### PR TITLE
chore: update version to 0.226.0 and enhance discovery candidate logic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.225.0",
+  "version": "0.226.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -2938,7 +2938,7 @@ export class DiscoverStructure {
             "info",
             `Found ${result.removalCandidates.length} removal candidate${
               result.removalCandidates.length === 1 ? "" : "s"
-            } (high error, low impact)`,
+            } (impact below costOfGrowth)`,
           );
         }
       }

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -66,14 +66,10 @@ export interface DiscoveryCandidate {
  *
  * @param baseCreature The creature to apply discovery changes to
  * @param discovery The discovery result containing candidate changes
- * @param costOfGrowth Optional cost of growth for scoring removal candidates.
- *                     When provided, removal candidates will have expectedErrorReduction
- *                     set to costOfGrowth since removing them improves score by that amount.
  */
 export function buildDiscoveryCandidates(
   baseCreature: Creature,
   discovery: DiscoverResult,
-  costOfGrowth?: number,
 ): DiscoveryCandidate[] {
   // Ensure the base creature has a UUID so discovery helpers function correctly.
   CreatureUtil.makeUUID(baseCreature);
@@ -407,6 +403,10 @@ export function buildDiscoveryCandidates(
   // Low-impact removal candidates (impact below costOfGrowth)
   // These neurons contribute essentially nothing to outputs - removing them improves
   // the creature's score because the complexity reduction benefit exceeds their contribution.
+  // NOTE: expectedErrorReduction is left undefined because:
+  // 1. Removal doesn't reduce error - it may slightly increase it
+  // 2. The improvement comes from score (complexity reduction), not error reduction
+  // 3. The filter explicitly passes undefined through for evaluation
   const { removalCandidates } = discovery;
   if (removalCandidates && removalCandidates.length > 0) {
     for (const candidate of removalCandidates) {
@@ -424,9 +424,7 @@ export function buildDiscoveryCandidates(
               `🪶 Removed low-impact neuron ${candidate.neuronUUID} (impact: ${
                 candidate.impact.toExponential(2)
               })`,
-            // Expected improvement = costOfGrowth (the score penalty being removed)
-            // No further analysis needed - the neuron's impact is already below costOfGrowth
-            expectedErrorReduction: costOfGrowth,
+            // No expectedErrorReduction - removal improves score via complexity reduction, not error
           },
         });
       }

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -63,10 +63,17 @@ export interface DiscoveryCandidate {
  * This function mirrors the logic that previously lived in `Neat.ts`, but the
  * resulting creatures are now returned for external evaluation instead of being
  * applied directly to the population.
+ *
+ * @param baseCreature The creature to apply discovery changes to
+ * @param discovery The discovery result containing candidate changes
+ * @param costOfGrowth Optional cost of growth for scoring removal candidates.
+ *                     When provided, removal candidates will have expectedErrorReduction
+ *                     set to costOfGrowth since removing them improves score by that amount.
  */
 export function buildDiscoveryCandidates(
   baseCreature: Creature,
   discovery: DiscoverResult,
+  costOfGrowth?: number,
 ): DiscoveryCandidate[] {
   // Ensure the base creature has a UUID so discovery helpers function correctly.
   CreatureUtil.makeUUID(baseCreature);
@@ -397,7 +404,9 @@ export function buildDiscoveryCandidates(
     });
   }
 
-  // Low-impact removal candidates (high error, low impact < 1%)
+  // Low-impact removal candidates (impact below costOfGrowth)
+  // These neurons contribute essentially nothing to outputs - removing them improves
+  // the creature's score because the complexity reduction benefit exceeds their contribution.
   const { removalCandidates } = discovery;
   if (removalCandidates && removalCandidates.length > 0) {
     for (const candidate of removalCandidates) {
@@ -412,11 +421,12 @@ export function buildDiscoveryCandidates(
           change: {
             type: "remove-low-impact",
             description:
-              `🪶 Removed low-impact neuron ${candidate.neuronUUID} (error: ${
-                candidate.totalError.toFixed(4)
-              }, impact: ${(candidate.impact * 100).toFixed(2)}%)`,
-            // Low-impact neurons don't have expectedImprovementPercentage from Rust
-            // The improvement comes from reduced compute, not reduced error
+              `🪶 Removed low-impact neuron ${candidate.neuronUUID} (impact: ${
+                candidate.impact.toExponential(2)
+              })`,
+            // Expected improvement = costOfGrowth (the score penalty being removed)
+            // No further analysis needed - the neuron's impact is already below costOfGrowth
+            expectedErrorReduction: costOfGrowth,
           },
         });
       }

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -48,7 +48,6 @@ export interface DiscoveryRunnerDeps {
   candidateBuilder?: (
     creature: Creature,
     discovery: DiscoverResult,
-    costOfGrowth?: number,
   ) => DiscoveryCandidate[];
   rustDiscoveryEnabled?: () => boolean;
 }
@@ -124,7 +123,6 @@ export class DiscoveryRunner {
   #candidateBuilder: (
     creature: Creature,
     discovery: DiscoverResult,
-    costOfGrowth?: number,
   ) => DiscoveryCandidate[];
   #rustDiscoveryEnabled: () => boolean;
 
@@ -235,7 +233,6 @@ export class DiscoveryRunner {
       const candidates = this.#candidateBuilder(
         creature,
         discoverResult,
-        config.costOfGrowth,
       );
       verboseLog(
         `Built ${candidates.length} candidate creature${

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -48,6 +48,7 @@ export interface DiscoveryRunnerDeps {
   candidateBuilder?: (
     creature: Creature,
     discovery: DiscoverResult,
+    costOfGrowth?: number,
   ) => DiscoveryCandidate[];
   rustDiscoveryEnabled?: () => boolean;
 }
@@ -123,6 +124,7 @@ export class DiscoveryRunner {
   #candidateBuilder: (
     creature: Creature,
     discovery: DiscoverResult,
+    costOfGrowth?: number,
   ) => DiscoveryCandidate[];
   #rustDiscoveryEnabled: () => boolean;
 
@@ -230,7 +232,11 @@ export class DiscoveryRunner {
       markPhase("Discovery phase", discoveryStart);
 
       const candidateBuildStart = performance.now();
-      const candidates = this.#candidateBuilder(creature, discoverResult);
+      const candidates = this.#candidateBuilder(
+        creature,
+        discoverResult,
+        config.costOfGrowth,
+      );
       verboseLog(
         `Built ${candidates.length} candidate creature${
           candidates.length === 1 ? "" : "s"

--- a/test/Creature.ts
+++ b/test/Creature.ts
@@ -395,6 +395,7 @@ Deno.test("Feed-forward", () => {
   const child = Offspring.breed(creature1, creature2);
 
   if (child) {
+    child.validate();
     // Check if the creature is feed-forward correctly
     for (i = 0; i < child.synapses.length; i++) {
       const from = child.synapses[i].from;

--- a/test/data/crippled-removal.json
+++ b/test/data/crippled-removal.json
@@ -1,0 +1,26 @@
+{
+  "input": 2,
+  "output": 1,
+  "neurons": [
+    {
+      "type": "hidden",
+      "squash": "RELU",
+      "bias": 0.5,
+      "uuid": "candidate-for-removal"
+    },
+    { "type": "output", "squash": "IDENTITY", "bias": 0, "uuid": "output-0" }
+  ],
+  "synapses": [
+    {
+      "fromUUID": "input-0",
+      "toUUID": "candidate-for-removal",
+      "weight": 1e-12
+    },
+    {
+      "fromUUID": "candidate-for-removal",
+      "toUUID": "output-0",
+      "weight": 1e-12
+    },
+    { "fromUUID": "input-1", "toUUID": "output-0", "weight": 1.0 }
+  ]
+}

--- a/test/discovery/RemovalCandidates.test.ts
+++ b/test/discovery/RemovalCandidates.test.ts
@@ -180,3 +180,139 @@ Deno.test("buildDiscoveryCandidates creates removal candidates for low-impact ne
     "Candidate creature should have no hidden neurons",
   );
 });
+
+Deno.test("buildDiscoveryCandidates sets expectedErrorReduction to costOfGrowth for removal candidates", () => {
+  const baseCreature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", squash: "RELU", bias: 0.5, uuid: "hidden-low-impact" },
+      { type: "output", squash: "IDENTITY", bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-low-impact", weight: 1e-12 },
+      { fromUUID: "hidden-low-impact", toUUID: "output-0", weight: 1e-12 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+
+  const costOfGrowth = 1e-7;
+
+  const discovery: DiscoverResult = {
+    ID: "test-removal-expected",
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: undefined,
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: [
+      {
+        neuronUUID: "hidden-low-impact",
+        totalError: 1.0,
+        impact: 1e-10, // Impact below costOfGrowth
+        reason: "Impact below costOfGrowth",
+      },
+    ],
+    candidateSquashes: undefined,
+  };
+
+  // Pass costOfGrowth to buildDiscoveryCandidates
+  const candidates = buildDiscoveryCandidates(
+    baseCreature,
+    discovery,
+    costOfGrowth,
+  );
+
+  const lowImpactCandidates = candidates.filter(
+    (c) => c.change.type === "remove-low-impact",
+  );
+
+  assertEquals(
+    lowImpactCandidates.length,
+    1,
+    "Should create one low-impact removal candidate",
+  );
+
+  const candidate = lowImpactCandidates[0];
+
+  // Verify expectedErrorReduction is set to costOfGrowth
+  assertEquals(
+    candidate.change.expectedErrorReduction,
+    costOfGrowth,
+    "Expected error reduction should equal costOfGrowth",
+  );
+});
+
+Deno.test("buildDiscoveryCandidates uses crippled-removal.json for near-zero weight neuron removal", async () => {
+  // Load the test creature with near-zero weight synapses
+  const jsonPath = new URL("../data/crippled-removal.json", import.meta.url);
+  const jsonText = await Deno.readTextFile(jsonPath);
+  const creatureJSON = JSON.parse(jsonText);
+  const baseCreature = Creature.fromJSON(creatureJSON);
+
+  const costOfGrowth = 1e-7;
+
+  // Simulate what Rust would return - neuron with near-zero weight synapses
+  // has impact below costOfGrowth
+  const discovery: DiscoverResult = {
+    ID: "crippled-removal-test",
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: undefined,
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: [
+      {
+        neuronUUID: "candidate-for-removal",
+        totalError: 0.001,
+        impact: 1e-24, // Near-zero impact due to 1e-12 weight synapses
+        reason: "Impact below costOfGrowth",
+      },
+    ],
+    candidateSquashes: undefined,
+  };
+
+  const candidates = buildDiscoveryCandidates(
+    baseCreature,
+    discovery,
+    costOfGrowth,
+  );
+
+  const removalCandidates = candidates.filter(
+    (c) => c.change.type === "remove-low-impact",
+  );
+
+  assertEquals(
+    removalCandidates.length,
+    1,
+    "Should identify the near-zero weight neuron for removal",
+  );
+
+  const candidate = removalCandidates[0];
+
+  // Verify the neuron was removed
+  const removedNeuronExists = candidate.creature.neurons.some(
+    (n) => n.uuid === "candidate-for-removal",
+  );
+  assertEquals(
+    removedNeuronExists,
+    false,
+    "candidate-for-removal neuron should be removed",
+  );
+
+  // Verify expectedErrorReduction is set to costOfGrowth
+  assertEquals(
+    candidate.change.expectedErrorReduction,
+    costOfGrowth,
+    "Removal should improve score by costOfGrowth",
+  );
+
+  // Verify the description mentions impact, not error
+  assertExists(
+    candidate.change.description,
+    "Should have a description",
+  );
+  assertEquals(
+    candidate.change.description?.includes("impact:"),
+    true,
+    "Description should mention impact",
+  );
+});

--- a/test/discovery/RemovalCandidates.test.ts
+++ b/test/discovery/RemovalCandidates.test.ts
@@ -181,7 +181,7 @@ Deno.test("buildDiscoveryCandidates creates removal candidates for low-impact ne
   );
 });
 
-Deno.test("buildDiscoveryCandidates sets expectedErrorReduction to costOfGrowth for removal candidates", () => {
+Deno.test("buildDiscoveryCandidates creates removal candidate with undefined expectedErrorReduction", () => {
   const baseCreature = Creature.fromJSON({
     input: 2,
     output: 1,
@@ -195,8 +195,6 @@ Deno.test("buildDiscoveryCandidates sets expectedErrorReduction to costOfGrowth 
       { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
     ],
   });
-
-  const costOfGrowth = 1e-7;
 
   const discovery: DiscoverResult = {
     ID: "test-removal-expected",
@@ -215,12 +213,7 @@ Deno.test("buildDiscoveryCandidates sets expectedErrorReduction to costOfGrowth 
     candidateSquashes: undefined,
   };
 
-  // Pass costOfGrowth to buildDiscoveryCandidates
-  const candidates = buildDiscoveryCandidates(
-    baseCreature,
-    discovery,
-    costOfGrowth,
-  );
+  const candidates = buildDiscoveryCandidates(baseCreature, discovery);
 
   const lowImpactCandidates = candidates.filter(
     (c) => c.change.type === "remove-low-impact",
@@ -234,11 +227,80 @@ Deno.test("buildDiscoveryCandidates sets expectedErrorReduction to costOfGrowth 
 
   const candidate = lowImpactCandidates[0];
 
-  // Verify expectedErrorReduction is set to costOfGrowth
+  // Verify expectedErrorReduction is undefined (not costOfGrowth)
+  // Removal candidates improve score via complexity reduction, not error reduction
+  // Setting it to costOfGrowth would cause them to be filtered out since
+  // costOfGrowth < costOfGrowth * multiplier (default multiplier = 2.0)
   assertEquals(
     candidate.change.expectedErrorReduction,
-    costOfGrowth,
-    "Expected error reduction should equal costOfGrowth",
+    undefined,
+    "Expected error reduction should be undefined for removal candidates",
+  );
+});
+
+/**
+ * This test verifies that removal candidates with expectedErrorReduction set to costOfGrowth
+ * would be filtered out during evaluation. The fix is to leave expectedErrorReduction as undefined.
+ *
+ * The filter logic in DiscoveryRunner.#filterCandidatesForEvaluation uses:
+ * - minExpectedImprovement = costOfGrowth * multiplier (default multiplier = 2.0)
+ * - Candidates pass if: expected === undefined OR expected >= minExpectedImprovement
+ *
+ * So if expectedErrorReduction = costOfGrowth, the check becomes:
+ * costOfGrowth >= costOfGrowth * 2.0 = FALSE (gets filtered out!)
+ *
+ * Removal candidates should have undefined expectedErrorReduction because:
+ * 1. They don't reduce error - they may slightly increase it
+ * 2. They improve SCORE (not error) by reducing complexity
+ * 3. The filter explicitly allows undefined through for cases like this
+ */
+Deno.test("removal candidates should have undefined expectedErrorReduction to pass filter", () => {
+  const baseCreature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", squash: "RELU", bias: 0.5, uuid: "hidden-low-impact" },
+      { type: "output", squash: "IDENTITY", bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-low-impact", weight: 1e-12 },
+      { fromUUID: "hidden-low-impact", toUUID: "output-0", weight: 1e-12 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+
+  const discovery: DiscoverResult = {
+    ID: "filter-test",
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: undefined,
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: [
+      {
+        neuronUUID: "hidden-low-impact",
+        totalError: 1.0,
+        impact: 1e-10,
+        reason: "Impact below costOfGrowth",
+      },
+    ],
+    candidateSquashes: undefined,
+  };
+
+  const candidates = buildDiscoveryCandidates(baseCreature, discovery);
+
+  const lowImpactCandidate = candidates.find(
+    (c) => c.change.type === "remove-low-impact",
+  );
+
+  assertExists(lowImpactCandidate, "Should create removal candidate");
+
+  // CRITICAL: expectedErrorReduction should be undefined for removal candidates
+  // If it were set to costOfGrowth, it would fail the filter check:
+  // costOfGrowth >= costOfGrowth * 2.0 = false (filtered out!)
+  assertEquals(
+    lowImpactCandidate.change.expectedErrorReduction,
+    undefined,
+    "Removal candidates should have undefined expectedErrorReduction to pass through filter",
   );
 });
 
@@ -248,8 +310,6 @@ Deno.test("buildDiscoveryCandidates uses crippled-removal.json for near-zero wei
   const jsonText = await Deno.readTextFile(jsonPath);
   const creatureJSON = JSON.parse(jsonText);
   const baseCreature = Creature.fromJSON(creatureJSON);
-
-  const costOfGrowth = 1e-7;
 
   // Simulate what Rust would return - neuron with near-zero weight synapses
   // has impact below costOfGrowth
@@ -270,11 +330,7 @@ Deno.test("buildDiscoveryCandidates uses crippled-removal.json for near-zero wei
     candidateSquashes: undefined,
   };
 
-  const candidates = buildDiscoveryCandidates(
-    baseCreature,
-    discovery,
-    costOfGrowth,
-  );
+  const candidates = buildDiscoveryCandidates(baseCreature, discovery);
 
   const removalCandidates = candidates.filter(
     (c) => c.change.type === "remove-low-impact",
@@ -298,11 +354,12 @@ Deno.test("buildDiscoveryCandidates uses crippled-removal.json for near-zero wei
     "candidate-for-removal neuron should be removed",
   );
 
-  // Verify expectedErrorReduction is set to costOfGrowth
+  // Verify expectedErrorReduction is undefined (not costOfGrowth)
+  // Removal improves score via complexity reduction, not error reduction
   assertEquals(
     candidate.change.expectedErrorReduction,
-    costOfGrowth,
-    "Removal should improve score by costOfGrowth",
+    undefined,
+    "Removal candidates should have undefined expectedErrorReduction",
   );
 
   // Verify the description mentions impact, not error


### PR DESCRIPTION
- Bumped version in deno.json to 0.226.0.
- Updated logging in DiscoverStructure to clarify the criteria for low-impact removal candidates.
- Modified the buildDiscoveryCandidates function to accept an optional costOfGrowth parameter, improving the evaluation of removal candidates based on their impact.
- Enhanced tests to validate the expectedErrorReduction for removal candidates, ensuring accurate scoring based on costOfGrowth.

These changes aim to refine the discovery process by integrating cost considerations and improving the clarity of candidate evaluation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies low‑impact removal criteria, leaves expectedErrorReduction undefined for such candidates, updates descriptions to emphasize impact, adds fixture-driven tests, and bumps version to 0.226.0.
> 
> - **Discovery/Structure**:
>   - Log tweak in `DiscoverStructure`: low‑impact removals reported as "impact below costOfGrowth".
>   - `buildDiscoveryCandidates` (`src/discovery/DiscoveryCandidates.ts`): for `remove-low-impact` changes, set description to use `impact` and keep `expectedErrorReduction` undefined.
> - **Runner**:
>   - Minor call formatting in `DiscoveryRunner` when building candidates (no behavior change).
> - **Tests/Fixtures**:
>   - Add `test/data/crippled-removal.json` and new tests in `test/discovery/RemovalCandidates.test.ts` verifying low‑impact removal behavior and undefined `expectedErrorReduction`.
>   - Validate offspring in `test/Creature.ts` after breeding.
> - **Meta**:
>   - Bump `deno.json` version to `0.226.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4de60f17cc2e41454e2b3050da253e160641d8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->