### PR TITLE
Cleanup: Remove deprecated PREBUILD_SYNAPSE_THRESHOLD from Creature.ts (#1487)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.14",
+  "version": "0.312.15",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1487.md
+++ b/docs/pr-summary-1487.md
@@ -1,0 +1,14 @@
+## Summary
+
+Removed the deprecated `PREBUILD_SYNAPSE_THRESHOLD` static constant from `Creature.ts`. This constant was superseded when the Creature class was refactored into focused modules (Issue #1409), with the active version living in `src/creature/CreatureTopology.ts`. No code referenced the deprecated `Creature.PREBUILD_SYNAPSE_THRESHOLD` — all usages already point to the `CreatureTopology` version. Closes #1487.
+
+## Evidence
+
+This is a pure cleanup change (removing 3 lines of dead code). No functional behaviour changed:
+- Verified via `grep` that no code references `Creature.PREBUILD_SYNAPSE_THRESHOLD`
+- All 3823 tests pass via `./quality.sh`
+
+## Test Plan
+
+- No new tests needed — this removes unused dead code with no behavioural change
+- All existing tests (3823) continue to pass

--- a/docs/pr-summary-1487.md
+++ b/docs/pr-summary-1487.md
@@ -1,11 +1,19 @@
 ## Summary
 
-Removed the deprecated `PREBUILD_SYNAPSE_THRESHOLD` static constant from `Creature.ts`. This constant was superseded when the Creature class was refactored into focused modules (Issue #1409), with the active version living in `src/creature/CreatureTopology.ts`. No code referenced the deprecated `Creature.PREBUILD_SYNAPSE_THRESHOLD` — all usages already point to the `CreatureTopology` version. Closes #1487.
+Removed the deprecated `PREBUILD_SYNAPSE_THRESHOLD` static constant from
+`Creature.ts`. This constant was superseded when the Creature class was
+refactored into focused modules (Issue #1409), with the active version living in
+`src/creature/CreatureTopology.ts`. No code referenced the deprecated
+`Creature.PREBUILD_SYNAPSE_THRESHOLD` — all usages already point to the
+`CreatureTopology` version. Closes #1487.
 
 ## Evidence
 
-This is a pure cleanup change (removing 3 lines of dead code). No functional behaviour changed:
-- Verified via `grep` that no code references `Creature.PREBUILD_SYNAPSE_THRESHOLD`
+This is a pure cleanup change (removing 3 lines of dead code). No functional
+behaviour changed:
+
+- Verified via `grep` that no code references
+  `Creature.PREBUILD_SYNAPSE_THRESHOLD`
 - All 3823 tests pass via `./quality.sh`
 
 ## Test Plan

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -143,10 +143,6 @@ export class Creature implements CreatureInternal {
 
   DEBUG: boolean = getGlobalDebug();
 
-  /** @deprecated Use PREBUILD_SYNAPSE_THRESHOLD from creature/CreatureTopology.ts */
-  public static readonly PREBUILD_SYNAPSE_THRESHOLD =
-    topology.PREBUILD_SYNAPSE_THRESHOLD;
-
   constructor(
     input: number,
     output: number,


### PR DESCRIPTION
## Summary

Removed the deprecated `PREBUILD_SYNAPSE_THRESHOLD` static constant from `Creature.ts`. This constant was superseded when the Creature class was refactored into focused modules (Issue #1409), with the active version living in `src/creature/CreatureTopology.ts`. No code referenced the deprecated `Creature.PREBUILD_SYNAPSE_THRESHOLD` — all usages already point to the `CreatureTopology` version. Closes #1487.

## Evidence

This is a pure cleanup change (removing 3 lines of dead code). No functional behaviour changed:
- Verified via `grep` that no code references `Creature.PREBUILD_SYNAPSE_THRESHOLD`
- All 3823 tests pass via `./quality.sh`

## Test Plan

- No new tests needed — this removes unused dead code with no behavioural change
- All existing tests (3823) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)