### PR TITLE
Performance: Selective cache invalidation by mutation type (#1445)

### DIFF
--- a/bench/SelectiveCacheInvalidation.ts
+++ b/bench/SelectiveCacheInvalidation.ts
@@ -1,0 +1,182 @@
+/**
+ * Benchmark for selective cache invalidation performance.
+ * Issue #1445: Selective cache invalidation by mutation type in Creature.ts.
+ *
+ * Measures the benefit of preserving hiddenNeuronUUIDs cache during
+ * connect/disconnect operations, which only change connections, not neurons.
+ *
+ * Usage:
+ *   deno run -A bench/SelectiveCacheInvalidation.ts
+ */
+
+import { Creature } from "../src/Creature.ts";
+import { IDENTITY } from "../src/methods/activations/types/IDENTITY.ts";
+import { AddConnection } from "../src/mutate/AddConnection.ts";
+
+function createLargeCreature(): Creature {
+  const creature = new Creature(50, 5, {
+    layers: [
+      { count: 100, squash: IDENTITY.NAME },
+      { count: 50, squash: IDENTITY.NAME },
+      { count: 25, squash: IDENTITY.NAME },
+    ],
+    outputLayer: { squash: IDENTITY.NAME },
+  });
+  return creature;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1) {
+    return `${(ms * 1000).toFixed(2)}µs`;
+  } else if (ms < 1000) {
+    return `${ms.toFixed(3)}ms`;
+  } else {
+    return `${(ms / 1000).toFixed(3)}s`;
+  }
+}
+
+function benchmarkSelectiveCacheInvalidation() {
+  console.log("=".repeat(60));
+  console.log("Selective Cache Invalidation Benchmark (Issue #1445)");
+  console.log("=".repeat(60));
+  console.log();
+
+  const creature = createLargeCreature();
+  console.log(`Creature stats:`);
+  console.log(`  Neurons: ${creature.neurons.length}`);
+  console.log(`  Synapses: ${creature.synapses.length}`);
+  console.log(
+    `  Hidden neurons: ${
+      creature.neurons.length - creature.input - creature.output
+    }`,
+  );
+  console.log();
+
+  // ── Benchmark 1: hiddenNeuronUUIDs preservation on connect/disconnect ──
+  console.log("─".repeat(60));
+  console.log("Benchmark 1: hiddenNeuronUUIDs cache preservation");
+  console.log("─".repeat(60));
+
+  // Build the hiddenNeuronUUIDs cache
+  const uuids = creature.getHiddenNeuronUUIDs();
+  console.log(`  UUID cache built: ${uuids.size} hidden neuron UUIDs`);
+
+  // Simulate connect/disconnect cycles and check if cache is preserved
+  const available = creature.getAvailableConnections();
+  const connectCount = Math.min(50, available.length);
+  const pairs = available.slice(0, connectCount);
+
+  let preservedCount = 0;
+  let rebuiltCount = 0;
+
+  for (const [from, to] of pairs) {
+    creature.connect(from, to, 0.1);
+    const current = creature.getHiddenNeuronUUIDs();
+    if (current === uuids) {
+      preservedCount++;
+    } else {
+      rebuiltCount++;
+    }
+  }
+
+  // Disconnect them back
+  for (const [from, to] of pairs) {
+    creature.disconnect(from, to);
+    const current = creature.getHiddenNeuronUUIDs();
+    if (current === uuids) {
+      preservedCount++;
+    } else {
+      rebuiltCount++;
+    }
+  }
+
+  const totalOps = connectCount * 2;
+  console.log(`  Total connect/disconnect ops: ${totalOps}`);
+  console.log(`  UUID cache preserved: ${preservedCount}/${totalOps}`);
+  console.log(`  UUID cache rebuilt: ${rebuiltCount}/${totalOps}`);
+  console.log(
+    `  Cache hit rate: ${((preservedCount / totalOps) * 100).toFixed(1)}%`,
+  );
+  console.log();
+
+  // ── Benchmark 2: Measure rebuild cost for large creatures ──
+  console.log("─".repeat(60));
+  console.log("Benchmark 2: UUID cache rebuild cost (what we avoid)");
+  console.log("─".repeat(60));
+
+  const iterations = 500;
+  const rebuildTimes: number[] = [];
+
+  for (let i = 0; i < iterations; i++) {
+    // Force a full clear to measure rebuild cost
+    creature.clearCache();
+    const start = performance.now();
+    creature.getHiddenNeuronUUIDs();
+    rebuildTimes.push(performance.now() - start);
+  }
+
+  const rebuildAvg = rebuildTimes.reduce((a, b) => a + b, 0) / iterations;
+  const totalSaved = rebuildAvg * preservedCount;
+  console.log(
+    `  UUID cache rebuild avg: ${formatDuration(rebuildAvg)} per rebuild`,
+  );
+  console.log(
+    `  Total time saved (${preservedCount} avoided rebuilds): ${
+      formatDuration(totalSaved)
+    }`,
+  );
+  console.log();
+
+  // ── Benchmark 3: AddConnection mutation throughput ──
+  console.log("─".repeat(60));
+  console.log("Benchmark 3: AddConnection mutation throughput");
+  console.log("─".repeat(60));
+
+  // Recreate to get a fresh creature
+  const freshCreature = createLargeCreature();
+  freshCreature.getHiddenNeuronUUIDs(); // Pre-build cache
+  freshCreature.getConnectionSet();
+  freshCreature.prebuildInwardIndex();
+
+  const addConn = new AddConnection(freshCreature);
+  const connTimes: number[] = [];
+  let added = 0;
+
+  for (let i = 0; i < 100; i++) {
+    const start = performance.now();
+    if (addConn.mutate()) {
+      added++;
+    }
+    connTimes.push(performance.now() - start);
+  }
+  const connAvg = connTimes.reduce((a, b) => a + b, 0) / connTimes.length;
+  console.log(`  AddConnection avg: ${formatDuration(connAvg)}`);
+  console.log(`  Connections added: ${added}`);
+
+  // Check UUID cache is still the same reference across two calls
+  const uuidRef1 = freshCreature.getHiddenNeuronUUIDs();
+  const uuidRef2 = freshCreature.getHiddenNeuronUUIDs();
+  console.log(
+    `  UUID cache still valid after mutations: ${uuidRef1 === uuidRef2}`,
+  );
+  console.log();
+
+  // ── Benchmark 4: Redundant invalidateScoreCache removal ──
+  console.log("─".repeat(60));
+  console.log(
+    "Benchmark 4: Redundant invalidateScoreCache() calls eliminated",
+  );
+  console.log("─".repeat(60));
+  console.log(
+    "  connect() and disconnect() no longer call invalidateScoreCache()",
+  );
+  console.log(
+    "  twice — clearCache() already handles it internally.",
+  );
+  console.log();
+
+  console.log("=".repeat(60));
+  console.log("Benchmark complete.");
+}
+
+benchmarkSelectiveCacheInvalidation();

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.311.18",
+  "version": "0.311.19",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1445.md
+++ b/docs/pr-summary-1445.md
@@ -1,0 +1,52 @@
+## Summary
+
+Selective cache invalidation by mutation type in `Creature.ts`. Closes #1445.
+
+Previously, `clearCache()` invalidated ALL caches on any structural change, including `hiddenNeuronUUIDs` — even when only connections changed (not neurons). This caused unnecessary rebuilds of the hidden neuron UUID set during connect/disconnect operations.
+
+### Changes
+
+1. **`clearCache(from, to)` selective path**: No longer clears `hiddenNeuronUUIDs` when called with valid from/to indices (connection-only changes). Adding/removing a connection does not change the set of neurons, so the UUID set remains valid.
+
+2. **`clearConnectionCaches()` private method**: New method for batch connect/disconnect operations that clears all connection-related caches without invalidating `hiddenNeuronUUIDs`.
+
+3. **Redundant `invalidateScoreCache()` removal**: `connect()` and `disconnect()` were calling `invalidateScoreCache()` explicitly after `clearCache()`, but `clearCache()` already calls it internally. Removed the redundant calls.
+
+4. **Updated `connectBatch()`/`disconnectBatch()`**: Now use `clearConnectionCaches()` instead of full `clearCache()` to preserve `hiddenNeuronUUIDs`.
+
+### Files Changed
+
+- `src/Creature.ts` — Selective cache invalidation logic, `clearConnectionCaches()` method, redundant call removal
+- `test/creature/SelectiveCacheInvalidation.ts` — 10 new tests for cache preservation behaviour
+- `test/Offspring/HiddenNeuronUUIDCache.ts` — Updated test to verify cache preservation (was testing the old unnecessary invalidation)
+- `bench/SelectiveCacheInvalidation.ts` — Benchmark showing 100% UUID cache hit rate during connect/disconnect
+
+## Evidence
+
+This is a backend performance change with no UI impact. Benchmark results:
+
+```
+Creature: 230 neurons, 11,375 synapses, 175 hidden neurons
+
+hiddenNeuronUUIDs cache preservation:
+  100 connect/disconnect ops: 100/100 cache preserved (100% hit rate)
+  UUID cache rebuild cost: ~3.17µs per rebuild avoided
+
+Redundant invalidateScoreCache() calls:
+  Eliminated 2 duplicate calls per connect()/disconnect() operation
+```
+
+## Test Plan
+
+- Added `test/creature/SelectiveCacheInvalidation.ts` with 10 tests:
+  - `connect()` preserves `hiddenNeuronUUIDs` cache (reference equality)
+  - `disconnect()` preserves `hiddenNeuronUUIDs` cache
+  - `connect()` invalidates `connectionSet` correctly
+  - `connect()` invalidates `availableConnectionsCache` correctly
+  - Full `clearCache()` invalidates everything including `hiddenNeuronUUIDs`
+  - `connect()` invalidates score cache
+  - `disconnect()` invalidates score cache
+  - `connectBatch()` preserves `hiddenNeuronUUIDs` cache
+  - `disconnectBatch()` preserves `hiddenNeuronUUIDs` cache
+  - Many connect/disconnect cycles preserve `hiddenNeuronUUIDs` on larger creature
+- Updated `test/Offspring/HiddenNeuronUUIDCache.ts` to verify new correct behaviour

