### PR TITLE
Refactor JSON output formatting in tests to use 1 space indentation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.175.2",
+  "version": "0.175.3",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.13",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -359,7 +359,7 @@ export class Neat {
           ensureDirSync(this.config.traceStore);
           Deno.writeTextFileSync(
             `${this.config.traceStore}/${traceNetwork.uuid}.json`,
-            JSON.stringify(traceNetwork.traceJSON(), null, 2),
+            JSON.stringify(traceNetwork.traceJSON(), null, 1),
           );
         }
       }

--- a/src/architecture/CreatureValidate.ts
+++ b/src/architecture/CreatureValidate.ts
@@ -372,7 +372,7 @@ function debugWrite(creature: Creature) {
       creature.DEBUG = false;
       Deno.writeTextFileSync(
         ".validate.json",
-        JSON.stringify(creature.exportJSON(), null, 2),
+        JSON.stringify(creature.exportJSON(), null, 1),
       );
     } finally {
       creature.DEBUG = true;

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -305,15 +305,15 @@ export class Offspring {
           offspring.DEBUG = false;
           Deno.writeTextFileSync(
             ".offspring-mother.json",
-            JSON.stringify(mother.exportJSON(), null, 2),
+            JSON.stringify(mother.exportJSON(), null, 1),
           );
           Deno.writeTextFileSync(
             ".offspring-offspring.json",
-            JSON.stringify(offspring.exportJSON(), null, 2),
+            JSON.stringify(offspring.exportJSON(), null, 1),
           );
           Deno.writeTextFileSync(
             ".offspring-father.json",
-            JSON.stringify(father.exportJSON(), null, 2),
+            JSON.stringify(father.exportJSON(), null, 1),
           );
 
           throw e;

--- a/src/architecture/Training.ts
+++ b/src/architecture/Training.ts
@@ -332,7 +332,7 @@ function trainDirBinary(
         CreatureUtil.makeUUID(creature);
         Deno.writeTextFileSync(
           `${failedDir}/${creature.uuid}.json`,
-          JSON.stringify(creature.traceJSON(), null, 2),
+          JSON.stringify(creature.traceJSON(), null, 1),
         );
       }
       creature.loadFrom(bestCreatureJSON, false);

--- a/src/breed/Breed.ts
+++ b/src/breed/Breed.ts
@@ -100,16 +100,16 @@ export class Breed {
     } catch (e) {
       Deno.writeTextFileSync(
         "./.source_mother.json",
-        JSON.stringify(mum.exportJSON(), null, 2),
+        JSON.stringify(mum.exportJSON(), null, 1),
       );
       Deno.writeTextFileSync(
         "./.source_father.json",
-        JSON.stringify(father.exportJSON(), null, 2),
+        JSON.stringify(father.exportJSON(), null, 1),
       );
 
       Deno.writeTextFileSync(
         "./.invalid_father.json",
-        JSON.stringify(fatherExport, null, 2),
+        JSON.stringify(fatherExport, null, 1),
       );
       throw e;
     }

--- a/src/reconstruct/CRISPR.ts
+++ b/src/reconstruct/CRISPR.ts
@@ -440,7 +440,7 @@ export class CRISPR {
       const name = `.CRISPR-ERROR-${dna.id}.json`;
       Deno.writeTextFileSync(
         name,
-        JSON.stringify(modifiedCreature.exportJSON(), null, 2),
+        JSON.stringify(modifiedCreature.exportJSON(), null, 1),
       );
 
       console.warn(`Invalid creature saved to ${name}`, e);

--- a/test/CRISPR/Append.ts
+++ b/test/CRISPR/Append.ts
@@ -36,7 +36,7 @@ Deno.test("CRISPR/Append", () => {
 
   Deno.writeTextFileSync(
     "test/data/CRISPR/.actual-range.json",
-    JSON.stringify((networkIF as Creature).exportJSON(), null, 2),
+    JSON.stringify((networkIF as Creature).exportJSON(), null, 1),
   );
   Deno.writeTextFileSync("test/data/CRISPR/.actual-range.json", actualTXT);
   assertEquals(actualTXT, expectedTXT, "should have converted");

--- a/test/CRISPR/CRISPR.ts
+++ b/test/CRISPR/CRISPR.ts
@@ -56,7 +56,7 @@ Deno.test("CRISPR_twice", () => {
   const expectedJSON = JSON.parse(
     Deno.readTextFileSync("test/data/CRISPR/expected-IF.json"),
   );
-  const expectedTXT = JSON.stringify(clean(expectedJSON), null, 2);
+  const expectedTXT = JSON.stringify(clean(expectedJSON), null, 1);
   const actualTXT = JSON.stringify(
     clean((networkIF2 as Creature).exportJSON()),
     null,
@@ -72,7 +72,7 @@ Deno.test("CRISPR-Volume", () => {
   const network = Creature.fromJSON(JSON.parse(networkTXT));
   Deno.writeTextFileSync(
     "test/data/CRISPR/.network.json",
-    JSON.stringify(network.internalJSON(), null, 2),
+    JSON.stringify(network.internalJSON(), null, 1),
   );
   network.validate();
   const crispr = new CRISPR(network);
@@ -181,7 +181,7 @@ Deno.test("CRISPR-multi-outputs1", () => {
   const network = Creature.fromJSON(json);
   Deno.writeTextFileSync(
     "test/data/CRISPR/.network-sane.json",
-    JSON.stringify(network.internalJSON(), null, 2),
+    JSON.stringify(network.internalJSON(), null, 1),
   );
   network.validate();
   const crispr = new CRISPR(network);
@@ -266,7 +266,7 @@ Deno.test("CRISPR-multi-outputs2", () => {
   const network = Creature.fromJSON(json);
   Deno.writeTextFileSync(
     "test/data/CRISPR/.network-sane2.json",
-    JSON.stringify(network.internalJSON(), null, 2),
+    JSON.stringify(network.internalJSON(), null, 1),
   );
   network.validate();
   const crispr = new CRISPR(network);
@@ -333,7 +333,7 @@ Deno.test("CRISPR-uuid", () => {
   const creature = Creature.fromJSON(json);
   Deno.writeTextFileSync(
     "test/data/CRISPR/.network-proximity-to-delisting.json",
-    JSON.stringify(creature.internalJSON(), null, 2),
+    JSON.stringify(creature.internalJSON(), null, 1),
   );
   creature.validate();
   const crispr = new CRISPR(creature);

--- a/test/CRISPR/From.ts
+++ b/test/CRISPR/From.ts
@@ -21,7 +21,7 @@ Deno.test("FromUUID", () => {
   const exported = creatureB.exportJSON();
   Deno.writeTextFileSync(
     "test/data/CRISPR/.actual-from-to.json",
-    JSON.stringify(exported, null, 2),
+    JSON.stringify(exported, null, 1),
   );
   let foundFromToA = false;
   let foundFromToB = false;

--- a/test/Compact/Cascade.ts
+++ b/test/Compact/Cascade.ts
@@ -92,7 +92,7 @@ Deno.test("CompactCascade", () => {
 
     Deno.writeTextFileSync(
       `${traceDir}/trace.json`,
-      JSON.stringify(creature.traceJSON(), null, 2),
+      JSON.stringify(creature.traceJSON(), null, 1),
     );
 
     compacted = compactUnused(creature.traceJSON(), config.plankConstant);
@@ -105,7 +105,7 @@ Deno.test("CompactCascade", () => {
   compacted.validate();
   Deno.writeTextFileSync(
     `${traceDir}/compacted.json`,
-    JSON.stringify(compacted.exportJSON(), null, 2),
+    JSON.stringify(compacted.exportJSON(), null, 1),
   );
 
   for (let i = data.length; i--;) {

--- a/test/Compact/Compact.ts
+++ b/test/Compact/Compact.ts
@@ -80,7 +80,7 @@ Deno.test("CompactSimple", () => {
   b.validate();
   Deno.writeTextFileSync(
     ".b.json",
-    JSON.stringify(b.internalJSON(), null, 2),
+    JSON.stringify(b.internalJSON(), null, 1),
   );
   const endNodes = b.neurons.length;
   const endConnections = b.synapses.length;
@@ -135,7 +135,7 @@ Deno.test("RandomizeCompact", () => {
 
     Deno.writeTextFileSync(
       `${traceDir}/a.json`,
-      JSON.stringify(a.internalJSON(), null, 2),
+      JSON.stringify(a.internalJSON(), null, 1),
     );
     const b = a.compact();
     if (!b) {
@@ -145,7 +145,7 @@ Deno.test("RandomizeCompact", () => {
       b.DEBUG = false;
       Deno.writeTextFileSync(
         `${traceDir}/b.json`,
-        JSON.stringify(b.internalJSON(), null, 2),
+        JSON.stringify(b.internalJSON(), null, 1),
       );
       b.DEBUG = true;
       b.validate();
@@ -226,7 +226,7 @@ Deno.test("CompactSelf", () => {
   b.validate();
   Deno.writeTextFileSync(
     ".b.json",
-    JSON.stringify(b.internalJSON(), null, 2),
+    JSON.stringify(b.internalJSON(), null, 1),
   );
   const endNodes = b.neurons.length;
   const endConnections = b.synapses.length;

--- a/test/Compact/CompactConstant.ts
+++ b/test/Compact/CompactConstant.ts
@@ -84,7 +84,7 @@ Deno.test("CompactConstants", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/0-start.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const outputs: Float32Array[] = new Array(data.length);
@@ -117,7 +117,7 @@ Deno.test("CompactConstants", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/1-trace.json`,
-    JSON.stringify(creature.traceJSON(), null, 2),
+    JSON.stringify(creature.traceJSON(), null, 1),
   );
 
   const compacted = compactUnused(
@@ -130,7 +130,7 @@ Deno.test("CompactConstants", () => {
   }
   Deno.writeTextFileSync(
     `${traceDir}/2-compacted.json`,
-    JSON.stringify(compacted.exportJSON(), null, 2),
+    JSON.stringify(compacted.exportJSON(), null, 1),
   );
 
   for (let i = data.length; i--;) {
@@ -174,7 +174,7 @@ Deno.test("CompactConstants", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/3-trace.json`,
-    JSON.stringify(compacted.traceJSON(), null, 2),
+    JSON.stringify(compacted.traceJSON(), null, 1),
   );
 
   const compacted2 = compactUnused(
@@ -185,7 +185,7 @@ Deno.test("CompactConstants", () => {
   if (compacted2) {
     Deno.writeTextFileSync(
       `${traceDir}/4-compacted.json`,
-      JSON.stringify(compacted2.exportJSON(), null, 2),
+      JSON.stringify(compacted2.exportJSON(), null, 1),
     );
 
     for (let i = data.length; i--;) {

--- a/test/Compact/CompactKeepOrder.ts
+++ b/test/Compact/CompactKeepOrder.ts
@@ -88,7 +88,7 @@ Deno.test("CompactKeepOrder", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/0-start.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const outputs: Float32Array[] = new Array(data.length);
@@ -121,7 +121,7 @@ Deno.test("CompactKeepOrder", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/1-trace.json`,
-    JSON.stringify(creature.traceJSON(), null, 2),
+    JSON.stringify(creature.traceJSON(), null, 1),
   );
 
   const compacted = compactUnused(
@@ -135,7 +135,7 @@ Deno.test("CompactKeepOrder", () => {
   compacted.validate();
   Deno.writeTextFileSync(
     `${traceDir}/2-compacted.json`,
-    JSON.stringify(compacted.exportJSON(), null, 2),
+    JSON.stringify(compacted.exportJSON(), null, 1),
   );
 
   for (let i = data.length; i--;) {
@@ -178,7 +178,7 @@ Deno.test("CompactKeepOrder", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/3-trace.json`,
-    JSON.stringify(compacted.traceJSON(), null, 2),
+    JSON.stringify(compacted.traceJSON(), null, 1),
   );
 
   const compacted2 = compactUnused(
@@ -189,7 +189,7 @@ Deno.test("CompactKeepOrder", () => {
   if (compacted2) {
     Deno.writeTextFileSync(
       `${traceDir}/4-compacted.json`,
-      JSON.stringify(compacted2.exportJSON(), null, 2),
+      JSON.stringify(compacted2.exportJSON(), null, 1),
     );
 
     for (let i = data.length; i--;) {

--- a/test/Compact/FixIF.ts
+++ b/test/Compact/FixIF.ts
@@ -110,7 +110,7 @@ Deno.test("FixIF", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/trace.json`,
-    JSON.stringify(creature.traceJSON(), null, 2),
+    JSON.stringify(creature.traceJSON(), null, 1),
   );
 
   const compacted = compactUnused(
@@ -123,7 +123,7 @@ Deno.test("FixIF", () => {
   }
   Deno.writeTextFileSync(
     `${traceDir}/compacted.json`,
-    JSON.stringify(compacted.exportJSON(), null, 2),
+    JSON.stringify(compacted.exportJSON(), null, 1),
   );
 
   for (let i = data.length; i--;) {

--- a/test/Compact/UnusedClipped.ts
+++ b/test/Compact/UnusedClipped.ts
@@ -89,7 +89,7 @@ Deno.test("UnusedClipped", () => {
 
     Deno.writeTextFileSync(
       `${traceDir}/trace.json`,
-      JSON.stringify(creature.traceJSON(), null, 2),
+      JSON.stringify(creature.traceJSON(), null, 1),
     );
 
     compacted = compactUnused(creature.traceJSON(), config.plankConstant);
@@ -103,7 +103,7 @@ Deno.test("UnusedClipped", () => {
   }
   Deno.writeTextFileSync(
     `${traceDir}/compacted.json`,
-    JSON.stringify(compacted.exportJSON(), null, 2),
+    JSON.stringify(compacted.exportJSON(), null, 1),
   );
 
   for (let i = data.length; i--;) {

--- a/test/Constants/AddNeuron.ts
+++ b/test/Constants/AddNeuron.ts
@@ -65,7 +65,7 @@ Deno.test("AddNeuron", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/0-start.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   for (let i = 0; i < 100; i++) {
     const tmpCreature = Creature.fromJSON(creature.exportJSON());

--- a/test/Creature.ts
+++ b/test/Creature.ts
@@ -49,11 +49,11 @@ function checkMutation(method: { name: string }) {
     }
   }
 
-  const json1 = JSON.stringify(creature.exportJSON(), null, 2);
+  const json1 = JSON.stringify(creature.exportJSON(), null, 1);
   for (let i = 10; i--;) {
     creature.mutate(method);
   }
-  const json2 = JSON.stringify(creature.exportJSON(), null, 2);
+  const json2 = JSON.stringify(creature.exportJSON(), null, 1);
 
   assertNotEquals(json1, json2);
 
@@ -122,13 +122,13 @@ async function evolveSet(
     if (Math.abs(nt0 - nt1) > 0.0001) {
       Deno.writeTextFileSync(
         ".start.json",
-        JSON.stringify(lastCreature.exportJSON(), null, 2),
+        JSON.stringify(lastCreature.exportJSON(), null, 1),
       );
       const nt2 = lastCreature.activate(input)[0];
 
       Deno.writeTextFileSync(
         ".end.json",
-        JSON.stringify(lastCreature.exportJSON(), null, 2),
+        JSON.stringify(lastCreature.exportJSON(), null, 1),
       );
 
       const n0 = Creature.fromJSON(lastCreature.exportJSON()).activate(
@@ -210,7 +210,7 @@ function trainSet(
     const results = train(creature, set, options);
     Deno.writeTextFileSync(
       `.trace/${attempts}.json`,
-      JSON.stringify(results.trace, null, 2),
+      JSON.stringify(results.trace, null, 1),
     );
     if (results.error >= error && attempts < 12) {
       console.info(`Error is: ${results.error}, required: ${error} RETRY`);
@@ -463,7 +463,7 @@ Deno.test("evolve XORgate", async () => {
   // deno-lint-ignore no-sync-fn-in-async-fn
   Deno.writeTextFileSync(
     ".evolve/XOR.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 });
 
@@ -650,7 +650,7 @@ Deno.test("NARX Sequence", async () => {
       } of ${maxAttempts}`,
     );
     if (attempts > maxAttempts) {
-      fail(JSON.stringify(result, null, 2));
+      fail(JSON.stringify(result, null, 1));
     }
   }
 });
@@ -721,7 +721,7 @@ Deno.test("evolveSHIFT", async () => {
   // deno-lint-ignore no-sync-fn-in-async-fn
   Deno.writeTextFileSync(
     ".evolve/SHIFT.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 });
 

--- a/test/IfElse.ts
+++ b/test/IfElse.ts
@@ -36,7 +36,7 @@ Deno.test("if-bias", () => {
     creature.exportJSON(),
     createBackPropagationConfig({}),
   );
-  const tmpJSON = JSON.stringify(creature.exportJSON(), null, 2);
+  const tmpJSON = JSON.stringify(creature.exportJSON(), null, 1);
 
   console.log(tmpJSON);
 
@@ -75,7 +75,7 @@ Deno.test("if/Else", () => {
     output: 1,
   };
   const network1 = Creature.fromJSON(json);
-  const tmpJSON = JSON.stringify(network1.exportJSON(), null, 2);
+  const tmpJSON = JSON.stringify(network1.exportJSON(), null, 1);
 
   console.log(tmpJSON);
   const creature2 = Creature.fromJSON(JSON.parse(tmpJSON));

--- a/test/Mean.ts
+++ b/test/Mean.ts
@@ -27,7 +27,7 @@ Deno.test("Mean", () => {
   creature.validate();
   Deno.writeTextFileSync(
     `${testDir}/fixed.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   const sparseConfig = new SparseConfig(
     creature.exportJSON(),

--- a/test/Offspring/Breed.ts
+++ b/test/Offspring/Breed.ts
@@ -160,7 +160,7 @@ Deno.test("CrossOver", () => {
     if (n.squash === "IF") {
       Deno.writeTextFileSync(
         ".cross_over.json",
-        JSON.stringify(child.exportJSON(), null, 2),
+        JSON.stringify(child.exportJSON(), null, 1),
       );
 
       break;

--- a/test/Offspring/EditParentByIndex.ts
+++ b/test/Offspring/EditParentByIndex.ts
@@ -103,7 +103,7 @@ function makeTestCreature(uuidPrefix: string): Creature {
   CreatureUtil.makeUUID(creature);
   Deno.writeTextFileSync(
     `${testDir}/${uuidPrefix}.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   return creature;
 }
@@ -123,7 +123,7 @@ Deno.test("Edit Parent by Index", () => {
   parent.validate();
   Deno.writeTextFileSync(
     `${testDir}/editedTarget.json`,
-    JSON.stringify(editedTarget.exportJSON(), null, 2),
+    JSON.stringify(editedTarget.exportJSON(), null, 1),
   );
 
   // Check overlap has increased

--- a/test/Offspring/GeneticCompatibility.ts
+++ b/test/Offspring/GeneticCompatibility.ts
@@ -102,7 +102,7 @@ function makeTestCreature(uuidPrefix: string): Creature {
   CreatureUtil.makeUUID(creature);
   Deno.writeTextFileSync(
     `${testDir}/${uuidPrefix}.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   return creature;
 }

--- a/test/Offspring/KeepOrder.ts
+++ b/test/Offspring/KeepOrder.ts
@@ -109,12 +109,12 @@ Deno.test("KeepOrder", () => {
   const mum = makeMum();
   Deno.writeTextFileSync(
     `${testDir}/mum.json`,
-    JSON.stringify(mum.exportJSON(), null, 2),
+    JSON.stringify(mum.exportJSON(), null, 1),
   );
   const dad = makeDad();
   Deno.writeTextFileSync(
     `${testDir}/dad.json`,
-    JSON.stringify(dad.exportJSON(), null, 2),
+    JSON.stringify(dad.exportJSON(), null, 1),
   );
   for (let i = 0; i < 10; i++) {
     const child = Offspring.breed(mum, dad);
@@ -128,6 +128,6 @@ function check(child: Creature) {
 
   Deno.writeTextFileSync(
     `${testDir}/child.json`,
-    JSON.stringify(child.exportJSON(), null, 2),
+    JSON.stringify(child.exportJSON(), null, 1),
   );
 }

--- a/test/Offspring/KeepSynapses.ts
+++ b/test/Offspring/KeepSynapses.ts
@@ -150,12 +150,12 @@ Deno.test("KeepSynapses", () => {
   const mum = makeMum();
   Deno.writeTextFileSync(
     `${testDir}/mum.json`,
-    JSON.stringify(mum.exportJSON(), null, 2),
+    JSON.stringify(mum.exportJSON(), null, 1),
   );
   const dad = makeDad();
   Deno.writeTextFileSync(
     `${testDir}/dad.json`,
-    JSON.stringify(dad.exportJSON(), null, 2),
+    JSON.stringify(dad.exportJSON(), null, 1),
   );
   for (let i = 0; i < 10; i++) {
     const child = Offspring.breed(mum, dad);

--- a/test/TraceAggregate.ts
+++ b/test/TraceAggregate.ts
@@ -30,7 +30,7 @@ Deno.test("TraceAggregateMINIMUM", () => {
   creature.validate();
   Deno.writeTextFileSync(
     "test/data/.a.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   const input = new Float32Array([0.1, 0.2]);
   creature.activate(input);
@@ -52,7 +52,7 @@ Deno.test("TraceAggregateMINIMUM", () => {
 
   Deno.writeTextFileSync(
     "test/data/.d.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   assertAlmostEquals(aOut[0], dOut[0], 0.0001);
 
@@ -83,7 +83,7 @@ Deno.test("TraceAggregateMAXIMUM", () => {
   creature.validate();
   Deno.writeTextFileSync(
     "test/data/.A.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   const input = new Float32Array([0.1, 0.2]);
   creature.activate(input);
@@ -107,7 +107,7 @@ Deno.test("TraceAggregateMAXIMUM", () => {
 
   Deno.writeTextFileSync(
     "test/data/.B.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   assertAlmostEquals(aOut[0], dOut[0], 0.0001);
 
@@ -139,7 +139,7 @@ Deno.test("TraceAggregateIF", () => {
   creature.validate();
   Deno.writeTextFileSync(
     "test/data/.a.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   const input = new Float32Array([0.1, 0.2]);
   creature.activate(input);
@@ -162,7 +162,7 @@ Deno.test("TraceAggregateIF", () => {
 
   Deno.writeTextFileSync(
     "test/data/.d.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   assertAlmostEquals(aOut[0], dOut[0], 0.0001);
 

--- a/test/Traced.ts
+++ b/test/Traced.ts
@@ -13,7 +13,7 @@ Deno.test("Traced", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/A.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
   const config = createBackPropagationConfig();
 
@@ -21,7 +21,7 @@ Deno.test("Traced", () => {
   if (compact) {
     Deno.writeTextFileSync(
       `${traceDir}/C.json`,
-      JSON.stringify(compact.exportJSON(), null, 2),
+      JSON.stringify(compact.exportJSON(), null, 1),
     );
   }
   const sparseConfig = new SparseConfig(creature.exportJSON(), config);
@@ -30,6 +30,6 @@ Deno.test("Traced", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/B.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 });

--- a/test/Train.ts
+++ b/test/Train.ts
@@ -80,7 +80,7 @@ Deno.test("train-XOR", () => {
 
   Deno.writeTextFileSync(
     `.trace/start.json`,
-    JSON.stringify(network.internalJSON(), null, 2),
+    JSON.stringify(network.internalJSON(), null, 1),
   );
   for (let attempts = 0; true; attempts++) {
     const results = train(network, trainingSet, {
@@ -89,7 +89,7 @@ Deno.test("train-XOR", () => {
     });
     Deno.writeTextFileSync(
       `.trace/${attempts}.json`,
-      JSON.stringify(results.trace, null, 2),
+      JSON.stringify(results.trace, null, 1),
     );
 
     if (results.error <= 0.26) {

--- a/test/breed/Samples.ts
+++ b/test/breed/Samples.ts
@@ -34,7 +34,7 @@ Deno.test("CompatibleFather-1", () => {
   const fatherActual = createCompatibleFather(mother, father);
   Deno.writeTextFileSync(
     `./test/breed/samples/.actual.json`,
-    JSON.stringify(fatherActual, null, 2),
+    JSON.stringify(fatherActual, null, 1),
   );
 
   Creature.fromJSON(fatherActual).validate();

--- a/test/ifPropagation.ts
+++ b/test/ifPropagation.ts
@@ -62,7 +62,7 @@ Deno.test("ifPropagation", () => {
   const traceJson = result.trace;
   Deno.writeTextFileSync(
     ".trace/ifPropagation.json",
-    JSON.stringify(traceJson, null, 2),
+    JSON.stringify(traceJson, null, 1),
   );
   let usedCount = 0;
   if (traceJson) {

--- a/test/propagate/Complex.ts
+++ b/test/propagate/Complex.ts
@@ -30,13 +30,13 @@ Deno.test("Complex Back Propagation", () => {
 
   Deno.writeTextFileSync(
     `${testDir}/0-start.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const generated = makeInputs(creature);
   Deno.writeTextFileSync(
     `${testDir}/input.json`,
-    JSON.stringify(generated, null, 2),
+    JSON.stringify(generated, null, 1),
   );
 
   const inputs = JSON.parse(
@@ -61,7 +61,7 @@ Deno.test("Complex Back Propagation", () => {
 
   Deno.writeTextFileSync(
     `${testDir}/1-trace.json`,
-    JSON.stringify(creature.traceJSON(), null, 2),
+    JSON.stringify(creature.traceJSON(), null, 1),
   );
 
   creature.propagateUpdate(config, sparseConfig);
@@ -69,7 +69,7 @@ Deno.test("Complex Back Propagation", () => {
 
   Deno.writeTextFileSync(
     `${testDir}/2-end.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   for (let i = 0; i < inputs.length; i++) {

--- a/test/propagate/Constants.ts
+++ b/test/propagate/Constants.ts
@@ -46,7 +46,7 @@ Deno.test("Constants", () => {
 
     Deno.writeTextFileSync(
       ".trace/0.json",
-      JSON.stringify(creature.exportJSON(), null, 2),
+      JSON.stringify(creature.exportJSON(), null, 1),
     );
 
     const config = createBackPropagationConfig({
@@ -72,7 +72,7 @@ Deno.test("Constants", () => {
 
     Deno.writeTextFileSync(
       ".trace/1.json",
-      JSON.stringify(creature.traceJSON(), null, 2),
+      JSON.stringify(creature.traceJSON(), null, 1),
     );
 
     creature.propagateUpdate(config, sparseConfig);
@@ -88,7 +88,7 @@ Deno.test("Constants", () => {
 
     Deno.writeTextFileSync(
       ".trace/2.json",
-      JSON.stringify(creature.exportJSON(), null, 2),
+      JSON.stringify(creature.exportJSON(), null, 1),
     );
 
     if (diff < 0.001 || attempts > 100) {
@@ -119,7 +119,7 @@ Deno.test("Constants Same", () => {
 
     Deno.writeTextFileSync(
       ".trace/0-clean.json",
-      JSON.stringify(creature.exportJSON(), null, 2),
+      JSON.stringify(creature.exportJSON(), null, 1),
     );
     const config = createBackPropagationConfig({
       disableRandomSamples: true,
@@ -142,7 +142,7 @@ Deno.test("Constants Same", () => {
 
     Deno.writeTextFileSync(
       ".trace/2-trace.json",
-      JSON.stringify(creature.traceJSON(), null, 2),
+      JSON.stringify(creature.traceJSON(), null, 1),
     );
 
     creature.propagateUpdate(config, sparseConfig);
@@ -159,7 +159,7 @@ Deno.test("Constants Same", () => {
 
     Deno.writeTextFileSync(
       ".trace/3-updated.json",
-      JSON.stringify(creature.exportJSON(), null, 2),
+      JSON.stringify(creature.exportJSON(), null, 1),
     );
 
     if (diff < 0.5 || attempts > 100) {
@@ -188,7 +188,7 @@ Deno.test("Constants Known Few", () => {
 
   Deno.writeTextFileSync(
     ".trace/0.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const inputs = [
@@ -216,7 +216,7 @@ Deno.test("Constants Known Few", () => {
 
   Deno.writeTextFileSync(
     ".trace/2.json",
-    JSON.stringify(creature.traceJSON(), null, 2),
+    JSON.stringify(creature.traceJSON(), null, 1),
   );
 
   creature.propagateUpdate(config, sparseConfig);
@@ -232,7 +232,7 @@ Deno.test("Constants Known Few", () => {
 
   Deno.writeTextFileSync(
     ".trace/3.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   assertAlmostEquals(
@@ -256,14 +256,14 @@ Deno.test("ConstantsMany", () => {
 
     Deno.writeTextFileSync(
       `${traceDir}/0-start.json`,
-      JSON.stringify(creature.exportJSON(), null, 2),
+      JSON.stringify(creature.exportJSON(), null, 1),
     );
 
     const observations = makeInputs();
 
     Deno.writeTextFileSync(
       `${traceDir}/observations.json`,
-      JSON.stringify(observations, null, 2),
+      JSON.stringify(observations, null, 1),
     );
     sampleInput = observations[22];
     let config = createBackPropagationConfig({
@@ -291,7 +291,7 @@ Deno.test("ConstantsMany", () => {
       }
       Deno.writeTextFileSync(
         `${traceDir}/1-trace.json`,
-        JSON.stringify(creature.traceJSON(), null, 2),
+        JSON.stringify(creature.traceJSON(), null, 1),
       );
 
       creature.propagateUpdate(config, sparseConfig);
@@ -304,7 +304,7 @@ Deno.test("ConstantsMany", () => {
 
     Deno.writeTextFileSync(
       `${traceDir}/2-end.json`,
-      JSON.stringify(creature.exportJSON(), null, 2),
+      JSON.stringify(creature.exportJSON(), null, 1),
     );
 
     if (attempt > 121) break;

--- a/test/propagate/IF.ts
+++ b/test/propagate/IF.ts
@@ -27,7 +27,7 @@ Deno.test("PropagateWeightsIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/data.json",
-      JSON.stringify(ts, null, 2),
+      JSON.stringify(ts, null, 1),
     );
     ts.forEach((item) => {
       const result = creatureA.activate(new Float32Array(item.input));
@@ -40,7 +40,7 @@ Deno.test("PropagateWeightsIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/A-clean.json",
-      JSON.stringify(exportJSON, null, 2),
+      JSON.stringify(exportJSON, null, 1),
     );
 
     exportJSON.synapses.forEach((c, indx) => {
@@ -51,7 +51,7 @@ Deno.test("PropagateWeightsIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/B-modified.json",
-      JSON.stringify(exportJSON, null, 2),
+      JSON.stringify(exportJSON, null, 1),
     );
 
     const creatureB = Creature.fromJSON(exportJSON);
@@ -70,12 +70,12 @@ Deno.test("PropagateWeightsIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/C-trace.json",
-      JSON.stringify(resultC.trace, null, 2),
+      JSON.stringify(resultC.trace, null, 1),
     );
 
     Deno.writeTextFileSync(
       ".trace/C-creature.json",
-      JSON.stringify(creatureC.exportJSON(), null, 2),
+      JSON.stringify(creatureC.exportJSON(), null, 1),
     );
 
     const errorC = calculateError(creatureC, ts);
@@ -100,7 +100,7 @@ Deno.test("PropagateWeightsIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/result.json",
-      JSON.stringify(resultC.trace, null, 2),
+      JSON.stringify(resultC.trace, null, 1),
     );
 
     break;
@@ -126,7 +126,7 @@ Deno.test("PropagateBiasIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/data.json",
-      JSON.stringify(ts, null, 2),
+      JSON.stringify(ts, null, 1),
     );
     ts.forEach((item) => {
       const result = creatureA.activate(new Float32Array(item.input));
@@ -139,7 +139,7 @@ Deno.test("PropagateBiasIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/A-clean.json",
-      JSON.stringify(exportJSON, null, 2),
+      JSON.stringify(exportJSON, null, 1),
     );
 
     exportJSON.neurons.forEach((node, indx) => {
@@ -151,7 +151,7 @@ Deno.test("PropagateBiasIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/B-modified.json",
-      JSON.stringify(exportJSON, null, 2),
+      JSON.stringify(exportJSON, null, 1),
     );
 
     const creatureB = Creature.fromJSON(exportJSON);
@@ -170,12 +170,12 @@ Deno.test("PropagateBiasIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/C-trace.json",
-      JSON.stringify(resultC.trace, null, 2),
+      JSON.stringify(resultC.trace, null, 1),
     );
 
     Deno.writeTextFileSync(
       ".trace/C-creature.json",
-      JSON.stringify(creatureC.exportJSON(), null, 2),
+      JSON.stringify(creatureC.exportJSON(), null, 1),
     );
 
     const errorC = calculateError(creatureC, ts);
@@ -200,7 +200,7 @@ Deno.test("PropagateBiasIF", () => {
 
     Deno.writeTextFileSync(
       ".trace/result.json",
-      JSON.stringify(resultC.trace, null, 2),
+      JSON.stringify(resultC.trace, null, 1),
     );
 
     const aHidden1 = creatureA.neurons.find((node) => node.uuid === "hidden-1");

--- a/test/propagate/Identity.ts
+++ b/test/propagate/Identity.ts
@@ -86,13 +86,13 @@ Deno.test("PropagateIdentity", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/0-start.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const inputs = makeData();
   Deno.writeTextFileSync(
     `${traceDir}/input.json`,
-    JSON.stringify(inputs, null, 2),
+    JSON.stringify(inputs, null, 1),
   );
 
   const targets: Float32Array[] = new Array(inputs.length);
@@ -108,7 +108,7 @@ Deno.test("PropagateIdentity", () => {
   neuron.bias = 0;
   Deno.writeTextFileSync(
     `${traceDir}/1-modified.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const modifiedError = calculateError(creature, inputs, targets);
@@ -127,13 +127,13 @@ Deno.test("PropagateIdentity", () => {
   const traced = creature.traceJSON();
   Deno.writeTextFileSync(
     `${traceDir}/2-trace.json`,
-    JSON.stringify(traced, null, 2),
+    JSON.stringify(traced, null, 1),
   );
 
   creature.propagateUpdate(config, sparseConfig);
   Deno.writeTextFileSync(
     `${traceDir}/3-end.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const endError = calculateError(creature, inputs, targets);
@@ -155,13 +155,13 @@ Deno.test("PropagateIdentityNoRealChange", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/0-start.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const inputs = makeData();
   Deno.writeTextFileSync(
     `${traceDir}/input.json`,
-    JSON.stringify(inputs, null, 2),
+    JSON.stringify(inputs, null, 1),
   );
 
   const targets: Float32Array[] = new Array(inputs.length);
@@ -178,7 +178,7 @@ Deno.test("PropagateIdentityNoRealChange", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/1-modified.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const startError = calculateError(creature, inputs, targets);
@@ -201,13 +201,13 @@ Deno.test("PropagateIdentityNoRealChange", () => {
   const traced = creature.traceJSON();
   Deno.writeTextFileSync(
     `${traceDir}/2-trace.json`,
-    JSON.stringify(traced, null, 2),
+    JSON.stringify(traced, null, 1),
   );
 
   creature.propagateUpdate(config, sparseConfig);
   Deno.writeTextFileSync(
     `${traceDir}/3-end.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const endError = calculateError(creature, inputs, targets);

--- a/test/propagate/Inverse.ts
+++ b/test/propagate/Inverse.ts
@@ -115,7 +115,7 @@ Deno.test("propagateInverseRandom", () => {
 
   Deno.writeTextFileSync(
     ".trace/data.json",
-    JSON.stringify(ts, null, 2),
+    JSON.stringify(ts, null, 1),
   );
   ts.forEach((item) => {
     const result = creatureA.activate(new Float32Array(item.input));
@@ -128,7 +128,7 @@ Deno.test("propagateInverseRandom", () => {
 
   Deno.writeTextFileSync(
     ".trace/1-clean.json",
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
 
   exportJSON.neurons.forEach((node, indx) => {
@@ -142,7 +142,7 @@ Deno.test("propagateInverseRandom", () => {
 
   Deno.writeTextFileSync(
     ".trace/2-modified.json",
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
 
   for (let attempts = 0; true; attempts++) {
@@ -156,7 +156,7 @@ Deno.test("propagateInverseRandom", () => {
 
     Deno.writeTextFileSync(
       ".trace/3-first.json",
-      JSON.stringify(creatureB.exportJSON(), null, 2),
+      JSON.stringify(creatureB.exportJSON(), null, 1),
     );
 
     const result2 = train(creatureB, ts, {
@@ -167,7 +167,7 @@ Deno.test("propagateInverseRandom", () => {
 
     Deno.writeTextFileSync(
       ".trace/4-last.json",
-      JSON.stringify(creatureB.exportJSON(), null, 2),
+      JSON.stringify(creatureB.exportJSON(), null, 1),
     );
 
     if (result1.error <= result2.error && attempts < 12) continue;
@@ -181,7 +181,7 @@ Deno.test("propagateInverseRandom", () => {
 
     Deno.writeTextFileSync(
       ".trace/result.json",
-      JSON.stringify(result2.trace, null, 2),
+      JSON.stringify(result2.trace, null, 1),
     );
 
     creatureA.neurons.forEach((n, indx) => {

--- a/test/propagate/Maximum.ts
+++ b/test/propagate/Maximum.ts
@@ -29,7 +29,7 @@ Deno.test("PropagateMaximum", () => {
 
     Deno.writeTextFileSync(
       ".trace/data.json",
-      JSON.stringify(ts, null, 2),
+      JSON.stringify(ts, null, 1),
     );
     ts.forEach((item) => {
       const result = creatureA.activate(new Float32Array(item.input));
@@ -42,7 +42,7 @@ Deno.test("PropagateMaximum", () => {
 
     Deno.writeTextFileSync(
       ".trace/A-clean.json",
-      JSON.stringify(exportJSON, null, 2),
+      JSON.stringify(exportJSON, null, 1),
     );
 
     exportJSON.neurons.forEach((node, indx) => {
@@ -56,7 +56,7 @@ Deno.test("PropagateMaximum", () => {
 
     Deno.writeTextFileSync(
       ".trace/B-modified.json",
-      JSON.stringify(exportJSON, null, 2),
+      JSON.stringify(exportJSON, null, 1),
     );
 
     const creatureB = Creature.fromJSON(exportJSON);
@@ -74,12 +74,12 @@ Deno.test("PropagateMaximum", () => {
 
     Deno.writeTextFileSync(
       ".trace/C-trace.json",
-      JSON.stringify(resultC.trace, null, 2),
+      JSON.stringify(resultC.trace, null, 1),
     );
 
     Deno.writeTextFileSync(
       ".trace/C-creature.json",
-      JSON.stringify(creatureC.exportJSON(), null, 2),
+      JSON.stringify(creatureC.exportJSON(), null, 1),
     );
 
     const errorC = calculateError(creatureC, ts);
@@ -104,12 +104,12 @@ Deno.test("PropagateMaximum", () => {
 
     Deno.writeTextFileSync(
       ".trace/D-creature.json",
-      JSON.stringify(creatureD.exportJSON(), null, 2),
+      JSON.stringify(creatureD.exportJSON(), null, 1),
     );
 
     Deno.writeTextFileSync(
       ".trace/E-creature.json",
-      JSON.stringify(creatureE.exportJSON(), null, 2),
+      JSON.stringify(creatureE.exportJSON(), null, 1),
     );
 
     assert(
@@ -124,7 +124,7 @@ Deno.test("PropagateMaximum", () => {
 
     Deno.writeTextFileSync(
       ".trace/result.json",
-      JSON.stringify(resultC.trace, null, 2),
+      JSON.stringify(resultC.trace, null, 1),
     );
 
     break;

--- a/test/propagate/MaximumSimple.ts
+++ b/test/propagate/MaximumSimple.ts
@@ -30,12 +30,12 @@ Deno.test("PropagateMaximumSimple", () => {
 
   Deno.writeTextFileSync(
     ".trace/A-clean.json",
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
 
   Deno.writeTextFileSync(
     ".trace/data.json",
-    JSON.stringify(ts, null, 2),
+    JSON.stringify(ts, null, 1),
   );
 
   exportJSON.neurons.forEach((node, indx) => {
@@ -49,7 +49,7 @@ Deno.test("PropagateMaximumSimple", () => {
 
   Deno.writeTextFileSync(
     ".trace/B-modified.json",
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
 
   const creatureB = Creature.fromJSON(exportJSON);
@@ -75,7 +75,7 @@ Deno.test("PropagateMaximumSimple", () => {
 
   Deno.writeTextFileSync(
     ".trace/C-trace.json",
-    JSON.stringify(creatureC.traceJSON(), null, 2),
+    JSON.stringify(creatureC.traceJSON(), null, 1),
   );
 
   creatureC.propagateUpdate(config, sparseConfig);
@@ -84,7 +84,7 @@ Deno.test("PropagateMaximumSimple", () => {
 
   Deno.writeTextFileSync(
     ".trace/D-creature.json",
-    JSON.stringify(creatureD.exportJSON(), null, 2),
+    JSON.stringify(creatureD.exportJSON(), null, 1),
   );
 
   const errorD = calculateError(creatureD, ts);

--- a/test/propagate/Mean.ts
+++ b/test/propagate/Mean.ts
@@ -85,14 +85,14 @@ Deno.test("PropagateMean", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/0-start.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   if (!existsSync(`${traceDir}/input.json`)) {
     const generated = makeInputs();
     Deno.writeTextFileSync(
       `${traceDir}/input.json`,
-      JSON.stringify(generated, null, 2),
+      JSON.stringify(generated, null, 1),
     );
   }
 
@@ -122,14 +122,14 @@ Deno.test("PropagateMean", () => {
   const traced = creature.traceJSON();
   Deno.writeTextFileSync(
     `${traceDir}/1-trace.json`,
-    JSON.stringify(traced, null, 2),
+    JSON.stringify(traced, null, 1),
   );
 
   creature.propagateUpdate(config, sparseConfig);
 
   Deno.writeTextFileSync(
     `${traceDir}/2-end.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   if (neuron.bias < 0.00001 || neuron.bias > 1) {

--- a/test/propagate/Minimum.ts
+++ b/test/propagate/Minimum.ts
@@ -31,7 +31,7 @@ Deno.test("PropagateMinimum", () => {
 
     Deno.writeTextFileSync(
       ".trace/data.json",
-      JSON.stringify(ts, null, 2),
+      JSON.stringify(ts, null, 1),
     );
     ts.forEach((item) => {
       const result = creature.activate(new Float32Array(item.input));
@@ -44,7 +44,7 @@ Deno.test("PropagateMinimum", () => {
 
     Deno.writeTextFileSync(
       ".trace/A-clean.json",
-      JSON.stringify(exportJSON, null, 2),
+      JSON.stringify(exportJSON, null, 1),
     );
 
     exportJSON.neurons.forEach((neuron, indx) => {
@@ -58,7 +58,7 @@ Deno.test("PropagateMinimum", () => {
 
     Deno.writeTextFileSync(
       ".trace/B-modified.json",
-      JSON.stringify(exportJSON, null, 2),
+      JSON.stringify(exportJSON, null, 1),
     );
 
     const creatureB = Creature.fromJSON(exportJSON);
@@ -79,12 +79,12 @@ Deno.test("PropagateMinimum", () => {
 
     Deno.writeTextFileSync(
       ".trace/C-trace.json",
-      JSON.stringify(resultC.trace, null, 2),
+      JSON.stringify(resultC.trace, null, 1),
     );
 
     Deno.writeTextFileSync(
       ".trace/C-creature.json",
-      JSON.stringify(creatureC.exportJSON(), null, 2),
+      JSON.stringify(creatureC.exportJSON(), null, 1),
     );
 
     if (attempts < 24) {
@@ -115,17 +115,17 @@ Deno.test("PropagateMinimum", () => {
 
     Deno.writeTextFileSync(
       ".trace/D-creature.json",
-      JSON.stringify(creatureD.exportJSON(), null, 2),
+      JSON.stringify(creatureD.exportJSON(), null, 1),
     );
 
     Deno.writeTextFileSync(
       ".trace/D-trace.json",
-      JSON.stringify(creatureD.traceJSON(), null, 2),
+      JSON.stringify(creatureD.traceJSON(), null, 1),
     );
 
     Deno.writeTextFileSync(
       ".trace/E-creature.json",
-      JSON.stringify(creatureE.exportJSON(), null, 2),
+      JSON.stringify(creatureE.exportJSON(), null, 1),
     );
 
     assert(
@@ -140,7 +140,7 @@ Deno.test("PropagateMinimum", () => {
 
     Deno.writeTextFileSync(
       ".trace/result.json",
-      JSON.stringify(resultC.trace, null, 2),
+      JSON.stringify(resultC.trace, null, 1),
     );
 
     break;

--- a/test/propagate/MultiLevel.ts
+++ b/test/propagate/MultiLevel.ts
@@ -114,7 +114,7 @@ Deno.test("propagateMultiLevelRandom", () => {
 
   Deno.writeTextFileSync(
     ".trace/data.json",
-    JSON.stringify(ts, null, 2),
+    JSON.stringify(ts, null, 1),
   );
   ts.forEach((item) => {
     const result = creatureA.activate(new Float32Array(item.input));
@@ -127,7 +127,7 @@ Deno.test("propagateMultiLevelRandom", () => {
 
   Deno.writeTextFileSync(
     ".trace/1-clean.json",
-    JSON.stringify(internalJSON, null, 2),
+    JSON.stringify(internalJSON, null, 1),
   );
 
   internalJSON.neurons.forEach((node, indx) => {
@@ -141,7 +141,7 @@ Deno.test("propagateMultiLevelRandom", () => {
 
   Deno.writeTextFileSync(
     ".trace/2-modified.json",
-    JSON.stringify(internalJSON, null, 2),
+    JSON.stringify(internalJSON, null, 1),
   );
 
   for (let attempts = 0; true; attempts++) {
@@ -155,7 +155,7 @@ Deno.test("propagateMultiLevelRandom", () => {
 
     Deno.writeTextFileSync(
       ".trace/3-first.json",
-      JSON.stringify(creatureB.internalJSON(), null, 2),
+      JSON.stringify(creatureB.internalJSON(), null, 1),
     );
 
     const result2 = train(creatureB, ts, {
@@ -165,7 +165,7 @@ Deno.test("propagateMultiLevelRandom", () => {
 
     Deno.writeTextFileSync(
       ".trace/4-last.json",
-      JSON.stringify(creatureB.internalJSON(), null, 2),
+      JSON.stringify(creatureB.internalJSON(), null, 1),
     );
 
     if (result2.error < 0.0001) break;
@@ -177,7 +177,7 @@ Deno.test("propagateMultiLevelRandom", () => {
 
     Deno.writeTextFileSync(
       ".trace/result.json",
-      JSON.stringify(result2.trace, null, 2),
+      JSON.stringify(result2.trace, null, 1),
     );
 
     break;
@@ -334,7 +334,7 @@ Deno.test("propagateMultiLevelKnownA", () => {
 
   Deno.writeTextFileSync(
     ".trace/1-clean.json",
-    JSON.stringify(internalJSON, null, 2),
+    JSON.stringify(internalJSON, null, 1),
   );
 
   internalJSON.neurons.forEach((node, indx) => {
@@ -348,7 +348,7 @@ Deno.test("propagateMultiLevelKnownA", () => {
 
   Deno.writeTextFileSync(
     ".trace/2-modified.json",
-    JSON.stringify(internalJSON, null, 2),
+    JSON.stringify(internalJSON, null, 1),
   );
 
   for (let attempts = 0; true; attempts++) {
@@ -362,7 +362,7 @@ Deno.test("propagateMultiLevelKnownA", () => {
 
     Deno.writeTextFileSync(
       ".trace/3-first.json",
-      JSON.stringify(creatureB.internalJSON(), null, 2),
+      JSON.stringify(creatureB.internalJSON(), null, 1),
     );
 
     const result2 = train(creatureB, ts, {
@@ -372,12 +372,12 @@ Deno.test("propagateMultiLevelKnownA", () => {
 
     Deno.writeTextFileSync(
       ".trace/4-last.json",
-      JSON.stringify(creatureB.internalJSON(), null, 2),
+      JSON.stringify(creatureB.internalJSON(), null, 1),
     );
 
     Deno.writeTextFileSync(
       ".trace/result.json",
-      JSON.stringify(result2.trace, null, 2),
+      JSON.stringify(result2.trace, null, 1),
     );
 
     if (attempts < 12) {
@@ -540,7 +540,7 @@ Deno.test("propagateMultiLevelKnownB", () => {
 
   Deno.writeTextFileSync(
     ".trace/start.json",
-    JSON.stringify(internalJSON, null, 2),
+    JSON.stringify(internalJSON, null, 1),
   );
 
   internalJSON.neurons.forEach((node, indx) => {
@@ -554,7 +554,7 @@ Deno.test("propagateMultiLevelKnownB", () => {
 
   Deno.writeTextFileSync(
     ".trace/changed.json",
-    JSON.stringify(internalJSON, null, 2),
+    JSON.stringify(internalJSON, null, 1),
   );
 
   for (let attempts = 0; true; attempts++) {
@@ -568,7 +568,7 @@ Deno.test("propagateMultiLevelKnownB", () => {
 
     Deno.writeTextFileSync(
       ".trace/first.json",
-      JSON.stringify(creatureB.internalJSON(), null, 2),
+      JSON.stringify(creatureB.internalJSON(), null, 1),
     );
 
     const result2 = train(creatureB, ts, {
@@ -578,7 +578,7 @@ Deno.test("propagateMultiLevelKnownB", () => {
 
     Deno.writeTextFileSync(
       ".trace/last.json",
-      JSON.stringify(creatureB.internalJSON(), null, 2),
+      JSON.stringify(creatureB.internalJSON(), null, 1),
     );
 
     if (result2.error < 0.0001) break;
@@ -590,7 +590,7 @@ Deno.test("propagateMultiLevelKnownB", () => {
 
     Deno.writeTextFileSync(
       ".trace/result.json",
-      JSON.stringify(result2.trace, null, 2),
+      JSON.stringify(result2.trace, null, 1),
     );
 
     break;

--- a/test/propagate/NoChangeWhenCorrect.ts
+++ b/test/propagate/NoChangeWhenCorrect.ts
@@ -111,7 +111,7 @@ Deno.test("NoChangeWhenCorrect", () => {
   const traced = creature.traceJSON();
   Deno.writeTextFileSync(
     `${traceDir}/trace.json`,
-    JSON.stringify(traced, null, 2),
+    JSON.stringify(traced, null, 1),
   );
 
   const info = traced.neurons.find((n) => n.uuid === "hidden-3b")?.trace;

--- a/test/propagate/PI.ts
+++ b/test/propagate/PI.ts
@@ -45,7 +45,7 @@ Deno.test("PI-repeat", () => {
   });
   Deno.writeTextFileSync(
     `${traceDir}/0.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const inA = [-1, 1, 0];
@@ -62,7 +62,7 @@ Deno.test("PI-repeat", () => {
 
     Deno.writeTextFileSync(
       `${traceDir}/traced-${i}.json`,
-      JSON.stringify(creature.traceJSON(), null, 2),
+      JSON.stringify(creature.traceJSON(), null, 1),
     );
 
     creature.propagateUpdate(config, sparseConfig);
@@ -83,7 +83,7 @@ Deno.test("PI-single", () => {
   });
   Deno.writeTextFileSync(
     ".trace/0.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const inA = [-1, 1, 0];
@@ -97,7 +97,7 @@ Deno.test("PI-single", () => {
 
   Deno.writeTextFileSync(
     ".trace/1.json",
-    JSON.stringify(creature.traceJSON(), null, 2),
+    JSON.stringify(creature.traceJSON(), null, 1),
   );
 
   creature.propagateUpdate(config, sparseConfig);
@@ -112,7 +112,7 @@ Deno.test("PI-single", () => {
 
   Deno.writeTextFileSync(
     ".trace/2.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   assertAlmostEquals(
@@ -143,7 +143,7 @@ Deno.test("PI Multiple", () => {
 
   Deno.writeTextFileSync(
     ".trace/0.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const sparseConfig = new SparseConfig(creature.exportJSON(), config);
@@ -159,7 +159,7 @@ Deno.test("PI Multiple", () => {
 
   Deno.writeTextFileSync(
     ".trace/2.json",
-    JSON.stringify(creature.traceJSON(), null, 2),
+    JSON.stringify(creature.traceJSON(), null, 1),
   );
 
   creature.propagateUpdate(config, sparseConfig);
@@ -175,7 +175,7 @@ Deno.test("PI Multiple", () => {
 
   Deno.writeTextFileSync(
     ".trace/3.json",
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   assertAlmostEquals(

--- a/test/propagate/STEP.ts
+++ b/test/propagate/STEP.ts
@@ -52,14 +52,14 @@ Deno.test("PropagateSTEP", () => {
 
   Deno.writeTextFileSync(
     `${testDir}/0-start.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   if (!existsSync(`${testDir}/input.json`)) {
     const generated = makeInputs();
     Deno.writeTextFileSync(
       `${testDir}/input.json`,
-      JSON.stringify(generated, null, 2),
+      JSON.stringify(generated, null, 1),
     );
   }
 
@@ -97,14 +97,14 @@ Deno.test("PropagateSTEP", () => {
   const traced = creature.traceJSON();
   Deno.writeTextFileSync(
     `${testDir}/1-trace.json`,
-    JSON.stringify(traced, null, 2),
+    JSON.stringify(traced, null, 1),
   );
 
   creature.propagateUpdate(config, sparseConfig);
 
   Deno.writeTextFileSync(
     `${testDir}/2-end.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   assertAlmostEquals(stepNeuron.bias, 1, 0.7);

--- a/test/propagate/SingleNeuron.ts
+++ b/test/propagate/SingleNeuron.ts
@@ -78,7 +78,7 @@ Deno.test("OneAndDone", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/0-start.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   const input = [-1, 0, 1];
@@ -92,7 +92,7 @@ Deno.test("OneAndDone", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/1-trace.json`,
-    JSON.stringify(creature.traceJSON(), null, 2),
+    JSON.stringify(creature.traceJSON(), null, 1),
   );
 
   creature.propagateUpdate(config, sparseConfig);
@@ -101,7 +101,7 @@ Deno.test("OneAndDone", () => {
 
   Deno.writeTextFileSync(
     `${traceDir}/2-done.json`,
-    JSON.stringify(creature.exportJSON(), null, 2),
+    JSON.stringify(creature.exportJSON(), null, 1),
   );
 
   assertAlmostEquals(
@@ -129,7 +129,7 @@ Deno.test("TwoSame", () => {
 
     Deno.writeTextFileSync(
       `${traceDir}/0-start.json`,
-      JSON.stringify(creature.traceJSON(), null, 2),
+      JSON.stringify(creature.traceJSON(), null, 1),
     );
     const config = createBackPropagationConfig({
       generations: 0,
@@ -147,7 +147,7 @@ Deno.test("TwoSame", () => {
 
     Deno.writeTextFileSync(
       `${traceDir}/1-trace.json`,
-      JSON.stringify(creature.traceJSON(), null, 2),
+      JSON.stringify(creature.traceJSON(), null, 1),
     );
 
     creature.propagateUpdate(config, sparseConfig);
@@ -157,7 +157,7 @@ Deno.test("TwoSame", () => {
 
     Deno.writeTextFileSync(
       `${traceDir}/2-done.json`,
-      JSON.stringify(creature.exportJSON(), null, 2),
+      JSON.stringify(creature.exportJSON(), null, 1),
     );
 
     if (
@@ -202,7 +202,7 @@ Deno.test("ManySame", () => {
 
     Deno.writeTextFileSync(
       ".trace/0-start.json",
-      JSON.stringify(creature.traceJSON(), null, 2),
+      JSON.stringify(creature.traceJSON(), null, 1),
     );
 
     const inA = [-1, 0, 1];
@@ -216,7 +216,7 @@ Deno.test("ManySame", () => {
 
     Deno.writeTextFileSync(
       ".trace/1-inA.json",
-      JSON.stringify(creature.traceJSON(), null, 2),
+      JSON.stringify(creature.traceJSON(), null, 1),
     );
 
     creature.propagateUpdate(config, sparseConfig);
@@ -226,7 +226,7 @@ Deno.test("ManySame", () => {
 
     Deno.writeTextFileSync(
       ".trace/4-done.json",
-      JSON.stringify(creature.exportJSON(), null, 2),
+      JSON.stringify(creature.exportJSON(), null, 1),
     );
 
     if (
@@ -260,7 +260,7 @@ Deno.test("propagateSingleNeuronRandom", () => {
   const creature = makeCreature();
   Deno.writeTextFileSync(
     ".trace/0-start.json",
-    JSON.stringify(creature.traceJSON(), null, 2),
+    JSON.stringify(creature.traceJSON(), null, 1),
   );
   const config = createBackPropagationConfig({});
 
@@ -281,7 +281,7 @@ Deno.test("propagateSingleNeuronRandom", () => {
 
   Deno.writeTextFileSync(
     ".trace/4-done.json",
-    JSON.stringify(creature.internalJSON(), null, 2),
+    JSON.stringify(creature.internalJSON(), null, 1),
   );
 
   for (let loop = 0; loop < 5; loop++) {

--- a/test/propagate/Trace.ts
+++ b/test/propagate/Trace.ts
@@ -25,7 +25,7 @@ Deno.test("Trace", () => {
 
   Deno.writeTextFileSync(
     "test/data/.learned.json",
-    JSON.stringify(json2, null, 2),
+    JSON.stringify(json2, null, 1),
   );
 });
 

--- a/test/propagate/bias/Simple.ts
+++ b/test/propagate/bias/Simple.ts
@@ -23,7 +23,7 @@ Deno.test("Bias-Simple", () => {
 
   Deno.writeTextFileSync(
     `${directory}/A-clean.json`,
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
 
   exportJSON.neurons.forEach((neuron, indx) => {
@@ -34,14 +34,14 @@ Deno.test("Bias-Simple", () => {
   const modifiedCreature = Creature.fromJSON(exportJSON);
   Deno.writeTextFileSync(
     `${directory}/B-modified.json`,
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
   let lastError = calculateError(modifiedCreature, td);
 
   for (let i = 0; i < 10; i++) {
     Deno.writeTextFileSync(
       `${directory}/C${i}--start.json`,
-      JSON.stringify(modifiedCreature.exportJSON(), null, 2),
+      JSON.stringify(modifiedCreature.exportJSON(), null, 1),
     );
     const results = train(modifiedCreature, td, {
       targetError: 0.01,
@@ -59,11 +59,11 @@ Deno.test("Bias-Simple", () => {
 
     Deno.writeTextFileSync(
       `${directory}/C${i}--trace.json`,
-      JSON.stringify(results.trace, null, 2),
+      JSON.stringify(results.trace, null, 1),
     );
     Deno.writeTextFileSync(
       `${directory}/C${i}-end.json`,
-      JSON.stringify(modifiedCreature.exportJSON(), null, 2),
+      JSON.stringify(modifiedCreature.exportJSON(), null, 1),
     );
     if (results.compact) Creature.fromJSON(results.compact).validate();
     if (results.error > lastError) {
@@ -191,7 +191,7 @@ function makeTrainData(creature: Creature) {
 
   Deno.writeTextFileSync(
     tdFN,
-    JSON.stringify(td, null, 2),
+    JSON.stringify(td, null, 1),
   );
   return td;
 }

--- a/test/propagate/biasIdentity/Simple.ts
+++ b/test/propagate/biasIdentity/Simple.ts
@@ -23,7 +23,7 @@ Deno.test("Simple", () => {
 
   Deno.writeTextFileSync(
     `${directory}/A-clean.json`,
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
 
   exportJSON.neurons.forEach((neuron, indx) => {
@@ -34,14 +34,14 @@ Deno.test("Simple", () => {
   const modifiedCreature = Creature.fromJSON(exportJSON);
   Deno.writeTextFileSync(
     `${directory}/B-modified.json`,
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
   let lastError = calculateError(modifiedCreature, td);
 
   for (let i = 0; i < 10; i++) {
     Deno.writeTextFileSync(
       `${directory}/C${i}--start.json`,
-      JSON.stringify(modifiedCreature.exportJSON(), null, 2),
+      JSON.stringify(modifiedCreature.exportJSON(), null, 1),
     );
     const results = train(modifiedCreature, td, {
       targetError: 0.01,
@@ -58,11 +58,11 @@ Deno.test("Simple", () => {
 
     Deno.writeTextFileSync(
       `${directory}/C${i}--trace.json`,
-      JSON.stringify(results.trace, null, 2),
+      JSON.stringify(results.trace, null, 1),
     );
     Deno.writeTextFileSync(
       `${directory}/C${i}-end.json`,
-      JSON.stringify(modifiedCreature.exportJSON(), null, 2),
+      JSON.stringify(modifiedCreature.exportJSON(), null, 1),
     );
     if (results.compact) Creature.fromJSON(results.compact).validate();
     if (results.error > lastError) {
@@ -190,7 +190,7 @@ function makeTrainData(creature: Creature) {
 
   Deno.writeTextFileSync(
     tdFN,
-    JSON.stringify(td, null, 2),
+    JSON.stringify(td, null, 1),
   );
   return td;
 }

--- a/test/propagate/minimum/Minimum.ts
+++ b/test/propagate/minimum/Minimum.ts
@@ -39,7 +39,7 @@ function check() {
 
   Deno.writeTextFileSync(
     `${directory}/A-clean.json`,
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
 
   exportJSON.neurons.forEach((neuron, indx) => {
@@ -54,14 +54,14 @@ function check() {
   const modifiedCreature = Creature.fromJSON(exportJSON);
   Deno.writeTextFileSync(
     `${directory}/B-modified.json`,
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
   let lastError = calculateError(modifiedCreature, td);
 
   for (let i = 0; i < 10; i++) {
     Deno.writeTextFileSync(
       `${directory}/${i}.json`,
-      JSON.stringify(modifiedCreature.exportJSON(), null, 2),
+      JSON.stringify(modifiedCreature.exportJSON(), null, 1),
     );
     const results = train(modifiedCreature, td, {
       targetError: 0.01,
@@ -79,14 +79,14 @@ function check() {
 
     Deno.writeTextFileSync(
       `${directory}/${i}-trace.json`,
-      JSON.stringify(results.trace, null, 2),
+      JSON.stringify(results.trace, null, 1),
     );
 
     if (results.compact) Creature.fromJSON(results.compact).validate();
     if (results.error > lastError) {
       Deno.writeTextFileSync(
         `${directory}/.error.json`,
-        JSON.stringify(modifiedCreature.exportJSON(), null, 2),
+        JSON.stringify(modifiedCreature.exportJSON(), null, 1),
       );
       Deno.writeTextFileSync(
         `${directory}/error-trace.json`,
@@ -164,7 +164,7 @@ function makeTrainData(creature: Creature) {
 
   Deno.writeTextFileSync(
     tdFN,
-    JSON.stringify(td, null, 2),
+    JSON.stringify(td, null, 1),
   );
   return td;
 }

--- a/test/propagate/simple/Simple.ts
+++ b/test/propagate/simple/Simple.ts
@@ -35,7 +35,7 @@ Deno.test("Simple", () => {
 
   Deno.writeTextFileSync(
     `${directory}/A-clean.json`,
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
 
   exportJSON.neurons.forEach((neuron, indx) => {
@@ -50,14 +50,14 @@ Deno.test("Simple", () => {
   const modifiedCreature = Creature.fromJSON(exportJSON);
   Deno.writeTextFileSync(
     `${directory}/B-modified.json`,
-    JSON.stringify(exportJSON, null, 2),
+    JSON.stringify(exportJSON, null, 1),
   );
   let lastError = calculateError(modifiedCreature, td);
 
   for (let i = 0; i < 10; i++) {
     Deno.writeTextFileSync(
       `${directory}/C${i}--start.json`,
-      JSON.stringify(modifiedCreature.exportJSON(), null, 2),
+      JSON.stringify(modifiedCreature.exportJSON(), null, 1),
     );
     const results = train(modifiedCreature, td, {
       targetError: 0.01,
@@ -74,11 +74,11 @@ Deno.test("Simple", () => {
 
     Deno.writeTextFileSync(
       `${directory}/C${i}--trace.json`,
-      JSON.stringify(results.trace, null, 2),
+      JSON.stringify(results.trace, null, 1),
     );
     Deno.writeTextFileSync(
       `${directory}/C${i}-end.json`,
-      JSON.stringify(modifiedCreature.exportJSON(), null, 2),
+      JSON.stringify(modifiedCreature.exportJSON(), null, 1),
     );
     if (results.compact) Creature.fromJSON(results.compact).validate();
     if (results.error > lastError) {
@@ -147,7 +147,7 @@ function makeTrainData(creature: Creature) {
 
   Deno.writeTextFileSync(
     tdFN,
-    JSON.stringify(td, null, 2),
+    JSON.stringify(td, null, 1),
   );
   return td;
 }

--- a/test/propagate/sparse/Trace.ts
+++ b/test/propagate/sparse/Trace.ts
@@ -28,7 +28,7 @@ Deno.test("propagate-trace", () => {
 
   Deno.writeTextFileSync(
     `${directory}/trace.json`,
-    JSON.stringify(results.trace, null, 2),
+    JSON.stringify(results.trace, null, 1),
   );
 
   let allNeuronTraced = true;
@@ -218,7 +218,7 @@ function makeTrainData(creature: Creature) {
 
   Deno.writeTextFileSync(
     tdFN,
-    JSON.stringify(td, null, 2),
+    JSON.stringify(td, null, 1),
   );
   return td;
 }


### PR DESCRIPTION
- Updated all instances of JSON.stringify() in test files to use 1 space for indentation instead of 2.
- This change was applied across various test files including Constants.ts, IF.ts, Identity.ts, Inverse.ts, Maximum.ts, Mean.ts, Minimum.ts, MultiLevel.ts, and others.
- The adjustment aims to standardize the output format for better readability and consistency in trace files generated during testing.