### PR TITLE
chore: update version to 0.229.0 and enhance combined removal candida…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.228.0",
+  "version": "0.229.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -421,6 +421,9 @@ export function buildDiscoveryCandidates(
   //   - Verify with actual activation data before removal
   //   - Consider average activation magnitude in addition to structural impact
   const { removalCandidates } = discovery;
+  // Track successfully removed candidates for combined removal
+  const successfulRemovals: typeof removalCandidates = [];
+
   if (removalCandidates && removalCandidates.length > 0) {
     let removalSuccessCount = 0;
     let removalFailureCount = 0;
@@ -445,6 +448,7 @@ export function buildDiscoveryCandidates(
       );
       if (removedLowImpactCreature) {
         removalSuccessCount++;
+        successfulRemovals.push(candidate);
         candidates.push({
           creature: removedLowImpactCreature,
           change: {
@@ -500,6 +504,53 @@ export function buildDiscoveryCandidates(
             testNeuronMatches.map((c) =>
               `${c.neuronUUID}:${c.impact.toExponential(2)}`
             ).join(", "),
+        );
+      }
+    }
+
+    // Build a COMBINED removal candidate that removes ALL successful candidates at once
+    // This allows cleaning up multiple low-impact neurons in a single operation
+    // The combined version competes with individual removals - best score wins
+    if (successfulRemovals.length >= 2) {
+      let combinedRemovalCreature: Creature | undefined = baseCreature;
+
+      // Apply each removal sequentially to the same creature
+      for (const candidate of successfulRemovals) {
+        if (!combinedRemovalCreature) break;
+
+        combinedRemovalCreature = DiscoverStructure.removeLowImpactNeuron(
+          discovery.ID,
+          combinedRemovalCreature,
+          candidate,
+        );
+      }
+
+      if (combinedRemovalCreature && combinedRemovalCreature !== baseCreature) {
+        // Format neuron IDs for git log message
+        const neuronIDs = successfulRemovals
+          .map((c) => shortID(c.neuronUUID))
+          .join(", ");
+
+        // Git-friendly message: clear, concise, good English
+        const description = successfulRemovals.length === 2
+          ? `🧹 Pruned 2 low-impact neurons in combined cleanup (${neuronIDs})`
+          : `🧹 Pruned ${successfulRemovals.length} low-impact neurons in combined cleanup`;
+
+        candidates.push({
+          creature: combinedRemovalCreature,
+          change: {
+            type: "remove-low-impact",
+            description,
+            // No expectedErrorReduction - removal improves score via complexity reduction, not error
+          },
+        });
+
+        // Detailed logging for diagnostics (not in git)
+        const impactDetails = successfulRemovals
+          .map((c) => `${shortID(c.neuronUUID)}:${c.impact.toExponential(2)}`)
+          .join(", ");
+        console.info(
+          `[DiscoveryCandidates] Created combined removal candidate: ${successfulRemovals.length} neurons [${impactDetails}]`,
         );
       }
     }


### PR DESCRIPTION
…te logic

- Bumped version in deno.json to 0.229.0.
- Introduced tracking for successfully removed candidates in buildDiscoveryCandidates.
- Added functionality to create a combined removal candidate for multiple low-impact neurons, improving efficiency in the cleanup process.
- Enhanced logging to provide detailed insights into combined removals, aiding in diagnostics.

These changes aim to streamline the removal process and improve the overall effectiveness of candidate management in the discovery workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a combined candidate to prune multiple low-impact neurons at once, tracks successful removals, improves logging, and bumps version to 0.229.0.
> 
> - **Discovery pipeline (`src/discovery/DiscoveryCandidates.ts`)**:
>   - Track `successfulRemovals` when removing low-impact neurons.
>   - Create a combined removal candidate applying all successful low-impact removals sequentially (when ≥2), with concise descriptions and candidate push.
>   - Enhance diagnostics: summarize success/failure counts with reasons, list lowest-impact candidates, detect test-pattern neurons, and log combined-removal details.
> - **Config**:
>   - Bump `deno.json` `version` to `0.229.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 828ba8a97e0ae69e3b5007af2f3403415acc1ded. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->