### PR TITLE
Update version to 0.262.0 and enhance cost function support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.261.0",
+  "version": "0.262.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/Costs.ts
+++ b/src/Costs.ts
@@ -12,6 +12,28 @@ import { MSE } from "./costs/MSE.ts";
 import { MSLE } from "./costs/MSLE.ts";
 
 /**
+ * Built-in cost names supported by this library.
+ *
+ * These are exposed as a `readonly` tuple so TypeScript can provide:
+ * - IDE autocompletion for known values
+ * - compile-time prevention of invalid values (eg. "XYZ")
+ *
+ * If you need to use custom cost names (eg. via `Costs.registerCostFactory()`),
+ * you can widen the options type with `NeatOptions<YourUnion>` in your program.
+ */
+export const BUILT_IN_COST_NAMES = [
+  CrossEntropy.NAME,
+  MSE.NAME,
+  MAE.NAME,
+  MAPE.NAME,
+  MSLE.NAME,
+  HINGE.NAME,
+] as const;
+
+/** Union of built-in cost name string literals. */
+export type BuiltInCostName = typeof BUILT_IN_COST_NAMES[number];
+
+/**
  * Factory class for creating cost function instances.
  * Provides access to various loss functions used in neural network training.
  */

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -5,6 +5,7 @@ import type {
   DiscoveryMinCandidatesPerCategory,
   NeatArguments,
 } from "./NeatOptions.ts";
