### PR TITLE
Update version to 0.191.0 in deno.json and modify logging in Discover…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.190.2",
+  "version": "0.191.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -277,7 +277,7 @@ class DataRecorder {
         if (this.timeoutTS && Date.now() > this.timeoutTS) {
           if (this.options.log) {
             console.warn(
-              `⚠️  Discovery ${
+              `⏲  Discovery ${
                 blue(this.ID)
               } timeout reached during file processing. ` +
                 `Processed ${counter.count} records. Proceeding with partial results for analysis.`,


### PR DESCRIPTION
…Directory to enhance clarity during discovery timeouts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps package to 0.191.0 and changes the discovery timeout warning emoji in logging.
> 
> - **Versioning**:
>   - Update `deno.json` `version` from `0.190.2` to `0.191.0`.
> - **Logging**:
>   - In `src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts`, change timeout warning message icon from `⚠️` to `⏲` during file processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6156f49b07ecc4606ceefe8ff15c2ba65129c0b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->