### PR TITLE
DRY: Improve evolution/training/discovery with shared utilities and bug fixes (#1392)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.25",
+  "version": "0.310.26",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1392.md
+++ b/docs/pr-summary-1392.md
@@ -1,0 +1,50 @@
+## Summary
+
+Apply DRY principle and fix inconsistencies across evolution, training, and
+discovery code. Closes #1392.
+
+Six improvements extracted from a systematic codebase review:
+
+1. **Shared `isAggregationSquash` utility** (`SquashUtils.ts`): Unified the
+   duplicate `isAggregationSquash` / `isAggregationSquashName` functions from
+   `CompactCreature.ts` and `Simplify.ts` into a single shared function. Uses a
+   `ReadonlySet` for O(1) lookup instead of a switch statement.
+
+2. **Shared parent selection** (`ParentSelection.ts`): Extracted duplicated
+   `selectParent` and `getDad` logic from `Breed.ts` (~120 lines) and
+   `ParallelBreeding.ts` (~70 lines) into shared `selectParent()` and
+   `findFather()` functions. Both breeding paths now use the same selection and
+   father-finding logic.
+
+3. **MemeticUpdate duplicate loop removal** (`MemeticUpdate.ts`): Removed an
+   exact duplicate loop (lines 25-29 were identical to 19-23) and a duplicate
+   `foundSet.delete()` call. No behavioural change.
+
+4. **Type safety for `discovery-replay`** (`LogApproach.ts`, `Neat.ts`): Added
+   `"discovery-replay"` to the `Approach` type union and switch statement,
+   eliminating the need for `as Approach` casts. Removed three such casts from
+   `DiscoveryReplayIntegration.ts`.
+
+5. **ModSquash focus-list relaxation** (`ModSquash.ts`): Fixed an inconsistency
+   where `ModBias` relaxes its focus-list constraint after 6 failed attempts but
+   `ModSquash` never relaxed, causing mutations to silently fail when the focus
+   list contained no eligible neurons. ModSquash now matches ModBias behaviour.
+
+6. **Test coverage**: Five new test files (26 tests total) covering all changes
+   above, written before implementation following TDD.
+
+## Evidence
+
+This is a backend-only refactoring and bug-fix change. All 2553 tests pass
+(including 26 new tests across five files).
+
+## Test Plan
+
+- Added `test/compact/IsAggregationSquash.ts` — 11 tests for the shared utility
+- Added `test/breed/ParentSelection.ts` — 5 tests for shared parent selection
+- Added `test/blackbox/MemeticUpdateDuplicateLoop.ts` — 5 tests for memetic
+  update bias/weight change tracking
+- Added `test/NEAT/LogApproachDiscoveryReplay.ts` — 2 tests for discovery-replay
+  approach type safety
+- Added `test/mutate/ModSquashFocusRelaxation.ts` — 3 tests for focus-list
+  relaxation behaviour

--- a/src/NEAT/LogApproach.ts
+++ b/src/NEAT/LogApproach.ts
@@ -12,7 +12,8 @@ export type Approach =
   | "backtrack"
   | "retry"
   | "discovery"
-  | "discovered";
+  | "discovered"
+  | "discovery-replay";
 
 export function logApproach(fittest: Creature, previous: Creature) {
   const fScoreTxt = getTag(fittest, "score");
@@ -89,7 +90,8 @@ export function logApproach(fittest: Creature, previous: Creature) {
           break;
         }
         case "discovery":
-        case "discovered": {
+        case "discovered":
+        case "discovery-replay": {
           const discoveryID = getTag(fittest, "discoveryID");
           const evaluation = getTag(fittest, "Discovery") ??
             getTag(fittest, "discovery");

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -1160,7 +1160,7 @@ export class Neat {
         CreatureUtil.makeUUID(replayedCreature);
 
         // Tag the creature to indicate it came from discovery replay
-        addTag(replayedCreature, "approach", "discovery-replay" as Approach);
+        addTag(replayedCreature, "approach", "discovery-replay");
 
         validateAfterDiscoveryOrThrow({
           baseCreature: fittest,

--- a/src/blackbox/MemeticUpdate.ts
+++ b/src/blackbox/MemeticUpdate.ts
@@ -22,12 +22,6 @@ export function memeticUpdate(
     biasMap.set(neuron.uuid, neuron.bias);
   }
 
-  for (let i = parent.input; i < parent.neurons.length; i++) {
-    const neuron = parent.neurons[i];
-    squashMap.set(neuron.uuid, neuron.squash ?? "NONE");
-    biasMap.set(neuron.uuid, neuron.bias);
-  }
-
   for (let i = child.input; i < child.neurons.length; i++) {
     const neuron = child.neurons[i];
     const squash = squashMap.get(neuron.uuid);
@@ -98,8 +92,6 @@ export function memeticUpdate(
         });
       }
     }
-
-    foundSet.delete(`${synapse.fromUUID}-${synapse.toUUID}`);
   }
 
   if (foundSet.size > 0) {

--- a/src/breed/Breed.ts
+++ b/src/breed/Breed.ts
@@ -1,12 +1,11 @@
 import { assert } from "@std/assert";
-import { Creature, type NeatOptions, Selection } from "../../mod.ts";
+import type { Creature, NeatOptions } from "../../mod.ts";
 import { Offspring } from "../architecture/Offspring.ts";
 import { discover } from "../blackbox/Discover.ts";
 import { createNeatConfig, type NeatConfig } from "../config/NeatConfig.ts";
 import type { Genus } from "../NEAT/Genus.ts";
-import { calculateAdaptiveTournamentSize } from "./AdaptiveTournamentSize.ts";
-import { createCompatibleFatherFromCreatures } from "./Father.ts";
 import { FitnessRanking } from "./FitnessRanking.ts";
+import { findFather, selectParent } from "./ParentSelection.ts";
 
 /**
  * Handles breeding operations between creatures in a NEAT population.
@@ -67,11 +66,11 @@ export class Breed {
     // Pre-compute fitness ranking once for the entire population
     const populationRanking = new FitnessRanking(this.genus.population);
 
-    const mum = this.selectParent(populationRanking, config);
+    const mum = selectParent(populationRanking, config);
 
     assert(mum, "Mother is undefined");
 
-    const dad = this.getDad(mum, config);
+    const dad = findFather(mum, this.genus, config);
     if (!dad) {
       console.warn(
         "No father found",
@@ -94,124 +93,5 @@ export class Breed {
     }
 
     return child;
-  }
-
-  /**
-   * Selects a father for breeding with the given mother.
-   *
-   * Creates a FitnessRanking for the filtered father population to enable
-   * efficient parent selection.
-   *
-   * @param mum - The mother creature
-   * @param config - NEAT configuration
-   * @returns A compatible father creature, or undefined if none found
-   */
-  private getDad(
-    mum: Creature,
-    config: NeatConfig,
-  ): Creature | undefined {
-    assert(mum.uuid, "Mother UUID is undefined");
-
-    let possibleFathers: Creature[] = [];
-
-    if (config.globalBreedingRate > Math.random()) {
-      possibleFathers = this.genus.population.filter((creature) =>
-        creature.uuid !== mum.uuid
-      );
-    }
-
-    if (possibleFathers.length === 0) {
-      const species = this.genus.findSpeciesByCreatureUUID(mum.uuid);
-
-      possibleFathers = species.creatures.filter((creature) =>
-        creature.uuid !== mum.uuid
-      );
-
-      if (possibleFathers.length === 0) {
-        const closestSpecies = this.genus.findClosestMatchingSpecies(mum);
-        if (closestSpecies) {
-          possibleFathers = closestSpecies.creatures;
-
-          if (possibleFathers.length === 0) {
-            possibleFathers = this.genus.population.filter((creature) =>
-              creature.uuid !== mum.uuid
-            );
-          }
-        }
-      }
-    }
-
-    if (possibleFathers.length === 0) {
-      return undefined;
-    }
-
-    // Create a new FitnessRanking for the filtered father population
-    const fatherRanking = new FitnessRanking(possibleFathers);
-    const father = this.selectParent(fatherRanking, config);
-    assert(father !== undefined, "Father is undefined");
-
-    // Issue #1034: Avoid JSON exports in parent selection compatibility check.
-    // Uses optimised function that works directly with Creature objects.
-    const fatherExport = createCompatibleFatherFromCreatures(mum, father);
-    try {
-      const compatibleFather = Creature.fromJSON(
-        fatherExport,
-      );
-
-      return compatibleFather;
-    } catch (e) {
-      Deno.writeTextFileSync(
-        "./.source_mother.json",
-        JSON.stringify(mum.exportJSON(), null, 1),
-      );
-      Deno.writeTextFileSync(
-        "./.source_father.json",
-        JSON.stringify(father.exportJSON(), null, 1),
-      );
-
-      Deno.writeTextFileSync(
-        "./.invalid_father.json",
-        JSON.stringify(fatherExport, null, 1),
-      );
-      throw e;
-    }
-  }
-
-  /**
-   * Selects a parent from a pre-computed fitness ranking based on the selection strategy.
-   *
-   * Uses the pre-computed FitnessRanking for O(1) or O(k) selection instead of
-   * recalculating fitness metrics on every selection.
-   *
-   * @param ranking - Pre-computed fitness ranking
-   * @param config - NEAT configuration
-   * @returns The selected parent creature
-   * @throws {Error} When selection fails or unknown selection strategy
-   */
-  private selectParent(ranking: FitnessRanking, config: NeatConfig): Creature {
-    switch (config.selection) {
-      case Selection.POWER: {
-        return ranking.selectPower(Selection.POWER.power);
-      }
-      case Selection.FITNESS_PROPORTIONATE: {
-        return ranking.selectFitnessProportionate();
-      }
-      case Selection.TOURNAMENT: {
-        // Issue #1019: Use adaptive tournament size that scales with population
-        // instead of fixed size of 5. This improves selection pressure for
-        // large populations and reduces variance for small populations.
-        const adaptiveSize = calculateAdaptiveTournamentSize(
-          ranking.sortedPopulation.length,
-        );
-
-        return ranking.selectTournament(
-          adaptiveSize,
-          Selection.TOURNAMENT.probability,
-        );
-      }
-      default: {
-        throw new Error(`Unknown selection: ${config.selection}`);
-      }
-    }
   }
 }

--- a/src/breed/ParallelBreeding.ts
+++ b/src/breed/ParallelBreeding.ts
@@ -1,13 +1,11 @@
-import { assert } from "@std/assert";
-import { Creature, type NeatOptions, Selection } from "../../mod.ts";
+import { Creature, type NeatOptions } from "../../mod.ts";
 import { Offspring } from "../architecture/Offspring.ts";
 import { discover } from "../blackbox/Discover.ts";
 import { createNeatConfig, type NeatConfig } from "../config/NeatConfig.ts";
 import type { WorkerHandler } from "../multithreading/workers/WorkerHandler.ts";
 import type { Genus } from "../NEAT/Genus.ts";
-import { calculateAdaptiveTournamentSize } from "./AdaptiveTournamentSize.ts";
-import { createCompatibleFatherFromCreatures } from "./Father.ts";
 import { FitnessRanking } from "./FitnessRanking.ts";
+import { findFather, selectParent } from "./ParentSelection.ts";
 
 /**
  * Represents a parent pair for breeding.
@@ -199,136 +197,17 @@ export class ParallelBreeding {
     populationRanking: FitnessRanking,
     config: NeatConfig,
   ): ParentPair | undefined {
-    const mum = this.selectParent(populationRanking, config);
+    const mum = selectParent(populationRanking, config);
     if (!mum) {
       return undefined;
     }
 
-    const dad = this.getDad(mum, config);
+    const dad = findFather(mum, this.genus, config);
     if (!dad) {
       return undefined;
     }
 
     return { mother: mum, father: dad };
-  }
-
-  /**
-   * Selects a father for breeding with the given mother.
-   *
-   * Creates a FitnessRanking for the filtered father population to enable
-   * efficient parent selection.
-   *
-   * @param mum - The mother creature
-   * @param config - NEAT configuration
-   * @returns A compatible father creature, or undefined if none found
-   */
-  private getDad(
-    mum: Creature,
-    config: NeatConfig,
-  ): Creature | undefined {
-    assert(mum.uuid, "Mother UUID is undefined");
-
-    let possibleFathers: Creature[] = [];
-
-    if (config.globalBreedingRate > Math.random()) {
-      possibleFathers = this.genus.population.filter((creature) =>
-        creature.uuid !== mum.uuid
-      );
-    }
-
-    if (possibleFathers.length === 0) {
-      const species = this.genus.findSpeciesByCreatureUUID(mum.uuid);
-
-      possibleFathers = species.creatures.filter((creature) =>
-        creature.uuid !== mum.uuid
-      );
-
-      if (possibleFathers.length === 0) {
-        const closestSpecies = this.genus.findClosestMatchingSpecies(mum);
-        if (closestSpecies) {
-          possibleFathers = closestSpecies.creatures;
-
-          if (possibleFathers.length === 0) {
-            possibleFathers = this.genus.population.filter((creature) =>
-              creature.uuid !== mum.uuid
-            );
-          }
-        }
-      }
-    }
-
-    if (possibleFathers.length === 0) {
-      return undefined;
-    }
-
-    // Create a new FitnessRanking for the filtered father population
-    const fatherRanking = new FitnessRanking(possibleFathers);
-    const father = this.selectParent(fatherRanking, config);
-    assert(father !== undefined, "Father is undefined");
-
-    // Issue #1034: Avoid JSON exports in parent selection compatibility check.
-    // Uses optimised function that works directly with Creature objects.
-    const fatherExport = createCompatibleFatherFromCreatures(mum, father);
-    try {
-      const compatibleFather = Creature.fromJSON(
-        fatherExport,
-      );
-
-      return compatibleFather;
-    } catch (e) {
-      Deno.writeTextFileSync(
-        "./.source_mother.json",
-        JSON.stringify(mum.exportJSON(), null, 1),
-      );
-      Deno.writeTextFileSync(
-        "./.source_father.json",
-        JSON.stringify(father.exportJSON(), null, 1),
-      );
-
-      Deno.writeTextFileSync(
-        "./.invalid_father.json",
-        JSON.stringify(fatherExport, null, 1),
-      );
-      throw e;
-    }
-  }
-
-  /**
-   * Selects a parent from a pre-computed fitness ranking based on the selection strategy.
-   *
-   * Uses the pre-computed FitnessRanking for O(1) or O(k) selection instead of
-   * recalculating fitness metrics on every selection.
-   *
-   * @param ranking - Pre-computed fitness ranking
-   * @param config - NEAT configuration
-   * @returns The selected parent creature
-   * @throws {Error} When selection fails or unknown selection strategy
-   */
-  private selectParent(ranking: FitnessRanking, config: NeatConfig): Creature {
-    switch (config.selection) {
-      case Selection.POWER: {
-        return ranking.selectPower(Selection.POWER.power);
-      }
-      case Selection.FITNESS_PROPORTIONATE: {
-        return ranking.selectFitnessProportionate();
-      }
-      case Selection.TOURNAMENT: {
-        // Issue #1019: Use adaptive tournament size that scales with population
-        // instead of fixed size of 5. This improves selection pressure for
-        // large populations and reduces variance for small populations.
-        const adaptiveSize = calculateAdaptiveTournamentSize(
-          ranking.sortedPopulation.length,
-        );
-
-        return ranking.selectTournament(
-          adaptiveSize,
-          Selection.TOURNAMENT.probability,
-        );
-      }
-      default: {
-        throw new Error(`Unknown selection: ${config.selection}`);
-      }
-    }
   }
 
   /**

--- a/src/breed/ParentSelection.ts
+++ b/src/breed/ParentSelection.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared parent selection utilities for breeding.
+ *
+ * Issue #1392: Extracted from Breed.ts and ParallelBreeding.ts to
+ * eliminate DRY violation where getDad() and selectParent() were
+ * independently defined with identical logic.
+ */
+
+import { assert } from "@std/assert";
+import { Creature, Selection } from "../../mod.ts";
+import type { NeatConfig } from "../config/NeatConfig.ts";
+import type { Genus } from "../NEAT/Genus.ts";
+import { calculateAdaptiveTournamentSize } from "./AdaptiveTournamentSize.ts";
+import { createCompatibleFatherFromCreatures } from "./Father.ts";
+import { FitnessRanking } from "./FitnessRanking.ts";
+
+/**
+ * Selects a parent from a pre-computed fitness ranking based on the selection strategy.
+ *
+ * Uses the pre-computed FitnessRanking for O(1) or O(k) selection instead of
+ * recalculating fitness metrics on every selection.
+ *
+ * @param ranking - Pre-computed fitness ranking
+ * @param config - NEAT configuration
+ * @returns The selected parent creature
+ * @throws {Error} When selection fails or unknown selection strategy
+ */
+export function selectParent(
+  ranking: FitnessRanking,
+  config: NeatConfig,
+): Creature {
+  switch (config.selection) {
+    case Selection.POWER: {
+      return ranking.selectPower(Selection.POWER.power);
+    }
+    case Selection.FITNESS_PROPORTIONATE: {
+      return ranking.selectFitnessProportionate();
+    }
+    case Selection.TOURNAMENT: {
+      // Issue #1019: Use adaptive tournament size that scales with population
+      // instead of fixed size of 5. This improves selection pressure for
+      // large populations and reduces variance for small populations.
+      const adaptiveSize = calculateAdaptiveTournamentSize(
+        ranking.sortedPopulation.length,
+      );
+
+      return ranking.selectTournament(
+        adaptiveSize,
+        Selection.TOURNAMENT.probability,
+      );
+    }
+    default: {
+      throw new Error(`Unknown selection: ${config.selection}`);
+    }
+  }
+}
+
+/**
+ * Selects a father for breeding with the given mother.
+ *
+ * Creates a FitnessRanking for the filtered father population to enable
+ * efficient parent selection. Falls back through species-based selection,
+ * closest species, and global population as needed.
+ *
+ * @param mum - The mother creature
+ * @param genus - The genus containing the population
+ * @param config - NEAT configuration
+ * @returns A compatible father creature, or undefined if none found
+ */
+export function findFather(
+  mum: Creature,
+  genus: Genus,
+  config: NeatConfig,
+): Creature | undefined {
+  assert(mum.uuid, "Mother UUID is undefined");
+
+  let possibleFathers: Creature[] = [];
+
+  if (config.globalBreedingRate > Math.random()) {
+    possibleFathers = genus.population.filter((creature) =>
+      creature.uuid !== mum.uuid
+    );
+  }
+
+  if (possibleFathers.length === 0) {
+    const species = genus.findSpeciesByCreatureUUID(mum.uuid);
+
+    possibleFathers = species.creatures.filter((creature) =>
+      creature.uuid !== mum.uuid
+    );
+
+    if (possibleFathers.length === 0) {
+      const closestSpecies = genus.findClosestMatchingSpecies(mum);
+      if (closestSpecies) {
+        possibleFathers = closestSpecies.creatures;
+
+        if (possibleFathers.length === 0) {
+          possibleFathers = genus.population.filter((creature) =>
+            creature.uuid !== mum.uuid
+          );
+        }
+      }
+    }
+  }
+
+  if (possibleFathers.length === 0) {
+    return undefined;
+  }
+
+  // Create a new FitnessRanking for the filtered father population
+  const fatherRanking = new FitnessRanking(possibleFathers);
+  const father = selectParent(fatherRanking, config);
+  assert(father !== undefined, "Father is undefined");
+
+  // Issue #1034: Avoid JSON exports in parent selection compatibility check.
+  // Uses optimised function that works directly with Creature objects.
+  const fatherExport = createCompatibleFatherFromCreatures(mum, father);
+  try {
+    const compatibleFather = Creature.fromJSON(
+      fatherExport,
+    );
+
+    return compatibleFather;
+  } catch (e) {
+    Deno.writeTextFileSync(
+      "./.source_mother.json",
+      JSON.stringify(mum.exportJSON(), null, 1),
+    );
+    Deno.writeTextFileSync(
+      "./.source_father.json",
+      JSON.stringify(father.exportJSON(), null, 1),
+    );
+
+    Deno.writeTextFileSync(
+      "./.invalid_father.json",
+      JSON.stringify(fatherExport, null, 1),
+    );
+    throw e;
+  }
+}

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -13,12 +13,13 @@ import { COMPLEMENT } from "../methods/activations/types/COMPLEMENT.ts";
 import { ABSOLUTE } from "../methods/activations/types/ABSOLUTE.ts";
 import { ReLU } from "../methods/activations/types/ReLU.ts";
 import { LeakyReLU } from "../methods/activations/types/LeakyReLU.ts";
-import { IF } from "../methods/activations/aggregate/IF.ts";
-import { MAXIMUM } from "../methods/activations/aggregate/MAXIMUM.ts";
-import { MINIMUM } from "../methods/activations/aggregate/MINIMUM.ts";
 import { HYPOT } from "../deprecated/HYPOT.ts";
 import { HYPOTv2 } from "../deprecated/HYPOTv2.ts";
 import { MEAN } from "../deprecated/MEAN.ts";
+import { isAggregationSquash } from "../methods/activations/SquashUtils.ts";
+import { IF } from "../methods/activations/aggregate/IF.ts";
+import { MAXIMUM } from "../methods/activations/aggregate/MAXIMUM.ts";
+import { MINIMUM } from "../methods/activations/aggregate/MINIMUM.ts";
 import {
   cleanupOrphanedNeurons,
   pruneDeadSubgraphs,
@@ -169,7 +170,7 @@ export function compactCreature(
     // aggregate consumers, but that is more complex and not required here.)
     const toNeurons = outConns.map((c) => neuronMap.get(c.toUUID));
     if (toNeurons.some((n) => !n)) continue;
-    if (toNeurons.some((n) => isAggregationSquashName(n!.squash))) continue;
+    if (toNeurons.some((n) => isAggregationSquash(n!.squash))) continue;
 
     // Avoid introducing self-loops or invalid forward-only edges via bypass.
     let unsafe = false;
@@ -573,17 +574,4 @@ function calculateWeightBiasPenalty(exported: CreatureExport): number {
 
   const avg = total / count;
   return (valuePenalty(max) + valuePenalty(avg)) / 2;
-}
-
-function isAggregationSquashName(name?: string): boolean {
-  switch (name) {
-    case MAXIMUM.NAME:
-    case MINIMUM.NAME:
-    case IF.NAME:
-    case HYPOT.NAME:
-    case HYPOTv2.NAME:
-      return true;
-    default:
-      return false;
-  }
 }

--- a/src/methods/activations/SquashUtils.ts
+++ b/src/methods/activations/SquashUtils.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared utility functions for squash (activation) function classification.
+ *
+ * Issue #1392: Extracted from CompactCreature.ts and Simplify.ts to
+ * eliminate DRY violation where isAggregationSquash/isAggregationSquashName
+ * were independently defined with identical logic.
+ *
+ * NOTE: Uses string literals rather than importing activation modules to
+ * avoid circular dependency issues with the Activations module graph.
+ */
+
+/** Names of aggregation-type squash functions (not scale-homogeneous). */
+const AGGREGATION_SQUASH_NAMES: ReadonlySet<string> = new Set([
+  "MAXIMUM",
+  "MINIMUM",
+  "IF",
+  "HYPOT",
+  "HYPOTv2",
+]);
+
+/**
+ * Determines whether a squash function is an aggregation type.
+ *
+ * Aggregation squashes (MAXIMUM, MINIMUM, IF, HYPOT, HYPOTv2) are not
+ * scale-homogeneous: scaling all inputs does not simply scale the output.
+ * This distinction matters for compaction (weight folding) and simplification
+ * (identity neuron removal), which are only safe for scale-homogeneous squashes.
+ *
+ * @param name - The squash function name to check
+ * @returns true if the squash is an aggregation type
+ */
+export function isAggregationSquash(name?: string): boolean {
+  if (!name) return false;
+  return AGGREGATION_SQUASH_NAMES.has(name);
+}

--- a/src/mutate/ModSquash.ts
+++ b/src/mutate/ModSquash.ts
@@ -21,10 +21,9 @@ export class ModActivation implements RadioactiveInterface {
 
       if (neuron.type === "constant") continue;
 
-      if (this.creature.inFocus(index, focusList)) {
-        changed = neuron.mutate(Mutation.MOD_SQUASH.name);
-        break;
-      }
+      if (!this.creature.inFocus(index, focusList) && attempts < 6) continue;
+      changed = neuron.mutate(Mutation.MOD_SQUASH.name);
+      break;
     }
 
     if (changed) {

--- a/src/optimize/Simplify.ts
+++ b/src/optimize/Simplify.ts
@@ -3,13 +3,9 @@ import { type CreatureExport, CreatureUtil } from "../../mod.ts";
 import type { NeuronExport } from "../architecture/NeuronInterfaces.ts";
 import type { SynapseExport } from "../architecture/SynapseInterfaces.ts";
 import { Creature } from "../Creature.ts";
-import { HYPOT } from "../deprecated/HYPOT.ts";
-import { HYPOTv2 } from "../deprecated/HYPOTv2.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import { Activations } from "../methods/activations/Activations.ts";
-import { IF } from "../methods/activations/aggregate/IF.ts";
-import { MAXIMUM } from "../methods/activations/aggregate/MAXIMUM.ts";
-import { MINIMUM } from "../methods/activations/aggregate/MINIMUM.ts";
+import { isAggregationSquash } from "../methods/activations/SquashUtils.ts";
 import { ABSOLUTE } from "../methods/activations/types/ABSOLUTE.ts";
 import { COMPLEMENT } from "../methods/activations/types/COMPLEMENT.ts";
 import { IDENTITY } from "../methods/activations/types/IDENTITY.ts";
@@ -174,21 +170,6 @@ export function removeKnownSign(exported: CreatureExport) {
   }
 
   return exported;
-}
-
-function isAggregationSquash(
-  squash?: string,
-): boolean {
-  switch (squash) {
-    case MAXIMUM.NAME:
-    case MINIMUM.NAME:
-    case HYPOT.NAME:
-    case HYPOTv2.NAME:
-    case IF.NAME:
-      return true;
-    default:
-      return false;
-  }
 }
 
 function simplifyConstants(exported: CreatureExport) {

--- a/test/Compact/IsAggregationSquash.ts
+++ b/test/Compact/IsAggregationSquash.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for the shared isAggregationSquash utility.
+ * Issue #1392: DRY - Unify duplicate isAggregationSquash/isAggregationSquashName
+ * from CompactCreature.ts and Simplify.ts into a single shared utility.
+ */
+import { assertEquals } from "@std/assert";
+import { isAggregationSquash } from "../../src/methods/activations/SquashUtils.ts";
+
+Deno.test("isAggregationSquash - returns true for MAXIMUM", () => {
+  assertEquals(isAggregationSquash("MAXIMUM"), true);
+});
+
+Deno.test("isAggregationSquash - returns true for MINIMUM", () => {
+  assertEquals(isAggregationSquash("MINIMUM"), true);
+});
+
+Deno.test("isAggregationSquash - returns true for IF", () => {
+  assertEquals(isAggregationSquash("IF"), true);
+});
+
+Deno.test("isAggregationSquash - returns true for HYPOT", () => {
+  assertEquals(isAggregationSquash("HYPOT"), true);
+});
+
+Deno.test("isAggregationSquash - returns true for HYPOTv2", () => {
+  assertEquals(isAggregationSquash("HYPOTv2"), true);
+});
+
+Deno.test("isAggregationSquash - returns false for LOGISTIC", () => {
+  assertEquals(isAggregationSquash("LOGISTIC"), false);
+});
+
+Deno.test("isAggregationSquash - returns false for IDENTITY", () => {
+  assertEquals(isAggregationSquash("IDENTITY"), false);
+});
+
+Deno.test("isAggregationSquash - returns false for TANH", () => {
+  assertEquals(isAggregationSquash("TANH"), false);
+});
+
+Deno.test("isAggregationSquash - returns false for ReLU", () => {
+  assertEquals(isAggregationSquash("ReLU"), false);
+});
+
+Deno.test("isAggregationSquash - returns false for undefined", () => {
+  assertEquals(isAggregationSquash(undefined), false);
+});
+
+Deno.test("isAggregationSquash - returns false for empty string", () => {
+  assertEquals(isAggregationSquash(""), false);
+});

--- a/test/NEAT/DiscoveryReplayIntegration.ts
+++ b/test/NEAT/DiscoveryReplayIntegration.ts
@@ -26,7 +26,6 @@ import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
 import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
 import { Neat } from "../../src/NEAT/Neat.ts";
 import { validateAfterDiscoveryOrThrow } from "../../src/discovery/DiscoveryPostValidate.ts";
-import type { Approach } from "../../src/NEAT/LogApproach.ts";
 import type { NeatOptions } from "../../src/config/NeatOptions.ts";
 
 /**
@@ -131,7 +130,7 @@ Deno.test("DiscoveryReplayIntegration - tags creature with discovery-replay appr
   CreatureUtil.makeUUID(replayedCreature);
 
   // This is the exact tagging code from Neat.ts line 1128
-  addTag(replayedCreature, "approach", "discovery-replay" as Approach);
+  addTag(replayedCreature, "approach", "discovery-replay");
 
   // Verify the tag was applied
   const approachTag = getTag(replayedCreature, "approach");
@@ -201,7 +200,7 @@ Deno.test("DiscoveryReplayIntegration - adds replayed creature to population arr
       result.improvement.creature as Parameters<typeof Creature.fromJSON>[0],
     );
     CreatureUtil.makeUUID(replayedCreature);
-    addTag(replayedCreature, "approach", "discovery-replay" as Approach);
+    addTag(replayedCreature, "approach", "discovery-replay");
 
     validateAfterDiscoveryOrThrow({
       baseCreature: baseCreature,
@@ -426,7 +425,7 @@ Deno.test("DiscoveryReplayIntegration - processes multiple replay results", () =
         result.improvement.creature as Parameters<typeof Creature.fromJSON>[0],
       );
       CreatureUtil.makeUUID(replayedCreature);
-      addTag(replayedCreature, "approach", "discovery-replay" as Approach);
+      addTag(replayedCreature, "approach", "discovery-replay");
 
       validateAfterDiscoveryOrThrow({
         baseCreature: baseCreature,

--- a/test/NEAT/LogApproachDiscoveryReplay.ts
+++ b/test/NEAT/LogApproachDiscoveryReplay.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for LogApproach 'discovery-replay' approach type.
+ * Issue #1392: Add 'discovery-replay' to the Approach type union
+ * to eliminate the 'as Approach' type cast in Neat.ts.
+ */
+import { assert } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature, type CreatureExport } from "../../mod.ts";
+import { type Approach, logApproach } from "../../src/NEAT/LogApproach.ts";
+
+function createTestCreature(
+  score: number,
+  approach: string,
+): Creature {
+  const creatureJSON: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "TANH", bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+    ],
+    tags: [
+      { name: "score", value: score.toString() },
+      { name: "approach", value: approach },
+    ],
+  };
+  return Creature.fromJSON(creatureJSON);
+}
+
+function createPreviousCreature(score: number): Creature {
+  const creatureJSON: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [],
+    tags: [
+      { name: "score", value: score.toString() },
+    ],
+  };
+  return Creature.fromJSON(creatureJSON);
+}
+
+Deno.test("logApproach - handles 'discovery-replay' approach without casting", () => {
+  const fittest = createTestCreature(0.9, "discovery-replay");
+  addTag(fittest, "discoveryID", "replay-test-123");
+  const previous = createPreviousCreature(0.8);
+
+  // 'discovery-replay' should be a valid Approach without needing 'as Approach'
+  const approach: Approach = "discovery-replay";
+  assert(approach === "discovery-replay");
+
+  let errorThrown = false;
+  try {
+    logApproach(fittest, previous);
+  } catch (e) {
+    errorThrown = true;
+    console.error("Unexpected error:", e);
+  }
+
+  assert(
+    !errorThrown,
+    "logApproach should handle 'discovery-replay' approach without error",
+  );
+});
+
+Deno.test("logApproach - all approaches including discovery-replay are valid", () => {
+  const allApproaches: Approach[] = [
+    "fine",
+    "trained",
+    "simplified",
+    "compact",
+    "backtrack",
+    "retry",
+    "discovery",
+    "discovered",
+    "discovery-replay",
+  ];
+
+  const previous = createPreviousCreature(0.7);
+
+  for (const approach of allApproaches) {
+    const fittest = createTestCreature(0.8, approach);
+
+    if (approach === "trained") {
+      addTag(fittest, "trainID", "test-train-id");
+    }
+    if (
+      approach === "discovery" || approach === "discovered" ||
+      approach === "discovery-replay"
+    ) {
+      addTag(fittest, "discoveryID", "test-discovery-id");
+    }
+    if (approach === "compact") {
+      addTag(fittest, "old-neurons", "5");
+      addTag(fittest, "old-synapses", "10");
+    }
+
+    let errorThrown = false;
+    try {
+      logApproach(fittest, previous);
+    } catch (e) {
+      errorThrown = true;
+      console.error(`Unexpected error for approach '${approach}':`, e);
+    }
+
+    assert(
+      !errorThrown,
+      `logApproach should not throw for '${approach}' approach`,
+    );
+  }
+});

--- a/test/blackbox/MemeticUpdateDuplicateLoop.ts
+++ b/test/blackbox/MemeticUpdateDuplicateLoop.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for MemeticUpdate functionality.
+ * Issue #1392: Verify memeticUpdate correctly tracks bias and weight changes
+ * between parent and child creatures (after fixing the duplicate loop).
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature, type CreatureExport } from "../../mod.ts";
+import { memeticUpdate } from "../../src/blackbox/MemeticUpdate.ts";
+import type { MemeticInterface } from "../../src/blackbox/MemeticInterface.ts";
+
+function createTestCreature(): CreatureExport {
+  return {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "LOGISTIC", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.8 },
+    ],
+  };
+}
+
+Deno.test("memeticUpdate - detects bias changes between parent and child", () => {
+  const parentJSON = createTestCreature();
+  const parent = Creature.fromJSON(parentJSON);
+  parent.memetic = { generation: 1, score: 0.5, biases: {}, weights: {} };
+
+  // Create a child with a different bias on hidden-1
+  const childJSON = createTestCreature();
+  childJSON.neurons[0].bias = 0.7; // Changed from 0.5
+  const child = Creature.fromJSON(childJSON);
+
+  const result = memeticUpdate(parent, child);
+  assert(result, "Should return a MemeticInterface");
+  assert(result.biases, "Should have biases object");
+  assert(
+    result.biases["hidden-1"] !== undefined,
+    "Should track bias change for hidden-1",
+  );
+});
+
+Deno.test("memeticUpdate - detects weight changes between parent and child", () => {
+  const parentJSON = createTestCreature();
+  const parent = Creature.fromJSON(parentJSON);
+  parent.memetic = { generation: 1, score: 0.5, biases: {}, weights: {} };
+
+  // Create a child with a different weight
+  const childJSON = createTestCreature();
+  childJSON.synapses[0].weight = 0.9; // Changed from 0.5
+  const child = Creature.fromJSON(childJSON);
+
+  const result = memeticUpdate(parent, child);
+  assert(result, "Should return a MemeticInterface");
+  assert(result.weights, "Should have weights object");
+});
+
+Deno.test("memeticUpdate - returns undefined when neuron counts differ", () => {
+  const parentJSON = createTestCreature();
+  const parent = Creature.fromJSON(parentJSON);
+  parent.memetic = { generation: 1, score: 0.5, biases: {}, weights: {} };
+
+  // Create a child with extra neuron
+  const childJSON = createTestCreature();
+  childJSON.neurons.splice(1, 0, {
+    type: "hidden",
+    uuid: "hidden-2",
+    squash: "TANH",
+    bias: 0.3,
+  });
+  childJSON.synapses.push(
+    { fromUUID: "hidden-1", toUUID: "hidden-2", weight: 0.5 },
+    { fromUUID: "hidden-2", toUUID: "output-0", weight: 0.4 },
+  );
+  const child = Creature.fromJSON(childJSON);
+
+  const result = memeticUpdate(parent, child);
+  assertEquals(
+    result,
+    undefined,
+    "Should return undefined when neuron counts differ",
+  );
+});
+
+Deno.test("memeticUpdate - returns undefined when squash functions differ", () => {
+  const parentJSON = createTestCreature();
+  const parent = Creature.fromJSON(parentJSON);
+  parent.memetic = { generation: 1, score: 0.5, biases: {}, weights: {} };
+
+  // Create a child with a different squash
+  const childJSON = createTestCreature();
+  childJSON.neurons[0].squash = "TANH"; // Changed from LOGISTIC
+  const child = Creature.fromJSON(childJSON);
+
+  const result = memeticUpdate(parent, child);
+  assertEquals(
+    result,
+    undefined,
+    "Should return undefined when squash functions differ",
+  );
+});
+
+Deno.test("memeticUpdate - preserves existing memetic data", () => {
+  const parentJSON = createTestCreature();
+  const parent = Creature.fromJSON(parentJSON);
+  const existingMemetic: MemeticInterface = {
+    generation: 1,
+    score: 0.5,
+    biases: { "hidden-1": 0.3 },
+    weights: {
+      "input-0": [{ toUUID: "hidden-1", weight: 0.4 }],
+    },
+  };
+  parent.memetic = existingMemetic;
+
+  // Create identical child (no changes)
+  const childJSON = createTestCreature();
+  const child = Creature.fromJSON(childJSON);
+
+  const result = memeticUpdate(parent, child);
+  assert(result, "Should return a MemeticInterface");
+  // The existing memetic biases should be preserved
+  assertEquals(
+    result.biases?.["hidden-1"],
+    0.3,
+    "Should preserve existing memetic bias data",
+  );
+});

