### PR TITLE
Fix combined removal candidate not created when one removal fails (#920)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.255.0",
+  "version": "0.255.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -579,28 +579,54 @@ export function buildDiscoveryCandidates(
     if (successfulRemovals.length >= 2) {
       let combinedRemovalCreature: Creature | undefined = baseCreature;
 
-      // Apply each removal sequentially to the same creature
-      for (const candidate of successfulRemovals) {
-        if (!combinedRemovalCreature) break;
+      // Track which neurons were actually removed in the combined creature
+      // (some may fail because they were already removed by orphan cleanup)
+      const actuallyRemoved: typeof successfulRemovals = [];
 
-        combinedRemovalCreature = DiscoverStructure.removeLowImpactNeuron(
+      // Apply each removal sequentially to the same creature
+      // Issue #920 fix: Continue with remaining removals if one fails
+      for (const candidate of successfulRemovals) {
+        if (!combinedRemovalCreature) {
+          // This should not happen, but guard against it
+          console.warn(
+            `[DiscoveryCandidates] Combined removal creature became undefined unexpectedly`,
+          );
+          break;
+        }
+
+        const result = DiscoverStructure.removeLowImpactNeuron(
           discovery.ID,
           combinedRemovalCreature,
           candidate,
           discoveryFailureCacheDir,
         );
+
+        if (result) {
+          // Removal succeeded - update the creature and track the removal
+          combinedRemovalCreature = result;
+          actuallyRemoved.push(candidate);
+        }
+        // If result is undefined, skip this removal but continue with others
+        // This can happen when:
+        // - The neuron was already removed by orphan cleanup from a previous removal
+        // - The neuron no longer exists in the modified creature structure
       }
 
-      if (combinedRemovalCreature && combinedRemovalCreature !== baseCreature) {
+      // Only create combined candidate if at least 2 removals succeeded
+      if (
+        combinedRemovalCreature &&
+        combinedRemovalCreature !== baseCreature &&
+        actuallyRemoved.length >= 2
+      ) {
         // Format neuron IDs for git log message
-        const neuronIDs = successfulRemovals
+        const neuronIDs = actuallyRemoved
           .map((c) => shortID(c.neuronUUID))
           .join(", ");
 
         // Git-friendly message: clear, concise, good English
-        const description = successfulRemovals.length === 2
+        const description = actuallyRemoved.length === 2
           ? `🧹 Pruned 2 low-impact neurons in combined cleanup (${neuronIDs})`
-          : `🧹 Pruned ${successfulRemovals.length} low-impact neurons in combined cleanup`;
+          : `🧹 Pruned ${actuallyRemoved.length} low-impact neurons in combined cleanup`;
 
         candidates.push({
           creature: combinedRemovalCreature,
@@ -612,11 +638,11 @@ export function buildDiscoveryCandidates(
         });
 
         // Detailed logging for diagnostics (not in git)
-        const impactDetails = successfulRemovals
+        const impactDetails = actuallyRemoved
           .map((c) => `${shortID(c.neuronUUID)}:${c.impact.toExponential(2)}`)
           .join(", ");
         console.info(
-          `[DiscoveryCandidates] Created combined removal candidate: ${successfulRemovals.length} neurons [${impactDetails}]`,
+          `[DiscoveryCandidates] Created combined removal candidate: ${actuallyRemoved.length} neurons [${impactDetails}]`,
         );
       }
     }

--- a/test/discovery/RemovalCandidates.ts
+++ b/test/discovery/RemovalCandidates.ts
@@ -375,6 +375,129 @@ Deno.test("buildDiscoveryCandidates uses crippled-removal.json for near-zero wei
 });
 
 /**
+ * Test for issue #920: Combined removal candidate should be created even if
+ * one removal fails during sequential application.
+ *
+ * When building a combined removal candidate, if one neuron was already removed
+ * as part of orphan cleanup from a previous removal, the loop should continue
+ * with remaining removals rather than aborting entirely.
+ *
+ * Expected: 42 individual + 1 combined = 43 total removal candidates
+ * Bug: Only 42 created because combined candidate loop breaks on first failure
+ */
+Deno.test("combined removal candidate should be created when some removals fail", () => {
+  // Create a creature where neuron A connects only to neuron B.
+  // The order in removalCandidates is [B, A, C]:
+  // - When B is removed first in the combined loop, A becomes orphaned and is cleaned up
+  // - When we try to remove A second, it fails (already removed by orphan cleanup)
+  // - The bug causes the loop to break, missing C
+  // - The fix should skip A and continue with C
+  const baseCreature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden",
+        squash: "RELU",
+        bias: 0.1,
+        uuid: "neuron-A-connects-only-to-B",
+      },
+      {
+        type: "hidden",
+        squash: "RELU",
+        bias: 0.2,
+        uuid: "neuron-B-target-of-A",
+      },
+      {
+        type: "hidden",
+        squash: "RELU",
+        bias: 0.3,
+        uuid: "neuron-C-independent",
+      },
+      { type: "output", squash: "IDENTITY", bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      // A connects only to B (so A becomes orphaned when B is removed)
+      {
+        fromUUID: "input-0",
+        toUUID: "neuron-A-connects-only-to-B",
+        weight: 0.1,
+      },
+      {
+        fromUUID: "neuron-A-connects-only-to-B",
+        toUUID: "neuron-B-target-of-A",
+        weight: 0.1,
+      },
+      // B connects to output
+      { fromUUID: "neuron-B-target-of-A", toUUID: "output-0", weight: 0.1 },
+      // C is independent - connects input to output
+      { fromUUID: "input-1", toUUID: "neuron-C-independent", weight: 0.1 },
+      { fromUUID: "neuron-C-independent", toUUID: "output-0", weight: 0.1 },
+    ],
+  });
+
+  // Order matters: B first (which orphans A), then A (which fails), then C
+  const discovery: DiscoverResult = {
+    ID: "issue-920-test",
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: undefined,
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: [
+      // B is removed first - this orphans A
+      {
+        neuronUUID: "neuron-B-target-of-A",
+        totalError: 0.001,
+        impact: 1e-10,
+        reason: "Low impact",
+      },
+      // A is removed second - should fail because it was already removed by orphan cleanup
+      {
+        neuronUUID: "neuron-A-connects-only-to-B",
+        totalError: 0.001,
+        impact: 1e-10,
+        reason: "Low impact",
+      },
+      // C is independent and should still be removed
+      {
+        neuronUUID: "neuron-C-independent",
+        totalError: 0.001,
+        impact: 1e-10,
+        reason: "Low impact",
+      },
+    ],
+    candidateSquashes: undefined,
+  };
+
+  const candidates = buildDiscoveryCandidates(baseCreature, discovery);
+
+  const removalCandidates = candidates.filter(
+    (c) => c.change.type === "remove-low-impact",
+  );
+
+  // Should have 3 individual + 1 combined = 4 candidates
+  // The bug was: only 3 created because the combined candidate wasn't built
+  // when removing A fails (A was already removed during B's orphan cleanup)
+  assertEquals(
+    removalCandidates.length >= 4,
+    true,
+    `Should create at least 4 removal candidates (3 individual + 1 combined), got ${removalCandidates.length}`,
+  );
+
+  // Find the combined candidate (description contains "combined" or "Pruned")
+  const combinedCandidate = removalCandidates.find(
+    (c) =>
+      c.change.description?.includes("combined") ||
+      c.change.description?.includes("Pruned"),
+  );
+
+  assertExists(
+    combinedCandidate,
+    "Should create a combined removal candidate even if some removals fail",
+  );
+});
+
+/**
  * Test for issue #912: removeLowImpactNeuron should clean up memetic data
  * when removing a neuron that is referenced in the memetic weights/biases.
  *


### PR DESCRIPTION
When building a combined removal candidate from multiple successful individual removals, if one removal failed during sequential application (e.g., because the neuron was already removed by orphan cleanup from a previous removal), the loop would break and no combined candidate was created.

The fix continues with remaining removals when one fails and only creates the combined candidate if at least 2 removals succeeded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Continue combined low‑impact neuron removals when some fail and create the combined candidate from those that succeeded; add test and bump patch version.
> 
> - **Discovery logic (`src/discovery/DiscoveryCandidates.ts`)**:
>   - Build combined `remove-low-impact` candidate by continuing when an individual removal returns `undefined` and tracking `actuallyRemoved` neurons.
>   - Only emit combined candidate if ≥2 removals succeeded; update descriptions/logging to reflect actual removals.
>   - Add guard/logging when combined creature unexpectedly becomes `undefined`.
> - **Tests (`test/discovery/RemovalCandidates.ts`)**:
>   - Add regression test for issue `#920` verifying a combined removal candidate is still created when some sequential removals fail.
> - **Version**:
>   - Bump `deno.json` version from `0.255.0` to `0.255.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98b8c56a822b3159d380b8d73ba5ab41ecd296a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->