### PR TITLE
V0.281.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ improvements (0.5-3%), which accumulate over time through repeated iterations.
 const result = await creature.discoveryDir(dataDir, {
   discoveryRecordTimeOutMinutes: 1,
   discoveryAnalysisTimeoutMinutes: 10,
-  discoveryMinImprovementPercentage: 0.01, // Accept 1%+ improvements
 });
 
 if (result.improvement) {

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.280.0",
+  "version": "0.281.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -99,9 +99,6 @@ const options: NeatOptions = {
   // Analysis phase (10 minutes for thorough analysis)
   discoveryAnalysisTimeoutMinutes: 10,
 
-  // Accept 1%+ improvements (realistic threshold for noise filtering)
-  discoveryMinImprovementPercentage: 0.01,
-
   // Cost of growth penalty (each synapse/neuron must earn back this cost)
   costOfGrowth: 0.001, // Default: candidates must reduce error > 0.001 per synapse
 
@@ -115,9 +112,9 @@ const options: NeatOptions = {
 
 ### Selection Strategy: Cost-Benefit Analysis
 
-Discovery uses a two-stage filter:
+Discovery uses a single acceptance rule:
 
-**Stage 1: Cost of Growth Gate**
+**Cost of Growth Gate**
 
 Each candidate that adds structural complexity must satisfy:
 `Error Reduction > Cost of Growth`
@@ -133,18 +130,11 @@ Each candidate that adds structural complexity must satisfy:
   They improve score by reducing complexity, not by reducing error. Removing
   elements that return a similar score will improve the creature's score
 
-**Stage 2: Minimum Improvement Threshold**
+**Take the Best**
 
-Among profitable candidates, only accept if improvement > 1%:
+If multiple candidates are profitable:
 
-- Filters random noise (< 1% is statistical variation)
-- Previous 10% threshold was unrealistic and rejected valid 1.58% improvements
-
-**Stage 3: Take the Best**
-
-If multiple candidates pass both filters:
-
-- ✅ **Select the candidate with the largest improvement**
+- ✅ **Select the candidate with the largest net improvement**
 - This maximizes progress per iteration
 
 Example:
@@ -162,7 +152,7 @@ Example:
 // Candidate D: Change squash, 0.1% improvement, cost = 0 (no structural growth)
 // Error reduction: 0.001, Cost: 0 → Profit: 0.001 ✅ (not filtered by cost-of-growth)
 
-// Result: Choose Candidate A (largest improvement at 1.2%)
+// Result: Choose the candidate with the largest net improvement
 ```
 
 ## Example: Distributed Discovery Script
@@ -311,7 +301,6 @@ if (import.meta.main) {
   const options: NeatOptions = {
     discoveryRecordTimeOutMinutes: 1,
     discoveryAnalysisTimeoutMinutes: 10,
-    discoveryMinImprovementPercentage: 0.01, // Accept 1%+ improvements
     discoveryMaxNeurons: 6,
     discoverySampleRate: 0.05,
   };

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1396,9 +1396,13 @@ export class Creature implements CreatureInternal {
     const maxTo = this.neurons.length - 1;
     const minTo = this.input;
 
-    const tmpSynapses: Synapse[] = [];
-    let lastFrom = -1;
-    let lastTo = -1;
+    // Merge duplicate synapses (same from/to/type) by summing weights.
+    // 29-Dec-2025: This is behaviour-preserving and fixes a long-standing issue
+    // where duplicates were silently dropped, changing forward-pass behaviour.
+    // See https://github.com/stSoftwareAU/NEAT-AI/issues/976
+    const merged = new Map<string, Synapse>();
+    const inboundCountsByTo = new Map<number, number>();
+
     this.synapses.forEach((synapse) => {
       if (removeSelfConnections && synapse.from === synapse.to) {
         return;
@@ -1406,28 +1410,54 @@ export class Creature implements CreatureInternal {
       if (removeBackConnections && synapse.from > synapse.to) {
         return;
       }
-      if (synapse.from === lastFrom && synapse.to === lastTo) {
-        console.warn("duplicate synapse " + synapse.from + "->" + synapse.to);
-      } else {
-        lastFrom = synapse.from;
-        lastTo = synapse.to;
-        if (synapse.to > maxTo) {
-          console.debug("Ignoring connection to above max", maxTo, synapse);
-        } else if (synapse.to < minTo) {
-          console.debug("Ignoring connection to below min", minTo, synapse);
-        } else if (synapse.weight && Number.isFinite(synapse.weight)) {
-          /** Zero weight may as well be removed */
-          tmpSynapses.push(synapse as Synapse);
-        } else {
-          if (this.neurons[synapse.to].type === "output") {
-            /** Don't remove the last one for an output neuron */
-            if (this.inwardConnections(synapse.to).length === 1) {
-              tmpSynapses.push(synapse as Synapse);
-            }
-          }
+
+      if (synapse.to > maxTo) {
+        console.debug("Ignoring connection to above max", maxTo, synapse);
+        return;
+      }
+      if (synapse.to < minTo) {
+        console.debug("Ignoring connection to below min", minTo, synapse);
+        return;
+      }
+
+      const typeKey = synapse.type ?? "";
+      const key = `${synapse.from}->${synapse.to}:${typeKey}`;
+
+      const existing = merged.get(key);
+      if (existing) {
+        existing.weight += synapse.weight;
+        // Merge tags conservatively (best-effort). If tags are present on either,
+        // keep a de-duplicated union.
+        if (synapse.tags?.length) {
+          const old = existing.tags ?? [];
+          existing.tags = [...new Set([...old, ...synapse.tags])];
+        }
+        return;
+      }
+
+      merged.set(key, synapse as Synapse);
+      inboundCountsByTo.set(
+        synapse.to,
+        (inboundCountsByTo.get(synapse.to) ?? 0) + 1,
+      );
+    });
+
+    const tmpSynapses: Synapse[] = [];
+    for (const synapse of merged.values()) {
+      if (synapse.weight !== 0 && Number.isFinite(synapse.weight)) {
+        tmpSynapses.push(synapse);
+        continue;
+      }
+
+      // Zero weight may as well be removed, except for the last inward connection
+      // to an output neuron (we keep one to preserve structural validity).
+      if (this.neurons[synapse.to].type === "output") {
+        const inbound = inboundCountsByTo.get(synapse.to) ?? 0;
+        if (inbound === 1) {
+          tmpSynapses.push(synapse);
         }
       }
-    });
+    }
 
     this.synapses = tmpSynapses;
 

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -44,6 +44,7 @@ import {
 import { SparseConfig } from "./propagate/sparse/SparseConfig.ts";
 import { upgradeOne } from "./upgrade/UpgradeOne.ts";
 import { CreatureExportBuilder } from "./utils/CreatureExportBuilder.ts";
+import { mergeTagsByNameValue } from "./utils/TagUtils.ts";
 import {
   type DiscoveryDirResult,
   DiscoveryRunner,
@@ -1427,10 +1428,9 @@ export class Creature implements CreatureInternal {
       if (existing) {
         existing.weight += synapse.weight;
         // Merge tags conservatively (best-effort). If tags are present on either,
-        // keep a de-duplicated union.
+        // keep a de-duplicated union by `{name, value}`.
         if (synapse.tags?.length) {
-          const old = existing.tags ?? [];
-          existing.tags = [...new Set([...old, ...synapse.tags])];
+          existing.tags = mergeTagsByNameValue(existing.tags, synapse.tags);
         }
         return;
       }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -27,6 +27,8 @@ import { submitDiscoveryRecordBatch } from "./SubmitDiscoveryRecordBatch.ts";
 const shouldLogDiscovery = (config: NeatConfig): boolean =>
   config.verbose || config.log > 0;
 
+const DEFAULT_DISCOVERY_MIN_IMPROVEMENT = 0.01; // 1% (29-Dec-2025)
+
 /**
  * Calculates the candidate counts that should be reported in the worker
  * "Candidates Found" summary.
@@ -85,13 +87,15 @@ class DiscoveryPerformanceStats {
   harmfulNeuronAnalysisTime = 0;
   squashAnalysisTime = 0;
 
-  // Raw discovery result counts (what Rust found)
-  helpfulSynapseRawCount = 0;
-  helpfulNeuronRawCount = 0;
-  harmfulSynapseCandidates = 0;
-  harmfulNeuronCandidates = 0;
-  squashRawCount = 0;
-  removalRawCount = 0;
+  // Candidate counts (final arrays returned to the caller).
+  // Note (29-Dec-2025): Counts are taken from the result arrays (not per-retry
+  // accumulation) so logs match what downstream consumers will actually see.
+  helpfulSynapseCount = 0;
+  helpfulNeuronCount = 0;
+  harmfulSynapseCount = 0;
+  harmfulNeuronCount = 0;
+  squashCount = 0;
+  removalCount = 0;
 
   // Other phases
   cleanupTime = 0;
@@ -163,15 +167,15 @@ class DiscoveryPerformanceStats {
         }`,
     );
 
-    // Candidate summary (raw Rust counts only; combos are built later after scoring).
-    const summaryCounts = calculateDiscoveryCandidateSummaryCounts({
-      helpfulSynapseRawCount: this.helpfulSynapseRawCount,
-      helpfulNeuronRawCount: this.helpfulNeuronRawCount,
-      harmfulSynapseCandidates: this.harmfulSynapseCandidates,
-      harmfulNeuronCandidates: this.harmfulNeuronCandidates,
-      squashRawCount: this.squashRawCount,
-      removalRawCount: this.removalRawCount,
-    });
+    // Candidate summary (counts match the arrays returned from recordDirectory()).
+    const summaryCounts = {
+      helpfulSynapses: this.helpfulSynapseCount,
+      helpfulNeurons: this.helpfulNeuronCount,
+      harmfulSynapses: this.harmfulSynapseCount,
+      harmfulNeurons: this.harmfulNeuronCount,
+      squashChanges: this.squashCount,
+      removalCandidates: this.removalCount,
+    };
 
     console.log(
       `\n🎯 ${yellow("Candidates Found")}:\n` +
@@ -265,6 +269,8 @@ class DataRecorder {
       disableCleanup: config.discoveryDisableCleanup,
       skipRecordPhase: config.discoverySkipRecordPhase,
       rustFlushBytesThreshold: config.discoveryRustFlushBytes,
+      improvementThreshold: config.discoveryMinImprovementPercentage ??
+        DEFAULT_DISCOVERY_MIN_IMPROVEMENT,
     };
   }
 
@@ -558,6 +564,56 @@ class DataRecorder {
         }`,
       );
     }
+
+    const improvementThreshold = config.discoveryMinImprovementPercentage ??
+      DEFAULT_DISCOVERY_MIN_IMPROVEMENT;
+
+    const classifyCandidateTag = (
+      gain: number,
+      comment?: string,
+    ): "CANDIDATE" | "FALLBACK" | "SPLIT-ERROR" => {
+      const normalised = typeof comment === "string"
+        ? comment.trim().toLowerCase()
+        : "";
+      if (normalised.includes("split-error")) return "SPLIT-ERROR";
+      if (normalised.includes("fallback")) return "FALLBACK";
+      if (gain > 0 && gain < improvementThreshold) return "FALLBACK";
+      return "CANDIDATE";
+    };
+
+    const formatGainPct = (gain: number): string => {
+      const pct = gain * 100;
+      const sign = pct >= 0 ? "+" : "";
+      return `${sign}${pct.toFixed(4)}%`;
+    };
+
+    const logCandidate = (
+      scope: "SYNAPSE" | "NEURON" | "HARMFUL-SYNAPSE" | "HARMFUL-NEURON",
+      from: string,
+      to: string,
+      gain: number,
+      improved: number,
+      total: number,
+      comment?: string,
+    ): void => {
+      const tag = classifyCandidateTag(gain, comment);
+      const commentText = comment ? ` comment=${JSON.stringify(comment)}` : "";
+      console.log(
+        `Discovery ${blue(this.ID)} ${scope} ${tag} ${from} -> ${to} expected=${
+          formatGainPct(gain)
+        } improved=${improved}/${total}${commentText}`,
+      );
+    };
+
+    const countFallbackCandidates = <
+      T extends { expectedCreatureScoreGain: number; comment?: string },
+    >(
+      candidates: T[] | undefined,
+    ): number =>
+      (candidates ?? []).filter((c) =>
+        classifyCandidateTag(c.expectedCreatureScoreGain, c.comment) ===
+          "FALLBACK"
+      ).length;
 
     const discoverStructure = new DiscoverStructure(
       creature,
@@ -919,15 +975,62 @@ class DataRecorder {
           if (shouldLogDiscovery(config)) {
             const helpfulSynapseCount = addHelpfulSynapse?.length ?? 0;
             const helpfulNeuronCount = addHelpfulNeurons?.length ?? 0;
-            const splitCount = splitSynapseInsertNeuronCandidates?.length ?? 0;
-            const harmfulCount = removeHarmfulSynapse ? 1 : 0;
+            const splitInsertCount =
+              splitSynapseInsertNeuronCandidates?.length ?? 0;
+            const harmfulSynapseCount = removeHarmfulSynapse ? 1 : 0;
+            const fallbackSynapses = countFallbackCandidates(addHelpfulSynapse);
+            const fallbackNeurons = countFallbackCandidates(addHelpfulNeurons);
+
+            const synapseMeta = candidateBundle.synapseMetadata;
+            const neuronMeta = candidateBundle.neuronMetadata;
+            const synapseMetaText = synapseMeta
+              ? `, synapse meta: found=${synapseMeta.candidatesFound} returned=${synapseMeta.candidatesReturned}`
+              : "";
+            const neuronMetaText = neuronMeta
+              ? `, neuron meta: found=${neuronMeta.candidatesFound} returned=${neuronMeta.candidatesReturned}`
+              : "";
+
             console.log(
               `Discovery ${blue(this.ID)} candidate collection ${
                 yellow(format(candidateCollectionTime, {
                   ignoreZero: true,
                 }))
-              } synapse candidates: ${helpfulSynapseCount}, neuron candidates: ${helpfulNeuronCount}, split candidates: ${splitCount}, harmful removals: ${harmfulCount}`,
+              } helpful synapses: ${helpfulSynapseCount} (fallback ${fallbackSynapses}), helpful neurons: ${helpfulNeuronCount} (fallback ${fallbackNeurons}), split-synapse-insert-neuron: ${splitInsertCount}, harmful synapse removals: ${harmfulSynapseCount}${synapseMetaText}${neuronMetaText}`,
             );
