### PR TITLE
Add RustFlushMetrics and diagnostics to DiscoverStructure

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.195.3",
+  "version": "0.195.4",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -24,6 +24,7 @@ import {
   type RustAnalyzeSynapsesResult,
   type RustCandidateNeuron,
   type RustCandidateSynapse,
+  type RustRecordBatchStats,
   type RustRecordInput,
 } from "./RustDiscovery.ts";
 import { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
@@ -116,10 +117,33 @@ interface NeuronErrorInfo {
   totalError: number;
 }
 
+export interface RustFlushMetrics extends RustRecordBatchStats {
+  recordsWithNoNeuronData: number;
+  recordsWithMismatchedNeuronCount: number;
+  recordsWithInputMismatch: number;
+  recordsWithOutputMismatch: number;
+  missingUuidEntries: number;
+  nonFiniteActivationCount: number;
+  nonFiniteValueCount: number;
+  nonFiniteErrorCount: number;
+  firstMissingUuidLocation?: string;
+  firstNonFiniteActivationLocation?: string;
+  firstNonFiniteValueLocation?: string;
+  firstNonFiniteErrorLocation?: string;
+}
+
 interface RustFlushDiagnostics {
   summary: string;
   warnings: string[];
   errors: string[];
+  metrics: RustFlushMetrics;
+}
+
+interface RustFlushAggregation {
+  expectedInputLength: number;
+  expectedOutputLength: number;
+  expectedNeuronCount: number;
+  metrics: RustFlushMetrics;
 }
 
 const RUST_HELPFUL_THRESHOLD = 0.1;
@@ -490,6 +514,7 @@ export class DiscoverStructure {
       this.creature.output,
       nonInputNeurons.length,
     );
+    const metrics = diagnostics.metrics;
 
     let recordIndices: number[] | undefined = undefined;
     if (this.rustBinaryFilePaths.size === 1 && this.rustBinaryFilePath) {
@@ -590,17 +615,43 @@ export class DiscoverStructure {
     }
 
     const errorMessage = result?.error || "Unknown error";
+    const errorDetails = result?.errorDetails;
+    const logDetails: Record<string, unknown> = {
+      pendingSamples,
+      timeoutExpired: timedOut,
+      binaryFilePath: this.rustBinaryFilePath,
+      forcedFocusNeurons: this.forcedFocusNeurons,
+      accumulatedSamples: this.rustAccumulatedData.length,
+      chunkFiles: this.rustChunkFiles.length,
+      longestRustUuidLength: metrics.longestNeuronUuidLength,
+      totalRustUuidBytes: metrics.totalNeuronUuidBytes,
+      maxRustErrorsPerNeuron: metrics.maxErrorValuesPerNeuron,
+      totalRustErrorValues: metrics.totalErrorValues,
+      rustRecordCount: metrics.sampleCount,
+    };
+    if (metrics.longestNeuronUuid && metrics.longestNeuronUuidLength > 0) {
+      logDetails.longestRustUuid = metrics.longestNeuronUuid;
+    }
+    if (metrics.inputLength !== undefined) {
+      logDetails.rustInputLength = metrics.inputLength;
+    }
+    if (metrics.outputLength !== undefined) {
+      logDetails.rustOutputLength = metrics.outputLength;
+    }
+    if (errorDetails) {
+      logDetails.rustRecordFailureStage = errorDetails.stage;
+      if (errorDetails.inputJsonLength !== undefined) {
+        logDetails.rustInputJsonLength = errorDetails.inputJsonLength;
+      }
+      if (errorDetails.inputBytesLength !== undefined) {
+        logDetails.rustInputBytes = errorDetails.inputBytesLength;
+      }
+      logDetails.recordDiscoveryStats = errorDetails.stats;
+    }
     this.log(
       "error",
       `Rust discovery recording failed: ${errorMessage}`,
-      {
-        pendingSamples,
-        timeoutExpired: timedOut,
-        binaryFilePath: this.rustBinaryFilePath,
-        forcedFocusNeurons: this.forcedFocusNeurons,
-        accumulatedSamples: this.rustAccumulatedData.length,
-        chunkFiles: this.rustChunkFiles.length,
-      },
+      logDetails,
     );
     return null;
   }
@@ -666,6 +717,32 @@ export class DiscoverStructure {
     return true;
   }
 
+  public static computeRustFlushMetrics(
+    data: RustRecordInput["training_data"],
+    expectedNeuronCount: number,
+    expectedInputLength: number,
+    expectedOutputLength: number,
+  ): RustRecordBatchStats {
+    const aggregation = DiscoverStructure.createRustFlushAggregationInternal(
+      expectedInputLength,
+      expectedOutputLength,
+      expectedNeuronCount,
+    );
+    data.forEach((record, recordIndex) => {
+      DiscoverStructure.observeRustTrainingRecordInternal(
+        aggregation,
+        record,
+        recordIndex,
+      );
+    });
+    const diagnostics = DiscoverStructure
+      .finalizeRustFlushDiagnosticsInternal(
+        aggregation,
+        DiscoverStructure.truncateForLogValue,
+      );
+    return diagnostics.metrics;
+  }
+
   private emitRustFlushDiagnostics(
     diagnostics: RustFlushDiagnostics,
     timedOut: boolean,
@@ -688,160 +765,269 @@ export class DiscoverStructure {
     diagnostics.errors.forEach((error) => this.log("error", error));
   }
 
+  private createRustFlushAggregation(
+    expectedInputLength: number,
+    expectedOutputLength: number,
+    expectedNeuronCount: number,
+  ): RustFlushAggregation {
+    return DiscoverStructure.createRustFlushAggregationInternal(
+      expectedInputLength,
+      expectedOutputLength,
+      expectedNeuronCount,
+    );
+  }
+
+  private observeRustTrainingRecord(
+    aggregation: RustFlushAggregation,
+    record: RustRecordInput["training_data"][number],
+    globalSampleIndex: number,
+  ): void {
+    DiscoverStructure.observeRustTrainingRecordInternal(
+      aggregation,
+      record,
+      globalSampleIndex,
+    );
+  }
+
+  private finalizeRustFlushDiagnostics(
+    aggregation: RustFlushAggregation,
+  ): RustFlushDiagnostics {
+    return DiscoverStructure.finalizeRustFlushDiagnosticsInternal(
+      aggregation,
+      (value, max) => this.truncateForLog(value, max),
+    );
+  }
+
   private inspectRustFlushBatch(
     rustTrainingData: RustRecordInput["training_data"],
     expectedInputLength: number,
     expectedOutputLength: number,
     expectedNeuronCount: number,
   ): RustFlushDiagnostics {
-    let recordsWithNoNeuronData = 0;
-    let recordsWithMismatchedNeuronCount = 0;
-    let recordsWithInputMismatch = 0;
-    let recordsWithOutputMismatch = 0;
-    let missingUuidEntries = 0;
-    let nonFiniteActivationCount = 0;
-    let nonFiniteValueCount = 0;
-    let nonFiniteErrorCount = 0;
-    let firstMissingUuidLocation: string | undefined;
-    let firstNonFiniteActivationLocation: string | undefined;
-    let firstNonFiniteValueLocation: string | undefined;
-    let firstNonFiniteErrorLocation: string | undefined;
-    let longestUuid = "";
-
+    const aggregation = this.createRustFlushAggregation(
+      expectedInputLength,
+      expectedOutputLength,
+      expectedNeuronCount,
+    );
     rustTrainingData.forEach((record, recordIndex) => {
-      const neuronData = record.neuron_data ?? [];
-      if (neuronData.length === 0) {
-        recordsWithNoNeuronData++;
-      }
-      if (neuronData.length !== expectedNeuronCount) {
-        recordsWithMismatchedNeuronCount++;
-      }
+      this.observeRustTrainingRecord(aggregation, record, recordIndex);
+    });
+    return this.finalizeRustFlushDiagnostics(aggregation);
+  }
 
-      if (record.input.length !== expectedInputLength) {
-        recordsWithInputMismatch++;
-      }
+  private truncateForLog(value: string, max = 120): string {
+    return DiscoverStructure.truncateForLogValue(value, max);
+  }
 
-      if (record.output.length !== expectedOutputLength) {
-        recordsWithOutputMismatch++;
-      }
+  private static truncateForLogValue(value: string, max = 120): string {
+    if (value.length <= max) {
+      return value;
+    }
+    return `${value.slice(0, max)}…`;
+  }
 
-      neuronData.forEach((neuron, neuronIndex) => {
-        const uuid = typeof neuron.neuron_uuid === "string"
-          ? neuron.neuron_uuid
-          : "";
+  private static createRustFlushAggregationInternal(
+    expectedInputLength: number,
+    expectedOutputLength: number,
+    expectedNeuronCount: number,
+  ): RustFlushAggregation {
+    return {
+      expectedInputLength,
+      expectedOutputLength,
+      expectedNeuronCount,
+      metrics: {
+        sampleCount: 0,
+        expectedNeuronCount,
+        totalNeuronRecords: 0,
+        totalNeuronUuidBytes: 0,
+        longestNeuronUuidLength: 0,
+        longestNeuronUuid: undefined,
+        totalErrorValues: 0,
+        maxErrorValuesPerNeuron: 0,
+        inputLength: undefined,
+        outputLength: undefined,
+        recordsWithNoNeuronData: 0,
+        recordsWithMismatchedNeuronCount: 0,
+        recordsWithInputMismatch: 0,
+        recordsWithOutputMismatch: 0,
+        missingUuidEntries: 0,
+        nonFiniteActivationCount: 0,
+        nonFiniteValueCount: 0,
+        nonFiniteErrorCount: 0,
+        firstMissingUuidLocation: undefined,
+        firstNonFiniteActivationLocation: undefined,
+        firstNonFiniteValueLocation: undefined,
+        firstNonFiniteErrorLocation: undefined,
+      },
+    };
+  }
 
-        if (uuid.length === 0) {
-          missingUuidEntries++;
-          if (firstMissingUuidLocation === undefined) {
-            firstMissingUuidLocation =
-              `record ${recordIndex}, neuron ${neuronIndex}`;
-          }
-        } else if (uuid.length > longestUuid.length) {
-          longestUuid = uuid;
+  private static observeRustTrainingRecordInternal(
+    aggregation: RustFlushAggregation,
+    record: RustRecordInput["training_data"][number],
+    globalSampleIndex: number,
+  ): void {
+    const metrics = aggregation.metrics;
+    metrics.sampleCount += 1;
+
+    if (metrics.inputLength === undefined) {
+      metrics.inputLength = record.input.length;
+    }
+    if (metrics.outputLength === undefined) {
+      metrics.outputLength = record.output.length;
+    }
+
+    if (record.input.length !== aggregation.expectedInputLength) {
+      metrics.recordsWithInputMismatch += 1;
+    }
+
+    if (record.output.length !== aggregation.expectedOutputLength) {
+      metrics.recordsWithOutputMismatch += 1;
+    }
+
+    const neuronData = record.neuron_data ?? [];
+    metrics.totalNeuronRecords += neuronData.length;
+
+    if (neuronData.length === 0) {
+      metrics.recordsWithNoNeuronData += 1;
+    }
+    if (neuronData.length !== aggregation.expectedNeuronCount) {
+      metrics.recordsWithMismatchedNeuronCount += 1;
+    }
+
+    neuronData.forEach((neuron, neuronIndex) => {
+      const uuid = typeof neuron.neuron_uuid === "string"
+        ? neuron.neuron_uuid
+        : "";
+      const uuidLength = uuid.length;
+      metrics.totalNeuronUuidBytes += uuidLength;
+
+      if (uuidLength === 0) {
+        metrics.missingUuidEntries += 1;
+        if (!metrics.firstMissingUuidLocation) {
+          metrics.firstMissingUuidLocation =
+            `record ${globalSampleIndex}, neuron ${neuronIndex}`;
         }
+      } else if (uuidLength > metrics.longestNeuronUuidLength) {
+        metrics.longestNeuronUuidLength = uuidLength;
+        metrics.longestNeuronUuid = uuid;
+      }
 
-        if (!Number.isFinite(neuron.activation)) {
-          nonFiniteActivationCount++;
-          if (firstNonFiniteActivationLocation === undefined) {
-            firstNonFiniteActivationLocation =
-              `record ${recordIndex}, neuron ${neuronIndex}`;
+      if (!Number.isFinite(neuron.activation)) {
+        metrics.nonFiniteActivationCount += 1;
+        if (!metrics.firstNonFiniteActivationLocation) {
+          metrics.firstNonFiniteActivationLocation =
+            `record ${globalSampleIndex}, neuron ${neuronIndex}`;
+        }
+      }
+
+      const value = (neuron as { value?: number }).value;
+      if (value !== undefined && value !== null && !Number.isFinite(value)) {
+        metrics.nonFiniteValueCount += 1;
+        if (!metrics.firstNonFiniteValueLocation) {
+          metrics.firstNonFiniteValueLocation =
+            `record ${globalSampleIndex}, neuron ${neuronIndex}`;
+        }
+      }
+
+      const errors = Array.isArray(neuron.errors) ? neuron.errors : [];
+      metrics.totalErrorValues += errors.length;
+      if (errors.length > metrics.maxErrorValuesPerNeuron) {
+        metrics.maxErrorValuesPerNeuron = errors.length;
+      }
+
+      errors.forEach((errorValue, errorIndex) => {
+        if (!Number.isFinite(errorValue)) {
+          metrics.nonFiniteErrorCount += 1;
+          if (!metrics.firstNonFiniteErrorLocation) {
+            metrics.firstNonFiniteErrorLocation =
+              `record ${globalSampleIndex}, neuron ${neuronIndex}, error ${errorIndex}`;
           }
         }
-        if (
-          neuron.value !== undefined && neuron.value !== null &&
-          !Number.isFinite(neuron.value)
-        ) {
-          nonFiniteValueCount++;
-          if (firstNonFiniteValueLocation === undefined) {
-            firstNonFiniteValueLocation =
-              `record ${recordIndex}, neuron ${neuronIndex}`;
-          }
-        }
-        neuron.errors.forEach((errorValue, errorIndex) => {
-          if (!Number.isFinite(errorValue)) {
-            nonFiniteErrorCount++;
-            if (firstNonFiniteErrorLocation === undefined) {
-              firstNonFiniteErrorLocation =
-                `record ${recordIndex}, neuron ${neuronIndex}, error ${errorIndex}`;
-            }
-          }
-        });
       });
     });
+  }
 
+  private static finalizeRustFlushDiagnosticsInternal(
+    aggregation: RustFlushAggregation,
+    truncate: (value: string, max?: number) => string,
+  ): RustFlushDiagnostics {
+    const { metrics } = aggregation;
     const summaryParts = [
-      `samples=${rustTrainingData.length}`,
-      `expectedNeuronCount=${expectedNeuronCount}`,
-      `recordsWithNoNeuronData=${recordsWithNoNeuronData}`,
-      `recordsWithMismatchedNeuronCount=${recordsWithMismatchedNeuronCount}`,
-      `missingUuidEntries=${missingUuidEntries}`,
-      `nonFiniteActivationValues=${nonFiniteActivationCount}`,
-      `nonFiniteNeuronValues=${nonFiniteValueCount}`,
-      `nonFiniteErrorValues=${nonFiniteErrorCount}`,
+      `samples=${metrics.sampleCount}`,
+      `expectedNeuronCount=${aggregation.expectedNeuronCount}`,
+      `recordsWithNoNeuronData=${metrics.recordsWithNoNeuronData}`,
+      `recordsWithMismatchedNeuronCount=${metrics.recordsWithMismatchedNeuronCount}`,
+      `recordsWithInputMismatch=${metrics.recordsWithInputMismatch}`,
+      `recordsWithOutputMismatch=${metrics.recordsWithOutputMismatch}`,
+      `missingUuidEntries=${metrics.missingUuidEntries}`,
+      `nonFiniteActivationValues=${metrics.nonFiniteActivationCount}`,
+      `nonFiniteNeuronValues=${metrics.nonFiniteValueCount}`,
+      `nonFiniteErrorValues=${metrics.nonFiniteErrorCount}`,
     ];
 
-    if (longestUuid.length > 0) {
+    if (metrics.longestNeuronUuid && metrics.longestNeuronUuidLength > 0) {
       summaryParts.push(
         `longestUuid="${
-          this.truncateForLog(longestUuid)
-        }" (${longestUuid.length})`,
+          truncate(metrics.longestNeuronUuid)
+        }" (${metrics.longestNeuronUuidLength})`,
       );
     }
 
     const warnings: string[] = [];
-    if (recordsWithNoNeuronData > 0) {
+    if (metrics.recordsWithNoNeuronData > 0) {
       warnings.push(
-        `Rust flush detected ${recordsWithNoNeuronData} record(s) without neuron data.`,
+        `Rust flush detected ${metrics.recordsWithNoNeuronData} record(s) without neuron data.`,
       );
     }
-    if (recordsWithMismatchedNeuronCount > 0) {
+    if (metrics.recordsWithMismatchedNeuronCount > 0) {
       warnings.push(
-        `Rust flush detected ${recordsWithMismatchedNeuronCount} record(s) with neuron count mismatch (expected ${expectedNeuronCount}).`,
+        `Rust flush detected ${metrics.recordsWithMismatchedNeuronCount} record(s) with neuron count mismatch (expected ${aggregation.expectedNeuronCount}).`,
       );
     }
-    if (recordsWithInputMismatch > 0) {
+    if (metrics.recordsWithInputMismatch > 0) {
       warnings.push(
-        `Rust flush detected ${recordsWithInputMismatch} record(s) where input length != expected ${expectedInputLength}.`,
+        `Rust flush detected ${metrics.recordsWithInputMismatch} record(s) where input length != expected ${aggregation.expectedInputLength}.`,
       );
     }
-    if (recordsWithOutputMismatch > 0) {
+    if (metrics.recordsWithOutputMismatch > 0) {
       warnings.push(
-        `Rust flush detected ${recordsWithOutputMismatch} record(s) where output length != expected ${expectedOutputLength}.`,
+        `Rust flush detected ${metrics.recordsWithOutputMismatch} record(s) where output length != expected ${aggregation.expectedOutputLength}.`,
       );
     }
 
     const errors: string[] = [];
-    if (missingUuidEntries > 0) {
-      const location = firstMissingUuidLocation
-        ? ` (first observed at ${firstMissingUuidLocation})`
+    if (metrics.missingUuidEntries > 0) {
+      const location = metrics.firstMissingUuidLocation
+        ? ` (first observed at ${metrics.firstMissingUuidLocation})`
         : "";
       errors.push(
-        `Rust flush encountered ${missingUuidEntries} neuron entries with missing UUID${location}.`,
+        `Rust flush encountered ${metrics.missingUuidEntries} neuron entries with missing UUID${location}.`,
       );
     }
-    if (nonFiniteActivationCount > 0) {
+    if (metrics.nonFiniteActivationCount > 0) {
       errors.push(
-        `Rust flush encountered ${nonFiniteActivationCount} non-finite activation value(s)${
-          firstNonFiniteActivationLocation
-            ? ` (first observed at ${firstNonFiniteActivationLocation})`
+        `Rust flush encountered ${metrics.nonFiniteActivationCount} non-finite activation value(s)${
+          metrics.firstNonFiniteActivationLocation
+            ? ` (first observed at ${metrics.firstNonFiniteActivationLocation})`
             : ""
         }.`,
       );
     }
-    if (nonFiniteValueCount > 0) {
+    if (metrics.nonFiniteValueCount > 0) {
       errors.push(
-        `Rust flush encountered ${nonFiniteValueCount} non-finite optional neuron value(s)${
-          firstNonFiniteValueLocation
-            ? ` (first observed at ${firstNonFiniteValueLocation})`
+        `Rust flush encountered ${metrics.nonFiniteValueCount} non-finite optional neuron value(s)${
+          metrics.firstNonFiniteValueLocation
+            ? ` (first observed at ${metrics.firstNonFiniteValueLocation})`
             : ""
         }.`,
       );
     }
-    if (nonFiniteErrorCount > 0) {
+    if (metrics.nonFiniteErrorCount > 0) {
       errors.push(
-        `Rust flush encountered ${nonFiniteErrorCount} non-finite error value(s)${
-          firstNonFiniteErrorLocation
-            ? ` (first observed at ${firstNonFiniteErrorLocation})`
+        `Rust flush encountered ${metrics.nonFiniteErrorCount} non-finite error value(s)${
+          metrics.firstNonFiniteErrorLocation
+            ? ` (first observed at ${metrics.firstNonFiniteErrorLocation})`
             : ""
         }.`,
       );
@@ -851,14 +1037,8 @@ export class DiscoverStructure {
       summary: `Rust flush diagnostics: ${summaryParts.join(", ")}`,
       warnings,
       errors,
+      metrics,
     };
-  }
-
-  private truncateForLog(value: string, max = 120): string {
-    if (value.length <= max) {
-      return value;
-    }
-    return `${value.slice(0, max)}…`;
   }
 
   private discoveries: CandidateSynapse[] = [];

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -26,10 +26,7 @@ import {
   type RustCandidateSynapse,
   type RustRecordInput,
 } from "./RustDiscovery.ts";
-import {
-  DEFAULT_RUST_FLUSH_RECORDS,
-  DEFAULT_RUST_STREAM_RECORDS,
-} from "./constants.ts";
+import { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
 
 export { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
 
@@ -119,49 +116,10 @@ interface NeuronErrorInfo {
   totalError: number;
 }
 
-export interface RustFlushMetrics {
-  sampleCount: number;
-  expectedNeuronCount: number;
-  expectedInputLength: number;
-  expectedOutputLength: number;
-  totalNeuronRecords: number;
-  totalNeuronUuidBytes: number;
-  longestNeuronUuid?: string;
-  longestNeuronUuidLength: number;
-  totalErrorValues: number;
-  maxErrorValuesPerNeuron: number;
-}
-
 interface RustFlushDiagnostics {
   summary: string;
   warnings: string[];
   errors: string[];
-  metrics: RustFlushMetrics;
-}
-
-interface RustFlushAggregation {
-  expectedInputLength: number;
-  expectedOutputLength: number;
-  expectedNeuronCount: number;
-  sampleCount: number;
-  recordsWithNoNeuronData: number;
-  recordsWithMismatchedNeuronCount: number;
-  recordsWithInputMismatch: number;
-  recordsWithOutputMismatch: number;
-  missingUuidEntries: number;
-  nonFiniteActivationCount: number;
-  nonFiniteValueCount: number;
-  nonFiniteErrorCount: number;
-  firstMissingUuidLocation?: string;
-  firstNonFiniteActivationLocation?: string;
-  firstNonFiniteValueLocation?: string;
-  firstNonFiniteErrorLocation?: string;
-  longestUuid?: string;
-  longestUuidLength: number;
-  totalNeuronRecords: number;
-  totalNeuronUuidBytes: number;
-  totalErrorValues: number;
-  maxErrorValuesPerNeuron: number;
 }
 
 const RUST_HELPFUL_THRESHOLD = 0.1;
@@ -193,7 +151,6 @@ export class DiscoverStructure {
   private usingRustDualWrite = false;
   private parquetFilePath: string | null = null;
   private rustFlushRecords: number;
-  private rustStreamRecords: number;
   private rustChunkFiles: string[] = [];
   private rustChunkCounter = 0;
   private syntheticBinaryMode = false;
@@ -223,65 +180,9 @@ export class DiscoverStructure {
     );
     this.timeoutTS = Date.now() + timeoutSeconds * 1000;
     this.rustFlushRecords = Math.max(1, rustFlushRecords);
-    this.rustStreamRecords = Math.max(
-      1,
-      Math.min(DEFAULT_RUST_STREAM_RECORDS, this.rustFlushRecords),
-    );
     this.deps = { ...DEFAULT_DISCOVER_STRUCTURE_DEPS, ...deps };
 
     Deno.mkdirSync(this.tempDir, { recursive: true });
-  }
-
-  public static computeRustFlushMetrics(
-    rustTrainingData: RustRecordInput["training_data"],
-    expectedNeuronCount: number,
-    expectedInputLength: number,
-    expectedOutputLength: number,
-  ): RustFlushMetrics {
-    let totalNeuronRecords = 0;
-    let totalNeuronUuidBytes = 0;
-    let totalErrorValues = 0;
-    let maxErrorValuesPerNeuron = 0;
-    let longestNeuronUuid = "";
-    let longestNeuronUuidLength = 0;
-
-    for (const record of rustTrainingData) {
-      const neuronData = record.neuron_data ?? [];
-      totalNeuronRecords += neuronData.length;
-
-      for (const neuron of neuronData) {
-        const uuid = typeof neuron.neuron_uuid === "string"
-          ? neuron.neuron_uuid
-          : "";
-        const uuidLength = uuid.length;
-        totalNeuronUuidBytes += uuidLength;
-        if (uuidLength > longestNeuronUuidLength) {
-          longestNeuronUuid = uuid;
-          longestNeuronUuidLength = uuidLength;
-        }
-
-        const errorLength = neuron.errors?.length ?? 0;
-        totalErrorValues += errorLength;
-        if (errorLength > maxErrorValuesPerNeuron) {
-          maxErrorValuesPerNeuron = errorLength;
-        }
-      }
-    }
-
-    return {
-      sampleCount: rustTrainingData.length,
-      expectedNeuronCount,
-      expectedInputLength,
-      expectedOutputLength,
-      totalNeuronRecords,
-      totalNeuronUuidBytes,
-      longestNeuronUuid: longestNeuronUuidLength > 0
-        ? longestNeuronUuid
-        : undefined,
-      longestNeuronUuidLength,
-      totalErrorValues,
-      maxErrorValuesPerNeuron,
-    };
   }
 
   public configureLogging(options: {
@@ -557,6 +458,48 @@ export class DiscoverStructure {
       neuron.type !== "input"
     );
 
+    const rustTrainingData = this.rustAccumulatedData.map((record, index) => {
+      const discoverMap = this.rustAccumulatedNeuronData[index];
+
+      const neuronData = nonInputNeurons.map((neuron) => {
+        const discoverRecord = discoverMap.get(neuron.uuid) || {
+          activation: this.creature.state.activations[neuron.index],
+          errors: [] as number[],
+        };
+
+        const errors = discoverRecord.errors.filter(Number.isFinite);
+
+        return {
+          neuron_uuid: neuron.uuid,
+          activation: discoverRecord.activation,
+          value: discoverRecord.value,
+          errors: errors,
+        };
+      });
+
+      return {
+        input: Array.from(record.input),
+        output: Array.from(record.output),
+        neuron_data: neuronData,
+      };
+    });
+
+    const diagnostics = this.inspectRustFlushBatch(
+      rustTrainingData,
+      this.creature.input,
+      this.creature.output,
+      nonInputNeurons.length,
+    );
+
+    let recordIndices: number[] | undefined = undefined;
+    if (this.rustBinaryFilePaths.size === 1 && this.rustBinaryFilePath) {
+      const fileIndices = this.selectedIndices[this.rustBinaryFilePath];
+      if (fileIndices && fileIndices.length >= pendingSamples) {
+        const recentIndices = fileIndices.slice(-pendingSamples);
+        recordIndices = recentIndices.slice();
+      }
+    }
+
     const now = Date.now();
     const timedOut = now > this.timeoutTS;
     if (timedOut) {
@@ -566,232 +509,100 @@ export class DiscoverStructure {
       );
     }
 
+    this.emitRustFlushDiagnostics(diagnostics, timedOut);
+
     const timeoutSeconds = timedOut
       ? 0
       : Math.max(0, Math.floor((this.timeoutTS - now) / 1000));
 
-    const aggregation = this.createRustFlushAggregation(
-      this.creature.input,
-      this.creature.output,
-      nonInputNeurons.length,
-    );
+    const rustInput: RustRecordInput = {
+      creature: rustCreature,
+      "training_data": rustTrainingData,
+      "temp_dir": tempDir,
+      "binary_file_path": this.rustBinaryFilePath || undefined,
+      "record_indices": recordIndices,
+      "timeout_seconds": timeoutSeconds,
+    };
 
-    const streamBatchSize = Math.max(
-      1,
-      Math.min(this.rustStreamRecords, pendingSamples),
-    );
-    const totalSlices = Math.ceil(pendingSamples / streamBatchSize);
+    const result = this.deps.recordDiscovery(rustInput);
 
-    let sequentialRecordIndices: number[] | undefined;
-    if (this.rustBinaryFilePaths.size === 1 && this.rustBinaryFilePath) {
-      const fileIndices = this.selectedIndices[this.rustBinaryFilePath];
-      if (fileIndices && fileIndices.length >= pendingSamples) {
-        sequentialRecordIndices = Array.from(
-          { length: pendingSamples },
-          (_, idx) => idx,
-        );
-      }
-    }
+    if (result && result.success && result.file) {
+      const parquetPath = `${tempDir}/${result.file}`;
 
-    const partFiles: string[] = [];
-    let rustErrorMessage: string | null = null;
-    let rustErrorDetails: unknown = undefined;
+      if (this.syntheticBinaryMode || this.rustBinaryFilePaths.size === 0) {
+        this.syntheticBinaryMode = true;
+        const tempBinaryFile = `${tempDir}/training_data.bin`;
+        const BYTES_PER_RECORD = (this.creature.input + this.creature.output) *
+          4;
+        const file = Deno.openSync(tempBinaryFile, {
+          create: true,
+          write: true,
+          truncate: true,
+        });
 
-    for (
-      let sliceStart = 0;
-      sliceStart < pendingSamples;
-      sliceStart += streamBatchSize
-    ) {
-      const sliceEnd = Math.min(sliceStart + streamBatchSize, pendingSamples);
-
-      const trainingDataSlice = this.buildRustTrainingSlice(
-        sliceStart,
-        sliceEnd,
-        nonInputNeurons,
-        aggregation,
-      );
-
-      const partIndex = partFiles.length;
-      const partDir = totalSlices === 1
-        ? tempDir
-        : `${tempDir}/parts/part-${partIndex.toString().padStart(5, "0")}`;
-
-      if (partDir !== tempDir) {
         try {
-          Deno.mkdirSync(partDir, { recursive: true });
-        } catch (error) {
-          if (!(error instanceof Deno.errors.AlreadyExists)) {
-            throw error;
+          const buffer = new Uint8Array(BYTES_PER_RECORD);
+          const recordArray = new Float32Array(buffer.buffer);
+          const sequentialIndices: number[] = [];
+
+          for (let i = 0; i < this.rustAccumulatedData.length; i++) {
+            const record = this.rustAccumulatedData[i];
+            for (let j = 0; j < this.creature.input; j++) {
+              recordArray[j] = record.input[j];
+            }
+            for (let j = 0; j < this.creature.output; j++) {
+              recordArray[this.creature.input + j] = record.output[j];
+            }
+            file.writeSync(buffer);
+            sequentialIndices.push(i);
           }
+
+          this.selectedIndices[tempBinaryFile] = sequentialIndices;
+          this.rustBinaryFilePaths.add(tempBinaryFile);
+          if (!this.rustBinaryFilePath) {
+            this.rustBinaryFilePath = tempBinaryFile;
+          }
+        } finally {
+          file.close();
         }
       }
 
-      const sliceRecordIndices = sequentialRecordIndices
-        ? Array.from({ length: sliceEnd - sliceStart }, (_, idx) => idx)
-        : undefined;
+      Deno.writeTextFileSync(
+        this.indicesFilePath,
+        JSON.stringify(this.selectedIndices),
+      );
 
-      const rustInput: RustRecordInput = {
-        creature: rustCreature,
-        "training_data": trainingDataSlice,
-        "temp_dir": partDir,
-        "binary_file_path": this.rustBinaryFilePath || undefined,
-        "record_indices": sliceRecordIndices,
-        "timeout_seconds": timeoutSeconds,
-      };
+      this.rustAccumulatedData = [];
+      this.rustAccumulatedNeuronData = [];
+      const flushDuration = Date.now() - now;
+      const remainingSeconds = Math.max(
+        0,
+        Math.floor((this.timeoutTS - Date.now()) / 1000),
+      );
+      this.log(
+        "info",
+        `Flushed ${pendingSamples} samples to ${parquetPath} in ${
+          this.formatMillis(flushDuration)
+        } (timeout remaining: ${remainingSeconds}s).`,
+      );
 
-      const result = this.deps.recordDiscovery(rustInput);
-
-      if (result && result.success && result.file) {
-        const partPath = `${partDir}/${result.file}`;
-        partFiles.push(partPath);
-      } else {
-        rustErrorMessage = result?.error || "Unknown error";
-        rustErrorDetails = result?.errorDetails;
-        break;
-      }
+      return parquetPath;
     }
 
-    const diagnostics = this.finalizeRustFlushDiagnostics(aggregation);
-    const metrics = diagnostics.metrics;
-    this.emitRustFlushDiagnostics(diagnostics, timedOut);
-
-    if (rustErrorMessage !== null || partFiles.length === 0) {
-      const errorMeta: Record<string, unknown> = {
+    const errorMessage = result?.error || "Unknown error";
+    this.log(
+      "error",
+      `Rust discovery recording failed: ${errorMessage}`,
+      {
         pendingSamples,
         timeoutExpired: timedOut,
         binaryFilePath: this.rustBinaryFilePath,
         forcedFocusNeurons: this.forcedFocusNeurons,
         accumulatedSamples: this.rustAccumulatedData.length,
         chunkFiles: this.rustChunkFiles.length,
-        longestRustUuid: metrics.longestNeuronUuid,
-        longestRustUuidLength: metrics.longestNeuronUuidLength,
-        totalRustUuidBytes: metrics.totalNeuronUuidBytes,
-        totalRustErrorValues: metrics.totalErrorValues,
-        maxRustErrorsPerNeuron: metrics.maxErrorValuesPerNeuron,
-        rustSampleCount: metrics.sampleCount,
-        expectedRustNeuronCount: metrics.expectedNeuronCount,
-        totalRustNeuronRecords: metrics.totalNeuronRecords,
-      };
-
-      if (rustErrorDetails) {
-        if ((rustErrorDetails as { stage?: unknown }).stage) {
-          errorMeta.recordDiscoveryStage = (rustErrorDetails as {
-            stage?: string;
-          }).stage;
-        }
-        if (
-          (rustErrorDetails as { inputJsonLength?: unknown })
-            .inputJsonLength !== undefined
-        ) {
-          errorMeta.rustInputJsonLength = (rustErrorDetails as {
-            inputJsonLength?: number;
-          }).inputJsonLength;
-        }
-        if (
-          (rustErrorDetails as { inputBytesLength?: unknown })
-            .inputBytesLength !== undefined
-        ) {
-          errorMeta.rustInputBytes = (rustErrorDetails as {
-            inputBytesLength?: number;
-          }).inputBytesLength;
-        }
-        if ((rustErrorDetails as { stats?: unknown }).stats) {
-          errorMeta.recordDiscoveryStats = (rustErrorDetails as {
-            stats?: unknown;
-          }).stats;
-        }
-      }
-
-      const message = rustErrorMessage ??
-        "Rust discovery recording failed: no parquet output generated";
-      this.log(
-        "error",
-        `Rust discovery recording failed: ${message}`,
-        errorMeta,
-      );
-      return null;
-    }
-
-    let parquetPath: string;
-    if (partFiles.length === 1 && totalSlices === 1) {
-      parquetPath = partFiles[0];
-    } else {
-      const outputFile = `${tempDir}/discovery_data.parquet`;
-      const mergeResult = this.deps.mergeDiscoveryParquet({
-        outputFile,
-        inputFiles: partFiles,
-      });
-
-      if (!mergeResult || !mergeResult.success) {
-        this.log(
-          "error",
-          "Rust discovery merge failed",
-          mergeResult?.error ?? "Unknown error",
-        );
-        return null;
-      }
-
-      parquetPath = mergeResult.outputFile ?? outputFile;
-    }
-
-    if (this.syntheticBinaryMode || this.rustBinaryFilePaths.size === 0) {
-      this.syntheticBinaryMode = true;
-      const tempBinaryFile = `${tempDir}/training_data.bin`;
-      const BYTES_PER_RECORD = (this.creature.input + this.creature.output) *
-        4;
-      const file = Deno.openSync(tempBinaryFile, {
-        create: true,
-        write: true,
-        truncate: true,
-      });
-
-      try {
-        const buffer = new Uint8Array(BYTES_PER_RECORD);
-        const recordArray = new Float32Array(buffer.buffer);
-        const sequentialIndices: number[] = [];
-
-        for (let i = 0; i < this.rustAccumulatedData.length; i++) {
-          const record = this.rustAccumulatedData[i];
-          for (let j = 0; j < this.creature.input; j++) {
-            recordArray[j] = record.input[j];
-          }
-          for (let j = 0; j < this.creature.output; j++) {
-            recordArray[this.creature.input + j] = record.output[j];
-          }
-          file.writeSync(buffer);
-          sequentialIndices.push(i);
-        }
-
-        this.selectedIndices[tempBinaryFile] = sequentialIndices;
-        this.rustBinaryFilePaths.add(tempBinaryFile);
-        if (!this.rustBinaryFilePath) {
-          this.rustBinaryFilePath = tempBinaryFile;
-        }
-      } finally {
-        file.close();
-      }
-    }
-
-    Deno.writeTextFileSync(
-      this.indicesFilePath,
-      JSON.stringify(this.selectedIndices),
+      },
     );
-
-    this.rustAccumulatedData = [];
-    this.rustAccumulatedNeuronData = [];
-    const flushDuration = Date.now() - now;
-    const remainingSeconds = Math.max(
-      0,
-      Math.floor((this.timeoutTS - Date.now()) / 1000),
-    );
-    this.log(
-      "info",
-      `Flushed ${pendingSamples} samples to ${parquetPath} in ${
-        this.formatMillis(flushDuration)
-      } (timeout remaining: ${remainingSeconds}s).`,
-    );
-
-    return parquetPath;
+    return null;
   }
 
   public flushRustChunk(): boolean {
@@ -877,204 +688,160 @@ export class DiscoverStructure {
     diagnostics.errors.forEach((error) => this.log("error", error));
   }
 
-  private createRustFlushAggregation(
+  private inspectRustFlushBatch(
+    rustTrainingData: RustRecordInput["training_data"],
     expectedInputLength: number,
     expectedOutputLength: number,
     expectedNeuronCount: number,
-  ): RustFlushAggregation {
-    return {
-      expectedInputLength,
-      expectedOutputLength,
-      expectedNeuronCount,
-      sampleCount: 0,
-      recordsWithNoNeuronData: 0,
-      recordsWithMismatchedNeuronCount: 0,
-      recordsWithInputMismatch: 0,
-      recordsWithOutputMismatch: 0,
-      missingUuidEntries: 0,
-      nonFiniteActivationCount: 0,
-      nonFiniteValueCount: 0,
-      nonFiniteErrorCount: 0,
-      longestUuid: undefined,
-      longestUuidLength: 0,
-      firstMissingUuidLocation: undefined,
-      firstNonFiniteActivationLocation: undefined,
-      firstNonFiniteValueLocation: undefined,
-      firstNonFiniteErrorLocation: undefined,
-      totalNeuronRecords: 0,
-      totalNeuronUuidBytes: 0,
-      totalErrorValues: 0,
-      maxErrorValuesPerNeuron: 0,
-    };
-  }
+  ): RustFlushDiagnostics {
+    let recordsWithNoNeuronData = 0;
+    let recordsWithMismatchedNeuronCount = 0;
+    let recordsWithInputMismatch = 0;
+    let recordsWithOutputMismatch = 0;
+    let missingUuidEntries = 0;
+    let nonFiniteActivationCount = 0;
+    let nonFiniteValueCount = 0;
+    let nonFiniteErrorCount = 0;
+    let firstMissingUuidLocation: string | undefined;
+    let firstNonFiniteActivationLocation: string | undefined;
+    let firstNonFiniteValueLocation: string | undefined;
+    let firstNonFiniteErrorLocation: string | undefined;
+    let longestUuid = "";
 
-  private observeRustTrainingRecord(
-    aggregation: RustFlushAggregation,
-    record: RustRecordInput["training_data"][number],
-    globalSampleIndex: number,
-  ): void {
-    const neuronData = record.neuron_data ?? [];
-    aggregation.sampleCount += 1;
+    rustTrainingData.forEach((record, recordIndex) => {
+      const neuronData = record.neuron_data ?? [];
+      if (neuronData.length === 0) {
+        recordsWithNoNeuronData++;
+      }
+      if (neuronData.length !== expectedNeuronCount) {
+        recordsWithMismatchedNeuronCount++;
+      }
 
-    if (neuronData.length === 0) {
-      aggregation.recordsWithNoNeuronData += 1;
-    }
-    if (neuronData.length !== aggregation.expectedNeuronCount) {
-      aggregation.recordsWithMismatchedNeuronCount += 1;
-    }
-    if (record.input.length !== aggregation.expectedInputLength) {
-      aggregation.recordsWithInputMismatch += 1;
-    }
-    if (record.output.length !== aggregation.expectedOutputLength) {
-      aggregation.recordsWithOutputMismatch += 1;
-    }
+      if (record.input.length !== expectedInputLength) {
+        recordsWithInputMismatch++;
+      }
 
-    aggregation.totalNeuronRecords += neuronData.length;
+      if (record.output.length !== expectedOutputLength) {
+        recordsWithOutputMismatch++;
+      }
 
-    neuronData.forEach((neuron, neuronIndex) => {
-      const uuid = typeof neuron.neuron_uuid === "string"
-        ? neuron.neuron_uuid
-        : "";
-      const uuidLength = uuid.length;
-      aggregation.totalNeuronUuidBytes += uuidLength;
+      neuronData.forEach((neuron, neuronIndex) => {
+        const uuid = typeof neuron.neuron_uuid === "string"
+          ? neuron.neuron_uuid
+          : "";
 
-      if (uuidLength === 0) {
-        aggregation.missingUuidEntries += 1;
-        if (aggregation.firstMissingUuidLocation === undefined) {
-          aggregation.firstMissingUuidLocation =
-            `record ${globalSampleIndex}, neuron ${neuronIndex}`;
+        if (uuid.length === 0) {
+          missingUuidEntries++;
+          if (firstMissingUuidLocation === undefined) {
+            firstMissingUuidLocation =
+              `record ${recordIndex}, neuron ${neuronIndex}`;
+          }
+        } else if (uuid.length > longestUuid.length) {
+          longestUuid = uuid;
         }
-      } else if (uuidLength > aggregation.longestUuidLength) {
-        aggregation.longestUuid = uuid;
-        aggregation.longestUuidLength = uuidLength;
-      }
 
-      if (!Number.isFinite(neuron.activation)) {
-        aggregation.nonFiniteActivationCount += 1;
-        if (aggregation.firstNonFiniteActivationLocation === undefined) {
-          aggregation.firstNonFiniteActivationLocation =
-            `record ${globalSampleIndex}, neuron ${neuronIndex}`;
-        }
-      }
-
-      if (
-        neuron.value !== undefined && neuron.value !== null &&
-        !Number.isFinite(neuron.value)
-      ) {
-        aggregation.nonFiniteValueCount += 1;
-        if (aggregation.firstNonFiniteValueLocation === undefined) {
-          aggregation.firstNonFiniteValueLocation =
-            `record ${globalSampleIndex}, neuron ${neuronIndex}`;
-        }
-      }
-
-      const errorValues = neuron.errors ?? [];
-      aggregation.totalErrorValues += errorValues.length;
-      if (errorValues.length > aggregation.maxErrorValuesPerNeuron) {
-        aggregation.maxErrorValuesPerNeuron = errorValues.length;
-      }
-
-      errorValues.forEach((errorValue, errorIndex) => {
-        if (!Number.isFinite(errorValue)) {
-          aggregation.nonFiniteErrorCount += 1;
-          if (aggregation.firstNonFiniteErrorLocation === undefined) {
-            aggregation.firstNonFiniteErrorLocation =
-              `record ${globalSampleIndex}, neuron ${neuronIndex}, error ${errorIndex}`;
+        if (!Number.isFinite(neuron.activation)) {
+          nonFiniteActivationCount++;
+          if (firstNonFiniteActivationLocation === undefined) {
+            firstNonFiniteActivationLocation =
+              `record ${recordIndex}, neuron ${neuronIndex}`;
           }
         }
+        if (
+          neuron.value !== undefined && neuron.value !== null &&
+          !Number.isFinite(neuron.value)
+        ) {
+          nonFiniteValueCount++;
+          if (firstNonFiniteValueLocation === undefined) {
+            firstNonFiniteValueLocation =
+              `record ${recordIndex}, neuron ${neuronIndex}`;
+          }
+        }
+        neuron.errors.forEach((errorValue, errorIndex) => {
+          if (!Number.isFinite(errorValue)) {
+            nonFiniteErrorCount++;
+            if (firstNonFiniteErrorLocation === undefined) {
+              firstNonFiniteErrorLocation =
+                `record ${recordIndex}, neuron ${neuronIndex}, error ${errorIndex}`;
+            }
+          }
+        });
       });
     });
-  }
-
-  private finalizeRustFlushDiagnostics(
-    aggregation: RustFlushAggregation,
-  ): RustFlushDiagnostics {
-    const metrics: RustFlushMetrics = {
-      sampleCount: aggregation.sampleCount,
-      expectedNeuronCount: aggregation.expectedNeuronCount,
-      expectedInputLength: aggregation.expectedInputLength,
-      expectedOutputLength: aggregation.expectedOutputLength,
-      totalNeuronRecords: aggregation.totalNeuronRecords,
-      totalNeuronUuidBytes: aggregation.totalNeuronUuidBytes,
-      longestNeuronUuid: aggregation.longestUuid,
-      longestNeuronUuidLength: aggregation.longestUuidLength,
-      totalErrorValues: aggregation.totalErrorValues,
-      maxErrorValuesPerNeuron: aggregation.maxErrorValuesPerNeuron,
-    };
 
     const summaryParts = [
-      `samples=${aggregation.sampleCount}`,
-      `expectedNeuronCount=${aggregation.expectedNeuronCount}`,
-      `recordsWithNoNeuronData=${aggregation.recordsWithNoNeuronData}`,
-      `recordsWithMismatchedNeuronCount=${aggregation.recordsWithMismatchedNeuronCount}`,
-      `missingUuidEntries=${aggregation.missingUuidEntries}`,
-      `nonFiniteActivationValues=${aggregation.nonFiniteActivationCount}`,
-      `nonFiniteNeuronValues=${aggregation.nonFiniteValueCount}`,
-      `nonFiniteErrorValues=${aggregation.nonFiniteErrorCount}`,
+      `samples=${rustTrainingData.length}`,
+      `expectedNeuronCount=${expectedNeuronCount}`,
+      `recordsWithNoNeuronData=${recordsWithNoNeuronData}`,
+      `recordsWithMismatchedNeuronCount=${recordsWithMismatchedNeuronCount}`,
+      `missingUuidEntries=${missingUuidEntries}`,
+      `nonFiniteActivationValues=${nonFiniteActivationCount}`,
+      `nonFiniteNeuronValues=${nonFiniteValueCount}`,
+      `nonFiniteErrorValues=${nonFiniteErrorCount}`,
     ];
 
-    if (metrics.longestNeuronUuidLength > 0 && metrics.longestNeuronUuid) {
+    if (longestUuid.length > 0) {
       summaryParts.push(
         `longestUuid="${
-          this.truncateForLog(metrics.longestNeuronUuid)
-        }" (${metrics.longestNeuronUuidLength})`,
+          this.truncateForLog(longestUuid)
+        }" (${longestUuid.length})`,
       );
     }
 
     const warnings: string[] = [];
-    if (aggregation.recordsWithNoNeuronData > 0) {
+    if (recordsWithNoNeuronData > 0) {
       warnings.push(
-        `Rust flush detected ${aggregation.recordsWithNoNeuronData} record(s) without neuron data.`,
+        `Rust flush detected ${recordsWithNoNeuronData} record(s) without neuron data.`,
       );
     }
-    if (aggregation.recordsWithMismatchedNeuronCount > 0) {
+    if (recordsWithMismatchedNeuronCount > 0) {
       warnings.push(
-        `Rust flush detected ${aggregation.recordsWithMismatchedNeuronCount} record(s) with neuron count mismatch (expected ${aggregation.expectedNeuronCount}).`,
+        `Rust flush detected ${recordsWithMismatchedNeuronCount} record(s) with neuron count mismatch (expected ${expectedNeuronCount}).`,
       );
     }
-    if (aggregation.recordsWithInputMismatch > 0) {
+    if (recordsWithInputMismatch > 0) {
       warnings.push(
-        `Rust flush detected ${aggregation.recordsWithInputMismatch} record(s) where input length != expected ${aggregation.expectedInputLength}.`,
+        `Rust flush detected ${recordsWithInputMismatch} record(s) where input length != expected ${expectedInputLength}.`,
       );
     }
-    if (aggregation.recordsWithOutputMismatch > 0) {
+    if (recordsWithOutputMismatch > 0) {
       warnings.push(
-        `Rust flush detected ${aggregation.recordsWithOutputMismatch} record(s) where output length != expected ${aggregation.expectedOutputLength}.`,
+        `Rust flush detected ${recordsWithOutputMismatch} record(s) where output length != expected ${expectedOutputLength}.`,
       );
     }
 
     const errors: string[] = [];
-    if (aggregation.missingUuidEntries > 0) {
-      const location = aggregation.firstMissingUuidLocation
-        ? ` (first observed at ${aggregation.firstMissingUuidLocation})`
+    if (missingUuidEntries > 0) {
+      const location = firstMissingUuidLocation
+        ? ` (first observed at ${firstMissingUuidLocation})`
         : "";
       errors.push(
-        `Rust flush encountered ${aggregation.missingUuidEntries} neuron entries with missing UUID${location}.`,
+        `Rust flush encountered ${missingUuidEntries} neuron entries with missing UUID${location}.`,
       );
     }
-    if (aggregation.nonFiniteActivationCount > 0) {
+    if (nonFiniteActivationCount > 0) {
       errors.push(
-        `Rust flush encountered ${aggregation.nonFiniteActivationCount} non-finite activation value(s)${
-          aggregation.firstNonFiniteActivationLocation
-            ? ` (first observed at ${aggregation.firstNonFiniteActivationLocation})`
+        `Rust flush encountered ${nonFiniteActivationCount} non-finite activation value(s)${
+          firstNonFiniteActivationLocation
+            ? ` (first observed at ${firstNonFiniteActivationLocation})`
             : ""
         }.`,
       );
     }
-    if (aggregation.nonFiniteValueCount > 0) {
+    if (nonFiniteValueCount > 0) {
       errors.push(
-        `Rust flush encountered ${aggregation.nonFiniteValueCount} non-finite optional neuron value(s)${
-          aggregation.firstNonFiniteValueLocation
-            ? ` (first observed at ${aggregation.firstNonFiniteValueLocation})`
+        `Rust flush encountered ${nonFiniteValueCount} non-finite optional neuron value(s)${
+          firstNonFiniteValueLocation
+            ? ` (first observed at ${firstNonFiniteValueLocation})`
             : ""
         }.`,
       );
     }
-    if (aggregation.nonFiniteErrorCount > 0) {
+    if (nonFiniteErrorCount > 0) {
       errors.push(
-        `Rust flush encountered ${aggregation.nonFiniteErrorCount} non-finite error value(s)${
-          aggregation.firstNonFiniteErrorLocation
-            ? ` (first observed at ${aggregation.firstNonFiniteErrorLocation})`
+        `Rust flush encountered ${nonFiniteErrorCount} non-finite error value(s)${
+          firstNonFiniteErrorLocation
+            ? ` (first observed at ${firstNonFiniteErrorLocation})`
             : ""
         }.`,
       );
@@ -1084,49 +851,7 @@ export class DiscoverStructure {
       summary: `Rust flush diagnostics: ${summaryParts.join(", ")}`,
       warnings,
       errors,
-      metrics,
     };
-  }
-
-  private buildRustTrainingSlice(
-    start: number,
-    end: number,
-    nonInputNeurons: Array<Creature["neurons"][number]>,
-    aggregation: RustFlushAggregation,
-  ): RustRecordInput["training_data"] {
-    const slice: RustRecordInput["training_data"] = [];
-
-    for (let i = start; i < end; i++) {
-      const record = this.rustAccumulatedData[i];
-      const discoverMap = this.rustAccumulatedNeuronData[i];
-
-      const neuronData = nonInputNeurons.map((neuron) => {
-        const discoverRecord = discoverMap.get(neuron.uuid) || {
-          activation: this.creature.state.activations[neuron.index],
-          errors: [] as number[],
-        };
-
-        const errors = discoverRecord.errors.filter(Number.isFinite);
-
-        return {
-          neuron_uuid: neuron.uuid,
-          activation: discoverRecord.activation,
-          value: discoverRecord.value,
-          errors,
-        };
-      });
-
-      const trainingRecord = {
-        input: Array.from(record.input),
-        output: Array.from(record.output),
-        "neuron_data": neuronData,
-      };
-
-      slice.push(trainingRecord);
-      this.observeRustTrainingRecord(aggregation, trainingRecord, i);
-    }
-
-    return slice;
   }
 
   private truncateForLog(value: string, max = 120): string {

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -116,10 +116,24 @@ interface NeuronErrorInfo {
   totalError: number;
 }
 
+export interface RustFlushMetrics {
+  sampleCount: number;
+  expectedNeuronCount: number;
+  expectedInputLength: number;
+  expectedOutputLength: number;
+  totalNeuronRecords: number;
+  totalNeuronUuidBytes: number;
+  longestNeuronUuid?: string;
+  longestNeuronUuidLength: number;
+  totalErrorValues: number;
+  maxErrorValuesPerNeuron: number;
+}
+
 interface RustFlushDiagnostics {
   summary: string;
   warnings: string[];
   errors: string[];
+  metrics: RustFlushMetrics;
 }
 
 const RUST_HELPFUL_THRESHOLD = 0.1;
@@ -183,6 +197,58 @@ export class DiscoverStructure {
     this.deps = { ...DEFAULT_DISCOVER_STRUCTURE_DEPS, ...deps };
 
     Deno.mkdirSync(this.tempDir, { recursive: true });
+  }
+
+  public static computeRustFlushMetrics(
+    rustTrainingData: RustRecordInput["training_data"],
+    expectedNeuronCount: number,
+    expectedInputLength: number,
+    expectedOutputLength: number,
+  ): RustFlushMetrics {
+    let totalNeuronRecords = 0;
+    let totalNeuronUuidBytes = 0;
+    let totalErrorValues = 0;
+    let maxErrorValuesPerNeuron = 0;
+    let longestNeuronUuid = "";
+    let longestNeuronUuidLength = 0;
+
+    for (const record of rustTrainingData) {
+      const neuronData = record.neuron_data ?? [];
+      totalNeuronRecords += neuronData.length;
+
+      for (const neuron of neuronData) {
+        const uuid = typeof neuron.neuron_uuid === "string"
+          ? neuron.neuron_uuid
+          : "";
+        const uuidLength = uuid.length;
+        totalNeuronUuidBytes += uuidLength;
+        if (uuidLength > longestNeuronUuidLength) {
+          longestNeuronUuid = uuid;
+          longestNeuronUuidLength = uuidLength;
+        }
+
+        const errorLength = neuron.errors?.length ?? 0;
+        totalErrorValues += errorLength;
+        if (errorLength > maxErrorValuesPerNeuron) {
+          maxErrorValuesPerNeuron = errorLength;
+        }
+      }
+    }
+
+    return {
+      sampleCount: rustTrainingData.length,
+      expectedNeuronCount,
+      expectedInputLength,
+      expectedOutputLength,
+      totalNeuronRecords,
+      totalNeuronUuidBytes,
+      longestNeuronUuid: longestNeuronUuidLength > 0
+        ? longestNeuronUuid
+        : undefined,
+      longestNeuronUuidLength,
+      totalErrorValues,
+      maxErrorValuesPerNeuron,
+    };
   }
 
   public configureLogging(options: {
@@ -490,6 +556,7 @@ export class DiscoverStructure {
       this.creature.output,
       nonInputNeurons.length,
     );
+    const metrics = diagnostics.metrics;
 
     let recordIndices: number[] | undefined = undefined;
     if (this.rustBinaryFilePaths.size === 1 && this.rustBinaryFilePath) {
@@ -590,17 +657,43 @@ export class DiscoverStructure {
     }
 
     const errorMessage = result?.error || "Unknown error";
+    const errorDetails = result?.errorDetails;
+    const errorMeta: Record<string, unknown> = {
+      pendingSamples,
+      timeoutExpired: timedOut,
+      binaryFilePath: this.rustBinaryFilePath,
+      forcedFocusNeurons: this.forcedFocusNeurons,
+      accumulatedSamples: this.rustAccumulatedData.length,
+      chunkFiles: this.rustChunkFiles.length,
+      longestRustUuid: metrics.longestNeuronUuid,
+      longestRustUuidLength: metrics.longestNeuronUuidLength,
+      totalRustUuidBytes: metrics.totalNeuronUuidBytes,
+      totalRustErrorValues: metrics.totalErrorValues,
+      maxRustErrorsPerNeuron: metrics.maxErrorValuesPerNeuron,
+      rustSampleCount: metrics.sampleCount,
+      expectedRustNeuronCount: metrics.expectedNeuronCount,
+      totalRustNeuronRecords: metrics.totalNeuronRecords,
+    };
+
+    if (errorDetails) {
+      if (errorDetails.stage) {
+        errorMeta.recordDiscoveryStage = errorDetails.stage;
+      }
+      if (errorDetails.inputJsonLength !== undefined) {
+        errorMeta.rustInputJsonLength = errorDetails.inputJsonLength;
+      }
+      if (errorDetails.inputBytesLength !== undefined) {
+        errorMeta.rustInputBytes = errorDetails.inputBytesLength;
+      }
+      if (errorDetails.stats) {
+        errorMeta.recordDiscoveryStats = errorDetails.stats;
+      }
+    }
+
     this.log(
       "error",
       `Rust discovery recording failed: ${errorMessage}`,
-      {
-        pendingSamples,
-        timeoutExpired: timedOut,
-        binaryFilePath: this.rustBinaryFilePath,
-        forcedFocusNeurons: this.forcedFocusNeurons,
-        accumulatedSamples: this.rustAccumulatedData.length,
-        chunkFiles: this.rustChunkFiles.length,
-      },
+      errorMeta,
     );
     return null;
   }
@@ -707,6 +800,11 @@ export class DiscoverStructure {
     let firstNonFiniteValueLocation: string | undefined;
     let firstNonFiniteErrorLocation: string | undefined;
     let longestUuid = "";
+    let longestUuidLength = 0;
+    let totalNeuronRecords = 0;
+    let totalUuidBytes = 0;
+    let totalErrorValues = 0;
+    let maxErrorValuesPerNeuron = 0;
 
     rustTrainingData.forEach((record, recordIndex) => {
       const neuronData = record.neuron_data ?? [];
@@ -725,19 +823,24 @@ export class DiscoverStructure {
         recordsWithOutputMismatch++;
       }
 
+      totalNeuronRecords += neuronData.length;
+
       neuronData.forEach((neuron, neuronIndex) => {
         const uuid = typeof neuron.neuron_uuid === "string"
           ? neuron.neuron_uuid
           : "";
+        const uuidLength = uuid.length;
+        totalUuidBytes += uuidLength;
 
-        if (uuid.length === 0) {
+        if (uuidLength === 0) {
           missingUuidEntries++;
           if (firstMissingUuidLocation === undefined) {
             firstMissingUuidLocation =
               `record ${recordIndex}, neuron ${neuronIndex}`;
           }
-        } else if (uuid.length > longestUuid.length) {
+        } else if (uuidLength > longestUuidLength) {
           longestUuid = uuid;
+          longestUuidLength = uuidLength;
         }
 
         if (!Number.isFinite(neuron.activation)) {
@@ -757,7 +860,12 @@ export class DiscoverStructure {
               `record ${recordIndex}, neuron ${neuronIndex}`;
           }
         }
-        neuron.errors.forEach((errorValue, errorIndex) => {
+        const errorValues = neuron.errors ?? [];
+        totalErrorValues += errorValues.length;
+        if (errorValues.length > maxErrorValuesPerNeuron) {
+          maxErrorValuesPerNeuron = errorValues.length;
+        }
+        errorValues.forEach((errorValue, errorIndex) => {
           if (!Number.isFinite(errorValue)) {
             nonFiniteErrorCount++;
             if (firstNonFiniteErrorLocation === undefined) {
@@ -768,6 +876,19 @@ export class DiscoverStructure {
         });
       });
     });
+
+    const metrics: RustFlushMetrics = {
+      sampleCount: rustTrainingData.length,
+      expectedNeuronCount,
+      expectedInputLength,
+      expectedOutputLength,
+      totalNeuronRecords,
+      totalNeuronUuidBytes: totalUuidBytes,
+      longestNeuronUuid: longestUuidLength > 0 ? longestUuid : undefined,
+      longestNeuronUuidLength: longestUuidLength,
+      totalErrorValues,
+      maxErrorValuesPerNeuron,
+    };
 
     const summaryParts = [
       `samples=${rustTrainingData.length}`,
@@ -780,11 +901,11 @@ export class DiscoverStructure {
       `nonFiniteErrorValues=${nonFiniteErrorCount}`,
     ];
 
-    if (longestUuid.length > 0) {
+    if (metrics.longestNeuronUuidLength > 0 && metrics.longestNeuronUuid) {
       summaryParts.push(
         `longestUuid="${
-          this.truncateForLog(longestUuid)
-        }" (${longestUuid.length})`,
+          this.truncateForLog(metrics.longestNeuronUuid)
+        }" (${metrics.longestNeuronUuidLength})`,
       );
     }
 
@@ -851,6 +972,7 @@ export class DiscoverStructure {
       summary: `Rust flush diagnostics: ${summaryParts.join(", ")}`,
       warnings,
       errors,
+      metrics,
     };
   }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -26,7 +26,10 @@ import {
   type RustCandidateSynapse,
   type RustRecordInput,
 } from "./RustDiscovery.ts";
-import { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DEFAULT_RUST_STREAM_RECORDS,
+} from "./constants.ts";
 
 export { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
 
@@ -136,6 +139,31 @@ interface RustFlushDiagnostics {
   metrics: RustFlushMetrics;
 }
 
+interface RustFlushAggregation {
+  expectedInputLength: number;
+  expectedOutputLength: number;
+  expectedNeuronCount: number;
+  sampleCount: number;
+  recordsWithNoNeuronData: number;
+  recordsWithMismatchedNeuronCount: number;
+  recordsWithInputMismatch: number;
+  recordsWithOutputMismatch: number;
+  missingUuidEntries: number;
+  nonFiniteActivationCount: number;
+  nonFiniteValueCount: number;
+  nonFiniteErrorCount: number;
+  firstMissingUuidLocation?: string;
+  firstNonFiniteActivationLocation?: string;
+  firstNonFiniteValueLocation?: string;
+  firstNonFiniteErrorLocation?: string;
+  longestUuid?: string;
+  longestUuidLength: number;
+  totalNeuronRecords: number;
+  totalNeuronUuidBytes: number;
+  totalErrorValues: number;
+  maxErrorValuesPerNeuron: number;
+}
+
 const RUST_HELPFUL_THRESHOLD = 0.1;
 const RUST_HARMFUL_THRESHOLD = -0.1;
 
@@ -165,6 +193,7 @@ export class DiscoverStructure {
   private usingRustDualWrite = false;
   private parquetFilePath: string | null = null;
   private rustFlushRecords: number;
+  private rustStreamRecords: number;
   private rustChunkFiles: string[] = [];
   private rustChunkCounter = 0;
   private syntheticBinaryMode = false;
@@ -194,6 +223,10 @@ export class DiscoverStructure {
     );
     this.timeoutTS = Date.now() + timeoutSeconds * 1000;
     this.rustFlushRecords = Math.max(1, rustFlushRecords);
+    this.rustStreamRecords = Math.max(
+      1,
+      Math.min(DEFAULT_RUST_STREAM_RECORDS, this.rustFlushRecords),
+    );
     this.deps = { ...DEFAULT_DISCOVER_STRUCTURE_DEPS, ...deps };
 
     Deno.mkdirSync(this.tempDir, { recursive: true });
@@ -524,49 +557,6 @@ export class DiscoverStructure {
       neuron.type !== "input"
     );
 
-    const rustTrainingData = this.rustAccumulatedData.map((record, index) => {
-      const discoverMap = this.rustAccumulatedNeuronData[index];
-
-      const neuronData = nonInputNeurons.map((neuron) => {
-        const discoverRecord = discoverMap.get(neuron.uuid) || {
-          activation: this.creature.state.activations[neuron.index],
-          errors: [] as number[],
-        };
-
-        const errors = discoverRecord.errors.filter(Number.isFinite);
-
-        return {
-          neuron_uuid: neuron.uuid,
-          activation: discoverRecord.activation,
-          value: discoverRecord.value,
-          errors: errors,
-        };
-      });
-
-      return {
-        input: Array.from(record.input),
-        output: Array.from(record.output),
-        neuron_data: neuronData,
-      };
-    });
-
-    const diagnostics = this.inspectRustFlushBatch(
-      rustTrainingData,
-      this.creature.input,
-      this.creature.output,
-      nonInputNeurons.length,
-    );
-    const metrics = diagnostics.metrics;
-
-    let recordIndices: number[] | undefined = undefined;
-    if (this.rustBinaryFilePaths.size === 1 && this.rustBinaryFilePath) {
-      const fileIndices = this.selectedIndices[this.rustBinaryFilePath];
-      if (fileIndices && fileIndices.length >= pendingSamples) {
-        const recentIndices = fileIndices.slice(-pendingSamples);
-        recordIndices = recentIndices.map((_value, idx) => idx);
-      }
-    }
-
     const now = Date.now();
     const timedOut = now > this.timeoutTS;
     if (timedOut) {
@@ -576,126 +566,232 @@ export class DiscoverStructure {
       );
     }
 
-    this.emitRustFlushDiagnostics(diagnostics, timedOut);
-
     const timeoutSeconds = timedOut
       ? 0
       : Math.max(0, Math.floor((this.timeoutTS - now) / 1000));
 
-    const rustInput: RustRecordInput = {
-      creature: rustCreature,
-      "training_data": rustTrainingData,
-      "temp_dir": tempDir,
-      "binary_file_path": this.rustBinaryFilePath || undefined,
-      "record_indices": recordIndices,
-      "timeout_seconds": timeoutSeconds,
-    };
+    const aggregation = this.createRustFlushAggregation(
+      this.creature.input,
+      this.creature.output,
+      nonInputNeurons.length,
+    );
 
-    const result = this.deps.recordDiscovery(rustInput);
+    const streamBatchSize = Math.max(
+      1,
+      Math.min(this.rustStreamRecords, pendingSamples),
+    );
+    const totalSlices = Math.ceil(pendingSamples / streamBatchSize);
 
-    if (result && result.success && result.file) {
-      const parquetPath = `${tempDir}/${result.file}`;
+    let sequentialRecordIndices: number[] | undefined;
+    if (this.rustBinaryFilePaths.size === 1 && this.rustBinaryFilePath) {
+      const fileIndices = this.selectedIndices[this.rustBinaryFilePath];
+      if (fileIndices && fileIndices.length >= pendingSamples) {
+        sequentialRecordIndices = Array.from(
+          { length: pendingSamples },
+          (_, idx) => idx,
+        );
+      }
+    }
 
-      if (this.syntheticBinaryMode || this.rustBinaryFilePaths.size === 0) {
-        this.syntheticBinaryMode = true;
-        const tempBinaryFile = `${tempDir}/training_data.bin`;
-        const BYTES_PER_RECORD = (this.creature.input + this.creature.output) *
-          4;
-        const file = Deno.openSync(tempBinaryFile, {
-          create: true,
-          write: true,
-          truncate: true,
-        });
+    const partFiles: string[] = [];
+    let rustErrorMessage: string | null = null;
+    let rustErrorDetails: unknown = undefined;
 
+    for (
+      let sliceStart = 0;
+      sliceStart < pendingSamples;
+      sliceStart += streamBatchSize
+    ) {
+      const sliceEnd = Math.min(sliceStart + streamBatchSize, pendingSamples);
+
+      const trainingDataSlice = this.buildRustTrainingSlice(
+        sliceStart,
+        sliceEnd,
+        nonInputNeurons,
+        aggregation,
+      );
+
+      const partIndex = partFiles.length;
+      const partDir = totalSlices === 1
+        ? tempDir
+        : `${tempDir}/parts/part-${partIndex.toString().padStart(5, "0")}`;
+
+      if (partDir !== tempDir) {
         try {
-          const buffer = new Uint8Array(BYTES_PER_RECORD);
-          const recordArray = new Float32Array(buffer.buffer);
-          const sequentialIndices: number[] = [];
-
-          for (let i = 0; i < this.rustAccumulatedData.length; i++) {
-            const record = this.rustAccumulatedData[i];
-            for (let j = 0; j < this.creature.input; j++) {
-              recordArray[j] = record.input[j];
-            }
-            for (let j = 0; j < this.creature.output; j++) {
-              recordArray[this.creature.input + j] = record.output[j];
-            }
-            file.writeSync(buffer);
-            sequentialIndices.push(i);
+          Deno.mkdirSync(partDir, { recursive: true });
+        } catch (error) {
+          if (!(error instanceof Deno.errors.AlreadyExists)) {
+            throw error;
           }
-
-          this.selectedIndices[tempBinaryFile] = sequentialIndices;
-          this.rustBinaryFilePaths.add(tempBinaryFile);
-          if (!this.rustBinaryFilePath) {
-            this.rustBinaryFilePath = tempBinaryFile;
-          }
-        } finally {
-          file.close();
         }
       }
 
-      Deno.writeTextFileSync(
-        this.indicesFilePath,
-        JSON.stringify(this.selectedIndices),
-      );
+      const sliceRecordIndices = sequentialRecordIndices
+        ? Array.from({ length: sliceEnd - sliceStart }, (_, idx) => idx)
+        : undefined;
 
-      this.rustAccumulatedData = [];
-      this.rustAccumulatedNeuronData = [];
-      const flushDuration = Date.now() - now;
-      const remainingSeconds = Math.max(
-        0,
-        Math.floor((this.timeoutTS - Date.now()) / 1000),
-      );
+      const rustInput: RustRecordInput = {
+        creature: rustCreature,
+        "training_data": trainingDataSlice,
+        "temp_dir": partDir,
+        "binary_file_path": this.rustBinaryFilePath || undefined,
+        "record_indices": sliceRecordIndices,
+        "timeout_seconds": timeoutSeconds,
+      };
+
+      const result = this.deps.recordDiscovery(rustInput);
+
+      if (result && result.success && result.file) {
+        const partPath = `${partDir}/${result.file}`;
+        partFiles.push(partPath);
+      } else {
+        rustErrorMessage = result?.error || "Unknown error";
+        rustErrorDetails = result?.errorDetails;
+        break;
+      }
+    }
+
+    const diagnostics = this.finalizeRustFlushDiagnostics(aggregation);
+    const metrics = diagnostics.metrics;
+    this.emitRustFlushDiagnostics(diagnostics, timedOut);
+
+    if (rustErrorMessage !== null || partFiles.length === 0) {
+      const errorMeta: Record<string, unknown> = {
+        pendingSamples,
+        timeoutExpired: timedOut,
+        binaryFilePath: this.rustBinaryFilePath,
+        forcedFocusNeurons: this.forcedFocusNeurons,
+        accumulatedSamples: this.rustAccumulatedData.length,
+        chunkFiles: this.rustChunkFiles.length,
+        longestRustUuid: metrics.longestNeuronUuid,
+        longestRustUuidLength: metrics.longestNeuronUuidLength,
+        totalRustUuidBytes: metrics.totalNeuronUuidBytes,
+        totalRustErrorValues: metrics.totalErrorValues,
+        maxRustErrorsPerNeuron: metrics.maxErrorValuesPerNeuron,
+        rustSampleCount: metrics.sampleCount,
+        expectedRustNeuronCount: metrics.expectedNeuronCount,
+        totalRustNeuronRecords: metrics.totalNeuronRecords,
+      };
+
+      if (rustErrorDetails) {
+        if ((rustErrorDetails as { stage?: unknown }).stage) {
+          errorMeta.recordDiscoveryStage = (rustErrorDetails as {
+            stage?: string;
+          }).stage;
+        }
+        if (
+          (rustErrorDetails as { inputJsonLength?: unknown })
+            .inputJsonLength !== undefined
+        ) {
+          errorMeta.rustInputJsonLength = (rustErrorDetails as {
+            inputJsonLength?: number;
+          }).inputJsonLength;
+        }
+        if (
+          (rustErrorDetails as { inputBytesLength?: unknown })
+            .inputBytesLength !== undefined
+        ) {
+          errorMeta.rustInputBytes = (rustErrorDetails as {
+            inputBytesLength?: number;
+          }).inputBytesLength;
+        }
+        if ((rustErrorDetails as { stats?: unknown }).stats) {
+          errorMeta.recordDiscoveryStats = (rustErrorDetails as {
+            stats?: unknown;
+          }).stats;
+        }
+      }
+
+      const message = rustErrorMessage ??
+        "Rust discovery recording failed: no parquet output generated";
       this.log(
-        "info",
-        `Flushed ${pendingSamples} samples to ${parquetPath} in ${
-          this.formatMillis(flushDuration)
-        } (timeout remaining: ${remainingSeconds}s).`,
+        "error",
+        `Rust discovery recording failed: ${message}`,
+        errorMeta,
       );
-
-      return parquetPath;
+      return null;
     }
 
-    const errorMessage = result?.error || "Unknown error";
-    const errorDetails = result?.errorDetails;
-    const errorMeta: Record<string, unknown> = {
-      pendingSamples,
-      timeoutExpired: timedOut,
-      binaryFilePath: this.rustBinaryFilePath,
-      forcedFocusNeurons: this.forcedFocusNeurons,
-      accumulatedSamples: this.rustAccumulatedData.length,
-      chunkFiles: this.rustChunkFiles.length,
-      longestRustUuid: metrics.longestNeuronUuid,
-      longestRustUuidLength: metrics.longestNeuronUuidLength,
-      totalRustUuidBytes: metrics.totalNeuronUuidBytes,
-      totalRustErrorValues: metrics.totalErrorValues,
-      maxRustErrorsPerNeuron: metrics.maxErrorValuesPerNeuron,
-      rustSampleCount: metrics.sampleCount,
-      expectedRustNeuronCount: metrics.expectedNeuronCount,
-      totalRustNeuronRecords: metrics.totalNeuronRecords,
-    };
+    let parquetPath: string;
+    if (partFiles.length === 1 && totalSlices === 1) {
+      parquetPath = partFiles[0];
+    } else {
+      const outputFile = `${tempDir}/discovery_data.parquet`;
+      const mergeResult = this.deps.mergeDiscoveryParquet({
+        outputFile,
+        inputFiles: partFiles,
+      });
 
-    if (errorDetails) {
-      if (errorDetails.stage) {
-        errorMeta.recordDiscoveryStage = errorDetails.stage;
+      if (!mergeResult || !mergeResult.success) {
+        this.log(
+          "error",
+          "Rust discovery merge failed",
+          mergeResult?.error ?? "Unknown error",
+        );
+        return null;
       }
-      if (errorDetails.inputJsonLength !== undefined) {
-        errorMeta.rustInputJsonLength = errorDetails.inputJsonLength;
-      }
-      if (errorDetails.inputBytesLength !== undefined) {
-        errorMeta.rustInputBytes = errorDetails.inputBytesLength;
-      }
-      if (errorDetails.stats) {
-        errorMeta.recordDiscoveryStats = errorDetails.stats;
+
+      parquetPath = mergeResult.outputFile ?? outputFile;
+    }
+
+    if (this.syntheticBinaryMode || this.rustBinaryFilePaths.size === 0) {
+      this.syntheticBinaryMode = true;
+      const tempBinaryFile = `${tempDir}/training_data.bin`;
+      const BYTES_PER_RECORD = (this.creature.input + this.creature.output) *
+        4;
+      const file = Deno.openSync(tempBinaryFile, {
+        create: true,
+        write: true,
+        truncate: true,
+      });
+
+      try {
+        const buffer = new Uint8Array(BYTES_PER_RECORD);
+        const recordArray = new Float32Array(buffer.buffer);
+        const sequentialIndices: number[] = [];
+
+        for (let i = 0; i < this.rustAccumulatedData.length; i++) {
+          const record = this.rustAccumulatedData[i];
+          for (let j = 0; j < this.creature.input; j++) {
+            recordArray[j] = record.input[j];
+          }
+          for (let j = 0; j < this.creature.output; j++) {
+            recordArray[this.creature.input + j] = record.output[j];
+          }
+          file.writeSync(buffer);
+          sequentialIndices.push(i);
+        }
+
+        this.selectedIndices[tempBinaryFile] = sequentialIndices;
+        this.rustBinaryFilePaths.add(tempBinaryFile);
+        if (!this.rustBinaryFilePath) {
+          this.rustBinaryFilePath = tempBinaryFile;
+        }
+      } finally {
+        file.close();
       }
     }
 
-    this.log(
-      "error",
-      `Rust discovery recording failed: ${errorMessage}`,
-      errorMeta,
+    Deno.writeTextFileSync(
+      this.indicesFilePath,
+      JSON.stringify(this.selectedIndices),
     );
-    return null;
+
+    this.rustAccumulatedData = [];
+    this.rustAccumulatedNeuronData = [];
+    const flushDuration = Date.now() - now;
+    const remainingSeconds = Math.max(
+      0,
+      Math.floor((this.timeoutTS - Date.now()) / 1000),
+    );
+    this.log(
+      "info",
+      `Flushed ${pendingSamples} samples to ${parquetPath} in ${
+        this.formatMillis(flushDuration)
+      } (timeout remaining: ${remainingSeconds}s).`,
+    );
+
+    return parquetPath;
   }
 
   public flushRustChunk(): boolean {
@@ -781,124 +877,140 @@ export class DiscoverStructure {
     diagnostics.errors.forEach((error) => this.log("error", error));
   }
 
-  private inspectRustFlushBatch(
-    rustTrainingData: RustRecordInput["training_data"],
+  private createRustFlushAggregation(
     expectedInputLength: number,
     expectedOutputLength: number,
     expectedNeuronCount: number,
-  ): RustFlushDiagnostics {
-    let recordsWithNoNeuronData = 0;
-    let recordsWithMismatchedNeuronCount = 0;
-    let recordsWithInputMismatch = 0;
-    let recordsWithOutputMismatch = 0;
-    let missingUuidEntries = 0;
-    let nonFiniteActivationCount = 0;
-    let nonFiniteValueCount = 0;
-    let nonFiniteErrorCount = 0;
-    let firstMissingUuidLocation: string | undefined;
-    let firstNonFiniteActivationLocation: string | undefined;
-    let firstNonFiniteValueLocation: string | undefined;
-    let firstNonFiniteErrorLocation: string | undefined;
-    let longestUuid = "";
-    let longestUuidLength = 0;
-    let totalNeuronRecords = 0;
-    let totalUuidBytes = 0;
-    let totalErrorValues = 0;
-    let maxErrorValuesPerNeuron = 0;
-
-    rustTrainingData.forEach((record, recordIndex) => {
-      const neuronData = record.neuron_data ?? [];
-      if (neuronData.length === 0) {
-        recordsWithNoNeuronData++;
-      }
-      if (neuronData.length !== expectedNeuronCount) {
-        recordsWithMismatchedNeuronCount++;
-      }
-
-      if (record.input.length !== expectedInputLength) {
-        recordsWithInputMismatch++;
-      }
-
-      if (record.output.length !== expectedOutputLength) {
-        recordsWithOutputMismatch++;
-      }
-
-      totalNeuronRecords += neuronData.length;
-
-      neuronData.forEach((neuron, neuronIndex) => {
-        const uuid = typeof neuron.neuron_uuid === "string"
-          ? neuron.neuron_uuid
-          : "";
-        const uuidLength = uuid.length;
-        totalUuidBytes += uuidLength;
-
-        if (uuidLength === 0) {
-          missingUuidEntries++;
-          if (firstMissingUuidLocation === undefined) {
-            firstMissingUuidLocation =
-              `record ${recordIndex}, neuron ${neuronIndex}`;
-          }
-        } else if (uuidLength > longestUuidLength) {
-          longestUuid = uuid;
-          longestUuidLength = uuidLength;
-        }
-
-        if (!Number.isFinite(neuron.activation)) {
-          nonFiniteActivationCount++;
-          if (firstNonFiniteActivationLocation === undefined) {
-            firstNonFiniteActivationLocation =
-              `record ${recordIndex}, neuron ${neuronIndex}`;
-          }
-        }
-        if (
-          neuron.value !== undefined && neuron.value !== null &&
-          !Number.isFinite(neuron.value)
-        ) {
-          nonFiniteValueCount++;
-          if (firstNonFiniteValueLocation === undefined) {
-            firstNonFiniteValueLocation =
-              `record ${recordIndex}, neuron ${neuronIndex}`;
-          }
-        }
-        const errorValues = neuron.errors ?? [];
-        totalErrorValues += errorValues.length;
-        if (errorValues.length > maxErrorValuesPerNeuron) {
-          maxErrorValuesPerNeuron = errorValues.length;
-        }
-        errorValues.forEach((errorValue, errorIndex) => {
-          if (!Number.isFinite(errorValue)) {
-            nonFiniteErrorCount++;
-            if (firstNonFiniteErrorLocation === undefined) {
-              firstNonFiniteErrorLocation =
-                `record ${recordIndex}, neuron ${neuronIndex}, error ${errorIndex}`;
-            }
-          }
-        });
-      });
-    });
-
-    const metrics: RustFlushMetrics = {
-      sampleCount: rustTrainingData.length,
-      expectedNeuronCount,
+  ): RustFlushAggregation {
+    return {
       expectedInputLength,
       expectedOutputLength,
-      totalNeuronRecords,
-      totalNeuronUuidBytes: totalUuidBytes,
-      longestNeuronUuid: longestUuidLength > 0 ? longestUuid : undefined,
-      longestNeuronUuidLength: longestUuidLength,
-      totalErrorValues,
-      maxErrorValuesPerNeuron,
+      expectedNeuronCount,
+      sampleCount: 0,
+      recordsWithNoNeuronData: 0,
+      recordsWithMismatchedNeuronCount: 0,
+      recordsWithInputMismatch: 0,
+      recordsWithOutputMismatch: 0,
+      missingUuidEntries: 0,
+      nonFiniteActivationCount: 0,
+      nonFiniteValueCount: 0,
+      nonFiniteErrorCount: 0,
+      longestUuid: undefined,
+      longestUuidLength: 0,
+      firstMissingUuidLocation: undefined,
+      firstNonFiniteActivationLocation: undefined,
+      firstNonFiniteValueLocation: undefined,
+      firstNonFiniteErrorLocation: undefined,
+      totalNeuronRecords: 0,
+      totalNeuronUuidBytes: 0,
+      totalErrorValues: 0,
+      maxErrorValuesPerNeuron: 0,
+    };
+  }
+
+  private observeRustTrainingRecord(
+    aggregation: RustFlushAggregation,
+    record: RustRecordInput["training_data"][number],
+    globalSampleIndex: number,
+  ): void {
+    const neuronData = record.neuron_data ?? [];
+    aggregation.sampleCount += 1;
+
+    if (neuronData.length === 0) {
+      aggregation.recordsWithNoNeuronData += 1;
+    }
+    if (neuronData.length !== aggregation.expectedNeuronCount) {
+      aggregation.recordsWithMismatchedNeuronCount += 1;
+    }
+    if (record.input.length !== aggregation.expectedInputLength) {
+      aggregation.recordsWithInputMismatch += 1;
+    }
+    if (record.output.length !== aggregation.expectedOutputLength) {
+      aggregation.recordsWithOutputMismatch += 1;
+    }
+
+    aggregation.totalNeuronRecords += neuronData.length;
+
+    neuronData.forEach((neuron, neuronIndex) => {
+      const uuid = typeof neuron.neuron_uuid === "string"
+        ? neuron.neuron_uuid
+        : "";
+      const uuidLength = uuid.length;
+      aggregation.totalNeuronUuidBytes += uuidLength;
+
+      if (uuidLength === 0) {
+        aggregation.missingUuidEntries += 1;
+        if (aggregation.firstMissingUuidLocation === undefined) {
+          aggregation.firstMissingUuidLocation =
+            `record ${globalSampleIndex}, neuron ${neuronIndex}`;
+        }
+      } else if (uuidLength > aggregation.longestUuidLength) {
+        aggregation.longestUuid = uuid;
+        aggregation.longestUuidLength = uuidLength;
+      }
+
+      if (!Number.isFinite(neuron.activation)) {
+        aggregation.nonFiniteActivationCount += 1;
+        if (aggregation.firstNonFiniteActivationLocation === undefined) {
+          aggregation.firstNonFiniteActivationLocation =
+            `record ${globalSampleIndex}, neuron ${neuronIndex}`;
+        }
+      }
+
+      if (
+        neuron.value !== undefined && neuron.value !== null &&
+        !Number.isFinite(neuron.value)
+      ) {
+        aggregation.nonFiniteValueCount += 1;
+        if (aggregation.firstNonFiniteValueLocation === undefined) {
+          aggregation.firstNonFiniteValueLocation =
+            `record ${globalSampleIndex}, neuron ${neuronIndex}`;
+        }
+      }
+
+      const errorValues = neuron.errors ?? [];
+      aggregation.totalErrorValues += errorValues.length;
+      if (errorValues.length > aggregation.maxErrorValuesPerNeuron) {
+        aggregation.maxErrorValuesPerNeuron = errorValues.length;
+      }
+
+      errorValues.forEach((errorValue, errorIndex) => {
+        if (!Number.isFinite(errorValue)) {
+          aggregation.nonFiniteErrorCount += 1;
+          if (aggregation.firstNonFiniteErrorLocation === undefined) {
+            aggregation.firstNonFiniteErrorLocation =
+              `record ${globalSampleIndex}, neuron ${neuronIndex}, error ${errorIndex}`;
+          }
+        }
+      });
+    });
+  }
+
+  private finalizeRustFlushDiagnostics(
+    aggregation: RustFlushAggregation,
+  ): RustFlushDiagnostics {
+    const metrics: RustFlushMetrics = {
+      sampleCount: aggregation.sampleCount,
+      expectedNeuronCount: aggregation.expectedNeuronCount,
+      expectedInputLength: aggregation.expectedInputLength,
+      expectedOutputLength: aggregation.expectedOutputLength,
+      totalNeuronRecords: aggregation.totalNeuronRecords,
+      totalNeuronUuidBytes: aggregation.totalNeuronUuidBytes,
+      longestNeuronUuid: aggregation.longestUuid,
+      longestNeuronUuidLength: aggregation.longestUuidLength,
+      totalErrorValues: aggregation.totalErrorValues,
+      maxErrorValuesPerNeuron: aggregation.maxErrorValuesPerNeuron,
     };
 
     const summaryParts = [
-      `samples=${rustTrainingData.length}`,
-      `expectedNeuronCount=${expectedNeuronCount}`,
-      `recordsWithNoNeuronData=${recordsWithNoNeuronData}`,
-      `recordsWithMismatchedNeuronCount=${recordsWithMismatchedNeuronCount}`,
-      `missingUuidEntries=${missingUuidEntries}`,
-      `nonFiniteActivationValues=${nonFiniteActivationCount}`,
-      `nonFiniteNeuronValues=${nonFiniteValueCount}`,
-      `nonFiniteErrorValues=${nonFiniteErrorCount}`,
+      `samples=${aggregation.sampleCount}`,
+      `expectedNeuronCount=${aggregation.expectedNeuronCount}`,
+      `recordsWithNoNeuronData=${aggregation.recordsWithNoNeuronData}`,
+      `recordsWithMismatchedNeuronCount=${aggregation.recordsWithMismatchedNeuronCount}`,
+      `missingUuidEntries=${aggregation.missingUuidEntries}`,
+      `nonFiniteActivationValues=${aggregation.nonFiniteActivationCount}`,
+      `nonFiniteNeuronValues=${aggregation.nonFiniteValueCount}`,
+      `nonFiniteErrorValues=${aggregation.nonFiniteErrorCount}`,
     ];
 
     if (metrics.longestNeuronUuidLength > 0 && metrics.longestNeuronUuid) {
@@ -910,59 +1022,59 @@ export class DiscoverStructure {
     }
 
     const warnings: string[] = [];
-    if (recordsWithNoNeuronData > 0) {
+    if (aggregation.recordsWithNoNeuronData > 0) {
       warnings.push(
-        `Rust flush detected ${recordsWithNoNeuronData} record(s) without neuron data.`,
+        `Rust flush detected ${aggregation.recordsWithNoNeuronData} record(s) without neuron data.`,
       );
     }
-    if (recordsWithMismatchedNeuronCount > 0) {
+    if (aggregation.recordsWithMismatchedNeuronCount > 0) {
       warnings.push(
-        `Rust flush detected ${recordsWithMismatchedNeuronCount} record(s) with neuron count mismatch (expected ${expectedNeuronCount}).`,
+        `Rust flush detected ${aggregation.recordsWithMismatchedNeuronCount} record(s) with neuron count mismatch (expected ${aggregation.expectedNeuronCount}).`,
       );
     }
-    if (recordsWithInputMismatch > 0) {
+    if (aggregation.recordsWithInputMismatch > 0) {
       warnings.push(
-        `Rust flush detected ${recordsWithInputMismatch} record(s) where input length != expected ${expectedInputLength}.`,
+        `Rust flush detected ${aggregation.recordsWithInputMismatch} record(s) where input length != expected ${aggregation.expectedInputLength}.`,
       );
     }
-    if (recordsWithOutputMismatch > 0) {
+    if (aggregation.recordsWithOutputMismatch > 0) {
       warnings.push(
-        `Rust flush detected ${recordsWithOutputMismatch} record(s) where output length != expected ${expectedOutputLength}.`,
+        `Rust flush detected ${aggregation.recordsWithOutputMismatch} record(s) where output length != expected ${aggregation.expectedOutputLength}.`,
       );
     }
 
     const errors: string[] = [];
-    if (missingUuidEntries > 0) {
-      const location = firstMissingUuidLocation
-        ? ` (first observed at ${firstMissingUuidLocation})`
+    if (aggregation.missingUuidEntries > 0) {
+      const location = aggregation.firstMissingUuidLocation
+        ? ` (first observed at ${aggregation.firstMissingUuidLocation})`
         : "";
       errors.push(
-        `Rust flush encountered ${missingUuidEntries} neuron entries with missing UUID${location}.`,
+        `Rust flush encountered ${aggregation.missingUuidEntries} neuron entries with missing UUID${location}.`,
       );
     }
-    if (nonFiniteActivationCount > 0) {
+    if (aggregation.nonFiniteActivationCount > 0) {
       errors.push(
-        `Rust flush encountered ${nonFiniteActivationCount} non-finite activation value(s)${
-          firstNonFiniteActivationLocation
-            ? ` (first observed at ${firstNonFiniteActivationLocation})`
+        `Rust flush encountered ${aggregation.nonFiniteActivationCount} non-finite activation value(s)${
+          aggregation.firstNonFiniteActivationLocation
+            ? ` (first observed at ${aggregation.firstNonFiniteActivationLocation})`
             : ""
         }.`,
       );
     }
-    if (nonFiniteValueCount > 0) {
+    if (aggregation.nonFiniteValueCount > 0) {
       errors.push(
-        `Rust flush encountered ${nonFiniteValueCount} non-finite optional neuron value(s)${
-          firstNonFiniteValueLocation
-            ? ` (first observed at ${firstNonFiniteValueLocation})`
+        `Rust flush encountered ${aggregation.nonFiniteValueCount} non-finite optional neuron value(s)${
+          aggregation.firstNonFiniteValueLocation
+            ? ` (first observed at ${aggregation.firstNonFiniteValueLocation})`
             : ""
         }.`,
       );
     }
-    if (nonFiniteErrorCount > 0) {
+    if (aggregation.nonFiniteErrorCount > 0) {
       errors.push(
-        `Rust flush encountered ${nonFiniteErrorCount} non-finite error value(s)${
-          firstNonFiniteErrorLocation
-            ? ` (first observed at ${firstNonFiniteErrorLocation})`
+        `Rust flush encountered ${aggregation.nonFiniteErrorCount} non-finite error value(s)${
+          aggregation.firstNonFiniteErrorLocation
+            ? ` (first observed at ${aggregation.firstNonFiniteErrorLocation})`
             : ""
         }.`,
       );
@@ -974,6 +1086,47 @@ export class DiscoverStructure {
       errors,
       metrics,
     };
+  }
+
+  private buildRustTrainingSlice(
+    start: number,
+    end: number,
+    nonInputNeurons: Array<Creature["neurons"][number]>,
+    aggregation: RustFlushAggregation,
+  ): RustRecordInput["training_data"] {
+    const slice: RustRecordInput["training_data"] = [];
+
+    for (let i = start; i < end; i++) {
+      const record = this.rustAccumulatedData[i];
+      const discoverMap = this.rustAccumulatedNeuronData[i];
+
+      const neuronData = nonInputNeurons.map((neuron) => {
+        const discoverRecord = discoverMap.get(neuron.uuid) || {
+          activation: this.creature.state.activations[neuron.index],
+          errors: [] as number[],
+        };
+
+        const errors = discoverRecord.errors.filter(Number.isFinite);
+
+        return {
+          neuron_uuid: neuron.uuid,
+          activation: discoverRecord.activation,
+          value: discoverRecord.value,
+          errors,
+        };
+      });
+
+      const trainingRecord = {
+        input: Array.from(record.input),
+        output: Array.from(record.output),
+        "neuron_data": neuronData,
+      };
+
+      slice.push(trainingRecord);
+      this.observeRustTrainingRecord(aggregation, trainingRecord, i);
+    }
+
+    return slice;
   }
 
   private truncateForLog(value: string, max = 120): string {

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -18,11 +18,39 @@ import { join } from "@std/path/join";
 /**
  * Result of recording discovery data via Rust module.
  */
+export interface RustRecordBatchStats {
+  sampleCount: number;
+  expectedNeuronCount: number;
+  totalNeuronRecords: number;
+  totalNeuronUuidBytes: number;
+  longestNeuronUuid?: string;
+  longestNeuronUuidLength: number;
+  totalErrorValues: number;
+  maxErrorValuesPerNeuron: number;
+  inputLength?: number;
+  outputLength?: number;
+}
+
+export type RustRecordFailureStage =
+  | "stringify"
+  | "encode"
+  | "ffi"
+  | "parse"
+  | "rust";
+
+export interface RustRecordErrorDetails {
+  stage: RustRecordFailureStage;
+  inputJsonLength?: number;
+  inputBytesLength?: number;
+  stats: RustRecordBatchStats;
+}
+
 export interface RustRecordResult {
   success: boolean;
   "temp_dir"?: string;
   file?: string;
   error?: string;
+  errorDetails?: RustRecordErrorDetails;
 }
 
 export interface RustCandidateSynapse {
@@ -156,6 +184,69 @@ export function creatureToRustFormat(creature: {
     })),
     input: creature.input,
     output: creature.output,
+  };
+}
+
+export function computeRustRecordStats(
+  input: RustRecordInput,
+): RustRecordBatchStats {
+  const sampleCount = input.training_data.length;
+  const expectedNeuronCount =
+    input.creature.neurons.filter((neuron) => neuron.type !== "input").length;
+
+  let totalNeuronRecords = 0;
+  let totalNeuronUuidBytes = 0;
+  let totalErrorValues = 0;
+  let maxErrorValuesPerNeuron = 0;
+  let longestNeuronUuid = "";
+  let longestNeuronUuidLength = 0;
+  let inputLength: number | undefined;
+  let outputLength: number | undefined;
+
+  for (const record of input.training_data) {
+    if (inputLength === undefined) {
+      inputLength = record.input.length;
+    }
+    if (outputLength === undefined) {
+      outputLength = record.output.length;
+    }
+
+    const neuronData = record.neuron_data ?? [];
+    totalNeuronRecords += neuronData.length;
+
+    for (const neuron of neuronData) {
+      const uuid = typeof neuron.neuron_uuid === "string"
+        ? neuron.neuron_uuid
+        : "";
+      const uuidLength = uuid.length;
+      totalNeuronUuidBytes += uuidLength;
+
+      if (uuidLength > longestNeuronUuidLength) {
+        longestNeuronUuid = uuid;
+        longestNeuronUuidLength = uuidLength;
+      }
+
+      const errors = neuron.errors ?? [];
+      totalErrorValues += errors.length;
+      if (errors.length > maxErrorValuesPerNeuron) {
+        maxErrorValuesPerNeuron = errors.length;
+      }
+    }
+  }
+
+  return {
+    sampleCount,
+    expectedNeuronCount,
+    totalNeuronRecords,
+    totalNeuronUuidBytes,
+    longestNeuronUuid: longestNeuronUuidLength > 0
+      ? longestNeuronUuid
+      : undefined,
+    longestNeuronUuidLength,
+    totalErrorValues,
+    maxErrorValuesPerNeuron,
+    inputLength,
+    outputLength,
   };
 }
 
@@ -666,46 +757,105 @@ export function recordDiscovery(
 
   assert(rustLib !== null, "Rust library should be loaded");
 
+  const stats = computeRustRecordStats(input);
+
+  const buildFailure = (
+    stage: RustRecordFailureStage,
+    message: string,
+    overrides: Partial<RustRecordErrorDetails> = {},
+  ): RustRecordResult => {
+    const details: RustRecordErrorDetails = {
+      stage,
+      stats,
+      ...(overrides.stats ? { stats: overrides.stats } : {}),
+      ...overrides,
+    };
+
+    if (
+      details.inputJsonLength === undefined && typeof inputJson === "string"
+    ) {
+      details.inputJsonLength = inputJson.length;
+    }
+
+    if (
+      details.inputBytesLength === undefined && inputBytes !== undefined
+    ) {
+      details.inputBytesLength = inputBytes.length;
+    }
+
+    return {
+      success: false,
+      error: message,
+      errorDetails: details,
+    };
+  };
+
+  let inputJson: string | undefined;
   try {
-    // Serialize input to JSON
-    const inputJson = JSON.stringify(input);
-    const inputBytes = new TextEncoder().encode(inputJson);
+    inputJson = JSON.stringify(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return buildFailure("stringify", message);
+  }
 
-    // Allocate memory for input string (C string - null terminated)
-    const inputBuffer = new Uint8Array(inputBytes.length + 1);
-    inputBuffer.set(inputBytes);
-    inputBuffer[inputBytes.length] = 0; // Null terminator
+  let inputBytes: Uint8Array | undefined;
+  try {
+    inputBytes = new TextEncoder().encode(inputJson);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return buildFailure("encode", message, {
+      inputJsonLength: inputJson.length,
+    });
+  }
 
-    const inputPtr = Deno.UnsafePointer.of(inputBuffer);
+  // Allocate memory for input string (C string - null terminated)
+  const inputBuffer = new Uint8Array(inputBytes.length + 1);
+  inputBuffer.set(inputBytes);
+  inputBuffer[inputBytes.length] = 0; // Null terminator
 
-    // Call Rust function
-    // Note: The Rust function signature should be:
-    // extern "C" fn record_discovery(input: *const c_char) -> *mut c_char
-    // The function reads the C string until null terminator
-    const resultPtr = rustLib.symbols["record_discovery"](inputPtr);
+  const inputPtr = Deno.UnsafePointer.of(inputBuffer);
 
-    if (resultPtr === null) {
+  let resultPtr: Deno.PointerValue | null = null;
+  let currentStage: RustRecordFailureStage = "ffi";
+
+  try {
+    resultPtr = rustLib.symbols["record_discovery"](inputPtr);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return buildFailure(currentStage, message);
+  }
+
+  if (resultPtr === null) {
+    return buildFailure("ffi", "Rust function returned null pointer");
+  }
+
+  try {
+    const resultJson = readCString(resultPtr);
+    currentStage = "parse";
+    const parsed = JSON.parse(resultJson) as RustRecordResult;
+
+    if (
+      !parsed.success &&
+      parsed.error?.includes("Invalid string length") &&
+      !parsed.errorDetails
+    ) {
       return {
-        success: false,
-        error: "Rust function returned null pointer",
+        ...parsed,
+        errorDetails: {
+          stage: "rust",
+          inputJsonLength: inputJson.length,
+          inputBytesLength: inputBytes.length,
+          stats,
+        },
       };
     }
 
-    // Read the result string from the pointer
-    const resultJson = readCString(resultPtr);
-
-    // Free the memory allocated by Rust
-    rustLib.symbols["free_discovery_result"](resultPtr);
-
-    // Parse the JSON result
-    const result = JSON.parse(resultJson) as RustRecordResult;
-
-    return result;
+    return parsed;
   } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : String(error),
-    };
+    const message = error instanceof Error ? error.message : String(error);
+    return buildFailure(currentStage, message);
+  } finally {
+    rustLib.symbols["free_discovery_result"](resultPtr);
   }
 }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/constants.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/constants.ts
@@ -5,3 +5,9 @@
  * and memory usage during multi-file discovery runs.
  */
 export const DEFAULT_RUST_FLUSH_RECORDS = 4_096;
+
+/**
+ * Maximum number of records to stream to the Rust recorder in a single call.
+ * This keeps JSON payloads bounded during discovery flushes to avoid OOMs.
+ */
+export const DEFAULT_RUST_STREAM_RECORDS = 512;

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_RUST_FLUSH_RECORDS,
   type DiscoverRecord,
   DiscoverStructure,
+  type RustFlushMetrics,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
   assertRustDiscoveryAvailable,
@@ -591,8 +592,6 @@ Deno.test({
     );
 
     assert(!input44, "Should have REMOVED synapse from input-44");
-
-    await discoverStructure.cleanUp();
   },
 });
 
@@ -779,8 +778,6 @@ Deno.test({
       viableNeurons.some((neuron) => neuron.uuid === selectedNeuronUUID[0]),
       "Selected neuron UUID must be from the viable neurons list",
     );
-
-    await discoverStructure.cleanUp();
   },
 });
 
@@ -987,12 +984,12 @@ Deno.test({
 
 Deno.test({
   name: "inspectRustFlushBatch exposes metrics for longest UUID tracking",
-  fn: () => {
+  fn() {
     const longUuid = "hidden-neuron-with-extended-identifier-001";
     const trainingData: RustRecordInput["training_data"] = [{
       input: [0.1, -0.2],
       output: [0.3],
-      neuron_data: [
+      "neuron_data": [
         {
           neuron_uuid: longUuid,
           activation: 0.51,
@@ -1008,20 +1005,44 @@ Deno.test({
       ],
     }];
 
-    const metrics = (DiscoverStructure as unknown as {
-      computeRustFlushMetrics: (
-        data: RustRecordInput["training_data"],
-        expectedNeuronCount: number,
+    const creature = makeCreature();
+    creature.validate();
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+
+    const aggregation = (discoverStructure as unknown as {
+      createRustFlushAggregation: (
         expectedInputLength: number,
         expectedOutputLength: number,
-      ) => {
-        longestNeuronUuidLength: number;
-        totalNeuronUuidBytes: number;
-        totalErrorValues: number;
-        maxErrorValuesPerNeuron: number;
-      };
-    }).computeRustFlushMetrics(trainingData, 2, 2, 1);
+        expectedNeuronCount: number,
+      ) => unknown;
+    }).createRustFlushAggregation(2, 1, 2);
 
+    (discoverStructure as unknown as {
+      observeRustTrainingRecord: (
+        aggregation: unknown,
+        record: RustRecordInput["training_data"][number],
+        globalSampleIndex: number,
+      ) => void;
+    }).observeRustTrainingRecord(aggregation, trainingData[0], 0);
+
+    const diagnostics = (discoverStructure as unknown as {
+      finalizeRustFlushDiagnostics: (
+        aggregation: unknown,
+      ) => {
+        summary: string;
+        warnings: string[];
+        errors: string[];
+        metrics: RustFlushMetrics;
+      };
+    }).finalizeRustFlushDiagnostics(aggregation);
+
+    const metrics = diagnostics.metrics;
     assertEquals(metrics.longestNeuronUuidLength, longUuid.length);
     assertEquals(
       metrics.totalNeuronUuidBytes,
@@ -1152,7 +1173,7 @@ Deno.test({
         return {
           input: Array.from(record.input),
           output: Array.from(record.output),
-          neuron_data: neuronData,
+          "neuron_data": neuronData,
         };
       });
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -5,6 +5,7 @@ import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
 import {
   type CandidateNeuron,
   DEFAULT_RUST_FLUSH_RECORDS,
+  type DiscoverRecord,
   DiscoverStructure,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
@@ -12,6 +13,8 @@ import {
   isRustDiscoveryEnabled,
   type RustAnalyzeNeuronsResult,
   type RustCandidateNeuron,
+  type RustRecordBatchStats,
+  type RustRecordInput,
   shouldSkipRustDiscoveryTests,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import { Creature } from "../../src/Creature.ts";
@@ -979,5 +982,250 @@ Deno.test({
 
     // Wait for cleanup to complete
     await cleanupPromise;
+  },
+});
+
+Deno.test({
+  name: "inspectRustFlushBatch exposes metrics for longest UUID tracking",
+  fn: () => {
+    const longUuid = "hidden-neuron-with-extended-identifier-001";
+    const trainingData: RustRecordInput["training_data"] = [{
+      input: [0.1, -0.2],
+      output: [0.3],
+      neuron_data: [
+        {
+          neuron_uuid: longUuid,
+          activation: 0.51,
+          value: 0.42,
+          errors: [0.01, -0.02, 0.03],
+        },
+        {
+          neuron_uuid: "output-0",
+          activation: 0.37,
+          value: 0.22,
+          errors: [-0.05],
+        },
+      ],
+    }];
+
+    const metrics = (DiscoverStructure as unknown as {
+      computeRustFlushMetrics: (
+        data: RustRecordInput["training_data"],
+        expectedNeuronCount: number,
+        expectedInputLength: number,
+        expectedOutputLength: number,
+      ) => {
+        longestNeuronUuidLength: number;
+        totalNeuronUuidBytes: number;
+        totalErrorValues: number;
+        maxErrorValuesPerNeuron: number;
+      };
+    }).computeRustFlushMetrics(trainingData, 2, 2, 1);
+
+    assertEquals(metrics.longestNeuronUuidLength, longUuid.length);
+    assertEquals(
+      metrics.totalNeuronUuidBytes,
+      longUuid.length + "output-0".length,
+    );
+    assertEquals(metrics.totalErrorValues, 4);
+    assertEquals(metrics.maxErrorValuesPerNeuron, 3);
+  },
+});
+
+Deno.test({
+  name:
+    "writeRustParquetChunk logs metrics when Invalid string length is reported",
+  fn: () => {
+    const longUuid = "hidden-neuron-with-extended-identifier-001";
+    const creature = Creature.fromJSON({
+      input: 2,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: longUuid,
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: longUuid, weight: 0.5 },
+        { fromUUID: longUuid, toUUID: "output-0", weight: -0.25 },
+      ],
+    });
+    creature.validate();
+    CreatureUtil.makeUUID(creature);
+
+    let expectedStats!: RustRecordBatchStats;
+
+    const recordDiscoveryCalls: RustRecordInput[] = [];
+    const originalMkdirSync = Deno.mkdirSync;
+    (Deno as unknown as { mkdirSync: typeof Deno.mkdirSync }).mkdirSync =
+      () => {};
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      60,
+      DEFAULT_RUST_FLUSH_RECORDS,
+      {
+        isRustDiscoveryEnabled: () => true,
+        isRustLibraryAvailable: () => true,
+        recordDiscovery: (input) => {
+          recordDiscoveryCalls.push(input);
+          return {
+            success: false,
+            error: "Invalid string length",
+            errorDetails: {
+              stage: "encode",
+              inputJsonLength: 512,
+              inputBytesLength: 704,
+              stats: expectedStats,
+            },
+          };
+        },
+        mergeDiscoveryParquet: () => ({ success: true, outputFile: "" }),
+        analyzeNeurons: () => ({ success: true, helpfulNeurons: [] }),
+        analyzeSynapses: () => ({
+          success: true,
+          helpfulSynapses: [],
+          harmfulSynapses: [],
+        }),
+        readDiscoveryRecords: () => ({ success: true, records: [] }),
+      },
+    );
+
+    const neuronMap = new Map<string, DiscoverRecord>();
+    neuronMap.set(longUuid, {
+      activation: 0.51,
+      value: 0.42,
+      errors: [0.01, -0.02, 0.03, -0.04],
+    });
+    neuronMap.set("output-0", {
+      activation: 0.37,
+      value: 0.22,
+      errors: [-0.05],
+    });
+
+    (discoverStructure as unknown as { usingRustDualWrite: boolean })
+      .usingRustDualWrite = true;
+    (discoverStructure as unknown as {
+      rustAccumulatedData: DataRecordInterface[];
+    })
+      .rustAccumulatedData = [{
+        input: new Float32Array([0.1, -0.2]),
+        output: new Float32Array([0.3]),
+      }];
+    (discoverStructure as unknown as {
+      rustAccumulatedNeuronData: Array<Map<string, DiscoverRecord>>;
+    }).rustAccumulatedNeuronData = [neuronMap];
+    (discoverStructure as unknown as { rustChunkFiles: string[] })
+      .rustChunkFiles = [];
+
+    {
+      const nonInputNeurons = creature.neurons.filter((neuron) =>
+        neuron.type !== "input"
+      );
+      const rustTrainingData = (discoverStructure as unknown as {
+        rustAccumulatedData: DataRecordInterface[];
+        rustAccumulatedNeuronData: Array<Map<string, DiscoverRecord>>;
+      }).rustAccumulatedData.map((record, index) => {
+        const discover = ((discoverStructure as unknown as {
+          rustAccumulatedNeuronData: Array<Map<string, DiscoverRecord>>;
+        }).rustAccumulatedNeuronData[index]) ??
+          new Map<string, DiscoverRecord>();
+
+        const neuronData = nonInputNeurons.map((neuron) => {
+          const mapped = discover.get(neuron.uuid);
+          return {
+            neuron_uuid: neuron.uuid,
+            activation: mapped?.activation ?? 0,
+            value: mapped?.value,
+            errors: mapped?.errors ? Array.from(mapped.errors) : [],
+          };
+        });
+
+        return {
+          input: Array.from(record.input),
+          output: Array.from(record.output),
+          neuron_data: neuronData,
+        };
+      });
+
+      expectedStats = (DiscoverStructure as unknown as {
+        computeRustFlushMetrics: (
+          data: RustRecordInput["training_data"],
+          expectedNeuronCount: number,
+          expectedInputLength: number,
+          expectedOutputLength: number,
+        ) => RustRecordBatchStats;
+      }).computeRustFlushMetrics(
+        rustTrainingData,
+        nonInputNeurons.length,
+        creature.input,
+        creature.output,
+      );
+    }
+
+    const originalError = console.error;
+    const errorLogs: Array<{ message: string; details: unknown }> = [];
+    console.error = (...args: unknown[]) => {
+      errorLogs.push({
+        message: String(args[0]),
+        details: args[1],
+      });
+    };
+
+    try {
+      const chunkDir = (discoverStructure as unknown as {
+        getNextChunkDir: () => string;
+      }).getNextChunkDir();
+
+      const result = (discoverStructure as unknown as {
+        writeRustParquetChunk: (dir: string) => string | null;
+      }).writeRustParquetChunk(chunkDir);
+
+      assertEquals(result, null);
+    } finally {
+      console.error = originalError;
+      (Deno as unknown as { mkdirSync: typeof Deno.mkdirSync }).mkdirSync =
+        originalMkdirSync;
+    }
+
+    assertEquals(
+      recordDiscoveryCalls.length,
+      1,
+      "Expected recordDiscovery to be invoked exactly once",
+    );
+    const errorLog = errorLogs.find((log) =>
+      log.message.includes("Rust discovery recording failed")
+    );
+    assert(errorLog, "Expected invalid string length failure to be logged");
+    const details = errorLog!.details as Record<string, unknown>;
+    assert(details, "Expected error log to include metadata");
+    assertEquals(
+      details.longestRustUuidLength,
+      expectedStats.longestNeuronUuidLength,
+    );
+    assertEquals(
+      details.totalRustUuidBytes,
+      expectedStats.totalNeuronUuidBytes,
+    );
+    assertEquals(
+      details.maxRustErrorsPerNeuron,
+      expectedStats.maxErrorValuesPerNeuron,
+    );
+    assertEquals(details.totalRustErrorValues, expectedStats.totalErrorValues);
+    assertEquals(details.rustInputJsonLength, 512);
+    assertEquals(details.rustInputBytes, 704);
+    assertEquals(
+      (details.recordDiscoveryStats as typeof expectedStats)
+        .longestNeuronUuidLength,
+      expectedStats.longestNeuronUuidLength,
+    );
   },
 });

--- a/test/discovery/DiscoverStructureRecordIndices.test.ts
+++ b/test/discovery/DiscoverStructureRecordIndices.test.ts
@@ -24,7 +24,7 @@ function makeCreature(): Creature {
   return creature;
 }
 
-Deno.test("DiscoverStructure normalises record indices for single binary chunk", async () => {
+Deno.test("DiscoverStructure preserves record indices for single binary chunk", async () => {
   const creature = makeCreature();
   const recordedInputs: RustRecordInput[] = [];
 
@@ -96,13 +96,119 @@ Deno.test("DiscoverStructure normalises record indices for single binary chunk",
       1,
       "recordDiscovery should be invoked once",
     );
+
     const [input] = recordedInputs;
     assert(input.record_indices, "record indices should be provided to Rust");
-    const expectedIndices = rawIndices.map((_value, idx) => idx);
     assertEquals(
       input.record_indices,
-      expectedIndices,
-      "record indices should be normalised to chunk-relative offsets",
+      rawIndices,
+      "record indices should retain their absolute offsets",
+    );
+  } finally {
+    await structure.cleanUp();
+  }
+});
+
+function makeBatch(
+  startIndex: number,
+  count: number,
+): { trainingRecords: DataRecordInterface[]; rawIndices: number[] } {
+  const trainingRecords: DataRecordInterface[] = [];
+  const rawIndices: number[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const activationSeed = startIndex + i;
+    const input = Float32Array.from([activationSeed / 100, 1]);
+    const output = Float32Array.from([activationSeed / 200]);
+    trainingRecords.push({ input, output });
+    rawIndices.push(startIndex + i);
+  }
+
+  return { trainingRecords, rawIndices };
+}
+
+Deno.test("DiscoverStructure keeps slice offsets across multiple chunk flushes", async () => {
+  const creature = makeCreature();
+  const recordedInputs: RustRecordInput[] = [];
+
+  const structure = new DiscoverStructure(
+    creature,
+    60,
+    100,
+    {
+      isRustDiscoveryEnabled: () => true,
+      isRustLibraryAvailable: () => true,
+      recordDiscovery: (input) => {
+        recordedInputs.push(input);
+        return {
+          success: true,
+          file: `chunk-${recordedInputs.length}.parquet`,
+        };
+      },
+      mergeDiscoveryParquet: () => ({
+        success: true,
+        outputFile: "merged.parquet",
+      }),
+      analyzeNeurons: () => ({
+        success: true,
+        helpfulNeurons: [],
+      }),
+      analyzeSynapses: () => ({
+        success: true,
+        helpfulSynapses: [],
+        harmfulSynapses: [],
+      }),
+      readDiscoveryRecords: () => ({
+        success: true,
+        records: [],
+      }),
+    },
+  );
+
+  const neuronPromises = new Map<string, Promise<void>>();
+
+  try {
+    structure.initialize(neuronPromises);
+
+    const firstBatch = makeBatch(0, 4);
+    assert(
+      structure.record(
+        firstBatch.trainingRecords,
+        neuronPromises,
+        "/tmp/fake.bin",
+        firstBatch.rawIndices,
+      ),
+      "first slice should record successfully",
+    );
+    assertEquals(structure.flushRustChunk(), true);
+
+    const secondBatch = makeBatch(512, 4);
+    assert(
+      structure.record(
+        secondBatch.trainingRecords,
+        neuronPromises,
+        "/tmp/fake.bin",
+        secondBatch.rawIndices,
+      ),
+      "second slice should record successfully",
+    );
+    assertEquals(structure.flushRustChunk(), true);
+
+    assertEquals(
+      recordedInputs.length,
+      2,
+      "each flush should invoke recordDiscovery",
+    );
+
+    assertEquals(
+      recordedInputs[0].record_indices,
+      firstBatch.rawIndices,
+      "first slice should keep base offsets",
+    );
+    assertEquals(
+      recordedInputs[1].record_indices,
+      secondBatch.rawIndices,
+      "second slice should reference its original offsets",
     );
   } finally {
     await structure.cleanUp();


### PR DESCRIPTION
- Introduced RustFlushMetrics interface to encapsulate metrics related to Rust training data.
- Enhanced RustFlushDiagnostics to include metrics.
- Implemented computeRustFlushMetrics method for calculating various metrics from training data.
- Updated error logging to include detailed metrics when Rust discovery fails.
- Added tests to verify metrics calculation and logging behavior during discovery failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces metrics-driven Rust flush diagnostics and enriched FFI error details, preserves absolute record indices across chunks, and adds targeted tests; bumps version and adds a streaming constant.
> 
> - **Discovery (TypeScript)**:
>   - **Metrics & Diagnostics**: Add `RustFlushMetrics` and batch aggregation to track UUID sizes, error counts, input/output mismatches, and non-finite values; expose summary/warnings/errors and include metrics in logs.
>   - **Utilities**: Add `computeRustFlushMetrics`, internal aggregation/observation/finalization helpers, and log truncation helpers.
>   - **Error Logging**: Log enriched details on Rust failures (failure stage, input sizes, stats).
>   - **Record Indices**: Preserve absolute `record_indices` and maintain offsets across multiple chunk flushes.
> - **FFI Layer (RustDiscovery.ts)**:
>   - Add `RustRecordBatchStats`, failure stages, and `RustRecordErrorDetails`.
>   - Implement `computeRustRecordStats` and enhance `recordDiscovery` to attach failure-stage metadata and stats.
> - **Constants**:
>   - Add `DEFAULT_RUST_STREAM_RECORDS` and keep `DEFAULT_RUST_FLUSH_RECORDS`.
> - **Tests**:
>   - Add tests for metrics aggregation, longest UUID tracking, enriched error logging, and record index preservation across chunks.
> - **Meta**:
>   - Bump version to `0.195.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39f91f18bb36f54be5f761b1001f0f033ea5eadf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->