### PR TITLE
Update version to 0.201.0 and enhance discovery candidate handling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.200.0",
+  "version": "0.201.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -1,7 +1,12 @@
 import { CreatureUtil } from "../architecture/CreatureUtils.ts";
-import { DiscoverStructure } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  type CandidateNeuron,
+  type CandidateSquash,
+  type CandidateSynapse,
+  DiscoverStructure,
+} from "../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { DiscoverResult } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
-import type { Creature } from "../Creature.ts";
+import { Creature } from "../Creature.ts";
 
 export type DiscoveryChangeType =
   | "add-synapses"
@@ -10,7 +15,8 @@ export type DiscoveryChangeType =
   | "change-squash"
   | "combo-add-remove"
   | "combo-add-change"
-  | "combo-all";
+  | "combo-all"
+  | "combo-best-of-category";
 
 export interface DiscoveryCandidate {
   creature: Creature;
@@ -60,6 +66,14 @@ export function buildDiscoveryCandidates(
     });
   }
 
+  candidates.push(
+    ...buildSingleNeuronCandidates(
+      discovery.ID,
+      baseCreature,
+      helpfulNeuronCandidates,
+    ),
+  );
+
   const addedSynapseCreature = DiscoverStructure.addHelpfulSynapses(
     discovery.ID,
     baseCreature,
@@ -76,6 +90,14 @@ export function buildDiscoveryCandidates(
       },
     });
   }
+
+  candidates.push(
+    ...buildSingleSynapseCandidates(
+      discovery.ID,
+      baseCreature,
+      addHelpfulSynapses,
+    ),
+  );
 
   const removedSynapseCreature = DiscoverStructure.removeSynapse(
     discovery.ID,
@@ -143,47 +165,186 @@ export function buildDiscoveryCandidates(
     }
   }
 
+  candidates.push(
+    ...buildSingleSquashCandidates(
+      discovery.ID,
+      baseCreature,
+      candidateSquashes,
+    ),
+  );
+
   const combinedCandidate = buildCombinedCandidate({
     baseCreature,
-    discovery,
-    includeAddNeurons: Boolean(addedNeuronCreature),
-    includeAddSynapses: Boolean(addedSynapseCreature),
-    includeRemoveSynapse: Boolean(removedSynapseCreature),
-    includeChangeSquash: Boolean(changedSquashCreature),
+    discoveryID: discovery.ID,
+    selection: {
+      addHelpfulNeurons: addedNeuronCreature
+        ? helpfulNeuronCandidates
+        : undefined,
+      addHelpfulSynapses: addedSynapseCreature ? addHelpfulSynapses : undefined,
+      removeHarmfulSynapse: removedSynapseCreature
+        ? removeHarmfulSynapse
+        : undefined,
+      candidateSquashes: changedSquashCreature ? candidateSquashes : undefined,
+    },
+    changeType: "combo-all",
+    description: "Combined discovery changes",
   });
   if (combinedCandidate) {
     candidates.push(combinedCandidate);
   }
 
+  const bestOfCategoryCandidate = buildBestOfCategoryCandidate(
+    baseCreature,
+    discovery,
+  );
+  if (bestOfCategoryCandidate) {
+    if (discovery.removeHarmfulSynapse) {
+      const sanitised = DiscoverStructure.removeSynapse(
+        discovery.ID,
+        bestOfCategoryCandidate.creature,
+        discovery.removeHarmfulSynapse,
+      );
+      if (sanitised) {
+        bestOfCategoryCandidate.creature = sanitised;
+      } else {
+        const enforced = enforceRemoval(
+          bestOfCategoryCandidate.creature,
+          discovery.removeHarmfulSynapse,
+        );
+        if (enforced) {
+          bestOfCategoryCandidate.creature = enforced;
+        }
+      }
+    }
+    candidates.push(bestOfCategoryCandidate);
+  }
+
   return candidates;
 }
 
