### PR TITLE
Update version to 0.284.0 in deno.json and enhance compactCreature fu…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.283.0",
+  "version": "0.284.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -5,14 +5,19 @@ import type { Approach } from "../NEAT/LogApproach.ts";
 import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import type { NeuronExport } from "../architecture/NeuronInterfaces.ts";
 import type { SynapseExport } from "../architecture/SynapseInterfaces.ts";
+import { valuePenalty } from "../architecture/Score.ts";
 import { IDENTITY } from "../methods/activations/types/IDENTITY.ts";
 import { LOGISTIC } from "../methods/activations/types/LOGISTIC.ts";
 import { COMPLEMENT } from "../methods/activations/types/COMPLEMENT.ts";
+import { ABSOLUTE } from "../methods/activations/types/ABSOLUTE.ts";
+import { ReLU } from "../methods/activations/types/ReLU.ts";
+import { LeakyReLU } from "../methods/activations/types/LeakyReLU.ts";
 import { IF } from "../methods/activations/aggregate/IF.ts";
 import { MAXIMUM } from "../methods/activations/aggregate/MAXIMUM.ts";
 import { MINIMUM } from "../methods/activations/aggregate/MINIMUM.ts";
 import { HYPOT } from "../deprecated/HYPOT.ts";
 import { HYPOTv2 } from "../deprecated/HYPOTv2.ts";
+import { MEAN } from "../deprecated/MEAN.ts";
 import {
   cleanupOrphanedNeurons,
   pruneDeadSubgraphs,
@@ -292,6 +297,23 @@ export function compactCreature(
     }
   }
 
+  // 30-Dec-2025: Simplify large weights for homogeneous squashes (issue #642).
+  //
+  // For ABSOLUTE and IDENTITY we can rescale a neuron's inbound weights/bias by 1/c and
+  // its outbound weights by c, without changing behaviour:
+  //
+  //   z  = Σ(wi*xi) + b
+  //   z' = z / c
+  //   f(z') = f(z) / c         (for ABSOLUTE and IDENTITY, with c > 0)
+  //   (v*c) * (f(z)/c) = v*f(z)
+  //
+  // This can turn a "huge inbound / tiny outbound" pair into two moderate values,
+  // reducing the score penalty (which is based on max/avg abs weights and biases).
+  const simplifiedLargeWeights = simplifyLargeWeights(compactCreature);
+  if (simplifiedLargeWeights) {
+    didCompact = true;
+  }
+
   // 29-Dec-2025: Behaviour-preserving pruning of zero-weight synapses.
   // See https://github.com/stSoftwareAU/NEAT-AI/issues/977
   const zeroResult = pruneZeroWeightSynapses(compactCreature);
@@ -346,6 +368,140 @@ export function compactCreature(
   }
 
   return undefined;
