### PR TITLE
Update version to 0.269.0 and enhance neuron activation logic in NEAT…

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ For detailed documentation, see the [docs/](./docs/) directory:
 - **[Discovery Guide](./docs/DISCOVERY_GUIDE.md)**: Complete guide to
   distributed, multi-machine discovery workflows
 - **[Elastic back propagation](./docs/BACKPROP_ELASTICITY.md)**: Why we prefer
-  minimum-change weight updates and avoid pushing saturated squashes (eg. ArcTan)
-  further into saturation
+  minimum-change weight updates and avoid pushing saturated squashes (eg.
+  ArcTan) further into saturation
 - **[DiscoveryDir API](./docs/DiscoveryDir.md)**: Technical API reference for
   `Creature.discoveryDir()` and data preparation
 - **[GPU Acceleration](./docs/GPU_ACCELERATION.md)**: GPU acceleration for

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ For detailed documentation, see the [docs/](./docs/) directory:
 
 - **[Discovery Guide](./docs/DISCOVERY_GUIDE.md)**: Complete guide to
   distributed, multi-machine discovery workflows
+- **[Elastic back propagation](./docs/BACKPROP_ELASTICITY.md)**: Why we prefer
+  minimum-change weight updates and avoid pushing saturated squashes (eg. ArcTan)
+  further into saturation
 - **[DiscoveryDir API](./docs/DiscoveryDir.md)**: Technical API reference for
   `Creature.discoveryDir()` and data preparation
 - **[GPU Acceleration](./docs/GPU_ACCELERATION.md)**: GPU acceleration for

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.268.0",
+  "version": "0.269.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/BACKPROP_ELASTICITY.md
+++ b/docs/BACKPROP_ELASTICITY.md
@@ -1,0 +1,128 @@
+## Elastic back propagation (minimum-change + safe-zone aware)
+
+This project uses a value-solving form of back propagation.
+
+Instead of only using chain-rule gradients everywhere, we often compute a
+**target pre-squash value** for a neuron and then adjust **biases and inbound
+synapse weights** to move the neuron toward that target.
+
+This works well for many squashes, but it can behave poorly near **saturation**
+(or near non-invertible regions) unless we actively avoid “forcing” already
+immovable neurons.
+
+### The core problem: saturation and inverse targets
+
+Some squashes have bounded activation ranges:
+
+- **ArcTan**: activation range is \((-\pi/2, +\pi/2)\)
+- **TANH**: activation range is \((-1, +1)\)
+- **LOGISTIC**: activation range is \((0, 1)\)
+- **HARD_TANH / ReLU6 / STEP**: piecewise and/or clipped regions
+
+If a neuron is already saturated and the training target is “at the boundary”,
+an inverse (`unSquash`) can imply an _enormous_ change in raw input for only a
+tiny change in activation.
+
+That can create large value-space errors which then:
+
+- dominate per-neuron traces in Explorer
+- cause discovery focus selection to “chase” meaningless outliers
+- slow evolution due to excessive error magnitudes
+
+### The fix: allocate error where it is cheapest to change
+
+When a neuron has many inbound synapses, we treat the neuron’s pre-activation
+as:
+
+\[ v = b + \sum_i (w_i \cdot a_i) \]
+
+If we want to change \(v\) by \(\Delta v\), the **minimum overall weight
+change** heuristic allocates per-link contribution changes proportional to
+\(a_i^2\).
+
+In code, each inbound link gets a score:
+
+- `score_i = (activation_i^2) * safeZoneFactor_i`
+
+Then:
+
+- `share_i = error * score_i / Σ(score)`
+
+This is “elasticity”: links that can move the neuron with smaller weight changes
+absorb more of the required value change.
+
+### Safe-zone awareness (don’t push saturated parents further)
+
+Many squashes implement `safeZoneAdjustment(rawInput, error, weight)` which
+returns a factor in \([0,1]\). It is designed to:
+
+- **prefer** updates when the neuron is in its strong-gradient region
+- **reduce** or **block** updates that push a saturated neuron further into
+  saturation
+- optionally allow “recovery” when the error would move the neuron back toward
+  the centre
+
+Important: `rawInput` here means the neuron’s **pre-squash value**, not a single
+synapse contribution.
+
+### Your example (why we prefer changing other parts)
+
+Scenario:
+
+```text
+output-0 (error ≈ +0.1)
+  ^
+  |   ArcTan is already near +π/2 (saturated)
+  |
+ArcTan(output-0)
+  ^
+  |
+hidden-1
+  ^
+  |
+input-0
+
+Extra path (example):
+input-0 ------------------ w:0.5 -----------------> ArcTan(output-0)
+```
+
+What we _do not_ want:
+
+```text
+Try to “force” ArcTan(output-0) further positive
+even though it is already near +π/2.
+```
+
+What we _do_ want (elastic backprop):
+
+```text
+Prefer adjusting the inbound weights/biases that can change v cheaply,
+and de-emphasise parents that are saturated (safeZoneFactor ≈ 0).
+```
+
+So, if `ArcTan(output-0)` is saturated, its safe-zone factor reduces the share
+of the error that we try to push “through” it. That shifts the learning pressure
+toward other inbound synapses or upstream neurons that are _not_ saturated.
+
+### About LeakyReLU (negative region)
+
+LeakyReLU does **not** have a hard saturation like ArcTan/TANH/LOGISTIC. Its
+slope is:
+
+- `1` for \(x \ge 0\)
+- `α` for \(x < 0\) (eg. 0.01)
+
+So it can still learn in the negative region, but it’s “stiffer” there.
+
+With elastic backprop + safe-zones:
+
+- we can **prefer** moving toward the positive region when appropriate
+- we can **resist** updates that push raw input more negative when it is already
+  far negative
+
+### Where to look in code
+
+- Elastic distribution helper: `src/propagate/ElasticDistribution.ts`
+- Back propagation application: `src/architecture/Neuron.ts`
+  (`Neuron.propagate()`)
+- Example saturating squash: `src/methods/activations/types/ArcTan.ts`

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -359,10 +359,16 @@ export class Creature implements CreatureInternal {
 
     for (let i = this.input; i < len; i++) {
       const n = neurons[i];
-      if (sparseConfig.traceNeeded(n.uuid)) {
-        n.activateAndTraceNeuron();
-      } else {
-        n.activateNeuron();
+      const result = sparseConfig.traceNeeded(n.uuid)
+        ? n.activateAndTraceNeuron()
+        : n.activateNeuron();
+
+      // Back propagation uses `hintValue` as the best available estimate of the
+      // neuron's pre-squash value. We store it for any neuron that may be
+      // propagated through (selected neurons + their paths) to avoid unstable
+      // inverse/derivative calculations.
+      if (sparseConfig.propagateNeeded(n.uuid)) {
+        this.state.node(n.index).hintValue = result.value;
       }
     }
 

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -30,6 +30,7 @@ import {
   adjustedWeight,
   calculateWeight,
 } from "../propagate/Weight.ts";
+import { distributeElasticError } from "../propagate/ElasticDistribution.ts";
 import type { DiscoverRecord } from "./ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { NeuronExport, NeuronInternal } from "./NeuronInterfaces.ts";
 import { noChangePropagate } from "./NoChangePropagate.ts";
@@ -565,7 +566,73 @@ export class Neuron implements TagsInterface, NeuronInternal {
       const listLength = inwardList.length;
 
       if (listLength) {
-        const errorPerLink = error / listLength;
+        // Elastic distribution: allocate more of the value-space error to
+        // upstream links that can change the output with smaller weight changes.
+        // For a linear pre-activation, minimum L2 weight change yields
+        // contribution shares proportional to activation².
+        //
+        // We also incorporate each upstream squash's `safeZoneAdjustment` so we
+        // avoid pushing already-saturated parents further into saturation.
+        const linkMeta = new Array<
+          { activation: number; safeZoneFactor: number }
+        >(
+          listLength,
+        );
+        const fromActivationCache = new Array<number>(listLength);
+        const fromWeightCache = new Array<number>(listLength);
+        const fromValueCache = new Array<number>(listLength);
+        const provisionalErrorPerLink = error / listLength;
+
+        for (let indx = 0; indx < listLength; indx++) {
+          const c = inwardList[indx];
+          const { from, to } = c;
+
+          if (from === to) {
+            linkMeta[indx] = { activation: 0, safeZoneFactor: 0 };
+            fromActivationCache[indx] = 0;
+            fromWeightCache[indx] = 0;
+            fromValueCache[indx] = 0;
+            continue;
+          }
+
+          const fromNeuron = this.creature.neurons[from];
+
+          const fromActivation = fromNeuron.adjustedActivation(config);
+
+          const fromWeight = adjustedWeight(state, c, config);
+
+          fromActivationCache[indx] = fromActivation;
+          fromWeightCache[indx] = fromWeight;
+          fromValueCache[indx] = fromWeight * fromActivation;
+
+          let safeZoneAdj = 1;
+          const type = fromNeuron.type;
+          if (
+            type !== "input" &&
+            type !== "constant" &&
+            sparseConfig.propagateNeeded(fromNeuron.uuid)
+          ) {
+            const fromSquash = fromNeuron.findSquash();
+            if (fromSquash.safeZoneAdjustment) {
+              // Important: rawInput must be the from-neuron's *pre-squash* value,
+              // not a synapse contribution (w*a).
+              const fromNS = state.node(from);
+              safeZoneAdj = fromSquash.safeZoneAdjustment(
+                fromNS.hintValue,
+                provisionalErrorPerLink,
+                fromWeight,
+              );
+            }
+          }
+          linkMeta[indx] = {
+            activation: fromActivation,
+            safeZoneFactor: safeZoneAdj,
+          };
+        }
+
+        const perLinkError = distributeElasticError(error, linkMeta, {
+          plankConstant: config.plankConstant,
+        });
 
         for (let indx = 0; indx < listLength; indx++) {
           const c = inwardList[indx];
@@ -575,78 +642,47 @@ export class Neuron implements TagsInterface, NeuronInternal {
 
           const fromNeuron = this.creature.neurons[from];
 
-          const fromActivation = fromNeuron.adjustedActivation(config);
+          const fromActivation = fromActivationCache[indx];
+          const fromWeight = fromWeightCache[indx];
+          if (Math.abs(fromWeight) <= config.plankConstant) continue;
 
-          const fromWeight = adjustedWeight(state, c, config);
-          if (Math.abs(fromWeight) > config.plankConstant) {
-            const fromValue = fromWeight * fromActivation;
+          const fromValue = fromValueCache[indx];
+          const thisLinkError = perLinkError[indx] ?? 0;
+          const targetFromValue = fromValue + thisLinkError;
 
-            let improvedFromActivation = fromActivation;
+          let improvedFromActivation = fromActivation;
 
-            const targetFromValue = fromValue + errorPerLink;
+          const type = fromNeuron.type;
+          if (
+            type !== "input" &&
+            type !== "constant" &&
+            sparseConfig.propagateNeeded(fromNeuron.uuid) &&
+            Math.abs(targetFromValue - fromValue) > config.plankConstant
+          ) {
+            const targetFromActivation = targetFromValue / fromWeight;
+            improvedFromActivation = fromNeuron.propagate(
+              targetFromActivation,
+              config,
+              sparseConfig,
+            );
+          }
 
-            const type = fromNeuron.type;
-            if (
-              type !== "input" &&
-              type !== "constant"
-            ) {
-              if (
-                sparseConfig.propagateNeeded(fromNeuron.uuid)
-              ) {
-                const fromSquash = fromNeuron.findSquash();
-                let safeZoneAdj = 1;
-                if (fromSquash.safeZoneAdjustment) {
-                  safeZoneAdj = fromSquash.safeZoneAdjustment(
-                    targetFromValue,
-                    errorPerLink,
-                    fromWeight,
-                  );
-                  if (
-                    fromSquash.verbose &&
-                    Math.abs(safeZoneAdj) < config.plankConstant
-                  ) {
-                    console.warn(
-                      `Out of safe zone for neuron ${fromNeuron.uuid}, squash ${fromSquash.getName()}, safeZoneAdj: ${safeZoneAdj}, targetFromValue: ${
-                        targetFromValue.toPrecision(3)
-                      }, errorPerLink: ${errorPerLink.toPrecision(3)}, `,
-                    );
-                  }
-                }
-                const safeTargetFromValue = fromValue +
-                  errorPerLink * safeZoneAdj;
-                if (
-                  Math.abs(safeTargetFromValue - fromValue) >
-                    config.plankConstant
-                ) {
-                  const targetFromActivation = safeTargetFromValue / fromWeight;
-                  improvedFromActivation = fromNeuron.propagate(
-                    targetFromActivation,
-                    config,
-                    sparseConfig,
-                  );
-                }
-              }
-            }
+          if (
+            updateNeeded &&
+            Math.abs(improvedFromActivation) > config.plankConstant
+          ) {
+            const cs = state.connection(from, to);
+            accumulateWeight(
+              c.weight,
+              cs,
+              targetFromValue,
+              improvedFromActivation,
+              config,
+            );
+            const aWeight = adjustedWeight(state, c, config);
 
-            if (
-              updateNeeded &&
-              Math.abs(improvedFromActivation) > config.plankConstant
-            ) {
-              const cs = state.connection(from, to);
-              accumulateWeight(
-                c.weight,
-                cs,
-                targetFromValue,
-                improvedFromActivation,
-                config,
-              );
-              const aWeight = adjustedWeight(state, c, config);
-
-              const improvedFromValue = improvedFromActivation *
-                aWeight;
-
-              improvedValue += improvedFromValue;
-            }
+            const improvedFromValue = improvedFromActivation * aWeight;
+            improvedValue += improvedFromValue;
           }
         }
       }

--- a/src/methods/activations/types/ArcTan.ts
+++ b/src/methods/activations/types/ArcTan.ts
@@ -44,17 +44,23 @@ export class ArcTan
     const lower = -Math.PI / 2 + ArcTan.EPSILON;
 
     if (activation >= upper) {
-      if (typeof hint === "number" && Number.isFinite(hint) && hint > 1e6) {
+      // ArcTan never truly reaches +π/2 for finite inputs.
+      // If we are asked to invert a saturated activation (often due to clamping),
+      // prefer the smallest-change solution by returning the current raw value.
+      // This prevents record/discovery paths from generating astronomical errors
+      // (eg. 1e12+) that dominate MSE and slow evolution dramatically.
+      if (typeof hint === "number" && Number.isFinite(hint)) {
         return hint;
       }
-      return Number.MAX_SAFE_INTEGER;
+      // Fallback to a large but *finite* value if no hint is available.
+      return 1e6;
     }
 
     if (activation <= lower) {
-      if (typeof hint === "number" && Number.isFinite(hint) && hint < -1e6) {
+      if (typeof hint === "number" && Number.isFinite(hint)) {
         return hint;
       }
-      return -Number.MAX_SAFE_INTEGER;
+      return -1e6;
     }
 
     const value = Math.tan(activation);

--- a/src/propagate/ElasticDistribution.ts
+++ b/src/propagate/ElasticDistribution.ts
@@ -1,0 +1,88 @@
+/**
+ * Error distribution helpers for back propagation.
+ *
+ * We use a minimum-change heuristic for a linear pre-activation:
+ *   v = b + Σ(w_i * a_i)
+ *
+ * If we want to change v by Δv, the smallest L2 change in weights that achieves
+ * the same Δv (with bias handled separately) allocates contribution changes
+ * proportional to \(a_i^2\).
+ *
+ * This is an "elasticity" mechanism: links with larger activations can absorb
+ * more of the value-space error with smaller weight changes, and links that are
+ * near saturation can be down-weighted via `safeZoneFactor`.
+ *
+ * Notes:
+ * - `safeZoneFactor` is expected in [0, 1], but we clamp defensively.
+ * - If nothing is movable (all scores ~0), we fall back to an equal split so we
+ *   still break symmetry (eg. when activations are all zero early in training).
+ *
+ * Australian English: "normalise", "behaviour".
+ */
+export type ElasticLink = Readonly<{
+  activation: number;
+  safeZoneFactor: number;
+}>;
+
+export function distributeElasticError(
+  error: number,
+  links: ReadonlyArray<ElasticLink>,
+  options?: Readonly<{
+    plankConstant?: number;
+  }>,
+): number[] {
+  const plankConstant = options?.plankConstant ?? 1e-12;
+
+  if (!Number.isFinite(error) || links.length === 0) {
+    return new Array(links.length).fill(0);
+  }
+
+  const scores = new Array<number>(links.length);
+  let denom = 0;
+  for (let i = 0; i < links.length; i++) {
+    const { activation, safeZoneFactor } = links[i];
+    if (!Number.isFinite(activation) || !Number.isFinite(safeZoneFactor)) {
+      scores[i] = 0;
+      continue;
+    }
+
+    const safe = Math.max(0, Math.min(1, safeZoneFactor));
+    const a2 = activation * activation;
+    const score = a2 * safe;
+    scores[i] = score;
+    denom += score;
+  }
+
+  if (denom <= plankConstant) {
+    // Fallback: equal split. This keeps learning moving when activations are
+    // near zero and the minimum-change heuristic is underdetermined.
+    const per = error / links.length;
+    return new Array(links.length).fill(per);
+  }
+
+  const shares = new Array<number>(links.length);
+  let sum = 0;
+  for (let i = 0; i < links.length; i++) {
+    const share = error * (scores[i] / denom);
+    shares[i] = share;
+    sum += share;
+  }
+
+  // Keep Σ shares == error (floating point tidy-up).
+  const residue = error - sum;
+  if (Math.abs(residue) > plankConstant) {
+    let bestIndx = -1;
+    let bestScore = -Infinity;
+    for (let i = 0; i < scores.length; i++) {
+      if (scores[i] > bestScore) {
+        bestScore = scores[i];
+        bestIndx = i;
+      }
+    }
+    if (bestIndx >= 0) {
+      shares[bestIndx] += residue;
+    }
+  }
+
+  return shares;
+}

--- a/test/propagate/ElasticDistribution.ts
+++ b/test/propagate/ElasticDistribution.ts
@@ -1,0 +1,39 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import { distributeElasticError } from "../../src/propagate/ElasticDistribution.ts";
+
+Deno.test("distributeElasticError: prefers higher-activation links (minimum-change)", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 1, safeZoneFactor: 1 },
+    { activation: 2, safeZoneFactor: 1 },
+  ]);
+
+  // We weight by activation², so scores are 1 and 4 → shares 2 and 8.
+  assertEquals(shares.length, 2);
+  assertAlmostEquals(shares[0], 2, 1e-12);
+  assertAlmostEquals(shares[1], 8, 1e-12);
+  assertAlmostEquals(shares[0] + shares[1], error, 1e-12);
+});
+
+Deno.test("distributeElasticError: honours safeZoneFactor (can fully block a link)", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 1, safeZoneFactor: 0 },
+    { activation: 2, safeZoneFactor: 1 },
+  ]);
+
+  assertAlmostEquals(shares[0], 0, 1e-12);
+  assertAlmostEquals(shares[1], error, 1e-12);
+});
+
+Deno.test("distributeElasticError: falls back to equal split when scores are all zero", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 1, safeZoneFactor: 0 },
+    { activation: 2, safeZoneFactor: 0 },
+  ]);
+
+  assertEquals(shares.length, 2);
+  assertAlmostEquals(shares[0], 5, 1e-12);
+  assertAlmostEquals(shares[1], 5, 1e-12);
+});

