### PR TITLE
Fix: Backprop: Add bias-weight coordination to prevent opposing updates (#1471)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.4",
+  "version": "0.312.5",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -217,6 +217,8 @@
     "favor",
     "topo",
     "checkpointing",
-    "stochasticity"
+    "stochasticity",
+    "Δeffect",
+    "Δweight"
   ]
 }

--- a/docs/pr-summary-1471.md
+++ b/docs/pr-summary-1471.md
@@ -4,32 +4,55 @@ Closes #1471
 
 ## Summary
 
-During backpropagation, bias and weight updates are computed independently. When these updates have opposing net effects on the neuron's pre-activation value, they can cancel each other out, wasting gradient computation. This PR adds a coordination step that detects and mitigates such opposing effects.
+During backpropagation, bias and weight updates are computed independently. When
+these updates have opposing net effects on the neuron's pre-activation value,
+they can cancel each other out, wasting gradient computation. This PR adds a
+coordination step that detects and mitigates such opposing effects.
 
 ## Key Design Decisions
 
 ### Effect-based comparison (not raw deltas)
-The actual effect of a weight change depends on the source neuron's activation: `effect = weight_delta * activation`. A weight decrease with a negative activation actually *increases* the output (aligned with a bias increase). The coordination compares `biasDelta` against `sum(weightDelta * activation)` to correctly identify opposing effects.
+
+The actual effect of a weight change depends on the source neuron's activation:
+`effect = weight_delta * activation`. A weight decrease with a negative
+activation actually _increases_ the output (aligned with a bias increase). The
+coordination compares `biasDelta` against `sum(weightDelta * activation)` to
+correctly identify opposing effects.
 
 ### Conservative threshold (0.95)
-Coordination only triggers when the smaller opposing force is at least 95% of the larger (near-perfect cancellation). This avoids interfering with gradient updates where opposing forces are unequal enough to still produce a meaningful net change.
+
+Coordination only triggers when the smaller opposing force is at least 95% of
+the larger (near-perfect cancellation). This avoids interfering with gradient
+updates where opposing forces are unequal enough to still produce a meaningful
+net change.
 
 ### Reduce both sides proportionally
-When cancellation is detected, both the bias and weight changes are reduced by `reductionFactor` (default 0.2). This avoids asymmetry where reducing only one side could push the neuron in the wrong direction during early training.
+
+When cancellation is detected, both the bias and weight changes are reduced by
+`reductionFactor` (default 0.2). This avoids asymmetry where reducing only one
+side could push the neuron in the wrong direction during early training.
 
 ### Minimum sample count
-Coordination requires at least `max(batchSize, 4)` accumulated samples per synapse before activating. With too few samples, gradient signals are too noisy for coordination to be reliable.
+
+Coordination requires at least `max(batchSize, 4)` accumulated samples per
+synapse before activating. With too few samples, gradient signals are too noisy
+for coordination to be reliable.
 
 ## Changes
 
-- **New**: `src/propagate/BackpropCoordination.ts` - Core coordination module with `coordinateBackpropUpdates()` function
-- **New**: `test/propagate/BackpropCoordination.ts` - 20 unit tests covering all coordination scenarios
-- **Modified**: `src/propagate/BackPropagation.ts` - Added `biasWeightCoordinationFactor` config option (default 0.2, range 0..1)
-- **Modified**: `src/architecture/Neuron.ts` - Integrated coordination into `propagateUpdate()`
+- **New**: `src/propagate/BackpropCoordination.ts` - Core coordination module
+  with `coordinateBackpropUpdates()` function
+- **New**: `test/propagate/BackpropCoordination.ts` - 20 unit tests covering all
+  coordination scenarios
+- **Modified**: `src/propagate/BackPropagation.ts` - Added
+  `biasWeightCoordinationFactor` config option (default 0.2, range 0..1)
+- **Modified**: `src/architecture/Neuron.ts` - Integrated coordination into
+  `propagateUpdate()`
 
 ## Test plan
 
-- [x] 20 unit tests for coordination logic (opposing, aligned, threshold boundary, activations, edge cases)
+- [x] 20 unit tests for coordination logic (opposing, aligned, threshold
+      boundary, activations, edge cases)
 - [x] All 3626 existing tests pass
 - [x] Convergence tests (Constants, SingleNeuron) pass
 - [x] XNOR evolve integration test passes

