### PR TITLE
V0.293.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.291.1",
+  "version": "0.291.2",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -154,6 +154,7 @@
     "parameterised",
     "checkin",
     "replayable",
-    "nulled"
+    "nulled",
+    "setweight"
   ]
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -41,6 +41,12 @@ type AddSynapseOp = {
   toNeuronUuid: string;
   weight: number;
 };
+type SetWeightOp = {
+  type: "setWeight";
+  fromNeuronUuid: string;
+  toNeuronUuid: string;
+  weight: number;
+};
 
 function buildUuidToIndexMap(creature: CreatureExport): Map<string, number> {
   const uuidToIndex = new Map<string, number>();
@@ -79,6 +85,7 @@ function canAddForwardOnlySynapse(
  * - Applies all operations in-order
  * - `removeSynapse`: removes matching (from,to) if present (no-op if missing)
  * - `addSynapse`: adds if absent; if present, updates weight (idempotent)
+ * - `setWeight`: updates weight of existing synapse (no-op if synapse missing)
  *
  * Notes:
  * - This function is intentionally conservative for forward-only creatures: it
@@ -286,6 +293,18 @@ export function applyCoordinatedStructuralCandidate(
           tags: meta?.tags ? meta.tags.map((t) => ({ ...t })) : undefined,
         });
       }
+      continue;
+    }
+
+    if ((op.type as string) === "setWeight") {
+      const set = op as unknown as SetWeightOp;
+      const existing = next.synapses.find((s) =>
+        s.fromUUID === set.fromNeuronUuid && s.toUUID === set.toNeuronUuid
+      );
+      if (existing) {
+        existing.weight = set.weight;
+      }
+      // No-op if synapse doesn't exist (idempotent).
       continue;
     }
   }

--- a/src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts
@@ -14,6 +14,7 @@
 export type CoordinatedStructuralOperation =
   | CoordinatedRemoveSynapseOperation
   | CoordinatedAddSynapseOperation
+  | CoordinatedSetWeightOperation
   | CoordinatedAddNeuronOperation
   | CoordinatedRemoveNeuronOperation
   | CoordinatedChangeSquashOperation
@@ -27,6 +28,13 @@ export interface CoordinatedRemoveSynapseOperation {
 
 export interface CoordinatedAddSynapseOperation {
   type: "addSynapse";
+  fromNeuronUuid: string;
+  toNeuronUuid: string;
+  weight: number;
+}
+
+export interface CoordinatedSetWeightOperation {
+  type: "setWeight";
   fromNeuronUuid: string;
   toNeuronUuid: string;
   weight: number;

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -271,6 +271,13 @@ function nearlyEqual(a: number, b: number): boolean {
   return diff <= 1e-7 * scale;
 }
 
+type SetWeightOp = {
+  type: "setWeight";
+  fromNeuronUuid: string;
+  toNeuronUuid: string;
+  weight: number;
+};
+
 function isAlreadyApplied(
   creature: Creature,
   entry: SuccessCacheEntry,
@@ -354,10 +361,20 @@ function isAlreadyApplied(
         });
         continue;
       }
-      if (op.type === "setWeight") {
-        expectedByEdge.set(edgeKey(op.fromNeuronUuid, op.toNeuronUuid), {
+      if ((op.type as string) === "setWeight") {
+        const set = op as unknown as SetWeightOp;
+        const key = edgeKey(set.fromNeuronUuid, set.toNeuronUuid);
+        const existing = expectedByEdge.get(key);
+        // setWeight is a no-op if the synapse doesn't exist. If the edge is
+        // already marked as absent (from a prior removeSynapse), leave it absent.
+        if (existing?.present === false) {
+          // No-op: leave the edge as absent.
+          continue;
+        }
+        // Otherwise, update the weight (synapse must be present).
+        expectedByEdge.set(key, {
           present: true,
-          weight: op.weight,
+          weight: set.weight,
         });
         continue;
       }

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -354,6 +354,13 @@ function isAlreadyApplied(
         });
         continue;
       }
+      if (op.type === "setWeight") {
+        expectedByEdge.set(edgeKey(op.fromNeuronUuid, op.toNeuronUuid), {
+          present: true,
+          weight: op.weight,
+        });
+        continue;
+      }
       // Unknown op: do not assume applied.
       return false;
     }

--- a/test/discovery/CoordinatedStructuralCandidate.ts
+++ b/test/discovery/CoordinatedStructuralCandidate.ts
@@ -338,3 +338,199 @@ Deno.test("applyCoordinatedStructuralCandidate: removeNeuron deletes neuron and 
     false,
   );
 });
