### PR TITLE
Update version to 0.275.0 in deno.json and enhance error distribution…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.274.2",
+  "version": "0.275.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -595,6 +595,7 @@ export class Neuron implements TagsInterface, NeuronInternal {
         const fromActivationCache = new Array<number>(listLength);
         const fromWeightCache = new Array<number>(listLength);
         const fromValueCache = new Array<number>(listLength);
+        const safeZoneFactorCache = new Array<number>(listLength);
         const provisionalErrorPerLink = error / listLength;
 
         for (let indx = 0; indx < listLength; indx++) {
@@ -642,11 +643,42 @@ export class Neuron implements TagsInterface, NeuronInternal {
             activation: fromActivation,
             safeZoneFactor: safeZoneAdj,
           };
+          safeZoneFactorCache[indx] = safeZoneAdj;
         }
 
-        const perLinkError = distributeElasticError(error, linkMeta, {
-          plankConstant: config.plankConstant,
-        });
+        // If every upstream link is blocked by safe-zone (eg. parents are deep in
+        // saturation), the standard elastic denominator can collapse to ~0.
+        //
+        // Historically we fell back to an equal split in `distributeElasticError`,
+        // which reintroduced “forced” upstream activation targets when recursion
+        // was enabled. For training, we still want learning to progress, but we
+        // prefer the minimum-change *weight* solution rather than an equal split.
+        //
+        // So: if safe-zone blocks everything, ignore safe-zone for distribution
+        // (use activation² only), while the recursion guard below prevents trying
+        // to push saturated parents via activation targets.
+        let perLinkError: number[];
+        let hasUsableSafeZone = false;
+        for (let i = 0; i < listLength; i++) {
+          const safe = safeZoneFactorCache[i] ?? 1;
+          if (Number.isFinite(safe) && safe > config.plankConstant) {
+            hasUsableSafeZone = true;
+            break;
+          }
+        }
+        if (hasUsableSafeZone) {
+          perLinkError = distributeElasticError(error, linkMeta, {
+            plankConstant: config.plankConstant,
+          });
+        } else {
+          const fallbackMeta = linkMeta.map((m) => ({
+            activation: m.activation,
+            safeZoneFactor: 1,
+          }));
+          perLinkError = distributeElasticError(error, fallbackMeta, {
+            plankConstant: config.plankConstant,
+          });
+        }
 
         for (let indx = 0; indx < listLength; indx++) {
           const c = inwardList[indx];
@@ -674,11 +706,29 @@ export class Neuron implements TagsInterface, NeuronInternal {
             Math.abs(targetFromValue - fromValue) > config.plankConstant
           ) {
             const targetFromActivation = targetFromValue / fromWeight;
-            improvedFromActivation = fromNeuron.propagate(
-              targetFromActivation,
-              config,
-              sparseConfig,
-            );
+            // Training-time constraint:
+            // Avoid recursing into parents when the implied activation target is
+            // infeasible for their squash range (common when this link's weight
+            // is tiny: (fromValue + share) / weight explodes).
+            //
+            // In this situation, the best minimum-change action is usually to
+            // adjust the *current* neuron's inbound weights/biases rather than
+            // forcing an upstream neuron to chase an impossible activation.
+            const safeZoneFactor = safeZoneFactorCache[indx] ?? 1;
+            if (Number.isFinite(safeZoneFactor) && safeZoneFactor > 0) {
+              const fromSquash = fromNeuron.findSquash();
+              const range = fromSquash.range;
+              const eps = 1e-9;
+              const outOfRange = targetFromActivation < range.low - eps ||
+                targetFromActivation > range.high + eps;
+              if (!outOfRange && Number.isFinite(targetFromActivation)) {
+                improvedFromActivation = fromNeuron.propagate(
+                  targetFromActivation,
+                  config,
+                  sparseConfig,
+                );
+              }
+            }
           }
 
           if (

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -607,6 +607,7 @@ export class Neuron implements TagsInterface, NeuronInternal {
             fromActivationCache[indx] = 0;
             fromWeightCache[indx] = 0;
             fromValueCache[indx] = 0;
+            safeZoneFactorCache[indx] = 0;
             continue;
           }
 

--- a/test/propagate/SaturatedArcTanDivertsToDirectPath.ts
+++ b/test/propagate/SaturatedArcTanDivertsToDirectPath.ts
@@ -1,0 +1,85 @@
+import { assertAlmostEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { ArcTan } from "../../src/methods/activations/types/ArcTan.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+import { SparseConfig } from "../../src/propagate/sparse/SparseConfig.ts";
+
+Deno.test(
+  "backprop: saturated ArcTan parent diverts error to feasible direct path (no forced upstream activation)",
+  () => {
+    // Path-of-least-resistance regression:
+    // If an ArcTan parent is deep in saturation, we should prefer updating the
+    // direct inbound weight rather than trying to recurse into the ArcTan neuron.
+
+    const creatureJSON: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          uuid: "sat-arctan",
+          type: "hidden",
+          squash: ArcTan.NAME,
+          bias: 100,
+        },
+        {
+          uuid: "output-0",
+          type: "output",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "sat-arctan", weight: 1 },
+        { fromUUID: "sat-arctan", toUUID: "output-0", weight: 1 },
+        { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJSON, true);
+    const config = createBackPropagationConfig({
+      generations: 0,
+      learningRate: 1,
+      batchSize: 1,
+      sparseRatio: 1,
+      trainingMutationRate: 0,
+      maximumWeightAdjustmentScale: 1000,
+      maximumBiasAdjustmentScale: 1000,
+      limitWeightScale: 1_000_000,
+      limitBiasScale: 1_000_000,
+    });
+    const sparseConfig = new SparseConfig(creature.exportJSON(), config);
+
+    // Trace to populate hintValue.
+    const actual = creature.activateAndTrace(
+      new Float32Array([1]),
+      false,
+      sparseConfig,
+    );
+
+    const arcTan = creature.neurons.find((n) => n.uuid === "sat-arctan")!;
+    const arcTanBiasBefore = arcTan.bias;
+    const output = creature.neurons.find((n) => n.uuid === "output-0")!;
+    const input0 = creature.neurons.find((n) => n.uuid === "input-0")!;
+
+    const wInputToOutBefore = creature.getSynapse(input0.index, output.index)!
+      .weight;
+
+    // Ask for a big negative shift.
+    creature.propagate(
+      new Float32Array([actual[0] - 10]),
+      config,
+      sparseConfig,
+    );
+    creature.propagateUpdate(config, sparseConfig);
+
+    // ArcTan bias should not be forced to move while saturated.
+    assertAlmostEquals(arcTan.bias, arcTanBiasBefore, 1e-12);
+
+    // The direct input->output weight should take the update.
+    const wInputToOutAfter = creature.getSynapse(input0.index, output.index)!
+      .weight;
+    assertAlmostEquals(wInputToOutAfter, wInputToOutBefore - 10, 1e-3);
+  },
+);

--- a/test/propagate/SaturationRecursionAvoidance.ts
+++ b/test/propagate/SaturationRecursionAvoidance.ts
@@ -1,0 +1,94 @@
+import { assertAlmostEquals, assertNotEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { ArcTan } from "../../src/methods/activations/types/ArcTan.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { TANH } from "../../src/methods/activations/types/TANH.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+import { SparseConfig } from "../../src/propagate/sparse/SparseConfig.ts";
+
+Deno.test(
+  "backprop: does not recurse into saturated bounded parents (ArcTan/TANH) when safe-zone blocks (prefers weight updates)",
+  () => {
+    // This reproduces the production failure mode:
+    // - two upstream bounded squashes are already deep into saturation
+    // - output asks for a large change
+    // - naive recursion tries to force those parents to move, even though their
+    //   safe-zone indicates they are effectively immovable.
+    //
+    // Desired behaviour: do not recurse (do not alter upstream biases), but still
+    // allow weight updates on the current neuron to absorb the change.
+
+    const creatureJSON: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          uuid: "sat-arctan",
+          type: "hidden",
+          squash: ArcTan.NAME,
+          bias: 100, // deep saturation: atan(100) ~ +pi/2
+        },
+        {
+          uuid: "sat-tanh",
+          type: "hidden",
+          squash: TANH.NAME,
+          bias: 100, // deep saturation: tanh(100) ~ +1
+        },
+        {
+          uuid: "output-0",
+          type: "output",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        // Keep parents saturated largely via bias; input weight is tiny so rawInput remains huge.
+        { fromUUID: "input-0", toUUID: "sat-arctan", weight: 1e-6 },
+        { fromUUID: "input-0", toUUID: "sat-tanh", weight: 1e-6 },
+        { fromUUID: "sat-arctan", toUUID: "output-0", weight: 1 },
+        { fromUUID: "sat-tanh", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJSON, true);
+    const config = createBackPropagationConfig({
+      generations: 0,
+      learningRate: 1,
+      batchSize: 1,
+      sparseRatio: 1,
+      trainingMutationRate: 0,
+      maximumWeightAdjustmentScale: 1000,
+      maximumBiasAdjustmentScale: 1000,
+      limitWeightScale: 1_000_000,
+      limitBiasScale: 1_000_000,
+    });
+    const sparseConfig = new SparseConfig(creature.exportJSON(), config);
+
+    // Trace so hintValue (rawInput) is available for safe-zone logic.
+    const actual = creature.activateAndTrace(
+      new Float32Array([0]),
+      false,
+      sparseConfig,
+    );
+    assertNotEquals(actual[0], 0, "sanity: output should be non-zero");
+
+    const arcTan = creature.neurons.find((n) => n.uuid === "sat-arctan")!;
+    const tanh = creature.neurons.find((n) => n.uuid === "sat-tanh")!;
+    const arcTanBiasBefore = arcTan.bias;
+    const tanhBiasBefore = tanh.bias;
+
+    // Large target change to trigger recursion temptation.
+    creature.propagate(
+      new Float32Array([-(actual[0] + 10)]),
+      config,
+      sparseConfig,
+    );
+    creature.propagateUpdate(config, sparseConfig);
+
+    // If recursion happened, these saturated parents would typically have their
+    // bias adjusted. We expect them to remain unchanged.
+    assertAlmostEquals(arcTan.bias, arcTanBiasBefore, 1e-12);
+    assertAlmostEquals(tanh.bias, tanhBiasBefore, 1e-12);
+  },
+);

--- a/test/propagate/SelfConnectionSafeZoneCache.ts
+++ b/test/propagate/SelfConnectionSafeZoneCache.ts
@@ -1,0 +1,94 @@
+import { assertAlmostEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { ArcTan } from "../../src/methods/activations/types/ArcTan.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+import { SparseConfig } from "../../src/propagate/sparse/SparseConfig.ts";
+
+Deno.test(
+  "backprop: self-connections do not affect safe-zone detection (same weight update as no self-loop)",
+  () => {
+    // Regression test (28-Dec-2025):
+    // When `from === to` (self-connection), `linkMeta[indx].safeZoneFactor` is set
+    // to 0 (blocked), but we must also record that 0 in `safeZoneFactorCache`.
+    //
+    // If we don't, later logic treats the self-loop as “safe” via `?? 1`,
+    // which wrongly chooses the safe-zone distribution path. Because all real
+    // links are blocked (safe-zone = 0), the safe-zone path falls back to an
+    // equal split and the self-loop “steals” half the error share even though
+    // it's ignored for weight updates.
+    //
+    // Correct behaviour: a dummy self-loop should not change weight updates.
+
+    function trainOnce(includeSelfLoop: boolean): number {
+      const creatureJSON: CreatureExport = {
+        input: 1,
+        output: 1,
+        neurons: [
+          {
+            uuid: "sat-arctan",
+            type: "hidden",
+            squash: ArcTan.NAME,
+            bias: 100, // abs(rawInput) > 4 => safeZoneAdjustment() returns 0
+          },
+          {
+            uuid: "output-0",
+            type: "output",
+            squash: IDENTITY.NAME,
+            bias: 0,
+          },
+        ],
+        synapses: [
+          // Keep the ArcTan neuron's raw input dominated by bias.
+          { fromUUID: "input-0", toUUID: "sat-arctan", weight: 0 },
+          { fromUUID: "sat-arctan", toUUID: "output-0", weight: 1 },
+          ...(includeSelfLoop
+            ? [{ fromUUID: "output-0", toUUID: "output-0", weight: 1 }]
+            : []),
+        ],
+      };
+
+      const creature = Creature.fromJSON(creatureJSON, true);
+      const config = createBackPropagationConfig({
+        generations: 0,
+        learningRate: 1,
+        batchSize: 1,
+        sparseRatio: 1,
+        trainingMutationRate: 0,
+        maximumWeightAdjustmentScale: 1000,
+        maximumBiasAdjustmentScale: 1000,
+        limitWeightScale: 1_000_000,
+        limitBiasScale: 1_000_000,
+      });
+      const sparseConfig = new SparseConfig(creature.exportJSON(), config);
+
+      const actual = creature.activateAndTrace(
+        new Float32Array([0]),
+        false,
+        sparseConfig,
+      );
+
+      const arcTan = creature.neurons.find((n) => n.uuid === "sat-arctan")!;
+      const output = creature.neurons.find((n) => n.uuid === "output-0")!;
+      const synapse = creature.getSynapse(arcTan.index, output.index)!;
+      const wBefore = synapse.weight;
+
+      // Ask for a value shift that the saturated parent cannot help with via recursion.
+      creature.propagate(
+        new Float32Array([actual[0] - 2]),
+        config,
+        sparseConfig,
+      );
+      creature.propagateUpdate(config, sparseConfig);
+
+      return creature.getSynapse(arcTan.index, output.index)!.weight - wBefore;
+    }
+
+    const deltaNoSelf = trainOnce(false);
+    const deltaWithSelf = trainOnce(true);
+
+    // Self-loop should not alter the weight update result.
+    assertAlmostEquals(deltaWithSelf, deltaNoSelf, 1e-9);
+  },
+);

--- a/test/propagate/TinyWeightRecursionAvoidance.ts
+++ b/test/propagate/TinyWeightRecursionAvoidance.ts
@@ -18,7 +18,7 @@ Deno.test(
       output: 1,
       neurons: [
         {
-          uuid: "logi-hidden",
+          uuid: "logistic-hidden",
           type: "hidden",
           squash: LOGISTIC.NAME,
           bias: 0,
@@ -31,10 +31,10 @@ Deno.test(
         },
       ],
       synapses: [
-        { fromUUID: "input-0", toUUID: "logi-hidden", weight: 1 },
+        { fromUUID: "input-0", toUUID: "logistic-hidden", weight: 1 },
 
         // Critical: tiny weight into output. This is where recursion explodes.
-        { fromUUID: "logi-hidden", toUUID: "output-0", weight: 1e-6 },
+        { fromUUID: "logistic-hidden", toUUID: "output-0", weight: 1e-6 },
 
         // Feasible alternative path:
         { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
@@ -57,7 +57,7 @@ Deno.test(
 
     creature.activateAndTrace(new Float32Array([1]), false, sparseConfig);
 
-    const hidden = creature.neurons.find((n) => n.uuid === "logi-hidden")!;
+    const hidden = creature.neurons.find((n) => n.uuid === "logistic-hidden")!;
     const biasBefore = hidden.bias;
 
     // Ask for a big negative output change.

--- a/test/propagate/TinyWeightRecursionAvoidance.ts
+++ b/test/propagate/TinyWeightRecursionAvoidance.ts
@@ -1,0 +1,71 @@
+import { assertAlmostEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { LOGISTIC } from "../../src/methods/activations/types/LOGISTIC.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+import { SparseConfig } from "../../src/propagate/sparse/SparseConfig.ts";
+
+Deno.test(
+  "backprop: avoids recursing activation targets through tiny weights (bounded squash parent)",
+  () => {
+    // Tiny weight -> modest value-space share implies huge requested activation:
+    //   targetFromActivation = (w*a + share) / w
+    // For bounded squashes, this is infeasible and should *not* trigger recursion.
+
+    const creatureJSON: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        {
+          uuid: "logi-hidden",
+          type: "hidden",
+          squash: LOGISTIC.NAME,
+          bias: 0,
+        },
+        {
+          uuid: "output-0",
+          type: "output",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "logi-hidden", weight: 1 },
+
+        // Critical: tiny weight into output. This is where recursion explodes.
+        { fromUUID: "logi-hidden", toUUID: "output-0", weight: 1e-6 },
+
+        // Feasible alternative path:
+        { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(creatureJSON, true);
+    const config = createBackPropagationConfig({
+      generations: 0,
+      learningRate: 1,
+      batchSize: 1,
+      sparseRatio: 1,
+      trainingMutationRate: 0,
+      maximumWeightAdjustmentScale: 1000,
+      maximumBiasAdjustmentScale: 1000,
+      limitWeightScale: 1_000_000,
+      limitBiasScale: 1_000_000,
+    });
+    const sparseConfig = new SparseConfig(creature.exportJSON(), config);
+
+    creature.activateAndTrace(new Float32Array([1]), false, sparseConfig);
+
+    const hidden = creature.neurons.find((n) => n.uuid === "logi-hidden")!;
+    const biasBefore = hidden.bias;
+
+    // Ask for a big negative output change.
+    creature.propagate(new Float32Array([-100]), config, sparseConfig);
+    creature.propagateUpdate(config, sparseConfig);
+
+    // If recursion happened through the tiny weight, the hidden bias would
+    // typically move as the solver tries to change activation.
+    assertAlmostEquals(hidden.bias, biasBefore, 1e-12);
+  },
+);


### PR DESCRIPTION
… logic in Neuron class

- Bumped version in deno.json to 0.275.0.
- Introduced a safeZoneFactorCache to improve error distribution handling in the Neuron class, allowing for more nuanced adjustments during training.
- Enhanced comments to clarify the logic behind safe-zone handling and its impact on error propagation.

These changes improve the functionality and maintainability of the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves training stability by preventing forced upstream activation targets when parents are saturated or links are tiny, and by making elastic error distribution robust when all links are blocked.
> 
> - In `Neuron.propagate`: adds `safeZoneFactorCache`, records self-connection safe-zone, and falls back to distribution ignoring safe-zone (activation²-only) when all links are blocked; adds range/finite checks before recursing to parents.
> - Prefers local weight/bias updates when upstream targets are out of squash range or unsafe (tiny weights, saturation).
> - Adds tests: `SaturatedArcTanDivertsToDirectPath`, `SaturationRecursionAvoidance`, `SelfConnectionSafeZoneCache`, `TinyWeightRecursionAvoidance` verifying non-recursion and correct distribution.
> - Bumps `deno.json` version to `0.275.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1704f4439b71ada4f618ad5121083ad5d800f43c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->