### PR TITLE
Update version to 0.291.1 in deno.json and enhance documentation for …

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.291.0",
+  "version": "0.291.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/DiscoveryDir.md
+++ b/docs/DiscoveryDir.md
@@ -37,6 +37,36 @@ standard squashes including ReLU, GELU, ELU, SELU, Softplus, LOGISTIC (sigmoid),
 and TANH. There is no TypeScript fallback path; without the Rust module the
 discovery phase is skipped.
 
+## Coordinated-structural candidates (7-Jan-2026)
+
+Some structural improvements are **epistatic**: no single edit helps in
+isolation, but a _group_ of edits helps when applied together. These are
+returned as **coordinated-structural** candidates, which must be applied as a
+single ordered ablation then re-scored once on the full training set.
+
+NEAT-AI intentionally treats this as a **stable contract**: as NEAT-AI-Discovery
+(Rust) adds more sophisticated discoveries over time, TypeScript should not need
+new “discovery types”. It should only need to support the evolving **operation
+vocabulary** and apply the ordered list atomically.
+
+### Supported operation vocabulary
+
+- `removeSynapse(fromNeuronUuid,toNeuronUuid)`
+- `addSynapse(fromNeuronUuid,toNeuronUuid,weight)` (idempotent: updates weight
+  if the synapse already exists)
+- `addNeuron(neuronUuid,neuronType,squash,bias,insertBeforeNeuronUuid?)`
+- `removeNeuron(neuronUuid)` (also removes attached synapses)
+- `changeSquash(neuronUuid,squash)`
+- `setBias(neuronUuid,bias)`
+
+### Forward-only note
+
+For forward-only creatures, `addNeuron.insertBeforeNeuronUuid` allows Rust to
+specify neuron placement so subsequent `addSynapse(newNeuron -> target)`
+respects forward-only ordering. If placement is omitted, NEAT-AI appends the
+neuron, which is safe for recurrent creatures but may be rejected for
+forward-only.
+
 ## Data Layout Expectations
 
 Discovery operates on two directories that can be shared across nodes:

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -4,11 +4,43 @@ import { Creature } from "../../Creature.ts";
 import {
   cleanupMemeticForRemovedNeuron,
   cleanupMemeticForRemovedSynapse,
+  cleanupOrphanedNeurons,
 } from "../../compact/CompactUtils.ts";
 import type {
   CoordinatedStructuralCandidate,
   CoordinatedStructuralOperation,
 } from "./CoordinatedStructuralCandidate.ts";
