### PR TITLE
Test: Add behavioural tests for backpropagation training pipeline (#1440)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.311.15",
+  "version": "0.311.16",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1440.md
+++ b/docs/pr-summary-1440.md
@@ -1,20 +1,40 @@
 ## Summary
 
-Add comprehensive behavioural tests for the backpropagation training pipeline. Closes #1440.
+Add comprehensive behavioural tests for the backpropagation training pipeline.
+Closes #1440.
 
 Seven new test files covering all modules identified in the issue:
 
-- **WeightConvergence.ts** (7 tests): Weight convergence over multiple accumulate/calculate cycles, batch boundary recalculation via `adjustedWeight`, disableWeightAdjustment flag, and generation blending dampening
-- **BiasConvergence.ts** (8 tests): Bias convergence, batch boundary behaviour via `adjustedBias`, disableBiasAdjustment flag, constant neuron handling, noChange flag, and generation blending dampening
-- **ElasticDistributionBehaviour.ts** (16 tests): Error conservation (shares sum to original error for positive, negative, and multi-link cases), proportional distribution based on activation², safe-zone factor effects, weight-based fallback, equal-split fallback, and non-finite edge cases
-- **BackPropagationConfigBehaviour.ts** (18 tests): Config defaults, learning rate bounds [0.001, 1], adjustment scale bounds, training mutation rate bounds, initial learning rate and decay clamping, strategy selection, decay monotonicity, and adaptive learning rate responses to improving/stagnant/worsening error
-- **ActivationRangeBehaviour.ts** (19 tests): Range construction and validation, boundary acceptance/rejection, NaN/Infinity rejection, limit clamping, and squash-specific range behaviour (ReLU, sigmoid, tanh patterns)
-- **ErrorHelperBehaviour.ts** (10 tests): Sign preservation, custom maxMagnitude values, non-finite handling, zero/fractional error edge cases
-- **RecordElasticityBehaviour.ts** (14 tests): Weight-squared proportional distribution, error conservation, combined safeZoneFactor × feasibilityFactor gating, per-squash feasibility (SQUARE, SELU, GELU, ELU, ReLU, IDENTITY), and constrained redistribution with range-limited squashes
+- **WeightConvergence.ts** (7 tests): Weight convergence over multiple
+  accumulate/calculate cycles, batch boundary recalculation via
+  `adjustedWeight`, disableWeightAdjustment flag, and generation blending
+  dampening
+- **BiasConvergence.ts** (8 tests): Bias convergence, batch boundary behaviour
+  via `adjustedBias`, disableBiasAdjustment flag, constant neuron handling,
+  noChange flag, and generation blending dampening
+- **ElasticDistributionBehaviour.ts** (16 tests): Error conservation (shares sum
+  to original error for positive, negative, and multi-link cases), proportional
+  distribution based on activation², safe-zone factor effects, weight-based
+  fallback, equal-split fallback, and non-finite edge cases
+- **BackPropagationConfigBehaviour.ts** (18 tests): Config defaults, learning
+  rate bounds [0.001, 1], adjustment scale bounds, training mutation rate
+  bounds, initial learning rate and decay clamping, strategy selection, decay
+  monotonicity, and adaptive learning rate responses to
+  improving/stagnant/worsening error
+- **ActivationRangeBehaviour.ts** (19 tests): Range construction and validation,
+  boundary acceptance/rejection, NaN/Infinity rejection, limit clamping, and
+  squash-specific range behaviour (ReLU, sigmoid, tanh patterns)
+- **ErrorHelperBehaviour.ts** (10 tests): Sign preservation, custom maxMagnitude
+  values, non-finite handling, zero/fractional error edge cases
+- **RecordElasticityBehaviour.ts** (14 tests): Weight-squared proportional
+  distribution, error conservation, combined safeZoneFactor × feasibilityFactor
+  gating, per-squash feasibility (SQUARE, SELU, GELU, ELU, ReLU, IDENTITY), and
+  constrained redistribution with range-limited squashes
 
 ## Evidence
 
-This is a purely test-only change with no UI components. All 3228 tests pass (0 failures) after adding the new test files.
+This is a purely test-only change with no UI components. All 3228 tests pass (0
+failures) after adding the new test files.
 
 ## Test Plan
 

--- a/docs/pr-summary-1440.md
+++ b/docs/pr-summary-1440.md
@@ -1,0 +1,29 @@
+## Summary
+
+Add comprehensive behavioural tests for the backpropagation training pipeline. Closes #1440.
+
+Seven new test files covering all modules identified in the issue:
+
+- **WeightConvergence.ts** (7 tests): Weight convergence over multiple accumulate/calculate cycles, batch boundary recalculation via `adjustedWeight`, disableWeightAdjustment flag, and generation blending dampening
+- **BiasConvergence.ts** (8 tests): Bias convergence, batch boundary behaviour via `adjustedBias`, disableBiasAdjustment flag, constant neuron handling, noChange flag, and generation blending dampening
+- **ElasticDistributionBehaviour.ts** (16 tests): Error conservation (shares sum to original error for positive, negative, and multi-link cases), proportional distribution based on activation², safe-zone factor effects, weight-based fallback, equal-split fallback, and non-finite edge cases
+- **BackPropagationConfigBehaviour.ts** (18 tests): Config defaults, learning rate bounds [0.001, 1], adjustment scale bounds, training mutation rate bounds, initial learning rate and decay clamping, strategy selection, decay monotonicity, and adaptive learning rate responses to improving/stagnant/worsening error
+- **ActivationRangeBehaviour.ts** (19 tests): Range construction and validation, boundary acceptance/rejection, NaN/Infinity rejection, limit clamping, and squash-specific range behaviour (ReLU, sigmoid, tanh patterns)
+- **ErrorHelperBehaviour.ts** (10 tests): Sign preservation, custom maxMagnitude values, non-finite handling, zero/fractional error edge cases
+- **RecordElasticityBehaviour.ts** (14 tests): Weight-squared proportional distribution, error conservation, combined safeZoneFactor × feasibilityFactor gating, per-squash feasibility (SQUARE, SELU, GELU, ELU, ReLU, IDENTITY), and constrained redistribution with range-limited squashes
+
+## Evidence
+
+This is a purely test-only change with no UI components. All 3228 tests pass (0 failures) after adding the new test files.
+
+## Test Plan
+
+- `test/propagate/WeightConvergence.ts` — 7 new tests
+- `test/propagate/BiasConvergence.ts` — 8 new tests
+- `test/propagate/ElasticDistributionBehaviour.ts` — 16 new tests
+- `test/propagate/BackPropagationConfigBehaviour.ts` — 18 new tests
+- `test/propagate/ActivationRangeBehaviour.ts` — 19 new tests
+- `test/propagate/ErrorHelperBehaviour.ts` — 10 new tests
+- `test/propagate/RecordElasticityBehaviour.ts` — 14 new tests
+
+Total: **92 new behavioural tests** across 7 files

--- a/test/propagate/ActivationRangeBehaviour.ts
+++ b/test/propagate/ActivationRangeBehaviour.ts
@@ -1,0 +1,198 @@
+/**
+ * Behavioural tests for ActivationRange.ts — verifying range tracking
+ * correctly captures min/max activations, validates boundaries, and
+ * limits values.
+ *
+ * These are "what" tests: they exercise real functions with test data
+ * and check outcomes, not implementation details.
+ *
+ * Closes #1440
+ */
+import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
+import { ActivationRange } from "../../src/propagate/ActivationRange.ts";
+
+// ---------------------------------------------------------------------------
+// Constructor - range creation
+// ---------------------------------------------------------------------------
+
+Deno.test("ActivationRange constructor - stores low and high bounds", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertAlmostEquals(range.low, -1, 1e-12);
+  assertAlmostEquals(range.high, 1, 1e-12);
+});
+
+Deno.test("ActivationRange constructor - rejects low >= high", () => {
+  assertThrows(
+    () => new ActivationRange("bad", 1, 1),
+    Error,
+    "low must be less than high",
+  );
+  assertThrows(
+    () => new ActivationRange("bad", 5, 3),
+    Error,
+    "low must be less than high",
+  );
+});
+
+Deno.test("ActivationRange constructor - supports wide ranges", () => {
+  const range = new ActivationRange("wide", -1e10, 1e10);
+  assertAlmostEquals(range.low, -1e10, 1);
+  assertAlmostEquals(range.high, 1e10, 1);
+});
+
+// ---------------------------------------------------------------------------
+// validate - activation within range passes
+// ---------------------------------------------------------------------------
+
+Deno.test("ActivationRange validate - accepts value within range", () => {
+  const range = new ActivationRange("test", -1, 1);
+  // Should not throw
+  range.validate(0);
+  range.validate(0.5);
+  range.validate(-0.5);
+  range.validate(1);
+  range.validate(-1);
+});
+
+Deno.test("ActivationRange validate - accepts boundary values", () => {
+  const range = new ActivationRange("test", 0, 10);
+  range.validate(0); // exact low boundary
+  range.validate(10); // exact high boundary
+});
+
+Deno.test("ActivationRange validate - rejects value above range", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertThrows(
+    () => range.validate(1.1),
+    Error,
+    "outside the valid range",
+  );
+});
+
+Deno.test("ActivationRange validate - rejects value below range", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertThrows(
+    () => range.validate(-1.1),
+    Error,
+    "outside the valid range",
+  );
+});
+
+Deno.test("ActivationRange validate - rejects NaN", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertThrows(
+    () => range.validate(NaN),
+    Error,
+    "outside the valid range",
+  );
+});
+
+Deno.test("ActivationRange validate - rejects Infinity", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertThrows(
+    () => range.validate(Infinity),
+    Error,
+    "outside the valid range",
+  );
+});
+
+Deno.test("ActivationRange validate - rejects -Infinity", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertThrows(
+    () => range.validate(-Infinity),
+    Error,
+    "outside the valid range",
+  );
+});
+
+Deno.test("ActivationRange validate - includes hint in error message when provided", () => {
+  const range = new ActivationRange("testSquash", -1, 1);
+  try {
+    range.validate(2.0, 0.5);
+    throw new Error("Should have thrown");
+  } catch (e) {
+    const msg = (e as Error).message;
+    assertEquals(
+      msg.includes("hint"),
+      true,
+      "Error message should include hint",
+    );
+    assertEquals(
+      msg.includes("testSquash"),
+      true,
+      "Error message should include name",
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// limit - clamps activation to range
+// ---------------------------------------------------------------------------
+
+Deno.test("ActivationRange limit - passes through values within range", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertAlmostEquals(range.limit(0.5), 0.5, 1e-12);
+  assertAlmostEquals(range.limit(-0.5), -0.5, 1e-12);
+  assertAlmostEquals(range.limit(0), 0, 1e-12);
+});
+
+Deno.test("ActivationRange limit - clamps values above range to high", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertAlmostEquals(range.limit(5.0), 1.0, 1e-12);
+  assertAlmostEquals(range.limit(100.0), 1.0, 1e-12);
+});
+
+Deno.test("ActivationRange limit - clamps values below range to low", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertAlmostEquals(range.limit(-5.0), -1.0, 1e-12);
+  assertAlmostEquals(range.limit(-100.0), -1.0, 1e-12);
+});
+
+Deno.test("ActivationRange limit - clamps positive Infinity to high", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertAlmostEquals(range.limit(Infinity), 1.0, 1e-12);
+});
+
+Deno.test("ActivationRange limit - clamps negative Infinity to low", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertAlmostEquals(range.limit(-Infinity), -1.0, 1e-12);
+});
+
+Deno.test("ActivationRange limit - throws for NaN", () => {
+  const range = new ActivationRange("test", -1, 1);
+  assertThrows(
+    () => range.limit(NaN),
+    Error,
+    "not finite",
+  );
+});
+
+Deno.test("ActivationRange limit - preserves boundary values exactly", () => {
+  const range = new ActivationRange("test", 0, 6);
+  assertAlmostEquals(range.limit(0), 0, 1e-12);
+  assertAlmostEquals(range.limit(6), 6, 1e-12);
+});
+
+// ---------------------------------------------------------------------------
+// Range used for specific squash types
+// ---------------------------------------------------------------------------
+
+Deno.test("ActivationRange - ReLU-like range [0, large] clamps negative", () => {
+  const range = new ActivationRange("ReLU", 0, 1e15);
+  assertAlmostEquals(range.limit(-0.5), 0, 1e-12);
+  assertAlmostEquals(range.limit(0.5), 0.5, 1e-12);
+});
+
+Deno.test("ActivationRange - sigmoid-like range [0, 1] clamps both sides", () => {
+  const range = new ActivationRange("LOGISTIC", 0, 1);
+  assertAlmostEquals(range.limit(-0.5), 0, 1e-12);
+  assertAlmostEquals(range.limit(1.5), 1.0, 1e-12);
+  assertAlmostEquals(range.limit(0.5), 0.5, 1e-12);
+});
+
+Deno.test("ActivationRange - tanh-like range [-1, 1] clamps both sides", () => {
+  const range = new ActivationRange("TANH", -1, 1);
+  assertAlmostEquals(range.limit(-1.5), -1, 1e-12);
+  assertAlmostEquals(range.limit(1.5), 1, 1e-12);
+  assertAlmostEquals(range.limit(0), 0, 1e-12);
+});

