### PR TITLE
Add functions to handle absolute filesystem paths in WASM activation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.295.8",
+  "version": "0.295.9",
   "publish": {
     "include": [
       "mod.ts",

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -143,6 +143,19 @@ let validateRangeFn:
 let limitRangeFn: ((squashType: number, value: number) => number) | null = null;
 let versionFn: (() => string) | null = null;
 
+/** True if path looks like an absolute filesystem path (Unix / or Windows C:\). */
+function isAbsoluteFileSystemPath(path: string): boolean {
+  return path.startsWith("/") || /^[A-Za-z]:[/\\]/.test(path);
+}
+
+/** Convert an absolute filesystem path to a file:// URL so import() loads from disk. */
+function pathToFileUrl(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  return path.startsWith("/")
+    ? `file://${normalized}`
+    : `file:///${normalized}`;
+}
+
 /**
  * Load and initialise the WASM module
  *
@@ -162,8 +175,12 @@ export async function initWasmActivation(
 
   initPromise = (async () => {
     try {
-      // Import the generated JS bindings
-      const modulePath = `${wasmPath}/wasm_activation.js`;
+      // Import the generated JS bindings. Use file:// URL for absolute paths
+      // so Deno loads from the filesystem when the library is loaded from JSR.
+      const jsPath = `${wasmPath.replace(/\/$/, "")}/wasm_activation.js`;
+      const modulePath = isAbsoluteFileSystemPath(jsPath)
+        ? pathToFileUrl(jsPath)
+        : jsPath;
       const module = await import(modulePath);
 
       // Initialize the WASM module


### PR DESCRIPTION
- Introduced `isAbsoluteFileSystemPath` to check if a path is an absolute filesystem path for both Unix and Windows formats.
- Added `pathToFileUrl` to convert absolute filesystem paths to `file://` URLs, ensuring compatibility with Deno's import mechanism.
- Updated the module path resolution in `initWasmActivation` to utilize these new functions, enhancing the loading process for WASM modules.

These changes improve the handling of file paths in WASM activation, facilitating smoother integration with local files.