+
+Deno.test("applyCoordinatedStructuralCandidate: setWeight updates existing synapse weight", () => {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: -0.001 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  const creature = Creature.fromJSON(base);
+
+  const candidate: CoordinatedStructuralCandidate = {
+    type: "coordinated_structural",
+    expectedCreatureScoreGain: 0.123,
+    operations: [
+      {
+        type: "setWeight",
+        fromNeuronUuid: "input-0",
+        toNeuronUuid: "hidden-0",
+        weight: 0.006,
+      },
+    ],
+    comment: "Adjust synapse weight: old=-0.001, new=0.006, delta=0.007",
+  };
+
+  const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+  const exported = mutated.exportJSON();
+
+  const updated = exported.synapses.find((s) =>
+    s.fromUUID === "input-0" && s.toUUID === "hidden-0"
+  );
+  assertExists(updated);
+  assertEquals(updated.weight, 0.006);
+
+  // Other synapse should be unchanged.
+  const unchanged = exported.synapses.find((s) =>
+    s.fromUUID === "hidden-0" && s.toUUID === "output-0"
+  );
+  assertExists(unchanged);
+  assertEquals(unchanged.weight, 0.25);
+});
+
+Deno.test("applyCoordinatedStructuralCandidate: setWeight is idempotent (applying twice is safe)", () => {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  const creature = Creature.fromJSON(base);
+
+  const candidate: CoordinatedStructuralCandidate = {
+    type: "coordinated_structural",
+    expectedCreatureScoreGain: 0.123,
+    operations: [
+      {
+        type: "setWeight",
+        fromNeuronUuid: "input-0",
+        toNeuronUuid: "hidden-0",
+        weight: 0.9,
+      },
+    ],
+  };
+
+  const once = applyCoordinatedStructuralCandidate(creature, candidate);
+  const twice = applyCoordinatedStructuralCandidate(once, candidate);
+
+  const syn1 = once.exportJSON().synapses.find((s) =>
+    s.fromUUID === "input-0" && s.toUUID === "hidden-0"
+  );
+  const syn2 = twice.exportJSON().synapses.find((s) =>
+    s.fromUUID === "input-0" && s.toUUID === "hidden-0"
+  );
+
+  assertExists(syn1);
+  assertExists(syn2);
+  assertEquals(syn1.weight, 0.9);
+  assertEquals(syn2.weight, 0.9);
+});
+
+Deno.test("applyCoordinatedStructuralCandidate: setWeight is no-op if synapse doesn't exist", () => {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  const creature = Creature.fromJSON(base);
+
+  const candidate: CoordinatedStructuralCandidate = {
+    type: "coordinated_structural",
+    expectedCreatureScoreGain: 0.123,
+    operations: [
+      {
+        type: "setWeight",
+        fromNeuronUuid: "input-0",
+        toNeuronUuid: "output-0",
+        weight: 0.9,
+      },
+    ],
+  };
+
+  const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+  const exported = mutated.exportJSON();
+
+  // Synapse should not exist (wasn't in original).
+  assertEquals(
+    exported.synapses.some((s) =>
+      s.fromUUID === "input-0" && s.toUUID === "output-0"
+    ),
+    false,
+  );
+
+  // Existing synapses should be unchanged.
+  const unchanged1 = exported.synapses.find((s) =>
+    s.fromUUID === "input-0" && s.toUUID === "hidden-0"
+  );
+  assertExists(unchanged1);
+  assertEquals(unchanged1.weight, 0.2);
+
+  const unchanged2 = exported.synapses.find((s) =>
+    s.fromUUID === "hidden-0" && s.toUUID === "output-0"
+  );
+  assertExists(unchanged2);
+  assertEquals(unchanged2.weight, 0.25);
+});
+
+Deno.test("applyCoordinatedStructuralCandidate: setWeight preserves synapse metadata (type/tags)", () => {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-0",
+        weight: 0.2,
+        type: "positive",
+        tags: [{ name: "discovered", value: "true" }],
+      },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  const creature = Creature.fromJSON(base);
+
+  const candidate: CoordinatedStructuralCandidate = {
+    type: "coordinated_structural",
+    expectedCreatureScoreGain: 0.123,
+    operations: [
+      {
+        type: "setWeight",
+        fromNeuronUuid: "input-0",
+        toNeuronUuid: "hidden-0",
+        weight: 0.9,
+      },
+    ],
+  };
+
+  const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+  const exported = mutated.exportJSON();
+
+  const updated = exported.synapses.find((s) =>
+    s.fromUUID === "input-0" && s.toUUID === "hidden-0"
+  );
+  assertExists(updated);
+  assertEquals(updated.weight, 0.9);
+  assertEquals(updated.type, "positive");
+  assertExists(updated.tags);
+  assertEquals(updated.tags.length, 1);
+  assertEquals(updated.tags[0].name, "discovered");
+  assertEquals(updated.tags[0].value, "true");
+});

