### PR TITLE
Update version to 0.253.0 and enhance debugging capabilities in disco…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.252.0",
+  "version": "0.253.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -95,6 +95,10 @@ interface DiscoveryCandidateChange {
   neuronDetails?: DiscoveredNeuronDetails;
   /** Details of synapse removal (for synapse removal candidates). */
   synapseDetails?: SynapseRemovalDetails;
+  /** Original Rust synapse candidate response (for add-synapses candidates). */
+  synapseCandidate?: CandidateSynapse;
+  /** Original Rust squash candidate response (for change-squash candidates). */
+  squashCandidate?: CandidateSquash;
 }
 
 export interface DiscoveryCandidate {
@@ -752,6 +756,7 @@ function buildSingleSynapseCandidates(
         } -> ${shortID(synapse.toNeuronUUID)}`,
         expectedErrorReduction: getExpected?.(synapse),
         sampleSize: synapse.totalCount,
+        synapseCandidate: synapse, // Store original Rust response for debugging
       },
     });
   }
@@ -866,6 +871,7 @@ function buildSingleSquashCandidates(
           shortID(squash.neuronUUID)
         } (${oldSquash} -> ${squash.squash}${improvement})`,
         expectedErrorReduction: scaledExpected,
+        squashCandidate: squash, // Store original Rust response for debugging
       },
     });
   }

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -748,11 +748,27 @@ export async function recordFailure(
       ...(discoveryVersion ? { discoveryVersion } : {}),
     };
 
-    // Include neuronDetails if available (for add-neurons candidates)
-    // This is what Rust requested
+    // Include the original Rust candidate response for debugging
+    // This allows comparison between what Rust suggested and what happened
     if (candidate.change.neuronDetails) {
       cacheEntry.rustRequest = {
         neuronDetails: candidate.change.neuronDetails,
+      };
+    }
+
+    // Include original Rust synapse candidate (for add-synapses candidates)
+    if (candidate.change.synapseCandidate) {
+      cacheEntry.rustRequest = {
+        ...((cacheEntry.rustRequest as Record<string, unknown>) ?? {}),
+        synapseCandidate: candidate.change.synapseCandidate,
+      };
+    }
+
+    // Include original Rust squash candidate (for change-squash candidates)
+    if (candidate.change.squashCandidate) {
+      cacheEntry.rustRequest = {
+        ...((cacheEntry.rustRequest as Record<string, unknown>) ?? {}),
+        squashCandidate: candidate.change.squashCandidate,
       };
     }
 
@@ -873,11 +889,27 @@ export function recordFailureSync(
       ...(discoveryVersion ? { discoveryVersion } : {}),
     };
 