--- a/test/propagate/BackPropagationConfigBehaviour.ts
+++ b/test/propagate/BackPropagationConfigBehaviour.ts
@@ -1,0 +1,250 @@
+/**
+ * Behavioural tests for BackPropagation.ts — verifying configuration
+ * parsing, defaults, learning rate bound enforcement, and learning rate
+ * strategy calculations.
+ *
+ * These are "what" tests: they exercise real functions with test data
+ * and check outcomes, not implementation details.
+ *
+ * Closes #1440
+ */
+import {
+  assert,
+  assertAlmostEquals,
+  assertEquals,
+  assertGreater,
+  assertGreaterOrEqual,
+  assertLessOrEqual,
+} from "@std/assert";
+import {
+  calculateLearningRate,
+  createBackPropagationConfig,
+  type ErrorFeedback,
+  limitValue,
+} from "../../src/propagate/BackPropagation.ts";
+
+// ---------------------------------------------------------------------------
+// Config defaults and validation
+// ---------------------------------------------------------------------------
+
+Deno.test("BackPropConfig - default batchSize is 64", () => {
+  const config = createBackPropagationConfig();
+  assertEquals(config.batchSize, 64);
+});
+
+Deno.test("BackPropConfig - default sparseRatio is 1", () => {
+  const config = createBackPropagationConfig();
+  assertAlmostEquals(config.sparseRatio, 1, 1e-9);
+});
+
+Deno.test("BackPropConfig - disableBiasAdjustment defaults to false", () => {
+  const config = createBackPropagationConfig();
+  assertEquals(config.disableBiasAdjustment, false);
+});
+
+Deno.test("BackPropConfig - disableWeightAdjustment defaults to false", () => {
+  const config = createBackPropagationConfig();
+  assertEquals(config.disableWeightAdjustment, false);
+});
+
+Deno.test("BackPropConfig - can enable disableBiasAdjustment", () => {
+  const config = createBackPropagationConfig({ disableBiasAdjustment: true });
+  assertEquals(config.disableBiasAdjustment, true);
+});
+
+Deno.test("BackPropConfig - can enable disableWeightAdjustment", () => {
+  const config = createBackPropagationConfig({
+    disableWeightAdjustment: true,
+  });
+  assertEquals(config.disableWeightAdjustment, true);
+});
+
+// ---------------------------------------------------------------------------
+// Learning rate bounds
+// ---------------------------------------------------------------------------
+
+Deno.test("BackPropConfig - learningRate clamped minimum to 0.001", () => {
+  const config = createBackPropagationConfig({ learningRate: 0 });
+  assertGreaterOrEqual(config.learningRate, 0.001);
+});
+
+Deno.test("BackPropConfig - learningRate clamped maximum to 1", () => {
+  const config = createBackPropagationConfig({ learningRate: 5 });
+  assertLessOrEqual(config.learningRate, 1);
+});
+
+Deno.test("BackPropConfig - negative learningRate becomes positive", () => {
+  const config = createBackPropagationConfig({ learningRate: -0.5 });
+  assertGreater(config.learningRate, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Adjustment scale bounds
+// ---------------------------------------------------------------------------
+
+Deno.test("BackPropConfig - maximumBiasAdjustmentScale cannot be negative", () => {
+  const config = createBackPropagationConfig({
+    maximumBiasAdjustmentScale: -5,
+  });
+  assertGreaterOrEqual(config.maximumBiasAdjustmentScale, 0);
+});
+
+Deno.test("BackPropConfig - maximumWeightAdjustmentScale cannot be negative", () => {
+  const config = createBackPropagationConfig({
+    maximumWeightAdjustmentScale: -5,
+  });
+  assertGreaterOrEqual(config.maximumWeightAdjustmentScale, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Training mutation rate bounds
+// ---------------------------------------------------------------------------
+
+Deno.test("BackPropConfig - trainingMutationRate clamped to [0.01, 1]", () => {
+  const low = createBackPropagationConfig({ trainingMutationRate: 0 });
+  assertGreaterOrEqual(low.trainingMutationRate, 0.01);
+
+  const high = createBackPropagationConfig({ trainingMutationRate: 5 });
+  assertLessOrEqual(high.trainingMutationRate, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Initial learning rate and decay bounds
+// ---------------------------------------------------------------------------
+
+Deno.test("BackPropConfig - initialLearningRate clamped to [0.001, 1]", () => {
+  const low = createBackPropagationConfig({ initialLearningRate: 0 });
+  assertGreaterOrEqual(low.initialLearningRate, 0.001);
+
+  const high = createBackPropagationConfig({ initialLearningRate: 5 });
+  assertLessOrEqual(high.initialLearningRate, 1);
+});
+
+Deno.test("BackPropConfig - learningRateDecay clamped to [0.1, 1]", () => {
+  const low = createBackPropagationConfig({ learningRateDecay: 0 });
+  assertGreaterOrEqual(low.learningRateDecay, 0.1);
+
+  const high = createBackPropagationConfig({ learningRateDecay: 5 });
+  assertLessOrEqual(high.learningRateDecay, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Config is frozen
+// ---------------------------------------------------------------------------
+
+Deno.test("BackPropConfig - config is deeply frozen", () => {
+  const config = createBackPropagationConfig({ learningRate: 0.5 });
+  assert(Object.isFrozen(config), "Config must be frozen");
+});
+
+// ---------------------------------------------------------------------------
+// Learning rate strategy selection
+// ---------------------------------------------------------------------------
+
+Deno.test("BackPropConfig - explicit learningRate forces fixed strategy", () => {
+  const config = createBackPropagationConfig({ learningRate: 0.1 });
+  assertEquals(config.learningRateStrategy, "fixed");
+});
+
+Deno.test("BackPropConfig - explicit strategy override works", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "decay",
+    learningRate: 0.1,
+  });
+  assertEquals(config.learningRateStrategy, "decay");
+});
+
+// ---------------------------------------------------------------------------
+// calculateLearningRate - decay monotonically decreases
+// ---------------------------------------------------------------------------
+
+Deno.test("calculateLearningRate decay - monotonically decreasing", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "decay",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.9,
+  });
+
+  let prev = calculateLearningRate(config, 0);
+  for (let i = 1; i <= 20; i++) {
+    const current = calculateLearningRate(config, i);
+    assertGreater(
+      prev,
+      current,
+      `Rate at iteration ${i} should be less than at ${i - 1}`,
+    );
+    assertGreater(current, 0, "Rate should stay positive");
+    prev = current;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// calculateLearningRate - adaptive responds to error feedback
+// ---------------------------------------------------------------------------
+
+Deno.test("calculateLearningRate adaptive - improving error gives higher rate than worsening", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.95,
+  });
+
+  const improving: ErrorFeedback = { previousError: 1.0, currentError: 0.5 };
+  const worsening: ErrorFeedback = { previousError: 1.0, currentError: 2.0 };
+
+  const lrImprove = calculateLearningRate(config, 0, improving);
+  const lrWorsen = calculateLearningRate(config, 0, worsening);
+
+  assertGreater(
+    lrImprove,
+    lrWorsen,
+    "Improving error should yield higher learning rate than worsening",
+  );
+});
+
+Deno.test("calculateLearningRate adaptive - stagnation boost is between improve and worsen", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.95,
+  });
+
+  const improving: ErrorFeedback = { previousError: 1.0, currentError: 0.5 };
+  const stagnant: ErrorFeedback = { previousError: 1.0, currentError: 0.97 };
+  const worsening: ErrorFeedback = { previousError: 1.0, currentError: 2.0 };
+
+  const lrImprove = calculateLearningRate(config, 0, improving);
+  const lrStagnant = calculateLearningRate(config, 0, stagnant);
+  const lrWorsen = calculateLearningRate(config, 0, worsening);
+
+  // Stagnation actually gets the highest boost (1.3) to escape plateaus
+  assertGreater(
+    lrStagnant,
+    lrImprove,
+    "Stagnation boost should be highest to escape plateau",
+  );
+  assertGreater(
+    lrStagnant,
+    lrWorsen,
+    "Stagnation boost should exceed worsening rate",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// limitValue - boundary behaviour
+// ---------------------------------------------------------------------------
+
+Deno.test("limitValue - very small values pass through", () => {
+  assertAlmostEquals(limitValue(1e-15), 1e-15, 1e-20);
+  assertAlmostEquals(limitValue(-1e-15), -1e-15, 1e-20);
+});
+
+Deno.test("limitValue - exactly at boundary passes through", () => {
+  assertAlmostEquals(limitValue(1e12), 1e12, 1);
+  assertAlmostEquals(limitValue(-1e12), -1e12, 1);
+});
+
+Deno.test("limitValue - just over boundary is clamped", () => {
+  assertEquals(limitValue(1e12 + 1), 1e12);
+  assertEquals(limitValue(-1e12 - 1), -1e12);
+});

--- a/test/propagate/BiasConvergence.ts
+++ b/test/propagate/BiasConvergence.ts
@@ -1,0 +1,298 @@
+/**
+ * Behavioural tests for Bias.ts — verifying biases converge towards
+ * target values over multiple accumulate/calculate cycles, and that
+ * batch size boundaries trigger proper recalculation.
+ *
+ * These are "what" tests: they exercise real functions with test data and
+ * check outcomes, not implementation details.
+ *
+ * Closes #1440
+ */
+import { assertAlmostEquals, assertGreater, assertLess } from "@std/assert";
+import {
+  createBackPropagationConfig,
+} from "../../src/propagate/BackPropagation.ts";
+import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import {
+  accumulateBias,
+  adjustedBias,
+  calculateBias,
+} from "../../src/propagate/Bias.ts";
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function makeSimpleCreature(): Creature {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 1.0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1 },
+    ],
+    input: 1,
+    output: 1,
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  return creature;
+}
+
+// ---------------------------------------------------------------------------
+// Bias convergence over multiple cycles
+// ---------------------------------------------------------------------------
+
+Deno.test("Bias convergence - repeated accumulation moves bias towards target", () => {
+  const creature = makeSimpleCreature();
+  const neuron = creature.neurons[1]; // hidden-0, bias=1.0
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 10_000,
+    batchSize: 1,
+  });
+
+  creature.clearState();
+  const ns = neuron.creature.state.node(neuron.index);
+
+  // Accumulate samples all pointing toward bias=5
+  // targetPreActivation=5, preActivation=1 (current bias) => delta=4, targetBias=1+4=5
+  for (let i = 0; i < 50; i++) {
+    accumulateBias(ns, 5.0, 1.0, 1.0, config);
+  }
+
+  const result = calculateBias(neuron, config);
+
+  // The bias should move towards 5.0 from the original 1.0
+  assertGreater(result, 1.0, "Bias should increase towards target");
+  assertLess(result, 5.1, "Bias should not overshoot the target");
+});
+
+Deno.test("Bias convergence - negative target moves bias downward", () => {
+  const creature = makeSimpleCreature();
+  const neuron = creature.neurons[1]; // hidden-0, bias=1.0
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 10_000,
+    batchSize: 1,
+  });
+
+  creature.clearState();
+  const ns = neuron.creature.state.node(neuron.index);
+
+  // Accumulate samples pointing toward bias=-3
+  // targetPreActivation=-3, preActivation=1 => delta=-4, targetBias=1+(-4)=-3
+  for (let i = 0; i < 50; i++) {
+    accumulateBias(ns, -3.0, 1.0, 1.0, config);
+  }
+
+  const result = calculateBias(neuron, config);
+
+  assertLess(result, 1.0, "Bias should decrease towards negative target");
+});
+
+// ---------------------------------------------------------------------------
+// Batch boundary behaviour via adjustedBias
+// ---------------------------------------------------------------------------
+
+Deno.test("adjustedBias - returns original bias before batch boundary", () => {
+  const creature = makeSimpleCreature();
+  const neuron = creature.neurons[1]; // hidden-0, bias=1.0
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    batchSize: 10,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 10_000,
+  });
+
+  creature.clearState();
+  const ns = neuron.creature.state.node(neuron.index);
+
+  // Accumulate fewer samples than batchSize
+  for (let i = 0; i < 5; i++) {
+    accumulateBias(ns, 10.0, 1.0, 1.0, config);
+  }
+
+  const result = adjustedBias(neuron, config);
+  assertAlmostEquals(
+    result,
+    1.0,
+    1e-9,
+    "Should return original bias before batch boundary",
+  );
+});
+
+Deno.test("adjustedBias - recalculates at batch boundary", () => {
+  const creature = makeSimpleCreature();
+  const neuron = creature.neurons[1]; // hidden-0, bias=1.0
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    batchSize: 10,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 10_000,
+  });
+
+  creature.clearState();
+  const ns = neuron.creature.state.node(neuron.index);
+
+  // Accumulate exactly batchSize samples pointing toward bias=5
+  for (let i = 0; i < 10; i++) {
+    accumulateBias(ns, 5.0, 1.0, 1.0, config);
+  }
+
+  const result = adjustedBias(neuron, config);
+
+  // At batch boundary, should recalculate and differ from original
+  assertGreater(result, 1.0, "Batch boundary should trigger recalculation");
+});
+
+Deno.test("adjustedBias - disableBiasAdjustment returns original", () => {
+  const creature = makeSimpleCreature();
+  const neuron = creature.neurons[1]; // hidden-0, bias=1.0
+  const config = createBackPropagationConfig({
+    disableBiasAdjustment: true,
+    generations: 0,
+    learningRate: 1,
+    batchSize: 1,
+  });
+
+  creature.clearState();
+  const ns = neuron.creature.state.node(neuron.index);
+
+  accumulateBias(ns, 100.0, 1.0, 1.0, config);
+
+  const result = adjustedBias(neuron, config);
+  assertAlmostEquals(
+    result,
+    1.0,
+    1e-9,
+    "Disabled adjustment should return original bias",
+  );
+});
+
+Deno.test("adjustedBias - constant neuron always returns its bias", () => {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+    ],
+    input: 1,
+    output: 1,
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+
+  // The constant neuron (index 1) has a fixed bias
+  const constantNeuron = creature.neurons[1];
+
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    batchSize: 1,
+  });
+
+  const result = adjustedBias(constantNeuron, config);
+  assertAlmostEquals(
+    result,
+    constantNeuron.bias,
+    1e-9,
+    "Constant neuron bias should not change",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// High-generation blending dampens adjustment
+// ---------------------------------------------------------------------------
+
+Deno.test("Bias convergence - higher generations dampen adjustment", () => {
+  const creature1 = makeSimpleCreature();
+  const neuron1 = creature1.neurons[1];
+  const lowGenConfig = createBackPropagationConfig({
+    generations: 1,
+    learningRate: 1,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 10_000,
+    batchSize: 1,
+  });
+
+  creature1.clearState();
+  const ns1 = neuron1.creature.state.node(neuron1.index);
+
+  for (let i = 0; i < 10; i++) {
+    accumulateBias(ns1, 10.0, 1.0, 1.0, lowGenConfig);
+  }
+  const resultLow = calculateBias(neuron1, lowGenConfig);
+
+  const creature2 = makeSimpleCreature();
+  const neuron2 = creature2.neurons[1];
+  const highGenConfig = createBackPropagationConfig({
+    generations: 100,
+    learningRate: 1,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 10_000,
+    batchSize: 1,
+  });
+
+  creature2.clearState();
+  const ns2 = neuron2.creature.state.node(neuron2.index);
+
+  for (let i = 0; i < 10; i++) {
+    accumulateBias(ns2, 10.0, 1.0, 1.0, highGenConfig);
+  }
+  const resultHigh = calculateBias(neuron2, highGenConfig);
+
+  const changeLow = Math.abs(resultLow - 1.0);
+  const changeHigh = Math.abs(resultHigh - 1.0);
+
+  assertGreater(
+    changeLow,
+    changeHigh,
+    "Higher generations should dampen the bias adjustment",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// noChange flag prevents calculation
+// ---------------------------------------------------------------------------
+
+Deno.test("Bias convergence - noChange flag preserves original bias", () => {
+  const creature = makeSimpleCreature();
+  const neuron = creature.neurons[1]; // hidden-0, bias=1.0
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 10_000,
+    batchSize: 1,
+  });
+
+  creature.clearState();
+  const ns = neuron.creature.state.node(neuron.index);
+
+  // Accumulate some data
+  for (let i = 0; i < 10; i++) {
+    accumulateBias(ns, 10.0, 1.0, 1.0, config);
+  }
+
+  // Set noChange flag
+  ns.noChange = true;
+
+  const result = calculateBias(neuron, config);
+  assertAlmostEquals(
+    result,
+    1.0,
+    1e-9,
+    "noChange flag should preserve original bias",
+  );
+});

--- a/test/propagate/ElasticDistributionBehaviour.ts
+++ b/test/propagate/ElasticDistributionBehaviour.ts
@@ -1,0 +1,261 @@
+/**
+ * Behavioural tests for ElasticDistribution.ts — verifying error
+ * conservation, proportional distribution, safe-zone effects, and
+ * fallback behaviour.
+ *
+ * These are "what" tests: they exercise real functions with test data
+ * and check outcomes, not implementation details.
+ *
+ * Closes #1440
+ */
+import { assertAlmostEquals, assertEquals, assertGreater } from "@std/assert";
+import {
+  distributeElasticError,
+  type ElasticLink,
+} from "../../src/propagate/ElasticDistribution.ts";
+
+// ---------------------------------------------------------------------------
+// Error conservation — total distributed error sums to original
+// ---------------------------------------------------------------------------
+
+Deno.test("ElasticDistribution conservation - two links sum to original error", () => {
+  const error = 7.5;
+  const links: ElasticLink[] = [
+    { activation: 1.5, safeZoneFactor: 0.8 },
+    { activation: 2.5, safeZoneFactor: 0.6 },
+  ];
+
+  const shares = distributeElasticError(error, links);
+  const sum = shares.reduce((a, b) => a + b, 0);
+
+  assertAlmostEquals(sum, error, 1e-9, "Shares should sum to original error");
+});
+
+Deno.test("ElasticDistribution conservation - many links sum to original error", () => {
+  const error = 42.0;
+  const links: ElasticLink[] = [
+    { activation: 0.1, safeZoneFactor: 1.0 },
+    { activation: 0.5, safeZoneFactor: 0.9 },
+    { activation: 1.0, safeZoneFactor: 0.7 },
+    { activation: 2.0, safeZoneFactor: 0.5 },
+    { activation: 3.0, safeZoneFactor: 1.0 },
+  ];
+
+  const shares = distributeElasticError(error, links);
+  const sum = shares.reduce((a, b) => a + b, 0);
+
+  assertAlmostEquals(sum, error, 1e-9, "Sum must equal original error");
+});
+
+Deno.test("ElasticDistribution conservation - negative error is conserved", () => {
+  const error = -15.3;
+  const links: ElasticLink[] = [
+    { activation: 1.0, safeZoneFactor: 1.0 },
+    { activation: 2.0, safeZoneFactor: 1.0 },
+    { activation: 0.5, safeZoneFactor: 1.0 },
+  ];
+
+  const shares = distributeElasticError(error, links);
+  const sum = shares.reduce((a, b) => a + b, 0);
+
+  assertAlmostEquals(sum, error, 1e-9, "Negative error should be conserved");
+});
+
+Deno.test("ElasticDistribution conservation - single link gets all error", () => {
+  const error = 12.0;
+  const shares = distributeElasticError(error, [
+    { activation: 5.0, safeZoneFactor: 1.0 },
+  ]);
+
+  assertEquals(shares.length, 1);
+  assertAlmostEquals(shares[0], error, 1e-9, "Single link gets all error");
+});
+
+// ---------------------------------------------------------------------------
+// Proportional distribution based on activation magnitudes
+// ---------------------------------------------------------------------------
+
+Deno.test("ElasticDistribution proportional - larger activation gets more error", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 1.0, safeZoneFactor: 1.0 },
+    { activation: 3.0, safeZoneFactor: 1.0 },
+  ]);
+
+  // activation²: 1 and 9, so shares: 1 and 9
+  assertAlmostEquals(shares[0], 1.0, 1e-9);
+  assertAlmostEquals(shares[1], 9.0, 1e-9);
+});
+
+Deno.test("ElasticDistribution proportional - negative activations use magnitude", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: -1.0, safeZoneFactor: 1.0 },
+    { activation: -3.0, safeZoneFactor: 1.0 },
+  ]);
+
+  // activation²: 1 and 9 (same as positive)
+  assertAlmostEquals(shares[0], 1.0, 1e-9);
+  assertAlmostEquals(shares[1], 9.0, 1e-9);
+});
+
+Deno.test("ElasticDistribution proportional - equal activations produce equal shares", () => {
+  const error = 12;
+  const shares = distributeElasticError(error, [
+    { activation: 2.0, safeZoneFactor: 1.0 },
+    { activation: 2.0, safeZoneFactor: 1.0 },
+    { activation: 2.0, safeZoneFactor: 1.0 },
+  ]);
+
+  assertAlmostEquals(shares[0], 4.0, 1e-9);
+  assertAlmostEquals(shares[1], 4.0, 1e-9);
+  assertAlmostEquals(shares[2], 4.0, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// Safe-zone factor reduces error allocation to saturated neurons
+// ---------------------------------------------------------------------------
+
+Deno.test("ElasticDistribution safe zone - low factor reduces share", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 2.0, safeZoneFactor: 0.1 }, // near saturation
+    { activation: 2.0, safeZoneFactor: 1.0 }, // healthy
+  ]);
+
+  // Same activation, but different safe zones
+  // Scores: 4*0.1=0.4 and 4*1.0=4.0
+  // Shares: 10*0.4/4.4 ≈ 0.909 and 10*4.0/4.4 ≈ 9.091
+  assertGreater(shares[1], shares[0], "Healthy link should get more error");
+  assertAlmostEquals(
+    shares[0] + shares[1],
+    error,
+    1e-9,
+    "Sum must match error",
+  );
+});
+
+Deno.test("ElasticDistribution safe zone - factor clamped to [0, 1]", () => {
+  const error = 10;
+  // safeZoneFactor > 1 should be clamped to 1
+  const shares = distributeElasticError(error, [
+    { activation: 1.0, safeZoneFactor: 5.0 },
+    { activation: 1.0, safeZoneFactor: 1.0 },
+  ]);
+
+  // Both clamped to 1, so equal shares
+  assertAlmostEquals(shares[0], 5.0, 1e-9);
+  assertAlmostEquals(shares[1], 5.0, 1e-9);
+});
+
+Deno.test("ElasticDistribution safe zone - negative factor treated as zero", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 1.0, safeZoneFactor: -0.5 }, // clamped to 0
+    { activation: 1.0, safeZoneFactor: 1.0 },
+  ]);
+
+  // First link effectively blocked
+  assertAlmostEquals(shares[0], 0, 1e-9);
+  assertAlmostEquals(shares[1], 10, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// Fallback when all activations are near-zero
+// ---------------------------------------------------------------------------
+
+Deno.test("ElasticDistribution fallback - weight-based when activations are zero", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 0, safeZoneFactor: 1, weight: 1 },
+    { activation: 0, safeZoneFactor: 1, weight: 3 },
+  ]);
+
+  // Weight-based fallback: scores 1²=1 and 3²=9
+  assertAlmostEquals(shares[0], 1, 1e-9);
+  assertAlmostEquals(shares[1], 9, 1e-9);
+});
+
+Deno.test("ElasticDistribution fallback - equal split when no weights or activations", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 0, safeZoneFactor: 1 },
+    { activation: 0, safeZoneFactor: 1 },
+    { activation: 0, safeZoneFactor: 1 },
+    { activation: 0, safeZoneFactor: 1 },
+  ]);
+
+  // Last resort: equal split
+  assertAlmostEquals(shares[0], 2.5, 1e-9);
+  assertAlmostEquals(shares[1], 2.5, 1e-9);
+  assertAlmostEquals(shares[2], 2.5, 1e-9);
+  assertAlmostEquals(shares[3], 2.5, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+Deno.test("ElasticDistribution edge - zero error distributes zeros", () => {
+  const shares = distributeElasticError(0, [
+    { activation: 1.0, safeZoneFactor: 1.0 },
+    { activation: 2.0, safeZoneFactor: 1.0 },
+  ]);
+
+  assertAlmostEquals(shares[0], 0, 1e-12);
+  assertAlmostEquals(shares[1], 0, 1e-12);
+});
+
+Deno.test("ElasticDistribution edge - empty links returns empty array", () => {
+  const shares = distributeElasticError(10, []);
+  assertEquals(shares.length, 0);
+});
+
+Deno.test("ElasticDistribution edge - non-finite error returns zeros", () => {
+  const shares = distributeElasticError(NaN, [
+    { activation: 1.0, safeZoneFactor: 1.0 },
+  ]);
+
+  assertEquals(shares[0], 0);
+});
+
+Deno.test("ElasticDistribution edge - non-finite activation treated as zero score", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: NaN, safeZoneFactor: 1.0 },
+    { activation: 2.0, safeZoneFactor: 1.0 },
+  ]);
+
+  // NaN activation gives score 0, so all error goes to second link
+  assertAlmostEquals(shares[0], 0, 1e-9);
+  assertAlmostEquals(shares[1], error, 1e-9);
+});
+
+Deno.test("ElasticDistribution edge - non-finite safeZoneFactor treated as zero score", () => {
+  const error = 10;
+  const shares = distributeElasticError(error, [
+    { activation: 1.0, safeZoneFactor: NaN },
+    { activation: 1.0, safeZoneFactor: 1.0 },
+  ]);
+
+  // NaN safeZoneFactor gives score 0, so all error goes to second link
+  assertAlmostEquals(shares[0], 0, 1e-9);
+  assertAlmostEquals(shares[1], error, 1e-9);
+});
+
+Deno.test("ElasticDistribution conservation - weight fallback preserves total", () => {
+  const error = 13.7;
+  const shares = distributeElasticError(error, [
+    { activation: 0, safeZoneFactor: 0, weight: 2 },
+    { activation: 0, safeZoneFactor: 0, weight: 5 },
+    { activation: 0, safeZoneFactor: 0, weight: 3 },
+  ]);
+
+  const sum = shares.reduce((a, b) => a + b, 0);
+  assertAlmostEquals(
+    sum,
+    error,
+    1e-9,
+    "Weight fallback should conserve total error",
+  );
+});

