### PR TITLE
Test: Add structured-clone safety tests for worker payloads (#1428)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.311.4",
+  "version": "0.311.5",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -209,6 +209,9 @@
     "xoshiro",
     "rotl",
     "deserialising",
-    "rustup"
+    "rustup",
+    "cloneable",
+    "cloneability",
+    "Cloneability"
   ]
 }

--- a/docs/pr-summary-1428.md
+++ b/docs/pr-summary-1428.md
@@ -1,0 +1,59 @@
+## Summary
+
+Investigate why the DataCloneError in WorkerHandler.discover() was not caught by
+tests, and add covering tests. Closes #1428.
+
+### Root Cause Analysis
+
+The DataCloneError occurred when `NeatConfig` (containing `logger` and `rng`
+function properties) was posted to a worker via `postMessage()`. The structured
+clone algorithm cannot serialise functions, causing a runtime crash.
+
+**Why tests missed it:** The `MockWorker` class bypassed the structured clone
+constraint entirely. Its `postMessage()` method accepted the data object directly
+in-process without going through the structured clone algorithm that real
+`Worker.postMessage()` uses. This meant any test using `MockWorker` (i.e. all
+worker tests running with `direct: true`) would silently accept non-cloneable
+payloads that would fail in production.
+
+### Changes
+
+1. **`MockWorker.postMessage()` now validates cloneability** - Added a
+   `structuredClone(data)` call at the top of `MockWorker.postMessage()` so it
+   mirrors the behaviour of a real Worker. Any future non-cloneable payload will
+   fail immediately in tests rather than silently passing.
+
+2. **New test file: `test/multithreading/WorkerPayloadCloneability.ts`** -
+   Five focused tests that verify:
+   - Raw `NeatConfig` with `logger`/`rng` functions **cannot** be structured-cloned
+   - Sanitised config (with `logger`/`rng` stripped) **can** be structured-cloned
+   - Full discovery `RequestData` with sanitised config survives `structuredClone`
+   - Full discovery `RequestData` with unsanitised config **fails** `structuredClone`
+   - All other `RequestData` variants (echo, evaluate, train, breed, initialise)
+     are structured-clone safe
+
+### Test Audit
+
+Audited the existing worker test suite (`test/Worker.ts`,
+`test/multithreading/WorkerPool.ts`, `test/multithreading/WorkStealingQueue.ts`).
+No mock/fake tests that grep source code for patterns were found. All existing
+tests exercise real code with test data and assert on outcomes. The one gap was
+that `MockWorker` didn't enforce the structured clone constraint - now fixed.
+
+## Evidence
+
+This is a backend/test-only change with no UI impact. Evidence is the test output:
+
+- All 2887 tests pass (including the 5 new tests)
+- `./quality.sh` passes cleanly (fmt, lint, type-check, all tests)
+
+## Test Plan
+
+- Added `test/multithreading/WorkerPayloadCloneability.ts` with 5 tests:
+  - `NeatConfig with logger and rng cannot be structured-cloned`
+  - `sanitised NeatConfig without logger/rng can be structured-cloned`
+  - `discovery RequestData with sanitised config can be structured-cloned`
+  - `discovery RequestData with unsanitised config fails structuredClone`
+  - `all non-discover RequestData variants are structured-clone safe`
+- Enhanced `MockWorker.postMessage()` to validate structured-clone safety,
+  which provides ongoing regression protection for all worker tests

--- a/docs/pr-summary-1428.md
+++ b/docs/pr-summary-1428.md
@@ -10,11 +10,11 @@ function properties) was posted to a worker via `postMessage()`. The structured
 clone algorithm cannot serialise functions, causing a runtime crash.
 
 **Why tests missed it:** The `MockWorker` class bypassed the structured clone
-constraint entirely. Its `postMessage()` method accepted the data object directly
-in-process without going through the structured clone algorithm that real
-`Worker.postMessage()` uses. This meant any test using `MockWorker` (i.e. all
-worker tests running with `direct: true`) would silently accept non-cloneable
-payloads that would fail in production.
+constraint entirely. Its `postMessage()` method accepted the data object
+directly in-process without going through the structured clone algorithm that
+real `Worker.postMessage()` uses. This meant any test using `MockWorker` (i.e.
+all worker tests running with `direct: true`) would silently accept
+non-cloneable payloads that would fail in production.
 
 ### Changes
 
