### PR TITLE
Update version to 0.285.0 in deno.json and enhance discovery performa…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.284.0",
+  "version": "0.285.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -105,96 +105,186 @@ class DiscoveryPerformanceStats {
   logSummary(discoveryID: string, config: NeatConfig): void {
     if (!shouldLogDiscovery(config)) return;
 
-    const formatTime = (ms: number) => format(ms, { ignoreZero: true });
-    const formatCount = (count: number) =>
-      yellow(count.toLocaleString("en-AU"));
-
     console.log(
-      `\n${blue("=".repeat(60))}\n` +
-        `${blue("Discovery Performance Summary")} ${blue(discoveryID)}\n` +
-        `${blue("=".repeat(60))}`,
-    );
+      formatDiscoveryPerformanceSummary(
+        discoveryID,
+        {
+          // Record phase
+          recordsProcessed: this.recordsProcessed,
+          filesProcessed: this.filesProcessed,
+          recordPhaseTime: this.recordPhaseTime,
+          initializationTime: this.initializationTime,
+          fileProcessingTime: this.fileProcessingTime,
+          promiseWaitTime: this.promiseWaitTime,
 
-    // Record phase summary
-    console.log(
-      `\n📊 ${yellow("Record Phase")}:\n` +
-        `  Records processed: ${formatCount(this.recordsProcessed)}\n` +
-        `  Files processed: ${formatCount(this.filesProcessed)}\n` +
-        `  Initialization: ${formatTime(this.initializationTime)}\n` +
-        `  File processing: ${formatTime(this.fileProcessingTime)}\n` +
-        `  Promise wait: ${formatTime(this.promiseWaitTime)}\n` +
-        `  Total record phase: ${formatTime(this.recordPhaseTime)}\n` +
-        `  Records/sec: ${
-          this.recordPhaseTime > 0
-            ? formatCount(
-              Math.round(
-                (this.recordsProcessed / this.recordPhaseTime) * 1000,
-              ),
-            )
-            : "n/a"
-        }`,
-    );
+          // Analysis phase
+          neuronsAnalyzed: this.neuronsAnalyzed,
+          retryAttempts: this.retryAttempts,
+          analysisPhaseTime: this.analysisPhaseTime,
+          focusSelectionTime: this.focusSelectionTime,
+          rustCombinedAnalysisTime: this.rustCombinedAnalysisTime,
+          neuronAnalysisTime: this.neuronAnalysisTime,
+          synapseAnalysisTime: this.synapseAnalysisTime,
+          harmfulSynapseAnalysisTime: this.harmfulSynapseAnalysisTime,
+          harmfulNeuronAnalysisTime: this.harmfulNeuronAnalysisTime,
+          squashAnalysisTime: this.squashAnalysisTime,
 
-    // Analysis phase summary
-    console.log(
-      `\n🔍 ${yellow("Analysis Phase")}:\n` +
-        `  Neurons analyzed: ${formatCount(this.neuronsAnalyzed)}\n` +
-        `  Retry attempts: ${formatCount(this.retryAttempts)}\n` +
-        `  Focus selection: ${formatTime(this.focusSelectionTime)}\n` +
-        `  Rust combined analysis: ${
-          formatTime(this.rustCombinedAnalysisTime)
-        }\n` +
-        `  Neuron analysis: ${formatTime(this.neuronAnalysisTime)}\n` +
-        `  Synapse analysis: ${formatTime(this.synapseAnalysisTime)}\n` +
-        `  Harmful synapse analysis: ${
-          formatTime(this.harmfulSynapseAnalysisTime)
-        }\n` +
-        `  Harmful neuron analysis: ${
-          formatTime(this.harmfulNeuronAnalysisTime)
-        }\n` +
-        `  Squash analysis: ${formatTime(this.squashAnalysisTime)}\n` +
-        `  Total analysis phase: ${formatTime(this.analysisPhaseTime)}\n` +
-        `  Neurons/sec: ${
-          this.analysisPhaseTime > 0
-            ? formatCount(
-              Math.round(
-                (this.neuronsAnalyzed / this.analysisPhaseTime) * 1000,
-              ),
-            )
-            : "n/a"
-        }`,
-    );
+          // Candidate counts (counts match the arrays returned from recordDirectory()).
+          helpfulSynapseCount: this.helpfulSynapseCount,
+          helpfulNeuronCount: this.helpfulNeuronCount,
+          harmfulSynapseCount: this.harmfulSynapseCount,
+          harmfulNeuronCount: this.harmfulNeuronCount,
+          squashCount: this.squashCount,
+          removalCount: this.removalCount,
 
-    // Candidate summary (counts match the arrays returned from recordDirectory()).
-    const summaryCounts = {
-      helpfulSynapses: this.helpfulSynapseCount,
-      helpfulNeurons: this.helpfulNeuronCount,
-      harmfulSynapses: this.harmfulSynapseCount,
-      harmfulNeurons: this.harmfulNeuronCount,
-      squashChanges: this.squashCount,
-      removalCandidates: this.removalCount,
-    };
-
-    console.log(
-      `\n🎯 ${yellow("Candidates Found")}:\n` +
-        `  Helpful synapses: ${formatCount(summaryCounts.helpfulSynapses)}\n` +
-        `  Helpful neurons: ${formatCount(summaryCounts.helpfulNeurons)}\n` +
-        `  Harmful synapses: ${formatCount(summaryCounts.harmfulSynapses)}\n` +
-        `  Harmful neurons: ${formatCount(summaryCounts.harmfulNeurons)}\n` +
-        `  Squash changes: ${formatCount(summaryCounts.squashChanges)}\n` +
-        `  Removal candidates: ${formatCount(summaryCounts.removalCandidates)}`,
-    );
-
-    // Overall summary
-    // Note: Re-scoring time is not included here as it happens after recordDirectory returns
-    // It is logged separately in DiscoveryRunner after re-scoring completes
-    console.log(
-      `\n⏱️  ${yellow("Overall")}:\n` +
-        `  Cleanup: ${formatTime(this.cleanupTime)}\n` +
-        `  Total time: ${formatTime(this.totalTime)}\n` +
-        `${blue("=".repeat(60))}\n`,
+          // Other phases
+          cleanupTime: this.cleanupTime,
+          totalTime: this.totalTime,
+        },
+        { colour: true },
+      ),
     );
   }
