### PR TITLE
Update version to 0.290.2 in deno.json and refine neuron calculation …

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.290.1",
+  "version": "0.290.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -346,8 +346,8 @@ export function compactCreature(
     delete compactCreature.memetic;
     removeTag(compactCreature, "approach-logged");
 
-    const oldNeurons = startExport.neurons.length -
-      startExport.input - startExport.output;
+    /** CreatureExport.neurons excludes inputs as the export does not include them.*/
+    const oldNeurons = startExport.neurons.length - startExport.output;
     addTag(compactCreature, "old-neurons", oldNeurons.toString());
 
     // Preserve forwardOnly semantics from source creature

--- a/src/compact/CompactUnused.ts
+++ b/src/compact/CompactUnused.ts
@@ -100,6 +100,8 @@ export function compactUnused(
     addTag(compacted, "approach", "compact" as Approach);
     delete compacted.memetic;
     removeTag(compacted, "approach-logged");
+    
+    /** Creature DOES have inputs, so we need to subtract them. */
     const oldNeurons = clean.neurons.length - clean.input - clean.output;
     addTag(compacted, "old-neurons", oldNeurons.toString());
     addTag(

--- a/src/compact/CompactUnused.ts
+++ b/src/compact/CompactUnused.ts
@@ -100,7 +100,7 @@ export function compactUnused(
     addTag(compacted, "approach", "compact" as Approach);
     delete compacted.memetic;
     removeTag(compacted, "approach-logged");
-    
+
     /** Creature DOES have inputs, so we need to subtract them. */
     const oldNeurons = clean.neurons.length - clean.input - clean.output;
     addTag(compacted, "old-neurons", oldNeurons.toString());


### PR DESCRIPTION
…logic in CompactCreature and CompactUnused modules. Adjusted comments for clarity regarding neuron exclusions in exports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts neuron-count tagging logic and clarifies input handling.
> 
> - Corrects `old-neurons` calculation in `CompactCreature` to subtract only `output` since `CreatureExport.neurons` excludes inputs
> - Adds clarifying comment in `CompactUnused` that full `Creature` includes inputs, so continue subtracting both `input` and `output`
> - Updates package version to `0.290.2` in `deno.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5c770b5ed746f3697842e29162e83711f3d0ec6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->