### PR TITLE
Refactor: Extract Creature.ts (3,069 lines) into focused modules (#1409)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.311.11",
+  "version": "0.311.12",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -214,6 +214,8 @@
     "cloneability",
     "Cloneability",
     "invertibility",
-    "favor"
+    "favor",
+    "topo",
+    "checkpointing"
   ]
 }

--- a/docs/pr-summary-1409.md
+++ b/docs/pr-summary-1409.md
@@ -7,14 +7,14 @@ delegates to specialised modules in `src/creature/`. The public API is unchanged
 
 ### New Module Structure
 
-| Module                    | Lines | Responsibility                                      |
-| ------------------------- | ----- | --------------------------------------------------- |
-| `CreatureActivation.ts`   | 452   | Forward pass, WASM activation, evaluation           |
-| `CreatureTopology.ts`     | 575   | Connection queries, binary search, caching, focus   |
-| `CreatureTraining.ts`     | 555   | Training orchestration, evolution, scoring           |
-| `CreatureSerialization.ts`| 334   | JSON import/export, cloning                          |
-| `CreatureMutation.ts`     | 225   | Network structure repair, random connections         |
-| `mod.ts`                  | 67    | Barrel re-export of all module functions             |
+| Module                     | Lines | Responsibility                                    |
+| -------------------------- | ----- | ------------------------------------------------- |
+| `CreatureActivation.ts`    | 452   | Forward pass, WASM activation, evaluation         |
+| `CreatureTopology.ts`      | 575   | Connection queries, binary search, caching, focus |
+| `CreatureTraining.ts`      | 555   | Training orchestration, evolution, scoring        |
+| `CreatureSerialization.ts` | 334   | JSON import/export, cloning                       |
+| `CreatureMutation.ts`      | 225   | Network structure repair, random connections      |
+| `mod.ts`                   | 67    | Barrel re-export of all module functions          |
 
 ### Before vs After
 

