### PR TITLE
Update version to 0.274.2 in deno.json and refactor version handling …

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.274.1",
+  "version": "0.274.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -1,50 +1,32 @@
+import { assert } from "@std/assert";
 import { removeTag } from "@stsoftware/tags/mod";
 import { Creature, CreatureUtil, Mutation } from "../../mod.ts";
 import { creatureValidate } from "../architecture/CreatureValidate.ts";
 import { discover } from "../blackbox/Discover.ts";
 import { memeticUpdate } from "../blackbox/MemeticUpdate.ts";
 import type { NeatConfig } from "../config/NeatConfig.ts";
-import type { RadioactiveInterface } from "../mutate/RadioactiveInterface.ts";
-import { AddNeuron } from "../mutate/AddNeuron.ts";
-import { SubNeuron } from "../mutate/SubNeuron.ts";
-import { AddConnection } from "../mutate/AddConnection.ts";
-import { SubConnection } from "../mutate/SubConnection.ts";
-import { ModWeight } from "../mutate/ModWeight.ts";
-import { ModBias } from "../mutate/ModBias.ts";
-import { assert } from "@std/assert";
-import { ModActivation as ModSquash } from "../mutate/ModSquash.ts";
-import { AddSelfCon } from "../mutate/AddSelfCon.ts";
-import { SubSelfCon } from "../mutate/SubSelfCon.ts";
 import { AddBackCon } from "../mutate/AddBackCon.ts";
+import { AddConnection } from "../mutate/AddConnection.ts";
+import { AddNeuron } from "../mutate/AddNeuron.ts";
+import { AddSelfCon } from "../mutate/AddSelfCon.ts";
+import { ModBias } from "../mutate/ModBias.ts";
+import { ModActivation as ModSquash } from "../mutate/ModSquash.ts";
+import { ModWeight } from "../mutate/ModWeight.ts";
+import type { RadioactiveInterface } from "../mutate/RadioactiveInterface.ts";
 import { SubBackCon } from "../mutate/SubBackCon.ts";
+import { SubConnection } from "../mutate/SubConnection.ts";
+import { SubNeuron } from "../mutate/SubNeuron.ts";
+import { SubSelfCon } from "../mutate/SubSelfCon.ts";
 import { SwapNeurons } from "../mutate/SwapNeurons.ts";
