### PR TITLE
Fix: Make evolve SIN function tests less flaky (#1455)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.311.14",
+  "version": "0.311.15",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -216,6 +216,7 @@
     "invertibility",
     "favor",
     "topo",
-    "checkpointing"
+    "checkpointing",
+    "stochasticity"
   ]
 }

--- a/docs/pr-summary-1455.md
+++ b/docs/pr-summary-1455.md
@@ -1,0 +1,26 @@
+## Summary
+
+Make `evolve_SIN_function` and `evolve SIN + COS` tests less flaky by using
+deterministic seeded random data and allowing multiple retry attempts. Closes #1455.
+
+The tests were flaky because:
+1. **Non-deterministic training data** - `Math.random()` produced different
+   training sets each run, causing inconsistent convergence behaviour.
+2. **No retry attempts** - evolution has inherent stochasticity beyond the
+   training data; a single attempt is insufficient for reliable results.
+
+The fix follows the pattern already established by the `evolve_Bigger_than` test,
+which uses `seededRandom()` and 3 attempts.
+
+## Evidence
+
+This is a test-only change with no UI or performance impact. All 3123 tests pass
+after the change, including the previously flaky tests.
+
+## Test Plan
+
+- Modified `evolve_SIN_function` in `test/Creature.ts` to use `seededRandom(99)`
+  and 3 retry attempts
+- Modified `evolve SIN + COS` in `test/Creature.ts` to use `seededRandom(77)`
+  and 3 retry attempts
+- Full quality gate (`./quality.sh`) passes with 3123 tests, 0 failures

--- a/docs/pr-summary-1455.md
+++ b/docs/pr-summary-1455.md
@@ -1,16 +1,18 @@
 ## Summary
 
 Make `evolve_SIN_function` and `evolve SIN + COS` tests less flaky by using
-deterministic seeded random data and allowing multiple retry attempts. Closes #1455.
+deterministic seeded random data and allowing multiple retry attempts. Closes
+#1455.
 
 The tests were flaky because:
+
 1. **Non-deterministic training data** - `Math.random()` produced different
    training sets each run, causing inconsistent convergence behaviour.
 2. **No retry attempts** - evolution has inherent stochasticity beyond the
    training data; a single attempt is insufficient for reliable results.
 
-The fix follows the pattern already established by the `evolve_Bigger_than` test,
-which uses `seededRandom()` and 3 attempts.
+The fix follows the pattern already established by the `evolve_Bigger_than`
+test, which uses `seededRandom()` and 3 attempts.
 
 ## Evidence
 

--- a/test/Creature.ts
+++ b/test/Creature.ts
@@ -625,16 +625,17 @@ Deno.test("train_SIN_function", () => {
 
 Deno.test("evolve_SIN_function", async () => {
   const set = [];
+  const rand = seededRandom(99);
 
   while (set.length < 100) {
-    const inputValue = Math.random() * Math.PI * 2;
+    const inputValue = rand() * Math.PI * 2;
     set.push({
       input: new Float32Array([inputValue / (Math.PI * 2)]),
       output: new Float32Array([(Math.sin(inputValue) + 1) / 2]),
     });
   }
 
-  await evolveSet(set, 10000, 0.065);
+  await evolveSet(set, 10000, 0.065, 3);
 });
 
 Deno.test("train_Bigger_than", () => {
@@ -736,9 +737,10 @@ Deno.test("train SIN + COS", () => {
 
 Deno.test("evolve SIN + COS", async () => {
   const set = [];
+  const rand = seededRandom(77);
 
   while (set.length < 100) {
-    const inputValue = Math.random() * Math.PI * 2;
+    const inputValue = rand() * Math.PI * 2;
     set.push({
       input: new Float32Array([inputValue / (Math.PI * 2)]),
       output: new Float32Array([
@@ -748,7 +750,7 @@ Deno.test("evolve SIN + COS", async () => {
     });
   }
 
-  await evolveSet(set, 100_000, 0.09);
+  await evolveSet(set, 100_000, 0.09, 3);
 });
 
 Deno.test("train_SHIFT", () => {


### PR DESCRIPTION
## Summary

Make `evolve_SIN_function` and `evolve SIN + COS` tests less flaky by using
deterministic seeded random data and allowing multiple retry attempts. Closes #1455.

The tests were flaky because:
1. **Non-deterministic training data** - `Math.random()` produced different
   training sets each run, causing inconsistent convergence behaviour.
2. **No retry attempts** - evolution has inherent stochasticity beyond the
   training data; a single attempt is insufficient for reliable results.

The fix follows the pattern already established by the `evolve_Bigger_than` test,
which uses `seededRandom()` and 3 attempts.

## Evidence

This is a test-only change with no UI or performance impact. All 3123 tests pass
after the change, including the previously flaky tests.

## Test Plan

- Modified `evolve_SIN_function` in `test/Creature.ts` to use `seededRandom(99)`
  and 3 retry attempts
- Modified `evolve SIN + COS` in `test/Creature.ts` to use `seededRandom(77)`
  and 3 retry attempts
- Full quality gate (`./quality.sh`) passes with 3123 tests, 0 failures