### PR TITLE
chore: update version to 0.227.1 and enhance removal candidate diagno…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.226.0",
+  "version": "0.227.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -4306,6 +4306,12 @@ export class DiscoverStructure {
    * @param removalCandidate - The low-impact neuron candidate to remove.
    * @returns A modified Creature with the neuron removed, or undefined if no change was made.
    */
+  // Track removal diagnostics across calls (static to aggregate across multiple removals)
+  private static removalDiagnostics = {
+    sameUUIDCount: 0,
+    firstSameUUIDLogged: false,
+  };
+
   public static removeLowImpactNeuron(
     ID: string,
     creature: Creature,
@@ -4334,6 +4340,9 @@ export class DiscoverStructure {
       JSON.stringify(exportJSON),
     );
 
+    const originalSynapseCount = simplifiedExport.synapses.length;
+    const originalNeuronCount = simplifiedExport.neurons.length;
+
     // Low-impact neurons have negligible effect on outputs, so we skip bias adjustment.
     // Just remove all synapses to/from this neuron.
     simplifiedExport.synapses = simplifiedExport.synapses.filter(
@@ -4347,13 +4356,30 @@ export class DiscoverStructure {
       (neuron) => neuron.uuid !== removalCandidate.neuronUUID,
     );
 
+    const removedSynapseCount = originalSynapseCount -
+      simplifiedExport.synapses.length;
+    const removedNeuronCount = originalNeuronCount -
+      simplifiedExport.neurons.length;
+
     const tmpCreature = Creature.fromJSON(simplifiedExport);
     // We modified the structure, so we must delete UUID
     delete tmpCreature.uuid;
     tmpCreature.fix();
 
+    // Check if fix() re-added any structure
+    const afterFixSynapseCount = tmpCreature.synapses.length;
+    const afterFixNeuronCount = tmpCreature.neurons.length;
+    const fixReaddedSynapses = afterFixSynapseCount -
+      simplifiedExport.synapses.length;
+    const fixReaddedNeurons = afterFixNeuronCount -
+      simplifiedExport.neurons.length;
+
     const tmpUUID = CreatureUtil.makeUUID(tmpCreature);
     if (tmpUUID !== creatureUUID) {
+      // Reset diagnostics on successful removal
+      this.removalDiagnostics.sameUUIDCount = 0;
+      this.removalDiagnostics.firstSameUUIDLogged = false;
+
       addTag(tmpCreature, "approach", "discovery" as Approach);
       addTag(tmpCreature, "discoveryID", ID);
       const summary =
@@ -4367,7 +4393,37 @@ export class DiscoverStructure {
 
       return tmpCreature;
     }
+
+    // UUID didn't change - track this case
+    this.removalDiagnostics.sameUUIDCount++;
+
+    // Log detailed diagnostics for first occurrence only
+    if (!this.removalDiagnostics.firstSameUUIDLogged) {
+      this.removalDiagnostics.firstSameUUIDLogged = true;
+      console.warn(
+        `[DiscoverStructure] removeLowImpactNeuron UUID unchanged after removal:`,
+        `\n  neuronUUID: ${removalCandidate.neuronUUID}`,
+        `\n  removedSynapses: ${removedSynapseCount}, removedNeurons: ${removedNeuronCount}`,
+        `\n  fix() re-added: synapses=${fixReaddedSynapses}, neurons=${fixReaddedNeurons}`,
+        `\n  originalUUID: ${creatureUUID}`,
+        `\n  newUUID: ${tmpUUID}`,
+      );
+    }
+
     return undefined;
+  }
+
+  /** Reset removal diagnostics (call at start of discovery to get fresh stats). */
+  public static resetRemovalDiagnostics(): void {
+    this.removalDiagnostics = {
+      sameUUIDCount: 0,
+      firstSameUUIDLogged: false,
+    };
+  }
+
+  /** Get count of removals that failed due to same UUID. */
+  public static getRemovalSameUUIDCount(): number {
+    return this.removalDiagnostics.sameUUIDCount;
   }
 
   /**

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -409,13 +409,29 @@ export function buildDiscoveryCandidates(
   // 3. The filter explicitly passes undefined through for evaluation
   const { removalCandidates } = discovery;
   if (removalCandidates && removalCandidates.length > 0) {
+    let removalSuccessCount = 0;
+    let removalFailureCount = 0;
+    const failureReasons: Map<string, number> = new Map();
+
     for (const candidate of removalCandidates) {
+      // Check if neuron exists in base creature
+      const neuronExists = baseCreature.neurons.some(
+        (n) => n.uuid === candidate.neuronUUID,
+      );
+      if (!neuronExists) {
+        const reason = "neuron_not_found";
+        failureReasons.set(reason, (failureReasons.get(reason) ?? 0) + 1);
+        removalFailureCount++;
+        continue;
+      }
+
       const removedLowImpactCreature = DiscoverStructure.removeLowImpactNeuron(
         discovery.ID,
         baseCreature,
         candidate,
       );
       if (removedLowImpactCreature) {
+        removalSuccessCount++;
         candidates.push({
           creature: removedLowImpactCreature,
           change: {
@@ -427,7 +443,23 @@ export function buildDiscoveryCandidates(
             // No expectedErrorReduction - removal improves score via complexity reduction, not error
           },
         });
+      } else {
+        const reason = "removal_returned_undefined";
+        failureReasons.set(reason, (failureReasons.get(reason) ?? 0) + 1);
+        removalFailureCount++;
       }
+    }
+
+    // Log diagnostic summary for removal candidates
+    if (removalCandidates.length > 0) {
+      const failureDetails = Array.from(failureReasons.entries())
+        .map(([reason, count]) => `${reason}: ${count}`)
+        .join(", ");
+      console.info(
+        `[DiscoveryCandidates] Removal candidates: ${removalCandidates.length} total, ` +
+          `${removalSuccessCount} succeeded, ${removalFailureCount} failed` +
+          (failureDetails ? ` (${failureDetails})` : ""),
+      );
     }
   }
 

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -766,9 +766,13 @@ export class DiscoveryRunner {
    * Filters discovery candidates for evaluation.
    *
    * Strategy:
-   * 1. Include all candidates with expected error reduction >= threshold (or undefined, which we'll evaluate)
-   * 2. If there are more than 2x CPU cores candidates, select the best estimated ones
-   * 3. We evaluate all candidates with sufficient expected improvement or undefined expected improvement
+   * 1. ALWAYS include a few random removal candidates (they improve score, not error)
+   * 2. Include candidates with expected error reduction >= threshold
+   * 3. If there are more than 2x CPU cores candidates, select the best estimated ones
+   *
+   * Removal candidates are treated separately because they don't reduce error -
+   * they improve SCORE by reducing complexity. So they shouldn't compete with
+   * add-neuron candidates that have expected error reduction.
    *
    * @param candidates - All discovery candidates
    * @param threadCount - Number of CPU threads available
@@ -791,8 +795,9 @@ export class DiscoveryRunner {
     const multiplier = config.discoveryMinImprovementVsCostOfGrowthMultiplier;
     const minExpectedImprovement = config.costOfGrowth * multiplier;
 
-    // Filter to candidates that meet the minimum expected improvement threshold or have undefined expected improvement
-    const positiveCandidates: DiscoveryCandidate[] = [];
+    // Separate candidates into categories
+    const removalCandidates: DiscoveryCandidate[] = [];
+    const otherCandidates: DiscoveryCandidate[] = [];
     const skipped: Array<{
       changeType?: DiscoveryChangeType;
       expected?: number;
@@ -801,11 +806,17 @@ export class DiscoveryRunner {
     for (const candidate of candidates) {
       CreatureUtil.makeUUID(candidate.creature);
       const expected = candidate.change.expectedErrorReduction;
+      const isRemovalCandidate = candidate.change.type === "remove-low-impact";
 
-      // Include candidates with: undefined expected improvement, or expected improvement meeting threshold
+      // Removal candidates are handled separately - they improve score, not error
+      if (isRemovalCandidate) {
+        removalCandidates.push(candidate);
+        continue;
+      }
+
       if (expected === undefined) {
-        // No expected value - include it for evaluation (combo candidates, remove-low-impact, etc.)
-        positiveCandidates.push(candidate);
+        // No expected value - include for evaluation (combo candidates, etc.)
+        otherCandidates.push(candidate);
       } else if (Number.isFinite(expected)) {
         // When multiplier is 0, use strict positive check (expected > 0)
         // Otherwise, check against threshold (expected >= minExpectedImprovement)
@@ -814,10 +825,8 @@ export class DiscoveryRunner {
           : expected >= minExpectedImprovement;
 
         if (meetsThreshold) {
-          // Expected impact meets or exceeds threshold - include it
-          positiveCandidates.push(candidate);
+          otherCandidates.push(candidate);
         } else {
-          // Expected impact below threshold - skip it
           skipped.push({
             changeType: candidate.change.type,
             expected,
@@ -832,46 +841,67 @@ export class DiscoveryRunner {
       }
     }
 
-    // If we have too many candidates, select the best estimated ones
-    if (positiveCandidates.length > maxCandidates) {
-      // Sort by expected error reduction (descending)
-      // Candidates with undefined expectedErrorReduction are included but sorted to the end
-      // so they're only included if there's room after all candidates with known estimates
-      positiveCandidates.sort((a, b) => {
-        const aExpected = a.change.expectedErrorReduction;
-        const bExpected = b.change.expectedErrorReduction;
+    // Sort other candidates by expected error reduction (descending)
+    // Candidates with undefined expectedErrorReduction are sorted to the end
+    otherCandidates.sort((a, b) => {
+      const aExpected = a.change.expectedErrorReduction;
+      const bExpected = b.change.expectedErrorReduction;
+      if (aExpected !== undefined && bExpected !== undefined) {
+        return bExpected - aExpected;
+      }
+      if (aExpected !== undefined) return -1;
+      if (bExpected !== undefined) return 1;
+      return 0;
+    });
 
-        // Both have values - sort by value (descending)
-        if (aExpected !== undefined && bExpected !== undefined) {
-          return bExpected - aExpected;
-        }
-        // Only a has value - a comes first
-        if (aExpected !== undefined) {
-          return -1;
-        }
-        // Only b has value - b comes first
-        if (bExpected !== undefined) {
-          return 1;
-        }
-        // Both undefined - maintain order
-        return 0;
-      });
+    // ALWAYS include a few random removal candidates (minimum 3, or all if fewer)
+    // These are added ON TOP of the regular selection, not competing for the same slots
+    const removalSampleSize = Math.min(removalCandidates.length, 3);
+    let selectedRemovalCandidates: DiscoveryCandidate[];
 
-      // Take the top candidates and mark the rest as skipped
-      const topCandidates = positiveCandidates.slice(0, maxCandidates);
-      const remaining = positiveCandidates.slice(maxCandidates);
+    if (removalCandidates.length <= removalSampleSize) {
+      selectedRemovalCandidates = removalCandidates;
+    } else {
+      // Fisher-Yates shuffle and take first N
+      const shuffled = [...removalCandidates];
+      for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+      }
+      selectedRemovalCandidates = shuffled.slice(0, removalSampleSize);
 
-      for (const candidate of remaining) {
+      console.info(
+        `[DiscoveryRunner] Randomly selected ${removalSampleSize} of ${removalCandidates.length} removal candidates for evaluation`,
+      );
+
+      // Mark remaining removal candidates as skipped
+      for (const candidate of shuffled.slice(removalSampleSize)) {
         skipped.push({
           changeType: candidate.change.type,
           expected: candidate.change.expectedErrorReduction,
         });
       }
-
-      return { filtered: topCandidates, skipped };
     }
 
-    return { filtered: positiveCandidates, skipped };
+    // Select other candidates up to the max limit
+    let selectedOtherCandidates: DiscoveryCandidate[];
+    if (otherCandidates.length <= maxCandidates) {
+      selectedOtherCandidates = otherCandidates;
+    } else {
+      selectedOtherCandidates = otherCandidates.slice(0, maxCandidates);
+
+      for (const candidate of otherCandidates.slice(maxCandidates)) {
+        skipped.push({
+          changeType: candidate.change.type,
+          expected: candidate.change.expectedErrorReduction,
+        });
+      }
+    }
+
+    // Combine: other candidates first, then removal candidates (added on top)
+    const filtered = [...selectedOtherCandidates, ...selectedRemovalCandidates];
+
+    return { filtered, skipped };
   }
 }
 

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1263,3 +1263,197 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "DiscoveryRunner evaluates removal candidates and includes them in evaluation summaries",
+  async () => {
+    // Create a creature with a hidden neuron that has near-zero weight synapses
+    // (low impact but valid structure)
+    const baseCreature = Creature.fromJSON({
+      input: 2,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "hidden-low-impact",
+          squash: "RELU",
+          bias: 0.5,
+        },
+        { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "hidden-low-impact", weight: 1e-12 },
+        { fromUUID: "hidden-low-impact", toUUID: "output-0", weight: 1e-12 },
+        { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+      ],
+    });
+    baseCreature.validate();
+    CreatureUtil.makeUUID(baseCreature);
+
+    // Discovery result with a removal candidate from Rust
+    const discoveryResult: DiscoverResult = {
+      ID: "REMOVAL_TEST",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: [
+        {
+          neuronUUID: "hidden-low-impact",
+          totalError: 5.0,
+          impact: 0.001, // Very low impact (0.1%)
+          reason: "High error but very low impact - candidate for removal",
+        },
+      ],
+      candidateSquashes: undefined,
+    };
+
+    // Error function - removal should improve score via complexity reduction
+    const baselineError = 0.5;
+    const computeError = (creature: Creature) => {
+      const json = creature.exportJSON();
+      const hasHiddenNeuron = json.neurons.some(
+        (n) => n.uuid === "hidden-low-impact",
+      );
+      // Removal may slightly increase error, but improves score via complexity reduction
+      return hasHiddenNeuron ? baselineError : baselineError + 0.001;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          computeError,
+        ),
+      // Use default candidateBuilder (buildDiscoveryCandidates) to test full flow
+    });
+
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options: makeOptions({ costOfGrowth: 0.01 }), // Set costOfGrowth so removal has benefit
+    });
+
+    // Verify evaluation summaries include the removal candidate
+    const candidateEvaluations =
+      result.evaluations?.filter((entry) => entry.kind === "candidate") ?? [];
+
+    // Should have at least one removal candidate evaluated
+    const removalCandidates = candidateEvaluations.filter(
+      (entry) => entry.changeType === "remove-low-impact",
+    );
+
+    assertEquals(
+      removalCandidates.length,
+      1,
+      `Expected 1 remove-low-impact candidate in evaluations, got ${removalCandidates.length}. ` +
+        `All candidate types: ${
+          candidateEvaluations.map((e) => e.changeType).join(", ")
+        }`,
+    );
+
+    // Verify the removal candidate has the expected description
+    const removalCandidate = removalCandidates[0];
+    assert(
+      removalCandidate.description?.includes("low-impact"),
+      `Expected description to mention 'low-impact', got: ${removalCandidate.description}`,
+    );
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner reserves slots for removal candidates even when many other candidates exist",
+  async () => {
+    const baseCreature = makeBaseCreature();
+
+    // Discovery result - we'll use custom candidateBuilder to control candidates
+    const discoveryResult: DiscoverResult = {
+      ID: "REMOVAL_SLOT_RESERVATION",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    // Custom candidate builder that creates many add-neuron candidates
+    // and several removal candidates
+    const candidateBuilder = (
+      _creature: Creature,
+      _discovery: DiscoverResult,
+    ): DiscoveryCandidate[] => {
+      const candidates: DiscoveryCandidate[] = [];
+
+      // Create 20 add-neuron candidates with high expected impact
+      for (let i = 0; i < 20; i++) {
+        const candidate = Creature.fromJSON(cloneCreatureJSON(baseCreature));
+        candidate.validate();
+        CreatureUtil.makeUUID(candidate);
+        candidates.push({
+          creature: candidate,
+          change: {
+            type: "add-neurons",
+            description: `add-neuron-${i}`,
+            expectedErrorReduction: 0.1 - i * 0.001, // Descending from 10% to 8.1%
+          },
+        });
+      }
+
+      // Create 10 removal candidates (undefined expected impact)
+      for (let i = 0; i < 10; i++) {
+        const candidate = Creature.fromJSON(cloneCreatureJSON(baseCreature));
+        candidate.validate();
+        CreatureUtil.makeUUID(candidate);
+        candidates.push({
+          creature: candidate,
+          change: {
+            type: "remove-low-impact",
+            description: `removal-${i}`,
+            // No expectedErrorReduction - removal candidates have undefined
+          },
+        });
+      }
+
+      return candidates;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          () => 0.5,
+        ),
+      candidateBuilder,
+    });
+
+    // Use only 2 threads to get max 4 candidates (tight budget forces selection)
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options: makeOptions({ threads: 2 }), // max 4 candidates
+    });
+
+    const candidateEvaluations =
+      result.evaluations?.filter((entry) => entry.kind === "candidate") ?? [];
+
+    // With max 4 candidates:
+    // - Removal slots = min(10, max(3, floor(4*0.25))) = min(10, 3) = 3
+    // - Other slots = 4 - 3 = 1
+    // So we should see at least 1 removal candidate evaluated
+    const removalEvaluations = candidateEvaluations.filter(
+      (e) => e.changeType === "remove-low-impact",
+    );
+
+    assert(
+      removalEvaluations.length >= 1,
+      `Expected at least 1 removal candidate to be evaluated even with many add-neuron candidates. ` +
+        `Got ${removalEvaluations.length} removal evaluations out of ${candidateEvaluations.length} total. ` +
+        `All evaluations: ${
+          candidateEvaluations.map((e) => e.changeType).join(", ")
+        }`,
+    );
+  },
+);


### PR DESCRIPTION
…stics

- Bumped version in deno.json to 0.227.1.
- Introduced static diagnostics tracking in DiscoverStructure for low-impact neuron removals, including counts of unchanged UUIDs and detailed logging for the first occurrence.
- Updated buildDiscoveryCandidates to log success and failure counts for removal candidates, improving visibility into the evaluation process.
- Enhanced DiscoveryRunner to ensure removal candidates are included in evaluations, even when other candidates are present, and to reserve slots for them in the selection process.
- Added tests to validate the evaluation and inclusion of removal candidates in various scenarios, ensuring robust functionality.

These changes aim to improve the clarity and effectiveness of the discovery process by refining the handling of removal candidates and enhancing diagnostic capabilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds diagnostics and slot-reservation for low-impact neuron removal, updates candidate filtering to always include some removals, and adds tests to validate behavior.
> 
> - **Discovery**:
>   - `DiscoverStructure.removeLowImpactNeuron(...)`: add static diagnostics (same-UUID counter, first-occurrence detailed log), track removed vs re-added items after `fix()`, plus `resetRemovalDiagnostics()`/`getRemovalSameUUIDCount()`.
>   - `DiscoveryCandidates.buildDiscoveryCandidates(...)`: when applying `removalCandidates`, record success/failure counts, categorize failure reasons, and log a concise summary; skip candidates whose neuron UUID isn’t present.
>   - `DiscoveryRunner.#filterCandidatesForEvaluation(...)`: treat `remove-low-impact` separately; always include a small random sample of removal candidates in addition to top "expected" candidates; sort others by `expectedErrorReduction`; log selection of sampled removals.
> - **Tests**:
>   - Add tests ensuring removal candidates are evaluated and that slots are reserved for them even with many other candidates.
> - **Chore**:
>   - Bump version to `0.227.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 431d58608db6d434d77b80a7c6f3a8ae8a376aec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->