### PR TITLE
Fix: Improve: Add quality.sh help flag and skip options for developer convenience (#1408)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ Before committing, run:
 ./quality.sh
 ```
 
-This script:
+This script runs the following steps by default:
 
 1. Updates dependencies (`deno outdated --update --latest`)
 2. Formats code (`deno fmt`)
@@ -162,8 +162,20 @@ This script:
 4. Checks bash script syntax
 5. Type-checks (`deno check`)
 6. Builds the Rust discovery library (if `../NEAT-AI-Discovery` exists)
-7. Verifies discovery library availability
-8. Runs all tests in parallel with leak detection
+7. Runs all tests in parallel with leak detection
+
+### Optional Flags
+
+```bash
+./quality.sh --help            # Show usage and step descriptions
+./quality.sh --skip-tests      # Skip test execution
+./quality.sh --skip-discovery  # Skip discovery library build and verification
+./quality.sh --lint-only       # Only run formatting + linting (includes bash check)
+./quality.sh --check-only      # Only run type-checking (deno check)
+./quality.sh --dry-run         # Show which steps would run without executing them
+```
+
+Flags can be combined, e.g. `./quality.sh --skip-tests --skip-discovery`.
 
 ### Deployment Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,15 @@ The quality gate runs:
 
 Keep running `./quality.sh` until it passes cleanly.
 
+For faster iteration, you can skip specific steps:
+
+```bash
+./quality.sh --help            # Show all available options
+./quality.sh --skip-tests      # Quick check without running tests
+./quality.sh --lint-only       # Only format + lint
+./quality.sh --check-only      # Only type-check
+```
+
 ### 5. Submit a Pull Request
 
 - Target the `Develop` branch.

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.311.10",
+  "version": "0.311.11",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1408.md
+++ b/docs/pr-summary-1408.md
@@ -1,18 +1,20 @@
 ## Summary
 
-Added `--help`, `--skip-tests`, `--skip-discovery`, `--lint-only`, `--check-only`,
-and `--dry-run` flags to `quality.sh` for faster development iteration. The script
-now shows `[N/M]` progress indicators for each step and documents exit codes.
-Closes #1408.
+Added `--help`, `--skip-tests`, `--skip-discovery`, `--lint-only`,
+`--check-only`, and `--dry-run` flags to `quality.sh` for faster development
+iteration. The script now shows `[N/M]` progress indicators for each step and
+documents exit codes. Closes #1408.
 
 ### Changes
 
 - **quality.sh**: Added flag parsing, `show_help()`, progress numbering, dry-run
-  mode, and step-skip logic. All existing behaviour is preserved when no flags are
-  provided. Added `--allow-run` to the test invocation for the new test file.
+  mode, and step-skip logic. All existing behaviour is preserved when no flags
+  are provided. Added `--allow-run` to the test invocation for the new test
+  file.
 - **test/QualityScript.ts**: 11 new tests verifying `--help`, `-h`, `--dry-run`,
-  `--skip-tests`, `--skip-discovery`, `--lint-only`, `--check-only`, unknown flag
-  rejection, combined skip flags, exit code documentation, and progress numbering.
+  `--skip-tests`, `--skip-discovery`, `--lint-only`, `--check-only`, unknown
+  flag rejection, combined skip flags, exit code documentation, and progress
+  numbering.
 - **AGENTS.md**: Updated Quality Gate section to document optional flags.
 - **CONTRIBUTING.md**: Added quick-reference for skip flags in the quality gate
   section.
@@ -20,7 +22,8 @@ Closes #1408.
 ## Evidence
 
 This is a CLI/script change with no visual output. Evidence is provided by the
-11 passing tests that exercise real script invocations and verify stdout/exit codes.
+11 passing tests that exercise real script invocations and verify stdout/exit
+codes.
 
 ```
 ok | 3024 passed (2 steps) | 0 failed

--- a/docs/pr-summary-1408.md
+++ b/docs/pr-summary-1408.md
@@ -1,0 +1,42 @@
+## Summary
+
+Added `--help`, `--skip-tests`, `--skip-discovery`, `--lint-only`, `--check-only`,
+and `--dry-run` flags to `quality.sh` for faster development iteration. The script
+now shows `[N/M]` progress indicators for each step and documents exit codes.
+Closes #1408.
+
+### Changes
+
+- **quality.sh**: Added flag parsing, `show_help()`, progress numbering, dry-run
+  mode, and step-skip logic. All existing behaviour is preserved when no flags are
+  provided. Added `--allow-run` to the test invocation for the new test file.
+- **test/QualityScript.ts**: 11 new tests verifying `--help`, `-h`, `--dry-run`,
+  `--skip-tests`, `--skip-discovery`, `--lint-only`, `--check-only`, unknown flag
+  rejection, combined skip flags, exit code documentation, and progress numbering.
+- **AGENTS.md**: Updated Quality Gate section to document optional flags.
+- **CONTRIBUTING.md**: Added quick-reference for skip flags in the quality gate
+  section.
+
+## Evidence
+
+This is a CLI/script change with no visual output. Evidence is provided by the
+11 passing tests that exercise real script invocations and verify stdout/exit codes.
+
+```
+ok | 3024 passed (2 steps) | 0 failed
+```
+
+## Test Plan
+
+- `test/QualityScript.ts` — 11 new tests:
+  - `quality.sh --help prints usage and exits 0`
+  - `quality.sh -h prints usage and exits 0`
+  - `quality.sh --dry-run shows steps without executing them`
+  - `quality.sh --dry-run --skip-tests omits test step`
+  - `quality.sh --dry-run --skip-discovery omits discovery steps`
+  - `quality.sh --dry-run --lint-only only shows fmt and lint steps`
+  - `quality.sh --dry-run --check-only only shows type-check step`
+  - `quality.sh rejects unknown flags`
+  - `quality.sh --dry-run --skip-tests --skip-discovery combines skips`
+  - `quality.sh --help output documents exit codes`
+  - `quality.sh --dry-run shows progress numbering`

--- a/quality.sh
+++ b/quality.sh
@@ -4,74 +4,242 @@ set -e
 # Ensure deno is in PATH (common install locations)
 export PATH="$HOME/.deno/bin:$PATH"
 
-deno outdated --update --latest
-deno fmt src test bench mod.ts docs
-deno lint --fix src test bench mod.ts
+# --- Flag parsing ---
+SKIP_TESTS=false
+SKIP_DISCOVERY=false
+LINT_ONLY=false
+CHECK_ONLY=false
+DRY_RUN=false
 
-echo "Checking bash script syntax..."
-fail=0
-while IFS= read -r f; do
-if ! bash -n "$f"; then
-  echo "❌ syntax error in $f" >&2
-  fail=1
-else
-  echo "✅ $f"
+show_help() {
+  cat <<'HELP'
+Usage: ./quality.sh [OPTIONS]
+
+Pre-commit quality gate that runs formatting, linting, type-checking,
+discovery build, and all tests.
+
+Options:
+  --help, -h          Show this help message and exit
+  --skip-tests        Skip test execution
+  --skip-discovery    Skip discovery library build and verification
+  --lint-only         Only run formatting + linting (includes bash check)
+  --check-only        Only run type-checking (deno check)
+  --dry-run           Show which steps would run without executing them
+
+Steps (default, all enabled):
+  [1/7] Updating dependencies
+  [2/7] Formatting code
+  [3/7] Linting
+  [4/7] Checking bash scripts
+  [5/7] Type-checking
+  [6/7] Building discovery library
+  [7/7] Running tests
+
+Exit codes:
+  0   All steps passed
+  1   A step failed or an unknown option was provided
+
+Examples:
+  ./quality.sh                          # Run all steps
+  ./quality.sh --skip-tests             # Quick check without tests
+  ./quality.sh --skip-discovery         # Skip discovery build/verify
+  ./quality.sh --lint-only              # Format + lint only
+  ./quality.sh --check-only             # Type-check only
+  ./quality.sh --skip-tests --skip-discovery  # Combine skip flags
+HELP
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    --skip-tests)
+      SKIP_TESTS=true
+      ;;
+    --skip-discovery)
+      SKIP_DISCOVERY=true
+      ;;
+    --lint-only)
+      LINT_ONLY=true
+      ;;
+    --check-only)
+      CHECK_ONLY=true
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      echo "Run './quality.sh --help' for usage information." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# --- Determine which steps to run ---
+RUN_DEPS=true
+RUN_FMT=true
+RUN_LINT=true
+RUN_BASH_CHECK=true
+RUN_TYPE_CHECK=true
+RUN_DISCOVERY=true
+RUN_TESTS=true
+
+if [ "$LINT_ONLY" = true ]; then
+  RUN_DEPS=true
+  RUN_FMT=true
+  RUN_LINT=true
+  RUN_BASH_CHECK=true
+  RUN_TYPE_CHECK=false
+  RUN_DISCOVERY=false
+  RUN_TESTS=false
 fi
