### PR TITLE
Fix: WASM Migration Phase 1: Add WASM activation option to Creature class with automatic fallback (#1118)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.292.26",
+  "version": "0.292.27",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.16",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/docs/pr-summary-1118.md
+++ b/docs/pr-summary-1118.md
@@ -2,7 +2,10 @@
 
 ## Summary
 
-This PR implements WASM Migration Phase 1, adding an optional WASM activation path to the `Creature` class with automatic fallback to JS when WASM cannot be used. The library remains fully functional while introducing optional WASM acceleration.
+This PR implements WASM Migration Phase 1, adding an optional WASM activation
+path to the `Creature` class with automatic fallback to JS when WASM cannot be
+used. The library remains fully functional while introducing optional WASM
+acceleration.
 
 ### Changes Made
 
@@ -12,7 +15,8 @@ This PR implements WASM Migration Phase 1, adding an optional WASM activation pa
 
 2. **WASM eligibility detection**
    - Added `isWasmEligible()` method to check if creature can use WASM
-   - Added `getUnsupportedWasmSquashFunctions()` to identify incompatible functions
+   - Added `getUnsupportedWasmSquashFunctions()` to identify incompatible
+     functions
    - Eligibility result is cached and invalidated on structural changes
 
 3. **Lazy WASM compilation with caching**
@@ -29,64 +33,70 @@ This PR implements WASM Migration Phase 1, adding an optional WASM activation pa
 
 All standard and aggregate squash functions are WASM-supported:
 
-| Category | Functions |
-|----------|-----------|
-| Standard | IDENTITY, ReLU, ReLU6, LeakyReLU, SELU, ELU |
-| Sigmoid-like | LOGISTIC, TANH, HARD_TANH, SOFTSIGN, Softplus |
-| Modern | Swish, Mish, GELU |
-| Trigonometric | SINE, Cosine, TAN, ArcTan |
-| Other | GAUSSIAN, BENT_IDENTITY, BIPOLAR_SIGMOID, BIPOLAR |
-| Discrete | STEP, COMPLEMENT |
-| Mathematical | ABSOLUTE, SQUARE, Cube, SQRT, StdInverse, Exponential |
-| Advanced | LogSigmoid, ISRU |
-| Aggregate | MINIMUM, MAXIMUM, IF |
+| Category      | Functions                                             |
+| ------------- | ----------------------------------------------------- |
+| Standard      | IDENTITY, ReLU, ReLU6, LeakyReLU, SELU, ELU           |
+| Sigmoid-like  | LOGISTIC, TANH, HARD_TANH, SOFTSIGN, Softplus         |
+| Modern        | Swish, Mish, GELU                                     |
+| Trigonometric | SINE, Cosine, TAN, ArcTan                             |
+| Other         | GAUSSIAN, BENT_IDENTITY, BIPOLAR_SIGMOID, BIPOLAR     |
+| Discrete      | STEP, COMPLEMENT                                      |
+| Mathematical  | ABSOLUTE, SQUARE, Cube, SQRT, StdInverse, Exponential |
+| Advanced      | LogSigmoid, ISRU                                      |
+| Aggregate     | MINIMUM, MAXIMUM, IF                                  |
 
 ### Unsupported Functions (fallback to JS)
 
 The following deprecated functions are not supported in WASM:
+
 - `MEAN` - Deprecated aggregate function
 - `HYPOT` - Deprecated aggregate function
 - `HYPOTv2` - Deprecated aggregate function
 
-When a creature uses any unsupported function, `activate()` with `useWasm=true` automatically falls back to the JS implementation.
+When a creature uses any unsupported function, `activate()` with `useWasm=true`
+automatically falls back to the JS implementation.
 
 ## Evidence
 
-This is a performance enhancement with no UI changes. The WASM prototype (PR #1117) demonstrated ~9.5x performance improvement for neural network activation. This PR integrates that capability into the main Creature API.
+This is a performance enhancement with no UI changes. The WASM prototype (PR
+#1117) demonstrated ~9.5x performance improvement for neural network activation.
+This PR integrates that capability into the main Creature API.
 
 ### Verification
 
 - All 1518+ existing tests pass without modification
 - 17 new unit tests added for WASM integration
-- Both JS and WASM paths produce identical results (within floating-point tolerance)
+- Both JS and WASM paths produce identical results (within floating-point
+  tolerance)
 
 ## Test Plan
 
 ### New Tests Added (`test/CreatureWasmActivation.ts`)
 
-| Test | Description |
-|------|-------------|
-| Module initialisation | WASM module loads successfully |
-| `activate()` accepts useWasm parameter | API works with new parameter |
-| `activate()` produces same results | JS and WASM outputs match |
-| `activateAndTrace()` accepts useWasm | API consistency (always uses JS) |
+| Test                                       | Description                                |
+| ------------------------------------------ | ------------------------------------------ |
+| Module initialisation                      | WASM module loads successfully             |
+| `activate()` accepts useWasm parameter     | API works with new parameter               |
+| `activate()` produces same results         | JS and WASM outputs match                  |
+| `activateAndTrace()` accepts useWasm       | API consistency (always uses JS)           |
 | `isWasmEligible()` for supported functions | Returns true for WASM-compatible creatures |
-| `isWasmEligible()` for MEAN | Returns false for unsupported function |
-| `isWasmEligible()` for HYPOT | Returns false for unsupported function |
-| Aggregate functions (IF, MINIMUM, MAXIMUM) | Supported in WASM |
-| Falls back to JS for unsupported squash | Automatic fallback works |
-| Caches compiled WASM activation | Lazy compilation and reuse |
-| Invalidates cache on clearState() | Cache management |
-| Buffer reuse works with useWasm | Performance optimisation |
-| Works with multiple outputs | Multi-output creatures |
-| Works with constant neurons | Constant neuron support |
-| All supported squash functions | 35 squash functions verified |
-| `getUnsupportedWasmSquashFunctions()` | Diagnostic method |
-| `disposeWasm()` cleans up resources | Resource management |
+| `isWasmEligible()` for MEAN                | Returns false for unsupported function     |
+| `isWasmEligible()` for HYPOT               | Returns false for unsupported function     |
+| Aggregate functions (IF, MINIMUM, MAXIMUM) | Supported in WASM                          |
+| Falls back to JS for unsupported squash    | Automatic fallback works                   |
+| Caches compiled WASM activation            | Lazy compilation and reuse                 |
+| Invalidates cache on clearState()          | Cache management                           |
+| Buffer reuse works with useWasm            | Performance optimisation                   |
+| Works with multiple outputs                | Multi-output creatures                     |
+| Works with constant neurons                | Constant neuron support                    |
+| All supported squash functions             | 35 squash functions verified               |
+| `getUnsupportedWasmSquashFunctions()`      | Diagnostic method                          |
+| `disposeWasm()` cleans up resources        | Resource management                        |
 
 ### Existing Tests
 
 All 1518+ existing tests pass without modification, verifying:
+
 - No breaking changes to public API
 - Both JS and WASM paths produce identical results
 - Backward compatibility maintained

--- a/docs/pr-summary-1118.md
+++ b/docs/pr-summary-1118.md
@@ -1,0 +1,120 @@
+# PR Summary: WASM Migration Phase 1 - Add WASM Activation Option (#1118)
+
+## Summary
+
+This PR implements WASM Migration Phase 1, adding an optional WASM activation path to the `Creature` class with automatic fallback to JS when WASM cannot be used. The library remains fully functional while introducing optional WASM acceleration.
+
+### Changes Made
+
+1. **Extended `activate()` and `activateAndTrace()` methods**
+   - Added optional `useWasm?: boolean` parameter (defaults to `false`)
+   - When `useWasm=true`, attempts WASM activation with automatic JS fallback
+
+2. **WASM eligibility detection**
+   - Added `isWasmEligible()` method to check if creature can use WASM
+   - Added `getUnsupportedWasmSquashFunctions()` to identify incompatible functions
+   - Eligibility result is cached and invalidated on structural changes
+
+3. **Lazy WASM compilation with caching**
+   - WASM binary compiled only on first WASM activation request
+   - Cached `WasmCreatureActivation` instance reused for subsequent calls
+   - Cache invalidated on `clearState()` and structural changes
+
+4. **Resource cleanup**
+   - Added `disposeWasm()` method for explicit cleanup
+   - Automatic cleanup in `dispose()` and `clearState()` methods
+   - WASM eligibility cache invalidated via `invalidateScoreCache()`
+
+### Supported Squash Functions (35 types)
+
+All standard and aggregate squash functions are WASM-supported:
+
+| Category | Functions |
+|----------|-----------|
+| Standard | IDENTITY, ReLU, ReLU6, LeakyReLU, SELU, ELU |
+| Sigmoid-like | LOGISTIC, TANH, HARD_TANH, SOFTSIGN, Softplus |
+| Modern | Swish, Mish, GELU |
+| Trigonometric | SINE, Cosine, TAN, ArcTan |
+| Other | GAUSSIAN, BENT_IDENTITY, BIPOLAR_SIGMOID, BIPOLAR |
+| Discrete | STEP, COMPLEMENT |
+| Mathematical | ABSOLUTE, SQUARE, Cube, SQRT, StdInverse, Exponential |
+| Advanced | LogSigmoid, ISRU |
+| Aggregate | MINIMUM, MAXIMUM, IF |
+
+### Unsupported Functions (fallback to JS)
+
+The following deprecated functions are not supported in WASM:
+- `MEAN` - Deprecated aggregate function
+- `HYPOT` - Deprecated aggregate function
+- `HYPOTv2` - Deprecated aggregate function
+
+When a creature uses any unsupported function, `activate()` with `useWasm=true` automatically falls back to the JS implementation.
+
+## Evidence
+
+This is a performance enhancement with no UI changes. The WASM prototype (PR #1117) demonstrated ~9.5x performance improvement for neural network activation. This PR integrates that capability into the main Creature API.
+
+### Verification
+
+- All 1518+ existing tests pass without modification
+- 17 new unit tests added for WASM integration
+- Both JS and WASM paths produce identical results (within floating-point tolerance)
+
+## Test Plan
+
+### New Tests Added (`test/CreatureWasmActivation.ts`)
+
+| Test | Description |
+|------|-------------|
+| Module initialisation | WASM module loads successfully |
+| `activate()` accepts useWasm parameter | API works with new parameter |
+| `activate()` produces same results | JS and WASM outputs match |
+| `activateAndTrace()` accepts useWasm | API consistency (always uses JS) |
+| `isWasmEligible()` for supported functions | Returns true for WASM-compatible creatures |
+| `isWasmEligible()` for MEAN | Returns false for unsupported function |
+| `isWasmEligible()` for HYPOT | Returns false for unsupported function |
+| Aggregate functions (IF, MINIMUM, MAXIMUM) | Supported in WASM |
+| Falls back to JS for unsupported squash | Automatic fallback works |
+| Caches compiled WASM activation | Lazy compilation and reuse |
+| Invalidates cache on clearState() | Cache management |
+| Buffer reuse works with useWasm | Performance optimisation |
+| Works with multiple outputs | Multi-output creatures |
+| Works with constant neurons | Constant neuron support |
+| All supported squash functions | 35 squash functions verified |
+| `getUnsupportedWasmSquashFunctions()` | Diagnostic method |
+| `disposeWasm()` cleans up resources | Resource management |
+
+### Existing Tests
+
+All 1518+ existing tests pass without modification, verifying:
+- No breaking changes to public API
+- Both JS and WASM paths produce identical results
+- Backward compatibility maintained
+
+## API Usage
+
+```typescript
+const creature = Creature.fromJSON(creatureJson);
+creature.fix();
+
+// Standard JS activation (unchanged)
+const jsOutput = creature.activate(input);
+
+// WASM activation (automatic fallback if not supported)
+const wasmOutput = creature.activate(input, false, false, true);
+
+// Check WASM eligibility
+if (creature.isWasmEligible()) {
+  console.log("Creature can use WASM acceleration");
+} else {
+  const unsupported = creature.getUnsupportedWasmSquashFunctions();
+  console.log("Unsupported squash functions:", unsupported);
+}
+
+// Explicit cleanup (optional - also called by dispose()/clearState())
+creature.disposeWasm();
+```
+
+## Breaking Changes
+
+None. All existing code continues to work without modification.

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -55,6 +55,12 @@ import {
   DiscoveryReplayRunner,
   type DiscoveryReplayRunnerLike,
 } from "./discovery/DiscoveryReplayRunner.ts";
+import {
+  compileCreatureToWasm,
+  isWasmActivationAvailable,
+  SQUASH_NAME_TO_TYPE,
+  WasmCreatureActivation,
+} from "./wasm/mod.ts";
 
 interface CreatureOptions {
   semanticVersion?: string;
@@ -228,6 +234,21 @@ export class Creature implements CreatureInternal {
   private cachedOutputBuffer?: Float32Array;
 
   /**
+   * Cached WASM activation instance for this creature.
+   * Lazily compiled on first WASM activation request.
+   * Issue #1118: WASM Migration Phase 1 - Add WASM activation option.
+   */
+  private cachedWasmActivation?: WasmCreatureActivation;
+
+  /**
+   * Cached WASM eligibility status for this creature.
+   * True if all neurons use WASM-supported squash functions.
+   * Invalidated on structural changes.
+   * Issue #1118: WASM Migration Phase 1 - Add WASM activation option.
+   */
+  private wasmEligibilityCache?: boolean;
+
+  /**
    * Debug mode flag.
    * @type {boolean}
    */
@@ -280,6 +301,7 @@ export class Creature implements CreatureInternal {
     this.clearState();
     this.clearCache();
     this.clearFocusCache();
+    this.disposeWasm(); // Issue #1118: Clean up WASM resources
     this.synapses.length = 0;
     this.neurons.length = 0;
   }
@@ -357,6 +379,9 @@ export class Creature implements CreatureInternal {
    */
   public invalidateScoreCache() {
     this.cachedScoreComponents = undefined;
+    // Issue #1118: Invalidate WASM eligibility cache on structural changes
+    // (squash functions may have changed)
+    this.wasmEligibilityCache = undefined;
   }
 
   private initialize(options: {
@@ -479,6 +504,9 @@ export class Creature implements CreatureInternal {
     // Clear cached output buffer to ensure fresh buffer on next activation
     // Issue #1094: Performance optimisation for buffer reuse
     delete this.cachedOutputBuffer;
+    // Clear WASM cache - structure may have changed
+    // Issue #1118: WASM Migration Phase 1
+    this.disposeWasm();
   }
 
   private creatureActivationFunction?: () => undefined;
@@ -511,6 +539,11 @@ export class Creature implements CreatureInternal {
    *   to avoid allocating a new Float32Array on each call. This reduces GC pressure
    *   but callers must not mutate the returned array as it may be overwritten.
    *   Issue #1094: Performance optimisation for repeated activations.
+   * @param {boolean} [useWasm=false] - When true, attempts to use WASM activation.
+   *   Falls back to JS if WASM is unavailable or creature uses unsupported squash functions.
+   *   Note: WASM activation does not support tracing, so this parameter is currently
+   *   ignored and JS activation is always used for activateAndTrace.
+   *   Issue #1118: WASM Migration Phase 1.
    * @returns {Float32Array} The output values after activation.
    */
   activateAndTrace(
@@ -518,7 +551,10 @@ export class Creature implements CreatureInternal {
     feedbackLoop: boolean,
     sparseConfig: SparseConfig,
     reuseBuffer: boolean = false,
+    _useWasm: boolean = false,
   ): Float32Array {
+    // WASM activation does not support tracing, always use JS for activateAndTrace
+    // The useWasm parameter is accepted for API consistency but currently ignored
     this.prepareNeurons();
     const activations = this.state.makeActivation(input, feedbackLoop);
 
@@ -553,13 +589,23 @@ export class Creature implements CreatureInternal {
    *   to avoid allocating a new Float32Array on each call. This reduces GC pressure
    *   but callers must not mutate the returned array as it may be overwritten.
    *   Issue #1094: Performance optimisation for repeated activations.
+   * @param {boolean} [useWasm=false] - When true, attempts to use WASM activation.
+   *   Falls back to JS if WASM is unavailable or creature uses unsupported squash functions.
+   *   Issue #1118: WASM Migration Phase 1.
    * @returns {Float32Array} The output values after activation.
    */
   activate(
     input: Float32Array,
     feedbackLoop: boolean = false,
     reuseBuffer: boolean = false,
+    useWasm: boolean = false,
   ): Float32Array {
+    // Attempt WASM activation if requested
+    if (useWasm && this.canUseWasm()) {
+      return this.activateWasm(input, reuseBuffer);
+    }
+
+    // Fall back to JS activation
     this.prepareNeurons();
     const activations = this.state.makeActivation(input, feedbackLoop);
 
@@ -575,6 +621,129 @@ export class Creature implements CreatureInternal {
 
     const lastHiddenNode = this.neurons.length - this.output;
     return this.extractOutputs(activations, lastHiddenNode, reuseBuffer);
+  }
+
+  /**
+   * Check if this creature can use WASM activation.
+   * Returns true if WASM is available and all squash functions are supported.
+   * Issue #1118: WASM Migration Phase 1.
+   *
+   * @returns {boolean} True if WASM activation can be used.
+   */
+  private canUseWasm(): boolean {
+    // Check if WASM module is available
+    if (!isWasmActivationAvailable()) {
+      return false;
+    }
+
+    // Check if creature is eligible for WASM (all squash functions supported)
+    return this.isWasmEligible();
+  }
+
+  /**
+   * Activate the creature using WASM.
+   * Lazily compiles the creature to WASM on first call.
+   * Issue #1118: WASM Migration Phase 1.
+   *
+   * @param {Float32Array} input - The input values for the creature.
+   * @param {boolean} reuseBuffer - Whether to reuse the cached output buffer.
+   * @returns {Float32Array} The output values after activation.
+   */
+  private activateWasm(
+    input: Float32Array,
+    reuseBuffer: boolean,
+  ): Float32Array {
+    // Lazily compile to WASM if not already done
+    if (!this.cachedWasmActivation) {
+      const compiled = compileCreatureToWasm(this);
+      this.cachedWasmActivation = WasmCreatureActivation.create(compiled) ??
+        undefined;
+
+      // If compilation failed, fall back to JS
+      if (!this.cachedWasmActivation) {
+        return this.activate(input, false, reuseBuffer, false);
+      }
+    }
+
+    // Activate using WASM
+    const wasmOutput = this.cachedWasmActivation.activate(input);
+
+    // Handle buffer reuse
+    if (reuseBuffer) {
+      if (
+        !this.cachedOutputBuffer ||
+        this.cachedOutputBuffer.length !== this.output
+      ) {
+        this.cachedOutputBuffer = new Float32Array(this.output);
+      }
+      this.cachedOutputBuffer.set(wasmOutput);
+      return this.cachedOutputBuffer;
+    }
+
+    return wasmOutput;
+  }
+
+  /**
+   * Check if this creature is eligible for WASM activation.
+   * A creature is eligible if all its neurons use WASM-supported squash functions.
+   * The result is cached and invalidated when structure changes.
+   * Issue #1118: WASM Migration Phase 1.
+   *
+   * @returns {boolean} True if all squash functions are WASM-supported.
+   */
+  isWasmEligible(): boolean {
+    // Return cached result if available
+    if (this.wasmEligibilityCache !== undefined) {
+      return this.wasmEligibilityCache;
+    }
+
+    // Check all non-input neurons for supported squash functions
+    const unsupported = this.getUnsupportedWasmSquashFunctions();
+    this.wasmEligibilityCache = unsupported.length === 0;
+
+    return this.wasmEligibilityCache;
+  }
+
+  /**
+   * Get the list of squash functions used by this creature that are not supported by WASM.
+   * Issue #1118: WASM Migration Phase 1.
+   *
+   * @returns {string[]} Array of unsupported squash function names (empty if all are supported).
+   */
+  getUnsupportedWasmSquashFunctions(): string[] {
+    const unsupported: string[] = [];
+    const seen = new Set<string>();
+
+    for (let i = this.input; i < this.neurons.length; i++) {
+      const neuron = this.neurons[i];
+      const squash = neuron.squash ?? "IDENTITY";
+
+      // Skip if we've already checked this squash function
+      if (seen.has(squash)) {
+        continue;
+      }
+      seen.add(squash);
+
+      // Check if squash function is in the WASM-supported list
+      if (!(squash in SQUASH_NAME_TO_TYPE)) {
+        unsupported.push(squash);
+      }
+    }
+
+    return unsupported;
+  }
+
+  /**
+   * Dispose of cached WASM resources.
+   * Call this when the creature structure changes or when done using WASM activation.
+   * Issue #1118: WASM Migration Phase 1.
+   */
+  disposeWasm(): void {
+    if (this.cachedWasmActivation) {
+      this.cachedWasmActivation.free();
+      this.cachedWasmActivation = undefined;
+    }
+    this.wasmEligibilityCache = undefined;
   }
 
   /**

--- a/test/CreatureWasmActivation.ts
+++ b/test/CreatureWasmActivation.ts
@@ -1,0 +1,830 @@
+/**
+ * Creature WASM Activation Integration Tests
+ *
+ * Issue #1118 - WASM Migration Phase 1: Add WASM activation option to Creature class
+ *
+ * These tests verify that:
+ * 1. Creature.activate() accepts optional useWasm parameter
+ * 2. WASM is used when requested and supported, with JS fallback otherwise
+ * 3. WASM eligibility detection works correctly
+ * 4. WASM compilation is cached and lazily initialised
+ * 5. Both JS and WASM paths produce identical results
+ */
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { Creature } from "../src/Creature.ts";
+import type { CreatureInternal } from "../src/architecture/CreatureInterfaces.ts";
+import {
+  initWasmActivation,
+  isWasmActivationAvailable,
+} from "../src/wasm/mod.ts";
+import { SparseConfig } from "../src/propagate/sparse/SparseConfig.ts";
+import { createBackPropagationConfig } from "../src/propagate/BackPropagation.ts";
+
+// Tolerance for floating point comparisons (WASM uses f32, JS uses f64)
+const TOLERANCE = 1e-5;
+
+/**
+ * Helper function to assert two Float32Arrays are close to each other
+ */
+function assertArrayClose(
+  actual: Float32Array,
+  expected: Float32Array,
+  message?: string,
+  tolerance: number = TOLERANCE,
+): void {
+  assertEquals(
+    actual.length,
+    expected.length,
+    `${message ?? ""}: Array lengths differ`,
+  );
+  for (let i = 0; i < actual.length; i++) {
+    assertAlmostEquals(
+      actual[i],
+      expected[i],
+      tolerance,
+      `${message ?? ""}[${i}]`,
+    );
+  }
+}
+
+// Get the project root directory for WASM module path
+const projectRoot = new URL("..", import.meta.url).pathname;
+const wasmPath = `${projectRoot}wasm_activation/pkg`;
+
+// Initialise WASM before tests
+Deno.test({
+  name: "Creature WASM: Module initialisation",
+  async fn() {
+    const result = await initWasmActivation(wasmPath);
+    assert(result, "WASM module should initialise successfully");
+    assert(isWasmActivationAvailable(), "WASM should be available after init");
+  },
+});
+
+// =============================================================================
+// Test: activate() with useWasm parameter
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: activate() accepts useWasm parameter",
+  fn() {
+    // Create a simple creature with WASM-compatible squash functions
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: -1.0 },
+        { from: 2, to: 3, weight: 2.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    const input = new Float32Array([1.0, 0.5]);
+
+    // Should work with useWasm=false (explicit JS)
+    const jsOutput = creature.activate(input, false, false, false);
+    assert(jsOutput.length === 1, "JS output should have correct length");
+
+    // Should work with useWasm=true (attempt WASM)
+    const wasmOutput = creature.activate(input, false, false, true);
+    assert(wasmOutput.length === 1, "WASM output should have correct length");
+
+    // Both should produce identical results
+    assertArrayClose(wasmOutput, jsOutput, "JS and WASM outputs should match");
+  },
+});
+
+Deno.test({
+  name: "Creature WASM: activate() with useWasm produces same results as JS",
+  fn() {
+    // Create a creature with multiple supported squash functions
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.1, squash: "ReLU" },
+        { type: "hidden", index: 3, bias: 0.2, squash: "TANH" },
+        { type: "hidden", index: 4, bias: 0.3, squash: "LOGISTIC" },
+        { type: "output", index: 5, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: 0.5 },
+        { from: 0, to: 3, weight: -0.5 },
+        { from: 1, to: 3, weight: 1.0 },
+        { from: 2, to: 4, weight: 1.0 },
+        { from: 3, to: 4, weight: 1.0 },
+        { from: 4, to: 5, weight: 2.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    // Test with various inputs
+    const testCases = [
+      new Float32Array([1.0, 0.0]),
+      new Float32Array([0.0, 1.0]),
+      new Float32Array([1.0, 1.0]),
+      new Float32Array([-1.0, -1.0]),
+      new Float32Array([2.0, 0.5]),
+      new Float32Array([-0.5, 0.5]),
+    ];
+
+    for (const input of testCases) {
+      const jsOutput = creature.activate(input, false, false, false);
+      const wasmOutput = creature.activate(input, false, false, true);
+      assertArrayClose(
+        wasmOutput,
+        jsOutput,
+        `Input: [${input.join(", ")}]`,
+      );
+    }
+  },
+});
+
+// =============================================================================
+// Test: activateAndTrace() with useWasm parameter
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: activateAndTrace() accepts useWasm parameter",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: -1.0 },
+        { from: 2, to: 3, weight: 2.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    const input = new Float32Array([1.0, 0.5]);
+    const creatureExport = creature.exportJSON();
+    const config = createBackPropagationConfig({
+      generations: 1,
+    });
+    const sparseConfig = new SparseConfig(creatureExport, config);
+
+    // activateAndTrace with useWasm should fallback to JS (tracing not supported in WASM)
+    // but still produce correct results
+    const jsOutput = creature.activateAndTrace(
+      input,
+      false,
+      sparseConfig,
+      false,
+      false,
+    );
+    const wasmOutput = creature.activateAndTrace(
+      input,
+      false,
+      sparseConfig,
+      false,
+      true,
+    );
+
+    assertArrayClose(
+      wasmOutput,
+      jsOutput,
+      "activateAndTrace outputs should match",
+    );
+  },
+});
+
+// =============================================================================
+// Test: WASM eligibility detection
+// =============================================================================
+
+Deno.test({
+  name:
+    "Creature WASM: isWasmEligible() returns true for supported squash functions",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+        { type: "hidden", index: 3, bias: 0.3, squash: "TANH" },
+        { type: "output", index: 4, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 3, weight: 1.0 },
+        { from: 2, to: 4, weight: 1.0 },
+        { from: 3, to: 4, weight: 1.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    assert(
+      creature.isWasmEligible(),
+      "Creature with supported squash functions should be WASM eligible",
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "Creature WASM: isWasmEligible() returns false for unsupported squash functions (MEAN)",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "MEAN" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: 1.0 },
+        { from: 2, to: 3, weight: 1.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    assert(
+      !creature.isWasmEligible(),
+      "Creature with MEAN squash should NOT be WASM eligible",
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "Creature WASM: isWasmEligible() returns false for unsupported squash functions (HYPOT)",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "HYPOT" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: 1.0 },
+        { from: 2, to: 3, weight: 1.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    assert(
+      !creature.isWasmEligible(),
+      "Creature with HYPOT squash should NOT be WASM eligible",
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "Creature WASM: isWasmEligible() supports aggregate functions (IF, MINIMUM, MAXIMUM)",
+  fn() {
+    // IF function
+    const ifCreatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 3, bias: 0, squash: "IF" },
+        { type: "output", index: 4, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 3, weight: 1.0, type: "condition" },
+        { from: 1, to: 3, weight: 1.0, type: "positive" },
+        { from: 2, to: 3, weight: 1.0, type: "negative" },
+        { from: 3, to: 4, weight: 1.0 },
+      ],
+      input: 3,
+      output: 1,
+    };
+    const ifCreature = Creature.fromJSON(ifCreatureJson);
+    ifCreature.fix();
+    assert(
+      ifCreature.isWasmEligible(),
+      "Creature with IF should be WASM eligible",
+    );
+
+    // MINIMUM function
+    const minCreatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0, squash: "MINIMUM" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: 1.0 },
+        { from: 2, to: 3, weight: 1.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+    const minCreature = Creature.fromJSON(minCreatureJson);
+    minCreature.fix();
+    assert(
+      minCreature.isWasmEligible(),
+      "Creature with MINIMUM should be WASM eligible",
+    );
+
+    // MAXIMUM function
+    const maxCreatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0, squash: "MAXIMUM" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: 1.0 },
+        { from: 2, to: 3, weight: 1.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+    const maxCreature = Creature.fromJSON(maxCreatureJson);
+    maxCreature.fix();
+    assert(
+      maxCreature.isWasmEligible(),
+      "Creature with MAXIMUM should be WASM eligible",
+    );
+  },
+});
+
+// =============================================================================
+// Test: Automatic fallback to JS when WASM cannot be used
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: Falls back to JS for unsupported squash functions",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "MEAN" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: 1.0 },
+        { from: 2, to: 3, weight: 1.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    const input = new Float32Array([1.0, 2.0]);
+
+    // Even with useWasm=true, should fallback to JS and produce correct results
+    const jsOutput = creature.activate(input, false, false, false);
+    const wasmOutput = creature.activate(input, false, false, true);
+
+    // MEAN squash: (1.0 + 2.0) / 2 + bias = 1.5 + 0.5 = 2.0
+    assertArrayClose(
+      wasmOutput,
+      jsOutput,
+      "Should fallback to JS for MEAN squash",
+    );
+  },
+});
+
+// =============================================================================
+// Test: WASM compilation caching
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: Caches compiled WASM activation",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: -1.0 },
+        { from: 2, to: 3, weight: 2.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    const input1 = new Float32Array([1.0, 0.5]);
+    const input2 = new Float32Array([2.0, 1.0]);
+
+    // First activation with WASM should compile
+    const output1 = creature.activate(input1, false, false, true);
+    assert(output1.length === 1);
+
+    // Second activation should use cached WASM activation
+    const output2 = creature.activate(input2, false, false, true);
+    assert(output2.length === 1);
+
+    // Results should still be correct
+    const jsOutput1 = creature.activate(input1, false, false, false);
+    const jsOutput2 = creature.activate(input2, false, false, false);
+
+    assertArrayClose(output1, jsOutput1);
+    assertArrayClose(output2, jsOutput2);
+  },
+});
+
+// =============================================================================
+// Test: WASM cache invalidation on structural changes
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: Invalidates cache on clearState()",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: -1.0 },
+        { from: 2, to: 3, weight: 2.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    const input = new Float32Array([1.0, 0.5]);
+
+    // Activate with WASM to compile and cache
+    const output1 = creature.activate(input, false, false, true);
+
+    // Clear state (simulates structural change)
+    creature.clearState();
+
+    // Should still work after clearState (will recompile if needed)
+    const output2 = creature.activate(input, false, false, true);
+
+    assertArrayClose(
+      output1,
+      output2,
+      "Results should be consistent after clearState",
+    );
+  },
+});
+
+// =============================================================================
+// Test: Buffer reuse with WASM
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: Buffer reuse works with useWasm",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: -1.0 },
+        { from: 2, to: 3, weight: 2.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    const input1 = new Float32Array([1.0, 0.5]);
+    const input2 = new Float32Array([2.0, 1.0]);
+
+    // Activate with WASM and buffer reuse - copy immediately to avoid overwrite
+    const output1 = new Float32Array(
+      creature.activate(input1, false, true, true),
+    );
+    const expected1 = creature.activate(input1, false, false, false);
+
+    const output2 = new Float32Array(
+      creature.activate(input2, false, true, true),
+    );
+    const expected2 = creature.activate(input2, false, false, false);
+
+    // Results should still be correct with buffer reuse
+    assertArrayClose(output1, expected1, "First output with buffer reuse");
+    assertArrayClose(output2, expected2, "Second output with buffer reuse");
+  },
+});
+
+// =============================================================================
+// Test: Multiple outputs with WASM
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: Works with multiple outputs",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+        { type: "output", index: 4, bias: 0.1, squash: "TANH" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: -1.0 },
+        { from: 2, to: 3, weight: 2.0 },
+        { from: 2, to: 4, weight: 1.0 },
+      ],
+      input: 2,
+      output: 2,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    const input = new Float32Array([1.0, 0.5]);
+
+    const jsOutput = creature.activate(input, false, false, false);
+    const wasmOutput = creature.activate(input, false, false, true);
+
+    assertEquals(jsOutput.length, 2, "JS output should have 2 values");
+    assertEquals(wasmOutput.length, 2, "WASM output should have 2 values");
+    assertArrayClose(wasmOutput, jsOutput, "Multi-output results should match");
+  },
+});
+
+// =============================================================================
+// Test: Constant neurons with WASM
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: Works with constant neurons",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "constant", index: 0, bias: 1.0 },
+        { type: "hidden", index: 2, bias: 0, squash: "IDENTITY" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 2.0 },
+        { from: 1, to: 2, weight: 1.0 },
+        { from: 2, to: 3, weight: 1.0 },
+      ],
+      input: 1,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    const input = new Float32Array([3.0]);
+
+    const jsOutput = creature.activate(input, false, false, false);
+    const wasmOutput = creature.activate(input, false, false, true);
+
+    assertArrayClose(
+      wasmOutput,
+      jsOutput,
+      "Constant neuron results should match",
+    );
+  },
+});
+
+// =============================================================================
+// Test: All supported squash functions with WASM
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: All supported squash functions produce correct results",
+  fn() {
+    // List of all WASM-supported squash functions
+    const supportedSquashFunctions = [
+      "IDENTITY",
+      "ReLU",
+      "ReLU6",
+      "LeakyReLU",
+      "SELU",
+      "ELU",
+      "LOGISTIC",
+      "TANH",
+      "HARD_TANH",
+      "SOFTSIGN",
+      "Softplus",
+      "Swish",
+      "Mish",
+      "GELU",
+      "SINE",
+      "Cosine",
+      "TAN",
+      "ArcTan",
+      "GAUSSIAN",
+      "BENT_IDENTITY",
+      "BIPOLAR_SIGMOID",
+      "BIPOLAR",
+      "STEP",
+      "COMPLEMENT",
+      "ABSOLUTE",
+      "SQUARE",
+      "Cube",
+      "SQRT",
+      "StdInverse",
+      "Exponential",
+      "LogSigmoid",
+      "ISRU",
+      "MINIMUM",
+      "MAXIMUM",
+      "IF",
+    ];
+
+    for (const squash of supportedSquashFunctions) {
+      // Create creature with specific squash function
+      let creatureJson: CreatureInternal;
+
+      if (squash === "IF") {
+        // IF requires special synapse types
+        creatureJson = {
+          neurons: [
+            { type: "hidden", index: 3, bias: 0, squash: "IF" },
+            { type: "output", index: 4, bias: 0, squash: "IDENTITY" },
+          ],
+          synapses: [
+            { from: 0, to: 3, weight: 1.0, type: "condition" },
+            { from: 1, to: 3, weight: 1.0, type: "positive" },
+            { from: 2, to: 3, weight: 1.0, type: "negative" },
+            { from: 3, to: 4, weight: 1.0 },
+          ],
+          input: 3,
+          output: 1,
+        };
+      } else if (squash === "MINIMUM" || squash === "MAXIMUM") {
+        // Aggregate functions need multiple inputs
+        creatureJson = {
+          neurons: [
+            { type: "hidden", index: 2, bias: 0.1, squash: squash },
+            { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+          ],
+          synapses: [
+            { from: 0, to: 2, weight: 1.0 },
+            { from: 1, to: 2, weight: 1.0 },
+            { from: 2, to: 3, weight: 1.0 },
+          ],
+          input: 2,
+          output: 1,
+        };
+      } else {
+        // Standard squash function
+        creatureJson = {
+          neurons: [
+            { type: "hidden", index: 2, bias: 0.1, squash: squash },
+            { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+          ],
+          synapses: [
+            { from: 0, to: 2, weight: 1.0 },
+            { from: 1, to: 2, weight: 0.5 },
+            { from: 2, to: 3, weight: 1.0 },
+          ],
+          input: 2,
+          output: 1,
+        };
+      }
+
+      const creature = Creature.fromJSON(creatureJson);
+      creature.fix();
+
+      assert(
+        creature.isWasmEligible(),
+        `Creature with ${squash} should be WASM eligible`,
+      );
+
+      // Use safe input values that won't cause issues with TAN, SQRT etc.
+      const inputSize = squash === "IF" ? 3 : 2;
+      const input = new Float32Array(inputSize).fill(0.5);
+
+      const jsOutput = creature.activate(input, false, false, false);
+      const wasmOutput = creature.activate(input, false, false, true);
+
+      assertArrayClose(
+        wasmOutput,
+        jsOutput,
+        `${squash} should produce matching results`,
+        1e-4, // Slightly larger tolerance for complex functions
+      );
+    }
+  },
+});
+
+// =============================================================================
+// Test: getUnsupportedWasmSquashFunctions()
+// =============================================================================
+
+Deno.test({
+  name:
+    "Creature WASM: getUnsupportedWasmSquashFunctions() returns correct list",
+  fn() {
+    // Creature with MEAN (unsupported)
+    const meanCreatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "MEAN" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: 1.0 },
+        { from: 2, to: 3, weight: 1.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const meanCreature = Creature.fromJSON(meanCreatureJson);
+    meanCreature.fix();
+
+    const unsupported = meanCreature.getUnsupportedWasmSquashFunctions();
+    assert(unsupported.includes("MEAN"), "Should report MEAN as unsupported");
+
+    // Creature with all supported squash functions
+    const supportedCreatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 2, to: 3, weight: 1.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const supportedCreature = Creature.fromJSON(supportedCreatureJson);
+    supportedCreature.fix();
+
+    const supportedUnsupported = supportedCreature
+      .getUnsupportedWasmSquashFunctions();
+    assertEquals(
+      supportedUnsupported.length,
+      0,
+      "Should have no unsupported squash functions",
+    );
+  },
+});
+
+// =============================================================================
+// Test: dispose() cleans up WASM resources
+// =============================================================================
+
+Deno.test({
+  name: "Creature WASM: disposeWasm() cleans up WASM resources",
+  fn() {
+    const creatureJson: CreatureInternal = {
+      neurons: [
+        { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+        { type: "output", index: 3, bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 2, weight: -1.0 },
+        { from: 2, to: 3, weight: 2.0 },
+      ],
+      input: 2,
+      output: 1,
+    };
+
+    const creature = Creature.fromJSON(creatureJson);
+    creature.fix();
+
+    const input = new Float32Array([1.0, 0.5]);
+
+    // Activate with WASM to compile and cache
+    creature.activate(input, false, false, true);
+
+    // Dispose WASM resources
+    creature.disposeWasm();
+
+    // Should still work after dispose (will recompile if useWasm=true is used again)
+    const output = creature.activate(input, false, false, true);
+    assert(output.length === 1, "Should still produce output after dispose");
+  },
+});


### PR DESCRIPTION
# PR Summary: WASM Migration Phase 1 - Add WASM Activation Option (#1118)

## Summary

This PR implements WASM Migration Phase 1, adding an optional WASM activation
path to the `Creature` class with automatic fallback to JS when WASM cannot be
used. The library remains fully functional while introducing optional WASM
acceleration.

### Changes Made

1. **Extended `activate()` and `activateAndTrace()` methods**
   - Added optional `useWasm?: boolean` parameter (defaults to `false`)
   - When `useWasm=true`, attempts WASM activation with automatic JS fallback

2. **WASM eligibility detection**
   - Added `isWasmEligible()` method to check if creature can use WASM
   - Added `getUnsupportedWasmSquashFunctions()` to identify incompatible
     functions
   - Eligibility result is cached and invalidated on structural changes

3. **Lazy WASM compilation with caching**
   - WASM binary compiled only on first WASM activation request
   - Cached `WasmCreatureActivation` instance reused for subsequent calls
   - Cache invalidated on `clearState()` and structural changes

4. **Resource cleanup**
   - Added `disposeWasm()` method for explicit cleanup
   - Automatic cleanup in `dispose()` and `clearState()` methods
   - WASM eligibility cache invalidated via `invalidateScoreCache()`

### Supported Squash Functions (35 types)

All standard and aggregate squash functions are WASM-supported:

| Category      | Functions                                             |
| ------------- | ----------------------------------------------------- |
| Standard      | IDENTITY, ReLU, ReLU6, LeakyReLU, SELU, ELU           |
| Sigmoid-like  | LOGISTIC, TANH, HARD_TANH, SOFTSIGN, Softplus         |
| Modern        | Swish, Mish, GELU                                     |
| Trigonometric | SINE, Cosine, TAN, ArcTan                             |
| Other         | GAUSSIAN, BENT_IDENTITY, BIPOLAR_SIGMOID, BIPOLAR     |
| Discrete      | STEP, COMPLEMENT                                      |
| Mathematical  | ABSOLUTE, SQUARE, Cube, SQRT, StdInverse, Exponential |
| Advanced      | LogSigmoid, ISRU                                      |
| Aggregate     | MINIMUM, MAXIMUM, IF                                  |

### Unsupported Functions (fallback to JS)

The following deprecated functions are not supported in WASM:

- `MEAN` - Deprecated aggregate function
- `HYPOT` - Deprecated aggregate function
- `HYPOTv2` - Deprecated aggregate function

When a creature uses any unsupported function, `activate()` with `useWasm=true`
automatically falls back to the JS implementation.

## Evidence

This is a performance enhancement with no UI changes. The WASM prototype (PR
#1117) demonstrated ~9.5x performance improvement for neural network activation.
This PR integrates that capability into the main Creature API.

### Verification

- All 1518+ existing tests pass without modification
- 17 new unit tests added for WASM integration
- Both JS and WASM paths produce identical results (within floating-point
  tolerance)

## Test Plan

### New Tests Added (`test/CreatureWasmActivation.ts`)

| Test                                       | Description                                |
| ------------------------------------------ | ------------------------------------------ |
| Module initialisation                      | WASM module loads successfully             |
| `activate()` accepts useWasm parameter     | API works with new parameter               |
| `activate()` produces same results         | JS and WASM outputs match                  |
| `activateAndTrace()` accepts useWasm       | API consistency (always uses JS)           |
| `isWasmEligible()` for supported functions | Returns true for WASM-compatible creatures |
| `isWasmEligible()` for MEAN                | Returns false for unsupported function     |
| `isWasmEligible()` for HYPOT               | Returns false for unsupported function     |
| Aggregate functions (IF, MINIMUM, MAXIMUM) | Supported in WASM                          |
| Falls back to JS for unsupported squash    | Automatic fallback works                   |
| Caches compiled WASM activation            | Lazy compilation and reuse                 |
| Invalidates cache on clearState()          | Cache management                           |
| Buffer reuse works with useWasm            | Performance optimisation                   |
| Works with multiple outputs                | Multi-output creatures                     |
| Works with constant neurons                | Constant neuron support                    |
| All supported squash functions             | 35 squash functions verified               |
| `getUnsupportedWasmSquashFunctions()`      | Diagnostic method                          |
| `disposeWasm()` cleans up resources        | Resource management                        |

### Existing Tests

All 1518+ existing tests pass without modification, verifying:

- No breaking changes to public API
- Both JS and WASM paths produce identical results
- Backward compatibility maintained

## API Usage

```typescript
const creature = Creature.fromJSON(creatureJson);
creature.fix();

// Standard JS activation (unchanged)
const jsOutput = creature.activate(input);

// WASM activation (automatic fallback if not supported)
const wasmOutput = creature.activate(input, false, false, true);

// Check WASM eligibility
if (creature.isWasmEligible()) {
  console.log("Creature can use WASM acceleration");
} else {
  const unsupported = creature.getUnsupportedWasmSquashFunctions();
  console.log("Unsupported squash functions:", unsupported);
}

// Explicit cleanup (optional - also called by dispose()/clearState())
creature.disposeWasm();
```

## Breaking Changes

None. All existing code continues to work without modification.

---

## Automated Fix Details
This PR addresses issue #1118: **WASM Migration Phase 1: Add WASM activation option to Creature class with automatic fallback**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1118