--- a/docs/pr-summary-1445.md
+++ b/docs/pr-summary-1445.md
@@ -2,24 +2,41 @@
 
 Selective cache invalidation by mutation type in `Creature.ts`. Closes #1445.
 
-Previously, `clearCache()` invalidated ALL caches on any structural change, including `hiddenNeuronUUIDs` — even when only connections changed (not neurons). This caused unnecessary rebuilds of the hidden neuron UUID set during connect/disconnect operations.
+Previously, `clearCache()` invalidated ALL caches on any structural change,
+including `hiddenNeuronUUIDs` — even when only connections changed (not
+neurons). This caused unnecessary rebuilds of the hidden neuron UUID set during
+connect/disconnect operations.
 
 ### Changes
 
-1. **`clearCache(from, to)` selective path**: No longer clears `hiddenNeuronUUIDs` when called with valid from/to indices (connection-only changes). Adding/removing a connection does not change the set of neurons, so the UUID set remains valid.
+1. **`clearCache(from, to)` selective path**: No longer clears
+   `hiddenNeuronUUIDs` when called with valid from/to indices (connection-only
+   changes). Adding/removing a connection does not change the set of neurons, so
+   the UUID set remains valid.
 
-2. **`clearConnectionCaches()` private method**: New method for batch connect/disconnect operations that clears all connection-related caches without invalidating `hiddenNeuronUUIDs`.
+2. **`clearConnectionCaches()` private method**: New method for batch
+   connect/disconnect operations that clears all connection-related caches
+   without invalidating `hiddenNeuronUUIDs`.
 
