### PR TITLE
Testing: Add unit tests for config module edge cases (#1483)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.8",
+  "version": "0.312.9",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1483.md
+++ b/docs/pr-summary-1483.md
@@ -1,20 +1,34 @@
 ## Summary
 
-Add dedicated unit tests for five config modules that lacked test coverage. Closes #1483.
+Add dedicated unit tests for five config modules that lacked test coverage.
+Closes #1483.
 
-The `src/config/` directory contains 13 source files but several had no dedicated test files. This PR adds focused unit tests to improve confidence in configuration validation and default value handling.
+The `src/config/` directory contains 13 source files but several had no
+dedicated test files. This PR adds focused unit tests to improve confidence in
+configuration validation and default value handling.
 
 ## Files Added
 
-- `test/config/BiasRegularisationConfig.ts` — 8 tests covering defaults, overrides, CLI string coercion, Required type verification, boolean fields, and zero l2Strength edge case
-- `test/config/DiscoveryMinCandidatesPerCategory.ts` — 8 tests covering defaults, overrides, partial overrides, CLI string coercion, zero values, and Required type verification
-- `test/config/NeatArguments.ts` — 9 tests verifying the full argument structure, sub-object configs, default values, array fields, boolean fields, logger/RNG presence, and optional string fields
-- `test/config/NeatOptions.ts` — 12 tests covering numeric string coercion, partial sub-object overrides, invalid input errors, seed/RNG determinism, verbose mode, and feedbackLoop validation
-- `test/config/TrainOptions.ts` — 10 tests verifying type structure, backpropagation fields, adjustment scales, learning rate strategies, and full configuration acceptance
+- `test/config/BiasRegularisationConfig.ts` — 8 tests covering defaults,
+  overrides, CLI string coercion, Required type verification, boolean fields,
+  and zero l2Strength edge case
+- `test/config/DiscoveryMinCandidatesPerCategory.ts` — 8 tests covering
+  defaults, overrides, partial overrides, CLI string coercion, zero values, and
+  Required type verification
+- `test/config/NeatArguments.ts` — 9 tests verifying the full argument
+  structure, sub-object configs, default values, array fields, boolean fields,
+  logger/RNG presence, and optional string fields
+- `test/config/NeatOptions.ts` — 12 tests covering numeric string coercion,
+  partial sub-object overrides, invalid input errors, seed/RNG determinism,
+  verbose mode, and feedbackLoop validation
+- `test/config/TrainOptions.ts` — 10 tests verifying type structure,
+  backpropagation fields, adjustment scales, learning rate strategies, and full
+  configuration acceptance
 
 ## Evidence
 
-This is a backend testing change with no UI components. All 3685 tests pass (including the 47 new tests) via `./quality.sh`.
+This is a backend testing change with no UI components. All 3685 tests pass
+(including the 47 new tests) via `./quality.sh`.
 
 ## Test Plan
 

--- a/docs/pr-summary-1483.md
+++ b/docs/pr-summary-1483.md
@@ -1,0 +1,27 @@
+## Summary
+
+Add dedicated unit tests for five config modules that lacked test coverage. Closes #1483.
+
+The `src/config/` directory contains 13 source files but several had no dedicated test files. This PR adds focused unit tests to improve confidence in configuration validation and default value handling.
+
+## Files Added
+
+- `test/config/BiasRegularisationConfig.ts` — 8 tests covering defaults, overrides, CLI string coercion, Required type verification, boolean fields, and zero l2Strength edge case
+- `test/config/DiscoveryMinCandidatesPerCategory.ts` — 8 tests covering defaults, overrides, partial overrides, CLI string coercion, zero values, and Required type verification
+- `test/config/NeatArguments.ts` — 9 tests verifying the full argument structure, sub-object configs, default values, array fields, boolean fields, logger/RNG presence, and optional string fields
+- `test/config/NeatOptions.ts` — 12 tests covering numeric string coercion, partial sub-object overrides, invalid input errors, seed/RNG determinism, verbose mode, and feedbackLoop validation
+- `test/config/TrainOptions.ts` — 10 tests verifying type structure, backpropagation fields, adjustment scales, learning rate strategies, and full configuration acceptance
+
+## Evidence
+
+This is a backend testing change with no UI components. All 3685 tests pass (including the 47 new tests) via `./quality.sh`.
+
+## Test Plan
+
+- Added `test/config/BiasRegularisationConfig.ts` (8 tests)
+- Added `test/config/DiscoveryMinCandidatesPerCategory.ts` (8 tests)
+- Added `test/config/NeatArguments.ts` (9 tests)
+- Added `test/config/NeatOptions.ts` (12 tests)
+- Added `test/config/TrainOptions.ts` (10 tests)
+- All tests exercise real code via `createNeatConfig()` or type validation
+- All tests pass via `./quality.sh` with 0 failures

--- a/test/config/BiasRegularisationConfig.ts
+++ b/test/config/BiasRegularisationConfig.ts
@@ -1,0 +1,130 @@
+import { assertEquals } from "@std/assert";
+import {
+  DEFAULT_BIAS_REGULARISATION_CONFIG,
+} from "../../src/config/BiasRegularisationConfig.ts";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+
+Deno.test("BiasRegularisationConfig - defaults are applied", () => {
+  const config = createNeatConfig({});
+  assertEquals(
+    config.biasRegularisation.enabled,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.enabled,
+  );
+  assertEquals(
+    config.biasRegularisation.maxAbsoluteBias,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.maxAbsoluteBias,
+  );
+  assertEquals(
+    config.biasRegularisation.maxBiasChange,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.maxBiasChange,
+  );
+  assertEquals(
+    config.biasRegularisation.l2Strength,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.l2Strength,
+  );
+  assertEquals(
+    config.biasRegularisation.preferSmallChanges,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.preferSmallChanges,
+  );
+  assertEquals(
+    config.biasRegularisation.smallChangeScale,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.smallChangeScale,
+  );
+});
+
+Deno.test("BiasRegularisationConfig - default values are sensible", () => {
+  assertEquals(DEFAULT_BIAS_REGULARISATION_CONFIG.enabled, true);
+  assertEquals(DEFAULT_BIAS_REGULARISATION_CONFIG.maxAbsoluteBias, 100);
+  assertEquals(DEFAULT_BIAS_REGULARISATION_CONFIG.maxBiasChange, 10);
+  assertEquals(DEFAULT_BIAS_REGULARISATION_CONFIG.l2Strength, 0.1);
+  assertEquals(DEFAULT_BIAS_REGULARISATION_CONFIG.preferSmallChanges, true);
+  assertEquals(DEFAULT_BIAS_REGULARISATION_CONFIG.smallChangeScale, 0.5);
+});
+
+Deno.test("BiasRegularisationConfig - custom values override defaults", () => {
+  const config = createNeatConfig({
+    biasRegularisation: {
+      enabled: false,
+      maxAbsoluteBias: 50,
+      maxBiasChange: 5,
+      l2Strength: 0.5,
+    },
+  });
+  assertEquals(config.biasRegularisation.enabled, false);
+  assertEquals(config.biasRegularisation.maxAbsoluteBias, 50);
+  assertEquals(config.biasRegularisation.maxBiasChange, 5);
+  assertEquals(config.biasRegularisation.l2Strength, 0.5);
+  // Non-overridden fields keep defaults
+  assertEquals(
+    config.biasRegularisation.preferSmallChanges,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.preferSmallChanges,
+  );
+});
+
+Deno.test("BiasRegularisationConfig - partial overrides keep other defaults", () => {
+  const config = createNeatConfig({
+    biasRegularisation: {
+      l2Strength: 0.3,
+    },
+  });
+  assertEquals(config.biasRegularisation.l2Strength, 0.3);
+  assertEquals(
+    config.biasRegularisation.enabled,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.enabled,
+  );
+  assertEquals(
+    config.biasRegularisation.maxAbsoluteBias,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.maxAbsoluteBias,
+  );
+  assertEquals(
+    config.biasRegularisation.maxBiasChange,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.maxBiasChange,
+  );
+});
+
+Deno.test("BiasRegularisationConfig - boolean fields accept boolean values", () => {
+  const config = createNeatConfig({
+    biasRegularisation: {
+      enabled: false,
+      preferSmallChanges: false,
+    },
+  });
+  assertEquals(config.biasRegularisation.enabled, false);
+  assertEquals(config.biasRegularisation.preferSmallChanges, false);
+});
+
+Deno.test("BiasRegularisationConfig - string values are parsed from CLI", () => {
+  const config = createNeatConfig({
+    biasRegularisation: {
+      maxAbsoluteBias: "200" as unknown as number,
+      maxBiasChange: "20" as unknown as number,
+      l2Strength: "0.05" as unknown as number,
+      smallChangeScale: "0.8" as unknown as number,
+    },
+  });
+  assertEquals(config.biasRegularisation.maxAbsoluteBias, 200);
+  assertEquals(config.biasRegularisation.maxBiasChange, 20);
+  assertEquals(config.biasRegularisation.l2Strength, 0.05);
+  assertEquals(config.biasRegularisation.smallChangeScale, 0.8);
+});
+
+Deno.test("BiasRegularisationConfig - Required type fills all fields", () => {
+  const config = createNeatConfig({});
+  const bias = config.biasRegularisation;
+  // All fields should be defined (not undefined) in the Required type
+  assertEquals(typeof bias.enabled, "boolean");
+  assertEquals(typeof bias.maxAbsoluteBias, "number");
+  assertEquals(typeof bias.maxBiasChange, "number");
+  assertEquals(typeof bias.l2Strength, "number");
+  assertEquals(typeof bias.preferSmallChanges, "boolean");
+  assertEquals(typeof bias.smallChangeScale, "number");
+});
+
+Deno.test("BiasRegularisationConfig - zero l2Strength disables regularisation penalty", () => {
+  const config = createNeatConfig({
+    biasRegularisation: {
+      l2Strength: 0,
+    },
+  });
+  assertEquals(config.biasRegularisation.l2Strength, 0);
+});

--- a/test/config/DiscoveryMinCandidatesPerCategory.ts
+++ b/test/config/DiscoveryMinCandidatesPerCategory.ts
@@ -1,0 +1,109 @@
+import { assertEquals } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY } from "../../src/config/NeatConfig.ts";
+
+Deno.test("DiscoveryMinCandidatesPerCategory - defaults are applied", () => {
+  const config = createNeatConfig({});
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.addNeurons,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addNeurons,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.addSynapses,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addSynapses,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.changeSquash,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.changeSquash,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.removeLowImpact,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.removeLowImpact,
+  );
+});
+
+Deno.test("DiscoveryMinCandidatesPerCategory - default values are sensible", () => {
+  assertEquals(DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addNeurons, 1);
+  assertEquals(DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addSynapses, 1);
+  assertEquals(DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.changeSquash, 1);
+  assertEquals(
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.removeLowImpact,
+    3,
+  );
+});
+
+Deno.test("DiscoveryMinCandidatesPerCategory - custom values override defaults", () => {
+  const config = createNeatConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 5,
+      addSynapses: 3,
+      changeSquash: 2,
+      removeLowImpact: 10,
+    },
+  });
+  assertEquals(config.discoveryMinCandidatesPerCategory.addNeurons, 5);
+  assertEquals(config.discoveryMinCandidatesPerCategory.addSynapses, 3);
+  assertEquals(config.discoveryMinCandidatesPerCategory.changeSquash, 2);
+  assertEquals(config.discoveryMinCandidatesPerCategory.removeLowImpact, 10);
+});
+
+Deno.test("DiscoveryMinCandidatesPerCategory - partial overrides keep other defaults", () => {
+  const config = createNeatConfig({
+    discoveryMinCandidatesPerCategory: {
+      removeLowImpact: 7,
+    },
+  });
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.addNeurons,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addNeurons,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.addSynapses,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addSynapses,
+  );
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.changeSquash,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.changeSquash,
+  );
+  assertEquals(config.discoveryMinCandidatesPerCategory.removeLowImpact, 7);
+});
+
+Deno.test("DiscoveryMinCandidatesPerCategory - string values are parsed from CLI", () => {
+  const config = createNeatConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: "4" as unknown as number,
+      addSynapses: "6" as unknown as number,
+      changeSquash: "2" as unknown as number,
+      removeLowImpact: "8" as unknown as number,
+    },
+  });
+  assertEquals(config.discoveryMinCandidatesPerCategory.addNeurons, 4);
+  assertEquals(config.discoveryMinCandidatesPerCategory.addSynapses, 6);
+  assertEquals(config.discoveryMinCandidatesPerCategory.changeSquash, 2);
+  assertEquals(config.discoveryMinCandidatesPerCategory.removeLowImpact, 8);
+});
+
+Deno.test("DiscoveryMinCandidatesPerCategory - zero values are allowed", () => {
+  const config = createNeatConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 0,
+      addSynapses: 0,
+      changeSquash: 0,
+      removeLowImpact: 0,
+    },
+  });
+  assertEquals(config.discoveryMinCandidatesPerCategory.addNeurons, 0);
+  assertEquals(config.discoveryMinCandidatesPerCategory.addSynapses, 0);
+  assertEquals(config.discoveryMinCandidatesPerCategory.changeSquash, 0);
+  assertEquals(config.discoveryMinCandidatesPerCategory.removeLowImpact, 0);
+});
+
+Deno.test("DiscoveryMinCandidatesPerCategory - Required type fills all fields", () => {
+  const config = createNeatConfig({});
+  const cats = config.discoveryMinCandidatesPerCategory;
+  // All fields should be defined (not undefined) in the Required type
+  assertEquals(typeof cats.addNeurons, "number");
+  assertEquals(typeof cats.addSynapses, "number");
+  assertEquals(typeof cats.changeSquash, "number");
+  assertEquals(typeof cats.removeLowImpact, "number");
+});