-interface CombinedCandidateContext {
+function buildSingleSynapseCandidates(
+  discoveryID: string,
+  baseCreature: Creature,
+  synapses?: CandidateSynapse[],
+): DiscoveryCandidate[] {
+  if (!synapses || synapses.length === 0) return [];
+  const entries: DiscoveryCandidate[] = [];
+  for (const synapse of synapses) {
+    const creature = DiscoverStructure.addHelpfulSynapses(
+      discoveryID,
+      baseCreature,
+      [synapse],
+    );
+    if (!creature) continue;
+    entries.push({
+      creature,
+      change: {
+        type: "add-synapses",
+        description:
+          `Added helpful synapse ${synapse.fromNeuronUUID} -> ${synapse.toNeuronUUID}`,
+      },
+    });
+  }
+  return entries;
+}
+
+function buildSingleNeuronCandidates(
+  discoveryID: string,
+  baseCreature: Creature,
+  neurons?: CandidateNeuron[],
+): DiscoveryCandidate[] {
+  if (!neurons || neurons.length === 0) return [];
+  const entries: DiscoveryCandidate[] = [];
+  for (const neuron of neurons) {
+    const creature = DiscoverStructure.addHelpfulNeurons(
+      discoveryID,
+      baseCreature,
+      [neuron],
+    );
+    if (!creature) continue;
+    entries.push({
+      creature,
+      change: {
+        type: "add-neurons",
+        description:
+          `Added discovery neuron linking ${neuron.fromNeuronUUID} -> ${neuron.toNeuronUUID}`,
+      },
+    });
+  }
+  return entries;
+}
+
+function buildSingleSquashCandidates(
+  discoveryID: string,
+  baseCreature: Creature,
+  squashes?: CandidateSquash[],
+): DiscoveryCandidate[] {
+  if (!squashes || squashes.length === 0) return [];
+  const entries: DiscoveryCandidate[] = [];
+  for (const squash of squashes) {
+    const creature = DiscoverStructure.changeSquash(
+      discoveryID,
+      baseCreature,
+      [squash],
+    );
+    if (!creature) continue;
+    entries.push({
+      creature,
+      change: {
+        type: "change-squash",
+        description:
+          `Changed squash for ${squash.neuronUUID} -> ${squash.squash}`,
+      },
+    });
+  }
+  return entries;
+}
+
+function enforceRemoval(
+  creature: Creature,
+  removal?: CandidateSynapse,
+): Creature | undefined {
+  if (!removal) return undefined;
+  const exportJSON = creature.exportJSON();
+  const filtered = exportJSON.synapses.filter((synapse) =>
+    !(synapse.fromUUID === removal.fromNeuronUUID &&
+      synapse.toUUID === removal.toNeuronUUID)
+  );
+  if (filtered.length === exportJSON.synapses.length) {
+    return undefined;
+  }
+  exportJSON.synapses = filtered;
+  const updated = Creature.fromJSON(exportJSON);
+  updated.fix();
+  return updated;
+}
+
+interface CombinedSelection {
+  addHelpfulSynapses?: CandidateSynapse[];
+  addHelpfulNeurons?: CandidateNeuron[];
+  removeHarmfulSynapse?: CandidateSynapse;
+  candidateSquashes?: CandidateSquash[];
+}
+
+interface CombinedCandidateArgs {
   baseCreature: Creature;
-  discovery: DiscoverResult;
-  includeAddNeurons: boolean;
-  includeAddSynapses: boolean;
-  includeRemoveSynapse: boolean;
-  includeChangeSquash: boolean;
+  discoveryID: string;
+  selection: CombinedSelection;
+  changeType: DiscoveryChangeType;
+  description: string;
 }
 
 function buildCombinedCandidate(
-  context: CombinedCandidateContext,
+  args: CombinedCandidateArgs,
 ): DiscoveryCandidate | undefined {
-  const {
-    baseCreature,
-    discovery,
-    includeAddNeurons,
-    includeAddSynapses,
-    includeRemoveSynapse,
-    includeChangeSquash,
-  } = context;
+  const { baseCreature, discoveryID, selection, changeType, description } =
+    args;
 
   const requestedCategories = [
-    includeAddNeurons,
-    includeAddSynapses,
-    includeRemoveSynapse,
-    includeChangeSquash,
+    Boolean(selection.addHelpfulNeurons?.length),
+    Boolean(selection.addHelpfulSynapses?.length),
+    Boolean(selection.removeHarmfulSynapse),
+    Boolean(selection.candidateSquashes?.length),
   ].filter(Boolean).length;
   if (requestedCategories < 2) {
     return undefined;
@@ -193,12 +354,11 @@ function buildCombinedCandidate(
   const appliedLabels: DiscoveryChangeType[] = [];
 
   const applyChange = (
-    enabled: boolean,
     label: DiscoveryChangeType,
-    mutator: (creature: Creature) => Creature | undefined,
+    mutator: (() => Creature | undefined) | undefined,
   ) => {
-    if (!enabled) return;
-    const updated = mutator(combinedCreature);
+    if (!mutator) return;
+    const updated = mutator();
     if (updated && updated !== combinedCreature) {
       combinedCreature = updated;
       appliedLabels.push(label);
@@ -206,47 +366,51 @@ function buildCombinedCandidate(
   };
 
   applyChange(
-    includeRemoveSynapse,
-    "remove-synapse",
-    (creature) =>
-      DiscoverStructure.removeSynapse(
-        discovery.ID,
-        creature,
-        discovery.removeHarmfulSynapse,
-      ) ?? undefined,
-  );
-
-  applyChange(
-    includeAddNeurons,
     "add-neurons",
-    (creature) =>
-      DiscoverStructure.addHelpfulNeurons(
-        discovery.ID,
-        creature,
-        discovery.addHelpfulNeurons,
-      ),
+    selection.addHelpfulNeurons && selection.addHelpfulNeurons.length > 0
+      ? () =>
+        DiscoverStructure.addHelpfulNeurons(
+          discoveryID,
+          combinedCreature,
+          selection.addHelpfulNeurons,
+        )
+      : undefined,
   );
 
   applyChange(
-    includeAddSynapses,
     "add-synapses",
-    (creature) =>
-      DiscoverStructure.addHelpfulSynapses(
-        discovery.ID,
-        creature,
-        discovery.addHelpfulSynapses,
-      ),
+    selection.addHelpfulSynapses && selection.addHelpfulSynapses.length > 0
+      ? () =>
+        DiscoverStructure.addHelpfulSynapses(
+          discoveryID,
+          combinedCreature,
+          selection.addHelpfulSynapses,
+        )
+      : undefined,
   );
 
   applyChange(
-    includeChangeSquash,
     "change-squash",
-    (creature) =>
-      DiscoverStructure.changeSquash(
-        discovery.ID,
-        creature,
-        discovery.candidateSquashes,
-      ),
+    selection.candidateSquashes && selection.candidateSquashes.length > 0
+      ? () =>
+        DiscoverStructure.changeSquash(
+          discoveryID,
+          combinedCreature,
+          selection.candidateSquashes,
+        )
+      : undefined,
+  );
+
+  applyChange(
+    "remove-synapse",
+    selection.removeHarmfulSynapse
+      ? () =>
+        DiscoverStructure.removeSynapse(
+          discoveryID,
+          combinedCreature,
+          selection.removeHarmfulSynapse,
+        ) ?? undefined
+      : undefined,
   );
 
   if (appliedLabels.length < 2 || combinedCreature === baseCreature) {
@@ -256,8 +420,50 @@ function buildCombinedCandidate(
   return {
     creature: combinedCreature,
     change: {
-      type: "combo-all",
-      description: `Combined discovery changes (${appliedLabels.join(", ")})`,
+      type: changeType,
+      description: `${description} (${appliedLabels.join(", ")})`,
     },
   };
+}
+
+function buildBestOfCategoryCandidate(
+  baseCreature: Creature,
+  discovery: DiscoverResult,
+): DiscoveryCandidate | undefined {
+  const bestSelection: CombinedSelection = {
+    addHelpfulSynapses: wrapBestCandidate(discovery.addHelpfulSynapses),
+    addHelpfulNeurons: wrapBestCandidate(discovery.addHelpfulNeurons),
+    candidateSquashes: wrapBestCandidate(discovery.candidateSquashes),
+    removeHarmfulSynapse: discovery.removeHarmfulSynapse,
+  };
+
+  return buildCombinedCandidate({
+    baseCreature,
+    discoveryID: discovery.ID,
+    selection: bestSelection,
+    changeType: "combo-best-of-category",
+    description: "Combined best discovery changes",
+  });
+}
+
+function wrapBestCandidate<
+  T extends { expectedImprovementPercentage?: number },
+>(
+  entries?: T[] | undefined,
+): T[] | undefined {
+  if (!entries || entries.length === 0) {
+    return undefined;
+  }
+  const best = entries.reduce((currentBest: T | undefined, candidate) => {
+    if (!currentBest) return candidate;
+    const bestScore = currentBest.expectedImprovementPercentage ??
+      Number.NEGATIVE_INFINITY;
+    const candidateScore = candidate.expectedImprovementPercentage ??
+      Number.NEGATIVE_INFINITY;
+    if (candidateScore > bestScore) {
+      return candidate;
+    }
+    return currentBest;
+  }, undefined);
+  return best ? [best] : undefined;
 }

--- a/test/discovery/DiscoveryCandidates.test.ts
+++ b/test/discovery/DiscoveryCandidates.test.ts
@@ -147,6 +147,13 @@ function findCandidate(
   return candidate;
 }
 
+function findCandidates(
+  candidates: DiscoveryCandidate[],
+  type: DiscoveryCandidate["change"]["type"],
+): DiscoveryCandidate[] {
+  return candidates.filter((entry) => entry.change.type === type);
+}
+
 function averageMSE(
   creature: Creature,
   trainingData: DataRecordInterface[],
@@ -179,6 +186,248 @@ Deno.test("buildDiscoveryCandidates returns empty list when there are no suggest
   const originalSynapseCount = base.exportJSON().synapses.length;
   assertEquals(originalSynapseCount, 5);
 });
+
+Deno.test(
+  "buildDiscoveryCandidates emits individual candidates for each helpful synapse",
+  () => {
+    const base = makeBaselineCreature();
+    const synapses: CandidateSynapse[] = [{
+      fromNeuronUUID: "input-2",
+      toNeuronUUID: "hidden-1",
+      weight: 0.99,
+      expectedImprovementPercentage: 0.25,
+      improvedCount: 5,
+      totalCount: 6,
+    }, {
+      fromNeuronUUID: "input-3",
+      toNeuronUUID: "hidden-2",
+      weight: -0.55,
+      expectedImprovementPercentage: 0.3,
+      improvedCount: 6,
+      totalCount: 7,
+    }];
+    const discovery: DiscoverResult = {
+      ID: "SYN-MULTI",
+      addHelpfulSynapses: synapses,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const candidates = buildDiscoveryCandidates(base, discovery);
+    const addSynapseCandidates = findCandidates(candidates, "add-synapses");
+
+    const findDedicatedCandidate = (target: CandidateSynapse) => {
+      return addSynapseCandidates.find((candidate) => {
+        const exported = candidate.creature.exportJSON();
+        const hasTarget = exported.synapses.some((synapse) =>
+          synapse.fromUUID === target.fromNeuronUUID &&
+          synapse.toUUID === target.toNeuronUUID &&
+          Math.abs(synapse.weight - target.weight) < 1e-9
+        );
+        if (!hasTarget) return false;
+        const hasOtherNew = synapses.some((other) => {
+          if (other === target) return false;
+          return exported.synapses.some((synapse) =>
+            synapse.fromUUID === other.fromNeuronUUID &&
+            synapse.toUUID === other.toNeuronUUID &&
+            Math.abs(synapse.weight - other.weight) < 1e-9
+          );
+        });
+        return !hasOtherNew;
+      });
+    };
+
+    assert(
+      findDedicatedCandidate(synapses[0]),
+      "Expected candidate dedicated to first helpful synapse",
+    );
+    assert(
+      findDedicatedCandidate(synapses[1]),
+      "Expected candidate dedicated to second helpful synapse",
+    );
+  },
+);
+
+Deno.test(
+  "buildDiscoveryCandidates emits individual candidates for each squash change",
+  () => {
+    const base = makeBaselineCreature();
+    const squashes: CandidateSquash[] = [{
+      neuronUUID: "hidden-1",
+      previousSquash: IDENTITY.NAME,
+      squash: TANH.NAME,
+      expectedImprovementPercentage: 0.4,
+      improvedError: 0.1,
+      currentError: 0.2,
+    }, {
+      neuronUUID: "hidden-2",
+      previousSquash: IDENTITY.NAME,
+      squash: Mish.NAME,
+      expectedImprovementPercentage: 0.3,
+      improvedError: 0.2,
+      currentError: 0.4,
+    }];
+    const discovery: DiscoverResult = {
+      ID: "SQUASH-MULTI",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      candidateSquashes: squashes,
+    };
+
+    const candidates = buildDiscoveryCandidates(base, discovery);
+    const squashCandidates = findCandidates(candidates, "change-squash");
+    assert(
+      squashCandidates.length >= squashes.length,
+      "Expected at least one candidate per squash suggestion",
+    );
+
+    for (const suggestion of squashes) {
+      const dedicated = squashCandidates.find((candidate) => {
+        const exported = candidate.creature.exportJSON();
+        const targetNeuron = exported.neurons.find((neuron) =>
+          neuron.uuid === suggestion.neuronUUID
+        );
+        if (!targetNeuron) return false;
+        const hasDesiredSquash = targetNeuron.squash === suggestion.squash;
+        const otherSuggestion = squashes.find((entry) =>
+          entry.neuronUUID !== suggestion.neuronUUID
+        );
+        const otherNeuron = otherSuggestion
+          ? exported.neurons.find((neuron) =>
+            neuron.uuid === otherSuggestion.neuronUUID
+          )
+          : undefined;
+        const otherChanged = otherNeuron
+          ? otherNeuron.squash === otherSuggestion?.squash
+          : false;
+        return hasDesiredSquash && !otherChanged;
+      });
+      assert(
+        dedicated,
+        `Expected dedicated candidate for squash on ${suggestion.neuronUUID}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "buildDiscoveryCandidates combines best candidate from each category",
+  () => {
+    const base = makeBaselineCreature();
+    const synapses: CandidateSynapse[] = [{
+      fromNeuronUUID: "input-2",
+      toNeuronUUID: "hidden-1",
+      weight: 0.91,
+      expectedImprovementPercentage: 0.05,
+      improvedCount: 3,
+      totalCount: 4,
+    }, {
+      fromNeuronUUID: "input-3",
+      toNeuronUUID: "hidden-2",
+      weight: -0.33,
+      expectedImprovementPercentage: 0.35,
+      improvedCount: 6,
+      totalCount: 7,
+    }];
+    const neurons: CandidateNeuron[] = [{
+      fromNeuronUUID: "input-2",
+      toNeuronUUID: "hidden-1",
+      incomingWeight: 0.45,
+      outgoingWeight: -0.12,
+      squash: TANH.NAME,
+      bias: 0.1,
+      expectedImprovementPercentage: 0.1,
+      improvedCount: 5,
+      totalCount: 6,
+    }, {
+      fromNeuronUUID: "input-3",
+      toNeuronUUID: "hidden-2",
+      incomingWeight: -0.38,
+      outgoingWeight: 0.22,
+      squash: Mish.NAME,
+      bias: -0.05,
+      expectedImprovementPercentage: 0.45,
+      improvedCount: 7,
+      totalCount: 8,
+    }];
+    const squashes: CandidateSquash[] = [{
+      neuronUUID: "hidden-1",
+      previousSquash: IDENTITY.NAME,
+      squash: Mish.NAME,
+      expectedImprovementPercentage: 0.05,
+      improvedError: 0.2,
+      currentError: 0.6,
+    }, {
+      neuronUUID: "hidden-2",
+      previousSquash: IDENTITY.NAME,
+      squash: TANH.NAME,
+      expectedImprovementPercentage: 0.34,
+      improvedError: 0.1,
+      currentError: 0.4,
+    }];
+    const removeCandidate: CandidateSynapse = {
+      fromNeuronUUID: "input-0",
+      toNeuronUUID: "hidden-1",
+      weight: -0.99,
+      expectedImprovementPercentage: 0.2,
+      improvedCount: 3,
+      totalCount: 5,
+    };
+
+    const discovery: DiscoverResult = {
+      ID: "BEST-COMBO",
+      addHelpfulSynapses: synapses,
+      addHelpfulNeurons: neurons,
+      removeHarmfulSynapse: removeCandidate,
+      candidateSquashes: squashes,
+    };
+
+    const candidates = buildDiscoveryCandidates(base, discovery);
+    const comboBest = findCandidate(candidates, "combo-best-of-category");
+    const exported = comboBest.creature.exportJSON();
+
+    const hasBestSynapse = exported.synapses.some((synapse) =>
+      synapse.fromUUID === synapses[1].fromNeuronUUID &&
+      synapse.toUUID === synapses[1].toNeuronUUID
+    );
+    assert(
+      hasBestSynapse,
+      "Best-of-category combo should include the top synapse candidate",
+    );
+
+    const discoveryNeuron = exported.neurons.find((neuron) =>
+      neuron.uuid.startsWith("hidden-discovery-")
+    );
+    assert(discoveryNeuron, "Expected discovery neuron to be present.");
+    assertEquals(
+      discoveryNeuron?.squash,
+      neurons[1].squash,
+      "Best discovery neuron should dictate squash for injected neuron.",
+    );
+
+    const hidden2 = exported.neurons.find((neuron) =>
+      neuron.uuid === "hidden-2"
+    );
+    assert(hidden2, "Hidden neuron 2 should exist.");
+    assertEquals(
+      hidden2?.squash,
+      squashes[1].squash,
+      "Best-of-category combo should update squash with highest expected gain.",
+    );
+
+    const harmfulStillExists = exported.synapses.some((synapse) =>
+      synapse.fromUUID === removeCandidate.fromNeuronUUID &&
+      synapse.toUUID === removeCandidate.toNeuronUUID
+    );
+    assertEquals(
+      harmfulStillExists,
+      false,
+      "Best-of-category combo should remove the harmful synapse.",
+    );
+  },
+);
 
 Deno.test({
   name:
@@ -234,13 +483,30 @@ Deno.test({
         crippledCreature,
         discovery,
       );
-      const types = candidates.map((candidate) => candidate.change.type).sort();
-      assertEquals(types, [
+      const types = candidates.map((candidate) => candidate.change.type);
+      const uniqueTypes = new Set(types);
+      const requiredTypes: DiscoveryCandidate["change"]["type"][] = [
         "add-synapses",
         "combo-add-remove",
         "combo-all",
         "remove-synapse",
-      ]);
+      ];
+      for (const required of requiredTypes) {
+        assert(
+          uniqueTypes.has(required),
+          `Expected discovery candidates to include ${required}`,
+        );
+      }
+      assert(
+        uniqueTypes.has("combo-best-of-category"),
+        "Expected to synthesise best-of-category combination",
+      );
+      const addSynapseCount = types.filter((type) => type === "add-synapses")
+        .length;
+      assert(
+        addSynapseCount >= (helpfulSynapses?.length ?? 0),
+        "Expected at least one candidate per helpful synapse",
+      );
 
       const addCandidate = findCandidate(candidates, "add-synapses");
       const addSynapses = addCandidate.creature.exportJSON().synapses;


### PR DESCRIPTION
- Bumped version in deno.json to 0.201.0.
- Refactored DiscoveryCandidates.ts to introduce new functions for building individual candidates for neurons, synapses, and squashes, improving modularity and clarity.
- Added support for a new candidate type "combo-best-of-category" to allow for the synthesis of the best candidates across different categories.
- Enhanced test coverage for discovery candidate generation, ensuring individual candidates are correctly emitted and combined.

These changes improve the flexibility and robustness of the discovery process, facilitating better candidate evaluations and outcomes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps to 0.201.0 and enhances discovery by emitting per-item candidates, adding a best-of-category combo, and refactoring combination logic with expanded tests.
> 
> - **Discovery** (`src/discovery/DiscoveryCandidates.ts`):
>   - Add `combo-best-of-category` to `DiscoveryChangeType`.
>   - Emit individual candidates for each helpful `synapse`, `neuron`, and `squash` via `buildSingle*Candidates` helpers.
>   - Refactor `buildCombinedCandidate` to accept a selection and apply changes sequentially; customizable change type/description.
>   - Introduce `buildBestOfCategoryCandidate` selecting top entries by `expectedImprovementPercentage` (via `wrapBestCandidate`).
>   - Add `enforceRemoval` fallback to ensure harmful synapse removal when needed.
> - **Tests** (`test/discovery/DiscoveryCandidates.test.ts`):
>   - Add tests validating per-synapse and per-squash candidates, best-of-category combo, and updated combo-all behavior.
>   - Update integration test expectations and assertions (including counts and presence of new combo type).
> - **Config**: bump `deno.json` version to `0.201.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd570905570741b290b8ce300863bd9b8fab7869. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->