### PR TITLE
Update version to 0.279.1 in deno.json and add timing diagnostics to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ const replay = await creature.discoveryReplayDir(dataDir, {
   discoveryReplayConcurrency: 8,
   // When verification is enabled, include claimed vs actual baseline drift details
   discoveryReplayRescoreBaseline: true,
+  // Optional: return timing diagnostics for visibility into where replay time is spent.
+  discoveryReplayDiagnostics: true,
 });
 
 if (replay.improvement) {
@@ -343,6 +345,9 @@ if (replay.baselineRescore?.changed) {
 }
 if (replay.verifiedImprovement?.improved) {
   console.log(replay.verifiedImprovement.message);
+}
+if (replay.diagnostics) {
+  console.log(replay.diagnostics.timingsMS);
 }
 ```
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.279.0",
+  "version": "0.279.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -96,6 +96,8 @@
     "extern",
     "overfitting",
     "unscored",
+    "rescoring",
+    "teardown",
     "Millis",
     "wgpu",
     "WGSL",

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -328,6 +328,14 @@ export interface NeatArguments {
   discoveryReplayRescoreBaseline: boolean;
 
   /**
+   * When true, replay records and returns simple timing diagnostics so callers can
+   * see where time is being spent (workers, rescoring, applying candidates, etc.).
+   *
+   * Defaults to false.
+   */
+  discoveryReplayDiagnostics: boolean;
+
+  /**
    * Minimum candidates to evaluate per discovery category.
    */
   discoveryMinCandidatesPerCategory: Required<

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -209,6 +209,7 @@ export function createNeatConfig(options: NeatOptions): NeatConfig {
       if (typeof user === "boolean") return user;
       return verify ? true : false;
     })(),
+    discoveryReplayDiagnostics: options.discoveryReplayDiagnostics ?? false,
     discoveryMinCandidatesPerCategory: {
       ...DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY,
       ...options.discoveryMinCandidatesPerCategory,

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -853,6 +853,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         };
       }
 
+      const prefix = "🦘";
       if (verifyScores && config.discoveryReplayRescoreBaseline) {
         const claimedScore = parseClaimedTagNumber(creature.tags, "score");
         const claimedError = parseClaimedTagNumber(creature.tags, "error");
@@ -860,7 +861,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
           claimedScore,
           originalEval.score,
         );
-        const prefix = "🦘";
         const reason = claimedScore === undefined
           ? `${prefix} Baseline rescore: no claimed score tag found, so I rescored on the current dataset (score=${originalEval.score}, error=${originalEval.error}).`
           : `${prefix} Score drift check: claimed score ${claimedScore} (error ${
@@ -898,7 +898,8 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
             error: best.error,
             scoreDelta,
             improved: scoreDelta > 0,
-            message: `Verified improvement on current dataset: ${message}`,
+            message:
+              `${prefix} Verified improvement on current dataset: ${message}`,
             creature: best.creature.exportJSON(),
           };
         }

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -43,11 +43,42 @@ export interface DiscoveryReplayEvaluationSummary {
   improved: boolean;
 }
 
+export interface DiscoveryReplayDiagnostics {
+  /**
+   * Timing breakdown in milliseconds. Values are best-effort and intended for
+   * visibility (where time is being spent), not micro-benchmarking.
+   */
+  timingsMS: {
+    total?: number;
+    setupWorkers?: number;
+    listEntries?: number;
+    sortEntries?: number;
+    applySingles?: number;
+    evaluateBaselineAndSingles?: number;
+    buildCombos?: number;
+    evaluateCombos?: number;
+    selectBest?: number;
+    teardownWorkers?: number;
+  };
+  counts: {
+    workerCount: number;
+    entriesLoaded: number;
+    singlesApplied: number;
+    singlesEvaluated: number;
+    combosBuilt: number;
+    combosEvaluated: number;
+    pruned: number;
+    skippedAlreadyApplied: number;
+    skippedNotApplicable: number;
+  };
+}
+
 export interface DiscoveryReplayDirResult {
   original: {
     error: number;
     score: number;
   };
+  diagnostics?: DiscoveryReplayDiagnostics;
   baselineRescore?: {
     claimedScore?: number;
     actualScore: number;
@@ -508,6 +539,13 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
     const replayConcurrency = verifyScores
       ? config.discoveryReplayConcurrency
       : config.threads;
+    const diagnosticsEnabled =
+      (config as unknown as { discoveryReplayDiagnostics?: boolean })
+        .discoveryReplayDiagnostics ?? false;
+    const totalStart = diagnosticsEnabled ? performance.now() : 0;
+    const timingsMS: DiscoveryReplayDiagnostics["timingsMS"] | undefined =
+      diagnosticsEnabled ? {} : undefined;
+    let resultToReturn: DiscoveryReplayDirResult | undefined;
 
     const successCacheDir = config.discoverySuccessCacheDir;
     if (!successCacheDir) {
@@ -525,6 +563,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
     try {
       if (!this.#deps.evaluateError) {
         const workerCount = replayConcurrency;
+        const setupStart = diagnosticsEnabled ? performance.now() : 0;
         for (let i = 0; i < workerCount; i++) {
           workers.push(
             new WorkerHandler(
@@ -535,6 +574,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
             ),
           );
         }
+        if (timingsMS) timingsMS.setupWorkers = performance.now() - setupStart;
       }
 
       const deps = {
@@ -567,18 +607,22 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       };
 
       // Load cache entries and prioritise by historical delta.
+      const listStart = diagnosticsEnabled ? performance.now() : 0;
       const allEntries = deps.listEntries(successCacheDir)
         .filter((e) =>
           typeof e.key === "string" && typeof e.changeType === "string"
         )
         // Do not persist combo entries; replay builds combos on demand from singles.
         .filter((e) => !e.changeType.startsWith("combo-"));
+      if (timingsMS) timingsMS.listEntries = performance.now() - listStart;
 
+      const sortStart = diagnosticsEnabled ? performance.now() : 0;
       allEntries.sort((a, b) => {
         const aDelta = safeNumber(a.scoreDelta) ?? 0;
         const bDelta = safeNumber(b.scoreDelta) ?? 0;
         return bDelta - aDelta;
       });
+      if (timingsMS) timingsMS.sortEntries = performance.now() - sortStart;
 
       const selectedEntries = allEntries.slice(
         0,
@@ -589,6 +633,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       let skippedNotApplicable = 0;
 
       // Apply all singles we can.
+      const applySinglesStart = diagnosticsEnabled ? performance.now() : 0;
       const singleCandidates: Array<{
         entry: SuccessCacheEntry;
         creature: Creature;
@@ -606,6 +651,9 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         CreatureUtil.makeUUID(applied);
         singleCandidates.push({ entry, creature: applied });
       }
+      if (timingsMS) {
+        timingsMS.applySingles = performance.now() - applySinglesStart;
+      }
 
       const tasksBaselineAndSingles: EvaluationTask[] = [
         { kind: "original", creature },
@@ -617,9 +665,16 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         })),
       ];
 
+      const evalBaselineAndSinglesStart = diagnosticsEnabled
+        ? performance.now()
+        : 0;
       const evaluatedBaselineAndSingles = await evaluateTasks(
         tasksBaselineAndSingles,
       );
+      if (timingsMS) {
+        timingsMS.evaluateBaselineAndSingles = performance.now() -
+          evalBaselineAndSinglesStart;
+      }
 
       const originalEval = {
         error: evaluatedBaselineAndSingles[0].error,
@@ -647,6 +702,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       }
 
       // Build combos from still-successful singles.
+      const buildCombosStart = diagnosticsEnabled ? performance.now() : 0;
       const combosToTry = buildComboIndices(
         successfulSingles,
         config.discoveryReplayMaxPairwise,
@@ -675,6 +731,9 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         CreatureUtil.makeUUID(current);
         comboCandidates.push({ indices, creature: current, entries });
       }
+      if (timingsMS) {
+        timingsMS.buildCombos = performance.now() - buildCombosStart;
+      }
 
       const comboTasks: EvaluationTask[] = comboCandidates.map((c) => ({
         kind: "combo" as const,
@@ -682,7 +741,11 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         description: describeCombo(c.entries),
       }));
 
+      const evaluateCombosStart = diagnosticsEnabled ? performance.now() : 0;
       const evaluatedCombos = await evaluateTasks(comboTasks);
+      if (timingsMS) {
+        timingsMS.evaluateCombos = performance.now() - evaluateCombosStart;
+      }
 
       const comboResults = evaluatedCombos.map((r, i) => ({
         creature: r.creature,
@@ -716,6 +779,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         })),
       ];
 
+      const selectBestStart = diagnosticsEnabled ? performance.now() : 0;
       allEvaluated.sort((a, b) => {
         const delta = (b.scoreDelta ?? 0) - (a.scoreDelta ?? 0);
         if (delta !== 0) return delta;
@@ -732,6 +796,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         return aKey.localeCompare(bKey);
       });
       const best = allEvaluated[0];
+      if (timingsMS) timingsMS.selectBest = performance.now() - selectBestStart;
 
       const evaluations: DiscoveryReplayEvaluationSummary[] = [
         {
@@ -770,6 +835,23 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         skippedNotApplicable,
         evaluations,
       };
+
+      if (diagnosticsEnabled) {
+        result.diagnostics = {
+          timingsMS: timingsMS ?? {},
+          counts: {
+            workerCount: workers.length,
+            entriesLoaded: allEntries.length,
+            singlesApplied: singleCandidates.length,
+            singlesEvaluated: singleResults.length,
+            combosBuilt: comboCandidates.length,
+            combosEvaluated: comboResults.length,
+            pruned,
+            skippedAlreadyApplied,
+            skippedNotApplicable,
+          },
+        };
+      }
 
       if (verifyScores && config.discoveryReplayRescoreBaseline) {
         const claimedScore = parseClaimedTagNumber(creature.tags, "score");
@@ -822,14 +904,23 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         }
       }
 
+      resultToReturn = result;
       return result;
     } finally {
+      const teardownStart = diagnosticsEnabled ? performance.now() : 0;
       for (const worker of workers) {
         try {
           worker.terminate();
         } catch {
           // Ignore termination errors.
         }
+      }
+      if (resultToReturn?.diagnostics?.timingsMS) {
+        resultToReturn.diagnostics.timingsMS.teardownWorkers =
+          diagnosticsEnabled ? performance.now() - teardownStart : undefined;
+        resultToReturn.diagnostics.timingsMS.total = diagnosticsEnabled
+          ? performance.now() - totalStart
+          : undefined;
       }
     }
   }