-3. **Redundant `invalidateScoreCache()` removal**: `connect()` and `disconnect()` were calling `invalidateScoreCache()` explicitly after `clearCache()`, but `clearCache()` already calls it internally. Removed the redundant calls.
+3. **Redundant `invalidateScoreCache()` removal**: `connect()` and
+   `disconnect()` were calling `invalidateScoreCache()` explicitly after
+   `clearCache()`, but `clearCache()` already calls it internally. Removed the
+   redundant calls.
 
-4. **Updated `connectBatch()`/`disconnectBatch()`**: Now use `clearConnectionCaches()` instead of full `clearCache()` to preserve `hiddenNeuronUUIDs`.
+4. **Updated `connectBatch()`/`disconnectBatch()`**: Now use
+   `clearConnectionCaches()` instead of full `clearCache()` to preserve
+   `hiddenNeuronUUIDs`.
 
 ### Files Changed
 
-- `src/Creature.ts` — Selective cache invalidation logic, `clearConnectionCaches()` method, redundant call removal
-- `test/creature/SelectiveCacheInvalidation.ts` — 10 new tests for cache preservation behaviour
-- `test/Offspring/HiddenNeuronUUIDCache.ts` — Updated test to verify cache preservation (was testing the old unnecessary invalidation)
-- `bench/SelectiveCacheInvalidation.ts` — Benchmark showing 100% UUID cache hit rate during connect/disconnect
+- `src/Creature.ts` — Selective cache invalidation logic,
+  `clearConnectionCaches()` method, redundant call removal
+- `test/creature/SelectiveCacheInvalidation.ts` — 10 new tests for cache
+  preservation behaviour
+- `test/Offspring/HiddenNeuronUUIDCache.ts` — Updated test to verify cache
+  preservation (was testing the old unnecessary invalidation)
+- `bench/SelectiveCacheInvalidation.ts` — Benchmark showing 100% UUID cache hit
+  rate during connect/disconnect
 
 ## Evidence
 