--- a/docs/pr-summary-1471.md
+++ b/docs/pr-summary-1471.md
@@ -1,0 +1,36 @@
+# Backprop: Add bias-weight coordination to prevent opposing updates (#1471)
+
+Closes #1471
+
+## Summary
+
+During backpropagation, bias and weight updates are computed independently. When these updates have opposing net effects on the neuron's pre-activation value, they can cancel each other out, wasting gradient computation. This PR adds a coordination step that detects and mitigates such opposing effects.
+
+## Key Design Decisions
+
+### Effect-based comparison (not raw deltas)
+The actual effect of a weight change depends on the source neuron's activation: `effect = weight_delta * activation`. A weight decrease with a negative activation actually *increases* the output (aligned with a bias increase). The coordination compares `biasDelta` against `sum(weightDelta * activation)` to correctly identify opposing effects.
+
+### Conservative threshold (0.95)
+Coordination only triggers when the smaller opposing force is at least 95% of the larger (near-perfect cancellation). This avoids interfering with gradient updates where opposing forces are unequal enough to still produce a meaningful net change.
+
+### Reduce both sides proportionally
+When cancellation is detected, both the bias and weight changes are reduced by `reductionFactor` (default 0.2). This avoids asymmetry where reducing only one side could push the neuron in the wrong direction during early training.
+
+### Minimum sample count
+Coordination requires at least `max(batchSize, 4)` accumulated samples per synapse before activating. With too few samples, gradient signals are too noisy for coordination to be reliable.
+
+## Changes
+
+- **New**: `src/propagate/BackpropCoordination.ts` - Core coordination module with `coordinateBackpropUpdates()` function
+- **New**: `test/propagate/BackpropCoordination.ts` - 20 unit tests covering all coordination scenarios
+- **Modified**: `src/propagate/BackPropagation.ts` - Added `biasWeightCoordinationFactor` config option (default 0.2, range 0..1)
+- **Modified**: `src/architecture/Neuron.ts` - Integrated coordination into `propagateUpdate()`
+
+## Test plan
+
+- [x] 20 unit tests for coordination logic (opposing, aligned, threshold boundary, activations, edge cases)
+- [x] All 3626 existing tests pass
+- [x] Convergence tests (Constants, SingleNeuron) pass
+- [x] XNOR evolve integration test passes
+- [x] quality.sh passes (fmt, lint, type-check, tests)

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -46,6 +46,7 @@ import {
   adjustedWeight,
   calculateWeight,
 } from "../propagate/Weight.ts";
+import { coordinateBackpropUpdates } from "../propagate/BackpropCoordination.ts";
 import type { DiscoverRecord } from "./ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { NeuronExport, NeuronInternal } from "./NeuronInterfaces.ts";
 import { noChangePropagate } from "./NoChangePropagate.ts";
