### PR TITLE
Fix: Neat Options to accept discovery cache (#997)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.292.9",
+  "version": "0.292.10",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/pr-summary-997.md
+++ b/docs/pr-summary-997.md
@@ -1,0 +1,54 @@
+## Summary
+
+This PR implements Issue #997: NEAT Options to accept a discovery cache directory.
+
+### Changes Made
+
+1. **New `discoveryCacheDir` option in NeatOptions**
+   - Added a new configuration option `discoveryCacheDir` to `NeatArguments.ts`
+   - When provided, this base directory is used to derive the `discoverySuccessCacheDir` (`{base}/success`) and `discoveryFailureCacheDir` (`{base}/failure`) unless explicitly overridden
+   - Empty strings are treated as undefined
+
+2. **Non-blocking background replay of cached discoveries**
+   - Created new `DiscoveryReplayQueue` class (`src/NEAT/DiscoveryReplayQueue.ts`) that handles background replay of cached discoveries against new fittest creatures
+   - Key features:
+     - Only one replay process runs at a time (as per issue requirements)
+     - When a new fittest is found during replay, it's queued for processing next
+     - Only the most recent queued creature is kept (older ones are discarded)
+     - Completed results are collected and integrated into the population
+
+3. **Integration with Neat class evolution loop**
+   - When a new "fittest" creature is found during evolution and `discoveryCacheDir` is configured, the discovery replay is automatically scheduled in the background
+   - Completed replay results are processed and improved creatures are added to the population with the `discovery-replay` approach tag
+   - The data directory is passed to the Neat instance via `setDataDir()` to enable replay functionality
+
+### Benefits
+
+- **Persistence of learnings**: Discoveries from previous evolution runs can be re-applied when evolution restarts
+- **Non-blocking**: The replay process runs in the background and doesn't block the main evolution loop
+- **Automatic configuration**: Setting `discoveryCacheDir` automatically configures the success and failure cache directories
+
+## Evidence
+
+Unable to generate screenshot: This is a CLI-only tool/library with no visual interface. The feature adds configuration options and background processing that don't produce visual output.
+
+## Test Plan
+
+- Added `test/NEAT/DiscoveryCacheDir.ts` with 6 tests covering:
+  - Default value is undefined
+  - Accepts valid directory paths
+  - Accepts relative paths
+  - Derives success/failure cache subdirectories automatically
+  - Explicit success/failure dirs override derived ones
+  - Empty strings treated as undefined
+
+- Added `test/NEAT/DiscoveryReplayQueue.ts` with 7 tests covering:
+  - Schedules replay when new fittest is detected
+  - Only one replay runs at a time
+  - Returns improved creature in results
+  - Skips replay if no cache directory configured
+  - Queues newest fittest when replay in progress
+  - `isReplayInProgress()` returns correct state
+  - `clearCompletedResults()` removes results
+
+All 1383 existing tests continue to pass.

--- a/docs/pr-summary-997.md
+++ b/docs/pr-summary-997.md
@@ -1,36 +1,51 @@
 ## Summary
 
-This PR implements Issue #997: NEAT Options to accept a discovery cache directory.
+This PR implements Issue #997: NEAT Options to accept a discovery cache
+directory.
 
 ### Changes Made
 
 1. **New `discoveryCacheDir` option in NeatOptions**
    - Added a new configuration option `discoveryCacheDir` to `NeatArguments.ts`
-   - When provided, this base directory is used to derive the `discoverySuccessCacheDir` (`{base}/success`) and `discoveryFailureCacheDir` (`{base}/failure`) unless explicitly overridden
+   - When provided, this base directory is used to derive the
+     `discoverySuccessCacheDir` (`{base}/success`) and
+     `discoveryFailureCacheDir` (`{base}/failure`) unless explicitly overridden
    - Empty strings are treated as undefined
 
 2. **Non-blocking background replay of cached discoveries**
-   - Created new `DiscoveryReplayQueue` class (`src/NEAT/DiscoveryReplayQueue.ts`) that handles background replay of cached discoveries against new fittest creatures
+   - Created new `DiscoveryReplayQueue` class
+     (`src/NEAT/DiscoveryReplayQueue.ts`) that handles background replay of
+     cached discoveries against new fittest creatures
    - Key features:
      - Only one replay process runs at a time (as per issue requirements)
-     - When a new fittest is found during replay, it's queued for processing next
+     - When a new fittest is found during replay, it's queued for processing
+       next
      - Only the most recent queued creature is kept (older ones are discarded)
      - Completed results are collected and integrated into the population
 
 3. **Integration with Neat class evolution loop**
-   - When a new "fittest" creature is found during evolution and `discoveryCacheDir` is configured, the discovery replay is automatically scheduled in the background
-   - Completed replay results are processed and improved creatures are added to the population with the `discovery-replay` approach tag
-   - The data directory is passed to the Neat instance via `setDataDir()` to enable replay functionality
+   - When a new "fittest" creature is found during evolution and
+     `discoveryCacheDir` is configured, the discovery replay is automatically
+     scheduled in the background
+   - Completed replay results are processed and improved creatures are added to
+     the population with the `discovery-replay` approach tag
+   - The data directory is passed to the Neat instance via `setDataDir()` to
+     enable replay functionality
 
 ### Benefits
 
-- **Persistence of learnings**: Discoveries from previous evolution runs can be re-applied when evolution restarts
-- **Non-blocking**: The replay process runs in the background and doesn't block the main evolution loop
-- **Automatic configuration**: Setting `discoveryCacheDir` automatically configures the success and failure cache directories
+- **Persistence of learnings**: Discoveries from previous evolution runs can be
+  re-applied when evolution restarts
+- **Non-blocking**: The replay process runs in the background and doesn't block
+  the main evolution loop
+- **Automatic configuration**: Setting `discoveryCacheDir` automatically
+  configures the success and failure cache directories
 
 ## Evidence
 
-Unable to generate screenshot: This is a CLI-only tool/library with no visual interface. The feature adds configuration options and background processing that don't produce visual output.
+Unable to generate screenshot: This is a CLI-only tool/library with no visual
+interface. The feature adds configuration options and background processing that
+don't produce visual output.
 
 ## Test Plan
 

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1150,6 +1150,9 @@ export class Creature implements CreatureInternal {
       workers,
     );
 
+    // Issue #997: Pass the data directory to enable discovery replay
+    neat.setDataDir(dataSetDir);
+
     neat.populatePopulation(this);
 
     let error = Infinity;

--- a/src/NEAT/DiscoveryReplayQueue.ts
+++ b/src/NEAT/DiscoveryReplayQueue.ts
@@ -1,0 +1,176 @@
+import type { Creature } from "../Creature.ts";
+import type { NeatOptions } from "../config/NeatOptions.ts";
+import {
+  type DiscoveryReplayDirResult,
+  DiscoveryReplayRunner,
+} from "../discovery/DiscoveryReplayRunner.ts";
+import { createNeatConfig } from "../config/NeatConfig.ts";
+
+/**
+ * Dependencies for the DiscoveryReplayQueue.
+ * These can be injected for testing purposes.
+ */
+export interface DiscoveryReplayQueueDeps {
+  /**
+   * Function to replay discoveries against a creature.
+   * Defaults to using the DiscoveryReplayRunner.
+   */
+  replayDir?: (
+    creature: Creature,
+    dataDir: string,
+    options: NeatOptions,
+  ) => Promise<DiscoveryReplayDirResult>;
+}
+
+/**
+ * Queue for non-blocking background replay of cached discoveries (Issue #997).
+ *
+ * When a new "fittest" creature is found during evolution, this queue manages
+ * the background replay of discoveries against it. Key characteristics:
+ *
+ * 1. Only one replay runs at a time (replay can take longer than evolution)
+ * 2. When a new fittest is found during replay, it's queued for processing next
+ * 3. Only the most recent queued creature is kept (older ones are discarded)
+ * 4. Completed results are collected for integration back into the population
+ */
+export class DiscoveryReplayQueue {
+  #deps: DiscoveryReplayQueueDeps;
+  #replayInProgress = false;
+  #queuedCreature: {
+    creature: Creature;
+    dataDir: string;
+    options: NeatOptions;
+  } | null = null;
+  #completedResults: DiscoveryReplayDirResult[] = [];
+  #currentPromise: Promise<void> | null = null;
+
+  constructor(deps: DiscoveryReplayQueueDeps = {}) {
+    this.#deps = {
+      replayDir: deps.replayDir ?? this.defaultReplayDir.bind(this),
+    };
+  }
+
+  /**
+   * Default replay implementation using DiscoveryReplayRunner.
+   */
+  private async defaultReplayDir(
+    creature: Creature,
+    dataDir: string,
+    options: NeatOptions,
+  ): Promise<DiscoveryReplayDirResult> {
+    const runner = new DiscoveryReplayRunner();
+    return await runner.replayDir({
+      creature,
+      dataDir,
+      options,
+    });
+  }
+
+  /**
+   * Schedule a replay of discoveries against the given creature.
+   *
+   * If a replay is already in progress, the creature is queued for processing
+   * when the current replay completes. Only the most recent queued creature
+   * is kept (older queued creatures are discarded).
+   *
+   * @param creature The fittest creature to replay discoveries against
+   * @param dataDir The directory containing the dataset
+   * @param options NEAT options (must include discoveryCacheDir)
+   */
+  scheduleReplay(
+    creature: Creature,
+    dataDir: string,
+    options: NeatOptions,
+  ): void {
+    const config = createNeatConfig(options);
+
+    // Skip if no cache directory is configured
+    if (!config.discoveryCacheDir) {
+      return;
+    }
+
+    if (this.#replayInProgress) {
+      // Queue this creature to be processed when the current replay completes
+      // Only keep the most recent queued creature
+      this.#queuedCreature = {
+        creature: creature.shallowClone(),
+        dataDir,
+        options,
+      };
+      return;
+    }
+
+    // Start the replay in the background
+    this.#startReplay(creature.shallowClone(), dataDir, options);
+  }
+
+  /**
+   * Start a replay in the background (non-blocking).
+   */
+  #startReplay(
+    creature: Creature,
+    dataDir: string,
+    options: NeatOptions,
+  ): void {
+    this.#replayInProgress = true;
+
+    this.#currentPromise = this.#deps.replayDir!(creature, dataDir, options)
+      .then((result) => {
+        this.#completedResults.push(result);
+      })
+      .catch((error) => {
+        console.error("[DiscoveryReplayQueue] Replay failed:", error);
+      })
+      .finally(() => {
+        this.#replayInProgress = false;
+        this.#currentPromise = null;
+
+        // Process the next queued creature if any
+        if (this.#queuedCreature) {
+          const queued = this.#queuedCreature;
+          this.#queuedCreature = null;
+          this.#startReplay(queued.creature, queued.dataDir, queued.options);
+        }
+      });
+  }
+
+  /**
+   * Check if a replay is currently in progress.
+   */
+  isReplayInProgress(): boolean {
+    return this.#replayInProgress;
+  }
+
+  /**
+   * Get and remove completed replay results.
+   * Returns an array of results that can be integrated into the population.
+   */
+  getCompletedResults(): DiscoveryReplayDirResult[] {
+    return [...this.#completedResults];
+  }
+
+  /**
+   * Clear all completed results after they have been processed.
+   */
+  clearCompletedResults(): void {
+    this.#completedResults.length = 0;
+  }
+
+  /**
+   * Wait for any in-progress replay to complete.
+   * Useful for testing and graceful shutdown.
+   */
+  async waitForCompletion(): Promise<void> {
+    // Collect all promises to wait for rather than awaiting in loop
+    while (this.#currentPromise || this.#queuedCreature) {
+      const promiseToWait = this.#currentPromise;
+      if (promiseToWait) {
+        // deno-lint-ignore no-await-in-loop
+        await promiseToWait;
+      }
+      // Small delay to allow the finally block to process queued creatures
+      // deno-lint-ignore no-await-in-loop
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+  }
+}

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -35,6 +35,7 @@ import { DiscoverStructure } from "../architecture/ErrorGuidedStructuralEvolutio
 import { isRustDiscoveryEnabled } from "../architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import { validateAfterDiscoveryOrThrow } from "../discovery/DiscoveryPostValidate.ts";
 import { PlateauDetector } from "./PlateauDetector.ts";
+import { DiscoveryReplayQueue } from "./DiscoveryReplayQueue.ts";
 
 /**
  * NEAT (NeuroEvolution of Augmenting Topologies) implementation.
@@ -76,6 +77,15 @@ export class Neat {
   CRISPRs: CrisprInterface[];
   /** Plateau detector for fitness stagnation detection (Issue #1039) */
   readonly plateauDetector: PlateauDetector;
+
+  /**
+   * Discovery replay queue for non-blocking background replay of cached
+   * discoveries against new fittest creatures (Issue #997).
+   */
+  readonly discoveryReplayQueue: DiscoveryReplayQueue;
+
+  /** Data directory for discovery replay (Issue #997) */
+  private dataDir?: string;
 
   /**
    * Creates a new NEAT instance for evolving neural networks.
@@ -121,6 +131,20 @@ export class Neat {
 
     // Initialize plateau detector (Issue #1039)
     this.plateauDetector = new PlateauDetector(this.config.plateauDetection);
+
+    // Initialize discovery replay queue (Issue #997)
+    this.discoveryReplayQueue = new DiscoveryReplayQueue();
+  }
+
+  /**
+   * Set the data directory for discovery replay (Issue #997).
+   * This is needed because the Neat class doesn't have direct access to the
+   * data directory - it's typically passed to evolveDir in Creature.
+   *
+   * @param dataDir The data directory containing training data
+   */
+  setDataDir(dataDir: string): void {
+    this.dataDir = dataDir;
   }
 
   /**
@@ -739,6 +763,17 @@ export class Neat {
           }
         }
       }
+
+      // Issue #997: Schedule background replay of cached discoveries against the new fittest.
+      // This allows learnings from previous discovery runs to be applied when evolution
+      // progresses. The replay runs in a non-blocking manner, one at a time.
+      if (this.dataDir && this.config.discoveryCacheDir) {
+        this.discoveryReplayQueue.scheduleReplay(
+          fittest,
+          this.dataDir,
+          this.config,
+        );
+      }
     }
 
     if (trainingTimeOutMinutes !== -1) { // If not timed out already
@@ -989,6 +1024,47 @@ export class Neat {
       r.discover.improvedCreature = null;
     }
     this.discoveryComplete.length = 0;
+
+    // Issue #997: Process completed background replay results and add improved
+    // creatures to the population. These are creatures that have had cached
+    // discovery improvements re-applied from previous evolution runs.
+    const replayResults = this.discoveryReplayQueue.getCompletedResults();
+    for (const result of replayResults) {
+      if (result.improvement?.creature) {
+        // The creature field is typed as `unknown` in DiscoveryReplayDirResult
+        // but is actually a CreatureExport from exportJSON()
+        const replayedCreature = Creature.fromJSON(
+          result.improvement.creature as Parameters<
+            typeof Creature.fromJSON
+          >[0],
+        );
+        CreatureUtil.makeUUID(replayedCreature);
+
+        // Tag the creature to indicate it came from discovery replay
+        addTag(replayedCreature, "approach", "discovery-replay" as Approach);
+
+        validateAfterDiscoveryOrThrow({
+          baseCreature: fittest,
+          discoveredCreature: replayedCreature,
+          discoveryID: result.improvement.key ?? "replay",
+          operation: "discovery-replay-addition",
+          feedbackLoop: this.config.feedbackLoop,
+        });
+
+        trainedPopulation.push(replayedCreature);
+
+        if (this.config.verbose) {
+          console.info(
+            `[Neat] Added replayed creature ${
+              blue(replayedCreature.uuid?.substring(0, 8) ?? "unknown")
+            } to population (score improvement: ${
+              result.improvement.scoreDelta?.toFixed(4) ?? "N/A"
+            })`,
+          );
+        }
+      }
+    }
+    this.discoveryReplayQueue.clearCompletedResults();
 
     /** make sure we do at least one more loop */
     if (trainedPopulation.length > 0 && this.additionalGenerationCount <= 0) {

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -239,6 +239,25 @@ export interface NeatArguments {
   discoverySkipRecordPhase: boolean;
 
   /**
+   * Base directory for discovery caching (Issue #997).
+   *
+   * When provided, this serves as the base directory for discovery cache operations:
+   * - Success cache is stored in `{discoveryCacheDir}/success/`
+   * - Failure cache is stored in `{discoveryCacheDir}/failure/`
+   *
+   * Additionally, when a new "fittest" creature is found during evolution,
+   * the cached discoveries are replayed against it in a non-blocking manner.
+   * This allows learnings from previous discovery runs to be applied when
+   * evolution restarts.
+   *
+   * The explicit `discoverySuccessCacheDir` and `discoveryFailureCacheDir`
+   * options take precedence over paths derived from this base directory.
+   *
+   * Delete this directory when the training dataset changes materially.
+   */
+  discoveryCacheDir?: string;
+
+  /**
    * Directory path to cache discovery failures.
    * When provided, discovery candidates that fail to improve the score are cached.
    * Subsequent discovery runs will skip candidates that match cached failures.

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -191,8 +191,27 @@ export function createNeatConfig(options: NeatOptions): NeatConfig {
     discoveryDisableCleanup: options.discoveryDisableCleanup ?? false,
     discoveryBaseDirectory: options.discoveryBaseDirectory,
     discoverySkipRecordPhase: options.discoverySkipRecordPhase ?? false,
-    discoveryFailureCacheDir: options.discoveryFailureCacheDir,
-    discoverySuccessCacheDir: options.discoverySuccessCacheDir,
+    // Issue #997: discoveryCacheDir provides a base directory for discovery caching.
+    // Empty strings are treated as undefined (not provided).
+    discoveryCacheDir:
+      options.discoveryCacheDir && options.discoveryCacheDir.trim()
+        ? options.discoveryCacheDir.trim()
+        : undefined,
+    // Issue #997: Derive failure/success cache dirs from discoveryCacheDir if not explicitly set.
+    discoveryFailureCacheDir: (() => {
+      if (options.discoveryFailureCacheDir) {
+        return options.discoveryFailureCacheDir;
+      }
+      const base = options.discoveryCacheDir?.trim();
+      return base ? `${base}/failure` : undefined;
+    })(),
+    discoverySuccessCacheDir: (() => {
+      if (options.discoverySuccessCacheDir) {
+        return options.discoverySuccessCacheDir;
+      }
+      const base = options.discoveryCacheDir?.trim();
+      return base ? `${base}/success` : undefined;
+    })(),
     discoveryReplayMaxSingles: options.discoveryReplayMaxSingles ??
       Math.max(2 * (options.threads ?? 1), 10),
     discoveryReplayMaxPairwise: options.discoveryReplayMaxPairwise ?? 10,

--- a/test/NEAT/DiscoveryCacheDir.ts
+++ b/test/NEAT/DiscoveryCacheDir.ts
@@ -1,0 +1,73 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+
+/**
+ * Tests for discoveryCacheDir option in NeatOptions (Issue #997).
+ *
+ * The discoveryCacheDir option enables:
+ * 1. Specifying a directory for discovery caching
+ * 2. Automatic background replay of discoveries against new fittest creatures
+ * 3. Passing the cache directory to the discovery process
+ */
+
+Deno.test("NeatConfig discoveryCacheDir - not set by default", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.discoveryCacheDir, undefined);
+});
+
+Deno.test("NeatConfig discoveryCacheDir - accepts valid directory path", () => {
+  const config = createNeatConfig({
+    discoveryCacheDir: "/tmp/discovery-cache",
+  });
+  assertEquals(config.discoveryCacheDir, "/tmp/discovery-cache");
+});
+
+Deno.test("NeatConfig discoveryCacheDir - accepts relative path", () => {
+  const config = createNeatConfig({
+    discoveryCacheDir: ".discovery/cache",
+  });
+  assertEquals(config.discoveryCacheDir, ".discovery/cache");
+});
+
+Deno.test("NeatConfig discoveryCacheDir - sets success and failure cache subdirectories", () => {
+  const config = createNeatConfig({
+    discoveryCacheDir: "/tmp/my-discovery-cache",
+  });
+
+  // When discoveryCacheDir is set, it should automatically configure
+  // discoverySuccessCacheDir and discoveryFailureCacheDir as subdirectories
+  assertExists(config.discoveryCacheDir);
+  assertEquals(config.discoveryCacheDir, "/tmp/my-discovery-cache");
+
+  // The success and failure cache dirs should be derived from discoveryCacheDir
+  // if not explicitly provided
+  assertEquals(
+    config.discoverySuccessCacheDir,
+    "/tmp/my-discovery-cache/success",
+  );
+  assertEquals(
+    config.discoveryFailureCacheDir,
+    "/tmp/my-discovery-cache/failure",
+  );
+});
+
+Deno.test("NeatConfig discoveryCacheDir - explicit success/failure dirs override derived ones", () => {
+  const config = createNeatConfig({
+    discoveryCacheDir: "/tmp/my-discovery-cache",
+    discoverySuccessCacheDir: "/custom/success",
+    discoveryFailureCacheDir: "/custom/failure",
+  });
+
+  // Explicit values should override the derived ones
+  assertEquals(config.discoverySuccessCacheDir, "/custom/success");
+  assertEquals(config.discoveryFailureCacheDir, "/custom/failure");
+});
+
+Deno.test("NeatConfig discoveryCacheDir - empty string is treated as undefined", () => {
+  const config = createNeatConfig({
+    discoveryCacheDir: "",
+  });
+  assertEquals(config.discoveryCacheDir, undefined);
+  assertEquals(config.discoverySuccessCacheDir, undefined);
+  assertEquals(config.discoveryFailureCacheDir, undefined);
+});

--- a/test/NEAT/DiscoveryReplayQueue.ts
+++ b/test/NEAT/DiscoveryReplayQueue.ts
@@ -1,0 +1,402 @@
+import { assertEquals, assertExists } from "@std/assert";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+import {
+  DiscoveryReplayQueue,
+  type DiscoveryReplayQueueDeps,
+} from "../../src/NEAT/DiscoveryReplayQueue.ts";
+import type { NeatOptions } from "../../src/config/NeatOptions.ts";
+
+/**
+ * Tests for DiscoveryReplayQueue (Issue #997).
+ *
+ * The DiscoveryReplayQueue handles non-blocking background replay of
+ * cached discoveries against the current fittest creature.
+ */
+
+function makeBaseCreature(): Creature {
+  const base: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-0", type: "hidden", squash: IDENTITY.NAME, bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.25 },
+    ],
+  };
+  return Creature.fromJSON(base);
+}
+
+Deno.test("DiscoveryReplayQueue - schedules replay when new fittest is detected", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "fittest-1";
+
+  let replayStarted = false;
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: (
+      _creature: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+    ) => {
+      replayStarted = true;
+      return Promise.resolve({
+        original: { error: 0.5, score: 0.5 },
+        evaluatedSingles: 0,
+        evaluatedCombos: 0,
+        pruned: 0,
+        skippedAlreadyApplied: 0,
+        skippedNotApplicable: 0,
+      });
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+
+  // Schedule replay for the fittest creature
+  queue.scheduleReplay(creature, "/tmp/data", {
+    discoveryCacheDir: "/tmp/cache",
+    costOfGrowth: 0,
+  });
+
+  // Wait for the async operation to complete
+  await queue.waitForCompletion();
+
+  assertEquals(replayStarted, true, "Replay should have been started");
+});
+
+Deno.test("DiscoveryReplayQueue - only one replay at a time", async () => {
+  const creature1 = makeBaseCreature();
+  creature1.uuid = "fittest-1";
+
+  const creature2 = makeBaseCreature();
+  creature2.uuid = "fittest-2";
+
+  let activeReplays = 0;
+  let maxActiveReplays = 0;
+  let totalReplays = 0;
+
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: async (
+      _creature: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+    ) => {
+      activeReplays++;
+      totalReplays++;
+      maxActiveReplays = Math.max(maxActiveReplays, activeReplays);
+
+      // Simulate some processing time
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      activeReplays--;
+      return {
+        original: { error: 0.5, score: 0.5 },
+        evaluatedSingles: 0,
+        evaluatedCombos: 0,
+        pruned: 0,
+        skippedAlreadyApplied: 0,
+        skippedNotApplicable: 0,
+      };
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+
+  // Schedule multiple replays rapidly
+  queue.scheduleReplay(creature1, "/tmp/data", {
+    discoveryCacheDir: "/tmp/cache",
+    costOfGrowth: 0,
+  });
+  queue.scheduleReplay(creature2, "/tmp/data", {
+    discoveryCacheDir: "/tmp/cache",
+    costOfGrowth: 0,
+  });
+
+  // Wait for all operations to complete
+  await queue.waitForCompletion();
+
+  assertEquals(maxActiveReplays, 1, "Only one replay should run at a time");
+  // The second creature should be queued, so eventually both should run
+  assertEquals(totalReplays >= 1, true, "At least one replay should have run");
+});
+
+Deno.test("DiscoveryReplayQueue - returns improved creature", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "fittest-1";
+
+  const improvedCreature = makeBaseCreature();
+  improvedCreature.uuid = "improved-1";
+
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: (
+      _creature: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+    ) => {
+      return Promise.resolve({
+        original: { error: 0.5, score: 0.5 },
+        improvement: {
+          key: "test-key",
+          changeType: "add-synapses",
+          error: 0.4,
+          score: 0.6,
+          scoreDelta: 0.1,
+          message: "Improved!",
+          creature: improvedCreature.exportJSON(),
+        },
+        evaluatedSingles: 1,
+        evaluatedCombos: 0,
+        pruned: 0,
+        skippedAlreadyApplied: 0,
+        skippedNotApplicable: 0,
+      });
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+
+  queue.scheduleReplay(creature, "/tmp/data", {
+    discoveryCacheDir: "/tmp/cache",
+    costOfGrowth: 0,
+  });
+
+  await queue.waitForCompletion();
+
+  const results = queue.getCompletedResults();
+  assertEquals(results.length, 1, "Should have one completed result");
+  assertExists(results[0].improvement, "Result should have improvement");
+  assertEquals(results[0].improvement?.score, 0.6);
+});
+
+Deno.test("DiscoveryReplayQueue - skips replay if no cache directory", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "fittest-1";
+
+  let replayAttempted = false;
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: (
+      _creature: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+    ) => {
+      replayAttempted = true;
+      return Promise.resolve({
+        original: { error: 0.5, score: 0.5 },
+        evaluatedSingles: 0,
+        evaluatedCombos: 0,
+        pruned: 0,
+        skippedAlreadyApplied: 0,
+        skippedNotApplicable: 0,
+      });
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+
+  // No discoveryCacheDir provided
+  queue.scheduleReplay(creature, "/tmp/data", {
+    costOfGrowth: 0,
+  });
+
+  await queue.waitForCompletion();
+
+  assertEquals(
+    replayAttempted,
+    false,
+    "Replay should not be attempted without cache directory",
+  );
+});
+
+Deno.test("DiscoveryReplayQueue - queues newest fittest when replay in progress", async () => {
+  const creature1 = makeBaseCreature();
+  creature1.uuid = "fittest-1";
+
+  const creature2 = makeBaseCreature();
+  creature2.uuid = "fittest-2";
+
+  const creature3 = makeBaseCreature();
+  creature3.uuid = "fittest-3";
+
+  const replayedCreatures: string[] = [];
+  // deno-lint-ignore no-explicit-any
+  let firstReplayResolve: any = null;
+
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: async (
+      creature: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+    ) => {
+      replayedCreatures.push(creature.uuid ?? "unknown");
+
+      // First replay waits for signal to complete
+      if (creature.uuid === "fittest-1") {
+        await new Promise<void>((resolve) => {
+          firstReplayResolve = resolve;
+        });
+      }
+
+      return {
+        original: { error: 0.5, score: 0.5 },
+        evaluatedSingles: 0,
+        evaluatedCombos: 0,
+        pruned: 0,
+        skippedAlreadyApplied: 0,
+        skippedNotApplicable: 0,
+      };
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+  const opts = { discoveryCacheDir: "/tmp/cache", costOfGrowth: 0 };
+
+  // Start first replay
+  queue.scheduleReplay(creature1, "/tmp/data", opts);
+
+  // Wait a tick for replay to start
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  // Queue more creatures while replay is in progress
+  queue.scheduleReplay(creature2, "/tmp/data", opts);
+  queue.scheduleReplay(creature3, "/tmp/data", opts);
+
+  // Complete the first replay
+  if (firstReplayResolve) {
+    firstReplayResolve();
+  }
+
+  await queue.waitForCompletion();
+
+  // Should replay the first creature, and then the last queued creature
+  // (creature2 should be replaced by creature3 in the queue)
+  assertEquals(replayedCreatures[0], "fittest-1");
+  // The second replay should be the newest queued creature
+  assertEquals(
+    replayedCreatures.includes("fittest-3"),
+    true,
+    "Should replay the newest queued creature",
+  );
+});
+
+Deno.test("DiscoveryReplayQueue - isReplayInProgress returns correct state", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "fittest-1";
+
+  // deno-lint-ignore no-explicit-any
+  let replayResolve: any = null;
+
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: async (
+      _creature: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+    ) => {
+      await new Promise<void>((resolve) => {
+        replayResolve = resolve;
+      });
+
+      return {
+        original: { error: 0.5, score: 0.5 },
+        evaluatedSingles: 0,
+        evaluatedCombos: 0,
+        pruned: 0,
+        skippedAlreadyApplied: 0,
+        skippedNotApplicable: 0,
+      };
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+
+  assertEquals(
+    queue.isReplayInProgress(),
+    false,
+    "No replay should be in progress initially",
+  );
+
+  queue.scheduleReplay(creature, "/tmp/data", {
+    discoveryCacheDir: "/tmp/cache",
+    costOfGrowth: 0,
+  });
+
+  // Wait a tick for replay to start
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assertEquals(
+    queue.isReplayInProgress(),
+    true,
+    "Replay should be in progress",
+  );
+
+  // Complete the replay
+  if (replayResolve) {
+    replayResolve();
+  }
+
+  await queue.waitForCompletion();
+
+  assertEquals(
+    queue.isReplayInProgress(),
+    false,
+    "No replay should be in progress after completion",
+  );
+});
+
+Deno.test("DiscoveryReplayQueue - clearCompletedResults removes results", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "fittest-1";
+
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: (
+      _creature: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+    ) => {
+      return Promise.resolve({
+        original: { error: 0.5, score: 0.5 },
+        improvement: {
+          key: "test-key",
+          changeType: "add-synapses",
+          error: 0.4,
+          score: 0.6,
+          scoreDelta: 0.1,
+          message: "Improved!",
+          creature: creature.exportJSON(),
+        },
+        evaluatedSingles: 1,
+        evaluatedCombos: 0,
+        pruned: 0,
+        skippedAlreadyApplied: 0,
+        skippedNotApplicable: 0,
+      });
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+
+  queue.scheduleReplay(creature, "/tmp/data", {
+    discoveryCacheDir: "/tmp/cache",
+    costOfGrowth: 0,
+  });
+
+  await queue.waitForCompletion();
+
+  assertEquals(
+    queue.getCompletedResults().length,
+    1,
+    "Should have one result",
+  );
+
+  queue.clearCompletedResults();
+
+  assertEquals(
+    queue.getCompletedResults().length,
+    0,
+    "Results should be cleared",
+  );
+});


### PR DESCRIPTION
## Summary

This PR implements Issue #997: NEAT Options to accept a discovery cache
directory.

### Changes Made

1. **New `discoveryCacheDir` option in NeatOptions**
   - Added a new configuration option `discoveryCacheDir` to `NeatArguments.ts`
   - When provided, this base directory is used to derive the
     `discoverySuccessCacheDir` (`{base}/success`) and
     `discoveryFailureCacheDir` (`{base}/failure`) unless explicitly overridden
   - Empty strings are treated as undefined

2. **Non-blocking background replay of cached discoveries**
   - Created new `DiscoveryReplayQueue` class
     (`src/NEAT/DiscoveryReplayQueue.ts`) that handles background replay of
     cached discoveries against new fittest creatures
   - Key features:
     - Only one replay process runs at a time (as per issue requirements)
     - When a new fittest is found during replay, it's queued for processing
       next
     - Only the most recent queued creature is kept (older ones are discarded)
     - Completed results are collected and integrated into the population

3. **Integration with Neat class evolution loop**
   - When a new "fittest" creature is found during evolution and
     `discoveryCacheDir` is configured, the discovery replay is automatically
     scheduled in the background
   - Completed replay results are processed and improved creatures are added to
     the population with the `discovery-replay` approach tag
   - The data directory is passed to the Neat instance via `setDataDir()` to
     enable replay functionality

### Benefits

- **Persistence of learnings**: Discoveries from previous evolution runs can be
  re-applied when evolution restarts
- **Non-blocking**: The replay process runs in the background and doesn't block
  the main evolution loop
- **Automatic configuration**: Setting `discoveryCacheDir` automatically
  configures the success and failure cache directories

## Evidence

Unable to generate screenshot: This is a CLI-only tool/library with no visual
interface. The feature adds configuration options and background processing that
don't produce visual output.

## Test Plan

- Added `test/NEAT/DiscoveryCacheDir.ts` with 6 tests covering:
  - Default value is undefined
  - Accepts valid directory paths
  - Accepts relative paths
  - Derives success/failure cache subdirectories automatically
  - Explicit success/failure dirs override derived ones
  - Empty strings treated as undefined

- Added `test/NEAT/DiscoveryReplayQueue.ts` with 7 tests covering:
  - Schedules replay when new fittest is detected
  - Only one replay runs at a time
  - Returns improved creature in results
  - Skips replay if no cache directory configured
  - Queues newest fittest when replay in progress
  - `isReplayInProgress()` returns correct state
  - `clearCompletedResults()` removes results

All 1383 existing tests continue to pass.

---

## Automated Fix Details
This PR addresses issue #997: **Neat Options to accept discovery cache**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #997