### PR TITLE
Update version to 0.245.0 and refactor discovery candidate handling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.244.0",
+  "version": "0.245.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -47,13 +47,13 @@ class DiscoveryPerformanceStats {
   harmfulNeuronAnalysisTime = 0;
   squashAnalysisTime = 0;
 
-  // Candidate counts
-  helpfulSynapseCandidates = 0;
-  helpfulNeuronCandidates = 0;
+  // Raw discovery result counts (what Rust found)
+  helpfulSynapseRawCount = 0;
+  helpfulNeuronRawCount = 0;
   harmfulSynapseCandidates = 0;
   harmfulNeuronCandidates = 0;
-  squashCandidates = 0;
-  removalCandidates = 0;
+  squashRawCount = 0;
+  removalRawCount = 0;
 
   // Other phases
   cleanupTime = 0;
@@ -126,14 +126,27 @@ class DiscoveryPerformanceStats {
     );
 
     // Candidate summary
+    // Calculate expected candidate counts that will be built:
+    // - Synapses: 1 combined + N individual = 1 + N (if any synapses exist)
+    // - Squashes: 1 combined + N individual = 1 + N (if any squashes exist)
+    // - Removals: N individual + 1 combined (if N >= 2) = N + (N >= 2 ? 1 : 0)
+    const expectedSynapseCandidates = this.helpfulSynapseRawCount > 0
+      ? 1 + this.helpfulSynapseRawCount
+      : 0;
+    const expectedSquashCandidates = this.squashRawCount > 0
+      ? 1 + this.squashRawCount
+      : 0;
+    const expectedRemovalCandidates = this.removalRawCount +
+      (this.removalRawCount >= 2 ? 1 : 0);
+
     console.log(
       `\n🎯 ${yellow("Candidates Found")}:\n` +
-        `  Helpful synapses: ${formatCount(this.helpfulSynapseCandidates)}\n` +
-        `  Helpful neurons: ${formatCount(this.helpfulNeuronCandidates)}\n` +
+        `  Helpful synapses: ${formatCount(expectedSynapseCandidates)}\n` +
+        `  Helpful neurons: ${formatCount(this.helpfulNeuronRawCount)}\n` +
         `  Harmful synapses: ${formatCount(this.harmfulSynapseCandidates)}\n` +
         `  Harmful neurons: ${formatCount(this.harmfulNeuronCandidates)}\n` +
-        `  Squash changes: ${formatCount(this.squashCandidates)}\n` +
-        `  Removal candidates: ${formatCount(this.removalCandidates)}`,
+        `  Squash changes: ${formatCount(expectedSquashCandidates)}\n` +
+        `  Removal candidates: ${formatCount(expectedRemovalCandidates)}`,
     );
 
     // Overall summary
@@ -981,14 +994,14 @@ class DataRecorder {
             ...(discoverResult.addHelpfulNeurons ?? []),
             ...addHelpfulNeurons,
           ];
