### PR TITLE
Update version to 0.200.0 and refactor DataRecorder analysis handling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.199.0",
+  "version": "0.200.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -668,105 +668,59 @@ class DataRecorder {
         }
 
         phaseDiagnostics.enterPhase("analysis_parallel");
-        const runAnalysisPhase = <T>(
-          enabled: boolean,
-          label: string,
-          executor: () => Promise<T>,
-        ): Promise<T | undefined> => {
-          if (!enabled) return Promise.resolve(undefined);
-          const stopTracking = phaseDiagnostics.startParallelPhase(label);
-          return executor()
-            .finally(() => {
-              stopTracking();
-            });
-        };
+        let addHelpfulNeurons: CandidateNeuron[] | undefined;
+        let addHelpfulSynapse: CandidateSynapse[] | undefined;
+        let removeHarmfulSynapse: CandidateSynapse | undefined;
+        let candidateSquashes: CandidateSquash[] | undefined;
 
-        const neuronPromise = runAnalysisPhase(
-          this.enableNeuronCandidates,
-          "analyze_neurons",
-          async () => {
-            const neuronAnalyzeStart = Date.now();
-            const addHelpfulNeurons = await discoverStructure
-              .analyzeMissingNeurons(
-                newFocusList,
-              );
-            this.refreshAnalysisTimeout(discoverStructure);
-            if (shouldLogDiscovery(options)) {
-              const neuronAnalyzeTime = Date.now() - neuronAnalyzeStart;
-              console.log(
-                `Discovery ${blue(this.ID)} analyze neurons time ${
-                  yellow(format(neuronAnalyzeTime, { ignoreZero: true }))
-                } found ${
-                  addHelpfulNeurons ? addHelpfulNeurons.length : 0
-                } neuron candidates`,
-              );
-            }
-            return addHelpfulNeurons;
+        const parallelStartTime = Date.now();
+        const candidateBundle = discoverStructure.collectRustAnalysisCandidates(
+          newFocusList,
+          {
+            helpfulSynapse: this.enableSynapseCandidates,
+            harmfulSynapse: this.enableHarmfulCandidates,
+            helpfulNeuron: this.enableNeuronCandidates,
           },
         );
 
-        const synapsePromise = runAnalysisPhase(
-          this.enableSynapseCandidates,
-          "analyze_helpful",
-          async () => {
-            const analyzeStartTime = Date.now();
-            const addHelpfulSynapse = await discoverStructure
-              .analyzeSelectedNeurons(
-                newFocusList,
-              );
-            this.refreshAnalysisTimeout(discoverStructure);
-            if (shouldLogDiscovery(options)) {
-              const analyzeTime = Date.now() - analyzeStartTime;
-              console.log(
-                `Discovery ${blue(this.ID)} analyze synapses time ${
-                  yellow(format(analyzeTime, { ignoreZero: true }))
-                } found ${
-                  addHelpfulSynapse ? addHelpfulSynapse.length : 0
-                } candidate${
-                  addHelpfulSynapse && addHelpfulSynapse.length === 1 ? "" : "s"
-                }`,
-              );
-            }
-            return addHelpfulSynapse;
-          },
-        );
+        if (candidateBundle) {
+          phaseDiagnostics.enterPhase("analysis_loop");
+          addHelpfulSynapse = this.enableSynapseCandidates
+            ? candidateBundle.helpfulSynapses
+            : undefined;
+          removeHarmfulSynapse = this.enableHarmfulCandidates
+            ? candidateBundle.harmfulSynapse
+            : undefined;
+          addHelpfulNeurons = this.enableNeuronCandidates
+            ? candidateBundle.helpfulNeurons
+            : undefined;
+          this.refreshAnalysisTimeout(discoverStructure);
 
-        const harmfulPromise = runAnalysisPhase(
-          this.enableHarmfulCandidates,
-          "analyze_harmful",
-          async () => {
-            const harmfulStartTime = Date.now();
-            const removeHarmfulSynapse = await discoverStructure
-              .analyzeSelectedNeuronsForRemoval(newFocusList);
-            this.refreshAnalysisTimeout(discoverStructure);
-            if (shouldLogDiscovery(options)) {
-              const harmfulTime = Date.now() - harmfulStartTime;
-              console.log(
-                `Discovery ${blue(this.ID)} analyze harmful time ${
-                  yellow(format(harmfulTime, { ignoreZero: true }))
-                } found ${removeHarmfulSynapse ? 1 : 0} candidates`,
-              );
-            }
-            return removeHarmfulSynapse;
-          },
-        );
+          if (shouldLogDiscovery(options)) {
+            const duration = Date.now() - parallelStartTime;
+            const helpfulSynapseCount = addHelpfulSynapse?.length ?? 0;
+            const helpfulNeuronCount = addHelpfulNeurons?.length ?? 0;
+            const harmfulCount = removeHarmfulSynapse ? 1 : 0;
+            console.log(
+              `Discovery ${blue(this.ID)} rust combined analysis ${
+                yellow(format(duration, {
+                  ignoreZero: true,
+                }))
+              } synapse candidates: ${helpfulSynapseCount}, neuron candidates: ${helpfulNeuronCount}, harmful removals: ${harmfulCount}`,
+            );
+          }
 
-        const squashPromise = runAnalysisPhase(
-          this.enableSquashCandidates,
-          "analyze_squash",
-          async () => {
+          if (this.enableSquashCandidates) {
             const squashStartTime = Date.now();
-            const candidateSquashes = await discoverStructure
+            // deno-lint-ignore no-await-in-loop
+            candidateSquashes = await discoverStructure
               .analyzeSelectedNeuronsSquashes(newFocusList);
             this.refreshAnalysisTimeout(discoverStructure);
             if (shouldLogDiscovery(options)) {
               const squashTime = Date.now() - squashStartTime;
-              const squashCount = candidateSquashes
-                ? candidateSquashes.length
-                : 0;
+              const squashCount = candidateSquashes?.length ?? 0;
               let squashSummaryText = "";
-              if (squashCount > 0) {
-                assert(candidateSquashes, "No candidate squashes");
+              if (squashCount > 0 && candidateSquashes) {
                 const squashSummary = candidateSquashes.map((candidate) => {
                   return `${candidate.neuronUUID} ${candidate.previousSquash} -> ${candidate.squash} improved: ${
                     (candidate.expectedImprovementPercentage * 100).toFixed(1)
@@ -784,30 +738,148 @@ class DataRecorder {
                 }${squashSummaryText}`,
               );
             }
-            return candidateSquashes;
-          },
-        );
+          }
+        } else {
+          const runAnalysisPhase = <T>(
+            enabled: boolean,
+            label: string,
+            executor: () => Promise<T>,
+          ): Promise<T | undefined> => {
+            if (!enabled) return Promise.resolve(undefined);
+            const stopTracking = phaseDiagnostics.startParallelPhase(label);
+            return executor()
+              .finally(() => {
+                stopTracking();
+              });
+          };
 
-        const analysisPromises: [
-          Promise<CandidateNeuron[] | undefined>,
-          Promise<CandidateSynapse[] | undefined>,
-          Promise<CandidateSynapse | undefined>,
-          Promise<CandidateSquash[] | undefined>,
-        ] = [
-          neuronPromise,
-          synapsePromise,
-          harmfulPromise,
-          squashPromise,
-        ];
-        // deno-lint-ignore no-await-in-loop
-        const analysisResults = await Promise.all(analysisPromises);
-        phaseDiagnostics.enterPhase("analysis_loop");
-        const [
-          addHelpfulNeurons,
-          addHelpfulSynapse,
-          removeHarmfulSynapse,
-          candidateSquashes,
-        ] = analysisResults;
+          const neuronPromise = runAnalysisPhase(
+            this.enableNeuronCandidates,
+            "analyze_neurons",
+            async () => {
+              const neuronAnalyzeStart = Date.now();
+              const helpfulNeurons = await discoverStructure
+                .analyzeMissingNeurons(
+                  newFocusList,
+                );
+              this.refreshAnalysisTimeout(discoverStructure);
+              if (shouldLogDiscovery(options)) {
+                const neuronAnalyzeTime = Date.now() - neuronAnalyzeStart;
+                console.log(
+                  `Discovery ${blue(this.ID)} analyze neurons time ${
+                    yellow(format(neuronAnalyzeTime, { ignoreZero: true }))
+                  } found ${
+                    helpfulNeurons ? helpfulNeurons.length : 0
+                  } neuron candidates`,
+                );
+              }
+              return helpfulNeurons;
+            },
+          );
+
+          const synapsePromise = runAnalysisPhase(
+            this.enableSynapseCandidates,
+            "analyze_helpful",
+            async () => {
+              const analyzeStartTime = Date.now();
+              const helpfulSynapses = await discoverStructure
+                .analyzeSelectedNeurons(
+                  newFocusList,
+                );
+              this.refreshAnalysisTimeout(discoverStructure);
+              if (shouldLogDiscovery(options)) {
+                const analyzeTime = Date.now() - analyzeStartTime;
+                console.log(
+                  `Discovery ${blue(this.ID)} analyze synapses time ${
+                    yellow(format(analyzeTime, { ignoreZero: true }))
+                  } found ${
+                    helpfulSynapses ? helpfulSynapses.length : 0
+                  } candidate${
+                    helpfulSynapses && helpfulSynapses.length === 1 ? "" : "s"
+                  }`,
+                );
+              }
+              return helpfulSynapses;
+            },
+          );
+
+          const harmfulPromise = runAnalysisPhase(
+            this.enableHarmfulCandidates,
+            "analyze_harmful",
+            async () => {
+              const harmfulStartTime = Date.now();
+              const harmfulSynapse = await discoverStructure
+                .analyzeSelectedNeuronsForRemoval(newFocusList);
+              this.refreshAnalysisTimeout(discoverStructure);
+              if (shouldLogDiscovery(options)) {
+                const harmfulTime = Date.now() - harmfulStartTime;
+                console.log(
+                  `Discovery ${blue(this.ID)} analyze harmful time ${
+                    yellow(format(harmfulTime, { ignoreZero: true }))
+                  } found ${harmfulSynapse ? 1 : 0} candidates`,
+                );
+              }
+              return harmfulSynapse;
+            },
+          );
+
+          const squashPromise = runAnalysisPhase(
+            this.enableSquashCandidates,
+            "analyze_squash",
+            async () => {
+              const squashStartTime = Date.now();
+              const squashes = await discoverStructure
+                .analyzeSelectedNeuronsSquashes(newFocusList);
+              this.refreshAnalysisTimeout(discoverStructure);
+              if (shouldLogDiscovery(options)) {
+                const squashTime = Date.now() - squashStartTime;
+                const squashCount = squashes ? squashes.length : 0;
+                let squashSummaryText = "";
+                if (squashCount > 0 && squashes) {
+                  const squashSummary = squashes.map((candidate) => {
+                    return `${candidate.neuronUUID} ${candidate.previousSquash} -> ${candidate.squash} improved: ${
+                      (candidate.expectedImprovementPercentage * 100).toFixed(
+                        1,
+                      )
+                    }% error: ${candidate.currentError.toFixed(4)} -> ${
+                      candidate.improvedError.toFixed(4)
+                    }`;
+                  });
+                  squashSummaryText = `, Summary: ${squashSummary.join(",")}`;
+                }
+                console.log(
+                  `Discovery ${blue(this.ID)} analyze squashes time ${
+                    yellow(format(squashTime, { ignoreZero: true }))
+                  } found ${squashCount} candidate${
+                    squashCount === 1 ? "" : "s"
+                  }${squashSummaryText}`,
+                );
+              }
+              return squashes;
+            },
+          );
+
+          const analysisPromises: [
+            Promise<CandidateNeuron[] | undefined>,
+            Promise<CandidateSynapse[] | undefined>,
+            Promise<CandidateSynapse | undefined>,
+            Promise<CandidateSquash[] | undefined>,
+          ] = [
+            neuronPromise,
+            synapsePromise,
+            harmfulPromise,
+            squashPromise,
+          ];
+          // deno-lint-ignore no-await-in-loop
+          const analysisResults = await Promise.all(analysisPromises);
+          phaseDiagnostics.enterPhase("analysis_loop");
+          [
+            addHelpfulNeurons,
+            addHelpfulSynapse,
+            removeHarmfulSynapse,
+            candidateSquashes,
+          ] = analysisResults;
+        }
 
         if (addHelpfulNeurons && addHelpfulNeurons.length > 0) {
           discoverResult.addHelpfulNeurons = [

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -12,6 +12,7 @@ import type { DataRecordInterface } from "../DataSet.ts";
 import {
   analyzeAll,
   analyzeNeurons,
+  analyzeParallel,
   analyzeSynapses,
   creatureToRustFormat,
   isRustDiscoveryEnabled,
@@ -30,6 +31,8 @@ import {
   type RustCandidateSynapse,
   type RustNeuronDiagnostic,
   type RustNeuronDiagnosticDetail,
+  type RustParallelAnalysisInput,
+  type RustParallelAnalysisResult,
   type RustRecordBatchStats,
   type RustRecordInput,
   type RustSynapseDiagnostic,
@@ -46,6 +49,7 @@ export interface DiscoverStructureDeps {
   mergeDiscoveryParquet: typeof mergeDiscoveryParquet;
   analyzeNeurons: typeof analyzeNeurons;
   analyzeSynapses: typeof analyzeSynapses;
+  analyzeParallel?: typeof analyzeParallel;
   analyzeAll?: typeof analyzeAll;
   readDiscoveryRecords: typeof readDiscoveryRecords;
   rankFocusNeurons?: typeof rankFocusNeurons;
@@ -58,6 +62,7 @@ const DEFAULT_DISCOVER_STRUCTURE_DEPS: DiscoverStructureDeps = {
   mergeDiscoveryParquet,
   analyzeNeurons,
   analyzeSynapses,
+  analyzeParallel,
   analyzeAll,
   readDiscoveryRecords,
   rankFocusNeurons,
@@ -121,6 +126,12 @@ export interface CandidateNeuron {
   expectedImprovementPercentage: number;
   improvedCount: number;
   totalCount: number;
+}
+
+interface CandidateAnalysisBundle {
+  helpfulSynapses?: CandidateSynapse[];
+  harmfulSynapse?: CandidateSynapse;
+  helpfulNeurons?: CandidateNeuron[];
 }
 
 type FocusSelectionMode = "weighted" | "forced" | "all" | "random";
@@ -1433,10 +1444,16 @@ export class DiscoverStructure {
       return [];
     }
 
-    candidates.sort((a, b) =>
+    const topCandidates = this.filterTopSynapseCandidates(candidates);
+    if (topCandidates.length === 0) {
+      this.logRustNoImprovement("synapse", focusList, rustResult.diagnostics);
+      return [];
+    }
+
+    topCandidates.sort((a, b) =>
       b.expectedImprovementPercentage - a.expectedImprovementPercentage
     );
-    return candidates;
+    return topCandidates;
   }
 
   private tryRustHarmfulCandidates(
@@ -1466,6 +1483,54 @@ export class DiscoverStructure {
       a.expectedImprovementPercentage - b.expectedImprovementPercentage
     );
     return candidates;
+  }
+
+  public collectRustAnalysisCandidates(
+    focusList: string[],
+    options: {
+      helpfulSynapse: boolean;
+      harmfulSynapse: boolean;
+      helpfulNeuron: boolean;
+    },
+  ): CandidateAnalysisBundle | undefined {
+    const includeSynapse = options.helpfulSynapse || options.harmfulSynapse;
+    const includeNeuron = options.helpfulNeuron;
+    if (!includeSynapse && !includeNeuron) {
+      return {};
+    }
+
+    const combinedResult = this.ensureRustCombinedAnalysis(
+      focusList,
+      includeSynapse,
+      includeNeuron,
+    );
+    if (!combinedResult) {
+      return undefined;
+    }
+
+    const bundle: CandidateAnalysisBundle = {};
+    if (options.helpfulSynapse) {
+      const helpfulSynapses = this.tryRustHelpfulSynapses(focusList);
+      if (helpfulSynapses && helpfulSynapses.length > 0) {
+        bundle.helpfulSynapses = helpfulSynapses;
+      }
+    }
+
+    if (options.harmfulSynapse) {
+      const harmfulSynapses = this.tryRustHarmfulCandidates(focusList);
+      if (harmfulSynapses && harmfulSynapses.length > 0) {
+        bundle.harmfulSynapse = harmfulSynapses[0];
+      }
+    }
+
+    if (options.helpfulNeuron) {
+      const helpfulNeurons = this.tryRustHelpfulNeurons(focusList);
+      if (helpfulNeurons && helpfulNeurons.length > 0) {
+        bundle.helpfulNeurons = helpfulNeurons;
+      }
+    }
+
+    return bundle;
   }
 
   private candidateKey(candidate: CandidateSynapse): string {
@@ -1523,6 +1588,23 @@ export class DiscoverStructure {
     return Array.from(grouped.values()).sort((a, b) =>
       b.expectedImprovementPercentage - a.expectedImprovementPercentage
     );
+  }
+
+  private filterTopSynapseCandidates(
+    candidates: CandidateSynapse[],
+  ): CandidateSynapse[] {
+    const grouped = new Map<string, CandidateSynapse>();
+    candidates.forEach((candidate) => {
+      const existing = grouped.get(candidate.toNeuronUUID);
+      if (
+        !existing ||
+        candidate.expectedImprovementPercentage >
+          existing.expectedImprovementPercentage
+      ) {
+        grouped.set(candidate.toNeuronUUID, candidate);
+      }
+    });
+    return Array.from(grouped.values());
   }
 
   private logHarmfulSynapse(candidate: CandidateSynapse): void {
@@ -1885,6 +1967,51 @@ export class DiscoverStructure {
     }
 
     const rustCreature = creatureToRustFormat(this.creature.exportJSON());
+
+    if (this.deps.analyzeParallel) {
+      const parallelInput: RustParallelAnalysisInput = {
+        parquetFile: this.parquetFilePath,
+        creature: rustCreature,
+        focusNeurons: focusList,
+        improvementThreshold: this.improvementThreshold,
+        harmfulThreshold: this.harmfulThreshold,
+        maxSynapseCandidates: includeSynapse
+          ? Math.max(50, focusList.length * 10)
+          : undefined,
+        maxNeuronCandidates: includeNeuron
+          ? Math.max(25, focusList.length * 5)
+          : undefined,
+        requireGpu: Deno.build.os === "darwin",
+        analysisDeadlineMs: this.analysisDeadlineMs,
+      };
+
+      const parallelResult = this.deps.analyzeParallel(parallelInput);
+      if (!parallelResult || !parallelResult.success) {
+        const reason = parallelResult?.error ??
+          "analysis did not return a result";
+        if (includeSynapse) {
+          this.logRustAnalysisUnavailable("synapse", focusList, reason);
+        }
+        if (includeNeuron) {
+          this.logRustAnalysisUnavailable("neuron", focusList, reason);
+        }
+        this.combinedRustAnalysis = undefined;
+        return undefined;
+      }
+      const converted = this.convertParallelAnalysisResult(parallelResult);
+      this.combinedRustAnalysis = {
+        key: cacheKey,
+        includeSynapse,
+        includeNeuron,
+        result: converted,
+      };
+      return converted;
+    }
+
+    if (!this.deps.analyzeAll) {
+      return undefined;
+    }
+
     const rustInput: RustAnalyzeAllInput = {
       parquetFile: this.parquetFilePath,
       creature: rustCreature,
@@ -1944,6 +2071,46 @@ export class DiscoverStructure {
       return undefined;
     }
     return cached.result;
+  }
+
+  private convertParallelAnalysisResult(
+    parallel: RustParallelAnalysisResult,
+  ): RustAnalyzeAllResult {
+    const hasSynapsePayload = Boolean(
+      parallel.helpfulSynapses?.length ||
+        parallel.harmfulSynapses?.length ||
+        parallel.synapseDiagnostics?.length,
+    );
+    const hasNeuronPayload = Boolean(
+      parallel.helpfulNeurons?.length ||
+        parallel.neuronDiagnostics?.length,
+    );
+
+    const synapseResult: RustAnalyzeSynapsesResult | undefined =
+      hasSynapsePayload
+        ? {
+          success: true,
+          gpuUsed: parallel.synapseGpuUsed,
+          helpfulSynapses: parallel.helpfulSynapses,
+          harmfulSynapses: parallel.harmfulSynapses,
+          diagnostics: parallel.synapseDiagnostics,
+        }
+        : undefined;
+    const neuronResult: RustAnalyzeNeuronsResult | undefined = hasNeuronPayload
+      ? {
+        success: true,
+        gpuUsed: parallel.neuronGpuUsed,
+        helpfulNeurons: parallel.helpfulNeurons,
+        diagnostics: parallel.neuronDiagnostics,
+      }
+      : undefined;
+
+    return {
+      success: parallel.success,
+      synapse: synapseResult,
+      neuron: neuronResult,
+      error: parallel.error,
+    };
   }
 
   private logAnalysisSkipped(scope: "synapse" | "neuron"): void {

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -134,6 +134,30 @@ export interface RustAnalyzeAllResult {
   error?: string;
 }
 
+export interface RustParallelAnalysisInput {
+  parquetFile: string;
+  creature: RustRecordInput["creature"];
+  focusNeurons: string[];
+  improvementThreshold?: number;
+  harmfulThreshold?: number;
+  maxSynapseCandidates?: number;
+  maxNeuronCandidates?: number;
+  requireGpu?: boolean;
+  analysisDeadlineMs?: number;
+}
+
+export interface RustParallelAnalysisResult {
+  success: boolean;
+  helpfulSynapses?: RustCandidateSynapse[];
+  harmfulSynapses?: RustCandidateSynapse[];
+  synapseDiagnostics?: RustSynapseDiagnostic[];
+  synapseGpuUsed?: boolean;
+  helpfulNeurons?: RustCandidateNeuron[];
+  neuronDiagnostics?: RustNeuronDiagnostic[];
+  neuronGpuUsed?: boolean;
+  error?: string;
+}
+
 export interface RustRankFocusInput {
   parquetFile: string;
   creature: RustRecordInput["creature"];
@@ -566,6 +590,11 @@ type RustDiscoverySymbols = {
     result: "pointer";
     nonblocking: false;
   };
+  "analyze_parallel": {
+    parameters: ["pointer"];
+    result: "pointer";
+    nonblocking: false;
+  };
   "analyze_all": {
     parameters: ["pointer"];
     result: "pointer";
@@ -652,6 +681,11 @@ export function loadRustLibrary(): boolean {
         nonblocking: false,
       },
       "analyze_synapses": {
+        parameters: ["pointer"],
+        result: "pointer",
+        nonblocking: false,
+      },
+      "analyze_parallel": {
         parameters: ["pointer"],
         result: "pointer",
         nonblocking: false,
@@ -1210,6 +1244,43 @@ export function analyzeAll(
     rustLib.symbols["free_discovery_result"](resultPtr);
 
     const result = JSON.parse(resultJson) as RustAnalyzeAllResult;
+    return result;
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function analyzeParallel(
+  input: RustParallelAnalysisInput,
+): RustParallelAnalysisResult | null {
+  if (!isRustLibraryAvailable()) {
+    return null;
+  }
+
+  assert(rustLib !== null, "Rust library should be loaded");
+
+  try {
+    const inputJson = JSON.stringify(input);
+    const inputBytes = new TextEncoder().encode(inputJson);
+    const inputBuffer = new Uint8Array(inputBytes.length + 1);
+    inputBuffer.set(inputBytes);
+    inputBuffer[inputBytes.length] = 0;
+    const inputPtr = Deno.UnsafePointer.of(inputBuffer);
+    const resultPtr = rustLib.symbols["analyze_parallel"](inputPtr);
+
+    if (resultPtr === null) {
+      return {
+        success: false,
+        error: "Rust function returned null pointer",
+      };
+    }
+
+    const resultJson = readCString(resultPtr);
+    rustLib.symbols["free_discovery_result"](resultPtr);
+    const result = JSON.parse(resultJson) as RustParallelAnalysisResult;
     return result;
   } catch (error) {
     return {

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -9,7 +9,8 @@ export type DiscoveryChangeType =
   | "remove-synapse"
   | "change-squash"
   | "combo-add-remove"
-  | "combo-add-change";
+  | "combo-add-change"
+  | "combo-all";
 
 export interface DiscoveryCandidate {
   creature: Creature;
@@ -142,5 +143,121 @@ export function buildDiscoveryCandidates(
     }
   }
 
+  const combinedCandidate = buildCombinedCandidate({
+    baseCreature,
+    discovery,
+    includeAddNeurons: Boolean(addedNeuronCreature),
+    includeAddSynapses: Boolean(addedSynapseCreature),
+    includeRemoveSynapse: Boolean(removedSynapseCreature),
+    includeChangeSquash: Boolean(changedSquashCreature),
+  });
+  if (combinedCandidate) {
+    candidates.push(combinedCandidate);
+  }
+
   return candidates;
+}
+
+interface CombinedCandidateContext {
+  baseCreature: Creature;
+  discovery: DiscoverResult;
+  includeAddNeurons: boolean;
+  includeAddSynapses: boolean;
+  includeRemoveSynapse: boolean;
+  includeChangeSquash: boolean;
+}
+
+function buildCombinedCandidate(
+  context: CombinedCandidateContext,
+): DiscoveryCandidate | undefined {
+  const {
+    baseCreature,
+    discovery,
+    includeAddNeurons,
+    includeAddSynapses,
+    includeRemoveSynapse,
+    includeChangeSquash,
+  } = context;
+
+  const requestedCategories = [
+    includeAddNeurons,
+    includeAddSynapses,
+    includeRemoveSynapse,
+    includeChangeSquash,
+  ].filter(Boolean).length;
+  if (requestedCategories < 2) {
+    return undefined;
+  }
+
+  let combinedCreature = baseCreature;
+  const appliedLabels: DiscoveryChangeType[] = [];
+
+  const applyChange = (
+    enabled: boolean,
+    label: DiscoveryChangeType,
+    mutator: (creature: Creature) => Creature | undefined,
+  ) => {
+    if (!enabled) return;
+    const updated = mutator(combinedCreature);
+    if (updated && updated !== combinedCreature) {
+      combinedCreature = updated;
+      appliedLabels.push(label);
+    }
+  };
+
+  applyChange(
+    includeRemoveSynapse,
+    "remove-synapse",
+    (creature) =>
+      DiscoverStructure.removeSynapse(
+        discovery.ID,
+        creature,
+        discovery.removeHarmfulSynapse,
+      ) ?? undefined,
+  );
+
+  applyChange(
+    includeAddNeurons,
+    "add-neurons",
+    (creature) =>
+      DiscoverStructure.addHelpfulNeurons(
+        discovery.ID,
+        creature,
+        discovery.addHelpfulNeurons,
+      ),
+  );
+
+  applyChange(
+    includeAddSynapses,
+    "add-synapses",
+    (creature) =>
+      DiscoverStructure.addHelpfulSynapses(
+        discovery.ID,
+        creature,
+        discovery.addHelpfulSynapses,
+      ),
+  );
+
+  applyChange(
+    includeChangeSquash,
+    "change-squash",
+    (creature) =>
+      DiscoverStructure.changeSquash(
+        discovery.ID,
+        creature,
+        discovery.candidateSquashes,
+      ),
+  );
+
+  if (appliedLabels.length < 2 || combinedCreature === baseCreature) {
+    return undefined;
+  }
+
+  return {
+    creature: combinedCreature,
+    change: {
+      type: "combo-all",
+      description: `Combined discovery changes (${appliedLabels.join(", ")})`,
+    },
+  };
 }

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -250,10 +250,10 @@ export class DiscoveryRunner {
           : "";
         const message =
           `${improved.candidate.change.type} for discovery ${discoverResult.ID} improved score by ${
-            scoreDelta >= 0 ? "+" : ""
-          }${scoreDelta.toFixed(4)} (from ${original.score.toFixed(4)} to ${
-            improved.score.toFixed(4)
-          }).${changeDescription ? changeDescription : ""}`;
+            scoreDelta.toPrecision(4)
+          } to ${improved.score.toPrecision(4)}.${
+            changeDescription ? changeDescription : ""
+          }`;
 
         outcome.improvement = {
           changeType: improved.candidate.change.type,

--- a/test/discovery/DiscoveryCandidates.test.ts
+++ b/test/discovery/DiscoveryCandidates.test.ts
@@ -4,6 +4,8 @@ import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
 import {
   type CandidateNeuron,
+  type CandidateSquash,
+  type CandidateSynapse,
   DEFAULT_RUST_FLUSH_RECORDS,
   DiscoverStructure,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
@@ -236,6 +238,7 @@ Deno.test({
       assertEquals(types, [
         "add-synapses",
         "combo-add-remove",
+        "combo-all",
         "remove-synapse",
       ]);
 
@@ -348,3 +351,114 @@ Deno.test("buildDiscoveryCandidates includes helpful neuron suggestions", () => 
     "Expected discovered neuron to include incoming and outgoing synapses.",
   );
 });
+
+Deno.test(
+  "buildDiscoveryCandidates synthesises combined candidate across categories",
+  () => {
+    const base = makeBaselineCreature();
+    const helpfulSynapses: CandidateSynapse[] = [{
+      fromNeuronUUID: "hidden-2",
+      toNeuronUUID: "output-0",
+      weight: 0.9,
+      expectedImprovementPercentage: 0.2,
+      improvedCount: 3,
+      totalCount: 5,
+    }];
+    const removeCandidate: CandidateSynapse = {
+      fromNeuronUUID: "input-0",
+      toNeuronUUID: "hidden-1",
+      weight: 0.1,
+      expectedImprovementPercentage: 0.15,
+      improvedCount: 4,
+      totalCount: 6,
+    };
+    const neuronCandidate: CandidateNeuron = {
+      fromNeuronUUID: "input-2",
+      toNeuronUUID: "hidden-2",
+      incomingWeight: 0.33,
+      outgoingWeight: -0.22,
+      squash: TANH.NAME,
+      bias: 0.07,
+      expectedImprovementPercentage: 0.18,
+      improvedCount: 6,
+      totalCount: 8,
+    };
+    const squashCandidate: CandidateSquash = {
+      neuronUUID: "hidden-1",
+      previousSquash: IDENTITY.NAME,
+      squash: Mish.NAME,
+      expectedImprovementPercentage: 0.21,
+      improvedError: 0.04,
+      currentError: 0.09,
+    };
+
+    const discovery: DiscoverResult = {
+      ID: "COMBO-ALL",
+      addHelpfulSynapses: helpfulSynapses,
+      addHelpfulNeurons: [neuronCandidate],
+      removeHarmfulSynapse: removeCandidate,
+      candidateSquashes: [squashCandidate],
+    };
+
+    const candidates = buildDiscoveryCandidates(base, discovery);
+    const comboAll = findCandidate(candidates, "combo-all");
+    const exported = comboAll.creature.exportJSON();
+
+    const harmfulStillExists = exported.synapses.some((synapse) =>
+      synapse.fromUUID === removeCandidate.fromNeuronUUID &&
+      synapse.toUUID === removeCandidate.toNeuronUUID
+    );
+    assertEquals(
+      harmfulStillExists,
+      false,
+      "Combined candidate should remove the harmful synapse.",
+    );
+
+    const helpfulSynapseExists = exported.synapses.some((synapse) =>
+      synapse.fromUUID === helpfulSynapses[0].fromNeuronUUID &&
+      synapse.toUUID === helpfulSynapses[0].toNeuronUUID &&
+      Math.abs(synapse.weight - helpfulSynapses[0].weight) < 1e-6
+    );
+    assert(
+      helpfulSynapseExists,
+      "Combined candidate should include the beneficial synapse.",
+    );
+
+    const hidden1 = exported.neurons.find((neuron) =>
+      neuron.uuid === "hidden-1"
+    );
+    assert(hidden1, "Hidden neuron should exist after combination.");
+    assertEquals(
+      hidden1?.squash,
+      squashCandidate.squash,
+      "Combined candidate should update the squash function.",
+    );
+
+    const incomingDiscoverySynapse = exported.synapses.find((synapse) =>
+      synapse.fromUUID === neuronCandidate.fromNeuronUUID &&
+      Math.abs(synapse.weight - neuronCandidate.incomingWeight) < 1e-6
+    );
+    assert(
+      incomingDiscoverySynapse,
+      "Expected discovery neuron incoming synapse to exist.",
+    );
+    const discoveredNeuronUUID = incomingDiscoverySynapse!.toUUID;
+    const outgoingDiscoverySynapse = exported.synapses.find((synapse) =>
+      synapse.fromUUID === discoveredNeuronUUID &&
+      synapse.toUUID === neuronCandidate.toNeuronUUID &&
+      Math.abs(synapse.weight - neuronCandidate.outgoingWeight) < 1e-6
+    );
+    assert(
+      outgoingDiscoverySynapse,
+      "Expected discovery neuron outgoing synapse to exist.",
+    );
+
+    const discoveredNeuron = exported.neurons.find((neuron) =>
+      neuron.uuid === discoveredNeuronUUID
+    );
+    assert(
+      discoveredNeuron,
+      "Combined candidate should include discovered neuron.",
+    );
+  },
+);

--- a/test/discovery/DiscoveryRunner.test.ts
+++ b/test/discovery/DiscoveryRunner.test.ts
@@ -243,6 +243,144 @@ Deno.test("DiscoveryRunner returns best improvement with informative message", a
   }
 });
 
+Deno.test(
+  "DiscoveryRunner considers combined multi-category candidate when selecting best result",
+  async () => {
+    const helpfulSynapse = {
+      fromNeuronUUID: "input-1",
+      toNeuronUUID: "hidden-1",
+      weight: 0.45,
+      expectedImprovementPercentage: 0.2,
+      improvedCount: 4,
+      totalCount: 6,
+    };
+    const harmfulSynapse = {
+      fromNeuronUUID: "input-1",
+      toNeuronUUID: "output-0",
+      weight: -0.25,
+      expectedImprovementPercentage: 0.1,
+      improvedCount: 3,
+      totalCount: 5,
+    };
+    const neuronCandidate = {
+      fromNeuronUUID: "input-0",
+      toNeuronUUID: "hidden-1",
+      incomingWeight: 0.4,
+      outgoingWeight: -0.3,
+      squash: "TANH",
+      bias: 0.05,
+      expectedImprovementPercentage: 0.22,
+      improvedCount: 5,
+      totalCount: 7,
+    };
+    const squashCandidate = {
+      neuronUUID: "hidden-1",
+      previousSquash: "IDENTITY",
+      squash: "ELU",
+      expectedImprovementPercentage: 0.18,
+      improvedError: 0.03,
+      currentError: 0.07,
+    };
+
+    const discoveryResult: DiscoverResult = {
+      ID: "DISCOVER_COMBINED",
+      addHelpfulSynapses: [helpfulSynapse],
+      addHelpfulNeurons: [neuronCandidate],
+      removeHarmfulSynapse: harmfulSynapse,
+      candidateSquashes: [squashCandidate],
+    };
+
+    const computeError = (creature: Creature) => {
+      const json = creature.exportJSON();
+      const synapses = json.synapses;
+      const neurons = json.neurons;
+
+      const hasHelpfulSynapse = synapses.some((synapse) =>
+        synapse.fromUUID === helpfulSynapse.fromNeuronUUID &&
+        synapse.toUUID === helpfulSynapse.toNeuronUUID &&
+        Math.abs(synapse.weight - helpfulSynapse.weight) < 1e-6
+      );
+      const harmfulSynapsePresent = synapses.some((synapse) =>
+        synapse.fromUUID === harmfulSynapse.fromNeuronUUID &&
+        synapse.toUUID === harmfulSynapse.toNeuronUUID
+      );
+      const hidden1 = neurons.find((neuron) =>
+        neuron.uuid === squashCandidate.neuronUUID
+      );
+      const squashUpdated = hidden1?.squash === squashCandidate.squash;
+
+      const incomingDiscoverySynapse = synapses.find((synapse) =>
+        synapse.fromUUID === neuronCandidate.fromNeuronUUID &&
+        Math.abs(synapse.weight - neuronCandidate.incomingWeight) < 1e-6
+      );
+      const discoveredNeuronUUID = incomingDiscoverySynapse?.toUUID;
+      const outgoingDiscoverySynapse = synapses.find((synapse) =>
+        discoveredNeuronUUID &&
+        synapse.fromUUID === discoveredNeuronUUID &&
+        synapse.toUUID === neuronCandidate.toNeuronUUID &&
+        Math.abs(synapse.weight - neuronCandidate.outgoingWeight) < 1e-6
+      );
+      const hasDiscoveredNeuron = Boolean(
+        discoveredNeuronUUID &&
+          outgoingDiscoverySynapse &&
+          neurons.some((neuron) => neuron.uuid === discoveredNeuronUUID),
+      );
+
+      if (
+        hasHelpfulSynapse && !harmfulSynapsePresent && squashUpdated &&
+        hasDiscoveredNeuron
+      ) {
+        return 0.15;
+      }
+      if (hasHelpfulSynapse && !harmfulSynapsePresent && squashUpdated) {
+        return 0.2;
+      }
+      if (hasHelpfulSynapse && !harmfulSynapsePresent) {
+        return 0.25;
+      }
+      if (hasHelpfulSynapse && squashUpdated) {
+        return 0.28;
+      }
+      if (hasHelpfulSynapse) {
+        return 0.32;
+      }
+      if (!harmfulSynapsePresent) {
+        return 0.4;
+      }
+      if (squashUpdated) {
+        return 0.45;
+      }
+      return 0.5;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          computeError,
+        ),
+    });
+
+    const result = await runner.discoverDir({
+      creature: makeBaseCreature(),
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    assert(result.improvement, "Expected an improvement to be recorded.");
+    assertEquals(
+      result.improvement?.changeType,
+      "combo-all",
+      "Combined candidate should be considered the best improvement.",
+    );
+    assert(
+      (result.improvement?.scoreDelta ?? 0) > 0,
+      "Combined candidate should improve the score.",
+    );
+  },
+);
+
 Deno.test("DiscoveryRunner returns no improvement when candidates are not better", async () => {
   const discoveryResult: DiscoverResult = {
     ID: "DISCOVER_NO_IMPROVEMENT",


### PR DESCRIPTION
- Bumped version in deno.json to 0.200.0.
- Refactored the DataRecorder class to streamline the analysis phase by consolidating candidate evaluations into a single method, improving clarity and efficiency.
- Introduced a new method for collecting analysis candidates, enhancing the ability to manage helpful and harmful synapse and neuron candidates in parallel.
- Improved logging for analysis phases to provide better insights into candidate evaluations and outcomes.

These changes enhance the overall performance and maintainability of the discovery process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Rust-backed parallel combined analysis and a new combo-all candidate, refactors discovery analysis flow and logging, and bumps version to 0.200.0.
> 
> - **Discovery/Analysis**:
>   - Add Rust parallel combined analysis (`analyze_parallel`) with fallback to legacy per-scope analysis; `ensureRustCombinedAnalysis` now prefers parallel and converts results.
>   - New `collectRustAnalysisCandidates` bundles helpful/harmful synapse and neuron candidates in one pass.
>   - Filter top synapse candidates per target (`filterTopSynapseCandidates`); refine neuron/synapse candidate handling and timeout refresh.
> - **DiscoveryCandidates**:
>   - Introduce `combo-all` synthesis combining add/remove/squash/neuron changes; extend `DiscoveryChangeType` and builder logic.
> - **DiscoveryRunner**:
>   - Consider `combo-all` when selecting best result; tighten improvement message formatting.
> - **Rust FFI**:
>   - Define `RustParallelAnalysisInput/Result` and expose `analyze_parallel`; wire symbols in `RustDiscovery`.
> - **Version**: Bump `deno.json` to `0.200.0`.
> - **Tests**: Add/extend tests for combo-all synthesis and runner selection; minor updates to expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af1b9d30d043acc78680ad43539a2db292fbf26c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->