### PR TITLE
Update version to 0.278.1 in deno.json and add internal documentation…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.278.0",
+  "version": "0.278.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -89,7 +89,12 @@ type EvaluationTask = {
   description?: string;
 };
 
-async function evaluateAll(
+/**
+ * Evaluate a batch of replay tasks across a set of workers.
+ *
+ * @internal
+ */
+export async function evaluateAll(
   workers: WorkerHandler[],
   tasks: EvaluationTask[],
   feedbackLoop: boolean,

--- a/test/discovery/DiscoveryReplayRunnerCoverage_test.ts
+++ b/test/discovery/DiscoveryReplayRunnerCoverage_test.ts
@@ -1,0 +1,369 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import type {
+  CandidateNeuron,
+  CandidateSquash,
+  CandidateSynapse,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { RemovalCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import type { SplitSynapseInsertNeuronCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/SplitSynapseInsertNeuronCandidate.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { TANH } from "../../src/methods/activations/types/TANH.ts";
+import { DiscoveryReplayRunner } from "../../src/discovery/DiscoveryReplayRunner.ts";
+import type { SuccessCacheEntry } from "../../src/discovery/SuccessCache.ts";
+
+function makeEntry(
+  key: string,
+  changeType: string,
+  rustRequest: Record<string, unknown>,
+): SuccessCacheEntry {
+  return {
+    key,
+    changeType,
+    description: key,
+    originalScore: 0.5,
+    candidateScore: 0.6,
+    scoreDelta: 0.1,
+    originalError: 1,
+    error: 0.9,
+    timestamp: new Date().toISOString(),
+    rustRequest,
+  };
+}
+
+Deno.test("DiscoveryReplayRunner: default applyEntry replays singles, then all-successful combo, returning best", async () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  });
+  creature.uuid = "base";
+
+  const addSynapse: CandidateSynapse = {
+    fromNeuronUUID: "input-0",
+    toNeuronUUID: "output-0",
+    weight: 0.5,
+    targetNeuronImpact: 1,
+    expectedCreatureErrorReduction: 0.01,
+    expectedCreatureScoreGain: 0.01,
+    improvedCount: 1,
+    totalCount: 1,
+    comment: "replay-test",
+  };
+
+  const changeSquash: CandidateSquash = {
+    neuronUUID: "hidden-0",
+    previousSquash: IDENTITY.NAME,
+    squash: TANH.NAME,
+    expectedCreatureScoreGain: 0.01,
+    improvedError: 0.9,
+    currentError: 1.0,
+    comment: "replay-test",
+  };
+
+  const eAdd = makeEntry("add", "add-synapses", {
+    synapseCandidate: addSynapse,
+  });
+  const eSquash = makeEntry("squash", "change-squash", {
+    squashCandidate: changeSquash,
+  });
+
+  const deleted: string[] = [];
+  const runner = new DiscoveryReplayRunner({
+    listEntries: () => [eAdd, eSquash],
+    deleteEntry: (_dir, entry) => deleted.push(entry.key),
+    // Use the default applyEntryUsingRustRequest by not overriding applyEntry.
+    evaluateError: (c) => {
+      const exported = c.exportJSON();
+      const hasDirect = exported.synapses.some((s) =>
+        s.fromUUID === "input-0" && s.toUUID === "output-0"
+      );
+      const hidden0 = c.neurons.find((n) => n.uuid === "hidden-0");
+      const hasTanh = hidden0?.squash === TANH.NAME;
+
+      // Baseline: 0.5
+      // Add synapse only: 0.6
+      // Change squash only: 0.61
+      // Both (combo): 0.7
+      const score = hasDirect && hasTanh
+        ? 0.7
+        : hasTanh
+        ? 0.61
+        : hasDirect
+        ? 0.6
+        : 0.5;
+      return Promise.resolve({ error: 0, score });
+    },
+  });
+
+  const result = await runner.replayDir({
+    creature,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      discoveryReplayMaxSingles: 10,
+      discoveryReplayMaxPairwise: 10,
+      discoveryReplayMaxTriples: 10,
+      threads: 1,
+    },
+  });
+
+  assertEquals(result.evaluatedSingles, 2);
+  assertEquals(result.pruned, 0);
+  assertEquals(deleted.length, 0);
+
+  assertExists(result.improvement);
+  assertEquals(result.improvement.changeType, "combo-successful");
+  assertEquals(result.improvement.score, 0.7);
+});
+
+Deno.test("DiscoveryReplayRunner: skips already-applied add-synapses candidates", async () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature.uuid = "base";
+
+  const addSynapse: CandidateSynapse = {
+    fromNeuronUUID: "input-0",
+    toNeuronUUID: "output-0",
+    weight: 0.5,
+    targetNeuronImpact: 1,
+    expectedCreatureErrorReduction: 0.01,
+    expectedCreatureScoreGain: 0.01,
+    improvedCount: 1,
+    totalCount: 1,
+  };
+
+  const entry = makeEntry("already", "add-synapses", {
+    synapseCandidate: addSynapse,
+  });
+  const runner = new DiscoveryReplayRunner({
+    listEntries: () => [entry],
+    evaluateError: () => Promise.resolve({ error: 0, score: 0.5 }),
+  });
+
+  const result = await runner.replayDir({
+    creature,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      threads: 1,
+    },
+  });
+
+  assertEquals(result.skippedAlreadyApplied, 1);
+  assertEquals(result.evaluatedSingles, 0);
+  assertEquals(result.improvement, undefined);
+});
+
+Deno.test("DiscoveryReplayRunner: prunes stale candidates (remove-low-impact + remove-synapse synapseDetails fallback)", async () => {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", squash: IDENTITY.NAME, bias: 0.25, uuid: "neuron-X" },
+      { type: "hidden", squash: IDENTITY.NAME, bias: -0.1, uuid: "neuron-T" },
+      { type: "output", squash: IDENTITY.NAME, bias: 0.05, uuid: "output-0" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "neuron-X", weight: 1.0 },
+      { fromUUID: "neuron-X", toUUID: "neuron-T", weight: -1.2 },
+      { fromUUID: "neuron-X", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "neuron-T", toUUID: "output-0", weight: 0.25 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: -0.25 },
+    ],
+  });
+  creature.uuid = "base";
+
+  const removal: RemovalCandidate = {
+    neuronUUID: "neuron-X",
+    totalError: 1,
+    impact: 0.0001,
+    reason: "test",
+    meanActivation: 0.4,
+  };
+
+  const removeSynapseDetails = {
+    fromNeuronUUID: "neuron-T",
+    toNeuronUUID: "output-0",
+  };
+
+  const eRemoval = makeEntry("low-impact", "remove-low-impact", {
+    removalCandidate: removal,
+  });
+  const eRemoveSyn = makeEntry("rm-syn", "remove-synapse", {
+    synapseDetails: removeSynapseDetails,
+  });
+
+  const deleted: string[] = [];
+  const runner = new DiscoveryReplayRunner({
+    listEntries: () => [eRemoval, eRemoveSyn],
+    deleteEntry: (_dir, entry) => deleted.push(entry.key),
+    evaluateError: (c) => {
+      // If we removed neuron-X or removed neuron-T->output-0, call it worse.
+      const exported = c.exportJSON();
+      const hasX = c.neurons.some((n) => n.uuid === "neuron-X");
+      const hasTSyn = exported.synapses.some((s) =>
+        s.fromUUID === "neuron-T" && s.toUUID === "output-0"
+      );
+      const score = hasX && hasTSyn ? 0.5 : 0.4;
+      return Promise.resolve({ error: 0, score });
+    },
+  });
+
+  const result = await runner.replayDir({
+    creature,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      threads: 1,
+    },
+  });
+
+  assertEquals(result.pruned, 2);
+  assertEquals(deleted.sort(), ["low-impact", "rm-syn"].sort());
+  assertEquals(result.improvement, undefined);
+});
+
+Deno.test("DiscoveryReplayRunner: add-neurons already-applied detection matches exponent buckets", async () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "added-1", type: "hidden", squash: IDENTITY.NAME, bias: 0.001 }, // e-3
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "added-1", weight: 0.12 }, // e-1
+      { fromUUID: "added-1", toUUID: "output-0", weight: 0.34 }, // e-1
+    ],
+  });
+  creature.uuid = "base";
+
+  const neuronDetails = {
+    fromNeuronUUID: "input-0",
+    toNeuronUUID: "output-0",
+    incomingWeight: 0.12,
+    outgoingWeight: 0.34,
+    bias: 0.001,
+    squash: IDENTITY.NAME,
+  };
+
+  const neuronCandidate: CandidateNeuron = {
+    fromNeuronUUID: "input-0",
+    toNeuronUUID: "output-0",
+    incomingWeight: 0.12,
+    outgoingWeight: 0.34,
+    squash: IDENTITY.NAME,
+    bias: 0.001,
+    targetNeuronImpact: 1,
+    expectedCreatureErrorReduction: 0.01,
+    expectedCreatureScoreGain: 0.01,
+    improvedCount: 1,
+    totalCount: 1,
+  };
+
+  const entry = makeEntry("n", "add-neurons", {
+    neuronDetails,
+    neuronCandidate,
+  });
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: () => [entry],
+    evaluateError: () => Promise.resolve({ error: 0, score: 0.5 }),
+  });
+
+  const result = await runner.replayDir({
+    creature,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      threads: 1,
+    },
+  });
+
+  assertEquals(result.skippedAlreadyApplied, 1);
+  assertEquals(result.evaluatedSingles, 0);
+});
+
+Deno.test("DiscoveryReplayRunner: split-synapse candidate can be replayed", async () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  });
+  creature.uuid = "base";
+
+  const split: SplitSynapseInsertNeuronCandidate = {
+    type: "split_synapse_insert_neuron",
+    fromNeuronUuid: "hidden-0",
+    toNeuronUuid: "output-0",
+    oldWeight: 0.25,
+    newNeuron: {
+      uuid: "hidden-split-0",
+      type: "hidden",
+      squash: IDENTITY.NAME,
+      bias: 0,
+    },
+    newSynapses: [
+      { from_uuid: "hidden-0", to_uuid: "hidden-split-0", weight: 0.6 },
+      { from_uuid: "hidden-split-0", to_uuid: "output-0", weight: 0.7 },
+    ],
+    expectedCreatureScoreGain: 0.01,
+  };
+
+  const entry = makeEntry("split", "split-synapse-insert-neuron", {
+    splitSynapseInsertNeuronCandidate: split,
+  });
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: () => [entry],
+    evaluateError: (c) => {
+      const hasSplit = c.neurons.some((n) => n.uuid === "hidden-split-0");
+      return Promise.resolve({ error: 0, score: hasSplit ? 0.6 : 0.5 });
+    },
+  });
+
+  const result = await runner.replayDir({
+    creature,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      threads: 1,
+    },
+  });
+
+  assertExists(result.improvement);
+  assertEquals(result.improvement.changeType, "split-synapse-insert-neuron");
+});

