### PR TITLE
Fix: Performance: Reduce TypeScript allocation in backward pass inner loop (#1379)

### DIFF
--- a/bench/BackpropAllocation.ts
+++ b/bench/BackpropAllocation.ts
@@ -1,0 +1,203 @@
+/**
+ * Issue #1379 - Benchmark: Backward pass TypeScript allocation overhead
+ *
+ * Measures the cost of allocating temporary arrays in the backward pass inner
+ * loop vs reusing pre-allocated buffers. The backward pass allocates 8 arrays
+ * per neuron per training sample; for a network with 800 neurons this creates
+ * ~6400 temporary arrays per sample.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-env bench/BackpropAllocation.ts
+ */
+
+import {
+  getSquashType,
+  initWasmActivation,
+  isWasmActivationAvailable,
+} from "../src/wasm/mod.ts";
+import { wasmFusedErrorDistribution } from "../src/wasm/WasmActivation.ts";
+import { BackpropBuffers } from "../src/propagate/BackpropBuffers.ts";
+
+// Initialise WASM
+const wasmInitialised = await initWasmActivation();
+if (!wasmInitialised) {
+  console.error("Failed to initialise WASM module.");
+  Deno.exit(1);
+}
+
+console.log(`WASM available: ${isWasmActivationAvailable()}`);
+
+// Seeded random for reproducibility
+function seededRandom(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return (state / 0x7fffffff) * 2 - 1;
+  };
+}
+
+const random = seededRandom(42);
+
+const SQUASH_NAMES = [
+  "ReLU",
+  "TANH",
+  "LOGISTIC",
+  "IDENTITY",
+  "GELU",
+  "LeakyReLU",
+];
+const SQUASH_TYPES = SQUASH_NAMES.map((n) => getSquashType(n));
+
+// ============================================================================
+// Simulate a full backward pass through a realistic network.
+// For each neuron we allocate 8 scratch arrays, populate them, then call
+// the fused WASM function.  This captures the allocation pattern from
+// Neuron.propagate() lines 663-671.
+// ============================================================================
+
+const NEURON_COUNT = 800;
+const MAX_INWARD = 20; // realistic max inward connections per neuron
+
+// Pre-generate per-neuron inward connection counts (variable lengths)
+const inwardCounts = new Array<number>(NEURON_COUNT);
+for (let i = 0; i < NEURON_COUNT; i++) {
+  inwardCounts[i] = Math.max(1, Math.floor(Math.abs(random()) * MAX_INWARD));
+}
+
+// Pre-generate upstream data for every synapse of every neuron
+const neuronSquashType = SQUASH_TYPES[0]; // ReLU for each neuron
+const neuronActivation = 0.5;
+const neuronTarget = 0.8;
+const neuronHint = 0.3;
+
+const allUpstreamSquash: number[][] = [];
+const allUpstreamHint: number[][] = [];
+const allUpstreamActivation: number[][] = [];
+const allUpstreamWeight: number[][] = [];
+
+for (let n = 0; n < NEURON_COUNT; n++) {
+  const len = inwardCounts[n];
+  const sq = new Array<number>(len);
+  const hi = new Array<number>(len);
+  const ac = new Array<number>(len);
+  const we = new Array<number>(len);
+  for (let i = 0; i < len; i++) {
+    sq[i] = SQUASH_TYPES[Math.floor(Math.abs(random()) * SQUASH_TYPES.length)];
+    hi[i] = random() * 5;
+    ac[i] = random();
+    we[i] = random() * 2;
+  }
+  allUpstreamSquash.push(sq);
+  allUpstreamHint.push(hi);
+  allUpstreamActivation.push(ac);
+  allUpstreamWeight.push(we);
+}
+
+// ============================================================================
+// Baseline: allocate fresh arrays per neuron (current code path)
+// ============================================================================
+Deno.bench({
+  name: `Fresh allocation per neuron (${NEURON_COUNT}N)`,
+  group: "backprop-allocation",
+  baseline: true,
+}, () => {
+  for (let n = 0; n < NEURON_COUNT; n++) {
+    const len = inwardCounts[n];
+
+    // Allocate 8 arrays (mirrors Neuron.propagate lines 663-671)
+    const fromActivationCache = new Array<number>(len);
+    const fromWeightCache = new Array<number>(len);
+    const fromValueCache = new Array<number>(len);
+    const safeZoneFactorCache = new Array<number>(len);
+
+    const fusedSquashTypes = new Uint8Array(len);
+    const fusedHintValues = new Float32Array(len);
+    const fusedActivations = new Float32Array(len);
+    const fusedWeights = new Float32Array(len);
+
+    // Populate (mirrors the cache-filling loop)
+    const srcSq = allUpstreamSquash[n];
+    const srcHi = allUpstreamHint[n];
+    const srcAc = allUpstreamActivation[n];
+    const srcWe = allUpstreamWeight[n];
+    for (let i = 0; i < len; i++) {
+      fromActivationCache[i] = srcAc[i];
+      fromWeightCache[i] = srcWe[i];
+      fromValueCache[i] = srcAc[i] * srcWe[i];
+      safeZoneFactorCache[i] = 1;
+      fusedSquashTypes[i] = srcSq[i];
+      fusedHintValues[i] = srcHi[i];
+      fusedActivations[i] = srcAc[i];
+      fusedWeights[i] = srcWe[i];
+    }
+
+    // Call fused WASM (mirrors the actual computation)
+    wasmFusedErrorDistribution(
+      neuronSquashType,
+      neuronActivation,
+      neuronTarget,
+      neuronHint,
+      fusedSquashTypes,
+      fusedHintValues,
+      fusedActivations,
+      fusedWeights,
+    );
+  }
+});
+
+// ============================================================================
+// Optimised: reuse pre-allocated buffers via BackpropBuffers
+// ============================================================================
+const buffers = new BackpropBuffers(MAX_INWARD);
+
+Deno.bench({
+  name: `Reused buffers per neuron (${NEURON_COUNT}N)`,
+  group: "backprop-allocation",
+}, () => {
+  for (let n = 0; n < NEURON_COUNT; n++) {
+    const len = inwardCounts[n];
+
+    const buf = buffers.acquire(len);
+
+    // Populate (identical logic)
+    const srcSq = allUpstreamSquash[n];
+    const srcHi = allUpstreamHint[n];
+    const srcAc = allUpstreamActivation[n];
+    const srcWe = allUpstreamWeight[n];
+    for (let i = 0; i < len; i++) {
+      buf.fromActivationCache[i] = srcAc[i];
+      buf.fromWeightCache[i] = srcWe[i];
+      buf.fromValueCache[i] = srcAc[i] * srcWe[i];
+      buf.safeZoneFactorCache[i] = 1;
+      buf.fusedSquashTypes[i] = srcSq[i];
+      buf.fusedHintValues[i] = srcHi[i];
+      buf.fusedActivations[i] = srcAc[i];
+      buf.fusedWeights[i] = srcWe[i];
+    }
+
+    // Call fused WASM (mirrors the actual computation)
+    wasmFusedErrorDistribution(
+      neuronSquashType,
+      neuronActivation,
+      neuronTarget,
+      neuronHint,
+      buf.fusedSquashTypes.subarray(0, len),
+      buf.fusedHintValues.subarray(0, len),
+      buf.fusedActivations.subarray(0, len),
+      buf.fusedWeights.subarray(0, len),
+    );
+
+    buffers.release(buf);
+  }
+});
+
+console.log("\n" + "=".repeat(70));
+console.log("Issue #1379: Backward pass TypeScript allocation overhead");
+console.log("=".repeat(70));
+console.log(
+  `Simulated ${NEURON_COUNT} neurons, max ${MAX_INWARD} inward connections.`,
+);
+console.log(
+  "Baseline allocates 8 fresh arrays per neuron; optimised reuses pre-allocated buffers.",
+);
+console.log("Lower is better.\n");

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.21",
+  "version": "0.310.22",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1379.md
+++ b/docs/pr-summary-1379.md
@@ -1,0 +1,71 @@
+## Summary
+
+Reduced TypeScript allocation pressure in the backward pass inner loop by
+introducing a stack-based pool of reusable buffer sets (`BackpropBuffers`).
+Previously, `Neuron.propagate()` allocated 8 fresh arrays per neuron per
+training sample. For a network with 800 neurons this created ~6400 short-lived
+arrays per sample, putting pressure on the garbage collector.
+
+The new `BackpropBuffers` class manages a pool of buffer sets that are acquired
+at the start of each `propagate()` call and released at the end. Since
+`propagate()` is recursive (depth-first backward pass), each recursion level
+gets its own buffer set from the pool. Buffers grow on demand and are reused
+across neurons and training samples. Closes #1379.
+
+## Evidence
+
+Benchmark results (Apple M4 Pro, Deno 2.6.8):
+
+```
+group backprop-allocation
+| Fresh allocation per neuron (800N)   |  711.5 µs |  1,406 iter/s |
+| Reused buffers per neuron (800N)     |  448.1 µs |  2,231 iter/s |
+
+summary
+  Fresh allocation per neuron (800N)
+     1.59x slower than Reused buffers per neuron (800N)
+```
+
+Second run confirms consistency:
+
+```
+group backprop-allocation
+| Fresh allocation per neuron (800N)   |  689.3 µs |  1,451 iter/s |
+| Reused buffers per neuron (800N)     |  448.3 µs |  2,231 iter/s |
+
+summary
+  Fresh allocation per neuron (800N)
+     1.54x slower than Reused buffers per neuron (800N)
+```
+
+**Result: 1.54x-1.59x faster** (37% reduction in per-backward-pass time).
+
+## Changes
+
+- **`src/propagate/BackpropBuffers.ts`** (new): Stack-based pool of reusable
+  `BackpropBufferSet` objects containing 4 `number[]` arrays and 4 typed arrays.
+- **`src/architecture/CreatureState.ts`**: Added optional `backpropBuffers` field,
+  lazily initialised to avoid overhead for evaluation-only creatures.
+- **`src/Creature.ts`**: Lazily initialises `backpropBuffers` on first
+  `propagate()` call.
+- **`src/architecture/Neuron.ts`**: Replaced 8 `new Array`/`new TypedArray`
+  allocations with `backpropBuffers.acquire()`/`release()`. Uses `subarray()`
+  views for WASM calls since buffers may be larger than `listLength`.
+- **`bench/BackpropAllocation.ts`** (new): Benchmark comparing fresh allocation
+  vs reused buffers across 800 neurons.
+
+## Test Plan
+
+- Added `test/propagate/BackpropBuffers.ts` (7 tests):
+  - Acquire returns buffer with sufficient capacity
+  - Released buffer is reused by next acquire
+  - Acquire without release gives distinct buffers (stack semantics)
+  - Grows capacity when larger buffer needed
+  - Zero initial capacity works
+  - Stack semantics for recursive use
+  - Typed array subarray works for WASM views
+- Added `test/propagate/BackpropBufferIntegration.ts` (3 tests):
+  - Multi-level training produces correct results with buffer reuse
+  - Wider network training exercises variable-length buffer acquisition
+  - `backpropBuffers` field initialised on first propagate
+- All 2250 existing tests continue to pass

