### PR TITLE
Type safety: Replace remaining `any` types in WASM activation layer (#1475)

### DIFF
--- a/bench/ParallelFitnessEvaluation.ts
+++ b/bench/ParallelFitnessEvaluation.ts
@@ -22,10 +22,9 @@ import type { WorkerHandler } from "../src/multithreading/workers/WorkerHandler.
  */
 class BenchMockWorker {
   private busyCount = 0;
-  // deno-lint-ignore no-explicit-any
-  private idleListeners: any[] = [];
+  private idleListeners: ((worker: BenchMockWorker) => void)[] = [];
 
-  addIdleListener(callback: unknown): void {
+  addIdleListener(callback: (worker: BenchMockWorker) => void): void {
     this.idleListeners.push(callback);
   }
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.5",
+  "version": "0.312.6",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1475.md
+++ b/docs/pr-summary-1475.md
@@ -1,0 +1,44 @@
+## Summary
+
+Replace remaining `any` types in the WASM activation layer with proper
+TypeScript interfaces, improving compile-time type safety and
+maintainability. Closes #1475.
+
+### Changes
+
+- **New `WasmCompiledNetwork` interface** (`src/wasm/WasmCompiledNetwork.ts`):
+  Mirrors the public API of the WASM `CompiledNetwork` class, providing
+  compile-time type checking without importing from WASM-generated bindings.
+- **`WasmActivation.ts`**: Replaced `private network: any` with
+  `private network: WasmCompiledNetwork` and removed both `no-explicit-any`
+  lint suppressions.
+- **`WasmModuleLoader.ts`**: Replaced `CompiledNetworkClass = any` with
+  `WasmCompiledNetworkConstructor` and updated `getCompiledNetworkClass()`
+  return type.
+- **`ParallelFitnessEvaluation.ts`** (bench): Replaced
+  `idleListeners: any[]` with `((worker: BenchMockWorker) => void)[]`.
+- **`mod.ts`**: Exported the new `WasmCompiledNetwork` and
+  `WasmCompiledNetworkConstructor` types.
+
+Note: The `any` in `globalAccessors.ts` is intentional (JSR compatibility,
+Issue #1429) and left unchanged per the issue description. The remaining
+`WasmModule = any` in `WasmModuleLoader.ts` covers the dynamically imported
+WASM JS bindings module and is out of scope for this issue.
+
+## Evidence
+
+This is a type-safety improvement with no visual or performance changes.
+All 3635 tests pass. `quality.sh` passes cleanly (fmt, lint, type-check,
+tests).
+
+## Test Plan
+
+- Added `test/wasm/WasmCompiledNetworkType.ts` with 8 tests verifying:
+  - `getCompiledNetworkClass()` returns a typed constructor
+  - Constructor creates valid `WasmCompiledNetwork` instances
+  - All interface methods (`activate`, `activate_into`, `activate_view`,
+    `activate_and_trace`, `reset_state`) work correctly
+  - Readonly properties (`num_inputs`, `num_neurons`, `num_synapses`) return
+    correct values
+  - Results from the typed interface match `WasmCreatureActivation` wrapper
+    output

--- a/docs/pr-summary-1475.md
+++ b/docs/pr-summary-1475.md
@@ -1,8 +1,8 @@
 ## Summary
 
 Replace remaining `any` types in the WASM activation layer with proper
-TypeScript interfaces, improving compile-time type safety and
-maintainability. Closes #1475.
+TypeScript interfaces, improving compile-time type safety and maintainability.
+Closes #1475.
 
 ### Changes
 
@@ -10,26 +10,25 @@ maintainability. Closes #1475.
   Mirrors the public API of the WASM `CompiledNetwork` class, providing
   compile-time type checking without importing from WASM-generated bindings.
 - **`WasmActivation.ts`**: Replaced `private network: any` with
-  `private network: WasmCompiledNetwork` and removed both `no-explicit-any`
-  lint suppressions.
+  `private network: WasmCompiledNetwork` and removed both `no-explicit-any` lint
+  suppressions.
 - **`WasmModuleLoader.ts`**: Replaced `CompiledNetworkClass = any` with
   `WasmCompiledNetworkConstructor` and updated `getCompiledNetworkClass()`
   return type.
-- **`ParallelFitnessEvaluation.ts`** (bench): Replaced
-  `idleListeners: any[]` with `((worker: BenchMockWorker) => void)[]`.
+- **`ParallelFitnessEvaluation.ts`** (bench): Replaced `idleListeners: any[]`
+  with `((worker: BenchMockWorker) => void)[]`.
 - **`mod.ts`**: Exported the new `WasmCompiledNetwork` and
   `WasmCompiledNetworkConstructor` types.
 
-Note: The `any` in `globalAccessors.ts` is intentional (JSR compatibility,
-Issue #1429) and left unchanged per the issue description. The remaining
-`WasmModule = any` in `WasmModuleLoader.ts` covers the dynamically imported
-WASM JS bindings module and is out of scope for this issue.
+Note: The `any` in `globalAccessors.ts` is intentional (JSR compatibility, Issue
+#1429) and left unchanged per the issue description. The remaining
+`WasmModule = any` in `WasmModuleLoader.ts` covers the dynamically imported WASM
+JS bindings module and is out of scope for this issue.
 
 ## Evidence
 
-This is a type-safety improvement with no visual or performance changes.
-All 3635 tests pass. `quality.sh` passes cleanly (fmt, lint, type-check,
-tests).
+This is a type-safety improvement with no visual or performance changes. All
+3635 tests pass. `quality.sh` passes cleanly (fmt, lint, type-check, tests).
 
 ## Test Plan
 

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -15,6 +15,8 @@ import type { Creature } from "../Creature.ts";
 import { WasmError } from "../errors/WasmError.ts";
 import { getLogger } from "../utils/Logger.ts";
 import { compileCreatureToWasm } from "./CompileToWasm.ts";
+import type { CompiledCreatureData } from "./CompileToWasm.ts";
+import type { WasmCompiledNetwork } from "./WasmCompiledNetwork.ts";
 import {
   getCompiledNetworkClass,
   getCrossEntropySumBatchPackedFn,
@@ -24,7 +26,6 @@ import {
   getMseSumBatchPackedFn,
   getMsleSumBatchPackedFn,
 } from "./WasmModuleLoader.ts";
-import type { CompiledCreatureData } from "./CompileToWasm.ts";
 
 /**
  * Trace entry from WASM activation
@@ -67,15 +68,17 @@ export interface WasmTraceResult {
  * method compatible with the JS-based activation.
  */
 export class WasmCreatureActivation {
-  // deno-lint-ignore no-explicit-any
-  private network: any;
+  private network: WasmCompiledNetwork;
   private numInputs: number;
   private numOutputs: number;
   private freed = false;
   private needsResetWhenStateless = true;
 
-  // deno-lint-ignore no-explicit-any
-  private constructor(network: any, numInputs: number, numOutputs: number) {
+  private constructor(
+    network: WasmCompiledNetwork,
+    numInputs: number,
+    numOutputs: number,
+  ) {
     this.network = network;
     this.numInputs = numInputs;
     this.numOutputs = numOutputs;

--- a/src/wasm/WasmCompiledNetwork.ts
+++ b/src/wasm/WasmCompiledNetwork.ts
@@ -1,0 +1,93 @@
+/**
+ * TypeScript interface for the WASM CompiledNetwork object.
+ *
+ * Issue #1475 - Type safety: Replace remaining `any` types in WASM activation layer.
+ *
+ * This interface mirrors the public API of the `CompiledNetwork` class defined
+ * in `wasm_activation/pkg/wasm_activation.d.ts`, providing compile-time type
+ * checking without importing from the WASM-generated bindings directly (which
+ * would trigger module loading).
+ *
+ * Property names use snake_case (quoted) to match the Rust-generated WASM
+ * bindings exactly.
+ */
+
+/**
+ * Interface describing the compiled WASM network object.
+ *
+ * A `WasmCompiledNetwork` is constructed from serialised neuron/synapse data
+ * and provides activation, tracing, and batch scoring entry points that
+ * execute entirely inside WASM.
+ */
+export interface WasmCompiledNetwork {
+  /** Release WASM-side memory. Safe to call multiple times. */
+  free(): void;
+
+  /** Disposable protocol for `using` declarations. */
+  [Symbol.dispose](): void;
+
+  /**
+   * Activate the network with the given input values.
+   * Returns the output values as a new Float32Array.
+   */
+  activate(input: Float32Array, num_outputs: number): Float32Array;
+
+  /**
+   * Activate the network and return a zero-copy Float32Array view over
+   * WASM memory.  The view is overwritten by subsequent activations.
+   */
+  // deno-lint-ignore camelcase
+  activate_view(input: Float32Array, num_outputs: number): Float32Array;
+
+  /**
+   * Activate the network, writing results into a pre-allocated output buffer.
+   */
+  // deno-lint-ignore camelcase
+  activate_into(input: Float32Array, output: Float32Array): void;
+
+  /**
+   * Activate the network with tracing for backpropagation support.
+   * Returns a combined Float32Array of outputs, activations, hint values,
+   * and trace data.
+   */
+  // deno-lint-ignore camelcase
+  activate_and_trace(input: Float32Array, num_outputs: number): Float32Array;
+
+  /**
+   * Batch activate and trace for 4 records simultaneously.
+   * Returns a packed Float32Array containing per-record lengths followed by
+   * concatenated per-record data.
+   */
+  // deno-lint-ignore camelcase
+  activate_and_trace_batch_4way(
+    inputs: Float32Array,
+    input_size: number,
+    num_outputs: number,
+  ): Float32Array;
+
+  /**
+   * Reset non-input activations to 0.0, restoring stateless behaviour.
+   */
+  // deno-lint-ignore camelcase
+  reset_state(): void;
+
+  /** Number of input neurons. */
+  // deno-lint-ignore camelcase
+  readonly num_inputs: number;
+
+  /** Total number of neurons in the network. */
+  // deno-lint-ignore camelcase
+  readonly num_neurons: number;
+
+  /** Total number of synapses in the network. */
+  // deno-lint-ignore camelcase
+  readonly num_synapses: number;
+}
+
+/**
+ * Constructor type for creating `WasmCompiledNetwork` instances from
+ * serialised data.
+ */
+export interface WasmCompiledNetworkConstructor {
+  new (data: Uint8Array): WasmCompiledNetwork;
+}

--- a/src/wasm/WasmModuleLoader.ts
+++ b/src/wasm/WasmModuleLoader.ts
@@ -11,18 +11,17 @@
  */
 
 import { getLogger } from "../utils/Logger.ts";
+import type { WasmCompiledNetworkConstructor } from "./WasmCompiledNetwork.ts";
 
 // deno-lint-ignore no-explicit-any
 type WasmModule = any;
-// deno-lint-ignore no-explicit-any
-type CompiledNetworkClass = any;
 
 // ---------------------------------------------------------------------------
 // Module-level state
 // ---------------------------------------------------------------------------
 
 let wasmModule: WasmModule | null = null;
-let compiledNetworkClass: CompiledNetworkClass | null = null;
+let compiledNetworkClass: WasmCompiledNetworkConstructor | null = null;
 let initPromise: Promise<boolean> | null = null;
 
 // Standalone function pointers
@@ -254,7 +253,9 @@ export function isWasmActivationAvailable(): boolean {
 // Function pointer getters (used by WasmStandaloneFunctions and WasmCreatureActivation)
 // ---------------------------------------------------------------------------
 
-export function getCompiledNetworkClass(): CompiledNetworkClass | null {
+export function getCompiledNetworkClass():
+  | WasmCompiledNetworkConstructor
+  | null {
   return compiledNetworkClass;
 }
 

--- a/src/wasm/mod.ts
+++ b/src/wasm/mod.ts
@@ -47,6 +47,12 @@ export {
   wasmVersion,
 } from "./WasmStandaloneFunctions.ts";
 
+// Issue #1475 - Typed interface for WASM compiled network
+export type {
+  WasmCompiledNetwork,
+  WasmCompiledNetworkConstructor,
+} from "./WasmCompiledNetwork.ts";
+
 // Issue #1405 - WasmCreatureActivation class and trace types from WasmActivation
 export {
   WasmCreatureActivation,

--- a/test/wasm/WasmCompiledNetworkType.ts
+++ b/test/wasm/WasmCompiledNetworkType.ts
@@ -1,0 +1,172 @@
+/**
+ * Issue #1475 - Type safety: Verify the WasmCompiledNetwork interface
+ * matches the actual WASM CompiledNetwork object.
+ *
+ * These tests create real WASM network objects via WasmCreatureActivation
+ * and verify the typed API works correctly at runtime.
+ */
+
+import {
+  assert,
+  assertAlmostEquals,
+  assertEquals,
+  assertExists,
+} from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import {
+  initWasmActivation,
+  WasmCreatureActivation,
+} from "../../src/wasm/mod.ts";
+import type {
+  WasmCompiledNetwork,
+  WasmCompiledNetworkConstructor,
+} from "../../src/wasm/mod.ts";
+import { getCompiledNetworkClass } from "../../src/wasm/WasmModuleLoader.ts";
+import { compileCreatureToWasm } from "../../src/wasm/CompileToWasm.ts";
+
+await initWasmActivation();
+
+// ---------------------------------------------------------------------------
+// WasmCompiledNetworkConstructor type
+// ---------------------------------------------------------------------------
+
+Deno.test("getCompiledNetworkClass returns a typed constructor", () => {
+  const ctor: WasmCompiledNetworkConstructor | null = getCompiledNetworkClass();
+  assertExists(ctor, "CompiledNetwork constructor should be available");
+  assertEquals(typeof ctor, "function");
+});
+
+Deno.test("WasmCompiledNetworkConstructor creates a valid network", () => {
+  const ctor = getCompiledNetworkClass();
+  assertExists(ctor);
+
+  const creature = new Creature(2, 1);
+  const compiled = compileCreatureToWasm(creature);
+  const network: WasmCompiledNetwork = new ctor(compiled.data);
+
+  assert(network.num_neurons > 0, "Should have neurons");
+  assert(network.num_inputs > 0, "Should have inputs");
+  assert(network.num_synapses >= 0, "Synapses should be non-negative");
+
+  network.free();
+});
+
+// ---------------------------------------------------------------------------
+// WasmCompiledNetwork interface methods
+// ---------------------------------------------------------------------------
+
+Deno.test("WasmCompiledNetwork.activate returns correct output length", () => {
+  const ctor = getCompiledNetworkClass();
+  assertExists(ctor);
+
+  const creature = new Creature(2, 1);
+  const compiled = compileCreatureToWasm(creature);
+  const network: WasmCompiledNetwork = new ctor(compiled.data);
+
+  const input = new Float32Array([0.5, 0.3]);
+  const output = network.activate(input, 1);
+  assertEquals(output.length, 1);
+
+  network.free();
+});
+
+Deno.test("WasmCompiledNetwork.activate_into writes to output buffer", () => {
+  const ctor = getCompiledNetworkClass();
+  assertExists(ctor);
+
+  const creature = new Creature(2, 1);
+  const compiled = compileCreatureToWasm(creature);
+  const network: WasmCompiledNetwork = new ctor(compiled.data);
+
+  const input = new Float32Array([0.5, 0.3]);
+  const output = new Float32Array(1);
+  network.activate_into(input, output);
+  assert(isFinite(output[0]), "Output should be finite");
+
+  network.free();
+});
+
+Deno.test("WasmCompiledNetwork.activate_view returns a Float32Array", () => {
+  const ctor = getCompiledNetworkClass();
+  assertExists(ctor);
+
+  const creature = new Creature(2, 1);
+  const compiled = compileCreatureToWasm(creature);
+  const network: WasmCompiledNetwork = new ctor(compiled.data);
+
+  const input = new Float32Array([0.5, 0.3]);
+  const view = network.activate_view(input, 1);
+  assertEquals(view.length, 1);
+  assert(isFinite(view[0]), "View output should be finite");
+
+  network.free();
+});
+
+Deno.test("WasmCompiledNetwork.activate_and_trace returns trace data", () => {
+  const ctor = getCompiledNetworkClass();
+  assertExists(ctor);
+
+  const creature = new Creature(2, 1);
+  const compiled = compileCreatureToWasm(creature);
+  const network: WasmCompiledNetwork = new ctor(compiled.data);
+
+  const input = new Float32Array([0.5, 0.3]);
+  const result = network.activate_and_trace(input, 1);
+  assert(result.length > 0, "Trace result should have data");
+
+  network.free();
+});
+
+Deno.test("WasmCompiledNetwork.reset_state does not throw", () => {
+  const ctor = getCompiledNetworkClass();
+  assertExists(ctor);
+
+  const creature = new Creature(2, 1);
+  const compiled = compileCreatureToWasm(creature);
+  const network: WasmCompiledNetwork = new ctor(compiled.data);
+
+  network.reset_state();
+
+  const input = new Float32Array([0.5, 0.3]);
+  const output = network.activate(input, 1);
+  assertEquals(output.length, 1);
+
+  network.free();
+});
+
+Deno.test("WasmCompiledNetwork.activate results match WasmCreatureActivation", () => {
+  const ctor = getCompiledNetworkClass();
+  assertExists(ctor);
+
+  const creature = new Creature(2, 1);
+  const compiled = compileCreatureToWasm(creature);
+
+  const network: WasmCompiledNetwork = new ctor(compiled.data);
+  const activation = WasmCreatureActivation.create(compiled);
+  assertExists(activation);
+
+  const input = new Float32Array([0.5, 0.3]);
+  const directOutput = network.activate(input, 1);
+  const wrapperOutput = activation.activate(input);
+
+  assertAlmostEquals(directOutput[0], wrapperOutput[0], 1e-6);
+
+  network.free();
+  activation.free();
+});
+
+Deno.test("WasmCompiledNetwork readonly properties are numbers", () => {
+  const ctor = getCompiledNetworkClass();
+  assertExists(ctor);
+
+  const creature = new Creature(3, 2);
+  const compiled = compileCreatureToWasm(creature);
+  const network: WasmCompiledNetwork = new ctor(compiled.data);
+
+  assertEquals(typeof network.num_inputs, "number");
+  assertEquals(typeof network.num_neurons, "number");
+  assertEquals(typeof network.num_synapses, "number");
+  assertEquals(network.num_inputs, 3);
+
+  network.free();
+});


### PR DESCRIPTION
## Summary

Replace remaining `any` types in the WASM activation layer with proper
TypeScript interfaces, improving compile-time type safety and
maintainability. Closes #1475.

### Changes

- **New `WasmCompiledNetwork` interface** (`src/wasm/WasmCompiledNetwork.ts`):
  Mirrors the public API of the WASM `CompiledNetwork` class, providing
  compile-time type checking without importing from WASM-generated bindings.
- **`WasmActivation.ts`**: Replaced `private network: any` with
  `private network: WasmCompiledNetwork` and removed both `no-explicit-any`
  lint suppressions.
- **`WasmModuleLoader.ts`**: Replaced `CompiledNetworkClass = any` with
  `WasmCompiledNetworkConstructor` and updated `getCompiledNetworkClass()`
  return type.
- **`ParallelFitnessEvaluation.ts`** (bench): Replaced
  `idleListeners: any[]` with `((worker: BenchMockWorker) => void)[]`.
- **`mod.ts`**: Exported the new `WasmCompiledNetwork` and
  `WasmCompiledNetworkConstructor` types.

Note: The `any` in `globalAccessors.ts` is intentional (JSR compatibility,
Issue #1429) and left unchanged per the issue description. The remaining
`WasmModule = any` in `WasmModuleLoader.ts` covers the dynamically imported
WASM JS bindings module and is out of scope for this issue.

## Evidence

This is a type-safety improvement with no visual or performance changes.
All 3635 tests pass. `quality.sh` passes cleanly (fmt, lint, type-check,
tests).

## Test Plan

- Added `test/wasm/WasmCompiledNetworkType.ts` with 8 tests verifying:
  - `getCompiledNetworkClass()` returns a typed constructor
  - Constructor creates valid `WasmCompiledNetwork` instances
  - All interface methods (`activate`, `activate_into`, `activate_view`,
    `activate_and_trace`, `reset_state`) work correctly
  - Readonly properties (`num_inputs`, `num_neurons`, `num_synapses`) return
    correct values
  - Results from the typed interface match `WasmCreatureActivation` wrapper
    output

🤖 Generated with [Claude Code](https://claude.com/claude-code)