--- a/test/discovery/DiscoveryReplayRunnerEvaluateAll_test.ts
+++ b/test/discovery/DiscoveryReplayRunnerEvaluateAll_test.ts
@@ -1,0 +1,29 @@
+import { assertEquals } from "@std/assert";
+import type { WorkerHandler } from "../../src/multithreading/workers/WorkerHandler.ts";
+import type { Creature } from "../../src/Creature.ts";
+import { evaluateAll } from "../../src/discovery/DiscoveryReplayRunner.ts";
+
+Deno.test("DiscoveryReplayRunner.evaluateAll: distributes evaluation across workers", async () => {
+  const makeWorker = (error: number) =>
+    ({
+      evaluate: (_creature: Creature, _feedbackLoop: boolean) =>
+        Promise.resolve({ taskID: 1, duration: 0, evaluate: { error } }),
+    }) as unknown as WorkerHandler;
+
+  const workers = [makeWorker(0.1), makeWorker(0.2)];
+
+  const tasks = [
+    { kind: "single" as const, creature: {} as unknown as Creature },
+    { kind: "single" as const, creature: {} as unknown as Creature },
+    { kind: "single" as const, creature: {} as unknown as Creature },
+  ];
+
+  const results = await evaluateAll(workers, tasks, false, 0);
+
+  // We don't care which worker took which task; we just want all tasks evaluated.
+  assertEquals(results.length, 3);
+  assertEquals(
+    results.map((r) => r.error).sort(),
+    [0.1, 0.1, 0.2].sort(),
+  );
+});

