### PR TITLE
Update version to 0.224.0 and remove debug logging from neuron share …

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.223.0",
+  "version": "0.224.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -74,16 +74,6 @@ export function buildDiscoveryCandidates(
 
   const scaledNeuronExpected = (candidate: CandidateNeuron) => {
     const share = impactEstimator.getNeuronShare(candidate.toNeuronUUID);
-
-    // DEBUG: Log raw vs scaled improvement for HARD_TANH debugging
-    console.info(
-      `[DEBUG-SCALING] Neuron ${candidate.toNeuronUUID}: raw=${
-        (candidate.expectedImprovementPercentage * 100).toFixed(4)
-      }%, share=${share.toFixed(6)}, scaled=${
-        ((candidate.expectedImprovementPercentage * share) * 100).toFixed(6)
-      }%`,
-    );
-
     // If we have recorded stats, use the actual error magnitude to scale more accurately
     if (candidate.targetNeuronStats) {
       const stats = candidate.targetNeuronStats;

--- a/src/discovery/NeuronErrorImpactEstimator.ts
+++ b/src/discovery/NeuronErrorImpactEstimator.ts
@@ -117,17 +117,6 @@ export class CreatureErrorImpactEstimator {
       const share = Math.min(1, rawShares[index]);
       shareMap.set(neuron.uuid, share);
     });
-
-    // DEBUG: Log output neuron shares
-    const outputNeurons = neurons.filter((n) => n.type === "output");
-    for (const neuron of outputNeurons) {
-      console.info(
-        `[DEBUG-SHARE] Output ${neuron.uuid}: share=${
-          shareMap.get(neuron.uuid)?.toFixed(6)
-        }`,
-      );
-    }
-
     return shareMap;
   }
 


### PR DESCRIPTION
…calculations

- Bumped version in deno.json to 0.224.0.
- Removed debug logging statements from DiscoveryCandidates and NeuronErrorImpactEstimator that tracked raw vs scaled improvement and output neuron shares, streamlining the code for production use.

These changes aim to enhance code clarity by eliminating unnecessary debug information while maintaining the functionality of neuron evaluation processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes debug logging from discovery error-share calculations and bumps package version to 0.224.0.
> 
> - **Discovery**:
>   - Remove debug logging in `src/discovery/DiscoveryCandidates.ts` (scaled improvement logs).
>   - Remove debug logging in `src/discovery/NeuronErrorImpactEstimator.ts` (output neuron share logs).
> - **Config**:
>   - Bump `deno.json` version to `0.224.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36a6da781d99edc778c808e8331fc1a5647626e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->