### PR TITLE
Refactor DataRecorder to enhance timeout handling for analysis phase

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.198.4",
+  "version": "0.198.5",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -32,8 +32,9 @@ class DataRecorder {
   private readonly sampleRate: number;
   private readonly discoveryBatchSize: number;
   private readonly ID: string;
-  private readonly timeoutTS: number;
+  private timeoutTS: number;
   private readonly timeoutSeconds: number;
+  private readonly analysisTimeoutSeconds: number;
   private readonly discoveryMaxNeurons: number;
   private readonly drainEveryNBatches: number;
   private readonly rustFlushRecords: number;
@@ -73,6 +74,15 @@ class DataRecorder {
     );
     this.timeoutSeconds = discoveryTimeOutMinutes * 60;
     this.timeoutTS = Date.now() + this.timeoutSeconds * 1000;
+
+    const analysisMinutesRaw = options.discoveryAnalysisTimeoutMinutes ??
+      3;
+    const analysisTimeoutMinutes = Math.min(60, analysisMinutesRaw);
+    assert(
+      analysisTimeoutMinutes > 0,
+      "Discovery analysis timeout minutes must be greater than 0",
+    );
+    this.analysisTimeoutSeconds = analysisTimeoutMinutes * 60;
 
     this.discoveryMaxNeurons = Math.max(
       1,
@@ -508,10 +518,10 @@ class DataRecorder {
 
       // Extend timeout for analysis phase - give it dedicated time regardless of recording duration
       // This ensures analysis isn't starved if recording takes a long time
-      const analysisTimeoutMinutes = options.discoveryAnalysisTimeoutMinutes ??
-        3; // Default 3 minutes for analysis
-      const analysisTimeoutSeconds = analysisTimeoutMinutes * 60;
+      const analysisTimeoutSeconds = this.analysisTimeoutSeconds;
+      const analysisTimeoutMinutes = analysisTimeoutSeconds / 60;
       discoverStructure.extendTimeoutForAnalysis(analysisTimeoutSeconds);
+      this.timeoutTS = Date.now() + analysisTimeoutSeconds * 1000;
 
       if (shouldLogDiscovery(options)) {
         console.log(


### PR DESCRIPTION
- Changed `timeoutTS` from a readonly to a mutable property to allow updates during the analysis phase.
- Introduced `analysisTimeoutSeconds` to manage dedicated time for analysis, ensuring it is not starved by recording duration.
- Added assertions to validate the analysis timeout configuration, improving error handling and clarity.

These changes improve the management of timeouts in the discovery process, ensuring more reliable analysis outcomes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines discovery timeout handling by making `timeoutTS` mutable and introducing a validated, configurable analysis timeout used to extend analysis phase duration.
> 
> - **DataRecorder (timeout handling)**:
>   - Make `timeoutTS` mutable to allow updates during analysis.
>   - Add `analysisTimeoutSeconds`, derived from `options.discoveryAnalysisTimeoutMinutes` (default 3, capped at 60) with assertions.
>   - Use `analysisTimeoutSeconds` to extend analysis phase via `extendTimeoutForAnalysis` and reset `timeoutTS`; improve related logging.
> - **Behavior/validation**:
>   - Enforce positive, bounded analysis timeout configuration; maintain existing discovery timeout logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d4458073e8ee2b94f3c69202b03bd3faecf02ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->