### PR TITLE
Fix: Memetic: Gradient-informed quantum adjustment (#1325)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.2",
+  "version": "0.310.3",
   "publish": {
     "include": [
       "mod.ts",

--- a/docs/pr-summary-1325.md
+++ b/docs/pr-summary-1325.md
@@ -1,0 +1,38 @@
+## Summary
+
+Implements gradient-informed quantum adjustment for memetic fine-tuning (#1325).
+
+The quantum adjustment in `FineTune.ts` previously used purely random scaling to explore parameter space. This change adds optional gradient hints that bias the direction of quantum adjustments based on the direction of parameter changes that led to score improvement. This is a hybrid approach: gradient-informed direction combined with random magnitude, preserving exploration while adding guidance.
+
+### Key changes:
+
+- **New `GradientHint` interface** (`src/blackbox/GradientHint.ts`): Represents gradient direction (+1/-1/0) and normalised magnitude (0-1) for a single parameter
+- **`applyGradientBias()` function**: Biases a random delta towards the gradient direction. When aligned, boosts magnitude by up to 50%. When opposing, probabilistically flips the delta (up to 70% chance based on gradient magnitude)
+- **`computeGradientHint()` function**: Derives gradient hints from the difference between current and previous parameter values plus score improvement. Magnitude is normalised using `|x| / (1 + |x|)` (same formula as `calculateEffectiveStep`)
+- **`quantumAdjust()` extended**: Accepts an optional `gradientHint` parameter applied after random delta generation but before momentum
+- **`tuneRandomize()` integration**: Automatically computes gradient hints for each bias and weight during fine-tuning when score improvement is available
+
+### Design decisions:
+
+- Gradient hints are computed from parameter change direction + score improvement (no full backpropagation pass required)
+- The gradient bias is applied before momentum, allowing both systems to contribute independently
+- Zero magnitude or zero direction gradient hints have no effect (backward compatible)
+- All existing tests pass unchanged — the feature is purely additive
+
+## Evidence
+
+This is a backend/algorithmic change with no visual output. Evidence is provided through comprehensive unit tests that verify:
+
+1. `applyGradientBias` correctly handles all edge cases (zero direction, zero magnitude, aligned deltas, opposing deltas, flip probability)
+2. `computeGradientHint` correctly derives direction and magnitude from parameter changes
+3. `quantumAdjust` accepts and uses gradient hints while maintaining backward compatibility
+4. `fineTuneImprovement` produces valid tuned creatures with gradient hints active
+5. All 2065 existing tests continue to pass
+
+## Test Plan
+
+- Added 23 new tests in `test/blackbox/GradientHint.ts`:
+  - 9 tests for `applyGradientBias` (zero direction, zero magnitude, zero delta, aligned boost, negative aligned boost, flip on oppose, keep on oppose, low magnitude, partial magnitude)
+  - 7 tests for `computeGradientHint` (no change, no improvement, negative improvement, positive direction, negative direction, magnitude scaling, magnitude bound)
+  - 6 tests for `quantumAdjust` with gradient hints (basic usage, no diff, backward compatible, zero magnitude, combined with momentum, combined with adaptive params)
+  - 1 integration test for `fineTuneImprovement` with gradient hints active

--- a/docs/pr-summary-1325.md
+++ b/docs/pr-summary-1325.md
@@ -2,37 +2,66 @@
 
 Implements gradient-informed quantum adjustment for memetic fine-tuning (#1325).
 
-The quantum adjustment in `FineTune.ts` previously used purely random scaling to explore parameter space. This change adds optional gradient hints that bias the direction of quantum adjustments based on the direction of parameter changes that led to score improvement. This is a hybrid approach: gradient-informed direction combined with random magnitude, preserving exploration while adding guidance.
+The quantum adjustment in `FineTune.ts` previously used purely random scaling to
+explore parameter space. This change adds optional gradient hints that bias the
+direction of quantum adjustments based on the direction of parameter changes
+that led to score improvement. This is a hybrid approach: gradient-informed
+direction combined with random magnitude, preserving exploration while adding
+guidance.
 
 ### Key changes:
 
-- **New `GradientHint` interface** (`src/blackbox/GradientHint.ts`): Represents gradient direction (+1/-1/0) and normalised magnitude (0-1) for a single parameter
-- **`applyGradientBias()` function**: Biases a random delta towards the gradient direction. When aligned, boosts magnitude by up to 50%. When opposing, probabilistically flips the delta (up to 70% chance based on gradient magnitude)
-- **`computeGradientHint()` function**: Derives gradient hints from the difference between current and previous parameter values plus score improvement. Magnitude is normalised using `|x| / (1 + |x|)` (same formula as `calculateEffectiveStep`)
-- **`quantumAdjust()` extended**: Accepts an optional `gradientHint` parameter applied after random delta generation but before momentum
-- **`tuneRandomize()` integration**: Automatically computes gradient hints for each bias and weight during fine-tuning when score improvement is available
+- **New `GradientHint` interface** (`src/blackbox/GradientHint.ts`): Represents
+  gradient direction (+1/-1/0) and normalised magnitude (0-1) for a single
+  parameter
+- **`applyGradientBias()` function**: Biases a random delta towards the gradient
+  direction. When aligned, boosts magnitude by up to 50%. When opposing,
+  probabilistically flips the delta (up to 70% chance based on gradient
+  magnitude)
+- **`computeGradientHint()` function**: Derives gradient hints from the
+  difference between current and previous parameter values plus score
+  improvement. Magnitude is normalised using `|x| / (1 + |x|)` (same formula as
+  `calculateEffectiveStep`)
+- **`quantumAdjust()` extended**: Accepts an optional `gradientHint` parameter
+  applied after random delta generation but before momentum
+- **`tuneRandomize()` integration**: Automatically computes gradient hints for
+  each bias and weight during fine-tuning when score improvement is available
 
 ### Design decisions:
 
-- Gradient hints are computed from parameter change direction + score improvement (no full backpropagation pass required)
-- The gradient bias is applied before momentum, allowing both systems to contribute independently
-- Zero magnitude or zero direction gradient hints have no effect (backward compatible)
+- Gradient hints are computed from parameter change direction + score
+  improvement (no full backpropagation pass required)
+- The gradient bias is applied before momentum, allowing both systems to
+  contribute independently
+- Zero magnitude or zero direction gradient hints have no effect (backward
+  compatible)
 - All existing tests pass unchanged — the feature is purely additive
 
 ## Evidence
 
-This is a backend/algorithmic change with no visual output. Evidence is provided through comprehensive unit tests that verify:
+This is a backend/algorithmic change with no visual output. Evidence is provided
+through comprehensive unit tests that verify:
 
-1. `applyGradientBias` correctly handles all edge cases (zero direction, zero magnitude, aligned deltas, opposing deltas, flip probability)
-2. `computeGradientHint` correctly derives direction and magnitude from parameter changes
-3. `quantumAdjust` accepts and uses gradient hints while maintaining backward compatibility
-4. `fineTuneImprovement` produces valid tuned creatures with gradient hints active
+1. `applyGradientBias` correctly handles all edge cases (zero direction, zero
+   magnitude, aligned deltas, opposing deltas, flip probability)
+2. `computeGradientHint` correctly derives direction and magnitude from
+   parameter changes
+3. `quantumAdjust` accepts and uses gradient hints while maintaining backward
+   compatibility
+4. `fineTuneImprovement` produces valid tuned creatures with gradient hints
+   active
 5. All 2065 existing tests continue to pass
 
 ## Test Plan
 
 - Added 23 new tests in `test/blackbox/GradientHint.ts`:
-  - 9 tests for `applyGradientBias` (zero direction, zero magnitude, zero delta, aligned boost, negative aligned boost, flip on oppose, keep on oppose, low magnitude, partial magnitude)
-  - 7 tests for `computeGradientHint` (no change, no improvement, negative improvement, positive direction, negative direction, magnitude scaling, magnitude bound)
-  - 6 tests for `quantumAdjust` with gradient hints (basic usage, no diff, backward compatible, zero magnitude, combined with momentum, combined with adaptive params)
+  - 9 tests for `applyGradientBias` (zero direction, zero magnitude, zero delta,
+    aligned boost, negative aligned boost, flip on oppose, keep on oppose, low
+    magnitude, partial magnitude)
+  - 7 tests for `computeGradientHint` (no change, no improvement, negative
+    improvement, positive direction, negative direction, magnitude scaling,
+    magnitude bound)
+  - 6 tests for `quantumAdjust` with gradient hints (basic usage, no diff,
+    backward compatible, zero magnitude, combined with momentum, combined with
+    adaptive params)
   - 1 integration test for `fineTuneImprovement` with gradient hints active

--- a/src/blackbox/FineTune.ts
+++ b/src/blackbox/FineTune.ts
@@ -24,6 +24,11 @@ import {
   DEFAULT_QUANTUM_STEP_CONFIG,
   type RequiredQuantumStepConfig,
 } from "../config/QuantumStepConfig.ts";
+import {
+  applyGradientBias,
+  computeGradientHint,
+  type GradientHint,
+} from "./GradientHint.ts";
 
 export const MIN_STEP = DEFAULT_QUANTUM_STEP_CONFIG.minStep;
 
@@ -72,6 +77,7 @@ export function calculateEffectiveStep(
  *                                  Higher values bias adjustment more strongly in the direction of change.
  * @param {number} suggestedDirection - Optional suggested direction from trajectory (-1, 0, or 1).
  * @param {AdaptiveQuantumParams} adaptiveParams - Optional adaptive parameters for step sizing.
+ * @param {GradientHint} gradientHint - Optional gradient information to bias the adjustment direction.
  * @returns {number} - The adjusted best value.
  */
 export function quantumAdjust(
@@ -82,6 +88,7 @@ export function quantumAdjust(
   momentumFactor?: number,
   suggestedDirection?: number,
   adaptiveParams?: AdaptiveQuantumParams,
+  gradientHint?: GradientHint,
 ): { value: number; changed: boolean } {
   // Calculate effective step size based on training progress
   const stepSize = adaptiveParams
@@ -103,6 +110,11 @@ export function quantumAdjust(
       delta = diff * Math.random() * scale;
     } else {
       delta = diff * Math.random() * (scale + 1) - diff;
+    }
+
+    // Apply gradient hint: bias delta direction using gradient information
+    if (gradientHint) {
+      delta = applyGradientBias(delta, gradientHint);
     }
 
     // Apply momentum: if we have a strong consistent trajectory, bias towards it
@@ -243,6 +255,13 @@ function tuneRandomize(
     };
   }
 
+  // Compute score improvement for gradient hint generation
+  // Scores are negative (closer to zero is better), so improvement is current - previous
+  const scoreImprovement = (Number.isFinite(fittest.score) &&
+      Number.isFinite(previousFittest.score))
+    ? (fittest.score! - previousFittest.score!)
+    : 0;
+
   // Build adaptive quantum params from creature scores and config
   const adaptiveParams: AdaptiveQuantumParams | undefined = quantumStepConfig &&
       Number.isFinite(fittest.score) &&
@@ -299,6 +318,13 @@ function tuneRandomize(
         }
       }
 
+      // Compute gradient hint from bias change direction and score improvement
+      const biasGradientHint = computeGradientHint(
+        fittestNeuron.bias,
+        previousNeuron.bias,
+        scoreImprovement,
+      );
+
       const result = quantumAdjust(
         fittestNeuron.bias,
         previousNeuron.bias,
@@ -307,6 +333,7 @@ function tuneRandomize(
         momentumFactor,
         suggestedDirection,
         adaptiveParams,
+        biasGradientHint,
       );
       candidateBiases.set(fittestNeuron.uuid, {
         original: fittestNeuron.bias,
@@ -350,6 +377,13 @@ function tuneRandomize(
         }
       }
 
+      // Compute gradient hint from weight change direction and score improvement
+      const weightGradientHint = computeGradientHint(
+        fittestSynapse.weight,
+        previousSynapse.weight,
+        scoreImprovement,
+      );
+
       const result = quantumAdjust(
         fittestSynapse.weight,
         previousSynapse.weight,
@@ -358,6 +392,7 @@ function tuneRandomize(
         momentumFactor,
         suggestedDirection,
         adaptiveParams,
+        weightGradientHint,
       );
 
       const entry = {

--- a/src/blackbox/GradientHint.ts
+++ b/src/blackbox/GradientHint.ts
@@ -1,0 +1,128 @@
+/**
+ * Gradient hint for informing quantum adjustments.
+ *
+ * During fine-tuning, gradient information from the elastic backpropagation
+ * system can optionally bias the direction and magnitude of quantum
+ * adjustments. This provides a hybrid approach: gradient-informed direction
+ * combined with random magnitude for exploration.
+ *
+ * The gradient direction is derived from the difference between current
+ * and previous parameter values, while magnitude is normalised based on
+ * the relative change. This lets fine-tuning leverage the direction of
+ * recent improvement without requiring a full backpropagation pass.
+ *
+ * Australian English: behaviour, optimise, normalise.
+ */
+
+/**
+ * Represents gradient information for a single parameter (weight or bias).
+ * Used to bias quantum adjustments towards the gradient-informed direction.
+ */
+export interface GradientHint {
+  /**
+   * The direction the gradient suggests this parameter should move.
+   * +1 = increase, -1 = decrease, 0 = no gradient information.
+   */
+  readonly direction: number;
+
+  /**
+   * The magnitude of the gradient, normalised to [0, 1].
+   * Higher values indicate stronger gradient signals.
+   * 0 means no gradient information is available.
+   */
+  readonly magnitude: number;
+}
+
+/**
+ * Applies a gradient hint to bias the direction of a quantum adjustment delta.
+ *
+ * The gradient hint biases the adjustment direction without eliminating
+ * randomness. When the random delta opposes the gradient direction,
+ * there is a probability (proportional to gradient magnitude) that the
+ * delta will be flipped to align with the gradient.
+ *
+ * @param delta - The randomly generated delta from quantum adjustment.
+ * @param hint - The gradient hint providing direction and magnitude.
+ * @param random - Optional random value for testability (0-1). Defaults to Math.random().
+ * @returns The adjusted delta, potentially flipped to align with gradient direction.
+ */
+export function applyGradientBias(
+  delta: number,
+  hint: GradientHint,
+  random?: number,
+): number {
+  // No hint direction means no adjustment
+  if (hint.direction === 0 || hint.magnitude === 0) {
+    return delta;
+  }
+
+  // If delta is zero, nothing to bias
+  if (delta === 0) {
+    return delta;
+  }
+
+  const deltaSign = Math.sign(delta);
+  const gradientSign = Math.sign(hint.direction);
+
+  // If already aligned with gradient, optionally amplify by magnitude
+  if (deltaSign === gradientSign) {
+    // Boost magnitude slightly when aligned: scale by (1 + magnitude * 0.5)
+    // This gives up to 50% extra magnitude when gradient is strong and aligned
+    return delta * (1 + hint.magnitude * 0.5);
+  }
+
+  // Delta opposes gradient direction - probabilistically flip it
+  // The probability of flipping increases with gradient magnitude
+  const flipProbability = hint.magnitude * 0.7; // Max 70% chance to flip
+  const effectiveRandom = random ?? Math.random();
+
+  if (effectiveRandom < flipProbability) {
+    // Flip delta to align with gradient direction
+    return -delta;
+  }
+
+  // Keep original delta (maintaining exploration)
+  return delta;
+}
+
+/**
+ * Computes a gradient hint from the difference between current and previous
+ * parameter values, plus the score improvement.
+ *
+ * The direction is the sign of the parameter change (the direction that
+ * produced improvement). The magnitude is derived from the score improvement,
+ * normalised using the formula: |Δscore| / (1 + |Δscore|) to keep it in [0, 1).
+ *
+ * @param currentValue - The current parameter value (from the fitter creature).
+ * @param previousValue - The previous parameter value.
+ * @param scoreImprovement - The score improvement (currentScore - previousScore). Positive means improvement.
+ * @returns A GradientHint, or undefined if there is no meaningful change.
+ */
+export function computeGradientHint(
+  currentValue: number,
+  previousValue: number,
+  scoreImprovement: number,
+): GradientHint | undefined {
+  const paramDelta = currentValue - previousValue;
+
+  // No parameter change means no gradient information
+  if (paramDelta === 0) {
+    return undefined;
+  }
+
+  // Only provide gradient hints when there was score improvement
+  // (positive scoreImprovement means the score got better/less negative)
+  if (scoreImprovement <= 0) {
+    return undefined;
+  }
+
+  // Direction: the sign of the parameter change that led to improvement
+  const direction = Math.sign(paramDelta);
+
+  // Magnitude: normalised from score improvement
+  // Uses the same normalisation as calculateEffectiveStep: |x| / (1 + |x|)
+  const absImprovement = Math.abs(scoreImprovement);
+  const magnitude = absImprovement / (1 + absImprovement);
+
+  return { direction, magnitude };
+}

--- a/test/blackbox/GradientHint.ts
+++ b/test/blackbox/GradientHint.ts
@@ -1,0 +1,304 @@
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import {
+  applyGradientBias,
+  computeGradientHint,
+  type GradientHint,
+} from "../../src/blackbox/GradientHint.ts";
+import {
+  fineTuneImprovement,
+  quantumAdjust,
+} from "../../src/blackbox/FineTune.ts";
+import { Creature } from "../../src/Creature.ts";
+import type { Approach } from "../../src/NEAT/LogApproach.ts";
+
+Deno.test("applyGradientBias - zero direction returns delta unchanged", () => {
+  const hint: GradientHint = { direction: 0, magnitude: 0.8 };
+  const result = applyGradientBias(0.5, hint, 0.1);
+  assertEquals(result, 0.5);
+});
+
+Deno.test("applyGradientBias - zero magnitude returns delta unchanged", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 0 };
+  const result = applyGradientBias(0.5, hint, 0.1);
+  assertEquals(result, 0.5);
+});
+
+Deno.test("applyGradientBias - zero delta returns zero", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 0.8 };
+  const result = applyGradientBias(0, hint, 0.1);
+  assertEquals(result, 0);
+});
+
+Deno.test("applyGradientBias - aligned delta is boosted", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 1.0 };
+  // Delta +0.5 aligns with gradient direction +1
+  const result = applyGradientBias(0.5, hint, 0.1);
+  // Should be boosted: 0.5 * (1 + 1.0 * 0.5) = 0.75
+  assertEquals(result, 0.75);
+});
+
+Deno.test("applyGradientBias - aligned negative delta is boosted", () => {
+  const hint: GradientHint = { direction: -1, magnitude: 0.6 };
+  // Delta -0.5 aligns with gradient direction -1
+  const result = applyGradientBias(-0.5, hint, 0.1);
+  // Should be boosted: -0.5 * (1 + 0.6 * 0.5) = -0.65
+  assertEquals(result, -0.65);
+});
+
+Deno.test("applyGradientBias - opposing delta flips when random < flipProbability", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 1.0 };
+  // Delta -0.5 opposes gradient direction +1
+  // flipProbability = 1.0 * 0.7 = 0.7, random = 0.1 < 0.7 → flip
+  const result = applyGradientBias(-0.5, hint, 0.1);
+  assertEquals(result, 0.5);
+});
+
+Deno.test("applyGradientBias - opposing delta kept when random >= flipProbability", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 1.0 };
+  // Delta -0.5 opposes gradient direction +1
+  // flipProbability = 1.0 * 0.7 = 0.7, random = 0.9 >= 0.7 → keep
+  const result = applyGradientBias(-0.5, hint, 0.9);
+  assertEquals(result, -0.5);
+});
+
+Deno.test("applyGradientBias - low magnitude reduces flip probability", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 0.1 };
+  // Delta -0.5 opposes gradient direction +1
+  // flipProbability = 0.1 * 0.7 = 0.07, random = 0.1 >= 0.07 → keep
+  const result = applyGradientBias(-0.5, hint, 0.1);
+  assertEquals(result, -0.5);
+});
+
+Deno.test("applyGradientBias - partial magnitude gives partial boost", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 0.5 };
+  // Delta +0.4 aligns with gradient direction +1
+  const result = applyGradientBias(0.4, hint, 0.1);
+  // Should be boosted: 0.4 * (1 + 0.5 * 0.5) = 0.5
+  assertEquals(result, 0.5);
+});
+
+Deno.test("quantumAdjust - accepts gradient hint and produces changed result", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 0.8 };
+  const result = quantumAdjust(
+    0.5,
+    0.3,
+    false,
+    false,
+    undefined,
+    undefined,
+    undefined,
+    hint,
+  );
+  // With diff = 0.2 (above MIN_STEP), should produce a changed result
+  assert(result.changed, "Should have changed with gradient hint");
+  assertNotEquals(result.value, 0.5, "Value should differ from currentBest");
+});
+
+Deno.test("quantumAdjust - gradient hint with no diff returns unchanged", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 0.8 };
+  const result = quantumAdjust(
+    0.5,
+    0.5,
+    false,
+    false,
+    undefined,
+    undefined,
+    undefined,
+    hint,
+  );
+  // diff = 0, so still no change
+  assert(!result.changed, "Should not change when diff is zero");
+  assertEquals(result.value, 0.5);
+});
+
+Deno.test("quantumAdjust - works without gradient hint (backward compatible)", () => {
+  const result = quantumAdjust(
+    0.5,
+    0.3,
+    false,
+    false,
+  );
+  assert(result.changed, "Should change without gradient hint");
+});
+
+Deno.test("quantumAdjust - gradient hint with zero magnitude behaves like no hint", () => {
+  const zeroHint: GradientHint = { direction: 1, magnitude: 0 };
+
+  // Run multiple times - with zero magnitude, gradient should have no effect
+  // Both should produce changed results with the same basic behaviour
+  let changedCount = 0;
+  for (let i = 0; i < 20; i++) {
+    const result = quantumAdjust(
+      0.5,
+      0.3,
+      false,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      zeroHint,
+    );
+    if (result.changed) changedCount++;
+  }
+  assert(changedCount > 0, "Should produce some changed results");
+});
+
+Deno.test("quantumAdjust - gradient hint combined with momentum", () => {
+  const hint: GradientHint = { direction: 1, magnitude: 0.8 };
+  const result = quantumAdjust(
+    0.5,
+    0.3,
+    false,
+    false,
+    1.5, // momentum factor
+    1, // suggested direction
+    undefined,
+    hint,
+  );
+  assert(result.changed, "Should change with both momentum and gradient");
+});
+
+Deno.test("quantumAdjust - gradient hint combined with adaptive params", () => {
+  const hint: GradientHint = { direction: -1, magnitude: 0.6 };
+  const result = quantumAdjust(
+    0.5,
+    0.3,
+    false,
+    false,
+    undefined,
+    undefined,
+    {
+      quantumStepConfig: { minStep: 0.0000001, maxStep: 0.001, errorScale: 10 },
+      previousScore: -0.5,
+      currentScore: -0.4,
+    },
+    hint,
+  );
+  assert(result.changed, "Should change with gradient and adaptive params");
+});
+
+// --- computeGradientHint tests ---
+
+Deno.test("computeGradientHint - no change returns undefined", () => {
+  const hint = computeGradientHint(0.5, 0.5, 0.1);
+  assertEquals(hint, undefined);
+});
+
+Deno.test("computeGradientHint - no score improvement returns undefined", () => {
+  const hint = computeGradientHint(0.6, 0.5, 0);
+  assertEquals(hint, undefined);
+});
+
+Deno.test("computeGradientHint - negative score improvement returns undefined", () => {
+  const hint = computeGradientHint(0.6, 0.5, -0.1);
+  assertEquals(hint, undefined);
+});
+
+Deno.test("computeGradientHint - positive change with improvement gives direction +1", () => {
+  const hint = computeGradientHint(0.6, 0.5, 0.1);
+  assert(hint !== undefined, "Should return a hint");
+  assertEquals(hint.direction, 1);
+  assert(hint.magnitude > 0, "Magnitude should be positive");
+  assert(hint.magnitude < 1, "Magnitude should be less than 1");
+});
+
+Deno.test("computeGradientHint - negative change with improvement gives direction -1", () => {
+  const hint = computeGradientHint(0.3, 0.5, 0.2);
+  assert(hint !== undefined, "Should return a hint");
+  assertEquals(hint.direction, -1);
+  assert(hint.magnitude > 0, "Magnitude should be positive");
+});
+
+Deno.test("computeGradientHint - large improvement gives higher magnitude", () => {
+  const smallHint = computeGradientHint(0.6, 0.5, 0.01);
+  const largeHint = computeGradientHint(0.6, 0.5, 1.0);
+  assert(smallHint !== undefined && largeHint !== undefined);
+  assert(
+    largeHint.magnitude > smallHint.magnitude,
+    `Large improvement magnitude ${largeHint.magnitude} should exceed small ${smallHint.magnitude}`,
+  );
+});
+
+Deno.test("computeGradientHint - magnitude is bounded below 1", () => {
+  const hint = computeGradientHint(0.6, 0.5, 1000);
+  assert(hint !== undefined, "Should return a hint");
+  assert(hint.magnitude < 1, "Magnitude should be bounded below 1");
+  assert(
+    hint.magnitude > 0.99,
+    "Magnitude should approach 1 for large improvements",
+  );
+});
+
+// --- fineTuneImprovement integration test ---
+
+Deno.test("fineTuneImprovement - produces tuned creatures with gradient hints active", () => {
+  const previousFittest: Creature = Creature.fromJSON({
+    "neurons": [{
+      "bias": 0,
+      "type": "input",
+      "squash": "LOGISTIC",
+      "index": 0,
+    }, {
+      "bias": 0,
+      "type": "input",
+      "squash": "LOGISTIC",
+      "index": 1,
+    }, {
+      "bias": -0.49135010426905,
+      "type": "output",
+      "squash": "BIPOLAR_SIGMOID",
+      "index": 2,
+    }],
+    "synapses": [{
+      "weight": 0.9967556172986067,
+      "from": 1,
+      "to": 2,
+    }, { "weight": 0.96864643541, "from": 0, "to": 2 }],
+    "input": 2,
+    "output": 1,
+    tags: [
+      { name: "score", value: "-0.5" },
+    ],
+  });
+
+  const fittest = Creature.fromJSON(previousFittest.exportJSON());
+  fittest.score = -0.4;
+  previousFittest.score = -0.5;
+  addTag(fittest, "approach", "trained" as Approach);
+  fittest.neurons[2].bias = 0.001;
+  fittest.synapses[0].weight = 0.011;
+
+  // fineTuneImprovement now uses gradient hints internally
+  const fineTuned = fineTuneImprovement(
+    fittest,
+    previousFittest,
+    false,
+    10,
+  );
+
+  assert(
+    fineTuned.length === 10,
+    "Should produce 10 fine-tuned creatures, was: " + fineTuned.length,
+  );
+
+  // Verify all tuned creatures have valid non-input neurons and synapses
+  for (const creature of fineTuned) {
+    assert(creature !== null, "Tuned creature should not be null");
+    for (const synapse of creature.synapses) {
+      assert(
+        Number.isFinite(synapse.weight),
+        "Synapse weight should be finite",
+      );
+    }
+    for (const neuron of creature.neurons) {
+      // Input neurons may have non-finite biases (pre-existing behaviour)
+      if (neuron.type !== "input") {
+        assert(
+          Number.isFinite(neuron.bias),
+          `Neuron bias should be finite for ${neuron.type} neuron, got: ${neuron.bias}`,
+        );
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Add gradient hints to bias quantum adjustments using the direction of parameter changes that led to score improvement
- New `GradientHint` interface with direction (+1/-1/0) and normalised magnitude (0-1)
- `applyGradientBias()` biases random deltas towards gradient direction (boost when aligned, probabilistic flip when opposing)
- `computeGradientHint()` derives hints from parameter change direction + score improvement
- Hybrid approach: gradient-informed direction with random magnitude preserves exploration while adding guidance

## Evidence
Backend/algorithmic change with no visual output. All 2065 tests pass including 23 new tests that verify correct behaviour of gradient hint computation, application, and integration with fine-tuning.

## Test Plan
- Added 23 new tests in `test/blackbox/GradientHint.ts`:
  - 9 tests for `applyGradientBias` (zero direction, zero magnitude, zero delta, aligned boost, negative aligned, flip/keep on oppose, low magnitude, partial magnitude)
  - 7 tests for `computeGradientHint` (no change, no/negative improvement, positive/negative direction, magnitude scaling, magnitude bound)
  - 6 tests for `quantumAdjust` with gradient hints (basic, no diff, backward compatible, zero magnitude, combined with momentum, combined with adaptive params)
  - 1 integration test for `fineTuneImprovement` with gradient hints active

Closes #1325

🤖 Generated with [Claude Code](https://claude.com/claude-code)