--- a/test/config/NeatArguments.ts
+++ b/test/config/NeatArguments.ts
@@ -1,0 +1,183 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { DEFAULT_BIAS_REGULARISATION_CONFIG } from "../../src/config/BiasRegularisationConfig.ts";
+import { DEFAULT_WEIGHT_REGULARISATION_CONFIG } from "../../src/config/WeightRegularisationConfig.ts";
+import { DEFAULT_QUANTUM_STEP_CONFIG } from "../../src/config/QuantumStepConfig.ts";
+import { DEFAULT_ENSEMBLE_DIVERSITY_CONFIG } from "../../src/config/EnsembleDiversityConfig.ts";
+import { DEFAULT_FINE_TUNE_POPULATION_CONFIG } from "../../src/config/FineTunePopulationConfig.ts";
+import { DEFAULT_STABILITY_ADAPTATION_CONFIG } from "../../src/config/StabilityAdaptationConfig.ts";
+import { DEFAULT_ADAPTIVE_MUTATION_THRESHOLDS } from "../../src/config/AdaptiveMutationThresholds.ts";
+import {
+  DEFAULT_COST_OF_GROWTH,
+  DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY,
+} from "../../src/config/NeatConfig.ts";
+
+Deno.test("NeatArguments - default config has all required top-level fields", () => {
+  const config = createNeatConfig({});
+
+  // Verify string fields
+  assertEquals(config.costName, "MSE");
+
+  // Verify numeric fields have sensible defaults
+  assertEquals(typeof config.creativeThinkingConnectionCount, "number");
+  assertEquals(typeof config.dataSetPartitionBreak, "number");
+  assertEquals(typeof config.trainingSampleRate, "number");
+  assertEquals(typeof config.targetError, "number");
+  assertEquals(typeof config.costOfGrowth, "number");
+  assertEquals(typeof config.iterations, "number");
+  assertEquals(typeof config.populationSize, "number");
+  assertEquals(typeof config.elitism, "number");
+  assertEquals(typeof config.maxConns, "number");
+  assertEquals(typeof config.maximumNumberOfNodes, "number");
+  assertEquals(typeof config.mutationRate, "number");
+  assertEquals(typeof config.mutationAmount, "number");
+  assertEquals(typeof config.timeoutMinutes, "number");
+  assertEquals(typeof config.trainPerGen, "number");
+  assertEquals(typeof config.log, "number");
+  assertEquals(typeof config.trainingBatchSize, "number");
+  assertEquals(typeof config.threads, "number");
+  assertEquals(typeof config.maximumBiasAdjustmentScale, "number");
+  assertEquals(typeof config.maximumWeightAdjustmentScale, "number");
+  assertEquals(typeof config.sparseRatio, "number");
+  assertEquals(typeof config.globalBreedingRate, "number");
+  assertEquals(typeof config.geneticCompatibilityThreshold, "number");
+  assertEquals(typeof config.discoverySampleRate, "number");
+
+  // Verify boolean fields
+  assertEquals(typeof config.debug, "boolean");
+  assertEquals(typeof config.feedbackLoop, "boolean");
+  assertEquals(typeof config.verbose, "boolean");
+  assertEquals(typeof config.enableRepetitiveTraining, "boolean");
+  assertEquals(typeof config.disableRandomSamples, "boolean");
+  assertEquals(typeof config.checkpointEveryGeneration, "boolean");
+});
+
+Deno.test("NeatArguments - default config has all sub-object configs", () => {
+  const config = createNeatConfig({});
+
+  // Verify sub-object configs are present and fully populated
+  assertNotEquals(config.biasRegularisation, undefined);
+  assertNotEquals(config.weightRegularisation, undefined);
+  assertNotEquals(config.quantumStep, undefined);
+  assertNotEquals(config.ensembleDiversity, undefined);
+  assertNotEquals(config.fineTunePopulation, undefined);
+  assertNotEquals(config.stabilityAdaptation, undefined);
+  assertNotEquals(config.adaptiveMutationThresholds, undefined);
+  assertNotEquals(config.plateauDetection, undefined);
+  assertNotEquals(config.discoveryMinCandidatesPerCategory, undefined);
+});
+
+Deno.test("NeatArguments - sub-object configs match their defaults", () => {
+  const config = createNeatConfig({});
+
+  // biasRegularisation
+  assertEquals(
+    config.biasRegularisation.enabled,
+    DEFAULT_BIAS_REGULARISATION_CONFIG.enabled,
+  );
+
+  // weightRegularisation
+  assertEquals(
+    config.weightRegularisation.enabled,
+    DEFAULT_WEIGHT_REGULARISATION_CONFIG.enabled,
+  );
+
+  // quantumStep
+  assertEquals(
+    config.quantumStep.minStep,
+    DEFAULT_QUANTUM_STEP_CONFIG.minStep,
+  );
+
+  // ensembleDiversity
+  assertEquals(
+    config.ensembleDiversity.enabled,
+    DEFAULT_ENSEMBLE_DIVERSITY_CONFIG.enabled,
+  );
+
+  // fineTunePopulation
+  assertEquals(
+    config.fineTunePopulation.minPopulationFraction,
+    DEFAULT_FINE_TUNE_POPULATION_CONFIG.minPopulationFraction,
+  );
+
+  // stabilityAdaptation
+  assertEquals(
+    config.stabilityAdaptation.enabled,
+    DEFAULT_STABILITY_ADAPTATION_CONFIG.enabled,
+  );
+
+  // adaptiveMutationThresholds
+  assertEquals(
+    config.adaptiveMutationThresholds.medium,
+    DEFAULT_ADAPTIVE_MUTATION_THRESHOLDS.medium,
+  );
+
+  // discoveryMinCandidatesPerCategory
+  assertEquals(
+    config.discoveryMinCandidatesPerCategory.addNeurons,
+    DEFAULT_DISCOVERY_MIN_CANDIDATES_PER_CATEGORY.addNeurons,
+  );
+});
+
+Deno.test("NeatArguments - default array fields are empty arrays", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.creatures.length, 0);
+  assertEquals(config.CRISPRs.length, 0);
+  assertEquals(config.focusList.length, 0);
+  assertEquals(config.discoveryFocusNeuronUUIDs.length, 0);
+});
+
+Deno.test("NeatArguments - default boolean fields have expected values", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.feedbackLoop, false);
+  assertEquals(config.verbose, false);
+  assertEquals(config.enableRepetitiveTraining, false);
+  assertEquals(config.checkpointEveryGeneration, false);
+  assertEquals(config.discoveryDisableCleanup, false);
+  assertEquals(config.discoverySkipRecordPhase, false);
+  assertEquals(config.discoveryDisableEvaluationSummaryLogging, false);
+  assertEquals(config.discoveryReplayVerifyScores, false);
+  assertEquals(config.discoveryReplayDiagnostics, false);
+});
+
+Deno.test("NeatArguments - default numeric fields have expected values", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.costName, "MSE");
+  assertEquals(config.populationSize, 50);
+  assertEquals(config.dataSetPartitionBreak, 2000);
+  assertEquals(config.targetError, 0.05);
+  assertEquals(config.costOfGrowth, DEFAULT_COST_OF_GROWTH);
+  assertEquals(config.trainPerGen, 1);
+  assertEquals(config.elitism, 1);
+  assertEquals(config.mutationAmount, 1);
+  assertEquals(config.trainingBatchSize, 100);
+  assertEquals(config.creativeThinkingConnectionCount, 1);
+  assertEquals(config.trainingSampleRate, 1);
+});
+
+Deno.test("NeatArguments - logger and rng are always present", () => {
+  const config = createNeatConfig({});
+  assertNotEquals(config.logger, undefined);
+  assertNotEquals(config.rng, undefined);
+  assertEquals(typeof config.logger.info, "function");
+  assertEquals(typeof config.rng.random, "function");
+});
+
+Deno.test("NeatArguments - optional string fields default to undefined", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.creatureStore, undefined);
+  assertEquals(config.experimentStore, undefined);
+  assertEquals(config.traceStore, undefined);
+  assertEquals(config.discoveryBaseDirectory, undefined);
+});
+
+Deno.test("NeatArguments - mutation array is populated with default mutations", () => {
+  const config = createNeatConfig({});
+  assertNotEquals(config.mutation.length, 0);
+});
+
+Deno.test("NeatArguments - selection is always present", () => {
+  const config = createNeatConfig({});
+  assertNotEquals(config.selection, undefined);
+  assertEquals(typeof config.selection.name, "string");
+});

