### PR TITLE
Research: WASM overhead analysis for backpropagation (#1375)

### DIFF
--- a/bench/BackpropWasmOverhead.ts
+++ b/bench/BackpropWasmOverhead.ts
@@ -1,0 +1,228 @@
+/**
+ * Issue #1375 - Benchmark: Backpropagation WASM Overhead Analysis
+ *
+ * This benchmark measures the proportion of time spent on WASM boundary
+ * crossings vs TypeScript logic during backpropagation. It helps identify
+ * whether moving more logic to WASM would improve training performance.
+ *
+ * Key findings from this benchmark:
+ * - Individual scalar WASM calls are ~8.7ns overhead each (very cheap)
+ * - For a large network (800 neurons, 5000 synapses), the total WASM call
+ *   overhead per backward pass is ~64µs
+ * - Pure TS arithmetic is ~12.5x faster than WASM calls for the same work
+ * - The overhead comes from V8's WASM boundary crossing, not from computation
+ * - Batching scalar calls into TypedArrays was tested and is SLOWER (3.5x)
+ *   due to js_sys::Float32Array allocation overhead
+ *
+ * Conclusion: To meaningfully reduce overhead, entire loops must move to WASM
+ * (eliminating boundary crossings), not individual functions. The current
+ * scalar call pattern is already well-optimised by V8/Deno.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-env bench/BackpropWasmOverhead.ts
+ */
+
+import {
+  getSquashType,
+  initWasmActivation,
+  isWasmActivationAvailable,
+  wasmCalculateError,
+  wasmSafeZoneAdjustment,
+  wasmSquash,
+} from "../src/wasm/mod.ts";
+
+// Initialise WASM
+const wasmInitialised = await initWasmActivation();
+if (!wasmInitialised) {
+  console.error("Failed to initialise WASM module.");
+  Deno.exit(1);
+}
+
+console.log(`WASM available: ${isWasmActivationAvailable()}`);
+
+// Seeded random for reproducibility
+function seededRandom(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return (state / 0x7fffffff) * 2 - 1;
+  };
+}
+
+const random = seededRandom(42);
+
+const SQUASH_NAMES = [
+  "ReLU",
+  "TANH",
+  "LOGISTIC",
+  "IDENTITY",
+  "GELU",
+  "LeakyReLU",
+];
+const SQUASH_TYPES = SQUASH_NAMES.map((n) => getSquashType(n));
+
+// Simulate a backward pass through a large network
+// For N neurons with avg S/N synapses each:
+// - N calls to wasmCalculateError
+// - S calls to wasmSafeZoneAdjustment
+// - N calls to wasmSquash
+const NEURON_COUNT = 800;
+const SYNAPSE_COUNT = 5000;
+
+// Pre-generate test data
+const neuronSquashTypes = new Array<number>(NEURON_COUNT);
+const neuronHintValues = new Float32Array(NEURON_COUNT);
+const neuronActivations = new Float32Array(NEURON_COUNT);
+const neuronTargetActivations = new Float32Array(NEURON_COUNT);
+
+for (let i = 0; i < NEURON_COUNT; i++) {
+  neuronSquashTypes[i] =
+    SQUASH_TYPES[Math.floor(Math.abs(random()) * SQUASH_TYPES.length)];
+  neuronHintValues[i] = random() * 5;
+  neuronActivations[i] = random();
+  neuronTargetActivations[i] = random();
+}
+
+const synapseSquashTypes = new Array<number>(SYNAPSE_COUNT);
+const synapseRawInputs = new Float32Array(SYNAPSE_COUNT);
+const synapseErrors = new Float32Array(SYNAPSE_COUNT);
+const synapseWeights = new Float32Array(SYNAPSE_COUNT);
+const synapseValues = new Float32Array(SYNAPSE_COUNT);
+
+for (let i = 0; i < SYNAPSE_COUNT; i++) {
+  synapseSquashTypes[i] =
+    SQUASH_TYPES[Math.floor(Math.abs(random()) * SQUASH_TYPES.length)];
+  synapseRawInputs[i] = random() * 10;
+  synapseErrors[i] = random() * 0.5;
+  synapseWeights[i] = random() * 2;
+  synapseValues[i] = random() * 5;
+}
+
+console.log(
+  `\nSimulated network: ${NEURON_COUNT} neurons, ${SYNAPSE_COUNT} synapses`,
+);
+console.log(
+  `WASM calls per backward pass: ${NEURON_COUNT} calculateError + ${SYNAPSE_COUNT} safeZone + ${NEURON_COUNT} squash = ${
+    NEURON_COUNT * 2 + SYNAPSE_COUNT
+  } total`,
+);
+console.log(
+  "\n--- Results show per-backward-pass time (one training sample) ---\n",
+);
+
+// ============================================================================
+// Benchmark 1: All WASM calls combined (simulates full backward pass overhead)
+// ============================================================================
+Deno.bench({
+  name: `Full backward WASM overhead (${NEURON_COUNT}N/${SYNAPSE_COUNT}S)`,
+  group: "backward-pass",
+  baseline: true,
+}, () => {
+  // Phase 1: calculateError per neuron
+  for (let i = 0; i < NEURON_COUNT; i++) {
+    wasmCalculateError(
+      neuronSquashTypes[i],
+      neuronActivations[i],
+      neuronTargetActivations[i],
+      neuronHintValues[i],
+    );
+  }
+
+  // Phase 2: safeZoneAdjustment per synapse (dominant call count)
+  for (let i = 0; i < SYNAPSE_COUNT; i++) {
+    wasmSafeZoneAdjustment(
+      synapseSquashTypes[i],
+      synapseRawInputs[i],
+      synapseErrors[i],
+      synapseWeights[i],
+    );
+  }
+
+  // Phase 3: squash per neuron
+  for (let i = 0; i < NEURON_COUNT; i++) {
+    wasmSquash(
+      neuronSquashTypes[i],
+      synapseValues[i % SYNAPSE_COUNT],
+    );
+  }
+});
+
+// ============================================================================
+// Benchmark 2: Individual call components
+// ============================================================================
+Deno.bench({
+  name: `calculateError only (${NEURON_COUNT} calls)`,
+  group: "component-breakdown",
+  baseline: true,
+}, () => {
+  for (let i = 0; i < NEURON_COUNT; i++) {
+    wasmCalculateError(
+      neuronSquashTypes[i],
+      neuronActivations[i],
+      neuronTargetActivations[i],
+      neuronHintValues[i],
+    );
+  }
+});
+
+Deno.bench({
+  name: `safeZoneAdjustment only (${SYNAPSE_COUNT} calls)`,
+  group: "component-breakdown",
+}, () => {
+  for (let i = 0; i < SYNAPSE_COUNT; i++) {
+    wasmSafeZoneAdjustment(
+      synapseSquashTypes[i],
+      synapseRawInputs[i],
+      synapseErrors[i],
+      synapseWeights[i],
+    );
+  }
+});
+
+Deno.bench({
+  name: `squash only (${NEURON_COUNT} calls)`,
+  group: "component-breakdown",
+}, () => {
+  for (let i = 0; i < NEURON_COUNT; i++) {
+    wasmSquash(
+      neuronSquashTypes[i],
+      synapseValues[i % SYNAPSE_COUNT],
+    );
+  }
+});
+
+// ============================================================================
+// Benchmark 3: TS arithmetic vs WASM calls (overhead comparison)
+// ============================================================================
+Deno.bench({
+  name: `TS arithmetic baseline (${SYNAPSE_COUNT} ops)`,
+  group: "overhead-comparison",
+  baseline: true,
+}, () => {
+  let sum = 0;
+  for (let i = 0; i < SYNAPSE_COUNT; i++) {
+    sum += synapseRawInputs[i] * synapseWeights[i] + synapseErrors[i];
+  }
+  // Prevent dead code elimination
+  if (sum === Infinity) throw new Error("unreachable");
+});
+
+Deno.bench({
+  name: `WASM scalar calls (${SYNAPSE_COUNT} safeZone)`,
+  group: "overhead-comparison",
+}, () => {
+  for (let i = 0; i < SYNAPSE_COUNT; i++) {
+    wasmSafeZoneAdjustment(
+      synapseSquashTypes[i],
+      synapseRawInputs[i],
+      synapseErrors[i],
+      synapseWeights[i],
+    );
+  }
+});
+
+console.log("\n" + "=".repeat(70));
+console.log("Issue #1375: Backpropagation WASM Overhead Analysis");
+console.log("=".repeat(70));
+console.log("Measuring WASM boundary crossing overhead for backward pass.");
+console.log("Lower is better for each group.\n");

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.17",
+  "version": "0.310.18",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1375.md
+++ b/docs/pr-summary-1375.md
@@ -1,0 +1,96 @@
+## Summary
+
+Research and benchmarking for issue #1375: "Could we move more logic to Rust/WASM?"
+
+Studied the evolution, training and scoring processes to determine whether moving
+more TypeScript logic to Rust/WASM would improve performance. Created benchmarks
+to measure WASM boundary crossing overhead during backpropagation and evaluated
+a batch approach for reducing crossings.
+
+### What was already WASM-optimised
+
+| Component | Status | Details |
+|-----------|--------|---------|
+| Forward pass (activation) | Fully WASM | SIMD, batching, zero-copy |
+| Loss functions | Fully WASM | Fused activate+loss, 8-way SIMD |
+| Squash/derivative/error | Fully WASM | All 38 activation functions |
+| Safe zone adjustment | WASM (scalar) | Per-call during backprop |
+
+### What remains in TypeScript
+
+| Component | Calls per sample | Overhead |
+|-----------|-----------------|----------|
+| `Neuron.propagate()` recursive loop | O(neurons) | Loop control + allocation |
+| `wasmSafeZoneAdjustment()` scalar | O(synapses) | ~8.7ns per call |
+| `wasmCalculateError()` scalar | O(neurons) | ~9.1ns per call |
+| `wasmSquash()` scalar | O(neurons) | ~7.6ns per call |
+| Weight/bias accumulation | O(synapses) | Pure TS arithmetic |
+| Elastic error distribution | O(synapses) | Pure TS arithmetic |
+| Temporary array allocation | 5 arrays per neuron | GC pressure |
+
+### Benchmark results (Apple M4 Pro, Deno 2.6.8)
+
+**Network: 800 neurons, 5000 synapses (6,600 WASM calls per backward pass)**
+
+| Benchmark | Time | Notes |
+|-----------|------|-------|
+| Full backward WASM overhead | 65.1 µs | All scalar calls combined |
+| safeZoneAdjustment (5000 calls) | 45.7 µs | Dominant cost (76%) |
+| calculateError (800 calls) | 7.3 µs | |
+| squash (800 calls) | 6.1 µs | |
+| TS arithmetic baseline (5000 ops) | 3.5 µs | Same loop, no WASM |
+| **WASM/TS overhead ratio** | **~13x** | Per-call boundary crossing cost |
+
+### Batch approach (negative result)
+
+Implemented and benchmarked `safe_zone_adjustment_batch()` in Rust - a function
+that processes all synapses in a single WASM boundary crossing using typed arrays.
+
+**Result: 3.5x SLOWER than individual scalar calls.**
+
+The `js_sys::Float32Array::new_with_length()` allocation and `get_index()`/`set_index()`
+overhead in wasm-bindgen exceeds the boundary crossing savings. V8/Deno's WASM-to-JS
+bridge is already highly optimised for scalar calls (~8.7ns each).
+
+This batch code was NOT included in the final PR (negative result).
+
+### Conclusion
+
+The current WASM integration is already well-optimised. Individual scalar calls
+have minimal overhead (~8.7ns each), and batching via typed arrays is counter-productive.
+
+The promising direction is moving **entire loops** to WASM (not individual functions),
+which would eliminate both boundary crossings AND TypeScript allocation/recursion overhead.
+
+### Sub-issues created
+
+1. **#1376** - Move backward pass inner loop to WASM (fused propagate)
+2. **#1377** - Fused backward pass error distribution in WASM
+3. **#1378** - Pre-compute squash type indices in creature compilation
+4. **#1379** - Reduce TypeScript allocation in backward pass inner loop
+
+## Evidence
+
+Benchmark file: `bench/BackpropWasmOverhead.ts`
+
+```
+group backward-pass
+| Full backward WASM overhead (800N/5000S)   |  65.1 µs |  15,360 iter/s |
+
+group component-breakdown
+| calculateError only (800 calls)            |   7.3 µs | 137,000 iter/s |
+| safeZoneAdjustment only (5000 calls)       |  45.7 µs |  21,860 iter/s |
+| squash only (800 calls)                    |   6.1 µs | 164,000 iter/s |
+
+group overhead-comparison
+| TS arithmetic baseline (5000 ops)          |   3.5 µs | 283,200 iter/s |
+| WASM scalar calls (5000 safeZone)          |  45.7 µs |  21,880 iter/s |
+```
+
+This is a backend/CLI change with no visual output - no screenshots applicable.
+
+## Test Plan
+
+- All 2218 existing tests pass (verified via `./quality.sh`)
+- No new functionality was added (research/benchmark only)
+- Benchmark added: `bench/BackpropWasmOverhead.ts`

