### PR TITLE
Update version to 0.271.0 and enhance neuron recording logic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,9 +9,9 @@
     "@std/csv": "jsr:@std/csv@1.0.6",
     "@std/fmt": "jsr:@std/fmt@1.0.8",
     "@std/fs": "jsr:@std/fs@1.0.20",
-    "@std/path": "jsr:@std/path@1.1.3",
+    "@std/path": "jsr:@std/path@1.1.4",
     "@std/streams": "jsr:@std/streams@1.0.14",
-    "@std/uuid": "jsr:@std/uuid@1.0.9",
+    "@std/uuid": "jsr:@std/uuid@1.1.0",
     "@std/testing/mock": "jsr:@std/testing@1.0.16/mock",
     "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.270.2",
+  "version": "0.271.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -37,6 +37,17 @@ export class Mutator {
   }
 
   /**
+   * Extracts the major version number from a semantic version string.
+   * @param version - Semantic version string (e.g. "4.0.0")
+   * @returns The major version number, or 0 if invalid/undefined
+   */
+  private getMajorVersion(version: string | undefined): number {
+    if (!version) return 0;
+    const major = parseInt(version.split(".")[0], 10);
+    return Number.isNaN(major) ? 0 : major;
+  }
+
+  /**
    * Mutates the given (or current) population
    */
   mutate(creatures: Creature[]): void {
@@ -128,10 +139,49 @@ export class Mutator {
       .mutation;
 
     const feedbackLoop = this.config.feedbackLoop;
-    const forwardOnly = creature.forwardOnly === true;
-    for (let attempts = 0; true; attempts++) {
-      const mutationMethod = mutationMethods[
-        Math.floor(Math.random() * mutationMethods.length)
+    const majorVersion = this.getMajorVersion(creature.semanticVersion);
+    const forwardOnly = majorVersion >= 4 || creature.forwardOnly === true;
+
+    // Avoid infinite loops: pre-filter for methods that can actually run under
+    // the current constraints.
+    const candidates = mutationMethods.filter((method) => {
+      switch (method.name) {
+        case Mutation.ADD_NODE.name:
+          return creature.neurons.length < this.config.maximumNumberOfNodes;
+        case Mutation.ADD_CONN.name:
+          return !(creature.synapses.length >= this.config.maxConns ||
+            creature.synapses.length >=
+              this.calculateMaxSynapses(
+                creature.input,
+                creature.neurons.length - creature.input - creature.output,
+                creature.output,
+              ));
+        case Mutation.SUB_NODE.name:
+          return creature.neurons.length > creature.input + creature.output;
+        case Mutation.SWAP_NODES.name:
+          return creature.neurons.length > creature.input + creature.output + 1;
+        case Mutation.ADD_BACK_CONN.name:
+        case Mutation.SUB_BACK_CONN.name:
+        case Mutation.ADD_SELF_CONN.name:
+        case Mutation.SUB_SELF_CONN.name:
+          // Self/back connections are only valid in feedback/memory mode and never
+          // for semanticVersion 4.x forward-only creatures.
+          return feedbackLoop !== false && forwardOnly === false;
+        default:
+          return true;
+      }
+    });
+
+    if (candidates.length === 0) {
+      throw new Error(
+        `No valid mutation methods available for creature (semanticVersion=${creature.semanticVersion}, forwardOnly=${forwardOnly}) ` +
+          `with config.feedbackLoop=${this.config.feedbackLoop}.`,
+      );
+    }
+
+    for (let attempts = 0; attempts < 10_000; attempts++) {
+      const mutationMethod = candidates[
+        Math.floor(Math.random() * candidates.length)
       ];
 
       if (Math.random() < 0.25) {
@@ -142,47 +192,12 @@ export class Mutator {
           continue;
         }
       }
-      switch (mutationMethod.name) {
-        case Mutation.ADD_NODE.name:
-          if (creature.neurons.length >= this.config.maximumNumberOfNodes) {
-            continue;
-          }
-          break;
-        case Mutation.ADD_CONN.name:
-          if (
-            creature.synapses.length >= this.config.maxConns ||
-            creature.synapses.length >=
-              this.calculateMaxSynapses(
-                creature.input,
-                creature.neurons.length - creature.input - creature.output,
-                creature.output,
-              )
-          ) {
-            continue;
-          }
-          break;
-        case Mutation.SUB_NODE.name:
-          if (creature.neurons.length <= creature.input + creature.output) {
-            continue;
-          }
-          break;
-        case Mutation.SWAP_NODES.name:
-          if (creature.neurons.length <= creature.input + creature.output + 1) {
-            continue;
-          }
-          break;
-        case Mutation.ADD_BACK_CONN.name:
-        case Mutation.SUB_BACK_CONN.name:
-        case Mutation.ADD_SELF_CONN.name:
-        case Mutation.SUB_SELF_CONN.name:
-          if (feedbackLoop === false || forwardOnly) {
-            continue;
-          }
-          break;
-      }
-
       return mutationMethod;
     }
+
+    // Extremely unlikely fallback: candidates exist but we keep skipping due to the
+    // 25% "bias/weight only" gate.
+    return candidates[0];
   }
 
   /**
@@ -203,7 +218,14 @@ export class Mutator {
 
     // If the caller enables feedback loops, forward-only constraints no longer apply.
     // Clear the flag so subsequent mutation/breeding can introduce memory connections.
-    if (this.config.feedbackLoop === true && creature.forwardOnly === true) {
+    // However, semanticVersion 4.x is a hard forward-only invariant and must never
+    // be cleared/relaxed.
+    const majorVersion = this.getMajorVersion(creature.semanticVersion);
+    if (
+      this.config.feedbackLoop === true &&
+      creature.forwardOnly === true &&
+      majorVersion < 4
+    ) {
       console.warn(
         `[Mutator] feedbackLoop=true requested for forwardOnly creature (${startUUID}); clearing creature.forwardOnly flag`,
       );

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -19,6 +19,7 @@ import type {
 } from "./DiscoverStructure.ts";
 import { isRustDiscoveryEnabled } from "./RustDiscovery.ts";
 import { PhaseDiagnostics } from "./PhaseDiagnostics.ts";
+import { submitDiscoveryRecordBatch } from "./SubmitDiscoveryRecordBatch.ts";
 
 const shouldLogDiscovery = (config: NeatConfig): boolean =>
   config.verbose || config.log > 0;
@@ -374,11 +375,11 @@ class DataRecorder {
           // 10ms window can be missed between loop iterations, which leads to
           // zero recorded Parquet artefacts even when we already buffered data.
           if (timeLeftMs <= 25 && params.dataSet.length > 0) {
-            const recorded = discoverStructure.record(
-              params.dataSet.splice(0),
-              params.neuronPromisesMap,
+            const recorded = submitDiscoveryRecordBatch(
+              discoverStructure,
+              params,
               filePath,
-              params.selectedIndices.splice(0),
+              { allowGraceAfterTimeout: true },
             );
             if (!recorded) break;
           }
@@ -419,11 +420,11 @@ class DataRecorder {
         params.dataSet.push(data);
 
         if (params.dataSet.length >= this.discoveryBatchSize) {
-          const recorded = discoverStructure.record(
-            params.dataSet.splice(0),
-            params.neuronPromisesMap,
+          const recorded = submitDiscoveryRecordBatch(
+            discoverStructure,
+            params,
             filePath,
-            params.selectedIndices.splice(0), // Pass and clear indices
+            { allowGraceAfterTimeout: true },
           );
           if (!recorded) break;
           assert(params.dataSet.length === 0, "Data set not empty");
@@ -476,11 +477,10 @@ class DataRecorder {
         // expired a moment earlier, `DiscoverStructure.record()` may still accept
         // a small grace batch (to avoid losing all buffered work under tight
         // deadlines).
-        const recorded = discoverStructure.record(
-          params.dataSet.splice(0),
-          params.neuronPromisesMap,
+        const recorded = submitDiscoveryRecordBatch(
+          discoverStructure,
+          params,
           filePath,
-          params.selectedIndices.splice(0),
           { allowGraceAfterTimeout: true },
         );
 
@@ -601,13 +601,13 @@ class DataRecorder {
 
           // Flush any remaining data for this file to ensure indices are correctly associated
           if (dataSet.length > 0) {
-            discoverStructure.record(
-              dataSet.splice(0),
-              neuronPromisesMap,
+            const recorded = submitDiscoveryRecordBatch(
+              discoverStructure,
+              { dataSet, neuronPromisesMap, selectedIndices },
               filePath,
-              selectedIndices.splice(0),
               { allowGraceAfterTimeout: true },
             );
+            if (!recorded) break;
             assert(dataSet.length === 0, "Data set not empty after flush");
             assert(
               selectedIndices.length === 0,

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -345,6 +345,16 @@ class DataRecorder {
       const recordBuffer = new Uint8Array(this.BYTES_PER_RECORD);
       const recordArray = new Float32Array(recordBuffer.buffer);
 
+      // Grace behaviour (24-Dec-2025): with very tight record deadlines (eg.
+      // 60ms) and heavy CI load, the timeout can expire before we manage to read
+      // even a single sample. That produces zero parquet artefacts and makes the
+      // timeout tests flaky.
+      //
+      // If we have not recorded anything at all yet, allow a single "grace read"
+      // of one record even when the timeout is already expired. The recorder
+      // layer applies a matching opt-in grace for persisting that final sample.
+      let usedGraceReadAfterTimeout = false;
+
       for (const recordIndex of selectedIndexes) {
         // If we're about to time out, flush any buffered samples as a partial
         // batch. This ensures we still persist useful work for large batch sizes
@@ -352,7 +362,10 @@ class DataRecorder {
         if (this.timeoutTS) {
           const now = Date.now();
           const timeLeftMs = this.timeoutTS - now;
-          if (timeLeftMs <= 0) break;
+          if (timeLeftMs <= 0) {
+            if (usedGraceReadAfterTimeout || params.counter.count > 0) break;
+            usedGraceReadAfterTimeout = true;
+          }
 
           // Keep this small: we just want to avoid crossing the deadline without
           // ever submitting a batch to the recorder.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -346,7 +346,26 @@ class DataRecorder {
       const recordArray = new Float32Array(recordBuffer.buffer);
 
       for (const recordIndex of selectedIndexes) {
-        if (this.timeoutTS && Date.now() > this.timeoutTS) break;
+        // If we're about to time out, flush any buffered samples as a partial
+        // batch. This ensures we still persist useful work for large batch sizes
+        // under tight record deadlines (eg. batch=512 with ~60ms timeout).
+        if (this.timeoutTS) {
+          const now = Date.now();
+          const timeLeftMs = this.timeoutTS - now;
+          if (timeLeftMs <= 0) break;
+
+          // Keep this small: we just want to avoid crossing the deadline without
+          // ever submitting a batch to the recorder.
+          if (timeLeftMs <= 10 && params.dataSet.length > 0) {
+            const recorded = discoverStructure.record(
+              params.dataSet.splice(0),
+              params.neuronPromisesMap,
+              filePath,
+              params.selectedIndices.splice(0),
+            );
+            if (!recorded) break;
+          }
+        }
 
         // Calculate the target position
         const targetPosition = recordIndex * this.BYTES_PER_RECORD;
@@ -429,6 +448,49 @@ class DataRecorder {
           // Give GC a chance to run periodically
           // deno-lint-ignore no-await-in-loop
           await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+      }
+
+      // Flush any partial batch. This matters for short record timeouts and
+      // large batch sizes (eg. 512) where we may not reach a full batch before
+      // the deadline, but we still want to persist the data already buffered.
+      if (params.dataSet.length > 0) {
+        // Only submit the final partial batch when we're still within the record
+        // timeout window; `DiscoverStructure.record()` intentionally aborts if
+        // the timeout already expired.
+        const withinTimeout = !this.timeoutTS || Date.now() <= this.timeoutTS;
+        const recorded = withinTimeout
+          ? discoverStructure.record(
+            params.dataSet.splice(0),
+            params.neuronPromisesMap,
+            filePath,
+            params.selectedIndices.splice(0),
+          )
+          : false;
+
+        if (!withinTimeout) {
+          // Drop buffered samples to release memory; we intentionally do not
+          // record them once the timeout has expired.
+          params.dataSet.splice(0);
+          params.selectedIndices.splice(0);
+        }
+
+        // Best-effort flush of the Rust chunk after the final (partial) batch.
+        // This keeps artefacts consistent when timeouts force partial recording.
+        if (discoverStructure.shouldFlushRustChunk()) {
+          const flushed = discoverStructure.flushRustChunk();
+          if (!flushed) {
+            console.warn(
+              `⚠️  Discovery ${
+                blue(this.ID)
+              } failed to flush discovery chunk after partial batch.`,
+            );
+          }
+        }
+
+        // If the recorder indicates we should stop (timeout), honour it.
+        if (!recorded) {
+          // No-op: exit function naturally.
         }
       }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -356,7 +356,11 @@ class DataRecorder {
 
           // Keep this small: we just want to avoid crossing the deadline without
           // ever submitting a batch to the recorder.
-          if (timeLeftMs <= 10 && params.dataSet.length > 0) {
+          //
+          // Note: 25ms is intentionally conservative. Under heavy CI load, a
+          // 10ms window can be missed between loop iterations, which leads to
+          // zero recorded Parquet artefacts even when we already buffered data.
+          if (timeLeftMs <= 25 && params.dataSet.length > 0) {
             const recorded = discoverStructure.record(
               params.dataSet.splice(0),
               params.neuronPromisesMap,
@@ -455,25 +459,17 @@ class DataRecorder {
       // large batch sizes (eg. 512) where we may not reach a full batch before
       // the deadline, but we still want to persist the data already buffered.
       if (params.dataSet.length > 0) {
-        // Only submit the final partial batch when we're still within the record
-        // timeout window; `DiscoverStructure.record()` intentionally aborts if
-        // the timeout already expired.
-        const withinTimeout = !this.timeoutTS || Date.now() <= this.timeoutTS;
-        const recorded = withinTimeout
-          ? discoverStructure.record(
-            params.dataSet.splice(0),
-            params.neuronPromisesMap,
-            filePath,
-            params.selectedIndices.splice(0),
-          )
-          : false;
-
-        if (!withinTimeout) {
-          // Drop buffered samples to release memory; we intentionally do not
-          // record them once the timeout has expired.
-          params.dataSet.splice(0);
-          params.selectedIndices.splice(0);
-        }
+        // Always attempt to submit the final partial batch. If the record window
+        // expired a moment earlier, `DiscoverStructure.record()` may still accept
+        // a small grace batch (to avoid losing all buffered work under tight
+        // deadlines).
+        const recorded = discoverStructure.record(
+          params.dataSet.splice(0),
+          params.neuronPromisesMap,
+          filePath,
+          params.selectedIndices.splice(0),
+          { allowGraceAfterTimeout: true },
+        );
 
         // Best-effort flush of the Rust chunk after the final (partial) batch.
         // This keeps artefacts consistent when timeouts force partial recording.
@@ -597,6 +593,7 @@ class DataRecorder {
               neuronPromisesMap,
               filePath,
               selectedIndices.splice(0),
+              { allowGraceAfterTimeout: true },
             );
             assert(dataSet.length === 0, "Data set not empty after flush");
             assert(

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -432,8 +432,15 @@ export class DiscoverStructure {
     // caller explicitly provides `options.baseDirectory`.
     let baseDir = options.baseDirectory ?? ".discovery";
     try {
-      const denoTest = Deno.env.get("DENO_TEST")?.toLowerCase() === "true";
-      if (options.baseDirectory === undefined && denoTest) {
+      const env = (key: string) => Deno.env.get(key)?.trim().toLowerCase();
+      const denoTest = env("DENO_TEST") === "1" || env("DENO_TEST") === "true";
+      const suiteDeterministic =
+        env("NEAT_AI_DISCOVERY_DETERMINISTIC") === "1" ||
+        env("NEAT_AI_DISCOVERY_DETERMINISTIC") === "true";
+
+      if (
+        options.baseDirectory === undefined && (denoTest || suiteDeterministic)
+      ) {
         baseDir = `.discovery/test-${Deno.pid}-${
           crypto.randomUUID().slice(0, 8)
         }`;

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -423,7 +423,24 @@ export class DiscoverStructure {
   ) {
     this.creature = creature;
     assert(creature.uuid, "Creature must have a UUID to discover structure.");
-    const baseDir = options.baseDirectory ?? ".discovery";
+    // In `deno test`, creature UUIDs are often deterministic across tests.
+    // When tests run concurrently, using a shared `${baseDir}/${creature.uuid}`
+    // directory can cause cross-test interference (eg. one test clearing the
+    // directory while another is still recording/analysing).
+    //
+    // To keep tests reliable, default to an isolated base directory unless the
+    // caller explicitly provides `options.baseDirectory`.
+    let baseDir = options.baseDirectory ?? ".discovery";
+    try {
+      const denoTest = Deno.env.get("DENO_TEST")?.toLowerCase() === "true";
+      if (options.baseDirectory === undefined && denoTest) {
+        baseDir = `.discovery/test-${Deno.pid}-${
+          crypto.randomUUID().slice(0, 8)
+        }`;
+      }
+    } catch {
+      // If env access is restricted, fall back to the default base directory.
+    }
     this.tempDir = `${baseDir}/${creature.uuid}`;
     this.indicesFilePath = `${this.tempDir}/selected_indices.json`;
     this.textDecoder = new TextDecoder();
@@ -780,29 +797,90 @@ export class DiscoverStructure {
     _neuronPromisesMap: Map<string, Promise<void>>,
     binaryFilePath?: string,
     recordIndices?: number[],
+    options?: Readonly<{
+      /**
+       * Allow a small "grace" batch after the timeout has technically expired.
+       *
+       * This is primarily used by the directory recorder, which may have
+       * buffered samples but miss the final submit window by a few milliseconds
+       * under heavy load. Keeping this opt-in preserves strict timeout semantics
+       * for callers that rely on record() being a hard cut-off.
+       */
+      allowGraceAfterTimeout?: boolean;
+    }>,
   ): boolean {
     assert(this.initialized, "Not initialized");
     const timedOut = Date.now() > this.timeoutTS;
-    if (timedOut) {
-      this.log(
-        "warn",
-        "Discovery recording timeout reached; skipping remaining samples.",
-      );
-    }
     this.recorded = true;
     this.cachedMaxOutputError = undefined;
 
     // Rust module is required - if not available, discovery was already skipped in initialize()
-    if (!this.usingRustDualWrite || timedOut) {
-      return false; // Discovery skipped - Rust not available or timed out
+    if (!this.usingRustDualWrite) {
+      return false; // Discovery skipped - Rust not available
+    }
+
+    // Under tight record deadlines (eg. 60ms timeout tests), we can end up with
+    // buffered samples in the caller, but miss the final submit window by a few
+    // milliseconds under load. If we refuse all record() calls after the timeout,
+    // we can produce *zero* Parquet artefacts, which makes discovery debugging
+    // and CI regressions very hard to reason about.
+    //
+    // So: if we have not recorded anything yet, accept a small grace batch even
+    // when the timeout is already expired.
+    let effectiveTrainingData = trainingData;
+    let effectiveRecordIndices = recordIndices;
+    if (timedOut) {
+      const hasAnyRecordedSoFar = this.rustChunkFiles.length > 0 ||
+        this.rustAccumulatedData.length > 0;
+      if (hasAnyRecordedSoFar) {
+        this.log(
+          "warn",
+          "Discovery recording timeout reached; skipping remaining samples.",
+        );
+        return false;
+      }
+
+      if (!options?.allowGraceAfterTimeout) {
+        this.log(
+          "warn",
+          "Discovery recording timeout reached; skipping remaining samples.",
+        );
+        return false;
+      }
+
+      // Grace capture: keep this small to avoid blowing the deadline further.
+      const MAX_GRACE_SAMPLES = 64;
+      const take = Math.min(effectiveTrainingData.length, MAX_GRACE_SAMPLES);
+      if (take <= 0) {
+        return false;
+      }
+      if (take < effectiveTrainingData.length) {
+        this.log(
+          "warn",
+          `Discovery recording timeout reached; capturing a small grace batch (${take}/${effectiveTrainingData.length}) to avoid empty artefacts.`,
+        );
+      } else {
+        this.log(
+          "warn",
+          `Discovery recording timeout reached; capturing ${take} grace sample(s) to avoid empty artefacts.`,
+        );
+      }
+
+      effectiveTrainingData = effectiveTrainingData.slice(0, take);
+      if (effectiveRecordIndices) {
+        effectiveRecordIndices = effectiveRecordIndices.slice(0, take);
+      }
     }
 
     // Track selected indices if provided (from binary file processing)
-    if (binaryFilePath && recordIndices && recordIndices.length > 0) {
+    if (
+      binaryFilePath && effectiveRecordIndices &&
+      effectiveRecordIndices.length > 0
+    ) {
       if (!this.selectedIndices[binaryFilePath]) {
         this.selectedIndices[binaryFilePath] = [];
       }
-      this.selectedIndices[binaryFilePath].push(...recordIndices);
+      this.selectedIndices[binaryFilePath].push(...effectiveRecordIndices);
 
       // Write indices to JSON file after accumulating them
       Deno.writeTextFileSync(
@@ -819,8 +897,8 @@ export class DiscoverStructure {
     }
 
     // Process each record and accumulate data for Rust batch processing
-    for (let i = 0; i < trainingData.length; i++) {
-      const record = trainingData[i];
+    for (let i = 0; i < effectiveTrainingData.length; i++) {
+      const record = effectiveTrainingData[i];
 
       try {
         // Activate creature with existing input

--- a/src/architecture/ErrorGuidedStructuralEvolution/SubmitDiscoveryRecordBatch.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/SubmitDiscoveryRecordBatch.ts
@@ -1,0 +1,50 @@
+import type { DataRecordInterface } from "../DataSet.ts";
+
+/**
+ * Submits a buffered discovery recording batch in a non-destructive way.
+ *
+ * Why (Australian English): The directory recorder buffers samples and then
+ * submits them to `DiscoverStructure.record()`. Under tight deadlines, a timeout
+ * race can cause `record()` to return false even after the caller has decided to
+ * flush. If we clear buffers before knowing `record()` accepted the data, we can
+ * lose samples and end up with zero Parquet artefacts.
+ *
+ * This helper only clears `params.dataSet` / `params.selectedIndices` if the
+ * recorder returns true.
+ */
+export function submitDiscoveryRecordBatch(
+  discoverStructure: Readonly<{
+    record: (
+      trainingData: DataRecordInterface[],
+      neuronPromisesMap: Map<string, Promise<void>>,
+      binaryFilePath?: string,
+      recordIndices?: number[],
+      options?: Readonly<{ allowGraceAfterTimeout?: boolean }>,
+    ) => boolean;
+  }>,
+  params: Readonly<{
+    dataSet: DataRecordInterface[];
+    neuronPromisesMap: Map<string, Promise<void>>;
+    selectedIndices: number[];
+  }>,
+  filePath: string,
+  options?: Readonly<{ allowGraceAfterTimeout?: boolean }>,
+): boolean {
+  if (params.dataSet.length === 0) return true;
+
+  // Pass the live arrays; `DiscoverStructure.record()` does not mutate them.
+  const recorded = discoverStructure.record(
+    params.dataSet,
+    params.neuronPromisesMap,
+    filePath,
+    params.selectedIndices,
+    options,
+  );
+
+  if (recorded) {
+    params.dataSet.splice(0);
+    params.selectedIndices.splice(0);
+  }
+
+  return recorded;
+}

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -28,6 +28,7 @@ import { distributeElasticError } from "../propagate/ElasticDistribution.ts";
 import {
   buildRecordElasticLinks,
   distributeRecordError,
+  recordTargetFeasibilityFactor,
 } from "../propagate/RecordElasticity.ts";
 import type { SparseConfig } from "../propagate/sparse/SparseConfig.ts";
 import {
@@ -830,9 +831,62 @@ export class Neuron implements TagsInterface, NeuronInternal {
             },
           );
 
+          // Hard guard: do not request impossible (or strongly undesired) target
+          // activations from upstream squashes. If a share would push a parent
+          // outside its feasible range, skip that link and reallocate the share
+          // across the remaining feasible parents.
+          //
+          // This avoids "hidden" clamping in `Neuron.record()` turning an
+          // impossible target (eg. negative for ABSOLUTE/ReLU) into a large,
+          // misleading error that then pollutes discovery metrics.
+          const feasibleLinks: Array<(typeof chosenLinks)[number]> = [];
+          const feasibleShares: number[] = [];
+          let blockedError = 0;
+
           for (let i = 0; i < chosenLinks.length; i++) {
             const link = chosenLinks[i];
             const share = shares[i] ?? 0;
+            if (!Number.isFinite(share) || Math.abs(share) <= 1e-12) continue;
+
+            const fromNeuron = link.fromNeuron;
+            const weight = link.synapse.weight;
+            if (!weight) continue;
+
+            const targetFromValue = link.fromValue + share;
+            const targetFromActivation = targetFromValue / weight;
+
+            const feasibility = recordTargetFeasibilityFactor(
+              fromNeuron,
+              targetFromActivation,
+            );
+            if (feasibility <= 0) {
+              blockedError += share;
+              continue;
+            }
+
+            feasibleLinks.push(link);
+            feasibleShares.push(share);
+          }
+
+          if (Math.abs(blockedError) > 1e-12 && feasibleLinks.length > 0) {
+            // Reallocate the blocked value-space share across feasible links.
+            const { shares: redistributed } = distributeRecordError(
+              blockedError,
+              feasibleLinks,
+              {
+                plankConstant: 1e-12,
+                allowEqualFallback: true,
+              },
+            );
+            for (let i = 0; i < redistributed.length; i++) {
+              feasibleShares[i] = (feasibleShares[i] ?? 0) +
+                (redistributed[i] ?? 0);
+            }
+          }
+
+          for (let i = 0; i < feasibleLinks.length; i++) {
+            const link = feasibleLinks[i];
+            const share = feasibleShares[i] ?? 0;
             if (!Number.isFinite(share) || Math.abs(share) <= 1e-12) continue;
 
             const fromNeuron = link.fromNeuron;

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -832,49 +832,74 @@ export class Neuron implements TagsInterface, NeuronInternal {
           );
 
           // Hard guard: do not request impossible (or strongly undesired) target
-          // activations from upstream squashes. If a share would push a parent
-          // outside its feasible range, skip that link and reallocate the share
-          // across the remaining feasible parents.
+          // activations from upstream squashes.
+          //
+          // Important: when we redistribute blocked error, we must re-check
+          // feasibility because a previously-feasible link can become infeasible
+          // after it absorbs additional share (regression test:
+          // `RedistributedBlockedErrorMaintainsFeasibility.ts`).
           //
           // This avoids "hidden" clamping in `Neuron.record()` turning an
           // impossible target (eg. negative for ABSOLUTE/ReLU) into a large,
           // misleading error that then pollutes discovery metrics.
-          const feasibleLinks: Array<(typeof chosenLinks)[number]> = [];
-          const feasibleShares: number[] = [];
-          let blockedError = 0;
+          const plankConstant = 1e-12;
 
-          for (let i = 0; i < chosenLinks.length; i++) {
-            const link = chosenLinks[i];
-            const share = shares[i] ?? 0;
-            if (!Number.isFinite(share) || Math.abs(share) <= 1e-12) continue;
+          let workingLinks: ReadonlyArray<(typeof chosenLinks)[number]> =
+            chosenLinks;
+          let workingShares: number[] = shares.slice();
 
-            const fromNeuron = link.fromNeuron;
-            const weight = link.synapse.weight;
-            if (!weight) continue;
+          // Iterate until stable: each loop removes at least one infeasible link
+          // (or terminates), so this always finishes in <= number of links.
+          for (let pass = 0; pass < chosenLinks.length + 1; pass++) {
+            const feasibleLinks: Array<(typeof chosenLinks)[number]> = [];
+            const feasibleShares: number[] = [];
+            let blockedError = 0;
 
-            const targetFromValue = link.fromValue + share;
-            const targetFromActivation = targetFromValue / weight;
+            for (let i = 0; i < workingLinks.length; i++) {
+              const link = workingLinks[i];
+              const share = workingShares[i] ?? 0;
+              if (
+                !Number.isFinite(share) || Math.abs(share) <= plankConstant
+              ) {
+                continue;
+              }
 
-            const feasibility = recordTargetFeasibilityFactor(
-              fromNeuron,
-              targetFromActivation,
-            );
-            if (feasibility <= 0) {
-              blockedError += share;
-              continue;
+              const fromNeuron = link.fromNeuron;
+              const weight = link.synapse.weight;
+              if (!weight) continue;
+
+              const targetFromValue = link.fromValue + share;
+              const targetFromActivation = targetFromValue / weight;
+
+              const feasibility = recordTargetFeasibilityFactor(
+                fromNeuron,
+                targetFromActivation,
+              );
+              if (feasibility <= 0) {
+                blockedError += share;
+                continue;
+              }
+
+              feasibleLinks.push(link);
+              feasibleShares.push(share);
             }
 
-            feasibleLinks.push(link);
-            feasibleShares.push(share);
-          }
+            // Nothing to redistribute, or nowhere feasible to put it.
+            if (
+              Math.abs(blockedError) <= plankConstant ||
+              feasibleLinks.length === 0
+            ) {
+              workingLinks = feasibleLinks;
+              workingShares = feasibleShares;
+              break;
+            }
 
-          if (Math.abs(blockedError) > 1e-12 && feasibleLinks.length > 0) {
             // Reallocate the blocked value-space share across feasible links.
             const { shares: redistributed } = distributeRecordError(
               blockedError,
               feasibleLinks,
               {
-                plankConstant: 1e-12,
+                plankConstant,
                 allowEqualFallback: true,
               },
             );
@@ -882,12 +907,18 @@ export class Neuron implements TagsInterface, NeuronInternal {
               feasibleShares[i] = (feasibleShares[i] ?? 0) +
                 (redistributed[i] ?? 0);
             }
+
+            // Re-check feasibility after redistribution on the next pass.
+            workingLinks = feasibleLinks;
+            workingShares = feasibleShares;
           }
 
-          for (let i = 0; i < feasibleLinks.length; i++) {
-            const link = feasibleLinks[i];
-            const share = feasibleShares[i] ?? 0;
-            if (!Number.isFinite(share) || Math.abs(share) <= 1e-12) continue;
+          for (let i = 0; i < workingLinks.length; i++) {
+            const link = workingLinks[i];
+            const share = workingShares[i] ?? 0;
+            if (!Number.isFinite(share) || Math.abs(share) <= plankConstant) {
+              continue;
+            }
 
             const fromNeuron = link.fromNeuron;
             const weight = link.synapse.weight;
@@ -895,6 +926,14 @@ export class Neuron implements TagsInterface, NeuronInternal {
 
             const targetFromValue = link.fromValue + share;
             const targetFromActivation = targetFromValue / weight;
+
+            // Final safety check in case of floating point edge-cases.
+            if (
+              recordTargetFeasibilityFactor(fromNeuron, targetFromActivation) <=
+                0
+            ) {
+              continue;
+            }
 
             fromNeuron.record(targetFromActivation, discoverMap);
           }

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -864,6 +864,18 @@ export class Neuron implements TagsInterface, NeuronInternal {
                 continue;
               }
 
+              // Safe-zone hard guard: if a parent is fully blocked (eg. deeply
+              // saturated ArcTan), do not recurse into it. If all parents are
+              // blocked, we stop recursion rather than forcing an equal-split
+              // attribution that would generate huge, misleading errors.
+              if (
+                !Number.isFinite(link.safeZoneFactor) ||
+                link.safeZoneFactor <= 0
+              ) {
+                blockedError += share;
+                continue;
+              }
+
               const fromNeuron = link.fromNeuron;
               const weight = link.synapse.weight;
               if (!weight) continue;

--- a/src/methods/activations/aggregate/IF.ts
+++ b/src/methods/activations/aggregate/IF.ts
@@ -16,6 +16,7 @@ import { accumulateBias, adjustedBias } from "../../../propagate/Bias.ts";
 import {
   buildRecordElasticLinks,
   distributeRecordError,
+  recordTargetFeasibilityFactor,
 } from "../../../propagate/RecordElasticity.ts";
 import type { SparseConfig } from "../../../propagate/sparse/SparseConfig.ts";
 import { accumulateWeight, adjustedWeight } from "../../../propagate/Weight.ts";
@@ -558,16 +559,90 @@ export class IF
       allowEqualFallback: true,
     });
 
-    for (let i = 0; i < chosenLinks.length; i++) {
-      const link = chosenLinks[i];
-      const share = shares[i] ?? 0;
-      if (!Number.isFinite(share) || Math.abs(share) <= 1e-12) continue;
+    const plankConstant = 1e-12;
+
+    let workingLinks: ReadonlyArray<(typeof chosenLinks)[number]> = chosenLinks;
+    let workingShares: number[] = shares.slice();
+
+    // Mirror `Neuron.record()` feasibility + safe-zone guards:
+    // - do not request impossible targets (range/negative constraints)
+    // - do not recurse into fully blocked parents (safeZoneFactor <= 0)
+    // - if blocked shares exist, redistribute and re-check until stable
+    for (let pass = 0; pass < chosenLinks.length + 1; pass++) {
+      const feasibleLinks: Array<(typeof chosenLinks)[number]> = [];
+      const feasibleShares: number[] = [];
+      let blockedError = 0;
+
+      for (let i = 0; i < workingLinks.length; i++) {
+        const link = workingLinks[i];
+        const share = workingShares[i] ?? 0;
+        if (!Number.isFinite(share) || Math.abs(share) <= plankConstant) {
+          continue;
+        }
+
+        if (!Number.isFinite(link.safeZoneFactor) || link.safeZoneFactor <= 0) {
+          blockedError += share;
+          continue;
+        }
+
+        const fromNeuron = link.fromNeuron;
+        const weight = link.synapse.weight;
+        if (!weight) continue;
+
+        const targetFromValue = link.fromValue + share;
+        const targetFromActivation = targetFromValue / weight;
+
+        const feasibility = recordTargetFeasibilityFactor(
+          fromNeuron,
+          targetFromActivation,
+        );
+        if (feasibility <= 0) {
+          blockedError += share;
+          continue;
+        }
+
+        feasibleLinks.push(link);
+        feasibleShares.push(share);
+      }
+
+      if (
+        Math.abs(blockedError) <= plankConstant || feasibleLinks.length === 0
+      ) {
+        workingLinks = feasibleLinks;
+        workingShares = feasibleShares;
+        break;
+      }
+
+      const { shares: redistributed } = distributeRecordError(
+        blockedError,
+        feasibleLinks,
+        { plankConstant, allowEqualFallback: true },
+      );
+      for (let i = 0; i < redistributed.length; i++) {
+        feasibleShares[i] = (feasibleShares[i] ?? 0) + (redistributed[i] ?? 0);
+      }
+
+      workingLinks = feasibleLinks;
+      workingShares = feasibleShares;
+    }
+
+    for (let i = 0; i < workingLinks.length; i++) {
+      const link = workingLinks[i];
+      const share = workingShares[i] ?? 0;
+      if (!Number.isFinite(share) || Math.abs(share) <= plankConstant) continue;
 
       const weight = link.synapse.weight;
       if (!weight) continue;
 
       const targetFromValue = link.fromValue + share;
       const targetFromActivation = targetFromValue / weight;
+      if (
+        recordTargetFeasibilityFactor(link.fromNeuron, targetFromActivation) <=
+          0
+      ) {
+        continue;
+      }
+
       link.fromNeuron.record(targetFromActivation, discoverMap);
     }
   }

--- a/src/propagate/RecordElasticity.ts
+++ b/src/propagate/RecordElasticity.ts
@@ -26,7 +26,76 @@ export type RecordElasticLink = Readonly<{
   fromActivation: number;
   fromValue: number;
   safeZoneFactor: number;
+  /**
+   * Record-time feasibility/comfort factor for the *implied* upstream target.
+   *
+   * This is intentionally separate from `safeZoneFactor`:
+   * - `safeZoneFactor` is about local plasticity / saturation in raw-input space
+   * - `feasibilityFactor` is about whether the requested *activation target* is
+   *   feasible (range-limited squashes) or strongly undesirable (ReLU-family
+   *   variants we prefer to keep non-negative during record attribution)
+   */
+  feasibilityFactor: number;
 }>;
+
+// Tiny epsilon to avoid flapping around exact boundaries.
+const RECORD_TARGET_EPSILON = 1e-9;
+
+// Squashes where out-of-range record targets are especially misleading during
+// attribution. For these, we treat out-of-range targets as blocked so we prefer
+// alternative synapses when available.
+const HARD_RANGE_SQUASHES = new Set<string>([
+  "ABSOLUTE",
+  "SQUARE",
+]);
+
+// During record-time attribution (Explorer/discovery analysis), we prefer to
+// avoid pushing these squashes negative when there is an alternative synapse.
+//
+// Rationale (Australian English): while some of these can technically output
+// negative values, pushing them negative during attribution can create large,
+// misleading neuron-level errors that then get redistributed elsewhere.
+const NEGATIVE_RESIST_SQUASHES = new Set<string>([
+  "Swish",
+  "SELU",
+  "GELU",
+  "LeakyReLU",
+  "ELU",
+]);
+
+export function recordTargetFeasibilityFactor(
+  fromNeuron: Neuron,
+  targetActivation: number,
+): number {
+  if (!Number.isFinite(targetActivation)) return 0;
+
+  const squash = fromNeuron.findSquash();
+  const range = squash.range;
+  const name = squash.getName();
+
+  // Hard feasibility: if the target activation is outside the squash output
+  // range, treat it as impossible for selected squashes where clamping hides
+  // impossibility and inflates discovery metrics.
+  if (HARD_RANGE_SQUASHES.has(name)) {
+    if (
+      targetActivation < range.low - RECORD_TARGET_EPSILON ||
+      targetActivation > range.high + RECORD_TARGET_EPSILON
+    ) {
+      return 0;
+    }
+  }
+
+  // Soft preference: for certain ReLU-family variants, prefer not to cross
+  // below zero during record attribution.
+  if (
+    NEGATIVE_RESIST_SQUASHES.has(name) &&
+    targetActivation < -RECORD_TARGET_EPSILON
+  ) {
+    return 0;
+  }
+
+  return 1;
+}
 
 export function getOrComputeRecordValue(
   neuron: Neuron,
@@ -114,12 +183,22 @@ export function buildRecordElasticLinks(
       }
     }
 
+    // Estimate the implied upstream activation target if this link absorbed a
+    // provisional equal share of error in value space.
+    const impliedTargetFromValue = fromValue + provisionalErrorPerLink;
+    const impliedTargetFromActivation = impliedTargetFromValue / c.weight;
+    const feasibilityFactor = (fromNeuron.type !== "input" &&
+        fromNeuron.type !== "constant")
+      ? recordTargetFeasibilityFactor(fromNeuron, impliedTargetFromActivation)
+      : 1;
+
     links.push({
       synapse: c,
       fromNeuron,
       fromActivation,
       fromValue,
       safeZoneFactor,
+      feasibilityFactor,
     });
   }
 
@@ -153,7 +232,7 @@ export function distributeRecordError(
 
   const meta = links.map((l) => ({
     activation: l.fromActivation,
-    safeZoneFactor: l.safeZoneFactor,
+    safeZoneFactor: l.safeZoneFactor * l.feasibilityFactor,
   }));
 
   // If everything is blocked, `distributeElasticError` will equal-split. That’s

--- a/src/propagate/RecordElasticity.ts
+++ b/src/propagate/RecordElasticity.ts
@@ -46,6 +46,8 @@ const RECORD_TARGET_EPSILON = 1e-9;
 // alternative synapses when available.
 const HARD_RANGE_SQUASHES = new Set<string>([
   "ABSOLUTE",
+  "ReLU",
+  "ReLU6",
   "SQUARE",
 ]);
 

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -124,7 +124,16 @@ function tryUpgradeToFour(creature: Creature): Creature {
       creatureValidate(creature, { forwardOnly: true });
       creature.semanticVersion = "4.0.0";
     } catch (_error) {
-      // Creature claims to be forward-only but isn't - clear the flag, stay at current version
+      // Creature claims to be forward-only but failed validation.
+      // Attempt repair first; if repair fails, clear the flag and stay at current version.
+      try {
+        creature.fix({ forwardOnly: true });
+        creatureValidate(creature, { forwardOnly: true });
+        creature.semanticVersion = "4.0.0";
+        return creature;
+      } catch (_fixError) {
+        // Fall through to clearing the flag below.
+      }
       console.warn(
         `[upgrade] Creature claims forwardOnly but failed validation; clearing flag`,
       );

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -55,7 +55,53 @@ function validateThreeX(creature: Creature): void {
  * regardless of whether the `forwardOnly` flag is set.
  */
 function validateFourX(creature: Creature): void {
-  creatureValidate(creature, { forwardOnly: true });
+  try {
+    creatureValidate(creature, { forwardOnly: true });
+    creature.forwardOnly = true;
+    return;
+  } catch (e) {
+    const error = e as Error;
+
+    // Production safety net: although 4.x is a hard forward-only invariant, we
+    // occasionally encounter corrupted persisted creatures (e.g. a back-connection
+    // sneaking in). Instead of crashing the entire job, attempt to repair using
+    // `fix({ forwardOnly: true })`.
+    if (
+      error.name === "SELF_CONNECTION" ||
+      error.name === "RECURSIVE_SYNAPSE"
+    ) {
+      console.warn(
+        `[upgrade] Corrupted 4.x creature (UUID: ${
+          creature.uuid ?? "unknown"
+        }) failed forward-only validation: ` +
+          `${error.name} - ${error.message}. Attempting repair via fix({ forwardOnly: true }).`,
+      );
+      try {
+        creature.fix({ forwardOnly: true });
+        creatureValidate(creature, { forwardOnly: true });
+        creature.forwardOnly = true;
+        return;
+      } catch (fixError) {
+        const fixErr = fixError as Error;
+        console.error(
+          `[upgrade] Repair failed for corrupted 4.x creature (UUID: ${
+            creature.uuid ?? "unknown"
+          }). ` +
+            `Downgrading to 2.0.0 to avoid crashing. ` +
+            `Original=${error.name}: ${error.message}. ` +
+            `FixError=${fixErr.name}: ${fixErr.message}`,
+        );
+
+        // Last resort: clear the forward-only guarantee and downgrade the semantic
+        // version so callers won't treat this as a forward-only invariant.
+        creature.forwardOnly = undefined;
+        creature.semanticVersion = "2.0.0";
+        return;
+      }
+    }
+
+    throw e;
+  }
 }
 
 /**

--- a/test/ErrorGuidedStructuralEvolution/NeuronDiscovery.ts
+++ b/test/ErrorGuidedStructuralEvolution/NeuronDiscovery.ts
@@ -321,6 +321,10 @@ Deno.test({
       const flushSuccess = discoverStructure.flushRustRecording();
       assert(flushSuccess, "Flush should succeed");
 
+      // Keep analysis bounded in tests. Rust logs the configured max timeout; we
+      // pass a short deadline so quality checks never hang here.
+      discoverStructure.extendTimeoutForAnalysis(5);
+
       const candidates = await discoverStructure.analyzeMissingNeurons([
         "output-0",
       ]);
@@ -385,6 +389,8 @@ Deno.test({
 
       // Test each output separately
       for (const outputUUID of ["output-0", "output-1"]) {
+        // Keep each Rust analysis call bounded.
+        discoverStructure.extendTimeoutForAnalysis(5);
         // deno-lint-ignore no-await-in-loop
         const candidates = await discoverStructure.analyzeMissingNeurons([
           outputUUID,
@@ -401,6 +407,7 @@ Deno.test({
       }
 
       // Test combined
+      discoverStructure.extendTimeoutForAnalysis(5);
       const allCandidates = await discoverStructure.analyzeMissingNeurons([
         "output-0",
         "output-1",
@@ -456,6 +463,9 @@ Deno.test({
       await Promise.all([...neuronPromises.values()]);
       discoverStructure.flushRustRecording();
 
+      // Hard cap analysis time so this test cannot stall `./quality.sh`.
+      discoverStructure.extendTimeoutForAnalysis(10);
+
       const focusNeurons = ["output-0", "output-1", "output-2"];
       const candidates = await discoverStructure.analyzeMissingNeurons(
         focusNeurons,
@@ -502,6 +512,9 @@ Deno.test({
       discoverStructure.record(trainingData, neuronPromises);
       await Promise.all([...neuronPromises.values()]);
       discoverStructure.flushRustRecording();
+
+      // Bound the combined analysis phase to keep the test suite responsive.
+      discoverStructure.extendTimeoutForAnalysis(10);
 
       // This is what DiscoverDirectory uses in production
       const bundle = discoverStructure.collectRustAnalysisCandidates(
@@ -583,6 +596,8 @@ Deno.test({
       console.log("\n--- Analysis (per output) ---");
       for (const outputUUID of ["output-0", "output-1"]) {
         console.log(`\nFocus: ${outputUUID}`);
+        // Keep each call bounded so diagnostics do not stall CI / quality checks.
+        discoverStructure.extendTimeoutForAnalysis(5);
         // deno-lint-ignore no-await-in-loop
         const candidates = await discoverStructure.analyzeMissingNeurons([
           outputUUID,
@@ -608,6 +623,7 @@ Deno.test({
       }
 
       console.log("\n--- Combined analysis ---");
+      discoverStructure.extendTimeoutForAnalysis(5);
       const allCandidates = await discoverStructure.analyzeMissingNeurons([
         "output-0",
         "output-1",

--- a/test/ErrorGuidedStructuralEvolution/SubmitDiscoveryRecordBatch.ts
+++ b/test/ErrorGuidedStructuralEvolution/SubmitDiscoveryRecordBatch.ts
@@ -1,0 +1,90 @@
+import { assertEquals } from "@std/assert";
+import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
+import { submitDiscoveryRecordBatch } from "../../src/architecture/ErrorGuidedStructuralEvolution/SubmitDiscoveryRecordBatch.ts";
+
+Deno.test(
+  "submitDiscoveryRecordBatch: preserves buffers when record() returns false (avoids splice data loss)",
+  () => {
+    const data: DataRecordInterface = {
+      input: new Float32Array([1]),
+      output: new Float32Array([2]),
+    };
+
+    const params = {
+      dataSet: [data],
+      neuronPromisesMap: new Map<string, Promise<void>>(),
+      selectedIndices: [123],
+    };
+
+    const calls: Array<{
+      options?: Readonly<{ allowGraceAfterTimeout?: boolean }>;
+      trainingDataLen: number;
+      indicesLen: number;
+    }> = [];
+
+    const discoverStructure = {
+      record: (
+        trainingData: DataRecordInterface[],
+        _neuronPromisesMap: Map<string, Promise<void>>,
+        _binaryFilePath?: string,
+        recordIndices?: number[],
+        options?: Readonly<{ allowGraceAfterTimeout?: boolean }>,
+      ) => {
+        calls.push({
+          options,
+          trainingDataLen: trainingData.length,
+          indicesLen: recordIndices?.length ?? 0,
+        });
+        return false;
+      },
+    } as const;
+
+    const recorded = submitDiscoveryRecordBatch(
+      discoverStructure,
+      params,
+      "/tmp/fake.bin",
+      { allowGraceAfterTimeout: true },
+    );
+
+    assertEquals(recorded, false);
+
+    // Critical regression assertion: buffers must not be cleared when record() is
+    // rejected (eg. due to a timeout race).
+    assertEquals(params.dataSet.length, 1);
+    assertEquals(params.selectedIndices.length, 1);
+
+    // Sanity: call shapes are correct.
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0]?.trainingDataLen, 1);
+    assertEquals(calls[0]?.indicesLen, 1);
+    assertEquals(calls[0]?.options?.allowGraceAfterTimeout, true);
+  },
+);
+
+Deno.test("submitDiscoveryRecordBatch: clears buffers when record() returns true", () => {
+  const data: DataRecordInterface = {
+    input: new Float32Array([1]),
+    output: new Float32Array([2]),
+  };
+
+  const params = {
+    dataSet: [data],
+    neuronPromisesMap: new Map<string, Promise<void>>(),
+    selectedIndices: [123],
+  };
+
+  const discoverStructure = {
+    record: () => true,
+  } as const;
+
+  const recorded = submitDiscoveryRecordBatch(
+    discoverStructure,
+    params,
+    "/tmp/fake.bin",
+    { allowGraceAfterTimeout: true },
+  );
+
+  assertEquals(recorded, true);
+  assertEquals(params.dataSet.length, 0);
+  assertEquals(params.selectedIndices.length, 0);
+});

--- a/test/Upgrade/UpgradeRepairsForwardOnlyCorruption.ts
+++ b/test/Upgrade/UpgradeRepairsForwardOnlyCorruption.ts
@@ -1,0 +1,38 @@
+import { assert } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { Synapse } from "../../src/architecture/Synapse.ts";
+import { upgrade } from "../../src/upgrade/Upgrade.ts";
+
+Deno.test("upgrade(): repairs corrupted 4.x forward-only creature with back connection", () => {
+  // Arrange: create a valid forward-only creature, then inject an invalid back connection.
+  const creature = new Creature(2, 1, { layers: [{ count: 1 }] });
+  creature.semanticVersion = "4.0.0";
+  creature.forwardOnly = true;
+
+  const hiddenIndex = creature.input; // first hidden neuron index
+  const outputIndex = creature.neurons.length - 1; // only output neuron
+  assert(outputIndex > hiddenIndex);
+
+  // Inject a back connection (output -> hidden), which is illegal for forward-only.
+  creature.synapses.push(new Synapse(outputIndex, hiddenIndex, 0.123));
+  creature.synapses.sort((
+    a,
+    b,
+  ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+  // Act: upgrading should not throw; it should repair the structure so it validates forward-only again.
+  const upgraded = upgrade(creature);
+
+  // Assert: the upgraded creature is forward-only valid and contains no back/self connections.
+  upgraded.validate({ forwardOnly: true });
+  for (const s of upgraded.synapses) {
+    assert(
+      s.from !== s.to,
+      "upgrade() should remove self-connections in forward-only mode",
+    );
+    assert(
+      s.from < s.to,
+      "upgrade() should remove back-connections in forward-only mode",
+    );
+  }
+});

--- a/test/Upgrade/VersionFourInvariant.ts
+++ b/test/Upgrade/VersionFourInvariant.ts
@@ -1,4 +1,4 @@
-import { assertThrows } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { Creature } from "../../mod.ts";
 import { upgrade } from "../../src/upgrade/Upgrade.ts";
 
@@ -10,7 +10,7 @@ import { upgrade } from "../../src/upgrade/Upgrade.ts";
  * still contains recurrent connections (self-loops / feedback connections).
  */
 Deno.test(
-  "upgrade throws for 4.x creatures with recurrent connections even when forwardOnly is unset",
+  "upgrade repairs 4.x creatures with recurrent connections even when forwardOnly is unset",
   () => {
     const creature = new Creature(2, 1, {
       layers: [{ count: 2 }],
@@ -21,6 +21,13 @@ Deno.test(
     const hiddenNeuron = creature.neurons[creature.input]; // First hidden neuron
     creature.connect(hiddenNeuron.index, hiddenNeuron.index, 0.5); // self-loop (recurrent)
 
-    assertThrows(() => upgrade(creature));
+    const upgraded = upgrade(creature);
+    assertEquals(upgraded.semanticVersion, "4.0.0");
+    upgraded.validate({ forwardOnly: true });
+    assertEquals(
+      upgraded.getSynapse(hiddenNeuron.index, hiddenNeuron.index),
+      null,
+      "upgrade() should remove self loops when semanticVersion is 4.x",
+    );
   },
 );

--- a/test/Upgrade/VersionThree.ts
+++ b/test/Upgrade/VersionThree.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { Creature } from "../../mod.ts";
 import { SEMANTIC_MAJOR_VERSION, upgrade } from "../../src/upgrade/Upgrade.ts";
 
@@ -185,7 +185,7 @@ Deno.test("upgrade should validate and not modify valid 4.x creatures", () => {
   );
 });
 
-Deno.test("upgrade should throw for forward-only 4.x creatures with recurrent connections", () => {
+Deno.test("upgrade should repair forward-only 4.x creatures with recurrent connections", () => {
   const creature = new Creature(2, 1, {
     layers: [{ count: 2 }],
     semanticVersion: "4.0.0",
@@ -195,7 +195,13 @@ Deno.test("upgrade should throw for forward-only 4.x creatures with recurrent co
   const hiddenNeuron = creature.neurons[creature.input]; // First hidden neuron
   creature.connect(hiddenNeuron.index, hiddenNeuron.index, 0.5);
 
-  assertThrows(() => upgrade(creature));
+  const upgraded = upgrade(creature);
+  upgraded.validate({ forwardOnly: true });
+  assertEquals(
+    upgraded.getSynapse(hiddenNeuron.index, hiddenNeuron.index),
+    null,
+    "upgrade() should remove recurrent self loops for forward-only 4.x creatures",
+  );
 });
 
 Deno.test("upgrade should validate and not modify future 10.x creatures", () => {

--- a/test/mutate/MutatorDoesNotCorruptForwardOnlyFourX.ts
+++ b/test/mutate/MutatorDoesNotCorruptForwardOnlyFourX.ts
@@ -1,15 +1,16 @@
-import { assert } from "@std/assert";
 import { Creature, Mutation } from "../../mod.ts";
 import { createNeatConfig } from "../../src/config/NeatConfig.ts";
 import { Mutator } from "../../src/NEAT/Mutator.ts";
+import { assertThrows } from "@std/assert";
 
-Deno.test("Mutator: feedbackLoop=true must not corrupt semanticVersion 4.x forward-only creatures", () => {
+Deno.test("Mutator: selectMutationMethod must not infinite-loop when only disallowed mutations are configured", () => {
   // Arrange: a forward-only 4.x creature.
   const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
   creature.semanticVersion = "4.0.0";
   creature.forwardOnly = true;
 
   // Configure mutator to only try adding back connections.
+  // This is disallowed for forward-only creatures; selection must fail fast.
   const mutator = new Mutator(
     createNeatConfig({
       feedbackLoop: true,
@@ -20,11 +21,6 @@ Deno.test("Mutator: feedbackLoop=true must not corrupt semanticVersion 4.x forwa
     }),
   );
 
-  // Act: attempt mutation.
-  mutator.mutate([creature]);
-
-  // Assert: still forward-only valid after mutation attempt.
-  creature.validate({ forwardOnly: true });
+  // Act/Assert: selection should throw (not hang).
+  assertThrows(() => mutator.selectMutationMethod(creature));
 });
-
-

--- a/test/mutate/MutatorDoesNotCorruptForwardOnlyFourX.ts
+++ b/test/mutate/MutatorDoesNotCorruptForwardOnlyFourX.ts
@@ -1,0 +1,30 @@
+import { assert } from "@std/assert";
+import { Creature, Mutation } from "../../mod.ts";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+
+Deno.test("Mutator: feedbackLoop=true must not corrupt semanticVersion 4.x forward-only creatures", () => {
+  // Arrange: a forward-only 4.x creature.
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.semanticVersion = "4.0.0";
+  creature.forwardOnly = true;
+
+  // Configure mutator to only try adding back connections.
+  const mutator = new Mutator(
+    createNeatConfig({
+      feedbackLoop: true,
+      // Keep it deterministic: only one mutation method in the list.
+      mutationRate: 1,
+      mutationAmount: 1,
+      mutation: [Mutation.ADD_BACK_CONN],
+    }),
+  );
+
+  // Act: attempt mutation.
+  mutator.mutate([creature]);
+
+  // Assert: still forward-only valid after mutation attempt.
+  creature.validate({ forwardOnly: true });
+});
+
+

--- a/test/propagate/biasIdentity/Simple.ts
+++ b/test/propagate/biasIdentity/Simple.ts
@@ -37,6 +37,10 @@ Deno.test("Simple", () => {
   let lastError = calculateError(modifiedCreature, td);
 
   for (let i = 0; i < 10; i++) {
+    // Defensive: ensure the output directory exists even under parallel test runs
+    // where other tests may clean up sibling `.test/propagate/*` directories.
+    Deno.mkdirSync(directory, { recursive: true });
+
     Deno.writeTextFileSync(
       `${directory}/C${i}--start.json`,
       JSON.stringify(modifiedCreature.exportJSON(), null, 1),
@@ -54,6 +58,7 @@ Deno.test("Simple", () => {
     modifiedCreature.validate();
     Creature.fromJSON(results.trace).validate();
 
+    Deno.mkdirSync(directory, { recursive: true });
     Deno.writeTextFileSync(
       `${directory}/C${i}--trace.json`,
       JSON.stringify(results.trace, null, 1),

--- a/test/propagate/record/RangeLimitedAttributionAvoidsImpossibleTargets.ts
+++ b/test/propagate/record/RangeLimitedAttributionAvoidsImpossibleTargets.ts
@@ -1,0 +1,79 @@
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { ABSOLUTE } from "../../../src/methods/activations/types/ABSOLUTE.ts";
+import { IDENTITY } from "../../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test(
+  "Creature.record: record attribution avoids impossible negative targets for non-negative squashes (ABSOLUTE)",
+  () => {
+    // Regression test for issue #950 (24-Dec-2025):
+    // Record-time error attribution used to request negative target activations
+    // from a non-negative squash (ABSOLUTE) when it had a large activation, even
+    // if an alternative inbound synapse could carry the error instead.
+
+    const creatureJSON: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          uuid: "abs-hidden",
+          type: "hidden",
+          squash: ABSOLUTE.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "id-hidden",
+          type: "hidden",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "output-0",
+          type: "output",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        // Make ABSOLUTE activation large (10) so naive elasticity strongly
+        // prefers pushing error through it.
+        { fromUUID: "input-0", toUUID: "abs-hidden", weight: 10 },
+        { fromUUID: "input-0", toUUID: "id-hidden", weight: 1 },
+
+        // But keep the ABSOLUTE -> output weight small so a value-space share
+        // implies a large (and potentially negative) requested activation.
+        { fromUUID: "abs-hidden", toUUID: "output-0", weight: 0.1 },
+        { fromUUID: "id-hidden", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJSON);
+
+    creature.activate(new Float32Array([1]));
+
+    // Current output is ~2. Request 0 so record-time error is negative.
+    const expected = new Float32Array([0]);
+    const map = creature.record(expected);
+
+    const absRec = map.get("abs-hidden");
+    assert(absRec, "expected a discovery record for abs-hidden");
+
+    const idRec = map.get("id-hidden");
+    assert(idRec, "expected a discovery record for id-hidden");
+
+    // Key assertion: we should avoid requesting impossible negative targets for
+    // ABSOLUTE, so it should not receive a recursive record() call.
+    assertEquals(
+      absRec.errors.length,
+      0,
+      "ABSOLUTE parent should not be asked to absorb negative record targets when an alternative exists",
+    );
+
+    // And we should still attribute the error somewhere upstream.
+    assert(
+      idRec.errors.length > 0,
+      "expected the feasible parent to receive record error attribution",
+    );
+  },
+);

--- a/test/propagate/record/RangeLimitedAttributionAvoidsImpossibleTargetsReLU.ts
+++ b/test/propagate/record/RangeLimitedAttributionAvoidsImpossibleTargetsReLU.ts
@@ -1,0 +1,145 @@
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { IDENTITY } from "../../../src/methods/activations/types/IDENTITY.ts";
+import { ReLU } from "../../../src/methods/activations/types/ReLU.ts";
+import { ReLU6 } from "../../../src/methods/activations/types/ReLU6.ts";
+
+Deno.test(
+  "Creature.record: record attribution avoids impossible negative targets for ReLU",
+  () => {
+    // Regression test for issue #950 (24-Dec-2025):
+    // ReLU output range is [0, +∞), so negative record targets are impossible.
+    // Record-time attribution must avoid routing negative value-space shares
+    // through ReLU parents when a feasible alternative exists.
+
+    const creatureJSON: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          uuid: "relu-hidden",
+          type: "hidden",
+          squash: ReLU.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "id-hidden",
+          type: "hidden",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "output-0",
+          type: "output",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        // Make ReLU activation large (10) so naive elasticity strongly prefers it.
+        { fromUUID: "input-0", toUUID: "relu-hidden", weight: 10 },
+        { fromUUID: "input-0", toUUID: "id-hidden", weight: 1 },
+
+        // But keep the ReLU -> output weight small so its value-space share can
+        // imply a large (and potentially negative) requested activation.
+        { fromUUID: "relu-hidden", toUUID: "output-0", weight: 0.1 },
+        { fromUUID: "id-hidden", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJSON);
+
+    creature.activate(new Float32Array([1]));
+
+    // Current output is ~2. Request 0 so record-time error is negative.
+    const expected = new Float32Array([0]);
+    const map = creature.record(expected);
+
+    const reluRec = map.get("relu-hidden");
+    assert(reluRec, "expected a discovery record for relu-hidden");
+
+    const idRec = map.get("id-hidden");
+    assert(idRec, "expected a discovery record for id-hidden");
+
+    // Key assertion: we should not request negative targets from ReLU, so it
+    // should not receive a recursive record() call.
+    assertEquals(
+      reluRec.errors.length,
+      0,
+      "ReLU parent should not be asked to absorb negative record targets when an alternative exists",
+    );
+
+    // And we should still attribute the error somewhere upstream.
+    assert(
+      idRec.errors.length > 0,
+      "expected the feasible parent to receive record error attribution",
+    );
+  },
+);
+
+Deno.test(
+  "Creature.record: record attribution avoids impossible negative targets for ReLU6",
+  () => {
+    // ReLU6 output range is [0, 6], so negative record targets are impossible.
+    // This test ensures range feasibility is enforced during record attribution.
+
+    const creatureJSON: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          uuid: "relu6-hidden",
+          type: "hidden",
+          squash: ReLU6.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "id-hidden",
+          type: "hidden",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "output-0",
+          type: "output",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        // Saturate ReLU6 to 6 so naive elasticity strongly prefers it.
+        { fromUUID: "input-0", toUUID: "relu6-hidden", weight: 10 },
+        { fromUUID: "input-0", toUUID: "id-hidden", weight: 1 },
+
+        // Keep the capped path's weight small to force negative implied targets.
+        { fromUUID: "relu6-hidden", toUUID: "output-0", weight: 0.1 },
+        { fromUUID: "id-hidden", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJSON);
+
+    creature.activate(new Float32Array([1]));
+
+    const expected = new Float32Array([0]);
+    const map = creature.record(expected);
+
+    const relu6Rec = map.get("relu6-hidden");
+    assert(relu6Rec, "expected a discovery record for relu6-hidden");
+
+    const idRec = map.get("id-hidden");
+    assert(idRec, "expected a discovery record for id-hidden");
+
+    assertEquals(
+      relu6Rec.errors.length,
+      0,
+      "ReLU6 parent should not be asked to absorb negative record targets when an alternative exists",
+    );
+
+    assert(
+      idRec.errors.length > 0,
+      "expected the feasible parent to receive record error attribution",
+    );
+  },
+);

--- a/test/propagate/record/RedistributedBlockedErrorMaintainsFeasibility.ts
+++ b/test/propagate/record/RedistributedBlockedErrorMaintainsFeasibility.ts
@@ -1,0 +1,97 @@
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { ABSOLUTE } from "../../../src/methods/activations/types/ABSOLUTE.ts";
+import { IDENTITY } from "../../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test(
+  "Creature.record: redistributed blocked error must not make a previously-feasible parent target infeasible (ABSOLUTE)",
+  () => {
+    // Regression test for issue #950 follow-up (24-Dec-2025):
+    //
+    // We filter out infeasible upstream targets and then redistribute the blocked
+    // value-space share across remaining links. The redistribution must *also*
+    // preserve feasibility.
+    //
+    // Without a second feasibility pass (or an iterative redistribution loop),
+    // an initially-feasible ABSOLUTE parent can receive extra negative share and
+    // end up with a negative requested activation, which then gets silently
+    // clamped inside `Neuron.record()` and pollutes discovery metrics.
+
+    const creatureJSON: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          uuid: "abs-victim",
+          type: "hidden",
+          squash: ABSOLUTE.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "abs-blocker",
+          type: "hidden",
+          squash: ABSOLUTE.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "id-alt",
+          type: "hidden",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "output-0",
+          type: "output",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        // Drive the ABSOLUTE activations to deterministic values.
+        // input=1 => abs-victim ~= 0.5, abs-blocker ~= 3, id-alt ~= 0.001
+        { fromUUID: "input-0", toUUID: "abs-victim", weight: 0.5 },
+        { fromUUID: "input-0", toUUID: "abs-blocker", weight: 3 },
+        { fromUUID: "input-0", toUUID: "id-alt", weight: 0.001 },
+
+        // Output aggregation:
+        // - abs-blocker has huge activation so elastic distribution allocates
+        //   most negative error to it, but the small-ish weight makes its implied
+        //   requested activation go negative (infeasible for ABSOLUTE).
+        // - abs-victim is initially feasible, but can become infeasible after it
+        //   receives the redistributed blocked error share.
+        { fromUUID: "abs-victim", toUUID: "output-0", weight: 1 },
+        { fromUUID: "abs-blocker", toUUID: "output-0", weight: 0.2 },
+        { fromUUID: "id-alt", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJSON);
+
+    creature.activate(new Float32Array([1]));
+
+    // Current output is ~1.101. Request 0 so record-time error is negative.
+    const expected = new Float32Array([0]);
+    const map = creature.record(expected);
+
+    const victimRec = map.get("abs-victim");
+    assert(victimRec, "expected a discovery record for abs-victim");
+
+    const altRec = map.get("id-alt");
+    assert(altRec, "expected a discovery record for id-alt");
+
+    // Key assertion: abs-victim starts feasible, but must not receive a record()
+    // recursion with a negative requested activation after redistribution.
+    assertEquals(
+      victimRec.errors.length,
+      0,
+      "redistribution must not push a feasible ABSOLUTE parent into an infeasible negative target",
+    );
+
+    // The error should still be attributed somewhere upstream.
+    assert(
+      altRec.errors.length > 0,
+      "expected the feasible alternative parent to receive record error attribution",
+    );
+  },
+);


### PR DESCRIPTION
- Bumped version in deno.json to 0.271.0.
- Introduced a feasibility factor in the Neuron class to prevent requesting impossible target activations, improving error distribution during recording.
- Enhanced the DataRecorder class to ensure partial batches are flushed before timeouts, optimizing data persistence under tight deadlines.
- Updated the RecordElasticity module to incorporate feasibility checks for upstream target activations, refining error handling during backpropagation.

These changes improve the robustness and accuracy of the NEAT framework's neuron recording and error management processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens robustness and correctness across discovery, mutation, recording, and upgrades.
> 
> - **Discovery recording resiliency**: pre-timeout partial-batch flushing, single grace read/submit after deadline, and non-destructive batch submission via `SubmitDiscoveryRecordBatch` to avoid data loss; optional final Rust chunk flush; isolated discovery base dir in tests.
> - **Feasibility-aware attribution**: introduce `recordTargetFeasibilityFactor` and propagate `feasibilityFactor` in `RecordElasticity`, `Neuron.record()`, and `IF` to avoid requesting impossible/undesired upstream targets (e.g., `ABSOLUTE`, `ReLU/ReLU6`); iterative redistribution maintains feasibility.
> - **Forward-only invariants**: `Mutator.selectMutationMethod` pre-filters illegal mutations (no self/back edges for 4.x), caps selection attempts, and preserves 4.x forward-only; `Upgrade` now validates, auto-repairs forward-only violations, and only downgrades as last resort.
> - **Timeout semantics**: `DiscoverStructure.record()` optionally accepts a small grace batch post-timeout to prevent empty artefacts; indices handling updated accordingly.
> - **Tests**: add coverage for batch submission, discovery analysis time-bounding, feasibility filters, redistribution stability, mutator selection failure on disallowed ops, and upgrade repair behavior.
> - **Meta**: bump version to `0.271.0` and update std deps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c75e51a1847e5db919c01cededd0c9edacecd3f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->