### PR TITLE
Refactor: Migrate remaining console.* calls to Logger (#1476)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.6",
+  "version": "0.312.7",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1476.md
+++ b/docs/pr-summary-1476.md
@@ -1,0 +1,34 @@
+## Summary
+
+Migrate all remaining `console.*` calls in `src/` to use `getLogger()` from the
+Logger abstraction for consistent log level control. Closes #1476.
+
+### Changes
+
+- **Removed commented-out debug code**: Deleted `// console.info(functionBody);`
+  from `src/methods/activations/aggregate/IF.ts`
+- **Updated 17 JSDoc examples** across 15 files to use `getLogger().info()`
+  instead of `console.log()`, ensuring documentation demonstrates the correct
+  logging pattern:
+  - 6 cost function files (CrossEntropy, HINGE, MSE, MAE, MAPE, MSLE)
+  - 3 architecture files (Score, Training, CreatureUtils)
+  - 2 breed files (Breed, GeneticCompatibility)
+  - 1 blackbox file (RestoreSource)
+  - 1 intelligent design module (mod.ts)
+  - 2 worker handler files (intelligentDesign and multithreading)
+
+After these changes, the only `console.*` calls remaining in `src/` are inside
+`src/utils/Logger.ts` itself (the Logger implementation that correctly delegates
+to console methods).
+
+## Evidence
+
+This is a backend/code-only change with no UI. Verified by:
+- `grep -r "console\." src/ --include="*.ts"` shows only Logger.ts references
+- All 3635 tests pass
+- `quality.sh` passes cleanly (fmt, lint, type-check, tests)
+
+## Test Plan
+
+- No new tests needed; this is a documentation and dead-code cleanup
+- All 3635 existing tests continue to pass unchanged

--- a/docs/pr-summary-1476.md
+++ b/docs/pr-summary-1476.md
@@ -24,6 +24,7 @@ to console methods).
 ## Evidence
 
 This is a backend/code-only change with no UI. Verified by:
+
 - `grep -r "console\." src/ --include="*.ts"` shows only Logger.ts references
 - All 3635 tests pass
 - `quality.sh` passes cleanly (fmt, lint, type-check, tests)