+import type { BuiltInCostName } from "../Costs.ts";
 import {
   DEFAULT_RUST_FLUSH_BYTES,
   DEFAULT_RUST_FLUSH_RECORDS,
@@ -51,7 +52,9 @@ export const DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY: Required<
  * Interface for NEAT (NeuroEvolution of Augmenting Topologies) training options.
  * Provides a read-only configuration object for the NEAT algorithm.
  */
-export type NeatConfig = Readonly<NeatArguments>;
+export type NeatConfig<TCostName extends string = BuiltInCostName> = Readonly<
+  NeatArguments<TCostName>
+>;
 
 /**
  * Creates a validated NEAT configuration from user options.
@@ -74,7 +77,9 @@ export type NeatConfig = Readonly<NeatArguments>;
  * });
  * ```
  */
-export function createNeatConfig(options: NeatOptions) {
+export function createNeatConfig<TCostName extends string = BuiltInCostName>(
+  options: NeatOptions<TCostName>,
+): NeatConfig<TCostName> {
   let selection: SelectionInterface = Selection.POWER;
   if (options.selection) {
     selection = options.selection;
@@ -87,13 +92,13 @@ export function createNeatConfig(options: NeatOptions) {
     }
   }
 
-  const config: NeatArguments = {
+  const config: NeatArguments<TCostName> = {
     creativeThinkingConnectionCount: options.creativeThinkingConnectionCount ??
       1,
     creatureStore: options.creatureStore,
     experimentStore: options.experimentStore,
     creatures: options.creatures ? options.creatures : [],
-    costName: options.costName || "MSE",
+    costName: (options.costName || "MSE") as TCostName,
     dataSetPartitionBreak: options.dataSetPartitionBreak ?? 2000,
     trainingSampleRate: options.trainingSampleRate ?? 1,
 
@@ -197,7 +202,7 @@ export function createNeatConfig(options: NeatOptions) {
   return Object.freeze(config);
 }
 
-function validate(config: NeatArguments) {
+function validate<TCostName extends string>(config: NeatArguments<TCostName>) {
   if (
     Number.isFinite(config.sparseRatio) === false || config.sparseRatio < 0 ||
     config.sparseRatio > 1

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -57,6 +57,24 @@ export type NeatConfig<TCostName extends string = BuiltInCostName> = Readonly<
 >;
 
 /**
+ * The default cost name applied by `createNeatConfig()` when none is provided.
+ *
+ * Keep this in sync with the runtime default in `createNeatConfig()`.
+ */
+type DefaultCostName = "MSE";
+
+/**
+ * If a caller provides a custom `TCostName` that does not include the runtime
+ * default ("MSE"), they must supply `costName` explicitly.
+ *
+ * This prevents an unsound type assertion where the runtime value is "MSE" but
+ * the return type claims it is `TCostName` (eg. `"CustomCost"`).
+ */
+type RequireCostNameWhenDefaultNotAllowed<TCostName extends string> =
+  DefaultCostName extends TCostName ? Record<never, never>
+    : { costName: TCostName };
+
+/**
  * Creates a validated NEAT configuration from user options.
  *
  * This function takes partial user options and fills in default values
@@ -77,7 +95,15 @@ export type NeatConfig<TCostName extends string = BuiltInCostName> = Readonly<
  * });
  * ```
  */
-export function createNeatConfig<TCostName extends string = BuiltInCostName>(
+export function createNeatConfig(
+  options: NeatOptions<BuiltInCostName>,
+): NeatConfig<BuiltInCostName>;
+export function createNeatConfig<TCostName extends string>(
+  options:
+    & NeatOptions<TCostName>
+    & RequireCostNameWhenDefaultNotAllowed<TCostName>,
+): NeatConfig<TCostName>;
+export function createNeatConfig<TCostName extends string>(
   options: NeatOptions<TCostName>,
 ): NeatConfig<TCostName> {
   let selection: SelectionInterface = Selection.POWER;
@@ -92,13 +118,21 @@ export function createNeatConfig<TCostName extends string = BuiltInCostName>(
     }
   }
 
+  let costName: TCostName;
+  if (options.costName !== undefined) {
+    costName = options.costName;
+  } else {
+    // Safe by construction: if costName is omitted, `TCostName` must include "MSE".
+    costName = "MSE" as unknown as TCostName;
+  }
+
   const config: NeatArguments<TCostName> = {
     creativeThinkingConnectionCount: options.creativeThinkingConnectionCount ??
       1,
     creatureStore: options.creatureStore,
     experimentStore: options.experimentStore,
     creatures: options.creatures ? options.creatures : [],
-    costName: (options.costName || "MSE") as TCostName,
+    costName,
     dataSetPartitionBreak: options.dataSetPartitionBreak ?? 2000,
     trainingSampleRate: options.trainingSampleRate ?? 1,
 

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -6,6 +6,7 @@ import type {
 import type { MutationInterface } from "../NEAT/MutationInterface.ts";
 import type { SelectionInterface } from "../methods/Selection.ts";
 import type { CrisprInterface } from "../../mod.ts";
+import type { BuiltInCostName } from "../Costs.ts";
 
 /**
  * Configuration for minimum candidates per discovery category.
@@ -25,9 +26,15 @@ export interface DiscoveryMinCandidatesPerCategory {
 /**
  * Interface for NEAT (NeuroEvolution of Augmenting Topologies) training options.
  */
-export interface NeatArguments {
-  /** The name of the cost function to use (optional). */
-  costName: string;
+/**
+ * Concrete, fully-populated configuration shape used internally after defaults
+ * are applied by `createNeatConfig()`.
+ *
+ * @internal
+ */
+export interface NeatArguments<TCostName extends string = BuiltInCostName> {
+  /** The name of the cost function to use. */
+  costName: TCostName;
 
   /**
    * Number of new links to create during the creative thinking phase.
@@ -305,8 +312,11 @@ export interface NeatArguments {
  * For discoveryMinCandidatesPerCategory, you can specify partial overrides
  * and defaults will be merged in.
  */
-export type NeatOptions =
-  & Omit<Partial<NeatArguments>, "discoveryMinCandidatesPerCategory">
+export type NeatOptions<TCostName extends string = BuiltInCostName> =
+  & Omit<
+    Partial<NeatArguments<TCostName>>,
+    "discoveryMinCandidatesPerCategory"
+  >
   & {
     /** Partial overrides for minimum candidates per category (defaults applied if not specified) */
     discoveryMinCandidatesPerCategory?: DiscoveryMinCandidatesPerCategory;

--- a/test/costName_types_test.ts
+++ b/test/costName_types_test.ts
@@ -1,4 +1,5 @@
 import type { NeatOptions } from "../mod.ts";
+import { createNeatConfig } from "../src/config/NeatConfig.ts";
 
 /**
  * Type-level tests for `NeatOptions.costName`.
@@ -18,6 +19,25 @@ const _invalid: NeatOptions = { costName: "XYZ" };
 
 // Escape hatch: callers with custom costs can widen the generic parameter.
 const _custom: NeatOptions<"MSE" | "XYZ"> = { costName: "XYZ" };
+
+/**
+ * Type-level tests for `createNeatConfig()` defaulting behaviour.
+ *
+ * The default cost name is currently "MSE". If callers provide a custom generic
+ * cost union that does NOT include "MSE", then `costName` must be supplied to
+ * avoid a runtime value that the type system says is impossible.
+ */
+
+// Default built-in config should allow omitting costName (defaults to "MSE").
+createNeatConfig({});
+
+// Custom configs must be explicit if they exclude the default "MSE".
+createNeatConfig<"CustomCost">({ costName: "CustomCost" });
+// @ts-expect-error - "MSE" is the runtime default, so omitting costName here is unsafe.
+createNeatConfig<"CustomCost">({});
+
+// If the custom union includes "MSE", omitting costName is safe and should compile.
+createNeatConfig<"MSE" | "CustomCost">({});
 
 Deno.test("type-only: NeatOptions.costName is restricted", () => {
   // Runtime is irrelevant; compilation is the test.

--- a/test/costName_types_test.ts
+++ b/test/costName_types_test.ts
@@ -22,4 +22,3 @@ const _custom: NeatOptions<"MSE" | "XYZ"> = { costName: "XYZ" };
 Deno.test("type-only: NeatOptions.costName is restricted", () => {
   // Runtime is irrelevant; compilation is the test.
 });
-

--- a/test/costName_types_test.ts
+++ b/test/costName_types_test.ts
@@ -1,0 +1,25 @@
+import type { NeatOptions } from "../mod.ts";
+
+/**
+ * Type-level tests for `NeatOptions.costName`.
+ *
+ * These intentionally rely on TypeScript compile-time behaviour:
+ * - `// @ts-expect-error` must FAIL compilation if the line does not error
+ * - valid literals should type-check cleanly
+ */
+
+// Valid built-in costs should be accepted.
+const _validMSE: NeatOptions = { costName: "MSE" };
+const _validMAE: NeatOptions = { costName: "MAE" };
+
+// Invalid cost names should be rejected at compile time.
+// @ts-expect-error - "XYZ" is not a built-in cost name.
+const _invalid: NeatOptions = { costName: "XYZ" };
+
+// Escape hatch: callers with custom costs can widen the generic parameter.
+const _custom: NeatOptions<"MSE" | "XYZ"> = { costName: "XYZ" };
+
+Deno.test("type-only: NeatOptions.costName is restricted", () => {
+  // Runtime is irrelevant; compilation is the test.
+});
+


### PR DESCRIPTION
- Bumped version in deno.json to 0.262.0.
- Introduced a new constant, BUILT_IN_COST_NAMES, to provide a list of supported cost function names, improving TypeScript autocompletion and type safety.
- Updated NeatConfig and NeatOptions to utilize the new BuiltInCostName type, ensuring better type management for cost function names in NEAT configurations.
- Enhanced createNeatConfig function to accept generic cost name types, allowing for more flexible configurations.

These changes aim to improve the usability and type safety of cost function management within the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens type-safety for cost function names by introducing built-in name tuple/types, making config types generic over cost names, overloading createNeatConfig with safe defaults, and adding type-level tests; bumps version to 0.262.0.
> 
> - **Types**:
>   - Add `BUILT_IN_COST_NAMES` and `BuiltInCostName` in `src/Costs.ts`.
>   - Make `NeatArguments`, `NeatOptions`, and `NeatConfig` generic over cost name (`TCostName`).
> - **Config API**:
>   - Overload `createNeatConfig()` to support generic cost names; default `costName` to `"MSE"` when allowed, otherwise require explicit `costName`.
>   - Update `validate()` to accept generic `NeatArguments<TCostName>`.
> - **Tests**:
>   - Add `test/costName_types_test.ts` to enforce compile-time restrictions and defaulting behavior for `costName`.
> - **Version**:
>   - Bump `deno.json` version to `0.262.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4ff0aeb77bae542ce25353d7100c228ec82d062. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->