--- a/test/discovery/DiscoveryReplayRunnerVerifyScores.ts
+++ b/test/discovery/DiscoveryReplayRunnerVerifyScores.ts
@@ -78,6 +78,38 @@ Deno.test("DiscoveryReplayRunner: detects baseline score drift when verification
   assert(result.baselineRescore.reason.length > 0);
 });
 
+Deno.test("DiscoveryReplayRunner: baselineRescore includes a helpful reason when no claimed score tag exists", async () => {
+  const base = makeBaseCreature();
+  base.uuid = "base";
+  base.tags = [{ name: "error", value: "0.2" }];
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: (_dir) => [],
+    evaluateError: (c) => {
+      assertEquals(c.uuid, "base");
+      return Promise.resolve({ error: 0.2, score: 0.5 });
+    },
+  });
+
+  const result = await runner.replayDir({
+    creature: base,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      threads: 1,
+      discoveryReplayVerifyScores: true,
+    },
+  });
+
+  assertExists(result.baselineRescore);
+  assertEquals(result.baselineRescore.claimedScore, undefined);
+  assertEquals(result.baselineRescore.actualScore, 0.5);
+  assertEquals(result.baselineRescore.actualError, 0.2);
+  assertEquals(result.baselineRescore.changed, false);
+  assert(result.baselineRescore.reason.startsWith("🦘 "));
+});
+
 Deno.test("DiscoveryReplayRunner: rejects stale 'better by cache metadata' candidates when verification enabled", async () => {
   const base = makeBaseCreature();
   base.uuid = "base";
@@ -129,6 +161,91 @@ Deno.test("DiscoveryReplayRunner: rejects stale 'better by cache metadata' candi
   assertEquals(deleted, [{ key: "stale", changeType: "add-synapses" }]);
   assertEquals(result.improvement, undefined);
   assertEquals(result.verifiedImprovement, undefined);
+});
+
+Deno.test("DiscoveryReplayRunner: considers all-removals combo as a separate outcome", async () => {
+  const base = makeBaseCreature();
+  base.uuid = "base";
+  base.tags = [
+    { name: "score", value: "1" },
+    { name: "error", value: "0.1" },
+  ];
+
+  const remove1 = makeEntry({
+    key: "r1",
+    changeType: "remove-synapse",
+    scoreDelta: 0.05,
+  });
+  const remove2 = makeEntry({
+    key: "r2",
+    changeType: "remove-neuron",
+    scoreDelta: 0.04,
+  });
+  const add1 = makeEntry({
+    key: "a1",
+    changeType: "add-synapses",
+    scoreDelta: 0.03,
+  });
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: (_dir) => [remove1, remove2, add1],
+    applyEntry: (current, entry) => {
+      const clone = Creature.fromJSON(current.exportJSON());
+      clone.uuid = `${current.uuid}-${entry.key}`;
+      return clone;
+    },
+    evaluateError: (c) => {
+      const id = c.uuid ?? "";
+      if (id === "base") return Promise.resolve({ error: 0.1, score: 1.0 });
+
+      // Singles: all succeed.
+      if (id.endsWith("-r1")) {
+        return Promise.resolve({ error: 0.1, score: 1.05 });
+      }
+      if (id.endsWith("-r2")) {
+        return Promise.resolve({ error: 0.1, score: 1.04 });
+      }
+      if (id.endsWith("-a1")) {
+        return Promise.resolve({ error: 0.1, score: 1.03 });
+      }
+
+      // Combos:
+      // - removals-only combo best
+      if (id.includes("-r1") && id.includes("-r2") && !id.includes("-a1")) {
+        return Promise.resolve({ error: 0.1, score: 1.06 });
+      }
+      // - all-successful combo slightly worse
+      if (id.includes("-r1") && id.includes("-r2") && id.includes("-a1")) {
+        return Promise.resolve({ error: 0.1, score: 1.055 });
+      }
+
+      return Promise.resolve({ error: 0.1, score: 1.0 });
+    },
+  });
+
+  const result = await runner.replayDir({
+    creature: base,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      threads: 1,
+      discoveryReplayVerifyScores: true,
+      discoveryReplayMaxSingles: 10,
+      discoveryReplayMaxPairwise: 10,
+      discoveryReplayMaxTriples: 10,
+    },
+  });
+
+  // We expect two combo evaluations:
+  // - all-successful combo (r1+r2+a1)
+  // - removals-only combo (r1+r2)
+  assertEquals(result.evaluatedCombos, 2);
+  assertExists(result.evaluations);
+  const comboDescriptions = result.evaluations
+    .filter((e) => e.kind === "combo")
+    .map((e) => e.description ?? "");
+  assert(comboDescriptions.some((d) => d.includes("cached pruning")));
 });
 
 Deno.test("DiscoveryReplayRunner: concurrency does not change which verified improvement is selected", async () => {
@@ -202,4 +319,40 @@ Deno.test("DiscoveryReplayRunner: concurrency does not change which verified imp
     r1.verifiedImprovement.creature.tags?.[0]?.value,
     r2.verifiedImprovement.creature.tags?.[0]?.value,
   );
+});
+
+Deno.test("DiscoveryReplayRunner: returns timing diagnostics when enabled", async () => {
+  const base = makeBaseCreature();
+  base.uuid = "base";
+  base.tags = [{ name: "score", value: "0.5" }];
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: (_dir) => [],
+    evaluateError: (c) => {
+      assertEquals(c.uuid, "base");
+      return Promise.resolve({ error: 0.2, score: 0.5 });
+    },
+  });
+
+  const result = await runner.replayDir({
+    creature: base,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      threads: 1,
+      discoveryReplayVerifyScores: true,
+      discoveryReplayDiagnostics: true,
+    },
+  });
+
+  assertExists(result.diagnostics);
+  assertExists(result.diagnostics.timingsMS.total);
+  assertExists(result.diagnostics.timingsMS.listEntries);
+  assertExists(result.diagnostics.timingsMS.sortEntries);
+  assertExists(result.diagnostics.timingsMS.applySingles);
+  assertExists(result.diagnostics.timingsMS.evaluateBaselineAndSingles);
+  assertExists(result.diagnostics.timingsMS.selectBest);
+  assertEquals(result.diagnostics.counts.entriesLoaded, 0);
+  assertEquals(result.diagnostics.counts.singlesEvaluated, 0);
 });


