### PR TITLE
Update version to 0.197.0 and enhance neuron impact calculations in D…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.196.3",
+  "version": "0.197.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -97,6 +97,7 @@
     "unscored",
     "Millis",
     "wgpu",
-    "WGSL"
+    "WGSL",
+    "honors"
   ]
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -136,6 +136,12 @@ interface NeuronErrorInfo {
   impact: number;
 }
 
+interface NeuronImpactInfo {
+  uuid: string;
+  neuronType: string;
+  impact: number;
+}
+
 export interface RustFlushMetrics extends RustRecordBatchStats {
   recordsWithNoNeuronData: number;
   recordsWithMismatchedNeuronCount: number;
@@ -242,6 +248,51 @@ export class DiscoverStructure {
     }
   }
 
+  private isSelectableNeuronType(neuronType: string | undefined): boolean {
+    return neuronType !== "input" && neuronType !== "constant";
+  }
+
+  private isSelectableNeuron(neuron: { type: string }): boolean {
+    return this.isSelectableNeuronType(neuron.type);
+  }
+
+  private async computeMaxOutputError(): Promise<number> {
+    if (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled()) {
+      return 0;
+    }
+
+    const outputs = this.creature.neurons.filter((neuron) =>
+      neuron.type === "output"
+    );
+    const promises = outputs.map(async (outputNeuron) => {
+      let neuronMax = 0;
+      try {
+        const records = await this.loadCSV(
+          `${this.tempDir}/${outputNeuron.uuid}.csv`,
+        );
+        records.forEach((record) => {
+          record.errors.forEach((err) => {
+            if (Number.isFinite(err)) {
+              neuronMax = Math.max(neuronMax, Math.abs(err));
+            }
+          });
+        });
+      } catch (error) {
+        if (this.loggingEnabled) {
+          this.log(
+            "debug",
+            `Failed to read output neuron errors for ${outputNeuron.uuid}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      return neuronMax;
+    });
+    const results = await Promise.all(promises);
+    return results.reduce((max, value) => Math.max(max, value), 0);
+  }
+
   /**
    * Extends the timeout to allow analysis phase to complete.
    * Call this after recording phase completes to ensure analysis gets adequate time.
@@ -275,7 +326,7 @@ export class DiscoverStructure {
 
     const validNeuronUUIDs = new Set(
       this.creature.neurons
-        .filter((neuron) => neuron.type !== "input")
+        .filter((neuron) => this.isSelectableNeuron(neuron))
         .map((neuron) => neuron.uuid),
     );
 
@@ -1164,29 +1215,29 @@ export class DiscoverStructure {
 
     if (Date.now() > this.timeoutTS) {
       this.log("warn", "Discovery timeout reached in analyzeSelectedNeurons");
+      this.logFocusSelectionDetails("synapse", focusList);
       return Promise.resolve(undefined);
     }
 
     if (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled()) {
-      if (this.loggingEnabled) {
-        this.log(
-          "debug",
-          "Rust discovery unavailable; skipping analyzeSelectedNeurons",
-        );
-      }
+      this.logRustAnalysisUnavailable(
+        "synapse",
+        focusList,
+        "Rust discovery unavailable",
+      );
       return Promise.resolve(undefined);
     }
 
     const rustCandidates = this.tryRustHelpfulSynapses(focusList);
-    if (!rustCandidates || rustCandidates.length === 0) {
-      if (this.loggingEnabled) {
-        this.log(
-          "debug",
-          `Rust helpful synapse analysis returned no candidates for ${
-            focusList.join(", ")
-          }.`,
-        );
-      }
+    if (!rustCandidates) {
+      this.logRustAnalysisUnavailable(
+        "synapse",
+        focusList,
+        "analysis did not return a result",
+      );
+      return Promise.resolve(undefined);
+    }
+    if (rustCandidates.length === 0) {
       return Promise.resolve(undefined);
     }
 
@@ -1203,29 +1254,29 @@ export class DiscoverStructure {
 
     if (Date.now() > this.timeoutTS) {
       this.log("warn", "Discovery timeout reached in analyzeMissingNeurons");
+      this.logFocusSelectionDetails("neuron", focusList);
       return Promise.resolve(undefined);
     }
 
     if (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled()) {
-      if (this.loggingEnabled) {
-        this.log(
-          "debug",
-          "Rust discovery unavailable; skipping analyzeMissingNeurons",
-        );
-      }
+      this.logRustAnalysisUnavailable(
+        "neuron",
+        focusList,
+        "Rust discovery unavailable",
+      );
       return Promise.resolve(undefined);
     }
 
     const rustCandidates = this.tryRustHelpfulNeurons(focusList);
-    if (!rustCandidates || rustCandidates.length === 0) {
-      if (this.loggingEnabled) {
-        this.log(
-          "debug",
-          `Rust neuron analysis returned no candidates for ${
-            focusList.join(", ")
-          }.`,
-        );
-      }
+    if (!rustCandidates) {
+      this.logRustAnalysisUnavailable(
+        "neuron",
+        focusList,
+        "analysis did not return a result",
+      );
+      return Promise.resolve(undefined);
+    }
+    if (rustCandidates.length === 0) {
       return Promise.resolve(undefined);
     }
 
@@ -1710,6 +1761,26 @@ export class DiscoverStructure {
     this.logRustDiagnostics(scope, diagnostics);
   }
 
+  private logRustAnalysisUnavailable(
+    scope: "synapse" | "neuron",
+    focusList: string[],
+    reason: string,
+  ): void {
+    if (focusList.length === 0) {
+      return;
+    }
+    const preview = focusList.length > 10
+      ? `${focusList.slice(0, 10).join(", ")} … (+${
+        focusList.length - 10
+      } more)`
+      : focusList.join(", ");
+    this.log(
+      "warn",
+      `Rust ${scope} analysis unavailable (${reason}) for focus neuron(s): ${preview}`,
+    );
+    this.logFocusSelectionDetails(scope, focusList);
+  }
+
   private isSynapseDiagnostic(
     diagnostic: RustSynapseDiagnostic | RustNeuronDiagnostic,
   ): diagnostic is RustSynapseDiagnostic {
@@ -1952,6 +2023,53 @@ export class DiscoverStructure {
     lines.length = 0;
 
     return newPartialLine;
+  }
+
+  public listNeuronsByImpact(): NeuronImpactInfo[] {
+    const entries: NeuronImpactInfo[] = this.creature.neurons
+      .filter((neuron) => this.isSelectableNeuron(neuron))
+      .map((neuron) => ({
+        uuid: neuron.uuid,
+        neuronType: neuron.type,
+        impact: this.calculateNeuronImpact(neuron.uuid),
+      }))
+      .map((entry) => ({
+        ...entry,
+        impact: Number.isFinite(entry.impact) && entry.impact > 0
+          ? entry.impact
+          : 0,
+      }));
+
+    entries.sort((a, b) => {
+      const delta = b.impact - a.impact;
+      if (Math.abs(delta) > 1e-6) {
+        return delta;
+      }
+      if (a.neuronType !== b.neuronType) {
+        return a.neuronType === "output" ? -1 : 1;
+      }
+      return a.uuid.localeCompare(b.uuid);
+    });
+
+    this.sanityCheckImpactOrdering(entries);
+    return entries;
+  }
+
+  private sanityCheckImpactOrdering(entries: NeuronImpactInfo[]): void {
+    const outputCount =
+      this.creature.neurons.filter((n) => n.type === "output").length;
+    if (outputCount === 0 || entries.length === 0) {
+      return;
+    }
+
+    const topSlice = entries.slice(0, Math.min(outputCount, entries.length));
+    const violation = topSlice.find((entry) => entry.neuronType !== "output");
+    if (violation) {
+      const message =
+        "Impact ordering sanity check failed: expected output neurons at the top of the list.";
+      this.log("error", message, { topSlice });
+      throw new Error(message);
+    }
   }
 
   private async openFileWithRetry(
@@ -2218,7 +2336,14 @@ export class DiscoverStructure {
           // Create a new path visited set for each branch to allow exploring all paths
           const branchPathVisited = new Set(pathVisited);
           const toImpact = calculateImpactRecursive(toUUID, branchPathVisited);
-          const weightContribution = Math.abs(synapse.weight) * toImpact;
+          if (!Number.isFinite(toImpact) || toImpact <= 0) {
+            continue;
+          }
+          const absWeight = Math.abs(synapse.weight);
+          let weightContribution = absWeight * toImpact;
+          if (weightContribution > toImpact) {
+            weightContribution = toImpact;
+          }
           maxImpact = Math.max(maxImpact, weightContribution);
         }
       }
@@ -2242,7 +2367,7 @@ export class DiscoverStructure {
     }
 
     const neurons = this.creature.neurons.filter((neuron) =>
-      neuron.type !== "input"
+      this.isSelectableNeuron(neuron)
     );
 
     // Process neurons in batches to avoid overwhelming the file system
@@ -2399,36 +2524,52 @@ export class DiscoverStructure {
     const neuronErrors = await this.listViableNeurons();
     if (neuronErrors.length === 0) return [];
 
+    const maxOutputError = await this.computeMaxOutputError();
+    const hasOutputCap = maxOutputError > 0;
+    const EPSILON = 0.0001;
+    const rawWeights = neuronErrors.map((n) => ({
+      uuid: n.uuid,
+      raw: n.totalError * (n.impact + EPSILON),
+    }));
+    const rawSum = rawWeights.reduce((sum, entry) => sum + entry.raw, 0);
+    const capTotal = hasOutputCap
+      ? Math.max(maxOutputError, EPSILON)
+      : rawSum || EPSILON;
+    const scale = hasOutputCap && rawSum > capTotal && rawSum > EPSILON
+      ? capTotal / rawSum
+      : 1;
+    if (scale < 1 && this.loggingEnabled) {
+      this.log(
+        "debug",
+        `Scaling weighted errors by ${
+          scale.toFixed(4)
+        } to respect output error cap ${maxOutputError.toFixed(4)}`,
+      );
+    }
+    const weightedValues = rawWeights.map((entry) => ({
+      uuid: entry.uuid,
+      weight: entry.raw * scale,
+    }));
+    const totalWeightedSum = weightedValues.reduce(
+      (sum, entry) => sum + entry.weight,
+      0,
+    );
+    const weightMapAll = new Map(
+      weightedValues.map((entry) => [entry.uuid, entry.weight]),
+    );
+
     if (neuronErrors.length <= count) {
       const uuids = neuronErrors.map((neuron) => neuron.uuid);
-      const EPSILON = 0.0001;
-      const weightMap = new Map(
-        neuronErrors.map((n) => [n.uuid, n.totalError * (n.impact + EPSILON)]),
-      );
       this.updateFocusSelectionSummary(
         "all",
         uuids,
-        weightMap,
-        undefined,
+        weightMapAll,
+        totalWeightedSum,
         "all viable neurons selected",
       );
       return uuids;
     }
     const selectedUUIDs: Set<string> = new Set();
-
-    // Calculate weighted values: error × impact
-    // Add a small epsilon to impact to ensure neurons with zero impact can still be selected
-    // (just with much lower probability)
-    const EPSILON = 0.0001;
-    const weightedValues = neuronErrors.map((n) => ({
-      uuid: n.uuid,
-      weight: n.totalError * (n.impact + EPSILON),
-    }));
-
-    const totalWeightedSum = weightedValues.reduce(
-      (sum, n) => sum + n.weight,
-      0,
-    );
 
     // Guard against NaN, Infinity, or zero total weighted sum
     if (!Number.isFinite(totalWeightedSum)) {
@@ -2584,9 +2725,11 @@ export class DiscoverStructure {
 
     // Check timeout before starting analysis
     if (Date.now() > this.timeoutTS) {
-      console.warn(
-        `Discovery timeout reached in analyzeSelectedNeuronsSquashes`,
+      this.log(
+        "warn",
+        "Discovery timeout reached in analyzeSelectedNeuronsSquashes",
       );
+      this.logFocusSelectionDetails("neuron", focusList);
       return undefined;
     }
 
@@ -3012,29 +3155,29 @@ export class DiscoverStructure {
         "warn",
         "Discovery timeout reached in analyzeSelectedNeuronsForRemoval",
       );
+      this.logFocusSelectionDetails("synapse", focusList);
       return Promise.resolve(undefined);
     }
 
     if (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled()) {
-      if (this.loggingEnabled) {
-        this.log(
-          "debug",
-          "Rust discovery unavailable; skipping analyzeSelectedNeuronsForRemoval",
-        );
-      }
+      this.logRustAnalysisUnavailable(
+        "synapse",
+        focusList,
+        "Rust discovery unavailable",
+      );
       return Promise.resolve(undefined);
     }
 
     const rustCandidates = this.tryRustHarmfulCandidates(focusList);
-    if (!rustCandidates || rustCandidates.length === 0) {
-      if (this.loggingEnabled) {
-        this.log(
-          "debug",
-          `Rust harmful synapse analysis returned no candidates for ${
-            focusList.join(", ")
-          }.`,
-        );
-      }
+    if (!rustCandidates) {
+      this.logRustAnalysisUnavailable(
+        "synapse",
+        focusList,
+        "analysis did not return a result",
+      );
+      return Promise.resolve(undefined);
+    }
+    if (rustCandidates.length === 0) {
       return Promise.resolve(undefined);
     }
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -997,23 +997,10 @@ Deno.test({
 });
 
 Deno.test({
-  name:
-    "listNeuronsByImpact honors outputs from complex creatures loaded from assets",
+  name: "listNeuronsByImpact honors outputs for larger in-repo fixtures",
   fn: async () => {
-    const fittestPath =
-      "/Users/nigelleck/src/NEAT-AI-Examples/assets/fittest_creature.json";
-    let jsonText: string;
-    try {
-      jsonText = await Deno.readTextFile(fittestPath);
-    } catch (error) {
-      console.warn(
-        `[ImpactTests] Skipping complex creature impact ordering test: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      return;
-    }
-
+    const fixtureUrl = new URL("../data/large.json", import.meta.url);
+    const jsonText = await Deno.readTextFile(fixtureUrl);
     const creature = Creature.fromJSON(JSON.parse(jsonText));
     CreatureUtil.makeUUID(creature);
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_RUST_FLUSH_RECORDS,
   type DiscoverRecord,
   DiscoverStructure,
+  type DiscoverStructureDeps,
   type RustFlushMetrics,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
@@ -678,6 +679,526 @@ Deno.test({
     } finally {
       await Deno.remove(dsAny.tempDir, { recursive: true }).catch(() => {});
     }
+  },
+});
+
+Deno.test({
+  name:
+    "calculateNeuronImpact caps bounded downstream contributions during focus selection",
+  fn: async () => {
+    const creatureJson: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "hidden-upstream",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "hidden",
+          uuid: "hidden-linear",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "hidden",
+          uuid: "hidden-tanh",
+          squash: TANH.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "hidden-linear", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "hidden-upstream", toUUID: "hidden-tanh", weight: 1e6 },
+        { fromUUID: "hidden-tanh", toUUID: "output-0", weight: 0.02 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    const dsAny = discoverStructure as unknown as {
+      calculateNeuronImpact: (uuid: string) => number;
+      tempDir: string;
+    };
+
+    try {
+      const tanhImpact = dsAny.calculateNeuronImpact("hidden-tanh");
+      assertAlmostEquals(tanhImpact, 0.02, 1e-6);
+
+      const upstreamImpact = dsAny.calculateNeuronImpact("hidden-upstream");
+      assertAlmostEquals(
+        upstreamImpact,
+        tanhImpact,
+        1e-6,
+        "Upstream impact should be capped by bounded TANH path",
+      );
+
+      const linearImpact = dsAny.calculateNeuronImpact("hidden-linear");
+      assertAlmostEquals(
+        linearImpact,
+        0.5,
+        1e-6,
+        "Linear neuron impact should equal its outgoing weight",
+      );
+    } finally {
+      await Deno.remove(dsAny.tempDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "selectNeuronsWeightedByError records bounded impact weights for saturating paths",
+  fn: async () => {
+    const creatureJson: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "hidden-linear",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "hidden",
+          uuid: "hidden-upstream",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "hidden",
+          uuid: "hidden-tanh",
+          squash: TANH.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "hidden-linear", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "hidden-upstream", toUUID: "hidden-tanh", weight: 1e6 },
+        { fromUUID: "hidden-tanh", toUUID: "output-0", weight: 0.02 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    const dsAny = discoverStructure as unknown as {
+      calculateNeuronImpact: (uuid: string) => number;
+      listViableNeurons: () => Promise<
+        Array<{ uuid: string; totalError: number; impact: number }>
+      >;
+      tempDir: string;
+    };
+
+    const tanhImpact = dsAny.calculateNeuronImpact("hidden-tanh");
+    const upstreamImpact = dsAny.calculateNeuronImpact("hidden-upstream");
+    const linearImpact = dsAny.calculateNeuronImpact("hidden-linear");
+
+    dsAny.listViableNeurons = () =>
+      Promise.resolve([
+        { uuid: "hidden-upstream", totalError: 10, impact: upstreamImpact },
+        { uuid: "hidden-linear", totalError: 10, impact: linearImpact },
+        { uuid: "hidden-tanh", totalError: 10, impact: tanhImpact },
+      ]);
+
+    try {
+      const selection = await discoverStructure.selectNeuronsWeightedByError(3);
+      assertEquals(
+        new Set(selection),
+        new Set(["hidden-upstream", "hidden-linear", "hidden-tanh"]),
+      );
+
+      const summary = (discoverStructure as unknown as {
+        lastFocusSelection?: {
+          neurons: Array<{ uuid: string; weight?: number }>;
+        };
+      }).lastFocusSelection;
+      assert(summary, "Focus summary should be recorded");
+      const weightEntries = new Map(
+        summary!.neurons.map((entry) => [entry.uuid, entry.weight ?? 0]),
+      );
+      const epsilon = 0.0001;
+      const expectedLinearWeight = 10 * (linearImpact + epsilon);
+      const expectedUpstreamWeight = 10 * (upstreamImpact + epsilon);
+
+      assertAlmostEquals(
+        weightEntries.get("hidden-linear") ?? 0,
+        expectedLinearWeight,
+        1e-6,
+      );
+      assertAlmostEquals(
+        weightEntries.get("hidden-upstream") ?? 0,
+        expectedUpstreamWeight,
+        1e-6,
+      );
+      assert(
+        expectedLinearWeight > expectedUpstreamWeight,
+        "Linear neuron should retain higher weighted error than bounded upstream path",
+      );
+    } finally {
+      await Deno.remove(dsAny.tempDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name: "listNeuronsByImpact orders outputs before hidden neurons",
+  fn: async () => {
+    const creatureJson: CreatureExport = {
+      input: 2,
+      output: 2,
+      neurons: [
+        {
+          type: "constant",
+          uuid: "const-0",
+          bias: 1,
+        },
+        {
+          type: "hidden",
+          uuid: "hidden-a",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "hidden",
+          uuid: "hidden-b",
+          squash: TANH.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-1",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.8 },
+        { fromUUID: "hidden-b", toUUID: "output-1", weight: 0.4 },
+        { fromUUID: "hidden-a", toUUID: "hidden-b", weight: 0.6 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    const dsAny = discoverStructure as unknown as {
+      listNeuronsByImpact: () => Array<{ uuid: string; neuronType: string }>;
+      tempDir: string;
+    };
+
+    try {
+      const ordered = dsAny.listNeuronsByImpact();
+      assert(
+        ordered.every((entry) => entry.uuid !== "const-0"),
+        "Constant neurons must be excluded from impact ordering",
+      );
+      const topTwo = ordered.slice(0, 2).map((entry) => entry.uuid);
+      assertEquals(new Set(topTwo), new Set(["output-0", "output-1"]));
+
+      const hiddenOrdering = ordered
+        .filter((entry) => entry.neuronType !== "output")
+        .map((entry) => entry.uuid);
+      assertEquals(hiddenOrdering[0], "hidden-a");
+    } finally {
+      await Deno.remove(dsAny.tempDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name: "setForcedFocusNeurons filters constants from overrides",
+  fn: async () => {
+    const creatureJson: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        { type: "constant", uuid: "const-0", bias: 1 },
+        {
+          type: "hidden",
+          uuid: "hidden-focus",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "const-0", toUUID: "output-0", weight: 0.7 },
+        { fromUUID: "hidden-focus", toUUID: "output-0", weight: 0.5 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    const dsAny = discoverStructure as unknown as {
+      forcedFocusNeurons?: string[] | null;
+      tempDir: string;
+    };
+
+    try {
+      discoverStructure.setForcedFocusNeurons([
+        "const-0",
+        "hidden-focus",
+        "output-0",
+      ]);
+      assertEquals(dsAny.forcedFocusNeurons, ["hidden-focus", "output-0"]);
+    } finally {
+      await Deno.remove(dsAny.tempDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "listNeuronsByImpact honors outputs from complex creatures loaded from assets",
+  fn: async () => {
+    const fittestPath =
+      "/Users/nigelleck/src/NEAT-AI-Examples/assets/fittest_creature.json";
+    let jsonText: string;
+    try {
+      jsonText = await Deno.readTextFile(fittestPath);
+    } catch (error) {
+      console.warn(
+        `[ImpactTests] Skipping complex creature impact ordering test: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return;
+    }
+
+    const creature = Creature.fromJSON(JSON.parse(jsonText));
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    const dsAny = discoverStructure as unknown as {
+      listNeuronsByImpact: () => Array<{ uuid: string; neuronType: string }>;
+      tempDir: string;
+    };
+
+    try {
+      const ordered = dsAny.listNeuronsByImpact();
+      const outputUUIDs = creature.neurons
+        .filter((neuron) => neuron.type === "output")
+        .map((neuron) => neuron.uuid);
+      const leading = ordered.slice(0, outputUUIDs.length).map((entry) =>
+        entry.uuid
+      );
+      assertEquals(new Set(leading), new Set(outputUUIDs));
+    } finally {
+      await Deno.remove(dsAny.tempDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "weighted focus selection caps combined weight to output error magnitude",
+  fn: async () => {
+    const creatureJson: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "hidden-large",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "hidden",
+          uuid: "hidden-small",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "hidden-large", toUUID: "output-0", weight: 2 },
+        { fromUUID: "hidden-small", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    const dsAny = discoverStructure as unknown as {
+      listViableNeurons: () => Promise<
+        Array<{ uuid: string; totalError: number; impact: number }>
+      >;
+      computeMaxOutputError: () => Promise<number>;
+      lastFocusSelection?: { totalWeight?: number };
+      recorded: boolean;
+      tempDir: string;
+      parquetFilePath: string | null;
+      deps: DiscoverStructureDeps;
+    };
+
+    dsAny.recorded = true;
+    dsAny.parquetFilePath = "unused.parquet";
+    dsAny.deps = {
+      ...dsAny.deps,
+      isRustDiscoveryEnabled: () => true,
+    };
+    dsAny.listViableNeurons = () =>
+      Promise.resolve([
+        { uuid: "hidden-large", totalError: 1_000_000, impact: 1 },
+        { uuid: "hidden-small", totalError: 500_000, impact: 1 },
+      ]);
+    dsAny.computeMaxOutputError = () => Promise.resolve(0.55);
+
+    try {
+      await discoverStructure.selectNeuronsWeightedByError(2);
+      const summary = dsAny.lastFocusSelection;
+      assert(summary, "Focus selection summary should exist");
+      assert(
+        summary!.totalWeight !== undefined &&
+          summary!.totalWeight <= 0.55 + 1e-6,
+        `Total weight ${summary?.totalWeight} should respect output error cap`,
+      );
+    } finally {
+      await Deno.remove(dsAny.tempDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "analyzeSelectedNeurons timeout logs focus selection summary for visibility",
+  fn: async () => {
+    const creatureJson: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "hidden-logger",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "hidden-logger", toUUID: "output-0", weight: 0.1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      1,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    const dsAny = discoverStructure as unknown as {
+      lastFocusSelection?: {
+        key: string;
+        mode: "weighted";
+        reason: string;
+        neurons: Array<{ uuid: string; weight: number }>;
+        totalWeight: number;
+      };
+      timeoutTS: number;
+      tempDir: string;
+    };
+
+    const focusList = ["hidden-logger"];
+    dsAny.lastFocusSelection = {
+      key: focusList.join("|"),
+      mode: "weighted",
+      reason: "unit-test",
+      neurons: [{ uuid: "hidden-logger", weight: 42 }],
+      totalWeight: 42,
+    };
+    dsAny.timeoutTS = Date.now() - 1; // Force timeout path
+
+    const warnMessages: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnMessages.push(args.map((part) => String(part)).join(" "));
+    };
+
+    try {
+      await discoverStructure.analyzeSelectedNeurons(focusList);
+    } finally {
+      console.warn = originalWarn;
+      await Deno.remove(dsAny.tempDir, { recursive: true }).catch(() => {});
+    }
+
+    const summaryLog = warnMessages.find((msg) =>
+      msg.includes("Focus selection [weighted]")
+    );
+    assert(
+      summaryLog,
+      "Expected timeout to emit focus selection summary for diagnostics",
+    );
   },
 });
 


### PR DESCRIPTION
…iscoverStructure

- Bumped version in deno.json to 0.197.0.
- Introduced new methods for calculating neuron impact, ensuring that contributions from neurons are capped appropriately during focus selection.
- Added logging for cases where output error caps are reached, improving transparency in the selection process.
- Refactored existing methods to utilize the new impact calculations, enhancing the overall efficiency of neuron and synapse analysis.

These changes optimize the discovery process by providing more accurate impact assessments and clearer diagnostics during neuron selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances `DiscoverStructure` with bounded impact/weighting and richer diagnostics, adds `listNeuronsByImpact`, and updates tests; bumps version to 0.197.0.
> 
> - **Discovery Core (`src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts`)**
>   - Adds output-aware error cap in `selectNeuronsWeightedByError` via `computeMaxOutputError`, scaling total weights and recording `totalWeight` in selection summary.
>   - Introduces bounded neuron impact propagation in `calculateNeuronImpact` (caps contribution to downstream impact; ignores non-finite/≤0 paths).
>   - Adds selectable neuron filtering (excludes `input`/`constant`) and applies it across focus/viable lists.
>   - Adds `listNeuronsByImpact()` with ordering and `sanityCheckImpactOrdering` ensuring outputs lead.
>   - Improves logging/diagnostics: focus selection details on timeouts/unavailable Rust, `logRustAnalysisUnavailable`, uniform warnings in analyze paths, and squash-analysis timeout logging.
> - **Tests (`test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts`)**
>   - Extensive new tests covering impact capping, weighted selection scaling to output error caps, impact ordering (outputs first), forced focus filtering, timeout logging, and larger fixture validation.
> - **Misc**
>   - Bump `deno.json` version to `0.197.0`.
>   - Update spellings in `docs/cspell.json` (add `honors`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 589e720cc5c96aaedf8a0f46eed2c71715c2f272. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->