### PR TITLE
V0.213.0

### DIFF
--- a/RANK_FOCUS_NEURONS_SPEC.md
+++ b/RANK_FOCUS_NEURONS_SPEC.md
@@ -1,0 +1,214 @@
+# rankFocusNeurons Algorithm Specification
+
+**Date:** 23-Nov-2025
+
+## Purpose
+
+`rankFocusNeurons` identifies which neurons have the highest potential for error reduction based on their error magnitude and influence on outputs. It should be a **fast calculation** (< 1 second for typical networks).
+
+## Current Problem
+
+Taking **173 seconds** for 463 neurons with 41,000 records. Expected time: **< 1 second**.
+
+## Algorithm
+
+### Input
+- `parquetFile`: Path to Parquet file containing ~41,000 records
+- `creature`: Network topology (neurons and synapses)
+- `maxResults`: Number of top neurons to return (e.g., 64)
+
+### Output
+For each non-input neuron:
+- `neuronUuid`: The neuron identifier
+- `totalError`: Average absolute error across all records
+- `impact`: Share of creature-level error this neuron can influence (0.0 to 1.0)
+
+Sorted by `totalError × impact` (descending).
+
+## Step-by-Step Calculation
+
+### Step 1: Read Parquet File **ONCE**
+```
+Read ALL records from parquetFile into memory
+- Records: 41,000 samples
+- Each record has neuron_data array with errors for each non-input neuron
+```
+**Complexity:** O(records) = 41,000 operations  
+**Time:** ~10-50ms
+
+### Step 2: Calculate totalError for Each Neuron
+```
+For each non-input neuron:
+  totalError = 0
+  count = 0
+  
+  For each record in parquet:
+    For each error in record.neuron_data[neuron].errors:
+      totalError += abs(error)
+      count++
+  
+  totalError = totalError / count
+```
+**Complexity:** O(neurons × records × errors_per_neuron)  
+= 463 × 41,000 × ~1 = ~19M simple operations  
+**Time:** ~100-200ms
+
+**Optimization:** Use vectorized operations (Polars/Arrow) instead of loops.
+
+### Step 3: Calculate Impact (Share) for Each Neuron **ONCE**
+
+This is a **single backward pass** through the network topology:
+
+```
+1. Build topology maps (once):
+   - inbound_connections: Map<neuronIndex, List<{fromIndex, weight}>>
+   - neuron_shares: Map<neuronIndex, 0.0>
+
+2. Initialize outputs:
+   baseShare = 1.0 / num_outputs
+   For each output neuron:
+     neuron_shares[output] = baseShare
+
+3. Backward propagation (single pass):
+   visited = Set()
+   
+   def propagate_share(neuronIndex, share, path):
+     if share <= 0 or neuronIndex in path:
+       return  # Prevent cycles
+     
+     neuron_shares[neuronIndex] += share
+     path.add(neuronIndex)
+     
+     inbound = inbound_connections[neuronIndex]
+     if inbound.isEmpty():
+       path.remove(neuronIndex)
+       return
+     
+     total_abs_weight = sum(abs(conn.weight) for conn in inbound)
+     
+     for conn in inbound:
+       if total_abs_weight > EPSILON:
+         fraction = abs(conn.weight) / total_abs_weight
+       else:
+         fraction = 1.0 / len(inbound)  # Equal split if all weights ~0
+       
+       propagate_share(conn.fromIndex, share * fraction, path)
+     
+     path.remove(neuronIndex)
+   
+   For each output neuron:
+     propagate_share(output, baseShare, Set())
+
+4. Cap shares at 1.0:
+   For each neuron:
+     neuron_shares[neuron] = min(1.0, neuron_shares[neuron])
+```
+
+**Complexity:** O(neurons + connections) = single graph traversal  
+= 463 neurons + ~few thousand connections = ~5,000 operations  
+**Time:** ~1-5ms
+
+### Step 4: Combine and Sort
+```
+For each non-input neuron:
+  score = totalError × impact
+  
+Sort neurons by score (descending)
+Return top maxResults neurons
+```
+**Complexity:** O(neurons × log neurons) = 463 × log(463) ≈ 4,000  
+**Time:** < 1ms
+
+## Total Expected Performance
+
+| Step | Complexity | Expected Time |
+|------|-----------|---------------|
+| 1. Read Parquet | O(records) | 10-50ms |
+| 2. Calculate totalError | O(neurons × records) | 100-200ms |
+| 3. Calculate impact | O(neurons + connections) | 1-5ms |
+| 4. Sort | O(neurons × log neurons) | < 1ms |
+| **TOTAL** | | **< 300ms** |
+
+**Current:** 173 seconds = **578x slower than expected!**
+
+## Common Performance Pitfalls
+
+### ❌ DON'T: Read Parquet Multiple Times
+```rust
+// BAD: Reading file for each neuron
+for neuron in neurons {
+  let records = read_parquet(path)?;  // 463 file reads!
+  let error = calculate_error(neuron, records);
+}
+```
+
+### ✅ DO: Read Once, Process All
+```rust
+// GOOD: Single file read
+let records = read_parquet(path)?;
+for neuron in neurons {
+  let error = calculate_error(neuron, &records);
+}
+```
+
+### ❌ DON'T: Recalculate Impact for Each Neuron
+```rust
+// BAD: 463 graph traversals
+for neuron in neurons {
+  let impact = calculate_impact_for_neuron(neuron, &topology);  // Full traversal each time!
+}
+```
+
+### ✅ DO: Single Backward Pass
+```rust
+// GOOD: One traversal for all neurons
+let all_impacts = calculate_all_impacts_once(&topology);
+for neuron in neurons {
+  let impact = all_impacts.get(neuron);
+}
+```
+
+### ❌ DON'T: Allocate Inside Loops
+```rust
+// BAD: Creating new vectors in hot loop
+for record in records {
+  for neuron in neurons {
+    let errors = Vec::new();  // 463 × 41,000 allocations!
+    // ...
+  }
+}
+```
+
+### ✅ DO: Reuse Allocations
+```rust
+// GOOD: Allocate once, reuse
+let mut error_accumulator = vec![0.0; num_neurons];
+let mut count_accumulator = vec![0; num_neurons];
+for record in records {
+  for (idx, neuron_data) in record.neuron_data.iter().enumerate() {
+    error_accumulator[idx] += neuron_data.error.abs();
+    count_accumulator[idx] += 1;
+  }
+}
+```
+
+## Debugging Checklist
+
+If `rankFocusNeurons` is slow, check:
+
+1. ✅ Is Parquet read only once at the start?
+2. ✅ Are we using vectorized operations (Polars) for aggregations?
+3. ✅ Is impact calculated via single backward pass, not per-neuron?
+4. ✅ Are topology maps built once, not per neuron?
+5. ✅ Are allocations outside hot loops?
+6. ✅ Is logging disabled or outside tight loops?
+7. ✅ Are we using `release` build, not `debug`?
+
+## Reference Implementation
+
+See TypeScript version:
+- `CreatureErrorImpactEstimator.getNeuronShare()` - calculates impact via backward propagation
+- File: `src/discovery/NeuronErrorImpactEstimator.ts:62-121`
+
+The TypeScript version calculates impact for **all neurons in a single pass** using backward propagation from outputs.
+

