### PR TITLE
Allow optional comment on Rust discovery candidates

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.259.2",
+  "version": "0.259.3",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
@@ -18,6 +18,11 @@ export interface RemovalCandidate {
   reason: string;
   /** Average activation for bias adjustment during removal (computed lazily). */
   averageActivation?: number;
+  /**
+   * Optional diagnostic comment emitted by the Rust discovery engine.
+   * This must not affect ranking/selection logic.
+   */
+  comment?: string;
 }
 
 /**
@@ -31,6 +36,7 @@ export function fromRustRemovalCandidate(
     totalError: rust.totalError,
     impact: rust.impact,
     reason: rust.reason,
+    comment: rust.comment,
   };
 }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -147,6 +147,11 @@ export interface CandidateSynapse {
   expectedCreatureScoreGain: number;
   improvedCount: number;
   totalCount: number;
+  /**
+   * Optional diagnostic comment (primarily surfaced from Rust candidates).
+   * This must not affect ranking/selection logic.
+   */
+  comment?: string;
   targetNeuronStats?: NeuronStats;
 }
 
@@ -166,6 +171,11 @@ export interface CandidateSquash {
   expectedCreatureScoreGain: number;
   improvedError: number;
   currentError: number;
+  /**
+   * Optional diagnostic comment (primarily for Rust experiments/telemetry).
+   * This must not affect ranking/selection logic.
+   */
+  comment?: string;
 }
 
 /**
@@ -191,6 +201,11 @@ export interface CandidateNeuron {
   expectedCreatureScoreGain: number;
   improvedCount: number;
   totalCount: number;
+  /**
+   * Optional diagnostic comment (primarily surfaced from Rust candidates).
+   * This must not affect ranking/selection logic.
+   */
+  comment?: string;
   targetNeuronStats?: NeuronStats;
 }
 
@@ -206,6 +221,11 @@ export interface CandidateHarmfulNeuron {
   expectedCreatureScoreGain: number;
   sampleCount: number;
   averageActivation: number; // Average activation across all samples for efficient bias adjustment
+  /**
+   * Optional diagnostic comment (primarily for Rust experiments/telemetry).
+   * This must not affect ranking/selection logic.
+   */
+  comment?: string;
 }
 
 interface CandidateAnalysisBundle {
@@ -1786,6 +1806,7 @@ export class DiscoverStructure {
       expectedCreatureScoreGain: candidate.expectedCreatureScoreGain,
       improvedCount: candidate.improvedCount,
       totalCount: candidate.totalCount,
+      comment: candidate.comment,
       targetNeuronStats: candidate.targetNeuronStats,
     };
   }
@@ -1805,6 +1826,7 @@ export class DiscoverStructure {
       expectedCreatureScoreGain: candidate.expectedCreatureScoreGain,
       improvedCount: candidate.improvedCount,
       totalCount: candidate.totalCount,
+      comment: candidate.comment,
       targetNeuronStats: candidate.targetNeuronStats,
     };
   }

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -100,6 +100,11 @@ export interface RustCandidateSynapse {
   expectedCreatureScoreGain: number;
   improvedCount: number;
   totalCount: number;
+  /**
+   * Optional diagnostic comment emitted by the Rust discovery engine.
+   * This must not affect ranking/selection logic.
+   */
+  comment?: string;
   targetNeuronStats?: NeuronStatsJson;
 }
 
@@ -127,6 +132,11 @@ export interface RustCandidateNeuron {
   expectedCreatureScoreGain: number;
   improvedCount: number;
   totalCount: number;
+  /**
+   * Optional diagnostic comment emitted by the Rust discovery engine.
+   * This must not affect ranking/selection logic.
+   */
+  comment?: string;
   targetNeuronStats?: NeuronStatsJson;
 }
 