--- a/test/discovery/DiscoveryReplayRunnerEvaluateAll_test.ts
+++ b/test/discovery/DiscoveryReplayRunnerEvaluateAll_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import type { WorkerHandler } from "../../src/multithreading/workers/WorkerHandler.ts";
-import type { Creature } from "../../src/Creature.ts";
+import { Creature } from "../../src/Creature.ts";
 import { evaluateAll } from "../../src/discovery/DiscoveryReplayRunner.ts";
 
 Deno.test("DiscoveryReplayRunner.evaluateAll: distributes evaluation across workers", async () => {
@@ -12,10 +12,23 @@ Deno.test("DiscoveryReplayRunner.evaluateAll: distributes evaluation across work
 
   const workers = [makeWorker(0.1), makeWorker(0.2)];
 
+  const baseCreature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [{
+      uuid: "output-0",
+      type: "output",
+      squash: "IDENTITY",
+      bias: 0,
+    }],
+    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.1 }],
+  });
+
   const tasks = [
-    { kind: "single" as const, creature: {} as unknown as Creature },
-    { kind: "single" as const, creature: {} as unknown as Creature },
-    { kind: "single" as const, creature: {} as unknown as Creature },
+    { kind: "single" as const, creature: baseCreature },
+    { kind: "single" as const, creature: baseCreature },
+    { kind: "single" as const, creature: baseCreature },
   ];
 
   const results = await evaluateAll(workers, tasks, false, 0);

