### PR TITLE
Update version to 0.243.0 and clarify squash change handling in Disco…

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,11 @@ structural cost are skipped entirely. This keeps discovery focused on proposals
 that can actually repay the growth penalty and prevents logs from being flooded
 with meaningless `+0.000%` deltas.
 
+**Note:** Squash changes (`change-squash`) are excluded from the cost-of-growth
+threshold check because they don't add structural complexity (no new synapses or
+neurons). They only modify the activation function of existing neurons, so there
+is no growth cost to penalise.
+
 ## Enabling the Rust Discovery Module
 
 The Rust FFI extension shipped via

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.242.0",
+  "version": "0.243.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -119,11 +119,15 @@ Discovery uses a two-stage filter:
 
 **Stage 1: Cost of Growth Gate**
 
-Each candidate must satisfy: `Error Reduction > Cost of Growth`
+Each candidate that adds structural complexity must satisfy:
+`Error Reduction > Cost of Growth`
 
 - New synapse: costs `1 × costOfGrowth`
 - New neuron: costs `~3 × costOfGrowth` (neuron + 2 synapses)
 - If error reduction < structural cost → **rejected** (unprofitable)
+- **Squash changes (`change-squash`) are excluded** from this check because they
+  don't add synapses or neurons - they only modify activation functions of
+  existing neurons, so there is no growth cost to penalise
 
 **Stage 2: Minimum Improvement Threshold**
 
@@ -150,6 +154,9 @@ Example:
 
 // Candidate C: Add 1 neuron, 0.5% improvement, cost = 0.003
 // Error reduction: 0.005, Cost: 0.003 → Profit: 0.002 ✅