--- a/test/propagate/LeakyReLUSafeZoneElastic.ts
+++ b/test/propagate/LeakyReLUSafeZoneElastic.ts
@@ -1,0 +1,85 @@
+import { assertAlmostEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { LeakyReLU } from "../../src/methods/activations/types/LeakyReLU.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+import { SparseConfig } from "../../src/propagate/sparse/SparseConfig.ts";
+
+Deno.test("backprop: LeakyReLU safe zone can divert elastic error away from far-negative raw inputs", () => {
+  // Topology:
+  //
+  // input-0 --(w=100)--> hidden-0(LeakyReLU) --(w=0.1)--> output-0(IDENTITY)
+  // input-1 ------------------------(w=1.0)------------------------^
+  //
+  // We choose input-0=-1 so hidden-0 rawInput≈-100 (far negative).
+  // Then we request a more negative output, so the per-link error is negative.
+  // LeakyReLU.safeZoneAdjustment() should block pushing rawInput further negative,
+  // causing elastic backprop to allocate (almost) all error to the direct input-1 link.
+  const creatureJSON: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        uuid: "hidden-0",
+        type: "hidden",
+        squash: LeakyReLU.NAME,
+        bias: 0,
+      },
+      {
+        uuid: "output-0",
+        type: "output",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 100 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1.0 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(creatureJSON, true);
+
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    batchSize: 1, // apply immediately
+    maximumWeightAdjustmentScale: 100,
+    maximumBiasAdjustmentScale: 100,
+    limitWeightScale: 1_000_000,
+    limitBiasScale: 1_000_000,
+    sparseRatio: 1,
+    trainingMutationRate: 0, // keep deterministic (no random mutations)
+  });
+
+  const sparseConfig = new SparseConfig(creature.exportJSON(), config);
+
+  // Forward pass with trace so we have correct hintValue (rawInput) for safeZoneAdjustment.
+  const actual = creature.activateAndTrace(
+    new Float32Array([-1, 1]),
+    false,
+    sparseConfig,
+  );
+
+  // Current output should be ≈ 0.9 (=-0.1 + 1.0)
+  assertAlmostEquals(actual[0], 0.9, 1e-7);
+
+  // Ask for a much lower output so the error is negative (pushes raw inputs more negative).
+  creature.propagate(new Float32Array([-9.1]), config, sparseConfig);
+  creature.propagateUpdate(config, sparseConfig);
+
+  // The direct input-1 -> output-0 weight should absorb most/all change.
+  // Expected: targetFromValue = 1 + (-10) = -9, activation=1 => weight≈-9.
+  const hidden0 = creature.neurons.find((n) => n.uuid === "hidden-0")!;
+  const output0 = creature.neurons.find((n) => n.uuid === "output-0")!;
+  const input1 = creature.neurons.find((n) => n.uuid === "input-1")!;
+
+  const wHiddenToOut =
+    creature.getSynapse(hidden0.index, output0.index)!.weight;
+  const wInput1ToOut = creature.getSynapse(input1.index, output0.index)!.weight;
+
+  assertAlmostEquals(wHiddenToOut, 0.1, 1e-9);
+  assertAlmostEquals(wInput1ToOut, -9, 1e-6);
+});

