### PR TITLE
Update version to 0.270.0 and enforce forward-only semantics in NEAT …

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ standard term the first time it appears.
    forward pass that maps inputs to outputs, allowing for quick and easy
    deployment of the trained model.
 
+## Feed-forward vs recurrent connections
+
+NEAT-AI supports two broad topology styles:
+
+- **Feed-forward (forward-only)**: No **recurrent connections**. This means:
+  - No **self-loops** (\(from == to\))
+  - No **feedback/backward connections** (\(from > to\), ie an edge that points to an earlier neuron index)
+  - Each activation depends only on the current input and upstream neuron activations
+
+- **Recurrent (feedback-enabled)**: **Recurrent connections** are allowed (self-loops and feedback/backward connections).
+  These can make use of previous activations and are useful for time-series style behaviours.
+
+In our production workloads, each record is treated as independent (no temporal dependence), so the default configuration is feed-forward/forward-only.
+
 5. **Unique Squash Functions**: The neural network supports unique squash
    functions such as IF, MAX and MIN. These functions provide more options for
    the activation function, which can lead to different network behaviours,

--- a/README.md
+++ b/README.md
@@ -66,13 +66,17 @@ NEAT-AI supports two broad topology styles:
 
 - **Feed-forward (forward-only)**: No **recurrent connections**. This means:
   - No **self-loops** (\(from == to\))
-  - No **feedback/backward connections** (\(from > to\), ie an edge that points to an earlier neuron index)
-  - Each activation depends only on the current input and upstream neuron activations
+  - No **feedback/backward connections** (\(from > to\), ie an edge that points
+    to an earlier neuron index)
+  - Each activation depends only on the current input and upstream neuron
+    activations
 
-- **Recurrent (feedback-enabled)**: **Recurrent connections** are allowed (self-loops and feedback/backward connections).
-  These can make use of previous activations and are useful for time-series style behaviours.
+- **Recurrent (feedback-enabled)**: **Recurrent connections** are allowed
+  (self-loops and feedback/backward connections). These can make use of previous
+  activations and are useful for time-series style behaviours.
 
-In our production workloads, each record is treated as independent (no temporal dependence), so the default configuration is feed-forward/forward-only.
+In our production workloads, each record is treated as independent (no temporal
+dependence), so the default configuration is feed-forward/forward-only.
 
 5. **Unique Squash Functions**: The neural network supports unique squash
    functions such as IF, MAX and MIN. These functions provide more options for

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.269.1",
+  "version": "0.270.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/BACKPROP_ELASTICITY.md
+++ b/docs/BACKPROP_ELASTICITY.md
@@ -10,6 +10,20 @@ This works well for many squashes, but it can behave poorly near **saturation**
 (or near non-invertible regions) unless we actively avoid “forcing” already
 immovable neurons.
 
+### Training vs recording (Explorer / discovery)
+
+There are two related flows:
+
+- **Training back propagation** (`Neuron.propagate()`): decides how to adjust
+  weights/biases.
+- **Recording/backprop attribution** (`Creature.record()` / `Neuron.record()`):
+  records per-neuron error signals for Explorer visualisation and for discovery.
+
+Both flows now apply the same core idea:
+
+- Prefer “plastic” paths
+- Treat saturated paths as a last resort
+
 ### The core problem: saturation and inverse targets
 
 Some squashes have bounded activation ranges:
@@ -72,18 +86,20 @@ Scenario:
 ```text
 output-0 (error ≈ +0.1)
   ^
-  |   ArcTan is already near +π/2 (saturated)
+  |  w0
   |
-ArcTan(output-0)
+ArcTan_hidden (near +π/2, saturated)
   ^
+  |  w1
   |
-hidden-1
+ReLU_hidden
   ^
+  |  w3..wN
   |
-input-0
+observations
 
-Extra path (example):
-input-0 ------------------ w:0.5 -----------------> ArcTan(output-0)
+Alternative path (preferred when ArcTan_hidden is saturated):
+ReLU_hidden ------------------ w2 -----------------> output-0
 ```
 
 What we _do not_ want:

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -142,6 +142,7 @@
     "flamegraph",
     "fallbacks",
     "Δerr",