--- a/test/config/NeatOptions.ts
+++ b/test/config/NeatOptions.ts
@@ -1,0 +1,139 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+
+Deno.test("NeatOptions - empty options produces valid config", () => {
+  const config = createNeatConfig({});
+  assertEquals(typeof config.populationSize, "number");
+  assertEquals(typeof config.mutationRate, "number");
+});
+
+Deno.test("NeatOptions - numeric string coercion for top-level fields", () => {
+  const config = createNeatConfig({
+    populationSize: "100" as unknown as number,
+    mutationRate: "0.5" as unknown as number,
+    targetError: "0.01" as unknown as number,
+    iterations: "500" as unknown as number,
+    elitism: "2" as unknown as number,
+    trainPerGen: "3" as unknown as number,
+    trainingBatchSize: "64" as unknown as number,
+    threads: "4" as unknown as number,
+    timeoutMinutes: "30" as unknown as number,
+  });
+  assertEquals(config.populationSize, 100);
+  assertEquals(config.mutationRate, 0.5);
+  assertEquals(config.targetError, 0.01);
+  assertEquals(config.iterations, 500);
+  assertEquals(config.elitism, 2);
+  assertEquals(config.trainPerGen, 3);
+  assertEquals(config.trainingBatchSize, 64);
+  assertEquals(config.threads, 4);
+  assertEquals(config.timeoutMinutes, 30);
+});
+
+Deno.test("NeatOptions - partial overrides for sub-object configs", () => {
+  const config = createNeatConfig({
+    biasRegularisation: { enabled: false },
+    weightRegularisation: { l2Strength: 0.5 },
+    quantumStep: { errorScale: 20 },
+  });
+  assertEquals(config.biasRegularisation.enabled, false);
+  assertEquals(config.weightRegularisation.l2Strength, 0.5);
+  assertEquals(config.quantumStep.errorScale, 20);
+});
+
+Deno.test("NeatOptions - CoerceNumeric handles nested sub-object string values", () => {
+  const config = createNeatConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: "3" as unknown as number,
+    },
+    adaptiveMutationThresholds: {
+      medium: "50" as unknown as number,
+      large: "200" as unknown as number,
+    },
+  });
+  assertEquals(config.discoveryMinCandidatesPerCategory.addNeurons, 3);
+  assertEquals(config.adaptiveMutationThresholds.medium, 50);
+  assertEquals(config.adaptiveMutationThresholds.large, 200);
+});
+
+Deno.test("NeatOptions - invalid numeric string throws", () => {
+  assertThrows(
+    () =>
+      createNeatConfig({
+        populationSize: "not_a_number" as unknown as number,
+      }),
+    Error,
+  );
+});
+
+Deno.test("NeatOptions - Omit list allows partial sub-object overrides", () => {
+  // NeatOptions Omit list should allow partial configs for sub-objects
+  // while NeatArguments requires Required<> versions
+  const config = createNeatConfig({
+    discoveryMinCandidatesPerCategory: { addNeurons: 5 },
+    adaptiveMutationThresholds: { medium: 30, large: 150 },
+    plateauDetection: { enabled: true },
+    stabilityAdaptation: { enabled: true },
+    weightRegularisation: { enabled: false },
+    biasRegularisation: { maxAbsoluteBias: 50 },
+    ensembleDiversity: { enabled: true },
+    quantumStep: { minStep: 0.001 },
+    fineTunePopulation: { successRateWindow: 5 },
+  });
+  assertEquals(config.discoveryMinCandidatesPerCategory.addNeurons, 5);
+  assertEquals(config.adaptiveMutationThresholds.medium, 30);
+  assertEquals(config.plateauDetection.enabled, true);
+  assertEquals(config.stabilityAdaptation.enabled, true);
+  assertEquals(config.weightRegularisation.enabled, false);
+  assertEquals(config.biasRegularisation.maxAbsoluteBias, 50);
+  assertEquals(config.ensembleDiversity.enabled, true);
+  assertEquals(config.quantumStep.minStep, 0.001);
+  assertEquals(config.fineTunePopulation.successRateWindow, 5);
+});
+
+Deno.test("NeatOptions - seed option produces deterministic RNG", () => {
+  const config1 = createNeatConfig({ seed: 42 });
+  const config2 = createNeatConfig({ seed: 42 });
+  // Same seed should produce same first random value
+  assertEquals(config1.rng.random(), config2.rng.random());
+});
+
+Deno.test("NeatOptions - seed accepts string from CLI", () => {
+  const config = createNeatConfig({
+    seed: "123" as unknown as number,
+  });
+  assertEquals(typeof config.rng.random(), "number");
+});
+
+Deno.test("NeatOptions - logLevel option is accepted", () => {
+  const config = createNeatConfig({ logLevel: "warn" });
+  assertEquals(typeof config.logger.info, "function");
+});
+
+Deno.test("NeatOptions - verbose enables logging", () => {
+  const config = createNeatConfig({ verbose: true });
+  assertEquals(config.verbose, true);
+  assertEquals(config.log, 1);
+});
+
+Deno.test("NeatOptions - feedbackLoop requires disableRandomSamples", () => {
+  // feedbackLoop=true should auto-set disableRandomSamples=true
+  const config = createNeatConfig({
+    feedbackLoop: true,
+    disableRandomSamples: true,
+  });
+  assertEquals(config.feedbackLoop, true);
+  assertEquals(config.disableRandomSamples, true);
+});
+
+Deno.test("NeatOptions - feedbackLoop without disableRandomSamples throws", () => {
+  assertThrows(
+    () =>
+      createNeatConfig({
+        feedbackLoop: true,
+        disableRandomSamples: false,
+      }),
+    Error,
+    "Feedback Loop",
+  );
+});

