### PR TITLE
Update version to 0.252.0 and enhance memetic data cleanup functionality

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.251.1",
+  "version": "0.252.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1,7 +1,10 @@
 import { assert } from "@std/assert";
 import { addTag, removeTag, type TagsInterface } from "@stsoftware/tags/mod";
 import { CreatureUtil } from "../../../mod.ts";
-import { cleanupOrphanedNeurons } from "../../compact/CompactUtils.ts";
+import {
+  cleanupMemeticForRemovedNeuron,
+  cleanupOrphanedNeurons,
+} from "../../compact/CompactUtils.ts";
 import { Creature } from "../../Creature.ts";
 import type { Approach } from "../../NEAT/LogApproach.ts";
 import { memeticUpdate } from "../../blackbox/MemeticUpdate.ts";
@@ -4692,6 +4695,13 @@ export class DiscoverStructure {
     // Remove the neuron itself
     simplifiedExport.neurons = simplifiedExport.neurons.filter(
       (neuron) => neuron.uuid !== removalCandidate.neuronUUID,
+    );
+
+    // Clean up memetic data for the removed neuron (fixes issue #912)
+    // This must be called before validation to prevent MEMETIC errors
+    cleanupMemeticForRemovedNeuron(
+      simplifiedExport,
+      removalCandidate.neuronUUID,
     );
 
     // Clean up any neurons that have become orphaned (no outward connections)

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -40,6 +40,10 @@ import {
   DiscoverStructure,
 } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { DiscoverResult } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import {
+  cleanupMemeticForRemovedNeuron,
+  cleanupMemeticForRemovedSynapse,
+} from "../compact/CompactUtils.ts";
 import { Creature } from "../Creature.ts";
 import { ValidationError } from "../errors/ValidationError.ts";
 
@@ -306,6 +310,13 @@ export function buildDiscoveryCandidates(
           );
 
           if (exportJSON.synapses.length < originalCount) {
+            // Clean up memetic data for the removed synapse
+            cleanupMemeticForRemovedSynapse(
+              exportJSON,
+              removalUUID.from,
+              removalUUID.to,
+            );
+
             const updated = Creature.fromJSON(exportJSON);
             // We modified the structure by filtering synapses, so we must delete UUID
             delete updated.uuid;
@@ -669,6 +680,13 @@ export function buildDiscoveryCandidates(
           );
 
           if (exportJSON.synapses.length < originalCount) {
+            // Clean up memetic data for the removed synapse
+            cleanupMemeticForRemovedSynapse(
+              exportJSON,
+              removalUUID.from,
+              removalUUID.to,
+            );
+
             const updated = Creature.fromJSON(exportJSON);
             // We modified the structure by filtering synapses, so we must delete UUID
             delete updated.uuid;
@@ -1065,6 +1083,13 @@ function buildCombinedCandidate(
 
       if (exportJSON.synapses.length < originalCount) {
         removed = true;
+        // Clean up memetic data for the removed synapse
+        cleanupMemeticForRemovedSynapse(
+          exportJSON,
+          removalUUID.from,
+          removalUUID.to,
+        );
+
         const updated = Creature.fromJSON(exportJSON);
         // We modified the structure by filtering synapses, so we must delete UUID
         delete updated.uuid;
@@ -1576,6 +1601,13 @@ function applyChangeToCreature(
         creatureJSON.synapses = creatureJSON.synapses.filter(
           (s) => !toRemove.has(`${s.fromUUID}->${s.toUUID}`),
         );
+
+        // Clean up memetic data for removed synapses
+        for (const synapseKey of toRemove) {
+          const [fromUUID, toUUID] = synapseKey.split("->");
+          cleanupMemeticForRemovedSynapse(creatureJSON, fromUUID, toUUID);
+        }
+
         creatureJSON.synapses.push(...toAdd);
 
         const result = Creature.fromJSON(creatureJSON);
@@ -1617,6 +1649,11 @@ function applyChangeToCreature(
         creatureJSON.synapses = creatureJSON.synapses.filter(
           (s) => !toRemove.has(s.fromUUID) && !toRemove.has(s.toUUID),
         );
+
+        // Clean up memetic data for removed neurons
+        for (const neuronUUID of toRemove) {
+          cleanupMemeticForRemovedNeuron(creatureJSON, neuronUUID);
+        }
 
         // Build set of remaining neuron UUIDs for synapse validation
         // Include input neurons (not in neurons array but referenced as input-N)

--- a/test/discovery/RemovalCandidates.ts
+++ b/test/discovery/RemovalCandidates.ts
@@ -373,3 +373,79 @@ Deno.test("buildDiscoveryCandidates uses crippled-removal.json for near-zero wei
     "Description should mention impact",
   );
 });
+
+/**
+ * Test for issue #912: removeLowImpactNeuron should clean up memetic data
+ * when removing a neuron that is referenced in the memetic weights/biases.
+ *
+ * Without the fix, this test would fail with:
+ * "Memetic from UUID {uuid} has no valid neuron."
+ */
+Deno.test("removeLowImpactNeuron cleans up memetic data for removed neuron", () => {
+  // Create a creature with memetic data that references the neuron we'll remove
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden",
+        squash: "RELU",
+        bias: 0.5,
+        uuid: "hidden-with-memetic",
+      },
+      { type: "output", squash: "IDENTITY", bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-with-memetic", weight: 0.1 },
+      { fromUUID: "hidden-with-memetic", toUUID: "output-0", weight: 0.2 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+    ],
+    memetic: {
+      generation: 1,
+      score: 0.5,
+      biases: {
+        "hidden-with-memetic": 0.5,
+        "output-0": 0.1,
+      },
+      weights: {
+        "input-0": [
+          { toUUID: "hidden-with-memetic", weight: 0.15 },
+        ],
+        "hidden-with-memetic": [
+          { toUUID: "output-0", weight: 0.25 },
+        ],
+        "input-1": [
+          { toUUID: "output-0", weight: 0.95 },
+        ],
+      },
+    },
+  });
+
+  const candidate: RemovalCandidate = {
+    neuronUUID: "hidden-with-memetic",
+    totalError: 5.0,
+    impact: 0.001, // Very low impact (0.1%)
+    reason: "High error but very low impact - far from outputs",
+  };
+
+  // This should NOT throw a MEMETIC validation error
+  const result = DiscoverStructure.removeLowImpactNeuron(
+    "test-memetic-cleanup",
+    creature,
+    candidate,
+  );
+
+  assertExists(result, "Should return a modified creature");
+
+  // Verify the neuron was removed
+  const hiddenNeurons = result.neurons.filter((n) => n.type === "hidden");
+  assertEquals(hiddenNeurons.length, 0, "Hidden neuron should be removed");
+
+  // Memetic data should be cleaned up (either deleted entirely or have references removed)
+  // The cleanupMemeticForRemovedNeuron function deletes the entire memetic object
+  assertEquals(
+    result.memetic,
+    undefined,
+    "Memetic data should be deleted when referencing neuron is removed",
+  );
+});


### PR DESCRIPTION
- Bumped version in deno.json to 0.252.0.
- Added cleanup functions for memetic data when neurons and synapses are removed, addressing issue #912.
- Updated DiscoverStructure and DiscoveryCandidates to utilize the new cleanup functions, ensuring that memetic references are properly managed during removals.
- Introduced tests to verify that memetic data is cleaned up correctly when low-impact neurons are removed, enhancing the robustness of the neural network framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure memetic data is cleaned when removing neurons/synapses to prevent validation errors (issue #912), with tests added and version bumped to 0.252.0.
> 
> - **Discovery core (`src/architecture/.../DiscoverStructure.ts`)**:
>   - Call `cleanupMemeticForRemovedNeuron` during `removeLowImpactNeuron` before validation.
>   - Keep `cleanupOrphanedNeurons` after structural removals.
> - **Candidate application (`src/discovery/DiscoveryCandidates.ts`)**:
>   - Clean memetic data via `cleanupMemeticForRemovedSynapse` whenever synapses are removed (single, combined, and apply-change paths).
>   - Clean memetic data via `cleanupMemeticForRemovedNeuron` when neurons are removed (single and apply-change paths).
> - **Tests**:
>   - Add test ensuring memetic cleanup on low‑impact neuron removal to avoid MEMETIC validation errors.
> - **Version**:
>   - Bump `deno.json` version to `0.252.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8b283da448acf0dc01ad5cd96ac810f94955a08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->