### PR TITLE
Update version to 0.306.0 and add WASM preloading functionality for w…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.305.0",
+  "version": "0.306.0",
   "publish": {
     "include": [
       "mod.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -215,3 +215,12 @@ export type {
   PlateauDetectionConfig,
   RequiredPlateauDetectionConfig,
 } from "./src/NEAT/PlateauDetector.ts";
+
+/**
+ * WASM preload for workers (Issue #1285)
+ *
+ * Call {@link fetchWasmForWorkers} in the main thread before spawning workers
+ * so WASM is fetched once and cached; workers then receive the cached payload
+ * instead of each fetching separately.
+ */
+export { fetchWasmForWorkers } from "./src/multithreading/workers/WorkerHandler.ts";

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -329,6 +329,20 @@ export async function loadWasmActivationInitPayloadAsync(): Promise<
 }
 
 /**
+ * Prefetch WASM activation in the main thread for use by workers.
+ *
+ * Issue #1285: Call this before spawning workers (e.g. GRQ training, portfolio,
+ * IntelligentDesign) so the main thread does one fetch and workers receive the
+ * cached payload instead of each worker triggering its own fetch. Avoids
+ * timeouts and duplicate work when many workers start at once.
+ *
+ * @returns Promise that resolves when the WASM payload is loaded and cached
+ */
+export async function fetchWasmForWorkers(): Promise<void> {
+  await loadWasmActivationInitPayloadAsync();
+}
+
+/**
  * Check if the WASM activation payload is available.
  *
  * Issue #1206 - Provides a way to check WASM availability without loading


### PR DESCRIPTION
…orkers. The new `fetchWasmForWorkers` function allows the main thread to preload WASM, improving performance by caching the payload for worker threads. This change addresses issue #1285.