--- a/docs/pr-summary-1409.md
+++ b/docs/pr-summary-1409.md
@@ -1,0 +1,73 @@
+## Summary
+
+Refactored the monolithic `Creature.ts` (3,069 lines) into five focused modules
+behind a facade pattern. The `Creature` class is now a thin 719-line facade that
+delegates to specialised modules in `src/creature/`. The public API is unchanged
+-- all existing imports and method calls work identically. Closes #1409.
+
+### New Module Structure
+
+| Module                    | Lines | Responsibility                                      |
+| ------------------------- | ----- | --------------------------------------------------- |
+| `CreatureActivation.ts`   | 452   | Forward pass, WASM activation, evaluation           |
+| `CreatureTopology.ts`     | 575   | Connection queries, binary search, caching, focus   |
+| `CreatureTraining.ts`     | 555   | Training orchestration, evolution, scoring           |
+| `CreatureSerialization.ts`| 334   | JSON import/export, cloning                          |
+| `CreatureMutation.ts`     | 225   | Network structure repair, random connections         |
+| `mod.ts`                  | 67    | Barrel re-export of all module functions             |
+
+### Before vs After
+
+- **Before**: `Creature.ts` was 3,069 lines containing activation, topology,
+  training, serialisation, and mutation logic in a single file
+- **After**: `Creature.ts` is 719 lines; each extracted module is under 575
+  lines with a single responsibility
+- **Circular dependencies**: Avoided using `import type` for type-only imports
+  (no runtime circular dependency) and dynamic `import()` in `evolveDir()`
+- **Public API**: No breaking changes; all methods remain on the `Creature`
+  class as thin delegation wrappers
+
+### Design Decisions
+
+- Modules accept `creature: Creature` as the first parameter rather than narrow
+  interfaces, since downstream functions (WASM, CreatureUtil, etc.) expect the
+  full `Creature` type
+- `TopologyCaches` interface holds cache state, passed from the `Creature`
+  facade to topology functions
+- Focus cache remains separate from topology caches (per Issue #1100)
+- `connect()`, `connectBatch()`, `disconnect()`, `disconnectBatch()` remain on
+  the `Creature` class since they directly mutate the synapses array and call
+  `clearCache()`
+
+## Evidence
+
+This is a pure refactoring with no behavioural changes. All 3,056 existing tests
+continue to pass, and 32 new tests verify the extracted module structure.
+
+## Test Plan
+
+- Added `test/creature/CreatureActivation.ts` (7 tests) verifying:
+  - WASM eligibility checking
+  - WASM disposal lifecycle
+  - Consistent activation output
+  - Non-finite input rejection
+- Added `test/creature/CreatureTopology.ts` (11 tests) verifying:
+  - Inward/outward connection queries
+  - Binary search and insertion point
+  - Self-connection detection
+  - Connection set and hidden neuron UUID generation
+  - Prebuild inward index
+  - Facade delegation consistency
+- Added `test/creature/CreatureMutation.ts` (7 tests) verifying:
+  - Random connection creation
+  - Zero-weight synapse removal
+  - Sorted synapses invariant
+  - Forward-only version bumping
+  - UUID change on structural modification
+- Added `test/creature/CreatureSerialization.ts` (7 tests) verifying:
+  - JSON export validity
+  - Trace JSON generation
+  - Round-trip serialisation
+  - LoadFrom content replacement
+  - Shallow clone independence
+- All 3,056 tests pass with `./quality.sh`

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1,8 +1,17 @@
-import { assert, fail } from "@std/assert";
-import { yellow } from "@std/fmt/colors";
-import { format } from "@std/fmt/duration";
-import { emptyDirSync } from "@std/fs";
-import { getTag, type TagInterface } from "@stsoftware/tags/mod";
+/**
+ * Creature.ts - Central coordinating class for AI entities in NEAT.
+ *
+ * Issue #1409: Refactored from 3,069 lines into a ~500-line facade.
+ * Responsibilities are delegated to focused modules in src/creature/:
+ * - CreatureActivation.ts  - Forward pass and WASM activation
+ * - CreatureTopology.ts    - Neuron/synapse management, connection queries
+ * - CreatureTraining.ts    - Training orchestration, evolution, scoring
+ * - CreatureSerialization.ts - JSON import/export, cloning
+ * - CreatureMutation.ts    - Network structure repair, random connections
+ */
+
+import { assert } from "@std/assert";
+import type { TagInterface } from "@stsoftware/tags/mod";
 import { getGlobalDebug } from "./globalAccessors.ts";
 import type {
   CreatureExport,
@@ -10,69 +19,38 @@ import type {
   CreatureTrace,
 } from "./architecture/CreatureInterfaces.ts";
 import { CreatureState } from "./architecture/CreatureState.ts";
-import { CreatureUtil } from "./architecture/CreatureUtils.ts";
 import { creatureValidate } from "./architecture/CreatureValidate.ts";
-import {
-  type DataRecordInterface,
-  makeDataDir,
-} from "./architecture/DataSet.ts";
+import type { DataRecordInterface } from "./architecture/DataSet.ts";
 import type { DiscoverRecord } from "./architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import { Neuron } from "./architecture/Neuron.ts";
-import type { NeuronTrace } from "./architecture/NeuronInterfaces.ts";
-import { calculate as calculateScore } from "./architecture/Score.ts";
 import { Synapse } from "./architecture/Synapse.ts";
-import type {
-  SynapseExport,
-  SynapseInternal,
-  SynapseTrace,
-} from "./architecture/SynapseInterfaces.ts";
-import { dataFiles } from "./architecture/Training.ts";
+import type { SynapseInternal } from "./architecture/SynapseInterfaces.ts";
 import type { MemeticInterface } from "./blackbox/MemeticInterface.ts";
 import { compactCreature } from "./compact/CompactCreature.ts";
-import { removeHiddenNeuron } from "./compact/CompactUtils.ts";
-import { createNeatConfig } from "./config/NeatConfig.ts";
 import type { NeatOptions } from "./config/NeatOptions.ts";
-import { Costs } from "./Costs.ts";
 import type { CostInterface } from "./costs/CostInterface.ts";
 import { Activations } from "./methods/activations/Activations.ts";
-import { WorkerHandler } from "./multithreading/workers/WorkerHandler.ts";
-import { Neat } from "./NEAT/Neat.ts";
-import {
-  type BackPropagationConfig,
-  createBackPropagationConfig,
-} from "./propagate/BackPropagation.ts";
-import { BackpropBuffers } from "./propagate/BackpropBuffers.ts";
-import { buildOutgoingSynapsesMap } from "./propagate/sparse/CalculatePathsToOutput.ts";
-import { SparseConfig } from "./propagate/sparse/SparseConfig.ts";
+import type { BackPropagationConfig } from "./propagate/BackPropagation.ts";
+import type { SparseConfig } from "./propagate/sparse/SparseConfig.ts";
 import type { SparseConfigLike } from "./propagate/sparse/SparseConfigLike.ts";
-import { upgradeOne } from "./upgrade/UpgradeOne.ts";
-import { CreatureExportBuilder } from "./utils/CreatureExportBuilder.ts";
-import { BufferPool } from "./utils/BufferPool.ts";
-import { mergeTagsByNameValue } from "./utils/TagUtils.ts";
-import {
-  type DiscoveryDirResult,
-  DiscoveryRunner,
-  type DiscoveryRunnerLike,
-} from "./discovery/DiscoveryRunner.ts";
-import {
-  type DiscoveryReplayDirResult,
-  DiscoveryReplayRunner,
-  type DiscoveryReplayRunnerLike,
-} from "./discovery/DiscoveryReplayRunner.ts";
-import {
-  compileCreatureToWasm,
-  ensureWasmActivation,
-  getOrCompileWasmModule,
-  isWasmActivationAvailable,
-  resolveWasmSquashName,
-  WasmCreatureActivation,
-} from "./wasm/mod.ts";
-import {
-  evictOldestWasmCreatureActivations,
-  noteWasmCreatureActivationUse,
-} from "./wasm/WasmCreatureActivationLRU.ts";
-import { getLogger } from "./utils/Logger.ts";
+import type { WasmCreatureActivation } from "./wasm/mod.ts";
 import { getRandomNumberGenerator } from "./utils/RandomNumberGenerator.ts";
+
+// Extracted modules
+import * as activation from "./creature/CreatureActivation.ts";
+import * as topology from "./creature/CreatureTopology.ts";
+import type { TopologyCaches } from "./creature/CreatureTopology.ts";
+import * as training from "./creature/CreatureTraining.ts";
+import * as serialisation from "./creature/CreatureSerialization.ts";
+import * as mutation from "./creature/CreatureMutation.ts";
+import type {
+  DiscoveryDirResult,
+  DiscoveryRunnerLike,
+} from "./discovery/DiscoveryRunner.ts";
+import type {
+  DiscoveryReplayDirResult,
+  DiscoveryReplayRunnerLike,
+} from "./discovery/DiscoveryReplayRunner.ts";
 
 interface CreatureOptions {
   semanticVersion?: string;
@@ -113,169 +91,54 @@ export interface CachedScoreComponents {
 /**
  * Creature Class
  *
- * The Creature class represents an AI entity within the NEAT (NeuroEvolution of Augmenting Topologies) framework.
- * It encapsulates the neural network structure and its associated behaviors, including activation, mutation,
- * propagation, and evolution processes. This class is integral to the simulation and evolution of neural networks.
+ * The Creature class represents an AI entity within the NEAT framework.
+ * It delegates to focused modules for each responsibility area.
  */
 export class Creature implements CreatureInternal {
-  /**
-   * The unique identifier of this creature.
-   * @type {string | undefined}
-   */
   uuid?: string;
-
-  /**
-   * The number of input neurons.
-   * @type {number}
-   */
   input: number;
-
-  /**
-   * The number of output neurons.
-   * @type {number}
-   */
   output: number;
-
-  /**
-   * The array of neurons within this creature.
-   * @type {Neuron[]}
-   */
   neurons: Neuron[];
-
-  /**
-   * Optional tags associated with the creature.
-   * @type {TagInterface[] | undefined}
-   */
   tags?: TagInterface[];
-
-  /**
-   * The score of the creature, used for evaluating fitness.
-   * @type {number | undefined}
-   */
   score?: number;
-
-  /**
-   * The array of synapses (connections) between neurons.
-   * @type {Synapse[]}
-   */
   synapses: Synapse[];
-
-  /** Records the origins of this creature. */
   memetic?: MemeticInterface;
-
-  /**
-   * The state of the creature, managing the internal state and activations.
-   * @type {CreatureState}
-   */
   readonly state: CreatureState = new CreatureState(this);
 
-  private cacheTo = new Map<number, Synapse[]>();
-  private cacheFrom = new Map<number, Synapse[]>();
-  private cacheSelf = new Map<number, Synapse[]>();
+  // Topology caches (managed by CreatureTopology module)
+  private _topoCaches: TopologyCaches = {
+    cacheTo: new Map(),
+    cacheFrom: new Map(),
+    cacheSelf: new Map(),
+    synapsesIndexedByTo: null,
+    connectionSet: null,
+    availableConnectionsCache: null,
+    hiddenNeuronUUIDs: null,
+    inwardCacheMissCount: 0,
+  };
+
+  // Focus cache (separate from topology caches per Issue #1100)
   private cacheFocus: Map<number, boolean> = new Map();
-
-  /**
-   * The focus list that the focus cache was built for.
-   * Issue #1100: Track focus list to detect when cache should be invalidated.
-   * If undefined, no focus cache has been built yet.
-   */
   private cacheFocusList: number[] | undefined = undefined;
-
-  /**
-   * Secondary index of synapses sorted by `to` field.
-   * Enables O(log n) binary search for inward connections instead of O(n) linear scan.
-   * Issue #1010: Performance optimisation for large creatures.
-   */
-  private synapsesIndexedByTo: Synapse[] | null = null;
-
-  /**
-   * Cached Set of existing connections as "from-to" strings.
-   * Enables O(1) lookup for connection existence checks.
-   * Issue #1036: Performance optimisation for ADD_CONNECTION mutation.
-   */
-  private connectionSet: Set<string> | null = null;
-
-  /**
-   * Cached array of available connection pairs [from, to].
-   * Enables O(1) retrieval of available connections after first computation.
-   * Issue #1098: Performance optimisation for AddConnection mutation.
-   */
-  private availableConnectionsCache: [number, number][] | null = null;
-
-  /**
-   * Cached Set of hidden neuron UUIDs.
-   * Enables O(1) lookup for genetic compatibility checks.
-   * Issue #1032: Performance optimisation for genetic compatibility checks.
-   */
-  private hiddenNeuronUUIDs: Set<string> | null = null;
 
   /** The version of this creature */
   public semanticVersion: string;
-
-  /**
-   * When true, this creature is intended to remain forward-only (no recurrent connections).
-   *
-   * Recurrent connections include:
-   * - self-loops (from === to)
-   * - feedback/backward connections (from > to)
-   * This flag survives export/import.
-   */
   public forwardOnly?: boolean;
-
-  /**
-   * Cached score components to avoid recalculating structure-dependent values
-   * on every score calculation. Invalidated when structure changes.
-   * Issue #1023: Performance optimization for large creatures.
-   */
   public cachedScoreComponents?: CachedScoreComponents;
-
-  /**
-   * Cached topology hash for this creature.
-   * The topology hash identifies creatures with identical network structure
-   * (neurons and connections) regardless of weights and biases.
-   * Issue #1016: Performance optimisation for evaluation deduplication.
-   */
   public topologyHash?: string;
 
-  /**
-   * Cached output buffer for activate() and activateAndTrace() methods.
-   *
-   * NOTE: Output buffer reuse was removed because it provided no measurable
-   * performance benefit in our benchmarks and is easy to misuse (callers may
-   * accidentally retain the returned array across calls).
-   */
-  // (left intentionally unused for backwards-compat doc history)
+  // WASM activation state (managed by CreatureActivation module)
+  /** @internal */
+  cachedWasmActivation?: WasmCreatureActivation;
+  /** @internal */
+  wasmEligibilityCache?: boolean;
 
-  /**
-   * Cached WASM activation instance for this creature.
-   * Lazily compiled on first WASM activation request.
-   * Issue #1118: WASM Migration Phase 1 - Add WASM activation option.
-   */
-  private cachedWasmActivation?: WasmCreatureActivation;
-
-  /**
-   * Cached WASM eligibility status for this creature.
-   * True if all neurons use WASM-supported squash functions.
-   * Invalidated on structural changes.
-   * Issue #1118: WASM Migration Phase 1 - Add WASM activation option.
-   */
-  private wasmEligibilityCache?: boolean;
-
-  /**
-   * Debug mode flag.
-   * @type {boolean}
-   */
   DEBUG: boolean = getGlobalDebug();
 
-  /**
-   * Constructs a new Creature instance.
-   *
-   * @param {number} input - The number of input neurons.
-   * @param {number} output - The number of output neurons.
-   * @param {Object} [options] - Configuration options for initializing the creature.
-   * @param {boolean} [options.lazyInitialization=false] - If true, the creature will not be initialized immediately.
-   * @param {Object[]} [options.layers] - Optional layers configuration.
-   */
+  /** @deprecated Use PREBUILD_SYNAPSE_THRESHOLD from creature/CreatureTopology.ts */
+  public static readonly PREBUILD_SYNAPSE_THRESHOLD =
+    topology.PREBUILD_SYNAPSE_THRESHOLD;
+
   constructor(
     input: number,
     output: number,
@@ -289,9 +152,6 @@ export class Creature implements CreatureInternal {
     this.tags = undefined;
     this.score = undefined;
     this.semanticVersion = options.semanticVersion ?? "0.0.1";
-    // Forward-only is a hard invariant for 4.x+ creatures.
-    // Setting this before `initialize()` prevents `fix()` from introducing
-    // recurrent connections (eg self-loops) during construction.
     const major = Number.parseInt(
       this.semanticVersion.split(".")[0] ?? "0",
       10,
@@ -307,110 +167,65 @@ export class Creature implements CreatureInternal {
     }
   }
 
-  /**
-   * Dispose of the creature and all held memory.
-   */
+  // ── Lifecycle ──────────────────────────────────────────────────────────
+
   public dispose() {
     this.clearState();
     this.clearCache();
     this.clearFocusCache();
-    this.disposeWasm(); // Issue #1118: Clean up WASM resources
+    this.disposeWasm();
     this.synapses.length = 0;
     this.neurons.length = 0;
   }
 
-  /**
-   * Clear the cache of connections.
-   *
-   * @param {number} [from=-1] - The starting index of the cache to clear.
-   * @param {number} [to=-1] - The ending index of the cache to clear.
-   */
   public clearCache(from: number = -1, to: number = -1) {
     if (from === -1 || to === -1) {
-      this.cacheTo.clear();
-      this.cacheFrom.clear();
-      this.cacheSelf.clear();
-      // Invalidate secondary index on full cache clear
-      this.synapsesIndexedByTo = null;
-      this.inwardCacheMissCount = 0;
-      // Invalidate connection set on full cache clear
-      this.connectionSet = null;
-      // Invalidate hidden neuron UUIDs cache on full cache clear
-      // Issue #1032: Performance optimisation for genetic compatibility checks
-      this.hiddenNeuronUUIDs = null;
-      // Invalidate available connections cache on full cache clear
-      // Issue #1098: Performance optimisation for AddConnection mutation
-      this.availableConnectionsCache = null;
-      // Invalidate topology hash on full cache clear (structure changed)
-      // Issue #1301: Performance optimisation for WASM compilation caching
+      this._topoCaches.cacheTo.clear();
+      this._topoCaches.cacheFrom.clear();
+      this._topoCaches.cacheSelf.clear();
+      this._topoCaches.synapsesIndexedByTo = null;
+      this._topoCaches.inwardCacheMissCount = 0;
+      this._topoCaches.connectionSet = null;
+      this._topoCaches.hiddenNeuronUUIDs = null;
+      this._topoCaches.availableConnectionsCache = null;
       this.topologyHash = undefined;
     } else {
-      this.cacheTo.delete(to);
-      this.cacheFrom.delete(from);
-      this.cacheSelf.delete(from);
-      // Invalidate secondary index on partial clear (structure changed)
-      this.synapsesIndexedByTo = null;
-      this.inwardCacheMissCount = 0;
-      // Invalidate connection set on partial clear (structure changed)
-      this.connectionSet = null;
-      // Invalidate hidden neuron UUIDs cache on partial clear (structure changed)
-      // Issue #1032: Performance optimisation for genetic compatibility checks
-      this.hiddenNeuronUUIDs = null;
-      // Invalidate available connections cache on partial clear (structure changed)
-      // Issue #1098: Performance optimisation for AddConnection mutation
-      this.availableConnectionsCache = null;
-      // Invalidate topology hash on partial clear (structure changed)
-      // Issue #1301: Performance optimisation for WASM compilation caching
+      this._topoCaches.cacheTo.delete(to);
+      this._topoCaches.cacheFrom.delete(from);
+      this._topoCaches.cacheSelf.delete(from);
+      this._topoCaches.synapsesIndexedByTo = null;
+      this._topoCaches.inwardCacheMissCount = 0;
+      this._topoCaches.connectionSet = null;
+      this._topoCaches.hiddenNeuronUUIDs = null;
+      this._topoCaches.availableConnectionsCache = null;
       this.topologyHash = undefined;
     }
-    // Issue #1100: Do NOT clear focus cache on structural changes.
-    // Focus cache validity depends on the focus list, not on structure.
-    // This allows focus cache to be reused across mutation batches when
-    // the focus list remains constant.
     this.invalidateScoreCache();
   }
 
-  /**
-   * Clear the focus cache.
-   *
-   * Issue #1100: Separate focus cache clearing from structural cache clearing.
-   * The focus cache maps neuron indices to focus status (true/false).
-   * It should be cleared when the focus list changes, not when structure changes.
-   *
-   * Call this method when:
-   * - The focus list changes between mutations
-   * - You want to force recalculation of focus status
-   *
-   * Do NOT call this method:
-   * - On structural changes (neurons/synapses added/removed)
-   * - Between mutations in the same batch with constant focus list
-   */
   public clearFocusCache(): void {
     this.cacheFocus.clear();
     this.cacheFocusList = undefined;
   }
 
-  /**
-   * Invalidate the cached score components.
-   * Should be called whenever structure changes (neurons/synapses added/removed,
-   * squash functions changed).
-   * Issue #1023: Performance optimization for large creatures.
-   */
   public invalidateScoreCache() {
     this.cachedScoreComponents = undefined;
-    // Issue #1118: Invalidate WASM eligibility cache on structural changes
-    // (squash functions may have changed)
     this.wasmEligibilityCache = undefined;
   }
 
+  clearState() {
+    delete this.score;
+    this.state.clear();
+    this.disposeWasm();
+  }
+
+  // ── Initialisation (private) ───────────────────────────────────────────
+
   private initialize(options: {
     layers?: { squash?: string; count: number }[];
-    outputLayer?: {
-      squash?: string;
-    };
+    outputLayer?: { squash?: string };
   }) {
     let fixNeeded = false;
-    // Create input neurons
     for (let i = this.input; i--;) {
       const type = "input";
       const neuron = new Neuron(`input-${this.input - i - 1}`, type, 0, this);
@@ -424,14 +239,12 @@ export class Creature implements CreatureInternal {
 
       for (let i = 0; i < options.layers.length; i++) {
         const layer = options.layers[i];
-
         for (let j = 0; j < layer.count; j++) {
           let tmpSquash = layer.squash ?? "*";
           if (tmpSquash === "*") {
             tmpSquash = Activations.pickRandomSquash();
             fixNeeded = true;
           }
-
           const neuron = new Neuron(
             crypto.randomUUID(),
             "hidden",
@@ -445,7 +258,6 @@ export class Creature implements CreatureInternal {
 
         const tmpOutput = this.output;
         this.output = 0;
-
         for (let k = lastStartIndx; k <= lastEndIndx; k++) {
           for (let l = lastEndIndx + 1; l < this.neurons.length; l++) {
             this.connect(k, l, Synapse.randomWeight());
@@ -456,7 +268,6 @@ export class Creature implements CreatureInternal {
         lastEndIndx = this.neurons.length - 1;
       }
 
-      // Create output neurons
       for (let indx = 0; indx < this.output; indx++) {
         const type = "output";
         let squash = Activations.pickRandomSquash();
@@ -482,7 +293,6 @@ export class Creature implements CreatureInternal {
         }
       }
     } else {
-      // Create output neurons
       for (let indx = 0; indx < this.output; indx++) {
         const type = "output";
         const neuron = new Neuron(
@@ -497,10 +307,8 @@ export class Creature implements CreatureInternal {
         fixNeeded = true;
       }
 
-      // Connect input neurons with output neurons directly
       for (let i = 0; i < this.input; i++) {
         for (let j = this.input; j < this.output + this.input; j++) {
-          /** https://stats.stackexchange.com/a/248040/147931 */
           const weight = getRandomNumberGenerator().random() * this.input *
             Math.sqrt(2 / this.input);
           this.connect(i, j, weight);
@@ -513,45 +321,13 @@ export class Creature implements CreatureInternal {
     }
   }
 
-  /**
-   * Clear the context of the creature.
-   */
-  clearState() {
-    delete this.score;
-    this.state.clear();
-    // Clear WASM cache - structure may have changed
-    // Issue #1118: WASM Migration Phase 1
-    this.disposeWasm();
-  }
+  // ── Activation ─────────────────────────────────────────────────────────
 
-  private prepareNeurons() {
-    if (this.state.preparedNeurons) {
-      return;
-    }
-    for (let i = this.input, len = this.neurons.length; i < len; i++) {
-      this.neurons[i].prepare();
-    }
-    this.state.preparedNeurons = true;
-  }
-
-  /**
-   * Activates the creature and traces the activity.
-   *
-   * Issue #1314 - Input values are validated to be finite. Non-finite values
-   * (Infinity, -Infinity, NaN) will throw an error to prevent corruption.
-   *
-   * @param {Float32Array} input - The input values for the creature.
-   * @param {boolean} feedbackLoop - Whether to use a feedback loop during activation.
-   * @param {SparseConfig} sparseConfig - The sparse configuration for tracing.
-   * @returns {Float32Array} The output values after activation.
-   * @throws {Error} If any input value is not finite.
-   */
   activateAndTrace(
     input: Float32Array,
     feedbackLoop: boolean,
     sparseConfig: SparseConfigLike,
   ): Float32Array {
-    // Issue #1314: Validate that all input values are finite
     for (let i = 0; i < input.length; i++) {
       if (!Number.isFinite(input[i])) {
         throw new Error(
@@ -561,37 +337,19 @@ export class Creature implements CreatureInternal {
         );
       }
     }
-
-    // Issue #1193: For forward-only creatures, feedbackLoop has no effect since there
-    // are no recurrent connections. Normalize to false for consistency and performance.
     const effectiveFeedbackLoop = this.forwardOnly === true
       ? false
       : feedbackLoop;
-
-    this.requireWasmOrThrow();
-    return this.activateAndTraceWasm(
+    activation.requireWasmOrThrow(this);
+    return activation.activateAndTraceWasm(
+      this,
       input,
       effectiveFeedbackLoop,
       sparseConfig,
     );
   }
 
-  /**
-   * Activates the creature without calculating traces.
-   *
-   * Issue #1314 - Input values are validated to be finite. Non-finite values
-   * (Infinity, -Infinity, NaN) will throw an error to prevent corruption.
-   *
-   * @param {Float32Array} input - The input values for the creature.
-   * @param {boolean} [feedbackLoop=false] - Whether to use a feedback loop during activation.
-   * @returns {Float32Array} The output values after activation.
-   * @throws {Error} If any input value is not finite.
-   */
-  activate(
-    input: Float32Array,
-    feedbackLoop: boolean = false,
-  ): Float32Array {
-    // Issue #1314: Validate that all input values are finite
+  activate(input: Float32Array, feedbackLoop: boolean = false): Float32Array {
     for (let i = 0; i < input.length; i++) {
       if (!Number.isFinite(input[i])) {
         throw new Error(
@@ -601,366 +359,37 @@ export class Creature implements CreatureInternal {
         );
       }
     }
-
-    // Issue #1193: For forward-only creatures, feedbackLoop has no effect since there
-    // are no recurrent connections. Normalize to false for consistency and performance.
     const effectiveFeedbackLoop = this.forwardOnly === true
       ? false
       : feedbackLoop;
-
-    this.requireWasmOrThrow();
-    return this.activateWasm(input, effectiveFeedbackLoop);
+    activation.requireWasmOrThrow(this);
+    return activation.activateWasm(this, input, effectiveFeedbackLoop);
   }
 
-  /**
-   * Check if this creature can use WASM activation.
-   * Returns true if WASM is available and all squash functions are supported.
-   * Issue #1118: WASM Migration Phase 1.
-   *
-   * @returns {boolean} True if WASM activation can be used.
-   */
-  /**
-   * Issue #1263: WASM activation is mandatory. Throws if WASM could not be loaded
-   * or creature is not WASM-eligible.
-   */
-  private requireWasmOrThrow(): void {
-    if (!isWasmActivationAvailable()) {
-      throw new Error(
-        "WASM activation could not be loaded. Ensure the NEAT-AI package is installed correctly. " +
-          "WASM activation is required.",
-      );
-    }
-    if (!this.isWasmEligible()) {
-      const unsupported = this.getUnsupportedWasmSquashFunctions();
-      throw new Error(
-        "This creature uses squash functions not supported by the current backend: " +
-          unsupported.join(", ") +
-          ". WASM activation is required.",
-      );
-    }
+  /** @internal Expose preparedNeurons flag for activation module */
+  get preparedNeurons(): boolean {
+    return this.state.preparedNeurons;
+  }
+  set preparedNeurons(value: boolean) {
+    this.state.preparedNeurons = value;
   }
 
-  /**
-   * Activate the creature using WASM. Backend is an implementation detail (Issue #1256).
-   * Lazily compiles the creature to WASM on first call.
-   *
-   * @param {Float32Array} input - The input values for the creature.
-   * @returns {Float32Array} The output values after activation.
-   */
-  private activateWasm(
-    input: Float32Array,
-    feedbackLoop: boolean,
-  ): Float32Array {
-    // Lazily compile to WASM if not already done
-    // Issue #1301: Use topology-based caching to avoid redundant compilation
-    if (!this.cachedWasmActivation) {
-      // Try to get from cache first (uses topology hash for cache key)
-      this.cachedWasmActivation = getOrCompileWasmModule(this) ?? undefined;
-
-      // Issue #1338: Under memory pressure (common in long-running parallel data-gen),
-      // instantiating `CompiledNetwork` can trap. Best-effort: evict old cached WASM
-      // activations and retry once before failing fast.
-      if (!this.cachedWasmActivation) {
-        evictOldestWasmCreatureActivations(64);
-        this.cachedWasmActivation = getOrCompileWasmModule(this) ?? undefined;
-      }
-
-      if (!this.cachedWasmActivation) {
-        // At this point WASM was selected and eligibility was already checked.
-        // Failing to instantiate the WASM network is unexpected; fail fast rather
-        // than silently falling back to JS and masking the problem.
-        fail(
-          "WASM activation was selected but failed to instantiate CompiledNetwork",
-        );
-      }
-
-      // Optimisation: for v4+ creatures explicitly marked forward-only, we can
-      // skip resetting WASM activation state when feedbackLoop=false because
-      // there are no recurrent/back edges that can read stale activations.
-      const major = Number.parseInt(
-        this.semanticVersion.split(".")[0] ?? "0",
-        10,
-      );
-      const forwardOnlyGuaranteed = Number.isFinite(major) && major >= 4 &&
-        this.forwardOnly === true;
-      this.cachedWasmActivation.setNeedsResetWhenStateless(
-        !forwardOnlyGuaranteed,
-      );
-    }
-
-    noteWasmCreatureActivationUse(this);
-
-    // `activate()` should be fast and output-only.
-    // Tracing/state backfill belongs in `activateAndTrace()`.
-    return this.cachedWasmActivation.activateWithState(input, feedbackLoop);
-  }
-
-  /**
-   * Activate the creature using WASM with tracing support for backpropagation.
-   * Issue #1121: WASM Migration Phase 4 - activateAndTrace
-   *
-   * This method:
-   * 1. Compiles the creature to WASM format (cached)
-   * 2. Calls the WASM activate_and_trace method
-   * 3. Applies the trace data to the creature's state (synapse usage flags)
-   * 4. Sets hintValues for backpropagation
-   *
-   * @param {Float32Array} input - The input values for the creature.
-   * @param {boolean} feedbackLoop - Whether to use a feedback loop during activation.
-   * @param {SparseConfig} sparseConfig - The sparse configuration for tracing.
-   * @returns {Float32Array} The output values after activation.
-   */
-  private activateAndTraceWasm(
-    input: Float32Array,
-    feedbackLoop: boolean,
-    sparseConfig: SparseConfigLike,
-  ): Float32Array {
-    // Lazily compile to WASM if not already done
-    // Issue #1301: Use topology-based caching to avoid redundant compilation
-    if (!this.cachedWasmActivation) {
-      // Try to get from cache first (uses topology hash for cache key)
-      this.cachedWasmActivation = getOrCompileWasmModule(this) ?? undefined;
-
-      // Issue #1338: Best-effort eviction + retry under memory pressure.
-      if (!this.cachedWasmActivation) {
-        evictOldestWasmCreatureActivations(64);
-        this.cachedWasmActivation = getOrCompileWasmModule(this) ?? undefined;
-      }
-
-      if (!this.cachedWasmActivation) {
-        fail(
-          "WASM activateAndTrace was selected but failed to instantiate CompiledNetwork",
-        );
-      }
-    }
-
-    noteWasmCreatureActivationUse(this);
-
-    // Prepare state for activation
-    this.prepareNeurons();
-    this.state.makeActivation(input, feedbackLoop);
-
-    // Call WASM activateAndTrace
-    const wasmResult = this.cachedWasmActivation.activateAndTraceWithFeedback(
-      input,
-      feedbackLoop,
-    );
-
-    // Apply activations to the state
-    const neurons = this.neurons;
-    for (let i = 0; i < wasmResult.activations.length; i++) {
-      const neuronIdx = this.input + i;
-      if (neuronIdx < neurons.length) {
-        this.state.activations[neuronIdx] = wasmResult.activations[i];
-      }
-    }
-
-    // Apply trace data to synapse states
-    // The trace entries contain information about which synapses were "used"
-    // for aggregate functions (MINIMUM, MAXIMUM, IF)
-    this.applyWasmTraceData(wasmResult.traceEntries, sparseConfig);
-
-    // Set hintValues for neurons that need propagation
-    // hintValue is the pre-squash value (for standard squash functions)
-    // or the activation (for aggregate functions)
-    for (let i = this.input; i < neurons.length; i++) {
-      const n = neurons[i];
-      if (sparseConfig.propagateNeeded(n.uuid)) {
-        this.state.node(n.index).hintValue =
-          wasmResult.hintValues[i - this.input];
-      }
-    }
-
-    return wasmResult.outputs;
-  }
-
-  /**
-   * Apply WASM trace data to synapse states.
-   * Issue #1121: WASM Migration Phase 4 - activateAndTrace
-   *
-   * This sets the `used` flag on synapse states for aggregate functions:
-   * - For MINIMUM/MAXIMUM: only the winning synapse is marked as used
-   * - For IF: condition synapses and active branch synapses are marked as used
-   * - For standard squash: all synapses are implicitly used (no action needed)
-   *
-   * @param traceEntries - The trace entries from WASM activation
-   * @param sparseConfig - The sparse configuration for tracing
-   */
-  private applyWasmTraceData(
-    traceEntries: Array<{ neuronRelativeIndex: number; traceInfo: number }>,
-    sparseConfig: SparseConfigLike,
-  ): void {
-    const neurons = this.neurons;
-
-    for (const entry of traceEntries) {
-      const neuronIdx = this.input + entry.neuronRelativeIndex;
-      if (neuronIdx >= neurons.length) continue;
-
-      const neuron = neurons[neuronIdx];
-      if (!sparseConfig.traceNeeded(neuron.uuid)) continue;
-
-      const inwardList = this.inwardConnections(neuronIdx);
-      if (inwardList.length === 0) continue;
-
-      // Sort by from index to match WASM ordering
-      const sortedInward = inwardList.slice().sort((a, b) => a.from - b.from);
-
-      const squash = neuron.squash ?? "IDENTITY";
-
-      if (squash === "MINIMUM" || squash === "MAXIMUM") {
-        // For MINIMUM/MAXIMUM: traceInfo is the local synapse index of the winning synapse
-        const winningLocalIdx = Math.round(entry.traceInfo);
-
-        // Mark all synapses as not used initially
-        for (const c of sortedInward) {
-          const cs = this.state.connection(c.from, c.to);
-          if (cs.used === undefined) cs.used = false;
-        }
-
-        // Mark only the winning synapse as used
-        if (winningLocalIdx >= 0 && winningLocalIdx < sortedInward.length) {
-          const winningConnection = sortedInward[winningLocalIdx];
-          this.state.connection(winningConnection.from, winningConnection.to)
-            .used = true;
-        }
-      } else if (squash === "IF") {
-        // For IF: traceInfo is 1.0 for positive branch, 0.0 for negative branch
-        const positiveBranch = entry.traceInfo > 0.5;
-
-        if (positiveBranch) {
-          // Positive branch: mark positive/standard synapses as used
-          for (const c of sortedInward) {
-            const cs = this.state.connection(c.from, c.to);
-            switch (c.type) {
-              case "condition":
-              case "negative":
-                if (cs.used === undefined) cs.used = false;
-                break;
-              default:
-                cs.used = true;
-            }
-          }
-        } else {
-          // Negative branch: mark negative synapses as used
-          for (const c of sortedInward) {
-            if (c.type === "negative") {
-              this.state.connection(c.from, c.to).used = true;
-            }
-          }
-        }
-      }
-    }
-
-    // For non-aggregate neurons that need tracing, mark all synapses as used
-    // (This matches the JS behaviour for standard squash functions)
-    for (let i = this.input; i < neurons.length; i++) {
-      const n = neurons[i];
-      if (!sparseConfig.traceNeeded(n.uuid)) continue;
-
-      const squash = n.squash ?? "IDENTITY";
-      if (squash === "MINIMUM" || squash === "MAXIMUM" || squash === "IF") {
-        // Already handled by trace entries
-        continue;
-      }
-
-      // Standard squash: all synapses are used
-      const inwardList = this.inwardConnections(i);
-      for (const c of inwardList) {
-        const cs = this.state.connection(c.from, c.to);
-        cs.used = true;
-      }
-    }
-  }
-
-  /**
-   * Check if this creature is eligible for WASM activation.
-   * A creature is eligible if all its neurons use WASM-supported squash functions.
-   * The result is cached and invalidated when structure changes.
-   * Issue #1118: WASM Migration Phase 1.
-   *
-   * @returns {boolean} True if all squash functions are WASM-supported.
-   */
   isWasmEligible(): boolean {
-    // Return cached result if available
-    if (this.wasmEligibilityCache !== undefined) {
-      return this.wasmEligibilityCache;
-    }
-
-    // Check all non-input neurons for supported squash functions
-    const unsupported = this.getUnsupportedWasmSquashFunctions();
-    this.wasmEligibilityCache = unsupported.length === 0;
-
-    return this.wasmEligibilityCache;
+    return activation.isWasmEligible(this);
   }
 
-  /**
-   * Get the list of squash functions used by this creature that are not supported by WASM.
-   * Issue #1118: WASM Migration Phase 1.
-   *
-   * @returns {string[]} Array of unsupported squash function names (empty if all are supported).
-   */
   getUnsupportedWasmSquashFunctions(): string[] {
-    const unsupported: string[] = [];
-    const seen = new Set<string>();
-
-    for (let i = this.input; i < this.neurons.length; i++) {
-      const neuron = this.neurons[i];
-      const squash = neuron.squash ?? "IDENTITY";
-
-      // Skip if we've already checked this squash function
-      if (seen.has(squash)) {
-        continue;
-      }
-      seen.add(squash);
-
-      // Check if squash function is in the WASM-supported list (or aliases to one)
-      if (resolveWasmSquashName(squash) === undefined) {
-        unsupported.push(squash);
-      }
-    }
-
-    return unsupported;
+    return activation.getUnsupportedWasmSquashFunctions(this);
   }
 
-  /**
-   * Dispose of cached WASM resources.
-   * Call this when the creature structure changes or when done using WASM activation.
-   * Issue #1118: WASM Migration Phase 1.
-   */
   disposeWasm(): void {
-    if (this.cachedWasmActivation) {
-      this.cachedWasmActivation.free();
-      this.cachedWasmActivation = undefined;
-    }
-    this.wasmEligibilityCache = undefined;
+    activation.disposeWasm(this);
   }
 
-  /**
-   * Extracts output values from the activations array.
-   *
-   * @param {Float32Array} activations - The full activations array.
-   * @param {number} lastHiddenNode - The index of the first output neuron.
-   * @returns {Float32Array} The output values.
-   */
-  private extractOutputs(
-    activations: Float32Array,
-    lastHiddenNode: number,
-  ): Float32Array {
-    return new Float32Array(activations.subarray(lastHiddenNode));
-  }
-
-  /**
-   * Compact the creature by removing redundant neurons and connections.
-   *
-   * @returns {Creature | undefined} A new compacted creature or undefined if no compaction occurred.
-   */
   compact(feedbackLoop: boolean): Creature | undefined {
     return compactCreature(this, feedbackLoop);
   }
 
-  /**
-   * Validate the creature structure.
-   */
   validate(options?: {
     neurons?: number;
     connections?: number;
@@ -970,459 +399,81 @@ export class Creature implements CreatureInternal {
     creatureValidate(this, options);
   }
 
-  /**
-   * Get a self-connection for the neuron at the given index.
-   *
-   * @param {number} indx - The index of the neuron.
-   * @returns {SynapseInternal | null} The self-connection or null if not found.
-   */
+  // ── Topology ───────────────────────────────────────────────────────────
+
   selfConnection(indx: number): SynapseInternal | null {
-    let results = this.cacheSelf.get(indx);
-    if (results === undefined) {
-      results = [];
-      const tmpList = this.synapses;
-      for (let i = tmpList.length; i--;) {
-        const c = tmpList[i];
-        if (c.to === indx && c.from === indx) {
-          results.push(c);
-        }
-      }
-
-      this.cacheSelf.set(indx, results);
-    }
-
-    if (results.length > 0) {
-      return results[0];
-    } else {
-      return null;
-    }
+    return topology.selfConnection(this, this._topoCaches, indx);
   }
 
-  /**
-   * Get the inward connections (afferent) for the neuron at the given index.
-   * Uses a secondary index sorted by `to` field for O(log n) binary search lookup.
-   * Issue #1010: Performance optimisation for large creatures.
-   *
-   * @param {number} toIndx - The index of the target neuron.
-   * @returns {Synapse[]} The list of inward connections.
-   */
   inwardConnections(toIndx: number): Synapse[] {
-    let results = this.cacheTo.get(toIndx);
-    if (results === undefined) {
-      results = this.lookupInwardConnections(toIndx);
-      this.cacheTo.set(toIndx, results);
-    }
-    return results;
+    return topology.inwardConnections(this, this._topoCaches, toIndx);
   }
 
-  /**
-   * Builds the secondary index of synapses sorted by `to` field.
-   * Called lazily when first needed for inward connection lookups.
-   * Issue #1010: Performance optimisation for large creatures.
-   */
-  private buildSynapsesIndexedByTo(): Synapse[] {
-    // Create a copy of synapses sorted by 'to' field, then by 'from' for stability
-    const indexed = this.synapses.slice().sort((a, b) => {
-      if (a.to !== b.to) return a.to - b.to;
-      return a.from - b.from;
-    });
-    return indexed;
-  }
-
-  /**
-   * Binary search for the start index in the secondary (to-sorted) index.
-   * Issue #1010: Performance optimisation for large creatures.
-   */
-  private binarySearchForToStartIndex(
-    index: Synapse[],
-    toIndx: number,
-  ): number {
-    let low = 0;
-    let high = index.length - 1;
-    let result = -1;
-
-    while (low <= high) {
-      const mid = Math.floor((low + high) / 2);
-      const midValue = index[mid];
-
-      if (midValue.to < toIndx) {
-        low = mid + 1;
-      } else if (midValue.to > toIndx) {
-        high = mid - 1;
-      } else {
-        result = mid; // Found a matching 'to', but need the first occurrence
-        high = mid - 1; // Look left to find the first match
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Threshold for switching from linear scan to building the secondary index.
-   * If we've done this many cache misses, it's worth building the sorted index.
-   * Issue #1010: Performance optimisation for large creatures.
-   */
-  private inwardCacheMissCount = 0;
-  private static readonly INWARD_INDEX_BUILD_THRESHOLD = 3;
-
-  /**
-   * Minimum number of synapses to trigger proactive index prebuilding.
-   * Only prebuild for large creatures where the upfront cost is worthwhile.
-   * Issue #1097: Performance - Prebuild inward synapse index after breed/mutation batch.
-   */
-  public static readonly PREBUILD_SYNAPSE_THRESHOLD = 1000;
-
-  /**
-   * Looks up inward connections using binary search on the secondary index.
-   * Falls back to linear scan if index is not built.
-   * Automatically builds the index after a few cache misses.
-   * Issue #1010: Performance optimisation for large creatures.
-   */
-  private lookupInwardConnections(toIndx: number): Synapse[] {
-    // If we have the secondary index, use binary search
-    if (this.synapsesIndexedByTo !== null) {
-      const index = this.synapsesIndexedByTo;
-      const startIndex = this.binarySearchForToStartIndex(index, toIndx);
-
-      if (startIndex === -1) {
-        return []; // No inward connections found
-      }
-
-      // Collect all synapses with matching 'to' index
-      const results: Synapse[] = [];
-      for (let i = startIndex; i < index.length; i++) {
-        const synapse = index[i];
-        if (synapse.to === toIndx) {
-          results.push(synapse);
-        } else {
-          break; // Since it's sorted, no need to continue once 'to' changes
-        }
-      }
-
-      return results;
-    }
-
-    // Track cache misses - if we're doing many lookups, build the index
-    this.inwardCacheMissCount++;
-    if (this.inwardCacheMissCount >= Creature.INWARD_INDEX_BUILD_THRESHOLD) {
-      // Build the index and use binary search for this and future lookups
-      this.synapsesIndexedByTo = this.buildSynapsesIndexedByTo();
-      return this.lookupInwardConnections(toIndx); // Recurse with index now built
-    }
-
-    // Fallback: linear scan for sparse lookups (O(n) but no sorting overhead)
-    const results: Synapse[] = [];
-    for (let i = 0, len = this.synapses.length; i < len; i++) {
-      const synapse = this.synapses[i];
-      if (synapse.to === toIndx) {
-        results.push(synapse);
-      }
-    }
-    return results;
-  }
-
-  /**
-   * Pre-builds the secondary index for inward connections.
-   * Call this after loading a creature or after a batch of mutations
-   * to optimise subsequent lookups.
-   * Issue #1010: Performance optimisation for large creatures.
-   */
   public prebuildInwardIndex(): void {
-    if (this.synapsesIndexedByTo === null) {
-      this.synapsesIndexedByTo = this.buildSynapsesIndexedByTo();
-    }
+    topology.prebuildInwardIndex(this, this._topoCaches);
   }
 
-  /**
-   * Checks if the inward synapse index has been built.
-   * This is primarily used for testing the prebuild optimisation.
-   * Issue #1097: Performance - Prebuild inward synapse index after breed/mutation batch.
-   *
-   * @returns {boolean} True if the index has been built, false otherwise.
-   */
   public isInwardIndexBuilt(): boolean {
-    return this.synapsesIndexedByTo !== null;
+    return topology.isInwardIndexBuilt(this._topoCaches);
   }
 
-  /**
-   * Conditionally prebuilds the inward index for large creatures.
-   * Only prebuilds if the creature has many synapses (>= PREBUILD_SYNAPSE_THRESHOLD).
-   * Issue #1097: Performance - Prebuild inward synapse index after breed/mutation batch.
-   */
   public prebuildInwardIndexIfLarge(): void {
-    if (this.synapses.length >= Creature.PREBUILD_SYNAPSE_THRESHOLD) {
-      this.prebuildInwardIndex();
-    }
+    topology.prebuildInwardIndexIfLarge(this, this._topoCaches);
   }
 
-  /**
-   * Bulk loads all inward connections into the cache.
-   * Use this when you know you'll need to look up many neurons.
-   * Issue #1010: Performance optimisation for large creatures.
-   */
   public bulkLoadInwardConnections(): void {
-    // Build secondary index if not already built
-    if (this.synapsesIndexedByTo === null) {
-      this.synapsesIndexedByTo = this.buildSynapsesIndexedByTo();
-    }
-
-    // Pre-populate cache for all neurons
-    const cacheTo = this.cacheTo;
-    for (let indx = 0, len = this.neurons.length; indx < len; indx++) {
-      if (!cacheTo.has(indx)) {
-        cacheTo.set(indx, []);
-      }
-    }
-
-    // Group synapses by their 'to' index using the sorted index
-    const index = this.synapsesIndexedByTo;
-    for (let i = 0, len = index.length; i < len; i++) {
-      const synapse = index[i];
-      const to = synapse.to;
-      const tmpResults = cacheTo.get(to);
-      if (tmpResults) {
-        tmpResults.push(synapse);
-      }
-    }
+    topology.bulkLoadInwardConnections(this, this._topoCaches);
   }
 
-  /**
-   * Builds and returns a Set of existing connections as "from-to" strings.
-   * Enables O(1) lookup for connection existence checks.
-   * Issue #1036: Performance optimisation for ADD_CONNECTION mutation.
-   *
-   * @returns {Set<string>} Set of connection keys in "from-to" format
-   */
   public getConnectionSet(): Set<string> {
-    if (this.connectionSet === null) {
-      this.connectionSet = new Set<string>();
-      for (let i = 0, len = this.synapses.length; i < len; i++) {
-        const synapse = this.synapses[i];
-        this.connectionSet.add(`${synapse.from}-${synapse.to}`);
-      }
-    }
-    return this.connectionSet;
+    return topology.getConnectionSet(this, this._topoCaches);
   }
 
-  /**
-   * Checks if a connection exists between two neurons in O(1) time.
-   * Issue #1036: Performance optimisation for ADD_CONNECTION mutation.
-   *
-   * @param {number} from - The index of the source neuron.
-   * @param {number} to - The index of the target neuron.
-   * @returns {boolean} True if the connection exists, false otherwise.
-   */
   public hasConnection(from: number, to: number): boolean {
-    return this.getConnectionSet().has(`${from}-${to}`);
+    return topology.hasConnection(this, this._topoCaches, from, to);
   }
 
-  /**
-   * Builds and returns a cached Set of hidden neuron UUIDs.
-   * Enables O(1) lookup for genetic compatibility checks.
-   * Issue #1032: Performance optimisation for genetic compatibility checks.
-   *
-   * @returns {Set<string>} Set of hidden neuron UUIDs
-   */
   public getHiddenNeuronUUIDs(): Set<string> {
-    if (this.hiddenNeuronUUIDs === null) {
-      this.hiddenNeuronUUIDs = new Set<string>();
-      for (let i = this.input, len = this.neurons.length; i < len; i++) {
-        const neuron = this.neurons[i];
-        if (neuron.type === "hidden") {
-          this.hiddenNeuronUUIDs.add(neuron.uuid);
-        }
-      }
-    }
-    return this.hiddenNeuronUUIDs;
+    return topology.getHiddenNeuronUUIDs(this, this._topoCaches);
   }
 
-  /**
-   * Returns a list of available forward-only connection slots (from, to pairs).
-   * This method efficiently finds all valid connection pairs where:
-   * - from < to (forward-only)
-   * - to >= input (cannot connect to input neurons)
-   * - target neuron is not a constant
-   * - connection doesn't already exist
-   *
-   * Issue #1036: Performance optimisation for ADD_CONNECTION mutation.
-   * Issue #1098: Results are cached and invalidated on structure changes.
-   *
-   * @param {number[]} [focusList] - Optional list of neuron indices to focus on.
-   *   When provided, returns only connections involving focused neurons or their paths.
-   * @returns {[number, number][]} Array of [from, to] tuples representing available connections.
-   */
   public getAvailableConnections(focusList?: number[]): [number, number][] {
-    // Build and cache all available connections if not already cached
-    if (this.availableConnectionsCache === null) {
-      this.availableConnectionsCache = this.computeAvailableConnections();
-    }
-
-    // If no focus list provided, return the cached array directly
-    if (!focusList || focusList.length === 0) {
-      return this.availableConnectionsCache;
-    }
-
-    // Filter cached connections based on focus list
-    return this.availableConnectionsCache.filter(([from, to]) => {
-      return this.inFocus(from, focusList) || this.inFocus(to, focusList);
-    });
+    return topology.getAvailableConnections(
+      this,
+      this._topoCaches,
+      focusList,
+      (index, fl) => this.inFocus(index, fl),
+    );
   }
 
-  /**
-   * Computes all available forward-only connection slots.
-   * This is called internally to build the cache.
-   * Issue #1098: Extracted to support caching.
-   *
-   * @returns {[number, number][]} Array of [from, to] tuples.
-   */
-  private computeAvailableConnections(): [number, number][] {
-    const connectionSet = this.getConnectionSet();
-    const available: [number, number][] = [];
-    const neurons = this.neurons;
-    const neuronCount = neurons.length;
-    const inputCount = this.input;
-
-    for (let fromIndx = 0; fromIndx < neuronCount; fromIndx++) {
-      // Start toIndx at max(fromIndx + 1, input) to ensure forward-only connections
-      // and that we don't connect to input neurons
-      const startTo = Math.max(fromIndx + 1, inputCount);
-
-      for (let toIndx = startTo; toIndx < neuronCount; toIndx++) {
-        const neuronTo = neurons[toIndx];
-
-        // Skip constant neurons
-        if (neuronTo.type === "constant") continue;
-
-        // Check if connection already exists using O(1) Set lookup
-        const key = `${fromIndx}-${toIndx}`;
-        if (!connectionSet.has(key)) {
-          available.push([fromIndx, toIndx]);
-        }
-      }
-    }
-
-    return available;
-  }
-
-  /**
-   * Checks if the available connections cache has been built.
-   * This is primarily used for testing the cache optimisation.
-   * Issue #1098: Performance - Cache available connection pairs.
-   *
-   * @returns {boolean} True if the cache has been built, false otherwise.
-   */
   public isAvailableConnectionsCacheBuilt(): boolean {
-    return this.availableConnectionsCache !== null;
+    return topology.isAvailableConnectionsCacheBuilt(this._topoCaches);
   }
 
-  /**
-   * Get the outward connections (efferent) for the neuron at the given index.
-   *
-   * @param {number} fromIndx - The index of the source neuron.
-   * @returns {Synapse[]} The list of outward connections.
-   */
   outwardConnections(fromIndx: number): Synapse[] {
-    let results = this.cacheFrom.get(fromIndx);
-    if (results === undefined) {
-      const startIndex = this.binarySearchForStartIndex(fromIndx);
-
-      if (startIndex !== -1) {
-        results = [];
-        for (let i = startIndex; i < this.synapses.length; i++) {
-          const tmp = this.synapses[i];
-          if (tmp.from === fromIndx) {
-            results.push(tmp);
-          } else {
-            break; // Since it's sorted, no need to continue once 'from' changes
-          }
-        }
-      } else {
-        results = []; // No connections found
-      }
-
-      this.cacheFrom.set(fromIndx, results);
-    }
-    return results;
+    return topology.outwardConnections(this, this._topoCaches, fromIndx);
   }
 
-  private binarySearchForStartIndex(fromIndx: number): number {
-    let low = 0;
-    let high = this.synapses.length - 1;
-    let result = -1; // Default to -1 if not found
-
-    while (low <= high) {
-      const mid = Math.floor((low + high) / 2);
-      const midValue = this.synapses[mid];
-
-      if (midValue.from < fromIndx) {
-        low = mid + 1;
-      } else if (midValue.from > fromIndx) {
-        high = mid - 1;
-      } else {
-        result = mid; // Found a matching 'from', but need the first occurrence
-        high = mid - 1; // Look left to find the first match
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Get a specific synapse between two neurons.
-   *
-   * @param {number} from - The index of the source neuron.
-   * @param {number} to - The index of the target neuron.
-   * @returns {Synapse | null} The synapse or null if not found.
-   */
   getSynapse(from: number, to: number): Synapse | null {
-    const outwardConnections = this.outwardConnections(from);
-
-    for (let indx = outwardConnections.length; indx--;) {
-      const c = outwardConnections[indx];
-      if (c.to === to) {
-        return c;
-      } else if (c.to < to) {
-        break;
-      }
-    }
-
-    return null;
+    return topology.getSynapse(this, this._topoCaches, from, to);
   }
 
-  /**
-   * Connect two neurons with a synapse.
-   *
-   * @param {number} from - The index of the source neuron.
-   * @param {number} to - The index of the target neuron.
-   * @param {number} weight - The weight of the synapse.
-   * @param {string} [type] - The type of the synapse.
-   * @returns {Synapse} The created synapse.
-   */
   connect(
     from: number,
     to: number,
     weight: number,
     type?: "positive" | "negative" | "condition",
   ): Synapse {
-    const connection = new Synapse(
-      from,
-      to,
-      weight,
-      type,
-    );
+    const connection = new Synapse(from, to, weight, type);
 
     let location = -1;
-
     for (let indx = this.synapses.length; indx--;) {
       const c = this.synapses[indx];
-
       if (c.from < from) {
         location = indx + 1;
         break;
       } else if (c.from === from) {
         assert(c.to !== to, "Connection already exists");
-
         if (c.to < to) {
           location = indx + 1;
           break;
@@ -1434,8 +485,6 @@ export class Creature implements CreatureInternal {
       }
     }
     if (location !== -1 && location < this.synapses.length) {
-      // Use splice() for in-place insertion - Issue #1093
-      // This reduces memory allocations from 3 to 0 compared to slice/spread
       this.synapses.splice(location, 0, connection);
     } else {
       this.synapses.push(connection);
@@ -1443,20 +492,11 @@ export class Creature implements CreatureInternal {
 
     this.clearCache(from, to);
     this.invalidateScoreCache();
-
     return connection;
   }
 
-  /**
-   * Disconnect two neurons by removing the synapse between them.
-   * Uses binary search for O(log n) lookup since synapses are sorted by (from, to).
-   * Issue #1101: Performance optimisation for large creatures.
-   *
-   * @param {number} from - The index of the source neuron.
-   * @param {number} to - The index of the target neuron.
-   */
   disconnect(from: number, to: number) {
-    const indx = this.binarySearchSynapse(from, to);
+    const indx = topology.binarySearchSynapse(this, from, to);
     if (indx !== -1) {
       this.synapses.splice(indx, 1);
       this.clearCache(from, to);
@@ -1464,19 +504,6 @@ export class Creature implements CreatureInternal {
     }
   }
 
-  /**
-   * Batch connect multiple synapses with a single cache invalidation.
-   * Issue #1102: Performance optimisation for operations that add multiple synapses.
-   *
-   * This method is significantly more efficient than calling connect() in a loop
-   * because it:
-   * 1. Sorts connections first to enable efficient insertion
-   * 2. Validates all connections before inserting any
-   * 3. Invalidates caches only once at the end
-   *
-   * @param connections Array of connection specifications
-   * @throws {Error} If any connection already exists or duplicates exist within batch
-   */
   connectBatch(
     connections: Array<{
       from: number;
@@ -1485,11 +512,8 @@ export class Creature implements CreatureInternal {
       type?: "positive" | "negative" | "condition";
     }>,
   ): void {
-    if (connections.length === 0) {
-      return;
-    }
+    if (connections.length === 0) return;
 
-    // Check for duplicates within the batch using a Set
     const batchSet = new Set<string>();
     for (const conn of connections) {
       const key = `${conn.from}-${conn.to}`;
@@ -1499,9 +523,8 @@ export class Creature implements CreatureInternal {
       batchSet.add(key);
     }
 
-    // Check that none of the connections already exist
     for (const conn of connections) {
-      const existing = this.binarySearchSynapse(conn.from, conn.to);
+      const existing = topology.binarySearchSynapse(this, conn.from, conn.to);
       if (existing !== -1) {
         throw new Error(
           `Connection ${conn.from}->${conn.to} already exists in creature`,
@@ -1509,20 +532,14 @@ export class Creature implements CreatureInternal {
       }
     }
 
-    // Sort connections by (from, to) for efficient insertion
     const sortedConnections = [...connections].sort((a, b) => {
-      if (a.from !== b.from) {
-        return a.from - b.from;
-      }
+      if (a.from !== b.from) return a.from - b.from;
       return a.to - b.to;
     });
 
-    // Insert all synapses
-    // We process in reverse order of sorted array when inserting to maintain
-    // correct positions as the array grows
     for (const conn of sortedConnections) {
       const synapse = new Synapse(conn.from, conn.to, conn.weight, conn.type);
-      const location = this.findInsertionPoint(conn.from, conn.to);
+      const location = topology.findInsertionPoint(this, conn.from, conn.to);
       if (location < this.synapses.length) {
         this.synapses.splice(location, 0, synapse);
       } else {
@@ -1530,1542 +547,173 @@ export class Creature implements CreatureInternal {
       }
     }
 
-    // Single cache invalidation at the end
     this.clearCache();
     this.invalidateScoreCache();
   }
 
-  /**
-   * Find the insertion point for a synapse to maintain sorted order.
-   * Uses binary search for O(log n) efficiency.
-   * Issue #1102: Helper method for connectBatch.
-   *
-   * @param from - The source neuron index.
-   * @param to - The target neuron index.
-   * @returns The index where the synapse should be inserted.
-   */
-  private findInsertionPoint(from: number, to: number): number {
-    const synapses = this.synapses;
-    let low = 0;
-    let high = synapses.length;
-
-    while (low < high) {
-      const mid = (low + high) >>> 1;
-      const syn = synapses[mid];
-
-      if (syn.from < from || (syn.from === from && syn.to < to)) {
-        low = mid + 1;
-      } else {
-        high = mid;
-      }
-    }
-
-    return low;
-  }
-
-  /**
-   * Batch disconnect multiple synapses with a single cache invalidation.
-   * Issue #1102: Performance optimisation for operations that remove multiple synapses.
-   *
-   * This method is significantly more efficient than calling disconnect() in a loop
-   * because it:
-   * 1. Finds all synapse indices first
-   * 2. Removes them in descending order to maintain correct indices
-   * 3. Invalidates caches only once at the end
-   *
-   * Non-existent connections are silently ignored.
-   *
-   * @param pairs Array of (from, to) pairs to disconnect
-   */
   disconnectBatch(pairs: Array<{ from: number; to: number }>): void {
-    if (pairs.length === 0) {
-      return;
-    }
+    if (pairs.length === 0) return;
 
-    // Find all indices to remove
     const indices: number[] = [];
     for (const pair of pairs) {
-      const idx = this.binarySearchSynapse(pair.from, pair.to);
-      if (idx !== -1) {
-        indices.push(idx);
-      }
+      const idx = topology.binarySearchSynapse(this, pair.from, pair.to);
+      if (idx !== -1) indices.push(idx);
     }
 
-    if (indices.length === 0) {
-      return;
-    }
+    if (indices.length === 0) return;
 
-    // Sort indices in descending order so we can remove from end to start
-    // without affecting the positions of earlier indices
     indices.sort((a, b) => b - a);
-
-    // Remove each synapse
     for (const idx of indices) {
       this.synapses.splice(idx, 1);
     }
 
-    // Single cache invalidation at the end
     this.clearCache();
     this.invalidateScoreCache();
   }
 
-  /**
-   * Binary search for a synapse by (from, to) indices.
-   * Synapses are sorted first by `from`, then by `to` within the same `from`.
-   * Issue #1101: Performance optimisation for disconnect operations.
-   *
-   * @param {number} from - The source neuron index.
-   * @param {number} to - The target neuron index.
-   * @returns {number} The index of the synapse, or -1 if not found.
-   */
-  private binarySearchSynapse(from: number, to: number): number {
-    const synapses = this.synapses;
-    let low = 0;
-    let high = synapses.length - 1;
+  // ── Focus ──────────────────────────────────────────────────────────────
 
-    while (low <= high) {
-      const mid = (low + high) >>> 1;
-      const syn = synapses[mid];
-
-      if (syn.from < from) {
-        low = mid + 1;
-      } else if (syn.from > from) {
-        high = mid - 1;
-      } else {
-        // syn.from === from, now compare `to`
-        if (syn.to < to) {
-          low = mid + 1;
-        } else if (syn.to > to) {
-          high = mid - 1;
-        } else {
-          return mid; // Found exact match
-        }
-      }
-    }
-
-    return -1; // Not found
-  }
-
-  /**
-   * Apply learnings to the creature using back propagation.
-   *
-   * @param {BackPropagationConfig} config - The back propagation configuration.
-   * @returns {boolean} True if the creature was changed, false otherwise.
-   */
-  applyLearnings(
-    config: BackPropagationConfig,
-    sparseConfig: SparseConfig,
-  ): boolean {
-    this.propagateUpdate(config, sparseConfig);
-
-    let changed = false;
-    for (let indx = this.neurons.length - 1; indx >= this.input; indx--) {
-      if (config.trainingMutationRate > getRandomNumberGenerator().random()) {
-        const n = this.neurons[indx];
-        if (sparseConfig.updateNeeded(n.uuid)) {
-          changed ||= n.applyLearnings();
-        }
-      }
-    }
-
-    if (changed) {
-      delete this.uuid;
-      delete this.memetic;
-      this.state.preparedNeurons = false;
-      this.fix();
-    }
-
-    return changed;
-  }
-
-  /**
-   * Propagate the expected values through the creature's network.
-   *
-   * @param {Float32Array} expected - The expected output values.
-   * @param {BackPropagationConfig} config - The back propagation configuration.
-   */
-  propagate(
-    expected: Float32Array,
-    config: BackPropagationConfig,
-    sparseConfig: SparseConfig,
-  ) {
-    this.state.cacheAdjustedActivation.clear();
-
-    // Issue #1379: Lazily initialise reusable backward pass buffers.
-    if (this.state.backpropBuffers === undefined) {
-      this.state.backpropBuffers = new BackpropBuffers();
-    }
-
-    const neurons = this.neurons;
-    const lastOutputIndx = neurons.length - this.output;
-
-    for (let indx = this.output; indx--;) {
-      const nodeIndex = lastOutputIndx + indx;
-
-      const n = neurons[nodeIndex];
-
-      if (sparseConfig.propagateNeeded(n.uuid)) {
-        n.propagate(
-          expected[indx],
-          config,
-          sparseConfig,
-        );
-      }
-    }
-  }
-
-  /**
-   * Record the expected values for back propagation.
-   *
-   * @param {Float32Array} expected - The expected output values.
-   * @param {BackPropagationConfig} config - The back propagation configuration.
-   */
-  record(
-    expected: Float32Array,
-  ): Map<string, DiscoverRecord> {
-    const neurons = this.neurons;
-    const lastOutputIndx = neurons.length - this.output;
-
-    const errorMap = new Map<string, DiscoverRecord>();
-    for (let indx = this.output; indx--;) {
-      const nodeIndex = lastOutputIndx + indx;
-
-      const n = neurons[nodeIndex];
-
-      n.record(
-        expected[indx],
-        errorMap,
-      );
-    }
-
-    // DIAGNOSTIC: Check for excessive total error count per sample
-    let totalErrors = 0;
-    for (const record of errorMap.values()) {
-      totalErrors += record.errors.length;
-    }
-
-    // Expected: approximately neurons.length * output (one error per neuron per output)
-    const expectedMax = neurons.length * this.output * 3;
-    if (totalErrors > expectedMax) {
-      getLogger().error(
-        `❌ CRITICAL: Sample generated ${totalErrors} total errors (expected ≤${expectedMax})`,
-      );
-      getLogger().error(
-        `   Neurons: ${neurons.length}, Outputs: ${this.output}, ErrorMap size: ${errorMap.size}`,
-      );
-      // Log top 5 neurons with most errors
-      const sorted = Array.from(errorMap.entries())
-        .sort((a, b) => b[1].errors.length - a[1].errors.length)
-        .slice(0, 5);
-      getLogger().error(`   Top 5 neurons by error count:`);
-      sorted.forEach(([uuid, rec]) => {
-        getLogger().error(`     - ${uuid}: ${rec.errors.length} errors`);
-      });
-
-      if (totalErrors > expectedMax * 10) {
-        throw new Error(
-          `Excessive errors detected: ${totalErrors} total errors in single sample ` +
-            `(expected ≤${expectedMax}). This indicates record() is being called too many times, ` +
-            `causing the performance issue and timeout.`,
-        );
-      }
-    }
-
-    return errorMap;
-  }
-
-  /**
-   * Update the propagated values in the creature's network.
-   *
-   * @param {BackPropagationConfig} config - The back propagation configuration.
-   */
-  propagateUpdate(config: BackPropagationConfig, sparseConfig: SparseConfig) {
-    let didUpdate = false;
-    for (let indx = this.input; indx < this.neurons.length; indx++) {
-      const n = this.neurons[indx];
-      if (sparseConfig.updateNeeded(n.uuid)) {
-        n.propagateUpdate(config);
-        didUpdate = true;
-      }
-    }
-    this.state.preparedNeurons = false;
-
-    // If weights/biases changed, any cached WASM compilation is now stale.
-    // Free it so the next activation recompiles with updated parameters.
-    if (didUpdate && this.cachedWasmActivation) {
-      this.cachedWasmActivation.free();
-      this.cachedWasmActivation = undefined;
-    }
-  }
-
-  /**
-   * Evolve the creature to achieve a lower error on a dataset.
-   *
-   * @param {string} dataSetDir - The directory containing the dataset.
-   * @param {NeatOptions} options - The NEAT configuration options.
-   * @returns {Promise<{ error: number; score: number; time: number }>} The evolution result.
-   */
-  async evolveDir(
-    dataSetDir: string,
-    options: NeatOptions,
-  ): Promise<
-    { error: number; score: number; time: number; generation: number }
-  > {
-    let interrupted = false;
-    const signalListener = () => {
-      getLogger().info("SIGTERM received, saving progress...");
-      interrupted = true;
-    };
-
-    Deno.addSignalListener("SIGTERM", signalListener);
-
-    const start = Date.now();
-    const config = createNeatConfig(options);
-
-    const endTimeMS = config.timeoutMinutes
-      ? start + Math.max(1, config.timeoutMinutes) * 60000
-      : 0;
-
-    const workers: WorkerHandler[] = [];
-
-    const threads = config.threads;
-
-    for (let i = threads; i--;) {
-      // Prefer real workers when threads > 1, but fall back to direct execution
-      // if worker startup fails (e.g. remote environment can't fetch/compile the
-      // worker module graph from JSR in time).
-      const preferDirect = threads === 1;
-      let w = new WorkerHandler(
-        dataSetDir,
-        config.costName,
-        preferDirect,
-        config.customCost,
-      );
-      try {
-        // Warm worker sequentially to avoid cold-cache download storms.
-        // deno-lint-ignore no-await-in-loop
-        await w.waitUntilReady();
-      } catch (err) {
-        try {
-          w.terminate();
-        } catch {
-          // Ignore termination errors.
-        }
-        if (!preferDirect) {
-          getLogger().warn(
-            "[Creature.evolveDir] Worker init failed; falling back to direct execution for this worker slot.",
-            err,
-          );
-          w = new WorkerHandler(
-            dataSetDir,
-            config.costName,
-            true,
-            config.customCost,
-          );
-          // deno-lint-ignore no-await-in-loop
-          await w.waitUntilReady();
-        } else {
-          throw err;
-        }
-      }
-      // Only add to the worker pool once initialization succeeded.
-      workers.push(w);
-    }
-
-    // Initialize the NEAT instance
-    const neat = new Neat(
-      this.input,
-      this.output,
-      config,
-      workers,
-    );
-
-    // Issue #997: Pass the data directory to enable discovery replay
-    neat.setDataDir(dataSetDir);
-
-    neat.populatePopulation(this);
-
-    let error = Infinity;
-    let bestScore = -Infinity;
-    let bestCreature: Creature | undefined;
-
-    let iterationStartMS = Date.now();
-    let generation = 0;
-    const targetError = config.targetError;
-    const iterations = config.iterations;
-
-    while (true) {
-      // deno-lint-ignore no-await-in-loop
-      const result = await neat.evolve(
-        bestCreature,
-      );
-
-      const fittest: Creature = result.fittest;
-      const fittestScore = fittest.score!;
-      assert(fittestScore >= bestScore, "Score is less than best score");
-      if (fittestScore > bestScore) {
-        const errorTmp = getTag(fittest, "error");
-        assert(errorTmp, "No error tag found");
-
-        error = Number.parseFloat(errorTmp);
-        assert(Number.isFinite(error), "Error is not finite");
-        assert(error >= 0, "Error is negative");
-        assert(
-          fittestScore - 1 <= error * -1,
-          `Score (absolute) less than error (score=${fittestScore}, error=${error})`,
-        );
-        bestScore = fittestScore;
-        bestCreature = Creature.fromJSON(fittest.exportJSON());
-        bestCreature.uuid = fittest.uuid;
-        bestCreature.score = bestScore;
-      }
-
-      const now = Date.now();
-      const timedOut = endTimeMS ? now > endTimeMS : false;
-
-      generation++;
-
-      const completed = interrupted || timedOut || error <= targetError ||
-        generation >= iterations;
-
-      if (
-        config.log &&
-        (generation % config.log === 0 || completed)
-      ) {
-        let avgTxt = "";
-        if (Number.isFinite(result.averageScore)) {
-          avgTxt = `(avg: ${yellow(result.averageScore.toFixed(4))})`;
-        }
-        getLogger().info(
-          "Generation",
-          generation,
-          "score",
-          fittest.score,
-          avgTxt,
-          "error",
-          error,
-          (config.log > 1 ? "avg " : "") + "time",
-          yellow(
-            format(Math.round((now - iterationStartMS) / config.log), {
-              ignoreZero: true,
-            }),
-          ),
-        );
-
-        iterationStartMS = now;
-      }
-
-      if (completed) {
-        if (interrupted) break;
-        if (neat.finishUp(iterations, endTimeMS, start, generation)) {
-          break;
-        }
-      }
-
-      // Checkpoint: Save creatures after each generation if enabled.
-      // No need on the final generation as that will be done by the normal process.
-      if (
-        config.checkpointEveryGeneration && config.creatureStore
-      ) {
-        this.writeCreatures(neat, config.creatureStore);
-      }
-    }
-
-    for (let i = workers.length; i--;) {
-      const w = workers[i];
-      w.terminate();
-    }
-    workers.length = 0; // Release the memory.
-
-    if (bestCreature) {
-      this.loadFrom(bestCreature, config.debug);
-    }
-
-    if (config.creatureStore) {
-      this.writeCreatures(neat, config.creatureStore);
-    }
-
-    Deno.removeSignalListener("SIGTERM", signalListener);
-    return {
-      error: error,
-      score: bestScore,
-      generation: generation,
-      time: Date.now() - start,
-    };
-  }
-
-  /**
-   * Evolve the creature to achieve a lower error on a dataset.
-   *
-   * @param {DataRecordInterface[]} dataSet - The dataset for evolution.
-   * @param {NeatOptions} options - The NEAT configuration options.
-   * @returns {Promise<{ error: number; score: number; time: number }>} The evolution result.
-   */
-  async evolveDataSet(
-    dataSet: DataRecordInterface[],
-    options: NeatOptions,
-  ): Promise<{ error: number; score: number; time: number }> {
-    const config = createNeatConfig(options);
-
-    const dataSetDir = makeDataDir(dataSet, config.dataSetPartitionBreak, {
-      input: this.input,
-      output: this.output,
-    });
-
-    const result = await this.evolveDir(dataSetDir, config);
-
-    Deno.removeSync(dataSetDir, { recursive: true });
-
-    return result;
-  }
-
-  /**
-   * Score the creature using a dataset.
-   *
-   * @param dataDir The directory containing the dataset.
-   * @param options The NEAT configuration options.
-   * @returns the score and error of the creature.
-   */
-  async scoreDir(
-    dataDir: string,
-    options: NeatOptions,
-  ): Promise<{ score: number; error: number }> {
-    const config = createNeatConfig(options);
-
-    const result = await this.evaluateDir(
-      dataDir,
-      Costs.find(config.costName),
-      config.feedbackLoop,
-    );
-
-    this.score = calculateScore(
-      this,
-      result.error,
-      config.costOfGrowth,
-    );
-    return { error: result.error, score: this.score };
-  }
-
-  /**
-   * Run the discovery process for this creature using a dataset directory.
-   *
-   * @param dataDir Directory containing the dataset subset used for discovery.
-   * @param options NEAT configuration options controlling discovery behaviour.
-   * @param deps Optional overrides, primarily for testing.
-   */
-  async discoveryDir(
-    dataDir: string,
-    options: NeatOptions,
-    deps?: { runner?: DiscoveryRunnerLike },
-  ): Promise<DiscoveryDirResult> {
-    const runner = deps?.runner ?? new DiscoveryRunner();
-
-    return await runner.discoverDir({
-      creature: this,
-      dataDir,
-      options,
-    });
-  }
-
-  /**
-   * Replay cached discovery successes against this creature using a dataset directory.
-   *
-   * This is designed for long-running workflows where discovery results may be
-   * overtaken by normal evolution before they are reintroduced into the
-   * population. Replay lets you re-apply previously successful candidates to the
-   * current fittest creature and prune stale cache entries when they no longer
-   * improve score.
-   *
-   * @param dataDir Directory containing the dataset subset used for replay scoring.
-   * @param options NEAT configuration options controlling replay behaviour.
-   * @param deps Optional overrides, primarily for testing.
-   */
-  async discoveryReplayDir(
-    dataDir: string,
-    options: NeatOptions,
-    deps?: { runner?: DiscoveryReplayRunnerLike },
-  ): Promise<DiscoveryReplayDirResult> {
-    const runner = deps?.runner ?? new DiscoveryReplayRunner();
-
-    return await runner.replayDir({
-      creature: this,
-      dataDir,
-      options,
-    });
-  }
-
-  /**
-   * Trace the creature using a dataset.
-   *
-   * @param dataDir The directory containing the dataset.
-   * @param options The NEAT configuration options.
-   * @returns the score and error of the creature.
-   */
-  traceDir(
-    dataDir: string,
-    options: NeatOptions,
-  ): { score: number; error: number } {
-    const dataResult = dataFiles(dataDir);
-    assert(dataResult.files.length > 0, "No data files found");
-    const config = createNeatConfig(options);
-    const cost = Costs.find(config.costName);
-    let error = 0;
-    let count = 0;
-    const backPropConfig = createBackPropagationConfig(config);
-    const creatureJSON = this.exportJSON();
-    // Issue #1294: Cache outgoing synapse map for path calculation.
-    const outgoingSynapsesMap = buildOutgoingSynapsesMap(creatureJSON);
-    const sparseConfig = new SparseConfig(
-      creatureJSON,
-      backPropConfig,
-      outgoingSynapsesMap,
-    );
-
-    const valuesCount = this.input + this.output;
-    const BYTES_PER_RECORD = valuesCount * 4; // Each float is 4 bytes
-    // Issue #1195: Increased from 128KB to 512KB for NVMe drives
-    const NVME_OPTIMAL_READ_SIZE = 512 * 1024; // 512 KB
-    const BATCH_SIZE = Math.max(
-      1,
-      Math.floor(NVME_OPTIMAL_READ_SIZE / BYTES_PER_RECORD),
-    );
-    const BYTES_PER_BATCH = BYTES_PER_RECORD * BATCH_SIZE;
-
-    // Shared buffers for batch processing
-    const batchBuffer = new Uint8Array(BYTES_PER_BATCH);
-    const batchArray = new Float32Array(batchBuffer.buffer);
-
-    // Issue #1297: Pre-allocated buffers to reduce allocation overhead in hot loop
-    const bufferPool = new BufferPool({ maxBuffersPerSize: 4 });
-    const observationsBuffer = bufferPool.acquire(this.input);
-    const targetsBuffer = bufferPool.acquire(this.output);
-
-    for (let fileIndx = dataResult.files.length; fileIndx--;) {
-      const filePath = dataResult.files[fileIndx];
-      const file = Deno.openSync(filePath, { read: true });
-
-      try {
-        while (true) {
-          // Read a batch of records
-          const bytesRead = file.readSync(batchBuffer);
-          if (bytesRead === null) {
-            break;
-          }
-          assert(bytesRead > 0, "Invalid number of bytes read");
-
-          const recordsRead = Math.floor(bytesRead / BYTES_PER_RECORD);
-          assert(
-            bytesRead % BYTES_PER_RECORD === 0,
-            "Invalid number of bytes read",
-          );
-
-          // Process each record in the batch
-          for (let recordIndex = 0; recordIndex < recordsRead; recordIndex++) {
-            const offset = recordIndex * valuesCount;
-            const inputEnd = offset + this.input;
-
-            // Issue #1297: Copy into pre-allocated buffers instead of creating new arrays
-            observationsBuffer.set(batchArray.subarray(offset, inputEnd));
-            targetsBuffer.set(
-              batchArray.subarray(inputEnd, offset + valuesCount),
-            );
-
-            const actuals = this.activateAndTrace(
-              observationsBuffer,
-              true,
-              sparseConfig,
-            );
-
-            this.propagate(targetsBuffer, backPropConfig, sparseConfig);
-
-            error += cost.calculate(targetsBuffer, actuals);
-            count++;
-          }
-        }
-      } finally {
-        file.close();
-      }
-    }
-    let averageError = 0;
-    if (count > 0) {
-      averageError = error / count;
-    }
-    this.score = calculateScore(
-      this,
-      averageError,
-      config.costOfGrowth,
-    );
-
-    return { error: averageError, score: this.score };
-  }
-
-  /**
-   * Evaluate a dataset and return the error.
-   *
-   * @param {string} dataDir - The directory containing the dataset.
-   * @param {CostInterface} cost - The cost function to evaluate the error.
-   * @param {boolean} feedbackLoop - Whether to use a feedback loop during evaluation.
-   * @returns {{ error: number }} The evaluation result.
-   */
-  async evaluateDir(
-    dataDir: string,
-    cost: CostInterface,
-    feedbackLoop: boolean,
-  ): Promise<{ error: number }> {
-    const dataResult = dataFiles(dataDir);
-    assert(dataResult.files.length > 0, "No data files found");
-
-    // Issue #1247: Auto-initialise WASM before scoring if not yet available.
-    await ensureWasmActivation();
-
-    // Issue #1229: WASM is required by default with no fallback.
-    this.requireWasmOrThrow();
-
-    let error = 0;
-    let count = 0;
-
-    const costName = cost.getName();
-    const major = Number.parseInt(
-      this.semanticVersion.split(".")[0] ?? "0",
-      10,
-    );
-    const forwardOnlyGuaranteed = Number.isFinite(major) && major >= 4 &&
-      this.forwardOnly === true;
-
-    // Issue #1193: For forward-only creatures, feedbackLoop has no effect since there
-    // are no recurrent connections. Normalize to false for consistency and performance.
-    const effectiveFeedbackLoop = forwardOnlyGuaranteed ? false : feedbackLoop;
-
-    // Ensure WASM network is compiled once for scoring.
-    if (!this.cachedWasmActivation) {
-      const compiled = compileCreatureToWasm(this);
-      this.cachedWasmActivation = WasmCreatureActivation.create(compiled) ??
-        undefined;
-
-      // Issue #1338: Best-effort eviction + retry under memory pressure.
-      if (!this.cachedWasmActivation) {
-        evictOldestWasmCreatureActivations(64);
-        this.cachedWasmActivation = WasmCreatureActivation.create(compiled) ??
-          undefined;
-      }
-      if (!this.cachedWasmActivation) {
-        fail(
-          "WASM activation was selected but failed to instantiate CompiledNetwork",
-        );
-      }
-      this.cachedWasmActivation.setNeedsResetWhenStateless(
-        !forwardOnlyGuaranteed,
-      );
-    }
-
-    noteWasmCreatureActivationUse(this);
-
-    // Pre-allocate a reusable output buffer for non-fused scoring.
-    const outputBuffer = new Float32Array(this.output);
-
-    const valuesCount = this.input + this.output;
-    const BYTES_PER_RECORD = valuesCount * 4; // Each float is 4 bytes
-    // Issue #1195: Increased from 128KB to 512KB for NVMe drives
-    const NVME_OPTIMAL_READ_SIZE = 512 * 1024; // 512 KB
-    const BATCH_SIZE = Math.max(
-      1,
-      Math.floor(NVME_OPTIMAL_READ_SIZE / BYTES_PER_RECORD),
-    );
-    const BYTES_PER_BATCH = BYTES_PER_RECORD * BATCH_SIZE;
-
-    // Shared buffers for batch processing
-    const batchBuffer = new Uint8Array(BYTES_PER_BATCH);
-    const batchArray = new Float32Array(batchBuffer.buffer);
-
-    // Fused WASM scoring is only valid for stateless scoring with supported cost functions.
-    // All built-in cost functions are supported: MSE, MAE, CROSS_ENTROPY, MAPE, MSLE, HINGE.
-    const supportedFusedCosts = [
-      "MSE",
-      "MAE",
-      "CROSS_ENTROPY",
-      "MAPE",
-      "MSLE",
-      "HINGE",
-    ] as const;
-    // Issue #1193: For forward-only creatures, feedbackLoop has no effect since there are
-    // no recurrent connections to preserve state. We can use the fused path regardless.
-    const useFusedWasm = forwardOnlyGuaranteed &&
-      supportedFusedCosts.includes(
-        costName as typeof supportedFusedCosts[number],
-      );
-
-    for (let fileIndx = dataResult.files.length; fileIndx--;) {
-      const filePath = dataResult.files[fileIndx];
-      const file = Deno.openSync(filePath, { read: true });
-
-      try {
-        while (true) {
-          // Read a batch of records
-          const bytesRead = file.readSync(batchBuffer);
-          if (bytesRead === null) {
-            break;
-          }
-          assert(bytesRead > 0, "Invalid number of bytes read");
-
-          const recordsRead = Math.floor(bytesRead / BYTES_PER_RECORD);
-          assert(
-            bytesRead % BYTES_PER_RECORD === 0,
-            "Invalid number of bytes read",
-          );
-
-          if (useFusedWasm) {
-            // Process the whole batch in a single WASM call:
-            // records are laid out as [inputs..., targets...] per record.
-            const floatsRead = recordsRead * valuesCount;
-            const slice = batchArray.subarray(0, floatsRead);
-            const wasm = this.cachedWasmActivation!;
-
-            switch (costName) {
-              case "MSE":
-                error += wasm.mseSumBatchPacked(slice, this.input, true);
-                break;
-              case "MAE":
-                error += wasm.maeSumBatchPacked(slice, this.input, true);
-                break;
-              case "CROSS_ENTROPY":
-                error += wasm.crossEntropySumBatchPacked(
-                  slice,
-                  this.input,
-                  true,
-                );
-                break;
-              case "MAPE":
-                error += wasm.mapeSumBatchPacked(slice, this.input, true);
-                break;
-              case "MSLE":
-                error += wasm.msleSumBatchPacked(slice, this.input, true);
-                break;
-              case "HINGE":
-                error += wasm.hingeSumBatchPacked(slice, this.input, true);
-                break;
-            }
-            count += recordsRead;
-            continue;
-          }
-
-          // Process each record in the batch
-          for (let recordIndex = 0; recordIndex < recordsRead; recordIndex++) {
-            const offset = recordIndex * valuesCount;
-            const inputEnd = offset + this.input;
-            const observations = batchArray.subarray(offset, inputEnd);
-            const target = batchArray.subarray(inputEnd, offset + valuesCount);
-
-            // Zero-allocation activation during scoring.
-            this.cachedWasmActivation!.activateIntoWithFeedback(
-              observations,
-              outputBuffer,
-              effectiveFeedbackLoop,
-            );
-            error += cost.calculate(target, outputBuffer);
-
-            count++;
-          }
-        }
-      } finally {
-        file.close();
-      }
-    }
-    if (count === 0) {
-      return { error: 0 };
-    } else {
-      const averageError = error / count;
-      if (Number.isFinite(averageError)) {
-        return { error: averageError };
-      } else {
-        getLogger().warn(
-          `AverageError: ${averageError} is not finite, Error: ${error}, Count: ${count}`,
-        );
-        return { error: Number.MAX_SAFE_INTEGER };
-      }
-    }
-  }
-
-  private writeCreatures(neat: Neat, dir: string) {
-    let counter = 1;
-    emptyDirSync(dir);
-    neat.population.forEach((creature) => {
-      const json = creature.exportJSON();
-
-      const txt = JSON.stringify(json, null, 1);
-
-      const filePath = dir + "/" + counter + ".json";
-      Deno.writeTextFileSync(filePath, txt);
-
-      counter++;
-    });
-  }
-
-  /**
-   * Check if a neuron is in focus.
-   *
-   * @param {number} index - The index of the neuron.
-   * @param {number[]} [focusList] - The list of focus indices.
-   * @param {Set<number>} [checked] - The set of checked indices.
-   * @returns {boolean} True if the neuron is in focus, false otherwise.
-   */
   public inFocus(
     index: number,
     focusList?: number[],
     checked: Set<number> = new Set(),
   ): boolean {
-    if (!focusList || focusList.length === 0) {
-      return true;
-    }
-
-    // Issue #1100: Check if the focus list matches the cached focus list.
-    // If the focus list is different, clear the cache and update the tracked list.
-    // This ensures the cache is only used when the focus list is the same.
-    if (!this.isFocusListMatch(focusList)) {
-      this.cacheFocus.clear();
-      // Store a copy of the focus list to avoid reference issues
-      this.cacheFocusList = [...focusList];
-    }
-
-    // Check the cache first if there is a focus list
-    if (this.cacheFocus.has(index)) {
-      return this.cacheFocus.get(index) as boolean;
-    }
-
-    if (checked.has(index)) {
-      this.cacheFocus.set(index, false);
-      return false;
-    }
-
-    checked.add(index);
-
-    for (let pos = 0; pos < focusList.length; pos++) {
-      const focusIndex = focusList[pos];
-
-      if (index === focusIndex) {
-        this.cacheFocus.set(index, true);
-        return true;
-      }
-
-      const toList = this.inwardConnections(index);
-
-      for (let i = toList.length; i--;) {
-        const checkIndx: number = toList[i].from;
-        if (checkIndx === index) {
-          this.cacheFocus.set(index, true);
-          return true;
-        }
-
-        if (this.inFocus(checkIndx, focusList, checked)) {
-          this.cacheFocus.set(index, true);
-          return true;
-        }
-      }
-    }
-
-    this.cacheFocus.set(index, false);
-    return false;
+    const result = topology.inFocus(
+      this,
+      this._topoCaches,
+      this.cacheFocus,
+      this.cacheFocusList,
+      index,
+      focusList,
+      checked,
+    );
+    this.cacheFocusList = result.updatedCacheFocusList;
+    return result.result;
   }
 
-  /**
-   * Check if the given focus list matches the cached focus list.
-   *
-   * Issue #1100: Used to detect when the focus cache should be invalidated.
-   *
-   * @param focusList - The focus list to check
-   * @returns true if the focus list matches the cached list
-   */
-  private isFocusListMatch(focusList: number[]): boolean {
-    const cached = this.cacheFocusList;
-    if (!cached) {
-      return false;
-    }
-    if (cached.length !== focusList.length) {
-      return false;
-    }
-    for (let i = 0; i < cached.length; i++) {
-      if (cached[i] !== focusList[i]) {
-        return false;
-      }
-    }
-    return true;
+  // ── Training ───────────────────────────────────────────────────────────
+
+  applyLearnings(
+    config: BackPropagationConfig,
+    sparseConfig: SparseConfig,
+  ): boolean {
+    return training.applyLearnings(this, config, sparseConfig);
   }
 
-  /**
-   * Create a random connection for the neuron at the given index.
-   *
-   * @param {number} indx - The index of the target neuron.
-   * @returns {Synapse | null} The created synapse or null if no connection was made.
-   */
+  propagate(
+    expected: Float32Array,
+    config: BackPropagationConfig,
+    sparseConfig: SparseConfig,
+  ) {
+    training.propagate(this, expected, config, sparseConfig);
+  }
+
+  record(expected: Float32Array): Map<string, DiscoverRecord> {
+    return training.record(this, expected);
+  }
+
+  propagateUpdate(config: BackPropagationConfig, sparseConfig: SparseConfig) {
+    training.propagateUpdate(this, config, sparseConfig);
+  }
+
+  evolveDir(
+    dataSetDir: string,
+    options: NeatOptions,
+  ): Promise<
+    { error: number; score: number; time: number; generation: number }
+  > {
+    return training.evolveDir(this, dataSetDir, options);
+  }
+
+  evolveDataSet(
+    dataSet: DataRecordInterface[],
+    options: NeatOptions,
+  ): Promise<{ error: number; score: number; time: number }> {
+    return training.evolveDataSet(this, dataSet, options);
+  }
+
+  scoreDir(
+    dataDir: string,
+    options: NeatOptions,
+  ): Promise<{ score: number; error: number }> {
+    return training.scoreDir(this, dataDir, options);
+  }
+
+  discoveryDir(
+    dataDir: string,
+    options: NeatOptions,
+    deps?: { runner?: DiscoveryRunnerLike },
+  ): Promise<DiscoveryDirResult> {
+    return training.discoveryDir(this, dataDir, options, deps);
+  }
+
+  discoveryReplayDir(
+    dataDir: string,
+    options: NeatOptions,
+    deps?: { runner?: DiscoveryReplayRunnerLike },
+  ): Promise<DiscoveryReplayDirResult> {
+    return training.discoveryReplayDir(this, dataDir, options, deps);
+  }
+
+  traceDir(
+    dataDir: string,
+    options: NeatOptions,
+  ): { score: number; error: number } {
+    return training.traceDir(this, dataDir, options);
+  }
+
+  evaluateDir(
+    dataDir: string,
+    cost: CostInterface,
+    feedbackLoop: boolean,
+  ): Promise<{ error: number }> {
+    return activation.evaluateDir(this, dataDir, cost, feedbackLoop);
+  }
+
+  // ── Mutation ───────────────────────────────────────────────────────────
+
   public makeRandomConnection(indx: number): Synapse | null {
-    assert(
-      Number.isInteger(indx),
-      `Index must be an integer, got: ${String(indx)}`,
-    );
-    assert(
-      indx >= 0 && indx < this.neurons.length,
-      `Index out of range: ${indx} (neurons length: ${this.neurons.length})`,
-    );
-
-    const toType = this.neurons[indx].type;
-    assert(toType !== "input", "Can't connect to input");
-    assert(toType !== "constant", "Can't connect to constant");
-
-    for (let attempts = 0; attempts < 12; attempts++) {
-      const from = Math.min(
-        this.neurons.length - this.output - 1,
-        // Even when recurrent connections are allowed, `makeRandomConnection()`
-        // is used as a repair step for disconnected neurons. A self-loop does
-        // not introduce any upstream signal, so it does not "fix" connectivity.
-        // We therefore never generate self-loops here.
-        Math.floor(getRandomNumberGenerator().random() * indx), // 0..(indx-1)
-      );
-      const c = this.getSynapse(from, indx);
-      if (c === null) {
-        return this.connect(
-          from,
-          indx,
-          Synapse.randomWeight(),
-        );
-      }
-    }
-    const firstOutputIndex = this.neurons.length - this.output;
-    for (let from = 0; from < indx; from++) {
-      if (from >= firstOutputIndex) continue;
-      const c = this.getSynapse(from, indx);
-      if (c === null) {
-        return this.connect(
-          from,
-          indx,
-          Synapse.randomWeight(),
-        );
-      }
-    }
-    return null;
+    return mutation.makeRandomConnection(this, indx);
   }
 
-  /**
-   * Fix the structure of the creature.
-   */
   fix(options?: {
-    /**
-     * When true, remove all recurrent connections (both feedback/backward connections and self-loops).
-     * Defaults to false (we allow them by default).
-     */
     forwardOnly?: boolean;
-    /**
-     * Remove recursive (back) synapses (from > to).
-     * Defaults to false.
-     */
     removeBackConnections?: boolean;
-    /**
-     * Remove self synapses (from === to).
-     * Defaults to false.
-     */
     removeSelfConnections?: boolean;
   }) {
-    const forwardOnly = options?.forwardOnly === true;
-    const removeBackConnections = forwardOnly ||
-      options?.removeBackConnections === true;
-    const removeSelfConnections = forwardOnly ||
-      options?.removeSelfConnections === true;
-
-    const holdDebug = this.DEBUG;
-    this.DEBUG = false;
-    const startUUID = CreatureUtil.makeUUID(this);
-    this.DEBUG = holdDebug;
-    const maxTo = this.neurons.length - 1;
-    const minTo = this.input;
-
-    // Merge duplicate synapses (same from/to/type) by summing weights.
-    // 29-Dec-2025: This is behaviour-preserving and fixes a long-standing issue
-    // where duplicates were silently dropped, changing forward-pass behaviour.
-    // See https://github.com/stSoftwareAU/NEAT-AI/issues/976
-    const merged = new Map<string, Synapse>();
-    const inboundCountsByTo = new Map<number, number>();
-
-    this.synapses.forEach((synapse) => {
-      if (removeSelfConnections && synapse.from === synapse.to) {
-        return;
-      }
-      if (removeBackConnections && synapse.from > synapse.to) {
-        return;
-      }
-
-      if (synapse.to > maxTo) {
-        getLogger().debug("Ignoring connection to above max", maxTo, synapse);
-        return;
-      }
-      if (synapse.to < minTo) {
-        getLogger().debug("Ignoring connection to below min", minTo, synapse);
-        return;
-      }
-
-      const typeKey = synapse.type ?? "";
-      const key = `${synapse.from}->${synapse.to}:${typeKey}`;
-
-      const existing = merged.get(key);
-      if (existing) {
-        existing.weight += synapse.weight;
-        // Merge tags conservatively (best-effort). If tags are present on either,
-        // keep a de-duplicated union by `{name, value}`.
-        if (synapse.tags?.length) {
-          existing.tags = mergeTagsByNameValue(existing.tags, synapse.tags);
-        }
-        return;
-      }
-
-      merged.set(key, synapse as Synapse);
-      inboundCountsByTo.set(
-        synapse.to,
-        (inboundCountsByTo.get(synapse.to) ?? 0) + 1,
-      );
-    });
-
-    const tmpSynapses: Synapse[] = [];
-    for (const synapse of merged.values()) {
-      if (synapse.weight !== 0 && Number.isFinite(synapse.weight)) {
-        tmpSynapses.push(synapse);
-        continue;
-      }
-
-      // Zero weight may as well be removed, except for the last inward connection
-      // to an output neuron (we keep one to preserve structural validity).
-      if (this.neurons[synapse.to].type === "output") {
-        const inbound = inboundCountsByTo.get(synapse.to) ?? 0;
-        if (inbound === 1) {
-          tmpSynapses.push(synapse);
-        }
-      }
-    }
-
-    this.synapses = tmpSynapses;
-
-    /* Make sure the synapses are sorted */
-    this.synapses.sort((a, b) => {
-      if (a.from === b.from) {
-        return a.to - b.to;
-      } else {
-        return a.from - b.from;
-      }
-    });
-
-    this.clearCache();
-
-    let neuronRemoved = true;
-
-    while (neuronRemoved) {
-      neuronRemoved = false;
-      for (
-        let pos = this.input;
-        pos < this.neurons.length - this.output;
-        pos++
-      ) {
-        if (this.neurons[pos].type === "output") continue;
-        if (
-          this.outwardConnections(pos).length === 0
-        ) {
-          if (this.DEBUG) {
-            getLogger().debug(
-              `fix() removing disconnected neuron ${pos} ${
-                this.neurons[pos].uuid
-              }`,
-            );
-          }
-          removeHiddenNeuron(this, pos);
-          neuronRemoved = true;
-          break;
-        }
-      }
-    }
-
-    for (let i = 1; i < this.synapses.length; i++) {
-      if (this.synapses[i - 1].from > this.synapses[i].from) {
-        getLogger().error(
-          "Synapses not sorted",
-          this.synapses[i - 1],
-          this.synapses[i],
-        );
-        this.synapses.sort((a, b) => {
-          if (a.from === b.from) {
-            return a.to - b.to;
-          } else {
-            return a.from - b.from;
-          }
-        });
-        break;
-      }
-    }
-
-    this.neurons.forEach((neuron) => {
-      neuron.fix();
-    });
-
-    if (forwardOnly) {
-      this.forwardOnly = true;
-
-      // Once a creature is confirmed forward-only, bump its semantic version to 4.0.0.
-      //
-      // Backwards compatibility: we never downgrade versions (e.g. 4.1.2 stays 4.1.2).
-      // We only bump when the major version is 2.x.x or 3.x.x.
-      const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(this.semanticVersion);
-      if (match) {
-        const major = Number.parseInt(match[1], 10);
-        if (major === 2 || major === 3) {
-          this.semanticVersion = "4.0.0";
-        }
-      }
-    }
-
-    const tmpDebug = this.DEBUG;
-    this.DEBUG = false;
-    delete this.uuid;
-    const endUUID = CreatureUtil.makeUUID(this);
-    this.DEBUG = tmpDebug;
-    if (startUUID !== endUUID) {
-      delete this.memetic;
-    }
+    mutation.fix(this, options);
   }
 
-  /**
-   * Get the output count of the creature.
-   *
-   * @returns {number} The number of output neurons.
-   */
+  // ── Serialisation ──────────────────────────────────────────────────────
+
   outputCount(): number {
     return this.output;
   }
 
-  /**
-   * Get the node count of the creature.
-   *
-   * @returns {number} The number of neurons.
-   */
   nodeCount(): number {
     return this.neurons.length;
   }
 
-  /**
-   * Convert the creature to a JSON object.
-   *
-   * @returns {CreatureExport} The JSON representation of the creature.
-   */
   exportJSON(): CreatureExport {
-    if (this.DEBUG) {
-      creatureValidate(this);
-    }
-    const builder = new CreatureExportBuilder(this);
-    const exportCreature: CreatureExport = builder.build();
-
-    return exportCreature;
+    return serialisation.exportJSON(this);
   }
 
-  /**
-   * Convert the creature to a trace JSON object.
-   *
-   * @returns {CreatureTrace} The trace JSON representation of the creature.
-   */
   traceJSON(): CreatureTrace {
-    const exportCreature = this.exportJSON();
-
-    const state = this.state;
-    let exportIndex = 0;
-    this.neurons.forEach((n) => {
-      if (n.type !== "input") {
-        if (n.type !== "constant") {
-          const indx = n.index;
-
-          const traceNeuron: NeuronTrace = exportCreature
-            .neurons[exportIndex] as NeuronTrace;
-
-          const ns = state.node(indx);
-          if (ns.count) {
-            (traceNeuron as NeuronTrace).trace = ns;
-          }
-        }
-        exportIndex++;
-      }
-    });
-
-    this.synapses.forEach((c, indx) => {
-      const exportConnection = exportCreature.synapses[indx] as SynapseTrace;
-      const cs = state.connection(c.from, c.to);
-      if (cs.count) {
-        exportConnection.trace = cs;
-      }
-    });
-
-    return exportCreature as CreatureTrace;
+    return serialisation.traceJSON(this);
   }
 
-  /**
-   * Load the creature from a JSON object.
-   *
-   * @param {CreatureInternal | CreatureExport} json - The JSON object representing the creature.
-   * @param {boolean} validate - Whether to validate the creature after loading.
-   */
   loadFrom(json: CreatureInternal | CreatureExport, validate: boolean) {
-    this.uuid = (json as CreatureInternal).uuid;
-    if (json.semanticVersion) {
-      this.semanticVersion = json.semanticVersion;
-    }
-    this.forwardOnly = (json as CreatureExport).forwardOnly;
-
-    // Preallocate arrays
-    const neuronCount = json.neurons.length;
-    const synapseCount = json.synapses.length;
-    this.neurons = new Array(neuronCount);
-    this.synapses = new Array(synapseCount);
-
-    if (json.tags) {
-      this.tags = [...json.tags];
-    }
-
-    this.clearState();
-    const state = this.state;
-    const uuidMap = new Map<string, number>();
-
-    // Optimize input neuron initialization
-    let i = json.input;
-    while (i--) {
-      const key = `input-${i}`;
-      uuidMap.set(key, i);
-      const n = new Neuron(key, "input", 0, this);
-      n.index = i;
-      this.neurons[i] = n;
-    }
-
-    let pos = json.input;
-    let outputIndex = 0;
-    const neurons = json.neurons;
-
-    // Process remaining neurons
-    for (let i = 0; i < neurons.length; i++) {
-      const jn = neurons[i];
-
-      if (jn.type === "input") continue;
-
-      if (jn.type === "output") {
-        (jn as { uuid: string }).uuid = `output-${outputIndex++}`;
-      }
-
-      const n = Neuron.fromJSON(jn, this);
-      n.index = pos;
-
-      if ((jn as NeuronTrace).trace) {
-        Object.assign(state.node(n.index), (jn as NeuronTrace).trace);
-      }
-
-      uuidMap.set(n.uuid, pos);
-      this.neurons[pos++] = n;
-    }
-
-    // Optimize synapse processing
-    const synapses = json.synapses;
-    let isSorted = true;
-    let lastFrom = -1;
-    let lastTo = -1;
-    for (let i = 0; i < synapseCount; i++) {
-      const synapse = synapses[i];
-      const se = synapse as SynapseExport;
-      const from = se.fromUUID
-        ? uuidMap.get(se.fromUUID)
-        : (synapse as SynapseInternal).from;
-
-      assert(from !== undefined, "FROM is undefined");
-
-      const to = se.toUUID
-        ? uuidMap.get(se.toUUID)
-        : (synapse as SynapseInternal).to;
-
-      if (to === undefined) {
-        fail(
-          `TO is undefined: uuid ${se.toUUID}, index ${
-            (synapse as SynapseInternal).to
-          }`,
-        );
-      }
-
-      if (isSorted) {
-        if (from > lastFrom) {
-          lastFrom = from;
-          lastTo = -1;
-        } else if (from < lastFrom || to <= lastTo) {
-          isSorted = false;
-        }
-        lastTo = to;
-      }
-
-      const tmpSynapse = new Synapse(from!, to!, synapse.weight, synapse.type);
-      this.synapses[i] = tmpSynapse;
-
-      if (synapse.tags) {
-        tmpSynapse.tags = synapse.tags.slice();
-      }
-
-      if ((synapse as SynapseTrace).trace) {
-        Object.assign(
-          state.connection(tmpSynapse.from, tmpSynapse.to),
-          (synapse as SynapseTrace).trace,
-        );
-      }
-    }
-
-    this.memetic = json.memetic;
-    this.clearCache();
-
-    // Perform sorting only if needed
-    if (!isSorted) {
-      this.synapses.sort((a, b) => {
-        if (a.from !== b.from) return a.from - b.from;
-        return a.to - b.to;
-      });
-    }
-
-    // Issue #1097: Prebuild inward index for large creatures after loading.
-    // This optimises subsequent inward connection lookups by avoiding
-    // linear scans before the lazy index build threshold is reached.
-    this.prebuildInwardIndexIfLarge();
-
-    if (validate) {
-      creatureValidate(this);
-    }
+    serialisation.loadFrom(this, json, validate);
   }
 
-  /**
-   * Convert a json object to a creature
-   */
   static fromJSON(
     json: CreatureInternal | CreatureExport,
     validate = false,
   ): Creature {
-    const semanticVersion = json.semanticVersion ?? "0.0.1";
-    if (semanticVersion.startsWith("0.")) {
-      json = upgradeOne(json);
-    }
-
-    const creature = new Creature(json.input, json.output, {
-      lazyInitialization: true,
-      semanticVersion: json.semanticVersion,
-    });
-
-    // Normalise legacy property names (nodes → neurons, connections → synapses).
-    // The intermediate `unknown` cast is required because legacy JSON may carry
-    // properties not declared on CreatureInternal/CreatureExport.
-    const raw = json as unknown as Record<string, unknown>;
-    if (raw.nodes) {
-      raw.neurons = raw.nodes;
-      delete raw.nodes;
-    }
-    if (raw.connections) {
-      raw.synapses = raw.connections;
-      delete raw.connections;
-    }
-    creature.loadFrom(json, validate);
-
-    return creature;
+    return serialisation.fromJSON(json, validate, Creature) as Creature;
   }
 
-  /**
-   * Creates a shallow clone of this creature.
-   *
-   * This method is significantly faster than using fromJSON(exportJSON())
-   * because it avoids JSON serialisation/deserialisation overhead.
-   *
-   * The clone:
-   * - Has its own independent arrays for neurons and synapses
-   * - Copies mutable state (uuid, score, memetic, tags)
-   * - Produces identical activation outputs as the original
-   * - Can be safely modified without affecting the original
-   *
-   * Issue #1025: Performance optimisation for fittest creature tracking.
-   *
-   * @returns A new Creature instance that is a shallow clone of this creature
-   */
   shallowClone(): Creature {
-    const clone = new Creature(this.input, this.output, {
-      lazyInitialization: true,
-      semanticVersion: this.semanticVersion,
-    });
-
-    // Copy basic properties
-    clone.uuid = this.uuid;
-    clone.score = this.score;
-    clone.forwardOnly = this.forwardOnly;
-    clone.DEBUG = this.DEBUG;
-
-    // Copy memetic (shallow copy is sufficient as it's treated as immutable)
-    if (this.memetic) {
-      clone.memetic = { ...this.memetic };
-    }
-
-    // Copy tags (shallow copy of array, each tag is immutable)
-    if (this.tags) {
-      clone.tags = [...this.tags];
-    }
-
-    // Copy cached score components
-    if (this.cachedScoreComponents) {
-      clone.cachedScoreComponents = { ...this.cachedScoreComponents };
-    }
-
-    // Copy neurons - create new Neuron instances to ensure independence
-    const neuronCount = this.neurons.length;
-    clone.neurons = new Array(neuronCount);
-
-    for (let i = 0; i < this.input; i++) {
-      const original = this.neurons[i];
-      const neuron = new Neuron(original.uuid, "input", 0, clone);
-      neuron.index = i;
-      // Neuron.tags has type 'undefined' but can hold TagInterface[] at runtime
-      // via TagsInterface. We copy the array if present.
-      const originalTags = original.tags as TagInterface[] | undefined;
-      if (originalTags) {
-        (neuron as { tags: TagInterface[] | undefined }).tags = [
-          ...originalTags,
-        ];
-      }
-      clone.neurons[i] = neuron;
-    }
-
-    for (let i = this.input; i < neuronCount; i++) {
-      const original = this.neurons[i];
-      const neuron = new Neuron(
-        original.uuid,
-        original.type,
-        original.bias,
-        clone,
-        original.squash,
-      );
-      neuron.index = i;
-      // Neuron.tags has type 'undefined' but can hold TagInterface[] at runtime
-      // via TagsInterface. We copy the array if present.
-      const originalTags = original.tags as TagInterface[] | undefined;
-      if (originalTags) {
-        (neuron as { tags: TagInterface[] | undefined }).tags = [
-          ...originalTags,
-        ];
-      }
-      clone.neurons[i] = neuron;
-    }
-
-    // Copy synapses - create new Synapse instances to ensure independence
-    const synapseCount = this.synapses.length;
-    clone.synapses = new Array(synapseCount);
-
-    for (let i = 0; i < synapseCount; i++) {
-      const original = this.synapses[i];
-      const synapse = new Synapse(
-        original.from,
-        original.to,
-        original.weight,
-        original.type,
-      );
-      if (original.tags) {
-        synapse.tags = [...original.tags];
-      }
-      clone.synapses[i] = synapse;
-    }
-
-    return clone;
+    return serialisation.shallowClone(this, Creature) as Creature;
   }
 }

--- a/src/creature/CreatureActivation.ts
+++ b/src/creature/CreatureActivation.ts
@@ -1,0 +1,452 @@
+/**
+ * CreatureActivation.ts - Forward pass and WASM activation logic.
+ *
+ * Extracted from Creature.ts (Issue #1409) to keep the Creature class
+ * under 500 lines and each module focused on a single responsibility.
+ */
+
+import { assert, fail } from "@std/assert";
+import type { Creature } from "../Creature.ts";
+import type { SparseConfigLike } from "../propagate/sparse/SparseConfigLike.ts";
+import {
+  compileCreatureToWasm,
+  getOrCompileWasmModule,
+  isWasmActivationAvailable,
+  resolveWasmSquashName,
+  WasmCreatureActivation,
+} from "../wasm/mod.ts";
+import {
+  evictOldestWasmCreatureActivations,
+  noteWasmCreatureActivationUse,
+} from "../wasm/WasmCreatureActivationLRU.ts";
+import type { CostInterface } from "../costs/CostInterface.ts";
+import { dataFiles } from "../architecture/Training.ts";
+import { getLogger } from "../utils/Logger.ts";
+
+/**
+ * Verify WASM is available and the creature is eligible.
+ * Throws if WASM could not be loaded or the creature is not WASM-eligible.
+ */
+export function requireWasmOrThrow(creature: Creature): void {
+  if (!isWasmActivationAvailable()) {
+    throw new Error(
+      "WASM activation could not be loaded. Ensure the NEAT-AI package is installed correctly. " +
+        "WASM activation is required.",
+    );
+  }
+  if (!isWasmEligible(creature)) {
+    const unsupported = getUnsupportedWasmSquashFunctions(creature);
+    throw new Error(
+      "This creature uses squash functions not supported by the current backend: " +
+        unsupported.join(", ") +
+        ". WASM activation is required.",
+    );
+  }
+}
+
+/**
+ * Check if this creature is eligible for WASM activation.
+ * A creature is eligible if all its neurons use WASM-supported squash functions.
+ * The result is cached and invalidated when structure changes.
+ * Issue #1118: WASM Migration Phase 1.
+ */
+export function isWasmEligible(creature: Creature): boolean {
+  if (creature.wasmEligibilityCache !== undefined) {
+    return creature.wasmEligibilityCache;
+  }
+  const unsupported = getUnsupportedWasmSquashFunctions(creature);
+  creature.wasmEligibilityCache = unsupported.length === 0;
+  return creature.wasmEligibilityCache;
+}
+
+/**
+ * Get the list of squash functions used by this creature that are not
+ * supported by WASM.
+ * Issue #1118: WASM Migration Phase 1.
+ */
+export function getUnsupportedWasmSquashFunctions(
+  creature: Creature,
+): string[] {
+  const unsupported: string[] = [];
+  const seen = new Set<string>();
+
+  for (let i = creature.input; i < creature.neurons.length; i++) {
+    const neuron = creature.neurons[i];
+    const squash = neuron.squash ?? "IDENTITY";
+    if (seen.has(squash)) continue;
+    seen.add(squash);
+    if (resolveWasmSquashName(squash) === undefined) {
+      unsupported.push(squash);
+    }
+  }
+  return unsupported;
+}
+
+/**
+ * Dispose of cached WASM resources.
+ * Call this when the creature structure changes or when done using WASM activation.
+ * Issue #1118: WASM Migration Phase 1.
+ */
+export function disposeWasm(creature: Creature): void {
+  if (creature.cachedWasmActivation) {
+    creature.cachedWasmActivation.free();
+    creature.cachedWasmActivation = undefined;
+  }
+  creature.wasmEligibilityCache = undefined;
+}
+
+/** Prepare non-input neurons for activation. */
+function prepareNeurons(creature: Creature): void {
+  if (creature.state.preparedNeurons) return;
+  for (let i = creature.input, len = creature.neurons.length; i < len; i++) {
+    creature.neurons[i].prepare();
+  }
+  creature.state.preparedNeurons = true;
+}
+
+/**
+ * Activate the creature using WASM (no tracing).
+ * Lazily compiles the creature to WASM on first call.
+ * Issue #1301: Uses topology-based caching to avoid redundant compilation.
+ */
+export function activateWasm(
+  creature: Creature,
+  input: Float32Array,
+  feedbackLoop: boolean,
+): Float32Array {
+  if (!creature.cachedWasmActivation) {
+    creature.cachedWasmActivation = getOrCompileWasmModule(creature) ??
+      undefined;
+
+    // Issue #1338: Under memory pressure, evict old cached WASM activations and retry.
+    if (!creature.cachedWasmActivation) {
+      evictOldestWasmCreatureActivations(64);
+      creature.cachedWasmActivation = getOrCompileWasmModule(creature) ??
+        undefined;
+    }
+
+    if (!creature.cachedWasmActivation) {
+      fail(
+        "WASM activation was selected but failed to instantiate CompiledNetwork",
+      );
+    }
+
+    const major = Number.parseInt(
+      creature.semanticVersion.split(".")[0] ?? "0",
+      10,
+    );
+    const forwardOnlyGuaranteed = Number.isFinite(major) && major >= 4 &&
+      creature.forwardOnly === true;
+    creature.cachedWasmActivation.setNeedsResetWhenStateless(
+      !forwardOnlyGuaranteed,
+    );
+  }
+
+  noteWasmCreatureActivationUse(creature);
+  return creature.cachedWasmActivation.activateWithState(input, feedbackLoop);
+}
+
+/**
+ * Activate the creature using WASM with tracing support for backpropagation.
+ * Issue #1121: WASM Migration Phase 4 - activateAndTrace.
+ */
+export function activateAndTraceWasm(
+  creature: Creature,
+  input: Float32Array,
+  feedbackLoop: boolean,
+  sparseConfig: SparseConfigLike,
+): Float32Array {
+  if (!creature.cachedWasmActivation) {
+    creature.cachedWasmActivation = getOrCompileWasmModule(creature) ??
+      undefined;
+
+    // Issue #1338: Best-effort eviction + retry under memory pressure.
+    if (!creature.cachedWasmActivation) {
+      evictOldestWasmCreatureActivations(64);
+      creature.cachedWasmActivation = getOrCompileWasmModule(creature) ??
+        undefined;
+    }
+
+    if (!creature.cachedWasmActivation) {
+      fail(
+        "WASM activateAndTrace was selected but failed to instantiate CompiledNetwork",
+      );
+    }
+  }
+
+  noteWasmCreatureActivationUse(creature);
+
+  prepareNeurons(creature);
+  creature.state.makeActivation(input, feedbackLoop);
+
+  const wasmResult = creature.cachedWasmActivation.activateAndTraceWithFeedback(
+    input,
+    feedbackLoop,
+  );
+
+  const neurons = creature.neurons;
+  for (let i = 0; i < wasmResult.activations.length; i++) {
+    const neuronIdx = creature.input + i;
+    if (neuronIdx < neurons.length) {
+      creature.state.activations[neuronIdx] = wasmResult.activations[i];
+    }
+  }
+
+  applyWasmTraceData(creature, wasmResult.traceEntries, sparseConfig);
+
+  for (let i = creature.input; i < neurons.length; i++) {
+    const n = neurons[i];
+    if (sparseConfig.propagateNeeded(n.uuid)) {
+      creature.state.node(n.index).hintValue =
+        wasmResult.hintValues[i - creature.input];
+    }
+  }
+
+  return wasmResult.outputs;
+}
+
+/**
+ * Apply WASM trace data to synapse states.
+ * Issue #1121: WASM Migration Phase 4 - activateAndTrace.
+ */
+function applyWasmTraceData(
+  creature: Creature,
+  traceEntries: Array<{ neuronRelativeIndex: number; traceInfo: number }>,
+  sparseConfig: SparseConfigLike,
+): void {
+  const neurons = creature.neurons;
+
+  for (const entry of traceEntries) {
+    const neuronIdx = creature.input + entry.neuronRelativeIndex;
+    if (neuronIdx >= neurons.length) continue;
+
+    const neuron = neurons[neuronIdx];
+    if (!sparseConfig.traceNeeded(neuron.uuid)) continue;
+
+    const inwardList = creature.inwardConnections(neuronIdx);
+    if (inwardList.length === 0) continue;
+
+    const sortedInward = inwardList.slice().sort((a, b) => a.from - b.from);
+    const squash = neuron.squash ?? "IDENTITY";
+
+    if (squash === "MINIMUM" || squash === "MAXIMUM") {
+      const winningLocalIdx = Math.round(entry.traceInfo);
+      for (const c of sortedInward) {
+        const cs = creature.state.connection(c.from, c.to);
+        if (cs.used === undefined) cs.used = false;
+      }
+      if (winningLocalIdx >= 0 && winningLocalIdx < sortedInward.length) {
+        const winningConnection = sortedInward[winningLocalIdx];
+        creature.state.connection(winningConnection.from, winningConnection.to)
+          .used = true;
+      }
+    } else if (squash === "IF") {
+      const positiveBranch = entry.traceInfo > 0.5;
+      if (positiveBranch) {
+        for (const c of sortedInward) {
+          const cs = creature.state.connection(c.from, c.to);
+          switch (c.type) {
+            case "condition":
+            case "negative":
+              if (cs.used === undefined) cs.used = false;
+              break;
+            default:
+              cs.used = true;
+          }
+        }
+      } else {
+        for (const c of sortedInward) {
+          if (c.type === "negative") {
+            creature.state.connection(c.from, c.to).used = true;
+          }
+        }
+      }
+    }
+  }
+
+  // For non-aggregate neurons that need tracing, mark all synapses as used
+  for (let i = creature.input; i < neurons.length; i++) {
+    const n = neurons[i];
+    if (!sparseConfig.traceNeeded(n.uuid)) continue;
+
+    const squash = n.squash ?? "IDENTITY";
+    if (squash === "MINIMUM" || squash === "MAXIMUM" || squash === "IF") {
+      continue;
+    }
+
+    const inwardList = creature.inwardConnections(i);
+    for (const c of inwardList) {
+      const cs = creature.state.connection(c.from, c.to);
+      cs.used = true;
+    }
+  }
+}
+
+/**
+ * Evaluate a dataset directory and return the average error.
+ * Supports fused WASM scoring for forward-only creatures.
+ *
+ * Issue #1229: WASM is required by default with no fallback.
+ */
+export async function evaluateDir(
+  creature: Creature,
+  dataDir: string,
+  cost: CostInterface,
+  feedbackLoop: boolean,
+): Promise<{ error: number }> {
+  const dataResult = dataFiles(dataDir);
+  assert(dataResult.files.length > 0, "No data files found");
+
+  // Issue #1247: Auto-initialise WASM before scoring if not yet available.
+  const { ensureWasmActivation } = await import("../wasm/mod.ts");
+  await ensureWasmActivation();
+
+  requireWasmOrThrow(creature);
+
+  let error = 0;
+  let count = 0;
+
+  const costName = cost.getName();
+  const major = Number.parseInt(
+    creature.semanticVersion.split(".")[0] ?? "0",
+    10,
+  );
+  const forwardOnlyGuaranteed = Number.isFinite(major) && major >= 4 &&
+    creature.forwardOnly === true;
+
+  const effectiveFeedbackLoop = forwardOnlyGuaranteed ? false : feedbackLoop;
+
+  // Ensure WASM network is compiled once for scoring.
+  if (!creature.cachedWasmActivation) {
+    const compiled = compileCreatureToWasm(creature);
+    creature.cachedWasmActivation = WasmCreatureActivation.create(compiled) ??
+      undefined;
+
+    // Issue #1338: Best-effort eviction + retry under memory pressure.
+    if (!creature.cachedWasmActivation) {
+      evictOldestWasmCreatureActivations(64);
+      creature.cachedWasmActivation = WasmCreatureActivation.create(compiled) ??
+        undefined;
+    }
+    if (!creature.cachedWasmActivation) {
+      fail(
+        "WASM activation was selected but failed to instantiate CompiledNetwork",
+      );
+    }
+    creature.cachedWasmActivation.setNeedsResetWhenStateless(
+      !forwardOnlyGuaranteed,
+    );
+  }
+
+  noteWasmCreatureActivationUse(creature);
+
+  const outputBuffer = new Float32Array(creature.output);
+  const valuesCount = creature.input + creature.output;
+  const BYTES_PER_RECORD = valuesCount * 4;
+  const NVME_OPTIMAL_READ_SIZE = 512 * 1024;
+  const BATCH_SIZE = Math.max(
+    1,
+    Math.floor(NVME_OPTIMAL_READ_SIZE / BYTES_PER_RECORD),
+  );
+  const BYTES_PER_BATCH = BYTES_PER_RECORD * BATCH_SIZE;
+
+  const batchBuffer = new Uint8Array(BYTES_PER_BATCH);
+  const batchArray = new Float32Array(batchBuffer.buffer);
+
+  const supportedFusedCosts = [
+    "MSE",
+    "MAE",
+    "CROSS_ENTROPY",
+    "MAPE",
+    "MSLE",
+    "HINGE",
+  ] as const;
+  const useFusedWasm = forwardOnlyGuaranteed &&
+    supportedFusedCosts.includes(
+      costName as typeof supportedFusedCosts[number],
+    );
+
+  for (let fileIndx = dataResult.files.length; fileIndx--;) {
+    const filePath = dataResult.files[fileIndx];
+    // deno-lint-ignore no-sync-fn-in-async-fn -- Intentional: synchronous I/O for batch processing performance.
+    const file = Deno.openSync(filePath, { read: true });
+
+    try {
+      while (true) {
+        const bytesRead = file.readSync(batchBuffer);
+        if (bytesRead === null) break;
+        assert(bytesRead > 0, "Invalid number of bytes read");
+
+        const recordsRead = Math.floor(bytesRead / BYTES_PER_RECORD);
+        assert(
+          bytesRead % BYTES_PER_RECORD === 0,
+          "Invalid number of bytes read",
+        );
+
+        if (useFusedWasm) {
+          const floatsRead = recordsRead * valuesCount;
+          const slice = batchArray.subarray(0, floatsRead);
+          const wasm = creature.cachedWasmActivation!;
+
+          switch (costName) {
+            case "MSE":
+              error += wasm.mseSumBatchPacked(slice, creature.input, true);
+              break;
+            case "MAE":
+              error += wasm.maeSumBatchPacked(slice, creature.input, true);
+              break;
+            case "CROSS_ENTROPY":
+              error += wasm.crossEntropySumBatchPacked(
+                slice,
+                creature.input,
+                true,
+              );
+              break;
+            case "MAPE":
+              error += wasm.mapeSumBatchPacked(slice, creature.input, true);
+              break;
+            case "MSLE":
+              error += wasm.msleSumBatchPacked(slice, creature.input, true);
+              break;
+            case "HINGE":
+              error += wasm.hingeSumBatchPacked(slice, creature.input, true);
+              break;
+          }
+          count += recordsRead;
+          continue;
+        }
+
+        for (let recordIndex = 0; recordIndex < recordsRead; recordIndex++) {
+          const offset = recordIndex * valuesCount;
+          const inputEnd = offset + creature.input;
+          const observations = batchArray.subarray(offset, inputEnd);
+          const target = batchArray.subarray(inputEnd, offset + valuesCount);
+
+          creature.cachedWasmActivation!.activateIntoWithFeedback(
+            observations,
+            outputBuffer,
+            effectiveFeedbackLoop,
+          );
+          error += cost.calculate(target, outputBuffer);
+          count++;
+        }
+      }
+    } finally {
+      file.close();
+    }
+  }
+
+  if (count === 0) {
+    return { error: 0 };
+  } else {
+    const averageError = error / count;
+    if (Number.isFinite(averageError)) {
+      return { error: averageError };
+    } else {
+      getLogger().warn(
+        `AverageError: ${averageError} is not finite, Error: ${error}, Count: ${count}`,
+      );
+      return { error: Number.MAX_SAFE_INTEGER };
+    }
+  }
+}

--- a/src/creature/CreatureMutation.ts
+++ b/src/creature/CreatureMutation.ts
@@ -1,0 +1,225 @@
+/**
+ * CreatureMutation.ts - Network structure repair and random connection creation.
+ *
+ * Extracted from Creature.ts (Issue #1409) to keep the Creature class
+ * under 500 lines and each module focused on a single responsibility.
+ */
+
+import { assert } from "@std/assert";
+import type { Creature } from "../Creature.ts";
+import type { Synapse } from "../architecture/Synapse.ts";
+import { Synapse as SynapseClass } from "../architecture/Synapse.ts";
+import { CreatureUtil } from "../architecture/CreatureUtils.ts";
+import { removeHiddenNeuron } from "../compact/CompactUtils.ts";
+import { mergeTagsByNameValue } from "../utils/TagUtils.ts";
+import { getLogger } from "../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
+
+/**
+ * Create a random connection for the neuron at the given index.
+ */
+export function makeRandomConnection(
+  creature: Creature,
+  indx: number,
+): Synapse | null {
+  assert(
+    Number.isInteger(indx),
+    `Index must be an integer, got: ${String(indx)}`,
+  );
+  assert(
+    indx >= 0 && indx < creature.neurons.length,
+    `Index out of range: ${indx} (neurons length: ${creature.neurons.length})`,
+  );
+
+  const toType = creature.neurons[indx].type;
+  assert(toType !== "input", "Can't connect to input");
+  assert(toType !== "constant", "Can't connect to constant");
+
+  for (let attempts = 0; attempts < 12; attempts++) {
+    const from = Math.min(
+      creature.neurons.length - creature.output - 1,
+      Math.floor(getRandomNumberGenerator().random() * indx),
+    );
+    const c = creature.getSynapse(from, indx);
+    if (c === null) {
+      return creature.connect(
+        from,
+        indx,
+        SynapseClass.randomWeight(),
+      );
+    }
+  }
+
+  const firstOutputIndex = creature.neurons.length - creature.output;
+  for (let from = 0; from < indx; from++) {
+    if (from >= firstOutputIndex) continue;
+    const c = creature.getSynapse(from, indx);
+    if (c === null) {
+      return creature.connect(
+        from,
+        indx,
+        SynapseClass.randomWeight(),
+      );
+    }
+  }
+  return null;
+}
+
+/**
+ * Fix the structure of the creature.
+ *
+ * Removes recurrent connections if requested, merges duplicate synapses,
+ * removes zero-weight synapses (except last output inbound), removes
+ * disconnected hidden neurons, sorts synapses, and bumps semantic version
+ * to 4.0.0 when forced forward-only.
+ */
+export function fix(
+  creature: Creature,
+  options?: {
+    forwardOnly?: boolean;
+    removeBackConnections?: boolean;
+    removeSelfConnections?: boolean;
+  },
+): void {
+  const forwardOnly = options?.forwardOnly === true;
+  const removeBackConnections = forwardOnly ||
+    options?.removeBackConnections === true;
+  const removeSelfConnections = forwardOnly ||
+    options?.removeSelfConnections === true;
+
+  const holdDebug = creature.DEBUG;
+  creature.DEBUG = false;
+  const startUUID = CreatureUtil.makeUUID(creature);
+  creature.DEBUG = holdDebug;
+  const maxTo = creature.neurons.length - 1;
+  const minTo = creature.input;
+
+  // Merge duplicate synapses (same from/to/type) by summing weights.
+  const merged = new Map<string, Synapse>();
+  const inboundCountsByTo = new Map<number, number>();
+
+  creature.synapses.forEach((synapse) => {
+    if (removeSelfConnections && synapse.from === synapse.to) return;
+    if (removeBackConnections && synapse.from > synapse.to) return;
+
+    if (synapse.to > maxTo) {
+      getLogger().debug("Ignoring connection to above max", maxTo, synapse);
+      return;
+    }
+    if (synapse.to < minTo) {
+      getLogger().debug("Ignoring connection to below min", minTo, synapse);
+      return;
+    }
+
+    const typeKey = synapse.type ?? "";
+    const key = `${synapse.from}->${synapse.to}:${typeKey}`;
+
+    const existing = merged.get(key);
+    if (existing) {
+      existing.weight += synapse.weight;
+      if (synapse.tags?.length) {
+        existing.tags = mergeTagsByNameValue(existing.tags, synapse.tags);
+      }
+      return;
+    }
+
+    merged.set(key, synapse as Synapse);
+    inboundCountsByTo.set(
+      synapse.to,
+      (inboundCountsByTo.get(synapse.to) ?? 0) + 1,
+    );
+  });
+
+  const tmpSynapses: Synapse[] = [];
+  for (const synapse of merged.values()) {
+    if (synapse.weight !== 0 && Number.isFinite(synapse.weight)) {
+      tmpSynapses.push(synapse);
+      continue;
+    }
+
+    if (creature.neurons[synapse.to].type === "output") {
+      const inbound = inboundCountsByTo.get(synapse.to) ?? 0;
+      if (inbound === 1) {
+        tmpSynapses.push(synapse);
+      }
+    }
+  }
+
+  creature.synapses = tmpSynapses;
+
+  creature.synapses.sort((a, b) => {
+    if (a.from === b.from) {
+      return a.to - b.to;
+    } else {
+      return a.from - b.from;
+    }
+  });
+
+  creature.clearCache();
+
+  let neuronRemoved = true;
+  while (neuronRemoved) {
+    neuronRemoved = false;
+    for (
+      let pos = creature.input;
+      pos < creature.neurons.length - creature.output;
+      pos++
+    ) {
+      if (creature.neurons[pos].type === "output") continue;
+      if (creature.outwardConnections(pos).length === 0) {
+        if (creature.DEBUG) {
+          getLogger().debug(
+            `fix() removing disconnected neuron ${pos} ${
+              creature.neurons[pos].uuid
+            }`,
+          );
+        }
+        removeHiddenNeuron(creature, pos);
+        neuronRemoved = true;
+        break;
+      }
+    }
+  }
+
+  for (let i = 1; i < creature.synapses.length; i++) {
+    if (creature.synapses[i - 1].from > creature.synapses[i].from) {
+      getLogger().error(
+        "Synapses not sorted",
+        creature.synapses[i - 1],
+        creature.synapses[i],
+      );
+      creature.synapses.sort((a, b) => {
+        if (a.from === b.from) {
+          return a.to - b.to;
+        } else {
+          return a.from - b.from;
+        }
+      });
+      break;
+    }
+  }
+
+  creature.neurons.forEach((neuron) => {
+    neuron.fix();
+  });
+
+  if (forwardOnly) {
+    creature.forwardOnly = true;
+    const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(creature.semanticVersion);
+    if (match) {
+      const major = Number.parseInt(match[1], 10);
+      if (major === 2 || major === 3) {
+        creature.semanticVersion = "4.0.0";
+      }
+    }
+  }
+
+  const tmpDebug = creature.DEBUG;
+  creature.DEBUG = false;
+  delete creature.uuid;
+  const endUUID = CreatureUtil.makeUUID(creature);
+  creature.DEBUG = tmpDebug;
+  if (startUUID !== endUUID) {
+    delete creature.memetic;
+  }
+}

--- a/src/creature/CreatureSerialization.ts
+++ b/src/creature/CreatureSerialization.ts
@@ -1,0 +1,334 @@
+/**
+ * CreatureSerialization.ts - JSON import/export and cloning.
+ *
+ * Extracted from Creature.ts (Issue #1409) to keep the Creature class
+ * under 500 lines and each module focused on a single responsibility.
+ */
+
+import { assert, fail } from "@std/assert";
+import type { TagInterface } from "@stsoftware/tags/mod";
+import type { Creature } from "../Creature.ts";
+import type {
+  CreatureExport,
+  CreatureInternal,
+  CreatureTrace,
+} from "../architecture/CreatureInterfaces.ts";
+import { creatureValidate } from "../architecture/CreatureValidate.ts";
+import { Neuron } from "../architecture/Neuron.ts";
+import type { NeuronTrace } from "../architecture/NeuronInterfaces.ts";
+import { Synapse } from "../architecture/Synapse.ts";
+import type {
+  SynapseExport,
+  SynapseInternal,
+  SynapseTrace,
+} from "../architecture/SynapseInterfaces.ts";
+import { upgradeOne } from "../upgrade/UpgradeOne.ts";
+import { CreatureExportBuilder } from "../utils/CreatureExportBuilder.ts";
+
+/**
+ * Convert the creature to a JSON export object.
+ */
+export function exportJSON(creature: Creature): CreatureExport {
+  if (creature.DEBUG) {
+    creatureValidate(creature);
+  }
+  const builder = new CreatureExportBuilder(creature);
+  return builder.build();
+}
+
+/**
+ * Convert the creature to a trace JSON object.
+ */
+export function traceJSON(creature: Creature): CreatureTrace {
+  const exportCreature = exportJSON(creature);
+
+  const state = creature.state;
+  let exportIndex = 0;
+  creature.neurons.forEach((n) => {
+    if (n.type !== "input") {
+      if (n.type !== "constant") {
+        const indx = n.index;
+
+        const traceNeuron: NeuronTrace = exportCreature
+          .neurons[exportIndex] as NeuronTrace;
+
+        const ns = state.node(indx);
+        if (ns.count) {
+          (traceNeuron as NeuronTrace).trace = ns;
+        }
+      }
+      exportIndex++;
+    }
+  });
+
+  creature.synapses.forEach((c, indx) => {
+    const exportConnection = exportCreature.synapses[indx] as SynapseTrace;
+    const cs = state.connection(c.from, c.to);
+    if (cs.count) {
+      exportConnection.trace = cs;
+    }
+  });
+
+  return exportCreature as CreatureTrace;
+}
+
+/**
+ * Load the creature from a JSON object.
+ */
+export function loadFrom(
+  creature: Creature,
+  json: CreatureInternal | CreatureExport,
+  validate: boolean,
+): void {
+  creature.uuid = (json as CreatureInternal).uuid;
+  if (json.semanticVersion) {
+    creature.semanticVersion = json.semanticVersion;
+  }
+  creature.forwardOnly = (json as CreatureExport).forwardOnly;
+
+  const neuronCount = json.neurons.length;
+  const synapseCount = json.synapses.length;
+  creature.neurons = new Array(neuronCount);
+  creature.synapses = new Array(synapseCount);
+
+  if (json.tags) {
+    creature.tags = [...json.tags];
+  }
+
+  creature.clearState();
+  const state = creature.state;
+  const uuidMap = new Map<string, number>();
+
+  let i = json.input;
+  while (i--) {
+    const key = `input-${i}`;
+    uuidMap.set(key, i);
+    const n = new Neuron(key, "input", 0, creature);
+    n.index = i;
+    creature.neurons[i] = n;
+  }
+
+  let pos = json.input;
+  let outputIndex = 0;
+  const neurons = json.neurons;
+
+  for (let i = 0; i < neurons.length; i++) {
+    const jn = neurons[i];
+    if (jn.type === "input") continue;
+
+    if (jn.type === "output") {
+      (jn as { uuid: string }).uuid = `output-${outputIndex++}`;
+    }
+
+    const n = Neuron.fromJSON(jn, creature);
+    n.index = pos;
+
+    if ((jn as NeuronTrace).trace) {
+      Object.assign(state.node(n.index), (jn as NeuronTrace).trace);
+    }
+
+    uuidMap.set(n.uuid, pos);
+    creature.neurons[pos++] = n;
+  }
+
+  const synapses = json.synapses;
+  let isSorted = true;
+  let lastFrom = -1;
+  let lastTo = -1;
+  for (let i = 0; i < synapseCount; i++) {
+    const synapse = synapses[i];
+    const se = synapse as SynapseExport;
+    const from = se.fromUUID
+      ? uuidMap.get(se.fromUUID)
+      : (synapse as SynapseInternal).from;
+
+    assert(from !== undefined, "FROM is undefined");
+
+    const to = se.toUUID
+      ? uuidMap.get(se.toUUID)
+      : (synapse as SynapseInternal).to;
+
+    if (to === undefined) {
+      fail(
+        `TO is undefined: uuid ${se.toUUID}, index ${
+          (synapse as SynapseInternal).to
+        }`,
+      );
+    }
+
+    if (isSorted) {
+      if (from > lastFrom) {
+        lastFrom = from;
+        lastTo = -1;
+      } else if (from < lastFrom || to <= lastTo) {
+        isSorted = false;
+      }
+      lastTo = to;
+    }
+
+    const tmpSynapse = new Synapse(from!, to!, synapse.weight, synapse.type);
+    creature.synapses[i] = tmpSynapse;
+
+    if (synapse.tags) {
+      tmpSynapse.tags = synapse.tags.slice();
+    }
+
+    if ((synapse as SynapseTrace).trace) {
+      Object.assign(
+        state.connection(tmpSynapse.from, tmpSynapse.to),
+        (synapse as SynapseTrace).trace,
+      );
+    }
+  }
+
+  creature.memetic = json.memetic;
+  creature.clearCache();
+
+  if (!isSorted) {
+    creature.synapses.sort((a, b) => {
+      if (a.from !== b.from) return a.from - b.from;
+      return a.to - b.to;
+    });
+  }
+
+  creature.prebuildInwardIndexIfLarge();
+
+  if (validate) {
+    creatureValidate(creature);
+  }
+}
+
+/**
+ * Factory method to create a creature from JSON.
+ * Handles semantic version upgrades via upgradeOne().
+ * Normalises legacy properties (nodes -> neurons, connections -> synapses).
+ */
+export function fromJSON(
+  json: CreatureInternal | CreatureExport,
+  validate: boolean,
+  CreatureClass: {
+    new (
+      input: number,
+      output: number,
+      options: { lazyInitialization: boolean; semanticVersion?: string },
+    ): Creature;
+  },
+): Creature {
+  const semanticVersion = json.semanticVersion ?? "0.0.1";
+  if (semanticVersion.startsWith("0.")) {
+    json = upgradeOne(json);
+  }
+
+  const creature = new CreatureClass(json.input, json.output, {
+    lazyInitialization: true,
+    semanticVersion: json.semanticVersion,
+  });
+
+  const raw = json as unknown as Record<string, unknown>;
+  if (raw.nodes) {
+    raw.neurons = raw.nodes;
+    delete raw.nodes;
+  }
+  if (raw.connections) {
+    raw.synapses = raw.connections;
+    delete raw.connections;
+  }
+  loadFrom(creature, json, validate);
+
+  return creature;
+}
+
+/**
+ * Creates a shallow clone of a creature.
+ * Significantly faster than using fromJSON(exportJSON()).
+ * Issue #1025: Performance optimisation for fittest creature tracking.
+ */
+export function shallowClone(
+  creature: Creature,
+  CreatureClass: {
+    new (
+      input: number,
+      output: number,
+      options: {
+        lazyInitialization: boolean;
+        semanticVersion: string;
+      },
+    ): Creature;
+  },
+): Creature {
+  const clone = new CreatureClass(creature.input, creature.output, {
+    lazyInitialization: true,
+    semanticVersion: creature.semanticVersion,
+  });
+
+  clone.uuid = creature.uuid;
+  clone.score = creature.score;
+  clone.forwardOnly = creature.forwardOnly;
+  clone.DEBUG = creature.DEBUG;
+
+  if (creature.memetic) {
+    clone.memetic = { ...creature.memetic };
+  }
+
+  if (creature.tags) {
+    clone.tags = [...creature.tags];
+  }
+
+  if (creature.cachedScoreComponents) {
+    clone.cachedScoreComponents = { ...creature.cachedScoreComponents };
+  }
+
+  const neuronCount = creature.neurons.length;
+  clone.neurons = new Array(neuronCount);
+
+  for (let i = 0; i < creature.input; i++) {
+    const original = creature.neurons[i];
+    const neuron = new Neuron(original.uuid, "input", 0, clone);
+    neuron.index = i;
+    const originalTags = original.tags as TagInterface[] | undefined;
+    if (originalTags) {
+      (neuron as { tags: TagInterface[] | undefined }).tags = [
+        ...originalTags,
+      ];
+    }
+    clone.neurons[i] = neuron;
+  }
+
+  for (let i = creature.input; i < neuronCount; i++) {
+    const original = creature.neurons[i];
+    const neuron = new Neuron(
+      original.uuid,
+      original.type,
+      original.bias,
+      clone,
+      original.squash,
+    );
+    neuron.index = i;
+    const originalTags = original.tags as TagInterface[] | undefined;
+    if (originalTags) {
+      (neuron as { tags: TagInterface[] | undefined }).tags = [
+        ...originalTags,
+      ];
+    }
+    clone.neurons[i] = neuron;
+  }
+
+  const synapseCount = creature.synapses.length;
+  clone.synapses = new Array(synapseCount);
+
+  for (let i = 0; i < synapseCount; i++) {
+    const original = creature.synapses[i];
+    const synapse = new Synapse(
+      original.from,
+      original.to,
+      original.weight,
+      original.type,
+    );
+    if (original.tags) {
+      synapse.tags = [...original.tags];
+    }
+    clone.synapses[i] = synapse;
+  }
+
+  return clone;
+}

--- a/src/creature/CreatureTopology.ts
+++ b/src/creature/CreatureTopology.ts
@@ -1,0 +1,575 @@
+/**
+ * CreatureTopology.ts - Neuron/synapse management and connection queries.
+ *
+ * Extracted from Creature.ts (Issue #1409) to keep the Creature class
+ * under 500 lines and each module focused on a single responsibility.
+ */
+
+import type { Creature } from "../Creature.ts";
+import type { Synapse } from "../architecture/Synapse.ts";
+
+/**
+ * Internal state for topology caches and indices.
+ * Stored on the Creature instance and passed to topology functions.
+ */
+export interface TopologyCaches {
+  cacheTo: Map<number, Synapse[]>;
+  cacheFrom: Map<number, Synapse[]>;
+  cacheSelf: Map<number, Synapse[]>;
+  synapsesIndexedByTo: Synapse[] | null;
+  connectionSet: Set<string> | null;
+  availableConnectionsCache: [number, number][] | null;
+  hiddenNeuronUUIDs: Set<string> | null;
+  inwardCacheMissCount: number;
+}
+
+/**
+ * Threshold for switching from linear scan to building the secondary index.
+ * Issue #1010: Performance optimisation for large creatures.
+ */
+export const INWARD_INDEX_BUILD_THRESHOLD = 3;
+
+/**
+ * Minimum number of synapses to trigger proactive index prebuilding.
+ * Issue #1097: Performance - Prebuild inward synapse index after breed/mutation batch.
+ */
+export const PREBUILD_SYNAPSE_THRESHOLD = 1000;
+
+/**
+ * Get a self-connection for the neuron at the given index.
+ */
+export function selfConnection(
+  creature: Creature,
+  caches: TopologyCaches,
+  indx: number,
+): Synapse | null {
+  let results = caches.cacheSelf.get(indx);
+  if (results === undefined) {
+    results = [];
+    const tmpList = creature.synapses;
+    for (let i = tmpList.length; i--;) {
+      const c = tmpList[i];
+      if (c.to === indx && c.from === indx) {
+        results.push(c);
+      }
+    }
+    caches.cacheSelf.set(indx, results);
+  }
+  return results.length > 0 ? results[0] : null;
+}
+
+/**
+ * Get the inward connections (afferent) for the neuron at the given index.
+ * Uses a secondary index sorted by `to` field for O(log n) binary search lookup.
+ * Issue #1010: Performance optimisation for large creatures.
+ */
+export function inwardConnections(
+  creature: Creature,
+  caches: TopologyCaches,
+  toIndx: number,
+): Synapse[] {
+  let results = caches.cacheTo.get(toIndx);
+  if (results === undefined) {
+    results = lookupInwardConnections(creature, caches, toIndx);
+    caches.cacheTo.set(toIndx, results);
+  }
+  return results;
+}
+
+/**
+ * Builds the secondary index of synapses sorted by `to` field.
+ * Issue #1010: Performance optimisation for large creatures.
+ */
+function buildSynapsesIndexedByTo(creature: Creature): Synapse[] {
+  return creature.synapses.slice().sort((a, b) => {
+    if (a.to !== b.to) return a.to - b.to;
+    return a.from - b.from;
+  });
+}
+
+/**
+ * Binary search for the start index in the secondary (to-sorted) index.
+ * Issue #1010: Performance optimisation for large creatures.
+ */
+function binarySearchForToStartIndex(
+  index: Synapse[],
+  toIndx: number,
+): number {
+  let low = 0;
+  let high = index.length - 1;
+  let result = -1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const midValue = index[mid];
+
+    if (midValue.to < toIndx) {
+      low = mid + 1;
+    } else if (midValue.to > toIndx) {
+      high = mid - 1;
+    } else {
+      result = mid;
+      high = mid - 1;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Looks up inward connections using binary search on the secondary index.
+ * Falls back to linear scan if index is not built.
+ * Automatically builds the index after a few cache misses.
+ * Issue #1010: Performance optimisation for large creatures.
+ */
+function lookupInwardConnections(
+  creature: Creature,
+  caches: TopologyCaches,
+  toIndx: number,
+): Synapse[] {
+  if (caches.synapsesIndexedByTo !== null) {
+    const index = caches.synapsesIndexedByTo;
+    const startIndex = binarySearchForToStartIndex(index, toIndx);
+
+    if (startIndex === -1) return [];
+
+    const results: Synapse[] = [];
+    for (let i = startIndex; i < index.length; i++) {
+      const synapse = index[i];
+      if (synapse.to === toIndx) {
+        results.push(synapse);
+      } else {
+        break;
+      }
+    }
+    return results;
+  }
+
+  caches.inwardCacheMissCount++;
+  if (caches.inwardCacheMissCount >= INWARD_INDEX_BUILD_THRESHOLD) {
+    caches.synapsesIndexedByTo = buildSynapsesIndexedByTo(creature);
+    return lookupInwardConnections(creature, caches, toIndx);
+  }
+
+  const results: Synapse[] = [];
+  for (let i = 0, len = creature.synapses.length; i < len; i++) {
+    const synapse = creature.synapses[i];
+    if (synapse.to === toIndx) {
+      results.push(synapse);
+    }
+  }
+  return results;
+}
+
+/**
+ * Pre-builds the secondary index for inward connections.
+ * Issue #1010: Performance optimisation for large creatures.
+ */
+export function prebuildInwardIndex(
+  creature: Creature,
+  caches: TopologyCaches,
+): void {
+  if (caches.synapsesIndexedByTo === null) {
+    caches.synapsesIndexedByTo = buildSynapsesIndexedByTo(creature);
+  }
+}
+
+/** Checks if the inward synapse index has been built. */
+export function isInwardIndexBuilt(caches: TopologyCaches): boolean {
+  return caches.synapsesIndexedByTo !== null;
+}
+
+/**
+ * Conditionally prebuilds the inward index for large creatures.
+ * Issue #1097: Performance - Prebuild inward synapse index after breed/mutation batch.
+ */
+export function prebuildInwardIndexIfLarge(
+  creature: Creature,
+  caches: TopologyCaches,
+): void {
+  if (creature.synapses.length >= PREBUILD_SYNAPSE_THRESHOLD) {
+    prebuildInwardIndex(creature, caches);
+  }
+}
+
+/**
+ * Bulk loads all inward connections into the cache.
+ * Issue #1010: Performance optimisation for large creatures.
+ */
+export function bulkLoadInwardConnections(
+  creature: Creature,
+  caches: TopologyCaches,
+): void {
+  if (caches.synapsesIndexedByTo === null) {
+    caches.synapsesIndexedByTo = buildSynapsesIndexedByTo(creature);
+  }
+
+  const cacheTo = caches.cacheTo;
+  for (let indx = 0, len = creature.neurons.length; indx < len; indx++) {
+    if (!cacheTo.has(indx)) {
+      cacheTo.set(indx, []);
+    }
+  }
+
+  const index = caches.synapsesIndexedByTo;
+  for (let i = 0, len = index.length; i < len; i++) {
+    const synapse = index[i];
+    const to = synapse.to;
+    const tmpResults = cacheTo.get(to);
+    if (tmpResults) {
+      tmpResults.push(synapse);
+    }
+  }
+}
+
+/**
+ * Builds and returns a Set of existing connections as "from-to" strings.
+ * Enables O(1) lookup for connection existence checks.
+ * Issue #1036: Performance optimisation for ADD_CONNECTION mutation.
+ */
+export function getConnectionSet(
+  creature: Creature,
+  caches: TopologyCaches,
+): Set<string> {
+  if (caches.connectionSet === null) {
+    caches.connectionSet = new Set<string>();
+    for (let i = 0, len = creature.synapses.length; i < len; i++) {
+      const synapse = creature.synapses[i];
+      caches.connectionSet.add(`${synapse.from}-${synapse.to}`);
+    }
+  }
+  return caches.connectionSet;
+}
+
+/**
+ * Checks if a connection exists between two neurons in O(1) time.
+ * Issue #1036: Performance optimisation for ADD_CONNECTION mutation.
+ */
+export function hasConnection(
+  creature: Creature,
+  caches: TopologyCaches,
+  from: number,
+  to: number,
+): boolean {
+  return getConnectionSet(creature, caches).has(`${from}-${to}`);
+}
+
+/**
+ * Builds and returns a cached Set of hidden neuron UUIDs.
+ * Enables O(1) lookup for genetic compatibility checks.
+ * Issue #1032: Performance optimisation for genetic compatibility checks.
+ */
+export function getHiddenNeuronUUIDs(
+  creature: Creature,
+  caches: TopologyCaches,
+): Set<string> {
+  if (caches.hiddenNeuronUUIDs === null) {
+    caches.hiddenNeuronUUIDs = new Set<string>();
+    for (let i = creature.input, len = creature.neurons.length; i < len; i++) {
+      const neuron = creature.neurons[i];
+      if (neuron.type === "hidden") {
+        caches.hiddenNeuronUUIDs.add(neuron.uuid);
+      }
+    }
+  }
+  return caches.hiddenNeuronUUIDs;
+}
+
+/**
+ * Returns a list of available forward-only connection slots (from, to pairs).
+ * Issue #1036, #1098: Performance optimisation for ADD_CONNECTION mutation.
+ */
+export function getAvailableConnections(
+  creature: Creature,
+  caches: TopologyCaches,
+  focusList?: number[],
+  inFocusFn?: (index: number, focusList?: number[]) => boolean,
+): [number, number][] {
+  if (caches.availableConnectionsCache === null) {
+    caches.availableConnectionsCache = computeAvailableConnections(
+      creature,
+      caches,
+    );
+  }
+
+  if (!focusList || focusList.length === 0) {
+    return caches.availableConnectionsCache;
+  }
+
+  return caches.availableConnectionsCache.filter(([from, to]) => {
+    return (inFocusFn?.(from, focusList) ?? true) ||
+      (inFocusFn?.(to, focusList) ?? true);
+  });
+}
+
+/**
+ * Computes all available forward-only connection slots.
+ * Issue #1098: Extracted to support caching.
+ */
+function computeAvailableConnections(
+  creature: Creature,
+  caches: TopologyCaches,
+): [number, number][] {
+  const connSet = getConnectionSet(creature, caches);
+  const available: [number, number][] = [];
+  const neurons = creature.neurons;
+  const neuronCount = neurons.length;
+  const inputCount = creature.input;
+
+  for (let fromIndx = 0; fromIndx < neuronCount; fromIndx++) {
+    const startTo = Math.max(fromIndx + 1, inputCount);
+    for (let toIndx = startTo; toIndx < neuronCount; toIndx++) {
+      const neuronTo = neurons[toIndx];
+      if (neuronTo.type === "constant") continue;
+      const key = `${fromIndx}-${toIndx}`;
+      if (!connSet.has(key)) {
+        available.push([fromIndx, toIndx]);
+      }
+    }
+  }
+  return available;
+}
+
+/** Checks if the available connections cache has been built. */
+export function isAvailableConnectionsCacheBuilt(
+  caches: TopologyCaches,
+): boolean {
+  return caches.availableConnectionsCache !== null;
+}
+
+/**
+ * Get the outward connections (efferent) for the neuron at the given index.
+ */
+export function outwardConnections(
+  creature: Creature,
+  caches: TopologyCaches,
+  fromIndx: number,
+): Synapse[] {
+  let results = caches.cacheFrom.get(fromIndx);
+  if (results === undefined) {
+    const startIndex = binarySearchForStartIndex(creature, fromIndx);
+
+    if (startIndex !== -1) {
+      results = [];
+      for (let i = startIndex; i < creature.synapses.length; i++) {
+        const tmp = creature.synapses[i];
+        if (tmp.from === fromIndx) {
+          results.push(tmp);
+        } else {
+          break;
+        }
+      }
+    } else {
+      results = [];
+    }
+
+    caches.cacheFrom.set(fromIndx, results);
+  }
+  return results;
+}
+
+/**
+ * Binary search for the first synapse with matching 'from' index.
+ */
+function binarySearchForStartIndex(
+  creature: Creature,
+  fromIndx: number,
+): number {
+  let low = 0;
+  let high = creature.synapses.length - 1;
+  let result = -1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const midValue = creature.synapses[mid];
+
+    if (midValue.from < fromIndx) {
+      low = mid + 1;
+    } else if (midValue.from > fromIndx) {
+      high = mid - 1;
+    } else {
+      result = mid;
+      high = mid - 1;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get a specific synapse between two neurons.
+ */
+export function getSynapse(
+  creature: Creature,
+  caches: TopologyCaches,
+  from: number,
+  to: number,
+): Synapse | null {
+  const outward = outwardConnections(creature, caches, from);
+
+  for (let indx = outward.length; indx--;) {
+    const c = outward[indx];
+    if (c.to === to) {
+      return c;
+    } else if (c.to < to) {
+      break;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Binary search for a synapse by (from, to) indices.
+ * Synapses are sorted first by `from`, then by `to` within the same `from`.
+ * Issue #1101: Performance optimisation for disconnect operations.
+ */
+export function binarySearchSynapse(
+  creature: Creature,
+  from: number,
+  to: number,
+): number {
+  const synapses = creature.synapses;
+  let low = 0;
+  let high = synapses.length - 1;
+
+  while (low <= high) {
+    const mid = (low + high) >>> 1;
+    const syn = synapses[mid];
+
+    if (syn.from < from) {
+      low = mid + 1;
+    } else if (syn.from > from) {
+      high = mid - 1;
+    } else {
+      if (syn.to < to) {
+        low = mid + 1;
+      } else if (syn.to > to) {
+        high = mid - 1;
+      } else {
+        return mid;
+      }
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Find the insertion point for a synapse to maintain sorted order.
+ * Uses binary search for O(log n) efficiency.
+ * Issue #1102: Helper method for connectBatch.
+ */
+export function findInsertionPoint(
+  creature: Creature,
+  from: number,
+  to: number,
+): number {
+  const synapses = creature.synapses;
+  let low = 0;
+  let high = synapses.length;
+
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    const syn = synapses[mid];
+
+    if (syn.from < from || (syn.from === from && syn.to < to)) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+
+  return low;
+}
+
+/**
+ * Check if a neuron is in focus.
+ */
+export function inFocus(
+  creature: Creature,
+  caches: TopologyCaches,
+  cacheFocus: Map<number, boolean>,
+  cacheFocusList: number[] | undefined,
+  index: number,
+  focusList?: number[],
+  checked: Set<number> = new Set(),
+): { result: boolean; updatedCacheFocusList: number[] | undefined } {
+  if (!focusList || focusList.length === 0) {
+    return { result: true, updatedCacheFocusList: cacheFocusList };
+  }
+
+  // Issue #1100: Check if the focus list matches the cached focus list.
+  let currentCacheFocusList = cacheFocusList;
+  if (!isFocusListMatch(currentCacheFocusList, focusList)) {
+    cacheFocus.clear();
+    currentCacheFocusList = [...focusList];
+  }
+
+  if (cacheFocus.has(index)) {
+    return {
+      result: cacheFocus.get(index) as boolean,
+      updatedCacheFocusList: currentCacheFocusList,
+    };
+  }
+
+  if (checked.has(index)) {
+    cacheFocus.set(index, false);
+    return { result: false, updatedCacheFocusList: currentCacheFocusList };
+  }
+
+  checked.add(index);
+
+  for (let pos = 0; pos < focusList.length; pos++) {
+    const focusIndex = focusList[pos];
+
+    if (index === focusIndex) {
+      cacheFocus.set(index, true);
+      return { result: true, updatedCacheFocusList: currentCacheFocusList };
+    }
+
+    const toList = inwardConnections(creature, caches, index);
+
+    for (let i = toList.length; i--;) {
+      const checkIndx: number = toList[i].from;
+      if (checkIndx === index) {
+        cacheFocus.set(index, true);
+        return { result: true, updatedCacheFocusList: currentCacheFocusList };
+      }
+
+      const sub = inFocus(
+        creature,
+        caches,
+        cacheFocus,
+        currentCacheFocusList,
+        checkIndx,
+        focusList,
+        checked,
+      );
+      currentCacheFocusList = sub.updatedCacheFocusList;
+      if (sub.result) {
+        cacheFocus.set(index, true);
+        return { result: true, updatedCacheFocusList: currentCacheFocusList };
+      }
+    }
+  }
+
+  cacheFocus.set(index, false);
+  return { result: false, updatedCacheFocusList: currentCacheFocusList };
+}
+
+/**
+ * Check if the given focus list matches the cached focus list.
+ * Issue #1100: Used to detect when the focus cache should be invalidated.
+ */
+function isFocusListMatch(
+  cached: number[] | undefined,
+  focusList: number[],
+): boolean {
+  if (!cached) return false;
+  if (cached.length !== focusList.length) return false;
+  for (let i = 0; i < cached.length; i++) {
+    if (cached[i] !== focusList[i]) return false;
+  }
+  return true;
+}

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -1,0 +1,555 @@
+/**
+ * CreatureTraining.ts - Training orchestration, evolution, and scoring.
+ *
+ * Extracted from Creature.ts (Issue #1409) to keep the Creature class
+ * under 500 lines and each module focused on a single responsibility.
+ */
+
+import { assert } from "@std/assert";
+import { yellow } from "@std/fmt/colors";
+import { format } from "@std/fmt/duration";
+import { emptyDirSync } from "@std/fs";
+import { getTag } from "@stsoftware/tags/mod";
+import type { Creature } from "../Creature.ts";
+import type { DataRecordInterface } from "../architecture/DataSet.ts";
+import { makeDataDir } from "../architecture/DataSet.ts";
+import type { DiscoverRecord } from "../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { calculate as calculateScore } from "../architecture/Score.ts";
+import { dataFiles } from "../architecture/Training.ts";
+import { createNeatConfig } from "../config/NeatConfig.ts";
+import type { NeatOptions } from "../config/NeatOptions.ts";
+import { Costs } from "../Costs.ts";
+import { WorkerHandler } from "../multithreading/workers/WorkerHandler.ts";
+import { Neat } from "../NEAT/Neat.ts";
+import {
+  type BackPropagationConfig,
+  createBackPropagationConfig,
+} from "../propagate/BackPropagation.ts";
+import { BackpropBuffers } from "../propagate/BackpropBuffers.ts";
+import { buildOutgoingSynapsesMap } from "../propagate/sparse/CalculatePathsToOutput.ts";
+import { SparseConfig } from "../propagate/sparse/SparseConfig.ts";
+import { BufferPool } from "../utils/BufferPool.ts";
+import {
+  type DiscoveryDirResult,
+  DiscoveryRunner,
+  type DiscoveryRunnerLike,
+} from "../discovery/DiscoveryRunner.ts";
+import {
+  type DiscoveryReplayDirResult,
+  DiscoveryReplayRunner,
+  type DiscoveryReplayRunnerLike,
+} from "../discovery/DiscoveryReplayRunner.ts";
+import { getLogger } from "../utils/Logger.ts";
+import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
+
+/**
+ * Propagate expected values backward through the network for all output neurons.
+ */
+export function propagate(
+  creature: Creature,
+  expected: Float32Array,
+  config: BackPropagationConfig,
+  sparseConfig: SparseConfig,
+): void {
+  creature.state.cacheAdjustedActivation.clear();
+
+  // Issue #1379: Lazily initialise reusable backward pass buffers.
+  if (creature.state.backpropBuffers === undefined) {
+    creature.state.backpropBuffers = new BackpropBuffers();
+  }
+
+  const neurons = creature.neurons;
+  const lastOutputIndx = neurons.length - creature.output;
+
+  for (let indx = creature.output; indx--;) {
+    const nodeIndex = lastOutputIndx + indx;
+    const n = neurons[nodeIndex];
+
+    if (sparseConfig.propagateNeeded(n.uuid)) {
+      n.propagate(expected[indx], config, sparseConfig);
+    }
+  }
+}
+
+/**
+ * Record expected values for discovery (error-guided structural evolution).
+ */
+export function record(
+  creature: Creature,
+  expected: Float32Array,
+): Map<string, DiscoverRecord> {
+  const neurons = creature.neurons;
+  const lastOutputIndx = neurons.length - creature.output;
+
+  const errorMap = new Map<string, DiscoverRecord>();
+  for (let indx = creature.output; indx--;) {
+    const nodeIndex = lastOutputIndx + indx;
+    const n = neurons[nodeIndex];
+    n.record(expected[indx], errorMap);
+  }
+
+  // DIAGNOSTIC: Check for excessive total error count per sample
+  let totalErrors = 0;
+  for (const rec of errorMap.values()) {
+    totalErrors += rec.errors.length;
+  }
+
+  const expectedMax = neurons.length * creature.output * 3;
+  if (totalErrors > expectedMax) {
+    getLogger().error(
+      `❌ CRITICAL: Sample generated ${totalErrors} total errors (expected ≤${expectedMax})`,
+    );
+    getLogger().error(
+      `   Neurons: ${neurons.length}, Outputs: ${creature.output}, ErrorMap size: ${errorMap.size}`,
+    );
+    const sorted = Array.from(errorMap.entries())
+      .sort((a, b) => b[1].errors.length - a[1].errors.length)
+      .slice(0, 5);
+    getLogger().error(`   Top 5 neurons by error count:`);
+    sorted.forEach(([uuid, rec]) => {
+      getLogger().error(`     - ${uuid}: ${rec.errors.length} errors`);
+    });
+
+    if (totalErrors > expectedMax * 10) {
+      throw new Error(
+        `Excessive errors detected: ${totalErrors} total errors in single sample ` +
+          `(expected ≤${expectedMax}). This indicates record() is being called too many times, ` +
+          `causing the performance issue and timeout.`,
+      );
+    }
+  }
+
+  return errorMap;
+}
+
+/**
+ * Update propagated gradients in neurons. Invalidates WASM if weights changed.
+ */
+export function propagateUpdate(
+  creature: Creature,
+  config: BackPropagationConfig,
+  sparseConfig: SparseConfig,
+): void {
+  let didUpdate = false;
+  for (let indx = creature.input; indx < creature.neurons.length; indx++) {
+    const n = creature.neurons[indx];
+    if (sparseConfig.updateNeeded(n.uuid)) {
+      n.propagateUpdate(config);
+      didUpdate = true;
+    }
+  }
+  creature.state.preparedNeurons = false;
+
+  if (didUpdate && creature.cachedWasmActivation) {
+    creature.cachedWasmActivation.free();
+    creature.cachedWasmActivation = undefined;
+  }
+}
+
+/**
+ * Apply learned weight/bias changes from backpropagation.
+ */
+export function applyLearnings(
+  creature: Creature,
+  config: BackPropagationConfig,
+  sparseConfig: SparseConfig,
+): boolean {
+  propagateUpdate(creature, config, sparseConfig);
+
+  let changed = false;
+  for (
+    let indx = creature.neurons.length - 1;
+    indx >= creature.input;
+    indx--
+  ) {
+    if (config.trainingMutationRate > getRandomNumberGenerator().random()) {
+      const n = creature.neurons[indx];
+      if (sparseConfig.updateNeeded(n.uuid)) {
+        changed ||= n.applyLearnings();
+      }
+    }
+  }
+
+  if (changed) {
+    delete creature.uuid;
+    delete creature.memetic;
+    creature.state.preparedNeurons = false;
+    creature.fix();
+  }
+
+  return changed;
+}
+
+/**
+ * Trace and propagate on a dataset directory.
+ * Returns score and error.
+ */
+export function traceDir(
+  creature: Creature,
+  dataDir: string,
+  options: NeatOptions,
+): { score: number; error: number } {
+  const dataResult = dataFiles(dataDir);
+  assert(dataResult.files.length > 0, "No data files found");
+  const config = createNeatConfig(options);
+  const cost = Costs.find(config.costName);
+  let error = 0;
+  let count = 0;
+  const backPropConfig = createBackPropagationConfig(config);
+  const creatureJSON = creature.exportJSON();
+  const outgoingSynapsesMap = buildOutgoingSynapsesMap(creatureJSON);
+  const sparseConfig = new SparseConfig(
+    creatureJSON,
+    backPropConfig,
+    outgoingSynapsesMap,
+  );
+
+  const valuesCount = creature.input + creature.output;
+  const BYTES_PER_RECORD = valuesCount * 4;
+  const NVME_OPTIMAL_READ_SIZE = 512 * 1024;
+  const BATCH_SIZE = Math.max(
+    1,
+    Math.floor(NVME_OPTIMAL_READ_SIZE / BYTES_PER_RECORD),
+  );
+  const BYTES_PER_BATCH = BYTES_PER_RECORD * BATCH_SIZE;
+
+  const batchBuffer = new Uint8Array(BYTES_PER_BATCH);
+  const batchArray = new Float32Array(batchBuffer.buffer);
+
+  const bufferPool = new BufferPool({ maxBuffersPerSize: 4 });
+  const observationsBuffer = bufferPool.acquire(creature.input);
+  const targetsBuffer = bufferPool.acquire(creature.output);
+
+  for (let fileIndx = dataResult.files.length; fileIndx--;) {
+    const filePath = dataResult.files[fileIndx];
+    const file = Deno.openSync(filePath, { read: true });
+
+    try {
+      while (true) {
+        const bytesRead = file.readSync(batchBuffer);
+        if (bytesRead === null) break;
+        assert(bytesRead > 0, "Invalid number of bytes read");
+
+        const recordsRead = Math.floor(bytesRead / BYTES_PER_RECORD);
+        assert(
+          bytesRead % BYTES_PER_RECORD === 0,
+          "Invalid number of bytes read",
+        );
+
+        for (let recordIndex = 0; recordIndex < recordsRead; recordIndex++) {
+          const offset = recordIndex * valuesCount;
+          const inputEnd = offset + creature.input;
+
+          observationsBuffer.set(batchArray.subarray(offset, inputEnd));
+          targetsBuffer.set(
+            batchArray.subarray(inputEnd, offset + valuesCount),
+          );
+
+          const actuals = creature.activateAndTrace(
+            observationsBuffer,
+            true,
+            sparseConfig,
+          );
+
+          propagate(creature, targetsBuffer, backPropConfig, sparseConfig);
+
+          error += cost.calculate(targetsBuffer, actuals);
+          count++;
+        }
+      }
+    } finally {
+      file.close();
+    }
+  }
+
+  let averageError = 0;
+  if (count > 0) {
+    averageError = error / count;
+  }
+  creature.score = calculateScore(
+    creature,
+    averageError,
+    config.costOfGrowth,
+  );
+
+  return { error: averageError, score: creature.score };
+}
+
+/** Write creatures to a directory for checkpointing. */
+function writeCreatures(neat: Neat, dir: string): void {
+  let counter = 1;
+  emptyDirSync(dir);
+  neat.population.forEach((c) => {
+    const json = c.exportJSON();
+    const txt = JSON.stringify(json, null, 1);
+    const filePath = dir + "/" + counter + ".json";
+    Deno.writeTextFileSync(filePath, txt);
+    counter++;
+  });
+}
+
+/**
+ * Evolve the creature on a dataset directory using NEAT.
+ * Supports multi-threaded workers, checkpointing, and timeout.
+ */
+export async function evolveDir(
+  creature: Creature,
+  dataSetDir: string,
+  options: NeatOptions,
+): Promise<
+  { error: number; score: number; time: number; generation: number }
+> {
+  let interrupted = false;
+  const signalListener = () => {
+    getLogger().info("SIGTERM received, saving progress...");
+    interrupted = true;
+  };
+
+  Deno.addSignalListener("SIGTERM", signalListener);
+
+  const start = Date.now();
+  const config = createNeatConfig(options);
+
+  const endTimeMS = config.timeoutMinutes
+    ? start + Math.max(1, config.timeoutMinutes) * 60000
+    : 0;
+
+  const workers: WorkerHandler[] = [];
+  const threads = config.threads;
+
+  for (let i = threads; i--;) {
+    const preferDirect = threads === 1;
+    let w = new WorkerHandler(
+      dataSetDir,
+      config.costName,
+      preferDirect,
+      config.customCost,
+    );
+    try {
+      // deno-lint-ignore no-await-in-loop
+      await w.waitUntilReady();
+    } catch (err) {
+      try {
+        w.terminate();
+      } catch {
+        // Ignore termination errors.
+      }
+      if (!preferDirect) {
+        getLogger().warn(
+          "[Creature.evolveDir] Worker init failed; falling back to direct execution for this worker slot.",
+          err,
+        );
+        w = new WorkerHandler(
+          dataSetDir,
+          config.costName,
+          true,
+          config.customCost,
+        );
+        // deno-lint-ignore no-await-in-loop
+        await w.waitUntilReady();
+      } else {
+        throw err;
+      }
+    }
+    workers.push(w);
+  }
+
+  const neat = new Neat(
+    creature.input,
+    creature.output,
+    config,
+    workers,
+  );
+
+  neat.setDataDir(dataSetDir);
+  neat.populatePopulation(creature);
+
+  let error = Infinity;
+  let bestScore = -Infinity;
+
+  // Dynamic import to avoid circular dependency at module load time.
+  const { Creature: CreatureClass } = await import("../Creature.ts");
+  let bestCreature: InstanceType<typeof CreatureClass> | undefined;
+
+  let iterationStartMS = Date.now();
+  let generation = 0;
+  const targetError = config.targetError;
+  const iterations = config.iterations;
+
+  while (true) {
+    // deno-lint-ignore no-await-in-loop
+    const result = await neat.evolve(bestCreature);
+
+    const fittest = result.fittest;
+    const fittestScore = fittest.score!;
+    assert(fittestScore >= bestScore, "Score is less than best score");
+    if (fittestScore > bestScore) {
+      const errorTmp = getTag(fittest, "error");
+      assert(errorTmp, "No error tag found");
+
+      error = Number.parseFloat(errorTmp);
+      assert(Number.isFinite(error), "Error is not finite");
+      assert(error >= 0, "Error is negative");
+      assert(
+        fittestScore - 1 <= error * -1,
+        `Score (absolute) less than error (score=${fittestScore}, error=${error})`,
+      );
+      bestScore = fittestScore;
+      bestCreature = CreatureClass.fromJSON(fittest.exportJSON());
+      bestCreature.uuid = fittest.uuid;
+      bestCreature.score = bestScore;
+    }
+
+    const now = Date.now();
+    const timedOut = endTimeMS ? now > endTimeMS : false;
+
+    generation++;
+
+    const completed = interrupted || timedOut || error <= targetError ||
+      generation >= iterations;
+
+    if (
+      config.log &&
+      (generation % config.log === 0 || completed)
+    ) {
+      let avgTxt = "";
+      if (Number.isFinite(result.averageScore)) {
+        avgTxt = `(avg: ${yellow(result.averageScore.toFixed(4))})`;
+      }
+      getLogger().info(
+        "Generation",
+        generation,
+        "score",
+        fittest.score,
+        avgTxt,
+        "error",
+        error,
+        (config.log > 1 ? "avg " : "") + "time",
+        yellow(
+          format(Math.round((now - iterationStartMS) / config.log), {
+            ignoreZero: true,
+          }),
+        ),
+      );
+
+      iterationStartMS = now;
+    }
+
+    if (completed) {
+      if (interrupted) break;
+      if (neat.finishUp(iterations, endTimeMS, start, generation)) {
+        break;
+      }
+    }
+
+    if (
+      config.checkpointEveryGeneration && config.creatureStore
+    ) {
+      writeCreatures(neat, config.creatureStore);
+    }
+  }
+
+  for (let i = workers.length; i--;) {
+    const w = workers[i];
+    w.terminate();
+  }
+  workers.length = 0;
+
+  if (bestCreature) {
+    creature.loadFrom(bestCreature, config.debug);
+  }
+
+  if (config.creatureStore) {
+    writeCreatures(neat, config.creatureStore);
+  }
+
+  Deno.removeSignalListener("SIGTERM", signalListener);
+  return {
+    error: error,
+    score: bestScore,
+    generation: generation,
+    time: Date.now() - start,
+  };
+}
+
+/**
+ * Evolve the creature on an in-memory dataset.
+ * Creates a temporary directory then calls evolveDir().
+ */
+export async function evolveDataSet(
+  creature: Creature,
+  dataSet: DataRecordInterface[],
+  options: NeatOptions,
+): Promise<{ error: number; score: number; time: number }> {
+  const config = createNeatConfig(options);
+
+  const dataSetDir = makeDataDir(dataSet, config.dataSetPartitionBreak, {
+    input: creature.input,
+    output: creature.output,
+  });
+
+  const result = await evolveDir(creature, dataSetDir, config);
+
+  // deno-lint-ignore no-sync-fn-in-async-fn -- Cleanup of temporary directory after async evolution.
+  Deno.removeSync(dataSetDir, { recursive: true });
+
+  return result;
+}
+
+/**
+ * Score the creature using a dataset directory.
+ */
+export async function scoreDir(
+  creature: Creature,
+  dataDir: string,
+  options: NeatOptions,
+): Promise<{ score: number; error: number }> {
+  const config = createNeatConfig(options);
+
+  const result = await creature.evaluateDir(
+    dataDir,
+    Costs.find(config.costName),
+    config.feedbackLoop,
+  );
+
+  creature.score = calculateScore(
+    creature,
+    result.error,
+    config.costOfGrowth,
+  );
+  return { error: result.error, score: creature.score };
+}
+
+/**
+ * Run the discovery process for this creature using a dataset directory.
+ */
+export async function discoveryDir(
+  creature: Creature,
+  dataDir: string,
+  options: NeatOptions,
+  deps?: { runner?: DiscoveryRunnerLike },
+): Promise<DiscoveryDirResult> {
+  const runner = deps?.runner ?? new DiscoveryRunner();
+  return await runner.discoverDir({
+    creature,
+    dataDir,
+    options,
+  });
+}
+
+/**
+ * Replay cached discovery successes against this creature.
+ */
+export async function discoveryReplayDir(
+  creature: Creature,
+  dataDir: string,
+  options: NeatOptions,
+  deps?: { runner?: DiscoveryReplayRunnerLike },
+): Promise<DiscoveryReplayDirResult> {
+  const runner = deps?.runner ?? new DiscoveryReplayRunner();
+  return await runner.replayDir({
+    creature,
+    dataDir,
+    options,
+  });
+}

--- a/src/creature/mod.ts
+++ b/src/creature/mod.ts
@@ -1,0 +1,67 @@
+/**
+ * Creature module - focused submodules extracted from Creature.ts.
+ *
+ * Issue #1409: Extract Creature.ts (3,069 lines) into focused modules.
+ *
+ * Each module handles a single responsibility:
+ * - CreatureActivation.ts  - Forward pass and WASM activation
+ * - CreatureTopology.ts    - Neuron/synapse management, connection queries
+ * - CreatureTraining.ts    - Training orchestration, evolution, scoring
+ * - CreatureSerialization.ts - JSON import/export, cloning
+ * - CreatureMutation.ts    - Network structure repair, random connections
+ */
+
+export {
+  activateAndTraceWasm,
+  activateWasm,
+  disposeWasm,
+  evaluateDir,
+  getUnsupportedWasmSquashFunctions,
+  isWasmEligible,
+  requireWasmOrThrow,
+} from "./CreatureActivation.ts";
+
+export {
+  binarySearchSynapse,
+  bulkLoadInwardConnections,
+  findInsertionPoint,
+  getAvailableConnections,
+  getConnectionSet,
+  getHiddenNeuronUUIDs,
+  getSynapse,
+  hasConnection,
+  inFocus,
+  INWARD_INDEX_BUILD_THRESHOLD,
+  inwardConnections,
+  isAvailableConnectionsCacheBuilt,
+  isInwardIndexBuilt,
+  outwardConnections,
+  PREBUILD_SYNAPSE_THRESHOLD,
+  prebuildInwardIndex,
+  prebuildInwardIndexIfLarge,
+  selfConnection,
+} from "./CreatureTopology.ts";
+export type { TopologyCaches } from "./CreatureTopology.ts";
+
+export {
+  applyLearnings,
+  discoveryDir,
+  discoveryReplayDir,
+  evolveDataSet,
+  evolveDir,
+  propagate,
+  propagateUpdate,
+  record,
+  scoreDir,
+  traceDir,
+} from "./CreatureTraining.ts";
+
+export {
+  exportJSON,
+  fromJSON,
+  loadFrom,
+  shallowClone,
+  traceJSON,
+} from "./CreatureSerialization.ts";
+
+export { fix, makeRandomConnection } from "./CreatureMutation.ts";

--- a/test/creature/CreatureActivation.ts
+++ b/test/creature/CreatureActivation.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for CreatureActivation module.
+ * Verifies WASM activation, eligibility checking, and disposal.
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
+import {
+  disposeWasm,
+  getUnsupportedWasmSquashFunctions,
+  isWasmEligible,
+  requireWasmOrThrow,
+} from "../../src/creature/CreatureActivation.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+Deno.test("isWasmEligible - standard creature is WASM-eligible", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  const eligible = isWasmEligible(creature);
+  assert(eligible, "Standard creature should be WASM-eligible");
+});
+
+Deno.test("isWasmEligible - via facade", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+
+  assertEquals(
+    isWasmEligible(creature),
+    creature.isWasmEligible(),
+    "Facade and module should agree on WASM eligibility",
+  );
+});
+
+Deno.test("getUnsupportedWasmSquashFunctions - returns empty for standard creature", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  const unsupported = getUnsupportedWasmSquashFunctions(creature);
+  assertEquals(
+    unsupported.length,
+    0,
+    "Standard creature should have no unsupported squash functions",
+  );
+});
+
+Deno.test("requireWasmOrThrow - does not throw for eligible creature", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+
+  // Should not throw
+  requireWasmOrThrow(creature);
+});
+
+Deno.test("disposeWasm - cleans up WASM state", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  // Activate once to populate WASM cache
+  creature.activate(new Float32Array([0.5, 0.5]));
+
+  // Dispose should clean up
+  disposeWasm(creature);
+  assertEquals(
+    creature.cachedWasmActivation,
+    undefined,
+    "WASM activation should be disposed",
+  );
+  assertEquals(
+    creature.wasmEligibilityCache,
+    undefined,
+    "WASM eligibility cache should be cleared",
+  );
+});
+
+Deno.test("activate - produces consistent output", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  const input = new Float32Array([0.3, 0.7]);
+  const out1 = creature.activate(input);
+  const out2 = creature.activate(input);
+
+  assertEquals(out1.length, 1, "Should have 1 output");
+  assertEquals(out2.length, 1, "Should have 1 output");
+  // Forward-only creature should produce same output for same input
+  if (creature.forwardOnly) {
+    assertEquals(out1[0], out2[0], "Same input should produce same output");
+  }
+});
+
+Deno.test("activate - rejects non-finite input", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+
+  assertThrows(
+    () => creature.activate(new Float32Array([NaN, 0.5])),
+    Error,
+    "finite number",
+    "Should reject NaN input",
+  );
+
+  assertThrows(
+    () => creature.activate(new Float32Array([Infinity, 0.5])),
+    Error,
+    "finite number",
+    "Should reject Infinity input",
+  );
+});

--- a/test/creature/CreatureMutation.ts
+++ b/test/creature/CreatureMutation.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for CreatureMutation module.
+ * Verifies fix() and makeRandomConnection() behaviour.
+ */
+
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
+import {
+  fix,
+  makeRandomConnection,
+} from "../../src/creature/CreatureMutation.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+Deno.test("makeRandomConnection - adds a connection to a hidden neuron", async () => {
+  await initWasmForTests();
+  const creature = new Creature(3, 1, {
+    layers: [{ count: 3 }],
+  });
+  creatureValidate(creature);
+
+  // Pick a hidden neuron
+  const hiddenIdx = creature.input;
+  const beforeCount = creature.synapses.length;
+
+  // Try to disconnect one first to make room
+  const inward = creature.inwardConnections(hiddenIdx);
+  if (inward.length > 1) {
+    creature.disconnect(inward[0].from, inward[0].to);
+    const result = makeRandomConnection(creature, hiddenIdx);
+    assert(result !== null, "Should create a random connection");
+    assertEquals(
+      creature.synapses.length,
+      beforeCount,
+      "Should have same count after disconnect+connect",
+    );
+  }
+});
+
+Deno.test("makeRandomConnection - via Creature facade", async () => {
+  await initWasmForTests();
+  const creature = new Creature(3, 1, {
+    layers: [{ count: 3 }],
+  });
+  creatureValidate(creature);
+
+  // Remove a connection to make room
+  const hiddenIdx = creature.input;
+  const inward = creature.inwardConnections(hiddenIdx);
+  if (inward.length > 1) {
+    creature.disconnect(inward[0].from, inward[0].to);
+    const result = creature.makeRandomConnection(hiddenIdx);
+    assert(result !== null, "Facade should create a random connection");
+  }
+});
+
+Deno.test("fix - removes zero-weight synapses", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  // Set a hidden neuron's inward synapse weight to zero
+  const hiddenIdx = creature.input;
+  const inward = creature.inwardConnections(hiddenIdx);
+  if (inward.length > 0) {
+    inward[0].weight = 0;
+    const beforeCount = creature.synapses.length;
+    fix(creature);
+    assert(
+      creature.synapses.length <= beforeCount,
+      "fix() should remove zero-weight synapses",
+    );
+  }
+  creatureValidate(creature);
+});
+
+Deno.test("fix - maintains sorted synapses", async () => {
+  await initWasmForTests();
+  const creature = new Creature(3, 2, {
+    layers: [{ count: 3 }],
+  });
+  creatureValidate(creature);
+
+  fix(creature);
+
+  for (let i = 1; i < creature.synapses.length; i++) {
+    const prev = creature.synapses[i - 1];
+    const curr = creature.synapses[i];
+    assert(
+      prev.from < curr.from ||
+        (prev.from === curr.from && prev.to <= curr.to),
+      `Synapses should be sorted: [${prev.from},${prev.to}] before [${curr.from},${curr.to}]`,
+    );
+  }
+});
+
+Deno.test("fix - via Creature facade", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  creature.fix();
+  creatureValidate(creature);
+});
+
+Deno.test("fix - with forwardOnly sets semanticVersion to 4.0.0", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+    semanticVersion: "3.0.0",
+  });
+
+  assertEquals(creature.semanticVersion, "3.0.0");
+  fix(creature, { forwardOnly: true });
+  assertEquals(creature.semanticVersion, "4.0.0");
+  assertEquals(creature.forwardOnly, true);
+});
+
+Deno.test("fix - clears UUID when structure changes", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  // Record original UUID
+  const json = creature.exportJSON();
+  const original = Creature.fromJSON(json);
+  const originalUUID = original.uuid;
+
+  // Add a zero-weight synapse to force structural change
+  const hiddenIdx = creature.input;
+  const inward = creature.inwardConnections(hiddenIdx);
+  if (inward.length > 0) {
+    inward[0].weight = 0;
+    fix(creature);
+    // UUID should change or be cleared if structure changed
+    if (creature.synapses.length !== original.synapses.length) {
+      assertNotEquals(
+        creature.uuid,
+        originalUUID,
+        "UUID should change when structure changes",
+      );
+    }
+  }
+});

--- a/test/creature/CreatureSerialization.ts
+++ b/test/creature/CreatureSerialization.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for CreatureSerialization module.
+ * Verifies exportJSON, traceJSON, loadFrom, fromJSON, and shallowClone
+ * produce correct results when called via the Creature facade.
+ */
+
+import { assert, assertEquals, assertNotStrictEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
+import {
+  exportJSON,
+  fromJSON,
+  loadFrom,
+  shallowClone,
+  traceJSON,
+} from "../../src/creature/CreatureSerialization.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+import { SparseConfig } from "../../src/propagate/sparse/SparseConfig.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+Deno.test("exportJSON - produces valid CreatureExport", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  const json = exportJSON(creature);
+  assertEquals(json.input, 2);
+  assertEquals(json.output, 1);
+  assert(json.neurons.length > 0, "Should have neurons");
+  assert(json.synapses.length > 0, "Should have synapses");
+
+  // Verify same result via facade
+  const facadeJson = creature.exportJSON();
+  assertEquals(
+    JSON.stringify(json),
+    JSON.stringify(facadeJson),
+    "Module function and facade should produce identical output",
+  );
+});
+
+Deno.test("traceJSON - includes trace data after activation", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+
+  const json = creature.exportJSON();
+  const bpConfig = createBackPropagationConfig({});
+  const sparseConfig = new SparseConfig(json, bpConfig);
+
+  creature.activateAndTrace(
+    new Float32Array([0.5, 0.5]),
+    false,
+    sparseConfig,
+  );
+
+  const trace = traceJSON(creature);
+  assertEquals(trace.input, 2);
+  assertEquals(trace.output, 1);
+});
+
+Deno.test("fromJSON - round-trips correctly", async () => {
+  await initWasmForTests();
+  const original = new Creature(3, 2, {
+    layers: [{ count: 3 }],
+  });
+  creatureValidate(original);
+
+  const json = original.exportJSON();
+  const restored = fromJSON(json, true, Creature);
+
+  assertEquals(restored.input, original.input);
+  assertEquals(restored.output, original.output);
+  assertEquals(restored.neurons.length, original.neurons.length);
+  assertEquals(restored.synapses.length, original.synapses.length);
+  creatureValidate(restored);
+});
+
+Deno.test("fromJSON - via Creature.fromJSON static method", async () => {
+  await initWasmForTests();
+  const original = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  const json = original.exportJSON();
+
+  const restored = Creature.fromJSON(json, true);
+  assertEquals(restored.input, 2);
+  assertEquals(restored.output, 1);
+  creatureValidate(restored);
+
+  // Activations should match
+  const input = new Float32Array([0.3, 0.7]);
+  const out1 = original.activate(input);
+  const out2 = restored.activate(input);
+  assertEquals(out1.length, out2.length);
+  for (let i = 0; i < out1.length; i++) {
+    assertEquals(out1[i], out2[i], `Output ${i} should match`);
+  }
+});
+
+Deno.test("loadFrom - replaces creature content", async () => {
+  await initWasmForTests();
+  const source = new Creature(2, 1, {
+    layers: [{ count: 3 }],
+  });
+  const target = new Creature(2, 1, { lazyInitialization: true });
+
+  const json = source.exportJSON();
+  loadFrom(target, json, true);
+
+  assertEquals(target.neurons.length, source.neurons.length);
+  assertEquals(target.synapses.length, source.synapses.length);
+  creatureValidate(target);
+});
+
+Deno.test("shallowClone - creates independent copy", async () => {
+  await initWasmForTests();
+  const original = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  original.score = 0.5;
+
+  const clone = shallowClone(original, Creature);
+
+  assertNotStrictEquals(clone, original, "Clone should be a different object");
+  assertEquals(clone.input, original.input);
+  assertEquals(clone.output, original.output);
+  assertEquals(clone.neurons.length, original.neurons.length);
+  assertEquals(clone.synapses.length, original.synapses.length);
+  assertEquals(clone.score, original.score);
+  creatureValidate(clone);
+
+  // Verify independence - modifying clone doesn't affect original
+  clone.score = 0.9;
+  assertEquals(original.score, 0.5, "Original score should be unchanged");
+});
+
+Deno.test("shallowClone - via Creature facade method", async () => {
+  await initWasmForTests();
+  const original = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+
+  const clone = original.shallowClone();
+
+  assertNotStrictEquals(clone, original);
+  assertEquals(clone.input, original.input);
+  assertEquals(clone.output, original.output);
+  assertEquals(clone.neurons.length, original.neurons.length);
+
+  // Activations should match
+  const input = new Float32Array([0.4, 0.6]);
+  const out1 = original.activate(input);
+  const out2 = clone.activate(input);
+  for (let i = 0; i < out1.length; i++) {
+    assertEquals(out1[i], out2[i]);
+  }
+});

--- a/test/creature/CreatureTopology.ts
+++ b/test/creature/CreatureTopology.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for CreatureTopology module.
+ * Verifies connection queries, binary search, caching, and focus logic.
+ */
+
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
+import {
+  binarySearchSynapse,
+  findInsertionPoint,
+  getConnectionSet,
+  getHiddenNeuronUUIDs,
+  getSynapse,
+  hasConnection,
+  inwardConnections,
+  outwardConnections,
+  prebuildInwardIndex,
+  selfConnection,
+  type TopologyCaches,
+} from "../../src/creature/CreatureTopology.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+function makeCaches(): TopologyCaches {
+  return {
+    cacheTo: new Map(),
+    cacheFrom: new Map(),
+    cacheSelf: new Map(),
+    synapsesIndexedByTo: null,
+    connectionSet: null,
+    availableConnectionsCache: null,
+    hiddenNeuronUUIDs: null,
+    inwardCacheMissCount: 0,
+  };
+}
+
+Deno.test("inwardConnections - finds correct inbound synapses", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  // Output neuron should have inward connections
+  const outputIdx = creature.neurons.length - 1;
+  const caches = makeCaches();
+  const inward = inwardConnections(creature, caches, outputIdx);
+  assert(inward.length > 0, "Output neuron should have inward connections");
+  for (const syn of inward) {
+    assertEquals(
+      syn.to,
+      outputIdx,
+      "All inward synapses should point to the target",
+    );
+  }
+});
+
+Deno.test("outwardConnections - finds correct outbound synapses", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  // Input neurons should have outward connections
+  const caches = makeCaches();
+  const outward = outwardConnections(creature, caches, 0);
+  assert(outward.length > 0, "Input neuron should have outward connections");
+  for (const syn of outward) {
+    assertEquals(
+      syn.from,
+      0,
+      "All outward synapses should come from the source",
+    );
+  }
+});
+
+Deno.test("getSynapse - returns synapse when found, null otherwise", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1);
+  creatureValidate(creature);
+
+  // Should find connections from input to output
+  const caches = makeCaches();
+  const found = getSynapse(creature, caches, 0, creature.input);
+  assert(found !== null, "Should find connection from input 0 to output");
+  assertEquals(found!.from, 0);
+  assertEquals(found!.to, creature.input);
+
+  // Should return null for non-existent connection
+  const notFound = getSynapse(creature, caches, creature.input, 0);
+  assertEquals(notFound, null, "Reverse connection should not exist");
+});
+
+Deno.test("binarySearchSynapse - finds correct index", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1);
+  creatureValidate(creature);
+
+  const syn = creature.synapses[0];
+  const idx = binarySearchSynapse(creature, syn.from, syn.to);
+  assertNotEquals(idx, -1, "Should find first synapse");
+  assertEquals(creature.synapses[idx].from, syn.from);
+  assertEquals(creature.synapses[idx].to, syn.to);
+
+  // Non-existent connection
+  const missing = binarySearchSynapse(creature, 999, 999);
+  assertEquals(missing, -1, "Should return -1 for non-existent");
+});
+
+Deno.test("findInsertionPoint - returns correct position", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1);
+  creatureValidate(creature);
+
+  // Insertion point at beginning
+  const pos = findInsertionPoint(creature, 0, 0);
+  assert(pos >= 0, "Should return a valid position");
+});
+
+Deno.test("selfConnection - detects self-connections", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1);
+  creatureValidate(creature);
+
+  const caches = makeCaches();
+  // Simple creature should not have self-connections
+  for (let i = 0; i < creature.neurons.length; i++) {
+    const sc = selfConnection(creature, caches, i);
+    assertEquals(sc, null, `Neuron ${i} should not have a self-connection`);
+  }
+});
+
+Deno.test("hasConnection - checks connection existence", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1);
+  creatureValidate(creature);
+
+  const caches = makeCaches();
+  const syn = creature.synapses[0];
+  assert(
+    hasConnection(creature, caches, syn.from, syn.to),
+    "Should find existing connection",
+  );
+  assert(
+    !hasConnection(creature, caches, 999, 999),
+    "Should not find non-existent connection",
+  );
+});
+
+Deno.test("getConnectionSet - returns all connection keys", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1);
+  creatureValidate(creature);
+
+  const caches = makeCaches();
+  const set = getConnectionSet(creature, caches);
+  assertEquals(
+    set.size,
+    creature.synapses.length,
+    "Set size should match synapse count",
+  );
+});
+
+Deno.test("getHiddenNeuronUUIDs - returns hidden neuron UUIDs", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 3 }],
+  });
+  creatureValidate(creature);
+
+  const caches = makeCaches();
+  const uuids = getHiddenNeuronUUIDs(creature, caches);
+  assertEquals(uuids.size, 3, "Should have 3 hidden neuron UUIDs");
+});
+
+Deno.test("prebuildInwardIndex - builds secondary index", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  const caches = makeCaches();
+  assertEquals(
+    caches.synapsesIndexedByTo,
+    null,
+    "Index should not exist initially",
+  );
+
+  prebuildInwardIndex(creature, caches);
+  assertNotEquals(
+    caches.synapsesIndexedByTo,
+    null,
+    "Index should be built after prebuild",
+  );
+});
+
+Deno.test("facade delegation matches direct module calls", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2 }],
+  });
+  creatureValidate(creature);
+
+  // Verify facade calls match module calls
+  const outputIdx = creature.neurons.length - 1;
+  const facadeInward = creature.inwardConnections(outputIdx);
+  const facadeOutward = creature.outwardConnections(0);
+
+  assert(facadeInward.length > 0, "Facade inwardConnections should work");
+  assert(facadeOutward.length > 0, "Facade outwardConnections should work");
+
+  // getSynapse via facade
+  const syn = creature.synapses[0];
+  const found = creature.getSynapse(syn.from, syn.to);
+  assert(found !== null);
+  assertEquals(found!.from, syn.from);
+  assertEquals(found!.to, syn.to);
+
+  // hasConnection via facade
+  assert(creature.hasConnection(syn.from, syn.to));
+});


### PR DESCRIPTION
## Summary
- Extracted 5 focused modules from the monolithic `Creature.ts` (3,069 lines) into `src/creature/`
- `Creature.ts` is now a 719-line facade that delegates to specialised modules
- Public API is unchanged — all existing imports and method calls work identically

| Module | Lines | Responsibility |
|--------|-------|----------------|
| `CreatureActivation.ts` | 452 | Forward pass, WASM activation, evaluation |
| `CreatureTopology.ts` | 575 | Connection queries, binary search, caching, focus |
| `CreatureTraining.ts` | 555 | Training orchestration, evolution, scoring |
| `CreatureSerialization.ts` | 334 | JSON import/export, cloning |
| `CreatureMutation.ts` | 225 | Network structure repair, random connections |

## Test plan
- [x] Added 32 new tests across 4 test files verifying extracted module structure
- [x] All 3,056 existing tests pass unchanged
- [x] `./quality.sh` passes (fmt, lint, type-check, tests)

Closes #1409

🤖 Generated with [Claude Code](https://claude.com/claude-code)