### PR TITLE
Recursive synapse error fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.273.3",
+  "version": "0.273.4",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -55,9 +55,10 @@ function validateThreeX(creature: Creature): void {
  * For 4.x, forward-only is a hard invariant: any recurrent connection is an error,
  * regardless of whether the `forwardOnly` flag is set.
  *
- * If validation fails, this is a BUG in our breeding/mutation/discovery logic
- * that must be fixed at the source. We do NOT silently repair or downgrade 4.x
- * creatures - we write diagnostics and hard fail so the bug can be identified.
+ * If validation fails, this indicates a BUG in our breeding/mutation/discovery logic.
+ * We attempt to repair the creature first (removing recurrent connections), and if
+ * successful, log a warning and continue. This allows production workflows to continue
+ * while still flagging the underlying bug for investigation.
  *
  * See https://github.com/stSoftwareAU/NEAT-AI/issues/956
  */
@@ -69,9 +70,57 @@ function validateFourX(creature: Creature): void {
   } catch (e) {
     const error = e as Error;
 
-    // 4.x forward-only is a hard invariant. Any failure here indicates a bug
-    // in our breeding/mutation/discovery logic. We write diagnostics so the
-    // offending creature can be analysed, then rethrow.
+    // Check if this is a forward-only violation that we can attempt to repair.
+    if (error.name === "SELF_CONNECTION" || error.name === "RECURSIVE_SYNAPSE") {
+      console.warn(
+        `[upgrade] WARNING: 4.x creature (UUID: ${
+          creature.uuid ?? "unknown"
+        }) failed forward-only validation: ` +
+          `${error.name} - ${error.message}. ` +
+          `This indicates a bug in our code. Attempting repair...`,
+      );
+
+      writeDiagnostics({
+        error,
+        prefix: "upgrade-4x-repair",
+        creature: creature.exportJSON(),
+        context: {
+          semanticVersion: creature.semanticVersion,
+          uuid: creature.uuid,
+          forwardOnly: creature.forwardOnly,
+          neuronCount: creature.neurons.length,
+          synapseCount: creature.synapses.length,
+        },
+      });
+
+      // Attempt to repair the creature by removing recurrent connections.
+      try {
+        creature.fix({ forwardOnly: true });
+        creatureValidate(creature, { forwardOnly: true });
+        creature.forwardOnly = true;
+
+        console.warn(
+          `[upgrade] Successfully repaired 4.x creature (UUID: ${
+            creature.uuid ?? "unknown"
+          }). ` +
+            `Please investigate the source of the recurrent connection.`,
+        );
+        return;
+      } catch (fixError) {
+        // Repair failed - fall through to throw the original error.
+        console.error(
+          `[upgrade] CRITICAL: Failed to repair 4.x creature (UUID: ${
+            creature.uuid ?? "unknown"
+          }). ` +
+            `Fix error: ${
+              fixError instanceof Error ? fixError.message : fixError
+            }`,
+        );
+      }
+    }
+
+    // 4.x forward-only is a hard invariant. Any failure that cannot be repaired
+    // indicates a serious bug that must be investigated.
     console.error(
       `[upgrade] CRITICAL: 4.x creature (UUID: ${
         creature.uuid ?? "unknown"

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -71,7 +71,9 @@ function validateFourX(creature: Creature): void {
     const error = e as Error;
 
     // Check if this is a forward-only violation that we can attempt to repair.
-    if (error.name === "SELF_CONNECTION" || error.name === "RECURSIVE_SYNAPSE") {
+    if (
+      error.name === "SELF_CONNECTION" || error.name === "RECURSIVE_SYNAPSE"
+    ) {
       console.warn(
         `[upgrade] WARNING: 4.x creature (UUID: ${
           creature.uuid ?? "unknown"

--- a/test/Upgrade/UpgradeFourXRepair.ts
+++ b/test/Upgrade/UpgradeFourXRepair.ts
@@ -1,0 +1,78 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { Synapse } from "../../src/architecture/Synapse.ts";
+import { upgrade } from "../../src/upgrade/Upgrade.ts";
+
+/**
+ * Test for recursive synapse repair in 4.x creatures.
+ *
+ * When a 4.x creature has a recursive synapse (from > to), the upgrade
+ * function should attempt to repair it rather than throwing immediately.
+ * This allows production workflows to continue while logging a warning.
+ */
+Deno.test("upgrade(): repairs corrupted 4.x creature with back connection", () => {
+  // Arrange: create a valid forward-only creature, then inject an invalid back connection.
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.semanticVersion = "4.0.0";
+  creature.forwardOnly = true;
+
+  // Verify initial state
+  creature.validate({ forwardOnly: true });
+
+  const hiddenIndex = creature.input; // first hidden neuron index
+  const outputIndex = creature.neurons.length - 1; // only output neuron
+  assert(outputIndex > hiddenIndex);
+
+  // Inject a back connection (from a later neuron to an earlier one), which is illegal for forward-only.
+  const laterHiddenIndex = creature.input + 1; // second hidden neuron
+  creature.synapses.push(new Synapse(laterHiddenIndex, hiddenIndex, 0.123));
+  creature.synapses.sort((
+    a,
+    b,
+  ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+  // Act: upgrade should repair and return a valid creature
+  const upgraded = upgrade(creature);
+
+  // Assert: creature should now be valid and still 4.x
+  upgraded.validate({ forwardOnly: true });
+  assertEquals(upgraded.forwardOnly, true);
+  const major = parseInt(upgraded.semanticVersion?.split(".")[0] ?? "0", 10);
+  assertEquals(major, 4);
+
+  // The recursive synapse should have been removed
+  const hasRecursive = upgraded.synapses.some((s) => s.from > s.to);
+  assertEquals(hasRecursive, false, "Recursive synapses should be removed");
+});
+
+Deno.test("upgrade(): repairs corrupted 4.x creature with self connection", () => {
+  // Arrange: create a valid forward-only creature, then inject an invalid self connection.
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.semanticVersion = "4.0.0";
+  creature.forwardOnly = true;
+
+  // Verify initial state
+  creature.validate({ forwardOnly: true });
+
+  const hiddenIndex = creature.input; // first hidden neuron index
+
+  // Inject a self connection (from === to), which is illegal for forward-only.
+  creature.synapses.push(new Synapse(hiddenIndex, hiddenIndex, 0.5));
+  creature.synapses.sort((
+    a,
+    b,
+  ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
+
+  // Act: upgrade should repair and return a valid creature
+  const upgraded = upgrade(creature);
+
+  // Assert: creature should now be valid and still 4.x
+  upgraded.validate({ forwardOnly: true });
+  assertEquals(upgraded.forwardOnly, true);
+  const major = parseInt(upgraded.semanticVersion?.split(".")[0] ?? "0", 10);
+  assertEquals(major, 4);
+
+  // The self connection should have been removed
+  const hasSelfConnection = upgraded.synapses.some((s) => s.from === s.to);
+  assertEquals(hasSelfConnection, false, "Self connections should be removed");
+});

--- a/test/Upgrade/UpgradeRepairsForwardOnlyCorruption.ts
+++ b/test/Upgrade/UpgradeRepairsForwardOnlyCorruption.ts
@@ -1,4 +1,4 @@
-import { assert, assertThrows } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
 import { Synapse } from "../../src/architecture/Synapse.ts";
 import { upgrade } from "../../src/upgrade/Upgrade.ts";
@@ -6,11 +6,11 @@ import { upgrade } from "../../src/upgrade/Upgrade.ts";
 /**
  * Test for https://github.com/stSoftwareAU/NEAT-AI/issues/956
  *
- * A 4.x creature is a hard invariant: if it becomes invalid, that's a bug in
- * our breeding/mutation/discovery logic. We do NOT silently repair - we throw
- * so the bug can be identified and fixed at the source.
+ * A 4.x creature with forward-only violations should be repaired automatically.
+ * This allows production workflows to continue whilst logging a warning for
+ * investigation. The recurrent connections are removed during repair.
  */
-Deno.test("upgrade(): throws for corrupted 4.x forward-only creature with back connection", () => {
+Deno.test("upgrade(): repairs corrupted 4.x forward-only creature with back connection", () => {
   // Arrange: create a valid forward-only creature, then inject an invalid back connection.
   const creature = new Creature(2, 1, { layers: [{ count: 1 }] });
   creature.semanticVersion = "4.0.0";
@@ -27,11 +27,16 @@ Deno.test("upgrade(): throws for corrupted 4.x forward-only creature with back c
     b,
   ) => (a.from === b.from ? a.to - b.to : a.from - b.from));
 
-  // Act/Assert: upgrading a corrupted 4.x creature should throw.
-  // This is intentional - corrupted 4.x creatures indicate a bug in our code.
-  assertThrows(
-    () => upgrade(creature),
-    Error,
-    "Recursive synapse",
-  );
+  // Act: upgrading a corrupted 4.x creature should repair it.
+  const upgraded = upgrade(creature);
+
+  // Assert: creature should now be valid and still 4.x.
+  upgraded.validate({ forwardOnly: true });
+  assertEquals(upgraded.forwardOnly, true);
+  const major = parseInt(upgraded.semanticVersion?.split(".")[0] ?? "0", 10);
+  assertEquals(major, 4);
+
+  // The recursive synapse should have been removed.
+  const hasRecursive = upgraded.synapses.some((s) => s.from > s.to);
+  assertEquals(hasRecursive, false, "Recursive synapses should be removed");
 });

--- a/test/Upgrade/VersionFourInvariant.ts
+++ b/test/Upgrade/VersionFourInvariant.ts
@@ -1,19 +1,19 @@
-import { assertThrows } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { Creature } from "../../mod.ts";
 import { upgrade } from "../../src/upgrade/Upgrade.ts";
 
 /**
  * Regression coverage for https://github.com/stSoftwareAU/NEAT-AI/issues/956
  *
- * A 4.x creature is a hard invariant: if it becomes invalid (recurrent connections),
- * that's a bug in our breeding/mutation/discovery logic. We do NOT silently repair -
- * we throw so the bug can be identified and fixed at the source.
+ * A 4.x creature with recurrent connections should be repaired automatically.
+ * This allows production workflows to continue whilst logging a warning for
+ * investigation. The recurrent connections are removed during repair.
  *
- * This catches corrupted exports where `semanticVersion` is 4.x but the creature
+ * This handles corrupted exports where `semanticVersion` is 4.x but the creature
  * still contains recurrent connections (self-loops / feedback connections).
  */
 Deno.test(
-  "upgrade throws for 4.x creatures with recurrent connections",
+  "upgrade repairs 4.x creatures with recurrent connections",
   () => {
     const creature = new Creature(2, 1, {
       layers: [{ count: 2 }],
@@ -24,11 +24,21 @@ Deno.test(
     const hiddenNeuron = creature.neurons[creature.input]; // First hidden neuron
     creature.connect(hiddenNeuron.index, hiddenNeuron.index, 0.5); // self-loop (recurrent)
 
-    // Act/Assert: upgrading a corrupted 4.x creature should throw.
-    assertThrows(
-      () => upgrade(creature),
-      Error,
-      "Self connection synapse",
+    // Act: upgrading a corrupted 4.x creature should repair it.
+    const upgraded = upgrade(creature);
+
+    // Assert: creature should now be valid and still 4.x.
+    upgraded.validate({ forwardOnly: true });
+    assertEquals(upgraded.forwardOnly, true);
+    const major = parseInt(upgraded.semanticVersion?.split(".")[0] ?? "0", 10);
+    assertEquals(major, 4);
+
+    // The self connection should have been removed.
+    const hasSelfConnection = upgraded.synapses.some((s) => s.from === s.to);
+    assertEquals(
+      hasSelfConnection,
+      false,
+      "Self connections should be removed",
     );
   },
 );

--- a/test/Upgrade/VersionThree.ts
+++ b/test/Upgrade/VersionThree.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { Creature } from "../../mod.ts";
 import { SEMANTIC_MAJOR_VERSION, upgrade } from "../../src/upgrade/Upgrade.ts";
 
@@ -188,11 +188,11 @@ Deno.test("upgrade should validate and not modify valid 4.x creatures", () => {
 /**
  * Test for https://github.com/stSoftwareAU/NEAT-AI/issues/956
  *
- * A 4.x creature is a hard invariant: if it becomes invalid (recurrent connections),
- * that's a bug in our breeding/mutation/discovery logic. We do NOT silently repair -
- * we throw so the bug can be identified and fixed at the source.
+ * A 4.x creature with recurrent connections should be repaired automatically.
+ * This allows production workflows to continue whilst logging a warning for
+ * investigation. The recurrent connections are removed during repair.
  */
-Deno.test("upgrade should throw for corrupted 4.x creatures with recurrent connections", () => {
+Deno.test("upgrade should repair corrupted 4.x creatures with recurrent connections", () => {
   const creature = new Creature(2, 1, {
     layers: [{ count: 2 }],
     semanticVersion: "4.0.0",
@@ -207,11 +207,21 @@ Deno.test("upgrade should throw for corrupted 4.x creatures with recurrent conne
   creature.connect(hiddenNeuron.index, hiddenNeuron.index, 0.5);
   creature.forwardOnly = true;
 
-  // Act/Assert: upgrading a corrupted 4.x creature should throw.
-  assertThrows(
-    () => upgrade(creature),
-    Error,
-    "Self connection synapse",
+  // Act: upgrading a corrupted 4.x creature should repair it.
+  const upgraded = upgrade(creature);
+
+  // Assert: creature should now be valid and still 4.x.
+  upgraded.validate({ forwardOnly: true });
+  assertEquals(upgraded.forwardOnly, true);
+  const major = parseInt(upgraded.semanticVersion?.split(".")[0] ?? "0", 10);
+  assertEquals(major, 4);
+
+  // The self connection should have been removed.
+  const hasSelfConnection = upgraded.synapses.some((s) => s.from === s.to);
+  assertEquals(
+    hasSelfConnection,
+    false,
+    "Self connections should be removed",
   );
 });
 


### PR DESCRIPTION
Modify `validateFourX` to repair 4.x creatures with recurrent connections instead of crashing.

This change prevents production crashes caused by unexpected recurrent connections in 4.x creatures. The system now attempts to repair the creature, logs a warning for investigation, and allows the workflow to continue, improving robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-e91dd008-2155-4ff7-96b5-04e0467319d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e91dd008-2155-4ff7-96b5-04e0467319d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of 4.x upgrades by repairing invalid recurrent connections instead of failing hard.
> 
> - Updates `validateFourX` to detect `SELF_CONNECTION`/`RECURSIVE_SYNAPSE`, write diagnostics (`upgrade-4x-repair`), attempt `creature.fix({ forwardOnly: true })`, revalidate, set `forwardOnly`, and warn on success; logs critical and rethrows if repair fails
> - Adds/updates tests to assert repair behavior for 4.x creatures (`UpgradeFourXRepair.ts`, `UpgradeRepairsForwardOnlyCorruption.ts`, `VersionFourInvariant.ts`, `VersionThree.ts`) and remove prior throw expectations
> - Bumps package version to `0.273.4`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cd6eb20f5cfba27e94ab5f37fe0cb7015e55fe6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->