### PR TITLE
Update version to 0.204.0 and enhance neuron impact calculations

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.203.0",
+  "version": "0.204.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -99,6 +99,7 @@
     "wgpu",
     "WGSL",
     "honors",
-    "recs"
+    "recs",
+    "deriv"
   ]
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -298,7 +298,10 @@ export class DiscoverStructure {
   }
 
   private async measureMaxOutputError(): Promise<number> {
-    if (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled()) {
+    if (
+      !this.recorded &&
+      (!this.parquetFilePath || !this.deps.isRustDiscoveryEnabled())
+    ) {
       return 0;
     }
 
@@ -1270,7 +1273,8 @@ export class DiscoverStructure {
   private discoveries: CandidateSynapse[] = [];
   private neuronDiscoveries: CandidateNeuron[] = [];
 
-  public analyzeSelectedNeurons(
+  // deno-lint-ignore require-await
+  public async analyzeSelectedNeurons(
     focusList: string[],
   ): Promise<CandidateSynapse[] | undefined> {
     if (focusList.length === 0) return Promise.resolve(undefined);
@@ -1310,7 +1314,8 @@ export class DiscoverStructure {
     return Promise.resolve(this.discoveries);
   }
 
-  public analyzeMissingNeurons(
+  // deno-lint-ignore require-await
+  public async analyzeMissingNeurons(
     focusList: string[],
   ): Promise<CandidateNeuron[] | undefined> {
     if (focusList.length === 0) return Promise.resolve(undefined);
@@ -2674,14 +2679,18 @@ export class DiscoverStructure {
   }
 
   /**
-   * Calculates the impact of a neuron on outputs by finding the maximum impact path to output neurons.
-   * Uses backward propagation from output neurons, taking the maximum impact across all paths.
-   * This ensures neurons on the same path don't get double-counted and avoids contradictory suggestions.
+   * Calculates the impact of a neuron on the network outputs.
+   * Impact is defined as the maximum weight path to any output neuron.
+   * The value is between 0 and 1 (or potentially higher if weights > 1, but typically scaled).
    *
    * @param neuronUUID - The UUID of the neuron to calculate impact for
+   * @param derivativeMap - Optional map of average derivatives to account for saturation
    * @returns The impact value (maximum absolute weight path to outputs)
    */
-  private calculateNeuronImpact(neuronUUID: string): number {
+  private calculateNeuronImpact(
+    neuronUUID: string,
+    derivativeMap?: Map<string, number>,
+  ): number {
     // Build maps for efficient lookup
     const neuronIndexMap = new Map<string, number>();
     const outputNeuronIndices = new Set<number>();
@@ -2700,7 +2709,7 @@ export class DiscoverStructure {
       return 0;
     }
     if (outputNeuronIndices.has(neuronIndex)) {
-      return 1.0;
+      return derivativeMap?.get(neuronUUID) ?? 1.0;
     }
 
     // Use dynamic programming to calculate impact
@@ -2733,11 +2742,12 @@ export class DiscoverStructure {
         return 0;
       }
 
-      // Output neurons have base impact of 1.0
+      // Output neurons have base impact of 1.0 * derivative
       if (outputNeuronIndices.has(index)) {
-        impactCache.set(uuid, 1.0);
+        const impact = derivativeMap?.get(uuid) ?? 1.0;
+        impactCache.set(uuid, impact);
         pathVisited.delete(uuid);
-        return 1.0;
+        return impact;
       }
 
       // Get outgoing synapses from this neuron
@@ -2764,13 +2774,23 @@ export class DiscoverStructure {
             continue;
           }
           const absWeight = Math.abs(synapse.weight);
-          let weightContribution = absWeight * toImpact;
-          if (weightContribution > toImpact) {
-            weightContribution = toImpact;
-          }
+          const weightContribution = absWeight * toImpact;
+          // if (weightContribution > toImpact) {
+          //   weightContribution = toImpact;
+          // }
           maxImpact = Math.max(maxImpact, weightContribution);
         }
       }
+
+      // Apply THIS neuron's derivative
+      let myDerivative: number;
+      if (derivativeMap) {
+        myDerivative = derivativeMap.get(uuid) ?? 1.0;
+      } else {
+        // Compute derivative on-the-fly using current activation state
+        myDerivative = this.computeSquashDerivative(uuid);
+      }
+      maxImpact *= myDerivative;
 
       pathVisited.delete(uuid);
       impactCache.set(uuid, maxImpact);
@@ -2778,6 +2798,56 @@ export class DiscoverStructure {
     };
 
     return calculateImpactRecursive(neuronUUID, new Set<string>());
+  }
+
+  /**
+   * Computes the squash function derivative for a neuron at its current activation.
+   * Uses the most recent activation from creature.state if available, otherwise returns 1.0.
+   *
+   * This accounts for saturation effects where neurons operating in saturated regions
+   * (e.g., TANH at large inputs) have very small derivatives and thus limited impact
+   * on output error regardless of their local error magnitude.
+   *
+   * For squash functions where we can compute the derivative from the output (like TANH, SIGMOID),
+   * we use the analytical formula. For others, we return 1.0 as a conservative estimate.
+   */
+  private computeSquashDerivative(neuronUUID: string): number {
+    const neuron = this.creature.neurons.find((n) => n.uuid === neuronUUID);
+    if (!neuron || neuron.type === "input" || neuron.type === "constant") {
+      return 1.0;
+    }
+
+    const squashName = neuron.squash ?? "IDENTITY";
+    const activation = this.creature.state.activations[neuron.index];
+
+    if (!Number.isFinite(activation)) {
+      return 1.0;
+    }
+
+    // Use analytical derivative formulas where possible
+    // For TANH: d/dx tanh(x) = 1 - tanh²(x) = 1 - activation²
+    // For SIGMOID: d/dx σ(x) = σ(x)(1 - σ(x)) = activation * (1 - activation)
+    switch (squashName) {
+      case "IDENTITY":
+        return 1.0;
+      case "TANH": {
+        const derivative = 1 - activation * activation;
+        return Number.isFinite(derivative) && derivative >= 0 ? derivative : 0;
+      }
+      case "LOGISTIC":
+      case "SIGMOID": {
+        const derivative = activation * (1 - activation);
+        return Number.isFinite(derivative) && derivative >= 0 ? derivative : 0;
+      }
+      case "RELU":
+        return activation > 0 ? 1.0 : 0.0;
+      case "LEAKY_RELU":
+        return activation > 0 ? 1.0 : 0.01;
+      default:
+        // For other activation functions, we can't easily compute the derivative
+        // from just the output, so return 1.0 as a conservative estimate
+        return 1.0;
+    }
   }
 
   /**
@@ -2897,6 +2967,53 @@ export class DiscoverStructure {
       ? Math.max(targetCount * 4, 64)
       : Number.POSITIVE_INFINITY;
 
+    // Pre-calculate average derivatives for all neurons to account for saturation
+    // This map will be used by calculateNeuronImpact
+    const derivativeMap = new Map<string, number>();
+
+    // Iterate all neurons in creature for derivatives
+    const allNeurons = this.creature.neurons;
+    const derivConcurrency = 16;
+    for (let i = 0; i < allNeurons.length; i += derivConcurrency) {
+      const chunk = allNeurons.slice(i, i + derivConcurrency);
+      // deno-lint-ignore no-await-in-loop
+      await Promise.all(chunk.map(async (n) => {
+        try {
+          const neuronSquashName = n.squash ?? "IDENTITY";
+          const neuronSquash = Activations.find(
+            neuronSquashName,
+          ) as ActivationInterface;
+          // Use same sampling logic
+          const records = await this.loadCSV(`${this.tempDir}/${n.uuid}.csv`);
+          let derivativeSum = 0;
+          let derivativeCount = 0;
+          const sampleSize = Math.min(records.length, 50);
+          const step = Math.max(1, Math.floor(records.length / sampleSize));
+
+          for (let j = 0; j < records.length; j += step) {
+            const val = records[j].value;
+            if (Number.isFinite(val)) {
+              const eps = 1e-4;
+              const y1 = neuronSquash.squash(val as number);
+              const y2 = neuronSquash.squash((val as number) + eps);
+              const derivative = (y2 - y1) / eps;
+              if (Number.isFinite(derivative)) {
+                derivativeSum += Math.abs(derivative);
+                derivativeCount++;
+              }
+            }
+            if (derivativeCount >= sampleSize) break;
+          }
+          const avg = derivativeCount > 0
+            ? derivativeSum / derivativeCount
+            : 1.0;
+          derivativeMap.set(n.uuid, avg);
+        } catch (_e) {
+          derivativeMap.set(n.uuid, 1.0);
+        }
+      }));
+    }
+
     const processNext = async () => {
       while (true) {
         const currentIndex = index++;
@@ -2913,6 +3030,10 @@ export class DiscoverStructure {
 
         const neuron = neurons[currentIndex];
         try {
+          const neuronSquashName = neuron.squash ?? "IDENTITY";
+          const neuronSquash = Activations.find(
+            neuronSquashName,
+          ) as ActivationInterface;
           // deno-lint-ignore no-await-in-loop
           const records = await this.loadCSV(
             `${this.tempDir}/${neuron.uuid}.csv`,
@@ -2921,7 +3042,15 @@ export class DiscoverStructure {
           let invalidErrorCount = 0;
           let absoluteErrorSum = 0;
           let errorValueCount = 0;
+          let activationDeltaSum = 0;
+          let activationDeltaCount = 0;
           for (const record of records) {
+            const baseValue = record.value;
+            const baseActivation = Number.isFinite(record.activation)
+              ? record.activation
+              : (Number.isFinite(baseValue)
+                ? neuronSquash.squash(baseValue as number)
+                : undefined);
             for (const err of record.errors) {
               if (!Number.isFinite(err)) {
                 invalidErrorCount++;
@@ -2929,6 +3058,25 @@ export class DiscoverStructure {
               }
               absoluteErrorSum += Math.abs(err);
               errorValueCount++;
+
+              if (
+                Number.isFinite(baseValue) && baseActivation !== undefined &&
+                Number.isFinite(baseActivation)
+              ) {
+                const targetValue = (baseValue as number) + err;
+                if (Number.isFinite(targetValue)) {
+                  const targetActivation = neuronSquash.squash(targetValue);
+                  if (Number.isFinite(targetActivation)) {
+                    const delta = Math.abs(
+                      targetActivation - (baseActivation as number),
+                    );
+                    if (Number.isFinite(delta)) {
+                      activationDeltaSum += delta;
+                      activationDeltaCount++;
+                    }
+                  }
+                }
+              }
             }
           }
 
@@ -2942,18 +3090,24 @@ export class DiscoverStructure {
             );
           }
 
-          const averageError = errorValueCount > 0
+          const averageRawError = errorValueCount > 0
             ? absoluteErrorSum / errorValueCount
             : 0;
+          const activationAverage = activationDeltaCount > 0
+            ? activationDeltaSum / activationDeltaCount
+            : averageRawError;
           const clampedError = maxOutputError > 0
-            ? Math.min(averageError, maxOutputError)
-            : averageError;
+            ? Math.min(activationAverage, maxOutputError)
+            : activationAverage;
 
           records.length = 0;
 
           let impact = impactCache.get(neuron.uuid);
           if (impact === undefined) {
-            const computedImpact = this.calculateNeuronImpact(neuron.uuid);
+            const computedImpact = this.calculateNeuronImpact(
+              neuron.uuid,
+              derivativeMap,
+            );
             impact = Number.isFinite(computedImpact) ? computedImpact : 0;
             impactCache.set(neuron.uuid, impact);
           }
@@ -3412,10 +3566,18 @@ export class DiscoverStructure {
     idealActivations.length = 0;
 
     if (bestSquash !== currentSquash) {
-      const expectedImprovementPercentage = (baselineError - lowestError) /
-        baselineError;
+      const rawImprovement = (baselineError - lowestError) / baselineError;
 
-      if (expectedImprovementPercentage > 0.01) {
+      // Scale by neuron's impact on output to avoid inflated expectations
+      const neuronImpact = this.calculateNeuronImpact(neuronUUID);
+      const impactScale = Number.isFinite(neuronImpact)
+        ? Math.min(Math.max(neuronImpact, 0), 1)
+        : 1.0; // Default to 1.0 if impact can't be calculated
+
+      const expectedImprovementPercentage = rawImprovement * impactScale;
+
+      // Return candidate even if improvement is small, but only if raw improvement was significant
+      if (rawImprovement > 0.01) {
         return {
           neuronUUID,
           previousSquash: currentSquash,

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -2785,9 +2785,13 @@ export class DiscoverStructure {
       // Apply THIS neuron's derivative
       let myDerivative: number;
       if (derivativeMap) {
+        // When derivativeMap is provided, use it or default to 1.0
+        // Never fall back to computeSquashDerivative here because we're in
+        // offline analysis context where creature.state may be stale/uninitialized
         myDerivative = derivativeMap.get(uuid) ?? 1.0;
       } else {
-        // Compute derivative on-the-fly using current activation state
+        // Only use computeSquashDerivative when no derivativeMap is provided
+        // (e.g., during online analysis when state is current)
         myDerivative = this.computeSquashDerivative(uuid);
       }
       maxImpact *= myDerivative;
@@ -2803,6 +2807,10 @@ export class DiscoverStructure {
   /**
    * Computes the squash function derivative for a neuron at its current activation.
    * Uses the most recent activation from creature.state if available, otherwise returns 1.0.
+   *
+   * WARNING: This method relies on creature.state which may be stale or uninitialized
+   * during offline analysis (e.g., in findCandidateSquash). When a derivativeMap is
+   * provided to calculateNeuronImpact, this method should NOT be used as a fallback.
    *
    * This accounts for saturation effects where neurons operating in saturated regions
    * (e.g., TANH at large inputs) have very small derivatives and thus limited impact
@@ -3568,8 +3576,40 @@ export class DiscoverStructure {
     if (bestSquash !== currentSquash) {
       const rawImprovement = (baselineError - lowestError) / baselineError;
 
+      // Compute average derivative from records to account for saturation
+      let derivativeSum = 0;
+      let derivativeCount = 0;
+      const sampleSize = Math.min(records.length, 50);
+      const step = Math.max(1, Math.floor(records.length / sampleSize));
+
+      for (let i = 0; i < records.length; i += step) {
+        const val = records[i].value;
+        if (Number.isFinite(val)) {
+          const eps = 1e-4;
+          const y1 = currentSquashMethod.squash(val as number);
+          const y2 = currentSquashMethod.squash((val as number) + eps);
+          const derivative = (y2 - y1) / eps;
+          if (Number.isFinite(derivative)) {
+            derivativeSum += Math.abs(derivative);
+            derivativeCount++;
+          }
+        }
+        if (derivativeCount >= sampleSize) break;
+      }
+
+      const avgDerivative = derivativeCount > 0
+        ? derivativeSum / derivativeCount
+        : 1.0;
+
+      // Create derivativeMap with this neuron's average derivative
+      const derivativeMap = new Map<string, number>();
+      derivativeMap.set(neuronUUID, avgDerivative);
+
       // Scale by neuron's impact on output to avoid inflated expectations
-      const neuronImpact = this.calculateNeuronImpact(neuronUUID);
+      const neuronImpact = this.calculateNeuronImpact(
+        neuronUUID,
+        derivativeMap,
+      );
       const impactScale = Number.isFinite(neuronImpact)
         ? Math.min(Math.max(neuronImpact, 0), 1)
         : 1.0; // Default to 1.0 if impact can't be calculated

--- a/test/discovery/DiscoverStructureFocus.ts
+++ b/test/discovery/DiscoverStructureFocus.ts
@@ -1,0 +1,125 @@
+import { assert } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import {
+  type DiscoverRecord,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { Activations } from "../../src/methods/activations/Activations.ts";
+import type { ActivationInterface } from "../../src/methods/activations/ActivationInterface.ts";
+
+function makeFocusCreature(): Creature {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-saturated", squash: "TANH", bias: 0 },
+      { type: "hidden", uuid: "hidden-linear", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-saturated", weight: 1 },
+      { fromUUID: "hidden-saturated", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-0", toUUID: "hidden-linear", weight: 1 },
+      { fromUUID: "hidden-linear", toUUID: "output-0", weight: 1 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+Deno.test("focus ranking scales neuron error by activation effect", async () => {
+  const creature = makeFocusCreature();
+  const discover = new DiscoverStructure(
+    creature,
+    10,
+    10,
+    {
+      isRustDiscoveryEnabled: () => false,
+      isRustLibraryAvailable: () => false,
+      recordDiscovery: () => ({
+        success: false,
+        error: "not needed",
+      }),
+      mergeDiscoveryParquet: () => ({
+        success: false,
+        error: "not needed",
+      }),
+      analyzeNeurons: () => ({
+        success: false,
+        error: "not needed",
+      }),
+      analyzeSynapses: () => ({
+        success: false,
+        error: "not needed",
+      }),
+      readDiscoveryRecords: () => ({
+        success: false,
+        error: "not needed",
+      }),
+      rankFocusNeurons: undefined,
+    },
+  );
+
+  const tanh = Activations.find("TANH") as ActivationInterface;
+  const saturatedValue = 1_000_000;
+  const saturatedActivation = tanh.squash(saturatedValue);
+
+  const recordsByUUID = new Map<string, DiscoverRecord[]>([
+    ["hidden-saturated", [{
+      activation: saturatedActivation,
+      value: saturatedValue,
+      errors: [1_000_000],
+    }]],
+    ["hidden-linear", [{
+      activation: 0,
+      value: 0,
+      errors: [0.2],
+    }]],
+    ["output-0", [{
+      activation: 0,
+      value: 0,
+      errors: [0.1],
+    }]],
+  ]);
+
+  const internal = discover as unknown as {
+    recorded: boolean;
+    initialized: boolean;
+    parquetFilePath: string | null;
+    cachedMaxOutputError?: { value: number; computedAt: number };
+    loadCSV: (file: string) => Promise<DiscoverRecord[]>;
+  };
+  internal.initialized = true;
+  internal.recorded = true;
+  internal.parquetFilePath = "mock.parquet";
+  internal.cachedMaxOutputError = {
+    value: 1,
+    computedAt: Date.now(),
+  };
+  internal.loadCSV = (file: string) => {
+    const fileName = file.split("/").pop() ?? "";
+    const uuid = fileName.replace(/\.csv$/, "");
+    const records = recordsByUUID.get(uuid);
+    if (!records) {
+      throw new Error(`No records for ${uuid}`);
+    }
+    return Promise.resolve(records);
+  };
+
+  try {
+    const neurons = await discover.listViableNeurons(3);
+    const linear = neurons.find((entry) => entry.uuid === "hidden-linear");
+    const saturated = neurons.find((entry) =>
+      entry.uuid === "hidden-saturated"
+    );
+    assert(linear, "linear neuron should be included in ranking");
+    assert(
+      (linear?.totalError ?? 0) > (saturated?.totalError ?? 0),
+      "Linear neuron should outrank saturated neuron once activation deltas are considered.",
+    );
+  } finally {
+    await discover.cleanUp();
+  }
+});

--- a/test/discovery/DiscoverStructureSquash.ts
+++ b/test/discovery/DiscoverStructureSquash.ts
@@ -96,3 +96,73 @@ Deno.test("squash estimates are computed in activation domain", () => {
     }
   }
 });
+
+function makeDilutedImpactCreature(): Creature {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-chain", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-0", toUUID: "hidden-chain", weight: 1 },
+      { fromUUID: "hidden-chain", toUUID: "output-0", weight: 1e-6 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+Deno.test("squash estimates scale by neuron impact to avoid inflated expectations", () => {
+  const creature = makeDilutedImpactCreature();
+  const discover = new DiscoverStructure(creature, 30);
+
+  const activations = Activations as unknown as {
+    list: () => ActivationInterface[];
+  };
+  const originalList = activations.list;
+  const hugeError = 1_000_000;
+
+  activations.list = () => [
+    new LookupActivation([
+      { input: 0, output: hugeError },
+      { input: 0.1, output: hugeError + 0.1 },
+    ]),
+    new STEP(),
+  ];
+
+  const records: DiscoverRecord[] = [
+    { activation: 0, value: 0, errors: [hugeError] },
+    { activation: 0.1, value: 0.1, errors: [hugeError] },
+  ];
+
+  const internal = discover as unknown as {
+    findCandidateSquash: (
+      neuronUUID: string,
+      recs: DiscoverRecord[],
+    ) => CandidateSquash | undefined;
+    tempDir: string;
+  };
+
+  try {
+    const candidate = internal.findCandidateSquash("hidden-chain", records);
+    assert(
+      candidate,
+      "Expected diluted chain neuron to return a squash candidate.",
+    );
+    assert(
+      candidate.expectedImprovementPercentage < 1e-4,
+      "Expected improvement should be scaled down by the neuron's tiny impact.",
+    );
+  } finally {
+    activations.list = originalList;
+    try {
+      Deno.removeSync(internal.tempDir, { recursive: true });
+    } catch {
+      // Ignore cleanup errors to keep the test resilient on CI.
+    }
+  }
+});

--- a/test/discovery/DiscoveryFocusSquashBounds.ts
+++ b/test/discovery/DiscoveryFocusSquashBounds.ts
@@ -1,0 +1,146 @@
+import { assert, assertAlmostEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+
+Deno.test("Focus selection accounts for squashing function bounds on downstream paths", () => {
+  // Create a network with two paths to output:
+  // Path A: input-0 -> hidden-direct -> output-0 (weight 1.0, IDENTITY squash)
+  // Path B: input-1 -> hidden-chain-1 -> hidden-chain-2 -> hidden-chain-3 -> output-0
+  //         (all weights 1.0, but hidden-chain-2 uses TANH which bounds output to [-1, 1])
+  //
+  // Even if hidden-chain-1 has activation of 1,000,000, TANH at hidden-chain-2 will
+  // clamp it to ~1.0, so hidden-chain-1's error impact is bounded by the squash function.
+
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-direct", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "hidden-chain-1", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "hidden-chain-2", squash: "TANH", bias: 0 },
+      { type: "hidden", uuid: "hidden-chain-3", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      // Direct path with IDENTITY throughout
+      { fromUUID: "input-0", toUUID: "hidden-direct", weight: 1.0 },
+      { fromUUID: "hidden-direct", toUUID: "output-0", weight: 1.0 },
+
+      // Chain path with TANH bottleneck
+      { fromUUID: "input-1", toUUID: "hidden-chain-1", weight: 1.0 },
+      { fromUUID: "hidden-chain-1", toUUID: "hidden-chain-2", weight: 1.0 },
+      { fromUUID: "hidden-chain-2", toUUID: "hidden-chain-3", weight: 1.0 },
+      { fromUUID: "hidden-chain-3", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+
+  // Activate with extreme value on chain path
+  creature.activate(new Float32Array([0.1, 1000000]));
+
+  // Create DiscoverStructure to access impact calculation
+  const discover = new DiscoverStructure(creature, 60);
+
+  // Calculate impact for each hidden neuron using the actual implementation
+  // deno-lint-ignore no-explicit-any
+  const directImpact = (discover as any).calculateNeuronImpact("hidden-direct");
+  // deno-lint-ignore no-explicit-any
+  const chain1Impact = (discover as any).calculateNeuronImpact(
+    "hidden-chain-1",
+  );
+  // deno-lint-ignore no-explicit-any
+  const chain2Impact = (discover as any).calculateNeuronImpact(
+    "hidden-chain-2",
+  );
+  // deno-lint-ignore no-explicit-any
+  const chain3Impact = (discover as any).calculateNeuronImpact(
+    "hidden-chain-3",
+  );
+
+  // hidden-direct has unbounded path to output (all IDENTITY)
+  // Its impact should be close to 1.0 (weight 1.0 * 1.0)
+  assertAlmostEquals(
+    directImpact,
+    1.0,
+    0.01,
+    "Direct path impact should be ~1.0",
+  );
+
+  // hidden-chain-1 feeds into TANH at hidden-chain-2
+  // Even with activation of 1,000,000, TANH derivative at that point is ~0
+  // So the effective impact is bounded by TANH's derivative range
+  assert(
+    chain1Impact < 0.1,
+    `hidden-chain-1 impact should be severely limited by downstream TANH bottleneck, got ${chain1Impact}`,
+  );
+
+  // hidden-chain-2 (the TANH node) has bounded output [-1, 1]
+  // Its impact is limited by its own derivative (max ~1.0 at x=0, approaches 0 at extremes)
+  // and the downstream weights (1.0 * 1.0 = 1.0)
+  assert(
+    chain2Impact <= 1.0,
+    `hidden-chain-2 impact should be bounded by TANH derivative, got ${chain2Impact}`,
+  );
+
+  // hidden-chain-3 is after TANH, so it receives bounded input
+  // Its impact should be close to 1.0 (weight 1.0 to output)
+  assertAlmostEquals(
+    chain3Impact,
+    1.0,
+    0.01,
+    "Post-TANH impact should be ~1.0",
+  );
+
+  // The key assertion: neurons before a squashing bottleneck should have
+  // much lower impact than neurons on unbounded paths
+  assert(
+    directImpact > chain1Impact * 10,
+    `Direct path impact (${directImpact}) should be >> chain-1 impact (${chain1Impact})`,
+  );
+});
+
+Deno.test("Focus selection correctly weights neurons by squash-bounded impact", () => {
+  // Simpler test: two neurons with same error, but one has TANH on path to output
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-unbounded", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "hidden-tanh", squash: "TANH", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-unbounded", weight: 1.0 },
+      { fromUUID: "hidden-unbounded", toUUID: "output-0", weight: 1.0 },
+      { fromUUID: "input-1", toUUID: "hidden-tanh", weight: 1.0 },
+      { fromUUID: "hidden-tanh", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+
+  // Activate with large value to push TANH into saturation
+  creature.activate(new Float32Array([5.0, 5.0]));
+
+  // Create DiscoverStructure to access impact calculation
+  const discover = new DiscoverStructure(creature, 60);
+
+  // deno-lint-ignore no-explicit-any
+  const unboundedImpact = (discover as any).calculateNeuronImpact(
+    "hidden-unbounded",
+  );
+  // deno-lint-ignore no-explicit-any
+  const tanhImpact = (discover as any).calculateNeuronImpact("hidden-tanh");
+
+  // IDENTITY has derivative of 1.0, TANH at x=5 has derivative ~0.0001
+  // So even though both have weight 1.0 to output, the TANH neuron's
+  // effective impact is much lower due to saturation
+  assert(
+    unboundedImpact > tanhImpact * 100,
+    `Unbounded impact (${unboundedImpact}) should be >> TANH impact (${tanhImpact}) when saturated`,
+  );
+});

--- a/test/discovery/FocusSelectionSensitivity.ts
+++ b/test/discovery/FocusSelectionSensitivity.ts
@@ -1,0 +1,144 @@
+import { assert } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+
+function makeSaturatedCreature(): Creature {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-a", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "TANH", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 1 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 1 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+Deno.test("selection penalizes neurons blocked by saturated downstream nodes", async () => {
+  const creature = makeSaturatedCreature();
+  // Force TypeScript-only mode to ensure we test the fallback logic
+  const discover = new DiscoverStructure(creature, 60, 1, {
+    isRustDiscoveryEnabled: () => false,
+  });
+
+  // Create data where output is saturated (input=100 -> tanh(100)=1)
+  // Target is 0, so error is -1.
+  // Inverse mapping for hidden-a will be huge (100 -> 0 requires -100 delta).
+  // But gradient is 0.
+  const trainingData = [
+    {
+      input: Float32Array.from([100]),
+      output: Float32Array.from([0]), // Target
+    },
+  ];
+
+  const neuronPromisesMap = new Map<string, Promise<void>>();
+  // @ts-ignore: private method
+  discover.initialize(neuronPromisesMap);
+  discover.record(trainingData, neuronPromisesMap);
+  await Promise.all(neuronPromisesMap.values());
+
+  // Flush recording to ensure CSVs are written (needed for loadCSV in fallback)
+  // In TypeScript mode, record() accumulates in memory but doesn't write CSVs unless initialized with async writes?
+  // Actually DiscoverStructure in TS mode writes CSVs directly in Neuron.record if async?
+  // No, Neuron.record (TS) calls squashMethod.record or default.
+  // Default just updates discoverMap.
+  // DiscoverStructure then needs to persist this map to CSVs?
+  // DiscoverStructure.record() doesn't flush CSVs.
+  // The `initialize` method sets up `neuronPromisesMap` which suggests async writing happens during record via promises?
+  // Let's check `Neuron.record`... it populates `discoverMap`.
+  // Who writes `discoverMap` to disk?
+  // DiscoverStructure.ts doesn't seem to write CSVs from `discoverMap` in `record()` loop?
+  // Ah, `loadCSV` reads from disk.
+  // If we run in TS mode, `rustAccumulatedNeuronData` is not used?
+  // Wait, `DiscoverStructure` seems to rely on `loadCSV` which implies files exist.
+  // If we are in TS mode, who writes the files?
+  // `Neuron.ts` doesn't write files.
+
+  // We need to manually trigger a write or ensure the test environment handles it.
+  // Or maybe we mock `loadCSV`?
+  // But `listViableNeuronsFallback` calls `loadCSV`.
+
+  // Let's look at how `listViableNeuronsFallback` gets data.
+  // It calls `this.loadCSV`.
+  // `loadCSV` checks `parquetFilePath` if Rust is enabled.
+  // If Rust is disabled, it tries to read CSV.
+  // Who writes the CSV?
+  // `Creature.ts` `evolveDir` calls `discoverDir`.
+
+  // In `DiscoverStructure.ts`:
+  // `record` -> calls `creature.record`.
+  // In TS mode, `creature.record` returns a Map.
+  // `DiscoverStructure` accumulates these maps in `rustAccumulatedNeuronData`.
+  // But if we are using `isRustDiscoveryEnabled: () => false`, we skip rust accumulation?
+
+  // Wait, `listViableNeuronsFallback` assumes CSVs exist.
+  // Where are they created?
+  // Perhaps `Neuron.ts` or `DiscoverStructure.ts` writes them?
+  // I don't see CSV writing code in the provided snippets.
+
+  // Let's manually persist the recorded data to CSVs for the test.
+  // The `discoverMap` is returned by `creature.record`.
+  // But `DiscoverStructure.record` discards the return value if not using Rust?
+  // No, `const discoverMap = this.creature.record(record.output);`
+  // It pushes to `rustAccumulatedNeuronData` ONLY if `usingRustDualWrite`?
+
+  // Actually, looking at `DiscoverStructure.ts`:
+  // `public record(...)`
+  // `if (!this.usingRustDualWrite || timedOut) return false;`
+  // So if Rust is disabled, `record` returns false and DOES NOTHING?
+
+  // If Rust is disabled, `DiscoverStructure` relies on... what?
+  // Maybe `initialize` sets up something?
+  // `initialize` calls `this.creature.neurons.forEach(...)`.
+
+  // If I want to test `listViableNeuronsFallback` logic, I need to make sure data exists.
+  // I will mock `loadCSV` in the test to return the data we want.
+
+  // @ts-ignore: accessing private method to mock
+  // deno-lint-ignore require-await
+  discover.loadCSV = async (path: string) => {
+    console.log(`loadCSV called for ${path}`);
+    if (path.includes("hidden-a")) {
+      return [{
+        activation: 100,
+        value: 100,
+        errors: [-100], // Huge error from inverse mapping
+      }];
+    }
+    if (path.includes("output-0")) {
+      return [{
+        activation: 1,
+        value: 100, // Saturated input
+        errors: [-1],
+      }];
+    }
+    return [];
+  };
+
+  const viable = await discover.listViableNeurons(10);
+  const hiddenInfo = viable.find((n) => n.uuid === "hidden-a");
+  assert(hiddenInfo, "Hidden neuron should be listed");
+
+  console.log("Hidden info:", hiddenInfo);
+
+  // With sensitivity fix, impact should be small.
+  // Calculate impact manually to verify expectation:
+  // Weight to output is 1.
+  // Derivative of output (TANH at 100) is ~0.
+  // Impact should be ~0.
+
+  // Currently impact is calculated statically as 1.0.
+  // We expect the fix to lower it.
+  assert(
+    hiddenInfo.impact < 0.1,
+    `Impact should be low due to saturation, was ${hiddenInfo.impact}`,
+  );
+});


### PR DESCRIPTION
- Bumped version in deno.json to 0.204.0.
- Modified the `measureMaxOutputError` method to include a check for the `recorded` state.
- Updated `analyzeSelectedNeurons` and `analyzeMissingNeurons` methods to be asynchronous.
- Enhanced the `calculateNeuronImpact` method to account for neuron derivatives, improving accuracy in impact assessments.
- Introduced a new method, `computeSquashDerivative`, to calculate the derivative of neuron activations, addressing saturation effects.
- Added tests to ensure that squash estimates scale by neuron impact, preventing inflated expectations.

These changes aim to improve the accuracy and reliability of neuron impact evaluations in the discovery process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves discovery by incorporating activation derivatives/saturation into neuron impact, focus selection, and squash improvement estimates, with new tests and minor async/guard tweaks.
> 
> - **Discovery logic (`src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts`)**:
>   - Adjust `measureMaxOutputError` to respect `recorded` state.
>   - Make `analyzeSelectedNeurons` and `analyzeMissingNeurons` async (lint-suppressed) and keep Rust-availability guards.
>   - Enhance `calculateNeuronImpact(neuronUUID, derivativeMap?)` to scale path impact by activation derivatives (handles saturation), including for outputs; add cycle-safe DP and optional derivative map.
>   - Add `computeSquashDerivative` to derive per-activation derivatives (IDENTITY/TANH/SIGMOID/RELU/etc.).
>   - In fallback focus ranking (`listViableNeuronsFallback`):
>     - Compute error in activation domain (activation deltas) and clamp by max output error.
>     - Precompute average derivatives per neuron from sampled records and pass to impact calc.
>   - In squash search (`findCandidateSquash`): scale expected improvement by neuron's impact and local derivative; return candidates when raw improvement is meaningful.
> - **Tests**:
>   - Add `test/discovery/DiscoverStructureFocus.ts` to verify ranking favors unsaturated neurons.
>   - Add `test/discovery/DiscoverStructureSquash.ts` to ensure squash estimates are activation-based and scaled by impact.
>   - Add `test/discovery/DiscoveryFocusSquashBounds.ts` to validate derivative-bounded impacts along paths.
>   - Add `test/discovery/FocusSelectionSensitivity.ts` to penalize neurons behind saturated outputs.
> - **Misc**:
>   - Bump `deno.json` version to `0.204.0`.
>   - Update `docs/cspell.json` dictionary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dc05adb4a15886672a96c0c03a7cbea220853ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->