### PR TITLE
Refactor input handling in recordDiscovery function for improved clarity

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.195.4",
+  "version": "0.195.5",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -759,6 +759,9 @@ export function recordDiscovery(
 
   const stats = computeRustRecordStats(input);
 
+  let inputJson: string | undefined;
+  let inputBytes: Uint8Array | undefined;
+
   const buildFailure = (
     stage: RustRecordFailureStage,
     message: string,
@@ -790,7 +793,6 @@ export function recordDiscovery(
     };
   };
 
-  let inputJson: string | undefined;
   try {
     inputJson = JSON.stringify(input);
   } catch (error) {
@@ -798,7 +800,6 @@ export function recordDiscovery(
     return buildFailure("stringify", message);
   }
 
-  let inputBytes: Uint8Array | undefined;
   try {
     inputBytes = new TextEncoder().encode(inputJson);
   } catch (error) {

--- a/test/ErrorGuidedStructuralEvolution/RustDiscoveryStringifyFailure.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/RustDiscoveryStringifyFailure.test.ts
@@ -1,0 +1,151 @@
+import { assert, assertEquals } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { join } from "@std/path/join";
+import {
+  closeRustLibrary,
+  recordDiscovery,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import type { RustRecordInput } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+
+Deno.test("recordDiscovery handles stringify failure before encoding", () => {
+  closeRustLibrary();
+
+  const extension = (() => {
+    switch (Deno.build.os) {
+      case "darwin":
+        return ".dylib";
+      case "linux":
+        return ".so";
+      case "windows":
+        return ".dll";
+      default:
+        return ".dylib";
+    }
+  })();
+  const fakeLibPath = join("/virtual", `libneat_ai_discovery${extension}`);
+
+  const fakeFileInfo: Deno.FileInfo = {
+    isFile: true,
+    isDirectory: false,
+    isSymlink: false,
+    isBlockDevice: false,
+    isCharDevice: false,
+    isFifo: false,
+    isSocket: false,
+    size: 0,
+    mtime: null,
+    atime: null,
+    birthtime: null,
+    ctime: null,
+    dev: 0,
+    ino: 0,
+    mode: 0,
+    nlink: 0,
+    blksize: 0,
+    blocks: 0,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+  };
+
+  const fakeLib = {
+    symbols: {
+      record_discovery: () => {
+        throw new Error("record_discovery should not be invoked");
+      },
+      analyze_synapses: () => {
+        throw new Error("analyze_synapses should not be invoked");
+      },
+      analyze_neurons: () => {
+        throw new Error("analyze_neurons should not be invoked");
+      },
+      read_discovery_records_ffi: () => {
+        throw new Error("read_discovery_records_ffi should not be invoked");
+      },
+      merge_discovery_parquet: () => {
+        throw new Error("merge_discovery_parquet should not be invoked");
+      },
+      free_discovery_result: () => {},
+    },
+    close: () => {},
+  } as unknown as Deno.DynamicLibrary<
+    {
+      record_discovery: { parameters: ["pointer"]; result: "pointer" };
+      analyze_synapses: { parameters: ["pointer"]; result: "pointer" };
+      analyze_neurons: { parameters: ["pointer"]; result: "pointer" };
+      read_discovery_records_ffi: {
+        parameters: ["pointer"];
+        result: "pointer";
+      };
+      merge_discovery_parquet: { parameters: ["pointer"]; result: "pointer" };
+      free_discovery_result: { parameters: ["pointer"]; result: "void" };
+    }
+  >;
+
+  const originalOverride = (() => {
+    try {
+      return Deno.env.get("NEAT_AI_DISCOVERY_LIB_PATH");
+    } catch {
+      return undefined;
+    }
+  })();
+
+  const dlopenStub = stub(Deno, "dlopen", () => fakeLib);
+  const statStub = stub(
+    Deno,
+    "statSync",
+    (_path: string | URL) => fakeFileInfo,
+  );
+  const permissionsStub = stub(
+    Deno.permissions,
+    "querySync",
+    (_desc: Deno.PermissionDescriptor) =>
+      ({
+        state: "granted",
+      }) as Deno.PermissionStatus,
+  );
+  const envStub = stub(
+    Deno.env,
+    "get",
+    (key: string) =>
+      key === "NEAT_AI_DISCOVERY_LIB_PATH" ? fakeLibPath : undefined,
+  );
+
+  try {
+    const invalidInput: RustRecordInput = {
+      creature: {
+        neurons: [],
+        synapses: [],
+        input: 1,
+        output: 1,
+      },
+      "training_data": [{
+        input: [
+          BigInt(1) as unknown as number,
+        ],
+        output: [0],
+      }],
+      "temp_dir": "/virtual/discovery",
+    };
+
+    const result = recordDiscovery(invalidInput);
+    assert(result, "recordDiscovery should return a failure result");
+    assertEquals(result.success, false);
+    assert(result.errorDetails, "error details should be supplied");
+    assertEquals(result.errorDetails.stage, "stringify");
+    assertEquals(result.error, "Do not know how to serialize a BigInt");
+  } finally {
+    closeRustLibrary();
+    dlopenStub.restore();
+    statStub.restore();
+    permissionsStub.restore();
+    envStub.restore();
+    if (originalOverride !== undefined) {
+      try {
+        Deno.env.set("NEAT_AI_DISCOVERY_LIB_PATH", originalOverride);
+      } catch {
+        // Ignore environments without --allow-env.
+      }
+    }
+  }
+});


### PR DESCRIPTION
- Moved the declaration of inputJson and inputBytes to the top of the recordDiscovery function for better visibility and organization.
- Removed redundant declarations of inputJson and inputBytes to streamline the code.

This update enhances the readability and maintainability of the recordDiscovery function.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hoists `inputJson`/`inputBytes` in `recordDiscovery` to improve error detail reporting and adds a test validating stringify failure handling without invoking FFI.
> 
> - **RustDiscovery**:
>   - Hoists `inputJson` and `inputBytes` declarations in `recordDiscovery` to enable capturing lengths in error details during failures.
> - **Tests**:
>   - Adds `test/ErrorGuidedStructuralEvolution/RustDiscoveryStringifyFailure.test.ts` to assert stringify failure is caught (with BigInt), reports stage `"stringify"`, and avoids FFI calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8775ddd55f82605f9f28936143de0d2dd8d7c366. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->