### PR TITLE
Confirm and convert error values in parquet

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.194.0",
+  "version": "0.194.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -31,7 +31,7 @@ import {
 
 export interface DiscoverRecord {
   activation: number;
-  errors: string;
+  errors: number[];
   value?: number;
 }
 
@@ -311,14 +311,10 @@ export class DiscoverStructure {
         const neuronData = nonInputNeurons.map((neuron) => {
           const discoverRecord = discoverMap.get(neuron.uuid) || {
             activation: this.creature.state.activations[neuron.index],
-            errors: "",
+            errors: [] as number[],
           };
 
-          const errors = discoverRecord.errors
-            ? discoverRecord.errors.split("|").map(Number).filter(
-              Number.isFinite,
-            )
-            : [];
+          const errors = discoverRecord.errors.filter(Number.isFinite);
 
           return {
             neuron_uuid: neuron.uuid,
@@ -581,7 +577,12 @@ export class DiscoverStructure {
       value = activation;
     }
 
-    return { value, activation, errors: record.errors };
+    const rawErrors = record.errors ?? "";
+    const errors = rawErrors.length === 0
+      ? []
+      : rawErrors.split("|").map(Number).filter(Number.isFinite);
+
+    return { value, activation, errors };
   }
 
   private processCSVChunk(
@@ -696,7 +697,7 @@ export class DiscoverStructure {
 
             fileRecords.push({
               activation,
-              errors: "", // Input neurons don't have errors
+              errors: [], // Input neurons don't have errors
             });
           }
         } finally {
@@ -781,7 +782,7 @@ export class DiscoverStructure {
       const converted = sortedRecords.map((r) => ({
         activation: r.activation,
         value: r.value ?? r.activation, // Use activation as fallback for value
-        errors: r.errors.map((e) => e.toString()).join("|"), // Join with pipe to match original format
+        errors: [...r.errors],
       }));
 
       return converted;
@@ -870,7 +871,7 @@ export class DiscoverStructure {
 
           let invalidErrorCount = 0;
           const totalError = records.reduce((sum, record) => {
-            const errors = record.errors.split("|").map(Number);
+            const errors = record.errors;
             const recordError = errors.reduce((eSum, e) => {
               if (!Number.isFinite(e)) {
                 invalidErrorCount++;
@@ -887,8 +888,7 @@ export class DiscoverStructure {
             neuronsWithInvalidErrors++;
             console.warn(
               `⚠️  WARNING: Neuron ${neuron.uuid} has ${invalidErrorCount} invalid error values (NaN/Infinity) out of ${
-                records.reduce((count, r) =>
-                  count + r.errors.split("|").length, 0)
+                records.reduce((count, r) => count + r.errors.length, 0)
               } total error values. This indicates a bug in error calculation or data corruption.`,
             );
           }
@@ -1091,7 +1091,7 @@ export class DiscoverStructure {
       if (Math.abs(activation) <= Number.EPSILON) continue;
 
       // Compute average downstream error
-      const errorList = toRecord.errors.split("|").map(Number);
+      const errorList = toRecord.errors;
       if (errorList.length === 0) continue; // Skip if no errors
 
       const avgError = errorList.reduce((a, b) => a + b, 0) / errorList.length;
@@ -1251,8 +1251,10 @@ export class DiscoverStructure {
         throw new Error("Activation is undefined");
       }
       currentActivations.push(activation);
-      const errors = record.errors.split("|").map(Number);
-      const avgError = errors.reduce((a, b) => a + b, 0) / errors.length;
+      const errors = record.errors;
+      const avgError = errors.length
+        ? errors.reduce((a, b) => a + b, 0) / errors.length
+        : 0;
 
       idealActivations.push(activation + avgError);
     });
@@ -1359,7 +1361,8 @@ export class DiscoverStructure {
       const activation = fromRecord.activation;
       if (Math.abs(activation) <= Number.EPSILON) continue;
 
-      const errorList = toRecord.errors.split("|").map(Number);
+      const errorList = toRecord.errors;
+      if (errorList.length === 0) continue;
       const avgError = errorList.reduce((a, b) => a + b, 0) / errorList.length;
       if (Math.abs(avgError) <= Number.EPSILON) continue;
 

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -677,7 +677,7 @@ export class Neuron implements TagsInterface, NeuronInternal {
     if (discoverRecord === undefined) {
       discoverRecord = {
         activation: currentActivation,
-        errors: "",
+        errors: [],
       };
       assert(discoverRecord !== undefined);
       discoverMap.set(this.uuid, discoverRecord);
@@ -715,11 +715,7 @@ export class Neuron implements TagsInterface, NeuronInternal {
         error = targetValue - currentValue!;
       }
 
-      if (discoverRecord.errors) {
-        discoverRecord.errors += "|" + error;
-      } else {
-        discoverRecord.errors = error.toString();
-      }
+      discoverRecord.errors.push(error);
 
       if (listLength) {
         const errorPerLink = error / listLength;

--- a/test/ErrorGuidedStructuralEvolution/DiscoverRecordErrors.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverRecordErrors.ts
@@ -1,0 +1,46 @@
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test("discovery records store errors as numeric arrays", () => {
+  const creatureJSON: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      {
+        uuid: "output-0",
+        type: "output",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1,
+      },
+    ],
+  };
+
+  const creature = Creature.fromJSON(creatureJSON);
+
+  // Activate once so the internal state reflects actual output values.
+  const input = new Float32Array([0.5]);
+  creature.activate(input);
+
+  const expected = new Float32Array([0]);
+  const discoverMap = creature.record(expected);
+
+  const record = discoverMap.get("output-0");
+  assert(record, "expected a discovery record for output-0");
+
+  const { errors } = record as unknown as { errors: unknown };
+  assert(Array.isArray(errors), "errors should be stored as an array");
+  assert(errors.length > 0, "errors should contain at least one entry");
+
+  for (const value of errors) {
+    assertEquals(typeof value, "number");
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Convert discovery record `errors` from pipe-delimited strings to numeric arrays across recording, I/O, and analysis, with a validating test.
> 
> - **Core data model**:
>   - Change `DiscoverRecord.errors` from `string` to `number[]` and update all producers/consumers accordingly.
> - **Recording/processing**:
>   - In `Neuron.record`, push numeric errors to `errors: number[]`.
>   - When flushing to Rust, pass filtered numeric `errors`; when reading Parquet, return numeric arrays.
>   - CSV parsing converts `errors` field to `number[]`; input neurons default to empty arrays.
> - **Analysis logic**:
>   - Replace string splitting with direct array usage in error aggregations (candidate synapse analysis, synapse harm analysis, neuron ranking, squash search), handling empty arrays safely.
> - **I/O and utilities**:
>   - Binary input loader initializes `errors` as empty arrays; indices counting updated to use array lengths.
> - **Tests**:
>   - Add `DiscoverRecordErrors` test asserting discovery records store `errors` as numeric arrays of numbers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c6c07bb656363c3a538d11172d746b25013fbaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->