### PR TITLE
Update version to 0.279.2 in deno.json and add candidate summary calc…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.279.1",
+  "version": "0.279.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -28,6 +28,40 @@ const shouldLogDiscovery = (config: NeatConfig): boolean =>
   config.verbose || config.log > 0;
 
 /**
+ * Calculates the candidate counts that should be reported in the worker
+ * "Candidates Found" summary.
+ *
+ * Note (29-Dec-2025): This summary intentionally reports *raw* Rust counts only.
+ * Combination candidates are built later by `DiscoveryRunner` **only after**
+ * single candidates have been scored and proven to improve. Counting combos here
+ * is misleading because it implies extra candidates exist before evaluation.
+ */
+export function calculateDiscoveryCandidateSummaryCounts(counts: {
+  helpfulSynapseRawCount: number;
+  helpfulNeuronRawCount: number;
+  harmfulSynapseCandidates: number;
+  harmfulNeuronCandidates: number;
+  squashRawCount: number;
+  removalRawCount: number;
+}): {
+  helpfulSynapses: number;
+  helpfulNeurons: number;
+  harmfulSynapses: number;
+  harmfulNeurons: number;
+  squashChanges: number;
+  removalCandidates: number;
+} {
+  return {
+    helpfulSynapses: counts.helpfulSynapseRawCount,
+    helpfulNeurons: counts.helpfulNeuronRawCount,
+    harmfulSynapses: counts.harmfulSynapseCandidates,
+    harmfulNeurons: counts.harmfulNeuronCandidates,
+    squashChanges: counts.squashRawCount,
+    removalCandidates: counts.removalRawCount,
+  };
+}
+
+/**
  * Tracks performance statistics throughout the discovery process.
  */
 class DiscoveryPerformanceStats {
@@ -129,32 +163,24 @@ class DiscoveryPerformanceStats {
         }`,
     );
 
-    // Candidate summary
-    // Calculate expected candidate counts that will be built:
-    // - Neurons: 1 combined + N individual = 1 + N (if any neurons exist)
-    // - Synapses: 1 combined + N individual = 1 + N (if any synapses exist)
-    // - Squashes: 1 combined + N individual = 1 + N (if any squashes exist)
-    // - Removals: N individual + 1 combined (if N >= 2) = N + (N >= 2 ? 1 : 0)
-    const expectedNeuronCandidates = this.helpfulNeuronRawCount > 0
-      ? 1 + this.helpfulNeuronRawCount
-      : 0;
-    const expectedSynapseCandidates = this.helpfulSynapseRawCount > 0
-      ? 1 + this.helpfulSynapseRawCount
-      : 0;
-    const expectedSquashCandidates = this.squashRawCount > 0
-      ? 1 + this.squashRawCount
-      : 0;
-    const expectedRemovalCandidates = this.removalRawCount +
-      (this.removalRawCount >= 2 ? 1 : 0);
+    // Candidate summary (raw Rust counts only; combos are built later after scoring).
+    const summaryCounts = calculateDiscoveryCandidateSummaryCounts({
+      helpfulSynapseRawCount: this.helpfulSynapseRawCount,
+      helpfulNeuronRawCount: this.helpfulNeuronRawCount,
+      harmfulSynapseCandidates: this.harmfulSynapseCandidates,
+      harmfulNeuronCandidates: this.harmfulNeuronCandidates,
+      squashRawCount: this.squashRawCount,
+      removalRawCount: this.removalRawCount,
+    });
 
     console.log(
       `\n🎯 ${yellow("Candidates Found")}:\n` +
-        `  Helpful synapses: ${formatCount(expectedSynapseCandidates)}\n` +
-        `  Helpful neurons: ${formatCount(expectedNeuronCandidates)}\n` +
-        `  Harmful synapses: ${formatCount(this.harmfulSynapseCandidates)}\n` +
-        `  Harmful neurons: ${formatCount(this.harmfulNeuronCandidates)}\n` +
-        `  Squash changes: ${formatCount(expectedSquashCandidates)}\n` +
-        `  Removal candidates: ${formatCount(expectedRemovalCandidates)}`,
+        `  Helpful synapses: ${formatCount(summaryCounts.helpfulSynapses)}\n` +
+        `  Helpful neurons: ${formatCount(summaryCounts.helpfulNeurons)}\n` +
+        `  Harmful synapses: ${formatCount(summaryCounts.harmfulSynapses)}\n` +
+        `  Harmful neurons: ${formatCount(summaryCounts.harmfulNeurons)}\n` +
+        `  Squash changes: ${formatCount(summaryCounts.squashChanges)}\n` +
+        `  Removal candidates: ${formatCount(summaryCounts.removalCandidates)}`,
     );
 
     // Overall summary

--- a/test/discovery/DiscoveryCandidateSummaryCounts.ts
+++ b/test/discovery/DiscoveryCandidateSummaryCounts.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "@std/assert";
+import {
+  calculateDiscoveryCandidateSummaryCounts,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts";
+
+Deno.test("Discovery candidate summary reports raw Rust counts (no implied combos)", () => {
+  const counts = calculateDiscoveryCandidateSummaryCounts({
+    helpfulSynapseRawCount: 2,
+    helpfulNeuronRawCount: 31,
+    harmfulSynapseCandidates: 0,
+    harmfulNeuronCandidates: 0,
+    squashRawCount: 2,
+    removalRawCount: 46,
+  });
+
+  assertEquals(counts, {
+    helpfulSynapses: 2,
+    helpfulNeurons: 31,
+    harmfulSynapses: 0,
+    harmfulNeurons: 0,
+    squashChanges: 2,
+    removalCandidates: 46,
+  });
+});
+
+Deno.test("Discovery candidate summary does not inflate removal counts when multiple exist", () => {
+  for (const removalRawCount of [0, 1, 2, 47]) {
+    const counts = calculateDiscoveryCandidateSummaryCounts({
+      helpfulSynapseRawCount: 0,
+      helpfulNeuronRawCount: 0,
+      harmfulSynapseCandidates: 0,
+      harmfulNeuronCandidates: 0,
+      squashRawCount: 0,
+      removalRawCount,
+    });
+    assertEquals(counts.removalCandidates, removalRawCount);
+  }
+});


### PR DESCRIPTION
…ulation in DiscoverDirectory.ts

- Bumped version in deno.json to 0.279.2.
- Introduced a new function, calculateDiscoveryCandidateSummaryCounts, to compute candidate counts for logging, ensuring clarity in the "Candidates Found" summary.
- Updated the logging in DiscoveryPerformanceStats to utilize the new summary counts, improving the accuracy of reported candidate statistics.

These changes enhance the functionality and maintainability of the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts discovery logging to report raw Rust candidate counts only and adds tests to validate the summary behavior.
> 
> - Introduces `calculateDiscoveryCandidateSummaryCounts` in `DiscoverDirectory.ts` and replaces previous combo-estimation logic in `DiscoveryPerformanceStats.logSummary`
> - Updates "Candidates Found" output to use computed raw counts (helpful/harmful synapses/neurons, squashes, removals)
> - Adds tests in `test/discovery/DiscoveryCandidateSummaryCounts.ts` ensuring no inflated combo/removal counts
> - Bumps `deno.json` version to `0.279.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1320837f77bbf2eac2caf528d1f9c737baa15326. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->