--- a/test/propagate/record/ArcTanSaturationClamp.ts
+++ b/test/propagate/record/ArcTanSaturationClamp.ts
@@ -1,0 +1,48 @@
+import { assert } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { ArcTan } from "../../../src/methods/activations/types/ArcTan.ts";
+
+Deno.test("Creature.record: ArcTan saturation does not produce astronomical errors", () => {
+  const creatureJSON: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      {
+        uuid: "output-0",
+        type: "output",
+        squash: ArcTan.NAME,
+        bias: 0,
+      },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        // Drive the pre-squash value deep into saturation.
+        weight: 1_000_000,
+      },
+    ],
+  };
+
+  const creature = Creature.fromJSON(creatureJSON);
+
+  // Activate once so record() has a current activation/value to compare against.
+  creature.activate(new Float32Array([1]));
+
+  // Request an impossible activation well beyond ArcTan's range; it will be clamped.
+  const expected = new Float32Array([Math.PI]);
+  const map = creature.record(expected);
+  const rec = map.get("output-0");
+  assert(rec, "Expected a record for output-0");
+
+  const err = rec.errors[0];
+  assert(Number.isFinite(err), `Expected finite error, got ${err}`);
+
+  // If record() produces errors of ~1e15 here, downstream MSE ends up ~1e30+.
+  // We deliberately keep this bounded to prevent Explorer + discovery from blowing up.
+  assert(
+    Math.abs(err) < 1e9,
+    `Expected non-astronomical error, got ${err}`,
+  );
+});


