### PR TITLE
Fix: Memetic: Adaptive fine-tuning population size based on improvement rate (#1323)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.1",
+  "version": "0.310.2",
   "publish": {
     "include": [
       "mod.ts",

--- a/docs/pr-summary-1323.md
+++ b/docs/pr-summary-1323.md
@@ -1,34 +1,58 @@
 ## Summary
 
-Implements adaptive fine-tuning population sizing based on improvement rate (#1323).
+Implements adaptive fine-tuning population sizing based on improvement rate
+(#1323).
 
-Previously, the fine-tuning population size was calculated using a fixed heuristic (20% of population or number of dead creatures). This change dynamically adjusts the size based on how successful fine-tuning has been in recent generations:
+Previously, the fine-tuning population size was calculated using a fixed
+heuristic (20% of population or number of dead creatures). This change
+dynamically adjusts the size based on how successful fine-tuning has been in
+recent generations:
 
-- **High success rate**: Increases fine-tune population size (up to 40% of population) to allocate more resources to a productive strategy
-- **Low success rate**: Decreases fine-tune population size (down to 10% of population) to reduce wasted computation
-- **No data yet**: Uses the base fraction (20%, matching the original heuristic) as a starting point
+- **High success rate**: Increases fine-tune population size (up to 40% of
+  population) to allocate more resources to a productive strategy
+- **Low success rate**: Decreases fine-tune population size (down to 10% of
+  population) to reduce wasted computation
+- **No data yet**: Uses the base fraction (20%, matching the original heuristic)
+  as a starting point
 
 ### Architecture
 
-1. **`FineTunePopulationConfig`** (`src/config/FineTunePopulationConfig.ts`): New config with `minPopulationFraction`, `maxPopulationFraction`, `basePopulationFraction`, and `successRateWindow` - follows the established config pattern (interface, Required type, defaults)
+1. **`FineTunePopulationConfig`** (`src/config/FineTunePopulationConfig.ts`):
+   New config with `minPopulationFraction`, `maxPopulationFraction`,
+   `basePopulationFraction`, and `successRateWindow` - follows the established
+   config pattern (interface, Required type, defaults)
 
-2. **`AdaptiveFineTuneTracker`** (`src/blackbox/AdaptiveFineTuneTracker.ts`): Tracks fine-tuning success rate using a rolling window and calculates adaptive population sizes via linear interpolation between min and max fractions
+2. **`AdaptiveFineTuneTracker`** (`src/blackbox/AdaptiveFineTuneTracker.ts`):
+   Tracks fine-tuning success rate using a rolling window and calculates
+   adaptive population sizes via linear interpolation between min and max
+   fractions
 
-3. **Integration into evolution loop** (`src/NEAT/Neat.ts`): Records whether the fittest creature in each generation originated from fine-tuning (approach tag "fine"), feeding outcomes into the tracker
+3. **Integration into evolution loop** (`src/NEAT/Neat.ts`): Records whether the
+   fittest creature in each generation originated from fine-tuning (approach tag
+   "fine"), feeding outcomes into the tracker
 
-4. **`FindTunePopulation`** (`src/blackbox/FineTunePopulation.ts`): Uses the tracker's `calculatePopSize()` instead of the fixed heuristic when the tracker is available
+4. **`FindTunePopulation`** (`src/blackbox/FineTunePopulation.ts`): Uses the
+   tracker's `calculatePopSize()` instead of the fixed heuristic when the
+   tracker is available
 
 ### Backward Compatibility
 
-The adaptive tracker is always created (initialised with the default config). The default `basePopulationFraction` of 0.2 matches the original `populationSize / 5` heuristic, so first-generation behaviour is unchanged. The dead-slots floor from the original heuristic is preserved.
+The adaptive tracker is always created (initialised with the default config).
+The default `basePopulationFraction` of 0.2 matches the original
+`populationSize / 5` heuristic, so first-generation behaviour is unchanged. The
+dead-slots floor from the original heuristic is preserved.
 
 ## Evidence
 
-This is a backend/algorithm change with no UI component. All functionality is verified through unit tests. The evolution integration test (`test/Evolve.ts`) passes successfully, confirming the adaptive tracker works correctly within the full evolution loop.
+This is a backend/algorithm change with no UI component. All functionality is
+verified through unit tests. The evolution integration test (`test/Evolve.ts`)
+passes successfully, confirming the adaptive tracker works correctly within the
+full evolution loop.
 
 ## Test Plan
 
 ### Config tests (`test/config/FineTunePopulationConfig.ts`) - 8 tests
+
 - Defaults applied when not specified
 - Custom values override defaults
 - Partial overrides merge with defaults
@@ -39,6 +63,7 @@ This is a backend/algorithm change with no UI component. All functionality is ve
 - Default values are sensible
 
 ### Tracker tests (`test/blackbox/AdaptiveFineTuneTracker.ts`) - 12 tests
+
 - Success rate is NaN with no outcomes
 - Success rate tracks correctly
 - All successes gives rate 1.0

--- a/docs/pr-summary-1323.md
+++ b/docs/pr-summary-1323.md
@@ -1,0 +1,53 @@
+## Summary
+
+Implements adaptive fine-tuning population sizing based on improvement rate (#1323).
+
+Previously, the fine-tuning population size was calculated using a fixed heuristic (20% of population or number of dead creatures). This change dynamically adjusts the size based on how successful fine-tuning has been in recent generations:
+
+- **High success rate**: Increases fine-tune population size (up to 40% of population) to allocate more resources to a productive strategy
+- **Low success rate**: Decreases fine-tune population size (down to 10% of population) to reduce wasted computation
+- **No data yet**: Uses the base fraction (20%, matching the original heuristic) as a starting point
+
+### Architecture
+
+1. **`FineTunePopulationConfig`** (`src/config/FineTunePopulationConfig.ts`): New config with `minPopulationFraction`, `maxPopulationFraction`, `basePopulationFraction`, and `successRateWindow` - follows the established config pattern (interface, Required type, defaults)
+
+2. **`AdaptiveFineTuneTracker`** (`src/blackbox/AdaptiveFineTuneTracker.ts`): Tracks fine-tuning success rate using a rolling window and calculates adaptive population sizes via linear interpolation between min and max fractions
+
+3. **Integration into evolution loop** (`src/NEAT/Neat.ts`): Records whether the fittest creature in each generation originated from fine-tuning (approach tag "fine"), feeding outcomes into the tracker
+
+4. **`FindTunePopulation`** (`src/blackbox/FineTunePopulation.ts`): Uses the tracker's `calculatePopSize()` instead of the fixed heuristic when the tracker is available
+
+### Backward Compatibility
+
+The adaptive tracker is always created (initialised with the default config). The default `basePopulationFraction` of 0.2 matches the original `populationSize / 5` heuristic, so first-generation behaviour is unchanged. The dead-slots floor from the original heuristic is preserved.
+
+## Evidence
+
+This is a backend/algorithm change with no UI component. All functionality is verified through unit tests. The evolution integration test (`test/Evolve.ts`) passes successfully, confirming the adaptive tracker works correctly within the full evolution loop.
+
+## Test Plan
+
+### Config tests (`test/config/FineTunePopulationConfig.ts`) - 8 tests
+- Defaults applied when not specified
+- Custom values override defaults
+- Partial overrides merge with defaults
+- String values coerced from CLI
+- maxPopulationFraction < minPopulationFraction throws
+- basePopulationFraction below min throws
+- basePopulationFraction above max throws
+- Default values are sensible
+
+### Tracker tests (`test/blackbox/AdaptiveFineTuneTracker.ts`) - 12 tests
+- Success rate is NaN with no outcomes
+- Success rate tracks correctly
+- All successes gives rate 1.0
+- All failures gives rate 0.0
+- Rolling window evicts old outcomes
+- Outcome count respects window size
+- calculatePopSize uses base fraction when no data
+- calculatePopSize increases with high success rate
+- calculatePopSize decreases with low success rate
+- Dead slots floor ensures minimum population
+- calculatePopSize bounded between min and max fractions
+- Mixed outcomes produce intermediate size

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -13,6 +13,7 @@ import {
 } from "../architecture/ElitismUtils.ts";
 import { Fitness } from "../architecture/Fitness.ts";
 import { calculate as calculateScore } from "../architecture/Score.ts";
+import { AdaptiveFineTuneTracker } from "../blackbox/AdaptiveFineTuneTracker.ts";
 import { fineTuneImprovement } from "../blackbox/FineTune.ts";
 import { FindTunePopulation } from "../blackbox/FineTunePopulation.ts";
 import { Breed } from "../breed/Breed.ts";
@@ -82,6 +83,9 @@ export class Neat {
   /** Plateau detector for fitness stagnation detection (Issue #1039) */
   readonly plateauDetector: PlateauDetector;
 
+  /** Adaptive fine-tune population tracker (Issue #1323) */
+  readonly fineTuneTracker: AdaptiveFineTuneTracker;
+
   /**
    * Discovery replay queue for non-blocking background replay of cached
    * discoveries against new fittest creatures (Issue #997).
@@ -140,6 +144,11 @@ export class Neat {
 
     // Initialize plateau detector (Issue #1039)
     this.plateauDetector = new PlateauDetector(this.config.plateauDetection);
+
+    // Issue #1323: Initialize adaptive fine-tune population tracker
+    this.fineTuneTracker = new AdaptiveFineTuneTracker(
+      this.config.fineTunePopulation,
+    );
 
     // Initialize discovery replay queue (Issue #997)
     this.discoveryReplayQueue = new DiscoveryReplayQueue();
@@ -798,6 +807,14 @@ export class Neat {
     // Issue #1039: Record fitness for plateau detection
     this.plateauDetector.recordFitness(fittest.score);
 
+    // Issue #1323: Record whether fine-tuning produced the new fittest
+    if (previousFittest) {
+      const approach = getTag(tmpFittest, "approach");
+      const fineTuneImproved = approach === "fine" &&
+        tmpFittest.uuid !== previousFittest.uuid;
+      this.fineTuneTracker.recordOutcome(fineTuneImproved);
+    }
+
     addTag(fittest, "score", fittest.score.toString());
 
     const error = getTag(fittest, "error");
@@ -914,7 +931,7 @@ export class Neat {
       newPopulation.push(creativeThinking);
     }
 
-    const ftp = new FindTunePopulation(this);
+    const ftp = new FindTunePopulation(this, this.fineTuneTracker);
     const fineTunedPopulation = ftp.make(
       fittest,
       previousFittest,

--- a/src/blackbox/AdaptiveFineTuneTracker.ts
+++ b/src/blackbox/AdaptiveFineTuneTracker.ts
@@ -1,0 +1,98 @@
+import type { RequiredFineTunePopulationConfig } from "../config/FineTunePopulationConfig.ts";
+
+/**
+ * Tracks the success rate of fine-tuning across generations and calculates
+ * an adaptive population size based on recent improvement history.
+ *
+ * Issue #1323: Instead of a fixed 20% fine-tuning population, this tracker
+ * dynamically adjusts the size based on whether fine-tuning has been
+ * producing improvements in recent generations.
+ */
+export class AdaptiveFineTuneTracker {
+  private readonly config: RequiredFineTunePopulationConfig;
+  private readonly outcomes: boolean[] = [];
+
+  constructor(config: RequiredFineTunePopulationConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Record the outcome of a generation's fine-tuning.
+   *
+   * @param improved - Whether any fine-tuned creature became the new fittest
+   *   (i.e., the fittest creature in the new generation originated from
+   *   fine-tuning)
+   */
+  recordOutcome(improved: boolean): void {
+    this.outcomes.push(improved);
+    if (this.outcomes.length > this.config.successRateWindow) {
+      this.outcomes.shift();
+    }
+  }
+
+  /**
+   * Calculate the current success rate based on the rolling window.
+   *
+   * @returns A number between 0 and 1 representing the fraction of recent
+   *   generations where fine-tuning produced an improvement. Returns NaN
+   *   when no outcomes have been recorded yet.
+   */
+  getSuccessRate(): number {
+    if (this.outcomes.length === 0) return NaN;
+    const successes = this.outcomes.filter((o) => o).length;
+    return successes / this.outcomes.length;
+  }
+
+  /**
+   * Calculate the adaptive fine-tune population size.
+   *
+   * The size is interpolated between min and max based on the success rate:
+   * - No data yet: uses the base population fraction
+   * - 0% success: uses min population fraction
+   * - 100% success: uses max population fraction
+   *
+   * The result is also bounded below by the number of "dead slots" available
+   * (matching the original heuristic's second term).
+   *
+   * @param populationSize - The configured total population size
+   * @param currentPopulationLength - Current number of living creatures
+   * @param elitism - Number of elite creatures retained
+   * @param trainingCompleteLength - Number of creatures that completed training
+   * @returns The fine-tune population size to use
+   */
+  calculatePopSize(
+    populationSize: number,
+    currentPopulationLength: number,
+    elitism: number,
+    trainingCompleteLength: number,
+  ): number {
+    const successRate = this.getSuccessRate();
+
+    let fraction: number;
+    if (Number.isNaN(successRate)) {
+      // No data yet - use the base fraction (matches original 20% heuristic)
+      fraction = this.config.basePopulationFraction;
+    } else {
+      // Linearly interpolate between min and max based on success rate
+      fraction = this.config.minPopulationFraction +
+        successRate *
+          (this.config.maxPopulationFraction -
+            this.config.minPopulationFraction);
+    }
+
+    const adaptiveSize = Math.ceil(populationSize * fraction);
+
+    // Also consider dead slots (original heuristic's second term)
+    const deadSlots = populationSize - currentPopulationLength -
+      elitism - trainingCompleteLength;
+
+    return Math.max(adaptiveSize, deadSlots);
+  }
+
+  /**
+   * Returns the number of recorded outcomes.
+   */
+  getOutcomeCount(): number {
+    return this.outcomes.length;
+  }
+}

--- a/src/blackbox/FineTunePopulation.ts
+++ b/src/blackbox/FineTunePopulation.ts
@@ -6,13 +6,16 @@ import { Species } from "../NEAT/Species.ts";
 import type { Neat } from "../NEAT/Neat.ts";
 import { logApproach } from "../NEAT/LogApproach.ts";
 import { restoreSource } from "./RestoreSource.ts";
+import type { AdaptiveFineTuneTracker } from "./AdaptiveFineTuneTracker.ts";
 
 import { retry } from "./Retry.ts";
 
 export class FindTunePopulation {
   private neat: Neat;
-  constructor(neat: Neat) {
+  private fineTuneTracker?: AdaptiveFineTuneTracker;
+  constructor(neat: Neat, fineTuneTracker?: AdaptiveFineTuneTracker) {
     this.neat = neat;
+    this.fineTuneTracker = fineTuneTracker;
   }
 
   make(
@@ -92,15 +95,22 @@ export class FindTunePopulation {
         "Failed to find previous fittest creature, all the same score as fittest. Skipping fine tuning.",
       );
     } else {
-      /** 20% of population or those that just died, leave one for the extended */
-      const fineTunePopSize = Math.max(
-        Math.ceil(
-          this.neat.config.populationSize / 5,
-        ),
-        this.neat.config.populationSize - this.neat.population.length -
-          this.neat.config.elitism -
+      /** Issue #1323: Adaptive fine-tune population size based on improvement rate */
+      const fineTunePopSize = this.fineTuneTracker
+        ? this.fineTuneTracker.calculatePopSize(
+          this.neat.config.populationSize,
+          this.neat.population.length,
+          this.neat.config.elitism,
           this.neat.trainingComplete.length,
-      );
+        )
+        : Math.max(
+          Math.ceil(
+            this.neat.config.populationSize / 5,
+          ),
+          this.neat.config.populationSize - this.neat.population.length -
+            this.neat.config.elitism -
+            this.neat.trainingComplete.length,
+        );
 
       const tunedUUID = new Set<string>();
 

--- a/src/config/FineTunePopulationConfig.ts
+++ b/src/config/FineTunePopulationConfig.ts
@@ -1,0 +1,65 @@
+/**
+ * Configuration for adaptive fine-tuning population sizing.
+ *
+ * Issue #1323: The fine-tuning population size was calculated using a fixed
+ * heuristic (20% of population or number of dead creatures). This configuration
+ * enables dynamic adjustment based on how successful fine-tuning has been in
+ * recent generations.
+ *
+ * When fine-tuning is producing improvements, the population size increases
+ * to allocate more resources to a productive strategy. When fine-tuning
+ * consistently fails, the size decreases to reduce wasted computation.
+ */
+
+/**
+ * Configuration for adaptive fine-tuning population sizing behaviour.
+ */
+export interface FineTunePopulationConfig {
+  /**
+   * Minimum fraction of the population allocated to fine-tuning.
+   * The fine-tune population size will never drop below
+   * `ceil(populationSize * minPopulationFraction)`.
+   * Default: 0.1 (10%)
+   */
+  minPopulationFraction?: number;
+
+  /**
+   * Maximum fraction of the population allocated to fine-tuning.
+   * The fine-tune population size will never exceed
+   * `ceil(populationSize * maxPopulationFraction)`.
+   * Default: 0.4 (40%)
+   */
+  maxPopulationFraction?: number;
+
+  /**
+   * Base fraction of the population allocated to fine-tuning when no
+   * success data is available yet.
+   * Default: 0.2 (20%, matching the original fixed heuristic)
+   */
+  basePopulationFraction?: number;
+
+  /**
+   * Number of recent generations to consider when calculating the
+   * fine-tuning success rate.
+   * Default: 10
+   */
+  successRateWindow?: number;
+}
+
+/**
+ * Required version of FineTunePopulationConfig with all fields populated.
+ */
+export type RequiredFineTunePopulationConfig = Required<
+  FineTunePopulationConfig
+>;
+
+/**
+ * Default values for fine-tune population configuration.
+ */
+export const DEFAULT_FINE_TUNE_POPULATION_CONFIG:
+  RequiredFineTunePopulationConfig = {
+    minPopulationFraction: 0.1,
+    maxPopulationFraction: 0.4,
+    basePopulationFraction: 0.2,
+    successRateWindow: 10,
+  };

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -10,6 +10,7 @@ import type { RequiredPlateauDetectionConfig } from "../NEAT/PlateauDetector.ts"
 import type { RequiredAdaptiveMutationThresholds } from "./AdaptiveMutationThresholds.ts";
 import type { DiscoveryMinCandidatesPerCategory } from "./DiscoveryMinCandidatesPerCategory.ts";
 import type { RequiredEnsembleDiversityConfig } from "./EnsembleDiversityConfig.ts";
+import type { RequiredFineTunePopulationConfig } from "./FineTunePopulationConfig.ts";
 import type { RequiredStabilityAdaptationConfig } from "./StabilityAdaptationConfig.ts";
 import type { RequiredQuantumStepConfig } from "./QuantumStepConfig.ts";
 import type { RequiredWeightRegularisationConfig } from "./WeightRegularisationConfig.ts";
@@ -487,4 +488,21 @@ export interface NeatArguments {
    * - errorScale: Scale factor for error-based adaptation (default: 10)
    */
   quantumStep: RequiredQuantumStepConfig;
+
+  /**
+   * Adaptive fine-tuning population sizing configuration.
+   *
+   * Issue #1323: Dynamically adjusts the fine-tuning population size based
+   * on how successful fine-tuning has been in recent generations.
+   *
+   * When fine-tuning produces improvements, more resources are allocated to it.
+   * When fine-tuning consistently fails, the population size decreases.
+   *
+   * Configuration options:
+   * - minPopulationFraction: Minimum fraction of population for fine-tuning (default: 0.1)
+   * - maxPopulationFraction: Maximum fraction of population for fine-tuning (default: 0.4)
+   * - basePopulationFraction: Starting fraction before success data exists (default: 0.2)
+   * - successRateWindow: Number of recent generations to consider (default: 10)
+   */
+  fineTunePopulation: RequiredFineTunePopulationConfig;
 }

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -18,6 +18,10 @@ import {
   DEFAULT_ENSEMBLE_DIVERSITY_CONFIG,
   type RequiredEnsembleDiversityConfig,
 } from "./EnsembleDiversityConfig.ts";
+import {
+  DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+  type RequiredFineTunePopulationConfig,
+} from "./FineTunePopulationConfig.ts";
 import type { NeatArguments } from "./NeatArguments.ts";
 import { parseDiscoverySampleRate, parseNumber } from "./ParseOptions.ts";
 import {
@@ -715,6 +719,39 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
         ),
       } as RequiredQuantumStepConfig;
     })(),
+    // Issue #1323: Adaptive fine-tuning population sizing
+    fineTunePopulation: (() => {
+      const overrides = opts.fineTunePopulation as
+        | Record<string, unknown>
+        | undefined;
+      const d = DEFAULT_FINE_TUNE_POPULATION_CONFIG;
+      return {
+        minPopulationFraction: parseNumber(
+          "Fine-tune population minPopulationFraction",
+          overrides?.minPopulationFraction,
+          d.minPopulationFraction,
+          { min: 0, max: 1 },
+        ),
+        maxPopulationFraction: parseNumber(
+          "Fine-tune population maxPopulationFraction",
+          overrides?.maxPopulationFraction,
+          d.maxPopulationFraction,
+          { min: 0, max: 1 },
+        ),
+        basePopulationFraction: parseNumber(
+          "Fine-tune population basePopulationFraction",
+          overrides?.basePopulationFraction,
+          d.basePopulationFraction,
+          { min: 0, max: 1 },
+        ),
+        successRateWindow: parseNumber(
+          "Fine-tune population successRateWindow",
+          overrides?.successRateWindow,
+          d.successRateWindow,
+          { integer: true, min: 1 },
+        ),
+      } as RequiredFineTunePopulationConfig;
+    })(),
   };
 
   // Cross-field validation for quantum step config
@@ -722,6 +759,38 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
     throw new Error(
       `Quantum step maxStep must be >= minStep. ` +
         `maxStep: ${config.quantumStep.maxStep}, minStep: ${config.quantumStep.minStep}`,
+    );
+  }
+
+  // Cross-field validation for fine-tune population config
+  if (
+    config.fineTunePopulation.maxPopulationFraction <
+      config.fineTunePopulation.minPopulationFraction
+  ) {
+    throw new Error(
+      `Fine-tune population maxPopulationFraction must be >= minPopulationFraction. ` +
+        `maxPopulationFraction: ${config.fineTunePopulation.maxPopulationFraction}, ` +
+        `minPopulationFraction: ${config.fineTunePopulation.minPopulationFraction}`,
+    );
+  }
+  if (
+    config.fineTunePopulation.basePopulationFraction <
+      config.fineTunePopulation.minPopulationFraction
+  ) {
+    throw new Error(
+      `Fine-tune population basePopulationFraction must be >= minPopulationFraction. ` +
+        `basePopulationFraction: ${config.fineTunePopulation.basePopulationFraction}, ` +
+        `minPopulationFraction: ${config.fineTunePopulation.minPopulationFraction}`,
+    );
+  }
+  if (
+    config.fineTunePopulation.basePopulationFraction >
+      config.fineTunePopulation.maxPopulationFraction
+  ) {
+    throw new Error(
+      `Fine-tune population basePopulationFraction must be <= maxPopulationFraction. ` +
+        `basePopulationFraction: ${config.fineTunePopulation.basePopulationFraction}, ` +
+        `maxPopulationFraction: ${config.fineTunePopulation.maxPopulationFraction}`,
     );
   }
 

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -1,6 +1,7 @@
 import type { AdaptiveMutationThresholds } from "./AdaptiveMutationThresholds.ts";
 import type { DiscoveryMinCandidatesPerCategory } from "./DiscoveryMinCandidatesPerCategory.ts";
 import type { EnsembleDiversityConfig } from "./EnsembleDiversityConfig.ts";
+import type { FineTunePopulationConfig } from "./FineTunePopulationConfig.ts";
 import type { NeatArguments } from "./NeatArguments.ts";
 import type { PlateauDetectionConfig } from "../NEAT/PlateauDetector.ts";
 import type { QuantumStepConfig } from "./QuantumStepConfig.ts";
@@ -70,6 +71,7 @@ export type NeatOptions =
     | "weightRegularisation"
     | "ensembleDiversity"
     | "quantumStep"
+    | "fineTunePopulation"
   >
   & {
     /** Partial overrides for minimum candidates per category (defaults applied if not specified) */
@@ -86,6 +88,8 @@ export type NeatOptions =
     ensembleDiversity?: EnsembleDiversityConfig;
     /** Partial overrides for quantum step configuration (defaults applied if not specified) */
     quantumStep?: QuantumStepConfig;
+    /** Partial overrides for fine-tune population configuration (defaults applied if not specified) */
+    fineTunePopulation?: FineTunePopulationConfig;
   };
 
 /**
@@ -116,6 +120,7 @@ export type NeatOptionsInput =
     | "weightRegularisation"
     | "ensembleDiversity"
     | "quantumStep"
+    | "fineTunePopulation"
   >
   & {
     [K in NumericOptionKeys]?: NonNullable<NeatOptions[K]> extends number
@@ -132,4 +137,5 @@ export type NeatOptionsInput =
     weightRegularisation?: CoerceNumeric<WeightRegularisationConfig>;
     ensembleDiversity?: CoerceNumeric<EnsembleDiversityConfig>;
     quantumStep?: CoerceNumeric<QuantumStepConfig>;
+    fineTunePopulation?: CoerceNumeric<FineTunePopulationConfig>;
   };

--- a/test/blackbox/AdaptiveFineTuneTracker.ts
+++ b/test/blackbox/AdaptiveFineTuneTracker.ts
@@ -1,0 +1,226 @@
+import {
+  assertEquals,
+  assertGreater,
+  assertGreaterOrEqual,
+  assertLessOrEqual,
+} from "@std/assert";
+import { AdaptiveFineTuneTracker } from "../../src/blackbox/AdaptiveFineTuneTracker.ts";
+import { DEFAULT_FINE_TUNE_POPULATION_CONFIG } from "../../src/config/FineTunePopulationConfig.ts";
+
+Deno.test(
+  "AdaptiveFineTuneTracker - success rate is NaN with no outcomes",
+  () => {
+    const tracker = new AdaptiveFineTuneTracker(
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+    );
+    assertEquals(Number.isNaN(tracker.getSuccessRate()), true);
+  },
+);
+
+Deno.test("AdaptiveFineTuneTracker - success rate tracks correctly", () => {
+  const tracker = new AdaptiveFineTuneTracker(
+    DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+  );
+  tracker.recordOutcome(true);
+  tracker.recordOutcome(false);
+  tracker.recordOutcome(true);
+  assertEquals(tracker.getSuccessRate(), 2 / 3);
+});
+
+Deno.test("AdaptiveFineTuneTracker - all successes gives rate 1.0", () => {
+  const tracker = new AdaptiveFineTuneTracker(
+    DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+  );
+  for (let i = 0; i < 5; i++) {
+    tracker.recordOutcome(true);
+  }
+  assertEquals(tracker.getSuccessRate(), 1.0);
+});
+
+Deno.test("AdaptiveFineTuneTracker - all failures gives rate 0.0", () => {
+  const tracker = new AdaptiveFineTuneTracker(
+    DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+  );
+  for (let i = 0; i < 5; i++) {
+    tracker.recordOutcome(false);
+  }
+  assertEquals(tracker.getSuccessRate(), 0.0);
+});
+
+Deno.test("AdaptiveFineTuneTracker - rolling window evicts old outcomes", () => {
+  const tracker = new AdaptiveFineTuneTracker({
+    ...DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+    successRateWindow: 3,
+  });
+
+  // Fill window with successes
+  tracker.recordOutcome(true);
+  tracker.recordOutcome(true);
+  tracker.recordOutcome(true);
+  assertEquals(tracker.getSuccessRate(), 1.0);
+
+  // New failures should evict old successes
+  tracker.recordOutcome(false);
+  tracker.recordOutcome(false);
+  tracker.recordOutcome(false);
+  assertEquals(tracker.getSuccessRate(), 0.0);
+});
+
+Deno.test(
+  "AdaptiveFineTuneTracker - outcome count respects window size",
+  () => {
+    const tracker = new AdaptiveFineTuneTracker({
+      ...DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+      successRateWindow: 5,
+    });
+    for (let i = 0; i < 10; i++) {
+      tracker.recordOutcome(true);
+    }
+    assertEquals(tracker.getOutcomeCount(), 5);
+  },
+);
+
+Deno.test(
+  "AdaptiveFineTuneTracker - calculatePopSize uses base fraction when no data",
+  () => {
+    const tracker = new AdaptiveFineTuneTracker(
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+    );
+    // populationSize=100, currentPop=80, elitism=1, training=0
+    // base fraction = 0.2, so ceil(100*0.2) = 20
+    // dead slots = 100-80-1-0 = 19
+    // max(20, 19) = 20
+    const popSize = tracker.calculatePopSize(100, 80, 1, 0);
+    assertEquals(popSize, 20);
+  },
+);
+
+Deno.test(
+  "AdaptiveFineTuneTracker - calculatePopSize increases with high success rate",
+  () => {
+    const tracker = new AdaptiveFineTuneTracker(
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+    );
+
+    // Record all successes
+    for (let i = 0; i < 10; i++) {
+      tracker.recordOutcome(true);
+    }
+
+    // success rate = 1.0
+    // fraction = 0.1 + 1.0 * (0.4 - 0.1) = 0.4
+    // adaptive size = ceil(100 * 0.4) = 40
+    const popSize = tracker.calculatePopSize(100, 80, 1, 0);
+    assertEquals(popSize, 40);
+  },
+);
+
+Deno.test(
+  "AdaptiveFineTuneTracker - calculatePopSize decreases with low success rate",
+  () => {
+    const tracker = new AdaptiveFineTuneTracker(
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+    );
+
+    // Record all failures
+    for (let i = 0; i < 10; i++) {
+      tracker.recordOutcome(false);
+    }
+
+    // success rate = 0.0
+    // fraction = 0.1 + 0.0 * (0.4 - 0.1) = 0.1
+    // adaptive size = ceil(100 * 0.1) = 10
+    // dead slots = 100-80-1-0 = 19
+    // max(10, 19) = 19
+    const popSize = tracker.calculatePopSize(100, 80, 1, 0);
+    assertEquals(popSize, 19);
+  },
+);
+
+Deno.test(
+  "AdaptiveFineTuneTracker - dead slots floor ensures minimum population",
+  () => {
+    const tracker = new AdaptiveFineTuneTracker({
+      ...DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+      minPopulationFraction: 0.05,
+    });
+
+    // Record all failures - fraction will be 0.05
+    for (let i = 0; i < 5; i++) {
+      tracker.recordOutcome(false);
+    }
+
+    // adaptive size = ceil(100 * 0.05) = 5
+    // dead slots = 100-50-1-0 = 49
+    // max(5, 49) = 49 (dead slots dominate)
+    const popSize = tracker.calculatePopSize(100, 50, 1, 0);
+    assertEquals(popSize, 49);
+  },
+);
+
+Deno.test(
+  "AdaptiveFineTuneTracker - calculatePopSize bounded between min and max fractions",
+  () => {
+    const config = {
+      minPopulationFraction: 0.1,
+      maxPopulationFraction: 0.4,
+      basePopulationFraction: 0.2,
+      successRateWindow: 10,
+    };
+
+    const populationSize = 100;
+    const currentPop = 90;
+    const elitism = 1;
+    const training = 0;
+
+    // Test with various success rates
+    for (let successes = 0; successes <= 10; successes++) {
+      const tracker = new AdaptiveFineTuneTracker(config);
+      for (let i = 0; i < 10; i++) {
+        tracker.recordOutcome(i < successes);
+      }
+      const popSize = tracker.calculatePopSize(
+        populationSize,
+        currentPop,
+        elitism,
+        training,
+      );
+      // Should always be at least min fraction
+      assertGreaterOrEqual(
+        popSize,
+        Math.ceil(populationSize * config.minPopulationFraction),
+      );
+      // When dead slots are small, should be at most max fraction
+      assertLessOrEqual(
+        popSize,
+        Math.max(
+          Math.ceil(populationSize * config.maxPopulationFraction),
+          populationSize - currentPop - elitism - training,
+        ),
+      );
+      assertGreater(popSize, 0);
+    }
+  },
+);
+
+Deno.test(
+  "AdaptiveFineTuneTracker - mixed outcomes produce intermediate size",
+  () => {
+    const tracker = new AdaptiveFineTuneTracker(
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG,
+    );
+
+    // 50% success rate
+    for (let i = 0; i < 10; i++) {
+      tracker.recordOutcome(i % 2 === 0);
+    }
+
+    // success rate = 0.5
+    // fraction = 0.1 + 0.5 * (0.4 - 0.1) = 0.25
+    // adaptive size = ceil(100 * 0.25) = 25
+    // dead slots = 100-90-1-0 = 9
+    // max(25, 9) = 25
+    const popSize = tracker.calculatePopSize(100, 90, 1, 0);
+    assertEquals(popSize, 25);
+  },
+);

--- a/test/config/FineTunePopulationConfig.ts
+++ b/test/config/FineTunePopulationConfig.ts
@@ -1,0 +1,155 @@
+import {
+  assertEquals,
+  assertGreater,
+  assertLessOrEqual,
+  assertThrows,
+} from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { DEFAULT_FINE_TUNE_POPULATION_CONFIG } from "../../src/config/FineTunePopulationConfig.ts";
+
+Deno.test(
+  "FineTunePopulationConfig - defaults applied when not specified",
+  () => {
+    const config = createNeatConfig({});
+    assertEquals(
+      config.fineTunePopulation.minPopulationFraction,
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG.minPopulationFraction,
+    );
+    assertEquals(
+      config.fineTunePopulation.maxPopulationFraction,
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG.maxPopulationFraction,
+    );
+    assertEquals(
+      config.fineTunePopulation.basePopulationFraction,
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG.basePopulationFraction,
+    );
+    assertEquals(
+      config.fineTunePopulation.successRateWindow,
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG.successRateWindow,
+    );
+  },
+);
+
+Deno.test(
+  "FineTunePopulationConfig - custom values override defaults",
+  () => {
+    const config = createNeatConfig({
+      fineTunePopulation: {
+        minPopulationFraction: 0.05,
+        maxPopulationFraction: 0.5,
+        basePopulationFraction: 0.25,
+        successRateWindow: 20,
+      },
+    });
+    assertEquals(config.fineTunePopulation.minPopulationFraction, 0.05);
+    assertEquals(config.fineTunePopulation.maxPopulationFraction, 0.5);
+    assertEquals(config.fineTunePopulation.basePopulationFraction, 0.25);
+    assertEquals(config.fineTunePopulation.successRateWindow, 20);
+  },
+);
+
+Deno.test(
+  "FineTunePopulationConfig - partial overrides merge with defaults",
+  () => {
+    const config = createNeatConfig({
+      fineTunePopulation: {
+        successRateWindow: 5,
+      },
+    });
+    assertEquals(
+      config.fineTunePopulation.minPopulationFraction,
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG.minPopulationFraction,
+    );
+    assertEquals(
+      config.fineTunePopulation.maxPopulationFraction,
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG.maxPopulationFraction,
+    );
+    assertEquals(
+      config.fineTunePopulation.basePopulationFraction,
+      DEFAULT_FINE_TUNE_POPULATION_CONFIG.basePopulationFraction,
+    );
+    assertEquals(config.fineTunePopulation.successRateWindow, 5);
+  },
+);
+
+Deno.test(
+  "FineTunePopulationConfig - string values coerced from CLI",
+  () => {
+    const config = createNeatConfig({
+      fineTunePopulation: {
+        minPopulationFraction: "0.05" as unknown as number,
+        maxPopulationFraction: "0.5" as unknown as number,
+        basePopulationFraction: "0.25" as unknown as number,
+        successRateWindow: "20" as unknown as number,
+      },
+    });
+    assertEquals(config.fineTunePopulation.minPopulationFraction, 0.05);
+    assertEquals(config.fineTunePopulation.maxPopulationFraction, 0.5);
+    assertEquals(config.fineTunePopulation.basePopulationFraction, 0.25);
+    assertEquals(config.fineTunePopulation.successRateWindow, 20);
+  },
+);
+
+Deno.test(
+  "FineTunePopulationConfig - maxPopulationFraction less than minPopulationFraction throws",
+  () => {
+    assertThrows(
+      () =>
+        createNeatConfig({
+          fineTunePopulation: {
+            minPopulationFraction: 0.5,
+            maxPopulationFraction: 0.1,
+          },
+        }),
+      Error,
+      "maxPopulationFraction must be >= minPopulationFraction",
+    );
+  },
+);
+
+Deno.test(
+  "FineTunePopulationConfig - basePopulationFraction below min throws",
+  () => {
+    assertThrows(
+      () =>
+        createNeatConfig({
+          fineTunePopulation: {
+            minPopulationFraction: 0.3,
+            basePopulationFraction: 0.1,
+          },
+        }),
+      Error,
+      "basePopulationFraction must be >= minPopulationFraction",
+    );
+  },
+);
+
+Deno.test(
+  "FineTunePopulationConfig - basePopulationFraction above max throws",
+  () => {
+    assertThrows(
+      () =>
+        createNeatConfig({
+          fineTunePopulation: {
+            maxPopulationFraction: 0.2,
+            basePopulationFraction: 0.3,
+          },
+        }),
+      Error,
+      "basePopulationFraction must be <= maxPopulationFraction",
+    );
+  },
+);
+
+Deno.test("FineTunePopulationConfig - default values are sensible", () => {
+  const d = DEFAULT_FINE_TUNE_POPULATION_CONFIG;
+  assertGreater(d.minPopulationFraction, 0);
+  assertLessOrEqual(d.minPopulationFraction, 1);
+  assertGreater(d.maxPopulationFraction, 0);
+  assertLessOrEqual(d.maxPopulationFraction, 1);
+  assertGreater(d.maxPopulationFraction, d.minPopulationFraction);
+  assertGreater(d.basePopulationFraction, 0);
+  assertLessOrEqual(d.basePopulationFraction, d.maxPopulationFraction);
+  assertGreater(d.basePopulationFraction, d.minPopulationFraction - 0.001);
+  assertGreater(d.successRateWindow, 0);
+});


### PR DESCRIPTION
## Summary

Implements adaptive fine-tuning population sizing based on improvement rate
(#1323).

Previously, the fine-tuning population size was calculated using a fixed
heuristic (20% of population or number of dead creatures). This change
dynamically adjusts the size based on how successful fine-tuning has been in
recent generations:

- **High success rate**: Increases fine-tune population size (up to 40% of
  population) to allocate more resources to a productive strategy
- **Low success rate**: Decreases fine-tune population size (down to 10% of
  population) to reduce wasted computation
- **No data yet**: Uses the base fraction (20%, matching the original heuristic)
  as a starting point

### Architecture

1. **`FineTunePopulationConfig`** (`src/config/FineTunePopulationConfig.ts`):
   New config with `minPopulationFraction`, `maxPopulationFraction`,
   `basePopulationFraction`, and `successRateWindow` - follows the established
   config pattern (interface, Required type, defaults)

2. **`AdaptiveFineTuneTracker`** (`src/blackbox/AdaptiveFineTuneTracker.ts`):
   Tracks fine-tuning success rate using a rolling window and calculates
   adaptive population sizes via linear interpolation between min and max
   fractions

3. **Integration into evolution loop** (`src/NEAT/Neat.ts`): Records whether the
   fittest creature in each generation originated from fine-tuning (approach tag
   "fine"), feeding outcomes into the tracker

4. **`FindTunePopulation`** (`src/blackbox/FineTunePopulation.ts`): Uses the
   tracker's `calculatePopSize()` instead of the fixed heuristic when the
   tracker is available

### Backward Compatibility

The adaptive tracker is always created (initialised with the default config).
The default `basePopulationFraction` of 0.2 matches the original
`populationSize / 5` heuristic, so first-generation behaviour is unchanged. The
dead-slots floor from the original heuristic is preserved.

## Evidence

This is a backend/algorithm change with no UI component. All functionality is
verified through unit tests. The evolution integration test (`test/Evolve.ts`)
passes successfully, confirming the adaptive tracker works correctly within the
full evolution loop.

## Test Plan

### Config tests (`test/config/FineTunePopulationConfig.ts`) - 8 tests

- Defaults applied when not specified
- Custom values override defaults
- Partial overrides merge with defaults
- String values coerced from CLI
- maxPopulationFraction < minPopulationFraction throws
- basePopulationFraction below min throws
- basePopulationFraction above max throws
- Default values are sensible

### Tracker tests (`test/blackbox/AdaptiveFineTuneTracker.ts`) - 12 tests

- Success rate is NaN with no outcomes
- Success rate tracks correctly
- All successes gives rate 1.0
- All failures gives rate 0.0
- Rolling window evicts old outcomes
- Outcome count respects window size
- calculatePopSize uses base fraction when no data
- calculatePopSize increases with high success rate
- calculatePopSize decreases with low success rate
- Dead slots floor ensures minimum population
- calculatePopSize bounded between min and max fractions
- Mixed outcomes produce intermediate size

---

## Automated Fix Details
This PR addresses issue #1323: **Memetic: Adaptive fine-tuning population size based on improvement rate**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1323