### PR TITLE
Remove redundant logging in DataRecorder class to streamline discover…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.196.1",
+  "version": "0.196.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -284,14 +284,6 @@ class DataRecorder {
     } finally {
       file.close();
     }
-
-    if (shouldLogDiscovery(this.options)) {
-      console.log(
-        `Discovery ${blue(this.ID)} read time ${
-          yellow(format(readTime, { ignoreZero: true }))
-        } for ${filePath} with ${params.counter.count} records`,
-      );
-    }
   }
 
   private async recordFiles(binaryFiles: string[]): Promise<DiscoverResult> {
@@ -401,14 +393,6 @@ class DataRecorder {
           neuronPromisesMap.set(uuid, Promise.resolve());
         }
         drainCounter.count = 0; // Reset drain counter after file
-
-        if (shouldLogDiscovery(this.options)) {
-          console.log(
-            `Discovery ${
-              blue(this.ID)
-            } drained promises after file ${filePath}`,
-          );
-        }
 
         if (this.timeoutTS && Date.now() > this.timeoutTS) {
           if (shouldLogDiscovery(this.options)) {


### PR DESCRIPTION
…y process

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes redundant discovery logs to reduce noise during directory processing; bumps version to 0.196.2.
> 
> - **Discovery logging** (`src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts`):
>   - Remove per-file read-time log after processing each file.
>   - Remove log when draining promises after each file to limit memory usage.
> - **Version**:
>   - Bump `deno.json` version from `0.196.1` to `0.196.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51417c1bb8d54d42764f2bd63e6f347f474949f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->