--- a/test/propagate/ErrorHelperBehaviour.ts
+++ b/test/propagate/ErrorHelperBehaviour.ts
@@ -1,0 +1,103 @@
+/**
+ * Behavioural tests for ErrorHelper.ts — verifying error clamping,
+ * sign preservation, and non-finite value handling.
+ *
+ * These are "what" tests: they exercise real functions with test data
+ * and check outcomes, not implementation details.
+ *
+ * Closes #1440
+ */
+import {
+  assertAlmostEquals,
+  assertEquals,
+  assertGreater,
+  assertLess,
+} from "@std/assert";
+import { ErrorHelper } from "../../src/propagate/ErrorHelper.ts";
+
+// ---------------------------------------------------------------------------
+// Sign preservation
+// ---------------------------------------------------------------------------
+
+Deno.test("ErrorHelper - preserves positive sign when clamping", () => {
+  const result = ErrorHelper.calculateClampedError(500, 100);
+  assertGreater(result, 0, "Positive error should remain positive");
+  assertAlmostEquals(result, 100, 1e-12);
+});
+
+Deno.test("ErrorHelper - preserves negative sign when clamping", () => {
+  const result = ErrorHelper.calculateClampedError(-500, 100);
+  assertLess(result, 0, "Negative error should remain negative");
+  assertAlmostEquals(result, -100, 1e-12);
+});
+
+// ---------------------------------------------------------------------------
+// Various maxMagnitude values
+// ---------------------------------------------------------------------------
+
+Deno.test("ErrorHelper - clamps to custom small maxMagnitude", () => {
+  assertEquals(ErrorHelper.calculateClampedError(5, 1), 1);
+  assertEquals(ErrorHelper.calculateClampedError(-5, 1), -1);
+});
+
+Deno.test("ErrorHelper - clamps to custom large maxMagnitude", () => {
+  assertEquals(ErrorHelper.calculateClampedError(2000, 1000), 1000);
+  assertEquals(ErrorHelper.calculateClampedError(-2000, 1000), -1000);
+});
+
+Deno.test("ErrorHelper - passes through values below maxMagnitude", () => {
+  assertAlmostEquals(ErrorHelper.calculateClampedError(5, 10), 5, 1e-12);
+  assertAlmostEquals(ErrorHelper.calculateClampedError(-5, 10), -5, 1e-12);
+});
+
+// ---------------------------------------------------------------------------
+// Non-finite handling
+// ---------------------------------------------------------------------------
+
+Deno.test("ErrorHelper - NaN returns 0 regardless of maxMagnitude", () => {
+  assertEquals(ErrorHelper.calculateClampedError(NaN, 50), 0);
+  assertEquals(ErrorHelper.calculateClampedError(NaN, 1), 0);
+});
+
+Deno.test("ErrorHelper - positive Infinity returns 0", () => {
+  assertEquals(ErrorHelper.calculateClampedError(Infinity, 50), 0);
+});
+
+Deno.test("ErrorHelper - negative Infinity returns 0", () => {
+  assertEquals(ErrorHelper.calculateClampedError(-Infinity, 50), 0);
+});
+
+// ---------------------------------------------------------------------------
+// Zero error
+// ---------------------------------------------------------------------------
+
+Deno.test("ErrorHelper - zero error passes through", () => {
+  assertAlmostEquals(ErrorHelper.calculateClampedError(0), 0, 1e-12);
+  assertAlmostEquals(ErrorHelper.calculateClampedError(0, 50), 0, 1e-12);
+});
+
+// ---------------------------------------------------------------------------
+// Fractional errors
+// ---------------------------------------------------------------------------
+
+Deno.test("ErrorHelper - very small error passes through", () => {
+  assertAlmostEquals(
+    ErrorHelper.calculateClampedError(0.000001),
+    0.000001,
+    1e-12,
+  );
+});
+
+Deno.test("ErrorHelper - fractional maxMagnitude works correctly", () => {
+  assertAlmostEquals(ErrorHelper.calculateClampedError(0.5, 0.1), 0.1, 1e-12);
+  assertAlmostEquals(
+    ErrorHelper.calculateClampedError(-0.5, 0.1),
+    -0.1,
+    1e-12,
+  );
+  assertAlmostEquals(
+    ErrorHelper.calculateClampedError(0.05, 0.1),
+    0.05,
+    1e-12,
+  );
+});

