### PR TITLE
Audit: Strengthen compound assertions in mutation operator tests (#1769)

### DIFF
--- a/docs/pr-summary-1769.md
+++ b/docs/pr-summary-1769.md
@@ -1,29 +1,8 @@
 ## Summary
 
-Final audit of mutation operator tests: removes Creature API tests misplaced in
-`test/mutate/` and consolidates the unique constant-neuron exclusion test into
-`AvailableConnectionsCache.ts`. Closes #1769.
-
-### Changes
-
-**AddConnectionOptimisation.ts removed (7 tests → 0):**
-
-Six tests tested Creature's `getConnectionSet()`, `hasConnection()`, and
-`getAvailableConnections()` methods — these are Creature API tests, not
-AddConnection mutation behaviour tests. They are already covered by:
-
-- `test/creature/CreatureTopology.ts` (getConnectionSet, hasConnection)
-- `test/creature/SelectiveCacheInvalidation.ts` (cache invalidation)
-
-The seventh test ("mutation adds connections and maintains validity") was a
-near-duplicate of `AvailableConnectionsCache.ts` test "tracks correctly through
-multiple mutations".
-
-**One unique test moved:**
-
-- "getAvailableConnections excludes constant neurons" moved to
-  `AvailableConnectionsCache.ts` as "excludes constant neurons from targets" —
-  the only test verifying this behaviour.
+Final audit pass on mutation operator tests: strengthens weak compound
+assertions in `AddNodeOutwardConnections.ts` by replacing `assert(a && b)` with
+separate `assertEquals()` calls for clearer failure diagnostics. Closes #1769.
 
 ### Full audit results
 
@@ -32,6 +11,8 @@ All 29 test files (165 test cases) in `test/mutate/` reviewed against criteria:
 - **Uniqueness**: No remaining duplicate or near-duplicate tests
 - **Behavioural testing**: All tests verify outcomes, not implementation details
 - **Meaningful tests**: Every test exercises real code with real assertions
+- **Assertion quality**: All assertions use specific assertion functions
+  (`assertEquals`, `assertThrows`, etc.) — no compound boolean `assert()` calls
 - **Organisation**: Tests are logically grouped and clearly named
 - **Cross-area overlap**: `test/NEAT/Mutator*.ts` tests mutation at the
   orchestration level, `test/mutate/` tests operators directly — complementary,
@@ -39,13 +20,11 @@ All 29 test files (165 test cases) in `test/mutate/` reviewed against criteria:
 
 ## Evidence
 
-- All 4716 tests pass
-- `./quality.sh --lint-only` and `./quality.sh --check-only` pass
+- All tests pass
+- `./quality.sh` passes
 
 ## Test Plan
 
-- Removed `test/mutate/AddConnectionOptimisation.ts` — 6 Creature API tests
-  already covered elsewhere, 1 near-duplicate
-- Added "excludes constant neurons from targets" test to
-  `test/mutate/AvailableConnectionsCache.ts`
+- Strengthened assertions in `test/mutate/AddNodeOutwardConnections.ts` —
+  replaced compound `assert(a && b)` with separate `assertEquals()` calls
 - All remaining tests verify behaviour with meaningful assertions

--- a/test/mutate/AddNodeOutwardConnections.ts
+++ b/test/mutate/AddNodeOutwardConnections.ts
@@ -1,4 +1,4 @@
-import { assert } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
 import type { CreatureInternal } from "../../src/architecture/CreatureInterfaces.ts";
 import { creatureValidate } from "../../src/architecture/CreatureValidate.ts";
@@ -75,10 +75,15 @@ Deno.test("IF hidden neuron keeps an outward connection after fix", () => {
 
   const hiddenIndex = 3;
   const outwardBefore = creature.outwardConnections(hiddenIndex);
-  assert(
-    outwardBefore.length === 1 &&
-      outwardBefore[0].to === hiddenIndex,
-    "Precondition failed: expected only a self connection before fix()",
+  assertEquals(
+    outwardBefore.length,
+    1,
+    "Precondition: expected exactly one outward connection before fix()",
+  );
+  assertEquals(
+    outwardBefore[0].to,
+    hiddenIndex,
+    "Precondition: the only outward connection should be a self-connection",
   );
 
   creature.fix();


### PR DESCRIPTION
## Summary

Final audit pass on mutation operator tests: strengthens weak compound
assertions in `AddNodeOutwardConnections.ts` by replacing `assert(a && b)` with
separate `assertEquals()` calls for clearer failure diagnostics. Closes #1769.

### Full audit results

All 29 test files (165 test cases) in `test/mutate/` reviewed against criteria:

- **Uniqueness**: No remaining duplicate or near-duplicate tests
- **Behavioural testing**: All tests verify outcomes, not implementation details
- **Meaningful tests**: Every test exercises real code with real assertions
- **Assertion quality**: All assertions use specific assertion functions
  (`assertEquals`, `assertThrows`, etc.) — no compound boolean `assert()` calls
- **Organisation**: Tests are logically grouped and clearly named
- **Cross-area overlap**: `test/NEAT/Mutator*.ts` tests mutation at the
  orchestration level, `test/mutate/` tests operators directly — complementary,
  not duplicate

## Evidence

- All tests pass
- `./quality.sh` passes

## Test Plan

- Strengthened assertions in `test/mutate/AddNodeOutwardConnections.ts` —
  replaced compound `assert(a && b)` with separate `assertEquals()` calls
- All remaining tests verify behaviour with meaningful assertions

---

## Automated Fix Details
This PR addresses issue #1769: **Audit: Mutation operator tests**

## Milestone
This PR is part of the **test-clean-up** milestone and targets the `milestone/test-clean-up` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1769
---

🤖 Processed by: stservice