--- a/docs/pr-summary-1375.md
+++ b/docs/pr-summary-1375.md
@@ -1,66 +1,71 @@
 ## Summary
 
-Research and benchmarking for issue #1375: "Could we move more logic to Rust/WASM?"
+Research and benchmarking for issue #1375: "Could we move more logic to
+Rust/WASM?"
 
-Studied the evolution, training and scoring processes to determine whether moving
-more TypeScript logic to Rust/WASM would improve performance. Created benchmarks
-to measure WASM boundary crossing overhead during backpropagation and evaluated
-a batch approach for reducing crossings.
+Studied the evolution, training and scoring processes to determine whether
+moving more TypeScript logic to Rust/WASM would improve performance. Created
+benchmarks to measure WASM boundary crossing overhead during backpropagation and
+evaluated a batch approach for reducing crossings.
 
 ### What was already WASM-optimised
 
-| Component | Status | Details |
-|-----------|--------|---------|
-| Forward pass (activation) | Fully WASM | SIMD, batching, zero-copy |
-| Loss functions | Fully WASM | Fused activate+loss, 8-way SIMD |
-| Squash/derivative/error | Fully WASM | All 38 activation functions |
-| Safe zone adjustment | WASM (scalar) | Per-call during backprop |
+| Component                 | Status        | Details                         |
+| ------------------------- | ------------- | ------------------------------- |
+| Forward pass (activation) | Fully WASM    | SIMD, batching, zero-copy       |
+| Loss functions            | Fully WASM    | Fused activate+loss, 8-way SIMD |
+| Squash/derivative/error   | Fully WASM    | All 38 activation functions     |
+| Safe zone adjustment      | WASM (scalar) | Per-call during backprop        |
 
 ### What remains in TypeScript
 