@@ -242,6 +252,11 @@ export interface RustRemovalCandidate {
   totalError: number;
   impact: number;
   reason: string; // e.g., "High error (5.0000) but very low impact (0.000100) - far from outputs"
+  /**
+   * Optional diagnostic comment emitted by the Rust discovery engine.
+   * This must not affect ranking/selection logic.
+   */
+  comment?: string;
 }
 
 /**

--- a/test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts
+++ b/test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts
@@ -1,0 +1,147 @@
+import { assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type {
+  RustCandidateNeuron,
+  RustCandidateSynapse,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+
+type DiscoverStructurePrivateApi = {
+  mapRustNeuronCandidate: (
+    candidate: RustCandidateNeuron,
+  ) => { comment?: string };
+  mapRustCandidate: (candidate: RustCandidateSynapse) => { comment?: string };
+};
+
+function makeCreatureWithUuid(): Creature {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 1 }],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+Deno.test(
+  "Rust discovery candidate parsing succeeds with optional comment field",
+  () => {
+    const baseDirectory = Deno.makeTempDirSync({ prefix: "neat-ai-comment-" });
+    try {
+      const discoverStructure = new DiscoverStructure(
+        makeCreatureWithUuid(),
+        1,
+        1,
+        {},
+        { baseDirectory, skipRecordPhase: true },
+      );
+
+      const neuronJson = JSON.stringify({
+        sourceNeuronUuid: "input-0",
+        targetNeuronUuid: "output-0",
+        incomingWeight: 0.42,
+        outgoingWeight: -0.13,
+        squash: "TANH",
+        bias: 0.01,
+        targetNeuronImpact: 1.0,
+        expectedCreatureErrorReduction: 0.0,
+        expectedCreatureScoreGain: 0.123,
+        improvedCount: 4,
+        totalCount: 5,
+        comment: "diagnostic: add-neuron suggested due to error spike cluster",
+      });
+
+      const parsedNeuron = JSON.parse(neuronJson) as RustCandidateNeuron;
+      const mappedNeuron =
+        (discoverStructure as unknown as DiscoverStructurePrivateApi)
+          .mapRustNeuronCandidate(parsedNeuron);
+      assertEquals(
+        mappedNeuron.comment,
+        "diagnostic: add-neuron suggested due to error spike cluster",
+      );
+
+      const synapseJson = JSON.stringify({
+        fromNeuronUuid: "input-0",
+        toNeuronUuid: "output-0",
+        weight: 0.99,
+        targetNeuronImpact: 1.0,
+        expectedCreatureErrorReduction: 0.0,
+        expectedCreatureScoreGain: 0.5,
+        improvedCount: 8,
+        totalCount: 10,
+        comment: "diagnostic: add-synapse chosen as strongest source",
+      });
+
+      const parsedSynapse = JSON.parse(synapseJson) as RustCandidateSynapse;
+      const mappedSynapse =
+        (discoverStructure as unknown as DiscoverStructurePrivateApi)
+          .mapRustCandidate(parsedSynapse);
+      assertEquals(
+        mappedSynapse.comment,
+        "diagnostic: add-synapse chosen as strongest source",
+      );
+    } finally {
+      Deno.removeSync(baseDirectory, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "Rust discovery candidate parsing succeeds when comment is absent",
+  () => {
+    const baseDirectory = Deno.makeTempDirSync({ prefix: "neat-ai-comment-" });
+    try {
+      const discoverStructure = new DiscoverStructure(
+        makeCreatureWithUuid(),
+        1,
+        1,
+        {},
+        { baseDirectory, skipRecordPhase: true },
+      );
+
+      const neuronJson = JSON.stringify({
+        sourceNeuronUuid: "input-0",
+        targetNeuronUuid: "output-0",
+        incomingWeight: 0.42,
+        outgoingWeight: -0.13,
+        squash: "TANH",
+        bias: 0.01,
+        targetNeuronImpact: 1.0,
+        expectedCreatureErrorReduction: 0.0,
+        expectedCreatureScoreGain: 0.123,
+        improvedCount: 4,
+        totalCount: 5,
+      });
+
+      const parsedNeuron = JSON.parse(neuronJson) as RustCandidateNeuron;
+      const mappedNeuron =
+        (discoverStructure as unknown as DiscoverStructurePrivateApi)
+          .mapRustNeuronCandidate(parsedNeuron);
+      assertEquals(mappedNeuron.comment, undefined);
+
+      const synapseJson = JSON.stringify({
+        fromNeuronUuid: "input-0",
+        toNeuronUuid: "output-0",
+        weight: 0.99,
+        targetNeuronImpact: 1.0,
+        expectedCreatureErrorReduction: 0.0,
+        expectedCreatureScoreGain: 0.5,
+        improvedCount: 8,
+        totalCount: 10,
+      });
+
+      const parsedSynapse = JSON.parse(synapseJson) as RustCandidateSynapse;
+      const mappedSynapse =
+        (discoverStructure as unknown as DiscoverStructurePrivateApi)
+          .mapRustCandidate(parsedSynapse);
+      assertEquals(mappedSynapse.comment, undefined);
+    } finally {
+      Deno.removeSync(baseDirectory, { recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
The Rust discovery engine may emit an optional comment field on candidates for diagnostics. TypeScript now tolerates and propagates this field without changing ranking/selection behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `comment` fields to Rust discovery candidate types and TS counterparts, maps them through, adds compatibility tests, and bumps version.
> 
> - **Discovery types**:
>   - Add optional `comment?: string` to `RustCandidateSynapse`, `RustCandidateNeuron`, `RustRemovalCandidate` and TS counterparts: `CandidateSynapse`, `CandidateNeuron`, `CandidateSquash`, `CandidateHarmfulNeuron`, `RemovalCandidate`.
> - **Mapping**:
>   - Pass through `comment` in `mapRustCandidate`, `mapRustNeuronCandidate`, and `fromRustRemovalCandidate`.
> - **Tests**:
>   - New tests validate parsing/mapping with and without `comment` in `RustDiscoveryCandidateCommentCompatibility.ts`.
> - **Version**:
>   - Bump `deno.json` version to `0.259.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85fc5830ec7d3fd1962f92e004288421bdf9037d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->