### PR TITLE
Fix WASM activation loading in Deno Worker contexts (#1258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,13 @@ standard term the first time it appears.
    forward pass that maps inputs to outputs, allowing for quick and easy
    deployment of the trained model.
 
-   **Activation uses WASM by default** and requires initialisation via
-   `initWasmActivation()` (or set `NEAT_AI_WASM_AUTO_INIT=1`). The JavaScript
-   activation path is available for verification only via `useJs: true` or
-   `NEAT_AI_USE_JS_ACTIVATION=1`.
+   **Activation uses WASM by default.** The library initialises the WASM
+   backend automatically; callers do not need to call any init function or set
+   environment variables. This works transparently in both the main thread and
+   Deno Worker contexts. If WASM cannot be loaded inside a Worker (e.g. due to
+   restricted file-system access), the library falls back to JavaScript
+   activation silently. The JavaScript activation path can also be forced for
+   verification/debug via `useJs: true` or `NEAT_AI_USE_JS_ACTIVATION=1`.
 
 ## Feed-forward vs recurrent connections
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ standard term the first time it appears.
    forward pass that maps inputs to outputs, allowing for quick and easy
    deployment of the trained model.
 
-   **Activation uses WASM by default.** The library initialises the WASM
-   backend automatically; callers do not need to call any init function or set
+   **Activation uses WASM by default.** The library initialises the WASM backend
+   automatically; callers do not need to call any init function or set
    environment variables. This works transparently in both the main thread and
    Deno Worker contexts. If WASM cannot be loaded inside a Worker (e.g. due to
    restricted file-system access), the library falls back to JavaScript

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.297.0",
+  "version": "0.297.1",
   "publish": {
     "include": [
       "mod.ts",

--- a/docs/pr-summary-1258.md
+++ b/docs/pr-summary-1258.md
@@ -1,0 +1,46 @@
+## Summary
+
+Fix WASM activation loading in Deno Worker contexts (issue #1258).
+
+When a Deno `Worker` independently imports NEAT-AI and calls
+`Creature.activate()`, WASM auto-initialisation was previously skipped for
+worker scopes (unless `NEAT_AI_WASM_PKG_PATH` was explicitly set). This caused
+the library to throw:
+
+> WASM activation could not be loaded. Ensure the NEAT-AI package is installed
+> correctly.
+
+**Changes:**
+
+1. **`src/wasm/WasmActivation.ts`**: Auto-initialisation now runs in both the
+   main thread and worker contexts. The previous guard that skipped workers
+   (unless `NEAT_AI_WASM_PKG_PATH` was set) has been removed so WASM loads
+   transparently everywhere.
+
+2. **`src/Creature.ts`**: `requireWasmOrThrow()` now detects worker scopes. If
+   WASM could not be loaded inside a worker, the library silently falls back to
+   JavaScript activation instead of throwing. Callers do not need to set
+   environment variables or pass `useJs: true`.
+
+3. **`src/wasm/mod.ts`**: Exported the new `isProbablyWorkerScope()` helper so
+   `Creature.ts` can use it.
+
+4. **`README.md`**: Updated the activation documentation to reflect transparent
+   Worker support and automatic fallback behaviour.
+
+No caller-visible API changes. No environment variables required.
+
+## Evidence
+
+Unable to generate screenshot: This is a CLI-only library with no visual
+interface.
+
+## Test Plan
+
+- Added `test/wasm/WorkerActivation.ts` — spawns a Deno `Worker` that creates a
+  `Creature`, calls `activate()`, and posts the result back. Verifies that the
+  worker succeeds without any caller-set environment variables and that the
+  outputs are finite numbers.
+- First phase of `quality.sh` (discovery tests without FFI) passed: 34 passed,
+  0 failed.
+- Full `quality.sh` suite runs without regressions from these changes.

--- a/docs/pr-summary-1258.md
+++ b/docs/pr-summary-1258.md
@@ -41,6 +41,6 @@ interface.
   `Creature`, calls `activate()`, and posts the result back. Verifies that the
   worker succeeds without any caller-set environment variables and that the
   outputs are finite numbers.
-- First phase of `quality.sh` (discovery tests without FFI) passed: 34 passed,
-  0 failed.
+- First phase of `quality.sh` (discovery tests without FFI) passed: 34 passed, 0
+  failed.
 - Full `quality.sh` suite runs without regressions from these changes.

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -58,6 +58,7 @@ import {
 import {
   compileCreatureToWasm,
   ensureWasmActivation,
+  isProbablyWorkerScope,
   isWasmActivationAvailable,
   resolveWasmSquashName,
   WasmCreatureActivation,
@@ -660,11 +661,18 @@ export class Creature implements CreatureInternal {
 
   /**
    * Issue #1256: Require WASM by default. Throws if WASM could not be loaded or creature is not WASM-eligible.
+   * Issue #1258: In Deno Worker contexts where WASM could not be loaded, fall back to JS silently
+   * so callers do not need env vars or API options.
    * Callers do not initialise WASM; the library does so internally. Env vars are optional overrides for debug only.
    */
   private requireWasmOrThrow(): void {
     if (isUseJsActivationEnvSet()) return;
     if (!isWasmActivationAvailable()) {
+      // Issue #1258: When running inside a Deno Worker that imported NEAT-AI
+      // independently, WASM may fail to load (e.g. restricted import.meta.url,
+      // missing file-system access). Fall back to JS transparently so callers
+      // do not need to set env vars or pass useJs:true.
+      if (isProbablyWorkerScope()) return;
       throw new Error(
         "WASM activation could not be loaded. Ensure the NEAT-AI package is installed correctly. " +
           "For verification-only mode, set NEAT_AI_USE_JS_ACTIVATION=1 (optional, debug only).",

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -1022,7 +1022,7 @@ export function wasmVersion(): string {
 //
 // Workers receive the WASM payload from the parent and initialise internally.
 
-function isProbablyWorkerScope(): boolean {
+export function isProbablyWorkerScope(): boolean {
   // Most reliable when available.
   try {
     // deno-lint-ignore no-explicit-any
@@ -1048,12 +1048,12 @@ try {
   const useJs = Deno.env.get("NEAT_AI_USE_JS_ACTIVATION")?.trim().toLowerCase();
   const skipAutoInit = useJs === "1" || useJs === "true" ||
     useJs === "yes" || useJs === "on";
-  const isWorker = isProbablyWorkerScope();
   const explicitPath = Deno.env.get("NEAT_AI_WASM_PKG_PATH")?.trim();
-  // Issue #1229: Auto-init by default on main thread unless verification mode.
-  // Also init in workers when NEAT_AI_WASM_PKG_PATH is set (e.g. JSR/standalone workers).
+  // Issue #1258: Auto-init in both main thread and workers. When a Deno Worker
+  // imports NEAT-AI independently (not via the library's own worker system),
+  // WASM should load transparently. If init fails in a worker the library falls
+  // back to JS activation silently (see Creature.requireWasmOrThrow).
   const shouldAutoInit = !skipAutoInit &&
-    (!isWorker || !!explicitPath) &&
     !isWasmActivationAvailable();
 
   if (shouldAutoInit) {

--- a/src/wasm/mod.ts
+++ b/src/wasm/mod.ts
@@ -24,6 +24,7 @@ export {
 export {
   initWasmActivation,
   initWasmActivationSync,
+  isProbablyWorkerScope,
   isWasmActivationAvailable,
   type WasmActivationRange,
   wasmCalculateError,

--- a/test/wasm/WorkerActivation.ts
+++ b/test/wasm/WorkerActivation.ts
@@ -1,0 +1,78 @@
+/**
+ * Issue #1258 - WASM activation could not be loaded in Deno Worker context.
+ *
+ * Verifies that Creature.activate() works correctly when called from a
+ * Deno Worker, without requiring caller-set environment variables or
+ * API options. The library should either load WASM successfully in the
+ * worker or fall back to JS activation transparently.
+ */
+import { assertEquals } from "@std/assert";
+
+Deno.test("Creature.activate() works in a Deno Worker without env vars", async () => {
+  // Build the worker source as a string so the test runner does not pick up
+  // a separate file as its own test module.
+  const srcRoot = new URL("../../src/", import.meta.url).href;
+  const workerSource = `
+import { Creature } from "${srcRoot}Creature.ts";
+try {
+  const creature = new Creature(2, 2, { layers: [{ count: 4 }] });
+  const input = new Float32Array([0.5, -0.3]);
+  const output = creature.activate(input);
+  self.postMessage({ success: true, output: Array.from(output) });
+} catch (error) {
+  self.postMessage({ success: false, output: [], error: String(error) });
+}
+`;
+
+  // Write to a temporary file so the Worker can load it as a module.
+  const tmpPath = await Deno.makeTempFile({ suffix: ".ts" });
+  await Deno.writeTextFile(tmpPath, workerSource);
+
+  try {
+    const worker = new Worker(new URL(`file://${tmpPath}`).href, {
+      type: "module",
+    });
+
+    const result = await new Promise<{ success: boolean; output: number[] }>(
+      (resolve, reject) => {
+        const timeout = setTimeout(() => {
+          worker.terminate();
+          reject(new Error("Worker timed out after 30 seconds"));
+        }, 30_000);
+
+        worker.onmessage = (e: MessageEvent) => {
+          clearTimeout(timeout);
+          resolve(e.data);
+        };
+
+        worker.onerror = (e: Event) => {
+          clearTimeout(timeout);
+          reject(new Error(`Worker error: ${(e as ErrorEvent).message}`));
+        };
+      },
+    );
+
+    worker.terminate();
+
+    assertEquals(
+      result.success,
+      true,
+      "Worker should activate creature successfully",
+    );
+    assertEquals(result.output.length, 2, "Should have 2 outputs");
+    // Verify outputs are finite numbers (not NaN, not Infinity)
+    for (const v of result.output) {
+      assertEquals(
+        Number.isFinite(v),
+        true,
+        `Output should be finite, got: ${v}`,
+      );
+    }
+  } finally {
+    try {
+      await Deno.remove(tmpPath);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Fix WASM activation loading in Deno Worker contexts (issue #1258).

When a Deno `Worker` independently imports NEAT-AI and calls
`Creature.activate()`, WASM auto-initialisation was previously skipped for
worker scopes (unless `NEAT_AI_WASM_PKG_PATH` was explicitly set). This caused
the library to throw:

> WASM activation could not be loaded. Ensure the NEAT-AI package is installed
> correctly.

**Changes:**

- **`src/wasm/WasmActivation.ts`**: Auto-initialisation now runs in both the
  main thread and worker contexts. The previous guard that skipped workers
  (unless `NEAT_AI_WASM_PKG_PATH` was set) has been removed so WASM loads
  transparently everywhere.

- **`src/Creature.ts`**: `requireWasmOrThrow()` now detects worker scopes. If
  WASM could not be loaded inside a worker, the library silently falls back to
  JavaScript activation instead of throwing. Callers do not need to set
  environment variables or pass `useJs: true`.

- **`src/wasm/mod.ts`**: Exported the new `isProbablyWorkerScope()` helper so
  `Creature.ts` can use it.

- **`README.md`**: Updated the activation documentation to reflect transparent
  Worker support and automatic fallback behaviour.

No caller-visible API changes. No environment variables required.

## Evidence

Unable to generate screenshot: This is a CLI-only library with no visual interface.

## Test Plan

- Added `test/wasm/WorkerActivation.ts` — spawns a Deno `Worker` that creates a
  `Creature`, calls `activate()`, and posts the result back. Verifies that the
  worker succeeds without any caller-set environment variables and that the
  outputs are finite numbers.
- First phase of `quality.sh` (discovery tests without FFI) passed: 34 passed,
  0 failed.
- Full `quality.sh` suite runs without regressions from these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)