-
-function upgradeSemanticVersionIfForwardOnlyConfirmed(creature: Creature) {
-  // Once forward-only is confirmed, bump 2.x.x/3.x.x → 4.0.0.
-  // Backwards compatibility: never downgrade (e.g. 4.1.2 stays 4.1.2).
-  const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(creature.semanticVersion);
-  if (!match) return;
-  const major = Number.parseInt(match[1], 10);
-  if (major === 2 || major === 3) {
-    creature.semanticVersion = "4.0.0";
-  }
-}
+import {
+  getMajorVersion,
+  upgradeSemanticVersionIfForwardOnlyConfirmed,
+} from "../upgrade/Upgrade.ts";
 
 export class Mutator {
   private config: NeatConfig;
   constructor(config: NeatConfig) {
     this.config = config;
-  }
-
-  /**
-   * Extracts the major version number from a semantic version string.
-   * @param version - Semantic version string (e.g. "4.0.0")
-   * @returns The major version number, or 0 if invalid/undefined
-   */
-  private getMajorVersion(version: string | undefined): number {
-    if (!version) return 0;
-    const major = parseInt(version.split(".")[0], 10);
-    return Number.isNaN(major) ? 0 : major;
   }
 
   /**
@@ -139,7 +121,7 @@ export class Mutator {
       .mutation;
 
     const feedbackLoop = this.config.feedbackLoop;
-    const majorVersion = this.getMajorVersion(creature.semanticVersion);
+    const majorVersion = getMajorVersion(creature.semanticVersion);
     const forwardOnly = majorVersion >= 4 || creature.forwardOnly === true;
 
     // Avoid infinite loops: pre-filter for methods that can actually run under
@@ -220,7 +202,7 @@ export class Mutator {
     // Clear the flag so subsequent mutation/breeding can introduce memory connections.
     // However, semanticVersion 4.x is a hard forward-only invariant and must never
     // be cleared/relaxed.
-    const majorVersion = this.getMajorVersion(creature.semanticVersion);
+    const majorVersion = getMajorVersion(creature.semanticVersion);
     if (
       this.config.feedbackLoop === true &&
       creature.forwardOnly === true &&

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -4,34 +4,16 @@ import { memeticUpdate } from "../blackbox/MemeticUpdate.ts";
 import { editParentByIndex } from "../breed/EditParentByIndex.ts";
 import { geneticCompatibility } from "../breed/GeneticCompatibility.ts";
 import { Creature } from "../Creature.ts";
-import { upgrade } from "../upgrade/Upgrade.ts";
+import {
+  getMajorVersion,
+  upgrade,
+  upgradeSemanticVersionIfForwardOnlyConfirmed,
+} from "../upgrade/Upgrade.ts";
 import { writeDiagnostics } from "../utils/Diagnostics.ts";
 import { CreatureUtil } from "./CreatureUtils.ts";
 import { creatureValidate } from "./CreatureValidate.ts";
 import { Neuron } from "./Neuron.ts";
 import type { SynapseExport, SynapseInternal } from "./SynapseInterfaces.ts";
-
-function upgradeSemanticVersionIfForwardOnlyConfirmed(creature: Creature) {
-  // Once forward-only is confirmed, bump 2.x.x/3.x.x → 4.0.0.
-  // Backwards compatibility: never downgrade (e.g. 4.1.2 stays 4.1.2).
-  const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(creature.semanticVersion);
-  if (!match) return;
-  const major = Number.parseInt(match[1], 10);
-  if (major === 2 || major === 3) {
-    creature.semanticVersion = "4.0.0";
-  }
-}
-
-/**
- * Extracts the major version number from a semantic version string.
- * @param version - Semantic version string (e.g., "3.1.0", "2.0.0")
- * @returns The major version number, or 0 if invalid/undefined
- */
-function getMajorVersion(version: string | undefined): number {
-  if (!version) return 0;
-  const major = parseInt(version.split(".")[0], 10);
-  return Number.isNaN(major) ? 0 : major;
-}
 
 class OffspringError extends Error {
   constructor(message: string) {

--- a/src/blackbox/FineTune.ts
+++ b/src/blackbox/FineTune.ts
@@ -50,7 +50,28 @@ export function quantumAdjust(
   return { value: currentBest, changed: false };
 }
 
-function addMissingSynapses(from: CreatureExport, to: CreatureExport) {
+function addMissingSynapses(
+  from: CreatureExport,
+  to: CreatureExport,
+  options: { forwardOnly: boolean },
+) {
+  const forwardOnly = options.forwardOnly === true;
+
+  // In forward-only mode, a synapse is valid only when its source neuron appears
+  // earlier than its destination neuron in the *target* creature's ordering.
+  //
+  // Important (Australian English): neuron UUIDs do not encode ordering; two valid
+  // forward-only creatures can share the same neurons but have different index
+  // orders. Copying a synapse by UUID across those orderings can create a
+  // recurrent/backward connection in the target, corrupting the creature.
+  const toIndexByUUID = new Map<string, number>();
+  for (let i = 0; i < to.input; i++) {
+    toIndexByUUID.set(`input-${i}`, i);
+  }
+  for (let i = 0; i < to.neurons.length; i++) {
+    toIndexByUUID.set(to.neurons[i].uuid, to.input + i);
+  }
+
   const toNeuronsMap = new Map<
     string,
     { type: string; squash?: string } | null
@@ -76,6 +97,14 @@ function addMissingSynapses(from: CreatureExport, to: CreatureExport) {
 
   from.synapses.forEach((s) => {
     if (toNeuronsMap.has(s.fromUUID) && toNeuronsMap.has(s.toUUID)) {
+      if (forwardOnly) {
+        const fromIndex = toIndexByUUID.get(s.fromUUID);
+        const toIndex = toIndexByUUID.get(s.toUUID);
+        // If we cannot resolve indices, do not attempt to add the synapse.
+        if (fromIndex === undefined || toIndex === undefined) return;
+        // Reject self-loops and backward/recurrent connections in forward-only mode.
+        if (fromIndex >= toIndex) return;
+      }
       if (!synapsesSet.has(`${s.fromUUID}->${s.toUUID}`)) {
         const toSynapse: SynapseExport = JSON.parse(JSON.stringify(s));
         toSynapse.weight = 0;
@@ -117,8 +146,8 @@ function tuneRandomize(
     };
   }
 
-  addMissingSynapses(fittestJSON, previousJSON);
-  addMissingSynapses(previousJSON, fittestJSON);
+  addMissingSynapses(fittestJSON, previousJSON, { forwardOnly });
+  addMissingSynapses(previousJSON, fittestJSON, { forwardOnly });
 
   const uuidNodeMap = new Map<string, NeuronExport>();
 
@@ -265,7 +294,13 @@ export function fineTuneImprovement(
     }
   }
 
-  const resultSame = tuneRandomize(fittest, previousFittest, false, backtrack);
+  const forwardOnly = feedbackLoop !== true;
+  const resultSame = tuneRandomize(
+    fittest,
+    previousFittest,
+    forwardOnly,
+    backtrack,
+  );
   if (resultSame.tuned) {
     const randomUUID = CreatureUtil.makeUUID(resultSame.tuned);
     if (!UUIDs.has(randomUUID)) {
@@ -282,7 +317,7 @@ export function fineTuneImprovement(
     const resultRandomize = tuneRandomize(
       fittest,
       previousFittest,
-      false,
+      forwardOnly,
       backtrack,
     );
     if (resultRandomize.tuned) {

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -49,17 +49,7 @@ import {
 } from "../compact/CompactUtils.ts";
 import { Creature } from "../Creature.ts";
 import { ValidationError } from "../errors/ValidationError.ts";
-
-/**
- * Extract the major version from a semantic version string.
- *
- * Invalid/undefined versions are treated as 0.
- */
-function getMajorVersion(version: string | undefined): number {
-  if (!version) return 0;
-  const major = Number.parseInt(version.split(".")[0], 10);
-  return Number.isNaN(major) ? 0 : major;
-}
+import { getMajorVersion } from "../upgrade/Upgrade.ts";
 
 /**
  * Upgrade 2.x/3.x creatures to 4.x once forward-only validity is confirmed.

--- a/src/discovery/DiscoveryPostValidate.ts
+++ b/src/discovery/DiscoveryPostValidate.ts
@@ -1,5 +1,6 @@
 import type { Creature } from "../Creature.ts";
 import { creatureValidate } from "../architecture/CreatureValidate.ts";
+import { getMajorVersion } from "../upgrade/Upgrade.ts";
 
 /**
  * Validate a creature immediately after applying discovery changes.
@@ -104,12 +105,6 @@ export function validateAfterDiscoveryOrThrow(args: {
         `Error=${error.name}: ${error.message}.${detail}`,
     );
   }
-}
-
-function getMajorVersion(version: string | undefined): number {
-  if (!version) return 0;
-  const major = Number.parseInt(version.split(".")[0], 10);
-  return Number.isNaN(major) ? 0 : major;
 }
 
 function bumpToFourIfForwardOnlyConfirmed(creature: Creature): void {

--- a/src/mutate/AddConnection.ts
+++ b/src/mutate/AddConnection.ts
@@ -4,12 +4,7 @@ import type { Creature } from "../Creature.ts";
 import type { Neuron } from "../architecture/Neuron.ts";
 import { Synapse } from "../architecture/Synapse.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
-
-function getMajorVersion(version: string | undefined): number {
-  if (!version) return 0;
-  const major = Number.parseInt(version.split(".")[0], 10);
-  return Number.isNaN(major) ? 0 : major;
-}
+import { getMajorVersion } from "../upgrade/Upgrade.ts";
 
 function bumpToFourIfForwardOnlyConfirmed(creature: Creature): void {
   const major = getMajorVersion(creature.semanticVersion);

--- a/src/reconstruct/CRISPR.ts
+++ b/src/reconstruct/CRISPR.ts
@@ -1,26 +1,12 @@
 import { assert } from "@std/assert";
 import { addTag, getTag, type TagsInterface } from "@stsoftware/tags/mod";
+import { CreatureUtil, Upgrade } from "../../mod.ts";
 import { Neuron } from "../architecture/Neuron.ts";
 import { Creature } from "../Creature.ts";
-import { CreatureUtil, Upgrade } from "../../mod.ts";
-
-function getMajorVersion(version: string | undefined): number {
-  if (!version) return 0;
-  const major = Number.parseInt(version.split(".")[0], 10);
-  return Number.isNaN(major) ? 0 : major;
-}
-
-function upgradeSemanticVersionIfForwardOnlyConfirmed(creature: Creature) {
-  // Once forward-only is confirmed, bump 2.x.x/3.x.x → 4.0.0.
-  // Backwards compatibility: never downgrade (e.g. 4.1.2 stays 4.1.2).
-  const version = creature.semanticVersion;
-  const match = version ? /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(version) : null;
-  if (!match) return;
-  const major = Number.parseInt(match[1], 10);
-  if (major === 2 || major === 3) {
-    creature.semanticVersion = "4.0.0";
-  }
-}
+import {
+  getMajorVersion,
+  upgradeSemanticVersionIfForwardOnlyConfirmed,
+} from "../upgrade/Upgrade.ts";
 
 /**
  * Interface representing the structure of the CRISPR modification data.
@@ -459,7 +445,20 @@ export class CRISPR {
         // Forward-only is a hard invariant for semanticVersion 4.x (and for any
         // creature explicitly marked as forward-only). CRISPR must never be able
         // to introduce recurrent connections into such creatures.
-        modifiedCreature.validate({ forwardOnly: true });
+        try {
+          modifiedCreature.validate({ forwardOnly: true });
+        } catch (e) {
+          const error = e as Error;
+          if (
+            error.name === "SELF_CONNECTION" ||
+            error.name === "RECURSIVE_SYNAPSE"
+          ) {
+            modifiedCreature.fix({ forwardOnly: true });
+            modifiedCreature.validate({ forwardOnly: true });
+          } else {
+            throw e;
+          }
+        }
         modifiedCreature.forwardOnly = true;
         upgradeSemanticVersionIfForwardOnlyConfirmed(modifiedCreature);
       } else {

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -19,10 +19,28 @@ export const SEMANTIC_MAJOR_VERSION = 4;
  * @param version - Semantic version string (e.g., "3.1.0", "2.0.0")
  * @returns The major version number, or 0 if invalid
  */
-function getMajorVersion(version: string | undefined): number {
+export function getMajorVersion(version: string | undefined): number {
   if (!version) return 0;
   const major = parseInt(version.split(".")[0], 10);
   return Number.isNaN(major) ? 0 : major;
+}
+
+/**
+ * Once forward-only has been confirmed by the caller, bump legacy 2.x.x/3.x.x
+ * creatures to 4.0.0.
+ *
+ * Backwards compatibility: never downgrade (e.g. 4.1.2 stays 4.1.2).
+ */
+export function upgradeSemanticVersionIfForwardOnlyConfirmed(
+  creature: { semanticVersion?: string },
+): void {
+  const version = creature.semanticVersion;
+  const match = version ? /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(version) : null;
+  if (!match) return;
+  const major = Number.parseInt(match[1], 10);
+  if (major === 2 || major === 3) {
+    creature.semanticVersion = "4.0.0";
+  }
 }
 
 /**

--- a/test/Upgrade/VersionHelpers.ts
+++ b/test/Upgrade/VersionHelpers.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "@std/assert";
+import {
+  getMajorVersion,
+  upgradeSemanticVersionIfForwardOnlyConfirmed,
+} from "../../src/upgrade/Upgrade.ts";
+
+Deno.test("getMajorVersion(): returns major version, or 0 for invalid/undefined", () => {
+  assertEquals(getMajorVersion(undefined), 0);
+  assertEquals(getMajorVersion(""), 0);
+  assertEquals(getMajorVersion("0.0.1"), 0);
+  assertEquals(getMajorVersion("2.0.0"), 2);
+  assertEquals(getMajorVersion("4.123.9"), 4);
+  assertEquals(getMajorVersion("not-a-version"), 0);
+});
+
+Deno.test(
+  "upgradeSemanticVersionIfForwardOnlyConfirmed(): bumps 2.x.x/3.x.x to 4.0.0 without downgrading 4.x",
+  () => {
+    const v2 = { semanticVersion: "2.1.9" };
+    upgradeSemanticVersionIfForwardOnlyConfirmed(v2);
+    assertEquals(v2.semanticVersion, "4.0.0");
+
+    const v3 = { semanticVersion: "3.0.0" };
+    upgradeSemanticVersionIfForwardOnlyConfirmed(v3);
+    assertEquals(v3.semanticVersion, "4.0.0");
+
+    const v4 = { semanticVersion: "4.1.2" };
+    upgradeSemanticVersionIfForwardOnlyConfirmed(v4);
+    assertEquals(v4.semanticVersion, "4.1.2");
+
+    const invalid = { semanticVersion: "2" };
+    upgradeSemanticVersionIfForwardOnlyConfirmed(invalid);
+    assertEquals(
+      invalid.semanticVersion,
+      "2",
+      "Non-semver inputs should be ignored to avoid accidental upgrades",
+    );
+  },
+);

--- a/test/blackbox/FineTuneForwardOnlyMissingSynapses.ts
+++ b/test/blackbox/FineTuneForwardOnlyMissingSynapses.ts
@@ -1,0 +1,93 @@
+import { assert } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { fineTuneImprovement } from "../../src/blackbox/FineTune.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+
+Deno.test(
+  "fineTuneImprovement (forward-only) must not introduce backward synapses when copying missing synapses between different neuron orderings",
+  () => {
+    // Two valid forward-only creatures can share the same neuron UUIDs but have
+    // different internal ordering. Copying a synapse by UUID across those
+    // orderings can create a backward/recurrent connection in the target.
+    //
+    // This test builds two minimal forward-only exports with reversed hidden
+    // neuron ordering. Each creature is valid on its own. Fine-tune attempts to
+    // union missing synapses; in forward-only mode it must skip any synapse that
+    // would become backward in the target ordering.
+
+    const base: Pick<
+      CreatureExport,
+      "semanticVersion" | "forwardOnly" | "input" | "output" | "tags"
+    > = {
+      semanticVersion: "4.0.0",
+      forwardOnly: true,
+      input: 1,
+      output: 1,
+      tags: [],
+    };
+
+    // Ordering A: input-0, h1, h2, output-0
+    const exportA: CreatureExport = {
+      ...base,
+      neurons: [
+        { uuid: "h1", type: "hidden", squash: "LOGISTIC", bias: 0 },
+        { uuid: "h2", type: "hidden", squash: "LOGISTIC", bias: 0 },
+        { uuid: "output-0", type: "output", squash: "LOGISTIC", bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "h1", weight: 1 },
+        { fromUUID: "h1", toUUID: "h2", weight: 1 },
+        { fromUUID: "h2", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    // Ordering B: input-0, h2, h1, output-0
+    // Synapse h2 -> h1 is forward in this ordering.
+    const exportB: CreatureExport = {
+      ...base,
+      neurons: [
+        { uuid: "h2", type: "hidden", squash: "LOGISTIC", bias: 0 },
+        { uuid: "h1", type: "hidden", squash: "LOGISTIC", bias: 0 },
+        { uuid: "output-0", type: "output", squash: "LOGISTIC", bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "h2", weight: 1 },
+        { fromUUID: "h2", toUUID: "h1", weight: 1 },
+        { fromUUID: "h1", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const fittest = Creature.fromJSON(exportA);
+    const previous = Creature.fromJSON(exportB);
+
+    fittest.forwardOnly = true;
+    previous.forwardOnly = true;
+    fittest.semanticVersion = "4.0.0";
+    previous.semanticVersion = "4.0.0";
+
+    // Ensure both are valid forward-only before fine-tuning.
+    fittest.validate({ forwardOnly: true });
+    previous.validate({ forwardOnly: true });
+
+    // Ensure fineTuneImprovement actually runs (it requires scores to differ).
+    fittest.score = 10;
+    previous.score = 9;
+
+    const tunedPopulation = fineTuneImprovement(
+      fittest,
+      previous,
+      false, // feedbackLoop=false => forward-only run
+      3,
+      false,
+    );
+
+    assert(
+      tunedPopulation.length > 0,
+      "Expected at least one tuned creature to be generated",
+    );
+
+    for (const tuned of tunedPopulation) {
+      tuned.validate({ forwardOnly: true });
+    }
+  },
+);


### PR DESCRIPTION
…in NEAT framework

- Bumped version in deno.json to 0.274.2.
- Refactored version handling logic across multiple files to centralize major version extraction and upgrade logic, improving maintainability.
- Enhanced validation and error handling for forward-only creatures, ensuring compliance with versioning rules.

These changes strengthen the integrity and clarity of the NEAT framework's version management and forward-only semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens forward-only guarantees and de-duplicates version logic.
> 
> - Centralizes `getMajorVersion` and `upgradeSemanticVersionIfForwardOnlyConfirmed` in `src/upgrade/Upgrade.ts`; updates imports in `Mutator`, `Offspring`, `AddConnection`, `CRISPR`, `Discovery*`
> - Tightens forward-only enforcement: validate/fix and crash-fast for 4.x in `Mutator` and `AddConnection`; `CRISPR` now repairs self/back connections under forward-only before re-validating
> - `FineTune`: adds `forwardOnly` option to `addMissingSynapses` and prevents adding backward/self connections by mapping UUIDs to indices; propagates forward-only through tuning paths
> - Discovery: uses shared version helpers and validates/fixes candidates with forward-only constraints when required
> - Adds tests: `test/Upgrade/VersionHelpers.ts` and `test/blackbox/FineTuneForwardOnlyMissingSynapses.ts` to cover version helpers and forward-only synapse copying
> - Bumps `deno.json` version to `0.274.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7bc80bc72ba30949de9756f107652e5efeac85a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->