@@ -589,16 +590,61 @@ export class Neuron implements TagsInterface, NeuronInternal {
   propagateUpdate(config: BackPropagationConfig) {
     const state = this.creature.state;
     const toList = this.creature.inwardConnections(this.index);
-    for (let i = toList.length; i--;) {
+
+    // Issue #1471: Calculate candidate weights and bias, then coordinate
+    // opposing changes before applying them. We collect the source
+    // activations so the coordination can compare the actual effect
+    // of weight changes (delta × activation) against bias changes.
+    //
+    // Coordination is skipped when the factor is 1.0 (no reduction)
+    // or when there are too few accumulated samples for reliable
+    // cancellation detection.
+    const coordinationEnabled = config.biasWeightCoordinationFactor < 1;
+
+    const currentWeights: number[] = [];
+    const candidateWeights: number[] = [];
+    const sourceActivations: number[] = [];
+    let minSynapseCount = Infinity;
+    for (let i = 0; i < toList.length; i++) {
       const c = toList[i];
       const cs = state.connection(c.from, c.to);
-      const aWeight = calculateWeight(cs, c, config);
-      c.weight = aWeight;
+      currentWeights.push(c.weight);
+      candidateWeights.push(calculateWeight(cs, c, config));
+      if (coordinationEnabled) {
+        sourceActivations.push(state.activations[c.from]);
+        if (cs.count < minSynapseCount) minSynapseCount = cs.count;
+      }
     }
 
-    const aBias = calculateBias(this, config);
+    const candidateBias = calculateBias(this, config);
 
-    this.bias = aBias;
+    // Only coordinate when we have enough accumulated samples for
+    // reliable cancellation detection. With very few samples, the
+    // gradient signals are too noisy for coordination to help.
+    // Require at least one full batch of samples.
+    const MIN_SAMPLES_FOR_COORDINATION = Math.max(config.batchSize, 4);
+    if (
+      coordinationEnabled && minSynapseCount >= MIN_SAMPLES_FOR_COORDINATION
+    ) {
+      const coordinated = coordinateBackpropUpdates(
+        this.bias,
+        candidateBias,
+        currentWeights,
+        candidateWeights,
+        sourceActivations,
+        config.biasWeightCoordinationFactor,
+      );
+
+      for (let i = 0; i < toList.length; i++) {
+        toList[i].weight = coordinated.weights[i];
+      }
+      this.bias = coordinated.bias;
+    } else {
+      for (let i = 0; i < toList.length; i++) {
+        toList[i].weight = candidateWeights[i];
+      }
+      this.bias = candidateBias;
+    }
   }
 
   /**

--- a/src/propagate/BackPropagation.ts
+++ b/src/propagate/BackPropagation.ts
@@ -71,6 +71,14 @@ export type BackPropagationArguments = {
 
   /** Number of iterations between warm restarts. Default 10, minimum 2. */
   warmRestartPeriod: number;
+
+  /**
+   * Issue #1471: Reduction factor for bias-weight coordination.
+   * When bias and weight updates oppose each other, the smaller opposing
+   * change is scaled by this factor (0..1). Default 0.2 matches fine-tuning.
+   * Set to 1.0 to disable coordination (all changes pass through).
+   */
+  biasWeightCoordinationFactor: number;
 };
 
 export type BackPropagationOptions = Partial<BackPropagationArguments>;
@@ -155,6 +163,13 @@ export function createBackPropagationConfig(
       1,
     ),
     warmRestartPeriod: Math.max(options?.warmRestartPeriod ?? 10, 2),
+    biasWeightCoordinationFactor: Math.min(
+      Math.max(
+        options?.biasWeightCoordinationFactor ?? 0.2,
+        0,
+      ),
+      1,
+    ),
   };
 
   return Object.freeze(config);

