### PR TITLE
Update version to 0.277.0 in deno.json and introduce split synapse in…

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,6 +21,8 @@ ignore:
   # Docs/config-only changes are not exercised by runtime coverage instrumentation.
   # Keep them out of patch coverage to avoid failing PRs that only adjust tooling.
   - "docs/cspell.json"
+  # Coverage-focused tests exist to exercise code paths deterministically; exclude them from Codecov reporting.
+  - "test/discovery/SplitSynapseInsertNeuronCandidateCoverage_test.ts"
   - "src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts"
   - "src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts"
   - "src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts"

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.276.0",
+  "version": "0.277.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -12,6 +12,9 @@ import {
   type DiscoverStructureOptions,
 } from "./DiscoverStructure.ts";
 import type {
+  SplitSynapseInsertNeuronCandidate,
+} from "./SplitSynapseInsertNeuronCandidate.ts";
+import type {
   CandidateHarmfulNeuron,
   CandidateNeuron,
   CandidateSquash,
@@ -300,6 +303,7 @@ class DataRecorder {
         ID: this.ID,
         addHelpfulSynapses: undefined,
         addHelpfulNeurons: undefined,
+        splitSynapseInsertNeuronCandidates: undefined,
         removeHarmfulSynapse: undefined,
         removeHarmfulNeurons: undefined,
         removalCandidates: undefined,
@@ -734,6 +738,7 @@ class DataRecorder {
             ID: this.ID,
             addHelpfulSynapses: undefined,
             addHelpfulNeurons: undefined,
+            splitSynapseInsertNeuronCandidates: undefined,
             removeHarmfulSynapse: undefined,
             removeHarmfulNeurons: undefined,
             removalCandidates: undefined,
@@ -774,6 +779,7 @@ class DataRecorder {
         ID: this.ID,
         addHelpfulSynapses: undefined,
         addHelpfulNeurons: undefined,
+        splitSynapseInsertNeuronCandidates: undefined,
         removeHarmfulSynapse: undefined,
         removeHarmfulNeurons: undefined,
         removalCandidates: undefined,
@@ -860,6 +866,9 @@ class DataRecorder {
 
         phaseDiagnostics.enterPhase("analysis_parallel");
         let addHelpfulNeurons: CandidateNeuron[] | undefined;
+        let splitSynapseInsertNeuronCandidates:
+          | SplitSynapseInsertNeuronCandidate[]
+          | undefined;
         let addHelpfulSynapse: CandidateSynapse[] | undefined;
         let removeHarmfulSynapse: CandidateSynapse | undefined;
         let removeHarmfulNeurons: CandidateHarmfulNeuron[] | undefined;
@@ -877,18 +886,21 @@ class DataRecorder {
           addHelpfulSynapse = candidateBundle.helpfulSynapses;
           removeHarmfulSynapse = candidateBundle.harmfulSynapse;
           addHelpfulNeurons = candidateBundle.helpfulNeurons;
+          splitSynapseInsertNeuronCandidates =
+            candidateBundle.splitSynapseInsertNeuronCandidates;
           this.refreshAnalysisTimeout(discoverStructure);
 
           if (shouldLogDiscovery(config)) {
             const helpfulSynapseCount = addHelpfulSynapse?.length ?? 0;
             const helpfulNeuronCount = addHelpfulNeurons?.length ?? 0;
+            const splitCount = splitSynapseInsertNeuronCandidates?.length ?? 0;
             const harmfulCount = removeHarmfulSynapse ? 1 : 0;
             console.log(
               `Discovery ${blue(this.ID)} candidate collection ${
                 yellow(format(candidateCollectionTime, {
                   ignoreZero: true,
                 }))
-              } synapse candidates: ${helpfulSynapseCount}, neuron candidates: ${helpfulNeuronCount}, harmful removals: ${harmfulCount}`,
+              } synapse candidates: ${helpfulSynapseCount}, neuron candidates: ${helpfulNeuronCount}, split candidates: ${splitCount}, harmful removals: ${harmfulCount}`,
             );
           }
 
@@ -1095,6 +1107,15 @@ class DataRecorder {
           ];
           perfStats.helpfulNeuronRawCount += addHelpfulNeurons.length;
         }
+        if (
+          splitSynapseInsertNeuronCandidates &&
+          splitSynapseInsertNeuronCandidates.length > 0
+        ) {
+          discoverResult.splitSynapseInsertNeuronCandidates = [
+            ...(discoverResult.splitSynapseInsertNeuronCandidates ?? []),
+            ...splitSynapseInsertNeuronCandidates,
+          ];
+        }
         if (addHelpfulSynapse && addHelpfulSynapse.length > 0) {
           discoverResult.addHelpfulSynapses = [
             ...(discoverResult.addHelpfulSynapses ?? []),
@@ -1125,6 +1146,7 @@ class DataRecorder {
         const foundCandidates = Boolean(
           discoverResult.addHelpfulSynapses ||
             discoverResult.addHelpfulNeurons ||
+            discoverResult.splitSynapseInsertNeuronCandidates ||
             discoverResult.removeHarmfulSynapse ||
             discoverResult.removeHarmfulNeurons ||
             discoverResult.candidateSquashes,

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
@@ -4,6 +4,9 @@ import type {
   CandidateSquash,
   CandidateSynapse,
 } from "./DiscoverStructure.ts";
+import type {
+  SplitSynapseInsertNeuronCandidate,
+} from "./SplitSynapseInsertNeuronCandidate.ts";
 import type { RustRemovalCandidate } from "./RustDiscovery.ts";
 
 /**
@@ -49,6 +52,14 @@ export interface DiscoverResult {
   ID: string;
   addHelpfulSynapses: CandidateSynapse[] | undefined;
   addHelpfulNeurons: CandidateNeuron[] | undefined;
+  /**
+   * Optional split-synapse candidates emitted by NEAT-AI-Discovery.
+   *
+   * Kept optional for backwards compatibility with older Rust library versions.
+   */
+  splitSynapseInsertNeuronCandidates?:
+    | SplitSynapseInsertNeuronCandidate[]
+    | undefined;
   removeHarmfulSynapse: CandidateSynapse | undefined;
   removeHarmfulNeurons: CandidateHarmfulNeuron[] | undefined;
   /** Low-impact neurons flagged for removal (from Rust focus ranking). */

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -14,6 +14,9 @@ import { Activations } from "../../methods/activations/Activations.ts";
 import { CreatureErrorImpactEstimator } from "../../discovery/NeuronErrorImpactEstimator.ts";
 import type { DataRecordInterface } from "../DataSet.ts";
 import { fromRustRemovalCandidate } from "./DiscoverResult.ts";
+import type {
+  SplitSynapseInsertNeuronCandidate,
+} from "./SplitSynapseInsertNeuronCandidate.ts";
 import {
   analyzeParallel,
   creatureToRustFormat,
@@ -34,6 +37,7 @@ import {
   type RustParallelAnalysisResult,
   type RustRecordBatchStats,
   type RustRecordInput,
+  type RustStructuralCandidate,
   type RustSynapseDiagnostic,
   type RustSynapseDiagnosticDetail,
 } from "./RustDiscovery.ts";
@@ -243,6 +247,7 @@ interface CandidateAnalysisBundle {
   helpfulSynapses?: CandidateSynapse[];
   harmfulSynapse?: CandidateSynapse;
   helpfulNeurons?: CandidateNeuron[];
+  splitSynapseInsertNeuronCandidates?: SplitSynapseInsertNeuronCandidate[];
 }
 
 type FocusSelectionMode = "weighted" | "forced" | "all" | "random";
@@ -1752,6 +1757,53 @@ export class DiscoverStructure {
     return candidates;
   }
 
+  private tryRustSplitSynapseInsertNeuronCandidates(
+    focusList: string[],
+  ): SplitSynapseInsertNeuronCandidate[] | undefined {
+    const rustResult = this.readRustCombinedAnalysis(
+      focusList,
+      false,
+      true,
+    )?.neuron;
+    if (!rustResult) {
+      return undefined;
+    }
+
+    const structural = rustResult.structuralCandidates ?? [];
+    if (structural.length === 0) {
+      return [];
+    }
+
+    const out: SplitSynapseInsertNeuronCandidate[] = [];
+    for (const candidate of structural) {
+      const typed = candidate as RustStructuralCandidate;
+      if (typed?.type !== "split_synapse_insert_neuron") {
+        continue;
+      }
+
+      // Enforce the Rust contract: exactly two synapses.
+      if (!Array.isArray(typed.newSynapses) || typed.newSynapses.length !== 2) {
+        this.log(
+          "warn",
+          `Skipping split-synapse candidate due to invalid newSynapses length (expected 2, got ${
+            typed.newSynapses?.length ?? "unknown"
+          })`,
+        );
+        continue;
+      }
+
+      out.push({
+        ...typed,
+        newSynapses: [
+          typed.newSynapses[0],
+          typed.newSynapses[1],
+        ],
+      });
+    }
+
+    return out;
+  }
+
   private tryRustHelpfulSynapses(
     focusList: string[],
   ): CandidateSynapse[] | undefined {
@@ -1846,6 +1898,13 @@ export class DiscoverStructure {
     const helpfulNeurons = this.tryRustHelpfulNeurons(focusList);
     if (helpfulNeurons && helpfulNeurons.length > 0) {
       bundle.helpfulNeurons = helpfulNeurons;
+    }
+
+    const splitCandidates = this.tryRustSplitSynapseInsertNeuronCandidates(
+      focusList,
+    );
+    if (splitCandidates && splitCandidates.length > 0) {
+      bundle.splitSynapseInsertNeuronCandidates = splitCandidates;
     }
 
     return bundle;
@@ -2329,6 +2388,9 @@ export class DiscoverStructure {
   private convertParallelAnalysisResult(
     parallel: RustParallelAnalysisResult,
   ): RustAnalyzeAllResult {
+    const structuralCandidates = parallel.structuralCandidates ??
+      (parallel as unknown as { candidates?: RustStructuralCandidate[] })
+        .candidates;
     const hasSynapsePayload = Boolean(
       parallel.helpfulSynapses?.length ||
         parallel.harmfulSynapses?.length ||
@@ -2336,6 +2398,7 @@ export class DiscoverStructure {
     );
     const hasNeuronPayload = Boolean(
       parallel.helpfulNeurons?.length ||
+        structuralCandidates?.length ||
         parallel.neuronDiagnostics?.length,
     );
 
@@ -2354,6 +2417,7 @@ export class DiscoverStructure {
         success: true,
         gpuUsed: parallel.neuronGpuUsed,
         helpfulNeurons: parallel.helpfulNeurons,
+        structuralCandidates,
         diagnostics: parallel.neuronDiagnostics,
       }
       : undefined;

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -1771,18 +1771,23 @@ export class DiscoverStructure {
 
     const structural = rustResult.structuralCandidates ?? [];
     if (structural.length === 0) {
+      this.logRustNoImprovement("neuron", focusList, rustResult.diagnostics);
       return [];
     }
 
     const out: SplitSynapseInsertNeuronCandidate[] = [];
+    let skippedWrongType = 0;
+    let skippedBadSynapseCount = 0;
     for (const candidate of structural) {
       const typed = candidate as RustStructuralCandidate;
       if (typed?.type !== "split_synapse_insert_neuron") {
+        skippedWrongType++;
         continue;
       }
 
       // Enforce the Rust contract: exactly two synapses.
       if (!Array.isArray(typed.newSynapses) || typed.newSynapses.length !== 2) {
+        skippedBadSynapseCount++;
         this.log(
           "warn",
           `Skipping split-synapse candidate due to invalid newSynapses length (expected 2, got ${
@@ -1799,6 +1804,17 @@ export class DiscoverStructure {
           typed.newSynapses[1],
         ],
       });
+    }
+
+    if (out.length === 0) {
+      if (skippedWrongType > 0 || skippedBadSynapseCount > 0) {
+        this.log(
+          "warn",
+          `Rust neuron analysis returned ${structural.length} structural candidate(s) but none were usable after validation (skipped wrong-type=${skippedWrongType}, bad-synapse-count=${skippedBadSynapseCount}).`,
+        );
+      }
+      this.logRustNoImprovement("neuron", focusList, rustResult.diagnostics);
+      return [];
     }
 
     return out;

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -141,6 +141,34 @@ export interface RustCandidateNeuron {
 }
 
 /**
+ * Structural candidate emitted by the Rust discovery engine: split an existing
+ * synapse by inserting a new hidden neuron between the source and target.
+ *
+ * Note: This shape is intentionally aligned with the JSON payload emitted by
+ * NEAT-AI-Discovery so TypeScript can consume it without lossy re-mapping.
+ */
+export interface RustSplitSynapseInsertNeuronCandidate {
+  type: "split_synapse_insert_neuron";
+  fromNeuronUuid: string;
+  toNeuronUuid: string;
+  oldWeight: number;
+  newNeuron: { uuid: string; type: "hidden"; squash: string; bias: number };
+  newSynapses: Array<{
+    from_uuid: string;
+    to_uuid: string;
+    weight: number;
+    type?: string;
+  }>;
+  expectedCreatureScoreGain: number;
+  comment?: string;
+  fromNeuronIndex?: number;
+  toNeuronIndex?: number;
+  targetNeuronImpact?: number;
+}
+
+export type RustStructuralCandidate = RustSplitSynapseInsertNeuronCandidate;
+
+/**
  * Encapsulates the synapse-centric branch of a parallel analysis run, including
  * whether the GPU path was used and any helpful or harmful synapse candidates.
  */
@@ -161,6 +189,12 @@ export interface RustAnalyzeNeuronsResult {
   success: boolean;
   gpuUsed?: boolean;
   helpfulNeurons?: RustCandidateNeuron[];
+  /**
+   * Optional structural candidates emitted as tagged variants.
+   * This allows NEAT-AI-Discovery to evolve additional candidate types without
+   * breaking older TypeScript consumers.
+   */
+  structuralCandidates?: RustStructuralCandidate[];
   diagnostics?: RustNeuronDiagnostic[];
   error?: string;
 }
@@ -214,6 +248,11 @@ export interface RustParallelAnalysisResult {
   synapseDiagnostics?: RustSynapseDiagnostic[];
   synapseGpuUsed?: boolean;
   helpfulNeurons?: RustCandidateNeuron[];
+  /**
+   * Optional structural candidates emitted as tagged variants.
+   * Supported variants are modelled by {@link RustStructuralCandidate}.
+   */
+  structuralCandidates?: RustStructuralCandidate[];
   neuronDiagnostics?: RustNeuronDiagnostic[];
   neuronGpuUsed?: boolean;
   error?: string;

--- a/src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts
@@ -3,6 +3,7 @@ import type { NeuronExport } from "../NeuronInterfaces.ts";
 import type { SynapseExport } from "../SynapseInterfaces.ts";
 import { CreatureUtil } from "../CreatureUtils.ts";
 import { Creature } from "../../Creature.ts";
+import { cleanupMemeticForRemovedSynapse } from "../../compact/CompactUtils.ts";
 
 export interface SplitSynapseInsertNeuronCandidateSynapse {
   "from_uuid": string;
@@ -241,6 +242,13 @@ export function applySplitSynapseInsertNeuronCandidate(
       `${s.fromUUID}->${s.toUUID}` !== originalKey
     ),
   };
+
+  // Clean up memetic data if it referenced the removed synapse.
+  cleanupMemeticForRemovedSynapse(
+    next,
+    candidate.fromNeuronUuid,
+    candidate.toNeuronUuid,
+  );
 
   // Insert neuron immediately before the original target neuron.
   const insertAt = toIndex - inputCount;

--- a/src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts
@@ -1,0 +1,276 @@
+import type { CreatureExport } from "../CreatureInterfaces.ts";
+import type { NeuronExport } from "../NeuronInterfaces.ts";
+import type { SynapseExport } from "../SynapseInterfaces.ts";
+import { CreatureUtil } from "../CreatureUtils.ts";
+import { Creature } from "../../Creature.ts";
+
+export interface SplitSynapseInsertNeuronCandidateSynapse {
+  "from_uuid": string;
+  "to_uuid": string;
+  weight: number;
+  type?: string;
+}
+
+/**
+ * Candidate emitted by NEAT-AI-Discovery (Rust): split an existing synapse by
+ * inserting a new hidden neuron between two existing neurons.
+ */
+export interface SplitSynapseInsertNeuronCandidate {
+  type: "split_synapse_insert_neuron";
+  fromNeuronUuid: string;
+  toNeuronUuid: string;
+  oldWeight: number;
+  newNeuron: { uuid: string; type: "hidden"; squash: string; bias: number };
+  newSynapses: [
+    SplitSynapseInsertNeuronCandidateSynapse,
+    SplitSynapseInsertNeuronCandidateSynapse,
+  ];
+  expectedCreatureScoreGain: number;
+  comment?: string;
+  fromNeuronIndex?: number;
+  toNeuronIndex?: number;
+  targetNeuronImpact?: number;
+}
+
+export interface ApplySplitSynapseInsertNeuronCandidateOptions {
+  /**
+   * Allowed absolute difference between the creature's synapse weight and the
+   * candidate's `oldWeight`.
+   *
+   * Defaults to 1e-6 to tolerate minor JSON rounding.
+   */
+  weightEpsilon?: number;
+}
+
+const DEFAULT_WEIGHT_EPSILON = 1e-6;
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isSynapseType(
+  value: unknown,
+): value is NonNullable<SynapseExport["type"]> {
+  return value === "positive" || value === "negative" || value === "condition";
+}
+
+function buildUuidToIndexMap(creature: CreatureExport): Map<string, number> {
+  const uuidToIndex = new Map<string, number>();
+  const inputCount = creature.input ?? 0;
+  for (let i = 0; i < inputCount; i++) {
+    uuidToIndex.set(`input-${i}`, i);
+  }
+  for (let i = 0; i < creature.neurons.length; i++) {
+    uuidToIndex.set(creature.neurons[i].uuid, inputCount + i);
+  }
+  return uuidToIndex;
+}
+
+function assertForwardOnlyOrThrow(creature: CreatureExport): void {
+  const uuidToIndex = buildUuidToIndexMap(creature);
+  for (const synapse of creature.synapses) {
+    const from = uuidToIndex.get(synapse.fromUUID);
+    const to = uuidToIndex.get(synapse.toUUID);
+    if (from === undefined || to === undefined) {
+      throw new Error(
+        `Cannot validate forward-only ordering: missing neuron UUID for synapse ${synapse.fromUUID} -> ${synapse.toUUID}`,
+      );
+    }
+    if (from >= to) {
+      throw new Error(
+        `Creature is not forward-only ordered (found self-loop or back-connection): ${synapse.fromUUID} -> ${synapse.toUUID}`,
+      );
+    }
+  }
+}
+
+/**
+ * Apply a split-synapse candidate deterministically.
+ *
+ * Behaviour:
+ * - Validates exactly one synapse exists from fromNeuronUuid → toNeuronUuid
+ * - Validates its weight matches oldWeight within epsilon
+ * - Inserts the new hidden neuron immediately before the original target neuron
+ *   in evaluation order (forward-only)
+ * - Removes the original synapse and adds exactly two new synapses
+ *
+ * Returns a new Creature instance (does not mutate the input creature).
+ */
+export function applySplitSynapseInsertNeuronCandidate(
+  creature: Creature,
+  candidate: SplitSynapseInsertNeuronCandidate,
+  options: ApplySplitSynapseInsertNeuronCandidateOptions = {},
+): Creature {
+  const weightEpsilon = options.weightEpsilon ?? DEFAULT_WEIGHT_EPSILON;
+
+  if (candidate.type !== "split_synapse_insert_neuron") {
+    throw new Error(
+      `Unsupported candidate type: ${candidate.type}`,
+    );
+  }
+
+  const base: CreatureExport = creature.exportJSON();
+  assertForwardOnlyOrThrow(base);
+
+  if (!candidate.fromNeuronUuid || !candidate.toNeuronUuid) {
+    throw new Error("Candidate must specify fromNeuronUuid and toNeuronUuid");
+  }
+  if (!isFiniteNumber(candidate.oldWeight)) {
+    throw new Error("Candidate oldWeight must be a finite number");
+  }
+  if (
+    !candidate.newNeuron || candidate.newNeuron.type !== "hidden" ||
+    typeof candidate.newNeuron.uuid !== "string" ||
+    candidate.newNeuron.uuid.length === 0
+  ) {
+    throw new Error("Candidate newNeuron must be a hidden neuron with a UUID");
+  }
+  if (
+    typeof candidate.newNeuron.squash !== "string" ||
+    candidate.newNeuron.squash.length === 0
+  ) {
+    throw new Error("Candidate newNeuron.squash must be a non-empty string");
+  }
+  if (!isFiniteNumber(candidate.newNeuron.bias)) {
+    throw new Error("Candidate newNeuron.bias must be a finite number");
+  }
+
+  const uuidToIndex = buildUuidToIndexMap(base);
+  const inputCount = base.input ?? 0;
+
+  const fromIndex = uuidToIndex.get(candidate.fromNeuronUuid);
+  const toIndex = uuidToIndex.get(candidate.toNeuronUuid);
+  if (fromIndex === undefined) {
+    throw new Error(
+      `fromNeuronUuid not found in creature: ${candidate.fromNeuronUuid}`,
+    );
+  }
+  if (toIndex === undefined) {
+    throw new Error(
+      `toNeuronUuid not found in creature: ${candidate.toNeuronUuid}`,
+    );
+  }
+  if (fromIndex >= toIndex) {
+    throw new Error(
+      `Candidate does not respect forward-only ordering: ${candidate.fromNeuronUuid} -> ${candidate.toNeuronUuid}`,
+    );
+  }
+  if (toIndex < inputCount) {
+    throw new Error(
+      `Candidate toNeuronUuid must not be an input neuron: ${candidate.toNeuronUuid}`,
+    );
+  }
+
+  const existingNeuronUUIDs = new Set<string>();
+  for (let i = 0; i < inputCount; i++) {
+    existingNeuronUUIDs.add(`input-${i}`);
+  }
+  for (const neuron of base.neurons) {
+    existingNeuronUUIDs.add(neuron.uuid);
+  }
+  if (existingNeuronUUIDs.has(candidate.newNeuron.uuid)) {
+    throw new Error(
+      `Candidate newNeuron UUID already exists in creature: ${candidate.newNeuron.uuid}`,
+    );
+  }
+
+  if (
+    !Array.isArray(candidate.newSynapses) || candidate.newSynapses.length !== 2
+  ) {
+    throw new Error(
+      "Candidate newSynapses must be an array of exactly two synapses",
+    );
+  }
+  const [s0, s1] = candidate.newSynapses;
+  const expected0 = `${candidate.fromNeuronUuid}->${candidate.newNeuron.uuid}`;
+  const expected1 = `${candidate.newNeuron.uuid}->${candidate.toNeuronUuid}`;
+  const got0 = `${s0.from_uuid}->${s0.to_uuid}`;
+  const got1 = `${s1.from_uuid}->${s1.to_uuid}`;
+  if (got0 !== expected0 || got1 !== expected1) {
+    throw new Error(
+      `Candidate newSynapses endpoints must be [${expected0}, ${expected1}], got [${got0}, ${got1}]`,
+    );
+  }
+  if (!isFiniteNumber(s0.weight) || !isFiniteNumber(s1.weight)) {
+    throw new Error("Candidate newSynapses weights must be finite numbers");
+  }
+  if (s0.type !== undefined && !isSynapseType(s0.type)) {
+    throw new Error(
+      `Unsupported synapse type for first new synapse: ${s0.type}`,
+    );
+  }
+  if (s1.type !== undefined && !isSynapseType(s1.type)) {
+    throw new Error(
+      `Unsupported synapse type for second new synapse: ${s1.type}`,
+    );
+  }
+
+  const originalKey = `${candidate.fromNeuronUuid}->${candidate.toNeuronUuid}`;
+  const originalMatches = base.synapses.filter((s) =>
+    `${s.fromUUID}->${s.toUUID}` === originalKey
+  );
+  if (originalMatches.length !== 1) {
+    throw new Error(
+      `Expected exactly one synapse ${originalKey} to exist, found ${originalMatches.length}`,
+    );
+  }
+  const original = originalMatches[0];
+  if (Math.abs(original.weight - candidate.oldWeight) > weightEpsilon) {
+    throw new Error(
+      `Synapse ${originalKey} weight mismatch: creature=${original.weight} candidate=${candidate.oldWeight} (epsilon=${weightEpsilon})`,
+    );
+  }
+
+  const existingSynapseKeys = new Set(
+    base.synapses.map((s) => `${s.fromUUID}->${s.toUUID}`),
+  );
+  if (
+    existingSynapseKeys.has(expected0) || existingSynapseKeys.has(expected1)
+  ) {
+    throw new Error(
+      `Candidate would create duplicate synapse(s): ${
+        existingSynapseKeys.has(expected0) ? expected0 : ""
+      } ${existingSynapseKeys.has(expected1) ? expected1 : ""}`.trim(),
+    );
+  }
+
+  const next: CreatureExport = {
+    ...base,
+    neurons: [...base.neurons],
+    synapses: base.synapses.filter((s) =>
+      `${s.fromUUID}->${s.toUUID}` !== originalKey
+    ),
+  };
+
+  // Insert neuron immediately before the original target neuron.
+  const insertAt = toIndex - inputCount;
+  const insertedNeuron: NeuronExport = {
+    uuid: candidate.newNeuron.uuid,
+    type: "hidden",
+    squash: candidate.newNeuron.squash,
+    bias: candidate.newNeuron.bias,
+  };
+  next.neurons.splice(insertAt, 0, insertedNeuron);
+
+  const newSynapse0: SynapseExport = {
+    fromUUID: candidate.fromNeuronUuid,
+    toUUID: candidate.newNeuron.uuid,
+    weight: s0.weight,
+    ...(s0.type ? { type: s0.type } : {}),
+  };
+  const newSynapse1: SynapseExport = {
+    fromUUID: candidate.newNeuron.uuid,
+    toUUID: candidate.toNeuronUuid,
+    weight: s1.weight,
+    ...(s1.type ? { type: s1.type } : {}),
+  };
+
+  next.synapses.push(newSynapse0, newSynapse1);
+
+  // Recreate creature to rebuild any internal caches.
+  const updated = Creature.fromJSON(next);
+  updated.forwardOnly = true;
+  updated.validate({ forwardOnly: true });
+  CreatureUtil.makeUUID(updated);
+  return updated;
+}

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -39,6 +39,10 @@ import {
   type CandidateSynapse,
   DiscoverStructure,
 } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  applySplitSynapseInsertNeuronCandidate,
+  type SplitSynapseInsertNeuronCandidate,
+} from "../architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts";
 import type {
   DiscoverResult,
   RemovalCandidate,
@@ -103,6 +107,7 @@ function buildUuidToIndexMap(
 export type DiscoveryChangeType =
   | "add-synapses"
   | "add-neurons"
+  | "split-synapse-insert-neuron"
   | "remove-synapse"
   | "remove-neuron"
   | "remove-low-impact"
@@ -146,6 +151,8 @@ interface DiscoveryCandidateChange {
   sampleSize?: number;
   /** Details of discovered neurons (for single neuron candidates). */
   neuronDetails?: DiscoveredNeuronDetails;
+  /** Original Rust split-synapse candidate response (for split-synapse candidates). */
+  splitSynapseInsertNeuronCandidate?: SplitSynapseInsertNeuronCandidate;
   /** Details of synapse removal (for synapse removal candidates). */
   synapseDetails?: SynapseRemovalDetails;
   /** Original Rust synapse candidate response (for add-synapses candidates). */
@@ -232,6 +239,8 @@ export function buildDiscoveryCandidates(
   } = discovery;
 
   const helpfulNeuronCandidates = discovery.addHelpfulNeurons;
+  const splitSynapseInsertNeuronCandidates =
+    discovery.splitSynapseInsertNeuronCandidates;
   const addedNeuronCreature = helpfulNeuronCandidates &&
       helpfulNeuronCandidates.length > 0
     ? DiscoverStructure.addHelpfulNeurons(
@@ -278,6 +287,47 @@ export function buildDiscoveryCandidates(
       discoveryFailureCacheDir,
     ),
   );
+
+  if (
+    splitSynapseInsertNeuronCandidates &&
+    splitSynapseInsertNeuronCandidates.length > 0
+  ) {
+    let skippedCount = 0;
+    for (const split of splitSynapseInsertNeuronCandidates) {
+      try {
+        const splitCreature = applySplitSynapseInsertNeuronCandidate(
+          baseCreature,
+          split,
+        );
+        candidates.push({
+          creature: splitCreature,
+          change: {
+            type: "split-synapse-insert-neuron",
+            description: `➗ Split synapse ${
+              shortID(split.fromNeuronUuid)
+            } -> ${shortID(split.toNeuronUuid)} (insert ${
+              shortID(split.newNeuron.uuid)
+            })`,
+            expectedErrorReduction: split.expectedCreatureScoreGain,
+            splitSynapseInsertNeuronCandidate: split,
+          },
+        });
+      } catch (error) {
+        skippedCount++;
+        console.info(
+          `[DiscoveryCandidates] Skipped split-synapse candidate ${split.fromNeuronUuid} -> ${split.toNeuronUuid}:`,
+          error,
+        );
+      }
+    }
+    if (skippedCount > 0) {
+      console.info(
+        `[DiscoveryCandidates] Skipped ${skippedCount}/${splitSynapseInsertNeuronCandidates.length} split-synapse candidate${
+          skippedCount === 1 ? "" : "s"
+        } (apply failed)`,
+      );
+    }
+  }
 
   const addedSynapseCreature = DiscoverStructure.addHelpfulSynapses(
     discovery.ID,
@@ -1519,6 +1569,15 @@ function applyChangeToCreature(
 
   try {
     switch (changeType) {
+      case "split-synapse-insert-neuron": {
+        const spec = candidate.change.splitSynapseInsertNeuronCandidate;
+        if (!spec) {
+          return undefined;
+        }
+        const result = applySplitSynapseInsertNeuronCandidate(creature, spec);
+        return result;
+      }
+
       case "add-synapses": {
         // Find synapses in candidate that don't exist in creature
         const existingSynapses = new Set(

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -223,6 +223,9 @@ export function buildDiscoveryCandidates(
   const getExpectedSquash = (candidate: CandidateSquash) =>
     candidate.expectedCreatureScoreGain;
 
+  const getExpectedSplit = (candidate: SplitSynapseInsertNeuronCandidate) =>
+    candidate.expectedCreatureScoreGain;
+
   const getExpectedRemoval = (candidate?: CandidateSynapse) => {
     if (!candidate) return undefined;
     const value = candidate.expectedCreatureScoreGain;
@@ -241,6 +244,8 @@ export function buildDiscoveryCandidates(
   const helpfulNeuronCandidates = discovery.addHelpfulNeurons;
   const splitSynapseInsertNeuronCandidates =
     discovery.splitSynapseInsertNeuronCandidates;
+  const successfulSplitSynapseInsertNeuronCandidates:
+    SplitSynapseInsertNeuronCandidate[] = [];
   const addedNeuronCreature = helpfulNeuronCandidates &&
       helpfulNeuronCandidates.length > 0
     ? DiscoverStructure.addHelpfulNeurons(
@@ -299,6 +304,7 @@ export function buildDiscoveryCandidates(
           baseCreature,
           split,
         );
+        successfulSplitSynapseInsertNeuronCandidates.push(split);
         candidates.push({
           creature: splitCreature,
           change: {
@@ -700,6 +706,10 @@ export function buildDiscoveryCandidates(
         addHelpfulSynapses: addedSynapseCreature
           ? addHelpfulSynapses
           : undefined,
+        splitSynapseInsertNeuronCandidates:
+          successfulSplitSynapseInsertNeuronCandidates.length > 0
+            ? successfulSplitSynapseInsertNeuronCandidates
+            : undefined,
         removeHarmfulSynapse: removedSynapseCreature
           ? removeHarmfulSynapse
           : undefined,
@@ -720,11 +730,18 @@ export function buildDiscoveryCandidates(
 
     const bestOfCategoryCandidate = buildBestOfCategoryCandidate(
       baseCreature,
-      discovery,
+      {
+        ...discovery,
+        splitSynapseInsertNeuronCandidates:
+          successfulSplitSynapseInsertNeuronCandidates.length > 0
+            ? successfulSplitSynapseInsertNeuronCandidates
+            : undefined,
+      },
       {
         synapse: getExpectedSynapse,
         neuron: getExpectedNeuron,
         squash: getExpectedSquash,
+        split: getExpectedSplit,
       },
       discoveryFailureCacheDir,
     );
@@ -1020,6 +1037,7 @@ export function shortID(id: string): string {
 interface CombinedSelection {
   addHelpfulSynapses?: CandidateSynapse[];
   addHelpfulNeurons?: CandidateNeuron[];
+  splitSynapseInsertNeuronCandidates?: SplitSynapseInsertNeuronCandidate[];
   removeHarmfulSynapse?: CandidateSynapse;
   removeHarmfulNeurons?: CandidateHarmfulNeuron[];
   candidateSquashes?: CandidateSquash[];
@@ -1038,6 +1056,7 @@ interface ScalingFunctions {
   synapse: (synapse: CandidateSynapse) => number | undefined;
   neuron: (neuron: CandidateNeuron) => number | undefined;
   squash: (squash: CandidateSquash) => number | undefined;
+  split: (candidate: SplitSynapseInsertNeuronCandidate) => number | undefined;
 }
 
 function buildCombinedCandidate(
@@ -1055,6 +1074,7 @@ function buildCombinedCandidate(
   const requestedCategories = [
     Boolean(selection.addHelpfulNeurons?.length),
     Boolean(selection.addHelpfulSynapses?.length),
+    Boolean(selection.splitSynapseInsertNeuronCandidates?.length),
     Boolean(selection.removeHarmfulSynapse),
     Boolean(selection.removeHarmfulNeurons?.length),
     Boolean(selection.candidateSquashes?.length),
@@ -1101,6 +1121,30 @@ function buildCombinedCandidate(
           selection.addHelpfulSynapses,
           discoveryFailureCacheDir,
         )
+      : undefined,
+  );
+
+  applyChange(
+    `split-synapse-insert-neuron: ${
+      selection.splitSynapseInsertNeuronCandidates?.length ?? 0
+    }`,
+    selection.splitSynapseInsertNeuronCandidates &&
+      selection.splitSynapseInsertNeuronCandidates.length > 0
+      ? () => {
+        let current = combinedCreature;
+        let appliedCount = 0;
+        for (const split of selection.splitSynapseInsertNeuronCandidates!) {
+          try {
+            current = applySplitSynapseInsertNeuronCandidate(current, split);
+            appliedCount++;
+          } catch {
+            // Best-effort: split candidates are emitted against the base
+            // creature, so some may become invalid after earlier structural
+            // edits in the combo pipeline.
+          }
+        }
+        return appliedCount > 0 ? current : undefined;
+      }
       : undefined,
   );
 
@@ -1223,6 +1267,10 @@ function buildBestOfCategoryCandidate(
     addHelpfulNeurons: wrapBestCandidate(
       discovery.addHelpfulNeurons,
       scaleFns.neuron,
+    ),
+    splitSynapseInsertNeuronCandidates: wrapBestCandidate(
+      discovery.splitSynapseInsertNeuronCandidates,
+      scaleFns.split,
     ),
     candidateSquashes: wrapBestCandidate(
       discovery.candidateSquashes,

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -211,6 +211,8 @@ export class DiscoveryRunner {
         ID: rawDiscover.ID,
         addHelpfulSynapses: rawDiscover.addHelpfulSynapses ?? undefined,
         addHelpfulNeurons: rawDiscover.addHelpfulNeurons ?? undefined,
+        splitSynapseInsertNeuronCandidates:
+          rawDiscover.splitSynapseInsertNeuronCandidates ?? undefined,
         removeHarmfulSynapse: rawDiscover.removeHarmfulSynapse ?? undefined,
         removeHarmfulNeurons: rawDiscover.removeHarmfulNeurons ?? undefined,
         removalCandidates: rawDiscover.removalCandidates ?? undefined,

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -174,6 +174,25 @@ export function buildCacheKey(candidate: DiscoveryCandidate): string {
 
   // Handle different candidate types
   switch (candidate.change.type) {
+    case "split-synapse-insert-neuron": {
+      const split = candidate.change.splitSynapseInsertNeuronCandidate;
+      if (split) {
+        const [s0, s1] = split.newSynapses;
+        parts.push(
+          split.fromNeuronUuid,
+          split.toNeuronUuid,
+          split.newNeuron.squash,
+          formatWeight(split.oldWeight),
+          formatWeight(s0.weight),
+          formatWeight(s1.weight),
+          formatWeight(split.newNeuron.bias),
+        );
+      } else {
+        parts.push(buildStructuralSignature(candidate));
+      }
+      break;
+    }
+
     case "add-neurons": {
       // For add-neurons, use neuronDetails if available
       const details = candidate.change.neuronDetails;
@@ -650,6 +669,15 @@ export async function recordFailure(
       };
     }
 
+    // Include original Rust split-synapse candidate (for split-synapse-insert-neuron candidates)
+    if (candidate.change.splitSynapseInsertNeuronCandidate) {
+      cacheEntry.rustRequest = {
+        ...((cacheEntry.rustRequest as Record<string, unknown>) ?? {}),
+        splitSynapseInsertNeuronCandidate:
+          candidate.change.splitSynapseInsertNeuronCandidate,
+      };
+    }
+
     // Include original Rust synapse candidate (for add-synapses candidates)
     if (candidate.change.synapseCandidate) {
       cacheEntry.rustRequest = {
@@ -809,6 +837,15 @@ export function recordFailureSync(
       cacheEntry.rustRequest = {
         ...((cacheEntry.rustRequest as Record<string, unknown>) ?? {}),
         neuronCandidate: candidate.change.neuronCandidate,
+      };
+    }
+
+    // Include original Rust split-synapse candidate (for split-synapse-insert-neuron candidates)
+    if (candidate.change.splitSynapseInsertNeuronCandidate) {
+      cacheEntry.rustRequest = {
+        ...((cacheEntry.rustRequest as Record<string, unknown>) ?? {}),
+        splitSynapseInsertNeuronCandidate:
+          candidate.change.splitSynapseInsertNeuronCandidate,
       };
     }
 

--- a/test/discovery/SplitSynapseInsertNeuronCandidateCombinedFromSuccessful_test.ts
+++ b/test/discovery/SplitSynapseInsertNeuronCandidateCombinedFromSuccessful_test.ts
@@ -1,0 +1,59 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import {
+  buildCombinedFromSuccessful,
+  type DiscoveryCandidate,
+} from "../../src/discovery/DiscoveryCandidates.ts";
+
+function makeBaseCreature(): Creature {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.25 }],
+  };
+  return Creature.fromJSON(base);
+}
+
+Deno.test("buildCombinedFromSuccessful skips split-synapse candidates with missing spec", () => {
+  const baseCreature = makeBaseCreature();
+
+  // A valid add-synapses candidate (adds one synapse to a hidden neuron we also add).
+  const withHidden: CreatureExport = baseCreature.exportJSON();
+  withHidden.neurons = [
+    { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+    ...withHidden.neurons,
+  ];
+  withHidden.synapses = [
+    ...withHidden.synapses,
+    { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+    { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.5 },
+  ];
+  const addSynapsesCandidate: DiscoveryCandidate = {
+    creature: Creature.fromJSON(withHidden),
+    change: { type: "add-synapses", description: "test add-synapses" },
+  };
+
+  // A malformed split candidate (type says split, but spec field is missing).
+  // This should be ignored by applyChangeToCreature.
+  const brokenSplitCandidate: DiscoveryCandidate = {
+    creature: baseCreature,
+    change: {
+      type: "split-synapse-insert-neuron",
+      description: "test split missing spec",
+    },
+  };
+
+  const combos = buildCombinedFromSuccessful(baseCreature, "discovery-test", [
+    addSynapsesCandidate,
+    brokenSplitCandidate,
+  ]);
+
+  // Only one candidate can be applied, so no combos should be emitted.
+  assertEquals(combos.length, 0);
+});

--- a/test/discovery/SplitSynapseInsertNeuronCandidateCombos_test.ts
+++ b/test/discovery/SplitSynapseInsertNeuronCandidateCombos_test.ts
@@ -1,0 +1,144 @@
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import type {
+  CandidateSynapse,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type {
+  SplitSynapseInsertNeuronCandidate,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { buildDiscoveryCandidates } from "../../src/discovery/DiscoveryCandidates.ts";
+
+function makeBaseCreature(): Creature {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  return Creature.fromJSON(base);
+}
+
+function makeAddSynapseCandidate(): CandidateSynapse {
+  return {
+    fromNeuronUUID: "input-0",
+    toNeuronUUID: "output-0",
+    weight: 0.5,
+    targetNeuronImpact: 1,
+    expectedCreatureErrorReduction: 0.01,
+    expectedCreatureScoreGain: 0.01,
+    improvedCount: 10,
+    totalCount: 10,
+    comment: "combo-test",
+  };
+}
+
+function makeSplitCandidate(): SplitSynapseInsertNeuronCandidate {
+  return {
+    type: "split_synapse_insert_neuron",
+    fromNeuronUuid: "hidden-0",
+    toNeuronUuid: "output-0",
+    oldWeight: 0.25,
+    newNeuron: {
+      uuid: "hidden-split-0",
+      type: "hidden",
+      squash: IDENTITY.NAME,
+      bias: 0,
+    },
+    newSynapses: [
+      { from_uuid: "hidden-0", to_uuid: "hidden-split-0", weight: 0.6 },
+      { from_uuid: "hidden-split-0", to_uuid: "output-0", weight: 0.7 },
+    ],
+    expectedCreatureScoreGain: 0.02,
+    comment: "combo-test",
+  };
+}
+
+function assertSplitApplied(exported: CreatureExport): void {
+  assert(exported.neurons.some((n) => n.uuid === "hidden-split-0"));
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "hidden-0" && s.toUUID === "output-0"
+    ),
+    false,
+  );
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "hidden-0" && s.toUUID === "hidden-split-0"
+    ),
+    true,
+  );
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "hidden-split-0" && s.toUUID === "output-0"
+    ),
+    true,
+  );
+}
+
+Deno.test("combo-all includes split-synapse-insert-neuron candidates", () => {
+  const baseCreature = makeBaseCreature();
+  const discovery: DiscoverResult = {
+    ID: "discovery-combo-test",
+    addHelpfulSynapses: [makeAddSynapseCandidate()],
+    addHelpfulNeurons: undefined,
+    splitSynapseInsertNeuronCandidates: [makeSplitCandidate()],
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
+    candidateSquashes: undefined,
+  };
+
+  const candidates = buildDiscoveryCandidates(baseCreature, discovery);
+  const comboAll = candidates.find((c) => c.change.type === "combo-all");
+  assert(comboAll);
+
+  const exported = comboAll.creature.exportJSON();
+  // Added synapse must exist.
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "input-0" && s.toUUID === "output-0"
+    ),
+    true,
+  );
+  // Split must be applied as well.
+  assertSplitApplied(exported);
+});
+
+Deno.test("combo-best-of-category includes split-synapse-insert-neuron candidates", () => {
+  const baseCreature = makeBaseCreature();
+  const discovery: DiscoverResult = {
+    ID: "discovery-best-combo-test",
+    addHelpfulSynapses: [makeAddSynapseCandidate()],
+    addHelpfulNeurons: undefined,
+    splitSynapseInsertNeuronCandidates: [makeSplitCandidate()],
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
+    candidateSquashes: undefined,
+  };
+
+  const candidates = buildDiscoveryCandidates(baseCreature, discovery);
+  const comboBest = candidates.find((c) =>
+    c.change.type === "combo-best-of-category"
+  );
+  assert(comboBest);
+
+  const exported = comboBest.creature.exportJSON();
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "input-0" && s.toUUID === "output-0"
+    ),
+    true,
+  );
+  assertSplitApplied(exported);
+});

--- a/test/discovery/SplitSynapseInsertNeuronCandidateCoverage_test.ts
+++ b/test/discovery/SplitSynapseInsertNeuronCandidateCoverage_test.ts
@@ -1,0 +1,109 @@
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import type {
+  SplitSynapseInsertNeuronCandidate,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import {
+  buildDiscoveryCandidates,
+  type DiscoveryCandidate,
+} from "../../src/discovery/DiscoveryCandidates.ts";
+import { buildCacheKey } from "../../src/discovery/FailureCache.ts";
+
+function makeBaseCreature(): Creature {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [{
+      uuid: "output-0",
+      type: "output",
+      squash: IDENTITY.NAME,
+      bias: 0,
+    }],
+    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.25 }],
+  };
+  return Creature.fromJSON(base);
+}
+
+function makeSplitCandidate(): SplitSynapseInsertNeuronCandidate {
+  return {
+    type: "split_synapse_insert_neuron",
+    fromNeuronUuid: "input-0",
+    toNeuronUuid: "output-0",
+    oldWeight: 0.25,
+    newNeuron: {
+      uuid: "hidden-split-0",
+      type: "hidden",
+      squash: IDENTITY.NAME,
+      bias: 0.1,
+    },
+    newSynapses: [
+      { "from_uuid": "input-0", "to_uuid": "hidden-split-0", weight: 0.5 },
+      { "from_uuid": "hidden-split-0", "to_uuid": "output-0", weight: -0.75 },
+    ],
+    expectedCreatureScoreGain: 0.123,
+    comment: "coverage-test",
+  };
+}
+
+Deno.test("coverage: buildDiscoveryCandidates includes split-synapse candidates", () => {
+  const creature = makeBaseCreature();
+
+  const discovery: DiscoverResult = {
+    ID: "discovery-test",
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: undefined,
+    splitSynapseInsertNeuronCandidates: [makeSplitCandidate()],
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
+    candidateSquashes: undefined,
+  };
+
+  const candidates = buildDiscoveryCandidates(creature, discovery, {
+    skipCombinedCandidates: true,
+  });
+
+  const splitCandidates = candidates.filter((c) =>
+    c.change.type === "split-synapse-insert-neuron"
+  );
+  assertEquals(splitCandidates.length, 1);
+
+  const exported = splitCandidates[0].creature.exportJSON();
+  assert(exported.neurons.some((n) => n.uuid === "hidden-split-0"));
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "input-0" && s.toUUID === "output-0"
+    ),
+    false,
+  );
+});
+
+Deno.test("coverage: FailureCache key + rustRequest capture for split-synapse candidate", () => {
+  const baseCreature = makeBaseCreature();
+  const discovery: DiscoverResult = {
+    ID: "discovery-test",
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: undefined,
+    splitSynapseInsertNeuronCandidates: [makeSplitCandidate()],
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
+    candidateSquashes: undefined,
+  };
+
+  const built = buildDiscoveryCandidates(baseCreature, discovery, {
+    skipCombinedCandidates: true,
+  });
+  const split = built.find((c) =>
+    c.change.type === "split-synapse-insert-neuron"
+  ) as DiscoveryCandidate | undefined;
+  assert(split);
+
+  // Build key (exercise split-synapse key path).
+  const key = buildCacheKey(split);
+  assert(key.includes("split-synapse-insert-neuron"));
+});

--- a/test/discovery/SplitSynapseInsertNeuronCandidateFailureCache_test.ts
+++ b/test/discovery/SplitSynapseInsertNeuronCandidateFailureCache_test.ts
@@ -1,0 +1,152 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path/join";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import type {
+  CandidateSynapse,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type {
+  SplitSynapseInsertNeuronCandidate,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { buildDiscoveryCandidates } from "../../src/discovery/DiscoveryCandidates.ts";
+import {
+  buildCacheKey,
+  recordFailure,
+  recordFailureSync,
+} from "../../src/discovery/FailureCache.ts";
+import { closeRustLibrary } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+
+function makeBaseCreature(): Creature {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  return Creature.fromJSON(base);
+}
+
+function makeAddSynapseCandidate(): CandidateSynapse {
+  return {
+    fromNeuronUUID: "input-0",
+    toNeuronUUID: "output-0",
+    weight: 0.5,
+    targetNeuronImpact: 1,
+    expectedCreatureErrorReduction: 0.01,
+    expectedCreatureScoreGain: 0.01,
+    improvedCount: 10,
+    totalCount: 10,
+    comment: "failure-cache-test",
+  };
+}
+
+function makeSplitCandidate(): SplitSynapseInsertNeuronCandidate {
+  return {
+    type: "split_synapse_insert_neuron",
+    fromNeuronUuid: "hidden-0",
+    toNeuronUuid: "output-0",
+    oldWeight: 0.25,
+    newNeuron: {
+      uuid: "hidden-split-0",
+      type: "hidden",
+      squash: IDENTITY.NAME,
+      bias: 0,
+    },
+    newSynapses: [
+      { from_uuid: "hidden-0", to_uuid: "hidden-split-0", weight: 0.6 },
+      { from_uuid: "hidden-split-0", to_uuid: "output-0", weight: 0.7 },
+    ],
+    expectedCreatureScoreGain: 0.02,
+    comment: "failure-cache-test",
+  };
+}
+
+Deno.test("FailureCache records split-synapse rustRequest (sync + async)", async () => {
+  const baseCreature = makeBaseCreature();
+  const discovery: DiscoverResult = {
+    ID: "discovery-failure-cache-test",
+    addHelpfulSynapses: [makeAddSynapseCandidate()],
+    addHelpfulNeurons: undefined,
+    splitSynapseInsertNeuronCandidates: [makeSplitCandidate()],
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
+    candidateSquashes: undefined,
+  };
+
+  const candidates = buildDiscoveryCandidates(baseCreature, discovery, {
+    skipCombinedCandidates: true,
+  });
+  const split = candidates.find((c) =>
+    c.change.type === "split-synapse-insert-neuron"
+  );
+  if (!split) {
+    throw new Error("Expected split-synapse candidate to be built");
+  }
+
+  const cacheDir = await Deno.makeTempDir({
+    prefix: "neat-ai-failure-cache-split-",
+  });
+  try {
+    const filePath = join(
+      cacheDir,
+      split.change.type,
+      `${buildCacheKey(split)}.json`,
+    );
+
+    recordFailureSync(
+      cacheDir,
+      split,
+      { originalScore: 1, candidateScore: 0.9, scoreDelta: -0.1, error: 1 },
+      baseCreature,
+    );
+
+    const parsedSync = JSON.parse(await Deno.readTextFile(filePath)) as Record<
+      string,
+      unknown
+    >;
+    const rustRequestSync = parsedSync.rustRequest as Record<string, unknown>;
+    assertEquals(
+      typeof rustRequestSync?.splitSynapseInsertNeuronCandidate,
+      "object",
+    );
+
+    // Also exercise the async recorder (same file path).
+    await recordFailure(
+      cacheDir,
+      split,
+      { originalScore: 1, candidateScore: 0.9, scoreDelta: -0.1, error: 1 },
+      baseCreature,
+    );
+
+    const parsedAsync = JSON.parse(await Deno.readTextFile(filePath)) as Record<
+      string,
+      unknown
+    >;
+    const rustRequestAsync = parsedAsync.rustRequest as Record<string, unknown>;
+    assertEquals(
+      typeof rustRequestAsync?.splitSynapseInsertNeuronCandidate,
+      "object",
+    );
+  } finally {
+    // If `getDiscoveryVersion()` loaded the FFI library, unload it to satisfy
+    // Deno's leak detector for this test case.
+    closeRustLibrary();
+
+    // Best-effort cleanup. (On Windows, open file handles can keep dirs locked.)
+    try {
+      await Deno.remove(cacheDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  }
+});

--- a/test/discovery/SplitSynapseInsertNeuronCandidateMemeticCleanup_test.ts
+++ b/test/discovery/SplitSynapseInsertNeuronCandidateMemeticCleanup_test.ts
@@ -1,0 +1,59 @@
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import {
+  applySplitSynapseInsertNeuronCandidate,
+  type SplitSynapseInsertNeuronCandidate,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test("split-synapse-insert-neuron: cleans up memetic data referencing removed synapse", () => {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.25 }],
+    memetic: {
+      generation: 1,
+      score: 123,
+      biases: {},
+      weights: {
+        "input-0": [{ toUUID: "output-0", weight: 0.99 }],
+      },
+    },
+  };
+
+  const creature = Creature.fromJSON(base);
+
+  // Confirm memetic is present before applying the candidate.
+  const before = creature.exportJSON();
+  assert(before.memetic);
+  assertEquals(before.memetic.weights["input-0"][0].toUUID, "output-0");
+
+  const candidate: SplitSynapseInsertNeuronCandidate = {
+    type: "split_synapse_insert_neuron",
+    fromNeuronUuid: "input-0",
+    toNeuronUuid: "output-0",
+    oldWeight: 0.25,
+    newNeuron: {
+      uuid: "hidden-split-0",
+      type: "hidden",
+      squash: IDENTITY.NAME,
+      bias: 0.1,
+    },
+    newSynapses: [
+      { from_uuid: "input-0", to_uuid: "hidden-split-0", weight: 0.5 },
+      { from_uuid: "hidden-split-0", to_uuid: "output-0", weight: -0.75 },
+    ],
+    expectedCreatureScoreGain: 0.123,
+  };
+
+  const mutated = applySplitSynapseInsertNeuronCandidate(creature, candidate);
+  const after = mutated.exportJSON();
+
+  // Memetic data must be deleted because it referenced the removed synapse.
+  assertEquals(after.memetic, undefined);
+});

--- a/test/discovery/SplitSynapseInsertNeuronCandidateRustLogging_test.ts
+++ b/test/discovery/SplitSynapseInsertNeuronCandidateRustLogging_test.ts
@@ -58,13 +58,17 @@ Deno.test(
       });
 
     const warns = withCapturedWarns(() => {
-      (ds as unknown as { tryRustSplitSynapseInsertNeuronCandidates: (f: string[]) => unknown })
+      (ds as unknown as {
+        tryRustSplitSynapseInsertNeuronCandidates: (f: string[]) => unknown;
+      })
         .tryRustSplitSynapseInsertNeuronCandidates(["output-0"]);
     });
 
     assert(
-      warns.some((m) => m.includes("Rust neuron analysis evaluated") &&
-        m.includes("found no improvements")),
+      warns.some((m) =>
+        m.includes("Rust neuron analysis evaluated") &&
+        m.includes("found no improvements")
+      ),
       `Expected a no-improvement warning, got:\n${warns.join("\n")}`,
     );
   },
@@ -87,16 +91,18 @@ Deno.test(
       });
 
     const warns = withCapturedWarns(() => {
-      (ds as unknown as { tryRustSplitSynapseInsertNeuronCandidates: (f: string[]) => unknown })
+      (ds as unknown as {
+        tryRustSplitSynapseInsertNeuronCandidates: (f: string[]) => unknown;
+      })
         .tryRustSplitSynapseInsertNeuronCandidates(["output-0"]);
     });
 
     assert(
-      warns.some((m) => m.includes("Rust neuron analysis evaluated") &&
-        m.includes("found no improvements")),
+      warns.some((m) =>
+        m.includes("Rust neuron analysis evaluated") &&
+        m.includes("found no improvements")
+      ),
       `Expected a no-improvement warning, got:\n${warns.join("\n")}`,
     );
   },
 );
-
-

--- a/test/discovery/SplitSynapseInsertNeuronCandidateRustLogging_test.ts
+++ b/test/discovery/SplitSynapseInsertNeuronCandidateRustLogging_test.ts
@@ -1,0 +1,102 @@
+import { assert } from "@std/assert";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { Creature } from "../../src/Creature.ts";
+import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+
+function makeDiscoverStructure(): DiscoverStructure {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "output-0", type: "output", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 1 }],
+  });
+  creature.validate({ forwardOnly: true });
+  CreatureUtil.makeUUID(creature);
+
+  return new DiscoverStructure(
+    creature,
+    10,
+    undefined,
+    {},
+    {
+      // Avoid clearing shared directories during concurrent tests.
+      skipRecordPhase: true,
+      baseDirectory: `.discovery/test-split-synapse-logging-${Deno.pid}`,
+    },
+  );
+}
+
+function withCapturedWarns(fn: () => void): string[] {
+  const messages: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    messages.push(args.map((a) => String(a)).join(" "));
+  };
+  try {
+    fn();
+  } finally {
+    console.warn = original;
+  }
+  return messages;
+}
+
+Deno.test(
+  "tryRustSplitSynapseInsertNeuronCandidates: logs no-improvement when Rust returns no structural candidates",
+  () => {
+    const ds = makeDiscoverStructure();
+
+    // Stub combined analysis payload.
+    (ds as unknown as { readRustCombinedAnalysis: () => unknown })
+      .readRustCombinedAnalysis = () => ({
+        neuron: {
+          structuralCandidates: [],
+          diagnostics: [],
+        },
+      });
+
+    const warns = withCapturedWarns(() => {
+      (ds as unknown as { tryRustSplitSynapseInsertNeuronCandidates: (f: string[]) => unknown })
+        .tryRustSplitSynapseInsertNeuronCandidates(["output-0"]);
+    });
+
+    assert(
+      warns.some((m) => m.includes("Rust neuron analysis evaluated") &&
+        m.includes("found no improvements")),
+      `Expected a no-improvement warning, got:\n${warns.join("\n")}`,
+    );
+  },
+);
+
+Deno.test(
+  "tryRustSplitSynapseInsertNeuronCandidates: logs no-improvement when all structural candidates are rejected",
+  () => {
+    const ds = makeDiscoverStructure();
+
+    (ds as unknown as { readRustCombinedAnalysis: () => unknown })
+      .readRustCombinedAnalysis = () => ({
+        neuron: {
+          structuralCandidates: [
+            { type: "unknown_variant" },
+            { type: "split_synapse_insert_neuron", newSynapses: [] },
+          ],
+          diagnostics: [],
+        },
+      });
+
+    const warns = withCapturedWarns(() => {
+      (ds as unknown as { tryRustSplitSynapseInsertNeuronCandidates: (f: string[]) => unknown })
+        .tryRustSplitSynapseInsertNeuronCandidates(["output-0"]);
+    });
+
+    assert(
+      warns.some((m) => m.includes("Rust neuron analysis evaluated") &&
+        m.includes("found no improvements")),
+      `Expected a no-improvement warning, got:\n${warns.join("\n")}`,
+    );
+  },
+);
+
+

--- a/test/discovery/SplitSynapseInsertNeuronCandidateValidation_test.ts
+++ b/test/discovery/SplitSynapseInsertNeuronCandidateValidation_test.ts
@@ -1,0 +1,107 @@
+import { assertThrows } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import {
+  applySplitSynapseInsertNeuronCandidate,
+  type SplitSynapseInsertNeuronCandidate,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+function makeBaseCreature(): Creature {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [{
+      uuid: "output-0",
+      type: "output",
+      squash: IDENTITY.NAME,
+      bias: 0,
+    }],
+    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.25 }],
+  };
+  return Creature.fromJSON(base);
+}
+
+function makeCandidate(
+  overrides: Partial<SplitSynapseInsertNeuronCandidate> = {},
+): SplitSynapseInsertNeuronCandidate {
+  return {
+    type: "split_synapse_insert_neuron",
+    fromNeuronUuid: "input-0",
+    toNeuronUuid: "output-0",
+    oldWeight: 0.25,
+    newNeuron: {
+      uuid: "hidden-split-0",
+      type: "hidden",
+      squash: IDENTITY.NAME,
+      bias: 0.1,
+    },
+    newSynapses: [
+      { "from_uuid": "input-0", "to_uuid": "hidden-split-0", weight: 0.5 },
+      { "from_uuid": "hidden-split-0", "to_uuid": "output-0", weight: -0.75 },
+    ],
+    expectedCreatureScoreGain: 0.123,
+    ...overrides,
+  };
+}
+
+Deno.test("split-synapse validation: throws when creature is not forward-only ordered", () => {
+  const bad: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    // Back-connection output -> hidden violates forward-only.
+    synapses: [{ fromUUID: "output-0", toUUID: "hidden-0", weight: 1 }],
+  };
+  const creature = Creature.fromJSON(bad);
+  assertThrows(() =>
+    applySplitSynapseInsertNeuronCandidate(creature, makeCandidate())
+  );
+});
+
+Deno.test("split-synapse validation: throws on oldWeight mismatch", () => {
+  const creature = makeBaseCreature();
+  assertThrows(() =>
+    applySplitSynapseInsertNeuronCandidate(
+      creature,
+      makeCandidate({ oldWeight: 0.251 }),
+    )
+  );
+});
+
+Deno.test("split-synapse validation: throws when newNeuron UUID already exists", () => {
+  const creature = makeBaseCreature();
+  assertThrows(() =>
+    applySplitSynapseInsertNeuronCandidate(
+      creature,
+      makeCandidate({
+        newNeuron: {
+          uuid: "output-0",
+          type: "hidden",
+          squash: IDENTITY.NAME,
+          bias: 0,
+        },
+      }),
+    )
+  );
+});
+
+Deno.test("split-synapse validation: throws when newSynapses endpoints are wrong", () => {
+  const creature = makeBaseCreature();
+  assertThrows(() =>
+    applySplitSynapseInsertNeuronCandidate(
+      creature,
+      makeCandidate({
+        newSynapses: [
+          { "from_uuid": "input-0", "to_uuid": "output-0", weight: 1 },
+          { "from_uuid": "output-0", "to_uuid": "hidden-split-0", weight: 1 },
+        ],
+      }),
+    )
+  );
+});

--- a/test/discovery/SplitSynapseInsertNeuronCandidate_test.ts
+++ b/test/discovery/SplitSynapseInsertNeuronCandidate_test.ts
@@ -1,0 +1,99 @@
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import {
+  applySplitSynapseInsertNeuronCandidate,
+  type SplitSynapseInsertNeuronCandidate,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test("split-synapse-insert-neuron: removes old synapse and inserts neuron + 2 synapses", () => {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 0.25,
+        type: "positive",
+      },
+    ],
+  };
+
+  const creature = Creature.fromJSON(base);
+  creature.activate(new Float32Array([1]));
+
+  const candidate: SplitSynapseInsertNeuronCandidate = {
+    type: "split_synapse_insert_neuron",
+    fromNeuronUuid: "input-0",
+    toNeuronUuid: "output-0",
+    oldWeight: 0.25,
+    newNeuron: {
+      uuid: "hidden-split-0",
+      type: "hidden",
+      squash: IDENTITY.NAME,
+      bias: 0.1,
+    },
+    newSynapses: [
+      { from_uuid: "input-0", to_uuid: "hidden-split-0", weight: 0.5 },
+      {
+        from_uuid: "hidden-split-0",
+        to_uuid: "output-0",
+        weight: -0.75,
+        type: "condition",
+      },
+    ],
+    expectedCreatureScoreGain: 0.123,
+  };
+
+  const mutated = applySplitSynapseInsertNeuronCandidate(creature, candidate);
+  const exported: CreatureExport = mutated.exportJSON();
+
+  assertEquals(exported.neurons.length, base.neurons.length + 1);
+  assert(exported.neurons.some((n) => n.uuid === "hidden-split-0"));
+
+  // Remove 1 synapse, add 2 => net +1.
+  assertEquals(exported.synapses.length, base.synapses.length + 1);
+
+  // Original synapse must be gone.
+  assertEquals(
+    exported.synapses.filter((s) =>
+      s.fromUUID === "input-0" && s.toUUID === "output-0"
+    ).length,
+    0,
+  );
+
+  // Two new synapses must exist with the requested weights/types.
+  const inToHidden = exported.synapses.find((s) =>
+    s.fromUUID === "input-0" && s.toUUID === "hidden-split-0"
+  );
+  const hiddenToOut = exported.synapses.find((s) =>
+    s.fromUUID === "hidden-split-0" && s.toUUID === "output-0"
+  );
+  assert(inToHidden);
+  assert(hiddenToOut);
+  assertEquals(inToHidden.weight, 0.5);
+  assertEquals(hiddenToOut.weight, -0.75);
+  assertEquals(hiddenToOut.type, "condition");
+
+  // Neuron must be inserted before the original target neuron.
+  const outIndex = exported.neurons.findIndex((n) => n.uuid === "output-0");
+  const hiddenIndex = exported.neurons.findIndex((n) =>
+    n.uuid === "hidden-split-0"
+  );
+  assert(hiddenIndex >= 0 && outIndex >= 0);
+  assert(hiddenIndex < outIndex);
+
+  // Mutated creature still activates (ordering must remain valid).
+  mutated.activate(new Float32Array([1]));
+
+  // Re-applying the same candidate should fail cleanly (idempotency).
+  assertThrows(() =>
+    applySplitSynapseInsertNeuronCandidate(mutated, candidate)
+  );
+});


### PR DESCRIPTION
…sert neuron candidate handling

- Bumped version in deno.json to 0.277.0.
- Added support for handling split synapse insert neuron candidates throughout the discovery and analysis processes.
- Enhanced the DiscoverResult and DiscoveryCandidates modules to accommodate new candidate types, improving the framework's capability to evolve neural structures.

These changes enhance the functionality and maintainability of the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces structural candidate support to evolve topology by splitting a synapse and inserting a hidden neuron, wired through discovery, analysis, and candidate application.
> 
> - New `SplitSynapseInsertNeuronCandidate` type and `applySplitSynapseInsertNeuronCandidate` to deterministically apply changes
> - Plumbs structural results from Rust: reads `structuralCandidates` in `RustDiscovery`, converts in `DiscoverStructure`, and exposes `splitSynapseInsertNeuronCandidates` in `DiscoverResult` and `DiscoverDirectory`
> - Extends `DiscoveryCandidates` to build/apply split candidates, include them in `combo-all`/`combo-best-of-category`, and generate failure-cache keys with original Rust payload capture
> - Updates `DiscoveryRunner` pass-through for the new field
> - Adds focused tests covering validation, application, combos, failure-cache, logging, and coverage paths
> - Misc: bump version to `0.277.0`; update `codecov.yml` (ignore coverage-only test, keep structural files ignored; enable `require_changes`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f3a726e77c3af891bb96d2f7a866237151c8b53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->