### PR TITLE
Audit: Improve remaining vague test names and add missing assertions in propagation module (#1766)

### DIFF
--- a/docs/pr-summary-1766.md
+++ b/docs/pr-summary-1766.md
@@ -1,11 +1,12 @@
 ## Summary
 
-Complete audit of all ~86 test files (~500+ test cases) in the propagation module
-(`test/propagate/`). Improved vague test names across 21 files to clearly describe
-the behaviour being verified, and added missing dampening comparison assertions to
-the Generation.ts tests. Addresses #1766.
+Complete audit of all ~86 test files (~500+ test cases) in the propagation
+module (`test/propagate/`). Improved vague test names across 21 files to clearly
+describe the behaviour being verified, and added missing dampening comparison
+assertions to the Generation.ts tests. Addresses #1766.
 
 This is the third PR in the audit series:
+
 - PR #1787: Consolidated and improved propagation module tests
 - PR #1788: Fixed vague test names, trivial tests, and missing assertions
 - This PR: Final pass - remaining vague test names and missing assertions
@@ -13,9 +14,13 @@ This is the third PR in the audit series:
 ## Changes
 
 ### Vague test names replaced with descriptive behaviour descriptions (21 files):
-- **AccumulateBias.ts**: "AccumulateBias-average" → describes convergence across diverse biases
-- **Complex.ts**: "Complex Back Propagation" → describes multi-hidden-layer output preservation
-- **Constants.ts**: All 4 tests renamed to describe specific convergence scenarios
+
+- **AccumulateBias.ts**: "AccumulateBias-average" → describes convergence across
+  diverse biases
+- **Complex.ts**: "Complex Back Propagation" → describes multi-hidden-layer
+  output preservation
+- **Constants.ts**: All 4 tests renamed to describe specific convergence
+  scenarios
 - **Generation.ts**: Renamed + added explicit dampening comparison assertions
 - **IF.ts**: Both tests renamed to describe IF activation error reduction
 - **Identity.ts**: Both tests renamed to describe bias perturbation recovery
@@ -23,27 +28,37 @@ This is the third PR in the audit series:
 - **Maximum.ts**: Renamed to describe MAXIMUM activation error reduction
 - **MaximumSimple.ts**: Renamed to describe single-cycle error reduction
 - **Minimum.ts**: Renamed to describe MINIMUM activation error reduction
-- **MultiLevel.ts**: All 3 tests renamed to describe multi-layer training behaviour
+- **MultiLevel.ts**: All 3 tests renamed to describe multi-layer training
+  behaviour
 - **PI.ts**: All 3 tests renamed with "PI:" prefix and clear descriptions
 - **STEP.ts**: Renamed to describe STEP/TANH neuron interaction
-- **SingleNeuron.ts**: "OneAndDone"/"TwoSame"/"ManySame" → describe convergence with sample counts
+- **SingleNeuron.ts**: "OneAndDone"/"TwoSame"/"ManySame" → describe convergence
+  with sample counts
 - **SkipCount.ts**: Renamed to describe synapse skip behaviour
-- **bias/Simple.ts**: Renamed to describe bias-only backprop error non-regression
+- **bias/Simple.ts**: Renamed to describe bias-only backprop error
+  non-regression
 - **large/Train.ts**: "large" → describes error non-regression on large network
-- **minimum/Minimum.ts**: "propagate/minimum" → describes MINIMUM activation training
-- **sparse/CalculatePathsToOutput.ts**: Renamed to describe downstream path calculation
-- **sparse/ChooseNeurons.ts**: Renamed to describe sparseRatio selection behaviour
+- **minimum/Minimum.ts**: "propagate/minimum" → describes MINIMUM activation
+  training
+- **sparse/CalculatePathsToOutput.ts**: Renamed to describe downstream path
+  calculation
+- **sparse/ChooseNeurons.ts**: Renamed to describe sparseRatio selection
+  behaviour
 - **sparse/Trace.ts**: Renamed to describe sparse tracing subset behaviour
 
 ### Missing assertions added:
+
 - **Generation.ts**: Added explicit assertions verifying that higher generations
-  produce adjustments closer to original values than generation 0 (dampening effect)
+  produce adjustments closer to original values than generation 0 (dampening
+  effect)
 
 ## Evidence
+
 - All 4824 tests pass
 - `./quality.sh` passes cleanly
 
 ## Test Plan
+
 - No new test files added; existing tests renamed for clarity
 - Generation.ts: 2 new assertions verify dampening comparison behaviour
 - All existing test logic preserved unchanged

--- a/docs/pr-summary-1766.md
+++ b/docs/pr-summary-1766.md
@@ -1,50 +1,49 @@
 ## Summary
 
-Second pass audit of all 83 remaining test files in `test/propagate/` to ensure
-they meet quality standards. Addresses #1766.
+Complete audit of all ~86 test files (~500+ test cases) in the propagation module
+(`test/propagate/`). Improved vague test names across 21 files to clearly describe
+the behaviour being verified, and added missing dampening comparison assertions to
+the Generation.ts tests. Addresses #1766.
 
-### Changes
+This is the third PR in the audit series:
+- PR #1787: Consolidated and improved propagation module tests
+- PR #1788: Fixed vague test names, trivial tests, and missing assertions
+- This PR: Final pass - remaining vague test names and missing assertions
 
-1. **SynapseState.ts**: Removed 2 trivial tests that only verified JavaScript
-   object mutability and instance independence (language features, not real
-   behaviour). Kept and improved the name of the constructor defaults test.
+## Changes
 
-2. **Trace.ts**: Renamed 4 vague hyphenated test names to descriptive
-   behavioural names (e.g. "Trace-load-memetic" → "Trace - loads creature with
-   memetic data from JSON").
+### Vague test names replaced with descriptive behaviour descriptions (21 files):
+- **AccumulateBias.ts**: "AccumulateBias-average" → describes convergence across diverse biases
+- **Complex.ts**: "Complex Back Propagation" → describes multi-hidden-layer output preservation
+- **Constants.ts**: All 4 tests renamed to describe specific convergence scenarios
+- **Generation.ts**: Renamed + added explicit dampening comparison assertions
+- **IF.ts**: Both tests renamed to describe IF activation error reduction
+- **Identity.ts**: Both tests renamed to describe bias perturbation recovery
+- **Inverse.ts**: Renamed to describe INVERSE activation convergence
+- **Maximum.ts**: Renamed to describe MAXIMUM activation error reduction
+- **MaximumSimple.ts**: Renamed to describe single-cycle error reduction
+- **Minimum.ts**: Renamed to describe MINIMUM activation error reduction
+- **MultiLevel.ts**: All 3 tests renamed to describe multi-layer training behaviour
+- **PI.ts**: All 3 tests renamed with "PI:" prefix and clear descriptions
+- **STEP.ts**: Renamed to describe STEP/TANH neuron interaction
+- **SingleNeuron.ts**: "OneAndDone"/"TwoSame"/"ManySame" → describe convergence with sample counts
+- **SkipCount.ts**: Renamed to describe synapse skip behaviour
+- **bias/Simple.ts**: Renamed to describe bias-only backprop error non-regression
+- **large/Train.ts**: "large" → describes error non-regression on large network
+- **minimum/Minimum.ts**: "propagate/minimum" → describes MINIMUM activation training
+- **sparse/CalculatePathsToOutput.ts**: Renamed to describe downstream path calculation
+- **sparse/ChooseNeurons.ts**: Renamed to describe sparseRatio selection behaviour
+- **sparse/Trace.ts**: Renamed to describe sparse tracing subset behaviour
 
-3. **simple/Simple.ts**: Renamed "Simple" to "simple backpropagation converges
-   after bias and weight perturbation".
+### Missing assertions added:
+- **Generation.ts**: Added explicit assertions verifying that higher generations
+  produce adjustments closer to original values than generation 0 (dampening effect)
 
-4. **biasIdentity/Simple.ts**: Renamed "Simple" to "bias-only backpropagation
-   converges with all-IDENTITY squash functions".
-
-5. **PI.ts**: Renamed "PI Multiple" to "PI - converges toward PI*input after
-   1000 random training samples".
-
-6. **Recorder/TestRecord.ts**: Renamed "record" to "record - playback error
-   remains consistent after recording and replay". Replaced commented-out
-   assertion with real assertions verifying playback error is finite and
-   consistent with recording error.
-
-### Audit Summary
-
-All 83 test files in `test/propagate/` (including subdirectories `record/`,
-`sparse/`, `bias/`, `biasIdentity/`, `calculateError/`, `large/`, `minimum/`,
-`simple/`, `Recorder/`) were reviewed against the audit criteria:
-
-- **No duplicates remain**: `biasIdentity/Simple.ts` and `bias/Simple.ts` are
-  distinct tests (all-IDENTITY vs mixed squash functions with different topology
-  configurations).
-- **All tests verify behaviour**: No source-grepping or implementation-detail
-  tests found.
-- **All tests have real assertions**: Fixed the one test (TestRecord.ts) that
-  had commented-out assertions.
-- **Test names clearly describe behaviour**: Fixed 7 vague test names across 6
-  files.
-
-## Test Plan
-
+## Evidence
 - All 4824 tests pass
 - `./quality.sh` passes cleanly
-- No production code changes — test-only audit
+
+## Test Plan
+- No new test files added; existing tests renamed for clarity
+- Generation.ts: 2 new assertions verify dampening comparison behaviour
+- All existing test logic preserved unchanged

--- a/test/propagate/AccumulateBias.ts
+++ b/test/propagate/AccumulateBias.ts
@@ -79,7 +79,7 @@ function makeCreature() {
   return creature;
 }
 
-Deno.test("AccumulateBias-average", () => {
+Deno.test("AccumulateBias-convergence: adjustedBias converges to target across diverse bias values", () => {
   let config = createBackPropagationConfig({
     generations: 0,
     learningRate: 1,

--- a/test/propagate/Complex.ts
+++ b/test/propagate/Complex.ts
@@ -21,7 +21,7 @@ function makeCreature() {
   return creature;
 }
 
-Deno.test("Complex Back Propagation", () => {
+Deno.test("backprop preserves outputs within tolerance on complex multi-hidden-layer network", () => {
   const creature = makeCreature();
   creature.clearState();
 

--- a/test/propagate/Constants.ts
+++ b/test/propagate/Constants.ts
@@ -39,7 +39,7 @@ function makeOutput(input: number[]) {
   return [sum];
 }
 
-Deno.test("Constants", () => {
+Deno.test("backprop converges single sample to constant-weighted target", () => {
   for (let attempts = 0; true; attempts++) {
     const creature = makeCreature();
     const traceDir = ".trace";
@@ -112,7 +112,7 @@ Deno.test("Constants", () => {
   }
 });
 
-Deno.test("Constants Same", () => {
+Deno.test("backprop converges repeated identical samples to constant target", () => {
   for (let attempts = 0; true; attempts++) {
     const creature = makeCreature();
 
@@ -183,7 +183,7 @@ Deno.test("Constants Same", () => {
   }
 });
 
-Deno.test("Constants Known Few", () => {
+Deno.test("backprop learns constant-weighted mapping from few known samples", () => {
   const creature = makeCreature();
   const traceDir = ".trace";
   ensureDirSync(traceDir);
@@ -245,7 +245,7 @@ Deno.test("Constants Known Few", () => {
   );
 });
 
-Deno.test("ConstantsMany", async () => {
+Deno.test("backprop converges over many generations with random training samples", async () => {
   await initWasmForTests();
   const traceDir = ".trace/ConstantsMany";
   ensureDirSync(traceDir);

--- a/test/propagate/Generation.ts
+++ b/test/propagate/Generation.ts
@@ -1,4 +1,4 @@
-import { assertAlmostEquals } from "@std/assert";
+import { assert, assertAlmostEquals } from "@std/assert";
 import type { CreatureTrace } from "../../src/architecture/CreatureInterfaces.ts";
 import { Creature } from "../../src/Creature.ts";
 import {
@@ -53,7 +53,7 @@ function makeCreature() {
   return creature;
 }
 
-Deno.test("calculateBias - generational dampening reduces bias adjustment", () => {
+Deno.test("calculateBias - generation 0 produces full adjustment, generation 1 produces dampened adjustment", () => {
   const creature = makeCreature();
 
   const outputNode = creature.neurons.find((node) => node.type === "output");
@@ -86,9 +86,17 @@ Deno.test("calculateBias - generational dampening reduces bias adjustment", () =
   );
 
   assertAlmostEquals(bias2, -0.77, 0.0001, `bias2: ${bias2.toFixed(3)}`);
+
+  // Dampening assertion: generation 1 moves bias less from original (1.0)
+  // than generation 0 does.
+  const originalBias = 1;
+  assert(
+    Math.abs(bias2 - originalBias) < Math.abs(bias - originalBias),
+    `generation 1 adjustment (${bias2}) should be closer to original bias (${originalBias}) than generation 0 (${bias})`,
+  );
 });
 
-Deno.test("calculateWeight - generational dampening reduces weight adjustment", () => {
+Deno.test("calculateWeight - generation 0 produces full adjustment, generation 10 produces dampened adjustment", () => {
   const creature = makeCreature();
 
   const connection = creature.getSynapse(1, 3);
@@ -131,4 +139,12 @@ Deno.test("calculateWeight - generational dampening reduces weight adjustment", 
   // min(10, 1*2) = 2, so the weight moves further from the original (1.0)
   // toward the gradient target (~0.1). averageWeight = (0.1+2.0)/3 = 0.7
   assertAlmostEquals(w2, 0.7, 0.1, `Weight: ${w2.toFixed(3)}`);
+
+  // Dampening assertion: generation 10 keeps weight closer to original (1.0)
+  // than generation 0 does.
+  const originalWeight = 1;
+  assert(
+    Math.abs(w2 - originalWeight) < Math.abs(w1 - originalWeight),
+    `generation 10 adjustment (${w2}) should be closer to original weight (${originalWeight}) than generation 0 (${w1})`,
+  );
 });

--- a/test/propagate/IF.ts
+++ b/test/propagate/IF.ts
@@ -9,7 +9,7 @@ import { initWasmForTests } from "../_initWasm.ts";
 
 ((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
 
-Deno.test("PropagateWeightsIF", async () => {
+Deno.test("IF activation: training reduces error after weight perturbation", async () => {
   await initWasmForTests();
   const creatureA = makeCreature();
   for (let attempts = 0; true; attempts++) {
@@ -109,7 +109,7 @@ Deno.test("PropagateWeightsIF", async () => {
   }
 });
 
-Deno.test("PropagateBiasIF", async () => {
+Deno.test("IF activation: training reduces error and recovers bias after perturbation", async () => {
   await initWasmForTests();
   const creatureA = makeCreature();
   for (let attempts = 0; true; attempts++) {

--- a/test/propagate/Identity.ts
+++ b/test/propagate/Identity.ts
@@ -78,7 +78,7 @@ function makeData() {
   return inputs;
 }
 
-Deno.test("PropagateIdentity", () => {
+Deno.test("backprop reduces error after bias perturbation on IDENTITY network", () => {
   const creature = makeCreature();
   const traceDir = ".test/propagateIdentity";
 
@@ -147,7 +147,7 @@ Deno.test("PropagateIdentity", () => {
   }
 });
 
-Deno.test("PropagateIdentityNoRealChange", () => {
+Deno.test("backprop produces minimal change when network nearly matches targets", () => {
   const creature = makeCreature();
   const traceDir = ".test/propagateIdentityNoRealChange";
 

--- a/test/propagate/Inverse.ts
+++ b/test/propagate/Inverse.ts
@@ -73,7 +73,7 @@ function makeCreature() {
   return creatureA;
 }
 
-Deno.test("propagateInverseRandom", () => {
+Deno.test("INVERSE activation: backprop converges towards original weights and biases after perturbation", () => {
   const creatureA = makeCreature();
   const squash = new COMPLEMENT();
   const ts = [];

--- a/test/propagate/Maximum.ts
+++ b/test/propagate/Maximum.ts
@@ -10,7 +10,7 @@ import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
 
 ((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
 
-Deno.test("PropagateMaximum", () => {
+Deno.test("MAXIMUM activation: training reduces error after bias and weight perturbation", () => {
   const creatureA = makeCreature();
   for (let attempts = 0; true; attempts++) {
     const ts: DataRecordInterface[] = [];

--- a/test/propagate/MaximumSimple.ts
+++ b/test/propagate/MaximumSimple.ts
@@ -9,7 +9,7 @@ import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
 
 ((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
 
-Deno.test("PropagateMaximumSimple", () => {
+Deno.test("MAXIMUM activation: single propagate-update cycle reduces error on simple network", () => {
   const creatureA = makeCreature();
 
   const ts: DataRecordInterface[] = [];

--- a/test/propagate/Minimum.ts
+++ b/test/propagate/Minimum.ts
@@ -12,7 +12,7 @@ import { initWasmForTests } from "../_initWasm.ts";
 
 ((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
 
-Deno.test("PropagateMinimum", async () => {
+Deno.test("MINIMUM activation: training reduces error after bias and weight perturbation", async () => {
   await initWasmForTests();
   for (let attempts = 0; true; attempts++) {
     const creature = makeCreature();

--- a/test/propagate/MultiLevel.ts
+++ b/test/propagate/MultiLevel.ts
@@ -74,7 +74,7 @@ function makeCreature() {
   return creatureA;
 }
 
-Deno.test("propagateMultiLevelRandom", () => {
+Deno.test("multi-hidden-layer IDENTITY network: training improves error with random data", () => {
   const creatureA = makeCreature();
 
   const ts = [];
@@ -193,7 +193,7 @@ Deno.test("propagateMultiLevelRandom", () => {
   }
 });
 
-Deno.test("propagateMultiLevelKnownA", async () => {
+Deno.test("multi-hidden-layer IDENTITY network: training improves error with known dataset A", async () => {
   await initWasmForTests();
   const creatureA = makeCreature();
 
@@ -412,7 +412,7 @@ Deno.test("propagateMultiLevelKnownA", async () => {
   }
 });
 
-Deno.test("propagateMultiLevelKnownB", async () => {
+Deno.test("multi-hidden-layer IDENTITY network: training improves error with known dataset B", async () => {
   await initWasmForTests();
   const creatureA = makeCreature();
 

--- a/test/propagate/PI.ts
+++ b/test/propagate/PI.ts
@@ -33,7 +33,7 @@ function makeOutput(input: number[]) {
   return [Math.PI * input[1]];
 }
 
-Deno.test("PI-repeat", () => {
+Deno.test("PI: repeated propagate-update cycles converge to PI*input target", () => {
   const creature = makeCreature();
   const traceDir = ".test/PI-repeat";
   ensureDirSync(traceDir);
@@ -72,7 +72,7 @@ Deno.test("PI-repeat", () => {
   assertAlmostEquals(Math.PI, outA2[0], 0.05);
 });
 
-Deno.test("PI-single", () => {
+Deno.test("PI: single propagate-update cycle moves output towards PI*input target", () => {
   const creature = makeCreature();
   const traceDir = ".trace";
   ensureDirSync(traceDir);
@@ -132,7 +132,7 @@ Deno.test("PI-single", () => {
   );
 });
 
-Deno.test("PI - converges toward PI*input after 1000 random training samples", () => {
+Deno.test("PI: converges toward PI*input after 1000 random training samples", () => {
   const creature = makeCreature();
   const traceDir = ".trace";
   ensureDirSync(traceDir);

--- a/test/propagate/STEP.ts
+++ b/test/propagate/STEP.ts
@@ -45,7 +45,7 @@ function makeInputs() {
   return inputs;
 }
 
-Deno.test("PropagateSTEP", async () => {
+Deno.test("STEP activation: backprop adjusts TANH neuron bias while STEP neuron remains stable", async () => {
   await initWasmForTests();
   const creature = makeCreature();
   const testDir = ".test/propagateSTEP";

--- a/test/propagate/SingleNeuron.ts
+++ b/test/propagate/SingleNeuron.ts
@@ -66,7 +66,7 @@ function makeOutput(input: number[]) {
   return output;
 }
 
-Deno.test("OneAndDone", () => {
+Deno.test("single hidden neuron: converges toward target with 100 repeated samples", () => {
   const creature = makeCreature();
   const traceDir = ".trace/OneAndDone";
   ensureDirSync(traceDir);
@@ -125,7 +125,7 @@ Deno.test("OneAndDone", () => {
   );
 });
 
-Deno.test("TwoSame", () => {
+Deno.test("single hidden neuron: converges within tolerance after 2 training samples", () => {
   const traceDir = ".trace/TwoSame";
   ensureDirSync(traceDir);
 
@@ -199,7 +199,7 @@ Deno.test("TwoSame", () => {
   }
 });
 
-Deno.test("ManySame", () => {
+Deno.test("single hidden neuron: converges tightly after 1000 repeated samples", () => {
   const creature = makeCreature();
   const traceDir = ".trace";
   ensureDirSync(traceDir);
@@ -268,7 +268,7 @@ Deno.test("ManySame", () => {
   }
 });
 
-Deno.test("propagateSingleNeuronRandom", () => {
+Deno.test("single hidden neuron: learns mapping from 1000 random training samples", () => {
   const creature = makeCreature();
   Deno.writeTextFileSync(
     ".trace/0-start.json",

--- a/test/propagate/SkipCount.ts
+++ b/test/propagate/SkipCount.ts
@@ -3,7 +3,7 @@ import { Creature, type CreatureExport } from "../../mod.ts";
 import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
 import { SparseConfig } from "../../src/propagate/sparse/SparseConfig.ts";
 
-Deno.test("SkipCount", () => {
+Deno.test("propagate skips synapse accumulation when output already matches target", () => {
   const config = createBackPropagationConfig({
     generations: 0,
     learningRate: 1,

--- a/test/propagate/bias/Simple.ts
+++ b/test/propagate/bias/Simple.ts
@@ -9,7 +9,7 @@ import { train } from "../../TrainTestOnlyUtil.ts";
 
 const directory = ".test/propagate/bias";
 
-Deno.test("Bias-Simple", () => {
+Deno.test("bias-only backprop: error does not regress across training iterations on multi-squash network", () => {
   setup();
   const cleanCreature = makeCreature();
 

--- a/test/propagate/large/Train.ts
+++ b/test/propagate/large/Train.ts
@@ -8,7 +8,7 @@ import { initWasmForTests } from "../../_initWasm.ts";
 
 ((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
 
-Deno.test("large", async () => {
+Deno.test("large network: training error does not regress significantly across iterations", async () => {
   await initWasmForTests();
   const directory = ".test/propagate/large";
   const trainingSet = JSON.parse(

--- a/test/propagate/minimum/Minimum.ts
+++ b/test/propagate/minimum/Minimum.ts
@@ -22,7 +22,7 @@ function setup() {
   Deno.mkdirSync(directory, { recursive: true });
 }
 
-Deno.test("propagate/minimum", () => {
+Deno.test("MINIMUM activation: error does not regress across training iterations on mixed-squash network", () => {
   check();
 });
 

--- a/test/propagate/sparse/CalculatePathsToOutput.ts
+++ b/test/propagate/sparse/CalculatePathsToOutput.ts
@@ -3,7 +3,7 @@ import type { CreatureExport } from "../../../src/architecture/CreatureInterface
 import { Creature } from "../../../src/Creature.ts";
 import { calculatePathsToOutput } from "../../../src/propagate/sparse/CalculatePathsToOutput.ts";
 
-Deno.test("calculatePathsToOutput", () => {
+Deno.test("calculatePathsToOutput returns all downstream neurons from chosen set to outputs", () => {
   const creature = makeCreature();
 
   const chosenSet = new Set<string>();

--- a/test/propagate/sparse/ChooseNeurons.ts
+++ b/test/propagate/sparse/ChooseNeurons.ts
@@ -3,7 +3,7 @@ import { Creature } from "../../../src/Creature.ts";
 import { createBackPropagationConfig } from "../../../src/propagate/BackPropagation.ts";
 import { chooseNeurons } from "../../../src/propagate/sparse/ChooseNeurons.ts";
 
-Deno.test("chooseNeurons", () => {
+Deno.test("chooseNeurons selects approximately sparseRatio fraction of eligible neurons", () => {
   const creature = Creature.fromJSON(
     JSON.parse(
       Deno.readTextFileSync("test/propagate/large/creature.json"),

--- a/test/propagate/sparse/Trace.ts
+++ b/test/propagate/sparse/Trace.ts
@@ -8,7 +8,7 @@ import { train } from "../../TrainTestOnlyUtil.ts";
 
 const directory = ".test/propagate/sparse";
 
-Deno.test("propagate-trace", () => {
+Deno.test("sparse training with low sparseRatio traces only a subset of neurons and synapses", () => {
   setup();
   const creature = makeCreature();
 


### PR DESCRIPTION
## Summary

Complete audit of all ~86 test files (~500+ test cases) in the propagation
module (`test/propagate/`). Improved vague test names across 21 files to clearly
describe the behaviour being verified, and added missing dampening comparison
assertions to the Generation.ts tests. Addresses #1766.

This is the third PR in the audit series:

- PR #1787: Consolidated and improved propagation module tests
- PR #1788: Fixed vague test names, trivial tests, and missing assertions
- This PR: Final pass - remaining vague test names and missing assertions

## Changes

### Vague test names replaced with descriptive behaviour descriptions (21 files):

- **AccumulateBias.ts**: "AccumulateBias-average" → describes convergence across
  diverse biases
- **Complex.ts**: "Complex Back Propagation" → describes multi-hidden-layer
  output preservation
- **Constants.ts**: All 4 tests renamed to describe specific convergence
  scenarios
- **Generation.ts**: Renamed + added explicit dampening comparison assertions
- **IF.ts**: Both tests renamed to describe IF activation error reduction
- **Identity.ts**: Both tests renamed to describe bias perturbation recovery
- **Inverse.ts**: Renamed to describe INVERSE activation convergence
- **Maximum.ts**: Renamed to describe MAXIMUM activation error reduction
- **MaximumSimple.ts**: Renamed to describe single-cycle error reduction
- **Minimum.ts**: Renamed to describe MINIMUM activation error reduction
- **MultiLevel.ts**: All 3 tests renamed to describe multi-layer training
  behaviour
- **PI.ts**: All 3 tests renamed with "PI:" prefix and clear descriptions
- **STEP.ts**: Renamed to describe STEP/TANH neuron interaction
- **SingleNeuron.ts**: "OneAndDone"/"TwoSame"/"ManySame" → describe convergence
  with sample counts
- **SkipCount.ts**: Renamed to describe synapse skip behaviour
- **bias/Simple.ts**: Renamed to describe bias-only backprop error
  non-regression
- **large/Train.ts**: "large" → describes error non-regression on large network
- **minimum/Minimum.ts**: "propagate/minimum" → describes MINIMUM activation
  training
- **sparse/CalculatePathsToOutput.ts**: Renamed to describe downstream path
  calculation
- **sparse/ChooseNeurons.ts**: Renamed to describe sparseRatio selection
  behaviour
- **sparse/Trace.ts**: Renamed to describe sparse tracing subset behaviour

### Missing assertions added:

- **Generation.ts**: Added explicit assertions verifying that higher generations
  produce adjustments closer to original values than generation 0 (dampening
  effect)

## Evidence

- All 4824 tests pass
- `./quality.sh` passes cleanly

## Test Plan

- No new test files added; existing tests renamed for clarity
- Generation.ts: 2 new assertions verify dampening comparison behaviour
- All existing test logic preserved unchanged

---

## Automated Fix Details
This PR addresses issue #1766: **Audit: Propagation module tests**

## Milestone
This PR is part of the **test-clean-up** milestone and targets the `milestone/test-clean-up` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Addresses #1766
---

🤖 Processed by: stservice