### PR TITLE
chore: update version to 0.240.0 and simplify change descriptions in …

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.238.1",
+  "version": "0.240.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -421,10 +421,9 @@ export function buildDiscoveryCandidates(
       creature: removedNeuronCreature,
       change: {
         type: "remove-neuron",
-        description:
-          `💀 Removed harmful neuron ${mostHarmful.neuronUUID} (error: ${
-            mostHarmful.errorMagnitude.toExponential(2)
-          })`,
+        description: `💀 Removed harmful neuron ${
+          shortID(mostHarmful.neuronUUID)
+        } (error: ${mostHarmful.errorMagnitude.toExponential(2)})`,
         expectedErrorReduction: mostHarmful.expectedImprovementPercentage,
         sampleSize: mostHarmful.sampleCount,
       },
@@ -484,10 +483,9 @@ export function buildDiscoveryCandidates(
           creature: removedLowImpactCreature,
           change: {
             type: "remove-low-impact",
-            description:
-              `🪶 Removed low-impact neuron ${candidate.neuronUUID} (impact: ${
-                candidate.impact.toExponential(2)
-              })`,
+            description: `🪶 Removed neuron ${
+              shortID(candidate.neuronUUID)
+            } (impact: ${candidate.impact.toExponential(2)})`,
             // No expectedErrorReduction - removal improves score via complexity reduction, not error
           },
         });

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -445,16 +445,11 @@ export class DiscoveryRunner {
           ? improved.candidate.change.description
           : improved.candidate.change.type;
         const changeType = improved.candidate.change.type;
-        // Include creature short ID (last 8 characters of UUID) in message for traceability
-        const creatureUUID = improved.candidate.creature.uuid;
-        const creatureShortID = creatureUUID && creatureUUID.length > 8
-          ? creatureUUID.slice(-8)
-          : creatureUUID ?? "unknown";
-        // Ensure message includes changeType for test compatibility
-        const message =
-          `${description} (${changeType}) for ${discoverResult.ID}: Score +${
-            scoreDelta.toPrecision(6)
-          } -> ${improved.score.toPrecision(6)} (${creatureShortID})`;
+        // Concise message format: description already conveys the change type via emoji and text
+        // Score delta uses toPrecision(6) for consistency with other metrics
+        const message = `${description} for ${discoverResult.ID}: Score +${
+          scoreDelta.toPrecision(6)
+        } -> ${improved.score.toPrecision(6)}`;
 
         outcome.improvement = {
           changeType,

--- a/test/discovery/DiscoveryMessageFormatting.ts
+++ b/test/discovery/DiscoveryMessageFormatting.ts
@@ -7,6 +7,9 @@
  * @module test/discovery/DiscoveryMessageFormatting
  */
 
+/* cspell:disable-next-line */
+// cspell:ignore ghij klmnopqrstuv ghijklmnopqr
+
 import { assert, assertEquals } from "@std/assert";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";

--- a/test/discovery/DiscoveryMessageFormatting.ts
+++ b/test/discovery/DiscoveryMessageFormatting.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for discovery message formatting improvements.
+ * - Neuron UUIDs should use shortID format
+ * - Messages should not duplicate change type information
+ * - Messages should not include redundant creature short ID
+ *
+ * @module test/discovery/DiscoveryMessageFormatting
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import type { NeatOptions } from "../../src/config/NeatOptions.ts";
+import { Creature } from "../../src/Creature.ts";
+import type { DiscoveryRunnerWorker } from "../../src/discovery/DiscoveryRunner.ts";
+import { DiscoveryRunner } from "../../src/discovery/DiscoveryRunner.ts";
+import { shortID } from "../../src/discovery/DiscoveryCandidates.ts";
+
+function makeOptions(overrides: Partial<NeatOptions> = {}): NeatOptions {
+  return {
+    iterations: 1,
+    creatureStore: "/tmp/store",
+    threads: 1,
+    costOfGrowth: 1e-10,
+    ...overrides,
+  } as NeatOptions;
+}
+
+// Helper to create a base creature with a removable hidden neuron
+function makeCreatureWithRemovableNeuron(neuronUUID: string) {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: neuronUUID, squash: "IDENTITY", bias: 0.001 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: neuronUUID, weight: 0.0001 },
+      { fromUUID: neuronUUID, toUUID: "output-0", weight: 0.0001 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+class FakeWorker implements DiscoveryRunnerWorker {
+  #discoverResult: DiscoverResult;
+  #computeError: (creature: Creature) => number;
+  #baseNeuronCount: number;
+
+  constructor(
+    discoverResult: DiscoverResult,
+    computeError: (creature: Creature) => number,
+    baseNeuronCount: number,
+  ) {
+    this.#discoverResult = discoverResult;
+    this.#computeError = computeError;
+    this.#baseNeuronCount = baseNeuronCount;
+  }
+
+  discover(
+    _creature: Creature,
+    _options: NeatOptions,
+  ): Promise<Awaited<ReturnType<DiscoveryRunnerWorker["discover"]>>> {
+    return Promise.resolve({
+      taskID: 1,
+      duration: 10,
+      discover: this.#discoverResult,
+    });
+  }
+
+  evaluate(
+    creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<Awaited<ReturnType<DiscoveryRunnerWorker["evaluate"]>>> {
+    const error = this.#computeError(creature);
+    const json = creature.exportJSON();
+    // Removal candidates get better scores (lower error after complexity adjustment)
+    const isRemoval = json.neurons.length < this.#baseNeuronCount;
+    const adjustedError = isRemoval ? error * 0.8 : error;
+    return Promise.resolve({
+      taskID: 2,
+      duration: 5,
+      evaluate: {
+        error: adjustedError,
+      },
+    });
+  }
+
+  terminate(): void {}
+}
+
+Deno.test(
+  "Discovery message uses shortID for remove-low-impact neuron UUID",
+  async () => {
+    const fullUUID = "3e979317-989f-4c5c-8272-02fd85be94a8";
+    const expectedShortID = shortID(fullUUID); // Should be "85be94a8"
+    const baseCreature = makeCreatureWithRemovableNeuron(fullUUID);
+    const baseNeuronCount = baseCreature.exportJSON().neurons.length;
+
+    const discoveryResult: DiscoverResult = {
+      ID: "MSG-FORMAT-TEST",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: [
+        {
+          neuronUUID: fullUUID,
+          totalError: 0.1,
+          impact: 1e-13,
+          reason: "low-impact",
+        },
+      ],
+      candidateSquashes: undefined,
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(discoveryResult, () => 0.5, baseNeuronCount),
+    });
+
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    // The description in evaluations should use short ID
+    const removalEval = result.evaluations?.find(
+      (e) => e.changeType === "remove-low-impact" && e.kind === "candidate",
+    );
+
+    assert(removalEval, "Should have a remove-low-impact evaluation");
+    assert(
+      removalEval.description?.includes(expectedShortID),
+      `Description should use shortID '${expectedShortID}', got: ${removalEval.description}`,
+    );
+    assertEquals(
+      removalEval.description?.includes(fullUUID),
+      false,
+      `Description should NOT contain full UUID '${fullUUID}', got: ${removalEval.description}`,
+    );
+  },
+);
+
+Deno.test(
+  "Discovery improvement message does not duplicate change type after descriptive text",
+  async () => {
+    const fullUUID = "abc12345-def6-7890-ghij-klmnopqrstuv";
+    const baseCreature = makeCreatureWithRemovableNeuron(fullUUID);
+    const baseNeuronCount = baseCreature.exportJSON().neurons.length;
+
+    const discoveryResult: DiscoverResult = {
+      ID: "NO-DUPLICATE-TEST",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: [
+        {
+          neuronUUID: fullUUID,
+          totalError: 0.1,
+          impact: 1e-14,
+          reason: "low-impact",
+        },
+      ],
+      candidateSquashes: undefined,
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(discoveryResult, () => 0.5, baseNeuronCount),
+    });
+
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    if (result.improvement?.message) {
+      // Message should NOT contain "(remove-low-impact)" since the description
+      // already says "Removed low-impact neuron"
+      assertEquals(
+        result.improvement.message.includes("(remove-low-impact)"),
+        false,
+        `Message should NOT contain redundant '(remove-low-impact)', got: ${result.improvement.message}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "Discovery improvement message does not include creature short ID at end",
+  async () => {
+    const fullUUID = "test1234-5678-90ab-cdef-ghijklmnopqr";
+    const baseCreature = makeCreatureWithRemovableNeuron(fullUUID);
+    const baseNeuronCount = baseCreature.exportJSON().neurons.length;
+
+    const discoveryResult: DiscoverResult = {
+      ID: "NO-CREATURE-ID-TEST",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: [
+        {
+          neuronUUID: fullUUID,
+          totalError: 0.1,
+          impact: 1e-14,
+          reason: "low-impact",
+        },
+      ],
+      candidateSquashes: undefined,
+    };
+
+    const runner = new DiscoveryRunner({
+      rustDiscoveryEnabled: () => true,
+      workerFactory: () =>
+        new FakeWorker(discoveryResult, () => 0.5, baseNeuronCount),
+    });
+
+    const result = await runner.discoverDir({
+      creature: baseCreature,
+      dataDir: "/tmp/data",
+      options: makeOptions(),
+    });
+
+    if (result.improvement?.message) {
+      // Message should NOT end with a parenthesised creature short ID
+      // The pattern (xxxxxxxx) at the end indicates the old format
+      const endsWithShortID = /\([a-f0-9]{8}\)$/.test(
+        result.improvement.message,
+      );
+      assertEquals(
+        endsWithShortID,
+        false,
+        `Message should NOT end with creature short ID, got: ${result.improvement.message}`,
+      );
+    }
+  },
+);
+
+Deno.test("shortID function returns last 8 chars of UUID", () => {
+  const fullUUID = "3e979317-989f-4c5c-8272-02fd85be94a8";
+  const result = shortID(fullUUID);
+  assertEquals(result, "85be94a8", "shortID should return last 8 characters");
+});
+
+Deno.test("shortID function returns full ID if too short", () => {
+  const shortStr = "abc123";
+  const result = shortID(shortStr);
+  assertEquals(result, shortStr, "shortID should return full ID if short");
+});
+
+Deno.test("shortID function returns full ID if no dashes", () => {
+  const noDashes = "abcdefghijklmnopqrstuvwxyz";
+  const result = shortID(noDashes);
+  assertEquals(
+    result,
+    noDashes,
+    "shortID should return full ID if no dashes (not a UUID)",
+  );
+});

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1356,8 +1356,9 @@ Deno.test(
     // Verify the removal candidate has the expected description
     const removalCandidate = removalCandidates[0];
     assert(
-      removalCandidate.description?.includes("low-impact"),
-      `Expected description to mention 'low-impact', got: ${removalCandidate.description}`,
+      removalCandidate.description?.includes("Removed neuron") &&
+        removalCandidate.description?.includes("impact:"),
+      `Expected description to mention 'Removed neuron' and 'impact:', got: ${removalCandidate.description}`,
     );
   },
 );


### PR DESCRIPTION
…DiscoveryCandidates

- Bumped version in deno.json to 0.240.0.
- Updated change descriptions in DiscoveryCandidates to use short IDs for neuron UUIDs, enhancing readability.
- Refined message formatting in DiscoveryRunner to eliminate redundant information while maintaining clarity.
- Adjusted tests to verify updated description formats for removal candidates.

These changes aim to improve the clarity and conciseness of logging related to neuron removals in the discovery process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies discovery messages (shortID UUIDs, no redundant details), adds focused tests, and bumps version to 0.240.0.
> 
> - **Discovery logging/message formatting**:
>   - `src/discovery/DiscoveryCandidates.ts`: Use `shortID(...)` for neuron/synapse UUIDs in descriptions; refine remove-neuron and remove-low-impact messages (concise impact/error formatting).
>   - `src/discovery/DiscoveryRunner.ts`: Streamline improvement message (no duplicated change type, remove trailing creature short ID; consistent score delta precision).
> - **Tests**:
>   - Add `test/discovery/DiscoveryMessageFormatting.ts` to validate shortID usage and concise message formatting.
>   - Update `test/discovery/DiscoveryRunner.ts` assertions to match new removal description format.
> - **Version**:
>   - `deno.json`: Bump version to `0.240.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4037b8e6851f0636c88db1b3e391cffab897e261. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->