### PR TITLE
Update Upgrade.ts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.264.0",
+  "version": "0.264.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -35,13 +35,13 @@ function validateThreeX(creature: Creature): void {
   try {
     creatureValidate(creature, { forwardOnly: true });
   } catch (error) {
-    throw new Error(
+    console.warn( new Error(
       `[upgrade] Version 3.x creature has invalid self/back connections. ` +
         `This should never happen - 3.x creatures must remain forward-only. ` +
         `UUID: ${creature.uuid}, Error: ${
           error instanceof Error ? error.message : error
         }`,
-    );
+    ));
   }
 }
 

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -35,13 +35,15 @@ function validateThreeX(creature: Creature): void {
   try {
     creatureValidate(creature, { forwardOnly: true });
   } catch (error) {
-    console.warn( new Error(
-      `[upgrade] Version 3.x creature has invalid self/back connections. ` +
-        `This should never happen - 3.x creatures must remain forward-only. ` +
-        `UUID: ${creature.uuid}, Error: ${
-          error instanceof Error ? error.message : error
-        }`,
-    ));
+    console.warn(
+      new Error(
+        `[upgrade] Version 3.x creature has invalid self/back connections. ` +
+          `This should never happen - 3.x creatures must remain forward-only. ` +
+          `UUID: ${creature.uuid}, Error: ${
+            error instanceof Error ? error.message : error
+          }`,
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Validation for 3.x creatures now logs a warning instead of throwing; package version bumped to 0.264.1.
> 
> - **Upgrade logic (`src/upgrade/Upgrade.ts`)**:
>   - `validateThreeX`: replaces thrown error with `console.warn(new Error(...))` when a 3.x creature fails forward-only validation.
> - **Versioning**:
>   - Bumps `deno.json` `version` from `0.264.0` to `0.264.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6cab98c68288544ddac149a1e200245e760719f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->