### PR TITLE
Discover not working

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.195.9",
+  "version": "0.195.10",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -313,6 +313,14 @@ class DataRecorder {
     if (Array.isArray(focusOverride) && focusOverride.length > 0) {
       discoverStructure.setForcedFocusNeurons(focusOverride);
     }
+    if (
+      typeof options.discoveryMinImprovementPercentage === "number" &&
+      Number.isFinite(options.discoveryMinImprovementPercentage)
+    ) {
+      discoverStructure.setImprovementThreshold(
+        options.discoveryMinImprovementPercentage,
+      );
+    }
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     const initializeStartTime = Date.now();
@@ -558,29 +566,6 @@ class DataRecorder {
           break;
         }
 
-        currentPhase = "analyze_helpful";
-        const analyzeStartTime = Date.now();
-
-        // deno-lint-ignore no-await-in-loop
-        const addHelpfulSynapse = await discoverStructure
-          .analyzeSelectedNeurons(
-            newFocusList,
-          );
-        if (shouldLogDiscovery(options)) {
-          const analyzeTime = Date.now() - analyzeStartTime;
-          console.log(
-            `Discovery ${blue(this.ID)} analyze time ${
-              yellow(format(analyzeTime, { ignoreZero: true }))
-            } found ${
-              addHelpfulSynapse ? addHelpfulSynapse.length : 0
-            } synapse candidates`,
-          );
-        }
-
-        if (addHelpfulSynapse) {
-          discoverResult.addHelpfulSynapses = addHelpfulSynapse;
-        }
-
         currentPhase = "analyze_neurons";
         const neuronAnalyzeStart = Date.now();
         // deno-lint-ignore no-await-in-loop
@@ -599,6 +584,31 @@ class DataRecorder {
         }
         if (addHelpfulNeurons && addHelpfulNeurons.length > 0) {
           discoverResult.addHelpfulNeurons = addHelpfulNeurons;
+        }
+
+        currentPhase = "analyze_helpful";
+        const analyzeStartTime = Date.now();
+
+        // deno-lint-ignore no-await-in-loop
+        const addHelpfulSynapse = await discoverStructure
+          .analyzeSelectedNeurons(
+            newFocusList,
+          );
+        if (shouldLogDiscovery(options)) {
+          const analyzeTime = Date.now() - analyzeStartTime;
+          console.log(
+            `Discovery ${blue(this.ID)} analyze synapses time ${
+              yellow(format(analyzeTime, { ignoreZero: true }))
+            } found ${
+              addHelpfulSynapse ? addHelpfulSynapse.length : 0
+            } candidate${
+              addHelpfulSynapse && addHelpfulSynapse.length === 1 ? "" : "s"
+            }`,
+          );
+        }
+
+        if (addHelpfulSynapse) {
+          discoverResult.addHelpfulSynapses = addHelpfulSynapse;
         }
 
         currentPhase = "analyze_harmful";

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -146,8 +146,8 @@ interface RustFlushAggregation {
   metrics: RustFlushMetrics;
 }
 
-const RUST_HELPFUL_THRESHOLD = 0.1;
-const RUST_HARMFUL_THRESHOLD = -0.1;
+const DEFAULT_RUST_HELPFUL_THRESHOLD = 0.1;
+const DEFAULT_RUST_HARMFUL_THRESHOLD = -0.1;
 
 /**
  * Implements Error-Driven Synapse Discovery, analyzing neuron activations
@@ -180,6 +180,9 @@ export class DiscoverStructure {
   private syntheticBinaryMode = false;
   private deps: DiscoverStructureDeps;
   private forcedFocusNeurons: string[] | null = null;
+  private forcedFocusIndex = 0;
+  private improvementThreshold = DEFAULT_RUST_HELPFUL_THRESHOLD;
+  private harmfulThreshold = DEFAULT_RUST_HARMFUL_THRESHOLD;
   constructor(
     creature: Creature,
     timeoutSeconds: number,
@@ -279,12 +282,36 @@ export class DiscoverStructure {
     }
 
     this.forcedFocusNeurons = Array.from(new Set(filtered));
+    this.forcedFocusIndex = 0;
     if (this.loggingEnabled) {
       this.log(
         "info",
         `Applying forced discovery focus neurons: ${
           this.forcedFocusNeurons.join(", ")
         }`,
+      );
+    }
+  }
+
+  public setImprovementThreshold(threshold: number): void {
+    const parsed = Number(threshold);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      if (this.loggingEnabled) {
+        this.log(
+          "warn",
+          `Ignored invalid discovery improvement threshold: ${threshold}`,
+        );
+      }
+      return;
+    }
+    this.improvementThreshold = parsed;
+    this.harmfulThreshold = -Math.abs(parsed);
+    if (this.loggingEnabled) {
+      this.log(
+        "info",
+        `Configured discovery improvement threshold to ${
+          (this.improvementThreshold * 100).toFixed(2)
+        }%.`,
       );
     }
   }
@@ -377,14 +404,14 @@ export class DiscoverStructure {
     if (timedOut) {
       this.log(
         "warn",
-        "Discovery recording timeout reached; preserving final batch before stopping.",
+        "Discovery recording timeout reached; skipping remaining samples.",
       );
     }
     this.recorded = true;
 
     // Rust module is required - if not available, discovery was already skipped in initialize()
-    if (!this.usingRustDualWrite) {
-      return false; // Discovery skipped - Rust not available
+    if (!this.usingRustDualWrite || timedOut) {
+      return false; // Discovery skipped - Rust not available or timed out
     }
 
     // Track selected indices if provided (from binary file processing)
@@ -623,11 +650,14 @@ export class DiscoverStructure {
         0,
         Math.floor((this.timeoutTS - Date.now()) / 1000),
       );
+      const flushRate = flushDuration > 0
+        ? (pendingSamples / (flushDuration / 1000)).toFixed(2)
+        : "∞";
       this.log(
         "info",
         `Flushed ${pendingSamples} samples to ${parquetPath} in ${
           this.formatMillis(flushDuration)
-        } (timeout remaining: ${remainingSeconds}s).`,
+        } (${flushRate} samples/sec, timeout remaining: ${remainingSeconds}s).`,
       );
 
       return parquetPath;
@@ -1224,7 +1254,7 @@ export class DiscoverStructure {
     const candidates = rustResult.helpfulNeurons
       .map((candidate) => this.mapRustNeuronCandidate(candidate))
       .filter((candidate) =>
-        candidate.expectedImprovementPercentage > RUST_HELPFUL_THRESHOLD
+        candidate.expectedImprovementPercentage > this.improvementThreshold
       );
 
     if (candidates.length === 0) {
@@ -1248,7 +1278,7 @@ export class DiscoverStructure {
     const candidates = rustResult.helpfulSynapses
       .map((candidate) => this.mapRustCandidate(candidate))
       .filter((candidate) =>
-        candidate.expectedImprovementPercentage > RUST_HELPFUL_THRESHOLD
+        candidate.expectedImprovementPercentage > this.improvementThreshold
       );
 
     if (candidates.length === 0) {
@@ -1272,7 +1302,7 @@ export class DiscoverStructure {
     const candidates = rustResult.harmfulSynapses
       .map((candidate) => this.mapRustCandidate(candidate))
       .filter((candidate) =>
-        candidate.expectedImprovementPercentage < RUST_HARMFUL_THRESHOLD
+        candidate.expectedImprovementPercentage < this.harmfulThreshold
       );
 
     if (candidates.length === 0) {
@@ -1401,7 +1431,7 @@ export class DiscoverStructure {
       parquetFile: this.parquetFilePath,
       creature: creatureToRustFormat(this.creature.exportJSON()),
       focusNeurons: focusList,
-      improvementThreshold: RUST_HELPFUL_THRESHOLD,
+      improvementThreshold: this.improvementThreshold,
       maxCandidates: Math.max(25, focusList.length * 5),
       requireGpu: Deno.build.os === "darwin",
     };
@@ -1456,7 +1486,7 @@ export class DiscoverStructure {
       parquetFile: this.parquetFilePath,
       creature: creatureToRustFormat(this.creature.exportJSON()),
       focusNeurons: focusList,
-      improvementThreshold: RUST_HELPFUL_THRESHOLD,
+      improvementThreshold: this.improvementThreshold,
       maxCandidates: Math.max(50, focusList.length * 10),
       requireGpu: Deno.build.os === "darwin",
     };
@@ -1906,23 +1936,37 @@ export class DiscoverStructure {
    */
   public async selectNeuronsWeightedByError(count: number): Promise<string[]> {
     assert(count > 0, "Count must be greater than 0");
-    if (this.forcedFocusNeurons && this.forcedFocusNeurons.length > 0) {
-      const trimmed = this.forcedFocusNeurons.slice(0, count);
-      if (
-        this.loggingEnabled && trimmed.length < this.forcedFocusNeurons.length
-      ) {
+    if (
+      this.forcedFocusNeurons && this.forcedFocusIndex <
+        this.forcedFocusNeurons.length
+    ) {
+      const nextIndex = Math.min(
+        this.forcedFocusIndex + count,
+        this.forcedFocusNeurons.length,
+      );
+      const trimmed = this.forcedFocusNeurons.slice(
+        this.forcedFocusIndex,
+        nextIndex,
+      );
+      this.forcedFocusIndex = nextIndex;
+      if (this.loggingEnabled) {
         this.log(
           "info",
-          `Trimming forced focus neurons from ${this.forcedFocusNeurons.length} to ${trimmed.length} to respect discoveryMaxNeurons=${count}`,
+          `Serving ${trimmed.length} forced focus neuron(s) (${this.forcedFocusIndex}/${this.forcedFocusNeurons.length} consumed).`,
         );
       }
-      if (this.loggingEnabled && trimmed.length < count) {
-        this.log(
-          "warn",
-          `Forced focus provided only ${trimmed.length} neuron(s) but ${count} requested; skipping weighted fallback.`,
-        );
+      if (this.forcedFocusIndex >= this.forcedFocusNeurons.length) {
+        if (this.loggingEnabled) {
+          this.log(
+            "info",
+            "All forced focus neurons evaluated; falling back to weighted selection.",
+          );
+        }
+        this.forcedFocusNeurons = null;
       }
-      return trimmed;
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
     }
     const neuronErrors = await this.listViableNeurons();
     if (neuronErrors.length === 0) return [];

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -137,6 +137,12 @@ export interface NeatArguments {
   /** Discovery Sample rate */
   discoverySampleRate: number;
 
+  /**
+   * Minimum expected improvement (0..1) that a discovery candidate must
+   * achieve in order to be considered helpful. Defaults to 0.1 (10%).
+   */
+  discoveryMinImprovementPercentage?: number;
+
   /** The maximum number of minutes to record for */
   discoveryTimeOutMinutes: number;
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoverRecordTimeout.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverRecordTimeout.ts
@@ -1,0 +1,100 @@
+import { assertEquals, assertFalse } from "@std/assert";
+import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { DiscoverStructureDeps } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+const STUB_DEPS: Partial<DiscoverStructureDeps> = {
+  isRustDiscoveryEnabled: () => true,
+  isRustLibraryAvailable: () => true,
+  recordDiscovery: () => ({
+    success: true,
+    file: "chunk.parquet",
+  }),
+  mergeDiscoveryParquet: () => ({
+    success: true,
+    outputFile: "output.parquet",
+  }),
+  analyzeNeurons: () => ({ success: true, helpfulNeurons: [] }),
+  analyzeSynapses: () => ({
+    success: true,
+    helpfulSynapses: [],
+    harmfulSynapses: [],
+  }),
+  readDiscoveryRecords: () => ({ success: true, records: [] }),
+};
+
+function makeTestCreature(): Creature {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [{
+      uuid: "output-0",
+      type: "output",
+      squash: IDENTITY.NAME,
+      bias: 0,
+    }],
+    synapses: [{
+      fromUUID: "input-0",
+      toUUID: "output-0",
+      weight: 0.5,
+    }, {
+      fromUUID: "input-1",
+      toUUID: "output-0",
+      weight: -0.25,
+    }],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+function makeTrainingData(): DataRecordInterface[] {
+  const samples: DataRecordInterface[] = [];
+  for (let i = 0; i < 5; i++) {
+    samples.push({
+      input: Float32Array.from([Math.random(), Math.random()]),
+      output: Float32Array.from([Math.random()]),
+    });
+  }
+  return samples;
+}
+
+Deno.test("DiscoverStructure.record aborts when timeout already expired", () => {
+  const creature = makeTestCreature();
+  const discoverStructure = new DiscoverStructure(
+    creature,
+    1, // timeoutSeconds
+    undefined,
+    STUB_DEPS,
+  );
+  const neuronPromises = new Map<string, Promise<void>>();
+  discoverStructure.initialize(neuronPromises);
+
+  // Force timeout to be in the past before recording begins.
+  (discoverStructure as unknown as { timeoutTS: number }).timeoutTS =
+    Date.now() - 10;
+
+  const trainingData = makeTrainingData();
+  const recorded = discoverStructure.record(
+    trainingData,
+    neuronPromises,
+    "test.bin",
+    [0, 1, 2, 3, 4],
+  );
+
+  assertFalse(recorded, "record should return false after timeout");
+
+  const accumulated = (discoverStructure as unknown as {
+    rustAccumulatedData: DataRecordInterface[];
+  }).rustAccumulatedData.length;
+  assertEquals(
+    accumulated,
+    0,
+    "No samples should be accumulated once timeout is reached",
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes discovery thresholds configurable, halts recording on timeout, iterates through forced-focus neurons progressively, and adds a test for record-timeout behavior.
> 
> - **Discovery pipeline**:
>   - Make improvement thresholds configurable via `NeatOptions.discoveryMinImprovementPercentage`; propagate to `DiscoverStructure` and Rust calls (replace fixed `RUST_*_THRESHOLD` with instance fields).
>   - Change analysis order/logs in `DiscoverDirectory`: analyze missing neurons before helpful/harmful synapses; refined log messages and pluralization.
>   - Incremental forced-focus handling: track progress with `forcedFocusIndex`, serve slices, and fall back to weighted selection after exhaustion.
>   - Enforce timeout in `record()`: skip accumulation and return `false` when expired; update timeout log phrasing; skip processing when Rust unavailable or timed out.
>   - Improve flush logging with samples/sec and remaining time; minor wording tweaks.
> - **Config**:
>   - Add `discoveryMinImprovementPercentage` to `NeatOptions` docs/interface.
> - **Tests**:
>   - Add `DiscoverRecordTimeout` test to verify no accumulation after timeout.
> - **Meta**:
>   - Bump `version` to `0.195.10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd4a13cb2f92cf89377e91ae45769a85c108105a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->