### PR TITLE
Refactor: Replace console logging with structured Logger abstraction (#1398)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.32",
+  "version": "0.310.33",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -202,6 +202,7 @@
     "finaliser",
     "mergesort",
     "NONEXISTENT",
-    "incl"
+    "incl",
+    "passthrough"
   ]
 }

--- a/docs/pr-summary-1398.md
+++ b/docs/pr-summary-1398.md
@@ -1,0 +1,58 @@
+# Refactor: Replace console logging with structured Logger abstraction (#1398)
+
+Closes #1398
+
+## Summary
+
+Replaced ~350 scattered `console.log/info/warn/error/debug` calls across the
+codebase with a configurable structured Logger abstraction. Consumers can now
+inject a custom logger via `NeatOptions`, control log verbosity with `logLevel`,
+or call `setLogger()` globally.
+
+## What Changed
+
+### New Files
+- **`src/utils/Logger.ts`** -- `Logger` interface, `LogLevel` type,
+  `createConsoleLogger()` factory with level filtering, `SILENT_LOGGER`,
+  `getLogger()`/`setLogger()` global accessor pair.
+- **`test/utils/Logger.ts`** -- 10 unit tests covering level filtering,
+  silent logger, round-trip get/set, argument passthrough, console method
+  mapping.
+- **`test/config/LoggerConfig.ts`** -- 8 integration tests covering config
+  defaults, custom logger injection, `logLevel` filtering, global logger
+  propagation, config freeze.
+
+### Config Integration
+- **`NeatArguments.ts`** -- Added `logger: Logger` field.
+- **`NeatOptions.ts`** -- Added `logger?: Logger` and `logLevel?: LogLevel`
+  options (omitted from `NeatOptionsInput` `CoerceNumeric` coercion since
+  loggers are not CLI-serialisable).
+- **`NeatConfig.ts`** -- Creates default console logger from `logLevel`
+  (default `"info"`) or uses the injected `logger`; calls `setLogger()` to
+  propagate globally.
+- **`mod.ts`** -- Exports `createConsoleLogger`, `getLogger`, `setLogger`,
+  `SILENT_LOGGER`, `Logger`, `LogLevel`.
+
+### Console Replacement (46 production files)
+Every `console.log(` was mapped to `getLogger().info(`, `console.info(` to
+`getLogger().info(`, `console.warn(` to `getLogger().warn(`,
+`console.error(` to `getLogger().error(`, `console.debug(` to
+`getLogger().debug(`. JSDoc examples containing `console.log` were
+preserved unchanged.
+
+## Evidence
+
+- `quality.sh` passes: formatting, linting, type-checking, all **2703 tests
+  pass** with 0 failures.
+- Final grep confirms zero remaining production `console.*()` calls outside
+  `Logger.ts` itself and JSDoc comment blocks.
+
+## Test Plan
+
+- [x] `test/utils/Logger.ts` -- Logger interface and level filtering
+- [x] `test/config/LoggerConfig.ts` -- Config integration (custom logger,
+      logLevel, global propagation, freeze)
+- [x] Full test suite (2703 tests) passes with no regressions
+- [x] `deno check` type-checking passes
+- [x] `deno fmt --check` formatting passes
+- [x] `deno lint` linting passes

--- a/docs/pr-summary-1398.md
+++ b/docs/pr-summary-1398.md
@@ -12,33 +12,34 @@ or call `setLogger()` globally.
 ## What Changed
 
 ### New Files
+
 - **`src/utils/Logger.ts`** -- `Logger` interface, `LogLevel` type,
   `createConsoleLogger()` factory with level filtering, `SILENT_LOGGER`,
   `getLogger()`/`setLogger()` global accessor pair.
-- **`test/utils/Logger.ts`** -- 10 unit tests covering level filtering,
-  silent logger, round-trip get/set, argument passthrough, console method
-  mapping.
+- **`test/utils/Logger.ts`** -- 10 unit tests covering level filtering, silent
+  logger, round-trip get/set, argument passthrough, console method mapping.
 - **`test/config/LoggerConfig.ts`** -- 8 integration tests covering config
   defaults, custom logger injection, `logLevel` filtering, global logger
   propagation, config freeze.
 
 ### Config Integration
+
 - **`NeatArguments.ts`** -- Added `logger: Logger` field.
 - **`NeatOptions.ts`** -- Added `logger?: Logger` and `logLevel?: LogLevel`
   options (omitted from `NeatOptionsInput` `CoerceNumeric` coercion since
   loggers are not CLI-serialisable).
-- **`NeatConfig.ts`** -- Creates default console logger from `logLevel`
-  (default `"info"`) or uses the injected `logger`; calls `setLogger()` to
-  propagate globally.
+- **`NeatConfig.ts`** -- Creates default console logger from `logLevel` (default
+  `"info"`) or uses the injected `logger`; calls `setLogger()` to propagate
+  globally.
 - **`mod.ts`** -- Exports `createConsoleLogger`, `getLogger`, `setLogger`,
   `SILENT_LOGGER`, `Logger`, `LogLevel`.
 
 ### Console Replacement (46 production files)
+
 Every `console.log(` was mapped to `getLogger().info(`, `console.info(` to
-`getLogger().info(`, `console.warn(` to `getLogger().warn(`,
-`console.error(` to `getLogger().error(`, `console.debug(` to
-`getLogger().debug(`. JSDoc examples containing `console.log` were
-preserved unchanged.
+`getLogger().info(`, `console.warn(` to `getLogger().warn(`, `console.error(` to
+`getLogger().error(`, `console.debug(` to `getLogger().debug(`. JSDoc examples
+containing `console.log` were preserved unchanged.
 
 ## Evidence
 

