### PR TITLE
Fix: Bug: limitValue() does not guard against NaN inputs (#1364)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.12",
+  "version": "0.310.13",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1364.md
+++ b/docs/pr-summary-1364.md
@@ -1,8 +1,14 @@
 ## Summary
 
-Fixed `limitValue()` in `src/propagate/BackPropagation.ts` to guard against `NaN` and `Infinity` inputs. The function is called from `toValue()` after WASM `unSquash` operations that could produce non-finite results. Previously, `NaN` would pass through unchecked because `NaN > 1e12` and `NaN < -1e12` both evaluate to `false`.
+Fixed `limitValue()` in `src/propagate/BackPropagation.ts` to guard against
+`NaN` and `Infinity` inputs. The function is called from `toValue()` after WASM
+`unSquash` operations that could produce non-finite results. Previously, `NaN`
+would pass through unchecked because `NaN > 1e12` and `NaN < -1e12` both
+evaluate to `false`.
 
-The fix (applied in #1363) uses `Number.isFinite()` to catch all non-finite values upfront: `NaN` returns `0` (a safe neutral value), and `Infinity`/`-Infinity` clamp to `+/-1e12`.
+The fix (applied in #1363) uses `Number.isFinite()` to catch all non-finite
+values upfront: `NaN` returns `0` (a safe neutral value), and
+`Infinity`/`-Infinity` clamp to `+/-1e12`.
 
 This PR adds additional edge case tests to strengthen coverage for issue #1364.
 
@@ -35,6 +41,7 @@ Full quality gate passed: 2208 tests passed, 0 failed.
   - `Infinity` clamped to `1e12`
   - `-Infinity` clamped to `-1e12`
   - `NaN` converted to `0`
-  - Computed `NaN` values (`0/0`, `Infinity - Infinity`, `Infinity * 0`) converted to `0`
+  - Computed `NaN` values (`0/0`, `Infinity - Infinity`, `Infinity * 0`)
+    converted to `0`
   - Negative zero handled correctly
   - Values just inside boundaries pass through unchanged

--- a/docs/pr-summary-1364.md
+++ b/docs/pr-summary-1364.md
@@ -1,0 +1,40 @@
+## Summary
+
+Fixed `limitValue()` in `src/propagate/BackPropagation.ts` to guard against `NaN` and `Infinity` inputs. The function is called from `toValue()` after WASM `unSquash` operations that could produce non-finite results. Previously, `NaN` would pass through unchecked because `NaN > 1e12` and `NaN < -1e12` both evaluate to `false`.
+
+The fix (applied in #1363) uses `Number.isFinite()` to catch all non-finite values upfront: `NaN` returns `0` (a safe neutral value), and `Infinity`/`-Infinity` clamp to `+/-1e12`.
+
+This PR adds additional edge case tests to strengthen coverage for issue #1364.
+
+## Evidence
+
+This is a backend bug fix with no UI changes. The fix is verified by unit tests:
+
+```
+running 9 tests from ./test/propagate/LimitValue.ts
+limitValue - clamps positive values above 1e12 ... ok
+limitValue - clamps negative values below -1e12 ... ok
+limitValue - passes through normal values ... ok
+limitValue - clamps positive Infinity to 1e12 ... ok
+limitValue - clamps negative Infinity to -1e12 ... ok
+limitValue - converts NaN to 0 ... ok
+limitValue - converts computed NaN values to 0 ... ok
+limitValue - handles negative zero ... ok
+limitValue - passes through values just inside boundaries ... ok
+
+ok | 9 passed | 0 failed
+```
+
+Full quality gate passed: 2208 tests passed, 0 failed.
+
+## Test Plan
+
+- `test/propagate/LimitValue.ts` — 9 tests covering:
+  - Clamping positive/negative values above/below `+/-1e12`
+  - Pass-through of normal values including boundary values at exactly `+/-1e12`
+  - `Infinity` clamped to `1e12`
+  - `-Infinity` clamped to `-1e12`
+  - `NaN` converted to `0`
+  - Computed `NaN` values (`0/0`, `Infinity - Infinity`, `Infinity * 0`) converted to `0`
+  - Negative zero handled correctly
+  - Values just inside boundaries pass through unchanged

--- a/test/propagate/LimitValue.ts
+++ b/test/propagate/LimitValue.ts
@@ -38,3 +38,23 @@ Deno.test("limitValue - clamps negative Infinity to -1e12", () => {
 Deno.test("limitValue - converts NaN to 0", () => {
   assertEquals(limitValue(NaN), 0);
 });
+
+Deno.test("limitValue - converts computed NaN values to 0", () => {
+  // NaN can arise from various arithmetic operations
+  assertEquals(limitValue(0 / 0), 0);
+  assertEquals(limitValue(Infinity - Infinity), 0);
+  assertEquals(limitValue(Infinity * 0), 0);
+});
+
+Deno.test("limitValue - handles negative zero", () => {
+  // -0 is finite and within range, should pass through as a valid number
+  const result = limitValue(-0);
+  assertEquals(result, 0);
+});
+
+Deno.test("limitValue - passes through values just inside boundaries", () => {
+  const justUnder = 1e12 - 1;
+  const justOver = -1e12 + 1;
+  assertEquals(limitValue(justUnder), justUnder);
+  assertEquals(limitValue(justOver), justOver);
+});


### PR DESCRIPTION
## Summary

Fixed `limitValue()` in `src/propagate/BackPropagation.ts` to guard against
`NaN` and `Infinity` inputs. The function is called from `toValue()` after WASM
`unSquash` operations that could produce non-finite results. Previously, `NaN`
would pass through unchecked because `NaN > 1e12` and `NaN < -1e12` both
evaluate to `false`.

The fix (applied in #1363) uses `Number.isFinite()` to catch all non-finite
values upfront: `NaN` returns `0` (a safe neutral value), and
`Infinity`/`-Infinity` clamp to `+/-1e12`.

This PR adds additional edge case tests to strengthen coverage for issue #1364.

## Evidence

This is a backend bug fix with no UI changes. The fix is verified by unit tests:

```
running 9 tests from ./test/propagate/LimitValue.ts
limitValue - clamps positive values above 1e12 ... ok
limitValue - clamps negative values below -1e12 ... ok
limitValue - passes through normal values ... ok
limitValue - clamps positive Infinity to 1e12 ... ok
limitValue - clamps negative Infinity to -1e12 ... ok
limitValue - converts NaN to 0 ... ok
limitValue - converts computed NaN values to 0 ... ok
limitValue - handles negative zero ... ok
limitValue - passes through values just inside boundaries ... ok

ok | 9 passed | 0 failed
```

Full quality gate passed: 2208 tests passed, 0 failed.

## Test Plan

- `test/propagate/LimitValue.ts` — 9 tests covering:
  - Clamping positive/negative values above/below `+/-1e12`
  - Pass-through of normal values including boundary values at exactly `+/-1e12`
  - `Infinity` clamped to `1e12`
  - `-Infinity` clamped to `-1e12`
  - `NaN` converted to `0`
  - Computed `NaN` values (`0/0`, `Infinity - Infinity`, `Infinity * 0`)
    converted to `0`
  - Negative zero handled correctly
  - Values just inside boundaries pass through unchanged

---

## Automated Fix Details
This PR addresses issue #1364: **Bug: limitValue() does not guard against NaN inputs**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1364