--- a/test/config/TrainOptions.ts
+++ b/test/config/TrainOptions.ts
@@ -1,0 +1,132 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import type { TrainOptions } from "../../src/config/TrainOptions.ts";
+
+Deno.test("TrainOptions - all fields are optional", () => {
+  // An empty object should satisfy the TrainOptions type
+  const opts: TrainOptions = {};
+  assertEquals(opts.log, undefined);
+  assertEquals(opts.targetError, undefined);
+  assertEquals(opts.iterations, undefined);
+  assertEquals(opts.traceStore, undefined);
+  assertEquals(opts.trainingSampleRate, undefined);
+  assertEquals(opts.trainingTimeOutMinutes, undefined);
+  assertEquals(opts.feedbackLoop, undefined);
+});
+
+Deno.test("TrainOptions - accepts partial training configuration", () => {
+  const opts: TrainOptions = {
+    log: 1,
+    targetError: 0.01,
+    iterations: 100,
+  };
+  assertEquals(opts.log, 1);
+  assertEquals(opts.targetError, 0.01);
+  assertEquals(opts.iterations, 100);
+});
+
+Deno.test("TrainOptions - accepts backpropagation fields", () => {
+  const opts: TrainOptions = {
+    learningRate: 0.01,
+    generations: 5,
+    batchSize: 32,
+    sparseRatio: 0.5,
+    disableBiasAdjustment: true,
+    disableWeightAdjustment: false,
+  };
+  assertEquals(opts.learningRate, 0.01);
+  assertEquals(opts.generations, 5);
+  assertEquals(opts.batchSize, 32);
+  assertEquals(opts.sparseRatio, 0.5);
+  assertEquals(opts.disableBiasAdjustment, true);
+  assertEquals(opts.disableWeightAdjustment, false);
+});
+
+Deno.test("TrainOptions - accepts adjustment scale fields", () => {
+  const opts: TrainOptions = {
+    maximumBiasAdjustmentScale: 5,
+    maximumWeightAdjustmentScale: 10,
+    limitBiasScale: 5000,
+    limitWeightScale: 50000,
+  };
+  assertEquals(opts.maximumBiasAdjustmentScale, 5);
+  assertEquals(opts.maximumWeightAdjustmentScale, 10);
+  assertEquals(opts.limitBiasScale, 5000);
+  assertEquals(opts.limitWeightScale, 50000);
+});
+
+Deno.test("TrainOptions - accepts learning rate strategy fields", () => {
+  const opts: TrainOptions = {
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.99,
+    warmRestartPeriod: 20,
+  };
+  assertEquals(opts.learningRateStrategy, "adaptive");
+  assertEquals(opts.initialLearningRate, 0.1);
+  assertEquals(opts.learningRateDecay, 0.99);
+  assertEquals(opts.warmRestartPeriod, 20);
+});
+
+Deno.test("TrainOptions - accepts all learning rate strategies", () => {
+  const strategies: Array<TrainOptions["learningRateStrategy"]> = [
+    "fixed",
+    "decay",
+    "adaptive",
+    "warm_restart",
+  ];
+  for (const strategy of strategies) {
+    const opts: TrainOptions = { learningRateStrategy: strategy };
+    assertEquals(opts.learningRateStrategy, strategy);
+  }
+});
+
+Deno.test("TrainOptions - accepts feedbackLoop field", () => {
+  const optsTrue: TrainOptions = { feedbackLoop: true };
+  const optsFalse: TrainOptions = { feedbackLoop: false };
+  assertEquals(optsTrue.feedbackLoop, true);
+  assertEquals(optsFalse.feedbackLoop, false);
+});
+
+Deno.test("TrainOptions - accepts traceStore path", () => {
+  const opts: TrainOptions = { traceStore: "/tmp/trace" };
+  assertEquals(opts.traceStore, "/tmp/trace");
+});
+
+Deno.test("TrainOptions - full configuration with all fields", () => {
+  const opts: TrainOptions = {
+    log: 1,
+    targetError: 0.01,
+    iterations: 50,
+    traceStore: "/tmp/trace",
+    trainingSampleRate: 0.8,
+    trainingTimeOutMinutes: 30,
+    feedbackLoop: false,
+    disableRandomSamples: false,
+    generations: 10,
+    learningRate: 0.01,
+    maximumBiasAdjustmentScale: 5,
+    maximumWeightAdjustmentScale: 10,
+    limitBiasScale: 5000,
+    limitWeightScale: 50000,
+    plankConstant: 0.001,
+    trainingMutationRate: 0.1,
+    disableBiasAdjustment: false,
+    disableWeightAdjustment: false,
+    batchSize: 64,
+    sparseRatio: 0.3,
+    learningRateStrategy: "decay",
+    initialLearningRate: 0.1,
+    learningRateDecay: 0.95,
+    warmRestartPeriod: 15,
+    biasWeightCoordinationFactor: 0.2,
+  };
+  // Verify a subset to confirm the full object is valid
+  assertNotEquals(opts, undefined);
+  assertEquals(opts.targetError, 0.01);
+  assertEquals(opts.biasWeightCoordinationFactor, 0.2);
+});
+
+Deno.test("TrainOptions - accepts bias-weight coordination factor", () => {
+  const opts: TrainOptions = { biasWeightCoordinationFactor: 0.5 };
+  assertEquals(opts.biasWeightCoordinationFactor, 0.5);
+});


