### PR TITLE
utilize gpus

### DIFF
--- a/GPU_ACCELERATION.md
+++ b/GPU_ACCELERATION.md
@@ -1,0 +1,155 @@
+# GPU Acceleration for Discovery on macOS
+
+## Overview
+
+The NEAT-AI Discovery Rust library **already supports GPU acceleration** on macOS using Metal via the `wgpu` crate. GPU acceleration is automatically enabled for Mac systems (`darwin`) and uses Metal under the hood for high-performance compute operations.
+
+## Current GPU Implementation
+
+### What's Already GPU-Accelerated
+
+1. **Synapse Analysis** - Both helpful and harmful synapse evaluation use GPU compute shaders
+2. **Neuron Analysis** - The helpful statistics calculation uses GPU, though activation function evaluation still runs on CPU
+
+### GPU Technology Stack
+
+- **wgpu 0.19** - Cross-platform GPU abstraction layer
+- **Metal** - Apple's GPU API (used automatically on macOS)
+- **Compute Shaders** - WGSL shaders for parallel processing
+
+## Verifying GPU Usage
+
+### Method 1: Check Logs
+
+When discovery runs with logging enabled, you'll now see messages like:
+
+```
+Rust synapse analysis using GPU (X helpful, Y harmful candidates)
+Rust neuron analysis using GPU (Z candidates)
+```
+
+If you see "using CPU fallback" instead, the GPU failed to initialise.
+
+### Method 2: Enable Debug Mode
+
+Set the environment variable to see detailed GPU diagnostics:
+
+```bash
+export NEAT_AI_DISCOVERY_GPU_DEBUG=1
+```
+
+This will print:
+- GPU adapter information
+- Device initialisation status
+- Any fallback to CPU
+
+### Method 3: Check Return Values
+
+The Rust analysis functions return a `gpuUsed` boolean field indicating whether GPU was actually used:
+
+```typescript
+const result = analyzeSynapses(input);
+if (result.gpuUsed) {
+  console.log("GPU acceleration is active!");
+} else {
+  console.warn("Falling back to CPU - check GPU availability");
+}
+```
+
+## Performance Considerations
+
+### GPU Utilization Improvements (2 Jan 2025)
+
+The code now batches multiple GPU operations together to improve utilization:
+
+- **Batched Evaluation**: Multiple synapse evaluations are collected and submitted together in batches of 32
+- **Better GPU Saturation**: Instead of submitting one operation at a time and waiting, multiple operations are queued before waiting
+- **Reduced Idle Time**: GPU spends less time waiting for CPU to prepare the next operation
+
+### Why It Might Still Be Slow
+
+Even with GPU acceleration, discovery can be CPU-bound due to:
+
+1. **Data I/O** - Reading Parquet files and preparing data for GPU
+2. **Neuron Analysis** - Activation function evaluation (GELU, ELU, SELU, etc.) still runs on CPU
+3. **Memory Transfers** - Copying data between CPU and GPU memory
+4. **Small Workloads** - GPU overhead may not be worth it for small datasets
+
+### Current GPU Usage
+
+The implementation uses GPU for:
+- ✅ Helpful synapse statistics (batched parallel evaluation)
+- ✅ Harmful synapse statistics (parallel evaluation)
+- ❌ Neuron activation function evaluation (still CPU-bound)
+
+### Future Optimisation Opportunities
+
+- Move activation function evaluation to GPU
+- Batch harmful synapse evaluations as well
+- Optimise memory transfers with buffer reuse
+- Use async GPU execution to overlap CPU/GPU work
+
+## Troubleshooting
+
+### GPU Not Being Used
+
+If you see "using CPU fallback" in logs:
+
+1. **Check Metal Support**: Ensure your Mac supports Metal (all modern Macs do)
+2. **Check Permissions**: Some systems may require GPU access permissions
+3. **Check wgpu Version**: Ensure `wgpu = "0.19"` in `Cargo.toml`
+4. **Rebuild**: After updating Rust code, rebuild the library:
+   ```bash
+   cd NEAT-AI-Discovery
+   cargo build --release
+   ```
+
+### Performance Issues
+
+If GPU is active but still slow:
+
+1. **Check Dataset Size**: GPU benefits increase with larger datasets
+2. **Monitor GPU Usage**: Use Activity Monitor or `gpuStats` to verify GPU is being utilised
+3. **Check Other Bottlenecks**: Parquet I/O, TypeScript processing, etc.
+
+## Configuration
+
+### Requiring GPU (Default on Mac)
+
+On macOS, GPU is required by default:
+
+```typescript
+requireGpu: Deno.build.os === "darwin"  // true on Mac
+```
+
+If GPU initialisation fails and `requireGpu` is true, discovery will fail with an error. If false, it falls back to CPU.
+
+### Disabling GPU Requirement
+
+To allow CPU fallback even on Mac:
+
+```typescript
+requireGpu: false  // Will use GPU if available, but fall back to CPU
+```
+
+## Technical Details
+
+### GPU Compute Shaders
+
+The GPU uses two compute shaders:
+
+1. **Helpful Synapse Shader** - Evaluates which synapses would help reduce error
+2. **Harmful Synapse Shader** - Evaluates which existing synapses are harmful
+
+Both use workgroup size of 256 threads for parallel processing.
+
+### Memory Layout
+
+Data is transferred to GPU as:
+- `GpuHelpfulSample` - Activation and error pairs
+- Results returned as `HelpfulContribution` or `HarmfulContribution`
+
+## Date
+
+2 Jan 2025
+

