### PR TITLE
DRY: Extract shared base for mutation operators (#1396)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.28",
+  "version": "0.310.29",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1396.md
+++ b/docs/pr-summary-1396.md
@@ -1,0 +1,41 @@
+## Summary
+
+Extract shared base utilities for mutation operators in `src/mutate/` to eliminate duplicated patterns. Closes #1396.
+
+Created `src/mutate/MutationUtils.ts` with four shared helpers:
+
+- **`selectFocusedNeuronIndex`**: Focus-aware neuron selection with retry and relaxation — replaces identical 12-attempt loops in `ModBias` and `ModSquash`
+- **`cleanupDisconnectedNeuron`**: Orphaned neuron cleanup (remove completely disconnected, or convert to constant) — replaces duplicate ~20-line blocks in `SubSelfCon` and `SubBackCon`
+- **`validateAndBumpForwardOnly`**: Forward-only validation with version-aware error handling and version bumping — replaces two duplicate try/catch blocks in `AddConnection`
+- **`bumpToFourIfForwardOnlyConfirmed`**: Semantic version bump helper (2.x/3.x → 4.0.0)
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/mutate/MutationUtils.ts` | **New** — shared utility module |
+| `test/mutate/MutationUtils.ts` | **New** — 13 tests for all utility functions |
+| `src/mutate/AddConnection.ts` | Replaced 2 duplicated validation blocks with `validateAndBumpForwardOnly` |
+| `src/mutate/ModBias.ts` | Replaced selection loop with `selectFocusedNeuronIndex` |
+| `src/mutate/ModSquash.ts` | Replaced selection loop with `selectFocusedNeuronIndex` |
+| `src/mutate/SubSelfCon.ts` | Replaced cleanup block with `cleanupDisconnectedNeuron` |
+| `src/mutate/SubBackCon.ts` | Replaced cleanup block with `cleanupDisconnectedNeuron` |
+
+Net reduction: **~117 lines** removed across 5 mutation files (143 deletions, 26 insertions in existing files).
+
+## Evidence
+
+This is a pure refactoring with no UI changes. All 2597 existing tests pass, confirming behaviour is preserved. The refactoring was validated by:
+
+- Running all mutation-specific tests (32 tests across ModBias, ModSquash, SubSelfCon, SubBackCon, AddConnection, and related test files)
+- Running forward-only validation tests (MutatorDoesNotCorruptForwardOnlyFourX, MutatorRepairsForwardOnlyFourXCorruption)
+- Running the full `quality.sh` gate (fmt, lint, type-check, all 2597 tests)
+
+## Test Plan
+
+- Added `test/mutate/MutationUtils.ts` with 13 tests covering:
+  - `selectFocusedNeuronIndex`: selects non-input neurons, skips constants, respects focus list, handles edge cases
+  - `cleanupDisconnectedNeuron`: removes disconnected neurons, converts to constant, preserves connected neurons, ignores non-hidden
+  - `bumpToFourIfForwardOnlyConfirmed`: bumps 2.x/3.x to 4.0.0, preserves 4.x
+  - `validateAndBumpForwardOnly`: validates and bumps valid creatures, preserves existing 4.x versions
+- All existing mutation tests continue to pass unchanged

--- a/docs/pr-summary-1396.md
+++ b/docs/pr-summary-1396.md
@@ -1,41 +1,55 @@
 ## Summary
 
-Extract shared base utilities for mutation operators in `src/mutate/` to eliminate duplicated patterns. Closes #1396.
+Extract shared base utilities for mutation operators in `src/mutate/` to
+eliminate duplicated patterns. Closes #1396.
 
 Created `src/mutate/MutationUtils.ts` with four shared helpers:
 
-- **`selectFocusedNeuronIndex`**: Focus-aware neuron selection with retry and relaxation — replaces identical 12-attempt loops in `ModBias` and `ModSquash`
-- **`cleanupDisconnectedNeuron`**: Orphaned neuron cleanup (remove completely disconnected, or convert to constant) — replaces duplicate ~20-line blocks in `SubSelfCon` and `SubBackCon`
-- **`validateAndBumpForwardOnly`**: Forward-only validation with version-aware error handling and version bumping — replaces two duplicate try/catch blocks in `AddConnection`
-- **`bumpToFourIfForwardOnlyConfirmed`**: Semantic version bump helper (2.x/3.x → 4.0.0)
+- **`selectFocusedNeuronIndex`**: Focus-aware neuron selection with retry and
+  relaxation — replaces identical 12-attempt loops in `ModBias` and `ModSquash`
+- **`cleanupDisconnectedNeuron`**: Orphaned neuron cleanup (remove completely
+  disconnected, or convert to constant) — replaces duplicate ~20-line blocks in
+  `SubSelfCon` and `SubBackCon`
+- **`validateAndBumpForwardOnly`**: Forward-only validation with version-aware
+  error handling and version bumping — replaces two duplicate try/catch blocks
+  in `AddConnection`
+- **`bumpToFourIfForwardOnlyConfirmed`**: Semantic version bump helper (2.x/3.x
+  → 4.0.0)
 
 ### Files changed
 
-| File | Change |
-|------|--------|
-| `src/mutate/MutationUtils.ts` | **New** — shared utility module |
-| `test/mutate/MutationUtils.ts` | **New** — 13 tests for all utility functions |
-| `src/mutate/AddConnection.ts` | Replaced 2 duplicated validation blocks with `validateAndBumpForwardOnly` |
-| `src/mutate/ModBias.ts` | Replaced selection loop with `selectFocusedNeuronIndex` |
-| `src/mutate/ModSquash.ts` | Replaced selection loop with `selectFocusedNeuronIndex` |
-| `src/mutate/SubSelfCon.ts` | Replaced cleanup block with `cleanupDisconnectedNeuron` |
-| `src/mutate/SubBackCon.ts` | Replaced cleanup block with `cleanupDisconnectedNeuron` |
+| File                           | Change                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------- |
+| `src/mutate/MutationUtils.ts`  | **New** — shared utility module                                           |
+| `test/mutate/MutationUtils.ts` | **New** — 13 tests for all utility functions                              |
+| `src/mutate/AddConnection.ts`  | Replaced 2 duplicated validation blocks with `validateAndBumpForwardOnly` |
+| `src/mutate/ModBias.ts`        | Replaced selection loop with `selectFocusedNeuronIndex`                   |
+| `src/mutate/ModSquash.ts`      | Replaced selection loop with `selectFocusedNeuronIndex`                   |
+| `src/mutate/SubSelfCon.ts`     | Replaced cleanup block with `cleanupDisconnectedNeuron`                   |
+| `src/mutate/SubBackCon.ts`     | Replaced cleanup block with `cleanupDisconnectedNeuron`                   |
 
-Net reduction: **~117 lines** removed across 5 mutation files (143 deletions, 26 insertions in existing files).
+Net reduction: **~117 lines** removed across 5 mutation files (143 deletions, 26
+insertions in existing files).
 
 ## Evidence
 
-This is a pure refactoring with no UI changes. All 2597 existing tests pass, confirming behaviour is preserved. The refactoring was validated by:
+This is a pure refactoring with no UI changes. All 2597 existing tests pass,
+confirming behaviour is preserved. The refactoring was validated by:
 
-- Running all mutation-specific tests (32 tests across ModBias, ModSquash, SubSelfCon, SubBackCon, AddConnection, and related test files)
-- Running forward-only validation tests (MutatorDoesNotCorruptForwardOnlyFourX, MutatorRepairsForwardOnlyFourXCorruption)
+- Running all mutation-specific tests (32 tests across ModBias, ModSquash,
+  SubSelfCon, SubBackCon, AddConnection, and related test files)
+- Running forward-only validation tests (MutatorDoesNotCorruptForwardOnlyFourX,
+  MutatorRepairsForwardOnlyFourXCorruption)
 - Running the full `quality.sh` gate (fmt, lint, type-check, all 2597 tests)
 
 ## Test Plan
 
 - Added `test/mutate/MutationUtils.ts` with 13 tests covering:
-  - `selectFocusedNeuronIndex`: selects non-input neurons, skips constants, respects focus list, handles edge cases
-  - `cleanupDisconnectedNeuron`: removes disconnected neurons, converts to constant, preserves connected neurons, ignores non-hidden
+  - `selectFocusedNeuronIndex`: selects non-input neurons, skips constants,
+    respects focus list, handles edge cases
+  - `cleanupDisconnectedNeuron`: removes disconnected neurons, converts to
+    constant, preserves connected neurons, ignores non-hidden
   - `bumpToFourIfForwardOnlyConfirmed`: bumps 2.x/3.x to 4.0.0, preserves 4.x
-  - `validateAndBumpForwardOnly`: validates and bumps valid creatures, preserves existing 4.x versions
+  - `validateAndBumpForwardOnly`: validates and bumps valid creatures, preserves
+    existing 4.x versions
 - All existing mutation tests continue to pass unchanged

--- a/src/mutate/AddConnection.ts
+++ b/src/mutate/AddConnection.ts
@@ -4,14 +4,7 @@ import type { Creature } from "../Creature.ts";
 import type { Neuron } from "../architecture/Neuron.ts";
 import { Synapse } from "../architecture/Synapse.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
-import { getMajorVersion } from "../upgrade/Upgrade.ts";
-
-function bumpToFourIfForwardOnlyConfirmed(creature: Creature): void {
-  const major = getMajorVersion(creature.semanticVersion);
-  if (major === 2 || major === 3) {
-    creature.semanticVersion = "4.0.0";
-  }
-}
+import { validateAndBumpForwardOnly } from "./MutationUtils.ts";
 
 export class AddConnection implements RadioactiveInterface {
   private creature: Creature;
@@ -38,33 +31,12 @@ export class AddConnection implements RadioactiveInterface {
     const enforceForwardOnly = this.creature.forwardOnly === true;
 
     if (enforceForwardOnly) {
-      const major = getMajorVersion(this.creature.semanticVersion);
       // Fail fast for 4.x+ (hard invariant). For pre-4.x we repair and continue,
       // because forward-only is not yet a hard guarantee until validated+upgraded.
-      try {
-        this.creature.validate({ forwardOnly: true });
-        bumpToFourIfForwardOnlyConfirmed(this.creature);
-      } catch (e) {
-        const error = e as Error;
-        if (major >= 4) {
-          throw new Error(
-            `[AddConnection] CRITICAL: 4.x forward-only creature is invalid before mutation: ` +
-              `${error.name} - ${error.message}`,
-          );
-        }
-
-        if (
-          error.name === "SELF_CONNECTION" || error.name === "RECURSIVE_SYNAPSE"
-        ) {
-          // Australian English: forward-only pre-4.x may temporarily be invalid; repair it
-          // so we can continue evolution and only lock the invariant once confirmed.
-          this.creature.fix({ forwardOnly: true });
-          this.creature.validate({ forwardOnly: true });
-          bumpToFourIfForwardOnlyConfirmed(this.creature);
-        } else {
-          throw e;
-        }
-      }
+      validateAndBumpForwardOnly(
+        this.creature,
+        "AddConnection before mutation",
+      );
 
       // Forward-only invariant: neuron indices must be consistent.
       //
@@ -121,29 +93,10 @@ export class AddConnection implements RadioactiveInterface {
     if (enforceForwardOnly) {
       // Validation is useful. For 4.x+ this is a hard failure; for pre-4.x we can
       // repair and continue, then bump to 4.x once forward-only is confirmed.
-      const major = getMajorVersion(this.creature.semanticVersion);
-      try {
-        this.creature.validate({ forwardOnly: true });
-        bumpToFourIfForwardOnlyConfirmed(this.creature);
-      } catch (e) {
-        const error = e as Error;
-        if (major >= 4) {
-          throw new Error(
-            `[AddConnection] CRITICAL: 4.x forward-only creature became invalid after mutation: ` +
-              `${error.name} - ${error.message}`,
-          );
-        }
-
-        if (
-          error.name === "SELF_CONNECTION" || error.name === "RECURSIVE_SYNAPSE"
-        ) {
-          this.creature.fix({ forwardOnly: true });
-          this.creature.validate({ forwardOnly: true });
-          bumpToFourIfForwardOnlyConfirmed(this.creature);
-        } else {
-          throw e;
-        }
-      }
+      validateAndBumpForwardOnly(
+        this.creature,
+        "AddConnection after mutation",
+      );
     }
     delete this.creature.memetic;
     return true;

--- a/src/mutate/ModBias.ts
+++ b/src/mutate/ModBias.ts
@@ -1,6 +1,7 @@
 import type { Creature } from "../Creature.ts";
 import { Mutation } from "../NEAT/Mutation.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
+import { selectFocusedNeuronIndex } from "./MutationUtils.ts";
 
 export class ModBias implements RadioactiveInterface {
   private creature: Creature;
@@ -14,20 +15,9 @@ export class ModBias implements RadioactiveInterface {
    * @param {number[]} [focusList] - The list of focus indices.
    */
   mutate(focusList?: number[]): boolean {
-    let changed = false;
-    for (let attempts = 0; attempts < 12; attempts++) {
-      // Has no effect on input node, so they are excluded
-      const index = Math.floor(
-        Math.random() * (this.creature.neurons.length - this.creature.input) +
-          this.creature.input,
-      );
-      const neuron = this.creature.neurons[index];
-      if (neuron.type === "constant") continue;
-      if (!this.creature.inFocus(index, focusList) && attempts < 6) continue;
-      changed = neuron.mutate(Mutation.MOD_BIAS.name);
-      break;
-    }
+    const index = selectFocusedNeuronIndex(this.creature, focusList);
+    if (index === -1) return false;
 
-    return changed;
+    return this.creature.neurons[index].mutate(Mutation.MOD_BIAS.name);
   }
 }

--- a/src/mutate/ModSquash.ts
+++ b/src/mutate/ModSquash.ts
@@ -1,6 +1,7 @@
 import type { Creature } from "../Creature.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
 import { Mutation } from "../../mod.ts";
+import { selectFocusedNeuronIndex } from "./MutationUtils.ts";
 
 export class ModActivation implements RadioactiveInterface {
   private creature: Creature;
@@ -9,22 +10,12 @@ export class ModActivation implements RadioactiveInterface {
   }
 
   mutate(focusList?: number[]): boolean {
-    let changed = false;
-    for (let attempts = 0; attempts < 12; attempts++) {
-      const index = Math.floor(
-        Math.random() * (
-              this.creature.neurons.length -
-              this.creature.input
-            ) + this.creature.input,
-      );
-      const neuron = this.creature.neurons[index];
+    const index = selectFocusedNeuronIndex(this.creature, focusList);
+    if (index === -1) return false;
 
-      if (neuron.type === "constant") continue;
-
-      if (!this.creature.inFocus(index, focusList) && attempts < 6) continue;
-      changed = neuron.mutate(Mutation.MOD_SQUASH.name);
-      break;
-    }
+    const changed = this.creature.neurons[index].mutate(
+      Mutation.MOD_SQUASH.name,
+    );
 
     if (changed) {
       delete this.creature.memetic;

--- a/src/mutate/MutationUtils.ts
+++ b/src/mutate/MutationUtils.ts
@@ -1,0 +1,148 @@
+import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
+import type { Creature } from "../Creature.ts";
+import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
+import { getMajorVersion } from "../upgrade/Upgrade.ts";
+
+/**
+ * Selects a random non-input, non-constant neuron index with focus-aware retry.
+ *
+ * Used by ModBias, ModSquash, and similar mutations that target a single neuron.
+ * Tries up to `maxAttempts` times; relaxes the focus constraint after `relaxAfter`
+ * attempts so the mutation can still proceed when the focus list is very restrictive.
+ *
+ * @param creature - The creature whose neurons to select from
+ * @param focusList - Optional focus list for targeted mutations
+ * @param maxAttempts - Maximum selection attempts (default 12)
+ * @param relaxAfter - Relax focus constraint after this many attempts (default 6)
+ * @returns The selected neuron index, or -1 if no valid neuron found
+ */
+export function selectFocusedNeuronIndex(
+  creature: Creature,
+  focusList?: number[],
+  maxAttempts?: number,
+  relaxAfter?: number,
+): number {
+  const effectiveMax = maxAttempts ?? 12;
+  const effectiveRelax = relaxAfter ?? 6;
+
+  for (let attempts = 0; attempts < effectiveMax; attempts++) {
+    const index = Math.floor(
+      Math.random() * (creature.neurons.length - creature.input) +
+        creature.input,
+    );
+    const neuron = creature.neurons[index];
+    if (neuron.type === "constant") continue;
+    if (
+      !creature.inFocus(index, focusList) && attempts < effectiveRelax
+    ) {
+      continue;
+    }
+    return index;
+  }
+
+  return -1;
+}
+
+/**
+ * Handles cleanup of a neuron that has lost all inward connections.
+ *
+ * When a synapse removal leaves a hidden neuron with no inward connections:
+ * - If it also has no outward connections, remove it entirely
+ * - If it still has outward connections, convert it to a constant
+ *   (squashing its bias through the activation function)
+ *
+ * Used by SubSelfCon and SubBackCon after disconnecting synapses.
+ *
+ * @param creature - The creature containing the neuron
+ * @param neuronIndex - The index of the neuron to check
+ * @returns true if the neuron was removed (indices shifted), false otherwise
+ */
+export function cleanupDisconnectedNeuron(
+  creature: Creature,
+  neuronIndex: number,
+): boolean {
+  const inwardList = creature.inwardConnections(neuronIndex);
+  if (inwardList.length > 0) return false;
+
+  const neuron = creature.neurons[neuronIndex];
+  if (neuron.type !== "hidden") return false;
+
+  const outwardList = creature.outwardConnections(neuronIndex);
+  if (outwardList.length === 0) {
+    console.info(
+      `Remove neuron ${neuron.uuid} as completely disconnected`,
+    );
+    removeHiddenNeuron(creature, neuronIndex);
+    return true;
+  }
+
+  // Convert to constant: squash the bias through the activation function
+  console.info(
+    `Convert neuron ${neuron.uuid} from ${neuron.type} to constant`,
+  );
+  const squash = neuron.findSquash();
+  const activation = squash as ActivationInterface;
+  if (activation.squash) {
+    const constantBias = activation.squash(neuron.bias);
+    console.info(
+      `Adjust neuron ${neuron.uuid} bias ${neuron.bias} to ${constantBias}`,
+    );
+    neuron.bias = constantBias;
+  }
+  neuron.type = "constant";
+  neuron.setSquash(undefined);
+  return false;
+}
+
+/**
+ * Validates a forward-only creature and bumps its semantic version to 4.x
+ * if it passes validation. For 4.x creatures, validation failures are fatal.
+ * For pre-4.x creatures, self-connection or recursive synapse errors trigger
+ * a fix-and-revalidate cycle.
+ *
+ * @param creature - The creature to validate
+ * @param operationName - Name of the calling operation for error messages
+ */
+export function validateAndBumpForwardOnly(
+  creature: Creature,
+  operationName: string,
+): void {
+  const major = getMajorVersion(creature.semanticVersion);
+  try {
+    creature.validate({ forwardOnly: true });
+    bumpToFourIfForwardOnlyConfirmed(creature);
+  } catch (e) {
+    const error = e as Error;
+    if (major >= 4) {
+      throw new Error(
+        `[${operationName}] CRITICAL: 4.x forward-only creature is invalid: ` +
+          `${error.name} - ${error.message}`,
+      );
+    }
+
+    if (
+      error.name === "SELF_CONNECTION" || error.name === "RECURSIVE_SYNAPSE"
+    ) {
+      creature.fix({ forwardOnly: true });
+      creature.validate({ forwardOnly: true });
+      bumpToFourIfForwardOnlyConfirmed(creature);
+    } else {
+      throw e;
+    }
+  }
+}
+
+/**
+ * Bumps the creature's semantic version to 4.0.0 if it is currently 2.x or 3.x.
+ *
+ * This confirms the creature as forward-only once validated, locking in the
+ * hard forward-only invariant from 4.x onward.
+ *
+ * @param creature - The creature whose version to bump
+ */
+export function bumpToFourIfForwardOnlyConfirmed(creature: Creature): void {
+  const major = getMajorVersion(creature.semanticVersion);
+  if (major === 2 || major === 3) {
+    creature.semanticVersion = "4.0.0";
+  }
+}

--- a/src/mutate/SubBackCon.ts
+++ b/src/mutate/SubBackCon.ts
@@ -1,7 +1,7 @@
 import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
 import type { Creature } from "../Creature.ts";
-import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
+import { cleanupDisconnectedNeuron } from "./MutationUtils.ts";
 
 export class SubBackCon implements RadioactiveInterface {
   private creature: Creature;
@@ -39,36 +39,10 @@ export class SubBackCon implements RadioactiveInterface {
     delete this.creature.memetic;
 
     // Cleanup: Check if TO neuron needs handling
-    const inwardList = this.creature.inwardConnections(pair[1]);
-    let toNeuronRemoved = false;
-    if (inwardList.length === 0) {
-      const toNeuron = this.creature.neurons[pair[1]];
-      if (toNeuron.type === "hidden") {
-        const outwardList = this.creature.outwardConnections(pair[1]);
-        if (outwardList.length === 0) {
-          console.info(
-            `Remove neuron ${toNeuron.uuid} as completely disconnected`,
-          );
-          removeHiddenNeuron(this.creature, pair[1]);
-          toNeuronRemoved = true;
-        } else {
-          console.info(
-            `Convert neuron ${toNeuron.uuid} from ${toNeuron.type} to constant`,
-          );
-          const squash = toNeuron.findSquash();
-          const activation = squash as ActivationInterface;
-          if (activation.squash) {
-            const constantBias = activation.squash(toNeuron.bias);
-            console.info(
-              `Adjust neuron ${toNeuron.uuid} bias ${toNeuron.bias} to ${constantBias}`,
-            );
-            toNeuron.bias = constantBias;
-          }
-          toNeuron.type = "constant";
-          toNeuron.setSquash(undefined);
-        }
-      }
-    }
+    const toNeuronRemoved = cleanupDisconnectedNeuron(
+      this.creature,
+      pair[1],
+    );
 
     // Adjust the 'from' index if the 'to' neuron was removed and it came before the 'from' neuron
     let fromIndex = pair[0];

--- a/src/mutate/SubSelfCon.ts
+++ b/src/mutate/SubSelfCon.ts
@@ -1,7 +1,6 @@
-import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
 import type { Creature } from "../Creature.ts";
-import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
+import { cleanupDisconnectedNeuron } from "./MutationUtils.ts";
 
 export class SubSelfCon implements RadioactiveInterface {
   private creature: Creature;
@@ -43,31 +42,7 @@ export class SubSelfCon implements RadioactiveInterface {
     delete this.creature.memetic;
 
     // Cleanup: Check if neuron now needs handling after losing self-connection
-    const inwardList = this.creature.inwardConnections(indx);
-    if (inwardList.length === 0 && neuron.type === "hidden") {
-      const outwardList = this.creature.outwardConnections(indx);
-      if (outwardList.length === 0) {
-        console.info(
-          `Remove neuron ${neuron.uuid} as completely disconnected`,
-        );
-        removeHiddenNeuron(this.creature, indx);
-      } else {
-        console.info(
-          `Convert neuron ${neuron.uuid} from ${neuron.type} to constant`,
-        );
-        const squash = neuron.findSquash();
-        const activation = squash as ActivationInterface;
-        if (activation.squash) {
-          const constantBias = activation.squash(neuron.bias);
-          console.info(
-            `Adjust neuron ${neuron.uuid} bias ${neuron.bias} to ${constantBias}`,
-          );
-          neuron.bias = constantBias;
-        }
-        neuron.type = "constant";
-        neuron.setSquash(undefined);
-      }
-    }
+    cleanupDisconnectedNeuron(this.creature, indx);
 
     return true;
   }

--- a/test/mutate/MutationUtils.ts
+++ b/test/mutate/MutationUtils.ts
@@ -1,0 +1,296 @@
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
+import {
+  bumpToFourIfForwardOnlyConfirmed,
+  cleanupDisconnectedNeuron,
+  selectFocusedNeuronIndex,
+  validateAndBumpForwardOnly,
+} from "../../src/mutate/MutationUtils.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+// --- selectFocusedNeuronIndex ---
+
+Deno.test("selectFocusedNeuronIndex - selects a non-input neuron", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 3 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 2, to: 3, weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+  });
+
+  for (let i = 0; i < 50; i++) {
+    const index = selectFocusedNeuronIndex(creature);
+    assert(index >= creature.input, "Should select non-input neuron");
+    assert(
+      index < creature.neurons.length,
+      "Should be within bounds",
+    );
+  }
+});
+
+Deno.test("selectFocusedNeuronIndex - skips constant neurons", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "constant", bias: 1.0, index: 2 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 3 },
+    ],
+    synapses: [
+      { from: 0, to: 3, weight: 1.0 },
+      { from: 2, to: 3, weight: 0.5 },
+    ],
+    input: 2,
+    output: 1,
+  });
+
+  // Should only select the output neuron (index 3), never the constant (index 2)
+  for (let i = 0; i < 50; i++) {
+    const index = selectFocusedNeuronIndex(creature);
+    if (index !== -1) {
+      assertEquals(index, 3, "Should only select the output neuron");
+    }
+  }
+});
+
+Deno.test("selectFocusedNeuronIndex - respects focus list", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+      { type: "hidden", squash: "LOGISTIC", bias: 0.3, index: 3 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 4 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 1, to: 3, weight: 1.0 },
+      { from: 2, to: 4, weight: 0.8 },
+      { from: 3, to: 4, weight: 0.9 },
+    ],
+    input: 2,
+    output: 1,
+  });
+
+  // With a focus list targeting index 2, we should often select index 2
+  let selectedIndex2 = false;
+  for (let i = 0; i < 100; i++) {
+    const index = selectFocusedNeuronIndex(creature, [2]);
+    if (index === 2) {
+      selectedIndex2 = true;
+      break;
+    }
+  }
+  assert(selectedIndex2, "Should eventually select the focused neuron");
+});
+
+Deno.test("selectFocusedNeuronIndex - returns -1 when only constants exist", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "constant", bias: 1.0, index: 1 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 2 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 1, to: 2, weight: 0.5 },
+    ],
+    input: 1,
+    output: 1,
+  });
+
+  // With only 2 non-input slots (constant + output) and maxAttempts=2,
+  // the output may be found. With only constants and maxAttempts=1,
+  // it could return -1
+  const index = selectFocusedNeuronIndex(creature, undefined, 1);
+  // Result is non-deterministic due to randomness; just verify the range
+  if (index !== -1) {
+    assert(index >= creature.input, "Should be non-input if found");
+  }
+});
+
+// --- cleanupDisconnectedNeuron ---
+
+Deno.test("cleanupDisconnectedNeuron - removes completely disconnected hidden neuron", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 3 },
+    ],
+    synapses: [
+      { from: 0, to: 3, weight: 1.0 },
+      { from: 1, to: 3, weight: 0.9 },
+    ],
+    input: 2,
+    output: 1,
+  });
+
+  // Neuron at index 2 has no inward or outward connections
+  const neuronCountBefore = creature.neurons.length;
+  const removed = cleanupDisconnectedNeuron(creature, 2);
+
+  assert(removed, "Should remove completely disconnected neuron");
+  assertEquals(
+    creature.neurons.length,
+    neuronCountBefore - 1,
+    "Neuron count should decrease by 1",
+  );
+  creatureValidate(creature);
+});
+
+Deno.test("cleanupDisconnectedNeuron - converts to constant when no inward but has outward", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 3 },
+    ],
+    synapses: [
+      { from: 2, to: 3, weight: 0.8 },
+      { from: 0, to: 3, weight: 1.0 },
+    ],
+    input: 2,
+    output: 1,
+  });
+
+  // Neuron at index 2 has no inward connections but has outward to 3
+  const removed = cleanupDisconnectedNeuron(creature, 2);
+
+  assertFalse(removed, "Should not remove neuron with outward connections");
+  assertEquals(
+    creature.neurons[2].type,
+    "constant",
+    "Should convert to constant",
+  );
+  creatureValidate(creature);
+});
+
+Deno.test("cleanupDisconnectedNeuron - does nothing when neuron has inward connections", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 3 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 2, to: 3, weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+  });
+
+  const neuronCountBefore = creature.neurons.length;
+  const typeBefore = creature.neurons[2].type;
+  const removed = cleanupDisconnectedNeuron(creature, 2);
+
+  assertFalse(removed, "Should not remove neuron with inward connections");
+  assertEquals(
+    creature.neurons.length,
+    neuronCountBefore,
+    "Neuron count should not change",
+  );
+  assertEquals(creature.neurons[2].type, typeBefore, "Type should not change");
+  creatureValidate(creature);
+});
+
+Deno.test("cleanupDisconnectedNeuron - does nothing for non-hidden neurons", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 2 },
+    ],
+    synapses: [],
+    input: 2,
+    output: 1,
+  });
+
+  const removed = cleanupDisconnectedNeuron(creature, 2);
+  assertFalse(removed, "Should not remove output neurons");
+});
+
+// --- bumpToFourIfForwardOnlyConfirmed ---
+
+Deno.test("bumpToFourIfForwardOnlyConfirmed - bumps 2.x to 4.0.0", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 2 },
+    ],
+    synapses: [{ from: 0, to: 2, weight: 1.0 }],
+    input: 2,
+    output: 1,
+  });
+  creature.semanticVersion = "2.1.0";
+  bumpToFourIfForwardOnlyConfirmed(creature);
+  assertEquals(creature.semanticVersion, "4.0.0");
+});
+
+Deno.test("bumpToFourIfForwardOnlyConfirmed - bumps 3.x to 4.0.0", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 2 },
+    ],
+    synapses: [{ from: 0, to: 2, weight: 1.0 }],
+    input: 2,
+    output: 1,
+  });
+  creature.semanticVersion = "3.0.0";
+  bumpToFourIfForwardOnlyConfirmed(creature);
+  assertEquals(creature.semanticVersion, "4.0.0");
+});
+
+Deno.test("bumpToFourIfForwardOnlyConfirmed - does not change 4.x", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 2 },
+    ],
+    synapses: [{ from: 0, to: 2, weight: 1.0 }],
+    input: 2,
+    output: 1,
+  });
+  creature.semanticVersion = "4.1.0";
+  bumpToFourIfForwardOnlyConfirmed(creature);
+  assertEquals(creature.semanticVersion, "4.1.0");
+});
+
+// --- validateAndBumpForwardOnly ---
+
+Deno.test("validateAndBumpForwardOnly - validates and bumps valid forward-only creature", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 3 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 2, to: 3, weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+  });
+  creature.forwardOnly = true;
+  creature.semanticVersion = "3.0.0";
+
+  validateAndBumpForwardOnly(creature, "TestOp");
+  assertEquals(creature.semanticVersion, "4.0.0");
+});
+
+Deno.test("validateAndBumpForwardOnly - already 4.x stays at same version", () => {
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 3 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 2, to: 3, weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+  });
+  creature.forwardOnly = true;
+  creature.semanticVersion = "4.2.0";
+
+  validateAndBumpForwardOnly(creature, "TestOp");
+  assertEquals(creature.semanticVersion, "4.2.0");
+});


### PR DESCRIPTION
## Summary

Extract shared base utilities for mutation operators in `src/mutate/` to eliminate duplicated patterns. Closes #1396.

Created `src/mutate/MutationUtils.ts` with four shared helpers:

- **`selectFocusedNeuronIndex`**: Focus-aware neuron selection with retry and relaxation — replaces identical 12-attempt loops in `ModBias` and `ModSquash`
- **`cleanupDisconnectedNeuron`**: Orphaned neuron cleanup (remove completely disconnected, or convert to constant) — replaces duplicate ~20-line blocks in `SubSelfCon` and `SubBackCon`
- **`validateAndBumpForwardOnly`**: Forward-only validation with version-aware error handling and version bumping — replaces two duplicate try/catch blocks in `AddConnection`
- **`bumpToFourIfForwardOnlyConfirmed`**: Semantic version bump helper (2.x/3.x → 4.0.0)

### Files changed

| File | Change |
|------|--------|
| `src/mutate/MutationUtils.ts` | **New** — shared utility module |
| `test/mutate/MutationUtils.ts` | **New** — 13 tests for all utility functions |
| `src/mutate/AddConnection.ts` | Replaced 2 duplicated validation blocks with `validateAndBumpForwardOnly` |
| `src/mutate/ModBias.ts` | Replaced selection loop with `selectFocusedNeuronIndex` |
| `src/mutate/ModSquash.ts` | Replaced selection loop with `selectFocusedNeuronIndex` |
| `src/mutate/SubSelfCon.ts` | Replaced cleanup block with `cleanupDisconnectedNeuron` |
| `src/mutate/SubBackCon.ts` | Replaced cleanup block with `cleanupDisconnectedNeuron` |

Net reduction: **~117 lines** removed across 5 mutation files (143 deletions, 26 insertions in existing files).

## Evidence

This is a pure refactoring with no UI changes. All 2597 existing tests pass, confirming behaviour is preserved. The refactoring was validated by:

- Running all mutation-specific tests (32 tests across ModBias, ModSquash, SubSelfCon, SubBackCon, AddConnection, and related test files)
- Running forward-only validation tests (MutatorDoesNotCorruptForwardOnlyFourX, MutatorRepairsForwardOnlyFourXCorruption)
- Running the full `quality.sh` gate (fmt, lint, type-check, all 2597 tests)

## Test Plan

- Added `test/mutate/MutationUtils.ts` with 13 tests covering:
  - `selectFocusedNeuronIndex`: selects non-input neurons, skips constants, respects focus list, handles edge cases
  - `cleanupDisconnectedNeuron`: removes disconnected neurons, converts to constant, preserves connected neurons, ignores non-hidden
  - `bumpToFourIfForwardOnlyConfirmed`: bumps 2.x/3.x to 4.0.0, preserves 4.x
  - `validateAndBumpForwardOnly`: validates and bumps valid creatures, preserves existing 4.x versions
- All existing mutation tests continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)