### PR TITLE
Correct Australian English spelling errors

### DIFF
--- a/bench/ActivateAndTrace.ts
+++ b/bench/ActivateAndTrace.ts
@@ -24,12 +24,12 @@ import { SparseConfig } from "../src/propagate/sparse/SparseConfig.ts";
  * ----------- ----------------------------- --------------------- --------------------------
  * Activate           360.4 ms           2.8 (268.8 ms … 448.8 ms) 443.2 ms 448.8 ms 448.8 ms
  *
- * M3 v0.131.0 improve max/min prpogation
+ * M3 v0.131.0 improve max/min propagation
  * benchmark          time/iter (avg)        iter/s      (min … max)           p75      p99     p995
  * ------------------ ----------------------------- --------------------- --------------------------
  * ActivateAndTrace          316.2 ms           3.2 (235.5 ms … 416.5 ms) 336.8 ms 416.5 ms 416.5 ms
  *
- * M3 v0.132.0 improve neuron prpogation
+ * M3 v0.132.0 improve neuron propagation
  * benchmark          time/iter (avg)        iter/s      (min … max)           p75      p99     p995
  * ------------------ ----------------------------- --------------------- --------------------------
  * ActivateAndTrace          294.5 ms           3.4 (214.2 ms … 343.7 ms) 327.0 ms 343.7 ms 343.7 ms

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -78,6 +78,15 @@
     "buildup",
     "headerless",
     "checkpointed",
-    "clearable"
+    "clearable",
+    "Plotly",
+    "Cytoscape",
+    "cytoscape",
+    "textposition",
+    "yaxis",
+    "automargin",
+    "autorange",
+    "xaxis",
+    "uniques"
   ]
 }


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-257232b9-edea-4203-9c33-962c01818c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-257232b9-edea-4203-9c33-962c01818c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix spelling in benchmark comments and expand cspell dictionary with Plotly/Cytoscape and plotting terms.
> 
> - **Benchmarks**:
>   - Fix typos in `bench/ActivateAndTrace.ts` comments (`prpogation` → `propagation`).
> - **Docs**:
>   - Extend `docs/cspell.json` dictionary with plotting/graph terms: `Plotly`, `Cytoscape`, `cytoscape`, `textposition`, `yaxis`, `automargin`, `autorange`, `xaxis`, `uniques`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71a44d4c83caab3132219af13a61b856be445e4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->