### PR TITLE
Enhance path handling in WASM activation (#1245)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.295.9",
+  "version": "0.295.10",
   "publish": {
     "include": [
       "mod.ts",

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -145,6 +145,10 @@ let versionFn: (() => string) | null = null;
 
 /** True if path looks like an absolute filesystem path (Unix / or Windows C:\). */
 function isAbsoluteFileSystemPath(path: string): boolean {
+  // URL pathnames (JSR, npm) must not be turned into file://.
+  if (path.startsWith("/@") || path.startsWith("/node_modules/")) {
+    return false;
+  }
   return path.startsWith("/") || /^[A-Za-z]:[/\\]/.test(path);
 }
 
@@ -1043,12 +1047,14 @@ try {
     const cwdPath = typeof Deno !== "undefined"
       ? `${Deno.cwd()}/wasm_activation/pkg`
       : "";
-    const libPath = `${
-      new URL("../../", import.meta.url).pathname
-    }wasm_activation/pkg`;
+    const fromRemote = typeof import.meta.url === "string" &&
+      (import.meta.url.startsWith("http://") || import.meta.url.startsWith("https://"));
+    const libPath = fromRemote
+      ? ""
+      : `${new URL("../../", import.meta.url).pathname}wasm_activation/pkg`;
     const firstPath = explicitPath || cwdPath || libPath;
-    let ok = await initWasmActivation(firstPath);
-    if (!ok && !explicitPath && cwdPath && firstPath === cwdPath) {
+    let ok = firstPath ? await initWasmActivation(firstPath) : false;
+    if (!ok && !explicitPath && cwdPath && firstPath === cwdPath && libPath) {
       ok = await initWasmActivation(libPath);
     }
   }

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -1048,7 +1048,8 @@ try {
       ? `${Deno.cwd()}/wasm_activation/pkg`
       : "";
     const fromRemote = typeof import.meta.url === "string" &&
-      (import.meta.url.startsWith("http://") || import.meta.url.startsWith("https://"));
+      (import.meta.url.startsWith("http://") ||
+        import.meta.url.startsWith("https://"));
     const libPath = fromRemote
       ? ""
       : `${new URL("../../", import.meta.url).pathname}wasm_activation/pkg`;


### PR DESCRIPTION
- Updated `isAbsoluteFileSystemPath` to exclude URL pathnames (e.g., `/@`, `/node_modules/`) from being treated as absolute filesystem paths.
- Refined the logic in `initWasmActivation` to differentiate between local and remote paths, improving the module loading process.

These changes enhance the accuracy of path resolution in WASM activation, ensuring better compatibility with various project structures.