### PR TITLE
Update version to 0.255.0 and remove expected error reduction calcula…

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,12 @@ results:
 
 1. **Disable library logging**: Set
    `discoveryDisableEvaluationSummaryLogging: true` in your options
-2. **Use exported formatting utilities**: Import `formatErrorDelta`,
-   `formatExpected`, and `formatPercentWithSignificantDigits` from the discovery
-   module to format summaries consistently
+2. **Use exported formatting utilities**: Import `formatErrorDelta` and
+   `formatPercentWithSignificantDigits` from the discovery module to format
+   summaries consistently
 
 ```typescript
-import { formatErrorDelta, formatExpected } from "./mod.ts";
+import { formatErrorDelta } from "./mod.ts";
 
 const result = await creature.discoveryDir(dataDir, {
   discoveryDisableEvaluationSummaryLogging: true, // Disable library logging

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.254.0",
+  "version": "0.255.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/mod.ts
+++ b/mod.ts
@@ -144,7 +144,6 @@ export { upgradeTwo } from "./src/upgrade/UpgradeTwo.ts";
  */
 export {
   formatErrorDelta,
-  formatExpected,
   formatPercentWithSignificantDigits,
 } from "./src/discovery/DiscoveryRunner.ts";
 

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -65,7 +65,6 @@ const DEFAULT_WORKER_FACTORY: DiscoveryRunnerWorkerFactory = (args) =>
   );
 
 const DEFAULT_RUST_CHECK = () => isRustDiscoveryEnabled();
-const EXPECTATION_ALERT_THRESHOLD = 25; // percentage-point gap before warning
 
 export interface DiscoveryDirInput {
   creature: Creature;
@@ -82,14 +81,8 @@ export interface DiscoveryEvaluationSummary {
   scoreDelta?: number;
   improved: boolean;
   archivePath?: string;
-  expectedErrorReductionPct?: number;
   errorDelta?: number;
   errorDeltaPct?: number;
-  expectationMismatch?: {
-    expectedPct: number;
-    actualPct: number;
-    gapPct: number;
-  };
   /** Details of discovered neuron (for single neuron candidates). */
   neuronDetails?: DiscoveredNeuronDetails;
 }
@@ -618,16 +611,6 @@ export class DiscoveryRunner {
         ? evaluation.error === 0 ? 0 : -100
         : (errorDelta / originalError) * 100;
 
-      const expectedErrorReductionPct = evaluation.candidate?.change
-          .expectedErrorReduction !== undefined
-        ? evaluation.candidate.change.expectedErrorReduction * 100
-        : undefined;
-
-      const expectationMismatch = this.#computeExpectationMismatch(
-        expectedErrorReductionPct,
-        evaluation.kind === "candidate" ? errorDeltaPct : undefined,
-      );
-
       let archivePath: string | undefined;
       const exportPayload = evaluation.kind === "original"
         ? originalExport
@@ -646,8 +629,6 @@ export class DiscoveryRunner {
           improved,
           errorDelta,
           errorDeltaPct,
-          expectedErrorReductionPct,
-          expectationMismatch,
           creature: exportPayload,
         });
       }
@@ -661,10 +642,8 @@ export class DiscoveryRunner {
         scoreDelta,
         improved,
         archivePath,
-        expectedErrorReductionPct,
         errorDelta,
         errorDeltaPct,
-        expectationMismatch,
         neuronDetails: evaluation.candidate?.change.neuronDetails,
       });
     }
@@ -699,17 +678,10 @@ export class DiscoveryRunner {
     const original = summaries.find((s) => s.kind === "original");
     const candidates = summaries.filter((s) => s.kind === "candidate");
 
-    // Sort candidates by expected improvement (descending), undefined values last
-    candidates.sort((a, b) => {
-      const aExp = a.expectedErrorReductionPct;
-      const bExp = b.expectedErrorReductionPct;
-      if (aExp === undefined && bExp === undefined) return 0;
-      if (aExp === undefined) return 1;
-      if (bExp === undefined) return -1;
-      return bExp - aExp;
-    });
+    // Sort candidates by actual improvement (scoreDelta descending)
+    candidates.sort((a, b) => (b.scoreDelta ?? 0) - (a.scoreDelta ?? 0));
 
-    // Identify the best candidate (first in sorted list)
+    // Identify the best candidate (highest score delta)
     const bestCandidate = candidates.length > 0 ? candidates[0] : undefined;
 
     console.info(
@@ -761,10 +733,6 @@ export class DiscoveryRunner {
       }
     }
 
-    const expectedText = summary.expectedErrorReductionPct !== undefined
-      ? ` expected ${this.#formatExpected(summary.expectedErrorReductionPct)}`
-      : "";
-
     const scoreText = `score=${summary.score.toPrecision(4)}`;
     const scoreDeltaText = summary.kind === "candidate" &&
         summary.scoreDelta !== undefined
@@ -776,28 +744,16 @@ export class DiscoveryRunner {
       ? ` ${summary.improved ? green("✓improved") : yellow("no-improvement")}`
       : "";
 
-    const mismatchText = summary.expectationMismatch
-      ? ` ${
-        red(
-          `⚠ mismatch expected ${
-            this.#formatExpected(summary.expectationMismatch.expectedPct)
-          } vs actual ${
-            this.#formatErrorDelta(summary.expectationMismatch.actualPct)
-          }`,
-        )
-      }`
-      : "";
-
     const bestMarker = isBest ? bold(cyan(" ★BEST")) : "";
 
     const mainInfo = summary.kind === "original"
       ? `error=${summary.error.toPrecision(6)} ${scoreText} ${errorDeltaText}`
       : `error=${
         summary.error.toPrecision(6)
-      } ${scoreText}${scoreDeltaText}${improvedText} ${errorDeltaText}${expectedText}${bestMarker}`;
+      } ${scoreText}${scoreDeltaText}${improvedText} ${errorDeltaText}${bestMarker}`;
 
     console.info(
-      `[DiscoveryRunner]   ${label}${description}: ${mainInfo}${mismatchText}`,
+      `[DiscoveryRunner]   ${label}${description}: ${mainInfo}`,
     );
 
     // Log full neuron details for ALL candidates with neuron details
@@ -823,33 +779,8 @@ export class DiscoveryRunner {
     }
   }
 
-  #computeExpectationMismatch(
-    expected?: number,
-    actual?: number,
-  ): { expectedPct: number; actualPct: number; gapPct: number } | undefined {
-    if (
-      expected === undefined || !Number.isFinite(expected) ||
-      actual === undefined || !Number.isFinite(actual)
-    ) {
-      return undefined;
-    }
-    const gap = expected - actual;
-    if (Math.abs(gap) < EXPECTATION_ALERT_THRESHOLD) {
-      return undefined;
-    }
-    return {
-      expectedPct: expected,
-      actualPct: actual,
-      gapPct: gap,
-    };
-  }
-
   #formatErrorDelta(value: number): string {
     return formatErrorDelta(value);
-  }
-
-  #formatExpected(value: number): string {
-    return formatExpected(value);
   }
 
   async #evaluateAll(
@@ -1292,17 +1223,4 @@ export function formatErrorDelta(value: number): string {
   if (value > 0.05) return green(formatted);
   if (value < -0.05) return red(formatted);
   return yellow(formatted);
-}
-
-/**
- * Formats an expected improvement percentage.
- *
- * @param value - The expected improvement percentage (e.g., 0.5 for 0.5%)
- * @returns Formatted string in cyan colour
- */
-export function formatExpected(value: number): string {
-  if (!Number.isFinite(value)) {
-    return cyan("n/a");
-  }
-  return cyan(formatPercentWithSignificantDigits(value));
 }

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -60,39 +60,10 @@ export interface PredictionDetails {
   bias?: number;
   /** Squash function used */
   squash?: string;
-  /** Expected improvement percentage from Rust */
-  expectedImprovementPct?: number;
   /** Number of samples where improvement was predicted */
   improvedCount?: number;
   /** Total samples analysed */
   totalCount?: number;
-  /** Example contribution calculation for a typical sample */
-  exampleContribution?: {
-    sourceActivation: number;
-    preActivation: number;
-    postActivation: number;
-    contribution: number;
-  };
-}
-
-/** Error comparison details for debugging prediction inversions */
-export interface ErrorComparison {
-  /** Original MSE before candidate was applied */
-  originalMSE: number;
-  /** MSE after candidate was applied */
-  candidateMSE: number;
-  /** Actual error reduction (originalMSE - candidateMSE, positive = improvement) */
-  actualErrorReduction: number;
-  /** Actual error reduction as percentage */
-  actualErrorReductionPct: number;
-  /** Expected error reduction from Rust prediction */
-  expectedErrorReduction?: number;
-  /** Expected error reduction as percentage from Rust */
-  expectedErrorReductionPct?: number;
-  /** Formula used for error calculation */
-  errorFormula: string;
-  /** Whether prediction direction was correct */
-  predictionDirectionCorrect?: boolean;
 }
 
 /** Information about the target neuron */
@@ -125,14 +96,12 @@ export interface FailureMetadata {
   /** NEAT-AI-Discovery library version that generated the candidate */
   discoveryVersion?: string;
 
-  // Enhanced diagnostic fields for debugging prediction inversions
+  // Diagnostic fields for debugging
 
   /** Diagnostics for first few samples used in prediction */
   sampleDiagnostics?: SampleDiagnostic[];
   /** Prediction details from Rust candidate */
   predictionDetails?: PredictionDetails;
-  /** Error comparison showing expected vs actual */
-  errorComparison?: ErrorComparison;
   /** Information about the target neuron */
   targetNeuronInfo?: TargetNeuronInfo;
 }
@@ -457,28 +426,13 @@ export function extractPredictionDetails(
       outgoingWeight: details.outgoingWeight,
       bias: details.bias,
       squash: details.squash,
-      expectedImprovementPct: change.expectedErrorReduction !== undefined
-        ? change.expectedErrorReduction * 100
-        : undefined,
     };
   }
 
-  // For add-synapses candidates, we need to look at the creature's synapses
+  // For add-synapses candidates
   if (change.type === "add-synapses") {
     return {
-      expectedImprovementPct: change.expectedErrorReduction !== undefined
-        ? change.expectedErrorReduction * 100
-        : undefined,
       totalCount: change.sampleSize,
-    };
-  }
-
-  // For change-squash candidates
-  if (change.type === "change-squash") {
-    return {
-      expectedImprovementPct: change.expectedErrorReduction !== undefined
-        ? change.expectedErrorReduction * 100
-        : undefined,
     };
   }
 
@@ -531,48 +485,6 @@ export function extractTargetNeuronInfo(
 }
 
 /**
- * Builds error comparison details from metadata.
- *
- * @param metadata - The failure metadata
- * @param expectedErrorReduction - Expected error reduction from candidate
- * @returns ErrorComparison details
- */
-export function buildErrorComparison(
-  metadata: FailureMetadata,
-  expectedErrorReduction?: number,
-): ErrorComparison | undefined {
-  if (metadata.originalError === undefined) return undefined;
-
-  const originalMSE = metadata.originalError;
-  const candidateMSE = metadata.error;
-  const actualErrorReduction = originalMSE - candidateMSE;
-  const actualErrorReductionPct = originalMSE === 0
-    ? (candidateMSE === 0 ? 0 : -100)
-    : (actualErrorReduction / originalMSE) * 100;
-
-  // Determine if prediction direction was correct
-  let predictionDirectionCorrect: boolean | undefined;
-  if (expectedErrorReduction !== undefined) {
-    const predictedImprovement = expectedErrorReduction > 0;
-    const actualImprovement = actualErrorReduction > 0;
-    predictionDirectionCorrect = predictedImprovement === actualImprovement;
-  }
-
-  return {
-    originalMSE,
-    candidateMSE,
-    actualErrorReduction,
-    actualErrorReductionPct,
-    expectedErrorReduction,
-    expectedErrorReductionPct: expectedErrorReduction !== undefined
-      ? expectedErrorReduction * 100
-      : undefined,
-    errorFormula: "MSE = (1/n) * Σ(predicted - actual)²",
-    predictionDirectionCorrect,
-  };
-}
-
-/**
  * Logs detailed prediction trace when NEAT_AI_TRACE_PREDICTION=1 is set.
  *
  * @param candidate - The candidate being traced
@@ -609,32 +521,6 @@ export function logPredictionTrace(
   if (cacheEntry.predictionDetails) {
     console.info("--- Rust Prediction Details ---");
     console.info(JSON.stringify(cacheEntry.predictionDetails, null, 2));
-    console.info("");
-  }
-
-  // Log error comparison
-  if (cacheEntry.errorComparison) {
-    console.info("--- Error Comparison ---");
-    const ec = cacheEntry.errorComparison as ErrorComparison;
-    console.info(`Original MSE:          ${ec.originalMSE.toExponential(6)}`);
-    console.info(`Candidate MSE:         ${ec.candidateMSE.toExponential(6)}`);
-    console.info(
-      `Actual Error Delta:    ${ec.actualErrorReduction.toExponential(6)} (${
-        ec.actualErrorReductionPct.toFixed(4)
-      }%)`,
-    );
-    if (ec.expectedErrorReductionPct !== undefined) {
-      console.info(
-        `Expected Error Delta:  ${
-          (ec.expectedErrorReduction ?? 0).toExponential(6)
-        } (${ec.expectedErrorReductionPct.toFixed(4)}%)`,
-      );
-      console.info(
-        `Prediction Direction:  ${
-          ec.predictionDirectionCorrect ? "✓ CORRECT" : "✗ INVERTED"
-        }`,
-      );
-    }
     console.info("");
   }
 
@@ -712,9 +598,8 @@ export function isCandidateCachedSync(
 /**
  * Records a discovery candidate as a failure in the cache.
  *
- * Enhanced with diagnostic fields to help debug prediction inversions:
+ * Includes diagnostic fields:
  * - predictionDetails: Rust prediction parameters
- * - errorComparison: Expected vs actual error with direction analysis
  * - targetNeuronInfo: Information about the target neuron
  *
  * @param cacheDir - The cache directory path
@@ -811,21 +696,10 @@ export async function recordFailure(
         cacheEntry.actualCreatureChange = actualChanges;
       }
 
-      // Enhanced diagnostics for debugging prediction inversions
-
       // Extract prediction details from the candidate
       const predictionDetails = extractPredictionDetails(candidate);
       if (predictionDetails) {
         cacheEntry.predictionDetails = predictionDetails;
-      }
-
-      // Build error comparison details
-      const errorComparison = buildErrorComparison(
-        metadata,
-        candidate.change.expectedErrorReduction,
-      );
-      if (errorComparison) {
-        cacheEntry.errorComparison = errorComparison;
       }
 
       // Extract target neuron info
@@ -853,9 +727,8 @@ export async function recordFailure(
 /**
  * Synchronously records a discovery candidate as a failure in the cache.
  *
- * Enhanced with diagnostic fields to help debug prediction inversions:
+ * Includes diagnostic fields:
  * - predictionDetails: Rust prediction parameters
- * - errorComparison: Expected vs actual error with direction analysis
  * - targetNeuronInfo: Information about the target neuron
  *
  * @param cacheDir - The cache directory path
@@ -952,21 +825,10 @@ export function recordFailureSync(
         cacheEntry.actualCreatureChange = actualChanges;
       }
 
-      // Enhanced diagnostics for debugging prediction inversions
-
       // Extract prediction details from the candidate
       const predictionDetails = extractPredictionDetails(candidate);
       if (predictionDetails) {
         cacheEntry.predictionDetails = predictionDetails;
-      }
-
-      // Build error comparison details
-      const errorComparison = buildErrorComparison(
-        metadata,
-        candidate.change.expectedErrorReduction,
-      );
-      if (errorComparison) {
-        cacheEntry.errorComparison = errorComparison;
       }
 
       // Extract target neuron info

--- a/test/discovery/DiscoveryRunner.ts
+++ b/test/discovery/DiscoveryRunner.ts
@@ -562,17 +562,14 @@ Deno.test("DiscoveryRunner records evaluation summaries and archives candidates"
   }
 });
 
-Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for synapses", async () => {
-  // Since Rust v0.1.133, expectedImprovementPercentage is already creature-level
-  // (Rust applies impact discounting internally). TypeScript should use it directly.
-  const rustProvidedImprovement = 0.6; // 60% creature-level improvement from Rust
+Deno.test("DiscoveryRunner evaluates synapse candidates correctly", async () => {
   const discoveryResult: DiscoverResult = {
-    ID: "RUST_DIRECT_SYNAPSE",
+    ID: "SYNAPSE_EVAL_TEST",
     addHelpfulSynapses: [{
       fromNeuronUUID: "input-1",
       toNeuronUUID: "hidden-1",
       weight: 0.45,
-      expectedImprovementPercentage: rustProvidedImprovement,
+      expectedImprovementPercentage: 0.6,
       improvedCount: 9,
       totalCount: 10,
     }],
@@ -611,19 +608,6 @@ Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for syn
   );
   assert(candidateEval, "expected add-synapses candidate evaluation");
 
-  // Verify TypeScript uses Rust's creature-level value directly (no re-scaling)
-  // The expectedErrorReductionPct should equal Rust's expectedImprovementPercentage * 100
-  assert(
-    candidateEval.expectedErrorReductionPct !== undefined,
-    "expected error reduction percentage to be defined",
-  );
-  assertAlmostEquals(
-    candidateEval.expectedErrorReductionPct!,
-    rustProvidedImprovement * 100, // 60% as percentage
-    1e-6,
-    "TypeScript should use Rust's creature-level value directly without re-scaling",
-  );
-
   // Verify the actual improvement percentage
   assertAlmostEquals(
     candidateEval.errorDeltaPct ?? 0,
@@ -632,34 +616,17 @@ Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for syn
   );
 });
 
-Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for neurons", async () => {
-  // Since Rust v0.1.123 (neurons) and v0.1.133 (synapses), expectedImprovementPercentage
-  // is already creature-level. TypeScript should use it directly without re-scaling.
+Deno.test("DiscoveryRunner evaluates neuron candidates correctly", async () => {
   const creature = makeDenseOutputCreature(100); // 100+ synapses to output
 
   // Set a baseline error for the creature
-  const baseError = 0.584263; // Similar to production error
+  const baseError = 0.584263;
   const { addTag } = await import("@stsoftware/tags/mod");
   addTag(creature, "error", baseError.toString());
 
-  // targetNeuronStats is still passed for backwards compatibility but TypeScript
-  // should NOT use it for scaling - Rust has already applied the impact discount
-  const targetNeuronStats = {
-    meanError: 0.05,
-    errorVariance: 0.001,
-    meanActivation: 0.3,
-    activationVariance: 0.01,
-    errorSpikeCount: 2,
-    activationSpikeCount: 1,
-    activationMin: -0.5,
-    activationMax: 1.2,
-  };
+  const expectedImprovementPct = 0.1; // 0.1% improvement
+  const errorReduction = baseError * (expectedImprovementPct / 100);
 
-  // Rust provides creature-level improvement directly (0.1% expected)
-  // This is already discounted by impact - TypeScript should NOT re-scale
-  const rustCreatureLevelImprovement = 0.001; // 0.1% creature-level from Rust
-
-  // Neuron candidate structure with incoming/outgoing weights, bias, and squash
   const neuronCandidate = {
     fromNeuronUUID: "input-1",
     toNeuronUUID: "hidden-1",
@@ -667,14 +634,13 @@ Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for neu
     outgoingWeight: -0.3,
     squash: "TANH",
     bias: 0.05,
-    expectedImprovementPercentage: rustCreatureLevelImprovement,
+    expectedImprovementPercentage: errorReduction,
     improvedCount: 9,
     totalCount: 10,
-    targetNeuronStats, // Passed for backwards compatibility, but NOT used for scaling
   };
 
   const discoveryResult: DiscoverResult = {
-    ID: "RUST_DIRECT_NEURON",
+    ID: "NEURON_EVAL_TEST",
     addHelpfulSynapses: undefined,
     addHelpfulNeurons: [neuronCandidate],
     removeHarmfulSynapse: undefined,
@@ -687,26 +653,13 @@ Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for neu
     discoveryResult,
     (creature: Creature) => {
       const json = creature.exportJSON();
-      // Check for the added neuron by finding its incoming and outgoing synapses
+      // Check for the added neuron by finding its incoming synapse
       const incomingSynapse = json.synapses.find((synapse) =>
         synapse.fromUUID === neuronCandidate.fromNeuronUUID &&
         Math.abs(synapse.weight - neuronCandidate.incomingWeight) < 1e-6
       );
-      const discoveredNeuronUUID = incomingSynapse?.toUUID;
-      const outgoingSynapse = discoveredNeuronUUID
-        ? json.synapses.find((synapse) =>
-          synapse.fromUUID === discoveredNeuronUUID &&
-          synapse.toUUID === neuronCandidate.toNeuronUUID &&
-          Math.abs(synapse.weight - neuronCandidate.outgoingWeight) < 1e-6
-        )
-        : undefined;
-      const hasDiscoveredNeuron = Boolean(
-        discoveredNeuronUUID &&
-          outgoingSynapse &&
-          json.neurons.some((neuron) => neuron.uuid === discoveredNeuronUUID),
-      );
-      // Actual improvement matches Rust's creature-level estimate
-      return hasDiscoveredNeuron ? baseError * 0.999 : baseError;
+      const hasNeuron = incomingSynapse !== undefined;
+      return hasNeuron ? baseError - errorReduction : baseError;
     },
   );
 
@@ -726,34 +679,12 @@ Deno.test("DiscoveryRunner uses Rust creature-level improvement directly for neu
   );
   assert(candidateEval, "expected add-neurons candidate evaluation");
 
-  // Verify TypeScript uses Rust's creature-level value directly (no re-scaling)
-  const expectedErrorReductionPct = candidateEval.expectedErrorReductionPct;
-  assert(
-    expectedErrorReductionPct !== undefined,
-    "expected error reduction percentage to be defined",
-  );
-
-  // TypeScript should use Rust's value directly: 0.1% (as percentage)
+  // Verify actual improvement percentage
   assertAlmostEquals(
-    expectedErrorReductionPct,
-    rustCreatureLevelImprovement * 100, // 0.1%
-    1e-6,
-    "TypeScript should use Rust's creature-level value directly without re-scaling",
-  );
-
-  // Actual improvement is 0.1% (0.584263 -> 0.5836)
-  const actualErrorDeltaPct = candidateEval.errorDeltaPct ?? 0;
-  assertAlmostEquals(
-    actualErrorDeltaPct,
-    0.1, // (0.584263 - 0.5836) / 0.584263 * 100 ≈ 0.1%
-    0.05, // Allow small tolerance
-  );
-
-  // Since Rust provides accurate creature-level values, expect close match
-  assertEquals(
-    candidateEval.expectationMismatch,
-    undefined,
-    `Expected no mismatch when Rust's creature-level estimate (${expectedErrorReductionPct}%) matches actual (${actualErrorDeltaPct}%)`,
+    candidateEval.errorDeltaPct ?? 0,
+    expectedImprovementPct,
+    0.01,
+    "actualErrorDeltaPct should match expected improvement",
   );
 });
 


