### PR TITLE
Enhancement: Consolidate batch accumulation 4-way/8-way functions (#1760)

### DIFF
--- a/docs/pr-summary-1760.md
+++ b/docs/pr-summary-1760.md
@@ -1,16 +1,23 @@
 ## Summary
 
-Consolidated the duplicated 4-way and 8-way batch accumulation functions in the propagate module into generic parameterised functions. Addresses #1760.
+Consolidated the duplicated 4-way and 8-way batch accumulation functions in the
+propagate module into generic parameterised functions. Addresses #1760.
 
-- Created `accumulateBiasBatchNWay()` in `src/propagate/Bias.ts` — a generic bias batch accumulation function parameterised by batch size
-- Created `accumulateWeightBatchNWay()` in `src/propagate/Weight.ts` — a generic weight batch accumulation function parameterised by batch size
-- Refactored `accumulateBiasBatch4Way()` and `accumulateBiasBatch8Way()` to delegate to the generic function
-- Refactored `accumulateWeightBatch4Way()` and `accumulateWeightBatch8Way()` to delegate to the generic function
-- All existing 4-way/8-way wrapper functions are preserved for backward compatibility — no callers need updating
+- Created `accumulateBiasBatchNWay()` in `src/propagate/Bias.ts` — a generic
+  bias batch accumulation function parameterised by batch size
+- Created `accumulateWeightBatchNWay()` in `src/propagate/Weight.ts` — a generic
+  weight batch accumulation function parameterised by batch size
+- Refactored `accumulateBiasBatch4Way()` and `accumulateBiasBatch8Way()` to
+  delegate to the generic function
+- Refactored `accumulateWeightBatch4Way()` and `accumulateWeightBatch8Way()` to
+  delegate to the generic function
+- All existing 4-way/8-way wrapper functions are preserved for backward
+  compatibility — no callers need updating
 
 ## Evidence
 
-All 4896 existing tests pass, plus 12 new tests for the generic functions. The wrapper functions delegate directly with zero logic duplication.
+All 4896 existing tests pass, plus 12 new tests for the generic functions. The
+wrapper functions delegate directly with zero logic duplication.
 
 ## Test Plan
 

--- a/docs/pr-summary-1760.md
+++ b/docs/pr-summary-1760.md
@@ -1,0 +1,31 @@
+## Summary
+
+Consolidated the duplicated 4-way and 8-way batch accumulation functions in the propagate module into generic parameterised functions. Addresses #1760.
+
+- Created `accumulateBiasBatchNWay()` in `src/propagate/Bias.ts` — a generic bias batch accumulation function parameterised by batch size
+- Created `accumulateWeightBatchNWay()` in `src/propagate/Weight.ts` — a generic weight batch accumulation function parameterised by batch size
+- Refactored `accumulateBiasBatch4Way()` and `accumulateBiasBatch8Way()` to delegate to the generic function
+- Refactored `accumulateWeightBatch4Way()` and `accumulateWeightBatch8Way()` to delegate to the generic function
+- All existing 4-way/8-way wrapper functions are preserved for backward compatibility — no callers need updating
+
+## Evidence
+
+All 4896 existing tests pass, plus 12 new tests for the generic functions. The wrapper functions delegate directly with zero logic duplication.
+
+## Test Plan
+
+- Added `test/propagate/AccumulateBiasBatchNWay.ts` (6 tests):
+  - Verifies NWay with batchSize=4 matches 4-way wrapper
+  - Verifies NWay with batchSize=8 matches 8-way wrapper
+  - Verifies NWay with batchSize=1 matches single accumulateBias call
+  - Verifies NWay with batchSize=6 (non-standard) matches individual calls
+  - Verifies non-finite values are skipped correctly
+  - Verifies multiple iterations with batchSize=3 accumulate correctly
+
+- Added `test/propagate/AccumulateWeightBatchNWay.ts` (6 tests):
+  - Verifies NWay with batchSize=4 matches 4-way wrapper
+  - Verifies NWay with batchSize=8 matches 8-way wrapper
+  - Verifies NWay with batchSize=1 matches single accumulateWeight call
+  - Verifies NWay with batchSize=6 (non-standard) matches individual calls
+  - Verifies non-finite values are skipped correctly
+  - Verifies multiple iterations with batchSize=3 accumulate correctly

--- a/src/propagate/Bias.ts
+++ b/src/propagate/Bias.ts
@@ -163,26 +163,29 @@ export function limitBias(
 }
 
 /**
- * Issue #1214 - Batch bias accumulation for 4 neurons simultaneously.
+ * Issue #1760 - Generic batch bias accumulation parameterised by batch size.
+ * Issue #1214 - Batch bias accumulation for N neurons simultaneously.
  * Issue #1314 - Non-finite values are skipped to prevent state corruption.
  *
- * Processes 4 neurons in a single call, enabling SIMD optimisation
+ * Processes `batchSize` neurons in a single call, enabling SIMD optimisation
  * via V8 when processing mini-batches during backpropagation.
  *
- * @param nsArray Array of 4 NeuronState objects to accumulate into
- * @param targetPreActivationValues Array of 4 target pre-activation values
- * @param preActivationValues Array of 4 current pre-activation values
- * @param currentBiases Array of 4 current neuron biases
- * @param config Backpropagation configuration
+ * @param nsArray Array of NeuronState objects to accumulate into
+ * @param targetPreActivationValues Array of target pre-activation values
+ * @param preActivationValues Array of current pre-activation values
+ * @param currentBiases Array of current neuron biases
+ * @param _config Backpropagation configuration
+ * @param batchSize Number of neurons to process
  */
-export function accumulateBiasBatch4Way(
+export function accumulateBiasBatchNWay(
   nsArray: NeuronState[],
   targetPreActivationValues: number[],
   preActivationValues: number[],
   currentBiases: number[],
   _config: BackPropagationConfig,
+  batchSize: number,
 ) {
-  for (let i = 0; i < 4; i++) {
+  for (let i = 0; i < batchSize; i++) {
     const targetPreActivation = targetPreActivationValues[i];
     const preActivation = preActivationValues[i];
     const currentBias = currentBiases[i];
@@ -214,52 +217,43 @@ export function accumulateBiasBatch4Way(
 }
 
 /**
+ * Issue #1214 - Batch bias accumulation for 4 neurons simultaneously.
+ * Delegates to the generic accumulateBiasBatchNWay (issue #1760).
+ */
+export function accumulateBiasBatch4Way(
+  nsArray: NeuronState[],
+  targetPreActivationValues: number[],
+  preActivationValues: number[],
+  currentBiases: number[],
+  config: BackPropagationConfig,
+) {
+  accumulateBiasBatchNWay(
+    nsArray,
+    targetPreActivationValues,
+    preActivationValues,
+    currentBiases,
+    config,
+    4,
+  );
+}
+
+/**
  * Issue #1214 - Batch bias accumulation for 8 neurons simultaneously.
- * Issue #1314 - Non-finite values are skipped to prevent state corruption.
- *
- * Processes 8 neurons in a single call, enabling SIMD optimisation
- * via V8 when processing mini-batches during backpropagation.
- *
- * @param nsArray Array of 8 NeuronState objects to accumulate into
- * @param targetPreActivationValues Array of 8 target pre-activation values
- * @param preActivationValues Array of 8 current pre-activation values
- * @param currentBiases Array of 8 current neuron biases
- * @param config Backpropagation configuration
+ * Delegates to the generic accumulateBiasBatchNWay (issue #1760).
  */
 export function accumulateBiasBatch8Way(
   nsArray: NeuronState[],
   targetPreActivationValues: number[],
   preActivationValues: number[],
   currentBiases: number[],
-  _config: BackPropagationConfig,
+  config: BackPropagationConfig,
 ) {
-  for (let i = 0; i < 8; i++) {
-    const targetPreActivation = targetPreActivationValues[i];
-    const preActivation = preActivationValues[i];
-    const currentBias = currentBiases[i];
-
-    if (
-      !Number.isFinite(targetPreActivation) ||
-      !Number.isFinite(preActivation) ||
-      !Number.isFinite(currentBias)
-    ) {
-      continue;
-    }
-
-    const biasDelta = targetPreActivation - preActivation;
-    if (!Number.isFinite(biasDelta)) {
-      continue;
-    }
-
-    const targetBias = currentBias + biasDelta;
-    if (!Number.isFinite(targetBias)) {
-      continue;
-    }
-
-    const ns = nsArray[i];
-    ns.count++;
-    ns.totalBias += targetBias;
-    // Issue #1653: Accumulate raw target bias; limitBias applied in calculateBias.
-    ns.totalAdjustedBias += targetBias;
-  }
+  accumulateBiasBatchNWay(
+    nsArray,
+    targetPreActivationValues,
+    preActivationValues,
+    currentBiases,
+    config,
+    8,
+  );
 }

--- a/src/propagate/Weight.ts
+++ b/src/propagate/Weight.ts
@@ -203,28 +203,31 @@ export function limitWeight(
 }
 
 /**
- * Issue #1214 - Batch weight accumulation for 4 synapses simultaneously.
+ * Issue #1760 - Generic batch weight accumulation parameterised by batch size.
+ * Issue #1214 - Batch weight accumulation for N synapses simultaneously.
  * Issue #1314 - Non-finite values are skipped to prevent state corruption.
  *
- * Processes 4 synapses in a single call, enabling SIMD optimisation
+ * Processes `batchSize` synapses in a single call, enabling SIMD optimisation
  * via V8 when processing mini-batches during backpropagation.
  *
- * @param currentWeights Array of 4 current synapse weights
- * @param csArray Array of 4 SynapseState objects to accumulate into
- * @param targetValues Array of 4 target values for weight calculation
- * @param activations Array of 4 activation values from source neurons
+ * @param currentWeights Array of current synapse weights
+ * @param csArray Array of SynapseState objects to accumulate into
+ * @param targetValues Array of target values for weight calculation
+ * @param activations Array of activation values from source neurons
  * @param config Backpropagation configuration
+ * @param batchSize Number of synapses to process
  */
-export function accumulateWeightBatch4Way(
+export function accumulateWeightBatchNWay(
   currentWeights: number[],
   csArray: SynapseState[],
   targetValues: number[],
   activations: number[],
   config: BackPropagationConfig,
+  batchSize: number,
 ) {
   const plankConstant = config.plankConstant;
 
-  for (let i = 0; i < 4; i++) {
+  for (let i = 0; i < batchSize; i++) {
     const activation = activations[i];
     const currentWeight = currentWeights[i];
     const targetValue = targetValues[i];
@@ -274,17 +277,29 @@ export function accumulateWeightBatch4Way(
 }
 
 /**
+ * Issue #1214 - Batch weight accumulation for 4 synapses simultaneously.
+ * Delegates to the generic accumulateWeightBatchNWay (issue #1760).
+ */
+export function accumulateWeightBatch4Way(
+  currentWeights: number[],
+  csArray: SynapseState[],
+  targetValues: number[],
+  activations: number[],
+  config: BackPropagationConfig,
+) {
+  accumulateWeightBatchNWay(
+    currentWeights,
+    csArray,
+    targetValues,
+    activations,
+    config,
+    4,
+  );
+}
+
+/**
  * Issue #1214 - Batch weight accumulation for 8 synapses simultaneously.
- * Issue #1314 - Non-finite values are skipped to prevent state corruption.
- *
- * Processes 8 synapses in a single call, enabling SIMD optimisation
- * via V8 when processing mini-batches during backpropagation.
- *
- * @param currentWeights Array of 8 current synapse weights
- * @param csArray Array of 8 SynapseState objects to accumulate into
- * @param targetValues Array of 8 target values for weight calculation
- * @param activations Array of 8 activation values from source neurons
- * @param config Backpropagation configuration
+ * Delegates to the generic accumulateWeightBatchNWay (issue #1760).
  */
 export function accumulateWeightBatch8Way(
   currentWeights: number[],
@@ -293,53 +308,12 @@ export function accumulateWeightBatch8Way(
   activations: number[],
   config: BackPropagationConfig,
 ) {
-  const plankConstant = config.plankConstant;
-
-  for (let i = 0; i < 8; i++) {
-    const activation = activations[i];
-    const currentWeight = currentWeights[i];
-    const targetValue = targetValues[i];
-
-    if (
-      !Number.isFinite(activation) ||
-      !Number.isFinite(currentWeight) ||
-      !Number.isFinite(targetValue)
-    ) {
-      continue;
-    }
-
-    const cs = csArray[i];
-
-    const sign = Math.sign(activation) || 1;
-    let tmpActivation = activation;
-
-    if (Math.abs(tmpActivation) < plankConstant) {
-      tmpActivation = plankConstant * sign;
-    }
-
-    const tmpValue = Math.abs(targetValue) > plankConstant
-      ? targetValue
-      : plankConstant * Math.sign(targetValue);
-
-    const tmpWeight = tmpValue / tmpActivation;
-
-    if (!Number.isFinite(tmpWeight)) {
-      continue;
-    }
-
-    // Issue #1653: Accumulate raw target weight; limitWeight applied in calculateWeight.
-    if (Math.abs(activation) > plankConstant) {
-      if (activation > 0) {
-        cs.totalPositiveActivation += activation;
-        cs.totalPositiveAdjustedValue += tmpWeight * activation;
-        cs.countPositiveActivations++;
-      } else if (activation < 0) {
-        cs.totalNegativeActivation += Math.abs(activation);
-        cs.totalNegativeAdjustedValue += tmpWeight * activation;
-        cs.countNegativeActivations++;
-      }
-    }
-
-    cs.count++;
-  }
+  accumulateWeightBatchNWay(
+    currentWeights,
+    csArray,
+    targetValues,
+    activations,
+    config,
+    8,
+  );
 }

--- a/test/propagate/AccumulateBiasBatchNWay.ts
+++ b/test/propagate/AccumulateBiasBatchNWay.ts
@@ -1,0 +1,324 @@
+/**
+ * Issue #1760 - Tests for generic batch bias accumulation parameterised by batch size.
+ *
+ * Verifies that accumulateBiasBatchNWay produces the same results as
+ * calling accumulateBias individually for various batch sizes.
+ */
+
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import { NeuronState } from "../../src/architecture/CreatureState.ts";
+import {
+  createBackPropagationConfig,
+} from "../../src/propagate/BackPropagation.ts";
+import {
+  accumulateBias,
+  accumulateBiasBatch4Way,
+  accumulateBiasBatch8Way,
+  accumulateBiasBatchNWay,
+} from "../../src/propagate/Bias.ts";
+
+/**
+ * Test that accumulateBiasBatchNWay with batchSize=4 matches accumulateBiasBatch4Way.
+ */
+Deno.test("AccumulateBiasBatchNWay-Matches4Way", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+  });
+
+  const currentBiases = [0.5, -0.3, 1.2, 0.0];
+  const targetPreActivationValues = [2.0, -1.5, 0.8, 3.0];
+  const preActivationValues = [1.0, -0.5, 0.2, 2.5];
+
+  const nWayStates = Array.from({ length: 4 }, () => new NeuronState());
+  const fourWayStates = Array.from({ length: 4 }, () => new NeuronState());
+
+  accumulateBiasBatchNWay(
+    nWayStates,
+    targetPreActivationValues,
+    preActivationValues,
+    currentBiases,
+    config,
+    4,
+  );
+
+  accumulateBiasBatch4Way(
+    fourWayStates,
+    targetPreActivationValues,
+    preActivationValues,
+    currentBiases,
+    config,
+  );
+
+  for (let i = 0; i < 4; i++) {
+    assertEquals(nWayStates[i].count, fourWayStates[i].count);
+    assertAlmostEquals(
+      nWayStates[i].totalBias,
+      fourWayStates[i].totalBias,
+      1e-10,
+    );
+    assertAlmostEquals(
+      nWayStates[i].totalAdjustedBias,
+      fourWayStates[i].totalAdjustedBias,
+      1e-10,
+    );
+  }
+});
+
+/**
+ * Test that accumulateBiasBatchNWay with batchSize=8 matches accumulateBiasBatch8Way.
+ */
+Deno.test("AccumulateBiasBatchNWay-Matches8Way", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+  });
+
+  const currentBiases = [0.5, -0.3, 1.2, 0.0, -1.0, 0.8, -0.5, 1.5];
+  const targetPreActivationValues = [
+    2.0,
+    -1.5,
+    0.8,
+    3.0,
+    -2.0,
+    1.0,
+    -0.5,
+    2.5,
+  ];
+  const preActivationValues = [1.0, -0.5, 0.2, 2.5, -1.5, 0.5, 0.1, 1.0];
+
+  const nWayStates = Array.from({ length: 8 }, () => new NeuronState());
+  const eightWayStates = Array.from({ length: 8 }, () => new NeuronState());
+
+  accumulateBiasBatchNWay(
+    nWayStates,
+    targetPreActivationValues,
+    preActivationValues,
+    currentBiases,
+    config,
+    8,
+  );
+
+  accumulateBiasBatch8Way(
+    eightWayStates,
+    targetPreActivationValues,
+    preActivationValues,
+    currentBiases,
+    config,
+  );
+
+  for (let i = 0; i < 8; i++) {
+    assertEquals(nWayStates[i].count, eightWayStates[i].count);
+    assertAlmostEquals(
+      nWayStates[i].totalBias,
+      eightWayStates[i].totalBias,
+      1e-10,
+    );
+    assertAlmostEquals(
+      nWayStates[i].totalAdjustedBias,
+      eightWayStates[i].totalAdjustedBias,
+      1e-10,
+    );
+  }
+});
+
+/**
+ * Test accumulateBiasBatchNWay with batchSize=1 matches a single accumulateBias call.
+ */
+Deno.test("AccumulateBiasBatchNWay-BatchSize1-MatchesSingleCall", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+  });
+
+  const singleState = new NeuronState();
+  const batchState = new NeuronState();
+
+  accumulateBias(singleState, 2.0, 1.0, 0.5, config);
+
+  accumulateBiasBatchNWay(
+    [batchState],
+    [2.0],
+    [1.0],
+    [0.5],
+    config,
+    1,
+  );
+
+  assertEquals(batchState.count, singleState.count);
+  assertAlmostEquals(batchState.totalBias, singleState.totalBias, 1e-10);
+  assertAlmostEquals(
+    batchState.totalAdjustedBias,
+    singleState.totalAdjustedBias,
+    1e-10,
+  );
+});
+
+/**
+ * Test accumulateBiasBatchNWay with batchSize=6 (non-standard size)
+ * matches individual accumulateBias calls.
+ */
+Deno.test("AccumulateBiasBatchNWay-BatchSize6-MatchesSingleCalls", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+  });
+
+  const batchSize = 6;
+  const currentBiases = [0.5, -0.3, 1.2, 0.0, -1.0, 0.8];
+  const targetPreActivationValues = [2.0, -1.5, 0.8, 3.0, -2.0, 1.0];
+  const preActivationValues = [1.0, -0.5, 0.2, 2.5, -1.5, 0.5];
+
+  const singleStates = Array.from(
+    { length: batchSize },
+    () => new NeuronState(),
+  );
+  const batchStates = Array.from(
+    { length: batchSize },
+    () => new NeuronState(),
+  );
+
+  for (let i = 0; i < batchSize; i++) {
+    accumulateBias(
+      singleStates[i],
+      targetPreActivationValues[i],
+      preActivationValues[i],
+      currentBiases[i],
+      config,
+    );
+  }
+
+  accumulateBiasBatchNWay(
+    batchStates,
+    targetPreActivationValues,
+    preActivationValues,
+    currentBiases,
+    config,
+    batchSize,
+  );
+
+  for (let i = 0; i < batchSize; i++) {
+    assertEquals(
+      batchStates[i].count,
+      singleStates[i].count,
+      `Neuron ${i}: count mismatch`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalBias,
+      singleStates[i].totalBias,
+      1e-10,
+      `Neuron ${i}: totalBias mismatch`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalAdjustedBias,
+      singleStates[i].totalAdjustedBias,
+      1e-10,
+      `Neuron ${i}: totalAdjustedBias mismatch`,
+    );
+  }
+});
+
+/**
+ * Test accumulateBiasBatchNWay with non-finite values skips correctly.
+ */
+Deno.test("AccumulateBiasBatchNWay-SkipsNonFiniteValues", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+  });
+
+  const currentBiases = [0.5, Infinity, 0.5, NaN];
+  const targetPreActivationValues = [2.0, 1.0, NaN, 1.0];
+  const preActivationValues = [1.0, 1.0, 1.0, 1.0];
+
+  const states = Array.from({ length: 4 }, () => new NeuronState());
+
+  accumulateBiasBatchNWay(
+    states,
+    targetPreActivationValues,
+    preActivationValues,
+    currentBiases,
+    config,
+    4,
+  );
+
+  // Only neuron 0 should have been accumulated (others have non-finite inputs)
+  assertEquals(states[0].count, 1);
+  assertEquals(states[1].count, 0);
+  assertEquals(states[2].count, 0);
+  assertEquals(states[3].count, 0);
+});
+
+/**
+ * Test accumulateBiasBatchNWay with multiple iterations accumulates correctly.
+ */
+Deno.test("AccumulateBiasBatchNWay-MultipleIterations-BatchSize3", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+  });
+
+  const batchSize = 3;
+  const singleStates = Array.from(
+    { length: batchSize },
+    () => new NeuronState(),
+  );
+  const batchStates = Array.from(
+    { length: batchSize },
+    () => new NeuronState(),
+  );
+
+  const iterations = 10;
+  for (let iter = 0; iter < iterations; iter++) {
+    const currentBiases = [0.5, -0.3, 1.2];
+    const targetPreActivationValues = [
+      Math.sin(iter),
+      Math.cos(iter),
+      Math.sin(iter * 2),
+    ];
+    const preActivationValues = [
+      Math.cos(iter) * 0.5,
+      Math.sin(iter) * 0.5,
+      Math.cos(iter * 2) * 0.5,
+    ];
+
+    for (let i = 0; i < batchSize; i++) {
+      accumulateBias(
+        singleStates[i],
+        targetPreActivationValues[i],
+        preActivationValues[i],
+        currentBiases[i],
+        config,
+      );
+    }
+
+    accumulateBiasBatchNWay(
+      batchStates,
+      targetPreActivationValues,
+      preActivationValues,
+      currentBiases,
+      config,
+      batchSize,
+    );
+  }
+
+  for (let i = 0; i < batchSize; i++) {
+    assertEquals(
+      batchStates[i].count,
+      singleStates[i].count,
+      `Neuron ${i}: count mismatch after ${iterations} iterations`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalBias,
+      singleStates[i].totalBias,
+      1e-5,
+      `Neuron ${i}: totalBias mismatch`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalAdjustedBias,
+      singleStates[i].totalAdjustedBias,
+      1e-5,
+      `Neuron ${i}: totalAdjustedBias mismatch`,
+    );
+  }
+});