+
+            for (const candidate of addHelpfulSynapse ?? []) {
+              logCandidate(
+                "SYNAPSE",
+                candidate.fromNeuronUUID,
+                candidate.toNeuronUUID,
+                candidate.expectedCreatureScoreGain,
+                candidate.improvedCount,
+                candidate.totalCount,
+                candidate.comment,
+              );
+            }
+            for (const candidate of addHelpfulNeurons ?? []) {
+              logCandidate(
+                "NEURON",
+                candidate.fromNeuronUUID,
+                candidate.toNeuronUUID,
+                candidate.expectedCreatureScoreGain,
+                candidate.improvedCount,
+                candidate.totalCount,
+                candidate.comment,
+              );
+            }
+            if (removeHarmfulSynapse) {
+              logCandidate(
+                "HARMFUL-SYNAPSE",
+                removeHarmfulSynapse.fromNeuronUUID,
+                removeHarmfulSynapse.toNeuronUUID,
+                removeHarmfulSynapse.expectedCreatureScoreGain,
+                removeHarmfulSynapse.improvedCount,
+                removeHarmfulSynapse.totalCount,
+                removeHarmfulSynapse.comment,
+              );
+            }
           }
 
           const squashStartTime = Date.now();
@@ -1124,6 +1227,53 @@ class DataRecorder {
             candidateSquashes,
             removeHarmfulNeurons,
           ] = analysisResults;
+
+          if (shouldLogDiscovery(config)) {
+            for (const candidate of addHelpfulSynapse ?? []) {
+              logCandidate(
+                "SYNAPSE",
+                candidate.fromNeuronUUID,
+                candidate.toNeuronUUID,
+                candidate.expectedCreatureScoreGain,
+                candidate.improvedCount,
+                candidate.totalCount,
+                candidate.comment,
+              );
+            }
+            for (const candidate of addHelpfulNeurons ?? []) {
+              logCandidate(
+                "NEURON",
+                candidate.fromNeuronUUID,
+                candidate.toNeuronUUID,
+                candidate.expectedCreatureScoreGain,
+                candidate.improvedCount,
+                candidate.totalCount,
+                candidate.comment,
+              );
+            }
+            if (removeHarmfulSynapse) {
+              logCandidate(
+                "HARMFUL-SYNAPSE",
+                removeHarmfulSynapse.fromNeuronUUID,
+                removeHarmfulSynapse.toNeuronUUID,
+                removeHarmfulSynapse.expectedCreatureScoreGain,
+                removeHarmfulSynapse.improvedCount,
+                removeHarmfulSynapse.totalCount,
+                removeHarmfulSynapse.comment,
+              );
+            }
+            for (const candidate of removeHarmfulNeurons ?? []) {
+              logCandidate(
+                "HARMFUL-NEURON",
+                candidate.neuronUUID,
+                candidate.neuronUUID,
+                candidate.expectedCreatureScoreGain,
+                candidate.sampleCount,
+                candidate.sampleCount,
+                candidate.comment,
+              );
+            }
+          }
         }
 
         if (addHelpfulNeurons && addHelpfulNeurons.length > 0) {
@@ -1131,7 +1281,6 @@ class DataRecorder {
             ...(discoverResult.addHelpfulNeurons ?? []),
             ...addHelpfulNeurons,
           ];
-          perfStats.helpfulNeuronRawCount += addHelpfulNeurons.length;
         }
         if (
           splitSynapseInsertNeuronCandidates &&
@@ -1147,25 +1296,21 @@ class DataRecorder {
             ...(discoverResult.addHelpfulSynapses ?? []),
             ...addHelpfulSynapse,
           ];
-          perfStats.helpfulSynapseRawCount += addHelpfulSynapse.length;
         }
         if (removeHarmfulSynapse && !discoverResult.removeHarmfulSynapse) {
           discoverResult.removeHarmfulSynapse = removeHarmfulSynapse;
-          perfStats.harmfulSynapseCandidates = 1;
         }
         if (candidateSquashes && candidateSquashes.length > 0) {
           discoverResult.candidateSquashes = [
             ...(discoverResult.candidateSquashes ?? []),
             ...candidateSquashes,
           ];
-          perfStats.squashRawCount += candidateSquashes.length;
         }
         if (removeHarmfulNeurons && removeHarmfulNeurons.length > 0) {
           discoverResult.removeHarmfulNeurons = [
             ...(discoverResult.removeHarmfulNeurons ?? []),
             ...removeHarmfulNeurons,
           ];
-          perfStats.harmfulNeuronCandidates += removeHarmfulNeurons.length;
         }
 
         // Check if we found any candidates
