### PR TITLE
Fix: Backprop: Reduce generational dampening that slows training convergence (#1436)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.2",
+  "version": "0.312.3",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1436.md
+++ b/docs/pr-summary-1436.md
@@ -1,0 +1,46 @@
+## Summary
+
+Reduce generational dampening in backpropagation that was slowing training
+convergence. Closes #1436.
+
+The `config.generations` parameter was creating excessive weight and bias
+inertia by blending accumulated gradients with too many copies of the original
+value. When generations was high (default random 1-100), the network was biased
+towards its original weights/biases and slow to adapt.
+
+### Changes
+
+1. **Cap effective generations** in `Weight.ts` and `Bias.ts` to at most 2x the
+   actual sample count. This ensures the gradient signal always has meaningful
+   influence regardless of the configured generations value.
+
+2. **Reduce default generations range** from 1-100 to 1-10 in
+   `BackPropagation.ts`. This reduces the baseline dampening even before the cap
+   takes effect.
+
+3. **Update existing test** in `Generation.ts` to reflect the new expected
+   weight value with reduced dampening (weight moves further toward gradient
+   target).
+
+## Evidence
+
+This is a backend/algorithm change with no visual output. Evidence is provided
+through unit tests that verify the reduced dampening behaviour:
+
+- Tests confirm high generations (100) no longer overwhelms 10+ gradient samples
+- Tests confirm the ratio of adjustment between low-gen and high-gen configs is
+  bounded (high-gen achieves at least 25% of low-gen adjustment)
+- All 3597 existing tests continue to pass
+
+## Test Plan
+
+- Added `test/propagate/GenerationalDampening.ts` with 8 new tests:
+  - `calculateWeight - high generations does not overwhelm gradient signal`
+  - `calculateWeight - dampening cap limits generational inertia`
+  - `calculateWeight - generations=0 still works correctly`
+  - `calculateBias - high generations does not overwhelm gradient signal`
+  - `calculateBias - dampening cap limits generational inertia`
+  - `calculateBias - generations=0 still works correctly`
+  - `createBackPropagationConfig - default generations is capped at reasonable value`
+  - `createBackPropagationConfig - explicit generations above cap is still respected`
+- Updated `test/propagate/Generation.ts` expected weight value to reflect reduced dampening

--- a/docs/pr-summary-1436.md
+++ b/docs/pr-summary-1436.md
@@ -43,4 +43,5 @@ through unit tests that verify the reduced dampening behaviour:
   - `calculateBias - generations=0 still works correctly`
   - `createBackPropagationConfig - default generations is capped at reasonable value`
   - `createBackPropagationConfig - explicit generations above cap is still respected`
-- Updated `test/propagate/Generation.ts` expected weight value to reflect reduced dampening
+- Updated `test/propagate/Generation.ts` expected weight value to reflect
+  reduced dampening

--- a/src/propagate/BackPropagation.ts
+++ b/src/propagate/BackPropagation.ts
@@ -10,8 +10,10 @@ export type BackPropagationArguments = {
   disableRandomSamples: boolean;
 
   /**
-   * The amount of previous generations if not set it'll be a random number between 1-100.
-   * The higher number of generations the lower the learning rate
+   * The amount of previous generations if not set it'll be a random number between 1-10.
+   * The higher number of generations the more dampening applied to weight/bias updates.
+   * Issue #1436: Reduced from 1-100 and capped in weight/bias calculation to
+   * prevent excessive inertia that slows training convergence.
    */
   generations: number;
 
@@ -82,8 +84,10 @@ export function createBackPropagationConfig(
   const config: BackPropagationArguments = {
     disableRandomSamples: options?.disableRandomSamples ?? false,
 
+    // Issue #1436: Reduce default range from 1-100 to 1-10 to avoid
+    // excessive generational dampening that slows training convergence.
     generations: Math.max(
-      options?.generations ?? Math.floor(rng.random() * 100) + 1,
+      options?.generations ?? Math.floor(rng.random() * 10) + 1,
       0,
     ),
 

--- a/src/propagate/Bias.ts
+++ b/src/propagate/Bias.ts
@@ -83,9 +83,16 @@ export function calculateBias(
     const ns = neuron.creature.state.node(neuron.index);
 
     if (!ns.noChange && ns.count) {
+      // Issue #1436: Cap effective generations to avoid overwhelming the
+      // gradient signal. Without this cap, high config.generations values
+      // create excessive bias inertia that slows convergence.
+      const effectiveGenerations = Math.min(
+        config.generations,
+        ns.count * 2,
+      );
       const totalBias = ns.totalAdjustedBias +
-        (neuron.bias * config.generations);
-      const samples = ns.count + config.generations;
+        (neuron.bias * effectiveGenerations);
+      const samples = ns.count + effectiveGenerations;
 
       const adjustedBias = totalBias / samples;
 

--- a/src/propagate/Weight.ts
+++ b/src/propagate/Weight.ts
@@ -127,7 +127,15 @@ export function calculateWeight(
         positiveWeight * cs.countPositiveActivations +
         negativeWeight * cs.countNegativeActivations;
 
-      const generations = config.generations + cs.count - totalActivationCount;
+      // Issue #1436: Cap effective generations to avoid overwhelming the
+      // gradient signal. Without this cap, high config.generations values
+      // create excessive weight inertia that slows convergence.
+      const rawGenerations = config.generations + cs.count -
+        totalActivationCount;
+      const generations = Math.min(
+        rawGenerations,
+        totalActivationCount * 2,
+      );
       const totalGenerationalWeight = c.weight * generations;
 
       // Blend adjusted and generational weights.

--- a/test/propagate/Generation.ts
+++ b/test/propagate/Generation.ts
@@ -127,5 +127,8 @@ Deno.test("Generation Weight", () => {
     config2,
   );
 
-  assertAlmostEquals(w2, 0.92, 0.1, `Weight: ${w2.toFixed(3)}`);
+  // Issue #1436: With generational dampening cap, effective generations is
+  // min(10, 1*2) = 2, so the weight moves further from the original (1.0)
+  // toward the gradient target (~0.1). averageWeight = (0.1+2.0)/3 = 0.7
+  assertAlmostEquals(w2, 0.7, 0.1, `Weight: ${w2.toFixed(3)}`);
 });

--- a/test/propagate/GenerationalDampening.ts
+++ b/test/propagate/GenerationalDampening.ts
@@ -1,0 +1,288 @@
+/**
+ * Issue #1436 - Tests for reduced generational dampening that slows training
+ * convergence. Verifies that the generational dampening factor is capped so
+ * that high config.generations values do not overwhelm the gradient signal.
+ */
+import { assertEquals, assertGreater, assertLess } from "@std/assert";
+import type { CreatureTrace } from "../../src/architecture/CreatureInterfaces.ts";
+import { Creature } from "../../src/Creature.ts";
+import {
+  createBackPropagationConfig,
+} from "../../src/propagate/BackPropagation.ts";
+import { accumulateBias, calculateBias } from "../../src/propagate/Bias.ts";
+import { SynapseState } from "../../src/propagate/SynapseState.ts";
+import {
+  accumulateWeight,
+  calculateWeight,
+} from "../../src/propagate/Weight.ts";
+import type { Synapse } from "../../src/architecture/Synapse.ts";
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function fakeSynapse(weight: number): Synapse {
+  return { weight, from: 0, to: 1 } as Synapse;
+}
+
+function makeCreature(bias: number) {
+  const creatureJSON: CreatureTrace = {
+    neurons: [
+      {
+        type: "output",
+        squash: "IDENTITY",
+        uuid: "output-0",
+        bias,
+        trace: {
+          count: 0,
+          hintValue: 0,
+          totalBias: 0,
+          totalAdjustedBias: 0,
+          minimumActivation: 0,
+          maximumActivation: 1,
+        },
+      },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "output-0",
+        weight: 1,
+        trace: {
+          count: 0,
+          totalPositiveActivation: 0,
+          totalNegativeActivation: 0,
+          countNegativeActivations: 0,
+          countPositiveActivations: 0,
+          totalPositiveAdjustedValue: 0,
+          totalNegativeAdjustedValue: 0,
+        },
+      },
+    ],
+    input: 1,
+    output: 1,
+  };
+  return Creature.fromJSON(creatureJSON);
+}
+
+// ---------------------------------------------------------------------------
+// Weight dampening cap tests
+// ---------------------------------------------------------------------------
+
+Deno.test("calculateWeight - high generations does not overwhelm gradient signal", () => {
+  // With high generations (100) and many samples, the gradient signal
+  // should still have a meaningful impact on the weight.
+  const config = createBackPropagationConfig({
+    generations: 100,
+    learningRate: 1,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+  const cs = new SynapseState();
+  const synapse = fakeSynapse(1.0);
+
+  // Accumulate 10 samples all pointing toward weight=3.0
+  for (let i = 0; i < 10; i++) {
+    accumulateWeight(1.0, cs, 3.0, 1.0, config);
+  }
+
+  const result = calculateWeight(cs, synapse, config);
+
+  // Issue #1436: With the cap, 10 samples should have a noticeable effect
+  // even with generations=100. The result should move meaningfully toward
+  // the target, not be stuck near the original weight of 1.0.
+  assertGreater(
+    result,
+    1.1,
+    "With 10 samples, weight should move noticeably from original 1.0",
+  );
+});
+
+Deno.test("calculateWeight - dampening cap limits generational inertia", () => {
+  // Compare weight adjustment with low vs high generations.
+  // After the fix, the difference should be bounded — high generations
+  // should not cause dramatically more inertia than moderate values.
+  const configLow = createBackPropagationConfig({
+    generations: 2,
+    learningRate: 1,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+  const configHigh = createBackPropagationConfig({
+    generations: 100,
+    learningRate: 1,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+
+  // Accumulate 20 samples pointing toward weight=5.0
+  const csLow = new SynapseState();
+  const csHigh = new SynapseState();
+  const synapse = fakeSynapse(1.0);
+
+  for (let i = 0; i < 20; i++) {
+    accumulateWeight(1.0, csLow, 5.0, 1.0, configLow);
+    accumulateWeight(1.0, csHigh, 5.0, 1.0, configHigh);
+  }
+
+  const resultLow = calculateWeight(csLow, synapse, configLow);
+  const resultHigh = calculateWeight(csHigh, synapse, configHigh);
+
+  // Both should move toward 5.0. With the cap, the high-generations result
+  // should not be dramatically worse than the low-generations result.
+  assertGreater(resultHigh, 1.0, "High gens should still move toward target");
+  // The ratio of adjustment should be bounded — high gens should achieve
+  // at least 25% of the adjustment that low gens achieves.
+  const adjustmentLow = resultLow - 1.0;
+  const adjustmentHigh = resultHigh - 1.0;
+  assertGreater(
+    adjustmentHigh / adjustmentLow,
+    0.25,
+    "High generations should not reduce adjustment by more than 4x vs low generations",
+  );
+});
+
+Deno.test("calculateWeight - generations=0 still works correctly", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    maximumWeightAdjustmentScale: 100,
+    limitWeightScale: 100_000,
+  });
+  const cs = new SynapseState();
+  const synapse = fakeSynapse(1.0);
+
+  accumulateWeight(1.0, cs, 3.0, 1.0, config);
+
+  const result = calculateWeight(cs, synapse, config);
+
+  // With generations=0, the result should be entirely driven by samples
+  assertGreater(result, 1.0, "Should move toward target weight of 3.0");
+});
+
+// ---------------------------------------------------------------------------
+// Bias dampening cap tests
+// ---------------------------------------------------------------------------
+
+Deno.test("calculateBias - high generations does not overwhelm gradient signal", () => {
+  const creature = makeCreature(1.0);
+  const outputNode = creature.neurons.find((n) => n.type === "output")!;
+
+  const config = createBackPropagationConfig({
+    generations: 100,
+    learningRate: 1,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 100_000,
+  });
+
+  const ns = creature.state.node(outputNode.index);
+
+  // Accumulate 10 samples all pointing toward bias=-2.0
+  // (targetPreActivation=targetBias-currentBias+preActivation pattern)
+  for (let i = 0; i < 10; i++) {
+    accumulateBias(ns, -2.0, 1.0, 1.0, config);
+  }
+
+  const result = calculateBias(outputNode, config);
+
+  // Issue #1436: With the cap, 10 samples should have a noticeable effect
+  // even with generations=100.
+  assertLess(
+    result,
+    0.9,
+    "With 10 samples, bias should move noticeably from original 1.0",
+  );
+});
+
+Deno.test("calculateBias - dampening cap limits generational inertia", () => {
+  // Compare bias adjustment with low vs high generations
+  const configLow = createBackPropagationConfig({
+    generations: 2,
+    learningRate: 1,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 100_000,
+  });
+  const configHigh = createBackPropagationConfig({
+    generations: 100,
+    learningRate: 1,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 100_000,
+  });
+
+  const creatureLow = makeCreature(0.0);
+  const creatureHigh = makeCreature(0.0);
+  const outputLow = creatureLow.neurons.find((n) => n.type === "output")!;
+  const outputHigh = creatureHigh.neurons.find((n) => n.type === "output")!;
+
+  const nsLow = creatureLow.state.node(outputLow.index);
+  const nsHigh = creatureHigh.state.node(outputHigh.index);
+
+  // Accumulate 20 samples pointing toward bias=5.0
+  for (let i = 0; i < 20; i++) {
+    accumulateBias(nsLow, 5.0, 0.0, 0.0, configLow);
+    accumulateBias(nsHigh, 5.0, 0.0, 0.0, configHigh);
+  }
+
+  const resultLow = calculateBias(outputLow, configLow);
+  const resultHigh = calculateBias(outputHigh, configHigh);
+
+  // Both should move toward 5.0
+  assertGreater(resultHigh, 0, "High gens should still move toward target");
+  // The high-gens adjustment should be at least 25% of the low-gens adjustment
+  const adjustmentLow = resultLow;
+  const adjustmentHigh = resultHigh;
+  assertGreater(
+    adjustmentHigh / adjustmentLow,
+    0.25,
+    "High generations should not reduce bias adjustment by more than 4x",
+  );
+});
+
+Deno.test("calculateBias - generations=0 still works correctly", () => {
+  const creature = makeCreature(1.0);
+  const outputNode = creature.neurons.find((n) => n.type === "output")!;
+
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    maximumBiasAdjustmentScale: 100,
+    limitBiasScale: 100_000,
+  });
+
+  const ns = creature.state.node(outputNode.index);
+  accumulateBias(ns, -2.0, 1.0, 1.0, config);
+
+  const result = calculateBias(outputNode, config);
+
+  // With generations=0, the result should be driven entirely by samples
+  assertLess(result, 1.0, "Should move toward target bias");
+});
+
+// ---------------------------------------------------------------------------
+// Default generations cap configuration tests
+// ---------------------------------------------------------------------------
+
+Deno.test("createBackPropagationConfig - default generations is capped at reasonable value", () => {
+  // Issue #1436: The default generations should not be excessively high.
+  // Run multiple times to ensure random values are capped.
+  for (let i = 0; i < 20; i++) {
+    const config = createBackPropagationConfig();
+    // Generations should be capped at a reasonable value (10)
+    assertLess(
+      config.generations,
+      11,
+      `Default generations should be capped at 10, got ${config.generations}`,
+    );
+    assertEquals(
+      config.generations >= 0,
+      true,
+      "Generations should be non-negative",
+    );
+  }
+});
+
+Deno.test("createBackPropagationConfig - explicit generations above cap is still respected", () => {
+  // Users can still set high generations explicitly
+  const config = createBackPropagationConfig({ generations: 50 });
+  assertEquals(config.generations, 50);
+});


### PR DESCRIPTION
## Summary

Reduce generational dampening in backpropagation that was slowing training
convergence. Closes #1436.

The `config.generations` parameter was creating excessive weight and bias
inertia by blending accumulated gradients with too many copies of the original
value. When generations was high (default random 1-100), the network was biased
towards its original weights/biases and slow to adapt.

### Changes

1. **Cap effective generations** in `Weight.ts` and `Bias.ts` to at most 2x the
   actual sample count. This ensures the gradient signal always has meaningful
   influence regardless of the configured generations value.

2. **Reduce default generations range** from 1-100 to 1-10 in
   `BackPropagation.ts`. This reduces the baseline dampening even before the cap
   takes effect.

3. **Update existing test** in `Generation.ts` to reflect the new expected
   weight value with reduced dampening (weight moves further toward gradient
   target).

## Evidence

This is a backend/algorithm change with no visual output. Evidence is provided
through unit tests that verify the reduced dampening behaviour:

- Tests confirm high generations (100) no longer overwhelms 10+ gradient samples
- Tests confirm the ratio of adjustment between low-gen and high-gen configs is
  bounded (high-gen achieves at least 25% of low-gen adjustment)
- All 3597 existing tests continue to pass

## Test Plan

- Added `test/propagate/GenerationalDampening.ts` with 8 new tests:
  - `calculateWeight - high generations does not overwhelm gradient signal`
  - `calculateWeight - dampening cap limits generational inertia`
  - `calculateWeight - generations=0 still works correctly`
  - `calculateBias - high generations does not overwhelm gradient signal`
  - `calculateBias - dampening cap limits generational inertia`
  - `calculateBias - generations=0 still works correctly`
  - `createBackPropagationConfig - default generations is capped at reasonable value`
  - `createBackPropagationConfig - explicit generations above cap is still respected`
- Updated `test/propagate/Generation.ts` expected weight value to reflect
  reduced dampening

> **Screenshot evidence not provided**: This appears to be a UI-related change but no screenshots were included. For UI changes, use Playwright MCP to capture screenshots as evidence: `browser_navigate` to open a relevant URL, then `browser_take_screenshot` to save to `docs/evidence/`.

---

## Automated Fix Details
This PR addresses issue #1436: **Backprop: Reduce generational dampening that slows training convergence**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1436