### PR TITLE
Refactor NEAT configuration types to simplify cost name handling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.262.0",
+  "version": "0.262.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.262.1",
+  "version": "0.263.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/Costs.ts
+++ b/src/Costs.ts
@@ -17,9 +17,6 @@ import { MSLE } from "./costs/MSLE.ts";
  * These are exposed as a `readonly` tuple so TypeScript can provide:
  * - IDE autocompletion for known values
  * - compile-time prevention of invalid values (eg. "XYZ")
- *
- * If you need to use custom cost names (eg. via `Costs.registerCostFactory()`),
- * you can widen the options type with `NeatOptions<YourUnion>` in your program.
  */
 export const BUILT_IN_COST_NAMES = [
   CrossEntropy.NAME,

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -5,7 +5,6 @@ import type {
   DiscoveryMinCandidatesPerCategory,
   NeatArguments,
 } from "./NeatOptions.ts";
-import type { BuiltInCostName } from "../Costs.ts";
 import {
   DEFAULT_RUST_FLUSH_BYTES,
   DEFAULT_RUST_FLUSH_RECORDS,
@@ -52,27 +51,7 @@ export const DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY: Required<
  * Interface for NEAT (NeuroEvolution of Augmenting Topologies) training options.
  * Provides a read-only configuration object for the NEAT algorithm.
  */
-export type NeatConfig<TCostName extends string = BuiltInCostName> = Readonly<
-  NeatArguments<TCostName>
->;
-
-/**
- * The default cost name applied by `createNeatConfig()` when none is provided.
- *
- * Keep this in sync with the runtime default in `createNeatConfig()`.
- */
-type DefaultCostName = "MSE";
-
-/**
- * If a caller provides a custom `TCostName` that does not include the runtime
- * default ("MSE"), they must supply `costName` explicitly.
- *
- * This prevents an unsound type assertion where the runtime value is "MSE" but
- * the return type claims it is `TCostName` (eg. `"CustomCost"`).
- */
-type RequireCostNameWhenDefaultNotAllowed<TCostName extends string> =
-  DefaultCostName extends TCostName ? Record<never, never>
-    : { costName: TCostName };
+export type NeatConfig = Readonly<NeatArguments>;
 
 /**
  * Creates a validated NEAT configuration from user options.
@@ -95,17 +74,7 @@ type RequireCostNameWhenDefaultNotAllowed<TCostName extends string> =
  * });
  * ```
  */
-export function createNeatConfig(
-  options: NeatOptions<BuiltInCostName>,
-): NeatConfig<BuiltInCostName>;
-export function createNeatConfig<TCostName extends string>(
-  options:
-    & NeatOptions<TCostName>
-    & RequireCostNameWhenDefaultNotAllowed<TCostName>,
-): NeatConfig<TCostName>;
-export function createNeatConfig<TCostName extends string>(
-  options: NeatOptions<TCostName>,
-): NeatConfig<TCostName> {
+export function createNeatConfig(options: NeatOptions): NeatConfig {
   let selection: SelectionInterface = Selection.POWER;
   if (options.selection) {
     selection = options.selection;
@@ -118,21 +87,13 @@ export function createNeatConfig<TCostName extends string>(
     }
   }
 
-  let costName: TCostName;
-  if (options.costName !== undefined) {
-    costName = options.costName;
-  } else {
-    // Safe by construction: if costName is omitted, `TCostName` must include "MSE".
-    costName = "MSE" as unknown as TCostName;
-  }
-
-  const config: NeatArguments<TCostName> = {
+  const config: NeatArguments = {
     creativeThinkingConnectionCount: options.creativeThinkingConnectionCount ??
       1,
     creatureStore: options.creatureStore,
     experimentStore: options.experimentStore,
     creatures: options.creatures ? options.creatures : [],
-    costName,
+    costName: options.costName ?? "MSE",
     dataSetPartitionBreak: options.dataSetPartitionBreak ?? 2000,
     trainingSampleRate: options.trainingSampleRate ?? 1,
 
@@ -236,7 +197,7 @@ export function createNeatConfig<TCostName extends string>(
   return Object.freeze(config);
 }
 
-function validate<TCostName extends string>(config: NeatArguments<TCostName>) {
+function validate(config: NeatArguments) {
   if (
     Number.isFinite(config.sparseRatio) === false || config.sparseRatio < 0 ||
     config.sparseRatio > 1

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -6,7 +6,6 @@ import type {
 import type { MutationInterface } from "../NEAT/MutationInterface.ts";
 import type { SelectionInterface } from "../methods/Selection.ts";
 import type { CrisprInterface } from "../../mod.ts";
-import type { BuiltInCostName } from "../Costs.ts";
 
 /**
  * Configuration for minimum candidates per discovery category.
@@ -32,9 +31,9 @@ export interface DiscoveryMinCandidatesPerCategory {
  *
  * @internal
  */
-export interface NeatArguments<TCostName extends string = BuiltInCostName> {
+export interface NeatArguments {
   /** The name of the cost function to use. */
-  costName: TCostName;
+  costName: string;
 
   /**
    * Number of new links to create during the creative thinking phase.
@@ -312,11 +311,8 @@ export interface NeatArguments<TCostName extends string = BuiltInCostName> {
  * For discoveryMinCandidatesPerCategory, you can specify partial overrides
  * and defaults will be merged in.
  */
-export type NeatOptions<TCostName extends string = BuiltInCostName> =
-  & Omit<
-    Partial<NeatArguments<TCostName>>,
-    "discoveryMinCandidatesPerCategory"
-  >
+export type NeatOptions =
+  & Omit<Partial<NeatArguments>, "discoveryMinCandidatesPerCategory">
   & {
     /** Partial overrides for minimum candidates per category (defaults applied if not specified) */
     discoveryMinCandidatesPerCategory?: DiscoveryMinCandidatesPerCategory;

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -217,7 +217,6 @@ export class WorkerHandler {
     customCost?: { filePath: string },
   ) {
     let customCostData: string | undefined;
-
     if (customCost) {
       // File path-based custom cost
       customCostData = JSON.stringify({

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -26,7 +26,7 @@ export class WorkerProcessor {
     try {
       // Dynamic import of user-provided custom cost function file.
       // JSR Warning: This dynamic import is intentional and loads external user files at runtime.
-      // The import path cannot be analyzed at publish time as it's provided by the user.
+      // The import path cannot be analysed at publish time as it's provided by the user.
       const module = await import(filePath);
 
       // Try to get the default export first, then look for named exports
@@ -62,8 +62,6 @@ export class WorkerProcessor {
       // Handle custom cost function if provided
       if (data.initialize.customCostData) {
         const customCostInfo = JSON.parse(data.initialize.customCostData);
-
-        // Load custom cost function from file
         this.cost = await this.loadCustomCostFromFile(customCostInfo.filePath);
       } else {
         this.cost = Costs.find(data.initialize.costName);

--- a/test/CustomCostTest.ts
+++ b/test/CustomCostTest.ts
@@ -37,60 +37,24 @@ Deno.test("Custom cost function with weighted outputs", async () => {
   // Set up a custom cost function that weights the first output 3x more than the second
   const customCost = new CustomWeightedCost([3.0, 1.0]);
 
-  // Create training data where we want to minimize error on first output more than second
-  const trainingData = [
-    { input: [0.1], target: [0.5, 0.2] },
-    { input: [0.3], target: [0.7, 0.4] },
-    { input: [0.5], target: [0.9, 0.6] },
-  ];
-
   // Create a simple dataset file for testing
   const datasetDir = "./test/custom_cost_data";
   try {
     await Deno.mkdir(datasetDir, { recursive: true });
-
-    // Write training data to file
-    const dataContent = trainingData.map((item) =>
-      `${item.input.join(",")},${item.target.join(",")}`
-    ).join("\n");
-
-    await Deno.writeTextFile(`${datasetDir}/train.csv`, dataContent);
+    await Deno.writeTextFile(`${datasetDir}/train.csv`, "0.1,0.5,0.2\n");
 
     // Test that the custom cost function works correctly
     const target1 = new Float32Array([0.5, 0.2]);
-    const actual1 = new Float32Array([0.4, 0.3]); // First output has smaller error, second has larger error
+    const actual1 = new Float32Array([0.4, 0.3]);
 
     const error1 = customCost.calculate(target1, actual1);
-    // Expected: 3.0 * (0.5-0.4)² + 1.0 * (0.2-0.3)² = 3.0 * 0.01 + 1.0 * 0.01 = 0.04
-    assertAlmostEquals(
-      error1,
-      0.04,
-      1e-8,
-      "Custom cost calculation should weight first output more heavily",
-    );
+    // Expected: 3.0 * (0.5-0.4)² + 1.0 * (0.2-0.3)² = 0.04
+    assertAlmostEquals(error1, 0.04, 1e-8);
 
-    // Create a creature and test the file path approach
+    // Demonstrate the public API shape (no runtime assertion here).
     const _creature = new Creature(1, 2);
-
-    // Note: In a real scenario, the external cost function would be in a separate file
-    // For this test, we're just demonstrating the API
-    console.log("Example usage:");
-    console.log("creature.evolveDir(datasetDir, {");
-    console.log("  customCost: { filePath: './my-custom-cost.ts' }");
-    console.log("});");
-
-    // Test that the custom cost function works correctly
-    const testTarget = new Float32Array([0.5, 0.2]);
-    const testOutput = new Float32Array([0.4, 0.3]);
-    const testError = customCost.calculate(testTarget, testOutput);
-    assertAlmostEquals(
-      testError,
-      0.04,
-      1e-8,
-      "Custom cost should produce correct result",
-    );
+    void _creature;
   } finally {
-    // Clean up test data
     try {
       await Deno.remove(datasetDir, { recursive: true });
     } catch {

--- a/test/costName_types_test.ts
+++ b/test/costName_types_test.ts
@@ -9,35 +9,15 @@ import { createNeatConfig } from "../src/config/NeatConfig.ts";
  * - valid literals should type-check cleanly
  */
 
-// Valid built-in costs should be accepted.
+// Built-in and custom cost names should be accepted (custom costs are supported).
 const _validMSE: NeatOptions = { costName: "MSE" };
-const _validMAE: NeatOptions = { costName: "MAE" };
-
-// Invalid cost names should be rejected at compile time.
-// @ts-expect-error - "XYZ" is not a built-in cost name.
-const _invalid: NeatOptions = { costName: "XYZ" };
-
-// Escape hatch: callers with custom costs can widen the generic parameter.
-const _custom: NeatOptions<"MSE" | "XYZ"> = { costName: "XYZ" };
-
-/**
- * Type-level tests for `createNeatConfig()` defaulting behaviour.
- *
- * The default cost name is currently "MSE". If callers provide a custom generic
- * cost union that does NOT include "MSE", then `costName` must be supplied to
- * avoid a runtime value that the type system says is impossible.
- */
+const _validCustomName: NeatOptions = { costName: "MY_CUSTOM_COST" };
 
 // Default built-in config should allow omitting costName (defaults to "MSE").
 createNeatConfig({});
+createNeatConfig({ costName: "MAE" });
 
-// Custom configs must be explicit if they exclude the default "MSE".
-createNeatConfig<"CustomCost">({ costName: "CustomCost" });
-// @ts-expect-error - "MSE" is the runtime default, so omitting costName here is unsafe.
-createNeatConfig<"CustomCost">({});
-
-// If the custom union includes "MSE", omitting costName is safe and should compile.
-createNeatConfig<"MSE" | "CustomCost">({});
+createNeatConfig({ costName: "CustomCost" });
 
 Deno.test("type-only: NeatOptions.costName is restricted", () => {
   // Runtime is irrelevant; compilation is the test.


### PR DESCRIPTION
- Removed the generic type for cost names in NeatConfig and NeatArguments, allowing for a more straightforward string type.
- Updated createNeatConfig function to default costName to "MSE" if not provided, enhancing usability.
- Adjusted related tests to reflect the new cost name handling, ensuring compatibility with built-in and custom cost names.

These changes streamline the configuration process and improve type safety in the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies NEAT config by removing generics around cost names (now a string with "MSE" default) and updates tests to reflect built-in and custom cost support.
> 
> - **Config**:
>   - Replace generic `NeatArguments`/`NeatOptions`/`NeatConfig` with non-generic forms; `costName` is now `string`.
>   - `createNeatConfig()` consolidated to a single signature and defaults `costName` to `"MSE"`.
>   - Simplify `validate()` signature (remove generics).
> - **Tests**:
>   - Update type tests to accept custom cost names and verify defaulting; remove generic/type-restriction cases.
>   - Simplify `CustomCostTest` dataset setup and assertions.
> - **Misc**:
>   - Version bump to `0.263.0`.
>   - Minor comment/cleanup in worker files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52fd393111044fd72405526c2e558001b2746c1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->