### PR TITLE
Add focus selection summary and diagnostics to DiscoverStructure

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.196.2",
+  "version": "0.196.3",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -98,6 +98,21 @@ class DataRecorder {
       .discoveryDisableSquashCandidates;
   }
 
+  private shouldAwaitCleanup(): boolean {
+    try {
+      const explicit = Deno.env.get("NEAT_DISCOVERY_AWAIT_CLEANUP");
+      if (explicit) {
+        const normalized = explicit.trim().toLowerCase();
+        return normalized === "1" || normalized === "true" ||
+          normalized === "yes";
+      }
+      const denoTest = Deno.env.get("DENO_TEST");
+      return denoTest?.toLowerCase() === "true";
+    } catch {
+      return false;
+    }
+  }
+
   private shuffleFiles(files: string[]): string[] {
     for (let i = files.length; i--;) {
       const j = Math.floor(Math.random() * (i + 1));
@@ -795,14 +810,18 @@ class DataRecorder {
         }
       })();
 
-      // Don't await cleanup - let it happen in the background
-      // Catch any errors to prevent unhandled rejections and resource leaks
-      cleanupPromise.catch((error) => {
-        console.error(
-          `❌ CRITICAL: Discovery ${this.ID} cleanup failed - potential resource leak:`,
-          error,
-        );
-      });
+      if (this.shouldAwaitCleanup()) {
+        await cleanupPromise;
+      } else {
+        // Don't await cleanup - let it happen in the background
+        // Catch any errors to prevent unhandled rejections and resource leaks
+        cleanupPromise.catch((error) => {
+          console.error(
+            `❌ CRITICAL: Discovery ${this.ID} cleanup failed - potential resource leak:`,
+            error,
+          );
+        });
+      }
 
       return discoverResult;
     } catch (error) {

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1639,7 +1639,9 @@ export class DiscoverStructure {
       totalWeight,
     };
     if (this.loggingEnabled && mode === "weighted") {
-      const preview = neurons.slice(0, Math.min(3, neurons.length)).map((entry) =>
+      const preview = neurons.slice(0, Math.min(3, neurons.length)).map((
+        entry,
+      ) =>
         entry.weight !== undefined
           ? `${entry.uuid} (weight ${entry.weight.toFixed(4)})`
           : entry.uuid
@@ -1662,7 +1664,9 @@ export class DiscoverStructure {
     if (!summary || summary.key !== focusKey) {
       this.log(
         "warn",
-        `Focus selection summary unavailable for ${scope} analysis (focus=${focusList.join(", ")})`,
+        `Focus selection summary unavailable for ${scope} analysis (focus=${
+          focusList.join(", ")
+        })`,
       );
       return;
     }
@@ -1674,9 +1678,7 @@ export class DiscoverStructure {
         ? `${entry.uuid} (weight ${entry.weight.toFixed(4)})`
         : entry.uuid
     );
-    const suffix = summary.neurons.length > displayEntries.length
-      ? ", …"
-      : "";
+    const suffix = summary.neurons.length > displayEntries.length ? ", …" : "";
     const totalInfo = summary.totalWeight !== undefined
       ? ` totalWeight=${summary.totalWeight.toFixed(4)}`
       : "";
@@ -1684,7 +1686,9 @@ export class DiscoverStructure {
       "warn",
       `Focus selection [${summary.mode}] ${
         summary.reason ? `(${summary.reason}) ` : ""
-      }for ${scope} analysis: ${displayEntries.join(", ")}${suffix}${totalInfo}`,
+      }for ${scope} analysis: ${
+        displayEntries.join(", ")
+      }${suffix}${totalInfo}`,
     );
   }
 
@@ -1700,9 +1704,7 @@ export class DiscoverStructure {
       : focusList.join(", ");
     this.log(
       "warn",
-      `Rust ${scope} analysis evaluated ${
-        focusList.length
-      } focus neuron(s) but found no improvements. Focus neurons: ${preview}`,
+      `Rust ${scope} analysis evaluated ${focusList.length} focus neuron(s) but found no improvements. Focus neurons: ${preview}`,
     );
     this.logFocusSelectionDetails(scope, focusList);
     this.logRustDiagnostics(scope, diagnostics);
@@ -1764,7 +1766,9 @@ export class DiscoverStructure {
       }
       if (detail.expectedImprovementPercentage !== undefined) {
         detailParts.push(
-          `expected=${(detail.expectedImprovementPercentage * 100).toFixed(2)}%`,
+          `expected=${
+            (detail.expectedImprovementPercentage * 100).toFixed(2)
+          }%`,
         );
       }
       if (detail.threshold !== undefined) {
@@ -1774,7 +1778,9 @@ export class DiscoverStructure {
         detailParts.push(`weight=${detail.suggestedWeight.toFixed(4)}`);
       }
     }
-    return `Rust synapse diagnostic for ${diagnostic.targetNeuronUuid}: ${reason} (${detailParts.join(", ")})`;
+    return `Rust synapse diagnostic for ${diagnostic.targetNeuronUuid}: ${reason} (${
+      detailParts.join(", ")
+    })`;
   }
 
   private formatNeuronDiagnostic(diagnostic: RustNeuronDiagnostic): string {
@@ -1807,7 +1813,9 @@ export class DiscoverStructure {
       }
       if (detail.expectedImprovementPercentage !== undefined) {
         detailParts.push(
-          `expected=${(detail.expectedImprovementPercentage * 100).toFixed(2)}%`,
+          `expected=${
+            (detail.expectedImprovementPercentage * 100).toFixed(2)
+          }%`,
         );
       }
       if (detail.threshold !== undefined) {
@@ -1817,7 +1825,9 @@ export class DiscoverStructure {
         detailParts.push(`outgoing=${detail.outgoingWeight.toFixed(4)}`);
       }
     }
-    return `Rust neuron diagnostic for ${diagnostic.targetNeuronUuid}: ${reason} (${detailParts.join(", ")})`;
+    return `Rust neuron diagnostic for ${diagnostic.targetNeuronUuid}: ${reason} (${
+      detailParts.join(", ")
+    })`;
   }
 
   private describeSynapseDiagnosticReason(

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -24,8 +24,10 @@ import {
   type RustAnalyzeSynapsesResult,
   type RustCandidateNeuron,
   type RustCandidateSynapse,
+  type RustNeuronDiagnostic,
   type RustRecordBatchStats,
   type RustRecordInput,
+  type RustSynapseDiagnostic,
 } from "./RustDiscovery.ts";
 import { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
 
@@ -109,6 +111,21 @@ export interface CandidateNeuron {
   totalCount: number;
 }
 
+type FocusSelectionMode = "weighted" | "forced" | "all" | "random";
+
+interface FocusSelectionSummaryEntry {
+  uuid: string;
+  weight?: number;
+}
+
+interface FocusSelectionSummary {
+  key: string;
+  mode: FocusSelectionMode;
+  reason: string;
+  neurons: FocusSelectionSummaryEntry[];
+  totalWeight?: number;
+}
+
 /**
  * Represents a neuron and its total accumulated error for ranking neurons during discovery.
  * Impact measures how much a neuron affects outputs through its outgoing synapse weights.
@@ -185,6 +202,7 @@ export class DiscoverStructure {
   private forcedFocusIndex = 0;
   private improvementThreshold = DEFAULT_RUST_HELPFUL_THRESHOLD;
   private harmfulThreshold = DEFAULT_RUST_HARMFUL_THRESHOLD;
+  private lastFocusSelection?: FocusSelectionSummary;
   constructor(
     creature: Creature,
     timeoutSeconds: number,
@@ -1249,17 +1267,24 @@ export class DiscoverStructure {
     focusList: string[],
   ): CandidateNeuron[] | undefined {
     const rustResult = this.runRustNeuronAnalysis(focusList);
-    if (!rustResult || !rustResult.helpfulNeurons) {
+    if (!rustResult) {
       return undefined;
     }
 
-    const candidates = rustResult.helpfulNeurons
+    const helpfulNeurons = rustResult.helpfulNeurons ?? [];
+    if (helpfulNeurons.length === 0) {
+      this.logRustNoImprovement("neuron", focusList, rustResult.diagnostics);
+      return [];
+    }
+
+    const candidates = helpfulNeurons
       .map((candidate) => this.mapRustNeuronCandidate(candidate))
       .filter((candidate) =>
         candidate.expectedImprovementPercentage > this.improvementThreshold
       );
 
     if (candidates.length === 0) {
+      this.logRustNoImprovement("neuron", focusList, rustResult.diagnostics);
       return [];
     }
 
@@ -1273,17 +1298,24 @@ export class DiscoverStructure {
     focusList: string[],
   ): CandidateSynapse[] | undefined {
     const rustResult = this.runRustSynapseAnalysis(focusList);
-    if (!rustResult || !rustResult.helpfulSynapses) {
+    if (!rustResult) {
       return undefined;
     }
 
-    const candidates = rustResult.helpfulSynapses
+    const helpfulSynapses = rustResult.helpfulSynapses ?? [];
+    if (helpfulSynapses.length === 0) {
+      this.logRustNoImprovement("synapse", focusList, rustResult.diagnostics);
+      return [];
+    }
+
+    const candidates = helpfulSynapses
       .map((candidate) => this.mapRustCandidate(candidate))
       .filter((candidate) =>
         candidate.expectedImprovementPercentage > this.improvementThreshold
       );
 
     if (candidates.length === 0) {
+      this.logRustNoImprovement("synapse", focusList, rustResult.diagnostics);
       return [];
     }
 
@@ -1581,6 +1613,250 @@ export class DiscoverStructure {
       default:
         console.log(...args);
         break;
+    }
+  }
+
+  private focusSelectionKey(focusList: readonly string[]): string {
+    return focusList.join("|");
+  }
+
+  private updateFocusSelectionSummary(
+    mode: FocusSelectionMode,
+    focusNeurons: readonly string[],
+    weightMap?: Map<string, number>,
+    reason: string = "",
+    totalWeight?: number,
+  ): void {
+    const neurons = focusNeurons.map((uuid) => ({
+      uuid,
+      weight: weightMap?.get(uuid),
+    }));
+    this.lastFocusSelection = {
+      key: this.focusSelectionKey(focusNeurons),
+      mode,
+      reason,
+      neurons,
+      totalWeight,
+    };
+    if (this.loggingEnabled && mode === "weighted") {
+      const preview = neurons.slice(0, Math.min(3, neurons.length)).map((entry) =>
+        entry.weight !== undefined
+          ? `${entry.uuid} (weight ${entry.weight.toFixed(4)})`
+          : entry.uuid
+      ).join(", ");
+      this.log(
+        "info",
+        `Weighted error x impact selection prioritised: ${preview}${
+          neurons.length > 3 ? ", …" : ""
+        }`,
+      );
+    }
+  }
+
+  private logFocusSelectionDetails(
+    scope: "synapse" | "neuron",
+    focusList: string[],
+  ): void {
+    const summary = this.lastFocusSelection;
+    const focusKey = this.focusSelectionKey(focusList);
+    if (!summary || summary.key !== focusKey) {
+      this.log(
+        "warn",
+        `Focus selection summary unavailable for ${scope} analysis (focus=${focusList.join(", ")})`,
+      );
+      return;
+    }
+    const displayEntries = summary.neurons.slice(
+      0,
+      Math.min(5, summary.neurons.length),
+    ).map((entry) =>
+      entry.weight !== undefined
+        ? `${entry.uuid} (weight ${entry.weight.toFixed(4)})`
+        : entry.uuid
+    );
+    const suffix = summary.neurons.length > displayEntries.length
+      ? ", …"
+      : "";
+    const totalInfo = summary.totalWeight !== undefined
+      ? ` totalWeight=${summary.totalWeight.toFixed(4)}`
+      : "";
+    this.log(
+      "warn",
+      `Focus selection [${summary.mode}] ${
+        summary.reason ? `(${summary.reason}) ` : ""
+      }for ${scope} analysis: ${displayEntries.join(", ")}${suffix}${totalInfo}`,
+    );
+  }
+
+  private logRustNoImprovement(
+    scope: "synapse" | "neuron",
+    focusList: string[],
+    diagnostics?: RustSynapseDiagnostic[] | RustNeuronDiagnostic[],
+  ): void {
+    const preview = focusList.length > 10
+      ? `${focusList.slice(0, 10).join(", ")} … (+${
+        focusList.length - 10
+      } more)`
+      : focusList.join(", ");
+    this.log(
+      "warn",
+      `Rust ${scope} analysis evaluated ${
+        focusList.length
+      } focus neuron(s) but found no improvements. Focus neurons: ${preview}`,
+    );
+    this.logFocusSelectionDetails(scope, focusList);
+    this.logRustDiagnostics(scope, diagnostics);
+  }
+
+  private isSynapseDiagnostic(
+    diagnostic: RustSynapseDiagnostic | RustNeuronDiagnostic,
+  ): diagnostic is RustSynapseDiagnostic {
+    return Object.prototype.hasOwnProperty.call(
+      diagnostic,
+      "evaluatedCandidates",
+    );
+  }
+
+  private logRustDiagnostics(
+    scope: "synapse" | "neuron",
+    diagnostics?: RustSynapseDiagnostic[] | RustNeuronDiagnostic[],
+  ): void {
+    if (!diagnostics || diagnostics.length === 0) {
+      this.log(
+        "warn",
+        `Rust ${scope} analysis did not return diagnostic detail for the evaluated neurons.`,
+      );
+      return;
+    }
+    diagnostics.forEach((diagnostic) => {
+      if (this.isSynapseDiagnostic(diagnostic)) {
+        this.log("warn", this.formatSynapseDiagnostic(diagnostic));
+      } else {
+        this.log("warn", this.formatNeuronDiagnostic(diagnostic));
+      }
+    });
+  }
+
+  private formatSynapseDiagnostic(diagnostic: RustSynapseDiagnostic): string {
+    const reason = this.describeSynapseDiagnosticReason(diagnostic.reason);
+    const detailParts = [
+      `evaluated=${diagnostic.evaluatedCandidates}`,
+      `withSamples=${diagnostic.candidatesWithSamples}`,
+      `targetRecords=${diagnostic.targetRecordCount}`,
+    ];
+    if (diagnostic.detail) {
+      const detail = diagnostic.detail;
+      if (detail.sourceNeuronUuid) {
+        detailParts.push(`source=${detail.sourceNeuronUuid}`);
+      }
+      if (detail.sampleCount !== undefined) {
+        detailParts.push(`samples=${detail.sampleCount}`);
+      }
+      if (
+        detail.improvedCount !== undefined ||
+        detail.worsenedCount !== undefined
+      ) {
+        detailParts.push(
+          `improved=${detail.improvedCount ?? 0}/worsened=${
+            detail.worsenedCount ?? 0
+          }`,
+        );
+      }
+      if (detail.expectedImprovementPercentage !== undefined) {
+        detailParts.push(
+          `expected=${(detail.expectedImprovementPercentage * 100).toFixed(2)}%`,
+        );
+      }
+      if (detail.threshold !== undefined) {
+        detailParts.push(`threshold=${(detail.threshold * 100).toFixed(2)}%`);
+      }
+      if (detail.suggestedWeight !== undefined) {
+        detailParts.push(`weight=${detail.suggestedWeight.toFixed(4)}`);
+      }
+    }
+    return `Rust synapse diagnostic for ${diagnostic.targetNeuronUuid}: ${reason} (${detailParts.join(", ")})`;
+  }
+
+  private formatNeuronDiagnostic(diagnostic: RustNeuronDiagnostic): string {
+    const reason = this.describeNeuronDiagnosticReason(diagnostic.reason);
+    const detailParts = [
+      `evaluated=${diagnostic.evaluatedSources}`,
+      `withSamples=${diagnostic.sourcesWithSamples}`,
+      `targetRecords=${diagnostic.targetRecordCount}`,
+    ];
+    if (diagnostic.detail) {
+      const detail = diagnostic.detail;
+      if (detail.sourceNeuronUuid) {
+        detailParts.push(`source=${detail.sourceNeuronUuid}`);
+      }
+      if (detail.orientation) {
+        detailParts.push(`orientation=${detail.orientation}`);
+      }
+      if (detail.sampleCount !== undefined) {
+        detailParts.push(`samples=${detail.sampleCount}`);
+      }
+      if (
+        detail.improvedCount !== undefined ||
+        detail.worsenedCount !== undefined
+      ) {
+        detailParts.push(
+          `improved=${detail.improvedCount ?? 0}/worsened=${
+            detail.worsenedCount ?? 0
+          }`,
+        );
+      }
+      if (detail.expectedImprovementPercentage !== undefined) {
+        detailParts.push(
+          `expected=${(detail.expectedImprovementPercentage * 100).toFixed(2)}%`,
+        );
+      }
+      if (detail.threshold !== undefined) {
+        detailParts.push(`threshold=${(detail.threshold * 100).toFixed(2)}%`);
+      }
+      if (detail.outgoingWeight !== undefined) {
+        detailParts.push(`outgoing=${detail.outgoingWeight.toFixed(4)}`);
+      }
+    }
+    return `Rust neuron diagnostic for ${diagnostic.targetNeuronUuid}: ${reason} (${detailParts.join(", ")})`;
+  }
+
+  private describeSynapseDiagnosticReason(
+    reason: RustSynapseDiagnostic["reason"],
+  ): string {
+    switch (reason) {
+      case "no_eligible_sources":
+        return "No eligible upstream sources";
+      case "no_diagnostics":
+        return "No diagnostics recorded";
+      case "no_samples":
+        return "No aligned samples found";
+      case "zero_improvement":
+        return "Zero net improvement observed";
+      case "below_threshold":
+        return "Expected improvement below threshold";
+      default:
+        return reason;
+    }
+  }
+
+  private describeNeuronDiagnosticReason(
+    reason: RustNeuronDiagnostic["reason"],
+  ): string {
+    switch (reason) {
+      case "no_eligible_sources":
+        return "No eligible upstream sources";
+      case "no_diagnostics":
+        return "No diagnostics recorded";
+      case "no_samples":
+        return "No aligned samples detected";
+      case "not_enough_activations":
+        return "Not enough activations to evaluate";
+      case "weight_degenerate":
+        return "Degenerate outgoing weight";
+      case "below_threshold":
+        return "Expected improvement below threshold";
+      default:
+        return reason;
     }
   }
 
@@ -2070,6 +2346,7 @@ export class DiscoverStructure {
    */
   public async selectNeuronsWeightedByError(count: number): Promise<string[]> {
     assert(count > 0, "Count must be greater than 0");
+    this.lastFocusSelection = undefined;
     if (
       this.forcedFocusNeurons && this.forcedFocusIndex <
         this.forcedFocusNeurons.length
@@ -2099,6 +2376,12 @@ export class DiscoverStructure {
         this.forcedFocusNeurons = null;
       }
       if (trimmed.length > 0) {
+        this.updateFocusSelectionSummary(
+          "forced",
+          trimmed,
+          undefined,
+          "forced focus override",
+        );
         return trimmed;
       }
     }
@@ -2106,7 +2389,18 @@ export class DiscoverStructure {
     if (neuronErrors.length === 0) return [];
 
     if (neuronErrors.length <= count) {
-      return neuronErrors.map((neuron) => neuron.uuid);
+      const uuids = neuronErrors.map((neuron) => neuron.uuid);
+      const EPSILON = 0.0001;
+      const weightMap = new Map(
+        neuronErrors.map((n) => [n.uuid, n.totalError * (n.impact + EPSILON)]),
+      );
+      this.updateFocusSelectionSummary(
+        "all",
+        uuids,
+        weightMap,
+        "all viable neurons selected",
+      );
+      return uuids;
     }
     const selectedUUIDs: Set<string> = new Set();
 
@@ -2141,7 +2435,14 @@ export class DiscoverStructure {
         `   Falling back to random neuron selection to continue discovery`,
       );
       const shuffled = [...neuronErrors].sort(() => Math.random() - 0.5);
-      return shuffled.slice(0, count).map((n) => n.uuid);
+      const fallback = shuffled.slice(0, count).map((n) => n.uuid);
+      this.updateFocusSelectionSummary(
+        "random",
+        fallback,
+        undefined,
+        "random selection due to invalid total weight",
+      );
+      return fallback;
     }
 
     if (totalWeightedSum <= 0) {
@@ -2151,7 +2452,14 @@ export class DiscoverStructure {
       console.warn(`   Falling back to random neuron selection`);
       // Fallback to random selection without weighting
       const shuffled = [...neuronErrors].sort(() => Math.random() - 0.5);
-      return shuffled.slice(0, count).map((n) => n.uuid);
+      const fallback = shuffled.slice(0, count).map((n) => n.uuid);
+      this.updateFocusSelectionSummary(
+        "random",
+        fallback,
+        undefined,
+        "random selection due to zero total weight",
+      );
+      return fallback;
     }
 
     // Use while loop with max iterations to prevent infinite loops
@@ -2210,7 +2518,18 @@ export class DiscoverStructure {
       );
     }
 
-    return Array.from(selectedUUIDs);
+    const selection = Array.from(selectedUUIDs);
+    const weightMap = new Map(
+      weightedValues.map((n) => [n.uuid, n.weight]),
+    );
+    this.updateFocusSelectionSummary(
+      "weighted",
+      selection,
+      weightMap,
+      "error x impact weighting",
+      totalWeightedSum,
+    );
+    return selection;
   }
 
   /**

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1624,8 +1624,8 @@ export class DiscoverStructure {
     mode: FocusSelectionMode,
     focusNeurons: readonly string[],
     weightMap?: Map<string, number>,
-    reason: string = "",
     totalWeight?: number,
+    reason = "",
   ): void {
     const neurons = focusNeurons.map((uuid) => ({
       uuid,
@@ -2380,6 +2380,7 @@ export class DiscoverStructure {
           "forced",
           trimmed,
           undefined,
+          undefined,
           "forced focus override",
         );
         return trimmed;
@@ -2398,6 +2399,7 @@ export class DiscoverStructure {
         "all",
         uuids,
         weightMap,
+        undefined,
         "all viable neurons selected",
       );
       return uuids;
@@ -2440,6 +2442,7 @@ export class DiscoverStructure {
         "random",
         fallback,
         undefined,
+        undefined,
         "random selection due to invalid total weight",
       );
       return fallback;
@@ -2456,6 +2459,7 @@ export class DiscoverStructure {
       this.updateFocusSelectionSummary(
         "random",
         fallback,
+        undefined,
         undefined,
         "random selection due to zero total weight",
       );
@@ -2526,8 +2530,8 @@ export class DiscoverStructure {
       "weighted",
       selection,
       weightMap,
-      "error x impact weighting",
       totalWeightedSum,
+      "error x impact weighting",
     );
     return selection;
   }

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -90,6 +90,7 @@ export interface RustAnalyzeSynapsesResult {
   gpuUsed?: boolean;
   helpfulSynapses?: RustCandidateSynapse[];
   harmfulSynapses?: RustCandidateSynapse[];
+  diagnostics?: RustSynapseDiagnostic[];
   error?: string;
 }
 
@@ -106,7 +107,63 @@ export interface RustAnalyzeNeuronsResult {
   success: boolean;
   gpuUsed?: boolean;
   helpfulNeurons?: RustCandidateNeuron[];
+  diagnostics?: RustNeuronDiagnostic[];
   error?: string;
+}
+
+export type RustSynapseDiagnosticReason =
+  | "no_eligible_sources"
+  | "no_diagnostics"
+  | "no_samples"
+  | "zero_improvement"
+  | "below_threshold";
+
+export interface RustSynapseDiagnosticDetail {
+  sourceNeuronUuid?: string;
+  sampleCount?: number;
+  sourceRecordCount?: number;
+  improvedCount?: number;
+  worsenedCount?: number;
+  expectedImprovementPercentage?: number;
+  threshold?: number;
+  suggestedWeight?: number;
+}
+
+export interface RustSynapseDiagnostic {
+  targetNeuronUuid: string;
+  reason: RustSynapseDiagnosticReason;
+  evaluatedCandidates: number;
+  candidatesWithSamples: number;
+  targetRecordCount: number;
+  detail?: RustSynapseDiagnosticDetail;
+}
+
+export type RustNeuronDiagnosticReason =
+  | "no_eligible_sources"
+  | "no_diagnostics"
+  | "no_samples"
+  | "not_enough_activations"
+  | "weight_degenerate"
+  | "below_threshold";
+
+export interface RustNeuronDiagnosticDetail {
+  sourceNeuronUuid?: string;
+  orientation?: string;
+  sampleCount?: number;
+  improvedCount?: number;
+  worsenedCount?: number;
+  expectedImprovementPercentage?: number;
+  threshold?: number;
+  outgoingWeight?: number;
+}
+
+export interface RustNeuronDiagnostic {
+  targetNeuronUuid: string;
+  reason: RustNeuronDiagnosticReason;
+  evaluatedSources: number;
+  sourcesWithSamples: number;
+  targetRecordCount: number;
+  detail?: RustNeuronDiagnosticDetail;
 }
 
 /**

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryDiagnostics.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryDiagnostics.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertStringIncludes } from "@std/assert";
+import { assert } from "@std/assert";
 import { stub } from "@std/testing/mock";
 import { Creature } from "../../src/Creature.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
@@ -44,13 +44,14 @@ Deno.test("logs diagnostics when Rust finds no improvements", () => {
   });
   try {
     const logNoImprovement = internals["logRustNoImprovement"] as (
+      this: DiscoverStructure,
       scope: "synapse" | "neuron",
       targets: string[],
       diagnostics?: unknown[],
     ) => void;
     assert(logNoImprovement, "Expected logRustNoImprovement to exist");
 
-    logNoImprovement("synapse", focusList, [{
+    logNoImprovement.call(structure, "synapse", focusList, [{
       targetNeuronUuid: "output-0",
       reason: "no_samples",
       evaluatedCandidates: 4,
@@ -66,16 +67,17 @@ Deno.test("logs diagnostics when Rust finds no improvements", () => {
     warnStub.restore();
   }
 
+  const lowerWarnings = warnings.map((line) => line.toLowerCase());
   assert(
-    warnings.length >= 2,
-    `Expected at least two warning lines, received ${warnings.length}`,
+    lowerWarnings.some((line) => line.includes("no improvements")),
+    `Expected at least one warning mentioning "no improvements", received ${
+      warnings.join(" | ")
+    }`,
   );
-  assertStringIncludes(
-    warnings[0],
-    "no improvements",
-  );
-  assertStringIncludes(
-    warnings[1],
-    "no aligned samples",
+  assert(
+    lowerWarnings.some((line) => line.includes("no aligned samples")),
+    `Expected at least one warning mentioning "no aligned samples", received ${
+      warnings.join(" | ")
+    }`,
   );
 });

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryDiagnostics.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryDiagnostics.test.ts
@@ -79,4 +79,3 @@ Deno.test("logs diagnostics when Rust finds no improvements", () => {
     "no aligned samples",
   );
 });
-

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryDiagnostics.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryDiagnostics.test.ts
@@ -1,0 +1,82 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import {
+  DEFAULT_RUST_FLUSH_RECORDS,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+
+Deno.test("logs diagnostics when Rust finds no improvements", () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [{
+      type: "output",
+      uuid: "output-0",
+      squash: "IDENTITY",
+      bias: 0,
+    }],
+    synapses: [],
+  });
+  CreatureUtil.makeUUID(creature);
+
+  const structure = new DiscoverStructure(
+    creature,
+    60,
+    DEFAULT_RUST_FLUSH_RECORDS,
+  );
+  structure.configureLogging({ discoveryID: "diag-test", verbose: false });
+
+  const focusList = ["output-0"];
+  const internals = structure as unknown as Record<string, unknown>;
+  internals["lastFocusSelection"] = {
+    key: focusList.join("|"),
+    mode: "weighted",
+    reason: "error x impact weighting",
+    neurons: [{ uuid: "output-0", weight: 1.23 }],
+    totalWeight: 1.23,
+  };
+
+  const warnings: string[] = [];
+  const warnStub = stub(console, "warn", (...args: unknown[]) => {
+    warnings.push(args.map((arg) => String(arg)).join(" "));
+  });
+  try {
+    const logNoImprovement = internals["logRustNoImprovement"] as (
+      scope: "synapse" | "neuron",
+      targets: string[],
+      diagnostics?: unknown[],
+    ) => void;
+    assert(logNoImprovement, "Expected logRustNoImprovement to exist");
+
+    logNoImprovement("synapse", focusList, [{
+      targetNeuronUuid: "output-0",
+      reason: "no_samples",
+      evaluatedCandidates: 4,
+      candidatesWithSamples: 0,
+      targetRecordCount: 128,
+      detail: {
+        sourceNeuronUuid: "hidden-1",
+        sampleCount: 0,
+        expectedImprovementPercentage: 0,
+      },
+    }]);
+  } finally {
+    warnStub.restore();
+  }
+
+  assert(
+    warnings.length >= 2,
+    `Expected at least two warning lines, received ${warnings.length}`,
+  );
+  assertStringIncludes(
+    warnings[0],
+    "no improvements",
+  );
+  assertStringIncludes(
+    warnings[1],
+    "no aligned samples",
+  );
+});
+

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.test.ts
@@ -16,6 +16,19 @@ import type {
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 
 Deno.test("Discovery flushes Rust recording in configured chunks", async () => {
+  const envKey = "NEAT_DISCOVERY_AWAIT_CLEANUP";
+  const previousValue = (() => {
+    try {
+      return Deno.env.get(envKey);
+    } catch {
+      return undefined;
+    }
+  })();
+  try {
+    Deno.env.set(envKey, "1");
+  } catch {
+    // ignore if env not accessible
+  }
   const tempDir = await Deno.makeTempDir({ prefix: "discovery-chunk-test-" });
   try {
     const dataFile = join(tempDir, "sample.bin");
@@ -109,6 +122,19 @@ Deno.test("Discovery flushes Rust recording in configured chunks", async () => {
     assertEquals(mergedChunks.length, 1);
     assertEquals(mergedChunks[0].length, 2);
   } finally {
+    if (previousValue === undefined) {
+      try {
+        Deno.env.delete(envKey);
+      } catch {
+        // ignore
+      }
+    } else {
+      try {
+        Deno.env.set(envKey, previousValue);
+      } catch {
+        // ignore
+      }
+    }
     await Deno.remove(tempDir, { recursive: true });
   }
 });


### PR DESCRIPTION
- Introduced new types and interfaces for focus selection, including `FocusSelectionMode` and `FocusSelectionSummary`, to enhance neuron and synapse selection processes.
- Updated methods to log focus selection details and diagnostics, improving transparency in the discovery process.
- Enhanced error handling by logging cases where no improvements are found during neuron and synapse analysis, providing clearer insights into selection outcomes.
- Refactored existing methods to utilize the new focus selection summary, ensuring consistent tracking of selection criteria and weights.

This update optimizes the discovery process by integrating detailed logging and diagnostics, leading to more informed decision-making during neuron and synapse selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds focus selection summary tracking and detailed Rust diagnostics/logging, introduces env-driven conditional cleanup awaiting, and updates tests accordingly.
> 
> - **Discovery (core)**:
>   - **Focus selection**: Track and log selection summaries (`FocusSelectionMode`, `FocusSelectionSummary`), including weights/total; integrate across forced/all/random/weighted paths.
>   - **Rust diagnostics**: Plumb and log diagnostics for neuron/synapse analyses; emit detailed reasons when no improvements are found.
> - **Rust FFI Types**:
>   - Add `diagnostics` to `analyzeSynapses/Neurons` results; define `RustSynapseDiagnostic*` and `RustNeuronDiagnostic*` types.
> - **Runner** (`src/architecture/.../DiscoverDirectory.ts`):
>   - Conditionally await cleanup based on `NEAT_DISCOVERY_AWAIT_CLEANUP`/`DENO_TEST`.
> - **Tests**:
>   - New `DiscoveryDiagnostics.test.ts` validating no-improvement diagnostics logging.
>   - Update `DiscoveryRustFlush.test.ts` to set env and ensure cleanup handling.
> - **Version**: Bump to `0.196.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bff598796b40091e2b8d05e239491e0504c676c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->