### PR TITLE
Update version to 0.270.2 and refine offspring versioning logic in Of…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.270.1",
+  "version": "0.270.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -77,11 +77,19 @@ export class Offspring {
     // Otherwise start at the lower version - validation will upgrade if appropriate.
     const motherMajor = getMajorVersion(mother.semanticVersion);
     const fatherMajor = getMajorVersion(father.semanticVersion);
-    const offspringVersion = (motherMajor >= 4 && fatherMajor >= 4)
-      ? mother.semanticVersion
-      : (motherMajor < fatherMajor
+    const bothParentsFourX = motherMajor >= 4 && fatherMajor >= 4;
+    const shouldBeForwardOnly = bothParentsFourX ||
+      options.forwardOnly === true ||
+      (options.forwardOnly === undefined &&
+        (mother.forwardOnly === true || father.forwardOnly === true));
+
+    const offspringVersion = shouldBeForwardOnly
+      ? ((motherMajor >= 4 && fatherMajor >= 4)
         ? mother.semanticVersion
-        : father.semanticVersion);
+        : (motherMajor < fatherMajor
+          ? mother.semanticVersion
+          : father.semanticVersion))
+      : "2.0.0";
 
     // Initialize offspring
     const offspring = new Creature(mother.input, mother.output, {
@@ -321,24 +329,26 @@ export class Offspring {
       offspring.memetic = memetic;
     }
 
-    const shouldBeForwardOnly = options.forwardOnly === true ||
-      (options.forwardOnly === undefined &&
-        (mum.forwardOnly === true || dad.forwardOnly === true));
-
-    // Check if both parents are 4.x (forward-only guaranteed)
-    const bothParentsFourX = motherMajor >= 4 && fatherMajor >= 4;
-
     try {
       creatureValidate(offspring);
 
       if (
-        options.forwardOnly === false && (mum.forwardOnly || dad.forwardOnly)
+        options.forwardOnly === false && !bothParentsFourX
       ) {
-        console.warn(
-          `[Offspring] feedbackLoop/memory mode requested; clearing forwardOnly on child (parents had forwardOnly)`,
-        );
-        offspring.forwardOnly = undefined;
+        // Feedback/memory mode explicitly requested. Ensure we do not create a
+        // semanticVersion 4.x creature (4.x is a hard "forward-only" invariant).
+        offspring.forwardOnly = false;
+        offspring.semanticVersion = "2.0.0";
       } else if (shouldBeForwardOnly) {
+        if (options.forwardOnly === false && bothParentsFourX) {
+          // Two 4.x parents are a hard forward-only invariant. If a caller requests
+          // feedback/memory mode here, it's a misuse of the API. We override it to
+          // keep invariants stable and avoid producing a "4.x but not forwardOnly"
+          // creature that later fails upgrade/validation.
+          console.warn(
+            `[Offspring] feedbackLoop/memory mode requested but both parents are 4.x; forcing forwardOnly child`,
+          );
+        }
         offspring.forwardOnly = true;
         try {
           offspring.validate({ forwardOnly: true });

--- a/test/FeedForward/ForwardOnlyFlag.ts
+++ b/test/FeedForward/ForwardOnlyFlag.ts
@@ -119,11 +119,11 @@ Deno.test("Breeding inherits forwardOnly by default (when a parent is forward-on
   child.validate({ forwardOnly: true });
 });
 
-Deno.test("Breeding with forwardOnly=false clears child forwardOnly (keeps memory connections)", () => {
+Deno.test("Breeding with forwardOnly=false sets child forwardOnly=false when parents are not 4.x", () => {
   const mumJson: CreatureExport = {
     input: 2,
     output: 1,
-    forwardOnly: true,
+    semanticVersion: "2.0.0",
     neurons: [
       { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0 },
       { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
@@ -137,7 +137,7 @@ Deno.test("Breeding with forwardOnly=false clears child forwardOnly (keeps memor
   const dadJson: CreatureExport = {
     input: 2,
     output: 1,
-    forwardOnly: true,
+    semanticVersion: "2.0.0",
     neurons: [
       { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0.1 },
       { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0.2 },

--- a/test/FeedForward/ForwardOnlyFlag.ts
+++ b/test/FeedForward/ForwardOnlyFlag.ts
@@ -160,6 +160,7 @@ Deno.test("Breeding with forwardOnly=false clears child forwardOnly (keeps memor
     if (child) break;
   }
   assert(child, "Expected child");
-  assertEquals(child.forwardOnly, undefined);
+  assertEquals(child.forwardOnly, false);
+  assertEquals(child.semanticVersion, "2.0.0");
   child.validate();
 });

--- a/test/Offspring/FeedbackModeSemanticVersion.ts
+++ b/test/Offspring/FeedbackModeSemanticVersion.ts
@@ -1,0 +1,71 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { Offspring } from "../../src/architecture/Offspring.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { upgrade } from "../../src/upgrade/Upgrade.ts";
+
+/**
+ * Regression test for issue #952 (24-Dec-2025).
+ *
+ * When feedback/memory mode is explicitly requested during breeding, the child
+ * must **not** be created as semanticVersion 4.x (forward-only invariant),
+ * otherwise future structural changes that add feedback connections will
+ * surface as `RECURSIVE_SYNAPSE` when the creature is later upgraded/cloned.
+ */
+Deno.test("Offspring: feedback mode must not create a 4.x child", () => {
+  const mumJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    semanticVersion: "4.0.0",
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+      // Extra connection so crossover can create a non-clone child.
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
+    ],
+  };
+  const dadJson: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    semanticVersion: "4.0.0",
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0.2 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: 0.3 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.7 },
+      // Extra connection so crossover can create a non-clone child.
+      { fromUUID: "input-1", toUUID: "output-0", weight: -0.15 },
+    ],
+  };
+
+  const mum = Creature.fromJSON(mumJson);
+  const dad = Creature.fromJSON(dadJson);
+  mum.validate({ forwardOnly: true });
+  dad.validate({ forwardOnly: true });
+
+  let child: Creature | undefined;
+  for (let attempt = 0; attempt < 200; attempt++) {
+    child = Offspring.breed(mum, dad, { forwardOnly: false });
+    if (child) break;
+  }
+  assert(child, "Expected child");
+
+  // Two 4.x parents are a hard forward-only invariant. Even if feedback mode is
+  // requested, the offspring must remain forward-only at 4.x.
+  assertEquals(child.forwardOnly, true);
+  assertEquals(child.semanticVersion, "4.0.0");
+
+  // Sanity: upgrade should continue to accept the child.
+  upgrade(Creature.fromJSON(child.exportJSON()));
+});

--- a/test/Offspring/FeedbackModeSemanticVersion.ts
+++ b/test/Offspring/FeedbackModeSemanticVersion.ts
@@ -8,12 +8,11 @@ import { upgrade } from "../../src/upgrade/Upgrade.ts";
 /**
  * Regression test for issue #952 (24-Dec-2025).
  *
- * When feedback/memory mode is explicitly requested during breeding, the child
- * must **not** be created as semanticVersion 4.x (forward-only invariant),
- * otherwise future structural changes that add feedback connections will
- * surface as `RECURSIVE_SYNAPSE` when the creature is later upgraded/cloned.
+ * Two 4.x parents are a hard forward-only invariant. Even if feedback/memory
+ * mode is explicitly requested, the offspring must remain a valid 4.x
+ * forward-only creature (and must not end up as "4.x but not forwardOnly").
  */
-Deno.test("Offspring: feedback mode must not create a 4.x child", () => {
+Deno.test("Offspring: two 4.x parents always produce a 4.x forward-only child", () => {
   const mumJson: CreatureExport = {
     input: 2,
     output: 1,


### PR DESCRIPTION
…fspring class

- Bumped version in deno.json to 0.270.2.
- Enhanced the logic for determining offspring semantic version based on parent versions, ensuring correct handling of forward-only constraints.
- Improved validation and warning mechanisms for offspring creation, particularly when both parents are marked as forward-only.

These changes enhance the robustness and clarity of version management in the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens breeding invariants and version handling.
> 
> - Refactors `Offspring.breed` to derive `shouldBeForwardOnly` and offspring `semanticVersion` from both parents and options
> - Forces 4.x forward-only offspring when both parents are 4.x; logs warning if feedback mode is requested in this case
> - When `forwardOnly=false` and parents are not both 4.x, sets `forwardOnly=false` and `semanticVersion` to `2.0.0`
> - Keeps upgrade path: validates, fixes violations for legacy (2.x) parents, and bumps to 4.0.0 only after forward-only confirmation
> - Updates test to expect `forwardOnly=false` and `2.0.0` in feedback mode for non-4.x parents; adds regression test ensuring two 4.x parents always yield a 4.x forward-only child
> - Bumps version in `deno.json` to `0.270.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd00a8c278a304b20c3d507d81e39b716afd44b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->