### PR TITLE
Refactor record index handling in DiscoverStructure for improved samp…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.195.0",
+  "version": "0.195.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -417,10 +417,9 @@ export class DiscoverStructure {
     let recordIndices: number[] | undefined = undefined;
     if (this.rustBinaryFilePaths.size === 1 && this.rustBinaryFilePath) {
       const fileIndices = this.selectedIndices[this.rustBinaryFilePath];
-      if (
-        fileIndices && fileIndices.length === this.rustAccumulatedData.length
-      ) {
-        recordIndices = fileIndices;
+      if (fileIndices && fileIndices.length >= pendingSamples) {
+        const recentIndices = fileIndices.slice(-pendingSamples);
+        recordIndices = recentIndices.map((_value, idx) => idx);
       }
     }
 

--- a/test/discovery/DiscoverStructureRecordIndices.test.ts
+++ b/test/discovery/DiscoverStructureRecordIndices.test.ts
@@ -1,0 +1,110 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
+import type { RustRecordInput } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+
+function makeCreature(): Creature {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: -0.25 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+Deno.test("DiscoverStructure normalises record indices for single binary chunk", async () => {
+  const creature = makeCreature();
+  const recordedInputs: RustRecordInput[] = [];
+
+  const structure = new DiscoverStructure(
+    creature,
+    60,
+    100,
+    {
+      isRustDiscoveryEnabled: () => true,
+      isRustLibraryAvailable: () => true,
+      recordDiscovery: (input) => {
+        recordedInputs.push(input);
+        return {
+          success: true,
+          file: "chunk.parquet",
+        };
+      },
+      mergeDiscoveryParquet: () => ({
+        success: true,
+        outputFile: "merged.parquet",
+      }),
+      analyzeNeurons: () => ({
+        success: true,
+        helpfulNeurons: [],
+      }),
+      analyzeSynapses: () => ({
+        success: true,
+        helpfulSynapses: [],
+        harmfulSynapses: [],
+      }),
+      readDiscoveryRecords: () => ({
+        success: true,
+        records: [],
+      }),
+    },
+  );
+
+  const neuronPromises = new Map<string, Promise<void>>();
+
+  try {
+    structure.initialize(neuronPromises);
+
+    const trainingRecords: DataRecordInterface[] = [];
+    const rawIndices: number[] = [];
+
+    for (let i = 0; i < 10; i++) {
+      const input = Float32Array.from([i / 10, (i + 1) / 10]);
+      const output = Float32Array.from([i / 5]);
+      trainingRecords.push({
+        input,
+        output,
+      });
+      rawIndices.push(100 + i * 37); // Large indices that exceed chunk length
+    }
+
+    const recorded = structure.record(
+      trainingRecords,
+      neuronPromises,
+      "/tmp/fake.bin",
+      rawIndices,
+    );
+    assert(recorded, "record call should succeed");
+
+    const flushed = structure.flushRustChunk();
+    assertEquals(flushed, true, "flush should succeed");
+
+    assertEquals(
+      recordedInputs.length,
+      1,
+      "recordDiscovery should be invoked once",
+    );
+    const [input] = recordedInputs;
+    assert(input.record_indices, "record indices should be provided to Rust");
+    const expectedIndices = rawIndices.map((_value, idx) => idx);
+    assertEquals(
+      input.record_indices,
+      expectedIndices,
+      "record indices should be normalised to chunk-relative offsets",
+    );
+  } finally {
+    await structure.cleanUp();
+  }
+});


### PR DESCRIPTION
…le processing

- Updated logic to select recent indices based on the number of pending samples, enhancing the accuracy of record indices used during discovery.
- This change ensures that the system can effectively manage and utilize available data, particularly when dealing with varying sample sizes.

This update improves the robustness of the discovery process by refining how record indices are determined.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes `record_indices` to chunk-relative offsets based on the most recent pending samples and adds a unit test to validate this behavior.
> 
> - **Discovery recording (Rust flush)**
>   - In `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts`:
>     - Normalize `record_indices` to chunk-relative offsets (`0..N-1`).
>     - Use only the most recent indices matching `pendingSamples` when a single binary source is present.
> - **Tests**
>   - Add `test/discovery/DiscoverStructureRecordIndices.test.ts` to verify indices normalization for single binary chunks and successful flush.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cd2bc2ad4359a1e6043ced5f0f1927ee4811777. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->