### PR TITLE
Update version to 0.198.2 and enhance DiscoveryRunner with evaluation…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,16 +1,16 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.198.1",
+  "version": "0.198.2",
   "imports": {
-    "@std/assert": "jsr:@std/assert@1.0.15",
+    "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",
     "@std/crypto": "jsr:@std/crypto@1.0.5",
     "@std/csv": "jsr:@std/csv@1.0.6",
     "@std/fmt": "jsr:@std/fmt@1.0.8",
-    "@std/fs": "jsr:@std/fs@1.0.19",
-    "@std/path": "jsr:@std/path@1.1.2",
-    "@std/streams": "jsr:@std/streams@1.0.13",
+    "@std/fs": "jsr:@std/fs@1.0.20",
+    "@std/path": "jsr:@std/path@1.1.3",
+    "@std/streams": "jsr:@std/streams@1.0.14",
     "@std/uuid": "jsr:@std/uuid@1.0.9",
     "@std/testing/mock": "jsr:@std/testing@1.0.16/mock",
     "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13"

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -1,4 +1,5 @@
 import { assert } from "@std/assert";
+import { join } from "@std/path/join";
 import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../architecture/CreatureUtils.ts";
 import type { DiscoverResult } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
@@ -7,7 +8,10 @@ import { calculate as calculateScore } from "../architecture/Score.ts";
 import type { Creature } from "../Creature.ts";
 import type { NeatOptions } from "../config/NeatOptions.ts";
 import { createNeatConfig } from "../config/NeatConfig.ts";
-import { buildDiscoveryCandidates } from "./DiscoveryCandidates.ts";
+import {
+  buildDiscoveryCandidates,
+  type DiscoveryChangeType,
+} from "./DiscoveryCandidates.ts";
 import { WorkerHandler } from "../multithreading/workers/WorkerHandler.ts";
 
 import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
@@ -60,6 +64,16 @@ export interface DiscoveryDirInput {
   options: NeatOptions;
 }
 
+export interface DiscoveryEvaluationSummary {
+  kind: "original" | "candidate";
+  changeType?: DiscoveryChangeType;
+  score: number;
+  error: number;
+  scoreDelta?: number;
+  improved: boolean;
+  archivePath?: string;
+}
+
 export interface DiscoveryDirResult {
   discovery: DiscoverResult;
   original: {
@@ -74,6 +88,8 @@ export interface DiscoveryDirResult {
     message: string;
     creature: CreatureExport;
   };
+  evaluations?: DiscoveryEvaluationSummary[];
+  candidateArchiveDir?: string;
 }
 
 export class DiscoveryRunner {
@@ -249,6 +265,19 @@ export class DiscoveryRunner {
         };
       }
 
+      const evaluationArtifacts = this.#recordEvaluationSummaries({
+        discoveryID: discoverResult.ID,
+        evaluationResults,
+        originalScore: original.score,
+        baseCreature: creature,
+      });
+      if (evaluationArtifacts.summaries.length > 0) {
+        outcome.evaluations = evaluationArtifacts.summaries;
+      }
+      if (evaluationArtifacts.archiveDir) {
+        outcome.candidateArchiveDir = evaluationArtifacts.archiveDir;
+      }
+
       markPhase("Total discoveryDir run", runStart);
       return outcome;
     } finally {
@@ -260,6 +289,133 @@ export class DiscoveryRunner {
         }
       }
     }