@@ -1213,7 +1358,6 @@ class DataRecorder {
       const removalCandidates = discoverStructure.getRemovalCandidates();
       if (removalCandidates && removalCandidates.length > 0) {
         discoverResult.removalCandidates = removalCandidates;
-        perfStats.removalRawCount = removalCandidates.length;
         if (shouldLogDiscovery(config)) {
           console.log(
             `Discovery ${blue(this.ID)} found ${
@@ -1282,6 +1426,20 @@ class DataRecorder {
 
       // Calculate total time after conditional await to include cleanup when awaited
       perfStats.totalTime = Date.now() - startTime;
+
+      // Candidate counts must reflect what we actually return, not per-retry accumulation.
+      perfStats.helpfulSynapseCount =
+        discoverResult.addHelpfulSynapses?.length ??
+          0;
+      perfStats.helpfulNeuronCount = discoverResult.addHelpfulNeurons?.length ??
+        0;
+      perfStats.harmfulSynapseCount = discoverResult.removeHarmfulSynapse
+        ? 1
+        : 0;
+      perfStats.harmfulNeuronCount =
+        discoverResult.removeHarmfulNeurons?.length ?? 0;
+      perfStats.squashCount = discoverResult.candidateSquashes?.length ?? 0;
+      perfStats.removalCount = discoverResult.removalCandidates?.length ?? 0;
 
       // Note: reScoringTime is not included in the performance summary as it happens
       // after recordDirectory returns. It is logged separately in DiscoveryRunner

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -27,8 +27,6 @@ import { submitDiscoveryRecordBatch } from "./SubmitDiscoveryRecordBatch.ts";
 const shouldLogDiscovery = (config: NeatConfig): boolean =>
   config.verbose || config.log > 0;
 
-const DEFAULT_DISCOVERY_MIN_IMPROVEMENT = 0.01; // 1% (29-Dec-2025)
-
 /**
  * Calculates the candidate counts that should be reported in the worker
  * "Candidates Found" summary.
@@ -269,8 +267,6 @@ class DataRecorder {
       disableCleanup: config.discoveryDisableCleanup,
       skipRecordPhase: config.discoverySkipRecordPhase,
       rustFlushBytesThreshold: config.discoveryRustFlushBytes,
-      improvementThreshold: config.discoveryMinImprovementPercentage ??
-        DEFAULT_DISCOVERY_MIN_IMPROVEMENT,
     };
   }
 
@@ -565,11 +561,8 @@ class DataRecorder {
       );
     }
 
-    const improvementThreshold = config.discoveryMinImprovementPercentage ??
-      DEFAULT_DISCOVERY_MIN_IMPROVEMENT;
-
     const classifyCandidateTag = (
-      gain: number,
+      _gain: number,
       comment?: string,
     ): "CANDIDATE" | "FALLBACK" | "SPLIT-ERROR" => {
       const normalised = typeof comment === "string"
@@ -577,7 +570,6 @@ class DataRecorder {
         : "";
       if (normalised.includes("split-error")) return "SPLIT-ERROR";
       if (normalised.includes("fallback")) return "FALLBACK";
-      if (gain > 0 && gain < improvementThreshold) return "FALLBACK";
       return "CANDIDATE";
     };
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -99,6 +99,20 @@ export interface DiscoverStructureOptions {
    * Primarily for testing and production tuning; defaults to ~50 MiB.
    */
   rustFlushBytesThreshold?: number;
+
+  /**
+   * Optional improvement threshold forwarded to NEAT-AI-Discovery's parallel analyser.
+   *
+   * Note (29-Dec-2025): The Rust engine may still return "fallback" candidates
+   * with expectedCreatureScoreGain > 0 but below this threshold. Consumers should
+   * treat those as intentionally-returned fallback candidates, not errors.
+   */
+  improvementThreshold?: number;
+
+  /**
+   * Optional harmful threshold forwarded to NEAT-AI-Discovery's parallel analyser.
+   */
+  harmfulThreshold?: number;
 }
 
 const OUTPUT_ERROR_CACHE_TTL_MS = 30_000;
@@ -248,6 +262,16 @@ interface CandidateAnalysisBundle {
   harmfulSynapse?: CandidateSynapse;
   helpfulNeurons?: CandidateNeuron[];
   splitSynapseInsertNeuronCandidates?: SplitSynapseInsertNeuronCandidate[];
+  /**
+   * Optional metadata returned by NEAT-AI-Discovery for the synapse analysis path.
+   * Used for logging only.
+   */
+  synapseMetadata?: { candidatesFound: number; candidatesReturned: number };
+  /**
+   * Optional metadata returned by NEAT-AI-Discovery for the neuron analysis path.
+   * Used for logging only.
+   */
+  neuronMetadata?: { candidatesFound: number; candidatesReturned: number };
 }
 
 type FocusSelectionMode = "weighted" | "forced" | "all" | "random";
@@ -434,6 +458,8 @@ export class DiscoverStructure {
   private analysisTimeoutGuardEnabled = true;
   private disableCleanup = false;
   private skipRecordPhase = false;
+  private improvementThreshold?: number;
+  private harmfulThreshold?: number;
   constructor(
     creature: Creature,
     timeoutSeconds: number,
@@ -489,6 +515,8 @@ export class DiscoverStructure {
     this.deps = { ...DEFAULT_DISCOVER_STRUCTURE_DEPS, ...deps };
     this.disableCleanup = options.disableCleanup ?? false;
     this.skipRecordPhase = options.skipRecordPhase ?? false;
+    this.improvementThreshold = options.improvementThreshold;
+    this.harmfulThreshold = options.harmfulThreshold;
 
     // Rough estimate per sample for JSON payload sizing:
     // - ~200 bytes per neuron record (uuid + activation + errors metadata)
@@ -1932,6 +1960,12 @@ export class DiscoverStructure {
     }
 
     const bundle: CandidateAnalysisBundle = {};
+    if (combinedResult.synapse?.metadata) {
+      bundle.synapseMetadata = combinedResult.synapse.metadata;
+    }
+    if (combinedResult.neuron?.metadata) {
+      bundle.neuronMetadata = combinedResult.neuron.metadata;
+    }
 
     const helpfulSynapses = this.tryRustHelpfulSynapses(focusList);
     if (helpfulSynapses && helpfulSynapses.length > 0) {
@@ -2378,6 +2412,8 @@ export class DiscoverStructure {
       parquetFile: this.parquetFilePath,
       creature: rustCreature,
       focusNeurons: focusList,
+      improvementThreshold: this.improvementThreshold,
+      harmfulThreshold: this.harmfulThreshold,
       maxSynapseCandidates: includeSynapse
         ? Math.max(50, focusList.length * 10)
         : undefined,
@@ -2455,6 +2491,7 @@ export class DiscoverStructure {
         ? {
           success: true,
           gpuUsed: parallel.synapseGpuUsed,
+          metadata: parallel.synapseMetadata,
           helpfulSynapses: parallel.helpfulSynapses,
           harmfulSynapses: parallel.harmfulSynapses,
           diagnostics: parallel.synapseDiagnostics,
@@ -2464,6 +2501,7 @@ export class DiscoverStructure {
       ? {
         success: true,
         gpuUsed: parallel.neuronGpuUsed,
+        metadata: parallel.neuronMetadata,
         helpfulNeurons: parallel.helpfulNeurons,
         structuralCandidates,
         diagnostics: parallel.neuronDiagnostics,

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -99,20 +99,6 @@ export interface DiscoverStructureOptions {
    * Primarily for testing and production tuning; defaults to ~50 MiB.
    */
   rustFlushBytesThreshold?: number;
-
-  /**
-   * Optional improvement threshold forwarded to NEAT-AI-Discovery's parallel analyser.
-   *
-   * Note (29-Dec-2025): The Rust engine may still return "fallback" candidates
-   * with expectedCreatureScoreGain > 0 but below this threshold. Consumers should
-   * treat those as intentionally-returned fallback candidates, not errors.
-   */
-  improvementThreshold?: number;
-
-  /**
-   * Optional harmful threshold forwarded to NEAT-AI-Discovery's parallel analyser.
-   */
-  harmfulThreshold?: number;
 }
 
 const OUTPUT_ERROR_CACHE_TTL_MS = 30_000;
@@ -458,8 +444,6 @@ export class DiscoverStructure {
   private analysisTimeoutGuardEnabled = true;
   private disableCleanup = false;
   private skipRecordPhase = false;
-  private improvementThreshold?: number;
-  private harmfulThreshold?: number;
   constructor(
     creature: Creature,
     timeoutSeconds: number,
@@ -515,8 +499,6 @@ export class DiscoverStructure {
     this.deps = { ...DEFAULT_DISCOVER_STRUCTURE_DEPS, ...deps };
     this.disableCleanup = options.disableCleanup ?? false;
     this.skipRecordPhase = options.skipRecordPhase ?? false;
-    this.improvementThreshold = options.improvementThreshold;
-    this.harmfulThreshold = options.harmfulThreshold;
 
     // Rough estimate per sample for JSON payload sizing:
     // - ~200 bytes per neuron record (uuid + activation + errors metadata)
@@ -2412,8 +2394,6 @@ export class DiscoverStructure {
       parquetFile: this.parquetFilePath,
       creature: rustCreature,
       focusNeurons: focusList,
-      improvementThreshold: this.improvementThreshold,
-      harmfulThreshold: this.harmfulThreshold,
       maxSynapseCandidates: includeSynapse
         ? Math.max(50, focusList.length * 10)
         : undefined,

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -175,6 +175,12 @@ export type RustStructuralCandidate = RustSplitSynapseInsertNeuronCandidate;
 export interface RustAnalyzeSynapsesResult {
   success: boolean;
   gpuUsed?: boolean;
+  /**
+   * Optional candidate metadata emitted by NEAT-AI-Discovery (when available).
+   *
+   * Note (29-Dec-2025): Older library versions will omit this field.
+   */
+  metadata?: RustCandidateMetadata;
   helpfulSynapses?: RustCandidateSynapse[];
   harmfulSynapses?: RustCandidateSynapse[];
   diagnostics?: RustSynapseDiagnostic[];
@@ -188,6 +194,12 @@ export interface RustAnalyzeSynapsesResult {
 export interface RustAnalyzeNeuronsResult {
   success: boolean;
   gpuUsed?: boolean;
+  /**
+   * Optional candidate metadata emitted by NEAT-AI-Discovery (when available).
+   *
+   * Note (29-Dec-2025): Older library versions will omit this field.
+   */
+  metadata?: RustCandidateMetadata;
   helpfulNeurons?: RustCandidateNeuron[];
   /**
    * Optional structural candidates emitted as tagged variants.
@@ -245,9 +257,21 @@ export interface RustParallelAnalysisResult {
   success: boolean;
   helpfulSynapses?: RustCandidateSynapse[];
   harmfulSynapses?: RustCandidateSynapse[];
+  /**
+   * Optional metadata describing synapse candidate discovery.
+   * - candidatesFound: how many candidates were considered/found before truncation
+   * - candidatesReturned: how many candidates were returned in `helpfulSynapses`
+   */
+  synapseMetadata?: RustCandidateMetadata;
   synapseDiagnostics?: RustSynapseDiagnostic[];
   synapseGpuUsed?: boolean;
   helpfulNeurons?: RustCandidateNeuron[];
+  /**
+   * Optional metadata describing neuron candidate discovery.
+   * - candidatesFound: how many candidates were considered/found before truncation
+   * - candidatesReturned: how many candidates were returned in `helpfulNeurons`
+   */
+  neuronMetadata?: RustCandidateMetadata;
   /**
    * Optional structural candidates emitted as tagged variants.
    * Supported variants are modelled by {@link RustStructuralCandidate}.
@@ -371,6 +395,16 @@ export interface RustSynapseDiagnostic {
   candidatesWithSamples: number;
   targetRecordCount: number;
   detail?: RustSynapseDiagnosticDetail;
+}
+
+/**
+ * Optional metadata emitted by NEAT-AI-Discovery describing candidate selection.
+ *
+ * This is used for logging/telemetry only and must not influence ranking logic.
+ */
+export interface RustCandidateMetadata {
+  candidatesFound: number;
+  candidatesReturned: number;
 }
 
 export type RustNeuronDiagnosticReason =

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -230,8 +230,6 @@ export interface RustParallelAnalysisInput {
   parquetFile: string;
   creature: RustRecordInput["creature"];
   focusNeurons: string[];
-  improvementThreshold?: number;
-  harmfulThreshold?: number;
   maxSynapseCandidates?: number;
   maxNeuronCandidates?: number;
   requireGpu?: boolean;

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -365,9 +365,14 @@ export class Neuron implements TagsInterface, NeuronInternal {
       }
     }
 
+    // Only consider a self-loop as a true "last resort".
+    //
+    // This avoids introducing self connections into otherwise feed-forward
+    // creatures (which can later be marked `forwardOnly=true` and validated).
     if (
       allowSelfTargets &&
       isForwardOnly === false &&
+      candidates.length === 0 &&
       !this.creature.getSynapse(this.index, this.index)
     ) {
       candidates.push(this.index);

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -13,7 +13,11 @@ import { MAXIMUM } from "../methods/activations/aggregate/MAXIMUM.ts";
 import { MINIMUM } from "../methods/activations/aggregate/MINIMUM.ts";
 import { HYPOT } from "../deprecated/HYPOT.ts";
 import { HYPOTv2 } from "../deprecated/HYPOTv2.ts";
-import { cleanupOrphanedNeurons } from "./CompactUtils.ts";
+import {
+  cleanupOrphanedNeurons,
+  pruneDeadSubgraphs,
+  pruneZeroWeightSynapses,
+} from "./CompactUtils.ts";
 
 /**
  * Compacts a creature by removing redundant neurons and connections.
@@ -288,6 +292,13 @@ export function compactCreature(
     }
   }
 
+  // 29-Dec-2025: Behaviour-preserving pruning of zero-weight synapses.
+  // See https://github.com/stSoftwareAU/NEAT-AI/issues/977
+  const zeroResult = pruneZeroWeightSynapses(compactCreature);
+  if (zeroResult.removedSynapses > 0) {
+    didCompact = true;
+  }
+
   /**
    * Clean up orphaned neurons using the robust iterative utility.
    *
@@ -299,6 +310,12 @@ export function compactCreature(
    */
   const orphanResult = cleanupOrphanedNeurons(compactCreature);
   if (orphanResult.removed > 0 || orphanResult.converted > 0) {
+    didCompact = true;
+  }
+
+  // Prune dead subgraphs (neurons/synapses that cannot influence any output).
+  const deadResult = pruneDeadSubgraphs(compactCreature);
+  if (deadResult.removedNeurons > 0 || deadResult.removedSynapses > 0) {
     didCompact = true;
   }
 

--- a/src/compact/CompactUtils.ts
+++ b/src/compact/CompactUtils.ts
@@ -339,10 +339,31 @@ export function mergeDuplicateSynapses(
 export function pruneZeroWeightSynapses(
   creatureExport: CreatureExport,
 ): PruneZeroWeightSynapsesResult {
+  // IF neurons require at least 3 inward connections with specific typed roles
+  // (condition/positive/negative). Even if a weight is zero, dropping a typed
+  // synapse can invalidate the structure and break activation semantics.
+  const ifNeuronUUIDs = new Set<string>();
+  for (const neuron of creatureExport.neurons) {
+    // Note: CreatureExport.neurons does not include input neurons (they are implicit),
+    // so `neuron.type` cannot be "input" here.
+    if (neuron.squash === "IF") {
+      ifNeuronUUIDs.add(neuron.uuid);
+    }
+  }
+
   const before = creatureExport.synapses.length;
-  creatureExport.synapses = creatureExport.synapses.filter((s) =>
-    Number.isFinite(s.weight) && s.weight !== 0
-  );
+  creatureExport.synapses = creatureExport.synapses.filter((s) => {
+    if (!Number.isFinite(s.weight)) return false;
+    if (s.weight !== 0) return true;
+
+    // Preserve typed synapses (eg IF condition/positive/negative).
+    if (s.type) return true;
+
+    // Extra safety: never prune a zero-weight synapse that targets an IF neuron.
+    if (ifNeuronUUIDs.has(s.toUUID)) return true;
+
+    return false;
+  });
 
   const removed = before - creatureExport.synapses.length;
   if (removed > 0) {

--- a/src/compact/CompactUtils.ts
+++ b/src/compact/CompactUtils.ts
@@ -265,6 +265,179 @@ export function cleanupOrphanedNeurons(
   return { removed: totalRemoved, converted: totalConverted };
 }
 
+export interface PruneDeadSubgraphsResult {
+  removedNeurons: number;
+  removedSynapses: number;
+}
+
+export interface PruneZeroWeightSynapsesResult {
+  removedSynapses: number;
+}
+
+export interface MergeDuplicateSynapsesResult {
+  merged: number;
+}
+
+/**
+ * Merge duplicate synapses (same from/to/type) by summing weights and removing
+ * duplicates.
+ *
+ * This is behaviour-preserving for forward passes.
+ *
+ * Note: we treat `type` as part of synapse identity. A synapse with a `type`
+ * (eg IF condition/positive/negative) is not equivalent to an untyped synapse.
+ *
+ * @param creatureExport - The CreatureExport to update (modified in place).
+ * @returns Count of duplicates merged (number of removed synapses).
+ */
+export function mergeDuplicateSynapses(
+  creatureExport: CreatureExport,
+): MergeDuplicateSynapsesResult {
+  const seen = new Map<string, number>(); // key -> index of first occurrence
+  const mergedSynapses: typeof creatureExport.synapses = [];
+  let mergedCount = 0;
+
+  for (const synapse of creatureExport.synapses) {
+    const typeKey = synapse.type ?? "";
+    const key = `${synapse.fromUUID}->${synapse.toUUID}:${typeKey}`;
+    const existingIndex = seen.get(key);
+    if (existingIndex === undefined) {
+      seen.set(key, mergedSynapses.length);
+      mergedSynapses.push({ ...synapse });
+      continue;
+    }
+
+    mergedSynapses[existingIndex].weight += synapse.weight;
+    mergedCount++;
+
+    // Best-effort tag merge.
+    if (synapse.tags?.length) {
+      const old = mergedSynapses[existingIndex].tags ?? [];
+      mergedSynapses[existingIndex].tags = [
+        ...new Set([...old, ...synapse.tags]),
+      ];
+    }
+  }
+
+  if (mergedCount > 0) {
+    creatureExport.synapses = mergedSynapses;
+    // Structure changed, so cached memetic references are no longer trustworthy.
+    delete creatureExport.memetic;
+  }
+
+  return { merged: mergedCount };
+}
+
+/**
+ * Prunes synapses whose weight is exactly zero.
+ *
+ * This is behaviour-preserving for forward passes.
+ *
+ * @param creatureExport - The CreatureExport to prune (modified in place).
+ * @returns Count of removed synapses.
+ */
+export function pruneZeroWeightSynapses(
+  creatureExport: CreatureExport,
+): PruneZeroWeightSynapsesResult {
+  const before = creatureExport.synapses.length;
+  creatureExport.synapses = creatureExport.synapses.filter((s) =>
+    Number.isFinite(s.weight) && s.weight !== 0
+  );
+
+  const removed = before - creatureExport.synapses.length;
+  if (removed > 0) {
+    // Structure changed, so cached memetic references are no longer trustworthy.
+    delete creatureExport.memetic;
+  }
+
+  return { removedSynapses: removed };
+}
+
+/**
+ * Prunes "dead" subgraphs: hidden/constant neurons (and their synapses) that
+ * cannot influence any output.
+ *
+ * A neuron can influence an output if there is at least one directed path from
+ * that neuron to any output neuron.
+ *
+ * This is behaviour-preserving for forward passes: removed elements were not
+ * able to affect any output activation.
+ *
+ * Notes:
+ * - Inputs are implicit (UUIDs like `input-0`) and are never removed.
+ * - Outputs are never removed.
+ * - This function modifies the CreatureExport in place.
+ *
+ * @param creatureExport - The CreatureExport to prune (modified in place).
+ * @returns Counts of removed neurons and removed synapses.
+ */
+export function pruneDeadSubgraphs(
+  creatureExport: CreatureExport,
+): PruneDeadSubgraphsResult {
+  // Build reverse adjacency: toUUID -> set(fromUUID)
+  const incoming = new Map<string, Set<string>>();
+  for (const synapse of creatureExport.synapses) {
+    let set = incoming.get(synapse.toUUID);
+    if (!set) {
+      set = new Set<string>();
+      incoming.set(synapse.toUUID, set);
+    }
+    set.add(synapse.fromUUID);
+  }
+
+  // Seed BFS from all outputs.
+  const canReachOutput = new Set<string>();
+  const queue: string[] = [];
+  for (const neuron of creatureExport.neurons) {
+    if (neuron.type === "output") {
+      canReachOutput.add(neuron.uuid);
+      queue.push(neuron.uuid);
+    }
+  }
+
+  // Reverse traversal: collect all ancestors of outputs.
+  while (queue.length) {
+    const current = queue.pop()!;
+    const parents = incoming.get(current);
+    if (!parents) continue;
+    for (const fromUUID of parents) {
+      if (!canReachOutput.has(fromUUID)) {
+        canReachOutput.add(fromUUID);
+        queue.push(fromUUID);
+      }
+    }
+  }
+
+  const toRemove = new Set<string>();
+  for (const neuron of creatureExport.neurons) {
+    if (neuron.type === "hidden" || neuron.type === "constant") {
+      if (!canReachOutput.has(neuron.uuid)) {
+        toRemove.add(neuron.uuid);
+      }
+    }
+  }
+
+  if (toRemove.size === 0) {
+    return { removedNeurons: 0, removedSynapses: 0 };
+  }
+
+  const beforeSynapses = creatureExport.synapses.length;
+  creatureExport.neurons = creatureExport.neurons.filter((n) =>
+    !toRemove.has(n.uuid)
+  );
+  creatureExport.synapses = creatureExport.synapses.filter((s) =>
+    !toRemove.has(s.fromUUID) && !toRemove.has(s.toUUID)
+  );
+
+  // Structure changed, so cached memetic references are no longer trustworthy.
+  delete creatureExport.memetic;
+
+  return {
+    removedNeurons: toRemove.size,
+    removedSynapses: beforeSynapses - creatureExport.synapses.length,
+  };
+}
+
 /**
  * Deletes memetic data if the removed synapse is referenced in it.
  *
@@ -342,6 +515,31 @@ export function cleanupOrphanedNeuronsInCreature(
   const result = cleanupOrphanedNeurons(exportJSON);
 
   if (result.removed > 0 || result.converted > 0) {
+    creature.loadFrom(exportJSON, true);
+  }
+
+  return result;
+}
+
+/**
+ * Prunes dead subgraphs from a live Creature instance.
+ *
+ * This is a convenience wrapper that exports the creature to JSON (without
+ * validation, to allow intermediate invalid states), prunes dead subgraphs, and
+ * reloads the creature if any modifications were made.
+ *
+ * @param creature - The Creature to prune (modified in place).
+ * @returns Counts of removed neurons and removed synapses.
+ */
+export function pruneDeadSubgraphsInCreature(
+  creature: Creature,
+): PruneDeadSubgraphsResult {
+  // Use the builder directly to bypass validation (creature may be in an intermediate state)
+  const builder = new CreatureExportBuilder(creature);
+  const exportJSON = builder.build();
+
+  const result = pruneDeadSubgraphs(exportJSON);
+  if (result.removedNeurons > 0 || result.removedSynapses > 0) {
     creature.loadFrom(exportJSON, true);
   }
 

--- a/src/compact/CompactUtils.ts
+++ b/src/compact/CompactUtils.ts
@@ -6,6 +6,7 @@ import type { Synapse } from "../architecture/Synapse.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import { Activations } from "../methods/activations/Activations.ts";
 import { CreatureExportBuilder } from "../utils/CreatureExportBuilder.ts";
+import { mergeTagsByNameValue } from "../utils/TagUtils.ts";
 
 /**
  * Result of cleaning up orphaned neurons.
@@ -312,10 +313,10 @@ export function mergeDuplicateSynapses(
 
     // Best-effort tag merge.
     if (synapse.tags?.length) {
-      const old = mergedSynapses[existingIndex].tags ?? [];
-      mergedSynapses[existingIndex].tags = [
-        ...new Set([...old, ...synapse.tags]),
-      ];
+      mergedSynapses[existingIndex].tags = mergeTagsByNameValue(
+        mergedSynapses[existingIndex].tags,
+        synapse.tags,
+      );
     }
   }
 
@@ -343,17 +344,21 @@ export function pruneZeroWeightSynapses(
   // (condition/positive/negative). Even if a weight is zero, dropping a typed
   // synapse can invalidate the structure and break activation semantics.
   const ifNeuronUUIDs = new Set<string>();
+  const outputNeuronUUIDs = new Set<string>();
   for (const neuron of creatureExport.neurons) {
     // Note: CreatureExport.neurons does not include input neurons (they are implicit),
     // so `neuron.type` cannot be "input" here.
     if (neuron.squash === "IF") {
       ifNeuronUUIDs.add(neuron.uuid);
     }
+    if (neuron.type === "output") {
+      outputNeuronUUIDs.add(neuron.uuid);
+    }
   }
 
   const before = creatureExport.synapses.length;
-  creatureExport.synapses = creatureExport.synapses.filter((s) => {
-    if (!Number.isFinite(s.weight)) return false;
+  const inboundKeptCountsByTo = new Map<string, number>();
+  const shouldAlwaysKeep = (s: typeof creatureExport.synapses[number]) => {
     if (s.weight !== 0) return true;
 
     // Preserve typed synapses (eg IF condition/positive/negative).
@@ -361,6 +366,41 @@ export function pruneZeroWeightSynapses(
 
     // Extra safety: never prune a zero-weight synapse that targets an IF neuron.
     if (ifNeuronUUIDs.has(s.toUUID)) return true;
+
+    return false;
+  };
+
+  // First pass: count inbound connections that will remain after pruning.
+  for (const s of creatureExport.synapses) {
+    if (!Number.isFinite(s.weight)) continue;
+    if (!shouldAlwaysKeep(s)) continue;
+    inboundKeptCountsByTo.set(
+      s.toUUID,
+      (inboundKeptCountsByTo.get(s.toUUID) ?? 0) + 1,
+    );
+  }
+
+  // Second pass: filter, preserving the last inbound connection to outputs for
+  // structural validity (mirrors Creature.fix() behaviour).
+  const preservedZeroInboundForOutput = new Set<string>();
+  creatureExport.synapses = creatureExport.synapses.filter((s) => {
+    if (!Number.isFinite(s.weight)) return false;
+    if (shouldAlwaysKeep(s)) return true;
+
+    // At this point, the synapse is:
+    // - finite
+    // - weight === 0
+    // - untyped
+    // - not targeting an IF neuron
+    //
+    // Prune it, unless it's the last inbound connection to an output neuron.
+    if (outputNeuronUUIDs.has(s.toUUID)) {
+      const inboundKept = inboundKeptCountsByTo.get(s.toUUID) ?? 0;
+      if (inboundKept === 0 && !preservedZeroInboundForOutput.has(s.toUUID)) {
+        preservedZeroInboundForOutput.add(s.toUUID);
+        return true;
+      }
+    }
 
     return false;
   });

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -157,14 +157,6 @@ export interface NeatArguments {
   discoverySampleRate: number;
 
   /**
-   * Minimum expected improvement (0..1) that a discovery candidate must
-   * achieve in order to be considered helpful. Defaults to 0.01 (1%).
-   *
-   * @see docs/DISCOVERY_GUIDE.md for the distributed discovery model
-   */
-  discoveryMinImprovementPercentage?: number;
-
-  /**
    * Minimum multiplier of costOfGrowth that a discovery candidate's expected
    * improvement must exceed before evaluation. Defaults to 2.0.
    *

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -32,6 +32,15 @@ export interface RequestData {
     costName: CostName;
     /** Serialized custom cost function data (if using custom cost) */
     customCostData?: string;
+    /**
+     * When true, enables verbose NEAT-AI-Discovery logging inside the worker
+     * by exporting `NEAT_AI_DISCOVERY_VERBOSE=1` before any discovery calls.
+     *
+     * Note (29-Dec-2025): This is only best-effort - it requires env permissions
+     * in the worker runtime. When unavailable, discovery still runs, just without
+     * Rust verbose logs.
+     */
+    discoveryVerbose?: boolean;
   };
   /** Creature evaluation request */
   evaluate?: {
@@ -225,12 +234,25 @@ export class WorkerHandler {
       });
     }
 
+    const discoveryVerbose = (() => {
+      try {
+        const value = Deno.env.get("NEAT_AI_DISCOVERY_VERBOSE");
+        if (!value) return false;
+        const normalised = value.trim().toLowerCase();
+        return normalised === "1" || normalised === "true" ||
+          normalised === "yes";
+      } catch {
+        return false;
+      }
+    })();
+
     const data: RequestData = {
       taskID: this.taskID++,
       initialize: {
         dataSetDir: dataSetDir,
         costName: costName,
         customCostData,
+        discoveryVerbose,
       },
     };
 

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -60,6 +60,13 @@ export class WorkerProcessor {
   async process(data: RequestData): Promise<ResponseData> {
     const start = Date.now();
     if (data.initialize) {
+      if (data.initialize.discoveryVerbose) {
+        try {
+          Deno.env.set("NEAT_AI_DISCOVERY_VERBOSE", "1");
+        } catch {
+          // Best-effort: worker may not have --allow-env.
+        }
+      }
       // Handle custom cost function if provided
       if (data.initialize.customCostData) {
         const customCostInfo = JSON.parse(data.initialize.customCostData);

--- a/src/utils/TagUtils.ts
+++ b/src/utils/TagUtils.ts
@@ -1,0 +1,41 @@
+import type { TagInterface } from "@stsoftware/tags/mod";
+
+/**
+ * De-duplicate tags by value equality, not reference equality.
+ *
+ * Note (29-Dec-2025): `Set<TagInterface>` de-duplicates by reference, so two
+ * distinct objects with identical `{name, value}` content would both be kept.
+ * This helper de-duplicates by `{name, value}` so merged synapses don't
+ * accumulate duplicate metadata tags.
+ */
+export function dedupeTagsByNameValue(
+  tags: TagInterface[] | undefined,
+): TagInterface[] | undefined {
+  if (!tags || tags.length === 0) return undefined;
+
+  const seen = new Set<string>();
+  const out: TagInterface[] = [];
+
+  for (const tag of tags) {
+    // TagInterface is expected to be `{ name, value }`. We build a stable key
+    // and treat identical (name,value) pairs as duplicates.
+    const key = `${tag.name}\u0000${String(tag.value)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(tag);
+  }
+
+  return out.length ? out : undefined;
+}
+
+/**
+ * Merge two tag arrays and de-duplicate by `{name, value}`.
+ */
+export function mergeTagsByNameValue(
+  a: TagInterface[] | undefined,
+  b: TagInterface[] | undefined,
+): TagInterface[] | undefined {
+  if (!a?.length) return dedupeTagsByNameValue(b);
+  if (!b?.length) return dedupeTagsByNameValue(a);
+  return dedupeTagsByNameValue([...a, ...b]);
+}

--- a/test/Compact/DeadSubgraphPruning.ts
+++ b/test/Compact/DeadSubgraphPruning.ts
@@ -1,0 +1,71 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../mod.ts";
+import { Creature } from "../../src/Creature.ts";
+import { pruneDeadSubgraphsInCreature } from "../../src/compact/CompactUtils.ts";
+
+function mulberry32(seed: number) {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6D2B79F5;
+    let x = Math.imul(t ^ (t >>> 15), 1 | t);
+    x ^= x + Math.imul(x ^ (x >>> 7), 61 | x);
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function makeCreature(): Creature {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-live", squash: "TANH", bias: 0.1 },
+
+      // Dead subgraph: internally connected (not orphaned), but has no path to any output.
+      { type: "hidden", uuid: "hidden-dead-1", squash: "TANH", bias: -0.2 },
+      { type: "hidden", uuid: "hidden-dead-2", squash: "TANH", bias: 0.3 },
+
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-live", weight: 1.25 },
+      { fromUUID: "hidden-live", toUUID: "output-0", weight: -0.75 },
+
+      { fromUUID: "input-0", toUUID: "hidden-dead-1", weight: 0.9 },
+      { fromUUID: "hidden-dead-1", toUUID: "hidden-dead-2", weight: -0.4 },
+      { fromUUID: "hidden-dead-2", toUUID: "hidden-dead-1", weight: 0.2 },
+    ],
+    input: 1,
+    output: 1,
+  };
+
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  return creature;
+}
+
+Deno.test("Dead subgraph pruning: removes unreachable subgraph without changing outputs", () => {
+  const creature = makeCreature();
+  const beforeNeuronCount = creature.neurons.length;
+  const beforeSynapseCount = creature.synapses.length;
+
+  const rnd = mulberry32(20251229);
+  const inputs: Float32Array[] = [];
+  for (let i = 0; i < 256; i++) {
+    // Keep values moderate to avoid saturating everything.
+    inputs.push(new Float32Array([(rnd() * 2 - 1) * 0.75]));
+  }
+
+  const beforeOutputs = inputs.map((x) => creature.activate(x));
+
+  const result = pruneDeadSubgraphsInCreature(creature);
+  assertEquals(result.removedNeurons, 2);
+  assertEquals(result.removedSynapses, 3);
+
+  creature.validate();
+
+  assertEquals(creature.neurons.length, beforeNeuronCount - 2);
+  assertEquals(creature.synapses.length, beforeSynapseCount - 3);
+
+  for (let i = 0; i < inputs.length; i++) {
+    const after = creature.activate(inputs[i]);
+    assertAlmostEquals(after[0], beforeOutputs[i][0], 0.000_000_1);
+  }
+});

--- a/test/Compact/MergeDuplicateSynapses.ts
+++ b/test/Compact/MergeDuplicateSynapses.ts
@@ -1,0 +1,69 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { mergeDuplicateSynapses } from "../../src/compact/CompactUtils.ts";
+
+const tagA = { name: "tag", value: "a" };
+const tagB = { name: "tag", value: "b" };
+
+Deno.test("mergeDuplicateSynapses: merges same from/to/type (sums weights), preserves typed separation, clears memetic", () => {
+  const exportJSON: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "input-0", toUUID: "output-0", weight: -0.2, tags: [tagB] },
+      // Typed duplicates should merge with same type only.
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-0",
+        weight: 0.1,
+        type: "condition",
+        tags: [tagA],
+      },
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-0",
+        weight: 0.2,
+        type: "condition",
+        tags: [tagB],
+      },
+      // Different type should remain separate.
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-0",
+        weight: 0.3,
+        type: "positive",
+      },
+    ],
+    memetic: { generation: 0, score: 0, biases: {}, weights: {} },
+  };
+
+  const result = mergeDuplicateSynapses(exportJSON);
+  assertEquals(result.merged, 2);
+  assertEquals(exportJSON.memetic, undefined);
+
+  // Should now have 3 synapses: merged output edge, merged condition edge, and positive edge.
+  assertEquals(exportJSON.synapses.length, 3);
+
+  const out = exportJSON.synapses.find((s) =>
+    s.fromUUID === "input-0" && s.toUUID === "output-0"
+  );
+  assertEquals(out?.weight, 0.3);
+
+  const condition = exportJSON.synapses.find((s) =>
+    s.fromUUID === "input-0" && s.toUUID === "hidden-0" &&
+    s.type === "condition"
+  );
+  assertEquals(condition?.weight, 0.3);
+  const tagValues = new Set((condition?.tags ?? []).map((t) => t.value));
+  assertEquals(tagValues, new Set(["a", "b"]));
+
+  const positive = exportJSON.synapses.find((s) =>
+    s.fromUUID === "input-0" && s.toUUID === "hidden-0" && s.type === "positive"
+  );
+  assertEquals(positive?.weight, 0.3);
+});

