### PR TITLE
Update version to 0.272.0 and enhance forward-only validation logic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,16 +1,16 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.271.0",
+  "version": "0.272.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",
     "@std/crypto": "jsr:@std/crypto@1.0.5",
     "@std/csv": "jsr:@std/csv@1.0.6",
     "@std/fmt": "jsr:@std/fmt@1.0.8",
-    "@std/fs": "jsr:@std/fs@1.0.20",
+    "@std/fs": "jsr:@std/fs@1.0.21",
     "@std/path": "jsr:@std/path@1.1.4",
-    "@std/streams": "jsr:@std/streams@1.0.14",
+    "@std/streams": "jsr:@std/streams@1.0.16",
     "@std/uuid": "jsr:@std/uuid@1.1.0",
     "@std/testing/mock": "jsr:@std/testing@1.0.16/mock",
     "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13"

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -334,12 +334,15 @@ export class Mutator {
                 `Violations(sample up to 10): ${violations.join(" | ")}`,
             );
 
-            // Forward-only 4.x is a hard guarantee: never repair by mutation.
+            // Forward-only 4.x is a hard guarantee. We must crash fast (even on
+            // unattended machines) so we can locate the logic that introduced a
+            // recurrent connection into a supposedly forward-only creature.
             if (creature.forwardOnly === true && major >= 4) {
               throw new Error(
                 `[Mutator] CRITICAL: forward-only 4.x creature became invalid after '${method.name}': ` +
                   `${error.name} - ${error.message}. ` +
-                  `This indicates a corruption bug (recurrent connections must never be introduced).`,
+                  `This indicates a corruption bug (recurrent connections must never be introduced). ` +
+                  `Violations(sample up to 10): ${violations.join(" | ")}`,
               );
             }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -607,7 +607,16 @@ class DataRecorder {
               filePath,
               { allowGraceAfterTimeout: true },
             );
