### PR TITLE
Fix: Unknown approach 'discovered' (#1082)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.292.0",
+  "version": "0.292.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/pr-summary-1082.md
+++ b/docs/pr-summary-1082.md
@@ -1,26 +1,40 @@
 ## Summary
 
-Fixed the "Unknown approach 'discovered'" error that occurred during the fine-tuning phase after a discovery process completed.
+Fixed the "Unknown approach 'discovered'" error that occurred during the
+fine-tuning phase after a discovery process completed.
 
 The root cause was a mismatch between:
-- `Neat.ts:392` which tags improved creatures with `approach='discovered'` (past tense)
-- `LogApproach.ts` which only recognised `'discovery'` (noun form) in its `Approach` type union
 
-The fix adds `'discovered'` to the `Approach` type and handles it in the switch statement alongside `'discovery'`, since both values indicate the creature came from the discovery process.
+- `Neat.ts:392` which tags improved creatures with `approach='discovered'` (past
+  tense)
+- `LogApproach.ts` which only recognised `'discovery'` (noun form) in its
+  `Approach` type union
+
+The fix adds `'discovered'` to the `Approach` type and handles it in the switch
+statement alongside `'discovery'`, since both values indicate the creature came
+from the discovery process.
 
 ## Evidence
 
-Unable to generate screenshot: This is a CLI-only library with no visual interface.
+Unable to generate screenshot: This is a CLI-only library with no visual
+interface.
 
 The bug is reproduced and verified fixed by the test case:
-- `test/NEAT/LogApproach.ts` - "logApproach: should handle 'discovered' approach without throwing error (issue #1082)"
+
+- `test/NEAT/LogApproach.ts` - "logApproach: should handle 'discovered' approach
+  without throwing error (issue #1082)"
 
 ## Test Plan
 
 Added `test/NEAT/LogApproach.ts` with the following test cases:
-- `logApproach: should handle 'discovered' approach without throwing error (issue #1082)` - Directly tests the reported bug
-- `logApproach: should handle 'discovery' approach without throwing error` - Ensures existing behaviour is preserved
-- `logApproach: should handle all valid approach types` - Comprehensive test for all 8 approach values
-- `logApproach: should throw error for truly unknown approaches` - Ensures invalid approaches still throw errors
+
+- `logApproach: should handle 'discovered' approach without throwing error (issue #1082)` -
+  Directly tests the reported bug
+- `logApproach: should handle 'discovery' approach without throwing error` -
+  Ensures existing behaviour is preserved
+- `logApproach: should handle all valid approach types` - Comprehensive test for
+  all 8 approach values
+- `logApproach: should throw error for truly unknown approaches` - Ensures
+  invalid approaches still throw errors
 
 All 1319 tests pass including the new tests.

--- a/docs/pr-summary-1082.md
+++ b/docs/pr-summary-1082.md
@@ -1,0 +1,26 @@
+## Summary
+
+Fixed the "Unknown approach 'discovered'" error that occurred during the fine-tuning phase after a discovery process completed.
+
+The root cause was a mismatch between:
+- `Neat.ts:392` which tags improved creatures with `approach='discovered'` (past tense)
+- `LogApproach.ts` which only recognised `'discovery'` (noun form) in its `Approach` type union
+
+The fix adds `'discovered'` to the `Approach` type and handles it in the switch statement alongside `'discovery'`, since both values indicate the creature came from the discovery process.
+
+## Evidence
+
+Unable to generate screenshot: This is a CLI-only library with no visual interface.
+
+The bug is reproduced and verified fixed by the test case:
+- `test/NEAT/LogApproach.ts` - "logApproach: should handle 'discovered' approach without throwing error (issue #1082)"
+
+## Test Plan
+
+Added `test/NEAT/LogApproach.ts` with the following test cases:
+- `logApproach: should handle 'discovered' approach without throwing error (issue #1082)` - Directly tests the reported bug
+- `logApproach: should handle 'discovery' approach without throwing error` - Ensures existing behaviour is preserved
+- `logApproach: should handle all valid approach types` - Comprehensive test for all 8 approach values
+- `logApproach: should throw error for truly unknown approaches` - Ensures invalid approaches still throw errors
+
+All 1319 tests pass including the new tests.

--- a/src/NEAT/LogApproach.ts
+++ b/src/NEAT/LogApproach.ts
@@ -11,7 +11,8 @@ export type Approach =
   | "compact"
   | "backtrack"
   | "retry"
-  | "discovery";
+  | "discovery"
+  | "discovered";
 
 export function logApproach(fittest: Creature, previous: Creature) {
   const fScoreTxt = getTag(fittest, "score");
@@ -87,7 +88,8 @@ export function logApproach(fittest: Creature, previous: Creature) {
           );
           break;
         }
-        case "discovery": {
+        case "discovery":
+        case "discovered": {
           const discoveryID = getTag(fittest, "discoveryID");
           const evaluation = getTag(fittest, "Discovery") ??
             getTag(fittest, "discovery");

--- a/test/NEAT/LogApproach.ts
+++ b/test/NEAT/LogApproach.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for LogApproach functionality.
+ * Issue #1082: Unknown approach 'discovered' error.
+ */
+
+import { assert, assertThrows } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature, type CreatureExport } from "../../mod.ts";
+import { type Approach, logApproach } from "../../src/NEAT/LogApproach.ts";
+
+/**
+ * Creates a simple test creature with a score and approach tag.
+ */
+function createTestCreatureWithApproach(
+  score: number,
+  approach: string,
+): Creature {
+  const creatureJSON: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "TANH", bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+    ],
+    tags: [
+      { name: "score", value: score.toString() },
+      { name: "approach", value: approach },
+    ],
+  };
+  return Creature.fromJSON(creatureJSON);
+}
+
+/**
+ * Creates a simple previous creature with a score.
+ */
+function createPreviousCreature(score: number): Creature {
+  const creatureJSON: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [],
+    tags: [
+      { name: "score", value: score.toString() },
+    ],
+  };
+  return Creature.fromJSON(creatureJSON);
+}
+
+Deno.test(
+  "logApproach: should handle 'discovered' approach without throwing error (issue #1082)",
+  () => {
+    const fittest = createTestCreatureWithApproach(0.9, "discovered");
+    addTag(fittest, "discoveryID", "test-discovery-123");
+    const previous = createPreviousCreature(0.8);
+
+    // This should NOT throw an error - the bug is that 'discovered' was not a valid approach
+    // After the fix, this should log the discovery message without throwing
+    let errorThrown = false;
+    try {
+      logApproach(fittest, previous);
+    } catch (e) {
+      errorThrown = true;
+      console.error("Unexpected error:", e);
+    }
+
+    assert(
+      !errorThrown,
+      "logApproach should not throw an error for 'discovered' approach",
+    );
+  },
+);
+
+Deno.test(
+  "logApproach: should handle 'discovery' approach without throwing error",
+  () => {
+    const fittest = createTestCreatureWithApproach(0.9, "discovery");
+    addTag(fittest, "discoveryID", "test-discovery-456");
+    const previous = createPreviousCreature(0.8);
+
+    let errorThrown = false;
+    try {
+      logApproach(fittest, previous);
+    } catch (e) {
+      errorThrown = true;
+      console.error("Unexpected error:", e);
+    }
+
+    assert(
+      !errorThrown,
+      "logApproach should not throw an error for 'discovery' approach",
+    );
+  },
+);
+
+Deno.test(
+  "logApproach: should handle all valid approach types",
+  () => {
+    const validApproaches: Approach[] = [
+      "fine",
+      "trained",
+      "simplified",
+      "compact",
+      "backtrack",
+      "retry",
+      "discovery",
+      "discovered",
+    ];
+
+    const previous = createPreviousCreature(0.7);
+
+    for (const approach of validApproaches) {
+      const fittest = createTestCreatureWithApproach(0.8, approach);
+
+      // Add additional tags that certain approaches expect
+      if (approach === "trained") {
+        addTag(fittest, "trainID", "test-train-id");
+      }
+      if (approach === "discovery" || approach === "discovered") {
+        addTag(fittest, "discoveryID", "test-discovery-id");
+      }
+      if (approach === "compact") {
+        addTag(fittest, "old-neurons", "5");
+        addTag(fittest, "old-synapses", "10");
+      }
+
+      let errorThrown = false;
+      try {
+        logApproach(fittest, previous);
+      } catch (e) {
+        errorThrown = true;
+        console.error(`Unexpected error for approach '${approach}':`, e);
+      }
+
+      assert(
+        !errorThrown,
+        `logApproach should not throw an error for '${approach}' approach`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "logApproach: should throw error for truly unknown approaches",
+  () => {
+    const fittest = createTestCreatureWithApproach(0.9, "invalid-approach");
+    const previous = createPreviousCreature(0.8);
+
+    assertThrows(
+      () => {
+        logApproach(fittest, previous);
+      },
+      Error,
+      "Unknown approach 'invalid-approach'",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Fixed the "Unknown approach 'discovered'" error that occurred during the
fine-tuning phase after a discovery process completed.

The root cause was a mismatch between:

- `Neat.ts:392` which tags improved creatures with `approach='discovered'` (past
  tense)
- `LogApproach.ts` which only recognised `'discovery'` (noun form) in its
  `Approach` type union

The fix adds `'discovered'` to the `Approach` type and handles it in the switch
statement alongside `'discovery'`, since both values indicate the creature came
from the discovery process.

## Evidence

Unable to generate screenshot: This is a CLI-only library with no visual
interface.

The bug is reproduced and verified fixed by the test case:

- `test/NEAT/LogApproach.ts` - "logApproach: should handle 'discovered' approach
  without throwing error (issue #1082)"

## Test Plan

Added `test/NEAT/LogApproach.ts` with the following test cases:

- `logApproach: should handle 'discovered' approach without throwing error (issue #1082)` -
  Directly tests the reported bug
- `logApproach: should handle 'discovery' approach without throwing error` -
  Ensures existing behaviour is preserved
- `logApproach: should handle all valid approach types` - Comprehensive test for
  all 8 approach values
- `logApproach: should throw error for truly unknown approaches` - Ensures
  invalid approaches still throw errors

All 1319 tests pass including the new tests.

---

## Automated Fix Details
This PR addresses issue #1082: **Unknown approach 'discovered'**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1082