@@ -48,5 +65,7 @@ Redundant invalidateScoreCache() calls:
   - `disconnect()` invalidates score cache
   - `connectBatch()` preserves `hiddenNeuronUUIDs` cache
   - `disconnectBatch()` preserves `hiddenNeuronUUIDs` cache
-  - Many connect/disconnect cycles preserve `hiddenNeuronUUIDs` on larger creature
-- Updated `test/Offspring/HiddenNeuronUUIDCache.ts` to verify new correct behaviour
+  - Many connect/disconnect cycles preserve `hiddenNeuronUUIDs` on larger
+    creature
+- Updated `test/Offspring/HiddenNeuronUUIDCache.ts` to verify new correct
+  behaviour

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -185,8 +185,18 @@ export class Creature implements CreatureInternal {
     this.neurons.length = 0;
   }
 
+  /**
+   * Clears topology caches after structural changes.
+   *
+   * Issue #1445: Selective cache invalidation by mutation type.
+   * When called with valid from/to indices (connection-only change),
+   * hiddenNeuronUUIDs is preserved because adding/removing a connection
+   * does not change the set of neurons.
+   */
   public clearCache(from: number = -1, to: number = -1) {
     if (from === -1 || to === -1) {
+      // Full invalidation: clears everything including hiddenNeuronUUIDs.
+      // Used when neurons are added/removed or structure is fully rebuilt.
       this._topoCaches.cacheTo.clear();
       this._topoCaches.cacheFrom.clear();
       this._topoCaches.cacheSelf.clear();
@@ -197,16 +207,37 @@ export class Creature implements CreatureInternal {
       this._topoCaches.availableConnectionsCache = null;
       this.topologyHash = undefined;
     } else {
+      // Connection-only invalidation: preserves hiddenNeuronUUIDs.
+      // Adding/removing a connection does not change the set of neurons,
+      // so the UUID set remains valid.
       this._topoCaches.cacheTo.delete(to);
       this._topoCaches.cacheFrom.delete(from);
       this._topoCaches.cacheSelf.delete(from);
       this._topoCaches.synapsesIndexedByTo = null;
       this._topoCaches.inwardCacheMissCount = 0;
       this._topoCaches.connectionSet = null;
-      this._topoCaches.hiddenNeuronUUIDs = null;
       this._topoCaches.availableConnectionsCache = null;
       this.topologyHash = undefined;
     }
+    this.invalidateScoreCache();
+  }
+
+  /**
+   * Clears connection-related caches without invalidating hiddenNeuronUUIDs.
+   *
+   * Issue #1445: Used by batch connect/disconnect operations that change
+   * connections but not the set of neurons. This avoids unnecessary
+   * rebuilds of the hiddenNeuronUUIDs set.
+   */
+  private clearConnectionCaches() {
+    this._topoCaches.cacheTo.clear();
+    this._topoCaches.cacheFrom.clear();
+    this._topoCaches.cacheSelf.clear();
+    this._topoCaches.synapsesIndexedByTo = null;
+    this._topoCaches.inwardCacheMissCount = 0;
+    this._topoCaches.connectionSet = null;
+    this._topoCaches.availableConnectionsCache = null;
+    this.topologyHash = undefined;
     this.invalidateScoreCache();
   }
 
@@ -497,8 +528,8 @@ export class Creature implements CreatureInternal {
       this.synapses.push(connection);
     }
 
+    // Issue #1445: clearCache(from, to) already calls invalidateScoreCache()
     this.clearCache(from, to);
-    this.invalidateScoreCache();
     return connection;
   }
 
