### PR TITLE
chore: update version to 0.228.0 and enhance removal candidate tracking

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.227.1",
+  "version": "0.228.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -53,6 +53,7 @@ class DiscoveryPerformanceStats {
   harmfulSynapseCandidates = 0;
   harmfulNeuronCandidates = 0;
   squashCandidates = 0;
+  removalCandidates = 0;
 
   // Other phases
   cleanupTime = 0;
@@ -131,7 +132,8 @@ class DiscoveryPerformanceStats {
         `  Helpful neurons: ${formatCount(this.helpfulNeuronCandidates)}\n` +
         `  Harmful synapses: ${formatCount(this.harmfulSynapseCandidates)}\n` +
         `  Harmful neurons: ${formatCount(this.harmfulNeuronCandidates)}\n` +
-        `  Squash changes: ${formatCount(this.squashCandidates)}`,
+        `  Squash changes: ${formatCount(this.squashCandidates)}\n` +
+        `  Removal candidates: ${formatCount(this.removalCandidates)}`,
     );
 
     // Overall summary
@@ -1051,6 +1053,7 @@ class DataRecorder {
       const removalCandidates = discoverStructure.getRemovalCandidates();
       if (removalCandidates && removalCandidates.length > 0) {
         discoverResult.removalCandidates = removalCandidates;
+        perfStats.removalCandidates = removalCandidates.length;
         if (shouldLogDiscovery(config)) {
           console.log(
             `Discovery ${blue(this.ID)} found ${

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -403,10 +403,23 @@ export function buildDiscoveryCandidates(
   // Low-impact removal candidates (impact below costOfGrowth)
   // These neurons contribute essentially nothing to outputs - removing them improves
   // the creature's score because the complexity reduction benefit exceeds their contribution.
+  //
   // NOTE: expectedErrorReduction is left undefined because:
   // 1. Removal doesn't reduce error - it may slightly increase it
   // 2. The improvement comes from score (complexity reduction), not error reduction
   // 3. The filter explicitly passes undefined through for evaluation
+  //
+  // INVESTIGATION NOTE (Dec 2025): Why might removing low-impact neurons INCREASE error?
+  // Observed behaviour: neurons with impact < 1e-10 sometimes increase error when removed.
+  // Potential causes:
+  //   a) Structural impact calculation may not reflect runtime activation patterns accurately
+  //   b) Neurons receiving signals that cancel out (net zero impact on path, but still contributing)
+  //   c) The neuron's bias adjustment during removal may not perfectly compensate
+  //   d) Non-linear interactions through downstream neurons may amplify small contributions
+  // Potential mitigations:
+  //   - Use stricter impact threshold (e.g., < 1e-12 instead of < 1e-10)
+  //   - Verify with actual activation data before removal
+  //   - Consider average activation magnitude in addition to structural impact
   const { removalCandidates } = discovery;
   if (removalCandidates && removalCandidates.length > 0) {
     let removalSuccessCount = 0;
@@ -460,6 +473,35 @@ export function buildDiscoveryCandidates(
           `${removalSuccessCount} succeeded, ${removalFailureCount} failed` +
           (failureDetails ? ` (${failureDetails})` : ""),
       );
+
+      // Log detailed list of removal candidates sorted by impact (lowest first)
+      // This helps identify if specific test neurons like "candidate-for-removal" are included
+      const sortedByImpact = [...removalCandidates].sort((a, b) =>
+        a.impact - b.impact
+      );
+      const topCandidates = sortedByImpact.slice(0, 10);
+      const candidateDetails = topCandidates.map((c) =>
+        `${shortID(c.neuronUUID)}:${c.impact.toExponential(2)}`
+      ).join(", ");
+      console.info(
+        `[DiscoveryCandidates] Top ${topCandidates.length} lowest-impact removal candidates: ${candidateDetails}`,
+      );
+
+      // Check for specific test neuron patterns (e.g., containing "candidate-for-removal")
+      // This helps verify test neurons are being properly identified
+      const testNeuronMatches = removalCandidates.filter((c) =>
+        c.neuronUUID.toLowerCase().includes("candidate") ||
+        c.neuronUUID.toLowerCase().includes("test") ||
+        c.neuronUUID.toLowerCase().includes("removal")
+      );
+      if (testNeuronMatches.length > 0) {
+        console.info(
+          `[DiscoveryCandidates] Found ${testNeuronMatches.length} potential test neuron(s) in removal list: ` +
+            testNeuronMatches.map((c) =>
+              `${c.neuronUUID}:${c.impact.toExponential(2)}`
+            ).join(", "),
+        );
+      }
     }
   }
 

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -854,32 +854,67 @@ export class DiscoveryRunner {
       return 0;
     });
 
-    // ALWAYS include a few random removal candidates (minimum 3, or all if fewer)
+    // ALWAYS include a few removal candidates (minimum 3, or all if fewer)
     // These are added ON TOP of the regular selection, not competing for the same slots
+    // Strategy: Pick randomly from the TOP 10 lowest-impact candidates (safest to remove)
     const removalSampleSize = Math.min(removalCandidates.length, 3);
     let selectedRemovalCandidates: DiscoveryCandidate[];
 
     if (removalCandidates.length <= removalSampleSize) {
       selectedRemovalCandidates = removalCandidates;
     } else {
-      // Fisher-Yates shuffle and take first N
-      const shuffled = [...removalCandidates];
-      for (let i = shuffled.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-      }
-      selectedRemovalCandidates = shuffled.slice(0, removalSampleSize);
+      // Extract impact values from candidate descriptions (format: "impact: X.XXe-XX")
+      const candidatesWithImpact = removalCandidates.map((candidate) => {
+        const impactMatch = candidate.change.description?.match(
+          /impact:\s*([\d.e+-]+)/i,
+        );
+        const impact = impactMatch ? parseFloat(impactMatch[1]) : 1e-10;
+        return { candidate, impact };
+      });
 
+      // Sort by impact ascending (lowest = safest to remove)
+      candidatesWithImpact.sort((a, b) => a.impact - b.impact);
+
+      // Take the top 10 lowest-impact candidates as the pool to select from
+      const TOP_N = 10;
+      const topCandidates = candidatesWithImpact.slice(0, TOP_N);
+
+      // Log the top 10 pool before selection
+      const topPoolDetails = topCandidates
+        .map((c) => `${c.impact.toExponential(2)}`)
+        .join(", ");
       console.info(
-        `[DiscoveryRunner] Randomly selected ${removalSampleSize} of ${removalCandidates.length} removal candidates for evaluation`,
+        `[DiscoveryRunner] Top ${topCandidates.length} lowest-impact removal candidates pool: [${topPoolDetails}]`,
       );
 
-      // Mark remaining removal candidates as skipped
-      for (const candidate of shuffled.slice(removalSampleSize)) {
-        skipped.push({
-          changeType: candidate.change.type,
-          expected: candidate.change.expectedErrorReduction,
-        });
+      // Fisher-Yates shuffle on the top candidates and take first N
+      for (let i = topCandidates.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [topCandidates[i], topCandidates[j]] = [
+          topCandidates[j],
+          topCandidates[i],
+        ];
+      }
+      const selected = topCandidates.slice(0, removalSampleSize);
+      selectedRemovalCandidates = selected.map((s) => s.candidate);
+
+      // Log which ones were chosen with their impact values
+      const selectedDetails = selected
+        .map((s) => `${s.impact.toExponential(2)}`)
+        .join(", ");
+      console.info(
+        `[DiscoveryRunner] ✓ Selected ${removalSampleSize} from top ${topCandidates.length}: [${selectedDetails}]`,
+      );
+
+      // Mark remaining candidates as skipped (both unselected from top pool and those outside top 10)
+      const selectedSet = new Set(selectedRemovalCandidates);
+      for (const item of candidatesWithImpact) {
+        if (!selectedSet.has(item.candidate)) {
+          skipped.push({
+            changeType: item.candidate.change.type,
+            expected: item.candidate.change.expectedErrorReduction,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
- Bumped version in deno.json to 0.228.0.
- Added a new property for tracking removal candidates in DiscoveryPerformanceStats.
- Enhanced logging in buildDiscoveryCandidates to provide detailed insights into low-impact removal candidates, including their impact values and identification of test neurons.
- Updated DiscoveryRunner to select removal candidates based on their impact, ensuring a more strategic approach to candidate evaluation.

These changes aim to improve the tracking and evaluation of removal candidates, enhancing the overall discovery process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tracks and logs low-impact removal candidates and selects them from the lowest-impact pool for evaluation; bumps version to 0.228.0.
> 
> - **Discovery performance and logging**:
>   - Add `removalCandidates` metric to `DiscoveryPerformanceStats` and include in summary output.
>   - Capture and report count when collecting `getRemovalCandidates()` in `DiscoverDirectory`.
>   - Enhance `buildDiscoveryCandidates` diagnostics: summarize successes/failures, list top lowest-impact candidates, and flag potential test neurons.
> - **Candidate filtering/selection**:
>   - In `DiscoveryRunner.#filterCandidatesForEvaluation`, always include up to 3 removal candidates chosen from the top 10 lowest-impact (parsed from `description`), with detailed logging of the pool and selections; mark others as skipped.
> - **Version**:
>   - Bump `deno.json` `version` to `0.228.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b1ce925c7ab920fbb0988f5f589adf2b955fa53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->