### PR TITLE
Update version to 0.261.0 and implement semantic version bump for for…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.260.0",
+  "version": "0.261.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1437,6 +1437,20 @@ export class Creature implements CreatureInternal {
 
     if (forwardOnly) {
       this.forwardOnly = true;
+
+      // Issue #937: Once a creature is confirmed forward-only, bump its semantic
+      // version from 2.x.x to 3.0.0. This lets downstream systems treat 3.x
+      // creatures as strictly feed-forward by default.
+      //
+      // Backwards compatibility: we never downgrade versions (e.g. 4.1.2 stays
+      // 4.1.2). We only bump when the major version is exactly 2.
+      const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(this.semanticVersion);
+      if (match) {
+        const major = Number.parseInt(match[1], 10);
+        if (major === 2) {
+          this.semanticVersion = "3.0.0";
+        }
+      }
     }
 
     const tmpDebug = this.DEBUG;

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -19,6 +19,17 @@ import { AddBackCon } from "../mutate/AddBackCon.ts";
 import { SubBackCon } from "../mutate/SubBackCon.ts";
 import { SwapNeurons } from "../mutate/SwapNeurons.ts";
 
+function upgradeSemanticVersionIfForwardOnlyConfirmed(creature: Creature) {
+  // Issue #937: once forward-only is confirmed, bump 2.x.x → 3.0.0.
+  // Backwards compatibility: never downgrade (e.g. 4.1.2 stays 4.1.2).
+  const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(creature.semanticVersion);
+  if (!match) return;
+  const major = Number.parseInt(match[1], 10);
+  if (major === 2) {
+    creature.semanticVersion = "3.0.0";
+  }
+}
+
 export class Mutator {
   private config: NeatConfig;
   constructor(config: NeatConfig) {
@@ -263,6 +274,15 @@ export class Mutator {
       if (this.config.feedbackLoop !== true || creature.forwardOnly === true) {
         try {
           creature.validate({ forwardOnly: true });
+
+          // In forward-only runs, most creatures should already be valid. Once we
+          // confirm that (via validation), mark + upgrade without requiring a fix().
+          if (this.config.feedbackLoop !== true) {
+            creature.forwardOnly = true;
+          }
+          if (creature.forwardOnly === true) {
+            upgradeSemanticVersionIfForwardOnlyConfirmed(creature);
+          }
         } catch (e) {
           const error = e as Error;
           if (

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -10,6 +10,17 @@ import { creatureValidate } from "./CreatureValidate.ts";
 import { Neuron } from "./Neuron.ts";
 import type { SynapseExport, SynapseInternal } from "./SynapseInterfaces.ts";
 
+function upgradeSemanticVersionIfForwardOnlyConfirmed(creature: Creature) {
+  // Issue #937: once forward-only is confirmed, bump 2.x.x → 3.0.0.
+  // Backwards compatibility: never downgrade (e.g. 4.1.2 stays 4.1.2).
+  const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(creature.semanticVersion);
+  if (!match) return;
+  const major = Number.parseInt(match[1], 10);
+  if (major === 2) {
+    creature.semanticVersion = "3.0.0";
+  }
+}
+
 class OffspringError extends Error {
   constructor(message: string) {
     super(message);
@@ -306,6 +317,7 @@ export class Offspring {
         offspring.forwardOnly = true;
         try {
           offspring.validate({ forwardOnly: true });
+          upgradeSemanticVersionIfForwardOnlyConfirmed(offspring);
         } catch (e) {
           const error = e as Error;
           if (

--- a/test/FeedForward/ForwardOnlySemanticVersion.ts
+++ b/test/FeedForward/ForwardOnlySemanticVersion.ts
@@ -1,0 +1,114 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+import { Mutation } from "../../src/NEAT/Mutation.ts";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { Offspring } from "../../src/architecture/Offspring.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test("Forward-only: breeding upgrades semanticVersion 2.x.x → 3.0.0 when validation passes", () => {
+  const mumJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    semanticVersion: "2.9.9",
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  };
+  const dadJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    semanticVersion: "2.9.9",
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0.2 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: 0.3 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.7 },
+      // Extra connection so crossover can create a non-clone child.
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
+    ],
+  };
+
+  const mum = Creature.fromJSON(mumJson);
+  const dad = Creature.fromJSON(dadJson);
+  mum.validate({ forwardOnly: true });
+  dad.validate({ forwardOnly: true });
+
+  let child: Creature | undefined;
+  for (let attempt = 0; attempt < 200; attempt++) {
+    child = Offspring.breed(mum, dad, { forwardOnly: true });
+    if (child) break;
+  }
+  assert(child, "Expected child");
+
+  // The child is confirmed forward-only via validate({ forwardOnly: true }) inside breed().
+  assertEquals(child.forwardOnly, true);
+  assertEquals(child.semanticVersion, "3.0.0");
+});
+
+Deno.test("Forward-only: mutation upgrades semanticVersion 2.x.x → 3.0.0 when validation passes", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.forwardOnly = true;
+  creature.semanticVersion = "2.9.9";
+  creature.validate({ forwardOnly: true });
+
+  const mutator = new Mutator(
+    createNeatConfig({
+      feedbackLoop: false,
+      mutationRate: 1,
+      mutationAmount: 1,
+      mutation: [Mutation.MOD_WEIGHT],
+      log: 0,
+    }),
+  );
+
+  let mutated = false;
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (mutator.mutateCreature(creature, Mutation.MOD_WEIGHT)) {
+      mutated = true;
+      break;
+    }
+  }
+  assert(mutated, "Expected creature to mutate");
+  assertEquals(creature.forwardOnly, true);
+  assertEquals(creature.semanticVersion, "3.0.0");
+});
+
+Deno.test("Forward-only: semanticVersion is never downgraded (e.g. 4.1.2 stays 4.1.2)", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.forwardOnly = true;
+  creature.semanticVersion = "4.1.2";
+  creature.validate({ forwardOnly: true });
+
+  const mutator = new Mutator(
+    createNeatConfig({
+      feedbackLoop: false,
+      mutationRate: 1,
+      mutationAmount: 1,
+      mutation: [Mutation.MOD_WEIGHT],
+      log: 0,
+    }),
+  );
+
+  let mutated = false;
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (mutator.mutateCreature(creature, Mutation.MOD_WEIGHT)) {
+      mutated = true;
+      break;
+    }
+  }
+  assert(mutated, "Expected creature to mutate");
+  assertEquals(creature.semanticVersion, "4.1.2");
+});

--- a/test/fix/ForwardOnly.ts
+++ b/test/fix/ForwardOnly.ts
@@ -1,8 +1,9 @@
-import { assert } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Creature, type CreatureExport } from "../../mod.ts";
 
 Deno.test("fix({ forwardOnly: true }) removes back + self connections", () => {
   const json: CreatureExport = {
+    semanticVersion: "2.1.7",
     neurons: [
       { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0 },
       { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
@@ -26,6 +27,9 @@ Deno.test("fix({ forwardOnly: true }) removes back + self connections", () => {
 
   creature.fix({ forwardOnly: true });
   creature.validate({ forwardOnly: true });
+
+  // Issue #937: once forward-only is confirmed, bump 2.x.x → 3.x.x.
+  assertEquals(creature.semanticVersion, "3.0.0");
 
   // Ensure structure is now strictly forward-only.
   creature.synapses.forEach((s) => {


### PR DESCRIPTION
…ward-only creatures

- Bumped version in deno.json to 0.261.0.
- Enhanced the Creature class to automatically bump the semantic version from 2.x.x to 3.0.0 when a creature is confirmed as forward-only, ensuring downstream systems treat these creatures as strictly feed-forward.
- Updated tests to validate the new versioning behavior for forward-only creatures, confirming the expected semantic version change.

These changes improve version management and clarity in the behavior of forward-only creatures within the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically bump `semanticVersion` from 2.x.x to `3.0.0` when a creature is validated as forward-only across fix, mutation, and breeding; add tests and bump package to 0.261.0.
> 
> - **Core (Creature)**:
>   - When `fix({ forwardOnly: true })` confirms forward-only, bump `semanticVersion` from `2.x.x` → `3.0.0` (never downgrade higher majors).
> - **NEAT Mutator**:
>   - After forward-only validation in `mutateCreature`, set `creature.forwardOnly = true` for non-feedback runs and upgrade `semanticVersion` via helper.
> - **Breeding (Offspring)**:
>   - On forward-only offspring validation, upgrade `semanticVersion` to `3.0.0` via helper.
> - **Tests**:
>   - Add `test/FeedForward/ForwardOnlySemanticVersion.ts` covering breeding/mutation upgrades and no-downgrade behavior.
>   - Update `test/fix/ForwardOnly.ts` to assert version bump post-fix.
> - **Config**:
>   - Bump package `version` to `0.261.0` in `deno.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74062029aa4ffc5d4667ef3fffcaa5d5f331c226. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->