### PR TITLE
chore: update version to 0.234.0 and implement discovery failure caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,42 @@ accumulating improvements over hundreds of iterations. See the
 [Discovery Guide](./docs/DISCOVERY_GUIDE.md) for real-world workflows and
 production-tuned configurations.
 
+### Discovery Failure Cache
+
+When running discovery iteratively with a stable training dataset, you can
+enable failure caching to avoid re-evaluating candidates that previously failed
+to improve the creature's score. This significantly speeds up discovery runs by
+skipping known-failing candidates.
+
+```typescript
+const result = await creature.discoveryDir(dataDir, {
+  discoveryFailureCacheDir: ".discovery/failure-cache",
+  // ... other options
+});
+```
+
+**How it works:**
+
+1. After evaluating candidates, those that fail to improve the score are cached
+2. On subsequent runs, cached candidates are skipped before evaluation
+3. Cache keys use weight/bias magnitude (exponent only), so only significant
+   changes trigger re-evaluation
+4. Delete the cache directory when your training dataset changes
+
+**When to use:**
+
+- Training dataset changes infrequently (e.g., once a day)
+- Running discovery repeatedly on the same creature
+- Want to reduce wasted computation on known-failing candidates
+
+**Cache key design:**
+
+- Uses the exponential component of weights/biases in scientific notation
+- Weights like `0.123` and `0.234` (both `e-1`) map to the same key
+- Weights like `0.001` (`e-3`) and `0.1` (`e-1`) map to different keys
+- This allows similar candidates to be cached together while still re-trying
+  when weights change significantly
+
 ### Forced Focus Overrides
 
 The discovery recorder now honours an optional `discoveryFocusNeuronUUIDs`

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.233.0",
+  "version": "0.234.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -153,6 +153,7 @@ export function createNeatConfig(options: NeatOptions) {
     discoveryDisableCleanup: options.discoveryDisableCleanup ?? false,
     discoveryBaseDirectory: options.discoveryBaseDirectory,
     discoverySkipRecordPhase: options.discoverySkipRecordPhase ?? false,
