### PR TITLE
Update version to 0.253.1 and adjust timeout settings in tests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.253.0",
+  "version": "0.253.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
@@ -186,11 +186,12 @@ Deno.test({
       const originalDenoTest = Deno.env.get("DENO_TEST");
       Deno.env.set("DENO_TEST", "true");
       try {
-        // Test with batch size 128, reasonable timeout for meaningful analysis
+        // Test with batch size 128, short timeout to test timeout handling
+        // Note: Rust library requires > 3 second timeout, otherwise defaults to 10 minutes
         const config128 = createNeatConfig({
           discoveryBatchSize: 128,
-          discoveryRecordTimeOutMinutes: 0.25, // 15 seconds
-          discoveryAnalysisTimeoutMinutes: 0.25, // 15 seconds for analysis
+          discoveryRecordTimeOutMinutes: 0.1, // 6 seconds (must be > 3s for Rust)
+          discoveryAnalysisTimeoutMinutes: 0.1, // 6 seconds for analysis
           discoverySampleRate: 1.0, // 100% sample rate
           log: 0,
         });
@@ -204,8 +205,8 @@ Deno.test({
         // Test with batch size 512, same timeout
         const config512 = createNeatConfig({
           discoveryBatchSize: 512,
-          discoveryRecordTimeOutMinutes: 0.25, // 15 seconds
-          discoveryAnalysisTimeoutMinutes: 0.25, // 15 seconds for analysis
+          discoveryRecordTimeOutMinutes: 0.1, // 6 seconds (must be > 3s for Rust)
+          discoveryAnalysisTimeoutMinutes: 0.1, // 6 seconds for analysis
           discoverySampleRate: 1.0,
           log: 0,
         });
@@ -267,14 +268,15 @@ Deno.test({
     const tmpDir = await createTempTestDir("partial-results");
 
     try {
-      // Create meaningful dataset
-      await createTestBinaryFile(creature, 150, tmpDir, "test.bin");
+      // Create larger dataset to ensure timeout is triggered
+      await createTestBinaryFile(creature, 200, tmpDir, "test.bin");
 
-      // Set reasonable timeout
+      // Short timeout to test timeout handling - should trigger partial results
+      // Note: Rust library requires > 3 second timeout, otherwise defaults to 10 minutes
       const config = createNeatConfig({
         discoveryBatchSize: 128,
-        discoveryRecordTimeOutMinutes: 0.25, // 15 seconds
-        discoveryAnalysisTimeoutMinutes: 0.25, // 15 seconds for analysis
+        discoveryRecordTimeOutMinutes: 0.1, // 6 seconds (must be > 3s for Rust)
+        discoveryAnalysisTimeoutMinutes: 0.1, // 6 seconds for analysis
         discoverySampleRate: 1.0,
         log: 0,
       });
@@ -318,16 +320,17 @@ Deno.test({
     const tmpDir = await createTempTestDir("file-timeout");
 
     try {
-      // Create multiple binary files
-      await createTestBinaryFile(creature, 80, tmpDir, "test1.bin");
-      await createTestBinaryFile(creature, 80, tmpDir, "test2.bin");
-      await createTestBinaryFile(creature, 80, tmpDir, "test3.bin");
+      // Create multiple binary files to ensure processing takes time
+      await createTestBinaryFile(creature, 100, tmpDir, "test1.bin");
+      await createTestBinaryFile(creature, 100, tmpDir, "test2.bin");
+      await createTestBinaryFile(creature, 100, tmpDir, "test3.bin");
 
-      // Reasonable timeout
+      // Short timeout to test timeout during file processing
+      // Note: Rust library requires > 3 second timeout, otherwise defaults to 10 minutes
       const config = createNeatConfig({
         discoveryBatchSize: 128,
-        discoveryRecordTimeOutMinutes: 0.25, // 15 seconds
-        discoveryAnalysisTimeoutMinutes: 0.25, // 15 seconds
+        discoveryRecordTimeOutMinutes: 0.1, // 6 seconds (must be > 3s for Rust)
+        discoveryAnalysisTimeoutMinutes: 0.1, // 6 seconds
         discoverySampleRate: 1.0,
         log: 0,
       });

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1308,7 +1308,8 @@ Deno.test(
 );
 
 Deno.test({
-  name: "DiscoveryRunner caches failed candidates when discoveryFailureCacheDir is set",
+  name:
+    "DiscoveryRunner caches failed candidates when discoveryFailureCacheDir is set",
   // Uses Rust FFI via recordFailure -> getDiscoveryVersion
   sanitizeOps: false,
   sanitizeResources: false,
@@ -1483,7 +1484,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "DiscoveryRunner skips cached Phase 2 combined candidates on subsequent runs",
+  name:
+    "DiscoveryRunner skips cached Phase 2 combined candidates on subsequent runs",
   // Uses Rust FFI via recordFailure -> getDiscoveryVersion
   sanitizeOps: false,
   sanitizeResources: false,
@@ -1954,7 +1956,8 @@ Deno.test(
 );
 
 Deno.test({
-  name: "DiscoveryRunner logs specific candidate types when skipped due to cache",
+  name:
+    "DiscoveryRunner logs specific candidate types when skipped due to cache",
   // Uses Rust FFI via recordFailure -> getDiscoveryVersion
   sanitizeOps: false,
   sanitizeResources: false,

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -1307,9 +1307,12 @@ Deno.test(
   },
 );
 
-Deno.test(
-  "DiscoveryRunner caches failed candidates when discoveryFailureCacheDir is set",
-  async () => {
+Deno.test({
+  name: "DiscoveryRunner caches failed candidates when discoveryFailureCacheDir is set",
+  // Uses Rust FFI via recordFailure -> getDiscoveryVersion
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
     const tempDir = await Deno.makeTempDir();
     const cacheDir = `${tempDir}/failure-cache`;
 
@@ -1383,11 +1386,14 @@ Deno.test(
       await Deno.remove(tempDir, { recursive: true });
     }
   },
-);
+});
 
-Deno.test(
-  "DiscoveryRunner skips cached candidates on subsequent runs",
-  async () => {
+Deno.test({
+  name: "DiscoveryRunner skips cached candidates on subsequent runs",
+  // Uses Rust FFI via recordFailure -> getDiscoveryVersion
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
     const tempDir = await Deno.makeTempDir();
     const cacheDir = `${tempDir}/failure-cache`;
 
@@ -1474,11 +1480,14 @@ Deno.test(
       await Deno.remove(tempDir, { recursive: true });
     }
   },
-);
+});
 
-Deno.test(
-  "DiscoveryRunner skips cached Phase 2 combined candidates on subsequent runs",
-  async () => {
+Deno.test({
+  name: "DiscoveryRunner skips cached Phase 2 combined candidates on subsequent runs",
+  // Uses Rust FFI via recordFailure -> getDiscoveryVersion
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
     const tempDir = await Deno.makeTempDir();
     const cacheDir = `${tempDir}/failure-cache`;
 
@@ -1584,11 +1593,14 @@ Deno.test(
       await Deno.remove(tempDir, { recursive: true });
     }
   },
-);
+});
 
-Deno.test(
-  "DiscoveryRunner does not cache successful candidates",
-  async () => {
+Deno.test({
+  name: "DiscoveryRunner does not cache successful candidates",
+  // Uses Rust FFI via recordFailure -> getDiscoveryVersion
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
     const tempDir = await Deno.makeTempDir();
     const cacheDir = `${tempDir}/failure-cache`;
 
@@ -1664,7 +1676,7 @@ Deno.test(
       await Deno.remove(tempDir, { recursive: true });
     }
   },
-);
+});
 
 Deno.test(
   "DiscoveryRunner respects discoveryMinCandidatesPerCategory for removal candidates",
@@ -1941,9 +1953,12 @@ Deno.test(
   },
 );
 
-Deno.test(
-  "DiscoveryRunner logs specific candidate types when skipped due to cache",
-  async () => {
+Deno.test({
+  name: "DiscoveryRunner logs specific candidate types when skipped due to cache",
+  // Uses Rust FFI via recordFailure -> getDiscoveryVersion
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
     const tempDir = await Deno.makeTempDir();
     const cacheDir = `${tempDir}/failure-cache`;
 
@@ -2039,7 +2054,7 @@ Deno.test(
       await Deno.remove(tempDir, { recursive: true });
     }
   },
-);
+});
 
 Deno.test({
   name: "DiscoveryRunner passes discoveryFailureCacheDir to candidate builder",


### PR DESCRIPTION
- Bumped version in deno.json to 0.253.1.
- Modified timeout settings in tests to shorter durations for better timeout handling, ensuring that the Rust library's requirements are met.
- Updated dataset sizes in tests to trigger timeouts effectively, enhancing the robustness of timeout handling during discovery processes.

These changes aim to improve the reliability of tests and ensure proper timeout management in the discovery framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shortens discovery timeouts and scales datasets to reliably trigger/validate timeout handling, refactors several tests to object-style with FFI sanitization, and bumps version to 0.253.1.
> 
> - **Tests**:
>   - **`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`**:
>     - Set `discoveryRecordTimeOutMinutes`/`discoveryAnalysisTimeoutMinutes` to `0.1` and increased dataset sizes/file counts to trigger timeouts and validate partial results.
>   - **`test/discovery/DiscoveryRunner.ts`**:
>     - Converted multiple tests to object-form `Deno.test({ name, fn })` and disabled sanitizers (`sanitizeOps`, `sanitizeResources`) for Rust FFI; preserved test logic.
> - **Config**:
>   - Bump `deno.json` `version` to `0.253.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f32686b87d51c997e5cd84be2e2b46cb9348fbca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->