### PR TITLE
fix: Move flaky performance test to benchmark (#1180)

### DIFF
--- a/bench/CreativeThinkingClone.ts
+++ b/bench/CreativeThinkingClone.ts
@@ -1,0 +1,135 @@
+/**
+ * Benchmark for creative thinking clone performance optimisation.
+ *
+ * Issue #1040: Performance - Reduce JSON cloning in creative thinking creature creation.
+ *
+ * The creative thinking process in Neat.evolve() creates a clone of the fittest
+ * creature to add random connections. Previously this used expensive JSON
+ * serialisation/deserialisation:
+ *   const creativeThinking = Creature.fromJSON(n.exportJSON());
+ *
+ * This has been optimised to use shallowClone():
+ *   const creativeThinking = n.shallowClone();
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write bench/CreativeThinkingClone.ts
+ */
+import { Creature } from "../src/Creature.ts";
+import { creatureValidate } from "../src/architecture/CreatureValidate.ts";
+
+// Create creatures of varying sizes to test performance scaling
+const smallCreature = new Creature(10, 5, {
+  layers: [{ count: 20 }],
+});
+smallCreature.uuid = "small-perf-test";
+smallCreature.score = 0.95;
+smallCreature.memetic = {
+  generation: 20,
+  weights: {},
+  biases: {},
+  score: 0.9,
+};
+creatureValidate(smallCreature);
+
+const mediumCreature = new Creature(50, 10, {
+  layers: [{ count: 100 }, { count: 50 }],
+});
+mediumCreature.uuid = "medium-perf-test";
+mediumCreature.score = 0.95;
+mediumCreature.memetic = {
+  generation: 20,
+  weights: {},
+  biases: {},
+  score: 0.9,
+};
+creatureValidate(mediumCreature);
+
+const largeCreature = new Creature(100, 20, {
+  layers: [{ count: 200 }, { count: 100 }, { count: 50 }],
+});
+largeCreature.uuid = "large-perf-test";
+largeCreature.score = 0.95;
+largeCreature.memetic = {
+  generation: 20,
+  weights: {},
+  biases: {},
+  score: 0.9,
+};
+creatureValidate(largeCreature);
+
+console.log("=== Creature Sizes ===");
+console.log(
+  `Small: ${smallCreature.neurons.length} neurons, ${smallCreature.synapses.length} synapses`,
+);
+console.log(
+  `Medium: ${mediumCreature.neurons.length} neurons, ${mediumCreature.synapses.length} synapses`,
+);
+console.log(
+  `Large: ${largeCreature.neurons.length} neurons, ${largeCreature.synapses.length} synapses`,
+);
+
+// Small creature benchmarks
+Deno.bench({
+  name: "Small creature - JSON clone (old method)",
+  group: "Small creature cloning",
+  baseline: true,
+  fn() {
+    const jsonClone = Creature.fromJSON(smallCreature.exportJSON());
+    delete jsonClone.memetic;
+    creatureValidate(jsonClone);
+  },
+});
+
+Deno.bench({
+  name: "Small creature - shallowClone (new method)",
+  group: "Small creature cloning",
+  fn() {
+    const shallowClone = smallCreature.shallowClone();
+    delete shallowClone.memetic;
+    creatureValidate(shallowClone);
+  },
+});
+
+// Medium creature benchmarks
+Deno.bench({
+  name: "Medium creature - JSON clone (old method)",
+  group: "Medium creature cloning",
+  baseline: true,
+  fn() {
+    const jsonClone = Creature.fromJSON(mediumCreature.exportJSON());
+    delete jsonClone.memetic;
+    creatureValidate(jsonClone);
+  },
+});
+
+Deno.bench({
+  name: "Medium creature - shallowClone (new method)",
+  group: "Medium creature cloning",
+  fn() {
+    const shallowClone = mediumCreature.shallowClone();
+    delete shallowClone.memetic;
+    creatureValidate(shallowClone);
+  },
+});
+
+// Large creature benchmarks
+Deno.bench({
+  name: "Large creature - JSON clone (old method)",
+  group: "Large creature cloning",
+  baseline: true,
+  fn() {
+    const jsonClone = Creature.fromJSON(largeCreature.exportJSON());
+    delete jsonClone.memetic;
+    creatureValidate(jsonClone);
+  },
+});
+
+Deno.bench({
+  name: "Large creature - shallowClone (new method)",
+  group: "Large creature cloning",
+  fn() {
+    const shallowClone = largeCreature.shallowClone();
+    delete shallowClone.memetic;
+    creatureValidate(shallowClone);
+  },
+});

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.293.16",
+  "version": "0.293.17",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.17",
     "@std/bytes": "jsr:@std/bytes@1.0.6",

--- a/test/NEAT/CreativeThinkingClone.ts
+++ b/test/NEAT/CreativeThinkingClone.ts
@@ -348,72 +348,10 @@ Deno.test("CreativeThinkingClone: clone UUID changes after modification", () => 
   );
 });
 