-done < <(find . -name "*.sh" -type f)
 
-if [ $fail -eq 1 ]; then
-  echo "❌ Bash script syntax errors found"
-  exit 1
+if [ "$CHECK_ONLY" = true ]; then
+  RUN_DEPS=false
+  RUN_FMT=false
+  RUN_LINT=false
+  RUN_BASH_CHECK=false
+  RUN_TYPE_CHECK=true
+  RUN_DISCOVERY=false
+  RUN_TESTS=false
 fi
 
-rm -rf .trace .test .coverage
-deno check
-
-if [[ -d ../NEAT-AI-Discovery ]]; then
-  (cd ../NEAT-AI-Discovery && ./scripts/runlib.sh)
+if [ "$SKIP_TESTS" = true ]; then
+  RUN_TESTS=false
 fi
-# # is intentionally loaded and kept in memory for performance (not a leak)
 
-echo "Verifying discovery library availability..."
-if ! deno run \
-  --allow-read \
-  --allow-env \
-  --allow-ffi \
-  --config ./deno.json \
-  scripts/check_discovery_safe.ts 2>&1; then
-  exit_code=$?
-  if [ $exit_code -eq 137 ] || [ $exit_code -eq 9 ]; then
-    echo ""
-    echo "❌ Discovery library crashed on load (Killed: 9 or exit code 137)"
-    echo "   This indicates a fatal crash (segmentation fault) in the Rust library."
-    echo "   Common causes:"
-    echo "   - Architecture mismatch (x86_64 vs arm64)"
-    echo "   - Missing dependencies"
-    echo "   - Library built for different macOS version"
-    echo "   - Bug in library initialization"
-    echo ""
-    echo "   Diagnostic steps:"
-    echo "   1. Check library architecture:"
-    echo "      file ~/.cargo/lib/libneat_ai_discovery.dylib"
-    echo "   2. Check dependencies:"
-    echo "      otool -L ~/.cargo/lib/libneat_ai_discovery.dylib"
-    echo "   3. Rebuild the library:"
-    echo "      cd ../NEAT-AI-Discovery && ./scripts/runlib.sh"
-  else
-    echo "❌ Discovery checks failed (exit code: $exit_code)"
+if [ "$SKIP_DISCOVERY" = true ]; then
+  RUN_DISCOVERY=false
+fi
+
+# --- Count active steps for progress numbering ---
+TOTAL=0
+[ "$RUN_DEPS" = true ] && TOTAL=$((TOTAL + 1))
+[ "$RUN_FMT" = true ] && TOTAL=$((TOTAL + 1))
+[ "$RUN_LINT" = true ] && TOTAL=$((TOTAL + 1))
+[ "$RUN_BASH_CHECK" = true ] && TOTAL=$((TOTAL + 1))
+[ "$RUN_TYPE_CHECK" = true ] && TOTAL=$((TOTAL + 1))
+[ "$RUN_DISCOVERY" = true ] && TOTAL=$((TOTAL + 1))
+[ "$RUN_TESTS" = true ] && TOTAL=$((TOTAL + 1))
+
+STEP=0
+
+progress() {
+  STEP=$((STEP + 1))
+  echo ""
+  echo "[$STEP/$TOTAL] $1"
+}
+
+# --- Dry run mode ---
+if [ "$DRY_RUN" = true ]; then
+  echo "DRY RUN — the following steps would be executed:"
+  echo ""
+  [ "$RUN_DEPS" = true ] && progress "Updating dependencies..."
+  [ "$RUN_FMT" = true ] && progress "Formatting code..."
+  [ "$RUN_LINT" = true ] && progress "Linting..."
+  [ "$RUN_BASH_CHECK" = true ] && progress "Checking bash scripts..."
+  [ "$RUN_TYPE_CHECK" = true ] && progress "Type-checking..."
+  [ "$RUN_DISCOVERY" = true ] && progress "Building discovery library..."
+  [ "$RUN_TESTS" = true ] && progress "Running tests..."
+  echo ""
+  echo "Total: $TOTAL steps"
+  exit 0
+fi
+
+# --- Execute steps ---
+
+if [ "$RUN_DEPS" = true ]; then
+  progress "Updating dependencies..."
+  deno outdated --update --latest
+fi
+
+if [ "$RUN_FMT" = true ]; then
+  progress "Formatting code..."
+  deno fmt src test bench mod.ts docs
+fi
+
+if [ "$RUN_LINT" = true ]; then
+  progress "Linting..."
+  deno lint --fix src test bench mod.ts
+fi
+
+if [ "$RUN_BASH_CHECK" = true ]; then
+  progress "Checking bash scripts..."
+  fail=0
+  while IFS= read -r f; do
+    if ! bash -n "$f"; then
+      echo "❌ syntax error in $f" >&2
+      fail=1
+    else
+      echo "✅ $f"
+    fi
+  done < <(find . -name "*.sh" -type f)
+
+  if [ $fail -eq 1 ]; then
+    echo "❌ Bash script syntax errors found"
+    exit 1
   fi