### PR DESCRIPTION
…tions

- Bumped version in deno.json to 0.255.0.
- Removed the `formatExpected` function and related expected error reduction calculations from the DiscoveryRunner and FailureCache modules, streamlining the evaluation process.
- Updated README.md to reflect the removal of `formatExpected` from the exported formatting utilities.
- Adjusted tests to ensure they align with the new evaluation logic, focusing on actual improvements without reliance on expected values.

These changes enhance the clarity and efficiency of the discovery process by eliminating unnecessary calculations and simplifying the evaluation logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates expected error reduction processing across discovery, switches sorting/logging to actual deltas, updates exports/docs/tests, and bumps version to 0.255.0.
> 
> - **Discovery**:
>   - **DiscoveryRunner**:
>     - Removes `expectedErrorReductionPct` and mismatch logic; deletes expectation threshold/computation and related log text.
>     - Sorts candidates by actual `scoreDelta` and logs only actual error/score deltas.
>     - Continues archiving summaries, now without expected fields.
>   - **FailureCache**:
>     - Drops expected-improvement and error-comparison diagnostics; trims metadata and trace output to essentials (prediction details, target neuron info, actual changes).
> - **API/Exports**:
>   - Removes `formatExpected` export from `mod.ts` and corresponding formatter from `DiscoveryRunner`.
> - **Docs**:
>   - README: updates evaluation logging guidance to exclude `formatExpected`; shows `formatErrorDelta` usage only.
> - **Tests**:
>   - Updates/renames tests to assert evaluation by actual improvement percentages and behavior without expected-value logic.
> - **Version**:
>   - Bumps `deno.json` version to `0.255.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfd623c7d29963aa17131cb8fcc249e0c0947b53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->