--- a/test/Compact/MergeDuplicateSynapses.ts
+++ b/test/Compact/MergeDuplicateSynapses.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertAlmostEquals, assertEquals } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { mergeDuplicateSynapses } from "../../src/compact/CompactUtils.ts";
 
@@ -58,7 +58,7 @@ Deno.test("mergeDuplicateSynapses: merges same from/to/type (sums weights), pres
     s.fromUUID === "input-0" && s.toUUID === "hidden-0" &&
     s.type === "condition"
   );
-  assertEquals(condition?.weight, 0.3);
+  assertAlmostEquals(condition?.weight ?? 0, 0.3);
   const tagValues = new Set((condition?.tags ?? []).map((t) => t.value));
   assertEquals(tagValues, new Set(["a", "b"]));
 

--- a/test/Compact/MergeDuplicateSynapsesTagDedup.ts
+++ b/test/Compact/MergeDuplicateSynapsesTagDedup.ts
@@ -1,0 +1,42 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { mergeDuplicateSynapses } from "../../src/compact/CompactUtils.ts";
+
+Deno.test("mergeDuplicateSynapses: de-duplicates tags by {name,value} (not reference equality)", () => {
+  // Two distinct objects with identical {name,value}.
+  const t1 = { name: "meta", value: "same" };
+  const t2 = { name: "meta", value: "same" };
+
+  const exportJSON: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [{
+      type: "output",
+      uuid: "output-0",
+      squash: "IDENTITY",
+      bias: 0,
+    }],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 0.25,
+        tags: [t1],
+      },
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 0.75,
+        tags: [t2],
+      },
+    ],
+  };
+
+  mergeDuplicateSynapses(exportJSON);
+
+  assertEquals(exportJSON.synapses.length, 1);
+  assertEquals(exportJSON.synapses[0].weight, 1.0);
+  assertEquals(exportJSON.synapses[0].tags?.length, 1);
+  assertEquals(exportJSON.synapses[0].tags?.[0].name, "meta");
+  assertEquals(exportJSON.synapses[0].tags?.[0].value, "same");
+});