--- a/src/propagate/BackpropCoordination.ts
+++ b/src/propagate/BackpropCoordination.ts
@@ -1,0 +1,128 @@
+/**
+ * Issue #1471 - Bias-weight coordination for backpropagation.
+ *
+ * During backpropagation, bias and weight updates are computed
+ * independently. When these updates have opposing net effects on the
+ * neuron's pre-activation value, they can cancel out, wasting gradient
+ * computation. This module detects such opposing effects and reduces
+ * both changes proportionally to eliminate the cancellation while
+ * preserving the net effect direction.
+ *
+ * The key insight is that the actual effect of a weight change depends
+ * on the activation of the source neuron: Δeffect = Δweight × activation.
+ * Comparing raw weight deltas with bias deltas would be incorrect because
+ * they operate in different units. Instead, we compare bias delta against
+ * the sum of (weight delta × activation) across all synapses.
+ *
+ * Coordination only triggers when the opposing magnitudes are close
+ * enough to risk significant cancellation (ratio >= 0.95).
+ *
+ * Australian English: behaviour, optimise, normalise.
+ */
+
+/**
+ * The minimum ratio (smaller / larger) of opposing effect magnitudes
+ * required before coordination is applied. At 0.95, coordination
+ * triggers only when the smaller opposing effect is at least 95% of
+ * the larger — i.e. when near-total cancellation would occur.
+ *
+ * A very conservative threshold avoids interfering with gradient
+ * updates where the opposing forces are unequal enough to still
+ * produce a meaningful net change. Only near-perfect cancellation
+ * (where >95% of the update is wasted) triggers coordination.
+ */
+const CANCELLATION_THRESHOLD = 0.95;
+
+/**
+ * Coordinates bias and weight updates from backpropagation to prevent
+ * opposing changes from cancelling each other out.
+ *
+ * When near-perfect cancellation is detected, both the bias and weight
+ * changes are reduced proportionally by the reductionFactor. This
+ * avoids the asymmetry problem where reducing only one side could
+ * push the neuron in the wrong direction during early training.
+ *
+ * @param currentBias - The neuron's current bias before update
+ * @param candidateBias - The bias calculated by backprop
+ * @param currentWeights - Array of current synapse weights
+ * @param candidateWeights - Array of candidate weights from backprop
+ * @param activations - Array of source neuron activations for each synapse
+ * @param reductionFactor - How much of the opposing changes to
+ *   keep (0..1). Default 0.2 matches fine-tuning coordination.
+ * @returns Coordinated bias and weight values
+ */
+export function coordinateBackpropUpdates(
+  currentBias: number,
+  candidateBias: number,
+  currentWeights: readonly number[],
+  candidateWeights: readonly number[],
+  activations: readonly number[],
+  reductionFactor: number,
+): { bias: number; weights: number[] } {
+  const biasDelta = candidateBias - currentBias;
+  const biasChanged = biasDelta !== 0;
+
+  // Compute weight deltas and the net effect on pre-activation value
+  const weightDeltas: number[] = [];
+  let anyWeightChanged = false;
+  let netWeightEffect = 0;
+  for (let i = 0; i < currentWeights.length; i++) {
+    const delta = candidateWeights[i] - currentWeights[i];
+    weightDeltas.push(delta);
+    if (delta !== 0) {
+      anyWeightChanged = true;
+      // The actual effect of this weight change on the neuron's
+      // pre-activation value is delta × activation
+      netWeightEffect += delta * activations[i];
+    }
+  }
+
+  // No coordination needed if only one side changed (or neither)
+  if (!biasChanged || !anyWeightChanged) {
+    return {
+      bias: candidateBias,
+      weights: candidateWeights.slice() as number[],
+    };
+  }
+
+  // Check if bias delta and net weight effect oppose each other
+  const biasSign = Math.sign(biasDelta);
+  const effectSign = Math.sign(netWeightEffect);
+
+  if (biasSign !== 0 && effectSign !== 0 && biasSign === -effectSign) {
+    const biasAbs = Math.abs(biasDelta);
+    const effectAbs = Math.abs(netWeightEffect);
+    const smaller = Math.min(biasAbs, effectAbs);
+    const larger = Math.max(biasAbs, effectAbs);
+
+    // Only coordinate when the smaller opposing force is significant
+    // relative to the larger — i.e. when cancellation would waste
+    // a meaningful portion of the gradient update.
+    // Use a small epsilon for floating-point comparison tolerance.
+    const EPSILON = 1e-10;
+    if (
+      larger > 0 &&
+      (smaller / larger) >= CANCELLATION_THRESHOLD - EPSILON
+    ) {
+      // Reduce both sides proportionally to eliminate cancellation
+      // without creating asymmetry that could push the neuron in
+      // the wrong direction during early training.
+      const adjustedWeights = currentWeights.map((w, i) => {
+        const delta = weightDeltas[i];
+        if (delta === 0) return w;
+        return w + delta * reductionFactor;
+      });
+      return {
+        bias: currentBias + biasDelta * reductionFactor,
+        weights: adjustedWeights,
+      };
+    }
+  }
+
+  // Aligned, one side is zero, or opposing but not close enough to
+  // risk significant cancellation — pass through unchanged.
+  return {
+    bias: candidateBias,
+    weights: candidateWeights.slice() as number[],
+  };
+}