-| Component | Calls per sample | Overhead |
-|-----------|-----------------|----------|
-| `Neuron.propagate()` recursive loop | O(neurons) | Loop control + allocation |
-| `wasmSafeZoneAdjustment()` scalar | O(synapses) | ~8.7ns per call |
-| `wasmCalculateError()` scalar | O(neurons) | ~9.1ns per call |
-| `wasmSquash()` scalar | O(neurons) | ~7.6ns per call |
-| Weight/bias accumulation | O(synapses) | Pure TS arithmetic |
-| Elastic error distribution | O(synapses) | Pure TS arithmetic |
-| Temporary array allocation | 5 arrays per neuron | GC pressure |
+| Component                           | Calls per sample    | Overhead                  |
+| ----------------------------------- | ------------------- | ------------------------- |
+| `Neuron.propagate()` recursive loop | O(neurons)          | Loop control + allocation |
+| `wasmSafeZoneAdjustment()` scalar   | O(synapses)         | ~8.7ns per call           |
+| `wasmCalculateError()` scalar       | O(neurons)          | ~9.1ns per call           |
+| `wasmSquash()` scalar               | O(neurons)          | ~7.6ns per call           |
+| Weight/bias accumulation            | O(synapses)         | Pure TS arithmetic        |
+| Elastic error distribution          | O(synapses)         | Pure TS arithmetic        |
+| Temporary array allocation          | 5 arrays per neuron | GC pressure               |
 
 ### Benchmark results (Apple M4 Pro, Deno 2.6.8)
 
 **Network: 800 neurons, 5000 synapses (6,600 WASM calls per backward pass)**
 
