### PR TITLE
fixed error handling of discovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.188.0",
+  "version": "0.189.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -848,7 +848,7 @@ export class Creature implements CreatureInternal {
 
       if (completed) {
         if (interrupted) break;
-        if (neat.finishUp()) {
+        if (neat.finishUp(iterations, endTimeMS)) {
           break;
         }
       }

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -137,8 +137,10 @@ export class Neat {
   private doNotStartMore = false;
   private cleanUpDelayCount = 0;
   private additionalGenerationCount = 0;
+  private discoveryWaitGenerations = 0;
+  private maxDiscoveryWaitGenerations = 0;
 
-  finishUp() {
+  finishUp(iterations?: number, endTimeMS?: number) {
     this.doNotStartMore = true;
 
     if (!this.cleanUpDelayCount) {
@@ -153,7 +155,59 @@ export class Neat {
     }
 
     if (this.discoveryInProgress.size > 0) {
-      console.info("Waiting for discovery to complete");
+      // Calculate max wait generations on first discovery wait
+      if (this.maxDiscoveryWaitGenerations === 0) {
+        let maxWaitByIterations = 20; // Default fallback
+        let maxWaitByTime = 20; // Default fallback
+
+        if (iterations) {
+          maxWaitByIterations = Math.max(1, Math.floor(iterations * 0.5));
+        }
+
+        if (endTimeMS) {
+          const remainingTimeMS = endTimeMS - Date.now();
+          if (remainingTimeMS > 0) {
+            // Estimate generations based on remaining time (assume 1 generation per 30 seconds as rough estimate)
+            const estimatedGenerations = Math.max(
+              1,
+              Math.floor(remainingTimeMS / 30000),
+            );
+            maxWaitByTime = Math.floor(estimatedGenerations * 0.5);
+          }
+        }
+
+        this.maxDiscoveryWaitGenerations = Math.min(
+          maxWaitByIterations,
+          maxWaitByTime,
+        );
+        console.info(
+          `Discovery timeout set to ${this.maxDiscoveryWaitGenerations} generations (50% of limiting factor)`,
+        );
+      }
+
+      this.discoveryWaitGenerations++;
+
+      if (this.discoveryWaitGenerations >= this.maxDiscoveryWaitGenerations) {
+        const stuckUUIDs = Array.from(this.discoveryInProgress.keys()).map(
+          (uuid) => uuid.substring(Math.max(0, uuid.length - 8)),
+        );
+        console.warn(
+          `Discovery timeout reached after ${this.discoveryWaitGenerations} generations. Clearing stuck discoveries: ${
+            stuckUUIDs.join(", ")
+          }`,
+        );
+
+        // Clear stuck discoveries to allow evolution to complete
+        this.discoveryInProgress.clear();
+        this.discoveryWaitGenerations = 0;
+        this.maxDiscoveryWaitGenerations = 0;
+
+        return false; // Continue to next iteration to check other conditions
+      }
+
+      console.info(
+        `Waiting for discovery to complete (${this.discoveryWaitGenerations}/${this.maxDiscoveryWaitGenerations})`,
+      );
 
       return false;
     }
@@ -229,6 +283,25 @@ export class Neat {
       this.discoveryComplete.push(r);
 
       this.discoveryInProgress.delete(uuid);
+    }).catch((error) => {
+      console.error(
+        `Discovery failed for creature ${
+          uuid.substring(Math.max(0, uuid.length - 8))
+        }:`,
+        error,
+      );
+
+      // Remove from discoveryInProgress to prevent infinite waiting
+      this.discoveryInProgress.delete(uuid);
+
+      // Add empty result to avoid breaking downstream logic
+      this.discoveryComplete.push({
+        taskID: 0,
+        duration: 0,
+        discover: {
+          ID: uuid,
+        },
+      });
     });
 
     this.discoveryInProgress.set(uuid, p);
@@ -382,6 +455,28 @@ export class Neat {
           );
         }
       }
+    }).catch((error) => {
+      console.error(
+        `Training failed for creature ${
+          uuid.substring(Math.max(0, uuid.length - 8))
+        }:`,
+        error,
+      );
+
+      // Remove from trainingInProgress to prevent infinite waiting
+      this.trainingInProgress.delete(uuid);
+
+      // Add empty result to avoid breaking downstream logic
+      this.trainingComplete.push({
+        taskID: 0,
+        duration: 0,
+        train: {
+          ID: uuid,
+          creature: JSON.stringify(creature.exportJSON()),
+          error: Number.POSITIVE_INFINITY,
+          trace: "",
+        },
+      });
     });
 
     this.trainingInProgress.set(uuid, p);

--- a/src/multithreading/workers/deno/worker.ts
+++ b/src/multithreading/workers/deno/worker.ts
@@ -1,4 +1,4 @@
-import type { RequestData } from "../WorkerHandler.ts";
+import type { RequestData, ResponseData } from "../WorkerHandler.ts";
 import { WorkerProcessor } from "../WorkerProcessor.ts";
 
 const processor = new WorkerProcessor();
@@ -7,7 +7,45 @@ const workerHandler =
   (self as unknown) as { onmessage: Function; postMessage: Function };
 
 workerHandler.onmessage = async function (message: { data: RequestData }) {
-  const result = await processor.process(message.data);
+  try {
+    const result = await processor.process(message.data);
+    workerHandler.postMessage(result);
+  } catch (error) {
+    console.error("Worker processing error:", error);
+    // Create a proper error response with operation-specific error field
+    const errorResponse: ResponseData = {
+      taskID: message.data.taskID,
+      duration: 0,
+    };
 
-  workerHandler.postMessage(result);
+    // Add operation-specific error field based on request type
+    if (message.data.evaluate) {
+      errorResponse.evaluate = {
+        error: Number.POSITIVE_INFINITY, // Use infinity to indicate evaluation failure
+      };
+    } else if (message.data.train) {
+      errorResponse.train = {
+        ID: "error",
+        creature: "",
+        error: Number.POSITIVE_INFINITY, // Use infinity to indicate training failure
+        trace: "",
+      };
+    } else if (message.data.discover) {
+      errorResponse.discover = {
+        ID: "error",
+      };
+    } else if (message.data.echo) {
+      errorResponse.echo = {
+        message: `Error: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    } else if (message.data.initialize) {
+      errorResponse.initialize = {
+        status: "ERROR",
+      };
+    }
+
+    workerHandler.postMessage(errorResponse);
+  }
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds iteration/time-based discovery timeout and comprehensive error handling in NEAT and workers to prevent hangs and ensure progress.
> 
> - **NEAT core**:
>   - `finishUp(iterations?, endTimeMS?)`: accepts timing/iteration context; introduces discovery wait counters and auto-timeout to clear stuck discoveries.
>   - Error handling: `scheduleDiscovery`/`scheduleTraining` now catch failures, log, remove from in-progress maps, and push minimal results to completion queues to avoid stalls.
> - **Worker (Deno)**:
>   - Wrap processing in try/catch; on error, return operation-specific `ResponseData` (evaluate/train/discover/echo/initialize) instead of throwing.
> - **Creature**:
>   - Calls `neat.finishUp(iterations, endTimeMS)` during evolution loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e19db471a398c2ae4f1057f2bda22446ca92bc10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->