### PR TITLE
Audit: Fix assertion quality issues in propagation module tests (#1766)

### DIFF
--- a/docs/pr-summary-1766.md
+++ b/docs/pr-summary-1766.md
@@ -6,10 +6,16 @@ test files (~455 test cases). Addresses #1766.
 
 ## Changes
 
-- **ActivationRangeTypedErrors.ts**: Replaced manual `if (ae.reason !== ...) throw new Error(...)` patterns with `assertEquals()` across all 4 tests for consistent, idiomatic assertions
-- **LimitBias.ts**: Fixed assertion message referencing wrong variable (`bias` instead of `bias2`)
+- **ActivationRangeTypedErrors.ts**: Replaced manual
+  `if (ae.reason !== ...) throw new Error(...)` patterns with `assertEquals()`
+  across all 4 tests for consistent, idiomatic assertions
+- **LimitBias.ts**: Fixed assertion message referencing wrong variable (`bias`
+  instead of `bias2`)
 - **Trace.ts**: Removed leftover `console.info(nodeState)` debug output
-- **SingleNeuron.ts**: Fixed test with impossible fail condition (`loop > 12` in a loop running 0–4, making the test a permanent no-op). Replaced with meaningful before/after error comparison verifying that training reduces prediction error
+- **SingleNeuron.ts**: Fixed test with impossible fail condition (`loop > 12` in
+  a loop running 0–4, making the test a permanent no-op). Replaced with
+  meaningful before/after error comparison verifying that training reduces
+  prediction error
 
 ## Audit Summary
 
@@ -30,7 +36,8 @@ This is the eighth PR in the audit series:
 - PR #1791: Removed duplicate tests and standardised batch test names
 - PR #1792: Removed duplicate WASM batch test files
 - PR #1793: Fixed broken Identity.ts test with missing assertions
-- This PR: Fixed assertion quality issues (manual checks, wrong variables, debug output, no-op test)
+- This PR: Fixed assertion quality issues (manual checks, wrong variables, debug
+  output, no-op test)
 
 ## Evidence
 
@@ -42,8 +49,10 @@ This is the eighth PR in the audit series:
 
 ## Test Plan
 
-- `test/propagate/ActivationRangeTypedErrors.ts` — 4 tests updated to use assertEquals
+- `test/propagate/ActivationRangeTypedErrors.ts` — 4 tests updated to use
+  assertEquals
 - `test/propagate/LimitBias.ts` — assertion message corrected
 - `test/propagate/Trace.ts` — debug output removed
-- `test/propagate/SingleNeuron.ts` — no-op test replaced with meaningful assertion
+- `test/propagate/SingleNeuron.ts` — no-op test replaced with meaningful
+  assertion
 - Full test suite (4788 tests) passes

--- a/docs/pr-summary-1766.md
+++ b/docs/pr-summary-1766.md
@@ -1,24 +1,19 @@
 ## Summary
 
-Final audit pass on propagation module tests: fixed a broken test in
-`Identity.ts` that had no meaningful assertions and was silently passing due to
-a WASM activation issue (in-place neuron bias mutation doesn't propagate to the
-WASM engine). Addresses #1766.
+Final quality pass on propagation module test audit: fixed remaining assertion
+quality issues across 4 test files found during comprehensive review of all 84
+test files (~455 test cases). Addresses #1766.
 
 ## Changes
 
-- **test/propagate/Identity.ts**: Rewrote both tests to use the correct
-  export-modify-recreate pattern (consistent with the rest of the test suite).
-  Test 1 ("backprop reduces error after bias perturbation") previously had NO
-  assertion verifying that error improved — it only printed to console. It also
-  mutated `neuron.bias` in-place, which has no effect on WASM activation. Now it
-  exports JSON, perturbs biases, recreates the creature, trains, and asserts
-  error improvement. Test 2 ("backprop produces minimal change") was similarly
-  cleaned up to use `DataRecordInterface` and clearer variable names.
+- **ActivationRangeTypedErrors.ts**: Replaced manual `if (ae.reason !== ...) throw new Error(...)` patterns with `assertEquals()` across all 4 tests for consistent, idiomatic assertions
+- **LimitBias.ts**: Fixed assertion message referencing wrong variable (`bias` instead of `bias2`)
+- **Trace.ts**: Removed leftover `console.info(nodeState)` debug output
+- **SingleNeuron.ts**: Fixed test with impossible fail condition (`loop > 12` in a loop running 0–4, making the test a permanent no-op). Replaced with meaningful before/after error comparison verifying that training reduces prediction error
 
 ## Audit Summary
 
-All 83 test files across `test/propagate/` (root and subdirectories) were
+All 84 test files across `test/propagate/` (root and subdirectories) were
 reviewed against the audit criteria:
 
 - **Uniqueness**: No duplicate or near-duplicate tests remain
@@ -26,7 +21,7 @@ reviewed against the audit criteria:
 - **Meaningful tests**: All tests have real assertions on real code
 - **Organisation**: Test names clearly describe the behaviour being verified
 
-This is the seventh PR in the audit series:
+This is the eighth PR in the audit series:
 
 - PR #1787: Consolidated and improved propagation module tests
 - PR #1788: Fixed vague test names, trivial tests, and missing assertions
@@ -34,17 +29,21 @@ This is the seventh PR in the audit series:
 - PR #1790: Final pass on test names and misleading filename
 - PR #1791: Removed duplicate tests and standardised batch test names
 - PR #1792: Removed duplicate WASM batch test files
-- This PR: Fixed broken Identity.ts test with missing assertions
+- PR #1793: Fixed broken Identity.ts test with missing assertions
+- This PR: Fixed assertion quality issues (manual checks, wrong variables, debug output, no-op test)
 
 ## Evidence
 
 - `deno fmt`, `deno lint`, `deno check` all pass
-- All propagation tests pass (26 backprop-related tests confirmed)
-- Identity.ts tests pass with meaningful assertions
+- Full test suite passes (4788 tests, 0 failures)
+- The SingleNeuron.ts fix is the most significant: the original test could never
+  fail because the condition `if (loop > 12)` was unreachable inside a loop
+  bounded to 0–4
 
 ## Test Plan
 
-- Verified both Identity.ts tests pass with
-  `deno test --allow-all test/propagate/Identity.ts`
-- Ran `./quality.sh --lint-only` and `./quality.sh --check-only` — both pass
-- Ran broader `--filter "backprop"` test suite — all 26 tests pass
+- `test/propagate/ActivationRangeTypedErrors.ts` — 4 tests updated to use assertEquals
+- `test/propagate/LimitBias.ts` — assertion message corrected
+- `test/propagate/Trace.ts` — debug output removed
+- `test/propagate/SingleNeuron.ts` — no-op test replaced with meaningful assertion
+- Full test suite (4788 tests) passes

--- a/test/propagate/ActivationRangeTypedErrors.ts
+++ b/test/propagate/ActivationRangeTypedErrors.ts
@@ -4,7 +4,7 @@
  *
  * Issue #1694
  */
-import { assertIsError, assertThrows } from "@std/assert";
+import { assertEquals, assertIsError, assertThrows } from "@std/assert";
 import { ActivationRange } from "../../src/propagate/ActivationRange.ts";
 import { ActivationError } from "../../src/errors/ActivationError.ts";
 
@@ -13,9 +13,11 @@ Deno.test("ActivationRange validate - throws ActivationError for out-of-range va
   const err = assertThrows(() => range.validate(2.0));
   assertIsError(err, ActivationError);
   const ae = err as ActivationError;
-  if (ae.reason !== "NON_FINITE_RESULT") {
-    throw new Error(`Expected reason NON_FINITE_RESULT, got ${ae.reason}`);
-  }
+  assertEquals(
+    ae.reason,
+    "NON_FINITE_RESULT",
+    "Expected NON_FINITE_RESULT reason",
+  );
 });
 
 Deno.test("ActivationRange validate - throws ActivationError for NaN", () => {
@@ -23,9 +25,11 @@ Deno.test("ActivationRange validate - throws ActivationError for NaN", () => {
   const err = assertThrows(() => range.validate(NaN));
   assertIsError(err, ActivationError);
   const ae = err as ActivationError;
-  if (ae.reason !== "NON_FINITE_RESULT") {
-    throw new Error(`Expected reason NON_FINITE_RESULT, got ${ae.reason}`);
-  }
+  assertEquals(
+    ae.reason,
+    "NON_FINITE_RESULT",
+    "Expected NON_FINITE_RESULT reason",
+  );
 });
 
 Deno.test("ActivationRange limit - throws ActivationError for NaN", () => {
@@ -33,9 +37,11 @@ Deno.test("ActivationRange limit - throws ActivationError for NaN", () => {
   const err = assertThrows(() => range.limit(NaN));
   assertIsError(err, ActivationError);
   const ae = err as ActivationError;
-  if (ae.reason !== "NON_FINITE_RESULT") {
-    throw new Error(`Expected reason NON_FINITE_RESULT, got ${ae.reason}`);
-  }
+  assertEquals(
+    ae.reason,
+    "NON_FINITE_RESULT",
+    "Expected NON_FINITE_RESULT reason",
+  );
 });
 
 Deno.test("ActivationRange limit - throws ActivationError for NaN with rawInput", () => {
@@ -43,7 +49,5 @@ Deno.test("ActivationRange limit - throws ActivationError for NaN with rawInput"
   const err = assertThrows(() => range.limit(NaN, 42));
   assertIsError(err, ActivationError);
   const ae = err as ActivationError;
-  if (ae.activation !== "ReLU") {
-    throw new Error(`Expected activation 'ReLU', got '${ae.activation}'`);
-  }
+  assertEquals(ae.activation, "ReLU", "Expected ReLU activation");
 });

--- a/test/propagate/LimitBias.ts
+++ b/test/propagate/LimitBias.ts
@@ -13,7 +13,7 @@ Deno.test("limitBias - clamps adjustment to maximumBiasAdjustmentScale", () => {
   assertAlmostEquals(0.7, bias, 0.001, `Bias: ${bias.toFixed(3)}`);
   const bias2 = limitBias(10, -0.5, config);
 
-  assertAlmostEquals(-0.3, bias2, 0.001, `Bias: ${bias.toFixed(3)}`);
+  assertAlmostEquals(-0.3, bias2, 0.001, `Bias: ${bias2.toFixed(3)}`);
 });
 
 Deno.test("limitBias - clamps large target to adjustment scale with learning rate", () => {

--- a/test/propagate/SingleNeuron.ts
+++ b/test/propagate/SingleNeuron.ts
@@ -1,4 +1,4 @@
-import { assert, assertAlmostEquals, fail } from "@std/assert";
+import { assert, assertAlmostEquals } from "@std/assert";
 import { ensureDirSync } from "@std/fs";
 import type { CreatureExport } from "../../mod.ts";
 import { Creature } from "../../src/Creature.ts";
@@ -270,14 +270,33 @@ Deno.test("single hidden neuron: converges tightly after 1000 repeated samples",
 
 Deno.test("single hidden neuron: learns mapping from 1000 random training samples", () => {
   const creature = makeCreature();
-  Deno.writeTextFileSync(
-    ".trace/0-start.json",
-    JSON.stringify(creature.traceJSON(), null, 1),
-  );
-  const config = createBackPropagationConfig({});
-
   const traceDir = ".trace";
   ensureDirSync(traceDir);
+  Deno.writeTextFileSync(
+    `${traceDir}/0-start.json`,
+    JSON.stringify(creature.traceJSON(), null, 1),
+  );
+
+  // Measure error before training
+  const testInputs = Array.from({ length: 5 }, () => [
+    Math.random() * 2 - 1,
+    Math.random() * 2 - 1,
+    Math.random() * 2 - 1,
+  ]);
+
+  let errorBefore = 0;
+  for (const inD of testInputs) {
+    const expected = makeOutput(inD);
+    const actual = creature.activate(new Float32Array(inD));
+    errorBefore += Math.abs(expected[0] - actual[0]);
+    errorBefore += Math.abs(expected[1] - actual[1]);
+  }
+
+  // Train with 1000 random samples
+  const config = createBackPropagationConfig({
+    learningRate: 0.1,
+    generations: 0,
+  });
   const sparseConfig = new SparseConfig(creature.exportJSON(), config);
   for (let i = 0; i < 1_000; i++) {
     const inC = [
@@ -292,24 +311,23 @@ Deno.test("single hidden neuron: learns mapping from 1000 random training sample
   creature.propagateUpdate(config, sparseConfig);
 
   Deno.writeTextFileSync(
-    ".trace/4-done.json",
+    `${traceDir}/4-done.json`,
     JSON.stringify(creature.exportJSON(), null, 1),
   );
 
-  for (let loop = 0; loop < 5; loop++) {
-    const inD = [
-      Math.random() * 2 - 1,
-      Math.random() * 2 - 1,
-      Math.random() * 2 - 1,
-    ];
-    const expectedOutput = makeOutput(inD);
-    const actualOutput = creature.activate(new Float32Array(inD));
-
-    if (
-      Math.abs(expectedOutput[0] - actualOutput[0]) > 0.7 ||
-      Math.abs(expectedOutput[1] - actualOutput[1]) > 0.7
-    ) {
-      if (loop > 12) fail("too many failures");
-    }
+  // Measure error after training - it should have improved
+  let errorAfter = 0;
+  for (const inD of testInputs) {
+    const expected = makeOutput(inD);
+    const actual = creature.activate(new Float32Array(inD));
+    errorAfter += Math.abs(expected[0] - actual[0]);
+    errorAfter += Math.abs(expected[1] - actual[1]);
   }
+
+  assert(
+    errorAfter < errorBefore,
+    `Training should reduce error: before=${errorBefore.toFixed(4)}, after=${
+      errorAfter.toFixed(4)
+    }`,
+  );
 });

--- a/test/propagate/Trace.ts
+++ b/test/propagate/Trace.ts
@@ -38,7 +38,6 @@ Deno.test("Trace - loads creature trace state with correct node count", () => {
     JSON.parse(Deno.readTextFileSync("test/data/traced.json")),
   );
   const nodeState = creature.state.node(999);
-  console.info(nodeState);
   assertEquals(nodeState.count, 1386);
 });
 


### PR DESCRIPTION
## Summary

Final quality pass on propagation module test audit: fixed remaining assertion
quality issues across 4 test files found during comprehensive review of all 84
test files (~455 test cases). Addresses #1766.

## Changes

- **ActivationRangeTypedErrors.ts**: Replaced manual
  `if (ae.reason !== ...) throw new Error(...)` patterns with `assertEquals()`
  across all 4 tests for consistent, idiomatic assertions
- **LimitBias.ts**: Fixed assertion message referencing wrong variable (`bias`
  instead of `bias2`)
- **Trace.ts**: Removed leftover `console.info(nodeState)` debug output
- **SingleNeuron.ts**: Fixed test with impossible fail condition (`loop > 12` in
  a loop running 0–4, making the test a permanent no-op). Replaced with
  meaningful before/after error comparison verifying that training reduces
  prediction error

## Audit Summary

All 84 test files across `test/propagate/` (root and subdirectories) were
reviewed against the audit criteria:

- **Uniqueness**: No duplicate or near-duplicate tests remain
- **Behavioural testing**: All tests verify outcomes, not implementation details
- **Meaningful tests**: All tests have real assertions on real code
- **Organisation**: Test names clearly describe the behaviour being verified

This is the eighth PR in the audit series:

- PR #1787: Consolidated and improved propagation module tests
- PR #1788: Fixed vague test names, trivial tests, and missing assertions
- PR #1789: Remaining vague test names and missing assertions
- PR #1790: Final pass on test names and misleading filename
- PR #1791: Removed duplicate tests and standardised batch test names
- PR #1792: Removed duplicate WASM batch test files
- PR #1793: Fixed broken Identity.ts test with missing assertions
- This PR: Fixed assertion quality issues (manual checks, wrong variables, debug
  output, no-op test)

## Evidence

- `deno fmt`, `deno lint`, `deno check` all pass
- Full test suite passes (4788 tests, 0 failures)
- The SingleNeuron.ts fix is the most significant: the original test could never
  fail because the condition `if (loop > 12)` was unreachable inside a loop
  bounded to 0–4

## Test Plan

- `test/propagate/ActivationRangeTypedErrors.ts` — 4 tests updated to use
  assertEquals
- `test/propagate/LimitBias.ts` — assertion message corrected
- `test/propagate/Trace.ts` — debug output removed
- `test/propagate/SingleNeuron.ts` — no-op test replaced with meaningful
  assertion
- Full test suite (4788 tests) passes

---

## Automated Fix Details
This PR addresses issue #1766: **Audit: Propagation module tests**

## Milestone
This PR is part of the **test-clean-up** milestone and targets the `milestone/test-clean-up` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Addresses #1766
---

🤖 Processed by: stservice