### PR TITLE
Update version to 0.282.0 in deno.json and implement candidate prunin…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.281.0",
+  "version": "0.282.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -1511,6 +1511,107 @@ export function buildCombinedFromSuccessful(
   return combinedCandidates;
 }
 
+export interface ScoredDiscoveryCandidate {
+  candidate: DiscoveryCandidate;
+  /** Measured score delta (candidateScore - originalScore) from Phase 1. */
+  scoreDelta: number;
+}
+
+/**
+ * Reduce a set of successful single-step candidates into a sensible, non-conflicting
+ * subset before building combination candidates.
+ *
+ * Rationale (production): discovery can surface multiple successful "alternatives"
+ * for the same structural slot (eg multiple add-neurons from the same source to
+ * the same target). Combining these alternatives is usually wasteful and can
+ * suppress better cross-slot combinations. Instead, we keep the best candidate
+ * per slot and allow combinations across different slots.
+ */
+export function pruneSuccessfulCandidatesForCombos(
+  successfulCandidates: ScoredDiscoveryCandidate[],
+): DiscoveryCandidate[] {
+  if (successfulCandidates.length === 0) return [];
+
+  const bestBySlot = new Map<string, ScoredDiscoveryCandidate>();
+  const unkeyed: ScoredDiscoveryCandidate[] = [];
+
+  for (const entry of successfulCandidates) {
+    const slotKey = getComboSlotKey(entry.candidate);
+    if (!slotKey) {
+      unkeyed.push(entry);
+      continue;
+    }
+    const current = bestBySlot.get(slotKey);
+    if (!current || entry.scoreDelta > current.scoreDelta) {
+      bestBySlot.set(slotKey, entry);
+    }
+  }
+
+  const pruned = [...bestBySlot.values(), ...unkeyed]
+    .sort((a, b) => {
+      if (a.scoreDelta !== b.scoreDelta) return b.scoreDelta - a.scoreDelta;
+      // Stable-ish tie-breaks for determinism.
+      const typeA = a.candidate.change.type;
+      const typeB = b.candidate.change.type;
+      if (typeA !== typeB) return typeA.localeCompare(typeB);
+      const descA = a.candidate.change.description ?? "";
+      const descB = b.candidate.change.description ?? "";
+      return descA.localeCompare(descB);
+    })
+    .map((e) => e.candidate);
+
+  return pruned;
+}
+
+function getComboSlotKey(candidate: DiscoveryCandidate): string | undefined {
+  const change = candidate.change;
+  switch (change.type) {
+    case "add-neurons": {
+      const from = change.neuronDetails?.fromNeuronUUID ??
+        change.neuronCandidate?.fromNeuronUUID;
+      const to = change.neuronDetails?.toNeuronUUID ??
+        change.neuronCandidate?.toNeuronUUID;
+      if (!from || !to) return undefined;
+      return `add-neurons:${from}->${to}`;
+    }
+    case "add-synapses": {
+      const from = change.synapseCandidate?.fromNeuronUUID;
+      const to = change.synapseCandidate?.toNeuronUUID;
+      if (!from || !to) return undefined;
+      return `add-synapses:${from}->${to}`;
+    }
+    case "remove-synapse": {
+      const details = change.synapseDetails;
+      if (!details) return undefined;
+      return `remove-synapse:${details.fromNeuronUUID}->${details.toNeuronUUID}`;
+    }
+    case "remove-low-impact": {
+      const uuid = change.removalCandidate?.neuronUUID ??
+        change.description?.match(/neuron\s+([a-zA-Z0-9_-]+)/i)?.[1];
+      if (!uuid) return undefined;
+      return `remove-neuron:${uuid}`;
+    }
+    case "remove-neuron": {
+      const uuid = change.harmfulNeuronCandidate?.neuronUUID ??
+        change.description?.match(/neuron\s+([a-zA-Z0-9_-]+)/i)?.[1];
+      if (!uuid) return undefined;
+      return `remove-neuron:${uuid}`;
+    }
+    case "change-squash": {
+      const uuid = change.squashCandidate?.neuronUUID;
+      if (!uuid) return undefined;
+      return `change-squash:${uuid}`;
+    }
+    case "split-synapse-insert-neuron": {
+      const spec = change.splitSynapseInsertNeuronCandidate;
+      if (!spec) return undefined;
+      return `split-synapse-insert-neuron:${spec.fromNeuronUuid}->${spec.toNeuronUuid}`;
+    }
+    default:
+      return undefined;
+  }
+}
+
 /**
  * Safely validates a creature and handles validation errors.
  *

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -19,6 +19,7 @@ import {
   type BuildDiscoveryCandidatesOptions,
   type DiscoveredNeuronDetails,
   type DiscoveryChangeType,
+  pruneSuccessfulCandidatesForCombos,
   shortID,
 } from "./DiscoveryCandidates.ts";
 import { isCandidateCachedSync, recordFailureSync } from "./FailureCache.ts";
@@ -351,10 +352,22 @@ export class DiscoveryRunner {
       if (successfulSingles.length >= 2) {
         const phase2Start = performance.now();
 
-        // Extract successful candidates for combination
-        const successfulCandidates = successfulSingles
-          .map((result) => result.candidate)
-          .filter((c): c is DiscoveryCandidate => c !== undefined);
+        // Extract successful candidates for combination and prune to a sensible
+        // best-per-slot set (eg. avoid combining multiple alternatives that target
+        // the same from→to add-neuron slot).
+        const scoredSuccessfulCandidates = successfulSingles
+          .map((result) => ({
+            candidate: result.candidate,
+            scoreDelta: result.score - original.score,
+          }))
+          .filter((entry): entry is {
+            candidate: DiscoveryCandidate;
+            scoreDelta: number;
+          } => entry.candidate !== undefined);
+
+        const successfulCandidates = pruneSuccessfulCandidatesForCombos(
+          scoredSuccessfulCandidates,
+        );
 
         // Build combined candidates from successful singles only
         const combinedCandidates = buildCombinedFromSuccessful(

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -571,6 +571,14 @@ export async function isCandidateCached(
   cacheDir: string,
   candidate: DiscoveryCandidate,
 ): Promise<boolean> {
+  // Combo candidates are derived from previously successful singles and are
+  // highly dependent on the *current* base creature. Caching them as failures
+  // can permanently suppress sensible re-tries as the creature evolves.
+  //
+  // We intentionally never treat combo-* candidates as failure-cacheable.
+  if (candidate.change.type.startsWith("combo-")) {
+    return false;
+  }
   try {
     const filePath = getCacheFilePath(cacheDir, candidate);
     const stat = await Deno.stat(filePath);
@@ -598,6 +606,10 @@ export function isCandidateCachedSync(
   cacheDir: string,
   candidate: DiscoveryCandidate,
 ): boolean {
+  // See async variant for rationale.
+  if (candidate.change.type.startsWith("combo-")) {
+    return false;
+  }
   try {
     const filePath = getCacheFilePath(cacheDir, candidate);
     const stat = Deno.statSync(filePath);
@@ -632,6 +644,10 @@ export async function recordFailure(
   metadata: FailureMetadata,
   baseCreature?: Creature,
 ): Promise<void> {
+  // Combo failures are not cached (see isCandidateCached for rationale).
+  if (candidate.change.type.startsWith("combo-")) {
+    return;
+  }
   try {
     const filePath = getCacheFilePath(cacheDir, candidate);
     const dir = dirname(filePath);
@@ -803,6 +819,10 @@ export function recordFailureSync(
   metadata: FailureMetadata,
   baseCreature?: Creature,
 ): void {
+  // Combo failures are not cached (see isCandidateCached for rationale).
+  if (candidate.change.type.startsWith("combo-")) {
+    return;
+  }
   try {
     const filePath = getCacheFilePath(cacheDir, candidate);
     const dir = dirname(filePath);

--- a/src/discovery/SuccessCache.ts
+++ b/src/discovery/SuccessCache.ts
@@ -122,6 +122,33 @@ export function recordSuccessSync(
 
   Deno.mkdirSync(dir, { recursive: true });
 
+  // De-duplicate by coarse key (exponent-bucketing) so parallel discovery across
+  // machines doesn't explode the replay workload. When we see a collision,
+  // keep the best-scoring entry.
+  try {
+    const existingRaw = Deno.readTextFileSync(filePath);
+    const existing = JSON.parse(existingRaw) as SuccessCacheEntry;
+    const existingDelta = typeof existing?.scoreDelta === "number"
+      ? existing.scoreDelta
+      : Number.NEGATIVE_INFINITY;
+    const existingScore = typeof existing?.candidateScore === "number"
+      ? existing.candidateScore
+      : Number.NEGATIVE_INFINITY;
+
+    const shouldReplace = metadata.scoreDelta > existingDelta ||
+      (metadata.scoreDelta === existingDelta &&
+        metadata.candidateScore > existingScore);
+    if (!shouldReplace) {
+      return;
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      // No existing entry: proceed with write.
+    } else {
+      // Corrupt/unreadable entry: overwrite best-effort.
+    }
+  }
+
   const discoveryVersion = getDiscoveryVersion();
   const cacheEntry: SuccessCacheEntry = {
     key: buildCacheKey(candidate),
@@ -143,7 +170,22 @@ export function recordSuccessSync(
     }
   }
 
-  Deno.writeTextFileSync(filePath, JSON.stringify(cacheEntry, null, 2));
+  // Best-effort atomic replace: write to a temp file then rename.
+  const tmpPath = join(
+    dir,
+    `${sanitiseForFilename(cacheEntry.key)}.tmp-${Date.now()}.json`,
+  );
+  Deno.writeTextFileSync(tmpPath, JSON.stringify(cacheEntry, null, 2));
+  try {
+    Deno.renameSync(tmpPath, filePath);
+  } catch {
+    Deno.writeTextFileSync(filePath, JSON.stringify(cacheEntry, null, 2));
+    try {
+      Deno.removeSync(tmpPath);
+    } catch {
+      // Ignore cleanup failure.
+    }
+  }
 }
 
 /**

--- a/test/discovery/DiscoveryCandidates.ts
+++ b/test/discovery/DiscoveryCandidates.ts
@@ -13,6 +13,7 @@ import { DiscoverStructure } from "../../src/architecture/ErrorGuidedStructuralE
 import {
   buildDiscoveryCandidates,
   type DiscoveryCandidate,
+  pruneSuccessfulCandidatesForCombos,
 } from "../../src/discovery/DiscoveryCandidates.ts";
 import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
 import { Mish } from "../../src/methods/activations/types/Mish.ts";
@@ -492,6 +493,117 @@ Deno.test("buildDiscoveryCandidates includes helpful neuron suggestions", () => 
     "Expected discovered neuron to include incoming and outgoing synapses.",
   );
 });
+
+Deno.test(
+  "pruneSuccessfulCandidatesForCombos keeps best add-neurons per from→to slot",
+  () => {
+    const base = makeBaselineCreature();
+    const discovery: DiscoverResult = {
+      ID: "PRUNE-ADD-NEURONS",
+      addHelpfulSynapses: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      removeHarmfulSynapse: undefined,
+      candidateSquashes: undefined,
+      addHelpfulNeurons: [
+        // Same from→to slot, two variants.
+        {
+          fromNeuronUUID: "input-0",
+          toNeuronUUID: "hidden-1",
+          incomingWeight: 0.42,
+          outgoingWeight: -0.27,
+          squash: TANH.NAME,
+          bias: 0.11,
+          targetNeuronImpact: 1.0,
+          expectedCreatureErrorReduction: 0,
+          expectedCreatureScoreGain: 0.25,
+          improvedCount: 8,
+          totalCount: 10,
+        },
+        {
+          fromNeuronUUID: "input-0",
+          toNeuronUUID: "hidden-1",
+          incomingWeight: 4.2,
+          outgoingWeight: -2.7,
+          squash: Mish.NAME,
+          bias: 1.1,
+          targetNeuronImpact: 1.0,
+          expectedCreatureErrorReduction: 0,
+          expectedCreatureScoreGain: 0.24,
+          improvedCount: 8,
+          totalCount: 10,
+        },
+        // Different slot.
+        {
+          fromNeuronUUID: "input-1",
+          toNeuronUUID: "hidden-2",
+          incomingWeight: 0.33,
+          outgoingWeight: -0.22,
+          squash: TANH.NAME,
+          bias: 0.07,
+          targetNeuronImpact: 1.0,
+          expectedCreatureErrorReduction: 0,
+          expectedCreatureScoreGain: 0.18,
+          improvedCount: 6,
+          totalCount: 8,
+        },
+      ],
+    };
+
+    const candidates = buildDiscoveryCandidates(base, discovery);
+    // buildDiscoveryCandidates may also emit a combined add-neurons candidate; for this
+    // test we only care about the dedicated single-step add-neuron candidates (which
+    // include neuronDetails).
+    const addNeuronCandidates = candidates.filter((c) =>
+      c.change.type === "add-neurons" && c.change.neuronDetails !== undefined
+    );
+    assertEquals(
+      addNeuronCandidates.length,
+      3,
+      "Precondition: expected 3 add-neurons candidates",
+    );
+
+    const slotA = addNeuronCandidates.filter((c) =>
+      c.change.neuronDetails?.fromNeuronUUID === "input-0" &&
+      c.change.neuronDetails?.toNeuronUUID === "hidden-1"
+    );
+    assertEquals(
+      slotA.length,
+      2,
+      "Precondition: expected 2 candidates for same slot",
+    );
+
+    // Give the second slotA candidate the larger measured gain.
+    const pruned = pruneSuccessfulCandidatesForCombos([
+      { candidate: slotA[0], scoreDelta: 0.001 },
+      { candidate: slotA[1], scoreDelta: 0.002 },
+      {
+        candidate: addNeuronCandidates.find((c) =>
+          c.change.neuronDetails?.fromNeuronUUID === "input-1" &&
+          c.change.neuronDetails?.toNeuronUUID === "hidden-2"
+        )!,
+        scoreDelta: 0.0005,
+      },
+    ]);
+
+    assertEquals(
+      pruned.length,
+      2,
+      "Should keep best candidate per from→to slot",
+    );
+    const keptSlotA = pruned.find((c) =>
+      c.change.type === "add-neurons" &&
+      c.change.neuronDetails?.fromNeuronUUID === "input-0" &&
+      c.change.neuronDetails?.toNeuronUUID === "hidden-1"
+    );
+    assert(keptSlotA, "Expected the input-0→hidden-1 slot to be kept");
+    assertEquals(
+      keptSlotA.change.neuronDetails?.squash,
+      slotA[1].change.neuronDetails?.squash,
+      "Should keep the best-scoring variant for the slot",
+    );
+  },
+);
 
 Deno.test(
   "buildDiscoveryCandidates synthesises combined candidate across categories",

--- a/test/discovery/FailureCache.ts
+++ b/test/discovery/FailureCache.ts
@@ -5,7 +5,9 @@ import {
   extractTargetNeuronInfo,
   formatWeight,
   isCandidateCached,
+  isCandidateCachedSync,
   recordFailure,
+  recordFailureSync,
 } from "../../src/discovery/FailureCache.ts";
 import { shortID } from "../../src/discovery/DiscoveryCandidates.ts";
 import type { DiscoveryCandidate } from "../../src/discovery/DiscoveryCandidates.ts";
@@ -437,6 +439,54 @@ Deno.test("recordFailure and isCandidateCached work together", async () => {
       cachedAfter,
       true,
       "Candidate should be cached after recording failure",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+    closeRustLibrary();
+  }
+});
+
+Deno.test("combo-* failures are not cached (combos are always re-scored)", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const creature = makeSimpleCreature();
+    const candidate = makeCandidate(
+      "combo-successful",
+      "🏗️ Combined successful changes",
+      creature,
+    );
+
+    // Recording a failure for a combo candidate should be a no-op.
+    await recordFailure(tempDir, candidate, {
+      originalScore: 0.5,
+      candidateScore: 0.49,
+      scoreDelta: -0.01,
+      error: 0.6,
+      originalError: 0.59,
+    });
+
+    const cachedAsync = await isCandidateCached(tempDir, candidate);
+    assertEquals(
+      cachedAsync,
+      false,
+      "Combo candidates should not be treated as cached failures (async)",
+    );
+
+    // Same behaviour for the sync API.
+    recordFailureSync(tempDir, candidate, {
+      originalScore: 0.5,
+      candidateScore: 0.49,
+      scoreDelta: -0.01,
+      error: 0.6,
+      originalError: 0.59,
+    });
+
+    const cachedSync = isCandidateCachedSync(tempDir, candidate);
+    assertEquals(
+      cachedSync,
+      false,
+      "Combo candidates should not be treated as cached failures (sync)",
     );
   } finally {
     await Deno.remove(tempDir, { recursive: true });

--- a/test/discovery/SuccessCache.ts
+++ b/test/discovery/SuccessCache.ts
@@ -6,6 +6,7 @@ import type { DiscoverResult } from "../../src/architecture/ErrorGuidedStructura
 import type {
   CandidateSynapse,
 } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { CandidateNeuron } from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
 import { buildDiscoveryCandidates } from "../../src/discovery/DiscoveryCandidates.ts";
 import { buildCacheKey } from "../../src/discovery/FailureCache.ts";
@@ -45,6 +46,41 @@ function makeAddSynapseCandidate(): CandidateSynapse {
     totalCount: 10,
     comment: "success-cache-test",
   };
+}
+
+function makeAddNeuronCandidatesWithKeyCollision(): CandidateNeuron[] {
+  // Two candidates that intentionally collide under buildCacheKey() because it
+  // buckets weights/biases by exponent only (e.g. 0.11 and 0.19 are both e-1).
+  return [
+    {
+      fromNeuronUUID: "input-0",
+      toNeuronUUID: "output-0",
+      incomingWeight: 0.11,
+      outgoingWeight: 0.12,
+      squash: "TANH",
+      bias: 0.13,
+      targetNeuronImpact: 1,
+      expectedCreatureErrorReduction: 0.01,
+      expectedCreatureScoreGain: 0.01,
+      improvedCount: 10,
+      totalCount: 10,
+      comment: "success-cache-collision-a",
+    },
+    {
+      fromNeuronUUID: "input-0",
+      toNeuronUUID: "output-0",
+      incomingWeight: 0.19,
+      outgoingWeight: 0.18,
+      squash: "TANH",
+      bias: 0.17,
+      targetNeuronImpact: 1,
+      expectedCreatureErrorReduction: 0.01,
+      expectedCreatureScoreGain: 0.01,
+      improvedCount: 10,
+      totalCount: 10,
+      comment: "success-cache-collision-b",
+    },
+  ];
 }
 
 Deno.test("SuccessCache records, lists, and deletes entries (sync)", async () => {
@@ -106,6 +142,90 @@ Deno.test("SuccessCache records, lists, and deletes entries (sync)", async () =>
     deleteSuccessSync(cacheDir, addSynapse);
     const listedAfterDelete = listSuccessEntriesSync(cacheDir);
     assertEquals(listedAfterDelete.length, 0);
+  } finally {
+    closeRustLibrary();
+    try {
+      await Deno.remove(cacheDir, { recursive: true });
+    } catch {
+      // Ignore cleanup failure in tests.
+    }
+  }
+});
+
+Deno.test("SuccessCache does not overwrite on key collisions", async () => {
+  const baseCreature = makeBaseCreature();
+  const discovery: DiscoverResult = {
+    ID: "discovery-success-cache-collision-test",
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: makeAddNeuronCandidatesWithKeyCollision(),
+    splitSynapseInsertNeuronCandidates: undefined,
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
+    candidateSquashes: undefined,
+  };
+
+  const candidates = buildDiscoveryCandidates(baseCreature, discovery, {
+    skipCombinedCandidates: true,
+  });
+  // buildDiscoveryCandidates may still emit combined add-neurons candidates; for this
+  // test we only care about dedicated single-step add-neuron candidates.
+  const addNeurons = candidates.filter((c) =>
+    c.change.type === "add-neurons" && c.change.neuronDetails !== undefined
+  );
+  assertEquals(addNeurons.length, 2);
+
+  const keyA = buildCacheKey(addNeurons[0]);
+  const keyB = buildCacheKey(addNeurons[1]);
+  assertEquals(
+    keyA,
+    keyB,
+    "Precondition: candidates should collide under buildCacheKey()",
+  );
+
+  const cacheDir = await Deno.makeTempDir({
+    prefix: "neat-ai-success-cache-collision-",
+  });
+
+  try {
+    recordSuccessSync(
+      cacheDir,
+      addNeurons[0],
+      {
+        originalScore: 1,
+        candidateScore: 1.01,
+        scoreDelta: 0.01,
+        originalError: 1,
+        error: 0.99,
+      },
+      baseCreature,
+    );
+    recordSuccessSync(
+      cacheDir,
+      addNeurons[1],
+      {
+        originalScore: 1,
+        candidateScore: 1.02,
+        scoreDelta: 0.02,
+        originalError: 1,
+        error: 0.98,
+      },
+      baseCreature,
+    );
+
+    const listed = listSuccessEntriesSync(cacheDir).filter((e) =>
+      e.changeType === "add-neurons"
+    );
+    assertEquals(
+      listed.length,
+      1,
+      "Expected colliding candidates to be de-duplicated into a single cached entry",
+    );
+    assertEquals(
+      listed[0].scoreDelta,
+      0.02,
+      "Expected the best-scoring entry to be retained for the key",
+    );
   } finally {
     closeRustLibrary();
     try {


### PR DESCRIPTION
…g logic

- Bumped version in deno.json to 0.282.0.
- Introduced a new function, pruneSuccessfulCandidatesForCombos, to optimize candidate selection by retaining the best candidates per structural slot, preventing redundant combinations.
- Enhanced caching logic in FailureCache to ensure combo candidates are not treated as failures, allowing for re-evaluation as the creature evolves.
- Updated SuccessCache to handle key collisions by retaining the best-scoring entry, improving cache management during candidate evaluation.

These changes enhance the efficiency and maintainability of the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes two-phase discovery and cache behavior.
> 
> - **Prunes combo inputs**: Adds `pruneSuccessfulCandidatesForCombos()` (with `getComboSlotKey`) to keep the best `scoreDelta` per slot (e.g., `add-neurons` from→to), integrated into `DiscoveryRunner` Phase 2
> - **Failure cache**: `isCandidateCached*()` and `recordFailure*()` ignore `combo-*` candidates to avoid suppressing re-tries
> - **Success cache**: `recordSuccessSync()` de-dupes on coarse `buildCacheKey()` collisions (keeps best score), and uses temp-file rename for best-effort atomic writes
> - **Tests**: New tests cover pruning behavior, non-caching of combo failures (sync/async), and success-cache collision retention
> - **Meta**: Bumps `deno.json` version to `0.282.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9316c62c3338faceaac8a83feb5e76dac5465709. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->