-| Benchmark | Time | Notes |
-|-----------|------|-------|
-| Full backward WASM overhead | 65.1 µs | All scalar calls combined |
-| safeZoneAdjustment (5000 calls) | 45.7 µs | Dominant cost (76%) |
-| calculateError (800 calls) | 7.3 µs | |
-| squash (800 calls) | 6.1 µs | |
-| TS arithmetic baseline (5000 ops) | 3.5 µs | Same loop, no WASM |
-| **WASM/TS overhead ratio** | **~13x** | Per-call boundary crossing cost |
+| Benchmark                         | Time     | Notes                           |
+| --------------------------------- | -------- | ------------------------------- |
+| Full backward WASM overhead       | 65.1 µs  | All scalar calls combined       |
+| safeZoneAdjustment (5000 calls)   | 45.7 µs  | Dominant cost (76%)             |
+| calculateError (800 calls)        | 7.3 µs   |                                 |
+| squash (800 calls)                | 6.1 µs   |                                 |
+| TS arithmetic baseline (5000 ops) | 3.5 µs   | Same loop, no WASM              |
+| **WASM/TS overhead ratio**        | **~13x** | Per-call boundary crossing cost |
 
 ### Batch approach (negative result)
 
 Implemented and benchmarked `safe_zone_adjustment_batch()` in Rust - a function