-          perfStats.helpfulNeuronCandidates += addHelpfulNeurons.length;
+          perfStats.helpfulNeuronRawCount += addHelpfulNeurons.length;
         }
         if (addHelpfulSynapse && addHelpfulSynapse.length > 0) {
           discoverResult.addHelpfulSynapses = [
             ...(discoverResult.addHelpfulSynapses ?? []),
             ...addHelpfulSynapse,
           ];
-          perfStats.helpfulSynapseCandidates += addHelpfulSynapse.length;
+          perfStats.helpfulSynapseRawCount += addHelpfulSynapse.length;
         }
         if (removeHarmfulSynapse && !discoverResult.removeHarmfulSynapse) {
           discoverResult.removeHarmfulSynapse = removeHarmfulSynapse;
@@ -999,7 +1012,7 @@ class DataRecorder {
             ...(discoverResult.candidateSquashes ?? []),
             ...candidateSquashes,
           ];
-          perfStats.squashCandidates += candidateSquashes.length;
+          perfStats.squashRawCount += candidateSquashes.length;
         }
         if (removeHarmfulNeurons && removeHarmfulNeurons.length > 0) {
           discoverResult.removeHarmfulNeurons = [
@@ -1053,7 +1066,7 @@ class DataRecorder {
       const removalCandidates = discoverStructure.getRemovalCandidates();
       if (removalCandidates && removalCandidates.length > 0) {
         discoverResult.removalCandidates = removalCandidates;
-        perfStats.removalCandidates = removalCandidates.length;
+        perfStats.removalRawCount = removalCandidates.length;
         if (shouldLogDiscovery(config)) {
           console.log(
             `Discovery ${blue(this.ID)} found ${

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -127,9 +127,13 @@ class DiscoveryPerformanceStats {
 
     // Candidate summary
     // Calculate expected candidate counts that will be built:
+    // - Neurons: 1 combined + N individual = 1 + N (if any neurons exist)
     // - Synapses: 1 combined + N individual = 1 + N (if any synapses exist)
     // - Squashes: 1 combined + N individual = 1 + N (if any squashes exist)
     // - Removals: N individual + 1 combined (if N >= 2) = N + (N >= 2 ? 1 : 0)
+    const expectedNeuronCandidates = this.helpfulNeuronRawCount > 0
+      ? 1 + this.helpfulNeuronRawCount
+      : 0;
     const expectedSynapseCandidates = this.helpfulSynapseRawCount > 0
       ? 1 + this.helpfulSynapseRawCount
       : 0;
@@ -142,7 +146,7 @@ class DiscoveryPerformanceStats {
     console.log(
       `\n🎯 ${yellow("Candidates Found")}:\n` +
         `  Helpful synapses: ${formatCount(expectedSynapseCandidates)}\n` +
-        `  Helpful neurons: ${formatCount(this.helpfulNeuronRawCount)}\n` +
+        `  Helpful neurons: ${formatCount(expectedNeuronCandidates)}\n` +
         `  Harmful synapses: ${formatCount(this.harmfulSynapseCandidates)}\n` +
         `  Harmful neurons: ${formatCount(this.harmfulNeuronCandidates)}\n` +
         `  Squash changes: ${formatCount(expectedSquashCandidates)}\n` +

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -40,12 +40,8 @@ import {
   DiscoverStructure,
 } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { DiscoverResult } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
-import { getTag } from "@stsoftware/tags/mod";
 import { Creature } from "../Creature.ts";
-import { CreatureErrorImpactEstimator } from "./NeuronErrorImpactEstimator.ts";
 import { ValidationError } from "../errors/ValidationError.ts";
-
-const EPSILON = 1e-9;
 
 export type DiscoveryChangeType =
   | "add-synapses"
@@ -130,69 +126,24 @@ export function buildDiscoveryCandidates(
   const skipCombos = options?.skipCombinedCandidates ?? false;
   // Ensure the base creature has a UUID so discovery helpers function correctly.
   CreatureUtil.makeUUID(baseCreature);
-  const impactEstimator = new CreatureErrorImpactEstimator(baseCreature);
 
-  const scaledNeuronExpected = (candidate: CandidateNeuron) => {
-    const share = impactEstimator.getNeuronShare(candidate.toNeuronUUID);
-    // If we have recorded stats, use the actual error magnitude to scale more accurately
-    if (candidate.targetNeuronStats) {
-      const stats = candidate.targetNeuronStats;
-      // Use mean error magnitude to estimate the actual error contribution
-      // The neuron-level improvement percentage is relative to the neuron's error
-      // We scale it by the share and the relative error magnitude
-      const neuronErrorMagnitude = Math.abs(stats.meanError) +
-        Math.sqrt(stats.errorVariance);
-      const creatureTotalErrorStr = getTag(baseCreature, "error");
-      if (creatureTotalErrorStr) {
-        const creatureTotalError = Number.parseFloat(creatureTotalErrorStr);
-        if (creatureTotalError > EPSILON && neuronErrorMagnitude > EPSILON) {
-          // Scale by: (neuron error / creature error) * share
-          const errorRatio = neuronErrorMagnitude / creatureTotalError;
-          return scaleExpectedImprovement(
-            candidate.expectedImprovementPercentage,
-            share * Math.min(1.0, errorRatio),
-          );
-        }
-      }
-    }
-    return scaleExpectedImprovement(
-      candidate.expectedImprovementPercentage,
-      share,
-    );
-  };
-  const scaledSynapseExpected = (candidate: CandidateSynapse) => {
-    const share = impactEstimator.getNeuronShare(candidate.toNeuronUUID);
-    // If we have recorded stats, use the actual error magnitude to scale more accurately
-    if (candidate.targetNeuronStats) {
-      const stats = candidate.targetNeuronStats;
-      const neuronErrorMagnitude = Math.abs(stats.meanError) +
-        Math.sqrt(stats.errorVariance);
-      const creatureTotalErrorStr = getTag(baseCreature, "error");
-      if (creatureTotalErrorStr) {
-        const creatureTotalError = Number.parseFloat(creatureTotalErrorStr);
-        if (creatureTotalError > EPSILON && neuronErrorMagnitude > EPSILON) {
-          const errorRatio = neuronErrorMagnitude / creatureTotalError;
-          return scaleExpectedImprovement(
-            candidate.expectedImprovementPercentage,
-            share * Math.min(1.0, errorRatio),
-          );
-        }
-      }
-    }
-    return scaleExpectedImprovement(
-      candidate.expectedImprovementPercentage,
-      share,
-    );
-  };
-  const scaledSquashExpected = (candidate: CandidateSquash) =>
-    scaleExpectedImprovement(
-      candidate.expectedImprovementPercentage,
-      impactEstimator.getNeuronShare(candidate.neuronUUID),
-    );
-  const scaledRemovalExpected = (candidate?: CandidateSynapse) => {
+  // Since Rust v0.1.123 (neurons) and v0.1.133 (synapses), the expectedImprovementPercentage
+  // returned by Rust is already creature-level (impact discounted). TypeScript should use
+  // these values directly without re-scaling. These helper functions are kept for API
+  // compatibility but simply return the Rust-provided value.
+  const getExpectedNeuron = (candidate: CandidateNeuron) =>
+    candidate.expectedImprovementPercentage;
+
+  const getExpectedSynapse = (candidate: CandidateSynapse) =>
+    candidate.expectedImprovementPercentage;
+
+  const getExpectedSquash = (candidate: CandidateSquash) =>
+    candidate.expectedImprovementPercentage;
+
+  const getExpectedRemoval = (candidate?: CandidateSynapse) => {
     if (!candidate) return undefined;
-    const scaled = scaledSynapseExpected(candidate);
-    return scaled !== undefined ? Math.abs(scaled) : undefined;
+    const value = candidate.expectedImprovementPercentage;
+    return value !== undefined ? Math.abs(value) : undefined;
   };
 
   const candidates: DiscoveryCandidate[] = [];
@@ -217,7 +168,7 @@ export function buildDiscoveryCandidates(
     const neuronSummary = summariseExpectedImprovement(
       mapScaledSummaryEntries(
         helpfulNeuronCandidates,
-        scaledNeuronExpected,
+        getExpectedNeuron,
         (candidate) => candidate.totalCount,
       ),
     );
@@ -246,7 +197,7 @@ export function buildDiscoveryCandidates(
       discovery.ID,
       baseCreature,
       helpfulNeuronCandidates,
-      scaledNeuronExpected,
+      getExpectedNeuron,
     ),
   );
 
@@ -259,7 +210,7 @@ export function buildDiscoveryCandidates(
     const synapseSummary = summariseExpectedImprovement(
       mapScaledSummaryEntries(
         addHelpfulSynapses,
-        scaledSynapseExpected,
+        getExpectedSynapse,
         (candidate) => candidate.totalCount,
       ),
     );
@@ -287,7 +238,7 @@ export function buildDiscoveryCandidates(
       discovery.ID,
       baseCreature,
       addHelpfulSynapses,
-      scaledSynapseExpected,
+      getExpectedSynapse,
     ),
   );
 
@@ -304,7 +255,7 @@ export function buildDiscoveryCandidates(
         description: `✂️ Removed harmful synapse ${
           shortID(removeHarmfulSynapse.fromNeuronUUID)
         } -> ${shortID(removeHarmfulSynapse.toNeuronUUID)}`,
-        expectedErrorReduction: scaledRemovalExpected(removeHarmfulSynapse),
+        expectedErrorReduction: getExpectedRemoval(removeHarmfulSynapse),
         sampleSize: removeHarmfulSynapse.totalCount,
         synapseDetails: {
           fromNeuronUUID: removeHarmfulSynapse.fromNeuronUUID,
@@ -393,7 +344,7 @@ export function buildDiscoveryCandidates(
     const changes = (candidateSquashes || []).map((c) => {
       const neuron = baseCreature.neurons.find((n) => n.uuid === c.neuronUUID);
       const oldSquash = neuron?.squash;
-      const improvementValue = scaledSquashExpected(c);
+      const improvementValue = getExpectedSquash(c);
       const improvement = improvementValue !== undefined
         ? ` expected: ${(improvementValue * 100).toFixed(1)}%`
         : "";
@@ -406,7 +357,7 @@ export function buildDiscoveryCandidates(
       ? `🎨 Changed activation function for ${changes.join(", ")}`
       : `🎨 Changed activation function on ${changes.length} high-error neurons`;
     const squashSummary = summariseExpectedImprovement(
-      mapScaledSummaryEntries(candidateSquashes, scaledSquashExpected),
+      mapScaledSummaryEntries(candidateSquashes, getExpectedSquash),
     );
 
     candidates.push({
@@ -455,7 +406,7 @@ export function buildDiscoveryCandidates(
       discovery.ID,
       baseCreature,
       candidateSquashes,
-      scaledSquashExpected,
+      getExpectedSquash,
     ),
   );
 
@@ -670,9 +621,9 @@ export function buildDiscoveryCandidates(
       baseCreature,
       discovery,
       {
-        synapse: scaledSynapseExpected,
-        neuron: scaledNeuronExpected,
-        squash: scaledSquashExpected,
+        synapse: getExpectedSynapse,
+        neuron: getExpectedNeuron,
+        squash: getExpectedSquash,
       },
     );
     if (bestOfCategoryCandidate) {
@@ -937,19 +888,6 @@ function mapScaledSummaryEntries<T>(
     });
   }
   return mapped;
-}
-
-function scaleExpectedImprovement(
-  raw?: number,
-  share?: number,
-): number | undefined {
-  if (raw === undefined || Number.isFinite(raw) === false) {
-    return undefined;
-  }
-  const safeShare = Number.isFinite(share)
-    ? Math.min(Math.max(share ?? 0, 0), 1)
-    : 0;
-  return raw * safeShare;
 }
 
 /** Returns the last 8 characters of a UUID or the full ID if short. */

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -918,14 +918,19 @@ export class DiscoveryRunner {
    * 3. Fill remaining slots with best expected improvements across categories
    * 4. Count failure cache statistics during selection (single pass)
    *
+   * NOTE: Rust is the single source of truth for candidate filtering based on
+   * expected improvement and cost-of-growth. TypeScript does NOT re-filter
+   * candidates based on these criteria (DRY principle).
+   *
+   * TypeScript filtering is limited to:
+   * - Failure cache: Skip candidates that previously failed to improve
+   * - Diversity selection: Ensure a mix of candidate types are evaluated
+   * - Slot allocation: Limit total candidates based on available CPU threads
+   *
    * Removal candidates (remove-low-impact, remove-neuron, remove-synapse) are treated
    * separately because they don't reduce error - they improve SCORE by reducing complexity.
-   * Removing elements that return a similar score will improve the creature's score.
    *
-   * Squash changes (change-squash) are excluded from cost-of-growth threshold checks
-   * because they don't add structural complexity (no new synapses or neurons).
-   *
-   * @param candidates - All discovery candidates
+   * @param candidates - All discovery candidates (pre-filtered by Rust)
    * @param threadCount - Number of CPU threads available
    * @param config - NEAT configuration
    * @param failureCacheDir - Optional failure cache directory for statistics
@@ -943,10 +948,6 @@ export class DiscoveryRunner {
       expected?: number;
     }>;
   } {
-    // Calculate the minimum expected improvement threshold
-    const multiplier = config.discoveryMinImprovementVsCostOfGrowthMultiplier;
-    const minExpectedImprovement = config.costOfGrowth * multiplier;
-
     // Group candidates by category for diversity selection
     const byCategory = new Map<string, DiscoveryCandidate[]>();
     const removalCandidates: DiscoveryCandidate[] = [];
@@ -965,18 +966,11 @@ export class DiscoveryRunner {
       cachedTypes: new Map<string, number>(),
     };
 
-    // Track candidates skipped due to cost-of-growth threshold
-    const thresholdSkipped = new Map<string, number>();
-
     for (const candidate of candidates) {
       CreatureUtil.makeUUID(candidate.creature);
-      const expected = candidate.change.expectedErrorReduction;
       const changeType = candidate.change.type;
 
-      // All removal types are excluded from cost-of-growth filtering because:
-      // 1. They don't add structural complexity (they remove it)
-      // 2. They improve score by reducing complexity, not by reducing error
-      // 3. Removing elements that return a similar score will improve the creature's score
+      // Identify removal candidates (handled separately for slot allocation)
       const isRemovalCandidate = changeType === "remove-low-impact" ||
         changeType === "remove-neuron" ||
         changeType === "remove-synapse";
@@ -1007,34 +1001,8 @@ export class DiscoveryRunner {
         continue; // Skip cached candidates - don't let them consume slots
       }
 
-      // Squash changes don't add structural complexity (no new synapses/neurons),
-      // so they shouldn't be filtered by cost-of-growth threshold
-      const isSquashChange = changeType === "change-squash";
-
-      // Check threshold for non-removal, non-squash candidates
-      let meetsThreshold = true;
-      if (!isSquashChange) {
-        if (expected !== undefined) {
-          if (!Number.isFinite(expected)) {
-            meetsThreshold = false;
-          } else {
-            meetsThreshold = multiplier === 0
-              ? expected > 0
-              : expected >= minExpectedImprovement;
-          }
-        }
-
-        if (!meetsThreshold) {
-          skipped.push({ changeType, expected });
-          thresholdSkipped.set(
-            changeType,
-            (thresholdSkipped.get(changeType) ?? 0) + 1,
-          );
-          continue;
-        }
-      }
-
       // Group by category for diversity selection
+      // NOTE: No threshold filtering - Rust is single source of truth
       if (!byCategory.has(changeType)) {
         byCategory.set(changeType, []);
       }
@@ -1064,22 +1032,6 @@ export class DiscoveryRunner {
           } due to previous failure: ${parts.join(", ")}`,
         );
       }
-    }
-
-    // Log candidates skipped due to cost-of-growth threshold
-    if (thresholdSkipped.size > 0) {
-      const totalThresholdSkipped = Array.from(thresholdSkipped.values())
-        .reduce((a, b) => a + b, 0);
-      const typeBreakdown = Array.from(thresholdSkipped.entries())
-        .map(([type, count]) => `${count} ${type}`)
-        .join(", ");
-      console.info(
-        `[DiscoveryRunner] ⏭️ Skipped ${totalThresholdSkipped} candidate${
-          totalThresholdSkipped === 1 ? "" : "s"
-        } below cost-of-growth threshold (${
-          minExpectedImprovement.toExponential(2)
-        }): ${typeBreakdown}`,
-      );
     }
 
     // Sort each category by expected improvement (descending)

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -284,20 +284,19 @@ export class DiscoveryRunner {
           failureCacheDir,
         );
       if (skipped.length > 0) {
-        const minThreshold = config.costOfGrowth *
-          config.discoveryMinImprovementVsCostOfGrowthMultiplier;
+        // Group skipped candidates by type for a cleaner summary
+        const skippedByType = new Map<string, number>();
+        for (const entry of skipped) {
+          const type = entry.changeType ?? "unknown";
+          skippedByType.set(type, (skippedByType.get(type) ?? 0) + 1);
+        }
+        const typeBreakdown = Array.from(skippedByType.entries())
+          .map(([type, count]) => `${count} ${type}`)
+          .join(", ");
         verboseLog(
           `Skipped ${skipped.length} candidate${
             skipped.length === 1 ? "" : "s"
-          } with expected improvement below ${
-            minThreshold.toPrecision(3)
-          } (${config.discoveryMinImprovementVsCostOfGrowthMultiplier}× costOfGrowth): ${
-            skipped.map((entry) =>
-              `${entry.changeType ?? "unknown"} (expected ${
-                entry.expected?.toPrecision(3) ?? "n/a"
-              })`
-            ).join(", ")
-          }.`,
+          } due to slot limits: ${typeBreakdown}.`,
         );
       }
 

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -562,14 +562,17 @@ Deno.test("DiscoveryRunner records evaluation summaries and archives candidates"
   }
 });
 
-Deno.test("DiscoveryRunner flags expectation mismatch when predictions diverge", async () => {
+Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for synapses", async () => {
+  // Since Rust v0.1.133, expectedImprovementPercentage is already creature-level
+  // (Rust applies impact discounting internally). TypeScript should use it directly.
+  const rustProvidedImprovement = 0.6; // 60% creature-level improvement from Rust
   const discoveryResult: DiscoverResult = {
-    ID: "EXPECT_MISMATCH",
+    ID: "RUST_DIRECT_SYNAPSE",
     addHelpfulSynapses: [{
       fromNeuronUUID: "input-1",
       toNeuronUUID: "hidden-1",
       weight: 0.45,
-      expectedImprovementPercentage: 0.6,
+      expectedImprovementPercentage: rustProvidedImprovement,
       improvedCount: 9,
       totalCount: 10,
     }],
@@ -607,26 +610,20 @@ Deno.test("DiscoveryRunner flags expectation mismatch when predictions diverge",
     entry.kind === "candidate" && entry.changeType === "add-synapses"
   );
   assert(candidateEval, "expected add-synapses candidate evaluation");
-  // With structural scaling, the target neuron's share of the output error is tiny
-  // (~0.82%) because the output fan-in now includes hundreds of equally weighted
-  // synapses. The 60% neuron-level improvement therefore becomes ~0.49%
-  // creature-level impact. Actual improvement is 1%, so the 0.51 percentage point
-  // gap stays below the 25% alert threshold and no mismatch should be detected.
-  assertEquals(
-    candidateEval.expectationMismatch,
-    undefined,
-    "expected no mismatch when scaled expected (~0.4%) is close to actual (1%)",
-  );
-  // Verify the scaled expected improvement percentage
+
+  // Verify TypeScript uses Rust's creature-level value directly (no re-scaling)
+  // The expectedErrorReductionPct should equal Rust's expectedImprovementPercentage * 100
   assert(
     candidateEval.expectedErrorReductionPct !== undefined,
-    "expected scaled error reduction percentage to be defined",
+    "expected error reduction percentage to be defined",
   );
   assertAlmostEquals(
     candidateEval.expectedErrorReductionPct!,
-    0.493,
-    1e-3,
+    rustProvidedImprovement * 100, // 60% as percentage
+    1e-6,
+    "TypeScript should use Rust's creature-level value directly without re-scaling",
   );
+
   // Verify the actual improvement percentage
   assertAlmostEquals(
     candidateEval.errorDeltaPct ?? 0,
@@ -635,9 +632,9 @@ Deno.test("DiscoveryRunner flags expectation mismatch when predictions diverge",
   );
 });
 
-Deno.test("DiscoveryRunner validates error estimates for non-trivial creatures with many synapses", async () => {
-  // Create a creature similar to production: many synapses pointing to output
-  // This tests that error estimates are reasonable and not wildly wrong
+Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for neurons", async () => {
+  // Since Rust v0.1.123 (neurons) and v0.1.133 (synapses), expectedImprovementPercentage
+  // is already creature-level. TypeScript should use it directly without re-scaling.
   const creature = makeDenseOutputCreature(100); // 100+ synapses to output
 
   // Set a baseline error for the creature
@@ -645,10 +642,10 @@ Deno.test("DiscoveryRunner validates error estimates for non-trivial creatures w
   const { addTag } = await import("@stsoftware/tags/mod");
   addTag(creature, "error", baseError.toString());
 
-  // Simulate a candidate with recorded stats (like production)
-  // The stats show the target neuron has moderate error
+  // targetNeuronStats is still passed for backwards compatibility but TypeScript
+  // should NOT use it for scaling - Rust has already applied the impact discount
   const targetNeuronStats = {
-    meanError: 0.05, // Moderate error at neuron level
+    meanError: 0.05,
     errorVariance: 0.001,
     meanActivation: 0.3,
     activationVariance: 0.01,
@@ -658,16 +655,20 @@ Deno.test("DiscoveryRunner validates error estimates for non-trivial creatures w
     activationMax: 1.2,
   };
 
+  // Rust provides creature-level improvement directly (0.1% expected)
+  // This is already discounted by impact - TypeScript should NOT re-scale
+  const rustCreatureLevelImprovement = 0.001; // 0.1% creature-level from Rust
+
   const discoveryResult: DiscoverResult = {
-    ID: "NON_TRIVIAL_TEST",
+    ID: "RUST_DIRECT_NEURON",
     addHelpfulSynapses: [{
       fromNeuronUUID: "input-1",
       toNeuronUUID: "hidden-1",
       weight: 0.45,
-      expectedImprovementPercentage: 0.333, // 33.3% neuron-level (like production)
+      expectedImprovementPercentage: rustCreatureLevelImprovement,
       improvedCount: 9,
       totalCount: 10,
-      targetNeuronStats, // Include stats for accurate scaling
+      targetNeuronStats, // Passed for backwards compatibility, but NOT used for scaling
     }],
     addHelpfulNeurons: undefined,
     removeHarmfulSynapse: undefined,
@@ -684,7 +685,7 @@ Deno.test("DiscoveryRunner validates error estimates for non-trivial creatures w
         synapse.fromUUID === "input-1" && synapse.toUUID === "hidden-1" &&
         Math.abs(synapse.weight - 0.45) < 1e-6
       );
-      // Actual improvement is small (0.1%) - realistic for complex creatures
+      // Actual improvement matches Rust's creature-level estimate
       return hasHelpful ? baseError * 0.999 : baseError;
     },
   );
@@ -705,29 +706,19 @@ Deno.test("DiscoveryRunner validates error estimates for non-trivial creatures w
   );
   assert(candidateEval, "expected add-synapses candidate evaluation");
 
-  // With stats-based scaling, the 33.3% neuron-level improvement should be
-  // scaled down significantly because:
-  // 1. The target neuron's share is small (~1/100 = 1%) due to many synapses
-  // 2. The neuron's error magnitude (0.05 + sqrt(0.001) ≈ 0.082) is small
-  //    relative to creature error (0.584)
-  // 3. Expected: 0.333 * (1/100) * (0.082/0.584) ≈ 0.0047% (very small)
+  // Verify TypeScript uses Rust's creature-level value directly (no re-scaling)
   const expectedErrorReductionPct = candidateEval.expectedErrorReductionPct;
   assert(
     expectedErrorReductionPct !== undefined,
-    "expected scaled error reduction percentage to be defined",
+    "expected error reduction percentage to be defined",
   );
 
-  // The scaled estimate should be MUCH smaller than the raw 33.3%
-  // It should be less than 1% (not 33%!)
-  assert(
-    expectedErrorReductionPct < 1.0,
-    `Expected scaled estimate (${expectedErrorReductionPct}%) to be < 1%, not the raw 33.3%`,
-  );
-
-  // The estimate should be positive but small
-  assert(
-    expectedErrorReductionPct > 0,
-    `Expected scaled estimate to be positive, got ${expectedErrorReductionPct}`,
+  // TypeScript should use Rust's value directly: 0.1% (as percentage)
+  assertAlmostEquals(
+    expectedErrorReductionPct,
+    rustCreatureLevelImprovement * 100, // 0.1%
+    1e-6,
+    "TypeScript should use Rust's creature-level value directly without re-scaling",
   );
 
   // Actual improvement is 0.1% (0.584263 -> 0.5836)
@@ -738,20 +729,11 @@ Deno.test("DiscoveryRunner validates error estimates for non-trivial creatures w
     0.05, // Allow small tolerance
   );
 
-  // The estimate should be within reasonable range of actual (not wildly wrong)
-  // Allow up to 10x difference for complex creatures (estimate could be conservative)
-  const ratio = Math.abs(expectedErrorReductionPct / actualErrorDeltaPct);
-  assert(
-    ratio < 10.0 && ratio > 0.1,
-    `Expected estimate (${expectedErrorReductionPct}%) to be within 10x of actual (${actualErrorDeltaPct}%), ratio: ${ratio}`,
-  );
-
-  // Most importantly: no mismatch warning should be triggered
-  // because the estimate is now reasonable (not 33% vs 0%)
+  // Since Rust provides accurate creature-level values, expect close match
   assertEquals(
     candidateEval.expectationMismatch,
     undefined,
-    `Expected no mismatch when estimate (${expectedErrorReductionPct}%) is reasonable compared to actual (${actualErrorDeltaPct}%)`,
+    `Expected no mismatch when Rust's creature-level estimate (${expectedErrorReductionPct}%) matches actual (${actualErrorDeltaPct}%)`,
   );
 });
 
@@ -961,61 +943,8 @@ Deno.test(
   },
 );
 