--- a/test/propagate/RecordElasticityBehaviour.ts
+++ b/test/propagate/RecordElasticityBehaviour.ts
@@ -1,0 +1,335 @@
+/**
+ * Behavioural tests for RecordElasticity.ts — verifying elasticity
+ * recording for discovery, weight-based distribution, feasibility
+ * factors, and constrained redistribution.
+ *
+ * These are "what" tests: they exercise real functions with test data
+ * and check outcomes, not implementation details.
+ *
+ * Closes #1440
+ */
+import { assertAlmostEquals, assertGreater, assertLess } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import type { Neuron } from "../../src/architecture/Neuron.ts";
+import type { Synapse } from "../../src/architecture/Synapse.ts";
+import {
+  constrainAndRedistributeRecordShares,
+  distributeRecordError,
+  type RecordElasticLink,
+  recordTargetFeasibilityFactor,
+} from "../../src/propagate/RecordElasticity.ts";
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function makeLink(opts: {
+  weight: number;
+  fromActivation: number;
+  safeZoneFactor?: number;
+  feasibilityFactor?: number;
+  fromNeuron?: Neuron;
+}): RecordElasticLink {
+  const weight = opts.weight;
+  const fromActivation = opts.fromActivation;
+  return {
+    synapse: { from: 0, to: 1, weight } as Synapse,
+    fromNeuron: opts.fromNeuron ?? { type: "input" } as unknown as Neuron,
+    fromActivation,
+    fromValue: weight * fromActivation,
+    safeZoneFactor: opts.safeZoneFactor ?? 1,
+    feasibilityFactor: opts.feasibilityFactor ?? 1,
+  };
+}
+
+function makeCreatureWithSquash(squashName: string): {
+  creature: Creature;
+  hiddenNeuron: Neuron;
+} {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: squashName, bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1 },
+    ],
+    input: 1,
+    output: 1,
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  return { creature, hiddenNeuron: creature.neurons[1] };
+}
+
+// ---------------------------------------------------------------------------
+// distributeRecordError - weight-based proportional distribution
+// ---------------------------------------------------------------------------
+
+Deno.test("RecordElasticity distribute - uses weight² for proportions", () => {
+  const links = [
+    makeLink({ weight: 1, fromActivation: 0.5 }),
+    makeLink({ weight: 2, fromActivation: 0.5 }),
+    makeLink({ weight: 3, fromActivation: 0.5 }),
+  ];
+
+  const result = distributeRecordError(14, links);
+
+  // Weight² scores: 1, 4, 9 => total 14
+  // Shares: 14*1/14=1, 14*4/14=4, 14*9/14=9
+  assertAlmostEquals(result.shares[0], 1, 1e-9);
+  assertAlmostEquals(result.shares[1], 4, 1e-9);
+  assertAlmostEquals(result.shares[2], 9, 1e-9);
+});
+
+Deno.test("RecordElasticity distribute - shares sum to original error", () => {
+  const links = [
+    makeLink({ weight: 1.5, fromActivation: 0.3 }),
+    makeLink({ weight: 2.5, fromActivation: 0.7 }),
+    makeLink({ weight: 0.5, fromActivation: 0.1 }),
+  ];
+
+  const result = distributeRecordError(7.5, links);
+  const sum = result.shares.reduce((a, b) => a + b, 0);
+
+  assertAlmostEquals(sum, 7.5, 1e-9, "Shares should sum to original error");
+});
+
+Deno.test("RecordElasticity distribute - negative error preserved in shares", () => {
+  const links = [
+    makeLink({ weight: 1, fromActivation: 0.5 }),
+    makeLink({ weight: 1, fromActivation: 0.5 }),
+  ];
+
+  const result = distributeRecordError(-6, links);
+
+  // Equal weights => equal shares of -6
+  assertAlmostEquals(result.shares[0], -3, 1e-9);
+  assertAlmostEquals(result.shares[1], -3, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// distributeRecordError - gating via safeZoneFactor and feasibilityFactor
+// ---------------------------------------------------------------------------
+
+Deno.test("RecordElasticity distribute - both gates combine multiplicatively", () => {
+  const links = [
+    makeLink({
+      weight: 2,
+      fromActivation: 0.5,
+      safeZoneFactor: 0.5,
+      feasibilityFactor: 0.5,
+    }),
+    makeLink({
+      weight: 2,
+      fromActivation: 0.5,
+      safeZoneFactor: 1.0,
+      feasibilityFactor: 1.0,
+    }),
+  ];
+
+  const result = distributeRecordError(10, links);
+
+  // First link gate: 0.5*0.5 = 0.25, second link gate: 1.0*1.0 = 1.0
+  // Scores: weight²*gate: 4*0.25=1 and 4*1.0=4
+  // Shares: 10*1/5=2 and 10*4/5=8
+  assertAlmostEquals(result.shares[0], 2, 1e-9);
+  assertAlmostEquals(result.shares[1], 8, 1e-9);
+});
+
+Deno.test("RecordElasticity distribute - fully blocked link gets zero", () => {
+  const links = [
+    makeLink({ weight: 2, fromActivation: 0.5, safeZoneFactor: 0 }),
+    makeLink({ weight: 1, fromActivation: 0.5 }),
+  ];
+
+  const result = distributeRecordError(10, links);
+
+  assertAlmostEquals(result.shares[0], 0, 1e-6);
+  assertAlmostEquals(result.shares[1], 10, 1e-6);
+});
+
+// ---------------------------------------------------------------------------
+// recordTargetFeasibilityFactor - per-squash behaviour
+// ---------------------------------------------------------------------------
+
+Deno.test("RecordElasticity feasibility - SQUARE out-of-range returns 0.1", () => {
+  const { hiddenNeuron } = makeCreatureWithSquash("SQUARE");
+  // SQUARE range is [0, +∞), negative target is out of range
+  const factor = recordTargetFeasibilityFactor(hiddenNeuron, -1);
+  assertAlmostEquals(factor, 0.1, 1e-9);
+});
+
+Deno.test("RecordElasticity feasibility - SQUARE in-range returns 1", () => {
+  const { hiddenNeuron } = makeCreatureWithSquash("SQUARE");
+  const factor = recordTargetFeasibilityFactor(hiddenNeuron, 0.5);
+  assertAlmostEquals(factor, 1, 1e-9);
+});
+
+Deno.test("RecordElasticity feasibility - SELU negative returns 0.1", () => {
+  const { hiddenNeuron } = makeCreatureWithSquash("SELU");
+  const factor = recordTargetFeasibilityFactor(hiddenNeuron, -0.5);
+  assertAlmostEquals(factor, 0.1, 1e-9);
+});
+
+Deno.test("RecordElasticity feasibility - SELU positive returns 1", () => {
+  const { hiddenNeuron } = makeCreatureWithSquash("SELU");
+  const factor = recordTargetFeasibilityFactor(hiddenNeuron, 0.5);
+  assertAlmostEquals(factor, 1, 1e-9);
+});
+
+Deno.test("RecordElasticity feasibility - GELU negative returns 0.1", () => {
+  const { hiddenNeuron } = makeCreatureWithSquash("GELU");
+  const factor = recordTargetFeasibilityFactor(hiddenNeuron, -0.5);
+  assertAlmostEquals(factor, 0.1, 1e-9);
+});
+
+Deno.test("RecordElasticity feasibility - ELU negative returns 0.1", () => {
+  const { hiddenNeuron } = makeCreatureWithSquash("ELU");
+  const factor = recordTargetFeasibilityFactor(hiddenNeuron, -0.5);
+  assertAlmostEquals(factor, 0.1, 1e-9);
+});
+
+Deno.test("RecordElasticity feasibility - ReLU6 out of range returns 0.1", () => {
+  // ReLU6 has range [0, 6], but it's in HARD_RANGE_SQUASHES? Let's check
+  // Actually ReLU6 might not be in HARD_RANGE_SQUASHES. Test ReLU instead.
+  const { hiddenNeuron } = makeCreatureWithSquash("ReLU");
+  const factor = recordTargetFeasibilityFactor(hiddenNeuron, -1);
+  assertAlmostEquals(factor, 0.1, 1e-9);
+});
+
+Deno.test("RecordElasticity feasibility - IDENTITY always returns 1", () => {
+  const { hiddenNeuron } = makeCreatureWithSquash("IDENTITY");
+  // IDENTITY has no range constraints
+  assertAlmostEquals(recordTargetFeasibilityFactor(hiddenNeuron, 100), 1, 1e-9);
+  assertAlmostEquals(
+    recordTargetFeasibilityFactor(hiddenNeuron, -100),
+    1,
+    1e-9,
+  );
+  assertAlmostEquals(recordTargetFeasibilityFactor(hiddenNeuron, 0), 1, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// constrainAndRedistributeRecordShares - redistribution behaviour
+// ---------------------------------------------------------------------------
+
+Deno.test("RecordElasticity constrain - unconstrained shares pass through", () => {
+  const links = [
+    makeLink({ weight: 1, fromActivation: 0.5 }),
+    makeLink({ weight: 1, fromActivation: 0.5 }),
+  ];
+  const shares = [4, 6];
+  const result = constrainAndRedistributeRecordShares(10, links, shares);
+
+  assertAlmostEquals(result[0], 4, 1e-9);
+  assertAlmostEquals(result[1], 6, 1e-9);
+});
+
+Deno.test("RecordElasticity constrain - blocked links redistribute to open links", () => {
+  const links = [
+    makeLink({
+      weight: 1,
+      fromActivation: 0.5,
+      safeZoneFactor: 0,
+      feasibilityFactor: 0,
+    }),
+    makeLink({ weight: 1, fromActivation: 0.5 }),
+    makeLink({ weight: 1, fromActivation: 0.5 }),
+  ];
+  const shares = [3, 3, 4];
+  const result = constrainAndRedistributeRecordShares(10, links, shares);
+
+  // First link blocked, its 3 redistributed between links 2 and 3
+  assertAlmostEquals(result[0], 0, 1e-9);
+  const openSum = result[1] + result[2];
+  assertAlmostEquals(openSum, 10, 1e-6, "Open links should absorb all error");
+});
+
+Deno.test("RecordElasticity constrain - all blocked results in zero shares clamped", () => {
+  const links = [
+    makeLink({
+      weight: 1,
+      fromActivation: 0.5,
+      safeZoneFactor: 0,
+      feasibilityFactor: 0,
+    }),
+    makeLink({
+      weight: 1,
+      fromActivation: 0.5,
+      safeZoneFactor: 0,
+      feasibilityFactor: 0,
+    }),
+  ];
+  const shares = [5, 5];
+  const result = constrainAndRedistributeRecordShares(10, links, shares);
+
+  // All blocked - shares clamped to 0
+  assertAlmostEquals(result[0], 0, 1e-9);
+  assertAlmostEquals(result[1], 0, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// constrainAndRedistributeRecordShares - range-limited squash
+// ---------------------------------------------------------------------------
+
+Deno.test("RecordElasticity constrain - ABSOLUTE squash blocks negative targets", () => {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-abs", squash: "ABSOLUTE", bias: 0 },
+      { type: "hidden", uuid: "hidden-id", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-abs", weight: 1 },
+      { fromUUID: "input-0", toUUID: "hidden-id", weight: 1 },
+      { fromUUID: "hidden-abs", toUUID: "output-0", weight: 1 },
+      { fromUUID: "hidden-id", toUUID: "output-0", weight: 1 },
+    ],
+    input: 1,
+    output: 1,
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  creature.activate(new Float32Array([0.5]));
+
+  const absNeuron = creature.neurons[1]; // hidden-abs
+  const idNeuron = creature.neurons[2]; // hidden-id
+
+  const links: RecordElasticLink[] = [
+    {
+      synapse: creature.synapses[2], // hidden-abs -> output
+      fromNeuron: absNeuron,
+      fromActivation: 0.5,
+      fromValue: 0.5,
+      safeZoneFactor: 1,
+      feasibilityFactor: recordTargetFeasibilityFactor(absNeuron, -1),
+    },
+    {
+      synapse: creature.synapses[3], // hidden-id -> output
+      fromNeuron: idNeuron,
+      fromActivation: 0.5,
+      fromValue: 0.5,
+      safeZoneFactor: 1,
+      feasibilityFactor: 1,
+    },
+  ];
+
+  // ABSOLUTE neuron has low feasibility for negative targets
+  assertLess(
+    links[0].feasibilityFactor,
+    links[1].feasibilityFactor,
+    "ABSOLUTE should have lower feasibility for negative target",
+  );
+
+  const result = distributeRecordError(-2, links);
+
+  // IDENTITY should absorb more negative error
+  assertGreater(
+    Math.abs(result.shares[1]),
+    Math.abs(result.shares[0]),
+    "IDENTITY link should absorb more negative error than ABSOLUTE",
+  );
+});

--- a/test/propagate/WeightConvergence.ts
+++ b/test/propagate/WeightConvergence.ts
@@ -1,0 +1,240 @@
+/**
+ * Behavioural tests for Weight.ts — verifying weights converge towards
+ * target values over multiple accumulate/calculate cycles, and that
+ * batch size boundaries trigger proper recalculation.
+ *
+ * These are "what" tests: they exercise real functions with test data and
+ * check outcomes, not implementation details.
+ *
+ * Closes #1440
+ */
+import { assertAlmostEquals, assertGreater, assertLess } from "@std/assert";
+import {
+  createBackPropagationConfig,
+} from "../../src/propagate/BackPropagation.ts";
+import { SynapseState } from "../../src/propagate/SynapseState.ts";
+import {
+  accumulateWeight,
+  adjustedWeight,
+  calculateWeight,
+} from "../../src/propagate/Weight.ts";
+import type { CreatureState } from "../../src/architecture/CreatureState.ts";
+import type { Synapse } from "../../src/architecture/Synapse.ts";
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function fakeSynapse(weight: number): Synapse {
+  return { weight, from: 0, to: 1 } as Synapse;
+}
+
+// ---------------------------------------------------------------------------
+// Weight convergence over multiple cycles
+// ---------------------------------------------------------------------------
+
+Deno.test("Weight convergence - repeated accumulation moves weight towards target", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+
+  const synapse = fakeSynapse(1.0);
+  const cs = new SynapseState();
+
+  // Accumulate many samples all pointing toward weight=3
+  // (activation=1, targetValue=3 => implied weight = 3/1 = 3)
+  for (let i = 0; i < 50; i++) {
+    accumulateWeight(synapse.weight, cs, 3.0, 1.0, config);
+  }
+
+  const result = calculateWeight(cs, synapse, config);
+
+  // The calculated weight should move towards 3.0 from the original 1.0
+  assertGreater(result, 1.0, "Weight should increase towards target");
+  assertLess(result, 3.1, "Weight should not overshoot the target");
+});
+
+Deno.test("Weight convergence - negative target moves weight downward", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+
+  const synapse = fakeSynapse(1.0);
+  const cs = new SynapseState();
+
+  // Accumulate samples pointing toward weight=-2
+  // (activation=1, targetValue=-2 => implied weight = -2/1 = -2)
+  for (let i = 0; i < 50; i++) {
+    accumulateWeight(synapse.weight, cs, -2.0, 1.0, config);
+  }
+
+  const result = calculateWeight(cs, synapse, config);
+
+  // The weight should move downward from 1.0 towards -2.0
+  assertLess(result, 1.0, "Weight should decrease towards negative target");
+});
+
+Deno.test("Weight convergence - mixed activations converge to blended target", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+
+  const synapse = fakeSynapse(0.5);
+  const cs = new SynapseState();
+
+  // Mix of positive and negative activations, all aiming for weight=2
+  for (let i = 0; i < 25; i++) {
+    accumulateWeight(synapse.weight, cs, 2.0, 1.0, config); // positive
+    accumulateWeight(synapse.weight, cs, -2.0, -1.0, config); // negative
+  }
+
+  const result = calculateWeight(cs, synapse, config);
+
+  // With consistent target weight of 2, result should move toward 2
+  assertGreater(result, 0.5, "Weight should increase from starting value");
+});
+
+// ---------------------------------------------------------------------------
+// Batch boundary behaviour via adjustedWeight
+// ---------------------------------------------------------------------------
+
+Deno.test("adjustedWeight - returns original weight before batch boundary", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    batchSize: 10,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+
+  const synapse = fakeSynapse(0.5);
+
+  // Create a mock CreatureState that returns our SynapseState
+  const cs = new SynapseState();
+  const mockState = {
+    connection: (_from: number, _to: number) => cs,
+  } as unknown as CreatureState;
+
+  // Accumulate fewer samples than batchSize
+  for (let i = 0; i < 5; i++) {
+    accumulateWeight(synapse.weight, cs, 3.0, 1.0, config);
+  }
+
+  // Before reaching batch boundary, adjustedWeight should return original
+  const result = adjustedWeight(mockState, synapse, config);
+  assertAlmostEquals(
+    result,
+    0.5,
+    1e-9,
+    "Should return original weight before batch boundary",
+  );
+});
+
+Deno.test("adjustedWeight - recalculates at batch boundary", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    batchSize: 10,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+
+  const synapse = fakeSynapse(0.5);
+
+  const cs = new SynapseState();
+  const mockState = {
+    connection: (_from: number, _to: number) => cs,
+  } as unknown as CreatureState;
+
+  // Accumulate exactly batchSize samples pointing toward weight=3
+  for (let i = 0; i < 10; i++) {
+    accumulateWeight(synapse.weight, cs, 3.0, 1.0, config);
+  }
+
+  // At batch boundary (count % batchSize === 0), should recalculate
+  const result = adjustedWeight(mockState, synapse, config);
+
+  // The batch-recalculated weight should differ from the original
+  assertGreater(result, 0.5, "Batch boundary should trigger recalculation");
+});
+
+Deno.test("adjustedWeight - disableWeightAdjustment returns original", () => {
+  const config = createBackPropagationConfig({
+    disableWeightAdjustment: true,
+    generations: 0,
+    learningRate: 1,
+    batchSize: 1,
+  });
+
+  const synapse = fakeSynapse(0.5);
+
+  const cs = new SynapseState();
+  const mockState = {
+    connection: (_from: number, _to: number) => cs,
+  } as unknown as CreatureState;
+
+  accumulateWeight(synapse.weight, cs, 10.0, 1.0, config);
+
+  const result = adjustedWeight(mockState, synapse, config);
+  assertAlmostEquals(
+    result,
+    0.5,
+    1e-9,
+    "Disabled adjustment should return original weight",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// High-generation blending dampens adjustment
+// ---------------------------------------------------------------------------
+
+Deno.test("Weight convergence - higher generations dampen adjustment", () => {
+  const lowGenConfig = createBackPropagationConfig({
+    generations: 1,
+    learningRate: 1,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+
+  const highGenConfig = createBackPropagationConfig({
+    generations: 100,
+    learningRate: 1,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+
+  const synapse = fakeSynapse(1.0);
+
+  // Low generations
+  const csLow = new SynapseState();
+  for (let i = 0; i < 10; i++) {
+    accumulateWeight(synapse.weight, csLow, 5.0, 1.0, lowGenConfig);
+  }
+  const resultLow = calculateWeight(csLow, synapse, lowGenConfig);
+
+  // High generations
+  const csHigh = new SynapseState();
+  for (let i = 0; i < 10; i++) {
+    accumulateWeight(synapse.weight, csHigh, 5.0, 1.0, highGenConfig);
+  }
+  const resultHigh = calculateWeight(csHigh, synapse, highGenConfig);
+
+  // More generations means more blending with original, so less change
+  const changeLow = Math.abs(resultLow - 1.0);
+  const changeHigh = Math.abs(resultHigh - 1.0);
+
+  assertGreater(
+    changeLow,
+    changeHigh,
+    "Higher generations should dampen the weight adjustment",
+  );
+});


### PR DESCRIPTION
## Summary

Add comprehensive behavioural tests for the backpropagation training pipeline. Closes #1440.

Seven new test files covering all modules identified in the issue:

- **WeightConvergence.ts** (7 tests): Weight convergence over multiple accumulate/calculate cycles, batch boundary recalculation via `adjustedWeight`, disableWeightAdjustment flag, and generation blending dampening
- **BiasConvergence.ts** (8 tests): Bias convergence, batch boundary behaviour via `adjustedBias`, disableBiasAdjustment flag, constant neuron handling, noChange flag, and generation blending dampening
- **ElasticDistributionBehaviour.ts** (16 tests): Error conservation (shares sum to original error for positive, negative, and multi-link cases), proportional distribution based on activation², safe-zone factor effects, weight-based fallback, equal-split fallback, and non-finite edge cases
- **BackPropagationConfigBehaviour.ts** (18 tests): Config defaults, learning rate bounds [0.001, 1], adjustment scale bounds, training mutation rate bounds, initial learning rate and decay clamping, strategy selection, decay monotonicity, and adaptive learning rate responses to improving/stagnant/worsening error
- **ActivationRangeBehaviour.ts** (19 tests): Range construction and validation, boundary acceptance/rejection, NaN/Infinity rejection, limit clamping, and squash-specific range behaviour (ReLU, sigmoid, tanh patterns)
- **ErrorHelperBehaviour.ts** (10 tests): Sign preservation, custom maxMagnitude values, non-finite handling, zero/fractional error edge cases
- **RecordElasticityBehaviour.ts** (14 tests): Weight-squared proportional distribution, error conservation, combined safeZoneFactor × feasibilityFactor gating, per-squash feasibility (SQUARE, SELU, GELU, ELU, ReLU, IDENTITY), and constrained redistribution with range-limited squashes

## Evidence

This is a purely test-only change with no UI components. All 3228 tests pass (0 failures) after adding the new test files.

## Test Plan

- `test/propagate/WeightConvergence.ts` — 7 new tests
- `test/propagate/BiasConvergence.ts` — 8 new tests
- `test/propagate/ElasticDistributionBehaviour.ts` — 16 new tests
- `test/propagate/BackPropagationConfigBehaviour.ts` — 18 new tests
- `test/propagate/ActivationRangeBehaviour.ts` — 19 new tests
- `test/propagate/ErrorHelperBehaviour.ts` — 10 new tests
- `test/propagate/RecordElasticityBehaviour.ts` — 14 new tests

Total: **92 new behavioural tests** across 7 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)