### PR TITLE
Add support for diagnostic comments in discovery tags

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.259.3",
+  "version": "0.259.4",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -4113,6 +4113,13 @@ export class DiscoverStructure {
       };
 
       addTag(addSynapse as TagsInterface, "discovery", "beneficial");
+      if (bestCandidate.comment) {
+        addTag(
+          addSynapse as TagsInterface,
+          "discovery-comment",
+          bestCandidate.comment,
+        );
+      }
       exportJSON.synapses.push(addSynapse);
       appliedSynapses.push(bestCandidate);
     });
@@ -4278,6 +4285,13 @@ export class DiscoverStructure {
         bias: candidate.bias,
       };
       addTag(newNeuron as TagsInterface, "discovered", candidate.squash);
+      if (candidate.comment) {
+        addTag(
+          newNeuron as TagsInterface,
+          "discovery-comment",
+          candidate.comment,
+        );
+      }
       // Diagnostic tags for troubleshooting
       addTag(
         newNeuron as TagsInterface,
@@ -4336,6 +4350,13 @@ export class DiscoverStructure {
         weight: candidate.incomingWeight,
       };
       addTag(incomingSynapse as TagsInterface, "discovery", "beneficial");
+      if (candidate.comment) {
+        addTag(
+          incomingSynapse as TagsInterface,
+          "discovery-comment",
+          candidate.comment,
+        );
+      }
       exportJSON.synapses.push(incomingSynapse);
 
       const outgoingSynapse = {
@@ -4344,6 +4365,13 @@ export class DiscoverStructure {
         weight: candidate.outgoingWeight,
       };
       addTag(outgoingSynapse as TagsInterface, "discovery", "beneficial");
+      if (candidate.comment) {
+        addTag(
+          outgoingSynapse as TagsInterface,
+          "discovery-comment",
+          candidate.comment,
+        );
+      }
       exportJSON.synapses.push(outgoingSynapse);
     });
 

--- a/test/discovery/DiscoveryCandidates.ts
+++ b/test/discovery/DiscoveryCandidates.ts
@@ -1,4 +1,5 @@
 import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { getTag, type TagsInterface } from "@stsoftware/tags/mod";
 import { Creature } from "../../src/Creature.ts";
 import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
@@ -90,6 +91,7 @@ Deno.test(
       expectedCreatureScoreGain: 0.25,
       improvedCount: 5,
       totalCount: 6,
+      comment: "rust: diagnostic comment for first synapse",
     }, {
       fromNeuronUUID: "input-3",
       toNeuronUUID: "hidden-2",
@@ -99,6 +101,7 @@ Deno.test(
       expectedCreatureScoreGain: 0.3,
       improvedCount: 6,
       totalCount: 7,
+      comment: "rust: diagnostic comment for second synapse",
     }];
     const discovery: DiscoverResult = {
       ID: "SYN-MULTI",
@@ -134,13 +137,35 @@ Deno.test(
       });
     };
 
-    assert(
-      findDedicatedCandidate(synapses[0]),
-      "Expected candidate dedicated to first helpful synapse",
+    const first = findDedicatedCandidate(synapses[0]);
+    assert(first, "Expected candidate dedicated to first helpful synapse");
+    const firstExport = first.creature.exportJSON();
+    const firstSynapse = firstExport.synapses.find((synapse) =>
+      synapse.fromUUID === synapses[0].fromNeuronUUID &&
+      synapse.toUUID === synapses[0].toNeuronUUID &&
+      Math.abs(synapse.weight - synapses[0].weight) < 1e-9
+    );
+    assert(firstSynapse, "Expected first candidate to contain target synapse");
+    assertEquals(
+      getTag(firstSynapse as unknown as TagsInterface, "discovery-comment"),
+      synapses[0].comment,
+    );
+
+    const second = findDedicatedCandidate(synapses[1]);
+    assert(second, "Expected candidate dedicated to second helpful synapse");
+    const secondExport = second.creature.exportJSON();
+    const secondSynapse = secondExport.synapses.find((synapse) =>
+      synapse.fromUUID === synapses[1].fromNeuronUUID &&
+      synapse.toUUID === synapses[1].toNeuronUUID &&
+      Math.abs(synapse.weight - synapses[1].weight) < 1e-9
     );
     assert(
-      findDedicatedCandidate(synapses[1]),
-      "Expected candidate dedicated to second helpful synapse",
+      secondSynapse,
+      "Expected second candidate to contain target synapse",
+    );
+    assertEquals(
+      getTag(secondSynapse as unknown as TagsInterface, "discovery-comment"),
+      synapses[1].comment,
     );
   },
 );
@@ -426,6 +451,7 @@ Deno.test("buildDiscoveryCandidates includes helpful neuron suggestions", () => 
     expectedCreatureScoreGain: 0.25,
     improvedCount: 8,
     totalCount: 10,
+    comment: "rust: diagnostic comment for added neuron",
   };
 
   const discovery: DiscoverResult = {
@@ -447,6 +473,10 @@ Deno.test("buildDiscoveryCandidates includes helpful neuron suggestions", () => 
   );
   assert(discoveryNeuron, "Expected a discovered neuron to be added.");
   assertEquals(discoveryNeuron?.squash, neuronCandidate.squash);
+  assertEquals(
+    getTag(discoveryNeuron as unknown as TagsInterface, "discovery-comment"),
+    neuronCandidate.comment,
+  );
 
   const incomingSynapseExists = exported.synapses.some((synapse) =>
     synapse.toUUID === discoveryNeuron?.uuid &&


### PR DESCRIPTION
- Enhanced the DiscoverStructure class to include optional comments for synapses and neurons during the discovery process.
- Updated the addTag function to handle "discovery-comment" tags, allowing for better tracking of diagnostic information.
- Modified tests to validate the inclusion of comments in the discovery candidates, ensuring that comments are correctly associated with their respective synapses and neurons.

These changes aim to improve the clarity and traceability of the discovery process by allowing users to attach comments to candidates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates optional candidate comments into `discovery-comment` tags on discovered synapses and neurons, updates tests to assert tags, and bumps version.
> 
> - **Discovery core**:
>   - Add `discovery-comment` tag when available on:
>     - Added helpful synapses in `DiscoverStructure.addHelpfulSynapses()`.
>     - Newly created neurons in `DiscoverStructure.addHelpfulNeurons()`.
>     - Incoming and outgoing synapses for newly added neurons.
> - **Tests**:
>   - Update `test/discovery/DiscoveryCandidates.ts` to assert presence of `discovery-comment` tags using `getTag` for added synapses and discovered neurons.
> - **Config**:
>   - Bump `deno.json` version to `0.259.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09f8a24a475a2d5fe3fc0c5338c19765c98c2042. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->