--- a/test/Compact/ZeroWeightSynapsePruning.ts
+++ b/test/Compact/ZeroWeightSynapsePruning.ts
@@ -1,0 +1,78 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../mod.ts";
+import { Creature } from "../../src/Creature.ts";
+
+function mulberry32(seed: number) {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6D2B79F5;
+    let x = Math.imul(t ^ (t >>> 15), 1 | t);
+    x ^= x + Math.imul(x ^ (x >>> 7), 61 | x);
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function makeCreature(): Creature {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-unused", squash: "TANH", bias: 0.2 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      // This path is live and determines outputs.
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1.25 },
+
+      // These synapses are behaviour-preserving dead weight:
+      // hidden-unused influences output only via a zero-weight edge.
+      { fromUUID: "input-0", toUUID: "hidden-unused", weight: -0.5 },
+      { fromUUID: "hidden-unused", toUUID: "output-0", weight: 0 },
+    ],
+    input: 1,
+    output: 1,
+  };
+
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  return creature;
+}
+
+Deno.test("Compact: prunes zero-weight synapses then removes newly-orphaned neurons (behaviour-preserving)", () => {
+  const creature = makeCreature();
+  const beforeNeuronCount = creature.neurons.length;
+  const beforeSynapseCount = creature.synapses.length;
+
+  const rnd = mulberry32(20251229);
+  const inputs: Float32Array[] = [];
+  for (let i = 0; i < 256; i++) {
+    inputs.push(new Float32Array([(rnd() * 2 - 1) * 0.9]));
+  }
+
+  const beforeOutputs = inputs.map((x) => creature.activate(x));
+
+  const compacted = creature.compact(false);
+
+  // Without zero-weight pruning inside compaction, this would be undefined because
+  // the network remains structurally unchanged (the dead-weight edge keeps the
+  // hidden neuron "connected").
+  assertEquals(typeof compacted !== "undefined", true);
+
+  compacted!.validate();
+
+  // Zero-weight synapse should be removed, which should orphan the hidden neuron,
+  // which should then be removed by orphan cleanup.
+  assertEquals(compacted!.neurons.length, beforeNeuronCount - 1);
+  // We remove:
+  // - the zero-weight synapse (hidden-unused -> output-0)
+  // - the inbound synapse to the newly removed neuron (input-0 -> hidden-unused)
+  assertEquals(compacted!.synapses.length, beforeSynapseCount - 2);
+  assertEquals(compacted!.synapses.some((s) => s.weight === 0), false);
+  assertEquals(
+    compacted!.neurons.some((n) => n.uuid === "hidden-unused"),
+    false,
+  );
+
+  for (let i = 0; i < inputs.length; i++) {
+    const after = compacted!.activate(inputs[i]);
+    assertAlmostEquals(after[0], beforeOutputs[i][0], 0.000_000_1);
+  }
+});

