### PR TITLE
Feature: Add reproducible random number generation (#1400)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.310.34",
+  "version": "0.310.35",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -206,6 +206,7 @@
     "passthrough",
     "PRNG",
     "seedable",
-    "xoshiro"
+    "xoshiro",
+    "rotl"
   ]
 }

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -203,6 +203,9 @@
     "mergesort",
     "NONEXISTENT",
     "incl",
-    "passthrough"
+    "passthrough",
+    "PRNG",
+    "seedable",
+    "xoshiro"
   ]
 }

--- a/docs/pr-summary-1400.md
+++ b/docs/pr-summary-1400.md
@@ -5,39 +5,38 @@ Closes #1400
 ## Summary
 
 Replaced all ~79 scattered `Math.random()` calls across the codebase with an
-injectable, seedable random number generator. Consumers can now pass a `seed`
-in `NeatOptions` for fully deterministic evolution runs, or inject a custom
-`rng` instance. Unseeded behaviour (backed by `Math.random()`) is preserved
-by default for backward compatibility.
+injectable, seedable random number generator. Consumers can now pass a `seed` in
+`NeatOptions` for fully deterministic evolution runs, or inject a custom `rng`
+instance. Unseeded behaviour (backed by `Math.random()`) is preserved by default
+for backward compatibility.
 
 ## What Changed
 
 ### New Files
 
-- **`src/utils/RandomNumberGenerator.ts`** -- `RandomNumberGenerator`
-  interface with `random()`, `randomInt(min, max)`, `choice(array)`,
-  `seeded` property. Two implementations: `SeededRng` (xoshiro256** PRNG
-  with SplitMix64 initialisation) and `UnseededRng` (wraps `Math.random()`).
-  Global instance pattern: `getRandomNumberGenerator()`/
-  `setRandomNumberGenerator()`. Factories: `createSeededRng(seed)`,
-  `createUnseededRng()`.
+- **`src/utils/RandomNumberGenerator.ts`** -- `RandomNumberGenerator` interface
+  with `random()`, `randomInt(min, max)`, `choice(array)`, `seeded` property.
+  Two implementations: `SeededRng` (xoshiro256** PRNG with SplitMix64
+  initialisation) and `UnseededRng` (wraps `Math.random()`). Global instance
+  pattern: `getRandomNumberGenerator()`/ `setRandomNumberGenerator()`.
+  Factories: `createSeededRng(seed)`, `createUnseededRng()`.
 - **`test/utils/RandomNumberGenerator.ts`** -- 21 unit tests covering
   reproducibility, range correctness, uniformity (chi-squared), diversity,
-  interleaved operations, edge cases (seed 0, large seed, single-element
-  choice, empty array).
-- **`test/config/NeatConfigRng.ts`** -- 10 integration tests covering
-  config seed parsing (number and string), unseeded default, custom rng
-  precedence, global RNG propagation, deterministic config defaults
-  (sparseRatio, globalBreedingRate, selection), and reproducible mutation
-  (MOD_WEIGHT and MOD_BIAS produce identical results with same seed).
+  interleaved operations, edge cases (seed 0, large seed, single-element choice,
+  empty array).
+- **`test/config/NeatConfigRng.ts`** -- 10 integration tests covering config
+  seed parsing (number and string), unseeded default, custom rng precedence,
+  global RNG propagation, deterministic config defaults (sparseRatio,
+  globalBreedingRate, selection), and reproducible mutation (MOD_WEIGHT and
+  MOD_BIAS produce identical results with same seed).
 
 ### Config Integration
 
 - **`NeatArguments.ts`** -- Added `rng: RandomNumberGenerator` field.
 - **`NeatOptions.ts`** -- Added `seed?: number` and
-  `rng?: RandomNumberGenerator` to `NeatOptions`; added
-  `seed?: number | string` and `rng?: RandomNumberGenerator` to
-  `NeatOptionsInput` for CLI support. Both added to Omit lists.
+  `rng?: RandomNumberGenerator` to `NeatOptions`; added `seed?: number | string`
+  and `rng?: RandomNumberGenerator` to `NeatOptionsInput` for CLI support. Both
+  added to Omit lists.
 - **`NeatConfig.ts`** -- Creates RNG at the very top of `createNeatConfig()`
   before any randomness: uses `options.rng` if provided, else
   `createSeededRng(seed)` if seed given, else `createUnseededRng()`. Calls
@@ -66,10 +65,10 @@ The only remaining `Math.random()` call in production code is inside
 
 ## Test Plan
 
-- [x] `test/utils/RandomNumberGenerator.ts` -- 21 unit tests for RNG
-      interface, xoshiro256** reproducibility, uniformity, edge cases
-- [x] `test/config/NeatConfigRng.ts` -- 10 integration tests for config
-      seed/rng parsing, global propagation, deterministic mutation
+- [x] `test/utils/RandomNumberGenerator.ts` -- 21 unit tests for RNG interface,
+      xoshiro256** reproducibility, uniformity, edge cases
+- [x] `test/config/NeatConfigRng.ts` -- 10 integration tests for config seed/rng
+      parsing, global propagation, deterministic mutation
 - [x] Full test suite (2822 tests) passes with no regressions
 - [x] `deno check` type-checking passes
 - [x] `deno fmt --check` formatting passes

--- a/docs/pr-summary-1400.md
+++ b/docs/pr-summary-1400.md
@@ -1,0 +1,76 @@
+# Feature: Add reproducible random number generation with seeding support (#1400)
+
+Closes #1400
+
+## Summary
+
+Replaced all ~79 scattered `Math.random()` calls across the codebase with an
+injectable, seedable random number generator. Consumers can now pass a `seed`
+in `NeatOptions` for fully deterministic evolution runs, or inject a custom
+`rng` instance. Unseeded behaviour (backed by `Math.random()`) is preserved
+by default for backward compatibility.
+
+## What Changed
+
+### New Files
+
+- **`src/utils/RandomNumberGenerator.ts`** -- `RandomNumberGenerator`
+  interface with `random()`, `randomInt(min, max)`, `choice(array)`,
+  `seeded` property. Two implementations: `SeededRng` (xoshiro256** PRNG
+  with SplitMix64 initialisation) and `UnseededRng` (wraps `Math.random()`).
+  Global instance pattern: `getRandomNumberGenerator()`/
+  `setRandomNumberGenerator()`. Factories: `createSeededRng(seed)`,
+  `createUnseededRng()`.
+- **`test/utils/RandomNumberGenerator.ts`** -- 21 unit tests covering
+  reproducibility, range correctness, uniformity (chi-squared), diversity,
+  interleaved operations, edge cases (seed 0, large seed, single-element
+  choice, empty array).
+- **`test/config/NeatConfigRng.ts`** -- 10 integration tests covering
+  config seed parsing (number and string), unseeded default, custom rng
+  precedence, global RNG propagation, deterministic config defaults
+  (sparseRatio, globalBreedingRate, selection), and reproducible mutation
+  (MOD_WEIGHT and MOD_BIAS produce identical results with same seed).
+
+### Config Integration
+
+- **`NeatArguments.ts`** -- Added `rng: RandomNumberGenerator` field.
+- **`NeatOptions.ts`** -- Added `seed?: number` and
+  `rng?: RandomNumberGenerator` to `NeatOptions`; added
+  `seed?: number | string` and `rng?: RandomNumberGenerator` to
+  `NeatOptionsInput` for CLI support. Both added to Omit lists.
+- **`NeatConfig.ts`** -- Creates RNG at the very top of `createNeatConfig()`
+  before any randomness: uses `options.rng` if provided, else
+  `createSeededRng(seed)` if seed given, else `createUnseededRng()`. Calls
+  `setRandomNumberGenerator()` to propagate globally. Replaced inline
+  `Math.random()` for selection, sparseRatio, and globalBreedingRate defaults.
+- **`mod.ts`** -- Exports `createSeededRng`, `createUnseededRng`,
+  `getRandomNumberGenerator`, `setRandomNumberGenerator`,
+  `RandomNumberGenerator` type.
+
+### Math.random() Replacement (38 production files)
+
+Every `Math.random()` call in `src/` was replaced with
+`getRandomNumberGenerator().random()` (or equivalent via a local `rng`
+variable). Files span mutation operators, breeding, architecture, discovery,
+backpropagation, activation functions, optimisation, and blackbox modules.
+
+The only remaining `Math.random()` call in production code is inside
+`UnseededRng.random()`, which is the intentional backward-compatible wrapper.
+
+## Evidence
+
+- `quality.sh` passes: formatting, linting, type-checking, all **2822 tests
+  pass** with 0 failures.
+- Final grep confirms zero remaining production `Math.random()` calls outside
+  `RandomNumberGenerator.ts` itself and JSDoc comment blocks.
+
+## Test Plan
+
+- [x] `test/utils/RandomNumberGenerator.ts` -- 21 unit tests for RNG
+      interface, xoshiro256** reproducibility, uniformity, edge cases
+- [x] `test/config/NeatConfigRng.ts` -- 10 integration tests for config
+      seed/rng parsing, global propagation, deterministic mutation
+- [x] Full test suite (2822 tests) passes with no regressions
+- [x] `deno check` type-checking passes
+- [x] `deno fmt --check` formatting passes
+- [x] `deno lint` linting passes

--- a/mod.ts
+++ b/mod.ts
@@ -240,3 +240,20 @@ export {
   SILENT_LOGGER,
 } from "./src/utils/Logger.ts";
 export type { Logger, LogLevel } from "./src/utils/Logger.ts";
+
+/**
+ * Random Number Generator
+ *
+ * Issue #1400: Reproducible random number generation with seeding support.
+ * Pass a `seed` in NeatOptions for deterministic evolution runs, or inject
+ * a custom RNG via the `rng` option.
+ *
+ * @see {@link module:src/utils/RandomNumberGenerator}
+ */
+export {
+  createSeededRng,
+  createUnseededRng,
+  getRandomNumberGenerator,
+  setRandomNumberGenerator,
+} from "./src/utils/RandomNumberGenerator.ts";
+export type { RandomNumberGenerator } from "./src/utils/RandomNumberGenerator.ts";

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -70,6 +70,7 @@ import {
   noteWasmCreatureActivationUse,
 } from "./wasm/WasmCreatureActivationLRU.ts";
 import { getLogger } from "./utils/Logger.ts";
