### PR TITLE
Enhancement: Add error-magnitude scaling to adaptive learning rate strategy (#1480)

### DIFF
--- a/bench/AdaptiveLearningRateConvergence.ts
+++ b/bench/AdaptiveLearningRateConvergence.ts
@@ -1,0 +1,170 @@
+/**
+ * Issue #1480 - Adaptive Learning Rate Scaling Benchmark
+ *
+ * Compares backpropagation convergence across different learning rate
+ * configurations and error-proportional scaling strategies, to determine
+ * whether error-magnitude-based scaling improves convergence.
+ *
+ * Run with:
+ *   deno run --allow-read --allow-env --allow-write bench/AdaptiveLearningRateConvergence.ts
+ */
+
+import { Creature } from "../src/Creature.ts";
+import type { CreatureExport } from "../src/architecture/CreatureInterfaces.ts";
+import {
+  type BackPropagationOptions,
+  calculateLearningRate,
+  createBackPropagationConfig,
+  type ErrorFeedback,
+} from "../src/propagate/BackPropagation.ts";
+import { SparseConfig } from "../src/propagate/sparse/SparseConfig.ts";
+
+// Simple target: input 0.5 -> output 0.3
+const INPUT = new Float32Array([0.5]);
+const TARGET = new Float32Array([0.3]);
+const TRAINING_ITERATIONS = 200;
+const TRIALS = 10;
+
+interface TrialResult {
+  name: string;
+  meanFinalError: number;
+  bestFinalError: number;
+  worstFinalError: number;
+}
+
+function createCreature(): Creature {
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "LOGISTIC", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.5 },
+    ],
+  };
+  return Creature.fromJSON(json);
+}
+
+function runTrial(
+  name: string,
+  options: BackPropagationOptions,
+): TrialResult {
+  const finalErrors: number[] = [];
+
+  for (let trial = 0; trial < TRIALS; trial++) {
+    const creature = createCreature();
+    const config = createBackPropagationConfig({
+      generations: 0,
+      disableRandomSamples: true,
+      batchSize: 1,
+      ...options,
+    });
+
+    const sparseConfig = new SparseConfig(creature.exportJSON(), config);
+
+    let previousError: number | undefined;
+
+    for (let i = 0; i < TRAINING_ITERATIONS; i++) {
+      creature.activateAndTrace(INPUT, false, sparseConfig);
+      creature.propagate(TARGET, config, sparseConfig);
+
+      // Calculate current error for adaptive feedback
+      const output = creature.activate(INPUT);
+      const currentError = Math.abs(output[0] - TARGET[0]);
+
+      // Build feedback for the next iteration's learning rate calculation
+      const errorFeedback: ErrorFeedback | undefined =
+        previousError !== undefined
+          ? { previousError, currentError }
+          : undefined;
+
+      const currentLR = calculateLearningRate(config, i, errorFeedback);
+      // Create iteration-specific config with the calculated learning rate
+      const iterConfig = createBackPropagationConfig({
+        ...config,
+        learningRate: currentLR,
+      });
+
+      creature.activateAndTrace(INPUT, false, sparseConfig);
+      creature.propagate(TARGET, iterConfig, sparseConfig);
+
+      previousError = currentError;
+    }
+
+    creature.propagateUpdate(config, sparseConfig);
+    creature.clearState();
+
+    const finalOutput = creature.activate(INPUT);
+    const finalError = Math.abs(finalOutput[0] - TARGET[0]);
+    finalErrors.push(finalError);
+  }
+
+  const mean = finalErrors.reduce((a, b) => a + b, 0) / finalErrors.length;
+  const best = Math.min(...finalErrors);
+  const worst = Math.max(...finalErrors);
+
+  return {
+    name,
+    meanFinalError: mean,
+    bestFinalError: best,
+    worstFinalError: worst,
+  };
+}
+
+console.log("\n" + "=".repeat(70));
+console.log("Issue #1480: Adaptive Learning Rate Scaling Benchmark");
+console.log("=".repeat(70));
+console.log(
+  `Problem: input=0.5 -> target=0.3 (LOGISTIC hidden, IDENTITY output)`,
+);
+console.log(
+  `Iterations: ${TRAINING_ITERATIONS}, Trials per config: ${TRIALS}`,
+);
+console.log();
+
+const configs: { name: string; options: BackPropagationOptions }[] = [
+  {
+    name: "Fixed LR=0.01 (default)",
+    options: { learningRate: 0.01, learningRateStrategy: "fixed" },
+  },
+  {
+    name: "Fixed LR=0.001",
+    options: { learningRate: 0.001, learningRateStrategy: "fixed" },
+  },
+  {
+    name: "Fixed LR=0.1",
+    options: { learningRate: 0.1, learningRateStrategy: "fixed" },
+  },
+  {
+    name: "Decay (default)",
+    options: { learningRateStrategy: "decay" },
+  },
+  {
+    name: "Adaptive (with magnitude)",
+    options: { learningRateStrategy: "adaptive" },
+  },
+  {
+    name: "Warm restart (default)",
+    options: { learningRateStrategy: "warm_restart" },
+  },
+];
+
+const results: TrialResult[] = [];
+for (const cfg of configs) {
+  const result = runTrial(cfg.name, cfg.options);
+  results.push(result);
+  console.log(
+    `${result.name.padEnd(35)} | mean=${
+      result.meanFinalError.toFixed(6)
+    } | best=${result.bestFinalError.toFixed(6)} | worst=${
+      result.worstFinalError.toFixed(6)
+    }`,
+  );
+}
+
+console.log("\n" + "=".repeat(70));
+console.log("Benchmark complete.");
+console.log("=".repeat(70) + "\n");

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.312.23",
+  "version": "0.312.24",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-1480.md
+++ b/docs/pr-summary-1480.md
@@ -1,0 +1,50 @@
+## Summary
+
+Add error-magnitude scaling to the adaptive learning rate strategy in backpropagation. Closes #1480.
+
+The adaptive strategy previously only adjusted the learning rate based on error *direction* (improving, stagnating, or worsening). This enhancement adds a second scaling component based on error *magnitude*, inspired by fine-tuning's `QuantumStepConfig` approach:
+
+- **Large errors** (far from optimum): learning rate scales up towards 2x, enabling bigger steps
+- **Small errors** (fine-tuning region): learning rate stays near 1x, enabling conservative convergence
+
+The magnitude scaling uses the same bounded normalisation as `QuantumStepConfig`:
+```
+normalisedError = |error| / (1 + |error|)  => bounded in [0, 1)
+magnitudeScale = 1 + normalisedError       => bounded in [1, 2)
+```
+
+This bridges the scale gap between backpropagation and fine-tuning identified in the issue.
+
+## Evidence
+
+### Benchmark Results
+
+```
+Problem: input=0.5 -> target=0.3 (LOGISTIC hidden, IDENTITY output)
+Iterations: 200, Trials per config: 10
+
+Fixed LR=0.01 (default)             | mean=0.018904 | best=0.018904 | worst=0.018904
+Fixed LR=0.001                      | mean=0.018912 | best=0.018912 | worst=0.018912
+Fixed LR=0.1                        | mean=0.018140 | best=0.018140 | worst=0.018140
+Decay (default)                     | mean=0.018907 | best=0.018907 | worst=0.018907
+Adaptive (with magnitude)           | mean=0.018907 | best=0.018907 | worst=0.018907
+Warm restart (default)              | mean=0.018905 | best=0.018905 | worst=0.018905
+```
+
+All strategies converge to similar final errors on this simple problem. The adaptive strategy with magnitude scaling performs comparably to other strategies. The enhancement is conservative — it adds magnitude awareness without disrupting convergence properties.
+
+All 3873 existing tests pass.
+
+## Test Plan
+
+- Added `test/propagate/AdaptiveMagnitudeScaling.ts` with 8 tests:
+  - Large error produces higher rate than small error
+  - Magnitude scale approaches 2x for very large errors
+  - Magnitude scale is 1x when error is near zero
+  - Worsening error still reduces rate despite large magnitude
+  - Stagnation with moderate error boosts appropriately
+  - Fixed strategy unaffected by error magnitude
+  - No feedback falls back to magnitude scale of 1
+  - Magnitude scale is monotonically increasing with error
+- Updated 3 existing tests in `test/propagate/BackPropagationConfig.ts` to account for magnitude scaling
+- Added benchmark `bench/AdaptiveLearningRateConvergence.ts`

