### PR TITLE
Fix: Performance: Batch synapse operations to reduce cache invalidation overhead (#1102)

### DIFF
--- a/bench/BatchSynapseOperations.ts
+++ b/bench/BatchSynapseOperations.ts
@@ -1,0 +1,250 @@
+/**
+ * Benchmark for batch synapse operations performance optimisation.
+ *
+ * Issue #1102: Performance - Batch synapse operations to reduce cache invalidation overhead
+ *
+ * This benchmark compares:
+ * 1. Individual connect() calls (each triggers cache invalidation)
+ * 2. connectBatch() (single cache invalidation at the end)
+ *
+ * The optimisation reduces cache invalidation from O(n) to O(1) for operations
+ * that add multiple synapses, which is particularly beneficial during breeding
+ * where many synapses are added to create offspring.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write bench/BatchSynapseOperations.ts
+ */
+import { Creature } from "../src/Creature.ts";
+import { creatureValidate } from "../src/architecture/CreatureValidate.ts";
+import { AddNeuron } from "../src/mutate/AddNeuron.ts";
+
+// Helper to create test creatures with available connections
+function createTestCreature(
+  inputCount: number,
+  outputCount: number,
+  hiddenNeurons: number,
+): Creature {
+  const creature = new Creature(inputCount, outputCount);
+  const addNeuron = new AddNeuron(creature);
+
+  for (let i = 0; i < hiddenNeurons; i++) {
+    addNeuron.mutate();
+  }
+
+  return creature;
+}
+
+// Small creature setup
+const smallCreature = createTestCreature(10, 5, 20);
+creatureValidate(smallCreature);
+const smallAvailable = smallCreature.getAvailableConnections();
+const smallConnections = smallAvailable.slice(0, 50).map(([from, to]) => ({
+  from,
+  to,
+  weight: Math.random() * 2 - 1,
+}));
+
+// Medium creature setup
+const mediumCreature = createTestCreature(30, 10, 80);
+creatureValidate(mediumCreature);
+const mediumAvailable = mediumCreature.getAvailableConnections();
+const mediumConnections = mediumAvailable.slice(0, 200).map(([from, to]) => ({
+  from,
+  to,
+  weight: Math.random() * 2 - 1,
+}));
+
+// Large creature setup (matching issue requirements)
+const largeCreature = createTestCreature(50, 20, 200);
+creatureValidate(largeCreature);
+const largeAvailable = largeCreature.getAvailableConnections();
+const largeConnections = largeAvailable.slice(0, 500).map(([from, to]) => ({
+  from,
+  to,
+  weight: Math.random() * 2 - 1,
+}));
+
+console.log("=== Creature Sizes ===");
+console.log(
+  `Small: ${smallCreature.neurons.length} neurons, ${smallCreature.synapses.length} synapses`,
+);
+console.log(
+  `Medium: ${mediumCreature.neurons.length} neurons, ${mediumCreature.synapses.length} synapses`,
+);
+console.log(
+  `Large: ${largeCreature.neurons.length} neurons, ${largeCreature.synapses.length} synapses`,
+);
+
+console.log("\n=== Connections to Add ===");
+console.log(`Small: ${smallConnections.length} connections`);
+console.log(`Medium: ${mediumConnections.length} connections`);
+console.log(`Large: ${largeConnections.length} connections`);
+
+// =============================================================================
+// Small Creature Benchmarks (50 connections)
+// =============================================================================
+
+Deno.bench({
+  name: "Small (50 conn): Individual connect() calls",
+  group: "connectBatch vs individual connect",
+  baseline: true,
+  fn() {
+    const creature = Creature.fromJSON(smallCreature.exportJSON());
+    for (const conn of smallConnections) {
+      creature.connect(conn.from, conn.to, conn.weight);
+    }
+  },
+});
+
+Deno.bench({
+  name: "Small (50 conn): connectBatch()",
+  group: "connectBatch vs individual connect",
+  fn() {
+    const creature = Creature.fromJSON(smallCreature.exportJSON());
+    creature.connectBatch(smallConnections);
+  },
+});
+
+// =============================================================================
+// Medium Creature Benchmarks (200 connections)
+// =============================================================================
+
+Deno.bench({
+  name: "Medium (200 conn): Individual connect() calls",
+  group: "connectBatch vs individual connect (medium)",
+  baseline: true,
+  fn() {
+    const creature = Creature.fromJSON(mediumCreature.exportJSON());
+    for (const conn of mediumConnections) {
+      creature.connect(conn.from, conn.to, conn.weight);
+    }
+  },
+});
+
+Deno.bench({
+  name: "Medium (200 conn): connectBatch()",
+  group: "connectBatch vs individual connect (medium)",
+  fn() {
+    const creature = Creature.fromJSON(mediumCreature.exportJSON());
+    creature.connectBatch(mediumConnections);
+  },
+});
+
+// =============================================================================
+// Large Creature Benchmarks (500 connections)
+// =============================================================================
+
+Deno.bench({
+  name: "Large (500 conn): Individual connect() calls",
+  group: "connectBatch vs individual connect (large)",
+  baseline: true,
+  fn() {
+    const creature = Creature.fromJSON(largeCreature.exportJSON());
+    for (const conn of largeConnections) {
+      creature.connect(conn.from, conn.to, conn.weight);
+    }
+  },
+});
+
+Deno.bench({
+  name: "Large (500 conn): connectBatch()",
+  group: "connectBatch vs individual connect (large)",
+  fn() {
+    const creature = Creature.fromJSON(largeCreature.exportJSON());
+    creature.connectBatch(largeConnections);
+  },
+});
+
+// =============================================================================
+// Disconnect Benchmarks
+// =============================================================================
+
+// Create creatures with connections to disconnect
+const disconnectSmall = Creature.fromJSON(smallCreature.exportJSON());
+disconnectSmall.connectBatch(smallConnections);
+const disconnectSmallPairs = smallConnections.slice(0, 30).map((c) => ({
+  from: c.from,
+  to: c.to,
+}));
+
+const disconnectMedium = Creature.fromJSON(mediumCreature.exportJSON());
+disconnectMedium.connectBatch(mediumConnections);
+const disconnectMediumPairs = mediumConnections.slice(0, 100).map((c) => ({
+  from: c.from,
+  to: c.to,
+}));
+
+const disconnectLarge = Creature.fromJSON(largeCreature.exportJSON());
+disconnectLarge.connectBatch(largeConnections);
+const disconnectLargePairs = largeConnections.slice(0, 250).map((c) => ({
+  from: c.from,
+  to: c.to,
+}));
+
+console.log("\n=== Connections to Remove ===");
+console.log(`Small: ${disconnectSmallPairs.length} connections`);
+console.log(`Medium: ${disconnectMediumPairs.length} connections`);
+console.log(`Large: ${disconnectLargePairs.length} connections`);
+
+Deno.bench({
+  name: "Small (30 disc): Individual disconnect() calls",
+  group: "disconnectBatch vs individual disconnect",
+  baseline: true,
+  fn() {
+    const creature = Creature.fromJSON(disconnectSmall.exportJSON());
+    for (const pair of disconnectSmallPairs) {
+      creature.disconnect(pair.from, pair.to);
+    }
+  },
+});
+
+Deno.bench({
+  name: "Small (30 disc): disconnectBatch()",
+  group: "disconnectBatch vs individual disconnect",
+  fn() {
+    const creature = Creature.fromJSON(disconnectSmall.exportJSON());
+    creature.disconnectBatch(disconnectSmallPairs);
+  },
+});
+
+Deno.bench({
+  name: "Medium (100 disc): Individual disconnect() calls",
+  group: "disconnectBatch vs individual disconnect (medium)",
+  baseline: true,
+  fn() {
+    const creature = Creature.fromJSON(disconnectMedium.exportJSON());
+    for (const pair of disconnectMediumPairs) {
+      creature.disconnect(pair.from, pair.to);
+    }
+  },
+});
+
+Deno.bench({
+  name: "Medium (100 disc): disconnectBatch()",
+  group: "disconnectBatch vs individual disconnect (medium)",
+  fn() {
+    const creature = Creature.fromJSON(disconnectMedium.exportJSON());
+    creature.disconnectBatch(disconnectMediumPairs);
+  },
+});
+
+Deno.bench({
+  name: "Large (250 disc): Individual disconnect() calls",
+  group: "disconnectBatch vs individual disconnect (large)",
+  baseline: true,
+  fn() {
+    const creature = Creature.fromJSON(disconnectLarge.exportJSON());
+    for (const pair of disconnectLargePairs) {
+      creature.disconnect(pair.from, pair.to);
+    }
+  },
+});
+
+Deno.bench({
+  name: "Large (250 disc): disconnectBatch()",
+  group: "disconnectBatch vs individual disconnect (large)",
+  fn() {
+    const creature = Creature.fromJSON(disconnectLarge.exportJSON());
+    creature.disconnectBatch(disconnectLargePairs);
+  },
+});

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.292.24",
+  "version": "0.292.25",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/pr-summary-1102.md
+++ b/docs/pr-summary-1102.md
@@ -1,12 +1,19 @@
 ## Summary
 
-Added batch synapse operations (`connectBatch()` and `disconnectBatch()`) to the `Creature` class to reduce cache invalidation overhead. Previously, operations that modified multiple synapses (like breeding) would call `clearCache()` and `invalidateScoreCache()` after each individual synapse change, causing redundant cache rebuilding.
+Added batch synapse operations (`connectBatch()` and `disconnectBatch()`) to the
+`Creature` class to reduce cache invalidation overhead. Previously, operations
+that modified multiple synapses (like breeding) would call `clearCache()` and
+`invalidateScoreCache()` after each individual synapse change, causing redundant
+cache rebuilding.
 
 The new batch methods:
-- **`connectBatch()`**: Adds multiple synapses with a single cache invalidation
-- **`disconnectBatch()`**: Removes multiple synapses with a single cache invalidation
 
-Updated `Offspring.breed()` to use `connectBatch()` instead of individual `connect()` calls.
+- **`connectBatch()`**: Adds multiple synapses with a single cache invalidation
+- **`disconnectBatch()`**: Removes multiple synapses with a single cache
+  invalidation
+
+Updated `Offspring.breed()` to use `connectBatch()` instead of individual
+`connect()` calls.
 
 ## Evidence
 
@@ -16,21 +23,24 @@ Performance comparison between batch operations and individual operations:
 
 **connectBatch() vs individual connect():**
 
-| Creature Size | Connections | Individual | Batch | Improvement |
-|---------------|-------------|------------|-------|-------------|
-| Small (35 neurons) | 50 | 52.8 µs | 16.7 µs | **3.17x faster** |
-| Medium (120 neurons) | 200 | 844.9 µs | 76.4 µs | **11.06x faster** |
-| Large (270 neurons) | 500 | 6.6 ms | 425.4 µs | **15.57x faster** |
+| Creature Size        | Connections | Individual | Batch    | Improvement       |
+| -------------------- | ----------- | ---------- | -------- | ----------------- |
+| Small (35 neurons)   | 50          | 52.8 µs    | 16.7 µs  | **3.17x faster**  |
+| Medium (120 neurons) | 200         | 844.9 µs   | 76.4 µs  | **11.06x faster** |
+| Large (270 neurons)  | 500         | 6.6 ms     | 425.4 µs | **15.57x faster** |
 
 **disconnectBatch() vs individual disconnect():**
 
-| Creature Size | Disconnections | Individual | Batch | Improvement |
-|---------------|----------------|------------|-------|-------------|
-| Small | 30 | 13.6 µs | 11.9 µs | 1.14x faster |
-| Medium | 100 | 57.6 µs | 52.4 µs | 1.10x faster |
-| Large | 250 | 409.5 µs | 397.7 µs | 1.03x faster |
+| Creature Size | Disconnections | Individual | Batch    | Improvement  |
+| ------------- | -------------- | ---------- | -------- | ------------ |
+| Small         | 30             | 13.6 µs    | 11.9 µs  | 1.14x faster |
+| Medium        | 100            | 57.6 µs    | 52.4 µs  | 1.10x faster |
+| Large         | 250            | 409.5 µs   | 397.7 µs | 1.03x faster |
 
-The `connectBatch()` improvement significantly exceeds the issue's expected 30-50% improvement, achieving up to **15.57x faster** performance for large creatures. The `disconnectBatch()` improvement is more modest because disconnect operations were already optimised with binary search (Issue #1101).
+The `connectBatch()` improvement significantly exceeds the issue's expected
+30-50% improvement, achieving up to **15.57x faster** performance for large
+creatures. The `disconnectBatch()` improvement is more modest because disconnect
+operations were already optimised with binary search (Issue #1101).
 
 ### Benchmark Command
 
@@ -43,6 +53,7 @@ deno bench --allow-read --allow-write bench/BatchSynapseOperations.ts
 Added 16 unit tests in `test/mutate/BatchSynapseOperations.ts`:
 
 **connectBatch() tests:**
+
 - `connectBatch(): adds multiple synapses in a single operation`
 - `connectBatch(): maintains correct synapse ordering`
 - `connectBatch(): handles empty array`
@@ -52,6 +63,7 @@ Added 16 unit tests in `test/mutate/BatchSynapseOperations.ts`:
 - `connectBatch(): throws on existing connections`
 
 **disconnectBatch() tests:**
+
 - `disconnectBatch(): removes multiple synapses in a single operation`
 - `disconnectBatch(): maintains correct synapse ordering`
 - `disconnectBatch(): handles empty array`
@@ -60,6 +72,7 @@ Added 16 unit tests in `test/mutate/BatchSynapseOperations.ts`:
 - `disconnectBatch(): handles mix of existent and non-existent connections`
 
 **Integration tests:**
+
 - `connectBatch() + disconnectBatch(): work together correctly`
 - `batch operations: produce same result as individual operations`
 - `batch operations: large creature stress test`
@@ -68,7 +81,8 @@ All existing tests (1493) continue to pass with the changes.
 
 ## Files Changed
 
-- `src/Creature.ts` - Added `connectBatch()`, `disconnectBatch()`, and `findInsertionPoint()` methods
+- `src/Creature.ts` - Added `connectBatch()`, `disconnectBatch()`, and
+  `findInsertionPoint()` methods
 - `src/architecture/Offspring.ts` - Updated breeding to use `connectBatch()`
 - `bench/BatchSynapseOperations.ts` - New benchmark file
 - `test/mutate/BatchSynapseOperations.ts` - New test file
@@ -76,6 +90,7 @@ All existing tests (1493) continue to pass with the changes.
 ## Related Issues
 
 - Fixes #1102
-- Related to #1090 (Find potential performance improvements in the evolution process)
+- Related to #1090 (Find potential performance improvements in the evolution
+  process)
 - Builds on #1101 (Binary search for disconnect operations)
 - Builds on #1093 (splice() for connect operations)

--- a/docs/pr-summary-1102.md
+++ b/docs/pr-summary-1102.md
@@ -1,0 +1,81 @@
+## Summary
+
+Added batch synapse operations (`connectBatch()` and `disconnectBatch()`) to the `Creature` class to reduce cache invalidation overhead. Previously, operations that modified multiple synapses (like breeding) would call `clearCache()` and `invalidateScoreCache()` after each individual synapse change, causing redundant cache rebuilding.
+
+The new batch methods:
+- **`connectBatch()`**: Adds multiple synapses with a single cache invalidation
+- **`disconnectBatch()`**: Removes multiple synapses with a single cache invalidation
+
+Updated `Offspring.breed()` to use `connectBatch()` instead of individual `connect()` calls.
+
+## Evidence
+
+### Benchmark Results
+
+Performance comparison between batch operations and individual operations:
+
+**connectBatch() vs individual connect():**
+
+| Creature Size | Connections | Individual | Batch | Improvement |
+|---------------|-------------|------------|-------|-------------|
+| Small (35 neurons) | 50 | 52.8 µs | 16.7 µs | **3.17x faster** |
+| Medium (120 neurons) | 200 | 844.9 µs | 76.4 µs | **11.06x faster** |
+| Large (270 neurons) | 500 | 6.6 ms | 425.4 µs | **15.57x faster** |
+
+**disconnectBatch() vs individual disconnect():**
+
+| Creature Size | Disconnections | Individual | Batch | Improvement |
+|---------------|----------------|------------|-------|-------------|
+| Small | 30 | 13.6 µs | 11.9 µs | 1.14x faster |
+| Medium | 100 | 57.6 µs | 52.4 µs | 1.10x faster |
+| Large | 250 | 409.5 µs | 397.7 µs | 1.03x faster |
+
+The `connectBatch()` improvement significantly exceeds the issue's expected 30-50% improvement, achieving up to **15.57x faster** performance for large creatures. The `disconnectBatch()` improvement is more modest because disconnect operations were already optimised with binary search (Issue #1101).
+
+### Benchmark Command
+
+```bash
+deno bench --allow-read --allow-write bench/BatchSynapseOperations.ts
+```
+
+## Test Plan
+
+Added 16 unit tests in `test/mutate/BatchSynapseOperations.ts`:
+
+**connectBatch() tests:**
+- `connectBatch(): adds multiple synapses in a single operation`
+- `connectBatch(): maintains correct synapse ordering`
+- `connectBatch(): handles empty array`
+- `connectBatch(): handles single connection`
+- `connectBatch(): supports synapse types`
+- `connectBatch(): throws on duplicate connections within batch`
+- `connectBatch(): throws on existing connections`
+
+**disconnectBatch() tests:**
+- `disconnectBatch(): removes multiple synapses in a single operation`
+- `disconnectBatch(): maintains correct synapse ordering`
+- `disconnectBatch(): handles empty array`
+- `disconnectBatch(): handles single disconnection`
+- `disconnectBatch(): silently ignores non-existent connections`
+- `disconnectBatch(): handles mix of existent and non-existent connections`
+
+**Integration tests:**
+- `connectBatch() + disconnectBatch(): work together correctly`
+- `batch operations: produce same result as individual operations`
+- `batch operations: large creature stress test`
+
+All existing tests (1493) continue to pass with the changes.
+
+## Files Changed
+
+- `src/Creature.ts` - Added `connectBatch()`, `disconnectBatch()`, and `findInsertionPoint()` methods
+- `src/architecture/Offspring.ts` - Updated breeding to use `connectBatch()`
+- `bench/BatchSynapseOperations.ts` - New benchmark file
+- `test/mutate/BatchSynapseOperations.ts` - New test file
+
+## Related Issues
+
+- Fixes #1102
+- Related to #1090 (Find potential performance improvements in the evolution process)
+- Builds on #1101 (Binary search for disconnect operations)
+- Builds on #1093 (splice() for connect operations)

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1125,6 +1125,151 @@ export class Creature implements CreatureInternal {
   }
 
   /**
+   * Batch connect multiple synapses with a single cache invalidation.
+   * Issue #1102: Performance optimisation for operations that add multiple synapses.
+   *
+   * This method is significantly more efficient than calling connect() in a loop
+   * because it:
+   * 1. Sorts connections first to enable efficient insertion
+   * 2. Validates all connections before inserting any
+   * 3. Invalidates caches only once at the end
+   *
+   * @param connections Array of connection specifications
+   * @throws {Error} If any connection already exists or duplicates exist within batch
+   */
+  connectBatch(
+    connections: Array<{
+      from: number;
+      to: number;
+      weight: number;
+      type?: "positive" | "negative" | "condition";
+    }>,
+  ): void {
+    if (connections.length === 0) {
+      return;
+    }
+
+    // Check for duplicates within the batch using a Set
+    const batchSet = new Set<string>();
+    for (const conn of connections) {
+      const key = `${conn.from}-${conn.to}`;
+      if (batchSet.has(key)) {
+        throw new Error(`Duplicate connection in batch: ${key} already exists`);
+      }
+      batchSet.add(key);
+    }
+
+    // Check that none of the connections already exist
+    for (const conn of connections) {
+      const existing = this.binarySearchSynapse(conn.from, conn.to);
+      if (existing !== -1) {
+        throw new Error(
+          `Connection ${conn.from}->${conn.to} already exists in creature`,
+        );
+      }
+    }
+
+    // Sort connections by (from, to) for efficient insertion
+    const sortedConnections = [...connections].sort((a, b) => {
+      if (a.from !== b.from) {
+        return a.from - b.from;
+      }
+      return a.to - b.to;
+    });
+
+    // Insert all synapses
+    // We process in reverse order of sorted array when inserting to maintain
+    // correct positions as the array grows
+    for (const conn of sortedConnections) {
+      const synapse = new Synapse(conn.from, conn.to, conn.weight, conn.type);
+      const location = this.findInsertionPoint(conn.from, conn.to);
+      if (location < this.synapses.length) {
+        this.synapses.splice(location, 0, synapse);
+      } else {
+        this.synapses.push(synapse);
+      }
+    }
+
+    // Single cache invalidation at the end
+    this.clearCache();
+    this.invalidateScoreCache();
+  }
+
+  /**
+   * Find the insertion point for a synapse to maintain sorted order.
+   * Uses binary search for O(log n) efficiency.
+   * Issue #1102: Helper method for connectBatch.
+   *
+   * @param from - The source neuron index.
+   * @param to - The target neuron index.
+   * @returns The index where the synapse should be inserted.
+   */
+  private findInsertionPoint(from: number, to: number): number {
+    const synapses = this.synapses;
+    let low = 0;
+    let high = synapses.length;
+
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      const syn = synapses[mid];
+
+      if (syn.from < from || (syn.from === from && syn.to < to)) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+
+    return low;
+  }
+
+  /**
+   * Batch disconnect multiple synapses with a single cache invalidation.
+   * Issue #1102: Performance optimisation for operations that remove multiple synapses.
+   *
+   * This method is significantly more efficient than calling disconnect() in a loop
+   * because it:
+   * 1. Finds all synapse indices first
+   * 2. Removes them in descending order to maintain correct indices
+   * 3. Invalidates caches only once at the end
+   *
+   * Non-existent connections are silently ignored.
+   *
+   * @param pairs Array of (from, to) pairs to disconnect
+   */
+  disconnectBatch(pairs: Array<{ from: number; to: number }>): void {
+    if (pairs.length === 0) {
+      return;
+    }
+
+    // Find all indices to remove
+    const indices: number[] = [];
+    for (const pair of pairs) {
+      const idx = this.binarySearchSynapse(pair.from, pair.to);
+      if (idx !== -1) {
+        indices.push(idx);
+      }
+    }
+
+    if (indices.length === 0) {
+      return;
+    }
+
+    // Sort indices in descending order so we can remove from end to start
+    // without affecting the positions of earlier indices
+    indices.sort((a, b) => b - a);
+
+    // Remove each synapse
+    for (const idx of indices) {
+      this.synapses.splice(idx, 1);
+    }
+
+    // Single cache invalidation at the end
+    this.clearCache();
+    this.invalidateScoreCache();
+  }
+
+  /**
    * Binary search for a synapse by (from, to) indices.
    * Synapses are sorted first by `from`, then by `to` within the same `from`.
    * Issue #1101: Performance optimisation for disconnect operations.

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -245,7 +245,19 @@ export class Offspring {
       indxMap.set(neuron.uuid, indx);
     });
 
-    // Connect synapses, reweighing as necessary
+    // Issue #1102: Collect all connections first, then batch connect
+    // This reduces cache invalidation overhead from O(n) to O(1)
+    const batchConnections: Array<{
+      from: number;
+      to: number;
+      weight: number;
+      type?: "positive" | "negative" | "condition";
+      tags?: SynapseExport["tags"];
+    }> = [];
+
+    // Track connections to avoid duplicates (matching original getSynapse check)
+    const connectionSet = new Set<string>();
+
     offspring.neurons.forEach((neuron) => {
       if (neuron.type !== "input") {
         const connections = connectionsMap.get(neuron.uuid);
@@ -260,15 +272,16 @@ export class Offspring {
             if (fromIndx <= toIndx) {
               const toType = offspring.neurons[toIndx].type;
               if (toType === "hidden" || toType === "output") {
-                if (!offspring.getSynapse(fromIndx, toIndx)) {
-                  const babySynapse = offspring.connect(
-                    fromIndx,
-                    toIndx,
-                    c.weight,
-                    c.type,
-                  );
-
-                  addTags(babySynapse, c);
+                const key = `${fromIndx}-${toIndx}`;
+                if (!connectionSet.has(key)) {
+                  connectionSet.add(key);
+                  batchConnections.push({
+                    from: fromIndx,
+                    to: toIndx,
+                    weight: c.weight,
+                    type: c.type,
+                    tags: c.tags,
+                  });
                 }
               } else {
                 throw new Error(
@@ -284,6 +297,19 @@ export class Offspring {
         });
       }
     });
+
+    // Batch connect all synapses with single cache invalidation
+    offspring.connectBatch(batchConnections);
+
+    // Apply tags to the created synapses
+    for (const conn of batchConnections) {
+      if (conn.tags) {
+        const synapse = offspring.getSynapse(conn.from, conn.to);
+        if (synapse) {
+          addTags(synapse, { tags: conn.tags });
+        }
+      }
+    }
 
     // Issue #1097: Prebuild inward index for large offspring.
     // This optimises subsequent inward connection lookups during validation

--- a/test/mutate/BatchSynapseOperations.ts
+++ b/test/mutate/BatchSynapseOperations.ts
@@ -1,0 +1,586 @@
+/**
+ * Tests for issue #1102: Batch synapse operations to reduce cache invalidation overhead
+ *
+ * This test file verifies the functionality and correctness of:
+ * 1. connectBatch() - Batch connect multiple synapses with single cache invalidation
+ * 2. disconnectBatch() - Batch disconnect multiple synapses with single cache invalidation
+ *
+ * The tests follow TDD - they define expected behaviour before implementation.
+ */
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
+import { AddNeuron } from "../../src/mutate/AddNeuron.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/**
+ * Helper to verify synapses are correctly ordered after operations.
+ * Synapses should be sorted by (from, to) pairs.
+ */
+function verifySynapseOrdering(creature: Creature): void {
+  for (let i = 1; i < creature.synapses.length; i++) {
+    const prev = creature.synapses[i - 1];
+    const curr = creature.synapses[i];
+
+    const isOrdered = prev.from < curr.from ||
+      (prev.from === curr.from && prev.to < curr.to);
+
+    assert(
+      isOrdered,
+      `Synapses out of order at index ${i}: ` +
+        `[${prev.from}->${prev.to}] should come before [${curr.from}->${curr.to}]`,
+    );
+  }
+}
+
+/**
+ * Helper to create a creature for testing.
+ */
+function createTestCreature(
+  inputCount: number,
+  outputCount: number,
+  hiddenNeurons: number,
+): Creature {
+  const creature = new Creature(inputCount, outputCount);
+  const addNeuron = new AddNeuron(creature);
+
+  for (let i = 0; i < hiddenNeurons; i++) {
+    addNeuron.mutate();
+  }
+
+  return creature;
+}
+
+// =============================================================================
+// connectBatch() Tests
+// =============================================================================
+
+Deno.test("connectBatch(): adds multiple synapses in a single operation", () => {
+  const json = {
+    input: 3,
+    output: 2,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+  const initialSynapseCount = creature.synapses.length;
+
+  // Batch connect multiple synapses
+  const connections: Array<{
+    from: number;
+    to: number;
+    weight: number;
+    type?: "positive" | "negative" | "condition";
+  }> = [
+    { from: 0, to: 3, weight: 0.5 },
+    { from: 1, to: 3, weight: -0.3 },
+    { from: 2, to: 4, weight: 0.7 },
+    { from: 0, to: 4, weight: 0.1 },
+  ];
+
+  creature.connectBatch(connections);
+
+  assertEquals(
+    creature.synapses.length,
+    initialSynapseCount + connections.length,
+  );
+  verifySynapseOrdering(creature);
+  creatureValidate(creature);
+});
+
+Deno.test("connectBatch(): maintains correct synapse ordering", () => {
+  const json = {
+    input: 5,
+    output: 3,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-2",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-2", toUUID: "output-1", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Add connections in random order - they should be sorted correctly
+  const connections = [
+    { from: 4, to: 7, weight: 0.1 }, // Last by sort order
+    { from: 0, to: 5, weight: 0.2 }, // First by sort order
+    { from: 2, to: 5, weight: 0.3 }, // Middle
+    { from: 0, to: 6, weight: 0.4 }, // After 0->5
+  ];
+
+  creature.connectBatch(connections);
+
+  verifySynapseOrdering(creature);
+  creatureValidate(creature);
+});
+
+Deno.test("connectBatch(): handles empty array", () => {
+  const creature = new Creature(2, 1);
+  const initialSynapseCount = creature.synapses.length;
+
+  creature.connectBatch([]);
+
+  assertEquals(creature.synapses.length, initialSynapseCount);
+  creatureValidate(creature);
+});
+
+Deno.test("connectBatch(): handles single connection", () => {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  creature.connectBatch([{ from: 0, to: 2, weight: 0.5 }]);
+
+  assertEquals(creature.synapses.length, 1);
+  assertEquals(creature.synapses[0].from, 0);
+  assertEquals(creature.synapses[0].to, 2);
+  creatureValidate(creature);
+});
+
+Deno.test("connectBatch(): supports synapse types", () => {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  creature.connectBatch([
+    { from: 0, to: 2, weight: 0.5, type: "positive" },
+    { from: 1, to: 2, weight: -0.3, type: "negative" },
+  ]);
+
+  assertEquals(creature.synapses.length, 2);
+  assertEquals(creature.synapses[0].type, "positive");
+  assertEquals(creature.synapses[1].type, "negative");
+  creatureValidate(creature);
+});
+
+Deno.test("connectBatch(): throws on duplicate connections within batch", () => {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  assertThrows(
+    () => {
+      creature.connectBatch([
+        { from: 0, to: 2, weight: 0.5 },
+        { from: 0, to: 2, weight: 0.3 }, // Duplicate
+      ]);
+    },
+    Error,
+    "already exists",
+  );
+});
+
+Deno.test("connectBatch(): throws on existing connections", () => {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  assertThrows(
+    () => {
+      creature.connectBatch([
+        { from: 0, to: 2, weight: 0.5 }, // Already exists
+      ]);
+    },
+    Error,
+    "already exists",
+  );
+});
+
+// =============================================================================
+// disconnectBatch() Tests
+// =============================================================================
+
+Deno.test("disconnectBatch(): removes multiple synapses in a single operation", () => {
+  const json = {
+    input: 3,
+    output: 2,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-2", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-0", toUUID: "output-1", weight: 1 },
+      { fromUUID: "input-1", toUUID: "output-1", weight: 1 },
+      { fromUUID: "input-2", toUUID: "output-1", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+  const initialSynapseCount = creature.synapses.length;
+  assertEquals(initialSynapseCount, 6);
+
+  // Batch disconnect
+  creature.disconnectBatch([
+    { from: 0, to: 3 },
+    { from: 1, to: 4 },
+    { from: 2, to: 3 },
+  ]);
+
+  assertEquals(creature.synapses.length, 3);
+  verifySynapseOrdering(creature);
+});
+
+Deno.test("disconnectBatch(): maintains correct synapse ordering", () => {
+  const json = {
+    input: 4,
+    output: 2,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-2", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-3", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-0", toUUID: "output-1", weight: 1 },
+      { fromUUID: "input-1", toUUID: "output-1", weight: 1 },
+      { fromUUID: "input-2", toUUID: "output-1", weight: 1 },
+      { fromUUID: "input-3", toUUID: "output-1", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Remove from various positions to test ordering maintenance
+  creature.disconnectBatch([
+    { from: 1, to: 4 }, // Middle
+    { from: 3, to: 5 }, // Near end
+    { from: 0, to: 4 }, // Beginning of second group
+  ]);
+
+  verifySynapseOrdering(creature);
+});
+
+Deno.test("disconnectBatch(): handles empty array", () => {
+  const creature = new Creature(2, 1);
+  const initialSynapseCount = creature.synapses.length;
+
+  creature.disconnectBatch([]);
+
+  assertEquals(creature.synapses.length, initialSynapseCount);
+});
+
+Deno.test("disconnectBatch(): handles single disconnection", () => {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  creature.disconnectBatch([{ from: 0, to: 2 }]);
+
+  assertEquals(creature.synapses.length, 1);
+  assertEquals(creature.synapses[0].from, 1);
+  assertEquals(creature.synapses[0].to, 2);
+});
+
+Deno.test("disconnectBatch(): silently ignores non-existent connections", () => {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // This should not throw - non-existent connections are silently ignored
+  creature.disconnectBatch([
+    { from: 1, to: 2 }, // Does not exist
+  ]);
+
+  assertEquals(creature.synapses.length, 1);
+});
+
+Deno.test("disconnectBatch(): handles mix of existent and non-existent connections", () => {
+  const json = {
+    input: 3,
+    output: 1,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 1 },
+      { fromUUID: "input-2", toUUID: "output-0", weight: 1 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  creature.disconnectBatch([
+    { from: 0, to: 3 }, // Exists
+    { from: 0, to: 4 }, // Does not exist (no such neuron)
+    { from: 2, to: 3 }, // Exists
+  ]);
+
+  assertEquals(creature.synapses.length, 1);
+  assertEquals(creature.synapses[0].from, 1);
+  assertEquals(creature.synapses[0].to, 3);
+});
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+Deno.test("connectBatch() + disconnectBatch(): work together correctly", () => {
+  const json = {
+    input: 4,
+    output: 2,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Add some connections
+  creature.connectBatch([
+    { from: 0, to: 4, weight: 0.5 },
+    { from: 1, to: 4, weight: 0.3 },
+    { from: 2, to: 5, weight: 0.7 },
+    { from: 3, to: 5, weight: 0.1 },
+  ]);
+
+  assertEquals(creature.synapses.length, 4);
+  verifySynapseOrdering(creature);
+
+  // Remove some connections
+  creature.disconnectBatch([
+    { from: 1, to: 4 },
+    { from: 3, to: 5 },
+  ]);
+
+  assertEquals(creature.synapses.length, 2);
+  verifySynapseOrdering(creature);
+  creatureValidate(creature);
+});
+
+Deno.test("batch operations: produce same result as individual operations", () => {
+  // Create two identical creatures
+  const json = {
+    input: 3,
+    output: 2,
+    neurons: [
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [],
+  };
+
+  const creature1 = Creature.fromJSON(json, true);
+  const creature2 = Creature.fromJSON(json, true);
+
+  const connections = [
+    { from: 0, to: 3, weight: 0.5 },
+    { from: 1, to: 4, weight: 0.3 },
+    { from: 2, to: 3, weight: 0.7 },
+  ];
+
+  // Creature 1: Use batch operation
+  creature1.connectBatch(connections);
+
+  // Creature 2: Use individual operations
+  for (const conn of connections) {
+    creature2.connect(conn.from, conn.to, conn.weight);
+  }
+
+  // Verify both have the same synapses
+  assertEquals(creature1.synapses.length, creature2.synapses.length);
+
+  for (let i = 0; i < creature1.synapses.length; i++) {
+    assertEquals(creature1.synapses[i].from, creature2.synapses[i].from);
+    assertEquals(creature1.synapses[i].to, creature2.synapses[i].to);
+    assertEquals(creature1.synapses[i].weight, creature2.synapses[i].weight);
+  }
+});
+
+Deno.test("batch operations: large creature stress test", () => {
+  const creature = createTestCreature(20, 5, 50);
+
+  // Get available connections
+  const available = creature.getAvailableConnections();
+  const toAdd = Math.min(100, available.length);
+
+  const connections = available.slice(0, toAdd).map(([from, to]) => ({
+    from,
+    to,
+    weight: Math.random() * 2 - 1,
+  }));
+
+  const initialCount = creature.synapses.length;
+  creature.connectBatch(connections);
+
+  assertEquals(creature.synapses.length, initialCount + toAdd);
+  verifySynapseOrdering(creature);
+  creatureValidate(creature);
+
+  // Now disconnect some
+  const toRemove = connections.slice(0, 50).map((c) => ({
+    from: c.from,
+    to: c.to,
+  }));
+
+  creature.disconnectBatch(toRemove);
+
+  assertEquals(creature.synapses.length, initialCount + toAdd - 50);
+  verifySynapseOrdering(creature);
+  creatureValidate(creature);
+});


### PR DESCRIPTION
## Summary

Added batch synapse operations (`connectBatch()` and `disconnectBatch()`) to the `Creature` class to reduce cache invalidation overhead. Previously, operations that modified multiple synapses (like breeding) would call `clearCache()` and `invalidateScoreCache()` after each individual synapse change, causing redundant cache rebuilding.

The new batch methods:
- **`connectBatch()`**: Adds multiple synapses with a single cache invalidation
- **`disconnectBatch()`**: Removes multiple synapses with a single cache invalidation

Updated `Offspring.breed()` to use `connectBatch()` instead of individual `connect()` calls.

## Evidence

### Benchmark Results

Performance comparison between batch operations and individual operations:

**connectBatch() vs individual connect():**

| Creature Size | Connections | Individual | Batch | Improvement |
|---------------|-------------|------------|-------|-------------|
| Small (35 neurons) | 50 | 52.8 µs | 16.7 µs | **3.17x faster** |
| Medium (120 neurons) | 200 | 844.9 µs | 76.4 µs | **11.06x faster** |
| Large (270 neurons) | 500 | 6.6 ms | 425.4 µs | **15.57x faster** |

**disconnectBatch() vs individual disconnect():**

| Creature Size | Disconnections | Individual | Batch | Improvement |
|---------------|----------------|------------|-------|-------------|
| Small | 30 | 13.6 µs | 11.9 µs | 1.14x faster |
| Medium | 100 | 57.6 µs | 52.4 µs | 1.10x faster |
| Large | 250 | 409.5 µs | 397.7 µs | 1.03x faster |

The `connectBatch()` improvement significantly exceeds the issue's expected 30-50% improvement, achieving up to **15.57x faster** performance for large creatures. The `disconnectBatch()` improvement is more modest because disconnect operations were already optimised with binary search (Issue #1101).

### Benchmark Command

```bash
deno bench --allow-read --allow-write bench/BatchSynapseOperations.ts
```

## Test Plan

Added 16 unit tests in `test/mutate/BatchSynapseOperations.ts`:

**connectBatch() tests:**
- `connectBatch(): adds multiple synapses in a single operation`
- `connectBatch(): maintains correct synapse ordering`
- `connectBatch(): handles empty array`
- `connectBatch(): handles single connection`
- `connectBatch(): supports synapse types`
- `connectBatch(): throws on duplicate connections within batch`
- `connectBatch(): throws on existing connections`

**disconnectBatch() tests:**
- `disconnectBatch(): removes multiple synapses in a single operation`
- `disconnectBatch(): maintains correct synapse ordering`
- `disconnectBatch(): handles empty array`
- `disconnectBatch(): handles single disconnection`
- `disconnectBatch(): silently ignores non-existent connections`
- `disconnectBatch(): handles mix of existent and non-existent connections`

**Integration tests:**
- `connectBatch() + disconnectBatch(): work together correctly`
- `batch operations: produce same result as individual operations`
- `batch operations: large creature stress test`

All existing tests (1493) continue to pass with the changes.

## Files Changed

- `src/Creature.ts` - Added `connectBatch()`, `disconnectBatch()`, and `findInsertionPoint()` methods
- `src/architecture/Offspring.ts` - Updated breeding to use `connectBatch()`
- `bench/BatchSynapseOperations.ts` - New benchmark file
- `test/mutate/BatchSynapseOperations.ts` - New test file

## Related Issues

- Fixes #1102
- Related to #1090 (Find potential performance improvements in the evolution process)
- Builds on #1101 (Binary search for disconnect operations)
- Builds on #1093 (splice() for connect operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)