+}
+
+function simplifyLargeWeights(exported: CreatureExport): boolean {
+  // Supported squashes are those that are scale-homogeneous in our implementation:
+  //
+  // For any k > 0: f(kx) = k f(x)
+  //
+  // This includes both "linear" squashes (ActivationInterface) and some
+  // aggregation squashes (NeuronActivationInterface) that remain homogeneous.
+  const candidateSquashes = new Set<string>([
+    ABSOLUTE.NAME,
+    IDENTITY.NAME,
+    ReLU.NAME,
+    LeakyReLU.NAME,
+    MAXIMUM.NAME,
+    MINIMUM.NAME,
+    IF.NAME,
+    HYPOT.NAME,
+    HYPOTv2.NAME,
+    MEAN.NAME,
+  ]);
+
+  // Only attempt rescaling when there is a meaningful imbalance (3+ orders of magnitude).
+  // The accept/reject gate below uses the same penalty logic as scoring, so this heuristic
+  // is purely a performance guard.
+  const IMBALANCE_RATIO = 1_000;
+
+  const inward = new Map<string, SynapseExport[]>();
+  const outward = new Map<string, SynapseExport[]>();
+  for (const s of exported.synapses) {
+    outward.set(s.fromUUID, (outward.get(s.fromUUID) ?? []).concat(s));
+    inward.set(s.toUUID, (inward.get(s.toUUID) ?? []).concat(s));
+  }
+
+  let changed = false;
+  let bestPenalty = calculateWeightBiasPenalty(exported);
+
+  for (const neuron of exported.neurons) {
+    if (neuron.type !== "hidden") continue;
+    if (!neuron.squash || !candidateSquashes.has(neuron.squash)) continue;
+
+    const inConns = inward.get(neuron.uuid) ?? [];
+    const outConns = outward.get(neuron.uuid) ?? [];
+    if (inConns.length === 0) continue;
+    if (outConns.length === 0) continue;
+
+    let maxIn = Math.abs(neuron.bias);
+    for (const s of inConns) maxIn = Math.max(maxIn, Math.abs(s.weight));
+
+    let maxOut = 0;
+    for (const s of outConns) maxOut = Math.max(maxOut, Math.abs(s.weight));
+
+    if (maxIn === 0 || maxOut === 0) continue;
+
+    const ratio = maxIn / maxOut;
+    if (ratio < 1 / IMBALANCE_RATIO || ratio > IMBALANCE_RATIO) {
+      // Choose c to equalise maxIn/c and maxOut*c, minimising their maximum.
+      const c = Math.sqrt(maxIn / maxOut);
+      if (!Number.isFinite(c) || c === 0 || c === 1) continue;
+
+      // Snapshot for revert.
+      const oldBias = neuron.bias;
+      const oldInWeights = inConns.map((s) => s.weight);
+      const oldOutWeights = outConns.map((s) => s.weight);
+
+      neuron.bias = neuron.bias / c;
+      for (const s of inConns) s.weight = s.weight / c;
+      for (const s of outConns) s.weight = s.weight * c;
+
+      // Reject if we introduced anything non-finite.
+      const allFinite = Number.isFinite(neuron.bias) &&
+        inConns.every((s) => Number.isFinite(s.weight)) &&
+        outConns.every((s) => Number.isFinite(s.weight));
+
+      if (!allFinite) {
+        neuron.bias = oldBias;
+        inConns.forEach((s, i) => s.weight = oldInWeights[i]);
+        outConns.forEach((s, i) => s.weight = oldOutWeights[i]);
+        continue;
+      }
+
+      const nextPenalty = calculateWeightBiasPenalty(exported);
+      if (nextPenalty + 1e-15 < bestPenalty) {
+        bestPenalty = nextPenalty;
+        changed = true;
+      } else {
+        // No improvement; revert.
+        neuron.bias = oldBias;
+        inConns.forEach((s, i) => s.weight = oldInWeights[i]);
+        outConns.forEach((s, i) => s.weight = oldOutWeights[i]);
+      }
+    }
+  }
+
+  if (changed) {
+    // Memetic values were tuned for the previous scale; treat them as stale.
+    delete exported.memetic;
+  }
+
+  return changed;
+}
+
+function calculateWeightBiasPenalty(exported: CreatureExport): number {
+  let max = 0;
+  let total = 0;
+  let count = 0;
+
+  for (const synapse of exported.synapses) {
+    const w = Math.abs(synapse.weight);
+    if (!Number.isFinite(w)) continue;
+    max = Math.max(max, w);
+    total += w;
+    count++;
+  }
+
+  // CreatureExport.neurons excludes inputs; bias is defined for all entries here.
+  for (const neuron of exported.neurons) {
+    const b = Math.abs(neuron.bias);
+    if (!Number.isFinite(b)) continue;
+    max = Math.max(max, b);
+    total += b;
+    count++;
+  }
+
+  // No weights/biases should never happen for a valid creature, but keep it safe.
+  if (count === 0) return 0;
+
+  // Mirror Score.calculateMaxOutOfBounds() safety: clamp to avoid tripping
+  // `valuePenalty()` asserts on absurd magnitudes.
+  if (max > Number.MAX_SAFE_INTEGER) max = Number.MAX_SAFE_INTEGER;
+  if (total > Number.MAX_SAFE_INTEGER) total = Number.MAX_SAFE_INTEGER;
+
+  const avg = total / count;
+  return (valuePenalty(max) + valuePenalty(avg)) / 2;
 }
 
 function isAggregationSquashName(name?: string): boolean {

--- a/test/Compact/CompactCreatureSimplifyLargeWeights.ts
+++ b/test/Compact/CompactCreatureSimplifyLargeWeights.ts
@@ -1,0 +1,72 @@
+import { assert, assertAlmostEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { compactCreature } from "../../src/compact/CompactCreature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { ABSOLUTE } from "../../src/methods/activations/types/ABSOLUTE.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+function maxAbsWeightAndBias(creature: Creature): number {
+  let max = 0;
+  for (const s of creature.synapses) max = Math.max(max, Math.abs(s.weight));
+  for (const n of creature.neurons) {
+    if (n.type !== "input") max = Math.max(max, Math.abs(n.bias));
+  }
+  return max;
+}
+
+Deno.test("compactCreature: simplifies large weights around ABSOLUTE without changing behaviour (issue #642)", () => {
+  // Arrange:
+  // input-0 --(1e6)--> hidden-0(ABSOLUTE, bias 1e6) --(1e-6)--> output-0(IDENTITY)
+  //
+  // output = 1e-6 * abs(1e6*x + 1e6) = abs(x + 1)
+  const json: CreatureExport = {
+    neurons: [
+      {
+        uuid: "hidden-0",
+        type: "hidden",
+        squash: ABSOLUTE.NAME,
+        bias: 1e6,
+      },
+      {
+        uuid: "output-0",
+        type: "output",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1e6 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 1,
+    output: 1,
+  };
+
+  const creature = Creature.fromJSON(json);
+  const beforeMax = maxAbsWeightAndBias(creature);
+  assert(
+    beforeMax >= 1e6,
+    "Sanity check: expected a very large starting value",
+  );
+
+  // Act
+  const compacted = compactCreature(creature, true);
+
+  // Assert
+  assert(compacted, "Expected compaction to occur (weight normalisation)");
+  compacted.validate();
+
+  const afterMax = maxAbsWeightAndBias(compacted);
+  assert(
+    afterMax < beforeMax,
+    `Expected max abs weight/bias to reduce (before=${beforeMax}, after=${afterMax})`,
+  );
+
+  // Behaviour should be preserved.
+  const inputs = [-3, -1, -0.25, 0, 0.25, 1, 3];
+  for (const x of inputs) {
+    const a = creature.activate(new Float32Array([x]), false)[0];
+    const b = compacted.activate(new Float32Array([x]), false)[0];
+    assertAlmostEquals(a, b, 1e-6, `x=${x} expected=${a} actual=${b}`);
+  }
+});

--- a/test/Compact/CompactCreatureSimplifyLargeWeightsSupportedSquashes.ts
+++ b/test/Compact/CompactCreatureSimplifyLargeWeightsSupportedSquashes.ts
@@ -1,0 +1,248 @@
+import { assert, assertAlmostEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { compactCreature } from "../../src/compact/CompactCreature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { IF } from "../../src/methods/activations/aggregate/IF.ts";
+import { MAXIMUM } from "../../src/methods/activations/aggregate/MAXIMUM.ts";
+import { MINIMUM } from "../../src/methods/activations/aggregate/MINIMUM.ts";
+import { ABSOLUTE } from "../../src/methods/activations/types/ABSOLUTE.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { LeakyReLU } from "../../src/methods/activations/types/LeakyReLU.ts";
+import { ReLU } from "../../src/methods/activations/types/ReLU.ts";
+import { HYPOT } from "../../src/deprecated/HYPOT.ts";
+import { HYPOTv2 } from "../../src/deprecated/HYPOTv2.ts";
+import { MEAN } from "../../src/deprecated/MEAN.ts";
+
+function maxAbsWeightAndBias(creature: Creature): number {
+  let max = 0;
+  for (const s of creature.synapses) max = Math.max(max, Math.abs(s.weight));
+  for (const n of creature.neurons) {
+    if (n.type !== "input") max = Math.max(max, Math.abs(n.bias));
+  }
+  return max;
+}
+
+function assertCompactionSimplifies(
+  name: string,
+  json: CreatureExport,
+  inputs: number[][],
+) {
+  Deno.test(
+    `compactCreature: simplifies large weights for ${name} without changing behaviour (issue #642)`,
+    () => {
+      const creature = Creature.fromJSON(json);
+      const beforeMax = maxAbsWeightAndBias(creature);
+      assert(
+        beforeMax >= 1e6,
+        "Sanity check: expected a very large starting value",
+      );
+
+      const compacted = compactCreature(creature, true);
+
+      // TDD expectation: once we support this squash, compaction should rescale.
+      assert(compacted, "Expected compaction to occur (weight normalisation)");
+      compacted.validate();
+
+      const afterMax = maxAbsWeightAndBias(compacted);
+      assert(
+        afterMax < beforeMax,
+        `Expected max abs weight/bias to reduce (before=${beforeMax}, after=${afterMax})`,
+      );
+
+      for (const input of inputs) {
+        const a = creature.activate(new Float32Array(input), false);
+        const b = compacted.activate(new Float32Array(input), false);
+        assert(a.length === b.length);
+        for (let i = 0; i < a.length; i++) {
+          assertAlmostEquals(
+            a[i],
+            b[i],
+            1e-6,
+            `${name} input=${JSON.stringify(input)} idx=${i} expected=${
+              a[i]
+            } actual=${b[i]}`,
+          );
+        }
+      }
+    },
+  );
+}
+
+// Linear squashes (weighted sum + bias, then squash)
+assertCompactionSimplifies(
+  ReLU.NAME,
+  {
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: ReLU.NAME, bias: 1e6 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1e6 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 1,
+    output: 1,
+  },
+  [[-3], [-1], [0], [1], [3]],
+);
+
+assertCompactionSimplifies(
+  LeakyReLU.NAME,
+  {
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: LeakyReLU.NAME, bias: -1e6 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1e6 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 1,
+    output: 1,
+  },
+  [[-3], [-1], [-0.25], [0.25], [1], [3]],
+);
+
+// Aggregate squashes (NeuronActivationInterface) - still scale-homogeneous in our implementations.
+assertCompactionSimplifies(
+  MAXIMUM.NAME,
+  {
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: MAXIMUM.NAME, bias: 1e6 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1e6 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -2e6 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 2,
+    output: 1,
+  },
+  [[-2, -2], [-2, 2], [2, -2], [2, 2]],
+);
+
+assertCompactionSimplifies(
+  MINIMUM.NAME,
+  {
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: MINIMUM.NAME, bias: 1e6 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1e6 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -2e6 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 2,
+    output: 1,
+  },
+  [[-2, -2], [-2, 2], [2, -2], [2, 2]],
+);
+
+assertCompactionSimplifies(
+  IF.NAME,
+  {
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IF.NAME, bias: 1e6 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-0",
+        weight: 1e6,
+        type: "condition",
+      },
+      {
+        fromUUID: "input-1",
+        toUUID: "hidden-0",
+        weight: 1e6,
+        type: "positive",
+      },
+      // Use a distinct source UUID for negative to avoid duplicate from/to pairs.
+      {
+        fromUUID: "input-2",
+        toUUID: "hidden-0",
+        weight: -1e6,
+        type: "negative",
+      },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 3,
+    output: 1,
+  },
+  [[-2, -3, -4], [-2, 3, 4], [2, -3, -4], [2, 3, 4]],
+);
+
+assertCompactionSimplifies(
+  HYPOT.NAME,
+  {
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: HYPOT.NAME, bias: 1e6 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1e6 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -2e6 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 2,
+    output: 1,
+  },
+  [[-2, -2], [-2, 2], [2, -2], [2, 2]],
+);
+
+assertCompactionSimplifies(
+  HYPOTv2.NAME,
+  {
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: HYPOTv2.NAME, bias: 1e6 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1e6 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -2e6 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 2,
+    output: 1,
+  },
+  [[-2, -2], [-2, 2], [2, -2], [2, 2]],
+);
+
+assertCompactionSimplifies(
+  MEAN.NAME,
+  {
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: MEAN.NAME, bias: 1e6 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1e6 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -2e6 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 2,
+    output: 1,
+  },
+  [[-2, -2], [-2, 2], [2, -2], [2, 2]],
+);
+
+// Sanity: keep the existing supported ones covered here too (optional redundancy).
+assertCompactionSimplifies(
+  ABSOLUTE.NAME,
+  {
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: ABSOLUTE.NAME, bias: 1e6 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1e6 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1e-6 },
+    ],
+    input: 1,
+    output: 1,
+  },
+  [[-3], [-1], [0], [1], [3]],
+);


### PR DESCRIPTION
…nctionality

- Bumped version in deno.json to 0.284.0.
- Introduced a new function, simplifyLargeWeights, to optimize weight scaling for certain neuron types, improving performance and reducing score penalties.
- Enhanced compactCreature logic to handle large weight simplifications, ensuring better management of neuron connections and maintaining behavior.

These changes improve the efficiency and maintainability of the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces behavior-preserving weight normalization to reduce extreme values without changing outputs.
> 
> - Adds `simplifyLargeWeights` in `CompactCreature.ts` that rescales a hidden neuron's inbound weights/bias by `1/c` and outbound weights by `c` when a large imbalance is detected; applies to homogeneous squashes (`ABSOLUTE`, `IDENTITY`, `ReLU`, `LeakyReLU`, `MAXIMUM`, `MINIMUM`, `IF`, `HYPOT`, `HYPOTv2`, `MEAN`).
> - Uses `calculateWeightBiasPenalty` (via `valuePenalty`) as an acceptance test; reverts if no improvement and clears `memetic` on change.
> - Integrates the normalization step into `compactCreature` before zero-weight pruning; preserves validation and forward-only semantics.
> - Adds tests `CompactCreatureSimplifyLargeWeights*.ts` verifying reduced max abs weight/bias and unchanged activations across supported squashes.
> - Bumps `deno.json` version to `0.284.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a68bd544199c70560029a7872240c124ef4fd16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->