--- a/test/propagate/AccumulateWeightBatchNWay.ts
+++ b/test/propagate/AccumulateWeightBatchNWay.ts
@@ -1,0 +1,377 @@
+/**
+ * Issue #1760 - Tests for generic batch weight accumulation parameterised by batch size.
+ *
+ * Verifies that accumulateWeightBatchNWay produces the same results as
+ * calling accumulateWeight individually for various batch sizes.
+ */
+
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import {
+  createBackPropagationConfig,
+} from "../../src/propagate/BackPropagation.ts";
+import { SynapseState } from "../../src/propagate/SynapseState.ts";
+import {
+  accumulateWeight,
+  accumulateWeightBatch4Way,
+  accumulateWeightBatch8Way,
+  accumulateWeightBatchNWay,
+} from "../../src/propagate/Weight.ts";
+
+/**
+ * Test that accumulateWeightBatchNWay with batchSize=4 matches accumulateWeightBatch4Way.
+ */
+Deno.test("AccumulateWeightBatchNWay-Matches4Way", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    plankConstant: 0.000_000_1,
+  });
+
+  const currentWeights = [0.5, -0.3, 1.2, 0.0];
+  const targetValues = [2.0, -1.5, 0.8, 3.0];
+  const activations = [1.0, 0.5, -0.8, 2.0];
+
+  const nWayStates = Array.from({ length: 4 }, () => new SynapseState());
+  const fourWayStates = Array.from({ length: 4 }, () => new SynapseState());
+
+  accumulateWeightBatchNWay(
+    currentWeights,
+    nWayStates,
+    targetValues,
+    activations,
+    config,
+    4,
+  );
+
+  accumulateWeightBatch4Way(
+    currentWeights,
+    fourWayStates,
+    targetValues,
+    activations,
+    config,
+  );
+
+  for (let i = 0; i < 4; i++) {
+    assertEquals(nWayStates[i].count, fourWayStates[i].count);
+    assertAlmostEquals(
+      nWayStates[i].totalPositiveActivation,
+      fourWayStates[i].totalPositiveActivation,
+      1e-10,
+    );
+    assertAlmostEquals(
+      nWayStates[i].totalNegativeActivation,
+      fourWayStates[i].totalNegativeActivation,
+      1e-10,
+    );
+    assertAlmostEquals(
+      nWayStates[i].totalPositiveAdjustedValue,
+      fourWayStates[i].totalPositiveAdjustedValue,
+      1e-10,
+    );
+    assertAlmostEquals(
+      nWayStates[i].totalNegativeAdjustedValue,
+      fourWayStates[i].totalNegativeAdjustedValue,
+      1e-10,
+    );
+    assertEquals(
+      nWayStates[i].countPositiveActivations,
+      fourWayStates[i].countPositiveActivations,
+    );
+    assertEquals(
+      nWayStates[i].countNegativeActivations,
+      fourWayStates[i].countNegativeActivations,
+    );
+  }
+});
+
+/**
+ * Test that accumulateWeightBatchNWay with batchSize=8 matches accumulateWeightBatch8Way.
+ */
+Deno.test("AccumulateWeightBatchNWay-Matches8Way", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    plankConstant: 0.000_000_1,
+  });
+
+  const currentWeights = [0.5, -0.3, 1.2, 0.0, -1.0, 0.8, -0.5, 1.5];
+  const targetValues = [2.0, -1.5, 0.8, 3.0, -2.0, 1.0, -0.5, 2.5];
+  const activations = [1.0, 0.5, -0.8, 2.0, -1.5, 0.3, 0.9, -0.6];
+
+  const nWayStates = Array.from({ length: 8 }, () => new SynapseState());
+  const eightWayStates = Array.from({ length: 8 }, () => new SynapseState());
+
+  accumulateWeightBatchNWay(
+    currentWeights,
+    nWayStates,
+    targetValues,
+    activations,
+    config,
+    8,
+  );
+
+  accumulateWeightBatch8Way(
+    currentWeights,
+    eightWayStates,
+    targetValues,
+    activations,
+    config,
+  );
+
+  for (let i = 0; i < 8; i++) {
+    assertEquals(nWayStates[i].count, eightWayStates[i].count);
+    assertAlmostEquals(
+      nWayStates[i].totalPositiveActivation,
+      eightWayStates[i].totalPositiveActivation,
+      1e-10,
+    );
+    assertAlmostEquals(
+      nWayStates[i].totalNegativeActivation,
+      eightWayStates[i].totalNegativeActivation,
+      1e-10,
+    );
+    assertAlmostEquals(
+      nWayStates[i].totalPositiveAdjustedValue,
+      eightWayStates[i].totalPositiveAdjustedValue,
+      1e-10,
+    );
+    assertAlmostEquals(
+      nWayStates[i].totalNegativeAdjustedValue,
+      eightWayStates[i].totalNegativeAdjustedValue,
+      1e-10,
+    );
+  }
+});
+
+/**
+ * Test accumulateWeightBatchNWay with batchSize=1 matches a single accumulateWeight call.
+ */
+Deno.test("AccumulateWeightBatchNWay-BatchSize1-MatchesSingleCall", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    plankConstant: 0.000_000_1,
+  });
+
+  const singleState = new SynapseState();
+  const batchState = new SynapseState();
+
+  accumulateWeight(0.5, singleState, 2.0, 1.0, config);
+
+  accumulateWeightBatchNWay(
+    [0.5],
+    [batchState],
+    [2.0],
+    [1.0],
+    config,
+    1,
+  );
+
+  assertEquals(batchState.count, singleState.count);
+  assertAlmostEquals(
+    batchState.totalPositiveActivation,
+    singleState.totalPositiveActivation,
+    1e-10,
+  );
+  assertAlmostEquals(
+    batchState.totalPositiveAdjustedValue,
+    singleState.totalPositiveAdjustedValue,
+    1e-10,
+  );
+  assertEquals(
+    batchState.countPositiveActivations,
+    singleState.countPositiveActivations,
+  );
+});
+
+/**
+ * Test accumulateWeightBatchNWay with batchSize=6 (non-standard size)
+ * matches individual accumulateWeight calls.
+ */
+Deno.test("AccumulateWeightBatchNWay-BatchSize6-MatchesSingleCalls", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+    plankConstant: 0.000_000_1,
+  });
+
+  const batchSize = 6;
+  const currentWeights = [0.5, -0.3, 1.2, 0.0, -1.0, 0.8];
+  const targetValues = [2.0, -1.5, 0.8, 3.0, -2.0, 1.0];
+  const activations = [1.0, 0.5, -0.8, 2.0, -1.5, 0.3];
+
+  const singleStates = Array.from(
+    { length: batchSize },
+    () => new SynapseState(),
+  );
+  const batchStates = Array.from(
+    { length: batchSize },
+    () => new SynapseState(),
+  );
+
+  for (let i = 0; i < batchSize; i++) {
+    accumulateWeight(
+      currentWeights[i],
+      singleStates[i],
+      targetValues[i],
+      activations[i],
+      config,
+    );
+  }
+
+  accumulateWeightBatchNWay(
+    currentWeights,
+    batchStates,
+    targetValues,
+    activations,
+    config,
+    batchSize,
+  );
+
+  for (let i = 0; i < batchSize; i++) {
+    assertEquals(
+      batchStates[i].count,
+      singleStates[i].count,
+      `Synapse ${i}: count mismatch`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalPositiveActivation,
+      singleStates[i].totalPositiveActivation,
+      1e-10,
+      `Synapse ${i}: totalPositiveActivation mismatch`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalNegativeActivation,
+      singleStates[i].totalNegativeActivation,
+      1e-10,
+      `Synapse ${i}: totalNegativeActivation mismatch`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalPositiveAdjustedValue,
+      singleStates[i].totalPositiveAdjustedValue,
+      1e-10,
+      `Synapse ${i}: totalPositiveAdjustedValue mismatch`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalNegativeAdjustedValue,
+      singleStates[i].totalNegativeAdjustedValue,
+      1e-10,
+      `Synapse ${i}: totalNegativeAdjustedValue mismatch`,
+    );
+    assertEquals(
+      batchStates[i].countPositiveActivations,
+      singleStates[i].countPositiveActivations,
+      `Synapse ${i}: countPositiveActivations mismatch`,
+    );
+    assertEquals(
+      batchStates[i].countNegativeActivations,
+      singleStates[i].countNegativeActivations,
+      `Synapse ${i}: countNegativeActivations mismatch`,
+    );
+  }
+});
+
+/**
+ * Test accumulateWeightBatchNWay with non-finite values skips correctly.
+ */
+Deno.test("AccumulateWeightBatchNWay-SkipsNonFiniteValues", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+  });
+
+  const currentWeights = [0.5, Infinity, 0.5, NaN];
+  const targetValues = [2.0, 1.0, NaN, 1.0];
+  const activations = [1.0, 1.0, 1.0, 1.0];
+
+  const states = Array.from({ length: 4 }, () => new SynapseState());
+
+  accumulateWeightBatchNWay(
+    currentWeights,
+    states,
+    targetValues,
+    activations,
+    config,
+    4,
+  );
+
+  // Only synapse 0 should have been accumulated (others have non-finite inputs)
+  assertEquals(states[0].count, 1);
+  assertEquals(states[1].count, 0);
+  assertEquals(states[2].count, 0);
+  assertEquals(states[3].count, 0);
+});
+
+/**
+ * Test accumulateWeightBatchNWay with multiple iterations accumulates correctly.
+ */
+Deno.test("AccumulateWeightBatchNWay-MultipleIterations-BatchSize3", () => {
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 1,
+  });
+
+  const batchSize = 3;
+  const singleStates = Array.from(
+    { length: batchSize },
+    () => new SynapseState(),
+  );
+  const batchStates = Array.from(
+    { length: batchSize },
+    () => new SynapseState(),
+  );
+
+  const iterations = 10;
+  for (let iter = 0; iter < iterations; iter++) {
+    const currentWeights = [0.5, -0.3, 1.2];
+    const targetValues = [
+      Math.sin(iter),
+      Math.cos(iter),
+      Math.sin(iter * 2),
+    ];
+    const activations = [
+      0.5 + 0.3 * Math.sin(iter),
+      -0.5 + 0.3 * Math.cos(iter),
+      0.8 * Math.sin(iter * 3),
+    ];
+
+    for (let i = 0; i < batchSize; i++) {
+      accumulateWeight(
+        currentWeights[i],
+        singleStates[i],
+        targetValues[i],
+        activations[i],
+        config,
+      );
+    }
+
+    accumulateWeightBatchNWay(
+      currentWeights,
+      batchStates,
+      targetValues,
+      activations,
+      config,
+      batchSize,
+    );
+  }
+
+  for (let i = 0; i < batchSize; i++) {
+    assertEquals(
+      batchStates[i].count,
+      singleStates[i].count,
+      `Synapse ${i}: count mismatch after ${iterations} iterations`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalPositiveActivation,
+      singleStates[i].totalPositiveActivation,
+      1e-5,
+      `Synapse ${i}: totalPositiveActivation mismatch`,
+    );
+    assertAlmostEquals(
+      batchStates[i].totalNegativeActivation,
+      singleStates[i].totalNegativeActivation,
+      1e-5,
+      `Synapse ${i}: totalNegativeActivation mismatch`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Consolidated the duplicated 4-way and 8-way batch accumulation functions in the
propagate module into generic parameterised functions. Addresses #1760.

- Created `accumulateBiasBatchNWay()` in `src/propagate/Bias.ts` — a generic
  bias batch accumulation function parameterised by batch size
- Created `accumulateWeightBatchNWay()` in `src/propagate/Weight.ts` — a generic
  weight batch accumulation function parameterised by batch size
- Refactored `accumulateBiasBatch4Way()` and `accumulateBiasBatch8Way()` to
  delegate to the generic function
- Refactored `accumulateWeightBatch4Way()` and `accumulateWeightBatch8Way()` to
  delegate to the generic function
- All existing 4-way/8-way wrapper functions are preserved for backward
  compatibility — no callers need updating

## Evidence

All 4896 existing tests pass, plus 12 new tests for the generic functions. The
wrapper functions delegate directly with zero logic duplication.

## Test Plan

- Added `test/propagate/AccumulateBiasBatchNWay.ts` (6 tests):
  - Verifies NWay with batchSize=4 matches 4-way wrapper
  - Verifies NWay with batchSize=8 matches 8-way wrapper
  - Verifies NWay with batchSize=1 matches single accumulateBias call
  - Verifies NWay with batchSize=6 (non-standard) matches individual calls
  - Verifies non-finite values are skipped correctly
  - Verifies multiple iterations with batchSize=3 accumulate correctly

- Added `test/propagate/AccumulateWeightBatchNWay.ts` (6 tests):
  - Verifies NWay with batchSize=4 matches 4-way wrapper
  - Verifies NWay with batchSize=8 matches 8-way wrapper
  - Verifies NWay with batchSize=1 matches single accumulateWeight call
  - Verifies NWay with batchSize=6 (non-standard) matches individual calls
  - Verifies non-finite values are skipped correctly
  - Verifies multiple iterations with batchSize=3 accumulate correctly

---

## Automated Fix Details
This PR addresses issue #1760: **Enhancement: Consolidate batch accumulation 4-way/8-way functions in propagate module (#1757)**

## Milestone
This PR is part of the **test-clean-up** milestone and targets the `milestone/test-clean-up` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Addresses #1760
---

🤖 Processed by: stservice