@@ -506,8 +537,8 @@ export class Creature implements CreatureInternal {
     const indx = topology.binarySearchSynapse(this, from, to);
     if (indx !== -1) {
       this.synapses.splice(indx, 1);
+      // Issue #1445: clearCache(from, to) already calls invalidateScoreCache()
       this.clearCache(from, to);
-      this.invalidateScoreCache();
     }
   }
 
@@ -554,8 +585,9 @@ export class Creature implements CreatureInternal {
       }
     }
 
-    this.clearCache();
-    this.invalidateScoreCache();
+    // Issue #1445: Preserve hiddenNeuronUUIDs — batch connect only changes
+    // connections, not the set of neurons.
+    this.clearConnectionCaches();
   }
 
   disconnectBatch(pairs: Array<{ from: number; to: number }>): void {
@@ -574,8 +606,9 @@ export class Creature implements CreatureInternal {
       this.synapses.splice(idx, 1);
     }
 
-    this.clearCache();
-    this.invalidateScoreCache();
+    // Issue #1445: Preserve hiddenNeuronUUIDs — batch disconnect only changes
+    // connections, not the set of neurons.
+    this.clearConnectionCaches();
   }
 
   // ── Focus ──────────────────────────────────────────────────────────────

--- a/test/Offspring/HiddenNeuronUUIDCache.ts
+++ b/test/Offspring/HiddenNeuronUUIDCache.ts
@@ -137,18 +137,18 @@ Deno.test("geneticCompatibility uses cached hiddenNeuronUUIDs", () => {
   assertEquals(compatibility, 1);
 });
 
