### PR TITLE
Audit: Fix assertion style and correct misleading test names (#1772)

### DIFF
--- a/docs/pr-summary-1772.md
+++ b/docs/pr-summary-1772.md
@@ -1,42 +1,38 @@
 ## Summary
 
-Final audit pass: strengthen weak assertions and improve test names in
-compact/optimisation tests. Closes #1772.
+Final audit pass on compact/optimisation tests: fix remaining assertion style
+inconsistency and correct misleading test names. Closes #1772.
 
 All test files in `test/Compact/`, `test/optimize/`, `test/optimization/`,
-`test/FeedForward/`, and `test/reconstruct/` have been reviewed against the
-audit criteria. Previous PRs addressed duplicates, trivial tests, and cross-area
-overlaps. This final pass strengthens the remaining weak assertions and improves
-test names.
+`test/FeedForward/`, and `test/reconstruct/` have been reviewed across 9 PRs.
+The audit confirmed:
+
+- **No duplicate tests remain** — prior passes removed all duplicates
+- **All tests verify behaviour** — no "how" tests (no source grepping, no
+  implementation detail assertions)
+- **All tests are meaningful** — no trivial/placeholder assertions
+- **Test names clearly describe behaviour** — misleading names corrected in this
+  pass
 
 ### Changes
 
-**CompactCreatureCloneOptimisation.ts** — strengthened two weak assertions and
-improved all 13 test names:
-
-- **Neuron tags test**: Previously only asserted the output neuron exists — it
-  never checked that the tagged neuron's tags survived compaction. Redesigned to
-  use a backward-synapse compaction scenario where the tagged LOGISTIC neuron
-  survives, then verifies the specific tag name and value.
-
-- **Creature-level tags test**: Previously only asserted `exported.tags` is
-  truthy. Now verifies the specific tag values ("model-version"/"1.0.0" and
-  "training-run"/"experiment-42") are present after compaction.
-
-- **Test names**: All 13 test names updated from implementation-focused names
-  (e.g. "optimised clone produces independent neuron arrays") to
-  behaviour-focused names (e.g. "compaction does not modify original creature
-  neurons").
+- **test/optimize/activate/RELU.ts**: Replaced `fail()` with
+  `assertAlmostEquals()` for consistency with all other activate tests
+- **test/optimize/activate/HYPOTv2.ts**: Corrected test name from "per-input
+  bias" to "uniform bias offset" — the bias is applied uniformly to all inputs,
+  not per-input
+- **test/optimization/MiniBatch.ts**: Corrected test name from "should
+  accumulate gradients across batch" to "different batch sizes converge to
+  similar error" — the test compares batch-size-1 vs batch-size-4 convergence,
+  not gradient accumulation
 
 ## Evidence
 
-- All 4509 tests pass
-- `./quality.sh` passes cleanly
+- `./quality.sh` passes: 4509 tests passed, 0 failed
+- All acceptance criteria met across 9 PRs (#1821–#1828 + this PR)
 
 ## Test Plan
 
-- Modified: `test/Compact/CompactCreatureCloneOptimisation.ts` (13 tests)
-  - Strengthened assertion: neuron tags verified by name/value after compaction
-  - Strengthened assertion: creature-level tags verified by name/value
-  - All test names improved to describe behaviour being verified
-- Full test suite passes (4509 tests, 0 failures)
+- No new tests added; existing tests improved with clearer names and consistent
+  assertion style
+- Verified all 4509 tests pass after changes

--- a/test/optimization/MiniBatch.ts
+++ b/test/optimization/MiniBatch.ts
@@ -3,7 +3,7 @@ import { Creature } from "../../src/Creature.ts";
 import type { TrainOptions } from "../../src/config/TrainOptions.ts";
 import { train } from "../TrainTestOnlyUtil.ts";
 
-Deno.test("optimization/MiniBatch - should accumulate gradients across batch", () => {
+Deno.test("optimization/MiniBatch - different batch sizes converge to similar error", () => {
   // Create a simple creature for testing
   const creature = Creature.fromJSON({
     neurons: [

--- a/test/optimize/activate/HYPOTv2.ts
+++ b/test/optimize/activate/HYPOTv2.ts
@@ -4,7 +4,7 @@ import type { CreatureExport } from "../../../src/architecture/CreatureInterface
 import { createBackPropagationConfig } from "../../../src/propagate/BackPropagation.ts";
 import { SparseConfig } from "../../../src/propagate/sparse/SparseConfig.ts";
 
-Deno.test("activate - HYPOTv2 squash applies per-input bias before hypotenuse", () => {
+Deno.test("activate - HYPOTv2 squash applies uniform bias offset before hypotenuse", () => {
   const directory = ".test/optimize/activate/HYPOTv2";
   Deno.mkdirSync(directory, { recursive: true });
   const json: CreatureExport = {

--- a/test/optimize/activate/RELU.ts
+++ b/test/optimize/activate/RELU.ts
@@ -1,4 +1,4 @@
-import { fail } from "@std/assert";
+import { assertAlmostEquals } from "@std/assert";
 import { Creature } from "../../../src/Creature.ts";
 import type { CreatureExport } from "../../../src/architecture/CreatureInterfaces.ts";
 
@@ -28,11 +28,6 @@ Deno.test("activate - RELU produces correct clamped output", () => {
     let expected = a * Math.E + b * -Math.LOG2E + c * Math.SQRT1_2 + Math.LN2;
     if (expected < 0) expected = 0;
 
-    const delta = expected - actual;
-    if (Math.abs(delta) > 0.000_005) {
-      fail(
-        `${p}) Expected: ${expected}, actual: ${actual}, delta: ${delta}`,
-      );
-    }
+    assertAlmostEquals(actual, expected, 0.000_005, `iteration ${p}`);
   }
 });


### PR DESCRIPTION
## Summary

Final audit pass on compact/optimisation tests: fix remaining assertion style
inconsistency and correct misleading test names. Closes #1772.

All test files in `test/Compact/`, `test/optimize/`, `test/optimization/`,
`test/FeedForward/`, and `test/reconstruct/` have been reviewed across 9 PRs.
The audit confirmed:

- **No duplicate tests remain** — prior passes removed all duplicates
- **All tests verify behaviour** — no "how" tests (no source grepping, no
  implementation detail assertions)
- **All tests are meaningful** — no trivial/placeholder assertions
- **Test names clearly describe behaviour** — misleading names corrected in this
  pass

### Changes

- **test/optimize/activate/RELU.ts**: Replaced `fail()` with
  `assertAlmostEquals()` for consistency with all other activate tests
- **test/optimize/activate/HYPOTv2.ts**: Corrected test name from "per-input
  bias" to "uniform bias offset" — the bias is applied uniformly to all inputs,
  not per-input
- **test/optimization/MiniBatch.ts**: Corrected test name from "should
  accumulate gradients across batch" to "different batch sizes converge to
  similar error" — the test compares batch-size-1 vs batch-size-4 convergence,
  not gradient accumulation

## Evidence

- `./quality.sh` passes: 4509 tests passed, 0 failed
- All acceptance criteria met across 9 PRs (#1821–#1828 + this PR)

## Test Plan

- No new tests added; existing tests improved with clearer names and consistent
  assertion style
- Verified all 4509 tests pass after changes

---

## Automated Fix Details
This PR addresses issue #1772: **Audit: Compact & optimisation tests**

## Milestone
This PR is part of the **test-clean-up** milestone and targets the `milestone/test-clean-up` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1772
---

🤖 Processed by: stservice