-    // Include neuronDetails if available (for add-neurons candidates)
-    // This is what Rust requested
+    // Include the original Rust candidate response for debugging
+    // This allows comparison between what Rust suggested and what happened
     if (candidate.change.neuronDetails) {
       cacheEntry.rustRequest = {
         neuronDetails: candidate.change.neuronDetails,
+      };
+    }
+
+    // Include original Rust synapse candidate (for add-synapses candidates)
+    if (candidate.change.synapseCandidate) {
+      cacheEntry.rustRequest = {
+        ...((cacheEntry.rustRequest as Record<string, unknown>) ?? {}),
+        synapseCandidate: candidate.change.synapseCandidate,
+      };
+    }
+
+    // Include original Rust squash candidate (for change-squash candidates)
+    if (candidate.change.squashCandidate) {
+      cacheEntry.rustRequest = {
+        ...((cacheEntry.rustRequest as Record<string, unknown>) ?? {}),
+        squashCandidate: candidate.change.squashCandidate,
       };
     }
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
@@ -171,13 +171,13 @@ Deno.test({
     const tmpDir512 = await createTempTestDir("batch-512");
 
     try {
-      // Create separate creatures for each test to avoid state issues
-      const creature128 = makeTestCreature(20);
+      // Create meaningful test creatures
+      const creature128 = makeTestCreature(15);
       CreatureUtil.makeUUID(creature128);
       creature128.clearState();
       await createTestBinaryFile(creature128, 100, tmpDir128, "test1.bin");
 
-      const creature512 = makeTestCreature(20);
+      const creature512 = makeTestCreature(15);
       CreatureUtil.makeUUID(creature512);
       creature512.clearState();
       await createTestBinaryFile(creature512, 100, tmpDir512, "test1.bin");
@@ -186,11 +186,11 @@ Deno.test({
       const originalDenoTest = Deno.env.get("DENO_TEST");
       Deno.env.set("DENO_TEST", "true");
       try {
-        // Test with batch size 128, very short timeout (1 second)
+        // Test with batch size 128, reasonable timeout for meaningful analysis
         const config128 = createNeatConfig({
           discoveryBatchSize: 128,
-          discoveryRecordTimeOutMinutes: 0.0167, // ~1 second
-          discoveryAnalysisTimeoutMinutes: 0.0167, // ~1 second for analysis
+          discoveryRecordTimeOutMinutes: 0.25, // 15 seconds
+          discoveryAnalysisTimeoutMinutes: 0.25, // 15 seconds for analysis
           discoverySampleRate: 1.0, // 100% sample rate
           log: 0,
         });
@@ -204,8 +204,8 @@ Deno.test({
         // Test with batch size 512, same timeout
         const config512 = createNeatConfig({
           discoveryBatchSize: 512,
-          discoveryRecordTimeOutMinutes: 0.0167, // ~1 second
-          discoveryAnalysisTimeoutMinutes: 0.0167, // ~1 second for analysis
+          discoveryRecordTimeOutMinutes: 0.25, // 15 seconds
+          discoveryAnalysisTimeoutMinutes: 0.25, // 15 seconds for analysis
           discoverySampleRate: 1.0,
           log: 0,
         });
@@ -260,22 +260,23 @@ Deno.test({
   ignore: shouldSkipRustDiscoveryTests(),
   async fn() {
     assertRustDiscoveryAvailable();
-    const creature = makeTestCreature(30);
+    const creature = makeTestCreature(15);
     CreatureUtil.makeUUID(creature);
     creature.clearState();
 
     const tmpDir = await createTempTestDir("partial-results");
 
     try {
-      // Create a dataset large enough to test timeout behavior
-      await createTestBinaryFile(creature, 200, tmpDir, "test.bin");
+      // Create meaningful dataset
+      await createTestBinaryFile(creature, 150, tmpDir, "test.bin");
 
-      // Set 2-second timeout
+      // Set reasonable timeout
       const config = createNeatConfig({
         discoveryBatchSize: 128,
-        discoveryRecordTimeOutMinutes: 0.033, // 2 seconds
+        discoveryRecordTimeOutMinutes: 0.25, // 15 seconds
+        discoveryAnalysisTimeoutMinutes: 0.25, // 15 seconds for analysis
         discoverySampleRate: 1.0,
-        log: 1, // Enable logging to verify diagnostics appear
+        log: 0,
       });
 
       // Set environment variable to ensure cleanup is awaited in tests (prevents leaks)
@@ -310,24 +311,25 @@ Deno.test({
   ignore: shouldSkipRustDiscoveryTests(),
   async fn() {
     assertRustDiscoveryAvailable();
-    const creature = makeTestCreature(25);
+    const creature = makeTestCreature(15);
     CreatureUtil.makeUUID(creature);
     creature.clearState();
 
     const tmpDir = await createTempTestDir("file-timeout");
 
     try {
-      // Create multiple binary files (reduced size for faster tests)
-      await createTestBinaryFile(creature, 100, tmpDir, "test1.bin");
-      await createTestBinaryFile(creature, 100, tmpDir, "test2.bin");
-      await createTestBinaryFile(creature, 100, tmpDir, "test3.bin");
+      // Create multiple binary files
+      await createTestBinaryFile(creature, 80, tmpDir, "test1.bin");
+      await createTestBinaryFile(creature, 80, tmpDir, "test2.bin");
+      await createTestBinaryFile(creature, 80, tmpDir, "test3.bin");
 
-      // Very short timeout - will hit during file processing
+      // Reasonable timeout
       const config = createNeatConfig({
         discoveryBatchSize: 128,
-        discoveryRecordTimeOutMinutes: 0.02, // ~1.2 seconds
+        discoveryRecordTimeOutMinutes: 0.25, // 15 seconds
+        discoveryAnalysisTimeoutMinutes: 0.25, // 15 seconds
         discoverySampleRate: 1.0,
-        log: 1, // Enable to see diagnostic logs
+        log: 0,
       });
 
       // Set environment variable to ensure cleanup is awaited in tests (prevents leaks)
@@ -369,14 +371,15 @@ Deno.test({
     const tmpDir = await createTempTestDir("success");
 
     try {
-      // Create small dataset that should complete
-      await createTestBinaryFile(creature, 50, tmpDir, "test.bin");
+      // Create meaningful dataset
+      await createTestBinaryFile(creature, 100, tmpDir, "test.bin");
 
       const config = createNeatConfig({
         discoveryBatchSize: 128,
-        discoveryRecordTimeOutMinutes: 0.05, // 3 seconds - plenty of time for small dataset
+        discoveryRecordTimeOutMinutes: 0.5, // 30 seconds - plenty of time
+        discoveryAnalysisTimeoutMinutes: 0.5, // 30 seconds
         discoverySampleRate: 1.0,
-        log: 1,
+        log: 0,
       });
 
       // Set environment variable to ensure cleanup is awaited in tests (prevents leaks)

--- a/test/ErrorGuidedStructuralEvolution/NeuronDiscovery.ts
+++ b/test/ErrorGuidedStructuralEvolution/NeuronDiscovery.ts
@@ -22,7 +22,6 @@ import {
   DiscoverStructure,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
-  isRustDiscoveryEnabled,
   shouldSkipRustDiscoveryTests,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
@@ -170,8 +169,9 @@ function makeMultiLayerScenario(): {
   crippledCreature.validate();
   CreatureUtil.makeUUID(crippledCreature);
 
+  // Meaningful dataset size for proper discovery testing
   const trainingData: DataRecordInterface[] = [];
-  for (let i = 0; i < 512; i++) {
+  for (let i = 0; i < 256; i++) {
     const input = new Float32Array(10);
     for (let j = 0; j < 10; j++) {
       input[j] = Math.random() * 2 - 1;
@@ -545,30 +545,7 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
-    const { targetCreature, crippledCreature, trainingData } =
-      makeMultiLayerScenario();
-
-    console.log("\n========================================");
-    console.log("NEURON DISCOVERY DIAGNOSTIC");
-    console.log("========================================\n");
-
-    console.log("Environment:");
-    console.log(`  Rust discovery enabled: ${isRustDiscoveryEnabled()}`);
-    console.log(`  DEFAULT_RUST_FLUSH_RECORDS: ${DEFAULT_RUST_FLUSH_RECORDS}`);
-
-    console.log("\nTarget creature:");
-    console.log(`  Neurons: ${targetCreature.neurons.length}`);
-    targetCreature.neurons.forEach((n) => {
-      console.log(`    ${n.uuid}: ${n.squash}`);
-    });
-
-    console.log("\nCrippled creature:");
-    console.log(`  Neurons: ${crippledCreature.neurons.length}`);
-    crippledCreature.neurons.forEach((n) => {
-      console.log(`    ${n.uuid}: ${n.squash}`);
-    });
-
-    console.log(`\nTraining data: ${trainingData.length} samples`);
+    const { crippledCreature, trainingData } = makeMultiLayerScenario();
 
     // Calculate error before discovery
     let totalError = 0;
@@ -581,9 +558,10 @@ Deno.test({
     const avgError = totalError / (trainingData.length * 2);
     console.log(`Average absolute error: ${avgError.toFixed(4)}`);
 
+    // Reasonable timeout for meaningful analysis
     const discoverStructure = new DiscoverStructure(
       crippledCreature,
-      180,
+      30, // 30 seconds
       DEFAULT_RUST_FLUSH_RECORDS,
     );
 


### PR DESCRIPTION
…very process

- Bumped version in deno.json to 0.253.0.
- Added original Rust synapse and squash candidate responses to DiscoveryCandidateChange for improved debugging.
- Updated FailureCache to include original Rust candidate responses, facilitating better comparison during failure analysis.
- Adjusted test configurations to use more meaningful dataset sizes and reasonable timeouts for improved test reliability.

These changes aim to enhance the robustness of the discovery process by providing better insights into candidate evaluations and improving test accuracy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds storage of original Rust synapse/squash candidates to discovery and failure cache, updates tests with more meaningful datasets/timeouts, and bumps version to 0.253.0.
> 
> - **Discovery**:
>   - Store original Rust candidate payloads on single candidates: `DiscoveryCandidateChange.synapseCandidate` and `squashCandidate`.
>   - Populate these fields when building `add-synapses` and `change-squash` candidates in `src/discovery/DiscoveryCandidates.ts`.
> - **Failure Cache**:
>   - Include `rustRequest` details (`neuronDetails`, `synapseCandidate`, `squashCandidate`) in both async/sync `recordFailure` paths for improved debugging.
> - **Tests**:
>   - Adjust dataset sizes and timeouts to be more realistic; reduce noisy diagnostics.
>   - Update timeout/recording configs across `test/ErrorGuidedStructuralEvolution/*` and simplify diagnostic logging.
> - **Version**:
>   - Bump `deno.json` version to `0.253.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e098e0233b956506f9a67714958d3741c4a1b7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->