### PR TITLE
Update version to 0.209.1 and optimize test performance

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.209.0",
+  "version": "0.209.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/test/ErrorGuidedStructuralEvolution/DiscoverInputOptimization.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverInputOptimization.ts
@@ -95,7 +95,7 @@ Deno.test({
     // Initialize discovery and record data
     const discoverStructure = new DiscoverStructure(
       creature,
-      60,
+      5, // Reduced from 60s to 5s for faster tests
       DEFAULT_RUST_FLUSH_RECORDS,
     );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
@@ -169,7 +169,7 @@ Deno.test({
     const creature = makeTestCreature();
     CreatureUtil.makeUUID(creature);
 
-    const trainingData = makeTrainingData(creature.input, creature.output, 200);
+    const trainingData = makeTrainingData(creature.input, creature.output, 50); // Reduced from 200 for faster tests
 
     // Create binary files in temp directory
     const dataDir = makeDataDir(trainingData, 100);
@@ -180,6 +180,8 @@ Deno.test({
         discoverySampleRate: 0.5, // Sample 50% of records
         discoveryBatchSize: 50,
         discoveryMaxNeurons: 3,
+        discoveryTimeOutMinutes: 0.05, // 3 seconds - sufficient for CI
+        discoveryAnalysisTimeoutMinutes: 0.05, // 3 seconds - sufficient for CI
         log: 0,
       });
 
@@ -215,7 +217,7 @@ Deno.test({
     // Method 1: Using Rust (Parquet) - Rust is required now
     const csvDiscoverStructure = new DiscoverStructure(
       creature,
-      60,
+      5, // Reduced from 60s to 5s for faster tests
       DEFAULT_RUST_FLUSH_RECORDS,
     );
     const csvNeuronPromisesMap: Map<string, Promise<void>> = new Map();
@@ -251,7 +253,7 @@ Deno.test({
 
       const binaryDiscoverStructure = new DiscoverStructure(
         binaryCreature,
-        60,
+        5, // Reduced from 60s to 5s for faster tests
         DEFAULT_RUST_FLUSH_RECORDS,
       );
       const binaryNeuronPromisesMap: Map<string, Promise<void>> = new Map();

--- a/test/ErrorGuidedStructuralEvolution/DiscoverInputOptimization.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverInputOptimization.ts
@@ -190,8 +190,13 @@ Deno.test({
 
       // Test passes if no errors occur - this verifies CSV approach works
     } finally {
-      // Cleanup temp directory
-      await Deno.remove(dataDir, { recursive: true });
+      // Cleanup temp directory - use removeSync for simpler, faster cleanup
+      try {
+        // deno-lint-ignore no-sync-fn-in-async-fn
+        Deno.removeSync(dataDir, { recursive: true });
+      } catch {
+        // Ignore cleanup errors
+      }
     }
   },
 });
@@ -342,8 +347,13 @@ Deno.test({
 
       await binaryDiscoverStructure.cleanUp();
     } finally {
-      // Cleanup temp directory
-      await Deno.remove(dataDir, { recursive: true });
+      // Cleanup temp directory - use removeSync for simpler, faster cleanup
+      try {
+        // deno-lint-ignore no-sync-fn-in-async-fn
+        Deno.removeSync(dataDir, { recursive: true });
+      } catch {
+        // Ignore cleanup errors
+      }
     }
   },
 });

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -113,8 +113,8 @@ const DRIVER_NEURON_UUID = "hidden-driver";
 const SUPPORT_NEURON_UUID = "hidden-support";
 const OUTPUT_NEURON_UUID = "output-0";
 
-const DISCOVERY_RECORD_COUNT = 512;
-const DISCOVERY_INPUT_COUNT = 256;
+const DISCOVERY_RECORD_COUNT = 10; // Reduced for faster tests (was 512, then 50)
+const DISCOVERY_INPUT_COUNT = 60; // Reduced from 256 - minimum needed for input-55 (was 256)
 
 type NeuronExport = CreatureExport["neurons"][number];
 type SynapseExport = CreatureExport["synapses"][number];
@@ -447,7 +447,7 @@ for (const testCase of NEURON_DISCOVERY_CASES) {
       const neuronPromisesMap: Map<string, Promise<void>> = new Map();
       const discoverStructure = new DiscoverStructure(
         crippledCreature,
-        120,
+        5, // Reduced from 120s to 5s for faster tests
         DEFAULT_RUST_FLUSH_RECORDS,
       );
       discoverStructure.initialize(neuronPromisesMap);

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -113,7 +113,7 @@ const DRIVER_NEURON_UUID = "hidden-driver";
 const SUPPORT_NEURON_UUID = "hidden-support";
 const OUTPUT_NEURON_UUID = "output-0";
 
-const DISCOVERY_RECORD_COUNT = 10; // Reduced for faster tests (was 512, then 50)
+const DISCOVERY_RECORD_COUNT = 50; // Minimum for reliable statistical analysis (was 512, reduced to 50 for faster tests while maintaining discovery reliability)
 const DISCOVERY_INPUT_COUNT = 60; // Reduced from 256 - minimum needed for input-55 (was 256)
 
 type NeuronExport = CreatureExport["neurons"][number];

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
@@ -117,15 +117,15 @@ Deno.test({
   fn: async () => {
     assertRustDiscoveryAvailable();
     // This test ensures batching prevents "too many open files" errors
-    const neuronCount = 150; // Use 150 for test speed, batching logic handles 1967+
+    const neuronCount = 100; // Reduced for faster tests, batching logic handles 1967+
     const creature = makeCreatureWithManyNeurons(neuronCount);
     CreatureUtil.makeUUID(creature);
 
-    const trainingData = makeTrainingData(creature.input, 100);
+    const trainingData = makeTrainingData(creature.input, 30); // Reduced for faster tests
 
     const discoverStructure = new DiscoverStructure(
       creature,
-      60,
+      5, // Reduced from 60s to 5s for faster tests
       DEFAULT_RUST_FLUSH_RECORDS,
     );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
@@ -183,11 +183,11 @@ Deno.test({
     const creature = makeCreatureWithManyNeurons(50);
     CreatureUtil.makeUUID(creature);
 
-    const trainingData = makeTrainingData(creature.input, 100);
+    const trainingData = makeTrainingData(creature.input, 30); // Reduced for faster tests
 
     const discoverStructure = new DiscoverStructure(
       creature,
-      60,
+      5, // Reduced from 60s to 5s for faster tests
       DEFAULT_RUST_FLUSH_RECORDS,
     );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
@@ -233,15 +233,15 @@ Deno.test({
   sanitizeOps: false, // Disable ops sanitization for FFI operations
   fn: async () => {
     assertRustDiscoveryAvailable();
-    const creature = makeCreatureWithManyNeurons(200);
+    const creature = makeCreatureWithManyNeurons(100); // Reduced for faster tests
     CreatureUtil.makeUUID(creature);
 
-    const trainingData = makeTrainingData(creature.input, 50);
+    const trainingData = makeTrainingData(creature.input, 20); // Reduced for faster tests
 
-    // Use very short timeout (1 second) to trigger timeout
+    // Use very short timeout (0.1 second) to trigger timeout quickly
     const discoverStructure = new DiscoverStructure(
       creature,
-      1,
+      0.1,
       DEFAULT_RUST_FLUSH_RECORDS,
     );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
@@ -257,8 +257,8 @@ Deno.test({
       throw new Error("Rust recording flush failed");
     }
 
-    // Wait to ensure timeout has passed
-    await new Promise((resolve) => setTimeout(resolve, 1100));
+    // Wait to ensure timeout has passed (0.1s timeout + small buffer)
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
     // Should handle timeout gracefully and return partial results
     const viableNeurons = await discoverStructure.listViableNeurons();
@@ -324,7 +324,7 @@ Deno.test({
 
     const discoverStructure = new DiscoverStructure(
       creature,
-      60,
+      5, // Reduced from 60s to 5s for faster tests
       DEFAULT_RUST_FLUSH_RECORDS,
     );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
@@ -373,12 +373,12 @@ Deno.test({
     const creature = makeCreatureWithManyNeurons(30);
     CreatureUtil.makeUUID(creature);
 
-    const trainingData = makeTrainingData(creature.input, 100);
+    const trainingData = makeTrainingData(creature.input, 20); // Reduced for faster tests
 
-    // Very short timeout
+    // Very short timeout (0.1 second) for fast test execution
     const discoverStructure = new DiscoverStructure(
       creature,
-      1,
+      0.1,
       DEFAULT_RUST_FLUSH_RECORDS,
     );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
@@ -394,8 +394,8 @@ Deno.test({
       throw new Error("Rust recording flush failed");
     }
 
-    // Wait for timeout to pass
-    await new Promise((resolve) => setTimeout(resolve, 1100));
+    // Wait for timeout to pass (0.1s timeout + small buffer)
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
     // These should all return quickly due to timeout checks
     const startTime = Date.now();
@@ -438,15 +438,15 @@ Deno.test({
   fn: async () => {
     assertRustDiscoveryAvailable();
     // This test verifies the batching logic by checking it doesn't load all files at once
-    const neuronCount = 150; // More than BATCH_SIZE (50)
+    const neuronCount = 100; // More than BATCH_SIZE (50), reduced for faster tests
     const creature = makeCreatureWithManyNeurons(neuronCount);
     CreatureUtil.makeUUID(creature);
 
-    const trainingData = makeTrainingData(creature.input, 50);
+    const trainingData = makeTrainingData(creature.input, 30); // Reduced for faster tests
 
     const discoverStructure = new DiscoverStructure(
       creature,
-      60,
+      5, // Reduced from 60s to 5s for faster tests
       DEFAULT_RUST_FLUSH_RECORDS,
     );
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.test.ts
@@ -116,8 +116,7 @@ Deno.test("Discovery flushes Rust recording in configured chunks", async () => {
     };
 
     await recordDirectory(creature, tempDir, options, deps);
-    // Allow asynchronous cleanup triggered by recordDirectory to complete.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Cleanup is already awaited when NEAT_DISCOVERY_AWAIT_CLEANUP is set
 
     assertEquals(recordCallSizes, [2, 2]);
     assertEquals(mergedChunks.length, 1);
@@ -136,6 +135,12 @@ Deno.test("Discovery flushes Rust recording in configured chunks", async () => {
         // ignore
       }
     }
-    await Deno.remove(tempDir, { recursive: true });
+    // Use removeSync - simpler, faster, and ensures all file handles are closed
+    try {
+      // deno-lint-ignore no-sync-fn-in-async-fn
+      Deno.removeSync(tempDir, { recursive: true });
+    } catch {
+      // Ignore cleanup errors
+    }
   }
 });

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.test.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.test.ts
@@ -69,6 +69,7 @@ Deno.test("Discovery flushes Rust recording in configured chunks", async () => {
       discoveryRustFlushRecords: 2,
       discoveryMaxNeurons: 1,
       threads: 1,
+      log: 0,
     };
 
     const recordCallSizes: number[] = [];

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
@@ -147,11 +147,11 @@ async function createTempTestDir(testName: string): Promise<string> {
 }
 
 // Test utility: Cleanup temp directory
-async function cleanupTempDir(dirPath: string) {
+function cleanupTempDir(dirPath: string) {
   try {
-    // Minimal delay - just yield to event loop for async cleanup
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await Deno.remove(dirPath, { recursive: true });
+    // Use removeSync - simpler, faster, and ensures all file handles are closed
+    // before removal completes (no possibility of resource leaks)
+    Deno.removeSync(dirPath, { recursive: true });
   } catch (_error) {
     // Ignore cleanup errors
   }
@@ -234,8 +234,8 @@ Deno.test({
         `Batch comparison: 128 produced ${count128} results, 512 produced ${count512} results`,
       );
     } finally {
-      await cleanupTempDir(tmpDir128);
-      await cleanupTempDir(tmpDir512);
+      cleanupTempDir(tmpDir128);
+      cleanupTempDir(tmpDir512);
     }
   },
 });
@@ -273,7 +273,7 @@ Deno.test({
       // The key is that it doesn't throw and returns a valid result structure
       console.log(`Partial results: ${JSON.stringify(result, null, 2)}`);
     } finally {
-      await cleanupTempDir(tmpDir);
+      cleanupTempDir(tmpDir);
     }
   },
 });
@@ -313,7 +313,7 @@ Deno.test({
       // The diagnostic log should show "timeout reached during file processing"
       // (visible in test output with log: true)
     } finally {
-      await cleanupTempDir(tmpDir);
+      cleanupTempDir(tmpDir);
     }
   },
 });
@@ -352,7 +352,7 @@ Deno.test({
           `squashes=${result.candidateSquashes?.length}`,
       );
     } finally {
-      await cleanupTempDir(tmpDir);
+      cleanupTempDir(tmpDir);
     }
   },
 });

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
@@ -149,8 +149,8 @@ async function createTempTestDir(testName: string): Promise<string> {
 // Test utility: Cleanup temp directory
 async function cleanupTempDir(dirPath: string) {
   try {
-    // Give background cleanup time to complete
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Minimal delay - just yield to event loop for async cleanup
+    await new Promise((resolve) => setTimeout(resolve, 0));
     await Deno.remove(dirPath, { recursive: true });
   } catch (_error) {
     // Ignore cleanup errors
@@ -172,12 +172,12 @@ Deno.test({
       const creature128 = makeTestCreature(20);
       CreatureUtil.makeUUID(creature128);
       creature128.clearState();
-      await createTestBinaryFile(creature128, 200, tmpDir128, "test1.bin");
+      await createTestBinaryFile(creature128, 100, tmpDir128, "test1.bin");
 
       const creature512 = makeTestCreature(20);
       CreatureUtil.makeUUID(creature512);
       creature512.clearState();
-      await createTestBinaryFile(creature512, 200, tmpDir512, "test1.bin");
+      await createTestBinaryFile(creature512, 100, tmpDir512, "test1.bin");
 
       // Test with batch size 128, very short timeout (1 second)
       const options128 = {
@@ -252,8 +252,8 @@ Deno.test({
     const tmpDir = await createTempTestDir("partial-results");
 
     try {
-      // Create a larger dataset
-      await createTestBinaryFile(creature, 500, tmpDir, "test.bin");
+      // Create a dataset large enough to test timeout behavior
+      await createTestBinaryFile(creature, 200, tmpDir, "test.bin");
 
       // Set 2-second timeout
       const options = {
@@ -290,10 +290,10 @@ Deno.test({
     const tmpDir = await createTempTestDir("file-timeout");
 
     try {
-      // Create multiple binary files
-      await createTestBinaryFile(creature, 200, tmpDir, "test1.bin");
-      await createTestBinaryFile(creature, 200, tmpDir, "test2.bin");
-      await createTestBinaryFile(creature, 200, tmpDir, "test3.bin");
+      // Create multiple binary files (reduced size for faster tests)
+      await createTestBinaryFile(creature, 100, tmpDir, "test1.bin");
+      await createTestBinaryFile(creature, 100, tmpDir, "test2.bin");
+      await createTestBinaryFile(creature, 100, tmpDir, "test3.bin");
 
       // Very short timeout - will hit during file processing
       const options = {

--- a/test/ErrorGuidedStructuralEvolution/PromiseChainErrorHandling.ts
+++ b/test/ErrorGuidedStructuralEvolution/PromiseChainErrorHandling.ts
@@ -52,7 +52,7 @@ Deno.test("Discovery promise chains have error handlers", async () => {
   CreatureUtil.makeUUID(creature);
   const discoverStructure = new DiscoverStructure(
     creature,
-    60,
+    5, // Reduced from 60s to 5s for faster tests
     DEFAULT_RUST_FLUSH_RECORDS,
   );
 
@@ -116,7 +116,7 @@ Deno.test({
     // Use an invalid temp directory path to force file write errors
     const discoverStructure = new DiscoverStructure(
       creature,
-      60,
+      5, // Reduced from 60s to 5s for faster tests
       DEFAULT_RUST_FLUSH_RECORDS,
     );
 
@@ -176,7 +176,7 @@ Deno.test("Discovery Promise.all() completes within timeout", async () => {
   CreatureUtil.makeUUID(creature);
   const discoverStructure = new DiscoverStructure(
     creature,
-    60,
+    5, // Reduced from 60s to 5s for faster tests
     DEFAULT_RUST_FLUSH_RECORDS,
   );
 

--- a/test/ErrorGuidedStructuralEvolution/RustDiscoveryPath.ts
+++ b/test/ErrorGuidedStructuralEvolution/RustDiscoveryPath.ts
@@ -104,7 +104,18 @@ Deno.test("rust discovery honours NEAT_AI_DISCOVERY_LIB_PATH override", async ()
     resetEnv("HOME", originalHome);
     resetEnv("USERPROFILE", originalUserProfile);
 
-    await Deno.remove(tempDir, { recursive: true });
-    await Deno.remove(tempHome, { recursive: true });
+    // Use removeSync - simpler, faster, and ensures all file handles are closed
+    try {
+      // deno-lint-ignore no-sync-fn-in-async-fn
+      Deno.removeSync(tempDir, { recursive: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+    try {
+      // deno-lint-ignore no-sync-fn-in-async-fn
+      Deno.removeSync(tempHome, { recursive: true });
+    } catch {
+      // Ignore cleanup errors
+    }
   }
 });


### PR DESCRIPTION
- Bumped version in deno.json to 0.209.1.
- Reduced various timeout and training data parameters across multiple test files to enhance test execution speed, including adjustments from 60s to 5s and from 200 to 30 records.
- Improved cleanup timing in tests to minimize delays and ensure efficient resource management.

These changes aim to streamline testing processes and improve overall performance during test execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up discovery tests by drastically reducing timeouts/data sizes and switching to synchronous cleanup, plus minor constants tuning and a version bump.
> 
> - **Tests (discovery)**:
>   - Reduce timeouts (e.g., 60–120s → ~5s; 1s → 0.1s) and shorten explicit waits.
>   - Lower dataset sizes (records/training data) and neuron counts across suites for faster runs.
>   - Switch temp directory cleanup to `Deno.removeSync(...)` and remove unnecessary async waits.
>   - Tune options for CI (e.g., `discoveryTimeOutMinutes`, `discoveryAnalysisTimeoutMinutes`, `discoveryBatchSize`, `log: 0`).
>   - Adjust constants: `DISCOVERY_RECORD_COUNT` `512` → `50`, `DISCOVERY_INPUT_COUNT` `256` → `60`.
> - **Package**:
>   - Update `deno.json` version to `0.209.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eda0645a11e1546d67e4b2c67d1aa6b583899eb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->