### PR TITLE
Audit: Strengthen weak assertions and fix misleading test names (#1769)

### DIFF
--- a/docs/pr-summary-1769.md
+++ b/docs/pr-summary-1769.md
@@ -15,10 +15,10 @@ in `test/mutate/`. Closes #1769.
    mutation" and added assertion that the hidden neuron count actually decreases
    (previously only checked mutation succeeded).
 
-3. **SubConnection.ts** - Rewrote "focus list limits removable connections"
-   test to properly account for transitive focus behaviour and added a new
-   negative test verifying that focus list returns false when no focused
-   connections are eligible.
+3. **SubConnection.ts** - Rewrote "focus list limits removable connections" test
+   to properly account for transitive focus behaviour and added a new negative
+   test verifying that focus list returns false when no focused connections are
+   eligible.
 
 4. **ConnectSplice.ts** - Renamed "correctly inserts at end of synapses array"
    to "correctly inserts and maintains order with higher from-index" (the
@@ -29,8 +29,8 @@ in `test/mutate/`. Closes #1769.
 
 - `test/NEAT/MutatorMutateCreature.ts` and `test/NEAT/MutatorBehavioural.ts`
   test individual mutation operators at the integration level through the
-  Mutator API. These are NOT duplicates — they test the orchestration layer,
-  not individual operators.
+  Mutator API. These are NOT duplicates — they test the orchestration layer, not
+  individual operators.
 
 ## Evidence
 

--- a/docs/pr-summary-1769.md
+++ b/docs/pr-summary-1769.md
@@ -1,87 +1,46 @@
 ## Summary
 
-Final audit pass on all test files in `test/mutate/` for quality standards:
-uniqueness, behavioural testing, meaningful assertions, and organisation. Closes
-#1769.
+Final audit pass strengthening weak assertions and fixing misleading test names
+in `test/mutate/`. Closes #1769.
 
-### Changes made (this PR)
+### Changes
 
-1. **Removed `test/mutate/AddNeuronSelfLoopFallback.ts`** (1 test):
-   - This was a "how" test that used heavy mocking (`stub(Math, "random")`,
-     disabled `Neuron.prototype.fix`, and overrode `creature.getSynapse`) to
-     force a specific internal code path. Recurrent self-loop behaviour is
-     already covered by `AddNeuronRecurrentAllowed.ts` through the public API.
+1. **SubNeuron.ts** - Strengthened "cascade removal" test to verify that
+   removing one neuron actually triggers cascade cleanup of orphaned neurons
+   (previously only checked validity). Strengthened "focus list" test to verify
+   that the non-focused neuron is preserved after mutation.
 
-2. **Renamed tests that referenced implementation details**:
-   - `AddConnectionOptimisation.ts`: "provides O(1) lookup" → "correctly
-     identifies existing and non-existing connections"; "cache invalidates" →
-     "reflects newly added connections"
-   - `AvailableConnectionsCache.ts`: Removed "cache" from all 6 test names; e.g.
-     "cache invalidates after disconnect" → "available connections update after
-     disconnect"
-   - `ConnectSplice.ts`: "with splice" → "after multiple insertions"
-   - `AddConnectionNoRedundantValidation.ts`: "does not call validate
-     internally" → "adds a connection and creature remains valid"; "without
-     internal validation" → "after successful mutation"
-   - `AddNeuronFocusSelection.ts`: "should use transitive focus checking" →
-     "downstream neurons are transitively in focus"
+2. **SubBackCon.ts** - Renamed "should remove completely disconnected hidden
+   neuron" to "should remove or convert disconnected hidden neuron after
+   mutation" and added assertion that the hidden neuron count actually decreases
+   (previously only checked mutation succeeded).
 
-3. **Fixed misleading file header comments**:
-   - `ConnectSplice.ts`: Changed "Benchmark test" to "Correctness tests"
-   - `AddConnectionOptimisation.ts`: Removed O(n²)/O(1) implementation details
-   - `AvailableConnectionsCache.ts`: Removed caching implementation details
-   - `AddConnectionNoRedundantValidation.ts`: Removed internal validation
-     details
+3. **SubConnection.ts** - Rewrote "focus list limits removable connections"
+   test to properly account for transitive focus behaviour and added a new
+   negative test verifying that focus list returns false when no focused
+   connections are eligible.
 
-4. **Consolidated near-duplicate tests in `AddConnectionOptimisation.ts`**:
-   - Merged "mutation still works correctly with optimisation" (small network)
-     and "mutation works correctly with large creature" (large network) into one
-     "mutation adds connections and maintains validity" test.
-
-5. **Strengthened weak focus-list assertions**:
-   - `AddBackCon.ts`: Focus list test now verifies synapse count increased and
-     new connection involves neurons related to the focus list.
-   - `AddSelfCon.ts`: Focus list test now asserts mutation succeeds and
-     self-connection targets the focused neuron.
-   - `AddSelfCon.ts`: Memetic test now asserts mutation succeeds instead of
-     silently passing on failure.
-   - `SubConnection.ts`: Focus list test now retries and asserts mutation
-     succeeds with synapse count verification.
-
-### Changes made (prior PRs)
-
-1. Removed duplicate `test/mutate/MutationStabilityTracker.ts` (13 tests) —
-   superseded by `test/NEAT/MutationStabilityTrackerBehavioural.ts`.
-2. Consolidated `test/mutate/SwapNodes.ts` into `SwapNeuronsBehavioural.ts`.
-3. Renamed `ConnectSpliceBenchmark.ts` to `ConnectSplice.ts`.
-4. Cleaned up implementation-detail tests in `AvailableConnectionsCache.ts`.
-5. Consolidated `ModActivation.ts` into `ModSquashBehavioural.ts`.
-6. Strengthened conditional assertions in `AddBackCon.ts`, `SubBackCon.ts`,
-   `SubConnection.ts`.
-7. Removed implementation-detail checks in `AddConnectionOptimisation.ts` and
-   `AvailableConnectionsCache.ts`.
+4. **ConnectSplice.ts** - Renamed "correctly inserts at end of synapses array"
+   to "correctly inserts and maintains order with higher from-index" (the
+   previous name was misleading as the test could not exercise the push-to-end
+   case).
 
 ### Cross-area duplicates noted
 
 - `test/NEAT/MutatorMutateCreature.ts` and `test/NEAT/MutatorBehavioural.ts`
-  test individual mutation operators at the integration level. These are NOT
-  duplicates — they test the Mutator orchestration layer, not individual
-  operators.
-- `ModWeightRegularisation.ts` and `ModBiasRegularisation.ts` have similar
-  structure but test different operators (ModWeight vs ModBias) with different
-  config types. Not duplicates.
+  test individual mutation operators at the integration level through the
+  Mutator API. These are NOT duplicates — they test the orchestration layer,
+  not individual operators.
 
 ## Evidence
 
-- All 4729 tests pass (net -2 from removing 1 test file and consolidating 1
-  test)
+- All 4730 tests pass
 - `./quality.sh` passes clean
 
 ## Test Plan
 
-- Verified no test regressions: 4729 passed, 0 failed
-- Removed 1 "how" test file (AddNeuronSelfLoopFallback.ts) that used heavy
-  mocking
-- Consolidated 1 near-duplicate test in AddConnectionOptimisation.ts
-- All remaining tests exercise real mutation code with meaningful assertions
-- All test names describe behaviour, not implementation details
+- Strengthened assertions in SubNeuron.ts (cascade removal, focus list)
+- Strengthened assertion in SubBackCon.ts (disconnected neuron cleanup)
+- Rewrote SubConnection.ts focus list test + added negative focus list test
+- Fixed misleading test name in ConnectSplice.ts
+- All test names now accurately describe the behaviour being verified

--- a/test/mutate/ConnectSplice.ts
+++ b/test/mutate/ConnectSplice.ts
@@ -121,7 +121,7 @@ Deno.test("connect(): correctly inserts at beginning of synapses array", () => {
   creatureValidate(creature);
 });
 
-Deno.test("connect(): correctly inserts at end of synapses array", () => {
+Deno.test("connect(): correctly inserts and maintains order with higher from-index", () => {
   // Creature structure:
   // Neurons: input-0 (0), input-1 (1), input-2 (2), hidden-1 (3), output-0 (4)
   const json = {
@@ -150,20 +150,7 @@ Deno.test("connect(): correctly inserts at end of synapses array", () => {
   const creature = Creature.fromJSON(json, true);
   const initialLength = creature.synapses.length;
 
-  // Add connection from hidden-1 (index 3) that goes to end by sort order
-  // Since 3->4 exists, we need a different connection
-  // input-2 (index 2) to output-0 (index 4) would sort after 0->3 but before 3->4
-  // Let's use input-2 to hidden-1 which sorts between input-0->hidden-1 and hidden-1->output-0
-  // Actually, we want something that sorts AFTER 3->4
-  // There are no valid forward connections after 3->4, so let's test push() case
-  // by using the empty synapses path - but that requires location === -1
-
-  // Let's redesign: to test the push() case (location === -1 || location >= length)
-  // we need a connection that either goes at the very end or the array is empty
-  // Since 3->4 is the last possible forward connection, any new connection
-  // will be inserted before it in sorted order, not after
-
-  // Test the push case with input-2 to output-0
+  // Add a connection with a higher from-index that sorts between existing ones
   creature.connect(2, 4, 0.3); // input-2 to output-0 (sorts after 0->3, before 3->4)
 
   assertEquals(creature.synapses.length, initialLength + 1);

--- a/test/mutate/SubBackCon.ts
+++ b/test/mutate/SubBackCon.ts
@@ -96,8 +96,10 @@ Deno.test("SubBackCon - should remove back connection successfully", () => {
   );
 });
 
-Deno.test("SubBackCon - should remove completely disconnected hidden neuron", () => {
-  // Create a creature where removing the back connection leaves a neuron disconnected
+Deno.test("SubBackCon - should remove or convert disconnected hidden neuron after mutation", () => {
+  // Create a creature where the hidden neuron's only outward connection
+  // is the back connection. Removing it leaves hidden with no outward path,
+  // so fix() should remove or convert the neuron.
   const creature = Creature.fromJSON({
     neurons: [
       {
@@ -114,11 +116,8 @@ Deno.test("SubBackCon - should remove completely disconnected hidden neuron", ()
       },
     ],
     synapses: [
-      // Only connection to hidden is from input
       { from: 0, to: 2, weight: 1.0 },
-      // Hidden to output - if we remove this, hidden has no outward
       { from: 2, to: 3, weight: 0.8 },
-      // Alternative path to output
       { from: 1, to: 3, weight: 0.9 },
     ],
     input: 2,
@@ -127,24 +126,33 @@ Deno.test("SubBackCon - should remove completely disconnected hidden neuron", ()
 
   creatureValidate(creature);
 
-  // Run mutations until we get the scenario we want
-  let attempts = 0;
-  const maxAttempts = 100;
-  let foundScenario = false;
+  let neuronCleanedUp = false;
 
-  while (attempts < maxAttempts && !foundScenario) {
+  for (let attempts = 0; attempts < 100; attempts++) {
     const testCreature = Creature.fromJSON(creature.exportJSON());
+    const hiddenCountBefore = testCreature.neurons.filter((n) =>
+      n.type === "hidden"
+    ).length;
+
     const mutator = new SubBackCon(testCreature);
     const changed = mutator.mutate();
 
+    creatureValidate(testCreature);
+
     if (changed) {
-      creatureValidate(testCreature);
-      foundScenario = true;
+      const hiddenCountAfter =
+        testCreature.neurons.filter((n) => n.type === "hidden").length;
+      if (hiddenCountAfter < hiddenCountBefore) {
+        neuronCleanedUp = true;
+        break;
+      }
     }
-    attempts++;
   }
 
-  assert(foundScenario, "Should be able to mutate within max attempts");
+  assert(
+    neuronCleanedUp,
+    "Disconnected hidden neuron should be removed or converted after back connection removal",
+  );
 });
 
 Deno.test("SubBackCon - mutation always produces valid creature even when neuron loses inward connections", () => {

--- a/test/mutate/SubConnection.ts
+++ b/test/mutate/SubConnection.ts
@@ -1,4 +1,4 @@
-import { assert } from "@std/assert";
+import { assert, assertFalse } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
 import { SubConnection } from "../../src/mutate/SubConnection.ts";
 import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
@@ -145,6 +145,11 @@ Deno.test("SubConnection - stress test produces valid creatures", () => {
 });
 
 Deno.test("SubConnection - focus list limits removable connections", () => {
+  // Focus on neuron 2 — SubConnection should only consider connections where
+  // at least one endpoint is in the transitive focus closure of neuron 2.
+  // With no focus list, the mutation returns false on a minimal creature.
+  // With focus on neuron 2, the mutation should succeed (removing a connection
+  // involving neuron 2 or its downstream output).
   let removedFocusedConnection = false;
 
   for (let attempt = 0; attempt < 50; attempt++) {
@@ -169,14 +174,14 @@ Deno.test("SubConnection - focus list limits removable connections", () => {
     const synapsesBeforeCount = creature.synapses.length;
 
     const mutator = new SubConnection(creature);
-    const changed = mutator.mutate([2]); // Focus on neuron at index 2
+    const changed = mutator.mutate([2]);
 
     creatureValidate(creature);
 
     if (changed) {
       assert(
-        creature.synapses.length <= synapsesBeforeCount,
-        "Should have same or fewer synapses after removal",
+        creature.synapses.length < synapsesBeforeCount,
+        "Should have fewer synapses after focused removal",
       );
       removedFocusedConnection = true;
       break;
@@ -187,4 +192,35 @@ Deno.test("SubConnection - focus list limits removable connections", () => {
     removedFocusedConnection,
     "Should remove a connection related to focused neuron within 50 attempts",
   );
+});
+
+Deno.test("SubConnection - focus list returns false when no focused connections are eligible", () => {
+  // Create a creature where the focused neuron has no removable forward
+  // connections, so the mutation should return false
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 2 },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 1, to: 2, weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+  });
+
+  creatureValidate(creature);
+
+  // Focus on an input neuron (index 0) — its only connections are to the
+  // output which may not be removable in a minimal network
+  const mutator = new SubConnection(creature);
+  // Use an invalid/nonexistent focus index to ensure no eligible connections
+  const changed = mutator.mutate([99]);
+
+  // With a focus index that doesn't match any neuron, nothing should be removed
+  assertFalse(
+    changed,
+    "Should return false when focus list has no matching connections",
+  );
+  creatureValidate(creature);
 });

--- a/test/mutate/SubNeuron.ts
+++ b/test/mutate/SubNeuron.ts
@@ -57,7 +57,8 @@ Deno.test("SubNeuron - should return false when no removable neurons exist", () 
 });
 
 Deno.test("SubNeuron - should handle cascade removal of orphaned neurons", () => {
-  // Create a chain where removing one neuron orphans another
+  // Create a chain: input->hidden1->hidden2->output, plus direct input->output.
+  // Removing hidden1 orphans hidden2 (no inward connections), so both should go.
   const creature = Creature.fromJSON({
     neurons: [
       { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
@@ -76,13 +77,33 @@ Deno.test("SubNeuron - should handle cascade removal of orphaned neurons", () =>
 
   creatureValidate(creature);
 
-  // Run multiple attempts to hit the cascade path
+  let cascadeOccurred = false;
   for (let i = 0; i < 50; i++) {
     const testCreature = Creature.fromJSON(creature.exportJSON());
+    const hiddenCountBefore = testCreature.neurons.filter((n) =>
+      n.type === "hidden"
+    ).length;
+
     const mutator = new SubNeuron(testCreature);
-    mutator.mutate();
+    const changed = mutator.mutate();
+
     creatureValidate(testCreature);
+
+    if (changed) {
+      const hiddenCountAfter =
+        testCreature.neurons.filter((n) => n.type === "hidden").length;
+      // If more than one hidden neuron was removed, cascade cleanup occurred
+      if (hiddenCountBefore - hiddenCountAfter > 1) {
+        cascadeOccurred = true;
+        break;
+      }
+    }
   }
+
+  assert(
+    cascadeOccurred,
+    "Should cascade-remove orphaned neurons when removing their only source",
+  );
 });
 
 Deno.test("SubNeuron - stress test produces valid creatures", () => {
@@ -117,29 +138,51 @@ Deno.test("SubNeuron - stress test produces valid creatures", () => {
 });
 
 Deno.test("SubNeuron - focus list limits removable neurons", () => {
-  const creature = Creature.fromJSON({
-    neurons: [
-      { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
-      { type: "hidden", squash: "LOGISTIC", bias: 0.3, index: 3 },
-      { type: "output", squash: "LOGISTIC", bias: 0.1, index: 4 },
-    ],
-    synapses: [
-      { from: 0, to: 2, weight: 1.0 },
-      { from: 1, to: 3, weight: 1.0 },
-      { from: 2, to: 4, weight: 0.8 },
-      { from: 3, to: 4, weight: 0.9 },
-    ],
-    input: 2,
-    output: 1,
-  });
+  let mutationSucceeded = false;
 
-  creatureValidate(creature);
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const creature = Creature.fromJSON({
+      neurons: [
+        { type: "hidden", squash: "LOGISTIC", bias: 0.5, index: 2 },
+        { type: "hidden", squash: "LOGISTIC", bias: 0.3, index: 3 },
+        { type: "output", squash: "LOGISTIC", bias: 0.1, index: 4 },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 1.0 },
+        { from: 1, to: 3, weight: 1.0 },
+        { from: 2, to: 4, weight: 0.8 },
+        { from: 3, to: 4, weight: 0.9 },
+      ],
+      input: 2,
+      output: 1,
+    });
 
-  // Focus only on one neuron
-  const mutator = new SubNeuron(creature);
-  mutator.mutate([2]);
+    creatureValidate(creature);
 
-  creatureValidate(creature);
+    // Focus only on neuron at index 2 — neuron at index 3 should not be removed
+    const mutator = new SubNeuron(creature);
+    const changed = mutator.mutate([2]);
+
+    creatureValidate(creature);
+
+    if (changed) {
+      // Verify the non-focused neuron (index 3) was preserved
+      const hasNeuron3 = creature.neurons.some((n) =>
+        n.type === "hidden" && n.bias === 0.3
+      );
+      assert(
+        hasNeuron3,
+        "Non-focused hidden neuron should be preserved when focus list excludes it",
+      );
+      mutationSucceeded = true;
+      break;
+    }
+  }
+
+  assert(
+    mutationSucceeded,
+    "SubNeuron with focus list should succeed within 50 attempts",
+  );
 });
 
 Deno.test("SubNeuron - can remove constant neurons", () => {


### PR DESCRIPTION
## Summary

Final audit pass strengthening weak assertions and fixing misleading test names
in `test/mutate/`. Closes #1769.

### Changes

1. **SubNeuron.ts** - Strengthened "cascade removal" test to verify that
   removing one neuron actually triggers cascade cleanup of orphaned neurons
   (previously only checked validity). Strengthened "focus list" test to verify
   that the non-focused neuron is preserved after mutation.

2. **SubBackCon.ts** - Renamed "should remove completely disconnected hidden
   neuron" to "should remove or convert disconnected hidden neuron after
   mutation" and added assertion that the hidden neuron count actually decreases
   (previously only checked mutation succeeded).

3. **SubConnection.ts** - Rewrote "focus list limits removable connections" test
   to properly account for transitive focus behaviour and added a new negative
   test verifying that focus list returns false when no focused connections are
   eligible.

4. **ConnectSplice.ts** - Renamed "correctly inserts at end of synapses array"
   to "correctly inserts and maintains order with higher from-index" (the
   previous name was misleading as the test could not exercise the push-to-end
   case).

### Cross-area duplicates noted

- `test/NEAT/MutatorMutateCreature.ts` and `test/NEAT/MutatorBehavioural.ts`
  test individual mutation operators at the integration level through the
  Mutator API. These are NOT duplicates — they test the orchestration layer, not
  individual operators.

## Evidence

- All 4730 tests pass
- `./quality.sh` passes clean

## Test Plan

- Strengthened assertions in SubNeuron.ts (cascade removal, focus list)
- Strengthened assertion in SubBackCon.ts (disconnected neuron cleanup)
- Rewrote SubConnection.ts focus list test + added negative focus list test
- Fixed misleading test name in ConnectSplice.ts
- All test names now accurately describe the behaviour being verified

---

## Automated Fix Details
This PR addresses issue #1769: **Audit: Mutation operator tests**

## Milestone
This PR is part of the **test-clean-up** milestone and targets the `milestone/test-clean-up` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1769
---

🤖 Processed by: stservice