### PR TITLE
Update version to 0.273.2 and enhance forward-only validation logic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.273.1",
+  "version": "0.273.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -293,13 +293,19 @@ export class Mutator {
 
       // Forward-only mode: if the creature is marked forward-only or the run is not using
       // feedback loops, ensure mutations can't accidentally keep recurrent connections.
-      if (this.config.feedbackLoop !== true || creature.forwardOnly === true) {
+      //
+      // Important: semanticVersion 4.x is a hard forward-only
+      // invariant, even if `creature.forwardOnly` is missing (legacy state/export).
+      const enforceForwardOnly = this.config.feedbackLoop !== true ||
+        creature.forwardOnly === true ||
+        majorVersion >= 4;
+      if (enforceForwardOnly) {
         try {
           creature.validate({ forwardOnly: true });
 
           // In forward-only runs, most creatures should already be valid. Once we
           // confirm that (via validation), mark + upgrade without requiring a fix().
-          if (this.config.feedbackLoop !== true) {
+          if (this.config.feedbackLoop !== true || majorVersion >= 4) {
             creature.forwardOnly = true;
           }
           if (creature.forwardOnly === true) {
@@ -368,7 +374,7 @@ export class Mutator {
               creature.clearCache();
               // After filtering recurrent synapses, run a forward-only fix pass again.
               //
-              // Rationale (Australian English): filtering can remove a required IF
+              // Rationale:filtering can remove a required IF
               // connection (or other structural invariant). Running fix() here is
               // acceptable because this is *repair*, not candidate generation.
               creature.fix({ forwardOnly: true });

--- a/src/architecture/ErrorGuidedStructuralEvolution/SubmitDiscoveryRecordBatch.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/SubmitDiscoveryRecordBatch.ts
@@ -3,7 +3,7 @@ import type { DataRecordInterface } from "../DataSet.ts";
 /**
  * Submits a buffered discovery recording batch in a non-destructive way.
  *
- * Why (Australian English): The directory recorder buffers samples and then
+ * Why:The directory recorder buffers samples and then
  * submits them to `DiscoverStructure.record()`. Under tight deadlines, a timeout
  * race can cause `record()` to return false even after the caller has decided to
  * flush. If we clear buffers before knowing `record()` accepted the data, we can

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -347,7 +347,7 @@ export class Neuron implements TagsInterface, NeuronInternal {
     // Forward-only safety: never create a self-loop as a "last resort" outward
     // connection when the creature is explicitly marked as forward-only.
     //
-    // Rationale (Australian English): self-loops are valid in recurrent/memory
+    // Rationale:self-loops are valid in recurrent/memory
     // mode, but they must not be introduced during `fix()` for forward-only
     // creatures.
     const isForwardOnly = this.creature.forwardOnly === true;

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -64,7 +64,7 @@ function getMajorVersion(version: string | undefined): number {
 /**
  * Upgrade 2.x/3.x creatures to 4.x once forward-only validity is confirmed.
  *
- * Rationale (Australian English): forward-only became a hard invariant in 4.x.
+ * Rationale:forward-only became a hard invariant in 4.x.
  * We should mark a creature as 4.x whenever we have just validated it as
  * forward-only, even if no repair was needed, so downstream logic treats
  * structurally identical creatures consistently.

--- a/src/mutate/AddConnection.ts
+++ b/src/mutate/AddConnection.ts
@@ -73,7 +73,7 @@ export class AddConnection implements RadioactiveInterface {
 
       // Forward-only invariant: neuron indices must be consistent.
       //
-      // Rationale (Australian English): if `neuron.index` does not match its
+      // Rationale:if `neuron.index` does not match its
       // position in the `creature.neurons[]` array, the creature is corrupted.
       // In forward-only mode we must fail fast rather than attempting to
       // continue in a partially-valid state.

--- a/src/propagate/RecordElasticity.ts
+++ b/src/propagate/RecordElasticity.ts
@@ -54,7 +54,7 @@ const HARD_RANGE_SQUASHES = new Set<string>([
 // During record-time attribution (Explorer/discovery analysis), we prefer to
 // avoid pushing these squashes negative when there is an alternative synapse.
 //
-// Rationale (Australian English): while some of these can technically output
+// Rationale:while some of these can technically output
 // negative values, pushing them negative during attribution can create large,
 // misleading neuron-level errors that then get redistributed elsewhere.
 const NEGATIVE_RESIST_SQUASHES = new Set<string>([

--- a/test/NEAT/MutatorForwardOnlySemanticVersion.ts
+++ b/test/NEAT/MutatorForwardOnlySemanticVersion.ts
@@ -1,0 +1,54 @@
+import { assertThrows } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+import { Mutation } from "../../src/NEAT/Mutation.ts";
+
+/**
+ * Regression test (26-Dec-2025).
+ *
+ * Bug: semanticVersion 4.x is a hard forward-only invariant, but some older
+ * code paths only enforced forward-only when `creature.forwardOnly === true`.
+ * This allowed a 4.x creature (missing the forwardOnly flag) to be mutated in
+ * feedbackLoop mode, introducing recurrent connections that later crashed
+ * during breeding/upgrade validation.
+ *
+ * Expected: Mutator must enforce forward-only for semanticVersion 4.x creatures
+ * even when the `forwardOnly` flag is missing.
+ */
+Deno.test("Mutator: semanticVersion 4.x enforces forward-only even without forwardOnly flag", () => {
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    semanticVersion: "4.0.0",
+    // Intentionally omit forwardOnly: true to simulate legacy exports/state.
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json);
+
+  const config = createNeatConfig({
+    // feedbackLoop=true makes this an easy reproduction: without enforcing
+    // semanticVersion 4.x, mutations like ADD_SELF_CONN can introduce
+    // recurrent synapses into a 4.x creature.
+    feedbackLoop: true,
+    mutationRate: 1,
+    mutationAmount: 1,
+  });
+  const mutator = new Mutator(config);
+
+  assertThrows(
+    () => mutator.mutateCreature(creature, Mutation.ADD_SELF_CONN),
+    Error,
+    "CRITICAL",
+  );
+});


### PR DESCRIPTION
- Bumped version in deno.json to 0.273.2.
- Improved validation logic in the Mutator class to enforce forward-only constraints, including handling legacy states.
- Refined comments for clarity regarding forward-only semantics and rationale for structural invariants.

These changes strengthen the integrity of the NEAT framework's handling of forward-only semantics and improve code clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens forward-only guarantees to prevent recurrent/self connections slipping into 4.x creatures.
> 
> - Enforces forward-only in `Mutator.mutateCreature` based on `semanticVersion>=4` even if `forwardOnly` is missing; validates, repairs pre-4.x, and crashes on 4.x violations; upgrades 2.x/3.x to 4.x when confirmed
> - Hardens `AddConnection` with pre/post forward-only validation, index consistency checks, and conditional repair/upgrade logic
> - Adds regression test `MutatorForwardOnlySemanticVersion.ts` to ensure 4.x forward-only is enforced without the flag
> - Bumps `deno.json` version to `0.273.2`; minor comment cleanups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff282a0825db8a008ff866166794c947b6084902. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->