### PR TITLE
Enhance DiscoveryRunner to pass discoveryFailureCacheDir to candidate…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.249.1",
+  "version": "0.249.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -13,6 +13,7 @@ import { createNeatConfig, type NeatConfig } from "../config/NeatConfig.ts";
 import {
   buildCombinedFromSuccessful,
   buildDiscoveryCandidates,
+  type BuildDiscoveryCandidatesOptions,
   type DiscoveredNeuronDetails,
   type DiscoveryChangeType,
   shortID,
@@ -126,7 +127,7 @@ export class DiscoveryRunner {
   #candidateBuilder: (
     creature: Creature,
     discovery: DiscoverResult,
-    options?: { skipCombinedCandidates?: boolean },
+    options?: BuildDiscoveryCandidatesOptions,
   ) => DiscoveryCandidate[];
   #rustDiscoveryEnabled: () => boolean;
 
@@ -246,7 +247,10 @@ export class DiscoveryRunner {
       const singleCandidates = this.#candidateBuilder(
         creature,
         discoverResult,
-        { skipCombinedCandidates: true },
+        {
+          skipCombinedCandidates: true,
+          discoveryFailureCacheDir: config.discoveryFailureCacheDir,
+        },
       );
 
       // Log candidate counts by type (always, not just verbose)

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -2041,6 +2041,86 @@ Deno.test(
   },
 );
 
+Deno.test({
+  name: "DiscoveryRunner passes discoveryFailureCacheDir to candidate builder",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const tempDir = await Deno.makeTempDir();
+    const cacheDir = `${tempDir}/failure-cache`;
+
+    try {
+      const discoveryResult: DiscoverResult = {
+        ID: "CACHE_DIR_PASSTHROUGH_TEST",
+        addHelpfulSynapses: [{
+          fromNeuronUUID: "input-1",
+          toNeuronUUID: "hidden-1",
+          weight: 0.45,
+          expectedImprovementPercentage: 0.2,
+          improvedCount: 5,
+          totalCount: 6,
+        }],
+        addHelpfulNeurons: undefined,
+        removeHarmfulSynapse: undefined,
+        removeHarmfulNeurons: undefined,
+        removalCandidates: undefined,
+        candidateSquashes: undefined,
+      };
+
+      // Track what options were passed to the candidate builder
+      let capturedOptions: { discoveryFailureCacheDir?: string } | undefined;
+
+      const mockCandidateBuilder = (
+        creature: Creature,
+        _discovery: DiscoverResult,
+        options?: {
+          skipCombinedCandidates?: boolean;
+          discoveryFailureCacheDir?: string;
+        },
+      ): DiscoveryCandidate[] => {
+        // Capture the options for assertion
+        capturedOptions = options;
+
+        // Return a simple candidate
+        const cloned = Creature.fromJSON(creature.exportJSON());
+        CreatureUtil.makeUUID(cloned);
+        return [{
+          creature: cloned,
+          change: {
+            type: "add-synapses",
+            description: "Test candidate",
+          },
+        }];
+      };
+
+      const runner = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            discoveryResult,
+            () => 0.5, // Fixed error
+          ),
+        candidateBuilder: mockCandidateBuilder,
+      });
+
+      await runner.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options: makeOptions({ discoveryFailureCacheDir: cacheDir }),
+      });
+
+      // Verify discoveryFailureCacheDir was passed to the candidate builder
+      assertEquals(
+        capturedOptions?.discoveryFailureCacheDir,
+        cacheDir,
+        "discoveryFailureCacheDir should be passed to candidate builder to enable issue recording",
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});
+
 // NOTE: Tests for TypeScript cost-of-growth filtering have been removed.
 // Rust is the single source of truth for candidate filtering (DRY principle).
 // See NEAT-AI-Discovery v0.1.133 for filtering logic.


### PR DESCRIPTION
… builder

- Updated the candidate builder options in DiscoveryRunner to include discoveryFailureCacheDir, allowing for better issue recording during the discovery process.
- Added a test to verify that discoveryFailureCacheDir is correctly passed to the candidate builder, ensuring proper functionality and traceability.

These changes aim to improve the robustness of the discovery process by facilitating the recording of failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> DiscoveryRunner now forwards `discoveryFailureCacheDir` to `buildDiscoveryCandidates`, updates the candidate builder options type, and adds a test; version bumped to 0.249.2.
> 
> - **Discovery**:
>   - Forwards `config.discoveryFailureCacheDir` to `buildDiscoveryCandidates` when building single candidates in `src/discovery/DiscoveryRunner.ts`.
>   - Updates `#candidateBuilder` signature to use `BuildDiscoveryCandidatesOptions`.
> - **Tests**:
>   - Adds test ensuring `discoveryFailureCacheDir` is passed to the candidate builder in `test/discovery/DiscoveryRunner.ts`.
> - **Version**:
>   - Bump `deno.json` version to `0.249.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aaf884792f750249634d279ee5d107f278e997f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->