### PR TITLE
chore: update version to 0.233.0 and implement synapse removal logic …

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.231.1",
+  "version": "0.233.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1,6 +1,7 @@
 import { assert } from "@std/assert";
 import { addTag, removeTag, type TagsInterface } from "@stsoftware/tags/mod";
 import { CreatureUtil } from "../../../mod.ts";
+import { removeHiddenNeuron } from "../../compact/CompactUtils.ts";
 import { Creature } from "../../Creature.ts";
 import type { Approach } from "../../NEAT/LogApproach.ts";
 import { memeticUpdate } from "../../blackbox/MemeticUpdate.ts";
@@ -3681,17 +3682,134 @@ export class DiscoverStructure {
     worseCandidate?: CandidateSynapse,
   ): Creature | null {
     if (!worseCandidate) return null;
+
+    // Find the synapse indices in the creature
+    const fromNeuron = creature.neurons.find(
+      (n) => n.uuid === worseCandidate.fromNeuronUUID,
+    );
+    const toNeuron = creature.neurons.find(
+      (n) => n.uuid === worseCandidate.toNeuronUUID,
+    );
+
+    if (!fromNeuron || !toNeuron) {
+      console.warn(
+        `[DiscoverStructure] removeSynapse: neuron(s) not found for synapse ${worseCandidate.fromNeuronUUID} -> ${worseCandidate.toNeuronUUID}`,
+      );
+      return null;
+    }
+
+    const fromIndx = fromNeuron.index;
+    const toIndx = toNeuron.index;
+
+    // Check if the synapse actually exists
+    const synapse = creature.getSynapse(fromIndx, toIndx);
+    if (!synapse) {
+      console.warn(
+        `[DiscoverStructure] removeSynapse: synapse ${worseCandidate.fromNeuronUUID} -> ${worseCandidate.toNeuronUUID} does not exist in creature`,
+      );
+      return null;
+    }
+
     const creatureUUID = CreatureUtil.makeUUID(creature);
     const exportJSON = creature.exportJSON();
-    exportJSON.synapses = exportJSON.synapses.filter((synapse) => {
-      return synapse.fromUUID !== worseCandidate.fromNeuronUUID ||
-        synapse.toUUID !== worseCandidate.toNeuronUUID;
+    exportJSON.synapses = exportJSON.synapses.filter((s) => {
+      return s.fromUUID !== worseCandidate.fromNeuronUUID ||
+        s.toUUID !== worseCandidate.toNeuronUUID;
     });
 
     const tmpCreature = Creature.fromJSON(exportJSON);
     // We modified the structure by filtering synapses, so we must delete UUID
     delete tmpCreature.uuid;
-    tmpCreature.fix();
+    delete tmpCreature.memetic;
+
+    // Handle cascading effects like SubConnection.ts does (instead of calling fix())
+    // Check if the "to" neuron has 0 inward connections
+    const toNeuronInTmp = tmpCreature.neurons.find(
+      (n) => n.uuid === worseCandidate.toNeuronUUID,
+    );
+    let toNeuronRemoved = false;
+
+    if (toNeuronInTmp) {
+      const toIndxInTmp = toNeuronInTmp.index;
+      const inwardList = tmpCreature.inwardConnections(toIndxInTmp);
+
+      if (inwardList.length === 0 && toNeuronInTmp.type === "hidden") {
+        const outwardList = tmpCreature.outwardConnections(toIndxInTmp);
+        if (outwardList.length === 0) {
+          // No inward or outward connections - remove entirely
+          console.info(
+            `[DiscoverStructure] removeSynapse: removing completely disconnected neuron ${toNeuronInTmp.uuid}`,
+          );
+          removeHiddenNeuron(tmpCreature, toIndxInTmp);
+          toNeuronRemoved = true;
+        } else {
+          // Has outward connections - convert to constant
+          console.info(
+            `[DiscoverStructure] removeSynapse: converting neuron ${toNeuronInTmp.uuid} to constant`,
+          );
+          const squash = toNeuronInTmp.findSquash();
+          const activation = squash as ActivationInterface;
+          if (activation.squash) {
+            const constantBias = activation.squash(toNeuronInTmp.bias);
+            console.info(
+              `[DiscoverStructure] removeSynapse: adjusting neuron ${toNeuronInTmp.uuid} bias ${toNeuronInTmp.bias} to ${constantBias}`,
+            );
+            toNeuronInTmp.bias = constantBias;
+          }
+          toNeuronInTmp.type = "constant";
+          toNeuronInTmp.setSquash(undefined);
+        }
+      }
+    }
+
+    // Check if the "from" neuron now has 0 outward connections
+    const fromNeuronInTmp = tmpCreature.neurons.find(
+      (n) => n.uuid === worseCandidate.fromNeuronUUID,
+    );
+
+    if (fromNeuronInTmp) {
+      // Adjust index if the "to" neuron was removed and came before "from"
+      let fromIndxInTmp = fromNeuronInTmp.index;
+      if (toNeuronRemoved && toIndx < fromIndxInTmp) {
+        // Index already adjusted by removeHiddenNeuron, find by UUID again
+        const fromNeuronUpdated = tmpCreature.neurons.find(
+          (n) => n.uuid === worseCandidate.fromNeuronUUID,
+        );
+        if (fromNeuronUpdated) {
+          fromIndxInTmp = fromNeuronUpdated.index;
+        }
+      }
+
+      const fromOutwardList = tmpCreature.outwardConnections(fromIndxInTmp);
+      if (fromOutwardList.length === 0) {
+        const fromNeuronType = tmpCreature.neurons[fromIndxInTmp]?.type;
+        if (fromNeuronType === "hidden" || fromNeuronType === "constant") {
+          console.info(
+            `[DiscoverStructure] removeSynapse: removing neuron ${worseCandidate.fromNeuronUUID} as no longer connected`,
+          );
+          removeHiddenNeuron(tmpCreature, fromIndxInTmp);
+        }
+      }
+    }
+
+    // Validate the creature - only call fix() as a last resort
+    try {
+      tmpCreature.validate();
+    } catch (validationError) {
+      console.warn(
+        `[DiscoverStructure] removeSynapse: creature became invalid after removing synapse ${worseCandidate.fromNeuronUUID} -> ${worseCandidate.toNeuronUUID}. ` +
+          `This is a bug that should be investigated. Error: ${validationError}. Attempting fix() as last resort.`,
+      );
+      tmpCreature.fix();
+      try {
+        tmpCreature.validate();
+      } catch (fixError) {
+        console.error(
+          `[DiscoverStructure] removeSynapse: fix() failed to repair creature. Error: ${fixError}`,
+        );
+        return null;
+      }
+    }
 
     const tmpUUID = CreatureUtil.makeUUID(tmpCreature);
     if (tmpUUID !== creatureUUID) {
@@ -3700,12 +3818,15 @@ export class DiscoverStructure {
       const summary =
         `☣️ Removed harmful synapse ${worseCandidate.fromNeuronUUID} -> ${worseCandidate.toNeuronUUID}`;
       addTag(tmpCreature, "Discovery", summary);
-      delete tmpCreature.memetic;
       removeTag(tmpCreature, "approach-logged");
-      tmpCreature.validate();
 
       return tmpCreature;
     }
+
+    // Synapse existed but removal didn't change UUID
+    console.warn(
+      `[DiscoverStructure] removeSynapse: synapse ${worseCandidate.fromNeuronUUID} -> ${worseCandidate.toNeuronUUID} existed but removal had no structural effect`,
+    );
     return null;
   }
 

--- a/test/discovery/DiscoveryCandidates.ts
+++ b/test/discovery/DiscoveryCandidates.ts
@@ -892,3 +892,189 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "harmful synapse removal appears as remove-synapse candidate in evaluation output",
+  () => {
+    const base = makeBaselineCreature();
+    // Use an existing synapse from the base creature as the harmful one
+    const harmfulSynapse: CandidateSynapse = {
+      fromNeuronUUID: "input-0",
+      toNeuronUUID: "hidden-1",
+      weight: -50.0, // Large negative weight simulating harmful synapse
+      expectedImprovementPercentage: 0.35,
+      improvedCount: 8,
+      totalCount: 10,
+    };
+
+    const discovery: DiscoverResult = {
+      ID: "HARMFUL-SYNAPSE-TEST",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: harmfulSynapse,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const candidates = buildDiscoveryCandidates(base, discovery);
+
+    // Verify that a "remove-synapse" candidate exists
+    const removeSynapseCandidate = candidates.find(
+      (c) => c.change.type === "remove-synapse",
+    );
+    assert(
+      removeSynapseCandidate,
+      "Expected 'remove-synapse' candidate to appear in evaluation output",
+    );
+
+    // Verify the candidate has the harmful synapse removed
+    const exported = removeSynapseCandidate.creature.exportJSON();
+    const harmfulStillExists = exported.synapses.some((synapse) =>
+      synapse.fromUUID === harmfulSynapse.fromNeuronUUID &&
+      synapse.toUUID === harmfulSynapse.toNeuronUUID
+    );
+    assertEquals(
+      harmfulStillExists,
+      false,
+      "Harmful synapse should be removed in the remove-synapse candidate",
+    );
+
+    // Verify candidate metadata
+    assertEquals(
+      removeSynapseCandidate.change.type,
+      "remove-synapse",
+      "Candidate type should be 'remove-synapse'",
+    );
+    assert(
+      removeSynapseCandidate.change.description?.includes("✂️"),
+      "Description should include scissors emoji",
+    );
+    assert(
+      removeSynapseCandidate.change.description?.includes("harmful"),
+      "Description should mention harmful synapse",
+    );
+    assertEquals(
+      removeSynapseCandidate.change.sampleSize,
+      harmfulSynapse.totalCount,
+      "Sample size should match harmful synapse total count",
+    );
+  },
+);
+
+Deno.test(
+  "removeSynapse returns valid creature when synapse exists",
+  () => {
+    const base = makeBaselineCreature();
+    // Target an existing synapse in the creature
+    const existingSynapse: CandidateSynapse = {
+      fromNeuronUUID: "input-0",
+      toNeuronUUID: "hidden-1",
+      weight: 0.1, // Match existing weight
+      expectedImprovementPercentage: 0.2,
+      improvedCount: 5,
+      totalCount: 10,
+    };
+
+    const result = DiscoverStructure.removeSynapse(
+      "TEST-REMOVE",
+      base,
+      existingSynapse,
+    );
+
+    assert(
+      result,
+      "removeSynapse should return a creature when synapse exists",
+    );
+
+    // Verify the synapse is actually removed
+    const exported = result.exportJSON();
+    const synapseStillExists = exported.synapses.some((synapse) =>
+      synapse.fromUUID === existingSynapse.fromNeuronUUID &&
+      synapse.toUUID === existingSynapse.toNeuronUUID
+    );
+    assertEquals(
+      synapseStillExists,
+      false,
+      "Synapse should not exist in returned creature",
+    );
+
+    // Verify creature is valid
+    result.validate();
+  },
+);
+
+Deno.test(
+  "removeSynapse returns null and logs warning when synapse doesn't exist",
+  () => {
+    const base = makeBaselineCreature();
+    // Target a non-existent synapse
+    const nonExistentSynapse: CandidateSynapse = {
+      fromNeuronUUID: "input-3",
+      toNeuronUUID: "output-1",
+      weight: 0.5,
+      expectedImprovementPercentage: 0.15,
+      improvedCount: 3,
+      totalCount: 8,
+    };
+
+    // Verify synapse doesn't exist
+    const exported = base.exportJSON();
+    const exists = exported.synapses.some((synapse) =>
+      synapse.fromUUID === nonExistentSynapse.fromNeuronUUID &&
+      synapse.toUUID === nonExistentSynapse.toNeuronUUID
+    );
+    assertEquals(exists, false, "Precondition: synapse should not exist");
+
+    // removeSynapse should return null (and log a warning)
+    const result = DiscoverStructure.removeSynapse(
+      "TEST-NON-EXISTENT",
+      base,
+      nonExistentSynapse,
+    );
+
+    assertEquals(
+      result,
+      null,
+      "removeSynapse should return null when synapse doesn't exist",
+    );
+  },
+);
+
+Deno.test(
+  "buildDiscoveryCandidates skips remove-synapse candidate when synapse doesn't exist",
+  () => {
+    const base = makeBaselineCreature();
+    // Use a synapse that doesn't exist in the creature
+    const nonExistentHarmfulSynapse: CandidateSynapse = {
+      fromNeuronUUID: "input-3",
+      toNeuronUUID: "output-1",
+      weight: -10.0,
+      expectedImprovementPercentage: 0.4,
+      improvedCount: 8,
+      totalCount: 10,
+    };
+
+    const discovery: DiscoverResult = {
+      ID: "NON-EXISTENT-HARMFUL",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: nonExistentHarmfulSynapse,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const candidates = buildDiscoveryCandidates(base, discovery);
+
+    // Should not produce a remove-synapse candidate
+    const removeSynapseCandidate = candidates.find(
+      (c) => c.change.type === "remove-synapse",
+    );
+    assertEquals(
+      removeSynapseCandidate,
+      undefined,
+      "Should not create remove-synapse candidate for non-existent synapse",
+    );
+  },
+);


### PR DESCRIPTION
…in DiscoverStructure

- Bumped version in deno.json to 0.233.0.
- Enhanced the removeSynapse method in DiscoverStructure to include detailed checks for synapse existence and neuron connectivity, improving robustness.
- Added logging for cases where synapses are not found or removal has no structural effect, aiding in debugging.
- Introduced tests to validate the behavior of removeSynapse, ensuring it correctly handles existing and non-existent synapses, and verifies the removal candidates in the evaluation output.

These changes aim to refine the synapse management process and enhance the overall functionality of the discovery workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements validated, cascaded synapse removal in DiscoverStructure, adds comprehensive tests for removal flows, and bumps version to 0.233.0.
> 
> - **Architecture**:
>   - **`src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts`**:
>     - Overhauls `removeSynapse` to verify neuron/synapse existence, remove the synapse, and cascade clean-up:
>       - Remove fully disconnected hidden neurons, or convert to `constant` when only outward connections remain (bias adjusted via activation).
>       - Remove upstream neuron if it becomes non-contributing; handles index shifts with `removeHiddenNeuron`.
>     - Adds strict validation, fallback `fix()` only on failure, improved tagging/UUID handling, and detailed logging for no-op/invalid cases.
>     - Imports and uses `removeHiddenNeuron` from `compact/CompactUtils`.
> - **Tests**:
>   - **`test/discovery/DiscoveryCandidates.ts`**:
>     - Adds tests verifying:
>       - `removeSynapse` removes existing synapses and returns a valid creature.
>       - `removeSynapse` returns `null` for non-existent synapses.
>       - Discovery outputs include `remove-synapse` candidates when applicable and skip when not.
> - **Config**:
>   - Bumps `deno.json` version to `0.233.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf5cdf789fb1f7b5af1e62c01dc3e964d2b011c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->