### PR TITLE
Update version to 0.208.0 and implement cost-of-growth filtering in d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ directory (ignored by git) and logs extended diagnostics whenever the Rust
 recorder flushes or hits the time-out path. Use it as the starting point for
 debugging “Invalid string length” failures without touching live workloads.
 
+### Discovery Cost-of-Growth Gate
+
+Discovery candidates are now triaged using the configured `costOfGrowth` setting
+before they reach the evaluator. Each new synapse consumes `1 x
+costOfGrowth`,
+while every new neuron consumes roughly `3 x costOfGrowth` (two synapses plus
+the neuron). Candidates whose expected error reduction is smaller than their
+structural cost are skipped entirely. This keeps discovery focused on proposals
+that can actually repay the growth penalty and prevents logs from being flooded
+with meaningless `+0.000%` deltas.
+
 ## Enabling the Rust Discovery Module
 
 The Rust FFI extension shipped via

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.205.0",
+  "version": "0.208.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -54,7 +54,11 @@ export interface NeatArguments {
   /** Focus rate, defining how much attention to give to the focus list (optional). */
   focusRate: number;
 
-  /** Cost of growth (optional). */
+  /**
+   * Cost of growth (optional). Penalises complex networks and filters discovery
+   * candidates: each new synapse consumes 1 x costOfGrowth, while each new
+   * neuron consumes ~3 x costOfGrowth (two synapses plus the neuron body).
+   */
   costOfGrowth: number;
 
   /** Percentage of the top-performing individuals to retain for the next generation. */

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -212,6 +212,26 @@ export class DiscoveryRunner {
           candidates.length === 1 ? "" : "s"
         }: ${candidates.map((c) => c.change.type).join(", ") || "none"}.`,
       );
+
+      const { filtered: filteredCandidates, skipped } = this
+        .#filterCandidatesByGrowthCost(
+          creature,
+          candidates,
+          config.costOfGrowth,
+        );
+      if (skipped.length > 0) {
+        verboseLog(
+          `Skipped ${skipped.length} candidate${
+            skipped.length === 1 ? "" : "s"
+          } below cost-of-growth threshold: ${
+            skipped.map((entry) =>
+              `${entry.changeType ?? "unknown"} (expected ${
+                entry.expected?.toPrecision(3) ?? "n/a"
+              } vs ${entry.threshold.toPrecision(3)})`
+            ).join(", ")
+          }.`,
+        );
+      }
       markPhase("Candidate synthesis", candidateBuildStart);
 
       const evaluationTasks: Array<{
@@ -220,7 +240,7 @@ export class DiscoveryRunner {
         candidate?: DiscoveryCandidate;
       }> = [
         { kind: "original", creature },
-        ...candidates.map((candidate) => ({
+        ...filteredCandidates.map((candidate) => ({
           kind: "candidate" as const,
           creature: candidate.creature,
           candidate,
@@ -547,7 +567,7 @@ export class DiscoveryRunner {
     if (!Number.isFinite(value)) {
       return yellow("±0.000%");
     }
-    const formatted = `${value >= 0 ? "+" : ""}${value.toFixed(3)}%`;
+    const formatted = formatPercentWithSignificantDigits(value);
     if (value > 0.05) return green(formatted);
     if (value < -0.05) return red(formatted);
     return yellow(formatted);
@@ -557,7 +577,7 @@ export class DiscoveryRunner {
     if (!Number.isFinite(value)) {
       return cyan("n/a");
     }
-    return cyan(`${value >= 0 ? "+" : ""}${value.toFixed(3)}%`);
+    return cyan(formatPercentWithSignificantDigits(value));
   }
 
   async #evaluateAll(
@@ -619,6 +639,76 @@ export class DiscoveryRunner {
 
     return results;
   }
+
+  #filterCandidatesByGrowthCost(
+    baseCreature: Creature,
+    candidates: DiscoveryCandidate[],
+    costOfGrowth: number,
+  ): {
+    filtered: DiscoveryCandidate[];
+    skipped: Array<{
+      changeType?: DiscoveryChangeType;
+      expected?: number;
+      threshold: number;
+    }>;
+  } {
+    if (!Number.isFinite(costOfGrowth) || costOfGrowth <= 0) {
+      return { filtered: candidates, skipped: [] };
+    }
+    const baseExport = baseCreature.exportJSON();
+    const baseHiddenUUIDs = new Set(
+      baseExport.neurons
+        .filter((neuron) => neuron.type === "hidden")
+        .map((neuron) => neuron.uuid),
+    );
+    const baseSynapseKeys = new Set(
+      baseExport.synapses.map((synapse) =>
+        `${synapse.fromUUID}->${synapse.toUUID}`
+      ),
+    );
+
+    const filtered: DiscoveryCandidate[] = [];
+    const skipped: Array<{
+      changeType?: DiscoveryChangeType;
+      expected?: number;
+      threshold: number;
+    }> = [];
+
+    for (const candidate of candidates) {
+      CreatureUtil.makeUUID(candidate.creature);
+      const candidateExport = candidate.creature.exportJSON();
+      const additions = countStructuralAdditions(
+        candidateExport,
+        baseHiddenUUIDs,
+        baseSynapseKeys,
+      );
+      const addedUnits = additions.addedHidden + additions.addedSynapses;
+      if (addedUnits <= 0) {
+        filtered.push(candidate);
+        continue;
+      }
+      const expected = candidate.change.expectedErrorReduction;
+      if (
+        expected === undefined || !Number.isFinite(expected) ||
+        expected <= 0
+      ) {
+        filtered.push(candidate);
+        continue;
+      }
+      const threshold = addedUnits * costOfGrowth;
+      if (expected < threshold) {
+        skipped.push({
+          changeType: candidate.change.type,
+          expected,
+          threshold,
+        });
+        continue;
+      }
+      filtered.push(candidate);
+    }
+
+    return { filtered, skipped };
+  }
 }
 
 function sanitiseSegment(value: string): string {
@@ -640,4 +730,61 @@ function safeRealPath(path: string): string {
   } catch {
     return path;
   }
+}
+
+function countStructuralAdditions(
+  candidate: CreatureExport,
+  baseHiddenUUIDs: Set<string>,
+  baseSynapseKeys: Set<string>,
+): { addedHidden: number; addedSynapses: number } {
+  let addedHidden = 0;
+  for (const neuron of candidate.neurons) {
+    if (neuron.type !== "hidden") continue;
+    if (!baseHiddenUUIDs.has(neuron.uuid)) {
+      addedHidden++;
+    }
+  }
+
+  let addedSynapses = 0;
+  for (const synapse of candidate.synapses) {
+    const key = `${synapse.fromUUID}->${synapse.toUUID}`;
+    if (!baseSynapseKeys.has(key)) {
+      addedSynapses++;
+    }
+  }
+
+  return { addedHidden, addedSynapses };
+}
+
+const MIN_PERCENT_FRACTION_DIGITS = 3;
+const SIGNIFICANT_PERCENT_DIGITS = 3;
+const MAX_PERCENT_FRACTION_DIGITS = 100;
+const ZERO_PERCENT = `+0.${"0".repeat(MIN_PERCENT_FRACTION_DIGITS)}%`;
+
+function formatPercentWithSignificantDigits(value: number): string {
+  if (value === 0) {
+    return ZERO_PERCENT;
+  }
+  const sign = value >= 0 ? "+" : "-";
+  const absValue = Math.abs(value);
+  const exponent = Math.floor(Math.log10(absValue));
+  let fractionDigits: number;
+  if (Number.isFinite(exponent) && exponent >= 0) {
+    const digitsBeforeDecimal = exponent + 1;
+    fractionDigits = Math.max(
+      MIN_PERCENT_FRACTION_DIGITS,
+      SIGNIFICANT_PERCENT_DIGITS - digitsBeforeDecimal,
+    );
+  } else {
+    const leadingZeros = Number.isFinite(exponent)
+      ? Math.abs(exponent) - 1
+      : SIGNIFICANT_PERCENT_DIGITS;
+    fractionDigits = Math.max(
+      MIN_PERCENT_FRACTION_DIGITS,
+      leadingZeros + SIGNIFICANT_PERCENT_DIGITS,
+    );
+  }
+  fractionDigits = Math.min(fractionDigits, MAX_PERCENT_FRACTION_DIGITS);
+  const magnitude = absValue.toFixed(fractionDigits);
+  return `${sign}${magnitude}%`;
 }

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -10,6 +10,7 @@ import type { NeatOptions } from "../../src/config/NeatOptions.ts";
 import { Creature } from "../../src/Creature.ts";
 import type { DiscoveryRunnerWorker } from "../../src/discovery/DiscoveryRunner.ts";
 import { DiscoveryRunner } from "../../src/discovery/DiscoveryRunner.ts";
+import type { DiscoveryCandidate } from "../../src/discovery/DiscoveryCandidates.ts";
 
 function makeBaseCreature() {
   const creature = Creature.fromJSON({
@@ -60,6 +61,14 @@ function makeDenseOutputCreature(extraFanIn: number) {
   creature.validate();
   CreatureUtil.makeUUID(creature);
   return creature;
+}
+
+function cloneCreatureJSON(
+  creature: Creature,
+): ReturnType<Creature["exportJSON"]> {
+  return JSON.parse(
+    JSON.stringify(creature.exportJSON()),
+  ) as ReturnType<Creature["exportJSON"]>;
 }
 
 class FakeWorker implements DiscoveryRunnerWorker {
@@ -760,3 +769,248 @@ Deno.test("DiscoveryRunner passes discovery focus neurons to worker", async () =
     // nothing
   }
 });
+
+Deno.test(
+  "DiscoveryRunner skips synapse candidates whose expected gain is below growth cost",
+  async () => {
+    const discoveryResult: DiscoverResult = {
+      ID: "COST_FILTER_SYN",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const baseCreature = makeBaseCreature();
+    const extraSynapse = {
+      fromUUID: "input-0",
+      toUUID: "output-0",
+      weight: 0.05,
+    };
+
+    const cloneExport = () => cloneCreatureJSON(baseCreature);
+
+    const candidateBuilder = (
+      _creature: Creature,
+      _discovery: DiscoverResult,
+    ): DiscoveryCandidate[] => {
+      const json = cloneExport();
+      json.synapses.push({
+        fromUUID: extraSynapse.fromUUID,
+        toUUID: extraSynapse.toUUID,
+        weight: extraSynapse.weight,
+      });
+      const candidate = Creature.fromJSON(json);
+      candidate.validate();
+      CreatureUtil.makeUUID(candidate);
+      return [{
+        creature: candidate,
+        change: {
+          type: "add-synapses",
+          description: "extra synapse",
+          expectedErrorReduction: 0.01,
+        },
+      }];
+    };
+
+    const computeError = (creature: Creature) => {
+      const json = creature.exportJSON();
+      const hasExtraSynapse = json.synapses.some((synapse) =>
+        synapse.fromUUID === extraSynapse.fromUUID &&
+        synapse.toUUID === extraSynapse.toUUID &&
+        Math.abs(synapse.weight - extraSynapse.weight) < 1e-9
+      );
+      return hasExtraSynapse ? 0.4 : 0.5;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          computeError,
+        ),
+      candidateBuilder,
+    });
+
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options: makeOptions({ costOfGrowth: 0.02 }),
+    });
+
+    assert(
+      !result.evaluations?.some((entry) => entry.kind === "candidate"),
+      "candidates with expected improvement below growth cost should be skipped",
+    );
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner skips neuron candidates whose expected gain is below aggregated growth cost",
+  async () => {
+    const discoveryResult: DiscoverResult = {
+      ID: "COST_FILTER_NEURON",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const baseCreature = makeBaseCreature();
+    const newNeuronUUID = "growth-test-hidden";
+
+    const candidateBuilder = (
+      _creature: Creature,
+      _discovery: DiscoverResult,
+    ): DiscoveryCandidate[] => {
+      const json = cloneCreatureJSON(baseCreature);
+      const outputCount = json.output ?? 1;
+      const outputOffset = json.neurons.length - outputCount;
+      json.neurons.splice(outputOffset, 0, {
+        type: "hidden",
+        uuid: newNeuronUUID,
+        squash: "IDENTITY",
+        bias: 0,
+      });
+      json.synapses.push({
+        fromUUID: "input-0",
+        toUUID: newNeuronUUID,
+        weight: 0.2,
+      });
+      json.synapses.push({
+        fromUUID: newNeuronUUID,
+        toUUID: "output-0",
+        weight: -0.2,
+      });
+      const candidate = Creature.fromJSON(json);
+      candidate.validate();
+      CreatureUtil.makeUUID(candidate);
+      return [{
+        creature: candidate,
+        change: {
+          type: "add-neurons",
+          description: "extra neuron",
+          expectedErrorReduction: 0.02,
+        },
+      }];
+    };
+
+    const computeError = (creature: Creature) => {
+      const json = creature.exportJSON();
+      const hasNewNeuron = json.neurons.some((neuron) =>
+        neuron.uuid === newNeuronUUID
+      );
+      return hasNewNeuron ? 0.3 : 0.5;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          computeError,
+        ),
+      candidateBuilder,
+    });
+
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options: makeOptions({ costOfGrowth: 0.01 }),
+    });
+
+    assert(
+      !result.evaluations?.some((entry) => entry.kind === "candidate"),
+      "neuron additions with expected gain below 3x cost should be skipped",
+    );
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner logs sub-basis deltas with at least three significant digits",
+  async () => {
+    const discoveryResult: DiscoverResult = {
+      ID: "DELTA_PRECISION",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const baseCreature = makeBaseCreature();
+    const tinyDelta = 1e-8;
+
+    const candidateBuilder = (
+      _creature: Creature,
+      _discovery: DiscoverResult,
+    ): DiscoveryCandidate[] => {
+      const json = cloneCreatureJSON(baseCreature);
+      json.synapses = json.synapses.map((synapse) =>
+        synapse.fromUUID === "hidden-1" && synapse.toUUID === "output-0"
+          ? { ...synapse, weight: synapse.weight + tinyDelta }
+          : synapse
+      );
+      const candidate = Creature.fromJSON(json);
+      candidate.validate();
+      CreatureUtil.makeUUID(candidate);
+      return [{
+        creature: candidate,
+        change: {
+          type: "add-synapses",
+          description: "tiny delta",
+          expectedErrorReduction: tinyDelta,
+        },
+      }];
+    };
+
+    const baselineError = 0.5;
+    const computeError = (creature: Creature) => {
+      const json = creature.exportJSON();
+      const hasTinyUpdate = json.synapses.some((synapse) =>
+        synapse.fromUUID === "hidden-1" && synapse.toUUID === "output-0" &&
+        Math.abs(synapse.weight - (0.5 + tinyDelta)) < 1e-10
+      );
+      return hasTinyUpdate ? baselineError - tinyDelta : baselineError;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          computeError,
+        ),
+      candidateBuilder,
+    });
+
+    const captured: string[] = [];
+    const originalInfo = console.info.bind(console);
+    console.info = (...args: unknown[]) => {
+      captured.push(args.map((arg) => String(arg)).join(" "));
+      originalInfo(...args);
+    };
+
+    try {
+      await runner.discoverDir({
+        creature: baseCreature,
+        dataDir: "/tmp/data",
+        options: makeOptions({ costOfGrowth: 0 }),
+      });
+    } finally {
+      console.info = originalInfo;
+    }
+
+    const candidateLine = captured.find((line) =>
+      line.includes("[DiscoveryRunner]   Candidate")
+    );
+    assert(candidateLine, "expected candidate log line to be recorded");
+    assert(
+      !candidateLine.includes("+0.000%"),
+      `non-zero deltas must show significant digits, got: ${candidateLine}`,
+    );
+  },
+);


### PR DESCRIPTION
…iscovery process

- Bumped version in deno.json to 0.208.0.
- Introduced a cost-of-growth mechanism to triage discovery candidates, ensuring that only those with expected error reductions exceeding their structural costs are considered.
- Enhanced the DiscoveryRunner to filter candidates based on their growth cost, improving the efficiency of the discovery process.
- Updated documentation in README.md to explain the new cost-of-growth gate and its implications for candidate evaluation.
- Added tests to validate the filtering logic for both synapse and neuron candidates, ensuring robustness in the discovery process.

These changes aim to refine the candidate selection process, focusing on proposals that can effectively repay their growth penalties, thereby enhancing overall performance and reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a growth-cost gate that filters discovery candidates by expected payoff vs structural cost, updates logging to show small percentage deltas precisely, and documents/tests the behavior; version bumped to 0.208.0.
> 
> - **Discovery**:
>   - **Cost-of-growth gate**: `DiscoveryRunner` filters candidates via `#filterCandidatesByGrowthCost()` using `costOfGrowth`; skips low-payoff additions and logs skipped details.
>   - **Evaluation pipeline**: Only evaluates `filteredCandidates`; passes `costOfGrowth` to scoring and supports verbose result logging.
>   - **Helpers**: Adds `countStructuralAdditions()` and significant-digit percent formatter; updates delta formatting in summaries.
> - **Config/Docs**:
>   - **`NeatOptions.costOfGrowth`**: Expanded docs explaining synapse (1×) and neuron (~3×) costs.
>   - **README**: New "Discovery Cost-of-Growth Gate" section.
> - **Tests**:
>   - Verify skipping of synapse and neuron candidates below growth threshold.
>   - Ensure sub-basis deltas render with ≥3 significant digits.
> - **Version**: Bump to `0.208.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbf210e2af80a83fcb3a3d7591adfee4abc471c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->