### PR TITLE
remove candidate

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.220.0",
+  "version": "0.220.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -290,6 +290,7 @@ class DataRecorder {
         addHelpfulNeurons: undefined,
         removeHarmfulSynapse: undefined,
         removeHarmfulNeurons: undefined,
+        removalCandidates: undefined,
         candidateSquashes: undefined,
       };
     }
@@ -621,6 +622,7 @@ class DataRecorder {
           addHelpfulNeurons: undefined,
           removeHarmfulSynapse: undefined,
           removeHarmfulNeurons: undefined,
+          removalCandidates: undefined,
           candidateSquashes: undefined,
         };
       }
@@ -659,6 +661,7 @@ class DataRecorder {
         addHelpfulNeurons: undefined,
         removeHarmfulSynapse: undefined,
         removeHarmfulNeurons: undefined,
+        removalCandidates: undefined,
         candidateSquashes: undefined,
       };
 
@@ -1029,6 +1032,21 @@ class DataRecorder {
         }
       }
       perfStats.analysisPhaseTime = Date.now() - analysisPhaseStartTime;
+
+      // Collect low-impact removal candidates from Rust focus ranking
+      const removalCandidates = discoverStructure.getRemovalCandidates();
+      if (removalCandidates && removalCandidates.length > 0) {
+        discoverResult.removalCandidates = removalCandidates;
+        if (shouldLogDiscovery(options)) {
+          console.log(
+            `Discovery ${blue(this.ID)} found ${
+              yellow(removalCandidates.length.toString())
+            } low-impact removal candidate${
+              removalCandidates.length === 1 ? "" : "s"
+            }`,
+          );
+        }
+      }
 
       phaseDiagnostics.enterPhase("complete");
       if (shouldLogDiscovery(options)) {

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
@@ -4,6 +4,35 @@ import type {
   CandidateSquash,
   CandidateSynapse,
 } from "./DiscoverStructure.ts";
+import type { RustRemovalCandidate } from "./RustDiscovery.ts";
+
+/**
+ * Candidate for removal based on low-impact + high-error analysis.
+ * Unlike CandidateHarmfulNeuron (which uses error > 1e10 threshold),
+ * these are identified by impact < 0.01 AND error > average.
+ */
+export interface RemovalCandidate {
+  neuronUUID: string;
+  totalError: number;
+  impact: number;
+  reason: string;
+  /** Average activation for bias adjustment during removal (computed lazily). */
+  averageActivation?: number;
+}
+
+/**
+ * Convert Rust removal candidate to local format.
+ */
+export function fromRustRemovalCandidate(
+  rust: RustRemovalCandidate,
+): RemovalCandidate {
+  return {
+    neuronUUID: rust.neuronUuid,
+    totalError: rust.totalError,
+    impact: rust.impact,
+    reason: rust.reason,
+  };
+}
 
 export interface DiscoverResult {
   ID: string;
@@ -11,6 +40,8 @@ export interface DiscoverResult {
   addHelpfulNeurons: CandidateNeuron[] | undefined;
   removeHarmfulSynapse: CandidateSynapse | undefined;
   removeHarmfulNeurons: CandidateHarmfulNeuron[] | undefined;
+  /** Low-impact neurons flagged for removal (from Rust focus ranking). */
+  removalCandidates: RemovalCandidate[] | undefined;
 
   candidateSquashes: CandidateSquash[] | undefined;
   reScoringTime?: number; // Time spent re-scoring candidates (ms)

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -9,6 +9,7 @@ import type { ActivationInterface } from "../../methods/activations/ActivationIn
 import { Activations } from "../../methods/activations/Activations.ts";
 import { CreatureErrorImpactEstimator } from "../../discovery/NeuronErrorImpactEstimator.ts";
 import type { DataRecordInterface } from "../DataSet.ts";
+import { fromRustRemovalCandidate } from "./DiscoverResult.ts";
 import {
   analyzeParallel,
   creatureToRustFormat,
@@ -329,6 +330,9 @@ export class DiscoverStructure {
     undefined;
   private lastNeuronScanStats?: NeuronScanStats;
   private analysisDeadlineMs?: number;
+  /** Low-impact neurons flagged for removal by Rust focus ranking. */
+  private cachedRemovalCandidates?:
+    import("./DiscoverResult.ts").RemovalCandidate[];
   private combinedRustAnalysis?: {
     key: string;
     includeSynapse: boolean;
@@ -2826,6 +2830,21 @@ export class DiscoverStructure {
         );
       }
 
+      // Capture low-impact removal candidates from Rust
+      if (result.removalCandidates && result.removalCandidates.length > 0) {
+        this.cachedRemovalCandidates = result.removalCandidates.map(
+          fromRustRemovalCandidate,
+        );
+        if (this.loggingEnabled) {
+          this.log(
+            "info",
+            `Found ${result.removalCandidates.length} removal candidate${
+              result.removalCandidates.length === 1 ? "" : "s"
+            } (high error, low impact)`,
+          );
+        }
+      }
+
       return result.neurons.map((entry) => ({
         uuid: entry.neuronUuid,
         totalError: entry.totalError,
@@ -4101,5 +4120,89 @@ export class DiscoverStructure {
       return tmpCreature;
     }
     return undefined;
+  }
+
+  /**
+   * Removes a low-impact neuron from the creature.
+   * Unlike removeHarmfulNeuron, this doesn't require averageActivation for bias adjustment
+   * since low-impact neurons (by definition) have negligible effect on downstream neurons.
+   *
+   * @param ID - Unique identifier for the discovery process.
+   * @param creature - The Creature instance to modify.
+   * @param removalCandidate - The low-impact neuron candidate to remove.
+   * @returns A modified Creature with the neuron removed, or undefined if no change was made.
+   */
+  public static removeLowImpactNeuron(
+    ID: string,
+    creature: Creature,
+    removalCandidate?: import("./DiscoverResult.ts").RemovalCandidate,
+  ): Creature | undefined {
+    if (!removalCandidate) return undefined;
+
+    const creatureUUID = CreatureUtil.makeUUID(creature);
+    const exportJSON = creature.exportJSON();
+
+    // Check if neuron exists
+    const neuronToRemove = exportJSON.neurons.find(
+      (neuron) => neuron.uuid === removalCandidate.neuronUUID,
+    );
+    if (!neuronToRemove) {
+      return undefined; // Neuron doesn't exist, nothing to remove
+    }
+
+    // Don't remove output neurons
+    if (neuronToRemove.type === "output") {
+      return undefined;
+    }
+
+    // Create a deep copy to modify
+    const simplifiedExport: typeof exportJSON = JSON.parse(
+      JSON.stringify(exportJSON),
+    );
+
+    // Low-impact neurons have negligible effect on outputs, so we skip bias adjustment.
+    // Just remove all synapses to/from this neuron.
+    simplifiedExport.synapses = simplifiedExport.synapses.filter(
+      (synapse) =>
+        synapse.fromUUID !== removalCandidate.neuronUUID &&
+        synapse.toUUID !== removalCandidate.neuronUUID,
+    );
+
+    // Remove the neuron itself
+    simplifiedExport.neurons = simplifiedExport.neurons.filter(
+      (neuron) => neuron.uuid !== removalCandidate.neuronUUID,
+    );
+
+    const tmpCreature = Creature.fromJSON(simplifiedExport);
+    // We modified the structure, so we must delete UUID
+    delete tmpCreature.uuid;
+    tmpCreature.fix();
+
+    const tmpUUID = CreatureUtil.makeUUID(tmpCreature);
+    if (tmpUUID !== creatureUUID) {
+      addTag(tmpCreature, "approach", "discovery" as Approach);
+      addTag(tmpCreature, "discoveryID", ID);
+      const summary =
+        `🪶 Removed low-impact neuron ${removalCandidate.neuronUUID} (error: ${
+          removalCandidate.totalError.toFixed(4)
+        }, impact: ${(removalCandidate.impact * 100).toFixed(2)}%)`;
+      addTag(tmpCreature, "Discovery", summary);
+      delete tmpCreature.memetic;
+      removeTag(tmpCreature, "approach-logged");
+      tmpCreature.validate();
+
+      return tmpCreature;
+    }
+    return undefined;
+  }
+
+  /**
+   * Returns low-impact neurons flagged for removal by Rust focus ranking.
+   * These neurons have high error but very low impact (< 1% contribution to outputs).
+   */
+  public getRemovalCandidates():
+    | import("./DiscoverResult.ts").RemovalCandidate[]
+    | undefined {
+    return this.cachedRemovalCandidates;
   }
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -149,9 +149,25 @@ export interface RustFocusNeuronScore {
   impact: number;
 }
 
+/**
+ * A neuron flagged for potential removal due to high error but very low impact.
+ * These neurons consume compute but don't meaningfully contribute to outputs.
+ *
+ * Criteria:
+ * - Impact < 0.01 (less than 1% contribution to outputs)
+ * - Error > average error across all neurons
+ */
+export interface RustRemovalCandidate {
+  neuronUuid: string;
+  totalError: number;
+  impact: number;
+  reason: string; // e.g., "High error (5.0000) but very low impact (0.000100) - far from outputs"
+}
+
 export interface RustRankFocusResult {
   success: boolean;
   neurons?: RustFocusNeuronScore[];
+  removalCandidates?: RustRemovalCandidate[];
   maxOutputError?: number;
   processedNeurons?: number;
   totalNeurons?: number;

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -18,6 +18,7 @@ export type DiscoveryChangeType =
   | "add-neurons"
   | "remove-synapse"
   | "remove-neuron"
+  | "remove-low-impact"
   | "change-squash"
   | "combo-add-remove"
   | "combo-add-change"
@@ -394,6 +395,32 @@ export function buildDiscoveryCandidates(
         sampleSize: mostHarmful.sampleCount,
       },
     });
+  }
+
+  // Low-impact removal candidates (high error, low impact < 1%)
+  const { removalCandidates } = discovery;
+  if (removalCandidates && removalCandidates.length > 0) {
+    for (const candidate of removalCandidates) {
+      const removedLowImpactCreature = DiscoverStructure.removeLowImpactNeuron(
+        discovery.ID,
+        baseCreature,
+        candidate,
+      );
+      if (removedLowImpactCreature) {
+        candidates.push({
+          creature: removedLowImpactCreature,
+          change: {
+            type: "remove-low-impact",
+            description:
+              `🪶 Removed low-impact neuron ${candidate.neuronUUID} (error: ${
+                candidate.totalError.toFixed(4)
+              }, impact: ${(candidate.impact * 100).toFixed(2)}%)`,
+            // Low-impact neurons don't have expectedImprovementPercentage from Rust
+            // The improvement comes from reduced compute, not reduced error
+          },
+        });
+      }
+    }
   }
 
   const combinedCandidate = buildCombinedCandidate({

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -212,6 +212,7 @@ export class DiscoveryRunner {
         addHelpfulNeurons: rawDiscover.addHelpfulNeurons ?? undefined,
         removeHarmfulSynapse: rawDiscover.removeHarmfulSynapse ?? undefined,
         removeHarmfulNeurons: rawDiscover.removeHarmfulNeurons ?? undefined,
+        removalCandidates: rawDiscover.removalCandidates ?? undefined,
         candidateSquashes: rawDiscover.candidateSquashes ?? undefined,
         reScoringTime: undefined, // Will be set after re-scoring completes
       };

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -7,6 +7,7 @@ import type {
   CandidateSquash,
   CandidateSynapse,
 } from "../../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { RemovalCandidate } from "../../architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
 import type { NeatOptions } from "../../config/NeatOptions.ts";
 import type { TrainOptions } from "../../config/TrainOptions.ts";
 import { MockWorker } from "./MockWorker.ts";
@@ -118,6 +119,8 @@ export interface ResponseData {
     removeHarmfulSynapse?: CandidateSynapse;
     /** Optional harmful neurons to remove */
     removeHarmfulNeurons?: CandidateHarmfulNeuron[];
+    /** Optional low-impact neurons to remove (from Rust focus ranking) */
+    removalCandidates?: RemovalCandidate[];
     /** Optional candidate activation functions */
     candidateSquashes?: CandidateSquash[];
     /** Time spent re-scoring candidates (ms) - set by DiscoveryRunner after evaluation */

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -224,6 +224,12 @@ export class WorkerProcessor {
               ? [...result.addHelpfulNeurons]
               : undefined,
             removeHarmfulSynapse: result.removeHarmfulSynapse,
+            removeHarmfulNeurons: result.removeHarmfulNeurons
+              ? [...result.removeHarmfulNeurons]
+              : undefined,
+            removalCandidates: result.removalCandidates
+              ? [...result.removalCandidates]
+              : undefined,
             candidateSquashes: result.candidateSquashes
               ? [...result.candidateSquashes]
               : undefined,
@@ -238,6 +244,14 @@ export class WorkerProcessor {
         if (result.addHelpfulNeurons) {
           // @ts-ignore - clearing to help GC
           result.addHelpfulNeurons = null;
+        }
+        if (result.removeHarmfulNeurons) {
+          // @ts-ignore - clearing to help GC
+          result.removeHarmfulNeurons = null;
+        }
+        if (result.removalCandidates) {
+          // @ts-ignore - clearing to help GC
+          result.removalCandidates = null;
         }
         if (result.candidateSquashes) {
           // @ts-ignore - clearing to help GC

--- a/test/discovery/CreatureDiscoveryDir.ts
+++ b/test/discovery/CreatureDiscoveryDir.ts
@@ -42,6 +42,7 @@ Deno.test("Creature.discoveryDir delegates to DiscoveryRunner and returns result
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       candidateSquashes: undefined,
     },
     original: {

--- a/test/discovery/DiscoveryCandidates.ts
+++ b/test/discovery/DiscoveryCandidates.ts
@@ -64,6 +64,7 @@ Deno.test("buildDiscoveryCandidates returns empty list when there are no suggest
     addHelpfulNeurons: undefined,
     removeHarmfulSynapse: undefined,
     removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
     candidateSquashes: undefined,
   };
 
@@ -101,6 +102,7 @@ Deno.test(
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       candidateSquashes: undefined,
     };
 
@@ -162,6 +164,7 @@ Deno.test(
       ID: "SQUASH-MULTI",
       addHelpfulSynapses: undefined,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       candidateSquashes: squashes,
@@ -271,6 +274,7 @@ Deno.test(
       ID: "BEST-COMBO",
       addHelpfulSynapses: synapses,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       addHelpfulNeurons: neurons,
       removeHarmfulSynapse: removeCandidate,
       candidateSquashes: squashes,
@@ -360,6 +364,7 @@ Deno.test(
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       removeHarmfulNeurons: harmfulNeurons,
+      removalCandidates: undefined,
       candidateSquashes: undefined,
     };
 
@@ -409,6 +414,7 @@ Deno.test("buildDiscoveryCandidates includes helpful neuron suggestions", () => 
     addHelpfulNeurons: [neuronCandidate],
     removeHarmfulSynapse: undefined,
     removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
     candidateSquashes: undefined,
   };
 
@@ -481,6 +487,7 @@ Deno.test(
       ID: "COMBO-ALL",
       addHelpfulSynapses: helpfulSynapses,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       addHelpfulNeurons: [neuronCandidate],
       removeHarmfulSynapse: removeCandidate,
       candidateSquashes: [squashCandidate],
@@ -567,6 +574,7 @@ Deno.test(
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       removeHarmfulNeurons: [harmfulNeuron],
+      removalCandidates: undefined,
       candidateSquashes: undefined,
     };
 
@@ -756,6 +764,7 @@ Deno.test(
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: removeSynapse,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       candidateSquashes: undefined,
     };
 
@@ -833,6 +842,7 @@ Deno.test(
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       candidateSquashes: squashChanges,
     };
 

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -157,6 +157,7 @@ Deno.test("DiscoveryRunner enables verbose discovery logging when verbose option
     addHelpfulNeurons: undefined,
     removeHarmfulSynapse: undefined,
     removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
     candidateSquashes: undefined,
   };
 
@@ -214,6 +215,7 @@ Deno.test("DiscoveryRunner returns best improvement with informative message", a
     }],
     addHelpfulNeurons: undefined,
     removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
   };
 
   const computeError = (creature: Creature) => {
@@ -336,6 +338,7 @@ Deno.test(
       addHelpfulNeurons: [neuronCandidate],
       removeHarmfulSynapse: harmfulSynapse,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       candidateSquashes: [squashCandidate],
     };
 
@@ -455,6 +458,7 @@ Deno.test("DiscoveryRunner returns no improvement when candidates are not better
     addHelpfulNeurons: undefined,
     removeHarmfulSynapse: undefined,
     removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
     candidateSquashes: undefined,
   };
 
@@ -487,6 +491,7 @@ Deno.test("DiscoveryRunner records evaluation summaries and archives candidates"
     addHelpfulNeurons: undefined,
     removeHarmfulSynapse: undefined,
     removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
     candidateSquashes: undefined,
   };
 
@@ -567,6 +572,7 @@ Deno.test("DiscoveryRunner flags expectation mismatch when predictions diverge",
     addHelpfulNeurons: undefined,
     removeHarmfulSynapse: undefined,
     removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
     candidateSquashes: undefined,
   };
 
@@ -662,6 +668,7 @@ Deno.test("DiscoveryRunner validates error estimates for non-trivial creatures w
     addHelpfulNeurons: undefined,
     removeHarmfulSynapse: undefined,
     removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
     candidateSquashes: undefined,
   };
 
@@ -751,6 +758,7 @@ Deno.test("DiscoveryRunner passes discovery focus neurons to worker", async () =
     addHelpfulNeurons: undefined,
     removeHarmfulSynapse: undefined,
     removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
     candidateSquashes: undefined,
   };
 
@@ -797,6 +805,7 @@ Deno.test(
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       candidateSquashes: undefined,
     };
 
@@ -874,6 +883,7 @@ Deno.test(
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       candidateSquashes: undefined,
     };
 
@@ -956,6 +966,7 @@ Deno.test(
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       candidateSquashes: undefined,
     };
 
@@ -1011,6 +1022,7 @@ Deno.test(
       addHelpfulNeurons: undefined,
       removeHarmfulSynapse: undefined,
       removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
       candidateSquashes: undefined,
     };
 

--- a/test/discovery/RemovalCandidates.test.ts
+++ b/test/discovery/RemovalCandidates.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for removal candidate functionality.
+ *
+ * Removal candidates are neurons with high error but very low impact (< 1%
+ * contribution to outputs). These neurons consume compute but don't
+ * meaningfully contribute to the creature's score.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { RemovalCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import { buildDiscoveryCandidates } from "../../src/discovery/DiscoveryCandidates.ts";
+import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+
+Deno.test("removeLowImpactNeuron removes neuron without bias adjustment", () => {
+  // Create a simple creature with a hidden neuron
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", squash: "RELU", bias: 0.5, uuid: "hidden-orphan" },
+      { type: "output", squash: "IDENTITY", bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-orphan", weight: 0.1 },
+      // Note: hidden-orphan has no outgoing connection to output - it's a dead end
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+
+  const candidate: RemovalCandidate = {
+    neuronUUID: "hidden-orphan",
+    totalError: 5.0,
+    impact: 0.001, // Very low impact (0.1%)
+    reason: "High error but very low impact - far from outputs",
+  };
+
+  const result = DiscoverStructure.removeLowImpactNeuron(
+    "test-discovery",
+    creature,
+    candidate,
+  );
+
+  assertExists(result, "Should return a modified creature");
+
+  // Verify the neuron was removed
+  const hiddenNeurons = result.neurons.filter((n) => n.type === "hidden");
+  assertEquals(hiddenNeurons.length, 0, "Hidden neuron should be removed");
+
+  // Verify remaining structure is intact
+  const nonInputNeurons = result.neurons.filter((n) => n.type !== "input");
+  assertEquals(
+    nonInputNeurons.length,
+    1,
+    "Should have 1 non-input neuron remaining (the output)",
+  );
+  assertEquals(result.synapses.length, 1, "Should have 1 synapse remaining");
+});
+
+Deno.test("removeLowImpactNeuron returns undefined for non-existent neuron", () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", squash: "IDENTITY", bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+
+  const candidate: RemovalCandidate = {
+    neuronUUID: "non-existent",
+    totalError: 5.0,
+    impact: 0.001,
+    reason: "Test",
+  };
+
+  const result = DiscoverStructure.removeLowImpactNeuron(
+    "test-discovery",
+    creature,
+    candidate,
+  );
+
+  assertEquals(result, undefined, "Should return undefined for missing neuron");
+});
+
+Deno.test("removeLowImpactNeuron returns undefined for output neurons", () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", squash: "IDENTITY", bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+
+  const candidate: RemovalCandidate = {
+    neuronUUID: "output-0",
+    totalError: 5.0,
+    impact: 0.001,
+    reason: "Test",
+  };
+
+  const result = DiscoverStructure.removeLowImpactNeuron(
+    "test-discovery",
+    creature,
+    candidate,
+  );
+
+  assertEquals(
+    result,
+    undefined,
+    "Should return undefined for output neurons",
+  );
+});
+
+Deno.test("buildDiscoveryCandidates creates removal candidates for low-impact neurons", () => {
+  const baseCreature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", squash: "RELU", bias: 0.5, uuid: "hidden-low-impact" },
+      { type: "output", squash: "IDENTITY", bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-low-impact", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+
+  const discovery: DiscoverResult = {
+    ID: "test-discovery",
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: undefined,
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: [
+      {
+        neuronUUID: "hidden-low-impact",
+        totalError: 5.0,
+        impact: 0.005, // 0.5% impact
+        reason: "High error (5.0000) but very low impact (0.005000)",
+      },
+    ],
+    candidateSquashes: undefined,
+  };
+
+  const candidates = buildDiscoveryCandidates(baseCreature, discovery);
+
+  // Should have at least one candidate for the low-impact removal
+  const lowImpactCandidates = candidates.filter(
+    (c) => c.change.type === "remove-low-impact",
+  );
+
+  assertEquals(
+    lowImpactCandidates.length,
+    1,
+    "Should create one low-impact removal candidate",
+  );
+
+  const candidate = lowImpactCandidates[0];
+  assertExists(candidate.creature, "Candidate should have a creature");
+  assertEquals(
+    candidate.change.type,
+    "remove-low-impact",
+    "Change type should be remove-low-impact",
+  );
+
+  // Verify the neuron was actually removed in the candidate creature
+  const hiddenNeurons = candidate.creature.neurons.filter(
+    (n) => n.type === "hidden",
+  );
+  assertEquals(
+    hiddenNeurons.length,
+    0,
+    "Candidate creature should have no hidden neurons",
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add low‑impact neuron removal candidates to the discovery pipeline, with Rust interop, candidate generation, worker plumbing, and tests.
> 
> - **Discovery (analysis + results)**
>   - Introduce `removalCandidates` to `DiscoverResult` for low‑impact (impact < 1%) high‑error neurons.
>   - Collect candidates from Rust focus ranking via `DiscoverStructure.getRemovalCandidates()` and include in outputs (incl. early‑exit paths) in `DiscoverDirectory`.
>   - Cache and log Rust‑provided removal candidates in `DiscoverStructure`.
>   - Add `DiscoverStructure.removeLowImpactNeuron()` to prune neurons without bias adjustment.
> - **Pipeline/Workers**
>   - Plumb `removalCandidates` through worker request/response types and handling (`WorkerHandler`, `WorkerProcessor`).
>   - `DiscoveryRunner` passes through `removalCandidates` and evaluation flow unchanged.
> - **Candidate synthesis**
>   - Update `buildDiscoveryCandidates` to create `remove-low-impact` candidates using `removeLowImpactNeuron()`.
> - **Rust interop**
>   - Add `RustRemovalCandidate` and extend `RustRankFocusResult` with `removalCandidates` in `RustDiscovery.ts`.
>   - Map Rust → TS via `fromRustRemovalCandidate()`.
> - **Types/Models**
>   - Add `RemovalCandidate` interface in `DiscoverResult.ts`.
> - **Tests**
>   - New `test/discovery/RemovalCandidates.test.ts` covering removal behavior and candidate building.
>   - Update existing tests to handle `removalCandidates` in fixtures.
> - **Version**
>   - Bump `deno.json` version to `0.220.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6da9a06a62ed9c809a540397b47399bb1a29099e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->