-Deno.test(
-  "DiscoveryRunner skips candidates with non-positive expected impact",
-  async () => {
-    const discoveryResult: DiscoverResult = {
-      ID: "NON_POSITIVE_FILTER",
-      addHelpfulSynapses: undefined,
-      addHelpfulNeurons: undefined,
-      removeHarmfulSynapse: undefined,
-      removeHarmfulNeurons: undefined,
-      removalCandidates: undefined,
-      candidateSquashes: undefined,
-    };
-
-    const baseCreature = makeBaseCreature();
-
-    const candidateBuilder = (
-      _creature: Creature,
-      _discovery: DiscoverResult,
-    ): DiscoveryCandidate[] => {
-      const json = cloneCreatureJSON(baseCreature);
-      const candidate = Creature.fromJSON(json);
-      candidate.validate();
-      CreatureUtil.makeUUID(candidate);
-      return [{
-        creature: candidate,
-        change: {
-          type: "add-synapses",
-          description: "non-positive candidate",
-          expectedErrorReduction: 0, // Non-positive expected impact
-        },
-      }];
-    };
-
-    const runner = new DiscoveryRunner({
-      rustDiscoveryEnabled: () => true,
-      workerFactory: () =>
-        new FakeWorker(
-          discoveryResult,
-          () => 0.5,
-        ),
-      candidateBuilder,
-    });
-
-    const result = await runner.discoverDir({
-      creature: baseCreature,
-      dataDir: "/tmp/data",
-      options: makeOptions(),
-    });
-
-    assert(
-      !result.evaluations?.some((entry) => entry.kind === "candidate"),
-      "candidates with non-positive expected impact should be skipped",
-    );
-  },
-);
+// NOTE: Test "DiscoveryRunner skips candidates with non-positive expected impact" removed.
+// Rust is the single source of truth for candidate filtering (DRY principle).
 
 Deno.test(
   "DiscoveryRunner includes candidates with undefined expectedErrorReduction for evaluation",
@@ -1073,109 +1002,8 @@ Deno.test(
   },
 );
 