--- a/docs/pr-summary-1480.md
+++ b/docs/pr-summary-1480.md
@@ -1,19 +1,28 @@
 ## Summary
 
-Add error-magnitude scaling to the adaptive learning rate strategy in backpropagation. Closes #1480.
+Add error-magnitude scaling to the adaptive learning rate strategy in
+backpropagation. Closes #1480.
 
-The adaptive strategy previously only adjusted the learning rate based on error *direction* (improving, stagnating, or worsening). This enhancement adds a second scaling component based on error *magnitude*, inspired by fine-tuning's `QuantumStepConfig` approach:
+The adaptive strategy previously only adjusted the learning rate based on error
+_direction_ (improving, stagnating, or worsening). This enhancement adds a
+second scaling component based on error _magnitude_, inspired by fine-tuning's
+`QuantumStepConfig` approach:
 
-- **Large errors** (far from optimum): learning rate scales up towards 2x, enabling bigger steps
-- **Small errors** (fine-tuning region): learning rate stays near 1x, enabling conservative convergence
+- **Large errors** (far from optimum): learning rate scales up towards 2x,
+  enabling bigger steps
+- **Small errors** (fine-tuning region): learning rate stays near 1x, enabling
+  conservative convergence
 
-The magnitude scaling uses the same bounded normalisation as `QuantumStepConfig`:
+The magnitude scaling uses the same bounded normalisation as
+`QuantumStepConfig`:
+
 ```
 normalisedError = |error| / (1 + |error|)  => bounded in [0, 1)
 magnitudeScale = 1 + normalisedError       => bounded in [1, 2)
 ```
 
