### PR TITLE
Enhance WASM activation management under memory pressure

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.308.8",
+  "version": "0.308.9",
   "publish": {
     "include": [
       "mod.ts",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -198,6 +198,7 @@
     "codegen",
     "MINSTD",
     "unregularised",
-    "Unregularised"
+    "Unregularised",
+    "finaliser"
   ]
 }

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -63,6 +63,10 @@ import {
   resolveWasmSquashName,
   WasmCreatureActivation,
 } from "./wasm/mod.ts";
+import {
+  evictOldestWasmCreatureActivations,
+  noteWasmCreatureActivationUse,
+} from "./wasm/WasmCreatureActivationLRU.ts";
 
 interface CreatureOptions {
   semanticVersion?: string;
@@ -647,6 +651,14 @@ export class Creature implements CreatureInternal {
       // Try to get from cache first (uses topology hash for cache key)
       this.cachedWasmActivation = getOrCompileWasmModule(this) ?? undefined;
 
+      // Issue #1338: Under memory pressure (common in long-running parallel data-gen),
+      // instantiating `CompiledNetwork` can trap. Best-effort: evict old cached WASM
+      // activations and retry once before failing fast.
+      if (!this.cachedWasmActivation) {
+        evictOldestWasmCreatureActivations(64);
+        this.cachedWasmActivation = getOrCompileWasmModule(this) ?? undefined;
+      }
+
       if (!this.cachedWasmActivation) {
         // At this point WASM was selected and eligibility was already checked.
         // Failing to instantiate the WASM network is unexpected; fail fast rather
@@ -669,6 +681,8 @@ export class Creature implements CreatureInternal {
         !forwardOnlyGuaranteed,
       );
     }
+
+    noteWasmCreatureActivationUse(this);
 
     // `activate()` should be fast and output-only.
     // Tracing/state backfill belongs in `activateAndTrace()`.
@@ -701,12 +715,20 @@ export class Creature implements CreatureInternal {
       // Try to get from cache first (uses topology hash for cache key)
       this.cachedWasmActivation = getOrCompileWasmModule(this) ?? undefined;
 
+      // Issue #1338: Best-effort eviction + retry under memory pressure.
+      if (!this.cachedWasmActivation) {
+        evictOldestWasmCreatureActivations(64);
+        this.cachedWasmActivation = getOrCompileWasmModule(this) ?? undefined;
+      }
+
       if (!this.cachedWasmActivation) {
         fail(
           "WASM activateAndTrace was selected but failed to instantiate CompiledNetwork",
         );
       }
     }
+
+    noteWasmCreatureActivationUse(this);
 
     // Prepare state for activation
     this.prepareNeurons();
@@ -2204,6 +2226,13 @@ export class Creature implements CreatureInternal {
       const compiled = compileCreatureToWasm(this);
       this.cachedWasmActivation = WasmCreatureActivation.create(compiled) ??
         undefined;
+
+      // Issue #1338: Best-effort eviction + retry under memory pressure.
+      if (!this.cachedWasmActivation) {
+        evictOldestWasmCreatureActivations(64);
+        this.cachedWasmActivation = WasmCreatureActivation.create(compiled) ??
+          undefined;
+      }
       if (!this.cachedWasmActivation) {
         fail(
           "WASM activation was selected but failed to instantiate CompiledNetwork",
@@ -2213,6 +2242,8 @@ export class Creature implements CreatureInternal {
         !forwardOnlyGuaranteed,
       );
     }
+
+    noteWasmCreatureActivationUse(this);
 
     // Pre-allocate a reusable output buffer for non-fused scoring.
     const outputBuffer = new Float32Array(this.output);

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -94,12 +94,21 @@ export class WorkerProcessor {
   private async initialiseWasmActivationFromPayload(
     payload: NonNullable<RequestData["initialize"]>["wasmActivation"],
   ): Promise<void> {
-    if (!payload) return;
     if (this.wasmInitAttempted) return;
     this.wasmInitAttempted = true;
 
     // If already initialised, nothing to do.
     if (isWasmActivationAvailable()) return;
+
+    // WASM is mandatory. If the parent did not supply the init payload, fail fast
+    // so the worker does not accept jobs that are guaranteed to fail later.
+    if (!payload) {
+      throw new Error(
+        "Worker WASM activation payload missing (WASM is required). " +
+          "Call fetchWasmForWorkers() before spawning workers, or ensure the NEAT-AI " +
+          "package includes `wasm_activation/pkg`.",
+      );
+    }
 
     // Import wasm-bindgen glue from the provided source to avoid file reads.
     const jsModuleUrl = `data:application/javascript;charset=utf-8,${

--- a/src/wasm/WasmCreatureActivationLRU.ts
+++ b/src/wasm/WasmCreatureActivationLRU.ts
@@ -1,0 +1,145 @@
+/**
+ * WASM Creature activation LRU eviction.
+ *
+ * Issue #1338: In long-running, highly-parallel workloads that touch many different
+ * creatures/models, caching `CompiledNetwork` instances on each `Creature` can
+ * accumulate large WASM heap usage. If GC/finalizers lag, instantiating a new
+ * `CompiledNetwork` may trap (often as `RuntimeError: unreachable`).
+ *
+ * This module implements a best-effort LRU that can proactively free older cached
+ * WASM activations by calling `creature.disposeWasm()`.
+ *
+ * Design notes:
+ * - We only keep `WeakRef`s to avoid preventing GC.
+ * - Eviction is conservative and only runs when the configured cap is exceeded.
+ * - Evicting a creature's cached activation is safe: it is recreated lazily on next use.
+ */
+
+import type { Creature } from "../Creature.ts";
+
+interface LruEntry {
+  ref: WeakRef<Creature>;
+  lastAccess: number;
+}
+
+const finaliser = new FinalizationRegistry<number>((id) => {
+  entries.delete(id);
+});
+
+const idByCreature = new WeakMap<Creature, number>();
+const entries = new Map<number, LruEntry>();
+let nextId = 1;
+
+// Default cap: keep memory bounded for inference/data-gen workloads without
+// noticeably impacting typical NEAT populations.
+let maxCachedWasmActivations = 512;
+
+function getOrAssignId(creature: Creature): number {
+  const existing = idByCreature.get(creature);
+  if (existing !== undefined) return existing;
+
+  const id = nextId++;
+  idByCreature.set(creature, id);
+  finaliser.register(creature, id);
+  return id;
+}
+
+function evictIfNeeded(): void {
+  while (entries.size > maxCachedWasmActivations) {
+    let oldestId: number | null = null;
+    let oldestTime = Infinity;
+
+    for (const [id, entry] of entries) {
+      if (entry.lastAccess < oldestTime) {
+        oldestTime = entry.lastAccess;
+        oldestId = id;
+      }
+    }
+
+    if (oldestId === null) return;
+
+    const entry = entries.get(oldestId);
+    if (!entry) {
+      entries.delete(oldestId);
+      continue;
+    }
+
+    const creature = entry.ref.deref();
+    entries.delete(oldestId);
+
+    if (!creature) {
+      continue;
+    }
+
+    try {
+      creature.disposeWasm();
+    } catch {
+      // Best-effort eviction; ignore failures.
+    }
+  }
+}
+
+/**
+ * Set the maximum number of cached WASM activations kept across all live creatures.
+ *
+ * Values < 1 are clamped to 1.
+ */
+export function setMaxCachedWasmCreatureActivations(max: number): void {
+  maxCachedWasmActivations = Math.max(1, Math.floor(max));
+  evictIfNeeded();
+}
+
+/**
+ * Get the current maximum number of cached WASM activations.
+ */
+export function getMaxCachedWasmCreatureActivations(): number {
+  return maxCachedWasmActivations;
+}
+
+/**
+ * Record usage of a creature's cached WASM activation and evict if needed.
+ *
+ * Call this after a creature successfully acquires/uses `cachedWasmActivation`.
+ */
+export function noteWasmCreatureActivationUse(creature: Creature): void {
+  const id = getOrAssignId(creature);
+  entries.set(id, {
+    ref: new WeakRef(creature),
+    lastAccess: performance.now(),
+  });
+  evictIfNeeded();
+}
+
+/**
+ * Apply memory-pressure relief by evicting up to `count` old entries immediately.
+ *
+ * Intended for use when instantiation fails (likely OOM) and a retry might succeed.
+ */
+export function evictOldestWasmCreatureActivations(count: number): void {
+  const target = Math.max(0, Math.floor(count));
+  if (target === 0) return;
+
+  for (let i = 0; i < target && entries.size > 0; i++) {
+    let oldestId: number | null = null;
+    let oldestTime = Infinity;
+
+    for (const [id, entry] of entries) {
+      if (entry.lastAccess < oldestTime) {
+        oldestTime = entry.lastAccess;
+        oldestId = id;
+      }
+    }
+
+    if (oldestId === null) return;
+
+    const entry = entries.get(oldestId);
+    entries.delete(oldestId);
+    const creature = entry?.ref.deref();
+    if (!creature) continue;
+    try {
+      creature.disposeWasm();
+    } catch {
+      // Ignore
+    }
+  }
+}

--- a/src/wasm/mod.ts
+++ b/src/wasm/mod.ts
@@ -64,3 +64,9 @@ export {
   setWasmCompilationCacheSize,
   type WasmCacheStats,
 } from "./WasmCompilationCache.ts";
+
+// Issue #1338 - Bound cached WASM activations under memory pressure
+export {
+  getMaxCachedWasmCreatureActivations,
+  setMaxCachedWasmCreatureActivations,
+} from "./WasmCreatureActivationLRU.ts";


### PR DESCRIPTION
- Introduced best-effort eviction of old cached WASM activations in the Creature class to mitigate instantiation failures during high memory usage scenarios.
- Added calls to note WASM creature activation usage for better tracking.
- Updated WorkerProcessor to ensure mandatory WASM activation payload is provided, throwing an error if missing.
- Exported new functions for managing cached WASM activations from WasmCreatureActivationLRU.

This addresses issue #1338 and improves overall stability in WASM activation handling.