### PR TITLE
Performance: Reduce WASM CompiledNetwork memory retention after creature.activate() (#1504)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.20",
+  "version": "0.312.21",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1504.md
+++ b/docs/pr-summary-1504.md
@@ -1,24 +1,28 @@
 ## Summary
 
-Reduce WASM CompiledNetwork memory retention for data-generation workloads. Closes #1504.
+Reduce WASM CompiledNetwork memory retention for data-generation workloads.
+Closes #1504.
 
-Adds `creature.activateSingleUse(input)` — a drop-in replacement for `activate()` that
-automatically disposes the cached WASM `CompiledNetwork` after each call. This prevents
-WASM heap accumulation in workloads where each creature is activated once or rarely.
+Adds `creature.activateSingleUse(input)` — a drop-in replacement for
+`activate()` that automatically disposes the cached WASM `CompiledNetwork` after
+each call. This prevents WASM heap accumulation in workloads where each creature
+is activated once or rarely.
 
-Also exports WASM cache management functions (`setMaxCachedWasmCreatureActivations`,
-`getMaxCachedWasmCreatureActivations`, `getCachedWasmActivationCount`) from the main
-`mod.ts` so data-gen workloads can tune the LRU cache cap (recommended: 64–128) or
-monitor cache pressure without importing internal modules.
+Also exports WASM cache management functions
+(`setMaxCachedWasmCreatureActivations`, `getMaxCachedWasmCreatureActivations`,
+`getCachedWasmActivationCount`) from the main `mod.ts` so data-gen workloads can
+tune the LRU cache cap (recommended: 64–128) or monitor cache pressure without
+importing internal modules.
 
 ### Changes
 
-- **`src/Creature.ts`**: Added `activateSingleUse(input, feedbackLoop?)` method that
-  calls `activate()` then `disposeWasm()` in a `try/finally` block
-- **`src/wasm/WasmCreatureActivationLRU.ts`**: Added `getCachedWasmActivationCount()`
-  for observability of current cache size
+- **`src/Creature.ts`**: Added `activateSingleUse(input, feedbackLoop?)` method
+  that calls `activate()` then `disposeWasm()` in a `try/finally` block
+- **`src/wasm/WasmCreatureActivationLRU.ts`**: Added
+  `getCachedWasmActivationCount()` for observability of current cache size
 - **`src/wasm/mod.ts`**: Exported `getCachedWasmActivationCount`
-- **`mod.ts`**: Exported cache management functions with documentation for data-gen usage
+- **`mod.ts`**: Exported cache management functions with documentation for
+  data-gen usage
 
 ## Evidence
 
@@ -26,8 +30,9 @@ This is a backend/API change with no visual output. Verified via unit tests:
 
 - 7 new tests in `test/wasm/SingleUseWasmActivation.ts` all pass
 - 11 existing tests in `test/wasm/WasmCreatureActivationLRU.ts` continue to pass
-- Full test suite (3865 tests) passes; one pre-existing flaky test (`evolve_Bigger_than`)
-  fails intermittently under parallel resource contention but passes in isolation
+- Full test suite (3865 tests) passes; one pre-existing flaky test
+  (`evolve_Bigger_than`) fails intermittently under parallel resource contention
+  but passes in isolation
 
 ## Test Plan
 

--- a/docs/pr-summary-1504.md
+++ b/docs/pr-summary-1504.md
@@ -1,0 +1,41 @@
+## Summary
+
+Reduce WASM CompiledNetwork memory retention for data-generation workloads. Closes #1504.
+
+Adds `creature.activateSingleUse(input)` — a drop-in replacement for `activate()` that
+automatically disposes the cached WASM `CompiledNetwork` after each call. This prevents
+WASM heap accumulation in workloads where each creature is activated once or rarely.
+
+Also exports WASM cache management functions (`setMaxCachedWasmCreatureActivations`,
+`getMaxCachedWasmCreatureActivations`, `getCachedWasmActivationCount`) from the main
+`mod.ts` so data-gen workloads can tune the LRU cache cap (recommended: 64–128) or
+monitor cache pressure without importing internal modules.
+
+### Changes
+
+- **`src/Creature.ts`**: Added `activateSingleUse(input, feedbackLoop?)` method that
+  calls `activate()` then `disposeWasm()` in a `try/finally` block
+- **`src/wasm/WasmCreatureActivationLRU.ts`**: Added `getCachedWasmActivationCount()`
+  for observability of current cache size
+- **`src/wasm/mod.ts`**: Exported `getCachedWasmActivationCount`
+- **`mod.ts`**: Exported cache management functions with documentation for data-gen usage
+
+## Evidence
+
+This is a backend/API change with no visual output. Verified via unit tests:
+
+- 7 new tests in `test/wasm/SingleUseWasmActivation.ts` all pass
+- 11 existing tests in `test/wasm/WasmCreatureActivationLRU.ts` continue to pass
+- Full test suite (3865 tests) passes; one pre-existing flaky test (`evolve_Bigger_than`)
+  fails intermittently under parallel resource contention but passes in isolation
+
+## Test Plan
+
+- `test/wasm/SingleUseWasmActivation.ts` — 7 new tests:
+  - `getCachedWasmActivationCount` returns a number
+  - `getCachedWasmActivationCount` increases after `activate()`
+  - `activateSingleUse` disposes WASM after activation
+  - `activateSingleUse` produces same results as `activate()`
+  - Multiple sequential single-use activations work
+  - `activateSingleUse` with `feedbackLoop` parameter
+  - `activateSingleUse` validates input and cleans up on error

--- a/mod.ts
+++ b/mod.ts
@@ -226,6 +226,30 @@ export type {
 export { fetchWasmForWorkers } from "./src/multithreading/workers/WorkerHandler.ts";
 
 /**
+ * WASM Activation Cache Management (Issue #1504)
+ *
+ * For data-generation workloads that activate many creatures only once,
+ * reducing the WASM cache cap prevents excessive memory retention.
+ *
+ * Recommended settings for data-gen workloads: 64–128.
+ *
+ * @example
+ * ```ts
+ * import { setMaxCachedWasmCreatureActivations } from "./mod.ts";
+ * // Reduce WASM cache for data-generation workloads
+ * setMaxCachedWasmCreatureActivations(64);
+ * ```
+ *
+ * Alternatively, use `creature.activateSingleUse(input)` which automatically
+ * disposes the WASM activation after each call, avoiding cache pressure entirely.
+ */
+export {
+  getCachedWasmActivationCount,
+  getMaxCachedWasmCreatureActivations,
+  setMaxCachedWasmCreatureActivations,
+} from "./src/wasm/WasmCreatureActivationLRU.ts";
+
+/**
  * Structured Logger
  *
  * Issue #1398: Configurable logging abstraction. Consumers can inject a custom

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -401,6 +401,26 @@ export class Creature implements CreatureInternal {
     return activation.activateWasm(this, input, effectiveFeedbackLoop);
   }
 
+  /**
+   * Activate the creature and immediately dispose WASM resources afterwards.
+   *
+   * Issue #1504: For data-generation workloads where each creature is activated
+   * once (or rarely), retaining cached `CompiledNetwork` instances wastes WASM
+   * heap memory. This method behaves identically to `activate()` but frees the
+   * WASM activation immediately after producing the result, so it does not
+   * contribute to LRU cache pressure.
+   */
+  activateSingleUse(
+    input: Float32Array,
+    feedbackLoop: boolean = false,
+  ): Float32Array {
+    try {
+      return this.activate(input, feedbackLoop);
+    } finally {
+      this.disposeWasm();
+    }
+  }
+
   /** @internal Expose preparedNeurons flag for activation module */
   get preparedNeurons(): boolean {
     return this.state.preparedNeurons;

--- a/src/wasm/WasmCreatureActivationLRU.ts
+++ b/src/wasm/WasmCreatureActivationLRU.ts
@@ -97,6 +97,16 @@ export function getMaxCachedWasmCreatureActivations(): number {
 }
 
 /**
+ * Get the current number of tracked WASM activation entries.
+ *
+ * Issue #1504: Observability for data-gen workloads to monitor WASM cache pressure.
+ * Note: this counts LRU entries; some may reference GC'd creatures (stale WeakRefs).
+ */
+export function getCachedWasmActivationCount(): number {
+  return entries.size;
+}
+
+/**
  * Record usage of a creature's cached WASM activation and evict if needed.
  *
  * Call this after a creature successfully acquires/uses `cachedWasmActivation`.

--- a/src/wasm/mod.ts
+++ b/src/wasm/mod.ts
@@ -90,7 +90,9 @@ export {
 } from "./WasmCompilationCache.ts";
 
 // Issue #1338 - Bound cached WASM activations under memory pressure
+// Issue #1504 - getCachedWasmActivationCount for observability
 export {
+  getCachedWasmActivationCount,
   getMaxCachedWasmCreatureActivations,
   setMaxCachedWasmCreatureActivations,
 } from "./WasmCreatureActivationLRU.ts";

--- a/test/wasm/SingleUseWasmActivation.ts
+++ b/test/wasm/SingleUseWasmActivation.ts
@@ -1,0 +1,193 @@
+/**
+ * SingleUseWasmActivation Unit Tests
+ *
+ * Issue #1504 - Reduce WASM CompiledNetwork memory retention after creature.activate()
+ *
+ * Verifies:
+ * 1. Single-use activation mode disposes WASM after activate()
+ * 2. Single-use mode still produces correct activation results
+ * 3. getCachedWasmActivationCount() returns accurate counts
+ * 4. Single-use mode works with multiple sequential activations
+ */
+
+import { assertEquals, assertGreater } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import {
+  getCachedWasmActivationCount,
+  getMaxCachedWasmCreatureActivations,
+  setMaxCachedWasmCreatureActivations,
+} from "../../src/wasm/WasmCreatureActivationLRU.ts";
+// Side-effect import to trigger WASM auto-initialisation
+import "../../src/wasm/WasmAutoInit.ts";
+
+/**
+ * Create a minimal creature for testing.
+ */
+function createTestCreature(): Creature {
+  const creature = new Creature(2, 1);
+  creature.fix();
+  return creature;
+}
+
+// ---------------------------------------------------------------------------
+// getCachedWasmActivationCount tests
+// ---------------------------------------------------------------------------
+
+Deno.test("SingleUseWasm: getCachedWasmActivationCount returns a number", () => {
+  const count = getCachedWasmActivationCount();
+  assertEquals(typeof count, "number");
+});
+
+Deno.test("SingleUseWasm: getCachedWasmActivationCount increases after activate", () => {
+  const original = getMaxCachedWasmCreatureActivations();
+  try {
+    setMaxCachedWasmCreatureActivations(512);
+
+    const creature = createTestCreature();
+    const input = new Float32Array([0.5, 0.3]);
+
+    const countBefore = getCachedWasmActivationCount();
+    creature.activate(input);
+    const countAfter = getCachedWasmActivationCount();
+
+    assertGreater(
+      countAfter,
+      countBefore,
+      "Cache count should increase after activation",
+    );
+
+    creature.dispose();
+  } finally {
+    setMaxCachedWasmCreatureActivations(original);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Single-use activation mode tests
+// ---------------------------------------------------------------------------
+
+Deno.test("SingleUseWasm: activateSingleUse disposes WASM after activation", () => {
+  const creature = createTestCreature();
+  const input = new Float32Array([0.5, 0.3]);
+
+  // Activate in single-use mode
+  const result = creature.activateSingleUse(input);
+
+  // Should produce valid output
+  assertEquals(result.length, 1, "Should return output of correct length");
+  assertEquals(
+    Number.isFinite(result[0]),
+    true,
+    "Output should be a finite number",
+  );
+
+  // WASM should be disposed after single-use activation
+  assertEquals(
+    creature.cachedWasmActivation,
+    undefined,
+    "cachedWasmActivation should be undefined after single-use activation",
+  );
+
+  creature.dispose();
+});
+
+Deno.test("SingleUseWasm: activateSingleUse produces same results as activate", () => {
+  const creature = createTestCreature();
+  const input = new Float32Array([0.5, 0.3]);
+
+  // Normal activation
+  const normalResult = creature.activate(input);
+
+  // Dispose and re-activate in single-use mode
+  creature.disposeWasm();
+  const singleUseResult = creature.activateSingleUse(input);
+
+  // Results should match
+  assertEquals(
+    normalResult.length,
+    singleUseResult.length,
+    "Output lengths should match",
+  );
+  for (let i = 0; i < normalResult.length; i++) {
+    assertEquals(
+      normalResult[i],
+      singleUseResult[i],
+      `Output at index ${i} should match`,
+    );
+  }
+
+  creature.dispose();
+});
+
+Deno.test("SingleUseWasm: multiple sequential single-use activations work", () => {
+  const creature = createTestCreature();
+
+  const inputs = [
+    new Float32Array([0.1, 0.2]),
+    new Float32Array([0.3, 0.4]),
+    new Float32Array([0.5, 0.6]),
+  ];
+
+  for (const input of inputs) {
+    const result = creature.activateSingleUse(input);
+    assertEquals(result.length, 1, "Each activation should produce output");
+    assertEquals(
+      Number.isFinite(result[0]),
+      true,
+      "Each output should be finite",
+    );
+
+    // WASM should be disposed after each call
+    assertEquals(
+      creature.cachedWasmActivation,
+      undefined,
+      "WASM should be disposed after each single-use activation",
+    );
+  }
+
+  creature.dispose();
+});
+
+Deno.test("SingleUseWasm: activateSingleUse with feedbackLoop parameter", () => {
+  const creature = createTestCreature();
+  const input = new Float32Array([0.5, 0.3]);
+
+  // Should accept feedbackLoop parameter
+  const result = creature.activateSingleUse(input, false);
+  assertEquals(
+    result.length,
+    1,
+    "Should return output with feedbackLoop=false",
+  );
+
+  assertEquals(
+    creature.cachedWasmActivation,
+    undefined,
+    "WASM should be disposed after single-use activation with feedbackLoop",
+  );
+
+  creature.dispose();
+});
+
+Deno.test("SingleUseWasm: activateSingleUse validates input", () => {
+  const creature = createTestCreature();
+  const badInput = new Float32Array([NaN, 0.3]);
+
+  let threw = false;
+  try {
+    creature.activateSingleUse(badInput);
+  } catch {
+    threw = true;
+  }
+
+  assertEquals(threw, true, "Should throw on non-finite input");
+
+  // WASM should still be cleaned up even after error
+  assertEquals(
+    creature.cachedWasmActivation,
+    undefined,
+    "WASM should be undefined after failed single-use activation",
+  );
+
+  creature.dispose();
+});


### PR DESCRIPTION
## Summary

Reduce WASM CompiledNetwork memory retention for data-generation workloads. Closes #1504.

Adds `creature.activateSingleUse(input)` — a drop-in replacement for `activate()` that
automatically disposes the cached WASM `CompiledNetwork` after each call. This prevents
WASM heap accumulation in workloads where each creature is activated once or rarely.

Also exports WASM cache management functions (`setMaxCachedWasmCreatureActivations`,
`getMaxCachedWasmCreatureActivations`, `getCachedWasmActivationCount`) from the main
`mod.ts` so data-gen workloads can tune the LRU cache cap (recommended: 64–128) or
monitor cache pressure without importing internal modules.

### Changes

- **`src/Creature.ts`**: Added `activateSingleUse(input, feedbackLoop?)` method that
  calls `activate()` then `disposeWasm()` in a `try/finally` block
- **`src/wasm/WasmCreatureActivationLRU.ts`**: Added `getCachedWasmActivationCount()`
  for observability of current cache size
- **`src/wasm/mod.ts`**: Exported `getCachedWasmActivationCount`
- **`mod.ts`**: Exported cache management functions with documentation for data-gen usage

## Evidence

This is a backend/API change with no visual output. Verified via unit tests:

- 7 new tests in `test/wasm/SingleUseWasmActivation.ts` all pass
- 11 existing tests in `test/wasm/WasmCreatureActivationLRU.ts` continue to pass
- Full test suite (3865 tests) passes; one pre-existing flaky test (`evolve_Bigger_than`)
  fails intermittently under parallel resource contention but passes in isolation

## Test plan

- `test/wasm/SingleUseWasmActivation.ts` — 7 new tests:
  - `getCachedWasmActivationCount` returns a number
  - `getCachedWasmActivationCount` increases after `activate()`
  - `activateSingleUse` disposes WASM after activation
  - `activateSingleUse` produces same results as `activate()`
  - Multiple sequential single-use activations work
  - `activateSingleUse` with `feedbackLoop` parameter
  - `activateSingleUse` validates input and cleans up on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)