### PR TITLE
Update version to 0.251.0 and implement orphaned neuron cleanup funct…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.249.2",
+  "version": "0.251.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1,10 +1,7 @@
 import { assert } from "@std/assert";
 import { addTag, removeTag, type TagsInterface } from "@stsoftware/tags/mod";
 import { CreatureUtil } from "../../../mod.ts";
-import {
-  cleanupOrphanedNeurons,
-  cleanupOrphanedNeuronsInCreature,
-} from "../../compact/CompactUtils.ts";
+import { cleanupOrphanedNeurons } from "../../compact/CompactUtils.ts";
 import { Creature } from "../../Creature.ts";
 import type { Approach } from "../../NEAT/LogApproach.ts";
 import { memeticUpdate } from "../../blackbox/MemeticUpdate.ts";
@@ -3849,40 +3846,16 @@ export class DiscoverStructure {
         s.toUUID !== worseCandidate.toNeuronUUID;
     });
 
+    // Clean up any neurons that have become orphaned after synapse removal.
+    // This handles both:
+    // - Converting hidden neurons with no inward connections to constants
+    // - Removing hidden/constant neurons with no outward connections
+    cleanupOrphanedNeurons(exportJSON);
+
     const tmpCreature = Creature.fromJSON(exportJSON);
     // We modified the structure by filtering synapses, so we must delete UUID
     delete tmpCreature.uuid;
     delete tmpCreature.memetic;