-Deno.test(
-  "DiscoveryRunner excludes zero-impact candidates when multiplier is 0",
-  async () => {
-    const discoveryResult: DiscoverResult = {
-      ID: "ZERO_MULTIPLIER",
-      addHelpfulSynapses: undefined,
-      addHelpfulNeurons: undefined,
-      removeHarmfulSynapse: undefined,
-      removeHarmfulNeurons: undefined,
-      removalCandidates: undefined,
-      candidateSquashes: undefined,
-    };
-
-    const baseCreature = makeBaseCreature();
-
-    const candidateBuilder = (
-      _creature: Creature,
-      _discovery: DiscoverResult,
-    ): DiscoveryCandidate[] => {
-      // Create three candidates: one with zero impact, one with positive, one with negative
-      const candidates: DiscoveryCandidate[] = [];
-
-      // Candidate 1: Zero impact (should be excluded)
-      const zeroCandidate = Creature.fromJSON(cloneCreatureJSON(baseCreature));
-      zeroCandidate.validate();
-      CreatureUtil.makeUUID(zeroCandidate);
-      candidates.push({
-        creature: zeroCandidate,
-        change: {
-          type: "add-neurons",
-          description: "zero-impact candidate",
-          expectedErrorReduction: 0, // Zero impact - should be excluded
-        },
-      });
-
-      // Candidate 2: Positive impact (should be included)
-      const positiveCandidate = Creature.fromJSON(
-        cloneCreatureJSON(baseCreature),
-      );
-      positiveCandidate.validate();
-      CreatureUtil.makeUUID(positiveCandidate);
-      candidates.push({
-        creature: positiveCandidate,
-        change: {
-          type: "add-synapses",
-          description: "positive-impact candidate",
-          expectedErrorReduction: 0.001, // Positive impact - should be included
-        },
-      });
-
-      // Candidate 3: Negative impact (should be excluded)
-      const negativeCandidate = Creature.fromJSON(
-        cloneCreatureJSON(baseCreature),
-      );
-      negativeCandidate.validate();
-      CreatureUtil.makeUUID(negativeCandidate);
-      candidates.push({
-        creature: negativeCandidate,
-        change: {
-          type: "add-neurons",
-          description: "negative-impact candidate",
-          expectedErrorReduction: -0.001, // Negative impact - should be excluded
-        },
-      });
-
-      return candidates;
-    };
-
-    const runner = new DiscoveryRunner({
-      rustDiscoveryEnabled: () => true,
-      workerFactory: () =>
-        new FakeWorker(
-          discoveryResult,
-          () => 0.5,
-        ),
-      candidateBuilder,
-    });
-
-    const options = makeOptions();
-    options.discoveryMinImprovementVsCostOfGrowthMultiplier = 0; // Set multiplier to 0
-
-    const result = await runner.discoverDir({
-      creature: baseCreature,
-      dataDir: "/tmp/data",
-      options,
-    });
-
-    // Only the positive-impact candidate should be evaluated
-    const candidateEvaluations =
-      result.evaluations?.filter((entry) => entry.kind === "candidate") ?? [];
-
-    assertEquals(
-      candidateEvaluations.length,
-      1,
-      "only one candidate with positive impact should be evaluated",
-    );
-
-    assert(
-      candidateEvaluations[0].description?.includes("positive-impact"),
-      "the evaluated candidate should be the positive-impact one",
-    );
-  },
-);
+// NOTE: Test "DiscoveryRunner excludes zero-impact candidates when multiplier is 0" removed.
+// Rust is the single source of truth for candidate filtering (DRY principle).
 
 Deno.test(
   "DiscoveryRunner logs sub-basis deltas with at least three significant digits",
@@ -2188,309 +2016,6 @@ Deno.test(
   },
 );
 