--- a/test/Compact/ZeroWeightSynapsePruningTyped.ts
+++ b/test/Compact/ZeroWeightSynapsePruningTyped.ts
@@ -2,17 +2,24 @@ import { assertEquals } from "@std/assert";
 import type { CreatureExport } from "../../mod.ts";
 import { pruneZeroWeightSynapses } from "../../src/compact/CompactUtils.ts";
 
-Deno.test("pruneZeroWeightSynapses: keeps typed synapses and protects IF targets", () => {
+Deno.test("pruneZeroWeightSynapses: keeps typed synapses, protects IF targets, and never disconnects outputs", () => {
   const exportJSON: CreatureExport = {
     input: 1,
-    output: 1,
+    output: 2,
     neurons: [
       { type: "hidden", uuid: "if-0", squash: "IF", bias: 0 },
       { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+      { type: "output", uuid: "output-1", squash: "IDENTITY", bias: -0.2 },
     ],
     synapses: [
-      // A zero-weight, untyped synapse to a normal output should be pruned.
+      // When an output has other inbound connections, a zero-weight, untyped
+      // synapse should be pruned.
       { fromUUID: "input-0", toUUID: "output-0", weight: 0 },
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.3 },
+
+      // Structural safety: when an output would otherwise have zero inbound
+      // connections, preserve the last inbound synapse (even if its weight is 0).
+      { fromUUID: "input-0", toUUID: "output-1", weight: 0 },
 
       // IF requires typed inbound connections; these must never be pruned.
       {
@@ -34,8 +41,11 @@ Deno.test("pruneZeroWeightSynapses: keeps typed synapses and protects IF targets
   assertEquals(result.removedSynapses, 1);
   assertEquals(exportJSON.memetic, undefined);
 
-  // We should keep 4 synapses (3 typed required by IF + 1 untyped zero to IF).
-  assertEquals(exportJSON.synapses.length, 4);
+  // We should keep 6 synapses:
+  // - 2 inbound to output-0 (zero pruned, non-zero kept) => 1 remains
+  // - 1 inbound to output-1 (kept for structural safety) => 1 remains
+  // - 3 typed required by IF + 1 untyped zero to IF => 4 remain
+  assertEquals(exportJSON.synapses.length, 6);
   assertEquals(
     exportJSON.synapses.filter((s) => s.toUUID === "if-0").length,
     4,
@@ -43,5 +53,15 @@ Deno.test("pruneZeroWeightSynapses: keeps typed synapses and protects IF targets
   assertEquals(
     exportJSON.synapses.some((s) => s.toUUID === "output-0" && s.weight === 0),
     false,
+  );
+  assertEquals(
+    exportJSON.synapses.some((s) =>
+      s.toUUID === "output-0" && s.weight === 0.3
+    ),
+    true,
+  );
+  assertEquals(
+    exportJSON.synapses.some((s) => s.toUUID === "output-1" && s.weight === 0),
+    true,
   );
 });

--- a/test/Compact/ZeroWeightSynapsePruningTyped.ts
+++ b/test/Compact/ZeroWeightSynapsePruningTyped.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../mod.ts";
+import { pruneZeroWeightSynapses } from "../../src/compact/CompactUtils.ts";
+
+Deno.test("pruneZeroWeightSynapses: keeps typed synapses and protects IF targets", () => {
+  const exportJSON: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "if-0", squash: "IF", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      // A zero-weight, untyped synapse to a normal output should be pruned.
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0 },
+
+      // IF requires typed inbound connections; these must never be pruned.
+      {
+        fromUUID: "input-0",
+        toUUID: "if-0",
+        weight: 0,
+        type: "condition",
+      },
+      { fromUUID: "input-0", toUUID: "if-0", weight: 0.2, type: "positive" },
+      { fromUUID: "input-0", toUUID: "if-0", weight: -0.2, type: "negative" },
+
+      // Extra safety: even untyped zero-weight edges to IF targets are preserved.
+      { fromUUID: "input-0", toUUID: "if-0", weight: 0 },
+    ],
+    memetic: { generation: 0, score: 0, biases: {}, weights: {} },
+  };
+
+  const result = pruneZeroWeightSynapses(exportJSON);
+  assertEquals(result.removedSynapses, 1);
+  assertEquals(exportJSON.memetic, undefined);
+
+  // We should keep 4 synapses (3 typed required by IF + 1 untyped zero to IF).
+  assertEquals(exportJSON.synapses.length, 4);
+  assertEquals(
+    exportJSON.synapses.filter((s) => s.toUUID === "if-0").length,
+    4,
+  );
+  assertEquals(
+    exportJSON.synapses.some((s) => s.toUUID === "output-0" && s.weight === 0),
+    false,
+  );
+});

--- a/test/fix/DuplicateSynapses.ts
+++ b/test/fix/DuplicateSynapses.ts
@@ -1,0 +1,61 @@
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import { Creature, type CreatureExport } from "../../mod.ts";
+
+function mulberry32(seed: number) {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6D2B79F5;
+    let x = Math.imul(t ^ (t >>> 15), 1 | t);
+    x ^= x + Math.imul(x ^ (x >>> 7), 61 | x);
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function makeCreature(): Creature {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.25 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 },
+      // Duplicate (same from/to). This should be merged, not dropped.
+      { fromUUID: "input-0", toUUID: "output-0", weight: -0.1 },
+    ],
+    input: 1,
+    output: 1,
+  };
+
+  // Note: validate=false is intentional. Real-world exports can be edited and end
+  // up containing duplicate synapses, which validation currently rejects.
+  const creature = Creature.fromJSON(json, false);
+  // Simulate a persisted memetic record that should be dropped when structure changes.
+  (creature as unknown as { memetic?: unknown }).memetic = { note: "test" };
+  return creature;
+}
+
+Deno.test("fix(): merges duplicate synapses by summing weights (behaviour-preserving)", () => {
+  const creature = makeCreature();
+
+  const rnd = mulberry32(20251229);
+  const inputs: Float32Array[] = [];
+  for (let i = 0; i < 256; i++) {
+    inputs.push(new Float32Array([(rnd() * 2 - 1) * 1.1]));
+  }
+
+  const before = inputs.map((x) => creature.activate(x)[0]);
+
+  creature.fix();
+  creature.validate();
+
+  assertEquals(creature.synapses.length, 1);
+  assertAlmostEquals(creature.synapses[0].weight, 0.4, 0.000_000_1);
+  assertEquals(
+    (creature as unknown as { memetic?: unknown }).memetic,
+    undefined,
+  );
+
+  for (let i = 0; i < inputs.length; i++) {
+    const after = creature.activate(inputs[i])[0];
+    assertAlmostEquals(after, before[i], 0.000_000_1);
+  }
+});

--- a/test/fix/DuplicateSynapsesTagDedup.ts
+++ b/test/fix/DuplicateSynapsesTagDedup.ts
@@ -1,0 +1,42 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../mod.ts";
+import { Creature } from "../../src/Creature.ts";
+
+Deno.test("fix(): when merging duplicate synapses, de-duplicates tags by {name,value}", () => {
+  const tag1 = { name: "source", value: "unit-test" };
+  const tag2 = { name: "source", value: "unit-test" };
+
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [{
+      type: "output",
+      uuid: "output-0",
+      squash: "IDENTITY",
+      bias: 0,
+    }],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 0.5,
+        tags: [tag1],
+      },
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 0.5,
+        tags: [tag2],
+      },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, false);
+  creature.fix();
+
+  assertEquals(creature.synapses.length, 1);
+  const tags = creature.synapses[0].tags ?? [];
+  assertEquals(tags.length, 1);
+  assertEquals(tags[0].name, "source");
+  assertEquals(tags[0].value, "unit-test");
+});

