### PR TITLE
Memetic: Configurable quantum step size based on training progress (#1330)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.309.1",
+  "version": "0.309.2",
   "publish": {
     "include": [
       "mod.ts",

--- a/docs/pr-summary-1330.md
+++ b/docs/pr-summary-1330.md
@@ -1,0 +1,48 @@
+## Summary
+
+Implements configurable quantum step size based on training progress for memetic fine-tuning (#1330).
+
+Previously, the quantum step size (`MIN_STEP = 0.000_000_1`) was a fixed constant used throughout fine-tuning. This change makes the step size adaptive: larger steps when far from the optimum (large score differences) and smaller steps near convergence (small score differences).
+
+### Changes
+
+- **New config**: `QuantumStepConfig` with `minStep`, `maxStep`, and `scaleFactor` fields
+- **New function**: `calculateStepSize()` computes adaptive step size using: `effectiveStep = minStep * (1 + scaleFactor * normalisedError)`, clamped to `[minStep, maxStep]`
+- **Modified**: `quantumAdjust()` accepts an optional `stepSize` parameter for custom quantisation granularity
+- **Modified**: `fineTuneImprovement()` and `tuneRandomize()` calculate and pass adaptive step sizes
+- **Config pipeline**: `QuantumStepConfig` integrated into `NeatArguments`, `NeatOptions`, `NeatConfig` following the established config pattern
+- **Threading**: Config passed through all callers (`Neat.ts`, `FineTunePopulation.ts`, `Retry.ts`)
+
+### Defaults
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `minStep` | `0.000_000_1` | Minimum step (backward compatible with previous `MIN_STEP`) |
+| `maxStep` | `0.000_1` | Maximum step for coarse exploration |
+| `scaleFactor` | `10` | Controls sensitivity to score differences |
+
+## Evidence
+
+This is a backend/algorithmic change with no UI. Verified via:
+- All 2009 existing tests continue to pass (backward compatibility preserved)
+- New unit tests verify adaptive step size calculation and quantisation behaviour
+- `./quality.sh` passes cleanly (fmt, lint, type-check, all tests)
+
+## Test Plan
+
+- `test/blackbox/QuantumStepSize.ts` - 10 tests for adaptive step size:
+  - `calculateStepSize` returns `minStep` when scores are equal or no previous score
+  - Larger score differences produce larger step sizes
+  - Step size never exceeds `maxStep` or falls below `minStep`
+  - Custom config values are respected
+  - `scaleFactor` of zero always returns `minStep`
+  - `quantumAdjust` uses custom step size for quantisation
+  - Default step size preserves backward compatibility
+  - Larger step sizes produce coarser quantisation
+- `test/config/QuantumStepConfigParsing.ts` - 8 tests for config parsing:
+  - Defaults used when not specified
+  - Custom `minStep`, `maxStep`, `scaleFactor` accepted
+  - String values accepted from CLI
+  - Cross-field validation: `maxStep < minStep` throws
+  - Negative `minStep` throws
+  - Zero `scaleFactor` accepted

--- a/docs/pr-summary-1330.md
+++ b/docs/pr-summary-1330.md
@@ -1,37 +1,51 @@
 ## Summary
 
-Implements configurable quantum step size based on training progress for memetic fine-tuning (#1330).
+Implements configurable quantum step size based on training progress for memetic
+fine-tuning (#1330).
 
-Previously, the quantum step size (`MIN_STEP = 0.000_000_1`) was a fixed constant used throughout fine-tuning. This change makes the step size adaptive: larger steps when far from the optimum (large score differences) and smaller steps near convergence (small score differences).
+Previously, the quantum step size (`MIN_STEP = 0.000_000_1`) was a fixed
+constant used throughout fine-tuning. This change makes the step size adaptive:
+larger steps when far from the optimum (large score differences) and smaller
+steps near convergence (small score differences).
 
 ### Changes
 
-- **New config**: `QuantumStepConfig` with `minStep`, `maxStep`, and `scaleFactor` fields
-- **New function**: `calculateStepSize()` computes adaptive step size using: `effectiveStep = minStep * (1 + scaleFactor * normalisedError)`, clamped to `[minStep, maxStep]`
-- **Modified**: `quantumAdjust()` accepts an optional `stepSize` parameter for custom quantisation granularity
-- **Modified**: `fineTuneImprovement()` and `tuneRandomize()` calculate and pass adaptive step sizes
-- **Config pipeline**: `QuantumStepConfig` integrated into `NeatArguments`, `NeatOptions`, `NeatConfig` following the established config pattern
-- **Threading**: Config passed through all callers (`Neat.ts`, `FineTunePopulation.ts`, `Retry.ts`)
+- **New config**: `QuantumStepConfig` with `minStep`, `maxStep`, and
+  `scaleFactor` fields
+- **New function**: `calculateStepSize()` computes adaptive step size using:
+  `effectiveStep = minStep * (1 + scaleFactor * normalisedError)`, clamped to
+  `[minStep, maxStep]`
+- **Modified**: `quantumAdjust()` accepts an optional `stepSize` parameter for
+  custom quantisation granularity
+- **Modified**: `fineTuneImprovement()` and `tuneRandomize()` calculate and pass
+  adaptive step sizes
+- **Config pipeline**: `QuantumStepConfig` integrated into `NeatArguments`,
+  `NeatOptions`, `NeatConfig` following the established config pattern
+- **Threading**: Config passed through all callers (`Neat.ts`,
+  `FineTunePopulation.ts`, `Retry.ts`)
 
 ### Defaults
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| `minStep` | `0.000_000_1` | Minimum step (backward compatible with previous `MIN_STEP`) |
-| `maxStep` | `0.000_1` | Maximum step for coarse exploration |
-| `scaleFactor` | `10` | Controls sensitivity to score differences |
+| Field         | Default       | Description                                                 |
+| ------------- | ------------- | ----------------------------------------------------------- |
+| `minStep`     | `0.000_000_1` | Minimum step (backward compatible with previous `MIN_STEP`) |
+| `maxStep`     | `0.000_1`     | Maximum step for coarse exploration                         |
+| `scaleFactor` | `10`          | Controls sensitivity to score differences                   |
 
 ## Evidence
 
 This is a backend/algorithmic change with no UI. Verified via:
+
 - All 2009 existing tests continue to pass (backward compatibility preserved)
-- New unit tests verify adaptive step size calculation and quantisation behaviour
+- New unit tests verify adaptive step size calculation and quantisation
+  behaviour
 - `./quality.sh` passes cleanly (fmt, lint, type-check, all tests)
 
 ## Test Plan
 
 - `test/blackbox/QuantumStepSize.ts` - 10 tests for adaptive step size:
-  - `calculateStepSize` returns `minStep` when scores are equal or no previous score
+  - `calculateStepSize` returns `minStep` when scores are equal or no previous
+    score
   - Larger score differences produce larger step sizes
   - Step size never exceeds `maxStep` or falls below `minStep`
   - Custom config values are respected

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -620,6 +620,7 @@ export class Neat {
         this.config.feedbackLoop,
         1,
         true,
+        this.config.quantumStep,
       );
       const forward = fineTuneImprovement(
         creature,
@@ -627,6 +628,7 @@ export class Neat {
         this.config.feedbackLoop,
         1,
         false,
+        this.config.quantumStep,
       );
 
       if (backtracked.length > 0 || forward.length > 0) {

--- a/src/blackbox/FineTune.ts
+++ b/src/blackbox/FineTune.ts
@@ -15,8 +15,43 @@ import {
   calculateTrajectoryMomentum,
   createAncestorSnapshot,
 } from "./MemeticTrajectory.ts";
+import type { RequiredQuantumStepConfig } from "../config/QuantumStepConfig.ts";
+import { DEFAULT_QUANTUM_STEP_CONFIG } from "../config/QuantumStepConfig.ts";
 
-export const MIN_STEP = 0.000_000_1;
+export const MIN_STEP = DEFAULT_QUANTUM_STEP_CONFIG.minStep;
+
+/**
+ * Calculates an adaptive step size based on score improvement between
+ * fittest and previous fittest creatures.
+ *
+ * Uses the formula: effectiveStep = minStep * (1 + scaleFactor * normalisedError)
+ * The result is clamped to [minStep, maxStep].
+ *
+ * @param fittestScore - The current fittest creature's score.
+ * @param previousScore - The previous fittest creature's score (undefined if none).
+ * @param config - Quantum step configuration.
+ * @returns The calculated step size.
+ */
+export function calculateStepSize(
+  fittestScore: number,
+  previousScore: number | undefined,
+  config: RequiredQuantumStepConfig,
+): number {
+  if (previousScore === undefined || !Number.isFinite(previousScore)) {
+    return config.minStep;
+  }
+
+  const scoreDiff = Math.abs(fittestScore - previousScore);
+
+  // Normalise the score difference: larger differences → values closer to 1
+  // Use a simple normalisation: clamp scoreDiff to [0, 1]
+  const normalisedError = Math.min(scoreDiff, 1);
+
+  const rawStep = config.minStep *
+    (1 + config.scaleFactor * normalisedError);
+
+  return Math.min(Math.max(rawStep, config.minStep), config.maxStep);
+}
 
 /**
  * Adjusts the best value based on the difference between the current best and previous best value.
@@ -29,6 +64,7 @@ export const MIN_STEP = 0.000_000_1;
  * @param {number} momentumFactor - Optional momentum factor (0.5-2.0) from trajectory analysis.
  *                                  Higher values bias adjustment more strongly in the direction of change.
  * @param {number} suggestedDirection - Optional suggested direction from trajectory (-1, 0, or 1).
+ * @param {number} stepSize - Optional quantum step size. Defaults to MIN_STEP.
  * @returns {number} - The adjusted best value.
  */
 export function quantumAdjust(
@@ -38,9 +74,11 @@ export function quantumAdjust(
   backtrack: boolean,
   momentumFactor?: number,
   suggestedDirection?: number,
+  stepSize?: number,
 ): { value: number; changed: boolean } {
+  const step = stepSize ?? MIN_STEP;
   const diff = currentBest - previousBest;
-  if (Math.abs(diff) >= MIN_STEP - MIN_STEP / 10) {
+  if (Math.abs(diff) >= step - step / 10) {
     const scale = backtrack ? 1 : 2;
     let delta: number;
 
@@ -74,15 +112,15 @@ export function quantumAdjust(
     }
 
     const adjustedValue = currentBest + delta;
-    const currentQuantum = Math.round(currentBest / MIN_STEP);
-    let quantum = Math.round(adjustedValue / MIN_STEP);
+    const currentQuantum = Math.round(currentBest / step);
+    let quantum = Math.round(adjustedValue / step);
 
-    /* Ensure the quantum value is at least one MIN_STEP different in the correct direction */
+    /* Ensure the quantum value is at least one step different in the correct direction */
     if (currentQuantum === quantum) {
       quantum += Math.sign(delta);
     }
 
-    const quantizedValue = quantum * MIN_STEP;
+    const quantizedValue = quantum * step;
 
     return { value: quantizedValue, changed: true };
   }
@@ -166,9 +204,12 @@ function addMissingSynapses(
 function tuneRandomize(
   fittest: Creature,
   previousFittest: Creature,
-  forwardOnly = false,
-  backtrack = false,
+  forwardOnly?: boolean,
+  backtrack?: boolean,
+  stepSize?: number,
 ) {
+  const effectiveForwardOnly = forwardOnly ?? false;
+  const effectiveBacktrack = backtrack ?? false;
   const previousJSON = previousFittest.exportJSON();
   const fittestJSON = fittest.exportJSON();
 
@@ -188,8 +229,12 @@ function tuneRandomize(
     };
   }
 
-  addMissingSynapses(fittestJSON, previousJSON, { forwardOnly });
-  addMissingSynapses(previousJSON, fittestJSON, { forwardOnly });
+  addMissingSynapses(fittestJSON, previousJSON, {
+    forwardOnly: effectiveForwardOnly,
+  });
+  addMissingSynapses(previousJSON, fittestJSON, {
+    forwardOnly: effectiveForwardOnly,
+  });
 
   const uuidNodeMap = new Map<string, NeuronExport>();
 
@@ -224,10 +269,11 @@ function tuneRandomize(
       const result = quantumAdjust(
         fittestNeuron.bias,
         previousNeuron.bias,
-        forwardOnly,
-        backtrack,
+        effectiveForwardOnly,
+        effectiveBacktrack,
         momentumFactor,
         suggestedDirection,
+        stepSize,
       );
       if (result.changed) {
         fittestNeuron.bias = result.value;
@@ -267,10 +313,11 @@ function tuneRandomize(
         const result = quantumAdjust(
           fittestSynapse.weight,
           previousSynapse.weight,
-          forwardOnly,
-          backtrack,
+          effectiveForwardOnly,
+          effectiveBacktrack,
           momentumFactor,
           suggestedDirection,
+          stepSize,
         );
         if (result.changed) {
           fittestSynapse.weight = result.value;
@@ -352,9 +399,13 @@ export function fineTuneImprovement(
   fittest: Creature,
   previousFittest: Creature | null,
   feedbackLoop: boolean,
-  popSize = 10,
-  backtrack = false,
+  popSize?: number,
+  backtrack?: boolean,
+  quantumStepConfig?: RequiredQuantumStepConfig,
 ) {
+  const effectivePopSize = popSize ?? 10;
+  const effectiveBacktrack = backtrack ?? false;
+
   if (previousFittest === null) {
     return [];
   }
@@ -366,6 +417,14 @@ export function fineTuneImprovement(
   ) {
     return [];
   }
+
+  // Calculate adaptive step size based on score difference
+  const config = quantumStepConfig ?? DEFAULT_QUANTUM_STEP_CONFIG;
+  const stepSize = calculateStepSize(
+    fittest.score,
+    previousFittest.score ?? undefined,
+    config,
+  );
 
   const fittestUUID = CreatureUtil.makeUUID(fittest);
   const UUIDs = new Set<string>();
@@ -387,7 +446,8 @@ export function fineTuneImprovement(
     fittest,
     previousFittest,
     forwardOnly,
-    backtrack,
+    effectiveBacktrack,
+    stepSize,
   );
   if (resultSame.tuned) {
     const randomUUID = CreatureUtil.makeUUID(resultSame.tuned);
@@ -399,14 +459,15 @@ export function fineTuneImprovement(
 
   for (
     let attempt = 0;
-    attempt < popSize * 2 && fineTuned.length < popSize;
+    attempt < effectivePopSize * 2 && fineTuned.length < effectivePopSize;
     attempt++
   ) {
     const resultRandomize = tuneRandomize(
       fittest,
       previousFittest,
       forwardOnly,
-      backtrack,
+      effectiveBacktrack,
+      stepSize,
     );
     if (resultRandomize.tuned) {
       const randomUUID = CreatureUtil.makeUUID(resultRandomize.tuned);

--- a/src/blackbox/FineTunePopulation.ts
+++ b/src/blackbox/FineTunePopulation.ts
@@ -113,6 +113,8 @@ export class FindTunePopulation {
           tmpPreviousFittest,
           this.neat.config.feedbackLoop,
           fineTunePopSize - 1,
+          undefined,
+          this.neat.config.quantumStep,
         );
         logApproach(fittest, tmpPreviousFittest);
       }
@@ -127,6 +129,8 @@ export class FindTunePopulation {
             restoredCreature,
             this.neat.config.feedbackLoop,
             2,
+            undefined,
+            this.neat.config.quantumStep,
           );
 
           fineTunedPopulation.push(...restoredTunedPopulation);
@@ -135,6 +139,8 @@ export class FindTunePopulation {
         const retryPopulation = retry(
           genus.population,
           this.neat.config.feedbackLoop,
+          undefined,
+          this.neat.config.quantumStep,
         );
         fineTunedPopulation.push(...retryPopulation);
       }
@@ -188,6 +194,8 @@ export class FindTunePopulation {
                 nextBestCreature,
                 this.neat.config.feedbackLoop,
                 speciesFineTunePopSize,
+                undefined,
+                this.neat.config.quantumStep,
               );
 
               fineTunedPopulation.push(...extendedTunedPopulation);
@@ -218,6 +226,8 @@ export class FindTunePopulation {
             extendedPreviousFittest,
             this.neat.config.feedbackLoop,
             extendedFineTunePopSize,
+            undefined,
+            this.neat.config.quantumStep,
           );
 
           fineTunedPopulation.push(...extendedTunedPopulation);

--- a/src/blackbox/Retry.ts
+++ b/src/blackbox/Retry.ts
@@ -1,6 +1,7 @@
 import { assert } from "@std/assert";
 import { addTag } from "@stsoftware/tags/mod";
 import type { Creature } from "../../mod.ts";
+import type { RequiredQuantumStepConfig } from "../config/QuantumStepConfig.ts";
 import type { Approach } from "../NEAT/LogApproach.ts";
 import { fineTuneImprovement } from "./FineTune.ts";
 import { restoreSource } from "./RestoreSource.ts";
@@ -11,8 +12,10 @@ const PLANK_CONSTANT = 0.000_000_000_001;
 export function retry(
   population: Creature[],
   feedbackLoop: boolean,
-  filter: Filter = "NONE",
+  filter?: Filter,
+  quantumStepConfig?: RequiredQuantumStepConfig,
 ): Creature[] {
+  const effectiveFilter = filter ?? "NONE";
   const possibleRetryPopulation = population.filter((creature) => {
     if (creature.memetic) {
       assert(creature.score);
@@ -25,10 +28,10 @@ export function retry(
       }
 
       // Apply the filter logic
-      if (filter === "FORWARD" && difference <= 0) {
+      if (effectiveFilter === "FORWARD" && difference <= 0) {
         return false;
       }
-      if (filter === "BACKWARDS" && difference >= 0) {
+      if (effectiveFilter === "BACKWARDS" && difference >= 0) {
         return false;
       }
 
@@ -80,6 +83,7 @@ export function retry(
       feedbackLoop,
       2,
       approach === "backtrack",
+      quantumStepConfig,
     );
 
     retryPopulation.forEach((creature) => {

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -10,6 +10,7 @@ import type { RequiredPlateauDetectionConfig } from "../NEAT/PlateauDetector.ts"
 import type { RequiredAdaptiveMutationThresholds } from "./AdaptiveMutationThresholds.ts";
 import type { DiscoveryMinCandidatesPerCategory } from "./DiscoveryMinCandidatesPerCategory.ts";
 import type { RequiredEnsembleDiversityConfig } from "./EnsembleDiversityConfig.ts";
+import type { RequiredQuantumStepConfig } from "./QuantumStepConfig.ts";
 import type { RequiredStabilityAdaptationConfig } from "./StabilityAdaptationConfig.ts";
 import type { RequiredWeightRegularisationConfig } from "./WeightRegularisationConfig.ts";
 
@@ -472,4 +473,18 @@ export interface NeatArguments {
    * - crossSpeciesBreedingThreshold: Trigger cross-species breeding below this (default: 0.2)
    */
   ensembleDiversity: RequiredEnsembleDiversityConfig;
+
+  /**
+   * Quantum step size configuration for memetic fine-tuning.
+   *
+   * Issue #1330: Adaptive quantum step size based on training progress.
+   * Controls the granularity of weight/bias adjustments during fine-tuning.
+   * Larger steps when far from optimum, smaller steps near convergence.
+   *
+   * Configuration options:
+   * - minStep: Minimum quantum step size (default: 0.000_000_1)
+   * - maxStep: Maximum quantum step size (default: 0.000_1)
+   * - scaleFactor: How strongly error magnitude influences step size (default: 10)
+   */
+  quantumStep: RequiredQuantumStepConfig;
 }

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -25,6 +25,10 @@ import {
   type RequiredStabilityAdaptationConfig,
 } from "./StabilityAdaptationConfig.ts";
 import {
+  DEFAULT_QUANTUM_STEP_CONFIG,
+  type RequiredQuantumStepConfig,
+} from "./QuantumStepConfig.ts";
+import {
   DEFAULT_WEIGHT_REGULARISATION_CONFIG,
   type RequiredWeightRegularisationConfig,
 } from "./WeightRegularisationConfig.ts";
@@ -684,7 +688,35 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
         ),
       } as RequiredEnsembleDiversityConfig;
     })(),
+    // Issue #1330: Quantum step size configuration for memetic fine-tuning
+    quantumStep: (() => {
+      const overrides = opts.quantumStep as
+        | Record<string, unknown>
+        | undefined;
+      const d = DEFAULT_QUANTUM_STEP_CONFIG;
+      return {
+        minStep: parseNumber(
+          "Quantum step minStep",
+          overrides?.minStep,
+          d.minStep,
+          { minExclusive: 0 },
+        ),
+        maxStep: parseNumber(
+          "Quantum step maxStep",
+          overrides?.maxStep,
+          d.maxStep,
+          { minExclusive: 0 },
+        ),
+        scaleFactor: parseNumber(
+          "Quantum step scaleFactor",
+          overrides?.scaleFactor,
+          d.scaleFactor,
+          { min: 0 },
+        ),
+      } as RequiredQuantumStepConfig;
+    })(),
   };
+
   validate(config);
   return Object.freeze(config);
 }
@@ -715,6 +747,14 @@ function validate(config: NeatArguments) {
     throw new Error(
       `Plateau detection rapidImprovementRate must be greater than minImprovementRate. ` +
         `rapidImprovementRate: ${plateauDetection.rapidImprovementRate}, minImprovementRate: ${plateauDetection.minImprovementRate}`,
+    );
+  }
+
+  const quantumStep = config.quantumStep;
+  if (quantumStep.maxStep < quantumStep.minStep) {
+    throw new Error(
+      `Quantum step maxStep must be greater than or equal to minStep. ` +
+        `maxStep: ${quantumStep.maxStep}, minStep: ${quantumStep.minStep}`,
     );
   }
 

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -3,6 +3,7 @@ import type { DiscoveryMinCandidatesPerCategory } from "./DiscoveryMinCandidates
 import type { EnsembleDiversityConfig } from "./EnsembleDiversityConfig.ts";
 import type { NeatArguments } from "./NeatArguments.ts";
 import type { PlateauDetectionConfig } from "../NEAT/PlateauDetector.ts";
+import type { QuantumStepConfig } from "./QuantumStepConfig.ts";
 import type { StabilityAdaptationConfig } from "./StabilityAdaptationConfig.ts";
 import type { WeightRegularisationConfig } from "./WeightRegularisationConfig.ts";
 
@@ -68,6 +69,7 @@ export type NeatOptions =
     | "stabilityAdaptation"
     | "weightRegularisation"
     | "ensembleDiversity"
+    | "quantumStep"
   >
   & {
     /** Partial overrides for minimum candidates per category (defaults applied if not specified) */
@@ -82,6 +84,8 @@ export type NeatOptions =
     weightRegularisation?: WeightRegularisationConfig;
     /** Partial overrides for ensemble diversity configuration (defaults applied if not specified) */
     ensembleDiversity?: EnsembleDiversityConfig;
+    /** Partial overrides for quantum step configuration (defaults applied if not specified) */
+    quantumStep?: QuantumStepConfig;
   };
 
 /**
@@ -111,6 +115,7 @@ export type NeatOptionsInput =
     | "stabilityAdaptation"
     | "weightRegularisation"
     | "ensembleDiversity"
+    | "quantumStep"
   >
   & {
     [K in NumericOptionKeys]?: NonNullable<NeatOptions[K]> extends number
@@ -126,4 +131,5 @@ export type NeatOptionsInput =
     stabilityAdaptation?: CoerceNumeric<StabilityAdaptationConfig>;
     weightRegularisation?: CoerceNumeric<WeightRegularisationConfig>;
     ensembleDiversity?: CoerceNumeric<EnsembleDiversityConfig>;
+    quantumStep?: CoerceNumeric<QuantumStepConfig>;
   };

--- a/src/config/QuantumStepConfig.ts
+++ b/src/config/QuantumStepConfig.ts
@@ -1,0 +1,57 @@
+/**
+ * Configuration for adaptive quantum step size during memetic fine-tuning.
+ *
+ * Issue #1330: Configurable quantum step size based on training progress.
+ *
+ * The quantum step size controls the minimum granularity of weight/bias
+ * adjustments during fine-tuning. Adaptive step sizing uses larger steps
+ * when far from the optimum and smaller steps when fine-tuning near
+ * convergence.
+ *
+ * The effective step is calculated as:
+ *   effectiveStep = minStep * (1 + scaleFactor * normalisedError)
+ *
+ * where normalisedError is clamped to [0, 1] based on the score improvement
+ * between the fittest and previous fittest creatures.
+ */
+
+/**
+ * Configuration for quantum step size behaviour.
+ */
+export interface QuantumStepConfig {
+  /**
+   * Minimum quantum step size (lower bound).
+   * This is the finest granularity used when close to convergence.
+   * Default: 0.000_000_1
+   */
+  minStep?: number;
+
+  /**
+   * Maximum quantum step size (upper bound).
+   * This is the coarsest granularity used when far from the optimum.
+   * Default: 0.000_1
+   */
+  maxStep?: number;
+
+  /**
+   * Scale factor controlling how strongly the error magnitude
+   * influences step size. Higher values produce larger steps when
+   * the error is large.
+   * Default: 10
+   */
+  scaleFactor?: number;
+}
+
+/**
+ * Required version of QuantumStepConfig with all fields populated.
+ */
+export type RequiredQuantumStepConfig = Required<QuantumStepConfig>;
+
+/**
+ * Default values for quantum step configuration.
+ */
+export const DEFAULT_QUANTUM_STEP_CONFIG: RequiredQuantumStepConfig = {
+  minStep: 0.000_000_1,
+  maxStep: 0.000_1,
+  scaleFactor: 10,
+};

--- a/test/blackbox/QuantumStepSize.ts
+++ b/test/blackbox/QuantumStepSize.ts
@@ -1,0 +1,151 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  calculateStepSize,
+  MIN_STEP,
+  quantumAdjust,
+} from "../../src/blackbox/FineTune.ts";
+import {
+  DEFAULT_QUANTUM_STEP_CONFIG,
+  type RequiredQuantumStepConfig,
+} from "../../src/config/QuantumStepConfig.ts";
+
+Deno.test("calculateStepSize - returns minStep when scores are equal", () => {
+  const config = DEFAULT_QUANTUM_STEP_CONFIG;
+  const step = calculateStepSize(-0.5, -0.5, config);
+  assertEquals(step, config.minStep);
+});
+
+Deno.test("calculateStepSize - returns minStep when no previous score", () => {
+  const config = DEFAULT_QUANTUM_STEP_CONFIG;
+  const step = calculateStepSize(-0.5, undefined, config);
+  assertEquals(step, config.minStep);
+});
+
+Deno.test("calculateStepSize - larger step for larger score difference", () => {
+  const config = DEFAULT_QUANTUM_STEP_CONFIG;
+  const smallDiff = calculateStepSize(-0.4, -0.5, config);
+  const largeDiff = calculateStepSize(-0.1, -0.9, config);
+  assert(
+    largeDiff > smallDiff,
+    `Large diff step (${largeDiff}) should be greater than small diff step (${smallDiff})`,
+  );
+});
+
+Deno.test("calculateStepSize - step never exceeds maxStep", () => {
+  const config = DEFAULT_QUANTUM_STEP_CONFIG;
+  // Very large score difference
+  const step = calculateStepSize(0, -1000, config);
+  assert(
+    step <= config.maxStep,
+    `Step (${step}) should not exceed maxStep (${config.maxStep})`,
+  );
+});
+
+Deno.test("calculateStepSize - step never below minStep", () => {
+  const config = DEFAULT_QUANTUM_STEP_CONFIG;
+  // Tiny score difference
+  const step = calculateStepSize(-0.5, -0.500001, config);
+  assert(
+    step >= config.minStep,
+    `Step (${step}) should not be below minStep (${config.minStep})`,
+  );
+});
+
+Deno.test("calculateStepSize - custom config respected", () => {
+  const config: RequiredQuantumStepConfig = {
+    minStep: 0.001,
+    maxStep: 0.1,
+    scaleFactor: 5,
+  };
+  const step = calculateStepSize(-0.1, -0.5, config);
+  assert(
+    step >= config.minStep,
+    `Step (${step}) should be >= minStep (${config.minStep})`,
+  );
+  assert(
+    step <= config.maxStep,
+    `Step (${step}) should be <= maxStep (${config.maxStep})`,
+  );
+});
+
+Deno.test("calculateStepSize - scaleFactor zero means always minStep", () => {
+  const config: RequiredQuantumStepConfig = {
+    minStep: 0.000_000_1,
+    maxStep: 0.000_1,
+    scaleFactor: 0,
+  };
+  const step = calculateStepSize(-0.1, -0.9, config);
+  assertEquals(step, config.minStep);
+});
+
+Deno.test("quantumAdjust - uses custom step size", () => {
+  const currentBest = 1.0;
+  const previousBest = 0.5;
+  const forwardOnly = true;
+  const customStep = 0.01;
+
+  const result = quantumAdjust(
+    currentBest,
+    previousBest,
+    forwardOnly,
+    false,
+    undefined,
+    undefined,
+    customStep,
+  );
+
+  // The result should be quantised to the custom step size
+  const quantumValue = Math.round(result.value / customStep);
+  const reQuantised = quantumValue * customStep;
+  assert(
+    Math.abs(result.value - reQuantised) < customStep / 100,
+    `Value (${result.value}) should be quantised to step ${customStep}, re-quantised: ${reQuantised}`,
+  );
+  assert(result.changed, "Result should indicate a change");
+});
+
+Deno.test("quantumAdjust - default step size preserves backward compatibility", () => {
+  const currentBest = 1.0;
+  const previousBest = 0.5;
+  const forwardOnly = true;
+
+  // Without custom step - should use MIN_STEP (default behaviour)
+  const result = quantumAdjust(
+    currentBest,
+    previousBest,
+    forwardOnly,
+    false,
+  );
+
+  const quantumValue = Math.round(result.value / MIN_STEP);
+  const reQuantised = quantumValue * MIN_STEP;
+  assert(
+    Math.abs(result.value - reQuantised) < MIN_STEP / 100,
+    `Value (${result.value}) should be quantised to MIN_STEP ${MIN_STEP}`,
+  );
+});
+
+Deno.test("quantumAdjust - larger step size produces coarser quantisation", () => {
+  const currentBest = 1.0;
+  const previousBest = 0.5;
+  const forwardOnly = true;
+  const largeStep = 0.1;
+
+  const result = quantumAdjust(
+    currentBest,
+    previousBest,
+    forwardOnly,
+    false,
+    undefined,
+    undefined,
+    largeStep,
+  );
+
+  // Should be quantised to 0.1 increments
+  const quantumValue = Math.round(result.value / largeStep);
+  const reQuantised = quantumValue * largeStep;
+  assert(
+    Math.abs(result.value - reQuantised) < largeStep / 100,
+    `Value (${result.value}) should be quantised to step ${largeStep}, got ${reQuantised}`,
+  );
+});

--- a/test/config/QuantumStepConfigParsing.ts
+++ b/test/config/QuantumStepConfigParsing.ts
@@ -1,0 +1,91 @@
+/**
+ * Issue #1330: Tests for parsing QuantumStepConfig in NeatConfig.
+ */
+import { assertEquals, fail } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { DEFAULT_QUANTUM_STEP_CONFIG } from "../../src/config/QuantumStepConfig.ts";
+
+Deno.test("QuantumStepConfig - defaults used when not specified", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.quantumStep.minStep, DEFAULT_QUANTUM_STEP_CONFIG.minStep);
+  assertEquals(config.quantumStep.maxStep, DEFAULT_QUANTUM_STEP_CONFIG.maxStep);
+  assertEquals(
+    config.quantumStep.scaleFactor,
+    DEFAULT_QUANTUM_STEP_CONFIG.scaleFactor,
+  );
+});
+
+Deno.test("QuantumStepConfig - custom minStep accepted", () => {
+  const config = createNeatConfig({
+    quantumStep: { minStep: 0.000_001 },
+  });
+  assertEquals(config.quantumStep.minStep, 0.000_001);
+  assertEquals(config.quantumStep.maxStep, DEFAULT_QUANTUM_STEP_CONFIG.maxStep);
+});
+
+Deno.test("QuantumStepConfig - custom maxStep accepted", () => {
+  const config = createNeatConfig({
+    quantumStep: { maxStep: 0.01 },
+  });
+  assertEquals(config.quantumStep.maxStep, 0.01);
+  assertEquals(config.quantumStep.minStep, DEFAULT_QUANTUM_STEP_CONFIG.minStep);
+});
+
+Deno.test("QuantumStepConfig - custom scaleFactor accepted", () => {
+  const config = createNeatConfig({
+    quantumStep: { scaleFactor: 5 },
+  });
+  assertEquals(config.quantumStep.scaleFactor, 5);
+});
+
+Deno.test("QuantumStepConfig - string values accepted from CLI", () => {
+  const config = createNeatConfig({
+    quantumStep: {
+      minStep: "0.001" as unknown as number,
+      maxStep: "0.1" as unknown as number,
+      scaleFactor: "5" as unknown as number,
+    },
+  });
+  assertEquals(config.quantumStep.minStep, 0.001);
+  assertEquals(config.quantumStep.maxStep, 0.1);
+  assertEquals(config.quantumStep.scaleFactor, 5);
+});
+
+Deno.test("QuantumStepConfig - maxStep less than minStep throws", () => {
+  try {
+    createNeatConfig({
+      quantumStep: { minStep: 0.01, maxStep: 0.001 },
+    });
+    fail("Expected error when maxStep < minStep");
+  } catch (e) {
+    const msg = (e as Error).message;
+    assertEquals(
+      msg.includes("maxStep") && msg.includes("minStep"),
+      true,
+      `Error should mention maxStep and minStep: ${msg}`,
+    );
+  }
+});
+
+Deno.test("QuantumStepConfig - negative minStep throws", () => {
+  try {
+    createNeatConfig({
+      quantumStep: { minStep: -0.001 },
+    });
+    fail("Expected error for negative minStep");
+  } catch (e) {
+    const msg = (e as Error).message;
+    assertEquals(
+      msg.includes("Quantum step minStep"),
+      true,
+      `Error should mention field: ${msg}`,
+    );
+  }
+});
+
+Deno.test("QuantumStepConfig - zero scaleFactor accepted", () => {
+  const config = createNeatConfig({
+    quantumStep: { scaleFactor: 0 },
+  });
+  assertEquals(config.quantumStep.scaleFactor, 0);
+});


### PR DESCRIPTION
## Summary

Implements configurable quantum step size based on training progress for memetic fine-tuning (#1330).

Previously, the quantum step size (`MIN_STEP = 0.000_000_1`) was a fixed constant used throughout fine-tuning. This change makes the step size adaptive: larger steps when far from the optimum (large score differences) and smaller steps near convergence (small score differences).

### Changes

- **New config**: `QuantumStepConfig` with `minStep`, `maxStep`, and `scaleFactor` fields
- **New function**: `calculateStepSize()` computes adaptive step size using: `effectiveStep = minStep * (1 + scaleFactor * normalisedError)`, clamped to `[minStep, maxStep]`
- **Modified**: `quantumAdjust()` accepts an optional `stepSize` parameter for custom quantisation granularity
- **Modified**: `fineTuneImprovement()` and `tuneRandomize()` calculate and pass adaptive step sizes
- **Config pipeline**: `QuantumStepConfig` integrated into `NeatArguments`, `NeatOptions`, `NeatConfig` following the established config pattern
- **Threading**: Config passed through all callers (`Neat.ts`, `FineTunePopulation.ts`, `Retry.ts`)

### Defaults

| Field | Default | Description |
|-------|---------|-------------|
| `minStep` | `0.000_000_1` | Minimum step (backward compatible with previous `MIN_STEP`) |
| `maxStep` | `0.000_1` | Maximum step for coarse exploration |
| `scaleFactor` | `10` | Controls sensitivity to score differences |

## Evidence

This is a backend/algorithmic change with no UI. Verified via:
- All 2009 existing tests continue to pass (backward compatibility preserved)
- 18 new unit tests verify adaptive step size calculation, quantisation behaviour, and config parsing
- `./quality.sh` passes cleanly (fmt, lint, type-check, all tests)

## Test Plan

- `test/blackbox/QuantumStepSize.ts` - 10 tests for adaptive step size:
  - `calculateStepSize` returns `minStep` when scores are equal or no previous score
  - Larger score differences produce larger step sizes
  - Step size never exceeds `maxStep` or falls below `minStep`
  - Custom config values are respected
  - `scaleFactor` of zero always returns `minStep`
  - `quantumAdjust` uses custom step size for quantisation
  - Default step size preserves backward compatibility
  - Larger step sizes produce coarser quantisation
- `test/config/QuantumStepConfigParsing.ts` - 8 tests for config parsing:
  - Defaults used when not specified
  - Custom `minStep`, `maxStep`, `scaleFactor` accepted
  - String values accepted from CLI
  - Cross-field validation: `maxStep < minStep` throws
  - Negative `minStep` throws
  - Zero `scaleFactor` accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)