-This bridges the scale gap between backpropagation and fine-tuning identified in the issue.
+This bridges the scale gap between backpropagation and fine-tuning identified in
+the issue.
 
 ## Evidence
 
@@ -31,7 +40,10 @@ Adaptive (with magnitude)           | mean=0.018907 | best=0.018907 | worst=0.01
 Warm restart (default)              | mean=0.018905 | best=0.018905 | worst=0.018905
 ```
 
-All strategies converge to similar final errors on this simple problem. The adaptive strategy with magnitude scaling performs comparably to other strategies. The enhancement is conservative — it adds magnitude awareness without disrupting convergence properties.
+All strategies converge to similar final errors on this simple problem. The
+adaptive strategy with magnitude scaling performs comparably to other
+strategies. The enhancement is conservative — it adds magnitude awareness
+without disrupting convergence properties.
 
 All 3873 existing tests pass.
 
@@ -46,5 +58,6 @@ All 3873 existing tests pass.
   - Fixed strategy unaffected by error magnitude
   - No feedback falls back to magnitude scale of 1
   - Magnitude scale is monotonically increasing with error
-- Updated 3 existing tests in `test/propagate/BackPropagationConfig.ts` to account for magnitude scaling
+- Updated 3 existing tests in `test/propagate/BackPropagationConfig.ts` to
+  account for magnitude scaling
 - Added benchmark `bench/AdaptiveLearningRateConvergence.ts`

--- a/src/propagate/BackPropagation.ts
+++ b/src/propagate/BackPropagation.ts
@@ -199,10 +199,12 @@ export function calculateLearningRate(
       return config.initialLearningRate *
         Math.pow(config.learningRateDecay, iteration);
     case "adaptive": {
-      // Adaptive strategy: adjust learning rate based on actual error feedback.
-      // When error is improving => maintain the current rate.
-      // When error stagnates  => increase the rate to escape the plateau.
-      // When error worsens    => reduce the rate to avoid overshooting.
+      // Issue #1480: Adaptive strategy with error-proportional scaling.
+      // Two components:
+      //   1. Direction adjustment: boost when improving/stagnating, reduce when worsening.
+      //   2. Magnitude scaling: larger steps when error is large (far from optimum),
+      //      smaller steps when error is small (fine-tuning region), inspired by
+      //      QuantumStepConfig's adaptive step sizing in fine-tuning.
       const baseRate = config.initialLearningRate;
 
       // Apply a slower decay than the pure decay strategy
@@ -210,6 +212,7 @@ export function calculateLearningRate(
       const adaptiveFactor = Math.pow(adaptiveDecay, iteration);
 
       let errorAdjustment = 1;
+      let magnitudeScale = 1;
       if (
         errorFeedback &&
         Number.isFinite(errorFeedback.previousError) &&
@@ -231,9 +234,18 @@ export function calculateLearningRate(
           // The worse the ratio, the more we reduce (down to 0.5x).
           errorAdjustment = Math.max(0.5, 1.0 / errorRatio);
         }
+
+        // Issue #1480: Error-magnitude scaling.
+        // Uses the same normalisation as fine-tuning's QuantumStepConfig:
+        //   normalisedError = |error| / (1 + |error|)  => bounded in [0, 1)
+        // When error is large, magnitudeScale approaches 2.0 (bigger steps).
+        // When error is small, magnitudeScale approaches 1.0 (conservative steps).
+        const absError = Math.abs(errorFeedback.currentError);
+        const normalisedError = absError / (1 + absError);
+        magnitudeScale = 1 + normalisedError;
       }
 
-      return baseRate * adaptiveFactor * errorAdjustment;
+      return baseRate * adaptiveFactor * errorAdjustment * magnitudeScale;
     }
     case "warm_restart": {
       // Issue #1437: Cosine annealing with warm restarts.

--- a/test/propagate/AdaptiveMagnitudeScaling.ts
+++ b/test/propagate/AdaptiveMagnitudeScaling.ts
@@ -1,0 +1,222 @@
+/**
+ * Issue #1480: Tests for error-magnitude scaling in the adaptive learning rate strategy.
+ *
+ * Verifies that the adaptive strategy scales the learning rate proportionally
+ * to error magnitude — larger steps when error is large (far from optimum),
+ * smaller steps when error is small (fine-tuning region).
+ */
+import {
+  assertAlmostEquals,
+  assertGreater,
+  assertLessOrEqual,
+} from "@std/assert";
+import {
+  calculateLearningRate,
+  createBackPropagationConfig,
+  type ErrorFeedback,
+} from "../../src/propagate/BackPropagation.ts";
+
+// ---------------------------------------------------------------------------
+// Magnitude scaling: large error produces higher learning rate
+// ---------------------------------------------------------------------------
+
+Deno.test("AdaptiveMagnitudeScaling - large error produces higher rate than small error", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.01,
+    learningRateDecay: 0.95,
+  });
+
+  // Large error scenario: currentError = 0.8, improving from 0.9
+  const largeErrorFeedback: ErrorFeedback = {
+    previousError: 0.9,
+    currentError: 0.8,
+  };
+
+  // Small error scenario: currentError = 0.01, improving from 0.02
+  const smallErrorFeedback: ErrorFeedback = {
+    previousError: 0.02,
+    currentError: 0.01,
+  };
+
+  const lrLargeError = calculateLearningRate(config, 0, largeErrorFeedback);
+  const lrSmallError = calculateLearningRate(config, 0, smallErrorFeedback);
+
+  // Both are improving (ratio < 0.95), so direction adjustment is the same (1.1).
+  // But magnitude scaling should make the large-error rate higher.
+  assertGreater(
+    lrLargeError,
+    lrSmallError,
+    "Large error should produce a higher adaptive learning rate",
+  );
+});
+
+Deno.test("AdaptiveMagnitudeScaling - magnitude scale approaches 2x for very large errors", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.01,
+    learningRateDecay: 1.0, // No decay, to isolate magnitude effect
+  });
+
+  // Very large error: normalisedError ≈ 1, so magnitudeScale ≈ 2.0
+  const hugeErrorFeedback: ErrorFeedback = {
+    previousError: 200,
+    currentError: 100,
+  };
+  const lrHugeError = calculateLearningRate(config, 0, hugeErrorFeedback);
+
+  // With no decay (factor=1), improving (adjustment=1.1), magnitudeScale ≈ 2.0:
+  // expected ≈ 0.01 * 1.0 * 1.1 * ~1.99 ≈ 0.0219
+  assertGreater(
+    lrHugeError,
+    0.01 * 1.1 * 1.9,
+    "Magnitude scale should approach 2x for large errors",
+  );
+  assertLessOrEqual(
+    lrHugeError,
+    0.01 * 1.1 * 2.0,
+    "Magnitude scale should not exceed 2x",
+  );
+});
+
+Deno.test("AdaptiveMagnitudeScaling - magnitude scale is 1x when error is near zero", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.01,
+    learningRateDecay: 1.0,
+  });
+
+  // Very small error: normalisedError ≈ 0, so magnitudeScale ≈ 1.0
+  const tinyErrorFeedback: ErrorFeedback = {
+    previousError: 0.001,
+    currentError: 0.0005,
+  };
+  const lrTinyError = calculateLearningRate(config, 0, tinyErrorFeedback);
+
+  // Expected ≈ 0.01 * 1.0 * 1.1 * ~1.0005 ≈ 0.011
+  assertAlmostEquals(
+    lrTinyError,
+    0.01 * 1.1 * (1 + 0.0005 / 1.0005),
+    1e-6,
+    "Magnitude scale should be near 1x for tiny errors",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Magnitude scaling interacts correctly with direction adjustment
+// ---------------------------------------------------------------------------
+
+Deno.test("AdaptiveMagnitudeScaling - worsening error still reduces rate despite large magnitude", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.01,
+    learningRateDecay: 1.0,
+  });
+
+  // Error worsened (ratio > 1): currentError = 1.0, previous = 0.5
+  const worseningFeedback: ErrorFeedback = {
+    previousError: 0.5,
+    currentError: 1.0,
+  };
+
+  const lr = calculateLearningRate(config, 0, worseningFeedback);
+
+  // Direction adjustment = max(0.5, 1/2.0) = 0.5
+  // Magnitude scale = 1 + (1 / (1 + 1)) = 1.5
+  // Expected = 0.01 * 1.0 * 0.5 * 1.5 = 0.0075
+  assertAlmostEquals(lr, 0.0075, 1e-6);
+});
+
+Deno.test("AdaptiveMagnitudeScaling - stagnation with moderate error boosts appropriately", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.01,
+    learningRateDecay: 1.0,
+  });
+
+  // Stagnation (ratio ≈ 0.97): currentError = 0.485, previous = 0.5
+  const stagnantFeedback: ErrorFeedback = {
+    previousError: 0.5,
+    currentError: 0.485,
+  };
+
+  const lr = calculateLearningRate(config, 0, stagnantFeedback);
+
+  // Direction adjustment = 1.3 (stagnation)
+  // Magnitude scale = 1 + (0.485 / 1.485) ≈ 1.3266
+  // Expected ≈ 0.01 * 1.0 * 1.3 * 1.3266 ≈ 0.01725
+  const expectedMagnitude = 1 + 0.485 / (1 + 0.485);
+  assertAlmostEquals(lr, 0.01 * 1.3 * expectedMagnitude, 1e-6);
+});
+
+// ---------------------------------------------------------------------------
+// Non-adaptive strategies are unaffected
+// ---------------------------------------------------------------------------
+
+Deno.test("AdaptiveMagnitudeScaling - fixed strategy unaffected by error magnitude", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "fixed",
+    learningRate: 0.01,
+  });
+
+  const feedbackLarge: ErrorFeedback = {
+    previousError: 1.0,
+    currentError: 0.8,
+  };
+  const feedbackSmall: ErrorFeedback = {
+    previousError: 0.01,
+    currentError: 0.005,
+  };
+
+  const lr1 = calculateLearningRate(config, 0, feedbackLarge);
+  const lr2 = calculateLearningRate(config, 0, feedbackSmall);
+
+  assertAlmostEquals(lr1, 0.01, 1e-9, "Fixed strategy ignores error feedback");
+  assertAlmostEquals(lr2, 0.01, 1e-9, "Fixed strategy ignores error feedback");
+});
+
+Deno.test("AdaptiveMagnitudeScaling - no feedback falls back to magnitude scale of 1", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.01,
+    learningRateDecay: 1.0,
+  });
+
+  // Without feedback, errorAdjustment=1 and magnitudeScale=1
+  const lr = calculateLearningRate(config, 0);
+  assertAlmostEquals(
+    lr,
+    0.01,
+    1e-9,
+    "No feedback should use magnitude scale of 1",
+  );
+});
+
+Deno.test("AdaptiveMagnitudeScaling - magnitude scale is monotonically increasing with error", () => {
+  const config = createBackPropagationConfig({
+    learningRateStrategy: "adaptive",
+    initialLearningRate: 0.01,
+    learningRateDecay: 1.0,
+  });
+
+  // Test with a series of increasing errors, all with the same improvement ratio
+  const errors = [0.001, 0.01, 0.1, 0.5, 1.0, 5.0, 100.0];
+  const rates: number[] = [];
+
+  for (const error of errors) {
+    const feedback: ErrorFeedback = {
+      previousError: error * 1.2, // Same ratio = 0.833... (improving)
+      currentError: error,
+    };
+    rates.push(calculateLearningRate(config, 0, feedback));
+  }
+
+  // Each rate should be >= the previous one (monotonically increasing with error)
+  for (let i = 1; i < rates.length; i++) {
+    assertGreater(
+      rates[i],
+      rates[i - 1],
+      `Rate at error=${errors[i]} should exceed rate at error=${errors[i - 1]}`,
+    );
+  }
+});

--- a/test/propagate/BackPropagationConfig.ts
+++ b/test/propagate/BackPropagationConfig.ts
@@ -150,8 +150,10 @@ Deno.test("calculateLearningRate - adaptive boosts when error improves", () => {
   const lr = calculateLearningRate(config, 0, feedback);
   const base = config.initialLearningRate;
 
-  // With 50% improvement ratio < 0.95, adjustment = 1.1
-  assertAlmostEquals(lr, base * 1.1, 1e-9);
+  // Issue #1480: With 50% improvement ratio < 0.95, direction adjustment = 1.1
+  // Magnitude scale = 1 + (0.5 / 1.5) = 4/3
+  const magnitudeScale = 1 + 0.5 / (1 + 0.5);
+  assertAlmostEquals(lr, base * 1.1 * magnitudeScale, 1e-9);
 });
 
 Deno.test("calculateLearningRate - adaptive increases on stagnation", () => {
@@ -169,8 +171,10 @@ Deno.test("calculateLearningRate - adaptive increases on stagnation", () => {
   const lr = calculateLearningRate(config, 0, feedback);
   const base = config.initialLearningRate;
 
-  // Stagnation => adjustment = 1.3
-  assertAlmostEquals(lr, base * 1.3, 1e-9);
+  // Issue #1480: Stagnation => direction adjustment = 1.3
+  // Magnitude scale = 1 + (0.97 / 1.97)
+  const magnitudeScale = 1 + 0.97 / (1 + 0.97);
+  assertAlmostEquals(lr, base * 1.3 * magnitudeScale, 1e-9);
 });
 
 Deno.test("calculateLearningRate - adaptive reduces when error worsens", () => {
@@ -188,8 +192,10 @@ Deno.test("calculateLearningRate - adaptive reduces when error worsens", () => {
   const lr = calculateLearningRate(config, 0, feedback);
   const base = config.initialLearningRate;
 
-  // Worsened => adjustment = max(0.5, 1/2) = 0.5
-  assertAlmostEquals(lr, base * 0.5, 1e-9);
+  // Issue #1480: Worsened => direction adjustment = max(0.5, 1/2) = 0.5
+  // Magnitude scale = 1 + (2.0 / 3.0) = 5/3
+  const magnitudeScale = 1 + 2.0 / (1 + 2.0);
+  assertAlmostEquals(lr, base * 0.5 * magnitudeScale, 1e-9);
 });
 
 Deno.test("calculateLearningRate - adaptive without feedback uses base decay", () => {

--- a/test/scripts/BashScriptSyntax.ts
+++ b/test/scripts/BashScriptSyntax.ts
@@ -79,7 +79,7 @@ Deno.test("scripts/rustlib.sh exports require_rust_tools function", async () => 
   const cmd = new Deno.Command("bash", {
     args: [
       "-c",
-      "source scripts/rustlib.sh && type require_rust_tools | head -1",
+      "source scripts/rustlib.sh && type require_rust_tools",
     ],
     stdout: "piped",
     stderr: "piped",
@@ -87,8 +87,9 @@ Deno.test("scripts/rustlib.sh exports require_rust_tools function", async () => 
   const { code, stdout } = await cmd.output();
   const output = new TextDecoder().decode(stdout).trim();
   assertEquals(code, 0, "require_rust_tools should be a defined function");
+  const firstLine = output.split("\n")[0];
   assert(
-    output.includes("function"),
-    `Expected function declaration, got: ${output}`,
+    firstLine.includes("function"),
+    `Expected function declaration, got: ${firstLine}`,
   );
 });


### PR DESCRIPTION
## Summary

Add error-magnitude scaling to the adaptive learning rate strategy in backpropagation. Closes #1480.

The adaptive strategy previously only adjusted the learning rate based on error *direction* (improving, stagnating, or worsening). This enhancement adds a second scaling component based on error *magnitude*, inspired by fine-tuning's `QuantumStepConfig` approach:

- **Large errors** (far from optimum): learning rate scales up towards 2x, enabling bigger steps
- **Small errors** (fine-tuning region): learning rate stays near 1x, enabling conservative convergence

The magnitude scaling uses the same bounded normalisation as `QuantumStepConfig`:
```
normalisedError = |error| / (1 + |error|)  => bounded in [0, 1)
magnitudeScale = 1 + normalisedError       => bounded in [1, 2)
```

This bridges the scale gap between backpropagation and fine-tuning identified in the issue.

## Evidence

### Benchmark Results

```
Problem: input=0.5 -> target=0.3 (LOGISTIC hidden, IDENTITY output)
Iterations: 200, Trials per config: 10

Fixed LR=0.01 (default)             | mean=0.018904 | best=0.018904 | worst=0.018904
Fixed LR=0.001                      | mean=0.018912 | best=0.018912 | worst=0.018912
Fixed LR=0.1                        | mean=0.018140 | best=0.018140 | worst=0.018140
Decay (default)                     | mean=0.018907 | best=0.018907 | worst=0.018907
Adaptive (with magnitude)           | mean=0.018907 | best=0.018907 | worst=0.018907
Warm restart (default)              | mean=0.018905 | best=0.018905 | worst=0.018905
```

All strategies converge to similar final errors on this simple problem. The adaptive strategy with magnitude scaling performs comparably. The enhancement is conservative — it adds magnitude awareness without disrupting convergence.

All 3873 existing tests pass.

## Test Plan

- Added `test/propagate/AdaptiveMagnitudeScaling.ts` with 8 tests verifying magnitude scaling behaviour
- Updated 3 existing tests in `test/propagate/BackPropagationConfig.ts` to account for magnitude scaling
- Added benchmark `bench/AdaptiveLearningRateConvergence.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)