### PR TITLE
V0.189.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,11 @@ jobs:
       id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      
+
       - name: Publish to JSR
         run: deno publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,4 +13,11 @@ jobs:
       id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
       - uses: actions/checkout@v4
-      - run: npx jsr publish
+      
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      
+      - name: Publish to JSR
+        run: deno publish

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.189.4",
+  "version": "0.189.5",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -73,6 +73,7 @@
     "egse",
     "Behavior",
     "Behavioral",
-    "APFS"
+    "APFS",
+    "analyzed"
   ]
 }

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -24,7 +24,9 @@ export class WorkerProcessor {
     filePath: string,
   ): Promise<CostInterface> {
     try {
-      // Dynamic import of the custom cost function file
+      // Dynamic import of user-provided custom cost function file.
+      // JSR Warning: This dynamic import is intentional and loads external user files at runtime.
+      // The import path cannot be analyzed at publish time as it's provided by the user.
       const module = await import(filePath);
 
       // Try to get the default export first, then look for named exports


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches CI to use `deno publish` with Deno setup and bumps version to 0.189.5.
> 
> - **CI/CD**:
>   - Update `/.github/workflows/publish.yml` to set up Deno (`denoland/setup-deno@v1`) and publish via `deno publish` instead of `npx jsr publish`.
> - **Release**:
>   - Bump version in `deno.json` from `0.189.4` to `0.189.5`.
> - **Docs/Spelling**:
>   - Add "analyzed" to `docs/cspell.json` dictionary.
> - **Code Comments**:
>   - Clarify intentional dynamic import behavior in `src/multithreading/workers/WorkerProcessor.ts` for user-provided cost functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a2b78c03aa37afacbed311e9ea3c88542dd322f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->