### PR TITLE
Improve: Add error types for Discovery and WASM failures (#1404)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.311.2",
+  "version": "0.311.3",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1404.md
+++ b/docs/pr-summary-1404.md
@@ -1,40 +1,41 @@
 ## Summary
 
 Add typed error classes `DiscoveryError` and `WasmError` so consumers can catch
-and handle specific failure modes programmatically. Previously the codebase threw
-generic `Error` instances for discovery FFI failures, data corruption, invalid
-creatures, WASM module loading, and activation failures. Closes #1404.
+and handle specific failure modes programmatically. Previously the codebase
+threw generic `Error` instances for discovery FFI failures, data corruption,
+invalid creatures, WASM module loading, and activation failures. Closes #1404.
 
 ### DiscoveryError
 
 Replaces generic `Error` in discovery/FFI code with a typed error carrying a
 `reason` field:
 
-| Reason             | Usage                                          |
-|--------------------|------------------------------------------------|
-| LIBRARY_NOT_FOUND  | Rust FFI library not at expected path          |
-| GPU_UNAVAILABLE    | Metal/GPU compute not available                |
-| FFI_CRASH          | Library could not be loaded or permission denied |
-| TIMEOUT            | Discovery operation timed out                  |
-| DATA_CORRUPTION    | Neuron error counts exceed reasonable maximums |
-| INVALID_CREATURE   | Discovery produced an invalid creature         |
+| Reason            | Usage                                            |
+| ----------------- | ------------------------------------------------ |
+| LIBRARY_NOT_FOUND | Rust FFI library not at expected path            |
+| GPU_UNAVAILABLE   | Metal/GPU compute not available                  |
+| FFI_CRASH         | Library could not be loaded or permission denied |
+| TIMEOUT           | Discovery operation timed out                    |
+| DATA_CORRUPTION   | Neuron error counts exceed reasonable maximums   |
+| INVALID_CREATURE  | Discovery produced an invalid creature           |
 
 ### WasmError
 
 Replaces generic `Error` in WASM activation code with a typed error carrying a
 `reason` field:
 
-| Reason             | Usage                                          |
-|--------------------|------------------------------------------------|
-| COMPILATION_FAILED | WASM module failed to compile                  |
-| ACTIVATION_FAILED  | Squash function not defined in WASM            |
-| MODULE_NOT_LOADED  | WASM not initialised                           |
+| Reason             | Usage                               |
+| ------------------ | ----------------------------------- |
+| COMPILATION_FAILED | WASM module failed to compile       |
+| ACTIVATION_FAILED  | Squash function not defined in WASM |
+| MODULE_NOT_LOADED  | WASM not initialised                |
 
 ### Files changed
 
 - `src/errors/DiscoveryError.ts` - New typed error class
 - `src/errors/WasmError.ts` - New typed error class
-- `src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts` - Use `DiscoveryError`
+- `src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts` - Use
+  `DiscoveryError`
 - `src/discovery/DiscoveryPostValidate.ts` - Use `DiscoveryError`
 - `src/wasm/WasmActivation.ts` - Use `WasmError` for module-not-loaded checks
 - `src/wasm/ActivationMethods.ts` - Use `WasmError` for squash function errors
@@ -49,7 +50,8 @@ tests continue to pass, plus 16 new error type tests verify the behaviour.
 
 - `test/errors/DiscoveryError.ts` - 9 tests covering all reason values,
   `instanceof` checks, and selective catching
-- `test/errors/WasmError.ts` - 7 tests covering all reason values,
-  `instanceof` checks, and selective catching
-- Existing tests in `test/ErrorGuidedStructuralEvolution/RustDiscoveryErrorValidation.ts`
-  continue to pass (they catch `Error`, which `DiscoveryError` extends)
+- `test/errors/WasmError.ts` - 7 tests covering all reason values, `instanceof`
+  checks, and selective catching
+- Existing tests in
+  `test/ErrorGuidedStructuralEvolution/RustDiscoveryErrorValidation.ts` continue
+  to pass (they catch `Error`, which `DiscoveryError` extends)

--- a/docs/pr-summary-1404.md
+++ b/docs/pr-summary-1404.md
@@ -1,0 +1,55 @@
+## Summary
+
+Add typed error classes `DiscoveryError` and `WasmError` so consumers can catch
+and handle specific failure modes programmatically. Previously the codebase threw
+generic `Error` instances for discovery FFI failures, data corruption, invalid
+creatures, WASM module loading, and activation failures. Closes #1404.
+
+### DiscoveryError
+
+Replaces generic `Error` in discovery/FFI code with a typed error carrying a
+`reason` field:
+
+| Reason             | Usage                                          |
+|--------------------|------------------------------------------------|
+| LIBRARY_NOT_FOUND  | Rust FFI library not at expected path          |
+| GPU_UNAVAILABLE    | Metal/GPU compute not available                |
+| FFI_CRASH          | Library could not be loaded or permission denied |
+| TIMEOUT            | Discovery operation timed out                  |
+| DATA_CORRUPTION    | Neuron error counts exceed reasonable maximums |
+| INVALID_CREATURE   | Discovery produced an invalid creature         |
+
+### WasmError
+
+Replaces generic `Error` in WASM activation code with a typed error carrying a
+`reason` field:
+
+| Reason             | Usage                                          |
+|--------------------|------------------------------------------------|
+| COMPILATION_FAILED | WASM module failed to compile                  |
+| ACTIVATION_FAILED  | Squash function not defined in WASM            |
+| MODULE_NOT_LOADED  | WASM not initialised                           |
+
+### Files changed
+
+- `src/errors/DiscoveryError.ts` - New typed error class
+- `src/errors/WasmError.ts` - New typed error class
+- `src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts` - Use `DiscoveryError`
+- `src/discovery/DiscoveryPostValidate.ts` - Use `DiscoveryError`
+- `src/wasm/WasmActivation.ts` - Use `WasmError` for module-not-loaded checks
+- `src/wasm/ActivationMethods.ts` - Use `WasmError` for squash function errors
+- `src/wasm/EnsureWasmActivation.ts` - Use `WasmError` for load failures
+
+## Evidence
+
+This is a backend/type-system change with no visual output. All 2882 existing
+tests continue to pass, plus 16 new error type tests verify the behaviour.
+
+## Test Plan
+
+- `test/errors/DiscoveryError.ts` - 9 tests covering all reason values,
+  `instanceof` checks, and selective catching
+- `test/errors/WasmError.ts` - 7 tests covering all reason values,
+  `instanceof` checks, and selective catching
+- Existing tests in `test/ErrorGuidedStructuralEvolution/RustDiscoveryErrorValidation.ts`
+  continue to pass (they catch `Error`, which `DiscoveryError` extends)

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
@@ -14,6 +14,7 @@
 import { assert } from "@std/assert";
 import { fromFileUrl } from "@std/path/from-file-url";
 import { join } from "@std/path/join";
+import { DiscoveryError } from "../../errors/DiscoveryError.ts";
 import { getLogger } from "../../utils/Logger.ts";
 
 const MAX_C_STRING_BYTES = 128 * 1024 * 1024; // 128 MiB guard for FFI strings
@@ -603,10 +604,11 @@ export function computeRustRecordStats(
           `Errors array sample (first 10):`,
           errors.slice(0, 10),
         );
-        throw new Error(
+        throw new DiscoveryError(
           `Data corruption detected: neuron ${uuid} has ${errorCount} errors, ` +
             `which far exceeds reasonable maximum (${maxReasonableErrorsPerNeuron}). ` +
             `With ${sampleCount} samples and ${outputCount} outputs, this is impossible and indicates a bug in error recording.`,
+          "DATA_CORRUPTION",
         );
       }
 
@@ -649,9 +651,10 @@ export function computeRustRecordStats(
     getLogger().error(
       `Max reasonable per record: ${maxReasonableErrorsPerRecord}`,
     );
-    throw new Error(
+    throw new DiscoveryError(
       `Data corruption detected: ${totalErrorValues} total error values for ${totalNeuronRecords} neuron records ` +
         `(max ${maxReasonableErrors}). This suggests a critical bug in the error accumulation logic.`,
+      "DATA_CORRUPTION",
     );
   }
 
@@ -1213,9 +1216,10 @@ export function assertRustDiscoveryAvailable(): void {
   const exists = rustLibraryExists();
 
   if (!exists) {
-    throw new Error(
+    throw new DiscoveryError(
       "Rust discovery library not available: Library file not found. " +
         "Install it into ~/.cargo/lib or set NEAT_AI_DISCOVERY_LIB_PATH environment variable.",
+      "LIBRARY_NOT_FOUND",
     );
   }
 
@@ -1229,14 +1233,15 @@ export function assertRustDiscoveryAvailable(): void {
           path: libPath,
         });
         if (permission.state !== "granted") {
-          throw new Error(
+          throw new DiscoveryError(
             "Rust discovery library not available: FFI permission denied. " +
               "Run with --allow-ffi flag to enable discovery.",
+            "FFI_CRASH",
           );
         }
       }
     } catch (error) {
-      if (error instanceof Error && error.message.includes("FFI permission")) {
+      if (error instanceof DiscoveryError) {
         throw error;
       }
       // Permission check failed, but might be for other reasons
@@ -1244,9 +1249,10 @@ export function assertRustDiscoveryAvailable(): void {
   }
 
   // Library exists and FFI is allowed, but still not enabled
-  throw new Error(
+  throw new DiscoveryError(
     "Rust discovery library not available: Library found but could not be loaded. " +
       "Rebuild the library via the NEAT-AI-Discovery project.",
+    "FFI_CRASH",
   );
 }
 

--- a/src/discovery/DiscoveryPostValidate.ts
+++ b/src/discovery/DiscoveryPostValidate.ts
@@ -1,5 +1,6 @@
 import type { Creature } from "../Creature.ts";
 import { creatureValidate } from "../architecture/CreatureValidate.ts";
+import { DiscoveryError } from "../errors/DiscoveryError.ts";
 import { getMajorVersion } from "../upgrade/Upgrade.ts";
 import type { DiscoveryCandidate } from "./DiscoveryCandidates.ts";
 import {
@@ -96,7 +97,7 @@ export function validateAfterDiscoveryOrThrow(args: {
       ? ` Violations(sample up to 10): ${violations.join(" | ")}`
       : "";
 
-    throw new Error(
+    throw new DiscoveryError(
       `[Discovery ${discoveryID}] CRITICAL: discovery operation '${operation}' produced an invalid creature. ` +
         `base=${
           baseCreature.uuid ?? "unknown"
@@ -110,6 +111,7 @@ export function validateAfterDiscoveryOrThrow(args: {
         }), ` +
         `hardInvariant=${isHardForwardOnlyInvariant}, attemptedRepair=${shouldAttemptForwardOnlyRepair}. ` +
         `Error=${error.name}: ${error.message}.${detail}`,
+      "INVALID_CREATURE",
     );
   }
 }

--- a/src/errors/DiscoveryError.ts
+++ b/src/errors/DiscoveryError.ts
@@ -1,0 +1,26 @@
+/**
+ * Typed error for discovery/FFI failures.
+ *
+ * Consumers can catch `DiscoveryError` and inspect `reason` to handle
+ * specific failure modes programmatically.
+ *
+ * @module DiscoveryError
+ */
+
+export type DiscoveryErrorReason =
+  | "LIBRARY_NOT_FOUND"
+  | "GPU_UNAVAILABLE"
+  | "FFI_CRASH"
+  | "TIMEOUT"
+  | "DATA_CORRUPTION"
+  | "INVALID_CREATURE";
+
+export class DiscoveryError extends Error {
+  override readonly name = "DiscoveryError";
+  readonly reason: DiscoveryErrorReason;
+
+  constructor(message: string, reason: DiscoveryErrorReason) {
+    super(message);
+    this.reason = reason;
+  }
+}

--- a/src/errors/WasmError.ts
+++ b/src/errors/WasmError.ts
@@ -1,0 +1,23 @@
+/**
+ * Typed error for WASM activation failures.
+ *
+ * Consumers can catch `WasmError` and inspect `reason` to handle
+ * specific failure modes programmatically.
+ *
+ * @module WasmError
+ */
+
+export type WasmErrorReason =
+  | "COMPILATION_FAILED"
+  | "ACTIVATION_FAILED"
+  | "MODULE_NOT_LOADED";
+
+export class WasmError extends Error {
+  override readonly name = "WasmError";
+  readonly reason: WasmErrorReason;
+
+  constructor(message: string, reason: WasmErrorReason) {
+    super(message);
+    this.reason = reason;
+  }
+}

--- a/src/wasm/ActivationMethods.ts
+++ b/src/wasm/ActivationMethods.ts
@@ -11,6 +11,7 @@
  * WASM must always be available and all squash functions must be defined in WASM.
  */
 
+import { WasmError } from "../errors/WasmError.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
 import { Activations } from "../methods/activations/Activations.ts";
 import { hasUnSquash } from "../methods/activations/TypeGuards.ts";
@@ -54,8 +55,9 @@ export function calculateError(
 ): number {
   const resolvedName = resolveWasmSquashName(squashName);
   if (resolvedName === undefined) {
-    throw new Error(
+    throw new WasmError(
       `Squash function '${squashName}' is not defined in WASM. All squash functions must be implemented in Rust/WASM.`,
+      "ACTIVATION_FAILED",
     );
   }
   const squashType = getSquashType(resolvedName);
@@ -85,8 +87,9 @@ export function safeZoneAdjustment(
 ): number {
   const resolvedName = resolveWasmSquashName(squashName);
   if (resolvedName === undefined) {
-    throw new Error(
+    throw new WasmError(
       `Squash function '${squashName}' is not defined in WASM. All squash functions must be implemented in Rust/WASM.`,
+      "ACTIVATION_FAILED",
     );
   }
   const squashType = getSquashType(resolvedName);
@@ -142,8 +145,9 @@ export function unSquash(
 
   const resolvedName = resolveWasmSquashName(squashName);
   if (resolvedName === undefined) {
-    throw new Error(
+    throw new WasmError(
       `Squash function '${squashName}' is not defined in WASM. All squash functions must be implemented in Rust/WASM.`,
+      "ACTIVATION_FAILED",
     );
   }
   const squashType = getSquashType(resolvedName);
@@ -170,8 +174,9 @@ export function squash(
 
   const resolvedName = resolveWasmSquashName(squashName);
   if (resolvedName === undefined) {
-    throw new Error(
+    throw new WasmError(
       `Squash function '${squashName}' is not defined in WASM. All squash functions must be implemented in Rust/WASM.`,
+      "ACTIVATION_FAILED",
     );
   }
   const squashType = getSquashType(resolvedName);

--- a/src/wasm/EnsureWasmActivation.ts
+++ b/src/wasm/EnsureWasmActivation.ts
@@ -4,6 +4,7 @@
  * Ensures WASM activation is initialised before scoring/evaluation. Callers do not
  * call init APIs; the library initialises the backend automatically (Issue #1256).
  */
+import { WasmError } from "../errors/WasmError.ts";
 import { initWasmActivation, isWasmActivationAvailable } from "./mod.ts";
 
 /**
@@ -22,9 +23,10 @@ export async function ensureWasmActivation(): Promise<void> {
   const success = await initWasmActivation();
 
   if (!success || !isWasmActivationAvailable()) {
-    throw new Error(
+    throw new WasmError(
       "WASM activation could not be loaded. Ensure the NEAT-AI package is installed correctly. " +
         "WASM activation is required.",
+      "MODULE_NOT_LOADED",
     );
   }
 }

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Creature } from "../Creature.ts";
+import { WasmError } from "../errors/WasmError.ts";
 import { getLogger } from "../utils/Logger.ts";
 import {
   compileCreatureToWasm,
@@ -774,7 +775,7 @@ export class WasmCreatureActivation {
       throw new Error("WasmCreatureActivation has been freed");
     }
     if (!mseSumBatchPackedFn) {
-      throw new Error("WASM module not initialised");
+      throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
     }
     return mseSumBatchPackedFn(
       this.network,
@@ -799,7 +800,7 @@ export class WasmCreatureActivation {
       throw new Error("WasmCreatureActivation has been freed");
     }
     if (!maeSumBatchPackedFn) {
-      throw new Error("WASM module not initialised");
+      throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
     }
     return maeSumBatchPackedFn(
       this.network,
@@ -824,7 +825,7 @@ export class WasmCreatureActivation {
       throw new Error("WasmCreatureActivation has been freed");
     }
     if (!crossEntropySumBatchPackedFn) {
-      throw new Error("WASM module not initialised");
+      throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
     }
     return crossEntropySumBatchPackedFn(
       this.network,
@@ -849,7 +850,7 @@ export class WasmCreatureActivation {
       throw new Error("WasmCreatureActivation has been freed");
     }
     if (!mapeSumBatchPackedFn) {
-      throw new Error("WASM module not initialised");
+      throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
     }
     return mapeSumBatchPackedFn(
       this.network,
@@ -875,7 +876,7 @@ export class WasmCreatureActivation {
       throw new Error("WasmCreatureActivation has been freed");
     }
     if (!msleSumBatchPackedFn) {
-      throw new Error("WASM module not initialised");
+      throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
     }
     return msleSumBatchPackedFn(
       this.network,
@@ -901,7 +902,7 @@ export class WasmCreatureActivation {
       throw new Error("WasmCreatureActivation has been freed");
     }
     if (!hingeSumBatchPackedFn) {
-      throw new Error("WASM module not initialised");
+      throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
     }
     return hingeSumBatchPackedFn(
       this.network,
@@ -968,7 +969,7 @@ export class WasmCreatureActivation {
  */
 export function wasmSquash(squashType: number, value: number): number {
   if (!squashFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   return squashFn(squashType, value);
 }
@@ -985,7 +986,7 @@ export function wasmSquash(squashType: number, value: number): number {
  */
 export function wasmDerivative(squashType: number, value: number): number {
   if (!derivativeFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   return derivativeFn(squashType, value);
 }
@@ -1011,7 +1012,7 @@ export function wasmUnSquash(
   hint?: number,
 ): number {
   if (!unsquashFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   // Use NaN as the hint when not provided, WASM will check for is_finite
   return unsquashFn(squashType, activation, hint ?? Number.NaN);
@@ -1041,7 +1042,7 @@ export function wasmSafeZoneAdjustment(
   weight?: number,
 ): number {
   if (!safeZoneAdjustmentFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   // Use NaN as the weight when not provided, WASM will check for is_finite
   // and default to 1.0
@@ -1073,7 +1074,7 @@ export function wasmSafeZoneAdjustmentBatch(
   weights: Float32Array,
 ): Float32Array {
   if (!safeZoneAdjustmentBatchFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   return safeZoneAdjustmentBatchFn(squashTypes, rawInputs, error, weights);
 }
@@ -1105,7 +1106,7 @@ export function wasmCalculateError(
   currentValue: number,
 ): number {
   if (!calculateErrorFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   return calculateErrorFn(
     squashType,
@@ -1154,7 +1155,7 @@ export function wasmFusedErrorDistribution(
   synapseWeights: Float32Array,
 ): FusedErrorDistributionResult {
   if (!fusedErrorDistributionFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   const flat = fusedErrorDistributionFn(
     neuronSquashType,
@@ -1190,7 +1191,7 @@ export interface WasmActivationRange {
  */
 export function wasmGetRange(squashType: number): WasmActivationRange {
   if (!getRangeFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   const arr = getRangeFn(squashType);
   return { low: arr[0], high: arr[1] };
@@ -1204,7 +1205,7 @@ export function wasmValidateRange(
   activation: number,
 ): boolean {
   if (!validateRangeFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   return validateRangeFn(squashType, activation);
 }
@@ -1214,7 +1215,7 @@ export function wasmValidateRange(
  */
 export function wasmLimitRange(squashType: number, value: number): number {
   if (!limitRangeFn) {
-    throw new Error("WASM module not initialised");
+    throw new WasmError("WASM module not initialised", "MODULE_NOT_LOADED");
   }
   return limitRangeFn(squashType, value);
 }

--- a/test/errors/DiscoveryError.ts
+++ b/test/errors/DiscoveryError.ts
@@ -1,0 +1,92 @@
+import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import {
+  DiscoveryError,
+  type DiscoveryErrorReason,
+} from "../../src/errors/DiscoveryError.ts";
+
+Deno.test("DiscoveryError - LIBRARY_NOT_FOUND reason", () => {
+  const error = new DiscoveryError(
+    "Rust library not found",
+    "LIBRARY_NOT_FOUND",
+  );
+  assertIsError(error, DiscoveryError);
+  assertEquals(error.message, "Rust library not found");
+  assertEquals(error.reason, "LIBRARY_NOT_FOUND");
+  assertEquals(error.name, "DiscoveryError");
+});
+
+Deno.test("DiscoveryError - GPU_UNAVAILABLE reason", () => {
+  const error = new DiscoveryError(
+    "Metal/GPU compute not available",
+    "GPU_UNAVAILABLE",
+  );
+  assertIsError(error, DiscoveryError);
+  assertEquals(error.reason, "GPU_UNAVAILABLE");
+});
+
+Deno.test("DiscoveryError - FFI_CRASH reason", () => {
+  const error = new DiscoveryError(
+    "Library returned unexpected exit code",
+    "FFI_CRASH",
+  );
+  assertIsError(error, DiscoveryError);
+  assertEquals(error.reason, "FFI_CRASH");
+});
+
+Deno.test("DiscoveryError - TIMEOUT reason", () => {
+  const error = new DiscoveryError(
+    "Discovery operation timed out",
+    "TIMEOUT",
+  );
+  assertIsError(error, DiscoveryError);
+  assertEquals(error.reason, "TIMEOUT");
+});
+
+Deno.test("DiscoveryError - DATA_CORRUPTION reason", () => {
+  const error = new DiscoveryError(
+    "Neuron error counts exceed reasonable maximum",
+    "DATA_CORRUPTION",
+  );
+  assertIsError(error, DiscoveryError);
+  assertEquals(error.reason, "DATA_CORRUPTION");
+});
+
+Deno.test("DiscoveryError - INVALID_CREATURE reason", () => {
+  const error = new DiscoveryError(
+    "Discovery operation produced an invalid creature",
+    "INVALID_CREATURE",
+  );
+  assertIsError(error, DiscoveryError);
+  assertEquals(error.reason, "INVALID_CREATURE");
+});
+
+Deno.test("DiscoveryError - is instanceof Error", () => {
+  const error = new DiscoveryError("test", "LIBRARY_NOT_FOUND");
+  assert(error instanceof Error);
+  assert(error instanceof DiscoveryError);
+});
+
+Deno.test("DiscoveryError - can be caught selectively", () => {
+  const fn = () => {
+    throw new DiscoveryError("lib not found", "LIBRARY_NOT_FOUND");
+  };
+
+  assertThrows(fn, DiscoveryError);
+});
+
+Deno.test("DiscoveryError - reason is typed", () => {
+  // Verify all expected reason values are valid
+  const reasons: DiscoveryErrorReason[] = [
+    "LIBRARY_NOT_FOUND",
+    "GPU_UNAVAILABLE",
+    "FFI_CRASH",
+    "TIMEOUT",
+    "DATA_CORRUPTION",
+    "INVALID_CREATURE",
+  ];
+
+  for (const reason of reasons) {
+    const error = new DiscoveryError(`test: ${reason}`, reason);
+    assertEquals(error.reason, reason);
+  }
+});

--- a/test/errors/WasmError.ts
+++ b/test/errors/WasmError.ts
@@ -1,0 +1,71 @@
+import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import { WasmError, type WasmErrorReason } from "../../src/errors/WasmError.ts";
+
+Deno.test("WasmError - COMPILATION_FAILED reason", () => {
+  const error = new WasmError(
+    "WASM module failed to compile",
+    "COMPILATION_FAILED",
+  );
+  assertIsError(error, WasmError);
+  assertEquals(error.message, "WASM module failed to compile");
+  assertEquals(error.reason, "COMPILATION_FAILED");
+  assertEquals(error.name, "WasmError");
+});
+
+Deno.test("WasmError - ACTIVATION_FAILED reason", () => {
+  const error = new WasmError(
+    "Activation function returned NaN",
+    "ACTIVATION_FAILED",
+  );
+  assertIsError(error, WasmError);
+  assertEquals(error.reason, "ACTIVATION_FAILED");
+});
+
+Deno.test("WasmError - MODULE_NOT_LOADED reason", () => {
+  const error = new WasmError(
+    "WASM not initialised",
+    "MODULE_NOT_LOADED",
+  );
+  assertIsError(error, WasmError);
+  assertEquals(error.reason, "MODULE_NOT_LOADED");
+});
+
+Deno.test("WasmError - is instanceof Error", () => {
+  const error = new WasmError("test", "MODULE_NOT_LOADED");
+  assert(error instanceof Error);
+  assert(error instanceof WasmError);
+});
+
+Deno.test("WasmError - can be caught selectively", () => {
+  const fn = () => {
+    throw new WasmError("module not loaded", "MODULE_NOT_LOADED");
+  };
+
+  assertThrows(fn, WasmError);
+});
+
+Deno.test("WasmError - reason is typed", () => {
+  // Verify all expected reason values are valid
+  const reasons: WasmErrorReason[] = [
+    "COMPILATION_FAILED",
+    "ACTIVATION_FAILED",
+    "MODULE_NOT_LOADED",
+  ];
+
+  for (const reason of reasons) {
+    const error = new WasmError(`test: ${reason}`, reason);
+    assertEquals(error.reason, reason);
+  }
+});
+
+Deno.test("WasmError - distinguishable from generic Error", () => {
+  try {
+    throw new WasmError("not loaded", "MODULE_NOT_LOADED");
+  } catch (e) {
+    if (e instanceof WasmError) {
+      assertEquals(e.reason, "MODULE_NOT_LOADED");
+    } else {
+      throw new Error("Expected WasmError instance");
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Add typed error classes `DiscoveryError` and `WasmError` so consumers can catch
and handle specific failure modes programmatically. Previously the codebase threw
generic `Error` instances for discovery FFI failures, data corruption, invalid
creatures, WASM module loading, and activation failures. Closes #1404.

### DiscoveryError

Replaces generic `Error` in discovery/FFI code with a typed error carrying a
`reason` field:

| Reason             | Usage                                          |
|--------------------|------------------------------------------------|
| LIBRARY_NOT_FOUND  | Rust FFI library not at expected path          |
| GPU_UNAVAILABLE    | Metal/GPU compute not available                |
| FFI_CRASH          | Library could not be loaded or permission denied |
| TIMEOUT            | Discovery operation timed out                  |
| DATA_CORRUPTION    | Neuron error counts exceed reasonable maximums |
| INVALID_CREATURE   | Discovery produced an invalid creature         |

### WasmError

Replaces generic `Error` in WASM activation code with a typed error carrying a
`reason` field:

| Reason             | Usage                                          |
|--------------------|------------------------------------------------|
| COMPILATION_FAILED | WASM module failed to compile                  |
| ACTIVATION_FAILED  | Squash function not defined in WASM            |
| MODULE_NOT_LOADED  | WASM not initialised                           |

### Files changed

- `src/errors/DiscoveryError.ts` - New typed error class
- `src/errors/WasmError.ts` - New typed error class
- `src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts` - Use `DiscoveryError`
- `src/discovery/DiscoveryPostValidate.ts` - Use `DiscoveryError`
- `src/wasm/WasmActivation.ts` - Use `WasmError` for module-not-loaded checks
- `src/wasm/ActivationMethods.ts` - Use `WasmError` for squash function errors
- `src/wasm/EnsureWasmActivation.ts` - Use `WasmError` for load failures

## Evidence

This is a backend/type-system change with no visual output. All 2882 existing
tests continue to pass, plus 16 new error type tests verify the behaviour.

## Test Plan

- `test/errors/DiscoveryError.ts` - 9 tests covering all reason values,
  `instanceof` checks, and selective catching
- `test/errors/WasmError.ts` - 7 tests covering all reason values,
  `instanceof` checks, and selective catching
- Existing tests in `test/ErrorGuidedStructuralEvolution/RustDiscoveryErrorValidation.ts`
  continue to pass (they catch `Error`, which `DiscoveryError` extends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)