+import { getRandomNumberGenerator } from "./utils/RandomNumberGenerator.ts";
 
 interface CreatureOptions {
   semanticVersion?: string;
@@ -432,7 +433,7 @@ export class Creature implements CreatureInternal {
           const neuron = new Neuron(
             crypto.randomUUID(),
             "hidden",
-            Math.random() * 0.2 - 0.1,
+            getRandomNumberGenerator().random() * 0.2 - 0.1,
             this,
             tmpSquash,
           );
@@ -465,7 +466,7 @@ export class Creature implements CreatureInternal {
         const neuron = new Neuron(
           `output-${indx}`,
           type,
-          Math.random() * 0.2 - 0.1,
+          getRandomNumberGenerator().random() * 0.2 - 0.1,
           this,
           squash,
         );
@@ -485,7 +486,7 @@ export class Creature implements CreatureInternal {
         const neuron = new Neuron(
           `output-${indx}`,
           type,
-          Math.random() * 0.2 - 0.1,
+          getRandomNumberGenerator().random() * 0.2 - 0.1,
           this,
           Activations.pickRandomSquash(),
         );
@@ -498,7 +499,7 @@ export class Creature implements CreatureInternal {
       for (let i = 0; i < this.input; i++) {
         for (let j = this.input; j < this.output + this.input; j++) {
           /** https://stats.stackexchange.com/a/248040/147931 */
-          const weight = Math.random() * this.input *
+          const weight = getRandomNumberGenerator().random() * this.input *
             Math.sqrt(2 / this.input);
           this.connect(i, j, weight);
         }
@@ -1657,7 +1658,7 @@ export class Creature implements CreatureInternal {
 
     let changed = false;
     for (let indx = this.neurons.length - 1; indx >= this.input; indx--) {
-      if (config.trainingMutationRate > Math.random()) {
+      if (config.trainingMutationRate > getRandomNumberGenerator().random()) {
         const n = this.neurons[indx];
         if (sparseConfig.updateNeeded(n.uuid)) {
           changed ||= n.applyLearnings();
@@ -2514,7 +2515,7 @@ export class Creature implements CreatureInternal {
         // is used as a repair step for disconnected neurons. A self-loop does
         // not introduce any upstream signal, so it does not "fix" connectivity.
         // We therefore never generate self-loops here.
-        Math.floor(Math.random() * indx), // 0..(indx-1)
+        Math.floor(getRandomNumberGenerator().random() * indx), // 0..(indx-1)
       );
       const c = this.getSynapse(from, indx);
       if (c === null) {

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -23,6 +23,7 @@ import {
   upgradeSemanticVersionIfForwardOnlyConfirmed,
 } from "../upgrade/Upgrade.ts";
 import { getLogger } from "../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 /**
  * Cache entry for valid mutation candidates.
@@ -138,8 +139,9 @@ export class Mutator {
    * Mutates the given (or current) population
    */
   mutate(creatures: Creature[]): void {
+    const rng = getRandomNumberGenerator();
     for (let i = creatures.length; i--;) {
-      if (Math.random() <= this.config.mutationRate) {
+      if (rng.random() <= this.config.mutationRate) {
         const creature = creatures[i];
         let original: Creature | undefined;
         if (creature.score !== undefined || creature.memetic) {
@@ -155,7 +157,7 @@ export class Mutator {
         for (let j = this.config.mutationAmount; j--;) {
           const mutationMethod = this.selectMutationMethod(creature);
 
-          const currentFocusList = Math.random() < this.config.focusRate
+          const currentFocusList = rng.random() < this.config.focusRate
             ? this.config.focusList
             : undefined;
 
@@ -408,9 +410,10 @@ export class Mutator {
     // Optimized weighted selection (Issue #1009).
     // Prefer weight/bias mutations based on creature size for faster convergence.
     // This replaces the rejection sampling loop that could iterate up to 10,000 times.
-    if (Math.random() < weightBiasPreference && weightBiasCount > 0) {
+    const rng = getRandomNumberGenerator();
+    if (rng.random() < weightBiasPreference && weightBiasCount > 0) {
       // Select uniformly from weight/bias mutations
-      const targetIndex = Math.floor(Math.random() * weightBiasCount);
+      const targetIndex = Math.floor(rng.random() * weightBiasCount);
       let found = 0;
       for (let i = 0; i < candidates.length; i++) {
         const name = candidates[i].name;
@@ -435,13 +438,13 @@ export class Mutator {
       );
       if (nonExpansionCandidates.length > 0) {
         return nonExpansionCandidates[
-          Math.floor(Math.random() * nonExpansionCandidates.length)
+          Math.floor(rng.random() * nonExpansionCandidates.length)
         ];
       }
     }
 
     // Fallback: select uniformly from all candidates
-    return candidates[Math.floor(Math.random() * candidates.length)];
+    return candidates[Math.floor(rng.random() * candidates.length)];
   }
 
   /**

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -43,6 +43,7 @@ import {
   DiscoveryReplayQueue,
 } from "./DiscoveryReplayQueue.ts";
 import { getLogger } from "../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 /**
  * NEAT (NeuroEvolution of Augmenting Topologies) implementation.
@@ -183,8 +184,9 @@ export class Neat {
     const cloned = JSON.parse(JSON.stringify(arr)) as T[];
 
     // Shuffle (Fisher-Yates)
+    const rng = getRandomNumberGenerator();
     for (let i = cloned.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
+      const j = Math.floor(rng.random() * (i + 1));
       [cloned[i], cloned[j]] = [cloned[j], cloned[i]];
     }
     return cloned;
@@ -937,7 +939,7 @@ export class Neat {
       const addConnection = new AddConnection(creativeThinking);
       for (let i = 0; i < this.config.creativeThinkingConnectionCount; i++) {
         addConnection.mutate(
-          Math.random() < this.config.focusRate
+          getRandomNumberGenerator().random() < this.config.focusRate
             ? this.config.focusList
             : undefined,
           {

--- a/src/architecture/CreatureUtils.ts
+++ b/src/architecture/CreatureUtils.ts
@@ -1,5 +1,6 @@
 import { generate as generateV5Sync } from "./SyncV5.ts";
 import type { Creature } from "../Creature.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 /**
  * Utility class for Creature-related operations.
@@ -36,8 +37,9 @@ export class CreatureUtil {
    */
   static shuffle(array: Int32Array): void {
     if (array.length > 1) {
+      const rng = getRandomNumberGenerator();
       for (let i = array.length; i--;) {
-        const j = Math.round(Math.random() * i);
+        const j = Math.round(rng.random() * i);
         [array[i], array[j]] = [array[j], array[i]];
       }
     }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts
@@ -22,6 +22,7 @@ import { isRustDiscoveryEnabled } from "./RustDiscovery.ts";
 import { PhaseDiagnostics } from "./PhaseDiagnostics.ts";
 import { submitDiscoveryRecordBatch } from "./SubmitDiscoveryRecordBatch.ts";
 import { getLogger } from "../../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../../utils/RandomNumberGenerator.ts";
 
 /**
  * Issue #1219 - Ensures WASM activation is initialised before discovery recording.
@@ -400,8 +401,9 @@ class DataRecorder {
   }
 
   private shuffleFiles(files: string[]): string[] {
+    const rng = getRandomNumberGenerator();
     for (let i = files.length; i--;) {
-      const j = Math.floor(Math.random() * (i + 1));
+      const j = Math.floor(rng.random() * (i + 1));
       [files[i], files[j]] = [files[j], files[i]];
     }
     return files;

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts
@@ -79,6 +79,7 @@ import {
   truncateForLogValue as truncateForLogValueImpl,
 } from "./RustFlushDiagnostics.ts";
 import { getLogger } from "../../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../../utils/RandomNumberGenerator.ts";
 
 export { DEFAULT_RUST_FLUSH_RECORDS } from "./constants.ts";
 export { DEFAULT_RUST_FLUSH_BYTES } from "./constants.ts";
@@ -2805,6 +2806,7 @@ export class DiscoverStructure {
     retryNumber?: number,
     mode: "add" | "remove" = "add",
   ): Promise<string[]> {
+    const rng = getRandomNumberGenerator();
     assert(count > 0, "Count must be greater than 0");
     this.lastFocusSelection = undefined;
     if (
@@ -2988,7 +2990,7 @@ export class DiscoverStructure {
       getLogger().warn(
         `   Falling back to random neuron selection to continue discovery`,
       );
-      const shuffled = [...neuronErrors].sort(() => Math.random() - 0.5);
+      const shuffled = [...neuronErrors].sort(() => rng.random() - 0.5);
       const fallback = shuffled.slice(0, count).map((n) => n.uuid);
       this.updateFocusSelectionSummary(
         "random",
@@ -3015,7 +3017,7 @@ export class DiscoverStructure {
       );
       getLogger().warn(`   Falling back to random neuron selection`);
       // Fallback to random selection without weighting
-      const shuffled = [...neuronErrors].sort(() => Math.random() - 0.5);
+      const shuffled = [...neuronErrors].sort(() => rng.random() - 0.5);
       const fallback = shuffled.slice(0, count).map((n) => n.uuid);
       this.updateFocusSelectionSummary(
         "random",
@@ -3050,7 +3052,7 @@ export class DiscoverStructure {
 
     while (selectedUUIDs.size < count && iterations < maxIterations) {
       iterations++;
-      const randValue = Math.random() * totalWeightedSum;
+      const randValue = rng.random() * totalWeightedSum;
       let cumulativeWeight = 0;
 
       for (const weighted of weightedValues) {
@@ -3069,7 +3071,7 @@ export class DiscoverStructure {
           // Fill remaining slots with random selection from unselected neurons
           const unselected = neuronErrors
             .filter((n) => !selectedUUIDs.has(n.uuid))
-            .sort(() => Math.random() - 0.5);
+            .sort(() => rng.random() - 0.5);
           const needed = count - selectedUUIDs.size;
           unselected.slice(0, needed).forEach((n) => selectedUUIDs.add(n.uuid));
           break;
@@ -3305,8 +3307,9 @@ export class DiscoverStructure {
     ) as ActivationInterface[];
 
     // Randomize the order of the squash functions using Fisher-Yates shuffle
+    const rng = getRandomNumberGenerator();
     for (let i = squashFunctions.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
+      const j = Math.floor(rng.random() * (i + 1));
       [squashFunctions[i], squashFunctions[j]] = [
         squashFunctions[j],
         squashFunctions[i],

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts
@@ -23,6 +23,7 @@ import type {
 import { ensureDirSync } from "@std/fs";
 import { join } from "@std/path";
 import { getLogger } from "../../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../../utils/RandomNumberGenerator.ts";
 
 /**
  * Validates a creature and attempts to fix it if validation fails.
@@ -604,7 +605,9 @@ export function addHelpfulNeurons(
 
     const newNeuronUUID =
       `hidden-discovery-${(globalThis.crypto?.randomUUID?.() ??
-        `fallback-${Math.random().toString(16).slice(2)}`)}`;
+        `fallback-${
+          getRandomNumberGenerator().random().toString(16).slice(2)
+        }`)}`;
     const newNeuron = {
       type: "hidden" as const,
       uuid: newNeuronUUID,

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts
@@ -23,7 +23,6 @@ import type {
 import { ensureDirSync } from "@std/fs";
 import { join } from "@std/path";
 import { getLogger } from "../../utils/Logger.ts";
-import { getRandomNumberGenerator } from "../../utils/RandomNumberGenerator.ts";
 
 /**
  * Validates a creature and attempts to fix it if validation fails.
@@ -603,11 +602,7 @@ export function addHelpfulNeurons(
       return;
     }
 
-    const newNeuronUUID =
-      `hidden-discovery-${(globalThis.crypto?.randomUUID?.() ??
-        `fallback-${
-          getRandomNumberGenerator().random().toString(16).slice(2)
-        }`)}`;
+    const newNeuronUUID = `hidden-discovery-${crypto.randomUUID()}`;
     const newNeuron = {
       type: "hidden" as const,
       uuid: newNeuronUUID,

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -2,6 +2,7 @@ import { assert } from "@std/assert";
 import { addTags, removeTag, type TagsInterface } from "@stsoftware/tags/mod";
 import type { Creature } from "../Creature.ts";
 import { getLogger } from "../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import { Activations } from "../methods/activations/Activations.ts";
 import type { ApplyLearningsInterface } from "../methods/activations/ApplyLearningsInterface.ts";
@@ -350,6 +351,8 @@ export class Neuron implements TagsInterface, NeuronInternal {
     delete this.squashMethodCache;
     delete this.squashTypeCache;
 
+    const rng = getRandomNumberGenerator();
+
     if (this.squash !== "IF") {
       const toList = this.creature.inwardConnections(this.index);
       toList.forEach((c) => {
@@ -373,7 +376,7 @@ export class Neuron implements TagsInterface, NeuronInternal {
         if (possibleSources.length > 0) {
           // Pick a random valid source
           const fromIndx =
-            possibleSources[Math.floor(Math.random() * possibleSources.length)];
+            possibleSources[Math.floor(rng.random() * possibleSources.length)];
           this.creature.connect(
             fromIndx,
             this.index,
@@ -385,7 +388,7 @@ export class Neuron implements TagsInterface, NeuronInternal {
       const toList = this.creature.inwardConnections(this.index);
       if (toList.length === 0) {
         const fromIndx = Math.floor(
-          Math.random() *
+          rng.random() *
             (this.creature.nodeCount() - this.creature.outputCount()),
         );
         this.creature.connect(
@@ -458,8 +461,9 @@ export class Neuron implements TagsInterface, NeuronInternal {
       return false;
     }
 
-    const targetIndex =
-      candidates[Math.floor(Math.random() * candidates.length)];
+    const targetIndex = candidates[
+      Math.floor(getRandomNumberGenerator().random() * candidates.length)
+    ];
     this.creature.connect(
       this.index,
       targetIndex,
@@ -1160,7 +1164,8 @@ export class Neuron implements TagsInterface, NeuronInternal {
         }
 
         // Generate a random modification value based on the quantum
-        const modification = (Math.random() * 2 - 1) * quantum;
+        const modification = (getRandomNumberGenerator().random() * 2 - 1) *
+          quantum;
 
         this.bias += modification;
         changed = true;

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -4,6 +4,7 @@ import { memeticUpdate } from "../blackbox/MemeticUpdate.ts";
 import { editParentByIndex } from "../breed/EditParentByIndex.ts";
 import { geneticCompatibility } from "../breed/GeneticCompatibility.ts";
 import { Creature } from "../Creature.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import {
   getMajorVersion,
   upgrade,
@@ -35,6 +36,7 @@ export class Offspring {
       forwardOnly?: boolean;
     } = {},
   ): Creature | undefined {
+    const rng = getRandomNumberGenerator();
     // Issue #1095: Use shallowClone() instead of JSON serialisation/deserialisation
     // for parent preparation. shallowClone() is 3-4x faster as it:
     // - Creates new Creature with copied neuron/synapse arrays
@@ -117,7 +119,7 @@ export class Offspring {
 
     for (const node of father.neurons) {
       if (node.type !== "input") {
-        if (Math.random() >= 0.5) {
+        if (rng.random() >= 0.5) {
           const connections = father.inwardConnections(node.index);
 
           Offspring.fixType(node, connections);
@@ -146,7 +148,7 @@ export class Offspring {
               const motherNeuron = motherNeuronMap.get(connection.fromUUID);
               fromNeuron = motherNeuron;
               let parent = mother;
-              if (!fromNeuron || Math.random() >= 0.5) {
+              if (!fromNeuron || rng.random() >= 0.5) {
                 const fatherNeuron = fatherNeuronMap.get(connection.fromUUID);
                 if (fatherNeuron) {
                   fromNeuron = fatherNeuron;

--- a/src/architecture/Synapse.ts
+++ b/src/architecture/Synapse.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import type { TagInterface } from "@stsoftware/tags/mod";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import type { SynapseExport, SynapseInternal } from "./SynapseInterfaces.ts";
 
 /**
@@ -44,7 +45,7 @@ export class Synapse implements SynapseInternal {
    * @returns A random weight value between -scale/2 and scale/2
    */
   public static randomWeight(scale = 1): number {
-    const rawWeight = Math.random() * scale - scale / 2;
+    const rawWeight = getRandomNumberGenerator().random() * scale - scale / 2;
 
     const plank = 0.000_000_1;
     /* Ensure the weight is at least one plank different and within sensible limits */

--- a/src/architecture/Training.ts
+++ b/src/architecture/Training.ts
@@ -7,6 +7,7 @@ import { Creature } from "../Creature.ts";
 import { compactUnused } from "../compact/CompactUnused.ts";
 import type { TrainOptions } from "../config/TrainOptions.ts";
 import { getLogger } from "../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import {
   calculateLearningRate,
   createBackPropagationConfig,
@@ -50,8 +51,9 @@ export function dataFiles(dataDir: string, options: TrainOptions = {}) {
   const files = binaryFiles;
 
   if (!options.disableRandomSamples) {
+    const rng = getRandomNumberGenerator();
     for (let i = files.length; i--;) {
-      const j = Math.round(Math.random() * i);
+      const j = Math.round(rng.random() * i);
       [files[i], files[j]] = [files[j], files[i]];
     }
   } else {

--- a/src/blackbox/FineTune.ts
+++ b/src/blackbox/FineTune.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_QUANTUM_STEP_CONFIG,
   type RequiredQuantumStepConfig,
 } from "../config/QuantumStepConfig.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 export const MIN_STEP = DEFAULT_QUANTUM_STEP_CONFIG.minStep;
 
@@ -98,11 +99,12 @@ export function quantumAdjust(
 
     // Apply momentum factor when available
     const effectiveMomentum = momentumFactor ?? 1.0;
+    const rng = getRandomNumberGenerator();
 
     if (forwardOnly) {
-      delta = diff * Math.random() * scale;
+      delta = diff * rng.random() * scale;
     } else {
-      delta = diff * Math.random() * (scale + 1) - diff;
+      delta = diff * rng.random() * (scale + 1) - diff;
     }
 
     // Apply momentum: if we have a strong consistent trajectory, bias towards it
@@ -115,7 +117,7 @@ export function quantumAdjust(
       if (Math.sign(delta) === suggestedDirection) {
         // Already moving in suggested direction, amplify
         delta *= effectiveMomentum;
-      } else if (Math.random() < 0.5) {
+      } else if (rng.random() < 0.5) {
         // Moving against suggested direction, sometimes flip
         delta = Math.abs(delta) * suggestedDirection +
           momentumBoost * suggestedDirection;

--- a/src/blackbox/FineTunePopulation.ts
+++ b/src/blackbox/FineTunePopulation.ts
@@ -10,6 +10,7 @@ import type { AdaptiveFineTuneTracker } from "./AdaptiveFineTuneTracker.ts";
 
 import { retry } from "./Retry.ts";
 import { getLogger } from "../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 export class FindTunePopulation {
   private neat: Neat;
@@ -220,8 +221,9 @@ export class FindTunePopulation {
           fineTunedPopulation.length;
         if (extendedFineTunePopSize > 0 && tmpFineTunePopulation.length > 0) {
           /* Choose a creature from near the top of the list. */
+          const rng = getRandomNumberGenerator();
           const location = Math.floor(
-            tmpFineTunePopulation.length * Math.random() * Math.random(),
+            tmpFineTunePopulation.length * rng.random() * rng.random(),
           );
 
           const extendedPreviousFittest = tmpFineTunePopulation[location];
@@ -265,7 +267,7 @@ export class FindTunePopulation {
       (sum, creature) => sum + 1 / (creatures.indexOf(creature) + 1),
       0,
     );
-    let random = Math.random() * totalWeight;
+    let random = getRandomNumberGenerator().random() * totalWeight;
 
     for (const creature of creatures) {
       random -= 1 / (creatures.indexOf(creature) + 1);

--- a/src/blackbox/Retry.ts
+++ b/src/blackbox/Retry.ts
@@ -5,6 +5,7 @@ import type { RequiredQuantumStepConfig } from "../config/QuantumStepConfig.ts";
 import type { Approach } from "../NEAT/LogApproach.ts";
 import { fineTuneImprovement } from "./FineTune.ts";
 import { restoreSource } from "./RestoreSource.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 export type Filter = "NONE" | "FORWARD" | "BACKWARDS";
 
@@ -57,8 +58,9 @@ export function retry(
     });
 
     // Get the index by multiplying two random numbers (favoring the top, but can be anywhere)
+    const rng = getRandomNumberGenerator();
     const randomIndx = Math.floor(
-      possibleRetryPopulation.length * Math.random() * Math.random(),
+      possibleRetryPopulation.length * rng.random() * rng.random(),
     );
     const tmpCreature = possibleRetryPopulation[randomIndx];
 

--- a/src/breed/Father.ts
+++ b/src/breed/Father.ts
@@ -1,6 +1,7 @@
 import type { Creature } from "../Creature.ts";
 import type { CreatureExport } from "../architecture/CreatureInterfaces.ts";
 import type { NeuronExport } from "../architecture/NeuronInterfaces.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 /**
  * Lightweight neuron info needed for compatibility check.
@@ -169,8 +170,9 @@ export function createCompatibleFather(
       !usedMotherUUIDs.has(motherNeuron.uuid)
     ) {
       // Randomly select one matching father neuron for the mapping
+      const rng = getRandomNumberGenerator();
       const selectedFatherNeuron = matchingFatherNeurons[
-        Math.floor(Math.random() * matchingFatherNeurons.length)
+        Math.floor(rng.random() * matchingFatherNeurons.length)
       ];
 
       uuidMapping.set(selectedFatherNeuron.uuid, motherNeuron.uuid);
@@ -279,8 +281,9 @@ export function createCompatibleFatherFromCreatures(
       !usedMotherUUIDs.has(motherNeuron.uuid)
     ) {
       // Randomly select one matching father neuron for the mapping
+      const rng = getRandomNumberGenerator();
       const selectedFatherNeuron = matchingFatherNeurons[
-        Math.floor(Math.random() * matchingFatherNeurons.length)
+        Math.floor(rng.random() * matchingFatherNeurons.length)
       ];
 
       uuidMapping.set(selectedFatherNeuron.uuid, motherNeuron.uuid);

--- a/src/breed/FitnessRanking.ts
+++ b/src/breed/FitnessRanking.ts
@@ -1,6 +1,7 @@
 import { assert } from "@std/assert";
 import { getTag } from "@stsoftware/tags/mod";
 import type { Creature } from "../Creature.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 /**
  * Pre-computed fitness ranking data for a population.
@@ -137,7 +138,8 @@ export class FitnessRanking {
    * @returns The selected creature
    */
   selectPower(power: number): Creature {
-    const r = Math.random();
+    const rng = getRandomNumberGenerator();
+    const r = rng.random();
     const index = Math.floor(
       Math.pow(r, power) * this.sortedPopulation.length,
     );
@@ -153,8 +155,9 @@ export class FitnessRanking {
    * @returns The selected creature
    */
   selectFitnessProportionate(): Creature {
+    const rng = getRandomNumberGenerator();
     const adjustFitness = Math.abs(this.minFitness);
-    const random = Math.random() * this.adjustedTotalFitness;
+    const random = rng.random() * this.adjustedTotalFitness;
     let value = 0;
 
     for (let i = 0; i < this.sortedPopulation.length; i++) {
@@ -167,7 +170,7 @@ export class FitnessRanking {
 
     // If all scores equal, return random creature
     return this.sortedPopulation[
-      Math.floor(Math.random() * this.sortedPopulation.length)
+      Math.floor(rng.random() * this.sortedPopulation.length)
     ];
   }
 
@@ -184,13 +187,14 @@ export class FitnessRanking {
    * @throws {Error} When no parent found in tournament
    */
   selectTournament(size: number, probability: number): Creature {
+    const rng = getRandomNumberGenerator();
     const actualSize = Math.min(size, this.sortedPopulation.length);
 
     // Create tournament participants
     const participants = new Array<Creature>(actualSize);
     for (let i = 0; i < actualSize; i++) {
       const randomIdx = Math.floor(
-        Math.random() * this.sortedPopulation.length,
+        rng.random() * this.sortedPopulation.length,
       );
       participants[i] = this.sortedPopulation[randomIdx];
     }
@@ -202,7 +206,7 @@ export class FitnessRanking {
 
     // Select with probability
     for (let i = 0; i < actualSize; i++) {
-      if (Math.random() < probability || i === actualSize - 1) {
+      if (rng.random() < probability || i === actualSize - 1) {
         return participants[i];
       }
     }

--- a/src/breed/ParentSelection.ts
+++ b/src/breed/ParentSelection.ts
@@ -10,6 +10,7 @@ import { assert } from "@std/assert";
 import { Creature, Selection } from "../../mod.ts";
 import type { NeatConfig } from "../config/NeatConfig.ts";
 import type { Genus } from "../NEAT/Genus.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { calculateAdaptiveTournamentSize } from "./AdaptiveTournamentSize.ts";
 import { createCompatibleFatherFromCreatures } from "./Father.ts";
 import { FitnessRanking } from "./FitnessRanking.ts";
@@ -76,7 +77,7 @@ export function findFather(
 
   let possibleFathers: Creature[] = [];
 
-  if (config.globalBreedingRate > Math.random()) {
+  if (config.globalBreedingRate > getRandomNumberGenerator().random()) {
     possibleFathers = genus.population.filter((creature) =>
       creature.uuid !== mum.uuid
     );

--- a/src/compact/CompactUnused.ts
+++ b/src/compact/CompactUnused.ts
@@ -7,6 +7,7 @@ import type { NeuronTrace } from "../architecture/NeuronInterfaces.ts";
 import type { NeuronActivationInterface } from "../methods/activations/NeuronActivationInterface.ts";
 import type { Approach } from "../NEAT/LogApproach.ts";
 import { createConstantOne, removeHiddenNeuron } from "./CompactUtils.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 export function compactUnused(
   traced: CreatureTrace,
@@ -226,7 +227,9 @@ export function removeNeuron(
     for (const synapse of fromList) {
       const toList = creature.inwardConnections(synapse.to);
       if (toList.length < 2) {
-        const randomFromIndx = Math.floor(Math.random() * creature.input);
+        const randomFromIndx = Math.floor(
+          getRandomNumberGenerator().random() * creature.input,
+        );
 
         /* Add a new connection which will be removed later because weight is zero */
         creature.connect(randomFromIndx, synapse.to, 0);

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -15,6 +15,7 @@ import type { RequiredStabilityAdaptationConfig } from "./StabilityAdaptationCon
 import type { RequiredQuantumStepConfig } from "./QuantumStepConfig.ts";
 import type { RequiredBiasRegularisationConfig } from "./BiasRegularisationConfig.ts";
 import type { Logger } from "../utils/Logger.ts";
+import type { RandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import type { RequiredWeightRegularisationConfig } from "./WeightRegularisationConfig.ts";
 
 /**
@@ -545,4 +546,15 @@ export interface NeatArguments {
    * console-based logger at "info" level.
    */
   logger: Logger;
+
+  /**
+   * Random number generator instance for reproducible evolution.
+   *
+   * Issue #1400: All stochastic operations (mutation, selection, breeding,
+   * shuffling) use this RNG instead of `Math.random()`. When a `seed` is
+   * provided via NeatOptions, a deterministic xoshiro256** PRNG is used;
+   * otherwise an unseeded wrapper around `Math.random()` preserves backward
+   * compatibility.
+   */
+  rng: RandomNumberGenerator;
 }

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -45,6 +45,12 @@ import {
   type Logger,
   setLogger,
 } from "../utils/Logger.ts";
+import {
+  createSeededRng,
+  createUnseededRng,
+  type RandomNumberGenerator,
+  setRandomNumberGenerator,
+} from "../utils/RandomNumberGenerator.ts";
 
 /**
  * Default cost of growth value used when not specified in options.
@@ -134,11 +140,24 @@ export type NeatConfig = Readonly<NeatArguments>;
  */
 export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
   const opts = options as Record<string, unknown>;
+
+  // Issue #1400: Set up the global RNG before anything else uses randomness.
+  const rng: RandomNumberGenerator = (() => {
+    if (options.rng) return options.rng;
+    const seedRaw = opts.seed;
+    if (seedRaw !== undefined && seedRaw !== null) {
+      const seed = parseNumber("Seed", seedRaw, 0, { min: 0 });
+      return createSeededRng(seed);
+    }
+    return createUnseededRng();
+  })();
+  setRandomNumberGenerator(rng);
+
   let selection: SelectionInterface = Selection.POWER;
   if (options.selection) {
     selection = options.selection;
   } else {
-    const r0 = Math.random();
+    const r0 = rng.random();
     if (r0 < 0.33) {
       selection = Selection.FITNESS_PROPORTIONATE;
     } else if (r0 < 0.66) {
@@ -289,7 +308,7 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
     sparseRatio: parseNumber(
       "Sparse Ratio",
       opts.sparseRatio,
-      Math.random() * Math.random(),
+      rng.random() * rng.random(),
       { min: 0, max: 1 },
     ),
     globalBreedingRate: Math.max(
@@ -297,7 +316,7 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
         parseNumber(
           "Global breeding rate",
           opts.globalBreedingRate,
-          Math.random(),
+          rng.random(),
           {
             min: 0,
             max: 1,
@@ -825,6 +844,8 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
       if (options.logger) return options.logger;
       return createConsoleLogger(options.logLevel ?? "info");
     })() as Logger,
+    // Issue #1400: Reproducible random number generation
+    rng,
   };
 
   // Issue #1398: Set the global logger so code without config access can use it

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -1,4 +1,5 @@
 import type { Logger, LogLevel } from "../utils/Logger.ts";
+import type { RandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import type { AdaptiveMutationThresholds } from "./AdaptiveMutationThresholds.ts";
 import type { DiscoveryMinCandidatesPerCategory } from "./DiscoveryMinCandidatesPerCategory.ts";
 import type { EnsembleDiversityConfig } from "./EnsembleDiversityConfig.ts";
@@ -76,6 +77,7 @@ export type NeatOptions =
     | "quantumStep"
     | "fineTunePopulation"
     | "logger"
+    | "rng"
   >
   & {
     /** Partial overrides for minimum candidates per category (defaults applied if not specified) */
@@ -107,6 +109,25 @@ export type NeatOptions =
      * Default: "info"
      */
     logLevel?: LogLevel;
+    /**
+     * Seed for reproducible random number generation.
+     *
+     * Issue #1400: When provided, all stochastic operations (mutation,
+     * selection, breeding, shuffling) use a deterministic xoshiro256**
+     * PRNG seeded with this value. Two runs with the same seed and
+     * configuration produce identical results.
+     *
+     * When omitted, an unseeded RNG backed by `Math.random()` is used
+     * for backward compatibility.
+     */
+    seed?: number;
+    /**
+     * Custom random number generator instance.
+     *
+     * Issue #1400: Advanced users can inject their own RNG implementation.
+     * Takes precedence over `seed` when both are provided.
+     */
+    rng?: RandomNumberGenerator;
   };
 
 /**
@@ -141,6 +162,8 @@ export type NeatOptionsInput =
     | "fineTunePopulation"
     | "logger"
     | "logLevel"
+    | "seed"
+    | "rng"
   >
   & {
     [K in NumericOptionKeys]?: NonNullable<NeatOptions[K]> extends number
@@ -163,4 +186,8 @@ export type NeatOptionsInput =
     logger?: Logger;
     /** Log level filter for the default console logger. */
     logLevel?: LogLevel;
+    /** Seed for reproducible random number generation. Accepts string from CLI. */
+    seed?: number | string;
+    /** Custom RNG instance (not coerced — functions cannot come from CLI). */
+    rng?: RandomNumberGenerator;
   };

--- a/src/discovery/BrittlenessScorer.ts
+++ b/src/discovery/BrittlenessScorer.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Creature } from "../Creature.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 /**
  * Options for brittleness scoring.
@@ -76,7 +77,9 @@ export function perturbInput(
   magnitude: number,
   seed?: number,
 ): Float32Array {
-  const random = seed !== undefined ? createSeededRandom(seed) : Math.random;
+  const random = seed !== undefined
+    ? createSeededRandom(seed)
+    : () => getRandomNumberGenerator().random();
   const perturbed = new Float32Array(input.length);
 
   for (let i = 0; i < input.length; i++) {
@@ -101,7 +104,8 @@ export class BrittlenessScorer {
     this.#options = {
       perturbationMagnitude: options.perturbationMagnitude ?? 0.1,
       perturbationsPerInput: options.perturbationsPerInput ?? 5,
-      seed: options.seed ?? Math.floor(Math.random() * 2147483647),
+      seed: options.seed ??
+        Math.floor(getRandomNumberGenerator().random() * 2147483647),
       brittlenessThreshold: options.brittlenessThreshold ??
         Number.POSITIVE_INFINITY,
     };

--- a/src/discovery/HoldoutValidator.ts
+++ b/src/discovery/HoldoutValidator.ts
@@ -16,6 +16,7 @@
 import type { Creature } from "../Creature.ts";
 import type { DataRecordInterface } from "../architecture/DataSet.ts";
 import { Costs } from "../Costs.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 /**
  * Options for holdout validation.
@@ -105,7 +106,9 @@ export function splitDataForHoldout(
   const indices = Array.from({ length: data.length }, (_, i) => i);
 
   // Use seeded or standard random for shuffling
-  const random = seed !== undefined ? createSeededRandom(seed) : Math.random;
+  const random = seed !== undefined
+    ? createSeededRandom(seed)
+    : () => getRandomNumberGenerator().random();
 
   // Fisher-Yates shuffle
   for (let i = indices.length - 1; i > 0; i--) {
@@ -181,7 +184,8 @@ export class HoldoutValidator {
   constructor(options: HoldoutValidatorOptions = {}) {
     this.#options = {
       holdoutPercentage: options.holdoutPercentage ?? 0.2,
-      seed: options.seed ?? Math.floor(Math.random() * 2147483647),
+      seed: options.seed ??
+        Math.floor(getRandomNumberGenerator().random() * 2147483647),
       maxPerformanceGap: options.maxPerformanceGap ?? Number.POSITIVE_INFINITY,
       costName: options.costName ?? "MSE",
     };

--- a/src/intelligentDesign/ImproveSquash.ts
+++ b/src/intelligentDesign/ImproveSquash.ts
@@ -18,6 +18,7 @@ import type { BestNeuronSquash } from "./BestNeuronSquash.ts";
 import { safeWriteText, safeWriteTextSync } from "./SafeWrite.ts";
 import { WorkerHandler } from "./workers/WorkerHandler.ts";
 import { getLogger } from "../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 function remainingTimeMs(deadlineMs: number): number {
   return Math.max(0, deadlineMs - Date.now());
@@ -215,8 +216,9 @@ export function makeModifiedCreatureWithPrevious(
  * @returns The shuffled array
  */
 export function shuffle<T>(array: T[]): T[] {
+  const rng = getRandomNumberGenerator();
   for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(rng.random() * (i + 1));
     [array[i], array[j]] = [array[j], array[i]];
   }
   return array;

--- a/src/methods/activations/Activations.ts
+++ b/src/methods/activations/Activations.ts
@@ -38,6 +38,7 @@ import { StdInverse } from "./types/StdInverse.ts";
 import { Swish } from "./types/Swish.ts";
 import { TAN } from "./types/TAN.ts";
 import { TANH } from "./types/TANH.ts";
+import { getRandomNumberGenerator } from "../../utils/RandomNumberGenerator.ts";
 
 export interface ActivationOptions {
   aliases?: string[];
@@ -89,7 +90,7 @@ export class Activations {
     const pool = exclude
       ? Activations.WEIGHTED_POOL.filter((name) => name !== exclude)
       : Activations.WEIGHTED_POOL;
-    const index = Math.floor(Math.random() * pool.length);
+    const index = Math.floor(getRandomNumberGenerator().random() * pool.length);
     return pool[index];
   }
 }

--- a/src/methods/activations/aggregate/IF.ts
+++ b/src/methods/activations/aggregate/IF.ts
@@ -23,6 +23,7 @@ import { accumulateWeight, adjustedWeight } from "../../../propagate/Weight.ts";
 import type { ApplyLearningsInterface } from "../ApplyLearningsInterface.ts";
 import type { NeuronActivationInterface } from "../NeuronActivationInterface.ts";
 import { IDENTITY } from "../types/IDENTITY.ts";
+import { getRandomNumberGenerator } from "../../../utils/RandomNumberGenerator.ts";
 
 export class IF
   implements
@@ -165,7 +166,7 @@ export class IF
           foundPositive = true;
           c.type = "positive";
         } else {
-          switch (Math.floor(Math.random() * 3)) {
+          switch (Math.floor(getRandomNumberGenerator().random() * 3)) {
             case 0:
               c.type = "condition";
               break;

--- a/src/mutate/AbstractMutationOperator.ts
+++ b/src/mutate/AbstractMutationOperator.ts
@@ -1,4 +1,5 @@
 import type { Creature } from "../Creature.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import type { RadioactiveInterface } from "./RadioactiveInterface.ts";
 
 /**
@@ -52,12 +53,13 @@ export abstract class AbstractMutationOperator implements RadioactiveInterface {
     relaxAfter = 6,
   ): number {
     const creature = this.creature;
+    const rng = getRandomNumberGenerator();
     const hiddenCount = creature.neurons.length - creature.input -
       creature.output;
     if (hiddenCount <= 0) return -1;
 
     for (let attempts = 0; attempts < maxAttempts; attempts++) {
-      const index = Math.floor(Math.random() * hiddenCount) + creature.input;
+      const index = Math.floor(rng.random() * hiddenCount) + creature.input;
       const neuron = creature.neurons[index];
       if (neuron.type !== "hidden") continue;
       if (
@@ -88,10 +90,11 @@ export abstract class AbstractMutationOperator implements RadioactiveInterface {
     relaxAfter = 6,
   ): number {
     const creature = this.creature;
+    const rng = getRandomNumberGenerator();
 
     for (let attempts = 0; attempts < maxAttempts; attempts++) {
       const index = Math.floor(
-        Math.random() * (creature.neurons.length - creature.input) +
+        rng.random() * (creature.neurons.length - creature.input) +
           creature.input,
       );
       const neuron = creature.neurons[index];

--- a/src/mutate/AddBackCon.ts
+++ b/src/mutate/AddBackCon.ts
@@ -1,4 +1,5 @@
 import { Synapse } from "../architecture/Synapse.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 
 export class AddBackCon extends AbstractMutationOperator {
@@ -35,7 +36,9 @@ export class AddBackCon extends AbstractMutationOperator {
       return false;
     }
 
-    const pair = available[Math.floor(Math.random() * available.length)];
+    const pair = available[
+      Math.floor(getRandomNumberGenerator().random() * available.length)
+    ];
     const fromIndx = pair[0].index;
     const toIndx = pair[1].index;
     creature.connect(fromIndx, toIndx, Synapse.randomWeight());

--- a/src/mutate/AddConnection.ts
+++ b/src/mutate/AddConnection.ts
@@ -3,6 +3,7 @@ import type { ConnectionOptions } from "../ConnectionOptions.ts";
 import type { Creature } from "../Creature.ts";
 import type { Neuron } from "../architecture/Neuron.ts";
 import { Synapse } from "../architecture/Synapse.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { getMajorVersion } from "../upgrade/Upgrade.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 
@@ -97,7 +98,9 @@ export class AddConnection extends AbstractMutationOperator {
       return false;
     }
 
-    const pair = available[Math.floor(Math.random() * available.length)];
+    const pair = available[
+      Math.floor(getRandomNumberGenerator().random() * available.length)
+    ];
     const fromIndex = pair[0];
     const toIndex = pair[1];
 

--- a/src/mutate/AddNeuron.ts
+++ b/src/mutate/AddNeuron.ts
@@ -3,6 +3,7 @@ import { CreatureUtil } from "../../mod.ts";
 import type { Creature } from "../Creature.ts";
 import { Neuron } from "../architecture/Neuron.ts";
 import { Synapse } from "../architecture/Synapse.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 import { getLogger } from "../utils/Logger.ts";
 
@@ -41,18 +42,19 @@ export class AddNeuron extends AbstractMutationOperator {
    */
   protected performMutation(focusList?: number[]): boolean {
     const creature = this.creature;
+    const rng = getRandomNumberGenerator();
     const startUUID = CreatureUtil.makeUUID(creature);
     delete creature.uuid;
     const forwardOnly = creature.forwardOnly === true;
     const neuron = new Neuron(
       crypto.randomUUID(),
       "hidden",
-      Math.random() * 0.2 - 0.1,
+      rng.random() * 0.2 - 0.1,
       creature,
     );
 
     let indx = Math.floor(
-      Math.random() *
+      rng.random() *
         (creature.neurons.length - creature.output - creature.input + 1),
     ) + creature.input;
 
@@ -336,7 +338,7 @@ export class AddNeuron extends AbstractMutationOperator {
 
     // Direct random selection from valid candidates
     return sourceCandidates[
-      Math.floor(Math.random() * sourceCandidates.length)
+      Math.floor(getRandomNumberGenerator().random() * sourceCandidates.length)
     ];
   }
 
@@ -382,7 +384,7 @@ export class AddNeuron extends AbstractMutationOperator {
 
     // Direct random selection from valid candidates
     return targetCandidates[
-      Math.floor(Math.random() * targetCandidates.length)
+      Math.floor(getRandomNumberGenerator().random() * targetCandidates.length)
     ];
   }
 }

--- a/src/mutate/AddSelfCon.ts
+++ b/src/mutate/AddSelfCon.ts
@@ -1,4 +1,5 @@
 import { Synapse } from "../architecture/Synapse.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 
 export class AddSelfCon extends AbstractMutationOperator {
@@ -27,7 +28,9 @@ export class AddSelfCon extends AbstractMutationOperator {
       return false;
     }
 
-    const neuron = possible[Math.floor(Math.random() * possible.length)];
+    const neuron = possible[
+      Math.floor(getRandomNumberGenerator().random() * possible.length)
+    ];
     const indx = neuron.index;
     creature.connect(indx, indx, Synapse.randomWeight());
 

--- a/src/mutate/ModBias.ts
+++ b/src/mutate/ModBias.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_BIAS_REGULARISATION_CONFIG,
   type RequiredBiasRegularisationConfig,
 } from "../config/BiasRegularisationConfig.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 
 /**
@@ -132,8 +133,9 @@ export class ModBias extends AbstractMutationOperator {
     currentBias: number,
     quantum: number,
   ): number {
+    const rng = getRandomNumberGenerator();
     // Base random modification
-    const baseModification = (Math.random() * 2 - 1) * quantum;
+    const baseModification = (rng.random() * 2 - 1) * quantum;
 
     if (this.config.l2Strength <= 0) {
       return baseModification;
@@ -142,7 +144,7 @@ export class ModBias extends AbstractMutationOperator {
     // L2 regularisation: create a bias towards zero
     // The pull towards zero is proportional to the current bias magnitude
     // and the l2Strength parameter
-    const l2Pull = -currentBias * this.config.l2Strength * Math.random();
+    const l2Pull = -currentBias * this.config.l2Strength * rng.random();
 
     // Blend the base modification with the L2 pull
     // Higher l2Strength means more influence from the pull towards zero
@@ -171,7 +173,8 @@ export class ModBias extends AbstractMutationOperator {
     }
 
     // Generate a random modification value based on the quantum
-    const modification = (Math.random() * 2 - 1) * quantum;
+    const modification = (getRandomNumberGenerator().random() * 2 - 1) *
+      quantum;
 
     return currentBias + modification;
   }

--- a/src/mutate/ModWeight.ts
+++ b/src/mutate/ModWeight.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_WEIGHT_REGULARISATION_CONFIG,
   type RequiredWeightRegularisationConfig,
 } from "../config/WeightRegularisationConfig.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 
 /**
@@ -63,7 +64,9 @@ export class ModWeight extends AbstractMutationOperator {
 
     let changed = false;
     if (relevantConnections.length > 0) {
-      const indx = Math.floor(Math.random() * relevantConnections.length);
+      const indx = Math.floor(
+        getRandomNumberGenerator().random() * relevantConnections.length,
+      );
       const connection = relevantConnections[indx];
 
       // Calculate the new weight with regularisation
@@ -150,8 +153,9 @@ export class ModWeight extends AbstractMutationOperator {
     currentWeight: number,
     quantum: number,
   ): number {
+    const rng = getRandomNumberGenerator();
     // Base random modification
-    const baseModification = (Math.random() * 2 - 1) * quantum;
+    const baseModification = (rng.random() * 2 - 1) * quantum;
 
     if (this.config.l2Strength <= 0) {
       return baseModification;
@@ -160,7 +164,7 @@ export class ModWeight extends AbstractMutationOperator {
     // L2 regularisation: create a bias towards zero
     // The pull towards zero is proportional to the current weight magnitude
     // and the l2Strength parameter
-    const l2Pull = -currentWeight * this.config.l2Strength * Math.random();
+    const l2Pull = -currentWeight * this.config.l2Strength * rng.random();
 
     // Blend the base modification with the L2 pull
     // Higher l2Strength means more influence from the pull towards zero
@@ -189,7 +193,8 @@ export class ModWeight extends AbstractMutationOperator {
     }
 
     // Generate a random modification value based on the quantum
-    const modification = (Math.random() * 2 - 1) * quantum;
+    const modification = (getRandomNumberGenerator().random() * 2 - 1) *
+      quantum;
 
     return currentWeight + modification;
   }

--- a/src/mutate/SubBackCon.ts
+++ b/src/mutate/SubBackCon.ts
@@ -1,5 +1,6 @@
 import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 import { getLogger } from "../utils/Logger.ts";
 
@@ -28,7 +29,9 @@ export class SubBackCon extends AbstractMutationOperator {
       return false;
     }
 
-    const pair = available[Math.floor(Math.random() * available.length)];
+    const pair = available[
+      Math.floor(getRandomNumberGenerator().random() * available.length)
+    ];
     this.creature.disconnect(pair[0], pair[1]);
 
     delete this.creature.memetic;

--- a/src/mutate/SubConnection.ts
+++ b/src/mutate/SubConnection.ts
@@ -3,6 +3,7 @@ import {
   cleanupOrphanedNeurons,
 } from "../compact/CompactUtils.ts";
 import { CreatureExportBuilder } from "../utils/CreatureExportBuilder.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 
 export class SubConnection extends AbstractMutationOperator {
@@ -53,7 +54,9 @@ export class SubConnection extends AbstractMutationOperator {
     }
 
     // Select a random connection to remove
-    const randomConn = possible[Math.floor(Math.random() * possible.length)];
+    const randomConn = possible[
+      Math.floor(getRandomNumberGenerator().random() * possible.length)
+    ];
 
     // Remove the selected synapse
     exportJSON.synapses = exportJSON.synapses.filter(

--- a/src/mutate/SubNeuron.ts
+++ b/src/mutate/SubNeuron.ts
@@ -3,6 +3,7 @@ import {
   cleanupOrphanedNeurons,
 } from "../compact/CompactUtils.ts";
 import { CreatureExportBuilder } from "../utils/CreatureExportBuilder.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 
 export class SubNeuron extends AbstractMutationOperator {
@@ -41,8 +42,11 @@ export class SubNeuron extends AbstractMutationOperator {
 
     for (let attempts = 0; attempts < 24; attempts++) {
       // Select a random removable neuron
-      const randomNeuron =
-        removableNeurons[Math.floor(Math.random() * removableNeurons.length)];
+      const randomNeuron = removableNeurons[
+        Math.floor(
+          getRandomNumberGenerator().random() * removableNeurons.length,
+        )
+      ];
       const neuronIdx = neuronIndexMap.get(randomNeuron.uuid);
 
       // Check focus list using transitive focus checking (relax after 12 attempts)

--- a/src/mutate/SubSelfCon.ts
+++ b/src/mutate/SubSelfCon.ts
@@ -1,5 +1,6 @@
 import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "./AbstractMutationOperator.ts";
 import { getLogger } from "../utils/Logger.ts";
 
@@ -30,7 +31,9 @@ export class SubSelfCon extends AbstractMutationOperator {
     }
 
     // All neurons in possible are safe to disconnect, so just pick one
-    const neuron = possible[Math.floor(Math.random() * possible.length)];
+    const neuron = possible[
+      Math.floor(getRandomNumberGenerator().random() * possible.length)
+    ];
     const indx = neuron.index;
 
     this.creature.disconnect(indx, indx);

--- a/src/optimize/Simplify.ts
+++ b/src/optimize/Simplify.ts
@@ -11,6 +11,7 @@ import { COMPLEMENT } from "../methods/activations/types/COMPLEMENT.ts";
 import { IDENTITY } from "../methods/activations/types/IDENTITY.ts";
 import { ReLU } from "../methods/activations/types/ReLU.ts";
 import type { SimplifyBiasInterface } from "./SimplifyBiasInterface.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 export function simplify(creature: Creature): Creature | undefined {
   const complexUUID = CreatureUtil.makeUUID(creature);
@@ -64,7 +65,9 @@ export function simplify(creature: Creature): Creature | undefined {
   if (identityUUIDs.length !== 0) {
     simplified = removeNeuron(
       exported,
-      identityUUIDs[Math.floor(Math.random() * identityUUIDs.length)],
+      identityUUIDs[
+        Math.floor(getRandomNumberGenerator().random() * identityUUIDs.length)
+      ],
     );
   }
 

--- a/src/propagate/BackPropagation.ts
+++ b/src/propagate/BackPropagation.ts
@@ -4,6 +4,7 @@ import {
   squash as wasmSquash,
   unSquash as wasmUnSquash,
 } from "../wasm/ActivationMethods.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 
 export type BackPropagationArguments = {
   disableRandomSamples: boolean;
@@ -74,11 +75,12 @@ export type BackPropagationConfig = Readonly<BackPropagationArguments>;
 export function createBackPropagationConfig(
   options?: BackPropagationOptions,
 ): BackPropagationConfig {
+  const rng = getRandomNumberGenerator();
   const config: BackPropagationArguments = {
     disableRandomSamples: options?.disableRandomSamples ?? false,
 
     generations: Math.max(
-      options?.generations ?? Math.floor(Math.random() * 100) + 1,
+      options?.generations ?? Math.floor(rng.random() * 100) + 1,
       0,
     ),
 
@@ -99,8 +101,8 @@ export function createBackPropagationConfig(
     learningRate: Math.min(
       Math.max(
         options?.learningRate ??
-          Math.random() * Math.random() *
-            Math
+          rng.random() * rng.random() *
+            rng
               .random(), /* Random number between 0..1 but on the lower side */
         0.001,
       ),
@@ -109,7 +111,7 @@ export function createBackPropagationConfig(
 
     trainingMutationRate: Math.min(
       Math.max(
-        options?.trainingMutationRate ?? Math.random(),
+        options?.trainingMutationRate ?? rng.random(),
         0.01,
       ),
       1,
@@ -126,7 +128,7 @@ export function createBackPropagationConfig(
         ? "fixed"
         // Randomize strategy selection for exploration with correct probabilities
         : (() => {
-          const rand = Math.random();
+          const rand = rng.random();
           if (rand < 0.4) return "decay";
           if (rand < 0.7) return "adaptive";
           return "fixed";

--- a/src/propagate/sparse/ChooseNeurons.ts
+++ b/src/propagate/sparse/ChooseNeurons.ts
@@ -1,6 +1,7 @@
 import type { CreatureExport } from "../../architecture/CreatureInterfaces.ts";
 import type { NeuronStateInterface } from "../../architecture/CreatureState.ts";
 import type { BackPropagationConfig } from "../BackPropagation.ts";
+import { getRandomNumberGenerator } from "../../utils/RandomNumberGenerator.ts";
 
 /**
  * Selects neurons for sparse backpropagation training.
@@ -122,8 +123,9 @@ function errorGuidedSort(
 }
 
 function fisherYatesShuffle<T>(array: T[]): void {
+  const rng = getRandomNumberGenerator();
   for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1)); // Get a random index from 0 to i (inclusive)
+    const j = Math.floor(rng.random() * (i + 1)); // Get a random index from 0 to i (inclusive)
     [array[i], array[j]] = [array[j], array[i]]; // Swap elements at index i and j
   }
 }

--- a/src/utils/RandomNumberGenerator.ts
+++ b/src/utils/RandomNumberGenerator.ts
@@ -1,0 +1,274 @@
+/**
+ * Reproducible random number generation with seeding support.
+ *
+ * Issue #1400: Provides a seedable PRNG (xoshiro256**) so that evolution
+ * runs can be reproduced exactly when the same seed is supplied.
+ *
+ * The module follows the same global-instance pattern as Logger (Issue #1398):
+ * - `getRandomNumberGenerator()` returns the active RNG instance
+ * - `setRandomNumberGenerator(rng)` replaces the global instance
+ * - `createSeededRng(seed)` creates a seeded (deterministic) instance
+ * - `createUnseededRng()` creates an unseeded instance backed by `Math.random()`
+ *
+ * All code that previously called `Math.random()` should instead call
+ * `getRandomNumberGenerator().random()`.
+ */
+
+/**
+ * Random number generator interface.
+ *
+ * Provides the core random operations used throughout the NEAT-AI codebase.
+ */
+export interface RandomNumberGenerator {
+  /**
+   * Returns a pseudo-random number in [0, 1), like `Math.random()`.
+   */
+  random(): number;
+
+  /**
+   * Returns a pseudo-random integer in [min, max] (inclusive).
+   */
+  randomInt(min: number, max: number): number;
+
+  /**
+   * Returns a random element from the given array.
+   * Throws if the array is empty.
+   */
+  choice<T>(array: readonly T[]): T;
+
+  /**
+   * Whether this RNG was created with a deterministic seed.
+   */
+  readonly seeded: boolean;
+}
+
+// ─── xoshiro256** implementation ────────────────────────────────────────────
+//
+// A fast, high-quality 64-bit PRNG. We operate on pairs of 32-bit values
+// (hi/lo) because JavaScript lacks native 64-bit integers. The state is
+// four 64-bit words (eight 32-bit values).
+
+/** A 64-bit value stored as two 32-bit halves. */
+interface U64 {
+  hi: number;
+  lo: number;
+}
+
+function u64(hi: number, lo: number): U64 {
+  return { hi: hi >>> 0, lo: lo >>> 0 };
+}
+
+function u64Add(a: U64, b: U64): U64 {
+  const lo = (a.lo + b.lo) >>> 0;
+  const carry = lo < a.lo ? 1 : 0;
+  const hi = (a.hi + b.hi + carry) >>> 0;
+  return { hi, lo };
+}
+
+function u64Mul(a: U64, b: U64): U64 {
+  // Schoolbook multiply keeping only the lower 64 bits.
+  const a0 = a.lo & 0xFFFF;
+  const a1 = a.lo >>> 16;
+  const a2 = a.hi & 0xFFFF;
+  const a3 = a.hi >>> 16;
+  const b0 = b.lo & 0xFFFF;
+  const b1 = b.lo >>> 16;
+  const b2 = b.hi & 0xFFFF;
+  const b3 = b.hi >>> 16;
+
+  let lo = 0;
+  let hi = 0;
+
+  lo = a0 * b0;
+  let mid = (lo >>> 16) + a1 * b0;
+  mid += a0 * b1;
+  if (mid > 0xFFFF_FFFF) mid = mid >>> 0; // wrap
+  lo = (lo & 0xFFFF) | ((mid & 0xFFFF) << 16);
+  hi = (mid >>> 16) + a2 * b0 + a1 * b1 + a0 * b2;
+  hi += (a3 * b0 + a2 * b1 + a1 * b2 + a0 * b3) << 16;
+
+  return { hi: hi >>> 0, lo: lo >>> 0 };
+}
+
+function u64Xor(a: U64, b: U64): U64 {
+  return { hi: (a.hi ^ b.hi) >>> 0, lo: (a.lo ^ b.lo) >>> 0 };
+}
+
+function u64ShiftLeft(v: U64, n: number): U64 {
+  if (n === 0) return v;
+  if (n >= 64) return u64(0, 0);
+  if (n >= 32) return u64((v.lo << (n - 32)) >>> 0, 0);
+  return u64(((v.hi << n) | (v.lo >>> (32 - n))) >>> 0, (v.lo << n) >>> 0);
+}
+
+function u64ShiftRight(v: U64, n: number): U64 {
+  if (n === 0) return v;
+  if (n >= 64) return u64(0, 0);
+  if (n >= 32) return u64(0, (v.hi >>> (n - 32)) >>> 0);
+  return u64((v.hi >>> n) >>> 0, ((v.lo >>> n) | (v.hi << (32 - n))) >>> 0);
+}
+
+function u64RotateLeft(v: U64, n: number): U64 {
+  const left = u64ShiftLeft(v, n);
+  const right = u64ShiftRight(v, 64 - n);
+  return u64Xor(left, right);
+}
+
+/** Convert a 64-bit value to a floating-point number in [0, 1). */
+function u64ToFloat(v: U64): number {
+  // Use the upper 53 bits: take all 32 of hi and the upper 21 of lo.
+  // This gives a 53-bit integer which we divide by 2^53.
+  const hi32 = v.hi >>> 0;
+  const lo21 = (v.lo >>> 11) >>> 0; // upper 21 bits of lo
+  // hi32 * 2^21 + lo21, then divide by 2^53
+  return (hi32 * 2_097_152 + lo21) / 9_007_199_254_740_992;
+}
+
+/**
+ * SplitMix64 — used only to initialise the xoshiro256** state from a
+ * single 64-bit seed. This ensures all four state words are non-zero.
+ */
+function splitMix64(seed: U64): { value: U64; next: U64 } {
+  const s = u64Add(seed, u64(0x9E37_79B9, 0x7F4A_7C15));
+  let z = s;
+  z = u64Xor(z, u64ShiftRight(z, 30));
+  z = u64Mul(z, u64(0xBF58_476D, 0x1CE4_E5B9));
+  z = u64Xor(z, u64ShiftRight(z, 27));
+  z = u64Mul(z, u64(0x94D0_49BB, 0x1331_11EB));
+  z = u64Xor(z, u64ShiftRight(z, 31));
+  return { value: z, next: s };
+}
+
+/**
+ * xoshiro256** state: four 64-bit words.
+ */
+interface Xoshiro256State {
+  s0: U64;
+  s1: U64;
+  s2: U64;
+  s3: U64;
+}
+
+function xoshiroNext(state: Xoshiro256State): number {
+  // result = rotl(s1 * 5, 7) * 9
+  const result = u64Mul(
+    u64RotateLeft(u64Mul(state.s1, u64(0, 5)), 7),
+    u64(0, 9),
+  );
+
+  const t = u64ShiftLeft(state.s1, 17);
+
+  state.s2 = u64Xor(state.s2, state.s0);
+  state.s3 = u64Xor(state.s3, state.s1);
+  state.s1 = u64Xor(state.s1, state.s2);
+  state.s0 = u64Xor(state.s0, state.s3);
+
+  state.s2 = u64Xor(state.s2, t);
+  state.s3 = u64RotateLeft(state.s3, 45);
+
+  return u64ToFloat(result);
+}
+
+function initState(seed: number): Xoshiro256State {
+  // Ensure seed is a safe integer
+  const safeSeed = Math.abs(Math.trunc(seed)) || 1;
+  let s = u64(0, safeSeed);
+
+  const r0 = splitMix64(s);
+  s = r0.next;
+  const r1 = splitMix64(s);
+  s = r1.next;
+  const r2 = splitMix64(s);
+  s = r2.next;
+  const r3 = splitMix64(s);
+
+  return { s0: r0.value, s1: r1.value, s2: r2.value, s3: r3.value };
+}
+
+// ─── Concrete implementations ───────────────────────────────────────────────
+
+class SeededRng implements RandomNumberGenerator {
+  readonly seeded = true;
+  private state: Xoshiro256State;
+
+  constructor(seed: number) {
+    this.state = initState(seed);
+  }
+
+  random(): number {
+    return xoshiroNext(this.state);
+  }
+
+  randomInt(min: number, max: number): number {
+    return Math.floor(this.random() * (max - min + 1)) + min;
+  }
+
+  choice<T>(array: readonly T[]): T {
+    if (array.length === 0) {
+      throw new Error("Cannot choose from an empty array");
+    }
+    return array[this.randomInt(0, array.length - 1)];
+  }
+}
+
+class UnseededRng implements RandomNumberGenerator {
+  readonly seeded = false;
+
+  random(): number {
+    return Math.random();
+  }
+
+  randomInt(min: number, max: number): number {
+    return Math.floor(this.random() * (max - min + 1)) + min;
+  }
+
+  choice<T>(array: readonly T[]): T {
+    if (array.length === 0) {
+      throw new Error("Cannot choose from an empty array");
+    }
+    return array[this.randomInt(0, array.length - 1)];
+  }
+}
+
+// ─── Global instance ────────────────────────────────────────────────────────
+
+/** The active global RNG instance. Starts unseeded for backward compatibility. */
+let globalRng: RandomNumberGenerator = new UnseededRng();
+
+/**
+ * Returns the currently active random number generator.
+ *
+ * All NEAT-AI code should call this instead of `Math.random()`.
+ */
+export function getRandomNumberGenerator(): RandomNumberGenerator {
+  return globalRng;
+}
+
+/**
+ * Replaces the global random number generator.
+ *
+ * Called by `createNeatConfig()` when a seed is provided.
+ */
+export function setRandomNumberGenerator(rng: RandomNumberGenerator): void {
+  globalRng = rng;
+}
+
+/**
+ * Creates a deterministic RNG seeded with the given value.
+ *
+ * Two instances created with the same seed will produce identical sequences.
+ *
+ * @param seed - A non-negative integer seed value.
+ */
+export function createSeededRng(seed: number): RandomNumberGenerator {
+  return new SeededRng(seed);
+}
+
+/**
+ * Creates an unseeded RNG backed by `Math.random()`.
+ *
+ * This is the default behaviour for backward compatibility.
+ */
+export function createUnseededRng(): RandomNumberGenerator {
+  return new UnseededRng();
+}

--- a/test/config/NeatConfigRng.ts
+++ b/test/config/NeatConfigRng.ts
@@ -1,0 +1,169 @@
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { Mutation } from "../../src/NEAT/Mutation.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+import {
+  createSeededRng,
+  getRandomNumberGenerator,
+} from "../../src/utils/RandomNumberGenerator.ts";
+
+/**
+ * Integration tests for Issue #1400: Reproducible random number generation.
+ *
+ * These tests verify that supplying a `seed` (or custom `rng`) in NeatOptions
+ * makes the NEAT algorithm's stochastic operations deterministic and
+ * reproducible.
+ */
+
+Deno.test("NeatConfig: seed option creates a seeded RNG", () => {
+  const config = createNeatConfig({ seed: 42 });
+  assertEquals(config.rng.seeded, true);
+});
+
+Deno.test("NeatConfig: seed option from string (CLI)", () => {
+  const config = createNeatConfig({ seed: "42" });
+  assertEquals(config.rng.seeded, true);
+});
+
+Deno.test("NeatConfig: no seed creates an unseeded RNG", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.rng.seeded, false);
+});
+
+Deno.test("NeatConfig: custom rng takes precedence over seed", () => {
+  const custom = createSeededRng(99);
+  const config = createNeatConfig({ seed: 42, rng: custom });
+  assertEquals(config.rng, custom);
+});
+
+Deno.test("NeatConfig: seed sets the global RNG", () => {
+  createNeatConfig({ seed: 42 });
+  const globalRng = getRandomNumberGenerator();
+  assertEquals(globalRng.seeded, true);
+});
+
+Deno.test("NeatConfig: same seed produces identical config defaults", () => {
+  // sparseRatio and globalBreedingRate use RNG when not explicitly set
+  const config1 = createNeatConfig({ seed: 12345 });
+  const config2 = createNeatConfig({ seed: 12345 });
+
+  assertEquals(config1.sparseRatio, config2.sparseRatio);
+  assertEquals(config1.globalBreedingRate, config2.globalBreedingRate);
+  assertEquals(config1.selection, config2.selection);
+});
+
+Deno.test("NeatConfig: different seeds produce different config defaults", () => {
+  // Run multiple pairs to increase confidence (randomised defaults differ)
+  let sparseRatioDiffers = false;
+  let breedingRateDiffers = false;
+
+  for (let seedA = 1; seedA <= 20; seedA++) {
+    const configA = createNeatConfig({ seed: seedA });
+    const configB = createNeatConfig({ seed: seedA + 1000 });
+
+    if (configA.sparseRatio !== configB.sparseRatio) sparseRatioDiffers = true;
+    if (configA.globalBreedingRate !== configB.globalBreedingRate) {
+      breedingRateDiffers = true;
+    }
+    if (sparseRatioDiffers && breedingRateDiffers) break;
+  }
+
+  assert(sparseRatioDiffers, "Expected sparseRatio to differ for some seeds");
+  assert(
+    breedingRateDiffers,
+    "Expected globalBreedingRate to differ for some seeds",
+  );
+});
+
+Deno.test("Mutation: same seed produces identical mutation results", () => {
+  const creatureJson = new Creature(3, 1, { layers: [{ count: 4 }] })
+    .exportJSON();
+
+  function mutateWithSeed(seed: number): string {
+    const config = createNeatConfig({
+      seed,
+      mutation: [Mutation.MOD_WEIGHT],
+      mutationRate: 1,
+      mutationAmount: 5,
+    });
+    const mutator = new Mutator(config);
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    for (let i = 0; i < 10; i++) {
+      mutator.mutateCreature(creature, Mutation.MOD_WEIGHT);
+    }
+
+    return JSON.stringify(creature.exportJSON());
+  }
+
+  const result1 = mutateWithSeed(42);
+  const result2 = mutateWithSeed(42);
+  assertEquals(
+    result1,
+    result2,
+    "Same seed should produce identical mutations",
+  );
+});
+
+Deno.test("Mutation: different seeds produce different results", () => {
+  const creatureJson = new Creature(3, 1, { layers: [{ count: 4 }] })
+    .exportJSON();
+
+  function mutateWithSeed(seed: number): string {
+    const config = createNeatConfig({
+      seed,
+      mutation: [Mutation.MOD_WEIGHT],
+      mutationRate: 1,
+      mutationAmount: 5,
+    });
+    const mutator = new Mutator(config);
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    for (let i = 0; i < 10; i++) {
+      mutator.mutateCreature(creature, Mutation.MOD_WEIGHT);
+    }
+
+    return JSON.stringify(creature.exportJSON());
+  }
+
+  const result1 = mutateWithSeed(42);
+  const result2 = mutateWithSeed(999);
+  assertNotEquals(
+    result1,
+    result2,
+    "Different seeds should produce different mutations",
+  );
+});
+
+Deno.test("Mutation: MOD_BIAS reproducible with seed", () => {
+  const creatureJson = new Creature(2, 1, { layers: [{ count: 3 }] })
+    .exportJSON();
+
+  function mutateWithSeed(seed: number): string {
+    const config = createNeatConfig({
+      seed,
+      mutation: [Mutation.MOD_BIAS],
+      mutationRate: 1,
+      mutationAmount: 5,
+    });
+    const mutator = new Mutator(config);
+    const creature = Creature.fromJSON(creatureJson);
+    CreatureUtil.makeUUID(creature);
+
+    for (let i = 0; i < 10; i++) {
+      mutator.mutateCreature(creature, Mutation.MOD_BIAS);
+    }
+
+    return JSON.stringify(creature.exportJSON());
+  }
+
+  assertEquals(
+    mutateWithSeed(77),
+    mutateWithSeed(77),
+    "Same seed should produce identical bias mutations",
+  );
+});

--- a/test/utils/RandomNumberGenerator.ts
+++ b/test/utils/RandomNumberGenerator.ts
@@ -1,0 +1,217 @@
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertThrows,
+} from "@std/assert";
+import {
+  createSeededRng,
+  createUnseededRng,
+  getRandomNumberGenerator,
+  type RandomNumberGenerator,
+  setRandomNumberGenerator,
+} from "../../src/utils/RandomNumberGenerator.ts";
+
+Deno.test("SeededRng: same seed produces same sequence", () => {
+  const rng1 = createSeededRng(42);
+  const rng2 = createSeededRng(42);
+
+  const seq1 = Array.from({ length: 100 }, () => rng1.random());
+  const seq2 = Array.from({ length: 100 }, () => rng2.random());
+
+  assertEquals(seq1, seq2);
+});
+
+Deno.test("SeededRng: different seeds produce different sequences", () => {
+  const rng1 = createSeededRng(42);
+  const rng2 = createSeededRng(123);
+
+  const seq1 = Array.from({ length: 10 }, () => rng1.random());
+  const seq2 = Array.from({ length: 10 }, () => rng2.random());
+
+  assertNotEquals(seq1, seq2);
+});
+
+Deno.test("SeededRng: random() returns values in [0, 1)", () => {
+  const rng = createSeededRng(7);
+  for (let i = 0; i < 10000; i++) {
+    const v = rng.random();
+    assert(v >= 0, `Expected >= 0, got ${v}`);
+    assert(v < 1, `Expected < 1, got ${v}`);
+  }
+});
+
+Deno.test("SeededRng: randomInt returns values in range", () => {
+  const rng = createSeededRng(99);
+  for (let i = 0; i < 1000; i++) {
+    const v = rng.randomInt(3, 7);
+    assert(v >= 3, `Expected >= 3, got ${v}`);
+    assert(v <= 7, `Expected <= 7, got ${v}`);
+    assertEquals(v, Math.floor(v), "Expected integer");
+  }
+});
+
+Deno.test("SeededRng: randomInt covers all values in range", () => {
+  const rng = createSeededRng(55);
+  const seen = new Set<number>();
+  for (let i = 0; i < 1000; i++) {
+    seen.add(rng.randomInt(0, 4));
+  }
+  assertEquals(seen.size, 5, "Expected all values 0-4 to be covered");
+});
+
+Deno.test("SeededRng: choice returns elements from array", () => {
+  const rng = createSeededRng(123);
+  const items = ["apple", "banana", "cherry"];
+  for (let i = 0; i < 100; i++) {
+    const picked = rng.choice(items);
+    assert(items.includes(picked), `Unexpected choice: ${picked}`);
+  }
+});
+
+Deno.test("SeededRng: choice throws on empty array", () => {
+  const rng = createSeededRng(1);
+  assertThrows(
+    () => rng.choice([]),
+    Error,
+    "Cannot choose from an empty array",
+  );
+});
+
+Deno.test("SeededRng: seeded property is true", () => {
+  const rng = createSeededRng(42);
+  assertEquals(rng.seeded, true);
+});
+
+Deno.test("UnseededRng: seeded property is false", () => {
+  const rng = createUnseededRng();
+  assertEquals(rng.seeded, false);
+});
+
+Deno.test("UnseededRng: random() returns values in [0, 1)", () => {
+  const rng = createUnseededRng();
+  for (let i = 0; i < 1000; i++) {
+    const v = rng.random();
+    assert(v >= 0, `Expected >= 0, got ${v}`);
+    assert(v < 1, `Expected < 1, got ${v}`);
+  }
+});
+
+Deno.test("UnseededRng: randomInt returns values in range", () => {
+  const rng = createUnseededRng();
+  for (let i = 0; i < 1000; i++) {
+    const v = rng.randomInt(0, 9);
+    assert(v >= 0 && v <= 9, `Out of range: ${v}`);
+    assertEquals(v, Math.floor(v), "Expected integer");
+  }
+});
+
+Deno.test("Global RNG: get/set round-trip", () => {
+  const original = getRandomNumberGenerator();
+  const custom = createSeededRng(42);
+  setRandomNumberGenerator(custom);
+
+  assertEquals(getRandomNumberGenerator(), custom);
+
+  // Restore original
+  setRandomNumberGenerator(original);
+});
+
+Deno.test("SeededRng: reproducible choice sequence", () => {
+  const items = [10, 20, 30, 40, 50];
+  const rng1 = createSeededRng(777);
+  const rng2 = createSeededRng(777);
+
+  const seq1 = Array.from({ length: 50 }, () => rng1.choice(items));
+  const seq2 = Array.from({ length: 50 }, () => rng2.choice(items));
+
+  assertEquals(seq1, seq2);
+});
+
+Deno.test("SeededRng: seed 0 treated as valid", () => {
+  const rng = createSeededRng(0);
+  // Should not throw; seed 0 is handled gracefully
+  const v = rng.random();
+  assert(v >= 0 && v < 1, `Expected [0, 1), got ${v}`);
+});
+
+Deno.test("SeededRng: large seed value", () => {
+  const rng = createSeededRng(Number.MAX_SAFE_INTEGER);
+  const v = rng.random();
+  assert(v >= 0 && v < 1, `Expected [0, 1), got ${v}`);
+});
+
+Deno.test("SeededRng: generates diverse values (not stuck)", () => {
+  const rng = createSeededRng(42);
+  const values = new Set<number>();
+  for (let i = 0; i < 100; i++) {
+    values.add(rng.random());
+  }
+  assert(
+    values.size > 90,
+    `Expected diversity, got ${values.size} unique values`,
+  );
+});
+
+Deno.test("SeededRng: uniform distribution (chi-squared)", () => {
+  const rng = createSeededRng(42);
+  const buckets = 10;
+  const counts = new Array(buckets).fill(0);
+  const n = 10000;
+
+  for (let i = 0; i < n; i++) {
+    const bucket = Math.min(Math.floor(rng.random() * buckets), buckets - 1);
+    counts[bucket]++;
+  }
+
+  // Chi-squared test: expected count per bucket = n / buckets
+  const expected = n / buckets;
+  let chiSquared = 0;
+  for (let i = 0; i < buckets; i++) {
+    chiSquared += (counts[i] - expected) ** 2 / expected;
+  }
+
+  // Critical value for 9 degrees of freedom at p=0.01 is ~21.67
+  assert(
+    chiSquared < 25,
+    `Chi-squared ${chiSquared} too high (distribution not uniform)`,
+  );
+});
+
+Deno.test("SeededRng: randomInt min equals max", () => {
+  const rng = createSeededRng(1);
+  for (let i = 0; i < 10; i++) {
+    assertEquals(rng.randomInt(5, 5), 5);
+  }
+});
+
+Deno.test("SeededRng: choice with single element", () => {
+  const rng = createSeededRng(1);
+  assertEquals(rng.choice(["only"]), "only");
+});
+
+Deno.test("Global RNG: default is unseeded", () => {
+  // Reset to default
+  const rng = createUnseededRng();
+  setRandomNumberGenerator(rng);
+  assertEquals(getRandomNumberGenerator().seeded, false);
+});
+
+Deno.test("SeededRng: interleaved operations are reproducible", () => {
+  const items = ["a", "b", "c", "d"];
+
+  function runSequence(rng: RandomNumberGenerator): string[] {
+    const results: string[] = [];
+    results.push(String(rng.random()));
+    results.push(String(rng.randomInt(0, 100)));
+    results.push(rng.choice(items));
+    results.push(String(rng.random()));
+    results.push(String(rng.randomInt(-10, 10)));
+    results.push(rng.choice(items));
+    return results;
+  }
+
+  const seq1 = runSequence(createSeededRng(42));
+  const seq2 = runSequence(createSeededRng(42));
+  assertEquals(seq1, seq2);
+});


### PR DESCRIPTION
## Summary
- Replaced all ~79 `Math.random()` calls across 38 production files with an injectable, seedable xoshiro256** PRNG
- Pass `seed` in NeatOptions for deterministic evolution runs, or inject a custom `rng` instance
- Unseeded behaviour backed by `Math.random()` preserved by default for backward compatibility

Closes #1400

## What Changed
- **New**: `src/utils/RandomNumberGenerator.ts` — `RandomNumberGenerator` interface, `SeededRng` (xoshiro256**), `UnseededRng`, global get/set, factories
- **Config**: `seed?: number` and `rng?: RandomNumberGenerator` added to NeatOptions/NeatOptionsInput/NeatArguments
- **38 files**: Every `Math.random()` replaced with `getRandomNumberGenerator().random()`
- **Exports**: `createSeededRng`, `createUnseededRng`, `getRandomNumberGenerator`, `setRandomNumberGenerator`, `RandomNumberGenerator` type

## Test plan
- [x] 21 unit tests for RNG (reproducibility, uniformity, edge cases)
- [x] 10 integration tests for config seed parsing and deterministic mutation
- [x] Full suite: 2822 tests pass, 0 failures
- [x] `deno check`, `deno fmt --check`, `deno lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)