### PR TITLE
Update version to 0.265.0 and enhance offspring versioning logic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.264.0",
+  "version": "0.265.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -21,6 +21,17 @@ function upgradeSemanticVersionIfForwardOnlyConfirmed(creature: Creature) {
   }
 }
 
+/**
+ * Extracts the major version number from a semantic version string.
+ * @param version - Semantic version string (e.g., "3.1.0", "2.0.0")
+ * @returns The major version number, or 0 if invalid/undefined
+ */
+function getMajorVersion(version: string | undefined): number {
+  if (!version) return 0;
+  const major = parseInt(version.split(".")[0], 10);
+  return Number.isNaN(major) ? 0 : major;
+}
+
 class OffspringError extends Error {
   constructor(message: string) {
     super(message);
@@ -61,10 +72,21 @@ export class Offspring {
       fixAliases = true;
     }
 
+    // Determine offspring semantic version based on BOTH parents.
+    // Only start at 3.x if BOTH parents are 3.x (validated forward-only).
+    // Otherwise start at the lower version - validation will upgrade if appropriate.
+    const motherMajor = getMajorVersion(mother.semanticVersion);
+    const fatherMajor = getMajorVersion(father.semanticVersion);
+    const offspringVersion = (motherMajor >= 3 && fatherMajor >= 3)
+      ? mother.semanticVersion
+      : (motherMajor < fatherMajor
+        ? mother.semanticVersion
+        : father.semanticVersion);
+
     // Initialize offspring
     const offspring = new Creature(mother.input, mother.output, {
       lazyInitialization: true,
-      semanticVersion: mother.semanticVersion,
+      semanticVersion: offspringVersion,
     });
     offspring.synapses = [];
     offspring.neurons = [];
@@ -303,6 +325,9 @@ export class Offspring {
       (options.forwardOnly === undefined &&
         (mum.forwardOnly === true || dad.forwardOnly === true));
 
+    // Check if both parents are 3.x (validated forward-only)
+    const bothParentsThreeX = motherMajor >= 3 && fatherMajor >= 3;
+
     try {
       creatureValidate(offspring);
 
@@ -333,12 +358,27 @@ export class Offspring {
                   offspring.neurons[s.from]?.ID?.() ?? "?"
                 }) -> ${s.to} (${offspring.neurons[s.to]?.ID?.() ?? "?"})`
               );
-            console.error(
-              `[Offspring] Forward-only violation after breed(). This indicates a bug. ` +
-                `Error=${error.name}: ${error.message}. ` +
+
+            // If BOTH parents are 3.x, this is a bug in the breeding logic
+            if (bothParentsThreeX) {
+              throw new Error(
+                `[Offspring] CRITICAL: Both parents are 3.x but offspring has self/back connections. ` +
+                  `This is a bug in the breeding logic that must be fixed. ` +
+                  `Mother: ${mother.uuid} (${mother.semanticVersion}), ` +
+                  `Father: ${father.uuid} (${father.semanticVersion}). ` +
+                  `Error=${error.name}: ${error.message}. ` +
+                  `Violations: ${violations.join(" | ")}`,
+              );
+            }
+
+            // If either parent is 2.x, fixing is expected and OK
+            console.warn(
+              `[Offspring] Forward-only violation after breed() with 2.x parent. ` +
+                `Fixing offspring. Error=${error.name}: ${error.message}. ` +
                 `Violations(sample up to 10): ${violations.join(" | ")}`,
             );
             offspring.fix({ forwardOnly: true });
+            upgradeSemanticVersionIfForwardOnlyConfirmed(offspring);
           } else {
             throw e;
           }

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -26,19 +26,22 @@ function getMajorVersion(version: string | undefined): number {
 
 /**
  * Validates that a 3.x creature is still forward-only.
- * Throws an error if the creature has self/back connections.
+ * If the creature has self/back connections, logs a warning but does NOT modify
+ * the creature. Fixing should only happen on offspring, not on parents during
+ * breeding.
  *
  * @param creature - The 3.x creature to validate
- * @throws {Error} If the creature has self/back connections
  */
 function validateThreeX(creature: Creature): void {
   try {
     creatureValidate(creature, { forwardOnly: true });
   } catch (error) {
-    throw new Error(
+    // This should never happen - 3.x creatures should have been validated.
+    // Log the error but don't modify the creature - offspring validation will
+    // handle any issues during breeding.
+    console.error(
       `[upgrade] Version 3.x creature has invalid self/back connections. ` +
-        `This should never happen - 3.x creatures must remain forward-only. ` +
-        `UUID: ${creature.uuid}, Error: ${
+        `This indicates a data integrity issue. UUID: ${creature.uuid}, Error: ${
           error instanceof Error ? error.message : error
         }`,
     );

--- a/test/Upgrade/VersionThree.ts
+++ b/test/Upgrade/VersionThree.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { Creature } from "../../mod.ts";
 import { SEMANTIC_MAJOR_VERSION, upgrade } from "../../src/upgrade/Upgrade.ts";
 
@@ -133,9 +133,9 @@ Deno.test("upgrade should validate and not modify 3.x.x creatures with patch ver
   );
 });
 
-// === 3.x creatures with self/back connections should throw an error ===
+// === 3.x creatures with self/back connections should log warning but not modify ===
 
-Deno.test("upgrade should throw error for 3.x creature with self-connection", () => {
+Deno.test("upgrade should log warning but not modify 3.x creature with self-connection", () => {
   // Create a creature and manually add a self-connection to simulate the error
   const creature = new Creature(2, 1, {
     layers: [{ count: 2 }],
@@ -146,11 +146,25 @@ Deno.test("upgrade should throw error for 3.x creature with self-connection", ()
   const hiddenNeuron = creature.neurons[creature.input]; // First hidden neuron
   creature.connect(hiddenNeuron.index, hiddenNeuron.index, 0.5);
 
-  assertThrows(
-    () => upgrade(creature),
-    Error,
-    "self/back connections",
-    "3.x creatures with self-connections should throw an error",
+  // Should not throw and should not modify - just log a warning
+  // (Fixing should only happen on offspring, not parents during breeding)
+  const upgraded = upgrade(creature);
+
+  assertEquals(
+    upgraded.semanticVersion,
+    "3.0.0",
+    "3.x creatures should not be modified by upgrade() - offspring validation handles fixing",
+  );
+
+  // Verify the self-connection was NOT removed (creature not modified)
+  const selfConnection = upgraded.getSynapse(
+    hiddenNeuron.index,
+    hiddenNeuron.index,
+  );
+  assertEquals(
+    selfConnection !== null,
+    true,
+    "Self-connection should NOT be removed - fixing happens on offspring only",
   );
 });
 


### PR DESCRIPTION
- Bumped version in deno.json to 0.265.0.
- Introduced a new function, getMajorVersion, to extract the major version from semantic version strings.
- Enhanced the Offspring class to determine offspring semantic version based on both parents' versions, ensuring correct versioning behavior.
- Updated validation logic to log warnings for 3.x creatures with self/back connections without modifying them, improving data integrity during breeding.

These changes improve version management and clarity in the NEAT framework's offspring handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps to 0.265.0 and revises offspring semantic version derivation and forward-only validation, while making 3.x upgrade validation warn-only and updating tests accordingly.
> 
> - **Architecture (`src/architecture/Offspring.ts`)**:
>   - Determine offspring `semanticVersion` using both parents via `getMajorVersion`; start at 3.x only if both parents are 3.x, otherwise use the lower parent's version.
>   - Forward-only handling: if both parents are 3.x and violations occur, throw a critical error; if any parent is 2.x, log, `fix({ forwardOnly: true })`, and upgrade semantic version when confirmed.
> - **Upgrade (`src/upgrade/Upgrade.ts`)**:
>   - `validateThreeX` now logs a warning for invalid 3.x (self/back connections) without modifying the creature; offspring logic handles fixes.
>   - Retains upgrade rules: 2.x + `forwardOnly: true` validates to 3.0.0; otherwise versions are preserved and validated.
> - **Tests (`test/Upgrade/VersionThree.ts`)**:
>   - Update to expect warning-not-throw for invalid 3.x and assert no modification (self-connection remains).
>   - Minor cleanup: remove unused `assertThrows` import.
> - **Config**:
>   - `deno.json`: version bumped to `0.265.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 905a1d671f8f0b9527c468e0560742daf588e508. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->