--- a/RANK_FOCUS_NEURONS_SPEC.md
+++ b/RANK_FOCUS_NEURONS_SPEC.md
@@ -4,21 +4,27 @@
 
 ## Purpose
 
-`rankFocusNeurons` identifies which neurons have the highest potential for error reduction based on their error magnitude and influence on outputs. It should be a **fast calculation** (< 1 second for typical networks).
+`rankFocusNeurons` identifies which neurons have the highest potential for error
+reduction based on their error magnitude and influence on outputs. It should be
+a **fast calculation** (< 1 second for typical networks).
 
 ## Current Problem
 
-Taking **173 seconds** for 463 neurons with 41,000 records. Expected time: **< 1 second**.
+Taking **173 seconds** for 463 neurons with 41,000 records. Expected time: **< 1
+second**.
 
 ## Algorithm
 
 ### Input
+
 - `parquetFile`: Path to Parquet file containing ~41,000 records
 - `creature`: Network topology (neurons and synapses)
 - `maxResults`: Number of top neurons to return (e.g., 64)
 
 ### Output
+
 For each non-input neuron:
+
 - `neuronUuid`: The neuron identifier
 - `totalError`: Average absolute error across all records
 - `impact`: Share of creature-level error this neuron can influence (0.0 to 1.0)
