### PR TITLE
Add analysis deadline handling to DiscoverStructure and RustDiscovery…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.198.2",
+  "version": "0.198.3",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -226,6 +226,7 @@ export class DiscoverStructure {
   private cachedMaxOutputError?: { value: number; computedAt: number } =
     undefined;
   private lastNeuronScanStats?: NeuronScanStats;
+  private analysisDeadlineMs?: number;
   constructor(
     creature: Creature,
     timeoutSeconds: number,
@@ -334,6 +335,7 @@ export class DiscoverStructure {
       `Analysis time must be greater than 0, was: ${analysisTimeSeconds}`,
     );
     this.timeoutTS = Date.now() + analysisTimeSeconds * 1000;
+    this.analysisDeadlineMs = this.timeoutTS;
   }
 
   public setForcedFocusNeurons(neuronUUIDs: readonly string[]): void {
@@ -1554,6 +1556,7 @@ export class DiscoverStructure {
       improvementThreshold: this.improvementThreshold,
       maxCandidates: Math.max(25, focusList.length * 5),
       requireGpu: Deno.build.os === "darwin",
+      analysisDeadlineMs: this.analysisDeadlineMs,
     };
 
     try {
@@ -1617,6 +1620,7 @@ export class DiscoverStructure {
       improvementThreshold: this.improvementThreshold,
       maxCandidates: Math.max(50, focusList.length * 10),
       requireGpu: Deno.build.os === "darwin",
+      analysisDeadlineMs: this.analysisDeadlineMs,
     };
 
     try {

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -83,6 +83,7 @@ export interface RustAnalyzeSynapsesInput {
   improvementThreshold?: number;
   maxCandidates?: number;
   requireGpu?: boolean;
+  analysisDeadlineMs?: number;
 }
 
 export interface RustAnalyzeSynapsesResult {
@@ -101,6 +102,7 @@ export interface RustAnalyzeNeuronsInput {
   improvementThreshold?: number;
   maxCandidates?: number;
   requireGpu?: boolean;
+  analysisDeadlineMs?: number;
 }
 
 export interface RustAnalyzeNeuronsResult {


### PR DESCRIPTION
… interfaces

- Introduced a new property `analysisDeadlineMs` in the `DiscoverStructure` class to track the analysis deadline.
- Updated the constructor to set the `analysisDeadlineMs` based on the timeout.
- Enhanced the `RustAnalyzeSynapsesInput` and `RustAnalyzeNeuronsInput` interfaces to include `analysisDeadlineMs`, improving input handling for Rust-based analysis.

These changes improve the management of analysis timing, ensuring better control over the discovery process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `analysisDeadlineMs` to track and pass analysis deadlines from `DiscoverStructure` into Rust neuron/synapse analysis inputs.
> 
> - **DiscoverStructure (`DiscoverStructure.ts`)**:
>   - Add private `analysisDeadlineMs` and set it in `extendTimeoutForAnalysis`.
>   - Pass `analysisDeadlineMs` into Rust inputs in `runRustNeuronAnalysis` and `runRustSynapseAnalysis`.
> - **RustDiscovery (`RustDiscovery.ts`)**:
>   - Extend `RustAnalyzeSynapsesInput` and `RustAnalyzeNeuronsInput` with optional `analysisDeadlineMs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40dc00c103a8f0799bf438d617a7a6f7138e035c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->