### PR TITLE
V.0.242.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.241.0",
+  "version": "0.242.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -199,6 +199,12 @@ export function buildDiscoveryCandidates(
         sampleSize: neuronSummary.sampleSize,
       },
     });
+  } else if (helpfulNeuronCandidates && helpfulNeuronCandidates.length > 0) {
+    console.info(
+      `[DiscoveryCandidates] Combined add-neurons candidate not created (${helpfulNeuronCandidates.length} neuron${
+        helpfulNeuronCandidates.length === 1 ? "" : "s"
+      } suggested but structure change returned undefined)`,
+    );
   }
 
   candidates.push(
@@ -234,6 +240,12 @@ export function buildDiscoveryCandidates(
         sampleSize: synapseSummary.sampleSize,
       },
     });
+  } else if (addHelpfulSynapses && addHelpfulSynapses.length > 0) {
+    console.info(
+      `[DiscoveryCandidates] Combined add-synapses candidate not created (${addHelpfulSynapses.length} synapse${
+        addHelpfulSynapses.length === 1 ? "" : "s"
+      } suggested but structure change returned undefined)`,
+    );
   }
 
   candidates.push(
@@ -396,6 +408,12 @@ export function buildDiscoveryCandidates(
         });
       }
     }
+  } else if (candidateSquashes && candidateSquashes.length > 0) {
+    console.info(
+      `[DiscoveryCandidates] Combined change-squash candidate not created (${candidateSquashes.length} squash${
+        candidateSquashes.length === 1 ? "" : "es"
+      } suggested but structure change returned undefined)`,
+    );
   }
 
   candidates.push(
@@ -688,13 +706,17 @@ function buildSingleSynapseCandidates(
 ): DiscoveryCandidate[] {
   if (!synapses || synapses.length === 0) return [];
   const entries: DiscoveryCandidate[] = [];
+  let skippedCount = 0;
   for (const synapse of synapses) {
     const creature = DiscoverStructure.addHelpfulSynapses(
       discoveryID,
       baseCreature,
       [synapse],
     );
-    if (!creature) continue;
+    if (!creature) {
+      skippedCount++;
+      continue;
+    }
     entries.push({
       creature,
       change: {
@@ -706,6 +728,13 @@ function buildSingleSynapseCandidates(
         sampleSize: synapse.totalCount,
       },
     });
+  }
+  if (skippedCount > 0) {
+    console.info(
+      `[DiscoveryCandidates] Skipped ${skippedCount}/${synapses.length} individual synapse candidate${
+        skippedCount === 1 ? "" : "s"
+      } (structure change returned undefined)`,
+    );
   }
   return entries;
 }
@@ -719,13 +748,17 @@ function buildSingleNeuronCandidates(
   if (!neurons || neurons.length === 0) return [];
   const baseNeuronUUIDs = new Set(baseCreature.neurons.map((n) => n.uuid));
   const entries: DiscoveryCandidate[] = [];
+  let skippedCount = 0;
   for (const neuron of neurons) {
     const creature = DiscoverStructure.addHelpfulNeurons(
       discoveryID,
       baseCreature,
       [neuron],
     );
-    if (!creature) continue;
+    if (!creature) {
+      skippedCount++;
+      continue;
+    }
 
     // Find the newly added neuron by comparing with base creature
     const addedNeuron = creature.neurons.find(
@@ -756,6 +789,13 @@ function buildSingleNeuronCandidates(
       },
     });
   }
+  if (skippedCount > 0) {
+    console.info(
+      `[DiscoveryCandidates] Skipped ${skippedCount}/${neurons.length} individual neuron candidate${
+        skippedCount === 1 ? "" : "s"
+      } (structure change returned undefined)`,
+    );
+  }
   return entries;
 }
 
@@ -767,13 +807,17 @@ function buildSingleSquashCandidates(
 ): DiscoveryCandidate[] {
   if (!squashes || squashes.length === 0) return [];
   const entries: DiscoveryCandidate[] = [];
+  let skippedCount = 0;
   for (const squash of squashes) {
     const creature = DiscoverStructure.changeSquash(
       discoveryID,
       baseCreature,
       [squash],
     );
-    if (!creature) continue;
+    if (!creature) {
+      skippedCount++;
+      continue;
+    }
 
     const neuron = baseCreature.neurons.find((n) =>
       n.uuid === squash.neuronUUID
@@ -794,6 +838,13 @@ function buildSingleSquashCandidates(
         expectedErrorReduction: scaledExpected,
       },
     });
+  }
+  if (skippedCount > 0) {
+    console.info(
+      `[DiscoveryCandidates] Skipped ${skippedCount}/${squashes.length} individual squash candidate${
+        skippedCount === 1 ? "" : "s"
+      } (structure change returned undefined)`,
+    );
   }
   return entries;
 }

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -253,7 +253,10 @@ export class DiscoveryRunner {
       const candidateCountsByType = new Map<string, number>();
       for (const candidate of singleCandidates) {
         const type = candidate.change.type;
-        candidateCountsByType.set(type, (candidateCountsByType.get(type) ?? 0) + 1);
+        candidateCountsByType.set(
+          type,
+          (candidateCountsByType.get(type) ?? 0) + 1,
+        );
       }
       const countBreakdown = Array.from(candidateCountsByType.entries())
         .map(([type, count]) => `${type}: ${count}`)
@@ -958,6 +961,9 @@ export class DiscoveryRunner {
       cachedTypes: new Map<string, number>(),
     };
 
+    // Track candidates skipped due to cost-of-growth threshold
+    const thresholdSkipped = new Map<string, number>();
+
     for (const candidate of candidates) {
       CreatureUtil.makeUUID(candidate.creature);
       const expected = candidate.change.expectedErrorReduction;
@@ -1004,6 +1010,10 @@ export class DiscoveryRunner {
 
       if (!meetsThreshold) {
         skipped.push({ changeType, expected });
+        thresholdSkipped.set(
+          changeType,
+          (thresholdSkipped.get(changeType) ?? 0) + 1,
+        );
         continue;
       }
 
@@ -1037,6 +1047,22 @@ export class DiscoveryRunner {
           } due to previous failure: ${parts.join(", ")}`,
         );
       }
+    }
+
+    // Log candidates skipped due to cost-of-growth threshold
+    if (thresholdSkipped.size > 0) {
+      const totalThresholdSkipped = Array.from(thresholdSkipped.values())
+        .reduce((a, b) => a + b, 0);
+      const typeBreakdown = Array.from(thresholdSkipped.entries())
+        .map(([type, count]) => `${count} ${type}`)
+        .join(", ");
+      console.info(
+        `[DiscoveryRunner] ⏭️ Skipped ${totalThresholdSkipped} candidate${
+          totalThresholdSkipped === 1 ? "" : "s"
+        } below cost-of-growth threshold (${
+          minExpectedImprovement.toExponential(2)
+        }): ${typeBreakdown}`,
+      );
     }
 
     // Sort each category by expected improvement (descending)

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -248,6 +248,22 @@ export class DiscoveryRunner {
         discoverResult,
         { skipCombinedCandidates: true },
       );
+
+      // Log candidate counts by type (always, not just verbose)
+      const candidateCountsByType = new Map<string, number>();
+      for (const candidate of singleCandidates) {
+        const type = candidate.change.type;
+        candidateCountsByType.set(type, (candidateCountsByType.get(type) ?? 0) + 1);
+      }
+      const countBreakdown = Array.from(candidateCountsByType.entries())
+        .map(([type, count]) => `${type}: ${count}`)
+        .join(", ");
+      console.info(
+        `[DiscoveryRunner] Built ${singleCandidates.length} candidate${
+          singleCandidates.length === 1 ? "" : "s"
+        }${countBreakdown ? ` (${countBreakdown})` : ""}`,
+      );
+
       verboseLog(
         `[Phase 1] Built ${singleCandidates.length} single candidate creature${
           singleCandidates.length === 1 ? "" : "s"
@@ -938,6 +954,8 @@ export class DiscoveryRunner {
       cachedRemoval: 0,
       totalOther: 0,
       cachedOther: 0,
+      /** Track cached candidate types for better diagnostics */
+      cachedTypes: new Map<string, number>(),
     };
 
     for (const candidate of candidates) {
@@ -965,6 +983,10 @@ export class DiscoveryRunner {
       cacheStats.totalOther++;
       if (isCached) {
         cacheStats.cachedOther++;
+        cacheStats.cachedTypes.set(
+          changeType,
+          (cacheStats.cachedTypes.get(changeType) ?? 0) + 1,
+        );
         continue; // Skip cached candidates - don't let them consume slots
       }
 
@@ -999,17 +1021,15 @@ export class DiscoveryRunner {
         const parts: string[] = [];
         if (cacheStats.cachedRemoval > 0) {
           parts.push(
-            `${cacheStats.cachedRemoval} removal candidate${
-              cacheStats.cachedRemoval === 1 ? "" : "s"
-            }`,
+            `${cacheStats.cachedRemoval} removal`,
           );
         }
+        // Include cached types breakdown for non-removal candidates
         if (cacheStats.cachedOther > 0) {
-          parts.push(
-            `${cacheStats.cachedOther} other candidate${
-              cacheStats.cachedOther === 1 ? "" : "s"
-            }`,
-          );
+          const typeBreakdown = Array.from(cacheStats.cachedTypes.entries())
+            .map(([type, count]) => `${count} ${type}`)
+            .join(", ");
+          parts.push(typeBreakdown || `${cacheStats.cachedOther} other`);
         }
         console.info(
           `[DiscoveryRunner] ⏭️ Skipped ${totalCached} candidate${

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -2087,3 +2087,179 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "DiscoveryRunner logs specific candidate types when skipped due to cache",
+  async () => {
+    const tempDir = await Deno.makeTempDir();
+    const cacheDir = `${tempDir}/failure-cache`;
+
+    try {
+      // Create discovery result with both synapse and squash candidates
+      const discoveryResult: DiscoverResult = {
+        ID: "CACHE_TYPE_LOGGING_TEST",
+        addHelpfulSynapses: [{
+          fromNeuronUUID: "input-1",
+          toNeuronUUID: "hidden-1",
+          weight: 0.45,
+          expectedImprovementPercentage: 0.2,
+          improvedCount: 5,
+          totalCount: 6,
+        }],
+        addHelpfulNeurons: undefined,
+        removeHarmfulSynapse: undefined,
+        removeHarmfulNeurons: undefined,
+        removalCandidates: undefined,
+        candidateSquashes: [{
+          neuronUUID: "hidden-1",
+          previousSquash: "IDENTITY",
+          squash: "TANH",
+          expectedImprovementPercentage: 0.3,
+          improvedError: 0.03,
+          currentError: 0.1,
+        }],
+      };
+
+      // All candidates will fail (worse than original)
+      const computeError = (_creature: Creature) => 0.6;
+
+      const runner = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            discoveryResult,
+            computeError,
+          ),
+      });
+
+      // First run - cache failures
+      await runner.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options: makeOptions({ discoveryFailureCacheDir: cacheDir }),
+      });
+
+      // Capture console output for second run
+      const captured: string[] = [];
+      const originalInfo = console.info.bind(console);
+      console.info = (...args: unknown[]) => {
+        captured.push(args.map((arg) => String(arg)).join(" "));
+        originalInfo(...args);
+      };
+
+      try {
+        // Second run - should log specific types being skipped
+        await runner.discoverDir({
+          creature: makeBaseCreature(),
+          dataDir: "/tmp/data",
+          options: makeOptions({ discoveryFailureCacheDir: cacheDir }),
+        });
+      } finally {
+        console.info = originalInfo;
+      }
+
+      // Find the skip log line
+      const skipLine = captured.find((line) =>
+        line.includes("[DiscoveryRunner]") && line.includes("Skipped") &&
+        line.includes("previous failure")
+      );
+
+      assert(
+        skipLine,
+        "Expected a log line about skipped candidates due to previous failure",
+      );
+
+      // Verify the log includes specific types, not just "other candidates"
+      assert(
+        skipLine.includes("add-synapses") || skipLine.includes("change-squash"),
+        `Expected skip log to include specific candidate types, got: ${skipLine}`,
+      );
+
+      // Verify it does NOT just say "other candidates" without breakdown
+      const hasTypeBreakdown = skipLine.includes("add-synapses") ||
+        skipLine.includes("change-squash");
+      assert(
+        hasTypeBreakdown,
+        `Expected type breakdown in skip log, got: ${skipLine}`,
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "DiscoveryRunner logs when candidates are skipped due to threshold",
+  async () => {
+    const discoveryResult: DiscoverResult = {
+      ID: "BELOW_MIN_EXPECTED_TEST", // Avoid "threshold" in the ID
+      addHelpfulSynapses: [{
+        fromNeuronUUID: "input-1",
+        toNeuronUUID: "hidden-1",
+        weight: 0.45,
+        expectedImprovementPercentage: 0.001, // Very small improvement
+        improvedCount: 5,
+        totalCount: 6,
+      }],
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    const captured: string[] = [];
+    const originalInfo = console.info.bind(console);
+    console.info = (...args: unknown[]) => {
+      captured.push(args.map((arg) => String(arg)).join(" "));
+      originalInfo(...args);
+    };
+
+    try {
+      const runner = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            discoveryResult,
+            () => 0.5,
+          ),
+      });
+
+      // Set high costOfGrowth so candidate is below threshold
+      await runner.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options: makeOptions({
+          costOfGrowth: 0.1, // High cost - candidate expected improvement won't meet threshold
+        }),
+      });
+    } finally {
+      console.info = originalInfo;
+    }
+
+    // Debug: print all captured lines that include DiscoveryRunner
+    const discoveryLines = captured.filter((l) =>
+      l.includes("[DiscoveryRunner]")
+    );
+
+    // Find the threshold skip log line - look for specific phrasing like
+    // "skipped due to threshold" or "below minimum improvement"
+    // Must NOT match file paths that happen to contain these words
+    const thresholdLine = captured.find((line) =>
+      line.includes("[DiscoveryRunner]") &&
+      !line.includes("Saved creature") && // Exclude file path lines
+      (line.includes("cost-of-growth") ||
+        line.includes("below minimum") ||
+        (line.includes("skipped") &&
+          (line.includes("threshold") || line.includes("improvement"))))
+    );
+
+    assertEquals(
+      thresholdLine !== undefined,
+      true,
+      `Expected a log line about candidates filtered below minimum expected improvement. Captured ${discoveryLines.length} DiscoveryRunner logs:\n${
+        discoveryLines.join("\n")
+      }`,
+    );
+  },
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds granular logging across discovery candidate build/filter phases (counts, cache-type breakdowns, threshold skips) with new tests and a version bump.
> 
> - **Discovery (logging/diagnostics)**
>   - `src/discovery/DiscoveryRunner.ts`:
>     - Always log built candidate counts by `change.type`.
>     - Log failure-cache skips with per-type breakdown (non-removal) and removal counts.
>     - Log candidates skipped for being below cost-of-growth threshold with per-type counts and threshold value.
>   - `src/discovery/DiscoveryCandidates.ts`:
>     - Log when combined candidates (`add-neurons`, `add-synapses`, `change-squash`) aren’t created.
>     - Track and log counts of skipped individual candidates in `buildSingle*` helpers (neurons/synapses/squashes).
> - **Tests**
>   - Add tests verifying cache-type skip logging and threshold-based skip logging in `test/discovery/DiscoveryRunner.ts`.
> - **Version**
>   - Bump `deno.json` version to `0.242.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f40a082bad579b9a27382ef807404bdc7aa9ca6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->