+}
+
+export interface DiscoveryPerformanceSummarySnapshot {
+  // Record phase stats
+  recordsProcessed: number;
+  filesProcessed: number;
+  recordPhaseTime: number;
+  initializationTime: number;
+  fileProcessingTime: number;
+  promiseWaitTime: number;
+
+  // Analysis phase stats
+  neuronsAnalyzed: number;
+  retryAttempts: number;
+  analysisPhaseTime: number;
+  focusSelectionTime: number;
+  rustCombinedAnalysisTime: number;
+  neuronAnalysisTime: number;
+  synapseAnalysisTime: number;
+  harmfulSynapseAnalysisTime: number;
+  harmfulNeuronAnalysisTime: number;
+  squashAnalysisTime: number;
+
+  // Candidate counts (final arrays returned to the caller)
+  helpfulSynapseCount: number;
+  helpfulNeuronCount: number;
+  harmfulSynapseCount: number;
+  harmfulNeuronCount: number;
+  squashCount: number;
+  removalCount: number;
+
+  // Other phases
+  cleanupTime: number;
+  totalTime: number;
+}
+
+export function formatDiscoveryPerformanceSummary(
+  discoveryID: string,
+  stats: DiscoveryPerformanceSummarySnapshot,
+  options: { colour: boolean },
+): string {
+  const maybeBlue = (text: string) => options.colour ? blue(text) : text;
+  const maybeYellow = (text: string) => options.colour ? yellow(text) : text;
+
+  const formatCount = (count: number) =>
+    maybeYellow(count.toLocaleString("en-AU"));
+
+  const formatTotalTime = (ms: number): string =>
+    format(msOrZero(ms), { ignoreZero: false });
+
+  // Important: `format(ms, { ignoreZero: true })` returns an empty string for 0ms.
+  // We treat that as "not recorded" and omit the line entirely to avoid confusing blank output.
+  const formatNonZeroTimeLine = (
+    label: string,
+    ms: number,
+  ): string | undefined => {
+    const rendered = format(ms, { ignoreZero: true });
+    if (!rendered) return undefined;
+    return `  ${label}: ${rendered}`;
+  };
+
+  const recordLines: string[] = [
+    `  Records processed: ${formatCount(stats.recordsProcessed)}`,
+    `  Files processed: ${formatCount(stats.filesProcessed)}`,
+    formatNonZeroTimeLine("Initialization", stats.initializationTime),
+    formatNonZeroTimeLine("File processing", stats.fileProcessingTime),
+    formatNonZeroTimeLine("Promise wait", stats.promiseWaitTime),
+    `  Total record phase: ${formatTotalTime(stats.recordPhaseTime)}`,
+    `  Records/sec: ${
+      stats.recordPhaseTime > 0
+        ? formatCount(
+          Math.round((stats.recordsProcessed / stats.recordPhaseTime) * 1000),
+        )
+        : "n/a"
+    }`,
+  ].filter((line): line is string => Boolean(line));
+
+  const analysisLines: string[] = [
+    `  Neurons analyzed: ${formatCount(stats.neuronsAnalyzed)}`,
+    `  Retry attempts: ${formatCount(stats.retryAttempts)}`,
+    formatNonZeroTimeLine("Focus selection", stats.focusSelectionTime),
+    formatNonZeroTimeLine(
+      "Rust combined analysis",
+      stats.rustCombinedAnalysisTime,
+    ),
+    formatNonZeroTimeLine("Neuron analysis", stats.neuronAnalysisTime),
+    formatNonZeroTimeLine("Synapse analysis", stats.synapseAnalysisTime),
+    formatNonZeroTimeLine(
+      "Harmful synapse analysis",
+      stats.harmfulSynapseAnalysisTime,
+    ),
+    formatNonZeroTimeLine(
+      "Harmful neuron analysis",
+      stats.harmfulNeuronAnalysisTime,
+    ),
+    formatNonZeroTimeLine("Squash analysis", stats.squashAnalysisTime),
+    `  Total analysis phase: ${formatTotalTime(stats.analysisPhaseTime)}`,
+    `  Neurons/sec: ${
+      stats.analysisPhaseTime > 0
+        ? formatCount(
+          Math.round((stats.neuronsAnalyzed / stats.analysisPhaseTime) * 1000),
+        )
+        : "n/a"
+    }`,
+  ].filter((line): line is string => Boolean(line));
+
+  const candidateLines: string[] = [
+    `  Helpful synapses: ${formatCount(stats.helpfulSynapseCount)}`,
+    `  Helpful neurons: ${formatCount(stats.helpfulNeuronCount)}`,
+    `  Harmful synapses: ${formatCount(stats.harmfulSynapseCount)}`,
+    `  Harmful neurons: ${formatCount(stats.harmfulNeuronCount)}`,
+    `  Squash changes: ${formatCount(stats.squashCount)}`,
+    `  Removal candidates: ${formatCount(stats.removalCount)}`,
+  ];
+
+  const overallLines: string[] = [
+    formatNonZeroTimeLine("Cleanup", stats.cleanupTime),
+    `  Total time: ${formatTotalTime(stats.totalTime)}`,
+  ].filter((line): line is string => Boolean(line));
+
+  return (
+    `\n${maybeBlue("=".repeat(60))}\n` +
+    `${maybeBlue("Discovery Performance Summary")} ${
+      maybeBlue(discoveryID)
+    }\n` +
+    `${maybeBlue("=".repeat(60))}` +
+    `\n\n📊 ${maybeYellow("Record Phase")}:\n` +
+    `${recordLines.join("\n")}` +
+    `\n\n🔍 ${maybeYellow("Analysis Phase")}:\n` +
+    `${analysisLines.join("\n")}` +
+    `\n\n🎯 ${maybeYellow("Candidates Found")}:\n` +
+    `${candidateLines.join("\n")}` +
+    `\n\n⏱️  ${maybeYellow("Overall")}:\n` +
+    `${overallLines.join("\n")}\n` +
+    `${maybeBlue("=".repeat(60))}\n`
+  );
+}
+
+function msOrZero(ms: number): number {
+  return Number.isFinite(ms) ? ms : 0;
 }
 
 export async function recordDirectory(

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -4453,7 +4453,12 @@ export class DiscoverStructure {
         weight: bestCandidate.weight,
       };
 
+      // Tag the new synapse so it can be identified later and survives export/import.
+      // This mirrors neuron tagging (see addHelpfulNeurons) and helps debug why
+      // add-synapses candidates are (or are not) appearing in logs.
+      addTag(addSynapse as TagsInterface, "discovered", "synapse");
       addTag(addSynapse as TagsInterface, "discovery", "beneficial");
+      addTag(addSynapse as TagsInterface, "discoveryID", ID);
       if (bestCandidate.comment) {
         addTag(
           addSynapse as TagsInterface,
@@ -4690,6 +4695,7 @@ export class DiscoverStructure {
         toUUID: newNeuronUUID,
         weight: candidate.incomingWeight,
       };
+      addTag(incomingSynapse as TagsInterface, "discoveryID", ID);
       addTag(incomingSynapse as TagsInterface, "discovery", "beneficial");
       if (candidate.comment) {
         addTag(
@@ -4705,6 +4711,7 @@ export class DiscoverStructure {
         toUUID: candidate.toNeuronUUID,
         weight: candidate.outgoingWeight,
       };
+      addTag(outgoingSynapse as TagsInterface, "discoveryID", ID);
       addTag(outgoingSynapse as TagsInterface, "discovery", "beneficial");
       if (candidate.comment) {
         addTag(

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -205,6 +205,13 @@ export function buildDiscoveryCandidates(
   discovery: DiscoverResult,
   options?: BuildDiscoveryCandidatesOptions,
 ): DiscoveryCandidate[] {
+  // When true, this function must only emit single-step candidates (phase 1).
+  // That means:
+  // - No multi-suggestion "combined" candidates within a category (eg apply 30 add-neurons at once)
+  // - No cross-category combo-* candidates
+  //
+  // Phase 2 combinations are built exclusively from successful singles via
+  // `buildCombinedFromSuccessful()`.
   const skipCombos = options?.skipCombinedCandidates ?? false;
   const discoveryFailureCacheDir = options?.discoveryFailureCacheDir;
   // Ensure the base creature has a UUID so discovery helpers function correctly.
@@ -246,7 +253,7 @@ export function buildDiscoveryCandidates(
     discovery.splitSynapseInsertNeuronCandidates;
   const successfulSplitSynapseInsertNeuronCandidates:
     SplitSynapseInsertNeuronCandidate[] = [];
-  const addedNeuronCreature = helpfulNeuronCandidates &&
+  const addedNeuronCreature = !skipCombos && helpfulNeuronCandidates &&
       helpfulNeuronCandidates.length > 0
     ? DiscoverStructure.addHelpfulNeurons(
       discovery.ID,
@@ -255,7 +262,7 @@ export function buildDiscoveryCandidates(
       discoveryFailureCacheDir,
     )
     : undefined;
-  if (addedNeuronCreature && helpfulNeuronCandidates) {
+  if (!skipCombos && addedNeuronCreature && helpfulNeuronCandidates) {
     const neuronSummary = summariseExpectedImprovement(
       mapScaledSummaryEntries(
         helpfulNeuronCandidates,
@@ -275,7 +282,9 @@ export function buildDiscoveryCandidates(
         sampleSize: neuronSummary.sampleSize,
       },
     });
-  } else if (helpfulNeuronCandidates && helpfulNeuronCandidates.length > 0) {
+  } else if (
+    !skipCombos && helpfulNeuronCandidates && helpfulNeuronCandidates.length > 0
+  ) {
     console.info(
       `[DiscoveryCandidates] Combined add-neurons candidate not created (${helpfulNeuronCandidates.length} neuron${
         helpfulNeuronCandidates.length === 1 ? "" : "s"
@@ -335,13 +344,15 @@ export function buildDiscoveryCandidates(
     }
   }
 
-  const addedSynapseCreature = DiscoverStructure.addHelpfulSynapses(
-    discovery.ID,
-    baseCreature,
-    addHelpfulSynapses,
-    discoveryFailureCacheDir,
-  );
-  if (addedSynapseCreature) {
+  const addedSynapseCreature = !skipCombos
+    ? DiscoverStructure.addHelpfulSynapses(
+      discovery.ID,
+      baseCreature,
+      addHelpfulSynapses,
+      discoveryFailureCacheDir,
+    )
+    : undefined;
+  if (!skipCombos && addedSynapseCreature) {
     const synapseSummary = summariseExpectedImprovement(
       mapScaledSummaryEntries(
         addHelpfulSynapses,
@@ -360,7 +371,9 @@ export function buildDiscoveryCandidates(
         sampleSize: synapseSummary.sampleSize,
       },
     });
-  } else if (addHelpfulSynapses && addHelpfulSynapses.length > 0) {
+  } else if (
+    !skipCombos && addHelpfulSynapses && addHelpfulSynapses.length > 0
+  ) {
     console.info(
       `[DiscoveryCandidates] Combined add-synapses candidate not created (${addHelpfulSynapses.length} synapse${
         addHelpfulSynapses.length === 1 ? "" : "s"
@@ -482,13 +495,15 @@ export function buildDiscoveryCandidates(
     }
   }
 
-  const changedSquashCreature = DiscoverStructure.changeSquash(
-    discovery.ID,
-    baseCreature,
-    candidateSquashes,
-    discoveryFailureCacheDir,
-  );
-  if (changedSquashCreature) {
+  const changedSquashCreature = !skipCombos
+    ? DiscoverStructure.changeSquash(
+      discovery.ID,
+      baseCreature,
+      candidateSquashes,
+      discoveryFailureCacheDir,
+    )
+    : undefined;
+  if (!skipCombos && changedSquashCreature) {
     const changes = (candidateSquashes || []).map((c) => {
       const neuron = baseCreature.neurons.find((n) => n.uuid === c.neuronUUID);
       const oldSquash = neuron?.squash;
@@ -542,7 +557,7 @@ export function buildDiscoveryCandidates(
         });
       }
     }
-  } else if (candidateSquashes && candidateSquashes.length > 0) {
+  } else if (!skipCombos && candidateSquashes && candidateSquashes.length > 0) {
     console.info(
       `[DiscoveryCandidates] Combined change-squash candidate not created (${candidateSquashes.length} squash${
         candidateSquashes.length === 1 ? "" : "es"
@@ -1886,19 +1901,44 @@ function applyChangeToCreature(
       }
 
       case "change-squash": {
-        // Copy squash changes from candidate
-        const candidateNeuronMap = new Map(
-          candidateJSON.neurons.map((n) => [n.uuid, n]),
-        );
-        let changed = false;
-        for (const neuron of creatureJSON.neurons) {
-          const candidateNeuron = candidateNeuronMap.get(neuron.uuid);
-          if (candidateNeuron && candidateNeuron.squash !== neuron.squash) {
-            neuron.squash = candidateNeuron.squash;
-            changed = true;
+        // Apply ONLY the intended squash change for this candidate.
+        //
+        // Why: candidate creature JSON contains a full snapshot of all neuron squashes
+        // (mostly unchanged). If we naively copy all squashes from the candidate we
+        // can accidentally revert earlier combo steps (eg change hidden-1 to TANH,
+        // then apply an output-0 LOGISTIC candidate that still has hidden-1=IDENTITY).
+        //
+        // In phase 2, combo candidates are built from successful single-step
+        // candidates, so we must apply their delta precisely.
+        const targetUUID = candidate.change.squashCandidate?.neuronUUID;
+        const targetSquash = candidate.change.squashCandidate?.squash;
+        if (targetUUID && targetSquash) {
+          let changed = false;
+          for (const neuron of creatureJSON.neurons) {
+            if (neuron.uuid !== targetUUID) continue;
+            if (neuron.squash !== targetSquash) {
+              neuron.squash = targetSquash;
+              changed = true;
+            }
+            break;
           }
+          if (!changed) return creature;
+        } else {
+          // Fallback (older candidates): apply by diffing candidate vs current, but only
+          // for neurons that differ AND are present in the current creature.
+          const candidateNeuronMap = new Map(
+            candidateJSON.neurons.map((n) => [n.uuid, n]),
+          );
+          let changed = false;
+          for (const neuron of creatureJSON.neurons) {
+            const candidateNeuron = candidateNeuronMap.get(neuron.uuid);
+            if (candidateNeuron && candidateNeuron.squash !== neuron.squash) {
+              neuron.squash = candidateNeuron.squash;
+              changed = true;
+            }
+          }
+          if (!changed) return creature;
         }
-        if (!changed) return creature;
 
         const result = Creature.fromJSON(creatureJSON);
         delete result.uuid;

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -959,7 +959,9 @@ export class DiscoveryRunner {
         }
         if (cache.cachedOther > 0) {
           const typeBreakdown = Array.from(cache.cachedOtherByType.entries())
-            .map(([type, count]) => `${count} ${type}`)
+            .map(([type, count]) =>
+              `${count} ${type} candidate${count === 1 ? "" : "s"}`
+            )
             .join(", ");
           parts.push(typeBreakdown || `${cache.cachedOther} other`);
         }

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -575,8 +575,17 @@ export async function isCandidateCached(
   // highly dependent on the *current* base creature. Caching them as failures
   // can permanently suppress sensible re-tries as the creature evolves.
   //
-  // We intentionally never treat combo-* candidates as failure-cacheable.
-  if (candidate.change.type.startsWith("combo-")) {
+  // Exception (30-Dec-2025): `combo-successful` is generated in phase 2 from
+  // the set of successful single-step candidates. It is still keyed by the
+  // resulting creature structure (see buildCacheKey fallback), so it will only
+  // be considered cached when the exact same combined outcome is re-proposed.
+  //
+  // This keeps the failure cache useful for repeated discovery runs on a stable
+  // creature while avoiding broad caching of other combo-* types.
+  if (
+    candidate.change.type.startsWith("combo-") &&
+    candidate.change.type !== "combo-successful"
+  ) {
     return false;
   }
   try {
@@ -607,7 +616,10 @@ export function isCandidateCachedSync(
   candidate: DiscoveryCandidate,
 ): boolean {
   // See async variant for rationale.
-  if (candidate.change.type.startsWith("combo-")) {
+  if (
+    candidate.change.type.startsWith("combo-") &&
+    candidate.change.type !== "combo-successful"
+  ) {
     return false;
   }
   try {
@@ -644,8 +656,11 @@ export async function recordFailure(
   metadata: FailureMetadata,
   baseCreature?: Creature,
 ): Promise<void> {
-  // Combo failures are not cached (see isCandidateCached for rationale).
-  if (candidate.change.type.startsWith("combo-")) {
+  // Combo failures are mostly not cached (see isCandidateCached for rationale).
+  if (
+    candidate.change.type.startsWith("combo-") &&
+    candidate.change.type !== "combo-successful"
+  ) {
     return;
   }
   try {
@@ -819,8 +834,11 @@ export function recordFailureSync(
   metadata: FailureMetadata,
   baseCreature?: Creature,
 ): void {
-  // Combo failures are not cached (see isCandidateCached for rationale).
-  if (candidate.change.type.startsWith("combo-")) {
+  // Combo failures are mostly not cached (see isCandidateCached for rationale).
+  if (
+    candidate.change.type.startsWith("combo-") &&
+    candidate.change.type !== "combo-successful"
+  ) {
     return;
   }
   try {

--- a/test/discovery/DiscoveryCandidates.ts
+++ b/test/discovery/DiscoveryCandidates.ts
@@ -1313,3 +1313,131 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "buildDiscoveryCandidates (skipCombinedCandidates) emits only single-step candidates for add-neurons/add-synapses/change-squash",
+  () => {
+    const base = makeBaselineCreature();
+    const discovery: DiscoverResult = {
+      ID: "PHASE1-SINGLES-ONLY",
+      addHelpfulSynapses: [{
+        fromNeuronUUID: "input-2",
+        toNeuronUUID: "hidden-1",
+        weight: 0.99,
+        targetNeuronImpact: 1.0,
+        expectedCreatureErrorReduction: 0,
+        expectedCreatureScoreGain: 0.25,
+        improvedCount: 5,
+        totalCount: 6,
+      }, {
+        fromNeuronUUID: "input-3",
+        toNeuronUUID: "hidden-2",
+        weight: -0.55,
+        targetNeuronImpact: 1.0,
+        expectedCreatureErrorReduction: 0,
+        expectedCreatureScoreGain: 0.3,
+        improvedCount: 6,
+        totalCount: 7,
+      }],
+      addHelpfulNeurons: [{
+        fromNeuronUUID: "input-2",
+        toNeuronUUID: "hidden-1",
+        incomingWeight: 0.45,
+        outgoingWeight: -0.12,
+        squash: TANH.NAME,
+        bias: 0.1,
+        targetNeuronImpact: 1.0,
+        expectedCreatureErrorReduction: 0,
+        expectedCreatureScoreGain: 0.1,
+        improvedCount: 5,
+        totalCount: 6,
+      }, {
+        fromNeuronUUID: "input-3",
+        toNeuronUUID: "hidden-2",
+        incomingWeight: -0.38,
+        outgoingWeight: 0.22,
+        squash: Mish.NAME,
+        bias: -0.05,
+        targetNeuronImpact: 1.0,
+        expectedCreatureErrorReduction: 0,
+        expectedCreatureScoreGain: 0.45,
+        improvedCount: 7,
+        totalCount: 8,
+      }],
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: [{
+        neuronUUID: "hidden-1",
+        previousSquash: IDENTITY.NAME,
+        squash: TANH.NAME,
+        expectedCreatureScoreGain: 0.4,
+        improvedError: 0.1,
+        currentError: 0.2,
+      }, {
+        neuronUUID: "hidden-2",
+        previousSquash: IDENTITY.NAME,
+        squash: Mish.NAME,
+        expectedCreatureScoreGain: 0.3,
+        improvedError: 0.2,
+        currentError: 0.4,
+      }],
+    };
+
+    const candidates = buildDiscoveryCandidates(base, discovery, {
+      skipCombinedCandidates: true,
+    });
+
+    // Phase-1 requirement: only dedicated single-step candidates should exist for these types.
+    const addNeuronCandidates = candidates.filter((c) =>
+      c.change.type === "add-neurons"
+    );
+    assertEquals(
+      addNeuronCandidates.length,
+      discovery.addHelpfulNeurons!.length,
+      "Expected exactly one add-neurons candidate per suggestion when skipCombinedCandidates is true",
+    );
+    assertEquals(
+      addNeuronCandidates.every((c) => c.change.neuronDetails !== undefined),
+      true,
+      "Expected add-neurons candidates to carry neuronDetails (single-step)",
+    );
+
+    const addSynapseCandidates = candidates.filter((c) =>
+      c.change.type === "add-synapses"
+    );
+    assertEquals(
+      addSynapseCandidates.length,
+      discovery.addHelpfulSynapses!.length,
+      "Expected exactly one add-synapses candidate per suggestion when skipCombinedCandidates is true",
+    );
+    assertEquals(
+      addSynapseCandidates.every((c) =>
+        c.change.synapseCandidate !== undefined
+      ),
+      true,
+      "Expected add-synapses candidates to carry synapseCandidate (single-step)",
+    );
+
+    const squashCandidates = candidates.filter((c) =>
+      c.change.type === "change-squash"
+    );
+    assertEquals(
+      squashCandidates.length,
+      discovery.candidateSquashes!.length,
+      "Expected exactly one change-squash candidate per suggestion when skipCombinedCandidates is true",
+    );
+    assertEquals(
+      squashCandidates.every((c) => c.change.squashCandidate !== undefined),
+      true,
+      "Expected change-squash candidates to carry squashCandidate (single-step)",
+    );
+
+    // Defensive: no combo-* should ever appear when skipCombinedCandidates is true.
+    assertEquals(
+      candidates.some((c) => c.change.type.startsWith("combo-")),
+      false,
+      "Expected no combo-* candidates when skipCombinedCandidates is true",
+    );
+  },
+);

--- a/test/discovery/DiscoveryPerformanceSummary.ts
+++ b/test/discovery/DiscoveryPerformanceSummary.ts
@@ -1,0 +1,77 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import {
+  formatDiscoveryPerformanceSummary,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts";
+
+Deno.test("Discovery performance summary omits unrecorded (zero) phase timings", () => {
+  const text = formatDiscoveryPerformanceSummary(
+    "deadbeef",
+    {
+      // Record phase
+      recordsProcessed: 10,
+      filesProcessed: 2,
+      initializationTime: 3,
+      fileProcessingTime: 2_000,
+      promiseWaitTime: 0, // unrecorded
+      recordPhaseTime: 2_003,
+
+      // Analysis phase
+      neuronsAnalyzed: 6,
+      retryAttempts: 0,
+      focusSelectionTime: 35_000,
+      rustCombinedAnalysisTime: 900_000,
+      neuronAnalysisTime: 0, // unrecorded
+      synapseAnalysisTime: 0, // unrecorded
+      harmfulSynapseAnalysisTime: 0, // unrecorded
+      harmfulNeuronAnalysisTime: 0, // unrecorded
+      squashAnalysisTime: 10_000,
+      analysisPhaseTime: 945_000,
+
+      // Candidate counts
+      helpfulSynapseCount: 1,
+      helpfulNeuronCount: 30,
+      harmfulSynapseCount: 0,
+      harmfulNeuronCount: 0,
+      squashCount: 1,
+      removalCount: 50,
+
+      // Overall
+      cleanupTime: 0, // async/unrecorded
+      totalTime: 1_200_000,
+    },
+    { colour: false },
+  );
+
+  // Must include core totals and counts
+  assertStringIncludes(text, "Discovery Performance Summary deadbeef");
+  assertStringIncludes(text, "Records processed:");
+  assertStringIncludes(text, "Total record phase:");
+  assertStringIncludes(text, "Total analysis phase:");
+  assertStringIncludes(text, "Total time:");
+
+  // Must not include blank/unrecorded phases
+  assert(
+    !text.includes("Promise wait:"),
+    `Expected 'Promise wait' to be omitted when unrecorded, got:\n${text}`,
+  );
+  assert(
+    !text.includes("Neuron analysis:"),
+    `Expected 'Neuron analysis' to be omitted when unrecorded, got:\n${text}`,
+  );
+  assert(
+    !text.includes("Synapse analysis:"),
+    `Expected 'Synapse analysis' to be omitted when unrecorded, got:\n${text}`,
+  );
+  assert(
+    !text.includes("Harmful synapse analysis:"),
+    `Expected 'Harmful synapse analysis' to be omitted when unrecorded, got:\n${text}`,
+  );
+  assert(
+    !text.includes("Harmful neuron analysis:"),
+    `Expected 'Harmful neuron analysis' to be omitted when unrecorded, got:\n${text}`,
+  );
+  assert(
+    !text.includes("Cleanup:"),
+    `Expected 'Cleanup' to be omitted when unrecorded, got:\n${text}`,
+  );
+});

--- a/test/discovery/DiscoverySynapseTagging.ts
+++ b/test/discovery/DiscoverySynapseTagging.ts
@@ -1,0 +1,64 @@
+import { assert, assertEquals } from "@std/assert";
+import { getTag } from "@stsoftware/tags/mod";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import {
+  type CandidateSynapse,
+  DiscoverStructure,
+} from "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { Creature } from "../../src/Creature.ts";
+
+Deno.test("Discovery addHelpfulSynapses tags new synapses and tags survive export/import", () => {
+  const base: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(base, true);
+
+  const discoveryID = "abcd1234";
+  const candidate: CandidateSynapse = {
+    fromNeuronUUID: "input-1",
+    toNeuronUUID: "output-0",
+    weight: 0.25,
+    targetNeuronImpact: 1,
+    expectedCreatureErrorReduction: 0,
+    expectedCreatureScoreGain: 0,
+    improvedCount: 0,
+    totalCount: 1,
+    comment: "test-candidate",
+  };
+
+  const updated = DiscoverStructure.addHelpfulSynapses(
+    discoveryID,
+    creature,
+    [candidate],
+  );
+  assert(updated);
+
+  const exported = updated.exportJSON();
+  const added = exported.synapses.find((s) =>
+    s.fromUUID === "input-1" && s.toUUID === "output-0"
+  );
+  assert(added, "Expected the helpful synapse to be added");
+
+  // Tag names are strings and values are persisted via JSON.
+  assertEquals(getTag(added, "discovered"), "synapse");
+  assertEquals(getTag(added, "discovery"), "beneficial");
+  assertEquals(getTag(added, "discoveryID"), discoveryID);
+  assertEquals(getTag(added, "discovery-comment"), "test-candidate");
+
+  // Roundtrip import/export preserves tags.
+  const roundTripped = Creature.fromJSON(exported, true).exportJSON();
+  const added2 = roundTripped.synapses.find((s) =>
+    s.fromUUID === "input-1" && s.toUUID === "output-0"
+  );
+  assert(added2);
+  assertEquals(getTag(added2, "discovered"), "synapse");
+  assertEquals(getTag(added2, "discoveryID"), discoveryID);
+});

--- a/test/discovery/DiscoverySynapseTagging.ts
+++ b/test/discovery/DiscoverySynapseTagging.ts
@@ -53,7 +53,7 @@ Deno.test("Discovery addHelpfulSynapses tags new synapses and tags survive expor
   assertEquals(getTag(added, "discoveryID"), discoveryID);
   assertEquals(getTag(added, "discovery-comment"), "test-candidate");
 
-  // Roundtrip import/export preserves tags.
+  // Round-trip import/export preserves tags.
   const roundTripped = Creature.fromJSON(exported, true).exportJSON();
   const added2 = roundTripped.synapses.find((s) =>
     s.fromUUID === "input-1" && s.toUUID === "output-0"

--- a/test/discovery/FailureCache.ts
+++ b/test/discovery/FailureCache.ts
@@ -446,14 +446,14 @@ Deno.test("recordFailure and isCandidateCached work together", async () => {
   }
 });
 
-Deno.test("combo-* failures are not cached (combos are always re-scored)", async () => {
+Deno.test("combo-* failures are not cached (except combo-successful)", async () => {
   const tempDir = await Deno.makeTempDir();
 
   try {
     const creature = makeSimpleCreature();
     const candidate = makeCandidate(
-      "combo-successful",
-      "🏗️ Combined successful changes",
+      "combo-all",
+      "🏗️ Combined all changes",
       creature,
     );
 
@@ -487,6 +487,50 @@ Deno.test("combo-* failures are not cached (combos are always re-scored)", async
       cachedSync,
       false,
       "Combo candidates should not be treated as cached failures (sync)",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+    closeRustLibrary();
+  }
+});
+
+Deno.test("combo-successful failures are cached (phase 2 cache)", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const creature = makeSimpleCreature();
+    const candidate = makeCandidate(
+      "combo-successful",
+      "🏗️ Combined successful changes",
+      creature,
+    );
+
+    // Initially should not be cached
+    assertEquals(
+      await isCandidateCached(tempDir, candidate),
+      false,
+      "Precondition: combo-successful should not be cached initially",
+    );
+
+    await recordFailure(tempDir, candidate, {
+      originalScore: 0.5,
+      candidateScore: 0.49,
+      scoreDelta: -0.01,
+      error: 0.6,
+      originalError: 0.59,
+    });
+
+    assertEquals(
+      await isCandidateCached(tempDir, candidate),
+      true,
+      "combo-successful should be cached after recording failure (async)",
+    );
+
+    // Sync API should match.
+    assertEquals(
+      isCandidateCachedSync(tempDir, candidate),
+      true,
+      "combo-successful should be cached after recording failure (sync)",
     );
   } finally {
     await Deno.remove(tempDir, { recursive: true });


### PR DESCRIPTION
…nce logging

- Bumped version in deno.json to 0.285.0.
- Refactored logging in DiscoveryPerformanceStats to utilize a new formatDiscoveryPerformanceSummary function, improving clarity and detail in performance summaries.
- Introduced a DiscoveryPerformanceSummarySnapshot interface to standardize performance statistics across different phases of discovery.
- Enhanced tagging of synapses in DiscoverStructure to include discovery IDs for better traceability.

These changes improve the accuracy and maintainability of performance logging within the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves observability and determinism of discovery while tightening candidate and cache behavior.
> 
> - **Structured summary output**: New `formatDiscoveryPerformanceSummary()` and `DiscoveryPerformanceSummarySnapshot` centralize logging; omits zero/unused timings and standardizes counts.
> - **Singles-only candidate phase**: `buildDiscoveryCandidates(..., { skipCombinedCandidates: true })` now emits only single-step `add-neurons`/`add-synapses`/`change-squash`; combo candidates are deferred to phase 2.
> - **Precise squash application**: `change-squash` applies only the intended neuron delta (avoids reverting prior combo steps); safe fallback for older candidates remains.
> - **Synapse tagging**: `addHelpfulSynapses` (and split-add neuron wiring) add `discovered`, `discovery`, and `discoveryID` tags; tags persist across export/import.
> - **Failure cache policy**: Combo candidates are not cached except `combo-successful`, which is now cached in both async/sync paths; improved pluralized cache logging in `DiscoveryRunner`.
> - **Tests**: Added coverage for performance summary formatting, singles-only behavior, synapse tagging, and failure-cache rules.
> - **Meta**: Bumps version to `0.285.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2668860dfa488eb6831937b85a9e49328bfb7bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->