### PR TITLE
docs: update README with enhanced library installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,21 +278,31 @@ The Rust FFI extension shipped via
 [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) provides
 the accelerated structural hints used by `discoveryDir()`. To enable it:
 
-1. Clone the repository alongside this project and build the library:
+1. Clone the repository alongside this project and build/install the library:
+
    ```bash
    git clone https://github.com/stSoftwareAU/NEAT-AI-Discovery.git
-   cd NEAT-AI-Discovery
-   cargo build --release
+   ../NEAT-AI-Discovery/scripts/runlib.sh
    ```
-2. Expose the compiled artefact to Deno by either copying it into `~/.cargo/lib`
-   or exporting an explicit path:
+
+   The `runlib.sh` script automatically:
+   - Installs Rust and Cargo if missing (no sudo required)
+   - Builds the library in release mode
+   - Installs it to `~/.cargo/lib/` with version tracking
+   - Signs it on macOS for FFI compatibility
+
+2. Alternatively, export an explicit path to the library:
+
    ```bash
-   export NEAT_AI_DISCOVERY_LIB_PATH="/absolute/path/to/NEAT-AI-Discovery/target/release/libneat_ai_discovery.$(uname | tr '[:upper:]' '[:lower:]' | sed 's/darwin/dylib/;s/linux/so/;s/windows/dll/')"
+   export NEAT_AI_DISCOVERY_LIB_PATH="/absolute/path/to/libneat_ai_discovery.dylib"
    ```
+
 3. Grant FFI permissions and validate the installation:
+
    ```bash
    deno run --allow-env --allow-ffi --allow-read scripts/check_discovery.ts
    ```
+
 4. In your application, guard discovery calls with `isRustDiscoveryEnabled()` so
    that controllers fail fast when the module is unavailable.
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.237.2",
+  "version": "0.237.3",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",


### PR DESCRIPTION
- Revised the installation steps for the NEAT-AI-Discovery library to include a script for building and installing the library automatically.
- Added details on the script's functionality, including Rust and Cargo installation, library building, and FFI compatibility on macOS.
- Clarified the alternative method for exporting the library path.

These changes aim to improve user experience by simplifying the setup process for the library.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines README discovery module installation using `runlib.sh`, clarifies explicit library path export, and bumps version to `0.237.3`.
> 
> - **Docs (README)**:
>   - Replace manual build steps with `../NEAT-AI-Discovery/scripts/runlib.sh` to auto-install Rust/Cargo, build, install to `~/.cargo/lib/`, and sign on macOS.
>   - Clarify alternative setup by exporting `NEAT_AI_DISCOVERY_LIB_PATH` to a specific `libneat_ai_discovery.dylib` path.
>   - Keep validation step using `scripts/check_discovery.ts` with FFI permissions.
> - **Version**:
>   - Update `deno.json` `version` from `0.237.2` to `0.237.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da8954b4bd8830284f12541fc0d2b6d531fce16a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->