### PR TITLE
Update version to 0.285.2 in deno.json and implement success entry ar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,12 +355,23 @@ if (replay.diagnostics) {
 1. Skips cached candidates that already appear to be applied to the current
    creature
 2. Re-scores the remaining candidates against the current creature
-3. Deletes cache entries that no longer improve score (stale successes)
+3. Archives cache entries that no longer improve score (obsolete successes) to
+   an `obsolete` directory at the same level as the success cache directory
 4. Tries combinations of still-successful candidates (pairs/triples/all) and
    returns the best improvement
 
-As with the failure cache, delete the success cache directory when your training
-dataset changes materially.
+**Obsolete entries archive:**
+
+When a cached success entry no longer results in an improvement (e.g., due to
+training data drift), it is moved to an `obsolete` directory rather than being
+deleted. This preserves the history of candidates that once resulted in
+improvements:
+
+- Success cache: `.discovery/success-cache/{changeType}/{key}.json`
+- Obsolete archive: `.discovery/obsolete/{changeType}/{key}.json`
+
+As with the failure cache, delete the success cache and obsolete directories
+when your training dataset changes materially.
 
 ### Discovery Candidate Category Limits
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.285.1",
+  "version": "0.285.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -21,7 +21,7 @@ import type { Creature } from "../Creature.ts";
 import { WorkerHandler } from "../multithreading/workers/WorkerHandler.ts";
 import { formatWeight } from "./FailureCache.ts";
 import {
-  deleteSuccessByKeySync,
+  archiveSuccessByKeySync,
   listSuccessEntriesSync,
   type SuccessCacheEntry,
 } from "./SuccessCache.ts";
@@ -117,7 +117,11 @@ export interface DiscoveryReplayRunnerLike {
 
 export interface DiscoveryReplayRunnerDeps {
   listEntries?: (dir: string) => SuccessCacheEntry[];
-  deleteEntry?: (dir: string, entry: SuccessCacheEntry) => void;
+  /**
+   * Archive an obsolete success cache entry instead of deleting it.
+   * This preserves history of candidates that once improved but no longer do.
+   */
+  archiveEntry?: (dir: string, entry: SuccessCacheEntry) => void;
   applyEntry?: (
     baseCreature: Creature,
     entry: SuccessCacheEntry,
@@ -507,7 +511,7 @@ function describeCombo(entries: SuccessCacheEntry[]): string {
 export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
   #deps: {
     listEntries: (dir: string) => SuccessCacheEntry[];
-    deleteEntry: (dir: string, entry: SuccessCacheEntry) => void;
+    archiveEntry: (dir: string, entry: SuccessCacheEntry) => void;
     applyEntry: (
       baseCreature: Creature,
       entry: SuccessCacheEntry,
@@ -522,9 +526,9 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
   constructor(deps: DiscoveryReplayRunnerDeps = {}) {
     this.#deps = {
       listEntries: deps.listEntries ?? listSuccessEntriesSync,
-      deleteEntry: deps.deleteEntry ??
+      archiveEntry: deps.archiveEntry ??
         ((dir, entry) =>
-          deleteSuccessByKeySync(dir, entry.changeType, entry.key)),
+          archiveSuccessByKeySync(dir, entry.changeType, entry.key)),
       applyEntry: deps.applyEntry ?? applyEntryUsingRustRequest,
       evaluateError: deps.evaluateError,
     };
@@ -697,7 +701,8 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         r.score <= originalEval.score
       );
       for (const failed of failedSingles) {
-        deps.deleteEntry(successCacheDir, failed.entry);
+        // Archive obsolete entries instead of deleting them to preserve history
+        deps.archiveEntry(successCacheDir, failed.entry);
         pruned++;
       }
 

--- a/src/discovery/SuccessCache.ts
+++ b/src/discovery/SuccessCache.ts
@@ -233,6 +233,73 @@ export function deleteSuccessByKeySync(
 }
 
 /**
+ * Computes the obsolete directory path for a given success cache directory.
+ *
+ * If the success cache is at `discovery/success-cache`, the obsolete directory
+ * will be at `discovery/obsolete`.
+ */
+export function getObsoleteDir(successCacheDir: string): string {
+  const parent = dirname(successCacheDir);
+  return join(parent, "obsolete");
+}
+
+/**
+ * Archives a cached success entry by moving it to the obsolete directory.
+ *
+ * This preserves the history of candidates that once resulted in improvements
+ * but no longer do (e.g., due to training data drift).
+ *
+ * The obsolete directory structure mirrors the success directory structure:
+ * - Success:  `discovery/success-cache/{changeType}/{key}.json`
+ * - Obsolete: `discovery/obsolete/{changeType}/{key}.json`
+ *
+ * @param cacheDir - The success cache directory path
+ * @param changeType - The type of change (e.g., "add-synapses", "remove-neuron")
+ * @param key - The cache key for the entry
+ */
+export function archiveSuccessByKeySync(
+  cacheDir: string,
+  changeType: string,
+  key: string,
+): void {
+  const sanitisedType = sanitiseForFilename(changeType);
+  const sanitisedKey = sanitiseForFilename(key);
+  const fileName = `${sanitisedKey}.json`;
+
+  const sourcePath = join(cacheDir, sanitisedType, fileName);
+  const obsoleteDir = getObsoleteDir(cacheDir);
+  const targetDir = join(obsoleteDir, sanitisedType);
+  const targetPath = join(targetDir, fileName);
+
+  try {
+    // Check if source file exists
+    Deno.statSync(sourcePath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      // Source file doesn't exist; nothing to archive
+      return;
+    }
+    throw error;
+  }
+
+  // Create the obsolete directory structure if it doesn't exist
+  Deno.mkdirSync(targetDir, { recursive: true });
+
+  try {
+    // Move the file using rename (atomic on same filesystem)
+    Deno.renameSync(sourcePath, targetPath);
+  } catch {
+    // Fallback: copy then delete (for cross-filesystem moves)
+    Deno.copyFileSync(sourcePath, targetPath);
+    try {
+      Deno.removeSync(sourcePath);
+    } catch {
+      // Ignore cleanup failure; the file has been archived
+    }
+  }
+}
+
+/**
  * Lists all cached success entries under a cache directory.
  *
  * Best-effort: corrupt files are skipped with a warning.

--- a/test/discovery/DiscoveryReplayRunner.ts
+++ b/test/discovery/DiscoveryReplayRunner.ts
@@ -71,12 +71,12 @@ Deno.test("DiscoveryReplayRunner prunes stale successes and prefers best combo",
     },
   });
 
-  const deleted: Array<{ key: string; changeType: string }> = [];
+  const archived: Array<{ key: string; changeType: string }> = [];
 
   const runner = new DiscoveryReplayRunner({
     listEntries: (_dir) => [e1, e2, e3, alreadyApplied],
-    deleteEntry: (_dir, entry) =>
-      deleted.push({ key: entry.key, changeType: entry.changeType }),
+    archiveEntry: (_dir, entry) =>
+      archived.push({ key: entry.key, changeType: entry.changeType }),
     applyEntry: (current, entry) => {
       const clone = Creature.fromJSON(current.exportJSON());
       clone.uuid = `${current.uuid ?? "base"}-${entry.key}`;
@@ -114,7 +114,7 @@ Deno.test("DiscoveryReplayRunner prunes stale successes and prefers best combo",
 
   assertEquals(result.evaluatedSingles, 3); // k1,k2,k3 (k4 is already-applied)
   assertEquals(result.pruned, 1);
-  assertEquals(deleted, [{ key: "k3", changeType: "remove-synapse" }]);
+  assertEquals(archived, [{ key: "k3", changeType: "remove-synapse" }]);
   assertEquals(result.skippedAlreadyApplied, 1);
 
   assertExists(result.improvement);

--- a/test/discovery/DiscoveryReplayRunnerArchive.ts
+++ b/test/discovery/DiscoveryReplayRunnerArchive.ts
@@ -1,0 +1,168 @@
+import { assertEquals, assertExists } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { DiscoveryReplayRunner } from "../../src/discovery/DiscoveryReplayRunner.ts";
+import type { SuccessCacheEntry } from "../../src/discovery/SuccessCache.ts";
+import {
+  archiveSuccessByKeySync,
+  getObsoleteDir,
+} from "../../src/discovery/SuccessCache.ts";
+import { join } from "@std/path/join";
+
+function makeBaseCreature(): Creature {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  return Creature.fromJSON(base);
+}
+
+function makeEntry(overrides: Partial<SuccessCacheEntry>): SuccessCacheEntry {
+  return {
+    key: overrides.key ?? "k",
+    changeType: overrides.changeType ?? "add-synapses",
+    description: overrides.description,
+    originalScore: overrides.originalScore ?? 0.5,
+    candidateScore: overrides.candidateScore ?? 0.6,
+    scoreDelta: overrides.scoreDelta ?? 0.1,
+    error: overrides.error ?? 0.4,
+    originalError: overrides.originalError ?? 0.5,
+    timestamp: overrides.timestamp ?? new Date().toISOString(),
+    rustRequest: overrides.rustRequest,
+    actualCreatureChange: overrides.actualCreatureChange,
+    discoveryVersion: overrides.discoveryVersion,
+  };
+}
+
+Deno.test("getObsoleteDir returns correct sibling directory", () => {
+  assertEquals(getObsoleteDir("/path/to/success-cache"), "/path/to/obsolete");
+  assertEquals(getObsoleteDir("discovery/success"), "discovery/obsolete");
+  assertEquals(
+    getObsoleteDir(".discovery/success-cache"),
+    ".discovery/obsolete",
+  );
+});
+
+Deno.test("archiveSuccessByKeySync moves file to obsolete directory", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const successCacheDir = join(tempDir, "success-cache");
+  const obsoleteDir = join(tempDir, "obsolete");
+  const changeType = "add-synapses";
+  const key = "test-key-123";
+
+  try {
+    // Create a success cache entry
+    const entryDir = join(successCacheDir, changeType);
+    await Deno.mkdir(entryDir, { recursive: true });
+    const entryPath = join(entryDir, `${key}.json`);
+    const entryContent = JSON.stringify({ key, changeType, test: true });
+    await Deno.writeTextFile(entryPath, entryContent);
+
+    // Verify the file exists in the success directory
+    const statBefore = await Deno.stat(entryPath);
+    assertExists(statBefore);
+
+    // Archive the entry
+    archiveSuccessByKeySync(successCacheDir, changeType, key);
+
+    // Verify the file no longer exists in the success directory
+    let sourceExists = true;
+    try {
+      await Deno.stat(entryPath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        sourceExists = false;
+      } else {
+        throw error;
+      }
+    }
+    assertEquals(sourceExists, false, "Source file should have been moved");
+
+    // Verify the file exists in the obsolete directory
+    const archivedPath = join(obsoleteDir, changeType, `${key}.json`);
+    const statAfter = await Deno.stat(archivedPath);
+    assertExists(statAfter);
+
+    // Verify the content is preserved
+    const archivedContent = await Deno.readTextFile(archivedPath);
+    assertEquals(archivedContent, entryContent);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("archiveSuccessByKeySync handles missing file gracefully", () => {
+  // Archiving a non-existent file should not throw
+  archiveSuccessByKeySync("/non/existent/path", "add-synapses", "missing-key");
+});
+
+Deno.test("DiscoveryReplayRunner archives obsolete entries instead of deleting", async () => {
+  const base = makeBaseCreature();
+
+  const successfulEntry = makeEntry({
+    key: "k1",
+    changeType: "add-synapses",
+    scoreDelta: 0.1,
+  });
+
+  const obsoleteEntry = makeEntry({
+    key: "k2",
+    changeType: "change-squash",
+    scoreDelta: 0.05,
+  });
+
+  const archived: Array<{ key: string; changeType: string }> = [];
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: (_dir) => [successfulEntry, obsoleteEntry],
+    archiveEntry: (_dir, entry) =>
+      archived.push({ key: entry.key, changeType: entry.changeType }),
+    applyEntry: (current, entry) => {
+      const clone = Creature.fromJSON(current.exportJSON());
+      clone.uuid = `${current.uuid ?? "base"}-${entry.key}`;
+      return clone;
+    },
+    evaluateError: (c) => {
+      const id = c.uuid ?? "";
+      if (id === "base") return Promise.resolve({ error: 0, score: 0.5 });
+      if (id.endsWith("-k1")) return Promise.resolve({ error: 0, score: 0.6 }); // success
+      if (id.endsWith("-k2")) return Promise.resolve({ error: 0, score: 0.49 }); // obsolete
+      return Promise.resolve({ error: 0, score: 0.5 });
+    },
+  });
+
+  base.uuid = "base";
+
+  const result = await runner.replayDir({
+    creature: base,
+    dataDir: "/tmp/does-not-matter",
+    options: {
+      discoverySuccessCacheDir: "/tmp/does-not-matter",
+      costOfGrowth: 0,
+      discoveryReplayMaxSingles: 10,
+      discoveryReplayMaxPairwise: 10,
+      discoveryReplayMaxTriples: 10,
+      threads: 1,
+    },
+  });
+
+  assertEquals(result.evaluatedSingles, 2);
+  assertEquals(result.pruned, 1);
+
+  // Verify the obsolete entry was archived
+  assertEquals(archived, [{ key: "k2", changeType: "change-squash" }]);
+
+  // Verify the successful entry is still reported as an improvement
+  assertExists(result.improvement);
+  assertEquals(result.improvement.changeType, "add-synapses");
+});

--- a/test/discovery/DiscoveryReplayRunnerCoverage.ts
+++ b/test/discovery/DiscoveryReplayRunnerCoverage.ts
@@ -76,10 +76,10 @@ Deno.test("DiscoveryReplayRunner: default applyEntry replays singles, then all-s
     squashCandidate: changeSquash,
   });
 
-  const deleted: string[] = [];
+  const archived: string[] = [];
   const runner = new DiscoveryReplayRunner({
     listEntries: () => [eAdd, eSquash],
-    deleteEntry: (_dir, entry) => deleted.push(entry.key),
+    archiveEntry: (_dir, entry) => archived.push(entry.key),
     // Use the default applyEntryUsingRustRequest by not overriding applyEntry.
     evaluateError: (c) => {
       const exported = c.exportJSON();
@@ -119,7 +119,7 @@ Deno.test("DiscoveryReplayRunner: default applyEntry replays singles, then all-s
 
   assertEquals(result.evaluatedSingles, 2);
   assertEquals(result.pruned, 0);
-  assertEquals(deleted.length, 0);
+  assertEquals(archived.length, 0);
 
   assertExists(result.improvement);
   assertEquals(result.improvement.changeType, "combo-successful");
@@ -214,10 +214,10 @@ Deno.test("DiscoveryReplayRunner: prunes stale candidates (remove-low-impact + r
     synapseDetails: removeSynapseDetails,
   });
 
-  const deleted: string[] = [];
+  const archived: string[] = [];
   const runner = new DiscoveryReplayRunner({
     listEntries: () => [eRemoval, eRemoveSyn],
-    deleteEntry: (_dir, entry) => deleted.push(entry.key),
+    archiveEntry: (_dir, entry) => archived.push(entry.key),
     evaluateError: (c) => {
       // If we removed neuron-X or removed neuron-T->output-0, call it worse.
       const exported = c.exportJSON();
@@ -241,7 +241,7 @@ Deno.test("DiscoveryReplayRunner: prunes stale candidates (remove-low-impact + r
   });
 
   assertEquals(result.pruned, 2);
-  assertEquals(deleted.sort(), ["low-impact", "rm-syn"].sort());
+  assertEquals(archived.sort(), ["low-impact", "rm-syn"].sort());
   assertEquals(result.improvement, undefined);
 });
 

--- a/test/discovery/DiscoveryReplayRunnerVerifyScores.ts
+++ b/test/discovery/DiscoveryReplayRunnerVerifyScores.ts
@@ -125,12 +125,12 @@ Deno.test("DiscoveryReplayRunner: rejects stale 'better by cache metadata' candi
     scoreDelta: 999,
   });
 
-  const deleted: Array<{ key: string; changeType: string }> = [];
+  const archived: Array<{ key: string; changeType: string }> = [];
 
   const runner = new DiscoveryReplayRunner({
     listEntries: (_dir) => [stale],
-    deleteEntry: (_dir, entry) =>
-      deleted.push({ key: entry.key, changeType: entry.changeType }),
+    archiveEntry: (_dir, entry) =>
+      archived.push({ key: entry.key, changeType: entry.changeType }),
     applyEntry: (current, entry) => {
       const clone = Creature.fromJSON(current.exportJSON());
       clone.uuid = `${current.uuid}-${entry.key}`;
@@ -158,7 +158,7 @@ Deno.test("DiscoveryReplayRunner: rejects stale 'better by cache metadata' candi
   });
 
   assertEquals(result.pruned, 1);
-  assertEquals(deleted, [{ key: "stale", changeType: "add-synapses" }]);
+  assertEquals(archived, [{ key: "stale", changeType: "add-synapses" }]);
   assertEquals(result.improvement, undefined);
   assertEquals(result.verifiedImprovement, undefined);
 });


### PR DESCRIPTION
…chiving

- Bumped version in deno.json to 0.285.2.
- Refactored success cache management to archive obsolete entries instead of deleting them, preserving historical data on candidates that previously improved performance.
- Updated related documentation in README.md to reflect the new archiving behavior and its implications for managing cached entries.

These changes enhance the robustness and traceability of the NEAT framework's caching mechanism.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces archival for obsolete replay successes to preserve history and improve traceability.
> 
> - DiscoveryReplayRunner now archives non-improving singles (`archiveEntry`) instead of deleting them; defaults to `archiveSuccessByKeySync`
> - Adds `getObsoleteDir` and `archiveSuccessByKeySync` in `SuccessCache` to move entries to `.discovery/obsolete/{changeType}/{key}.json`
> - Updates and extends tests to validate archiving behavior and paths; existing expectations switched from delete → archive
> - README updated to document replay archiving behavior and directory structure
> - Version bump in `deno.json` from `0.285.1` to `0.285.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7a38703f3bc5321d7e95da9908650a72a118cd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->