### PR TITLE
Update version to 0.283.0 in deno.json and enhance error handling in …

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.282.1",
+  "version": "0.283.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -864,8 +864,27 @@ export class Neuron implements TagsInterface, NeuronInternal {
 
       let error = 0;
       if (Math.abs(targetActivation - currentActivation) > 1e-8) {
-        const targetValue = toValue(this, targetActivation, currentValue);
-        error = targetValue - currentValue!;
+        // Prefer activation-specific error semantics when available.
+        //
+        // Rationale: some discrete squashes (eg. STEP/BIPOLAR) intentionally clamp
+        // error in value-space (via `ErrorHelper`) to prevent extreme raw values
+        // from poisoning discovery statistics.
+        //
+        // Fallback: if the squash does not implement `calculateError()`, compute a
+        // generic value-space delta using `toValue()`.
+        const calculateError = (squashMethod as ActivationInterface)
+          .calculateError;
+        if (calculateError !== undefined) {
+          error = calculateError.call(
+            squashMethod,
+            currentActivation,
+            targetActivation,
+            currentValue!,
+          );
+        } else {
+          const targetValue = toValue(this, targetActivation, currentValue);
+          error = targetValue - currentValue!;
+        }
       }
 
       // CRITICAL FIX: Track if this is the first visit to this neuron

--- a/test/discovery/STEPRecordingIntegration.ts
+++ b/test/discovery/STEPRecordingIntegration.ts
@@ -8,6 +8,7 @@
 import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
 import { Creature } from "../../src/Creature.ts";
+import { BIPOLAR } from "../../src/methods/activations/types/BIPOLAR.ts";
 import { STEP } from "../../src/methods/activations/types/STEP.ts";
 
 // =============================================================================
@@ -341,14 +342,10 @@ Deno.test("STEP recording: at threshold (x=0)", () => {
 });
 
 // =============================================================================
-// Extreme Value Tests (NOT Clamped in Recording)
+// Extreme Value Tests (Clamped via calculateError)
 // =============================================================================
 
-Deno.test("STEP recording: extreme values preserve actual magnitude", () => {
-  // NOTE: Unlike calculateError() which clamps to ±100, the recording flow
-  // preserves actual error magnitudes for discovery analysis. This is intentional
-  // as discovery needs accurate error information to select focus neurons.
-
+Deno.test("STEP recording: extreme values are clamped (prevents exploding discovery errors)", () => {
   const creatureJSON: CreatureExport = {
     input: 1,
     output: 1,
@@ -367,9 +364,11 @@ Deno.test("STEP recording: extreme values preserve actual magnitude", () => {
 
   const creature = Creature.fromJSON(creatureJSON);
 
+  // Regression: extreme values should not explode recorded error statistics.
+  //
   // Input -1000 -> STEP outputs 0
-  // Request output of 1 -> error = 1 - (-1000) = 1001
-  // Recording does NOT clamp - preserves actual magnitude
+  // Request output of 1 -> raw value-space error = 1 - (-1000) = 1001
+  // With activation.calculateError() semantics, this must be clamped to +100.
   const input = new Float32Array([-1000]);
   creature.activate(input);
 
@@ -382,14 +381,60 @@ Deno.test("STEP recording: extreme values preserve actual magnitude", () => {
   assert(record.errors.length > 0, "should have at least one error");
   assertAlmostEquals(
     record.errors[0],
-    1001,
+    100,
     1e-6,
-    "recording preserves actual error magnitude (1001 = 1 - (-1000))",
+    "recording clamps extreme STEP value errors to +100",
   );
 
   // Verify error is finite and has correct sign
   assert(Number.isFinite(record.errors[0]), "error should be finite");
   assert(record.errors[0] > 0, "error should be positive (pushing toward 1)");
+});
+
+// =============================================================================
+// BIPOLAR Clamp Regression
+// =============================================================================
+
+Deno.test("BIPOLAR recording: extreme values are clamped (prevents exploding discovery errors)", () => {
+  const creatureJSON: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      {
+        uuid: "output-0",
+        type: "output",
+        squash: BIPOLAR.NAME,
+        bias: 0,
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(creatureJSON);
+
+  // Input +1e10 -> BIPOLAR outputs +1
+  // Request output -1 -> raw value-space error ≈ -1 - 1e10
+  // With activation.calculateError() semantics, this must be clamped to -100.
+  const input = new Float32Array([1e10]);
+  creature.activate(input);
+
+  const expected = new Float32Array([-1]);
+  const discoverMap = creature.record(expected);
+
+  const record = discoverMap.get("output-0");
+  assert(record, "expected a discovery record for output-0");
+
+  assert(record.errors.length > 0, "should have at least one error");
+  assertAlmostEquals(
+    record.errors[0],
+    -100,
+    1e-6,
+    "recording clamps extreme BIPOLAR value errors to -100",
+  );
+  assert(Number.isFinite(record.errors[0]), "error should be finite");
+  assert(record.errors[0] < 0, "error should be negative (pushing toward -1)");
 });
 
 // =============================================================================


### PR DESCRIPTION
…Neuron class

- Bumped version in deno.json to 0.283.0.
- Improved error calculation logic in the Neuron class to utilize activation-specific semantics when available, preventing extreme raw values from affecting discovery statistics.
- Added tests to ensure clamping behavior for extreme values in STEP and BIPOLAR activations, enhancing robustness in error handling during discovery.

These changes improve the accuracy and reliability of the NEAT framework's activation error management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves discovery error robustness by leveraging activation-specific error semantics and validating clamp behavior.
> 
> - Update `Neuron.record()` to prefer `calculateError()` from the activation when available; fallback to value-space delta via `toValue()`
> - Ensures discrete activations (e.g., `STEP`, `BIPOLAR`) clamp extreme value errors during discovery to avoid skewed statistics
> - Add integration tests covering STEP magnitude cases and clamp regressions for both `STEP` and `BIPOLAR`
> - Bump package version in `deno.json` to `0.283.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20d17ac9c64c0860ebf6818735875c5062fbba26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->