### PR TITLE
Add rustFlushBytesThreshold to control payload size before Rust flush…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.259.4",
+  "version": "0.259.5",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -234,6 +234,7 @@ class DataRecorder {
       baseDirectory: config.discoveryBaseDirectory,
       disableCleanup: config.discoveryDisableCleanup,
       skipRecordPhase: config.discoverySkipRecordPhase,
+      rustFlushBytesThreshold: config.discoveryRustFlushBytes,
     };
   }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -37,7 +37,10 @@ import {
   type RustSynapseDiagnostic,
   type RustSynapseDiagnosticDetail,
 } from "./RustDiscovery.ts";
-import { DEFAULT_RUST_FLUSH_BYTES, DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
+import {
+  DEFAULT_RUST_FLUSH_BYTES,
+  DEFAULT_RUST_FLUSH_RECORDS,
+} from "./constants.ts";
 import { emptyDirSync, ensureDirSync } from "@std/fs";
 import { dirname, join } from "@std/path";
 
@@ -446,8 +449,9 @@ export class DiscoverStructure {
     // Rough estimate per sample for JSON payload sizing:
     // - ~200 bytes per neuron record (uuid + activation + errors metadata)
     // - ~4 bytes per float for input/output values
-    const nonInputNeuronCount = creature.neurons.filter((n) => n.type !== "input")
-      .length;
+    const nonInputNeuronCount =
+      creature.neurons.filter((n) => n.type !== "input")
+        .length;
     this.rustEstimatedBytesPerSample = (200 * nonInputNeuronCount) +
       (4 * (creature.input + creature.output));
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -37,11 +37,12 @@ import {
   type RustSynapseDiagnostic,
   type RustSynapseDiagnosticDetail,
 } from "./RustDiscovery.ts";
-import { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
+import { DEFAULT_RUST_FLUSH_BYTES, DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
 import { emptyDirSync, ensureDirSync } from "@std/fs";
-import { join } from "@std/path";
+import { dirname, join } from "@std/path";
 
 export { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
+export { DEFAULT_RUST_FLUSH_BYTES } from "./constants.ts";
 
 export interface DiscoverStructureDeps {
   isRustDiscoveryEnabled: typeof isRustDiscoveryEnabled;
@@ -84,6 +85,13 @@ export interface DiscoverStructureOptions {
    * Useful for debugging to re-run analysis on existing data.
    */
   skipRecordPhase?: boolean;
+
+  /**
+   * Estimated payload size threshold (in bytes) before forcing a Rust flush.
+   *
+   * Primarily for testing and production tuning; defaults to ~50 MiB.
+   */
+  rustFlushBytesThreshold?: number;
 }
 
 const OUTPUT_ERROR_CACHE_TTL_MS = 30_000;
@@ -370,11 +378,14 @@ export class DiscoverStructure {
   // Rust recording: accumulate data for Rust Parquet writing (Rust is required)
   private rustAccumulatedData: DataRecordInterface[] = [];
   private rustAccumulatedNeuronData: Array<Map<string, DiscoverRecord>> = [];
+  private rustAccumulatedEstimatedBytes = 0;
+  private rustEstimatedBytesPerSample = 0;
   private rustBinaryFilePath: string | null = null;
   private rustBinaryFilePaths: Set<string> = new Set(); // Track all binary file paths
   private usingRustDualWrite = false;
   private parquetFilePath: string | null = null;
   private rustFlushRecords: number;
+  private rustFlushBytesThreshold: number;
   private rustChunkFiles: string[] = [];
   private rustChunkCounter = 0;
   private syntheticBinaryMode = false;
@@ -424,9 +435,21 @@ export class DiscoverStructure {
     );
     this.timeoutTS = Date.now() + timeoutSeconds * 1000;
     this.rustFlushRecords = Math.max(1, rustFlushRecords);
+    this.rustFlushBytesThreshold = Math.max(
+      1,
+      options.rustFlushBytesThreshold ?? DEFAULT_RUST_FLUSH_BYTES,
+    );
     this.deps = { ...DEFAULT_DISCOVER_STRUCTURE_DEPS, ...deps };
     this.disableCleanup = options.disableCleanup ?? false;
     this.skipRecordPhase = options.skipRecordPhase ?? false;
+
+    // Rough estimate per sample for JSON payload sizing:
+    // - ~200 bytes per neuron record (uuid + activation + errors metadata)
+    // - ~4 bytes per float for input/output values
+    const nonInputNeuronCount = creature.neurons.filter((n) => n.type !== "input")
+      .length;
+    this.rustEstimatedBytesPerSample = (200 * nonInputNeuronCount) +
+      (4 * (creature.input + creature.output));
 
     // Only clear the directory if we're not skipping the record phase
     // When skipping, just ensure it exists (for tests that don't use existing data)
@@ -794,6 +817,7 @@ export class DiscoverStructure {
         // Accumulate data for Rust (Parquet format)
         this.rustAccumulatedData.push(record);
         this.rustAccumulatedNeuronData.push(discoverMap);
+        this.rustAccumulatedEstimatedBytes += this.rustEstimatedBytesPerSample;
       } catch (error) {
         // If we hit the excessive record() calls error, add context about which sample
         if (
@@ -819,7 +843,8 @@ export class DiscoverStructure {
 
   public shouldFlushRustChunk(): boolean {
     if (!this.usingRustDualWrite) return false;
-    return this.rustAccumulatedData.length >= this.rustFlushRecords;
+    if (this.rustAccumulatedData.length >= this.rustFlushRecords) return true;
+    return this.rustAccumulatedEstimatedBytes >= this.rustFlushBytesThreshold;
   }
 
   /**
@@ -992,6 +1017,7 @@ export class DiscoverStructure {
 
       this.rustAccumulatedData = [];
       this.rustAccumulatedNeuronData = [];
+      this.rustAccumulatedEstimatedBytes = 0;
 
       return parquetPath;
     }
@@ -1082,6 +1108,7 @@ export class DiscoverStructure {
     }
 
     const outputFile = `${this.tempDir}/discovery_data.parquet`;
+    const chunkFilesToCleanup = [...this.rustChunkFiles];
     const mergeResult = this.deps.mergeDiscoveryParquet({
       outputFile,
       inputFiles: [...this.rustChunkFiles],
@@ -1098,6 +1125,22 @@ export class DiscoverStructure {
     this.parquetFilePath = mergeResult.outputFile ?? outputFile;
     this.combinedRustAnalysis = undefined;
     this.rustChunkFiles = [];
+
+    if (!this.disableCleanup) {
+      for (const file of chunkFilesToCleanup) {
+        try {
+          Deno.removeSync(file);
+        } catch {
+          // Ignore cleanup failures - discovery can still proceed with merged output.
+        }
+        try {
+          // Remove the chunk directory too (batch temp directory cleanup).
+          Deno.removeSync(dirname(file), { recursive: true });
+        } catch {
+          // Ignore directory cleanup failures.
+        }
+      }
+    }
     return true;
   }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/constants.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/constants.ts
@@ -11,3 +11,12 @@ export const DEFAULT_RUST_FLUSH_RECORDS = 4_096;
  * This keeps JSON payloads bounded during discovery flushes to avoid OOMs.
  */
 export const DEFAULT_RUST_STREAM_RECORDS = 512;
+
+/**
+ * Default estimated payload size threshold (in bytes) before flushing a Rust
+ * discovery chunk.
+ *
+ * This is a conservative ceiling to avoid V8's maximum string length during
+ * JSON.stringify() when preparing FFI payloads (e.g. "Invalid string length").
+ */
+export const DEFAULT_RUST_FLUSH_BYTES = 50 * 1024 * 1024; // ~50 MiB

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -5,7 +5,10 @@ import type {
   DiscoveryMinCandidatesPerCategory,
   NeatArguments,
 } from "./NeatOptions.ts";
-import { DEFAULT_RUST_FLUSH_RECORDS } from "../architecture/ErrorGuidedStructuralEvolution/constants.ts";
+import {
+  DEFAULT_RUST_FLUSH_BYTES,
+  DEFAULT_RUST_FLUSH_RECORDS,
+} from "../architecture/ErrorGuidedStructuralEvolution/constants.ts";
 
 /**
  * Default cost of growth value used when not specified in options.
@@ -168,6 +171,8 @@ export function createNeatConfig(options: NeatOptions) {
     discoveryBufferSize: options.discoveryBufferSize || 0,
     discoveryRustFlushRecords: options.discoveryRustFlushRecords ??
       DEFAULT_RUST_FLUSH_RECORDS,
+    discoveryRustFlushBytes: options.discoveryRustFlushBytes ??
+      DEFAULT_RUST_FLUSH_BYTES,
     discoveryMaxNeurons: options.discoveryMaxNeurons ?? 6, // Default 6 neurons (was 0 - production-tuned)
     discoveryDrainEveryNBatches: options.discoveryDrainEveryNBatches ?? 10,
     discoveryFocusNeuronUUIDs: options.discoveryFocusNeuronUUIDs
@@ -356,6 +361,14 @@ function validate(config: NeatArguments) {
   ) {
     throw new Error(
       `Discovery Rust Flush Records must be an integer greater than 0 was: ${config.discoveryRustFlushRecords}`,
+    );
+  }
+  if (
+    Number.isFinite(config.discoveryRustFlushBytes) === false ||
+    config.discoveryRustFlushBytes < 1
+  ) {
+    throw new Error(
+      `Discovery Rust Flush Bytes must be greater than 0 was: ${config.discoveryRustFlushBytes}`,
     );
   }
   if (!Array.isArray(config.discoveryFocusNeuronUUIDs)) {

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -205,6 +205,15 @@ export interface NeatArguments {
   discoveryRustFlushRecords: number;
 
   /**
+   * Estimated payload size threshold (in bytes) before flushing a Rust discovery
+   * chunk.
+   *
+   * This prevents V8 hitting JSON.stringify() maximum string length limits when
+   * recording for long periods with large creatures. Defaults to ~50 MiB.
+   */
+  discoveryRustFlushBytes: number;
+
+  /**
    * The maximum number of neurons to analyze per discovery iteration.
    * Defaults to 6 (production-tuned - balances thoroughness with speed).
    */

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructureChunkCleanup.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructureChunkCleanup.ts
@@ -1,0 +1,235 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
+import type {
+  RustMergeParquetInput,
+  RustMergeParquetResult,
+  RustParallelAnalysisResult,
+  RustReadResult,
+  RustRecordInput,
+  RustRecordResult,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import type { DiscoverStructureDeps } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+function makeMinimalCreature(): Creature {
+  const exportJSON: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden",
+        uuid: "hidden-0",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+      {
+        type: "output",
+        uuid: "output-0",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.75 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(exportJSON);
+  CreatureUtil.makeUUID(creature);
+  creature.validate();
+  return creature;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function makeTwoSamples(): DataRecordInterface[] {
+  return [
+    { input: Float32Array.from([0.1]), output: Float32Array.from([0.2]) },
+    { input: Float32Array.from([0.3]), output: Float32Array.from([0.4]) },
+  ];
+}
+
+Deno.test({
+  name: "flushRustRecording cleans up chunk files and directories after merge",
+  permissions: {
+    read: true,
+    write: true,
+    ffi: false,
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const baseDir = await Deno.makeTempDir({ prefix: "neat-discovery-clean-" });
+    const creature = makeMinimalCreature();
+
+    const createdChunkFiles: string[] = [];
+    const createdChunkDirs: string[] = [];
+
+    const deps: Partial<DiscoverStructureDeps> = {
+      isRustDiscoveryEnabled: () => true,
+      isRustLibraryAvailable: () => true,
+      recordDiscovery: (input: RustRecordInput): RustRecordResult => {
+        const file = `chunk-${createdChunkFiles.length + 1}.parquet`;
+        const chunkFile = `${input.temp_dir}/${file}`;
+        Deno.writeTextFileSync(chunkFile, "placeholder");
+        createdChunkFiles.push(chunkFile);
+        createdChunkDirs.push(input.temp_dir);
+        return { success: true, temp_dir: input.temp_dir, file };
+      },
+      mergeDiscoveryParquet: (
+        input: RustMergeParquetInput,
+      ): RustMergeParquetResult => {
+        Deno.writeTextFileSync(input.outputFile, "merged");
+        return { success: true, outputFile: input.outputFile };
+      },
+      analyzeParallel: (): RustParallelAnalysisResult => ({
+        success: true,
+        helpfulNeurons: [],
+        helpfulSynapses: [],
+        harmfulSynapses: [],
+      }),
+      readDiscoveryRecords: (): RustReadResult => ({ success: true, records: [] }),
+    };
+
+    const discovery = new DiscoverStructure(
+      creature,
+      60,
+      1, // flush every record batch to create multiple chunks deterministically
+      deps,
+      { baseDirectory: baseDir },
+    );
+
+    const neuronPromises = new Map<string, Promise<void>>();
+    discovery.initialize(neuronPromises);
+
+    const samples = makeTwoSamples();
+    assertEquals(
+      discovery.record([samples[0]], neuronPromises, "/tmp/fake.bin", [0]),
+      true,
+    );
+    assertEquals(discovery.flushRustChunk(), true);
+
+    assertEquals(
+      discovery.record([samples[1]], neuronPromises, "/tmp/fake.bin", [1]),
+      true,
+    );
+    assertEquals(discovery.flushRustChunk(), true);
+
+    // Sanity: chunk files are present before merge cleanup.
+    assertEquals(await pathExists(createdChunkFiles[0]), true);
+    assertEquals(await pathExists(createdChunkFiles[1]), true);
+
+    assertEquals(discovery.flushRustRecording(), true);
+
+    // Post-merge cleanup should remove chunk files and their directories.
+    assertEquals(await pathExists(createdChunkFiles[0]), false);
+    assertEquals(await pathExists(createdChunkFiles[1]), false);
+    assertEquals(await pathExists(createdChunkDirs[0]), false);
+    assertEquals(await pathExists(createdChunkDirs[1]), false);
+
+    await discovery.cleanUp();
+    try {
+      // deno-lint-ignore no-sync-fn-in-async-fn
+      Deno.removeSync(baseDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  },
+});
+
+Deno.test({
+  name: "flushRustRecording preserves chunk files when cleanup is disabled",
+  permissions: {
+    read: true,
+    write: true,
+    ffi: false,
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const baseDir = await Deno.makeTempDir({ prefix: "neat-discovery-keep-" });
+    const creature = makeMinimalCreature();
+
+    const createdChunkFiles: string[] = [];
+    const createdChunkDirs: string[] = [];
+
+    const deps: Partial<DiscoverStructureDeps> = {
+      isRustDiscoveryEnabled: () => true,
+      isRustLibraryAvailable: () => true,
+      recordDiscovery: (input: RustRecordInput): RustRecordResult => {
+        const file = `chunk-${createdChunkFiles.length + 1}.parquet`;
+        const chunkFile = `${input.temp_dir}/${file}`;
+        Deno.writeTextFileSync(chunkFile, "placeholder");
+        createdChunkFiles.push(chunkFile);
+        createdChunkDirs.push(input.temp_dir);
+        return { success: true, temp_dir: input.temp_dir, file };
+      },
+      mergeDiscoveryParquet: (
+        input: RustMergeParquetInput,
+      ): RustMergeParquetResult => {
+        Deno.writeTextFileSync(input.outputFile, "merged");
+        return { success: true, outputFile: input.outputFile };
+      },
+      analyzeParallel: (): RustParallelAnalysisResult => ({
+        success: true,
+        helpfulNeurons: [],
+        helpfulSynapses: [],
+        harmfulSynapses: [],
+      }),
+      readDiscoveryRecords: (): RustReadResult => ({ success: true, records: [] }),
+    };
+
+    const discovery = new DiscoverStructure(
+      creature,
+      60,
+      1,
+      deps,
+      { baseDirectory: baseDir, disableCleanup: true },
+    );
+
+    const neuronPromises = new Map<string, Promise<void>>();
+    discovery.initialize(neuronPromises);
+
+    const samples = makeTwoSamples();
+    assertEquals(
+      discovery.record([samples[0]], neuronPromises, "/tmp/fake.bin", [0]),
+      true,
+    );
+    assertEquals(discovery.flushRustChunk(), true);
+
+    assertEquals(
+      discovery.record([samples[1]], neuronPromises, "/tmp/fake.bin", [1]),
+      true,
+    );
+    assertEquals(discovery.flushRustChunk(), true);
+
+    assertEquals(discovery.flushRustRecording(), true);
+
+    // Cleanup disabled - chunk files/dirs should still exist.
+    assertEquals(await pathExists(createdChunkFiles[0]), true);
+    assertEquals(await pathExists(createdChunkFiles[1]), true);
+    assertEquals(await pathExists(createdChunkDirs[0]), true);
+    assertEquals(await pathExists(createdChunkDirs[1]), true);
+
+    await discovery.cleanUp();
+    try {
+      // deno-lint-ignore no-sync-fn-in-async-fn
+      Deno.removeSync(baseDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  },
+});
+

--- a/test/ErrorGuidedStructuralEvolution/DiscoverStructureChunkCleanup.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverStructureChunkCleanup.ts
@@ -100,7 +100,10 @@ Deno.test({
         helpfulSynapses: [],
         harmfulSynapses: [],
       }),
-      readDiscoveryRecords: (): RustReadResult => ({ success: true, records: [] }),
+      readDiscoveryRecords: (): RustReadResult => ({
+        success: true,
+        records: [],
+      }),
     };
 
     const discovery = new DiscoverStructure(
@@ -188,7 +191,10 @@ Deno.test({
         helpfulSynapses: [],
         harmfulSynapses: [],
       }),
-      readDiscoveryRecords: (): RustReadResult => ({ success: true, records: [] }),
+      readDiscoveryRecords: (): RustReadResult => ({
+        success: true,
+        records: [],
+      }),
     };
 
     const discovery = new DiscoverStructure(
@@ -232,4 +238,3 @@ Deno.test({
     }
   },
 });
-

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryRustFlush.ts
@@ -143,3 +143,132 @@ Deno.test("Discovery flushes Rust recording in configured chunks", async () => {
     }
   }
 });
+
+Deno.test("Discovery flushes Rust recording based on estimated payload size", async () => {
+  const envKey = "NEAT_DISCOVERY_AWAIT_CLEANUP";
+  const previousValue = (() => {
+    try {
+      return Deno.env.get(envKey);
+    } catch {
+      return undefined;
+    }
+  })();
+  try {
+    Deno.env.set(envKey, "1");
+  } catch {
+    // ignore if env not accessible
+  }
+
+  const tempDir = await Deno.makeTempDir({ prefix: "discovery-byte-flush-" });
+  try {
+    const dataFile = join(tempDir, "sample.bin");
+    const recordCount = 4;
+    const valuesPerRecord = 2; // input + output
+    const buffer = new Float32Array(recordCount * valuesPerRecord);
+
+    for (let i = 0; i < recordCount; i++) {
+      buffer[i * valuesPerRecord] = i;
+      buffer[i * valuesPerRecord + 1] = i * 2;
+    }
+
+    await Deno.writeFile(dataFile, new Uint8Array(buffer.buffer));
+
+    const creature = Creature.fromJSON({
+      input: 1,
+      output: 1,
+      neurons: [
+        { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0 },
+        { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+        { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+      ],
+    });
+    creature.validate();
+    CreatureUtil.makeUUID(creature);
+
+    const config = createNeatConfig({
+      costName: "MSE",
+      costOfGrowth: 0,
+      discoverySampleRate: 1,
+      discoveryBatchSize: 1,
+      discoveryRecordTimeOutMinutes: 0.05, // 3 seconds - sufficient for CI
+      discoveryAnalysisTimeoutMinutes: 0.05, // 3 seconds - sufficient for CI
+      discoveryDrainEveryNBatches: 1,
+      discoveryRustFlushRecords: 1_000_000, // ensure bytes trigger the flush
+      discoveryRustFlushBytes: 300, // smaller than 1-sample estimate for this creature
+      discoveryMaxNeurons: 1,
+      threads: 1,
+      log: 0,
+    });
+
+    const recordCallSizes: number[] = [];
+    const mergedChunks: string[][] = [];
+
+    const deps: Partial<DiscoverStructureDeps> = {
+      isRustDiscoveryEnabled: () => true,
+      isRustLibraryAvailable: () => true,
+      recordDiscovery: (input: RustRecordInput): RustRecordResult => {
+        recordCallSizes.push(input.training_data.length);
+        const chunkFile = join(
+          input.temp_dir,
+          `chunk-${recordCallSizes.length}.parquet`,
+        );
+        Deno.writeTextFileSync(chunkFile, "placeholder");
+        return {
+          success: true,
+          temp_dir: input.temp_dir,
+          file: `chunk-${recordCallSizes.length}.parquet`,
+        };
+      },
+      mergeDiscoveryParquet: (
+        input: RustMergeParquetInput,
+      ): RustMergeParquetResult => {
+        mergedChunks.push([...input.inputFiles]);
+        Deno.writeTextFileSync(input.outputFile, "merged");
+        return {
+          success: true,
+          outputFile: input.outputFile,
+        };
+      },
+      analyzeParallel: (): RustParallelAnalysisResult => ({
+        success: true,
+        helpfulNeurons: [],
+        helpfulSynapses: [],
+        harmfulSynapses: [],
+      }),
+      readDiscoveryRecords: (): RustReadResult => ({
+        success: true,
+        records: [],
+      }),
+    };
+
+    await recordDirectory(creature, tempDir, config, deps);
+    // Cleanup is already awaited when NEAT_DISCOVERY_AWAIT_CLEANUP is set
+
+    assertEquals(recordCallSizes, [1, 1, 1, 1]);
+    assertEquals(mergedChunks.length, 1);
+    assertEquals(mergedChunks[0].length, 4);
+  } finally {
+    if (previousValue === undefined) {
+      try {
+        Deno.env.delete(envKey);
+      } catch {
+        // ignore
+      }
+    } else {
+      try {
+        Deno.env.set(envKey, previousValue);
+      } catch {
+        // ignore
+      }
+    }
+    try {
+      // deno-lint-ignore no-sync-fn-in-async-fn
+      Deno.removeSync(tempDir, { recursive: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+});

--- a/test/NEAT/NeatConfig.ts
+++ b/test/NEAT/NeatConfig.ts
@@ -5,6 +5,7 @@ import {
   MAX_ANALYSIS_TIMEOUT_MINUTES,
   MIN_ANALYSIS_TIMEOUT_MINUTES,
 } from "../../src/config/NeatConfig.ts";
+import { DEFAULT_RUST_FLUSH_BYTES } from "../../src/architecture/ErrorGuidedStructuralEvolution/constants.ts";
 import { Selection } from "../../mod.ts";
 
 Deno.test("NeatConfig debug", () => {
@@ -53,6 +54,24 @@ Deno.test("NeatConfig discoveryMinCandidatesPerCategory defaults", () => {
     config.discoveryMinCandidatesPerCategory.removeLowImpact,
     DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.removeLowImpact,
   );
+});
+
+Deno.test("NeatConfig discoveryRustFlushBytes defaults", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.discoveryRustFlushBytes, DEFAULT_RUST_FLUSH_BYTES);
+});
+
+Deno.test("NeatConfig discoveryRustFlushBytes validation - non-positive throws", () => {
+  try {
+    createNeatConfig({ discoveryRustFlushBytes: 0 });
+    fail("Should throw for non-positive discoveryRustFlushBytes");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes("Discovery Rust Flush Bytes"),
+      true,
+      `Error should mention the field name: ${(e as Error).message}`,
+    );
+  }
 });
 
 Deno.test("NeatConfig discoveryMinCandidatesPerCategory partial override", () => {


### PR DESCRIPTION
… (#935)

- Introduced DEFAULT_RUST_FLUSH_BYTES constant to set a default estimated payload size threshold for flushing Rust discovery chunks, preventing V8's maximum string length issues during JSON.stringify().
- Updated DiscoverStructure and DiscoverDirectory classes to utilize the new threshold, allowing for more efficient memory management during data recording.
- Enhanced NeatConfig and NeatOptions to include configuration for discoveryRustFlushBytes, ensuring users can customize this setting.
- Added tests to validate the new flushing behavior based on estimated payload size, improving robustness in handling large data records.

These changes aim to enhance the discovery process by providing better control over memory usage during Rust data handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable byte-threshold to trigger Rust discovery flushes, wires it through config, and cleans up chunk files/directories after merge, with tests.
> 
> - **Discovery**:
>   - Add bytes-based flush threshold via `DEFAULT_RUST_FLUSH_BYTES` and `rustFlushBytesThreshold` in `DiscoverStructureOptions`; estimate payload per-sample and track accumulated bytes; `shouldFlushRustChunk()` now flushes on record count or byte size.
>   - After successful merge, remove chunk `.parquet` files and their directories when cleanup is enabled.
> - **Config**:
>   - Introduce `discoveryRustFlushBytes` in `NeatOptions`/`NeatConfig` with defaults and validation; pass through in `DiscoverDirectory` options.
> - **Tests**:
>   - Add tests for chunk cleanup behavior and byte-threshold-based flushing; add defaults/validation tests for `discoveryRustFlushBytes`.
> - **Version**:
>   - Bump package version to `0.259.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5369ccdfab3e1a05a0b0b149f1a32bc6f48becc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->