### PR TITLE
Refactor buildDiscoveryCandidates to remove combined candidate logic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.259.1",
+  "version": "0.259.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -501,8 +501,6 @@ export function buildDiscoveryCandidates(
   //   - Verify with actual activation data before removal
   //   - Consider average activation magnitude in addition to structural impact
   const { removalCandidates } = discovery;
-  // Track successfully removed candidates for combined removal
-  const successfulRemovals: typeof removalCandidates = [];
 
   if (removalCandidates && removalCandidates.length > 0) {
     let removalSuccessCount = 0;
@@ -529,7 +527,6 @@ export function buildDiscoveryCandidates(
       );
       if (removedLowImpactCreature) {
         removalSuccessCount++;
-        successfulRemovals.push(candidate);
         candidates.push({
           creature: removedLowImpactCreature,
           change: {
@@ -586,80 +583,6 @@ export function buildDiscoveryCandidates(
             testNeuronMatches.map((c) =>
               `${c.neuronUUID}:${c.impact.toExponential(2)}`
             ).join(", "),
-        );
-      }
-    }
-
-    // Build a COMBINED removal candidate that removes ALL successful candidates at once
-    // This allows cleaning up multiple low-impact neurons in a single operation
-    // The combined version competes with individual removals - best score wins
-    if (successfulRemovals.length >= 2) {
-      let combinedRemovalCreature: Creature | undefined = baseCreature;
-
-      // Track which neurons were actually removed in the combined creature
-      // (some may fail because they were already removed by orphan cleanup)
-      const actuallyRemoved: typeof successfulRemovals = [];
-
-      // Apply each removal sequentially to the same creature
-      // Issue #920 fix: Continue with remaining removals if one fails
-      for (const candidate of successfulRemovals) {
-        if (!combinedRemovalCreature) {
-          // This should not happen, but guard against it
-          console.warn(
-            `[DiscoveryCandidates] Combined removal creature became undefined unexpectedly`,
-          );
-          break;
-        }
-
-        const result = DiscoverStructure.removeLowImpactNeuron(
-          discovery.ID,
-          combinedRemovalCreature,
-          candidate,
-          discoveryFailureCacheDir,
-        );
-
-        if (result) {
-          // Removal succeeded - update the creature and track the removal
-          combinedRemovalCreature = result;
-          actuallyRemoved.push(candidate);
-        }
-        // If result is undefined, skip this removal but continue with others
-        // This can happen when:
-        // - The neuron was already removed by orphan cleanup from a previous removal
-        // - The neuron no longer exists in the modified creature structure
-      }
-
-      // Only create combined candidate if at least 2 removals succeeded
-      if (
-        combinedRemovalCreature &&
-        combinedRemovalCreature !== baseCreature &&
-        actuallyRemoved.length >= 2
-      ) {
-        // Format neuron IDs for git log message
-        const neuronIDs = actuallyRemoved
-          .map((c) => shortID(c.neuronUUID))
-          .join(", ");
-
-        // Git-friendly message: clear, concise, good English
-        const description = actuallyRemoved.length === 2
-          ? `🧹 Pruned 2 low-impact neurons in combined cleanup (${neuronIDs})`
-          : `🧹 Pruned ${actuallyRemoved.length} low-impact neurons in combined cleanup`;
-
-        candidates.push({
-          creature: combinedRemovalCreature,
-          change: {
-            type: "remove-low-impact",
-            description,
-            // No expectedErrorReduction - removal improves score via complexity reduction, not error
-          },
-        });
-
-        // Detailed logging for diagnostics (not in git)
-        const impactDetails = actuallyRemoved
-          .map((c) => `${shortID(c.neuronUUID)}:${c.impact.toExponential(2)}`)
-          .join(", ");
-        console.info(
-          `[DiscoveryCandidates] Created combined removal candidate: ${actuallyRemoved.length} neurons [${impactDetails}]`,
         );
       }
     }

--- a/test/discovery/DiscoveryCandidates.ts
+++ b/test/discovery/DiscoveryCandidates.ts
@@ -1118,3 +1118,56 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "buildDiscoveryCandidates does not build combined removal candidates during Phase 1 (skipCombinedCandidates)",
+  () => {
+    const base = makeBaselineCreature();
+    const discovery: DiscoverResult = {
+      ID: "REMOVAL-SKIP-COMBOS",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      candidateSquashes: undefined,
+      removalCandidates: [
+        {
+          neuronUUID: "hidden-1",
+          totalError: 0,
+          impact: 1e-11,
+          reason: "test-removal-1",
+        },
+        {
+          neuronUUID: "hidden-2",
+          totalError: 0,
+          impact: 1e-10,
+          reason: "test-removal-2",
+        },
+      ],
+    };
+
+    const candidates = buildDiscoveryCandidates(base, discovery, {
+      skipCombinedCandidates: true,
+    });
+
+    // We expect exactly one candidate per removal suggestion (no combined "cleanup" candidate).
+    const removalCandidates = candidates.filter((c) =>
+      c.change.type === "remove-low-impact"
+    );
+    assertEquals(
+      removalCandidates.length,
+      2,
+      "Expected only dedicated remove-low-impact candidates when combos are skipped",
+    );
+
+    // Defensive: ensure none look like a combined cleanup description.
+    const hasCombinedCleanup = removalCandidates.some((c) =>
+      (c.change.description ?? "").toLowerCase().includes("combined")
+    );
+    assertEquals(
+      hasCombinedCleanup,
+      false,
+      "Expected no combined removal candidate when skipCombinedCandidates is true",
+    );
+  },
+);

--- a/test/discovery/RemovalCandidates.ts
+++ b/test/discovery/RemovalCandidates.ts
@@ -10,7 +10,10 @@ import { assertEquals, assertExists } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
 import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { RemovalCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
-import { buildDiscoveryCandidates } from "../../src/discovery/DiscoveryCandidates.ts";
+import {
+  buildCombinedFromSuccessful,
+  buildDiscoveryCandidates,
+} from "../../src/discovery/DiscoveryCandidates.ts";
 import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
 
 Deno.test("removeLowImpactNeuron removes neuron without bias adjustment", () => {
@@ -378,12 +381,12 @@ Deno.test("buildDiscoveryCandidates uses crippled-removal.json for near-zero wei
  * Test for issue #920: Combined removal candidate should be created even if
  * one removal fails during sequential application.
  *
- * When building a combined removal candidate, if one neuron was already removed
- * as part of orphan cleanup from a previous removal, the loop should continue
- * with remaining removals rather than aborting entirely.
+ * When building a combined candidate (Phase 2), if one neuron is already removed
+ * as part of orphan cleanup from a previous removal, the combination loop should
+ * continue with remaining removals rather than aborting entirely.
  *
- * Expected: 42 individual + 1 combined = 43 total removal candidates
- * Bug: Only 42 created because combined candidate loop breaks on first failure
+ * Expected: We still produce a combined candidate that removes the remaining
+ * neurons (even if one step becomes a no-op because it was already removed).
  */
 Deno.test("combined removal candidate should be created when some removals fail", () => {
   // Create a creature where neuron A connects only to neuron B.
@@ -469,32 +472,56 @@ Deno.test("combined removal candidate should be created when some removals fail"
     candidateSquashes: undefined,
   };
 
-  const candidates = buildDiscoveryCandidates(baseCreature, discovery);
+  // Phase 1: build single removal candidates only.
+  const singleCandidates = buildDiscoveryCandidates(baseCreature, discovery, {
+    skipCombinedCandidates: true,
+  });
 
-  const removalCandidates = candidates.filter(
+  const removalCandidates = singleCandidates.filter(
     (c) => c.change.type === "remove-low-impact",
   );
 
-  // Should have 3 individual + 1 combined = 4 candidates
-  // The bug was: only 3 created because the combined candidate wasn't built
-  // when removing A fails (A was already removed during B's orphan cleanup)
+  // We should have 3 single removal candidates (no combined candidates in Phase 1).
   assertEquals(
-    removalCandidates.length >= 4,
-    true,
-    `Should create at least 4 removal candidates (3 individual + 1 combined), got ${removalCandidates.length}`,
+    removalCandidates.length,
+    3,
+    `Should create 3 single removal candidates, got ${removalCandidates.length}`,
   );
 
-  // Find the combined candidate (description contains "combined" or "Pruned")
-  const combinedCandidate = removalCandidates.find(
+  // Phase 2: pretend these were "successful" and build combinations.
+  const combinedCandidates = buildCombinedFromSuccessful(
+    baseCreature,
+    discovery.ID,
+    removalCandidates,
+  );
+
+  const combinedRemovalCandidate = combinedCandidates.find(
     (c) =>
-      c.change.description?.includes("combined") ||
-      c.change.description?.includes("Pruned"),
+      c.change.type === "combo-successful" &&
+      (c.change.description?.includes("Pruned") ?? false),
   );
 
   assertExists(
-    combinedCandidate,
-    "Should create a combined removal candidate even if some removals fail",
+    combinedRemovalCandidate,
+    "Should create a combined removal candidate even if one removal step becomes a no-op",
   );
+
+  // Verify the combined candidate removed B and C (A may also be removed as an orphan).
+  const combinedExport = combinedRemovalCandidate.creature.exportJSON();
+  for (
+    const removedUUID of [
+      "neuron-B-target-of-A",
+      "neuron-A-connects-only-to-B",
+      "neuron-C-independent",
+    ]
+  ) {
+    const exists = combinedExport.neurons.some((n) => n.uuid === removedUUID);
+    assertEquals(
+      exists,
+      false,
+      `${removedUUID} should be removed in combined candidate`,
+    );
+  }
 });
 
 /**


### PR DESCRIPTION
- Removed the logic for tracking successful removals and creating combined removal candidates in the `buildDiscoveryCandidates` function.
- Updated related comments and cleaned up the code to streamline the removal process.
- Added a test to ensure that combined removal candidates are not built when the `skipCombinedCandidates` option is enabled, verifying expected behavior.

These changes aim to simplify the candidate building process and improve clarity in the codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes inline combined removal from `buildDiscoveryCandidates`, introduces two-phase combo generation via `buildCombinedFromSuccessful`, and updates tests accordingly.
> 
> - **DiscoveryCandidates**:
>   - Remove inline combined low-impact removal logic and tracking within `buildDiscoveryCandidates`.
>   - Add two-phase combo flow: `skipCombinedCandidates` option and new `buildCombinedFromSuccessful` to combine successful singles.
>   - Implement `applyChangeToCreature` and combo description utilities to safely merge changes; retain cross-category combos (`combo-all`, `combo-best-of-category`).
> - **Tests**:
>   - Add test to ensure no combined removals when `skipCombinedCandidates` is true (Phase 1).
>   - Update combined-removal test to use Phase 2 via `buildCombinedFromSuccessful` and validate outcomes.
> - **Meta**:
>   - Bump version to `0.259.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e94800c50d2f2849e878cc151161f23a87335c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->