### PR TITLE
Update version to 0.273.0 and enhance validation logic for forward-on…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.272.1",
+  "version": "0.273.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -2,6 +2,7 @@
   "version": "0.2",
   "language": "en-GB",
   "words": [
+    "AJSON",
     "mkdirp",
     "tsmerge",
     "githubusercontent",
@@ -143,6 +144,7 @@
     "fallbacks",
     "Δerr",
     "Δscore",
-    "knowably"
+    "knowably",
+    "BJSON"
   ]
 }

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -358,7 +358,7 @@ export class Mutator {
               //
               // Australian English: this is intentionally redundant because this path
               // can run unattended and we prefer deterministic recovery for pre-4.x
-              // creatures rather than flakey test failures.
+              // creatures rather than flaky test failures.
               creature.synapses = creature.synapses.filter((s) =>
                 s.from !== s.to && s.from < s.to
               );

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -337,7 +337,7 @@ export class Mutator {
             // Forward-only 4.x is a hard guarantee. We must crash fast (even on
             // unattended machines) so we can locate the logic that introduced a
             // recurrent connection into a supposedly forward-only creature.
-            if (creature.forwardOnly === true && major >= 4) {
+            if (major >= 4) {
               throw new Error(
                 `[Mutator] CRITICAL: forward-only 4.x creature became invalid after '${method.name}': ` +
                   `${error.name} - ${error.message}. ` +
@@ -347,6 +347,33 @@ export class Mutator {
             }
 
             creature.fix({ forwardOnly: true });
+
+            // Re-validate after fix() so we don't carry a corrupted creature forward.
+            // Once validated in a forward-only run, mark + upgrade to 4.x.
+            try {
+              creature.validate({ forwardOnly: true });
+            } catch (_stillInvalid) {
+              // Defensive fallback: if fix() did not fully remove recurrent links,
+              // explicitly filter self/back connections and re-validate.
+              //
+              // Australian English: this is intentionally redundant because this path
+              // can run unattended and we prefer deterministic recovery for pre-4.x
+              // creatures rather than flakey test failures.
+              creature.synapses = creature.synapses.filter((s) =>
+                s.from !== s.to && s.from < s.to
+              );
+              creature.synapses.sort((a, b) =>
+                a.from === b.from ? a.to - b.to : a.from - b.from
+              );
+              creature.clearCache();
+              creature.validate({ forwardOnly: true });
+            }
+            if (this.config.feedbackLoop !== true) {
+              creature.forwardOnly = true;
+            }
+            if (creature.forwardOnly === true) {
+              upgradeSemanticVersionIfForwardOnlyConfirmed(creature);
+            }
           } else {
             // Keep behaviour consistent with Offspring.breed(): only forward-only
             // violations are repaired here; all other validation failures must surface.

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -366,6 +366,12 @@ export class Mutator {
                 a.from === b.from ? a.to - b.to : a.from - b.from
               );
               creature.clearCache();
+              // After filtering recurrent synapses, run a forward-only fix pass again.
+              //
+              // Rationale (Australian English): filtering can remove a required IF
+              // connection (or other structural invariant). Running fix() here is
+              // acceptable because this is *repair*, not candidate generation.
+              creature.fix({ forwardOnly: true });
               creature.validate({ forwardOnly: true });
             }
             if (this.config.feedbackLoop !== true) {

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -32,6 +32,7 @@ import { CRISPR, type CrisprInterface } from "../reconstruct/CRISPR.ts";
 import { simplify } from "../optimize/Simplify.ts";
 import { DiscoverStructure } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import { isRustDiscoveryEnabled } from "../architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import { validateAfterDiscoveryOrThrow } from "../discovery/DiscoveryPostValidate.ts";
 
 /**
  * NEAT (NeuroEvolution of Augmenting Topologies) implementation.
@@ -863,6 +864,13 @@ export class Neat {
         r.discover.addHelpfulSynapses,
       );
       if (addedSynapseCreature) {
+        validateAfterDiscoveryOrThrow({
+          baseCreature: fittest,
+          discoveredCreature: addedSynapseCreature,
+          discoveryID: r.discover.ID,
+          operation: "addHelpfulSynapses",
+          feedbackLoop: this.config.feedbackLoop,
+        });
         trainedPopulation.push(addedSynapseCreature);
       }
 
@@ -872,6 +880,13 @@ export class Neat {
         r.discover.removeHarmfulSynapse,
       );
       if (removedSynapseCreature) {
+        validateAfterDiscoveryOrThrow({
+          baseCreature: fittest,
+          discoveredCreature: removedSynapseCreature,
+          discoveryID: r.discover.ID,
+          operation: "removeSynapse",
+          feedbackLoop: this.config.feedbackLoop,
+        });
         trainedPopulation.push(removedSynapseCreature);
 
         if (addedSynapseCreature) {
@@ -882,6 +897,13 @@ export class Neat {
           );
 
           if (combinedSynapseCreature) {
+            validateAfterDiscoveryOrThrow({
+              baseCreature: fittest,
+              discoveredCreature: combinedSynapseCreature,
+              discoveryID: r.discover.ID,
+              operation: "removeSynapse+addHelpfulSynapses",
+              feedbackLoop: this.config.feedbackLoop,
+            });
             trainedPopulation.push(combinedSynapseCreature);
           }
         }
@@ -893,6 +915,13 @@ export class Neat {
         r.discover.candidateSquashes,
       );
       if (changedSquashCreature) {
+        validateAfterDiscoveryOrThrow({
+          baseCreature: fittest,
+          discoveredCreature: changedSquashCreature,
+          discoveryID: r.discover.ID,
+          operation: "changeSquash",
+          feedbackLoop: this.config.feedbackLoop,
+        });
         trainedPopulation.push(changedSquashCreature);
 
         if (addedSynapseCreature) {
@@ -903,6 +932,13 @@ export class Neat {
           );
 
           if (combinedSynapseCreature) {
+            validateAfterDiscoveryOrThrow({
+              baseCreature: fittest,
+              discoveredCreature: combinedSynapseCreature,
+              discoveryID: r.discover.ID,
+              operation: "addHelpfulSynapses+changeSquash",
+              feedbackLoop: this.config.feedbackLoop,
+            });
             trainedPopulation.push(combinedSynapseCreature);
           }
         }

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -62,6 +62,21 @@ function getMajorVersion(version: string | undefined): number {
 }
 
 /**
+ * Upgrade 2.x/3.x creatures to 4.x once forward-only validity is confirmed.
+ *
+ * Rationale (Australian English): forward-only became a hard invariant in 4.x.
+ * We should mark a creature as 4.x whenever we have just validated it as
+ * forward-only, even if no repair was needed, so downstream logic treats
+ * structurally identical creatures consistently.
+ */
+function bumpToFourIfForwardOnlyConfirmed(creature: Creature): void {
+  const major = getMajorVersion(creature.semanticVersion);
+  if (major === 2 || major === 3) {
+    creature.semanticVersion = "4.0.0";
+  }
+}
+
+/**
  * Determine whether forward-only must be enforced for this creature.
  *
  * - If `forwardOnly` is true, we must reject recurrent connections.
@@ -1437,6 +1452,7 @@ function validateAndFixCreatureSync(
     if (enforceForwardOnly) {
       creature.validate({ forwardOnly: true });
       creature.forwardOnly = true;
+      bumpToFourIfForwardOnlyConfirmed(creature);
     } else {
       creature.validate();
     }
@@ -1475,6 +1491,7 @@ function validateAndFixCreatureSync(
       if (enforceForwardOnly) {
         creature.validate({ forwardOnly: true });
         creature.forwardOnly = true;
+        bumpToFourIfForwardOnlyConfirmed(creature);
       } else {
         creature.validate();
       }

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -50,6 +50,51 @@ import {
 import { Creature } from "../Creature.ts";
 import { ValidationError } from "../errors/ValidationError.ts";
 
+/**
+ * Extract the major version from a semantic version string.
+ *
+ * Invalid/undefined versions are treated as 0.
+ */
+function getMajorVersion(version: string | undefined): number {
+  if (!version) return 0;
+  const major = Number.parseInt(version.split(".")[0], 10);
+  return Number.isNaN(major) ? 0 : major;
+}
+
+/**
+ * Determine whether forward-only must be enforced for this creature.
+ *
+ * - If `forwardOnly` is true, we must reject recurrent connections.
+ * - If the creature is 4.x+, forward-only is a hard invariant.
+ */
+function shouldEnforceForwardOnly(creature: Creature): boolean {
+  return creature.forwardOnly === true ||
+    getMajorVersion(creature.semanticVersion) >= 4;
+}
+
+/**
+ * Build a UUID → neuron index mapping from an exported creature JSON.
+ *
+ * Note: `CreatureExport.neurons` excludes input neurons. Its ordering matches the
+ * creature's internal indices, offset by `input`.
+ */
+function buildUuidToIndexMap(
+  creatureJSON: { input: number; neurons: Array<{ uuid: string }> },
+): Map<string, number> {
+  const uuidToIndex = new Map<string, number>();
+  const inputCount = creatureJSON.input ?? 0;
+
+  for (let i = 0; i < inputCount; i++) {
+    uuidToIndex.set(`input-${i}`, i);
+  }
+
+  for (let i = 0; i < creatureJSON.neurons.length; i++) {
+    uuidToIndex.set(creatureJSON.neurons[i].uuid, inputCount + i);
+  }
+
+  return uuidToIndex;
+}
+
 export type DiscoveryChangeType =
   | "add-synapses"
   | "add-neurons"
@@ -1386,9 +1431,15 @@ function validateAndFixCreatureSync(
   creature: Creature,
   changeType: DiscoveryChangeType,
 ): Creature {
+  const enforceForwardOnly = shouldEnforceForwardOnly(creature);
   try {
     // Preferred path: validate first - if this passes, no fix() needed
-    creature.validate();
+    if (enforceForwardOnly) {
+      creature.validate({ forwardOnly: true });
+      creature.forwardOnly = true;
+    } else {
+      creature.validate();
+    }
     return creature;
   } catch (error) {
     // Validation failed - this indicates our modification logic created an invalid creature
@@ -1412,11 +1463,21 @@ function validateAndFixCreatureSync(
     console.warn(
       `[DiscoveryCandidates] Calling fix() on ${changeType} change - this indicates a bug in modification logic that should be addressed`,
     );
-    creature.fix();
+    if (enforceForwardOnly) {
+      creature.fix({ forwardOnly: true });
+      creature.forwardOnly = true;
+    } else {
+      creature.fix();
+    }
 
     // Validate again after fix() to ensure it's now valid
     try {
-      creature.validate();
+      if (enforceForwardOnly) {
+        creature.validate({ forwardOnly: true });
+        creature.forwardOnly = true;
+      } else {
+        creature.validate();
+      }
     } catch (fixError) {
       console.error(
         `[DiscoveryCandidates] Creature still invalid after fix() for ${changeType}: ${fixError}`,
@@ -1444,6 +1505,10 @@ function applyChangeToCreature(
   const candidateJSON = candidate.creature.exportJSON();
   const creatureJSON = creature.exportJSON();
   const baseJSON = baseCreature.exportJSON();
+  const enforceForwardOnly = shouldEnforceForwardOnly(creature);
+  const uuidToIndex = enforceForwardOnly
+    ? buildUuidToIndexMap(creatureJSON)
+    : undefined;
 
   try {
     switch (changeType) {
@@ -1467,7 +1532,14 @@ function applyChangeToCreature(
           (s) =>
             !existingSynapses.has(`${s.fromUUID}->${s.toUUID}`) &&
             existingNeurons.has(s.fromUUID) &&
-            existingNeurons.has(s.toUUID),
+            existingNeurons.has(s.toUUID) &&
+            (!enforceForwardOnly ||
+              (() => {
+                const from = uuidToIndex?.get(s.fromUUID);
+                const to = uuidToIndex?.get(s.toUUID);
+                // Forward-only: reject self-loops and back connections.
+                return from !== undefined && to !== undefined && from < to;
+              })()),
         );
         if (newSynapses.length === 0) return creature;
 
@@ -1633,7 +1705,13 @@ function applyChangeToCreature(
         const toAdd = candidateJSON.synapses.filter(
           (s) =>
             !baseSynapses.has(`${s.fromUUID}->${s.toUUID}`) &&
-            !creatureSynapses.has(`${s.fromUUID}->${s.toUUID}`),
+            !creatureSynapses.has(`${s.fromUUID}->${s.toUUID}`) &&
+            (!enforceForwardOnly ||
+              (() => {
+                const from = uuidToIndex?.get(s.fromUUID);
+                const to = uuidToIndex?.get(s.toUUID);
+                return from !== undefined && to !== undefined && from < to;
+              })()),
         );
 
         if (toRemove.size === 0 && toAdd.length === 0) return creature;
@@ -1705,6 +1783,10 @@ function applyChangeToCreature(
           remainingNeurons.add(`input-${i}`);
         }
 
+        const uuidToIndexAfterRemovals = enforceForwardOnly
+          ? buildUuidToIndexMap(creatureJSON)
+          : undefined;
+
         // Add reconnection synapses: new in candidate but not in creature
         // These maintain connectivity after neuron removal
         // IMPORTANT: Only add synapses where BOTH endpoints exist in the current creature
@@ -1714,7 +1796,13 @@ function applyChangeToCreature(
             !baseSynapses.has(`${s.fromUUID}->${s.toUUID}`) &&
             !creatureSynapses.has(`${s.fromUUID}->${s.toUUID}`) &&
             remainingNeurons.has(s.fromUUID) &&
-            remainingNeurons.has(s.toUUID),
+            remainingNeurons.has(s.toUUID) &&
+            (!enforceForwardOnly ||
+              (() => {
+                const from = uuidToIndexAfterRemovals?.get(s.fromUUID);
+                const to = uuidToIndexAfterRemovals?.get(s.toUUID);
+                return from !== undefined && to !== undefined && from < to;
+              })()),
         );
 
         if (toRemove.size === 0 && toAdd.length === 0) return creature;

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -1642,13 +1642,24 @@ function applyChangeToCreature(
           updatedNeurons.add(`input-${i}`);
         }
 
+        const uuidToIndexAfterInsertion = enforceForwardOnly
+          ? buildUuidToIndexMap(creatureJSON)
+          : undefined;
+
         // Find synapses connected to these new neurons
         // Only include synapses where BOTH endpoints exist in current creature
         const newSynapses = candidateJSON.synapses.filter(
           (s) =>
             (newNeuronUUIDs.has(s.fromUUID) || newNeuronUUIDs.has(s.toUUID)) &&
             updatedNeurons.has(s.fromUUID) &&
-            updatedNeurons.has(s.toUUID),
+            updatedNeurons.has(s.toUUID) &&
+            (!enforceForwardOnly ||
+              (() => {
+                const from = uuidToIndexAfterInsertion?.get(s.fromUUID);
+                const to = uuidToIndexAfterInsertion?.get(s.toUUID);
+                // Forward-only: reject self-loops and back connections.
+                return from !== undefined && to !== undefined && from < to;
+              })()),
         );
         creatureJSON.synapses.push(...newSynapses);
 

--- a/src/discovery/DiscoveryPostValidate.ts
+++ b/src/discovery/DiscoveryPostValidate.ts
@@ -1,0 +1,138 @@
+import type { Creature } from "../Creature.ts";
+import { creatureValidate } from "../architecture/CreatureValidate.ts";
+
+/**
+ * Validate a creature immediately after applying discovery changes.
+ *
+ * Goal: fail fast near the discovery logic that introduced corruption, rather than
+ * surfacing later during unrelated phases (e.g. breeding calling upgrade()).
+ *
+ * Forward-only is enforced when:
+ * - the run is configured as forward-only (feedbackLoop !== true), OR
+ * - the base creature is explicitly forwardOnly, OR
+ * - the base creature is 4.x+ (4.x is a hard forward-only invariant).
+ *
+ * Notes (Australian English):
+ * - This function is intentionally strict; any failure indicates a bug in our code,
+ *   not a "bad creature".
+ * - We include a small sample of recurrent violations to improve triage.
+ */
+export function validateAfterDiscoveryOrThrow(args: {
+  /** The base creature the discovery change was applied to (usually the fittest). */
+  baseCreature: Creature;
+  /** The resulting creature after discovery modification. */
+  discoveredCreature: Creature;
+  /** Discovery session ID (for log correlation). */
+  discoveryID: string;
+  /** Human-readable operation label (e.g. "addHelpfulSynapses", "removeSynapse"). */
+  operation: string;
+  /** The config feedbackLoop flag for the current run. */
+  feedbackLoop: boolean | undefined;
+}): void {
+  const {
+    baseCreature,
+    discoveredCreature,
+    discoveryID,
+    operation,
+    feedbackLoop,
+  } = args;
+
+  const baseMajor = getMajorVersion(baseCreature.semanticVersion);
+  const discoveredMajor = getMajorVersion(discoveredCreature.semanticVersion);
+
+  // 4.x+ is a hard forward-only invariant. If either the base or the discovered
+  // creature is already 4.x+, we must fail fast (no silent repair).
+  const isHardForwardOnlyInvariant = baseMajor >= 4 || discoveredMajor >= 4;
+
+  // Pre-4.x: it's valid for a creature to temporarily contain recurrent links even
+  // in a forward-only run; we repair it (fix+re-validate), then bump to 4.x once
+  // forward-only is confirmed.
+  const shouldAttemptForwardOnlyRepair = !isHardForwardOnlyInvariant &&
+    (feedbackLoop !== true || baseCreature.forwardOnly === true ||
+      discoveredCreature.forwardOnly === true);
+
+  try {
+    if (isHardForwardOnlyInvariant) {
+      creatureValidate(discoveredCreature, { forwardOnly: true });
+      discoveredCreature.forwardOnly = true;
+      return;
+    }
+
+    if (shouldAttemptForwardOnlyRepair) {
+      try {
+        creatureValidate(discoveredCreature, { forwardOnly: true });
+        discoveredCreature.forwardOnly = true;
+        bumpToFourIfForwardOnlyConfirmed(discoveredCreature);
+        return;
+      } catch (_preFourValidationError) {
+        // Try to repair the transient corruption, then validate again.
+        discoveredCreature.fix({ forwardOnly: true });
+        creatureValidate(discoveredCreature, { forwardOnly: true });
+        discoveredCreature.forwardOnly = true;
+        bumpToFourIfForwardOnlyConfirmed(discoveredCreature);
+        return;
+      }
+    }
+
+    // Recurrent mode (or forward-only not requested): just ensure general validity.
+    creatureValidate(discoveredCreature);
+  } catch (e) {
+    const error = e as Error;
+    const violations =
+      (isHardForwardOnlyInvariant || shouldAttemptForwardOnlyRepair)
+        ? sampleForwardOnlyViolations(discoveredCreature, 10)
+        : [];
+
+    const detail = violations.length > 0
+      ? ` Violations(sample up to 10): ${violations.join(" | ")}`
+      : "";
+
+    throw new Error(
+      `[Discovery ${discoveryID}] CRITICAL: discovery operation '${operation}' produced an invalid creature. ` +
+        `base=${
+          baseCreature.uuid ?? "unknown"
+        } (v${baseCreature.semanticVersion}, forwardOnly=${
+          baseCreature.forwardOnly === true
+        }), ` +
+        `result=${
+          discoveredCreature.uuid ?? "unknown"
+        } (v${discoveredCreature.semanticVersion}, forwardOnly=${
+          discoveredCreature.forwardOnly === true
+        }), ` +
+        `hardInvariant=${isHardForwardOnlyInvariant}, attemptedRepair=${shouldAttemptForwardOnlyRepair}. ` +
+        `Error=${error.name}: ${error.message}.${detail}`,
+    );
+  }
+}
+
+function getMajorVersion(version: string | undefined): number {
+  if (!version) return 0;
+  const major = Number.parseInt(version.split(".")[0], 10);
+  return Number.isNaN(major) ? 0 : major;
+}
+
+function bumpToFourIfForwardOnlyConfirmed(creature: Creature): void {
+  const major = getMajorVersion(creature.semanticVersion);
+  if (major === 2 || major === 3) {
+    creature.semanticVersion = "4.0.0";
+  }
+}
+
+function sampleForwardOnlyViolations(
+  creature: Creature,
+  limit: number,
+): string[] {
+  const out: string[] = [];
+  const synapses = creature.synapses;
+  for (let i = 0; i < synapses.length && out.length < limit; i++) {
+    const s = synapses[i];
+    if (s.from === s.to || s.from > s.to) {
+      out.push(
+        `${i}) ${s.from} (${
+          creature.neurons[s.from]?.ID?.() ?? "?"
+        }) -> ${s.to} (${creature.neurons[s.to]?.ID?.() ?? "?"})`,
+      );
+    }
+  }
+  return out;
+}

--- a/src/discovery/DiscoveryPostValidate.ts
+++ b/src/discovery/DiscoveryPostValidate.ts
@@ -55,6 +55,7 @@ export function validateAfterDiscoveryOrThrow(args: {
     if (isHardForwardOnlyInvariant) {
       creatureValidate(discoveredCreature, { forwardOnly: true });
       discoveredCreature.forwardOnly = true;
+      bumpToFourIfForwardOnlyConfirmed(discoveredCreature);
       return;
     }
 

--- a/src/mutate/AddConnection.ts
+++ b/src/mutate/AddConnection.ts
@@ -5,6 +5,19 @@ import type { Neuron } from "../architecture/Neuron.ts";
 import { Synapse } from "../architecture/Synapse.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
 
+function getMajorVersion(version: string | undefined): number {
+  if (!version) return 0;
+  const major = Number.parseInt(version.split(".")[0], 10);
+  return Number.isNaN(major) ? 0 : major;
+}
+
+function bumpToFourIfForwardOnlyConfirmed(creature: Creature): void {
+  const major = getMajorVersion(creature.semanticVersion);
+  if (major === 2 || major === 3) {
+    creature.semanticVersion = "4.0.0";
+  }
+}
+
 export class AddConnection implements RadioactiveInterface {
   private creature: Creature;
   constructor(creature: Creature) {
@@ -30,6 +43,34 @@ export class AddConnection implements RadioactiveInterface {
     const enforceForwardOnly = this.creature.forwardOnly === true;
 
     if (enforceForwardOnly) {
+      const major = getMajorVersion(this.creature.semanticVersion);
+      // Fail fast for 4.x+ (hard invariant). For pre-4.x we repair and continue,
+      // because forward-only is not yet a hard guarantee until validated+upgraded.
+      try {
+        this.creature.validate({ forwardOnly: true });
+        bumpToFourIfForwardOnlyConfirmed(this.creature);
+      } catch (e) {
+        const error = e as Error;
+        if (major >= 4) {
+          throw new Error(
+            `[AddConnection] CRITICAL: 4.x forward-only creature is invalid before mutation: ` +
+              `${error.name} - ${error.message}`,
+          );
+        }
+
+        if (
+          error.name === "SELF_CONNECTION" || error.name === "RECURSIVE_SYNAPSE"
+        ) {
+          // Australian English: forward-only pre-4.x may temporarily be invalid; repair it
+          // so we can continue evolution and only lock the invariant once confirmed.
+          this.creature.fix({ forwardOnly: true });
+          this.creature.validate({ forwardOnly: true });
+          bumpToFourIfForwardOnlyConfirmed(this.creature);
+        } else {
+          throw e;
+        }
+      }
+
       // Forward-only invariant: neuron indices must be consistent.
       //
       // Rationale (Australian English): if `neuron.index` does not match its
@@ -94,9 +135,31 @@ export class AddConnection implements RadioactiveInterface {
 
     this.creature.connect(fromIndex, toIndex, weight);
     if (enforceForwardOnly) {
-      // Validation is useful, but if it fails we should crash fast rather than
-      // trying to limp on (this typically runs unattended).
-      this.creature.validate({ forwardOnly: true });
+      // Validation is useful. For 4.x+ this is a hard failure; for pre-4.x we can
+      // repair and continue, then bump to 4.x once forward-only is confirmed.
+      const major = getMajorVersion(this.creature.semanticVersion);
+      try {
+        this.creature.validate({ forwardOnly: true });
+        bumpToFourIfForwardOnlyConfirmed(this.creature);
+      } catch (e) {
+        const error = e as Error;
+        if (major >= 4) {
+          throw new Error(
+            `[AddConnection] CRITICAL: 4.x forward-only creature became invalid after mutation: ` +
+              `${error.name} - ${error.message}`,
+          );
+        }
+
+        if (
+          error.name === "SELF_CONNECTION" || error.name === "RECURSIVE_SYNAPSE"
+        ) {
+          this.creature.fix({ forwardOnly: true });
+          this.creature.validate({ forwardOnly: true });
+          bumpToFourIfForwardOnlyConfirmed(this.creature);
+        } else {
+          throw e;
+        }
+      }
     }
     delete this.creature.memetic;
     return true;

--- a/test/NEAT/MutatorForwardOnlyIFConditionsRepair.ts
+++ b/test/NEAT/MutatorForwardOnlyIFConditionsRepair.ts
@@ -1,0 +1,63 @@
+import { assert } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { Creature } from "../../src/Creature.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+
+Deno.test(
+  "Mutator: forward-only repair must also satisfy IF_CONDITIONS after removing recurrent links",
+  () => {
+    const config = createNeatConfig({
+      feedbackLoop: false,
+    });
+    const mutator = new Mutator(config);
+
+    // Arrange: a pre-4.x forward-only creature where an IF neuron has 3 inbound
+    // connections, but one is a back-connection (output -> hidden). Removing the
+    // back-connection would leave only 2 inbound connections, triggering
+    // IF_CONDITIONS unless repair adds a replacement forward connection.
+    const tmp: CreatureExport = {
+      neurons: [
+        { type: "hidden", uuid: "hidden-0", squash: "IF", bias: 0.1 },
+        { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+      ],
+      synapses: [
+        {
+          fromUUID: "input-0",
+          toUUID: "hidden-0",
+          weight: 0.2,
+          type: "positive",
+        },
+        {
+          fromUUID: "input-1",
+          toUUID: "hidden-0",
+          weight: -0.4,
+          type: "condition",
+        },
+        // Illegal in forward-only: output -> hidden is a back connection.
+        {
+          fromUUID: "output-0",
+          toUUID: "hidden-0",
+          weight: 0.3,
+          type: "negative",
+        },
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.8 },
+      ],
+      // Use 3 inputs so the IF neuron index is > 2 and the IF_CONDITIONS
+      // validation is actually enforced.
+      input: 3,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(tmp);
+    creature.forwardOnly = true;
+    creature.semanticVersion = "2.0.0";
+
+    // Act: run a harmless mutation to trigger the repair+validation path.
+    mutator.mutateCreature(creature, { name: "MOD_WEIGHT" }, undefined);
+
+    // Assert: creature remains valid forward-only and IF invariants are satisfied.
+    creature.validate({ forwardOnly: true });
+    assert(creature.forwardOnly === true);
+  },
+);

--- a/test/NEAT/MutatorForwardOnlyRepair.ts
+++ b/test/NEAT/MutatorForwardOnlyRepair.ts
@@ -1,0 +1,36 @@
+import { assert } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { Creature } from "../../src/Creature.ts";
+import { Synapse } from "../../src/architecture/Synapse.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+
+Deno.test(
+  "Mutator: in forward-only runs, fixes SELF_CONNECTION for pre-4.x creatures and upgrades to 4.x",
+  () => {
+    const config = createNeatConfig({
+      feedbackLoop: false,
+    });
+    const mutator = new Mutator(config);
+
+    const creature = new Creature(2, 1, { layers: [{ count: 1 }] });
+    creature.forwardOnly = true;
+    creature.semanticVersion = "2.0.0";
+
+    // Inject corruption: self-loop on first hidden neuron.
+    const hiddenIndex = creature.input;
+    creature.synapses.push(new Synapse(hiddenIndex, hiddenIndex, 0.123));
+    creature.synapses.sort((
+      a,
+      b,
+    ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+    // Trigger the forward-only validation path by running a harmless mutation.
+    mutator.mutateCreature(creature, { name: "MOD_WEIGHT" }, undefined);
+
+    creature.validate({ forwardOnly: true });
+    assert(
+      creature.semanticVersion.startsWith("4."),
+      `Expected creature to be upgraded to 4.x, got ${creature.semanticVersion}`,
+    );
+  },
+);

--- a/test/discovery/CombinedCandidateSequentialApplication.ts
+++ b/test/discovery/CombinedCandidateSequentialApplication.ts
@@ -333,6 +333,110 @@ Deno.test(
 );
 
 Deno.test(
+  "buildCombinedFromSuccessful: add-neurons (forward-only 4.x) filters recurrent synapses instead of relying on fix()",
+  () => {
+    // Arrange: forward-only base creature.
+    const base = makeTestCreature();
+    base.forwardOnly = true;
+    base.semanticVersion = "4.0.0";
+    base.validate({ forwardOnly: true });
+
+    const baseJSON = base.exportJSON();
+
+    // Candidate A: add a new neuron, but also (incorrectly) includes a back connection
+    // involving that new neuron. In forward-only mode this must be filtered out
+    // *before* validation, otherwise DiscoveryCandidates falls back to fix().
+    const addNeuronsJSON = structuredClone(baseJSON);
+    addNeuronsJSON.neurons.splice(0, 0, {
+      type: "hidden",
+      uuid: "hidden-D",
+      squash: "TANH",
+      bias: 0.15,
+    });
+    addNeuronsJSON.synapses.push(
+      { fromUUID: "input-0", toUUID: "hidden-D", weight: 0.4 },
+      { fromUUID: "hidden-D", toUUID: "output-0", weight: 0.4 },
+      // Illegal in forward-only: hidden-C is after hidden-D in the neurone list,
+      // so this becomes a back connection (from > to) once indices are rebuilt.
+      { fromUUID: "hidden-C", toUUID: "hidden-D", weight: 0.123 },
+    );
+
+    const addNeuronsCreature = Creature.fromJSON(addNeuronsJSON);
+    delete addNeuronsCreature.uuid;
+    addNeuronsCreature.validate(); // Recurrent is allowed in general mode.
+    CreatureUtil.makeUUID(addNeuronsCreature);
+
+    const addNeuronsCandidate: DiscoveryCandidate = {
+      creature: addNeuronsCreature,
+      change: {
+        type: "add-neurons",
+        description:
+          "Adds hidden-D but includes an illegal back connection hidden-C -> hidden-D",
+      },
+    };
+
+    // Candidate B: ensure we actually build a combination.
+    const removeSynapseJSON = structuredClone(baseJSON);
+    removeSynapseJSON.synapses = removeSynapseJSON.synapses.filter(
+      (s) => !(s.fromUUID === "hidden-A" && s.toUUID === "hidden-C"),
+    );
+    removeSynapseJSON.synapses.push({
+      fromUUID: "hidden-A",
+      toUUID: "output-0",
+      weight: 0.25,
+    });
+    const removeSynapseCreature = Creature.fromJSON(removeSynapseJSON);
+    delete removeSynapseCreature.uuid;
+    removeSynapseCreature.fix();
+    CreatureUtil.makeUUID(removeSynapseCreature);
+
+    const removeSynapseCandidate: DiscoveryCandidate = {
+      creature: removeSynapseCreature,
+      change: {
+        type: "remove-synapse",
+        description: "Removed hidden-A -> hidden-C synapse",
+        synapseDetails: {
+          fromNeuronUUID: "hidden-A",
+          toNeuronUUID: "hidden-C",
+        },
+      },
+    };
+
+    // Act: capture warnings so we can detect if DiscoveryCandidates had to fall back to fix().
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    try {
+      const combined = buildCombinedFromSuccessful(
+        base,
+        "TEST_DISCOVERY",
+        [addNeuronsCandidate, removeSynapseCandidate],
+      );
+
+      // Assert: we should not need to call fix() in the forward-only path.
+      // If a recurrent synapse slips through, validation fails and we warn before fixing.
+      assertEquals(
+        warnings.length,
+        0,
+        `Expected no warnings (no fix() fallback), got ${warnings.length}: ${
+          warnings.map((w) => w.join(" ")).join(" | ")
+        }`,
+      );
+
+      // Sanity: any produced combination remains forward-only valid.
+      for (const candidate of combined) {
+        candidate.creature.validate({ forwardOnly: true });
+      }
+    } finally {
+      console.warn = originalWarn;
+    }
+  },
+);
+
+Deno.test(
   "buildCombinedFromSuccessful: add-neurons chain keeps new neurons in candidate order (new -> new -> existing)",
   () => {
     const base = makeTestCreature();

--- a/test/discovery/CombinedCandidateSequentialApplication.ts
+++ b/test/discovery/CombinedCandidateSequentialApplication.ts
@@ -260,6 +260,79 @@ Deno.test(
 );
 
 Deno.test(
+  "buildCombinedFromSuccessful: forward-only (4.x) combinations must not introduce recurrent synapses",
+  () => {
+    // Arrange: a forward-only (feed-forward) base creature.
+    const base = makeTestCreature();
+    base.forwardOnly = true;
+    base.semanticVersion = "4.0.0";
+    base.validate({ forwardOnly: true });
+
+    const baseJSON = base.exportJSON();
+
+    // Candidate A: adds a *back* connection (hidden-C -> hidden-A). This is illegal in forward-only mode.
+    // This simulates a Rust hint that is fine in recurrent mode, but must be rejected/filtered in 4.x.
+    const addBackSynapseJSON = structuredClone(baseJSON);
+    addBackSynapseJSON.synapses.push({
+      fromUUID: "hidden-C",
+      toUUID: "hidden-A",
+      weight: 0.123,
+    });
+    const addBackSynapseCreature = Creature.fromJSON(addBackSynapseJSON);
+    delete addBackSynapseCreature.uuid;
+    CreatureUtil.makeUUID(addBackSynapseCreature);
+
+    const addBackSynapseCandidate: DiscoveryCandidate = {
+      creature: addBackSynapseCreature,
+      change: {
+        type: "add-synapses",
+        description:
+          "Adds back connection hidden-C -> hidden-A (should be rejected in forward-only)",
+      },
+    };
+
+    // Candidate B: a second change so buildCombinedFromSuccessful produces a combination.
+    const removeSynapseJSON = structuredClone(baseJSON);
+    removeSynapseJSON.synapses = removeSynapseJSON.synapses.filter(
+      (s) => !(s.fromUUID === "hidden-B" && s.toUUID === "hidden-C"),
+    );
+    removeSynapseJSON.synapses.push({
+      fromUUID: "hidden-B",
+      toUUID: "output-0",
+      weight: 0.25,
+    });
+    const removeSynapseCreature = Creature.fromJSON(removeSynapseJSON);
+    delete removeSynapseCreature.uuid;
+    removeSynapseCreature.fix();
+    CreatureUtil.makeUUID(removeSynapseCreature);
+
+    const removeSynapseCandidate: DiscoveryCandidate = {
+      creature: removeSynapseCreature,
+      change: {
+        type: "remove-synapse",
+        description: "Removed hidden-B -> hidden-C synapse",
+        synapseDetails: {
+          fromNeuronUUID: "hidden-B",
+          toNeuronUUID: "hidden-C",
+        },
+      },
+    };
+
+    // Act: combine successful candidates.
+    const combined = buildCombinedFromSuccessful(
+      base,
+      "TEST_DISCOVERY",
+      [addBackSynapseCandidate, removeSynapseCandidate],
+    );
+    // Assert: either no combination is produced (because the illegal synapse is rejected),
+    // or any produced combination must still be forward-only valid.
+    for (const candidate of combined) {
+      candidate.creature.validate({ forwardOnly: true });
+    }
+  },
+);
+
+Deno.test(
   "buildCombinedFromSuccessful: add-neurons chain keeps new neurons in candidate order (new -> new -> existing)",
   () => {
     const base = makeTestCreature();

--- a/test/discovery/DiscoveryCandidatesForwardOnlyVersionBump.ts
+++ b/test/discovery/DiscoveryCandidatesForwardOnlyVersionBump.ts
@@ -1,0 +1,93 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { buildCombinedFromSuccessful } from "../../src/discovery/DiscoveryCandidates.ts";
+import type { DiscoveryCandidate } from "../../src/discovery/DiscoveryCandidates.ts";
+
+// cspell:ignore TESTDISC
+
+Deno.test(
+  "buildCombinedFromSuccessful: forward-only pre-4.x should be bumped to 4.x even when validation succeeds (no fix path)",
+  () => {
+    // Arrange: a forward-only creature that is already valid but still marked as 2.x.
+    const base = new Creature(2, 1, { layers: [{ count: 1 }] });
+    base.forwardOnly = true;
+    base.semanticVersion = "2.0.0";
+    base.validate({ forwardOnly: true });
+
+    const baseJSON = base.exportJSON();
+
+    const hidden = baseJSON.neurons.find((n) => n.type === "hidden");
+    const output = baseJSON.neurons.find((n) => n.type === "output");
+    assert(hidden, "Expected a hidden neuron in the base creature");
+    assert(output, "Expected an output neuron in the base creature");
+
+    // Pick alternate squashes so we guarantee a change regardless of defaults.
+    const hiddenAltSquash = hidden.squash === "TANH" ? "IDENTITY" : "TANH";
+    const outputAltSquash = output.squash === "TANH" ? "IDENTITY" : "TANH";
+
+    // Candidate A: change the hidden squash only.
+    const candidateAJSON = structuredClone(baseJSON);
+    const candidateAHidden = candidateAJSON.neurons.find((n) =>
+      n.type === "hidden"
+    );
+    assert(candidateAHidden);
+    candidateAHidden.squash = hiddenAltSquash;
+    const candidateACreature = Creature.fromJSON(candidateAJSON);
+    candidateACreature.forwardOnly = true;
+    candidateACreature.semanticVersion = "2.0.0";
+
+    const candidateA: DiscoveryCandidate = {
+      creature: candidateACreature,
+      change: {
+        type: "change-squash",
+        description: "Change hidden squash",
+      },
+    };
+
+    // Candidate B: change output squash, but also include the hidden change so a
+    // combination doesn't accidentally revert the earlier change.
+    const candidateBJSON = structuredClone(baseJSON);
+    const candidateBHidden = candidateBJSON.neurons.find((n) =>
+      n.type === "hidden"
+    );
+    const candidateBOutput = candidateBJSON.neurons.find((n) =>
+      n.type === "output"
+    );
+    assert(candidateBHidden);
+    assert(candidateBOutput);
+    candidateBHidden.squash = hiddenAltSquash;
+    candidateBOutput.squash = outputAltSquash;
+    const candidateBCreature = Creature.fromJSON(candidateBJSON);
+    candidateBCreature.forwardOnly = true;
+    candidateBCreature.semanticVersion = "2.0.0";
+
+    const candidateB: DiscoveryCandidate = {
+      creature: candidateBCreature,
+      change: {
+        type: "change-squash",
+        description: "Change output squash",
+      },
+    };
+
+    // Act: build combinations, which applies changes and runs validateAndFixCreatureSync().
+    const combined = buildCombinedFromSuccessful(base, "TESTDISC", [
+      candidateA,
+      candidateB,
+    ]);
+
+    // Assert: a combination is produced, remains forward-only valid, and is bumped to 4.x.
+    assert(combined.length > 0, "Expected at least one combined candidate");
+    for (const c of combined) {
+      c.creature.validate({ forwardOnly: true });
+      assertEquals(
+        c.creature.forwardOnly,
+        true,
+        "Expected forwardOnly to remain true after combining candidates",
+      );
+      assert(
+        c.creature.semanticVersion.startsWith("4."),
+        `Expected semanticVersion to be bumped to 4.x, got ${c.creature.semanticVersion}`,
+      );
+    }
+  },
+);

--- a/test/discovery/DiscoveryPostValidate.ts
+++ b/test/discovery/DiscoveryPostValidate.ts
@@ -81,6 +81,38 @@ Deno.test(
 );
 
 Deno.test(
+  "validateAfterDiscoveryOrThrow: hard invariant bumps discovered (2.x/3.x) to 4.x when base is 4.x",
+  () => {
+    const base = new Creature(2, 1, { layers: [{ count: 1 }] });
+    base.forwardOnly = true;
+    base.semanticVersion = "4.0.0";
+    base.validate({ forwardOnly: true });
+
+    // Simulate a discovered creature that lost its semanticVersion during
+    // export/import (Australian English: this happens in distributed workflows).
+    const discovered = Creature.fromJSON(base.exportJSON());
+    discovered.forwardOnly = true;
+    discovered.semanticVersion = "2.0.0";
+
+    validateAfterDiscoveryOrThrow({
+      baseCreature: base,
+      discoveredCreature: discovered,
+      discoveryID: "TESTDISC",
+      operation: "unit-test",
+      feedbackLoop: false,
+    });
+
+    // With a 4.x base, forward-only is a hard invariant; any validated result
+    // should be marked + upgraded to 4.x for consistency.
+    if (!discovered.semanticVersion.startsWith("4.")) {
+      throw new Error(
+        `Expected semanticVersion to be bumped to 4.x, got ${discovered.semanticVersion}`,
+      );
+    }
+  },
+);
+
+Deno.test(
   "validateAfterDiscoveryOrThrow: does not throw when feedbackLoop is enabled and base is not forward-only",
   () => {
     const base = new Creature(2, 1, { layers: [{ count: 1 }] });

--- a/test/discovery/DiscoveryPostValidate.ts
+++ b/test/discovery/DiscoveryPostValidate.ts
@@ -1,0 +1,110 @@
+import { assertThrows } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { Synapse } from "../../src/architecture/Synapse.ts";
+import { validateAfterDiscoveryOrThrow } from "../../src/discovery/DiscoveryPostValidate.ts";
+
+Deno.test(
+  "validateAfterDiscoveryOrThrow: throws for forward-only base when discovery result has back connection",
+  () => {
+    const base = new Creature(2, 1, { layers: [{ count: 1 }] });
+    base.forwardOnly = true;
+    base.semanticVersion = "4.0.0";
+
+    const discovered = Creature.fromJSON(base.exportJSON());
+    discovered.forwardOnly = true;
+    discovered.semanticVersion = "4.0.0";
+
+    const hiddenIndex = discovered.input; // first hidden neuron
+    const outputIndex = discovered.neurons.length - 1;
+
+    // Inject a back connection: output -> hidden (illegal in forward-only).
+    discovered.synapses.push(new Synapse(outputIndex, hiddenIndex, 0.123));
+    discovered.synapses.sort((
+      a,
+      b,
+    ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+    assertThrows(
+      () =>
+        validateAfterDiscoveryOrThrow({
+          baseCreature: base,
+          discoveredCreature: discovered,
+          discoveryID: "TESTDISC",
+          operation: "unit-test",
+          feedbackLoop: false,
+        }),
+      Error,
+      "CRITICAL",
+    );
+  },
+);
+
+Deno.test(
+  "validateAfterDiscoveryOrThrow: pre-4.x forward-only repairs corruption and upgrades to 4.x",
+  () => {
+    const base = new Creature(2, 1, { layers: [{ count: 1 }] });
+    base.forwardOnly = true;
+    base.semanticVersion = "2.0.0";
+
+    const discovered = Creature.fromJSON(base.exportJSON());
+    discovered.forwardOnly = true;
+    discovered.semanticVersion = "2.0.0";
+
+    const hiddenIndex = discovered.input; // first hidden neuron
+    const outputIndex = discovered.neurons.length - 1;
+
+    // Inject a back connection: output -> hidden (illegal in forward-only, but fixable pre-4.x).
+    discovered.synapses.push(new Synapse(outputIndex, hiddenIndex, 0.123));
+    discovered.synapses.sort((
+      a,
+      b,
+    ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+    validateAfterDiscoveryOrThrow({
+      baseCreature: base,
+      discoveredCreature: discovered,
+      discoveryID: "TESTDISC",
+      operation: "unit-test",
+      feedbackLoop: false,
+    });
+
+    // Should be repaired + upgraded once forward-only is confirmed.
+    discovered.validate({ forwardOnly: true });
+    if (!discovered.semanticVersion.startsWith("4.")) {
+      throw new Error(
+        `Expected semanticVersion to be bumped to 4.x after repair, got ${discovered.semanticVersion}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "validateAfterDiscoveryOrThrow: does not throw when feedbackLoop is enabled and base is not forward-only",
+  () => {
+    const base = new Creature(2, 1, { layers: [{ count: 1 }] });
+    base.forwardOnly = false;
+    base.semanticVersion = "2.0.0";
+
+    const discovered = Creature.fromJSON(base.exportJSON());
+    discovered.forwardOnly = false;
+    discovered.semanticVersion = "2.0.0";
+
+    const hiddenIndex = discovered.input; // first hidden neuron
+    const outputIndex = discovered.neurons.length - 1;
+
+    // Back connection is allowed in recurrent mode.
+    discovered.synapses.push(new Synapse(outputIndex, hiddenIndex, 0.123));
+    discovered.synapses.sort((
+      a,
+      b,
+    ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+    validateAfterDiscoveryOrThrow({
+      baseCreature: base,
+      discoveredCreature: discovered,
+      discoveryID: "TESTDISC",
+      operation: "unit-test",
+      feedbackLoop: true,
+    });
+  },
+);

--- a/test/discovery/DiscoveryPostValidate.ts
+++ b/test/discovery/DiscoveryPostValidate.ts
@@ -3,6 +3,8 @@ import { Creature } from "../../src/Creature.ts";
 import { Synapse } from "../../src/architecture/Synapse.ts";
 import { validateAfterDiscoveryOrThrow } from "../../src/discovery/DiscoveryPostValidate.ts";
 
+// cspell:ignore TESTDISC
+
 Deno.test(
   "validateAfterDiscoveryOrThrow: throws for forward-only base when discovery result has back connection",
   () => {

--- a/test/mutate/AddConnectionForwardOnlyRepair.ts
+++ b/test/mutate/AddConnectionForwardOnlyRepair.ts
@@ -1,0 +1,58 @@
+import { assert, assertThrows } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { Synapse } from "../../src/architecture/Synapse.ts";
+import { AddConnection } from "../../src/mutate/AddConnection.ts";
+
+// cspell:ignore TESTDISC
+
+Deno.test(
+  "AddConnection: pre-4.x forwardOnly repairs self/back connections instead of throwing",
+  () => {
+    const creature = new Creature(2, 1, { layers: [{ count: 1 }] });
+    creature.forwardOnly = true;
+    creature.semanticVersion = "2.0.0";
+
+    const hiddenIndex = creature.input;
+    assert(hiddenIndex < creature.neurons.length - creature.output);
+
+    // Inject a self connection (invalid for forward-only, but tolerated pre-4.x via repair).
+    creature.synapses.push(new Synapse(hiddenIndex, hiddenIndex, 0.123));
+    creature.synapses.sort((
+      a,
+      b,
+    ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+    const mutator = new AddConnection(creature);
+    mutator.mutate();
+
+    // Should be valid forward-only after repair.
+    creature.validate({ forwardOnly: true });
+    assert(
+      creature.semanticVersion.startsWith("4."),
+      "Expected upgrade to 4.x after validation",
+    );
+  },
+);
+
+Deno.test(
+  "AddConnection: 4.x forwardOnly throws if creature is already corrupted",
+  () => {
+    const creature = new Creature(2, 1, { layers: [{ count: 1 }] });
+    creature.forwardOnly = true;
+    creature.semanticVersion = "4.0.0";
+
+    const hiddenIndex = creature.input;
+    creature.synapses.push(new Synapse(hiddenIndex, hiddenIndex, 0.123));
+    creature.synapses.sort((
+      a,
+      b,
+    ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+    const mutator = new AddConnection(creature);
+    assertThrows(
+      () => mutator.mutate(),
+      Error,
+      "CRITICAL",
+    );
+  },
+);

--- a/test/mutate/MutatorRepairsForwardOnlyFourXCorruption.ts
+++ b/test/mutate/MutatorRepairsForwardOnlyFourXCorruption.ts
@@ -17,6 +17,7 @@ import { Synapse } from "../../src/architecture/Synapse.ts";
 Deno.test("AddConnection: forward-only throws if the creature already contains a recurrent synapse", () => {
   const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
   creature.forwardOnly = true;
+  creature.semanticVersion = "4.0.0";
 
   const hiddenIndex = creature.input;
   const outputIndex = creature.neurons.length - 1;
@@ -33,7 +34,11 @@ Deno.test("AddConnection: forward-only throws if the creature already contains a
   creature.disconnect(0, hiddenIndex);
 
   const add = new AddConnection(creature);
-  assertThrows(() => add.mutate());
+  assertThrows(
+    () => add.mutate(),
+    Error,
+    "CRITICAL",
+  );
 
   // Sanity: the creature is indeed invalid forward-only due to the injected synapse.
   assertEquals(creature.getSynapse(outputIndex, hiddenIndex) !== null, true);


### PR DESCRIPTION
…ly creatures

- Bumped version in deno.json to 0.273.0.
- Introduced validation checks after synapse modifications to ensure compliance with forward-only constraints.
- Added utility functions to determine major version and enforce forward-only rules during creature modifications.
- Enhanced tests to validate that forward-only creatures do not introduce recurrent synapses, ensuring robustness in the NEAT framework.

These changes improve the integrity and reliability of the NEAT framework's handling of forward-only semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens correctness for forward-only runs and discovery outputs.
> 
> - Adds `validateAfterDiscoveryOrThrow` and invokes it in `Neat` after `addHelpfulSynapses`, `removeSynapse`, and `changeSquash`
> - Tightens `Mutator` forward-only path: crash on 4.x violations, repair+revalidate pre-4.x, filter self/back synapses if needed, then set `forwardOnly` and bump semantic version to `4.x`
> - Updates `DiscoveryCandidates` to enforce forward-only during candidate application (index mapping, filtering self/back edges) and to validate/fix with forward-only where required; bumps to `4.x` upon confirmation
> - Hardens `AddConnection` for forward-only: pre-validate, fail-fast on 4.x corruption, repair+revalidate for pre-4.x, and bump to `4.x` when confirmed
> - Adds focused tests covering forward-only repair/upgrade, IF condition preservation, discovery combinations in 4.x, and post-discovery validation
> - Misc: bump version to `0.273.0`; add `AJSON`/`BJSON` to `cspell`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f181b1ab169b77d3817ad09f0535ba32995ae02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->