### PR TITLE
Test: Remove timing-based assertions from unit tests (#1446)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.311.19",
+  "version": "0.311.20",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1446.md
+++ b/docs/pr-summary-1446.md
@@ -1,0 +1,42 @@
+## Summary
+
+Removed timing-based assertions (`performance.now()`) from two unit test files
+and replaced them with behavioural assertions that verify correctness rather than
+performance. Closes #1446.
+
+Per AGENTS.md guidelines, unit tests must not use timing APIs since tests run in
+parallel, making performance measurements unreliable. The performance properties
+are already covered by existing benchmarks (`bench/ScoreCalculationCache.ts` and
+`bench/AvailableConnectionsCache.ts`).
+
+### Changes
+
+- **`test/score/ScoreCacheWeightBias.ts`**: Replaced the
+  "performance - caching should avoid redundant iterations" test with a
+  behavioural test that verifies the cache reference persists across 100
+  calculations with varying error values — confirming the cache is reused without
+  relying on timing.
+
+- **`test/mutate/AddConnectionOptimisation.ts`**: Replaced the
+  "performance with large creature" test with a behavioural test that verifies
+  mutation correctness at scale — checking creature validity and that synapse
+  counts match the number of successful mutations, rather than timing the
+  operations.
+
+## Evidence
+
+This is a test-only change with no UI or performance implications. Existing
+benchmarks in `bench/ScoreCalculationCache.ts` and
+`bench/AvailableConnectionsCache.ts` already cover the performance aspects that
+were previously (unreliably) tested in unit tests.
+
+All 3291 tests pass with 0 failures after the changes.
+
+## Test Plan
+
+- Modified `test/score/ScoreCacheWeightBias.ts` — replaced timing test with
+  cache persistence behavioural test
+- Modified `test/mutate/AddConnectionOptimisation.ts` — replaced timing test
+  with mutation correctness behavioural test
+- Ran `./quality.sh` — all formatting, linting, type-checking, and 3291 tests
+  pass

--- a/docs/pr-summary-1446.md
+++ b/docs/pr-summary-1446.md
@@ -1,8 +1,8 @@
 ## Summary
 
 Removed timing-based assertions (`performance.now()`) from two unit test files
-and replaced them with behavioural assertions that verify correctness rather than
-performance. Closes #1446.
+and replaced them with behavioural assertions that verify correctness rather
+than performance. Closes #1446.
 
 Per AGENTS.md guidelines, unit tests must not use timing APIs since tests run in
 parallel, making performance measurements unreliable. The performance properties
@@ -11,17 +11,15 @@ are already covered by existing benchmarks (`bench/ScoreCalculationCache.ts` and
 
 ### Changes
 
-- **`test/score/ScoreCacheWeightBias.ts`**: Replaced the
-  "performance - caching should avoid redundant iterations" test with a
-  behavioural test that verifies the cache reference persists across 100
-  calculations with varying error values — confirming the cache is reused without
-  relying on timing.
+- **`test/score/ScoreCacheWeightBias.ts`**: Replaced the "performance - caching
+  should avoid redundant iterations" test with a behavioural test that verifies
+  the cache reference persists across 100 calculations with varying error values
+  — confirming the cache is reused without relying on timing.
 
-- **`test/mutate/AddConnectionOptimisation.ts`**: Replaced the
-  "performance with large creature" test with a behavioural test that verifies
-  mutation correctness at scale — checking creature validity and that synapse
-  counts match the number of successful mutations, rather than timing the
-  operations.
+- **`test/mutate/AddConnectionOptimisation.ts`**: Replaced the "performance with
+  large creature" test with a behavioural test that verifies mutation
+  correctness at scale — checking creature validity and that synapse counts
+  match the number of successful mutations, rather than timing the operations.
 
 ## Evidence
 

--- a/test/mutate/AddConnectionOptimisation.ts
+++ b/test/mutate/AddConnectionOptimisation.ts
@@ -171,8 +171,8 @@ Deno.test("AddConnection: mutation still works correctly with optimisation", () 
   creatureValidate(creature);
 });
 
-Deno.test("AddConnection: performance with large creature", () => {
-  // Create a creature with many neurons to test performance
+Deno.test("AddConnection: mutation works correctly with large creature", () => {
+  // Create a creature with many neurons to test mutation behaviour at scale
   const creature = new Creature(10, 5);
   creatureValidate(creature);
 
@@ -181,24 +181,24 @@ Deno.test("AddConnection: performance with large creature", () => {
     addNeuron.mutate();
   }
 
-  const startTime = performance.now();
+  const initialSynapseCount = creature.synapses.length;
 
   const addConnection = new AddConnection(creature);
+  let connectionsAdded = 0;
   for (let i = 100; i--;) {
-    addConnection.mutate();
+    if (addConnection.mutate()) {
+      connectionsAdded++;
+    }
   }
 
-  const endTime = performance.now();
-  const elapsed = endTime - startTime;
-
-  // Creature should still be valid
+  // Creature should still be valid after many mutations
   creatureValidate(creature);
 
-  // Log performance for visibility (not a hard assertion as it depends on machine)
-  console.log(
-    `AddConnection: 100 mutations on ${creature.neurons.length} neurons took ${
-      elapsed.toFixed(2)
-    }ms`,
+  // Synapse count should reflect added connections
+  assertEquals(
+    creature.synapses.length,
+    initialSynapseCount + connectionsAdded,
+    "Synapse count should match initial count plus added connections",
   );
 });
 

--- a/test/score/ScoreCacheWeightBias.ts
+++ b/test/score/ScoreCacheWeightBias.ts
@@ -292,39 +292,29 @@ Deno.test("ScoreCacheWeightBias: multiple score calculations with different erro
   );
 });
 
-Deno.test("ScoreCacheWeightBias: performance - caching should avoid redundant iterations", () => {
+Deno.test("ScoreCacheWeightBias: cache should persist across many calculations with varying errors", () => {
   const creature = createLargeCreature();
 
-  // Calculate score multiple times and time it
-  const iterations = 100;
-
-  // First calculation (builds cache)
-  const start1 = performance.now();
+  // First calculation builds the cache
   calculate(creature, 0.1, 0.0001);
-  const firstCalculationTime = performance.now() - start1;
+  const cachedComponents = creature.cachedScoreComponents;
 
-  // Subsequent calculations (should use cache)
-  const start2 = performance.now();
-  for (let i = 0; i < iterations - 1; i++) {
-    // Simulate what happens in fitness evaluation - only error changes
-    calculate(creature, 0.1 + i * 0.001, 0.0001);
-  }
-  const cachedCalculationsTime = performance.now() - start2;
-
-  const avgCachedTime = cachedCalculationsTime / (iterations - 1);
-
-  // Cached calculations should be faster than first calculation
-  // (This is a soft assertion - we just verify caching is working)
-  console.log(
-    `First calculation: ${firstCalculationTime.toFixed(3)}ms, ` +
-      `Avg cached: ${avgCachedTime.toFixed(3)}ms`,
+  assertNotEquals(
+    cachedComponents,
+    undefined,
+    "Cache should exist after first calculation",
   );
 
-  // The cache should be reused across all calculations
-  assertNotEquals(
+  // Subsequent calculations with different errors should reuse the same cache
+  for (let i = 0; i < 99; i++) {
+    calculate(creature, 0.1 + i * 0.001, 0.0001);
+  }
+
+  // The cache reference should remain the same (not recreated)
+  assertEquals(
     creature.cachedScoreComponents,
-    undefined,
-    "Cache should exist after multiple calculations",
+    cachedComponents,
+    "Cache should be reused across all calculations when structure is unchanged",
   );
 });
 


### PR DESCRIPTION
## Summary

Removed timing-based assertions (`performance.now()`) from two unit test files
and replaced them with behavioural assertions that verify correctness rather than
performance. Closes #1446.

Per AGENTS.md guidelines, unit tests must not use timing APIs since tests run in
parallel, making performance measurements unreliable. The performance properties
are already covered by existing benchmarks (`bench/ScoreCalculationCache.ts` and
`bench/AvailableConnectionsCache.ts`).

### Changes

- **`test/score/ScoreCacheWeightBias.ts`**: Replaced the
  "performance - caching should avoid redundant iterations" test with a
  behavioural test that verifies the cache reference persists across 100
  calculations with varying error values — confirming the cache is reused without
  relying on timing.

- **`test/mutate/AddConnectionOptimisation.ts`**: Replaced the
  "performance with large creature" test with a behavioural test that verifies
  mutation correctness at scale — checking creature validity and that synapse
  counts match the number of successful mutations, rather than timing the
  operations.

## Evidence

This is a test-only change with no UI or performance implications. Existing
benchmarks in `bench/ScoreCalculationCache.ts` and
`bench/AvailableConnectionsCache.ts` already cover the performance aspects that
were previously (unreliably) tested in unit tests.

All 3291 tests pass with 0 failures after the changes.

## Test Plan

- Modified `test/score/ScoreCacheWeightBias.ts` — replaced timing test with
  cache persistence behavioural test
- Modified `test/mutate/AddConnectionOptimisation.ts` — replaced timing test
  with mutation correctness behavioural test
- Ran `./quality.sh` — all formatting, linting, type-checking, and 3291 tests
  pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)