+
+// Local operation shapes (kept small and structural so the editor stays happy even
+// if its module graph gets temporarily out-of-date). Deno `check` remains the
+// source-of-truth for type safety.
+type AddNeuronOp = {
+  type: "addNeuron";
+  neuronUuid: string;
+  neuronType: "hidden" | "output";
+  squash: string;
+  bias: number;
+  insertBeforeNeuronUuid?: string;
+};
+
+type RemoveNeuronOp = { type: "removeNeuron"; neuronUuid: string };
+type ChangeSquashOp = {
+  type: "changeSquash";
+  neuronUuid: string;
+  squash: string;
+};
+type SetBiasOp = { type: "setBias"; neuronUuid: string; bias: number };
+type RemoveSynapseOp = {
+  type: "removeSynapse";
+  fromNeuronUuid: string;
+  toNeuronUuid: string;
+};
+type AddSynapseOp = {
+  type: "addSynapse";
+  fromNeuronUuid: string;
+  toNeuronUuid: string;
+  weight: number;
+};
 
 function buildUuidToIndexMap(creature: CreatureExport): Map<string, number> {
   const uuidToIndex = new Map<string, number>();
@@ -82,33 +114,34 @@ export function applyCoordinatedStructuralCandidate(
   for (const op of ops) {
     if (!op || typeof op.type !== "string") continue;
 
-    if (op.type === "addNeuron") {
+    if ((op.type as string) === "addNeuron") {
+      const add = op as unknown as AddNeuronOp;
       // Ensure deterministic idempotency: if neuron already exists, update fields.
       const existingIndex = next.neurons.findIndex((n) =>
-        n.uuid === op.neuronUuid
+        n.uuid === add.neuronUuid
       );
       if (existingIndex >= 0) {
         // Some exports treat neuron entries as readonly, so replace the object.
         next.neurons[existingIndex] = {
           ...next.neurons[existingIndex],
-          uuid: op.neuronUuid,
-          type: op.neuronType,
-          squash: op.squash,
-          bias: op.bias,
+          uuid: add.neuronUuid,
+          type: add.neuronType,
+          squash: add.squash,
+          bias: add.bias,
         };
         continue;
       }
 
       const newNeuron = {
-        uuid: op.neuronUuid,
-        type: op.neuronType,
-        squash: op.squash,
-        bias: op.bias,
+        uuid: add.neuronUuid,
+        type: add.neuronType,
+        squash: add.squash,
+        bias: add.bias,
       };
 
-      if (typeof op.insertBeforeNeuronUuid === "string") {
+      if (typeof add.insertBeforeNeuronUuid === "string") {
         const beforeIdx = next.neurons.findIndex((n) =>
-          n.uuid === op.insertBeforeNeuronUuid
+          n.uuid === add.insertBeforeNeuronUuid
         );
         if (beforeIdx >= 0) {
           next.neurons.splice(beforeIdx, 0, newNeuron);
@@ -125,7 +158,7 @@ export function applyCoordinatedStructuralCandidate(
 
       // Default placement must preserve the invariant that hidden neurons appear
       // before output neurons (even when recurrent connections are allowed).
-      if (op.neuronType === "hidden") {
+      if (add.neuronType === "hidden") {
         const firstOutputIdx = next.neurons.findIndex((n) =>
           n.type === "output"
         );
@@ -140,8 +173,9 @@ export function applyCoordinatedStructuralCandidate(
       continue;
     }
 
-    if (op.type === "removeNeuron") {
-      const uuid = op.neuronUuid;
+    if ((op.type as string) === "removeNeuron") {
+      const remove = op as unknown as RemoveNeuronOp;
+      const uuid = remove.neuronUuid;
       const beforeNeuronCount = next.neurons.length;
       next.neurons = next.neurons.filter((n) => n.uuid !== uuid);
       if (next.neurons.length === beforeNeuronCount) {
@@ -166,45 +200,55 @@ export function applyCoordinatedStructuralCandidate(
       continue;
     }
 
-    if (op.type === "changeSquash") {
-      const n = next.neurons.find((x) => x.uuid === op.neuronUuid);
-      if (n) n.squash = op.squash;
+    if ((op.type as string) === "changeSquash") {
+      const change = op as unknown as ChangeSquashOp;
+      const n = next.neurons.find((x) => x.uuid === change.neuronUuid);
+      if (n) n.squash = change.squash;
       continue;
     }
 
-    if (op.type === "setBias") {
-      const n = next.neurons.find((x) => x.uuid === op.neuronUuid);
-      if (n) n.bias = op.bias;
+    if ((op.type as string) === "setBias") {
+      const set = op as unknown as SetBiasOp;
+      const n = next.neurons.find((x) => x.uuid === set.neuronUuid);
+      if (n) n.bias = set.bias;
       continue;
     }
 
-    if (op.type === "removeSynapse") {
+    if ((op.type as string) === "removeSynapse") {
+      const remove = op as unknown as RemoveSynapseOp;
       const existing = next.synapses.find((s) =>
-        s.fromUUID === op.fromNeuronUuid && s.toUUID === op.toNeuronUuid
+        s.fromUUID === remove.fromNeuronUuid && s.toUUID === remove.toNeuronUuid
       );
       if (existing) {
-        removedSynapseMeta.set(edgeKey(op.fromNeuronUuid, op.toNeuronUuid), {
-          type: existing.type,
-          tags: existing.tags
-            ? existing.tags.map((t) => ({ ...t }))
-            : undefined,
-        });
+        removedSynapseMeta.set(
+          edgeKey(remove.fromNeuronUuid, remove.toNeuronUuid),
+          {
+            type: existing.type,
+            tags: existing.tags
+              ? existing.tags.map((t) => ({ ...t }))
+              : undefined,
+          },
+        );
       }
       const before = next.synapses.length;
       next.synapses = next.synapses.filter((s) =>
-        !(s.fromUUID === op.fromNeuronUuid && s.toUUID === op.toNeuronUuid)
+        !(
+          s.fromUUID === remove.fromNeuronUuid &&
+          s.toUUID === remove.toNeuronUuid
+        )
       );
       if (next.synapses.length !== before) {
         cleanupMemeticForRemovedSynapse(
           next,
-          op.fromNeuronUuid,
-          op.toNeuronUuid,
+          remove.fromNeuronUuid,
+          remove.toNeuronUuid,
         );
       }
       continue;
     }
 
-    if (op.type === "addSynapse") {
+    if ((op.type as string) === "addSynapse") {
+      const add = op as unknown as AddSynapseOp;
       // Ensure both endpoints exist; avoid crashing on stale ops.
       const existingNeuronUUIDs = new Set<string>();
       const inputCount = next.input ?? 0;
@@ -213,29 +257,31 @@ export function applyCoordinatedStructuralCandidate(
       }
       for (const n of next.neurons) existingNeuronUUIDs.add(n.uuid);
       if (
-        !existingNeuronUUIDs.has(op.fromNeuronUuid) ||
-        !existingNeuronUUIDs.has(op.toNeuronUuid)
+        !existingNeuronUUIDs.has(add.fromNeuronUuid) ||
+        !existingNeuronUUIDs.has(add.toNeuronUuid)
       ) {
         continue;
       }
 
-      if (!canAddForwardOnlySynapse(next, op.fromNeuronUuid, op.toNeuronUuid)) {
+      if (
+        !canAddForwardOnlySynapse(next, add.fromNeuronUuid, add.toNeuronUuid)
+      ) {
         continue;
       }
 
       const existing = next.synapses.find((s) =>
-        s.fromUUID === op.fromNeuronUuid && s.toUUID === op.toNeuronUuid
+        s.fromUUID === add.fromNeuronUuid && s.toUUID === add.toNeuronUuid
       );
       if (existing) {
-        existing.weight = op.weight;
+        existing.weight = add.weight;
       } else {
         const meta = removedSynapseMeta.get(
-          edgeKey(op.fromNeuronUuid, op.toNeuronUuid),
+          edgeKey(add.fromNeuronUuid, add.toNeuronUuid),
         );
         next.synapses.push({
-          fromUUID: op.fromNeuronUuid,
-          toUUID: op.toNeuronUuid,
-          weight: op.weight,
+          fromUUID: add.fromNeuronUuid,
+          toUUID: add.toNeuronUuid,
+          weight: add.weight,
           type: meta?.type,
           tags: meta?.tags ? meta.tags.map((t) => ({ ...t })) : undefined,
         });
@@ -243,6 +289,11 @@ export function applyCoordinatedStructuralCandidate(
       continue;
     }
   }
+
+  // Clean up any neurons that have become orphaned after the coordinated edits.
+  // This prevents validation failures (eg. NO_OUTWARD_CONNECTIONS) from triggering
+  // fix() as a side effect, which can bump semanticVersion for forward-only creatures.
+  cleanupOrphanedNeurons(next);
 
   const updated = Creature.fromJSON(next);
   delete updated.uuid;

--- a/test/discovery/CoordinatedStructuralRemoveNeuronCleanupOrphans.ts
+++ b/test/discovery/CoordinatedStructuralRemoveNeuronCleanupOrphans.ts
@@ -1,0 +1,59 @@
+import { assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import type { CoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
+import { applyCoordinatedStructuralCandidate } from "../../src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+Deno.test(
+  "applyCoordinatedStructuralCandidate: removeNeuron cleans up orphaned neurons to avoid forward-only fix() bumping semanticVersion (7-Jan-2026)",
+  () => {
+    const base: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      semanticVersion: "3.9.0",
+      neurons: [
+        { uuid: "hidden-a", type: "hidden", squash: IDENTITY.NAME, bias: 0.0 },
+        { uuid: "hidden-b", type: "hidden", squash: IDENTITY.NAME, bias: 0.0 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0.0 },
+      ],
+      synapses: [
+        // Keep a valid direct path so that pruning the orphaned branch remains valid.
+        { fromUUID: "input-0", toUUID: "output-0", weight: 0.1 },
+        // Branch that will become orphaned after removing hidden-b.
+        { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.2 },
+        { fromUUID: "hidden-a", toUUID: "hidden-b", weight: 0.3 },
+        { fromUUID: "hidden-b", toUUID: "output-0", weight: 0.4 },
+      ],
+    };
+    const creature = Creature.fromJSON(base);
+
+    const candidate: CoordinatedStructuralCandidate = {
+      type: "coordinated_structural",
+      expectedCreatureScoreGain: 0.01,
+      operations: [
+        {
+          type: "removeNeuron",
+          neuronUuid: "hidden-b",
+        },
+      ],
+    };
+
+    const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+
+    // Regression: without orphan cleanup, validate() throws NO_OUTWARD_CONNECTIONS for hidden-a,
+    // triggering fix({ forwardOnly: true }) which bumps semanticVersion 3.x.x -> 4.0.0.
+    assertEquals(mutated.semanticVersion, "3.9.0");
+
+    const exported = mutated.exportJSON();
+    assertEquals(exported.neurons.some((n) => n.uuid === "hidden-b"), false);
+    assertEquals(exported.neurons.some((n) => n.uuid === "hidden-a"), false);
+    assertEquals(
+      exported.synapses.some((s) =>
+        s.fromUUID === "input-0" && s.toUUID === "hidden-a"
+      ),
+      false,
+    );
+  },
+);


### PR DESCRIPTION
…coordinated structural candidates

- Bumped version in deno.json to 0.291.1.
- Added detailed documentation on coordinated-structural candidates, including their operational vocabulary and handling for forward-only creatures.
- Improved type definitions in ApplyCoordinatedStructuralCandidate for better clarity and maintainability of neuron operations.
- Implemented cleanup functionality for orphaned neurons to prevent validation failures after structural edits.

These changes improve the clarity of the documentation and enhance the functionality of the NEAT framework's structural evolution process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens coordinated-structural application and docs while preserving semantic version stability.
> 
> - Implemented `cleanupOrphanedNeurons` in `applyCoordinatedStructuralCandidate` to prevent forward-only validation from invoking fix() and bumping `semanticVersion`; maintains idempotent neuron/synapse ops and respects forward-only ordering
> - Introduced local op types and explicit casting; preserves synapse metadata across remove→add sequences
> - Added regression test `CoordinatedStructuralRemoveNeuronCleanupOrphans.ts` verifying orphan cleanup and stable `semanticVersion`
> - Expanded `DiscoveryDir.md` with coordinated-structural candidate overview, supported operation vocabulary, and forward-only placement notes
> - Bumped `deno.json` version to `0.291.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb41348f9e5ab5e7f11609569c4911e096916b6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->