### PR TITLE
Add neuronCandidate to DiscoveryCandidateChange and update FailureCac…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.256.0",
+  "version": "0.256.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -100,6 +100,8 @@ interface DiscoveryCandidateChange {
   synapseDetails?: SynapseRemovalDetails;
   /** Original Rust synapse candidate response (for add-synapses candidates). */
   synapseCandidate?: CandidateSynapse;
+  /** Original Rust neuron candidate response (for add-neurons candidates). */
+  neuronCandidate?: CandidateNeuron;
   /** Original Rust squash candidate response (for change-squash candidates). */
   squashCandidate?: CandidateSquash;
   /** Original Rust removal candidate response (for remove-low-impact candidates). */
@@ -860,6 +862,8 @@ function buildSingleNeuronCandidates(
           bias: neuron.bias,
           squash: neuron.squash,
         },
+        // Store the full Rust neuron candidate for failure cache debugging
+        neuronCandidate: neuron,
       },
     });
   }

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -641,6 +641,15 @@ export async function recordFailure(
       };
     }
 
+    // Include full Rust neuron candidate (for add-neurons candidates)
+    // This includes expectedImprovementPercentage, improvedCount, totalCount, targetNeuronStats
+    if (candidate.change.neuronCandidate) {
+      cacheEntry.rustRequest = {
+        ...((cacheEntry.rustRequest as Record<string, unknown>) ?? {}),
+        neuronCandidate: candidate.change.neuronCandidate,
+      };
+    }
+
     // Include original Rust synapse candidate (for add-synapses candidates)
     if (candidate.change.synapseCandidate) {
       cacheEntry.rustRequest = {
@@ -791,6 +800,15 @@ export function recordFailureSync(
     if (candidate.change.neuronDetails) {
       cacheEntry.rustRequest = {
         neuronDetails: candidate.change.neuronDetails,
+      };
+    }
+
+    // Include full Rust neuron candidate (for add-neurons candidates)
+    // This includes expectedImprovementPercentage, improvedCount, totalCount, targetNeuronStats
+    if (candidate.change.neuronCandidate) {
+      cacheEntry.rustRequest = {
+        ...((cacheEntry.rustRequest as Record<string, unknown>) ?? {}),
+        neuronCandidate: candidate.change.neuronCandidate,
       };
     }
 


### PR DESCRIPTION
…he for enhanced debugging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stores full Rust neuron candidate on add-neuron changes and persists it in failure cache entries to aid diagnostics.
> 
> - **Discovery**:
>   - Extend `DiscoveryCandidateChange` with `neuronCandidate` (full Rust response for add-neurons).
>   - Populate `change.neuronCandidate` in single add-neuron candidates in `buildSingleNeuronCandidates()`.
> - **Failure Cache**:
>   - Persist `neuronCandidate` under `rustRequest` in `recordFailure()` and `recordFailureSync()` when present.
> - **Version**:
>   - Bump `deno.json` version to `0.256.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 829f1778ba0bed68cb26b7461e30317d3e7241b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->