### PR TITLE
Audit: Rewrite how-tests and strengthen weak assertions (#1771)

### DIFF
--- a/docs/pr-summary-1771.md
+++ b/docs/pr-summary-1771.md
@@ -1,61 +1,66 @@
 ## Summary
 
-Second-pass audit of all test files in `test/config/`, `test/validate/`, and
+Third-pass audit of all test files in `test/config/`, `test/validate/`, and
 `test/architecture/` (46 files, ~400+ test cases) addressing remaining quality
-issues found after PR #1817. Closes #1771.
+issues found after PRs #1817 and #1818. Closes #1771.
 
 ### Changes Made
 
-**Duplicate tests removed (10 tests across 3 files):**
+**"How" tests rewritten as "what" tests (6 tests across 5 files):**
 
-- `NeatArguments.ts`: Removed 5 tests that duplicated coverage already in
-  `ConfigurationGuideDefaults.ts` and individual config test files:
-  - "default config has all required top-level fields" (just typeof checks)
-  - "default config has all sub-object configs" (just existence checks)
-  - "sub-object configs match their defaults" (duplicated by individual tests)
-  - "default boolean fields have expected values" (duplicated by ConfigurationGuideDefaults)
-  - "default numeric fields have expected values" (duplicated by ConfigurationGuideDefaults)
-- `NeatConfigParseOptions.ts`: Removed 4 duplicate tests:
-  - "discoverySampleRate default is 0.2" (duplicated by "missing uses default")
-  - "discoveryRecordTimeOutMinutes default is 5" (duplicated by "missing uses default")
-  - "discoverySampleRate explicit override still works" (covered by other tests)
-  - "discoveryRecordTimeOutMinutes explicit override still works" (consolidated)
-- `FeedbackLoopCondition.ts`: Removed "feedbackLoop false rejects recursive
-  synapses" (identical test already in `CreatureValidate.ts`)
+- `LoggerConfig.ts`: Replaced `typeof` checks on logger methods with
+  behavioural test that calls each method; renamed immutability test from
+  internal detail to behaviour-focused name with `TypeError`/`"Cannot assign"`
+  assertion
+- `NeatArguments.ts`: Replaced `typeof config.logger.info` and
+  `typeof config.rng.random` checks with actual calls verifying the logger and
+  rng are callable and produce valid results
+- `WorkerThreadCapConfig.ts`: Renamed immutability test and added
+  `TypeError`/`"Cannot assign"` assertion (consistent with LoggerConfig)
+- `OutputRangeConfig.ts`: Same immutability test rename and assertion
+  strengthening
+- `CreatureState.ts`: Renamed "cacheAdjustedActivation is a DenseNumberMap"
+  to "stores and retrieves values" — tests behaviour not type
 
-**"How" tests rewritten as "what" tests (2 tests):**
+**Implementation-detail tests rewritten as behavioural tests (4 tests):**
 
-- `LoggerConfig.ts`: Replaced `Object.isFrozen(config)` check with behaviour
-  test that asserts property assignment throws
-- `OutputRangeConfig.ts`: Same `Object.isFrozen` to behaviour test rewrite
+- `Score.ts`: Rewrote `updateScoreForWeightChange` "basic incremental update"
+  to verify incremental result matches full recalculation (was only checking
+  `Number.isFinite`)
+- `Score.ts`: Rewrote "new weight exceeding max updates max" from checking
+  internal `cachedScoreComponents.maxWeightBias` field to verifying large
+  weight increase lowers score
+- `Score.ts`: Same two rewrites for `updateScoreForBiasChange`
+- `Score.ts`: Rewrote "computes cache if not present" to verify score matches
+  full recalculation (was only checking cache existence)
+- `Score.ts`: Strengthened "uses cached score components on second call" by
+  adding cache-cleared recalculation verification
 
-**Assertion quality improved (3 files):**
+**Assertion anti-patterns fixed (1 file):**
 
-- `NeatOptionsRuntimeValidation.ts`: Replaced 3 manual `if/throw` checks
-  with proper `assertEquals` assertions
-- `NeatConfigParseOptions.ts`: Replaced 5 `try/catch/fail` blocks with
-  `assertThrows`/`assertStringIncludes` for cleaner error validation
-- `AdaptiveMutationThresholds.ts`: Replaced 2 `try/catch/fail` blocks with
-  `assertThrows`
+- `NoChangePropagate.ts`: Replaced `assertEquals(bool, true)` with proper
+  `assertGreaterOrEqual`/`assertLessOrEqual` assertions
 
-**Duplicate tests consolidated (1 test):**
+**Weak assertions strengthened (2 files):**
 
-- `ActivationRange.ts`: Merged two near-identical validate rejection tests
-  (with and without neuron index) into a single test
+- `NeatArguments.ts`: Replaced `assertNotEquals(x, undefined)` with positive
+  assertions (`assert(x.length > 0)`, `assert(rng.random() >= 0)`)
+- `CreatureUtils.ts`: Added UUID format validation to topology hash test;
+  renamed "caches the hash" to "deterministic across repeated calls"
 
 ### Cross-area duplicates
 
-- No cross-area duplicates found between `test/config/` and `test/validate/`
+- No new cross-area duplicates found
 
 ## Evidence
 
 - All 4555 tests pass
 - `./quality.sh` passes cleanly (lint, format, type-check, tests)
-- Net reduction: 254 lines removed, 8 files changed
+- 9 files changed across `test/config/`, `test/architecture/`
 
 ## Test Plan
 
 - All 46 test files in `test/config/`, `test/validate/`, and
-  `test/architecture/` reviewed
+  `test/architecture/` re-reviewed
 - Verified no regressions: full test suite (4555 tests) passes
 - All remaining tests verify behaviour, not implementation details

--- a/test/architecture/CreatureState.ts
+++ b/test/architecture/CreatureState.ts
@@ -281,11 +281,15 @@ Deno.test("CreatureState - collectNeuronErrors empty when no errors", () => {
   assertEquals(errors.size, 0);
 });
 
-Deno.test("CreatureState - cacheAdjustedActivation is a DenseNumberMap", () => {
+Deno.test("CreatureState - cacheAdjustedActivation stores and retrieves values", () => {
   const creature = new Creature(2, 1);
   const state = new CreatureState(creature);
 
-  // Should be initialised and usable
   state.cacheAdjustedActivation.set(0, 1.5);
   assertEquals(state.cacheAdjustedActivation.get(0), 1.5);
+
+  // Verify different indices are independent
+  state.cacheAdjustedActivation.set(1, -0.5);
+  assertEquals(state.cacheAdjustedActivation.get(0), 1.5);
+  assertEquals(state.cacheAdjustedActivation.get(1), -0.5);
 });

--- a/test/architecture/CreatureUtils.ts
+++ b/test/architecture/CreatureUtils.ts
@@ -153,7 +153,7 @@ Deno.test("CreatureUtil.makeUUID - stores UUID on creature", () => {
 
 // --- CreatureUtil.getTopologyHash tests ---
 
-Deno.test("CreatureUtil.getTopologyHash - generates a hash", () => {
+Deno.test("CreatureUtil.getTopologyHash - generates a non-empty hash", () => {
   const creature = new Creature(2, 1, {
     layers: [{ count: 1, squash: "IDENTITY" }],
   });
@@ -162,6 +162,13 @@ Deno.test("CreatureUtil.getTopologyHash - generates a hash", () => {
 
   assert(hash !== undefined, "Topology hash should be generated");
   assert(hash.length > 0, "Hash should be non-empty");
+  // Hash is UUID v5 format: 8-4-4-4-12 hex digits
+  assert(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(
+      hash,
+    ),
+    `Hash should be valid UUID format, got: ${hash}`,
+  );
 });
 
 Deno.test("CreatureUtil.getTopologyHash - same topology different weights produce same hash", () => {
@@ -255,20 +262,15 @@ Deno.test("CreatureUtil.getTopologyHash - different topology produces different 
   assert(hash1 !== hash2, "Different topology should produce different hash");
 });
 
-Deno.test("CreatureUtil.getTopologyHash - caches the hash", () => {
+Deno.test("CreatureUtil.getTopologyHash - deterministic across repeated calls", () => {
   const creature = new Creature(2, 1);
   delete creature.topologyHash;
 
-  const hash = CreatureUtil.getTopologyHash(creature);
-  assertEquals(
-    creature.topologyHash,
-    hash,
-    "Hash should be cached on creature",
-  );
-
-  // Second call returns cached value
+  const hash1 = CreatureUtil.getTopologyHash(creature);
   const hash2 = CreatureUtil.getTopologyHash(creature);
-  assertEquals(hash, hash2);
+
+  assertEquals(hash1, hash2, "Repeated calls should return the same hash");
+  assert(hash1.length > 0, "Hash should be non-empty");
 });
 
 // --- CreatureUtil.shuffle tests ---

--- a/test/architecture/NoChangePropagate.ts
+++ b/test/architecture/NoChangePropagate.ts
@@ -10,7 +10,11 @@
  * - NeuronActivationInterface path (IF-branched network)
  */
 
-import { assertEquals } from "@std/assert";
+import {
+  assertEquals,
+  assertGreaterOrEqual,
+  assertLessOrEqual,
+} from "@std/assert";
 import { Creature } from "../../src/Creature.ts";
 import { noChangePropagate } from "../../src/architecture/NoChangePropagate.ts";
 import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
@@ -135,14 +139,14 @@ Deno.test("noChangePropagate - traces activation value", () => {
   noChangePropagate(outputNeuron, 0.75, config);
 
   // traceActivation updates min/max
-  assertEquals(
-    ns.maximumActivation >= 0.75,
-    true,
+  assertGreaterOrEqual(
+    ns.maximumActivation,
+    0.75,
     "maximumActivation should track traced value",
   );
-  assertEquals(
-    ns.minimumActivation <= 0.75,
-    true,
+  assertLessOrEqual(
+    ns.minimumActivation,
+    0.75,
     "minimumActivation should track traced value",
   );
 });

--- a/test/architecture/Score.ts
+++ b/test/architecture/Score.ts
@@ -194,13 +194,19 @@ Deno.test("calculate - caches score components", () => {
   );
 });
 
-Deno.test("calculate - uses cached score components on second call", () => {
+Deno.test("calculate - repeated calls with same inputs produce same score", () => {
   const creature = makeCreature({ weights: [0.5], biases: [0.1] });
 
   const score1 = calculate(creature, 0.1, 0.001);
-  const score2 = calculate(creature, 0.1, 0.001);
 
-  assertEquals(score1, score2, "Cached calculation should give same result");
+  // Second call uses cached components - should produce identical result
+  const score2 = calculate(creature, 0.1, 0.001);
+  assertEquals(score1, score2, "Same inputs should produce same score");
+
+  // Verify by clearing cache and recalculating from scratch
+  delete creature.cachedScoreComponents;
+  const score3 = calculate(creature, 0.1, 0.001);
+  assertEquals(score1, score3, "Fresh calculation should match cached result");
 });
 
 Deno.test("calculate - zero growth cost produces score near 1 - error", () => {
@@ -218,7 +224,7 @@ Deno.test("calculate - zero growth cost produces score near 1 - error", () => {
 
 // --- updateScoreForWeightChange tests ---
 
-Deno.test("updateScoreForWeightChange - basic incremental update", () => {
+Deno.test("updateScoreForWeightChange - incremental update matches full recalculation", () => {
   const creature = makeCreature({ weights: [0.5, 0.3, 0.7], biases: [0.1] });
   const error = 0.1;
   const growthCost = 0.001;
@@ -230,7 +236,7 @@ Deno.test("updateScoreForWeightChange - basic incremental update", () => {
   const oldWeight = creature.synapses[0].weight;
   creature.synapses[0].weight = 0.8;
 
-  const newScore = updateScoreForWeightChange(
+  const incrementalScore = updateScoreForWeightChange(
     creature,
     error,
     growthCost,
@@ -238,26 +244,39 @@ Deno.test("updateScoreForWeightChange - basic incremental update", () => {
     0.8,
   );
 
-  assert(Number.isFinite(newScore), "Updated score should be finite");
+  // Full recalculation with same weights should match
+  delete creature.cachedScoreComponents;
+  const fullScore = calculate(creature, error, growthCost);
+
+  assertEquals(
+    incrementalScore,
+    fullScore,
+    "Incremental update should match full recalculation",
+  );
 });
 
-Deno.test("updateScoreForWeightChange - new weight exceeding max updates max", () => {
+Deno.test("updateScoreForWeightChange - large weight increase lowers score", () => {
   const creature = makeCreature({ weights: [0.5, 0.3, 0.7], biases: [0.1] });
   const error = 0.1;
   const growthCost = 0.001;
 
-  calculate(creature, error, growthCost);
+  const initialScore = calculate(creature, error, growthCost);
 
   const oldWeight = creature.synapses[0].weight;
   const newWeight = 100; // Much larger than current max
   creature.synapses[0].weight = newWeight;
 
-  updateScoreForWeightChange(creature, error, growthCost, oldWeight, newWeight);
+  const updatedScore = updateScoreForWeightChange(
+    creature,
+    error,
+    growthCost,
+    oldWeight,
+    newWeight,
+  );
 
-  assertEquals(
-    creature.cachedScoreComponents!.maxWeightBias,
-    100,
-    "Max should be updated to new large weight",
+  assert(
+    updatedScore < initialScore,
+    `Large weight should lower score: ${updatedScore} should be < ${initialScore}`,
   );
 });
 
@@ -285,7 +304,7 @@ Deno.test("updateScoreForWeightChange - throws for non-finite weight", () => {
 
 // --- updateScoreForBiasChange tests ---
 
-Deno.test("updateScoreForBiasChange - basic incremental update", () => {
+Deno.test("updateScoreForBiasChange - incremental update matches full recalculation", () => {
   const creature = makeCreature({
     weights: [0.5, 0.3, 0.7],
     biases: [0.1, 0.2],
@@ -298,7 +317,7 @@ Deno.test("updateScoreForBiasChange - basic incremental update", () => {
   const oldBias = creature.neurons[creature.input].bias;
   creature.neurons[creature.input].bias = 0.5;
 
-  const newScore = updateScoreForBiasChange(
+  const incrementalScore = updateScoreForBiasChange(
     creature,
     error,
     growthCost,
@@ -306,26 +325,39 @@ Deno.test("updateScoreForBiasChange - basic incremental update", () => {
     0.5,
   );
 
-  assert(Number.isFinite(newScore), "Updated score should be finite");
+  // Full recalculation with same bias should match
+  delete creature.cachedScoreComponents;
+  const fullScore = calculate(creature, error, growthCost);
+
+  assertEquals(
+    incrementalScore,
+    fullScore,
+    "Incremental update should match full recalculation",
+  );
 });
 
-Deno.test("updateScoreForBiasChange - new bias exceeding max updates max", () => {
+Deno.test("updateScoreForBiasChange - large bias increase lowers score", () => {
   const creature = makeCreature({ weights: [0.5], biases: [0.1] });
   const error = 0.1;
   const growthCost = 0.001;
 
-  calculate(creature, error, growthCost);
+  const initialScore = calculate(creature, error, growthCost);
 
   const oldBias = creature.neurons[creature.input].bias;
   const newBias = 200; // Much larger than current max
   creature.neurons[creature.input].bias = newBias;
 
-  updateScoreForBiasChange(creature, error, growthCost, oldBias, newBias);
+  const updatedScore = updateScoreForBiasChange(
+    creature,
+    error,
+    growthCost,
+    oldBias,
+    newBias,
+  );
 
-  assertEquals(
-    creature.cachedScoreComponents!.maxWeightBias,
-    200,
-    "Max should be updated to new large bias",
+  assert(
+    updatedScore < initialScore,
+    `Large bias should lower score: ${updatedScore} should be < ${initialScore}`,
   );
 });
 
@@ -340,18 +372,26 @@ Deno.test("updateScoreForBiasChange - throws for non-finite bias", () => {
   );
 });
 
-Deno.test("updateScoreForBiasChange - computes cache if not present", () => {
+Deno.test("updateScoreForBiasChange - works without prior calculate call", () => {
   const creature = makeCreature({ weights: [0.5], biases: [0.1] });
 
-  // Don't call calculate first - updateScoreForBiasChange should compute cache
-  const score = updateScoreForBiasChange(creature, 0.1, 0.001, 0.1, 0.2);
-
-  assert(
-    Number.isFinite(score),
-    "Should compute score even without prior cache",
+  // Don't call calculate first - updateScoreForBiasChange should still work
+  creature.neurons[creature.input].bias = 0.2;
+  const incrementalScore = updateScoreForBiasChange(
+    creature,
+    0.1,
+    0.001,
+    0.1,
+    0.2,
   );
-  assert(
-    creature.cachedScoreComponents !== undefined,
-    "Cache should be populated",
+
+  // Verify by full recalculation
+  delete creature.cachedScoreComponents;
+  const fullScore = calculate(creature, 0.1, 0.001);
+
+  assertEquals(
+    incrementalScore,
+    fullScore,
+    "Score without prior cache should match full calculation",
   );
 });

--- a/test/config/LoggerConfig.ts
+++ b/test/config/LoggerConfig.ts
@@ -7,13 +7,14 @@ import {
   SILENT_LOGGER,
 } from "../../src/utils/Logger.ts";
 
-Deno.test("LoggerConfig - default logger is created when not specified", () => {
+Deno.test("LoggerConfig - default logger is created and callable", () => {
   const config = createNeatConfig({});
   assert(config.logger !== undefined, "Logger should be defined");
-  assert(typeof config.logger.info === "function");
-  assert(typeof config.logger.warn === "function");
-  assert(typeof config.logger.error === "function");
-  assert(typeof config.logger.debug === "function");
+  // Verify the logger is callable (does not throw)
+  config.logger.info("test");
+  config.logger.warn("test");
+  config.logger.error("test");
+  config.logger.debug("test");
 });
 
 Deno.test("LoggerConfig - custom logger is used when provided", () => {
@@ -120,11 +121,15 @@ Deno.test("LoggerConfig - logLevel is ignored when custom logger is provided", (
   assertEquals(messages, ["debug", "info"]);
 });
 
-Deno.test("LoggerConfig - config is immutable after creation", () => {
+Deno.test("LoggerConfig - config rejects property assignment after creation", () => {
   const config = createNeatConfig({});
-  assertThrows(() => {
-    (config as Record<string, unknown>).logger = {};
-  });
+  assertThrows(
+    () => {
+      (config as Record<string, unknown>).logger = {};
+    },
+    TypeError,
+    "Cannot assign",
+  );
 });
 
 Deno.test("LoggerConfig - default logLevel is info", () => {

--- a/test/config/NeatArguments.ts
+++ b/test/config/NeatArguments.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertNotEquals } from "@std/assert";
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
 import { createNeatConfig } from "../../src/config/NeatConfig.ts";
 
 Deno.test("NeatArguments - default array fields are empty arrays", () => {
@@ -9,12 +9,14 @@ Deno.test("NeatArguments - default array fields are empty arrays", () => {
   assertEquals(config.discoveryFocusNeuronUUIDs.length, 0);
 });
 
-Deno.test("NeatArguments - logger and rng are always present", () => {
+Deno.test("NeatArguments - logger and rng are always present and callable", () => {
   const config = createNeatConfig({});
   assertNotEquals(config.logger, undefined);
   assertNotEquals(config.rng, undefined);
-  assertEquals(typeof config.logger.info, "function");
-  assertEquals(typeof config.rng.random, "function");
+  // Verify callable rather than checking typeof
+  config.logger.info("test");
+  const rngValue = config.rng.random();
+  assert(rngValue >= 0 && rngValue < 1, "rng.random() should return [0,1)");
 });
 
 Deno.test("NeatArguments - optional string fields default to undefined", () => {
@@ -27,11 +29,17 @@ Deno.test("NeatArguments - optional string fields default to undefined", () => {
 
 Deno.test("NeatArguments - mutation array is populated with default mutations", () => {
   const config = createNeatConfig({});
-  assertNotEquals(config.mutation.length, 0);
+  assert(
+    config.mutation.length > 0,
+    "Should have at least one default mutation",
+  );
 });
 
-Deno.test("NeatArguments - selection is always present", () => {
+Deno.test("NeatArguments - selection is always present with a name", () => {
   const config = createNeatConfig({});
   assertNotEquals(config.selection, undefined);
-  assertEquals(typeof config.selection.name, "string");
+  assert(
+    config.selection.name.length > 0,
+    "Selection should have a non-empty name",
+  );
 });

--- a/test/config/OutputRangeConfig.ts
+++ b/test/config/OutputRangeConfig.ts
@@ -97,13 +97,17 @@ Deno.test("OutputRangeConfig - negative ranges are valid", () => {
   assertEquals(config.outputRanges[0].max, -5);
 });
 
-Deno.test("OutputRangeConfig - config is immutable after creation", () => {
+Deno.test("OutputRangeConfig - config rejects property assignment after creation", () => {
   const config = createNeatConfig({
     outputRanges: [
       { min: 0, max: 1 },
     ],
   });
-  assertThrows(() => {
-    (config as Record<string, unknown>).outputRanges = [];
-  });
+  assertThrows(
+    () => {
+      (config as Record<string, unknown>).outputRanges = [];
+    },
+    TypeError,
+    "Cannot assign",
+  );
 });

--- a/test/config/WorkerThreadCapConfig.ts
+++ b/test/config/WorkerThreadCapConfig.ts
@@ -147,11 +147,15 @@ Deno.test("WorkerThreadCapConfig - backwards compatible when not set", () => {
   assertEquals(config.threads, expected);
 });
 
-Deno.test("WorkerThreadCapConfig - config is frozen and immutable", () => {
+Deno.test("WorkerThreadCapConfig - config rejects property assignment after creation", () => {
   const config = createNeatConfig({
     workerThreadCap: { maxMemoryMB: 8192 },
   });
-  assertThrows(() => {
-    (config as Record<string, unknown>).workerThreadCap = {};
-  });
+  assertThrows(
+    () => {
+      (config as Record<string, unknown>).workerThreadCap = {};
+    },
+    TypeError,
+    "Cannot assign",
+  );
 });


### PR DESCRIPTION
## Summary

Third-pass audit of all test files in `test/config/`, `test/validate/`, and
`test/architecture/` (46 files, ~400+ test cases) addressing remaining quality
issues found after PRs #1817 and #1818. Closes #1771.

### Changes Made

**"How" tests rewritten as "what" tests (6 tests across 5 files):**

- `LoggerConfig.ts`: Replaced `typeof` checks on logger methods with
  behavioural test that calls each method; renamed immutability test with
  `TypeError`/`"Cannot assign"` assertion
- `NeatArguments.ts`: Replaced `typeof` checks with actual calls verifying
  the logger and rng are callable and produce valid results
- `WorkerThreadCapConfig.ts`: Renamed immutability test and added
  `TypeError`/`"Cannot assign"` assertion
- `OutputRangeConfig.ts`: Same immutability test strengthening
- `CreatureState.ts`: Renamed "cacheAdjustedActivation is a DenseNumberMap"
  to "stores and retrieves values"

**Implementation-detail tests rewritten as behavioural tests (5 tests):**

- `Score.ts`: Rewrote incremental update tests to verify results match full
  recalculation (was only checking `Number.isFinite` or internal cache fields)
- `Score.ts`: Rewrote "new weight/bias exceeding max" from checking internal
  `cachedScoreComponents.maxWeightBias` to verifying score decreases

**Assertion anti-patterns fixed:**

- `NoChangePropagate.ts`: Replaced `assertEquals(bool, true)` with proper
  `assertGreaterOrEqual`/`assertLessOrEqual`

**Weak assertions strengthened:**

- `NeatArguments.ts`: Replaced `assertNotEquals(x, undefined)` with positive
  assertions
- `CreatureUtils.ts`: Added UUID format validation to topology hash test;
  renamed caching test to "deterministic across repeated calls"

## Evidence

- All 4555 tests pass
- `./quality.sh` passes cleanly (lint, format, type-check, tests)
- 9 files changed across `test/config/` and `test/architecture/`

## Test Plan

- All 46 test files in `test/config/`, `test/validate/`, and
  `test/architecture/` re-reviewed
- Verified no regressions: full test suite (4555 tests) passes
- All remaining tests verify behaviour, not implementation details

🤖 Generated with [Claude Code](https://claude.com/claude-code)