+
+// Candidate D: Change squash, 0.1% improvement, cost = 0 (no structural growth)
+// Error reduction: 0.001, Cost: 0 → Profit: 0.001 ✅ (not filtered by cost-of-growth)
 
 // Result: Choose Candidate A (largest improvement at 1.2%)
 ```

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -921,6 +921,9 @@ export class DiscoveryRunner {
    * Removal candidates are treated separately because they don't reduce error -
    * they improve SCORE by reducing complexity.
    *
+   * Squash changes (change-squash) are excluded from cost-of-growth threshold checks
+   * because they don't add structural complexity (no new synapses or neurons).
+   *
    * @param candidates - All discovery candidates
    * @param threadCount - Number of CPU threads available
    * @param config - NEAT configuration
@@ -996,25 +999,31 @@ export class DiscoveryRunner {
         continue; // Skip cached candidates - don't let them consume slots
       }
 
-      // Check threshold for non-removal candidates
-      let meetsThreshold = true;
-      if (expected !== undefined) {
-        if (!Number.isFinite(expected)) {
-          meetsThreshold = false;
-        } else {
-          meetsThreshold = multiplier === 0
-            ? expected > 0
-            : expected >= minExpectedImprovement;
-        }
-      }
+      // Squash changes don't add structural complexity (no new synapses/neurons),
+      // so they shouldn't be filtered by cost-of-growth threshold
+      const isSquashChange = changeType === "change-squash";
 
-      if (!meetsThreshold) {
-        skipped.push({ changeType, expected });
-        thresholdSkipped.set(
-          changeType,
-          (thresholdSkipped.get(changeType) ?? 0) + 1,
-        );
-        continue;
+      // Check threshold for non-removal, non-squash candidates
+      let meetsThreshold = true;
+      if (!isSquashChange) {
+        if (expected !== undefined) {
+          if (!Number.isFinite(expected)) {
+            meetsThreshold = false;
+          } else {
+            meetsThreshold = multiplier === 0
+              ? expected > 0
+              : expected >= minExpectedImprovement;
+          }
+        }
+
+        if (!meetsThreshold) {
+          skipped.push({ changeType, expected });
+          thresholdSkipped.set(
+            changeType,
+            (thresholdSkipped.get(changeType) ?? 0) + 1,
+          );
+          continue;
+        }
       }
 
       // Group by category for diversity selection

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -2263,3 +2263,104 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "DiscoveryRunner does not filter squash changes by cost-of-growth threshold",
+  async () => {
+    const creature = makeBaseCreature();
+    const hiddenNeuron = creature.neurons.find((n) => n.uuid === "hidden-1");
+    assert(hiddenNeuron, "Should have hidden-1 neuron");
+
+    // Create discovery result with:
+    // 1. A squash change with very low expected improvement (below threshold)
+    // 2. An add-synapses candidate with similarly low expected improvement (should be filtered)
+    const discoveryResult: DiscoverResult = {
+      ID: "SQUASH_THRESHOLD_TEST",
+      addHelpfulSynapses: [{
+        fromNeuronUUID: "input-0",
+        toNeuronUUID: "output-0",
+        weight: 0.1,
+        expectedImprovementPercentage: 0.0001, // Very small - below threshold
+        improvedCount: 1,
+        totalCount: 10,
+      }],
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: [{
+        neuronUUID: "hidden-1",
+        previousSquash: "IDENTITY",
+        squash: "TANH",
+        expectedImprovementPercentage: 0.0001, // Very small - below threshold
+        improvedError: 0.49,
+        currentError: 0.5,
+      }],
+    };
+
+    const captured: string[] = [];
+    const originalInfo = console.info.bind(console);
+    console.info = (...args: unknown[]) => {
+      captured.push(args.map((arg) => String(arg)).join(" "));
+      originalInfo(...args);
+    };
+
+    try {
+      const runner = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            discoveryResult,
+            () => 0.5,
+          ),
+      });
+
+      // Set high costOfGrowth and multiplier so threshold is high
+      // costOfGrowth = 0.01, multiplier = 2.0 → threshold = 0.02
+      // Both candidates have expected = 0.0001, which is < 0.02
+      await runner.discoverDir({
+        creature,
+        dataDir: "/tmp/data",
+        options: makeOptions({
+          costOfGrowth: 0.01,
+          discoveryMinImprovementVsCostOfGrowthMultiplier: 2.0,
+        }),
+      });
+    } finally {
+      console.info = originalInfo;
+    }
+
+    // Find log lines about skipped candidates
+    const skipLines = captured.filter((line) =>
+      line.includes("[DiscoveryRunner]") &&
+      line.includes("Skipped") &&
+      line.includes("cost-of-growth")
+    );
+
+    // Verify that add-synapses was filtered (should appear in skip log)
+    const addSynapsesFiltered = skipLines.some((line) =>
+      line.includes("add-synapses")
+    );
+
+    // Verify that change-squash was NOT filtered (should NOT appear in skip log)
+    const squashFiltered = skipLines.some((line) =>
+      line.includes("change-squash")
+    );
+
+    assertEquals(
+      addSynapsesFiltered,
+      true,
+      `Expected add-synapses candidate to be filtered by cost-of-growth threshold. Skip logs: ${
+        skipLines.join("\n")
+      }`,
+    );
+
+    assertEquals(
+      squashFiltered,
+      false,
+      `Expected change-squash candidate NOT to be filtered by cost-of-growth threshold (squash changes don't add structural complexity). Skip logs: ${
+        skipLines.join("\n")
+      }`,
+    );
+  },
+);


### PR DESCRIPTION
…veryRunner

- Bumped version in deno.json to 0.243.0.
- Updated documentation in README.md and DISCOVERY_GUIDE.md to specify that squash changes are excluded from cost-of-growth threshold checks as they do not add structural complexity.
- Enhanced comments in DiscoveryRunner.ts to reflect the new handling of squash changes.
- Added tests to verify that squash changes are not filtered by the cost-of-growth threshold, ensuring accurate behavior during discovery.

These changes improve clarity and ensure that the discovery process correctly handles different types of candidate changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Excludes `change-squash` candidates from the cost-of-growth gate, adds a verifying test, updates docs, and bumps version to 0.243.0.
> 
> - **Discovery logic**
>   - Update `#filterCandidatesForEvaluation` in `src/discovery/DiscoveryRunner.ts` to skip cost-of-growth threshold checks for `change-squash` candidates (no structural growth), while retaining checks for other types.
>   - Add explanatory comments and refined skip logging for threshold and cache cases.
> - **Tests**
>   - Add test in `test/discovery/DiscoveryRunner.ts` asserting `change-squash` is not filtered by the cost-of-growth threshold and `add-synapses` is.
> - **Docs**
>   - Clarify in `README.md` and `docs/DISCOVERY_GUIDE.md` that `change-squash` is exempt from the cost-of-growth gate; add example illustrating this.
> - **Version**
>   - Bump `deno.json` version to `0.243.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67074ebbd776010c7bf7db3205d7b6e2bab3ec7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->