### PR TITLE
Fix: Performance: Cache hidden neuron UUIDs for genetic compatibility checks (#1032)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.291.23",
+  "version": "0.291.24",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -154,6 +154,13 @@ export class Creature implements CreatureInternal {
    */
   private connectionSet: Set<string> | null = null;
 
+  /**
+   * Cached Set of hidden neuron UUIDs.
+   * Enables O(1) lookup for genetic compatibility checks.
+   * Issue #1032: Performance optimisation for genetic compatibility checks.
+   */
+  private hiddenNeuronUUIDs: Set<string> | null = null;
+
   /** The version of this creature */
   public semanticVersion: string;
 
@@ -246,6 +253,9 @@ export class Creature implements CreatureInternal {
       this.inwardCacheMissCount = 0;
       // Invalidate connection set on full cache clear
       this.connectionSet = null;
+      // Invalidate hidden neuron UUIDs cache on full cache clear
+      // Issue #1032: Performance optimisation for genetic compatibility checks
+      this.hiddenNeuronUUIDs = null;
     } else {
       this.cacheTo.delete(to);
       this.cacheFrom.delete(from);
@@ -255,6 +265,9 @@ export class Creature implements CreatureInternal {
       this.inwardCacheMissCount = 0;
       // Invalidate connection set on partial clear (structure changed)
       this.connectionSet = null;
+      // Invalidate hidden neuron UUIDs cache on partial clear (structure changed)
+      // Issue #1032: Performance optimisation for genetic compatibility checks
+      this.hiddenNeuronUUIDs = null;
     }
     this.cacheFocus.clear();
     this.invalidateScoreCache();
@@ -708,6 +721,26 @@ export class Creature implements CreatureInternal {
    */
   public hasConnection(from: number, to: number): boolean {
     return this.getConnectionSet().has(`${from}-${to}`);
+  }
+
+  /**
+   * Builds and returns a cached Set of hidden neuron UUIDs.
+   * Enables O(1) lookup for genetic compatibility checks.
+   * Issue #1032: Performance optimisation for genetic compatibility checks.
+   *
+   * @returns {Set<string>} Set of hidden neuron UUIDs
+   */
+  public getHiddenNeuronUUIDs(): Set<string> {
+    if (this.hiddenNeuronUUIDs === null) {
+      this.hiddenNeuronUUIDs = new Set<string>();
+      for (let i = this.input, len = this.neurons.length; i < len; i++) {
+        const neuron = this.neurons[i];
+        if (neuron.type === "hidden") {
+          this.hiddenNeuronUUIDs.add(neuron.uuid);
+        }
+      }
+    }
+    return this.hiddenNeuronUUIDs;
   }
 
   /**

--- a/src/breed/GeneticCompatibility.ts
+++ b/src/breed/GeneticCompatibility.ts
@@ -12,6 +12,8 @@ import type { Creature } from "../../mod.ts";
  * The compatibility is calculated as the ratio of matching hidden neurons to the
  * total number of hidden neurons in the smaller creature.
  *
+ * Issue #1032: Uses cached hidden neuron UUIDs for improved performance.
+ *
  * @param father - The first creature for compatibility calculation
  * @param mother - The second creature for compatibility calculation
  * @returns A compatibility score between 0 and 1, where higher values indicate better compatibility
@@ -28,12 +30,9 @@ export function geneticCompatibility(
   father: Creature,
   mother: Creature,
 ): number {
-  const fatherNeurons = new Set(
-    father.neurons.filter((n) => n.type === "hidden").map((n) => n.uuid),
-  );
-  const motherNeurons = new Set(
-    mother.neurons.filter((n) => n.type === "hidden").map((n) => n.uuid),
-  );
+  // Use cached hidden neuron UUIDs for improved performance (Issue #1032)
+  const fatherNeurons = father.getHiddenNeuronUUIDs();
+  const motherNeurons = mother.getHiddenNeuronUUIDs();
 
   const smallestNeuronSet = fatherNeurons.size < motherNeurons.size
     ? fatherNeurons

--- a/test/Offspring/HiddenNeuronUUIDCache.ts
+++ b/test/Offspring/HiddenNeuronUUIDCache.ts
@@ -1,0 +1,154 @@
+import { assertEquals } from "@std/assert";
+import { emptyDirSync } from "@std/fs";
+import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { geneticCompatibility } from "../../src/breed/GeneticCompatibility.ts";
+
+const testDir = ".test/HiddenNeuronUUIDCache";
+emptyDirSync(testDir);
+
+/**
+ * Creates a test creature with the specified hidden neuron UUIDs.
+ */
+function makeCreatureWithHiddenNeurons(
+  hiddenUUIDs: string[],
+): Creature {
+  const json: CreatureExport = {
+    neurons: hiddenUUIDs.map((uuid) => ({
+      type: "hidden" as const,
+      uuid,
+      bias: 0.1,
+      squash: "TANH",
+    })),
+    synapses: [],
+    input: 2,
+    output: 1,
+  };
+
+  // Add output neuron
+  json.neurons.push({
+    type: "output",
+    uuid: "output-0",
+    bias: 0.1,
+    squash: "TANH",
+  });
+
+  // Connect input to hidden neurons
+  for (const uuid of hiddenUUIDs) {
+    json.synapses.push({
+      fromUUID: "input-0",
+      toUUID: uuid,
+      weight: 0.5,
+    });
+  }
+
+  // Connect hidden neurons to output
+  for (const uuid of hiddenUUIDs) {
+    json.synapses.push({
+      fromUUID: uuid,
+      toUUID: "output-0",
+      weight: 0.5,
+    });
+  }
+
+  return Creature.fromJSON(json);
+}
+
+Deno.test("getHiddenNeuronUUIDs returns correct Set of hidden neuron UUIDs", () => {
+  const hiddenUUIDs = ["hidden-1", "hidden-2", "hidden-3"];
+  const creature = makeCreatureWithHiddenNeurons(hiddenUUIDs);
+
+  const result = creature.getHiddenNeuronUUIDs();
+
+  assertEquals(result.size, 3);
+  assertEquals(result.has("hidden-1"), true);
+  assertEquals(result.has("hidden-2"), true);
+  assertEquals(result.has("hidden-3"), true);
+  assertEquals(result.has("output-0"), false);
+  assertEquals(result.has("input-0"), false);
+});
+
+Deno.test("getHiddenNeuronUUIDs returns cached Set on subsequent calls", () => {
+  const hiddenUUIDs = ["hidden-a", "hidden-b"];
+  const creature = makeCreatureWithHiddenNeurons(hiddenUUIDs);
+
+  const result1 = creature.getHiddenNeuronUUIDs();
+  const result2 = creature.getHiddenNeuronUUIDs();
+
+  // Should return the same Set instance (not a new one)
+  assertEquals(result1, result2);
+});
+
+Deno.test("getHiddenNeuronUUIDs cache is invalidated when clearCache is called", () => {
+  const hiddenUUIDs = ["hidden-x", "hidden-y"];
+  const creature = makeCreatureWithHiddenNeurons(hiddenUUIDs);
+
+  const result1 = creature.getHiddenNeuronUUIDs();
+  creature.clearCache();
+  const result2 = creature.getHiddenNeuronUUIDs();
+
+  // Should return a new Set instance after cache clear
+  assertEquals(result1 !== result2, true);
+  // But contents should be the same
+  assertEquals(result2.size, 2);
+  assertEquals(result2.has("hidden-x"), true);
+  assertEquals(result2.has("hidden-y"), true);
+});
+
+Deno.test("getHiddenNeuronUUIDs returns empty Set for creature with no hidden neurons", () => {
+  const json: CreatureExport = {
+    neurons: [
+      {
+        type: "output",
+        uuid: "output-0",
+        bias: 0.1,
+        squash: "TANH",
+      },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 0.5,
+      },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  const creature = Creature.fromJSON(json);
+  const result = creature.getHiddenNeuronUUIDs();
+
+  assertEquals(result.size, 0);
+});
+
+Deno.test("geneticCompatibility uses cached hiddenNeuronUUIDs", () => {
+  const sharedUUIDs = ["shared-1", "shared-2"];
+  const father = makeCreatureWithHiddenNeurons(sharedUUIDs);
+  const mother = makeCreatureWithHiddenNeurons(sharedUUIDs);
+
+  // Call getHiddenNeuronUUIDs to populate the cache
+  father.getHiddenNeuronUUIDs();
+  mother.getHiddenNeuronUUIDs();
+
+  // Genetic compatibility should use the cached Sets
+  const compatibility = geneticCompatibility(father, mother);
+
+  assertEquals(compatibility, 1);
+});
+
+Deno.test("getHiddenNeuronUUIDs cache is invalidated on connect", () => {
+  const hiddenUUIDs = ["hidden-1"];
+  const creature = makeCreatureWithHiddenNeurons(hiddenUUIDs);
+
+  const result1 = creature.getHiddenNeuronUUIDs();
+
+  // Adding a new connection should invalidate the cache
+  // (even though hidden neurons haven't changed, the structure has)
+  creature.connect(1, creature.neurons.length - 1, 0.3);
+
+  const result2 = creature.getHiddenNeuronUUIDs();
+
+  // Should return a new Set instance after structure change
+  assertEquals(result1 !== result2, true);
+});


### PR DESCRIPTION
## Summary

Implements performance optimisation for genetic compatibility checks by caching hidden neuron UUIDs in the Creature object.

### Problem

In `src/breed/GeneticCompatibility.ts`, Sets were created from filtered arrays on every compatibility check:

```typescript
const fatherNeurons = new Set(
  father.neurons.filter((n) => n.type === "hidden").map((n) => n.uuid),
);
```

This filter + map + Set creation happens frequently during breeding operations.

### Solution

- Added `hiddenNeuronUUIDs` cache field to Creature class
- Added `getHiddenNeuronUUIDs()` method that builds and returns the cached Set lazily
- Cache is invalidated in `clearCache()` when structure changes (neurons added/removed)
- Updated `geneticCompatibility()` to use the cached Set

### Files Modified

- `src/Creature.ts` - Added cache field and getter method
- `src/breed/GeneticCompatibility.ts` - Updated to use cached Set
- `test/Offspring/HiddenNeuronUUIDCache.ts` - Added comprehensive tests

## Evidence

This is a performance optimisation that reduces redundant Set creation. The expected impact is 20-30% faster genetic compatibility checks during breeding, as mentioned in issue #1032.

The improvement is structural - instead of creating new Sets on every `geneticCompatibility()` call, we now reuse cached Sets. This avoids:
- Filtering the neurons array (O(n))
- Mapping filtered results to UUIDs (O(n))
- Creating a new Set from the mapped array (O(n))

With caching, subsequent calls are O(1) lookups until the cache is invalidated.

## Test Plan

Added 6 new tests in `test/Offspring/HiddenNeuronUUIDCache.ts`:
- `getHiddenNeuronUUIDs returns correct Set of hidden neuron UUIDs`
- `getHiddenNeuronUUIDs returns cached Set on subsequent calls`
- `getHiddenNeuronUUIDs cache is invalidated when clearCache is called`
- `getHiddenNeuronUUIDs returns empty Set for creature with no hidden neurons`
- `geneticCompatibility uses cached hiddenNeuronUUIDs`
- `getHiddenNeuronUUIDs cache is invalidated on connect`

All existing tests continue to pass (1262 tests).

Fixes #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)