--- a/docs/pr-summary-1379.md
+++ b/docs/pr-summary-1379.md
@@ -44,8 +44,8 @@ summary
 
 - **`src/propagate/BackpropBuffers.ts`** (new): Stack-based pool of reusable
   `BackpropBufferSet` objects containing 4 `number[]` arrays and 4 typed arrays.
-- **`src/architecture/CreatureState.ts`**: Added optional `backpropBuffers` field,
-  lazily initialised to avoid overhead for evaluation-only creatures.
+- **`src/architecture/CreatureState.ts`**: Added optional `backpropBuffers`
+  field, lazily initialised to avoid overhead for evaluation-only creatures.
 - **`src/Creature.ts`**: Lazily initialises `backpropBuffers` on first
   `propagate()` call.
 - **`src/architecture/Neuron.ts`**: Replaced 8 `new Array`/`new TypedArray`

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -40,6 +40,7 @@ import {
   type BackPropagationConfig,
   createBackPropagationConfig,
 } from "./propagate/BackPropagation.ts";
+import { BackpropBuffers } from "./propagate/BackpropBuffers.ts";
 import { buildOutgoingSynapsesMap } from "./propagate/sparse/CalculatePathsToOutput.ts";
 import { SparseConfig } from "./propagate/sparse/SparseConfig.ts";
 import { upgradeOne } from "./upgrade/UpgradeOne.ts";