-Deno.test(
-  "DiscoveryRunner logs when candidates are skipped due to threshold",
-  async () => {
-    const discoveryResult: DiscoverResult = {
-      ID: "BELOW_MIN_EXPECTED_TEST", // Avoid "threshold" in the ID
-      addHelpfulSynapses: [{
-        fromNeuronUUID: "input-1",
-        toNeuronUUID: "hidden-1",
-        weight: 0.45,
-        expectedImprovementPercentage: 0.001, // Very small improvement
-        improvedCount: 5,
-        totalCount: 6,
-      }],
-      addHelpfulNeurons: undefined,
-      removeHarmfulSynapse: undefined,
-      removeHarmfulNeurons: undefined,
-      removalCandidates: undefined,
-      candidateSquashes: undefined,
-    };
-
-    const captured: string[] = [];
-    const originalInfo = console.info.bind(console);
-    console.info = (...args: unknown[]) => {
-      captured.push(args.map((arg) => String(arg)).join(" "));
-      originalInfo(...args);
-    };
-
-    try {
-      const runner = new DiscoveryRunner({
-        rustDiscoveryEnabled: () => true,
-        workerFactory: () =>
-          new FakeWorker(
-            discoveryResult,
-            () => 0.5,
-          ),
-      });
-
-      // Set high costOfGrowth so candidate is below threshold
-      await runner.discoverDir({
-        creature: makeBaseCreature(),
-        dataDir: "/tmp/data",
-        options: makeOptions({
-          costOfGrowth: 0.1, // High cost - candidate expected improvement won't meet threshold
-        }),
-      });
-    } finally {
-      console.info = originalInfo;
-    }
-
-    // Debug: print all captured lines that include DiscoveryRunner
-    const discoveryLines = captured.filter((l) =>
-      l.includes("[DiscoveryRunner]")
-    );
-
-    // Find the threshold skip log line - look for specific phrasing like
-    // "skipped due to threshold" or "below minimum improvement"
-    // Must NOT match file paths that happen to contain these words
-    const thresholdLine = captured.find((line) =>
-      line.includes("[DiscoveryRunner]") &&
-      !line.includes("Saved creature") && // Exclude file path lines
-      (line.includes("cost-of-growth") ||
-        line.includes("below minimum") ||
-        (line.includes("skipped") &&
-          (line.includes("threshold") || line.includes("improvement"))))
-    );
-
-    assertEquals(
-      thresholdLine !== undefined,
-      true,
-      `Expected a log line about candidates filtered below minimum expected improvement. Captured ${discoveryLines.length} DiscoveryRunner logs:\n${
-        discoveryLines.join("\n")
-      }`,
-    );
-  },
-);
-
-Deno.test(
-  "DiscoveryRunner does not filter squash changes by cost-of-growth threshold",
-  async () => {
-    const creature = makeBaseCreature();
-    const hiddenNeuron = creature.neurons.find((n) => n.uuid === "hidden-1");
-    assert(hiddenNeuron, "Should have hidden-1 neuron");
-
-    // Create discovery result with:
-    // 1. A squash change with very low expected improvement (below threshold)
-    // 2. An add-synapses candidate with similarly low expected improvement (should be filtered)
-    const discoveryResult: DiscoverResult = {
-      ID: "SQUASH_THRESHOLD_TEST",
-      addHelpfulSynapses: [{
-        fromNeuronUUID: "input-0",
-        toNeuronUUID: "output-0",
-        weight: 0.1,
-        expectedImprovementPercentage: 0.0001, // Very small - below threshold
-        improvedCount: 1,
-        totalCount: 10,
-      }],
-      addHelpfulNeurons: undefined,
-      removeHarmfulSynapse: undefined,
-      removeHarmfulNeurons: undefined,
-      removalCandidates: undefined,
-      candidateSquashes: [{
-        neuronUUID: "hidden-1",
-        previousSquash: "IDENTITY",
-        squash: "TANH",
-        expectedImprovementPercentage: 0.0001, // Very small - below threshold
-        improvedError: 0.49,
-        currentError: 0.5,
-      }],
-    };
-
-    const captured: string[] = [];
-    const originalInfo = console.info.bind(console);
-    console.info = (...args: unknown[]) => {
-      captured.push(args.map((arg) => String(arg)).join(" "));
-      originalInfo(...args);
-    };
-
-    try {
-      const runner = new DiscoveryRunner({
-        rustDiscoveryEnabled: () => true,
-        workerFactory: () =>
-          new FakeWorker(
-            discoveryResult,
-            () => 0.5,
-          ),
-      });
-
-      // Set high costOfGrowth and multiplier so threshold is high
-      // costOfGrowth = 0.01, multiplier = 2.0 → threshold = 0.02
-      // Both candidates have expected = 0.0001, which is < 0.02
-      await runner.discoverDir({
-        creature,
-        dataDir: "/tmp/data",
-        options: makeOptions({
-          costOfGrowth: 0.01,
-          discoveryMinImprovementVsCostOfGrowthMultiplier: 2.0,
-        }),
-      });
-    } finally {
-      console.info = originalInfo;
-    }
-
-    // Find log lines about skipped candidates
-    const skipLines = captured.filter((line) =>
-      line.includes("[DiscoveryRunner]") &&
-      line.includes("Skipped") &&
-      line.includes("cost-of-growth")
-    );
-
-    // Verify that add-synapses was filtered (should appear in skip log)
-    const addSynapsesFiltered = skipLines.some((line) =>
-      line.includes("add-synapses")
-    );
-
-    // Verify that change-squash was NOT filtered (should NOT appear in skip log)
-    const squashFiltered = skipLines.some((line) =>
-      line.includes("change-squash")
-    );
-
-    assertEquals(
-      addSynapsesFiltered,
-      true,
-      `Expected add-synapses candidate to be filtered by cost-of-growth threshold. Skip logs: ${
-        skipLines.join("\n")
-      }`,
-    );
-
-    assertEquals(
-      squashFiltered,
-      false,
-      `Expected change-squash candidate NOT to be filtered by cost-of-growth threshold (squash changes don't add structural complexity). Skip logs: ${
-        skipLines.join("\n")
-      }`,
-    );
-  },
-);
-
-Deno.test(
-  "DiscoveryRunner does not filter removal candidates by cost-of-growth threshold",
-  async () => {
-    const creature = makeBaseCreature();
-
-    // Create discovery result with removal candidates that have very low expected improvement
-    const discoveryResult: DiscoverResult = {
-      ID: "REMOVAL_THRESHOLD_TEST",
-      addHelpfulSynapses: [{
-        fromNeuronUUID: "input-0",
-        toNeuronUUID: "output-0",
-        weight: 0.1,
-        expectedImprovementPercentage: 0.0001, // Very small - below threshold
-        improvedCount: 1,
-        totalCount: 10,
-      }],
-      addHelpfulNeurons: undefined,
-      removeHarmfulSynapse: {
-        fromNeuronUUID: "input-0",
-        toNeuronUUID: "hidden-1",
-        weight: -0.5,
-        expectedImprovementPercentage: 0.0001, // Very small - below threshold
-        improvedCount: 1,
-        totalCount: 10,
-      },
-      removeHarmfulNeurons: [{
-        neuronUUID: "hidden-1",
-        errorMagnitude: 0.0001, // Very small - below threshold
-        sampleCount: 10,
-        averageActivation: 0.0,
-        expectedImprovementPercentage: 0.0001,
-      }],
-      removalCandidates: [{
-        neuronUUID: "hidden-1",
-        totalError: 1.0,
-        impact: 0.0001, // Very small - below threshold
-        reason: "Impact below costOfGrowth",
-      }],
-      candidateSquashes: undefined,
-    };
-
-    const captured: string[] = [];
-    const originalInfo = console.info.bind(console);
-    console.info = (...args: unknown[]) => {
-      captured.push(args.map((arg) => String(arg)).join(" "));
-      originalInfo(...args);
-    };
-
-    try {
-      const runner = new DiscoveryRunner({
-        rustDiscoveryEnabled: () => true,
-        workerFactory: () =>
-          new FakeWorker(
-            discoveryResult,
-            () => 0.5,
-          ),
-      });
-
-      // Set high costOfGrowth and multiplier so threshold is high
-      // costOfGrowth = 0.01, multiplier = 2.0 → threshold = 0.02
-      // All candidates have expected = 0.0001, which is < 0.02
-      await runner.discoverDir({
-        creature,
-        dataDir: "/tmp/data",
-        options: makeOptions({
-          costOfGrowth: 0.01,
-          discoveryMinImprovementVsCostOfGrowthMultiplier: 2.0,
-        }),
-      });
-    } finally {
-      console.info = originalInfo;
-    }
-
-    // Find log lines about skipped candidates
-    const skipLines = captured.filter((line) =>
-      line.includes("[DiscoveryRunner]") &&
-      line.includes("Skipped") &&
-      line.includes("cost-of-growth")
-    );
-
-    // Verify that add-synapses was filtered (should appear in skip log)
-    const addSynapsesFiltered = skipLines.some((line) =>
-      line.includes("add-synapses")
-    );
-
-    // Verify that removal candidates were NOT filtered
-    const removeSynapseFiltered = skipLines.some((line) =>
-      line.includes("remove-synapse")
-    );
-    const removeNeuronFiltered = skipLines.some((line) =>
-      line.includes("remove-neuron")
-    );
-    const removeLowImpactFiltered = skipLines.some((line) =>
-      line.includes("remove-low-impact")
-    );
-
-    assertEquals(
-      addSynapsesFiltered,
-      true,
-      `Expected add-synapses candidate to be filtered by cost-of-growth threshold. Skip logs: ${
-        skipLines.join("\n")
-      }`,
-    );
-
-    assertEquals(
-      removeSynapseFiltered,
-      false,
-      `Expected remove-synapse candidate NOT to be filtered (removal doesn't add structural complexity). Skip logs: ${
-        skipLines.join("\n")
-      }`,
-    );
-
-    assertEquals(
-      removeNeuronFiltered,
-      false,
-      `Expected remove-neuron candidate NOT to be filtered (removal doesn't add structural complexity). Skip logs: ${
-        skipLines.join("\n")
-      }`,
-    );
-
-    assertEquals(
-      removeLowImpactFiltered,
-      false,
-      `Expected remove-low-impact candidate NOT to be filtered (removal improves score by reducing complexity). Skip logs: ${
-        skipLines.join("\n")
-      }`,
-    );
-  },
-);
+// NOTE: Tests for TypeScript cost-of-growth filtering have been removed.
+// Rust is the single source of truth for candidate filtering (DRY principle).
+// See NEAT-AI-Discovery v0.1.133 for filtering logic.

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -659,18 +659,24 @@ Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for neu
   // This is already discounted by impact - TypeScript should NOT re-scale
   const rustCreatureLevelImprovement = 0.001; // 0.1% creature-level from Rust
 