--- a/test/breed/ParentSelection.ts
+++ b/test/breed/ParentSelection.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the shared parent selection utility.
+ * Issue #1392: DRY - Extract duplicated selectParent/getDad logic
+ * from Breed.ts and ParallelBreeding.ts into shared functions.
+ */
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import {
+  Creature,
+  type CreatureExport,
+  CreatureUtil,
+  Selection,
+} from "../../mod.ts";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { Genus } from "../../src/NEAT/Genus.ts";
+import { findFather, selectParent } from "../../src/breed/ParentSelection.ts";
+import { FitnessRanking } from "../../src/breed/FitnessRanking.ts";
+
+function createScoredCreature(score: number): Creature {
+  const hiddenUUID = crypto.randomUUID();
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden",
+        uuid: hiddenUUID,
+        squash: "LOGISTIC",
+        bias: 0.1,
+      },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: hiddenUUID, weight: 0.5 },
+      { fromUUID: hiddenUUID, toUUID: "output-0", weight: 0.8 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  CreatureUtil.makeUUID(creature);
+  creature.score = score;
+  addTag(creature, "score", score.toString());
+  return creature;
+}
+
+function createGenus(creatures: Creature[]): Genus {
+  const genus = new Genus();
+  for (const creature of creatures) {
+    genus.addCreature(creature);
+  }
+  return genus;
+}
+
+Deno.test(
+  "selectParent - returns a creature from the ranking with POWER selection",
+  () => {
+    const creatures = [
+      createScoredCreature(0.9),
+      createScoredCreature(0.7),
+      createScoredCreature(0.5),
+    ];
+
+    const ranking = new FitnessRanking(creatures);
+    const config = createNeatConfig({ selection: Selection.POWER });
+
+    const parent = selectParent(ranking, config);
+    assert(parent, "Should select a parent");
+    assert(
+      creatures.some((c) => c.uuid === parent.uuid),
+      "Selected parent should be from the population",
+    );
+  },
+);
+
+Deno.test(
+  "selectParent - returns a creature with FITNESS_PROPORTIONATE selection",
+  () => {
+    const creatures = [
+      createScoredCreature(0.9),
+      createScoredCreature(0.7),
+      createScoredCreature(0.5),
+    ];
+
+    const ranking = new FitnessRanking(creatures);
+    const config = createNeatConfig({
+      selection: Selection.FITNESS_PROPORTIONATE,
+    });
+
+    const parent = selectParent(ranking, config);
+    assert(parent, "Should select a parent");
+  },
+);
+
+Deno.test(
+  "selectParent - returns a creature with TOURNAMENT selection",
+  () => {
+    const creatures = [
+      createScoredCreature(0.9),
+      createScoredCreature(0.7),
+      createScoredCreature(0.5),
+      createScoredCreature(0.3),
+      createScoredCreature(0.1),
+    ];
+
+    const ranking = new FitnessRanking(creatures);
+    const config = createNeatConfig({ selection: Selection.TOURNAMENT });
+
+    const parent = selectParent(ranking, config);
+    assert(parent, "Should select a parent");
+  },
+);
+
+Deno.test("findFather - returns a compatible father from the genus", () => {
+  const creatures = [
+    createScoredCreature(0.9),
+    createScoredCreature(0.7),
+    createScoredCreature(0.5),
+  ];
+
+  const config = createNeatConfig({ selection: Selection.POWER });
+  const genus = createGenus(creatures);
+  const mum = creatures[0];
+
+  const dad = findFather(mum, genus, config);
+  // With only 3 creatures, we should find a father
+  // (unless random selection picks the mother's UUID, but that's filtered out)
+  if (dad) {
+    assertNotEquals(
+      dad.uuid,
+      mum.uuid,
+      "Father should not be the same creature as the mother",
+    );
+  }
+});
+
+Deno.test("findFather - returns undefined when no fathers available", () => {
+  // Create a population with only one creature
+  const creatures = [createScoredCreature(0.9)];
+
+  const config = createNeatConfig({ selection: Selection.POWER });
+  const genus = createGenus(creatures);
+  const mum = creatures[0];
+
+  const dad = findFather(mum, genus, config);
+  assertEquals(
+    dad,
+    undefined,
+    "Should return undefined when no fathers available",
+  );
+});