+  }
+
+  #recordEvaluationSummaries(
+    params: {
+      discoveryID: string;
+      evaluationResults: Array<{
+        kind: "original" | "candidate";
+        candidate?: DiscoveryCandidate;
+        error: number;
+        score: number;
+      }>;
+      originalScore: number;
+      baseCreature: Creature;
+    },
+  ): { summaries: DiscoveryEvaluationSummary[]; archiveDir?: string } {
+    const { discoveryID, evaluationResults, originalScore, baseCreature } =
+      params;
+    const summaries: DiscoveryEvaluationSummary[] = [];
+    const labelCounts = new Map<string, number>();
+
+    let archiveDir: string | undefined;
+    let resolvedArchiveDir: string | undefined;
+
+    const ensureArchiveDir = (): string | undefined => {
+      if (archiveDir) return archiveDir;
+
+      const safeDiscoveryID = sanitiseSegment(discoveryID || "discovery");
+      const timestamp = makeArchiveTimestamp();
+      const targetDir = join(
+        ".discovery",
+        "candidates",
+        safeDiscoveryID,
+        timestamp,
+      );
+      try {
+        Deno.mkdirSync(targetDir, { recursive: true });
+        archiveDir = targetDir;
+        resolvedArchiveDir = safeRealPath(targetDir);
+      } catch (error) {
+        console.warn(
+          "[DiscoveryRunner] Failed to create discovery candidate archive:",
+          error,
+        );
+        archiveDir = undefined;
+      }
+      return archiveDir;
+    };
+
+    const persistCreature = (
+      baseLabel: string,
+      payload: Record<string, unknown>,
+    ): string | undefined => {
+      const dir = ensureArchiveDir();
+      if (!dir) {
+        return undefined;
+      }
+      try {
+        const safeLabel = sanitiseSegment(baseLabel);
+        const index = (labelCounts.get(safeLabel) ?? 0) + 1;
+        labelCounts.set(safeLabel, index);
+        const suffix = index === 1 ? "" : `-${index}`;
+        const filePath = join(dir, `${safeLabel}${suffix}.json`);
+        Deno.writeTextFileSync(filePath, JSON.stringify(payload, null, 1));
+        return safeRealPath(filePath);
+      } catch (error) {
+        console.warn(
+          `[DiscoveryRunner] Failed to persist discovery candidate '${baseLabel}':`,
+          error,
+        );
+        return undefined;
+      }
+    };
+
+    const originalExport = baseCreature.exportJSON();
+
+    for (const evaluation of evaluationResults) {
+      const changeType = evaluation.candidate?.change.type;
+      const scoreDelta = evaluation.score - originalScore;
+      const improved = evaluation.kind === "candidate" && scoreDelta > 0;
+
+      let archivePath: string | undefined;
+      const exportPayload = evaluation.kind === "original"
+        ? originalExport
+        : evaluation.candidate?.creature.exportJSON();
+
+      if (exportPayload) {
+        const label = evaluation.kind === "original"
+          ? "original"
+          : `candidate-${changeType ?? "unknown"}`;
+        archivePath = persistCreature(label, {
+          kind: evaluation.kind,
+          changeType,
+          score: evaluation.score,
+          error: evaluation.error,
+          scoreDelta,
+          improved,
+          creature: exportPayload,
+        });
+      }
+
+      summaries.push({
+        kind: evaluation.kind,
+        changeType,
+        score: evaluation.score,
+        error: evaluation.error,
+        scoreDelta,
+        improved,
+        archivePath,
+      });
+    }
+
+    if (archiveDir) {
+      try {
+        const summaryPath = join(archiveDir, "summary.json");
+        Deno.writeTextFileSync(summaryPath, JSON.stringify(summaries, null, 1));
+      } catch (error) {
+        console.warn(
+          "[DiscoveryRunner] Failed to persist discovery evaluation summary:",
+          error,
+        );
+      }
+    }
+
+    return {
+      summaries,
+      archiveDir: resolvedArchiveDir ?? archiveDir,
+    };
   }
 
   async #evaluateAll(
@@ -320,5 +476,26 @@ export class DiscoveryRunner {
     await Promise.all(workers.map((worker) => processNext(worker)));
 
     return results;
+  }
+}
+
+function sanitiseSegment(value: string): string {
+  const lowered = value.toLowerCase();
+  const cleaned = lowered.replace(/[^a-z0-9._-]+/g, "-").replace(
+    /^-+|-+$/g,
+    "",
+  );
+  return cleaned.length > 0 ? cleaned : "entry";
+}
+
+function makeArchiveTimestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function safeRealPath(path: string): string {
+  try {
+    return Deno.realPathSync(path);
+  } catch {
+    return path;
   }
 }