--- a/test/discovery/DiscoveryReplayRunnerAlreadyAppliedCoordinatedStructural.ts
+++ b/test/discovery/DiscoveryReplayRunnerAlreadyAppliedCoordinatedStructural.ts
@@ -86,3 +86,83 @@ Deno.test(
     assertEquals(result.evaluatedSingles, 0);
   },
 );
+
+Deno.test(
+  "DiscoveryReplayRunner skips coordinated-structural entries with setWeight that already appear applied",
+  async () => {
+    const baseExport: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        // Already at the post-candidate weight.
+        { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.006 },
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+      ],
+    };
+    const base = Creature.fromJSON(baseExport);
+    base.uuid = "base";
+
+    const coordinatedEntry: SuccessCacheEntry = {
+      key: "coordinated-structural_setweight",
+      changeType: "coordinated-structural",
+      originalScore: 0.5,
+      candidateScore: 0.6,
+      scoreDelta: 0.1,
+      error: 0.4,
+      originalError: 0.5,
+      timestamp: new Date().toISOString(),
+      rustRequest: {
+        coordinatedStructuralCandidate: {
+          operations: [
+            {
+              type: "setWeight",
+              fromNeuronUuid: "input-0",
+              toNeuronUuid: "hidden-0",
+              weight: 0.006,
+            },
+          ],
+          expectedCreatureScoreGain: 0.001,
+          comment: "Adjust synapse weight: old=-0.001, new=0.006, delta=0.007",
+        },
+      },
+    };
+
+    const runner = new DiscoveryReplayRunner({
+      listEntries: (_dir) => [coordinatedEntry],
+      // Fail fast if we accidentally try to apply/evaluate.
+      applyEntry: () => {
+        throw new Error("applyEntry should not be called for already-applied");
+      },
+      evaluateError: (creature) => {
+        // Replay always evaluates the baseline creature once.
+        if (creature.uuid === "base") {
+          return Promise.resolve({ error: 0, score: 0.5 });
+        }
+        throw new Error(
+          "evaluateError should not be called for already-applied candidate creatures",
+        );
+      },
+    });
+
+    const result = await runner.replayDir({
+      creature: base,
+      dataDir: "/tmp/does-not-matter",
+      options: {
+        discoverySuccessCacheDir: "/tmp/does-not-matter",
+        costOfGrowth: 0,
+        discoveryReplayMaxSingles: 10,
+        discoveryReplayMaxPairwise: 10,
+        discoveryReplayMaxTriples: 10,
+        threads: 1,
+      },
+    });
+
+    assertEquals(result.skippedAlreadyApplied, 1);
+    assertEquals(result.evaluatedSingles, 0);
+  },
+);