-Deno.test("getHiddenNeuronUUIDs cache is invalidated on connect", () => {
+Deno.test("getHiddenNeuronUUIDs cache is preserved on connect", () => {
   const hiddenUUIDs = ["hidden-1"];
   const creature = makeCreatureWithHiddenNeurons(hiddenUUIDs);
 
   const result1 = creature.getHiddenNeuronUUIDs();
 
-  // Adding a new connection should invalidate the cache
-  // (even though hidden neurons haven't changed, the structure has)
+  // Issue #1445: Adding a connection does not change the set of neurons,
+  // so hiddenNeuronUUIDs should be preserved (same reference).
   creature.connect(1, creature.neurons.length - 1, 0.3);
 
   const result2 = creature.getHiddenNeuronUUIDs();
 
-  // Should return a new Set instance after structure change
-  assertEquals(result1 !== result2, true);
+  // Should return the same Set instance — connect only changes connections
+  assertEquals(result1 === result2, true);
 });

--- a/test/creature/SelectiveCacheInvalidation.ts
+++ b/test/creature/SelectiveCacheInvalidation.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for issue #1445: Selective cache invalidation by mutation type.
+ *
+ * Verifies that:
+ * - connect()/disconnect() preserve hiddenNeuronUUIDs cache (no neurons change)
+ * - connect()/disconnect() properly invalidate connection-related caches
+ * - Full clearCache() still clears everything
+ * - Score cache is properly invalidated by all operations that affect it
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
+import { calculate } from "../../src/architecture/Score.ts";
+import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+function createTestCreature(): Creature {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden" as const,
+        uuid: "hidden-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "hidden" as const,
+        uuid: "hidden-2",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 1 },
+      { fromUUID: "input-1", toUUID: "hidden-2", weight: 1 },
+      { fromUUID: "hidden-1", toUUID: "hidden-2", weight: 0.5 },
+      { fromUUID: "hidden-2", toUUID: "output-0", weight: 1 },
+    ],
+  };
+  return Creature.fromJSON(json, true);
+}
+
+// ── hiddenNeuronUUIDs preservation tests ──
+
+Deno.test("SelectiveCacheInvalidation: connect() preserves hiddenNeuronUUIDs cache", () => {
+  const creature = createTestCreature();
+
+  // Build the hiddenNeuronUUIDs cache
+  const uuids1 = creature.getHiddenNeuronUUIDs();
+  assertEquals(uuids1.size, 2, "Should have 2 hidden neuron UUIDs");
+
+  // Add a connection (doesn't change neuron set)
+  creature.connect(0, 4, 0.5); // input-0 to output-0
+
+  // hiddenNeuronUUIDs should still be cached (same object reference)
+  const uuids2 = creature.getHiddenNeuronUUIDs();
+  assertEquals(uuids2.size, 2, "Should still have 2 hidden neuron UUIDs");
+  assert(
+    uuids1 === uuids2,
+    "Should be the same Set reference (cache preserved after connect)",
+  );
+
+  creatureValidate(creature);
+});
+
+Deno.test("SelectiveCacheInvalidation: disconnect() preserves hiddenNeuronUUIDs cache", () => {
+  const creature = createTestCreature();
+
+  // Add an extra connection so we can disconnect without breaking the creature
+  creature.connect(0, 3, 0.3); // input-0 to hidden-2
+
+  // Build the hiddenNeuronUUIDs cache
+  const uuids1 = creature.getHiddenNeuronUUIDs();
+  assertEquals(uuids1.size, 2, "Should have 2 hidden neuron UUIDs");
+
+  // Remove a connection (doesn't change neuron set)
+  creature.disconnect(0, 3); // Remove input-0 to hidden-2
+
+  // hiddenNeuronUUIDs should still be cached (same object reference)
+  const uuids2 = creature.getHiddenNeuronUUIDs();
+  assertEquals(uuids2.size, 2, "Should still have 2 hidden neuron UUIDs");
+  assert(
+    uuids1 === uuids2,
+    "Should be the same Set reference (cache preserved after disconnect)",
+  );
+
+  creatureValidate(creature);
+});
+
+// ── Connection-related cache invalidation tests ──
+
+Deno.test("SelectiveCacheInvalidation: connect() invalidates connectionSet", () => {
+  const creature = createTestCreature();
+
+  // Build the connection set cache
+  const connSet1 = creature.getConnectionSet();
+  const size1 = connSet1.size;
+
+  // Add a connection
+  creature.connect(0, 4, 0.5);
+
+  // Connection set should be rebuilt (different reference)
+  const connSet2 = creature.getConnectionSet();
+  assertEquals(connSet2.size, size1 + 1, "Connection set should grow by 1");
+  assert(
+    connSet1 !== connSet2,
+    "Connection set should be a new Set after connect()",
+  );
+});
+
+Deno.test("SelectiveCacheInvalidation: connect() invalidates availableConnectionsCache", () => {
+  const creature = createTestCreature();
+
+  // Build available connections cache
+  const available1 = creature.getAvailableConnections();
+  const count1 = available1.length;
+
+  // Add a connection
+  creature.connect(0, 4, 0.5);
+
+  // Available connections should be recomputed
+  const available2 = creature.getAvailableConnections();
+  assertEquals(
+    available2.length,
+    count1 - 1,
+    "Available connections should shrink by 1",
+  );
+  assert(
+    available1 !== available2,
+    "Available connections should be a new array after connect()",
+  );
+});
+
+// ── Full clearCache still works ──
+
+Deno.test("SelectiveCacheInvalidation: full clearCache() invalidates everything", () => {
+  const creature = createTestCreature();
+
+  // Build all caches
+  const uuids1 = creature.getHiddenNeuronUUIDs();
+  creature.getConnectionSet();
+  creature.getAvailableConnections();
+  creature.prebuildInwardIndex();
+
+  // Full clear
+  creature.clearCache();
+
+  // Everything should be invalidated
+  assertEquals(
+    creature.isAvailableConnectionsCacheBuilt(),
+    false,
+    "Available connections cache should be cleared",
+  );
+  assertEquals(
+    creature.isInwardIndexBuilt(),
+    false,
+    "Inward index should be cleared",
+  );
+
+  // Rebuilding should produce different references
+  const uuids2 = creature.getHiddenNeuronUUIDs();
+  assert(
+    uuids1 !== uuids2,
+    "hiddenNeuronUUIDs should be a new Set after full clearCache()",
+  );
+});
+
+// ── Score cache invalidation correctness ──
+
+Deno.test("SelectiveCacheInvalidation: connect() invalidates score cache", () => {
+  const creature = createTestCreature();
+
+  // Force score cache to be built by calculating
+  calculate(creature, 0.1, 0.0001);
+  assert(
+    creature.cachedScoreComponents !== undefined,
+    "Score cache should exist after calculate",
+  );
+
+  // connect() should invalidate score cache
+  creature.connect(0, 4, 0.5);
+  assertEquals(
+    creature.cachedScoreComponents,
+    undefined,
+    "Score cache should be invalidated after connect()",
+  );
+});
+
+Deno.test("SelectiveCacheInvalidation: disconnect() invalidates score cache", () => {
+  const creature = createTestCreature();
+
+  // Add an extra connection first
+  creature.connect(0, 3, 0.3);
+
+  // Build score cache
+  calculate(creature, 0.1, 0.0001);
+  assert(
+    creature.cachedScoreComponents !== undefined,
+    "Score cache should exist after calculate",
+  );
+
+  // disconnect() should invalidate score cache
+  creature.disconnect(0, 3);
+  assertEquals(
+    creature.cachedScoreComponents,
+    undefined,
+    "Score cache should be invalidated after disconnect()",
+  );
+});
+
+// ── connectBatch / disconnectBatch preserve hiddenNeuronUUIDs ──
+
+Deno.test("SelectiveCacheInvalidation: connectBatch() preserves hiddenNeuronUUIDs cache", () => {
+  const creature = createTestCreature();
+
+  // Build the hiddenNeuronUUIDs cache
+  const uuids1 = creature.getHiddenNeuronUUIDs();
+  assertEquals(uuids1.size, 2);
+
+  // Add batch connections (doesn't change neuron set)
+  creature.connectBatch([
+    { from: 0, to: 4, weight: 0.5 },
+    { from: 1, to: 4, weight: 0.3 },
+  ]);
+
+  // hiddenNeuronUUIDs should still be cached (same reference)
+  const uuids2 = creature.getHiddenNeuronUUIDs();
+  assertEquals(uuids2.size, 2);
+  assert(
+    uuids1 === uuids2,
+    "Should be the same Set reference (cache preserved) after connectBatch",
+  );
+
+  creatureValidate(creature);
+});
+
+Deno.test("SelectiveCacheInvalidation: disconnectBatch() preserves hiddenNeuronUUIDs cache", () => {
+  const creature = createTestCreature();
+
+  // Add extra connections to disconnect
+  creature.connect(0, 4, 0.5);
+  creature.connect(1, 4, 0.3);
+
+  // Build the hiddenNeuronUUIDs cache
+  const uuids1 = creature.getHiddenNeuronUUIDs();
+  assertEquals(uuids1.size, 2);
+
+  // Remove batch connections
+  creature.disconnectBatch([
+    { from: 0, to: 4 },
+    { from: 1, to: 4 },
+  ]);
+
+  // hiddenNeuronUUIDs should still be cached (same reference)
+  const uuids2 = creature.getHiddenNeuronUUIDs();
+  assertEquals(uuids2.size, 2);
+  assert(
+    uuids1 === uuids2,
+    "Should be the same Set reference (cache preserved) after disconnectBatch",
+  );
+
+  creatureValidate(creature);
+});
+
+// ── Larger creature tests for correctness ──
+
+Deno.test("SelectiveCacheInvalidation: many connect/disconnect preserve hiddenNeuronUUIDs", () => {
+  const creature = new Creature(5, 2, {
+    layers: [
+      { count: 10, squash: IDENTITY.NAME },
+      { count: 5, squash: IDENTITY.NAME },
+    ],
+    outputLayer: { squash: IDENTITY.NAME },
+  });
+  creatureValidate(creature);
+
+  // Build and record the UUID set
+  const uuids1 = creature.getHiddenNeuronUUIDs();
+  const uuidCount = uuids1.size;
+  assert(uuidCount > 0, "Should have hidden neurons");
+
+  // Perform multiple connect/disconnect cycles
+  const available = creature.getAvailableConnections();
+  const toAdd = available.slice(0, Math.min(5, available.length));
+
+  for (const [from, to] of toAdd) {
+    creature.connect(from, to, 0.1);
+    // After each connect, UUID cache should be preserved (same reference)
+    const currentUUIDs = creature.getHiddenNeuronUUIDs();
+    assert(
+      currentUUIDs === uuids1,
+      `UUID cache should be same reference after connecting ${from}->${to}`,
+    );
+  }
+
+  // Disconnect some
+  for (const [from, to] of toAdd) {
+    creature.disconnect(from, to);
+    const currentUUIDs = creature.getHiddenNeuronUUIDs();
+    assert(
+      currentUUIDs === uuids1,
+      `UUID cache should be same reference after disconnecting ${from}->${to}`,
+    );
+  }
+
+  creatureValidate(creature);
+});


