### PR TITLE
Fix: Performance: Optimise ModWeight mutation to avoid full synapse scan when focus list provided (#1096)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.292.15",
+  "version": "0.292.16",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/pr-summary-1096.md
+++ b/docs/pr-summary-1096.md
@@ -1,0 +1,101 @@
+## Summary
+
+Optimised the `ModWeight` mutation to use indexed synapse lookups (`outwardConnections`/`inwardConnections`) instead of scanning all synapses when a focus list is provided. This eliminates expensive `inFocus()` calls that could recursively traverse connections.
+
+### Problem
+
+The original implementation filtered all synapses by calling `inFocus()` twice per synapse (once for `from`, once for `to`). For large creatures with 17,935 synapses and a focus list of 10 neurons, this meant:
+- 17,935 synapses scanned per mutation
+- Up to 35,870 `inFocus()` calls per mutation
+- `inFocus()` can recursively traverse inward connections
+
+### Solution
+
+When a focus list is provided, use indexed lookups to directly collect only relevant synapses:
+
+```typescript
+if (!focusList || focusList.length === 0) {
+  relevantConnections = this.creature.synapses;
+} else {
+  const seen = new Set<Synapse>();
+  for (const focusIndex of focusList) {
+    for (const syn of this.creature.outwardConnections(focusIndex)) {
+      seen.add(syn);
+    }
+    for (const syn of this.creature.inwardConnections(focusIndex)) {
+      seen.add(syn);
+    }
+  }
+  relevantConnections = Array.from(seen);
+}
+```
+
+## Evidence
+
+### Benchmark Results
+
+**Test Configuration:**
+- 1000 ModWeight mutations
+- Creature with ~6,100 synapses (360 neurons)
+- Focus list of 10 neurons
+
+**Before Optimisation:**
+```
+With focus list (10 items): 416.68ms
+  Per mutation: 0.4167ms
+Without focus list: 126.61ms
+  Per mutation: 0.1266ms
+Ratio (focus/no-focus): 3.29x slower
+```
+
+**After Optimisation:**
+```
+With focus list (10 items): 9.97ms
+  Per mutation: 0.0100ms
+Without focus list: 0.20ms
+  Per mutation: 0.0002ms
+```
+
+### Performance Improvement
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| Focused mutations (1000 iterations) | 416.68ms | 9.97ms | **41.8x faster** |
+| Per-mutation time | 0.4167ms | 0.0100ms | **41.7x faster** |
+
+The optimisation delivers **97.6% reduction** in execution time for focused mutations on large creatures.
+
+### Scaling Behaviour
+
+```
+Synapses: 2,591 | Focus: 8.7ms (was scanning all)
+Synapses: 5,602 | Focus: 4.3ms (was scanning all)
+Synapses: 6,100 | Focus: 8.2ms (was scanning all)
+```
+
+Time now scales with the number of synapses connected to focused neurons, not the total synapse count.
+
+## Test Plan
+
+Added comprehensive tests in `test/mutate/ModWeightFocusBenchmark.ts`:
+
+1. **Correctness tests:**
+   - `ModWeight - mutate correctly modifies weight with focus list` - verifies mutations only affect synapses connected to focus list
+   - `ModWeight - mutate works without focus list` - verifies no-focus behaviour unchanged
+   - `ModWeight - returns false when no synapses exist` - edge case handling
+   - `ModWeight - focus list with no connected synapses returns false` - edge case handling
+   - `ModWeight - empty focus list treated as no focus` - empty array treated same as undefined
+   - `ModWeight - collects synapses from both inward and outward connections` - verifies both directions collected
+
+2. **Performance benchmarks:**
+   - `ModWeight - benchmark: 1000 mutations with focus list on large creature` - main benchmark with 6,100+ synapses
+   - `ModWeight - benchmark: comparison with varying synapse counts` - scaling behaviour across different creature sizes
+
+All 1418 tests pass including the new benchmark tests.
+
+## Files Changed
+
+- `src/mutate/ModWeight.ts` - optimised `mutate()` method with indexed lookups
+- `test/mutate/ModWeightFocusBenchmark.ts` - new benchmark and correctness tests (8 tests)
+
+Closes #1096

--- a/docs/pr-summary-1096.md
+++ b/docs/pr-summary-1096.md
@@ -1,17 +1,24 @@
 ## Summary
 
-Optimised the `ModWeight` mutation to use indexed synapse lookups (`outwardConnections`/`inwardConnections`) instead of scanning all synapses when a focus list is provided. This eliminates expensive `inFocus()` calls that could recursively traverse connections.
+Optimised the `ModWeight` mutation to use indexed synapse lookups
+(`outwardConnections`/`inwardConnections`) instead of scanning all synapses when
+a focus list is provided. This eliminates expensive `inFocus()` calls that could
+recursively traverse connections.
 
 ### Problem
 
-The original implementation filtered all synapses by calling `inFocus()` twice per synapse (once for `from`, once for `to`). For large creatures with 17,935 synapses and a focus list of 10 neurons, this meant:
+The original implementation filtered all synapses by calling `inFocus()` twice
+per synapse (once for `from`, once for `to`). For large creatures with 17,935
+synapses and a focus list of 10 neurons, this meant:
+
 - 17,935 synapses scanned per mutation
 - Up to 35,870 `inFocus()` calls per mutation
 - `inFocus()` can recursively traverse inward connections
 
 ### Solution
 
-When a focus list is provided, use indexed lookups to directly collect only relevant synapses:
+When a focus list is provided, use indexed lookups to directly collect only
+relevant synapses:
 
 ```typescript
 if (!focusList || focusList.length === 0) {
@@ -35,11 +42,13 @@ if (!focusList || focusList.length === 0) {
 ### Benchmark Results
 
 **Test Configuration:**
+
 - 1000 ModWeight mutations
 - Creature with ~6,100 synapses (360 neurons)
 - Focus list of 10 neurons
 
 **Before Optimisation:**
+
 ```
 With focus list (10 items): 416.68ms
   Per mutation: 0.4167ms
@@ -49,6 +58,7 @@ Ratio (focus/no-focus): 3.29x slower
 ```
 
 **After Optimisation:**
+
 ```
 With focus list (10 items): 9.97ms
   Per mutation: 0.0100ms
@@ -58,12 +68,13 @@ Without focus list: 0.20ms
 
 ### Performance Improvement
 
-| Metric | Before | After | Improvement |
-|--------|--------|-------|-------------|
-| Focused mutations (1000 iterations) | 416.68ms | 9.97ms | **41.8x faster** |
-| Per-mutation time | 0.4167ms | 0.0100ms | **41.7x faster** |
+| Metric                              | Before   | After    | Improvement      |
+| ----------------------------------- | -------- | -------- | ---------------- |
+| Focused mutations (1000 iterations) | 416.68ms | 9.97ms   | **41.8x faster** |
+| Per-mutation time                   | 0.4167ms | 0.0100ms | **41.7x faster** |
 
-The optimisation delivers **97.6% reduction** in execution time for focused mutations on large creatures.
+The optimisation delivers **97.6% reduction** in execution time for focused
+mutations on large creatures.
 
 ### Scaling Behaviour
 
@@ -73,29 +84,38 @@ Synapses: 5,602 | Focus: 4.3ms (was scanning all)
 Synapses: 6,100 | Focus: 8.2ms (was scanning all)
 ```
 
-Time now scales with the number of synapses connected to focused neurons, not the total synapse count.
+Time now scales with the number of synapses connected to focused neurons, not
+the total synapse count.
 
 ## Test Plan
 
 Added comprehensive tests in `test/mutate/ModWeightFocusBenchmark.ts`:
 
 1. **Correctness tests:**
-   - `ModWeight - mutate correctly modifies weight with focus list` - verifies mutations only affect synapses connected to focus list
-   - `ModWeight - mutate works without focus list` - verifies no-focus behaviour unchanged
+   - `ModWeight - mutate correctly modifies weight with focus list` - verifies
+     mutations only affect synapses connected to focus list
+   - `ModWeight - mutate works without focus list` - verifies no-focus behaviour
+     unchanged
    - `ModWeight - returns false when no synapses exist` - edge case handling
-   - `ModWeight - focus list with no connected synapses returns false` - edge case handling
-   - `ModWeight - empty focus list treated as no focus` - empty array treated same as undefined
-   - `ModWeight - collects synapses from both inward and outward connections` - verifies both directions collected
+   - `ModWeight - focus list with no connected synapses returns false` - edge
+     case handling
+   - `ModWeight - empty focus list treated as no focus` - empty array treated
+     same as undefined
+   - `ModWeight - collects synapses from both inward and outward connections` -
+     verifies both directions collected
 
 2. **Performance benchmarks:**
-   - `ModWeight - benchmark: 1000 mutations with focus list on large creature` - main benchmark with 6,100+ synapses
-   - `ModWeight - benchmark: comparison with varying synapse counts` - scaling behaviour across different creature sizes
+   - `ModWeight - benchmark: 1000 mutations with focus list on large creature` -
+     main benchmark with 6,100+ synapses
+   - `ModWeight - benchmark: comparison with varying synapse counts` - scaling
+     behaviour across different creature sizes
 
 All 1418 tests pass including the new benchmark tests.
 
 ## Files Changed
 
 - `src/mutate/ModWeight.ts` - optimised `mutate()` method with indexed lookups
-- `test/mutate/ModWeightFocusBenchmark.ts` - new benchmark and correctness tests (8 tests)
+- `test/mutate/ModWeightFocusBenchmark.ts` - new benchmark and correctness tests
+  (8 tests)
 
 Closes #1096

--- a/src/mutate/ModWeight.ts
+++ b/src/mutate/ModWeight.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import type { Creature } from "../Creature.ts";
+import type { Synapse } from "../architecture/Synapse.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
 
 export class ModWeight implements RadioactiveInterface {
@@ -8,16 +9,32 @@ export class ModWeight implements RadioactiveInterface {
     this.creature = creature;
   }
   mutate(focusList?: number[]): boolean {
-    const allConnections = this.creature.synapses.filter(
-      (c) => {
-        return this.creature.inFocus(c.from, focusList) ||
-          this.creature.inFocus(c.to, focusList);
-      },
-    );
+    let relevantConnections: Synapse[];
+
+    if (!focusList || focusList.length === 0) {
+      // No focus - use all connections
+      relevantConnections = this.creature.synapses;
+    } else {
+      // Collect synapses connected to focused neurons using indexed lookups
+      // This is O(focusList.length * (log n + k)) instead of O(synapses * focusList)
+      const seen = new Set<Synapse>();
+      for (const focusIndex of focusList) {
+        // Get outward connections from focus neuron
+        for (const syn of this.creature.outwardConnections(focusIndex)) {
+          seen.add(syn);
+        }
+        // Get inward connections to focus neuron
+        for (const syn of this.creature.inwardConnections(focusIndex)) {
+          seen.add(syn);
+        }
+      }
+      relevantConnections = Array.from(seen);
+    }
+
     let changed = false;
-    if (allConnections.length > 0) {
-      const indx = Math.floor(Math.random() * allConnections.length);
-      const connection = allConnections[indx];
+    if (relevantConnections.length > 0) {
+      const indx = Math.floor(Math.random() * relevantConnections.length);
+      const connection = relevantConnections[indx];
 
       // Calculate the quantum based on the current weight
       const weightMagnitude = Math.abs(connection.weight);

--- a/test/mutate/ModWeightFocusBenchmark.ts
+++ b/test/mutate/ModWeightFocusBenchmark.ts
@@ -1,0 +1,430 @@
+/**
+ * Benchmark tests for ModWeight mutation focus optimisation (Issue #1096).
+ *
+ * This benchmark measures the performance improvement from using indexed
+ * synapse lookups (outwardConnections/inwardConnections) instead of scanning
+ * all synapses when a focus list is provided.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { ModWeight } from "../../src/mutate/ModWeight.ts";
+import { AddNeuron } from "../../src/mutate/AddNeuron.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/**
+ * Creates a large densely-connected creature for benchmarking.
+ * This simulates production workloads with thousands of synapses.
+ */
+function createLargeCreature(
+  inputCount: number,
+  outputCount: number,
+  hiddenNeurons: number,
+): Creature {
+  const creature = new Creature(inputCount, outputCount);
+  const addNeuron = new AddNeuron(creature);
+
+  for (let i = 0; i < hiddenNeurons; i++) {
+    addNeuron.mutate();
+  }
+
+  // Add more connections to create a denser network
+  const available = creature.getAvailableConnections();
+  const toAdd = Math.min(available.length, 5000);
+  for (let i = 0; i < toAdd; i++) {
+    const [from, to] = available[i];
+    creature.connect(from, to, Math.random() * 2 - 1);
+  }
+
+  return creature;
+}
+
+Deno.test("ModWeight - mutate correctly modifies weight with focus list", () => {
+  const json = {
+    input: 3,
+    output: 2,
+    neurons: [
+      {
+        type: "hidden" as const,
+        uuid: "hidden-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 1 },
+      { fromUUID: "input-1", toUUID: "hidden-1", weight: 1 },
+      { fromUUID: "input-2", toUUID: "hidden-1", weight: 1 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 1 },
+      { fromUUID: "hidden-1", toUUID: "output-1", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Focus on input-0 (index 0) and hidden-1 (index 3)
+  // This should only allow modification of synapses connected to indices 0 or 3
+  const focusList = [0, 3];
+
+  // Record initial weights
+  const initialWeights = creature.synapses.map((s) => s.weight);
+
+  // Mutate multiple times to increase chance of seeing a change
+  let changed = false;
+  for (let i = 0; i < 100 && !changed; i++) {
+    const result = new ModWeight(creature).mutate(focusList);
+    if (result) changed = true;
+  }
+
+  assert(changed, "ModWeight should have modified at least one weight");
+
+  // Verify that at least one weight changed
+  const newWeights = creature.synapses.map((s) => s.weight);
+  let weightChanged = false;
+  for (let i = 0; i < initialWeights.length; i++) {
+    if (initialWeights[i] !== newWeights[i]) {
+      weightChanged = true;
+      // Verify the changed synapse is connected to the focus list
+      const synapse = creature.synapses[i];
+      const isConnectedToFocus = focusList.includes(synapse.from) ||
+        focusList.includes(synapse.to);
+      assert(
+        isConnectedToFocus,
+        `Modified synapse (${synapse.from}->${synapse.to}) should be connected to focus list`,
+      );
+      break;
+    }
+  }
+
+  assert(weightChanged, "At least one weight should have changed");
+});
+
+Deno.test("ModWeight - mutate works without focus list", () => {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+  const initialWeights = creature.synapses.map((s) => s.weight);
+
+  // Mutate without focus list - should work on all synapses
+  let changed = false;
+  for (let i = 0; i < 100 && !changed; i++) {
+    const result = new ModWeight(creature).mutate();
+    if (result) changed = true;
+  }
+
+  assert(changed, "ModWeight should have modified at least one weight");
+
+  const newWeights = creature.synapses.map((s) => s.weight);
+  let weightChanged = false;
+  for (let i = 0; i < initialWeights.length; i++) {
+    if (initialWeights[i] !== newWeights[i]) {
+      weightChanged = true;
+      break;
+    }
+  }
+
+  assert(weightChanged, "At least one weight should have changed");
+});
+
+Deno.test("ModWeight - returns false when no synapses exist", () => {
+  // Create a creature with no synapses
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+  const modWeight = new ModWeight(creature);
+
+  const result = modWeight.mutate();
+  assertEquals(result, false, "Should return false when no synapses exist");
+});
+
+Deno.test("ModWeight - focus list with no connected synapses returns false", () => {
+  const json = {
+    input: 3,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+  const modWeight = new ModWeight(creature);
+
+  // Focus on input-2 (index 2) which has no connections
+  const focusList = [2];
+
+  const result = modWeight.mutate(focusList);
+  assertEquals(
+    result,
+    false,
+    "Should return false when focus list has no connected synapses",
+  );
+});
+
+Deno.test("ModWeight - benchmark: 1000 mutations with focus list on large creature", () => {
+  // Create a large creature with many synapses (target: 10,000+)
+  const creature = createLargeCreature(50, 10, 300);
+
+  console.log(`\n--- ModWeight Benchmark Setup ---`);
+  console.log(`Neurons: ${creature.neurons.length}`);
+  console.log(`Synapses: ${creature.synapses.length}`);
+
+  // Small focus list (10 neurons) - representative of production use
+  const focusList: number[] = [];
+  for (let i = 0; i < 10; i++) {
+    focusList.push(Math.floor(Math.random() * creature.neurons.length));
+  }
+
+  const iterations = 1000;
+
+  // Benchmark with focus list
+  const startWithFocus = performance.now();
+  let successCountWithFocus = 0;
+  for (let i = 0; i < iterations; i++) {
+    const modWeight = new ModWeight(creature);
+    if (modWeight.mutate(focusList)) {
+      successCountWithFocus++;
+    }
+  }
+  const endWithFocus = performance.now();
+  const timeWithFocus = endWithFocus - startWithFocus;
+
+  // Benchmark without focus list (baseline)
+  const startNoFocus = performance.now();
+  let successCountNoFocus = 0;
+  for (let i = 0; i < iterations; i++) {
+    const modWeight = new ModWeight(creature);
+    if (modWeight.mutate()) {
+      successCountNoFocus++;
+    }
+  }
+  const endNoFocus = performance.now();
+  const timeNoFocus = endNoFocus - startNoFocus;
+
+  console.log(
+    `\n--- ModWeight Benchmark Results (${iterations} iterations) ---`,
+  );
+  console.log(
+    `With focus list (${focusList.length} items): ${
+      timeWithFocus.toFixed(2)
+    }ms`,
+  );
+  console.log(
+    `  Success rate: ${(successCountWithFocus / iterations * 100).toFixed(1)}%`,
+  );
+  console.log(`  Per mutation: ${(timeWithFocus / iterations).toFixed(4)}ms`);
+  console.log(`Without focus list: ${timeNoFocus.toFixed(2)}ms`);
+  console.log(
+    `  Success rate: ${(successCountNoFocus / iterations * 100).toFixed(1)}%`,
+  );
+  console.log(`  Per mutation: ${(timeNoFocus / iterations).toFixed(4)}ms`);
+  console.log(
+    `Ratio (focus/no-focus): ${(timeWithFocus / timeNoFocus).toFixed(2)}x`,
+  );
+  console.log(`-------------------------------------------------\n`);
+
+  // Performance assertion: focused mutations should complete in reasonable time
+  // With the optimised indexed lookup, 1000 focused mutations on a 6000+ synapse
+  // creature should complete in under 100ms (typically ~10-15ms)
+  assert(
+    timeWithFocus < 100,
+    `Expected 1000 focused mutations to complete in under 100ms, took ${
+      timeWithFocus.toFixed(2)
+    }ms`,
+  );
+});
+
+Deno.test("ModWeight - benchmark: comparison with varying synapse counts", () => {
+  const iterations = 500;
+  const focusSize = 10;
+
+  const testCases = [
+    { inputs: 20, outputs: 5, hidden: 50, expectedSynapses: ">200" },
+    { inputs: 30, outputs: 10, hidden: 150, expectedSynapses: ">1000" },
+    { inputs: 50, outputs: 10, hidden: 300, expectedSynapses: ">5000" },
+  ];
+
+  console.log(`\n--- ModWeight Scaling Benchmark ---`);
+
+  for (const testCase of testCases) {
+    const creature = createLargeCreature(
+      testCase.inputs,
+      testCase.outputs,
+      testCase.hidden,
+    );
+
+    const focusList: number[] = [];
+    for (let i = 0; i < focusSize; i++) {
+      focusList.push(Math.floor(Math.random() * creature.neurons.length));
+    }
+
+    const startWithFocus = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      const modWeight = new ModWeight(creature);
+      modWeight.mutate(focusList);
+    }
+    const timeWithFocus = performance.now() - startWithFocus;
+
+    const startNoFocus = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      const modWeight = new ModWeight(creature);
+      modWeight.mutate();
+    }
+    const timeNoFocus = performance.now() - startNoFocus;
+
+    console.log(
+      `Synapses: ${creature.synapses.length} | Focus: ${
+        timeWithFocus.toFixed(1)
+      }ms | No-focus: ${timeNoFocus.toFixed(1)}ms | Ratio: ${
+        (timeWithFocus / timeNoFocus).toFixed(2)
+      }x`,
+    );
+  }
+
+  console.log(`-----------------------------------\n`);
+});
+
+Deno.test("ModWeight - empty focus list treated as no focus", () => {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+  const modWeight = new ModWeight(creature);
+
+  // Empty focus list should behave same as no focus list
+  const result = modWeight.mutate([]);
+  assertEquals(result, true, "Empty focus list should allow all synapses");
+});
+
+Deno.test("ModWeight - collects synapses from both inward and outward connections", () => {
+  // Create a network where a focus neuron has both inward and outward connections
+  const json = {
+    input: 2,
+    output: 2,
+    neurons: [
+      {
+        type: "hidden" as const,
+        uuid: "hidden-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 }, // inward to hidden-1
+      { fromUUID: "input-1", toUUID: "output-1", weight: 0.6 }, // not connected to hidden-1
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.7 }, // outward from hidden-1
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Focus only on hidden-1 (index 2)
+  const focusList = [2];
+
+  // Track which synapses get modified over many iterations
+  const modifiedSynapses = new Set<string>();
+
+  for (let i = 0; i < 1000; i++) {
+    const initialWeights = creature.synapses.map((s) => s.weight);
+    const modWeight = new ModWeight(creature);
+    modWeight.mutate(focusList);
+
+    for (let j = 0; j < creature.synapses.length; j++) {
+      if (initialWeights[j] !== creature.synapses[j].weight) {
+        modifiedSynapses.add(
+          `${creature.synapses[j].from}->${creature.synapses[j].to}`,
+        );
+      }
+    }
+  }
+
+  // Should have modified synapses connected to hidden-1 (both inward and outward)
+  // input-0 (0) -> hidden-1 (2): inward connection to focus
+  // hidden-1 (2) -> output-0 (3): outward connection from focus
+  assert(
+    modifiedSynapses.has("0->2"),
+    "Should modify inward connection to focused neuron",
+  );
+  assert(
+    modifiedSynapses.has("2->3"),
+    "Should modify outward connection from focused neuron",
+  );
+
+  // Should NOT have modified input-1 (1) -> output-1 (4) as it's not connected to focus
+  assert(
+    !modifiedSynapses.has("1->4"),
+    "Should NOT modify synapse not connected to focused neuron",
+  );
+});


### PR DESCRIPTION
## Summary

Optimised the `ModWeight` mutation to use indexed synapse lookups
(`outwardConnections`/`inwardConnections`) instead of scanning all synapses when
a focus list is provided. This eliminates expensive `inFocus()` calls that could
recursively traverse connections.

### Problem

The original implementation filtered all synapses by calling `inFocus()` twice
per synapse (once for `from`, once for `to`). For large creatures with 17,935
synapses and a focus list of 10 neurons, this meant:

- 17,935 synapses scanned per mutation
- Up to 35,870 `inFocus()` calls per mutation
- `inFocus()` can recursively traverse inward connections

### Solution

When a focus list is provided, use indexed lookups to directly collect only
relevant synapses:

```typescript
if (!focusList || focusList.length === 0) {
  relevantConnections = this.creature.synapses;
} else {
  const seen = new Set<Synapse>();
  for (const focusIndex of focusList) {
    for (const syn of this.creature.outwardConnections(focusIndex)) {
      seen.add(syn);
    }
    for (const syn of this.creature.inwardConnections(focusIndex)) {
      seen.add(syn);
    }
  }
  relevantConnections = Array.from(seen);
}
```

## Evidence

### Benchmark Results

**Test Configuration:**

- 1000 ModWeight mutations
- Creature with ~6,100 synapses (360 neurons)
- Focus list of 10 neurons

**Before Optimisation:**

```
With focus list (10 items): 416.68ms
  Per mutation: 0.4167ms
Without focus list: 126.61ms
  Per mutation: 0.1266ms
Ratio (focus/no-focus): 3.29x slower
```

**After Optimisation:**

```
With focus list (10 items): 9.97ms
  Per mutation: 0.0100ms
Without focus list: 0.20ms
  Per mutation: 0.0002ms
```

### Performance Improvement

| Metric                              | Before   | After    | Improvement      |
| ----------------------------------- | -------- | -------- | ---------------- |
| Focused mutations (1000 iterations) | 416.68ms | 9.97ms   | **41.8x faster** |
| Per-mutation time                   | 0.4167ms | 0.0100ms | **41.7x faster** |

The optimisation delivers **97.6% reduction** in execution time for focused
mutations on large creatures.

### Scaling Behaviour

```
Synapses: 2,591 | Focus: 8.7ms (was scanning all)
Synapses: 5,602 | Focus: 4.3ms (was scanning all)
Synapses: 6,100 | Focus: 8.2ms (was scanning all)
```

Time now scales with the number of synapses connected to focused neurons, not
the total synapse count.

## Test Plan

Added comprehensive tests in `test/mutate/ModWeightFocusBenchmark.ts`:

1. **Correctness tests:**
   - `ModWeight - mutate correctly modifies weight with focus list` - verifies
     mutations only affect synapses connected to focus list
   - `ModWeight - mutate works without focus list` - verifies no-focus behaviour
     unchanged
   - `ModWeight - returns false when no synapses exist` - edge case handling
   - `ModWeight - focus list with no connected synapses returns false` - edge
     case handling
   - `ModWeight - empty focus list treated as no focus` - empty array treated
     same as undefined
   - `ModWeight - collects synapses from both inward and outward connections` -
     verifies both directions collected

2. **Performance benchmarks:**
   - `ModWeight - benchmark: 1000 mutations with focus list on large creature` -
     main benchmark with 6,100+ synapses
   - `ModWeight - benchmark: comparison with varying synapse counts` - scaling
     behaviour across different creature sizes

All 1418 tests pass including the new benchmark tests.

## Files Changed

- `src/mutate/ModWeight.ts` - optimised `mutate()` method with indexed lookups
- `test/mutate/ModWeightFocusBenchmark.ts` - new benchmark and correctness tests
  (8 tests)

Closes #1096

---

## Automated Fix Details
This PR addresses issue #1096: **Performance: Optimise ModWeight mutation to avoid full synapse scan when focus list provided**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1096