### PR DESCRIPTION
… framework

- Bumped version in deno.json to 0.269.0.
- Added elastic back propagation logic in Neuron class to improve weight updates based on activation and safe zone adjustments.
- Introduced new documentation on elastic back propagation in README.md to explain the rationale behind minimum-change weight updates.
- Refined ArcTan activation function to handle saturated inputs more gracefully, preventing extreme errors during back propagation.

These changes enhance the stability and performance of the NEAT framework's learning processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an elastic, minimum‑change backprop strategy and stabilizes behavior near saturation.
> 
> - Integrates elastic error allocation in `Neuron.propagate()` using activation² weighting and per‑parent `safeZoneAdjustment`; avoids pushing saturated parents
> - Stores `hintValue` during `Creature.activateAndTrace()` for stable inverse/derivative use in backprop
> - Refines `ArcTan.unSquash()` to return finite, hint‑guided values near ±π/2 to prevent astronomical errors
> - New helper `src/propagate/ElasticDistribution.ts` with unit tests; adds LeakyReLU safe‑zone elastic test and ArcTan saturation clamp record test
> - Documentation: new `docs/BACKPROP_ELASTICITY.md` and README link explaining minimum‑change, safe‑zone‑aware backprop
> - Version bump to `0.269.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e22551c0f634756b1c6e0a3f6634c1f66317217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->