### PR TITLE
Refactor logging in discovery process to use centralized logging func…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.194.3",
+  "version": "0.194.4",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -9,6 +9,9 @@ import type { DiscoverResult } from "./DiscoverResult.ts";
 import { DiscoverStructure } from "./DiscoverStructure.ts";
 import { isRustDiscoveryEnabled } from "./RustDiscovery.ts";
 
+const shouldLogDiscovery = (options: NeatOptions): boolean =>
+  Boolean(options.verbose || (options.log && options.log > 0));
+
 export async function recordDirectory(
   creature: Creature,
   dataDir: string,
@@ -102,7 +105,7 @@ class DataRecorder {
   async recordDirectory(dataDir: string): Promise<DiscoverResult> {
     // Check if Rust discovery module is available
     if (!isRustDiscoveryEnabled()) {
-      if (this.options.log) {
+      if (shouldLogDiscovery(this.options)) {
         console.warn(
           `⚠️  Discovery skipped: Rust module not available. Discovery requires the NEAT-AI-Discovery Rust library to be built and available.`,
         );
@@ -136,7 +139,7 @@ class DataRecorder {
       drainCounter: { count: number };
     },
   ) {
-    if (this.options.log) {
+    if (shouldLogDiscovery(this.options)) {
       console.log(`Discovery ${blue(this.ID)} processing ${filePath}`);
     }
 
@@ -220,7 +223,7 @@ class DataRecorder {
             }
             params.drainCounter.count = 0;
 
-            if (this.options.log) {
+            if (shouldLogDiscovery(this.options)) {
               console.log(
                 `Discovery ${
                   blue(this.ID)
@@ -242,7 +245,7 @@ class DataRecorder {
       file.close();
     }
 
-    if (this.options.log) {
+    if (shouldLogDiscovery(this.options)) {
       console.log(
         `Discovery ${blue(this.ID)} read time ${
           yellow(format(readTime, { ignoreZero: true }))
@@ -256,7 +259,7 @@ class DataRecorder {
     const startTime = Date.now();
     let currentPhase = "initialization"; // Track phase for timeout diagnostics
 
-    if (options.log) {
+    if (shouldLogDiscovery(options)) {
       console.info(
         `Discovery ${
           blue(this.ID)
@@ -281,7 +284,7 @@ class DataRecorder {
     // Declare timing variables outside try block for error diagnostics
     let fileProcessTime = 0;
 
-    if (options.log) {
+    if (shouldLogDiscovery(options)) {
       console.log(
         `Discovery ${blue(this.ID)} initialize time ${
           yellow(format(initializeTime, { ignoreZero: true }))
@@ -331,7 +334,7 @@ class DataRecorder {
         }
         drainCounter.count = 0; // Reset drain counter after file
 
-        if (this.options.log) {
+        if (shouldLogDiscovery(this.options)) {
           console.log(
             `Discovery ${
               blue(this.ID)
@@ -340,7 +343,7 @@ class DataRecorder {
         }
 
         if (this.timeoutTS && Date.now() > this.timeoutTS) {
-          if (this.options.log) {
+          if (shouldLogDiscovery(this.options)) {
             console.warn(
               `⏲  Discovery ${
                 blue(this.ID)
@@ -361,7 +364,7 @@ class DataRecorder {
       );
 
       const scannedTime = Date.now() - startTime;
-      if (options.log) {
+      if (shouldLogDiscovery(options)) {
         console.log(
           `Discovery ${blue(this.ID)} scanning time ${
             yellow(format(scannedTime, { ignoreZero: true }))
@@ -411,7 +414,7 @@ class DataRecorder {
       const rustFlushSuccess = discoverStructure.flushRustRecording();
       if (!rustFlushSuccess) {
         // Rust recording failed - return empty result (discovery skipped)
-        if (options.log) {
+        if (shouldLogDiscovery(options)) {
           console.warn(
             `⚠️  Discovery ${
               blue(this.ID)
@@ -426,7 +429,7 @@ class DataRecorder {
         };
       }
 
-      if (options.log) {
+      if (shouldLogDiscovery(options)) {
         const recordTime = Date.now() - startTime;
         console.log(
           `Discovery ${blue(this.ID)} recorded time ${
@@ -442,7 +445,7 @@ class DataRecorder {
       const analysisTimeoutSeconds = analysisTimeoutMinutes * 60;
       discoverStructure.extendTimeoutForAnalysis(analysisTimeoutSeconds);
 
-      if (options.log) {
+      if (shouldLogDiscovery(options)) {
         console.log(
           `Discovery ${blue(this.ID)} analysis timeout extended by ${
             yellow(analysisTimeoutMinutes.toString())
@@ -463,7 +466,7 @@ class DataRecorder {
       const addHelpfulSynapse = await discoverStructure.analyze(
         this.discoveryMaxNeurons,
       );
-      if (options.log) {
+      if (shouldLogDiscovery(options)) {
         const analyzeTime = Date.now() - analyzeStartTime;
         console.log(
           `Discovery ${blue(this.ID)} analyze time ${
@@ -484,7 +487,7 @@ class DataRecorder {
         .analyzeSynapsesForRemoval(
           this.discoveryMaxNeurons,
         );
-      if (options.log) {
+      if (shouldLogDiscovery(options)) {
         const harmfulTime = Date.now() - harmfulStartTime;
         console.log(
           `Discovery ${blue(this.ID)} analyze harmful time ${
@@ -502,7 +505,7 @@ class DataRecorder {
         .analyzeNeuronsSquashes(
           this.discoveryMaxNeurons,
         );
-      if (options.log) {
+      if (shouldLogDiscovery(options)) {
         const squashTime = Date.now() - squashStartTime;
         const squashCount = candidateSquashes ? candidateSquashes.length : 0;
         let squashSummaryText = "";
@@ -530,7 +533,7 @@ class DataRecorder {
       }
 
       currentPhase = "complete";
-      if (options.log) {
+      if (shouldLogDiscovery(options)) {
         const totalTime = Date.now() - startTime;
         console.log(
           `Discovery ${blue(this.ID)} analysis complete, total time ${
@@ -542,11 +545,11 @@ class DataRecorder {
       // Schedule cleanup to happen asynchronously without blocking the response
       // This prevents slow filesystem operations from delaying the discovery result
       const cleanupPromise = (async () => {
-        if (options.log) {
+        if (shouldLogDiscovery(options)) {
           console.log(`Discovery ${blue(this.ID)} performing cleanup...`);
         }
         await discoverStructure.cleanUp();
-        if (options.log) {
+        if (shouldLogDiscovery(options)) {
           console.log(`Discovery ${blue(this.ID)} cleanup complete.`);
         }
       })();
@@ -582,14 +585,14 @@ class DataRecorder {
       );
       console.error(`     - Total: ${format(totalTime, { ignoreZero: true })}`);
 
-      if (options.log) {
+      if (shouldLogDiscovery(options)) {
         console.log(
           `Discovery ${blue(this.ID)} error occurred, performing cleanup...`,
         );
       }
       try {
         await discoverStructure.cleanUp();
-        if (options.log) {
+        if (shouldLogDiscovery(options)) {
           console.log(`Discovery ${blue(this.ID)} cleanup complete.`);
         }
       } catch (cleanupError) {

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -100,6 +100,11 @@ export class DiscoveryRunner {
 
     const { creature, dataDir } = input;
     const config = createNeatConfig(input.options);
+    const verboseLog = (...args: unknown[]) => {
+      if (config.verbose) {
+        console.info("[DiscoveryRunner]", ...args);
+      }
+    };
     if (config.discoverySampleRate <= 0) {
       throw new Error(
         "Discovery requires a positive discoverySampleRate.",
@@ -113,6 +118,7 @@ export class DiscoveryRunner {
 
     CreatureUtil.makeUUID(creature);
 
+    const verboseLogging = Boolean(config.verbose);
     const workerCount = Math.max(1, config.threads);
     const workers: DiscoveryRunnerWorker[] = [];
     try {
@@ -125,9 +131,20 @@ export class DiscoveryRunner {
         }));
       }
 
+      const workerOptions: NeatOptions = (config.log && config.log > 0) ||
+          !config.verbose
+        ? config
+        : { ...config, log: 1 };
+
+      verboseLog(
+        `Starting discovery for creature ${creature.uuid ?? "unknown"} using ${
+          workerCount === 1 ? "single" : workerCount
+        } worker${workerCount === 1 ? "" : "s"}.`,
+      );
+
       const discoveryResponse = await workers[0].discover(
         creature,
-        config,
+        workerOptions,
       );
       assert(
         discoveryResponse.discover,
@@ -141,7 +158,19 @@ export class DiscoveryRunner {
         candidateSquashes: rawDiscover.candidateSquashes ?? undefined,
       };
 
+      const addCount = discoverResult.addHelpfulSynapses?.length ?? 0;
+      const removePresent = discoverResult.removeHarmfulSynapse ? 1 : 0;
+      const squashCount = discoverResult.candidateSquashes?.length ?? 0;
+      verboseLog(
+        `Discovery ${discoverResult.ID} suggested ${addCount} add, ${removePresent} remove, ${squashCount} squash candidate(s).`,
+      );
+
       const candidates = this.#candidateBuilder(creature, discoverResult);
+      verboseLog(
+        `Built ${candidates.length} candidate creature${
+          candidates.length === 1 ? "" : "s"
+        }: ${candidates.map((c) => c.change.type).join(", ") || "none"}.`,
+      );
 
       const evaluationTasks: Array<{
         kind: "original" | "candidate";
@@ -161,6 +190,7 @@ export class DiscoveryRunner {
         evaluationTasks,
         config.feedbackLoop,
         config.costOfGrowth,
+        verboseLogging,
       );
 
       const original = evaluationResults.find((result) =>
@@ -224,6 +254,7 @@ export class DiscoveryRunner {
     }>,
     feedbackLoop: boolean,
     costOfGrowth: number,
+    verbose: boolean,
   ) {
     const queue = tasks.slice();
     const results: Array<{
@@ -256,6 +287,15 @@ export class DiscoveryRunner {
         error,
         score,
       });
+
+      if (verbose) {
+        console.info("[DiscoveryRunner] Evaluation result", {
+          kind: task.kind,
+          change: task.candidate?.change.type,
+          error,
+          score,
+        });
+      }
 
       await processNext(worker);
     };

--- a/test/discovery/DiscoveryCandidates.test.ts
+++ b/test/discovery/DiscoveryCandidates.test.ts
@@ -1,17 +1,24 @@
 import { assert, assertEquals } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
-import type {
-  CandidateSquash,
-  CandidateSynapse,
-} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import {
+  assertRustDiscoveryAvailable,
+  shouldSkipRustDiscoveryTests,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import {
   buildDiscoveryCandidates,
   type DiscoveryCandidate,
 } from "../../src/discovery/DiscoveryCandidates.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { LeakyReLU } from "../../src/methods/activations/types/LeakyReLU.ts";
+import { Mish } from "../../src/methods/activations/types/Mish.ts";
+import { TANH } from "../../src/methods/activations/types/TANH.ts";
+import { MSE } from "../../src/costs/MSE.ts";
 
-function makeBaseCreature() {
+function makeBaselineCreature(): Creature {
   const creature = Creature.fromJSON({
     input: 4,
     output: 2,
@@ -34,56 +41,122 @@ function makeBaseCreature() {
   return creature;
 }
 
-function cloneBaseCreature() {
-  return Creature.fromJSON(makeBaseCreature().exportJSON());
+function makeTargetCreature(): Creature {
+  const creature = Creature.fromJSON({
+    neurons: [
+      {
+        type: "hidden",
+        uuid: "hidden-3",
+        squash: IDENTITY.NAME,
+        bias: Math.PI,
+      },
+      {
+        type: "hidden",
+        uuid: "hidden-4",
+        squash: TANH.NAME,
+        bias: Math.SQRT1_2,
+      },
+      {
+        type: "output",
+        uuid: "output-0",
+        squash: IDENTITY.NAME,
+        bias: -0.123,
+      },
+      {
+        type: "output",
+        uuid: "output-1",
+        squash: LeakyReLU.NAME,
+        bias: 0.456,
+      },
+      {
+        type: "output",
+        uuid: "output-2",
+        squash: Mish.NAME,
+        bias: 0.345,
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-33", toUUID: "hidden-3", weight: -0.3 },
+      { fromUUID: "input-50", toUUID: "hidden-4", weight: 0.3 },
+      { fromUUID: "input-11", toUUID: "hidden-3", weight: -0.1 },
+      { fromUUID: "input-22", toUUID: "hidden-4", weight: 0.2 },
+      { fromUUID: "hidden-3", toUUID: "output-0", weight: 0.6 },
+      { fromUUID: "hidden-4", toUUID: "output-1", weight: 0.7 },
+      { fromUUID: "input-10", toUUID: "output-2", weight: -0.4 },
+      { fromUUID: "hidden-4", toUUID: "output-2", weight: 0.13 },
+    ],
+    input: 100,
+    output: 3,
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
 }
 
-function makeAddCandidate(): CandidateSynapse {
-  return {
-    fromNeuronUUID: "hidden-2",
-    toNeuronUUID: "output-0",
-    weight: 0.42,
-    expectedImprovementPercentage: 0.25,
-    improvedCount: 12,
-    totalCount: 20,
-  };
-}
-
-function makeRemoveCandidate(): CandidateSynapse {
-  return {
-    fromNeuronUUID: "hidden-1",
-    toNeuronUUID: "output-0",
-    weight: 0.2,
-    expectedImprovementPercentage: 0.3,
-    improvedCount: 15,
-    totalCount: 20,
-  };
-}
-
-function makeSquashCandidate(): CandidateSquash {
-  return {
-    neuronUUID: "hidden-2",
-    previousSquash: "IDENTITY",
-    squash: "TANH",
-    expectedImprovementPercentage: 0.35,
-    improvedError: 0.1,
-    currentError: 0.2,
-  };
-}
-
-function assertSynapse(
+function generateTrainingData(
   creature: Creature,
-  fromUUID: string,
-  toUUID: string,
-) {
-  const found = creature.exportJSON().synapses.some((synapse) =>
-    synapse.fromUUID === fromUUID && synapse.toUUID === toUUID
-  );
-  assert(found, `Expected synapse ${fromUUID}->${toUUID} to exist`);
+  sampleCount = 1024,
+): DataRecordInterface[] {
+  const trainingData: DataRecordInterface[] = [];
+  for (let sample = 0; sample < sampleCount; sample++) {
+    const inputValues = new Float32Array(creature.input);
+    for (let i = 0; i < creature.input; i++) {
+      inputValues[i] = Math.random() * 2 - 1;
+    }
+    const outputValues = creature.activate(inputValues);
+    trainingData.push({
+      input: new Float32Array(inputValues),
+      output: new Float32Array(outputValues),
+    });
+  }
+  return trainingData;
+}
+
+function makeCrippledCreature(targetCreature: Creature): Creature {
+  const exported = targetCreature.exportJSON();
+  exported.synapses = exported.synapses.filter((synapse) => {
+    const removeHidden3 = synapse.fromUUID === "input-33" &&
+      synapse.toUUID === "hidden-3";
+    const removeHidden4 = synapse.fromUUID === "input-22" &&
+      synapse.toUUID === "hidden-4";
+    return !(removeHidden3 || removeHidden4);
+  });
+  exported.synapses.push({
+    fromUUID: "input-44",
+    toUUID: "hidden-3",
+    weight: 1,
+  });
+  const crippled = Creature.fromJSON(exported);
+  crippled.validate();
+  CreatureUtil.makeUUID(crippled);
+  return crippled;
+}
+
+function findCandidate(
+  candidates: DiscoveryCandidate[],
+  type: DiscoveryCandidate["change"]["type"],
+): DiscoveryCandidate {
+  const candidate = candidates.find((entry) => entry.change.type === type);
+  assert(candidate, `Expected to find candidate for ${type}`);
+  return candidate;
+}
+
+function averageMSE(
+  creature: Creature,
+  trainingData: DataRecordInterface[],
+): number {
+  const evaluator = Creature.fromJSON(creature.exportJSON());
+  const mse = new MSE();
+  let total = 0;
+  for (const record of trainingData) {
+    const prediction = evaluator.activate(new Float32Array(record.input));
+    total += mse.calculate(record.output, prediction);
+  }
+  return total / trainingData.length;
 }
 
 Deno.test("buildDiscoveryCandidates returns empty list when there are no suggestions", () => {
-  const base = makeBaseCreature();
+  const base = makeBaselineCreature();
   const discovery: DiscoverResult = {
     ID: "ABCD1234",
     addHelpfulSynapses: undefined,
@@ -96,130 +169,125 @@ Deno.test("buildDiscoveryCandidates returns empty list when there are no suggest
     discovery,
   );
   assertEquals(candidates.length, 0);
-  // Original creature should not be altered
   const originalSynapseCount = base.exportJSON().synapses.length;
   assertEquals(originalSynapseCount, 5);
 });
 
-Deno.test("buildDiscoveryCandidates includes helpful synapse candidate", () => {
-  const base = makeBaseCreature();
-  const addCandidate = makeAddCandidate();
-  const discovery: DiscoverResult = {
-    ID: "HELP1234",
-    addHelpfulSynapses: [addCandidate],
-    removeHarmfulSynapse: undefined,
-    candidateSquashes: undefined,
-  };
+Deno.test({
+  name:
+    "buildDiscoveryCandidates integrates live discovery data for add/remove combinations",
+  ignore: shouldSkipRustDiscoveryTests(),
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    assertRustDiscoveryAvailable();
+    const targetCreature = makeTargetCreature();
+    const trainingData = generateTrainingData(targetCreature);
+    const crippledCreature = makeCrippledCreature(targetCreature);
 
-  const candidates: DiscoveryCandidate[] = buildDiscoveryCandidates(
-    base,
-    discovery,
-  );
+    const discoverStructure = new DiscoverStructure(crippledCreature, 60);
+    const neuronPromises: Map<string, Promise<void>> = new Map();
+    discoverStructure.initialize(neuronPromises);
+    try {
+      const recorded = discoverStructure.record(trainingData, neuronPromises);
+      assert(recorded, "Recording discovery dataset should succeed");
+      await Promise.all([...neuronPromises.values()]);
 
-  assertEquals(candidates.length, 1);
-  assertEquals(candidates[0].change.type, "add-synapses");
-  assertSynapse(
-    candidates[0].creature,
-    addCandidate.fromNeuronUUID,
-    addCandidate.toNeuronUUID,
-  );
-  // Ensure original is untouched
-  assertEquals(
-    CreatureUtil.makeUUID(base),
-    CreatureUtil.makeUUID(cloneBaseCreature()),
-  );
-});
+      const flushSuccess = discoverStructure.flushRustRecording();
+      assert(flushSuccess, "Flushing discovery data should succeed");
 
-Deno.test("buildDiscoveryCandidates generates combinations for add and remove", () => {
-  const base = makeBaseCreature();
-  const addCandidate = makeAddCandidate();
-  const removeCandidate = makeRemoveCandidate();
-  const discovery: DiscoverResult = {
-    ID: "COMBO1",
-    addHelpfulSynapses: [addCandidate],
-    removeHarmfulSynapse: removeCandidate,
-    candidateSquashes: undefined,
-  };
+      await discoverStructure.analyzeSelectedNeurons(["hidden-4"]);
+      const helpfulSynapses = await discoverStructure.analyzeSelectedNeurons([
+        "hidden-3",
+      ]);
+      assert(
+        helpfulSynapses && helpfulSynapses.length >= 2,
+        "Expected at least two helpful synapse candidates",
+      );
 
-  const candidates: DiscoveryCandidate[] = buildDiscoveryCandidates(
-    base,
-    discovery,
-  );
-  const types = candidates.map((candidate) => candidate.change.type);
-  assertEquals(types.sort(), [
-    "add-synapses",
-    "combo-add-remove",
-    "remove-synapse",
-  ]);
+      const removeCandidate = await discoverStructure
+        .analyzeSelectedNeuronsForRemoval([
+          "hidden-3",
+        ]);
+      assert(removeCandidate, "Expected a harmful synapse candidate");
 
-  const removeEntry = candidates.find((candidate) =>
-    candidate.change.type === "remove-synapse"
-  );
-  assert(removeEntry);
-  const removedSynapses = removeEntry.creature.exportJSON().synapses;
-  assertEquals(
-    removedSynapses.some((synapse) =>
-      synapse.fromUUID === removeCandidate.fromNeuronUUID &&
-      synapse.toUUID === removeCandidate.toNeuronUUID
-    ),
-    false,
-  );
+      const discovery: DiscoverResult = {
+        ID: "TEST-DISCOVERY",
+        addHelpfulSynapses: helpfulSynapses ?? undefined,
+        removeHarmfulSynapse: removeCandidate,
+        candidateSquashes: undefined,
+      };
 
-  const comboEntry = candidates.find((candidate) =>
-    candidate.change.type === "combo-add-remove"
-  );
-  assert(comboEntry);
-  assertSynapse(
-    comboEntry.creature,
-    addCandidate.fromNeuronUUID,
-    addCandidate.toNeuronUUID,
-  );
-});
+      const candidates = buildDiscoveryCandidates(
+        crippledCreature,
+        discovery,
+      );
+      const types = candidates.map((candidate) => candidate.change.type).sort();
+      assertEquals(types, [
+        "add-synapses",
+        "combo-add-remove",
+        "remove-synapse",
+      ]);
 
-Deno.test("buildDiscoveryCandidates combines helpful synapses with squash changes", () => {
-  const base = makeBaseCreature();
-  const addCandidate = makeAddCandidate();
-  const squashCandidate = makeSquashCandidate();
-  const discovery: DiscoverResult = {
-    ID: "COMBO2",
-    addHelpfulSynapses: [addCandidate],
-    removeHarmfulSynapse: undefined,
-    candidateSquashes: [squashCandidate],
-  };
+      const addCandidate = findCandidate(candidates, "add-synapses");
+      const addSynapses = addCandidate.creature.exportJSON().synapses;
+      const restoredInput22 = addSynapses.some((synapse) =>
+        synapse.fromUUID === "input-22" && synapse.toUUID === "hidden-4"
+      );
+      const restoredInput33 = addSynapses.some((synapse) =>
+        synapse.fromUUID === "input-33" && synapse.toUUID === "hidden-3"
+      );
+      assert(
+        restoredInput22 && restoredInput33,
+        "Expected missing synapses to be restored by add-synapses candidate",
+      );
 
-  const candidates: DiscoveryCandidate[] = buildDiscoveryCandidates(
-    base,
-    discovery,
-  );
-  const types = candidates.map((candidate) => candidate.change.type);
-  assertEquals(types.sort(), [
-    "add-synapses",
-    "change-squash",
-    "combo-add-change",
-  ]);
+      const removeEntry = findCandidate(candidates, "remove-synapse");
+      const removedSynapses = removeEntry.creature.exportJSON().synapses;
+      const removedInput44 = removedSynapses.some((synapse) =>
+        synapse.fromUUID === "input-44" && synapse.toUUID === "hidden-3"
+      );
+      assert(!removedInput44, "Harmful synapse should be removed");
 
-  const changeEntry = candidates.find((candidate) =>
-    candidate.change.type === "change-squash"
-  );
-  assert(changeEntry);
-  const changedNeuron = changeEntry.creature.exportJSON().neurons.find((
-    neuron,
-  ) => neuron.uuid === squashCandidate.neuronUUID);
-  assert(changedNeuron);
-  assertEquals(changedNeuron.squash, squashCandidate.squash);
+      const comboEntry = findCandidate(candidates, "combo-add-remove");
+      const comboSynapses = comboEntry.creature.exportJSON().synapses;
+      const comboHasInput22 = comboSynapses.some((synapse) =>
+        synapse.fromUUID === "input-22" && synapse.toUUID === "hidden-4"
+      );
+      const comboHasInput33 = comboSynapses.some((synapse) =>
+        synapse.fromUUID === "input-33" && synapse.toUUID === "hidden-3"
+      );
+      const comboRemovedInput44 = comboSynapses.some((synapse) =>
+        synapse.fromUUID === "input-44" && synapse.toUUID === "hidden-3"
+      );
+      assert(
+        comboHasInput22 && comboHasInput33,
+        "Combo candidate should contain newly discovered synapses",
+      );
+      assert(
+        !comboRemovedInput44,
+        "Combo candidate should exclude the harmful synapse",
+      );
 
-  const comboEntry = candidates.find((candidate) =>
-    candidate.change.type === "combo-add-change"
-  );
-  assert(comboEntry);
-  const comboNeuron = comboEntry.creature.exportJSON().neurons.find((neuron) =>
-    neuron.uuid === squashCandidate.neuronUUID
-  );
-  assert(comboNeuron);
-  assertEquals(comboNeuron.squash, squashCandidate.squash);
-  assertSynapse(
-    comboEntry.creature,
-    addCandidate.fromNeuronUUID,
-    addCandidate.toNeuronUUID,
-  );
+      const baselineError = averageMSE(crippledCreature, trainingData);
+      const removeError = averageMSE(removeEntry.creature, trainingData);
+      const comboError = averageMSE(comboEntry.creature, trainingData);
+      const addError = averageMSE(addCandidate.creature, trainingData);
+
+      assert(
+        removeError < baselineError,
+        "Removing harmful synapses should reduce mean squared error",
+      );
+      assert(
+        comboError < baselineError,
+        "Combining discovered changes should reduce mean squared error",
+      );
+      assert(
+        comboError <= addError,
+        "Combo candidate should not perform worse than adding synapses alone",
+      );
+    } finally {
+      await discoverStructure.cleanUp();
+    }
+  },
 });

--- a/test/discovery/DiscoveryRunner.test.ts
+++ b/test/discovery/DiscoveryRunner.test.ts
@@ -28,6 +28,7 @@ function makeBaseCreature() {
 class FakeWorker implements DiscoveryRunnerWorker {
   #discoverResult: DiscoverResult;
   #computeError: (creature: Creature) => number;
+  lastDiscoverOptions?: NeatOptions;
 
   constructor(
     discoverResult: DiscoverResult,
@@ -39,8 +40,9 @@ class FakeWorker implements DiscoveryRunnerWorker {
 
   discover(
     _creature: Creature,
-    _options: NeatOptions,
+    options: NeatOptions,
   ): Promise<Awaited<ReturnType<DiscoveryRunnerWorker["discover"]>>> {
+    this.lastDiscoverOptions = options;
     return Promise.resolve({
       taskID: 1,
       duration: 10,
@@ -97,6 +99,39 @@ Deno.test("DiscoveryRunner throws when Rust discovery is disabled", async () => 
       Error,
       "Discovery requires the NEAT-AI-Discovery Rust library",
     );
+  } finally {
+    // nothing
+  }
+});
+
+Deno.test("DiscoveryRunner enables verbose discovery logging when verbose option is set", async () => {
+  const discoveryResult: DiscoverResult = {
+    ID: "VERBOSE",
+    addHelpfulSynapses: undefined,
+    removeHarmfulSynapse: undefined,
+    candidateSquashes: undefined,
+  };
+
+  const worker = new FakeWorker(
+    discoveryResult,
+    () => 1.0,
+  );
+
+  const runner = new DiscoveryRunner({
+    rustDiscoveryEnabled: () => true,
+    workerFactory: () => worker,
+  });
+
+  try {
+    await runner.discoverDir({
+      creature: makeBaseCreature(),
+      dataDir: "/tmp/data",
+      options: makeOptions({ verbose: true }),
+    });
+
+    assert(worker.lastDiscoverOptions);
+    assertEquals(worker.lastDiscoverOptions.verbose, true);
+    assertEquals(worker.lastDiscoverOptions.log, 1);
   } finally {
     // nothing
   }


### PR DESCRIPTION
…tion

- Introduced `shouldLogDiscovery` function to streamline logging checks across the discovery process, enhancing code readability and maintainability.
- Updated all relevant logging conditions in `DataRecorder` and `DiscoveryRunner` to utilize the new function, ensuring consistent logging behavior based on verbosity settings.
- Added verbose logging capabilities in `DiscoveryRunner` to provide detailed insights during discovery operations.

This refactor improves the clarity of logging logic and facilitates easier adjustments to logging behavior in the future.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes discovery logging via `shouldLogDiscovery`, adds verbose diagnostics in `DiscoveryRunner`, and updates/expands tests including an integration-style candidates test and verbose-option propagation.
> 
> - **Discovery logging**
>   - Introduce `shouldLogDiscovery(options)` and replace ad-hoc `options.log` checks across `DiscoverDirectory.ts` for consistent verbosity handling.
>   - Add `verboseLog` helper and conditional verbose output in `DiscoveryRunner` (start/end, suggestion counts, candidate build, evaluation results).
>   - Ensure workers receive appropriate options: derive `workerOptions` to set `log: 1` when `verbose` is true.
> - **Behavioral tweaks**
>   - Pass adjusted `workerOptions` to `workers[0].discover`.
>   - Minor console messages standardized (drains, timeouts, analysis phases, cleanup).
> - **Tests**
>   - `DiscoveryRunner.test.ts`: add test verifying verbose logging propagates (`lastDiscoverOptions.log === 1`), extend `FakeWorker` to capture options.
>   - `DiscoveryCandidates.test.ts`: replace stubbed candidates with live discovery pipeline using `DiscoverStructure`, generated training data, and MSE-based assertions; validate add/remove/combo behaviors and error improvements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29e17ece6c2cbd3fa8f52b616e5fab7b7b6234fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->