### PR TITLE
Enhance WASM activation initialization to support new options object …

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.295.1",
+  "version": "0.295.2",
   "publish": {
     "include": [
       "mod.ts",

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -227,8 +227,18 @@ export function initWasmActivationSync(
   }
 
   try {
-    // Initialize synchronously
-    jsBindings.initSync(wasmBinary);
+    // Initialize synchronously.
+    //
+    // wasm-bindgen recently changed the signature to prefer a single options object:
+    //   initSync({ module: <bytes|WebAssembly.Module> })
+    // Passing raw bytes triggers a deprecation warning in newer generated glue.
+    //
+    // We support both shapes for compatibility with older generated bindings.
+    try {
+      jsBindings.initSync({ module: wasmBinary });
+    } catch {
+      jsBindings.initSync(wasmBinary);
+    }
 
     // Store references to the exports
     wasmModule = jsBindings;


### PR DESCRIPTION
…format

Updated the `initWasmActivationSync` function to accommodate recent changes in the `wasm-bindgen` signature, which now prefers a single options object for initialization. The function now attempts to initialize using the new format and falls back to the previous method for compatibility with older bindings. This change improves the robustness of WASM activation handling.