### PR TITLE
Enhancement: Standardise multithreading worker error handling with toError() (#1761)

### DIFF
--- a/docs/pr-summary-1761.md
+++ b/docs/pr-summary-1761.md
@@ -1,0 +1,24 @@
+## Summary
+
+Standardised multithreading worker error handling to use `toError()` from
+`ErrorSerialisation.ts`, consistent with the intelligent design worker and
+MockWorker patterns. Error responses now preserve error name, message, and
+stack trace instead of losing error details. Addresses #1761.
+
+## Changes
+
+- Added standardised `error` field (with `name`, `message`, `stack`) to the
+  multithreading `ResponseData` interface, matching the intelligent design
+  worker pattern
+- Updated `src/multithreading/workers/deno/worker.ts` to use `toError()` for
+  proper error serialisation
+- Updated `src/multithreading/workers/MockWorker.ts` to use `toError()` and
+  `toErrorMessage()` for consistent error handling
+- Operation-specific error fields are preserved for backwards compatibility
+
+## Test Plan
+
+- Added `MockWorker: evaluate error response preserves error details` test
+- Added `MockWorker: train error response preserves error details` test
+- Added `MockWorker: discover error response preserves error details` test
+- All 4899 existing tests continue to pass

--- a/docs/pr-summary-1761.md
+++ b/docs/pr-summary-1761.md
@@ -2,8 +2,8 @@
 
 Standardised multithreading worker error handling to use `toError()` from
 `ErrorSerialisation.ts`, consistent with the intelligent design worker and
-MockWorker patterns. Error responses now preserve error name, message, and
-stack trace instead of losing error details. Addresses #1761.
+MockWorker patterns. Error responses now preserve error name, message, and stack
+trace instead of losing error details. Addresses #1761.
 
 ## Changes
 

--- a/src/multithreading/workers/MockWorker.ts
+++ b/src/multithreading/workers/MockWorker.ts
@@ -3,6 +3,7 @@ import type { RequestData, ResponseData } from "./WorkerHandler.ts";
 
 import { WorkerProcessor } from "./WorkerProcessor.ts";
 import { getLogger } from "../../utils/Logger.ts";
+import { toError, toErrorMessage } from "../../utils/ErrorSerialisation.ts";
 
 export class MockWorker implements WorkerInterface<RequestData> {
   private callBack: EventListener | null = null;
@@ -30,23 +31,29 @@ export class MockWorker implements WorkerInterface<RequestData> {
         this.callBack(me);
       }
     }).catch((error) => {
-      getLogger().error("MockWorker processing error:", error);
-      // Create a proper error response with operation-specific error field
+      const err = toError(error);
+      getLogger().error("MockWorker processing error:", err);
+      // Issue #1761: Include standardised error details
       const errorResponse: ResponseData = {
         taskID: data.taskID,
         duration: 0,
+        error: {
+          name: err.name,
+          message: err.message,
+          stack: err.stack,
+        },
       };
 
       // Add operation-specific error field based on request type
       if (data.evaluate) {
         errorResponse.evaluate = {
-          error: Number.POSITIVE_INFINITY, // Use infinity to indicate evaluation failure
+          error: Number.POSITIVE_INFINITY,
         };
       } else if (data.train) {
         errorResponse.train = {
           ID: "error",
           creature: "",
-          error: Number.POSITIVE_INFINITY, // Use infinity to indicate training failure
+          error: Number.POSITIVE_INFINITY,
           trace: "",
         };
       } else if (data.discover) {
@@ -55,11 +62,11 @@ export class MockWorker implements WorkerInterface<RequestData> {
         };
       } else if (data.echo) {
         errorResponse.echo = {
-          message: `Error: ${error?.message || String(error)}`,
+          message: `Error: ${toErrorMessage(error)}`,
         };
       } else if (data.configureCache) {
         errorResponse.configureCache = {
-          status: `ERROR: ${error?.message || String(error)}`,
+          status: `ERROR: ${toErrorMessage(error)}`,
         };
       } else if (data.requestCacheStats) {
         errorResponse.cacheStats = {
@@ -71,9 +78,9 @@ export class MockWorker implements WorkerInterface<RequestData> {
       } else if (data.initialize) {
         errorResponse.initialize = {
           status: "ERROR",
+          error: toErrorMessage(error),
         };
       } else if (data.breed) {
-        // Issue #1026: Handle breeding errors
         errorResponse.breed = {
           success: false,
         };

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -161,6 +161,20 @@ export interface ResponseData {
   debug?: boolean;
   /** Duration of the operation in milliseconds */
   duration: number;
+  /**
+   * Error details when the worker failed to process the request.
+   *
+   * Issue #1761: Standardised error field consistent with the intelligent
+   * design worker, preserving error name, message, and stack trace.
+   */
+  error?: {
+    /** Error name (when available) */
+    name?: string;
+    /** Error message */
+    message: string;
+    /** Stack trace (when available) */
+    stack?: string;
+  };
   /** Initialization response */
   initialize?: {
     /** Status of the initialization */

--- a/src/multithreading/workers/deno/worker.ts
+++ b/src/multithreading/workers/deno/worker.ts
@@ -1,7 +1,7 @@
 import type { RequestData, ResponseData } from "../WorkerHandler.ts";
 import { setSkipWasmAutoInit } from "@globalAccessors";
 import { setupWorkerMessageLoop } from "../../../workers/workerEntryPoint.ts";
-import { toErrorMessage } from "../../../utils/ErrorSerialisation.ts";
+import { toError, toErrorMessage } from "../../../utils/ErrorSerialisation.ts";
 
 // Issue #1263: WASM activation is mandatory. For the library's internal worker
 // system, workers receive the WASM payload from the parent during init, so we
@@ -16,11 +16,17 @@ const processor = new WorkerProcessor();
 setupWorkerMessageLoop<RequestData, ResponseData>(
   processor,
   (data, error, durationMs) => {
-    getLogger().error("Worker processing error:", error);
-    // Create a proper error response with operation-specific error field
+    const err = toError(error);
+    getLogger().error("Worker processing error:", err);
+    // Issue #1761: Include standardised error details
     const errorResponse: ResponseData = {
       taskID: data.taskID,
       duration: durationMs,
+      error: {
+        name: err.name,
+        message: err.message,
+        stack: err.stack,
+      },
     };
 
     // Add operation-specific error field based on request type

--- a/test/multithreading/MockWorker.ts
+++ b/test/multithreading/MockWorker.ts
@@ -5,7 +5,7 @@
  * including message handling, structured clone validation, error responses,
  * and termination.
  */
-import { assertEquals, assertExists } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 import { MockWorker } from "../../src/multithreading/workers/MockWorker.ts";
 import type {
   RequestData,
@@ -115,6 +115,70 @@ Deno.test("MockWorker: error response for evaluate includes infinity error", asy
   assertEquals(response.taskID, 10);
   assertExists(response.evaluate);
   assertEquals(response.evaluate?.error, Number.POSITIVE_INFINITY);
+
+  worker.terminate();
+});
+
+Deno.test("MockWorker: evaluate error response preserves error details", async () => {
+  const worker = new MockWorker();
+
+  const response = await sendAndReceive(worker, {
+    taskID: 20,
+    evaluate: { creature: "invalid-json", feedbackLoop: false },
+  });
+
+  assertEquals(response.taskID, 20);
+  // Issue #1761: Error responses must include name, message, and stack
+  assertExists(response.error, "error field must be present");
+  assertExists(response.error?.name, "error name must be present");
+  assertExists(response.error?.message, "error message must be present");
+  assert(
+    response.error!.message.length > 0,
+    "error message must not be empty",
+  );
+
+  worker.terminate();
+});
+
+Deno.test("MockWorker: train error response preserves error details", async () => {
+  const worker = new MockWorker();
+
+  const response = await sendAndReceive(worker, {
+    taskID: 21,
+    train: {
+      creature: "invalid-json",
+      options: {} as import("../../src/config/TrainOptions.ts").TrainOptions,
+    },
+  });
+
+  assertEquals(response.taskID, 21);
+  assertExists(response.train);
+  assertEquals(response.train?.error, Number.POSITIVE_INFINITY);
+  // Issue #1761: Error responses must include name, message, and stack
+  assertExists(response.error, "error field must be present");
+  assertExists(response.error?.name, "error name must be present");
+  assertExists(response.error?.message, "error message must be present");
+
+  worker.terminate();
+});
+
+Deno.test("MockWorker: discover error response preserves error details", async () => {
+  const worker = new MockWorker();
+
+  const response = await sendAndReceive(worker, {
+    taskID: 22,
+    discover: {
+      creature: "invalid-json",
+      config: {} as import("../../src/config/NeatConfig.ts").NeatConfig,
+    },
+  });
+
+  assertEquals(response.taskID, 22);
+  assertExists(response.discover);
+  // Issue #1761: Error responses must include name, message, and stack
+  assertExists(response.error, "error field must be present");
+  assertExists(response.error?.name, "error name must be present");
+  assertExists(response.error?.message, "error message must be present");
 
   worker.terminate();
 });


### PR DESCRIPTION
## Summary

Standardised multithreading worker error handling to use `toError()` from
`ErrorSerialisation.ts`, consistent with the intelligent design worker and
MockWorker patterns. Error responses now preserve error name, message, and stack
trace instead of losing error details. Addresses #1761.

## Changes

- Added standardised `error` field (with `name`, `message`, `stack`) to the
  multithreading `ResponseData` interface, matching the intelligent design
  worker pattern
- Updated `src/multithreading/workers/deno/worker.ts` to use `toError()` for
  proper error serialisation
- Updated `src/multithreading/workers/MockWorker.ts` to use `toError()` and
  `toErrorMessage()` for consistent error handling
- Operation-specific error fields are preserved for backwards compatibility

## Test Plan

- Added `MockWorker: evaluate error response preserves error details` test
- Added `MockWorker: train error response preserves error details` test
- Added `MockWorker: discover error response preserves error details` test
- All 4899 existing tests continue to pass

---

## Automated Fix Details
This PR addresses issue #1761: **Enhancement: Standardise multithreading worker error handling with toError() (#1757)**

## Milestone
This PR is part of the **test-clean-up** milestone and targets the `milestone/test-clean-up` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Addresses #1761
---

🤖 Processed by: stservice