### PR TITLE
Retry discovery

### DIFF
--- a/DISCOVERY_TIMEOUT_SEPARATION.md
+++ b/DISCOVERY_TIMEOUT_SEPARATION.md
@@ -171,9 +171,7 @@ while (retryAttempt <= maxRetries) {
   );
 
   // Filter out already-attempted neurons
-  const newFocusList = focusList.filter((uuid) =>
-    !attemptedNeurons.has(uuid)
-  );
+  const newFocusList = focusList.filter((uuid) => !attemptedNeurons.has(uuid));
 
   // Run all four analysis types on these neurons
   const addHelpfulSynapse = await discoverStructure.analyzeSelectedNeurons(

--- a/DISCOVERY_TIMEOUT_SEPARATION.md
+++ b/DISCOVERY_TIMEOUT_SEPARATION.md
@@ -123,3 +123,144 @@ wasted work** - Recorded data is always analyzed ✅ **Predictable behavior** -
 Analysis gets guaranteed time allocation ✅ **Configurable** - Users can tune
 both timeouts independently ✅ **Backward compatible** - Default of 3 minutes
 works for existing code
+
+## Intelligent Retry Logic (15-Nov-2024)
+
+### Problem
+
+The expensive recording phase could take minutes, but if the randomly selected
+neurons didn't yield any discoveries, the entire effort was wasted:
+
+```
+Recording phase: 7m 9s (processing 20 records)
+Analysis phase: Selected 6 neurons randomly
+  - Analyze helpful synapses: found 0 candidates
+  - Analyze helpful neurons: found 0 candidates
+  - Analyze harmful synapses: found 0 candidates
+  - Analyze squashes: found 0 candidates
+Result: 0 candidates (wasted 7+ minutes of recording work)
+```
+
+The recorded data in the Parquet file was perfectly good, but we only tried one
+random set of neurons and gave up.
+
+### Solution
+
+**Retry with different neurons if no candidates found:**
+
+The analysis phase now automatically retries with different randomly selected
+neurons if:
+
+1. No candidates were found in the initial analysis
+2. Analysis timeout hasn't been reached (`discoveryAnalysisTimeoutMinutes`)
+3. There are still untried neurons available
+
+### Implementation
+
+**Retry Loop in DiscoverDirectory:**
+
+```typescript
+const attemptedNeurons = new Set<string>();
+let retryAttempt = 0;
+const maxRetries = 10;
+
+while (retryAttempt <= maxRetries) {
+  // Select neurons (weighted by error)
+  const focusList = await discoverStructure.selectNeuronsWeightedByError(
+    this.discoveryMaxNeurons,
+  );
+
+  // Filter out already-attempted neurons
+  const newFocusList = focusList.filter((uuid) =>
+    !attemptedNeurons.has(uuid)
+  );
+
+  // Run all four analysis types on these neurons
+  const addHelpfulSynapse = await discoverStructure.analyzeSelectedNeurons(
+    newFocusList,
+  );
+  const addHelpfulNeurons = await discoverStructure.analyzeMissingNeurons(
+    newFocusList,
+  );
+  const removeHarmfulSynapse = await discoverStructure
+    .analyzeSelectedNeuronsForRemoval(newFocusList);
+  const candidateSquashes = await discoverStructure
+    .analyzeSelectedNeuronsSquashes(newFocusList);
+
+  // Check if we found any candidates
+  const foundCandidates = Boolean(
+    addHelpfulSynapse ||
+      addHelpfulNeurons ||
+      removeHarmfulSynapse ||
+      candidateSquashes,
+  );
+
+  if (foundCandidates) {
+    break; // Success! Exit retry loop
+  }
+
+  // Check if we still have time for another retry
+  const timeRemaining = this.timeoutTS - Date.now();
+  if (timeRemaining <= 0) {
+    break; // Timeout reached, stop retrying
+  }
+
+  retryAttempt++;
+  // Try again with different neurons...
+}
+```
+
+### Expected Behavior
+
+**Before Retry Logic:**
+
+```
+Discovery recording: 7m 9s
+Discovery selected 6 focus neurons in 2s
+  - Analyze helpful: found 0 candidates
+  - Analyze neurons: found 0 candidates
+  - Analyze harmful: found 0 candidates
+  - Analyze squashes: found 0 candidates
+Total time: 7m 15s
+Result: 0 candidates (7+ minutes wasted)
+```
+
+**After Retry Logic:**
+
+```
+Discovery recording: 7m 9s
+Discovery selected 6 focus neurons in 2s
+  - Analyze helpful: found 0 candidates
+  - Analyze neurons: found 0 candidates
+  - Analyze harmful: found 0 candidates
+  - Analyze squashes: found 0 candidates
+Discovery no candidates found, retrying with different neurons (2m 58s remaining)
+Discovery selected 6 focus neurons in 2s (retry 1, 6 already tried)
+  - Analyze helpful: found 2 candidates ✓
+  - Analyze neurons: found 1 candidate ✓
+  - Analyze harmful: found 0 candidates
+  - Analyze squashes: found 1 candidate ✓
+Discovery found candidates after 1 retry attempt
+Total time: 7m 25s
+Result: 4 candidates found (recording work not wasted!)
+```
+
+### Key Features
+
+1. **Tracks attempted neurons** - Avoids analyzing the same neurons twice
+2. **Respects analysis timeout** - Only retries while time remains
+3. **Reuses recorded data** - No need to re-record, just analyze different
+   neurons
+4. **Max retry limit** - Prevents infinite loops (default: 10 retries)
+5. **Weighted selection** - Each retry still uses error-weighted selection for
+   new neurons
+6. **Early exit on success** - Stops immediately when candidates are found
+
+### Benefits
+
+✅ **Maximizes recording investment** - Tries multiple neuron sets using same
+recorded data ✅ **Increases discovery success rate** - More chances to find
+improvements ✅ **Time-bounded** - Respects `discoveryAnalysisTimeoutMinutes`
+limit ✅ **No duplicate work** - Tracks and skips already-analyzed neurons ✅
+**Automatic** - No configuration needed, works out of the box ✅ **Minimal
+overhead** - Only retries when needed (no candidates found)

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.195.8",
+  "version": "0.195.9",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -510,108 +510,192 @@ class DataRecorder {
         candidateSquashes: undefined,
       };
 
-      const focusSelectStart = Date.now();
-      const focusList = await discoverStructure.selectNeuronsWeightedByError(
-        this.discoveryMaxNeurons,
-      );
-      if (shouldLogDiscovery(options)) {
-        const selectTime = Date.now() - focusSelectStart;
-        console.log(
-          `Discovery ${blue(this.ID)} selected ${
-            yellow(focusList.length.toString())
-          } focus neuron${focusList.length === 1 ? "" : "s"} in ${
-            yellow(format(selectTime, { ignoreZero: true }))
-          }`,
+      // Track attempted neurons to avoid re-analyzing the same ones
+      const attemptedNeurons = new Set<string>();
+      let retryAttempt = 0;
+      const maxRetries = 10; // Reasonable limit to prevent infinite loops
+
+      // Retry loop: try different neurons if no candidates found and time remains
+      // Sequential execution is intentional - we check results after each attempt
+      while (retryAttempt <= maxRetries) {
+        const focusSelectStart = Date.now();
+        // deno-lint-ignore no-await-in-loop
+        const focusList = await discoverStructure.selectNeuronsWeightedByError(
+          this.discoveryMaxNeurons,
         );
-      }
 
-      currentPhase = "analyze_helpful";
-      const analyzeStartTime = Date.now();
-
-      const addHelpfulSynapse = focusList.length > 0
-        ? await discoverStructure.analyzeSelectedNeurons(focusList)
-        : undefined;
-      if (shouldLogDiscovery(options)) {
-        const analyzeTime = Date.now() - analyzeStartTime;
-        console.log(
-          `Discovery ${blue(this.ID)} analyze time ${
-            yellow(format(analyzeTime, { ignoreZero: true }))
-          } found ${
-            addHelpfulSynapse ? addHelpfulSynapse.length : 0
-          } synapse candidates`,
+        // Filter out neurons we've already tried
+        const newFocusList = focusList.filter((uuid) =>
+          !attemptedNeurons.has(uuid)
         );
-      }
 
-      if (addHelpfulSynapse) {
-        discoverResult.addHelpfulSynapses = addHelpfulSynapse;
-      }
-
-      currentPhase = "analyze_neurons";
-      const neuronAnalyzeStart = Date.now();
-      const addHelpfulNeurons = focusList.length > 0
-        ? await discoverStructure.analyzeMissingNeurons(focusList)
-        : undefined;
-      if (shouldLogDiscovery(options)) {
-        const neuronAnalyzeTime = Date.now() - neuronAnalyzeStart;
-        console.log(
-          `Discovery ${blue(this.ID)} analyze neurons time ${
-            yellow(format(neuronAnalyzeTime, { ignoreZero: true }))
-          } found ${
-            addHelpfulNeurons ? addHelpfulNeurons.length : 0
-          } neuron candidates`,
-        );
-      }
-      if (addHelpfulNeurons && addHelpfulNeurons.length > 0) {
-        discoverResult.addHelpfulNeurons = addHelpfulNeurons;
-      }
-
-      currentPhase = "analyze_harmful";
-      const harmfulStartTime = Date.now();
-      const removeHarmfulSynapse = focusList.length > 0
-        ? await discoverStructure.analyzeSelectedNeuronsForRemoval(focusList)
-        : undefined;
-      if (shouldLogDiscovery(options)) {
-        const harmfulTime = Date.now() - harmfulStartTime;
-        console.log(
-          `Discovery ${blue(this.ID)} analyze harmful time ${
-            yellow(format(harmfulTime, { ignoreZero: true }))
-          } found ${removeHarmfulSynapse ? 1 : 0} candidates`,
-        );
-      }
-      if (removeHarmfulSynapse) {
-        discoverResult.removeHarmfulSynapse = removeHarmfulSynapse;
-      }
-
-      currentPhase = "analyze_squash";
-      const squashStartTime = Date.now();
-      const candidateSquashes = focusList.length > 0
-        ? await discoverStructure.analyzeSelectedNeuronsSquashes(focusList)
-        : undefined;
-      if (shouldLogDiscovery(options)) {
-        const squashTime = Date.now() - squashStartTime;
-        const squashCount = candidateSquashes ? candidateSquashes.length : 0;
-        let squashSummaryText = "";
-        if (squashCount > 0) {
-          assert(candidateSquashes, "No candidate squashes");
-          const squashSummary = candidateSquashes.map((candidate) => {
-            return `${candidate.neuronUUID} ${candidate.previousSquash} -> ${candidate.squash} improved: ${
-              (candidate.expectedImprovementPercentage * 100).toFixed(1)
-            }% error: ${candidate.currentError.toFixed(4)} -> ${
-              candidate.improvedError.toFixed(4)
-            }`;
-          });
-          squashSummaryText = `, Summary: ${squashSummary.join(",")}`;
+        if (shouldLogDiscovery(options)) {
+          const selectTime = Date.now() - focusSelectStart;
+          const retryMsg = retryAttempt > 0
+            ? ` (retry ${retryAttempt}, ${attemptedNeurons.size} already tried)`
+            : "";
+          console.log(
+            `Discovery ${blue(this.ID)} selected ${
+              yellow(newFocusList.length.toString())
+            } focus neuron${newFocusList.length === 1 ? "" : "s"} in ${
+              yellow(format(selectTime, { ignoreZero: true }))
+            }${retryMsg}`,
+          );
         }
-        console.log(
-          `Discovery ${blue(this.ID)} analyze squashes time ${
-            yellow(format(squashTime, { ignoreZero: true }))
-          } found ${squashCount} candidate${
-            squashCount === 1 ? "" : "s"
-          }${squashSummaryText}`,
+
+        // Mark these neurons as attempted
+        newFocusList.forEach((uuid) => attemptedNeurons.add(uuid));
+
+        // If we have no new neurons to try, stop retrying
+        if (newFocusList.length === 0) {
+          if (shouldLogDiscovery(options)) {
+            console.log(
+              `Discovery ${
+                blue(this.ID)
+              } no new neurons to analyze, stopping retry loop`,
+            );
+          }
+          break;
+        }
+
+        currentPhase = "analyze_helpful";
+        const analyzeStartTime = Date.now();
+
+        // deno-lint-ignore no-await-in-loop
+        const addHelpfulSynapse = await discoverStructure
+          .analyzeSelectedNeurons(
+            newFocusList,
+          );
+        if (shouldLogDiscovery(options)) {
+          const analyzeTime = Date.now() - analyzeStartTime;
+          console.log(
+            `Discovery ${blue(this.ID)} analyze time ${
+              yellow(format(analyzeTime, { ignoreZero: true }))
+            } found ${
+              addHelpfulSynapse ? addHelpfulSynapse.length : 0
+            } synapse candidates`,
+          );
+        }
+
+        if (addHelpfulSynapse) {
+          discoverResult.addHelpfulSynapses = addHelpfulSynapse;
+        }
+
+        currentPhase = "analyze_neurons";
+        const neuronAnalyzeStart = Date.now();
+        // deno-lint-ignore no-await-in-loop
+        const addHelpfulNeurons = await discoverStructure.analyzeMissingNeurons(
+          newFocusList,
         );
-      }
-      if (candidateSquashes) {
-        discoverResult.candidateSquashes = candidateSquashes;
+        if (shouldLogDiscovery(options)) {
+          const neuronAnalyzeTime = Date.now() - neuronAnalyzeStart;
+          console.log(
+            `Discovery ${blue(this.ID)} analyze neurons time ${
+              yellow(format(neuronAnalyzeTime, { ignoreZero: true }))
+            } found ${
+              addHelpfulNeurons ? addHelpfulNeurons.length : 0
+            } neuron candidates`,
+          );
+        }
+        if (addHelpfulNeurons && addHelpfulNeurons.length > 0) {
+          discoverResult.addHelpfulNeurons = addHelpfulNeurons;
+        }
+
+        currentPhase = "analyze_harmful";
+        const harmfulStartTime = Date.now();
+        // deno-lint-ignore no-await-in-loop
+        const removeHarmfulSynapse = await discoverStructure
+          .analyzeSelectedNeuronsForRemoval(newFocusList);
+        if (shouldLogDiscovery(options)) {
+          const harmfulTime = Date.now() - harmfulStartTime;
+          console.log(
+            `Discovery ${blue(this.ID)} analyze harmful time ${
+              yellow(format(harmfulTime, { ignoreZero: true }))
+            } found ${removeHarmfulSynapse ? 1 : 0} candidates`,
+          );
+        }
+        if (removeHarmfulSynapse) {
+          discoverResult.removeHarmfulSynapse = removeHarmfulSynapse;
+        }
+
+        currentPhase = "analyze_squash";
+        const squashStartTime = Date.now();
+        // deno-lint-ignore no-await-in-loop
+        const candidateSquashes = await discoverStructure
+          .analyzeSelectedNeuronsSquashes(newFocusList);
+        if (shouldLogDiscovery(options)) {
+          const squashTime = Date.now() - squashStartTime;
+          const squashCount = candidateSquashes ? candidateSquashes.length : 0;
+          let squashSummaryText = "";
+          if (squashCount > 0) {
+            assert(candidateSquashes, "No candidate squashes");
+            const squashSummary = candidateSquashes.map((candidate) => {
+              return `${candidate.neuronUUID} ${candidate.previousSquash} -> ${candidate.squash} improved: ${
+                (candidate.expectedImprovementPercentage * 100).toFixed(1)
+              }% error: ${candidate.currentError.toFixed(4)} -> ${
+                candidate.improvedError.toFixed(4)
+              }`;
+            });
+            squashSummaryText = `, Summary: ${squashSummary.join(",")}`;
+          }
+          console.log(
+            `Discovery ${blue(this.ID)} analyze squashes time ${
+              yellow(format(squashTime, { ignoreZero: true }))
+            } found ${squashCount} candidate${
+              squashCount === 1 ? "" : "s"
+            }${squashSummaryText}`,
+          );
+        }
+        if (candidateSquashes) {
+          discoverResult.candidateSquashes = candidateSquashes;
+        }
+
+        // Check if we found any candidates
+        const foundCandidates = Boolean(
+          discoverResult.addHelpfulSynapses ||
+            discoverResult.addHelpfulNeurons ||
+            discoverResult.removeHarmfulSynapse ||
+            discoverResult.candidateSquashes,
+        );
+
+        // If we found candidates, we're done
+        if (foundCandidates) {
+          if (shouldLogDiscovery(options) && retryAttempt > 0) {
+            console.log(
+              `Discovery ${
+                blue(this.ID)
+              } found candidates after ${retryAttempt} retry attempt${
+                retryAttempt === 1 ? "" : "s"
+              }`,
+            );
+          }
+          break;
+        }
+
+        // Check if we still have time for another retry
+        const timeRemaining = this.timeoutTS - Date.now();
+        if (timeRemaining <= 0) {
+          if (shouldLogDiscovery(options)) {
+            console.log(
+              `Discovery ${
+                blue(this.ID)
+              } no candidates found and analysis timeout reached`,
+            );
+          }
+          break;
+        }
+
+        // Log retry decision
+        retryAttempt++;
+        if (shouldLogDiscovery(options)) {
+          console.log(
+            `Discovery ${
+              blue(this.ID)
+            } no candidates found, retrying with different neurons (${
+              yellow(format(timeRemaining, { ignoreZero: true }))
+            } remaining)`,
+          );
+        }
       }
 
       currentPhase = "complete";

--- a/test/propagate/bias/Simple.ts
+++ b/test/propagate/bias/Simple.ts
@@ -166,7 +166,14 @@ function makeTrainData(creature: Creature) {
     const input = JSON.parse(
       Deno.readTextFileSync(tdFN),
     );
-    return input;
+    // Convert cached objects back to Float32Arrays
+    // Float32Arrays serialize as objects with numeric keys {"0": val, "1": val}
+    return input.map((
+      record: { input: Record<string, number>; output: Record<string, number> },
+    ) => ({
+      input: new Float32Array(Object.values(record.input)),
+      output: new Float32Array(Object.values(record.output)),
+    }));
   } // deno-lint-ignore no-empty
   catch (_e) {}
 

--- a/test/propagate/biasIdentity/Simple.ts
+++ b/test/propagate/biasIdentity/Simple.ts
@@ -165,7 +165,14 @@ function makeTrainData(creature: Creature) {
     const input = JSON.parse(
       Deno.readTextFileSync(tdFN),
     );
-    return input;
+    // Convert cached objects back to Float32Arrays
+    // Float32Arrays serialize as objects with numeric keys {"0": val, "1": val}
+    return input.map((
+      record: { input: Record<string, number>; output: Record<string, number> },
+    ) => ({
+      input: new Float32Array(Object.values(record.input)),
+      output: new Float32Array(Object.values(record.output)),
+    }));
   } // deno-lint-ignore no-empty
   catch (_e) {}
 

--- a/test/propagate/minimum/Minimum.ts
+++ b/test/propagate/minimum/Minimum.ts
@@ -142,7 +142,14 @@ function makeTrainData(creature: Creature) {
     const input = JSON.parse(
       Deno.readTextFileSync(tdFN),
     );
-    return input;
+    // Convert cached objects back to Float32Arrays
+    // Float32Arrays serialize as objects with numeric keys {"0": val, "1": val}
+    return input.map((
+      record: { input: Record<string, number>; output: Record<string, number> },
+    ) => ({
+      input: new Float32Array(Object.values(record.input)),
+      output: new Float32Array(Object.values(record.output)),
+    }));
   } // deno-lint-ignore no-empty
   catch (_e) {}
 

--- a/test/propagate/simple/Simple.ts
+++ b/test/propagate/simple/Simple.ts
@@ -123,7 +123,14 @@ function makeTrainData(creature: Creature) {
     const input = JSON.parse(
       Deno.readTextFileSync(tdFN),
     );
-    return input;
+    // Convert cached objects back to Float32Arrays
+    // Float32Arrays serialize as objects with numeric keys {"0": val, "1": val}
+    return input.map((
+      record: { input: Record<string, number>; output: Record<string, number> },
+    ) => ({
+      input: new Float32Array(Object.values(record.input)),
+      output: new Float32Array(Object.values(record.output)),
+    }));
   } // deno-lint-ignore no-empty
   catch (_e) {}
 

--- a/test/propagate/sparse/Trace.ts
+++ b/test/propagate/sparse/Trace.ts
@@ -195,7 +195,14 @@ function makeTrainData(creature: Creature) {
     const input = JSON.parse(
       Deno.readTextFileSync(tdFN),
     );
-    return input;
+    // Convert cached objects back to Float32Arrays
+    // Float32Arrays serialize as objects with numeric keys {"0": val, "1": val}
+    return input.map((
+      record: { input: Record<string, number>; output: Record<string, number> },
+    ) => ({
+      input: new Float32Array(Object.values(record.input)),
+      output: new Float32Array(Object.values(record.output)),
+    }));
   } // deno-lint-ignore no-empty
   catch (_e) {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a retry loop in discovery analysis that reselects untried neurons until candidates are found or timeout, and updates tests to rehydrate Float32Arrays from cached JSON.
> 
> - **Discovery Core (`src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts`)**
>   - Implement retry loop for analysis: reselects neurons (error-weighted), skips previously attempted (`Set`), and retries up to `maxRetries` while time remains.
>   - Early-exit when any candidates are found; logs retry attempts and timing for each analysis step.
>   - Preserves analysis timeout by checking remaining time per loop; integrates with existing per-phase timeout extension.
> - **Tests**
>   - Update training data loaders in `test/propagate/*` to rehydrate `Float32Array` inputs/outputs from cached JSON objects.
> - **Docs (`DISCOVERY_TIMEOUT_SEPARATION.md`)**
>   - Add section detailing intelligent retry logic, implementation snippet, expected behavior, and benefits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10c56f955795a5c7b8b7adf97926ae8cb6017c58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->