### PR TITLE
Update version to 0.290.0 in deno.json and enhance synapse handling i…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.289.1",
+  "version": "0.290.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -63,10 +63,34 @@ export function applyCoordinatedStructuralCandidate(
     return creature;
   }
 
+  // Track removed synapses so a later addSynapse can preserve metadata (type/tags)
+  // when a Rust candidate performs a weight adjustment via remove+add.
+  const removedSynapseMeta = new Map<
+    string,
+    {
+      type?: "positive" | "negative" | "condition";
+      tags?: Array<{ name: string; value: string }>;
+    }
+  >();
+
+  const edgeKey = (fromUUID: string, toUUID: string): string =>
+    `${fromUUID}→${toUUID}`;
+
   for (const op of ops) {
     if (!op || typeof op.type !== "string") continue;
 
     if (op.type === "removeSynapse") {
+      const existing = next.synapses.find((s) =>
+        s.fromUUID === op.fromNeuronUuid && s.toUUID === op.toNeuronUuid
+      );
+      if (existing) {
+        removedSynapseMeta.set(edgeKey(op.fromNeuronUuid, op.toNeuronUuid), {
+          type: existing.type,
+          tags: existing.tags
+            ? existing.tags.map((t) => ({ ...t }))
+            : undefined,
+        });
+      }
       const before = next.synapses.length;
       next.synapses = next.synapses.filter((s) =>
         !(s.fromUUID === op.fromNeuronUuid && s.toUUID === op.toNeuronUuid)
@@ -106,10 +130,15 @@ export function applyCoordinatedStructuralCandidate(
       if (existing) {
         existing.weight = op.weight;
       } else {
+        const meta = removedSynapseMeta.get(
+          edgeKey(op.fromNeuronUuid, op.toNeuronUuid),
+        );
         next.synapses.push({
           fromUUID: op.fromNeuronUuid,
           toUUID: op.toNeuronUuid,
           weight: op.weight,
+          type: meta?.type,
+          tags: meta?.tags ? meta.tags.map((t) => ({ ...t })) : undefined,
         });
       }
       continue;

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -262,6 +262,15 @@ function isSynapsePresent(
   );
 }
 
+function nearlyEqual(a: number, b: number): boolean {
+  if (a === b) return true;
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+  const diff = Math.abs(a - b);
+  if (diff <= 1e-12) return true;
+  const scale = Math.max(1, Math.abs(a), Math.abs(b));
+  return diff <= 1e-7 * scale;
+}
+
 function isAlreadyApplied(
   creature: Creature,
   entry: SuccessCacheEntry,
@@ -312,9 +321,61 @@ function isAlreadyApplied(
 
   // Coordinated structural candidates are multi-op groups and may not be
   // trivially “already applied” (eg remove/remove/add sequences).
-  // We conservatively re-evaluate them when present in the cache.
+  // We treat them as already applied only when we can verify every operation.
   if (type === "coordinated-structural") {
-    return false;
+    const spec = req.coordinatedStructuralCandidate as
+      | CoordinatedStructuralCandidate
+      | undefined;
+    const ops = spec?.operations;
+    if (!Array.isArray(ops) || ops.length === 0) return false;
+
+    // Reduce the ordered operation list into a final expected state per edge.
+    // This handles weight adjustments that Rust expresses as remove+add on the
+    // same synapse: the last op wins.
+    const expectedByEdge = new Map<
+      string,
+      { present: boolean; weight?: number }
+    >();
+    const edgeKey = (fromUUID: string, toUUID: string): string =>
+      `${fromUUID}\0${toUUID}`;
+
+    for (const op of ops) {
+      if (!op || typeof op.type !== "string") return false;
+      if (op.type === "removeSynapse") {
+        expectedByEdge.set(edgeKey(op.fromNeuronUuid, op.toNeuronUuid), {
+          present: false,
+        });
+        continue;
+      }
+      if (op.type === "addSynapse") {
+        expectedByEdge.set(edgeKey(op.fromNeuronUuid, op.toNeuronUuid), {
+          present: true,
+          weight: op.weight,
+        });
+        continue;
+      }
+      // Unknown op: do not assume applied.
+      return false;
+    }
+
+    const exported = creature.exportJSON();
+    for (const [key, expected] of expectedByEdge.entries()) {
+      const [fromUUID, toUUID] = key.split("\0");
+      const synapse = exported.synapses.find((s) =>
+        s.fromUUID === fromUUID && s.toUUID === toUUID
+      );
+
+      if (!expected.present) {
+        if (synapse) return false;
+        continue;
+      }
+
+      if (!synapse) return false;
+      if (expected.weight === undefined) return false;
+      if (!nearlyEqual(synapse.weight, expected.weight)) return false;
+    }
+
+    return true;
   }
 
   if (type === "add-neurons") {

--- a/test/discovery/CoordinatedStructuralCandidatePreserveSynapseMetadata.ts
+++ b/test/discovery/CoordinatedStructuralCandidatePreserveSynapseMetadata.ts
@@ -1,0 +1,58 @@
+import { assertEquals, assertExists } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import type { CoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
+import { applyCoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test(
+  "applyCoordinatedStructuralCandidate: remove+add preserves synapse type/tags when adjusting weight",
+  () => {
+    const base: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        {
+          fromUUID: "input-0",
+          toUUID: "output-0",
+          weight: 0.01,
+          type: "condition",
+          tags: [{ name: "original", value: "yes" }],
+        },
+      ],
+    };
+    const creature = Creature.fromJSON(base);
+
+    const candidate: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.001,
+      operations: [
+        {
+          type: "removeSynapse",
+          fromNeuronUuid: "input-0",
+          toNeuronUuid: "output-0",
+        },
+        {
+          type: "addSynapse",
+          fromNeuronUuid: "input-0",
+          toNeuronUuid: "output-0",
+          weight: 0.02,
+        },
+      ],
+    };
+
+    const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+    const exported = mutated.exportJSON();
+    const synapse = exported.synapses.find((s) =>
+      s.fromUUID === "input-0" && s.toUUID === "output-0"
+    );
+    assertExists(synapse);
+    assertEquals(synapse.weight, 0.02);
+    assertEquals(synapse.type, "condition");
+    assertEquals(synapse.tags, [{ name: "original", value: "yes" }]);
+  },
+);

--- a/test/discovery/DiscoveryReplayRunnerAlreadyAppliedCoordinatedStructural.ts
+++ b/test/discovery/DiscoveryReplayRunnerAlreadyAppliedCoordinatedStructural.ts
@@ -1,0 +1,88 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { DiscoveryReplayRunner } from "../../src/discovery/DiscoveryReplayRunner.ts";
+import type { SuccessCacheEntry } from "../../src/discovery/SuccessCache.ts";
+
+Deno.test(
+  "DiscoveryReplayRunner skips coordinated-structural entries that already appear applied",
+  async () => {
+    const baseExport: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        // Already at the post-candidate weight.
+        { fromUUID: "input-0", toUUID: "output-0", weight: 0.02 },
+      ],
+    };
+    const base = Creature.fromJSON(baseExport);
+    base.uuid = "base";
+
+    const coordinatedEntry: SuccessCacheEntry = {
+      key: "coordinated-structural_deadbeef",
+      changeType: "coordinated-structural",
+      originalScore: 0.5,
+      candidateScore: 0.6,
+      scoreDelta: 0.1,
+      error: 0.4,
+      originalError: 0.5,
+      timestamp: new Date().toISOString(),
+      rustRequest: {
+        coordinatedStructuralCandidate: {
+          operations: [
+            {
+              type: "removeSynapse",
+              fromNeuronUuid: "input-0",
+              toNeuronUuid: "output-0",
+            },
+            {
+              type: "addSynapse",
+              fromNeuronUuid: "input-0",
+              toNeuronUuid: "output-0",
+              weight: 0.02,
+            },
+          ],
+          expectedCreatureScoreGain: 0.001,
+        },
+      },
+    };
+
+    const runner = new DiscoveryReplayRunner({
+      listEntries: (_dir) => [coordinatedEntry],
+      // Fail fast if we accidentally try to apply/evaluate.
+      applyEntry: () => {
+        throw new Error("applyEntry should not be called for already-applied");
+      },
+      evaluateError: (creature) => {
+        // Replay always evaluates the baseline creature once.
+        if (creature.uuid === "base") {
+          return Promise.resolve({ error: 0, score: 0.5 });
+        }
+        throw new Error(
+          "evaluateError should not be called for already-applied candidate creatures",
+        );
+      },
+    });
+
+    const result = await runner.replayDir({
+      creature: base,
+      dataDir: "/tmp/does-not-matter",
+      options: {
+        discoverySuccessCacheDir: "/tmp/does-not-matter",
+        costOfGrowth: 0,
+        discoveryReplayMaxSingles: 10,
+        discoveryReplayMaxPairwise: 10,
+        discoveryReplayMaxTriples: 10,
+        threads: 1,
+      },
+    });
+
+    assertEquals(result.skippedAlreadyApplied, 1);
+    assertEquals(result.evaluatedSingles, 0);
+  },
+);


### PR DESCRIPTION
…n ApplyCoordinatedStructuralCandidate

- Bumped version in deno.json to 0.290.0.
- Added functionality to track removed synapses and preserve their metadata during weight adjustments in ApplyCoordinatedStructuralCandidate.
- Introduced a nearlyEqual function in DiscoveryReplayRunner to improve floating-point comparison for synapse weights.

These changes enhance the structural evolution process and improve the accuracy of synapse management within the NEAT framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances coordinated structural evolution and replay correctness.
> 
> - In `ApplyCoordinatedStructuralCandidate`, track removed synapses to preserve `type`/`tags` on subsequent `addSynapse` (weight-adjust via remove+add); respects forward-only constraints
> - In `DiscoveryReplayRunner`, add `nearlyEqual` and a stricter `isAlreadyApplied` for `coordinated-structural` by reducing ops to expected per-edge presence/weight and verifying against exported synapses; skips redundant entries
> - Add tests: `CoordinatedStructuralCandidatePreserveSynapseMetadata.ts` and `DiscoveryReplayRunnerAlreadyAppliedCoordinatedStructural.ts`
> - Bump `deno.json` version to `0.290.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd8a02fa3ea83eeb434ced7ab408aab535281eb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->