### PR TITLE
Performance: Optimise max weight/bias recalculation (#1442)

### DIFF
--- a/bench/MaxWeightBiasRecalculation.ts
+++ b/bench/MaxWeightBiasRecalculation.ts
@@ -1,0 +1,393 @@
+/**
+ * Benchmark for max weight/bias recalculation performance.
+ * Issue #1442: Optimise max weight/bias recalculation in Score.ts.
+ *
+ * This benchmark measures the performance of the runner-up max (secondMax)
+ * optimisation. When the current maximum weight/bias is reduced, the
+ * secondMax enables O(1) max recovery instead of an O(n) full scan.
+ *
+ * Usage:
+ *   deno run -A bench/MaxWeightBiasRecalculation.ts
+ */
+
+import { Creature } from "../src/Creature.ts";
+import {
+  calculate,
+  updateScoreForBiasChange,
+  updateScoreForWeightChange,
+} from "../src/architecture/Score.ts";
+import { IDENTITY } from "../src/methods/activations/types/IDENTITY.ts";
+
+function createLargeCreature(): Creature {
+  const creature = new Creature(50, 5, {
+    layers: [
+      { count: 100, squash: IDENTITY.NAME },
+      { count: 50, squash: IDENTITY.NAME },
+      { count: 25, squash: IDENTITY.NAME },
+    ],
+    outputLayer: { squash: IDENTITY.NAME },
+  });
+  return creature;
+}
+
+function createVeryLargeCreature(): Creature {
+  const creature = new Creature(100, 10, {
+    layers: [
+      { count: 200, squash: IDENTITY.NAME },
+      { count: 150, squash: IDENTITY.NAME },
+      { count: 100, squash: IDENTITY.NAME },
+      { count: 50, squash: IDENTITY.NAME },
+    ],
+    outputLayer: { squash: IDENTITY.NAME },
+  });
+  return creature;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1) {
+    return `${(ms * 1000).toFixed(2)}µs`;
+  } else if (ms < 1000) {
+    return `${ms.toFixed(3)}ms`;
+  } else {
+    return `${(ms / 1000).toFixed(3)}s`;
+  }
+}
+
+interface BenchmarkResult {
+  scenario: string;
+  creature: {
+    neurons: number;
+    synapses: number;
+    hiddenNeurons: number;
+  };
+  iterations: number;
+  totalTime: number;
+  avgTime: number;
+}
+
+/**
+ * Benchmark: max weight is reduced, triggering the max recalculation path.
+ *
+ * Each iteration:
+ * 1. Sets a synapse to be the max (high value)
+ * 2. Populates the cache
+ * 3. Reduces that max synapse, triggering max recalculation
+ *
+ * The secondMax optimisation avoids a full scan on every other reduction.
+ */
+function benchmarkMaxRecalcWeight(
+  creature: Creature,
+  iterations: number,
+): BenchmarkResult {
+  const growthCost = 0.0001;
+  const error = 0.1;
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    // Reset: set synapse 0 to a high value and rebuild cache
+    creature.synapses[0].weight = 100 + i;
+    creature.invalidateScoreCache();
+    calculate(creature, error, growthCost);
+
+    // Now reduce the max weight, triggering max recalculation
+    const synapse = creature.synapses[0];
+    const oldWeight = synapse.weight;
+    const newWeight = 0.1;
+    synapse.weight = newWeight;
+    updateScoreForWeightChange(
+      creature,
+      error,
+      growthCost,
+      oldWeight,
+      newWeight,
+    );
+  }
+  const totalTime = performance.now() - start;
+
+  return {
+    scenario: "Weight max recalculation (with secondMax)",
+    creature: {
+      neurons: creature.neurons.length,
+      synapses: creature.synapses.length,
+      hiddenNeurons: creature.neurons.length - creature.input - creature.output,
+    },
+    iterations,
+    totalTime,
+    avgTime: totalTime / iterations,
+  };
+}
+
+/**
+ * Benchmark: repeated max reductions that alternate between
+ * secondMax fast path and full scan fallback.
+ *
+ * This measures the real-world scenario where multiple consecutive
+ * max reductions occur.
+ */
+function benchmarkRepeatedMaxReductions(
+  creature: Creature,
+  iterations: number,
+): BenchmarkResult {
+  const growthCost = 0.0001;
+  const error = 0.1;
+
+  // Set up a clear hierarchy of weights
+  creature.synapses[0].weight = 100;
+  creature.synapses[1].weight = 90;
+  creature.synapses[2].weight = 80;
+  creature.invalidateScoreCache();
+  calculate(creature, error, growthCost);
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    // Reduce the current max, triggering secondMax path or full scan
+    const cached = creature.cachedScoreComponents!;
+    const maxVal = cached.maxWeightBias;
+
+    // Find a synapse with the max value and reduce it
+    for (let j = 0; j < creature.synapses.length; j++) {
+      if (Math.abs(creature.synapses[j].weight) === maxVal) {
+        const oldWeight = creature.synapses[j].weight;
+        const newWeight = 0.01;
+        creature.synapses[j].weight = newWeight;
+        updateScoreForWeightChange(
+          creature,
+          error,
+          growthCost,
+          oldWeight,
+          newWeight,
+        );
+        break;
+      }
+    }
+
+    // Restore: set synapse 0 back to max for next iteration
+    const oldW = creature.synapses[0].weight;
+    const newW = 100 + i;
+    creature.synapses[0].weight = newW;
+    updateScoreForWeightChange(creature, error, growthCost, oldW, newW);
+  }
+  const totalTime = performance.now() - start;
+
+  return {
+    scenario: "Repeated max reductions (alternating fast/scan paths)",
+    creature: {
+      neurons: creature.neurons.length,
+      synapses: creature.synapses.length,
+      hiddenNeurons: creature.neurons.length - creature.input - creature.output,
+    },
+    iterations,
+    totalTime,
+    avgTime: totalTime / iterations,
+  };
+}
+
+/**
+ * Benchmark: max bias reduction.
+ */
+function benchmarkMaxRecalcBias(
+  creature: Creature,
+  iterations: number,
+): BenchmarkResult {
+  const growthCost = 0.0001;
+  const error = 0.1;
+  const targetNeuronIdx = creature.input;
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    // Reset: set bias to a high value and rebuild cache
+    creature.neurons[targetNeuronIdx].bias = 100 + i;
+    creature.invalidateScoreCache();
+    calculate(creature, error, growthCost);
+
+    // Reduce the max bias, triggering max recalculation
+    const neuron = creature.neurons[targetNeuronIdx];
+    const oldBias = neuron.bias;
+    const newBias = 0.1;
+    neuron.bias = newBias;
+    updateScoreForBiasChange(creature, error, growthCost, oldBias, newBias);
+  }
+  const totalTime = performance.now() - start;
+
+  return {
+    scenario: "Bias max recalculation (with secondMax)",
+    creature: {
+      neurons: creature.neurons.length,
+      synapses: creature.synapses.length,
+      hiddenNeurons: creature.neurons.length - creature.input - creature.output,
+    },
+    iterations,
+    totalTime,
+    avgTime: totalTime / iterations,
+  };
+}
+
+/**
+ * Benchmark a mixed scenario with some max-reducing mutations.
+ */
+function benchmarkMixedMutations(
+  creature: Creature,
+  iterations: number,
+): BenchmarkResult {
+  const growthCost = 0.0001;
+  const error = 0.1;
+
+  // Set up with a clear max
+  creature.synapses[0].weight = 100;
+  creature.invalidateScoreCache();
+  calculate(creature, error, growthCost);
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    if (i % 5 === 0) {
+      // Every 5th iteration: reduce the max (triggers secondMax path)
+      const synapse = creature.synapses[0];
+      const oldWeight = synapse.weight;
+      const newWeight = 0.1;
+      synapse.weight = newWeight;
+      updateScoreForWeightChange(
+        creature,
+        error,
+        growthCost,
+        oldWeight,
+        newWeight,
+      );
+
+      // Restore for next time
+      const oldW2 = synapse.weight;
+      synapse.weight = 100;
+      updateScoreForWeightChange(creature, error, growthCost, oldW2, 100);
+    } else {
+      // Normal mutations (fast path - no max change)
+      const idx = (i % (creature.synapses.length - 1)) + 1;
+      const synapse = creature.synapses[idx];
+      const oldWeight = synapse.weight;
+      const newWeight = oldWeight + (Math.random() - 0.5) * 0.2;
+      synapse.weight = newWeight;
+      updateScoreForWeightChange(
+        creature,
+        error,
+        growthCost,
+        oldWeight,
+        newWeight,
+      );
+    }
+  }
+  const totalTime = performance.now() - start;
+
+  return {
+    scenario: "Mixed mutations (~20% max-reducing)",
+    creature: {
+      neurons: creature.neurons.length,
+      synapses: creature.synapses.length,
+      hiddenNeurons: creature.neurons.length - creature.input - creature.output,
+    },
+    iterations,
+    totalTime,
+    avgTime: totalTime / iterations,
+  };
+}
+
+function printResult(result: BenchmarkResult): void {
+  console.log(`\n${result.scenario}:`);
+  console.log(
+    `  Creature: ${result.creature.neurons} neurons, ${result.creature.synapses} synapses`,
+  );
+  console.log(`  Iterations: ${result.iterations}`);
+  console.log(`  Total time: ${formatDuration(result.totalTime)}`);
+  console.log(`  Average per iteration: ${formatDuration(result.avgTime)}`);
+}
+
+function runBenchmark() {
+  console.log("=".repeat(70));
+  console.log("Max Weight/Bias Recalculation Benchmark (Issue #1442)");
+  console.log("=".repeat(70));
+
+  const iterations = 1000;
+  const warmupIterations = 100;
+
+  // Create test creatures
+  const largeCreature = createLargeCreature();
+  const veryLargeCreature = createVeryLargeCreature();
+
+  console.log(`\nCreature sizes:`);
+  console.log(
+    `  Large: ${largeCreature.neurons.length} neurons, ${largeCreature.synapses.length} synapses`,
+  );
+  console.log(
+    `  Very Large: ${veryLargeCreature.neurons.length} neurons, ${veryLargeCreature.synapses.length} synapses`,
+  );
+
+  // Warmup
+  console.log(`\nWarming up with ${warmupIterations} iterations...`);
+  const warmupCreature = createLargeCreature();
+  for (let i = 0; i < warmupIterations; i++) {
+    calculate(warmupCreature, Math.random() * 0.5, 0.0001);
+    warmupCreature.invalidateScoreCache();
+  }
+
+  const results: BenchmarkResult[] = [];
+
+  // Large creature benchmarks
+  console.log("\n--- Large Creature Benchmarks ---");
+  results.push(benchmarkMaxRecalcWeight(createLargeCreature(), iterations));
+  printResult(results[results.length - 1]);
+
+  results.push(
+    benchmarkRepeatedMaxReductions(createLargeCreature(), iterations),
+  );
+  printResult(results[results.length - 1]);
+
+  results.push(benchmarkMaxRecalcBias(createLargeCreature(), iterations));
+  printResult(results[results.length - 1]);
+
+  results.push(benchmarkMixedMutations(createLargeCreature(), iterations));
+  printResult(results[results.length - 1]);
+
+  // Very large creature benchmarks
+  console.log("\n--- Very Large Creature Benchmarks ---");
+  results.push(
+    benchmarkMaxRecalcWeight(createVeryLargeCreature(), iterations),
+  );
+  printResult(results[results.length - 1]);
+
+  results.push(
+    benchmarkRepeatedMaxReductions(createVeryLargeCreature(), iterations),
+  );
+  printResult(results[results.length - 1]);
+
+  results.push(benchmarkMaxRecalcBias(createVeryLargeCreature(), iterations));
+  printResult(results[results.length - 1]);
+
+  results.push(
+    benchmarkMixedMutations(createVeryLargeCreature(), iterations),
+  );
+  printResult(results[results.length - 1]);
+
+  // Summary
+  console.log("\n" + "=".repeat(70));
+  console.log("Summary");
+  console.log("=".repeat(70));
+
+  // JSON summary
+  const summary = {
+    benchmark: "MaxWeightBiasRecalculation",
+    issue: 1442,
+    iterations,
+    results: results.map((r) => ({
+      scenario: r.scenario,
+      neurons: r.creature.neurons,
+      synapses: r.creature.synapses,
+      totalTimeMs: r.totalTime,
+      avgTimeMs: r.avgTime,
+    })),
+  };
+
+  console.log("\nJSON Summary:");
+  console.log(JSON.stringify(summary, null, 2));
+
+  return summary;
+}
+
+// Run the benchmark
+runBenchmark();

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.311.17",
+  "version": "0.311.18",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1442.md
+++ b/docs/pr-summary-1442.md
@@ -1,0 +1,70 @@
+## Summary
+
+Optimise max weight/bias recalculation in Score.ts by maintaining a runner-up
+(second-highest) max value in the score cache. When the current maximum
+weight or bias is reduced during an incremental update, the runner-up
+enables O(1) max recovery instead of requiring an O(n) full scan of all
+synapses and neurons. Closes #1442.
+
+### Changes
+
+- **`src/Creature.ts`**: Added `secondMaxWeightBias` field to the
+  `CachedScoreComponents` interface.
+- **`src/architecture/Score.ts`**:
+  - `computeAndCacheScoreComponents()` now tracks both max and second-max
+    during the initial full scan (no additional pass needed).
+  - `updateScoreForWeightChange()` and `updateScoreForBiasChange()` use the
+    cached second-max for O(1) max recovery when the current max is reduced.
+    The second-max is marked stale (`-1`) after use and re-established on the
+    next full scan.
+  - Renamed `findNewMaxWeightBias()` / `findNewMaxWeightBiasForBias()` to
+    `scanMaxForWeightChange()` / `scanMaxForBiasChange()` and updated them to
+    return both max and second-max in a single scan pass.
+  - Added staleness tracking: second-max is invalidated when a value equal to
+    it is reduced, preventing stale values from producing incorrect results.
+
+### How it works
+
+1. **Full scan** (initial cache build or stale second-max): Tracks both the
+   highest and second-highest absolute weight/bias values.
+2. **First max reduction** after a full scan: Uses the cached second-max for
+   O(1) recovery. No scan needed.
+3. **Second max reduction** (if second-max is stale): Falls back to a single
+   scan that re-establishes both max and second-max.
+
+This means the first max reduction after any full scan is always O(1), and
+alternating max reductions produce O(1) / O(n) / O(1) / O(n) behaviour,
+effectively halving the number of full scans in the worst case.
+
+## Evidence
+
+This is a purely backend/algorithmic change with no visual output.
+
+Benchmark results from `bench/MaxWeightBiasRecalculation.ts`:
+
+| Scenario | Creature Size | Avg per iteration |
+|---|---|---|
+| Repeated max reductions | 230 neurons, 11,375 synapses | 0.51 us |
+| Mixed mutations (~20% max-reducing) | 230 neurons, 11,375 synapses | 0.46 us |
+| Repeated max reductions | 610 neurons, 70,500 synapses | 0.43 us |
+| Mixed mutations (~20% max-reducing) | 610 neurons, 70,500 synapses | 0.22 us |
+
+The "Repeated max reductions" and "Mixed mutations" scenarios show
+sub-microsecond performance because the second-max enables O(1) recovery
+without scanning all synapses. In contrast, a full scan of 70,500 synapses
+takes approximately 2.7ms.
+
+## Test Plan
+
+- Added `test/score/MaxWeightBiasRecalculation.ts` with 8 tests:
+  - Reducing max weight matches full recalculation
+  - Reducing max bias matches full recalculation
+  - Repeated max reductions match full recalculation
+  - Max cached correctly after new weight exceeds current max
+  - Max correctly tracks bias as the global max
+  - Negative weights tracked by absolute value
+  - Interleaved weight and bias mutations match full recalculation
+  - Large creature max reduction matches full recalculation
+- All existing 3,281 tests pass unchanged
+- Added `bench/MaxWeightBiasRecalculation.ts` benchmark for measuring the
+  optimisation impact

