### PR TITLE
Bent identity safeszone

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.273.4",
+  "version": "0.274.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -27,8 +27,8 @@ import {
 import { distributeElasticError } from "../propagate/ElasticDistribution.ts";
 import {
   buildRecordElasticLinks,
+  constrainAndRedistributeRecordShares,
   distributeRecordError,
-  recordTargetFeasibilityFactor,
 } from "../propagate/RecordElasticity.ts";
 import type { SparseConfig } from "../propagate/sparse/SparseConfig.ts";
 import {
@@ -840,104 +840,32 @@ export class Neuron implements TagsInterface, NeuronInternal {
             },
           );
 
-          // Hard guard: do not request impossible (or strongly undesired) target
-          // activations from upstream squashes.
-          //
-          // Important: when we redistribute blocked error, we must re-check
-          // feasibility because a previously-feasible link can become infeasible
-          // after it absorbs additional share (regression test:
-          // `RedistributedBlockedErrorMaintainsFeasibility.ts`).
-          //
-          // This avoids "hidden" clamping in `Neuron.record()` turning an
-          // impossible target (eg. negative for ABSOLUTE/ReLU) into a large,
-          // misleading error that then pollutes discovery metrics.
           const plankConstant = 1e-12;
 
-          let workingLinks: ReadonlyArray<(typeof chosenLinks)[number]> =
-            chosenLinks;
-          let workingShares: number[] = shares.slice();
+          // Clamp each per-link share to what its upstream squash can actually
+          // accept (or what we strongly prefer), then redistribute residue.
+          //
+          // Example: ABSOLUTE ∈ [0, +∞). If a share implies a negative target,
+          // we clamp to the boundary (target=0) and push the remaining error
+          // into other links.
+          const constrainedShares = constrainAndRedistributeRecordShares(
+            error,
+            chosenLinks,
+            shares,
+            { plankConstant },
+          );
 
