### PR TITLE
Update version to 0.285.1 in deno.json and enhance logging in Discove…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.285.0",
+  "version": "0.285.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -854,7 +854,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       }
 
       const prefix = "🦘";
-      const shortID = creature.uuid ?? "Unknown".slice(-8);
+      const shortID = (creature.uuid ?? "Unknown").slice(-8);
       if (verifyScores && config.discoveryReplayRescoreBaseline) {
         const claimedScore = parseClaimedTagNumber(creature.tags, "score");
         const claimedError = parseClaimedTagNumber(creature.tags, "error");

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -854,6 +854,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       }
 
       const prefix = "🦘";
+      const shortID = creature.uuid ?? "Unknown".slice(-8);
       if (verifyScores && config.discoveryReplayRescoreBaseline) {
         const claimedScore = parseClaimedTagNumber(creature.tags, "score");
         const claimedError = parseClaimedTagNumber(creature.tags, "error");
@@ -862,10 +863,10 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
           originalEval.score,
         );
         const reason = claimedScore === undefined
-          ? `${prefix} Baseline rescore: no claimed score tag found, so I rescored on the current dataset (score=${originalEval.score}, error=${originalEval.error}).`
+          ? `${prefix} Baseline rescore: no claimed score tag found, so I rescored for ${shortID} (score=${originalEval.score}, error=${originalEval.error}).`
           : `${prefix} Score drift check: claimed score ${claimedScore} (error ${
             claimedError ?? "?"
-          }) vs actual score ${originalEval.score} (error ${originalEval.error}) on the current dataset.`;
+          }) vs actual score ${originalEval.score} (error ${originalEval.error}) for ${shortID}.`;
 
         void claimedError; // Claimed error is optional; callers can re-tag using actualError.
 
@@ -899,7 +900,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
             scoreDelta,
             improved: scoreDelta > 0,
             message:
-              `${prefix} Verified improvement on current dataset: ${message}`,
+              `${prefix} Verified improvement for ${shortID}: ${message}`,
             creature: best.creature.exportJSON(),
           };
         }

--- a/test/discovery/DiscoveryReplayRunnerShortID.ts
+++ b/test/discovery/DiscoveryReplayRunnerShortID.ts
@@ -1,0 +1,87 @@
+import { assertEquals, assertExists } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { DiscoveryReplayRunner } from "../../src/discovery/DiscoveryReplayRunner.ts";
+import type { SuccessCacheEntry } from "../../src/discovery/SuccessCache.ts";
+
+function makeBaseCreature(): Creature {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  return Creature.fromJSON(base);
+}
+
+function makeEntry(overrides: Partial<SuccessCacheEntry>): SuccessCacheEntry {
+  return {
+    key: overrides.key ?? "k",
+    changeType: overrides.changeType ?? "add-synapses",
+    description: overrides.description,
+    originalScore: overrides.originalScore ?? 0.5,
+    candidateScore: overrides.candidateScore ?? 0.6,
+    scoreDelta: overrides.scoreDelta ?? 0.1,
+    error: overrides.error ?? 0.4,
+    originalError: overrides.originalError ?? 0.5,
+    timestamp: overrides.timestamp ?? new Date().toISOString(),
+    rustRequest: overrides.rustRequest,
+    actualCreatureChange: overrides.actualCreatureChange,
+    discoveryVersion: overrides.discoveryVersion,
+  };
+}
+
+Deno.test("DiscoveryReplayRunner: verifiedImprovement shortens creature uuid to last 8 chars", async () => {
+  const base = makeBaseCreature();
+  base.uuid = "01234567-89ab-cdef-0123-456789abcdef";
+  base.tags = [
+    { name: "score", value: "1" },
+    { name: "error", value: "0.1" },
+  ];
+
+  const entry = makeEntry({
+    key: "a",
+    changeType: "add-synapses",
+    scoreDelta: 0.1,
+  });
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: (_dir) => [entry],
+    applyEntry: (current, e) => {
+      const clone = Creature.fromJSON(current.exportJSON());
+      clone.uuid = `${current.uuid}-${e.key}`;
+      return clone;
+    },
+    evaluateError: (c) => {
+      const id = c.uuid ?? "";
+      if (id === base.uuid) return Promise.resolve({ error: 0.1, score: 1.0 });
+      if (id.endsWith("-a")) return Promise.resolve({ error: 0.1, score: 1.1 });
+      return Promise.resolve({ error: 0.1, score: 1.0 });
+    },
+  });
+
+  const result = await runner.replayDir({
+    creature: base,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      threads: 1,
+      discoveryReplayVerifyScores: true,
+    },
+  });
+
+  assertExists(result.verifiedImprovement);
+  assertEquals(
+    result.verifiedImprovement.message.includes("for 89abcdef:"),
+    true,
+  );
+});


### PR DESCRIPTION
…ryReplayRunner

- Bumped version in deno.json to 0.285.1.
- Improved logging in DiscoveryReplayRunner to include a short ID for creatures in baseline rescore messages, enhancing clarity in performance reporting.

These changes improve the readability and traceability of logs within the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves replay logging clarity and adds coverage.
> 
> - `DiscoveryReplayRunner`: includes a short creature ID `shortID` (last 8 chars of `uuid`) in baseline rescore and verified-improvement messages
> - Adds test `test/discovery/DiscoveryReplayRunnerShortID.ts` to assert the short ID appears in messages (e.g., `for 89abcdef:`)
> - Bumps package version in `deno.json` to `0.285.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fa68f42d5c873462f48ea8ec4aa1f578c43d051. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->