--- a/test/fix/FixKeepsLastZeroWeightOutputSynapse.ts
+++ b/test/fix/FixKeepsLastZeroWeightOutputSynapse.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../mod.ts";
+import { Creature } from "../../src/Creature.ts";
+
+Deno.test("fix(): keeps the last zero-weight inbound synapse to an output (structure safety)", () => {
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      // Only inbound connection to output, but weight is zero.
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, false);
+  creature.fix();
+  creature.validate();
+
+  assertEquals(creature.synapses.length, 1);
+  assertEquals(creature.synapses[0].weight, 0);
+  assertEquals(creature.neurons.some((n) => n.uuid === "output-0"), true);
+});

--- a/test/fix/ForwardOnlyNoSelfLoops.ts
+++ b/test/fix/ForwardOnlyNoSelfLoops.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../mod.ts";
+import { Creature } from "../../src/Creature.ts";
+
+Deno.test("fix({ forwardOnly:true }): never creates self-loops; removes neurons with no forward targets", () => {
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    semanticVersion: "2.9.9",
+    neurons: [
+      // Hidden neuron deliberately has no connections.
+      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      // Keep output valid/connected.
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
+    ],
+  };
+
+  // Intentionally skip validation to simulate a "dirty" edited export.
+  const creature = Creature.fromJSON(json, false);
+  creature.forwardOnly = true;
+
+  creature.fix({ forwardOnly: true });
+
+  // Should be forward-only valid after fix.
+  creature.validate({ forwardOnly: true });
+
+  // Never create self loops in forward-only mode.
+  assertEquals(creature.synapses.some((s) => s.from === s.to), false);
+
+  // The disconnected hidden neuron should be removed entirely.
+  assertEquals(creature.neurons.some((n) => n.uuid === "hidden-0"), false);
+});