### PR DESCRIPTION
…DiscoveryReplayRunner

- Bumped version in deno.json to 0.279.1.
- Introduced a new option, `discoveryReplayDiagnostics`, to enable timing diagnostics during replay, providing insights into where time is spent in the evaluation process.
- Updated the DiscoveryReplayRunner to record and return timing information, enhancing performance visibility.
- Enhanced README.md to document the new diagnostics feature and its usage.
- Added tests to verify the functionality of the new diagnostics feature.

These changes improve the functionality and maintainability of the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces optional replay diagnostics for visibility into replay performance.
> 
> - Adds `discoveryReplayDiagnostics` config; `DiscoveryReplayRunner` now records and returns `diagnostics` with `timingsMS` (e.g., `total`, `setupWorkers`, `listEntries`, `sortEntries`, `applySingles`, `evaluateBaselineAndSingles`, `buildCombos`, `evaluateCombos`, `selectBest`, `teardownWorkers`) and count metrics
> - Enhances replay selection: considers an all-removals combo as a distinct outcome; prefixes baseline rescore and verified-improvement messages with `🦘`
> - Documents usage in `README.md` (example shows `replay.diagnostics.timingsMS`) and adds targeted tests for diagnostics, baseline rescore messaging, removals-only combos, and concurrency determinism
> - Updates `NeatArguments`/`NeatConfig` to surface defaults; bumps version in `deno.json` to `0.279.1`; adds spelling entries in `docs/cspell.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 735e99b98bbcc471817b67aa34db80100d32b1af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->