### PR TITLE
Enhance ELU activation function to handle non-finite inputs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.265.0",
+  "version": "0.266.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/methods/activations/types/ELU.ts
+++ b/src/methods/activations/types/ELU.ts
@@ -33,6 +33,7 @@ export class ELU implements ActivationInterface, UnSquashInterface {
   }
 
   squash(x: number): number {
+    if (!Number.isFinite(x)) return 0; // guard for NaN or Infinity
     const value = x > 0 ? x : ELU.ALPHA * (Math.exp(x) - 1);
     return this.range.limit(value, x);
   }

--- a/src/methods/activations/types/ELU.ts
+++ b/src/methods/activations/types/ELU.ts
@@ -33,7 +33,7 @@ export class ELU implements ActivationInterface, UnSquashInterface {
   }
 
   squash(x: number): number {
-    if (!Number.isFinite(x)) return 0; // guard for NaN or Infinity
+    if (Number.isNaN(x)) return 0; // guard for NaN only; let range.limit() handle Infinity
     const value = x > 0 ? x : ELU.ALPHA * (Math.exp(x) - 1);
     return this.range.limit(value, x);
   }

--- a/test/squash/activations/ELU.ts
+++ b/test/squash/activations/ELU.ts
@@ -8,18 +8,26 @@ Deno.test("ELU: squash handles NaN input gracefully", () => {
   const result = fn.squash(NaN);
   assertEquals(result, 0, "squash(NaN) should return 0");
   assert(Number.isFinite(result), "squash(NaN) must return a finite value");
+});
 
-  // Also check positive and negative Infinity
+Deno.test("ELU: squash handles Infinity correctly via range.limit()", () => {
+  const fn = new ELU();
+
+  // For +Infinity: ELU formula gives x (since x > 0), then range.limit() caps to MAX_SAFE_INTEGER
   const posInf = fn.squash(Infinity);
-  assert(
-    Number.isFinite(posInf),
-    "squash(Infinity) must return a finite value",
+  assertEquals(
+    posInf,
+    Number.MAX_SAFE_INTEGER,
+    "squash(Infinity) should return MAX_SAFE_INTEGER (capped by range.limit)",
   );
 
+  // For -Infinity: ELU formula gives α * (exp(-Infinity) - 1) = 1 * (0 - 1) = -1
+  // This is within the valid range [-α, MAX_SAFE_INTEGER], so it returns -1
   const negInf = fn.squash(-Infinity);
-  assert(
-    Number.isFinite(negInf),
-    "squash(-Infinity) must return a finite value",
+  assertEquals(
+    negInf,
+    -1,
+    "squash(-Infinity) should return -1 (mathematically correct for ELU)",
   );
 });
 

--- a/test/squash/activations/ELU.ts
+++ b/test/squash/activations/ELU.ts
@@ -1,5 +1,27 @@
-import { assert, assertAlmostEquals } from "@std/assert";
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
 import { ELU } from "../../../src/methods/activations/types/ELU.ts";
+
+Deno.test("ELU: squash handles NaN input gracefully", () => {
+  const fn = new ELU();
+
+  // Should return 0 for NaN input (not throw or return NaN)
+  const result = fn.squash(NaN);
+  assertEquals(result, 0, "squash(NaN) should return 0");
+  assert(Number.isFinite(result), "squash(NaN) must return a finite value");
+
+  // Also check positive and negative Infinity
+  const posInf = fn.squash(Infinity);
+  assert(
+    Number.isFinite(posInf),
+    "squash(Infinity) must return a finite value",
+  );
+
+  const negInf = fn.squash(-Infinity);
+  assert(
+    Number.isFinite(negInf),
+    "squash(-Infinity) must return a finite value",
+  );
+});
 
 Deno.test("ELU: squash, unsquash, and derivative cross-check", () => {
   const fn = new ELU();


### PR DESCRIPTION
- Added a guard clause in the ELU class's squash method to return 0 for NaN and ensure finite values for Infinity inputs.
- Introduced new tests to validate the behavior of the squash method when handling NaN and Infinity, confirming it returns finite values as expected.

These changes improve the robustness of the ELU activation function in handling edge cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> ELU.squash now guards NaN (returns 0) and relies on range limiting for Infinity, with new tests validating these cases.
> 
> - **Activation: `ELU`**
>   - Add NaN guard in `squash(x)` to return `0`; keep Infinity handling via `range.limit()`.
> - **Tests**
>   - Add tests for `squash(NaN) => 0` and Infinity behavior (capped `+∞`, `-1` for `-∞`).
>   - Cross-check test for `squash`/`unSquash`/`derivative` updated to ensure numerical consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e66898afaa15194ee88ffd25c845e68ceb0c4ff7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->