### PR TITLE
Update version to 0.260.0 and implement forward-only mode in Creature…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.259.5",
+  "version": "0.260.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -127,6 +127,12 @@ export class Creature implements CreatureInternal {
   public semanticVersion: string;
 
   /**
+   * When true, this creature is intended to remain forward-only (no self/back connections).
+   * This flag survives export/import.
+   */
+  public forwardOnly?: boolean;
+
+  /**
    * Debug mode flag.
    * @type {boolean}
    */
@@ -154,6 +160,7 @@ export class Creature implements CreatureInternal {
     this.tags = undefined;
     this.score = undefined;
     this.semanticVersion = options.semanticVersion ?? "0.0.1";
+    this.forwardOnly = undefined;
 
     if (!options.lazyInitialization) {
       this.initialize(options);
@@ -400,8 +407,13 @@ export class Creature implements CreatureInternal {
   /**
    * Validate the creature structure.
    */
-  validate() {
-    creatureValidate(this);
+  validate(options?: {
+    neurons?: number;
+    connections?: number;
+    feedbackLoop?: boolean;
+    forwardOnly?: boolean;
+  }) {
+    creatureValidate(this, options);
   }
 
   /**
@@ -1298,7 +1310,29 @@ export class Creature implements CreatureInternal {
   /**
    * Fix the structure of the creature.
    */
-  fix() {
+  fix(options?: {
+    /**
+     * When true, remove both back connections and self connections.
+     * Defaults to false (we allow them by default).
+     */
+    forwardOnly?: boolean;
+    /**
+     * Remove recursive (back) synapses (from > to).
+     * Defaults to false.
+     */
+    removeBackConnections?: boolean;
+    /**
+     * Remove self synapses (from === to).
+     * Defaults to false.
+     */
+    removeSelfConnections?: boolean;
+  }) {
+    const forwardOnly = options?.forwardOnly === true;
+    const removeBackConnections = forwardOnly ||
+      options?.removeBackConnections === true;
+    const removeSelfConnections = forwardOnly ||
+      options?.removeSelfConnections === true;
+
     const holdDebug = this.DEBUG;
     this.DEBUG = false;
     const startUUID = CreatureUtil.makeUUID(this);
@@ -1310,6 +1344,12 @@ export class Creature implements CreatureInternal {
     let lastFrom = -1;
     let lastTo = -1;
     this.synapses.forEach((synapse) => {
+      if (removeSelfConnections && synapse.from === synapse.to) {
+        return;
+      }
+      if (removeBackConnections && synapse.from > synapse.to) {
+        return;
+      }
       if (synapse.from === lastFrom && synapse.to === lastTo) {
         console.warn("duplicate synapse " + synapse.from + "->" + synapse.to);
       } else {
@@ -1394,6 +1434,10 @@ export class Creature implements CreatureInternal {
     this.neurons.forEach((neuron) => {
       neuron.fix();
     });
+
+    if (forwardOnly) {
+      this.forwardOnly = true;
+    }
 
     const tmpDebug = this.DEBUG;
     this.DEBUG = false;
@@ -1487,6 +1531,7 @@ export class Creature implements CreatureInternal {
     if (json.semanticVersion) {
       this.semanticVersion = json.semanticVersion;
     }
+    this.forwardOnly = (json as CreatureExport).forwardOnly;
 
     // Preallocate arrays
     const neuronCount = json.neurons.length;

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -117,6 +117,7 @@ export class Mutator {
       .mutation;
 
     const feedbackLoop = this.config.feedbackLoop;
+    const forwardOnly = creature.forwardOnly === true;
     for (let attempts = 0; true; attempts++) {
       const mutationMethod = mutationMethods[
         Math.floor(Math.random() * mutationMethods.length)
@@ -163,7 +164,7 @@ export class Mutator {
         case Mutation.SUB_BACK_CONN.name:
         case Mutation.ADD_SELF_CONN.name:
         case Mutation.SUB_SELF_CONN.name:
-          if (feedbackLoop === false) {
+          if (feedbackLoop === false || forwardOnly) {
             continue;
           }
           break;
@@ -244,7 +245,24 @@ export class Mutator {
     if (changed) {
       delete creature.uuid;
       creature.state.preparedNeurons = false;
+      // Always run the general fix first.
       creature.fix();
+
+      // Forward-only mode: if the creature is marked forward-only or the run is not using
+      // feedback loops, ensure mutations can't accidentally keep self/back connections.
+      if (this.config.feedbackLoop !== true || creature.forwardOnly === true) {
+        try {
+          creature.validate({ forwardOnly: true });
+        } catch (e) {
+          const error = e as Error;
+          if (
+            error.name === "SELF_CONNECTION" ||
+            error.name === "RECURSIVE_SYNAPSE"
+          ) {
+            creature.fix({ forwardOnly: true });
+          }
+        }
+      }
     }
     if (creature.DEBUG) {
       creatureValidate(creature);

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -189,6 +189,16 @@ export class Mutator {
     assert(method.name, "Mutate name is required");
     const startUUID = CreatureUtil.makeUUID(creature);
     let mutator: RadioactiveInterface | undefined;
+
+    // If the caller enables feedback loops, forward-only constraints no longer apply.
+    // Clear the flag so subsequent mutation/breeding can introduce memory connections.
+    if (this.config.feedbackLoop === true && creature.forwardOnly === true) {
+      console.warn(
+        `[Mutator] feedbackLoop=true requested for forwardOnly creature (${startUUID}); clearing creature.forwardOnly flag`,
+      );
+      creature.forwardOnly = undefined;
+    }
+
     switch (method.name) {
       case Mutation.ADD_NODE.name:
         mutator = new AddNeuron(creature);
@@ -259,7 +269,28 @@ export class Mutator {
             error.name === "SELF_CONNECTION" ||
             error.name === "RECURSIVE_SYNAPSE"
           ) {
+            const violations = creature.synapses
+              .map((s, i) => ({ s, i }))
+              .filter(({ s }) => s.from === s.to || s.from > s.to)
+              .slice(0, 10)
+              .map(({ s, i }) =>
+                `${i}) ${s.from} (${
+                  creature.neurons[s.from]?.ID?.() ?? "?"
+                }) -> ${s.to} (${creature.neurons[s.to]?.ID?.() ?? "?"})`
+              );
+            console.error(
+              `[Mutator] Forward-only violation after '${method.name}'. This indicates a bug: ` +
+                `creature is marked forwardOnly=${
+                  creature.forwardOnly === true
+                } and/or feedbackLoop=${this.config.feedbackLoop}. ` +
+                `Error=${error.name}: ${error.message}. ` +
+                `Violations(sample up to 10): ${violations.join(" | ")}`,
+            );
             creature.fix({ forwardOnly: true });
+          } else {
+            // Keep behaviour consistent with Offspring.breed(): only forward-only
+            // violations are repaired here; all other validation failures must surface.
+            throw e;
           }
         }
       }

--- a/src/architecture/CreatureInterfaces.ts
+++ b/src/architecture/CreatureInterfaces.ts
@@ -21,6 +21,15 @@ interface CreatureCommon extends TagsInterface {
   /** Number of output neurons. */
   output: number;
 
+  /**
+   * Marks this creature as forward-only (no self connections or back connections).
+   *
+   * This flag survives export/import and lets production systems enforce that
+   * once a creature is confirmed forward-only it stays that way through
+   * breeding/mutation.
+   */
+  forwardOnly?: boolean;
+
   memetic?: MemeticInterface;
 
   /** Semantic version of the creature */

--- a/src/architecture/CreatureValidate.ts
+++ b/src/architecture/CreatureValidate.ts
@@ -11,8 +11,26 @@ const VALID_NEURON_UUID_PATTERN = /^[A-Za-z0-9-]+$/;
  */
 export function creatureValidate(
   creature: Creature,
-  options?: { neurons?: number; connections?: number; feedbackLoop?: boolean },
+  options?: {
+    neurons?: number;
+    connections?: number;
+    /**
+     * When false, recursive (back) synapses are rejected.
+     * When true/undefined, recursive synapses are allowed.
+     */
+    feedbackLoop?: boolean;
+    /**
+     * Convenience option for production feed-forward validation.
+     * When true, both recursive (back) synapses and self connections are rejected.
+     *
+     * Note: By default (undefined/false) we allow both, as this library supports
+     * memory connections.
+     */
+    forwardOnly?: boolean;
+  },
 ) {
+  const forwardOnly = options?.forwardOnly === true;
+  const feedbackLoop = forwardOnly ? false : options?.feedbackLoop;
   if (options && options.neurons) {
     if (creature.neurons.length !== options.neurons) {
       throw new ValidationError(
@@ -274,6 +292,16 @@ export function creatureValidate(
       throw new Error(indx + ") connection points to an input node");
     }
 
+    if (forwardOnly && c.from === c.to) {
+      debugWrite(creature);
+      throw new ValidationError(
+        `${indx}) Self connection synapse ${c.from} (${
+          creature.neurons[c.from].ID()
+        }) -> ${c.to} (${creature.neurons[c.to].ID()})`,
+        "SELF_CONNECTION",
+      );
+    }
+
     if (c.from < lastFrom) {
       throw new Error(indx + ") synapses not sorted");
     } else if (c.from > lastFrom) {
@@ -296,8 +324,8 @@ export function creatureValidate(
     if (c.from > c.to) {
       /** When feed back is enabled we allow recursive synapses */
       if (
-        options && options.feedbackLoop !== undefined &&
-        options.feedbackLoop === false
+        feedbackLoop !== undefined &&
+        feedbackLoop === false
       ) {
         debugWrite(creature);
         throw new ValidationError(

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -24,7 +24,10 @@ export class Offspring {
   static breed(
     mum: Creature,
     dad: Creature,
-    options: { geneticCompatibilityThreshold?: number } = {},
+    options: {
+      geneticCompatibilityThreshold?: number;
+      forwardOnly?: boolean;
+    } = {},
   ): Creature | undefined {
     const mother = upgrade(Creature.fromJSON(mum.exportJSON()));
     CreatureUtil.makeUUID(mother);
@@ -285,8 +288,28 @@ export class Offspring {
       offspring.memetic = memetic;
     }
 
+    const shouldBeForwardOnly = options.forwardOnly === true ||
+      mum.forwardOnly === true || dad.forwardOnly === true;
+
     try {
       creatureValidate(offspring);
+
+      if (shouldBeForwardOnly) {
+        offspring.forwardOnly = true;
+        try {
+          offspring.validate({ forwardOnly: true });
+        } catch (e) {
+          const error = e as Error;
+          if (
+            error.name === "SELF_CONNECTION" ||
+            error.name === "RECURSIVE_SYNAPSE"
+          ) {
+            offspring.fix({ forwardOnly: true });
+          } else {
+            throw e;
+          }
+        }
+      }
 
       return offspring;
     } catch (e) {

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -289,12 +289,20 @@ export class Offspring {
     }
 
     const shouldBeForwardOnly = options.forwardOnly === true ||
-      mum.forwardOnly === true || dad.forwardOnly === true;
+      (options.forwardOnly === undefined &&
+        (mum.forwardOnly === true || dad.forwardOnly === true));
 
     try {
       creatureValidate(offspring);
 
-      if (shouldBeForwardOnly) {
+      if (
+        options.forwardOnly === false && (mum.forwardOnly || dad.forwardOnly)
+      ) {
+        console.warn(
+          `[Offspring] feedbackLoop/memory mode requested; clearing forwardOnly on child (parents had forwardOnly)`,
+        );
+        offspring.forwardOnly = undefined;
+      } else if (shouldBeForwardOnly) {
         offspring.forwardOnly = true;
         try {
           offspring.validate({ forwardOnly: true });
@@ -304,6 +312,20 @@ export class Offspring {
             error.name === "SELF_CONNECTION" ||
             error.name === "RECURSIVE_SYNAPSE"
           ) {
+            const violations = offspring.synapses
+              .map((s, i) => ({ s, i }))
+              .filter(({ s }) => s.from === s.to || s.from > s.to)
+              .slice(0, 10)
+              .map(({ s, i }) =>
+                `${i}) ${s.from} (${
+                  offspring.neurons[s.from]?.ID?.() ?? "?"
+                }) -> ${s.to} (${offspring.neurons[s.to]?.ID?.() ?? "?"})`
+              );
+            console.error(
+              `[Offspring] Forward-only violation after breed(). This indicates a bug. ` +
+                `Error=${error.name}: ${error.message}. ` +
+                `Violations(sample up to 10): ${violations.join(" | ")}`,
+            );
             offspring.fix({ forwardOnly: true });
           } else {
             throw e;

--- a/src/breed/Breed.ts
+++ b/src/breed/Breed.ts
@@ -76,6 +76,7 @@ export class Breed {
       dad,
       {
         geneticCompatibilityThreshold: config.geneticCompatibilityThreshold,
+        forwardOnly: config.feedbackLoop !== true,
       },
     );
 

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -60,6 +60,16 @@ export interface NeatArguments {
    * Enable feedback loop where the previous result feeds back into the next interaction.
    * Useful for time-series forecasting and recurrent neural networks.
    * More information: https://www.mathworks.com/help/deeplearning/ug/design-time-series-narx-feedback-neural-networks.html
+   *
+   * ## Forward-only default
+   * If this is **unset** (or `false`), the NEAT engine treats the run as **forward-only**:
+   * - Self/back connections are **not selected** as mutation operations.
+   *
+   * Forward-only mode does **not** automatically strip legacy self/back connections on load.
+   * However, when a creature is mutated/bred in forward-only mode, any self/back connections
+   * are removed so we "evolve away" from legacy feedback structures over a few generations.
+   *
+   * To enable memory connections, set `feedbackLoop: true`.
    */
   feedbackLoop: boolean;
 

--- a/src/errors/ValidationError.ts
+++ b/src/errors/ValidationError.ts
@@ -4,6 +4,7 @@ export type ValidationErrorName =
   | "NO_INWARD_CONNECTIONS"
   | "IF_CONDITIONS"
   | "RECURSIVE_SYNAPSE"
+  | "SELF_CONNECTION"
   | "MEMETIC";
 
 export class ValidationError extends Error {

--- a/src/utils/CreatureExportBuilder.ts
+++ b/src/utils/CreatureExportBuilder.ts
@@ -20,6 +20,7 @@ export class CreatureExportBuilder {
     const synapsesLength = synapses.length;
     const json: CreatureExport = {
       semanticVersion: creature.semanticVersion,
+      forwardOnly: creature.forwardOnly ? true : undefined,
       neurons: new Array<NeuronExport>(
         neuronsLength - input,
       ),

--- a/test/Creature.ts
+++ b/test/Creature.ts
@@ -26,7 +26,14 @@ function checkMutation(method: { name: string }) {
     ],
   });
   creatureValidate(creature);
-  const mutator = new Mutator(createNeatConfig({}));
+  const memoryMutation = method.name === Mutation.ADD_BACK_CONN.name ||
+    method.name === Mutation.SUB_BACK_CONN.name ||
+    method.name === Mutation.ADD_SELF_CONN.name ||
+    method.name === Mutation.SUB_SELF_CONN.name;
+  const mutator = new Mutator(createNeatConfig({
+    // Forward-only is the default. Enable feedbackLoop only when testing memory mutations.
+    feedbackLoop: memoryMutation ? true : false,
+  }));
   for (let i = 12; i--;) {
     if (mutator.mutateCreature(creature, method)) break;
   }

--- a/test/ErrorGuidedStructuralEvolution/DiscoverInputOptimization.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverInputOptimization.ts
@@ -83,7 +83,8 @@ function makeTrainingData(
 
 // Note: Leak detection disabled for this test - Rust library is intentionally loaded and kept in memory
 Deno.test({
-  name: "Baseline: Input neurons are correctly recorded and loaded from CSV",
+  name:
+    "Baseline: Input neurons are correctly loaded from binary when indices are provided",
   ignore: !isRustDiscoveryEnabled(),
   sanitizeResources: false, // Disable leak detection - Rust FFI library load/unload is expected
   sanitizeOps: false, // Disable ops sanitization for FFI operations
@@ -92,74 +93,99 @@ Deno.test({
     CreatureUtil.makeUUID(creature);
 
     const trainingData = makeTrainingData(creature.input, creature.output, 100);
+    const dataDir = makeDataDir(trainingData, 100, {
+      input: creature.input,
+      output: creature.output,
+    });
 
-    // Initialize discovery and record data
-    const discoverStructure = new DiscoverStructure(
-      creature,
-      5, // Reduced from 60s to 5s for faster tests
-      DEFAULT_RUST_FLUSH_RECORDS,
-    );
-    const neuronPromisesMap: Map<string, Promise<void>> = new Map();
+    try {
+      // Initialize discovery and record data (inputs are read back from binary using indices)
+      const discoverStructure = new DiscoverStructure(
+        creature,
+        5, // Reduced from 60s to 5s for faster tests
+        DEFAULT_RUST_FLUSH_RECORDS,
+      );
+      const neuronPromisesMap: Map<string, Promise<void>> = new Map();
 
-    discoverStructure.initialize(neuronPromisesMap);
-    const recorded = discoverStructure.record(trainingData, neuronPromisesMap);
-    assert(recorded, "Record should succeed");
-    await Promise.all([...neuronPromisesMap.values()]);
+      discoverStructure.initialize(neuronPromisesMap);
 
-    // Flush Rust recording (required for Parquet file creation)
-    const flushSuccess = discoverStructure.flushRustRecording();
-    assert(flushSuccess, "Rust flush should succeed");
+      const recordIndices = Array.from(
+        { length: trainingData.length },
+        (_, i) => i,
+      );
+      const binaryFilePath = `${dataDir}/0.bin`;
 
-    // Access the private loadCSV method to verify input neurons are recorded
-    const testAccess =
-      discoverStructure as unknown as DiscoverStructureTestAccess;
-    const loadNeuronRecords = testAccess.loadNeuronRecords.bind(
-      discoverStructure,
-    );
-    const tempDir = testAccess.tempDir;
+      const recorded = discoverStructure.record(
+        trainingData,
+        neuronPromisesMap,
+        binaryFilePath,
+        recordIndices,
+      );
+      assert(recorded, "Record should succeed");
+      await Promise.all([...neuronPromisesMap.values()]);
 
-    // Load input neuron records
-    const input0Records = await loadNeuronRecords(`${tempDir}/input-0`);
-    const input1Records = await loadNeuronRecords(`${tempDir}/input-1`);
-    const input2Records = await loadNeuronRecords(`${tempDir}/input-2`);
+      // Flush Rust recording (required for Parquet file creation)
+      const flushSuccess = discoverStructure.flushRustRecording();
+      assert(flushSuccess, "Rust flush should succeed");
 
-    // Verify we got the right number of records
-    assertEquals(
-      input0Records.length,
-      100,
-      "Should have 100 records for input-0",
-    );
-    assertEquals(
-      input1Records.length,
-      100,
-      "Should have 100 records for input-1",
-    );
-    assertEquals(
-      input2Records.length,
-      100,
-      "Should have 100 records for input-2",
-    );
+      // Access the private loadNeuronRecords method to verify input neurons are readable
+      const testAccess =
+        discoverStructure as unknown as DiscoverStructureTestAccess;
+      const loadNeuronRecords = testAccess.loadNeuronRecords.bind(
+        discoverStructure,
+      );
+      const tempDir = testAccess.tempDir;
 
-    // Verify the values match the training data
-    for (let i = 0; i < trainingData.length; i++) {
+      // Load input neuron records (input neurons are never stored in Parquet)
+      const input0Records = await loadNeuronRecords(`${tempDir}/input-0`);
+      const input1Records = await loadNeuronRecords(`${tempDir}/input-1`);
+      const input2Records = await loadNeuronRecords(`${tempDir}/input-2`);
+
+      // Verify we got the right number of records
       assertEquals(
-        input0Records[i].activation,
-        trainingData[i].input[0],
-        `Input-0 record ${i} should match training data`,
+        input0Records.length,
+        100,
+        "Should have 100 records for input-0",
       );
       assertEquals(
-        input1Records[i].activation,
-        trainingData[i].input[1],
-        `Input-1 record ${i} should match training data`,
+        input1Records.length,
+        100,
+        "Should have 100 records for input-1",
       );
       assertEquals(
-        input2Records[i].activation,
-        trainingData[i].input[2],
-        `Input-2 record ${i} should match training data`,
+        input2Records.length,
+        100,
+        "Should have 100 records for input-2",
       );
+
+      // Verify the values match the training data
+      for (let i = 0; i < trainingData.length; i++) {
+        assertEquals(
+          input0Records[i].activation,
+          trainingData[i].input[0],
+          `Input-0 record ${i} should match training data`,
+        );
+        assertEquals(
+          input1Records[i].activation,
+          trainingData[i].input[1],
+          `Input-1 record ${i} should match training data`,
+        );
+        assertEquals(
+          input2Records[i].activation,
+          trainingData[i].input[2],
+          `Input-2 record ${i} should match training data`,
+        );
+      }
+
+      await discoverStructure.cleanUp();
+    } finally {
+      // Cleanup temp directory
+      try {
+        await Deno.remove(dataDir, { recursive: true });
+      } catch {
+        // Ignore cleanup errors
+      }
     }
-
-    await discoverStructure.cleanUp();
   },
 });
 
@@ -209,7 +235,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Binary optimization: Input values read from binary match CSV values",
+  name:
+    "Binary optimisation: Input values read from binary match expected values",
   ignore: !isRustDiscoveryEnabled(),
   sanitizeResources: false, // Disable leak detection - Rust FFI library load/unload is expected
   sanitizeOps: false, // Disable ops sanitization for FFI operations
@@ -226,39 +253,7 @@ Deno.test({
       });
     }
 
-    // Method 1: Using Rust (Parquet) - Rust is required now
-    const csvDiscoverStructure = new DiscoverStructure(
-      creature,
-      5, // Reduced from 60s to 5s for faster tests
-      DEFAULT_RUST_FLUSH_RECORDS,
-    );
-    const csvNeuronPromisesMap: Map<string, Promise<void>> = new Map();
-    csvDiscoverStructure.initialize(csvNeuronPromisesMap);
-    const csvRecorded = csvDiscoverStructure.record(
-      trainingData,
-      csvNeuronPromisesMap,
-    );
-    assert(csvRecorded, "Record should succeed");
-    await Promise.all([...csvNeuronPromisesMap.values()]);
-
-    // Flush Rust recording (required for Parquet file creation)
-    const csvFlushSuccess = csvDiscoverStructure.flushRustRecording();
-    assert(csvFlushSuccess, "Rust flush should succeed");
-
-    // Load CSV records
-    const csvTestAccess =
-      csvDiscoverStructure as unknown as DiscoverStructureTestAccess;
-    const loadNeuronRecords = csvTestAccess.loadNeuronRecords.bind(
-      csvDiscoverStructure,
-    );
-    const csvTempDir = csvTestAccess.tempDir;
-    const csvInput0 = await loadNeuronRecords(`${csvTempDir}/input-0`);
-    const csvInput1 = await loadNeuronRecords(`${csvTempDir}/input-1`);
-    const csvInput2 = await loadNeuronRecords(`${csvTempDir}/input-2`);
-
-    await csvDiscoverStructure.cleanUp();
-
-    // Method 2: Using binary files (optimized path)
+    // Using binary files (optimised path)
     const dataDir = makeDataDir(trainingData, 50);
 
     try {
@@ -318,40 +313,15 @@ Deno.test({
         `${binaryTestAccess.tempDir}/input-2`,
       );
 
-      // Verify binary reads match CSV reads
-      assertEquals(
-        binaryInput0.length,
-        csvInput0.length,
-        "Input-0 should have same number of records",
-      );
-      assertEquals(
-        binaryInput1.length,
-        csvInput1.length,
-        "Input-1 should have same number of records",
-      );
-      assertEquals(
-        binaryInput2.length,
-        csvInput2.length,
-        "Input-2 should have same number of records",
-      );
+      assertEquals(binaryInput0.length, trainingData.length);
+      assertEquals(binaryInput1.length, trainingData.length);
+      assertEquals(binaryInput2.length, trainingData.length);
 
-      // Verify values match
-      for (let i = 0; i < csvInput0.length; i++) {
-        assertEquals(
-          binaryInput0[i].activation,
-          csvInput0[i].activation,
-          `Input-0 record ${i} should match`,
-        );
-        assertEquals(
-          binaryInput1[i].activation,
-          csvInput1[i].activation,
-          `Input-1 record ${i} should match`,
-        );
-        assertEquals(
-          binaryInput2[i].activation,
-          csvInput2[i].activation,
-          `Input-2 record ${i} should match`,
-        );
+      // Verify values match the deterministic dataset
+      for (let i = 0; i < trainingData.length; i++) {
+        assertEquals(binaryInput0[i].activation, trainingData[i].input[0]);
+        assertEquals(binaryInput1[i].activation, trainingData[i].input[1]);
+        assertEquals(binaryInput2[i].activation, trainingData[i].input[2]);
       }
 
       await binaryDiscoverStructure.cleanUp();

--- a/test/FeedForward/ForwardOnlyFlag.ts
+++ b/test/FeedForward/ForwardOnlyFlag.ts
@@ -74,3 +74,92 @@ Deno.test("Breeding honours forwardOnly flag (child becomes forward-only)", () =
     );
   });
 });
+
+Deno.test("Breeding inherits forwardOnly by default (when a parent is forward-only)", () => {
+  const mumJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  };
+  const dadJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0.2 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: 0.3 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.7 },
+      // Extra connection so crossover can create a non-clone child.
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
+    ],
+  };
+
+  const mum = Creature.fromJSON(mumJson);
+  const dad = Creature.fromJSON(dadJson);
+  let child: Creature | undefined;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    child = Offspring.breed(mum, dad);
+    if (child) break;
+  }
+  assert(child, "Expected child");
+  assertEquals(child.forwardOnly, true);
+  child.validate({ forwardOnly: true });
+});
+
+Deno.test("Breeding with forwardOnly=false clears child forwardOnly (keeps memory connections)", () => {
+  const mumJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  };
+  const dadJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0.2 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: 0.3 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.7 },
+      // Extra connection so crossover can create a non-clone child.
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
+    ],
+  };
+
+  const mum = Creature.fromJSON(mumJson);
+  const dad = Creature.fromJSON(dadJson);
+
+  let child: Creature | undefined;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    child = Offspring.breed(mum, dad, { forwardOnly: false });
+    if (child) break;
+  }
+  assert(child, "Expected child");
+  assertEquals(child.forwardOnly, undefined);
+  child.validate();
+});

--- a/test/FeedForward/ForwardOnlyFlag.ts
+++ b/test/FeedForward/ForwardOnlyFlag.ts
@@ -1,0 +1,76 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Synapse } from "../../src/architecture/Synapse.ts";
+import { Offspring } from "../../src/architecture/Offspring.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test("forwardOnly flag survives export/import", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.forwardOnly = true;
+
+  const exported = creature.exportJSON();
+  assert(exported.forwardOnly === true);
+
+  const loaded = Creature.fromJSON(exported);
+  assertEquals(loaded.forwardOnly, true);
+});
+
+Deno.test("Breeding honours forwardOnly flag (child becomes forward-only)", () => {
+  const mumJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  };
+  const dadJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: 0.3 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.7 },
+      // Extra connection so crossover can create a non-clone child.
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
+    ],
+  };
+
+  const loadedMum = Creature.fromJSON(mumJson);
+  const dad = Creature.fromJSON(dadJson);
+
+  // Inject a legacy self connection into mum to simulate older populations.
+  const hiddenIndex = loadedMum.input;
+  loadedMum.synapses.push(new Synapse(hiddenIndex, hiddenIndex, 0.25));
+  loadedMum.synapses.sort((a, b) =>
+    a.from === b.from ? a.to - b.to : a.from - b.from
+  );
+
+  let child: Creature | undefined;
+  for (let attempt = 0; attempt < 50; attempt++) {
+    child = Offspring.breed(loadedMum, dad, { forwardOnly: true });
+    if (child) break;
+  }
+  assert(child, "Expected child");
+  assertEquals(child.forwardOnly, true);
+
+  // Ensure no self/back connections remain.
+  child.synapses.forEach((s) => {
+    assert(
+      s.from < s.to,
+      `Expected forward-only synapse, got ${s.from}->${s.to}`,
+    );
+  });
+});

--- a/test/FeedForward/ForwardOnlyLegacy.ts
+++ b/test/FeedForward/ForwardOnlyLegacy.ts
@@ -1,0 +1,50 @@
+import { assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { Synapse } from "../../src/architecture/Synapse.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+import { Mutation } from "../../src/NEAT/Mutation.ts";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+
+Deno.test("Forward-only: mutated creatures remove legacy self/back connections", () => {
+  // feedbackLoop is unset/false => forward-only mutation selection.
+  const config = createNeatConfig({
+    feedbackLoop: false,
+    mutationRate: 1,
+    mutationAmount: 1,
+    mutation: [Mutation.MOD_WEIGHT],
+    log: 0,
+  });
+  const mutator = new Mutator(config);
+
+  const creature = new Creature(2, 2, { layers: [{ count: 2 }] });
+
+  const hiddenIndex = creature.input;
+  const beforeSelfCount =
+    creature.synapses.filter((s) =>
+      s.from === hiddenIndex && s.to === hiddenIndex
+    ).length;
+  assertEquals(beforeSelfCount, 0);
+
+  // Inject a legacy self connection (as seen in older populations).
+  creature.synapses.push(new Synapse(hiddenIndex, hiddenIndex, 0.5));
+  creature.synapses.sort((
+    a,
+    b,
+  ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+  const legacySelfCount =
+    creature.synapses.filter((s) =>
+      s.from === hiddenIndex && s.to === hiddenIndex
+    ).length;
+  assertEquals(legacySelfCount, 1);
+
+  // Mutating in forward-only mode should strip self/back connections on changed creatures.
+  // (The original fittest creature remains unchanged until it is mutated/replaced.)
+  mutator.mutate([creature]);
+
+  const afterSelfCount =
+    creature.synapses.filter((s) =>
+      s.from === hiddenIndex && s.to === hiddenIndex
+    ).length;
+  assertEquals(afterSelfCount, 0);
+});

--- a/test/FeedForward/ForwardOnlyUnexpectedValidationError.ts
+++ b/test/FeedForward/ForwardOnlyUnexpectedValidationError.ts
@@ -1,0 +1,40 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+import { Mutation } from "../../src/NEAT/Mutation.ts";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+
+Deno.test("Forward-only: unexpected validation errors are re-thrown during mutation", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  assert(creature.synapses.length > 0, "Test requires at least one synapse");
+
+  // Force forward-only validation path (feedbackLoop unset/false).
+  const mutator = new Mutator(
+    createNeatConfig({
+      feedbackLoop: false,
+      mutationRate: 1,
+      mutationAmount: 1,
+      mutation: [Mutation.MOD_WEIGHT],
+      log: 0,
+    }),
+  );
+
+  // Inject a validation failure that is NOT SELF_CONNECTION or RECURSIVE_SYNAPSE.
+  // This simulates any other structural failure (e.g. NO_INWARD_CONNECTIONS, MEMETIC).
+  (creature as unknown as { validate: () => void }).validate = () => {
+    const err = new Error("Injected validation error");
+    err.name = "MEMETIC";
+    throw err;
+  };
+
+  let thrown: Error | undefined;
+  try {
+    mutator.mutateCreature(creature, Mutation.MOD_WEIGHT);
+  } catch (e) {
+    thrown = e as Error;
+  }
+
+  assert(thrown, "Expected mutateCreature() to throw");
+  assertEquals(thrown.name, "MEMETIC");
+  assertEquals(thrown.message, "Injected validation error");
+});

--- a/test/FeedForward/ForwardOnlyViolationLogging.ts
+++ b/test/FeedForward/ForwardOnlyViolationLogging.ts
@@ -1,0 +1,80 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+import { Mutation } from "../../src/NEAT/Mutation.ts";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test("Forward-only: violation is logged and repaired on mutate", () => {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "hidden-0", weight: 0.25 }, // illegal self connection
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json);
+  assertEquals(creature.forwardOnly, true);
+
+  const logged: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    logged.push(args.map((a) => String(a)).join(" "));
+  };
+
+  try {
+    const mutator = new Mutator(
+      createNeatConfig({
+        feedbackLoop: false, // forward-only run
+        mutationRate: 1,
+        mutationAmount: 1,
+        mutation: [Mutation.MOD_WEIGHT],
+        log: 0,
+      }),
+    );
+
+    // Force a mutation attempt.
+    mutator.mutateCreature(creature, Mutation.MOD_WEIGHT);
+
+    // Must remain forward-only and have no self/back connections after repair.
+    assertEquals(creature.forwardOnly, true);
+    creature.validate({ forwardOnly: true });
+
+    assert(
+      logged.some((line) =>
+        line.includes("Forward-only violation") &&
+        line.includes("SELF_CONNECTION")
+      ),
+      `Expected forward-only violation log, got:\n${logged.join("\n")}`,
+    );
+  } finally {
+    console.error = originalError;
+  }
+});
+
+Deno.test("FeedbackLoop enabled clears forwardOnly flag", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.forwardOnly = true;
+
+  const mutator = new Mutator(
+    createNeatConfig({
+      feedbackLoop: true,
+      mutationRate: 1,
+      mutationAmount: 1,
+      mutation: [Mutation.MOD_WEIGHT],
+      log: 0,
+    }),
+  );
+
+  mutator.mutateCreature(creature, Mutation.MOD_WEIGHT);
+  assertEquals(creature.forwardOnly, undefined);
+});

--- a/test/FeedForward/MutateActions.ts
+++ b/test/FeedForward/MutateActions.ts
@@ -106,7 +106,9 @@ Deno.test("forwardOnly creatures block memory mutations even when feedbackLoop i
       method.name === Mutation.SUB_SELF_CONN.name ||
       method.name === Mutation.ADD_BACK_CONN.name
     ) {
-      throw new Error(`Invalid mutation for forwardOnly creature: ${method.name}`);
+      throw new Error(
+        `Invalid mutation for forwardOnly creature: ${method.name}`,
+      );
     }
   }
 });

--- a/test/FeedForward/MutateActions.ts
+++ b/test/FeedForward/MutateActions.ts
@@ -87,3 +87,26 @@ Deno.test("memory enabled", () => {
   }
   assert(found, "No back connection methods found");
 });
+
+Deno.test("forwardOnly creatures block memory mutations even when feedbackLoop is enabled", () => {
+  const creature = makeCreature();
+  creature.forwardOnly = true;
+
+  const config = createNeatConfig({
+    feedbackLoop: true,
+    mutation: Mutation.ALL,
+  });
+  const mutator = new Mutator(config);
+
+  for (let i = 0; i < 100; i++) {
+    const method: MutationInterface = mutator.selectMutationMethod(creature);
+    if (
+      method.name === Mutation.ADD_SELF_CONN.name ||
+      method.name === Mutation.SUB_BACK_CONN.name ||
+      method.name === Mutation.SUB_SELF_CONN.name ||
+      method.name === Mutation.ADD_BACK_CONN.name
+    ) {
+      throw new Error(`Invalid mutation for forwardOnly creature: ${method.name}`);
+    }
+  }
+});

--- a/test/fix/ForwardOnly.ts
+++ b/test/fix/ForwardOnly.ts
@@ -1,0 +1,37 @@
+import { assert } from "@std/assert";
+import { Creature, type CreatureExport } from "../../mod.ts";
+
+Deno.test("fix({ forwardOnly: true }) removes back + self connections", () => {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1.0 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+
+      // Back + self connections that should be removed when forwardOnly is enabled.
+      { fromUUID: "output-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "hidden-0", weight: 0.25 },
+    ],
+    input: 1,
+    output: 1,
+  };
+
+  const creature = Creature.fromJSON(json);
+
+  // Default validation allows memory + self connections.
+  creature.validate();
+
+  creature.fix({ forwardOnly: true });
+  creature.validate({ forwardOnly: true });
+
+  // Ensure structure is now strictly forward-only.
+  creature.synapses.forEach((s) => {
+    assert(
+      s.from < s.to,
+      `Expected strict forward-only synapse, got ${s.from}->${s.to}`,
+    );
+  });
+});

--- a/test/validate/CreatureValidate.ts
+++ b/test/validate/CreatureValidate.ts
@@ -428,3 +428,61 @@ Deno.test("Recursive", () => {
     );
   }
 });
+
+Deno.test("Forward-only: default validate allows back + self connections", () => {
+  const creature = new Creature(10, 2, { layers: [{ count: 5 }] });
+  creature.DEBUG = true;
+
+  // Add one back connection and one self connection.
+  creature.synapses.push(new Synapse(12, 11, 0.5));
+  creature.synapses.push(new Synapse(11, 11, 0.25));
+  creature.synapses.sort((a, b) => {
+    if (a.from === b.from) return a.to - b.to;
+    return a.from - b.from;
+  });
+
+  // By default we allow back connections (memory) and self connections.
+  creature.validate();
+});
+
+Deno.test("Forward-only: validate() rejects back connections when enabled", () => {
+  const creature = new Creature(10, 2, { layers: [{ count: 5 }] });
+  creature.DEBUG = true;
+  creature.synapses.push(new Synapse(12, 11, 0.5));
+  creature.synapses.sort((a, b) => {
+    if (a.from === b.from) return a.to - b.to;
+    return a.from - b.from;
+  });
+
+  try {
+    creature.validate({ forwardOnly: true });
+    fail("Expected error");
+  } catch (e) {
+    const error = e as Error;
+    assert(
+      error.name === "RECURSIVE_SYNAPSE",
+      `Unexpected name: ${error.name}`,
+    );
+  }
+});
+
+Deno.test("Forward-only: validate() rejects self connections when enabled", () => {
+  const creature = new Creature(10, 2, { layers: [{ count: 5 }] });
+  creature.DEBUG = true;
+  creature.synapses.push(new Synapse(11, 11, 0.5));
+  creature.synapses.sort((a, b) => {
+    if (a.from === b.from) return a.to - b.to;
+    return a.from - b.from;
+  });
+
+  try {
+    creature.validate({ forwardOnly: true });
+    fail("Expected error");
+  } catch (e) {
+    const error = e as Error;
+    assert(
+      error.name === "SELF_CONNECTION",
+      `Unexpected name: ${error.name}`,
+    );
+  }
+});


### PR DESCRIPTION
… class

- Bumped version in deno.json to 0.260.0.
- Introduced a new `forwardOnly` flag in the Creature class to enforce forward-only behavior, preventing self and back connections.
- Updated validation and mutation logic to respect the `forwardOnly` setting, ensuring that creatures marked as such cannot have recursive or self connections.
- Enhanced the `fix` and `validate` methods to accommodate the new behavior, improving structural integrity during breeding and mutation processes.
- Added tests to validate the new forward-only functionality, ensuring expected behavior in various scenarios.

These changes aim to enhance the evolutionary capabilities of the NEAT framework by allowing for more controlled and predictable creature behaviors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a persisted `forwardOnly` flag and enforce feed-forward (no self/back synapses) across validate/fix/mutate/breed, with auto-repair, logging, and config-driven defaults; add tests and bump to 0.260.0.
> 
> - **Core — forward-only mode**
>   - Add persisted `Creature.forwardOnly` (export/import via `CreatureExportBuilder`, `Creature.loadFrom`).
>   - `Creature.fix(options)` can remove back/self synapses and set `forwardOnly`.
>   - `Creature.validate(options)`/`creatureValidate` support `forwardOnly` and enhanced `feedbackLoop`; introduce `SELF_CONNECTION` error.
> - **Mutation**
>   - `Mutator.selectMutationMethod` blocks self/back mutations when `feedbackLoop === false` or `creature.forwardOnly === true`.
>   - `mutateCreature` clears `forwardOnly` when `feedbackLoop === true`; otherwise validates forward-only and auto-repairs violations with detailed logging.
> - **Breeding**
>   - `Offspring.breed` adds `forwardOnly` option and inheritance from parents; enforces/repairs forward-only violations or clears flag when memory mode requested.
>   - `Breed.breed` wires config: `forwardOnly` set when `feedbackLoop !== true`.
> - **Config/Errors**
>   - `NeatOptions.feedbackLoop` docs: forward-only is default unless enabled.
>   - Extend `ValidationErrorName` with `SELF_CONNECTION`.
> - **Tests**
>   - Add comprehensive forward-only tests (flag persistence, mutation/breeding enforcement, violation logging, legacy cleanup, fix()) and adjust discovery tests to binary path.
> - **Version**
>   - Bump `deno.json` version to `0.260.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6fcaaed9f878b459aefe9a5e4a0e0dffd2d6dfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->