### PR TITLE
chore: update version to 0.238.0 and introduce discovery candidate ca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,35 @@ const result = await creature.discoveryDir(dataDir, {
   scientific notation - weights like `0.123` and `0.234` (both `e-1`) map to the
   same key, while `0.001` (`e-3`) and `0.1` (`e-1`) map to different keys
 
+### Discovery Candidate Category Limits
+
+You can control the minimum number of candidates evaluated per category. This is
+useful when certain mutation types are more successful for your use case. For
+example, if neuron removal is working well but adding neurons isn't, you can
+increase the removal candidates and reduce add-neurons candidates.
+
+```typescript
+const result = await creature.discoveryDir(dataDir, {
+  discoveryMinCandidatesPerCategory: {
+    addNeurons: 0, // Skip add-neurons candidates
+    addSynapses: 1, // Minimum 1 add-synapses candidate
+    changeSquash: 1, // Minimum 1 change-squash candidate
+    removeLowImpact: 10, // Evaluate 10 removal candidates
+  },
+  // ... other options
+});
+```
+
+**Default values:**
+
+- `addNeurons`: 1
+- `addSynapses`: 1
+- `changeSquash`: 1
+- `removeLowImpact`: 3
+
+Higher values mean more candidates of that type will be evaluated. Set to 0 to
+skip a category entirely.
+
 ### Forced Focus Overrides
 
 The discovery recorder now honours an optional `discoveryFocusNeuronUUIDs`

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.237.3",
+  "version": "0.238.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/mod.ts
+++ b/mod.ts
@@ -52,7 +52,10 @@ export { CreatureUtil } from "./src/architecture/CreatureUtils.ts";
  *
  * @see {@link module:src/config/NeatOptions}
  */
-export type { NeatOptions } from "./src/config/NeatOptions.ts";
+export type {
+  DiscoveryMinCandidatesPerCategory,
+  NeatOptions,
+} from "./src/config/NeatOptions.ts";
 
 /**
  * Cost Interface

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -1,7 +1,10 @@
 import type { NeatOptions } from "../../mod.ts";
 import { Selection, type SelectionInterface } from "../methods/Selection.ts";
 import { Mutation } from "../NEAT/Mutation.ts";
-import type { NeatArguments } from "./NeatOptions.ts";
+import type {
+  DiscoveryMinCandidatesPerCategory,
+  NeatArguments,
+} from "./NeatOptions.ts";
 import { DEFAULT_RUST_FLUSH_RECORDS } from "../architecture/ErrorGuidedStructuralEvolution/constants.ts";
 
 /**
@@ -14,6 +17,20 @@ export const DEFAULT_COST_OF_GROWTH = 0.000_000_1;
  * Minimum allowed cost of growth value.
  */
 export const MIN_COST_OF_GROWTH = 0.000_000_000_1;
+
+/**
+ * Default minimum candidates per discovery category.
+ * These values reflect the current behaviour where diversity selection
+ * picks at least 1 from each category, and removal candidates sample 3.
+ */
+export const DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY: Required<
+  DiscoveryMinCandidatesPerCategory
+> = {
+  addNeurons: 1,
+  addSynapses: 1,
+  changeSquash: 1,
+  removeLowImpact: 3,
+};
 
 /**
  * Interface for NEAT (NeuroEvolution of Augmenting Topologies) training options.
@@ -154,6 +171,10 @@ export function createNeatConfig(options: NeatOptions) {
     discoveryBaseDirectory: options.discoveryBaseDirectory,
     discoverySkipRecordPhase: options.discoverySkipRecordPhase ?? false,
     discoveryFailureCacheDir: options.discoveryFailureCacheDir,
+    discoveryMinCandidatesPerCategory: {
+      ...DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY,
+      ...options.discoveryMinCandidatesPerCategory,
+    } as Required<DiscoveryMinCandidatesPerCategory>,
   };
   validate(config);
   return Object.freeze(config);
@@ -345,5 +366,42 @@ function validate(config: NeatArguments) {
     throw new Error(
       `Discovery Min Improvement vs Cost of Growth Multiplier must be zero or more was: ${config.discoveryMinImprovementVsCostOfGrowthMultiplier}`,
     );
+  }
+
+  // Validate discoveryMinCandidatesPerCategory
+  const minCandidates = config.discoveryMinCandidatesPerCategory;
+  if (minCandidates) {
+    if (
+      !Number.isInteger(minCandidates.addNeurons) ||
+      minCandidates.addNeurons < 0
+    ) {
+      throw new Error(
+        `Discovery min candidates for addNeurons must be a non-negative integer, was: ${minCandidates.addNeurons}`,
+      );
+    }
+    if (
+      !Number.isInteger(minCandidates.addSynapses) ||
+      minCandidates.addSynapses < 0
+    ) {
+      throw new Error(
+        `Discovery min candidates for addSynapses must be a non-negative integer, was: ${minCandidates.addSynapses}`,
+      );
+    }
+    if (
+      !Number.isInteger(minCandidates.changeSquash) ||
+      minCandidates.changeSquash < 0
+    ) {
+      throw new Error(
+        `Discovery min candidates for changeSquash must be a non-negative integer, was: ${minCandidates.changeSquash}`,
+      );
+    }
+    if (
+      !Number.isInteger(minCandidates.removeLowImpact) ||
+      minCandidates.removeLowImpact < 0
+    ) {
+      throw new Error(
+        `Discovery min candidates for removeLowImpact must be a non-negative integer, was: ${minCandidates.removeLowImpact}`,
+      );
+    }
   }
 }

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -8,6 +8,21 @@ import type { SelectionInterface } from "../methods/Selection.ts";
 import type { CrisprInterface } from "../../mod.ts";
 
 /**
+ * Configuration for minimum candidates per discovery category.
+ * This allows fine-tuning how many candidates from each category are evaluated.
+ */
+export interface DiscoveryMinCandidatesPerCategory {
+  /** Minimum candidates for add-neurons category. Default: 1 */
+  addNeurons?: number;
+  /** Minimum candidates for add-synapses category. Default: 1 */
+  addSynapses?: number;
+  /** Minimum candidates for change-squash category. Default: 1 */
+  changeSquash?: number;
+  /** Minimum candidates for remove-low-impact category. Default: 3 */
+  removeLowImpact?: number;
+}
+
+/**
  * Interface for NEAT (NeuroEvolution of Augmenting Topologies) training options.
  */
 export interface NeatArguments {
@@ -246,6 +261,34 @@ export interface NeatArguments {
    * so only significant weight changes will trigger re-evaluation.
    */
   discoveryFailureCacheDir?: string;
+
+  /**
+   * Minimum candidates to evaluate per discovery category.
+   * Allows fine-tuning the balance between different mutation types.
+   *
+   * Categories:
+   * - addNeurons: For "add-neurons" candidates (default: 1)
+   * - addSynapses: For "add-synapses" candidates (default: 1)
+   * - changeSquash: For "change-squash" candidates (default: 1)
+   * - removeLowImpact: For "remove-low-impact" candidates (default: 3)
+   *
+   * Higher values mean more candidates of that type will be evaluated.
+   * Useful when certain mutation types are more successful for your use case.
+   */
+  discoveryMinCandidatesPerCategory: Required<
+    DiscoveryMinCandidatesPerCategory
+  >;
 }
 
-export type NeatOptions = Partial<NeatArguments>;
+/**
+ * Options for NEAT configuration.
+ * All properties are optional; defaults are applied in createNeatConfig().
+ * For discoveryMinCandidatesPerCategory, you can specify partial overrides
+ * and defaults will be merged in.
+ */
+export type NeatOptions =
+  & Omit<Partial<NeatArguments>, "discoveryMinCandidatesPerCategory">
+  & {
+    /** Partial overrides for minimum candidates per category (defaults applied if not specified) */
+    discoveryMinCandidatesPerCategory?: DiscoveryMinCandidatesPerCategory;
+  };

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -1042,16 +1042,33 @@ export class DiscoveryRunner {
     // while also scaling with CPU count on larger machines
     const maxCandidates = Math.max(2 * threadCount, byCategory.size);
 
-    // PHASE 1: Select at least one from each category (ensuring diversity)
+    // PHASE 1: Select minimum from each category (ensuring diversity)
     const selected: DiscoveryCandidate[] = [];
     const usedFromCategory = new Map<string, number>();
 
-    // Take the best from each non-removal category first
-    for (const [type, categoryCandidates] of byCategory) {
-      if (categoryCandidates.length > 0) {
-        selected.push(categoryCandidates[0]);
-        usedFromCategory.set(type, 1);
+    // Get configured minimums per category
+    const minPerCategory = config.discoveryMinCandidatesPerCategory;
+    const getCategoryMin = (type: string): number => {
+      switch (type) {
+        case "add-neurons":
+          return minPerCategory.addNeurons;
+        case "add-synapses":
+          return minPerCategory.addSynapses;
+        case "change-squash":
+          return minPerCategory.changeSquash;
+        default:
+          return 1; // Default for unknown categories
       }
+    };
+
+    // Take the configured minimum from each non-removal category first
+    for (const [type, categoryCandidates] of byCategory) {
+      const minRequired = getCategoryMin(type);
+      const toTake = Math.min(minRequired, categoryCandidates.length);
+      for (let i = 0; i < toTake; i++) {
+        selected.push(categoryCandidates[i]);
+      }
+      usedFromCategory.set(type, toTake);
     }
 
     // PHASE 2: Fill remaining slots with best overall candidates
@@ -1114,7 +1131,10 @@ export class DiscoveryRunner {
     }
 
     // PHASE 3: Select removal candidates (separately, added on top)
-    const removalSampleSize = Math.min(removalCandidates.length, 3);
+    const removalSampleSize = Math.min(
+      removalCandidates.length,
+      minPerCategory.removeLowImpact,
+    );
     let selectedRemovalCandidates: DiscoveryCandidate[];
 
     if (removalCandidates.length <= removalSampleSize) {
@@ -1132,8 +1152,9 @@ export class DiscoveryRunner {
       // Sort by impact ascending (lowest = safest to remove)
       candidatesWithImpact.sort((a, b) => a.impact - b.impact);
 
-      // Take the top 10 lowest-impact candidates as the pool to select from
-      const TOP_N = 10;
+      // Take the top N lowest-impact candidates as the pool to select from
+      // Scale the pool size based on the configured removal sample size
+      const TOP_N = Math.max(10, removalSampleSize * 3);
       const topCandidates = candidatesWithImpact.slice(0, TOP_N);
 
       // Log the top 10 pool before selection

--- a/test/NEAT/NeatConfig.ts
+++ b/test/NEAT/NeatConfig.ts
@@ -1,5 +1,8 @@
 import { assertEquals, fail } from "@std/assert";
-import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import {
+  createNeatConfig,
+  DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY,
+} from "../../src/config/NeatConfig.ts";
 import { Selection } from "../../mod.ts";
 
 Deno.test("NeatConfig debug", () => {
@@ -28,4 +31,110 @@ Deno.test("NeatConfig selection", () => {
 Deno.test("NeatConfig verbose", () => {
   const config = createNeatConfig({ verbose: true });
   assertEquals(config.verbose, true);
+});
+
+Deno.test("NeatConfig discoveryMinCandidatesPerCategory defaults", () => {
+  const config = createNeatConfig({});
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.addNeurons,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addNeurons,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.addSynapses,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addSynapses,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.changeSquash,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.changeSquash,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.removeLowImpact,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.removeLowImpact,
+  );
+});
+
+Deno.test("NeatConfig discoveryMinCandidatesPerCategory partial override", () => {
+  const config = createNeatConfig({
+    discoveryMinCandidatesPerCategory: {
+      removeLowImpact: 10,
+    },
+  });
+  // Custom value should be used
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.removeLowImpact,
+    10,
+  );
+  // Other values should use defaults
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.addNeurons,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addNeurons,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.addSynapses,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addSynapses,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.changeSquash,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.changeSquash,
+  );
+});
+
+Deno.test("NeatConfig discoveryMinCandidatesPerCategory full override", () => {
+  const config = createNeatConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 5,
+      addSynapses: 3,
+      changeSquash: 2,
+      removeLowImpact: 10,
+    },
+  });
+  assertEquals(config.discoveryMinCandidatesPerCategory.addNeurons, 5);
+  assertEquals(config.discoveryMinCandidatesPerCategory.addSynapses, 3);
+  assertEquals(config.discoveryMinCandidatesPerCategory.changeSquash, 2);
+  assertEquals(config.discoveryMinCandidatesPerCategory.removeLowImpact, 10);
+});
+
+Deno.test("NeatConfig discoveryMinCandidatesPerCategory validation - negative addNeurons", () => {
+  try {
+    createNeatConfig({
+      discoveryMinCandidatesPerCategory: {
+        addNeurons: -1,
+      },
+    });
+    fail("Should throw for negative addNeurons");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes("addNeurons"),
+      true,
+      `Error should mention addNeurons: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NeatConfig discoveryMinCandidatesPerCategory validation - negative removeLowImpact", () => {
+  try {
+    createNeatConfig({
+      discoveryMinCandidatesPerCategory: {
+        removeLowImpact: -5,
+      },
+    });
+    fail("Should throw for negative removeLowImpact");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes("removeLowImpact"),
+      true,
+      `Error should mention removeLowImpact: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NeatConfig discoveryMinCandidatesPerCategory allows zero values", () => {
+  const config = createNeatConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 0,
+      removeLowImpact: 0,
+    },
+  });
+  assertEquals(config.discoveryMinCandidatesPerCategory.addNeurons, 0);
+  assertEquals(config.discoveryMinCandidatesPerCategory.removeLowImpact, 0);
 });

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1891,7 +1891,7 @@ Deno.test(
           if (json.neurons.length < baseNeuronCount) {
             removalEvaluated++;
           }
-          return originalEvaluate(creature, feedbackLoop);
+          return await originalEvaluate(creature, feedbackLoop);
         };
         return worker;
       },
@@ -1963,7 +1963,7 @@ Deno.test(
           if (json.neurons.length > baseNeuronCount) {
             addNeuronsEvaluated++;
           }
-          return originalEvaluate(creature, feedbackLoop);
+          return await originalEvaluate(creature, feedbackLoop);
         };
         return worker;
       },
@@ -2063,7 +2063,7 @@ Deno.test(
           if (json.neurons.length < baseNeuronCount) {
             removalEvaluated++;
           }
-          return originalEvaluate(creature, feedbackLoop);
+          return await originalEvaluate(creature, feedbackLoop);
         };
         return worker;
       },

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1816,3 +1816,273 @@ Deno.test(
     }
   },
 );
