### PR TITLE
chore: update version to 0.235.0 and enhance discovery candidate filt…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.234.0",
+  "version": "0.235.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -924,8 +924,6 @@ export class DiscoveryRunner {
       expected?: number;
     }>;
   } {
-    const maxCandidates = 2 * threadCount;
-
     // Calculate the minimum expected improvement threshold
     const multiplier = config.discoveryMinImprovementVsCostOfGrowthMultiplier;
     const minExpectedImprovement = config.costOfGrowth * multiplier;
@@ -1032,6 +1030,10 @@ export class DiscoveryRunner {
       });
     }
 
+    // Calculate maxCandidates: ensure we have enough slots for diversity (one per category)
+    // while also scaling with CPU count on larger machines
+    const maxCandidates = Math.max(2 * threadCount, byCategory.size);
+
     // PHASE 1: Select at least one from each category (ensuring diversity)
     const selected: DiscoveryCandidate[] = [];
     const usedFromCategory = new Map<string, number>();
@@ -1045,47 +1047,47 @@ export class DiscoveryRunner {
     }
 
     // PHASE 2: Fill remaining slots with best overall candidates
-    const remainingSlots = maxCandidates - selected.length;
-    if (remainingSlots > 0) {
-      // Collect all remaining candidates (not yet selected) with their expected values
-      const remaining: Array<{
-        candidate: DiscoveryCandidate;
-        expected: number | undefined;
-      }> = [];
+    // Always collect remaining candidates to ensure complete skipped tracking
+    const remaining: Array<{
+      candidate: DiscoveryCandidate;
+      expected: number | undefined;
+    }> = [];
 
-      for (const [type, categoryCandidates] of byCategory) {
-        const usedCount = usedFromCategory.get(type) ?? 0;
-        for (let i = usedCount; i < categoryCandidates.length; i++) {
-          remaining.push({
-            candidate: categoryCandidates[i],
-            expected: categoryCandidates[i].change.expectedErrorReduction,
-          });
-        }
-      }
-
-      // Sort by expected improvement (descending)
-      remaining.sort((a, b) => {
-        if (a.expected !== undefined && b.expected !== undefined) {
-          return b.expected - a.expected;
-        }
-        if (a.expected !== undefined) return -1;
-        if (b.expected !== undefined) return 1;
-        return 0;
-      });
-
-      // Take the best remaining candidates
-      const additionalCount = Math.min(remainingSlots, remaining.length);
-      for (let i = 0; i < additionalCount; i++) {
-        selected.push(remaining[i].candidate);
-      }
-
-      // Mark the rest as skipped
-      for (let i = additionalCount; i < remaining.length; i++) {
-        skipped.push({
-          changeType: remaining[i].candidate.change.type,
-          expected: remaining[i].expected,
+    for (const [type, categoryCandidates] of byCategory) {
+      const usedCount = usedFromCategory.get(type) ?? 0;
+      for (let i = usedCount; i < categoryCandidates.length; i++) {
+        remaining.push({
+          candidate: categoryCandidates[i],
+          expected: categoryCandidates[i].change.expectedErrorReduction,
         });
       }
+    }
+
+    // Sort by expected improvement (descending)
+    remaining.sort((a, b) => {
+      if (a.expected !== undefined && b.expected !== undefined) {
+        return b.expected - a.expected;
+      }
+      if (a.expected !== undefined) return -1;
+      if (b.expected !== undefined) return 1;
+      return 0;
+    });
+
+    // Calculate available slots (may be 0 or negative if categories exceed maxCandidates)
+    const remainingSlots = Math.max(0, maxCandidates - selected.length);
+
+    // Take the best remaining candidates up to available slots
+    const additionalCount = Math.min(remainingSlots, remaining.length);
+    for (let i = 0; i < additionalCount; i++) {
+      selected.push(remaining[i].candidate);
+    }
+
+    // Mark the rest as skipped (always executed, even when remainingSlots <= 0)
+    for (let i = additionalCount; i < remaining.length; i++) {
+      skipped.push({
+        changeType: remaining[i].candidate.change.type,
+        expected: remaining[i].expected,
+      });
     }
 
     // Log diversity selection summary

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -20,11 +20,7 @@ import {
 import { WorkerHandler } from "../multithreading/workers/WorkerHandler.ts";
 
 import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
-import {
-  filterCachedCandidates,
-  isCandidateCachedSync,
-  recordFailureSync,
-} from "./FailureCache.ts";
+import { isCandidateCachedSync, recordFailureSync } from "./FailureCache.ts";
 
 export interface DiscoveryRunnerWorker {
   discover(
@@ -286,27 +282,17 @@ export class DiscoveryRunner {
         );
       }
 
-      // Filter out cached failures if failure cache is enabled
-      const { filtered: uncachedCandidates, cachedCount } =
-        filterCachedCandidates(failureCacheDir, filteredSingleCandidates);
-      if (cachedCount > 0) {
-        verboseLog(
-          `Skipped ${cachedCount} candidate${
-            cachedCount === 1 ? "" : "s"
-          } from failure cache (previously failed to improve).`,
-        );
-      }
-
       markPhase("Candidate synthesis (Phase 1)", candidateBuildStart);
 
       // Phase 1 evaluation: Score single candidates + original
+      // Note: Cached candidates are already filtered out in #filterCandidatesForEvaluation
       const phase1Tasks: Array<{
         kind: "original" | "candidate";
         creature: Creature;
         candidate?: DiscoveryCandidate;
       }> = [
         { kind: "original", creature },
-        ...uncachedCandidates.map((candidate) => ({
+        ...filteredSingleCandidates.map((candidate) => ({
           kind: "candidate" as const,
           creature: candidate.creature,
           candidate,
@@ -375,19 +361,9 @@ export class DiscoveryRunner {
               failureCacheDir,
             );
 
-          // Filter out cached failures for combined candidates too
-          const { filtered: filteredCombos, cachedCount: comboCachedCount } =
-            filterCachedCandidates(failureCacheDir, thresholdFilteredCombos);
-          if (comboCachedCount > 0) {
-            verboseLog(
-              `[Phase 2] Skipped ${comboCachedCount} combined candidate${
-                comboCachedCount === 1 ? "" : "s"
-              } from failure cache.`,
-            );
-          }
-
-          if (filteredCombos.length > 0) {
-            const phase2Tasks = filteredCombos.map((candidate) => ({
+          // Note: Cached candidates are already filtered out in #filterCandidatesForEvaluation
+          if (thresholdFilteredCombos.length > 0) {
+            const phase2Tasks = thresholdFilteredCombos.map((candidate) => ({
               kind: "candidate" as const,
               creature: candidate.creature,
               candidate,

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -984,13 +984,19 @@ export class DiscoveryRunner {
       // Removal candidates are handled separately - they improve score, not error
       if (isRemovalCandidate) {
         cacheStats.totalRemoval++;
-        if (isCached) cacheStats.cachedRemoval++;
+        if (isCached) {
+          cacheStats.cachedRemoval++;
+          continue; // Skip cached candidates - don't let them consume slots
+        }
         removalCandidates.push(candidate);
         continue;
       }
 
       cacheStats.totalOther++;
-      if (isCached) cacheStats.cachedOther++;
+      if (isCached) {
+        cacheStats.cachedOther++;
+        continue; // Skip cached candidates - don't let them consume slots
+      }
 
       // Check threshold for non-removal candidates
       let meetsThreshold = true;

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -20,7 +20,11 @@ import {
 import { WorkerHandler } from "../multithreading/workers/WorkerHandler.ts";
 
 import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
-import { filterCachedCandidates, recordFailureSync } from "./FailureCache.ts";
+import {
+  filterCachedCandidates,
+  isCandidateCachedSync,
+  recordFailureSync,
+} from "./FailureCache.ts";
 
 export interface DiscoveryRunnerWorker {
   discover(
@@ -254,11 +258,15 @@ export class DiscoveryRunner {
         }: ${singleCandidates.map((c) => c.change.type).join(", ") || "none"}.`,
       );
 
+      // Get failure cache directory for statistics and filtering
+      const failureCacheDir = config.discoveryFailureCacheDir;
+
       const { filtered: filteredSingleCandidates, skipped } = this
         .#filterCandidatesForEvaluation(
           singleCandidates,
           workerCount,
           config,
+          failureCacheDir,
         );
       if (skipped.length > 0) {
         const minThreshold = config.costOfGrowth *
@@ -279,7 +287,6 @@ export class DiscoveryRunner {
       }
 
       // Filter out cached failures if failure cache is enabled
-      const failureCacheDir = config.discoveryFailureCacheDir;
       const { filtered: uncachedCandidates, cachedCount } =
         filterCachedCandidates(failureCacheDir, filteredSingleCandidates);
       if (cachedCount > 0) {
@@ -365,6 +372,7 @@ export class DiscoveryRunner {
               combinedCandidates,
               workerCount,
               config,
+              failureCacheDir,
             );
 
           // Filter out cached failures for combined candidates too
@@ -914,22 +922,25 @@ export class DiscoveryRunner {
    * Filters discovery candidates for evaluation.
    *
    * Strategy:
-   * 1. ALWAYS include a few random removal candidates (they improve score, not error)
-   * 2. Include candidates with expected error reduction >= threshold
-   * 3. If there are more than 2x CPU cores candidates, select the best estimated ones
+   * 1. Group candidates by category (add-neurons, add-synapses, change-squash, remove-low-impact)
+   * 2. Select at least one from each category (ensuring diversity)
+   * 3. Fill remaining slots with best expected improvements across categories
+   * 4. Count failure cache statistics during selection (single pass)
    *
    * Removal candidates are treated separately because they don't reduce error -
-   * they improve SCORE by reducing complexity. So they shouldn't compete with
-   * add-neuron candidates that have expected error reduction.
+   * they improve SCORE by reducing complexity.
    *
    * @param candidates - All discovery candidates
    * @param threadCount - Number of CPU threads available
+   * @param config - NEAT configuration
+   * @param failureCacheDir - Optional failure cache directory for statistics
    * @returns Filtered candidates ready for evaluation and list of skipped candidates
    */
   #filterCandidatesForEvaluation(
     candidates: DiscoveryCandidate[],
     threadCount: number,
     config: NeatConfig,
+    failureCacheDir?: string,
   ): {
     filtered: DiscoveryCandidate[];
     skipped: Array<{
@@ -943,68 +954,174 @@ export class DiscoveryRunner {
     const multiplier = config.discoveryMinImprovementVsCostOfGrowthMultiplier;
     const minExpectedImprovement = config.costOfGrowth * multiplier;
 
-    // Separate candidates into categories
+    // Group candidates by category for diversity selection
+    const byCategory = new Map<string, DiscoveryCandidate[]>();
     const removalCandidates: DiscoveryCandidate[] = [];
-    const otherCandidates: DiscoveryCandidate[] = [];
     const skipped: Array<{
       changeType?: DiscoveryChangeType;
       expected?: number;
     }> = [];
 
+    // Track failure cache statistics (single pass)
+    const cacheStats = {
+      totalRemoval: 0,
+      cachedRemoval: 0,
+      totalOther: 0,
+      cachedOther: 0,
+    };
+
     for (const candidate of candidates) {
       CreatureUtil.makeUUID(candidate.creature);
       const expected = candidate.change.expectedErrorReduction;
-      const isRemovalCandidate = candidate.change.type === "remove-low-impact";
+      const changeType = candidate.change.type;
+      const isRemovalCandidate = changeType === "remove-low-impact";
+
+      // Check failure cache (single pass for all candidates)
+      const isCached = failureCacheDir
+        ? isCandidateCachedSync(failureCacheDir, candidate)
+        : false;
 
       // Removal candidates are handled separately - they improve score, not error
       if (isRemovalCandidate) {
+        cacheStats.totalRemoval++;
+        if (isCached) cacheStats.cachedRemoval++;
         removalCandidates.push(candidate);
         continue;
       }
 
-      if (expected === undefined) {
-        // No expected value - include for evaluation (combo candidates, etc.)
-        otherCandidates.push(candidate);
-      } else if (Number.isFinite(expected)) {
-        // When multiplier is 0, use strict positive check (expected > 0)
-        // Otherwise, check against threshold (expected >= minExpectedImprovement)
-        const meetsThreshold = multiplier === 0
-          ? expected > 0
-          : expected >= minExpectedImprovement;
+      cacheStats.totalOther++;
+      if (isCached) cacheStats.cachedOther++;
 
-        if (meetsThreshold) {
-          otherCandidates.push(candidate);
+      // Check threshold for non-removal candidates
+      let meetsThreshold = true;
+      if (expected !== undefined) {
+        if (!Number.isFinite(expected)) {
+          meetsThreshold = false;
         } else {
-          skipped.push({
-            changeType: candidate.change.type,
-            expected,
+          meetsThreshold = multiplier === 0
+            ? expected > 0
+            : expected >= minExpectedImprovement;
+        }
+      }
+
+      if (!meetsThreshold) {
+        skipped.push({ changeType, expected });
+        continue;
+      }
+
+      // Group by category for diversity selection
+      if (!byCategory.has(changeType)) {
+        byCategory.set(changeType, []);
+      }
+      byCategory.get(changeType)!.push(candidate);
+    }
+
+    // Log failure cache statistics (single pass complete)
+    if (failureCacheDir) {
+      if (cacheStats.cachedRemoval > 0 || cacheStats.cachedOther > 0) {
+        const parts: string[] = [];
+        if (cacheStats.totalRemoval > 0) {
+          parts.push(
+            `removal: ${cacheStats.cachedRemoval}/${cacheStats.totalRemoval} cached`,
+          );
+        }
+        if (cacheStats.totalOther > 0) {
+          parts.push(
+            `other: ${cacheStats.cachedOther}/${cacheStats.totalOther} cached`,
+          );
+        }
+        console.info(
+          `[DiscoveryRunner] Failure cache stats: ${parts.join(", ")}`,
+        );
+      }
+    }
+
+    // Sort each category by expected improvement (descending)
+    for (const [_type, categoryCandidates] of byCategory) {
+      categoryCandidates.sort((a, b) => {
+        const aExpected = a.change.expectedErrorReduction;
+        const bExpected = b.change.expectedErrorReduction;
+        if (aExpected !== undefined && bExpected !== undefined) {
+          return bExpected - aExpected;
+        }
+        if (aExpected !== undefined) return -1;
+        if (bExpected !== undefined) return 1;
+        return 0;
+      });
+    }
+
+    // PHASE 1: Select at least one from each category (ensuring diversity)
+    const selected: DiscoveryCandidate[] = [];
+    const usedFromCategory = new Map<string, number>();
+
+    // Take the best from each non-removal category first
+    for (const [type, categoryCandidates] of byCategory) {
+      if (categoryCandidates.length > 0) {
+        selected.push(categoryCandidates[0]);
+        usedFromCategory.set(type, 1);
+      }
+    }
+
+    // PHASE 2: Fill remaining slots with best overall candidates
+    const remainingSlots = maxCandidates - selected.length;
+    if (remainingSlots > 0) {
+      // Collect all remaining candidates (not yet selected) with their expected values
+      const remaining: Array<{
+        candidate: DiscoveryCandidate;
+        expected: number | undefined;
+      }> = [];
+
+      for (const [type, categoryCandidates] of byCategory) {
+        const usedCount = usedFromCategory.get(type) ?? 0;
+        for (let i = usedCount; i < categoryCandidates.length; i++) {
+          remaining.push({
+            candidate: categoryCandidates[i],
+            expected: categoryCandidates[i].change.expectedErrorReduction,
           });
         }
-      } else {
-        // Non-finite expected value - skip it
+      }
+
+      // Sort by expected improvement (descending)
+      remaining.sort((a, b) => {
+        if (a.expected !== undefined && b.expected !== undefined) {
+          return b.expected - a.expected;
+        }
+        if (a.expected !== undefined) return -1;
+        if (b.expected !== undefined) return 1;
+        return 0;
+      });
+
+      // Take the best remaining candidates
+      const additionalCount = Math.min(remainingSlots, remaining.length);
+      for (let i = 0; i < additionalCount; i++) {
+        selected.push(remaining[i].candidate);
+      }
+
+      // Mark the rest as skipped
+      for (let i = additionalCount; i < remaining.length; i++) {
         skipped.push({
-          changeType: candidate.change.type,
-          expected,
+          changeType: remaining[i].candidate.change.type,
+          expected: remaining[i].expected,
         });
       }
     }
 
-    // Sort other candidates by expected error reduction (descending)
-    // Candidates with undefined expectedErrorReduction are sorted to the end
-    otherCandidates.sort((a, b) => {
-      const aExpected = a.change.expectedErrorReduction;
-      const bExpected = b.change.expectedErrorReduction;
-      if (aExpected !== undefined && bExpected !== undefined) {
-        return bExpected - aExpected;
-      }
-      if (aExpected !== undefined) return -1;
-      if (bExpected !== undefined) return 1;
-      return 0;
-    });
+    // Log diversity selection summary
+    const diversitySummary = Array.from(byCategory.keys())
+      .map((type) => {
+        const total = byCategory.get(type)!.length;
+        const selectedCount = selected.filter((c) => c.change.type === type)
+          .length;
+        return `${type}: ${selectedCount}/${total}`;
+      })
+      .join(", ");
+    if (byCategory.size > 0) {
+      console.info(
+        `[DiscoveryRunner] Category diversity: ${diversitySummary}`,
+      );
+    }
 
-    // ALWAYS include a few removal candidates (minimum 3, or all if fewer)
-    // These are added ON TOP of the regular selection, not competing for the same slots
-    // Strategy: Pick randomly from the TOP 10 lowest-impact candidates (safest to remove)
+    // PHASE 3: Select removal candidates (separately, added on top)
     const removalSampleSize = Math.min(removalCandidates.length, 3);
     let selectedRemovalCandidates: DiscoveryCandidate[];
 
@@ -1043,18 +1160,18 @@ export class DiscoveryRunner {
           topCandidates[i],
         ];
       }
-      const selected = topCandidates.slice(0, removalSampleSize);
-      selectedRemovalCandidates = selected.map((s) => s.candidate);
+      const selectedTop = topCandidates.slice(0, removalSampleSize);
+      selectedRemovalCandidates = selectedTop.map((s) => s.candidate);
 
       // Log which ones were chosen with their impact values
-      const selectedDetails = selected
+      const selectedDetails = selectedTop
         .map((s) => `${s.impact.toExponential(2)}`)
         .join(", ");
       console.info(
-        `[DiscoveryRunner] ✓ Selected ${removalSampleSize} from top ${topCandidates.length}: [${selectedDetails}]`,
+        `[DiscoveryRunner] ✓ Selected ${removalSampleSize} removal from top ${topCandidates.length}: [${selectedDetails}]`,
       );
 
-      // Mark remaining candidates as skipped (both unselected from top pool and those outside top 10)
+      // Mark remaining candidates as skipped
       const selectedSet = new Set(selectedRemovalCandidates);
       for (const item of candidatesWithImpact) {
         if (!selectedSet.has(item.candidate)) {
@@ -1066,23 +1183,8 @@ export class DiscoveryRunner {
       }
     }
 
-    // Select other candidates up to the max limit
-    let selectedOtherCandidates: DiscoveryCandidate[];
-    if (otherCandidates.length <= maxCandidates) {
-      selectedOtherCandidates = otherCandidates;
-    } else {
-      selectedOtherCandidates = otherCandidates.slice(0, maxCandidates);
-
-      for (const candidate of otherCandidates.slice(maxCandidates)) {
-        skipped.push({
-          changeType: candidate.change.type,
-          expected: candidate.change.expectedErrorReduction,
-        });
-      }
-    }
-
     // Combine: other candidates first, then removal candidates (added on top)
-    const filtered = [...selectedOtherCandidates, ...selectedRemovalCandidates];
+    const filtered = [...selected, ...selectedRemovalCandidates];
 
     return { filtered, skipped };
   }


### PR DESCRIPTION
…ering logic

- Bumped version in deno.json to 0.235.0.
- Improved the filtering logic in DiscoveryRunner to include failure cache statistics during candidate selection, ensuring a more efficient evaluation process.
- Enhanced candidate grouping by category to ensure diversity in selection, improving the overall robustness of the discovery process.

These changes aim to refine the candidate evaluation strategy and enhance the effectiveness of the discovery workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps version and overhauls DiscoveryRunner candidate filtering to be category-diverse with integrated failure-cache checks/stats and centralized filtering across phases.
> 
> - **Discovery** (`src/discovery/DiscoveryRunner.ts`):
>   - **Centralized filtering**: `#filterCandidatesForEvaluation` now takes `config` and optional `failureCacheDir`, performs failure-cache checks via `isCandidateCachedSync`, and is used for both single and combined candidates (removed separate cache-filtering calls).
>   - **Selection strategy**:
>     - Group by change type; select at least one per category for diversity.
>     - Fill remaining slots by highest `expectedErrorReduction`; log category diversity summary.
>     - Handle `remove-low-impact` separately: sample up to 3 from top-10 lowest-impact; refined logging of selections.
>   - **Failure cache stats**: Collect and log cached vs total candidates (removal/other) during filtering.
>   - **Evaluation phases**: Phase 1/2 now rely on pre-filtered candidates; removed `uncachedCandidates` flow and redundant combo cache filtering.
> - **Config** (`deno.json`):
>   - Version bumped to `0.235.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f74de551228d947be20f9c151c6d175ad4eaf065. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->