--- a/test/mutate/ModSquashFocusRelaxation.ts
+++ b/test/mutate/ModSquashFocusRelaxation.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for ModSquash focus-list relaxation behaviour.
+ * Issue #1392: ModSquash should relax focus-list constraint after several
+ * attempts, consistent with ModBias behaviour.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { ModActivation } from "../../src/mutate/ModSquash.ts";
+import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
+
+Deno.test("ModSquash - relaxes focus list after several failed attempts", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+      { type: "hidden", squash: "TANH", bias: 0.3, index: 3 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 4 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 1, to: 3, weight: 1.0 },
+      { from: 2, to: 4, weight: 0.8 },
+      { from: 3, to: 4, weight: 0.9 },
+    ],
+    input: 2,
+    output: 1,
+  });
+
+  creatureValidate(creature);
+
+  // Use a focus list that targets a non-existent neuron index.
+  // With the old code, ModSquash would never mutate because it never relaxes.
+  // With the fix, it should eventually relax and mutate any eligible neuron.
+  const impossibleFocusList = [999];
+
+  let changed = false;
+  for (let trial = 0; trial < 50; trial++) {
+    const testCreature = Creature.fromJSON(creature.exportJSON());
+    const mutator = new ModActivation(testCreature);
+    changed = mutator.mutate(impossibleFocusList);
+    if (changed) {
+      creatureValidate(testCreature);
+      break;
+    }
+  }
+
+  // With relaxation, it should eventually mutate despite the impossible focus list
+  assert(
+    changed,
+    "ModSquash should relax focus list and still mutate when no focused neurons are found",
+  );
+});
+
+Deno.test("ModSquash - prefers focused neurons when available", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+      { type: "hidden", squash: "TANH", bias: 0.3, index: 3 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 4 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 1, to: 3, weight: 1.0 },
+      { from: 2, to: 4, weight: 0.8 },
+      { from: 3, to: 4, weight: 0.9 },
+    ],
+    input: 2,
+    output: 1,
+  });
+
+  creatureValidate(creature);
+
+  // Focus on neuron at index 2 (hidden)
+  const focusList = [2];
+
+  let changed = false;
+  for (let trial = 0; trial < 50; trial++) {
+    const testCreature = Creature.fromJSON(creature.exportJSON());
+    const mutator = new ModActivation(testCreature);
+    changed = mutator.mutate(focusList);
+    if (changed) {
+      creatureValidate(testCreature);
+      break;
+    }
+  }
+
+  assert(changed, "Should be able to mutate when focused neuron exists");
+});
+
+Deno.test("ModSquash - skips constant neurons", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      {
+        type: "constant",
+        uuid: "const-1",
+        bias: 0.5,
+      },
+      { type: "output", uuid: "output-0", squash: "LOGISTIC", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1.0 },
+      { fromUUID: "const-1", toUUID: "output-0", weight: 0.5 },
+    ],
+    input: 1,
+    output: 1,
+  });
+
+  creatureValidate(creature);
+
+  // The output neuron can be mutated, but the constant cannot
+  for (let i = 0; i < 100; i++) {
+    const testCreature = Creature.fromJSON(creature.exportJSON());
+    const testMutator = new ModActivation(testCreature);
+    testMutator.mutate();
+    const constantNeuron = testCreature.neurons.find((n) =>
+      n.type === "constant"
+    );
+    assertEquals(
+      constantNeuron!.bias,
+      0.5,
+      "Constant neuron should not be modified",
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Apply DRY principle and fix inconsistencies across evolution, training, and
discovery code. Closes #1392.

Six improvements extracted from a systematic codebase review:

1. **Shared `isAggregationSquash` utility** (`SquashUtils.ts`): Unified the
   duplicate `isAggregationSquash` / `isAggregationSquashName` functions from
   `CompactCreature.ts` and `Simplify.ts` into a single shared function. Uses a
   `ReadonlySet` for O(1) lookup instead of a switch statement.

2. **Shared parent selection** (`ParentSelection.ts`): Extracted duplicated
   `selectParent` and `getDad` logic from `Breed.ts` (~120 lines) and
   `ParallelBreeding.ts` (~70 lines) into shared `selectParent()` and
   `findFather()` functions. Both breeding paths now use the same selection and
   father-finding logic.

3. **MemeticUpdate duplicate loop removal** (`MemeticUpdate.ts`): Removed an
   exact duplicate loop (lines 25-29 were identical to 19-23) and a duplicate
   `foundSet.delete()` call. No behavioural change.

4. **Type safety for `discovery-replay`** (`LogApproach.ts`, `Neat.ts`): Added
   `"discovery-replay"` to the `Approach` type union and switch statement,
   eliminating the need for `as Approach` casts.

5. **ModSquash focus-list relaxation** (`ModSquash.ts`): Fixed an inconsistency
   where `ModBias` relaxes its focus-list constraint after 6 failed attempts but
   `ModSquash` never relaxed, causing mutations to silently fail when the focus
   list contained no eligible neurons. ModSquash now matches ModBias behaviour.

6. **Test coverage**: Five new test files (26 tests total) covering all changes
   above, written before implementation following TDD.

## Test plan

- [x] Added `test/Compact/IsAggregationSquash.ts` — 11 tests for the shared utility
- [x] Added `test/breed/ParentSelection.ts` — 5 tests for shared parent selection
- [x] Added `test/blackbox/MemeticUpdateDuplicateLoop.ts` — 5 tests for memetic update
- [x] Added `test/NEAT/LogApproachDiscoveryReplay.ts` — 2 tests for discovery-replay type safety
- [x] Added `test/mutate/ModSquashFocusRelaxation.ts` — 3 tests for focus-list relaxation
- [x] All 2553 tests pass via `./quality.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)