### PR TITLE
Update version to 0.273.1 and adjust coverage configuration in codeco…

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,9 @@ coverage:
 # Ignore files that require external dependencies (Rust discovery library)
 # These files have low coverage in CI because the Rust extension isn't available
 ignore:
+  # Docs/config-only changes are not exercised by runtime coverage instrumentation.
+  # Keep them out of patch coverage to avoid failing PRs that only adjust tooling.
+  - "docs/cspell.json"
   - "src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts"
   - "src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts"
   - "src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts"

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.273.0",
+  "version": "0.273.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",


### PR DESCRIPTION
…v.yml

- Bumped version in deno.json to 0.273.1.
- Added an entry to codecov.yml to ignore docs/config-only changes, preventing coverage failures for tooling adjustments.

These changes improve version management and maintain coverage accuracy in the project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Versioning**
> 
> - Bump `deno.json` version from `0.273.0` to `0.273.1`.
> 
> **Coverage configuration**
> 
> - Update `codecov.yml` to ignore `docs/cspell.json` so config-only changes don't affect patch coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1145bcd6eae52082d8dc2e937c787e1369a52c9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->