### PR TITLE
chore: update version to 0.237.2 and enhance failure metadata tracking

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.237.1",
+  "version": "0.237.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -412,6 +412,7 @@ export class DiscoveryRunner {
               candidateScore: failed.score,
               scoreDelta: failed.score - original.score,
               error: failed.error,
+              originalError: original.error,
             }, creature); // Pass base creature for actual changes extraction
             cachedFailuresCount++;
           }

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -437,11 +437,13 @@ export async function recordFailure(
       cacheEntry.sampleSize = candidate.change.sampleSize;
     }
 
-    // Compute and include actual error reduction if originalError is available
+    // Compute and include actual error reduction if both errors are finite
     // actualErrorReduction = originalError - candidateError (positive means improvement)
+    // Skip if either error is non-finite (NaN, Infinity) as this indicates evaluation issues
     if (
       metadata.originalError !== undefined &&
-      Number.isFinite(metadata.originalError)
+      Number.isFinite(metadata.originalError) &&
+      Number.isFinite(metadata.error)
     ) {
       const actualErrorReduction = metadata.originalError - metadata.error;
       cacheEntry.actualErrorReduction = actualErrorReduction;
@@ -522,11 +524,13 @@ export function recordFailureSync(
       cacheEntry.sampleSize = candidate.change.sampleSize;
     }
 
-    // Compute and include actual error reduction if originalError is available
+    // Compute and include actual error reduction if both errors are finite
     // actualErrorReduction = originalError - candidateError (positive means improvement)
+    // Skip if either error is non-finite (NaN, Infinity) as this indicates evaluation issues
     if (
       metadata.originalError !== undefined &&
-      Number.isFinite(metadata.originalError)
+      Number.isFinite(metadata.originalError) &&
+      Number.isFinite(metadata.error)
     ) {
       const actualErrorReduction = metadata.originalError - metadata.error;
       cacheEntry.actualErrorReduction = actualErrorReduction;

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -24,7 +24,7 @@ export interface FailureMetadata {
   candidateScore: number;
   scoreDelta: number;
   error: number;
-  /** Original error before the candidate change was applied */
+  /** Re-scored error of the original creature (without candidate changes applied) */
   originalError?: number;
   timestamp?: string;
 }

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -24,6 +24,8 @@ export interface FailureMetadata {
   candidateScore: number;
   scoreDelta: number;
   error: number;
+  /** Original error before the candidate change was applied */
+  originalError?: number;
   timestamp?: string;
 }
 
@@ -435,6 +437,16 @@ export async function recordFailure(
       cacheEntry.sampleSize = candidate.change.sampleSize;
     }
 
+    // Compute and include actual error reduction if originalError is available
+    // actualErrorReduction = originalError - candidateError (positive means improvement)
+    if (
+      metadata.originalError !== undefined &&
+      Number.isFinite(metadata.originalError)
+    ) {
+      const actualErrorReduction = metadata.originalError - metadata.error;
+      cacheEntry.actualErrorReduction = actualErrorReduction;
+    }
+
     // Extract and include actual creature changes for verification
     // This is what TypeScript actually created (after fix() etc.)
     if (baseCreature) {
@@ -508,6 +520,16 @@ export function recordFailureSync(
     // Include sample size if available
     if (candidate.change.sampleSize !== undefined) {
       cacheEntry.sampleSize = candidate.change.sampleSize;
+    }
+
+    // Compute and include actual error reduction if originalError is available
+    // actualErrorReduction = originalError - candidateError (positive means improvement)
+    if (
+      metadata.originalError !== undefined &&
+      Number.isFinite(metadata.originalError)
+    ) {
+      const actualErrorReduction = metadata.originalError - metadata.error;
+      cacheEntry.actualErrorReduction = actualErrorReduction;
     }
 
     // Extract and include actual creature changes for verification

--- a/test/discovery/FailureCache.ts
+++ b/test/discovery/FailureCache.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
 import {
   buildCacheKey,
   extractExponent,
@@ -617,4 +617,152 @@ Deno.test("buildCacheKey produces deterministic keys regardless of neuron order"
     key2,
     "Cache keys should be identical for structurally identical creatures regardless of neuron declaration order",
   );
+});
+
+Deno.test("recordFailure computes actualErrorReduction when originalError is provided", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const creature = makeSimpleCreature();
+    const candidate: DiscoveryCandidate = {
+      creature,
+      change: {
+        type: "add-neurons",
+        description: "Add neuron test",
+        expectedErrorReduction: 0.05, // Expected 5% reduction
+        neuronDetails: {
+          fromNeuronUUID: "input-0",
+          toNeuronUUID: "output-0",
+          incomingWeight: 0.5,
+          outgoingWeight: -0.3,
+          bias: 0.1,
+          squash: "TANH",
+        },
+      },
+    };
+
+    // Record failure with originalError provided
+    // originalError = 0.6, candidateError = 0.58
+    // actualErrorReduction = 0.6 - 0.58 = 0.02 (positive means improvement)
+    await recordFailure(tempDir, candidate, {
+      originalScore: 0.5,
+      candidateScore: 0.48,
+      scoreDelta: -0.02,
+      error: 0.58,
+      originalError: 0.6,
+    });
+
+    // Read the cache file to verify actualErrorReduction was stored
+    const key = buildCacheKey(candidate);
+    const filePath = `${tempDir}/add-neurons/${key}.json`;
+    const content = await Deno.readTextFile(filePath);
+    const parsed = JSON.parse(content);
+
+    // Verify both expected and actual error reduction are present
+    assertEquals(
+      parsed.expectedErrorReduction,
+      0.05,
+      "Expected error reduction should be stored",
+    );
+    assertAlmostEquals(
+      parsed.actualErrorReduction,
+      0.02,
+      1e-9,
+      "Actual error reduction should be computed and stored (0.6 - 0.58 = 0.02)",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("recordFailure omits actualErrorReduction when originalError is not provided", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const creature = makeSimpleCreature();
+    const candidate: DiscoveryCandidate = {
+      creature,
+      change: {
+        type: "add-synapses",
+        description: "Add synapse test",
+        expectedErrorReduction: 0.03,
+      },
+    };
+
+    // Record failure WITHOUT originalError
+    await recordFailure(tempDir, candidate, {
+      originalScore: 0.5,
+      candidateScore: 0.48,
+      scoreDelta: -0.02,
+      error: 0.58,
+      // originalError not provided
+    });
+
+    // Read the cache file to verify actualErrorReduction was NOT stored
+    const key = buildCacheKey(candidate);
+    const filePath = `${tempDir}/add-synapses/${key}.json`;
+    const content = await Deno.readTextFile(filePath);
+    const parsed = JSON.parse(content);
+
+    // Verify expected error reduction is present but actual is not
+    assertEquals(
+      parsed.expectedErrorReduction,
+      0.03,
+      "Expected error reduction should be stored",
+    );
+    assertEquals(
+      parsed.actualErrorReduction,
+      undefined,
+      "Actual error reduction should NOT be stored when originalError is missing",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("recordFailure handles negative actualErrorReduction (error increased)", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const creature = makeSimpleCreature();
+    const candidate: DiscoveryCandidate = {
+      creature,
+      change: {
+        type: "add-neurons",
+        description: "Add neuron that made things worse",
+        expectedErrorReduction: 0.02, // Expected 2% reduction
+      },
+    };
+
+    // Record failure where error actually increased
+    // originalError = 0.5, candidateError = 0.55
+    // actualErrorReduction = 0.5 - 0.55 = -0.05 (negative means error increased)
+    await recordFailure(tempDir, candidate, {
+      originalScore: 0.5,
+      candidateScore: 0.45,
+      scoreDelta: -0.05,
+      error: 0.55,
+      originalError: 0.5,
+    });
+
+    // Read the cache file to verify actualErrorReduction captures the negative value
+    const key = buildCacheKey(candidate);
+    const filePath = `${tempDir}/add-neurons/${key}.json`;
+    const content = await Deno.readTextFile(filePath);
+    const parsed = JSON.parse(content);
+
+    assertAlmostEquals(
+      parsed.actualErrorReduction,
+      -0.05,
+      1e-9,
+      "Actual error reduction should be negative when error increased",
+    );
+    assertEquals(
+      parsed.expectedErrorReduction,
+      0.02,
+      "Expected error reduction should still be the predicted value",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
 });

--- a/test/discovery/FailureCache.ts
+++ b/test/discovery/FailureCache.ts
@@ -766,3 +766,56 @@ Deno.test("recordFailure handles negative actualErrorReduction (error increased)
     await Deno.remove(tempDir, { recursive: true });
   }
 });
+
+Deno.test("recordFailure omits actualErrorReduction when candidateError is Infinity", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const creature = makeSimpleCreature();
+    const candidate: DiscoveryCandidate = {
+      creature,
+      change: {
+        type: "add-neurons",
+        description: "Add neuron that caused evaluation failure",
+        expectedErrorReduction: 0.02,
+      },
+    };
+
+    // Record failure where candidate error is Infinity (worker evaluation failed)
+    // This happens when workers return Number.POSITIVE_INFINITY on failure
+    // Without proper validation, this would store -Infinity in the cache
+    await recordFailure(tempDir, candidate, {
+      originalScore: 0.5,
+      candidateScore: -1, // Score is also bad when error is Infinity
+      scoreDelta: -1.5,
+      error: Number.POSITIVE_INFINITY, // Worker evaluation failure
+      originalError: 0.5, // Original was finite
+    });
+
+    // Read the cache file to verify actualErrorReduction was NOT stored
+    const key = buildCacheKey(candidate);
+    const filePath = `${tempDir}/add-neurons/${key}.json`;
+    const content = await Deno.readTextFile(filePath);
+    const parsed = JSON.parse(content);
+
+    // actualErrorReduction should NOT be stored (it would be -Infinity otherwise)
+    assertEquals(
+      parsed.actualErrorReduction,
+      undefined,
+      "actualErrorReduction should NOT be stored when candidateError is Infinity",
+    );
+    // But error and originalError should still be recorded in metadata
+    assertEquals(
+      parsed.error,
+      null, // JSON serialises Infinity as null
+      "error should be recorded (as null in JSON for Infinity)",
+    );
+    assertEquals(
+      parsed.originalError,
+      0.5,
+      "originalError should be recorded",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
- Bumped version in deno.json to 0.237.2.
- Added originalError property to FailureMetadata interface for better diagnostics.
- Updated recordFailure and recordFailureSync functions to compute actualErrorReduction when originalError is provided.
- Introduced tests to verify correct computation and storage of actualErrorReduction based on originalError.

These changes aim to improve the accuracy of failure tracking and enhance the overall effectiveness of the discovery process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds originalError to failure metadata and computes/stores actualErrorReduction for cached failures, updates DiscoveryRunner to pass it through, and adds targeted tests; bumps version to 0.237.2.
> 
> - **Failure cache** (`src/discovery/FailureCache.ts`):
>   - Extend `FailureMetadata` with optional `originalError`.
>   - Compute and store `actualErrorReduction` when both `originalError` and candidate `error` are finite.
>   - Preserve existing metadata (e.g., `expectedErrorReduction`, `sampleSize`) and actual creature change extraction.
> - **Discovery runner** (`src/discovery/DiscoveryRunner.ts`):
>   - When caching failed candidates, include `originalError` from the original evaluation.
> - **Tests** (`test/discovery/FailureCache.ts`):
>   - Add tests covering `actualErrorReduction` computation, omission when `originalError` missing or non-finite, and negative reductions; include `assertAlmostEquals`.
> - **Config**:
>   - Bump version in `deno.json` to `0.237.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e369c05e2f74a09342f1551853007525c740a71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->