### PR TITLE
Update version to 0.195.0 and enhance discovery memory management

### DIFF
--- a/DISCOVERY_MEMORY_FIXES.md
+++ b/DISCOVERY_MEMORY_FIXES.md
@@ -235,6 +235,15 @@ if (options.log) {
 Consider recycling discovery workers periodically to prevent memory accumulation
 in long-running processes.
 
+### 5. **Chunked Rust Recording**
+
+- **Problem**: Large in-memory buffers being converted to JSON for a single Rust
+  flush could exceed the V8 heap limit.
+- **Fix**: Introduced `discoveryRustFlushRecords` so recordings are flushed to
+  the Rust side in smaller Parquet chunks, merging them after scanning.
+- **Impact**: Dramatically lowers JavaScript heap pressure, allowing workers to
+  process much larger sample sets without exhausting memory.
+
 ## Performance Improvements Summary
 
 - **Buffer size reduction**: 256KB → 10KB (25x reduction)

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.194.7",
+  "version": "0.195.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",
@@ -12,6 +12,7 @@
     "@std/path": "jsr:@std/path@1.1.2",
     "@std/streams": "jsr:@std/streams@1.0.13",
     "@std/uuid": "jsr:@std/uuid@1.0.9",
+    "@std/testing/mock": "jsr:@std/testing@1.0.16/mock",
     "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13"
   },
   "test": {

--- a/docs/DiscoveryDir.md
+++ b/docs/DiscoveryDir.md
@@ -116,6 +116,17 @@ adapt:
   running any side-effects.
 - Touch `.run.pid` to acknowledge the worker is still alive between iterations.
 
+## Memory Management
+
+- Tune `discoveryRustFlushRecords` to control how many discovery samples are
+  buffered in memory before the Rust recorder is flushed. Lowering the value
+  (for example `--discoveryRustFlushRecords=2048`) reduces V8 heap growth at the
+  cost of more frequent, smaller Parquet chunks and extra merge work at the end
+  of the run.
+- The default chunk size (4,096 samples) balances throughput and peak memory for
+  most workloads, but busy datasets or constrained workers may benefit from
+  smaller chunks coupled with increased batch timeout settings.
+
 ## Handling Discovery Results
 
 `discoveryDir()` returns an object containing baseline metrics, raw discovery

--- a/quality.sh
+++ b/quality.sh
@@ -22,7 +22,7 @@ fi
 
 rm -rf .trace .test .coverage
 deno check
-
+(cd ../NEAT-AI-Discovery && ./scripts/runlib.sh)
 # # is intentionally loaded and kept in memory for performance (not a leak)
 
 echo "Verifying discovery library availability..."

--- a/src/NEAT/LogApproach.ts
+++ b/src/NEAT/LogApproach.ts
@@ -1,6 +1,6 @@
 import { addTag, getTag } from "@stsoftware/tags/mod";
 import type { Creature } from "../../mod.ts";
-import { blue, bold, cyan, green } from "@std/fmt/colors";
+import { blue, bold, cyan } from "@std/fmt/colors";
 import { assert } from "@std/assert";
 
 // Define a union type for the possible approaches
@@ -89,14 +89,13 @@ export function logApproach(fittest: Creature, previous: Creature) {
         }
         case "discovery": {
           const discoveryID = getTag(fittest, "discoveryID");
-          const evaluation = getTag(fittest, "discovery");
+          const evaluation = getTag(fittest, "Discovery") ??
+            getTag(fittest, "discovery");
 
           console.info(
             bold(cyan("Discovery")),
             blue(`${discoveryID}`),
-            evaluation === "beneficial"
-              ? green("beneficial")
-              : cyan(evaluation ?? "unknown"),
+            evaluation ?? cyan("unknown"),
             "increased fitness by",
             fScore - pScore,
             "to",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -6,7 +6,11 @@ import type { NeatOptions } from "../../config/NeatOptions.ts";
 import { CreatureUtil } from "../CreatureUtils.ts";
 import type { DataRecordInterface } from "../DataSet.ts";
 import type { DiscoverResult } from "./DiscoverResult.ts";
-import { DiscoverStructure } from "./DiscoverStructure.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+  type DiscoverStructureDeps,
+} from "./DiscoverStructure.ts";
 import { isRustDiscoveryEnabled } from "./RustDiscovery.ts";
 
 const shouldLogDiscovery = (options: NeatOptions): boolean =>
@@ -16,8 +20,9 @@ export async function recordDirectory(
   creature: Creature,
   dataDir: string,
   options: NeatOptions,
+  deps: Partial<DiscoverStructureDeps> = {},
 ) {
-  const recorder = new DataRecorder(creature, options);
+  const recorder = new DataRecorder(creature, options, deps);
   return await recorder.recordDirectory(dataDir);
 }
 
@@ -31,10 +36,13 @@ class DataRecorder {
   private readonly timeoutSeconds: number;
   private readonly discoveryMaxNeurons: number;
   private readonly drainEveryNBatches: number;
+  private readonly rustFlushRecords: number;
+  private readonly discoverDeps: Partial<DiscoverStructureDeps>;
 
   constructor(
     private readonly creature: Creature,
     private readonly options: NeatOptions,
+    deps: Partial<DiscoverStructureDeps>,
   ) {
     this.BYTES_PER_RECORD = (creature.input + creature.output) * 4;
     const discoveryBufferSize = options.discoveryBufferSize || 128 * 1024;
@@ -71,6 +79,11 @@ class DataRecorder {
       1,
       options.discoveryDrainEveryNBatches ?? 10,
     );
+    this.rustFlushRecords = Math.max(
+      1,
+      options.discoveryRustFlushRecords ?? DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    this.discoverDeps = deps;
   }
 
   private shuffleFiles(files: string[]): string[] {
@@ -104,7 +117,10 @@ class DataRecorder {
 
   async recordDirectory(dataDir: string): Promise<DiscoverResult> {
     // Check if Rust discovery module is available
-    if (!isRustDiscoveryEnabled()) {
+    const rustEnabled = this.discoverDeps.isRustDiscoveryEnabled
+      ? this.discoverDeps.isRustDiscoveryEnabled()
+      : isRustDiscoveryEnabled();
+    if (!rustEnabled) {
       if (shouldLogDiscovery(this.options)) {
         console.warn(
           `⚠️  Discovery skipped: Rust module not available. Discovery requires the NEAT-AI-Discovery Rust library to be built and available.`,
@@ -232,6 +248,17 @@ class DataRecorder {
             }
           }
 
+          if (discoverStructure.shouldFlushRustChunk()) {
+            const flushed = discoverStructure.flushRustChunk();
+            if (!flushed) {
+              console.warn(
+                `⚠️  Discovery ${
+                  blue(this.ID)
+                } failed to flush discovery chunk after batch.`,
+              );
+            }
+          }
+
           // Give GC a chance to run periodically
           // deno-lint-ignore no-await-in-loop
           await new Promise((resolve) => setTimeout(resolve, 0));
@@ -274,6 +301,8 @@ class DataRecorder {
     const discoverStructure = new DiscoverStructure(
       creature,
       this.timeoutSeconds,
+      this.rustFlushRecords,
+      this.discoverDeps,
     );
     discoverStructure.configureLogging({
       discoveryID: this.ID,
@@ -327,6 +356,16 @@ class DataRecorder {
             selectedIndices.length === 0,
             "Indices not empty after flush",
           );
+          if (discoverStructure.shouldFlushRustChunk()) {
+            const flushed = discoverStructure.flushRustChunk();
+            if (!flushed) {
+              console.warn(
+                `⚠️  Discovery ${
+                  blue(this.ID)
+                } failed to flush discovery chunk after file ${filePath}.`,
+              );
+            }
+          }
         }
 
         // Drain promises after each file to limit memory usage

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -15,6 +15,7 @@ import {
   creatureToRustFormat,
   isRustDiscoveryEnabled,
   isRustLibraryAvailable,
+  mergeDiscoveryParquet,
   readDiscoveryRecords,
   recordDiscovery,
   type RustAnalyzeNeuronsInput,
@@ -25,6 +26,29 @@ import {
   type RustCandidateSynapse,
   type RustRecordInput,
 } from "./RustDiscovery.ts";
+import { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
+
+export { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
+
+export interface DiscoverStructureDeps {
+  isRustDiscoveryEnabled: typeof isRustDiscoveryEnabled;
+  isRustLibraryAvailable: typeof isRustLibraryAvailable;
+  recordDiscovery: typeof recordDiscovery;
+  mergeDiscoveryParquet: typeof mergeDiscoveryParquet;
+  analyzeNeurons: typeof analyzeNeurons;
+  analyzeSynapses: typeof analyzeSynapses;
+  readDiscoveryRecords: typeof readDiscoveryRecords;
+}
+
+const DEFAULT_DISCOVER_STRUCTURE_DEPS: DiscoverStructureDeps = {
+  isRustDiscoveryEnabled,
+  isRustLibraryAvailable,
+  recordDiscovery,
+  mergeDiscoveryParquet,
+  analyzeNeurons,
+  analyzeSynapses,
+  readDiscoveryRecords,
+};
 
 /**
  * Implements Error-Driven Synapse Discovery, a neuroevolution technique for optimizing neural network structures.
@@ -120,7 +144,17 @@ export class DiscoverStructure {
   private rustBinaryFilePaths: Set<string> = new Set(); // Track all binary file paths
   private usingRustDualWrite = false;
   private parquetFilePath: string | null = null;
-  constructor(creature: Creature, timeoutSeconds: number) {
+  private rustFlushRecords: number;
+  private rustChunkFiles: string[] = [];
+  private rustChunkCounter = 0;
+  private syntheticBinaryMode = false;
+  private deps: DiscoverStructureDeps;
+  constructor(
+    creature: Creature,
+    timeoutSeconds: number,
+    rustFlushRecords: number = DEFAULT_RUST_FLUSH_RECORDS,
+    deps: Partial<DiscoverStructureDeps> = {},
+  ) {
     this.creature = creature;
     assert(creature.uuid, "Creature must have a UUID to discover structure.");
     this.tempDir = `.discovery/${creature.uuid}_${
@@ -138,6 +172,8 @@ export class DiscoverStructure {
       `Timeout seconds must be less than 1 hour: was ${timeoutSeconds}`,
     );
     this.timeoutTS = Date.now() + timeoutSeconds * 1000;
+    this.rustFlushRecords = Math.max(1, rustFlushRecords);
+    this.deps = { ...DEFAULT_DISCOVER_STRUCTURE_DEPS, ...deps };
 
     Deno.mkdirSync(this.tempDir, { recursive: true });
   }
@@ -175,7 +211,7 @@ export class DiscoverStructure {
     this.initialized = true;
 
     // Check if Rust discovery is enabled (requires both library file AND FFI permissions)
-    if (!isRustDiscoveryEnabled()) {
+    if (!this.deps.isRustDiscoveryEnabled()) {
       console.warn(
         `⚠️  Discovery requires the NEAT-AI-Discovery Rust library and FFI permissions. Discovery will be skipped.`,
       );
@@ -296,6 +332,11 @@ export class DiscoverStructure {
     return true;
   }
 
+  public shouldFlushRustChunk(): boolean {
+    if (!this.usingRustDualWrite) return false;
+    return this.rustAccumulatedData.length >= this.rustFlushRecords;
+  }
+
   /**
    * Flushes accumulated Rust recording data and writes to Parquet via Rust module.
    * This is called after all record() batches complete.
@@ -307,224 +348,234 @@ export class DiscoverStructure {
    * If Rust module is not available, this returns false and discovery is skipped.
    * If there's no accumulated data (empty training data), this returns true (valid no-op).
    */
-  public flushRustRecording(): boolean {
-    // If Rust is not being used, return false (discovery skipped)
-    if (!this.usingRustDualWrite) {
-      return false;
+  private getNextChunkDir(): string {
+    const index = ++this.rustChunkCounter;
+    const dir = `${this.tempDir}/chunks/chunk-${
+      index.toString().padStart(5, "0")
+    }`;
+    try {
+      Deno.mkdirSync(dir, { recursive: true });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.AlreadyExists)) {
+        throw error;
+      }
     }
+    return dir;
+  }
 
-    // If there's no data to flush, return true (valid no-op, not an error)
-    if (this.rustAccumulatedData.length === 0) {
-      return true;
-    }
-
+  private writeRustParquetChunk(tempDir: string): string | null {
     // Check if creature has been cleaned up (race condition protection)
     // @ts-ignore - creature can be null after cleanUp()
     if (!this.creature) {
       console.warn(
         `⚠️  Discovery recording skipped: creature has been cleaned up.`,
       );
-      return false;
+      return null;
     }
 
-    // Now actually load the library (lazy loading - only when we need to write)
-    if (!isRustLibraryAvailable()) {
+    if (!this.deps.isRustLibraryAvailable()) {
       console.warn(
         `⚠️  Rust library not available when flushing. Discovery recording failed.`,
       );
+      return null;
+    }
+
+    const creatureExport = this.creature.exportJSON();
+    const rustCreature = creatureToRustFormat(creatureExport);
+    const pendingSamples = this.rustAccumulatedData.length;
+
+    const nonInputNeurons = this.creature.neurons.filter((neuron) =>
+      neuron.type !== "input"
+    );
+
+    const rustTrainingData = this.rustAccumulatedData.map((record, index) => {
+      const discoverMap = this.rustAccumulatedNeuronData[index];
+
+      const neuronData = nonInputNeurons.map((neuron) => {
+        const discoverRecord = discoverMap.get(neuron.uuid) || {
+          activation: this.creature.state.activations[neuron.index],
+          errors: [] as number[],
+        };
+
+        const errors = discoverRecord.errors.filter(Number.isFinite);
+
+        return {
+          neuron_uuid: neuron.uuid,
+          activation: discoverRecord.activation,
+          value: discoverRecord.value,
+          errors: errors,
+        };
+      });
+
+      return {
+        input: Array.from(record.input),
+        output: Array.from(record.output),
+        neuron_data: neuronData,
+      };
+    });
+
+    let recordIndices: number[] | undefined = undefined;
+    if (this.rustBinaryFilePaths.size === 1 && this.rustBinaryFilePath) {
+      const fileIndices = this.selectedIndices[this.rustBinaryFilePath];
+      if (
+        fileIndices && fileIndices.length === this.rustAccumulatedData.length
+      ) {
+        recordIndices = fileIndices;
+      }
+    }
+
+    const now = Date.now();
+    const timedOut = now > this.timeoutTS;
+    if (timedOut) {
+      this.log(
+        "warn",
+        "Submitting flush request to Rust after recording timeout expired. Continuing with captured data.",
+      );
+    }
+
+    const timeoutSeconds = timedOut
+      ? 0
+      : Math.max(0, Math.floor((this.timeoutTS - now) / 1000));
+
+    const rustInput: RustRecordInput = {
+      creature: rustCreature,
+      "training_data": rustTrainingData,
+      "temp_dir": tempDir,
+      "binary_file_path": this.rustBinaryFilePath || undefined,
+      "record_indices": recordIndices,
+      "timeout_seconds": timeoutSeconds,
+    };
+
+    const result = this.deps.recordDiscovery(rustInput);
+
+    if (result && result.success && result.file) {
+      const parquetPath = `${tempDir}/${result.file}`;
+
+      if (this.syntheticBinaryMode || this.rustBinaryFilePaths.size === 0) {
+        this.syntheticBinaryMode = true;
+        const tempBinaryFile = `${tempDir}/training_data.bin`;
+        const BYTES_PER_RECORD = (this.creature.input + this.creature.output) *
+          4;
+        const file = Deno.openSync(tempBinaryFile, {
+          create: true,
+          write: true,
+          truncate: true,
+        });
+
+        try {
+          const buffer = new Uint8Array(BYTES_PER_RECORD);
+          const recordArray = new Float32Array(buffer.buffer);
+          const sequentialIndices: number[] = [];
+
+          for (let i = 0; i < this.rustAccumulatedData.length; i++) {
+            const record = this.rustAccumulatedData[i];
+            for (let j = 0; j < this.creature.input; j++) {
+              recordArray[j] = record.input[j];
+            }
+            for (let j = 0; j < this.creature.output; j++) {
+              recordArray[this.creature.input + j] = record.output[j];
+            }
+            file.writeSync(buffer);
+            sequentialIndices.push(i);
+          }
+
+          this.selectedIndices[tempBinaryFile] = sequentialIndices;
+          this.rustBinaryFilePaths.add(tempBinaryFile);
+          if (!this.rustBinaryFilePath) {
+            this.rustBinaryFilePath = tempBinaryFile;
+          }
+        } finally {
+          file.close();
+        }
+      }
+
+      Deno.writeTextFileSync(
+        this.indicesFilePath,
+        JSON.stringify(this.selectedIndices),
+      );
+
+      this.rustAccumulatedData = [];
+      this.rustAccumulatedNeuronData = [];
+      const flushDuration = Date.now() - now;
+      const remainingSeconds = Math.max(
+        0,
+        Math.floor((this.timeoutTS - Date.now()) / 1000),
+      );
+      this.log(
+        "info",
+        `Flushed ${pendingSamples} samples to ${parquetPath} in ${
+          this.formatMillis(flushDuration)
+        } (timeout remaining: ${remainingSeconds}s).`,
+      );
+
+      return parquetPath;
+    }
+
+    console.error(
+      `❌ Rust discovery recording failed: ${result?.error || "Unknown error"}`,
+    );
+    return null;
+  }
+
+  public flushRustChunk(): boolean {
+    if (!this.usingRustDualWrite || this.rustAccumulatedData.length === 0) {
       return false;
     }
 
     try {
-      const creatureExport = this.creature.exportJSON();
-      const rustCreature = creatureToRustFormat(creatureExport);
-      const pendingSamples = this.rustAccumulatedData.length;
-
-      const nonInputNeurons = this.creature.neurons.filter((neuron) =>
-        neuron.type !== "input"
-      );
-
-      const rustTrainingData = this.rustAccumulatedData.map((record, index) => {
-        const discoverMap = this.rustAccumulatedNeuronData[index];
-
-        const neuronData = nonInputNeurons.map((neuron) => {
-          const discoverRecord = discoverMap.get(neuron.uuid) || {
-            activation: this.creature.state.activations[neuron.index],
-            errors: [] as number[],
-          };
-
-          const errors = discoverRecord.errors.filter(Number.isFinite);
-
-          return {
-            neuron_uuid: neuron.uuid,
-            activation: discoverRecord.activation,
-            value: discoverRecord.value,
-            errors: errors,
-          };
-        });
-
-        return {
-          input: Array.from(record.input),
-          output: Array.from(record.output),
-          neuron_data: neuronData,
-        };
-      });
-
-      // Prepare record indices if we have binary files with specific indices
-      // NOTE: Indices stored in selectedIndices are file-specific (indices within each binary file),
-      // not training-data indices. When multiple files are processed, we can't reliably map
-      // file-specific indices to training-data indices without tracking offsets.
-      // For single file: use file-specific indices (they should map 1:1 to training data)
-      // For multiple files: use sequential indices (0, 1, 2, ...) to match training data order
-      let recordIndices: number[] | undefined = undefined;
-      if (this.rustBinaryFilePaths.size === 1 && this.rustBinaryFilePath) {
-        // Single binary file: use its file-specific indices
-        // These should map 1:1 to training data since only one file was processed
-        const fileIndices = this.selectedIndices[this.rustBinaryFilePath];
-        if (fileIndices && fileIndices.length > 0) {
-          // Verify indices match training data length (should be 1:1 for single file)
-          if (fileIndices.length === this.rustAccumulatedData.length) {
-            recordIndices = fileIndices;
-          } else {
-            // Mismatch - use sequential indices for safety
-            recordIndices = undefined;
-          }
-        } else {
-          // No indices found - use sequential indices
-          recordIndices = undefined;
-        }
-      } else if (this.rustBinaryFilePaths.size > 1) {
-        // Multiple binary files: can't map file-specific indices to training-data indices
-        // Use sequential indices (0, 1, 2, ...) to match training data order
-        recordIndices = undefined;
-      } else {
-        // No binary file - don't provide record_indices (let Rust process all records sequentially)
-        // This ensures obs_index in Parquet matches the training data index (0, 1, 2, ...)
-        recordIndices = undefined;
+      const chunkDir = this.getNextChunkDir();
+      const parquetPath = this.writeRustParquetChunk(chunkDir);
+      if (!parquetPath) {
+        return false;
       }
-
-      const now = Date.now();
-      const timedOut = now > this.timeoutTS;
-      if (timedOut) {
-        this.log(
-          "warn",
-          "Submitting flush request to Rust after recording timeout expired. Continuing with captured data.",
-        );
-      }
-
-      // Calculate timeout_seconds, ensuring it's non-negative. If we've already
-      // exceeded the timeout window we pass zero so Rust can decide whether to proceed.
-      const timeoutSeconds = timedOut
-        ? 0
-        : Math.max(0, Math.floor((this.timeoutTS - now) / 1000));
-
-      const rustInput: RustRecordInput = {
-        creature: rustCreature,
-        "training_data": rustTrainingData,
-        "temp_dir": this.tempDir,
-        "binary_file_path": this.rustBinaryFilePath || undefined,
-        "record_indices": recordIndices,
-        "timeout_seconds": timeoutSeconds,
-      };
-
-      const result = recordDiscovery(rustInput);
-
-      if (result && result.success && result.file) {
-        this.parquetFilePath = `${this.tempDir}/${result.file}`;
-
-        // Write indices file for input neuron binary reading
-        // For single file: use the calculated recordIndices or sequential indices
-        // For multiple files: write all file-specific indices (even though we use sequential for Rust)
-        if (this.rustBinaryFilePaths.size > 0) {
-          let indicesToWrite: BinaryRecordIndices;
-          if (this.rustBinaryFilePaths.size === 1 && recordIndices) {
-            // Single file with valid indices: use the calculated indices
-            indicesToWrite = {
-              [this.rustBinaryFilePath!]: recordIndices,
-            };
-          } else {
-            // Multiple files or no valid indices: write all file-specific indices
-            // (Note: Rust will use sequential indices, but we preserve file-specific indices for reference)
-            indicesToWrite = { ...this.selectedIndices };
-          }
-          Deno.writeTextFileSync(
-            this.indicesFilePath,
-            JSON.stringify(indicesToWrite),
-          );
-        } else if (this.rustAccumulatedData.length > 0) {
-          // No binary file path - create a temporary binary file from training data
-          // This allows input neurons to be read (they're always read from binary files)
-          const tempBinaryFile = `${this.tempDir}/training_data.bin`;
-          const BYTES_PER_RECORD =
-            (this.creature.input + this.creature.output) * 4;
-          const file = Deno.openSync(tempBinaryFile, {
-            create: true,
-            write: true,
-            truncate: true,
-          });
-
-          try {
-            const buffer = new Uint8Array(BYTES_PER_RECORD);
-            const recordArray = new Float32Array(buffer.buffer);
-            const sequentialIndices: number[] = [];
-
-            for (let i = 0; i < this.rustAccumulatedData.length; i++) {
-              const record = this.rustAccumulatedData[i];
-              // Write input values
-              for (let j = 0; j < this.creature.input; j++) {
-                recordArray[j] = record.input[j];
-              }
-              // Write output values
-              for (let j = 0; j < this.creature.output; j++) {
-                recordArray[this.creature.input + j] = record.output[j];
-              }
-
-              file.writeSync(buffer);
-              sequentialIndices.push(i);
-            }
-
-            // Write indices file pointing to the temporary binary file
-            const indices: BinaryRecordIndices = {
-              [tempBinaryFile]: sequentialIndices,
-            };
-            Deno.writeTextFileSync(
-              this.indicesFilePath,
-              JSON.stringify(indices),
-            );
-
-            // Store the temporary binary file path
-            this.rustBinaryFilePath = tempBinaryFile;
-          } finally {
-            file.close();
-          }
-        }
-
-        // Clear accumulated data after successful write
-        this.rustAccumulatedData = [];
-        this.rustAccumulatedNeuronData = [];
-        const flushDuration = Date.now() - now;
-        const remainingSeconds = Math.max(
-          0,
-          Math.floor((this.timeoutTS - Date.now()) / 1000),
-        );
-        this.log(
-          "info",
-          `Flushed ${pendingSamples} samples to ${this.parquetFilePath} in ${
-            this.formatMillis(flushDuration)
-          } (timeout remaining: ${remainingSeconds}s).`,
-        );
-
-        return true;
-      }
-      console.error(
-        `❌ Rust discovery recording failed: ${
-          result?.error || "Unknown error"
-        }`,
-      );
-      return false;
-    } catch {
+      this.rustChunkFiles.push(parquetPath);
+      return true;
+    } catch (error) {
+      console.error("❌ Failed to flush discovery chunk:", error);
       return false;
     }
+  }
+
+  public flushRustRecording(): boolean {
+    if (!this.usingRustDualWrite) {
+      return false;
+    }
+
+    if (this.rustAccumulatedData.length > 0) {
+      if (!this.flushRustChunk()) {
+        return false;
+      }
+    }
+
+    if (this.rustChunkFiles.length === 0) {
+      this.parquetFilePath = null;
+      return true;
+    }
+
+    if (!this.deps.isRustLibraryAvailable()) {
+      console.warn(
+        `⚠️  Rust library not available when merging discovery chunks. Discovery recording failed.`,
+      );
+      return false;
+    }
+
+    const outputFile = `${this.tempDir}/discovery_data.parquet`;
+    const mergeResult = this.deps.mergeDiscoveryParquet({
+      outputFile,
+      inputFiles: [...this.rustChunkFiles],
+    });
+
+    if (!mergeResult || !mergeResult.success) {
+      console.error(
+        "❌ Rust discovery merge failed:",
+        mergeResult?.error ?? "Unknown error",
+      );
+      return false;
+    }
+
+    this.parquetFilePath = mergeResult.outputFile ?? outputFile;
+    this.rustChunkFiles = [];
+    return true;
   }
 
   private discoveries: CandidateSynapse[] = [];
@@ -540,7 +591,7 @@ export class DiscoverStructure {
       return Promise.resolve(undefined);
     }
 
-    if (!this.parquetFilePath || !isRustDiscoveryEnabled()) {
+    if (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled()) {
       if (this.loggingEnabled) {
         this.log(
           "debug",
@@ -579,7 +630,7 @@ export class DiscoverStructure {
       return Promise.resolve(undefined);
     }
 
-    if (!this.parquetFilePath || !isRustDiscoveryEnabled()) {
+    if (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled()) {
       if (this.loggingEnabled) {
         this.log(
           "debug",
@@ -811,7 +862,10 @@ export class DiscoverStructure {
       return undefined;
     }
 
-    if (!isRustDiscoveryEnabled() || !isRustLibraryAvailable()) {
+    if (
+      !this.deps.isRustDiscoveryEnabled() ||
+      !this.deps.isRustLibraryAvailable()
+    ) {
       return undefined;
     }
 
@@ -825,7 +879,7 @@ export class DiscoverStructure {
     };
 
     try {
-      const result = analyzeNeurons(rustInput);
+      const result = this.deps.analyzeNeurons(rustInput);
       if (!result || !result.success) {
         if (this.loggingEnabled) {
           this.log(
@@ -861,7 +915,10 @@ export class DiscoverStructure {
       return undefined;
     }
 
-    if (!isRustDiscoveryEnabled() || !isRustLibraryAvailable()) {
+    if (
+      !this.deps.isRustDiscoveryEnabled() ||
+      !this.deps.isRustLibraryAvailable()
+    ) {
       return undefined;
     }
 
@@ -875,7 +932,7 @@ export class DiscoverStructure {
     };
 
     try {
-      const result = analyzeSynapses(rustInput);
+      const result = this.deps.analyzeSynapses(rustInput);
       if (!result || !result.success) {
         if (this.loggingEnabled) {
           this.log(
@@ -1180,7 +1237,7 @@ export class DiscoverStructure {
     }
 
     // Read from Parquet via Rust FFI (simple approach - optimize later)
-    const readResult = readDiscoveryRecords({
+    const readResult = this.deps.readDiscoveryRecords({
       parquet_file: this.parquetFilePath,
       neuron_uuid: neuronUUID,
     });
@@ -1617,7 +1674,9 @@ export class DiscoverStructure {
     if (tmpUUID !== creatureUUID) {
       addTag(tmpCreature, "approach", "discovery" as Approach);
       addTag(tmpCreature, "discoveryID", ID);
-      addTag(tmpCreature, "discovery", "harmful");
+      const summary =
+        `☣️ Removed harmful synapse ${worseCandidate.fromNeuronUUID} -> ${worseCandidate.toNeuronUUID}`;
+      addTag(tmpCreature, "Discovery", summary);
       delete tmpCreature.memetic;
       removeTag(tmpCreature, "approach-logged");
       tmpCreature.validate();
@@ -1643,6 +1702,8 @@ export class DiscoverStructure {
     if (!helpfulSynapses || helpfulSynapses.length === 0) return;
     const creatureUUID = CreatureUtil.makeUUID(creature);
     const exportJSON = creature.exportJSON();
+
+    const appliedSynapses: CandidateSynapse[] = [];
 
     helpfulSynapses.forEach((bestCandidate) => {
       const foundSynapse = exportJSON.synapses.find((synapse) => {
@@ -1675,16 +1736,21 @@ export class DiscoverStructure {
 
       addTag(addSynapse as TagsInterface, "discovery", "beneficial");
       exportJSON.synapses.push(addSynapse);
+      appliedSynapses.push(bestCandidate);
     });
 
     const tmpCreature = Creature.fromJSON(exportJSON);
     tmpCreature.fix();
 
     const tmpUUID = CreatureUtil.makeUUID(tmpCreature);
-    if (tmpUUID !== creatureUUID) {
+    if (tmpUUID !== creatureUUID && appliedSynapses.length > 0) {
+      const exemplar = appliedSynapses[0];
+      const summary = appliedSynapses.length === 1
+        ? `🕵🏻‍♂️ Added helpful synapse ${exemplar.fromNeuronUUID} -> ${exemplar.toNeuronUUID}`
+        : `🕵🏻‍♂️ Added ${appliedSynapses.length} helpful synapses (eg ${exemplar.fromNeuronUUID} -> ${exemplar.toNeuronUUID})`;
       addTag(tmpCreature, "approach", "discovery" as Approach);
       addTag(tmpCreature, "discoveryID", ID);
-      addTag(tmpCreature, "discovery", "beneficial");
+      addTag(tmpCreature, "Discovery", summary);
       if (tmpCreature.memetic) {
         tmpCreature.memetic = memeticUpdate(creature, tmpCreature);
       }
@@ -1711,6 +1777,7 @@ export class DiscoverStructure {
     );
     const processedKeys = new Set<string>();
     const addedNeuronUUIDs: string[] = [];
+    const appliedCandidates: CandidateNeuron[] = [];
 
     helpfulNeurons.forEach((candidate) => {
       const key = `${candidate.fromNeuronUUID}->${candidate.toNeuronUUID}`;
@@ -1747,6 +1814,7 @@ export class DiscoverStructure {
       }
       existingNeuronUUIDs.add(newNeuronUUID);
       addedNeuronUUIDs.push(newNeuronUUID);
+      appliedCandidates.push(candidate);
 
       const incomingSynapse = {
         fromUUID: candidate.fromNeuronUUID,
@@ -1776,7 +1844,13 @@ export class DiscoverStructure {
     if (tmpUUID !== creatureUUID) {
       addTag(tmpCreature, "approach", "discovery" as Approach);
       addTag(tmpCreature, "discoveryID", ID);
-      addTag(tmpCreature, "discovery", "neuron");
+      if (appliedCandidates.length > 0) {
+        const exemplar = appliedCandidates[0];
+        const summary = appliedCandidates.length === 1
+          ? `🕵🏻‍♂️ Added discovery neuron linking ${exemplar.fromNeuronUUID} -> ${exemplar.toNeuronUUID}`
+          : `🕵🏻‍♂️ Added ${appliedCandidates.length} discovery neurons (eg ${exemplar.fromNeuronUUID} -> ${exemplar.toNeuronUUID})`;
+        addTag(tmpCreature, "Discovery", summary);
+      }
       if (tmpCreature.memetic) {
         tmpCreature.memetic = memeticUpdate(creature, tmpCreature);
       }
@@ -1806,6 +1880,8 @@ export class DiscoverStructure {
     const creatureUUID = CreatureUtil.makeUUID(creature);
     const exportJSON = creature.exportJSON();
 
+    const appliedSquashes: CandidateSquash[] = [];
+
     helpfulSquashes.forEach((bestCandidate) => {
       const foundNeuron = exportJSON.neurons.find((neuron) => {
         return neuron.uuid === bestCandidate.neuronUUID;
@@ -1819,6 +1895,7 @@ export class DiscoverStructure {
       addTag(foundNeuron as TagsInterface, "discovered", bestCandidate.squash);
 
       foundNeuron.squash = bestCandidate.squash;
+      appliedSquashes.push(bestCandidate);
     });
 
     const tmpCreature = Creature.fromJSON(exportJSON);
@@ -1828,7 +1905,13 @@ export class DiscoverStructure {
     if (tmpUUID !== creatureUUID) {
       addTag(tmpCreature, "approach", "discovery" as Approach);
       addTag(tmpCreature, "discoveryID", ID);
-      addTag(tmpCreature, "discovery", "squash");
+      if (appliedSquashes.length > 0) {
+        const exemplar = appliedSquashes[0];
+        const summary = appliedSquashes.length === 1
+          ? `🕵🏻‍♂️ Swapped ${exemplar.neuronUUID} squash to ${exemplar.squash}`
+          : `🕵🏻‍♂️ Updated squash on ${appliedSquashes.length} neurons (eg ${exemplar.neuronUUID} -> ${exemplar.squash})`;
+        addTag(tmpCreature, "Discovery", summary);
+      }
       if (tmpCreature.memetic) {
         tmpCreature.memetic = memeticUpdate(creature, tmpCreature);
       }
@@ -1864,7 +1947,7 @@ export class DiscoverStructure {
       return Promise.resolve(undefined);
     }
 
-    if (!this.parquetFilePath || !isRustDiscoveryEnabled()) {
+    if (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled()) {
       if (this.loggingEnabled) {
         this.log(
           "debug",

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -307,6 +307,11 @@ type RustDiscoverySymbols = {
     result: "pointer";
     nonblocking: false;
   };
+  "merge_discovery_parquet": {
+    parameters: ["pointer"];
+    result: "pointer";
+    nonblocking: false;
+  };
   "free_discovery_result": {
     parameters: ["pointer"];
     result: "void";
@@ -363,6 +368,11 @@ export function loadRustLibrary(): boolean {
         nonblocking: false,
       },
       "read_discovery_records_ffi": {
+        parameters: ["pointer"],
+        result: "pointer",
+        nonblocking: false,
+      },
+      "merge_discovery_parquet": {
         parameters: ["pointer"],
         result: "pointer",
         nonblocking: false,
@@ -530,6 +540,56 @@ export function readDiscoveryRecords(
     // Parse the JSON result
     const result = JSON.parse(resultJson) as RustReadResult;
 
+    return result;
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export interface RustMergeParquetInput {
+  outputFile: string;
+  inputFiles: string[];
+}
+
+export interface RustMergeParquetResult {
+  success: boolean;
+  outputFile?: string;
+  error?: string;
+}
+
+export function mergeDiscoveryParquet(
+  input: RustMergeParquetInput,
+): RustMergeParquetResult | null {
+  if (!isRustLibraryAvailable()) {
+    return null;
+  }
+
+  assert(rustLib !== null, "Rust library should be loaded");
+
+  try {
+    const inputJson = JSON.stringify(input);
+    const inputBytes = new TextEncoder().encode(inputJson);
+    const inputBuffer = new Uint8Array(inputBytes.length + 1);
+    inputBuffer.set(inputBytes);
+    inputBuffer[inputBytes.length] = 0;
+
+    const inputPtr = Deno.UnsafePointer.of(inputBuffer);
+    const resultPtr = rustLib.symbols["merge_discovery_parquet"](inputPtr);
+
+    if (resultPtr === null) {
+      return {
+        success: false,
+        error: "Rust function returned null pointer",
+      };
+    }
+
+    const resultJson = readCString(resultPtr);
+    rustLib.symbols["free_discovery_result"](resultPtr);
+
+    const result = JSON.parse(resultJson) as RustMergeParquetResult;
     return result;
   } catch (error) {
     return {

--- a/src/architecture/ErrorGuidedStructuralEvolution/constants.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Default number of records to accumulate before flushing discovery data to Rust.
+ *
+ * This matches the legacy behaviour (4_096 records) that balances IO pressure
+ * and memory usage during multi-file discovery runs.
+ */
+export const DEFAULT_RUST_FLUSH_RECORDS = 4_096;

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -2,6 +2,7 @@ import type { NeatOptions } from "../../mod.ts";
 import { Selection, type SelectionInterface } from "../methods/Selection.ts";
 import { Mutation } from "../NEAT/Mutation.ts";
 import type { NeatArguments } from "./NeatOptions.ts";
+import { DEFAULT_RUST_FLUSH_RECORDS } from "../architecture/ErrorGuidedStructuralEvolution/constants.ts";
 
 /**
  * Interface for NEAT (NeuroEvolution of Augmenting Topologies) training options.
@@ -90,7 +91,7 @@ export function createNeatConfig(options: NeatOptions) {
     traceStore: options.traceStore,
     trainPerGen: options.trainPerGen ?? 1,
 
-    log: options.log ?? 0,
+    log: options.log ?? (options.verbose ? 1 : 0),
     verbose: options.verbose ? true : false,
 
     enableRepetitiveTraining: options.enableRepetitiveTraining || false,
@@ -117,6 +118,8 @@ export function createNeatConfig(options: NeatOptions) {
       3,
     discoveryBatchSize: options.discoveryBatchSize || 128,
     discoveryBufferSize: options.discoveryBufferSize || 0,
+    discoveryRustFlushRecords: options.discoveryRustFlushRecords ??
+      DEFAULT_RUST_FLUSH_RECORDS,
     discoveryMaxNeurons: options.discoveryMaxNeurons || 0,
     discoveryDrainEveryNBatches: options.discoveryDrainEveryNBatches ?? 10,
     customCost: options.customCost,
@@ -280,6 +283,14 @@ function validate(config: NeatArguments) {
   ) {
     throw new Error(
       `Discovery Analysis Timeout Minutes must be greater than 0 was: ${config.discoveryAnalysisTimeoutMinutes}`,
+    );
+  }
+  if (
+    Number.isInteger(config.discoveryRustFlushRecords) === false ||
+    config.discoveryRustFlushRecords < 1
+  ) {
+    throw new Error(
+      `Discovery Rust Flush Records must be an integer greater than 0 was: ${config.discoveryRustFlushRecords}`,
     );
   }
 }

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -149,6 +149,13 @@ export interface NeatArguments {
   /** The read buffer size, default 128k */
   discoveryBufferSize: number;
 
+  /**
+   * Maximum number of discovery samples to keep in memory before forcing a flush
+   * to the Rust recorder. Lower values reduce peak memory usage at the cost of
+   * more frequent I/O.
+   */
+  discoveryRustFlushRecords: number;
+
   /** The maximum number of neurons to discover */
   discoveryMaxNeurons: number;
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoverInputOptimization.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverInputOptimization.ts
@@ -5,6 +5,7 @@ import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
 import { makeDataDir } from "../../src/architecture/DataSet.ts";
 import { recordDirectory } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts";
 import {
+  DEFAULT_RUST_FLUSH_RECORDS,
   type DiscoverRecord,
   DiscoverStructure,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
@@ -92,7 +93,11 @@ Deno.test({
     const trainingData = makeTrainingData(creature.input, creature.output, 100);
 
     // Initialize discovery and record data
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);
@@ -208,7 +213,11 @@ Deno.test({
     }
 
     // Method 1: Using Rust (Parquet) - Rust is required now
-    const csvDiscoverStructure = new DiscoverStructure(creature, 60);
+    const csvDiscoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const csvNeuronPromisesMap: Map<string, Promise<void>> = new Map();
     csvDiscoverStructure.initialize(csvNeuronPromisesMap);
     const csvRecorded = csvDiscoverStructure.record(
@@ -240,7 +249,11 @@ Deno.test({
       const binaryCreature = makeTestCreature();
       CreatureUtil.makeUUID(binaryCreature);
 
-      const binaryDiscoverStructure = new DiscoverStructure(binaryCreature, 60);
+      const binaryDiscoverStructure = new DiscoverStructure(
+        binaryCreature,
+        60,
+        DEFAULT_RUST_FLUSH_RECORDS,
+      );
       const binaryNeuronPromisesMap: Map<string, Promise<void>> = new Map();
       binaryDiscoverStructure.initialize(binaryNeuronPromisesMap);
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoverNeuron.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverNeuron.ts
@@ -2,7 +2,10 @@ import { assert } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
-import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import { isRustDiscoveryEnabled } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import { Creature } from "../../src/Creature.ts";
 import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
@@ -149,7 +152,11 @@ Deno.test({
     /**
      * Instantiate the discovery mechanism
      */
-    const discoverStructure = new DiscoverStructure(crippledCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      crippledCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
     const recorded = discoverStructure.record(trainingData, neuronPromisesMap);

--- a/test/ErrorGuidedStructuralEvolution/DiscoverSquash.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverSquash.ts
@@ -2,16 +2,19 @@ import { assert, fail } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
-import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import { isRustDiscoveryEnabled } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import { Creature } from "../../src/Creature.ts";
 import { ABSOLUTE } from "../../src/methods/activations/types/ABSOLUTE.ts";
 import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
 import { LeakyReLU } from "../../src/methods/activations/types/LeakyReLU.ts";
 import { Mish } from "../../src/methods/activations/types/Mish.ts";
-import { TANH } from "../../src/methods/activations/types/TANH.ts";
-import { ReLU6 } from "../../src/methods/activations/types/ReLU6.ts";
 import { ReLU } from "../../src/methods/activations/types/ReLU.ts";
+import { ReLU6 } from "../../src/methods/activations/types/ReLU6.ts";
+import { TANH } from "../../src/methods/activations/types/TANH.ts";
 
 function makeCreature() {
   const json: CreatureExport = {
@@ -126,7 +129,11 @@ Deno.test({
     /**
      * Instantiate the discovery mechanism
      */
-    const discoverStructure = new DiscoverStructure(crippledCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      crippledCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
     const recorded = discoverStructure.record(trainingData, neuronPromisesMap);

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -4,6 +4,7 @@ import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
 import {
   type CandidateNeuron,
+  DEFAULT_RUST_FLUSH_RECORDS,
   DiscoverStructure,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
@@ -379,7 +380,11 @@ for (const testCase of NEURON_DISCOVERY_CASES) {
         targetCreature,
       );
       const neuronPromisesMap: Map<string, Promise<void>> = new Map();
-      const discoverStructure = new DiscoverStructure(crippledCreature, 120);
+      const discoverStructure = new DiscoverStructure(
+        crippledCreature,
+        120,
+        DEFAULT_RUST_FLUSH_RECORDS,
+      );
       discoverStructure.initialize(neuronPromisesMap);
       const recorded = discoverStructure.record(
         trainingData,
@@ -549,7 +554,11 @@ Deno.test({
     /**
      * Instantiate the discovery mechanism
      */
-    const discoverStructure = new DiscoverStructure(crippledCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      crippledCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
     const recorded = discoverStructure.record(trainingData, neuronPromisesMap);
@@ -621,7 +630,11 @@ Deno.test({
     /**
      * Instantiate the discovery mechanism
      */
-    const discoverStructure = new DiscoverStructure(crippledCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      crippledCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
     const recorded = discoverStructure.record(trainingData, neuronPromisesMap);
@@ -704,7 +717,11 @@ Deno.test({
       });
     }
 
-    const discoverStructure = new DiscoverStructure(targetCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      targetCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
 
@@ -746,7 +763,11 @@ Deno.test({
     // Create empty training data
     const trainingData: DataRecordInterface[] = [];
 
-    const discoverStructure = new DiscoverStructure(targetCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      targetCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
 
@@ -791,7 +812,11 @@ Deno.test({
     ];
 
     // Create DiscoverStructure with normal timeout
-    const discoverStructure = new DiscoverStructure(targetCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      targetCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
 
@@ -842,7 +867,11 @@ Deno.test({
     ];
 
     // Create DiscoverStructure
-    const discoverStructure = new DiscoverStructure(targetCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      targetCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructureCleanUp.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructureCleanUp.test.ts
@@ -4,6 +4,7 @@ import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import {
   type CandidateNeuron,
   type CandidateSynapse,
+  DEFAULT_RUST_FLUSH_RECORDS,
   DiscoverStructure,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import { Creature } from "../../src/Creature.ts";
@@ -50,7 +51,11 @@ Deno.test({
   sanitizeResources: false,
   fn: async () => {
     const creature = makeMinimalCreature();
-    const discovery = new DiscoverStructure(creature, 5);
+    const discovery = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
 
     const neuronPromises = new Map<string, Promise<void>>();
     discovery.initialize(neuronPromises);

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
@@ -2,7 +2,10 @@ import { assert, assertEquals, assertExists } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
-import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
   assertRustDiscoveryAvailable,
   shouldSkipRustDiscoveryTests,
@@ -120,7 +123,11 @@ Deno.test({
 
     const trainingData = makeTrainingData(creature.input, 100);
 
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);
@@ -178,7 +185,11 @@ Deno.test({
 
     const trainingData = makeTrainingData(creature.input, 100);
 
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);
@@ -228,7 +239,11 @@ Deno.test({
     const trainingData = makeTrainingData(creature.input, 50);
 
     // Use very short timeout (1 second) to trigger timeout
-    const discoverStructure = new DiscoverStructure(creature, 1);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      1,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);
@@ -284,7 +299,11 @@ Deno.test({
       trainingData.push({ input, output: new Float32Array(output) });
     }
 
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);
@@ -334,7 +353,11 @@ Deno.test({
     const trainingData = makeTrainingData(creature.input, 100);
 
     // Very short timeout
-    const discoverStructure = new DiscoverStructure(creature, 1);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      1,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);
@@ -398,7 +421,11 @@ Deno.test({
 
     const trainingData = makeTrainingData(creature.input, 50);
 
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.test.ts
@@ -1,0 +1,112 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path/join";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import type { NeatOptions } from "../../src/config/NeatOptions.ts";
+import { recordDirectory } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts";
+import type { DiscoverStructureDeps } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type {
+  RustAnalyzeNeuronsResult,
+  RustAnalyzeSynapsesResult,
+  RustMergeParquetInput,
+  RustMergeParquetResult,
+  RustReadResult,
+  RustRecordInput,
+  RustRecordResult,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+
+Deno.test("Discovery flushes Rust recording in configured chunks", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "discovery-chunk-test-" });
+  try {
+    const dataFile = join(tempDir, "sample.bin");
+    const recordCount = 4;
+    const valuesPerRecord = 2; // input + output
+    const buffer = new Float32Array(recordCount * valuesPerRecord);
+
+    for (let i = 0; i < recordCount; i++) {
+      buffer[i * valuesPerRecord] = i;
+      buffer[i * valuesPerRecord + 1] = i * 2;
+    }
+
+    await Deno.writeFile(dataFile, new Uint8Array(buffer.buffer));
+
+    const creature = Creature.fromJSON({
+      input: 1,
+      output: 1,
+      neurons: [
+        { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0 },
+        { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+        { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+      ],
+    });
+    creature.validate();
+    CreatureUtil.makeUUID(creature);
+
+    const options: NeatOptions = {
+      costName: "MSE",
+      costOfGrowth: 0,
+      discoverySampleRate: 1,
+      discoveryBatchSize: 1,
+      discoveryTimeOutMinutes: 1,
+      discoveryAnalysisTimeoutMinutes: 1,
+      discoveryDrainEveryNBatches: 1,
+      discoveryRustFlushRecords: 2,
+      discoveryMaxNeurons: 1,
+      threads: 1,
+    };
+
+    const recordCallSizes: number[] = [];
+    const mergedChunks: string[][] = [];
+
+    const deps: Partial<DiscoverStructureDeps> = {
+      isRustDiscoveryEnabled: () => true,
+      isRustLibraryAvailable: () => true,
+      recordDiscovery: (
+        input: RustRecordInput,
+      ): RustRecordResult => {
+        recordCallSizes.push(input.training_data.length);
+        const chunkFile = join(
+          input.temp_dir,
+          `chunk-${recordCallSizes.length}.parquet`,
+        );
+        Deno.writeTextFileSync(chunkFile, "placeholder");
+        return {
+          success: true,
+          temp_dir: input.temp_dir,
+          file: `chunk-${recordCallSizes.length}.parquet`,
+        };
+      },
+      mergeDiscoveryParquet: (
+        input: RustMergeParquetInput,
+      ): RustMergeParquetResult => {
+        mergedChunks.push([...input.inputFiles]);
+        Deno.writeTextFileSync(input.outputFile, "merged");
+        return {
+          success: true,
+          outputFile: input.outputFile,
+        };
+      },
+      analyzeNeurons: (): RustAnalyzeNeuronsResult => ({ success: true }),
+      analyzeSynapses: (): RustAnalyzeSynapsesResult => ({
+        success: true,
+        helpfulSynapses: [],
+        harmfulSynapses: [],
+      }),
+      readDiscoveryRecords: (): RustReadResult => ({
+        success: true,
+        records: [],
+      }),
+    };
+
+    await recordDirectory(creature, tempDir, options, deps);
+
+    assertEquals(recordCallSizes, [2, 2]);
+    assertEquals(mergedChunks.length, 1);
+    assertEquals(mergedChunks[0].length, 2);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});

--- a/test/ErrorGuidedStructuralEvolution/InvalidDataDetection.ts
+++ b/test/ErrorGuidedStructuralEvolution/InvalidDataDetection.ts
@@ -1,7 +1,10 @@
 import { assert, assertExists } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
-import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
   assertRustDiscoveryAvailable,
   shouldSkipRustDiscoveryTests,
@@ -77,7 +80,11 @@ Deno.test({
       trainingData.push({ input, output });
     }
 
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);
@@ -130,7 +137,11 @@ Deno.test({
     const creature = makeSimpleCreature();
     CreatureUtil.makeUUID(creature);
 
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
 

--- a/test/ErrorGuidedStructuralEvolution/MinimalCreatureTest.ts
+++ b/test/ErrorGuidedStructuralEvolution/MinimalCreatureTest.ts
@@ -1,7 +1,10 @@
 import { assert, assertExists } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
-import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
   assertRustDiscoveryAvailable,
   shouldSkipRustDiscoveryTests,
@@ -48,7 +51,11 @@ Deno.test({
       trainingData.push({ input, output });
     }
 
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);
@@ -129,7 +136,11 @@ Deno.test({
       trainingData.push({ input, output });
     }
 
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);
@@ -224,7 +235,11 @@ Deno.test({
       trainingData.push({ input, output });
     }
 
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     discoverStructure.initialize(neuronPromisesMap);

--- a/test/ErrorGuidedStructuralEvolution/PromiseChainErrorHandling.ts
+++ b/test/ErrorGuidedStructuralEvolution/PromiseChainErrorHandling.ts
@@ -1,7 +1,10 @@
 import { assert, assertEquals } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
-import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
   assertRustDiscoveryAvailable,
   shouldSkipRustDiscoveryTests,
@@ -47,7 +50,11 @@ function makeSimpleCreature(): Creature {
 Deno.test("Discovery promise chains have error handlers", async () => {
   const creature = makeSimpleCreature();
   CreatureUtil.makeUUID(creature);
-  const discoverStructure = new DiscoverStructure(creature, 60);
+  const discoverStructure = new DiscoverStructure(
+    creature,
+    60,
+    DEFAULT_RUST_FLUSH_RECORDS,
+  );
 
   const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
@@ -107,7 +114,11 @@ Deno.test({
     CreatureUtil.makeUUID(creature);
 
     // Use an invalid temp directory path to force file write errors
-    const discoverStructure = new DiscoverStructure(creature, 60);
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
 
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
@@ -163,7 +174,11 @@ Deno.test({
 Deno.test("Discovery Promise.all() completes within timeout", async () => {
   const creature = makeSimpleCreature();
   CreatureUtil.makeUUID(creature);
-  const discoverStructure = new DiscoverStructure(creature, 60);
+  const discoverStructure = new DiscoverStructure(
+    creature,
+    60,
+    DEFAULT_RUST_FLUSH_RECORDS,
+  );
 
   const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 

--- a/test/ErrorGuidedStructuralEvolution/WeightedError.ts
+++ b/test/ErrorGuidedStructuralEvolution/WeightedError.ts
@@ -2,7 +2,10 @@ import { assert, assertAlmostEquals, fail } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
-import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
   assertRustDiscoveryAvailable,
   shouldSkipRustDiscoveryTests,
@@ -162,7 +165,11 @@ Deno.test({
       /**
        * Instantiate the discovery mechanism
        */
-      const discoverStructure = new DiscoverStructure(crippledCreature, 60);
+      const discoverStructure = new DiscoverStructure(
+        crippledCreature,
+        60,
+        DEFAULT_RUST_FLUSH_RECORDS,
+      );
       const neuronPromisesMap: Map<string, Promise<void>> = new Map();
       discoverStructure.initialize(neuronPromisesMap);
       const recorded = discoverStructure.record(
@@ -237,7 +244,11 @@ Deno.test({
     /**
      * Instantiate the discovery mechanism
      */
-    const discoverStructure = new DiscoverStructure(crippledCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      crippledCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromisesMap);
     const recorded = discoverStructure.record(trainingData, neuronPromisesMap);

--- a/test/discovery/DiscoveryCandidates.test.ts
+++ b/test/discovery/DiscoveryCandidates.test.ts
@@ -2,7 +2,10 @@ import { assert, assertEquals } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
-import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
 import {
   assertRustDiscoveryAvailable,
@@ -185,7 +188,11 @@ Deno.test({
     const trainingData = generateTrainingData(targetCreature);
     const crippledCreature = makeCrippledCreature(targetCreature);
 
-    const discoverStructure = new DiscoverStructure(crippledCreature, 60);
+    const discoverStructure = new DiscoverStructure(
+      crippledCreature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
     const neuronPromises: Map<string, Promise<void>> = new Map();
     discoverStructure.initialize(neuronPromises);
     try {


### PR DESCRIPTION
- Bumped version in deno.json to 0.195.0.
- Introduced `discoveryRustFlushRecords` to control memory usage by flushing Rust recordings in smaller chunks, reducing JavaScript heap pressure.
- Updated documentation to reflect new memory management strategies and tuning options for `discoveryRustFlushRecords`.
- Enhanced logging and error handling in the discovery process to improve robustness and clarity.

This update improves performance and memory efficiency during discovery operations, particularly for larger datasets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable, chunked flushing of discovery records to Rust (with Parquet merge), dependency-injectable discovery pipeline, updated docs/tests, and version bump.
> 
> - **Discovery engine**:
>   - Add `DEFAULT_RUST_FLUSH_RECORDS` (4,096) and new option `options.discoveryRustFlushRecords`.
>   - Implement chunked Rust recording: `shouldFlushRustChunk()`, `flushRustChunk()`, and internal Parquet chunk writer; merge chunks into a final Parquet at end.
>   - Introduce DI via `DiscoverStructureDeps` for Rust FFI calls and feature checks; thread `deps` through `DiscoverDirectory.recordDirectory()`.
>   - Periodically flush chunks during file/batch processing; improved timeout handling, promise draining, and cleanup.
>   - Update discovery tagging/logging to use human-readable `"Discovery"` tag in summaries.
> - **FFI/Bindings**:
>   - Add `merge_discovery_parquet` FFI symbol and `mergeDiscoveryParquet()` wrapper.
> - **Config**:
>   - Wire `discoveryRustFlushRecords` through `NeatOptions`/`NeatConfig` with defaults and validation; adjust `log` default when `verbose` is set.
> - **Docs**:
>   - Document memory tuning for `discoveryRustFlushRecords` and add memory fixes note on chunked Rust recording.
> - **Tooling/Tests**:
>   - Enhance `quality.sh` to build discovery lib and run tests with/without FFI.
>   - Add `DiscoveryRustFlush.test.ts` and update existing tests to pass flush-size default.
> - **Version**:
>   - Bump to `0.195.0` and add `@std/testing/mock` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc0262e48d0828da6eb5a6e4c4c64f1c3291360e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->