--- a/test/discovery/DiscoveryReplayRunnerAlreadyAppliedCoordinatedStructural.ts
+++ b/test/discovery/DiscoveryReplayRunnerAlreadyAppliedCoordinatedStructural.ts
@@ -166,3 +166,88 @@ Deno.test(
     assertEquals(result.evaluatedSingles, 0);
   },
 );
+
+Deno.test(
+  "DiscoveryReplayRunner skips coordinated-structural entries with removeSynapse followed by setWeight that already appear applied",
+  async () => {
+    const baseExport: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+        { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        // Synapse is absent (removed), which matches the final state after removeSynapse + setWeight
+        // (setWeight is a no-op when synapse doesn't exist)
+        { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+      ],
+    };
+    const base = Creature.fromJSON(baseExport);
+    base.uuid = "base";
+
+    const coordinatedEntry: SuccessCacheEntry = {
+      key: "coordinated-structural_remove_setweight",
+      changeType: "coordinated-structural",
+      originalScore: 0.5,
+      candidateScore: 0.6,
+      scoreDelta: 0.1,
+      error: 0.4,
+      originalError: 0.5,
+      timestamp: new Date().toISOString(),
+      rustRequest: {
+        coordinatedStructuralCandidate: {
+          operations: [
+            {
+              type: "removeSynapse",
+              fromNeuronUuid: "input-0",
+              toNeuronUuid: "hidden-0",
+            },
+            {
+              type: "setWeight",
+              fromNeuronUuid: "input-0",
+              toNeuronUuid: "hidden-0",
+              weight: 0.006,
+            },
+          ],
+          expectedCreatureScoreGain: 0.001,
+          comment: "Remove synapse then try to set weight (no-op)",
+        },
+      },
+    };
+
+    const runner = new DiscoveryReplayRunner({
+      listEntries: (_dir) => [coordinatedEntry],
+      // Fail fast if we accidentally try to apply/evaluate.
+      applyEntry: () => {
+        throw new Error("applyEntry should not be called for already-applied");
+      },
+      evaluateError: (creature) => {
+        // Replay always evaluates the baseline creature once.
+        if (creature.uuid === "base") {
+          return Promise.resolve({ error: 0, score: 0.5 });
+        }
+        throw new Error(
+          "evaluateError should not be called for already-applied candidate creatures",
+        );
+      },
+    });
+
+    const result = await runner.replayDir({
+      creature: base,
+      dataDir: "/tmp/does-not-matter",
+      options: {
+        discoverySuccessCacheDir: "/tmp/does-not-matter",
+        costOfGrowth: 0,
+        discoveryReplayMaxSingles: 10,
+        discoveryReplayMaxPairwise: 10,
+        discoveryReplayMaxTriples: 10,
+        threads: 1,
+      },
+    });
+
+    assertEquals(result.skippedAlreadyApplied, 1);
+    assertEquals(result.evaluatedSingles, 0);
+  },
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces weight-adjustment support in coordinated structural workflows and ensures replay correctly skips already-applied entries.
> 
> - Adds `setWeight` op to `CoordinatedStructuralCandidate` and applies it in `ApplyCoordinatedStructuralCandidate` (idempotent; no-op if synapse missing; preserves metadata)
> - Enhances `DiscoveryReplayRunner.isAlreadyApplied` to evaluate `setWeight`, including `removeSynapse` + `setWeight` sequences
> - Adds targeted tests covering apply/update/idempotency/no-op/metadata and replay skip behavior
> - Bumps `deno.json` version and updates `docs/cspell.json` dictionary
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7271647315cecd4d15942f8314c9f019d99c2361. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->