### PR TITLE
Update version to 0.274.1 in deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.274.0",
+  "version": "0.274.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/test/propagate/record/ElasticRecordClampsAndRedistributesSwishNonNegative.ts
+++ b/test/propagate/record/ElasticRecordClampsAndRedistributesSwishNonNegative.ts
@@ -1,0 +1,58 @@
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { IDENTITY } from "../../../src/methods/activations/types/IDENTITY.ts";
+import { Swish } from "../../../src/methods/activations/types/Swish.ts";
+
+Deno.test(
+  "Creature.record: prefers not pushing Swish negative, clamps and redistributes residue",
+  () => {
+    // Swish can output negatives, but record attribution treats negative targets
+    // as undesirable when there is an alternative (soft clamp to >= 0).
+    //
+    // This covers the "soft lower bound" branch for Swish + residue redistribution.
+
+    const creatureJSON: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        { uuid: "swish-hidden", type: "hidden", squash: Swish.NAME, bias: 0 },
+        { uuid: "id-hidden", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "swish-hidden", weight: 1 },
+        { fromUUID: "input-0", toUUID: "id-hidden", weight: 1 },
+
+        // Equal weights => initial shares are similar.
+        { fromUUID: "swish-hidden", toUUID: "output-0", weight: 1 },
+        { fromUUID: "id-hidden", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJSON);
+    creature.activate(new Float32Array([1]));
+
+    // Current output ≈ swish(1) + 1 ≈ 1.731.
+    // Request a large negative output so the error is strongly negative.
+    const map = creature.record(new Float32Array([-10]));
+
+    const swishRec = map.get("swish-hidden");
+    const idRec = map.get("id-hidden");
+
+    assert(swishRec, "expected a discovery record for swish-hidden");
+    assert(idRec, "expected a discovery record for id-hidden");
+
+    assertEquals(swishRec.errors.length, 1);
+    const swishMax = swishRec.errors
+      .filter(Number.isFinite)
+      .reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    assert(
+      swishMax < 100,
+      `expected Swish record error to be clamped/bounded, got swishMax=${swishMax}`,
+    );
+
+    // Residue must be redistributed to the feasible alternative path.
+    assert(idRec.errors.length > 0);
+  },
+);

--- a/test/propagate/record/ElasticRecordClampsAndRedistributesUpperBounds.ts
+++ b/test/propagate/record/ElasticRecordClampsAndRedistributesUpperBounds.ts
@@ -1,0 +1,58 @@
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../../src/Creature.ts";
+import { IDENTITY } from "../../../src/methods/activations/types/IDENTITY.ts";
+import { ReLU6 } from "../../../src/methods/activations/types/ReLU6.ts";
+
+Deno.test(
+  "Creature.record: clamps to ReLU6 upper bound and redistributes residue",
+  () => {
+    // Covers the "positive residue" clamp+redistribute path:
+    // - ReLU6 activation range is [0, 6].
+    // - Requesting a large positive output implies a large positive value-space error.
+    // - Attribution initially allocates most share to the ReLU6 path, but clamping
+    //   prevents requesting activation > 6. The leftover share must be redistributed.
+
+    const creatureJSON: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        { uuid: "relu6-hidden", type: "hidden", squash: ReLU6.NAME, bias: 0 },
+        { uuid: "id-hidden", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "relu6-hidden", weight: 1 },
+        { fromUUID: "input-0", toUUID: "id-hidden", weight: 1 },
+
+        // Weight-based record scoring (shares ∝ w²) will favour relu6-hidden.
+        { fromUUID: "relu6-hidden", toUUID: "output-0", weight: 1 },
+        { fromUUID: "id-hidden", toUUID: "output-0", weight: 0.2 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJSON);
+    creature.activate(new Float32Array([1]));
+
+    // Current output ≈ relu6(1) + 0.2 = 1.2. Request far above ReLU6's max.
+    const map = creature.record(new Float32Array([20]));
+
+    const relu6Rec = map.get("relu6-hidden");
+    const idRec = map.get("id-hidden");
+
+    assert(relu6Rec, "expected a discovery record for relu6-hidden");
+    assert(idRec, "expected a discovery record for id-hidden");
+
+    assertEquals(relu6Rec.errors.length, 1);
+    const relu6Max = relu6Rec.errors
+      .filter(Number.isFinite)
+      .reduce((m, v) => Math.max(m, Math.abs(v)), 0);
+    assert(
+      relu6Max < 1e4,
+      `expected ReLU6 record error to be bounded, got relu6Max=${relu6Max}`,
+    );
+
+    // Residue must be redistributed somewhere feasible.
+    assert(idRec.errors.length > 0);
+  },
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds coverage for `Creature.record` behavior around activation bounds and residue redistribution.
> 
> - New tests: `ElasticRecordClampsAndRedistributesSwishNonNegative.ts` (soft clamp of Swish negatives and redistribution) and `ElasticRecordClampsAndRedistributesUpperBounds.ts` (ReLU6 upper bound clamp and redistribution)
> - Bumps package version in `deno.json` to `0.274.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb70760f58b5d35b0afcd829acb94c6db8d2c61f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->