### PR TITLE
Update version to 0.214.1 and simplify improvement threshold logic in…

### DIFF
--- a/RUST_NO_ELIGIBLE_UPSTREAM_FIX.md
+++ b/RUST_NO_ELIGIBLE_UPSTREAM_FIX.md
@@ -2,17 +2,23 @@
 
 ## Problem
 
-The Rust discovery library is returning `"no_eligible_sources"` diagnostics for neurons that should have eligible upstream sources. This is causing valid discovery candidates to be incorrectly filtered out.
+The Rust discovery library is returning `"no_eligible_sources"` diagnostics for
+neurons that should have eligible upstream sources. This is causing valid
+discovery candidates to be incorrectly filtered out.
 
 ## Expected Behavior
 
-All non-input neurons in a valid creature **must** have at least one inward synapse. Therefore, for any non-input neuron, there should always be potential upstream sources to evaluate for synapse discovery.
+All non-input neurons in a valid creature **must** have at least one inward
+synapse. Therefore, for any non-input neuron, there should always be potential
+upstream sources to evaluate for synapse discovery.
 
 ## Current Issue
 
 The Rust library is reporting `"no_eligible_sources"` for neurons that:
+
 - Are not input neurons (input neurons legitimately have no upstream sources)
-- Are part of a valid creature (which requires all non-input neurons to have inward synapses)
+- Are part of a valid creature (which requires all non-input neurons to have
+  inward synapses)
 - Should have eligible upstream neurons available for synapse discovery
 
 ## Example from Logs