--- a/test/discovery/SuccessCacheCoverage_test.ts
+++ b/test/discovery/SuccessCacheCoverage_test.ts
@@ -1,0 +1,181 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path/join";
+import { Creature } from "../../src/Creature.ts";
+import {
+  deleteSuccessByKeySync,
+  listSuccessEntriesSync,
+  recordSuccessSync,
+} from "../../src/discovery/SuccessCache.ts";
+import type { DiscoveryCandidate } from "../../src/discovery/DiscoveryCandidates.ts";
+import { closeRustLibrary } from "../../src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+
+Deno.test("SuccessCache: listSuccessEntriesSync returns [] for missing directory and skips corrupt JSON", async () => {
+  const missing = join(await Deno.makeTempDir(), "does-not-exist");
+  assertEquals(listSuccessEntriesSync(missing), []);
+
+  const cacheDir = await Deno.makeTempDir({
+    prefix: "neat-ai-success-cache-bad-",
+  });
+  try {
+    const typeDir = join(cacheDir, "add-synapses");
+    await Deno.mkdir(typeDir, { recursive: true });
+    await Deno.writeTextFile(join(typeDir, "bad.json"), "{not-json");
+    assertEquals(listSuccessEntriesSync(cacheDir), []);
+  } finally {
+    try {
+      await Deno.remove(cacheDir, { recursive: true });
+    } catch {
+      // Ignore cleanup failures.
+    }
+  }
+});
+
+Deno.test("SuccessCache: deleteSuccessByKeySync ignores missing files", async () => {
+  const cacheDir = await Deno.makeTempDir({
+    prefix: "neat-ai-success-cache-del-",
+  });
+  try {
+    deleteSuccessByKeySync(cacheDir, "add-synapses", "missing-key");
+  } finally {
+    try {
+      await Deno.remove(cacheDir, { recursive: true });
+    } catch {
+      // Ignore cleanup failures.
+    }
+  }
+});
+
+Deno.test("SuccessCache: recordSuccessSync captures rustRequest fields for many candidate shapes", async () => {
+  const cacheDir = await Deno.makeTempDir({
+    prefix: "neat-ai-success-cache-rust-",
+  });
+  try {
+    const baseCreature = Creature.fromJSON({
+      input: 1,
+      output: 1,
+      neurons: [{
+        uuid: "output-0",
+        type: "output",
+        squash: "IDENTITY",
+        bias: 0,
+      }],
+      synapses: [],
+    });
+
+    const candidate: DiscoveryCandidate = {
+      creature: baseCreature,
+      change: {
+        type: "add-neurons",
+        description: "all-fields",
+        neuronDetails: {
+          fromNeuronUUID: "input-0",
+          toNeuronUUID: "output-0",
+          incomingWeight: 0.1,
+          outgoingWeight: 0.2,
+          bias: 0.01,
+          squash: "IDENTITY",
+        },
+        neuronCandidate: {
+          fromNeuronUUID: "input-0",
+          toNeuronUUID: "output-0",
+          incomingWeight: 0.1,
+          outgoingWeight: 0.2,
+          bias: 0.01,
+          squash: "IDENTITY",
+          targetNeuronImpact: 1,
+          expectedCreatureErrorReduction: 0.01,
+          expectedCreatureScoreGain: 0.01,
+          improvedCount: 1,
+          totalCount: 1,
+        },
+        splitSynapseInsertNeuronCandidate: {
+          type: "split_synapse_insert_neuron",
+          fromNeuronUuid: "a",
+          toNeuronUuid: "b",
+          oldWeight: 0.1,
+          newNeuron: { uuid: "c", type: "hidden", squash: "IDENTITY", bias: 0 },
+          newSynapses: [
+            { from_uuid: "a", to_uuid: "c", weight: 0.2 },
+            { from_uuid: "c", to_uuid: "b", weight: 0.3 },
+          ],
+          expectedCreatureScoreGain: 0.01,
+        },
+        synapseCandidate: {
+          fromNeuronUUID: "input-0",
+          toNeuronUUID: "output-0",
+          weight: 0.5,
+          targetNeuronImpact: 1,
+          expectedCreatureErrorReduction: 0.01,
+          expectedCreatureScoreGain: 0.01,
+          improvedCount: 1,
+          totalCount: 1,
+        },
+        squashCandidate: {
+          neuronUUID: "output-0",
+          previousSquash: "IDENTITY",
+          squash: "TANH",
+          expectedCreatureScoreGain: 0.01,
+          improvedError: 0.9,
+          currentError: 1.0,
+        },
+        removalCandidate: {
+          neuronUUID: "x",
+          totalError: 1,
+          impact: 0.0001,
+          reason: "test",
+        },
+        harmfulNeuronCandidate: {
+          neuronUUID: "y",
+          errorMagnitude: 1,
+          expectedCreatureScoreGain: 0.01,
+          sampleCount: 1,
+          averageActivation: 0,
+        },
+        harmfulSynapseCandidate: {
+          fromNeuronUUID: "m",
+          toNeuronUUID: "n",
+          weight: 0.1,
+          targetNeuronImpact: 1,
+          expectedCreatureErrorReduction: 0.01,
+          expectedCreatureScoreGain: 0.01,
+          improvedCount: 1,
+          totalCount: 1,
+        },
+        synapseDetails: { fromNeuronUUID: "m", toNeuronUUID: "n" },
+      },
+    };
+
+    recordSuccessSync(
+      cacheDir,
+      candidate,
+      {
+        originalScore: 1,
+        candidateScore: 2,
+        scoreDelta: 1,
+        originalError: 1,
+        error: 0.5,
+      },
+      baseCreature,
+    );
+
+    const entries = listSuccessEntriesSync(cacheDir);
+    assertEquals(entries.length, 1);
+    const rr = entries[0].rustRequest as Record<string, unknown>;
+    assertEquals(typeof rr.neuronDetails, "object");
+    assertEquals(typeof rr.neuronCandidate, "object");
+    assertEquals(typeof rr.splitSynapseInsertNeuronCandidate, "object");
+    assertEquals(typeof rr.synapseCandidate, "object");
+    assertEquals(typeof rr.squashCandidate, "object");
+    assertEquals(typeof rr.removalCandidate, "object");
+    assertEquals(typeof rr.harmfulNeuronCandidate, "object");
+    assertEquals(typeof rr.harmfulSynapseCandidate, "object");
+    assertEquals(typeof rr.synapseDetails, "object");
+  } finally {
+    closeRustLibrary();
+    try {
+      await Deno.remove(cacheDir, { recursive: true });
+    } catch {
+      // Ignore cleanup failures.
+    }
+  }
+});


### PR DESCRIPTION
… for evaluateAll function in DiscoveryReplayRunner.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens replay and cache reliability and exposes a small internal helper.
> 
> - **Export** `evaluateAll` in `src/discovery/DiscoveryReplayRunner.ts` with JSDoc `@internal` to parallelize worker evaluations
> - **Add tests**:
>   - `test/discovery/DiscoveryReplayRunnerCoverage_test.ts` covering single replays, combo aggregation, already-applied detection, pruning stale entries, exponent-bucket matching for `add-neurons`, and split-synapse replay
>   - `test/discovery/DiscoveryReplayRunnerEvaluateAll_test.ts` verifying task distribution across workers
>   - `test/discovery/SuccessCacheCoverage_test.ts` validating listing behavior on missing/corrupt files, safe deletion, and comprehensive `rustRequest` capture for multiple candidate shapes
> - **Version** bump in `deno.json` to `0.278.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef43aa56a13ee0f87f5e07885d6210ed7ffa49b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->