+  // Neuron candidate structure with incoming/outgoing weights, bias, and squash
+  const neuronCandidate = {
+    fromNeuronUUID: "input-1",
+    toNeuronUUID: "hidden-1",
+    incomingWeight: 0.45,
+    outgoingWeight: -0.3,
+    squash: "TANH",
+    bias: 0.05,
+    expectedImprovementPercentage: rustCreatureLevelImprovement,
+    improvedCount: 9,
+    totalCount: 10,
+    targetNeuronStats, // Passed for backwards compatibility, but NOT used for scaling
+  };
+
   const discoveryResult: DiscoverResult = {
     ID: "RUST_DIRECT_NEURON",
-    addHelpfulSynapses: [{
-      fromNeuronUUID: "input-1",
-      toNeuronUUID: "hidden-1",
-      weight: 0.45,
-      expectedImprovementPercentage: rustCreatureLevelImprovement,
-      improvedCount: 9,
-      totalCount: 10,
-      targetNeuronStats, // Passed for backwards compatibility, but NOT used for scaling
-    }],
-    addHelpfulNeurons: undefined,
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: [neuronCandidate],
     removeHarmfulSynapse: undefined,
     removeHarmfulNeurons: undefined,
     removalCandidates: undefined,
@@ -681,12 +687,26 @@ Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for neu
     discoveryResult,
     (creature: Creature) => {
       const json = creature.exportJSON();
-      const hasHelpful = json.synapses.some((synapse) =>
-        synapse.fromUUID === "input-1" && synapse.toUUID === "hidden-1" &&
-        Math.abs(synapse.weight - 0.45) < 1e-6
+      // Check for the added neuron by finding its incoming and outgoing synapses
+      const incomingSynapse = json.synapses.find((synapse) =>
+        synapse.fromUUID === neuronCandidate.fromNeuronUUID &&
+        Math.abs(synapse.weight - neuronCandidate.incomingWeight) < 1e-6
+      );
+      const discoveredNeuronUUID = incomingSynapse?.toUUID;
+      const outgoingSynapse = discoveredNeuronUUID
+        ? json.synapses.find((synapse) =>
+          synapse.fromUUID === discoveredNeuronUUID &&
+          synapse.toUUID === neuronCandidate.toNeuronUUID &&
+          Math.abs(synapse.weight - neuronCandidate.outgoingWeight) < 1e-6
+        )
+        : undefined;
+      const hasDiscoveredNeuron = Boolean(
+        discoveredNeuronUUID &&
+          outgoingSynapse &&
+          json.neurons.some((neuron) => neuron.uuid === discoveredNeuronUUID),
       );
       // Actual improvement matches Rust's creature-level estimate
-      return hasHelpful ? baseError * 0.999 : baseError;
+      return hasDiscoveredNeuron ? baseError * 0.999 : baseError;
     },
   );
 
@@ -702,9 +722,9 @@ Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for neu
   });
 
   const candidateEval = result.evaluations?.find((entry) =>
-    entry.kind === "candidate" && entry.changeType === "add-synapses"
+    entry.kind === "candidate" && entry.changeType === "add-neurons"
   );