-
-    // Handle cascading effects like SubConnection.ts does (instead of calling fix())
-    // Check if the "to" neuron has 0 inward connections and convert to constant if needed
-    const toNeuronInTmp = tmpCreature.neurons.find(
-      (n) => n.uuid === worseCandidate.toNeuronUUID,
-    );
-
-    if (toNeuronInTmp) {
-      const toIndxInTmp = toNeuronInTmp.index;
-      const inwardList = tmpCreature.inwardConnections(toIndxInTmp);
-
-      if (inwardList.length === 0 && toNeuronInTmp.type === "hidden") {
-        const outwardList = tmpCreature.outwardConnections(toIndxInTmp);
-        if (outwardList.length > 0) {
-          // Has outward connections but no inward - convert to constant
-          const squash = toNeuronInTmp.findSquash();
-          const activation = squash as ActivationInterface;
-          if (activation.squash) {
-            const constantBias = activation.squash(toNeuronInTmp.bias);
-            toNeuronInTmp.bias = constantBias;
-          }
-          toNeuronInTmp.type = "constant";
-          toNeuronInTmp.setSquash(undefined);
-        }
-      }
-    }
-
-    // Clean up any neurons that have become orphaned (no outward connections)
-    // This handles cascade removal when removing a synapse leaves neurons dangling
-    cleanupOrphanedNeuronsInCreature(tmpCreature);
 
     // Validate the creature - only call fix() as a last resort
     const validationResult = this.validateAndFixIfNeeded(

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1,7 +1,10 @@
 import { assert } from "@std/assert";
 import { addTag, removeTag, type TagsInterface } from "@stsoftware/tags/mod";
 import { CreatureUtil } from "../../../mod.ts";
-import { removeHiddenNeuron } from "../../compact/CompactUtils.ts";
+import {
+  cleanupOrphanedNeurons,
+  cleanupOrphanedNeuronsInCreature,
+} from "../../compact/CompactUtils.ts";
 import { Creature } from "../../Creature.ts";
 import type { Approach } from "../../NEAT/LogApproach.ts";
 import { memeticUpdate } from "../../blackbox/MemeticUpdate.ts";
@@ -3852,11 +3855,10 @@ export class DiscoverStructure {
     delete tmpCreature.memetic;
 
     // Handle cascading effects like SubConnection.ts does (instead of calling fix())
-    // Check if the "to" neuron has 0 inward connections
+    // Check if the "to" neuron has 0 inward connections and convert to constant if needed
     const toNeuronInTmp = tmpCreature.neurons.find(
       (n) => n.uuid === worseCandidate.toNeuronUUID,
     );
-    let toNeuronRemoved = false;
 
     if (toNeuronInTmp) {
       const toIndxInTmp = toNeuronInTmp.index;
@@ -3864,25 +3866,12 @@ export class DiscoverStructure {
 
       if (inwardList.length === 0 && toNeuronInTmp.type === "hidden") {
         const outwardList = tmpCreature.outwardConnections(toIndxInTmp);
-        if (outwardList.length === 0) {
-          // No inward or outward connections - remove entirely
-          console.info(
-            `[DiscoverStructure] removeSynapse: removing completely disconnected neuron ${toNeuronInTmp.uuid}`,
-          );
-          removeHiddenNeuron(tmpCreature, toIndxInTmp);
-          toNeuronRemoved = true;
-        } else {
-          // Has outward connections - convert to constant
-          console.info(
-            `[DiscoverStructure] removeSynapse: converting neuron ${toNeuronInTmp.uuid} to constant`,
-          );
+        if (outwardList.length > 0) {
+          // Has outward connections but no inward - convert to constant
           const squash = toNeuronInTmp.findSquash();
           const activation = squash as ActivationInterface;
           if (activation.squash) {
             const constantBias = activation.squash(toNeuronInTmp.bias);
-            console.info(
-              `[DiscoverStructure] removeSynapse: adjusting neuron ${toNeuronInTmp.uuid} bias ${toNeuronInTmp.bias} to ${constantBias}`,
-            );
             toNeuronInTmp.bias = constantBias;
           }
           toNeuronInTmp.type = "constant";
@@ -3891,35 +3880,9 @@ export class DiscoverStructure {
       }
     }
 
-    // Check if the "from" neuron now has 0 outward connections
-    const fromNeuronInTmp = tmpCreature.neurons.find(
-      (n) => n.uuid === worseCandidate.fromNeuronUUID,
-    );
-
-    if (fromNeuronInTmp) {
-      // Adjust index if the "to" neuron was removed and came before "from"
-      let fromIndxInTmp = fromNeuronInTmp.index;
-      if (toNeuronRemoved && toIndx < fromIndxInTmp) {
-        // Index already adjusted by removeHiddenNeuron, find by UUID again
-        const fromNeuronUpdated = tmpCreature.neurons.find(
-          (n) => n.uuid === worseCandidate.fromNeuronUUID,
-        );
-        if (fromNeuronUpdated) {
-          fromIndxInTmp = fromNeuronUpdated.index;
-        }
-      }
-
-      const fromOutwardList = tmpCreature.outwardConnections(fromIndxInTmp);
-      if (fromOutwardList.length === 0) {
-        const fromNeuronType = tmpCreature.neurons[fromIndxInTmp]?.type;
-        if (fromNeuronType === "hidden" || fromNeuronType === "constant") {
-          console.info(
-            `[DiscoverStructure] removeSynapse: removing neuron ${worseCandidate.fromNeuronUUID} as no longer connected`,
-          );
-          removeHiddenNeuron(tmpCreature, fromIndxInTmp);
-        }
-      }
-    }
+    // Clean up any neurons that have become orphaned (no outward connections)
+    // This handles cascade removal when removing a synapse leaves neurons dangling
+    cleanupOrphanedNeuronsInCreature(tmpCreature);
 
     // Validate the creature - only call fix() as a last resort
     const validationResult = this.validateAndFixIfNeeded(
@@ -4657,6 +4620,11 @@ export class DiscoverStructure {
       (neuron) => neuron.uuid !== harmfulNeuron.neuronUUID,
     );
 
+    // Clean up any neurons that have become orphaned (no outward connections)
+    // This prevents validation failures when neurons that only connected to
+    // the removed neuron are left dangling
+    cleanupOrphanedNeurons(simplifiedExport);
+
     const tmpCreature = Creature.fromJSON(simplifiedExport);
     // We modified the structure, so we must delete UUID
     delete tmpCreature.uuid;
@@ -4752,6 +4720,11 @@ export class DiscoverStructure {
     simplifiedExport.neurons = simplifiedExport.neurons.filter(
       (neuron) => neuron.uuid !== removalCandidate.neuronUUID,
     );
+
+    // Clean up any neurons that have become orphaned (no outward connections)
+    // This prevents validation failures when neurons that only connected to
+    // the removed neuron are left dangling
+    cleanupOrphanedNeurons(simplifiedExport);
 
     const removedSynapseCount = originalSynapseCount -
       simplifiedExport.synapses.length;

--- a/src/compact/CompactUtils.ts
+++ b/src/compact/CompactUtils.ts
@@ -3,6 +3,19 @@ import type { Creature } from "../Creature.ts";
 import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import { Neuron } from "../architecture/Neuron.ts";
 import type { Synapse } from "../architecture/Synapse.ts";
+import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
+import { Activations } from "../methods/activations/Activations.ts";
+import { CreatureExportBuilder } from "../utils/CreatureExportBuilder.ts";
+
+/**
+ * Result of cleaning up orphaned neurons.
+ */
+export interface CleanupOrphanedResult {
+  /** Number of neurons removed. */
+  removed: number;
+  /** Number of hidden neurons converted to constants. */
+  converted: number;
+}
 
 export function createConstantOne(creature: Creature, count: number) {
   let uuid;
@@ -159,10 +172,13 @@ export function removeHiddenNeuron(creature: Creature, indx: number) {
  * Also cleans up memetic data references to removed neurons.
  *
  * @param creatureExport - The CreatureExport to clean up (modified in place).
- * @returns The number of neurons removed.
+ * @returns The cleanup result with counts of removed and converted neurons.
  */
-export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
+export function cleanupOrphanedNeurons(
+  creatureExport: CreatureExport,
+): CleanupOrphanedResult {
   let totalRemoved = 0;
+  let totalConverted = 0;
   let changedThisPass: boolean;
   const allRemovedUUIDs = new Set<string>();
 
@@ -186,12 +202,23 @@ export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
           neuronsWithOutwardConnections.has(neuron.uuid)
         ) {
           // Has outward connections but no inward - convert to constant
-          // The bias becomes the constant value (already "squashed" by having no input)
+          // A hidden neuron with bias X and squash function outputs squash(0 + X)
+          // when receiving no input, so we must apply the squash function to get
+          // the correct constant value.
+          let constantBias = neuron.bias;
+          if (neuron.squash) {
+            const squashFn = Activations.find(neuron.squash);
+            const activation = squashFn as ActivationInterface;
+            if (activation?.squash) {
+              constantBias = activation.squash(neuron.bias);
+            }
+          }
           creatureExport.neurons[i] = {
             type: "constant",
             uuid: neuron.uuid,
-            bias: neuron.bias,
+            bias: constantBias,
           };
+          totalConverted++;
           changedThisPass = true;
         }
       }
@@ -235,7 +262,7 @@ export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
     delete creatureExport.memetic;
   }
 
-  return totalRemoved;
+  return { removed: totalRemoved, converted: totalConverted };
 }
 
 /**
@@ -294,19 +321,29 @@ export function cleanupMemeticForRemovedNeuron(
 /**
  * Cleans up orphaned neurons from a live Creature instance.
  *
- * This is a convenience wrapper that exports the creature to JSON,
- * calls cleanupOrphanedNeurons, and reloads the creature.
+ * This is a convenience wrapper that exports the creature to JSON (without
+ * validation, to allow intermediate invalid states), calls cleanupOrphanedNeurons,
+ * and reloads the creature if any modifications were made.
+ *
+ * This function handles:
+ * 1. Converting hidden neurons with no inward connections to constants
+ * 2. Removing hidden/constant neurons with no outward connections
  *
  * @param creature - The Creature to clean up (modified in place).
- * @returns The number of neurons removed.
+ * @returns The cleanup result with counts of removed and converted neurons.
  */
-export function cleanupOrphanedNeuronsInCreature(creature: Creature): number {
-  const exportJSON = creature.exportJSON();
-  const removed = cleanupOrphanedNeurons(exportJSON);
+export function cleanupOrphanedNeuronsInCreature(
+  creature: Creature,
+): CleanupOrphanedResult {
+  // Use the builder directly to bypass validation (creature may be in an intermediate state)
+  const builder = new CreatureExportBuilder(creature);
+  const exportJSON = builder.build();
 
-  if (removed > 0) {
+  const result = cleanupOrphanedNeurons(exportJSON);
+
+  if (result.removed > 0 || result.converted > 0) {
     creature.loadFrom(exportJSON, true);
   }
 
-  return removed;
+  return result;
 }

--- a/src/compact/CompactUtils.ts
+++ b/src/compact/CompactUtils.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import type { Creature } from "../Creature.ts";
+import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import { Neuron } from "../architecture/Neuron.ts";
 import type { Synapse } from "../architecture/Synapse.ts";
 
@@ -139,4 +140,101 @@ export function removeHiddenNeuron(creature: Creature, indx: number) {
   });
 
   creature.clearCache();
+}
+
+/**
+ * Cleans up orphaned neurons from a CreatureExport.
+ *
+ * Orphaned neurons are hidden or constant neurons that have no outward
+ * connections. This can occur when a neuron is removed and other neurons
+ * that only connected to it are left dangling.
+ *
+ * This function modifies the CreatureExport in place, removing orphaned
+ * neurons and their associated synapses. The cleanup is performed
+ * iteratively until no more orphaned neurons are found (cascade removal).
+ *
+ * @param creatureExport - The CreatureExport to clean up (modified in place).
+ * @returns The number of neurons removed.
+ */
+export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
+  let totalRemoved = 0;
+  let removedThisPass: number;
+
+  do {
+    removedThisPass = 0;
+
+    // Build a set of all source UUIDs (neurons that have outward connections)
+    const neuronsWithOutwardConnections = new Set<string>();
+    for (const synapse of creatureExport.synapses) {
+      neuronsWithOutwardConnections.add(synapse.fromUUID);
+    }
+
+    // Find neurons that are orphaned (hidden/constant with no outward connections)
+    const orphanedUUIDs: string[] = [];
+    for (const neuron of creatureExport.neurons) {
+      if (neuron.type === "hidden" || neuron.type === "constant") {
+        if (!neuronsWithOutwardConnections.has(neuron.uuid)) {
+          orphanedUUIDs.push(neuron.uuid);
+        }
+      }
+    }
+
+    if (orphanedUUIDs.length > 0) {
+      const orphanSet = new Set(orphanedUUIDs);
+
+      // Remove orphaned neurons
+      creatureExport.neurons = creatureExport.neurons.filter(
+        (n) => !orphanSet.has(n.uuid),
+      );
+
+      // Remove synapses that connect TO orphaned neurons
+      creatureExport.synapses = creatureExport.synapses.filter(
+        (s) => !orphanSet.has(s.toUUID),
+      );
+
+      removedThisPass = orphanedUUIDs.length;
+      totalRemoved += removedThisPass;
+    }
+  } while (removedThisPass > 0);
+
+  return totalRemoved;
+}
+
+/**
+ * Cleans up orphaned neurons from a live Creature instance.
+ *
+ * Orphaned neurons are hidden or constant neurons that have no outward
+ * connections. This can occur when a synapse/neuron is removed and other
+ * neurons that only connected to it are left dangling.
+ *
+ * This function modifies the Creature in place, removing orphaned neurons
+ * and their associated synapses. The cleanup is performed iteratively
+ * until no more orphaned neurons are found (cascade removal).
+ *
+ * @param creature - The Creature to clean up (modified in place).
+ * @returns The number of neurons removed.
+ */
+export function cleanupOrphanedNeuronsInCreature(creature: Creature): number {
+  let totalRemoved = 0;
+  let removedThisPass: number;
+
+  do {
+    removedThisPass = 0;
+
+    // Find orphaned neurons (hidden/constant with no outward connections)
+    // Process from highest index to lowest to avoid index shifts during removal
+    for (let i = creature.neurons.length - 1; i >= creature.input; i--) {
+      const neuron = creature.neurons[i];
+      if (neuron.type === "hidden" || neuron.type === "constant") {
+        const outwardList = creature.outwardConnections(i);
+        if (outwardList.length === 0) {
+          removeHiddenNeuron(creature, i);
+          removedThisPass++;
+          totalRemoved++;
+        }
+      }
+    }
+  } while (removedThisPass > 0);
+
+  return totalRemoved;
 }

--- a/src/compact/CompactUtils.ts
+++ b/src/compact/CompactUtils.ts
@@ -156,12 +156,15 @@ export function removeHiddenNeuron(creature: Creature, indx: number) {
  * This function modifies the CreatureExport in place. The cleanup is performed
  * iteratively until no more orphaned neurons are found (cascade removal).
  *
+ * Also cleans up memetic data references to removed neurons.
+ *
  * @param creatureExport - The CreatureExport to clean up (modified in place).
  * @returns The number of neurons removed.
  */
 export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
   let totalRemoved = 0;
   let changedThisPass: boolean;
+  const allRemovedUUIDs = new Set<string>();
 
   do {
     changedThisPass = false;
@@ -207,6 +210,11 @@ export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
     if (orphanedUUIDs.length > 0) {
       const orphanSet = new Set(orphanedUUIDs);
 
+      // Track all removed UUIDs for memetic cleanup
+      for (const uuid of orphanedUUIDs) {
+        allRemovedUUIDs.add(uuid);
+      }
+
       // Remove orphaned neurons
       creatureExport.neurons = creatureExport.neurons.filter(
         (n) => !orphanSet.has(n.uuid),
@@ -222,7 +230,65 @@ export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
     }
   } while (changedThisPass);
 
+  // Delete memetic if any neurons were removed (structure changed)
+  if (allRemovedUUIDs.size > 0) {
+    delete creatureExport.memetic;
+  }
+
   return totalRemoved;
+}
+
+/**
+ * Deletes memetic data if the removed synapse is referenced in it.
+ *
+ * @param creatureExport - The CreatureExport to clean up (modified in place).
+ * @param fromUUID - The source neuron UUID of the removed synapse.
+ * @param toUUID - The target neuron UUID of the removed synapse.
+ */
+export function cleanupMemeticForRemovedSynapse(
+  creatureExport: CreatureExport,
+  fromUUID: string,
+  toUUID: string,
+): void {
+  const memetic = creatureExport.memetic;
+  if (!memetic?.weights) return;
+
+  const weights = memetic.weights[fromUUID];
+  if (weights?.some((w) => w.toUUID === toUUID)) {
+    delete creatureExport.memetic;
+  }
+}
+
+/**
+ * Deletes memetic data if the removed neuron is referenced in it.
+ *
+ * @param creatureExport - The CreatureExport to clean up (modified in place).
+ * @param neuronUUID - The UUID of the neuron that was removed.
+ */
+export function cleanupMemeticForRemovedNeuron(
+  creatureExport: CreatureExport,
+  neuronUUID: string,
+): void {
+  const memetic = creatureExport.memetic;
+  if (!memetic) return;
+
+  // Check if neuron is in weights (as source or target) or biases
+  if (memetic.weights) {
+    if (memetic.weights[neuronUUID]) {
+      delete creatureExport.memetic;
+      return;
+    }
+    for (const weights of Object.values(memetic.weights)) {
+      if (weights?.some((w) => w.toUUID === neuronUUID)) {
+        delete creatureExport.memetic;
+        return;
+      }
+    }
+  }
+
+  if (memetic.biases?.[neuronUUID] !== undefined) {
+    delete creatureExport.memetic;
+  }
 }
 
 /**

--- a/src/compact/CompactUtils.ts
+++ b/src/compact/CompactUtils.ts
@@ -145,12 +145,15 @@ export function removeHiddenNeuron(creature: Creature, indx: number) {
 /**
  * Cleans up orphaned neurons from a CreatureExport.
  *
- * Orphaned neurons are hidden or constant neurons that have no outward
- * connections. This can occur when a neuron is removed and other neurons
- * that only connected to it are left dangling.
+ * This function handles two types of orphaned neurons:
+ * 1. Hidden/constant neurons with no outward connections - these are removed
+ * 2. Hidden neurons with no inward connections but with outward connections -
+ *    these are converted to constants
  *
- * This function modifies the CreatureExport in place, removing orphaned
- * neurons and their associated synapses. The cleanup is performed
+ * This can occur when a neuron is removed and other neurons that only
+ * connected to/from it are left dangling.
+ *
+ * This function modifies the CreatureExport in place. The cleanup is performed
  * iteratively until no more orphaned neurons are found (cascade removal).
  *
  * @param creatureExport - The CreatureExport to clean up (modified in place).
@@ -158,18 +161,40 @@ export function removeHiddenNeuron(creature: Creature, indx: number) {
  */
 export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
   let totalRemoved = 0;
-  let removedThisPass: number;
+  let changedThisPass: boolean;
 
   do {
-    removedThisPass = 0;
+    changedThisPass = false;
 
-    // Build a set of all source UUIDs (neurons that have outward connections)
+    // Build sets for connection analysis
     const neuronsWithOutwardConnections = new Set<string>();
+    const neuronsWithInwardConnections = new Set<string>();
     for (const synapse of creatureExport.synapses) {
       neuronsWithOutwardConnections.add(synapse.fromUUID);
+      neuronsWithInwardConnections.add(synapse.toUUID);
     }
 
-    // Find neurons that are orphaned (hidden/constant with no outward connections)
+    // First pass: Convert hidden neurons with no inward connections (but have outward) to constants
+    for (let i = 0; i < creatureExport.neurons.length; i++) {
+      const neuron = creatureExport.neurons[i];
+      if (neuron.type === "hidden") {
+        if (
+          !neuronsWithInwardConnections.has(neuron.uuid) &&
+          neuronsWithOutwardConnections.has(neuron.uuid)
+        ) {
+          // Has outward connections but no inward - convert to constant
+          // The bias becomes the constant value (already "squashed" by having no input)
+          creatureExport.neurons[i] = {
+            type: "constant",
+            uuid: neuron.uuid,
+            bias: neuron.bias,
+          };
+          changedThisPass = true;
+        }
+      }
+    }
+
+    // Second pass: Find and remove neurons with no outward connections
     const orphanedUUIDs: string[] = [];
     for (const neuron of creatureExport.neurons) {
       if (neuron.type === "hidden" || neuron.type === "constant") {
@@ -192,10 +217,10 @@ export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
         (s) => !orphanSet.has(s.toUUID),
       );
 
-      removedThisPass = orphanedUUIDs.length;
-      totalRemoved += removedThisPass;
+      totalRemoved += orphanedUUIDs.length;
+      changedThisPass = true;
     }
-  } while (removedThisPass > 0);
+  } while (changedThisPass);
 
   return totalRemoved;
 }
@@ -203,38 +228,19 @@ export function cleanupOrphanedNeurons(creatureExport: CreatureExport): number {
 /**
  * Cleans up orphaned neurons from a live Creature instance.
  *
- * Orphaned neurons are hidden or constant neurons that have no outward
- * connections. This can occur when a synapse/neuron is removed and other
- * neurons that only connected to it are left dangling.
- *
- * This function modifies the Creature in place, removing orphaned neurons
- * and their associated synapses. The cleanup is performed iteratively
- * until no more orphaned neurons are found (cascade removal).
+ * This is a convenience wrapper that exports the creature to JSON,
+ * calls cleanupOrphanedNeurons, and reloads the creature.
  *
  * @param creature - The Creature to clean up (modified in place).
  * @returns The number of neurons removed.
  */
 export function cleanupOrphanedNeuronsInCreature(creature: Creature): number {
-  let totalRemoved = 0;
-  let removedThisPass: number;
+  const exportJSON = creature.exportJSON();
+  const removed = cleanupOrphanedNeurons(exportJSON);
 
-  do {
-    removedThisPass = 0;
+  if (removed > 0) {
+    creature.loadFrom(exportJSON, true);
+  }
 
-    // Find orphaned neurons (hidden/constant with no outward connections)
-    // Process from highest index to lowest to avoid index shifts during removal
-    for (let i = creature.neurons.length - 1; i >= creature.input; i--) {
-      const neuron = creature.neurons[i];
-      if (neuron.type === "hidden" || neuron.type === "constant") {
-        const outwardList = creature.outwardConnections(i);
-        if (outwardList.length === 0) {
-          removeHiddenNeuron(creature, i);
-          removedThisPass++;
-          totalRemoved++;
-        }
-      }
-    }
-  } while (removedThisPass > 0);
-
-  return totalRemoved;
+  return removed;
 }

--- a/src/mutate/SubConnection.ts
+++ b/src/mutate/SubConnection.ts
@@ -1,4 +1,7 @@
-import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
+import {
+  cleanupOrphanedNeuronsInCreature,
+  removeHiddenNeuron,
+} from "../compact/CompactUtils.ts";
 import type { Creature } from "../Creature.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
@@ -42,9 +45,9 @@ export class SubConnection implements RadioactiveInterface {
     this.creature.disconnect(randomConn.from, randomConn.to);
 
     delete this.creature.memetic;
-    const inwardList = this.creature.inwardConnections(randomConn.to);
 
-    let toNeuronRemoved = false;
+    // Check if the 'to' neuron has lost all inward connections
+    const inwardList = this.creature.inwardConnections(randomConn.to);
     if (inwardList.length === 0) {
       const neuron = this.creature.neurons[randomConn.to];
       if (neuron.type === "hidden") {
@@ -52,24 +55,13 @@ export class SubConnection implements RadioactiveInterface {
         const outwardList = this.creature.outwardConnections(randomConn.to);
         if (outwardList.length === 0) {
           // No inward or outward connections - remove entirely
-          console.info(
-            `Remove neuron ${neuron.uuid} as completely disconnected`,
-          );
           removeHiddenNeuron(this.creature, randomConn.to);
-          toNeuronRemoved = true;
         } else {
           // Has outward connections - convert to constant
-          console.info(
-            `Constant neuron ${neuron.uuid} convert ${neuron.type} to constant`,
-          );
-
           const squash = neuron.findSquash();
           const activation = squash as ActivationInterface;
           if (activation.squash) {
             const constantBias = activation.squash(neuron.bias);
-            console.info(
-              `Adjust neuron ${neuron.uuid} bias ${neuron.bias} to ${constantBias}`,
-            );
             neuron.bias = constantBias;
           }
           neuron.type = "constant";
@@ -78,19 +70,10 @@ export class SubConnection implements RadioactiveInterface {
       }
     }
 
-    // Adjust the 'from' index if the 'to' neuron was removed and it came before the 'from' neuron
-    let fromIndex = randomConn.from;
-    if (toNeuronRemoved && randomConn.to < randomConn.from) {
-      fromIndex--;
-    }
-    const fromOutwardList = this.creature.outwardConnections(fromIndex);
-    if (fromOutwardList.length === 0) {
-      const fromNeuron = this.creature.neurons[fromIndex];
-      if (fromNeuron.type === "hidden" || fromNeuron.type === "constant") {
-        console.info(`Remove neuron ${fromNeuron.uuid} as no longer connected`);
-        removeHiddenNeuron(this.creature, fromIndex);
-      }
-    }
+    // Clean up any neurons that have become orphaned (no outward connections)
+    // This handles cascade removal when removing a synapse leaves neurons dangling
+    cleanupOrphanedNeuronsInCreature(this.creature);
+
     return true;
   }
 }

--- a/src/mutate/SubConnection.ts
+++ b/src/mutate/SubConnection.ts
@@ -1,9 +1,8 @@
-import {
-  cleanupOrphanedNeuronsInCreature,
-  removeHiddenNeuron,
-} from "../compact/CompactUtils.ts";
+import { cleanupOrphanedNeurons } from "../compact/CompactUtils.ts";
 import type { Creature } from "../Creature.ts";
+import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
+import { Activations } from "../methods/activations/Activations.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
 
 export class SubConnection implements RadioactiveInterface {
@@ -18,21 +17,42 @@ export class SubConnection implements RadioactiveInterface {
    * @param {number[]} [focusList] - The list of focus indices.
    */
   public mutate(focusList?: number[]): boolean {
-    // List of possible connections that can be removed
-    const possible = [];
+    // Export the creature to JSON for clean manipulation
+    const exportJSON = this.creature.exportJSON();
 
-    for (let i = 0; i < this.creature.synapses.length; i++) {
-      const conn = this.creature.synapses[i];
-      // Check if it is not disabling a node (forward connections only)
-      if (conn.to > conn.from) {
-        if (
-          this.creature.inFocus(conn.to, focusList) ||
-          this.creature.inFocus(conn.from, focusList)
-        ) {
-          // Post-removal logic handles neurons left with 0 connections:
-          // - Hidden neurons with 0 inward connections become constants
-          // - Hidden neurons with 0 outward connections are removed
-          possible.push(conn);
+    // Build a map of neuron UUIDs to their export data for quick lookup
+    const neuronMap = new Map(
+      exportJSON.neurons.map((n) => [n.uuid, n]),
+    );
+
+    // List of possible connections that can be removed (forward connections only)
+    const possible: { fromUUID: string; toUUID: string }[] = [];
+
+    // Build neuron index map for focus checking
+    const neuronIndexMap = new Map<string, number>();
+    let idx = 0;
+    // Input neurons first (implicit, not in export)
+    for (let i = 0; i < this.creature.input; i++) {
+      neuronIndexMap.set(`input-${i}`, idx++);
+    }
+    // Then exported neurons
+    for (const neuron of exportJSON.neurons) {
+      neuronIndexMap.set(neuron.uuid, idx++);
+    }
+
+    for (const synapse of exportJSON.synapses) {
+      const fromIdx = neuronIndexMap.get(synapse.fromUUID);
+      const toIdx = neuronIndexMap.get(synapse.toUUID);
+
+      // Only consider forward connections (to > from)
+      if (fromIdx !== undefined && toIdx !== undefined && toIdx > fromIdx) {
+        // Check focus list
+        const inFocus = !focusList ||
+          focusList.includes(fromIdx) ||
+          focusList.includes(toIdx);
+
+        if (inFocus) {
+          possible.push({ fromUUID: synapse.fromUUID, toUUID: synapse.toUUID });
         }
       }
     }
@@ -41,38 +61,62 @@ export class SubConnection implements RadioactiveInterface {
       return false;
     }
 
+    // Select a random connection to remove
     const randomConn = possible[Math.floor(Math.random() * possible.length)];
-    this.creature.disconnect(randomConn.from, randomConn.to);
 
-    delete this.creature.memetic;
+    // Remove the selected synapse
+    exportJSON.synapses = exportJSON.synapses.filter(
+      (s) =>
+        s.fromUUID !== randomConn.fromUUID || s.toUUID !== randomConn.toUUID,
+    );
 
     // Check if the 'to' neuron has lost all inward connections
-    const inwardList = this.creature.inwardConnections(randomConn.to);
-    if (inwardList.length === 0) {
-      const neuron = this.creature.neurons[randomConn.to];
-      if (neuron.type === "hidden") {
-        // Check if this neuron also has no outward connections
-        const outwardList = this.creature.outwardConnections(randomConn.to);
-        if (outwardList.length === 0) {
-          // No inward or outward connections - remove entirely
-          removeHiddenNeuron(this.creature, randomConn.to);
-        } else {
-          // Has outward connections - convert to constant
-          const squash = neuron.findSquash();
-          const activation = squash as ActivationInterface;
-          if (activation.squash) {
-            const constantBias = activation.squash(neuron.bias);
-            neuron.bias = constantBias;
+    const toNeuron = neuronMap.get(randomConn.toUUID);
+    if (toNeuron && toNeuron.type === "hidden") {
+      const hasInward = exportJSON.synapses.some(
+        (s) => s.toUUID === randomConn.toUUID,
+      );
+
+      if (!hasInward) {
+        const hasOutward = exportJSON.synapses.some(
+          (s) => s.fromUUID === randomConn.toUUID,
+        );
+
+        if (hasOutward) {
+          // Has outward connections but no inward - convert to constant
+          // Calculate the constant bias using the squash function
+          let constantBias = toNeuron.bias;
+          if (toNeuron.squash) {
+            const squashFn = Activations.find(toNeuron.squash);
+            const activation = squashFn as ActivationInterface;
+            if (activation?.squash) {
+              constantBias = activation.squash(toNeuron.bias);
+            }
           }
-          neuron.type = "constant";
-          neuron.setSquash(undefined);
+
+          // Replace the hidden neuron with a constant neuron
+          const neuronIndex = exportJSON.neurons.findIndex(
+            (n) => n.uuid === randomConn.toUUID,
+          );
+          if (neuronIndex !== -1) {
+            exportJSON.neurons[neuronIndex] = {
+              type: "constant",
+              uuid: toNeuron.uuid,
+              bias: constantBias,
+            };
+          }
         }
+        // If no outward connections either, cleanupOrphanedNeurons will remove it
       }
     }
 
     // Clean up any neurons that have become orphaned (no outward connections)
     // This handles cascade removal when removing a synapse leaves neurons dangling
-    cleanupOrphanedNeuronsInCreature(this.creature);
+    cleanupOrphanedNeurons(exportJSON);
+
+    // Reload the creature from the modified export
+    delete (exportJSON as CreatureExport & { memetic?: unknown }).memetic;
+    this.creature.loadFrom(exportJSON, true);
 
     return true;
   }

--- a/src/mutate/SubConnection.ts
+++ b/src/mutate/SubConnection.ts
@@ -3,8 +3,6 @@ import {
   cleanupOrphanedNeurons,
 } from "../compact/CompactUtils.ts";
 import type { Creature } from "../Creature.ts";
-import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
-import { Activations } from "../methods/activations/Activations.ts";
 import { CreatureExportBuilder } from "../utils/CreatureExportBuilder.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
 
@@ -24,11 +22,6 @@ export class SubConnection implements RadioactiveInterface {
     // Use the builder directly to avoid validation (creature may be in an intermediate state)
     const builder = new CreatureExportBuilder(this.creature);
     const exportJSON = builder.build();
-
-    // Build a map of neuron UUIDs to their export data for quick lookup
-    const neuronMap = new Map(
-      exportJSON.neurons.map((n) => [n.uuid, n]),
-    );
 
     // List of possible connections that can be removed (forward connections only)
     const possible: { fromUUID: string; toUUID: string }[] = [];
@@ -82,48 +75,10 @@ export class SubConnection implements RadioactiveInterface {
       randomConn.toUUID,
     );
 
-    // Check if the 'to' neuron has lost all inward connections
-    const toNeuron = neuronMap.get(randomConn.toUUID);
-    if (toNeuron && toNeuron.type === "hidden") {
-      const hasInward = exportJSON.synapses.some(
-        (s) => s.toUUID === randomConn.toUUID,
-      );
-
-      if (!hasInward) {
-        const hasOutward = exportJSON.synapses.some(
-          (s) => s.fromUUID === randomConn.toUUID,
-        );
-
-        if (hasOutward) {
-          // Has outward connections but no inward - convert to constant
-          // Calculate the constant bias using the squash function
-          let constantBias = toNeuron.bias;
-          if (toNeuron.squash) {
-            const squashFn = Activations.find(toNeuron.squash);
-            const activation = squashFn as ActivationInterface;
-            if (activation?.squash) {
-              constantBias = activation.squash(toNeuron.bias);
-            }
-          }
-
-          // Replace the hidden neuron with a constant neuron
-          const neuronIndex = exportJSON.neurons.findIndex(
-            (n) => n.uuid === randomConn.toUUID,
-          );
-          if (neuronIndex !== -1) {
-            exportJSON.neurons[neuronIndex] = {
-              type: "constant",
-              uuid: toNeuron.uuid,
-              bias: constantBias,
-            };
-          }
-        }
-        // If no outward connections either, cleanupOrphanedNeurons will remove it
-      }
-    }
-
-    // Clean up any neurons that have become orphaned (no outward connections)
-    // This handles cascade removal when removing a synapse leaves neurons dangling
+    // Clean up any neurons that have become orphaned after synapse removal.
+    // This handles both:
+    // - Converting hidden neurons with no inward connections to constants
+    // - Removing hidden/constant neurons with no outward connections
     cleanupOrphanedNeurons(exportJSON);
 
     // Reload the creature from the modified export

--- a/src/mutate/SubConnection.ts
+++ b/src/mutate/SubConnection.ts
@@ -1,8 +1,11 @@
-import { cleanupOrphanedNeurons } from "../compact/CompactUtils.ts";
+import {
+  cleanupMemeticForRemovedSynapse,
+  cleanupOrphanedNeurons,
+} from "../compact/CompactUtils.ts";
 import type { Creature } from "../Creature.ts";
-import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import { Activations } from "../methods/activations/Activations.ts";
+import { CreatureExportBuilder } from "../utils/CreatureExportBuilder.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
 
 export class SubConnection implements RadioactiveInterface {
@@ -18,7 +21,9 @@ export class SubConnection implements RadioactiveInterface {
    */
   public mutate(focusList?: number[]): boolean {
     // Export the creature to JSON for clean manipulation
-    const exportJSON = this.creature.exportJSON();
+    // Use the builder directly to avoid validation (creature may be in an intermediate state)
+    const builder = new CreatureExportBuilder(this.creature);
+    const exportJSON = builder.build();
 
     // Build a map of neuron UUIDs to their export data for quick lookup
     const neuronMap = new Map(
@@ -70,6 +75,13 @@ export class SubConnection implements RadioactiveInterface {
         s.fromUUID !== randomConn.fromUUID || s.toUUID !== randomConn.toUUID,
     );
 
+    // Clean up memetic data for the removed synapse
+    cleanupMemeticForRemovedSynapse(
+      exportJSON,
+      randomConn.fromUUID,
+      randomConn.toUUID,
+    );
+
     // Check if the 'to' neuron has lost all inward connections
     const toNeuron = neuronMap.get(randomConn.toUUID);
     if (toNeuron && toNeuron.type === "hidden") {
@@ -115,8 +127,9 @@ export class SubConnection implements RadioactiveInterface {
     cleanupOrphanedNeurons(exportJSON);
 
     // Reload the creature from the modified export
-    delete (exportJSON as CreatureExport & { memetic?: unknown }).memetic;
-    this.creature.loadFrom(exportJSON, true);
+    // Note: We pass false for validation to match the old in-place mutation behavior.
+    // Validation is handled elsewhere (e.g., by the caller or by fix() if needed).
+    this.creature.loadFrom(exportJSON, false);
 
     return true;
   }

--- a/src/mutate/SubNeuron.ts
+++ b/src/mutate/SubNeuron.ts
@@ -1,53 +1,87 @@
 import type { Creature } from "../Creature.ts";
+import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
-import {
-  cleanupOrphanedNeuronsInCreature,
-  removeHiddenNeuron,
-} from "../compact/CompactUtils.ts";
+import { cleanupOrphanedNeurons } from "../compact/CompactUtils.ts";
 
 export class SubNeuron implements RadioactiveInterface {
   private creature: Creature;
   constructor(creature: Creature) {
     this.creature = creature;
   }
+
   /**
    * Subtract a neuron from the network.
    *
    * @param {number[]} [focusList] - The list of focus indices.
    */
   mutate(focusList?: number[]): boolean {
+    // Export the creature to JSON for clean manipulation
+    const exportJSON = this.creature.exportJSON();
+
+    // Filter to only hidden and constant neurons (removable)
+    const removableNeurons = exportJSON.neurons.filter(
+      (n) => n.type === "hidden" || n.type === "constant",
+    );
+
     // Check if there are neurons left to remove
-    if (
-      this.creature.neurons.length ===
-        this.creature.input + this.creature.output
-    ) {
+    if (removableNeurons.length === 0) {
       return false;
     }
 
-    let changed = false;
+    // Build neuron index map for focus checking
+    const neuronIndexMap = new Map<string, number>();
+    let idx = 0;
+    // Input neurons first (implicit, not in export)
+    for (let i = 0; i < this.creature.input; i++) {
+      neuronIndexMap.set(`input-${i}`, idx++);
+    }
+    // Then exported neurons
+    for (const neuron of exportJSON.neurons) {
+      neuronIndexMap.set(neuron.uuid, idx++);
+    }
+
+    let selectedNeuronUUID: string | undefined;
+
     for (let attempts = 0; attempts < 24; attempts++) {
-      // Select a neuron which isn't an input or output neuron
-      const indx = Math.floor(
-        Math.random() *
-            (this.creature.neurons.length - this.creature.output -
-              this.creature.input) +
-          this.creature.input,
-      );
+      // Select a random removable neuron
+      const randomNeuron =
+        removableNeurons[Math.floor(Math.random() * removableNeurons.length)];
+      const neuronIdx = neuronIndexMap.get(randomNeuron.uuid);
 
-      if (attempts < 12 && !this.creature.inFocus(indx, focusList)) continue;
+      // Check focus list (relax after 12 attempts)
+      if (attempts < 12 && focusList && neuronIdx !== undefined) {
+        if (!focusList.includes(neuronIdx)) {
+          continue;
+        }
+      }
 
-      removeHiddenNeuron(this.creature, indx);
-
-      // Clean up any neurons that have become orphaned (no outward connections)
-      // This handles cascade removal when removing a neuron leaves others dangling
-      cleanupOrphanedNeuronsInCreature(this.creature);
-
-      changed = true;
+      selectedNeuronUUID = randomNeuron.uuid;
       break;
     }
 
-    delete this.creature.memetic;
+    if (!selectedNeuronUUID) {
+      return false;
+    }
 
-    return changed;
+    // Remove all synapses to/from this neuron
+    exportJSON.synapses = exportJSON.synapses.filter(
+      (s) =>
+        s.fromUUID !== selectedNeuronUUID && s.toUUID !== selectedNeuronUUID,
+    );
+
+    // Remove the neuron itself
+    exportJSON.neurons = exportJSON.neurons.filter(
+      (n) => n.uuid !== selectedNeuronUUID,
+    );
+
+    // Clean up any neurons that have become orphaned (no outward connections)
+    // This handles cascade removal when removing a neuron leaves others dangling
+    cleanupOrphanedNeurons(exportJSON);
+
+    // Reload the creature from the modified export
+    delete (exportJSON as CreatureExport & { memetic?: unknown }).memetic;
+    this.creature.loadFrom(exportJSON, true);
+
+    return true;
   }
 }

--- a/src/mutate/SubNeuron.ts
+++ b/src/mutate/SubNeuron.ts
@@ -1,7 +1,10 @@
 import type { Creature } from "../Creature.ts";
-import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
-import { cleanupOrphanedNeurons } from "../compact/CompactUtils.ts";
+import {
+  cleanupMemeticForRemovedNeuron,
+  cleanupOrphanedNeurons,
+} from "../compact/CompactUtils.ts";
+import { CreatureExportBuilder } from "../utils/CreatureExportBuilder.ts";
 
 export class SubNeuron implements RadioactiveInterface {
   private creature: Creature;
@@ -16,7 +19,9 @@ export class SubNeuron implements RadioactiveInterface {
    */
   mutate(focusList?: number[]): boolean {
     // Export the creature to JSON for clean manipulation
-    const exportJSON = this.creature.exportJSON();
+    // Use the builder directly to avoid validation (creature may be in an intermediate state)
+    const builder = new CreatureExportBuilder(this.creature);
+    const exportJSON = builder.build();
 
     // Filter to only hidden and constant neurons (removable)
     const removableNeurons = exportJSON.neurons.filter(
@@ -74,13 +79,17 @@ export class SubNeuron implements RadioactiveInterface {
       (n) => n.uuid !== selectedNeuronUUID,
     );
 
+    // Clean up memetic data for the removed neuron
+    cleanupMemeticForRemovedNeuron(exportJSON, selectedNeuronUUID);
+
     // Clean up any neurons that have become orphaned (no outward connections)
     // This handles cascade removal when removing a neuron leaves others dangling
     cleanupOrphanedNeurons(exportJSON);
 
     // Reload the creature from the modified export
-    delete (exportJSON as CreatureExport & { memetic?: unknown }).memetic;
-    this.creature.loadFrom(exportJSON, true);
+    // Note: We pass false for validation to match the old in-place mutation behavior.
+    // Validation is handled elsewhere (e.g., by the caller or by fix() if needed).
+    this.creature.loadFrom(exportJSON, false);
 
     return true;
   }

--- a/src/mutate/SubNeuron.ts
+++ b/src/mutate/SubNeuron.ts
@@ -1,6 +1,9 @@
 import type { Creature } from "../Creature.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
-import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
+import {
+  cleanupOrphanedNeuronsInCreature,
+  removeHiddenNeuron,
+} from "../compact/CompactUtils.ts";
 
 export class SubNeuron implements RadioactiveInterface {
   private creature: Creature;
@@ -33,46 +36,11 @@ export class SubNeuron implements RadioactiveInterface {
 
       if (attempts < 12 && !this.creature.inFocus(indx, focusList)) continue;
 
-      // Collect neurons that might need cleanup after removing this one
-      const incomingConnections = this.creature.inwardConnections(indx);
-      const neuronsToCheck: number[] = [];
-
-      for (const conn of incomingConnections) {
-        const sourceNeuron = this.creature.neurons[conn.from];
-        // If the source is a hidden neuron and this is its only outward connection
-        if (
-          sourceNeuron.type === "hidden" &&
-          this.creature.outwardConnections(conn.from).length === 1
-        ) {
-          neuronsToCheck.push(conn.from);
-        }
-      }
-
       removeHiddenNeuron(this.creature, indx);
 
-      // Cleanup: Remove source neurons that are now left with 0 outward connections
-      // Sort in reverse order so removal doesn't affect indices
-      neuronsToCheck.sort((a, b) => b - a);
-      for (const sourceIndx of neuronsToCheck) {
-        // Adjust index if neurons before it were removed
-        let adjustedIndx = sourceIndx;
-        if (sourceIndx > indx) {
-          adjustedIndx--;
-        }
-
-        if (this.creature.outwardConnections(adjustedIndx).length === 0) {
-          const sourceNeuron = this.creature.neurons[adjustedIndx];
-          if (
-            sourceNeuron &&
-            (sourceNeuron.type === "hidden" || sourceNeuron.type === "constant")
-          ) {
-            console.info(
-              `Remove neuron ${sourceNeuron.uuid} as no longer connected`,
-            );
-            removeHiddenNeuron(this.creature, adjustedIndx);
-          }
-        }
-      }
+      // Clean up any neurons that have become orphaned (no outward connections)
+      // This handles cascade removal when removing a neuron leaves others dangling
+      cleanupOrphanedNeuronsInCreature(this.creature);
 
       changed = true;
       break;

--- a/test/Compact/CleanupOrphanedNeurons.ts
+++ b/test/Compact/CleanupOrphanedNeurons.ts
@@ -1,9 +1,10 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
 import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
 import { cleanupOrphanedNeurons } from "../../src/compact/CompactUtils.ts";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { LOGISTIC } from "../../src/methods/activations/types/LOGISTIC.ts";
+import { TANH } from "../../src/methods/activations/types/TANH.ts";
 
 ((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
 
@@ -366,9 +367,138 @@ Deno.test("cleanupOrphanedNeurons - returns correct count of removed neurons", (
   };
 
   // Run cleanup and check return value
-  const removedCount = cleanupOrphanedNeurons(creatureExport);
+  const result = cleanupOrphanedNeurons(creatureExport);
 
   // Should have removed 2 neurons (orphan-2 first, then orphan-1)
-  assertEquals(removedCount, 2);
+  assertEquals(result.removed, 2);
+  assertEquals(result.converted, 0);
   assertEquals(creatureExport.neurons.length, 1);
+});
+
+Deno.test("cleanupOrphanedNeurons - should apply squash function when converting hidden to constant", () => {
+  // A hidden neuron with bias X and squash function (e.g., LOGISTIC) would output
+  // squash(0 + X) when receiving no input. When converted to a constant, the bias
+  // must be transformed through the squash function.
+  //
+  // This test verifies the fix for the bug where cleanupOrphanedNeurons was copying
+  // the raw bias value directly instead of applying the activation function.
+
+  const rawBias = 0.5;
+  const logistic = new LOGISTIC();
+  const expectedSquashedBias = logistic.squash(rawBias); // Should be ~0.6224593312
+
+  const creatureExport: CreatureExport = {
+    neurons: [
+      {
+        type: "hidden",
+        squash: LOGISTIC.NAME,
+        bias: rawBias,
+        uuid: "hidden-no-inward",
+      },
+      {
+        type: "output",
+        squash: LOGISTIC.NAME,
+        bias: 0.1,
+        uuid: "output-0",
+      },
+    ],
+    synapses: [
+      // Hidden -> output (hidden has outward but NO inward connections)
+      {
+        fromUUID: "hidden-no-inward",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+      // Input to output (to keep structure valid)
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  // Run cleanup - should convert hidden to constant with squashed bias
+  cleanupOrphanedNeurons(creatureExport);
+
+  // The hidden neuron should have been converted to a constant
+  const convertedNeuron = creatureExport.neurons.find(
+    (n) => n.uuid === "hidden-no-inward",
+  );
+  assertEquals(
+    convertedNeuron?.type,
+    "constant",
+    "Hidden neuron should be converted to constant",
+  );
+
+  // The bias should be the SQUASHED value, not the raw bias
+  assertAlmostEquals(
+    convertedNeuron?.bias ?? 0,
+    expectedSquashedBias,
+    0.0001,
+    `Constant bias should be squashed (expected ${expectedSquashedBias}, got ${convertedNeuron?.bias})`,
+  );
+
+  // Verify the creature is valid after cleanup
+  const creature = Creature.fromJSON(creatureExport);
+  creatureValidate(creature);
+});
+
+Deno.test("cleanupOrphanedNeurons - should apply TANH squash function when converting hidden to constant", () => {
+  // Test with a different activation function (TANH) to ensure the fix
+  // works generically for all squash functions.
+
+  const rawBias = 1.5;
+  const tanh = new TANH();
+  const expectedSquashedBias = tanh.squash(rawBias); // Should be ~0.9051482536
+
+  const creatureExport: CreatureExport = {
+    neurons: [
+      {
+        type: "hidden",
+        squash: TANH.NAME,
+        bias: rawBias,
+        uuid: "hidden-tanh",
+      },
+      {
+        type: "output",
+        squash: LOGISTIC.NAME,
+        bias: 0.1,
+        uuid: "output-0",
+      },
+    ],
+    synapses: [
+      // Hidden -> output (hidden has outward but NO inward connections)
+      {
+        fromUUID: "hidden-tanh",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+      // Input to output
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  // Run cleanup
+  cleanupOrphanedNeurons(creatureExport);
+
+  // Verify the constant neuron has the TANH-squashed bias
+  const convertedNeuron = creatureExport.neurons.find(
+    (n) => n.uuid === "hidden-tanh",
+  );
+  assertEquals(convertedNeuron?.type, "constant");
+  assertAlmostEquals(
+    convertedNeuron?.bias ?? 0,
+    expectedSquashedBias,
+    0.0001,
+    `Constant bias should be TANH-squashed (expected ${expectedSquashedBias}, got ${convertedNeuron?.bias})`,
+  );
 });

--- a/test/Compact/CleanupOrphanedNeurons.ts
+++ b/test/Compact/CleanupOrphanedNeurons.ts
@@ -487,8 +487,10 @@ Deno.test("cleanupOrphanedNeurons - should apply TANH squash function when conve
     output: 1,
   };
 
-  // Run cleanup
-  cleanupOrphanedNeurons(creatureExport);
+  // Run cleanup and verify the result counts
+  const result = cleanupOrphanedNeurons(creatureExport);
+  assertEquals(result.converted, 1, "Should have converted 1 neuron");
+  assertEquals(result.removed, 0, "Should have removed 0 neurons");
 
   // Verify the constant neuron has the TANH-squashed bias
   const convertedNeuron = creatureExport.neurons.find(

--- a/test/Compact/CleanupOrphanedNeurons.ts
+++ b/test/Compact/CleanupOrphanedNeurons.ts
@@ -1,0 +1,374 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
+import { cleanupOrphanedNeurons } from "../../src/compact/CompactUtils.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { LOGISTIC } from "../../src/methods/activations/types/LOGISTIC.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+Deno.test("cleanupOrphanedNeurons - should remove hidden neuron with no outward connections", () => {
+  // Create a creature export with a hidden neuron that has no outward connections
+  const creatureExport: CreatureExport = {
+    neurons: [
+      {
+        type: "hidden",
+        squash: LOGISTIC.NAME,
+        bias: 0.5,
+        uuid: "orphan-hidden-1",
+      },
+      {
+        type: "hidden",
+        squash: LOGISTIC.NAME,
+        bias: 0.3,
+        uuid: "valid-hidden-2",
+      },
+      {
+        type: "output",
+        squash: LOGISTIC.NAME,
+        bias: 0.1,
+        uuid: "output-0",
+      },
+    ],
+    synapses: [
+      // Input to orphan hidden (has inward but no outward)
+      {
+        fromUUID: "input-0",
+        toUUID: "orphan-hidden-1",
+        weight: 1.0,
+      },
+      // Input to valid hidden
+      {
+        fromUUID: "input-0",
+        toUUID: "valid-hidden-2",
+        weight: 1.0,
+      },
+      // Valid hidden to output
+      {
+        fromUUID: "valid-hidden-2",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  // Before cleanup, trying to create a creature should fail validation
+  // because orphan-hidden-1 has no outward connections
+  assertThrows(
+    () => {
+      const creature = Creature.fromJSON(creatureExport);
+      creatureValidate(creature);
+    },
+    Error,
+    "no outward connections",
+  );
+
+  // Run cleanup
+  cleanupOrphanedNeurons(creatureExport);
+
+  // After cleanup, the creature should be valid
+  const creature = Creature.fromJSON(creatureExport);
+  creatureValidate(creature);
+
+  // The orphaned neuron should have been removed
+  assertEquals(creatureExport.neurons.length, 2);
+  assertEquals(
+    creatureExport.neurons.find((n) => n.uuid === "orphan-hidden-1"),
+    undefined,
+    "Orphaned neuron should be removed",
+  );
+
+  // The synapse to the orphaned neuron should also be removed
+  assertEquals(creatureExport.synapses.length, 2);
+  assertEquals(
+    creatureExport.synapses.find((s) => s.toUUID === "orphan-hidden-1"),
+    undefined,
+    "Synapse to orphaned neuron should be removed",
+  );
+});
+
+Deno.test("cleanupOrphanedNeurons - should handle cascade removal of orphaned neurons", () => {
+  // Create a creature export where removing one neuron creates another orphan
+  // A -> B -> C -> output
+  // If we remove C, then B becomes orphaned, then A becomes orphaned
+  const creatureExport: CreatureExport = {
+    neurons: [
+      {
+        type: "hidden",
+        squash: LOGISTIC.NAME,
+        bias: 0.5,
+        uuid: "hidden-A",
+      },
+      {
+        type: "hidden",
+        squash: LOGISTIC.NAME,
+        bias: 0.3,
+        uuid: "hidden-B",
+      },
+      {
+        type: "output",
+        squash: LOGISTIC.NAME,
+        bias: 0.1,
+        uuid: "output-0",
+      },
+    ],
+    synapses: [
+      // Input to hidden A
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-A",
+        weight: 1.0,
+      },
+      // A -> B (only outward connection from A)
+      {
+        fromUUID: "hidden-A",
+        toUUID: "hidden-B",
+        weight: 1.0,
+      },
+      // Input directly to output (to keep output valid)
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  // Hidden-B has no outward connections - this is the initial orphan
+  // When B is removed, hidden-A will also become an orphan
+
+  // Run cleanup - should remove both A and B
+  cleanupOrphanedNeurons(creatureExport);
+
+  // After cleanup, only output neuron should remain
+  assertEquals(creatureExport.neurons.length, 1);
+  assertEquals(creatureExport.neurons[0].uuid, "output-0");
+
+  // Only the direct input -> output synapse should remain
+  assertEquals(creatureExport.synapses.length, 1);
+  assertEquals(creatureExport.synapses[0].toUUID, "output-0");
+
+  // Create creature to verify it's valid
+  const creature = Creature.fromJSON(creatureExport);
+  creatureValidate(creature);
+});
+
+Deno.test("cleanupOrphanedNeurons - should remove constant neurons with no outward connections", () => {
+  // Constant neurons with no outward connections should also be removed
+  // (they serve no purpose if not connected to anything)
+  const creatureExport: CreatureExport = {
+    neurons: [
+      {
+        type: "constant",
+        bias: 1.0,
+        uuid: "orphan-constant",
+      },
+      {
+        type: "output",
+        squash: LOGISTIC.NAME,
+        bias: 0.1,
+        uuid: "output-0",
+      },
+    ],
+    synapses: [
+      // Input directly to output
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  // Run cleanup
+  cleanupOrphanedNeurons(creatureExport);
+
+  // The orphaned constant should have been removed
+  assertEquals(creatureExport.neurons.length, 1);
+  assertEquals(creatureExport.neurons[0].uuid, "output-0");
+});
+
+Deno.test("cleanupOrphanedNeurons - should not remove output neurons even if no outward connections", () => {
+  // Output neurons never have outward connections by design, so they should not be removed
+  const creatureExport: CreatureExport = {
+    neurons: [
+      {
+        type: "output",
+        squash: LOGISTIC.NAME,
+        bias: 0.1,
+        uuid: "output-0",
+      },
+    ],
+    synapses: [
+      // Input directly to output
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  const neuronCountBefore = creatureExport.neurons.length;
+
+  // Run cleanup
+  cleanupOrphanedNeurons(creatureExport);
+
+  // Output neuron should still be there
+  assertEquals(creatureExport.neurons.length, neuronCountBefore);
+  assertEquals(creatureExport.neurons[0].uuid, "output-0");
+});
+
+Deno.test("cleanupOrphanedNeurons - simulates remove-low-impact scenario from issue", () => {
+  // This test simulates the exact scenario from the issue:
+  // A low-impact neuron is removed, but its removal leaves another hidden neuron
+  // with no outward connections (previously only connected to the removed neuron)
+
+  const creatureExport: CreatureExport = {
+    neurons: [
+      {
+        type: "hidden",
+        squash: LOGISTIC.NAME,
+        bias: 0.5,
+        uuid: "feeder-hidden",
+      },
+      {
+        type: "hidden",
+        squash: LOGISTIC.NAME,
+        bias: 0.3,
+        uuid: "low-impact-target",
+      },
+      {
+        type: "output",
+        squash: LOGISTIC.NAME,
+        bias: 0.1,
+        uuid: "output-0",
+      },
+    ],
+    synapses: [
+      // Input to feeder hidden
+      {
+        fromUUID: "input-0",
+        toUUID: "feeder-hidden",
+        weight: 1.0,
+      },
+      // Feeder hidden -> low-impact target (feeder's ONLY outward connection)
+      {
+        fromUUID: "feeder-hidden",
+        toUUID: "low-impact-target",
+        weight: 0.001, // Low weight = low impact
+      },
+      // Low-impact target to output
+      {
+        fromUUID: "low-impact-target",
+        toUUID: "output-0",
+        weight: 0.001, // Low weight = low impact
+      },
+      // Direct connection to output (keeps output valid)
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  // Verify initial creature is valid
+  const initialCreature = Creature.fromJSON(creatureExport);
+  creatureValidate(initialCreature);
+
+  // Simulate remove-low-impact: remove the low-impact-target neuron
+  creatureExport.neurons = creatureExport.neurons.filter(
+    (n) => n.uuid !== "low-impact-target",
+  );
+  creatureExport.synapses = creatureExport.synapses.filter(
+    (s) =>
+      s.toUUID !== "low-impact-target" && s.fromUUID !== "low-impact-target",
+  );
+
+  // Without cleanup, this would be invalid because feeder-hidden
+  // now has no outward connections
+  assertThrows(
+    () => {
+      const creature = Creature.fromJSON(creatureExport);
+      creatureValidate(creature);
+    },
+    Error,
+    "no outward connections",
+  );
+
+  // Run cleanup to fix the orphaned neurons
+  cleanupOrphanedNeurons(creatureExport);
+
+  // Now the creature should be valid
+  const creature = Creature.fromJSON(creatureExport);
+  creatureValidate(creature);
+
+  // Only output neuron should remain (feeder-hidden should be cleaned up too)
+  assertEquals(creatureExport.neurons.length, 1);
+  assertEquals(creatureExport.neurons[0].uuid, "output-0");
+});
+
+Deno.test("cleanupOrphanedNeurons - returns correct count of removed neurons", () => {
+  const creatureExport: CreatureExport = {
+    neurons: [
+      {
+        type: "hidden",
+        squash: LOGISTIC.NAME,
+        bias: 0.5,
+        uuid: "orphan-1",
+      },
+      {
+        type: "hidden",
+        squash: LOGISTIC.NAME,
+        bias: 0.3,
+        uuid: "orphan-2",
+      },
+      {
+        type: "output",
+        squash: LOGISTIC.NAME,
+        bias: 0.1,
+        uuid: "output-0",
+      },
+    ],
+    synapses: [
+      // Input to orphan 1 (no outward)
+      {
+        fromUUID: "input-0",
+        toUUID: "orphan-1",
+        weight: 1.0,
+      },
+      // Orphan 1 -> orphan 2 (orphan 2 has no outward)
+      {
+        fromUUID: "orphan-1",
+        toUUID: "orphan-2",
+        weight: 1.0,
+      },
+      // Direct connection to output
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1.0,
+      },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  // Run cleanup and check return value
+  const removedCount = cleanupOrphanedNeurons(creatureExport);
+
+  // Should have removed 2 neurons (orphan-2 first, then orphan-1)
+  assertEquals(removedCount, 2);
+  assertEquals(creatureExport.neurons.length, 1);
+});


### PR DESCRIPTION
…ionality

- Bumped version in deno.json to 0.251.0.
- Introduced cleanupOrphanedNeurons and cleanupOrphanedNeuronsInCreature functions to remove hidden or constant neurons with no outward connections, preventing validation failures.
- Updated DiscoverStructure, SubConnection, and SubNeuron classes to utilize the new cleanup functions, ensuring proper handling of orphaned neurons during synapse and neuron removals.

These changes enhance the robustness of the neural network framework by ensuring that orphaned neurons are effectively managed, improving overall stability and validation processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce orphaned-neuron and memetic cleanup utilities and apply them in discovery/mutation flows; add targeted tests; bump version to 0.251.0.
> 
> - **Core utilities**:
>   - Add `cleanupOrphanedNeurons`, `cleanupOrphanedNeuronsInCreature`, `cleanupMemeticForRemovedSynapse`, `cleanupMemeticForRemovedNeuron` in `src/compact/CompactUtils.ts` to convert hidden-without-inward to constants, remove hidden/constant without outward, and purge memetic refs.
> - **Discovery**:
>   - Replace manual cascade logic with `cleanupOrphanedNeurons` in `DiscoverStructure.removeSynapse`, `removeHarmfulNeuron`, and `removeLowImpactNeuron` to prevent dangling neurons.
> - **Mutation**:
>   - Refactor `SubConnection` and `SubNeuron` to operate on exported JSON via `CreatureExportBuilder`, remove selected synapses/neurons by UUID, clean memetic, run `cleanupOrphanedNeurons`, then reload creature.
> - **Tests**:
>   - Add `test/Compact/CleanupOrphanedNeurons.ts` covering removal, cascade cleanup, constant/output handling, return counts, and correct bias squashing on conversion (e.g., `LOGISTIC`, `TANH`).
> - **Version**:
>   - Bump `deno.json` version to `0.251.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c332cb4093fd2a473efada8a53ae91d9c740a5de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->