### PR DESCRIPTION
## Summary

Selective cache invalidation by mutation type in `Creature.ts`. Closes #1445.

Previously, `clearCache()` invalidated ALL caches on any structural change, including `hiddenNeuronUUIDs` — even when only connections changed (not neurons). This caused unnecessary rebuilds of the hidden neuron UUID set during connect/disconnect operations.

### Changes

1. **`clearCache(from, to)` selective path**: No longer clears `hiddenNeuronUUIDs` when called with valid from/to indices (connection-only changes). Adding/removing a connection does not change the set of neurons, so the UUID set remains valid.

2. **`clearConnectionCaches()` private method**: New method for batch connect/disconnect operations that clears all connection-related caches without invalidating `hiddenNeuronUUIDs`.

3. **Redundant `invalidateScoreCache()` removal**: `connect()` and `disconnect()` were calling `invalidateScoreCache()` explicitly after `clearCache()`, but `clearCache()` already calls it internally. Removed the redundant calls.

4. **Updated `connectBatch()`/`disconnectBatch()`**: Now use `clearConnectionCaches()` instead of full `clearCache()` to preserve `hiddenNeuronUUIDs`.

### Files Changed

- `src/Creature.ts` — Selective cache invalidation logic, `clearConnectionCaches()` method, redundant call removal
- `test/creature/SelectiveCacheInvalidation.ts` — 10 new tests for cache preservation behaviour
- `test/Offspring/HiddenNeuronUUIDCache.ts` — Updated test to verify cache preservation (was testing the old unnecessary invalidation)
- `bench/SelectiveCacheInvalidation.ts` — Benchmark showing 100% UUID cache hit rate during connect/disconnect

