### PR TITLE
Remove push triggers from GitHub workflows for CodeQL, coverage, and …

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,6 @@
 name: "CodeQL Advanced"
 
 on:
-  push:
-    branches: ["Develop"]
   pull_request:
     branches: ["Develop"]
   schedule:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - Develop
-  push:
-    branches:
-      - Develop
 
 jobs:
   quality:

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -3,9 +3,6 @@ on:
   pull_request:
     branches:
       - Develop
-  push:
-    branches:
-      - Develop
 
 jobs:
   spellcheck: # run the action

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.193.2",
+  "version": "0.193.3",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",


### PR DESCRIPTION
…spellcheck, ensuring they only run on pull requests to the Develop branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes push triggers from CodeQL, coverage, and spellcheck workflows so they run only on pull requests to the Develop branch (CodeQL schedule retained).
> 
> - **CI Workflows**:
>   - `/.github/workflows/codeql.yml`: Remove `push` trigger; keep `pull_request` for `Develop` and existing `schedule`.
>   - `/.github/workflows/coverage.yaml`: Remove `push` trigger; keep `pull_request` for `Develop`.
>   - `/.github/workflows/spellcheck.yaml`: Remove `push` trigger; keep `pull_request` for `Develop`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c4ec1b50285f7b06401729912ff2353e5d47d1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->