### PR TITLE
chore: update version to 0.236.0 and enhance synapse removal details

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,11 +230,13 @@ const result = await creature.discoveryDir(dataDir, {
 
 **Cache key design:**
 
-- Uses the exponential component of weights/biases in scientific notation
-- Weights like `0.123` and `0.234` (both `e-1`) map to the same key
-- Weights like `0.001` (`e-3`) and `0.1` (`e-1`) map to different keys
-- This allows similar candidates to be cached together while still re-trying
-  when weights change significantly
+- **Neuron removal** (`remove-neuron`, `remove-low-impact`): Uses just the
+  neuron UUID - if removal failed once, it won't succeed until the creature
+  structure changes significantly
+- **Synapse removal** (`remove-synapse`): Uses just the from/to neuron UUIDs
+- **Other candidates**: Uses the exponential component of weights/biases in
+  scientific notation - weights like `0.123` and `0.234` (both `e-1`) map to the
+  same key, while `0.001` (`e-3`) and `0.1` (`e-1`) map to different keys
 
 ### Forced Focus Overrides
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.235.0",
+  "version": "0.236.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -44,6 +44,14 @@ export interface DiscoveredNeuronDetails {
   squash: string;
 }
 
+/** Details of a synapse removal for caching/logging. */
+export interface SynapseRemovalDetails {
+  /** Source neuron UUID. */
+  fromNeuronUUID: string;
+  /** Target neuron UUID. */
+  toNeuronUUID: string;
+}
+
 interface DiscoveryCandidateChange {
   type: DiscoveryChangeType;
   description?: string;
@@ -51,6 +59,8 @@ interface DiscoveryCandidateChange {
   sampleSize?: number;
   /** Details of discovered neurons (for single neuron candidates). */
   neuronDetails?: DiscoveredNeuronDetails;
+  /** Details of synapse removal (for synapse removal candidates). */
+  synapseDetails?: SynapseRemovalDetails;
 }
 
 export interface DiscoveryCandidate {
@@ -240,14 +250,20 @@ export function buildDiscoveryCandidates(
     baseCreature,
     removeHarmfulSynapse,
   );
-  if (removedSynapseCreature) {
+  if (removedSynapseCreature && removeHarmfulSynapse) {
     candidates.push({
       creature: removedSynapseCreature,
       change: {
         type: "remove-synapse",
-        description: "✂️ Removed harmful synapse",
+        description: `✂️ Removed harmful synapse ${
+          shortID(removeHarmfulSynapse.fromNeuronUUID)
+        } -> ${shortID(removeHarmfulSynapse.toNeuronUUID)}`,
         expectedErrorReduction: scaledRemovalExpected(removeHarmfulSynapse),
-        sampleSize: removeHarmfulSynapse?.totalCount,
+        sampleSize: removeHarmfulSynapse.totalCount,
+        synapseDetails: {
+          fromNeuronUUID: removeHarmfulSynapse.fromNeuronUUID,
+          toNeuronUUID: removeHarmfulSynapse.toNeuronUUID,
+        },
       },
     });
 

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -998,20 +998,27 @@ export class DiscoveryRunner {
 
     // Log failure cache statistics (single pass complete)
     if (failureCacheDir) {
-      if (cacheStats.cachedRemoval > 0 || cacheStats.cachedOther > 0) {
+      const totalCached = cacheStats.cachedRemoval + cacheStats.cachedOther;
+      if (totalCached > 0) {
         const parts: string[] = [];
-        if (cacheStats.totalRemoval > 0) {
+        if (cacheStats.cachedRemoval > 0) {
           parts.push(
-            `removal: ${cacheStats.cachedRemoval}/${cacheStats.totalRemoval} cached`,
+            `${cacheStats.cachedRemoval} removal candidate${
+              cacheStats.cachedRemoval === 1 ? "" : "s"
+            }`,
           );
         }
-        if (cacheStats.totalOther > 0) {
+        if (cacheStats.cachedOther > 0) {
           parts.push(
-            `other: ${cacheStats.cachedOther}/${cacheStats.totalOther} cached`,
+            `${cacheStats.cachedOther} other candidate${
+              cacheStats.cachedOther === 1 ? "" : "s"
+            }`,
           );
         }
         console.info(
-          `[DiscoveryRunner] Failure cache stats: ${parts.join(", ")}`,
+          `[DiscoveryRunner] ⏭️ Skipped ${totalCached} candidate${
+            totalCached === 1 ? "" : "s"
+          } due to previous failure: ${parts.join(", ")}`,
         );
       }
     }

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -89,7 +89,7 @@ export function buildCacheKey(candidate: DiscoveryCandidate): string {
 
     case "remove-low-impact":
     case "remove-neuron": {
-      // For neuron removal, just use the neuron UUID - no structural signature needed.
+      // For neuron removal, prefer the neuron UUID from description.
       // If removal failed once, it won't succeed until the creature structure changes
       // significantly (at which point the cache should be cleared anyway).
       const uuidMatch = candidate.change.description?.match(
@@ -97,18 +97,24 @@ export function buildCacheKey(candidate: DiscoveryCandidate): string {
       );
       if (uuidMatch) {
         parts.push(uuidMatch[1]);
+      } else {
+        // Fallback: use structural signature to avoid cache collisions
+        parts.push(buildStructuralSignature(candidate));
       }
-      // No structural signature - just the neuron UUID is sufficient
       break;
     }
 
     case "remove-synapse": {
-      // For synapse removal, use from/to UUIDs from synapseDetails
+      // For synapse removal, use from/to UUIDs from synapseDetails.
+      // synapseDetails is always set for remove-synapse candidates created by
+      // buildDiscoveryCandidates - assert to catch any future code changes.
       const synapseDetails = candidate.change.synapseDetails;
-      if (synapseDetails) {
-        parts.push(synapseDetails.fromNeuronUUID, synapseDetails.toNeuronUUID);
+      if (!synapseDetails) {
+        throw new Error(
+          "remove-synapse candidate missing synapseDetails - this indicates a bug",
+        );
       }
-      // No structural signature - just the synapse endpoints are sufficient
+      parts.push(synapseDetails.fromNeuronUUID, synapseDetails.toNeuronUUID);
       break;
     }
 

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -56,8 +56,9 @@ export function formatWeight(weight: number): string {
  *
  * The key incorporates:
  * - Change type
- * - Structural information (neuron UUIDs for connections)
- * - Weight/bias magnitudes (exponents only)
+ * - For neuron removal: just the neuron UUID (simple, fast lookup)
+ * - For synapse removal: just the from/to UUIDs
+ * - For other types: structural information and weight magnitudes
  *
  * @param candidate - The discovery candidate to generate a key for
  * @returns A string suitable for use as a cache filename
@@ -88,15 +89,26 @@ export function buildCacheKey(candidate: DiscoveryCandidate): string {
 
     case "remove-low-impact":
     case "remove-neuron": {
-      // Extract neuron UUID from description (format: "... neuron UUID ...")
+      // For neuron removal, just use the neuron UUID - no structural signature needed.
+      // If removal failed once, it won't succeed until the creature structure changes
+      // significantly (at which point the cache should be cleared anyway).
       const uuidMatch = candidate.change.description?.match(
         /neuron\s+([a-zA-Z0-9_-]+)/i,
       );
       if (uuidMatch) {
         parts.push(uuidMatch[1]);
       }
-      // Also include a structural hash for uniqueness
-      parts.push(buildStructuralSignature(candidate));
+      // No structural signature - just the neuron UUID is sufficient
+      break;
+    }
+
+    case "remove-synapse": {
+      // For synapse removal, use from/to UUIDs from synapseDetails
+      const synapseDetails = candidate.change.synapseDetails;
+      if (synapseDetails) {
+        parts.push(synapseDetails.fromNeuronUUID, synapseDetails.toNeuronUUID);
+      }
+      // No structural signature - just the synapse endpoints are sufficient
       break;
     }
 
@@ -108,7 +120,6 @@ export function buildCacheKey(candidate: DiscoveryCandidate): string {
     }
 
     case "add-synapses":
-    case "remove-synapse":
     default: {
       // For synapses and other types, use structural signature
       parts.push(buildStructuralSignature(candidate));

--- a/test/discovery/CombinedCandidateSequentialApplication.ts
+++ b/test/discovery/CombinedCandidateSequentialApplication.ts
@@ -210,6 +210,10 @@ Deno.test(
       change: {
         type: "remove-synapse",
         description: "Removed hidden-A -> hidden-C synapse",
+        synapseDetails: {
+          fromNeuronUUID: "hidden-A",
+          toNeuronUUID: "hidden-C",
+        },
       },
     };
 

--- a/test/discovery/FailureCache.ts
+++ b/test/discovery/FailureCache.ts
@@ -241,6 +241,161 @@ Deno.test("buildCacheKey handles remove-low-impact candidates", () => {
   );
 });
 
+Deno.test("buildCacheKey avoids cache collision when description is undefined", () => {
+  // Issue: If description is undefined, parts only contains [type], causing all
+  // such candidates to have identical cache keys regardless of their structure.
+  const creature1 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-a", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature1.validate();
+  CreatureUtil.makeUUID(creature1);
+
+  const creature2 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-b", squash: "TANH", bias: 0.3 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-b", weight: 0.8 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: 0.8 },
+    ],
+  });
+  creature2.validate();
+  CreatureUtil.makeUUID(creature2);
+
+  // Both candidates have undefined description - should NOT produce same key
+  const candidate1: DiscoveryCandidate = {
+    creature: creature1,
+    change: { type: "remove-neuron" },
+  };
+  const candidate2: DiscoveryCandidate = {
+    creature: creature2,
+    change: { type: "remove-neuron" },
+  };
+
+  const key1 = buildCacheKey(candidate1);
+  const key2 = buildCacheKey(candidate2);
+
+  assert(
+    key1 !== key2,
+    "Different creatures with undefined description should have different cache keys",
+  );
+  // Keys should contain more than just the type
+  assert(
+    key1.length > "remove-neuron".length + 5,
+    "Key should contain structural information, not just type",
+  );
+});
+
+Deno.test("buildCacheKey avoids cache collision when description doesn't match regex", () => {
+  // Issue: If description doesn't match the neuron UUID regex pattern,
+  // no fallback was called, causing identical cache keys.
+  const creature1 = makeSimpleCreature();
+  const creature2 = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "other-hidden", squash: "TANH", bias: 0.9 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "other-hidden", weight: 1.5 },
+      { fromUUID: "other-hidden", toUUID: "output-0", weight: 1.5 },
+    ],
+  });
+  creature2.validate();
+  CreatureUtil.makeUUID(creature2);
+
+  // Descriptions that don't match the pattern /neuron\s+([a-zA-Z0-9_-]+)/i
+  const candidate1: DiscoveryCandidate = {
+    creature: creature1,
+    change: {
+      type: "remove-low-impact",
+      description: "Some unrelated description",
+    },
+  };
+  const candidate2: DiscoveryCandidate = {
+    creature: creature2,
+    change: {
+      type: "remove-low-impact",
+      description: "Another unrelated description",
+    },
+  };
+
+  const key1 = buildCacheKey(candidate1);
+  const key2 = buildCacheKey(candidate2);
+
+  assert(
+    key1 !== key2,
+    "Different creatures with non-matching descriptions should have different cache keys",
+  );
+});
+
+Deno.test("buildCacheKey throws for remove-synapse without synapseDetails", () => {
+  // remove-synapse candidates created by buildDiscoveryCandidates always have synapseDetails.
+  // This test verifies we catch any future code changes that might break this invariant.
+  const creature = makeSimpleCreature();
+
+  const candidate: DiscoveryCandidate = {
+    creature,
+    change: { type: "remove-synapse" },
+  };
+
+  try {
+    buildCacheKey(candidate);
+    throw new Error(
+      "Expected buildCacheKey to throw for missing synapseDetails",
+    );
+  } catch (error) {
+    assert(
+      (error as Error).message.includes("missing synapseDetails"),
+      `Expected error about missing synapseDetails, got: ${
+        (error as Error).message
+      }`,
+    );
+  }
+});
+
+Deno.test("buildCacheKey works for remove-synapse with synapseDetails", () => {
+  // Verify proper cache key generation when synapseDetails is provided
+  const creature1 = makeSimpleCreature();
+  const creature2 = makeSimpleCreature();
+
+  const candidate1: DiscoveryCandidate = {
+    creature: creature1,
+    change: {
+      type: "remove-synapse",
+      synapseDetails: { fromNeuronUUID: "input-0", toNeuronUUID: "hidden-1" },
+    },
+  };
+  const candidate2: DiscoveryCandidate = {
+    creature: creature2,
+    change: {
+      type: "remove-synapse",
+      synapseDetails: { fromNeuronUUID: "hidden-1", toNeuronUUID: "output-0" },
+    },
+  };
+
+  const key1 = buildCacheKey(candidate1);
+  const key2 = buildCacheKey(candidate2);
+
+  assert(key1 !== key2, "Different synapses should have different cache keys");
+  assert(key1.includes("remove-synapse"), "Key should include type");
+  assert(key1.includes("input-0"), "Key should include fromNeuronUUID");
+  assert(key1.includes("hidden-1"), "Key should include toNeuronUUID");
+});
+
 Deno.test("recordFailure and isCandidateCached work together", async () => {
   const tempDir = await Deno.makeTempDir();
 


### PR DESCRIPTION
- Bumped version in deno.json to 0.236.0.
- Introduced SynapseRemovalDetails interface to provide structured information about synapse removals, including source and target neuron UUIDs.
- Updated DiscoveryCandidateChange to include synapseDetails for better tracking of synapse removal candidates.
- Enhanced logging in DiscoveryRunner to provide clearer statistics on skipped candidates due to previous failures.

These changes aim to improve the clarity and effectiveness of synapse management within the discovery process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines failure-cache keying (neuron/synapse-specific), adds `synapseDetails` to candidates, enhances logging, updates docs, and bumps version to 0.236.0.
> 
> - **Discovery/Failure Cache**:
>   - Refactor `buildCacheKey`:
>     - `remove-neuron`/`remove-low-impact`: key by neuron UUID (fallback to structural signature if missing/mismatched description).
>     - `remove-synapse`: key by `from/to` UUIDs via `change.synapseDetails` (throws if absent).
>     - Other types: continue using structural signature with weight/bias exponents.
> - **Discovery Candidates**:
>   - Add `SynapseRemovalDetails` and `change.synapseDetails`.
>   - Populate `synapseDetails`, `sampleSize`, and concise description for `remove-synapse` candidates.
> - **Runner/Logging**:
>   - Improve failure-cache skip logging with totals and category breakdown.
> - **Tests**:
>   - Add tests preventing cache key collisions and asserting `remove-synapse` requires/properly uses `synapseDetails`.
>   - Update combo application test to include `synapseDetails`.
> - **Docs**:
>   - Update README cache key design to reflect neuron/synapse-specific keys.
> - **Version**:
>   - Bump `deno.json` version to `0.236.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e97e35772892d8e82c466ca0a0b93e35785068a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->