--- a/test/fix/NeuronSelfLoopLastResort.ts
+++ b/test/fix/NeuronSelfLoopLastResort.ts
@@ -1,0 +1,29 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../mod.ts";
+import { Creature } from "../../src/Creature.ts";
+
+Deno.test("Neuron.fix(): in recurrent mode, self-loop is only used as a last resort (no forward targets)", () => {
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    // Deliberately invalid ordering: output before hidden.
+    // This lets us place a hidden neuron at the end so it has no forward targets.
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+      { type: "hidden", uuid: "hidden-tail", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, false);
+
+  // Recurrent mode (not forward-only): self-loops are allowed.
+  creature.forwardOnly = false;
+  creature.fix();
+
+  // We intentionally do not validate here because the neuron ordering is invalid by design.
+  // The point is to exercise the "self-loop as last resort" branch.
+  assertEquals(creature.synapses.some((s) => s.from === s.to), true);
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Core/compact (behaviour-preserving cleanups)**
> - `Creature.fix()` now merges duplicate synapses (sum weights) with tag de-dupe, prunes zero-weight edges except the last inbound to outputs, and removes disconnected hidden neurons
> - `compactCreature()` adds `pruneZeroWeightSynapses` and `pruneDeadSubgraphs`; new helpers in `CompactUtils.ts` and tag utilities in `utils/TagUtils.ts`
> - `Neuron`: self-loop considered only as last resort (never in `forwardOnly`)
> 
> **Discovery logging/metrics**
> - `DiscoverDirectory`: logs per-candidate details, classifies fallback/split-error, reports counts that match returned arrays, and surfaces Rust candidate metadata
> - `DiscoverStructure`/`RustDiscovery`: plumb optional `{candidatesFound,candidatesReturned}` metadata for synapse/neuron analysis; remove unused `improvementThreshold`/`harmfulThreshold` from Rust input
> 
> **Worker/runtime**
> - Propagate `NEAT_AI_DISCOVERY_VERBOSE` to workers (`WorkerHandler`/`WorkerProcessor`) for optional Rust-side verbose logs
> 
> **Docs/config**
> - Remove `discoveryMinImprovementPercentage` from examples/options and simplify selection strategy to cost-of-growth gate + best-net-improvement
> 
> **Tests**
> - New tests covering duplicate-synapse merge (with tag de-dupe), zero-weight pruning (typed/IF safety), dead-subgraph pruning, forward-only no self-loops, and structural safety for outputs
> 
> **Version**
> - Bump to `0.281.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad1470670790467554b96c87d839cb412c5414bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->