### PR TITLE
refactor: remove verbose logging from DiscoverStructure class

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.238.0",
+  "version": "0.238.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -836,15 +836,6 @@ export class DiscoverStructure {
       };
     });
 
-    // Verbose logging: report neuron coverage in this batch
-    // Note: All records contain the same set of neurons (nonInputNeurons), so no need to iterate
-    if (this.loggingEnabled && pendingSamples > 0) {
-      this.log(
-        "debug",
-        `Parquet batch includes ${nonInputNeurons.length} neurons across ${pendingSamples} samples.`,
-      );
-    }
-
     const diagnostics = this.inspectRustFlushBatch(
       rustTrainingData,
       this.creature.input,
@@ -936,20 +927,6 @@ export class DiscoverStructure {
 
       this.rustAccumulatedData = [];
       this.rustAccumulatedNeuronData = [];
-      const flushDuration = Date.now() - now;
-      const remainingSeconds = Math.max(
-        0,
-        Math.floor((this.timeoutTS - Date.now()) / 1000),
-      );
-      const flushRate = flushDuration > 0
-        ? (pendingSamples / (flushDuration / 1000)).toFixed(2)
-        : "∞";
-      this.log(
-        "info",
-        `Flushed ${pendingSamples} samples to ${parquetPath} in ${
-          this.formatMillis(flushDuration)
-        } (${flushRate} samples/sec, timeout remaining: ${remainingSeconds}s).`,
-      );
 
       return parquetPath;
     }


### PR DESCRIPTION
- Eliminated redundant logging related to neuron coverage and flush duration in the DiscoverStructure class.
- This change simplifies the code and reduces unnecessary output during the discovery process, enhancing performance and clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes neuron-coverage and flush-duration/rate logs from `DiscoverStructure`'s Rust flush path; bumps package to 0.238.1.
> 
> - **Core (Discovery)**:
>   - Remove debug/info logs for Parquet batch neuron coverage and post-flush duration/rate in `DiscoverStructure.writeRustParquetChunk`.
>   - Retain diagnostics via `inspectRustFlushBatch` and `emitRustFlushDiagnostics` (no functional changes to data flow).
> - **Meta**:
>   - Bump `deno.json` version to `0.238.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbc4adf47b77973161e7c59f18be772da0fa417a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->