--- a/src/architecture/CreatureUtils.ts
+++ b/src/architecture/CreatureUtils.ts
@@ -61,7 +61,7 @@ export class CreatureUtil {
    * @example
    * ```ts
    * const uuid = CreatureUtil.makeUUID(creature);
-   * console.log(`Creature UUID: ${uuid}`);
+   * getLogger().info(`Creature UUID: ${uuid}`);
    * ```
    */
   static makeUUID(creature: Creature): string {
@@ -128,7 +128,7 @@ export class CreatureUtil {
    * @example
    * ```ts
    * const hash = CreatureUtil.getTopologyHash(creature);
-   * console.log(`Creature topology hash: ${hash}`);
+   * getLogger().info(`Creature topology hash: ${hash}`);
    * ```
    */
   static getTopologyHash(creature: Creature): string {

--- a/src/architecture/Score.ts
+++ b/src/architecture/Score.ts
@@ -22,7 +22,7 @@ import { getLogger } from "../utils/Logger.ts";
  * @example
  * ```ts
  * const score = calculate(creature, 0.1, 0.0001);
- * console.log(`Creature score: ${score}`);
+ * getLogger().info(`Creature score: ${score}`);
  * ```
  */
 export function calculate(
@@ -64,7 +64,7 @@ export function calculate(
  * @example
  * ```ts
  * const penalty = valuePenalty(10.5);
- * console.log(`Penalty for value 10.5: ${penalty}`);
+ * getLogger().info(`Penalty for value 10.5: ${penalty}`);
  * ```
  */
 export function valuePenalty(value: number): number {

--- a/src/architecture/Training.ts
+++ b/src/architecture/Training.ts
@@ -33,7 +33,7 @@ import { CreatureUtil } from "./CreatureUtils.ts";
  * @example
  * ```ts
  * const dataResult = dataFiles("./training-data", { disableRandomSamples: false });
- * console.log(`Found ${dataResult.files.length} training files`);
+ * getLogger().info(`Found ${dataResult.files.length} training files`);
  * ```
  */
 export function dataFiles(dataDir: string, options: TrainOptions = {}) {
@@ -84,7 +84,7 @@ export function dataFiles(dataDir: string, options: TrainOptions = {}) {
  *   iterations: 10,
  *   targetError: 0.01,
  * }, Costs.find("MSE"));
- * console.log(`Training completed with error: ${result.error}`);
+ * getLogger().info(`Training completed with error: ${result.error}`);
  * ```
  */
 export function trainDir(

--- a/src/blackbox/RestoreSource.ts
+++ b/src/blackbox/RestoreSource.ts
@@ -19,7 +19,7 @@ import type { Approach } from "../NEAT/LogApproach.ts";
  * ```ts
  * const restoredCreature = restoreSource(creature);
  * if (restoredCreature) {
- *   console.log("Creature restored from memetic data");
+ *   getLogger().info("Creature restored from memetic data");
  * }
  * ```
  */

--- a/src/breed/Breed.ts
+++ b/src/breed/Breed.ts
@@ -26,7 +26,7 @@ import { getLogger } from "../utils/Logger.ts";
  * const breed = new Breed(genus, config);
  * const offspring = breed.breed();
  * if (offspring) {
- *   console.log("New offspring created");
+ *   getLogger().info("New offspring created");
  * }
  * ```
  */

--- a/src/breed/GeneticCompatibility.ts
+++ b/src/breed/GeneticCompatibility.ts
@@ -26,7 +26,7 @@ import { getCachedDistance, setCachedDistance } from "./DistanceCache.ts";
  * ```ts
  * const compatibility = geneticCompatibility(father, mother);
  * if (compatibility > 0.5) {
- *   console.log("Creatures are genetically compatible for breeding");
+ *   getLogger().info("Creatures are genetically compatible for breeding");
  * }
  * ```
  */

--- a/src/costs/CrossEntropy.ts
+++ b/src/costs/CrossEntropy.ts
@@ -33,7 +33,7 @@ import type { CostInterface } from "./CostInterface.ts";
  * const target = new Float32Array([1, 0, 1]); // True labels
  * const output = new Float32Array([0.9, 0.1, 0.8]); // Predicted probabilities
  * const error = ce.calculate(target, output);
- * console.log(error); // Cross entropy loss
+ * getLogger().info(error); // Cross entropy loss
  * ```
  */
 export class CrossEntropy implements CostInterface {

--- a/src/costs/HINGE.ts
+++ b/src/costs/HINGE.ts
@@ -32,7 +32,7 @@ import type { CostInterface } from "./CostInterface.ts";
  * const target = new Float32Array([1, -1, 1]); // True labels
  * const output = new Float32Array([0.8, -0.3, 1.2]); // Predictions
  * const error = hinge.calculate(target, output);
- * console.log(error); // Hinge loss
+ * getLogger().info(error); // Hinge loss
  * ```
  */
 export class HINGE implements CostInterface {

--- a/src/costs/MAE.ts
+++ b/src/costs/MAE.ts
@@ -31,7 +31,7 @@ import type { CostInterface } from "./CostInterface.ts";
  * const target = new Float32Array([1.0, 2.0, 3.0]);
  * const output = new Float32Array([0.9, 2.1, 2.8]);
  * const error = mae.calculate(target, output);
- * console.log(error); // Average absolute error
+ * getLogger().info(error); // Average absolute error
  * ```
  */
 export class MAE implements CostInterface {

--- a/src/costs/MAPE.ts
+++ b/src/costs/MAPE.ts
@@ -32,7 +32,7 @@ import type { CostInterface } from "./CostInterface.ts";
  * const target = new Float32Array([100, 200, 300]);
  * const output = new Float32Array([95, 210, 285]);
  * const error = mape.calculate(target, output);
- * console.log(error); // Mean absolute percentage error
+ * getLogger().info(error); // Mean absolute percentage error
  * ```
  */
 export class MAPE implements CostInterface {

--- a/src/costs/MSE.ts
+++ b/src/costs/MSE.ts
@@ -30,7 +30,7 @@ import type { CostInterface } from "./CostInterface.ts";
  * const target = new Float32Array([1.0, 2.0, 3.0]);
  * const output = new Float32Array([0.9, 2.1, 2.8]);
  * const error = mse.calculate(target, output);
- * console.log(error); // Average squared error
+ * getLogger().info(error); // Average squared error
  * ```
  */
 export class MSE implements CostInterface {

--- a/src/costs/MSLE.ts
+++ b/src/costs/MSLE.ts
@@ -33,7 +33,7 @@ import type { CostInterface } from "./CostInterface.ts";
  * const target = new Float32Array([1, 10, 100]);
  * const output = new Float32Array([0.9, 11, 95]);
  * const error = msle.calculate(target, output);
- * console.log(error); // Mean squared logarithmic error
+ * getLogger().info(error); // Mean squared logarithmic error
  * ```
  */
 export class MSLE implements CostInterface {

--- a/src/intelligentDesign/mod.ts
+++ b/src/intelligentDesign/mod.ts
@@ -43,7 +43,7 @@
  *     "./training-data",
  *     currentScore,
  *   );
- *   console.log(message);
+ *   getLogger().info(message);
  *   await safeWriteJson("./best.json", creature);
  * }
  * ```

--- a/src/intelligentDesign/workers/WorkerHandler.ts
+++ b/src/intelligentDesign/workers/WorkerHandler.ts
@@ -143,7 +143,7 @@ async function loadWasmActivationInitPayloadOrThrow(): Promise<
  * ```ts
  * const worker = new WorkerHandler();
  * const result = await worker.score(creature, neuronUUID, dataDir, options);
- * console.log(`Score: ${result.score?.score}`);
+ * getLogger().info(`Score: ${result.score?.score}`);
  * worker.terminate();
  * ```
  */

--- a/src/methods/activations/aggregate/IF.ts
+++ b/src/methods/activations/aggregate/IF.ts
@@ -90,7 +90,6 @@ export class IF
 
     functionBody += this.inlineActivation(neuron);
     functionBody += `return { activation:a[${neuron.index}], value:0 };`;
-    // console.info(functionBody);
     const foundFunction = findActivationFunction(functionBody, cache);
     if (foundFunction) {
       return foundFunction;

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -384,7 +384,7 @@ export function isWasmActivationPayloadAvailable(): boolean {
  * ```ts
  * const worker = new WorkerHandler("./data", "MSE", false);
  * const result = await worker.evaluate(creature, false);
- * console.log(`Evaluation error: ${result.evaluate?.error}`);
+ * getLogger().info(`Evaluation error: ${result.evaluate?.error}`);
  * ```
  */
 export class WorkerHandler {


### PR DESCRIPTION
## Summary

Migrate all remaining `console.*` calls in `src/` to use `getLogger()` from the
Logger abstraction for consistent log level control. Closes #1476.

### Changes

- **Removed commented-out debug code**: Deleted `// console.info(functionBody);`
  from `src/methods/activations/aggregate/IF.ts`
- **Updated 17 JSDoc examples** across 15 files to use `getLogger().info()`
  instead of `console.log()`, ensuring documentation demonstrates the correct
  logging pattern:
  - 6 cost function files (CrossEntropy, HINGE, MSE, MAE, MAPE, MSLE)
  - 3 architecture files (Score, Training, CreatureUtils)
  - 2 breed files (Breed, GeneticCompatibility)
  - 1 blackbox file (RestoreSource)
  - 1 intelligent design module (mod.ts)
  - 2 worker handler files (intelligentDesign and multithreading)

After these changes, the only `console.*` calls remaining in `src/` are inside
`src/utils/Logger.ts` itself (the Logger implementation that correctly delegates
to console methods).

## Evidence

This is a backend/code-only change with no UI. Verified by:
- `grep -r "console\." src/ --include="*.ts"` shows only Logger.ts references
- All 3635 tests pass
- `quality.sh` passes cleanly (fmt, lint, type-check, tests)

## Test Plan

- No new tests needed; this is a documentation and dead-code cleanup
- All 3635 existing tests continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)