-  exit 1
 fi
 
-echo ""
-echo "Running tests..."
-NEAT_AI_DISCOVERY_DETERMINISTIC=1 deno test \
-  --allow-read \
-  --allow-write \
-  --allow-net \
-  --allow-env \
-  --trace-leaks \
-  --allow-ffi \
-  --v8-flags=--max-old-space-size=8192 \
-  --parallel \
-  --config ./deno.json
+if [ "$RUN_TYPE_CHECK" = true ]; then
+  progress "Type-checking..."
+  rm -rf .trace .test .coverage
+  deno check
+fi
+
+if [ "$RUN_DISCOVERY" = true ]; then
+  progress "Building discovery library..."
+  if [[ -d ../NEAT-AI-Discovery ]]; then
+    (cd ../NEAT-AI-Discovery && ./scripts/runlib.sh)
+  fi
+  # # is intentionally loaded and kept in memory for performance (not a leak)
+
+  echo "Verifying discovery library availability..."
+  if ! deno run \
+    --allow-read \
+    --allow-env \
+    --allow-ffi \
+    --config ./deno.json \
+    scripts/check_discovery_safe.ts 2>&1; then
+    exit_code=$?
+    if [ $exit_code -eq 137 ] || [ $exit_code -eq 9 ]; then
+      echo ""
+      echo "❌ Discovery library crashed on load (Killed: 9 or exit code 137)"
+      echo "   This indicates a fatal crash (segmentation fault) in the Rust library."
+      echo "   Common causes:"
+      echo "   - Architecture mismatch (x86_64 vs arm64)"
+      echo "   - Missing dependencies"
+      echo "   - Library built for different macOS version"
+      echo "   - Bug in library initialisation"
+      echo ""
+      echo "   Diagnostic steps:"
+      echo "   1. Check library architecture:"
+      echo "      file ~/.cargo/lib/libneat_ai_discovery.dylib"
+      echo "   2. Check dependencies:"
+      echo "      otool -L ~/.cargo/lib/libneat_ai_discovery.dylib"
+      echo "   3. Rebuild the library:"
+      echo "      cd ../NEAT-AI-Discovery && ./scripts/runlib.sh"
+    else
+      echo "❌ Discovery checks failed (exit code: $exit_code)"
+    fi
+    exit 1
+  fi
+fi
+
+if [ "$RUN_TESTS" = true ]; then
+  progress "Running tests..."
+  NEAT_AI_DISCOVERY_DETERMINISTIC=1 deno test \
+    --allow-read \
+    --allow-write \
+    --allow-net \
+    --allow-env \
+    --allow-run \
+    --trace-leaks \
+    --allow-ffi \
+    --v8-flags=--max-old-space-size=8192 \
+    --parallel \
+    --config ./deno.json
+fi