@@ -28,15 +34,18 @@ Sorted by `totalError × impact` (descending).
 ## Step-by-Step Calculation
 
 ### Step 1: Read Parquet File **ONCE**
+
 ```
 Read ALL records from parquetFile into memory
 - Records: 41,000 samples
 - Each record has neuron_data array with errors for each non-input neuron
 ```
-**Complexity:** O(records) = 41,000 operations  
+
+**Complexity:** O(records) = 41,000 operations\
 **Time:** ~10-50ms
 
 ### Step 2: Calculate totalError for Each Neuron
+
 ```
 For each non-input neuron:
   totalError = 0
@@ -49,8 +58,9 @@ For each non-input neuron:
   
   totalError = totalError / count
 ```
-**Complexity:** O(neurons × records × errors_per_neuron)  
-= 463 × 41,000 × ~1 = ~19M simple operations  
+
+**Complexity:** O(neurons × records × errors_per_neuron)\
+= 463 × 41,000 × ~1 = ~19M simple operations\
 **Time:** ~100-200ms
 
 **Optimization:** Use vectorized operations (Polars/Arrow) instead of loops.
@@ -104,11 +114,12 @@ This is a **single backward pass** through the network topology:
      neuron_shares[neuron] = min(1.0, neuron_shares[neuron])
 ```
 
-**Complexity:** O(neurons + connections) = single graph traversal  
-= 463 neurons + ~few thousand connections = ~5,000 operations  
+**Complexity:** O(neurons + connections) = single graph traversal\
+= 463 neurons + ~few thousand connections = ~5,000 operations\
 **Time:** ~1-5ms
 
 ### Step 4: Combine and Sort
+
 ```
 For each non-input neuron:
   score = totalError × impact