--- a/test/propagate/BackpropCoordination.ts
+++ b/test/propagate/BackpropCoordination.ts
@@ -1,0 +1,399 @@
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { coordinateBackpropUpdates } from "../../src/propagate/BackpropCoordination.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+Deno.test(
+  "coordinateBackpropUpdates - no changes passes through",
+  () => {
+    const result = coordinateBackpropUpdates(
+      0.5, // currentBias
+      0.5, // candidateBias (unchanged)
+      [0.3, -0.2], // currentWeights
+      [0.3, -0.2], // candidateWeights (unchanged)
+      [1.0, 1.0], // activations
+      0.2, // reductionFactor
+    );
+    assertEquals(result.bias, 0.5);
+    assertEquals(result.weights, [0.3, -0.2]);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - bias-only change passes through",
+  () => {
+    const result = coordinateBackpropUpdates(
+      0.5,
+      0.7, // bias changed
+      [0.3],
+      [0.3], // weights unchanged
+      [1.0], // activations
+      0.2,
+    );
+    assertEquals(result.bias, 0.7, "Bias-only change should pass through");
+    assertEquals(result.weights, [0.3]);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - weight-only change passes through",
+  () => {
+    const result = coordinateBackpropUpdates(
+      0.5,
+      0.5, // bias unchanged
+      [0.3],
+      [0.5], // weight changed
+      [1.0], // activations
+      0.2,
+    );
+    assertEquals(result.bias, 0.5);
+    assertEquals(
+      result.weights,
+      [0.5],
+      "Weight-only change should pass through",
+    );
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - aligned changes pass through unchanged",
+  () => {
+    // Bias +0.3, net weight effect = +0.5 (same direction as bias)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.3, // bias +0.3
+      [0.5, 0.2],
+      [0.8, 0.4], // weights +0.3 and +0.2
+      [1.0, 1.0], // all activations positive
+      0.2,
+    );
+    assertEquals(result.bias, 1.3, "Aligned bias should pass through");
+    assertEquals(
+      result.weights,
+      [0.8, 0.4],
+      "Aligned weights should pass through",
+    );
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - negative activation flips effect direction",
+  () => {
+    // Bias +0.5, weight delta -0.5 but activation is -1.0
+    // Net weight effect = (-0.5) * (-1.0) = +0.5 (aligned with bias!)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.5, // bias +0.5
+      [0.5],
+      [0.0], // weight -0.5
+      [-1.0], // negative activation flips effect
+      0.2,
+    );
+
+    // Both should pass through (aligned when accounting for activation)
+    assertEquals(result.bias, 1.5);
+    assertEquals(result.weights, [0.0]);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - equal opposing effects triggers coordination",
+  () => {
+    // Bias +0.5, weight delta -0.5, activation 1.0
+    // Net effect = -0.5 (perfect opposition, ratio 1.0 >= 0.95)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.5, // bias +0.5
+      [0.5],
+      [0.0], // weight -0.5
+      [1.0], // activation
+      0.2,
+    );
+
+    // Both sides reduced: bias 1.0 + 0.5 * 0.2 = 1.1
+    assertAlmostEquals(result.bias, 1.1, 1e-10);
+    // Weight also reduced: 0.5 + (-0.5) * 0.2 = 0.4
+    assertAlmostEquals(result.weights[0], 0.4, 1e-10);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - reduces both sides with near-perfect cancellation",
+  () => {
+    // Bias +0.96, weight effect = -1.0 (ratio 0.96/1.0 = 0.96 >= 0.95)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.96, // bias +0.96 (smaller opposing effect)
+      [1.0],
+      [0.0], // weight -1.0 (larger)
+      [1.0], // activation
+      0.2,
+    );
+
+    // Bias reduced: 1.0 + 0.96 * 0.2 = 1.192
+    assertAlmostEquals(result.bias, 1.192, 1e-10);
+    // Weight also reduced: 1.0 + (-1.0) * 0.2 = 0.8
+    assertAlmostEquals(result.weights[0], 0.8, 1e-10);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - reduces both sides when weights are smaller",
+  () => {
+    // Bias -1.0, weight effect = +0.97 (ratio 0.97/1.0 = 0.97 >= 0.95)
+    const result = coordinateBackpropUpdates(
+      2.0,
+      1.0, // bias -1.0 (larger)
+      [0.5],
+      [1.47], // weight +0.97, activation 1.0, effect = +0.97
+      [1.0], // activation
+      0.2,
+    );
+
+    // Bias reduced: 2.0 + (-1.0) * 0.2 = 1.8
+    assertAlmostEquals(result.bias, 1.8, 1e-10);
+    // Weight reduced: 0.5 + 0.97 * 0.2 = 0.694
+    assertAlmostEquals(result.weights[0], 0.694, 1e-10);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - skips coordination when ratio below threshold",
+  () => {
+    // Bias +0.5, weight effect = -1.0 (ratio 0.5/1.0 = 0.5, well below 0.95)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.5, // bias +0.5
+      [1.0],
+      [0.0], // weight -1.0
+      [1.0], // activation
+      0.2,
+    );
+
+    // Both should pass through (ratio below threshold)
+    assertEquals(result.bias, 1.5);
+    assertEquals(result.weights, [0.0]);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - skips when opposing effects are unequal",
+  () => {
+    // Bias +0.5, weight effect = -0.6 (ratio 0.5/0.6 = 0.83, below 0.95)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.5,
+      [0.8, 0.5],
+      [0.5, 0.2], // weights -0.3 and -0.3, effect = -0.6
+      [1.0, 1.0],
+      0.2,
+    );
+
+    // Both should pass through (ratio 0.83 < 0.95)
+    assertEquals(result.bias, 1.5);
+    assertEquals(result.weights, [0.5, 0.2]);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - configurable reduction factor",
+  () => {
+    // With reductionFactor 0.5, both sides keep 50%
+    // Bias +0.5, weight effect = -0.5 (ratio 1.0 >= 0.95)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.5, // bias +0.5
+      [0.5],
+      [0.0], // weight -0.5
+      [1.0], // activation
+      0.5,
+    );
+
+    // Bias reduced: 1.0 + 0.5 * 0.5 = 1.25
+    assertAlmostEquals(result.bias, 1.25, 1e-10);
+    // Weight reduced: 0.5 + (-0.5) * 0.5 = 0.25
+    assertAlmostEquals(result.weights[0], 0.25, 1e-10);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - zero reduction factor eliminates both changes",
+  () => {
+    // Ratio 1.0 (equal opposing), reductionFactor 0
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.5, // bias +0.5
+      [0.5],
+      [0.0], // weight -0.5
+      [1.0], // activation
+      0.0, // eliminate both
+    );
+
+    // Both deltas zeroed: stays at originals
+    assertAlmostEquals(result.bias, 1.0, 1e-10);
+    assertAlmostEquals(result.weights[0], 0.5, 1e-10);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - full reduction factor (1.0) preserves everything",
+  () => {
+    // Ratio 1.0, reductionFactor 1.0
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.5, // bias +0.5
+      [0.5],
+      [0.0], // weight -0.5
+      [1.0], // activation
+      1.0, // keep everything
+    );
+
+    // Both pass through (reduction factor 1.0 = no reduction)
+    assertAlmostEquals(result.bias, 1.5, 1e-10);
+    assertAlmostEquals(result.weights[0], 0.0, 1e-10);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - unchanged weights in mixed array preserved",
+  () => {
+    // Bias -1.0, weight effects +0.3, 0.0, +0.67 = net +0.97
+    // Ratio 0.97/1.0 = 0.97 >= 0.95 (triggers coordination)
+    const result = coordinateBackpropUpdates(
+      2.0,
+      1.0, // bias -1.0
+      [0.5, 0.3, 0.1],
+      [0.8, 0.3, 0.77], // +0.3, 0.0, +0.67
+      [1.0, 1.0, 1.0], // activations
+      0.2,
+    );
+
+    // Bias reduced: 2.0 + (-1.0) * 0.2 = 1.8
+    assertAlmostEquals(result.bias, 1.8, 1e-10);
+    // Unchanged weight [1] should remain unchanged
+    assertEquals(result.weights[1], 0.3);
+    // Changed weights should be reduced
+    assertAlmostEquals(result.weights[0], 0.5 + 0.3 * 0.2, 1e-10); // 0.56
+    assertAlmostEquals(result.weights[2], 0.1 + 0.67 * 0.2, 1e-10); // 0.234
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - empty weights array with bias change",
+  () => {
+    const result = coordinateBackpropUpdates(
+      0.5,
+      0.8,
+      [],
+      [],
+      [], // empty activations
+      0.2,
+    );
+    assertEquals(
+      result.bias,
+      0.8,
+      "Bias should pass through with empty weights",
+    );
+    assertEquals(result.weights.length, 0);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - all results are finite",
+  () => {
+    const result = coordinateBackpropUpdates(
+      0.5,
+      0.7,
+      [0.0, -0.5, 1.0],
+      [0.1, -0.3, 0.8],
+      [1.0, 0.5, -0.3], // activations
+      0.2,
+    );
+    assert(Number.isFinite(result.bias), "Bias should be finite");
+    for (const w of result.weights) {
+      assert(Number.isFinite(w), `Weight should be finite: ${w}`);
+    }
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - exactly at threshold triggers coordination",
+  () => {
+    // Bias +0.95, weight effect = -1.0 (ratio 0.95/1.0 = 0.95)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.95, // bias +0.95 (smaller)
+      [1.0],
+      [0.0], // weight -1.0 (larger effect)
+      [1.0], // activation
+      0.2,
+    );
+
+    // Should trigger coordination: both reduced
+    // Bias: 1.0 + 0.95 * 0.2 = 1.19
+    assertAlmostEquals(result.bias, 1.19, 1e-10);
+    // Weight: 1.0 + (-1.0) * 0.2 = 0.8
+    assertAlmostEquals(result.weights[0], 0.8, 1e-10);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - just below threshold skips coordination",
+  () => {
+    // Bias +0.94, weight effect = -1.0 (ratio 0.94/1.0 = 0.94 < 0.95)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.94, // bias +0.94 (smaller)
+      [1.0],
+      [0.0], // weight -1.0 (larger effect)
+      [1.0], // activation
+      0.2,
+    );
+
+    // Should NOT trigger coordination: pass through
+    assertAlmostEquals(result.bias, 1.94, 1e-10);
+    assertEquals(result.weights, [0.0]);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - activation magnitude scales effect correctly",
+  () => {
+    // Bias +0.5, weight delta -2.0, but activation is only 0.25
+    // Net weight effect = (-2.0) * 0.25 = -0.5 (opposing, ratio 1.0 >= 0.95)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.5, // bias +0.5
+      [1.0],
+      [-1.0], // weight delta = -2.0
+      [0.25], // small activation scales effect down
+      0.2,
+    );
+
+    // Should trigger coordination (equal opposing effects)
+    // Bias: 1.0 + 0.5 * 0.2 = 1.1
+    assertAlmostEquals(result.bias, 1.1, 1e-10);
+    // Weight: 1.0 + (-2.0) * 0.2 = 0.6
+    assertAlmostEquals(result.weights[0], 0.6, 1e-10);
+  },
+);
+
+Deno.test(
+  "coordinateBackpropUpdates - zero activation means no weight effect",
+  () => {
+    // Bias +0.5, weight delta -1.0, but activation is 0
+    // Net weight effect = 0 (no opposing effect)
+    const result = coordinateBackpropUpdates(
+      1.0,
+      1.5, // bias +0.5
+      [1.0],
+      [0.0], // weight delta = -1.0
+      [0.0], // zero activation
+      0.2,
+    );
+
+    // Net weight effect is 0, so no opposing — pass through
+    assertEquals(result.bias, 1.5);
+    assertEquals(result.weights, [0.0]);
+  },
+);


### PR DESCRIPTION
# Backprop: Add bias-weight coordination to prevent opposing updates (#1471)

Closes #1471

## Summary

During backpropagation, bias and weight updates are computed independently. When
these updates have opposing net effects on the neuron's pre-activation value,
they can cancel each other out, wasting gradient computation. This PR adds a
coordination step that detects and mitigates such opposing effects.

## Key Design Decisions

### Effect-based comparison (not raw deltas)

The actual effect of a weight change depends on the source neuron's activation:
`effect = weight_delta * activation`. A weight decrease with a negative
activation actually _increases_ the output (aligned with a bias increase). The
coordination compares `biasDelta` against `sum(weightDelta * activation)` to
correctly identify opposing effects.

### Conservative threshold (0.95)

Coordination only triggers when the smaller opposing force is at least 95% of
the larger (near-perfect cancellation). This avoids interfering with gradient
updates where opposing forces are unequal enough to still produce a meaningful
net change.

### Reduce both sides proportionally

When cancellation is detected, both the bias and weight changes are reduced by
`reductionFactor` (default 0.2). This avoids asymmetry where reducing only one
side could push the neuron in the wrong direction during early training.

### Minimum sample count

Coordination requires at least `max(batchSize, 4)` accumulated samples per
synapse before activating. With too few samples, gradient signals are too noisy
for coordination to be reliable.

## Changes

- **New**: `src/propagate/BackpropCoordination.ts` - Core coordination module
  with `coordinateBackpropUpdates()` function
- **New**: `test/propagate/BackpropCoordination.ts` - 20 unit tests covering all
  coordination scenarios
- **Modified**: `src/propagate/BackPropagation.ts` - Added
  `biasWeightCoordinationFactor` config option (default 0.2, range 0..1)
- **Modified**: `src/architecture/Neuron.ts` - Integrated coordination into
  `propagateUpdate()`

## Test plan

- [x] 20 unit tests for coordination logic (opposing, aligned, threshold
      boundary, activations, edge cases)
- [x] All 3626 existing tests pass
- [x] Convergence tests (Constants, SingleNeuron) pass
- [x] XNOR evolve integration test passes
- [x] quality.sh passes (fmt, lint, type-check, tests)

---

## Automated Fix Details
This PR addresses issue #1471: **Backprop: Add bias-weight coordination to prevent opposing updates**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1471