-            if (!recorded) break;
+            if (!recorded) {
+              // 25-Dec-2025: When the recorder declines a batch (typically
+              // because the record timeout has expired), we are about to abort
+              // recording altogether. Clear the local buffers so the
+              // post-processing invariants hold (and we don't assert/crash on
+              // intentionally partial recording).
+              dataSet.length = 0;
+              selectedIndices.length = 0;
+              break;
+            }
             assert(dataSet.length === 0, "Data set not empty after flush");
             assert(
               selectedIndices.length === 0,

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -344,6 +344,14 @@ export class Neuron implements TagsInterface, NeuronInternal {
       return true;
     }
 
+    // Forward-only safety: never create a self-loop as a "last resort" outward
+    // connection when the creature is explicitly marked as forward-only.
+    //
+    // Rationale (Australian English): self-loops are valid in recurrent/memory
+    // mode, but they must not be introduced during `fix()` for forward-only
+    // creatures.
+    const isForwardOnly = this.creature.forwardOnly === true;
+
     const candidates: number[] = [];
     const nodeCount = this.creature.nodeCount();
 
@@ -359,6 +367,7 @@ export class Neuron implements TagsInterface, NeuronInternal {
 
     if (
       allowSelfTargets &&
+      isForwardOnly === false &&
       !this.creature.getSynapse(this.index, this.index)
     ) {
       candidates.push(this.index);

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -5,6 +5,7 @@ import { editParentByIndex } from "../breed/EditParentByIndex.ts";
 import { geneticCompatibility } from "../breed/GeneticCompatibility.ts";
 import { Creature } from "../Creature.ts";
 import { upgrade } from "../upgrade/Upgrade.ts";
+import { writeDiagnostics } from "../utils/Diagnostics.ts";
 import { CreatureUtil } from "./CreatureUtils.ts";
 import { creatureValidate } from "./CreatureValidate.ts";
 import { Neuron } from "./Neuron.ts";
@@ -416,19 +417,13 @@ export class Offspring {
         default:
           console.error(e);
           offspring.DEBUG = false;
-          Deno.writeTextFileSync(
-            ".offspring-mother.json",
-            JSON.stringify(mother.exportJSON(), null, 1),
-          );
-          Deno.writeTextFileSync(
-            ".offspring-offspring.json",
-            JSON.stringify(offspring.exportJSON(), null, 1),
-          );
-          Deno.writeTextFileSync(
-            ".offspring-father.json",
-            JSON.stringify(father.exportJSON(), null, 1),
-          );
-
+          writeDiagnostics({
+            error,
+            prefix: "offspring",
+            mother: mother.exportJSON(),
+            father: father.exportJSON(),
+            offspring: offspring.exportJSON(),
+          });
           throw e;
       }
     }

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -7,6 +7,7 @@ import type { NeuronExport } from "../architecture/NeuronInterfaces.ts";
 import type { SynapseExport } from "../architecture/SynapseInterfaces.ts";
 import { IDENTITY } from "../methods/activations/types/IDENTITY.ts";
 import { LOGISTIC } from "../methods/activations/types/LOGISTIC.ts";
+import { cleanupOrphanedNeurons } from "./CompactUtils.ts";
 
 /**
  * Compacts a creature by removing redundant neurons and connections.
@@ -159,38 +160,42 @@ export function compactCreature(
     }
   }
 
-  /** clean up dangling neurons */
-  let danglesFound: boolean;
-  do {
-    danglesFound = false;
-    for (const neuron of compactCreature.neurons) {
-      if (neuron.type === "hidden" || neuron.type === "constant") {
-        const outConns = outwardConnections.get(neuron.uuid) || [];
-        if (outConns.length === 0) {
-          compactCreature.neurons = compactCreature.neurons.filter((n) =>
-            n.uuid !== neuron.uuid
-          );
-          neuronMap.delete(neuron.uuid);
-          compactCreature.synapses = compactCreature.synapses.filter((s) =>
-            s.toUUID !== neuron.uuid
-          );
-          didCompact = true;
-          break;
-        }
-      }
-    }
-  } while (danglesFound);
+  /**
+   * Clean up orphaned neurons using the robust iterative utility.
+   *
+   * This replaces a previous buggy loop that failed to:
+   * - Set `danglesFound = true` when removing neurons (so iteration never continued)
+   * - Rebuild the outwardConnections map after backward-synapse removal
+   *
+   * See https://github.com/stSoftwareAU/NEAT-AI/issues/956
+   */
+  const orphanResult = cleanupOrphanedNeurons(compactCreature);
+  if (orphanResult.removed > 0 || orphanResult.converted > 0) {
+    didCompact = true;
+  }
 
   if (didCompact) {
     addTag(compactCreature, "approach", "compact" as Approach);
     delete compactCreature.memetic;
     removeTag(compactCreature, "approach-logged");
 
-    const oldNeurons = compactCreature.neurons.length -
-      compactCreature.input - compactCreature.output;
+    const oldNeurons = startExport.neurons.length -
+      startExport.input - startExport.output;
     addTag(compactCreature, "old-neurons", oldNeurons.toString());
 
+    // Preserve forwardOnly semantics from source creature
+    if (creature.forwardOnly === true) {
+      compactCreature.forwardOnly = true;
+    }
+
     const c = Creature.fromJSON(compactCreature);
+
+    // Validate the compacted creature to catch any structural issues early.
+    // A 4.x forward-only creature must remain valid; any failure here is a bug.
+    c.validate();
+    if (!feedbackLoop && creature.forwardOnly === true) {
+      c.validate({ forwardOnly: true });
+    }
 
     return c;
   }

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -5,6 +5,7 @@ import { trainDir } from "../../architecture/Training.ts";
 import { Costs } from "../../Costs.ts";
 import type { CostInterface } from "../../costs/CostInterface.ts";
 import { Creature } from "../../Creature.ts";
+import { writeDiagnostics } from "../../utils/Diagnostics.ts";
 import type { RequestData, ResponseData } from "./WorkerHandler.ts";
 
 export class WorkerProcessor {
@@ -99,19 +100,12 @@ export class WorkerProcessor {
         };
       } catch (error) {
         console.error(error);
-        Deno.mkdirSync(".diagnostics", { recursive: true });
-        Deno.writeTextFileSync(
-          `.diagnostics/error.txt`,
-          `error: ${error}`,
-        );
-        Deno.writeTextFileSync(
-          `.diagnostics/creature.txt`,
-          data.evaluate.creature,
-        );
-        Deno.writeTextFileSync(
-          `.diagnostics/data.json`,
-          JSON.stringify(data, null, 2),
-        );
+        writeDiagnostics({
+          error,
+          prefix: "evaluate",
+          creature: data.evaluate.creature,
+          context: { taskID: data.taskID, data },
+        });
         throw error;
       } finally {
         // Ensure creature is disposed even if an error occurs

--- a/src/mutate/AddConnection.ts
+++ b/src/mutate/AddConnection.ts
@@ -1,3 +1,4 @@
+import { assert } from "@std/assert";
 import type { ConnectionOptions } from "../ConnectionOptions.ts";
 import type { Creature } from "../Creature.ts";
 import type { Neuron } from "../architecture/Neuron.ts";
@@ -20,8 +21,30 @@ export class AddConnection implements RadioactiveInterface {
   public mutate(focusList?: number[], options: ConnectionOptions = {
     weightScale: 1,
   }): boolean {
-    // Create an array of all uncreated (feedforward) connections
-    const available: [Neuron, Neuron][] = [];
+    // Create an array of all uncreated connections.
+    //
+    // When the creature is explicitly marked as forward-only, we must only
+    // consider forward-only (feed-forward) index pairs. This must not rely on
+    // semantic versions.
+    const available: [number, number, Neuron, Neuron][] = [];
+    const enforceForwardOnly = this.creature.forwardOnly === true;
+
+    if (enforceForwardOnly) {
+      // Forward-only invariant: neuron indices must be consistent.
+      //
+      // Rationale (Australian English): if `neuron.index` does not match its
+      // position in the `creature.neurons[]` array, the creature is corrupted.
+      // In forward-only mode we must fail fast rather than attempting to
+      // continue in a partially-valid state.
+      for (let i = 0; i < this.creature.neurons.length; i++) {
+        if (this.creature.neurons[i].index !== i) {
+          throw new Error(
+            `[AddConnection] Corrupt creature: neuron.index mismatch at neurons[${i}] ` +
+              `(neuron.index=${this.creature.neurons[i].index}).`,
+          );
+        }
+      }
+    }
 
     for (
       let fromIndx = 0;
@@ -42,7 +65,10 @@ export class AddConnection implements RadioactiveInterface {
         if (neuronTo.type === "constant") continue;
 
         if (!neuronFrom.isProjectingTo(neuronTo)) {
-          available.push([neuronFrom, neuronTo]);
+          // `fromIndx`/`toIndx` are the canonical neuron indices. Do not use
+          // `neuron.index` here - it can be corrupted in bad exports and would
+          // allow accidental backward connections.
+          available.push([fromIndx, toIndx, neuronFrom, neuronTo]);
         }
       }
     }
@@ -52,12 +78,26 @@ export class AddConnection implements RadioactiveInterface {
     }
 
     const pair = available[Math.floor(Math.random() * available.length)];
-    const fromIndex = pair[0].index;
-    const toIndex = pair[1].index;
+    const fromIndex = pair[0];
+    const toIndex = pair[1];
+
+    if (enforceForwardOnly) {
+      // Defensive guard: forward-only creatures must never gain recurrent
+      // connections.
+      assert(
+        fromIndex < toIndex,
+        `[AddConnection] Forward-only violation: attempted to connect ${fromIndex} -> ${toIndex}`,
+      );
+    }
 
     const weight = Synapse.randomWeight(options.weightScale);
 
     this.creature.connect(fromIndex, toIndex, weight);
+    if (enforceForwardOnly) {
+      // Validation is useful, but if it fails we should crash fast rather than
+      // trying to limp on (this typically runs unattended).
+      this.creature.validate({ forwardOnly: true });
+    }
     delete this.creature.memetic;
     return true;
   }

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -1,5 +1,6 @@
 import { Creature } from "../Creature.ts";
 import { creatureValidate } from "../architecture/CreatureValidate.ts";
+import { writeDiagnostics } from "../utils/Diagnostics.ts";
 import { upgradeTwo } from "./UpgradeTwo.ts";
 
 /**
@@ -53,6 +54,12 @@ function validateThreeX(creature: Creature): void {
  *
  * For 4.x, forward-only is a hard invariant: any recurrent connection is an error,
  * regardless of whether the `forwardOnly` flag is set.
+ *
+ * If validation fails, this is a BUG in our breeding/mutation/discovery logic
+ * that must be fixed at the source. We do NOT silently repair or downgrade 4.x
+ * creatures - we write diagnostics and hard fail so the bug can be identified.
+ *
+ * See https://github.com/stSoftwareAU/NEAT-AI/issues/956
  */
 function validateFourX(creature: Creature): void {
   try {
@@ -62,43 +69,29 @@ function validateFourX(creature: Creature): void {
   } catch (e) {
     const error = e as Error;
 
-    // Production safety net: although 4.x is a hard forward-only invariant, we
-    // occasionally encounter corrupted persisted creatures (e.g. a back-connection
-    // sneaking in). Instead of crashing the entire job, attempt to repair using
-    // `fix({ forwardOnly: true })`.
-    if (
-      error.name === "SELF_CONNECTION" ||
-      error.name === "RECURSIVE_SYNAPSE"
-    ) {
-      console.warn(
-        `[upgrade] Corrupted 4.x creature (UUID: ${
-          creature.uuid ?? "unknown"
-        }) failed forward-only validation: ` +
-          `${error.name} - ${error.message}. Attempting repair via fix({ forwardOnly: true }).`,
-      );
-      try {
-        creature.fix({ forwardOnly: true });
-        creatureValidate(creature, { forwardOnly: true });
-        creature.forwardOnly = true;
-        return;
-      } catch (fixError) {
-        const fixErr = fixError as Error;
-        console.error(
-          `[upgrade] Repair failed for corrupted 4.x creature (UUID: ${
-            creature.uuid ?? "unknown"
-          }). ` +
-            `Downgrading to 2.0.0 to avoid crashing. ` +
-            `Original=${error.name}: ${error.message}. ` +
-            `FixError=${fixErr.name}: ${fixErr.message}`,
-        );
+    // 4.x forward-only is a hard invariant. Any failure here indicates a bug
+    // in our breeding/mutation/discovery logic. We write diagnostics so the
+    // offending creature can be analysed, then rethrow.
+    console.error(
+      `[upgrade] CRITICAL: 4.x creature (UUID: ${
+        creature.uuid ?? "unknown"
+      }) failed forward-only validation: ` +
+        `${error.name} - ${error.message}. ` +
+        `This is a bug in our code that must be fixed (not the creature).`,
+    );
 
-        // Last resort: clear the forward-only guarantee and downgrade the semantic
-        // version so callers won't treat this as a forward-only invariant.
-        creature.forwardOnly = undefined;
-        creature.semanticVersion = "2.0.0";
-        return;
-      }
-    }
+    writeDiagnostics({
+      error,
+      prefix: "upgrade-4x",
+      creature: creature.exportJSON(),
+      context: {
+        semanticVersion: creature.semanticVersion,
+        uuid: creature.uuid,
+        forwardOnly: creature.forwardOnly,
+        neuronCount: creature.neurons.length,
+        synapseCount: creature.synapses.length,
+      },
+    });
 
     throw e;
   }

--- a/src/utils/Diagnostics.ts
+++ b/src/utils/Diagnostics.ts
@@ -1,0 +1,105 @@
+import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
+
+const DIAGNOSTICS_DIR = ".diagnostics";
+
+/**
+ * Options for writing diagnostic files when an error occurs.
+ */
+export interface DiagnosticsOptions {
+  /** The error that occurred. */
+  error: Error | unknown;
+  /** Optional prefix for file names (e.g., "breed", "upgrade"). */
+  prefix?: string;
+  /** Primary creature export (optional). */
+  creature?: CreatureExport | string;
+  /** Mother creature export for breeding errors (optional). */
+  mother?: CreatureExport;
+  /** Father creature export for breeding errors (optional). */
+  father?: CreatureExport;
+  /** Offspring creature export for breeding errors (optional). */
+  offspring?: CreatureExport;
+  /** Additional context data to include (optional). */
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Writes diagnostic files for debugging errors.
+ *
+ * This utility centralises the pattern of writing error information and
+ * creature state to disk when an invariant is violated. It follows the
+ * DRY principle by providing a single implementation used across the
+ * codebase.
+ *
+ * Files are written to `.diagnostics/` with an optional prefix.
+ *
+ * @param options - The diagnostic options containing error and creature data.
+ */
+export function writeDiagnostics(options: DiagnosticsOptions): void {
+  const {
+    error,
+    prefix,
+    creature,
+    mother,
+    father,
+    offspring,
+    context,
+  } = options;
+
+  try {
+    Deno.mkdirSync(DIAGNOSTICS_DIR, { recursive: true });
+  } catch {
+    // Directory may already exist; ignore errors.
+  }
+
+  const filePrefix = prefix ? `${prefix}-` : "";
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  // Write error text
+  const errorText = error instanceof Error
+    ? `${error.name}: ${error.message}\n\nStack:\n${error.stack ?? "N/A"}`
+    : `Error: ${String(error)}`;
+  Deno.writeTextFileSync(
+    `${DIAGNOSTICS_DIR}/${filePrefix}error-${timestamp}.txt`,
+    errorText,
+  );
+
+  // Write creature JSON(s)
+  if (creature) {
+    const creatureJson = typeof creature === "string"
+      ? creature
+      : JSON.stringify(creature, null, 2);
+    Deno.writeTextFileSync(
+      `${DIAGNOSTICS_DIR}/${filePrefix}creature-${timestamp}.json`,
+      creatureJson,
+    );
+  }
+
+  if (mother) {
+    Deno.writeTextFileSync(
+      `${DIAGNOSTICS_DIR}/${filePrefix}mother-${timestamp}.json`,
+      JSON.stringify(mother, null, 2),
+    );
+  }
+
+  if (father) {
+    Deno.writeTextFileSync(
+      `${DIAGNOSTICS_DIR}/${filePrefix}father-${timestamp}.json`,
+      JSON.stringify(father, null, 2),
+    );
+  }
+
+  if (offspring) {
+    Deno.writeTextFileSync(
+      `${DIAGNOSTICS_DIR}/${filePrefix}offspring-${timestamp}.json`,
+      JSON.stringify(offspring, null, 2),
+    );
+  }
+
+  // Write context if provided
+  if (context) {
+    Deno.writeTextFileSync(
+      `${DIAGNOSTICS_DIR}/${filePrefix}context-${timestamp}.json`,
+      JSON.stringify(context, null, 2),
+    );
+  }
+}

--- a/test/Compact/CleanupOrphanedNeurons.ts
+++ b/test/Compact/CleanupOrphanedNeurons.ts
@@ -1,8 +1,8 @@
 import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
 import { cleanupOrphanedNeurons } from "../../src/compact/CompactUtils.ts";
-import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { LOGISTIC } from "../../src/methods/activations/types/LOGISTIC.ts";
 import { TANH } from "../../src/methods/activations/types/TANH.ts";
 

--- a/test/Compact/CompactCreatureNoOrphans.ts
+++ b/test/Compact/CompactCreatureNoOrphans.ts
@@ -1,0 +1,176 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { compactCreature } from "../../src/compact/CompactCreature.ts";
+import { Synapse } from "../../src/architecture/Synapse.ts";
+import { Neuron } from "../../src/architecture/Neuron.ts";
+
+/**
+ * Regression test for https://github.com/stSoftwareAU/NEAT-AI/issues/956
+ *
+ * The historic failure mode was that `compactCreature()` could leave orphaned
+ * hidden neurons (no outward connections) when removing backward synapses in
+ * non-feedbackLoop mode. This happened because:
+ *
+ * 1. The `outwardConnections` map was not rebuilt after backward-synapse removal.
+ * 2. The `danglesFound` flag was never set to `true`, so the do/while loop
+ *    only ran once and never iterated to find cascade orphans.
+ *
+ * A 4.x forward-only creature MUST remain valid after compaction; any orphaned
+ * neuron is a bug in our code.
+ */
+Deno.test("compactCreature: removes orphaned neurons when backward synapses are stripped (issue #956)", () => {
+  // Arrange: Build a creature where removing a backward synapse orphans a neuron.
+  //
+  // Structure (before compaction):
+  //   input-0 ──▶ hidden-A ──▶ hidden-B ──▶ output-0
+  //                   ▲            │
+  //                   └────────────┘ (backward synapse, from > to)
+  //
+  // When feedbackLoop=false, the backward synapse hidden-B -> hidden-A is removed.
+  // hidden-B still has the forward connection to output-0, so it's NOT orphaned.
+  // This tests that compaction handles backward removal correctly without
+  // corrupting valid neurons.
+
+  const creature = new Creature(1, 1, { lazyInitialization: true });
+  creature.semanticVersion = "4.0.0";
+  creature.forwardOnly = true;
+
+  // Manually build neurons in correct order: input, hidden-A, hidden-B, output
+  // Input neuron (index 0)
+  const inputNeuron = new Neuron("input-0", "input", 0, creature);
+  inputNeuron.index = 0;
+
+  // hidden-A (index 1)
+  const hiddenA = new Neuron("hidden-A", "hidden", 0.1, creature, "IDENTITY");
+  hiddenA.index = 1;
+
+  // hidden-B (index 2)
+  const hiddenB = new Neuron("hidden-B", "hidden", 0.2, creature, "IDENTITY");
+  hiddenB.index = 2;
+
+  // Output neuron (index 3)
+  const outputNeuron = new Neuron(
+    "output-0",
+    "output",
+    0,
+    creature,
+    "IDENTITY",
+  );
+  outputNeuron.index = 3;
+
+  creature.neurons = [inputNeuron, hiddenA, hiddenB, outputNeuron];
+
+  // Synapses:
+  // input-0 -> hidden-A (forward)
+  // hidden-A -> hidden-B (forward)
+  // hidden-B -> output-0 (forward)
+  // hidden-B -> hidden-A (BACKWARD, index 2 -> 1) - this will be stripped
+  creature.synapses = [
+    new Synapse(0, 1, 1.0), // input-0 -> hidden-A
+    new Synapse(1, 2, 0.5), // hidden-A -> hidden-B
+    new Synapse(2, 1, 0.3), // hidden-B -> hidden-A (backward!)
+    new Synapse(2, 3, 1.0), // hidden-B -> output-0
+  ];
+  creature.synapses.sort((a, b) =>
+    a.from === b.from ? a.to - b.to : a.from - b.from
+  );
+
+  // Sanity check: creature is currently invalid for forward-only due to backward synapse
+  let caughtError = false;
+  try {
+    creature.validate({ forwardOnly: true });
+  } catch {
+    caughtError = true;
+  }
+  assert(
+    caughtError,
+    "Creature should fail forward-only validation before compaction",
+  );
+
+  // Act: Compact with feedbackLoop=false (strips backward synapses)
+  const compacted = compactCreature(creature, false);
+
+  // Assert: compaction should have occurred (backward synapse removed)
+  assert(compacted !== undefined, "Compaction should have occurred");
+
+  // The compacted creature MUST be valid (no orphaned neurons)
+  compacted.validate(); // General validation
+  compacted.validate({ forwardOnly: true }); // Forward-only validation
+
+  // hidden-B should still exist (it has a valid outward connection to output)
+  const hasHiddenB = compacted.neurons.some((n) => n.uuid === "hidden-B");
+  assertEquals(
+    hasHiddenB,
+    true,
+    "hidden-B should remain (has outward to output)",
+  );
+
+  // Verify forward-only semantics preserved
+  assertEquals(compacted.forwardOnly, true, "forwardOnly should be preserved");
+});
+
+Deno.test("compactCreature: cascade removal of multiple orphaned neurons", () => {
+  // Arrange: Build a chain where removing one synapse orphans multiple neurons.
+  //
+  // Structure:
+  //   input-0 ──▶ hidden-A ──▶ output-0
+  //                   │
+  //                   └──▶ hidden-B ──▶ hidden-C (backward to hidden-A)
+  //
+  // When the backward synapse hidden-C -> hidden-A is removed:
+  // - hidden-C has no outward connections -> orphaned
+  // - Removing hidden-C orphans hidden-B (its only outward was to hidden-C)
+
+  const creature = new Creature(1, 1, { lazyInitialization: true });
+  creature.semanticVersion = "4.0.0";
+  creature.forwardOnly = true;
+
+  // Neurons in order: input, hidden-A, hidden-B, hidden-C, output
+  const inputNeuron = new Neuron("input-0", "input", 0, creature);
+  inputNeuron.index = 0;
+
+  const hiddenA = new Neuron("hidden-A", "hidden", 0.1, creature, "IDENTITY");
+  hiddenA.index = 1;
+
+  const hiddenB = new Neuron("hidden-B", "hidden", 0.2, creature, "IDENTITY");
+  hiddenB.index = 2;
+
+  const hiddenC = new Neuron("hidden-C", "hidden", 0.3, creature, "IDENTITY");
+  hiddenC.index = 3;
+
+  const outputNeuron = new Neuron(
+    "output-0",
+    "output",
+    0,
+    creature,
+    "IDENTITY",
+  );
+  outputNeuron.index = 4;
+
+  creature.neurons = [inputNeuron, hiddenA, hiddenB, hiddenC, outputNeuron];
+
+  creature.synapses = [
+    new Synapse(0, 1, 1.0), // input-0 -> hidden-A
+    new Synapse(1, 2, 0.5), // hidden-A -> hidden-B
+    new Synapse(1, 4, 1.0), // hidden-A -> output-0
+    new Synapse(2, 3, 0.4), // hidden-B -> hidden-C
+    new Synapse(3, 1, 0.3), // hidden-C -> hidden-A (backward!)
+  ];
+  creature.synapses.sort((a, b) =>
+    a.from === b.from ? a.to - b.to : a.from - b.from
+  );
+
+  // Act
+  const compacted = compactCreature(creature, false);
+
+  // Assert
+  assert(compacted !== undefined, "Compaction should have occurred");
+  compacted.validate();
+  compacted.validate({ forwardOnly: true });
+
+  // Both hidden-B and hidden-C should be removed (cascade)
+  const hasHiddenB = compacted.neurons.some((n) => n.uuid === "hidden-B");
+  const hasHiddenC = compacted.neurons.some((n) => n.uuid === "hidden-C");
+  assertEquals(hasHiddenB, false, "hidden-B should be cascade-removed");
+  assertEquals(hasHiddenC, false, "hidden-C should be removed");
+});

--- a/test/Upgrade/UpgradeRepairsForwardOnlyCorruption.ts
+++ b/test/Upgrade/UpgradeRepairsForwardOnlyCorruption.ts
@@ -1,9 +1,16 @@
-import { assert } from "@std/assert";
+import { assert, assertThrows } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
 import { Synapse } from "../../src/architecture/Synapse.ts";
 import { upgrade } from "../../src/upgrade/Upgrade.ts";
 
-Deno.test("upgrade(): repairs corrupted 4.x forward-only creature with back connection", () => {
+/**
+ * Test for https://github.com/stSoftwareAU/NEAT-AI/issues/956
+ *
+ * A 4.x creature is a hard invariant: if it becomes invalid, that's a bug in
+ * our breeding/mutation/discovery logic. We do NOT silently repair - we throw
+ * so the bug can be identified and fixed at the source.
+ */
+Deno.test("upgrade(): throws for corrupted 4.x forward-only creature with back connection", () => {
   // Arrange: create a valid forward-only creature, then inject an invalid back connection.
   const creature = new Creature(2, 1, { layers: [{ count: 1 }] });
   creature.semanticVersion = "4.0.0";
@@ -20,19 +27,11 @@ Deno.test("upgrade(): repairs corrupted 4.x forward-only creature with back conn
     b,
   ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
 
-  // Act: upgrading should not throw; it should repair the structure so it validates forward-only again.
-  const upgraded = upgrade(creature);
-
-  // Assert: the upgraded creature is forward-only valid and contains no back/self connections.
-  upgraded.validate({ forwardOnly: true });
-  for (const s of upgraded.synapses) {
-    assert(
-      s.from !== s.to,
-      "upgrade() should remove self-connections in forward-only mode",
-    );
-    assert(
-      s.from < s.to,
-      "upgrade() should remove back-connections in forward-only mode",
-    );
-  }
+  // Act/Assert: upgrading a corrupted 4.x creature should throw.
+  // This is intentional - corrupted 4.x creatures indicate a bug in our code.
+  assertThrows(
+    () => upgrade(creature),
+    Error,
+    "Recursive synapse",
+  );
 });

--- a/test/Upgrade/VersionFourInvariant.ts
+++ b/test/Upgrade/VersionFourInvariant.ts
@@ -1,16 +1,19 @@
-import { assertEquals } from "@std/assert";
+import { assertThrows } from "@std/assert";
 import { Creature } from "../../mod.ts";
 import { upgrade } from "../../src/upgrade/Upgrade.ts";
 
 /**
- * Regression coverage: semanticVersion 4.x implies a forward-only (feed-forward)
- * topology, regardless of whether the `forwardOnly` flag is present.
+ * Regression coverage for https://github.com/stSoftwareAU/NEAT-AI/issues/956
+ *
+ * A 4.x creature is a hard invariant: if it becomes invalid (recurrent connections),
+ * that's a bug in our breeding/mutation/discovery logic. We do NOT silently repair -
+ * we throw so the bug can be identified and fixed at the source.
  *
  * This catches corrupted exports where `semanticVersion` is 4.x but the creature
  * still contains recurrent connections (self-loops / feedback connections).
  */
 Deno.test(
-  "upgrade repairs 4.x creatures with recurrent connections even when forwardOnly is unset",
+  "upgrade throws for 4.x creatures with recurrent connections",
   () => {
     const creature = new Creature(2, 1, {
       layers: [{ count: 2 }],
@@ -21,13 +24,11 @@ Deno.test(
     const hiddenNeuron = creature.neurons[creature.input]; // First hidden neuron
     creature.connect(hiddenNeuron.index, hiddenNeuron.index, 0.5); // self-loop (recurrent)
 
-    const upgraded = upgrade(creature);
-    assertEquals(upgraded.semanticVersion, "4.0.0");
-    upgraded.validate({ forwardOnly: true });
-    assertEquals(
-      upgraded.getSynapse(hiddenNeuron.index, hiddenNeuron.index),
-      null,
-      "upgrade() should remove self loops when semanticVersion is 4.x",
+    // Act/Assert: upgrading a corrupted 4.x creature should throw.
+    assertThrows(
+      () => upgrade(creature),
+      Error,
+      "Self connection synapse",
     );
   },
 );

--- a/test/Upgrade/VersionThree.ts
+++ b/test/Upgrade/VersionThree.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { Creature } from "../../mod.ts";
 import { SEMANTIC_MAJOR_VERSION, upgrade } from "../../src/upgrade/Upgrade.ts";
 
@@ -185,7 +185,14 @@ Deno.test("upgrade should validate and not modify valid 4.x creatures", () => {
   );
 });
 
-Deno.test("upgrade should repair forward-only 4.x creatures with recurrent connections", () => {
+/**
+ * Test for https://github.com/stSoftwareAU/NEAT-AI/issues/956
+ *
+ * A 4.x creature is a hard invariant: if it becomes invalid (recurrent connections),
+ * that's a bug in our breeding/mutation/discovery logic. We do NOT silently repair -
+ * we throw so the bug can be identified and fixed at the source.
+ */
+Deno.test("upgrade should throw for corrupted 4.x creatures with recurrent connections", () => {
   const creature = new Creature(2, 1, {
     layers: [{ count: 2 }],
     semanticVersion: "4.0.0",
@@ -193,14 +200,18 @@ Deno.test("upgrade should repair forward-only 4.x creatures with recurrent conne
   creature.forwardOnly = true;
 
   const hiddenNeuron = creature.neurons[creature.input]; // First hidden neuron
+  // Inject a recurrent self-loop. `connect()` guards against adding recurrent
+  // links when `forwardOnly` is set, so temporarily clear the flag to simulate
+  // a corrupted persisted creature.
+  creature.forwardOnly = undefined;
   creature.connect(hiddenNeuron.index, hiddenNeuron.index, 0.5);
+  creature.forwardOnly = true;
 
-  const upgraded = upgrade(creature);
-  upgraded.validate({ forwardOnly: true });
-  assertEquals(
-    upgraded.getSynapse(hiddenNeuron.index, hiddenNeuron.index),
-    null,
-    "upgrade() should remove recurrent self loops for forward-only 4.x creatures",
+  // Act/Assert: upgrading a corrupted 4.x creature should throw.
+  assertThrows(
+    () => upgrade(creature),
+    Error,
+    "Self connection synapse",
   );
 });
 

--- a/test/discovery/ForwardOnlyDiscoveryValidation.ts
+++ b/test/discovery/ForwardOnlyDiscoveryValidation.ts
@@ -18,7 +18,12 @@ Deno.test("Discovery: forward-only legacy can be repaired by stripping recurrent
 
   const modified = Creature.fromJSON(original.exportJSON());
   const hiddenIndex = modified.input;
+  // Inject a recurrent self-loop. `connect()` now guards against creating
+  // recurrent links on forward-only creatures, so temporarily clear the flag to
+  // simulate a corrupted persisted export.
+  modified.forwardOnly = undefined;
   modified.connect(hiddenIndex, hiddenIndex, 0.5); // self-loop (recurrent)
+  modified.forwardOnly = true;
 
   const result = (DiscoverStructure as unknown as {
     validateAndFixIfNeeded: (
@@ -45,7 +50,12 @@ Deno.test("Discovery: forward-only 4.x repairs by stripping recurrent connection
 
   const modified = Creature.fromJSON(original.exportJSON());
   const hiddenIndex = modified.input;
+  // Inject a recurrent self-loop. `connect()` now guards against creating
+  // recurrent links on forward-only creatures, so temporarily clear the flag to
+  // simulate a corrupted persisted export.
+  modified.forwardOnly = undefined;
   modified.connect(hiddenIndex, hiddenIndex, 0.5); // self-loop (recurrent)
+  modified.forwardOnly = true;
 
   const result = (DiscoverStructure as unknown as {
     validateAndFixIfNeeded: (

--- a/test/mutate/MutatorRepairsForwardOnlyFourXCorruption.ts
+++ b/test/mutate/MutatorRepairsForwardOnlyFourXCorruption.ts
@@ -1,0 +1,51 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { AddConnection } from "../../src/mutate/AddConnection.ts";
+import { Synapse } from "../../src/architecture/Synapse.ts";
+
+/**
+ * Regression coverage for https://github.com/stSoftwareAU/NEAT-AI/issues/955
+ *
+ * The historic failure mode was that `AddConnection` used `neuron.index` fields
+ * when creating a synapse. If those indices are corrupted, `ADD_CONN` can
+ * accidentally create a backward connection (from > to) even though it enumerates
+ * feed-forward (fromIndx < toIndx) pairs.
+ *
+ * This test corrupts `neuron.index` to reproduce the bug deterministically and
+ * asserts `AddConnection` still creates the correct forward-only connection.
+ */
+Deno.test("AddConnection: forward-only throws if the creature already contains a recurrent synapse", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.forwardOnly = true;
+
+  const hiddenIndex = creature.input;
+  const outputIndex = creature.neurons.length - 1;
+
+  // Inject a backward (recurrent) synapse with valid indices.
+  creature.synapses.push(new Synapse(outputIndex, hiddenIndex, 0.5));
+  creature.synapses.sort((
+    a,
+    b,
+  ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+  // Ensure there is at least one missing eligible forward connection so
+  // AddConnection actually mutates.
+  creature.disconnect(0, hiddenIndex);
+
+  const add = new AddConnection(creature);
+  assertThrows(() => add.mutate());
+
+  // Sanity: the creature is indeed invalid forward-only due to the injected synapse.
+  assertEquals(creature.getSynapse(outputIndex, hiddenIndex) !== null, true);
+});
+
+Deno.test("AddConnection: forward-only throws if neuron.index fields are inconsistent", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.forwardOnly = true;
+
+  // Corrupt the index metadata (this should never happen in real creatures).
+  creature.neurons[creature.input].index = creature.input + 1;
+
+  const add = new AddConnection(creature);
+  assertThrows(() => add.mutate());
+});


### PR DESCRIPTION
- Bumped version in deno.json to 0.272.0.
- Updated the imports for @std/fs and @std/streams to their latest versions.
- Improved error handling in the Mutator and Neuron classes to ensure that forward-only creatures maintain their integrity, with clear crash conditions for recurrent connections.
- Refactored the AddConnection mutation logic to enforce forward-only constraints and validate connections, ensuring that recurrent connections are not introduced.
- Enhanced diagnostics and error reporting in the Upgrade and WorkerProcessor classes to capture and log critical validation failures for forward-only creatures.

These changes strengthen the robustness and reliability of the NEAT framework's handling of forward-only semantics and improve error diagnostics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens forward-only guarantees and centralizes diagnostics, fixing compaction orphan bugs and tightening validation paths.
> 
> - Hard-fail 4.x forward-only violations in `Mutator`, `Upgrade`, and `AddConnection`; prevent self-loop creation in `Neuron.ensureHiddenOutwardConnection`
> - New `utils/Diagnostics.ts` and adoption in `Offspring` and `WorkerProcessor` for standardized error dumps
> - `compactCreature` uses `cleanupOrphanedNeurons` utility, preserves `forwardOnly`, and validates results to avoid orphaned neurons (issue #956)
> - Discovery: safer final-batch handling; clear buffers when recorder declines to maintain invariants under timeouts
> - Extensive regression tests for forward-only invariants, compaction orphans, discovery repair behavior, and mutate edge cases
> - Bump version to `0.272.0`; update `@std/fs` and `@std/streams`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52782c689b682a062f1b34f4dbf59982acd2b990. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->