### PR TITLE
Update version to 0.254.0 and introduce analysis timeout constraints

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.253.0",
+  "version": "0.254.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -19,6 +19,18 @@ export const DEFAULT_COST_OF_GROWTH = 0.000_000_1;
 export const MIN_COST_OF_GROWTH = 0.000_000_000_1;
 
 /**
+ * Minimum allowed discovery analysis timeout in minutes.
+ * The Rust library requires at least 3 seconds (0.05 minutes).
+ */
+export const MIN_ANALYSIS_TIMEOUT_MINUTES = 0.05; // 3 seconds
+
+/**
+ * Maximum allowed discovery analysis timeout in minutes.
+ * The Rust library allows up to 1 hour (60 minutes).
+ */
+export const MAX_ANALYSIS_TIMEOUT_MINUTES = 60; // 1 hour
+
+/**
  * Default minimum candidates per discovery category.
  * These values reflect the current behaviour where diversity selection
  * picks at least 1 from each category, and removal candidates sample 3.
@@ -328,12 +340,14 @@ function validate(config: NeatArguments) {
       `Genetic Compatibility Threshold must be between 0 and 1 was: ${config.geneticCompatibilityThreshold}`,
     );
   }
+  // Rust library requires timeout between 3 seconds (0.05 min) and 1 hour (60 min)
   if (
     Number.isFinite(config.discoveryAnalysisTimeoutMinutes) === false ||
-    config.discoveryAnalysisTimeoutMinutes <= 0
+    config.discoveryAnalysisTimeoutMinutes < MIN_ANALYSIS_TIMEOUT_MINUTES ||
+    config.discoveryAnalysisTimeoutMinutes > MAX_ANALYSIS_TIMEOUT_MINUTES
   ) {
     throw new Error(
-      `Discovery Analysis Timeout Minutes must be greater than 0 was: ${config.discoveryAnalysisTimeoutMinutes}`,
+      `Discovery Analysis Timeout Minutes must be between ${MIN_ANALYSIS_TIMEOUT_MINUTES} (3 seconds) and ${MAX_ANALYSIS_TIMEOUT_MINUTES} (1 hour), was: ${config.discoveryAnalysisTimeoutMinutes}`,
     );
   }
   if (

--- a/test/NEAT/NeatConfig.ts
+++ b/test/NEAT/NeatConfig.ts
@@ -2,6 +2,8 @@ import { assertEquals, fail } from "@std/assert";
 import {
   createNeatConfig,
   DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY,
+  MAX_ANALYSIS_TIMEOUT_MINUTES,
+  MIN_ANALYSIS_TIMEOUT_MINUTES,
 } from "../../src/config/NeatConfig.ts";
 import { Selection } from "../../mod.ts";
 
@@ -137,4 +139,101 @@ Deno.test("NeatConfig discoveryMinCandidatesPerCategory allows zero values", () 
   });
   assertEquals(config.discoveryMinCandidatesPerCategory.addNeurons, 0);
   assertEquals(config.discoveryMinCandidatesPerCategory.removeLowImpact, 0);
+});
+
+Deno.test("NeatConfig discoveryAnalysisTimeoutMinutes - valid at minimum bound", () => {
+  const config = createNeatConfig({
+    discoveryAnalysisTimeoutMinutes: MIN_ANALYSIS_TIMEOUT_MINUTES,
+  });
+  assertEquals(
+    config.discoveryAnalysisTimeoutMinutes,
+    MIN_ANALYSIS_TIMEOUT_MINUTES,
+  );
+});
+
+Deno.test("NeatConfig discoveryAnalysisTimeoutMinutes - valid at maximum bound", () => {
+  const config = createNeatConfig({
+    discoveryAnalysisTimeoutMinutes: MAX_ANALYSIS_TIMEOUT_MINUTES,
+  });
+  assertEquals(
+    config.discoveryAnalysisTimeoutMinutes,
+    MAX_ANALYSIS_TIMEOUT_MINUTES,
+  );
+});
+
+Deno.test("NeatConfig discoveryAnalysisTimeoutMinutes - valid within bounds", () => {
+  const config = createNeatConfig({
+    discoveryAnalysisTimeoutMinutes: 10,
+  });
+  assertEquals(config.discoveryAnalysisTimeoutMinutes, 10);
+});
+
+Deno.test("NeatConfig discoveryAnalysisTimeoutMinutes - below minimum throws", () => {
+  try {
+    createNeatConfig({
+      discoveryAnalysisTimeoutMinutes: 0.01, // Below 0.05 (3 seconds)
+    });
+    fail("Should throw for timeout below minimum");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes(String(MIN_ANALYSIS_TIMEOUT_MINUTES)),
+      true,
+      `Error should mention minimum bound: ${(e as Error).message}`,
+    );
+    assertEquals(
+      (e as Error).message.includes(String(MAX_ANALYSIS_TIMEOUT_MINUTES)),
+      true,
+      `Error should mention maximum bound: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NeatConfig discoveryAnalysisTimeoutMinutes - above maximum throws", () => {
+  try {
+    createNeatConfig({
+      discoveryAnalysisTimeoutMinutes: 61, // Above 60 (1 hour)
+    });
+    fail("Should throw for timeout above maximum");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes(String(MIN_ANALYSIS_TIMEOUT_MINUTES)),
+      true,
+      `Error should mention minimum bound: ${(e as Error).message}`,
+    );
+    assertEquals(
+      (e as Error).message.includes(String(MAX_ANALYSIS_TIMEOUT_MINUTES)),
+      true,
+      `Error should mention maximum bound: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NeatConfig discoveryAnalysisTimeoutMinutes - zero throws", () => {
+  try {
+    createNeatConfig({
+      discoveryAnalysisTimeoutMinutes: 0,
+    });
+    fail("Should throw for zero timeout");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes("Discovery Analysis Timeout Minutes"),
+      true,
+      `Error should mention the field name: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NeatConfig discoveryAnalysisTimeoutMinutes - negative throws", () => {
+  try {
+    createNeatConfig({
+      discoveryAnalysisTimeoutMinutes: -5,
+    });
+    fail("Should throw for negative timeout");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes("Discovery Analysis Timeout Minutes"),
+      true,
+      `Error should mention the field name: ${(e as Error).message}`,
+    );
+  }
 });


### PR DESCRIPTION
- Bumped version in deno.json to 0.254.0.
- Added minimum and maximum constraints for discovery analysis timeout in NeatConfig, ensuring values are between 3 seconds (0.05 minutes) and 1 hour (60 minutes).
- Updated validation logic to enforce these constraints and provide clearer error messages.
- Introduced comprehensive tests to validate the new timeout constraints, ensuring robustness in configuration handling.

These changes enhance the configuration management by enforcing strict timeout limits, improving the reliability of the discovery process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces bounded discovery analysis timeout (0.05–60 min), adds validation tests, and bumps version to 0.254.0.
> 
> - **Config (`src/config/NeatConfig.ts`)**:
>   - Add `MIN_ANALYSIS_TIMEOUT_MINUTES` (0.05) and `MAX_ANALYSIS_TIMEOUT_MINUTES` (60).
>   - Validate `discoveryAnalysisTimeoutMinutes` within new bounds with clearer error message.
> - **Tests (`test/NEAT/NeatConfig.ts`)**:
>   - Add tests for timeout min/max bounds, in-range value, and out-of-range errors.
> - **Meta**:
>   - Bump `deno.json` version to `0.254.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 439112ecd215b13a3fb6e182f089933ca75f0e24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->