### PR TITLE
Backpropagation: Improve training with error-feedback learning rate, weight-based elastic fallback, and error-guided sparse selection (#1388)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.23",
+  "version": "0.310.24",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1388.md
+++ b/docs/pr-summary-1388.md
@@ -1,37 +1,58 @@
 ## Summary
 
-Three targeted improvements to the backpropagation training process. Closes #1388.
+Three targeted improvements to the backpropagation training process. Closes
+#1388.
 
 ### 1. Error-feedback adaptive learning rate
 
-The existing "adaptive" learning rate strategy was purely time-based — it used a slower decay with sinusoidal oscillation but never looked at actual training error. The comment in the code acknowledged: *"Could be enhanced to use actual error feedback in the future"*.
+The existing "adaptive" learning rate strategy was purely time-based — it used a
+slower decay with sinusoidal oscillation but never looked at actual training
+error. The comment in the code acknowledged: _"Could be enhanced to use actual
+error feedback in the future"_.
 
 Now the adaptive strategy uses real error feedback from the training loop:
-- **Error improving** (ratio < 0.95): slightly boost the rate (1.1x)
-- **Error stagnating** (ratio 0.95–1.0): increase the rate to escape the plateau (1.3x)
-- **Error worsening** (ratio > 1.0): reduce the rate proportionally (down to 0.5x)
 
-The fixed and decay strategies are unchanged. Backward compatible — works without error feedback.
+- **Error improving** (ratio < 0.95): slightly boost the rate (1.1x)
+- **Error stagnating** (ratio 0.95–1.0): increase the rate to escape the plateau
+  (1.3x)
+- **Error worsening** (ratio > 1.0): reduce the rate proportionally (down to
+  0.5x)
+
+The fixed and decay strategies are unchanged. Backward compatible — works
+without error feedback.
 
 ### 2. Weight-based elastic distribution fallback
 
-When all activations are near zero (common during early training), the elastic error distribution previously fell back to an equal split across all links. This ignores that links with larger weights carry more influence.
+When all activations are near zero (common during early training), the elastic
+error distribution previously fell back to an equal split across all links. This
+ignores that links with larger weights carry more influence.
 
-Now the fallback uses `weight²` scoring — matching the approach already used by record-time elasticity (`RecordElasticity.ts`). Links with larger weights absorb proportionally more error. Falls back to equal split only when both activations and weights are zero.
+Now the fallback uses `weight²` scoring — matching the approach already used by
+record-time elasticity (`RecordElasticity.ts`). Links with larger weights absorb
+proportionally more error. Falls back to equal split only when both activations
+and weights are zero.
 
 ### 3. Error-guided sparse neuron selection
 
-When sparse training is active (`sparseRatio < 1`), neurons were previously selected randomly via Fisher-Yates shuffle. The `totalErrorAbsolute` field was already being accumulated during propagation but never read.
+When sparse training is active (`sparseRatio < 1`), neurons were previously
+selected randomly via Fisher-Yates shuffle. The `totalErrorAbsolute` field was
+already being accumulated during propagation but never read.
 
-Now the accumulated per-neuron error data from the previous iteration is used to prioritise high-error neurons for training. This focuses training effort on neurons with the most room for improvement. Falls back to random selection when no error data is available (first iteration).
+Now the accumulated per-neuron error data from the previous iteration is used to
+prioritise high-error neurons for training. This focuses training effort on
+neurons with the most room for improvement. Falls back to random selection when
+no error data is available (first iteration).
 
 ## Evidence
 
-These are backend/algorithmic changes with no UI component. All 2271 tests pass including 16 new tests covering the three improvements. The `quality.sh` gate passes cleanly.
+These are backend/algorithmic changes with no UI component. All 2271 tests pass
+including 16 new tests covering the three improvements. The `quality.sh` gate
+passes cleanly.
 
 ## Test Plan
 
 ### New tests
+
 - `test/optimization/ErrorFeedbackLearningRate.ts` (5 tests):
   - Adaptive rate increases when error stagnates
   - Adaptive rate decreases when error worsens
@@ -53,4 +74,6 @@ These are backend/algorithmic changes with no UI component. All 2271 tests pass 
   - sparseRatio 1 returns all neurons regardless of errors
 
 ### Modified tests
-- `test/optimization/AdaptiveVsDecay.ts`: Updated oscillation test to verify error-feedback responsiveness instead of sinusoidal pattern
+
+- `test/optimization/AdaptiveVsDecay.ts`: Updated oscillation test to verify
+  error-feedback responsiveness instead of sinusoidal pattern

--- a/docs/pr-summary-1388.md
+++ b/docs/pr-summary-1388.md
@@ -1,0 +1,56 @@
+## Summary
+
+Three targeted improvements to the backpropagation training process. Closes #1388.
+
+### 1. Error-feedback adaptive learning rate
+
+The existing "adaptive" learning rate strategy was purely time-based — it used a slower decay with sinusoidal oscillation but never looked at actual training error. The comment in the code acknowledged: *"Could be enhanced to use actual error feedback in the future"*.
+
+Now the adaptive strategy uses real error feedback from the training loop:
+- **Error improving** (ratio < 0.95): slightly boost the rate (1.1x)
+- **Error stagnating** (ratio 0.95–1.0): increase the rate to escape the plateau (1.3x)
+- **Error worsening** (ratio > 1.0): reduce the rate proportionally (down to 0.5x)
+
+The fixed and decay strategies are unchanged. Backward compatible — works without error feedback.
+
+### 2. Weight-based elastic distribution fallback
+
+When all activations are near zero (common during early training), the elastic error distribution previously fell back to an equal split across all links. This ignores that links with larger weights carry more influence.
+
+Now the fallback uses `weight²` scoring — matching the approach already used by record-time elasticity (`RecordElasticity.ts`). Links with larger weights absorb proportionally more error. Falls back to equal split only when both activations and weights are zero.
+
+### 3. Error-guided sparse neuron selection
+
+When sparse training is active (`sparseRatio < 1`), neurons were previously selected randomly via Fisher-Yates shuffle. The `totalErrorAbsolute` field was already being accumulated during propagation but never read.
+
+Now the accumulated per-neuron error data from the previous iteration is used to prioritise high-error neurons for training. This focuses training effort on neurons with the most room for improvement. Falls back to random selection when no error data is available (first iteration).
+
+## Evidence
+
+These are backend/algorithmic changes with no UI component. All 2271 tests pass including 16 new tests covering the three improvements. The `quality.sh` gate passes cleanly.
+
+## Test Plan
+
+### New tests
+- `test/optimization/ErrorFeedbackLearningRate.ts` (5 tests):
+  - Adaptive rate increases when error stagnates
+  - Adaptive rate decreases when error worsens
+  - Fixed and decay strategies ignore error feedback
+  - Adaptive without error feedback still works (backward compatible)
+  - Adaptive rate stays within reasonable bounds
+- `test/propagate/WeightBasedElasticFallback.ts` (8 tests):
+  - Weight-based fallback prefers larger weights
+  - Equal weights give equal split
+  - Uses absolute weight value (negative weights)
+  - Falls back to equal split when no weight data
+  - Activation-based scoring takes priority over weight-based
+  - All zero weights fall back to equal split
+  - Backward compatibility without weight field
+  - Weight fallback with tiny activations below plankConstant
+- `test/propagate/sparse/ErrorGuidedChooseNeurons.ts` (3 tests):
+  - Error-guided selection prefers high-error neurons
+  - Works without neuron errors (backward compatible)
+  - sparseRatio 1 returns all neurons regardless of errors
+
+### Modified tests
+- `test/optimization/AdaptiveVsDecay.ts`: Updated oscillation test to verify error-feedback responsiveness instead of sinusoidal pattern

--- a/src/architecture/CreatureState.ts
+++ b/src/architecture/CreatureState.ts
@@ -146,6 +146,24 @@ export class CreatureState {
     return this.activations;
   }
 
+  /**
+   * Collects per-neuron error data for error-guided sparse selection.
+   * Returns a map from neuron UUID to NeuronStateInterface.
+   * Issue #1388: Error-guided sparse neuron selection.
+   */
+  collectNeuronErrors(): Map<string, NeuronStateInterface> {
+    const errors = new Map<string, NeuronStateInterface>();
+    for (const [indx, state] of this.nodeMap) {
+      if (state.totalErrorAbsolute > 0) {
+        const neuron = this.creature.neurons[indx];
+        if (neuron && neuron.uuid) {
+          errors.set(neuron.uuid, state);
+        }
+      }
+    }
+    return errors;
+  }
+
   clear() {
     this.preparedNeurons = false;
     this.nodeMap.clear();

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -764,12 +764,15 @@ export class Neuron implements TagsInterface, NeuronInternal {
         if (hasUsableSafeZone) {
           perLinkError = fusedResult.perLinkError;
         } else {
-          // Fallback: ignore safe zones, use activation² only
+          // Fallback: ignore safe zones, use activation² only.
+          // Include weight data for the weight-based fallback when activations
+          // are near zero (Issue #1388).
           const fallbackMeta = new Array(listLength);
           for (let i = 0; i < listLength; i++) {
             fallbackMeta[i] = {
               activation: fusedActivations[i],
               safeZoneFactor: 1,
+              weight: fromWeightCache[i],
             };
           }
           perLinkError = distributeElasticError(error, fallbackMeta, {

--- a/src/architecture/Training.ts
+++ b/src/architecture/Training.ts
@@ -9,6 +9,7 @@ import type { TrainOptions } from "../config/TrainOptions.ts";
 import {
   calculateLearningRate,
   createBackPropagationConfig,
+  type ErrorFeedback,
 } from "../propagate/BackPropagation.ts";
 import { buildOutgoingSynapsesMap } from "../propagate/sparse/CalculatePathsToOutput.ts";
 import { SparseConfig } from "../propagate/sparse/SparseConfig.ts";
@@ -174,6 +175,7 @@ function trainDirBinary(
   }
 
   let bestError: number | undefined = undefined;
+  let previousIterationError: number | undefined = undefined;
   let trainingFailures = 0;
   let bestCreatureJSON = creature.exportJSON();
   let bestTraceJSON = creature.traceJSON();
@@ -183,16 +185,23 @@ function trainDirBinary(
   // Issue #1294: Build outgoing synapse map once and cache it.
   // Map construction is O(synapses) and dominated calculatePathsToOutput cost.
   const outgoingSynapsesMap = buildOutgoingSynapsesMap(bestCreatureJSON);
-  const sparseConfig = new SparseConfig(
+  let sparseConfig = new SparseConfig(
     bestCreatureJSON,
     backPropConfig,
     outgoingSynapsesMap,
   );
 
   while (true) {
+    // Issue #1388: Pass error feedback to the adaptive learning rate strategy.
+    const errorFeedback: ErrorFeedback | undefined =
+      previousIterationError !== undefined && bestError !== undefined
+        ? { previousError: previousIterationError, currentError: bestError }
+        : undefined;
+
     const currentLearningRate = calculateLearningRate(
       backPropConfig,
       iteration,
+      errorFeedback,
     );
 
     iteration++;
@@ -371,6 +380,9 @@ function trainDirBinary(
       );
     }
 
+    // Issue #1388: Track error history for adaptive learning rate feedback.
+    previousIterationError = bestError;
+
     if (bestError !== undefined && bestError < error) {
       trainingFailures++;
       if (trainingStopped === false) {
@@ -396,6 +408,12 @@ function trainDirBinary(
       creature.loadFrom(bestCreatureJSON, false);
       lastTraceJSON = bestTraceJSON;
     } else {
+      // Issue #1388: Collect neuron error data before clearing state.
+      // This feeds into error-guided sparse neuron selection for the next iteration.
+      const neuronErrors = backPropConfig.sparseRatio < 1
+        ? creature.state.collectNeuronErrors()
+        : undefined;
+
       lastTraceJSON = creature.traceJSON();
       if (bestError === undefined || bestError > error) {
         bestTraceJSON = lastTraceJSON;
@@ -405,6 +423,17 @@ function trainDirBinary(
 
       creature.applyLearnings(iterationConfig, sparseConfig);
       creature.clearState();
+
+      // Issue #1388: Rebuild sparse config with error-guided neuron selection
+      // when sparse training is active and we have error data.
+      if (neuronErrors && neuronErrors.size > 0) {
+        sparseConfig = new SparseConfig(
+          bestCreatureJSON,
+          backPropConfig,
+          outgoingSynapsesMap,
+          neuronErrors,
+        );
+      }
     }
 
     if (timedOut || bestError <= targetError || iteration >= iterations) {

--- a/src/propagate/BackPropagation.ts
+++ b/src/propagate/BackPropagation.ts
@@ -150,9 +150,22 @@ export function createBackPropagationConfig(
   return Object.freeze(config);
 }
 
+/**
+ * Optional error feedback for the adaptive learning rate strategy.
+ * When provided, the adaptive strategy adjusts the learning rate based on
+ * whether training is improving, stagnating, or worsening.
+ */
+export interface ErrorFeedback {
+  /** Error from the previous iteration */
+  previousError: number;
+  /** Error from the current iteration */
+  currentError: number;
+}
+
 export function calculateLearningRate(
   config: BackPropagationConfig,
   iteration: number,
+  errorFeedback?: ErrorFeedback,
 ): number {
   switch (config.learningRateStrategy) {
     case "fixed":
@@ -161,23 +174,41 @@ export function calculateLearningRate(
       return config.initialLearningRate *
         Math.pow(config.learningRateDecay, iteration);
     case "adaptive": {
-      // Adaptive strategy: adjust learning rate based on training progress
-      // This is different from decay which only decreases over time
+      // Adaptive strategy: adjust learning rate based on actual error feedback.
+      // When error is improving => maintain the current rate.
+      // When error stagnates  => increase the rate to escape the plateau.
+      // When error worsens    => reduce the rate to avoid overshooting.
       const baseRate = config.initialLearningRate;
 
-      // For now, implement a simple adaptive strategy that:
-      // 1. Starts with initial learning rate
-      // 2. Decays more slowly than the decay strategy
-      // 3. Could be enhanced to use actual error feedback in the future
-
-      // Use a slower decay rate for adaptive strategy to allow oscillation to be visible
-      const adaptiveDecay = Math.sqrt(config.learningRateDecay); // Slower decay
+      // Apply a slower decay than the pure decay strategy
+      const adaptiveDecay = Math.sqrt(config.learningRateDecay);
       const adaptiveFactor = Math.pow(adaptiveDecay, iteration);
 
-      // Add significant variation to make it truly adaptive and non-monotonic
-      const variation = 1 + 0.3 * Math.sin(iteration * 0.8); // Larger oscillation
+      let errorAdjustment = 1;
+      if (
+        errorFeedback &&
+        Number.isFinite(errorFeedback.previousError) &&
+        Number.isFinite(errorFeedback.currentError) &&
+        errorFeedback.previousError > 0
+      ) {
+        // Ratio of current to previous error: <1 = improving, ~1 = stagnant, >1 = worsening
+        const errorRatio = errorFeedback.currentError /
+          errorFeedback.previousError;
 
-      return baseRate * adaptiveFactor * variation;
+        if (errorRatio < 0.95) {
+          // Good improvement: maintain or slightly boost the rate
+          errorAdjustment = 1.1;
+        } else if (errorRatio < 1.0) {
+          // Stagnation: increase rate to escape plateau
+          errorAdjustment = 1.3;
+        } else {
+          // Error worsened: reduce the rate to avoid overshooting.
+          // The worse the ratio, the more we reduce (down to 0.5x).
+          errorAdjustment = Math.max(0.5, 1.0 / errorRatio);
+        }
+      }
+
+      return baseRate * adaptiveFactor * errorAdjustment;
     }
     default:
       return config.learningRate;

--- a/src/propagate/ElasticDistribution.ts
+++ b/src/propagate/ElasticDistribution.ts
@@ -22,6 +22,8 @@
 export type ElasticLink = Readonly<{
   activation: number;
   safeZoneFactor: number;
+  /** Optional synapse weight, used for weight-based fallback when activations are near zero. */
+  weight?: number;
 }>;
 
 export function distributeElasticError(
@@ -54,8 +56,43 @@ export function distributeElasticError(
   }
 
   if (denom <= plankConstant) {
-    // Fallback: equal split. This keeps learning moving when activations are
-    // near zero and the minimum-change heuristic is underdetermined.
+    // Primary fallback: weight-based scoring (weight²).
+    // When activations are near zero the minimum-change heuristic is
+    // underdetermined. Links with larger weights carry more influence and
+    // should absorb proportionally more error — mirroring the record-time
+    // elasticity approach (RecordElasticity.ts uses weight²).
+    let weightDenom = 0;
+    const weightScores = new Array<number>(links.length);
+    for (let i = 0; i < links.length; i++) {
+      const w = (links[i] as { weight?: number }).weight;
+      const w2 = (w !== null && w !== undefined && Number.isFinite(w))
+        ? w * w
+        : 0;
+      weightScores[i] = w2;
+      weightDenom += w2;
+    }
+
+    if (weightDenom > plankConstant) {
+      const weightShares = new Array<number>(links.length);
+      let wSum = 0;
+      for (let i = 0; i < links.length; i++) {
+        const share = error * (weightScores[i] / weightDenom);
+        weightShares[i] = share;
+        wSum += share;
+      }
+      // Floating-point tidy-up
+      const wResidue = error - wSum;
+      if (Math.abs(wResidue) > plankConstant) {
+        let bestIdx = 0;
+        for (let i = 1; i < weightScores.length; i++) {
+          if (weightScores[i] > weightScores[bestIdx]) bestIdx = i;
+        }
+        weightShares[bestIdx] += wResidue;
+      }
+      return weightShares;
+    }
+
+    // Last resort: equal split when both activations and weights are zero.
     const per = error / links.length;
     return new Array(links.length).fill(per);
   }

--- a/src/propagate/sparse/ChooseNeurons.ts
+++ b/src/propagate/sparse/ChooseNeurons.ts
@@ -1,9 +1,23 @@
 import type { CreatureExport } from "../../architecture/CreatureInterfaces.ts";
+import type { NeuronStateInterface } from "../../architecture/CreatureState.ts";
 import type { BackPropagationConfig } from "../BackPropagation.ts";
 
+/**
+ * Selects neurons for sparse backpropagation training.
+ *
+ * When neuronErrors are provided (from a previous iteration), uses error-guided
+ * selection: neurons with higher accumulated error are prioritised, as they
+ * have the most room for improvement. Falls back to random selection when
+ * no error data is available.
+ *
+ * @param creature - The exported creature definition
+ * @param config - Backpropagation configuration (includes sparseRatio)
+ * @param neuronErrors - Optional per-neuron error data from previous iteration
+ */
 export function chooseNeurons(
   creature: CreatureExport,
   config: BackPropagationConfig,
+  neuronErrors?: ReadonlyMap<string, NeuronStateInterface>,
 ): Readonly<Set<string>> {
   // Handle the special case where sparseRatio is 1.
   if (config.sparseRatio === 1) {
@@ -28,16 +42,30 @@ export function chooseNeurons(
     Math.ceil(eligibleNeurons.length * config.sparseRatio),
   );
 
-  // Shuffle the eligible neurons to get random starting points.
-  fisherYatesShuffle(eligibleNeurons);
+  // Sort or shuffle eligible neurons based on error data availability.
+  if (neuronErrors && neuronErrors.size > 0) {
+    // Error-guided selection: sort by descending totalErrorAbsolute.
+    // Neurons with higher accumulated error are prioritised for training
+    // as they have the most room for improvement.
+    errorGuidedSort(eligibleNeurons, neuronErrors);
+  } else {
+    // No error data available: fall back to random selection.
+    fisherYatesShuffle(eligibleNeurons);
+  }
 
   // Set of chosen neurons and a queue to expand the cluster.
   const selectedNeurons = new Set<string>();
   const queue: string[] = [];
 
   // Select the initial neurons up to the required number.
+  const hasErrorData = neuronErrors !== undefined && neuronErrors.size > 0;
   for (let i = 0; i < numberOfNeuronsToSelect; i++) {
     const neuronUUID = eligibleNeurons[i].uuid;
+    // When error-guided, add directly to selectedNeurons to guarantee
+    // high-error neurons are included (they are sorted first).
+    if (hasErrorData) {
+      selectedNeurons.add(neuronUUID);
+    }
     queue.push(neuronUUID);
   }
 
@@ -72,6 +100,25 @@ export function chooseNeurons(
 
   // Freeze the set to make it immutable.
   return Object.freeze(selectedNeurons);
+}
+
+/**
+ * Sorts neurons by descending accumulated error, with randomisation among
+ * neurons that have similar error levels to maintain exploration diversity.
+ */
+function errorGuidedSort(
+  neurons: { uuid: string; type: string }[],
+  neuronErrors: ReadonlyMap<string, NeuronStateInterface>,
+): void {
+  // First shuffle to break ties randomly
+  fisherYatesShuffle(neurons);
+
+  // Then stable-sort by descending error (high error neurons first)
+  neurons.sort((a, b) => {
+    const errorA = neuronErrors.get(a.uuid)?.totalErrorAbsolute ?? 0;
+    const errorB = neuronErrors.get(b.uuid)?.totalErrorAbsolute ?? 0;
+    return errorB - errorA;
+  });
 }
 
 function fisherYatesShuffle<T>(array: T[]): void {

--- a/src/propagate/sparse/SparseConfig.ts
+++ b/src/propagate/sparse/SparseConfig.ts
@@ -1,4 +1,5 @@
 import type { CreatureExport } from "../../architecture/CreatureInterfaces.ts";
+import type { NeuronStateInterface } from "../../architecture/CreatureState.ts";
 import type { BackPropagationConfig } from "../BackPropagation.ts";
 import type { OutgoingSynapsesMap } from "./CalculatePathsToOutput.ts";
 import { calculatePathsToOutput } from "./CalculatePathsToOutput.ts";
@@ -14,13 +15,17 @@ export class SparseConfig {
    * @param outgoingSynapsesMap Optional pre-built outgoing synapse map.
    *   When supplied, avoids rebuilding the O(synapses) map internally.
    *   Issue #1294: Path-to-output caching for sparse training.
+   * @param neuronErrors Optional per-neuron error data from previous iteration.
+   *   When supplied, error-guided neuron selection prioritises high-error neurons.
+   *   Issue #1388: Error-guided sparse neuron selection.
    */
   constructor(
     creature: CreatureExport,
     config: BackPropagationConfig,
     outgoingSynapsesMap?: OutgoingSynapsesMap,
+    neuronErrors?: ReadonlyMap<string, NeuronStateInterface>,
   ) {
-    this.selectedNeurons = chooseNeurons(creature, config);
+    this.selectedNeurons = chooseNeurons(creature, config, neuronErrors);
     this.paths = calculatePathsToOutput(
       this.selectedNeurons,
       creature,

--- a/test/optimization/AdaptiveVsDecay.ts
+++ b/test/optimization/AdaptiveVsDecay.ts
@@ -45,35 +45,36 @@ Deno.test("optimization/AdaptiveVsDecay - should produce different learning rate
   );
 });
 
-Deno.test("optimization/AdaptiveVsDecay - adaptive should have oscillation pattern", () => {
+Deno.test("optimization/AdaptiveVsDecay - adaptive responds to error feedback", () => {
   const config = createBackPropagationConfig({
     learningRateStrategy: "adaptive",
     initialLearningRate: 0.1,
     learningRateDecay: 0.95,
   });
 
-  // Test that adaptive strategy has the expected oscillation pattern
-  const rates = [];
-  for (let i = 0; i < 10; i++) {
-    rates.push(calculateLearningRate(config, i));
-  }
+  // Without error feedback, adaptive uses slower decay (sqrt of decay rate)
+  const rateWithoutFeedback = calculateLearningRate(config, 5);
 
-  // Check that rates are not monotonically decreasing (unlike decay)
-  let isMonotonic = true;
-  for (let i = 1; i < rates.length; i++) {
-    if (rates[i] > rates[i - 1]) {
-      isMonotonic = false;
-      break;
-    }
-  }
+  // With stagnation feedback, rate should be higher (boosted to escape plateau)
+  const rateWithStagnation = calculateLearningRate(config, 5, {
+    previousError: 0.5,
+    currentError: 0.499,
+  });
 
-  // Adaptive strategy should NOT be monotonically decreasing due to oscillation
+  // With improvement feedback, rate should be maintained/slightly boosted
+  const rateWithImprovement = calculateLearningRate(config, 5, {
+    previousError: 0.5,
+    currentError: 0.3,
+  });
+
+  // Stagnation should produce a higher rate than improvement (to escape plateau)
   assert(
-    !isMonotonic,
-    "Adaptive strategy should not be monotonically decreasing due to oscillation pattern",
+    rateWithStagnation > rateWithImprovement,
+    `Stagnation rate (${rateWithStagnation}) should exceed improvement rate (${rateWithImprovement})`,
   );
 
-  console.log(
-    "✅ Adaptive strategy has oscillation pattern (not monotonically decreasing)",
-  );
+  // All rates should be positive
+  assert(rateWithoutFeedback > 0, "Rate without feedback should be positive");
+  assert(rateWithStagnation > 0, "Rate with stagnation should be positive");
+  assert(rateWithImprovement > 0, "Rate with improvement should be positive");
 });

--- a/test/optimization/ErrorFeedbackLearningRate.ts
+++ b/test/optimization/ErrorFeedbackLearningRate.ts
@@ -1,0 +1,127 @@
+import { assert, assertAlmostEquals } from "@std/assert";
+import {
+  calculateLearningRate,
+  createBackPropagationConfig,
+} from "../../src/propagate/BackPropagation.ts";
+
+Deno.test("optimization/ErrorFeedback - adaptive rate increases when error stagnates", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.95,
+  });
+
+  // Simulate stagnation: error barely changes across iterations
+  const stagnantRate = calculateLearningRate(config, 5, {
+    previousError: 0.5,
+    currentError: 0.499,
+  });
+
+  // Simulate improvement: error is decreasing noticeably
+  const improvingRate = calculateLearningRate(config, 5, {
+    previousError: 0.5,
+    currentError: 0.3,
+  });
+
+  // When stagnating, the learning rate should be higher to escape the plateau
+  assert(
+    stagnantRate > improvingRate,
+    `Stagnant rate (${stagnantRate}) should be > improving rate (${improvingRate})`,
+  );
+});
+
+Deno.test("optimization/ErrorFeedback - adaptive rate decreases when error increases", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.95,
+  });
+
+  // Error got worse: learning rate should decrease
+  const worseRate = calculateLearningRate(config, 5, {
+    previousError: 0.3,
+    currentError: 0.5,
+  });
+
+  // Error improved: learning rate should be maintained
+  const betterRate = calculateLearningRate(config, 5, {
+    previousError: 0.5,
+    currentError: 0.3,
+  });
+
+  assert(
+    worseRate < betterRate,
+    `Worsening rate (${worseRate}) should be < improving rate (${betterRate})`,
+  );
+});
+
+Deno.test("optimization/ErrorFeedback - fixed and decay strategies ignore error feedback", () => {
+  const fixedConfig = createBackPropagationConfig({
+    learningRateStrategy: "fixed",
+    learningRate: 0.05,
+  });
+
+  const decayConfig = createBackPropagationConfig({
+    learningRateStrategy: "decay",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.95,
+  });
+
+  // Fixed strategy should return the same rate regardless of error feedback
+  const fixedWithFeedback = calculateLearningRate(fixedConfig, 5, {
+    previousError: 0.5,
+    currentError: 0.3,
+  });
+  const fixedWithoutFeedback = calculateLearningRate(fixedConfig, 5);
+  assertAlmostEquals(fixedWithFeedback, fixedWithoutFeedback, 1e-12);
+
+  // Decay strategy should return the same rate regardless of error feedback
+  const decayWithFeedback = calculateLearningRate(decayConfig, 5, {
+    previousError: 0.5,
+    currentError: 0.3,
+  });
+  const decayWithoutFeedback = calculateLearningRate(decayConfig, 5);
+  assertAlmostEquals(decayWithFeedback, decayWithoutFeedback, 1e-12);
+});
+
+Deno.test("optimization/ErrorFeedback - adaptive without error feedback still works", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.95,
+  });
+
+  // Should not throw when called without error feedback (backwards compatible)
+  const rate = calculateLearningRate(config, 5);
+  assert(Number.isFinite(rate), "Rate should be finite");
+  assert(rate > 0, "Rate should be positive");
+});
+
+Deno.test("optimization/ErrorFeedback - adaptive rate stays within reasonable bounds", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.95,
+  });
+
+  // Even with extreme stagnation, rate should not exceed initial rate
+  const extremeStagnation = calculateLearningRate(config, 5, {
+    previousError: 0.5,
+    currentError: 0.4999999,
+  });
+
+  assert(
+    extremeStagnation <= config.initialLearningRate * 2,
+    `Rate (${extremeStagnation}) should not exceed 2x initial (${
+      config.initialLearningRate * 2
+    })`,
+  );
+  assert(extremeStagnation > 0, "Rate should be positive");
+
+  // Even with worsening error, rate should stay positive
+  const worseError = calculateLearningRate(config, 5, {
+    previousError: 0.1,
+    currentError: 0.9,
+  });
+  assert(worseError > 0, "Rate should be positive even when error worsens");
+});

--- a/test/propagate/WeightBasedElasticFallback.ts
+++ b/test/propagate/WeightBasedElasticFallback.ts
@@ -1,0 +1,111 @@
+import { assertAlmostEquals } from "@std/assert";
+import { distributeElasticError } from "../../src/propagate/ElasticDistribution.ts";
+
+Deno.test("distributeElasticError: weight-based fallback prefers larger weights when activations are zero", () => {
+  const error = 10;
+  // All activations zero, safe zones zero => fallback path
+  // But with weights provided, should use weight² scoring instead of equal split
+  const shares = distributeElasticError(error, [
+    { activation: 0, safeZoneFactor: 0, weight: 1 },
+    { activation: 0, safeZoneFactor: 0, weight: 3 },
+  ]);
+
+  // With weight-based fallback, scores are 1² and 3² = 1 and 9
+  // So shares should be 10 * 1/10 = 1 and 10 * 9/10 = 9
+  assertAlmostEquals(shares[0], 1, 1e-12);
+  assertAlmostEquals(shares[1], 9, 1e-12);
+  assertAlmostEquals(shares[0] + shares[1], error, 1e-12);
+});
+
+Deno.test("distributeElasticError: weight-based fallback with equal weights gives equal split", () => {
+  const error = 12;
+  const shares = distributeElasticError(error, [
+    { activation: 0, safeZoneFactor: 0, weight: 2 },
+    { activation: 0, safeZoneFactor: 0, weight: 2 },
+    { activation: 0, safeZoneFactor: 0, weight: 2 },
+  ]);
+
+  // Equal weights => equal shares
+  assertAlmostEquals(shares[0], 4, 1e-12);
+  assertAlmostEquals(shares[1], 4, 1e-12);
+  assertAlmostEquals(shares[2], 4, 1e-12);
+});
+
+Deno.test("distributeElasticError: weight-based fallback uses absolute weight", () => {
+  const error = 10;
+  // Negative weights should contribute same as positive (weight² is always positive)
+  const shares = distributeElasticError(error, [
+    { activation: 0, safeZoneFactor: 0, weight: -3 },
+    { activation: 0, safeZoneFactor: 0, weight: 1 },
+  ]);
+
+  // Scores: (-3)²=9 and 1²=1 => shares 9 and 1
+  assertAlmostEquals(shares[0], 9, 1e-12);
+  assertAlmostEquals(shares[1], 1, 1e-12);
+});
+
+Deno.test("distributeElasticError: falls back to equal split only when both activations and weights are zero", () => {
+  const error = 10;
+  // No weights provided (undefined) and activations are zero => true equal split
+  const shares = distributeElasticError(error, [
+    { activation: 0, safeZoneFactor: 0 },
+    { activation: 0, safeZoneFactor: 0 },
+  ]);
+
+  // Should still equal-split when no weight info available
+  assertAlmostEquals(shares[0], 5, 1e-12);
+  assertAlmostEquals(shares[1], 5, 1e-12);
+});
+
+Deno.test("distributeElasticError: activation-based scoring takes priority over weight-based", () => {
+  const error = 10;
+  // When activations are non-zero, activation² * safeZone should still be used
+  const shares = distributeElasticError(error, [
+    { activation: 1, safeZoneFactor: 1, weight: 10 },
+    { activation: 2, safeZoneFactor: 1, weight: 1 },
+  ]);
+
+  // Activation-based scores: 1²=1 and 2²=4
+  // Shares: 2 and 8 (weights are irrelevant since activations are available)
+  assertAlmostEquals(shares[0], 2, 1e-12);
+  assertAlmostEquals(shares[1], 8, 1e-12);
+});
+
+Deno.test("distributeElasticError: weight-based fallback with all zero weights falls back to equal split", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 0, safeZoneFactor: 0, weight: 0 },
+    { activation: 0, safeZoneFactor: 0, weight: 0 },
+  ]);
+
+  // All weights zero => true equal split (last resort)
+  assertAlmostEquals(shares[0], 5, 1e-12);
+  assertAlmostEquals(shares[1], 5, 1e-12);
+});
+
+Deno.test("distributeElasticError: preserves backward compatibility without weight field", () => {
+  // Existing tests should still pass - links without weight field
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 1, safeZoneFactor: 1 },
+    { activation: 2, safeZoneFactor: 1 },
+  ]);
+
+  assertAlmostEquals(shares[0], 2, 1e-12);
+  assertAlmostEquals(shares[1], 8, 1e-12);
+});
+
+Deno.test("distributeElasticError: weight fallback with tiny activations below plankConstant", () => {
+  const error = 6;
+  // Activations are tiny (below plankConstant) but safe zones are 1
+  // In this case activation² * safeZone will be tiny, triggering fallback
+  const shares = distributeElasticError(error, [
+    { activation: 1e-15, safeZoneFactor: 1, weight: 1 },
+    { activation: 1e-15, safeZoneFactor: 1, weight: 2 },
+  ], { plankConstant: 1e-12 });
+
+  // Activation scores are ~1e-30 (below plankConstant), so weight fallback kicks in
+  // Weight scores: 1²=1, 2²=4 => shares 6/5*1=1.2 and 6/5*4=4.8
+  assertAlmostEquals(shares[0], 1.2, 1e-12);
+  assertAlmostEquals(shares[1], 4.8, 1e-12);
+});

--- a/test/propagate/sparse/ErrorGuidedChooseNeurons.ts
+++ b/test/propagate/sparse/ErrorGuidedChooseNeurons.ts
@@ -1,0 +1,123 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../../src/Creature.ts";
+import { createBackPropagationConfig } from "../../../src/propagate/BackPropagation.ts";
+import { chooseNeurons } from "../../../src/propagate/sparse/ChooseNeurons.ts";
+import type { NeuronStateInterface } from "../../../src/architecture/CreatureState.ts";
+
+Deno.test("chooseNeurons: error-guided selection prefers high-error neurons", () => {
+  const creature = Creature.fromJSON(
+    JSON.parse(
+      Deno.readTextFileSync("test/propagate/large/creature.json"),
+    ),
+  );
+
+  const config = createBackPropagationConfig({
+    sparseRatio: 0.05,
+  });
+
+  const creatureJSON = creature.exportJSON();
+
+  // Build neuron error data: assign high error to a few specific neurons
+  const neuronErrors = new Map<string, NeuronStateInterface>();
+  const hiddenNeurons = creatureJSON.neurons.filter(
+    (n) => n.type === "hidden" || n.type === "output",
+  );
+
+  // Give a few neurons very high error
+  const highErrorUUIDs = new Set<string>();
+  for (let i = 0; i < Math.min(3, hiddenNeurons.length); i++) {
+    const uuid = hiddenNeurons[i].uuid;
+    highErrorUUIDs.add(uuid);
+    neuronErrors.set(uuid, {
+      count: 100,
+      totalBias: 0,
+      totalAdjustedBias: 0,
+      hintValue: 0,
+      maximumActivation: 1,
+      minimumActivation: -1,
+      totalErrorAbsolute: 1000, // Very high error
+    });
+  }
+
+  // Give remaining neurons very low error
+  for (let i = 3; i < hiddenNeurons.length; i++) {
+    const uuid = hiddenNeurons[i].uuid;
+    neuronErrors.set(uuid, {
+      count: 100,
+      totalBias: 0,
+      totalAdjustedBias: 0,
+      hintValue: 0,
+      maximumActivation: 1,
+      minimumActivation: -1,
+      totalErrorAbsolute: 0.001, // Very low error
+    });
+  }
+
+  const result = chooseNeurons(creatureJSON, config, neuronErrors);
+
+  // High-error neurons should be preferentially selected
+  let highErrorSelected = 0;
+  for (const uuid of highErrorUUIDs) {
+    if (result.has(uuid)) {
+      highErrorSelected++;
+    }
+  }
+
+  // With error-guided selection, high-error neurons should be much more likely to be selected
+  assert(
+    highErrorSelected > 0,
+    `At least one high-error neuron should be selected, but got ${highErrorSelected}`,
+  );
+});
+
+Deno.test("chooseNeurons: works without neuron errors (backward compatible)", () => {
+  const creature = Creature.fromJSON(
+    JSON.parse(
+      Deno.readTextFileSync("test/propagate/large/creature.json"),
+    ),
+  );
+
+  const config = createBackPropagationConfig({
+    sparseRatio: 0.05,
+  });
+
+  // Call without neuronErrors parameter — should still work
+  const result = chooseNeurons(creature.exportJSON(), config);
+
+  const validNeurons = creature.neurons.filter((neuron) =>
+    neuron.type === "hidden" || neuron.type === "output"
+  );
+  const expectedSize = Math.ceil(validNeurons.length * config.sparseRatio);
+
+  // Should select approximately the expected number
+  assert(
+    Math.abs(result.size - expectedSize) <= 1,
+    `Expected ~${expectedSize} neurons, got ${result.size}`,
+  );
+});
+
+Deno.test("chooseNeurons: sparseRatio 1 returns all neurons regardless of errors", () => {
+  const creature = Creature.fromJSON(
+    JSON.parse(
+      Deno.readTextFileSync("test/propagate/large/creature.json"),
+    ),
+  );
+
+  const config = createBackPropagationConfig({
+    sparseRatio: 1,
+  });
+
+  // Even with neuron errors, sparseRatio=1 should select all
+  const neuronErrors = new Map<string, NeuronStateInterface>();
+  const result = chooseNeurons(creature.exportJSON(), config, neuronErrors);
+
+  const validNeurons = creature.neurons.filter((neuron) =>
+    neuron.type === "hidden" || neuron.type === "output"
+  );
+
+  assertEquals(
+    result.size,
+    validNeurons.length,
+    "sparseRatio=1 should select all neurons",
+  );
+});


### PR DESCRIPTION
## Summary

Three targeted improvements to the backpropagation training process. Closes #1388.

### 1. Error-feedback adaptive learning rate

The existing "adaptive" learning rate strategy was purely time-based — it used a slower decay with sinusoidal oscillation but never looked at actual training error. The comment in the code acknowledged: *"Could be enhanced to use actual error feedback in the future"*.

Now the adaptive strategy uses real error feedback from the training loop:
- **Error improving** (ratio < 0.95): slightly boost the rate (1.1x)
- **Error stagnating** (ratio 0.95–1.0): increase the rate to escape the plateau (1.3x)
- **Error worsening** (ratio > 1.0): reduce the rate proportionally (down to 0.5x)

The fixed and decay strategies are unchanged. Backward compatible — works without error feedback.

### 2. Weight-based elastic distribution fallback

When all activations are near zero (common during early training), the elastic error distribution previously fell back to an equal split across all links. This ignores that links with larger weights carry more influence.

Now the fallback uses `weight²` scoring — matching the approach already used by record-time elasticity (`RecordElasticity.ts`). Links with larger weights absorb proportionally more error. Falls back to equal split only when both activations and weights are zero.

### 3. Error-guided sparse neuron selection

When sparse training is active (`sparseRatio < 1`), neurons were previously selected randomly via Fisher-Yates shuffle. The `totalErrorAbsolute` field was already being accumulated during propagation but never read.

Now the accumulated per-neuron error data from the previous iteration is used to prioritise high-error neurons for training. This focuses training effort on neurons with the most room for improvement. Falls back to random selection when no error data is available (first iteration).

## Evidence

These are backend/algorithmic changes with no UI component. All 2271 tests pass including 16 new tests covering the three improvements. The `quality.sh` gate passes cleanly.

## Test Plan

### New tests
- `test/optimization/ErrorFeedbackLearningRate.ts` (5 tests):
  - Adaptive rate increases when error stagnates
  - Adaptive rate decreases when error worsens
  - Fixed and decay strategies ignore error feedback
  - Adaptive without error feedback still works (backward compatible)
  - Adaptive rate stays within reasonable bounds
- `test/propagate/WeightBasedElasticFallback.ts` (8 tests):
  - Weight-based fallback prefers larger weights
  - Equal weights give equal split
  - Uses absolute weight value (negative weights)
  - Falls back to equal split when no weight data
  - Activation-based scoring takes priority over weight-based
  - All zero weights fall back to equal split
  - Backward compatibility without weight field
  - Weight fallback with tiny activations below plankConstant
- `test/propagate/sparse/ErrorGuidedChooseNeurons.ts` (3 tests):
  - Error-guided selection prefers high-error neurons
  - Works without neuron errors (backward compatible)
  - sparseRatio 1 returns all neurons regardless of errors

### Modified tests
- `test/optimization/AdaptiveVsDecay.ts`: Updated oscillation test to verify error-feedback responsiveness instead of sinusoidal pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)