### PR TITLE
chore: update version to 0.231.0 and enhance discovery candidate logic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.229.0",
+  "version": "0.231.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -1178,34 +1178,34 @@ export function buildCombinedFromSuccessful(
   if (successfulCandidates.length > 2 && successfulCandidates.length <= 6) {
     for (let i = 0; i < successfulCandidates.length; i++) {
       for (let j = i + 1; j < successfulCandidates.length; j++) {
-        const candA = successfulCandidates[i];
-        const candB = successfulCandidates[j];
+        const candidateA = successfulCandidates[i];
+        const candidateB = successfulCandidates[j];
 
         // Skip if same type (already handled above)
-        if (candA.change.type === candB.change.type) continue;
+        if (candidateA.change.type === candidateB.change.type) continue;
 
         let pairCreature = applyChangeToCreature(
           baseCreature,
-          candA,
+          candidateA,
           discoveryID,
         );
         if (pairCreature && pairCreature !== baseCreature) {
           pairCreature = applyChangeToCreature(
             pairCreature,
-            candB,
+            candidateB,
             discoveryID,
           );
           if (pairCreature) {
             const emoji = selectCombinationEmoji([
-              candA.change.type,
-              candB.change.type,
+              candidateA.change.type,
+              candidateB.change.type,
             ]);
             combinedCandidates.push({
               creature: pairCreature,
               change: {
                 type: "combo-successful",
                 description:
-                  `${emoji} Combined ${candA.change.type} + ${candB.change.type}`,
+                  `${emoji} Combined ${candidateA.change.type} + ${candidateB.change.type}`,
               },
             });
           }

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -23,7 +23,8 @@ export type DiscoveryChangeType =
   | "combo-add-remove"
   | "combo-add-change"
   | "combo-all"
-  | "combo-best-of-category";
+  | "combo-best-of-category"
+  | "combo-successful";
 
 /** Details of a discovered neuron for logging/debugging. */
 export interface DiscoveredNeuronDetails {
@@ -57,6 +58,15 @@ export interface DiscoveryCandidate {
   change: DiscoveryCandidateChange;
 }
 
+export interface BuildDiscoveryCandidatesOptions {
+  /**
+   * If true, skip building combined candidates.
+   * Used for two-phase scoring where combos are built after evaluating singles.
+   * @default false
+   */
+  skipCombinedCandidates?: boolean;
+}
+
 /**
  * Build a list of possible improved creatures based on discovery suggestions.
  *
@@ -66,11 +76,14 @@ export interface DiscoveryCandidate {
  *
  * @param baseCreature The creature to apply discovery changes to
  * @param discovery The discovery result containing candidate changes
+ * @param options Options controlling candidate building
  */
 export function buildDiscoveryCandidates(
   baseCreature: Creature,
   discovery: DiscoverResult,
+  options?: BuildDiscoveryCandidatesOptions,
 ): DiscoveryCandidate[] {
+  const skipCombos = options?.skipCombinedCandidates ?? false;
   // Ensure the base creature has a UUID so discovery helpers function correctly.
   CreatureUtil.makeUUID(baseCreature);
   const impactEstimator = new CreatureErrorImpactEstimator(baseCreature);
@@ -238,7 +251,8 @@ export function buildDiscoveryCandidates(
       },
     });
 
-    if (addedSynapseCreature && removeHarmfulSynapse) {
+    // Only build combined candidates if not skipped (for two-phase scoring)
+    if (!skipCombos && addedSynapseCreature && removeHarmfulSynapse) {
       let combinedAddRemove = DiscoverStructure.addHelpfulSynapses(
         discovery.ID,
         removedSynapseCreature,
@@ -343,7 +357,8 @@ export function buildDiscoveryCandidates(
       },
     });
 
-    if (addedSynapseCreature) {
+    // Only build combined candidates if not skipped (for two-phase scoring)
+    if (!skipCombos && addedSynapseCreature) {
       const combinedAddChange = DiscoverStructure.changeSquash(
         discovery.ID,
         addedSynapseCreature,
@@ -556,89 +571,96 @@ export function buildDiscoveryCandidates(
     }
   }
 
-  const combinedCandidate = buildCombinedCandidate({
-    baseCreature,
-    discoveryID: discovery.ID,
-    selection: {
-      addHelpfulNeurons: addedNeuronCreature
-        ? helpfulNeuronCandidates
-        : undefined,
-      addHelpfulSynapses: addedSynapseCreature ? addHelpfulSynapses : undefined,
-      removeHarmfulSynapse: removedSynapseCreature
-        ? removeHarmfulSynapse
-        : undefined,
-      removeHarmfulNeurons: removedNeuronCreature
-        ? removeHarmfulNeurons
-        : undefined,
-      candidateSquashes: changedSquashCreature ? candidateSquashes : undefined,
-    },
-    changeType: "combo-all",
-    description: "🏗️ Combined all discovery changes",
-  });
-  if (combinedCandidate) {
-    candidates.push(combinedCandidate);
-  }
+  // Only build combined candidates if not skipped (for two-phase scoring)
+  if (!skipCombos) {
+    const combinedCandidate = buildCombinedCandidate({
+      baseCreature,
+      discoveryID: discovery.ID,
+      selection: {
+        addHelpfulNeurons: addedNeuronCreature
+          ? helpfulNeuronCandidates
+          : undefined,
+        addHelpfulSynapses: addedSynapseCreature
+          ? addHelpfulSynapses
+          : undefined,
+        removeHarmfulSynapse: removedSynapseCreature
+          ? removeHarmfulSynapse
+          : undefined,
+        removeHarmfulNeurons: removedNeuronCreature
+          ? removeHarmfulNeurons
+          : undefined,
+        candidateSquashes: changedSquashCreature
+          ? candidateSquashes
+          : undefined,
+      },
+      changeType: "combo-all",
+      description: "🏗️ Combined all discovery changes",
+    });
+    if (combinedCandidate) {
+      candidates.push(combinedCandidate);
+    }
 
-  const bestOfCategoryCandidate = buildBestOfCategoryCandidate(
-    baseCreature,
-    discovery,
-    {
-      synapse: scaledSynapseExpected,
-      neuron: scaledNeuronExpected,
-      squash: scaledSquashExpected,
-    },
-  );
-  if (bestOfCategoryCandidate) {
-    if (discovery.removeHarmfulSynapse) {
-      // Always remove directly without checking first to ensure deterministic removal
-      const removalUUID = {
-        from: discovery.removeHarmfulSynapse.fromNeuronUUID,
-        to: discovery.removeHarmfulSynapse.toNeuronUUID,
-      };
+    const bestOfCategoryCandidate = buildBestOfCategoryCandidate(
+      baseCreature,
+      discovery,
+      {
+        synapse: scaledSynapseExpected,
+        neuron: scaledNeuronExpected,
+        squash: scaledSquashExpected,
+      },
+    );
+    if (bestOfCategoryCandidate) {
+      if (discovery.removeHarmfulSynapse) {
+        // Always remove directly without checking first to ensure deterministic removal
+        const removalUUID = {
+          from: discovery.removeHarmfulSynapse.fromNeuronUUID,
+          to: discovery.removeHarmfulSynapse.toNeuronUUID,
+        };
 
-      // Keep removing until it's definitely gone (fix() might re-add it)
-      let currentCreature = bestOfCategoryCandidate.creature;
-      let attempts = 0;
-      const maxAttempts = 10; // Prevent infinite loops
+        // Keep removing until it's definitely gone (fix() might re-add it)
+        let currentCreature = bestOfCategoryCandidate.creature;
+        let attempts = 0;
+        const maxAttempts = 10; // Prevent infinite loops
 
-      while (attempts < maxAttempts) {
-        const exportJSON = currentCreature.exportJSON();
-        const originalCount = exportJSON.synapses.length;
-        exportJSON.synapses = exportJSON.synapses.filter((synapse) =>
-          !(synapse.fromUUID === removalUUID.from &&
-            synapse.toUUID === removalUUID.to)
-        );
-
-        if (exportJSON.synapses.length < originalCount) {
-          const updated = Creature.fromJSON(exportJSON);
-          // We modified the structure by filtering synapses, so we must delete UUID
-          delete updated.uuid;
-          updated.fix();
-
-          // Verify it's still removed after fix()
-          const verifyJSON = updated.exportJSON();
-          const stillExists = verifyJSON.synapses.some((synapse) =>
-            synapse.fromUUID === removalUUID.from &&
-            synapse.toUUID === removalUUID.to
+        while (attempts < maxAttempts) {
+          const exportJSON = currentCreature.exportJSON();
+          const originalCount = exportJSON.synapses.length;
+          exportJSON.synapses = exportJSON.synapses.filter((synapse) =>
+            !(synapse.fromUUID === removalUUID.from &&
+              synapse.toUUID === removalUUID.to)
           );
 
-          if (!stillExists) {
-            // Successfully removed and stayed removed
+          if (exportJSON.synapses.length < originalCount) {
+            const updated = Creature.fromJSON(exportJSON);
+            // We modified the structure by filtering synapses, so we must delete UUID
+            delete updated.uuid;
+            updated.fix();
+
+            // Verify it's still removed after fix()
+            const verifyJSON = updated.exportJSON();
+            const stillExists = verifyJSON.synapses.some((synapse) =>
+              synapse.fromUUID === removalUUID.from &&
+              synapse.toUUID === removalUUID.to
+            );
+
+            if (!stillExists) {
+              // Successfully removed and stayed removed
+              currentCreature = updated;
+              break;
+            }
+            // Still exists, try again
             currentCreature = updated;
+          } else {
+            // Synapse doesn't exist, we're done
             break;
           }
-          // Still exists, try again
-          currentCreature = updated;
-        } else {
-          // Synapse doesn't exist, we're done
-          break;
+          attempts++;
         }
-        attempts++;
-      }
 
-      bestOfCategoryCandidate.creature = currentCreature;
+        bestOfCategoryCandidate.creature = currentCreature;
+      }
+      candidates.push(bestOfCategoryCandidate);
     }
-    candidates.push(bestOfCategoryCandidate);
   }
 
   return candidates;
@@ -1069,4 +1091,305 @@ function wrapBestCandidate<
     return currentBest;
   }, undefined);
   return best ? [best] : undefined;
+}
+
+/**
+ * Build combined creatures from successful single candidates.
+ *
+ * This function is used in two-phase discovery scoring:
+ * 1. Phase 1: Evaluate single candidates
+ * 2. Phase 2: Call this function with successful candidates to create combinations
+ *
+ * Only combines candidates that have proven to improve score individually.
+ * Creates pairwise combinations and an all-successful combination.
+ *
+ * @param baseCreature The original creature before any changes
+ * @param discoveryID The discovery session identifier
+ * @param successfulCandidates Candidates that improved score in Phase 1
+ * @returns Combined candidates to evaluate in Phase 2
+ */
+export function buildCombinedFromSuccessful(
+  baseCreature: Creature,
+  discoveryID: string,
+  successfulCandidates: DiscoveryCandidate[],
+): DiscoveryCandidate[] {
+  if (successfulCandidates.length < 2) {
+    return [];
+  }
+
+  const combinedCandidates: DiscoveryCandidate[] = [];
+
+  // Group successful candidates by their change type for targeted combination
+  const byType = new Map<string, DiscoveryCandidate[]>();
+  for (const candidate of successfulCandidates) {
+    const type = candidate.change.type;
+    if (!byType.has(type)) {
+      byType.set(type, []);
+    }
+    byType.get(type)!.push(candidate);
+  }
+
+  // Build all-successful combination by applying changes sequentially
+  let combinedCreature = baseCreature;
+  const appliedTypes: string[] = [];
+  const appliedDescriptions: string[] = [];
+
+  // Apply changes in a deterministic order (sorted by type name)
+  const sortedTypes = [...byType.keys()].sort();
+  for (const type of sortedTypes) {
+    const candidates = byType.get(type)!;
+    // Use the first (or best) candidate of each type
+    const best = candidates[0];
+
+    // Try to apply this change to the combined creature
+    const applied = applyChangeToCreature(
+      combinedCreature,
+      best,
+      discoveryID,
+    );
+
+    if (applied && applied !== combinedCreature) {
+      combinedCreature = applied;
+      appliedTypes.push(type);
+      const shortDesc = best.change.description?.split(" ")[0] || type;
+      appliedDescriptions.push(shortDesc);
+    }
+  }
+
+  if (appliedTypes.length >= 2 && combinedCreature !== baseCreature) {
+    // Select emoji based on the combination
+    const emoji = selectCombinationEmoji(appliedTypes);
+    const description =
+      `${emoji} Combined ${appliedTypes.length} successful changes: ${
+        appliedTypes.join(", ")
+      }`;
+
+    combinedCandidates.push({
+      creature: combinedCreature,
+      change: {
+        type: "combo-successful",
+        description,
+      },
+    });
+  }
+
+  // If we have more than 2 successful candidates, also try pairwise combinations
+  // to see if any pair performs better than the full combination
+  if (successfulCandidates.length > 2 && successfulCandidates.length <= 6) {
+    for (let i = 0; i < successfulCandidates.length; i++) {
+      for (let j = i + 1; j < successfulCandidates.length; j++) {
+        const candA = successfulCandidates[i];
+        const candB = successfulCandidates[j];
+
+        // Skip if same type (already handled above)
+        if (candA.change.type === candB.change.type) continue;
+
+        let pairCreature = applyChangeToCreature(
+          baseCreature,
+          candA,
+          discoveryID,
+        );
+        if (pairCreature && pairCreature !== baseCreature) {
+          pairCreature = applyChangeToCreature(
+            pairCreature,
+            candB,
+            discoveryID,
+          );
+          if (pairCreature) {
+            const emoji = selectCombinationEmoji([
+              candA.change.type,
+              candB.change.type,
+            ]);
+            combinedCandidates.push({
+              creature: pairCreature,
+              change: {
+                type: "combo-successful",
+                description:
+                  `${emoji} Combined ${candA.change.type} + ${candB.change.type}`,
+              },
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return combinedCandidates;
+}
+
+/**
+ * Apply a candidate's change to a creature, returning the modified creature.
+ */
+function applyChangeToCreature(
+  creature: Creature,
+  candidate: DiscoveryCandidate,
+  _discoveryID: string,
+): Creature | undefined {
+  const changeType = candidate.change.type;
+  const candidateJSON = candidate.creature.exportJSON();
+  const creatureJSON = creature.exportJSON();
+
+  try {
+    switch (changeType) {
+      case "add-synapses": {
+        // Find synapses in candidate that don't exist in creature
+        const existingSynapses = new Set(
+          creatureJSON.synapses.map((s) => `${s.fromUUID}->${s.toUUID}`),
+        );
+        const newSynapses = candidateJSON.synapses.filter(
+          (s) => !existingSynapses.has(`${s.fromUUID}->${s.toUUID}`),
+        );
+        if (newSynapses.length === 0) return creature;
+
+        creatureJSON.synapses.push(...newSynapses);
+        const result = Creature.fromJSON(creatureJSON);
+        delete result.uuid;
+        result.fix();
+        CreatureUtil.makeUUID(result);
+        return result;
+      }
+
+      case "add-neurons": {
+        // Find neurons in candidate that don't exist in creature
+        const existingNeurons = new Set(
+          creatureJSON.neurons.map((n) => n.uuid),
+        );
+        const candidateNeurons = candidateJSON.neurons.filter(
+          (n) => n.type === "hidden" && !existingNeurons.has(n.uuid),
+        );
+        if (candidateNeurons.length === 0) return creature;
+
+        // Find synapses connected to these new neurons
+        const newNeuronUUIDs = new Set(candidateNeurons.map((n) => n.uuid));
+        const newSynapses = candidateJSON.synapses.filter(
+          (s) => newNeuronUUIDs.has(s.fromUUID) || newNeuronUUIDs.has(s.toUUID),
+        );
+
+        // Insert neurons before outputs
+        const outputCount = creatureJSON.output ?? 1;
+        const outputOffset = creatureJSON.neurons.length - outputCount;
+        creatureJSON.neurons.splice(outputOffset, 0, ...candidateNeurons);
+        creatureJSON.synapses.push(...newSynapses);
+
+        const result = Creature.fromJSON(creatureJSON);
+        delete result.uuid;
+        result.fix();
+        CreatureUtil.makeUUID(result);
+        return result;
+      }
+
+      case "change-squash": {
+        // Copy squash changes from candidate
+        const candidateNeuronMap = new Map(
+          candidateJSON.neurons.map((n) => [n.uuid, n]),
+        );
+        let changed = false;
+        for (const neuron of creatureJSON.neurons) {
+          const candidateNeuron = candidateNeuronMap.get(neuron.uuid);
+          if (candidateNeuron && candidateNeuron.squash !== neuron.squash) {
+            neuron.squash = candidateNeuron.squash;
+            changed = true;
+          }
+        }
+        if (!changed) return creature;
+
+        const result = Creature.fromJSON(creatureJSON);
+        delete result.uuid;
+        result.fix();
+        CreatureUtil.makeUUID(result);
+        return result;
+      }
+
+      case "remove-synapse": {
+        // Find synapses removed in candidate
+        const candidateSynapses = new Set(
+          candidateJSON.synapses.map((s) => `${s.fromUUID}->${s.toUUID}`),
+        );
+        const removedSynapses = creatureJSON.synapses.filter(
+          (s) => !candidateSynapses.has(`${s.fromUUID}->${s.toUUID}`),
+        );
+        if (removedSynapses.length === 0) return creature;
+
+        creatureJSON.synapses = creatureJSON.synapses.filter((s) =>
+          candidateSynapses.has(`${s.fromUUID}->${s.toUUID}`)
+        );
+        const result = Creature.fromJSON(creatureJSON);
+        delete result.uuid;
+        result.fix();
+        CreatureUtil.makeUUID(result);
+        return result;
+      }
+
+      case "remove-neuron":
+      case "remove-low-impact": {
+        // Find neurons removed in candidate
+        const candidateNeurons = new Set(
+          candidateJSON.neurons.map((n) => n.uuid),
+        );
+        const removedNeurons = creatureJSON.neurons.filter(
+          (n) => n.type === "hidden" && !candidateNeurons.has(n.uuid),
+        );
+        if (removedNeurons.length === 0) return creature;
+
+        const removedUUIDs = new Set(removedNeurons.map((n) => n.uuid));
+        creatureJSON.neurons = creatureJSON.neurons.filter(
+          (n) => !removedUUIDs.has(n.uuid),
+        );
+        creatureJSON.synapses = creatureJSON.synapses.filter(
+          (s) => !removedUUIDs.has(s.fromUUID) && !removedUUIDs.has(s.toUUID),
+        );
+
+        const result = Creature.fromJSON(creatureJSON);
+        delete result.uuid;
+        result.fix();
+        CreatureUtil.makeUUID(result);
+        return result;
+      }
+
+      default:
+        // For combo types or unknown, just return the candidate's creature
+        // This shouldn't happen in two-phase scoring but provides a fallback
+        console.warn(
+          `[DiscoveryCandidates] Unknown change type for combination: ${changeType}`,
+        );
+        return undefined;
+    }
+  } catch (error) {
+    console.warn(
+      `[DiscoveryCandidates] Failed to apply ${changeType} change during combination:`,
+      error,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Select an appropriate emoji for the combination based on change types.
+ */
+function selectCombinationEmoji(types: string[]): string {
+  const typeSet = new Set(types);
+
+  // Fun, informative emoji selections based on what's being combined
+  if (typeSet.has("remove-low-impact") && typeSet.has("add-neurons")) {
+    return "🦋"; // Metamorphosis - shedding old, gaining new
+  }
+  if (typeSet.has("remove-low-impact") || typeSet.has("remove-neuron")) {
+    return "✂️"; // Pruning/trimming
+  }
+  if (typeSet.has("add-neurons") && typeSet.has("add-synapses")) {
+    return "🌱"; // Growing - adding structure
+  }
+  if (typeSet.has("change-squash")) {
+    return "🎭"; // Transformation - changing behaviour
+  }
+  if (typeSet.has("add-neurons")) {
+    return "🧠"; // Neural growth
+  }
+  if (typeSet.has("add-synapses")) {
+    return "🔗"; // Connecting
+  }
+  if (types.length >= 3) {
+    return "🏆"; // Triple or more combination - achievement!
+  }
+  return "🔬"; // Generic scientific discovery
 }

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -1110,7 +1110,7 @@ function wrapBestCandidate<
  */
 export function buildCombinedFromSuccessful(
   baseCreature: Creature,
-  discoveryID: string,
+  _discoveryID: string,
   successfulCandidates: DiscoveryCandidate[],
 ): DiscoveryCandidate[] {
   if (successfulCandidates.length < 2) {
@@ -1145,7 +1145,7 @@ export function buildCombinedFromSuccessful(
     const applied = applyChangeToCreature(
       combinedCreature,
       best,
-      discoveryID,
+      baseCreature,
     );
 
     if (applied && applied !== combinedCreature) {
@@ -1184,24 +1184,25 @@ export function buildCombinedFromSuccessful(
         // Skip if same type (already handled above)
         if (candidateA.change.type === candidateB.change.type) continue;
 
-        let pairCreature = applyChangeToCreature(
+        const afterA = applyChangeToCreature(
           baseCreature,
           candidateA,
-          discoveryID,
+          baseCreature,
         );
-        if (pairCreature && pairCreature !== baseCreature) {
-          pairCreature = applyChangeToCreature(
-            pairCreature,
+        if (afterA && afterA !== baseCreature) {
+          const afterBoth = applyChangeToCreature(
+            afterA,
             candidateB,
-            discoveryID,
+            baseCreature,
           );
-          if (pairCreature) {
+          // Verify candidateB actually changed something (not just returned afterA unchanged)
+          if (afterBoth && afterBoth !== afterA) {
             const emoji = selectCombinationEmoji([
               candidateA.change.type,
               candidateB.change.type,
             ]);
             combinedCandidates.push({
-              creature: pairCreature,
+              creature: afterBoth,
               change: {
                 type: "combo-successful",
                 description:
@@ -1219,15 +1220,20 @@ export function buildCombinedFromSuccessful(
 
 /**
  * Apply a candidate's change to a creature, returning the modified creature.
+ *
+ * @param creature The creature to apply the change to (may have prior modifications)
+ * @param candidate The candidate containing the change to apply
+ * @param baseCreature The original creature before any changes (used for removal detection)
  */
 function applyChangeToCreature(
   creature: Creature,
   candidate: DiscoveryCandidate,
-  _discoveryID: string,
+  baseCreature: Creature,
 ): Creature | undefined {
   const changeType = candidate.change.type;
   const candidateJSON = candidate.creature.exportJSON();
   const creatureJSON = creature.exportJSON();
+  const baseJSON = baseCreature.exportJSON();
 
   try {
     switch (changeType) {
@@ -1301,18 +1307,39 @@ function applyChangeToCreature(
       }
 
       case "remove-synapse": {
-        // Find synapses removed in candidate
+        // Find synapses that were in base but removed in candidate
+        // This ensures we only remove what the candidate intended to remove,
+        // not synapses added by previous operations in the combination
+        const baseSynapses = new Set(
+          baseJSON.synapses.map((s) => `${s.fromUUID}->${s.toUUID}`),
+        );
         const candidateSynapses = new Set(
           candidateJSON.synapses.map((s) => `${s.fromUUID}->${s.toUUID}`),
         );
-        const removedSynapses = creatureJSON.synapses.filter(
-          (s) => !candidateSynapses.has(`${s.fromUUID}->${s.toUUID}`),
+        const creatureSynapses = new Set(
+          creatureJSON.synapses.map((s) => `${s.fromUUID}->${s.toUUID}`),
         );
-        if (removedSynapses.length === 0) return creature;
 
-        creatureJSON.synapses = creatureJSON.synapses.filter((s) =>
-          candidateSynapses.has(`${s.fromUUID}->${s.toUUID}`)
+        // Synapses to remove: existed in base but not in candidate
+        const toRemove = new Set(
+          [...baseSynapses].filter((key) => !candidateSynapses.has(key)),
         );
+
+        // Also add reconnection synapses: new in candidate but not in creature
+        // These maintain connectivity after removal
+        const toAdd = candidateJSON.synapses.filter(
+          (s) =>
+            !baseSynapses.has(`${s.fromUUID}->${s.toUUID}`) &&
+            !creatureSynapses.has(`${s.fromUUID}->${s.toUUID}`),
+        );
+
+        if (toRemove.size === 0 && toAdd.length === 0) return creature;
+
+        creatureJSON.synapses = creatureJSON.synapses.filter(
+          (s) => !toRemove.has(`${s.fromUUID}->${s.toUUID}`),
+        );
+        creatureJSON.synapses.push(...toAdd);
+
         const result = Creature.fromJSON(creatureJSON);
         delete result.uuid;
         result.fix();
@@ -1322,22 +1349,46 @@ function applyChangeToCreature(
 
       case "remove-neuron":
       case "remove-low-impact": {
-        // Find neurons removed in candidate
+        // Find neurons that were in base but removed in candidate
+        // This ensures we only remove what the candidate intended to remove,
+        // not neurons added by previous operations in the combination
+        const baseNeurons = new Set(
+          baseJSON.neurons.filter((n) => n.type === "hidden").map((n) =>
+            n.uuid
+          ),
+        );
         const candidateNeurons = new Set(
           candidateJSON.neurons.map((n) => n.uuid),
         );
-        const removedNeurons = creatureJSON.neurons.filter(
-          (n) => n.type === "hidden" && !candidateNeurons.has(n.uuid),
+        const baseSynapses = new Set(
+          baseJSON.synapses.map((s) => `${s.fromUUID}->${s.toUUID}`),
         );
-        if (removedNeurons.length === 0) return creature;
+        const creatureSynapses = new Set(
+          creatureJSON.synapses.map((s) => `${s.fromUUID}->${s.toUUID}`),
+        );
 
-        const removedUUIDs = new Set(removedNeurons.map((n) => n.uuid));
+        // Neurons to remove: existed in base (as hidden) but not in candidate
+        const toRemove = new Set(
+          [...baseNeurons].filter((uuid) => !candidateNeurons.has(uuid)),
+        );
+
+        // Also add reconnection synapses: new in candidate but not in creature
+        // These maintain connectivity after neuron removal
+        const toAdd = candidateJSON.synapses.filter(
+          (s) =>
+            !baseSynapses.has(`${s.fromUUID}->${s.toUUID}`) &&
+            !creatureSynapses.has(`${s.fromUUID}->${s.toUUID}`),
+        );
+
+        if (toRemove.size === 0 && toAdd.length === 0) return creature;
+
         creatureJSON.neurons = creatureJSON.neurons.filter(
-          (n) => !removedUUIDs.has(n.uuid),
+          (n) => !toRemove.has(n.uuid),
         );
         creatureJSON.synapses = creatureJSON.synapses.filter(
-          (s) => !removedUUIDs.has(s.fromUUID) && !removedUUIDs.has(s.toUUID),
+          (s) => !toRemove.has(s.fromUUID) && !toRemove.has(s.toUUID),
         );
+        creatureJSON.synapses.push(...toAdd);
 
         const result = Creature.fromJSON(creatureJSON);
         delete result.uuid;

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -11,6 +11,7 @@ import type { Creature } from "../Creature.ts";
 import type { NeatOptions } from "../config/NeatOptions.ts";
 import { createNeatConfig, type NeatConfig } from "../config/NeatConfig.ts";
 import {
+  buildCombinedFromSuccessful,
   buildDiscoveryCandidates,
   type DiscoveredNeuronDetails,
   type DiscoveryChangeType,
@@ -48,6 +49,7 @@ export interface DiscoveryRunnerDeps {
   candidateBuilder?: (
     creature: Creature,
     discovery: DiscoverResult,
+    options?: { skipCombinedCandidates?: boolean },
   ) => DiscoveryCandidate[];
   rustDiscoveryEnabled?: () => boolean;
 }
@@ -123,6 +125,7 @@ export class DiscoveryRunner {
   #candidateBuilder: (
     creature: Creature,
     discovery: DiscoverResult,
+    options?: { skipCombinedCandidates?: boolean },
   ) => DiscoveryCandidate[];
   #rustDiscoveryEnabled: () => boolean;
 
@@ -229,20 +232,30 @@ export class DiscoveryRunner {
       );
       markPhase("Discovery phase", discoveryStart);
 
+      // ======================================================================
+      // TWO-PHASE DISCOVERY SCORING
+      // ======================================================================
+      // Phase 1: Build and evaluate SINGLE candidates (no combos)
+      // Phase 2: Combine only successful candidates and evaluate combos
+      // ======================================================================
+
       const candidateBuildStart = performance.now();
-      const candidates = this.#candidateBuilder(
+
+      // Phase 1: Build single candidates only (skip combined candidates)
+      const singleCandidates = this.#candidateBuilder(
         creature,
         discoverResult,
+        { skipCombinedCandidates: true },
       );
       verboseLog(
-        `Built ${candidates.length} candidate creature${
-          candidates.length === 1 ? "" : "s"
-        }: ${candidates.map((c) => c.change.type).join(", ") || "none"}.`,
+        `[Phase 1] Built ${singleCandidates.length} single candidate creature${
+          singleCandidates.length === 1 ? "" : "s"
+        }: ${singleCandidates.map((c) => c.change.type).join(", ") || "none"}.`,
       );
 
-      const { filtered: filteredCandidates, skipped } = this
+      const { filtered: filteredSingleCandidates, skipped } = this
         .#filterCandidatesForEvaluation(
-          candidates,
+          singleCandidates,
           workerCount,
           config,
         );
@@ -263,37 +276,113 @@ export class DiscoveryRunner {
           }.`,
         );
       }
-      markPhase("Candidate synthesis", candidateBuildStart);
+      markPhase("Candidate synthesis (Phase 1)", candidateBuildStart);
 
-      const evaluationTasks: Array<{
+      // Phase 1 evaluation: Score single candidates + original
+      const phase1Tasks: Array<{
         kind: "original" | "candidate";
         creature: Creature;
         candidate?: DiscoveryCandidate;
       }> = [
         { kind: "original", creature },
-        ...filteredCandidates.map((candidate) => ({
+        ...filteredSingleCandidates.map((candidate) => ({
           kind: "candidate" as const,
           creature: candidate.creature,
           candidate,
         })),
       ];
 
-      const evaluationStart = performance.now();
-      const evaluationResults = await this.#evaluateAll(
+      const phase1Start = performance.now();
+      const phase1Results = await this.#evaluateAll(
         workers,
-        evaluationTasks,
+        phase1Tasks,
         config.feedbackLoop,
         config.costOfGrowth,
         verboseLogging,
       );
-      const reScoringTime = performance.now() - evaluationStart;
-      markPhase("Candidate evaluation", evaluationStart);
+      const phase1Time = performance.now() - phase1Start;
+      markPhase("Phase 1 evaluation (singles)", phase1Start);
 
-      const original = evaluationResults.find((result) =>
+      const original = phase1Results.find((result) =>
         result.kind === "original"
       );
       assert(original, "Original creature was not evaluated");
 
+      // Find successful single candidates (improved score)
+      const successfulSingles = phase1Results
+        .filter((result) => result.kind === "candidate")
+        .filter((result) => result.score > original.score);
+
+      verboseLog(
+        `[Phase 1] Found ${successfulSingles.length} successful single candidate${
+          successfulSingles.length === 1 ? "" : "s"
+        } out of ${phase1Tasks.length - 1} evaluated.`,
+      );
+
+      // Phase 2: Build and evaluate combined candidates from successful singles
+      let phase2Results: typeof phase1Results = [];
+      let phase2Time = 0;
+
+      if (successfulSingles.length >= 2) {
+        const phase2Start = performance.now();
+
+        // Extract successful candidates for combination
+        const successfulCandidates = successfulSingles
+          .map((result) => result.candidate)
+          .filter((c): c is DiscoveryCandidate => c !== undefined);
+
+        // Build combined candidates from successful singles only
+        const combinedCandidates = buildCombinedFromSuccessful(
+          creature,
+          discoverResult.ID,
+          successfulCandidates,
+        );
+
+        if (combinedCandidates.length > 0) {
+          verboseLog(
+            `[Phase 2] Built ${combinedCandidates.length} combined candidate${
+              combinedCandidates.length === 1 ? "" : "s"
+            } from ${successfulSingles.length} successful singles.`,
+          );
+
+          // Filter combined candidates (apply same thresholds)
+          const { filtered: filteredCombos } = this
+            .#filterCandidatesForEvaluation(
+              combinedCandidates,
+              workerCount,
+              config,
+            );
+
+          if (filteredCombos.length > 0) {
+            const phase2Tasks = filteredCombos.map((candidate) => ({
+              kind: "candidate" as const,
+              creature: candidate.creature,
+              candidate,
+            }));
+
+            phase2Results = await this.#evaluateAll(
+              workers,
+              phase2Tasks,
+              config.feedbackLoop,
+              config.costOfGrowth,
+              verboseLogging,
+            );
+          }
+        }
+
+        phase2Time = performance.now() - phase2Start;
+        markPhase("Phase 2 evaluation (combos)", phase2Start);
+      } else {
+        verboseLog(
+          `[Phase 2] Skipped - need 2+ successful singles for combination (found ${successfulSingles.length}).`,
+        );
+      }
+
+      // Combine all evaluation results
+      const evaluationResults = [...phase1Results, ...phase2Results];
+      const reScoringTime = phase1Time + phase2Time;
+
+      // Find the best improvement across all candidates (single and combined)
       const improved = evaluationResults
         .filter((result) => result.kind === "candidate")
         .filter((result) => result.score > original.score)
@@ -360,10 +449,15 @@ export class DiscoveryRunner {
 
       if (verboseLogging && reScoringTime > 0) {
         const formattedTime = format(reScoringTime, { ignoreZero: true });
+        const totalCandidates = evaluationResults.length - 1; // Exclude original
+        const phase1Count = phase1Tasks.length - 1;
+        const phase2Count = phase2Results.length;
         verboseLog(
-          `Re-scoring phase: ${formattedTime} (${
-            evaluationTasks.length - 1
-          } candidate${evaluationTasks.length - 1 === 1 ? "" : "s"} evaluated)`,
+          `Re-scoring complete: ${formattedTime} total (${totalCandidates} candidate${
+            totalCandidates === 1 ? "" : "s"
+          } evaluated: ${phase1Count} single${
+            phase2Count > 0 ? ` + ${phase2Count} combo` : ""
+          })`,
         );
       }
 

--- a/test/discovery/CombinedCandidateSequentialApplication.ts
+++ b/test/discovery/CombinedCandidateSequentialApplication.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for sequential application of discovery candidates.
+ *
+ * Verifies that when combining "add" and "remove" operations,
+ * newly added elements are NOT incorrectly removed.
+ *
+ * Bug scenario:
+ * - "add-neurons" runs before "remove-neuron" (alphabetical sorting)
+ * - Remove logic compares creature (with new neurons) to candidate (built from base)
+ * - New neurons incorrectly identified as "removed" because they're not in candidate
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { Creature } from "../../src/Creature.ts";
+import {
+  buildCombinedFromSuccessful,
+  type DiscoveryCandidate,
+} from "../../src/discovery/DiscoveryCandidates.ts";
+
+/**
+ * Creates a base creature with known structure for testing.
+ */
+function makeTestCreature() {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-A", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "hidden-B", squash: "IDENTITY", bias: 0.1 },
+      { type: "hidden", uuid: "hidden-C", squash: "IDENTITY", bias: 0.2 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-A", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-B", weight: 0.5 },
+      { fromUUID: "hidden-A", toUUID: "hidden-C", weight: 0.3 },
+      { fromUUID: "hidden-B", toUUID: "hidden-C", weight: 0.3 },
+      { fromUUID: "hidden-C", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+Deno.test(
+  "buildCombinedFromSuccessful: add-neurons + remove-neuron preserves added neurons",
+  () => {
+    const base = makeTestCreature();
+    const baseJSON = base.exportJSON();
+
+    // Create "add-neurons" candidate: adds hidden-D
+    const addNeuronsJSON = structuredClone(baseJSON);
+    const outputIndex = addNeuronsJSON.neurons.findIndex((n) =>
+      n.type === "output"
+    );
+    addNeuronsJSON.neurons.splice(outputIndex, 0, {
+      type: "hidden",
+      uuid: "hidden-D",
+      squash: "TANH",
+      bias: 0.15,
+    });
+    addNeuronsJSON.synapses.push(
+      { fromUUID: "input-0", toUUID: "hidden-D", weight: 0.4 },
+      { fromUUID: "hidden-D", toUUID: "output-0", weight: 0.4 },
+    );
+    const addNeuronsCreature = Creature.fromJSON(addNeuronsJSON);
+    delete addNeuronsCreature.uuid;
+    addNeuronsCreature.fix();
+    CreatureUtil.makeUUID(addNeuronsCreature);
+
+    const addNeuronsCandidate: DiscoveryCandidate = {
+      creature: addNeuronsCreature,
+      change: {
+        type: "add-neurons",
+        description: "Added hidden-D neuron",
+      },
+    };
+
+    // Create "remove-neuron" candidate: removes hidden-C
+    const removeNeuronJSON = structuredClone(baseJSON);
+    removeNeuronJSON.neurons = removeNeuronJSON.neurons.filter(
+      (n) => n.uuid !== "hidden-C",
+    );
+    removeNeuronJSON.synapses = removeNeuronJSON.synapses.filter(
+      (s) => s.fromUUID !== "hidden-C" && s.toUUID !== "hidden-C",
+    );
+    // Reconnect A and B directly to output
+    removeNeuronJSON.synapses.push(
+      { fromUUID: "hidden-A", toUUID: "output-0", weight: 0.3 },
+      { fromUUID: "hidden-B", toUUID: "output-0", weight: 0.3 },
+    );
+    const removeNeuronCreature = Creature.fromJSON(removeNeuronJSON);
+    delete removeNeuronCreature.uuid;
+    removeNeuronCreature.fix();
+    CreatureUtil.makeUUID(removeNeuronCreature);
+
+    const removeNeuronCandidate: DiscoveryCandidate = {
+      creature: removeNeuronCreature,
+      change: {
+        type: "remove-neuron",
+        description: "Removed hidden-C neuron",
+      },
+    };
+
+    // Build combined candidates
+    const combined = buildCombinedFromSuccessful(
+      base,
+      "TEST_DISCOVERY",
+      [addNeuronsCandidate, removeNeuronCandidate],
+    );
+
+    // Should have at least one combined candidate
+    assertExists(combined.length > 0, "Should produce combined candidates");
+
+    // Find the combo-successful candidate
+    const combo = combined.find((c) => c.change.type === "combo-successful");
+    assertExists(combo, "Should have a combo-successful candidate");
+
+    const comboJSON = combo.creature.exportJSON();
+    const hiddenNeurons = comboJSON.neurons.filter((n) => n.type === "hidden");
+    const neuronUUIDs = hiddenNeurons.map((n) => n.uuid);
+
+    // Critical assertion: hidden-D (added) should exist
+    assertEquals(
+      neuronUUIDs.includes("hidden-D"),
+      true,
+      `Added neuron hidden-D should be preserved. Found neurons: ${
+        neuronUUIDs.join(", ")
+      }`,
+    );
+
+    // hidden-C (removed) should NOT exist
+    assertEquals(
+      neuronUUIDs.includes("hidden-C"),
+      false,
+      `Removed neuron hidden-C should not exist. Found neurons: ${
+        neuronUUIDs.join(", ")
+      }`,
+    );
+
+    // Original neurons A and B should still exist
+    assertEquals(
+      neuronUUIDs.includes("hidden-A"),
+      true,
+      "Original neuron hidden-A should exist",
+    );
+    assertEquals(
+      neuronUUIDs.includes("hidden-B"),
+      true,
+      "Original neuron hidden-B should exist",
+    );
+
+    // Final expected structure: A, B, D (not C)
+    assertEquals(
+      hiddenNeurons.length,
+      3,
+      `Should have 3 hidden neurons (A, B, D). Found: ${
+        neuronUUIDs.join(", ")
+      }`,
+    );
+  },
+);
+
+Deno.test(
+  "buildCombinedFromSuccessful: add-synapses + remove-synapse preserves added synapses",
+  () => {
+    const base = makeTestCreature();
+    const baseJSON = base.exportJSON();
+
+    // Create "add-synapses" candidate: adds input-1 -> hidden-A synapse
+    const addSynapsesJSON = structuredClone(baseJSON);
+    addSynapsesJSON.synapses.push({
+      fromUUID: "input-1",
+      toUUID: "hidden-A",
+      weight: 0.35,
+    });
+    const addSynapsesCreature = Creature.fromJSON(addSynapsesJSON);
+    delete addSynapsesCreature.uuid;
+    addSynapsesCreature.fix();
+    CreatureUtil.makeUUID(addSynapsesCreature);
+
+    const addSynapsesCandidate: DiscoveryCandidate = {
+      creature: addSynapsesCreature,
+      change: {
+        type: "add-synapses",
+        description: "Added input-1 -> hidden-A synapse",
+      },
+    };
+
+    // Create "remove-synapse" candidate: removes hidden-A -> hidden-C synapse
+    const removeSynapseJSON = structuredClone(baseJSON);
+    removeSynapseJSON.synapses = removeSynapseJSON.synapses.filter(
+      (s) => !(s.fromUUID === "hidden-A" && s.toUUID === "hidden-C"),
+    );
+    // Reconnect hidden-A directly to output
+    removeSynapseJSON.synapses.push({
+      fromUUID: "hidden-A",
+      toUUID: "output-0",
+      weight: 0.25,
+    });
+    const removeSynapseCreature = Creature.fromJSON(removeSynapseJSON);
+    delete removeSynapseCreature.uuid;
+    removeSynapseCreature.fix();
+    CreatureUtil.makeUUID(removeSynapseCreature);
+
+    const removeSynapseCandidate: DiscoveryCandidate = {
+      creature: removeSynapseCreature,
+      change: {
+        type: "remove-synapse",
+        description: "Removed hidden-A -> hidden-C synapse",
+      },
+    };
+
+    // Build combined candidates
+    const combined = buildCombinedFromSuccessful(
+      base,
+      "TEST_DISCOVERY",
+      [addSynapsesCandidate, removeSynapseCandidate],
+    );
+
+    // Should have at least one combined candidate
+    assertExists(combined.length > 0, "Should produce combined candidates");
+
+    // Find the combo-successful candidate
+    const combo = combined.find((c) => c.change.type === "combo-successful");
+    assertExists(combo, "Should have a combo-successful candidate");
+
+    const comboJSON = combo.creature.exportJSON();
+    const synapseKeys = comboJSON.synapses.map((s) =>
+      `${s.fromUUID}->${s.toUUID}`
+    );
+
+    // Critical assertion: added synapse should exist
+    assertEquals(
+      synapseKeys.includes("input-1->hidden-A"),
+      true,
+      `Added synapse input-1->hidden-A should be preserved. Found synapses: ${
+        synapseKeys.join(", ")
+      }`,
+    );
+
+    // Removed synapse should NOT exist
+    assertEquals(
+      synapseKeys.includes("hidden-A->hidden-C"),
+      false,
+      `Removed synapse hidden-A->hidden-C should not exist. Found synapses: ${
+        synapseKeys.join(", ")
+      }`,
+    );
+  },
+);

--- a/test/discovery/CombinedCandidateSequentialApplication.ts
+++ b/test/discovery/CombinedCandidateSequentialApplication.ts
@@ -10,7 +10,7 @@
  * - New neurons incorrectly identified as "removed" because they're not in candidate
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import { Creature } from "../../src/Creature.ts";
 import {
@@ -112,7 +112,7 @@ Deno.test(
     );
 
     // Should have at least one combined candidate
-    assertExists(combined.length > 0, "Should produce combined candidates");
+    assert(combined.length > 0, "Should produce combined candidates");
 
     // Find the combo-successful candidate
     const combo = combined.find((c) => c.change.type === "combo-successful");
@@ -221,7 +221,7 @@ Deno.test(
     );
 
     // Should have at least one combined candidate
-    assertExists(combined.length > 0, "Should produce combined candidates");
+    assert(combined.length > 0, "Should produce combined candidates");
 
     // Find the combo-successful candidate
     const combo = combined.find((c) => c.change.type === "combo-successful");

--- a/test/discovery/TwoPhaseDiscoveryScoring.ts
+++ b/test/discovery/TwoPhaseDiscoveryScoring.ts
@@ -1,0 +1,501 @@
+/**
+ * Tests for two-phase discovery scoring.
+ *
+ * The two-phase approach:
+ * 1. Phase 1: Score all SINGLE candidates first
+ * 2. Phase 2: Only combine candidates that improved (score > original)
+ *
+ * This ensures combined creatures are only built from proven successful candidates,
+ * rather than combining changes that individually don't work.
+ */
+
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import type { NeatOptions } from "../../src/config/NeatOptions.ts";
+import { Creature } from "../../src/Creature.ts";
+import type { DiscoveryRunnerWorker } from "../../src/discovery/DiscoveryRunner.ts";
+import { DiscoveryRunner } from "../../src/discovery/DiscoveryRunner.ts";
+
+function makeBaseCreature() {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: -0.25 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+class FakeWorker implements DiscoveryRunnerWorker {
+  #discoverResult: DiscoverResult;
+  #computeError: (creature: Creature) => number;
+  evaluationCallCount = 0;
+
+  constructor(
+    discoverResult: DiscoverResult,
+    computeError: (creature: Creature) => number,
+  ) {
+    this.#discoverResult = discoverResult;
+    this.#computeError = computeError;
+  }
+
+  discover(
+    _creature: Creature,
+    _options: NeatOptions,
+  ): Promise<Awaited<ReturnType<DiscoveryRunnerWorker["discover"]>>> {
+    return Promise.resolve({
+      taskID: 1,
+      duration: 10,
+      discover: this.#discoverResult,
+    });
+  }
+
+  evaluate(
+    creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<Awaited<ReturnType<DiscoveryRunnerWorker["evaluate"]>>> {
+    this.evaluationCallCount++;
+    const error = this.#computeError(creature);
+    return Promise.resolve({
+      taskID: 2,
+      duration: 5,
+      evaluate: {
+        error,
+      },
+    });
+  }
+
+  terminate(): void {
+    // no-op for fake worker
+  }
+}
+
+function makeOptions(overrides: NeatOptions = {}): NeatOptions {
+  return {
+    discoveryRecordTimeOutMinutes: 0.05,
+    discoveryAnalysisTimeoutMinutes: 0.05,
+    threads: 4, // Use multiple threads for parallel scoring
+    costOfGrowth: 0,
+    costName: "MSE",
+    ...overrides,
+  };
+}
+
+Deno.test(
+  "DiscoveryRunner two-phase scoring: only combines successful candidates",
+  async () => {
+    // Scenario:
+    // - Candidate A (synapse) - successful (reduces error)
+    // - Candidate B (neuron) - successful (reduces error)
+    // - Combined A+B - should be even better
+    // - Candidate C (squash) - NOT successful (increases error)
+    //
+    // Combined creature should only combine A + B (not C).
+
+    const helpfulSynapse = {
+      fromNeuronUUID: "input-1",
+      toNeuronUUID: "hidden-1",
+      weight: 0.45,
+      expectedImprovementPercentage: 0.2,
+      improvedCount: 4,
+      totalCount: 6,
+    };
+    const helpfulNeuron = {
+      fromNeuronUUID: "input-0",
+      toNeuronUUID: "hidden-1",
+      incomingWeight: 0.4,
+      outgoingWeight: -0.3,
+      squash: "TANH",
+      bias: 0.05,
+      expectedImprovementPercentage: 0.22,
+      improvedCount: 5,
+      totalCount: 7,
+    };
+    // This squash change doesn't actually help in this scenario
+    const unhelpfulSquash = {
+      neuronUUID: "hidden-1",
+      previousSquash: "IDENTITY",
+      squash: "STEP",
+      expectedImprovementPercentage: 0.18,
+      improvedError: 0.03,
+      currentError: 0.07,
+    };
+
+    const discoveryResult: DiscoverResult = {
+      ID: "TWO_PHASE_TEST",
+      addHelpfulSynapses: [helpfulSynapse],
+      addHelpfulNeurons: [helpfulNeuron],
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: [unhelpfulSquash],
+    };
+
+    const baseError = 0.5;
+
+    const computeError = (creature: Creature) => {
+      const json = creature.exportJSON();
+      const synapses = json.synapses;
+      const neurons = json.neurons;
+
+      // Check for helpful synapse
+      const hasHelpfulSynapse = synapses.some((synapse) =>
+        synapse.fromUUID === helpfulSynapse.fromNeuronUUID &&
+        synapse.toUUID === helpfulSynapse.toNeuronUUID &&
+        Math.abs(synapse.weight - helpfulSynapse.weight) < 1e-6
+      );
+
+      // Check for helpful neuron (look for a new hidden neuron with TANH squash)
+      const incomingDiscoverySynapse = synapses.find((synapse) =>
+        synapse.fromUUID === helpfulNeuron.fromNeuronUUID &&
+        Math.abs(synapse.weight - helpfulNeuron.incomingWeight) < 1e-6
+      );
+      const discoveredNeuronUUID = incomingDiscoverySynapse?.toUUID;
+      const hasHelpfulNeuron = Boolean(
+        discoveredNeuronUUID &&
+          neurons.some((neuron) =>
+            neuron.uuid === discoveredNeuronUUID && neuron.squash === "TANH"
+          ),
+      );
+
+      // Check for unhelpful squash (hidden-1 changed to STEP)
+      const hidden1 = neurons.find((neuron) => neuron.uuid === "hidden-1");
+      const hasUnhelpfulSquash = hidden1?.squash === "STEP";
+
+      // Assign errors based on what changes are present:
+      // - Both helpful changes: best result (0.3)
+      // - Just helpful synapse: 0.4
+      // - Just helpful neuron: 0.4
+      // - Unhelpful squash: WORSE (0.55)
+      // - Original: 0.5
+
+      if (hasHelpfulSynapse && hasHelpfulNeuron && !hasUnhelpfulSquash) {
+        return 0.3; // Best - combined successful candidates
+      }
+      if (hasHelpfulSynapse && hasHelpfulNeuron && hasUnhelpfulSquash) {
+        return 0.35; // Combined with bad squash - still okay but not best
+      }
+      if (hasHelpfulSynapse && !hasUnhelpfulSquash) {
+        return 0.4; // Good improvement from synapse
+      }
+      if (hasHelpfulNeuron && !hasUnhelpfulSquash) {
+        return 0.4; // Good improvement from neuron
+      }
+      if (hasUnhelpfulSquash) {
+        return 0.55; // Worse than original - squash hurts
+      }
+      return baseError;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          computeError,
+        ),
+    });
+
+    const result = await runner.discoverDir({
+      creature: makeBaseCreature(),
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    // Should have an improvement
+    assertExists(result.improvement, "Should find an improvement");
+
+    // The best result should be the combined successful candidates (error=0.3)
+    // not including the unhelpful squash change
+    assertEquals(
+      result.improvement.error < 0.35,
+      true,
+      `Best improvement should have error < 0.35 (combined successful), got ${result.improvement.error}`,
+    );
+
+    // Check evaluations
+    assertExists(result.evaluations, "Should have evaluation summaries");
+
+    // The squash-only candidate should show no improvement
+    const squashOnlyEval = result.evaluations.find(
+      (e) => e.changeType === "change-squash" && e.kind === "candidate",
+    );
+    if (squashOnlyEval) {
+      assertEquals(
+        squashOnlyEval.improved,
+        false,
+        "Squash-only candidate should show no improvement",
+      );
+    }
+
+    // Verify the improvement message includes an emoji
+    assert(
+      /[\u{1F300}-\u{1F9FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/u.test(
+        result.improvement.message,
+      ),
+      `Improvement message should include an emoji, got: ${result.improvement.message}`,
+    );
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner two-phase scoring: returns single candidate when no combinations improve",
+  async () => {
+    // Scenario: Only one candidate improves, so no combination phase
+
+    const helpfulSynapse = {
+      fromNeuronUUID: "input-1",
+      toNeuronUUID: "hidden-1",
+      weight: 0.45,
+      expectedImprovementPercentage: 0.2,
+      improvedCount: 4,
+      totalCount: 6,
+    };
+
+    const discoveryResult: DiscoverResult = {
+      ID: "SINGLE_SUCCESS",
+      addHelpfulSynapses: [helpfulSynapse],
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const computeError = (creature: Creature) => {
+      const json = creature.exportJSON();
+      const hasHelpful = json.synapses.some((synapse) =>
+        synapse.fromUUID === helpfulSynapse.fromNeuronUUID &&
+        synapse.toUUID === helpfulSynapse.toNeuronUUID &&
+        Math.abs(synapse.weight - helpfulSynapse.weight) < 1e-6
+      );
+      return hasHelpful ? 0.4 : 0.5;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          computeError,
+        ),
+    });
+
+    const result = await runner.discoverDir({
+      creature: makeBaseCreature(),
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    assertExists(result.improvement, "Should find single improvement");
+    assertEquals(
+      result.improvement.changeType.includes("combo"),
+      false,
+      "Should be a single candidate improvement, not a combo",
+    );
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner two-phase scoring: no combination phase when only one candidate succeeds",
+  async () => {
+    // Only one of multiple candidates improves, so no combination should be attempted
+
+    const helpfulSynapse = {
+      fromNeuronUUID: "input-1",
+      toNeuronUUID: "hidden-1",
+      weight: 0.45,
+      expectedImprovementPercentage: 0.2,
+      improvedCount: 4,
+      totalCount: 6,
+    };
+    // This neuron doesn't help
+    const unhelpfulNeuron = {
+      fromNeuronUUID: "input-0",
+      toNeuronUUID: "hidden-1",
+      incomingWeight: 0.4,
+      outgoingWeight: -0.3,
+      squash: "TANH",
+      bias: 0.05,
+      expectedImprovementPercentage: 0.22,
+      improvedCount: 5,
+      totalCount: 7,
+    };
+
+    const discoveryResult: DiscoverResult = {
+      ID: "ONE_SUCCESS_ONLY",
+      addHelpfulSynapses: [helpfulSynapse],
+      addHelpfulNeurons: [unhelpfulNeuron],
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const computeError = (creature: Creature) => {
+      const json = creature.exportJSON();
+      const synapses = json.synapses;
+      const neurons = json.neurons;
+
+      // Check for synapse (improves)
+      const hasHelpfulSynapse = synapses.some((synapse) =>
+        synapse.fromUUID === helpfulSynapse.fromNeuronUUID &&
+        synapse.toUUID === helpfulSynapse.toNeuronUUID &&
+        Math.abs(synapse.weight - helpfulSynapse.weight) < 1e-6
+      );
+
+      // Check for neuron (doesn't improve, makes it worse)
+      const incomingDiscoverySynapse = synapses.find((synapse) =>
+        synapse.fromUUID === unhelpfulNeuron.fromNeuronUUID &&
+        Math.abs(synapse.weight - unhelpfulNeuron.incomingWeight) < 1e-6
+      );
+      const discoveredNeuronUUID = incomingDiscoverySynapse?.toUUID;
+      const hasUnhelpfulNeuron = Boolean(
+        discoveredNeuronUUID &&
+          neurons.some((neuron) =>
+            neuron.uuid === discoveredNeuronUUID && neuron.squash === "TANH"
+          ),
+      );
+
+      if (hasHelpfulSynapse && hasUnhelpfulNeuron) {
+        return 0.45; // Combined - neuron adds overhead
+      }
+      if (hasHelpfulSynapse) {
+        return 0.4; // Best result - synapse alone
+      }
+      if (hasUnhelpfulNeuron) {
+        return 0.55; // Worse - neuron alone hurts
+      }
+      return 0.5;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          computeError,
+        ),
+    });
+
+    const result = await runner.discoverDir({
+      creature: makeBaseCreature(),
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    assertExists(result.improvement, "Should find an improvement");
+    // The best should be synapse-only (error=0.4), not combined (error=0.45)
+    assertEquals(
+      result.improvement.error,
+      0.4,
+      "Best improvement should be synapse-only with error 0.4",
+    );
+
+    // Verify it's not a combo type
+    assertEquals(
+      result.improvement.changeType.includes("combo"),
+      false,
+      `Should be a single candidate, not combo. Got: ${result.improvement.changeType}`,
+    );
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner two-phase scoring: combination outperforms individual candidates",
+  async () => {
+    // Two candidates individually improve, and combined they're even better
+
+    const helpfulSynapse = {
+      fromNeuronUUID: "input-1",
+      toNeuronUUID: "hidden-1",
+      weight: 0.45,
+      expectedImprovementPercentage: 0.2,
+      improvedCount: 4,
+      totalCount: 6,
+    };
+    const helpfulSquash = {
+      neuronUUID: "hidden-1",
+      previousSquash: "IDENTITY",
+      squash: "TANH",
+      expectedImprovementPercentage: 0.15,
+      improvedError: 0.03,
+      currentError: 0.07,
+    };
+
+    const discoveryResult: DiscoverResult = {
+      ID: "COMBO_WINS",
+      addHelpfulSynapses: [helpfulSynapse],
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: [helpfulSquash],
+    };
+
+    const computeError = (creature: Creature) => {
+      const json = creature.exportJSON();
+
+      const hasHelpfulSynapse = json.synapses.some((synapse) =>
+        synapse.fromUUID === helpfulSynapse.fromNeuronUUID &&
+        synapse.toUUID === helpfulSynapse.toNeuronUUID &&
+        Math.abs(synapse.weight - helpfulSynapse.weight) < 1e-6
+      );
+
+      const hidden1 = json.neurons.find((neuron) => neuron.uuid === "hidden-1");
+      const hasHelpfulSquash = hidden1?.squash === "TANH";
+
+      // Combined is best
+      if (hasHelpfulSynapse && hasHelpfulSquash) {
+        return 0.3; // Combined - best
+      }
+      if (hasHelpfulSynapse) {
+        return 0.4; // Synapse alone
+      }
+      if (hasHelpfulSquash) {
+        return 0.42; // Squash alone
+      }
+      return 0.5;
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(
+          discoveryResult,
+          computeError,
+        ),
+    });
+
+    const result = await runner.discoverDir({
+      creature: makeBaseCreature(),
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    assertExists(result.improvement, "Should find an improvement");
+
+    // The best should be the combination (error=0.3)
+    assertEquals(
+      result.improvement.error,
+      0.3,
+      `Best improvement should be combined with error 0.3, got ${result.improvement.error}`,
+    );
+
+    // The change type should indicate it's a combination of successful candidates
+    assert(
+      result.improvement.changeType.includes("combo"),
+      `Should be a combo type, got: ${result.improvement.changeType}`,
+    );
+  },
+);


### PR DESCRIPTION
- Bumped version in deno.json to 0.231.0.
- Added a new change type "combo-successful" to track successful combinations of candidates.
- Introduced options for skipping combined candidates during the discovery process, allowing for two-phase scoring.
- Enhanced the buildDiscoveryCandidates function to support the new options and improve candidate evaluation.

These changes aim to refine the discovery process by enabling more strategic candidate combinations and improving overall evaluation efficiency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces two-phase discovery scoring (singles → successful-combos), adds `combo-successful` change type and `skipCombinedCandidates` option, updates runner flow, and adds targeted tests.
> 
> - **Discovery**:
>   - Add `combo-successful` to `DiscoveryChangeType` and implement `buildCombinedFromSuccessful()` to combine only successful single candidates.
>   - Add `BuildDiscoveryCandidatesOptions` with `skipCombinedCandidates` and gate all combo synthesis behind it.
>   - Implement safe sequential application helpers (`applyChangeToCreature`, `selectCombinationEmoji`) to avoid removing newly added structure and ensure deterministic merges.
>   - Guard existing combo builds (`combo-add-remove`, `combo-add-change`, `combo-all`, `combo-best-of-category`) with `skipCombinedCandidates`.
> - **Runner (`src/discovery/DiscoveryRunner.ts`)**:
>   - Switch to two-phase evaluation: build/evaluate singles, then build/evaluate combos from Phase 1 successes.
>   - Adjust `candidateBuilder` signature to accept options; integrate combo filtering, result aggregation, and concise phase logging.
> - **Tests**:
>   - Add `test/discovery/CombinedCandidateSequentialApplication.ts` to verify adds aren’t undone by removals when combining.
>   - Add `test/discovery/TwoPhaseDiscoveryScoring.ts` to validate two-phase flow, combo-only-from-success, and combo outperforming singles.
> - **Meta**:
>   - Bump version to `0.231.0` in `deno.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c12377c5afc360e6aa1a77f0f630689bbcccfc52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->