### PR TITLE
Refactor: Add import map aliases for deep activation function imports (#1478)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -21,7 +21,15 @@
     "@std/streams": "jsr:@std/streams@1.0.17",
     "@std/uuid": "jsr:@std/uuid@1.1.0",
     "@std/testing/mock": "jsr:@std/testing@1.0.17/mock",
-    "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13"
+    "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13",
+    "@architecture/": "./src/architecture/",
+    "@errors/": "./src/errors/",
+    "@methods/": "./src/methods/",
+    "@neat/": "./src/NEAT/",
+    "@optimize/": "./src/optimize/",
+    "@propagate/": "./src/propagate/",
+    "@utils/": "./src/utils/",
+    "@globalAccessors": "./src/globalAccessors.ts"
   },
   "test": {
     "include": [

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.18",
+  "version": "0.312.19",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1478.md
+++ b/docs/pr-summary-1478.md
@@ -1,0 +1,33 @@
+## Summary
+
+Add import map aliases to `deno.json` for commonly imported internal modules, replacing deep relative imports (`../../../` or deeper) with clean path aliases across 39 files. This follows the established pattern already used for `@std/` and `@stsoftware/` dependencies. Closes #1478.
+
+## Changes
+
+### Import map aliases added to `deno.json`:
+- `@architecture/` → `./src/architecture/`
+- `@errors/` → `./src/errors/`
+- `@methods/` → `./src/methods/`
+- `@neat/` → `./src/NEAT/`
+- `@optimize/` → `./src/optimize/`
+- `@propagate/` → `./src/propagate/`
+- `@utils/` → `./src/utils/`
+- `@globalAccessors` → `./src/globalAccessors.ts`
+
+### Files updated (39 total):
+- **30 activation type files** (`src/methods/activations/types/*.ts`) - replaced `@propagate/`, `@errors/`, `@optimize/` aliases
+- **3 activation aggregate files** (`src/methods/activations/aggregate/*.ts`) - replaced `@propagate/`, `@architecture/`, `@optimize/`, `@neat/`, `@utils/` aliases
+- **2 worker files** (`src/multithreading/workers/deno/worker.ts`, `src/intelligentDesign/workers/deno/worker.ts`) - replaced `@globalAccessors` alias
+- **1 architecture file** (`src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts`) - replaced `@architecture/` alias
+
+## Evidence
+
+This is a pure refactoring change with no visual or behavioural changes:
+- `deno check mod.ts` passes cleanly
+- `deno publish --dry-run` succeeds (import map aliases are rewritten at publish time)
+- `quality.sh --skip-discovery` passes: all 3826 tests pass
+- Zero deep relative imports remain in `src/` (verified with grep)
+
+## Test Plan
+
+No new tests required - this is a mechanical import path refactoring. All 3826 existing tests pass, confirming no regressions.

--- a/docs/pr-summary-1478.md
+++ b/docs/pr-summary-1478.md
@@ -1,10 +1,14 @@
 ## Summary
 
-Add import map aliases to `deno.json` for commonly imported internal modules, replacing deep relative imports (`../../../` or deeper) with clean path aliases across 39 files. This follows the established pattern already used for `@std/` and `@stsoftware/` dependencies. Closes #1478.
+Add import map aliases to `deno.json` for commonly imported internal modules,
+replacing deep relative imports (`../../../` or deeper) with clean path aliases
+across 39 files. This follows the established pattern already used for `@std/`
+and `@stsoftware/` dependencies. Closes #1478.
 
 ## Changes
 
 ### Import map aliases added to `deno.json`:
+
 - `@architecture/` → `./src/architecture/`
 - `@errors/` → `./src/errors/`
 - `@methods/` → `./src/methods/`
@@ -15,19 +19,30 @@ Add import map aliases to `deno.json` for commonly imported internal modules, re
 - `@globalAccessors` → `./src/globalAccessors.ts`
 
 ### Files updated (39 total):
-- **30 activation type files** (`src/methods/activations/types/*.ts`) - replaced `@propagate/`, `@errors/`, `@optimize/` aliases
-- **3 activation aggregate files** (`src/methods/activations/aggregate/*.ts`) - replaced `@propagate/`, `@architecture/`, `@optimize/`, `@neat/`, `@utils/` aliases
-- **2 worker files** (`src/multithreading/workers/deno/worker.ts`, `src/intelligentDesign/workers/deno/worker.ts`) - replaced `@globalAccessors` alias
-- **1 architecture file** (`src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts`) - replaced `@architecture/` alias
+
+- **30 activation type files** (`src/methods/activations/types/*.ts`) - replaced
+  `@propagate/`, `@errors/`, `@optimize/` aliases
+- **3 activation aggregate files** (`src/methods/activations/aggregate/*.ts`) -
+  replaced `@propagate/`, `@architecture/`, `@optimize/`, `@neat/`, `@utils/`
+  aliases
+- **2 worker files** (`src/multithreading/workers/deno/worker.ts`,
+  `src/intelligentDesign/workers/deno/worker.ts`) - replaced `@globalAccessors`
+  alias
+- **1 architecture file**
+  (`src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts`) -
+  replaced `@architecture/` alias
 
 ## Evidence
 
 This is a pure refactoring change with no visual or behavioural changes:
+
 - `deno check mod.ts` passes cleanly
-- `deno publish --dry-run` succeeds (import map aliases are rewritten at publish time)
+- `deno publish --dry-run` succeeds (import map aliases are rewritten at publish
+  time)
 - `quality.sh --skip-discovery` passes: all 3826 tests pass
 - Zero deep relative imports remain in `src/` (verified with grep)
 
 ## Test Plan
 
-No new tests required - this is a mechanical import path refactoring. All 3826 existing tests pass, confirming no regressions.
+No new tests required - this is a mechanical import path refactoring. All 3826
+existing tests pass, confirming no regressions.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts
@@ -6,7 +6,7 @@
  */
 
 import { addTag, removeTag, type TagsInterface } from "@stsoftware/tags/mod";
-import { CreatureUtil } from "../../../mod.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import {
   cleanupMemeticForRemovedNeuron,
   cleanupOrphanedNeurons,

--- a/src/intelligentDesign/workers/deno/worker.ts
+++ b/src/intelligentDesign/workers/deno/worker.ts
@@ -6,7 +6,7 @@
 
 import type { RequestData } from "../WorkerHandler.ts";
 import type { ResponseData } from "../ResponseData.ts";
-import { setSkipWasmAutoInit } from "../../../globalAccessors.ts";
+import { setSkipWasmAutoInit } from "@globalAccessors";
 
 // Issue #1263: WASM activation is mandatory. For the library's internal worker
 // system, workers receive the WASM payload from the parent during init, so we

--- a/src/methods/activations/aggregate/IF.ts
+++ b/src/methods/activations/aggregate/IF.ts
@@ -1,29 +1,29 @@
-import { CreatureUtil } from "../../../architecture/CreatureUtils.ts";
-import type { DiscoverRecord } from "../../../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
-import type { Neuron } from "../../../architecture/Neuron.ts";
-import { Mutation } from "../../../NEAT/Mutation.ts";
-import { findActivationFunction } from "../../../optimize/FunctionCache.ts";
-import type { InlineActivationInterface } from "../../../optimize/InlineActivationInterface.ts";
-import type { MakeActivationFunctionInterface } from "../../../optimize/MakeActivationFunctionInterface.ts";
-import { makeSynapsesValue } from "../../../optimize/makeSynapsesValue.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import type { DiscoverRecord } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { Neuron } from "@architecture/Neuron.ts";
+import { Mutation } from "@neat/Mutation.ts";
+import { findActivationFunction } from "@optimize/FunctionCache.ts";
+import type { InlineActivationInterface } from "@optimize/InlineActivationInterface.ts";
+import type { MakeActivationFunctionInterface } from "@optimize/MakeActivationFunctionInterface.ts";
+import { makeSynapsesValue } from "@optimize/makeSynapsesValue.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
 import {
   type BackPropagationConfig,
   limitValue,
   toValue,
-} from "../../../propagate/BackPropagation.ts";
-import { accumulateBias, adjustedBias } from "../../../propagate/Bias.ts";
+} from "@propagate/BackPropagation.ts";
+import { accumulateBias, adjustedBias } from "@propagate/Bias.ts";
 import {
   buildRecordElasticLinks,
   constrainAndRedistributeRecordShares,
   distributeRecordError,
-} from "../../../propagate/RecordElasticity.ts";
-import type { SparseConfig } from "../../../propagate/sparse/SparseConfig.ts";
-import { accumulateWeight, adjustedWeight } from "../../../propagate/Weight.ts";
+} from "@propagate/RecordElasticity.ts";
+import type { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
+import { accumulateWeight, adjustedWeight } from "@propagate/Weight.ts";
 import type { ApplyLearningsInterface } from "../ApplyLearningsInterface.ts";
 import type { NeuronActivationInterface } from "../NeuronActivationInterface.ts";
 import { IDENTITY } from "../types/IDENTITY.ts";
-import { getRandomNumberGenerator } from "../../../utils/RandomNumberGenerator.ts";
+import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 
 export class IF
   implements

--- a/src/methods/activations/aggregate/MAXIMUM.ts
+++ b/src/methods/activations/aggregate/MAXIMUM.ts
@@ -1,20 +1,20 @@
 import { assert } from "@std/assert";
-import type { DiscoverRecord } from "../../../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
-import type { Neuron } from "../../../architecture/Neuron.ts";
-import { findActivationFunction } from "../../../optimize/FunctionCache.ts";
-import type { InlineActivationInterface } from "../../../optimize/InlineActivationInterface.ts";
-import type { MakeActivationFunctionInterface } from "../../../optimize/MakeActivationFunctionInterface.ts";
-import { makeSynapsesValue } from "../../../optimize/makeSynapsesValue.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
+import type { DiscoverRecord } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { Neuron } from "@architecture/Neuron.ts";
+import { findActivationFunction } from "@optimize/FunctionCache.ts";
+import type { InlineActivationInterface } from "@optimize/InlineActivationInterface.ts";
+import type { MakeActivationFunctionInterface } from "@optimize/MakeActivationFunctionInterface.ts";
+import { makeSynapsesValue } from "@optimize/makeSynapsesValue.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
 import {
   type BackPropagationConfig,
   toValue,
-} from "../../../propagate/BackPropagation.ts";
-import { accumulateBias, adjustedBias } from "../../../propagate/Bias.ts";
-import { getOrComputeRecordValue } from "../../../propagate/RecordElasticity.ts";
-import type { SparseConfig } from "../../../propagate/sparse/SparseConfig.ts";
-import type { SynapseState } from "../../../propagate/SynapseState.ts";
-import { accumulateWeight, adjustedWeight } from "../../../propagate/Weight.ts";
+} from "@propagate/BackPropagation.ts";
+import { accumulateBias, adjustedBias } from "@propagate/Bias.ts";
+import { getOrComputeRecordValue } from "@propagate/RecordElasticity.ts";
+import type { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
+import type { SynapseState } from "@propagate/SynapseState.ts";
+import { accumulateWeight, adjustedWeight } from "@propagate/Weight.ts";
 import type { ApplyLearningsInterface } from "../ApplyLearningsInterface.ts";
 import type { NeuronActivationInterface } from "../NeuronActivationInterface.ts";
 import { IDENTITY } from "../types/IDENTITY.ts";

--- a/src/methods/activations/aggregate/MINIMUM.ts
+++ b/src/methods/activations/aggregate/MINIMUM.ts
@@ -1,20 +1,20 @@
 import { assert } from "@std/assert";
-import type { DiscoverRecord } from "../../../architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
-import type { Neuron } from "../../../architecture/Neuron.ts";
-import { findActivationFunction } from "../../../optimize/FunctionCache.ts";
-import type { InlineActivationInterface } from "../../../optimize/InlineActivationInterface.ts";
-import type { MakeActivationFunctionInterface } from "../../../optimize/MakeActivationFunctionInterface.ts";
-import { makeSynapsesValue } from "../../../optimize/makeSynapsesValue.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
+import type { DiscoverRecord } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { Neuron } from "@architecture/Neuron.ts";
+import { findActivationFunction } from "@optimize/FunctionCache.ts";
+import type { InlineActivationInterface } from "@optimize/InlineActivationInterface.ts";
+import type { MakeActivationFunctionInterface } from "@optimize/MakeActivationFunctionInterface.ts";
+import { makeSynapsesValue } from "@optimize/makeSynapsesValue.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
 import {
   type BackPropagationConfig,
   toValue,
-} from "../../../propagate/BackPropagation.ts";
-import { accumulateBias, adjustedBias } from "../../../propagate/Bias.ts";
-import { getOrComputeRecordValue } from "../../../propagate/RecordElasticity.ts";
-import type { SparseConfig } from "../../../propagate/sparse/SparseConfig.ts";
-import type { SynapseState } from "../../../propagate/SynapseState.ts";
-import { accumulateWeight, adjustedWeight } from "../../../propagate/Weight.ts";
+} from "@propagate/BackPropagation.ts";
+import { accumulateBias, adjustedBias } from "@propagate/Bias.ts";
+import { getOrComputeRecordValue } from "@propagate/RecordElasticity.ts";
+import type { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
+import type { SynapseState } from "@propagate/SynapseState.ts";
+import { accumulateWeight, adjustedWeight } from "@propagate/Weight.ts";
 import type { ApplyLearningsInterface } from "../ApplyLearningsInterface.ts";
 import type { NeuronActivationInterface } from "../NeuronActivationInterface.ts";
 import { IDENTITY } from "../types/IDENTITY.ts";

--- a/src/methods/activations/types/ABSOLUTE.ts
+++ b/src/methods/activations/types/ABSOLUTE.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/ArcTan.ts
+++ b/src/methods/activations/types/ArcTan.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/BENT_IDENTITY.ts
+++ b/src/methods/activations/types/BENT_IDENTITY.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/BIPOLAR.ts
+++ b/src/methods/activations/types/BIPOLAR.ts
@@ -1,6 +1,6 @@
 import { assert } from "@std/assert";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/BIPOLAR_SIGMOID.ts
+++ b/src/methods/activations/types/BIPOLAR_SIGMOID.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/COMPLEMENT.ts
+++ b/src/methods/activations/types/COMPLEMENT.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/Cosine.ts
+++ b/src/methods/activations/types/Cosine.ts
@@ -9,12 +9,12 @@
  * https://en.wikipedia.org/wiki/Inverse_trigonometric_functions#Arccosine
  */
 import { assert } from "@std/assert";
-import type { SimplifyBiasInterface } from "../../../optimize/SimplifyBiasInterface.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
+import type { SimplifyBiasInterface } from "@optimize/SimplifyBiasInterface.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 
 export class Cosine
   implements ActivationInterface, UnSquashInterface, SimplifyBiasInterface {

--- a/src/methods/activations/types/Cube.ts
+++ b/src/methods/activations/types/Cube.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/ELU.ts
+++ b/src/methods/activations/types/ELU.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/Exponential.ts
+++ b/src/methods/activations/types/Exponential.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/GAUSSIAN.ts
+++ b/src/methods/activations/types/GAUSSIAN.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/GELU.ts
+++ b/src/methods/activations/types/GELU.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/HARD_TANH.ts
+++ b/src/methods/activations/types/HARD_TANH.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/IDENTITY.ts
+++ b/src/methods/activations/types/IDENTITY.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/ISRU.ts
+++ b/src/methods/activations/types/ISRU.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/LOGISTIC.ts
+++ b/src/methods/activations/types/LOGISTIC.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/LeakyReLU.ts
+++ b/src/methods/activations/types/LeakyReLU.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/LogSigmoid.ts
+++ b/src/methods/activations/types/LogSigmoid.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/Mish.ts
+++ b/src/methods/activations/types/Mish.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/ReLU.ts
+++ b/src/methods/activations/types/ReLU.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/ReLU6.ts
+++ b/src/methods/activations/types/ReLU6.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";
 

--- a/src/methods/activations/types/SELU.ts
+++ b/src/methods/activations/types/SELU.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/SINE.ts
+++ b/src/methods/activations/types/SINE.ts
@@ -1,11 +1,11 @@
 import { assert } from "@std/assert";
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import type { SimplifyBiasInterface } from "../../../optimize/SimplifyBiasInterface.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import type { SimplifyBiasInterface } from "@optimize/SimplifyBiasInterface.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 
 /**
  * SINE Activation Function

--- a/src/methods/activations/types/SOFTSIGN.ts
+++ b/src/methods/activations/types/SOFTSIGN.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/SQRT.ts
+++ b/src/methods/activations/types/SQRT.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 

--- a/src/methods/activations/types/SQUARE.ts
+++ b/src/methods/activations/types/SQUARE.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 

--- a/src/methods/activations/types/STEP.ts
+++ b/src/methods/activations/types/STEP.ts
@@ -1,7 +1,7 @@
 import { assert } from "@std/assert";
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/Softplus.ts
+++ b/src/methods/activations/types/Softplus.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/StdInverse.ts
+++ b/src/methods/activations/types/StdInverse.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/Swish.ts
+++ b/src/methods/activations/types/Swish.ts
@@ -1,5 +1,5 @@
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/TAN.ts
+++ b/src/methods/activations/types/TAN.ts
@@ -1,7 +1,7 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import type { SimplifyBiasInterface } from "../../../optimize/SimplifyBiasInterface.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import type { SimplifyBiasInterface } from "@optimize/SimplifyBiasInterface.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/methods/activations/types/TANH.ts
+++ b/src/methods/activations/types/TANH.ts
@@ -1,6 +1,6 @@
-import { ActivationError } from "../../../errors/ActivationError.ts";
-import { ActivationRange } from "../../../propagate/ActivationRange.ts";
-import { ErrorHelper } from "../../../propagate/ErrorHelper.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { ErrorHelper } from "@propagate/ErrorHelper.ts";
 import { ERROR_EPSILON } from "../AbstractActivationInterface.ts";
 import type { ActivationInterface } from "../ActivationInterface.ts";
 import type { UnSquashInterface } from "../UnSquashInterface.ts";

--- a/src/multithreading/workers/deno/worker.ts
+++ b/src/multithreading/workers/deno/worker.ts
@@ -1,5 +1,5 @@
 import type { RequestData, ResponseData } from "../WorkerHandler.ts";
-import { setSkipWasmAutoInit } from "../../../globalAccessors.ts";
+import { setSkipWasmAutoInit } from "@globalAccessors";
 
 // Issue #1263: WASM activation is mandatory. For the library's internal worker
 // system, workers receive the WASM payload from the parent during init, so we


### PR DESCRIPTION
## Summary

Add import map aliases to `deno.json` for commonly imported internal modules, replacing deep relative imports (`../../../` or deeper) with clean path aliases across 39 files. This follows the established pattern already used for `@std/` and `@stsoftware/` dependencies. Closes #1478.

## Changes

### Import map aliases added to `deno.json`:
- `@architecture/` → `./src/architecture/`
- `@errors/` → `./src/errors/`
- `@methods/` → `./src/methods/`
- `@neat/` → `./src/NEAT/`
- `@optimize/` → `./src/optimize/`
- `@propagate/` → `./src/propagate/`
- `@utils/` → `./src/utils/`
- `@globalAccessors` → `./src/globalAccessors.ts`

### Files updated (39 total):
- **30 activation type files** (`src/methods/activations/types/*.ts`) - replaced `@propagate/`, `@errors/`, `@optimize/` aliases
- **3 activation aggregate files** (`src/methods/activations/aggregate/*.ts`) - replaced `@propagate/`, `@architecture/`, `@optimize/`, `@neat/`, `@utils/` aliases
- **2 worker files** (`src/multithreading/workers/deno/worker.ts`, `src/intelligentDesign/workers/deno/worker.ts`) - replaced `@globalAccessors` alias
- **1 architecture file** (`src/architecture/ErrorGuidedStructuralEvolution/DiscoveryApplication.ts`) - replaced `@architecture/` alias

## Evidence

This is a pure refactoring change with no visual or behavioural changes:
- `deno check mod.ts` passes cleanly
- `deno publish --dry-run` succeeds (import map aliases are rewritten at publish time)
- `quality.sh --skip-discovery` passes: all 3826 tests pass
- Zero deep relative imports remain in `src/` (verified with grep)

## Test Plan

No new tests required - this is a mechanical import path refactoring. All 3826 existing tests pass, confirming no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)