@@ -23,26 +23,32 @@ payloads that would fail in production.
    mirrors the behaviour of a real Worker. Any future non-cloneable payload will
    fail immediately in tests rather than silently passing.
 
-2. **New test file: `test/multithreading/WorkerPayloadCloneability.ts`** -
-   Five focused tests that verify:
-   - Raw `NeatConfig` with `logger`/`rng` functions **cannot** be structured-cloned
-   - Sanitised config (with `logger`/`rng` stripped) **can** be structured-cloned
-   - Full discovery `RequestData` with sanitised config survives `structuredClone`
-   - Full discovery `RequestData` with unsanitised config **fails** `structuredClone`
+2. **New test file: `test/multithreading/WorkerPayloadCloneability.ts`** - Five
+   focused tests that verify:
+   - Raw `NeatConfig` with `logger`/`rng` functions **cannot** be
+     structured-cloned
+   - Sanitised config (with `logger`/`rng` stripped) **can** be
+     structured-cloned
+   - Full discovery `RequestData` with sanitised config survives
+     `structuredClone`
+   - Full discovery `RequestData` with unsanitised config **fails**
+     `structuredClone`
    - All other `RequestData` variants (echo, evaluate, train, breed, initialise)
      are structured-clone safe
 
 ### Test Audit
 
 Audited the existing worker test suite (`test/Worker.ts`,
-`test/multithreading/WorkerPool.ts`, `test/multithreading/WorkStealingQueue.ts`).
-No mock/fake tests that grep source code for patterns were found. All existing
-tests exercise real code with test data and assert on outcomes. The one gap was
-that `MockWorker` didn't enforce the structured clone constraint - now fixed.
+`test/multithreading/WorkerPool.ts`,
+`test/multithreading/WorkStealingQueue.ts`). No mock/fake tests that grep source
+code for patterns were found. All existing tests exercise real code with test
+data and assert on outcomes. The one gap was that `MockWorker` didn't enforce
+the structured clone constraint - now fixed.
 
 ## Evidence
 
-This is a backend/test-only change with no UI impact. Evidence is the test output:
+This is a backend/test-only change with no UI impact. Evidence is the test
+output:
 
 - All 2887 tests pass (including the 5 new tests)
 - `./quality.sh` passes cleanly (fmt, lint, type-check, all tests)
@@ -55,5 +61,5 @@ This is a backend/test-only change with no UI impact. Evidence is the test outpu
   - `discovery RequestData with sanitised config can be structured-cloned`
   - `discovery RequestData with unsanitised config fails structuredClone`
   - `all non-discover RequestData variants are structured-clone safe`
-- Enhanced `MockWorker.postMessage()` to validate structured-clone safety,
-  which provides ongoing regression protection for all worker tests
+- Enhanced `MockWorker.postMessage()` to validate structured-clone safety, which
+  provides ongoing regression protection for all worker tests

