### PR TITLE
Fix: Replace deprecated codecov/test-results-action with codecov-action@v5 (#1060)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -243,10 +243,12 @@ jobs:
           check_run_annotations_branch: ${{ github.head_ref || github.ref_name }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && (steps.create_coverage_files.outcome == 'success' || steps.create_coverage_files_fallback.outcome == 'success') }}
-        uses: codecov/test-results-action@v1
+        if: ${{ !cancelled() && (steps.create_coverage_files.outcome == 'success' || steps.create_coverage_files_fallback.outcome == 'success') && steps.check_junit.outputs.junit_exists == 'true' }}
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
+          report_type: test_results
 
       - name: Fail Build if Tests Failed
         if: ${{ steps.create_coverage_files.outputs.test_failed == 'true' || steps.create_coverage_files_fallback.outputs.test_failed == 'true' }}

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.291.17",
+  "version": "0.291.18",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",


### PR DESCRIPTION
## Summary
- Replace deprecated `codecov/test-results-action@v1` with `codecov/codecov-action@v5`
- Add `report_type: test_results` parameter as required by the new action
- Add JUnit file existence check before uploading test results

Closes #1060

## Test plan
- [ ] Verify the coverage workflow runs successfully on this PR
- [ ] Check that test results are uploaded to Codecov correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates coverage workflow to use the maintained Codecov action and avoid uploading invalid test reports.
> 
> - Replace `codecov/test-results-action@v1` with `codecov/codecov-action@v5`, specifying `files: junit.xml` and `report_type: test_results`
> - Gate Codecov upload on `check_junit` output (`junit_exists == 'true'`) to ensure valid JUnit XML before upload
> - Bump `deno.json` version from `0.291.17` to `0.291.18`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21181452f19ec3f95296acca9e65605328b0af8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->