### PR DESCRIPTION
## Summary

Add dedicated unit tests for five config modules that lacked test coverage. Closes #1483.

The `src/config/` directory contains 13 source files but several had no dedicated test files. This PR adds focused unit tests to improve confidence in configuration validation and default value handling.

## Files Added

- `test/config/BiasRegularisationConfig.ts` — 8 tests covering defaults, overrides, CLI string coercion, Required type verification, boolean fields, and zero l2Strength edge case
- `test/config/DiscoveryMinCandidatesPerCategory.ts` — 8 tests covering defaults, overrides, partial overrides, CLI string coercion, zero values, and Required type verification
- `test/config/NeatArguments.ts` — 9 tests verifying the full argument structure, sub-object configs, default values, array fields, boolean fields, logger/RNG presence, and optional string fields
- `test/config/NeatOptions.ts` — 12 tests covering numeric string coercion, partial sub-object overrides, invalid input errors, seed/RNG determinism, verbose mode, and feedbackLoop validation
- `test/config/TrainOptions.ts` — 10 tests verifying type structure, backpropagation fields, adjustment scales, learning rate strategies, and full configuration acceptance

## Evidence

This is a backend testing change with no UI components. All 3685 tests pass (including the 47 new tests) via `./quality.sh`.

## Test Plan

- Added `test/config/BiasRegularisationConfig.ts` (8 tests)
- Added `test/config/DiscoveryMinCandidatesPerCategory.ts` (8 tests)
- Added `test/config/NeatArguments.ts` (9 tests)
- Added `test/config/NeatOptions.ts` (12 tests)
- Added `test/config/TrainOptions.ts` (10 tests)
- All tests exercise real code via `createNeatConfig()` or type validation
- All tests pass via `./quality.sh` with 0 failures