-          // Iterate until stable: each loop removes at least one infeasible link
-          // (or terminates), so this always finishes in <= number of links.
-          for (let pass = 0; pass < chosenLinks.length + 1; pass++) {
-            const feasibleLinks: Array<(typeof chosenLinks)[number]> = [];
-            const feasibleShares: number[] = [];
-            let blockedError = 0;
-
-            for (let i = 0; i < workingLinks.length; i++) {
-              const link = workingLinks[i];
-              const share = workingShares[i] ?? 0;
-              if (
-                !Number.isFinite(share) || Math.abs(share) <= plankConstant
-              ) {
-                continue;
-              }
-
-              // Safe-zone hard guard: if a parent is fully blocked (eg. deeply
-              // saturated ArcTan), do not recurse into it. If all parents are
-              // blocked, we stop recursion rather than forcing an equal-split
-              // attribution that would generate huge, misleading errors.
-              if (
-                !Number.isFinite(link.safeZoneFactor) ||
-                link.safeZoneFactor <= 0
-              ) {
-                blockedError += share;
-                continue;
-              }
-
-              const fromNeuron = link.fromNeuron;
-              const weight = link.synapse.weight;
-              if (!weight) continue;
-
-              const targetFromValue = link.fromValue + share;
-              const targetFromActivation = targetFromValue / weight;
-
-              const feasibility = recordTargetFeasibilityFactor(
-                fromNeuron,
-                targetFromActivation,
-              );
-              if (feasibility <= 0) {
-                blockedError += share;
-                continue;
-              }
-
-              feasibleLinks.push(link);
-              feasibleShares.push(share);
-            }
-
-            // Nothing to redistribute, or nowhere feasible to put it.
-            if (
-              Math.abs(blockedError) <= plankConstant ||
-              feasibleLinks.length === 0
-            ) {
-              workingLinks = feasibleLinks;
-              workingShares = feasibleShares;
-              break;
-            }
-
-            // Reallocate the blocked value-space share across feasible links.
-            const { shares: redistributed } = distributeRecordError(
-              blockedError,
-              feasibleLinks,
-              {
-                plankConstant,
-                allowEqualFallback: true,
-              },
-            );
-            for (let i = 0; i < redistributed.length; i++) {
-              feasibleShares[i] = (feasibleShares[i] ?? 0) +
-                (redistributed[i] ?? 0);
-            }
-
-            // Re-check feasibility after redistribution on the next pass.
-            workingLinks = feasibleLinks;
-            workingShares = feasibleShares;
-          }
-
-          for (let i = 0; i < workingLinks.length; i++) {
-            const link = workingLinks[i];
-            const share = workingShares[i] ?? 0;
+          for (let i = 0; i < chosenLinks.length; i++) {
+            const link = chosenLinks[i];
+            const share = constrainedShares[i] ?? 0;
             if (!Number.isFinite(share) || Math.abs(share) <= plankConstant) {
+              continue;
+            }
+
+            // Safe-zone hard guard: do not recurse into fully blocked parents.
+            if (
+              !Number.isFinite(link.safeZoneFactor) || link.safeZoneFactor <= 0
+            ) {
               continue;
             }
 
@@ -947,14 +875,6 @@ export class Neuron implements TagsInterface, NeuronInternal {
 
             const targetFromValue = link.fromValue + share;
             const targetFromActivation = targetFromValue / weight;
-
-            // Final safety check in case of floating point edge-cases.
-            if (
-              recordTargetFeasibilityFactor(fromNeuron, targetFromActivation) <=
-                0
-            ) {
-              continue;
-            }
 
             fromNeuron.record(targetFromActivation, discoverMap);
           }

--- a/src/methods/activations/aggregate/IF.ts
+++ b/src/methods/activations/aggregate/IF.ts
@@ -15,8 +15,8 @@ import {
 import { accumulateBias, adjustedBias } from "../../../propagate/Bias.ts";
 import {
   buildRecordElasticLinks,
+  constrainAndRedistributeRecordShares,
   distributeRecordError,
-  recordTargetFeasibilityFactor,
 } from "../../../propagate/RecordElasticity.ts";
 import type { SparseConfig } from "../../../propagate/sparse/SparseConfig.ts";
 import { accumulateWeight, adjustedWeight } from "../../../propagate/Weight.ts";
@@ -561,87 +561,27 @@ export class IF
 
     const plankConstant = 1e-12;
 
-    let workingLinks: ReadonlyArray<(typeof chosenLinks)[number]> = chosenLinks;
-    let workingShares: number[] = shares.slice();
+    const constrainedShares = constrainAndRedistributeRecordShares(
+      error,
+      chosenLinks,
+      shares,
+      { plankConstant },
+    );
 
-    // Mirror `Neuron.record()` feasibility + safe-zone guards:
-    // - do not request impossible targets (range/negative constraints)
-    // - do not recurse into fully blocked parents (safeZoneFactor <= 0)
-    // - if blocked shares exist, redistribute and re-check until stable
-    for (let pass = 0; pass < chosenLinks.length + 1; pass++) {
-      const feasibleLinks: Array<(typeof chosenLinks)[number]> = [];
-      const feasibleShares: number[] = [];
-      let blockedError = 0;
-
-      for (let i = 0; i < workingLinks.length; i++) {
-        const link = workingLinks[i];
-        const share = workingShares[i] ?? 0;
-        if (!Number.isFinite(share) || Math.abs(share) <= plankConstant) {
-          continue;
-        }
-
-        if (!Number.isFinite(link.safeZoneFactor) || link.safeZoneFactor <= 0) {
-          blockedError += share;
-          continue;
-        }
-
-        const fromNeuron = link.fromNeuron;
-        const weight = link.synapse.weight;
-        if (!weight) continue;
-
-        const targetFromValue = link.fromValue + share;
-        const targetFromActivation = targetFromValue / weight;
-
-        const feasibility = recordTargetFeasibilityFactor(
-          fromNeuron,
-          targetFromActivation,
-        );
-        if (feasibility <= 0) {
-          blockedError += share;
-          continue;
-        }
-
-        feasibleLinks.push(link);
-        feasibleShares.push(share);
-      }
-
-      if (
-        Math.abs(blockedError) <= plankConstant || feasibleLinks.length === 0
-      ) {
-        workingLinks = feasibleLinks;
-        workingShares = feasibleShares;
-        break;
-      }
-
-      const { shares: redistributed } = distributeRecordError(
-        blockedError,
-        feasibleLinks,
-        { plankConstant, allowEqualFallback: true },
-      );
-      for (let i = 0; i < redistributed.length; i++) {
-        feasibleShares[i] = (feasibleShares[i] ?? 0) + (redistributed[i] ?? 0);
-      }
-
-      workingLinks = feasibleLinks;
-      workingShares = feasibleShares;
-    }
-
-    for (let i = 0; i < workingLinks.length; i++) {
-      const link = workingLinks[i];
-      const share = workingShares[i] ?? 0;
+    for (let i = 0; i < chosenLinks.length; i++) {
+      const link = chosenLinks[i];
+      const share = constrainedShares[i] ?? 0;
       if (!Number.isFinite(share) || Math.abs(share) <= plankConstant) continue;
+
+      if (!Number.isFinite(link.safeZoneFactor) || link.safeZoneFactor <= 0) {
+        continue;
+      }
 
       const weight = link.synapse.weight;
       if (!weight) continue;
 
       const targetFromValue = link.fromValue + share;
       const targetFromActivation = targetFromValue / weight;
-      if (
-        recordTargetFeasibilityFactor(link.fromNeuron, targetFromActivation) <=
-          0
-      ) {
-        continue;
-      }
 
       link.fromNeuron.record(targetFromActivation, discoverMap);
     }

--- a/src/propagate/RecordElasticity.ts
+++ b/src/propagate/RecordElasticity.ts
@@ -75,15 +75,18 @@ export function recordTargetFeasibilityFactor(
   const range = squash.range;
   const name = squash.getName();
 
-  // Hard feasibility: if the target activation is outside the squash output
-  // range, treat it as impossible for selected squashes where clamping hides
-  // impossibility and inflates discovery metrics.
+  // Preference weighting (NOT hard blocking):
+  //
+  // For some squashes, requesting out-of-range targets (or strongly undesirable
+  // targets) can inflate record-time error attribution. We bias away from these
+  // paths, but we do not hard-block them here because we support “partial”
+  // allocation (clamp to feasible boundary + redistribute residue).
   if (HARD_RANGE_SQUASHES.has(name)) {
     if (
       targetActivation < range.low - RECORD_TARGET_EPSILON ||
       targetActivation > range.high + RECORD_TARGET_EPSILON
     ) {
-      return 0;
+      return 0.1;
     }
   }
 
@@ -93,10 +96,147 @@ export function recordTargetFeasibilityFactor(
     NEGATIVE_RESIST_SQUASHES.has(name) &&
     targetActivation < -RECORD_TARGET_EPSILON
   ) {
-    return 0;
+    return 0.1;
   }
 
   return 1;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}
+
+/**
+ * Clamp + redistribute record-time shares so we never request impossible (or
+ * strongly undesirable) upstream activation targets.
+ *
+ * Example: ABSOLUTE has activation range [0, +∞). If a link’s allocated share
+ * would imply a negative target activation, we clamp that share to the
+ * boundary (target=0) and redistribute the leftover error to other links.
+ */
+export function constrainAndRedistributeRecordShares(
+  error: number,
+  links: ReadonlyArray<RecordElasticLink>,
+  shares: ReadonlyArray<number>,
+  options?: Readonly<{
+    plankConstant?: number;
+  }>,
+): number[] {
+  const plankConstant = options?.plankConstant ?? 1e-12;
+  const workingShares = shares.slice();
+
+  // Preallocate bounds arrays for stability / perf.
+  const minShareBound = new Array<number>(links.length);
+  const maxShareBound = new Array<number>(links.length);
+
+  for (let pass = 0; pass < links.length + 2; pass++) {
+    let sum = 0;
+
+    // Clamp each share to what its upstream squash can accept.
+    for (let i = 0; i < links.length; i++) {
+      const link = links[i];
+      const weight = link.synapse.weight;
+      const fromNeuron = link.fromNeuron;
+      const fromValue = link.fromValue;
+
+      let minTarget = -Infinity;
+      let maxTarget = Infinity;
+
+      if (
+        fromNeuron.type !== "input" &&
+        fromNeuron.type !== "constant"
+      ) {
+        const squash = fromNeuron.findSquash();
+        const name = squash.getName();
+
+        if (HARD_RANGE_SQUASHES.has(name)) {
+          minTarget = squash.range.low;
+          maxTarget = squash.range.high;
+        } else if (NEGATIVE_RESIST_SQUASHES.has(name)) {
+          // Soft preference: avoid going negative when alternatives exist.
+          minTarget = Math.max(0, squash.range.low);
+          maxTarget = squash.range.high;
+        }
+      }
+
+      let minShare = -Infinity;
+      let maxShare = Infinity;
+
+      // If we cannot recurse meaningfully (no weight / blocked safe-zone),
+      // clamp to 0 share.
+      const gate = Math.max(
+        0,
+        Math.min(1, link.safeZoneFactor * link.feasibilityFactor),
+      );
+      if (!weight || !Number.isFinite(weight) || gate <= plankConstant) {
+        minShare = 0;
+        maxShare = 0;
+      } else {
+        const a = Number.isFinite(minTarget)
+          ? (weight * minTarget - fromValue)
+          : -Infinity;
+        const b = Number.isFinite(maxTarget)
+          ? (weight * maxTarget - fromValue)
+          : Infinity;
+        minShare = Math.min(a, b);
+        maxShare = Math.max(a, b);
+      }
+
+      minShareBound[i] = minShare;
+      maxShareBound[i] = maxShare;
+
+      const s = Number.isFinite(workingShares[i]) ? workingShares[i] : 0;
+      const clampedShare = clamp(s, minShare, maxShare);
+      workingShares[i] = clampedShare;
+      sum += clampedShare;
+    }
+
+    // Leftover value-space error after clamping.
+    const residue = error - sum;
+    if (!Number.isFinite(residue) || Math.abs(residue) <= plankConstant) {
+      break;
+    }
+
+    // Find links that still have capacity to absorb residue in the required direction.
+    const eligibleLinks: RecordElasticLink[] = [];
+    const eligibleIndex: number[] = [];
+    for (let i = 0; i < links.length; i++) {
+      const s = workingShares[i] ?? 0;
+      if (residue > 0) {
+        if (s < (maxShareBound[i] ?? 0) - plankConstant) {
+          eligibleLinks.push(links[i]);
+          eligibleIndex.push(i);
+        }
+      } else {
+        if (s > (minShareBound[i] ?? 0) + plankConstant) {
+          eligibleLinks.push(links[i]);
+          eligibleIndex.push(i);
+        }
+      }
+    }
+
+    if (eligibleLinks.length === 0) {
+      break;
+    }
+
+    // Redistribute residue across remaining-capacity links using elasticity.
+    const { shares: redistributed } = distributeRecordError(
+      residue,
+      eligibleLinks,
+      {
+        plankConstant,
+        allowEqualFallback: true,
+      },
+    );
+    for (let j = 0; j < eligibleIndex.length; j++) {
+      const idx = eligibleIndex[j];
+      workingShares[idx] = (workingShares[idx] ?? 0) + (redistributed[j] ?? 0);
+    }
+  }
+
+  return workingShares;
 }
 
 export function getOrComputeRecordValue(
@@ -232,8 +372,20 @@ export function distributeRecordError(
     return { links, shares: new Array(links.length).fill(0) };
   }
 
+  // IMPORTANT:
+  // Training-time elasticity uses activation² because it approximates the
+  // minimum L2 *weight-change* solution for achieving a target Δv:
+  //   minimise Σ(Δw_i²) s.t. Σ(a_i Δw_i) = Δv  => shares ∝ a_i²
+  //
+  // Record-time attribution recursively calls `fromNeuron.record(targetActivation)`,
+  // i.e. it implies changing *upstream activations*, not weights. For changing
+  // activations, the analogous minimum L2 solution is:
+  //   minimise Σ(Δa_i²) s.t. Σ(w_i Δa_i) = Δv  => shares ∝ w_i²
+  //
+  // This prevents “exploding” implied targets when a link has a tiny weight:
+  //   targetFromActivation = (fromValue + share) / weight.
   const meta = links.map((l) => ({
-    activation: l.fromActivation,
+    activation: Math.abs(l.synapse.weight),
     safeZoneFactor: l.safeZoneFactor * l.feasibilityFactor,
   }));
 

--- a/test/propagate/record/ElasticRecordAvoidsTinyWeight.ts
+++ b/test/propagate/record/ElasticRecordAvoidsTinyWeight.ts
@@ -1,0 +1,55 @@
+import { assert } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { IDENTITY } from "../../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test("record: avoids attributing error to tiny-weight links", () => {
+  // If record attribution pushes value-space error into a link with an extremely
+  // small weight, the implied upstream activation target becomes enormous:
+  //   targetFromActivation = (fromValue + share) / weight
+  //
+  // This test creates two parallel parents feeding an IDENTITY output:
+  // - parent-tiny has huge activation but tiny weight (so tiny contribution)
+  // - parent-big has normal activation and normal weight (so real contribution)
+  //
+  // We expect record() to recurse mainly into parent-big and NOT generate an
+  // astronomical error on parent-tiny.
+  const creatureJSON: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { uuid: "parent-tiny", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "parent-big", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      // Drive parent activations.
+      { fromUUID: "input-0", toUUID: "parent-tiny", weight: 1000 }, // activation ~1000
+      { fromUUID: "input-1", toUUID: "parent-big", weight: 1 }, // activation ~1
+
+      // Two inbound links into output:
+      { fromUUID: "parent-tiny", toUUID: "output-0", weight: 1e-6 },
+      { fromUUID: "parent-big", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(creatureJSON);
+  creature.activate(new Float32Array([1, 1]));
+
+  // Current output ≈ (1000 * 1e-6) + (1 * 1) = 1.001. Target 0 => error ~ -1.001.
+  const discoverMap = creature.record(new Float32Array([0]));
+
+  const tiny = discoverMap.get("parent-tiny");
+  const big = discoverMap.get("parent-big");
+
+  assert(big, "Expected record entry for parent-big");
+
+  if (tiny) {
+    const finite = tiny.errors.filter(Number.isFinite);
+    const maxAbs = finite.reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    assert(
+      maxAbs < 1e6,
+      `Expected tiny-weight parent to be de-emphasised, got maxAbs=${maxAbs}`,
+    );
+  }
+});

--- a/test/propagate/record/RangeLimitedAttributionAvoidsImpossibleTargets.ts
+++ b/test/propagate/record/RangeLimitedAttributionAvoidsImpossibleTargets.ts
@@ -52,8 +52,10 @@ Deno.test(
 
     creature.activate(new Float32Array([1]));
 
-    // Current output is ~2. Request 0 so record-time error is negative.
-    const expected = new Float32Array([0]);
+    // Current output is ~2. Request a *far* negative target so the value-space
+    // error is large enough that naive attribution would imply a negative
+    // target activation for ABSOLUTE (impossible, since ABSOLUTE ∈ [0, +∞)).
+    const expected = new Float32Array([-100]);
     const map = creature.record(expected);
 
     const absRec = map.get("abs-hidden");
@@ -62,12 +64,20 @@ Deno.test(
     const idRec = map.get("id-hidden");
     assert(idRec, "expected a discovery record for id-hidden");
 
-    // Key assertion: we should avoid requesting impossible negative targets for
-    // ABSOLUTE, so it should not receive a recursive record() call.
+    // Key assertion: we should not request an impossible negative target from
+    // ABSOLUTE. Instead, record attribution should clamp to the boundary (0)
+    // and redistribute residue to other links.
     assertEquals(
       absRec.errors.length,
-      0,
-      "ABSOLUTE parent should not be asked to absorb negative record targets when an alternative exists",
+      1,
+      "ABSOLUTE parent should receive at most a boundary-clamped record attribution",
+    );
+    const absMax = absRec.errors
+      .filter(Number.isFinite)
+      .reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    assert(
+      absMax < 1000,
+      `Expected ABSOLUTE record error to be bounded, got absMax=${absMax}`,
     );
 
     // And we should still attribute the error somewhere upstream.

--- a/test/propagate/record/RangeLimitedAttributionAvoidsImpossibleTargetsReLU.ts
+++ b/test/propagate/record/RangeLimitedAttributionAvoidsImpossibleTargetsReLU.ts
@@ -52,8 +52,10 @@ Deno.test(
 
     creature.activate(new Float32Array([1]));
 
-    // Current output is ~2. Request 0 so record-time error is negative.
-    const expected = new Float32Array([0]);
+    // Current output is ~2. Request a *far* negative target so the value-space
+    // error is large enough that naive attribution would imply a negative
+    // target activation for ReLU (impossible, since ReLU ∈ [0, +∞)).
+    const expected = new Float32Array([-100]);
     const map = creature.record(expected);
 
     const reluRec = map.get("relu-hidden");
@@ -62,12 +64,20 @@ Deno.test(
     const idRec = map.get("id-hidden");
     assert(idRec, "expected a discovery record for id-hidden");
 
-    // Key assertion: we should not request negative targets from ReLU, so it
-    // should not receive a recursive record() call.
+    // Key assertion: we should not request an impossible negative target from
+    // ReLU. Instead, record attribution should clamp to the boundary (0) and
+    // redistribute residue to other links.
     assertEquals(
       reluRec.errors.length,
-      0,
-      "ReLU parent should not be asked to absorb negative record targets when an alternative exists",
+      1,
+      "ReLU parent should receive at most a boundary-clamped record attribution",
+    );
+    const reluMax = reluRec.errors
+      .filter(Number.isFinite)
+      .reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    assert(
+      reluMax < 1000,
+      `Expected ReLU record error to be bounded, got reluMax=${reluMax}`,
     );
 
     // And we should still attribute the error somewhere upstream.
@@ -122,7 +132,9 @@ Deno.test(
 
     creature.activate(new Float32Array([1]));
 
-    const expected = new Float32Array([0]);
+    // Same idea for ReLU6: force a large negative target so naive attribution
+    // would try to request a negative ReLU6 activation (impossible).
+    const expected = new Float32Array([-100]);
     const map = creature.record(expected);
 
     const relu6Rec = map.get("relu6-hidden");
@@ -133,8 +145,15 @@ Deno.test(
 
     assertEquals(
       relu6Rec.errors.length,
-      0,
-      "ReLU6 parent should not be asked to absorb negative record targets when an alternative exists",
+      1,
+      "ReLU6 parent should receive at most a boundary-clamped record attribution",
+    );
+    const relu6Max = relu6Rec.errors
+      .filter(Number.isFinite)
+      .reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    assert(
+      relu6Max < 1000,
+      `Expected ReLU6 record error to be bounded, got relu6Max=${relu6Max}`,
     );
 
     assert(

--- a/test/propagate/record/RedistributedBlockedErrorMaintainsFeasibility.ts
+++ b/test/propagate/record/RedistributedBlockedErrorMaintainsFeasibility.ts
@@ -80,12 +80,21 @@ Deno.test(
     const altRec = map.get("id-alt");
     assert(altRec, "expected a discovery record for id-alt");
 
-    // Key assertion: abs-victim starts feasible, but must not receive a record()
-    // recursion with a negative requested activation after redistribution.
+    // Key assertion: abs-victim starts feasible. After redistribution, it may
+    // receive additional negative share, but it must be clamped to ABSOLUTE's
+    // boundary (activation >= 0) rather than being pushed into an impossible
+    // negative target.
     assertEquals(
       victimRec.errors.length,
-      0,
-      "redistribution must not push a feasible ABSOLUTE parent into an infeasible negative target",
+      1,
+      "redistribution should clamp ABSOLUTE to the feasible boundary rather than pushing negative targets",
+    );
+    const victimMax = victimRec.errors
+      .filter(Number.isFinite)
+      .reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    assert(
+      victimMax < 1000,
+      `expected ABSOLUTE victim record error to be bounded, got victimMax=${victimMax}`,
     );
 
     // The error should still be attributed somewhere upstream.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves record-time error attribution to avoid infeasible upstream targets and tiny-weight explosions, and adds targeted tests.
> 
> - Introduces and applies `constrainAndRedistributeRecordShares` in `Neuron.record` and `methods/activations/aggregate/IF.record` to clamp per-link `shares` to upstream squash ranges and redistribute residue; retains safe-zone guards
> - Changes `distributeRecordError` to weight elasticity by `|w|` (shares ∝ w²) instead of activation; adjusts `recordTargetFeasibilityFactor` to a soft preference (0.1) rather than hard block
> - Adds tests: `ElasticRecordAvoidsTinyWeight.ts`, `RangeLimitedAttributionAvoidsImpossibleTargets*.ts` (ABSOLUTE, ReLU, ReLU6), and `RedistributedBlockedErrorMaintainsFeasibility.ts`
> - Bumps version in `deno.json` to `0.274.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355f6a50c220331ec05455fbfd7df346b4fc9708. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->