@@ -116,24 +127,26 @@ For each non-input neuron:
 Sort neurons by score (descending)
 Return top maxResults neurons
 ```
-**Complexity:** O(neurons × log neurons) = 463 × log(463) ≈ 4,000  
+
+**Complexity:** O(neurons × log neurons) = 463 × log(463) ≈ 4,000\
 **Time:** < 1ms
 
 ## Total Expected Performance
 
-| Step | Complexity | Expected Time |
-|------|-----------|---------------|
-| 1. Read Parquet | O(records) | 10-50ms |
-| 2. Calculate totalError | O(neurons × records) | 100-200ms |
-| 3. Calculate impact | O(neurons + connections) | 1-5ms |
-| 4. Sort | O(neurons × log neurons) | < 1ms |
-| **TOTAL** | | **< 300ms** |
+| Step                    | Complexity               | Expected Time |
+| ----------------------- | ------------------------ | ------------- |
+| 1. Read Parquet         | O(records)               | 10-50ms       |
+| 2. Calculate totalError | O(neurons × records)     | 100-200ms     |
+| 3. Calculate impact     | O(neurons + connections) | 1-5ms         |
+| 4. Sort                 | O(neurons × log neurons) | < 1ms         |
+| **TOTAL**               |                          | **< 300ms**   |
 
 **Current:** 173 seconds = **578x slower than expected!**
 
 ## Common Performance Pitfalls
 
 ### ❌ DON'T: Read Parquet Multiple Times
+
 ```rust
 // BAD: Reading file for each neuron
 for neuron in neurons {
@@ -143,6 +156,7 @@ for neuron in neurons {
 ```
 
 ### ✅ DO: Read Once, Process All
+
 ```rust
 // GOOD: Single file read
 let records = read_parquet(path)?;
@@ -152,6 +166,7 @@ for neuron in neurons {
 ```
 
 ### ❌ DON'T: Recalculate Impact for Each Neuron
+
 ```rust
 // BAD: 463 graph traversals
 for neuron in neurons {
@@ -160,6 +175,7 @@ for neuron in neurons {
 ```
 
 ### ✅ DO: Single Backward Pass
+
 ```rust
 // GOOD: One traversal for all neurons
 let all_impacts = calculate_all_impacts_once(&topology);
@@ -169,6 +185,7 @@ for neuron in neurons {
 ```
 
 ### ❌ DON'T: Allocate Inside Loops
+
 ```rust
 // BAD: Creating new vectors in hot loop
 for record in records {
@@ -180,6 +197,7 @@ for record in records {
 ```
 
 ### ✅ DO: Reuse Allocations
+
 ```rust
 // GOOD: Allocate once, reuse
 let mut error_accumulator = vec![0.0; num_neurons];
@@ -207,8 +225,10 @@ If `rankFocusNeurons` is slow, check:
 ## Reference Implementation
 
 See TypeScript version:
-- `CreatureErrorImpactEstimator.getNeuronShare()` - calculates impact via backward propagation
+
+- `CreatureErrorImpactEstimator.getNeuronShare()` - calculates impact via
+  backward propagation
 - File: `src/discovery/NeuronErrorImpactEstimator.ts:62-121`
 
-The TypeScript version calculates impact for **all neurons in a single pass** using backward propagation from outputs.
-
+The TypeScript version calculates impact for **all neurons in a single pass**
+using backward propagation from outputs.

--- a/TIMEOUT_STRATEGY.md
+++ b/TIMEOUT_STRATEGY.md
@@ -4,7 +4,8 @@
 
 ## The Problem
 
-Current timeout strategy is **horizontal** - tries to analyze all focus neurons but may timeout before completing upstream analysis for any of them.
+Current timeout strategy is **horizontal** - tries to analyze all focus neurons
+but may timeout before completing upstream analysis for any of them.
 
 ## Current (Horizontal) Timeout ❌
 
@@ -24,7 +25,8 @@ F:   [scan errors].......................[TIMEOUT - no upstream analysis]
 Result: 0 useful candidates because no upstream analysis completed
 ```
 
-**Message:** "Target insider-volume-check-14 had no upstream neurons to analyse."
+**Message:** "Target insider-volume-check-14 had no upstream neurons to
+analyse."
 
 ## Proposed (Vertical) Timeout ✅
 
@@ -44,7 +46,8 @@ F:   [not started]                          │ TIMEOUT (skipped)
 Result: 4 complete analyses with full upstream candidates
 ```
 
-**Benefit:** Get useful candidates for neurons A, B, C, D even if E and F timeout.
+**Benefit:** Get useful candidates for neurons A, B, C, D even if E and F
+timeout.
 
 ## Implementation Strategy
 
@@ -130,7 +133,8 @@ fn analyze_all(focus_neurons: Vec<String>, total_deadline: Instant) {
 }
 ```
 
-**Benefit:** Most impactful neurons get analyzed first, maximizing value even with timeout.
+**Benefit:** Most impactful neurons get analyzed first, maximizing value even
+with timeout.
 
 ## Current Code Structure
 
@@ -155,7 +159,8 @@ fn analyze_neurons(focus_list: Vec<String>, deadline_ms: u64) {
 }
 ```
 
-**Problem:** Deadline check happens BEFORE completing analysis for current neuron.
+**Problem:** Deadline check happens BEFORE completing analysis for current
+neuron.
 
 ```rust
 // BETTER (GOOD): Vertical timeout
@@ -210,14 +215,17 @@ fn analyze_neuron_complete(neuron: String, deadline: Instant) -> Result<Analysis
 ## What This Fixes
 
 **Before (Horizontal):**
+
 ```
 [NEAT-AI-Discovery][verbose] analyse_neurons reached analysis deadline; returning partial results.
 [NEAT-AI-Discovery][verbose] Target insider-volume-check-14 had no upstream neurons to analyse.
 [NEAT-AI-Discovery][verbose] Target proximity-check-near-zero-SP500-inclusion-v3 had no upstream neurons to analyse.
 ```
+
 Result: 0 useful candidates
 
 **After (Vertical):**
+
 ```
 [NEAT-AI-Discovery][verbose] ✓ Completed analysis for output-0 (23 candidates)
 [NEAT-AI-Discovery][verbose] ✓ Completed analysis for 57882a2a-fbb1-44fd-8807-865cec35a49a (15 candidates)
@@ -225,6 +233,7 @@ Result: 0 useful candidates
 [NEAT-AI-Discovery][verbose] ✓ Completed analysis for proximity-check-near-zero-SP500-inclusion-v3 (12 candidates)
 [NEAT-AI-Discovery][verbose] ⏱️  Timeout during analysis of next-neuron-uuid. Returning 4/6 complete analyses.
 ```
+
 Result: 68 useful candidates from 4 complete analyses!
 
 ## Recommendation
@@ -238,4 +247,3 @@ Implement **Option 3 (Priority Queue)** with **vertical timeout**:
 5. Return whatever completed analyses we have
 
 This ensures we get maximum value even with timeout constraints.
-

--- a/TIMEOUT_STRATEGY.md
+++ b/TIMEOUT_STRATEGY.md
@@ -1,0 +1,241 @@
+# Discovery Timeout Strategy: Vertical vs Horizontal
+
+**Date:** 23-Nov-2025
+
+## The Problem
+
+Current timeout strategy is **horizontal** - tries to analyze all focus neurons but may timeout before completing upstream analysis for any of them.
+
+## Current (Horizontal) Timeout ❌
+
+```
+Focus Neurons: [A, B, C, D, E, F]
+
+Timeline:
+0s   ─────────────────────────────────────> 60s (TIMEOUT)
+     ↓                                       ↓
+A:   [scan errors].......................[TIMEOUT - no upstream analysis]
+B:   [scan errors].......................[TIMEOUT - no upstream analysis]  
+C:   [scan errors].......................[TIMEOUT - no upstream analysis]
+D:   [scan errors].......................[TIMEOUT - no upstream analysis]
+E:   [scan errors].......................[TIMEOUT - no upstream analysis]
+F:   [scan errors].......................[TIMEOUT - no upstream analysis]
+
+Result: 0 useful candidates because no upstream analysis completed
+```
+
+**Message:** "Target insider-volume-check-14 had no upstream neurons to analyse."
+
+## Proposed (Vertical) Timeout ✅
+
+```
+Focus Neurons: [A, B, C, D, E, F]
+
+Timeline:
+0s   ─────────────────────────────────────> 60s (TIMEOUT)
+     ↓                     ↓                 ↓
+A:   [scan][upstream]──✓─┐                  │
+B:   [scan][upstream]──✓─┤ Complete!        │
+C:   [scan][upstream]──✓─┘                  │
+D:   [scan][upstream──────────────────✓]────┤ Complete!
+E:   [scan][upstream──────────────────────] │ TIMEOUT (partial)
+F:   [not started]                          │ TIMEOUT (skipped)
+
+Result: 4 complete analyses with full upstream candidates
+```
+
+**Benefit:** Get useful candidates for neurons A, B, C, D even if E and F timeout.
+
+## Implementation Strategy
+
+### Option 1: Per-Neuron Timeout Budget
+
+```rust
+fn analyze_all(focus_neurons: Vec<String>, total_deadline: Instant) {
+    let mut results = Vec::new();
+    
+    for focus_neuron in focus_neurons {
+        let remaining_time = total_deadline - Instant::now();
+        if remaining_time.is_zero() {
+            log::warn!("⏱️  Analysis deadline reached. Analyzed {}/{} focus neurons.", 
+                       results.len(), focus_neurons.len());
+            break;  // Return partial results
+        }
+        
+        // Analyze THIS neuron completely (scan errors + find upstream)
+        match analyze_neuron_complete(focus_neuron, remaining_time) {
+            Ok(candidates) => {
+                results.extend(candidates);
+                log::debug!("✓ Completed analysis for {}", focus_neuron);
+            }
+            Err(Timeout) => {
+                log::warn!("⏱️  Timeout during analysis of {}. Returning results for {}/{} neurons.",
+                           focus_neuron, results.len(), focus_neurons.len());
+                break;
+            }
+        }
+    }
+    
+    return results;
+}
+```
+
+### Option 2: Adaptive Timeout Per Neuron
+
+```rust
+fn analyze_all(focus_neurons: Vec<String>, total_deadline: Instant) {
+    let total_time_budget = total_deadline - Instant::now();
+    let time_per_neuron = total_time_budget / focus_neurons.len();
+    
+    for (idx, focus_neuron) in focus_neurons.iter().enumerate() {
+        let neuron_deadline = Instant::now() + time_per_neuron;
+        
+        match analyze_neuron_with_deadline(focus_neuron, neuron_deadline) {
+            Ok(candidates) => {
+                results.extend(candidates);
+            }
+            Err(Timeout) => {
+                // This neuron took too long, skip to next
+                log::warn!("⏱️  Neuron {} exceeded time budget, skipping", focus_neuron);
+                continue;
+            }
+        }
+        
+        // Check global deadline
+        if Instant::now() >= total_deadline {
+            log::warn!("⏱️  Global deadline reached after {}/{} neurons", 
+                       idx + 1, focus_neurons.len());
+            break;
+        }
+    }
+}
+```
+
+### Option 3: Priority Queue (Best First)
+
+```rust
+// Analyze neurons in order of highest potential error reduction
+fn analyze_all(focus_neurons: Vec<String>, total_deadline: Instant) {
+    // Sort by totalError × impact (descending)
+    let sorted_neurons = sort_by_potential_impact(focus_neurons);
+    
+    for neuron in sorted_neurons {
+        if Instant::now() >= total_deadline {
+            break;
+        }
+        
+        // Fully analyze the highest-priority neurons first
+        analyze_neuron_complete(neuron, total_deadline)?;
+    }
+}
+```
+
+**Benefit:** Most impactful neurons get analyzed first, maximizing value even with timeout.
+
+## Current Code Structure
+
+The problem is in how `analyzeAll` / `analyze_parallel` handles the deadline:
+
+```rust
+// CURRENT (BAD): Horizontal timeout
+fn analyze_neurons(focus_list: Vec<String>, deadline_ms: u64) {
+    let deadline = Instant::now() + Duration::from_millis(deadline_ms);
+    
+    for neuron in focus_list {
+        // Check deadline at TOP of loop
+        if Instant::now() >= deadline {
+            log::warn!("analyse_neurons reached analysis deadline");
+            break;  // ← This leaves current neuron incomplete!
+        }
+        
+        // Start analyzing neuron...
+        scan_errors_for_neuron(neuron)?;
+        // But timeout before finding upstream neurons!
+    }
+}
+```
+
+**Problem:** Deadline check happens BEFORE completing analysis for current neuron.
+
+```rust
+// BETTER (GOOD): Vertical timeout
+fn analyze_neurons(focus_list: Vec<String>, deadline_ms: u64) {
+    let deadline = Instant::now() + Duration::from_millis(deadline_ms);
+    let mut completed = Vec::new();
+    
+    for neuron in focus_list {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            log::warn!("Deadline reached. Completed {}/{} neurons", 
+                       completed.len(), focus_list.len());
+            break;
+        }
+        
+        // Analyze THIS neuron COMPLETELY (with timeout guard inside)
+        match analyze_neuron_complete(neuron, deadline) {
+            Ok(result) => {
+                completed.push(result);
+                log::debug!("✓ Completed {}", neuron);
+            }
+            Err(Timeout) => {
+                log::warn!("Timeout during {}. Skipping to preserve completed analyses.", neuron);
+                break;  // ← Return what we have so far
+            }
+        }
+    }
+    
+    return completed;
+}
+
+fn analyze_neuron_complete(neuron: String, deadline: Instant) -> Result<Analysis, Error> {
+    // Step 1: Scan errors (fast)
+    let errors = scan_errors(neuron)?;
+    
+    // Step 2: Find upstream neurons (the part that's failing!)
+    if Instant::now() >= deadline {
+        return Err(Timeout);  // Don't start if we can't finish
+    }
+    let upstream = find_upstream_neurons(neuron, deadline)?;
+    
+    // Step 3: Analyze upstream connections
+    if Instant::now() >= deadline {
+        return Err(Timeout);
+    }
+    let candidates = analyze_upstream_connections(neuron, upstream, deadline)?;
+    
+    Ok(Analysis { neuron, candidates })
+}
+```
+
+## What This Fixes
+
+**Before (Horizontal):**
+```
+[NEAT-AI-Discovery][verbose] analyse_neurons reached analysis deadline; returning partial results.
+[NEAT-AI-Discovery][verbose] Target insider-volume-check-14 had no upstream neurons to analyse.
+[NEAT-AI-Discovery][verbose] Target proximity-check-near-zero-SP500-inclusion-v3 had no upstream neurons to analyse.
+```
+Result: 0 useful candidates
+
+**After (Vertical):**
+```
+[NEAT-AI-Discovery][verbose] ✓ Completed analysis for output-0 (23 candidates)
+[NEAT-AI-Discovery][verbose] ✓ Completed analysis for 57882a2a-fbb1-44fd-8807-865cec35a49a (15 candidates)
+[NEAT-AI-Discovery][verbose] ✓ Completed analysis for insider-volume-check-14 (18 candidates)
+[NEAT-AI-Discovery][verbose] ✓ Completed analysis for proximity-check-near-zero-SP500-inclusion-v3 (12 candidates)
+[NEAT-AI-Discovery][verbose] ⏱️  Timeout during analysis of next-neuron-uuid. Returning 4/6 complete analyses.
+```
+Result: 68 useful candidates from 4 complete analyses!
+
+## Recommendation
+
+Implement **Option 3 (Priority Queue)** with **vertical timeout**:
+
+1. Sort focus neurons by `totalError × impact` (already done in TypeScript)
+2. Analyze highest-priority neurons FIRST
+3. Complete each neuron fully (errors + upstream) before moving to next
+4. Check deadline BETWEEN neurons, not during neuron analysis
+5. Return whatever completed analyses we have
+
+This ensures we get maximum value even with timeout constraints.
+

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.212.0",
+  "version": "0.213.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -791,6 +791,20 @@ export class DiscoverStructure {
       };
     });
 
+    // Verbose logging: report neuron coverage in this batch
+    if (this.loggingEnabled && pendingSamples > 0) {
+      const uniqueNeuronUUIDs = new Set<string>();
+      rustTrainingData.forEach((record) => {
+        record.neuron_data.forEach((neuron) => {
+          uniqueNeuronUUIDs.add(neuron.neuron_uuid);
+        });
+      });
+      this.log(
+        "debug",
+        `Parquet batch includes ${uniqueNeuronUUIDs.size} unique neurons across ${pendingSamples} samples (${nonInputNeurons.length} non-input neurons in creature).`,
+      );
+    }
+
     const diagnostics = this.inspectRustFlushBatch(
       rustTrainingData,
       this.creature.input,
@@ -3025,9 +3039,13 @@ export class DiscoverStructure {
         const duration = result.durationMs !== undefined
           ? this.formatMillis(result.durationMs)
           : "unknown time";
+        const scannedInfo = result.processedNeurons !== undefined &&
+            result.totalNeurons !== undefined
+          ? ` Scanned ${result.processedNeurons}/${result.totalNeurons} neurons.`
+          : "";
         this.log(
           "debug",
-          `Rust focus ranking returned ${result.neurons.length} neuron(s) in ${duration}.`,
+          `Rust focus ranking returned ${result.neurons.length} neuron(s) in ${duration}.${scannedInfo}`,
         );
       }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -792,16 +792,11 @@ export class DiscoverStructure {
     });
 
     // Verbose logging: report neuron coverage in this batch
+    // Note: All records contain the same set of neurons (nonInputNeurons), so no need to iterate
     if (this.loggingEnabled && pendingSamples > 0) {
-      const uniqueNeuronUUIDs = new Set<string>();
-      rustTrainingData.forEach((record) => {
-        record.neuron_data.forEach((neuron) => {
-          uniqueNeuronUUIDs.add(neuron.neuron_uuid);
-        });
-      });
       this.log(
         "debug",
-        `Parquet batch includes ${uniqueNeuronUUIDs.size} unique neurons across ${pendingSamples} samples (${nonInputNeurons.length} non-input neurons in creature).`,
+        `Parquet batch includes ${nonInputNeurons.length} neurons across ${pendingSamples} samples.`,
       );
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds specs for rankFocusNeurons and vertical timeout strategy, improves discovery logging (Parquet batch coverage and focus ranking stats), and bumps to 0.213.0.
> 
> - **Docs**:
>   - Add `RANK_FOCUS_NEURONS_SPEC.md` detailing algorithm and performance expectations for `rankFocusNeurons`.
>   - Add `TIMEOUT_STRATEGY.md` outlining vertical timeout approach with implementation options.
> - **Discovery Logging**:
>   - In `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts`:
>     - Log Parquet batch neuron coverage: `nonInputNeurons.length` × `pendingSamples`.
>     - Enhance Rust focus ranking debug log to include scanned `processedNeurons/totalNeurons` and duration.
> - **Version**:
>   - Update `deno.json` `version` to `0.213.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa255396166e9d7f98f83b972937b676fa14cc8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->