--- a/src/multithreading/workers/MockWorker.ts
+++ b/src/multithreading/workers/MockWorker.ts
@@ -20,6 +20,11 @@ export class MockWorker implements WorkerInterface {
 
   private processor = new WorkerProcessor();
   postMessage(data: RequestData, _transfer?: Transferable[]) {
+    // Issue #1428: Validate that the payload is structured-clone safe, just
+    // like a real Worker.postMessage() would. This catches non-cloneable data
+    // (functions, symbols, etc.) that would cause a DataCloneError in production.
+    structuredClone(data);
+
     this.processor.process(data).then((result) => {
       type MockEvent = Event & { data: ResponseData };
       const me = new Event("mock") as MockEvent;

--- a/test/multithreading/WorkerPayloadCloneability.ts
+++ b/test/multithreading/WorkerPayloadCloneability.ts
@@ -1,0 +1,190 @@
+/**
+ * Issue #1428: Verify that worker payloads are structured-clone safe.
+ *
+ * The DataCloneError occurred because NeatConfig contains non-cloneable
+ * properties (logger functions and RNG methods) that cannot survive the
+ * structured clone algorithm used by worker.postMessage().
+ *
+ * The fix in WorkerHandler.discover() strips logger and rng before posting.
+ * These tests ensure the sanitisation works and would catch any regression
+ * where non-cloneable data is sent to workers.
+ */
+import { assert, assertExists, assertThrows } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import type { NeatConfig } from "../../src/config/NeatConfig.ts";
+import type { RequestData } from "../../src/multithreading/workers/WorkerHandler.ts";
+
+/**
+ * Strips non-cloneable properties from a NeatConfig, mirroring the
+ * sanitisation logic in WorkerHandler.discover().
+ */
+function sanitiseConfigForWorker(config: NeatConfig): NeatConfig {
+  const configForWorker = { ...config } as Record<string, unknown>;
+  delete configForWorker.logger;
+  delete configForWorker.rng;
+  return configForWorker as NeatConfig;
+}
+
+Deno.test("NeatConfig with logger and rng cannot be structured-cloned", () => {
+  const config = createNeatConfig({ costName: "MSE" });
+
+  // The raw config contains function properties that are not cloneable
+  assertExists(config.logger, "config should have a logger");
+  assertExists(config.rng, "config should have an rng");
+  assert(
+    typeof config.logger.debug === "function",
+    "logger.debug should be a function",
+  );
+  assert(
+    typeof config.rng.random === "function",
+    "rng.random should be a function",
+  );
+
+  // structuredClone must reject an object containing functions
+  assertThrows(
+    () => structuredClone(config),
+    DOMException,
+    "could not be cloned",
+    "NeatConfig with functions should not be cloneable via structuredClone",
+  );
+});
+
+Deno.test("sanitised NeatConfig without logger/rng can be structured-cloned", () => {
+  const config = createNeatConfig({ costName: "MSE" });
+  const sanitised = sanitiseConfigForWorker(config);
+
+  // The sanitised config should not have logger or rng
+  assert(
+    !("logger" in sanitised),
+    "sanitised config should not have logger",
+  );
+  assert(
+    !("rng" in sanitised),
+    "sanitised config should not have rng",
+  );
+
+  // structuredClone must succeed on the sanitised config
+  // Cast to Record to avoid TS inference issues with Readonly + deleted keys
+  const cloned = structuredClone(
+    sanitised as unknown as Record<string, unknown>,
+  );
+  assertExists(cloned, "cloned config should exist");
+  assert(cloned.costName === "MSE", "cloned config should preserve costName");
+  assert(
+    cloned.populationSize === config.populationSize,
+    "cloned config should preserve populationSize",
+  );
+});
+
+Deno.test("discovery RequestData with sanitised config can be structured-cloned", () => {
+  const config = createNeatConfig({ costName: "MSE" });
+  const sanitised = sanitiseConfigForWorker(config);
+
+  // Build a discover RequestData payload identical to WorkerHandler.discover()
+  const data: RequestData = {
+    taskID: 1,
+    discover: {
+      creature: JSON.stringify({
+        neurons: [],
+        synapses: [],
+        input: 1,
+        output: 1,
+      }),
+      config: sanitised,
+    },
+  };
+
+  // The full payload must survive structuredClone (same as postMessage)
+  const cloned = structuredClone(data);
+  assertExists(cloned.discover, "cloned data should have discover field");
+  assert(
+    cloned.discover.config.costName === "MSE",
+    "cloned discover config should preserve costName",
+  );
+});
+
+Deno.test("discovery RequestData with unsanitised config fails structuredClone", () => {
+  const config = createNeatConfig({ costName: "MSE" });
+
+  // Build a discover RequestData with the raw (unsanitised) config
+  const data: RequestData = {
+    taskID: 1,
+    discover: {
+      creature: JSON.stringify({
+        neurons: [],
+        synapses: [],
+        input: 1,
+        output: 1,
+      }),
+      config: config,
+    },
+  };
+
+  // This must fail - the raw config contains functions
+  assertThrows(
+    () => structuredClone(data),
+    DOMException,
+    "could not be cloned",
+    "RequestData with unsanitised NeatConfig should not be cloneable",
+  );
+});
+
+Deno.test("all non-discover RequestData variants are structured-clone safe", () => {
+  // Verify that other RequestData types don't contain non-cloneable data
+
+  const echoData: RequestData = {
+    taskID: 1,
+    echo: { message: "test", ms: 10 },
+  };
+  assertExists(structuredClone(echoData), "echo payload should be cloneable");
+
+  const evaluateData: RequestData = {
+    taskID: 2,
+    evaluate: {
+      creature: JSON.stringify({ neurons: [], synapses: [] }),
+      feedbackLoop: false,
+    },
+  };
+  assertExists(
+    structuredClone(evaluateData),
+    "evaluate payload should be cloneable",
+  );
+
+  const trainData: RequestData = {
+    taskID: 3,
+    train: {
+      creature: JSON.stringify({ neurons: [], synapses: [] }),
+      options: { targetError: 0.05, iterations: 10 },
+    },
+  };
+  assertExists(
+    structuredClone(trainData),
+    "train payload should be cloneable",
+  );
+
+  const breedData: RequestData = {
+    taskID: 4,
+    breed: {
+      mother: JSON.stringify({ neurons: [], synapses: [] }),
+      father: JSON.stringify({ neurons: [], synapses: [] }),
+      geneticCompatibilityThreshold: 0.3,
+      forwardOnly: false,
+    },
+  };
+  assertExists(
+    structuredClone(breedData),
+    "breed payload should be cloneable",
+  );
+
+  const initData: RequestData = {
+    taskID: 5,
+    initialize: {
+      dataSetDir: "/tmp",
+      costName: "MSE",
+    },
+  };
+  assertExists(
+    structuredClone(initData),
+    "initialize payload should be cloneable",
+  );
+});


### PR DESCRIPTION
## Summary

Investigate why the DataCloneError in WorkerHandler.discover() was not caught by
tests, and add covering tests. Closes #1428.

### Root Cause Analysis

The DataCloneError occurred when `NeatConfig` (containing `logger` and `rng`
function properties) was posted to a worker via `postMessage()`. The structured
clone algorithm cannot serialise functions, causing a runtime crash.

**Why tests missed it:** The `MockWorker` class bypassed the structured clone
constraint entirely. Its `postMessage()` method accepted the data object directly
in-process without going through the structured clone algorithm that real
`Worker.postMessage()` uses. This meant any test using `MockWorker` (i.e. all
worker tests running with `direct: true`) would silently accept non-cloneable
payloads that would fail in production.

### Changes

1. **`MockWorker.postMessage()` now validates cloneability** - Added a
   `structuredClone(data)` call at the top of `MockWorker.postMessage()` so it
   mirrors the behaviour of a real Worker. Any future non-cloneable payload will
   fail immediately in tests rather than silently passing.

2. **New test file: `test/multithreading/WorkerPayloadCloneability.ts`** -
   Five focused tests that verify:
   - Raw `NeatConfig` with `logger`/`rng` functions **cannot** be structured-cloned
   - Sanitised config (with `logger`/`rng` stripped) **can** be structured-cloned
   - Full discovery `RequestData` with sanitised config survives `structuredClone`
   - Full discovery `RequestData` with unsanitised config **fails** `structuredClone`
   - All other `RequestData` variants (echo, evaluate, train, breed, initialise)
     are structured-clone safe

### Test Audit

Audited the existing worker test suite (`test/Worker.ts`,
`test/multithreading/WorkerPool.ts`, `test/multithreading/WorkStealingQueue.ts`).
No mock/fake tests that grep source code for patterns were found. All existing
tests exercise real code with test data and assert on outcomes. The one gap was
that `MockWorker` didn't enforce the structured clone constraint - now fixed.

## Evidence

This is a backend/test-only change with no UI impact. Evidence is the test output:

- All 2887 tests pass (including the 5 new tests)
- `./quality.sh` passes cleanly (fmt, lint, type-check, all tests)

## Test Plan

- Added `test/multithreading/WorkerPayloadCloneability.ts` with 5 tests:
  - `NeatConfig with logger and rng cannot be structured-cloned`
  - `sanitised NeatConfig without logger/rng can be structured-cloned`
  - `discovery RequestData with sanitised config can be structured-cloned`
  - `discovery RequestData with unsanitised config fails structuredClone`
  - `all non-discover RequestData variants are structured-clone safe`
- Enhanced `MockWorker.postMessage()` to validate structured-clone safety,
  which provides ongoing regression protection for all worker tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)