+
+Deno.test(
+  "DiscoveryRunner respects discoveryMinCandidatesPerCategory for removal candidates",
+  async () => {
+    // Create a creature with 10 hidden neurons that can be removed
+    const neurons: Array<{
+      type: "hidden" | "output";
+      uuid: string;
+      squash: string;
+      bias: number;
+    }> = Array.from({ length: 10 }, (_, i) => ({
+      type: "hidden" as const,
+      uuid: `hidden-${i}`,
+      squash: "RELU",
+      bias: 0.1,
+    }));
+    neurons.push({
+      type: "output",
+      uuid: "output-0",
+      squash: "IDENTITY",
+      bias: 0,
+    });
+
+    const synapses = [
+      ...Array.from({ length: 10 }, (_, i) => [
+        { fromUUID: "input-0", toUUID: `hidden-${i}`, weight: 1e-12 },
+        { fromUUID: `hidden-${i}`, toUUID: "output-0", weight: 1e-12 },
+      ]).flat(),
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+    ];
+
+    const baseCreature = Creature.fromJSON({
+      input: 2,
+      output: 1,
+      neurons,
+      synapses,
+    });
+    baseCreature.validate();
+    CreatureUtil.makeUUID(baseCreature);
+
+    const baseNeuronCount = baseCreature.exportJSON().neurons.length;
+
+    // Track which candidates are evaluated
+    let removalEvaluated = 0;
+
+    const discoveryResult: DiscoverResult = {
+      ID: "MIN_REMOVAL_CANDIDATES_TEST",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      // Create 10 removal candidates (matching our creature's hidden neurons)
+      removalCandidates: Array.from({ length: 10 }, (_, i) => ({
+        neuronUUID: `hidden-${i}`,
+        totalError: 0.1,
+        impact: 1e-15 * (i + 1), // Different impacts for sorting
+        reason: "low-impact",
+      })),
+      candidateSquashes: undefined,
+    };
+
+    const computeError = (_creature: Creature) => 0.5;
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () => {
+        const worker = new FakeWorker(discoveryResult, computeError);
+        // Wrap evaluate to track removal candidates
+        const originalEvaluate = worker.evaluate.bind(worker);
+        worker.evaluate = async (creature, feedbackLoop) => {
+          const json = creature.exportJSON();
+          // Check if it's a removal candidate (fewer neurons than base)
+          if (json.neurons.length < baseNeuronCount) {
+            removalEvaluated++;
+          }
+          return originalEvaluate(creature, feedbackLoop);
+        };
+        return worker;
+      },
+    });
+
+    // Test with custom minimum of 5 removal candidates instead of default 3
+    const options = makeOptions({
+      discoveryMinCandidatesPerCategory: {
+        removeLowImpact: 5,
+      },
+    });
+
+    await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options,
+    });
+
+    assertEquals(
+      removalEvaluated,
+      5,
+      `Expected 5 removal candidates to be evaluated (configured minimum), got ${removalEvaluated}`,
+    );
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner respects discoveryMinCandidatesPerCategory for add-neurons",
+  async () => {
+    // Track how many add-neurons candidates are evaluated
+    let addNeuronsEvaluated = 0;
+
+    // Create discovery result with many add-neurons candidates
+    const addHelpfulNeurons = Array.from({ length: 10 }, (_, i) => ({
+      fromNeuronUUID: `input-${i % 2}`,
+      toNeuronUUID: "output-0",
+      squash: "RELU" as const,
+      incomingWeight: 0.5 + i * 0.01,
+      outgoingWeight: 0.5 + i * 0.01,
+      bias: 0.1 + i * 0.001,
+      expectedImprovementPercentage: 0.01 - i * 0.0001, // Decreasing improvement
+      improvedCount: 8 - i,
+      totalCount: 10,
+    }));
+
+    const discoveryResult: DiscoverResult = {
+      ID: "MIN_ADD_NEURONS_TEST",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const baseCreature = makeBaseCreature();
+    const baseNeuronCount = baseCreature.exportJSON().neurons.length;
+
+    const computeError = (_creature: Creature) => 0.5;
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () => {
+        const worker = new FakeWorker(discoveryResult, computeError);
+        const originalEvaluate = worker.evaluate.bind(worker);
+        worker.evaluate = async (creature, feedbackLoop) => {
+          const json = creature.exportJSON();
+          // Check if it's an add-neurons candidate (more neurons than base)
+          if (json.neurons.length > baseNeuronCount) {
+            addNeuronsEvaluated++;
+          }
+          return originalEvaluate(creature, feedbackLoop);
+        };
+        return worker;
+      },
+    });
+
+    // Test with custom minimum of 5 add-neurons candidates instead of default 1
+    const options = makeOptions({
+      discoveryMinCandidatesPerCategory: {
+        addNeurons: 5,
+      },
+    });
+
+    await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options,
+    });
+
+    // Should evaluate at least 5 (the configured minimum) from add-neurons category
+    // May evaluate more if there are available slots
+    assert(
+      addNeuronsEvaluated >= 5,
+      `Expected at least 5 add-neurons candidates to be evaluated (configured minimum), got ${addNeuronsEvaluated}`,
+    );
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner uses default values when discoveryMinCandidatesPerCategory is not set",
+  async () => {
+    // Create a creature with 10 hidden neurons that can be removed
+    const neurons: Array<{
+      type: "hidden" | "output";
+      uuid: string;
+      squash: string;
+      bias: number;
+    }> = Array.from({ length: 10 }, (_, i) => ({
+      type: "hidden" as const,
+      uuid: `hidden-${i}`,
+      squash: "RELU",
+      bias: 0.1,
+    }));
+    neurons.push({
+      type: "output",
+      uuid: "output-0",
+      squash: "IDENTITY",
+      bias: 0,
+    });
+
+    const synapses = [
+      ...Array.from({ length: 10 }, (_, i) => [
+        { fromUUID: "input-0", toUUID: `hidden-${i}`, weight: 1e-12 },
+        { fromUUID: `hidden-${i}`, toUUID: "output-0", weight: 1e-12 },
+      ]).flat(),
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+    ];
+
+    const baseCreature = Creature.fromJSON({
+      input: 2,
+      output: 1,
+      neurons,
+      synapses,
+    });
+    baseCreature.validate();
+    CreatureUtil.makeUUID(baseCreature);
+
+    const baseNeuronCount = baseCreature.exportJSON().neurons.length;
+
+    // Track removal candidates evaluated
+    let removalEvaluated = 0;
+
+    const discoveryResult: DiscoverResult = {
+      ID: "DEFAULT_MIN_CANDIDATES_TEST",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      // Create 10 removal candidates (matching our creature's hidden neurons)
+      removalCandidates: Array.from({ length: 10 }, (_, i) => ({
+        neuronUUID: `hidden-${i}`,
+        totalError: 0.1,
+        impact: 1e-15 * (i + 1),
+        reason: "low-impact",
+      })),
+      candidateSquashes: undefined,
+    };
+
+    const computeError = (_creature: Creature) => 0.5;
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () => {
+        const worker = new FakeWorker(discoveryResult, computeError);
+        const originalEvaluate = worker.evaluate.bind(worker);
+        worker.evaluate = async (creature, feedbackLoop) => {
+          const json = creature.exportJSON();
+          if (json.neurons.length < baseNeuronCount) {
+            removalEvaluated++;
+          }
+          return originalEvaluate(creature, feedbackLoop);
+        };
+        return worker;
+      },
+    });
+
+    // Use default options (no discoveryMinCandidatesPerCategory override)
+    const options = makeOptions({});
+
+    await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options,
+    });
+
+    // Default for removeLowImpact is 3
+    assertEquals(
+      removalEvaluated,
+      3,
+      `Expected 3 removal candidates with default config, got ${removalEvaluated}`,
+    );
+  },
+);