--- a/test/QualityScript.ts
+++ b/test/QualityScript.ts
@@ -1,0 +1,255 @@
+import { assert, assertEquals } from "@std/assert";
+
+/**
+ * Tests for quality.sh flag parsing and behaviour.
+ *
+ * These tests invoke quality.sh with --dry-run to verify flag parsing
+ * without actually running the quality steps.
+ */
+
+/** Helper to run quality.sh with given args and return stdout + exit code. */
+async function runQuality(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command("bash", {
+    args: ["./quality.sh", ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: Deno.cwd(),
+  });
+  const output = await command.output();
+  return {
+    stdout: new TextDecoder().decode(output.stdout),
+    stderr: new TextDecoder().decode(output.stderr),
+    code: output.code,
+  };
+}
+
+Deno.test(
+  {
+    name: "quality.sh --help prints usage and exits 0",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["--help"]);
+      assertEquals(result.code, 0, "Expected exit code 0 for --help");
+      assert(
+        result.stdout.includes("Usage:"),
+        "Expected help output to contain 'Usage:'",
+      );
+      assert(
+        result.stdout.includes("--help"),
+        "Expected help output to mention --help flag",
+      );
+      assert(
+        result.stdout.includes("--skip-tests"),
+        "Expected help output to mention --skip-tests flag",
+      );
+      assert(
+        result.stdout.includes("--skip-discovery"),
+        "Expected help output to mention --skip-discovery flag",
+      );
+      assert(
+        result.stdout.includes("--lint-only"),
+        "Expected help output to mention --lint-only flag",
+      );
+      assert(
+        result.stdout.includes("--check-only"),
+        "Expected help output to mention --check-only flag",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh -h prints usage and exits 0",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["-h"]);
+      assertEquals(result.code, 0, "Expected exit code 0 for -h");
+      assert(
+        result.stdout.includes("Usage:"),
+        "Expected help output to contain 'Usage:'",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh --dry-run shows steps without executing them",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["--dry-run"]);
+      assertEquals(result.code, 0, "Expected exit code 0 for --dry-run");
+      assert(
+        result.stdout.includes("[1/"),
+        "Expected step numbering in output",
+      );
+      assert(
+        result.stdout.includes("DRY RUN"),
+        "Expected dry run indicator in output",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh --dry-run --skip-tests omits test step",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["--dry-run", "--skip-tests"]);
+      assertEquals(result.code, 0);
+      assert(
+        !result.stdout.includes("Running tests"),
+        "Expected test step to be skipped",
+      );
+      assert(
+        result.stdout.includes("Formatting"),
+        "Expected format step to be present",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh --dry-run --skip-discovery omits discovery steps",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["--dry-run", "--skip-discovery"]);
+      assertEquals(result.code, 0);
+      assert(
+        !result.stdout.includes("Building discovery"),
+        "Expected discovery build step to be skipped",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh --dry-run --lint-only only shows fmt and lint steps",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["--dry-run", "--lint-only"]);
+      assertEquals(result.code, 0);
+      assert(
+        result.stdout.includes("Formatting"),
+        "Expected format step",
+      );
+      assert(
+        result.stdout.includes("Linting"),
+        "Expected lint step",
+      );
+      assert(
+        !result.stdout.includes("Type-checking"),
+        "Expected type-check to be excluded in lint-only mode",
+      );
+      assert(
+        !result.stdout.includes("Running tests"),
+        "Expected tests to be excluded in lint-only mode",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh --dry-run --check-only only shows type-check step",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["--dry-run", "--check-only"]);
+      assertEquals(result.code, 0);
+      assert(
+        result.stdout.includes("Type-checking"),
+        "Expected type-check step",
+      );
+      assert(
+        !result.stdout.includes("Formatting"),
+        "Expected format to be excluded in check-only mode",
+      );
+      assert(
+        !result.stdout.includes("Running tests"),
+        "Expected tests to be excluded in check-only mode",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh rejects unknown flags",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["--unknown-flag"]);
+      assert(result.code !== 0, "Expected non-zero exit code for unknown flag");
+      assert(
+        result.stderr.includes("Unknown option"),
+        "Expected error message about unknown option",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh --dry-run --skip-tests --skip-discovery combines skips",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality([
+        "--dry-run",
+        "--skip-tests",
+        "--skip-discovery",
+      ]);
+      assertEquals(result.code, 0);
+      assert(
+        !result.stdout.includes("Running tests"),
+        "Expected tests to be skipped",
+      );
+      assert(
+        !result.stdout.includes("Building discovery"),
+        "Expected discovery to be skipped",
+      );
+      assert(
+        result.stdout.includes("Formatting"),
+        "Expected format step to remain",
+      );
+      assert(
+        result.stdout.includes("Type-checking"),
+        "Expected type-check step to remain",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh --help output documents exit codes",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["--help"]);
+      assert(
+        result.stdout.includes("Exit codes"),
+        "Expected help to document exit codes",
+      );
+    },
+  },
+);
+
+Deno.test(
+  {
+    name: "quality.sh --dry-run shows progress numbering",
+    permissions: { run: true, read: true },
+    fn: async () => {
+      const result = await runQuality(["--dry-run"]);
+      assertEquals(result.code, 0);
+      const stepPattern = /\[\d+\/\d+\]/;
+      assert(
+        stepPattern.test(result.stdout),
+        "Expected [N/M] step numbering format in output",
+      );
+    },
+  },
+);


### PR DESCRIPTION
## Summary

Added `--help`, `--skip-tests`, `--skip-discovery`, `--lint-only`,
`--check-only`, and `--dry-run` flags to `quality.sh` for faster development
iteration. The script now shows `[N/M]` progress indicators for each step and
documents exit codes. Closes #1408.

### Changes

- **quality.sh**: Added flag parsing, `show_help()`, progress numbering, dry-run
  mode, and step-skip logic. All existing behaviour is preserved when no flags
  are provided. Added `--allow-run` to the test invocation for the new test
  file.
- **test/QualityScript.ts**: 11 new tests verifying `--help`, `-h`, `--dry-run`,
  `--skip-tests`, `--skip-discovery`, `--lint-only`, `--check-only`, unknown
  flag rejection, combined skip flags, exit code documentation, and progress
  numbering.
- **AGENTS.md**: Updated Quality Gate section to document optional flags.
- **CONTRIBUTING.md**: Added quick-reference for skip flags in the quality gate
  section.

## Evidence

This is a CLI/script change with no visual output. Evidence is provided by the
11 passing tests that exercise real script invocations and verify stdout/exit
codes.

```
ok | 3024 passed (2 steps) | 0 failed
```

## Test Plan

- `test/QualityScript.ts` — 11 new tests:
  - `quality.sh --help prints usage and exits 0`
  - `quality.sh -h prints usage and exits 0`
  - `quality.sh --dry-run shows steps without executing them`
  - `quality.sh --dry-run --skip-tests omits test step`
  - `quality.sh --dry-run --skip-discovery omits discovery steps`
  - `quality.sh --dry-run --lint-only only shows fmt and lint steps`
  - `quality.sh --dry-run --check-only only shows type-check step`
  - `quality.sh rejects unknown flags`
  - `quality.sh --dry-run --skip-tests --skip-discovery combines skips`
  - `quality.sh --help output documents exit codes`
  - `quality.sh --dry-run shows progress numbering`

> **Screenshot evidence not provided**: This appears to be a UI-related change but no screenshots were included. For UI changes, use Playwright MCP to capture screenshots as evidence: `browser_navigate` to open a relevant URL, then `browser_take_screenshot` to save to `docs/evidence/`.

---

## Automated Fix Details
This PR addresses issue #1408: **Improve: Add quality.sh help flag and skip options for developer convenience**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1408