### PR TITLE
Update version to 0.248.1 and revise comparison note for clarity

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -8,9 +8,10 @@ network architectures (feedforward, CNN, RNN) and modern Large Language Models
 our approaches, our unique innovations, and identifies shortcomings that
 represent future work opportunities.
 
-**Note**: This comparison is written from the perspective of someone who
-understands NEAT deeply but is learning about other ML approaches. It aims to
-stay accurate and links to authoritative sources whenever new ideas are
+**Note**: You don't need to be an expert in neural networks or the NEAT
+algorithm to get value from this comparison. We start with a high-level
+introduction to NEAT and only assume basic familiarity with ML concepts. It
+aims to stay accurate and links to authoritative sources whenever new ideas are
 introduced.
 
 ## Terminology Cheat Sheet

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -10,8 +10,8 @@ represent future work opportunities.
 
 **Note**: You don't need to be an expert in neural networks or the NEAT
 algorithm to get value from this comparison. We start with a high-level
-introduction to NEAT and only assume basic familiarity with ML concepts. It
-aims to stay accurate and links to authoritative sources whenever new ideas are
+introduction to NEAT and only assume basic familiarity with ML concepts. It aims
+to stay accurate and links to authoritative sources whenever new ideas are
 introduced.
 
 ## Terminology Cheat Sheet

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.248.0",
+  "version": "0.248.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",


### PR DESCRIPTION
- Bumped version in deno.json to 0.248.1.
- Revised the note in COMPARISON.md to emphasize that prior expertise in NEAT or neural networks is not required to benefit from the comparison, providing a more accessible introduction for readers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps version to 0.248.1 and clarifies the introductory note in COMPARISON.md to be more accessible to non-experts.
> 
> - **Docs**:
>   - Clarify the introductory note in `COMPARISON.md` to emphasize accessibility for readers without NEAT/NN expertise.
> - **Release**:
>   - Update `deno.json` version from `0.248.0` to `0.248.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4994e861b7754d82ee1f0c5315a446c392cf1c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->