## Evidence

This is a backend performance change with no UI impact. Benchmark results:

```
Creature: 230 neurons, 11,375 synapses, 175 hidden neurons

hiddenNeuronUUIDs cache preservation:
  100 connect/disconnect ops: 100/100 cache preserved (100% hit rate)
  UUID cache rebuild cost: ~3.17µs per rebuild avoided

Redundant invalidateScoreCache() calls:
  Eliminated 2 duplicate calls per connect()/disconnect() operation
```

## Test Plan

- Added `test/creature/SelectiveCacheInvalidation.ts` with 10 tests:
  - `connect()` preserves `hiddenNeuronUUIDs` cache (reference equality)
  - `disconnect()` preserves `hiddenNeuronUUIDs` cache
  - `connect()` invalidates `connectionSet` correctly
  - `connect()` invalidates `availableConnectionsCache` correctly
  - Full `clearCache()` invalidates everything including `hiddenNeuronUUIDs`
  - `connect()` invalidates score cache
  - `disconnect()` invalidates score cache
  - `connectBatch()` preserves `hiddenNeuronUUIDs` cache
  - `disconnectBatch()` preserves `hiddenNeuronUUIDs` cache
  - Many connect/disconnect cycles preserve `hiddenNeuronUUIDs` on larger creature
- Updated `test/Offspring/HiddenNeuronUUIDCache.ts` to verify new correct behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)