### PR TITLE
Update version to 0.267.0 and enhance bias compensation logic in neur…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.266.0",
+  "version": "0.267.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
@@ -16,8 +16,12 @@ export interface RemovalCandidate {
   totalError: number;
   impact: number;
   reason: string;
-  /** Average activation for bias adjustment during removal (computed lazily). */
-  averageActivation?: number;
+  /**
+   * Mean activation of the removed neuron across the discovery dataset.
+   * Used for bias compensation during ablation so downstream neurons preserve
+   * their average pre-activation value.
+   */
+  meanActivation?: number;
   /**
    * Optional diagnostic comment emitted by the Rust discovery engine.
    * This must not affect ranking/selection logic.
@@ -36,6 +40,7 @@ export function fromRustRemovalCandidate(
     totalError: rust.totalError,
     impact: rust.impact,
     reason: rust.reason,
+    meanActivation: rust.meanActivation,
     comment: rust.comment,
   };
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -4986,8 +4986,37 @@ export class DiscoverStructure {
     const originalSynapseCount = simplifiedExport.synapses.length;
     const originalNeuronCount = simplifiedExport.neurons.length;
 
-    // Low-impact neurons have negligible effect on outputs, so we skip bias adjustment.
-    // Just remove all synapses to/from this neuron.
+    // Bias compensation (average-preserving ablation):
+    // For each outgoing synapse X -> T with weight w, removing X deletes an average
+    // contribution of (w * meanActivation(X)) from T's pre-activation sum.
+    // Compensate by adjusting T.bias += w * meanActivation(X) for all targets T.
+    const meanActivation = removalCandidate.meanActivation;
+    if (typeof meanActivation === "number" && Number.isFinite(meanActivation)) {
+      const outgoing = simplifiedExport.synapses.filter(
+        (synapse) => synapse.fromUUID === removalCandidate.neuronUUID,
+      );
+
+      if (outgoing.length > 0) {
+        const weightSumsByTarget = new Map<string, number>();
+        for (const synapse of outgoing) {
+          if (synapse.toUUID === removalCandidate.neuronUUID) continue;
+          weightSumsByTarget.set(
+            synapse.toUUID,
+            (weightSumsByTarget.get(synapse.toUUID) ?? 0) + synapse.weight,
+          );
+        }
+
+        for (const [targetUUID, weightSum] of weightSumsByTarget) {
+          const target = simplifiedExport.neurons.find((n) =>
+            n.uuid === targetUUID
+          );
+          if (!target) continue;
+          target.bias = (target.bias ?? 0) + (weightSum * meanActivation);
+        }
+      }
+    }
+
+    // Remove all synapses to/from this neuron.
     simplifiedExport.synapses = simplifiedExport.synapses.filter(
       (synapse) =>
         synapse.fromUUID !== removalCandidate.neuronUUID &&

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -253,6 +253,12 @@ export interface RustRemovalCandidate {
   impact: number;
   reason: string; // e.g., "High error (5.0000) but very low impact (0.000100) - far from outputs"
   /**
+   * Mean activation of the removed neuron across the full discovery dataset.
+   * Used for bias compensation during ablation so downstream neurons preserve
+   * their average pre-activation value.
+   */
+  meanActivation?: number;
+  /**
    * Optional diagnostic comment emitted by the Rust discovery engine.
    * This must not affect ranking/selection logic.
    */

--- a/test/discovery/RemovalCandidates.ts
+++ b/test/discovery/RemovalCandidates.ts
@@ -16,7 +16,69 @@ import {
 } from "../../src/discovery/DiscoveryCandidates.ts";
 import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
 
-Deno.test("removeLowImpactNeuron removes neuron without bias adjustment", () => {
+Deno.test("removeLowImpactNeuron applies bias compensation for outgoing synapses", () => {
+  // X -> T removes average contribution of (w * meanActivation(X)) from T's pre-activation sum,
+  // so compensate by adjusting T.bias += w * meanActivation(X).
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", squash: "IDENTITY", bias: 0.25, uuid: "neuron-X" },
+      { type: "hidden", squash: "IDENTITY", bias: -0.1, uuid: "neuron-T" },
+      { type: "output", squash: "IDENTITY", bias: 0.05, uuid: "output-0" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "neuron-X", weight: 1.0 },
+      { fromUUID: "neuron-X", toUUID: "neuron-T", weight: -1.2 },
+      { fromUUID: "neuron-X", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "neuron-T", toUUID: "output-0", weight: 0.25 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: -0.25 },
+    ],
+  });
+
+  const candidate: RemovalCandidate = {
+    neuronUUID: "neuron-X",
+    totalError: 5.0,
+    impact: 0.001,
+    reason: "Test",
+    meanActivation: 0.4,
+  };
+
+  const result = DiscoverStructure.removeLowImpactNeuron(
+    "test-discovery",
+    creature,
+    candidate,
+  );
+
+  assertExists(result, "Should return a modified creature");
+
+  // Verify the neuron was removed
+  assertEquals(
+    result.neurons.some((n) => n.uuid === "neuron-X"),
+    false,
+    "Removed neuron should not exist",
+  );
+  assertEquals(
+    result.exportJSON().synapses.some((s) =>
+      s.fromUUID === "neuron-X" || s.toUUID === "neuron-X"
+    ),
+    false,
+    "All synapses to/from removed neuron should be removed",
+  );
+
+  // Bias compensation checks:
+  // - neuron-T.bias += (-1.2 * 0.4) = -0.48
+  // - output-0.bias += (0.5 * 0.4) = +0.2
+  const neuronT = result.neurons.find((n) => n.uuid === "neuron-T");
+  assertExists(neuronT, "Target neuron should remain");
+  assertEquals(neuronT.bias, -0.1 + (-1.2 * 0.4));
+
+  const output0 = result.neurons.find((n) => n.uuid === "output-0");
+  assertExists(output0, "Output neuron should remain");
+  assertEquals(output0.bias, 0.05 + (0.5 * 0.4));
+});
+
+Deno.test("removeLowImpactNeuron makes no bias changes when removed neuron has no outgoing synapses", () => {
   // Create a simple creature with a hidden neuron
   const creature = Creature.fromJSON({
     input: 2,
@@ -37,6 +99,7 @@ Deno.test("removeLowImpactNeuron removes neuron without bias adjustment", () => 
     totalError: 5.0,
     impact: 0.001, // Very low impact (0.1%)
     reason: "High error but very low impact - far from outputs",
+    meanActivation: 123.456, // Should be ignored because there are no outgoing synapses
   };
 
   const result = DiscoverStructure.removeLowImpactNeuron(
@@ -59,6 +122,10 @@ Deno.test("removeLowImpactNeuron removes neuron without bias adjustment", () => 
     "Should have 1 non-input neuron remaining (the output)",
   );
   assertEquals(result.synapses.length, 1, "Should have 1 synapse remaining");
+
+  const output0 = result.neurons.find((n) => n.uuid === "output-0");
+  assertExists(output0, "Output neuron should remain");
+  assertEquals(output0.bias, 0, "Output bias should be unchanged");
 });
 
 Deno.test("removeLowImpactNeuron returns undefined for non-existent neuron", () => {


### PR DESCRIPTION
…on removal process

- Bumped version in deno.json to 0.267.0.
- Updated the RemovalCandidate interface to include meanActivation for bias compensation during neuron removal.
- Enhanced the DiscoverStructure class to adjust target neuron biases based on the mean activation of removed neurons, ensuring average-preserving ablation.
- Added tests to validate the new bias compensation behavior when removing low-impact neurons, confirming expected adjustments to target neuron biases.

These changes improve the accuracy of neuron removal processes in the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements average-preserving bias compensation when removing low-impact neurons, adds `meanActivation` to candidate types, updates mapping, adds tests, and bumps version to 0.267.0.
> 
> - **Evolution logic**:
>   - **Bias-compensated ablation**: In `DiscoverStructure.removeLowImpactNeuron`, adjust downstream neuron `bias` by `Σ(weight) * meanActivation` per target before removing all connections and the neuron.
> - **Types/interop**:
>   - Extend `RemovalCandidate` and `RustRemovalCandidate` with optional `meanActivation`; update `fromRustRemovalCandidate` mapping in `DiscoverResult.ts`.
> - **Tests**:
>   - Add tests validating bias compensation effects and no-op bias changes when the removed neuron has no outgoing synapses.
> - **Version**: bump `deno.json` version to `0.267.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b7a8d93333f17f2a74852db25d6e0d7522c70b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->