--- a/GPU_ACCELERATION.md
+++ b/GPU_ACCELERATION.md
@@ -2,14 +2,19 @@
 
 ## Overview
 
-The NEAT-AI Discovery Rust library **already supports GPU acceleration** on macOS using Metal via the `wgpu` crate. GPU acceleration is automatically enabled for Mac systems (`darwin`) and uses Metal under the hood for high-performance compute operations.
+The NEAT-AI Discovery Rust library **already supports GPU acceleration** on
+macOS using Metal via the `wgpu` crate. GPU acceleration is automatically
+enabled for Mac systems (`darwin`) and uses Metal under the hood for
+high-performance compute operations.
 
 ## Current GPU Implementation
 
 ### What's Already GPU-Accelerated
 
-1. **Synapse Analysis** - Both helpful and harmful synapse evaluation use GPU compute shaders
-2. **Neuron Analysis** - The helpful statistics calculation uses GPU, though activation function evaluation still runs on CPU
+1. **Synapse Analysis** - Both helpful and harmful synapse evaluation use GPU
+   compute shaders
+2. **Neuron Analysis** - The helpful statistics calculation uses GPU, though
+   activation function evaluation still runs on CPU
 
 ### GPU Technology Stack
 
@@ -39,13 +44,15 @@ export NEAT_AI_DISCOVERY_GPU_DEBUG=1
 ```
 
 This will print:
+
 - GPU adapter information
 - Device initialisation status
 - Any fallback to CPU
 
 ### Method 3: Check Return Values
 
-The Rust analysis functions return a `gpuUsed` boolean field indicating whether GPU was actually used:
+The Rust analysis functions return a `gpuUsed` boolean field indicating whether
+GPU was actually used:
 
 ```typescript
 const result = analyzeSynapses(input);
@@ -62,22 +69,27 @@ if (result.gpuUsed) {
 
 The code now batches multiple GPU operations together to improve utilization:
 
-- **Batched Evaluation**: Multiple synapse evaluations are collected and submitted together in batches of 32
-- **Better GPU Saturation**: Instead of submitting one operation at a time and waiting, multiple operations are queued before waiting
-- **Reduced Idle Time**: GPU spends less time waiting for CPU to prepare the next operation
+- **Batched Evaluation**: Multiple synapse evaluations are collected and
+  submitted together in batches of 32
+- **Better GPU Saturation**: Instead of submitting one operation at a time and
+  waiting, multiple operations are queued before waiting
+- **Reduced Idle Time**: GPU spends less time waiting for CPU to prepare the
+  next operation
 
 ### Why It Might Still Be Slow
 
 Even with GPU acceleration, discovery can be CPU-bound due to:
 
 1. **Data I/O** - Reading Parquet files and preparing data for GPU
-2. **Neuron Analysis** - Activation function evaluation (GELU, ELU, SELU, etc.) still runs on CPU
+2. **Neuron Analysis** - Activation function evaluation (GELU, ELU, SELU, etc.)
+   still runs on CPU
 3. **Memory Transfers** - Copying data between CPU and GPU memory
 4. **Small Workloads** - GPU overhead may not be worth it for small datasets
 
 ### Current GPU Usage
 
 The implementation uses GPU for:
+
 - ✅ Helpful synapse statistics (batched parallel evaluation)
 - ✅ Harmful synapse statistics (parallel evaluation)
 - ❌ Neuron activation function evaluation (still CPU-bound)
@@ -109,7 +121,8 @@ If you see "using CPU fallback" in logs:
 If GPU is active but still slow:
 
 1. **Check Dataset Size**: GPU benefits increase with larger datasets
-2. **Monitor GPU Usage**: Use Activity Monitor or `gpuStats` to verify GPU is being utilised
+2. **Monitor GPU Usage**: Use Activity Monitor or `gpuStats` to verify GPU is
+   being utilised
 3. **Check Other Bottlenecks**: Parquet I/O, TypeScript processing, etc.
 
 ## Configuration
@@ -119,17 +132,18 @@ If GPU is active but still slow:
 On macOS, GPU is required by default:
 
 ```typescript
-requireGpu: Deno.build.os === "darwin"  // true on Mac
+requireGpu: Deno.build.os === "darwin"; // true on Mac
 ```
 
-If GPU initialisation fails and `requireGpu` is true, discovery will fail with an error. If false, it falls back to CPU.
+If GPU initialisation fails and `requireGpu` is true, discovery will fail with
+an error. If false, it falls back to CPU.
 
 ### Disabling GPU Requirement
 
 To allow CPU fallback even on Mac:
 
 ```typescript
-requireGpu: false  // Will use GPU if available, but fall back to CPU
+requireGpu: false; // Will use GPU if available, but fall back to CPU
 ```
 
 ## Technical Details
@@ -146,10 +160,10 @@ Both use workgroup size of 256 threads for parallel processing.
 ### Memory Layout
 
 Data is transferred to GPU as:
+
 - `GpuHelpfulSample` - Activation and error pairs
 - Results returned as `HelpfulContribution` or `HarmfulContribution`
 
 ## Date
 
 2 Jan 2025
-

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.196.0",
+  "version": "0.196.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -95,6 +95,7 @@
     "extern",
     "overfitting",
     "unscored",
-    "Millis"
+    "Millis",
+    "wgpu"
   ]
 }

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -96,6 +96,7 @@
     "overfitting",
     "unscored",
     "Millis",
