### PR TITLE
Update version to 0.259.1 and enhance discovery issue recording

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.259.0",
+  "version": "0.259.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -3845,6 +3845,95 @@ export class DiscoverStructure {
   }
 
   /**
+   * Records a discovery issue to the issues subdirectory for debugging.
+   *
+   * This is used for cases where the creature may still validate, but the discovery
+   * candidate is logically broken for our forward-pass evaluation ordering (eg,
+   * a candidate proposes a from → to link where the "from" neuron is after the
+   * target neuron in the evaluation order, making the new neuron's activation
+   * effectively zero at that stage).
+   *
+   * @param originalCreature - The original creature before modifications.
+   * @param discoveryID - Unique identifier for the discovery process.
+   * @param operationType - Type of operation (eg, "add-neurons").
+   * @param issueType - Short discriminator for the issue kind.
+   * @param details - JSON-serialisable diagnostic payload.
+   * @param discoveryFailureCacheDir - Base directory for the failure cache.
+   */
+  private static recordDiscoveryIssue(
+    originalCreature: Creature,
+    discoveryID: string,
+    operationType: string,
+    issueType: string,
+    details: unknown,
+    discoveryFailureCacheDir: string,
+  ): void {
+    try {
+      // Create timestamp in Australian format (yyyymmdd-HHmmss)
+      const now = new Date();
+      const timestamp = now.toISOString()
+        .replace(/[-:]/g, "")
+        .replace("T", "-")
+        .slice(0, 15);
+
+      const issueDir = join(
+        discoveryFailureCacheDir,
+        "issues",
+        `${timestamp}-${discoveryID}-${operationType}-${issueType}`,
+      );
+      ensureDirSync(issueDir);
+
+      const detailsPath = join(issueDir, "candidate.json");
+      Deno.writeTextFileSync(detailsPath, JSON.stringify(details, null, 2));
+
+      const originalPath = join(issueDir, "original-creature.json");
+      Deno.writeTextFileSync(
+        originalPath,
+        JSON.stringify(originalCreature.exportJSON(), null, 2),
+      );
+
+      const errorPath = join(issueDir, "error.txt");
+      const detailsRecord = details as Record<string, unknown> | null;
+      const message =
+        detailsRecord && typeof detailsRecord["message"] === "string"
+          ? detailsRecord["message"]
+          : undefined;
+      const fromIndex =
+        detailsRecord && typeof detailsRecord["fromIndex"] === "number"
+          ? detailsRecord["fromIndex"]
+          : undefined;
+      const targetIndex = detailsRecord &&
+          typeof detailsRecord["targetIndex"] === "number"
+        ? detailsRecord["targetIndex"]
+        : undefined;
+      const errorContent = [
+        `Discovery Issue Report`,
+        `======================`,
+        ``,
+        `Timestamp: ${now.toISOString()}`,
+        `Discovery ID: ${discoveryID}`,
+        `Operation Type: ${operationType}`,
+        `Issue Type: ${issueType}`,
+        ``,
+        `Summary: Candidate is incompatible with forward-pass evaluation ordering.`,
+        message ? `Message: ${message}` : undefined,
+        fromIndex !== undefined ? `fromIndex: ${fromIndex}` : undefined,
+        targetIndex !== undefined ? `targetIndex: ${targetIndex}` : undefined,
+      ].filter((line) => line !== undefined).join("\n");
+      Deno.writeTextFileSync(errorPath, errorContent);
+
+      console.warn(
+        `[Discovery ${discoveryID}] Discovery issue recorded to: ${issueDir}`,
+      );
+    } catch (recordError) {
+      // Don't let recording failure prevent the main flow
+      console.error(
+        `[Discovery ${discoveryID}] Failed to record discovery issue: ${recordError}`,
+      );
+    }
+  }
+
+  /**
    * Removes a synapse from the creature if it is determined to be harmful.
    * This method is used to prune synapses that consistently worsen prediction error.
    * @param ID - Unique identifier for the discovery process.
@@ -4110,6 +4199,52 @@ export class DiscoverStructure {
         return neuron.uuid === candidate.toNeuronUUID;
       });
       if (!targetNeuron) return;
+
+      // Guard: ensure the source neuron is evaluated before the target neuron.
+      //
+      // This should always be true for Rust-proposed add-neuron candidates in a
+      // feed-forward creature. If it isn't, the new neuron's activation will be
+      // computed before its inputs are available, making the mutation ineffective
+      // (activation looks like zero at that stage).
+      const fromIndex = candidate.fromNeuronUUID.startsWith("input-")
+        ? -1
+        : exportJSON.neurons.findIndex((n) =>
+          n.uuid === candidate.fromNeuronUUID
+        );
+      const toIndex = exportJSON.neurons.findIndex((n) =>
+        n.uuid === candidate.toNeuronUUID
+      );
+
+      if (fromIndex >= 0 && toIndex >= 0 && fromIndex >= toIndex) {
+        const summary =
+          `from neuron must be before target neuron (fromIndex=${fromIndex}, targetIndex=${toIndex})`;
+        console.warn(
+          `[Discovery ${ID}] addHelpfulNeurons: Skipping candidate ${candidate.fromNeuronUUID} -> ${candidate.toNeuronUUID}: ${summary}`,
+        );
+
+        if (discoveryFailureCacheDir) {
+          this.recordDiscoveryIssue(
+            creature,
+            ID,
+            "add-neurons",
+            "ordering",
+            {
+              message: summary,
+              fromNeuronUUID: candidate.fromNeuronUUID,
+              toNeuronUUID: candidate.toNeuronUUID,
+              fromIndex,
+              targetIndex: toIndex,
+              candidate,
+              neuronOrder: exportJSON.neurons.map((n) => ({
+                uuid: n.uuid,
+                type: n.type,
+              })),
+            },
+            discoveryFailureCacheDir,
+          );
+        }
+        return;
+      }
 
       const newNeuronUUID =
         `hidden-discovery-${(globalThis.crypto?.randomUUID?.() ??

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -1566,10 +1566,43 @@ function applyChangeToCreature(
         );
         if (candidateNeurons.length === 0) return creature;
 
-        // Insert neurons before outputs
-        const outputCount = creatureJSON.output ?? 1;
-        const outputOffset = creatureJSON.neurons.length - outputCount;
-        creatureJSON.neurons.splice(outputOffset, 0, ...candidateNeurons);
+        // Insert each neuron in a forward-pass-safe position.
+        //
+        // For add-neurons candidates, the new neuron typically connects to an
+        // existing target neuron (new -> target). If we insert the new neuron
+        // after that target, the target can't receive its activation in the same
+        // forward pass (effectively zero at that stage).
+        for (const neuron of candidateNeurons) {
+          const outgoing = candidateJSON.synapses.find((s) =>
+            s.fromUUID === neuron.uuid
+          );
+          const targetUUID = outgoing?.toUUID;
+          const targetIndex = targetUUID
+            ? creatureJSON.neurons.findIndex((n) => n.uuid === targetUUID)
+            : -1;
+          const firstOutputIndex = creatureJSON.neurons.findIndex((n) =>
+            n.type === "output"
+          );
+
+          if (targetIndex >= 0) {
+            const target = creatureJSON.neurons[targetIndex];
+            if (target.type === "output") {
+              // Keep outputs contiguous at the end of the list.
+              if (firstOutputIndex >= 0) {
+                creatureJSON.neurons.splice(firstOutputIndex, 0, neuron);
+              } else {
+                creatureJSON.neurons.push(neuron);
+              }
+            } else {
+              // Hidden target: must be before the target neuron.
+              creatureJSON.neurons.splice(targetIndex, 0, neuron);
+            }
+          } else if (firstOutputIndex >= 0) {
+            creatureJSON.neurons.splice(firstOutputIndex, 0, neuron);
+          } else {
+            creatureJSON.neurons.push(neuron);
+          }
+        }
 
         // Update existing neurons set to include newly added neurons and input neurons
         const updatedNeurons = new Set(

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -1566,43 +1566,77 @@ function applyChangeToCreature(
         );
         if (candidateNeurons.length === 0) return creature;
 
-        // Insert each neuron in a forward-pass-safe position.
+        // Insert new neurons in a forward-pass-safe position based on the *candidate*
+        // neurone ordering (not by guessing from a single outgoing synapse).
         //
-        // For add-neurons candidates, the new neuron typically connects to an
-        // existing target neuron (new -> target). If we insert the new neuron
-        // after that target, the target can't receive its activation in the same
-        // forward pass (effectively zero at that stage).
-        for (const neuron of candidateNeurons) {
-          const outgoing = candidateJSON.synapses.find((s) =>
-            s.fromUUID === neuron.uuid
-          );
-          const targetUUID = outgoing?.toUUID;
-          const targetIndex = targetUUID
-            ? creatureJSON.neurons.findIndex((n) => n.uuid === targetUUID)
-            : -1;
-          const firstOutputIndex = creatureJSON.neurons.findIndex((n) =>
+        // Why: a new neuron may target another new neuron (new -> new), or it may
+        // have multiple outgoing targets. In those cases, inserting each neuron by
+        // looking up only one outgoing target in the current creature can create a
+        // backward edge (fromIndex > toIndex), breaking forward-pass ordering.
+        //
+        // Strategy: keep the existing neurone list intact and splice in the newly
+        // added neurons as ordered blocks before their next non-new "anchor" neurone
+        // in the candidate list. This preserves the candidate creature's ordering
+        // constraints while also retaining any neurons introduced by earlier steps
+        // in a combination.
+        const newNeuronUUIDs = new Set(candidateNeurons.map((n) => n.uuid));
+        const candidateNewNeuronMap = new Map(
+          candidateNeurons.map((n) => [n.uuid, n] as const),
+        );
+        const END_ANCHOR = "__END__";
+
+        const anchorToNewNeurons = new Map<string, typeof candidateNeurons>();
+        const candidateUUIDs = candidateJSON.neurons.map((n) => n.uuid);
+        for (let i = 0; i < candidateUUIDs.length; i++) {
+          const uuid = candidateUUIDs[i];
+          if (!newNeuronUUIDs.has(uuid)) continue;
+
+          let anchorUUID: string | undefined;
+          for (let j = i + 1; j < candidateUUIDs.length; j++) {
+            const nextUUID = candidateUUIDs[j];
+            if (!newNeuronUUIDs.has(nextUUID)) {
+              anchorUUID = nextUUID;
+              break;
+            }
+          }
+
+          const key = anchorUUID ?? END_ANCHOR;
+          const neuron = candidateNewNeuronMap.get(uuid);
+          if (!neuron) continue;
+          const list = anchorToNewNeurons.get(key) ?? [];
+          list.push(neuron);
+          anchorToNewNeurons.set(key, list);
+        }
+
+        const inserted = new Set<string>();
+        const mergedNeurons: typeof creatureJSON.neurons = [];
+        for (const neuron of creatureJSON.neurons) {
+          const toInsert = anchorToNewNeurons.get(neuron.uuid);
+          if (toInsert && toInsert.length > 0) {
+            for (const newNeuron of toInsert) {
+              if (inserted.has(newNeuron.uuid)) continue;
+              mergedNeurons.push(newNeuron);
+              inserted.add(newNeuron.uuid);
+            }
+          }
+          mergedNeurons.push(neuron);
+        }
+
+        // Any remaining new neurons (eg, anchor was removed by a prior combo step)
+        // are inserted before the first output to keep outputs contiguous.
+        const remaining = candidateNeurons.filter((n) => !inserted.has(n.uuid));
+        if (remaining.length > 0) {
+          const firstOutputIndex = mergedNeurons.findIndex((n) =>
             n.type === "output"
           );
-
-          if (targetIndex >= 0) {
-            const target = creatureJSON.neurons[targetIndex];
-            if (target.type === "output") {
-              // Keep outputs contiguous at the end of the list.
-              if (firstOutputIndex >= 0) {
-                creatureJSON.neurons.splice(firstOutputIndex, 0, neuron);
-              } else {
-                creatureJSON.neurons.push(neuron);
-              }
-            } else {
-              // Hidden target: must be before the target neuron.
-              creatureJSON.neurons.splice(targetIndex, 0, neuron);
-            }
-          } else if (firstOutputIndex >= 0) {
-            creatureJSON.neurons.splice(firstOutputIndex, 0, neuron);
-          } else {
-            creatureJSON.neurons.push(neuron);
-          }
+          const insertAt = firstOutputIndex >= 0
+            ? firstOutputIndex
+            : mergedNeurons.length;
+          mergedNeurons.splice(insertAt, 0, ...remaining);
+          for (const neuron of remaining) inserted.add(neuron.uuid);
         }
+
+        creatureJSON.neurons = mergedNeurons;
 
         // Update existing neurons set to include newly added neurons and input neurons
         const updatedNeurons = new Set(
@@ -1615,7 +1649,6 @@ function applyChangeToCreature(
 
         // Find synapses connected to these new neurons
         // Only include synapses where BOTH endpoints exist in current creature
-        const newNeuronUUIDs = new Set(candidateNeurons.map((n) => n.uuid));
         const newSynapses = candidateJSON.synapses.filter(
           (s) =>
             (newNeuronUUIDs.has(s.fromUUID) || newNeuronUUIDs.has(s.toUUID)) &&

--- a/test/ErrorGuidedStructuralEvolution/ValidateAndFixIfNeeded.ts
+++ b/test/ErrorGuidedStructuralEvolution/ValidateAndFixIfNeeded.ts
@@ -7,7 +7,7 @@
  * 3. Validation issues are recorded to the issues subdirectory when discoveryFailureCacheDir is set
  */
 
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import {
@@ -210,6 +210,80 @@ Deno.test({
       // A full integration test would need to trigger an actual validation failure
     } finally {
       // Clean up temporary directory
+      try {
+        await Deno.remove(tempDir, { recursive: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "addHelpfulNeurons records an issue when from neuron is after target neuron",
+  permissions: {
+    read: true,
+    write: true,
+    ffi: false,
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const tempDir = await Deno.makeTempDir({ prefix: "neat_test_ordering_" });
+    const issuesDir = join(tempDir, "issues");
+
+    try {
+      const creature = makeTestCreature();
+
+      const result = DiscoverStructure.addHelpfulNeurons(
+        "test-ordering-id",
+        creature,
+        [{
+          // This ordering is invalid for our forward-pass evaluation because
+          // hidden-1 appears after hidden-0 in the neuron list.
+          fromNeuronUUID: "hidden-1",
+          toNeuronUUID: "hidden-0",
+          incomingWeight: 0.5,
+          outgoingWeight: 0.5,
+          squash: IDENTITY.NAME,
+          bias: 0.1,
+          targetNeuronImpact: 1.0,
+          expectedCreatureErrorReduction: 0,
+          expectedCreatureScoreGain: 0.05,
+          improvedCount: 10,
+          totalCount: 20,
+        }],
+        tempDir,
+      );
+
+      assertEquals(
+        result,
+        undefined,
+        "Expected addHelpfulNeurons to skip invalid ordering candidate",
+      );
+
+      const issueDirs: string[] = [];
+      for await (const entry of Deno.readDir(issuesDir)) {
+        if (entry.isDirectory) issueDirs.push(entry.name);
+      }
+
+      assert(
+        issueDirs.length >= 1,
+        `Expected at least one issue directory under ${issuesDir}`,
+      );
+
+      // Validate the recorded issue has an error report for quick triage.
+      const issueDir = join(issuesDir, issueDirs.sort().at(-1)!);
+      const errorPath = join(issueDir, "error.txt");
+      const errorText = await Deno.readTextFile(errorPath);
+      assert(
+        errorText.includes("from neuron must be before target neuron") ||
+          errorText.includes("fromIndex") ||
+          errorText.includes("targetIndex"),
+        `Expected issue error.txt to contain ordering diagnostics. Got:\n${errorText}`,
+      );
+    } finally {
       try {
         await Deno.remove(tempDir, { recursive: true });
       } catch {

--- a/test/discovery/CombinedCandidateSequentialApplication.ts
+++ b/test/discovery/CombinedCandidateSequentialApplication.ts
@@ -260,6 +260,120 @@ Deno.test(
 );
 
 Deno.test(
+  "buildCombinedFromSuccessful: add-neurons chain keeps new neurons in candidate order (new -> new -> existing)",
+  () => {
+    const base = makeTestCreature();
+    const baseJSON = base.exportJSON();
+
+    // Create "add-neurons" candidate: adds hidden-D -> hidden-E -> hidden-A chain.
+    //
+    // Both hidden-D and hidden-E are new neurons. The merge logic must keep:
+    // hidden-D before hidden-E before hidden-A, otherwise hidden-D -> hidden-E
+    // becomes a backward edge and breaks forward-pass ordering.
+    const addNeuronsJSON = structuredClone(baseJSON);
+    const targetIndex = addNeuronsJSON.neurons.findIndex((n) =>
+      n.uuid === "hidden-A"
+    );
+    assert(targetIndex >= 0, "Expected hidden-A to exist in base creature");
+
+    // Insert the chain in the intended (candidate) order.
+    addNeuronsJSON.neurons.splice(
+      targetIndex,
+      0,
+      {
+        type: "hidden",
+        uuid: "hidden-D",
+        squash: "TANH",
+        bias: 0.11,
+      },
+      {
+        type: "hidden",
+        uuid: "hidden-E",
+        squash: "TANH",
+        bias: 0.12,
+      },
+    );
+
+    addNeuronsJSON.synapses.push(
+      { fromUUID: "input-0", toUUID: "hidden-D", weight: 0.4 },
+      { fromUUID: "hidden-D", toUUID: "hidden-E", weight: 0.35 },
+      { fromUUID: "hidden-E", toUUID: "hidden-A", weight: 0.3 },
+    );
+
+    const addNeuronsCreature = Creature.fromJSON(addNeuronsJSON);
+    delete addNeuronsCreature.uuid;
+    addNeuronsCreature.fix();
+    CreatureUtil.makeUUID(addNeuronsCreature);
+
+    const addNeuronsCandidate: DiscoveryCandidate = {
+      creature: addNeuronsCreature,
+      change: {
+        type: "add-neurons",
+        description: "Added hidden-D -> hidden-E -> hidden-A chain",
+      },
+    };
+
+    // Second candidate so buildCombinedFromSuccessful produces combinations.
+    const removeSynapseJSON = structuredClone(baseJSON);
+    removeSynapseJSON.synapses = removeSynapseJSON.synapses.filter(
+      (s) => !(s.fromUUID === "hidden-A" && s.toUUID === "hidden-C"),
+    );
+    removeSynapseJSON.synapses.push({
+      fromUUID: "hidden-A",
+      toUUID: "output-0",
+      weight: 0.25,
+    });
+    const removeSynapseCreature = Creature.fromJSON(removeSynapseJSON);
+    delete removeSynapseCreature.uuid;
+    removeSynapseCreature.fix();
+    CreatureUtil.makeUUID(removeSynapseCreature);
+
+    const removeSynapseCandidate: DiscoveryCandidate = {
+      creature: removeSynapseCreature,
+      change: {
+        type: "remove-synapse",
+        description: "Removed hidden-A -> hidden-C synapse",
+        synapseDetails: {
+          fromNeuronUUID: "hidden-A",
+          toNeuronUUID: "hidden-C",
+        },
+      },
+    };
+
+    const combined = buildCombinedFromSuccessful(
+      base,
+      "TEST_DISCOVERY",
+      [addNeuronsCandidate, removeSynapseCandidate],
+    );
+
+    assert(combined.length > 0, "Should produce combined candidates");
+    const combo = combined.find((c) => c.change.type === "combo-successful");
+    assertExists(combo, "Should have a combo-successful candidate");
+
+    const comboJSON = combo.creature.exportJSON();
+    const indexOf = (uuid: string) =>
+      comboJSON.neurons.findIndex((n) => n.uuid === uuid);
+
+    const dIndex = indexOf("hidden-D");
+    const eIndex = indexOf("hidden-E");
+    const aIndex = indexOf("hidden-A");
+
+    assert(dIndex >= 0, "Expected hidden-D to exist in combined creature");
+    assert(eIndex >= 0, "Expected hidden-E to exist in combined creature");
+    assert(aIndex >= 0, "Expected hidden-A to exist in combined creature");
+
+    assert(
+      dIndex < eIndex,
+      `Expected hidden-D (index ${dIndex}) to be before hidden-E (index ${eIndex})`,
+    );
+    assert(
+      eIndex < aIndex,
+      `Expected hidden-E (index ${eIndex}) to be before hidden-A (index ${aIndex})`,
+    );
+  },
+);
+
+Deno.test(
   "buildCombinedFromSuccessful: add-synapses + remove-synapse preserves added synapses",
   () => {
     const base = makeTestCreature();

--- a/test/discovery/CombinedCandidateSequentialApplication.ts
+++ b/test/discovery/CombinedCandidateSequentialApplication.ts
@@ -164,6 +164,102 @@ Deno.test(
 );
 
 Deno.test(
+  "buildCombinedFromSuccessful: add-neurons targeting hidden neuron keeps new neuron before target",
+  () => {
+    const base = makeTestCreature();
+    const baseJSON = base.exportJSON();
+
+    // Create "add-neurons" candidate: adds hidden-D and targets hidden-A (a hidden neuron).
+    // The new neuron must be inserted BEFORE hidden-A; otherwise hidden-A can't receive
+    // hidden-D's activation during the forward pass.
+    const addNeuronsJSON = structuredClone(baseJSON);
+    const targetIndex = addNeuronsJSON.neurons.findIndex((n) =>
+      n.uuid === "hidden-A"
+    );
+    assert(targetIndex >= 0, "Expected hidden-A to exist in base creature");
+
+    addNeuronsJSON.neurons.splice(targetIndex, 0, {
+      type: "hidden",
+      uuid: "hidden-D",
+      squash: "TANH",
+      bias: 0.15,
+    });
+    addNeuronsJSON.synapses.push(
+      { fromUUID: "input-0", toUUID: "hidden-D", weight: 0.4 },
+      { fromUUID: "hidden-D", toUUID: "hidden-A", weight: 0.4 },
+    );
+    const addNeuronsCreature = Creature.fromJSON(addNeuronsJSON);
+    delete addNeuronsCreature.uuid;
+    addNeuronsCreature.fix();
+    CreatureUtil.makeUUID(addNeuronsCreature);
+
+    const addNeuronsCandidate: DiscoveryCandidate = {
+      creature: addNeuronsCreature,
+      change: {
+        type: "add-neurons",
+        description: "Added hidden-D neuron targeting hidden-A",
+      },
+    };
+
+    // Second candidate so buildCombinedFromSuccessful produces combinations.
+    // Use remove-synapse to keep the structure change simple.
+    const removeSynapseJSON = structuredClone(baseJSON);
+    removeSynapseJSON.synapses = removeSynapseJSON.synapses.filter(
+      (s) => !(s.fromUUID === "hidden-B" && s.toUUID === "hidden-C"),
+    );
+    // Reconnect hidden-B directly to output
+    removeSynapseJSON.synapses.push({
+      fromUUID: "hidden-B",
+      toUUID: "output-0",
+      weight: 0.25,
+    });
+    const removeSynapseCreature = Creature.fromJSON(removeSynapseJSON);
+    delete removeSynapseCreature.uuid;
+    removeSynapseCreature.fix();
+    CreatureUtil.makeUUID(removeSynapseCreature);
+
+    const removeSynapseCandidate: DiscoveryCandidate = {
+      creature: removeSynapseCreature,
+      change: {
+        type: "remove-synapse",
+        description: "Removed hidden-B -> hidden-C synapse",
+        synapseDetails: {
+          fromNeuronUUID: "hidden-B",
+          toNeuronUUID: "hidden-C",
+        },
+      },
+    };
+
+    const combined = buildCombinedFromSuccessful(
+      base,
+      "TEST_DISCOVERY",
+      [addNeuronsCandidate, removeSynapseCandidate],
+    );
+
+    assert(combined.length > 0, "Should produce combined candidates");
+    const combo = combined.find((c) => c.change.type === "combo-successful");
+    assertExists(combo, "Should have a combo-successful candidate");
+
+    const comboJSON = combo.creature.exportJSON();
+    const indexOf = (uuid: string) =>
+      comboJSON.neurons.findIndex((n) => n.uuid === uuid);
+
+    const newIndex = indexOf("hidden-D");
+    const targetHiddenIndex = indexOf("hidden-A");
+    assert(newIndex >= 0, "Expected hidden-D to exist in combined creature");
+    assert(
+      targetHiddenIndex >= 0,
+      "Expected hidden-A to exist in combined creature",
+    );
+
+    assert(
+      newIndex < targetHiddenIndex,
+      `Expected hidden-D (index ${newIndex}) to be before hidden-A (index ${targetHiddenIndex})`,
+    );
+  },
+);
+
+Deno.test(
   "buildCombinedFromSuccessful: add-synapses + remove-synapse preserves added synapses",
   () => {
     const base = makeTestCreature();


### PR DESCRIPTION
- Bumped version in deno.json to 0.259.1.
- Introduced a new method to record discovery issues for cases where neuron ordering is invalid, improving debugging capabilities.
- Updated neuron insertion logic to ensure new neurons are placed correctly relative to target neurons, preventing structural violations.
- Added tests to verify that discovery issues are recorded appropriately when neuron ordering is incorrect.

These changes aim to improve the robustness of the discovery process by enhancing error tracking and ensuring proper neuron placement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces forward-pass-safe add-neuron behavior with issue recording, updates combo merge to preserve candidate neuron ordering, and adds tests; bumps version to 0.259.1.
> 
> - **Discovery (core)**:
>   - Add `recordDiscoveryIssue()` to persist non-fatal discovery issues under `issues/`.
>   - In `addHelpfulNeurons`, guard against invalid source→target ordering; skip and record `ordering` issue with diagnostics.
> - **Discovery (combination logic)**:
>   - In `DiscoveryCandidates.applyChangeToCreature('add-neurons')`, insert new neurons based on candidate ordering via anchor blocks, preserving forward-pass order and output contiguity; include only synapses whose endpoints still exist (incl. `input-*`).
> - **Tests**:
>   - Add ordering-issue test for `addHelpfulNeurons` (writes `error.txt`).
>   - Add combo tests ensuring: new-before-target placement; multi-new chains keep order; reconnection synapses (incl. from inputs) are preserved; combo descriptions use proper wording/emojis.
> - **Version**:
>   - Bump `deno.json` version to `0.259.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c530ed7d0e09bc56e65039d7cc0689bb132e997e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->