--- a/test/discovery/DiscoveryRunner.test.ts
+++ b/test/discovery/DiscoveryRunner.test.ts
@@ -274,6 +274,78 @@ Deno.test("DiscoveryRunner returns no improvement when candidates are not better
   }
 });
 
+Deno.test("DiscoveryRunner records evaluation summaries and archives candidates", async () => {
+  const discoveryResult: DiscoverResult = {
+    ID: "ARCHIVE_TEST",
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: undefined,
+    removeHarmfulSynapse: undefined,
+    candidateSquashes: undefined,
+  };
+
+  const baseCreature = makeBaseCreature();
+  const candidateCreature = Creature.fromJSON(baseCreature.exportJSON());
+  CreatureUtil.makeUUID(candidateCreature);
+
+  const computeError = (creature: Creature) =>
+    creature === candidateCreature ? 0.25 : 0.5;
+
+  const tempDir = await Deno.makeTempDir();
+  const previousCwd = Deno.cwd();
+
+  const runner = new DiscoveryRunner({
+    rustDiscoveryEnabled: () => true,
+    workerFactory: () =>
+      new FakeWorker(
+        discoveryResult,
+        computeError,
+      ),
+    candidateBuilder: () => [{
+      creature: candidateCreature,
+      change: { type: "add-neurons", description: "test candidate" },
+    }],
+  });
+
+  try {
+    Deno.chdir(tempDir);
+
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    assert(result.evaluations);
+    assertEquals(result.evaluations.length, 2);
+
+    const originalEval = result.evaluations.find((entry) =>
+      entry.kind === "original"
+    );
+    const candidateEval = result.evaluations.find((entry) =>
+      entry.kind === "candidate"
+    );
+
+    assert(originalEval);
+    assert(candidateEval);
+    assertEquals(candidateEval.improved, true);
+    assert(
+      (candidateEval.scoreDelta ?? 0) > 0,
+      "candidate should record positive score delta",
+    );
+
+    assert(result.candidateArchiveDir);
+    assert(candidateEval.archivePath);
+
+    const summaryPath = `${result.candidateArchiveDir}/summary.json`;
+    const summary = JSON.parse(await Deno.readTextFile(summaryPath));
+    assert(Array.isArray(summary));
+    assertEquals(summary.length, 2);
+  } finally {
+    Deno.chdir(previousCwd);
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
 Deno.test("DiscoveryRunner passes discovery focus neurons to worker", async () => {
   const discoveryResult: DiscoverResult = {
     ID: "DISCOVER_FOCUS",


### PR DESCRIPTION
… summaries

- Bumped version in deno.json to 0.198.2.
- Updated the import for @std/assert to version 1.0.16 and other standard libraries to their latest versions.
- Added functionality in DiscoveryRunner to record evaluation summaries and archive candidates, improving the tracking of discovery outcomes.
- Introduced new interfaces for evaluation summaries, enhancing the clarity and structure of evaluation data.
- Implemented tests to verify the correct recording of evaluation summaries and candidate archiving.

These changes improve the robustness and transparency of the discovery process, providing better insights into candidate evaluations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add evaluation summary recording and candidate archiving to `DiscoveryRunner`, plus version and std lib updates.
> 
> - **Discovery**:
>   - `DiscoveryRunner`
>     - Records per-evaluation summaries (kind, changeType, error/score, scoreDelta, improved) and returns them via `DiscoveryDirResult.evaluations`.
>     - Archives original/candidate exports to `.discovery/candidates/<discoveryID>/<timestamp>/` with per-entry JSON and `summary.json`; exposes `candidateArchiveDir`.
>     - Adds helpers `sanitiseSegment`, `makeArchiveTimestamp`, `safeRealPath`; uses `@std/path/join`.
>     - Introduces `DiscoveryEvaluationSummary` interface.
> - **Tests**:
>   - Add test to verify evaluation summaries and candidate archiving.
> - **Config/Deps**:
>   - Bump `version` to `0.198.2`.
>   - Update std imports: `@std/assert@1.0.16`, `@std/fs@1.0.20`, `@std/path@1.1.3`, `@std/streams@1.0.14`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7963ef90d9966002d0ed2ff5559fe2e22eb5683c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->