@@ -1685,6 +1686,11 @@ export class Creature implements CreatureInternal {
     sparseConfig: SparseConfig,
   ) {
     this.state.cacheAdjustedActivation.clear();
+
+    // Issue #1379: Lazily initialise reusable backward pass buffers.
+    if (this.state.backpropBuffers === undefined) {
+      this.state.backpropBuffers = new BackpropBuffers();
+    }
 
     const neurons = this.neurons;
     const lastOutputIndx = neurons.length - this.output;

--- a/src/architecture/CreatureState.ts
+++ b/src/architecture/CreatureState.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import type { Creature } from "../Creature.ts";
+import type { BackpropBuffers } from "../propagate/BackpropBuffers.ts";
 import { SynapseState } from "../propagate/SynapseState.ts";
 import { DenseNumberMap } from "./DenseNumberMap.ts";
 
@@ -81,6 +82,12 @@ export class CreatureState {
    * Issue #1041: Use TypedArray for dense neuron state storage.
    */
   readonly cacheAdjustedActivation: DenseNumberMap;
+  /**
+   * Issue #1379: Pre-allocated reusable buffers for backward pass.
+   * Lazily initialised on first backward pass to avoid overhead for
+   * creatures that are only used for forward activation (evaluation).
+   */
+  backpropBuffers?: BackpropBuffers;
   public preparedNeurons = false;
 
   constructor(creature: Creature) {

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -660,15 +660,20 @@ export class Neuron implements TagsInterface, NeuronInternal {
         // use values that produce correct behaviour in the fused function:
         // - Self-loops: activation=0 → elastic score=0 (excluded from distribution)
         // - Input/constant: squash=Identity → safeZone=1 (fully safe)
-        const fromActivationCache = new Array<number>(listLength);
-        const fromWeightCache = new Array<number>(listLength);
-        const fromValueCache = new Array<number>(listLength);
-        const safeZoneFactorCache = new Array<number>(listLength);
 
-        const fusedSquashTypes = new Uint8Array(listLength);
-        const fusedHintValues = new Float32Array(listLength);
-        const fusedActivations = new Float32Array(listLength);
-        const fusedWeights = new Float32Array(listLength);
+        // Issue #1379: Acquire reusable buffers instead of allocating fresh
+        // arrays. The pool is stack-based so recursive propagate() calls each
+        // get their own set.
+        const backpropBuffers = state.backpropBuffers!;
+        const buf = backpropBuffers.acquire(listLength);
+        const fromActivationCache = buf.fromActivationCache;
+        const fromWeightCache = buf.fromWeightCache;
+        const fromValueCache = buf.fromValueCache;
+        const safeZoneFactorCache = buf.safeZoneFactorCache;
+        const fusedSquashTypes = buf.fusedSquashTypes;
+        const fusedHintValues = buf.fusedHintValues;
+        const fusedActivations = buf.fusedActivations;
+        const fusedWeights = buf.fusedWeights;
 
         for (let indx = 0; indx < listLength; indx++) {
           const c = inwardList[indx];
@@ -716,15 +721,17 @@ export class Neuron implements TagsInterface, NeuronInternal {
 
         // Single fused WASM call: calculateError + safeZoneAdjustment + elastic
         // Issue #1378: Use pre-computed cached squash type
+        // Issue #1379: Pass correctly-sized views since buffers may be
+        // larger than listLength.
         const fusedResult = fusedErrorDistribution(
           this.cachedSquashType(),
           activation,
           targetActivation,
           ns.hintValue,
-          fusedSquashTypes,
-          fusedHintValues,
-          fusedActivations,
-          fusedWeights,
+          fusedSquashTypes.subarray(0, listLength),
+          fusedHintValues.subarray(0, listLength),
+          fusedActivations.subarray(0, listLength),
+          fusedWeights.subarray(0, listLength),
         );
 
         const error = fusedResult.error;
@@ -839,6 +846,10 @@ export class Neuron implements TagsInterface, NeuronInternal {
             improvedValue += improvedFromValue;
           }
         }
+
+        // Issue #1379: Return buffers to the pool for reuse by subsequent
+        // neurons or future training samples.
+        backpropBuffers.release(buf);
       }
 
       if (updateNeeded) {

--- a/src/propagate/BackpropBuffers.ts
+++ b/src/propagate/BackpropBuffers.ts
@@ -1,0 +1,106 @@
+/**
+ * Issue #1379 - Pre-allocated reusable buffers for backward pass.
+ *
+ * The backward pass in Neuron.propagate() allocates 8 temporary arrays per
+ * neuron per training sample. For a network with 800 neurons this creates
+ * ~6400 short-lived arrays per sample, putting pressure on the GC.
+ *
+ * This class provides a stack-based pool of buffer sets that are reused across
+ * neurons. Because propagate() is recursive (neuron A's propagate calls
+ * neuron B's propagate), multiple buffer sets may be active simultaneously.
+ * The stack grows on demand to accommodate the recursion depth.
+ */
+
+/** A single set of scratch buffers for one propagate() invocation. */
+export interface BackpropBufferSet {
+  /** Cached upstream activations (JS number array for mixed reads). */
+  fromActivationCache: number[];
+  /** Cached synapse weights. */
+  fromWeightCache: number[];
+  /** Cached weight * activation products. */
+  fromValueCache: number[];
+  /** Safe zone factors extracted from fused WASM result. */
+  safeZoneFactorCache: number[];
+  /** Upstream squash type indices for WASM. */
+  fusedSquashTypes: Uint8Array;
+  /** Upstream pre-squash hint values for WASM. */
+  fusedHintValues: Float32Array;
+  /** Upstream activations for WASM. */
+  fusedActivations: Float32Array;
+  /** Synapse weights for WASM. */
+  fusedWeights: Float32Array;
+  /** Current allocated capacity. */
+  capacity: number;
+}
+
+/**
+ * Stack-based pool of reusable backward pass buffer sets.
+ *
+ * Usage:
+ *   const buf = buffers.acquire(listLength);
+ *   // ... use buf.fromActivationCache[0..listLength-1] etc. ...
+ *   buffers.release(buf);
+ *
+ * Buffers are not zeroed on acquire — callers must write before reading,
+ * which is already the case in the existing propagate() code.
+ */
+export class BackpropBuffers {
+  private pool: BackpropBufferSet[] = [];
+
+  /**
+   * @param initialCapacity - Initial buffer capacity (typically the maximum
+   *   inward connection count across all neurons in the creature).
+   */
+  constructor(private initialCapacity: number = 0) {}
+
+  /**
+   * Acquire a buffer set with at least `minLength` capacity.
+   * If the pool has a suitable set it is reused; otherwise a new one is
+   * allocated (or an existing one is grown).
+   */
+  acquire(minLength: number): BackpropBufferSet {
+    const buf = this.pool.pop();
+    if (buf !== undefined) {
+      if (buf.capacity >= minLength) {
+        return buf;
+      }
+      // Grow the existing set to accommodate the larger length.
+      return this.grow(buf, minLength);
+    }
+    // No pooled buffer — allocate a fresh set.
+    const cap = Math.max(minLength, this.initialCapacity);
+    return this.allocate(cap);
+  }
+
+  /** Return a buffer set to the pool for reuse. */
+  release(buf: BackpropBufferSet): void {
+    this.pool.push(buf);
+  }
+
+  private allocate(capacity: number): BackpropBufferSet {
+    return {
+      fromActivationCache: new Array<number>(capacity),
+      fromWeightCache: new Array<number>(capacity),
+      fromValueCache: new Array<number>(capacity),
+      safeZoneFactorCache: new Array<number>(capacity),
+      fusedSquashTypes: new Uint8Array(capacity),
+      fusedHintValues: new Float32Array(capacity),
+      fusedActivations: new Float32Array(capacity),
+      fusedWeights: new Float32Array(capacity),
+      capacity,
+    };
+  }
+
+  private grow(buf: BackpropBufferSet, newCapacity: number): BackpropBufferSet {
+    buf.fromActivationCache = new Array<number>(newCapacity);
+    buf.fromWeightCache = new Array<number>(newCapacity);
+    buf.fromValueCache = new Array<number>(newCapacity);
+    buf.safeZoneFactorCache = new Array<number>(newCapacity);
+    buf.fusedSquashTypes = new Uint8Array(newCapacity);
+    buf.fusedHintValues = new Float32Array(newCapacity);
+    buf.fusedActivations = new Float32Array(newCapacity);
+    buf.fusedWeights = new Float32Array(newCapacity);
+    buf.capacity = newCapacity;
+    return buf;
+  }
+}

--- a/test/propagate/BackpropBufferIntegration.ts
+++ b/test/propagate/BackpropBufferIntegration.ts
@@ -1,0 +1,181 @@
+import { assert, assertLess } from "@std/assert";
+import type { CreatureInternal } from "../../src/architecture/CreatureInterfaces.ts";
+import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
+import { Creature } from "../../src/Creature.ts";
+import { train } from "../TrainTestOnlyUtil.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/**
+ * Issue #1379 - Integration test verifying that backward pass training
+ * produces correct results when using pre-allocated reusable buffers.
+ *
+ * This test exercises the buffer pool through real multi-level propagation:
+ * recursive propagate() calls acquire their own buffer sets from the pool.
+ */
+Deno.test("BackpropBuffers - multi-level training produces correct results", async () => {
+  await initWasmForTests();
+
+  // 3-input, 2-hidden, 1-output network with multi-level backward pass
+  const creatureJson: CreatureInternal = {
+    neurons: [
+      { type: "hidden", index: 3, squash: "IDENTITY", bias: 0.1 },
+      { type: "hidden", index: 4, squash: "IDENTITY", bias: -0.1 },
+      { type: "output", index: 5, squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { from: 0, to: 3, weight: 1 },
+      { from: 1, to: 3, weight: 1 },
+      { from: 1, to: 4, weight: 1 },
+      { from: 2, to: 4, weight: 1 },
+      { from: 3, to: 5, weight: 0.5 },
+      { from: 4, to: 5, weight: -0.5 },
+    ],
+    input: 3,
+    output: 1,
+  };
+
+  // Target function: 0.5*(i0+i1+0.1) - 0.5*(i1+i2-0.1)
+  //                = 0.5*i0 - 0.5*i2 + 0.1
+  const dataSet: DataRecordInterface[] = [
+    {
+      input: new Float32Array([1, 0, 0]),
+      output: new Float32Array([0.6]),
+    },
+    {
+      input: new Float32Array([0, 0, 1]),
+      output: new Float32Array([-0.4]),
+    },
+    {
+      input: new Float32Array([1, 1, 1]),
+      output: new Float32Array([0.1]),
+    },
+    {
+      input: new Float32Array([0.5, -0.5, 0.5]),
+      output: new Float32Array([-0.15]),
+    },
+  ];
+
+  // Perturb weights slightly so training has something to learn
+  const json = Creature.fromJSON(creatureJson).exportJSON();
+  for (const s of json.synapses) {
+    s.weight += 0.02;
+  }
+  for (const n of json.neurons) {
+    n.bias = (n.bias ?? 0) + 0.01;
+  }
+
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+
+  const result = train(creature, dataSet, {
+    iterations: 100,
+    targetError: 0,
+  });
+
+  // Training should reduce error — backward pass with buffer reuse must
+  // produce the same learning behaviour as fresh allocations.
+  assertLess(result.error, 0.1, "Training should reduce error significantly");
+});
+
+Deno.test("BackpropBuffers - training with wider network exercises buffer reuse", async () => {
+  await initWasmForTests();
+
+  // Wider network: 4 inputs → 3 hidden → 2 outputs
+  // This creates multiple inward connections per neuron, exercising
+  // variable-length buffer acquisition.
+  const creatureJson: CreatureInternal = {
+    neurons: [
+      { type: "hidden", index: 4, squash: "IDENTITY", bias: 0 },
+      { type: "hidden", index: 5, squash: "IDENTITY", bias: 0 },
+      { type: "hidden", index: 6, squash: "IDENTITY", bias: 0 },
+      { type: "output", index: 7, squash: "IDENTITY", bias: 0 },
+      { type: "output", index: 8, squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { from: 0, to: 4, weight: 1 },
+      { from: 1, to: 4, weight: 0.5 },
+      { from: 1, to: 5, weight: 1 },
+      { from: 2, to: 5, weight: 0.5 },
+      { from: 2, to: 6, weight: 1 },
+      { from: 3, to: 6, weight: 0.5 },
+      { from: 4, to: 7, weight: 1 },
+      { from: 5, to: 7, weight: -1 },
+      { from: 5, to: 8, weight: 1 },
+      { from: 6, to: 8, weight: -1 },
+    ],
+    input: 4,
+    output: 2,
+  };
+
+  const dataSet: DataRecordInterface[] = [];
+  // Generate training data from the known network
+  const creature = Creature.fromJSON(creatureJson);
+  creature.validate();
+
+  for (let i = 0; i < 8; i++) {
+    const input = new Float32Array(4);
+    for (let j = 0; j < 4; j++) {
+      input[j] = Math.sin(i * 7 + j * 3) * 0.8;
+    }
+    const output = creature.activate(input);
+    dataSet.push({ input, output: new Float32Array(output) });
+  }
+
+  // Perturb and retrain
+  const json = creature.exportJSON();
+  for (const s of json.synapses) {
+    s.weight += 0.03;
+  }
+  for (const n of json.neurons) {
+    n.bias = (n.bias ?? 0) + 0.02;
+  }
+
+  const perturbedCreature = Creature.fromJSON(json);
+  perturbedCreature.validate();
+
+  const result = train(perturbedCreature, dataSet, {
+    iterations: 200,
+    targetError: 0,
+  });
+
+  assertLess(result.error, 0.1, "Wider network training should converge");
+});
+
+Deno.test("BackpropBuffers - backpropBuffers field initialised on first propagate", async () => {
+  await initWasmForTests();
+
+  const creatureJson: CreatureInternal = {
+    neurons: [
+      { type: "hidden", index: 2, squash: "IDENTITY", bias: 0 },
+      { type: "output", index: 3, squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1 },
+      { from: 1, to: 2, weight: 1 },
+      { from: 2, to: 3, weight: 1 },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  const creature = Creature.fromJSON(creatureJson);
+  creature.validate();
+
+  // Before training, backpropBuffers should not be initialised
+  assert(
+    creature.state.backpropBuffers === undefined,
+    "Buffers should not exist before training",
+  );
+
+  const dataSet: DataRecordInterface[] = [
+    { input: new Float32Array([1, 0]), output: new Float32Array([1.5]) },
+  ];
+
+  train(creature, dataSet, { iterations: 1, targetError: 0 });
+
+  // After training, backpropBuffers should be initialised
+  assert(
+    creature.state.backpropBuffers !== undefined,
+    "Buffers should exist after training",
+  );
+});

--- a/test/propagate/BackpropBuffers.ts
+++ b/test/propagate/BackpropBuffers.ts
@@ -1,0 +1,131 @@
+import {
+  assertAlmostEquals,
+  assertEquals,
+  assertGreaterOrEqual,
+} from "@std/assert";
+import {
+  BackpropBuffers,
+  type BackpropBufferSet,
+} from "../../src/propagate/BackpropBuffers.ts";
+
+Deno.test("BackpropBuffers - acquire returns buffer with sufficient capacity", () => {
+  const pool = new BackpropBuffers(10);
+  const buf = pool.acquire(5);
+
+  assertGreaterOrEqual(buf.capacity, 5);
+  assertGreaterOrEqual(buf.fromActivationCache.length, 5);
+  assertGreaterOrEqual(buf.fromWeightCache.length, 5);
+  assertGreaterOrEqual(buf.fromValueCache.length, 5);
+  assertGreaterOrEqual(buf.safeZoneFactorCache.length, 5);
+  assertGreaterOrEqual(buf.fusedSquashTypes.length, 5);
+  assertGreaterOrEqual(buf.fusedHintValues.length, 5);
+  assertGreaterOrEqual(buf.fusedActivations.length, 5);
+  assertGreaterOrEqual(buf.fusedWeights.length, 5);
+
+  pool.release(buf);
+});
+
+Deno.test("BackpropBuffers - released buffer is reused by next acquire", () => {
+  const pool = new BackpropBuffers(10);
+  const buf1 = pool.acquire(5);
+
+  // Write a marker value
+  buf1.fromActivationCache[0] = 42;
+  pool.release(buf1);
+
+  const buf2 = pool.acquire(5);
+
+  // Should be the same object (reused from pool)
+  assertEquals(buf2.fromActivationCache[0], 42);
+
+  pool.release(buf2);
+});
+
+Deno.test("BackpropBuffers - acquire without release gives distinct buffers", () => {
+  const pool = new BackpropBuffers(10);
+  const buf1 = pool.acquire(5);
+  const buf2 = pool.acquire(5);
+
+  // Different objects (stack-based: buf1 still in use)
+  buf1.fromActivationCache[0] = 1;
+  buf2.fromActivationCache[0] = 2;
+  assertEquals(buf1.fromActivationCache[0], 1);
+  assertEquals(buf2.fromActivationCache[0], 2);
+
+  pool.release(buf2);
+  pool.release(buf1);
+});
+
+Deno.test("BackpropBuffers - grows capacity when larger buffer needed", () => {
+  const pool = new BackpropBuffers(5);
+  const buf = pool.acquire(5);
+  pool.release(buf);
+
+  // Now request a larger buffer — should grow the pooled one
+  const buf2 = pool.acquire(20);
+  assertGreaterOrEqual(buf2.capacity, 20);
+  assertGreaterOrEqual(buf2.fromActivationCache.length, 20);
+  assertGreaterOrEqual(buf2.fusedSquashTypes.length, 20);
+
+  pool.release(buf2);
+});
+
+Deno.test("BackpropBuffers - zero initial capacity works", () => {
+  const pool = new BackpropBuffers();
+  const buf = pool.acquire(3);
+
+  assertGreaterOrEqual(buf.capacity, 3);
+  assertGreaterOrEqual(buf.fromActivationCache.length, 3);
+
+  pool.release(buf);
+});
+
+Deno.test("BackpropBuffers - stack semantics for recursive use", () => {
+  const pool = new BackpropBuffers(10);
+
+  // Simulate recursive propagation: acquire 3 levels deep, release in reverse
+  const buffers: BackpropBufferSet[] = [];
+  for (let depth = 0; depth < 3; depth++) {
+    const buf = pool.acquire(5);
+    buf.fromActivationCache[0] = depth;
+    buffers.push(buf);
+  }
+
+  // Each has its own data
+  for (let depth = 0; depth < 3; depth++) {
+    assertEquals(buffers[depth].fromActivationCache[0], depth);
+  }
+
+  // Release in reverse order (LIFO, like function returns)
+  for (let depth = 2; depth >= 0; depth--) {
+    pool.release(buffers[depth]);
+  }
+
+  // Re-acquire should reuse pooled buffers
+  const reacquired = pool.acquire(5);
+  assertGreaterOrEqual(reacquired.capacity, 5);
+  pool.release(reacquired);
+});
+
+Deno.test("BackpropBuffers - typed array subarray works for WASM views", () => {
+  const pool = new BackpropBuffers(20);
+  const buf = pool.acquire(10);
+
+  // Write data to first 5 elements
+  for (let i = 0; i < 5; i++) {
+    buf.fusedSquashTypes[i] = i + 1;
+    buf.fusedActivations[i] = (i + 1) * 0.1;
+  }
+
+  // subarray creates a view of the correct length
+  const squashView = buf.fusedSquashTypes.subarray(0, 5);
+  const activationView = buf.fusedActivations.subarray(0, 5);
+
+  assertEquals(squashView.length, 5);
+  assertEquals(activationView.length, 5);
+  assertEquals(squashView[0], 1);
+  assertEquals(squashView[4], 5);
+  assertAlmostEquals(activationView[0], 0.1, 1e-6);
+
+  pool.release(buf);
+});


### PR DESCRIPTION
## Summary

Reduced TypeScript allocation pressure in the backward pass inner loop by
introducing a stack-based pool of reusable buffer sets (`BackpropBuffers`).
Previously, `Neuron.propagate()` allocated 8 fresh arrays per neuron per
training sample. For a network with 800 neurons this created ~6400 short-lived
arrays per sample, putting pressure on the garbage collector.

The new `BackpropBuffers` class manages a pool of buffer sets that are acquired
at the start of each `propagate()` call and released at the end. Since
`propagate()` is recursive (depth-first backward pass), each recursion level
gets its own buffer set from the pool. Buffers grow on demand and are reused
across neurons and training samples. Closes #1379.

## Evidence

Benchmark results (Apple M4 Pro, Deno 2.6.8):

```
group backprop-allocation
| Fresh allocation per neuron (800N)   |  711.5 µs |  1,406 iter/s |
| Reused buffers per neuron (800N)     |  448.1 µs |  2,231 iter/s |

summary
  Fresh allocation per neuron (800N)
     1.59x slower than Reused buffers per neuron (800N)
```

Second run confirms consistency:

```
group backprop-allocation
| Fresh allocation per neuron (800N)   |  689.3 µs |  1,451 iter/s |
| Reused buffers per neuron (800N)     |  448.3 µs |  2,231 iter/s |

summary
  Fresh allocation per neuron (800N)
     1.54x slower than Reused buffers per neuron (800N)
```

**Result: 1.54x-1.59x faster** (37% reduction in per-backward-pass time).

## Changes

- **`src/propagate/BackpropBuffers.ts`** (new): Stack-based pool of reusable
  `BackpropBufferSet` objects containing 4 `number[]` arrays and 4 typed arrays.
- **`src/architecture/CreatureState.ts`**: Added optional `backpropBuffers`
  field, lazily initialised to avoid overhead for evaluation-only creatures.
- **`src/Creature.ts`**: Lazily initialises `backpropBuffers` on first
  `propagate()` call.
- **`src/architecture/Neuron.ts`**: Replaced 8 `new Array`/`new TypedArray`
  allocations with `backpropBuffers.acquire()`/`release()`. Uses `subarray()`
  views for WASM calls since buffers may be larger than `listLength`.
- **`bench/BackpropAllocation.ts`** (new): Benchmark comparing fresh allocation
  vs reused buffers across 800 neurons.

## Test Plan

- Added `test/propagate/BackpropBuffers.ts` (7 tests):
  - Acquire returns buffer with sufficient capacity
  - Released buffer is reused by next acquire
  - Acquire without release gives distinct buffers (stack semantics)
  - Grows capacity when larger buffer needed
  - Zero initial capacity works
  - Stack semantics for recursive use
  - Typed array subarray works for WASM views
- Added `test/propagate/BackpropBufferIntegration.ts` (3 tests):
  - Multi-level training produces correct results with buffer reuse
  - Wider network training exercises variable-length buffer acquisition
  - `backpropBuffers` field initialised on first propagate
- All 2250 existing tests continue to pass

---

## Automated Fix Details
This PR addresses issue #1379: **Performance: Reduce TypeScript allocation in backward pass inner loop**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1379