--- a/mod.ts
+++ b/mod.ts
@@ -224,3 +224,19 @@ export type {
  * instead of each fetching separately.
  */
 export { fetchWasmForWorkers } from "./src/multithreading/workers/WorkerHandler.ts";
+
+/**
+ * Structured Logger
+ *
+ * Issue #1398: Configurable logging abstraction. Consumers can inject a custom
+ * logger via NeatOptions or call setLogger() globally.
+ *
+ * @see {@link module:src/utils/Logger}
+ */
+export {
+  createConsoleLogger,
+  getLogger,
+  setLogger,
+  SILENT_LOGGER,
+} from "./src/utils/Logger.ts";
+export type { Logger, LogLevel } from "./src/utils/Logger.ts";

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -69,6 +69,7 @@ import {
   evictOldestWasmCreatureActivations,
   noteWasmCreatureActivationUse,
 } from "./wasm/WasmCreatureActivationLRU.ts";
+import { getLogger } from "./utils/Logger.ts";
 
 interface CreatureOptions {
   semanticVersion?: string;
@@ -1743,19 +1744,19 @@ export class Creature implements CreatureInternal {
     // Expected: approximately neurons.length * output (one error per neuron per output)
     const expectedMax = neurons.length * this.output * 3;
     if (totalErrors > expectedMax) {
-      console.error(
+      getLogger().error(
         `❌ CRITICAL: Sample generated ${totalErrors} total errors (expected ≤${expectedMax})`,
       );
-      console.error(
+      getLogger().error(
         `   Neurons: ${neurons.length}, Outputs: ${this.output}, ErrorMap size: ${errorMap.size}`,
       );
       // Log top 5 neurons with most errors
       const sorted = Array.from(errorMap.entries())
         .sort((a, b) => b[1].errors.length - a[1].errors.length)
         .slice(0, 5);
-      console.error(`   Top 5 neurons by error count:`);
+      getLogger().error(`   Top 5 neurons by error count:`);
       sorted.forEach(([uuid, rec]) => {
-        console.error(`     - ${uuid}: ${rec.errors.length} errors`);
+        getLogger().error(`     - ${uuid}: ${rec.errors.length} errors`);
       });
 
       if (totalErrors > expectedMax * 10) {
@@ -1809,7 +1810,7 @@ export class Creature implements CreatureInternal {
   > {
     let interrupted = false;
     const signalListener = () => {
-      console.log("SIGTERM received, saving progress...");
+      getLogger().info("SIGTERM received, saving progress...");
       interrupted = true;
     };
 
@@ -1848,7 +1849,7 @@ export class Creature implements CreatureInternal {
           // Ignore termination errors.
         }
         if (!preferDirect) {
-          console.warn(
+          getLogger().warn(
             "[Creature.evolveDir] Worker init failed; falling back to direct execution for this worker slot.",
             err,
           );
@@ -1932,7 +1933,7 @@ export class Creature implements CreatureInternal {
         if (Number.isFinite(result.averageScore)) {
           avgTxt = `(avg: ${yellow(result.averageScore.toFixed(4))})`;
         }
-        console.log(
+        getLogger().info(
           "Generation",
           generation,
           "score",
@@ -2373,7 +2374,7 @@ export class Creature implements CreatureInternal {
       if (Number.isFinite(averageError)) {
         return { error: averageError };
       } else {
-        console.warn(
+        getLogger().warn(
           `AverageError: ${averageError} is not finite, Error: ${error}, Count: ${count}`,
         );
         return { error: Number.MAX_SAFE_INTEGER };
@@ -2588,11 +2589,11 @@ export class Creature implements CreatureInternal {
       }
 
       if (synapse.to > maxTo) {
-        console.debug("Ignoring connection to above max", maxTo, synapse);
+        getLogger().debug("Ignoring connection to above max", maxTo, synapse);
         return;
       }
       if (synapse.to < minTo) {
-        console.debug("Ignoring connection to below min", minTo, synapse);
+        getLogger().debug("Ignoring connection to below min", minTo, synapse);
         return;
       }
 
@@ -2661,7 +2662,7 @@ export class Creature implements CreatureInternal {
           this.outwardConnections(pos).length === 0
         ) {
           if (this.DEBUG) {
-            console.debug(
+            getLogger().debug(
               `fix() removing disconnected neuron ${pos} ${
                 this.neurons[pos].uuid
               }`,
@@ -2676,7 +2677,7 @@ export class Creature implements CreatureInternal {
 
     for (let i = 1; i < this.synapses.length; i++) {
       if (this.synapses[i - 1].from > this.synapses[i].from) {
-        console.error(
+        getLogger().error(
           "Synapses not sorted",
           this.synapses[i - 1],
           this.synapses[i],

--- a/src/NEAT/DiscoveryReplayQueue.ts
+++ b/src/NEAT/DiscoveryReplayQueue.ts
@@ -5,6 +5,7 @@ import {
   DiscoveryReplayRunner,
 } from "../discovery/DiscoveryReplayRunner.ts";
 import { createNeatConfig } from "../config/NeatConfig.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 // Re-export for use by Neat.ts (Issue #1150)
 export type { DiscoveryReplayDirResult };
@@ -185,7 +186,7 @@ export class DiscoveryReplayQueue {
         this.#completedResults.push(result);
       })
       .catch((error) => {
-        console.error("[DiscoveryReplayQueue] Replay failed:", error);
+        getLogger().error("[DiscoveryReplayQueue] Replay failed:", error);
       })
       .finally(() => {
         this.#replayInProgress = false;

--- a/src/NEAT/LogApproach.ts
+++ b/src/NEAT/LogApproach.ts
@@ -2,6 +2,7 @@ import { addTag, getTag } from "@stsoftware/tags/mod";
 import type { Creature } from "../../mod.ts";
 import { blue, bold, cyan } from "@std/fmt/colors";
 import { assert } from "@std/assert";
+import { getLogger } from "../utils/Logger.ts";
 
 // Define a union type for the possible approaches
 export type Approach =
@@ -35,7 +36,7 @@ export function logApproach(fittest: Creature, previous: Creature) {
         case "fine": {
           const restored = getTag(previous, "restored");
           const restoredMsg = restored ? `Restored: ${restored}` : "";
-          console.info(
+          getLogger().info(
             "Fine tuning increased fitness by",
             fScore - pScore,
             "to",
@@ -47,7 +48,7 @@ export function logApproach(fittest: Creature, previous: Creature) {
           break;
         }
         case "backtrack": {
-          console.info(
+          getLogger().info(
             "Backtracking increased fitness by",
             fScore - pScore,
             "to",
@@ -58,7 +59,7 @@ export function logApproach(fittest: Creature, previous: Creature) {
           break;
         }
         case "simplified": {
-          console.info(
+          getLogger().info(
             "Simplifying improved by",
             fScore - pScore,
             "to",
@@ -67,7 +68,7 @@ export function logApproach(fittest: Creature, previous: Creature) {
           break;
         }
         case "retry": {
-          console.info(
+          getLogger().info(
             "Retrying increased fitness by",
             fScore - pScore,
             "to",
@@ -79,7 +80,7 @@ export function logApproach(fittest: Creature, previous: Creature) {
         }
         case "trained": {
           const trainID = getTag(fittest, "trainID");
-          console.info(
+          getLogger().info(
             bold(cyan("Training")),
             blue(`${trainID}`),
             "increased fitness by",
@@ -96,7 +97,7 @@ export function logApproach(fittest: Creature, previous: Creature) {
           const evaluation = getTag(fittest, "Discovery") ??
             getTag(fittest, "discovery");
 
-          console.info(
+          getLogger().info(
             bold(cyan("Discovery")),
             blue(`${discoveryID}`),
             evaluation ?? cyan("unknown"),
@@ -111,7 +112,7 @@ export function logApproach(fittest: Creature, previous: Creature) {
           const oldNeuronsTxt = getTag(fittest, "old-neurons");
           assert(oldNeuronsTxt, "Old neurons must be defined");
           const oldNeurons = Number.parseInt(oldNeuronsTxt);
-          console.info(
+          getLogger().info(
             "Compacting increased fitness by",
             fScore - pScore,
             "to",

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -22,6 +22,7 @@ import {
   getMajorVersion,
   upgradeSemanticVersionIfForwardOnlyConfirmed,
 } from "../upgrade/Upgrade.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 /**
  * Cache entry for valid mutation candidates.
@@ -468,7 +469,7 @@ export class Mutator {
       creature.forwardOnly === true &&
       majorVersion < 4
     ) {
-      console.warn(
+      getLogger().warn(
         `[Mutator] feedbackLoop=true requested for forwardOnly creature (${startUUID}); clearing creature.forwardOnly flag`,
       );
       creature.forwardOnly = undefined;
@@ -482,7 +483,7 @@ export class Mutator {
     const changed = mutator.mutate(focusList);
 
     if (!changed && (!focusList || focusList.length === 0)) {
-      console.info(
+      getLogger().info(
         `${method.name} didn't mutate the creature. ${creature.input} observations, ${
           creature.neurons.length - creature.input - creature.output
         } neurons, ${creature.output} outputs, ${creature.synapses.length} synapses`,
@@ -535,7 +536,7 @@ export class Mutator {
                   creature.neurons[s.from]?.ID?.() ?? "?"
                 }) -> ${s.to} (${creature.neurons[s.to]?.ID?.() ?? "?"})`
               );
-            console.error(
+            getLogger().error(
               `[Mutator] Forward-only violation after '${method.name}'. This indicates a bug: ` +
                 `creature is marked forwardOnly=${
                   creature.forwardOnly === true
@@ -604,7 +605,7 @@ export class Mutator {
 
     const endUUID = CreatureUtil.makeUUID(creature);
     if (startUUID === endUUID) {
-      console.warn(
+      getLogger().warn(
         `UUID didn't change after ${method.name} mutation, changed: ${changed}`,
       );
       return false;

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -42,6 +42,7 @@ import {
   type DiscoveryReplayDirResult,
   DiscoveryReplayQueue,
 } from "./DiscoveryReplayQueue.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 /**
  * NEAT (NeuroEvolution of Augmenting Topologies) implementation.
@@ -208,7 +209,7 @@ export class Neat {
         this.discoveryInProgress.size > 0 || this.trainingInProgress.size > 0
       ) {
         this.cleanUpDelayCount = 2;
-        console.info(
+        getLogger().info(
           `Set training/discovery clean up count to ${this.cleanUpDelayCount}`,
         );
       }
@@ -252,7 +253,7 @@ export class Neat {
               maxWaitByTime = maxGenerationsIn5Minutes;
             }
 
-            console.info(
+            getLogger().info(
               `Avg time per generation: ${
                 Math.round(avgTimePerGeneration)
               }ms, max wait: ${maxGenerationsIn5Minutes} generations in 5 minutes`,
@@ -275,7 +276,7 @@ export class Neat {
           maxWaitByIterations,
           maxWaitByTime,
         );
-        console.info(
+        getLogger().info(
           `Discovery timeout set to ${this.maxDiscoveryWaitGenerations} generations (based on limiting factor)`,
         );
       }
@@ -286,7 +287,7 @@ export class Neat {
         const stuckUUIDs = Array.from(this.discoveryInProgress.keys()).map(
           (uuid) => uuid.substring(Math.max(0, uuid.length - 8)),
         );
-        console.warn(
+        getLogger().warn(
           `[Neat] Discovery timeout reached after ${this.discoveryWaitGenerations} generations. Clearing stuck discoveries: ${
             stuckUUIDs.join(", ")
           }`,
@@ -303,7 +304,7 @@ export class Neat {
       const inProgressUUIDs = Array.from(this.discoveryInProgress.keys()).map(
         (uuid) => uuid.substring(Math.max(0, uuid.length - 8)),
       );
-      console.info(
+      getLogger().info(
         `[Neat] Waiting for discovery to complete (${this.discoveryWaitGenerations}/${this.maxDiscoveryWaitGenerations}) - In progress: ${
           inProgressUUIDs.join(", ")
         }`,
@@ -313,19 +314,19 @@ export class Neat {
     }
 
     if (this.trainingInProgress.size > 0) {
-      console.info("Waiting for training to complete");
+      getLogger().info("Waiting for training to complete");
       return false;
     }
 
     if (this.cleanUpDelayCount > 0) {
-      console.info(
+      getLogger().info(
         `Waiting for training/discovery clean up ${this.cleanUpDelayCount}`,
       );
       this.cleanUpDelayCount--;
       return false;
     }
     if (this.additionalGenerationCount > 0) {
-      console.info(
+      getLogger().info(
         `Waiting for additional generation${
           this.additionalGenerationCount > 1 ? "s" : ""
         }`,
@@ -370,12 +371,12 @@ export class Neat {
     // Issue #1290: Use work-stealing pool for smarter worker selection
     const w = this.workerPool.selectWorker();
     if (!w) {
-      console.warn("[Neat] No workers available for discovery");
+      getLogger().warn("[Neat] No workers available for discovery");
       return;
     }
 
     if (this.config.verbose) {
-      console.info(
+      getLogger().info(
         `Discovery ${
           blue(uuid.substring(Math.max(0, uuid.length - 8)))
         } scheduled`,
@@ -392,7 +393,7 @@ export class Neat {
     const effectiveTimeout = Math.min(timeOutMinutes, adaptiveTimeout);
 
     if (this.config.verbose) {
-      console.info(
+      getLogger().info(
         `[Neat] Adaptive discovery timeout: ${adaptiveTimeout.toFixed(2)}m ` +
           `(neurons=${creature.neurons.length}, synapses=${creature.synapses.length}), ` +
           `effective=${effectiveTimeout.toFixed(2)}m`,
@@ -407,7 +408,7 @@ export class Neat {
 
     const taskStartTime = Date.now();
     if (this.config.verbose) {
-      console.info(
+      getLogger().info(
         `[Neat] Discovery request sent to worker for ${
           blue(uuid.substring(Math.max(0, uuid.length - 8)))
         }`,
@@ -425,7 +426,7 @@ export class Neat {
       this.lastDiscoveryDurationMS = discoveryDurationMS;
 
       if (this.config.verbose) {
-        console.info(
+        getLogger().info(
           `[Neat] Discovery completed for ${
             blue(uuid.substring(Math.max(0, uuid.length - 8)))
           } after ${(discoveryDurationMS / 1000).toFixed(1)}s`,
@@ -452,7 +453,7 @@ export class Neat {
         r.discover.improvedCreature = improvedCreature.exportJSON();
 
         if (this.config.verbose) {
-          console.info(
+          getLogger().info(
             `[Neat] Built improved creature from discovery ${
               blue(uuid.substring(Math.max(0, uuid.length - 8)))
             } with ${
@@ -466,7 +467,7 @@ export class Neat {
 
       this.discoveryInProgress.delete(uuid);
     }).catch((error) => {
-      console.error(
+      getLogger().error(
         `[Neat] Discovery failed for creature ${
           uuid.substring(Math.max(0, uuid.length - 8))
         } after ${((Date.now() - taskStartTime) / 1000).toFixed(1)}s:`,
@@ -528,13 +529,13 @@ export class Neat {
     if (result.improvement) {
       const changeType = result.improvement.changeType ?? "unknown";
       const scoreDelta = result.improvement.scoreDelta?.toFixed(6) ?? "N/A";
-      console.info(
+      getLogger().info(
         `[Neat] Discovery replay: ${
           blue(changeType)
         } improved score by ${scoreDelta} (${parts.join(", ")})`,
       );
     } else {
-      console.info(
+      getLogger().info(
         `[Neat] Discovery replay: no improvement found (${parts.join(", ")})`,
       );
     }
@@ -545,13 +546,13 @@ export class Neat {
         (e) => e.improved && e.kind !== "original",
       );
       if (successfulCandidates.length > 0) {
-        console.info("[Neat] Successful replay candidates:");
+        getLogger().info("[Neat] Successful replay candidates:");
         for (const candidate of successfulCandidates) {
           const kind = candidate.kind === "combo" ? "combo" : "single";
           const changeType = candidate.changeType ?? "unknown";
           const description = candidate.description ?? candidate.key ?? "";
           const scoreDelta = candidate.scoreDelta?.toFixed(6) ?? "N/A";
-          console.info(
+          getLogger().info(
             `  - [${kind}] ${
               blue(changeType)
             }: ${description} (+${scoreDelta})`,
@@ -593,12 +594,12 @@ export class Neat {
     // Issue #1290: Use work-stealing pool for smarter worker selection
     const w = this.workerPool.selectWorker();
     if (!w) {
-      console.warn("[Neat] No workers available for training");
+      getLogger().warn("[Neat] No workers available for training");
       return;
     }
 
     if (this.config.verbose) {
-      console.info(
+      getLogger().info(
         `Training ${
           blue(uuid.substring(Math.max(0, uuid.length - 8)))
         } scheduled`,
@@ -628,7 +629,7 @@ export class Neat {
 
       let trainingImprovement = true;
       if (r.train.error > parseFloat(errorTx)) {
-        console.warn(
+        getLogger().warn(
           `Training ${
             blue(r.train.ID)
           } caused a higher error of ${r.train.error} from ${errorTx}`,
@@ -679,7 +680,7 @@ export class Neat {
           r.train.forward = JSON.stringify(forwardCreature);
         }
       } else if (trainingImprovement === false) {
-        console.warn(
+        getLogger().warn(
           `Training ${
             blue(r.train.ID)
           } caused a higher error of ${r.train.error} from ${errorTx} and no tuning`,
@@ -704,7 +705,7 @@ export class Neat {
         }
       }
     }).catch((error) => {
-      console.error(
+      getLogger().error(
         `Training failed for creature ${
           uuid.substring(Math.max(0, uuid.length - 8))
         }:`,
@@ -771,7 +772,7 @@ export class Neat {
       genus.addCreature(creature);
     }
     if (this.population.length === 0) {
-      console.warn("All creatures died, using zombies");
+      getLogger().warn("All creatures died, using zombies");
     }
 
     const numberOfElitists = this.config.elitism > 1
@@ -803,7 +804,7 @@ export class Neat {
       );
       if (previousFittest.score === tmpFittest.score) {
         if (previousFittest.uuid !== tmpFittest.uuid) {
-          console.info(
+          getLogger().info(
             `Fittest creature ${
               tmpFittest.uuid.substring(0, 8)
             } has the same score as previous fittest ${
@@ -864,7 +865,7 @@ export class Neat {
           this.scheduleDiscovery(fittest, trainingTimeOutMinutes);
         } else {
           if (this.config.verbose) {
-            console.info(
+            getLogger().info(
               `Skipping discovery: insufficient time (${trainingTimeOutMinutes}m remaining, ${estimatedDiscoveryMinutes}m estimated)`,
             );
           }
@@ -991,7 +992,7 @@ export class Neat {
         mutationRate: adjustedMutationRate,
       });
       if (this.config.verbose) {
-        console.info(
+        getLogger().info(
           `[Plateau] Stagnation detected - mutation rate increased from ` +
             `${(this.config.mutationRate * 100).toFixed(1)}% to ` +
             `${(adjustedMutationRate * 100).toFixed(1)}% ` +
@@ -1023,7 +1024,7 @@ export class Neat {
 
       const json = JSON.parse(r.train.creature);
       if (this.config.verbose) {
-        console.info(
+        getLogger().info(
           `Training ${blue(r.train.ID)} completed ${
             r.duration
               ? "after " + format(r.duration, { ignoreZero: true })
@@ -1055,7 +1056,7 @@ export class Neat {
 
       if (compactJSON) {
         if (this.config.verbose) {
-          console.info(
+          getLogger().info(
             `Training ${blue(r.train.ID)} compacted`,
           );
         }
@@ -1114,7 +1115,7 @@ export class Neat {
         trainedPopulation.push(discoveredCreature);
 
         if (this.config.verbose) {
-          console.info(
+          getLogger().info(
             `[Neat] Added discovered creature ${
               blue(discoveredCreature.uuid?.substring(0, 8) ?? "unknown")
             } to population (from discovery ${
@@ -1173,7 +1174,7 @@ export class Neat {
         trainedPopulation.push(replayedCreature);
 
         if (this.config.verbose) {
-          console.info(
+          getLogger().info(
             `[Neat] Added replayed creature ${
               blue(replayedCreature.uuid?.substring(0, 8) ?? "unknown")
             } to population (score improvement: ${

--- a/src/architecture/DeDuplicator.ts
+++ b/src/architecture/DeDuplicator.ts
@@ -4,6 +4,7 @@ import type { Breed } from "../breed/Breed.ts";
 import { Creature } from "../Creature.ts";
 import type { Mutator } from "../NEAT/Mutator.ts";
 import { BloomFilter } from "../utils/BloomFilter.ts";
+import { getLogger } from "../utils/Logger.ts";
 import { CreatureUtil } from "./CreatureUtils.ts";
 
 /**
@@ -96,7 +97,7 @@ export class DeDuplicator {
             this.breed.options.populationSize!
         ) {
           if (this.breed.options.debug || this.breed.options.verbose) {
-            console.debug(
+            getLogger().debug(
               `Culling duplicate creature at ${indx - toRemove.length} of ${
                 creatures.length - toRemove.length
               }`,
@@ -120,7 +121,7 @@ export class DeDuplicator {
       const difference = format(end - start, {
         ignoreZero: true,
       });
-      console.log(
+      getLogger().info(
         `DeDuplication of ${toRemove.length} creatures to ${creatures.length} in ${difference} (previous experiment ${
           format(
             previousExperimentMS,
@@ -180,7 +181,7 @@ export class DeDuplicator {
           this.bloomFilter.add(key3);
           return;
         } else if (attempts > 48) {
-          console.error(
+          getLogger().error(
             `Can't deDuplicate creature at ${index} of ${creatures.length}`,
           );
           creatures.splice(index, 1);
@@ -195,7 +196,7 @@ export class DeDuplicator {
   private logPopulationSize(creatures: Creature[]) {
     if (creatures.length > this.breed.options.populationSize! + 1) {
       if (this.breed.options.debug || this.breed.options.verbose) {
-        console.debug(
+        getLogger().debug(
           `Over populated ${creatures.length}, expected ${this.breed.options
             .populationSize!}.`,
         );

--- a/src/architecture/ElitismUtils.ts
+++ b/src/architecture/ElitismUtils.ts
@@ -1,8 +1,9 @@
 import { assert } from "@std/assert";
 import { blue, bold, green, red, white, yellow } from "@std/fmt/colors";
+import { addTag, getTag } from "@stsoftware/tags/mod";
 import type { Creature } from "../Creature.ts";
 import type { Approach } from "../NEAT/LogApproach.ts";
-import { addTag, getTag } from "@stsoftware/tags/mod";
+import { getLogger } from "../utils/Logger.ts";
 
 interface ElitistsResults {
   elitists: Creature[];
@@ -86,7 +87,7 @@ export function logVerbose(creatures: Creature[]): number {
       if (trainVariant) {
         trainMsg += `, Variant: ${trainVariant}`;
       }
-      console.info(trainMsg);
+      getLogger().info(trainMsg);
       addTag(creature, "trainMsg", trainMsg);
     }
     const sourceUUID = getTag(creature, "CRISPR-SOURCE");
@@ -101,7 +102,7 @@ export function logVerbose(creatures: Creature[]): number {
           Number.parseFloat(error);
         const dnaID = getTag(creature, "CRISPR-DNA");
 
-        console.info(
+        getLogger().info(
           `CRISPR ${blue(dnaID ?? "unknown")} Score: ${
             yellow(score.toString())
           }, Error: ${yellow(sourceError)} -> ${yellow(error)}` + (diff > 0

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -21,6 +21,7 @@ import type {
 import { isRustDiscoveryEnabled } from "./RustDiscovery.ts";
 import { PhaseDiagnostics } from "./PhaseDiagnostics.ts";
 import { submitDiscoveryRecordBatch } from "./SubmitDiscoveryRecordBatch.ts";
+import { getLogger } from "../../utils/Logger.ts";
 
 /**
  * Issue #1219 - Ensures WASM activation is initialised before discovery recording.
@@ -119,7 +120,7 @@ class DiscoveryPerformanceStats {
   logSummary(discoveryID: string, config: NeatConfig): void {
     if (!shouldLogDiscovery(config)) return;
 
-    console.log(
+    getLogger().info(
       formatDiscoveryPerformanceSummary(
         discoveryID,
         {
@@ -435,7 +436,7 @@ class DataRecorder {
       : isRustDiscoveryEnabled();
     if (!rustEnabled) {
       if (shouldLogDiscovery(this.config)) {
-        console.warn(
+        getLogger().warn(
           `🔧 Discovery skipped: Rust module or GPU not available. Discovery requires the NEAT-AI-Discovery Rust library to be built and available, and a GPU to be present.`,
         );
       }
@@ -542,7 +543,7 @@ class DataRecorder {
         readTime += Date.now() - readStartTime;
 
         if (bytesRead === null || bytesRead !== this.BYTES_PER_RECORD) {
-          console.warn(
+          getLogger().warn(
             `Failed to read complete record at index ${recordIndex}`,
           );
           continue;
@@ -589,7 +590,7 @@ class DataRecorder {
             params.drainCounter.count = 0;
 
             if (shouldLogDiscovery(this.config)) {
-              console.log(
+              getLogger().info(
                 `Discovery ${
                   blue(this.ID)
                 } drained promises after ${this.drainEveryNBatches} batches`,
@@ -600,7 +601,7 @@ class DataRecorder {
           if (discoverStructure.shouldFlushRustChunk()) {
             const flushed = discoverStructure.flushRustChunk();
             if (!flushed) {
-              console.warn(
+              getLogger().warn(
                 `⚠️  Discovery ${
                   blue(this.ID)
                 } failed to flush discovery chunk after batch.`,
@@ -634,7 +635,7 @@ class DataRecorder {
         if (discoverStructure.shouldFlushRustChunk()) {
           const flushed = discoverStructure.flushRustChunk();
           if (!flushed) {
-            console.warn(
+            getLogger().warn(
               `⚠️  Discovery ${
                 blue(this.ID)
               } failed to flush discovery chunk after partial batch.`,
@@ -663,7 +664,7 @@ class DataRecorder {
     const perfStats = new DiscoveryPerformanceStats();
 
     if (shouldLogDiscovery(config)) {
-      console.info(
+      getLogger().info(
         `Discovery ${
           blue(this.ID)
         } with ${binaryFiles.length} binary files, sample rate: ${
@@ -703,7 +704,7 @@ class DataRecorder {
     ): void => {
       const tag = classifyCandidateTag(gain, comment);
       const commentText = comment ? ` comment=${JSON.stringify(comment)}` : "";
-      console.log(
+      getLogger().info(
         `Discovery ${blue(this.ID)} ${scope} ${tag} ${from} -> ${to} expected=${
           formatGainPct(gain)
         } improved=${improved}/${total}${commentText}`,
@@ -746,7 +747,7 @@ class DataRecorder {
     let fileProcessTime = 0;
 
     if (shouldLogDiscovery(config)) {
-      console.log(
+      getLogger().info(
         `Discovery ${blue(this.ID)} initialize time ${
           yellow(format(initializeTime, { ignoreZero: true }))
         }`,
@@ -770,7 +771,7 @@ class DataRecorder {
       // Skip the entire recording phase if using existing parquet files
       if (skipRecording) {
         if (shouldLogDiscovery(config)) {
-          console.log(
+          getLogger().info(
             `Discovery ${
               blue(this.ID)
             } skipping record phase - using existing parquet files from: ${discoverStructure.getTempDir()}`,
@@ -816,7 +817,7 @@ class DataRecorder {
             if (discoverStructure.shouldFlushRustChunk()) {
               const flushed = discoverStructure.flushRustChunk();
               if (!flushed) {
-                console.warn(
+                getLogger().warn(
                   `⚠️  Discovery ${
                     blue(this.ID)
                   } failed to flush discovery chunk after file ${filePath}.`,
@@ -837,7 +838,7 @@ class DataRecorder {
 
           if (this.timeoutTS && Date.now() > this.timeoutTS) {
             if (shouldLogDiscovery(this.config)) {
-              console.warn(
+              getLogger().warn(
                 `⏲  Discovery ${
                   blue(this.ID)
                 } timeout reached during file processing. ` +
@@ -863,7 +864,7 @@ class DataRecorder {
 
         const scannedTime = Date.now() - startTime;
         if (shouldLogDiscovery(config)) {
-          console.log(
+          getLogger().info(
             `Discovery ${blue(this.ID)} scanning time ${
               yellow(format(scannedTime, { ignoreZero: true }))
             }`,
@@ -894,7 +895,7 @@ class DataRecorder {
             timeoutPromise,
           ]);
         } catch (error) {
-          console.error(
+          getLogger().error(
             `❌ DISCOVERY WRITE ERROR for ${blue(this.ID)}:`,
             error,
           );
@@ -915,7 +916,7 @@ class DataRecorder {
         if (!rustFlushSuccess) {
           // Rust recording failed - return empty result (discovery skipped)
           if (shouldLogDiscovery(config)) {
-            console.warn(
+            getLogger().warn(
               `⚠️  Discovery ${
                 blue(this.ID)
               }: Rust recording failed, discovery skipped.`,
@@ -937,7 +938,7 @@ class DataRecorder {
         perfStats.recordPhaseTime = recordPhaseEndTime - startTime;
 
         if (shouldLogDiscovery(config)) {
-          console.log(
+          getLogger().info(
             `Discovery ${blue(this.ID)} recorded time ${
               yellow(format(perfStats.recordPhaseTime, { ignoreZero: true }))
             }`,
@@ -955,7 +956,7 @@ class DataRecorder {
       this.timeoutTS = analysisDeadlineAt;
 
       if (shouldLogDiscovery(config)) {
-        console.log(
+        getLogger().info(
           `Discovery ${blue(this.ID)} analysis timeout extended by ${
             yellow(analysisTimeoutMinutes.toString())
           }m`,
@@ -987,7 +988,7 @@ class DataRecorder {
         // while avoiding long-running Rust analysis on GPU-backed machines.
         if (this.discoveryMaxNeurons <= 0) {
           if (shouldLogDiscovery(config)) {
-            console.log(
+            getLogger().info(
               `Discovery ${
                 blue(this.ID)
               } skipping analysis phase because discoveryMaxNeurons <= 0`,
@@ -1014,7 +1015,7 @@ class DataRecorder {
           const retryMsg = retryAttempt > 0
             ? ` (retry ${retryAttempt}, ${attemptedNeurons.size} already tried)`
             : "";
-          console.log(
+          getLogger().info(
             `Discovery ${blue(this.ID)} selected ${
               yellow(newFocusList.length.toString())
             } focus neuron${newFocusList.length === 1 ? "" : "s"} in ${
@@ -1030,7 +1031,7 @@ class DataRecorder {
         // If we have no new neurons to try, stop retrying
         if (newFocusList.length === 0) {
           if (shouldLogDiscovery(config)) {
-            console.log(
+            getLogger().info(
               `Discovery ${
                 blue(this.ID)
               } no new neurons to analyze, stopping retry loop`,
@@ -1095,7 +1096,7 @@ class DataRecorder {
               ? `, neuron meta: found=${neuronMeta.candidatesFound} returned=${neuronMeta.candidatesReturned}`
               : "";
 
-            console.log(
+            getLogger().info(
               `Discovery ${blue(this.ID)} candidate collection ${
                 yellow(format(candidateCollectionTime, {
                   ignoreZero: true,
@@ -1158,7 +1159,7 @@ class DataRecorder {
               });
               squashSummaryText = `, Summary: ${squashSummary.join(",")}`;
             }
-            console.log(
+            getLogger().info(
               `Discovery ${blue(this.ID)} analyze squashes time ${
                 yellow(format(squashTime, { ignoreZero: true }))
               } found ${squashCount} candidate${
@@ -1190,7 +1191,7 @@ class DataRecorder {
               const neuronAnalyzeTime = Date.now() - neuronAnalyzeStart;
               perfStats.neuronAnalysisTime += neuronAnalyzeTime;
               if (shouldLogDiscovery(config)) {
-                console.log(
+                getLogger().info(
                   `Discovery ${blue(this.ID)} analyze neurons time ${
                     yellow(format(neuronAnalyzeTime, { ignoreZero: true }))
                   } found ${
@@ -1214,7 +1215,7 @@ class DataRecorder {
               const analyzeTime = Date.now() - analyzeStartTime;
               perfStats.synapseAnalysisTime += analyzeTime;
               if (shouldLogDiscovery(config)) {
-                console.log(
+                getLogger().info(
                   `Discovery ${blue(this.ID)} analyze synapses time ${
                     yellow(format(analyzeTime, { ignoreZero: true }))
                   } found ${
@@ -1238,7 +1239,7 @@ class DataRecorder {
               const harmfulTime = Date.now() - harmfulStartTime;
               perfStats.harmfulSynapseAnalysisTime += harmfulTime;
               if (shouldLogDiscovery(config)) {
-                console.log(
+                getLogger().info(
                   `Discovery ${blue(this.ID)} analyze harmful time ${
                     yellow(format(harmfulTime, { ignoreZero: true }))
                   } found ${harmfulSynapse ? 1 : 0} candidates`,
@@ -1272,7 +1273,7 @@ class DataRecorder {
                   });
                   squashSummaryText = `, Summary: ${squashSummary.join(",")}`;
                 }
-                console.log(
+                getLogger().info(
                   `Discovery ${blue(this.ID)} analyze squashes time ${
                     yellow(format(squashTime, { ignoreZero: true }))
                   } found ${squashCount} candidate${
@@ -1297,7 +1298,7 @@ class DataRecorder {
                 const harmfulNeuronCount = harmfulNeurons
                   ? harmfulNeurons.length
                   : 0;
-                console.log(
+                getLogger().info(
                   `Discovery ${blue(this.ID)} analyze harmful neurons time ${
                     yellow(format(harmfulNeuronTime, { ignoreZero: true }))
                   } found ${harmfulNeuronCount} candidate${
@@ -1428,7 +1429,7 @@ class DataRecorder {
             discoverResult.candidateSquashes,
         );
         if (foundCandidates && shouldLogDiscovery(config)) {
-          console.log(
+          getLogger().info(
             `Discovery ${
               blue(this.ID)
             } accumulated candidate updates; continuing search while time remains.`,
@@ -1438,7 +1439,7 @@ class DataRecorder {
         const timeRemaining = this.timeoutTS - Date.now();
         if (timeRemaining <= 0) {
           if (shouldLogDiscovery(config)) {
-            console.log(
+            getLogger().info(
               `Discovery ${
                 blue(this.ID)
               } analysis timeout reached after evaluating ${attemptedNeurons.size} neuron(s)`,
@@ -1450,7 +1451,7 @@ class DataRecorder {
         perfStats.retryAttempts = retryAttempt;
         retryAttempt++;
         if (shouldLogDiscovery(config)) {
-          console.log(
+          getLogger().info(
             `Discovery ${blue(this.ID)} retrying with different neurons (${
               yellow(format(timeRemaining, { ignoreZero: true }))
             } remaining, retry ${retryAttempt})`,
@@ -1464,7 +1465,7 @@ class DataRecorder {
       if (removalCandidates && removalCandidates.length > 0) {
         discoverResult.removalCandidates = removalCandidates;
         if (shouldLogDiscovery(config)) {
-          console.log(
+          getLogger().info(
             `Discovery ${blue(this.ID)} found ${
               yellow(removalCandidates.length.toString())
             } low-impact removal candidate${
@@ -1477,7 +1478,7 @@ class DataRecorder {
       phaseDiagnostics.enterPhase("complete");
       if (shouldLogDiscovery(config)) {
         const totalTime = Date.now() - startTime;
-        console.log(
+        getLogger().info(
           `Discovery ${blue(this.ID)} analysis complete, total time ${
             yellow(format(totalTime, { ignoreZero: true }))
           }, starting cleanup...`,
@@ -1490,19 +1491,19 @@ class DataRecorder {
       const cleanupStartTime = Date.now();
       const cleanupPromise = (async () => {
         if (shouldLogDiscovery(config)) {
-          console.log(`Discovery ${blue(this.ID)} performing cleanup...`);
+          getLogger().info(`Discovery ${blue(this.ID)} performing cleanup...`);
         }
         await discoverStructure.cleanUp();
         perfStats.cleanupTime = Date.now() - cleanupStartTime;
         if (shouldLogDiscovery(config)) {
-          console.log(`Discovery ${blue(this.ID)} cleanup complete.`);
+          getLogger().info(`Discovery ${blue(this.ID)} cleanup complete.`);
         }
       })();
 
       if (this.shouldAwaitCleanup()) {
         await cleanupPromise;
         if (shouldLogDiscovery(config)) {
-          console.log(
+          getLogger().info(
             `Discovery ${blue(this.ID)} cleanup awaited and complete (${
               format(perfStats.cleanupTime, { ignoreZero: true })
             }).`,
@@ -1512,13 +1513,13 @@ class DataRecorder {
         // Don't await cleanup - let it happen in the background
         // Catch any errors to prevent unhandled rejections and resource leaks
         cleanupPromise.catch((error) => {
-          console.error(
+          getLogger().error(
             `❌ CRITICAL: Discovery ${this.ID} cleanup failed - potential resource leak:`,
             error,
           );
         });
         if (shouldLogDiscovery(config)) {
-          console.log(
+          getLogger().info(
             `Discovery ${
               blue(this.ID)
             } cleanup scheduled (async, non-blocking - results will be returned immediately).`,
@@ -1557,44 +1558,46 @@ class DataRecorder {
     } catch (error) {
       // On error, show diagnostics unconditionally (indicates a bug)
       const totalTime = Date.now() - startTime;
-      console.error(
+      getLogger().error(
         `❌ DISCOVERY ERROR for ${blue(this.ID)} after ${
           format(totalTime, { ignoreZero: true })
         }:`,
       );
-      console.error(`   Error: ${error}`);
+      getLogger().error(`   Error: ${error}`);
       const phaseSnapshot = phaseDiagnostics.snapshot();
-      console.error(`   Current phase: ${phaseSnapshot.currentPhase}`);
+      getLogger().error(`   Current phase: ${phaseSnapshot.currentPhase}`);
       if (phaseSnapshot.parallelPhases.length > 0) {
-        console.error(
+        getLogger().error(
           `   Active analysis phases: ${
             phaseSnapshot.parallelPhases.join(", ")
           }`,
         );
       }
-      console.error(`   Phase timing diagnostics:`);
-      console.error(
+      getLogger().error(`   Phase timing diagnostics:`);
+      getLogger().error(
         `     - Initialize: ${format(initializeTime, { ignoreZero: true })}`,
       );
-      console.error(
+      getLogger().error(
         `     - File processing: ${
           format(fileProcessTime, { ignoreZero: true })
         }`,
       );
-      console.error(`     - Total: ${format(totalTime, { ignoreZero: true })}`);
+      getLogger().error(
+        `     - Total: ${format(totalTime, { ignoreZero: true })}`,
+      );
 
       if (shouldLogDiscovery(config)) {
-        console.log(
+        getLogger().info(
           `Discovery ${blue(this.ID)} error occurred, performing cleanup...`,
         );
       }
       try {
         await discoverStructure.cleanUp();
         if (shouldLogDiscovery(config)) {
-          console.log(`Discovery ${blue(this.ID)} cleanup complete.`);
+          getLogger().info(`Discovery ${blue(this.ID)} cleanup complete.`);
         }
       } catch (cleanupError) {
-        console.error(
+        getLogger().error(
           `❌ WARNING: Discovery ${this.ID} cleanup failed after error:`,
           cleanupError,
         );

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -78,6 +78,7 @@ import {
   observeRustTrainingRecord as observeRustTrainingRecordImpl,
   truncateForLogValue as truncateForLogValueImpl,
 } from "./RustFlushDiagnostics.ts";
+import { getLogger } from "../../utils/Logger.ts";
 
 export { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
 export { DEFAULT_RUST_FLUSH_BYTES } from "./constants.ts";
@@ -310,7 +311,7 @@ export class DiscoverStructure {
       const stat = Deno.statSync(mergedParquetPath);
       if (stat.isFile && stat.size > 0) {
         if (this.loggingEnabled) {
-          console.log(
+          getLogger().info(
             `[Discovery ${this.discoveryID}] Skipping record phase - using existing parquet file: ${mergedParquetPath}`,
           );
         }
@@ -332,7 +333,7 @@ export class DiscoverStructure {
         );
         if (parquetChunks.length > 0) {
           if (this.loggingEnabled) {
-            console.log(
+            getLogger().info(
               `[Discovery ${this.discoveryID}] Skipping record phase - found ${parquetChunks.length} existing chunk files in: ${chunksDir}`,
             );
           }
@@ -348,7 +349,7 @@ export class DiscoverStructure {
     }
 
     if (this.loggingEnabled) {
-      console.log(
+      getLogger().info(
         `[Discovery ${this.discoveryID}] No existing parquet files found - proceeding with recording`,
       );
     }
@@ -559,7 +560,7 @@ export class DiscoverStructure {
     // Skip directory removal if cleanup is disabled (for debugging)
     if (this.disableCleanup) {
       if (this.loggingEnabled) {
-        console.log(
+        getLogger().info(
           `[Discovery ${this.discoveryID}] Cleanup disabled - preserving temporary files at: ${this.tempDir}`,
         );
       }
@@ -570,7 +571,7 @@ export class DiscoverStructure {
       await Deno.remove(this.tempDir, { recursive: true });
     } catch (error) {
       // Ignore cleanup errors to prevent crashes
-      console.warn(`Failed to cleanup discovery temp dir: ${error}`);
+      getLogger().warn(`Failed to cleanup discovery temp dir: ${error}`);
     }
   }
 
@@ -743,16 +744,16 @@ export class DiscoverStructure {
         if (
           error instanceof Error && error.message.includes("Excessive record()")
         ) {
-          console.error(
+          getLogger().error(
             `❌ Error occurred while processing sample ${
               i + 1
             }/${trainingData.length}`,
           );
-          console.error(
+          getLogger().error(
             `   Total samples accumulated so far: ${this.rustAccumulatedData.length}`,
           );
-          console.error(`   Input: ${record.input.slice(0, 5)}...`);
-          console.error(`   Output: ${record.output.slice(0, 5)}...`);
+          getLogger().error(`   Input: ${record.input.slice(0, 5)}...`);
+          getLogger().error(`   Output: ${record.output.slice(0, 5)}...`);
         }
         throw error;
       }
@@ -800,14 +801,14 @@ export class DiscoverStructure {
     // Check if creature has been cleaned up (race condition protection)
     // @ts-ignore - creature can be null after cleanUp()
     if (!this.creature) {
-      console.warn(
+      getLogger().warn(
         `⚠️  Discovery recording skipped: creature has been cleaned up.`,
       );
       return null;
     }
 
     if (!this.deps.isRustLibraryAvailable()) {
-      console.warn(
+      getLogger().warn(
         `⚠️  Rust library not available when flushing. Discovery recording failed.`,
       );
       return null;
@@ -1005,7 +1006,7 @@ export class DiscoverStructure {
       this.rustChunkFiles.push(parquetPath);
       return true;
     } catch (error) {
-      console.error("❌ Failed to flush discovery chunk:", error);
+      getLogger().error("❌ Failed to flush discovery chunk:", error);
       return false;
     }
   }
@@ -1042,7 +1043,7 @@ export class DiscoverStructure {
     });
 
     if (!mergeResult || !mergeResult.success) {
-      console.error(
+      getLogger().error(
         "❌ Rust discovery merge failed:",
         mergeResult?.error ?? "Unknown error",
       );
@@ -1585,19 +1586,19 @@ export class DiscoverStructure {
 
     switch (level) {
       case "debug":
-        if (this.loggingEnabled) console.debug(...args);
+        if (this.loggingEnabled) getLogger().debug(...args);
         break;
       case "info":
-        if (this.loggingEnabled) console.info(...args);
+        if (this.loggingEnabled) getLogger().info(...args);
         break;
       case "warn":
-        console.warn(...args);
+        getLogger().warn(...args);
         break;
       case "error":
-        console.error(...args);
+        getLogger().error(...args);
         break;
       default:
-        console.log(...args);
+        getLogger().info(...args);
         break;
     }
   }
@@ -1724,7 +1725,7 @@ export class DiscoverStructure {
       }
     } catch (error) {
       // Don't fail discovery if we can't write the analysis file
-      console.warn(
+      getLogger().warn(
         `Failed to write focus selection analysis: ${
           error instanceof Error ? error.message : String(error)
         }`,
@@ -2279,7 +2280,7 @@ export class DiscoverStructure {
           error instanceof Error &&
           error.message.includes("Too many open files") && retries < maxRetries
         ) {
-          console.warn(
+          getLogger().warn(
             `Too many open files, retrying in ${delay}ms (attempt ${
               retries + 1
             }/${maxRetries})`,
@@ -2328,7 +2329,7 @@ export class DiscoverStructure {
             // Read the record
             const bytesRead = file.readSync(recordBuffer);
             if (bytesRead === null || bytesRead !== BYTES_PER_RECORD) {
-              console.warn(
+              getLogger().warn(
                 `Failed to read record ${recordIndex} from ${binaryFile}`,
               );
               continue;
@@ -2594,7 +2595,7 @@ export class DiscoverStructure {
     targetCount?: number,
   ): NeuronErrorInfo[] {
     if (!this.recorded) {
-      console.warn("No recorded data to list neurons.");
+      getLogger().warn("No recorded data to list neurons.");
       return [];
     }
 
@@ -2621,10 +2622,10 @@ export class DiscoverStructure {
     }
 
     // Rust discovery is required - no fallback
-    console.error(
+    getLogger().error(
       `❌ CRITICAL: Rust focus ranking failed. Discovery cannot proceed without Rust analysis.`,
     );
-    console.error(
+    getLogger().error(
       `   Ensure NEAT-AI-Discovery Rust library is properly built and available.`,
     );
     return [];
@@ -2973,10 +2974,10 @@ export class DiscoverStructure {
 
     // Guard against NaN, Infinity, or zero total weighted sum
     if (!Number.isFinite(totalWeightedSum)) {
-      console.error(
+      getLogger().error(
         `❌ CRITICAL ERROR: totalWeightedSum is ${totalWeightedSum} (NaN or Infinity). This indicates corrupt error/impact calculations in the discovery process!`,
       );
-      console.error(
+      getLogger().error(
         `   Neuron weighted summary: ${
           weightedValues.slice(0, 5).map((n) =>
             `${n.uuid.slice(-8)}: weight=${n.weight}`
@@ -2984,7 +2985,7 @@ export class DiscoverStructure {
         }...`,
       );
       // Fallback to random selection to prevent infinite loops
-      console.warn(
+      getLogger().warn(
         `   Falling back to random neuron selection to continue discovery`,
       );
       const shuffled = [...neuronErrors].sort(() => Math.random() - 0.5);
@@ -3009,10 +3010,10 @@ export class DiscoverStructure {
     }
 
     if (totalWeightedSum <= 0) {
-      console.warn(
+      getLogger().warn(
         `⚠️  WARNING: totalWeightedSum is ${totalWeightedSum} (zero or negative). All neurons have zero error × impact?`,
       );
-      console.warn(`   Falling back to random neuron selection`);
+      getLogger().warn(`   Falling back to random neuron selection`);
       // Fallback to random selection without weighting
       const shuffled = [...neuronErrors].sort(() => Math.random() - 0.5);
       const fallback = shuffled.slice(0, count).map((n) => n.uuid);
@@ -3080,13 +3081,13 @@ export class DiscoverStructure {
     }
 
     if (iterations >= maxIterations) {
-      console.error(
+      getLogger().error(
         `❌ ERROR: Selection reached max iterations (${maxIterations}), only selected ${selectedUUIDs.size}/${count} neurons`,
       );
-      console.error(
+      getLogger().error(
         `   This should not happen with the hybrid approach. Please report this.`,
       );
-      console.error(
+      getLogger().error(
         `   totalWeightedSum: ${totalWeightedSum}, neuronErrors.length: ${neuronErrors.length}`,
       );
     }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts
@@ -22,6 +22,7 @@ import type {
 } from "./DiscoverStructureTypes.ts";
 import { ensureDirSync } from "@std/fs";
 import { join } from "@std/path";
+import { getLogger } from "../../utils/Logger.ts";
 
 /**
  * Validates a creature and attempts to fix it if validation fails.
@@ -83,7 +84,7 @@ export function validateAndFixIfNeeded(
       );
     }
 
-    console.warn(
+    getLogger().warn(
       `[Discovery ${discoveryID}] Creature became invalid after ${operationType}: ${error.name} - ${error.message}. ` +
         `This is a bug that should be investigated. Attempting fix() as last resort.`,
     );
@@ -107,7 +108,7 @@ export function validateAndFixIfNeeded(
       }
       return { success: true, fixWasCalled: true, validationError: error };
     } catch (fixError) {
-      console.error(
+      getLogger().error(
         `[Discovery ${discoveryID}] fix() failed to repair creature after ${operationType}. Error: ${fixError}`,
       );
       return { success: false, fixWasCalled: true, validationError: error };
@@ -183,12 +184,12 @@ function recordValidationIssue(
     ].join("\n");
     Deno.writeTextFileSync(errorPath, errorContent);
 
-    console.warn(
+    getLogger().warn(
       `[Discovery ${discoveryID}] Validation issue recorded to: ${issueDir}`,
     );
   } catch (recordError) {
     // Don't let recording failure prevent the main flow
-    console.error(
+    getLogger().error(
       `[Discovery ${discoveryID}] Failed to record validation issue: ${recordError}`,
     );
   }
@@ -265,12 +266,12 @@ export function recordDiscoveryIssue(
     ].filter((line) => line !== undefined).join("\n");
     Deno.writeTextFileSync(errorPath, errorContent);
 
-    console.warn(
+    getLogger().warn(
       `[Discovery ${discoveryID}] Discovery issue recorded to: ${issueDir}`,
     );
   } catch (recordError) {
     // Don't let recording failure prevent the main flow
-    console.error(
+    getLogger().error(
       `[Discovery ${discoveryID}] Failed to record discovery issue: ${recordError}`,
     );
   }
@@ -302,7 +303,7 @@ export function removeSynapse(
   );
 
   if (!fromNeuron || !toNeuron) {
-    console.warn(
+    getLogger().warn(
       `[DiscoverStructure] removeSynapse: neuron(s) not found for synapse ${worseCandidate.fromNeuronUUID} -> ${worseCandidate.toNeuronUUID}`,
     );
     return null;
@@ -314,7 +315,7 @@ export function removeSynapse(
   // Check if the synapse actually exists
   const synapse = creature.getSynapse(fromIndx, toIndx);
   if (!synapse) {
-    console.warn(
+    getLogger().warn(
       `[DiscoverStructure] removeSynapse: synapse ${worseCandidate.fromNeuronUUID} -> ${worseCandidate.toNeuronUUID} does not exist in creature`,
     );
     return null;
@@ -364,7 +365,7 @@ export function removeSynapse(
   }
 
   // Synapse existed but removal didn't change UUID
-  console.warn(
+  getLogger().warn(
     `[DiscoverStructure] removeSynapse: synapse ${worseCandidate.fromNeuronUUID} -> ${worseCandidate.toNeuronUUID} existed but removal had no structural effect`,
   );
   return null;
@@ -398,7 +399,7 @@ export function addHelpfulSynapses(
     });
 
     if (foundSynapse) {
-      console.warn(
+      getLogger().warn(
         `[Discovery ${ID}] Synapse ${bestCandidate.fromNeuronUUID} -> ${bestCandidate.toNeuronUUID} already exists, skipping`,
       );
       return;
@@ -409,7 +410,7 @@ export function addHelpfulSynapses(
     });
     if (!foundFromNeuron) {
       if (!bestCandidate.fromNeuronUUID.startsWith("input-")) {
-        console.warn(
+        getLogger().warn(
           `[Discovery ${ID}] Source neuron ${bestCandidate.fromNeuronUUID} not found, skipping synapse`,
         );
         return;
@@ -421,7 +422,7 @@ export function addHelpfulSynapses(
       return neuron.uuid === bestCandidate.toNeuronUUID;
     });
     if (!foundToNeuron) {
-      console.warn(
+      getLogger().warn(
         `[Discovery ${ID}] Target neuron ${bestCandidate.toNeuronUUID} not found or is not hidden/output, skipping synapse`,
       );
       return;
@@ -451,7 +452,7 @@ export function addHelpfulSynapses(
   });
 
   if (appliedSynapses.length === 0) {
-    console.warn(
+    getLogger().warn(
       `[Discovery ${ID}] No synapses could be added from ${helpfulSynapses.length} candidates`,
     );
     return;
@@ -485,7 +486,7 @@ export function addHelpfulSynapses(
       afterFixSynapseCount !== beforeFixSynapseCount ||
       afterFixNeuronCount !== beforeFixNeuronCount
     ) {
-      console.warn(
+      getLogger().warn(
         `[Discovery ${ID}] fix() modified structure: synapses ${beforeFixSynapseCount} -> ${afterFixSynapseCount}, neurons ${beforeFixNeuronCount} -> ${afterFixNeuronCount}`,
       );
     }
@@ -573,7 +574,7 @@ export function addHelpfulNeurons(
     if (fromIndex >= 0 && toIndex >= 0 && fromIndex >= toIndex) {
       const summary =
         `from neuron must be before target neuron (fromIndex=${fromIndex}, targetIndex=${toIndex})`;
-      console.warn(
+      getLogger().warn(
         `[Discovery ${ID}] addHelpfulNeurons: Skipping candidate ${candidate.fromNeuronUUID} -> ${candidate.toNeuronUUID}: ${summary}`,
       );
 
@@ -704,7 +705,7 @@ export function addHelpfulNeurons(
   });
 
   if (addedNeuronUUIDs.length === 0) {
-    console.warn(
+    getLogger().warn(
       `[Discovery ${ID}] No neurons could be added from ${helpfulNeurons.length} candidates`,
     );
     return;
@@ -738,7 +739,7 @@ export function addHelpfulNeurons(
       afterFixSynapseCount !== beforeFixSynapseCount ||
       afterFixNeuronCount !== beforeFixNeuronCount
     ) {
-      console.warn(
+      getLogger().warn(
         `[Discovery ${ID}] fix() modified structure: synapses ${beforeFixSynapseCount} -> ${afterFixSynapseCount}, neurons ${beforeFixNeuronCount} -> ${afterFixNeuronCount}`,
       );
     }
@@ -807,7 +808,7 @@ export function changeSquash(
   });
 
   if (appliedSquashes.length === 0) {
-    console.warn(
+    getLogger().warn(
       `[Discovery ${ID}] No squash changes could be applied from ${helpfulSquashes.length} candidates`,
     );
     return;
@@ -842,7 +843,7 @@ export function changeSquash(
       afterFixSynapseCount !== beforeFixSynapseCount ||
       afterFixNeuronCount !== beforeFixNeuronCount
     ) {
-      console.warn(
+      getLogger().warn(
         `[Discovery ${ID}] fix() modified structure: synapses ${beforeFixSynapseCount} -> ${afterFixSynapseCount}, neurons ${beforeFixNeuronCount} -> ${afterFixNeuronCount}`,
       );
     }
@@ -1156,7 +1157,7 @@ export function removeLowImpactNeuron(
   // Log detailed diagnostics for first occurrence only
   if (!removalDiagnostics.firstSameUUIDLogged) {
     removalDiagnostics.firstSameUUIDLogged = true;
-    console.warn(
+    getLogger().warn(
       `[DiscoverStructure] removeLowImpactNeuron UUID unchanged after removal:`,
       `\n  neuronUUID: ${removalCandidate.neuronUUID}`,
       `\n  removedSynapses: ${removedSynapseCount}, removedNeurons: ${removedNeuronCount}`,

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -14,6 +14,7 @@
 import { assert } from "@std/assert";
 import { fromFileUrl } from "@std/path/from-file-url";
 import { join } from "@std/path/join";
+import { getLogger } from "../../utils/Logger.ts";
 
 const MAX_C_STRING_BYTES = 128 * 1024 * 1024; // 128 MiB guard for FFI strings
 
@@ -589,16 +590,19 @@ export function computeRustRecordStats(
       );
 
       if (errorCount > maxReasonableErrorsPerNeuron) {
-        console.error(
+        getLogger().error(
           `❌ CRITICAL: Neuron ${uuid} has ${errorCount} errors, which exceeds reasonable maximum (${maxReasonableErrorsPerNeuron})!`,
         );
-        console.error(
+        getLogger().error(
           `This indicates data corruption in the TypeScript logic.`,
         );
-        console.error(
+        getLogger().error(
           `Samples: ${sampleCount}, Outputs: ${outputCount}, Max per neuron: ${maxReasonableErrorsPerNeuron}`,
         );
-        console.error(`Errors array sample (first 10):`, errors.slice(0, 10));
+        getLogger().error(
+          `Errors array sample (first 10):`,
+          errors.slice(0, 10),
+        );
         throw new Error(
           `Data corruption detected: neuron ${uuid} has ${errorCount} errors, ` +
             `which far exceeds reasonable maximum (${maxReasonableErrorsPerNeuron}). ` +
@@ -613,7 +617,7 @@ export function computeRustRecordStats(
         Math.ceil(sampleCount * outputCount * 1.5),
       );
       if (errorCount > warningThreshold) {
-        console.warn(
+        getLogger().warn(
           `⚠️  Neuron ${uuid} has ${errorCount} errors (expected ≤${warningThreshold} for ${sampleCount} samples × ${outputCount} outputs). ` +
             `During backprop, record() should be called once per sample per output. Multiple calls suggest a logic error.`,
         );
@@ -631,18 +635,18 @@ export function computeRustRecordStats(
   );
   const maxReasonableErrors = totalNeuronRecords * maxReasonableErrorsPerRecord;
   if (totalErrorValues > maxReasonableErrors) {
-    console.error(
+    getLogger().error(
       `❌ CRITICAL: Total error values (${totalErrorValues}) exceeds reasonable maximum (${maxReasonableErrors})!`,
     );
-    console.error(
+    getLogger().error(
       `With ${sampleCount} samples and ${expectedNeuronCount} neurons (${totalNeuronRecords} neuron records), this is impossible.`,
     );
-    console.error(
+    getLogger().error(
       `Average errors per neuron record: ${
         (totalErrorValues / totalNeuronRecords).toFixed(2)
       }`,
     );
-    console.error(
+    getLogger().error(
       `Max reasonable per record: ${maxReasonableErrorsPerRecord}`,
     );
     throw new Error(
@@ -915,7 +919,7 @@ export function loadRustLibrary(): boolean {
         path: libPath,
       });
       if (permission.state !== "granted") {
-        console.warn(
+        getLogger().warn(
           `FFI permission denied for discovery library at ${libPath}. ` +
             "Run with --allow-ffi to enable Rust discovery.",
         );
@@ -968,7 +972,7 @@ export function loadRustLibrary(): boolean {
     rustLib = Deno.dlopen(libPath, symbols);
     return true;
   } catch (error) {
-    console.warn(
+    getLogger().warn(
       `Failed to load Rust discovery library from ${libPath}:`,
       error,
     );
@@ -1013,7 +1017,7 @@ export function getDiscoveryVersion(): string | undefined {
   try {
     const resultPtr = rustLib.symbols["get_library_version"]();
     if (resultPtr === null) {
-      console.warn(
+      getLogger().warn(
         "[RustDiscovery] get_library_version returned null pointer.",
       );
       cachedDiscoveryVersion = undefined;
@@ -1029,14 +1033,14 @@ export function getDiscoveryVersion(): string | undefined {
       return parsed.version;
     }
 
-    console.warn(
+    getLogger().warn(
       "[RustDiscovery] get_library_version failed:",
       parsed.error ?? "unknown error",
     );
     cachedDiscoveryVersion = undefined;
     return undefined;
   } catch (error) {
-    console.warn("[RustDiscovery] get_library_version threw:", error);
+    getLogger().warn("[RustDiscovery] get_library_version threw:", error);
     cachedDiscoveryVersion = undefined;
     return undefined;
   }
@@ -1060,7 +1064,7 @@ export function isRustGpuAvailable(): boolean {
     if (resultPtr === null) {
       if (!rustGpuWarningEmitted) {
         rustGpuWarningEmitted = true;
-        console.warn(
+        getLogger().warn(
           "⚠️  Discovery GPU probe returned a null pointer. " +
             "Discovery will be disabled on this worker.",
         );
@@ -1077,7 +1081,7 @@ export function isRustGpuAvailable(): boolean {
     } catch {
       if (!rustGpuWarningEmitted) {
         rustGpuWarningEmitted = true;
-        console.warn(
+        getLogger().warn(
           "⚠️  Discovery GPU probe returned invalid JSON. " +
             "Discovery will be disabled on this worker.",
           resultJson,
@@ -1090,7 +1094,7 @@ export function isRustGpuAvailable(): boolean {
       if (!rustGpuWarningEmitted) {
         rustGpuWarningEmitted = true;
         const detail = parsed.error ?? "no usable GPU detected";
-        console.warn(
+        getLogger().warn(
           "🚧 Discovery disabled: Rust discovery library is loaded but no usable GPU " +
             `was reported for this worker (${detail}).`,
         );
@@ -1102,7 +1106,7 @@ export function isRustGpuAvailable(): boolean {
   } catch (error) {
     if (!rustGpuWarningEmitted) {
       rustGpuWarningEmitted = true;
-      console.warn(
+      getLogger().warn(
         "⚠️  Discovery GPU probe threw an error. Discovery will be disabled " +
           "on this worker.",
         error,

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustFlushDiagnostics.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustFlushDiagnostics.ts
@@ -12,6 +12,7 @@ import type {
   RustFlushDiagnostics,
   RustFlushMetrics,
 } from "./DiscoverStructureTypes.ts";
+import { getLogger } from "../../utils/Logger.ts";
 
 /**
  * Truncates a string for log output.
@@ -154,19 +155,19 @@ export function observeRustTrainingRecord(
     );
 
     if (errorCount > maxReasonableErrorsPerNeuronPerRecord) {
-      console.error(
+      getLogger().error(
         `❌ CRITICAL: Neuron ${uuid} has ${errorCount} errors in record ${globalSampleIndex}, ` +
           `which exceeds reasonable maximum (${maxReasonableErrorsPerNeuronPerRecord})!`,
       );
-      console.error(
+      getLogger().error(
         `Record ${globalSampleIndex}, Neuron ${neuronIndex}`,
       );
-      console.error(
+      getLogger().error(
         `Outputs: ${outputCount} (expected ≤${
           outputCount * 2
         } errors per neuron per sample)`,
       );
-      console.error(`Errors array sample (first 10):`, errors.slice(0, 10));
+      getLogger().error(`Errors array sample (first 10):`, errors.slice(0, 10));
       throw new Error(
         `Data corruption detected: neuron ${uuid} has ${errorCount} errors in a single record, ` +
           `which far exceeds reasonable maximum (${maxReasonableErrorsPerNeuronPerRecord}). ` +
@@ -177,7 +178,7 @@ export function observeRustTrainingRecord(
     // LOG WARNING: Log if we're seeing unusually high error counts per sample
     const warningThreshold = Math.max(5, Math.ceil(outputCount * 1.5));
     if (errorCount > warningThreshold) {
-      console.warn(
+      getLogger().warn(
         `⚠️  Record ${globalSampleIndex}: Neuron ${uuid} has ${errorCount} errors ` +
           `(expected ≤${warningThreshold} for ${outputCount} outputs). ` +
           `During backprop, record() should be called once per output. Multiple calls suggest a logic error.`,

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -1,6 +1,7 @@
 import { assert } from "@std/assert";
 import { addTags, removeTag, type TagsInterface } from "@stsoftware/tags/mod";
 import type { Creature } from "../Creature.ts";
+import { getLogger } from "../utils/Logger.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import { Activations } from "../methods/activations/Activations.ts";
 import type { ApplyLearningsInterface } from "../methods/activations/ApplyLearningsInterface.ts";
@@ -920,14 +921,14 @@ export class Neuron implements TagsInterface, NeuronInternal {
     // DIAGNOSTIC: Log if we're accumulating excessive errors
     // Note: Errors accumulate from all paths (correct behavior), but recursion should only happen once
     if (!isNewRecord && discoverRecord.errors.length > 200) {
-      console.warn(
+      getLogger().warn(
         `⚠️  PERFORMANCE: Neuron ${this.uuid} has ${discoverRecord.errors.length} accumulated errors`,
       );
-      console.warn(
+      getLogger().warn(
         `  Type: ${this.type}, Inward connections: ${listLength}`,
       );
       if (discoverRecord.errors.length > 500) {
-        console.error(
+        getLogger().error(
           `❌ CRITICAL: Neuron ${this.uuid} has ${discoverRecord.errors.length} errors - likely infinite recursion!`,
         );
         throw new Error(

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -10,6 +10,7 @@ import {
   upgradeSemanticVersionIfForwardOnlyConfirmed,
 } from "../upgrade/Upgrade.ts";
 import { writeDiagnostics } from "../utils/Diagnostics.ts";
+import { getLogger } from "../utils/Logger.ts";
 import { CreatureUtil } from "./CreatureUtils.ts";
 import { creatureValidate } from "./CreatureValidate.ts";
 import { Neuron } from "./Neuron.ts";
@@ -372,7 +373,7 @@ export class Offspring {
           // feedback/memory mode here, it's a misuse of the API. We override it to
           // keep invariants stable and avoid producing a "4.x but not forwardOnly"
           // creature that later fails upgrade/validation.
-          console.warn(
+          getLogger().warn(
             `[Offspring] feedbackLoop/memory mode requested but both parents are 4.x; forcing forwardOnly child`,
           );
         }
@@ -409,7 +410,7 @@ export class Offspring {
             }
 
             // If either parent is 2.x, fixing is expected and OK
-            console.warn(
+            getLogger().warn(
               `[Offspring] Forward-only violation after breed() with 2.x parent. ` +
                 `Fixing offspring. Error=${error.name}: ${error.message}. ` +
                 `Violations(sample up to 10): ${violations.join(" | ")}`,
@@ -441,7 +442,7 @@ export class Offspring {
           offspring.validate();
           return offspring;
         default:
-          console.error(e);
+          getLogger().error(e);
           offspring.DEBUG = false;
           writeDiagnostics({
             error,

--- a/src/architecture/Score.ts
+++ b/src/architecture/Score.ts
@@ -1,6 +1,7 @@
 import { assert } from "@std/assert";
 import type { CachedScoreComponents, Creature } from "../Creature.ts";
 import { SEMANTIC_MAJOR_VERSION } from "../upgrade/Upgrade.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 /**
  * Calculates the fitness score for a creature based on its error and complexity.
@@ -169,11 +170,11 @@ function computeAndCacheScoreComponents(
 
   // Handle overflow protection
   if (maxWeightBias > Number.MAX_SAFE_INTEGER) {
-    console.log("Max is too large", maxWeightBias);
+    getLogger().info("Max is too large", maxWeightBias);
     maxWeightBias = Number.MAX_SAFE_INTEGER;
   }
   if (totalWeightBias > Number.MAX_SAFE_INTEGER) {
-    console.log("Total is too large", totalWeightBias);
+    getLogger().info("Total is too large", totalWeightBias);
     totalWeightBias = Number.MAX_SAFE_INTEGER;
   }
 

--- a/src/architecture/Training.ts
+++ b/src/architecture/Training.ts
@@ -6,6 +6,7 @@ import type { CostInterface } from "../costs/CostInterface.ts";
 import { Creature } from "../Creature.ts";
 import { compactUnused } from "../compact/CompactUnused.ts";
 import type { TrainOptions } from "../config/TrainOptions.ts";
+import { getLogger } from "../utils/Logger.ts";
 import {
   calculateLearningRate,
   createBackPropagationConfig,
@@ -138,7 +139,7 @@ function trainDirBinary(
 
   const ID = uuid.substring(Math.max(0, uuid.length - 8));
   if (options.log) {
-    console.info(
+    getLogger().info(
       `Training ${blue(ID)} with ${binaryFiles.length} binary file${
         binaryFiles.length > 1 ? "s" : ""
       }, target error: ${yellow(targetError.toString())}, iterations: ${
@@ -271,7 +272,7 @@ function trainDirBinary(
           // Read the single record
           const bytesRead = file.readSync(recordBuffer);
           if (bytesRead === null || bytesRead !== BYTES_PER_RECORD) {
-            console.warn(
+            getLogger().warn(
               `Failed to read complete record at index ${recordIndex}`,
             );
             continue;
@@ -296,7 +297,7 @@ function trainDirBinary(
           errorSum += sampleError;
           counter++;
           if (Number.isFinite(errorSum) === false) {
-            console.warn(
+            getLogger().warn(
               `Training ${
                 blue(ID)
               } stopped as errorSum is not finite: ${errorSum} sampleError: ${sampleError} counter: ${counter} record.output: ${targetsBuffer} output: ${output}`,
@@ -306,7 +307,7 @@ function trainDirBinary(
           } else if (bestError !== undefined && counter < knownSampleCount) {
             const bestPossibleError = errorSum / knownSampleCount;
             if (bestPossibleError > bestError) {
-              console.warn(
+              getLogger().warn(
                 `Training ${blue(ID)} stopped as 'best possible' error ${
                   yellow(bestPossibleError.toFixed(3))
                 } > 'best' error ${yellow(bestError.toFixed(3))} at counter ${
@@ -325,7 +326,7 @@ function trainDirBinary(
           if (diff > 60_000) {
             lastTS = now;
             const totalTime = now - startTS;
-            console.log(
+            getLogger().info(
               `Training ${blue(ID)} samples`,
               yellow(counter.toLocaleString("en-AU")),
               `${
@@ -356,7 +357,7 @@ function trainDirBinary(
 
             if (timeoutTS && now > timeoutTS) {
               timedOut = true;
-              console.log(
+              getLogger().info(
                 `Training ${blue(ID)} timed out after ${
                   yellow(format(totalTime, { ignoreZero: true }))
                 }`,
@@ -386,7 +387,7 @@ function trainDirBinary(
     if (bestError !== undefined && bestError < error) {
       trainingFailures++;
       if (trainingStopped === false) {
-        console.warn(
+        getLogger().warn(
           `Training ${blue(ID)} made the error: ${
             yellow(bestError.toFixed(3))
           }, worse: ${yellow(error.toFixed(3))}, target: ${

--- a/src/architecture/TrainingMetrics.ts
+++ b/src/architecture/TrainingMetrics.ts
@@ -9,6 +9,8 @@
  * - Error-Guided Structural Evolution (EGSE)
  */
 
+import { getLogger } from "../utils/Logger.ts";
+
 export interface TrainingMetrics {
   /** Unique identifier for this training session */
   sessionId: string;
@@ -198,33 +200,39 @@ export class TrainingMetricsCollector {
     const totalTime = Date.now() - this.metrics.startTime;
     const minutes = totalTime / (1000 * 60);
 
-    console.log(
+    getLogger().info(
       `\n📊 Training Metrics Report - Session: ${this.metrics.sessionId}`,
     );
-    console.log(`⏱️  Total Time: ${minutes.toFixed(1)} minutes`);
-    console.log(`🎯 Best Fitness: ${this.metrics.bestFitness.toFixed(6)}`);
-    console.log(
+    getLogger().info(`⏱️  Total Time: ${minutes.toFixed(1)} minutes`);
+    getLogger().info(
+      `🎯 Best Fitness: ${this.metrics.bestFitness.toFixed(6)}`,
+    );
+    getLogger().info(
       `📈 Total Improvements: ${this.metrics.summary.totalImprovements}`,
     );
-    console.log(
+    getLogger().info(
       `⚡ Improvements/Min: ${
         (this.metrics.summary.totalImprovements / minutes).toFixed(2)
       }`,
     );
 
-    console.log(`\n🔍 Strategy Breakdown:`);
+    getLogger().info(`\n🔍 Strategy Breakdown:`);
     for (const [strategy, stats] of Object.entries(summary)) {
       if (stats.count > 0) {
-        console.log(`  ${strategy}:`);
-        console.log(`    Count: ${stats.count}`);
-        console.log(
+        getLogger().info(`  ${strategy}:`);
+        getLogger().info(`    Count: ${stats.count}`);
+        getLogger().info(
           `    Total Improvement: ${stats.totalImprovement.toFixed(6)}`,
         );
-        console.log(`    Avg Improvement: ${stats.avgImprovement.toFixed(6)}`);
-        console.log(
+        getLogger().info(
+          `    Avg Improvement: ${stats.avgImprovement.toFixed(6)}`,
+        );
+        getLogger().info(
           `    Best Improvement: ${stats.bestImprovement.toFixed(6)}`,
         );
-        console.log(`    % of Total: ${stats.improvementPercent.toFixed(1)}%`);
+        getLogger().info(
+          `    % of Total: ${stats.improvementPercent.toFixed(1)}%`,
+        );
       }
     }
 
@@ -234,7 +242,7 @@ export class TrainingMetricsCollector {
       .sort((a, b) => b[1].totalImprovement - a[1].totalImprovement)[0];
 
     if (bestStrategy) {
-      console.log(
+      getLogger().info(
         `\n🏆 Best Strategy: ${bestStrategy[0]} (${
           bestStrategy[1].totalImprovement.toFixed(6)
         } total improvement)`,

--- a/src/blackbox/FineTunePopulation.ts
+++ b/src/blackbox/FineTunePopulation.ts
@@ -9,6 +9,7 @@ import { restoreSource } from "./RestoreSource.ts";
 import type { AdaptiveFineTuneTracker } from "./AdaptiveFineTuneTracker.ts";
 
 import { retry } from "./Retry.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 export class FindTunePopulation {
   private neat: Neat;
@@ -91,7 +92,7 @@ export class FindTunePopulation {
 
     let fineTunedPopulation: Creature[] = [];
     if (!tmpPreviousFittest) {
-      console.warn(
+      getLogger().warn(
         "Failed to find previous fittest creature, all the same score as fittest. Skipping fine tuning.",
       );
     } else {

--- a/src/breed/Breed.ts
+++ b/src/breed/Breed.ts
@@ -6,6 +6,7 @@ import { createNeatConfig, type NeatConfig } from "../config/NeatConfig.ts";
 import type { Genus } from "../NEAT/Genus.ts";
 import { FitnessRanking } from "./FitnessRanking.ts";
 import { findFather, selectParent } from "./ParentSelection.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 /**
  * Handles breeding operations between creatures in a NEAT population.
@@ -72,7 +73,7 @@ export class Breed {
 
     const dad = findFather(mum, this.genus, config);
     if (!dad) {
-      console.warn(
+      getLogger().warn(
         "No father found",
       );
 

--- a/src/breed/EnsembleDiversityScoring.ts
+++ b/src/breed/EnsembleDiversityScoring.ts
@@ -19,6 +19,7 @@
  */
 
 import type { Creature } from "../Creature.ts";
+import { getLogger } from "../utils/Logger.ts";
 import {
   DEFAULT_ENSEMBLE_DIVERSITY_CONFIG,
   type EnsembleDiversityConfig,
@@ -504,7 +505,7 @@ export class EnsembleDiversityScoring {
       if (needsCrossBreeding) {
         message += " [CROSS-BREED]";
       }
-      console.info(message);
+      getLogger().info(message);
     }
   }
 
@@ -535,7 +536,7 @@ export class EnsembleDiversityScoring {
 
     const avgDiversity = speciesCount > 0 ? totalDiversity / speciesCount : 0;
 
-    console.info(
+    getLogger().info(
       `[EnsembleDiversity] Population: ${totalCreatures} creatures, ` +
         `${speciesCount} species, ` +
         `avg diversity: ${(avgDiversity * 100).toFixed(1)}%, ` +

--- a/src/breed/ParallelBreeding.ts
+++ b/src/breed/ParallelBreeding.ts
@@ -6,6 +6,7 @@ import type { WorkerHandler } from "../multithreading/workers/WorkerHandler.ts";
 import type { Genus } from "../NEAT/Genus.ts";
 import { FitnessRanking } from "./FitnessRanking.ts";
 import { findFather, selectParent } from "./ParentSelection.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 /**
  * Represents a parent pair for breeding.
@@ -168,7 +169,7 @@ export class ParallelBreeding {
           results[currentIndex] = undefined;
         }
       } catch (error) {
-        console.warn(
+        getLogger().warn(
           `[ParallelBreeding] Worker breeding failed: ${
             error instanceof Error ? error.message : String(error)
           }`,
@@ -247,7 +248,7 @@ export class ParallelBreeding {
 
           resolve(child);
         } catch (error) {
-          console.warn(
+          getLogger().warn(
             `[ParallelBreeding] Breeding failed: ${
               error instanceof Error ? error.message : String(error)
             }`,

--- a/src/compact/CompactUnused.ts
+++ b/src/compact/CompactUnused.ts
@@ -2,6 +2,7 @@ import { assert } from "@std/assert";
 import { addTag, removeTag } from "@stsoftware/tags/mod";
 import { Creature, type CreatureTrace, CreatureUtil } from "../../mod.ts";
 import { creatureValidate } from "../architecture/CreatureValidate.ts";
+import { getLogger } from "../utils/Logger.ts";
 import type { NeuronTrace } from "../architecture/NeuronInterfaces.ts";
 import type { NeuronActivationInterface } from "../methods/activations/NeuronActivationInterface.ts";
 import type { Approach } from "../NEAT/LogApproach.ts";
@@ -88,7 +89,7 @@ export function compactUnused(
         creatureValidate(compacted);
       } catch (e) {
         const errorMsg = (e as Error).message;
-        console.warn("compactUnused", errorMsg);
+        getLogger().warn("compactUnused", errorMsg);
         compacted.fix();
       }
     }
@@ -153,7 +154,7 @@ export function removeNeuron(
     for (const synapse of fromList) {
       const connection = creature.getSynapse(constantNeuron.index, synapse.to);
       if (connection) {
-        console.info(
+        getLogger().info(
           `compactUnused: ${neuron.uuid} already connected to ${constantNeuron.uuid}`,
         );
         if (!synapse.type || !connection.type) {
@@ -165,13 +166,13 @@ export function removeNeuron(
               synapse.type = connection.type;
             }
           } else {
-            console.warn(
+            getLogger().warn(
               `compactUnused: ${neuron.uuid} already connected to ${constantNeuron.uuid} with weight ${connection.weight} required ${synapse.weight}`,
             );
             return false;
           }
         } else {
-          console.warn(
+          getLogger().warn(
             `compactUnused: ${neuron.uuid} already connected to ${constantNeuron.uuid} with type ${connection.type} required ${connection.type}`,
           );
           return false;
@@ -185,7 +186,7 @@ export function removeNeuron(
         synapse.to,
       );
       if (connection) {
-        console.info(
+        getLogger().info(
           `compactUnused: ${neuron.uuid} already connected to ${constantNeuron.uuid}`,
         );
         if (synapse.type) {

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -14,6 +14,7 @@ import type { RequiredFineTunePopulationConfig } from "./FineTunePopulationConfi
 import type { RequiredStabilityAdaptationConfig } from "./StabilityAdaptationConfig.ts";
 import type { RequiredQuantumStepConfig } from "./QuantumStepConfig.ts";
 import type { RequiredBiasRegularisationConfig } from "./BiasRegularisationConfig.ts";
+import type { Logger } from "../utils/Logger.ts";
 import type { RequiredWeightRegularisationConfig } from "./WeightRegularisationConfig.ts";
 
 /**
@@ -535,4 +536,13 @@ export interface NeatArguments {
    * - successRateWindow: Number of recent generations to consider (default: 10)
    */
   fineTunePopulation: RequiredFineTunePopulationConfig;
+
+  /**
+   * Structured logger instance for NEAT-AI output.
+   *
+   * Issue #1398: Consumers can inject a custom logger for integration
+   * with external logging systems. When not provided, defaults to a
+   * console-based logger at "info" level.
+   */
+  logger: Logger;
 }

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -40,6 +40,11 @@ import {
   DEFAULT_WEIGHT_REGULARISATION_CONFIG,
   type RequiredWeightRegularisationConfig,
 } from "./WeightRegularisationConfig.ts";
+import {
+  createConsoleLogger,
+  type Logger,
+  setLogger,
+} from "../utils/Logger.ts";
 
 /**
  * Default cost of growth value used when not specified in options.
@@ -815,7 +820,15 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
         ),
       } as RequiredFineTunePopulationConfig;
     })(),
+    // Issue #1398: Structured logging configuration
+    logger: (() => {
+      if (options.logger) return options.logger;
+      return createConsoleLogger(options.logLevel ?? "info");
+    })() as Logger,
   };
+
+  // Issue #1398: Set the global logger so code without config access can use it
+  setLogger(config.logger);
 
   // Cross-field validation for quantum step config
   if (config.quantumStep.maxStep < config.quantumStep.minStep) {

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -1,3 +1,4 @@
+import type { Logger, LogLevel } from "../utils/Logger.ts";
 import type { AdaptiveMutationThresholds } from "./AdaptiveMutationThresholds.ts";
 import type { DiscoveryMinCandidatesPerCategory } from "./DiscoveryMinCandidatesPerCategory.ts";
 import type { EnsembleDiversityConfig } from "./EnsembleDiversityConfig.ts";
@@ -74,6 +75,7 @@ export type NeatOptions =
     | "ensembleDiversity"
     | "quantumStep"
     | "fineTunePopulation"
+    | "logger"
   >
   & {
     /** Partial overrides for minimum candidates per category (defaults applied if not specified) */
@@ -94,6 +96,17 @@ export type NeatOptions =
     quantumStep?: QuantumStepConfig;
     /** Partial overrides for fine-tune population configuration (defaults applied if not specified) */
     fineTunePopulation?: FineTunePopulationConfig;
+    /**
+     * Custom logger instance. When provided, all NEAT-AI log output is
+     * routed through this logger instead of the default console logger.
+     */
+    logger?: Logger;
+    /**
+     * Log level filter when using the default console logger.
+     * Ignored when a custom `logger` is provided.
+     * Default: "info"
+     */
+    logLevel?: LogLevel;
   };
 
 /**
@@ -126,6 +139,8 @@ export type NeatOptionsInput =
     | "ensembleDiversity"
     | "quantumStep"
     | "fineTunePopulation"
+    | "logger"
+    | "logLevel"
   >
   & {
     [K in NumericOptionKeys]?: NonNullable<NeatOptions[K]> extends number
@@ -144,4 +159,8 @@ export type NeatOptionsInput =
     ensembleDiversity?: CoerceNumeric<EnsembleDiversityConfig>;
     quantumStep?: CoerceNumeric<QuantumStepConfig>;
     fineTunePopulation?: CoerceNumeric<FineTunePopulationConfig>;
+    /** Custom logger instance (not coerced — functions cannot come from CLI). */
+    logger?: Logger;
+    /** Log level filter for the default console logger. */
+    logLevel?: LogLevel;
   };

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -32,6 +32,7 @@
  */
 
 import { CreatureUtil } from "../architecture/CreatureUtils.ts";
+import { getLogger } from "../utils/Logger.ts";
 import {
   type CandidateHarmfulNeuron,
   type CandidateNeuron,
@@ -286,7 +287,7 @@ export function buildDiscoveryCandidates(
   } else if (
     !skipCombos && helpfulNeuronCandidates && helpfulNeuronCandidates.length > 0
   ) {
-    console.info(
+    getLogger().info(
       `[DiscoveryCandidates] Combined add-neurons candidate not created (${helpfulNeuronCandidates.length} neuron${
         helpfulNeuronCandidates.length === 1 ? "" : "s"
       } suggested but structure change returned undefined)`,
@@ -328,14 +329,14 @@ export function buildDiscoveryCandidates(
         });
       } catch (error) {
         skippedCount++;
-        console.info(
+        getLogger().info(
           `[DiscoveryCandidates] Skipped coordinated-structural candidate (apply failed):`,
           error,
         );
       }
     }
     if (skippedCount > 0) {
-      console.info(
+      getLogger().info(
         `[DiscoveryCandidates] Skipped ${skippedCount}/${coordinatedStructuralCandidates.length} coordinated-structural candidate${
           skippedCount === 1 ? "" : "s"
         } (apply failed)`,
@@ -373,7 +374,7 @@ export function buildDiscoveryCandidates(
   } else if (
     !skipCombos && addHelpfulSynapses && addHelpfulSynapses.length > 0
   ) {
-    console.info(
+    getLogger().info(
       `[DiscoveryCandidates] Combined add-synapses candidate not created (${addHelpfulSynapses.length} synapse${
         addHelpfulSynapses.length === 1 ? "" : "s"
       } suggested but structure change returned undefined)`,
@@ -557,7 +558,7 @@ export function buildDiscoveryCandidates(
       }
     }
   } else if (!skipCombos && candidateSquashes && candidateSquashes.length > 0) {
-    console.info(
+    getLogger().info(
       `[DiscoveryCandidates] Combined change-squash candidate not created (${candidateSquashes.length} squash${
         candidateSquashes.length === 1 ? "" : "es"
       } suggested but structure change returned undefined)`,
@@ -671,7 +672,7 @@ export function buildDiscoveryCandidates(
       const failureDetails = Array.from(failureReasons.entries())
         .map(([reason, count]) => `${reason}: ${count}`)
         .join(", ");
-      console.info(
+      getLogger().info(
         `[DiscoveryCandidates] Removal candidates: ${removalCandidates.length} total, ` +
           `${removalSuccessCount} succeeded, ${removalFailureCount} failed` +
           (failureDetails ? ` (${failureDetails})` : ""),
@@ -686,7 +687,7 @@ export function buildDiscoveryCandidates(
       const candidateDetails = topCandidates.map((c) =>
         `${shortID(c.neuronUUID)}:${c.impact.toExponential(2)}`
       ).join(", ");
-      console.info(
+      getLogger().info(
         `[DiscoveryCandidates] Top ${topCandidates.length} lowest-impact removal candidates: ${candidateDetails}`,
       );
 
@@ -698,7 +699,7 @@ export function buildDiscoveryCandidates(
         c.neuronUUID.toLowerCase().includes("removal")
       );
       if (testNeuronMatches.length > 0) {
-        console.info(
+        getLogger().info(
           `[DiscoveryCandidates] Found ${testNeuronMatches.length} potential test neuron(s) in removal list: ` +
             testNeuronMatches.map((c) =>
               `${c.neuronUUID}:${c.impact.toExponential(2)}`
@@ -847,7 +848,7 @@ function buildSingleSynapseCandidates(
     });
   }
   if (skippedCount > 0) {
-    console.info(
+    getLogger().info(
       `[DiscoveryCandidates] Skipped ${skippedCount}/${synapses.length} individual synapse candidate${
         skippedCount === 1 ? "" : "s"
       } (structure change returned undefined)`,
@@ -911,7 +912,7 @@ function buildSingleNeuronCandidates(
     });
   }
   if (skippedCount > 0) {
-    console.info(
+    getLogger().info(
       `[DiscoveryCandidates] Skipped ${skippedCount}/${neurons.length} individual neuron candidate${
         skippedCount === 1 ? "" : "s"
       } (structure change returned undefined)`,
@@ -964,7 +965,7 @@ function buildSingleSquashCandidates(
     });
   }
   if (skippedCount > 0) {
-    console.info(
+    getLogger().info(
       `[DiscoveryCandidates] Skipped ${skippedCount}/${squashes.length} individual squash candidate${
         skippedCount === 1 ? "" : "s"
       } (structure change returned undefined)`,
@@ -1511,7 +1512,7 @@ export function buildCombinedFromSuccessful(
 
   // Log summary of generated combinations
   if (combinedCandidates.length > 0) {
-    console.info(
+    getLogger().info(
       `[DiscoveryCandidates] Generated ${combinedCandidates.length} combination candidate${
         combinedCandidates.length === 1 ? "" : "s"
       } from ${successfulCandidates.length} successful singles`,
@@ -1661,16 +1662,16 @@ function validateAndFixCreatureSync(
       );
 
     // Log the validation failure with details
-    console.warn(
+    getLogger().warn(
       `[DiscoveryCandidates] Validation failed for ${changeType} change: ${validationError.message}`,
     );
-    console.warn(
+    getLogger().warn(
       `[DiscoveryCandidates] Cannot write debug file in synchronous context`,
     );
 
     // Last resort: call fix() to repair the creature
     // This should be treated as a bug - the modification logic should be improved
-    console.warn(
+    getLogger().warn(
       `[DiscoveryCandidates] Calling fix() on ${changeType} change - this indicates a bug in modification logic that should be addressed`,
     );
     if (enforceForwardOnly) {
@@ -1690,7 +1691,7 @@ function validateAndFixCreatureSync(
         creature.validate();
       }
     } catch (fixError) {
-      console.error(
+      getLogger().error(
         `[DiscoveryCandidates] Creature still invalid after fix() for ${changeType}: ${fixError}`,
       );
       throw fixError;
@@ -2072,13 +2073,13 @@ function applyChangeToCreature(
       default:
         // For combo types or unknown, just return the candidate's creature
         // This shouldn't happen in two-phase scoring but provides a fallback
-        console.warn(
+        getLogger().warn(
           `[DiscoveryCandidates] Unknown change type for combination: ${changeType}`,
         );
         return undefined;
     }
   } catch (error) {
-    console.warn(
+    getLogger().warn(
       `[DiscoveryCandidates] Failed to apply ${changeType} change during combination:`,
       error,
     );

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -1,4 +1,5 @@
 import { assertExists } from "@std/assert";
+import { getLogger } from "../utils/Logger.ts";
 import type { CostName } from "../Costs.ts";
 import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "../architecture/CreatureUtils.ts";
@@ -717,7 +718,7 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
               // Ignore termination errors.
             }
             if (!preferDirect) {
-              console.warn(
+              getLogger().warn(
                 "[DiscoveryReplayRunner] Worker init failed; falling back to direct execution for this worker slot.",
                 err,
               );

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -1,4 +1,5 @@
 import { assert, assertExists } from "@std/assert";
+import { getLogger } from "../utils/Logger.ts";
 import { bold, cyan, green, red, yellow } from "@std/fmt/colors";
 import { format } from "@std/fmt/duration";
 import { join } from "@std/path/join";
@@ -146,7 +147,7 @@ export class DiscoveryRunner {
     const config = createNeatConfig(input.options);
     const verboseLog = (...args: unknown[]) => {
       if (config.verbose) {
-        console.info("[DiscoveryRunner]", ...args);
+        getLogger().info("[DiscoveryRunner]", ...args);
       }
     };
     if (config.discoverySampleRate <= 0) {
@@ -199,7 +200,7 @@ export class DiscoveryRunner {
               // Swallow termination errors as worker may already be closed.
             }
             if (!preferDirect) {
-              console.warn(
+              getLogger().warn(
                 "[DiscoveryRunner] Worker init failed; falling back to direct execution for this worker slot.",
                 err,
               );
@@ -303,7 +304,7 @@ export class DiscoveryRunner {
       const countBreakdown = Array.from(candidateCountsByType.entries())
         .map(([type, count]) => `${type}: ${count}`)
         .join(", ");
-      console.info(
+      getLogger().info(
         `[DiscoveryRunner] Built ${singleCandidates.length} candidate${
           singleCandidates.length === 1 ? "" : "s"
         }${countBreakdown ? ` (${countBreakdown})` : ""}`,
@@ -657,7 +658,7 @@ export class DiscoveryRunner {
         archiveDir = targetDir;
         resolvedArchiveDir = safeRealPath(targetDir);
       } catch (error) {
-        console.warn(
+        getLogger().warn(
           "[DiscoveryRunner] Failed to create discovery candidate archive:",
           error,
         );
@@ -683,7 +684,7 @@ export class DiscoveryRunner {
         Deno.writeTextFileSync(filePath, JSON.stringify(payload, null, 1));
         return safeRealPath(filePath);
       } catch (error) {
-        console.warn(
+        getLogger().warn(
           `[DiscoveryRunner] Failed to persist discovery candidate '${baseLabel}':`,
           error,
         );
@@ -744,7 +745,7 @@ export class DiscoveryRunner {
         const summaryPath = join(archiveDir, "summary.json");
         Deno.writeTextFileSync(summaryPath, JSON.stringify(summaries, null, 1));
       } catch (error) {
-        console.warn(
+        getLogger().warn(
           "[DiscoveryRunner] Failed to persist discovery evaluation summary:",
           error,
         );
@@ -775,7 +776,7 @@ export class DiscoveryRunner {
     // Identify the best candidate (highest score delta)
     const bestCandidate = candidates.length > 0 ? candidates[0] : undefined;
 
-    console.info(
+    getLogger().info(
       `[DiscoveryRunner] ${
         bold(`Discovery ${discoveryID} evaluation summary:`)
       }`,
@@ -843,7 +844,7 @@ export class DiscoveryRunner {
         summary.error.toPrecision(6)
       } ${scoreText}${scoreDeltaText}${improvedText} ${errorDeltaText}${bestMarker}`;
 
-    console.info(
+    getLogger().info(
       `[DiscoveryRunner]   ${label}${description}: ${mainInfo}`,
     );
 
@@ -852,7 +853,7 @@ export class DiscoveryRunner {
     if (summary.neuronDetails) {
       const nd = summary.neuronDetails;
       const prefix = isBest ? "★ " : "  ";
-      console.info(
+      getLogger().info(
         `[DiscoveryRunner]     ${prefix}neuron: ` +
           `from=${shortID(nd.fromNeuronUUID)} to=${shortID(nd.toNeuronUUID)} ` +
           `squash=${nd.squash} ` +
@@ -864,7 +865,7 @@ export class DiscoveryRunner {
     }
 
     if (summary.archivePath) {
-      console.info(
+      getLogger().info(
         `[DiscoveryRunner]     Saved creature at ${summary.archivePath}`,
       );
     }
@@ -918,7 +919,7 @@ export class DiscoveryRunner {
       });
 
       if (verbose) {
-        console.info("[DiscoveryRunner] Evaluation result", {
+        getLogger().info("[DiscoveryRunner] Evaluation result", {
           kind: task.kind,
           change: task.candidate?.change.type,
           error,
@@ -1006,7 +1007,7 @@ export class DiscoveryRunner {
             .join(", ");
           parts.push(typeBreakdown || `${cache.cachedOther} other`);
         }
-        console.info(
+        getLogger().info(
           `[DiscoveryRunner] ⏭️ Skipped ${cache.totalCached} candidate${
             cache.totalCached === 1 ? "" : "s"
           } due to previous failure: ${parts.join(", ")}`,
@@ -1022,7 +1023,7 @@ export class DiscoveryRunner {
         .map(([type, counts]) => `${type}: ${counts.selected}/${counts.total}`)
         .join(", ");
       if (diversitySummary.length > 0) {
-        console.info(
+        getLogger().info(
           `[DiscoveryRunner] Category diversity: ${diversitySummary}`,
         );
       }
@@ -1032,14 +1033,14 @@ export class DiscoveryRunner {
     if (result.diagnostics?.removalSelection) {
       const removal = result.diagnostics.removalSelection;
       if (removal.poolImpacts.length > 0) {
-        console.info(
+        getLogger().info(
           `[DiscoveryRunner] Top ${removal.poolImpacts.length} lowest-impact removal candidates pool: [${
             removal.poolImpacts.join(", ")
           }]`,
         );
       }
       if (removal.selectedImpacts.length > 0) {
-        console.info(
+        getLogger().info(
           `[DiscoveryRunner] ✓ Selected ${removal.selectedImpacts.length} removal from top ${removal.poolImpacts.length}: [${
             removal.selectedImpacts.join(", ")
           }]`,

--- a/src/discovery/EnhancedDiscoveryValidator.ts
+++ b/src/discovery/EnhancedDiscoveryValidator.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Creature } from "../Creature.ts";
+import { getLogger } from "../utils/Logger.ts";
 import type { DataRecordInterface } from "../architecture/DataSet.ts";
 import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
 import {
@@ -373,12 +374,12 @@ export class EnhancedDiscoveryValidator {
     const status = result.passed ? "✓ PASSED" : "✗ FAILED";
     const changeType = candidate.change.type;
 
-    console.info(
+    getLogger().info(
       `[EnhancedValidator] ${status} ${changeType}`,
     );
 
     if (result.holdoutResult) {
-      console.info(
+      getLogger().info(
         `[EnhancedValidator]   Holdout: error=${
           result.holdoutResult.holdoutError.toPrecision(4)
         } gap=${(result.holdoutResult.performanceGap ?? 0).toPrecision(4)}`,
@@ -386,7 +387,7 @@ export class EnhancedDiscoveryValidator {
     }
 
     if (result.brittlenessResult) {
-      console.info(
+      getLogger().info(
         `[EnhancedValidator]   Brittleness: score=${
           result.brittlenessResult.brittlenessScore.toPrecision(4)
         } variance=${result.brittlenessResult.outputVariance.toPrecision(4)}`,
@@ -394,7 +395,7 @@ export class EnhancedDiscoveryValidator {
     }
 
     if (result.combinedBrittlenessScore !== undefined) {
-      console.info(
+      getLogger().info(
         `[EnhancedValidator]   Combined: ${
           result.combinedBrittlenessScore.toPrecision(4)
         }`,
@@ -403,7 +404,7 @@ export class EnhancedDiscoveryValidator {
 
     if (result.rejectionReasons && result.rejectionReasons.length > 0) {
       for (const reason of result.rejectionReasons) {
-        console.info(`[EnhancedValidator]   Rejection: ${reason}`);
+        getLogger().info(`[EnhancedValidator]   Rejection: ${reason}`);
       }
     }
   }

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -21,6 +21,7 @@ import { dirname } from "@std/path/dirname";
 import { join } from "@std/path/join";
 import { crypto as stdCrypto } from "@std/crypto";
 import { getDiscoveryVersion } from "../architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import { getLogger } from "../utils/Logger.ts";
 import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
 import type { Creature } from "../Creature.ts";
 
@@ -577,46 +578,50 @@ export function logPredictionTrace(
 ): void {
   if (!isPredictionTracingEnabled()) return;
 
-  console.info("=".repeat(80));
-  console.info("[PREDICTION TRACE] Candidate evaluation details");
-  console.info("=".repeat(80));
-  console.info(`Change Type: ${candidate.change.type}`);
-  console.info(`Description: ${candidate.change.description}`);
-  console.info("");
+  getLogger().info("=".repeat(80));
+  getLogger().info("[PREDICTION TRACE] Candidate evaluation details");
+  getLogger().info("=".repeat(80));
+  getLogger().info(`Change Type: ${candidate.change.type}`);
+  getLogger().info(`Description: ${candidate.change.description}`);
+  getLogger().info("");
 
   // Log score comparison from metadata
-  console.info("--- Score Comparison ---");
-  console.info(`Original Score:    ${metadata.originalScore.toPrecision(8)}`);
-  console.info(`Candidate Score:   ${metadata.candidateScore.toPrecision(8)}`);
-  console.info(
+  getLogger().info("--- Score Comparison ---");
+  getLogger().info(
+    `Original Score:    ${metadata.originalScore.toPrecision(8)}`,
+  );
+  getLogger().info(
+    `Candidate Score:   ${metadata.candidateScore.toPrecision(8)}`,
+  );
+  getLogger().info(
     `Score Delta:       ${metadata.scoreDelta.toPrecision(8)} (${
       metadata.scoreDelta > 0 ? "IMPROVED" : "DEGRADED"
     })`,
   );
-  console.info("");
+  getLogger().info("");
 
   // Log prediction details
   if (cacheEntry.predictionDetails) {
-    console.info("--- Rust Prediction Details ---");
-    console.info(JSON.stringify(cacheEntry.predictionDetails, null, 2));
-    console.info("");
+    getLogger().info("--- Rust Prediction Details ---");
+    getLogger().info(JSON.stringify(cacheEntry.predictionDetails, null, 2));
+    getLogger().info("");
   }
 
   // Log target neuron info
   if (cacheEntry.targetNeuronInfo) {
-    console.info("--- Target Neuron Info ---");
-    console.info(JSON.stringify(cacheEntry.targetNeuronInfo, null, 2));
-    console.info("");
+    getLogger().info("--- Target Neuron Info ---");
+    getLogger().info(JSON.stringify(cacheEntry.targetNeuronInfo, null, 2));
+    getLogger().info("");
   }
 
   // Log actual changes
   if (cacheEntry.actualCreatureChange) {
-    console.info("--- Actual Creature Changes ---");
-    console.info(JSON.stringify(cacheEntry.actualCreatureChange, null, 2));
-    console.info("");
+    getLogger().info("--- Actual Creature Changes ---");
+    getLogger().info(JSON.stringify(cacheEntry.actualCreatureChange, null, 2));
+    getLogger().info("");
   }
 
-  console.info("=".repeat(80));
+  getLogger().info("=".repeat(80));
 }
 
 /**
@@ -656,7 +661,7 @@ export async function isCandidateCached(
       return false;
     }
     // Log unexpected errors but don't fail
-    console.warn(
+    getLogger().warn(
       `[FailureCache] Error checking cache for candidate: ${error}`,
     );
     return false;
@@ -690,7 +695,7 @@ export function isCandidateCachedSync(
       return false;
     }
     // Log unexpected errors but don't fail
-    console.warn(
+    getLogger().warn(
       `[FailureCache] Error checking cache for candidate: ${error}`,
     );
     return false;
@@ -869,7 +874,7 @@ export async function recordFailure(
     await Deno.writeTextFile(filePath, JSON.stringify(cacheEntry, null, 2));
   } catch (error) {
     // Log but don't fail - caching is an optimisation, not critical
-    console.warn(
+    getLogger().warn(
       `[FailureCache] Failed to record failure for candidate ${candidate.change.type}: ${error}`,
     );
   }
@@ -1047,7 +1052,7 @@ export function recordFailureSync(
     Deno.writeTextFileSync(filePath, JSON.stringify(cacheEntry, null, 2));
   } catch (error) {
     // Log but don't fail - caching is an optimisation, not critical
-    console.warn(
+    getLogger().warn(
       `[FailureCache] Failed to record failure for candidate ${candidate.change.type}: ${error}`,
     );
   }

--- a/src/discovery/SuccessCache.ts
+++ b/src/discovery/SuccessCache.ts
@@ -18,6 +18,7 @@
 import { dirname } from "@std/path/dirname";
 import { join } from "@std/path/join";
 import { getDiscoveryVersion } from "../architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import { getLogger } from "../utils/Logger.ts";
 import type { Creature } from "../Creature.ts";
 import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
 import { buildCacheKey, extractActualCreatureChanges } from "./FailureCache.ts";
@@ -324,7 +325,7 @@ export function listSuccessEntriesSync(cacheDir: string): SuccessCacheEntry[] {
             results.push(parsed);
           }
         } catch (error) {
-          console.warn(
+          getLogger().warn(
             `[SuccessCache] Failed to parse success cache entry '${filePath}':`,
             error,
           );

--- a/src/intelligentDesign/ImproveSquash.ts
+++ b/src/intelligentDesign/ImproveSquash.ts
@@ -17,6 +17,7 @@ import { alternativeSquashes } from "./AlternativeSquashes.ts";
 import type { BestNeuronSquash } from "./BestNeuronSquash.ts";
 import { safeWriteText, safeWriteTextSync } from "./SafeWrite.ts";
 import { WorkerHandler } from "./workers/WorkerHandler.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 function remainingTimeMs(deadlineMs: number): number {
   return Math.max(0, deadlineMs - Date.now());
@@ -189,7 +190,7 @@ export function makeModifiedCreatureWithPrevious(
   assert(previousSquash, "Previous squash should be defined");
 
   if (neuronData.squash === nextSquash) {
-    console.warn(
+    getLogger().warn(
       `${neuronData.uuid} Squash should be different from ${nextSquash}`,
     );
   }
@@ -299,7 +300,7 @@ export async function scanForSquashImprovements(
           // ignore
         }
         if (makeDirectWorker) {
-          console.warn(
+          getLogger().warn(
             "[ImproveSquash] Worker init failed; falling back to direct execution for this worker slot.",
             err,
           );
@@ -340,7 +341,7 @@ export async function scanForSquashImprovements(
       // Check timeout
       const now = Date.now();
       if (now - start > timeoutMs) {
-        console.warn(`Timeout after: ${now - start}ms`);
+        getLogger().warn(`Timeout after: ${now - start}ms`);
         timedOut = true;
         break;
       }
@@ -361,7 +362,7 @@ export async function scanForSquashImprovements(
         const throttleNow = Date.now();
 
         if (throttleNow - lastThrottleTime > 60_000) {
-          console.log(
+          getLogger().info(
             `Throttling: waiting for tasks to complete... pending: ${pendingCount}, max: ${maxPending}, found: ${bestNeuronSquashMap.size}`,
           );
           lastThrottleTime = throttleNow;
@@ -378,7 +379,7 @@ export async function scanForSquashImprovements(
 
       // Skip if neuron already has target squash
       if (targetSquash === neuron.squash) {
-        console.log(
+        getLogger().info(
           `Neuron ${
             neuron.uuid?.slice(-8)
           } already has squash ${targetSquash}, skipping.`,
@@ -423,7 +424,7 @@ export async function scanForSquashImprovements(
               `Neuron ${shortId} ${previousSquash} -> ${targetSquash}, score: ${
                 res.score.score.toPrecision(6)
               } improved by ${(res.score.score - bestScore).toPrecision(3)}`;
-            console.log(lastMessage);
+            getLogger().info(lastMessage);
 
             const path = `${outputDir}/${targetSquash}_${shortId}.json`;
 
@@ -487,7 +488,7 @@ export async function scanForSquashImprovements(
                             3,
                           )
                         }`;
-                      console.log(alternativeMessage);
+                      getLogger().info(alternativeMessage);
 
                       const altPath =
                         `${outputDir}/${altSquash}_${shortId}.json`;
@@ -598,7 +599,10 @@ export async function scanForSquashImprovements(
       try {
         worker.terminate();
       } catch (error) {
-        console.error("Failed to terminate Intelligent Design worker:", error);
+        getLogger().error(
+          "Failed to terminate Intelligent Design worker:",
+          error,
+        );
       }
     }
   }

--- a/src/intelligentDesign/TacitKnowledge.ts
+++ b/src/intelligentDesign/TacitKnowledge.ts
@@ -12,6 +12,7 @@ import { addTag } from "@stsoftware/tags/mod";
 import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import type { NeuronExport } from "../architecture/NeuronInterfaces.ts";
 import { Creature } from "../Creature.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 /**
  * Tacit knowledge is a mapping from neuron UUID to squash function name.
@@ -82,7 +83,7 @@ export function makeModifiedCreature(
   assert(previousSquash, "Previous squash should be defined");
 
   if (neuronData.squash === nextSquash) {
-    console.warn(
+    getLogger().warn(
       `${neuronData.uuid.slice(-8)} Squash already set to ${nextSquash}`,
     );
   }
@@ -143,7 +144,7 @@ export function cleanKnowledge(
   for (const key of Object.keys(cleanedHive)) {
     const creatureSquash = validNeuronUUIDs.get(key);
     if (!creatureSquash) {
-      console.warn(
+      getLogger().warn(
         `Removing invalid hive knowledge for ${
           key.slice(-8)
         }: not found in the creature.`,
@@ -155,7 +156,7 @@ export function cleanKnowledge(
   // Add missing neurons to hive knowledge
   validNeuronUUIDs.forEach((squash, uuid) => {
     if (!cleanedHive[uuid]) {
-      console.warn(
+      getLogger().warn(
         `No hive knowledge for ${
           uuid.slice(-8)
         } with squash ${squash}, adding.`,

--- a/src/intelligentDesign/workers/WorkerHandler.ts
+++ b/src/intelligentDesign/workers/WorkerHandler.ts
@@ -12,6 +12,7 @@ import type { Creature } from "../../Creature.ts";
 import type { NeatOptions } from "../../config/NeatOptions.ts";
 import type { ResponseData } from "./ResponseData.ts";
 import { MockWorker } from "./MockWorker.ts";
+import { getLogger } from "../../utils/Logger.ts";
 
 export interface WasmActivationInitPayload {
   /**
@@ -198,14 +199,14 @@ export class WorkerHandler {
         ].filter(Boolean).join(" | ");
         const err = new Error(msg, { cause: ev.error });
         captureInitError(err);
-        console.error(msg, ev.error ?? ev);
+        getLogger().error(msg, ev.error ?? ev);
       });
       this.worker.addEventListener("messageerror", (e) => {
         const msg =
           `ID worker messageerror event during init (workerID=${this.workerID}) | script=${workerUrl}`;
         const err = new Error(msg, { cause: e });
         captureInitError(err);
-        console.error(msg, e);
+        getLogger().error(msg, e);
       });
     }
 

--- a/src/multithreading/workers/MockWorker.ts
+++ b/src/multithreading/workers/MockWorker.ts
@@ -5,6 +5,7 @@ import type {
 } from "./WorkerHandler.ts";
 
 import { WorkerProcessor } from "./WorkerProcessor.ts";
+import { getLogger } from "../../utils/Logger.ts";
 
 export class MockWorker implements WorkerInterface {
   private callBack: EventListener | null = null;
@@ -27,7 +28,7 @@ export class MockWorker implements WorkerInterface {
         this.callBack(me);
       }
     }).catch((error) => {
-      console.error("MockWorker processing error:", error);
+      getLogger().error("MockWorker processing error:", error);
       // Create a proper error response with operation-specific error field
       const errorResponse: ResponseData = {
         taskID: data.taskID,

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -16,6 +16,7 @@ import type {
 import type { NeatConfig } from "../../config/NeatConfig.ts";
 import type { TrainOptions } from "../../config/TrainOptions.ts";
 import { MockWorker } from "./MockWorker.ts";
+import { getLogger } from "../../utils/Logger.ts";
 
 export interface WasmActivationInitPayload {
   /**
@@ -470,14 +471,14 @@ export class WorkerHandler {
         ].filter(Boolean).join(" | ");
         const err = new Error(msg, { cause: ev.error });
         captureInitError(err);
-        console.error(msg, ev.error ?? ev);
+        getLogger().error(msg, ev.error ?? ev);
       });
       this.worker.addEventListener("messageerror", (e) => {
         const msg =
           `Worker messageerror event during init (workerID=${this.workerID}) | script=${workerUrl}`;
         const err = new Error(msg, { cause: e });
         captureInitError(err);
-        console.error(msg, e);
+        getLogger().error(msg, e);
       });
     } else {
       this.worker = new MockWorker();
@@ -593,7 +594,7 @@ export class WorkerHandler {
 
     // Log discovery response receipt
     if (data.discover) {
-      console.log(
+      getLogger().info(
         `[WorkerHandler] Received discovery response for taskID: ${data.taskID}`,
       );
     }
@@ -620,7 +621,7 @@ export class WorkerHandler {
 
     // Log discovery request posting
     if (data.discover) {
-      console.log(
+      getLogger().info(
         `[WorkerHandler] Posting discovery request to worker (taskID: ${data.taskID})`,
       );
     }
@@ -663,7 +664,7 @@ export class WorkerHandler {
       this.ready.then(() => {
         // Log discovery request posting
         if (data.discover) {
-          console.log(
+          getLogger().info(
             `[WorkerHandler] Posting discovery request to worker (taskID: ${data.taskID})`,
           );
         }

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -14,6 +14,7 @@ import {
   isWasmActivationAvailable,
 } from "../../wasm/mod.ts";
 import type { RequestData, ResponseData } from "./WorkerHandler.ts";
+import { getLogger } from "../../utils/Logger.ts";
 
 type DiscoverResponsePayload = NonNullable<ResponseData["discover"]>;
 
@@ -234,7 +235,7 @@ export class WorkerProcessor {
           },
         };
       } catch (error) {
-        console.error(error);
+        getLogger().error(error);
         writeDiagnostics({
           error,
           prefix: "evaluate",
@@ -324,7 +325,7 @@ export class WorkerProcessor {
         creatureValidate(creature);
 
         if (data.discover.config.log) {
-          console.log(
+          getLogger().info(
             `[Worker] Starting discovery for creature (taskID: ${data.taskID})...`,
           );
         }
@@ -336,7 +337,7 @@ export class WorkerProcessor {
         );
 
         if (data.discover.config.log) {
-          console.log(
+          getLogger().info(
             `[Worker] Discovery complete for creature (taskID: ${data.taskID}), preparing response...`,
           );
         }
@@ -350,7 +351,7 @@ export class WorkerProcessor {
         clearDiscoverResultForGC(result);
 
         if (data.discover!.config.log) {
-          console.log(
+          getLogger().info(
             `[Worker] Returning discovery response (taskID: ${data.taskID})...`,
           );
         }

--- a/src/multithreading/workers/deno/worker.ts
+++ b/src/multithreading/workers/deno/worker.ts
@@ -7,6 +7,7 @@ import type { RequestData, ResponseData } from "../WorkerHandler.ts";
 (globalThis as any).__NEAT_AI_SKIP_WASM_AUTO_INIT = true;
 
 const { WorkerProcessor } = await import("../WorkerProcessor.ts");
+const { getLogger } = await import("../../../utils/Logger.ts");
 const processor = new WorkerProcessor();
 const workerHandler =
   // deno-lint-ignore ban-types
@@ -51,7 +52,7 @@ workerHandler.onmessage = async function (message: { data: RequestData }) {
     }
     workerHandler.postMessage(result);
   } catch (error) {
-    console.error("Worker processing error:", error);
+    getLogger().error("Worker processing error:", error);
     // Create a proper error response with operation-specific error field
     const errorResponse: ResponseData = {
       taskID: message.data.taskID,

--- a/src/mutate/AddNeuron.ts
+++ b/src/mutate/AddNeuron.ts
@@ -4,6 +4,7 @@ import type { Creature } from "../Creature.ts";
 import { Neuron } from "../architecture/Neuron.ts";
 import { Synapse } from "../architecture/Synapse.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 /**
  * Selects a suitable outward connection target for a newly inserted neuron.
@@ -235,7 +236,7 @@ export class AddNeuron extends AbstractMutationOperator {
     // delete this.creature.memetic;
     const endUUID = CreatureUtil.makeUUID(creature);
     if (startUUID === endUUID) {
-      console.warn("AddNeuron: No change.");
+      getLogger().warn("AddNeuron: No change.");
       return false;
     } else {
       return true;

--- a/src/mutate/SubBackCon.ts
+++ b/src/mutate/SubBackCon.ts
@@ -1,6 +1,7 @@
 import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 export class SubBackCon extends AbstractMutationOperator {
   protected performMutation(focusList?: number[]): boolean {
@@ -40,20 +41,20 @@ export class SubBackCon extends AbstractMutationOperator {
       if (toNeuron.type === "hidden") {
         const outwardList = this.creature.outwardConnections(pair[1]);
         if (outwardList.length === 0) {
-          console.info(
+          getLogger().info(
             `Remove neuron ${toNeuron.uuid} as completely disconnected`,
           );
           removeHiddenNeuron(this.creature, pair[1]);
           toNeuronRemoved = true;
         } else {
-          console.info(
+          getLogger().info(
             `Convert neuron ${toNeuron.uuid} from ${toNeuron.type} to constant`,
           );
           const squash = toNeuron.findSquash();
           const activation = squash as ActivationInterface;
           if (activation.squash) {
             const constantBias = activation.squash(toNeuron.bias);
-            console.info(
+            getLogger().info(
               `Adjust neuron ${toNeuron.uuid} bias ${toNeuron.bias} to ${constantBias}`,
             );
             toNeuron.bias = constantBias;
@@ -74,7 +75,7 @@ export class SubBackCon extends AbstractMutationOperator {
     if (fromOutwardList.length === 0) {
       const fromNeuron = this.creature.neurons[fromIndex];
       if (fromNeuron.type === "hidden" || fromNeuron.type === "constant") {
-        console.info(
+        getLogger().info(
           `Remove neuron ${fromNeuron.uuid} as no longer connected`,
         );
         removeHiddenNeuron(this.creature, fromIndex);

--- a/src/mutate/SubSelfCon.ts
+++ b/src/mutate/SubSelfCon.ts
@@ -1,6 +1,7 @@
 import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 export class SubSelfCon extends AbstractMutationOperator {
   protected performMutation(focusList?: number[]): boolean {
@@ -41,19 +42,19 @@ export class SubSelfCon extends AbstractMutationOperator {
     if (inwardList.length === 0 && neuron.type === "hidden") {
       const outwardList = this.creature.outwardConnections(indx);
       if (outwardList.length === 0) {
-        console.info(
+        getLogger().info(
           `Remove neuron ${neuron.uuid} as completely disconnected`,
         );
         removeHiddenNeuron(this.creature, indx);
       } else {
-        console.info(
+        getLogger().info(
           `Convert neuron ${neuron.uuid} from ${neuron.type} to constant`,
         );
         const squash = neuron.findSquash();
         const activation = squash as ActivationInterface;
         if (activation.squash) {
           const constantBias = activation.squash(neuron.bias);
-          console.info(
+          getLogger().info(
             `Adjust neuron ${neuron.uuid} bias ${neuron.bias} to ${constantBias}`,
           );
           neuron.bias = constantBias;

--- a/src/reconstruct/CRISPR.ts
+++ b/src/reconstruct/CRISPR.ts
@@ -7,6 +7,7 @@ import {
   getMajorVersion,
   upgradeSemanticVersionIfForwardOnlyConfirmed,
 } from "../upgrade/Upgrade.ts";
+import { getLogger } from "../utils/Logger.ts";
 
 /**
  * Interface representing the structure of the CRISPR modification data.
@@ -471,7 +472,7 @@ export class CRISPR {
         JSON.stringify(modifiedCreature.exportJSON(), null, 1),
       );
 
-      console.warn(`Invalid creature saved to ${name}`, e);
+      getLogger().warn(`Invalid creature saved to ${name}`, e);
       return this.creature;
     }
 

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -1,6 +1,7 @@
 import { Creature } from "../Creature.ts";
 import { creatureValidate } from "../architecture/CreatureValidate.ts";
 import { writeDiagnostics } from "../utils/Diagnostics.ts";
+import { getLogger } from "../utils/Logger.ts";
 import { upgradeTwo } from "./UpgradeTwo.ts";
 
 /**
@@ -58,7 +59,7 @@ function validateThreeX(creature: Creature): void {
     // This should never happen - 3.x creatures should have been validated.
     // Log the error but don't modify the creature - offspring validation will
     // handle any issues during breeding.
-    console.error(
+    getLogger().error(
       `[upgrade] Version 3.x creature has invalid recurrent connections. ` +
         `This indicates a data integrity issue. UUID: ${creature.uuid}, Error: ${
           error instanceof Error ? error.message : error
@@ -92,7 +93,7 @@ function validateFourX(creature: Creature): void {
     if (
       error.name === "SELF_CONNECTION" || error.name === "RECURSIVE_SYNAPSE"
     ) {
-      console.warn(
+      getLogger().warn(
         `[upgrade] WARNING: 4.x creature (UUID: ${
           creature.uuid ?? "unknown"
         }) failed forward-only validation: ` +
@@ -119,7 +120,7 @@ function validateFourX(creature: Creature): void {
         creatureValidate(creature, { forwardOnly: true });
         creature.forwardOnly = true;
 
-        console.warn(
+        getLogger().warn(
           `[upgrade] Successfully repaired 4.x creature (UUID: ${
             creature.uuid ?? "unknown"
           }). ` +
@@ -128,7 +129,7 @@ function validateFourX(creature: Creature): void {
         return;
       } catch (fixError) {
         // Repair failed - fall through to throw the original error.
-        console.error(
+        getLogger().error(
           `[upgrade] CRITICAL: Failed to repair 4.x creature (UUID: ${
             creature.uuid ?? "unknown"
           }). ` +
@@ -141,7 +142,7 @@ function validateFourX(creature: Creature): void {
 
     // 4.x forward-only is a hard invariant. Any failure that cannot be repaired
     // indicates a serious bug that must be investigated.
-    console.error(
+    getLogger().error(
       `[upgrade] CRITICAL: 4.x creature (UUID: ${
         creature.uuid ?? "unknown"
       }) failed forward-only validation: ` +
@@ -196,7 +197,7 @@ function tryUpgradeToFour(creature: Creature): Creature {
       } catch (_fixError) {
         // Fall through to clearing the flag below.
       }
-      console.warn(
+      getLogger().warn(
         `[upgrade] Creature claims forwardOnly but failed validation; clearing flag`,
       );
       creature.forwardOnly = undefined;

--- a/src/upgrade/UpgradeTwo.ts
+++ b/src/upgrade/UpgradeTwo.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { Creature, type SynapseExport } from "../../mod.ts";
+import { getLogger } from "../utils/Logger.ts";
 import type {
   CreatureExport,
   CreatureInternal,
@@ -50,7 +51,7 @@ function removeHYPOT(json: CreatureExport) {
   for (let i = 0; i < neuronsLength; i++) {
     const neuron = neurons[i];
     if (neuron.squash === "HYPOT") {
-      console.log("Replacing HYPOT neuron", neuron.uuid);
+      getLogger().info("Replacing HYPOT neuron", neuron.uuid);
       changed = true;
       for (let j = 0; j < synapsesLength; j++) {
         const synapse = synapses[j];
@@ -115,7 +116,7 @@ function removeHYPOT(json: CreatureExport) {
   try {
     tempCreature.validate();
   } catch (e) {
-    console.log("Creature is not valid", e);
+    getLogger().info("Creature is not valid", e);
     tempCreature.fix();
   }
   return tempCreature.exportJSON();
@@ -130,7 +131,7 @@ function removeHYPOTv2(json: CreatureExport) {
   for (let i = 0; i < neuronsLength; i++) {
     const neuron = neurons[i];
     if (neuron.squash === "HYPOTv2") {
-      console.log("Replacing HYPOTv2 neuron", neuron.uuid);
+      getLogger().info("Replacing HYPOTv2 neuron", neuron.uuid);
       changed = true;
       for (let j = 0; j < synapsesLength; j++) {
         const synapse = synapses[j];
@@ -169,7 +170,7 @@ function removeHYPOTv2(json: CreatureExport) {
   try {
     tempCreature.validate();
   } catch (e) {
-    console.log("Creature is not valid", e);
+    getLogger().info("Creature is not valid", e);
     delete tempCreature.memetic;
     tempCreature.fix();
   }

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,0 +1,105 @@
+/**
+ * Structured logging abstraction for NEAT-AI.
+ *
+ * Issue #1398: Replace scattered console logging with a configurable logger
+ * that consumers can override for integration with external logging systems.
+ */
+
+/**
+ * Log level enumeration ordered by severity.
+ *
+ * Messages at or above the configured level are emitted; lower-severity
+ * messages are silently dropped.
+ */
+export type LogLevel = "debug" | "info" | "warn" | "error" | "none";
+
+/**
+ * Logger interface with standard log levels.
+ *
+ * Consumers may implement this interface to redirect NEAT-AI log output
+ * to their own logging infrastructure (e.g. pino, winston, cloud logging).
+ */
+export interface Logger {
+  debug(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+
+/** Numeric severity values for comparing log levels. */
+const LOG_LEVEL_SEVERITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  none: 4,
+};
+
+/**
+ * Creates the default logger that delegates to `console` methods,
+ * filtered by the given log level.
+ *
+ * @param level - Minimum severity to emit. Defaults to `"info"`.
+ * @returns A {@link Logger} that writes to the console.
+ */
+export function createConsoleLogger(level?: LogLevel): Logger {
+  const effectiveLevel = level ?? "info";
+  const threshold = LOG_LEVEL_SEVERITY[effectiveLevel];
+
+  return {
+    debug(...args: unknown[]) {
+      if (threshold <= LOG_LEVEL_SEVERITY.debug) {
+        console.debug(...args);
+      }
+    },
+    info(...args: unknown[]) {
+      if (threshold <= LOG_LEVEL_SEVERITY.info) {
+        console.info(...args);
+      }
+    },
+    warn(...args: unknown[]) {
+      if (threshold <= LOG_LEVEL_SEVERITY.warn) {
+        console.warn(...args);
+      }
+    },
+    error(...args: unknown[]) {
+      if (threshold <= LOG_LEVEL_SEVERITY.error) {
+        console.error(...args);
+      }
+    },
+  };
+}
+
+/**
+ * A silent logger that discards all messages.
+ *
+ * Useful for silencing output during tests or when logging is unwanted.
+ */
+export const SILENT_LOGGER: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+/**
+ * Global logger instance used by NEAT-AI internals.
+ *
+ * Defaults to a console logger at `"info"` level. Call {@link setLogger}
+ * to replace it, or pass a custom logger via NeatOptions.
+ */
+let _globalLogger: Logger = createConsoleLogger("info");
+
+/** Returns the current global logger. */
+export function getLogger(): Logger {
+  return _globalLogger;
+}
+
+/**
+ * Replaces the global logger.
+ *
+ * @param logger - The new logger to use globally.
+ */
+export function setLogger(logger: Logger): void {
+  _globalLogger = logger;
+}

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Creature } from "../Creature.ts";
+import { getLogger } from "../utils/Logger.ts";
 import {
   compileCreatureToWasm,
   type CompiledCreatureData,
@@ -220,11 +221,14 @@ export async function initWasmActivation(): Promise<boolean> {
       const isNotFound = code === "ERR_MODULE_NOT_FOUND" ||
         /module not found/i.test(msg);
       if (isNotFound) {
-        console.warn(
+        getLogger().warn(
           "WASM activation: pkg not found at the canonical package location.",
         );
       } else {
-        console.error("Failed to initialise WASM activation module:", error);
+        getLogger().error(
+          "Failed to initialise WASM activation module:",
+          error,
+        );
       }
       return false;
     } finally {
@@ -254,7 +258,7 @@ export function initWasmActivationSync(
   // Sync init should not run concurrently with async init; if async is in-flight,
   // fail fast to avoid re-entrancy into wasm-bindgen initialisation.
   if (initPromise) {
-    console.error(
+    getLogger().error(
       "Failed to initialise WASM activation module sync: async init in progress",
     );
     return false;
@@ -297,7 +301,10 @@ export function initWasmActivationSync(
 
     return true;
   } catch (error) {
-    console.error("Failed to initialise WASM activation module sync:", error);
+    getLogger().error(
+      "Failed to initialise WASM activation module sync:",
+      error,
+    );
     return false;
   }
 }
@@ -350,7 +357,7 @@ export class WasmCreatureActivation {
    */
   static create(compiled: CompiledCreatureData): WasmCreatureActivation | null {
     if (!CompiledNetwork) {
-      console.error("WASM module not initialised");
+      getLogger().error("WASM module not initialised");
       return null;
     }
 
@@ -364,7 +371,7 @@ export class WasmCreatureActivation {
         compiled.numOutputs,
       );
     } catch (error) {
-      console.error("Failed to create WASM activation:", error);
+      getLogger().error("Failed to create WASM activation:", error);
       return null;
     }
   }

--- a/test/config/LoggerConfig.ts
+++ b/test/config/LoggerConfig.ts
@@ -1,0 +1,149 @@
+import { assert, assertEquals } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import {
+  getLogger,
+  type Logger,
+  setLogger,
+  SILENT_LOGGER,
+} from "../../src/utils/Logger.ts";
+
+Deno.test("LoggerConfig - default logger is created when not specified", () => {
+  const config = createNeatConfig({});
+  assert(config.logger !== undefined, "Logger should be defined");
+  assert(typeof config.logger.info === "function");
+  assert(typeof config.logger.warn === "function");
+  assert(typeof config.logger.error === "function");
+  assert(typeof config.logger.debug === "function");
+});
+
+Deno.test("LoggerConfig - custom logger is used when provided", () => {
+  const messages: string[] = [];
+  const custom: Logger = {
+    debug(...args) {
+      messages.push(`debug:${args.join(",")}`);
+    },
+    info(...args) {
+      messages.push(`info:${args.join(",")}`);
+    },
+    warn(...args) {
+      messages.push(`warn:${args.join(",")}`);
+    },
+    error(...args) {
+      messages.push(`error:${args.join(",")}`);
+    },
+  };
+
+  const config = createNeatConfig({ logger: custom });
+  assertEquals(config.logger, custom);
+
+  config.logger.info("test message");
+  assertEquals(messages, ["info:test message"]);
+});
+
+Deno.test("LoggerConfig - logLevel controls default logger filtering", () => {
+  const captured: string[] = [];
+  const original = {
+    debug: console.debug,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+  };
+
+  try {
+    console.debug = () => captured.push("debug");
+    console.info = () => captured.push("info");
+    console.warn = () => captured.push("warn");
+    console.error = () => captured.push("error");
+
+    const config = createNeatConfig({ logLevel: "warn" });
+    config.logger.debug("d");
+    config.logger.info("i");
+    config.logger.warn("w");
+    config.logger.error("e");
+
+    assertEquals(captured, ["warn", "error"]);
+  } finally {
+    console.debug = original.debug;
+    console.info = original.info;
+    console.warn = original.warn;
+    console.error = original.error;
+  }
+});
+
+Deno.test("LoggerConfig - SILENT_LOGGER can be injected via options", () => {
+  const config = createNeatConfig({ logger: SILENT_LOGGER });
+  assertEquals(config.logger, SILENT_LOGGER);
+  // Should not throw or produce output
+  config.logger.info("silent");
+  config.logger.error("silent");
+});
+
+Deno.test("LoggerConfig - createNeatConfig sets the global logger", () => {
+  const originalGlobal = getLogger();
+  try {
+    const custom: Logger = {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+    };
+
+    createNeatConfig({ logger: custom });
+    assertEquals(getLogger(), custom);
+  } finally {
+    setLogger(originalGlobal);
+  }
+});
+
+Deno.test("LoggerConfig - logLevel is ignored when custom logger is provided", () => {
+  const messages: string[] = [];
+  const custom: Logger = {
+    debug() {
+      messages.push("debug");
+    },
+    info() {
+      messages.push("info");
+    },
+    warn() {
+      messages.push("warn");
+    },
+    error() {
+      messages.push("error");
+    },
+  };
+
+  // Even though logLevel is "error", custom logger should receive all calls
+  const config = createNeatConfig({ logger: custom, logLevel: "error" });
+  config.logger.debug("d");
+  config.logger.info("i");
+  assertEquals(config.logger, custom);
+  assertEquals(messages, ["debug", "info"]);
+});
+
+Deno.test("LoggerConfig - config is frozen with logger", () => {
+  const config = createNeatConfig({});
+  assert(Object.isFrozen(config), "Config should be frozen");
+});
+
+Deno.test("LoggerConfig - default logLevel is info", () => {
+  const captured: string[] = [];
+  const original = {
+    debug: console.debug,
+    info: console.info,
+  };
+
+  try {
+    console.debug = () => captured.push("debug");
+    console.info = () => captured.push("info");
+
+    const config = createNeatConfig({});
+    config.logger.debug("should not appear");
+    config.logger.info("should appear");
+
+    // debug should be filtered (default is info)
+    assertEquals(captured, ["info"]);
+  } finally {
+    console.debug = original.debug;
+    console.info = original.info;
+  }
+});

--- a/test/utils/Logger.ts
+++ b/test/utils/Logger.ts
@@ -1,0 +1,275 @@
+import { assertEquals } from "@std/assert";
+import {
+  createConsoleLogger,
+  getLogger,
+  type Logger,
+  setLogger,
+  SILENT_LOGGER,
+} from "../../src/utils/Logger.ts";
+
+Deno.test("createConsoleLogger: default level filters debug", () => {
+  const captured: { level: string; args: unknown[] }[] = [];
+  const original = {
+    debug: console.debug,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+  };
+
+  try {
+    console.debug = (...args: unknown[]) =>
+      captured.push({ level: "debug", args });
+    console.info = (...args: unknown[]) =>
+      captured.push({ level: "info", args });
+    console.warn = (...args: unknown[]) =>
+      captured.push({ level: "warn", args });
+    console.error = (...args: unknown[]) =>
+      captured.push({ level: "error", args });
+
+    const logger = createConsoleLogger(); // default = "info"
+    logger.debug("should not appear");
+    logger.info("info message");
+    logger.warn("warn message");
+    logger.error("error message");
+
+    assertEquals(captured.length, 3);
+    assertEquals(captured[0].level, "info");
+    assertEquals(captured[1].level, "warn");
+    assertEquals(captured[2].level, "error");
+  } finally {
+    console.debug = original.debug;
+    console.info = original.info;
+    console.warn = original.warn;
+    console.error = original.error;
+  }
+});
+
+Deno.test("createConsoleLogger: debug level emits all", () => {
+  const captured: string[] = [];
+  const original = {
+    debug: console.debug,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+  };
+
+  try {
+    console.debug = () => captured.push("debug");
+    console.info = () => captured.push("info");
+    console.warn = () => captured.push("warn");
+    console.error = () => captured.push("error");
+
+    const logger = createConsoleLogger("debug");
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    assertEquals(captured, ["debug", "info", "warn", "error"]);
+  } finally {
+    console.debug = original.debug;
+    console.info = original.info;
+    console.warn = original.warn;
+    console.error = original.error;
+  }
+});
+
+Deno.test("createConsoleLogger: error level filters info and warn", () => {
+  const captured: string[] = [];
+  const original = {
+    debug: console.debug,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+  };
+
+  try {
+    console.debug = () => captured.push("debug");
+    console.info = () => captured.push("info");
+    console.warn = () => captured.push("warn");
+    console.error = () => captured.push("error");
+
+    const logger = createConsoleLogger("error");
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    assertEquals(captured, ["error"]);
+  } finally {
+    console.debug = original.debug;
+    console.info = original.info;
+    console.warn = original.warn;
+    console.error = original.error;
+  }
+});
+
+Deno.test("createConsoleLogger: none level silences everything", () => {
+  const captured: string[] = [];
+  const original = {
+    debug: console.debug,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+  };
+
+  try {
+    console.debug = () => captured.push("debug");
+    console.info = () => captured.push("info");
+    console.warn = () => captured.push("warn");
+    console.error = () => captured.push("error");
+
+    const logger = createConsoleLogger("none");
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    assertEquals(captured.length, 0);
+  } finally {
+    console.debug = original.debug;
+    console.info = original.info;
+    console.warn = original.warn;
+    console.error = original.error;
+  }
+});
+
+Deno.test("createConsoleLogger: warn level filters debug and info", () => {
+  const captured: string[] = [];
+  const original = {
+    debug: console.debug,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+  };
+
+  try {
+    console.debug = () => captured.push("debug");
+    console.info = () => captured.push("info");
+    console.warn = () => captured.push("warn");
+    console.error = () => captured.push("error");
+
+    const logger = createConsoleLogger("warn");
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    assertEquals(captured, ["warn", "error"]);
+  } finally {
+    console.debug = original.debug;
+    console.info = original.info;
+    console.warn = original.warn;
+    console.error = original.error;
+  }
+});
+
+Deno.test("SILENT_LOGGER: emits nothing", () => {
+  // SILENT_LOGGER should not throw and should not produce output
+  SILENT_LOGGER.debug("noop");
+  SILENT_LOGGER.info("noop");
+  SILENT_LOGGER.warn("noop");
+  SILENT_LOGGER.error("noop");
+});
+
+Deno.test("getLogger/setLogger: round-trip", () => {
+  const original = getLogger();
+  try {
+    const custom: Logger = {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+    };
+    setLogger(custom);
+    assertEquals(getLogger(), custom);
+  } finally {
+    setLogger(original);
+  }
+});
+
+Deno.test("setLogger: custom logger receives messages", () => {
+  const original = getLogger();
+  try {
+    const messages: { level: string; args: unknown[] }[] = [];
+    const custom: Logger = {
+      debug(...args) {
+        messages.push({ level: "debug", args });
+      },
+      info(...args) {
+        messages.push({ level: "info", args });
+      },
+      warn(...args) {
+        messages.push({ level: "warn", args });
+      },
+      error(...args) {
+        messages.push({ level: "error", args });
+      },
+    };
+
+    setLogger(custom);
+    const logger = getLogger();
+    logger.info("hello", 42);
+    logger.error("bad");
+
+    assertEquals(messages.length, 2);
+    assertEquals(messages[0].level, "info");
+    assertEquals(messages[0].args, ["hello", 42]);
+    assertEquals(messages[1].level, "error");
+    assertEquals(messages[1].args, ["bad"]);
+  } finally {
+    setLogger(original);
+  }
+});
+
+Deno.test("createConsoleLogger: passes arguments through", () => {
+  const captured: unknown[][] = [];
+  const original = console.info;
+
+  try {
+    console.info = (...args: unknown[]) => captured.push(args);
+
+    const logger = createConsoleLogger("info");
+    logger.info("message", { key: "value" }, 123);
+
+    assertEquals(captured.length, 1);
+    assertEquals(captured[0], ["message", { key: "value" }, 123]);
+  } finally {
+    console.info = original;
+  }
+});
+
+Deno.test("createConsoleLogger: each level maps to correct console method", () => {
+  const levels: (keyof Logger)[] = ["debug", "info", "warn", "error"];
+
+  for (const level of levels) {
+    const captured: string[] = [];
+    const original = {
+      debug: console.debug,
+      info: console.info,
+      warn: console.warn,
+      error: console.error,
+    };
+
+    try {
+      console.debug = () => captured.push("debug");
+      console.info = () => captured.push("info");
+      console.warn = () => captured.push("warn");
+      console.error = () => captured.push("error");
+
+      const logger = createConsoleLogger(level);
+      logger[level]("test");
+
+      assertEquals(
+        captured,
+        [level],
+        `Level ${level} should map to console.${level}`,
+      );
+    } finally {
+      console.debug = original.debug;
+      console.info = original.info;
+      console.warn = original.warn;
+      console.error = original.error;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Add `Logger` interface with configurable log levels (`debug`, `info`, `warn`, `error`, `none`) in `src/utils/Logger.ts`
- Replace ~350 direct `console.*` calls across 46 production files with `getLogger()` calls
- Consumers can inject a custom logger via `NeatOptions.logger` or control verbosity with `NeatOptions.logLevel`
- Export `createConsoleLogger`, `getLogger`, `setLogger`, `SILENT_LOGGER`, `Logger`, `LogLevel` from `mod.ts`

## Test plan
- [x] 10 new unit tests for Logger (level filtering, silent logger, get/set round-trip, argument passthrough)
- [x] 8 new integration tests for config (custom logger, logLevel filtering, global propagation, freeze)
- [x] Full test suite: 2703 passed, 0 failed
- [x] `deno fmt --check`, `deno lint`, `deno check` all pass
- [x] `quality.sh` passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1398