### PR TITLE
Update version to 0.288.1 in deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.288.0",
+  "version": "0.288.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/methods/activations/aggregate/IF.ts
+++ b/src/methods/activations/aggregate/IF.ts
@@ -236,7 +236,11 @@ export class IF
       // intentionally avoids connecting from outputs, so a final output neuron may
       // never reach 3 inbound links. Rather than throwing (flaky initialisation),
       // deterministically downgrade to a standard squash.
-      neuron.squash = neuron.type === "output" ? "IDENTITY" : "TANH";
+      if (neuron.type === "output") {
+        neuron.squash = "IDENTITY";
+      } else {
+        neuron.squash = "TANH";
+      }
       return;
     }
 

--- a/test/NEAT/NeatConfigCoverage.ts
+++ b/test/NEAT/NeatConfigCoverage.ts
@@ -38,7 +38,9 @@ Deno.test("NEAT/NeatConfigCoverage - discoveryMinCandidatesPerCategory validatio
 Deno.test("NEAT/NeatConfigCoverage - discoveryRustFlushRecords validation (non-positive throws)", () => {
   try {
     createNeatConfig({ discoveryRustFlushRecords: 0 });
-    fail("Expected createNeatConfig() to throw for non-positive discoveryRustFlushRecords");
+    fail(
+      "Expected createNeatConfig() to throw for non-positive discoveryRustFlushRecords",
+    );
   } catch (e) {
     assertEquals(
       (e as Error).message.includes("Discovery Rust Flush Records"),
@@ -53,7 +55,9 @@ Deno.test("NEAT/NeatConfigCoverage - discoveryFocusNeuronUUIDs must be an array"
     createNeatConfig({
       discoveryFocusNeuronUUIDs: (123 as unknown as string[]),
     });
-    fail("Expected createNeatConfig() to throw for non-array discoveryFocusNeuronUUIDs");
+    fail(
+      "Expected createNeatConfig() to throw for non-array discoveryFocusNeuronUUIDs",
+    );
   } catch (e) {
     assertEquals(
       // The failure can occur during defaulting (spread) before validation,
@@ -70,7 +74,9 @@ Deno.test("NEAT/NeatConfigCoverage - discoveryFocusNeuronUUIDs entries must be n
     createNeatConfig({
       discoveryFocusNeuronUUIDs: [""],
     });
-    fail("Expected createNeatConfig() to throw for empty discoveryFocusNeuronUUIDs entry");
+    fail(
+      "Expected createNeatConfig() to throw for empty discoveryFocusNeuronUUIDs entry",
+    );
   } catch (e) {
     assertEquals(
       (e as Error).message.includes("non-empty strings"),
@@ -93,5 +99,3 @@ Deno.test("NEAT/NeatConfigCoverage - discoveryReplayConcurrency default path whe
   assertEquals(config.discoveryReplayVerifyScores, true);
   assertEquals(config.discoveryReplayConcurrency >= 1, true);
 });
-
-

--- a/test/NEAT/NeatConfigCoverage.ts
+++ b/test/NEAT/NeatConfigCoverage.ts
@@ -1,0 +1,97 @@
+import { assertEquals, fail } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+
+Deno.test("NEAT/NeatConfigCoverage - discoveryMinCandidatesPerCategory validation (negative addSynapses)", () => {
+  try {
+    createNeatConfig({
+      discoveryMinCandidatesPerCategory: {
+        addSynapses: -1,
+      },
+    });
+    fail("Expected createNeatConfig() to throw for negative addSynapses");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes("addSynapses"),
+      true,
+      `Error should mention addSynapses: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NEAT/NeatConfigCoverage - discoveryMinCandidatesPerCategory validation (negative changeSquash)", () => {
+  try {
+    createNeatConfig({
+      discoveryMinCandidatesPerCategory: {
+        changeSquash: -1,
+      },
+    });
+    fail("Expected createNeatConfig() to throw for negative changeSquash");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes("changeSquash"),
+      true,
+      `Error should mention changeSquash: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NEAT/NeatConfigCoverage - discoveryRustFlushRecords validation (non-positive throws)", () => {
+  try {
+    createNeatConfig({ discoveryRustFlushRecords: 0 });
+    fail("Expected createNeatConfig() to throw for non-positive discoveryRustFlushRecords");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes("Discovery Rust Flush Records"),
+      true,
+      `Error should mention the field name: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NEAT/NeatConfigCoverage - discoveryFocusNeuronUUIDs must be an array", () => {
+  try {
+    createNeatConfig({
+      discoveryFocusNeuronUUIDs: (123 as unknown as string[]),
+    });
+    fail("Expected createNeatConfig() to throw for non-array discoveryFocusNeuronUUIDs");
+  } catch (e) {
+    assertEquals(
+      // The failure can occur during defaulting (spread) before validation,
+      // so the message is implementation-dependent (eg. "is not iterable").
+      (e as Error).message.length > 0,
+      true,
+      `Error should mention discoveryFocusNeuronUUIDs: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NEAT/NeatConfigCoverage - discoveryFocusNeuronUUIDs entries must be non-empty", () => {
+  try {
+    createNeatConfig({
+      discoveryFocusNeuronUUIDs: [""],
+    });
+    fail("Expected createNeatConfig() to throw for empty discoveryFocusNeuronUUIDs entry");
+  } catch (e) {
+    assertEquals(
+      (e as Error).message.includes("non-empty strings"),
+      true,
+      `Error should mention non-empty strings: ${(e as Error).message}`,
+    );
+  }
+});
+
+Deno.test("NEAT/NeatConfigCoverage - discoveryReplayConcurrency coerces non-positive to 1", () => {
+  const config = createNeatConfig({ discoveryReplayConcurrency: 0 });
+  assertEquals(config.discoveryReplayConcurrency, 1);
+});
+
+Deno.test("NEAT/NeatConfigCoverage - discoveryReplayConcurrency default path when verify enabled", () => {
+  // This is a lightweight smoke check to execute the defaulting logic.
+  const config = createNeatConfig({
+    discoveryReplayVerifyScores: true,
+  });
+  assertEquals(config.discoveryReplayVerifyScores, true);
+  assertEquals(config.discoveryReplayConcurrency >= 1, true);
+});
+
+

--- a/test/fix/IFDowngradeDuringFix.ts
+++ b/test/fix/IFDowngradeDuringFix.ts
@@ -1,32 +1,20 @@
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
-import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { IF } from "../../src/methods/activations/aggregate/IF.ts";
 
 Deno.test("fix/IFDowngradeDuringFix - IF.fix should downgrade when 3rd inbound cannot be created", () => {
-  // Arrange: create a valid tiny creature, then force an output neuron squash to IF
-  // so `Creature.fix()` must run IF.fix(). With output=2, makeRandomConnection()
-  // cannot source from other outputs, so only two inputs are eligible and the 3rd
-  // inbound link is impossible.
-  const json: CreatureExport = {
-    neurons: [
-      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
-      { type: "output", uuid: "output-1", squash: "IDENTITY", bias: 0 },
-    ],
-    synapses: [
-      { fromUUID: "input-0", toUUID: "output-1", weight: 0.5 },
-      { fromUUID: "input-1", toUUID: "output-1", weight: -0.25 },
-    ],
-    input: 2,
-    output: 2,
-  };
-
-  const creature = Creature.fromJSON(json);
+  // Arrange: in a tiny 2->2 creature, each output has exactly 2 inbound connections
+  // (from the 2 inputs). IF requires 3 (condition/positive/negative), but
+  // `makeRandomConnection()` intentionally avoids sourcing from outputs, so a 3rd
+  // inbound connection for an output neuron is impossible here.
+  const creature = new Creature(2, 2);
   const target = creature.neurons.find((n) => n.uuid === "output-1");
-  if (!target) throw new Error("Expected output-1 neuron to exist");
+  assert(target, "Expected output-1 neuron to exist");
+  assertEquals(creature.inwardConnections(target.index).length, 2);
 
-  // Force the problematic squash, then repair.
+  // Force the problematic squash, then run the IF repair directly.
   target.squash = "IF";
-  creature.fix();
+  new IF().fix(target);
 
   // Assert: IF should be downgraded deterministically for outputs.
   assertEquals(target.squash, "IDENTITY");

--- a/test/fix/IFDowngradeDuringFix.ts
+++ b/test/fix/IFDowngradeDuringFix.ts
@@ -32,5 +32,3 @@ Deno.test("fix/IFDowngradeDuringFix - IF.fix should downgrade when 3rd inbound c
   assertEquals(target.squash, "IDENTITY");
   creature.validate();
 });
-
-

--- a/test/fix/IFDowngradeDuringFix.ts
+++ b/test/fix/IFDowngradeDuringFix.ts
@@ -14,9 +14,46 @@ Deno.test("fix/IFDowngradeDuringFix - IF.fix should downgrade when 3rd inbound c
 
   // Force the problematic squash, then run the IF repair directly.
   target.squash = "IF";
-  new IF().fix(target);
+  const originalMutate = target.mutate.bind(target);
+  // Defensive: if IF.fix falls through to mutate(), this test should fail.
+  // We want to specifically exercise the downgrade path.
+  (target as unknown as { mutate: (name: string) => boolean }).mutate = () => {
+    throw new Error("Unexpected mutate() during IF.fix downgrade path");
+  };
+  try {
+    new IF().fix(target);
+  } finally {
+    (target as unknown as { mutate: (name: string) => boolean }).mutate =
+      originalMutate;
+  }
 
   // Assert: IF should be downgraded deterministically for outputs.
   assertEquals(target.squash, "IDENTITY");
   creature.validate();
+});
+
+Deno.test("fix/IFDowngradeDuringFix - IF.fix downgrades non-output neurons to TANH in the same edge case", () => {
+  // This test intentionally constructs an *invalid* creature state (by changing an
+  // output neuron to type 'hidden') purely to exercise the non-output downgrade
+  // branch for coverage. We do not call creature.validate() here.
+  const creature = new Creature(2, 2);
+  const target = creature.neurons.find((n) => n.uuid === "output-1");
+  assert(target, "Expected output-1 neuron to exist");
+  assertEquals(creature.inwardConnections(target.index).length, 2);
+
+  (target as unknown as { type: string }).type = "hidden";
+  target.squash = "IF";
+
+  const originalMutate = target.mutate.bind(target);
+  (target as unknown as { mutate: (name: string) => boolean }).mutate = () => {
+    throw new Error("Unexpected mutate() during IF.fix downgrade path");
+  };
+  try {
+    new IF().fix(target);
+  } finally {
+    (target as unknown as { mutate: (name: string) => boolean }).mutate =
+      originalMutate;
+  }
+
+  assertEquals(target.squash, "TANH");
 });

--- a/test/fix/IFDowngradeDuringFix.ts
+++ b/test/fix/IFDowngradeDuringFix.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+
+Deno.test("fix/IFDowngradeDuringFix - IF.fix should downgrade when 3rd inbound cannot be created", () => {
+  // Arrange: create a valid tiny creature, then force an output neuron squash to IF
+  // so `Creature.fix()` must run IF.fix(). With output=2, makeRandomConnection()
+  // cannot source from other outputs, so only two inputs are eligible and the 3rd
+  // inbound link is impossible.
+  const json: CreatureExport = {
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-1", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-1", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "output-1", weight: -0.25 },
+    ],
+    input: 2,
+    output: 2,
+  };
+
+  const creature = Creature.fromJSON(json);
+  const target = creature.neurons.find((n) => n.uuid === "output-1");
+  if (!target) throw new Error("Expected output-1 neuron to exist");
+
+  // Force the problematic squash, then repair.
+  target.squash = "IF";
+  creature.fix();
+
+  // Assert: IF should be downgraded deterministically for outputs.
+  assertEquals(target.squash, "IDENTITY");
+  creature.validate();
+});
+
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Add tests**: `test/NEAT/NeatConfigCoverage.ts` validates error paths and defaults for `createNeatConfig` (negative values, array validation, replay concurrency coercion/verification).
> - **Add tests**: `test/fix/IFDowngradeDuringFix.ts` verifies `IF.fix` deterministically downgrades to `IDENTITY` for outputs and `TANH` for non-outputs when 3 inbound links aren't possible.
> - **Refactor (minor)**: Replace ternary with explicit branch in `IF.fix` downgrade path in `src/methods/activations/aggregate/IF.ts` (no behavior change).
> - **Chore**: Bump `deno.json` version to `0.288.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daac7732dc982ede3e5c55407cf54f9e85546718. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->