--- a/docs/pr-summary-1442.md
+++ b/docs/pr-summary-1442.md
@@ -1,27 +1,27 @@
 ## Summary
 
 Optimise max weight/bias recalculation in Score.ts by maintaining a runner-up
-(second-highest) max value in the score cache. When the current maximum
-weight or bias is reduced during an incremental update, the runner-up
-enables O(1) max recovery instead of requiring an O(n) full scan of all
-synapses and neurons. Closes #1442.
+(second-highest) max value in the score cache. When the current maximum weight
+or bias is reduced during an incremental update, the runner-up enables O(1) max
+recovery instead of requiring an O(n) full scan of all synapses and neurons.
+Closes #1442.
 
 ### Changes
 
 - **`src/Creature.ts`**: Added `secondMaxWeightBias` field to the
   `CachedScoreComponents` interface.
 - **`src/architecture/Score.ts`**:
-  - `computeAndCacheScoreComponents()` now tracks both max and second-max
-    during the initial full scan (no additional pass needed).
+  - `computeAndCacheScoreComponents()` now tracks both max and second-max during
+    the initial full scan (no additional pass needed).
   - `updateScoreForWeightChange()` and `updateScoreForBiasChange()` use the
-    cached second-max for O(1) max recovery when the current max is reduced.
-    The second-max is marked stale (`-1`) after use and re-established on the
-    next full scan.
+    cached second-max for O(1) max recovery when the current max is reduced. The
+    second-max is marked stale (`-1`) after use and re-established on the next
+    full scan.
   - Renamed `findNewMaxWeightBias()` / `findNewMaxWeightBiasForBias()` to
     `scanMaxForWeightChange()` / `scanMaxForBiasChange()` and updated them to
     return both max and second-max in a single scan pass.