### PR DESCRIPTION
…tegory limits

- Bumped version in deno.json to 0.238.0.
- Added DiscoveryMinCandidatesPerCategory interface to allow configuration of minimum candidates evaluated per category during discovery.
- Updated NeatOptions and NeatConfig to incorporate new discovery candidate limits, enhancing flexibility in candidate evaluation.
- Enhanced DiscoveryRunner to respect configured minimums for each category, ensuring a more tailored discovery process.
- Added tests to validate the new configuration options and their impact on candidate evaluation.

These changes aim to improve the customization of the discovery process, allowing users to fine-tune candidate evaluations based on their specific needs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable minimum candidate counts per discovery category (with defaults), applies them in `DiscoveryRunner`, updates docs, exports types, adds tests, and bumps version to 0.238.0.
> 
> - **Config/API**:
>   - Define `DiscoveryMinCandidatesPerCategory` and default `DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY`.
>   - Extend `NeatArguments`/`NeatOptions` to support `discoveryMinCandidatesPerCategory` (partial overrides merged with defaults) and export types from `mod.ts`.
>   - Validate all per-category mins as non-negative integers.
> - **Discovery**:
>   - Update `DiscoveryRunner` selection to honor configured minimums for `add-neurons`, `add-synapses`, `change-squash`; sample `remove-low-impact` per `removeLowImpact` and scale removal TOP_N pool.
> - **Docs**:
>   - Add README section “Discovery Candidate Category Limits” with usage and default values.
> - **Tests**:
>   - Add/expand tests for defaults, partial/full overrides, validation errors, and that runner respects per-category mins and defaults.
> - **Version**:
>   - Bump `deno.json` version to `0.238.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc7cbd821ac7762f86021452fdef57341e245e3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->