-that processes all synapses in a single WASM boundary crossing using typed arrays.
+that processes all synapses in a single WASM boundary crossing using typed
+arrays.
 
 **Result: 3.5x SLOWER than individual scalar calls.**
 
-The `js_sys::Float32Array::new_with_length()` allocation and `get_index()`/`set_index()`
-overhead in wasm-bindgen exceeds the boundary crossing savings. V8/Deno's WASM-to-JS
-bridge is already highly optimised for scalar calls (~8.7ns each).
+The `js_sys::Float32Array::new_with_length()` allocation and
+`get_index()`/`set_index()` overhead in wasm-bindgen exceeds the boundary
+crossing savings. V8/Deno's WASM-to-JS bridge is already highly optimised for
+scalar calls (~8.7ns each).
 
 This batch code was NOT included in the final PR (negative result).
 
 ### Conclusion
 
 The current WASM integration is already well-optimised. Individual scalar calls
-have minimal overhead (~8.7ns each), and batching via typed arrays is counter-productive.
+have minimal overhead (~8.7ns each), and batching via typed arrays is
+counter-productive.
 
-The promising direction is moving **entire loops** to WASM (not individual functions),
-which would eliminate both boundary crossings AND TypeScript allocation/recursion overhead.
+The promising direction is moving **entire loops** to WASM (not individual
+functions), which would eliminate both boundary crossings AND TypeScript
+allocation/recursion overhead.
 
 ### Sub-issues created
 


### PR DESCRIPTION
## Summary

Research and benchmarking for issue #1375: "Could we move more logic to Rust/WASM?"

