### PR TITLE
V0.291.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.290.2",
+  "version": "0.291.0",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -111,6 +111,13 @@ export function applyCoordinatedStructuralCandidate(
           next.neurons.splice(beforeIdx, 0, newNeuron);
           continue;
         }
+
+        // `insertBeforeNeuronUuid` is an explicit ordering intent. If the target
+        // neuron is missing and this creature is forward-only, appending would
+        // violate layer ordering (hidden after output). Treat as a no-op instead.
+        if (next.forwardOnly === true) {
+          continue;
+        }
       }
 
       // Default: append at the end (safe for non-forward-only creatures).

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -79,6 +79,82 @@ export function applyCoordinatedStructuralCandidate(
   for (const op of ops) {
     if (!op || typeof op.type !== "string") continue;
 
+    if (op.type === "addNeuron") {
+      // Ensure deterministic idempotency: if neuron already exists, update fields.
+      const existingIndex = next.neurons.findIndex((n) =>
+        n.uuid === op.neuronUuid
+      );
+      if (existingIndex >= 0) {
+        // Some exports treat neuron entries as readonly, so replace the object.
+        next.neurons[existingIndex] = {
+          ...next.neurons[existingIndex],
+          uuid: op.neuronUuid,
+          type: op.neuronType,
+          squash: op.squash,
+          bias: op.bias,
+        };
+        continue;
+      }
+
+      const newNeuron = {
+        uuid: op.neuronUuid,
+        type: op.neuronType,
+        squash: op.squash,
+        bias: op.bias,
+      };
+
+      if (typeof op.insertBeforeNeuronUuid === "string") {
+        const beforeIdx = next.neurons.findIndex((n) =>
+          n.uuid === op.insertBeforeNeuronUuid
+        );
+        if (beforeIdx >= 0) {
+          next.neurons.splice(beforeIdx, 0, newNeuron);
+          continue;
+        }
+      }
+
+      // Default: append at the end (safe for non-forward-only creatures).
+      next.neurons.push(newNeuron);
+      continue;
+    }
+
+    if (op.type === "removeNeuron") {
+      const uuid = op.neuronUuid;
+      const beforeNeuronCount = next.neurons.length;
+      next.neurons = next.neurons.filter((n) => n.uuid !== uuid);
+      if (next.neurons.length === beforeNeuronCount) {
+        // No-op if neuron didn't exist (idempotent).
+        continue;
+      }
+
+      // Remove any synapses that reference the neuron, and clean up memetic state.
+      const removedEdges: Array<{ fromUUID: string; toUUID: string }> = [];
+      for (const s of next.synapses) {
+        if (s.fromUUID === uuid || s.toUUID === uuid) {
+          removedEdges.push({ fromUUID: s.fromUUID, toUUID: s.toUUID });
+        }
+      }
+      next.synapses = next.synapses.filter((s) =>
+        !(s.fromUUID === uuid || s.toUUID === uuid)
+      );
+      for (const e of removedEdges) {
+        cleanupMemeticForRemovedSynapse(next, e.fromUUID, e.toUUID);
+      }
+      continue;
+    }
+
+    if (op.type === "changeSquash") {
+      const n = next.neurons.find((x) => x.uuid === op.neuronUuid);
+      if (n) n.squash = op.squash;
+      continue;
+    }
+
+    if (op.type === "setBias") {
+      const n = next.neurons.find((x) => x.uuid === op.neuronUuid);
+      if (n) n.bias = op.bias;
+      continue;
+    }
+
     if (op.type === "removeSynapse") {
       const existing = next.synapses.find((s) =>
         s.fromUUID === op.fromNeuronUuid && s.toUUID === op.toNeuronUuid

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -1,7 +1,10 @@
 import type { CreatureExport } from "../CreatureInterfaces.ts";
 import { CreatureUtil } from "../CreatureUtils.ts";
 import { Creature } from "../../Creature.ts";
-import { cleanupMemeticForRemovedSynapse } from "../../compact/CompactUtils.ts";
+import {
+  cleanupMemeticForRemovedNeuron,
+  cleanupMemeticForRemovedSynapse,
+} from "../../compact/CompactUtils.ts";
 import type {
   CoordinatedStructuralCandidate,
   CoordinatedStructuralOperation,
@@ -120,8 +123,20 @@ export function applyCoordinatedStructuralCandidate(
         }
       }
 
-      // Default: append at the end (safe for non-forward-only creatures).
-      next.neurons.push(newNeuron);
+      // Default placement must preserve the invariant that hidden neurons appear
+      // before output neurons (even when recurrent connections are allowed).
+      if (op.neuronType === "hidden") {
+        const firstOutputIdx = next.neurons.findIndex((n) =>
+          n.type === "output"
+        );
+        if (firstOutputIdx >= 0) {
+          next.neurons.splice(firstOutputIdx, 0, newNeuron);
+        } else {
+          next.neurons.push(newNeuron);
+        }
+      } else {
+        next.neurons.push(newNeuron);
+      }
       continue;
     }
 
@@ -147,6 +162,7 @@ export function applyCoordinatedStructuralCandidate(
       for (const e of removedEdges) {
         cleanupMemeticForRemovedSynapse(next, e.fromUUID, e.toUUID);
       }
+      cleanupMemeticForRemovedNeuron(next, uuid);
       continue;
     }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts
@@ -13,7 +13,11 @@
 
 export type CoordinatedStructuralOperation =
   | CoordinatedRemoveSynapseOperation
-  | CoordinatedAddSynapseOperation;
+  | CoordinatedAddSynapseOperation
+  | CoordinatedAddNeuronOperation
+  | CoordinatedRemoveNeuronOperation
+  | CoordinatedChangeSquashOperation
+  | CoordinatedSetBiasOperation;
 
 export interface CoordinatedRemoveSynapseOperation {
   type: "removeSynapse";
@@ -26,6 +30,41 @@ export interface CoordinatedAddSynapseOperation {
   fromNeuronUuid: string;
   toNeuronUuid: string;
   weight: number;
+}
+
+export interface CoordinatedAddNeuronOperation {
+  type: "addNeuron";
+  /** Deterministic UUID emitted by Rust so replays remain stable. */
+  neuronUuid: string;
+  /** Usually "hidden". Kept explicit to support future use-cases. */
+  neuronType: "hidden" | "output";
+  squash: string;
+  bias: number;
+  /**
+   * Optional placement hint for forward-only creatures.
+   *
+   * If set, the neuron will be inserted immediately before this neuron UUID in
+   * the `neurons[]` array so a subsequent `addSynapse(newNeuron -> target)` can
+   * satisfy forward-only ordering.
+   */
+  insertBeforeNeuronUuid?: string;
+}
+
+export interface CoordinatedRemoveNeuronOperation {
+  type: "removeNeuron";
+  neuronUuid: string;
+}
+
+export interface CoordinatedChangeSquashOperation {
+  type: "changeSquash";
+  neuronUuid: string;
+  squash: string;
+}
+
+export interface CoordinatedSetBiasOperation {
+  type: "setBias";
+  neuronUuid: string;
+  bias: number;
 }
 
 export interface CoordinatedStructuralCandidate {

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -208,6 +208,34 @@ export function buildCacheKey(candidate: DiscoveryCandidate): string {
               o.toNeuronUuid ?? "?"
             }:w${w}`;
           }
+          if (t === "addNeuron") {
+            const o = op as {
+              neuronUuid?: string;
+              neuronType?: string;
+              squash?: string;
+              bias?: number;
+              insertBeforeNeuronUuid?: string;
+            };
+            const b = typeof o.bias === "number" ? formatWeight(o.bias) : "?";
+            return `addNeuron:${o.neuronUuid ?? "?"}:type${
+              o.neuronType ?? "?"
+            }:s${o.squash ?? "?"}:b${b}:before${
+              o.insertBeforeNeuronUuid ?? "-"
+            }`;
+          }
+          if (t === "removeNeuron") {
+            const o = op as { neuronUuid?: string };
+            return `removeNeuron:${o.neuronUuid ?? "?"}`;
+          }
+          if (t === "changeSquash") {
+            const o = op as { neuronUuid?: string; squash?: string };
+            return `changeSquash:${o.neuronUuid ?? "?"}:s${o.squash ?? "?"}`;
+          }
+          if (t === "setBias") {
+            const o = op as { neuronUuid?: string; bias?: number };
+            const b = typeof o.bias === "number" ? formatWeight(o.bias) : "?";
+            return `setBias:${o.neuronUuid ?? "?"}:b${b}`;
+          }
           return JSON.stringify(op);
         }).join("|");
         parts.push(stableShortHash(opKey));

--- a/test/discovery/CoordinatedStructuralAddNeuronInsertBeforeMissing.ts
+++ b/test/discovery/CoordinatedStructuralAddNeuronInsertBeforeMissing.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import type { CoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
+import { applyCoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test(
+  "applyCoordinatedStructuralCandidate: addNeuron with missing insertBefore is a no-op for forward-only creatures",
+  () => {
+    const base: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.25 }],
+    };
+    const creature = Creature.fromJSON(base);
+
+    const candidate: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.01,
+      operations: [
+        {
+          type: "addNeuron",
+          neuronUuid: "hidden-should-not-exist",
+          neuronType: "hidden",
+          squash: IDENTITY.NAME,
+          bias: 0,
+          insertBeforeNeuronUuid: "does-not-exist",
+        },
+      ],
+    };
+
+    const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+    const exported = mutated.exportJSON();
+
+    assertEquals(
+      exported.neurons.some((n) => n.uuid === "hidden-should-not-exist"),
+      false,
+    );
+    assertEquals(exported.neurons.length, base.neurons.length);
+    assertEquals(exported.synapses.length, base.synapses.length);
+  },
+);

--- a/test/discovery/CoordinatedStructuralCandidate.ts
+++ b/test/discovery/CoordinatedStructuralCandidate.ts
@@ -220,3 +220,121 @@ Deno.test("applyCoordinatedStructuralCandidate: empty operations is a no-op retu
   const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
   assertEquals(mutated, creature);
 });
+
+Deno.test("applyCoordinatedStructuralCandidate: addNeuron can insert before a target so forward-only addSynapse is valid", () => {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.25 }],
+  };
+  const creature = Creature.fromJSON(base);
+
+  const candidate: CoordinatedStructuralCandidate = {
+    type: "coordinated_structural",
+    expectedCreatureScoreGain: 0.01,
+    operations: [
+      {
+        type: "removeSynapse",
+        fromNeuronUuid: "input-0",
+        toNeuronUuid: "output-0",
+      },
+      {
+        type: "addNeuron",
+        neuronUuid: "hidden-inserted",
+        neuronType: "hidden",
+        squash: IDENTITY.NAME,
+        bias: 0.0,
+        insertBeforeNeuronUuid: "output-0",
+      },
+      {
+        type: "addSynapse",
+        fromNeuronUuid: "input-0",
+        toNeuronUuid: "hidden-inserted",
+        weight: 1.0,
+      },
+      {
+        type: "addSynapse",
+        fromNeuronUuid: "hidden-inserted",
+        toNeuronUuid: "output-0",
+        weight: 0.5,
+      },
+    ],
+  };
+
+  const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+  const exported = mutated.exportJSON();
+
+  // Neuron should exist and appear before output-0 in forward-only ordering.
+  const idxHidden = exported.neurons.findIndex((n) =>
+    n.uuid === "hidden-inserted"
+  );
+  const idxOutput = exported.neurons.findIndex((n) => n.uuid === "output-0");
+  assertEquals(idxHidden >= 0, true);
+  assertEquals(idxOutput >= 0, true);
+  assertEquals(idxHidden < idxOutput, true);
+
+  // New synapses should exist.
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "input-0" && s.toUUID === "hidden-inserted" &&
+      s.weight === 1.0
+    ),
+    true,
+  );
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "hidden-inserted" && s.toUUID === "output-0" &&
+      s.weight === 0.5
+    ),
+    true,
+  );
+});
+
+Deno.test("applyCoordinatedStructuralCandidate: removeNeuron deletes neuron and any connected synapses", () => {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  const creature = Creature.fromJSON(base);
+
+  const candidate: CoordinatedStructuralCandidate = {
+    type: "coordinated_structural",
+    expectedCreatureScoreGain: 0.01,
+    operations: [
+      {
+        type: "removeNeuron",
+        neuronUuid: "hidden-0",
+      },
+    ],
+  };
+
+  const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+  const exported = mutated.exportJSON();
+
+  assertEquals(exported.neurons.some((n) => n.uuid === "hidden-0"), false);
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "input-0" && s.toUUID === "hidden-0"
+    ),
+    false,
+  );
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "hidden-0" && s.toUUID === "output-0"
+    ),
+    false,
+  );
+});

--- a/test/discovery/CoordinatedStructuralCandidateMoreOps.ts
+++ b/test/discovery/CoordinatedStructuralCandidateMoreOps.ts
@@ -1,0 +1,235 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import type { CoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
+import { applyCoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import { TANH } from "../../src/methods/activations/types/TANH.ts";
+
+Deno.test(
+  "applyCoordinatedStructuralCandidate: addNeuron updates an existing neuron (idempotent replay)",
+  () => {
+    const base: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+      ],
+    };
+    const creature = Creature.fromJSON(base);
+
+    const candidate: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.01,
+      operations: [
+        {
+          type: "addNeuron",
+          neuronUuid: "hidden-0",
+          neuronType: "hidden",
+          squash: TANH.NAME,
+          bias: 0.5,
+        },
+      ],
+    };
+
+    const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+    const exported = mutated.exportJSON();
+
+    const neuron = exported.neurons.find((n) => n.uuid === "hidden-0");
+    assertEquals(neuron?.squash, TANH.NAME);
+    assertEquals(neuron?.bias, 0.5);
+    assertEquals(exported.neurons.length, base.neurons.length);
+  },
+);
+
+Deno.test(
+  "applyCoordinatedStructuralCandidate: addNeuron with missing insertBefore inserts before outputs for non-forward-only creatures",
+  () => {
+    const base: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: false,
+      neurons: [
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.25 }],
+    };
+    const creature = Creature.fromJSON(base);
+
+    const candidate: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.01,
+      operations: [
+        {
+          type: "addNeuron",
+          neuronUuid: "hidden-appended",
+          neuronType: "hidden",
+          squash: IDENTITY.NAME,
+          bias: 0.0,
+          insertBeforeNeuronUuid: "does-not-exist",
+        },
+        // Keep the neuron alive: a lone hidden neuron will be removed by `fix()`.
+        {
+          type: "addSynapse",
+          fromNeuronUuid: "input-0",
+          toNeuronUuid: "hidden-appended",
+          weight: 1.0,
+        },
+        {
+          type: "addSynapse",
+          fromNeuronUuid: "hidden-appended",
+          toNeuronUuid: "output-0",
+          weight: 0.5,
+        },
+      ],
+    };
+
+    const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+    const exported = mutated.exportJSON();
+
+    assertEquals(exported.neurons.length, base.neurons.length + 1);
+    assertEquals(exported.neurons.at(0)?.uuid, "hidden-appended");
+    assertEquals(exported.neurons.at(1)?.uuid, "output-0");
+    assertEquals(
+      exported.synapses.some((s) =>
+        s.fromUUID === "input-0" && s.toUUID === "hidden-appended" &&
+        s.weight === 1.0
+      ),
+      true,
+    );
+    assertEquals(
+      exported.synapses.some((s) =>
+        s.fromUUID === "hidden-appended" && s.toUUID === "output-0" &&
+        s.weight === 0.5
+      ),
+      true,
+    );
+  },
+);
+
+Deno.test(
+  "applyCoordinatedStructuralCandidate: changeSquash updates existing neuron squash",
+  () => {
+    const base: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+      ],
+    };
+    const creature = Creature.fromJSON(base);
+
+    const candidate: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.01,
+      operations: [
+        {
+          type: "changeSquash",
+          neuronUuid: "hidden-0",
+          squash: TANH.NAME,
+        },
+      ],
+    };
+
+    const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+    const exported = mutated.exportJSON();
+
+    assertEquals(
+      exported.neurons.find((n) => n.uuid === "hidden-0")?.squash,
+      TANH.NAME,
+    );
+  },
+);
+
+Deno.test(
+  "applyCoordinatedStructuralCandidate: setBias updates existing neuron bias",
+  () => {
+    const base: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+      ],
+    };
+    const creature = Creature.fromJSON(base);
+
+    const candidate: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.01,
+      operations: [
+        {
+          type: "setBias",
+          neuronUuid: "hidden-0",
+          bias: -0.25,
+        },
+      ],
+    };
+
+    const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+    const exported = mutated.exportJSON();
+
+    assertEquals(
+      exported.neurons.find((n) => n.uuid === "hidden-0")?.bias,
+      -0.25,
+    );
+  },
+);
+
+Deno.test(
+  "applyCoordinatedStructuralCandidate: removeNeuron is a no-op when neuron is missing",
+  () => {
+    const base: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+      ],
+    };
+    const creature = Creature.fromJSON(base);
+
+    const candidate: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.01,
+      operations: [
+        {
+          type: "removeNeuron",
+          neuronUuid: "missing-neuron",
+        },
+      ],
+    };
+
+    const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+    const exported = mutated.exportJSON();
+
+    assertEquals(exported.neurons.length, base.neurons.length);
+    assertEquals(exported.synapses.length, base.synapses.length);
+    assertEquals(
+      exported.neurons.some((n) => n.uuid === "missing-neuron"),
+      false,
+    );
+  },
+);

--- a/test/discovery/CoordinatedStructuralRemoveNeuronMemeticCleanup.ts
+++ b/test/discovery/CoordinatedStructuralRemoveNeuronMemeticCleanup.ts
@@ -1,0 +1,58 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import type { CoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
+import { applyCoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test(
+  "applyCoordinatedStructuralCandidate: removeNeuron cleans memetic references to avoid MEMETIC validation errors",
+  () => {
+    const base: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      // Keep this at 3.x so we can detect accidental `fix({ forwardOnly: true })`
+      // calls (which bump to 4.0.0).
+      semanticVersion: "3.2.1",
+      neurons: [
+        { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+        // Preserve a valid topology after removal (output still has an inbound edge).
+        { fromUUID: "input-0", toUUID: "output-0", weight: 0.05 },
+      ],
+      memetic: {
+        generation: 1,
+        score: 0,
+        // Empty weights keeps this test focused on the missing neuron-level cleanup.
+        weights: {},
+        biases: {
+          "hidden-0": 0.1,
+        },
+      },
+    };
+    const creature = Creature.fromJSON(base);
+
+    const candidate: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.01,
+      operations: [
+        {
+          type: "removeNeuron",
+          neuronUuid: "hidden-0",
+        },
+      ],
+    };
+
+    const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+    const exported = mutated.exportJSON();
+
+    assertEquals(exported.neurons.some((n) => n.uuid === "hidden-0"), false);
+    assertEquals(exported.memetic, undefined);
+    assertEquals(exported.semanticVersion, "3.2.1");
+  },
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extends coordinated structural evolution with neuron-level operations and robust application semantics.
> 
> - Implements `addNeuron`, `removeNeuron`, `changeSquash`, and `setBias` in `applyCoordinatedStructuralCandidate` with idempotent updates, forward-only ordering (including `insertBeforeNeuronUuid`), and memetic cleanup via `cleanupMemeticForRemoved{Synapse,Neuron}`
> - Preserves/updates synapse metadata across remove+add cycles; validates/fixes creature post-ops
> - Expands `CoordinatedStructuralCandidate` types to include new ops
> - Updates `FailureCache` cache-key generation to encode new ops (including weight/bias exponent bucketing)
> - Adds focused tests covering insertion ordering, idempotent neuron update, neuron removal (and memetic cleanup), squash/bias changes, and forward-only constraints
> - Bumps package version to `0.291.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9e89b1163f50a40becabf1c20c61e7e2891d498. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->