+    discoveryFailureCacheDir: options.discoveryFailureCacheDir,
   };
   validate(config);
   return Object.freeze(config);

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -234,6 +234,18 @@ export interface NeatArguments {
    * Defaults to false (always record).
    */
   discoverySkipRecordPhase: boolean;
+
+  /**
+   * Directory path to cache discovery failures.
+   * When provided, discovery candidates that fail to improve the score are cached.
+   * Subsequent discovery runs will skip candidates that match cached failures.
+   *
+   * Delete this directory when the training dataset changes to allow re-evaluation.
+   *
+   * Cache keys use the exponential component of weights/biases (formatted in scientific notation)
+   * so only significant weight changes will trigger re-evaluation.
+   */
+  discoveryFailureCacheDir?: string;
 }
 
 export type NeatOptions = Partial<NeatArguments>;

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -20,6 +20,7 @@ import {
 import { WorkerHandler } from "../multithreading/workers/WorkerHandler.ts";
 
 import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
+import { filterCachedCandidates, recordFailureSync } from "./FailureCache.ts";
 
 export interface DiscoveryRunnerWorker {
   discover(
@@ -276,6 +277,19 @@ export class DiscoveryRunner {
           }.`,
         );
       }
+
+      // Filter out cached failures if failure cache is enabled
+      const failureCacheDir = config.discoveryFailureCacheDir;
+      const { filtered: uncachedCandidates, cachedCount } =
+        filterCachedCandidates(failureCacheDir, filteredSingleCandidates);
+      if (cachedCount > 0) {
+        verboseLog(
+          `Skipped ${cachedCount} candidate${
+            cachedCount === 1 ? "" : "s"
+          } from failure cache (previously failed to improve).`,
+        );
+      }
+
       markPhase("Candidate synthesis (Phase 1)", candidateBuildStart);
 
       // Phase 1 evaluation: Score single candidates + original
@@ -285,7 +299,7 @@ export class DiscoveryRunner {
         candidate?: DiscoveryCandidate;
       }> = [
         { kind: "original", creature },
-        ...filteredSingleCandidates.map((candidate) => ({
+        ...uncachedCandidates.map((candidate) => ({
           kind: "candidate" as const,
           creature: candidate.creature,
           candidate,
@@ -387,6 +401,35 @@ export class DiscoveryRunner {
         .filter((result) => result.kind === "candidate")
         .filter((result) => result.score > original.score)
         .sort((a, b) => b.score - a.score)[0];
+
+      // Cache failed candidates if failure cache is enabled
+      if (failureCacheDir) {
+        const failedCandidates = evaluationResults
+          .filter((result) => result.kind === "candidate")
+          .filter((result) => result.score <= original.score)
+          .filter((result) => result.candidate !== undefined);
+
+        let cachedFailuresCount = 0;
+        for (const failed of failedCandidates) {
+          if (failed.candidate) {
+            recordFailureSync(failureCacheDir, failed.candidate, {
+              originalScore: original.score,
+              candidateScore: failed.score,
+              scoreDelta: failed.score - original.score,
+              error: failed.error,
+            });
+            cachedFailuresCount++;
+          }
+        }
+
+        if (cachedFailuresCount > 0 && verboseLogging) {
+          verboseLog(
+            `Cached ${cachedFailuresCount} failed candidate${
+              cachedFailuresCount === 1 ? "" : "s"
+            } to failure cache.`,
+          );
+        }
+      }
 
       // Update discoverResult with re-scoring time for potential use in summary
       discoverResult.reScoringTime = reScoringTime;

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -360,12 +360,23 @@ export class DiscoveryRunner {
           );
 
           // Filter combined candidates (apply same thresholds)
-          const { filtered: filteredCombos } = this
+          const { filtered: thresholdFilteredCombos } = this
             .#filterCandidatesForEvaluation(
               combinedCandidates,
               workerCount,
               config,
             );
+
+          // Filter out cached failures for combined candidates too
+          const { filtered: filteredCombos, cachedCount: comboCachedCount } =
+            filterCachedCandidates(failureCacheDir, thresholdFilteredCombos);
+          if (comboCachedCount > 0) {
+            verboseLog(
+              `[Phase 2] Skipped ${comboCachedCount} combined candidate${
+                comboCachedCount === 1 ? "" : "s"
+              } from failure cache.`,
+            );
+          }
 
           if (filteredCombos.length > 0) {
             const phase2Tasks = filteredCombos.map((candidate) => ({

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -1,0 +1,338 @@
+/**
+ * Discovery Failure Cache Module
+ *
+ * Provides caching for discovery candidates that failed to improve the creature's score.
+ * This prevents re-evaluating the same failing candidates when the training dataset
+ * hasn't changed.
+ *
+ * Cache keys are based on:
+ * - Change type (add-synapses, add-neurons, remove-low-impact, etc.)
+ * - Structural signature (neuron UUIDs, synapse connections)
+ * - Weight/bias magnitude (using exponent only, so similar weights map to same key)
+ *
+ * @module FailureCache
+ */
+
+import { join } from "@std/path/join";
+import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
+
+/** Metadata stored alongside cached failures for debugging/analysis */
+export interface FailureMetadata {
+  originalScore: number;
+  candidateScore: number;
+  scoreDelta: number;
+  error: number;
+  timestamp?: string;
+}
+
+/**
+ * Extracts the exponent from a number's scientific notation.
+ * This allows similar weights (same order of magnitude) to map to the same cache key.
+ *
+ * @param value - The number to extract the exponent from
+ * @returns The exponent (e.g., 0.001 → -3, 100 → 2)
+ */
+export function extractExponent(value: number): number {
+  if (value === 0) return -999; // Sentinel for zero
+  const absValue = Math.abs(value);
+  return Math.floor(Math.log10(absValue));
+}
+
+/**
+ * Formats a weight/bias using only its exponent for cache key generation.
+ * This ensures that weights with the same order of magnitude produce the same key.
+ *
+ * @param weight - The weight or bias value
+ * @returns A string like "e-3" or "e2"
+ */
+export function formatWeight(weight: number): string {
+  const exp = extractExponent(weight);
+  return `e${exp}`;
+}
+
+/**
+ * Builds a deterministic cache key for a discovery candidate.
+ *
+ * The key incorporates:
+ * - Change type
+ * - Structural information (neuron UUIDs for connections)
+ * - Weight/bias magnitudes (exponents only)
+ *
+ * @param candidate - The discovery candidate to generate a key for
+ * @returns A string suitable for use as a cache filename
+ */
+export function buildCacheKey(candidate: DiscoveryCandidate): string {
+  const parts: string[] = [candidate.change.type];
+
+  // Handle different candidate types
+  switch (candidate.change.type) {
+    case "add-neurons": {
+      // For add-neurons, use neuronDetails if available
+      const details = candidate.change.neuronDetails;
+      if (details) {
+        parts.push(
+          details.fromNeuronUUID,
+          details.toNeuronUUID,
+          details.squash,
+          formatWeight(details.incomingWeight),
+          formatWeight(details.outgoingWeight),
+          formatWeight(details.bias),
+        );
+      } else {
+        // Fallback: use creature structure
+        parts.push(buildStructuralSignature(candidate));
+      }
+      break;
+    }
+
+    case "remove-low-impact":
+    case "remove-neuron": {
+      // Extract neuron UUID from description (format: "... neuron UUID ...")
+      const uuidMatch = candidate.change.description?.match(
+        /neuron\s+([a-zA-Z0-9_-]+)/i,
+      );
+      if (uuidMatch) {
+        parts.push(uuidMatch[1]);
+      }
+      // Also include a structural hash for uniqueness
+      parts.push(buildStructuralSignature(candidate));
+      break;
+    }
+
+    case "change-squash": {
+      // For squash changes, include the squash function names from description
+      // and a structural signature
+      parts.push(buildStructuralSignature(candidate));
+      break;
+    }
+
+    case "add-synapses":
+    case "remove-synapse":
+    default: {
+      // For synapses and other types, use structural signature
+      parts.push(buildStructuralSignature(candidate));
+      break;
+    }
+  }
+
+  // Create a safe filename from the key parts
+  return sanitiseForFilename(parts.join("_"));
+}
+
+/**
+ * Builds a structural signature from the creature's neurons and synapses.
+ * Uses exponents for weights/biases to group similar structures together.
+ */
+function buildStructuralSignature(candidate: DiscoveryCandidate): string {
+  const exported = candidate.creature.exportJSON();
+  const sigParts: string[] = [];
+
+  // Include neuron signatures (UUID, squash, bias exponent)
+  for (const neuron of exported.neurons) {
+    if (neuron.type === "hidden") {
+      sigParts.push(
+        `n:${neuron.uuid}:${neuron.squash}:${formatWeight(neuron.bias)}`,
+      );
+    }
+  }
+
+  // Include synapse signatures (from→to, weight exponent)
+  // Sort for determinism
+  const sortedSynapses = [...exported.synapses].sort((a, b) => {
+    const keyA = `${a.fromUUID}->${a.toUUID}`;
+    const keyB = `${b.fromUUID}->${b.toUUID}`;
+    return keyA.localeCompare(keyB);
+  });
+
+  for (const synapse of sortedSynapses) {
+    sigParts.push(
+      `s:${synapse.fromUUID}->${synapse.toUUID}:${
+        formatWeight(synapse.weight)
+      }`,
+    );
+  }
+
+  return sigParts.join("|");
+}
+
+/**
+ * Converts a string to a safe filename by replacing invalid characters.
+ */
+function sanitiseForFilename(value: string): string {
+  // Replace characters not allowed in filenames with underscores
+  // Keep alphanumeric, hyphens, underscores, and dots
+  return value
+    .replace(/[^a-zA-Z0-9_\-.]/g, "_")
+    .replace(/_+/g, "_") // Collapse multiple underscores
+    .replace(/^_|_$/g, "") // Remove leading/trailing underscores
+    .slice(0, 200); // Limit length for filesystem compatibility
+}
+
+/**
+ * Gets the cache file path for a candidate.
+ */
+function getCacheFilePath(
+  cacheDir: string,
+  candidate: DiscoveryCandidate,
+): string {
+  const key = buildCacheKey(candidate);
+  const typeDir = candidate.change.type;
+  return join(cacheDir, typeDir, `${key}.json`);
+}
+
+/**
+ * Checks if a discovery candidate is already cached as a failure.
+ *
+ * @param cacheDir - The cache directory path
+ * @param candidate - The candidate to check
+ * @returns true if the candidate was previously cached as a failure
+ */
+export async function isCandidateCached(
+  cacheDir: string,
+  candidate: DiscoveryCandidate,
+): Promise<boolean> {
+  try {
+    const filePath = getCacheFilePath(cacheDir, candidate);
+    const stat = await Deno.stat(filePath);
+    return stat.isFile;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    // Log unexpected errors but don't fail
+    console.warn(
+      `[FailureCache] Error checking cache for candidate: ${error}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Synchronously checks if a discovery candidate is already cached as a failure.
+ *
+ * @param cacheDir - The cache directory path
+ * @param candidate - The candidate to check
+ * @returns true if the candidate was previously cached as a failure
+ */
+export function isCandidateCachedSync(
+  cacheDir: string,
+  candidate: DiscoveryCandidate,
+): boolean {
+  try {
+    const filePath = getCacheFilePath(cacheDir, candidate);
+    const stat = Deno.statSync(filePath);
+    return stat.isFile;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    // Log unexpected errors but don't fail
+    console.warn(
+      `[FailureCache] Error checking cache for candidate: ${error}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Records a discovery candidate as a failure in the cache.
+ *
+ * @param cacheDir - The cache directory path
+ * @param candidate - The candidate that failed to improve
+ * @param metadata - Additional metadata about the failure
+ */
+export async function recordFailure(
+  cacheDir: string,
+  candidate: DiscoveryCandidate,
+  metadata: FailureMetadata,
+): Promise<void> {
+  try {
+    const filePath = getCacheFilePath(cacheDir, candidate);
+    const dir = filePath.substring(0, filePath.lastIndexOf("/"));
+
+    // Ensure directory exists
+    await Deno.mkdir(dir, { recursive: true });
+
+    // Write cache entry with metadata
+    const cacheEntry = {
+      key: buildCacheKey(candidate),
+      changeType: candidate.change.type,
+      description: candidate.change.description,
+      ...metadata,
+      timestamp: new Date().toISOString(),
+    };
+
+    await Deno.writeTextFile(filePath, JSON.stringify(cacheEntry, null, 2));
+  } catch (error) {
+    // Log but don't fail - caching is an optimisation, not critical
+    console.warn(
+      `[FailureCache] Failed to record failure for candidate ${candidate.change.type}: ${error}`,
+    );
+  }
+}
+
+/**
+ * Synchronously records a discovery candidate as a failure in the cache.
+ *
+ * @param cacheDir - The cache directory path
+ * @param candidate - The candidate that failed to improve
+ * @param metadata - Additional metadata about the failure
+ */
+export function recordFailureSync(
+  cacheDir: string,
+  candidate: DiscoveryCandidate,
+  metadata: FailureMetadata,
+): void {
+  try {
+    const filePath = getCacheFilePath(cacheDir, candidate);
+    const dir = filePath.substring(0, filePath.lastIndexOf("/"));
+
+    // Ensure directory exists
+    Deno.mkdirSync(dir, { recursive: true });
+
+    // Write cache entry with metadata
+    const cacheEntry = {
+      key: buildCacheKey(candidate),
+      changeType: candidate.change.type,
+      description: candidate.change.description,
+      ...metadata,
+      timestamp: new Date().toISOString(),
+    };
+
+    Deno.writeTextFileSync(filePath, JSON.stringify(cacheEntry, null, 2));
+  } catch (error) {
+    // Log but don't fail - caching is an optimisation, not critical
+    console.warn(
+      `[FailureCache] Failed to record failure for candidate ${candidate.change.type}: ${error}`,
+    );
+  }
+}
+
+/**
+ * Filters candidates, removing those that are already cached as failures.
+ *
+ * @param cacheDir - The cache directory path (if undefined, no filtering is done)
+ * @param candidates - The candidates to filter
+ * @returns Object with filtered candidates and count of skipped candidates
+ */
+export function filterCachedCandidates(
+  cacheDir: string | undefined,
+  candidates: DiscoveryCandidate[],
+): { filtered: DiscoveryCandidate[]; cachedCount: number } {
+  if (!cacheDir) {
+    return { filtered: candidates, cachedCount: 0 };
+  }
+
+  const filtered: DiscoveryCandidate[] = [];
+  let cachedCount = 0;
+
+  for (const candidate of candidates) {
+    if (isCandidateCachedSync(cacheDir, candidate)) {
+      cachedCount++;
+    } else {
+      filtered.push(candidate);
+    }
+  }
+
+  return { filtered, cachedCount };
+}

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -13,6 +13,7 @@
  * @module FailureCache
  */
 
+import { dirname } from "@std/path/dirname";
 import { join } from "@std/path/join";
 import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
 
@@ -248,7 +249,7 @@ export async function recordFailure(
 ): Promise<void> {
   try {
     const filePath = getCacheFilePath(cacheDir, candidate);
-    const dir = filePath.substring(0, filePath.lastIndexOf("/"));
+    const dir = dirname(filePath);
 
     // Ensure directory exists
     await Deno.mkdir(dir, { recursive: true });
@@ -285,7 +286,7 @@ export function recordFailureSync(
 ): void {
   try {
     const filePath = getCacheFilePath(cacheDir, candidate);
-    const dir = filePath.substring(0, filePath.lastIndexOf("/"));
+    const dir = dirname(filePath);
 
     // Ensure directory exists
     Deno.mkdirSync(dir, { recursive: true });

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -123,18 +123,24 @@ export function buildCacheKey(candidate: DiscoveryCandidate): string {
 /**
  * Builds a structural signature from the creature's neurons and synapses.
  * Uses exponents for weights/biases to group similar structures together.
+ *
+ * Includes both hidden and output neurons (sorted by UUID for determinism).
+ * Input neurons are excluded as they have no squash/bias.
  */
 function buildStructuralSignature(candidate: DiscoveryCandidate): string {
   const exported = candidate.creature.exportJSON();
   const sigParts: string[] = [];
 
   // Include neuron signatures (UUID, squash, bias exponent)
-  for (const neuron of exported.neurons) {
-    if (neuron.type === "hidden") {
-      sigParts.push(
-        `n:${neuron.uuid}:${neuron.squash}:${formatWeight(neuron.bias)}`,
-      );
-    }
+  // Filter to hidden and output neurons, then sort by UUID for determinism
+  const relevantNeurons = exported.neurons
+    .filter((n) => n.type === "hidden" || n.type === "output")
+    .sort((a, b) => a.uuid.localeCompare(b.uuid));
+
+  for (const neuron of relevantNeurons) {
+    sigParts.push(
+      `n:${neuron.uuid}:${neuron.squash}:${formatWeight(neuron.bias)}`,
+    );
   }
 
   // Include synapse signatures (from→to, weight exponent)

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1457,3 +1457,252 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "DiscoveryRunner caches failed candidates when discoveryFailureCacheDir is set",
+  async () => {
+    const tempDir = await Deno.makeTempDir();
+    const cacheDir = `${tempDir}/failure-cache`;
+
+    try {
+      const discoveryResult: DiscoverResult = {
+        ID: "CACHE_FAILURES_TEST",
+        addHelpfulSynapses: [{
+          fromNeuronUUID: "input-1",
+          toNeuronUUID: "hidden-1",
+          weight: 0.45,
+          expectedImprovementPercentage: 0.2,
+          improvedCount: 5,
+          totalCount: 6,
+        }],
+        addHelpfulNeurons: undefined,
+        removeHarmfulSynapse: undefined,
+        removeHarmfulNeurons: undefined,
+        removalCandidates: undefined,
+        candidateSquashes: undefined,
+      };
+
+      // All candidates will fail (worse than original)
+      const computeError = (_creature: Creature) => 0.6; // All worse
+
+      const runner = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            discoveryResult,
+            computeError,
+          ),
+      });
+
+      await runner.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options: makeOptions({ discoveryFailureCacheDir: cacheDir }),
+      });
+
+      // Verify cache directory was created and has content
+      const typeDir = `${cacheDir}/add-synapses`;
+      const entries: Deno.DirEntry[] = [];
+      for await (const entry of Deno.readDir(typeDir)) {
+        entries.push(entry);
+      }
+
+      assert(
+        entries.length > 0,
+        "Cache directory should contain at least one entry for failed candidate",
+      );
+
+      // Verify the cache file contains expected metadata
+      const cacheFile = entries[0];
+      const cacheContent = JSON.parse(
+        await Deno.readTextFile(`${typeDir}/${cacheFile.name}`),
+      );
+      assertEquals(
+        cacheContent.changeType,
+        "add-synapses",
+        "Cache entry should have correct change type",
+      );
+      assert(
+        cacheContent.timestamp,
+        "Cache entry should have timestamp",
+      );
+      assert(
+        cacheContent.scoreDelta < 0 || cacheContent.scoreDelta === 0,
+        "Cache entry should show non-positive score delta (failure)",
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner skips cached candidates on subsequent runs",
+  async () => {
+    const tempDir = await Deno.makeTempDir();
+    const cacheDir = `${tempDir}/failure-cache`;
+
+    try {
+      const discoveryResult: DiscoverResult = {
+        ID: "SKIP_CACHED_TEST",
+        addHelpfulSynapses: [{
+          fromNeuronUUID: "input-1",
+          toNeuronUUID: "hidden-1",
+          weight: 0.45,
+          expectedImprovementPercentage: 0.2,
+          improvedCount: 5,
+          totalCount: 6,
+        }],
+        addHelpfulNeurons: undefined,
+        removeHarmfulSynapse: undefined,
+        removeHarmfulNeurons: undefined,
+        removalCandidates: undefined,
+        candidateSquashes: undefined,
+      };
+
+      let evaluationCount = 0;
+      const computeError = (creature: Creature) => {
+        // Count evaluations (excluding original which has no candidate)
+        const json = creature.exportJSON();
+        const hasTestSynapse = json.synapses.some((s) =>
+          s.fromUUID === "input-1" && s.toUUID === "hidden-1" &&
+          Math.abs(s.weight - 0.45) < 1e-6
+        );
+        if (hasTestSynapse) {
+          evaluationCount++;
+        }
+        return 0.6; // All worse
+      };
+
+      const runner = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            discoveryResult,
+            computeError,
+          ),
+      });
+
+      const options = makeOptions({ discoveryFailureCacheDir: cacheDir });
+
+      // First run - should evaluate the candidate
+      await runner.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options,
+      });
+
+      const firstRunEvaluations = evaluationCount;
+      assert(
+        firstRunEvaluations >= 1,
+        `First run should evaluate at least one synapse candidate, got ${firstRunEvaluations}`,
+      );
+
+      // Reset counter
+      evaluationCount = 0;
+
+      // Second run - should skip cached candidates
+      const result2 = await runner.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options,
+      });
+
+      // The synapse candidate should not be evaluated again (cached)
+      assertEquals(
+        evaluationCount,
+        0,
+        "Second run should not evaluate cached candidates",
+      );
+
+      // Verify no improvement (since we skipped all candidates)
+      assertEquals(
+        result2.improvement,
+        undefined,
+        "Should have no improvement when all candidates are cached",
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner does not cache successful candidates",
+  async () => {
+    const tempDir = await Deno.makeTempDir();
+    const cacheDir = `${tempDir}/failure-cache`;
+
+    try {
+      const discoveryResult: DiscoverResult = {
+        ID: "NO_CACHE_SUCCESS_TEST",
+        addHelpfulSynapses: [{
+          fromNeuronUUID: "input-1",
+          toNeuronUUID: "hidden-1",
+          weight: 0.45,
+          expectedImprovementPercentage: 0.5,
+          improvedCount: 9,
+          totalCount: 10,
+        }],
+        addHelpfulNeurons: undefined,
+        removeHarmfulSynapse: undefined,
+        removeHarmfulNeurons: undefined,
+        removalCandidates: undefined,
+        candidateSquashes: undefined,
+      };
+
+      // The candidate will improve things
+      const computeError = (creature: Creature) => {
+        const json = creature.exportJSON();
+        const hasTestSynapse = json.synapses.some((s) =>
+          s.fromUUID === "input-1" && s.toUUID === "hidden-1" &&
+          Math.abs(s.weight - 0.45) < 1e-6
+        );
+        return hasTestSynapse ? 0.3 : 0.5; // Synapse improves things
+      };
+
+      const runner = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            discoveryResult,
+            computeError,
+          ),
+      });
+
+      const result = await runner.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options: makeOptions({ discoveryFailureCacheDir: cacheDir }),
+      });
+
+      // Verify we got an improvement
+      assert(
+        result.improvement,
+        "Should have found an improvement",
+      );
+
+      // Verify cache directory either doesn't exist or has no add-synapses entries
+      // (successful candidates should not be cached)
+      try {
+        const typeDir = `${cacheDir}/add-synapses`;
+        const entries: Deno.DirEntry[] = [];
+        for await (const entry of Deno.readDir(typeDir)) {
+          entries.push(entry);
+        }
+        assertEquals(
+          entries.length,
+          0,
+          "Successful candidates should not be cached",
+        );
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+        // Directory doesn't exist, which is fine (no failures to cache)
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+);

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1628,6 +1628,116 @@ Deno.test(
 );
 
 Deno.test(
+  "DiscoveryRunner skips cached Phase 2 combined candidates on subsequent runs",
+  async () => {
+    const tempDir = await Deno.makeTempDir();
+    const cacheDir = `${tempDir}/failure-cache`;
+
+    try {
+      // Use 2 SQUASH changes - these create single candidates with stable cache keys
+      // (no generated UUIDs). Both improve individually but their combined fails.
+      // Base creature has hidden-1 with IDENTITY squash.
+      const discoveryResult: DiscoverResult = {
+        ID: "PHASE2_CACHE_TEST",
+        addHelpfulSynapses: undefined,
+        addHelpfulNeurons: undefined,
+        removeHarmfulSynapse: undefined,
+        removeHarmfulNeurons: undefined,
+        removalCandidates: undefined,
+        candidateSquashes: [
+          {
+            neuronUUID: "hidden-1",
+            previousSquash: "IDENTITY",
+            squash: "TANH", // Change hidden-1's squash to TANH
+            expectedImprovementPercentage: 0.3,
+            improvedError: 0.4,
+            currentError: 0.5,
+          },
+          {
+            neuronUUID: "output-0",
+            previousSquash: "IDENTITY",
+            squash: "LOGISTIC", // Change output's squash to LOGISTIC
+            expectedImprovementPercentage: 0.3,
+            improvedError: 0.4,
+            currentError: 0.5,
+          },
+        ],
+      };
+
+      let phase2EvaluationCount = 0;
+
+      const computeError = (creature: Creature) => {
+        const json = creature.exportJSON();
+
+        // Check for TANH on hidden-1
+        const hasTanh = json.neurons.some((n) =>
+          n.uuid === "hidden-1" && n.squash === "TANH"
+        );
+        // Check for LOGISTIC on output-0
+        const hasLogistic = json.neurons.some((n) =>
+          n.uuid === "output-0" && n.squash === "LOGISTIC"
+        );
+
+        // Track combined candidate evaluations (both squash changes present)
+        if (hasTanh && hasLogistic) {
+          phase2EvaluationCount++;
+          return 0.6; // Combined candidate is worse
+        }
+
+        // Individual squash changes improve
+        if (hasTanh || hasLogistic) {
+          return 0.4; // Individual candidates improve
+        }
+
+        return 0.5; // Original
+      };
+
+      const runner = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            discoveryResult,
+            computeError,
+          ),
+      });
+
+      const options = makeOptions({ discoveryFailureCacheDir: cacheDir });
+
+      // First run - Phase 2 combined candidate should be evaluated and cached
+      await runner.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options,
+      });
+
+      const firstRunPhase2Evaluations = phase2EvaluationCount;
+      assert(
+        firstRunPhase2Evaluations >= 1,
+        `First run should evaluate combined candidate, got ${firstRunPhase2Evaluations}`,
+      );
+
+      // Reset counter
+      phase2EvaluationCount = 0;
+
+      // Second run - Phase 2 combined candidate should be skipped (cached failure)
+      await runner.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options,
+      });
+
+      assertEquals(
+        phase2EvaluationCount,
+        0,
+        "Second run should skip cached combined candidates",
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
   "DiscoveryRunner does not cache successful candidates",
   async () => {
     const tempDir = await Deno.makeTempDir();

--- a/test/discovery/FailureCache.ts
+++ b/test/discovery/FailureCache.ts
@@ -1,0 +1,365 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  buildCacheKey,
+  extractExponent,
+  formatWeight,
+  isCandidateCached,
+  recordFailure,
+} from "../../src/discovery/FailureCache.ts";
+import type { DiscoveryCandidate } from "../../src/discovery/DiscoveryCandidates.ts";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+
+function makeSimpleCreature(): Creature {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+function makeCandidate(
+  changeType: string,
+  description: string,
+  creature?: Creature,
+): DiscoveryCandidate {
+  return {
+    creature: creature ?? makeSimpleCreature(),
+    change: {
+      type: changeType as DiscoveryCandidate["change"]["type"],
+      description,
+    },
+  };
+}
+
+Deno.test("extractExponent returns correct exponent for various numbers", () => {
+  // Large positive number
+  assertEquals(extractExponent(123456.789), 5);
+
+  // Small positive number
+  assertEquals(extractExponent(0.000123), -4);
+
+  // Negative number
+  assertEquals(extractExponent(-456.78), 2);
+
+  // Very small number (scientific notation)
+  assertEquals(extractExponent(1.23e-10), -10);
+
+  // Very large number
+  assertEquals(extractExponent(9.87e15), 15);
+
+  // Number close to 1
+  assertEquals(extractExponent(1.5), 0);
+
+  // Zero returns a sentinel value
+  assertEquals(extractExponent(0), -999);
+
+  // Very small number close to zero
+  assertEquals(extractExponent(1e-300), -300);
+});
+
+Deno.test("formatWeight formats weight using exponent only", () => {
+  // Tests that similar weights map to the same string
+  assertEquals(formatWeight(0.123), "e-1");
+  assertEquals(formatWeight(0.234), "e-1"); // Same exponent, same key
+  assertEquals(formatWeight(0.0123), "e-2");
+  assertEquals(formatWeight(-0.123), "e-1"); // Sign doesn't affect exponent
+
+  // Large weights
+  assertEquals(formatWeight(1234.5), "e3");
+  assertEquals(formatWeight(9999.9), "e3");
+
+  // Zero
+  assertEquals(formatWeight(0), "e-999");
+});
+
+Deno.test("buildCacheKey creates reproducible keys for add-synapses candidates", () => {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.123 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.456 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+
+  const candidate = makeCandidate("add-synapses", "test synapse", creature);
+  const key = buildCacheKey(candidate);
+
+  // Key should be deterministic
+  const key2 = buildCacheKey(candidate);
+  assertEquals(key, key2, "Cache key should be reproducible");
+
+  // Key should contain the change type
+  assert(key.includes("add-synapses"), "Key should include change type");
+});
+
+Deno.test("buildCacheKey creates different keys for significantly different weights", () => {
+  const creature1 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.001 }, // e-3
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature1.validate();
+  CreatureUtil.makeUUID(creature1);
+
+  const creature2 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 10.0 }, // e1 (different order of magnitude)
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature2.validate();
+  CreatureUtil.makeUUID(creature2);
+
+  const candidate1 = makeCandidate("add-synapses", "test", creature1);
+  const candidate2 = makeCandidate("add-synapses", "test", creature2);
+
+  const key1 = buildCacheKey(candidate1);
+  const key2 = buildCacheKey(candidate2);
+
+  assert(
+    key1 !== key2,
+    "Cache keys should differ for significantly different weights",
+  );
+});
+
+Deno.test("buildCacheKey creates same keys for similar weights", () => {
+  const creature1 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.123 }, // e-1
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature1.validate();
+  CreatureUtil.makeUUID(creature1);
+
+  const creature2 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.234 }, // e-1 (same order of magnitude)
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature2.validate();
+  CreatureUtil.makeUUID(creature2);
+
+  const candidate1 = makeCandidate("add-synapses", "test", creature1);
+  const candidate2 = makeCandidate("add-synapses", "test", creature2);
+
+  const key1 = buildCacheKey(candidate1);
+  const key2 = buildCacheKey(candidate2);
+
+  assertEquals(
+    key1,
+    key2,
+    "Cache keys should be same for weights with same order of magnitude",
+  );
+});
+
+Deno.test("buildCacheKey includes neuron details for add-neurons candidates", () => {
+  const creature = makeSimpleCreature();
+  const candidate: DiscoveryCandidate = {
+    creature,
+    change: {
+      type: "add-neurons",
+      description: "Add neuron",
+      neuronDetails: {
+        fromNeuronUUID: "input-0",
+        toNeuronUUID: "output-0",
+        incomingWeight: 0.5,
+        outgoingWeight: -0.3,
+        bias: 0.1,
+        squash: "TANH",
+      },
+    },
+  };
+
+  const key = buildCacheKey(candidate);
+  assert(key.includes("add-neurons"), "Key should include change type");
+  assert(key.includes("input-0"), "Key should include from neuron UUID");
+  assert(key.includes("output-0"), "Key should include to neuron UUID");
+  assert(key.includes("TANH"), "Key should include squash function");
+});
+
+Deno.test("buildCacheKey handles remove-low-impact candidates", () => {
+  const creature = makeSimpleCreature();
+  const candidate: DiscoveryCandidate = {
+    creature,
+    change: {
+      type: "remove-low-impact",
+      description: "Remove low-impact neuron hidden-1 (impact: 1.23e-10)",
+    },
+  };
+
+  const key = buildCacheKey(candidate);
+  assert(key.includes("remove-low-impact"), "Key should include change type");
+  // The key should extract the neuron UUID from description
+  assert(
+    key.includes("hidden-1"),
+    "Key should include neuron UUID from description",
+  );
+});
+
+Deno.test("recordFailure and isCandidateCached work together", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const creature = makeSimpleCreature();
+    const candidate = makeCandidate("add-synapses", "test synapse", creature);
+
+    // Initially should not be cached
+    const cachedBefore = await isCandidateCached(tempDir, candidate);
+    assertEquals(
+      cachedBefore,
+      false,
+      "Candidate should not be cached initially",
+    );
+
+    // Record the failure
+    await recordFailure(tempDir, candidate, {
+      originalScore: 0.5,
+      candidateScore: 0.4,
+      scoreDelta: -0.1,
+      error: 0.6,
+    });
+
+    // Now should be cached
+    const cachedAfter = await isCandidateCached(tempDir, candidate);
+    assertEquals(
+      cachedAfter,
+      true,
+      "Candidate should be cached after recording failure",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("isCandidateCached returns false when cache dir doesn't exist", async () => {
+  const nonExistentDir = "/tmp/non-existent-discovery-cache-" + Date.now();
+  const candidate = makeCandidate("add-synapses", "test", makeSimpleCreature());
+
+  const cached = await isCandidateCached(nonExistentDir, candidate);
+  assertEquals(
+    cached,
+    false,
+    "Should return false for non-existent cache directory",
+  );
+});
+
+Deno.test("recordFailure creates directory structure if needed", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const nestedDir = `${tempDir}/nested/cache/dir`;
+
+  try {
+    const creature = makeSimpleCreature();
+    const candidate = makeCandidate("change-squash", "test squash", creature);
+
+    // Record failure in nested directory that doesn't exist
+    await recordFailure(nestedDir, candidate, {
+      originalScore: 0.5,
+      candidateScore: 0.45,
+      scoreDelta: -0.05,
+      error: 0.55,
+    });
+
+    // Verify the cache file was created
+    const cached = await isCandidateCached(nestedDir, candidate);
+    assertEquals(
+      cached,
+      true,
+      "Candidate should be cached in newly created directory",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("different change types create different cache keys", () => {
+  const creature = makeSimpleCreature();
+
+  const synapsesCandidate = makeCandidate("add-synapses", "test", creature);
+  const neuronsCandidate = makeCandidate("add-neurons", "test", creature);
+  const squashCandidate = makeCandidate("change-squash", "test", creature);
+
+  const key1 = buildCacheKey(synapsesCandidate);
+  const key2 = buildCacheKey(neuronsCandidate);
+  const key3 = buildCacheKey(squashCandidate);
+
+  assert(
+    key1 !== key2,
+    "add-synapses and add-neurons should have different keys",
+  );
+  assert(
+    key2 !== key3,
+    "add-neurons and change-squash should have different keys",
+  );
+  assert(
+    key1 !== key3,
+    "add-synapses and change-squash should have different keys",
+  );
+});
+
+Deno.test("buildCacheKey handles edge case of empty synapses", () => {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1.0 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+
+  const candidate = makeCandidate("add-synapses", "test", creature);
+  const key = buildCacheKey(candidate);
+
+  // Should not throw and should produce a valid key
+  assert(typeof key === "string", "Key should be a string");
+  assert(key.length > 0, "Key should not be empty");
+});

--- a/test/discovery/FailureCache.ts
+++ b/test/discovery/FailureCache.ts
@@ -363,3 +363,103 @@ Deno.test("buildCacheKey handles edge case of empty synapses", () => {
   assert(typeof key === "string", "Key should be a string");
   assert(key.length > 0, "Key should not be empty");
 });
+
+Deno.test("buildCacheKey creates different keys for different output squash functions", () => {
+  // Issue: Output neurons were excluded from structural signature, so candidates
+  // differing only in output neuron squash functions would have identical keys.
+  const creature1 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature1.validate();
+  CreatureUtil.makeUUID(creature1);
+
+  const creature2 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "TANH", bias: 0.1 }, // Different squash
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature2.validate();
+  CreatureUtil.makeUUID(creature2);
+
+  const candidate1 = makeCandidate("change-squash", "test", creature1);
+  const candidate2 = makeCandidate("change-squash", "test", creature2);
+
+  const key1 = buildCacheKey(candidate1);
+  const key2 = buildCacheKey(candidate2);
+
+  assert(
+    key1 !== key2,
+    "Cache keys should differ when output neuron squash functions differ",
+  );
+});
+
+Deno.test("buildCacheKey produces deterministic keys regardless of neuron order", () => {
+  // Issue: Hidden neurons weren't sorted, so the same structure with neurons
+  // in different order could produce different signatures.
+
+  // Creature with hidden neurons in one order
+  const creature1 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-a", squash: "TANH", bias: 0.5 },
+      { type: "hidden", uuid: "hidden-b", squash: "RELU", bias: 0.3 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: 0.5 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature1.validate();
+  CreatureUtil.makeUUID(creature1);
+
+  // Same creature with hidden neurons declared in reverse order
+  const creature2 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-b", squash: "RELU", bias: 0.3 },
+      { type: "hidden", uuid: "hidden-a", squash: "TANH", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: 0.5 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature2.validate();
+  CreatureUtil.makeUUID(creature2);
+
+  const candidate1 = makeCandidate("add-synapses", "test", creature1);
+  const candidate2 = makeCandidate("add-synapses", "test", creature2);
+
+  const key1 = buildCacheKey(candidate1);
+  const key2 = buildCacheKey(candidate2);
+
+  assertEquals(
+    key1,
+    key2,
+    "Cache keys should be identical for structurally identical creatures regardless of neuron declaration order",
+  );
+});


### PR DESCRIPTION
- Bumped version in deno.json to 0.234.0.
- Added a new feature to cache discovery failures, allowing the system to skip candidates that previously failed to improve the score, enhancing efficiency in iterative discovery runs.
- Updated NeatOptions and NeatConfig to include a new property for specifying the failure cache directory.
- Enhanced DiscoveryRunner to filter out cached candidates and cache failed candidates during discovery evaluations.
- Introduced tests to validate the caching mechanism, ensuring that failed candidates are correctly cached and skipped in subsequent runs.

These changes aim to optimize the discovery process by reducing redundant evaluations and improving overall performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a discovery failure cache with optional directory, integrating skip-and-record logic into DiscoveryRunner and documenting it, plus tests and a version bump.
> 
> - **Discovery**:
>   - **Failure cache**: New `src/discovery/FailureCache.ts` to key, check, and persist failed candidates (exponent-based keys).
>   - **Runner integration**: `DiscoveryRunner` filters cached candidates in Phase 1 and 2 via `filterCachedCandidates` and records failures via `recordFailureSync` when `discoveryFailureCacheDir` is set.
> - **Config/API**:
>   - Add `discoveryFailureCacheDir` to `NeatOptions`/`NeatConfig`.
> - **Docs**:
>   - README adds "Discovery Failure Cache" section with usage, behavior, and caveats.
> - **Tests**:
>   - Add unit tests for cache keying, recording, skipping, and ensuring successful candidates aren’t cached.
> - **Version**:
>   - Bump `deno.json` version to `0.234.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76b4a5ff61989d832d2fce176d527f2d701fc53b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->