-    "wgpu"
+    "wgpu",
+    "WGSL"
   ]
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1458,7 +1458,9 @@ export class DiscoverStructure {
       if (this.loggingEnabled && result.gpuUsed !== undefined) {
         this.log(
           "info",
-          `Rust neuron analysis ${result.gpuUsed ? "using GPU" : "using CPU fallback"} (${result.helpfulNeurons?.length ?? 0} candidates)`,
+          `Rust neuron analysis ${
+            result.gpuUsed ? "using GPU" : "using CPU fallback"
+          } (${result.helpfulNeurons?.length ?? 0} candidates)`,
         );
       }
       return result;
@@ -1519,7 +1521,11 @@ export class DiscoverStructure {
       if (this.loggingEnabled && result.gpuUsed !== undefined) {
         this.log(
           "info",
-          `Rust synapse analysis ${result.gpuUsed ? "using GPU" : "using CPU fallback"} (${result.helpfulSynapses?.length ?? 0} helpful, ${result.harmfulSynapses?.length ?? 0} harmful candidates)`,
+          `Rust synapse analysis ${
+            result.gpuUsed ? "using GPU" : "using CPU fallback"
+          } (${result.helpfulSynapses?.length ?? 0} helpful, ${
+            result.harmfulSynapses?.length ?? 0
+          } harmful candidates)`,
         );
       }
       return result;

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1455,6 +1455,12 @@ export class DiscoverStructure {
           JSON.stringify({ focusList, result }, (_key, value) => value, 2),
         );
       }
+      if (this.loggingEnabled && result.gpuUsed !== undefined) {
+        this.log(
+          "info",
+          `Rust neuron analysis ${result.gpuUsed ? "using GPU" : "using CPU fallback"} (${result.helpfulNeurons?.length ?? 0} candidates)`,
+        );
+      }
       return result;
     } catch (error) {
       this.log(
@@ -1508,6 +1514,12 @@ export class DiscoverStructure {
         console.log(
           "rust-analysis",
           JSON.stringify({ focusList, result }, (_key, value) => value, 2),
+        );
+      }
+      if (this.loggingEnabled && result.gpuUsed !== undefined) {
+        this.log(
+          "info",
+          `Rust synapse analysis ${result.gpuUsed ? "using GPU" : "using CPU fallback"} (${result.helpfulSynapses?.length ?? 0} helpful, ${result.harmfulSynapses?.length ?? 0} harmful candidates)`,
         );
       }
       return result;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Logs GPU vs CPU fallback for Rust analyses and adds a macOS GPU acceleration guide; minor version bump.
> 
> - **Discovery (TypeScript)**:
>   - Log GPU vs CPU fallback in `runRustNeuronAnalysis` and `runRustSynapseAnalysis` using `result.gpuUsed`, including candidate counts.
> - **Docs**:
>   - Add `GPU_ACCELERATION.md` detailing macOS GPU acceleration (wgpu/Metal), verification, performance, config, and troubleshooting.
>   - Update spellcheck dictionary in `docs/cspell.json` with `wgpu` and `WGSL`.
> - **Version**:
>   - Bump `deno.json` version to `0.196.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c535b7bc5d8517722c0bd76df18ca4535b68d1f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->