### PR TITLE
Fix: Performance: Prebuild inward synapse index after breed/mutation batch (#1097)

### DIFF
--- a/bench/PrebuildInwardIndex.ts
+++ b/bench/PrebuildInwardIndex.ts
@@ -1,0 +1,168 @@
+/**
+ * Benchmark: Prebuild inward synapse index after breed/mutation batch (Issue #1097)
+ *
+ * This benchmark measures the performance improvement from proactively prebuilding
+ * the inward synapse index after breeding and mutation operations.
+ *
+ * The optimisation:
+ * - Previously: Lazy index building after 3 cache misses caused O(n) linear scans
+ * - Now: Proactive prebuilding for large creatures (>= 1000 synapses) eliminates
+ *   repeated linear scans during subsequent operations
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write bench/PrebuildInwardIndex.ts
+ */
+import { Creature } from "../src/Creature.ts";
+import { Offspring } from "../src/architecture/Offspring.ts";
+import { Mutator } from "../src/NEAT/Mutator.ts";
+import { createNeatConfig } from "../src/config/NeatConfig.ts";
+
+// Create parent creatures for breeding benchmarks
+const largeMum = new Creature(30, 10, {
+  layers: [{ count: 100 }, { count: 80 }, { count: 50 }],
+});
+largeMum.validate();
+
+const largeDad = new Creature(30, 10, {
+  layers: [{ count: 90 }, { count: 70 }, { count: 60 }],
+});
+largeDad.validate();
+
+console.log("=== Creature Sizes ===");
+console.log(
+  `Parent (mum): ${largeMum.neurons.length} neurons, ${largeMum.synapses.length} synapses`,
+);
+console.log(
+  `Parent (dad): ${largeDad.neurons.length} neurons, ${largeDad.synapses.length} synapses`,
+);
+
+// Create mutator for mutation benchmarks
+const config = createNeatConfig({
+  mutationRate: 1.0,
+  mutationAmount: 3,
+});
+const mutator = new Mutator(config);
+
+/**
+ * Benchmark: Offspring.breed() with prebuild
+ *
+ * This measures the full breeding process including the prebuild optimisation.
+ * The offspring will have its inward index prebuilt immediately after connecting
+ * all synapses, which benefits subsequent validation and memetic updates.
+ */
+Deno.bench({
+  name: "Offspring.breed() with prebuild (current)",
+  group: "Breeding performance",
+  baseline: true,
+  fn() {
+    const offspring = Offspring.breed(largeMum, largeDad);
+    if (offspring) {
+      // Simulate typical post-breeding operations that use inward connections
+      offspring.validate();
+      for (let i = 0; i < 5; i++) {
+        const randomIndex = Math.floor(
+          Math.random() * (offspring.neurons.length - offspring.input),
+        ) + offspring.input;
+        offspring.inwardConnections(randomIndex);
+      }
+    }
+  },
+});
+
+/**
+ * Benchmark: Breeding + multiple inward lookups
+ *
+ * This demonstrates the benefit when many inward lookups are performed
+ * immediately after breeding (e.g., during validation or memetic updates).
+ */
+Deno.bench({
+  name: "Breeding + 20 inward lookups",
+  group: "Post-breeding operations",
+  fn() {
+    const offspring = Offspring.breed(largeMum, largeDad);
+    if (offspring) {
+      // Simulate many inward lookups that benefit from prebuild
+      for (let i = 0; i < 20; i++) {
+        const randomIndex = Math.floor(
+          Math.random() * (offspring.neurons.length - offspring.input),
+        ) + offspring.input;
+        offspring.inwardConnections(randomIndex);
+      }
+    }
+  },
+});
+
+/**
+ * Benchmark: Mutation batch with prebuild
+ *
+ * This measures mutation performance when the prebuild optimisation is applied.
+ * After the mutation batch, the inward index is prebuilt for large creatures.
+ */
+Deno.bench({
+  name: "Mutation batch + inward lookups",
+  group: "Mutation performance",
+  fn() {
+    // Clone a large creature for mutation
+    const creature = Creature.fromJSON(largeMum.exportJSON());
+
+    // Mutate the creature (this triggers prebuild for large creatures)
+    mutator.mutate([creature]);
+
+    // Simulate post-mutation operations that use inward connections
+    for (let i = 0; i < 10; i++) {
+      const randomIndex = Math.floor(
+        Math.random() * (creature.neurons.length - creature.input),
+      ) + creature.input;
+      creature.inwardConnections(randomIndex);
+    }
+  },
+});
+
+/**
+ * Benchmark: Load from JSON with prebuild
+ *
+ * This measures the performance of loading a large creature and immediately
+ * performing inward lookups, which now benefits from the prebuild optimisation.
+ */
+Deno.bench({
+  name: "Load from JSON + inward lookups",
+  group: "Loading performance",
+  fn() {
+    const json = largeMum.exportJSON();
+    const creature = Creature.fromJSON(json);
+
+    // Simulate operations that use inward connections
+    for (let i = 0; i < 10; i++) {
+      const randomIndex = Math.floor(
+        Math.random() * (creature.neurons.length - creature.input),
+      ) + creature.input;
+      creature.inwardConnections(randomIndex);
+    }
+  },
+});
+
+/**
+ * Benchmark: Without prebuild (simulated baseline)
+ *
+ * This simulates the old behaviour by clearing the index after operations
+ * and measuring the cost of lazy rebuilding.
+ */
+Deno.bench({
+  name: "Load + clear cache + inward lookups (no prebuild simulation)",
+  group: "Loading performance",
+  fn() {
+    const json = largeMum.exportJSON();
+    const creature = Creature.fromJSON(json);
+
+    // Simulate the old behaviour by clearing the prebuilt index
+    creature.clearCache();
+
+    // This will now use the lazy build (after 3 cache misses)
+    for (let i = 0; i < 10; i++) {
+      const randomIndex = Math.floor(
+        Math.random() * (creature.neurons.length - creature.input),
+      ) + creature.input;
+      creature.inwardConnections(randomIndex);
+    }
+  },
+});

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.292.16",
+  "version": "0.292.17",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/pr-summary-1097.md
+++ b/docs/pr-summary-1097.md
@@ -2,15 +2,22 @@
 
 ## Summary
 
-This PR adds proactive prebuilding of the inward synapse index for large creatures (>= 1000 synapses) in key locations to eliminate repeated O(n) linear scans during breeding, mutation, and loading operations.
+This PR adds proactive prebuilding of the inward synapse index for large
+creatures (>= 1000 synapses) in key locations to eliminate repeated O(n) linear
+scans during breeding, mutation, and loading operations.
 
-The inward synapse index (`synapsesIndexedByTo`) in `src/Creature.ts` was previously built lazily after 3 cache misses. During breeding and mutation batches, this resulted in multiple linear scans before the index was built. For large creatures with 17,935 synapses, this added up quickly.
+The inward synapse index (`synapsesIndexedByTo`) in `src/Creature.ts` was
+previously built lazily after 3 cache misses. During breeding and mutation
+batches, this resulted in multiple linear scans before the index was built. For
+large creatures with 17,935 synapses, this added up quickly.
 
 ### Changes Made
 
-1. **Added `PREBUILD_SYNAPSE_THRESHOLD` constant** (1000 synapses) to control when proactive prebuilding occurs
+1. **Added `PREBUILD_SYNAPSE_THRESHOLD` constant** (1000 synapses) to control
+   when proactive prebuilding occurs
 2. **Added `isInwardIndexBuilt()` method** for testing the prebuild optimisation
-3. **Added `prebuildInwardIndexIfLarge()` method** that conditionally prebuilds for large creatures
+3. **Added `prebuildInwardIndexIfLarge()` method** that conditionally prebuilds
+   for large creatures
 4. **Called `prebuildInwardIndexIfLarge()` in three key locations:**
    - `Offspring.breed()` - After connecting all synapses
    - `Mutator.mutate()` - After mutation batch completes
@@ -36,6 +43,7 @@ summary
 ```
 
 **Key Performance Improvements:**
+
 - **Load from JSON + inward lookups**: 1.69x faster with prebuild
 - **Breeding + 20 inward lookups**: Benefits from immediate index availability
 - **Mutation batch + inward lookups**: Index available immediately after batch
@@ -43,6 +51,7 @@ summary
 ### How It Works
 
 Before this change:
+
 1. Creature loaded/bred/mutated
 2. First inward connection lookup triggers O(n) linear scan (cache miss 1)
 3. Second lookup triggers another O(n) scan (cache miss 2)
@@ -50,6 +59,7 @@ Before this change:
 5. Fourth lookup finally triggers index build, then uses O(log n) binary search
 
 After this change:
+
 1. Creature loaded/bred/mutated
 2. Index prebuilt immediately for large creatures (>= 1000 synapses)
 3. All lookups use O(log n) binary search from the first call
@@ -58,13 +68,20 @@ After this change:
 
 Added comprehensive tests in `test/PrebuildInwardIndex.ts`:
 
-1. **Offspring.breed() prebuilds inward index for large creatures** - Verifies large offspring have prebuilt index
-2. **Offspring.breed() does not prebuild inward index for small creatures** - Verifies small offspring skip prebuild
-3. **Mutator.mutate() prebuilds inward index for large creatures** - Verifies large mutated creatures have prebuilt index
-4. **prebuildInwardIndexIfLarge() does not build index for small creatures** - Verifies conditional prebuild respects threshold
-5. **Creature.fromJSON() prebuilds inward index for large creatures** - Verifies large loaded creatures have prebuilt index
-6. **Creature.fromJSON() does not prebuild inward index for small creatures** - Verifies small loaded creatures skip prebuild
-7. **loadFrom() prebuilds inward index for large creatures** - Verifies loadFrom() triggers prebuild
+1. **Offspring.breed() prebuilds inward index for large creatures** - Verifies
+   large offspring have prebuilt index
+2. **Offspring.breed() does not prebuild inward index for small creatures** -
+   Verifies small offspring skip prebuild
+3. **Mutator.mutate() prebuilds inward index for large creatures** - Verifies
+   large mutated creatures have prebuilt index
+4. **prebuildInwardIndexIfLarge() does not build index for small creatures** -
+   Verifies conditional prebuild respects threshold
+5. **Creature.fromJSON() prebuilds inward index for large creatures** - Verifies
+   large loaded creatures have prebuilt index
+6. **Creature.fromJSON() does not prebuild inward index for small creatures** -
+   Verifies small loaded creatures skip prebuild
+7. **loadFrom() prebuilds inward index for large creatures** - Verifies
+   loadFrom() triggers prebuild
 8. **prebuildInwardIndex() builds the index** - Verifies explicit prebuild works
 9. **clearCache() clears the inward index** - Verifies cache clearing works
 
@@ -72,13 +89,18 @@ All 1427 tests pass including the new tests.
 
 ## Files Modified
 
-- `src/Creature.ts` - Added PREBUILD_SYNAPSE_THRESHOLD, isInwardIndexBuilt(), prebuildInwardIndexIfLarge(), and call in loadFrom()
-- `src/architecture/Offspring.ts` - Added prebuildInwardIndexIfLarge() call after connecting synapses
-- `src/NEAT/Mutator.ts` - Added prebuildInwardIndexIfLarge() call after mutation batch
+- `src/Creature.ts` - Added PREBUILD_SYNAPSE_THRESHOLD, isInwardIndexBuilt(),
+  prebuildInwardIndexIfLarge(), and call in loadFrom()
+- `src/architecture/Offspring.ts` - Added prebuildInwardIndexIfLarge() call
+  after connecting synapses
+- `src/NEAT/Mutator.ts` - Added prebuildInwardIndexIfLarge() call after mutation
+  batch
 - `test/PrebuildInwardIndex.ts` - New test file with 9 tests
 - `bench/PrebuildInwardIndex.ts` - New benchmark file
 
 ## Related Issues
 
-- Sub-issue of #1090 (Find potential performance improvements in the evolution process)
-- Builds on #1010 (Performance: Add indexed synapse lookup for inward connections)
+- Sub-issue of #1090 (Find potential performance improvements in the evolution
+  process)
+- Builds on #1010 (Performance: Add indexed synapse lookup for inward
+  connections)

--- a/docs/pr-summary-1097.md
+++ b/docs/pr-summary-1097.md
@@ -1,0 +1,84 @@
+# PR Summary: Performance - Prebuild inward synapse index after breed/mutation batch (#1097)
+
+## Summary
+
+This PR adds proactive prebuilding of the inward synapse index for large creatures (>= 1000 synapses) in key locations to eliminate repeated O(n) linear scans during breeding, mutation, and loading operations.
+
+The inward synapse index (`synapsesIndexedByTo`) in `src/Creature.ts` was previously built lazily after 3 cache misses. During breeding and mutation batches, this resulted in multiple linear scans before the index was built. For large creatures with 17,935 synapses, this added up quickly.
+
+### Changes Made
+
+1. **Added `PREBUILD_SYNAPSE_THRESHOLD` constant** (1000 synapses) to control when proactive prebuilding occurs
+2. **Added `isInwardIndexBuilt()` method** for testing the prebuild optimisation
+3. **Added `prebuildInwardIndexIfLarge()` method** that conditionally prebuilds for large creatures
+4. **Called `prebuildInwardIndexIfLarge()` in three key locations:**
+   - `Offspring.breed()` - After connecting all synapses
+   - `Mutator.mutate()` - After mutation batch completes
+   - `loadFrom()` - After loading from JSON
+
+## Evidence
+
+### Benchmark Results (Apple M4 Pro)
+
+```
+=== Creature Sizes ===
+Parent (mum): 270 neurons, 15500 synapses
+Parent (dad): 260 neurons, 13800 synapses
+
+| benchmark                                                      | time/iter (avg) |
+| -------------------------------------------------------------- | --------------- |
+| Load from JSON + inward lookups                                |          2.5 ms |
+| Load + clear cache + inward lookups (no prebuild simulation)   |          4.2 ms |
+
+summary
+  Load from JSON + inward lookups
+     1.69x faster than Load + clear cache + inward lookups (no prebuild simulation)
+```
+
+**Key Performance Improvements:**
+- **Load from JSON + inward lookups**: 1.69x faster with prebuild
+- **Breeding + 20 inward lookups**: Benefits from immediate index availability
+- **Mutation batch + inward lookups**: Index available immediately after batch
+
+### How It Works
+
+Before this change:
+1. Creature loaded/bred/mutated
+2. First inward connection lookup triggers O(n) linear scan (cache miss 1)
+3. Second lookup triggers another O(n) scan (cache miss 2)
+4. Third lookup triggers another O(n) scan (cache miss 3)
+5. Fourth lookup finally triggers index build, then uses O(log n) binary search
+
+After this change:
+1. Creature loaded/bred/mutated
+2. Index prebuilt immediately for large creatures (>= 1000 synapses)
+3. All lookups use O(log n) binary search from the first call
+
+## Test Plan
+
+Added comprehensive tests in `test/PrebuildInwardIndex.ts`:
+
+1. **Offspring.breed() prebuilds inward index for large creatures** - Verifies large offspring have prebuilt index
+2. **Offspring.breed() does not prebuild inward index for small creatures** - Verifies small offspring skip prebuild
+3. **Mutator.mutate() prebuilds inward index for large creatures** - Verifies large mutated creatures have prebuilt index
+4. **prebuildInwardIndexIfLarge() does not build index for small creatures** - Verifies conditional prebuild respects threshold
+5. **Creature.fromJSON() prebuilds inward index for large creatures** - Verifies large loaded creatures have prebuilt index
+6. **Creature.fromJSON() does not prebuild inward index for small creatures** - Verifies small loaded creatures skip prebuild
+7. **loadFrom() prebuilds inward index for large creatures** - Verifies loadFrom() triggers prebuild
+8. **prebuildInwardIndex() builds the index** - Verifies explicit prebuild works
+9. **clearCache() clears the inward index** - Verifies cache clearing works
+
+All 1427 tests pass including the new tests.
+
+## Files Modified
+
+- `src/Creature.ts` - Added PREBUILD_SYNAPSE_THRESHOLD, isInwardIndexBuilt(), prebuildInwardIndexIfLarge(), and call in loadFrom()
+- `src/architecture/Offspring.ts` - Added prebuildInwardIndexIfLarge() call after connecting synapses
+- `src/NEAT/Mutator.ts` - Added prebuildInwardIndexIfLarge() call after mutation batch
+- `test/PrebuildInwardIndex.ts` - New test file with 9 tests
+- `bench/PrebuildInwardIndex.ts` - New benchmark file
+
+## Related Issues
+
+- Sub-issue of #1090 (Find potential performance improvements in the evolution process)
+- Builds on #1010 (Performance: Add indexed synapse lookup for inward connections)

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -683,6 +683,13 @@ export class Creature implements CreatureInternal {
   private static readonly INWARD_INDEX_BUILD_THRESHOLD = 3;
 
   /**
+   * Minimum number of synapses to trigger proactive index prebuilding.
+   * Only prebuild for large creatures where the upfront cost is worthwhile.
+   * Issue #1097: Performance - Prebuild inward synapse index after breed/mutation batch.
+   */
+  public static readonly PREBUILD_SYNAPSE_THRESHOLD = 1000;
+
+  /**
    * Looks up inward connections using binary search on the secondary index.
    * Falls back to linear scan if index is not built.
    * Automatically builds the index after a few cache misses.
@@ -740,6 +747,28 @@ export class Creature implements CreatureInternal {
   public prebuildInwardIndex(): void {
     if (this.synapsesIndexedByTo === null) {
       this.synapsesIndexedByTo = this.buildSynapsesIndexedByTo();
+    }
+  }
+
+  /**
+   * Checks if the inward synapse index has been built.
+   * This is primarily used for testing the prebuild optimisation.
+   * Issue #1097: Performance - Prebuild inward synapse index after breed/mutation batch.
+   *
+   * @returns {boolean} True if the index has been built, false otherwise.
+   */
+  public isInwardIndexBuilt(): boolean {
+    return this.synapsesIndexedByTo !== null;
+  }
+
+  /**
+   * Conditionally prebuilds the inward index for large creatures.
+   * Only prebuilds if the creature has many synapses (>= PREBUILD_SYNAPSE_THRESHOLD).
+   * Issue #1097: Performance - Prebuild inward synapse index after breed/mutation batch.
+   */
+  public prebuildInwardIndexIfLarge(): void {
+    if (this.synapses.length >= Creature.PREBUILD_SYNAPSE_THRESHOLD) {
+      this.prebuildInwardIndex();
     }
   }
 
@@ -2109,6 +2138,11 @@ export class Creature implements CreatureInternal {
         return a.to - b.to;
       });
     }
+
+    // Issue #1097: Prebuild inward index for large creatures after loading.
+    // This optimises subsequent inward connection lookups by avoiding
+    // linear scans before the lazy index build threshold is reached.
+    this.prebuildInwardIndexIfLarge();
 
     if (validate) {
       creatureValidate(this);

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -84,6 +84,11 @@ export class Mutator {
           }
         }
 
+        // Issue #1097: Prebuild inward index for large creatures after mutation batch.
+        // This optimises subsequent inward connection lookups by avoiding
+        // linear scans before the lazy index build threshold is reached.
+        creature.prebuildInwardIndexIfLarge();
+
         if (this.config.debug) {
           creatureValidate(creature);
         }

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -285,6 +285,11 @@ export class Offspring {
       }
     });
 
+    // Issue #1097: Prebuild inward index for large offspring.
+    // This optimises subsequent inward connection lookups during validation
+    // and memetic updates by avoiding linear scans.
+    offspring.prebuildInwardIndexIfLarge();
+
     offspring.clearState();
 
     delete offspring.uuid;

--- a/test/PrebuildInwardIndex.ts
+++ b/test/PrebuildInwardIndex.ts
@@ -1,0 +1,316 @@
+/**
+ * Test: Prebuild inward synapse index after breed/mutation batch (Issue #1097)
+ *
+ * This test verifies that prebuildInwardIndex() is called proactively in key locations:
+ * 1. After breeding a new creature (Offspring.breed())
+ * 2. After mutation batch completes (Mutator.mutate())
+ * 3. After loading from JSON (Creature.fromJSON() / loadFrom())
+ *
+ * The optimisation only applies to creatures with many synapses (>= 1000 by default)
+ * to balance upfront cost vs amortised benefit.
+ */
+import { assertEquals } from "@std/assert";
+import { Creature } from "../src/Creature.ts";
+import type { CreatureInternal } from "../src/architecture/CreatureInterfaces.ts";
+import { Offspring } from "../src/architecture/Offspring.ts";
+import { Mutator } from "../src/NEAT/Mutator.ts";
+import { createNeatConfig } from "../src/config/NeatConfig.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/**
+ * Creates a large creature with the specified number of neurons and approximately
+ * the given number of synapses for testing the prebuild optimisation.
+ */
+function createLargeCreature(
+  inputCount: number,
+  outputCount: number,
+  hiddenLayers: number[],
+): Creature {
+  const layers = hiddenLayers.map((count) => ({ count }));
+  const creature = new Creature(inputCount, outputCount, { layers });
+  creature.validate();
+  return creature;
+}
+
+/**
+ * Creates a simple small creature for testing cases where prebuilding
+ * should NOT occur (under the synapse threshold).
+ */
+function createSmallCreature(): Creature {
+  const json: CreatureInternal = {
+    neurons: [
+      { type: "input", squash: "LOGISTIC", index: 0 },
+      { type: "input", squash: "LOGISTIC", index: 1 },
+      { type: "hidden", squash: "LOGISTIC", index: 2, bias: 0 },
+      { type: "output", squash: "LOGISTIC", index: 3, bias: 0 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1 },
+      { from: 1, to: 2, weight: 2 },
+      { from: 2, to: 3, weight: 3 },
+    ],
+    input: 2,
+    output: 1,
+  };
+  return Creature.fromJSON(json);
+}
+
+// ============================================================================
+// Tests for Offspring.breed()
+// ============================================================================
+
+Deno.test("Offspring.breed() prebuilds inward index for large creatures", () => {
+  // Create two large parent creatures with many synapses
+  const mum = createLargeCreature(30, 10, [100, 80, 50]);
+  const dad = createLargeCreature(30, 10, [90, 70, 60]);
+
+  // Verify the parents have enough synapses to trigger prebuilding
+  assertEquals(
+    mum.synapses.length >= 1000,
+    true,
+    `Mother should have >= 1000 synapses, has ${mum.synapses.length}`,
+  );
+  assertEquals(
+    dad.synapses.length >= 1000,
+    true,
+    `Father should have >= 1000 synapses, has ${dad.synapses.length}`,
+  );
+
+  // Breed offspring
+  const offspring = Offspring.breed(mum, dad);
+  if (offspring === undefined) {
+    // Breeding can sometimes return undefined (e.g., if child equals parent)
+    // Skip this test run
+    return;
+  }
+
+  // Verify the offspring has many synapses
+  assertEquals(
+    offspring.synapses.length >= 1000,
+    true,
+    `Offspring should have >= 1000 synapses, has ${offspring.synapses.length}`,
+  );
+
+  // Verify the inward index is prebuilt
+  assertEquals(
+    offspring.isInwardIndexBuilt(),
+    true,
+    "Offspring should have prebuilt inward index after breed()",
+  );
+});
+
+Deno.test("Offspring.breed() does not prebuild inward index for small creatures", () => {
+  // Create small parent creatures
+  const mum = createSmallCreature();
+  const dad = createSmallCreature();
+
+  // Verify the parents have few synapses
+  assertEquals(
+    mum.synapses.length < 1000,
+    true,
+    `Mother should have < 1000 synapses, has ${mum.synapses.length}`,
+  );
+
+  // Breed offspring
+  const offspring = Offspring.breed(mum, dad);
+  if (offspring === undefined) {
+    return;
+  }
+
+  // Small creatures should not have prebuilt index (not worth the upfront cost)
+  assertEquals(
+    offspring.isInwardIndexBuilt(),
+    false,
+    "Small offspring should not have prebuilt inward index",
+  );
+});
+
+// ============================================================================
+// Tests for Mutator.mutate()
+// ============================================================================
+
+Deno.test("Mutator.mutate() prebuilds inward index for large creatures", () => {
+  // Create a large creature
+  const creature = createLargeCreature(30, 10, [100, 80, 50]);
+
+  assertEquals(
+    creature.synapses.length >= 1000,
+    true,
+    `Creature should have >= 1000 synapses, has ${creature.synapses.length}`,
+  );
+
+  // Clear the inward index to start fresh
+  creature.clearCache();
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    false,
+    "Index should be cleared before mutation",
+  );
+
+  // Create a mutator and mutate the creature
+  const config = createNeatConfig({
+    mutationRate: 1.0, // Always mutate
+    mutationAmount: 3, // Multiple mutations per batch
+  });
+  const mutator = new Mutator(config);
+  mutator.mutate([creature]);
+
+  // After mutation batch, the index should be prebuilt
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    true,
+    "Large creature should have prebuilt inward index after mutation batch",
+  );
+});
+
+Deno.test("prebuildInwardIndexIfLarge() does not build index for small creatures", () => {
+  // Create a small creature
+  const creature = createSmallCreature();
+
+  assertEquals(
+    creature.synapses.length < 1000,
+    true,
+    `Creature should have < 1000 synapses, has ${creature.synapses.length}`,
+  );
+
+  // Clear the index
+  creature.clearCache();
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    false,
+    "Index should be cleared before test",
+  );
+
+  // Conditionally prebuild - should not build for small creatures
+  creature.prebuildInwardIndexIfLarge();
+
+  // Small creatures should not have prebuilt index via prebuildInwardIndexIfLarge()
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    false,
+    "Small creature should not have prebuilt inward index via prebuildInwardIndexIfLarge()",
+  );
+});
+
+// ============================================================================
+// Tests for Creature.fromJSON() / loadFrom()
+// ============================================================================
+
+Deno.test("Creature.fromJSON() prebuilds inward index for large creatures", () => {
+  // Create a large creature and export it
+  const original = createLargeCreature(30, 10, [100, 80, 50]);
+  const json = original.exportJSON();
+
+  assertEquals(
+    json.synapses.length >= 1000,
+    true,
+    `JSON should have >= 1000 synapses, has ${json.synapses.length}`,
+  );
+
+  // Load from JSON
+  const loaded = Creature.fromJSON(json);
+
+  // Verify the inward index is prebuilt
+  assertEquals(
+    loaded.isInwardIndexBuilt(),
+    true,
+    "Large creature should have prebuilt inward index after fromJSON()",
+  );
+});
+
+Deno.test("Creature.fromJSON() does not prebuild inward index for small creatures", () => {
+  // Create a small creature and export it
+  const original = createSmallCreature();
+  const json = original.exportJSON();
+
+  assertEquals(
+    json.synapses.length < 1000,
+    true,
+    `JSON should have < 1000 synapses, has ${json.synapses.length}`,
+  );
+
+  // Load from JSON
+  const loaded = Creature.fromJSON(json);
+
+  // Small creatures should not have prebuilt index
+  assertEquals(
+    loaded.isInwardIndexBuilt(),
+    false,
+    "Small creature should not have prebuilt inward index after fromJSON()",
+  );
+});
+
+Deno.test("loadFrom() prebuilds inward index for large creatures", () => {
+  // Create a large creature and export it
+  const original = createLargeCreature(30, 10, [100, 80, 50]);
+  const json = original.exportJSON();
+
+  assertEquals(
+    json.synapses.length >= 1000,
+    true,
+    `JSON should have >= 1000 synapses, has ${json.synapses.length}`,
+  );
+
+  // Create a new creature and load from JSON
+  const creature = new Creature(json.input, json.output, {
+    lazyInitialization: true,
+    semanticVersion: json.semanticVersion,
+  });
+  creature.loadFrom(json, true);
+
+  // Verify the inward index is prebuilt
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    true,
+    "Large creature should have prebuilt inward index after loadFrom()",
+  );
+});
+
+// ============================================================================
+// Tests for explicit prebuildInwardIndex() calls
+// ============================================================================
+
+Deno.test("prebuildInwardIndex() builds the index", () => {
+  const creature = createSmallCreature();
+
+  // Ensure the index is not built
+  creature.clearCache();
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    false,
+    "Index should be cleared",
+  );
+
+  // Explicitly prebuild
+  creature.prebuildInwardIndex();
+
+  // Now the index should be built
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    true,
+    "Index should be built after prebuildInwardIndex()",
+  );
+});
+
+Deno.test("clearCache() clears the inward index", () => {
+  const creature = createSmallCreature();
+
+  // Build the index
+  creature.prebuildInwardIndex();
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    true,
+    "Index should be built",
+  );
+
+  // Clear the cache
+  creature.clearCache();
+
+  // Index should be cleared
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    false,
+    "Index should be cleared after clearCache()",
+  );
+});


### PR DESCRIPTION
# PR Summary: Performance - Prebuild inward synapse index after breed/mutation batch (#1097)

## Summary

This PR adds proactive prebuilding of the inward synapse index for large
creatures (>= 1000 synapses) in key locations to eliminate repeated O(n) linear
scans during breeding, mutation, and loading operations.

The inward synapse index (`synapsesIndexedByTo`) in `src/Creature.ts` was
previously built lazily after 3 cache misses. During breeding and mutation
batches, this resulted in multiple linear scans before the index was built. For
large creatures with 17,935 synapses, this added up quickly.

### Changes Made

1. **Added `PREBUILD_SYNAPSE_THRESHOLD` constant** (1000 synapses) to control
   when proactive prebuilding occurs
2. **Added `isInwardIndexBuilt()` method** for testing the prebuild optimisation
3. **Added `prebuildInwardIndexIfLarge()` method** that conditionally prebuilds
   for large creatures
4. **Called `prebuildInwardIndexIfLarge()` in three key locations:**
   - `Offspring.breed()` - After connecting all synapses
   - `Mutator.mutate()` - After mutation batch completes
   - `loadFrom()` - After loading from JSON

## Evidence

### Benchmark Results (Apple M4 Pro)

```
=== Creature Sizes ===
Parent (mum): 270 neurons, 15500 synapses
Parent (dad): 260 neurons, 13800 synapses

| benchmark                                                      | time/iter (avg) |
| -------------------------------------------------------------- | --------------- |
| Load from JSON + inward lookups                                |          2.5 ms |
| Load + clear cache + inward lookups (no prebuild simulation)   |          4.2 ms |

summary
  Load from JSON + inward lookups
     1.69x faster than Load + clear cache + inward lookups (no prebuild simulation)
```

**Key Performance Improvements:**

- **Load from JSON + inward lookups**: 1.69x faster with prebuild
- **Breeding + 20 inward lookups**: Benefits from immediate index availability
- **Mutation batch + inward lookups**: Index available immediately after batch

### How It Works

Before this change:

1. Creature loaded/bred/mutated
2. First inward connection lookup triggers O(n) linear scan (cache miss 1)
3. Second lookup triggers another O(n) scan (cache miss 2)
4. Third lookup triggers another O(n) scan (cache miss 3)
5. Fourth lookup finally triggers index build, then uses O(log n) binary search

After this change:

1. Creature loaded/bred/mutated
2. Index prebuilt immediately for large creatures (>= 1000 synapses)
3. All lookups use O(log n) binary search from the first call

## Test Plan

Added comprehensive tests in `test/PrebuildInwardIndex.ts`:

1. **Offspring.breed() prebuilds inward index for large creatures** - Verifies
   large offspring have prebuilt index
2. **Offspring.breed() does not prebuild inward index for small creatures** -
   Verifies small offspring skip prebuild
3. **Mutator.mutate() prebuilds inward index for large creatures** - Verifies
   large mutated creatures have prebuilt index
4. **prebuildInwardIndexIfLarge() does not build index for small creatures** -
   Verifies conditional prebuild respects threshold
5. **Creature.fromJSON() prebuilds inward index for large creatures** - Verifies
   large loaded creatures have prebuilt index
6. **Creature.fromJSON() does not prebuild inward index for small creatures** -
   Verifies small loaded creatures skip prebuild
7. **loadFrom() prebuilds inward index for large creatures** - Verifies
   loadFrom() triggers prebuild
8. **prebuildInwardIndex() builds the index** - Verifies explicit prebuild works
9. **clearCache() clears the inward index** - Verifies cache clearing works

All 1427 tests pass including the new tests.

## Files Modified

- `src/Creature.ts` - Added PREBUILD_SYNAPSE_THRESHOLD, isInwardIndexBuilt(),
  prebuildInwardIndexIfLarge(), and call in loadFrom()
- `src/architecture/Offspring.ts` - Added prebuildInwardIndexIfLarge() call
  after connecting synapses
- `src/NEAT/Mutator.ts` - Added prebuildInwardIndexIfLarge() call after mutation
  batch
- `test/PrebuildInwardIndex.ts` - New test file with 9 tests
- `bench/PrebuildInwardIndex.ts` - New benchmark file

## Related Issues

- Sub-issue of #1090 (Find potential performance improvements in the evolution
  process)
- Builds on #1010 (Performance: Add indexed synapse lookup for inward
  connections)

---

## Automated Fix Details
This PR addresses issue #1097: **Performance: Prebuild inward synapse index after breed/mutation batch**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1097