### PR TITLE
Refactor: Introduce typed error classes for configuration and topology errors (#1479)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.19",
+  "version": "0.312.20",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1479.md
+++ b/docs/pr-summary-1479.md
@@ -1,0 +1,30 @@
+## Summary
+
+Introduce typed `ConfigurationError` and `TopologyError` classes following the existing error class pattern (`DiscoveryError`, `WasmError`, `ActivationError`). Migrated all generic `throw new Error()` calls in the 5 highest-impact files to use the appropriate typed error class, enabling consumers to catch errors by type and inspect structured `reason` fields.
+
+Closes #1479.
+
+### Changes
+
+- **New error classes** in `src/errors/`:
+  - `ConfigurationError` with reasons: `INVALID_TYPE`, `OUT_OF_RANGE`, `NOT_INTEGER`, `NOT_FINITE`, `CROSS_FIELD_VALIDATION`
+  - `TopologyError` with reasons: `INVALID_NEURON_TYPE`, `INVALID_SQUASH`, `MISSING_SQUASH`, `INVALID_CONNECTION`, `INVALID_STATE`, `DUPLICATE_UUID`, `MISSING_NEURON`, `SORT_FAILURE`, `EXCESSIVE_ERRORS`
+
+- **Migrated files**:
+  - `src/config/ParseOptions.ts` — 11 errors → `ConfigurationError`
+  - `src/config/NeatConfig.ts` — 9 errors → `ConfigurationError`
+  - `src/architecture/Neuron.ts` — 11 errors → `TopologyError` (5 "Not implemented" placeholders left as-is)
+  - `src/architecture/Offspring.ts` — 16 errors → `TopologyError`
+  - `src/architecture/CreatureValidate.ts` — 12 errors → `TopologyError` (existing `ValidationError` calls preserved)
+
+## Evidence
+
+This is a backend/CLI change with no visual output. All 3848 existing tests pass, plus 33 new tests verify the error classes and their integration.
+
+## Test Plan
+
+- `test/errors/ConfigurationError.ts` — 9 tests covering all reason types, instanceof checks, and selective catching
+- `test/errors/TopologyError.ts` — 13 tests covering all reason types, instanceof checks, and selective catching
+- `test/errors/ConfigurationErrorIntegration.ts` — 6 tests verifying `parseNumber` and `parseDiscoverySampleRate` throw `ConfigurationError`
+- `test/errors/TopologyErrorIntegration.ts` — 5 tests verifying `Neuron` constructor, validate, exportJSON, and mutate throw `TopologyError`
+- All 3848 existing tests continue to pass (backward-compatible since new classes extend `Error`)

--- a/docs/pr-summary-1479.md
+++ b/docs/pr-summary-1479.md
@@ -1,30 +1,45 @@
 ## Summary
 
-Introduce typed `ConfigurationError` and `TopologyError` classes following the existing error class pattern (`DiscoveryError`, `WasmError`, `ActivationError`). Migrated all generic `throw new Error()` calls in the 5 highest-impact files to use the appropriate typed error class, enabling consumers to catch errors by type and inspect structured `reason` fields.
+Introduce typed `ConfigurationError` and `TopologyError` classes following the
+existing error class pattern (`DiscoveryError`, `WasmError`, `ActivationError`).
+Migrated all generic `throw new Error()` calls in the 5 highest-impact files to
+use the appropriate typed error class, enabling consumers to catch errors by
+type and inspect structured `reason` fields.
 
 Closes #1479.
 
 ### Changes
 
 - **New error classes** in `src/errors/`:
-  - `ConfigurationError` with reasons: `INVALID_TYPE`, `OUT_OF_RANGE`, `NOT_INTEGER`, `NOT_FINITE`, `CROSS_FIELD_VALIDATION`
-  - `TopologyError` with reasons: `INVALID_NEURON_TYPE`, `INVALID_SQUASH`, `MISSING_SQUASH`, `INVALID_CONNECTION`, `INVALID_STATE`, `DUPLICATE_UUID`, `MISSING_NEURON`, `SORT_FAILURE`, `EXCESSIVE_ERRORS`
+  - `ConfigurationError` with reasons: `INVALID_TYPE`, `OUT_OF_RANGE`,
+    `NOT_INTEGER`, `NOT_FINITE`, `CROSS_FIELD_VALIDATION`
+  - `TopologyError` with reasons: `INVALID_NEURON_TYPE`, `INVALID_SQUASH`,
+    `MISSING_SQUASH`, `INVALID_CONNECTION`, `INVALID_STATE`, `DUPLICATE_UUID`,
+    `MISSING_NEURON`, `SORT_FAILURE`, `EXCESSIVE_ERRORS`
 
 - **Migrated files**:
   - `src/config/ParseOptions.ts` — 11 errors → `ConfigurationError`
   - `src/config/NeatConfig.ts` — 9 errors → `ConfigurationError`
-  - `src/architecture/Neuron.ts` — 11 errors → `TopologyError` (5 "Not implemented" placeholders left as-is)
+  - `src/architecture/Neuron.ts` — 11 errors → `TopologyError` (5 "Not
+    implemented" placeholders left as-is)
   - `src/architecture/Offspring.ts` — 16 errors → `TopologyError`
-  - `src/architecture/CreatureValidate.ts` — 12 errors → `TopologyError` (existing `ValidationError` calls preserved)
+  - `src/architecture/CreatureValidate.ts` — 12 errors → `TopologyError`
+    (existing `ValidationError` calls preserved)
 
 ## Evidence
 
-This is a backend/CLI change with no visual output. All 3848 existing tests pass, plus 33 new tests verify the error classes and their integration.
+This is a backend/CLI change with no visual output. All 3848 existing tests
+pass, plus 33 new tests verify the error classes and their integration.
 
 ## Test Plan
 
-- `test/errors/ConfigurationError.ts` — 9 tests covering all reason types, instanceof checks, and selective catching
-- `test/errors/TopologyError.ts` — 13 tests covering all reason types, instanceof checks, and selective catching
-- `test/errors/ConfigurationErrorIntegration.ts` — 6 tests verifying `parseNumber` and `parseDiscoverySampleRate` throw `ConfigurationError`
-- `test/errors/TopologyErrorIntegration.ts` — 5 tests verifying `Neuron` constructor, validate, exportJSON, and mutate throw `TopologyError`
-- All 3848 existing tests continue to pass (backward-compatible since new classes extend `Error`)
+- `test/errors/ConfigurationError.ts` — 9 tests covering all reason types,
+  instanceof checks, and selective catching
+- `test/errors/TopologyError.ts` — 13 tests covering all reason types,
+  instanceof checks, and selective catching
+- `test/errors/ConfigurationErrorIntegration.ts` — 6 tests verifying
+  `parseNumber` and `parseDiscoverySampleRate` throw `ConfigurationError`
+- `test/errors/TopologyErrorIntegration.ts` — 5 tests verifying `Neuron`
+  constructor, validate, exportJSON, and mutate throw `TopologyError`
+- All 3848 existing tests continue to pass (backward-compatible since new
+  classes extend `Error`)

--- a/src/architecture/CreatureValidate.ts
+++ b/src/architecture/CreatureValidate.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import type { Creature } from "../Creature.ts";
+import { TopologyError } from "../errors/TopologyError.ts";
 import { ValidationError } from "../errors/ValidationError.ts";
 
 const MAX_NEURON_UUID_LENGTH = 256;
@@ -186,8 +187,9 @@ export function creatureValidate(
         stats.input++;
         const toList = creature.inwardConnections(indx);
         if (toList.length > 0) {
-          throw new Error(
+          throw new TopologyError(
             `'input' neuron ${neuron.ID()} has inward connections: ${toList.length}`,
+            "INVALID_CONNECTION",
           );
         }
         break;
@@ -197,13 +199,15 @@ export function creatureValidate(
         const toList = creature.inwardConnections(indx);
         if (toList.length > 0) {
           debugWrite(creature);
-          throw new Error(
+          throw new TopologyError(
             `'${neuron.type}' neuron ${neuron.ID()} has inward connections: ${toList.length}`,
+            "INVALID_CONNECTION",
           );
         }
         if (neuron.squash) {
-          throw new Error(
+          throw new TopologyError(
             `Node ${neuron.ID()} '${neuron.type}' has squash: ${neuron.squash}`,
+            "INVALID_SQUASH",
           );
         }
         const fromList = creature.outwardConnections(indx);
@@ -234,13 +238,15 @@ export function creatureValidate(
           );
         }
         if (neuron.bias === undefined) {
-          throw new Error(
+          throw new TopologyError(
             `hidden neuron ${neuron.ID()} should have a bias was: ${neuron.bias}`,
+            "INVALID_STATE",
           );
         }
         if (!Number.isFinite(neuron.bias)) {
-          throw new Error(
+          throw new TopologyError(
             `${neuron.ID()}) hidden neuron should have a finite bias was: ${neuron.bias}`,
+            "INVALID_STATE",
           );
         }
 
@@ -254,7 +260,10 @@ export function creatureValidate(
         break;
       }
       default:
-        throw new Error(`${neuron.ID()}) Invalid type: ${neuron.type}`);
+        throw new TopologyError(
+          `${neuron.ID()}) Invalid type: ${neuron.type}`,
+          "INVALID_NEURON_TYPE",
+        );
     }
 
     if (neuron.index !== indx) {
@@ -265,7 +274,10 @@ export function creatureValidate(
     }
 
     if (neuron.creature !== creature) {
-      throw new Error(`node ${neuron.ID()} creature mismatch`);
+      throw new TopologyError(
+        `node ${neuron.ID()} creature mismatch`,
+        "INVALID_STATE",
+      );
     }
   });
 
@@ -277,8 +289,9 @@ export function creatureValidate(
   }
 
   if (stats.output !== creature.output) {
-    throw new Error(
+    throw new TopologyError(
       `Expected ${creature.output} output neurons found: ${stats.output}`,
+      "INVALID_STATE",
     );
   }
 
@@ -289,7 +302,10 @@ export function creatureValidate(
     const toNode = creature.neurons[c.to];
 
     if (toNode.type === "input") {
-      throw new Error(indx + ") connection points to an input node");
+      throw new TopologyError(
+        indx + ") connection points to an input node",
+        "INVALID_CONNECTION",
+      );
     }
 
     if (forwardOnly && c.from === c.to) {
@@ -303,20 +319,22 @@ export function creatureValidate(
     }
 
     if (c.from < lastFrom) {
-      throw new Error(indx + ") synapses not sorted");
+      throw new TopologyError(indx + ") synapses not sorted", "SORT_FAILURE");
     } else if (c.from > lastFrom) {
       lastTo = -1;
     }
 
     if (c.from === lastFrom) {
       if (c.to < lastTo) {
-        throw new Error(
+        throw new TopologyError(
           indx + ") synapses not sorted " + c.from + "->" + c.to +
             " last to: " + lastTo,
+          "SORT_FAILURE",
         );
       } else if (c.to === lastTo) {
-        throw new Error(
+        throw new TopologyError(
           indx + ") duplicate self connection synapse " + c.from + "->" + c.to,
+          "INVALID_CONNECTION",
         );
       }
     }

--- a/src/architecture/Neuron.ts
+++ b/src/architecture/Neuron.ts
@@ -1,6 +1,7 @@
 import { assert } from "@std/assert";
 import { addTags, removeTag, type TagsInterface } from "@stsoftware/tags/mod";
 import type { Creature } from "../Creature.ts";
+import { TopologyError } from "../errors/TopologyError.ts";
 import { getLogger } from "../utils/Logger.ts";
 import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import type { ActivationInterface } from "../methods/activations/ActivationInterface.ts";
@@ -129,15 +130,16 @@ export class Neuron implements TagsInterface, NeuronInternal {
 
     if (type !== "input") {
       if (type !== "output" && type !== "hidden" && type !== "constant") {
-        throw new Error("invalid type: " + type);
+        throw new TopologyError("invalid type: " + type, "INVALID_NEURON_TYPE");
       }
 
       this.bias = bias;
 
       if (type === "constant") {
         if (squash) {
-          throw new Error(
+          throw new TopologyError(
             "constants should not have a squash was: " + squash,
+            "INVALID_SQUASH",
           );
         }
       } else {
@@ -159,15 +161,24 @@ export class Neuron implements TagsInterface, NeuronInternal {
   public validate() {
     if (this.type === "output" || this.type === "hidden") {
       if (!this.squash) {
-        throw new Error(`Missing squash for ${this.type} neuron`);
+        throw new TopologyError(
+          `Missing squash for ${this.type} neuron`,
+          "MISSING_SQUASH",
+        );
       }
     } else {
       if (this.squash) {
-        throw new Error(`Unexpected squash for ${this.type} neuron`);
+        throw new TopologyError(
+          `Unexpected squash for ${this.type} neuron`,
+          "INVALID_SQUASH",
+        );
       }
 
       if (this.squashMethodCache) {
-        throw new Error(`Unexpected squashMethodCache for ${this.type} neuron`);
+        throw new TopologyError(
+          `Unexpected squashMethodCache for ${this.type} neuron`,
+          "INVALID_STATE",
+        );
       }
     }
   }
@@ -981,10 +992,11 @@ export class Neuron implements TagsInterface, NeuronInternal {
         getLogger().error(
           `❌ CRITICAL: Neuron ${this.uuid} has ${discoverRecord.errors.length} errors - likely infinite recursion!`,
         );
-        throw new Error(
+        throw new TopologyError(
           `Excessive error accumulation detected on neuron ${this.uuid}. ` +
             `Got ${discoverRecord.errors.length} errors. ` +
             `This suggests infinite recursion in backpropagation.`,
+          "EXCESSIVE_ERRORS",
         );
       }
     }
@@ -1176,10 +1188,16 @@ export class Neuron implements TagsInterface, NeuronInternal {
    */
   mutate(method: string): boolean {
     if (typeof method !== "string") {
-      throw new Error("Mutate method wrong type: " + (typeof method));
+      throw new TopologyError(
+        "Mutate method wrong type: " + (typeof method),
+        "INVALID_STATE",
+      );
     }
     if (this.type === "input") {
-      throw new Error("Mutate on wrong node type: " + this.type);
+      throw new TopologyError(
+        "Mutate on wrong node type: " + this.type,
+        "INVALID_NEURON_TYPE",
+      );
     }
     let changed = false;
     switch (method) {
@@ -1189,7 +1207,10 @@ export class Neuron implements TagsInterface, NeuronInternal {
           case "output":
             break;
           default:
-            throw new Error(`Can't modify activation for type ${this.type}`);
+            throw new TopologyError(
+              `Can't modify activation for type ${this.type}`,
+              "INVALID_NEURON_TYPE",
+            );
         }
         const tmpSquash = Activations.pickRandomSquash(this.squash);
 
@@ -1218,7 +1239,10 @@ export class Neuron implements TagsInterface, NeuronInternal {
         break;
       }
       default:
-        throw new Error("Unknown mutate method: " + method);
+        throw new TopologyError(
+          "Unknown mutate method: " + method,
+          "INVALID_STATE",
+        );
     }
     if (changed) {
       delete this.creature.uuid;
@@ -1240,7 +1264,10 @@ export class Neuron implements TagsInterface, NeuronInternal {
    */
   exportJSON(): NeuronExport {
     if (this.type === "input") {
-      throw new Error(`Should not be exporting 'input'`);
+      throw new TopologyError(
+        `Should not be exporting 'input'`,
+        "INVALID_NEURON_TYPE",
+      );
     } else if (this.type === "constant") {
       return {
         type: this.type,

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -4,6 +4,7 @@ import { memeticUpdate } from "../blackbox/MemeticUpdate.ts";
 import { editParentByIndex } from "../breed/EditParentByIndex.ts";
 import { geneticCompatibility } from "../breed/GeneticCompatibility.ts";
 import { Creature } from "../Creature.ts";
+import { TopologyError } from "../errors/TopologyError.ts";
 import { getRandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
 import {
   getMajorVersion,
@@ -156,7 +157,10 @@ export class Offspring {
                 }
               }
               if (!fromNeuron) {
-                throw new Error(`Can't find ${connection.fromUUID}`);
+                throw new TopologyError(
+                  `Can't find ${connection.fromUUID}`,
+                  "MISSING_NEURON",
+                );
               }
 
               neuronMap.set(fromNeuron.uuid, fromNeuron);
@@ -171,7 +175,10 @@ export class Offspring {
             }
           }
         } else {
-          throw new Error(`Can't find connections for ${uuid}`);
+          throw new TopologyError(
+            `Can't find connections for ${uuid}`,
+            "MISSING_NEURON",
+          );
         }
       }
     } while (addedMissing);
@@ -184,13 +191,19 @@ export class Offspring {
       if (!tmpUUIDs.has(neuron.uuid)) {
         const connections = connectionsMap.get(neuron.uuid);
         if (!connections) {
-          throw new Error(`Can't find connections for ${neuron.uuid}`);
+          throw new TopologyError(
+            `Can't find connections for ${neuron.uuid}`,
+            "MISSING_NEURON",
+          );
         }
         tmpUUIDs.add(neuron.uuid);
         connections.forEach((connection) => {
           const fromNeuron = neuronMap.get(connection.fromUUID);
           if (!fromNeuron) {
-            throw new Error(`Can't find ${connection.fromUUID}`);
+            throw new TopologyError(
+              `Can't find ${connection.fromUUID}`,
+              "MISSING_NEURON",
+            );
           } else if (fromNeuron.type !== "input") {
             cloneNode(fromNeuron);
           }
@@ -212,7 +225,7 @@ export class Offspring {
       if (node !== undefined) {
         cloneNode(node);
       } else {
-        throw new Error(`Can't find output-${indx}`);
+        throw new TopologyError(`Can't find output-${indx}`, "MISSING_NEURON");
       }
     }
 
@@ -265,7 +278,10 @@ export class Offspring {
       if (neuron.type !== "input") {
         const connections = connectionsMap.get(neuron.uuid);
         if (!connections) {
-          throw new Error(`Can't find connections for ${neuron.uuid}`);
+          throw new TopologyError(
+            `Can't find connections for ${neuron.uuid}`,
+            "MISSING_NEURON",
+          );
         }
         connections.forEach((c) => {
           const fromIndx = indxMap.get(c.fromUUID);
@@ -287,13 +303,15 @@ export class Offspring {
                   });
                 }
               } else {
-                throw new Error(
+                throw new TopologyError(
                   `Can't connect to ${toType} neuron at indx=${toIndx} of type ${toType}!`,
+                  "INVALID_CONNECTION",
                 );
               }
             } else {
-              throw new Error(
+              throw new TopologyError(
                 `${neuron.ID()} fromIndx=${fromIndx} > toIndx=${toIndx}`,
+                "INVALID_CONNECTION",
               );
             }
           }
@@ -401,13 +419,14 @@ export class Offspring {
 
             // If BOTH parents are 4.x, this is a bug in the breeding logic
             if (bothParentsFourX) {
-              throw new Error(
+              throw new TopologyError(
                 `[Offspring] CRITICAL: Both parents are 4.x but offspring has recurrent connections. ` +
                   `This is a bug in the breeding logic that must be fixed. ` +
                   `Mother: ${mother.uuid} (${mother.semanticVersion}), ` +
                   `Father: ${father.uuid} (${father.semanticVersion}). ` +
                   `Error=${error.name}: ${error.message}. ` +
                   `Violations: ${violations.join(" | ")}`,
+                "INVALID_CONNECTION",
               );
             }
 
@@ -533,23 +552,29 @@ export class Offspring {
       }
 
       if (a.uuid === b.uuid) {
-        throw new Error(`Duplicate uuid ${a.uuid}`);
+        throw new TopologyError(`Duplicate uuid ${a.uuid}`, "DUPLICATE_UUID");
       }
       let indxA = firstMap.get(a.uuid);
       if (indxA === undefined) {
         indxA = secondMap.get(a.uuid);
-        if (indxA === undefined) throw new Error(`Can't find ${a.uuid}`);
+        if (indxA === undefined) {
+          throw new TopologyError(`Can't find ${a.uuid}`, "MISSING_NEURON");
+        }
         indxA += 0.1;
       }
 
       let indxB = firstMap.get(b.uuid);
       if (indxB === undefined) {
         indxB = secondMap.get(b.uuid);
-        if (indxB === undefined) throw new Error(`Can't find ${b.uuid}`);
+        if (indxB === undefined) {
+          throw new TopologyError(`Can't find ${b.uuid}`, "MISSING_NEURON");
+        }
         indxB += 0.1;
       }
 
-      if (indxA === indxB) throw new Error(`Duplicate index ${indxA}`);
+      if (indxA === indxB) {
+        throw new TopologyError(`Duplicate index ${indxA}`, "DUPLICATE_UUID");
+      }
 
       return indxA - indxB;
     });
@@ -572,8 +597,9 @@ export class Offspring {
             } else if (secondIndx !== undefined) {
               indx = secondIndx;
             } else {
-              throw new Error(
+              throw new TopologyError(
                 `Can't find ${uuid} in father or mother creatures!`,
+                "MISSING_NEURON",
               );
             }
             connectionsMap.get(uuid)?.forEach((connection) => {
@@ -630,9 +656,13 @@ export class Offspring {
         return a.index - b.index;
       } else {
         const aIndx = childMap.get(a.uuid);
-        if (aIndx === undefined) throw new Error(`Can't find ${a.uuid}`);
+        if (aIndx === undefined) {
+          throw new TopologyError(`Can't find ${a.uuid}`, "MISSING_NEURON");
+        }
         const bIndx = childMap.get(b.uuid);
-        if (bIndx === undefined) throw new Error(`Can't find ${b.uuid}`);
+        if (bIndx === undefined) {
+          throw new TopologyError(`Can't find ${b.uuid}`, "MISSING_NEURON");
+        }
 
         /*
          * Sort by index in child array, if not input or output.

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -1,4 +1,5 @@
 import type { NeatOptionsInput } from "./NeatOptions.ts";
+import { ConfigurationError } from "../errors/ConfigurationError.ts";
 import { getGlobalDebug } from "../globalAccessors.ts";
 import {
   DEFAULT_RUST_FLUSH_BYTES,
@@ -850,9 +851,10 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
 
   // Cross-field validation for quantum step config
   if (config.quantumStep.maxStep < config.quantumStep.minStep) {
-    throw new Error(
+    throw new ConfigurationError(
       `Quantum step maxStep must be >= minStep. ` +
         `maxStep: ${config.quantumStep.maxStep}, minStep: ${config.quantumStep.minStep}`,
+      "CROSS_FIELD_VALIDATION",
     );
   }
 
@@ -861,30 +863,33 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
     config.fineTunePopulation.maxPopulationFraction <
       config.fineTunePopulation.minPopulationFraction
   ) {
-    throw new Error(
+    throw new ConfigurationError(
       `Fine-tune population maxPopulationFraction must be >= minPopulationFraction. ` +
         `maxPopulationFraction: ${config.fineTunePopulation.maxPopulationFraction}, ` +
         `minPopulationFraction: ${config.fineTunePopulation.minPopulationFraction}`,
+      "CROSS_FIELD_VALIDATION",
     );
   }
   if (
     config.fineTunePopulation.basePopulationFraction <
       config.fineTunePopulation.minPopulationFraction
   ) {
-    throw new Error(
+    throw new ConfigurationError(
       `Fine-tune population basePopulationFraction must be >= minPopulationFraction. ` +
         `basePopulationFraction: ${config.fineTunePopulation.basePopulationFraction}, ` +
         `minPopulationFraction: ${config.fineTunePopulation.minPopulationFraction}`,
+      "CROSS_FIELD_VALIDATION",
     );
   }
   if (
     config.fineTunePopulation.basePopulationFraction >
       config.fineTunePopulation.maxPopulationFraction
   ) {
-    throw new Error(
+    throw new ConfigurationError(
       `Fine-tune population basePopulationFraction must be <= maxPopulationFraction. ` +
         `basePopulationFraction: ${config.fineTunePopulation.basePopulationFraction}, ` +
         `maxPopulationFraction: ${config.fineTunePopulation.maxPopulationFraction}`,
+      "CROSS_FIELD_VALIDATION",
     );
   }
 
@@ -895,8 +900,9 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
 function validate(config: NeatArguments) {
   // Cross-field validation not covered by parseNumber
   if (config.feedbackLoop === true && config.disableRandomSamples === false) {
-    throw new Error(
+    throw new ConfigurationError(
       "Feedback Loop, Disable Random Samples must be set together",
+      "CROSS_FIELD_VALIDATION",
     );
   }
 
@@ -904,9 +910,10 @@ function validate(config: NeatArguments) {
   if (
     adaptiveThresholds.large <= adaptiveThresholds.medium
   ) {
-    throw new Error(
+    throw new ConfigurationError(
       `Adaptive mutation large threshold must be greater than medium threshold. ` +
         `Large: ${adaptiveThresholds.large}, Medium: ${adaptiveThresholds.medium}`,
+      "CROSS_FIELD_VALIDATION",
     );
   }
 
@@ -915,23 +922,26 @@ function validate(config: NeatArguments) {
     plateauDetection.rapidImprovementRate <=
       plateauDetection.minImprovementRate
   ) {
-    throw new Error(
+    throw new ConfigurationError(
       `Plateau detection rapidImprovementRate must be greater than minImprovementRate. ` +
         `rapidImprovementRate: ${plateauDetection.rapidImprovementRate}, minImprovementRate: ${plateauDetection.minImprovementRate}`,
+      "CROSS_FIELD_VALIDATION",
     );
   }
 
   if (!Array.isArray(config.discoveryFocusNeuronUUIDs)) {
-    throw new Error(
+    throw new ConfigurationError(
       "Discovery focus neuron UUIDs must be an array when provided.",
+      "INVALID_TYPE",
     );
   }
   for (const uuid of config.discoveryFocusNeuronUUIDs) {
     if (typeof uuid !== "string" || uuid.trim().length === 0) {
-      throw new Error(
+      throw new ConfigurationError(
         `Discovery focus neuron UUIDs must be non-empty strings, found: ${
           String(uuid)
         }`,
+        "INVALID_TYPE",
       );
     }
   }

--- a/src/config/ParseOptions.ts
+++ b/src/config/ParseOptions.ts
@@ -6,6 +6,8 @@
  * happen once in createNeatConfig. NeatConfig is always valid after creation.
  */
 
+import { ConfigurationError } from "../errors/ConfigurationError.ts";
+
 export interface NumberConstraints {
   /** Minimum value (inclusive). */
   min?: number;
@@ -26,7 +28,7 @@ export interface NumberConstraints {
  * @param defaultValue - Value to use when undefined/absent
  * @param constraints - Optional min, max, integer constraints
  * @returns Parsed, validated number
- * @throws Error with clear message when value fails to parse or is out of range
+ * @throws ConfigurationError with clear message when value fails to parse or is out of range
  */
 export function parseNumber(
   fieldName: string,
@@ -42,20 +44,23 @@ export function parseNumber(
   if (typeof value === "string") {
     num = Number(value);
     if (!Number.isFinite(num) || value.trim() === "") {
-      throw new Error(
+      throw new ConfigurationError(
         `${fieldName} must be a number, got: ${JSON.stringify(value)}`,
+        "NOT_FINITE",
       );
     }
   } else if (typeof value === "number") {
     num = value;
     if (!Number.isFinite(num)) {
-      throw new Error(
+      throw new ConfigurationError(
         `${fieldName} must be a finite number, got: ${value}`,
+        "NOT_FINITE",
       );
     }
   } else {
-    throw new Error(
+    throw new ConfigurationError(
       `${fieldName} must be a number or string, got: ${typeof value}`,
+      "INVALID_TYPE",
     );
   }
 
@@ -67,8 +72,9 @@ export function parseNumber(
 
   if (constraints?.integer) {
     if (!Number.isInteger(num)) {
-      throw new Error(
+      throw new ConfigurationError(
         `${fieldName} must be an integer, got: ${num}`,
+        "NOT_INTEGER",
       );
     }
   }
@@ -77,16 +83,18 @@ export function parseNumber(
     const rangeMsg = constraints.max !== undefined
       ? `between ${constraints.min} and ${constraints.max}`
       : `at least ${constraints.min}`;
-    throw new Error(
+    throw new ConfigurationError(
       `${fieldName} must be ${rangeMsg}, got: ${num}`,
+      "OUT_OF_RANGE",
     );
   }
 
   if (
     constraints?.minExclusive !== undefined && num <= constraints.minExclusive
   ) {
-    throw new Error(
+    throw new ConfigurationError(
       `${fieldName} must be greater than ${constraints.minExclusive}, got: ${num}`,
+      "OUT_OF_RANGE",
     );
   }
 
@@ -94,8 +102,9 @@ export function parseNumber(
     const rangeMsg = constraints.min !== undefined
       ? `between ${constraints.min} and ${constraints.max}`
       : `at most ${constraints.max}`;
-    throw new Error(
+    throw new ConfigurationError(
       `${fieldName} must be ${rangeMsg}, got: ${num}`,
+      "OUT_OF_RANGE",
     );
   }
 
@@ -121,22 +130,25 @@ export function parseDiscoverySampleRate(
   if (typeof value === "string") {
     num = Number(value);
     if (!Number.isFinite(num) || value.trim() === "") {
-      throw new Error(
+      throw new ConfigurationError(
         `Discovery sample rate must be -1 (disabled) or between 0 and 1, got: ${
           JSON.stringify(value)
         }`,
+        "OUT_OF_RANGE",
       );
     }
   } else if (typeof value === "number") {
     num = value;
     if (!Number.isFinite(num)) {
-      throw new Error(
+      throw new ConfigurationError(
         `Discovery sample rate must be -1 (disabled) or between 0 and 1, got: ${num}`,
+        "NOT_FINITE",
       );
     }
   } else {
-    throw new Error(
+    throw new ConfigurationError(
       `Discovery sample rate must be a number or string, got: ${typeof value}`,
+      "INVALID_TYPE",
     );
   }
 
@@ -152,7 +164,8 @@ export function parseDiscoverySampleRate(
   if (num >= 0 && num <= 1) {
     return num;
   }
-  throw new Error(
+  throw new ConfigurationError(
     `Discovery sample rate must be -1 (disabled) or between 0 and 1, got: ${num}`,
+    "OUT_OF_RANGE",
   );
 }

--- a/src/errors/ConfigurationError.ts
+++ b/src/errors/ConfigurationError.ts
@@ -1,0 +1,25 @@
+/**
+ * Typed error for configuration parsing and validation failures.
+ *
+ * Consumers can catch `ConfigurationError` and inspect `reason` to handle
+ * specific failure modes programmatically.
+ *
+ * @module ConfigurationError
+ */
+
+export type ConfigurationErrorReason =
+  | "INVALID_TYPE"
+  | "OUT_OF_RANGE"
+  | "NOT_INTEGER"
+  | "NOT_FINITE"
+  | "CROSS_FIELD_VALIDATION";
+
+export class ConfigurationError extends Error {
+  override readonly name = "ConfigurationError";
+  readonly reason: ConfigurationErrorReason;
+
+  constructor(message: string, reason: ConfigurationErrorReason) {
+    super(message);
+    this.reason = reason;
+  }
+}

--- a/src/errors/TopologyError.ts
+++ b/src/errors/TopologyError.ts
@@ -1,0 +1,29 @@
+/**
+ * Typed error for network topology errors.
+ *
+ * Consumers can catch `TopologyError` and inspect `reason` to handle
+ * specific failure modes programmatically.
+ *
+ * @module TopologyError
+ */
+
+export type TopologyErrorReason =
+  | "INVALID_NEURON_TYPE"
+  | "INVALID_SQUASH"
+  | "MISSING_SQUASH"
+  | "INVALID_CONNECTION"
+  | "INVALID_STATE"
+  | "DUPLICATE_UUID"
+  | "MISSING_NEURON"
+  | "SORT_FAILURE"
+  | "EXCESSIVE_ERRORS";
+
+export class TopologyError extends Error {
+  override readonly name = "TopologyError";
+  readonly reason: TopologyErrorReason;
+
+  constructor(message: string, reason: TopologyErrorReason) {
+    super(message);
+    this.reason = reason;
+  }
+}

--- a/test/errors/ConfigurationError.ts
+++ b/test/errors/ConfigurationError.ts
@@ -1,0 +1,96 @@
+import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import {
+  ConfigurationError,
+  type ConfigurationErrorReason,
+} from "../../src/errors/ConfigurationError.ts";
+
+Deno.test("ConfigurationError - INVALID_TYPE reason", () => {
+  const error = new ConfigurationError(
+    "Threads must be a number or string, got: boolean",
+    "INVALID_TYPE",
+  );
+  assertIsError(error, ConfigurationError);
+  assertEquals(
+    error.message,
+    "Threads must be a number or string, got: boolean",
+  );
+  assertEquals(error.reason, "INVALID_TYPE");
+  assertEquals(error.name, "ConfigurationError");
+});
+
+Deno.test("ConfigurationError - OUT_OF_RANGE reason", () => {
+  const error = new ConfigurationError(
+    "Population Size must be at least 2, got: 0",
+    "OUT_OF_RANGE",
+  );
+  assertIsError(error, ConfigurationError);
+  assertEquals(error.reason, "OUT_OF_RANGE");
+});
+
+Deno.test("ConfigurationError - NOT_INTEGER reason", () => {
+  const error = new ConfigurationError(
+    "Threads must be an integer, got: 3.5",
+    "NOT_INTEGER",
+  );
+  assertIsError(error, ConfigurationError);
+  assertEquals(error.reason, "NOT_INTEGER");
+});
+
+Deno.test("ConfigurationError - NOT_FINITE reason", () => {
+  const error = new ConfigurationError(
+    "Target error must be a finite number, got: Infinity",
+    "NOT_FINITE",
+  );
+  assertIsError(error, ConfigurationError);
+  assertEquals(error.reason, "NOT_FINITE");
+});
+
+Deno.test("ConfigurationError - CROSS_FIELD_VALIDATION reason", () => {
+  const error = new ConfigurationError(
+    "Quantum step maxStep must be >= minStep",
+    "CROSS_FIELD_VALIDATION",
+  );
+  assertIsError(error, ConfigurationError);
+  assertEquals(error.reason, "CROSS_FIELD_VALIDATION");
+});
+
+Deno.test("ConfigurationError - is instanceof Error", () => {
+  const error = new ConfigurationError("test", "INVALID_TYPE");
+  assert(error instanceof Error);
+  assert(error instanceof ConfigurationError);
+});
+
+Deno.test("ConfigurationError - can be caught selectively", () => {
+  const fn = () => {
+    throw new ConfigurationError("bad config", "OUT_OF_RANGE");
+  };
+
+  assertThrows(fn, ConfigurationError);
+});
+
+Deno.test("ConfigurationError - reason is typed", () => {
+  const reasons: ConfigurationErrorReason[] = [
+    "INVALID_TYPE",
+    "OUT_OF_RANGE",
+    "NOT_INTEGER",
+    "NOT_FINITE",
+    "CROSS_FIELD_VALIDATION",
+  ];
+
+  for (const reason of reasons) {
+    const error = new ConfigurationError(`test: ${reason}`, reason);
+    assertEquals(error.reason, reason);
+  }
+});
+
+Deno.test("ConfigurationError - distinguishable from generic Error", () => {
+  try {
+    throw new ConfigurationError("bad value", "OUT_OF_RANGE");
+  } catch (e) {
+    if (e instanceof ConfigurationError) {
+      assertEquals(e.reason, "OUT_OF_RANGE");
+    } else {
+      throw new Error("Expected ConfigurationError instance");
+    }
+  }
+});

--- a/test/errors/ConfigurationErrorIntegration.ts
+++ b/test/errors/ConfigurationErrorIntegration.ts
@@ -1,0 +1,51 @@
+import { assertIsError, assertThrows } from "@std/assert";
+import { ConfigurationError } from "../../src/errors/ConfigurationError.ts";
+import { parseDiscoverySampleRate, parseNumber } from "../../src/config/ParseOptions.ts";
+
+Deno.test("parseNumber throws ConfigurationError for non-numeric string", () => {
+  const error = assertThrows(
+    () => parseNumber("Threads", "abc", 1),
+    ConfigurationError,
+  );
+  assertIsError(error, ConfigurationError);
+});
+
+Deno.test("parseNumber throws ConfigurationError for non-finite number", () => {
+  const error = assertThrows(
+    () => parseNumber("Threads", Infinity, 1),
+    ConfigurationError,
+  );
+  assertIsError(error, ConfigurationError);
+});
+
+Deno.test("parseNumber throws ConfigurationError for wrong type", () => {
+  const error = assertThrows(
+    () => parseNumber("Threads", true, 1),
+    ConfigurationError,
+  );
+  assertIsError(error, ConfigurationError);
+});
+
+Deno.test("parseNumber throws ConfigurationError for non-integer", () => {
+  const error = assertThrows(
+    () => parseNumber("Threads", 3.5, 1, { integer: true }),
+    ConfigurationError,
+  );
+  assertIsError(error, ConfigurationError);
+});
+
+Deno.test("parseNumber throws ConfigurationError for out of range", () => {
+  const error = assertThrows(
+    () => parseNumber("Population Size", 0, 50, { min: 2 }),
+    ConfigurationError,
+  );
+  assertIsError(error, ConfigurationError);
+});
+
+Deno.test("parseDiscoverySampleRate throws ConfigurationError for invalid value", () => {
+  const error = assertThrows(
+    () => parseDiscoverySampleRate(-0.5, 0.2),
+    ConfigurationError,
+  );
+  assertIsError(error, ConfigurationError);
+});

--- a/test/errors/ConfigurationErrorIntegration.ts
+++ b/test/errors/ConfigurationErrorIntegration.ts
@@ -1,6 +1,9 @@
 import { assertIsError, assertThrows } from "@std/assert";
 import { ConfigurationError } from "../../src/errors/ConfigurationError.ts";
-import { parseDiscoverySampleRate, parseNumber } from "../../src/config/ParseOptions.ts";
+import {
+  parseDiscoverySampleRate,
+  parseNumber,
+} from "../../src/config/ParseOptions.ts";
 
 Deno.test("parseNumber throws ConfigurationError for non-numeric string", () => {
   const error = assertThrows(

--- a/test/errors/TopologyError.ts
+++ b/test/errors/TopologyError.ts
@@ -1,0 +1,133 @@
+import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import {
+  TopologyError,
+  type TopologyErrorReason,
+} from "../../src/errors/TopologyError.ts";
+
+Deno.test("TopologyError - INVALID_NEURON_TYPE reason", () => {
+  const error = new TopologyError(
+    "invalid type: foo",
+    "INVALID_NEURON_TYPE",
+  );
+  assertIsError(error, TopologyError);
+  assertEquals(error.message, "invalid type: foo");
+  assertEquals(error.reason, "INVALID_NEURON_TYPE");
+  assertEquals(error.name, "TopologyError");
+});
+
+Deno.test("TopologyError - INVALID_SQUASH reason", () => {
+  const error = new TopologyError(
+    "constants should not have a squash was: TANH",
+    "INVALID_SQUASH",
+  );
+  assertIsError(error, TopologyError);
+  assertEquals(error.reason, "INVALID_SQUASH");
+});
+
+Deno.test("TopologyError - MISSING_SQUASH reason", () => {
+  const error = new TopologyError(
+    "Missing squash for hidden neuron",
+    "MISSING_SQUASH",
+  );
+  assertIsError(error, TopologyError);
+  assertEquals(error.reason, "MISSING_SQUASH");
+});
+
+Deno.test("TopologyError - INVALID_CONNECTION reason", () => {
+  const error = new TopologyError(
+    "connection points to an input node",
+    "INVALID_CONNECTION",
+  );
+  assertIsError(error, TopologyError);
+  assertEquals(error.reason, "INVALID_CONNECTION");
+});
+
+Deno.test("TopologyError - INVALID_STATE reason", () => {
+  const error = new TopologyError(
+    "hidden neuron should have a finite bias",
+    "INVALID_STATE",
+  );
+  assertIsError(error, TopologyError);
+  assertEquals(error.reason, "INVALID_STATE");
+});
+
+Deno.test("TopologyError - DUPLICATE_UUID reason", () => {
+  const error = new TopologyError(
+    "Duplicate uuid abc-123",
+    "DUPLICATE_UUID",
+  );
+  assertIsError(error, TopologyError);
+  assertEquals(error.reason, "DUPLICATE_UUID");
+});
+
+Deno.test("TopologyError - MISSING_NEURON reason", () => {
+  const error = new TopologyError(
+    "Can't find neuron-abc",
+    "MISSING_NEURON",
+  );
+  assertIsError(error, TopologyError);
+  assertEquals(error.reason, "MISSING_NEURON");
+});
+
+Deno.test("TopologyError - SORT_FAILURE reason", () => {
+  const error = new TopologyError(
+    "synapses not sorted",
+    "SORT_FAILURE",
+  );
+  assertIsError(error, TopologyError);
+  assertEquals(error.reason, "SORT_FAILURE");
+});
+
+Deno.test("TopologyError - EXCESSIVE_ERRORS reason", () => {
+  const error = new TopologyError(
+    "Excessive error accumulation detected",
+    "EXCESSIVE_ERRORS",
+  );
+  assertIsError(error, TopologyError);
+  assertEquals(error.reason, "EXCESSIVE_ERRORS");
+});
+
+Deno.test("TopologyError - is instanceof Error", () => {
+  const error = new TopologyError("test", "INVALID_NEURON_TYPE");
+  assert(error instanceof Error);
+  assert(error instanceof TopologyError);
+});
+
+Deno.test("TopologyError - can be caught selectively", () => {
+  const fn = () => {
+    throw new TopologyError("bad topology", "INVALID_CONNECTION");
+  };
+
+  assertThrows(fn, TopologyError);
+});
+
+Deno.test("TopologyError - reason is typed", () => {
+  const reasons: TopologyErrorReason[] = [
+    "INVALID_NEURON_TYPE",
+    "INVALID_SQUASH",
+    "MISSING_SQUASH",
+    "INVALID_CONNECTION",
+    "INVALID_STATE",
+    "DUPLICATE_UUID",
+    "MISSING_NEURON",
+    "SORT_FAILURE",
+    "EXCESSIVE_ERRORS",
+  ];
+
+  for (const reason of reasons) {
+    const error = new TopologyError(`test: ${reason}`, reason);
+    assertEquals(error.reason, reason);
+  }
+});
+
+Deno.test("TopologyError - distinguishable from generic Error", () => {
+  try {
+    throw new TopologyError("bad topology", "INVALID_CONNECTION");
+  } catch (e) {
+    if (e instanceof TopologyError) {
+      assertEquals(e.reason, "INVALID_CONNECTION");
+    } else {
+      throw new Error("Expected TopologyError instance");
+    }
+  }
+});

--- a/test/errors/TopologyErrorIntegration.ts
+++ b/test/errors/TopologyErrorIntegration.ts
@@ -1,0 +1,57 @@
+import { assertIsError, assertThrows } from "@std/assert";
+import { TopologyError } from "../../src/errors/TopologyError.ts";
+import { Creature } from "../../src/Creature.ts";
+import { Neuron } from "../../src/architecture/Neuron.ts";
+
+Deno.test("Neuron constructor throws TopologyError for invalid type", () => {
+  const creature = new Creature(2, 1);
+  const error = assertThrows(
+    () => new Neuron("test-1", "bogus" as "hidden", 0, creature),
+    TopologyError,
+  );
+  assertIsError(error, TopologyError);
+});
+
+Deno.test("Neuron constructor throws TopologyError for constant with squash", () => {
+  const creature = new Creature(2, 1);
+  const error = assertThrows(
+    () => new Neuron("test-1", "constant", 0, creature, "TANH"),
+    TopologyError,
+  );
+  assertIsError(error, TopologyError);
+});
+
+Deno.test("Neuron.validate throws TopologyError for missing squash on hidden", () => {
+  const creature = new Creature(2, 1);
+  const neuron = new Neuron("test-1", "hidden", 0, creature, "TANH");
+  neuron.index = 2;
+  // Force squash to be undefined to trigger validation error
+  (neuron as unknown as { squash: undefined }).squash = undefined;
+  const error = assertThrows(
+    () => neuron.validate(),
+    TopologyError,
+  );
+  assertIsError(error, TopologyError);
+});
+
+Deno.test("Neuron.exportJSON throws TopologyError for input type", () => {
+  const creature = new Creature(2, 1);
+  const neuron = new Neuron("input-0", "input", Infinity, creature);
+  neuron.index = 0;
+  const error = assertThrows(
+    () => neuron.exportJSON(),
+    TopologyError,
+  );
+  assertIsError(error, TopologyError);
+});
+
+Deno.test("Neuron.mutate throws TopologyError for input node", () => {
+  const creature = new Creature(2, 1);
+  const neuron = new Neuron("input-0", "input", Infinity, creature);
+  neuron.index = 0;
+  const error = assertThrows(
+    () => neuron.mutate("SUB_NODE"),
+    TopologyError,
+  );
+  assertIsError(error, TopologyError);
+});


### PR DESCRIPTION
## Summary

Introduce typed `ConfigurationError` and `TopologyError` classes following the existing error class pattern (`DiscoveryError`, `WasmError`, `ActivationError`). Migrated all generic `throw new Error()` calls in the 5 highest-impact files to use the appropriate typed error class, enabling consumers to catch errors by type and inspect structured `reason` fields.

Closes #1479.

### Changes

- **New error classes** in `src/errors/`:
  - `ConfigurationError` with reasons: `INVALID_TYPE`, `OUT_OF_RANGE`, `NOT_INTEGER`, `NOT_FINITE`, `CROSS_FIELD_VALIDATION`
  - `TopologyError` with reasons: `INVALID_NEURON_TYPE`, `INVALID_SQUASH`, `MISSING_SQUASH`, `INVALID_CONNECTION`, `INVALID_STATE`, `DUPLICATE_UUID`, `MISSING_NEURON`, `SORT_FAILURE`, `EXCESSIVE_ERRORS`

- **Migrated files**:
  - `src/config/ParseOptions.ts` — 11 errors → `ConfigurationError`
  - `src/config/NeatConfig.ts` — 9 errors → `ConfigurationError`
  - `src/architecture/Neuron.ts` — 11 errors → `TopologyError` (5 "Not implemented" placeholders left as-is)
  - `src/architecture/Offspring.ts` — 16 errors → `TopologyError`
  - `src/architecture/CreatureValidate.ts` — 12 errors → `TopologyError` (existing `ValidationError` calls preserved)

## Evidence

This is a backend/CLI change with no visual output. All 3848 existing tests pass, plus 33 new tests verify the error classes and their integration.

## Test Plan

- `test/errors/ConfigurationError.ts` — 9 tests covering all reason types, instanceof checks, and selective catching
- `test/errors/TopologyError.ts` — 13 tests covering all reason types, instanceof checks, and selective catching
- `test/errors/ConfigurationErrorIntegration.ts` — 6 tests verifying `parseNumber` and `parseDiscoverySampleRate` throw `ConfigurationError`
- `test/errors/TopologyErrorIntegration.ts` — 5 tests verifying `Neuron` constructor, validate, exportJSON, and mutate throw `TopologyError`
- All 3848 existing tests continue to pass (backward-compatible since new classes extend `Error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)