-  assert(candidateEval, "expected add-synapses candidate evaluation");
+  assert(candidateEval, "expected add-neurons candidate evaluation");
 
   // Verify TypeScript uses Rust's creature-level value directly (no re-scaling)
   const expectedErrorReductionPct = candidateEval.expectedErrorReductionPct;


### PR DESCRIPTION
- Bumped version in deno.json to 0.245.0.
- Refactored candidate counting in DiscoveryPerformanceStats to use raw counts instead of candidate counts for improved clarity.
- Updated DiscoveryRunner to utilize Rust's creature-level improvement values directly, eliminating unnecessary scaling.
- Removed outdated tests related to cost-of-growth filtering, as Rust is now the single source of truth for candidate filtering.

These changes enhance the accuracy and efficiency of the discovery process, ensuring better alignment with Rust's logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use Rust creature-level expected improvements end-to-end, replace TS-side scaling/threshold filtering with diversity+cache-only selection, switch perf stats to raw discovery counts, and bump version.
> 
> - **Discovery pipeline**:
>   - **Use Rust creature-level improvements directly**: Remove TS re-scaling; `getExpected*` now forward Rust `expectedImprovementPercentage` for neurons/synapses/squash/removal.
>   - **Simplify candidate filtering**: Drop TS cost-of-growth threshold checks; keep failure-cache skipping, category diversity, and slot-based selection only.
> - **Performance stats** (`DiscoverDirectory`):
>   - Replace candidate counters with raw discovery counts: `helpful{Synapse,Neuron}RawCount`, `squashRawCount`, `removalRawCount`.
>   - Log expected built-candidate totals computed from raw counts.
> - **Tests**:
>   - Add assertions that TS uses Rust values directly for synapse and neuron improvements.
>   - Remove tests tied to TS-side threshold filtering and non-positive/zero-impact exclusions; retain inclusion of undefined expected cases and removal slot behavior.
> - **Meta**:
>   - Bump version to `0.245.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0004d0fd1c4020b9ee54e794e4dbc44110a34526. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->