### PR TITLE
Refactor neuron selection and analysis to incorporate cost of growth

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.220.2",
+  "version": "0.221.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -523,7 +523,7 @@ export class DiscoverStructure {
     // Check if Rust discovery is enabled (requires both library file AND FFI permissions)
     if (!this.deps.isRustDiscoveryEnabled()) {
       console.warn(
-        `⚠️  Discovery requires the NEAT-AI-Discovery Rust library and FFI permissions. Discovery will be skipped.`,
+        `ℹ️  Discovery requires the NEAT-AI-Discovery Rust library and FFI permissions. Discovery will be skipped.`,
       );
       // Set up empty promises - discovery will fail gracefully
       this.creature.neurons.forEach((neuron) => {

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -138,6 +138,8 @@ export function createNeatConfig(options: NeatOptions) {
       : [],
     discoveryDisableEvaluationSummaryLogging:
       options.discoveryDisableEvaluationSummaryLogging ?? false,
+    discoveryMinImprovementVsCostOfGrowthMultiplier:
+      options.discoveryMinImprovementVsCostOfGrowthMultiplier ?? 2.0,
     customCost: options.customCost,
     checkpointEveryGeneration: options.checkpointEveryGeneration ?? false,
   };
@@ -322,5 +324,14 @@ function validate(config: NeatArguments) {
         }`,
       );
     }
+  }
+  if (
+    Number.isFinite(config.discoveryMinImprovementVsCostOfGrowthMultiplier) ===
+      false ||
+    config.discoveryMinImprovementVsCostOfGrowthMultiplier < 0
+  ) {
+    throw new Error(
+      `Discovery Min Improvement vs Cost of Growth Multiplier must be zero or more was: ${config.discoveryMinImprovementVsCostOfGrowthMultiplier}`,
+    );
   }
 }

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -164,6 +164,21 @@ export interface NeatArguments {
   discoveryMinImprovementPercentage?: number;
 
   /**
+   * Minimum multiplier of costOfGrowth that a discovery candidate's expected
+   * improvement must exceed before evaluation. Defaults to 2.0.
+   *
+   * This filter is applied early in the discovery pipeline to exclude candidates
+   * where expectedErrorReduction < (multiplier × costOfGrowth).
+   *
+   * For example, with costOfGrowth=0.0000001 and multiplier=2.0:
+   * - Candidates with expected improvement < 0.0000002 are excluded
+   * - This filters out candidates unlikely to provide meaningful benefit
+   *
+   * Set to 0 to disable this filter (only the positive-impact check will apply).
+   */
+  discoveryMinImprovementVsCostOfGrowthMultiplier: number;
+
+  /**
    * The maximum number of minutes to record for.
    * Defaults to 1 minute (sufficient for ~50k records at 700 records/sec).
    */

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -782,8 +782,9 @@ export class DiscoveryRunner {
     const maxCandidates = 2 * threadCount;
 
     // Calculate the minimum expected improvement threshold
-    const minExpectedImprovement = config.costOfGrowth *
-      (config.discoveryMinImprovementVsCostOfGrowthMultiplier ?? 2.0);
+    const multiplier = config.discoveryMinImprovementVsCostOfGrowthMultiplier ??
+      2.0;
+    const minExpectedImprovement = config.costOfGrowth * multiplier;
 
     // Filter to candidates that meet the minimum expected improvement threshold or have undefined expected improvement
     const positiveCandidates: DiscoveryCandidate[] = [];
@@ -796,17 +797,29 @@ export class DiscoveryRunner {
       CreatureUtil.makeUUID(candidate.creature);
       const expected = candidate.change.expectedErrorReduction;
 
-      // Include candidates with: undefined expected improvement, or expected improvement >= threshold
+      // Include candidates with: undefined expected improvement, or expected improvement meeting threshold
       if (expected === undefined) {
         // No expected value - include it for evaluation (combo candidates, remove-low-impact, etc.)
         positiveCandidates.push(candidate);
-      } else if (
-        Number.isFinite(expected) && expected >= minExpectedImprovement
-      ) {
-        // Expected impact meets or exceeds threshold - include it
-        positiveCandidates.push(candidate);
+      } else if (Number.isFinite(expected)) {
+        // When multiplier is 0, use strict positive check (expected > 0)
+        // Otherwise, check against threshold (expected >= minExpectedImprovement)
+        const meetsThreshold = multiplier === 0
+          ? expected > 0
+          : expected >= minExpectedImprovement;
+
+        if (meetsThreshold) {
+          // Expected impact meets or exceeds threshold - include it
+          positiveCandidates.push(candidate);
+        } else {
+          // Expected impact below threshold - skip it
+          skipped.push({
+            changeType: candidate.change.type,
+            expected,
+          });
+        }
       } else {
-        // Expected impact below threshold - skip it
+        // Non-finite expected value - skip it
         skipped.push({
           changeType: candidate.change.type,
           expected,

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -760,9 +760,9 @@ export class DiscoveryRunner {
    * Filters discovery candidates for evaluation.
    *
    * Strategy:
-   * 1. Include all candidates with positive expected error reduction (or undefined, which we'll re-score)
+   * 1. Include all candidates with expected error reduction >= threshold (or undefined, which we'll evaluate)
    * 2. If there are more than 2x CPU cores candidates, select the best estimated ones
-   * 3. We re-score all candidates with positive expected improvement
+   * 3. We evaluate all candidates with sufficient expected improvement or undefined expected improvement
    *
    * @param candidates - All discovery candidates
    * @param threadCount - Number of CPU threads available
@@ -785,7 +785,7 @@ export class DiscoveryRunner {
     const minExpectedImprovement = config.costOfGrowth *
       (config.discoveryMinImprovementVsCostOfGrowthMultiplier ?? 2.0);
 
-    // Filter to candidates that meet the minimum expected improvement threshold
+    // Filter to candidates that meet the minimum expected improvement threshold or have undefined expected improvement
     const positiveCandidates: DiscoveryCandidate[] = [];
     const skipped: Array<{
       changeType?: DiscoveryChangeType;
@@ -796,16 +796,17 @@ export class DiscoveryRunner {
       CreatureUtil.makeUUID(candidate.creature);
       const expected = candidate.change.expectedErrorReduction;
 
-      // Only include candidates with expected improvement >= threshold
-      if (
-        expected !== undefined &&
-        Number.isFinite(expected) &&
-        expected >= minExpectedImprovement
+      // Include candidates with: undefined expected improvement, or expected improvement >= threshold
+      if (expected === undefined) {
+        // No expected value - include it for evaluation (combo candidates, remove-low-impact, etc.)
+        positiveCandidates.push(candidate);
+      } else if (
+        Number.isFinite(expected) && expected >= minExpectedImprovement
       ) {
         // Expected impact meets or exceeds threshold - include it
         positiveCandidates.push(candidate);
       } else {
-        // Expected impact below threshold or undefined - skip it
+        // Expected impact below threshold - skip it
         skipped.push({
           changeType: candidate.change.type,
           expected,

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -9,7 +9,7 @@ import { isRustDiscoveryEnabled } from "../architecture/ErrorGuidedStructuralEvo
 import { calculate as calculateScore } from "../architecture/Score.ts";
 import type { Creature } from "../Creature.ts";
 import type { NeatOptions } from "../config/NeatOptions.ts";
-import { createNeatConfig } from "../config/NeatConfig.ts";
+import { createNeatConfig, type NeatConfig } from "../config/NeatConfig.ts";
 import {
   buildDiscoveryCandidates,
   type DiscoveredNeuronDetails,
@@ -238,12 +238,17 @@ export class DiscoveryRunner {
         .#filterCandidatesForEvaluation(
           candidates,
           workerCount,
+          config,
         );
       if (skipped.length > 0) {
+        const minThreshold = config.costOfGrowth *
+          (config.discoveryMinImprovementVsCostOfGrowthMultiplier ?? 2.0);
         verboseLog(
           `Skipped ${skipped.length} candidate${
             skipped.length === 1 ? "" : "s"
-          } with non-positive expected impact or below selection threshold: ${
+          } with expected improvement below ${minThreshold.toPrecision(3)} (${
+            config.discoveryMinImprovementVsCostOfGrowthMultiplier ?? 2.0
+          }× costOfGrowth): ${
             skipped.map((entry) =>
               `${entry.changeType ?? "unknown"} (expected ${
                 entry.expected?.toPrecision(3) ?? "n/a"
@@ -766,6 +771,7 @@ export class DiscoveryRunner {
   #filterCandidatesForEvaluation(
     candidates: DiscoveryCandidate[],
     threadCount: number,
+    config: NeatConfig,
   ): {
     filtered: DiscoveryCandidate[];
     skipped: Array<{
@@ -775,7 +781,11 @@ export class DiscoveryRunner {
   } {
     const maxCandidates = 2 * threadCount;
 
-    // Filter to candidates with positive expected impact (or undefined, which we'll re-score)
+    // Calculate the minimum expected improvement threshold
+    const minExpectedImprovement = config.costOfGrowth *
+      (config.discoveryMinImprovementVsCostOfGrowthMultiplier ?? 2.0);
+
+    // Filter to candidates that meet the minimum expected improvement threshold
     const positiveCandidates: DiscoveryCandidate[] = [];
     const skipped: Array<{
       changeType?: DiscoveryChangeType;
@@ -786,15 +796,16 @@ export class DiscoveryRunner {
       CreatureUtil.makeUUID(candidate.creature);
       const expected = candidate.change.expectedErrorReduction;
 
-      // Include candidates with positive expected impact or undefined (will be re-scored)
-      if (expected === undefined) {
-        // No expected value - include it for re-scoring
-        positiveCandidates.push(candidate);
-      } else if (Number.isFinite(expected) && expected > 0) {
-        // Positive expected impact - include it
+      // Only include candidates with expected improvement >= threshold
+      if (
+        expected !== undefined &&
+        Number.isFinite(expected) &&
+        expected >= minExpectedImprovement
+      ) {
+        // Expected impact meets or exceeds threshold - include it
         positiveCandidates.push(candidate);
       } else {
-        // Non-positive expected impact - skip it
+        // Expected impact below threshold or undefined - skip it
         skipped.push({
           changeType: candidate.change.type,
           expected,

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1074,6 +1074,110 @@ Deno.test(
 );
 
 Deno.test(
+  "DiscoveryRunner excludes zero-impact candidates when multiplier is 0",
+  async () => {
+    const discoveryResult: DiscoverResult = {
+      ID: "ZERO_MULTIPLIER",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const baseCreature = makeBaseCreature();
+
+    const candidateBuilder = (
+      _creature: Creature,
+      _discovery: DiscoverResult,
+    ): DiscoveryCandidate[] => {
+      // Create three candidates: one with zero impact, one with positive, one with negative
+      const candidates: DiscoveryCandidate[] = [];
+
+      // Candidate 1: Zero impact (should be excluded)
+      const zeroCandidate = Creature.fromJSON(cloneCreatureJSON(baseCreature));
+      zeroCandidate.validate();
+      CreatureUtil.makeUUID(zeroCandidate);
+      candidates.push({
+        creature: zeroCandidate,
+        change: {
+          type: "add-neurons",
+          description: "zero-impact candidate",
+          expectedErrorReduction: 0, // Zero impact - should be excluded
+        },
+      });
+
+      // Candidate 2: Positive impact (should be included)
+      const positiveCandidate = Creature.fromJSON(
+        cloneCreatureJSON(baseCreature),
+      );
+      positiveCandidate.validate();
+      CreatureUtil.makeUUID(positiveCandidate);
+      candidates.push({
+        creature: positiveCandidate,
+        change: {
+          type: "add-synapses",
+          description: "positive-impact candidate",
+          expectedErrorReduction: 0.001, // Positive impact - should be included
+        },
+      });
+
+      // Candidate 3: Negative impact (should be excluded)
+      const negativeCandidate = Creature.fromJSON(
+        cloneCreatureJSON(baseCreature),
+      );
+      negativeCandidate.validate();
+      CreatureUtil.makeUUID(negativeCandidate);
+      candidates.push({
+        creature: negativeCandidate,
+        change: {
+          type: "add-neurons",
+          description: "negative-impact candidate",
+          expectedErrorReduction: -0.001, // Negative impact - should be excluded
+        },
+      });
+
+      return candidates;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          () => 0.5,
+        ),
+      candidateBuilder,
+    });
+
+    const options = makeOptions();
+    options.discoveryMinImprovementVsCostOfGrowthMultiplier = 0; // Set multiplier to 0
+
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options,
+    });
+
+    // Only the positive-impact candidate should be evaluated
+    const candidateEvaluations =
+      result.evaluations?.filter((entry) => entry.kind === "candidate") ?? [];
+
+    assertEquals(
+      candidateEvaluations.length,
+      1,
+      "only one candidate with positive impact should be evaluated",
+    );
+
+    assert(
+      candidateEvaluations[0].description?.includes("positive-impact"),
+      "the evaluated candidate should be the positive-impact one",
+    );
+  },
+);
+
+Deno.test(
   "DiscoveryRunner logs sub-basis deltas with at least three significant digits",
   async () => {
     const discoveryResult: DiscoverResult = {

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1018,6 +1018,62 @@ Deno.test(
 );
 
 Deno.test(
+  "DiscoveryRunner includes candidates with undefined expectedErrorReduction for evaluation",
+  async () => {
+    const discoveryResult: DiscoverResult = {
+      ID: "UNDEFINED_EXPECTED",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const baseCreature = makeBaseCreature();
+
+    const candidateBuilder = (
+      _creature: Creature,
+      _discovery: DiscoverResult,
+    ): DiscoveryCandidate[] => {
+      const json = cloneCreatureJSON(baseCreature);
+      const candidate = Creature.fromJSON(json);
+      candidate.validate();
+      CreatureUtil.makeUUID(candidate);
+      return [{
+        creature: candidate,
+        change: {
+          type: "combo-all",
+          description: "combo candidate without expected impact",
+          // expectedErrorReduction is undefined - typical for combo candidates
+        },
+      }];
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          () => 0.5,
+        ),
+      candidateBuilder,
+    });
+
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    assert(
+      result.evaluations?.some((entry) => entry.kind === "candidate"),
+      "candidates with undefined expectedErrorReduction should be included for evaluation",
+    );
+  },
+);
+
+Deno.test(
   "DiscoveryRunner logs sub-basis deltas with at least three significant digits",
   async () => {
     const discoveryResult: DiscoverResult = {

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -514,7 +514,11 @@ Deno.test("DiscoveryRunner records evaluation summaries and archives candidates"
       ),
     candidateBuilder: () => [{
       creature: candidateCreature,
-      change: { type: "add-neurons", description: "test candidate" },
+      change: {
+        type: "add-neurons",
+        description: "test candidate",
+        expectedErrorReduction: 0.1, // Must exceed 2x costOfGrowth
+      },
     }],
   });
 
@@ -836,7 +840,7 @@ Deno.test(
         change: {
           type: "add-synapses",
           description: "extra synapse",
-          expectedErrorReduction: 0.01, // Positive expected impact
+          expectedErrorReduction: 0.05, // Must exceed 2x costOfGrowth (0.02 * 2 = 0.04)
         },
       }];
     };


### PR DESCRIPTION
- Introduced DEFAULT_COST_OF_GROWTH as a single source of truth for cost thresholds in neuron selection.
- Updated analyze and selectNeuronsWeightedByError methods to accept costOfGrowth as a parameter, enhancing flexibility in neuron evaluation.
- Refactored selection logic to differentiate between "add" and "remove" modes based on costOfGrowth, improving the efficiency of neuron and synapse management.
- Enhanced tests to validate the new costOfGrowth parameter across various discovery scenarios, ensuring robust functionality.

These changes aim to refine the neuron discovery process by integrating cost considerations, leading to more effective and efficient evaluations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable multiplier threshold vs `costOfGrowth` to filter discovery candidates, updates runner filtering/logging, wires through config with validation, and expands tests; bumps version.
> 
> - **Discovery Pipeline**:
>   - **Candidate Filtering**: `DiscoveryRunner` now filters candidates by `expectedErrorReduction >= discoveryMinImprovementVsCostOfGrowthMultiplier × costOfGrowth`; includes candidates with undefined expectations; when multiplier=0, only strictly positive expected values pass.
>   - **Logging**: Verbose skip message shows computed threshold and reason; minor wording/emoji tweak in `DiscoverStructure.initialize()`.
> - **Config**:
>   - **New Option**: `discoveryMinImprovementVsCostOfGrowthMultiplier` added to `NeatOptions` with docs, default `2.0` in `NeatConfig`, and validation (≥ 0).
> - **Tests**:
>   - Added/updated tests to cover threshold filtering, undefined expectations inclusion, and multiplier=0 semantics; adjusted expected values accordingly.
> - **Misc**:
>   - Bump package `version` in `deno.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9a0abbdc30231891ef6540e163de8e10fe7cac2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->