-    "Δscore"
+    "Δscore",
+    "knowably"
   ]
 }

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -127,7 +127,11 @@ export class Creature implements CreatureInternal {
   public semanticVersion: string;
 
   /**
-   * When true, this creature is intended to remain forward-only (no self/back connections).
+   * When true, this creature is intended to remain forward-only (no recurrent connections).
+   *
+   * Recurrent connections include:
+   * - self-loops (from === to)
+   * - feedback/backward connections (from > to)
    * This flag survives export/import.
    */
   public forwardOnly?: boolean;
@@ -1280,14 +1284,27 @@ export class Creature implements CreatureInternal {
    * @returns {Synapse | null} The created synapse or null if no connection was made.
    */
   public makeRandomConnection(indx: number): Synapse | null {
+    assert(
+      Number.isInteger(indx),
+      `Index must be an integer, got: ${String(indx)}`,
+    );
+    assert(
+      indx >= 0 && indx < this.neurons.length,
+      `Index out of range: ${indx} (neurons length: ${this.neurons.length})`,
+    );
+
     const toType = this.neurons[indx].type;
     assert(toType !== "input", "Can't connect to input");
     assert(toType !== "constant", "Can't connect to constant");
 
+    const forwardOnly = this.forwardOnly === true;
+
     for (let attempts = 0; attempts < 12; attempts++) {
       const from = Math.min(
         this.neurons.length - this.output - 1,
-        Math.floor(Math.random() * indx + 1),
+        forwardOnly
+          ? Math.floor(Math.random() * indx) // 0..(indx-1)
+          : Math.floor(Math.random() * indx + 1), // 0..indx (includes self)
       );
       const c = this.getSynapse(from, indx);
       if (c === null) {
@@ -1300,6 +1317,7 @@ export class Creature implements CreatureInternal {
     }
     const firstOutputIndex = this.neurons.length - this.output;
     for (let from = 0; from <= indx; from++) {
+      if (forwardOnly && from === indx) continue; // No self-loops in forward-only mode.
       if (from >= firstOutputIndex && from !== indx) continue;
       const c = this.getSynapse(from, indx);
       if (c === null) {
@@ -1318,7 +1336,7 @@ export class Creature implements CreatureInternal {
    */
   fix(options?: {
     /**
-     * When true, remove both back connections and self connections.
+     * When true, remove all recurrent connections (both feedback/backward connections and self-loops).
      * Defaults to false (we allow them by default).
      */
     forwardOnly?: boolean;
@@ -1444,17 +1462,15 @@ export class Creature implements CreatureInternal {
     if (forwardOnly) {
       this.forwardOnly = true;
 
-      // Issue #937: Once a creature is confirmed forward-only, bump its semantic
-      // version from 2.x.x to 3.0.0. This lets downstream systems treat 3.x
-      // creatures as strictly feed-forward by default.
+      // Once a creature is confirmed forward-only, bump its semantic version to 4.0.0.
       //
-      // Backwards compatibility: we never downgrade versions (e.g. 4.1.2 stays
-      // 4.1.2). We only bump when the major version is exactly 2.
+      // Backwards compatibility: we never downgrade versions (e.g. 4.1.2 stays 4.1.2).
+      // We only bump when the major version is 2.x.x or 3.x.x.
       const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(this.semanticVersion);
       if (match) {
         const major = Number.parseInt(match[1], 10);
-        if (major === 2) {
-          this.semanticVersion = "3.0.0";
+        if (major === 2 || major === 3) {
+          this.semanticVersion = "4.0.0";
         }
       }
     }

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -20,13 +20,13 @@ import { SubBackCon } from "../mutate/SubBackCon.ts";
 import { SwapNeurons } from "../mutate/SwapNeurons.ts";
 
 function upgradeSemanticVersionIfForwardOnlyConfirmed(creature: Creature) {
-  // Issue #937: once forward-only is confirmed, bump 2.x.x → 3.0.0.
+  // Once forward-only is confirmed, bump 2.x.x/3.x.x → 4.0.0.
   // Backwards compatibility: never downgrade (e.g. 4.1.2 stays 4.1.2).
   const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(creature.semanticVersion);
   if (!match) return;
   const major = Number.parseInt(match[1], 10);
-  if (major === 2) {
-    creature.semanticVersion = "3.0.0";
+  if (major === 2 || major === 3) {
+    creature.semanticVersion = "4.0.0";
   }
 }
 
@@ -270,7 +270,7 @@ export class Mutator {
       creature.fix();
 
       // Forward-only mode: if the creature is marked forward-only or the run is not using
-      // feedback loops, ensure mutations can't accidentally keep self/back connections.
+      // feedback loops, ensure mutations can't accidentally keep recurrent connections.
       if (this.config.feedbackLoop !== true || creature.forwardOnly === true) {
         try {
           creature.validate({ forwardOnly: true });
@@ -289,6 +289,11 @@ export class Mutator {
             error.name === "SELF_CONNECTION" ||
             error.name === "RECURSIVE_SYNAPSE"
           ) {
+            const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(
+              creature.semanticVersion,
+            );
+            const major = match ? Number.parseInt(match[1], 10) : 0;
+
             const violations = creature.synapses
               .map((s, i) => ({ s, i }))
               .filter(({ s }) => s.from === s.to || s.from > s.to)
@@ -306,6 +311,16 @@ export class Mutator {
                 `Error=${error.name}: ${error.message}. ` +
                 `Violations(sample up to 10): ${violations.join(" | ")}`,
             );
+
+            // Forward-only 4.x is a hard guarantee: never repair by mutation.
+            if (creature.forwardOnly === true && major >= 4) {
+              throw new Error(
+                `[Mutator] CRITICAL: forward-only 4.x creature became invalid after '${method.name}': ` +
+                  `${error.name} - ${error.message}. ` +
+                  `This indicates a corruption bug (recurrent connections must never be introduced).`,
+              );
+            }
+
             creature.fix({ forwardOnly: true });
           } else {
             // Keep behaviour consistent with Offspring.breed(): only forward-only

--- a/src/architecture/CreatureInterfaces.ts
+++ b/src/architecture/CreatureInterfaces.ts
@@ -22,7 +22,11 @@ interface CreatureCommon extends TagsInterface {
   output: number;
 
   /**
-   * Marks this creature as forward-only (no self connections or back connections).
+   * Marks this creature as forward-only (no recurrent connections).
+   *
+   * Recurrent connections include:
+   * - self-loops (from === to)
+   * - feedback/backward connections (from > to)
    *
    * This flag survives export/import and lets production systems enforce that
    * once a creature is confirmed forward-only it stays that way through

--- a/src/architecture/CreatureValidate.ts
+++ b/src/architecture/CreatureValidate.ts
@@ -21,10 +21,10 @@ export function creatureValidate(
     feedbackLoop?: boolean;
     /**
      * Convenience option for production feed-forward validation.
-     * When true, both recursive (back) synapses and self connections are rejected.
+     * When true, all recurrent connections are rejected (both feedback/backward synapses and self-loops).
      *
-     * Note: By default (undefined/false) we allow both, as this library supports
-     * memory connections.
+     * Note: By default (undefined/false) we allow recurrent connections, as this library supports
+     * recurrent (memory) topologies.
      */
     forwardOnly?: boolean;
   },

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -3785,9 +3785,28 @@ export class DiscoverStructure {
     candidate: unknown,
     discoveryFailureCacheDir?: string,
   ): { success: boolean; fixWasCalled: boolean; validationError?: Error } {
+    const enforceForwardOnly = originalCreature.forwardOnly === true;
+
+    const bumpToFourIfForwardOnlyConfirmed = () => {
+      const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(creature.semanticVersion);
+      if (!match) return;
+      const major = Number.parseInt(match[1], 10);
+      if (Number.isNaN(major)) return;
+      // Backwards compatibility: never downgrade.
+      if (major === 2 || major === 3) {
+        creature.semanticVersion = "4.0.0";
+      }
+    };
+
     // First attempt validation
     try {
-      creature.validate();
+      if (enforceForwardOnly) {
+        creature.validate({ forwardOnly: true });
+        creature.forwardOnly = true;
+        bumpToFourIfForwardOnlyConfirmed();
+      } else {
+        creature.validate();
+      }
       return { success: true, fixWasCalled: false };
     } catch (validationError) {
       const error = validationError as Error;
@@ -3810,12 +3829,23 @@ export class DiscoverStructure {
           `This is a bug that should be investigated. Attempting fix() as last resort.`,
       );
 
-      // Attempt to fix the creature
-      creature.fix();
+      // Attempt to fix the creature.
+      // If the original creature is forward-only, ensure we repair by removing recurrent connections.
+      if (enforceForwardOnly) {
+        creature.fix({ forwardOnly: true });
+      } else {
+        creature.fix();
+      }
 
       // Re-validate after fix
       try {
-        creature.validate();
+        if (enforceForwardOnly) {
+          creature.validate({ forwardOnly: true });
+          creature.forwardOnly = true;
+          bumpToFourIfForwardOnlyConfirmed();
+        } else {
+          creature.validate();
+        }
         return { success: true, fixWasCalled: true, validationError: error };
       } catch (fixError) {
         console.error(

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -706,7 +706,16 @@ export class DiscoverStructure {
     });
 
     // Initialize the indices file as an empty JSON object
-    Deno.writeTextFileSync(this.indicesFilePath, "{}", { createNew: true });
+    try {
+      Deno.writeTextFileSync(this.indicesFilePath, "{}", { createNew: true });
+    } catch (e) {
+      // Tests (and some discovery flows) can legitimately re-enter initialise for the same
+      // temp directory knowably. If the file already exists, keep it.
+      if (e instanceof Deno.errors.AlreadyExists) {
+        return;
+      }
+      throw e;
+    }
   }
 
   /**

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -24,13 +24,17 @@ import {
   adjustedBias,
   calculateBias,
 } from "../propagate/Bias.ts";
+import { distributeElasticError } from "../propagate/ElasticDistribution.ts";
+import {
+  buildRecordElasticLinks,
+  distributeRecordError,
+} from "../propagate/RecordElasticity.ts";
 import type { SparseConfig } from "../propagate/sparse/SparseConfig.ts";
 import {
   accumulateWeight,
   adjustedWeight,
   calculateWeight,
 } from "../propagate/Weight.ts";
-import { distributeElasticError } from "../propagate/ElasticDistribution.ts";
 import type { DiscoverRecord } from "./ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { NeuronExport, NeuronInternal } from "./NeuronInterfaces.ts";
 import { noChangePropagate } from "./NoChangePropagate.ts";
@@ -807,33 +811,38 @@ export class Neuron implements TagsInterface, NeuronInternal {
         discoverRecord.errors.push(error);
 
         if (listLength) {
-          const errorPerLink = error / listLength;
+          // Elastic record attribution: prefer pushing error through upstream
+          // neurons that are in their safe zone (plastic), and avoid pushing
+          // saturated parents unless there is no alternative.
+          const provisionalErrorPerLink = error / listLength;
+          const links = buildRecordElasticLinks(
+            this,
+            inwardList,
+            discoverMap,
+            provisionalErrorPerLink,
+          );
+          const { links: chosenLinks, shares } = distributeRecordError(
+            error,
+            links,
+            {
+              plankConstant: 1e-12,
+              allowEqualFallback: true, // last resort if all are blocked
+            },
+          );
 
-          for (let indx = 0; indx < listLength; indx++) {
-            const c = inwardList[indx];
-            const { from, to } = c;
+          for (let i = 0; i < chosenLinks.length; i++) {
+            const link = chosenLinks[i];
+            const share = shares[i] ?? 0;
+            if (!Number.isFinite(share) || Math.abs(share) <= 1e-12) continue;
 
-            if (from === to) continue;
+            const fromNeuron = link.fromNeuron;
+            const weight = link.synapse.weight;
+            if (!weight) continue;
 
-            const fromNeuron = this.creature.neurons[from];
+            const targetFromValue = link.fromValue + share;
+            const targetFromActivation = targetFromValue / weight;
 
-            const type = fromNeuron.type;
-            if (
-              c.weight &&
-              type !== "input" &&
-              type !== "constant"
-            ) {
-              const fromActivation = state.activations[from];
-
-              const fromValue = c.weight * fromActivation;
-
-              const targetFromValue = fromValue + errorPerLink;
-              const targetFromActivation = targetFromValue / c.weight;
-              fromNeuron.record(
-                targetFromActivation,
-                discoverMap,
-              );
-            }
+            fromNeuron.record(targetFromActivation, discoverMap);
           }
         }
       }

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -11,13 +11,13 @@ import { Neuron } from "./Neuron.ts";
 import type { SynapseExport, SynapseInternal } from "./SynapseInterfaces.ts";
 
 function upgradeSemanticVersionIfForwardOnlyConfirmed(creature: Creature) {
-  // Issue #937: once forward-only is confirmed, bump 2.x.x → 3.0.0.
+  // Once forward-only is confirmed, bump 2.x.x/3.x.x → 4.0.0.
   // Backwards compatibility: never downgrade (e.g. 4.1.2 stays 4.1.2).
   const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(creature.semanticVersion);
   if (!match) return;
   const major = Number.parseInt(match[1], 10);
-  if (major === 2) {
-    creature.semanticVersion = "3.0.0";
+  if (major === 2 || major === 3) {
+    creature.semanticVersion = "4.0.0";
   }
 }
 
@@ -73,11 +73,11 @@ export class Offspring {
     }
 
     // Determine offspring semantic version based on BOTH parents.
-    // Only start at 3.x if BOTH parents are 3.x (validated forward-only).
+    // Only start at 4.x if BOTH parents are 4.x (forward-only guaranteed).
     // Otherwise start at the lower version - validation will upgrade if appropriate.
     const motherMajor = getMajorVersion(mother.semanticVersion);
     const fatherMajor = getMajorVersion(father.semanticVersion);
-    const offspringVersion = (motherMajor >= 3 && fatherMajor >= 3)
+    const offspringVersion = (motherMajor >= 4 && fatherMajor >= 4)
       ? mother.semanticVersion
       : (motherMajor < fatherMajor
         ? mother.semanticVersion
@@ -325,8 +325,8 @@ export class Offspring {
       (options.forwardOnly === undefined &&
         (mum.forwardOnly === true || dad.forwardOnly === true));
 
-    // Check if both parents are 3.x (validated forward-only)
-    const bothParentsThreeX = motherMajor >= 3 && fatherMajor >= 3;
+    // Check if both parents are 4.x (forward-only guaranteed)
+    const bothParentsFourX = motherMajor >= 4 && fatherMajor >= 4;
 
     try {
       creatureValidate(offspring);
@@ -359,10 +359,10 @@ export class Offspring {
                 }) -> ${s.to} (${offspring.neurons[s.to]?.ID?.() ?? "?"})`
               );
 
-            // If BOTH parents are 3.x, this is a bug in the breeding logic
-            if (bothParentsThreeX) {
+            // If BOTH parents are 4.x, this is a bug in the breeding logic
+            if (bothParentsFourX) {
               throw new Error(
-                `[Offspring] CRITICAL: Both parents are 3.x but offspring has self/back connections. ` +
+                `[Offspring] CRITICAL: Both parents are 4.x but offspring has recurrent connections. ` +
                   `This is a bug in the breeding logic that must be fixed. ` +
                   `Mother: ${mother.uuid} (${mother.semanticVersion}), ` +
                   `Father: ${father.uuid} (${father.semanticVersion}). ` +

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -52,11 +52,12 @@ export interface NeatArguments {
    *
    * ## Forward-only default
    * If this is **unset** (or `false`), the NEAT engine treats the run as **forward-only**:
-   * - Self/back connections are **not selected** as mutation operations.
+   * - Recurrent connections (self-loops and feedback/backward connections) are **not selected**
+   *   as mutation operations.
    *
-   * Forward-only mode does **not** automatically strip legacy self/back connections on load.
-   * However, when a creature is mutated/bred in forward-only mode, any self/back connections
-   * are removed so we "evolve away" from legacy feedback structures over a few generations.
+   * Forward-only mode does **not** automatically strip legacy recurrent connections on load.
+   * However, when a creature is mutated/bred in forward-only mode, recurrent connections are
+   * removed so we "evolve away" from legacy recurrent structures over a few generations.
    *
    * To enable memory connections, set `feedbackLoop: true`.
    */

--- a/src/methods/activations/aggregate/IF.ts
+++ b/src/methods/activations/aggregate/IF.ts
@@ -13,6 +13,10 @@ import {
   toValue,
 } from "../../../propagate/BackPropagation.ts";
 import { accumulateBias, adjustedBias } from "../../../propagate/Bias.ts";
+import {
+  buildRecordElasticLinks,
+  distributeRecordError,
+} from "../../../propagate/RecordElasticity.ts";
 import type { SparseConfig } from "../../../propagate/sparse/SparseConfig.ts";
 import { accumulateWeight, adjustedWeight } from "../../../propagate/Weight.ts";
 import type { ApplyLearningsInterface } from "../ApplyLearningsInterface.ts";
@@ -532,37 +536,39 @@ export class IF
       error = targetValue - currentValue;
     }
 
-    const listLength = inward.length;
-    const errorPerLink = error /
-      (condition > 0 ? positiveCount : negativeCount);
-    // Iterate over the shuffled indices
-    for (let indx = listLength; indx--;) {
-      const c = inward[indx];
+    const eligible = inward.filter((c) => {
+      if (c.from === c.to) return false;
+      if (c.type === "condition") return false;
+      if (c.type === "positive" && condition <= 0) return false;
+      if (c.type === "negative" && condition > 0) return false;
+      return true;
+    });
 
-      if (c.from === c.to) continue;
-      if (c.type === "condition") continue;
-      if (c.type === "positive" && condition <= 0) continue;
-      if (c.type === "negative" && condition > 0) continue;
+    if (eligible.length === 0) return;
 
-      const fromNeuron = neuron.creature.neurons[c.from];
+    const provisionalErrorPerLink = error / eligible.length;
+    const links = buildRecordElasticLinks(
+      neuron,
+      eligible,
+      discoverMap,
+      provisionalErrorPerLink,
+    );
+    const { links: chosenLinks, shares } = distributeRecordError(error, links, {
+      plankConstant: 1e-12,
+      allowEqualFallback: true,
+    });
 
-      const fromWeight = c.weight;
+    for (let i = 0; i < chosenLinks.length; i++) {
+      const link = chosenLinks[i];
+      const share = shares[i] ?? 0;
+      if (!Number.isFinite(share) || Math.abs(share) <= 1e-12) continue;
 
-      if (
-        fromWeight &&
-        fromNeuron.type !== "input" &&
-        fromNeuron.type !== "constant"
-      ) {
-        const fromActivation = state.activations[fromNeuron.index];
-        const fromValue = fromWeight * fromActivation;
-        const targetFromValue = fromValue + errorPerLink;
-        const targetFromActivation = targetFromValue / fromWeight;
+      const weight = link.synapse.weight;
+      if (!weight) continue;
 
-        fromNeuron.record(
-          targetFromActivation,
-          discoverMap,
-        );
-      }
+      const targetFromValue = link.fromValue + share;
+      const targetFromActivation = targetFromValue / weight;
+      link.fromNeuron.record(targetFromActivation, discoverMap);
     }
   }
 }

--- a/src/methods/activations/aggregate/MAXIMUM.ts
+++ b/src/methods/activations/aggregate/MAXIMUM.ts
@@ -11,6 +11,7 @@ import {
   toValue,
 } from "../../../propagate/BackPropagation.ts";
 import { accumulateBias, adjustedBias } from "../../../propagate/Bias.ts";
+import { getOrComputeRecordValue } from "../../../propagate/RecordElasticity.ts";
 import type { SparseConfig } from "../../../propagate/sparse/SparseConfig.ts";
 import type { SynapseState } from "../../../propagate/SynapseState.ts";
 import { accumulateWeight, adjustedWeight } from "../../../propagate/Weight.ts";
@@ -331,6 +332,7 @@ export class MAXIMUM
     let mainValue = Number.MIN_SAFE_INTEGER;
     let mainNeuron;
     let mainWeight;
+    let mainSafeZone = 0;
     for (let indx = 0; indx < toList.length; indx++) {
       const c = toList[indx];
       if (c.from === c.to) continue;
@@ -345,15 +347,30 @@ export class MAXIMUM
         const fromActivation = state.activations[fromNeuron.index];
 
         const fromValue = c.weight * fromActivation;
-        if (fromValue > mainValue) {
+        let safeZone = 1;
+        const squash = fromNeuron.findSquash();
+        if (squash.safeZoneAdjustment) {
+          const rawInput = getOrComputeRecordValue(fromNeuron, discoverMap);
+          safeZone = squash.safeZoneAdjustment(rawInput, error, c.weight);
+        }
+
+        if (
+          fromValue > mainValue ||
+          (fromValue === mainValue && safeZone > mainSafeZone)
+        ) {
           mainValue = fromValue;
           mainNeuron = fromNeuron;
           mainWeight = c.weight;
+          mainSafeZone = safeZone;
         }
       }
     }
     if (mainNeuron) {
       assert(mainWeight, "mainWeight not found");
+      if (mainSafeZone <= 1e-12) {
+        // Fully blocked: don't force recursion through an immovable max path.
+        return;
+      }
       const targetFromValue = mainValue + error;
 
       const targetFromActivation = targetFromValue / mainWeight;

--- a/src/methods/activations/aggregate/MINIMUM.ts
+++ b/src/methods/activations/aggregate/MINIMUM.ts
@@ -11,6 +11,7 @@ import {
   toValue,
 } from "../../../propagate/BackPropagation.ts";
 import { accumulateBias, adjustedBias } from "../../../propagate/Bias.ts";
+import { getOrComputeRecordValue } from "../../../propagate/RecordElasticity.ts";
 import type { SparseConfig } from "../../../propagate/sparse/SparseConfig.ts";
 import type { SynapseState } from "../../../propagate/SynapseState.ts";
 import { accumulateWeight, adjustedWeight } from "../../../propagate/Weight.ts";
@@ -334,6 +335,7 @@ export class MINIMUM
     let mainValue = Number.MAX_SAFE_INTEGER;
     let mainNeuron;
     let mainWeight;
+    let mainSafeZone = 0;
     for (let indx = 0; indx < toList.length; indx++) {
       const c = toList[indx];
       if (c.from === c.to) continue;
@@ -348,15 +350,30 @@ export class MINIMUM
         const fromActivation = state.activations[fromNeuron.index];
 
         const fromValue = c.weight * fromActivation;
-        if (fromValue < mainValue) {
+        let safeZone = 1;
+        const squash = fromNeuron.findSquash();
+        if (squash.safeZoneAdjustment) {
+          const rawInput = getOrComputeRecordValue(fromNeuron, discoverMap);
+          safeZone = squash.safeZoneAdjustment(rawInput, error, c.weight);
+        }
+
+        if (
+          fromValue < mainValue ||
+          (fromValue === mainValue && safeZone > mainSafeZone)
+        ) {
           mainValue = fromValue;
           mainNeuron = fromNeuron;
           mainWeight = c.weight;
+          mainSafeZone = safeZone;
         }
       }
     }
     if (mainNeuron) {
       assert(mainWeight, "mainWeight not found");
+      if (mainSafeZone <= 1e-12) {
+        // Fully blocked: don't force recursion through an immovable min path.
+        return;
+      }
       const targetFromValue = mainValue + error;
 
       const targetFromActivation = targetFromValue / mainWeight;

--- a/src/methods/activations/types/ArcTan.ts
+++ b/src/methods/activations/types/ArcTan.ts
@@ -150,14 +150,17 @@ export class ArcTan
     // Ideal gradient zone: roughly x ∈ [−2, 2]
     if (abs <= 2) return 1;
 
+    // Out of bounds: too flat for meaningful updates.
+    // Even if the error direction would “recover”, the required raw change is
+    // too large to be a sensible optimisation step.
+    if (abs > 4) return 0;
+
     // Recovery zone: allow updates that move toward center
     if (rawInput > 2 && error < 0) return 0.3;
     if (rawInput < -2 && error > 0) return 0.3;
 
     // Fade zone: x ∈ [2, 4]
     if (abs <= 4) return 1 - (abs - 2) / 2;
-
-    // Out of bounds: too flat for meaningful updates
     return 0;
   }
 }

--- a/src/mutate/AddNeuron.ts
+++ b/src/mutate/AddNeuron.ts
@@ -49,6 +49,7 @@ export class AddNeuron implements RadioactiveInterface {
     const creature = this.creature;
     const startUUID = CreatureUtil.makeUUID(creature);
     delete creature.uuid;
+    const forwardOnly = creature.forwardOnly === true;
     const neuron = new Neuron(
       crypto.randomUUID(),
       "hidden",
@@ -145,6 +146,11 @@ export class AddNeuron implements RadioactiveInterface {
         assert(outputNeuron, "Expected at least one output neuron");
         targetNeuronIndex = outputNeuron.index;
       }
+
+      // Last resort: in recurrent-capable mode, a self-loop is valid.
+      if (targetNeuronIndex === -1 && !forwardOnly) {
+        targetNeuronIndex = neuron.index;
+      }
     }
 
     // Ensure we always have a valid target (should never be -1 with our fallbacks)
@@ -169,9 +175,13 @@ export class AddNeuron implements RadioactiveInterface {
           }
         }
       }
-      // If we can't find a target without an existing connection, keep the
-      // existing outward connection and stop searching.
+      // If we can't find a target without an existing connection:
+      // - in recurrent-capable mode, we may fall back to a self-loop
+      // - otherwise, keep the existing outward connection and stop searching.
       if (!foundNewTarget) {
+        if (!forwardOnly && !creature.getSynapse(neuron.index, neuron.index)) {
+          targetNeuronIndex = neuron.index;
+        }
         break;
       }
     }
@@ -224,6 +234,23 @@ export class AddNeuron implements RadioactiveInterface {
         outwardConnections = creature.outwardConnections(neuron.index);
         // If still empty after cache clear, fall back.
         if (outwardConnections.length === 0) {
+          // Last resort: in recurrent-capable mode, a self-loop is valid and
+          // guarantees the neuron has an outward connection.
+          if (
+            !forwardOnly && !creature.getSynapse(neuron.index, neuron.index)
+          ) {
+            creature.connect(
+              neuron.index,
+              neuron.index,
+              Synapse.randomWeight(),
+            );
+            creature.clearCache(neuron.index);
+            outwardConnections = creature.outwardConnections(neuron.index);
+            if (outwardConnections.length > 0) {
+              // Outward connection repaired.
+              return true;
+            }
+          }
           throw new Error(
             "AddNeuron: failed to create outward connection (unexpected: neuron is not connected to any later neuron)",
           );

--- a/src/mutate/AddNeuron.ts
+++ b/src/mutate/AddNeuron.ts
@@ -5,6 +5,35 @@ import { Neuron } from "../architecture/Neuron.ts";
 import { Synapse } from "../architecture/Synapse.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
 
+/**
+ * Selects a suitable outward connection target for a newly inserted neuron.
+ *
+ * In **forward-only** mode we must not introduce recurrent connections, which
+ * includes both self-loops and feedback/backward connections.
+ *
+ * In **recurrent-capable** mode (creature is not marked forward-only), it is
+ * valid to select recurring connections (including self-loops).
+ */
+export function pickOutwardTargetNeuronIndex(
+  creature: Creature,
+  neuronIndex: number,
+  toIndex: number,
+): number {
+  if (toIndex === -1) return -1;
+
+  const forwardOnly = creature.forwardOnly === true;
+  const minTargetIndex = forwardOnly
+    ? Math.max(toIndex, neuronIndex + 1)
+    : toIndex;
+
+  const nonConstantIndx = creature.neurons.findIndex((
+    n,
+  ) => (n.index >= minTargetIndex && n.type !== "constant"));
+
+  if (nonConstantIndx === -1) return -1;
+  return creature.neurons[nonConstantIndx].index;
+}
+
 export class AddNeuron implements RadioactiveInterface {
   private creature: Creature;
   constructor(creature: Creature) {
@@ -89,16 +118,11 @@ export class AddNeuron implements RadioactiveInterface {
 
     // First, try to use the originally selected toIndex if it's valid and non-constant
     if (toIndex !== -1) {
-      // Guard: the outward target must be a *later* neuron to keep the graph feed-forward.
-      // `toIndex` can equal the newly inserted neuron's index, which would create a self-loop.
-      const minTargetIndex = Math.max(toIndex, neuron.index + 1);
-      const nonConstantIndx = creature.neurons.findIndex((
-        n,
-      ) => (n.index >= minTargetIndex && n.type !== "constant"));
-
-      if (nonConstantIndx !== -1) {
-        targetNeuronIndex = creature.neurons[nonConstantIndx].index;
-      }
+      targetNeuronIndex = pickOutwardTargetNeuronIndex(
+        creature,
+        neuron.index,
+        toIndex,
+      );
     }
 
     // If we don't have a target yet, use fallback logic.

--- a/src/mutate/AddNeuron.ts
+++ b/src/mutate/AddNeuron.ts
@@ -89,9 +89,12 @@ export class AddNeuron implements RadioactiveInterface {
 
     // First, try to use the originally selected toIndex if it's valid and non-constant
     if (toIndex !== -1) {
+      // Guard: the outward target must be a *later* neuron to keep the graph feed-forward.
+      // `toIndex` can equal the newly inserted neuron's index, which would create a self-loop.
+      const minTargetIndex = Math.max(toIndex, neuron.index + 1);
       const nonConstantIndx = creature.neurons.findIndex((
         n,
-      ) => (n.index >= toIndex && n.type !== "constant"));
+      ) => (n.index >= minTargetIndex && n.type !== "constant"));
 
       if (nonConstantIndx !== -1) {
         targetNeuronIndex = creature.neurons[nonConstantIndx].index;

--- a/src/mutate/AddNeuron.ts
+++ b/src/mutate/AddNeuron.ts
@@ -98,7 +98,7 @@ export class AddNeuron implements RadioactiveInterface {
       }
     }
 
-    // If we don't have a target yet, use fallback logic
+    // If we don't have a target yet, use fallback logic.
     if (targetNeuronIndex === -1) {
       // If the original toIndex doesn't work, find any valid target after the neuron
       for (let i = neuron.index + 1; i < creature.neurons.length; i++) {
@@ -109,29 +109,22 @@ export class AddNeuron implements RadioactiveInterface {
         }
       }
 
-      // If still no target found, use the first output neuron
+      // If still no target found, use the first output neuron.
+      // This is always a forward connection because new neurons are only inserted
+      // before outputs.
       if (targetNeuronIndex === -1) {
         const firstOutputIndex = creature.neurons.length - creature.output;
-        if (
-          firstOutputIndex >= 0 && firstOutputIndex < creature.neurons.length
-        ) {
-          const outputNeuron = creature.neurons[firstOutputIndex];
-          if (outputNeuron) {
-            targetNeuronIndex = outputNeuron.index;
-          }
-        }
-      }
-
-      // Last resort: self-connection (ensures neuron always has outward connection)
-      if (targetNeuronIndex === -1) {
-        targetNeuronIndex = neuron.index;
+        const outputNeuron = creature.neurons[firstOutputIndex];
+        assert(outputNeuron, "Expected at least one output neuron");
+        targetNeuronIndex = outputNeuron.index;
       }
     }
 
     // Ensure we always have a valid target (should never be -1 with our fallbacks)
-    // But if it is, use self-connection as absolute last resort
     if (targetNeuronIndex === -1) {
-      targetNeuronIndex = neuron.index;
+      throw new Error(
+        "AddNeuron: failed to find a valid outward connection target",
+      );
     }
 
     // Find a target that doesn't already have a connection from this neuron
@@ -149,11 +142,9 @@ export class AddNeuron implements RadioactiveInterface {
           }
         }
       }
-      // If we can't find a target without an existing connection,
-      // use self-connection (which should be valid for hidden neurons)
+      // If we can't find a target without an existing connection, keep the
+      // existing outward connection and stop searching.
       if (!foundNewTarget) {
-        targetNeuronIndex = neuron.index;
-        // If self-connection also exists, that's okay - fix() will handle it
         break;
       }
     }
@@ -182,7 +173,7 @@ export class AddNeuron implements RadioactiveInterface {
     if (outwardConnections.length === 0) {
       // Find any valid target that doesn't have a connection yet
       let connectionCreated = false;
-      for (let i = neuron.index; i < creature.neurons.length; i++) {
+      for (let i = neuron.index + 1; i < creature.neurons.length; i++) {
         const candidate = creature.neurons[i];
         if (candidate && candidate.type !== "constant") {
           // Check if connection doesn't exist before creating
@@ -204,21 +195,11 @@ export class AddNeuron implements RadioactiveInterface {
       if (!connectionCreated) {
         creature.clearCache(neuron.index);
         outwardConnections = creature.outwardConnections(neuron.index);
-        // If still empty after cache clear, force create self-connection
+        // If still empty after cache clear, fall back.
         if (outwardConnections.length === 0) {
-          // Self-connection must not exist - create it
-          if (!creature.getSynapse(neuron.index, neuron.index)) {
-            creature.connect(
-              neuron.index,
-              neuron.index,
-              Synapse.randomWeight(),
-            );
-          } else {
-            // Self-connection exists but not found in cache - clear and verify
-            creature.clearCache();
-            outwardConnections = creature.outwardConnections(neuron.index);
-            // If still empty, this is a serious issue - but at least we tried
-          }
+          throw new Error(
+            "AddNeuron: failed to create outward connection (unexpected: neuron is not connected to any later neuron)",
+          );
         }
       }
     }

--- a/src/propagate/RecordElasticity.ts
+++ b/src/propagate/RecordElasticity.ts
@@ -1,0 +1,175 @@
+import type { Neuron } from "../architecture/Neuron.ts";
+import type { Synapse } from "../architecture/Synapse.ts";
+import type { DiscoverRecord } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { distributeElasticError } from "./ElasticDistribution.ts";
+
+/**
+ * Recording-time elasticity helpers.
+ *
+ * Explorer + discovery use `Creature.record()` / `Neuron.record()` to attribute
+ * value-space error to upstream paths. Historically the record path distributed
+ * error equally across inbound links, which can heavily over-attribute error to
+ * saturated squashes (eg. ArcTan near ±π/2).
+ *
+ * These helpers mirror training-time behaviour:
+ * - prefer “plastic” links (large activation => smaller weight change needed)
+ * - use safe-zone gates to avoid pushing already saturated parents further
+ *
+ * Note: record-time uses *raw* creature weights and *raw* activations from the
+ * forward pass (not adjusted weights/biases), because it is an attribution /
+ * analysis path rather than a training update.
+ */
+
+export type RecordElasticLink = Readonly<{
+  synapse: Synapse;
+  fromNeuron: Neuron;
+  fromActivation: number;
+  fromValue: number;
+  safeZoneFactor: number;
+}>;
+
+export function getOrComputeRecordValue(
+  neuron: Neuron,
+  discoverMap: Map<string, DiscoverRecord>,
+): number {
+  const existing = discoverMap.get(neuron.uuid);
+  if (
+    existing && typeof existing.value === "number" &&
+    Number.isFinite(existing.value)
+  ) {
+    return existing.value;
+  }
+
+  const state = neuron.creature.state;
+  const activations = state.activations;
+
+  let value = neuron.bias;
+  if (neuron.type === "input") {
+    value = activations[neuron.index];
+  } else if (neuron.type === "constant") {
+    value = neuron.bias;
+  } else {
+    const inward = neuron.creature.inwardConnections(neuron.index);
+    for (let i = inward.length; i--;) {
+      const c = inward[i];
+      if (c.from === c.to) continue;
+      value += c.weight * activations[c.from];
+    }
+  }
+
+  if (existing) {
+    existing.value = value;
+  } else {
+    discoverMap.set(neuron.uuid, {
+      activation: state.activations[neuron.index],
+      errors: [],
+      value,
+    });
+  }
+
+  return value;
+}
+
+export function buildRecordElasticLinks(
+  neuron: Neuron,
+  inward: ReadonlyArray<Synapse>,
+  discoverMap: Map<string, DiscoverRecord>,
+  provisionalErrorPerLink: number,
+  options?: Readonly<{
+    includeInputNodes?: boolean;
+  }>,
+): RecordElasticLink[] {
+  const includeInputNodes = options?.includeInputNodes ?? false;
+
+  const state = neuron.creature.state;
+  const activations = state.activations;
+
+  const links: RecordElasticLink[] = [];
+  for (let i = 0; i < inward.length; i++) {
+    const c = inward[i];
+    if (c.from === c.to) continue;
+    if (!c.weight) continue;
+
+    const fromNeuron = neuron.creature.neurons[c.from];
+    if (
+      includeInputNodes === false &&
+      (fromNeuron.type === "input" || fromNeuron.type === "constant")
+    ) {
+      continue;
+    }
+
+    const fromActivation = activations[fromNeuron.index];
+    const fromValue = c.weight * fromActivation;
+
+    let safeZoneFactor = 1;
+    if (fromNeuron.type !== "input" && fromNeuron.type !== "constant") {
+      const squash = fromNeuron.findSquash();
+      if (squash.safeZoneAdjustment) {
+        const rawInput = getOrComputeRecordValue(fromNeuron, discoverMap);
+        safeZoneFactor = squash.safeZoneAdjustment(
+          rawInput,
+          provisionalErrorPerLink,
+          c.weight,
+        );
+      }
+    }
+
+    links.push({
+      synapse: c,
+      fromNeuron,
+      fromActivation,
+      fromValue,
+      safeZoneFactor,
+    });
+  }
+
+  return links;
+}
+
+/**
+ * Distributes record-time error across inbound links using the same basic
+ * elasticity heuristic as training time, but with record-time inputs.
+ *
+ * Returns the chosen links and per-link shares aligned to that link list.
+ */
+export function distributeRecordError(
+  error: number,
+  links: ReadonlyArray<RecordElasticLink>,
+  options?: Readonly<{
+    plankConstant?: number;
+    /**
+     * When true, if all safe-zone/activation scores are zero we still fall back
+     * to an equal split (last resort).
+     */
+    allowEqualFallback?: boolean;
+  }>,
+): { links: ReadonlyArray<RecordElasticLink>; shares: number[] } {
+  const plankConstant = options?.plankConstant ?? 1e-12;
+  const allowEqualFallback = options?.allowEqualFallback ?? true;
+
+  if (!Number.isFinite(error) || links.length === 0) {
+    return { links, shares: new Array(links.length).fill(0) };
+  }
+
+  const meta = links.map((l) => ({
+    activation: l.fromActivation,
+    safeZoneFactor: l.safeZoneFactor,
+  }));
+
+  // If everything is blocked, `distributeElasticError` will equal-split. That’s
+  // acceptable as a last resort, but we allow opting out for callers that want
+  // to stop recursion instead.
+  if (!allowEqualFallback) {
+    let denom = 0;
+    for (const m of meta) {
+      denom += (m.activation * m.activation) *
+        Math.max(0, Math.min(1, m.safeZoneFactor));
+    }
+    if (denom <= plankConstant) {
+      return { links, shares: new Array(links.length).fill(0) };
+    }
+  }
+
+  const shares = distributeElasticError(error, meta, { plankConstant });
+  return { links, shares };
+}

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -5,13 +5,13 @@ import { upgradeTwo } from "./UpgradeTwo.ts";
 /**
  * The current major version.
  *
- * Version 3.x indicates the creature has been validated as strictly forward-only
- * (no self/back connections). Once at 3.x, the creature must remain forward-only
+ * Version 4.x indicates the creature has been validated as strictly forward-only
+ * (no recurrent connections). Once at 4.x, the creature must remain forward-only
  * and any violation is an error condition.
  *
  * Creatures with forwardOnly: false (explicitly allowing feedback loops) stay at 2.x.
  */
-export const SEMANTIC_MAJOR_VERSION = 3;
+export const SEMANTIC_MAJOR_VERSION = 4;
 
 /**
  * Extracts the major version number from a semantic version string.
@@ -26,7 +26,7 @@ function getMajorVersion(version: string | undefined): number {
 
 /**
  * Validates that a 3.x creature is still forward-only.
- * If the creature has self/back connections, logs a warning but does NOT modify
+ * If the creature has recurrent connections, logs a warning but does NOT modify
  * the creature. Fixing should only happen on offspring, not on parents during
  * breeding.
  *
@@ -40,7 +40,7 @@ function validateThreeX(creature: Creature): void {
     // Log the error but don't modify the creature - offspring validation will
     // handle any issues during breeding.
     console.error(
-      `[upgrade] Version 3.x creature has invalid self/back connections. ` +
+      `[upgrade] Version 3.x creature has invalid recurrent connections. ` +
         `This indicates a data integrity issue. UUID: ${creature.uuid}, Error: ${
           error instanceof Error ? error.message : error
         }`,
@@ -49,26 +49,36 @@ function validateThreeX(creature: Creature): void {
 }
 
 /**
- * Attempts to upgrade a 2.x creature to 3.x if it's validated as forward-only.
+ * Validates that a 4.x forward-only creature is still forward-only.
  *
- * Version 3.x is assigned when:
+ * For 4.x, forward-only is a hard invariant: any recurrent connection is an error.
+ */
+function validateFourX(creature: Creature): void {
+  if (creature.forwardOnly !== true) return;
+  creatureValidate(creature, { forwardOnly: true });
+}
+
+/**
+ * Attempts to upgrade a 2.x/3.x creature to 4.x if it's validated as forward-only.
+ *
+ * Version 4.x is assigned when:
  * - forwardOnly === true AND the creature passes forward-only validation
  *
- * Creatures with forwardOnly: false or undefined stay at 2.x:
+ * Creatures with forwardOnly: false or undefined stay at their current major:
  * - forwardOnly: false = explicitly allows feedback loops
  * - forwardOnly: undefined = status not yet determined
  *
  * @param creature - The creature to potentially upgrade
- * @returns The upgraded creature (at version 3.x) or unchanged creature (at 2.x)
+ * @returns The upgraded creature (at version 4.x) or unchanged creature
  */
-function tryUpgradeToThree(creature: Creature): Creature {
+function tryUpgradeToFour(creature: Creature): Creature {
   // forwardOnly === true - validate it's actually forward-only before upgrading
   if (creature.forwardOnly === true) {
     try {
       creatureValidate(creature, { forwardOnly: true });
-      creature.semanticVersion = "3.0.0";
+      creature.semanticVersion = "4.0.0";
     } catch (_error) {
-      // Creature claims to be forward-only but isn't - clear the flag, stay at 2.x
+      // Creature claims to be forward-only but isn't - clear the flag, stay at current version
       console.warn(
         `[upgrade] Creature claims forwardOnly but failed validation; clearing flag`,
       );
@@ -88,8 +98,9 @@ function tryUpgradeToThree(creature: Creature): Creature {
  *
  * Upgrade path:
  * - 0.x/1.x/undefined → 2.x (format migration via upgradeTwo)
- * - 2.x → 3.x (if forwardOnly: true and validated as forward-only)
- * - 3.x+ → validated to ensure still forward-only (throws if not)
+ * - 2.x/3.x → 4.x (if forwardOnly: true and validated as forward-only)
+ * - 3.x → validated to warn (legacy only; never thrown in production)
+ * - 4.x+ → validated to ensure still forward-only (throws if not)
  *
  * @param creature - The creature to upgrade
  * @returns The upgraded creature
@@ -98,32 +109,38 @@ function tryUpgradeToThree(creature: Creature): Creature {
 export function upgrade(creature: Creature): Creature {
   const majorVersion = getMajorVersion(creature.semanticVersion);
 
-  // Already at version 3.x or higher - validate it's still forward-only
-  if (majorVersion >= 3) {
+  // Already at version 4.x or higher - enforce forward-only for forwardOnly creatures
+  if (majorVersion >= 4) {
+    validateFourX(creature);
+    return creature;
+  }
+
+  // Version 3.x is legacy forward-only: warn-only if recurrent connections appear.
+  if (majorVersion === 3) {
     validateThreeX(creature);
     return creature;
   }
 
-  // At version 2.x - try to upgrade to 3.x if forwardOnly status is confirmed
+  // At version 2.x - try to upgrade to 4.x if forwardOnly status is confirmed
   if (majorVersion === 2) {
-    return tryUpgradeToThree(creature);
+    return tryUpgradeToFour(creature);
   }
 
-  // Upgrade from 1.x → 2.x, then try 3.x
+  // Upgrade from 1.x → 2.x, then try 4.x
   if (majorVersion === 1) {
     const v2 = upgradeTwo(creature.exportJSON());
     const upgraded = Creature.fromJSON(v2);
-    return tryUpgradeToThree(upgraded);
+    return tryUpgradeToFour(upgraded);
   }
 
-  // Version 0 or unknown - set to 1.0.0 first, then upgrade to 2.x, then try 3.x
+  // Version 0 or unknown - set to 1.0.0 first, then upgrade to 2.x, then try 4.x
   // This handles undefined versions, invalid formats, and "0.x" versions
   if (majorVersion === 0) {
     const json = creature.exportJSON();
     json.semanticVersion = "1.0.0"; // Set to 1.0.0 so upgradeTwo can process it
     const v2 = upgradeTwo(json);
     const upgraded = Creature.fromJSON(v2);
-    return tryUpgradeToThree(upgraded);
+    return tryUpgradeToFour(upgraded);
   }
 
   return creature;

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -49,12 +49,12 @@ function validateThreeX(creature: Creature): void {
 }
 
 /**
- * Validates that a 4.x forward-only creature is still forward-only.
+ * Validates that a 4.x (or later) creature is still forward-only.
  *
- * For 4.x, forward-only is a hard invariant: any recurrent connection is an error.
+ * For 4.x, forward-only is a hard invariant: any recurrent connection is an error,
+ * regardless of whether the `forwardOnly` flag is set.
  */
 function validateFourX(creature: Creature): void {
-  if (creature.forwardOnly !== true) return;
   creatureValidate(creature, { forwardOnly: true });
 }
 
@@ -109,7 +109,7 @@ function tryUpgradeToFour(creature: Creature): Creature {
 export function upgrade(creature: Creature): Creature {
   const majorVersion = getMajorVersion(creature.semanticVersion);
 
-  // Already at version 4.x or higher - enforce forward-only for forwardOnly creatures
+  // Already at version 4.x or higher - enforce forward-only invariant.
   if (majorVersion >= 4) {
     validateFourX(creature);
     return creature;

--- a/test/FeedForward/AddNeuronForwardOnly.ts
+++ b/test/FeedForward/AddNeuronForwardOnly.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { AddNeuron } from "../../src/mutate/AddNeuron.ts";
+
+/**
+ * Regression coverage: forward-only creatures must not gain recurrent connections
+ * (self-loops or feedback/backward connections) during structural mutations.
+ */
+Deno.test("Forward-only: AddNeuron does not introduce recurrent connections", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.forwardOnly = true;
+  creature.validate({ forwardOnly: true });
+
+  const beforeNeurons = creature.neurons.length;
+  const beforeSynapses = creature.synapses.length;
+
+  const addNeuron = new AddNeuron(creature);
+  const changed = addNeuron.mutate();
+
+  assertEquals(changed, true);
+  assertEquals(creature.neurons.length, beforeNeurons + 1);
+  assertEquals(creature.synapses.length > beforeSynapses, true);
+
+  // This is the hard invariant we care about.
+  creature.validate({ forwardOnly: true });
+});

--- a/test/FeedForward/ForwardOnlySemanticVersion.ts
+++ b/test/FeedForward/ForwardOnlySemanticVersion.ts
@@ -55,7 +55,7 @@ Deno.test("Forward-only: breeding upgrades semanticVersion 2.x.x → 3.0.0 when 
 
   // The child is confirmed forward-only via validate({ forwardOnly: true }) inside breed().
   assertEquals(child.forwardOnly, true);
-  assertEquals(child.semanticVersion, "3.0.0");
+  assertEquals(child.semanticVersion, "4.0.0");
 });
 
 Deno.test("Forward-only: mutation upgrades semanticVersion 2.x.x → 3.0.0 when validation passes", () => {
@@ -83,7 +83,7 @@ Deno.test("Forward-only: mutation upgrades semanticVersion 2.x.x → 3.0.0 when 
   }
   assert(mutated, "Expected creature to mutate");
   assertEquals(creature.forwardOnly, true);
-  assertEquals(creature.semanticVersion, "3.0.0");
+  assertEquals(creature.semanticVersion, "4.0.0");
 });
 
 Deno.test("Forward-only: semanticVersion is never downgraded (e.g. 4.1.2 stays 4.1.2)", () => {

--- a/test/FeedForward/MakeRandomConnectionForwardOnly.ts
+++ b/test/FeedForward/MakeRandomConnectionForwardOnly.ts
@@ -1,0 +1,43 @@
+import { assert } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+
+/**
+ * Regression coverage: `Creature.makeRandomConnection()` is used at runtime by
+ * some aggregate squashes (eg `IF`) to repair missing wiring. When a creature is
+ * marked forward-only, this helper must never create recurrent connections
+ * (self-loops or feedback/backward connections).
+ */
+Deno.test("Forward-only: makeRandomConnection() never creates recurrent connections", () => {
+  // Create a small creature with hidden neurons so there are plenty of missing
+  // potential connections into a target neuron.
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+  creature.forwardOnly = true;
+
+  // Pick a hidden neuron (not input, not constant) as the target.
+  const toIndex = creature.input; // First non-input neuron should be hidden.
+
+  // Make sure there is at least one missing eligible connection so the helper
+  // has something to create.
+  creature.disconnect(0, toIndex);
+  creature.disconnect(1, toIndex);
+
+  // Try a few times to ensure we actually add a connection.
+  let created = false;
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const synapse = creature.makeRandomConnection(toIndex);
+    if (synapse) {
+      created = true;
+      assert(
+        synapse.from < synapse.to,
+        `Expected a strictly feed-forward connection, got ${synapse.from}->${synapse.to}`,
+      );
+      assert(
+        synapse.to === toIndex,
+        `Expected connection to target neuron ${toIndex}, got ${synapse.from}->${synapse.to}`,
+      );
+      break;
+    }
+  }
+
+  assert(created, "Expected makeRandomConnection() to create a connection");
+});

--- a/test/Upgrade/VersionFourInvariant.ts
+++ b/test/Upgrade/VersionFourInvariant.ts
@@ -1,0 +1,26 @@
+import { assertThrows } from "@std/assert";
+import { Creature } from "../../mod.ts";
+import { upgrade } from "../../src/upgrade/Upgrade.ts";
+
+/**
+ * Regression coverage: semanticVersion 4.x implies a forward-only (feed-forward)
+ * topology, regardless of whether the `forwardOnly` flag is present.
+ *
+ * This catches corrupted exports where `semanticVersion` is 4.x but the creature
+ * still contains recurrent connections (self-loops / feedback connections).
+ */
+Deno.test(
+  "upgrade throws for 4.x creatures with recurrent connections even when forwardOnly is unset",
+  () => {
+    const creature = new Creature(2, 1, {
+      layers: [{ count: 2 }],
+      semanticVersion: "4.0.0",
+    });
+    // Intentionally leave `forwardOnly` undefined to simulate a corrupted export.
+
+    const hiddenNeuron = creature.neurons[creature.input]; // First hidden neuron
+    creature.connect(hiddenNeuron.index, hiddenNeuron.index, 0.5); // self-loop (recurrent)
+
+    assertThrows(() => upgrade(creature));
+  },
+);

--- a/test/Upgrade/VersionThree.ts
+++ b/test/Upgrade/VersionThree.ts
@@ -1,15 +1,15 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { Creature } from "../../mod.ts";
 import { SEMANTIC_MAJOR_VERSION, upgrade } from "../../src/upgrade/Upgrade.ts";
 
 /**
  * Tests for the upgrade() function.
  *
- * Version 3.x indicates the creature has been validated as strictly forward-only
- * (no self/back connections). Once at 3.x, the creature must remain forward-only
+ * Version 4.x indicates the creature has been validated as strictly forward-only
+ * (no recurrent connections). Once at 4.x, the creature must remain forward-only
  * and any violation is an error condition.
  *
- * - forwardOnly: true + validated = upgrade to 3.x
+ * - forwardOnly: true + validated = upgrade to 4.x
  * - forwardOnly: false = stay at 2.x (explicitly allows feedback loops)
  * - forwardOnly: undefined = stay at 2.x (status not yet determined)
  */
@@ -17,8 +17,8 @@ import { SEMANTIC_MAJOR_VERSION, upgrade } from "../../src/upgrade/Upgrade.ts";
 Deno.test("SEMANTIC_MAJOR_VERSION should be 3", () => {
   assertEquals(
     SEMANTIC_MAJOR_VERSION,
-    3,
-    "Current semantic major version should be 3",
+    4,
+    "Current semantic major version should be 4",
   );
 });
 
@@ -57,7 +57,7 @@ Deno.test("upgrade should not modify 2.x.x creatures with patch versions and und
 
 // === 2.x creatures with forwardOnly: true upgrade to 3.x if valid ===
 
-Deno.test("upgrade should upgrade 2.x creatures with forwardOnly: true to 3.x", () => {
+Deno.test("upgrade should upgrade 2.x creatures with forwardOnly: true to 4.x", () => {
   const creature = new Creature(2, 1, {
     layers: [{ count: 2 }],
     semanticVersion: "2.0.0",
@@ -68,8 +68,8 @@ Deno.test("upgrade should upgrade 2.x creatures with forwardOnly: true to 3.x", 
 
   assertEquals(
     upgraded.semanticVersion,
-    "3.0.0",
-    "2.x creatures with forwardOnly: true should be upgraded to 3.x",
+    "4.0.0",
+    "2.x creatures with forwardOnly: true should be upgraded to 4.x",
   );
   assertEquals(
     upgraded.forwardOnly,
@@ -170,7 +170,7 @@ Deno.test("upgrade should log warning but not modify 3.x creature with self-conn
 
 // === Future versions should be validated ===
 
-Deno.test("upgrade should validate and not modify future 4.x creatures", () => {
+Deno.test("upgrade should validate and not modify valid 4.x creatures", () => {
   const creature = new Creature(2, 1, {
     layers: [{ count: 2 }],
     semanticVersion: "4.0.0",
@@ -181,8 +181,21 @@ Deno.test("upgrade should validate and not modify future 4.x creatures", () => {
   assertEquals(
     upgraded.semanticVersion,
     "4.0.0",
-    "Future version creatures should be validated and not downgraded",
+    "Valid 4.x creatures should be validated and not downgraded",
   );
+});
+
+Deno.test("upgrade should throw for forward-only 4.x creatures with recurrent connections", () => {
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+    semanticVersion: "4.0.0",
+  });
+  creature.forwardOnly = true;
+
+  const hiddenNeuron = creature.neurons[creature.input]; // First hidden neuron
+  creature.connect(hiddenNeuron.index, hiddenNeuron.index, 0.5);
+
+  assertThrows(() => upgrade(creature));
 });
 
 Deno.test("upgrade should validate and not modify future 10.x creatures", () => {
@@ -217,7 +230,7 @@ Deno.test("upgrade should upgrade 1.x creatures to 2.x when forwardOnly undefine
   );
 });
 
-Deno.test("upgrade should upgrade 1.x creatures with forwardOnly: true to 3.x", () => {
+Deno.test("upgrade should upgrade 1.x creatures with forwardOnly: true to 4.x", () => {
   const creature = new Creature(2, 1, {
     layers: [{ count: 2 }],
     semanticVersion: "1.0.0",
@@ -228,8 +241,8 @@ Deno.test("upgrade should upgrade 1.x creatures with forwardOnly: true to 3.x", 
 
   assertEquals(
     upgraded.semanticVersion,
-    "3.0.0",
-    "1.x creatures with forwardOnly: true should be upgraded to 3.x",
+    "4.0.0",
+    "1.x creatures with forwardOnly: true should be upgraded to 4.x",
   );
 });
 

--- a/test/discovery/ForwardOnlyDiscoveryValidation.ts
+++ b/test/discovery/ForwardOnlyDiscoveryValidation.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+
+/**
+ * Regression coverage: discovery must respect forward-only invariants.
+ *
+ * - If a forward-only creature is still on a legacy semantic version, discovery repairs
+ *   accidental recurrent connections by stripping them and emits a 4.x creature.
+ * - If a forward-only creature is already 4.x, discovery still strips recurrent connections
+ *   (new creature) and keeps it at 4.x.
+ */
+Deno.test("Discovery: forward-only legacy can be repaired by stripping recurrent connections", () => {
+  const original = new Creature(2, 1, { layers: [{ count: 2 }] });
+  original.forwardOnly = true;
+  original.semanticVersion = "3.0.0";
+  original.validate({ forwardOnly: true });
+
+  const modified = Creature.fromJSON(original.exportJSON());
+  const hiddenIndex = modified.input;
+  modified.connect(hiddenIndex, hiddenIndex, 0.5); // self-loop (recurrent)
+
+  const result = (DiscoverStructure as unknown as {
+    validateAndFixIfNeeded: (
+      creature: Creature,
+      originalCreature: Creature,
+      discoveryID: string,
+      operationType: string,
+      candidate: unknown,
+      discoveryFailureCacheDir?: string,
+    ) => { success: boolean; fixWasCalled: boolean };
+  }).validateAndFixIfNeeded(modified, original, "test", "unit", {});
+
+  assertEquals(result.success, true);
+  assertEquals(result.fixWasCalled, true);
+  modified.validate({ forwardOnly: true });
+  assertEquals(modified.semanticVersion, "4.0.0");
+});
+
+Deno.test("Discovery: forward-only 4.x repairs by stripping recurrent connections (new creature)", () => {
+  const original = new Creature(2, 1, { layers: [{ count: 2 }] });
+  original.forwardOnly = true;
+  original.semanticVersion = "4.0.0";
+  original.validate({ forwardOnly: true });
+
+  const modified = Creature.fromJSON(original.exportJSON());
+  const hiddenIndex = modified.input;
+  modified.connect(hiddenIndex, hiddenIndex, 0.5); // self-loop (recurrent)
+
+  const result = (DiscoverStructure as unknown as {
+    validateAndFixIfNeeded: (
+      creature: Creature,
+      originalCreature: Creature,
+      discoveryID: string,
+      operationType: string,
+      candidate: unknown,
+      discoveryFailureCacheDir?: string,
+    ) => { success: boolean; fixWasCalled: boolean };
+  }).validateAndFixIfNeeded(modified, original, "test", "unit", {});
+
+  assertEquals(result.success, true);
+  assertEquals(result.fixWasCalled, true);
+  modified.validate({ forwardOnly: true });
+  assertEquals(modified.semanticVersion, "4.0.0");
+});

--- a/test/fix/ForwardOnly.ts
+++ b/test/fix/ForwardOnly.ts
@@ -28,8 +28,8 @@ Deno.test("fix({ forwardOnly: true }) removes back + self connections", () => {
   creature.fix({ forwardOnly: true });
   creature.validate({ forwardOnly: true });
 
-  // Issue #937: once forward-only is confirmed, bump 2.x.x → 3.x.x.
-  assertEquals(creature.semanticVersion, "3.0.0");
+  // Once forward-only is confirmed, bump to 4.x.x.
+  assertEquals(creature.semanticVersion, "4.0.0");
 
   // Ensure structure is now strictly forward-only.
   creature.synapses.forEach((s) => {

--- a/test/mutate/AddNeuronRecurrentAllowed.ts
+++ b/test/mutate/AddNeuronRecurrentAllowed.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { pickOutwardTargetNeuronIndex } from "../../src/mutate/AddNeuron.ts";
+
+/**
+ * Regression coverage: recurring connections (including self-loops) are valid
+ * when a creature is **not** marked as forward-only.
+ */
+Deno.test("AddNeuron: recurring targets are allowed when creature is not forward-only", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 1 }] });
+
+  // Default validation allows recurrent connections.
+  creature.validate();
+
+  // In recurrent-capable mode (forwardOnly is undefined), it is valid to target
+  // the same neuron index (self-loop).
+  assertEquals(creature.forwardOnly, undefined);
+  assertEquals(
+    pickOutwardTargetNeuronIndex(creature, 2, 2),
+    2,
+  );
+
+  // Edge case: caller may not have found a 'to' index.
+  assertEquals(
+    pickOutwardTargetNeuronIndex(creature, 2, -1),
+    -1,
+  );
+
+  // In forward-only mode, we must never select a self-loop target.
+  creature.forwardOnly = true;
+  creature.validate({ forwardOnly: true });
+  assertEquals(
+    pickOutwardTargetNeuronIndex(creature, 2, 2),
+    3,
+  );
+
+  // Edge case: even with a supplied toIndex, no valid target may exist once we
+  // apply the forward-only constraint (minTargetIndex > max index).
+  const lastIndex = creature.neurons.length - 1;
+  assertEquals(
+    pickOutwardTargetNeuronIndex(creature, lastIndex, lastIndex),
+    -1,
+  );
+});

--- a/test/mutate/AddNeuronSelfLoopFallback.ts
+++ b/test/mutate/AddNeuronSelfLoopFallback.ts
@@ -1,0 +1,93 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { Neuron } from "../../src/architecture/Neuron.ts";
+import { AddNeuron } from "../../src/mutate/AddNeuron.ts";
+
+/**
+ * Regression coverage:
+ *
+ * In recurrent-capable mode (ie `forwardOnly` is unset), `AddNeuron` may fall back
+ * to a self-loop as the *last resort* outward connection if all forward targets
+ * are exhausted/unavailable.
+ *
+ * This is defensive: the normal path should always find a forward target, but we
+ * must not throw in recurrent mode when a self-connection is valid.
+ */
+Deno.test("AddNeuron: recurrent mode can fall back to a self-loop as last resort", () => {
+  // No hidden layers: the newly added neuron is the only hidden neuron, which
+  // makes it easy to identify during the mutation.
+  const creature = new Creature(2, 1, { layers: [] });
+
+  // Recurrent-capable mode.
+  assertEquals(creature.forwardOnly, undefined);
+
+  const originalGetSynapse = creature.getSynapse.bind(creature);
+  const originalNeuronFix = Neuron.prototype.fix;
+  const originalRandom = Math.random;
+  let insertedHiddenIndex: number | undefined;
+
+  try {
+    // For this regression we intentionally disable `Neuron.fix()` so we can
+    // prove `AddNeuron` itself handles the last-resort outward-connection
+    // behaviour (rather than relying on neuron-level repairs).
+    Neuron.prototype.fix = function () {
+      // no-op
+    };
+
+    // Make the mutation deterministic:
+    // - Ensure `toIndex` is a forward target (not the new neuron's own index),
+    //   so we don't "accidentally" pick a self-loop via the primary path.
+    const randomSeq = [
+      0.5, // Neuron bias
+      0.2, // Hidden neuron's squash selection
+      0.1, // New neuron index (range is 1, so this is stable)
+      0.1, // fromIndex selection (pos 0)
+      0.6, // toIndex selection (pos > neuron.index)
+    ];
+    let randomIdx = 0;
+    Math.random = () => randomSeq[randomIdx++] ?? 0.1;
+
+    // Simulate an edge case where forward targets are "exhausted" from the new
+    // neuron by making `getSynapse()` *pretend* every forward target already has
+    // a connection, while still allowing a self-loop.
+    //
+    // This reproduces the real-world effect of stale caches / corrupted state
+    // where AddNeuron's forward-only fallback search cannot find a usable target.
+    creature.getSynapse = ((from: number, to: number) => {
+      if (insertedHiddenIndex === undefined) {
+        insertedHiddenIndex = creature.neurons.find((n) => n.type === "hidden")
+          ?.index;
+      }
+
+      if (insertedHiddenIndex !== undefined && from === insertedHiddenIndex) {
+        // Allow self-loop to be created as a last resort.
+        if (to === insertedHiddenIndex) return null;
+        // Block all forward targets by pretending they already exist.
+        return {} as unknown as ReturnType<typeof originalGetSynapse>;
+      }
+
+      return originalGetSynapse(from, to);
+    }) as typeof creature.getSynapse;
+
+    const addNeuron = new AddNeuron(creature);
+    const changed = addNeuron.mutate();
+
+    assertEquals(changed, true);
+
+    const hidden = creature.neurons.find((n) => n.type === "hidden");
+    assert(hidden, "Expected a hidden neuron to be added");
+    assert(
+      creature.synapses.some((s) =>
+        s.from === hidden.index && s.to === hidden.index
+      ),
+      "Expected a self-loop synapse as the last resort outward connection",
+    );
+
+    // Default validation allows recurrent connections.
+    creature.validate();
+  } finally {
+    Neuron.prototype.fix = originalNeuronFix;
+    Math.random = originalRandom;
+    creature.getSynapse = originalGetSynapse as typeof creature.getSynapse;
+  }
+});

--- a/test/propagate/record/ArcTanNearSaturationClamp.ts
+++ b/test/propagate/record/ArcTanNearSaturationClamp.ts
@@ -1,0 +1,47 @@
+import { assert } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { ArcTan } from "../../../src/methods/activations/types/ArcTan.ts";
+
+Deno.test("Creature.record: ArcTan near-saturation target does not explode value-space errors", () => {
+  const creatureJSON: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      {
+        uuid: "output-0",
+        type: "output",
+        squash: ArcTan.NAME,
+        bias: 0,
+      },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1_000_000,
+      },
+    ],
+  };
+
+  const creature = Creature.fromJSON(creatureJSON);
+  creature.activate(new Float32Array([1]));
+
+  // Ask for a target *inside* the valid ArcTan range, but extremely close to +π/2.
+  // Without additional guarding, tan(target) can be astronomically large even though the
+  // activation difference is tiny, which makes record() errors misleadingly huge.
+  const upper = Math.PI / 2;
+  // Push closer than 1e-9: tan(π/2 - 1e-12) is ~1e12 which historically caused
+  // value-space errors that dominate Explorer MSE.
+  const expected = new Float32Array([upper - 1e-12]);
+  const map = creature.record(expected);
+  const rec = map.get("output-0");
+  assert(rec, "Expected a record for output-0");
+
+  const err = rec.errors[0];
+  assert(Number.isFinite(err), `Expected finite error, got ${err}`);
+  assert(
+    Math.abs(err) < 1e9,
+    `Expected near-saturation error to be bounded, got ${err}`,
+  );
+});

--- a/test/propagate/record/ElasticRecordIFPrefersPlasticPath.ts
+++ b/test/propagate/record/ElasticRecordIFPrefersPlasticPath.ts
@@ -1,0 +1,69 @@
+import { assert } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { ArcTan } from "../../../src/methods/activations/types/ArcTan.ts";
+import { IF } from "../../../src/methods/activations/aggregate/IF.ts";
+import { ReLU } from "../../../src/methods/activations/types/ReLU.ts";
+
+Deno.test("record(IF): prefers plastic positive-branch paths over saturated ArcTan parents", () => {
+  // IF output chooses positive branch when condition > 0.
+  // We provide two positive sources:
+  // - hidden-arctan saturated (raw ~1e12)
+  // - hidden-relu normal (raw ~1)
+  //
+  // record() should recurse into hidden-relu and avoid attributing massive
+  // value-space error to the saturated ArcTan parent.
+  const creatureJSON: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { uuid: "hidden-arctan", type: "hidden", squash: ArcTan.NAME, bias: 0 },
+      { uuid: "hidden-relu", type: "hidden", squash: ReLU.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IF.NAME, bias: 0 },
+    ],
+    synapses: [
+      // Make condition positive.
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1, type: "condition" },
+
+      // Drive hidden nodes.
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-arctan",
+        weight: 1_000_000_000_000,
+      },
+      { fromUUID: "input-0", toUUID: "hidden-relu", weight: 1 },
+
+      // Two positive branches into IF.
+      {
+        fromUUID: "hidden-arctan",
+        toUUID: "output-0",
+        weight: 1,
+        type: "positive",
+      },
+      {
+        fromUUID: "hidden-relu",
+        toUUID: "output-0",
+        weight: 1,
+        type: "positive",
+      },
+    ],
+  };
+
+  const creature = Creature.fromJSON(creatureJSON);
+  creature.activate(new Float32Array([1, 1]));
+
+  const discoverMap = creature.record(new Float32Array([0]));
+  const arctanRec = discoverMap.get("hidden-arctan");
+  const reluRec = discoverMap.get("hidden-relu");
+
+  assert(reluRec, "Expected record entry for hidden-relu");
+
+  if (arctanRec) {
+    const finite = arctanRec.errors.filter(Number.isFinite);
+    const maxAbs = finite.reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    assert(
+      maxAbs < 1e9,
+      `Expected ArcTan path to be de-emphasised, got maxAbs=${maxAbs}`,
+    );
+  }
+});

--- a/test/propagate/record/ElasticRecordPrefersPlasticPath.ts
+++ b/test/propagate/record/ElasticRecordPrefersPlasticPath.ts
@@ -1,0 +1,62 @@
+import { assert } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { ArcTan } from "../../../src/methods/activations/types/ArcTan.ts";
+import { IDENTITY } from "../../../src/methods/activations/types/IDENTITY.ts";
+import { ReLU } from "../../../src/methods/activations/types/ReLU.ts";
+
+Deno.test("record: prefers plastic paths over saturated ArcTan parents", () => {
+  // Two parallel parents feed the output:
+  // - hidden-arctan is saturated (raw input ~1e6)
+  // - hidden-relu is in a normal range (raw input ~1)
+  //
+  // We want record() attribution to push error back into hidden-relu, and avoid
+  // calling record() on the saturated ArcTan parent (last resort).
+  const creatureJSON: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { uuid: "hidden-arctan", type: "hidden", squash: ArcTan.NAME, bias: 0 },
+      { uuid: "hidden-relu", type: "hidden", squash: ReLU.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      // Force ArcTan extremely close to +π/2 (raw input ~1e12).
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-arctan",
+        weight: 1_000_000_000_000,
+      },
+      { fromUUID: "input-0", toUUID: "hidden-relu", weight: 1 },
+      { fromUUID: "hidden-arctan", toUUID: "output-0", weight: 1 },
+      { fromUUID: "hidden-relu", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(creatureJSON);
+  const _output = creature.activate(new Float32Array([1]));
+
+  // Current output is atan(1e12) + relu(1) ≈ 1.5708 + 1.
+  // Request a much lower value so naive record() will attempt to push the ArcTan
+  // parent out of saturation (which implies a massive raw-value move).
+  const discoverMap = creature.record(new Float32Array([0]));
+
+  const arctanRec = discoverMap.get("hidden-arctan");
+  const reluRec = discoverMap.get("hidden-relu");
+
+  // Expect the relu path to be the one we recurse into.
+  assert(reluRec, "Expected record entry for hidden-relu");
+
+  // We expect to avoid recording saturated ArcTan parent at all (preferred).
+  // If it exists, it must not have been assigned a huge error.
+  if (arctanRec) {
+    const finite = arctanRec.errors.filter(Number.isFinite);
+    const maxAbs = finite.reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    assert(
+      maxAbs < 1e9,
+      `Expected ArcTan path to be de-emphasised, got maxAbs=${maxAbs}`,
+    );
+  } else {
+    // Preferred behaviour: we do not recurse into the saturated ArcTan parent.
+  }
+});


### PR DESCRIPTION
…framework

- Bumped version in deno.json to 0.270.0.
- Updated documentation in README.md to clarify the distinction between feed-forward and recurrent connections.
- Enhanced the Creature class to ensure that once a creature is marked as forward-only, it cannot have recurrent connections, updating the semantic versioning logic accordingly.
- Refactored validation and upgrade logic to reflect the new major version (4.x) for forward-only creatures, ensuring strict adherence to the forward-only constraint.
- Updated tests to validate the new versioning behavior and ensure correct handling of recurrent connections.

These changes improve the clarity and robustness of the NEAT framework's handling of creature semantics and versioning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Forward-only as a 4.x invariant**
> 
> - Promote confirmed forward-only creatures to `semanticVersion` 4.x and strictly reject any recurrent (self/back) connections in 4.x across `Creature.fix/validate`, `Mutator.mutateCreature`, `Offspring.breed`, `upgrade()`; legacy 3.x warns, 2.x/3.x are auto-bumped to 4.0.0 when validated
> - Mutation/connection helpers updated to respect `forwardOnly` (e.g. `makeRandomConnection`, `AddNeuron` with `pickOutwardTargetNeuronIndex`), preventing recurrent edges; discovery paths validate/repair and bump to 4.x
> 
> **Elastic record-time attribution**
> 
> - New `RecordElasticity` utilities used by `Neuron.record()` and aggregate squashes (`IF`, `MAXIMUM`, `MINIMUM`) to distribute error by activation² and safe-zone factors, preferring plastic paths and avoiding saturated parents; refined `ArcTan.safeZoneAdjustment`
> 
> **Docs and version**
> 
> - Add README section clarifying feed-forward vs recurrent connections; expand backprop elasticity doc; cspell additions
> - Bump package version to `0.270.0`
> 
> **Tests**
> 
> - Extensive new tests for forward-only invariants (including 4.x upgrade/validation), connection helpers, mutation behavior, discovery validation, and elastic record-time behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38b0b487834030f328b66e64cf33b3858fcf4b37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->