### PR TITLE
Disable cspell for discovery

### DIFF
--- a/test/discovery/DiscoveryMessageFormatting.ts
+++ b/test/discovery/DiscoveryMessageFormatting.ts
@@ -7,6 +7,9 @@
  * @module test/discovery/DiscoveryMessageFormatting
  */
 
+/* cspell:disable-next-line */
+// cspell:ignore ghij klmnopqrstuv ghijklmnopqr
+
 import { assert, assertEquals } from "@std/assert";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";


### PR DESCRIPTION
Add CSpell ignore directives to `DiscoveryMessageFormatting.ts` to suppress warnings for test UUID segments.

---
<a href="https://cursor.com/background-agent?bcId=bc-73f9cb20-e5e0-4e13-a1fe-431791cc2208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73f9cb20-e5e0-4e13-a1fe-431791cc2208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add cspell ignore directives to `test/discovery/DiscoveryMessageFormatting.ts` to silence spellcheck warnings for test UUID fragments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1074e062d72ae64b9be35001df4599e4b6bc00ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->