### PR TITLE
Update version to 0.223.0 and add debug logging for neuron share calc…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.222.0",
+  "version": "0.223.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -74,6 +74,16 @@ export function buildDiscoveryCandidates(
 
   const scaledNeuronExpected = (candidate: CandidateNeuron) => {
     const share = impactEstimator.getNeuronShare(candidate.toNeuronUUID);
+
+    // DEBUG: Log raw vs scaled improvement for HARD_TANH debugging
+    console.info(
+      `[DEBUG-SCALING] Neuron ${candidate.toNeuronUUID}: raw=${
+        (candidate.expectedImprovementPercentage * 100).toFixed(4)
+      }%, share=${share.toFixed(6)}, scaled=${
+        ((candidate.expectedImprovementPercentage * share) * 100).toFixed(6)
+      }%`,
+    );
+
     // If we have recorded stats, use the actual error magnitude to scale more accurately
     if (candidate.targetNeuronStats) {
       const stats = candidate.targetNeuronStats;

--- a/src/discovery/NeuronErrorImpactEstimator.ts
+++ b/src/discovery/NeuronErrorImpactEstimator.ts
@@ -117,6 +117,17 @@ export class CreatureErrorImpactEstimator {
       const share = Math.min(1, rawShares[index]);
       shareMap.set(neuron.uuid, share);
     });
+
+    // DEBUG: Log output neuron shares
+    const outputNeurons = neurons.filter((n) => n.type === "output");
+    for (const neuron of outputNeurons) {
+      console.info(
+        `[DEBUG-SHARE] Output ${neuron.uuid}: share=${
+          shareMap.get(neuron.uuid)?.toFixed(6)
+        }`,
+      );
+    }
+
     return shareMap;
   }
 


### PR DESCRIPTION
…ulations

- Bumped version in deno.json to 0.223.0.
- Introduced debug logging in DiscoveryCandidates and NeuronErrorImpactEstimator to track raw vs scaled improvement and output neuron shares, aiding in the debugging of HARD_TANH behavior.

These changes aim to enhance visibility into the neuron evaluation process, facilitating easier debugging and analysis of performance metrics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add debug logging for neuron share and scaled improvement calculations, and bump package version to 0.223.0.
> 
> - **Discovery/Debug Logging**:
>   - `src/discovery/DiscoveryCandidates.ts`: log raw vs scaled improvement per neuron in `scaledNeuronExpected`.
>   - `src/discovery/NeuronErrorImpactEstimator.ts`: log output neuron shares after share computation.
> - **Version**:
>   - Bump `deno.json` `version` to `0.223.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c2501c2ed876ee63094103f17642dc8fb2bcc84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->