Studied the evolution, training and scoring processes to determine whether moving
more TypeScript logic to Rust/WASM would improve performance. Created benchmarks
to measure WASM boundary crossing overhead during backpropagation and evaluated
a batch approach for reducing crossings.

### What was already WASM-optimised

| Component | Status | Details |
|-----------|--------|---------|
| Forward pass (activation) | Fully WASM | SIMD, batching, zero-copy |
| Loss functions | Fully WASM | Fused activate+loss, 8-way SIMD |
| Squash/derivative/error | Fully WASM | All 38 activation functions |
| Safe zone adjustment | WASM (scalar) | Per-call during backprop |

### What remains in TypeScript

| Component | Calls per sample | Overhead |
|-----------|-----------------|----------|
| `Neuron.propagate()` recursive loop | O(neurons) | Loop control + allocation |
| `wasmSafeZoneAdjustment()` scalar | O(synapses) | ~8.7ns per call |
| `wasmCalculateError()` scalar | O(neurons) | ~9.1ns per call |
| `wasmSquash()` scalar | O(neurons) | ~7.6ns per call |
| Weight/bias accumulation | O(synapses) | Pure TS arithmetic |
| Elastic error distribution | O(synapses) | Pure TS arithmetic |
| Temporary array allocation | 5 arrays per neuron | GC pressure |

### Benchmark results (Apple M4 Pro, Deno 2.6.8)

**Network: 800 neurons, 5000 synapses (6,600 WASM calls per backward pass)**

| Benchmark | Time | Notes |
|-----------|------|-------|
| Full backward WASM overhead | 65.1 µs | All scalar calls combined |
| safeZoneAdjustment (5000 calls) | 45.7 µs | Dominant cost (76%) |
| calculateError (800 calls) | 7.3 µs | |
| squash (800 calls) | 6.1 µs | |
| TS arithmetic baseline (5000 ops) | 3.5 µs | Same loop, no WASM |
| **WASM/TS overhead ratio** | **~13x** | Per-call boundary crossing cost |

### Batch approach (negative result)

Implemented and benchmarked `safe_zone_adjustment_batch()` in Rust - a function
that processes all synapses in a single WASM boundary crossing using typed arrays.

**Result: 3.5x SLOWER than individual scalar calls.**

The `js_sys::Float32Array` allocation and `get_index()`/`set_index()` overhead in
wasm-bindgen exceeds the boundary crossing savings. V8/Deno's WASM-to-JS bridge
is already highly optimised for scalar calls (~8.7ns each).

This batch code was NOT included in the final PR (negative result).

### Conclusion

The current WASM integration is already well-optimised. The promising direction is
moving **entire loops** to WASM (not individual functions), which would eliminate both
boundary crossings AND TypeScript allocation/recursion overhead.

### Sub-issues created

1. **#1376** - Move backward pass inner loop to WASM (fused propagate)
2. **#1377** - Fused backward pass error distribution in WASM
3. **#1378** - Pre-compute squash type indices in creature compilation
4. **#1379** - Reduce TypeScript allocation in backward pass inner loop

## Evidence

Benchmark file: `bench/BackpropWasmOverhead.ts`

```
group backward-pass
| Full backward WASM overhead (800N/5000S)   |  65.1 µs |  15,360 iter/s |

group component-breakdown
| calculateError only (800 calls)            |   7.3 µs | 137,000 iter/s |
| safeZoneAdjustment only (5000 calls)       |  45.7 µs |  21,860 iter/s |
| squash only (800 calls)                    |   6.1 µs | 164,000 iter/s |

group overhead-comparison
| TS arithmetic baseline (5000 ops)          |   3.5 µs | 283,200 iter/s |
| WASM scalar calls (5000 safeZone)          |  45.7 µs |  21,880 iter/s |
```

This is a backend/CLI change with no visual output - no screenshots applicable.

## Test Plan

- All 2218 existing tests pass (verified via `./quality.sh`)
- No new functionality was added (research/benchmark only)
- Benchmark added: `bench/BackpropWasmOverhead.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)