-  - Added staleness tracking: second-max is invalidated when a value equal to
-    it is reduced, preventing stale values from producing incorrect results.
+  - Added staleness tracking: second-max is invalidated when a value equal to it
+    is reduced, preventing stale values from producing incorrect results.
 
 ### How it works
 
@@ -42,17 +42,17 @@ This is a purely backend/algorithmic change with no visual output.
 
 Benchmark results from `bench/MaxWeightBiasRecalculation.ts`:
 
-| Scenario | Creature Size | Avg per iteration |
-|---|---|---|
-| Repeated max reductions | 230 neurons, 11,375 synapses | 0.51 us |
-| Mixed mutations (~20% max-reducing) | 230 neurons, 11,375 synapses | 0.46 us |
-| Repeated max reductions | 610 neurons, 70,500 synapses | 0.43 us |
-| Mixed mutations (~20% max-reducing) | 610 neurons, 70,500 synapses | 0.22 us |
+| Scenario                            | Creature Size                | Avg per iteration |
+| ----------------------------------- | ---------------------------- | ----------------- |
+| Repeated max reductions             | 230 neurons, 11,375 synapses | 0.51 us           |
+| Mixed mutations (~20% max-reducing) | 230 neurons, 11,375 synapses | 0.46 us           |
+| Repeated max reductions             | 610 neurons, 70,500 synapses | 0.43 us           |
+| Mixed mutations (~20% max-reducing) | 610 neurons, 70,500 synapses | 0.22 us           |
 
 The "Repeated max reductions" and "Mixed mutations" scenarios show
