### PR TITLE
Update version to 0.290.1 in deno.json and enhance cache key generati…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.290.0",
+  "version": "0.290.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -178,8 +178,38 @@ export function buildCacheKey(candidate: DiscoveryCandidate): string {
     case "coordinated-structural": {
       const spec = candidate.change.coordinatedStructuralCandidate;
       if (spec?.operations && Array.isArray(spec.operations)) {
-        const opKey = `coordinated:` +
-          spec.operations.map((op) => JSON.stringify(op)).join("|");
+        // Coordinated structural candidates frequently represent "adjust weight"
+        // operations as remove+add on the same synapse. We intentionally bucket
+        // addSynapse weights by exponent so keys remain stable under normal
+        // evolutionary weight drift and do not explode the cache with near
+        // duplicates.
+        const opKey = `coordinated:` + spec.operations.map((op) => {
+          if (!op || typeof op !== "object") return JSON.stringify(op);
+          const t = (op as { type?: string }).type;
+          if (t === "removeSynapse") {
+            const o = op as {
+              fromNeuronUuid?: string;
+              toNeuronUuid?: string;
+            };
+            return `removeSynapse:${o.fromNeuronUuid ?? "?"}->${
+              o.toNeuronUuid ?? "?"
+            }`;
+          }
+          if (t === "addSynapse") {
+            const o = op as {
+              fromNeuronUuid?: string;
+              toNeuronUuid?: string;
+              weight?: number;
+            };
+            const w = typeof o.weight === "number"
+              ? formatWeight(o.weight)
+              : "?";
+            return `addSynapse:${o.fromNeuronUuid ?? "?"}->${
+              o.toNeuronUuid ?? "?"
+            }:w${w}`;
+          }
+          return JSON.stringify(op);
+        }).join("|");
         parts.push(stableShortHash(opKey));
       } else {
         parts.push(buildStructuralSignature(candidate));

--- a/test/discovery/FailureCacheCoordinatedStructuralKeyBucketing.ts
+++ b/test/discovery/FailureCacheCoordinatedStructuralKeyBucketing.ts
@@ -1,0 +1,109 @@
+import { assert } from "@std/assert";
+import { assertEquals } from "@std/assert/equals";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import type { CoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
+import { Creature } from "../../src/Creature.ts";
+import type { DiscoveryCandidate } from "../../src/discovery/DiscoveryCandidates.ts";
+import { buildCacheKey } from "../../src/discovery/FailureCache.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+function makeCreature(): Creature {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.01 }],
+  };
+  return Creature.fromJSON(base);
+}
+
+Deno.test(
+  "buildCacheKey: coordinated-structural buckets addSynapse weight by exponent (stable under normal training drift)",
+  () => {
+    const creature = makeCreature();
+
+    const specA: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.01,
+      operations: [
+        {
+          type: "removeSynapse",
+          fromNeuronUuid: "input-0",
+          toNeuronUuid: "output-0",
+        },
+        {
+          type: "addSynapse",
+          fromNeuronUuid: "input-0",
+          toNeuronUuid: "output-0",
+          weight: 0.07451205, // e-2
+        },
+      ],
+    };
+
+    const specA2: CoordinatedStructuralCandidate = {
+      ...specA,
+      operations: [
+        specA.operations[0],
+        {
+          type: "addSynapse",
+          fromNeuronUuid: "input-0",
+          toNeuronUuid: "output-0",
+          weight: 0.0999, // also e-2
+        },
+      ],
+    };
+
+    const specB: CoordinatedStructuralCandidate = {
+      ...specA,
+      operations: [
+        specA.operations[0],
+        {
+          type: "addSynapse",
+          fromNeuronUuid: "input-0",
+          toNeuronUuid: "output-0",
+          weight: 0.1001, // e-1
+        },
+      ],
+    };
+
+    const candidateA: DiscoveryCandidate = {
+      creature,
+      change: {
+        type: "coordinated-structural",
+        coordinatedStructuralCandidate: specA,
+      },
+    };
+    const candidateA2: DiscoveryCandidate = {
+      creature,
+      change: {
+        type: "coordinated-structural",
+        coordinatedStructuralCandidate: specA2,
+      },
+    };
+    const candidateB: DiscoveryCandidate = {
+      creature,
+      change: {
+        type: "coordinated-structural",
+        coordinatedStructuralCandidate: specB,
+      },
+    };
+
+    const keyA = buildCacheKey(candidateA);
+    const keyA2 = buildCacheKey(candidateA2);
+    const keyB = buildCacheKey(candidateB);
+
+    assert(keyA.includes("coordinated-structural"));
+    assertEquals(
+      keyA,
+      keyA2,
+      "Expected coordinated-structural key to ignore exact float differences within same exponent",
+    );
+    assert(
+      keyA !== keyB,
+      "Expected coordinated-structural key to differ when weight exponent differs",
+    );
+  },
+);


### PR DESCRIPTION
…on for coordinated structural candidates in FailureCache.ts

- Bumped version in deno.json to 0.290.1.
- Improved cache key generation logic in FailureCache.ts to better handle "removeSynapse" and "addSynapse" operations, ensuring stability under weight drift and reducing cache duplication.

These changes enhance the performance and reliability of the NEAT framework's candidate evaluation process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves determinism and de-duplication of failure cache entries for coordinated structural candidates.
> 
> - In `buildCacheKey` for `coordinated-structural`, normalize ops: map `removeSynapse` to `from->to` and bucket `addSynapse` weights by exponent via `formatWeight`, then hash (`stableShortHash`) of the normalized op string
> - Fallback remains structural signature when no ops present
> - Adds `FailureCacheCoordinatedStructuralKeyBucketing.ts` test to ensure keys are stable within the same weight exponent and differ across exponents
> - Bumps `deno.json` version to `0.290.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b52802fe50fc5d00b06260bb78b5ae4137796ef6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->