@@ -22,6 +28,7 @@ The Rust library is reporting `"no_eligible_sources"` for neurons that:
 ```
 
 This message appears even when:
+
 - The creature is valid (all neurons have required connections)
 - There are ~2000 observations/samples available
 - The neuron is not an input neuron
@@ -30,27 +37,38 @@ This message appears even when:
 
 The "no eligible upstream sources" check may be:
 
-1. **Overly restrictive filtering**: Filtering out all potential sources because they're already connected, when we should still consider them for analysis
-2. **Incorrect eligibility logic**: The eligibility check may be incorrectly determining that no sources are available
-3. **Missing source types**: Not considering all valid source neuron types (e.g., input neurons, hidden neurons, other output neurons)
-4. **Sample alignment issue**: Incorrectly determining that no aligned samples exist, when samples should be available
+1. **Overly restrictive filtering**: Filtering out all potential sources because
+   they're already connected, when we should still consider them for analysis
+2. **Incorrect eligibility logic**: The eligibility check may be incorrectly
+   determining that no sources are available
+3. **Missing source types**: Not considering all valid source neuron types
+   (e.g., input neurons, hidden neurons, other output neurons)
+4. **Sample alignment issue**: Incorrectly determining that no aligned samples
+   exist, when samples should be available
 
 ## Requested Fix
 
 ### Option 1: Remove or Relax the "No Eligible Sources" Check (Recommended)
 
-If a neuron is not an input neuron and the creature is valid, there should always be eligible upstream sources. The check should:
+If a neuron is not an input neuron and the creature is valid, there should
+always be eligible upstream sources. The check should:
 
-1. **Only apply to input neurons**: Input neurons legitimately have no upstream sources
-2. **For non-input neurons**: Always assume eligible sources exist, or at minimum, log a warning if truly none are found (as this would indicate a creature validation bug)
+1. **Only apply to input neurons**: Input neurons legitimately have no upstream
+   sources
+2. **For non-input neurons**: Always assume eligible sources exist, or at
+   minimum, log a warning if truly none are found (as this would indicate a
+   creature validation bug)
 
 ### Option 2: Improve Eligibility Detection
 
 If the check must remain, improve it to:
 
-1. **Check all neuron types**: Consider input, hidden, and output neurons as potential sources
-2. **Don't filter by existing connections**: Even if a synapse already exists, the source neuron is still "eligible" for analysis purposes
-3. **Verify sample availability**: Ensure the check isn't incorrectly determining that no samples are available
+1. **Check all neuron types**: Consider input, hidden, and output neurons as
+   potential sources
+2. **Don't filter by existing connections**: Even if a synapse already exists,
+   the source neuron is still "eligible" for analysis purposes
+3. **Verify sample availability**: Ensure the check isn't incorrectly
+   determining that no samples are available
 4. **Add detailed logging**: When "no eligible sources" is detected, log:
    - Neuron UUID and type
    - Number of existing inward synapses
@@ -60,21 +78,28 @@ If the check must remain, improve it to:
 
 ### Option 3: Make it a Warning, Not a Filter
 
-Instead of filtering out candidates with "no eligible sources", make it a diagnostic warning but still allow the analysis to proceed. The TypeScript side can then decide whether to proceed or skip based on the full context.
+Instead of filtering out candidates with "no eligible sources", make it a
+diagnostic warning but still allow the analysis to proceed. The TypeScript side
+can then decide whether to proceed or skip based on the full context.
 
 ## Expected Outcome
 
 After the fix:
 
-1. **Valid neurons should not report "no eligible sources"** unless they are input neurons
+1. **Valid neurons should not report "no eligible sources"** unless they are
+   input neurons
 2. **Discovery should proceed** for all non-input neurons with available samples
-3. **If truly no sources exist** (which would indicate a creature validation bug), it should be logged as an error/warning, not silently filtered
+3. **If truly no sources exist** (which would indicate a creature validation
+   bug), it should be logged as an error/warning, not silently filtered
 
 ## Related Code Locations
 
 - Rust diagnostic reason: `"no_eligible_sources"` in synapse/neuron diagnostics
-- TypeScript mapping: `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts:2529-2530` and `2548-2549`
-- Rust interfaces: `RustSynapseDiagnostic` and `RustNeuronDiagnostic` with `reason: "no_eligible_sources"`
+- TypeScript mapping:
+  `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts:2529-2530`
+  and `2548-2549`
+- Rust interfaces: `RustSynapseDiagnostic` and `RustNeuronDiagnostic` with
+  `reason: "no_eligible_sources"`
 
 ## Validation
 
@@ -89,6 +114,7 @@ To verify the fix:
 ## Notes
 
 - The user suspects this is appearing incorrectly for valid neurons
-- A neuron connected to all ~2000 observations would be a valid case for "no eligible sources" (all already connected), but this is unlikely
-- The more likely issue is overly aggressive filtering or incorrect eligibility logic in the Rust library
-
+- A neuron connected to all ~2000 observations would be a valid case for "no
+  eligible sources" (all already connected), but this is unlikely
+- The more likely issue is overly aggressive filtering or incorrect eligibility
+  logic in the Rust library

--- a/RUST_NO_ELIGIBLE_UPSTREAM_FIX.md
+++ b/RUST_NO_ELIGIBLE_UPSTREAM_FIX.md
@@ -1,0 +1,94 @@
+# Rust Discovery: Fix "No Eligible Upstream Sources" Diagnostic
+
+## Problem
+
+The Rust discovery library is returning `"no_eligible_sources"` diagnostics for neurons that should have eligible upstream sources. This is causing valid discovery candidates to be incorrectly filtered out.
+
+## Expected Behavior
+
+All non-input neurons in a valid creature **must** have at least one inward synapse. Therefore, for any non-input neuron, there should always be potential upstream sources to evaluate for synapse discovery.
+
+## Current Issue
+
+The Rust library is reporting `"no_eligible_sources"` for neurons that:
+- Are not input neurons (input neurons legitimately have no upstream sources)
+- Are part of a valid creature (which requires all non-input neurons to have inward synapses)
+- Should have eligible upstream neurons available for synapse discovery
+
+## Example from Logs
+
+```
+[NEAT-AI-Discovery][verbose] Target adjustment-node-00003-v4 had no eligible upstream neurons to evaluate.
+```
+
+This message appears even when:
+- The creature is valid (all neurons have required connections)
+- There are ~2000 observations/samples available
+- The neuron is not an input neuron
+
+## Root Cause Hypothesis
+
+The "no eligible upstream sources" check may be:
+
+1. **Overly restrictive filtering**: Filtering out all potential sources because they're already connected, when we should still consider them for analysis
+2. **Incorrect eligibility logic**: The eligibility check may be incorrectly determining that no sources are available
+3. **Missing source types**: Not considering all valid source neuron types (e.g., input neurons, hidden neurons, other output neurons)
+4. **Sample alignment issue**: Incorrectly determining that no aligned samples exist, when samples should be available
+
+## Requested Fix
+
+### Option 1: Remove or Relax the "No Eligible Sources" Check (Recommended)
+
+If a neuron is not an input neuron and the creature is valid, there should always be eligible upstream sources. The check should:
+
+1. **Only apply to input neurons**: Input neurons legitimately have no upstream sources
+2. **For non-input neurons**: Always assume eligible sources exist, or at minimum, log a warning if truly none are found (as this would indicate a creature validation bug)
+
+### Option 2: Improve Eligibility Detection
+
+If the check must remain, improve it to:
+
+1. **Check all neuron types**: Consider input, hidden, and output neurons as potential sources
+2. **Don't filter by existing connections**: Even if a synapse already exists, the source neuron is still "eligible" for analysis purposes
+3. **Verify sample availability**: Ensure the check isn't incorrectly determining that no samples are available
+4. **Add detailed logging**: When "no eligible sources" is detected, log:
+   - Neuron UUID and type
+   - Number of existing inward synapses
+   - Number of potential source neurons in the creature
+   - Number of samples available
+   - Why each potential source was filtered out
+
+### Option 3: Make it a Warning, Not a Filter
+
+Instead of filtering out candidates with "no eligible sources", make it a diagnostic warning but still allow the analysis to proceed. The TypeScript side can then decide whether to proceed or skip based on the full context.
+
+## Expected Outcome
+
+After the fix:
+
+1. **Valid neurons should not report "no eligible sources"** unless they are input neurons
+2. **Discovery should proceed** for all non-input neurons with available samples
+3. **If truly no sources exist** (which would indicate a creature validation bug), it should be logged as an error/warning, not silently filtered
+
+## Related Code Locations
+
+- Rust diagnostic reason: `"no_eligible_sources"` in synapse/neuron diagnostics
+- TypeScript mapping: `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts:2529-2530` and `2548-2549`
+- Rust interfaces: `RustSynapseDiagnostic` and `RustNeuronDiagnostic` with `reason: "no_eligible_sources"`
+
+## Validation
+
+To verify the fix:
+
+1. Run discovery on a creature with ~2000 samples
+2. Check that "no eligible upstream sources" only appears for:
+   - Input neurons (legitimate)
+   - Cases where it's truly impossible (with detailed logging explaining why)
+3. Verify that discovery candidates are not incorrectly filtered out
+
+## Notes
+
+- The user suspects this is appearing incorrectly for valid neurons
+- A neuron connected to all ~2000 observations would be a valid case for "no eligible sources" (all already connected), but this is unlikely
+- The more likely issue is overly aggressive filtering or incorrect eligibility logic in the Rust library
+

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.214.0",
+  "version": "0.214.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -472,14 +472,6 @@ class DataRecorder {
     if (Array.isArray(focusOverride) && focusOverride.length > 0) {
       discoverStructure.setForcedFocusNeurons(focusOverride);
     }
-    if (
-      typeof options.discoveryMinImprovementPercentage === "number" &&
-      Number.isFinite(options.discoveryMinImprovementPercentage)
-    ) {
-      discoverStructure.setImprovementThreshold(
-        options.discoveryMinImprovementPercentage,
-      );
-    }
     const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
     const initializeStartTime = Date.now();

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -267,24 +267,19 @@ interface RustFlushAggregation {
 }
 
 /**
- * Discovery thresholds tuned for continuous incremental improvement (23-Nov-2025)
- *
- * Discovery is designed for SMALL, INCREMENTAL improvements (0.5-3% per iteration)
- * that accumulate over time through repeated runs across multiple machines.
- *
- * DO NOT expect 10%+ improvements in a single iteration - that's unrealistic!
+ * Discovery accepts ANY positive improvement, no matter how small. This allows
+ * continuous incremental improvements that accumulate over time through repeated
+ * runs across multiple machines.
  *
  * Example real-world results:
  * - 100 iterations × 1.5% average = ~16% total improvement
  * - With 5 machines running continuously = 5× faster progress
  *
- * A 1% threshold accepts meaningful improvements while filtering random noise.
- * Previous 10% threshold rejected valid 1.58% improvements.
+ * All candidates with positive expected improvement are evaluated, and the
+ * re-scoring phase determines which actually improve the creature's score.
  *
  * @see docs/DISCOVERY_GUIDE.md for details on the distributed discovery model
  */
-const DEFAULT_RUST_HELPFUL_THRESHOLD = 0.01; // 1% improvement threshold (was 0.1 / 10%)
-const DEFAULT_RUST_HARMFUL_THRESHOLD = -0.01; // -1% degradation threshold (was -0.1 / -10%)
 
 /**
  * Implements Error-Driven Structural Discovery, analyzing neuron activations and errors
@@ -339,10 +334,8 @@ export class DiscoverStructure {
   private deps: DiscoverStructureDeps;
   private forcedFocusNeurons: string[] | null = null;
   private forcedFocusIndex = 0;
-  private improvementThreshold = DEFAULT_RUST_HELPFUL_THRESHOLD;
   private neuronImpactEstimator?: CreatureErrorImpactEstimator;
   private neuronIndexMap?: Map<string, number>;
-  private harmfulThreshold = DEFAULT_RUST_HARMFUL_THRESHOLD;
   private lastFocusSelection?: FocusSelectionSummary;
   private cachedMaxOutputError?: { value: number; computedAt: number } =
     undefined;
@@ -522,29 +515,6 @@ export class DiscoverStructure {
         `Applying forced discovery focus neurons: ${
           this.forcedFocusNeurons.join(", ")
         }`,
-      );
-    }
-  }
-
-  public setImprovementThreshold(threshold: number): void {
-    const parsed = Number(threshold);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-      if (this.loggingEnabled) {
-        this.log(
-          "warn",
-          `Ignored invalid discovery improvement threshold: ${threshold}`,
-        );
-      }
-      return;
-    }
-    this.improvementThreshold = parsed;
-    this.harmfulThreshold = -Math.abs(parsed);
-    if (this.loggingEnabled) {
-      this.log(
-        "info",
-        `Configured discovery improvement threshold to ${
-          (this.improvementThreshold * 100).toFixed(2)
-        }%.`,
       );
     }
   }
@@ -1503,9 +1473,7 @@ export class DiscoverStructure {
 
     const candidates = helpfulNeurons
       .map((candidate) => this.mapRustNeuronCandidate(candidate))
-      .filter((candidate) =>
-        candidate.expectedImprovementPercentage > this.improvementThreshold
-      );
+      .filter((candidate) => candidate.expectedImprovementPercentage > 0);
 
     if (candidates.length === 0) {
       this.logRustNoImprovement("neuron", focusList, rustResult.diagnostics);
@@ -1539,9 +1507,7 @@ export class DiscoverStructure {
 
     const candidates = helpfulSynapses
       .map((candidate) => this.mapRustCandidate(candidate))
-      .filter((candidate) =>
-        candidate.expectedImprovementPercentage > this.improvementThreshold
-      );
+      .filter((candidate) => candidate.expectedImprovementPercentage > 0);
 
     if (candidates.length === 0) {
       this.logRustNoImprovement("synapse", focusList, rustResult.diagnostics);
@@ -1575,9 +1541,7 @@ export class DiscoverStructure {
 
     const candidates = rustResult.harmfulSynapses
       .map((candidate) => this.mapRustCandidate(candidate))
-      .filter((candidate) =>
-        candidate.expectedImprovementPercentage < this.harmfulThreshold
-      );
+      .filter((candidate) => candidate.expectedImprovementPercentage < 0);
 
     if (candidates.length === 0) {
       return [];
@@ -1772,7 +1736,6 @@ export class DiscoverStructure {
       parquetFile: this.parquetFilePath,
       creature: creatureToRustFormat(this.creature.exportJSON()),
       focusNeurons: focusList,
-      improvementThreshold: this.improvementThreshold,
       maxCandidates: Math.max(25, focusList.length * 5),
       requireGpu: Deno.build.os === "darwin",
       analysisDeadlineMs: this.analysisDeadlineMs,
@@ -1836,7 +1799,6 @@ export class DiscoverStructure {
       parquetFile: this.parquetFilePath,
       creature: creatureToRustFormat(this.creature.exportJSON()),
       focusNeurons: focusList,
-      improvementThreshold: this.improvementThreshold,
       maxCandidates: Math.max(50, focusList.length * 10),
       requireGpu: Deno.build.os === "darwin",
       analysisDeadlineMs: this.analysisDeadlineMs,
@@ -2170,8 +2132,6 @@ export class DiscoverStructure {
         parquetFile: this.parquetFilePath,
         creature: rustCreature,
         focusNeurons: focusList,
-        improvementThreshold: this.improvementThreshold,
-        harmfulThreshold: this.harmfulThreshold,
         maxSynapseCandidates: includeSynapse
           ? Math.max(50, focusList.length * 10)
           : undefined,
@@ -2213,8 +2173,6 @@ export class DiscoverStructure {
       parquetFile: this.parquetFilePath,
       creature: rustCreature,
       focusNeurons: focusList,
-      improvementThreshold: this.improvementThreshold,
-      harmfulThreshold: this.harmfulThreshold,
       maxSynapseCandidates: includeSynapse
         ? Math.max(50, focusList.length * 10)
         : undefined,
@@ -2527,6 +2485,9 @@ export class DiscoverStructure {
   ): string {
     switch (reason) {
       case "no_eligible_sources":
+        // Note: This may indicate a Rust library issue - all non-input neurons should have
+        // inward synapses. If this appears for valid neurons, it may be a filtering issue
+        // in the Rust library (e.g., all potential sources are already connected or filtered out).
         return "No eligible upstream sources";
       case "no_diagnostics":
         return "No diagnostics recorded";
@@ -2546,6 +2507,9 @@ export class DiscoverStructure {
   ): string {
     switch (reason) {
       case "no_eligible_sources":
+        // Note: This may indicate a Rust library issue - all non-input neurons should have
+        // inward synapses. If this appears for valid neurons, it may be a filtering issue
+        // in the Rust library (e.g., all potential sources are already connected or filtered out).
         return "No eligible upstream sources";
       case "no_diagnostics":
         return "No diagnostics recorded";
@@ -3664,11 +3628,8 @@ export class DiscoverStructure {
 
       const expectedImprovementPercentage = scaledImprovement * impactScale;
 
-      // Return candidate even if improvement is small, but only if raw improvement was significant
-      // Use a lower threshold for small sample counts to allow test cases to pass
-      // With more samples, we can be more strict
-      const improvementThreshold = sampleCount < 10 ? 0.001 : 0.01;
-      if (rawImprovement > improvementThreshold) {
+      // Accept any positive improvement (no threshold filtering)
+      if (rawImprovement > 0) {
         // Clear large arrays to help GC (after we've used them for improvement calculation)
         rawValues.length = 0;
         currentActivations.length = 0;


### PR DESCRIPTION
… discovery process

- Bumped version in deno.json to 0.214.1.
- Removed the improvement threshold setting from the DataRecorder and DiscoverStructure classes, allowing for any positive improvement to be accepted during candidate evaluations.
- Updated filtering logic to evaluate all candidates with positive expected improvement, enhancing the discovery process's flexibility and effectiveness.

These changes aim to streamline the discovery process by focusing on all potential improvements, regardless of size, thereby facilitating continuous incremental advancements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies discovery to evaluate any candidate with positive expected improvement, removes threshold plumbing, adds docs and logging notes for Rust "no_eligible_sources", and bumps version to 0.214.1.
> 
> - **Discovery pipeline**:
>   - Remove improvement threshold configuration and related fields/methods in `DiscoverStructure` and stop passing thresholds to Rust inputs.
>   - Change candidate filtering to accept `> 0` improvements (helpful) and `< 0` (harmful) for synapses/neurons; update squash analysis to accept any positive raw improvement.
>   - Drop threshold setting from `DiscoverDirectory` setup.
> - **Diagnostics/Logging**:
>   - Add clarifying notes when Rust returns `reason: "no_eligible_sources"` for neuron/synapse diagnostics.
> - **Docs**:
>   - Add `RUST_NO_ELIGIBLE_UPSTREAM_FIX.md` outlining the issue and proposed fixes for erroneous "no_eligible_sources" diagnostics in Rust.
> - **Version**:
>   - Bump `deno.json` version to `0.214.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e48caebe3d0ed7282db52948a9dd52e45a3ed46e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->