### PR TITLE
V0.191.1 fixed failing tests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.191.0",
+  "version": "0.191.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1244,7 +1244,7 @@ export class DiscoverStructure {
     const creatureUUID = CreatureUtil.makeUUID(creature);
     const exportJSON = creature.exportJSON();
     exportJSON.synapses = exportJSON.synapses.filter((synapse) => {
-      return synapse.fromUUID !== worseCandidate.fromNeuronUUID &&
+      return synapse.fromUUID !== worseCandidate.fromNeuronUUID ||
         synapse.toUUID !== worseCandidate.toNeuronUUID;
     });
 

--- a/src/mutate/SubBackCon.ts
+++ b/src/mutate/SubBackCon.ts
@@ -40,6 +40,7 @@ export class SubBackCon implements RadioactiveInterface {
 
     // Cleanup: Check if TO neuron needs handling
     const inwardList = this.creature.inwardConnections(pair[1]);
+    let toNeuronRemoved = false;
     if (inwardList.length === 0) {
       const toNeuron = this.creature.neurons[pair[1]];
       if (toNeuron.type === "hidden") {
@@ -49,6 +50,7 @@ export class SubBackCon implements RadioactiveInterface {
             `Remove neuron ${toNeuron.uuid} as completely disconnected`,
           );
           removeHiddenNeuron(this.creature, pair[1]);
+          toNeuronRemoved = true;
         } else {
           console.info(
             `Convert neuron ${toNeuron.uuid} from ${toNeuron.type} to constant`,
@@ -68,15 +70,20 @@ export class SubBackCon implements RadioactiveInterface {
       }
     }
 
+    // Adjust the 'from' index if the 'to' neuron was removed and it came before the 'from' neuron
+    let fromIndex = pair[0];
+    if (toNeuronRemoved && pair[1] < pair[0]) {
+      fromIndex--;
+    }
     // Cleanup: Check if FROM neuron needs removal
-    const fromOutwardList = this.creature.outwardConnections(pair[0]);
+    const fromOutwardList = this.creature.outwardConnections(fromIndex);
     if (fromOutwardList.length === 0) {
-      const fromNeuron = this.creature.neurons[pair[0]];
+      const fromNeuron = this.creature.neurons[fromIndex];
       if (fromNeuron.type === "hidden" || fromNeuron.type === "constant") {
         console.info(
           `Remove neuron ${fromNeuron.uuid} as no longer connected`,
         );
-        removeHiddenNeuron(this.creature, pair[0]);
+        removeHiddenNeuron(this.creature, fromIndex);
       }
     }
 

--- a/src/mutate/SubConnection.ts
+++ b/src/mutate/SubConnection.ts
@@ -44,6 +44,7 @@ export class SubConnection implements RadioactiveInterface {
     delete this.creature.memetic;
     const inwardList = this.creature.inwardConnections(randomConn.to);
 
+    let toNeuronRemoved = false;
     if (inwardList.length === 0) {
       const neuron = this.creature.neurons[randomConn.to];
       if (neuron.type === "hidden") {
@@ -55,6 +56,7 @@ export class SubConnection implements RadioactiveInterface {
             `Remove neuron ${neuron.uuid} as completely disconnected`,
           );
           removeHiddenNeuron(this.creature, randomConn.to);
+          toNeuronRemoved = true;
         } else {
           // Has outward connections - convert to constant
           console.info(
@@ -76,12 +78,17 @@ export class SubConnection implements RadioactiveInterface {
       }
     }
 
-    const fromOutwardList = this.creature.outwardConnections(randomConn.from);
+    // Adjust the 'from' index if the 'to' neuron was removed and it came before the 'from' neuron
+    let fromIndex = randomConn.from;
+    if (toNeuronRemoved && randomConn.to < randomConn.from) {
+      fromIndex--;
+    }
+    const fromOutwardList = this.creature.outwardConnections(fromIndex);
     if (fromOutwardList.length === 0) {
-      const fromNeuron = this.creature.neurons[randomConn.from];
+      const fromNeuron = this.creature.neurons[fromIndex];
       if (fromNeuron.type === "hidden" || fromNeuron.type === "constant") {
         console.info(`Remove neuron ${fromNeuron.uuid} as no longer connected`);
-        removeHiddenNeuron(this.creature, randomConn.from);
+        removeHiddenNeuron(this.creature, fromIndex);
       }
     }
     return true;

--- a/test/ErrorGuidedStructuralEvolution/DiscoverNeuron.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverNeuron.ts
@@ -163,11 +163,14 @@ Deno.test("Error-Driven Synapse Discovery neuron discovery", async () => {
   betterCreature.validate();
   const betterCreatureJSON = betterCreature.exportJSON();
   /** Verify synapses that were removed are discovered again: */
-  const input44 = betterCreatureJSON.synapses.find((synapse) =>
-    synapse.fromUUID === "input-44"
+  const input44ToHidden3 = betterCreatureJSON.synapses.find((synapse) =>
+    synapse.fromUUID === "input-44" && synapse.toUUID === "hidden-3"
   );
 
-  assert(!input44, "Should have REMOVED synapse from input-44");
+  assert(
+    !input44ToHidden3,
+    "Should have REMOVED synapse from input-44 to hidden-3",
+  );
 
   await discoverStructure.cleanUp();
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes harmful synapse removal logic and mutation cleanup (handling neuron index shifts) and updates tests; bumps version to 0.191.1.
> 
> - **Discovery/Pruning**:
>   - Fix `DiscoverStructure.removeSynapse` filter to remove only the exact synapse matching both `fromUUID` and `toUUID`.
> - **Mutation cleanup**:
>   - `SubBackCon` and `SubConnection`: handle possible removal of the `to` neuron and adjust `from` index before checking/removing upstream neuron; convert orphan hidden neurons to `constant` or remove when fully disconnected.
> - **Tests**:
>   - Strengthen assertion to verify removal of synapse `input-44 -> hidden-3` in `DiscoverNeuron` test.
> - **Version**:
>   - Bump `deno.json` version to `0.191.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27216a53c7e6bfcfcbcbdb62b2fd405700b80847. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->