### PR TITLE
Bang for buck2

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.197.0",
+  "version": "0.198.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.198.0",
+  "version": "0.198.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.15",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -25,9 +25,11 @@ import {
   type RustCandidateNeuron,
   type RustCandidateSynapse,
   type RustNeuronDiagnostic,
+  type RustNeuronDiagnosticDetail,
   type RustRecordBatchStats,
   type RustRecordInput,
   type RustSynapseDiagnostic,
+  type RustSynapseDiagnosticDetail,
 } from "./RustDiscovery.ts";
 import { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
 
@@ -52,6 +54,8 @@ const DEFAULT_DISCOVER_STRUCTURE_DEPS: DiscoverStructureDeps = {
   analyzeSynapses,
   readDiscoveryRecords,
 };
+
+const OUTPUT_ERROR_CACHE_TTL_MS = 30_000;
 
 /**
  * Implements Error-Driven Synapse Discovery, a neuroevolution technique for optimizing neural network structures.
@@ -126,11 +130,18 @@ interface FocusSelectionSummary {
   totalWeight?: number;
 }
 
+interface NeuronScanStats {
+  processed: number;
+  total: number;
+  timedOut: boolean;
+  durationMs: number;
+}
+
 /**
  * Represents a neuron and its total accumulated error for ranking neurons during discovery.
  * Impact measures how much a neuron affects outputs through its outgoing synapse weights.
  */
-interface NeuronErrorInfo {
+export interface NeuronErrorInfo {
   uuid: string;
   totalError: number;
   impact: number;
@@ -209,6 +220,9 @@ export class DiscoverStructure {
   private improvementThreshold = DEFAULT_RUST_HELPFUL_THRESHOLD;
   private harmfulThreshold = DEFAULT_RUST_HARMFUL_THRESHOLD;
   private lastFocusSelection?: FocusSelectionSummary;
+  private cachedMaxOutputError?: { value: number; computedAt: number } =
+    undefined;
+  private lastNeuronScanStats?: NeuronScanStats;
   constructor(
     creature: Creature,
     timeoutSeconds: number,
@@ -256,7 +270,7 @@ export class DiscoverStructure {
     return this.isSelectableNeuronType(neuron.type);
   }
 
-  private async computeMaxOutputError(): Promise<number> {
+  private async measureMaxOutputError(): Promise<number> {
     if (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled()) {
       return 0;
     }
@@ -291,6 +305,19 @@ export class DiscoverStructure {
     });
     const results = await Promise.all(promises);
     return results.reduce((max, value) => Math.max(max, value), 0);
+  }
+
+  private async getMaxOutputError(): Promise<number> {
+    const now = Date.now();
+    if (
+      this.cachedMaxOutputError &&
+      now - this.cachedMaxOutputError.computedAt < OUTPUT_ERROR_CACHE_TTL_MS
+    ) {
+      return this.cachedMaxOutputError.value;
+    }
+    const measured = await this.measureMaxOutputError();
+    this.cachedMaxOutputError = { value: measured, computedAt: now };
+    return measured;
   }
 
   /**
@@ -431,6 +458,8 @@ export class DiscoverStructure {
     this.creature.dispose();
     this.discoveries = [];
     this.neuronDiscoveries = [];
+    this.cachedMaxOutputError = undefined;
+    this.lastNeuronScanStats = undefined;
 
     // Clear selectedIndices to help GC
     this.selectedIndices = {};
@@ -479,6 +508,7 @@ export class DiscoverStructure {
       );
     }
     this.recorded = true;
+    this.cachedMaxOutputError = undefined;
 
     // Rust module is required - if not available, discovery was already skipped in initialize()
     if (!this.usingRustDualWrite || timedOut) {
@@ -1215,6 +1245,7 @@ export class DiscoverStructure {
 
     if (Date.now() > this.timeoutTS) {
       this.log("warn", "Discovery timeout reached in analyzeSelectedNeurons");
+      this.logAnalysisSkipped("synapse");
       this.logFocusSelectionDetails("synapse", focusList);
       return Promise.resolve(undefined);
     }
@@ -1254,6 +1285,7 @@ export class DiscoverStructure {
 
     if (Date.now() > this.timeoutTS) {
       this.log("warn", "Discovery timeout reached in analyzeMissingNeurons");
+      this.logAnalysisSkipped("neuron");
       this.logFocusSelectionDetails("neuron", focusList);
       return Promise.resolve(undefined);
     }
@@ -1781,6 +1813,19 @@ export class DiscoverStructure {
     this.logFocusSelectionDetails(scope, focusList);
   }
 
+  private logAnalysisSkipped(scope: "synapse" | "neuron"): void {
+    const stats = this.lastNeuronScanStats;
+    if (!stats?.timedOut) {
+      return;
+    }
+    this.log(
+      "warn",
+      `Skipping Rust ${scope} analysis because neuron scanning consumed ${
+        this.formatMillis(stats.durationMs)
+      } (${stats.processed}/${stats.total} neurons processed).`,
+    );
+  }
+
   private isSynapseDiagnostic(
     diagnostic: RustSynapseDiagnostic | RustNeuronDiagnostic,
   ): diagnostic is RustSynapseDiagnostic {
@@ -1801,13 +1846,69 @@ export class DiscoverStructure {
       );
       return;
     }
+    let totalEvaluated = 0;
+    let bestImprovement = Number.NEGATIVE_INFINITY;
+    let bestDetail:
+      | {
+        improvement: number;
+        threshold?: number;
+        weight?: number;
+        target: string;
+      }
+      | undefined;
     diagnostics.forEach((diagnostic) => {
+      const evaluated = (diagnostic as RustSynapseDiagnostic)
+        .evaluatedCandidates ??
+        (diagnostic as RustNeuronDiagnostic).evaluatedSources ??
+        0;
+      totalEvaluated += evaluated;
+      const detail = diagnostic.detail;
+      if (detail) {
+        const improvement = typeof detail.expectedImprovementPercentage ===
+            "number"
+          ? detail.expectedImprovementPercentage
+          : undefined;
+        if (
+          improvement !== undefined &&
+          improvement > bestImprovement
+        ) {
+          bestImprovement = improvement;
+          bestDetail = {
+            improvement,
+            threshold: detail.threshold,
+            weight: (("suggestedWeight" in detail &&
+                typeof (detail as RustSynapseDiagnosticDetail)
+                    .suggestedWeight === "number")
+              ? (detail as RustSynapseDiagnosticDetail).suggestedWeight
+              : undefined) ??
+              (("outgoingWeight" in detail &&
+                  typeof (detail as RustNeuronDiagnosticDetail)
+                      .outgoingWeight === "number")
+                ? (detail as RustNeuronDiagnosticDetail).outgoingWeight
+                : undefined),
+            target: diagnostic.targetNeuronUuid,
+          };
+        }
+      }
       if (this.isSynapseDiagnostic(diagnostic)) {
         this.log("warn", this.formatSynapseDiagnostic(diagnostic));
       } else {
         this.log("warn", this.formatNeuronDiagnostic(diagnostic));
       }
     });
+    if (bestDetail && totalEvaluated > 0) {
+      const improvementPct = `${(bestDetail.improvement * 100).toFixed(4)}%`;
+      const thresholdPct = bestDetail.threshold !== undefined
+        ? `${(bestDetail.threshold * 100).toFixed(4)}%`
+        : "the configured threshold";
+      const weightInfo = bestDetail.weight !== undefined
+        ? ` (weight ${bestDetail.weight.toFixed(4)})`
+        : "";
+      this.log(
+        "warn",
+        `Rust ${scope} analysis evaluated ${totalEvaluated} candidate(s); best improvement ${improvementPct} for ${bestDetail.target}${weightInfo} but threshold was ${thresholdPct}.`,
+      );
+    }
   }
 
   private formatSynapseDiagnostic(diagnostic: RustSynapseDiagnostic): string {
@@ -2360,105 +2461,160 @@ export class DiscoverStructure {
    * Lists neurons sorted by their total error, useful for error-driven selection processes.
    * Now also includes impact calculation for weighted selection.
    */
-  public async listViableNeurons(): Promise<NeuronErrorInfo[]> {
+  public async listViableNeurons(
+    targetCount?: number,
+  ): Promise<NeuronErrorInfo[]> {
     if (!this.recorded) {
       console.warn("No recorded data to list neurons.");
       return [];
     }
 
+    const start = Date.now();
     const neurons = this.creature.neurons.filter((neuron) =>
       this.isSelectableNeuron(neuron)
     );
-
-    // Process neurons in batches to avoid overwhelming the file system
-    // with too many concurrent file operations (prevents "too many open files" errors)
-    const BATCH_SIZE = 50;
+    const totalNeurons = neurons.length;
     const results: NeuronErrorInfo[] = [];
     let totalInvalidErrorCount = 0;
     let neuronsWithInvalidErrors = 0;
+    let processedCount = 0;
+    let timedOut = false;
+    const maxOutputError = await this.getMaxOutputError();
+    const impactCache = new Map<string, number>();
 
-    for (let i = 0; i < neurons.length; i += BATCH_SIZE) {
-      const batch = neurons.slice(i, i + BATCH_SIZE);
+    const concurrency = Math.min(
+      Math.max(4, Math.min(32, totalNeurons || 1)),
+      totalNeurons || 1,
+    );
+    let index = 0;
+    let stopRequested = false;
+    const earlyLimit = targetCount
+      ? Math.max(targetCount * 4, 64)
+      : Number.POSITIVE_INFINITY;
 
-      // Check timeout before each batch
-      if (Date.now() > this.timeoutTS) {
-        console.warn(
-          `Discovery timeout reached while listing neurons (${i}/${neurons.length} processed)`,
-        );
-        break;
-      }
+    const processNext = async () => {
+      while (true) {
+        const currentIndex = index++;
+        if (currentIndex >= totalNeurons) {
+          break;
+        }
+        if (Date.now() > this.timeoutTS) {
+          timedOut = true;
+          break;
+        }
+        if (stopRequested) {
+          break;
+        }
 
-      const batchPromises = batch.map(async (neuron) => {
+        const neuron = neurons[currentIndex];
         try {
+          // deno-lint-ignore no-await-in-loop
           const records = await this.loadCSV(
             `${this.tempDir}/${neuron.uuid}.csv`,
           );
 
           let invalidErrorCount = 0;
-          const totalError = records.reduce((sum, record) => {
-            const errors = record.errors;
-            const recordError = errors.reduce((eSum, e) => {
-              if (!Number.isFinite(e)) {
+          let absoluteErrorSum = 0;
+          let errorValueCount = 0;
+          for (const record of records) {
+            for (const err of record.errors) {
+              if (!Number.isFinite(err)) {
                 invalidErrorCount++;
-                return eSum;
+                continue;
               }
-              return eSum + Math.abs(e);
-            }, 0);
-            return sum + recordError;
-          }, 0);
+              absoluteErrorSum += Math.abs(err);
+              errorValueCount++;
+            }
+          }
 
-          // Warn if invalid data was detected
           if (invalidErrorCount > 0) {
             totalInvalidErrorCount += invalidErrorCount;
             neuronsWithInvalidErrors++;
             console.warn(
               `⚠️  WARNING: Neuron ${neuron.uuid} has ${invalidErrorCount} invalid error values (NaN/Infinity) out of ${
-                records.reduce((count, r) => count + r.errors.length, 0)
+                errorValueCount + invalidErrorCount
               } total error values. This indicates a bug in error calculation or data corruption.`,
             );
           }
 
-          // Clear records array to help GC
+          const averageError = errorValueCount > 0
+            ? absoluteErrorSum / errorValueCount
+            : 0;
+          const clampedError = maxOutputError > 0
+            ? Math.min(averageError, maxOutputError)
+            : averageError;
+
           records.length = 0;
 
-          // Check if totalError is valid
-          if (!Number.isFinite(totalError)) {
-            console.error(
-              `❌ ERROR: Neuron ${neuron.uuid} has invalid totalError (${totalError}). This should never happen!`,
-            );
-            return { uuid: neuron.uuid, totalError: 0, impact: 0 };
+          let impact = impactCache.get(neuron.uuid);
+          if (impact === undefined) {
+            const computedImpact = this.calculateNeuronImpact(neuron.uuid);
+            impact = Number.isFinite(computedImpact) ? computedImpact : 0;
+            impactCache.set(neuron.uuid, impact);
           }
 
-          // Calculate impact on outputs
-          const impact = this.calculateNeuronImpact(neuron.uuid);
-          const validImpact = Number.isFinite(impact) ? impact : 0;
-
-          return {
+          results.push({
             uuid: neuron.uuid,
-            totalError: totalError,
-            impact: validImpact,
-          };
-        } catch (e) {
-          console.error(`Error processing neuron ${neuron.uuid}`, e);
-          return { uuid: neuron.uuid, totalError: 0, impact: 0 }; // Handle gracefully
+            totalError: clampedError,
+            impact,
+          });
+        } catch (error) {
+          console.error(`Error processing neuron ${neuron.uuid}`, error);
+        } finally {
+          processedCount++;
+          if (this.loggingEnabled && processedCount % 25 === 0) {
+            this.log(
+              "debug",
+              `Neuron scan progress: ${processedCount}/${totalNeurons} processed`,
+            );
+          }
+          if (!stopRequested && results.length >= earlyLimit) {
+            stopRequested = true;
+          }
         }
-      });
+      }
+    };
 
-      // deno-lint-ignore no-await-in-loop
-      const batchResults = await Promise.all(batchPromises);
-      results.push(...batchResults);
+    const workers = Array.from({ length: concurrency }, () => processNext());
+    await Promise.all(workers);
 
-      // Clear batch results to help GC
-      batchResults.length = 0;
-    }
+    const durationMs = Date.now() - start;
+    this.lastNeuronScanStats = {
+      processed: processedCount,
+      total: totalNeurons,
+      timedOut,
+      durationMs,
+    };
 
-    // Report summary of invalid data if any was found
     if (totalInvalidErrorCount > 0) {
       console.error(
         `❌ DISCOVERY DATA QUALITY ISSUE: Found ${totalInvalidErrorCount} invalid error values across ${neuronsWithInvalidErrors} neurons (out of ${neurons.length} total)`,
       );
       console.error(
         `   This suggests a bug in creature.record() or error calculation during discovery recording.`,
+      );
+    }
+
+    if (timedOut) {
+      this.log(
+        "warn",
+        `Neuron scan timed out after ${
+          this.formatMillis(durationMs)
+        } (${processedCount}/${totalNeurons} processed). Continuing with partial results.`,
+      );
+    } else if (stopRequested && this.loggingEnabled) {
+      this.log(
+        "debug",
+        `Neuron scan reached early target of ${earlyLimit} neurons in ${
+          this.formatMillis(durationMs)
+        }.`,
+      );
+    } else if (this.loggingEnabled) {
+      this.log(
+        "debug",
+        `Neuron scan completed in ${
+          this.formatMillis(durationMs)
+        } (${processedCount} neurons).`,
       );
     }
 
@@ -2521,10 +2677,10 @@ export class DiscoverStructure {
         return trimmed;
       }
     }
-    const neuronErrors = await this.listViableNeurons();
+    const neuronErrors = await this.listViableNeurons(count);
     if (neuronErrors.length === 0) return [];
 
-    const maxOutputError = await this.computeMaxOutputError();
+    const maxOutputError = await this.getMaxOutputError();
     const hasOutputCap = maxOutputError > 0;
     const EPSILON = 0.0001;
     const rawWeights = neuronErrors.map((n) => ({
@@ -2538,12 +2694,15 @@ export class DiscoverStructure {
     const scale = hasOutputCap && rawSum > capTotal && rawSum > EPSILON
       ? capTotal / rawSum
       : 1;
-    if (scale < 1 && this.loggingEnabled) {
+    if (scale < 0.9999) {
+      const scaleLabel = scale < 0.0001
+        ? scale.toExponential(2)
+        : scale.toFixed(4);
       this.log(
         "debug",
-        `Scaling weighted errors by ${
-          scale.toFixed(4)
-        } to respect output error cap ${maxOutputError.toFixed(4)}`,
+        `Scaling weighted errors by ${scaleLabel} to respect output error cap ${
+          maxOutputError.toFixed(4)
+        }`,
       );
     }
     const weightedValues = rawWeights.map((entry) => ({
@@ -2729,6 +2888,7 @@ export class DiscoverStructure {
         "warn",
         "Discovery timeout reached in analyzeSelectedNeuronsSquashes",
       );
+      this.logAnalysisSkipped("neuron");
       this.logFocusSelectionDetails("neuron", focusList);
       return undefined;
     }
@@ -3155,6 +3315,7 @@ export class DiscoverStructure {
         "warn",
         "Discovery timeout reached in analyzeSelectedNeuronsForRemoval",
       );
+      this.logAnalysisSkipped("synapse");
       this.logFocusSelectionDetails("synapse", focusList);
       return Promise.resolve(undefined);
     }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -16,6 +16,7 @@ import {
   isRustDiscoveryEnabled,
   isRustLibraryAvailable,
   mergeDiscoveryParquet,
+  rankFocusNeurons,
   readDiscoveryRecords,
   recordDiscovery,
   type RustAnalyzeNeuronsInput,
@@ -43,6 +44,7 @@ export interface DiscoverStructureDeps {
   analyzeNeurons: typeof analyzeNeurons;
   analyzeSynapses: typeof analyzeSynapses;
   readDiscoveryRecords: typeof readDiscoveryRecords;
+  rankFocusNeurons?: typeof rankFocusNeurons;
 }
 
 const DEFAULT_DISCOVER_STRUCTURE_DEPS: DiscoverStructureDeps = {
@@ -53,6 +55,7 @@ const DEFAULT_DISCOVER_STRUCTURE_DEPS: DiscoverStructureDeps = {
   analyzeNeurons,
   analyzeSynapses,
   readDiscoveryRecords,
+  rankFocusNeurons,
 };
 
 const OUTPUT_ERROR_CACHE_TTL_MS = 30_000;
@@ -2469,6 +2472,88 @@ export class DiscoverStructure {
       return [];
     }
 
+    const rustResult = this.tryRustFocusRanking(targetCount);
+    if (rustResult) {
+      return rustResult;
+    }
+
+    return await this.listViableNeuronsFallback(targetCount);
+  }
+
+  private tryRustFocusRanking(
+    targetCount?: number,
+  ): NeuronErrorInfo[] | undefined {
+    if (
+      !this.parquetFilePath ||
+      !this.deps.rankFocusNeurons ||
+      !this.deps.isRustDiscoveryEnabled()
+    ) {
+      return undefined;
+    }
+
+    try {
+      const rustCreature = creatureToRustFormat(this.creature.exportJSON());
+      const maxResults = Math.max(
+        targetCount ?? this.creature.neurons.length,
+        64,
+      );
+      const result = this.deps.rankFocusNeurons({
+        parquetFile: this.parquetFilePath,
+        creature: rustCreature,
+        maxResults,
+      });
+
+      if (!result || !result.success || !result.neurons) {
+        if (this.loggingEnabled && result?.error) {
+          this.log(
+            "debug",
+            `Rust focus ranking failed: ${result.error}`,
+          );
+        }
+        return undefined;
+      }
+
+      if (result.maxOutputError !== undefined) {
+        this.cachedMaxOutputError = {
+          value: result.maxOutputError,
+          computedAt: Date.now(),
+        };
+      }
+
+      this.lastNeuronScanStats = {
+        processed: result.processedNeurons ?? result.neurons.length,
+        total: result.totalNeurons ?? this.creature.neurons.length,
+        durationMs: result.durationMs ?? 0,
+        timedOut: false,
+      };
+
+      if (this.loggingEnabled) {
+        const duration = result.durationMs !== undefined
+          ? this.formatMillis(result.durationMs)
+          : "unknown time";
+        this.log(
+          "debug",
+          `Rust focus ranking returned ${result.neurons.length} neuron(s) in ${duration}.`,
+        );
+      }
+
+      return result.neurons.map((entry) => ({
+        uuid: entry.neuronUuid,
+        totalError: entry.totalError,
+        impact: entry.impact,
+      }));
+    } catch (error) {
+      if (this.loggingEnabled) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.log("debug", `Rust focus ranking threw error: ${message}`);
+      }
+      return undefined;
+    }
+  }
+
+  private async listViableNeuronsFallback(
+    targetCount?: number,
+  ): Promise<NeuronErrorInfo[]> {
     const start = Date.now();
     const neurons = this.creature.neurons.filter((neuron) =>
       this.isSelectableNeuron(neuron)

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -111,6 +111,28 @@ export interface RustAnalyzeNeuronsResult {
   error?: string;
 }
 
+export interface RustRankFocusInput {
+  parquetFile: string;
+  creature: RustRecordInput["creature"];
+  maxResults?: number;
+}
+
+export interface RustFocusNeuronScore {
+  neuronUuid: string;
+  totalError: number;
+  impact: number;
+}
+
+export interface RustRankFocusResult {
+  success: boolean;
+  neurons?: RustFocusNeuronScore[];
+  maxOutputError?: number;
+  processedNeurons?: number;
+  totalNeurons?: number;
+  durationMs?: number;
+  error?: string;
+}
+
 export type RustSynapseDiagnosticReason =
   | "no_eligible_sources"
   | "no_diagnostics"
@@ -536,6 +558,11 @@ type RustDiscoverySymbols = {
     result: "pointer";
     nonblocking: false;
   };
+  "rank_focus_neurons": {
+    parameters: ["pointer"];
+    result: "pointer";
+    nonblocking: false;
+  };
   "free_discovery_result": {
     parameters: ["pointer"];
     result: "void";
@@ -612,6 +639,11 @@ export function loadRustLibrary(): boolean {
         nonblocking: false,
       },
       "merge_discovery_parquet": {
+        parameters: ["pointer"],
+        result: "pointer",
+        nonblocking: false,
+      },
+      "rank_focus_neurons": {
         parameters: ["pointer"],
         result: "pointer",
         nonblocking: false,
@@ -779,6 +811,45 @@ export function readDiscoveryRecords(
     // Parse the JSON result
     const result = JSON.parse(resultJson) as RustReadResult;
 
+    return result;
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function rankFocusNeurons(
+  input: RustRankFocusInput,
+): RustRankFocusResult | null {
+  if (!isRustLibraryAvailable()) {
+    return null;
+  }
+
+  assert(rustLib !== null, "Rust library should be loaded");
+
+  try {
+    const inputJson = JSON.stringify(input);
+    const inputBytes = new TextEncoder().encode(inputJson);
+    const inputBuffer = new Uint8Array(inputBytes.length + 1);
+    inputBuffer.set(inputBytes);
+    inputBuffer[inputBytes.length] = 0;
+
+    const inputPtr = Deno.UnsafePointer.of(inputBuffer);
+    const resultPtr = rustLib.symbols["rank_focus_neurons"](inputPtr);
+
+    if (resultPtr === null) {
+      return {
+        success: false,
+        error: "Rust function returned null pointer",
+      };
+    }
+
+    const resultJson = readCString(resultPtr);
+    rustLib.symbols["free_discovery_result"](resultPtr);
+
+    const result = JSON.parse(resultJson) as RustRankFocusResult;
     return result;
   } catch (error) {
     return {

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -8,6 +8,7 @@ import {
   type DiscoverRecord,
   DiscoverStructure,
   type DiscoverStructureDeps,
+  type NeuronErrorInfo,
   type RustFlushMetrics,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
@@ -1030,6 +1031,166 @@ Deno.test({
 });
 
 Deno.test({
+  name: "listViableNeurons clamps errors to maximum output error",
+  fn: async () => {
+    const creatureJson: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "hidden-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.5 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    const dsAny = discoverStructure as unknown as {
+      recorded: boolean;
+      tempDir: string;
+      loadCSV: (path: string) => Promise<DiscoverRecord[]>;
+      getMaxOutputError: () => Promise<number>;
+    };
+    dsAny.recorded = true;
+    dsAny.tempDir = ".";
+
+    const csvData = new Map<string, DiscoverRecord[]>([
+      ["output-0", [{
+        activation: 0,
+        errors: [0.5, -0.55],
+      }]],
+      ["hidden-0", [{
+        activation: 0,
+        errors: [1.2, -1.1],
+      }]],
+    ]);
+
+    dsAny.loadCSV = (path: string) => {
+      const file = path.split("/").pop() ?? "";
+      const uuid = file.replace(".csv", "");
+      const records = csvData.get(uuid) ?? [];
+      return Promise.resolve(records.map((record) => ({
+        activation: record.activation,
+        value: record.value,
+        errors: [...record.errors],
+      })));
+    };
+    dsAny.getMaxOutputError = () => Promise.resolve(0.55);
+
+    const neuronErrors = await discoverStructure.listViableNeurons();
+    const hidden = neuronErrors.find((entry) => entry.uuid === "hidden-0");
+    const output = neuronErrors.find((entry) => entry.uuid === "output-0");
+    assert(hidden);
+    assert(output);
+    assert(
+      hidden.totalError <= 0.55 + 1e-6,
+      `Hidden neuron error ${hidden.totalError} should not exceed output cap`,
+    );
+    assertAlmostEquals(output.totalError, 0.525, 0.001);
+  },
+});
+
+Deno.test({
+  name:
+    "selectNeuronsWeightedByError favours neurons with higher error-impact weight",
+  fn: async () => {
+    const creatureJson: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "hidden-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.3 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+    );
+    const dsAny = discoverStructure as unknown as {
+      recorded: boolean;
+      tempDir: string;
+      listViableNeurons: () => Promise<NeuronErrorInfo[]>;
+      getMaxOutputError: () => Promise<number>;
+    };
+    dsAny.recorded = true;
+    dsAny.tempDir = ".";
+    dsAny.listViableNeurons = () =>
+      Promise.resolve([
+        { uuid: "output-0", totalError: 0.55, impact: 1 },
+        { uuid: "hidden-0", totalError: 0.2, impact: 0.5 },
+      ]);
+    dsAny.getMaxOutputError = () => Promise.resolve(0.55);
+
+    const originalRandom = Math.random;
+    let seed = 42;
+    Math.random = () => {
+      seed = (seed * 16807) % 2147483647;
+      return (seed - 1) / 2147483646;
+    };
+
+    const selectionCounts = new Map<string, number>();
+    try {
+      for (let i = 0; i < 100; i++) {
+        // deno-lint-ignore no-await-in-loop
+        const selection = await discoverStructure.selectNeuronsWeightedByError(
+          1,
+        );
+        const uuid = selection[0];
+        selectionCounts.set(uuid, (selectionCounts.get(uuid) ?? 0) + 1);
+      }
+    } finally {
+      Math.random = originalRandom;
+    }
+
+    assert(
+      (selectionCounts.get("output-0") ?? 0) >
+        (selectionCounts.get("hidden-0") ?? 0),
+      `Expected output neuron to be chosen more frequently. Counts: ${
+        JSON.stringify(
+          Object.fromEntries(selectionCounts.entries()),
+        )
+      }`,
+    );
+  },
+});
+
+Deno.test({
   name:
     "weighted focus selection caps combined weight to output error magnitude",
   fn: async () => {
@@ -1074,7 +1235,7 @@ Deno.test({
       listViableNeurons: () => Promise<
         Array<{ uuid: string; totalError: number; impact: number }>
       >;
-      computeMaxOutputError: () => Promise<number>;
+      getMaxOutputError: () => Promise<number>;
       lastFocusSelection?: { totalWeight?: number };
       recorded: boolean;
       tempDir: string;
@@ -1093,7 +1254,7 @@ Deno.test({
         { uuid: "hidden-large", totalError: 1_000_000, impact: 1 },
         { uuid: "hidden-small", totalError: 500_000, impact: 1 },
       ]);
-    dsAny.computeMaxOutputError = () => Promise.resolve(0.55);
+    dsAny.getMaxOutputError = () => Promise.resolve(0.55);
 
     try {
       await discoverStructure.selectNeuronsWeightedByError(2);

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1191,6 +1191,78 @@ Deno.test({
 });
 
 Deno.test({
+  name: "listViableNeurons prefers rust focus ranking results when available",
+  fn: async () => {
+    const creatureJson: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "hidden-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          type: "output",
+          uuid: "output-0",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.5 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    const stubResult = {
+      success: true,
+      neurons: [
+        { neuronUuid: "output-0", totalError: 0.55, impact: 1 },
+        { neuronUuid: "hidden-0", totalError: 0.3, impact: 0.4 },
+      ],
+      maxOutputError: 0.55,
+      processedNeurons: 2,
+      totalNeurons: 2,
+      durationMs: 12,
+    };
+
+    const discoverStructure = new DiscoverStructure(
+      creature,
+      5,
+      DEFAULT_RUST_FLUSH_RECORDS,
+      {
+        isRustDiscoveryEnabled: () => true,
+        isRustLibraryAvailable: () => true,
+        rankFocusNeurons: () => stubResult,
+      },
+    );
+    const dsAny = discoverStructure as unknown as {
+      recorded: boolean;
+      parquetFilePath: string | null;
+      lastNeuronScanStats?: {
+        processed: number;
+        total: number;
+        timedOut: boolean;
+        durationMs: number;
+      };
+    };
+    dsAny.recorded = true;
+    dsAny.parquetFilePath = "stub.parquet";
+
+    const ranked = await discoverStructure.listViableNeurons(1);
+    assertEquals(ranked.length, 2);
+    assertEquals(ranked[0].uuid, "output-0");
+    assertEquals(ranked[1].uuid, "hidden-0");
+    assertEquals(dsAny.lastNeuronScanStats?.processed, 2);
+    assertEquals(dsAny.lastNeuronScanStats?.timedOut, false);
+  },
+});
+
+Deno.test({
   name:
     "weighted focus selection caps combined weight to output error magnitude",
   fn: async () => {

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
@@ -263,15 +263,38 @@ Deno.test({
     // Should handle timeout gracefully and return partial results
     const viableNeurons = await discoverStructure.listViableNeurons();
 
+    const dsAny = discoverStructure as unknown as {
+      lastNeuronScanStats?: {
+        processed: number;
+        total: number;
+        timedOut: boolean;
+      };
+    };
+    const scanStats = dsAny.lastNeuronScanStats;
+
     assertExists(
       viableNeurons,
       "Should return neurons list even after timeout",
     );
-    // May have processed some neurons before timeout
-    assert(
-      viableNeurons.length < 200,
-      "Should have stopped early due to timeout",
-    );
+
+    if (scanStats?.timedOut) {
+      // TypeScript fallback path should stop early and return fewer entries
+      assert(
+        viableNeurons.length < 200,
+        "TypeScript fallback scan should have stopped early due to timeout",
+      );
+    } else {
+      // Rust focus ranking path completes even if the JS timeout elapsed earlier.
+      assert(
+        scanStats?.processed === scanStats?.total,
+        "Rust focus ranking should process all selectable neurons",
+      );
+      assertEquals(
+        viableNeurons.length,
+        scanStats?.processed ?? viableNeurons.length,
+        "Rust focus ranking should return every processed neuron",
+      );
+    }
 
     await discoverStructure.cleanUp();
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Rust-backed `rank_focus_neurons` for `listViableNeurons` with cached stats/error, falling back to TypeScript scan when unavailable; updates FFI and tests.
> 
> - **Discovery (TypeScript)**:
>   - Prefer Rust focus ranking via `tryRustFocusRanking()` in `listViableNeurons`; fallback preserved in `listViableNeuronsFallback()`.
>   - Caches `maxOutputError` from Rust and records `lastNeuronScanStats` (processed/total/duration, no timeout).
>   - Injects `rankFocusNeurons` into `DiscoverStructureDeps` and default deps.
> - **Rust FFI (bindings)**:
>   - Add `rank_focus_neurons` symbol and wrapper `rankFocusNeurons()`.
>   - Define `RustRankFocusInput`, `RustFocusNeuronScore`, `RustRankFocusResult`.
> - **Tests**:
>   - New test ensuring `listViableNeurons` prefers Rust ranking when available.
>   - Timeout robustness test updated to handle Rust path vs TS fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c6b0054db6b29e7ad38ed306adcd20c578943d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->