-Deno.test("CreativeThinkingClone: performance improvement over JSON clone", () => {
-  // Create a moderately sized creature for performance testing
-  const original = new Creature(50, 10, {
-    layers: [{ count: 100 }, { count: 50 }],
-  });
-  original.uuid = "perf-test";
-  original.score = 0.95;
-  original.memetic = {
-    generation: 20,
-    weights: {},
-    biases: {},
-    score: 0.9,
-  };
-  creatureValidate(original);
-
-  const iterations = 50;
-
-  // Benchmark JSON clone (old method)
-  performance.mark("json-start");
-  for (let i = 0; i < iterations; i++) {
-    const jsonClone = Creature.fromJSON(original.exportJSON());
-    delete jsonClone.memetic;
-    // Validate to ensure it's a proper clone
-    creatureValidate(jsonClone);
-  }
-  performance.mark("json-end");
-  const jsonDuration = performance.measure("json", "json-start", "json-end")
-    .duration;
-
-  // Benchmark shallow clone (new method)
-  performance.mark("shallow-start");
-  for (let i = 0; i < iterations; i++) {
-    const shallowClone = original.shallowClone();
-    delete shallowClone.memetic;
-    // Validate to ensure it's a proper clone
-    creatureValidate(shallowClone);
-  }
-  performance.mark("shallow-end");
-  const shallowDuration = performance.measure(
-    "shallow",
-    "shallow-start",
-    "shallow-end",
-  ).duration;
-
-  const speedup = jsonDuration / shallowDuration;
-  console.info(
-    `Creative Thinking Clone Performance: JSON clone: ${
-      jsonDuration.toFixed(2)
-    }ms, ` +
-      `Shallow clone: ${shallowDuration.toFixed(2)}ms, ` +
-      `Speedup: ${speedup.toFixed(2)}x`,
-  );
-
-  // Allow 10% tolerance for timing variability in CI environments.
-  // ShallowClone should generally be faster, but measurement noise
-  // can occasionally make timings close or even reversed.
-  const toleranceMultiplier = 1.1;
-  assert(
-    shallowDuration < jsonDuration * toleranceMultiplier,
-    `Shallow clone (${
-      shallowDuration.toFixed(2)
-    }ms) should not be significantly slower than JSON clone (${
-      jsonDuration.toFixed(2)
-    }ms) - tolerance: ${(toleranceMultiplier * 100 - 100).toFixed(0)}%`,
-  );
-});
+// NOTE: Performance testing for shallowClone vs JSON clone has been moved to
+// bench/CreativeThinkingClone.ts to avoid flaky tests in CI. Unit tests run
+// in parallel, making timing measurements unreliable. Use `deno bench` for
+// performance validation.
 
 Deno.test("CreativeThinkingClone: forwardOnly flag preserved through creative thinking", () => {
   const original = new Creature(3, 2, {


### PR DESCRIPTION
## Summary

Fixes the flaky CI test failure reported on PR #1180.

The `CreativeThinkingClone: performance improvement over JSON clone` test was failing in CI because:
- Unit tests run in parallel, making timing measurements unreliable
- CI environments have variable performance characteristics
- The test asserted a 10% tolerance which is insufficient for parallel test execution

## Changes

- **Removed** performance assertion from unit test file (`test/NEAT/CreativeThinkingClone.ts`)
- **Created** dedicated benchmark file (`bench/CreativeThinkingClone.ts`)
- Uses `Deno.bench` for proper performance measurement

## Benchmark Results

The benchmark shows shallowClone is 1.26-1.32x faster than JSON clone across creature sizes:

| Creature Size | JSON Clone | Shallow Clone | Speedup |
|---------------|------------|---------------|---------|
| Small (35 neurons) | 61.7 µs | 46.6 µs | 1.32x |
| Medium (210 neurons) | 1.7 ms | 1.3 ms | 1.28x |
| Large (470 neurons) | 8.0 ms | 6.3 ms | 1.26x |

## Test Plan

- [x] `./quality.sh` passes
- [x] Unit tests pass (7 tests in CreativeThinkingClone.ts)
- [x] Benchmark runs successfully with `deno bench bench/CreativeThinkingClone.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)