### PR TITLE
Enhance creature validation with UUID checks in CreatureValidate

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.195.1",
+  "version": "0.195.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/CreatureValidate.ts
+++ b/src/architecture/CreatureValidate.ts
@@ -2,6 +2,9 @@ import { assert } from "@std/assert";
 import type { Creature } from "../Creature.ts";
 import { ValidationError } from "../errors/ValidationError.ts";
 
+const MAX_NEURON_UUID_LENGTH = 256;
+const VALID_NEURON_UUID_PATTERN = /^[A-Za-z0-9-]+$/;
+
 /**
  * Validate the creature
  * @param options specific values to check
@@ -47,6 +50,20 @@ export function creatureValidate(
     const uuid = neuron.uuid;
     if (!uuid) {
       throw new ValidationError(`${neuron.ID()}) no UUID`, "OTHER");
+    }
+    if (uuid.length > MAX_NEURON_UUID_LENGTH) {
+      debugWrite(creature);
+      throw new ValidationError(
+        `${neuron.ID()}) UUID length ${uuid.length} exceeds maximum allowed ${MAX_NEURON_UUID_LENGTH}`,
+        "OTHER",
+      );
+    }
+    if (!VALID_NEURON_UUID_PATTERN.test(uuid)) {
+      debugWrite(creature);
+      throw new ValidationError(
+        `${neuron.ID()}) invalid UUID characters: ${uuid}`,
+        "OTHER",
+      );
     }
     if (UUIDs.has(uuid)) {
       debugWrite(creature);

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -380,6 +380,8 @@ export class DiscoverStructure {
       return null;
     }
 
+    this.creature.validate();
+
     const creatureExport = this.creature.exportJSON();
     const rustCreature = creatureToRustFormat(creatureExport);
     const pendingSamples = this.rustAccumulatedData.length;
@@ -868,6 +870,8 @@ export class DiscoverStructure {
       return undefined;
     }
 
+    this.creature.validate();
+
     const rustInput: RustAnalyzeNeuronsInput = {
       parquetFile: this.parquetFilePath,
       creature: creatureToRustFormat(this.creature.exportJSON()),
@@ -920,6 +924,8 @@ export class DiscoverStructure {
     ) {
       return undefined;
     }
+
+    this.creature.validate();
 
     const rustInput: RustAnalyzeSynapsesInput = {
       parquetFile: this.parquetFilePath,

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryUuidValidation.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryUuidValidation.test.ts
@@ -1,0 +1,41 @@
+import { assertThrows } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { ValidationError } from "../../src/errors/ValidationError.ts";
+
+Deno.test("DiscoverStructure validates creature before Rust export", () => {
+  const creature = new Creature(10, 2, { layers: [{ count: 10 }] });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+
+  const hiddenIndex = creature.input;
+  creature.neurons[hiddenIndex].uuid = `hidden-${"x".repeat(300)}`;
+
+  const discoverStructure = new DiscoverStructure(creature, 5, 1, {
+    isRustDiscoveryEnabled: () => true,
+    isRustLibraryAvailable: () => true,
+    recordDiscovery: () => ({ success: true, temp_dir: "", file: "" }),
+    mergeDiscoveryParquet: () => ({ success: true, output_file: "" }),
+    analyzeNeurons: () => {
+      throw new Error("analyzeNeurons should not run when validation fails");
+    },
+    analyzeSynapses: () => {
+      throw new Error("analyzeSynapses should not run when validation fails");
+    },
+    readDiscoveryRecords: () => ({ success: true, records: [] }),
+  });
+
+  (discoverStructure as unknown as { parquetFilePath: string | null })
+    .parquetFilePath = "dummy.parquet";
+
+  const runner = discoverStructure as unknown as {
+    runRustNeuronAnalysis(focusList: string[]): void;
+  };
+
+  assertThrows(
+    () => runner.runRustNeuronAnalysis(["hidden-0"]),
+    ValidationError,
+    "UUID",
+  );
+});

--- a/test/validate/CreatureValidate.ts
+++ b/test/validate/CreatureValidate.ts
@@ -257,6 +257,41 @@ Deno.test("Duplicate UUID", () => {
   }
 });
 
+Deno.test("UUID too long", () => {
+  const creature = new Creature(10, 2, { layers: [{ count: 10 }] });
+  creature.DEBUG = true;
+  const hiddenIndex = creature.input;
+  const longSuffix = "x".repeat(300);
+  creature.neurons[hiddenIndex].uuid = `hidden-${longSuffix}`;
+  try {
+    creatureValidate(creature);
+    fail("Expected error");
+  } catch (e) {
+    const error = e as Error;
+    assert(
+      error.name === "OTHER",
+      `Unexpected name: ${error.name}`,
+    );
+  }
+});
+
+Deno.test("UUID invalid characters", () => {
+  const creature = new Creature(10, 2, { layers: [{ count: 10 }] });
+  creature.DEBUG = true;
+  const hiddenIndex = creature.input;
+  creature.neurons[hiddenIndex].uuid = "hidden uuid";
+  try {
+    creatureValidate(creature);
+    fail("Expected error");
+  } catch (e) {
+    const error = e as Error;
+    assert(
+      error.name === "OTHER",
+      `Unexpected name: ${error.name}`,
+    );
+  }
+});
+
 Deno.test("invalid input UUID", () => {
   const creature = new Creature(10, 2, { layers: [{ count: 10 }] });
   creature.DEBUG = true;


### PR DESCRIPTION
- Introduced maximum length and character pattern validation for UUIDs in the creature validation process.
- Added error handling for cases where UUIDs exceed the maximum length or contain invalid characters.
- Updated tests to cover scenarios for long and invalid UUIDs, ensuring robust validation.

This update improves the integrity of creature data by enforcing stricter UUID validation rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds strict neuron UUID length/charset validation and runs creature validation before Rust discovery/analysis, with corresponding tests.
> 
> - **Validation**:
>   - Enforce neuron UUID constraints in `src/architecture/CreatureValidate.ts`:
>     - Max length `256` and allowed pattern `[A-Za-z0-9-]+`; throw `ValidationError` on violations.
> - **Discovery**:
>   - Call `creature.validate()` before Rust Parquet flush and analyses in `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts` (`writeRustParquetChunk`, `runRustNeuronAnalysis`, `runRustSynapseAnalysis`).
> - **Tests**:
>   - Add `test/ErrorGuidedStructuralEvolution/DiscoveryUuidValidation.test.ts` to ensure validation runs before Rust export.
>   - Extend `test/validate/CreatureValidate.ts` with cases for overly long and invalid-character UUIDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69a09d651db63fad9c810b36e8c60a8042ded583. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->