-sub-microsecond performance because the second-max enables O(1) recovery
-without scanning all synapses. In contrast, a full scan of 70,500 synapses
-takes approximately 2.7ms.
+sub-microsecond performance because the second-max enables O(1) recovery without
+scanning all synapses. In contrast, a full scan of 70,500 synapses takes
+approximately 2.7ms.
 
 ## Test Plan
 

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -66,6 +66,7 @@ interface CreatureOptions {
  * Issue #1023: Performance optimisation for large creatures.
  * Issue #1011: Cache weight/bias statistics incrementally.
  * Issue #1045: Added totalWeightBias and countWeightBias for incremental updates.
+ * Issue #1442: Added secondMaxWeightBias for O(1) max recovery.
  */
 export interface CachedScoreComponents {
   /** Number of hidden neurons (neurons.length - input - output) */
@@ -86,6 +87,12 @@ export interface CachedScoreComponents {
    * Issue #1045: Required for incremental updates.
    */
   countWeightBias: number;
+  /**
+   * Second-highest absolute value among all weights and biases.
+   * Issue #1442: Enables O(1) max recovery when the current max is reduced,
+   * avoiding an O(n) full scan of all synapses and neurons.
+   */
+  secondMaxWeightBias: number;
 }
 
 /**

--- a/src/architecture/Score.ts
+++ b/src/architecture/Score.ts
@@ -134,7 +134,9 @@ function computeAndCacheScoreComponents(
 
   // Issue #1011: Calculate max/avg weight/bias in the same pass as complexity penalty
   // This avoids a separate full iteration over synapses and neurons.
+  // Issue #1442: Also track second-max for O(1) max recovery.
   let maxWeightBias = 0;
+  let secondMaxWeightBias = 0;
   let totalWeightBias = 0;
   let countWeightBias = 0;
 
@@ -147,7 +149,12 @@ function computeAndCacheScoreComponents(
       `Weight: ${synapse.weight} is not finite`,
     );
     const w = Math.abs(synapse.weight);
-    if (w > maxWeightBias) maxWeightBias = w;
+    if (w > maxWeightBias) {
+      secondMaxWeightBias = maxWeightBias;
+      maxWeightBias = w;
+    } else if (w > secondMaxWeightBias) {
+      secondMaxWeightBias = w;
+    }
     totalWeightBias += w;
     countWeightBias++;
   }
@@ -161,7 +168,12 @@ function computeAndCacheScoreComponents(
 
     assert(Number.isFinite(neuron.bias), `Bias: ${neuron.bias} is not finite`);
     const b = Math.abs(neuron.bias);
-    if (b > maxWeightBias) maxWeightBias = b;
+    if (b > maxWeightBias) {
+      secondMaxWeightBias = maxWeightBias;
+      maxWeightBias = b;
+    } else if (b > secondMaxWeightBias) {
+      secondMaxWeightBias = b;
+    }
     totalWeightBias += b;
     countWeightBias++;
   }
@@ -189,6 +201,7 @@ function computeAndCacheScoreComponents(
 
   // Cache the computed values
   // Issue #1045: Also cache total and count for incremental updates
+  // Issue #1442: Also cache secondMaxWeightBias for O(1) max recovery
   const cached: CachedScoreComponents = {
     hiddenNeuronCount,
     squashComplexityPenalty,
@@ -196,6 +209,7 @@ function computeAndCacheScoreComponents(
     avgWeightBias,
     totalWeightBias,
     countWeightBias,
+    secondMaxWeightBias,
   };
   creature.cachedScoreComponents = cached;
 
@@ -272,16 +286,42 @@ export function updateScoreForWeightChange(
   // Update the average
   const newAvg = newTotal / cached.countWeightBias;
 
-  // Update the max - this requires more care
-  // If newAbs is greater than current max, use newAbs
-  // If oldAbs was the max and newAbs is smaller, we need to recalculate
+  // Update the max and secondMax
+  // Issue #1442: Use secondMax for O(1) max recovery when possible.
+  // secondMax < 0 means it is stale and cannot be trusted.
   let newMax = cached.maxWeightBias;
+  let newSecondMax = cached.secondMaxWeightBias;
+
   if (newAbs > newMax) {
+    // New value exceeds current max
+    newSecondMax = newMax;
     newMax = newAbs;
   } else if (oldAbs === cached.maxWeightBias && newAbs < oldAbs) {
-    // The old value was the max and is now smaller, need to find new max
-    // This is the slow path, but it's rare
-    newMax = findNewMaxWeightBias(creature, oldWeight, newWeight);
+    // The old value was the max and is now smaller
+    if (newSecondMax >= 0) {
+      // Use the runner-up to avoid a full scan (O(1) instead of O(n))
+      if (newAbs >= newSecondMax) {
+        newMax = newAbs;
+      } else {
+        newMax = newSecondMax;
+      }
+      // secondMax is consumed; mark as stale
+      newSecondMax = -1;
+    } else {
+      // secondMax is stale, must scan to find new max and secondMax
+      const result = scanMaxForWeightChange(creature, oldWeight, newWeight);
+      newMax = result.max;
+      newSecondMax = result.secondMax;
+    }
+  } else {
+    // Invalidate secondMax if the old value matched it and was reduced
+    if (oldAbs === newSecondMax && newAbs < oldAbs) {
+      newSecondMax = -1;
+    }
+    // Track new runner-up values
+    if (newSecondMax >= 0 && newAbs > newSecondMax && newAbs < newMax) {
+      newSecondMax = newAbs;
+    }
   }
 
   // Update the cache with new values
@@ -290,6 +330,7 @@ export function updateScoreForWeightChange(
     maxWeightBias: newMax,
     avgWeightBias: newAvg,
     totalWeightBias: newTotal,
+    secondMaxWeightBias: newSecondMax,
   };
 
   // Calculate penalty with new values
@@ -339,16 +380,42 @@ export function updateScoreForBiasChange(
   // Update the average
   const newAvg = newTotal / cached.countWeightBias;
 
-  // Update the max - this requires more care
-  // If newAbs is greater than current max, use newAbs
-  // If oldAbs was the max and newAbs is smaller, we need to recalculate
+  // Update the max and secondMax
+  // Issue #1442: Use secondMax for O(1) max recovery when possible.
+  // secondMax < 0 means it is stale and cannot be trusted.
   let newMax = cached.maxWeightBias;
+  let newSecondMax = cached.secondMaxWeightBias;
+
   if (newAbs > newMax) {
+    // New value exceeds current max
+    newSecondMax = newMax;
     newMax = newAbs;
   } else if (oldAbs === cached.maxWeightBias && newAbs < oldAbs) {
-    // The old value was the max and is now smaller, need to find new max
-    // This is the slow path, but it's rare
-    newMax = findNewMaxWeightBiasForBias(creature, oldBias, newBias);
+    // The old value was the max and is now smaller
+    if (newSecondMax >= 0) {
+      // Use the runner-up to avoid a full scan (O(1) instead of O(n))
+      if (newAbs >= newSecondMax) {
+        newMax = newAbs;
+      } else {
+        newMax = newSecondMax;
+      }
+      // secondMax is consumed; mark as stale
+      newSecondMax = -1;
+    } else {
+      // secondMax is stale, must scan to find new max and secondMax
+      const result = scanMaxForBiasChange(creature, oldBias, newBias);
+      newMax = result.max;
+      newSecondMax = result.secondMax;
+    }
+  } else {
+    // Invalidate secondMax if the old value matched it and was reduced
+    if (oldAbs === newSecondMax && newAbs < oldAbs) {
+      newSecondMax = -1;
+    }
+    // Track new runner-up values
+    if (newSecondMax >= 0 && newAbs > newSecondMax && newAbs < newMax) {
+      newSecondMax = newAbs;
+    }
   }
 
   // Update the cache with new values
@@ -357,6 +424,7 @@ export function updateScoreForBiasChange(
     maxWeightBias: newMax,
     avgWeightBias: newAvg,
     totalWeightBias: newTotal,
+    secondMaxWeightBias: newSecondMax,
   };
 
   // Calculate penalty with new values
@@ -364,22 +432,30 @@ export function updateScoreForBiasChange(
   return calculateScore(error, creature, penalty, growthCost);
 }
 
+/** Result of scanning for new max and second-max values. */
+interface MaxScanResult {
+  max: number;
+  secondMax: number;
+}
+
 /**
- * Finds the new maximum weight/bias after a weight change when the old value
- * was the previous maximum.
+ * Scans all weights and biases to find the new max and second-max after a
+ * weight change when the old value was the previous maximum.
  * Issue #1045: Helper for incremental updates.
+ * Issue #1442: Also returns secondMax to avoid future full scans.
  *
  * @param creature - The creature
  * @param oldWeight - The previous weight (being replaced)
  * @param newWeight - The new weight
- * @returns The new maximum
+ * @returns The new max and second-max values
  */
-function findNewMaxWeightBias(
+function scanMaxForWeightChange(
   creature: Creature,
   oldWeight: number,
   newWeight: number,
-): number {
-  let newMax = Math.abs(newWeight);
+): MaxScanResult {
+  let max = Math.abs(newWeight);
+  let secondMax = 0;
 
   // Check all synapses
   const synapses = creature.synapses;
@@ -388,41 +464,58 @@ function findNewMaxWeightBias(
     // Skip the synapse with the old weight (it's being replaced)
     if (w === oldWeight) continue;
     const absW = Math.abs(w);
-    if (absW > newMax) newMax = absW;
+    if (absW > max) {
+      secondMax = max;
+      max = absW;
+    } else if (absW > secondMax) {
+      secondMax = absW;
+    }
   }
 
   // Check all non-input neuron biases
   const neurons = creature.neurons;
   for (let i = creature.input, len = neurons.length; i < len; i++) {
     const absB = Math.abs(neurons[i].bias);
-    if (absB > newMax) newMax = absB;
+    if (absB > max) {
+      secondMax = max;
+      max = absB;
+    } else if (absB > secondMax) {
+      secondMax = absB;
+    }
   }
 
-  return newMax;
+  return { max, secondMax };
 }
 
 /**
- * Finds the new maximum weight/bias after a bias change when the old value
- * was the previous maximum.
+ * Scans all weights and biases to find the new max and second-max after a
+ * bias change when the old value was the previous maximum.
  * Issue #1045: Helper for incremental updates.
+ * Issue #1442: Also returns secondMax to avoid future full scans.
  *
  * @param creature - The creature
  * @param oldBias - The previous bias (being replaced)
  * @param newBias - The new bias
- * @returns The new maximum
+ * @returns The new max and second-max values
  */
-function findNewMaxWeightBiasForBias(
+function scanMaxForBiasChange(
   creature: Creature,
   oldBias: number,
   newBias: number,
-): number {
-  let newMax = Math.abs(newBias);
+): MaxScanResult {
+  let max = Math.abs(newBias);
+  let secondMax = 0;
 
   // Check all synapses
   const synapses = creature.synapses;
   for (let i = 0, len = synapses.length; i < len; i++) {
     const absW = Math.abs(synapses[i].weight);
-    if (absW > newMax) newMax = absW;
+    if (absW > max) {
+      secondMax = max;
+      max = absW;
+    } else if (absW > secondMax) {
+      secondMax = absW;
+    }
   }
 
   // Check all non-input neuron biases
@@ -432,8 +525,13 @@ function findNewMaxWeightBiasForBias(
     // Skip the neuron with the old bias (it's being replaced)
     if (b === oldBias) continue;
     const absB = Math.abs(b);
-    if (absB > newMax) newMax = absB;
+    if (absB > max) {
+      secondMax = max;
+      max = absB;
+    } else if (absB > secondMax) {
+      secondMax = absB;
+    }
   }
 
-  return newMax;
+  return { max, secondMax };
 }

--- a/test/score/MaxWeightBiasRecalculation.ts
+++ b/test/score/MaxWeightBiasRecalculation.ts
@@ -1,0 +1,375 @@
+/**
+ * Tests for max weight/bias recalculation optimisation.
+ * Issue #1442: Optimise max weight/bias recalculation in Score.ts.
+ *
+ * These tests verify that the top-K tracking for max weight/bias values
+ * produces correct results across various scenarios, particularly when
+ * the current max is reduced and the new max must be found efficiently.
+ */
+
+import { assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import {
+  calculate,
+  updateScoreForBiasChange,
+  updateScoreForWeightChange,
+} from "../../src/architecture/Score.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+function createCreature(
+  options: {
+    hiddenCount?: number;
+    weights?: number[];
+    biases?: number[];
+  } = {},
+): Creature {
+  const hiddenCount = options.hiddenCount ?? 2;
+  const creature = new Creature(2, 1, {
+    layers: [{ count: hiddenCount, squash: IDENTITY.NAME }],
+    outputLayer: { squash: IDENTITY.NAME },
+  });
+
+  if (options.weights) {
+    for (
+      let i = 0;
+      i < options.weights.length && i < creature.synapses.length;
+      i++
+    ) {
+      creature.synapses[i].weight = options.weights[i];
+    }
+  }
+  if (options.biases) {
+    for (let i = 0; i < options.biases.length; i++) {
+      const neuronIdx = creature.input + i;
+      if (neuronIdx < creature.neurons.length) {
+        creature.neurons[neuronIdx].bias = options.biases[i];
+      }
+    }
+  }
+  delete creature.cachedScoreComponents;
+  return creature;
+}
+
+Deno.test("MaxRecalc: reducing max weight matches full recalculation", () => {
+  // Set up creature where synapse 0 has the clear max weight
+  const creature = createCreature({
+    weights: [10, 2, 3, 1, 0.5, 0.5, 0.5],
+    biases: [0.1, 0.1, 0.1],
+  });
+  const error = 0.1;
+  const growthCost = 0.001;
+
+  // Populate cache
+  calculate(creature, error, growthCost);
+
+  // Reduce the max weight (synapse 0: 10 -> 1)
+  const oldWeight = creature.synapses[0].weight;
+  const newWeight = 1.0;
+  creature.synapses[0].weight = newWeight;
+
+  const incrementalScore = updateScoreForWeightChange(
+    creature,
+    error,
+    growthCost,
+    oldWeight,
+    newWeight,
+  );
+
+  // Verify against full recalculation
+  creature.invalidateScoreCache();
+  const fullRecalcScore = calculate(creature, error, growthCost);
+
+  assertEquals(
+    incrementalScore,
+    fullRecalcScore,
+    "Reducing max weight should produce same score as full recalc",
+  );
+});
+
+Deno.test("MaxRecalc: reducing max bias matches full recalculation", () => {
+  // Set up creature where neuron 0 (first hidden) has the max bias
+  const creature = createCreature({
+    weights: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
+    biases: [15, 0.2, 0.3],
+  });
+  const error = 0.1;
+  const growthCost = 0.001;
+
+  // Populate cache
+  calculate(creature, error, growthCost);
+
+  // Reduce the max bias
+  const neuronIdx = creature.input;
+  const oldBias = creature.neurons[neuronIdx].bias;
+  const newBias = 0.1;
+  creature.neurons[neuronIdx].bias = newBias;
+
+  const incrementalScore = updateScoreForBiasChange(
+    creature,
+    error,
+    growthCost,
+    oldBias,
+    newBias,
+  );
+
+  // Verify against full recalculation
+  creature.invalidateScoreCache();
+  const fullRecalcScore = calculate(creature, error, growthCost);
+
+  assertEquals(
+    incrementalScore,
+    fullRecalcScore,
+    "Reducing max bias should produce same score as full recalc",
+  );
+});
+
+Deno.test("MaxRecalc: repeated max reductions match full recalculation", () => {
+  // Start with a clear max and reduce it repeatedly
+  const creature = createCreature({
+    weights: [20, 8, 5, 3, 1, 0.5, 0.5],
+    biases: [0.1, 0.1, 0.1],
+  });
+  const error = 0.1;
+  const growthCost = 0.001;
+
+  // Populate cache
+  calculate(creature, error, growthCost);
+
+  // Reduce synapse 0 from 20 to 7 (new max should be synapse 1 at 8)
+  let oldWeight = creature.synapses[0].weight;
+  let newWeight = 7;
+  creature.synapses[0].weight = newWeight;
+  updateScoreForWeightChange(creature, error, growthCost, oldWeight, newWeight);
+
+  // Now reduce synapse 1 from 8 to 4 (new max should be synapse 0 at 7)
+  oldWeight = creature.synapses[1].weight;
+  newWeight = 4;
+  creature.synapses[1].weight = newWeight;
+  updateScoreForWeightChange(creature, error, growthCost, oldWeight, newWeight);
+
+  // Now reduce synapse 0 from 7 to 2 (new max should be synapse 2 at 5)
+  oldWeight = creature.synapses[0].weight;
+  newWeight = 2;
+  creature.synapses[0].weight = newWeight;
+  const incrementalScore = updateScoreForWeightChange(
+    creature,
+    error,
+    growthCost,
+    oldWeight,
+    newWeight,
+  );
+
+  // Verify against full recalculation
+  creature.invalidateScoreCache();
+  const fullRecalcScore = calculate(creature, error, growthCost);
+
+  assertEquals(
+    incrementalScore,
+    fullRecalcScore,
+    "Repeated max reductions should produce same score as full recalc",
+  );
+});
+
+Deno.test("MaxRecalc: max cached correctly after new weight exceeds current max", () => {
+  const creature = createCreature({
+    weights: [5, 3, 1, 0.5, 0.5, 0.5, 0.5],
+    biases: [0.1, 0.1, 0.1],
+  });
+  const error = 0.1;
+  const growthCost = 0.001;
+
+  // Populate cache
+  calculate(creature, error, growthCost);
+  assertEquals(creature.cachedScoreComponents!.maxWeightBias, 5);
+
+  // Set a new max by increasing synapse 2
+  const oldWeight = creature.synapses[2].weight;
+  const newWeight = 50;
+  creature.synapses[2].weight = newWeight;
+  updateScoreForWeightChange(creature, error, growthCost, oldWeight, newWeight);
+
+  assertEquals(
+    creature.cachedScoreComponents!.maxWeightBias,
+    50,
+    "Max should be updated to the new larger weight",
+  );
+
+  // Now reduce it back - should find the original max (5)
+  const oldWeight2 = creature.synapses[2].weight;
+  const newWeight2 = 0.1;
+  creature.synapses[2].weight = newWeight2;
+  updateScoreForWeightChange(
+    creature,
+    error,
+    growthCost,
+    oldWeight2,
+    newWeight2,
+  );
+
+  // Verify against full recalculation
+  creature.invalidateScoreCache();
+  calculate(creature, error, growthCost);
+  assertEquals(
+    creature.cachedScoreComponents!.maxWeightBias,
+    5,
+    "Max should revert to the next highest value after reduction",
+  );
+});
+
+Deno.test("MaxRecalc: max correctly tracks bias as the global max", () => {
+  // Set up where bias is the global max, not any weight
+  const creature = createCreature({
+    weights: [1, 1, 1, 1, 1, 1, 1],
+    biases: [25, 0.1, 0.1],
+  });
+  const error = 0.1;
+  const growthCost = 0.001;
+
+  calculate(creature, error, growthCost);
+  assertEquals(creature.cachedScoreComponents!.maxWeightBias, 25);
+
+  // Reduce the bias - max should come from weights or other biases
+  const neuronIdx = creature.input;
+  const oldBias = creature.neurons[neuronIdx].bias;
+  const newBias = 0.5;
+  creature.neurons[neuronIdx].bias = newBias;
+
+  updateScoreForBiasChange(creature, error, growthCost, oldBias, newBias);
+
+  // Verify against full recalculation
+  creature.invalidateScoreCache();
+  calculate(creature, error, growthCost);
+  assertEquals(
+    creature.cachedScoreComponents!.maxWeightBias,
+    1,
+    "Max should be found from weights when bias is reduced",
+  );
+});
+
+Deno.test("MaxRecalc: negative weights tracked by absolute value", () => {
+  // The max is a negative weight (by absolute value)
+  const creature = createCreature({
+    weights: [-12, 3, 1, 0.5, 0.5, 0.5, 0.5],
+    biases: [0.1, 0.1, 0.1],
+  });
+  const error = 0.1;
+  const growthCost = 0.001;
+
+  calculate(creature, error, growthCost);
+  assertEquals(creature.cachedScoreComponents!.maxWeightBias, 12);
+
+  // Reduce the absolute max (change -12 to -2)
+  const oldWeight = creature.synapses[0].weight;
+  const newWeight = -2;
+  creature.synapses[0].weight = newWeight;
+  const incrementalScore = updateScoreForWeightChange(
+    creature,
+    error,
+    growthCost,
+    oldWeight,
+    newWeight,
+  );
+
+  // Verify against full recalculation
+  creature.invalidateScoreCache();
+  const fullRecalcScore = calculate(creature, error, growthCost);
+
+  assertEquals(
+    incrementalScore,
+    fullRecalcScore,
+    "Negative weight max reduction should match full recalc",
+  );
+  assertEquals(
+    creature.cachedScoreComponents!.maxWeightBias,
+    3,
+    "New max should be 3 (next largest absolute value)",
+  );
+});
+
+Deno.test("MaxRecalc: interleaved weight and bias mutations match full recalc", () => {
+  const creature = createCreature({
+    weights: [10, 5, 2, 1, 0.5, 0.5, 0.5],
+    biases: [8, 3, 0.1],
+  });
+  const error = 0.1;
+  const growthCost = 0.001;
+
+  calculate(creature, error, growthCost);
+
+  // Reduce max weight from 10 to 4
+  let oldW = creature.synapses[0].weight;
+  creature.synapses[0].weight = 4;
+  updateScoreForWeightChange(creature, error, growthCost, oldW, 4);
+
+  // Now bias (8) is the max. Reduce it to 3.
+  const neuronIdx = creature.input;
+  const oldB = creature.neurons[neuronIdx].bias;
+  creature.neurons[neuronIdx].bias = 3;
+  updateScoreForBiasChange(creature, error, growthCost, oldB, 3);
+
+  // Now max should be synapse 1 at 5
+  // Reduce synapse 1 from 5 to 1
+  oldW = creature.synapses[1].weight;
+  creature.synapses[1].weight = 1;
+  const incrementalScore = updateScoreForWeightChange(
+    creature,
+    error,
+    growthCost,
+    oldW,
+    1,
+  );
+
+  // Verify against full recalculation
+  creature.invalidateScoreCache();
+  const fullRecalcScore = calculate(creature, error, growthCost);
+
+  assertEquals(
+    incrementalScore,
+    fullRecalcScore,
+    "Interleaved weight and bias mutations should match full recalc",
+  );
+});
+
+Deno.test("MaxRecalc: large creature max reduction matches full recalculation", () => {
+  // Create a larger creature to test with more synapses
+  const creature = new Creature(10, 3, {
+    layers: [
+      { count: 20, squash: IDENTITY.NAME },
+      { count: 10, squash: IDENTITY.NAME },
+    ],
+    outputLayer: { squash: IDENTITY.NAME },
+  });
+
+  // Set a clear max on the first synapse
+  creature.synapses[0].weight = 50;
+  delete creature.cachedScoreComponents;
+
+  const error = 0.1;
+  const growthCost = 0.001;
+
+  calculate(creature, error, growthCost);
+  assertEquals(creature.cachedScoreComponents!.maxWeightBias, 50);
+
+  // Reduce the max
+  const oldWeight = creature.synapses[0].weight;
+  const newWeight = 0.1;
+  creature.synapses[0].weight = newWeight;
+
+  const incrementalScore = updateScoreForWeightChange(
+    creature,
+    error,
+    growthCost,
+    oldWeight,
+    newWeight,
+  );
+
+  // Verify against full recalculation
+  creature.invalidateScoreCache();
+  const fullRecalcScore = calculate(creature, error, growthCost);
+
+  assertEquals(
+    incrementalScore,
+    fullRecalcScore,
+    "Large creature max reduction should match full recalc",
+  );
+});


### PR DESCRIPTION
## Summary

Optimise max weight/bias recalculation in Score.ts by maintaining a runner-up
(second-highest) max value in the score cache. When the current maximum
weight or bias is reduced during an incremental update, the runner-up
enables O(1) max recovery instead of requiring an O(n) full scan of all
synapses and neurons. Closes #1442.

### Changes

- **`src/Creature.ts`**: Added `secondMaxWeightBias` field to the
  `CachedScoreComponents` interface.
- **`src/architecture/Score.ts`**:
  - `computeAndCacheScoreComponents()` now tracks both max and second-max
    during the initial full scan (no additional pass needed).
  - `updateScoreForWeightChange()` and `updateScoreForBiasChange()` use the
    cached second-max for O(1) max recovery when the current max is reduced.
    The second-max is marked stale (`-1`) after use and re-established on the
    next full scan.
  - Renamed `findNewMaxWeightBias()` / `findNewMaxWeightBiasForBias()` to
    `scanMaxForWeightChange()` / `scanMaxForBiasChange()` and updated them to
    return both max and second-max in a single scan pass.
  - Added staleness tracking: second-max is invalidated when a value equal to
    it is reduced, preventing stale values from producing incorrect results.

### How it works

1. **Full scan** (initial cache build or stale second-max): Tracks both the
   highest and second-highest absolute weight/bias values.
2. **First max reduction** after a full scan: Uses the cached second-max for
   O(1) recovery. No scan needed.
3. **Second max reduction** (if second-max is stale): Falls back to a single
   scan that re-establishes both max and second-max.

This means the first max reduction after any full scan is always O(1), and
alternating max reductions produce O(1) / O(n) / O(1) / O(n) behaviour,
effectively halving the number of full scans in the worst case.

## Evidence

This is a purely backend/algorithmic change with no visual output.

Benchmark results from `bench/MaxWeightBiasRecalculation.ts`:

| Scenario | Creature Size | Avg per iteration |
|---|---|---|
| Repeated max reductions | 230 neurons, 11,375 synapses | 0.51µs |
| Mixed mutations (~20% max-reducing) | 230 neurons, 11,375 synapses | 0.46µs |
| Repeated max reductions | 610 neurons, 70,500 synapses | 0.43µs |
| Mixed mutations (~20% max-reducing) | 610 neurons, 70,500 synapses | 0.22µs |

The "Repeated max reductions" and "Mixed mutations" scenarios show
sub-microsecond performance because the second-max enables O(1) recovery
without scanning all synapses. In contrast, a full scan of 70,500 synapses
takes approximately 2.7ms.

## Test Plan

- Added `test/score/MaxWeightBiasRecalculation.ts` with 8 tests:
  - Reducing max weight matches full recalculation
  - Reducing max bias matches full recalculation
  - Repeated max reductions match full recalculation
  - Max cached correctly after new weight exceeds current max
  - Max correctly tracks bias as the global max
  - Negative weights tracked by absolute value
  - Interleaved weight and bias mutations match full recalculation
  - Large creature max reduction matches full recalculation
- All existing 3,281 tests pass unchanged
- Added `bench/MaxWeightBiasRecalculation.ts` benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)