### PR TITLE
Update version to 0.269.1 and enhance Rust library discovery options

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.269.0",
+  "version": "0.269.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -642,6 +642,24 @@ function resolveOverridePath(libName: string): string | null {
   }
 }
 
+export type RustLibrarySearchOptions = Readonly<{
+  /**
+   * Optional override path (file or directory) that should win over all defaults.
+   * This mirrors the `NEAT_AI_DISCOVERY_LIB_PATH` environment variable.
+   */
+  overridePath?: string;
+  /**
+   * Home directory used for resolving `~/.cargo/lib`.
+   * When omitted, the HOME/USERPROFILE environment variables are used (if available).
+   */
+  homeDir?: string;
+  /**
+   * Current working directory used for resolving local `./target/release`.
+   * Defaults to `Deno.cwd()` when omitted.
+   */
+  cwd?: string;
+}>;
+
 /**
  * Resolves the path to the Rust library.
  *
@@ -656,21 +674,39 @@ function resolveOverridePath(libName: string): string | null {
 export function findRustLibrary(): string | null {
   const libName = `libneat_ai_discovery${getLibraryExtension()}`;
 
-  const overridePath = resolveOverridePath(libName);
-  if (overridePath) {
-    return overridePath;
-  }
+  // Read override/home from environment (best effort).
+  const overridePath = resolveOverridePath(libName) ?? undefined;
 
-  // Try to get home directory, but handle gracefully if --allow-env is not granted
   let homeDir: string | undefined;
   try {
-    homeDir = Deno.env.get("HOME") || Deno.env.get("USERPROFILE");
+    homeDir = Deno.env.get("HOME") || Deno.env.get("USERPROFILE") || undefined;
   } catch {
-    // --allow-env not granted, skip HOME directory check
     homeDir = undefined;
   }
 
-  // Check ~/.cargo/lib/ first (production installation)
+  return findRustLibraryFromOptions({ overridePath, homeDir });
+}
+
+/**
+ * Same resolution logic as `findRustLibrary()`, but driven by explicit inputs.
+ *
+ * This exists so tests can validate override precedence without mutating global
+ * process environment variables (which are shared across parallel tests).
+ */
+export function findRustLibraryFromOptions(
+  options: RustLibrarySearchOptions,
+): string | null {
+  const libName = `libneat_ai_discovery${getLibraryExtension()}`;
+
+  const overridePath = options.overridePath?.trim();
+  if (overridePath) {
+    const overrideResolved = resolveLibraryCandidate(overridePath, libName);
+    if (overrideResolved) {
+      return overrideResolved;
+    }
+  }
+
+  const homeDir = options.homeDir;
   if (homeDir) {
     const cargoLibPath = resolveLibraryCandidate(
       join(homeDir, ".cargo", "lib"),
@@ -681,16 +717,15 @@ export function findRustLibrary(): string | null {
     }
   }
 
-  // Check local build artifacts inside this repository
+  const cwd = options.cwd ?? Deno.cwd();
   const localTargetPath = resolveLibraryCandidate(
-    join(Deno.cwd(), "target", "release"),
+    join(cwd, "target", "release"),
     libName,
   );
   if (localTargetPath) {
     return localTargetPath;
   }
 
-  // Check sibling NEAT-AI-Discovery repository (development workflow)
   const siblingDir = fromFileUrl(
     new URL(
       "../../../NEAT-AI-Discovery/target/release",

--- a/test/ErrorGuidedStructuralEvolution/RustDiscoveryPath.ts
+++ b/test/ErrorGuidedStructuralEvolution/RustDiscoveryPath.ts
@@ -1,5 +1,5 @@
 import { assert } from "@std/assert";
-import { rustLibraryExists } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import { findRustLibraryFromOptions } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 
 function expectedLibraryExtension(): string {
   switch (Deno.build.os) {
@@ -15,45 +15,6 @@ function expectedLibraryExtension(): string {
 }
 
 Deno.test("rust discovery honours NEAT_AI_DISCOVERY_LIB_PATH override", async () => {
-  const envPermissionStatus = await (async () => {
-    try {
-      return await Deno.permissions.query({ name: "env" as const });
-    } catch {
-      return { state: "denied" } as const;
-    }
-  })();
-
-  if (envPermissionStatus.state !== "granted") {
-    console.warn(
-      "Skipping NEAT_AI_DISCOVERY_LIB_PATH override test because env permission is not granted.",
-    );
-    return;
-  }
-
-  const originalOverride = (() => {
-    try {
-      return Deno.env.get("NEAT_AI_DISCOVERY_LIB_PATH");
-    } catch {
-      return undefined;
-    }
-  })();
-
-  const originalHome = (() => {
-    try {
-      return Deno.env.get("HOME");
-    } catch {
-      return undefined;
-    }
-  })();
-
-  const originalUserProfile = (() => {
-    try {
-      return Deno.env.get("USERPROFILE");
-    } catch {
-      return undefined;
-    }
-  })();
-
   const tempDir = await Deno.makeTempDir({ prefix: "rust-lib-override-" });
   const tempHome = await Deno.makeTempDir({ prefix: "rust-lib-home-" });
   const libName = `libneat_ai_discovery${expectedLibraryExtension()}`;
@@ -63,47 +24,17 @@ Deno.test("rust discovery honours NEAT_AI_DISCOVERY_LIB_PATH override", async ()
   await Deno.writeTextFile(fakeLibraryPath, "");
 
   try {
-    // Temporarily clear existing override so the baseline assertion is meaningful
-    try {
-      Deno.env.delete("NEAT_AI_DISCOVERY_LIB_PATH");
-    } catch {
-      // Ignore if we cannot delete (no env permission); the guard below will still pass if override is absent.
-    }
-
-    // Point HOME/USERPROFILE to empty directories so default search cannot succeed
-    Deno.env.set("HOME", tempHome);
-    Deno.env.set("USERPROFILE", tempHome);
-
+    const resolved = findRustLibraryFromOptions({
+      overridePath: fakeLibraryPath,
+      // Force defaults to miss; override should still win regardless.
+      homeDir: tempHome,
+      cwd: tempHome,
+    });
     assert(
-      !rustLibraryExists(),
-      "Expected rustLibraryExists() to fail without an override path",
-    );
-
-    Deno.env.set("NEAT_AI_DISCOVERY_LIB_PATH", fakeLibraryPath);
-    assert(
-      rustLibraryExists(),
-      "Expected rustLibraryExists() to detect the library via override path",
+      resolved === fakeLibraryPath,
+      `Expected override path to win, got ${resolved}`,
     );
   } finally {
-    const resetEnv = (
-      key: string,
-      value: string | undefined,
-    ) => {
-      try {
-        if (value === undefined) {
-          Deno.env.delete(key);
-        } else {
-          Deno.env.set(key, value);
-        }
-      } catch {
-        // Ignore env clean-up issues when --allow-env is not granted
-      }
-    };
-
-    resetEnv("NEAT_AI_DISCOVERY_LIB_PATH", originalOverride);
-    resetEnv("HOME", originalHome);
-    resetEnv("USERPROFILE", originalUserProfile);
-
     // Use removeSync - simpler, faster, and ensures all file handles are closed
     try {
       // deno-lint-ignore no-sync-fn-in-async-fn


### PR DESCRIPTION
- Bumped version in deno.json to 0.269.1.
- Introduced RustLibrarySearchOptions type to allow for optional override path, home directory, and current working directory in Rust library resolution.
- Refactored findRustLibrary function to utilize the new options, improving flexibility in library discovery.
- Updated tests to validate the new options and ensure correct behavior when resolving library paths.

These changes enhance the configurability and robustness of the Rust library discovery process in the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances Rust library discovery to be testable and configurable without mutating environment variables.
> 
> - Add `RustLibrarySearchOptions` and new `findRustLibraryFromOptions(options)` supporting `overridePath`, `homeDir`, and `cwd`
> - Refactor `findRustLibrary()` to read env (best effort) and delegate to `findRustLibraryFromOptions`
> - Update test to validate override precedence via options rather than env mutation
> - Bump package version in `deno.json` to `0.269.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e39ca14dfd6906f6a4c4d4c3500c9d28c2d90f73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->