### PR TITLE
Enhancement: Add L1/L2 weight regularisation during backpropagation

### DIFF
--- a/docs/pr-summary-1859.md
+++ b/docs/pr-summary-1859.md
@@ -1,16 +1,25 @@
 ## Summary
 
-Add L1/L2 weight and bias regularisation (weight decay) during backpropagation. Closes #1859.
+Add L1/L2 weight and bias regularisation (weight decay) during backpropagation.
+Closes #1859.
 
 Four new configurable parameters are added to `BackPropagationArguments`:
-- `l1WeightDecay` / `l2WeightDecay` — L1 (sparsity) and L2 (decay) penalties for synapse weights
-- `l1BiasDecay` / `l2BiasDecay` — L1 (sparsity) and L2 (decay) penalties for neuron biases
+
+- `l1WeightDecay` / `l2WeightDecay` — L1 (sparsity) and L2 (decay) penalties for
+  synapse weights
+- `l1BiasDecay` / `l2BiasDecay` — L1 (sparsity) and L2 (decay) penalties for
+  neuron biases
 
 All default to 0 (disabled), preserving backward compatibility. When enabled:
-- **L2** shrinks weights/biases proportionally to magnitude: `w *= (1 - lr * λ)`
-- **L1** applies soft-thresholding, driving small values to zero and snapping to zero when the penalty exceeds the magnitude
 
-Regularisation is applied via extracted helper functions (`applyWeightRegularisation`, `applyBiasRegularisation`) on all return paths of `limitWeight()` and `limitBias()`, ensuring it works both with and without gradient updates, and integrates cleanly with sparse training (`sparseRatio`).
+- **L2** shrinks weights/biases proportionally to magnitude: `w *= (1 - lr * λ)`
+- **L1** applies soft-thresholding, driving small values to zero and snapping to
+  zero when the penalty exceeds the magnitude
+
+Regularisation is applied via extracted helper functions
+(`applyWeightRegularisation`, `applyBiasRegularisation`) on all return paths of
+`limitWeight()` and `limitBias()`, ensuring it works both with and without
+gradient updates, and integrates cleanly with sparse training (`sparseRatio`).
 
 ## Evidence
 

--- a/docs/pr-summary-1859.md
+++ b/docs/pr-summary-1859.md
@@ -1,0 +1,40 @@
+## Summary
+
+Add L1/L2 weight and bias regularisation (weight decay) during backpropagation. Closes #1859.
+
+Four new configurable parameters are added to `BackPropagationArguments`:
+- `l1WeightDecay` / `l2WeightDecay` — L1 (sparsity) and L2 (decay) penalties for synapse weights
+- `l1BiasDecay` / `l2BiasDecay` — L1 (sparsity) and L2 (decay) penalties for neuron biases
+
+All default to 0 (disabled), preserving backward compatibility. When enabled:
+- **L2** shrinks weights/biases proportionally to magnitude: `w *= (1 - lr * λ)`
+- **L1** applies soft-thresholding, driving small values to zero and snapping to zero when the penalty exceeds the magnitude
+
+Regularisation is applied via extracted helper functions (`applyWeightRegularisation`, `applyBiasRegularisation`) on all return paths of `limitWeight()` and `limitBias()`, ensuring it works both with and without gradient updates, and integrates cleanly with sparse training (`sparseRatio`).
+
+## Evidence
+
+- 15 weight regularisation tests and 8 bias regularisation tests all pass
+- Existing 4516 tests continue to pass with no regressions
+- Quality gate (`./quality.sh`) passes cleanly
+
+## Test Plan
+
+- `test/propagate/WeightRegularisation.ts` — 15 tests covering:
+  - L2 weight decay reduces positive/negative weight magnitudes
+  - L2 strength controls decay rate
+  - L2 disabled when strength is 0
+  - L2 works alongside gradient updates
+  - L1 drives small weights toward zero
+  - L1 snaps to zero when penalty exceeds weight
+  - L1 strength controls sparsity pressure
+  - Elastic net (L1+L2) combines penalties
+  - Progressive reduction over multiple iterations
+  - Integration with sparseRatio
+  - Defaults to disabled (0)
+- `test/propagate/BiasRegularisation.ts` — 8 tests covering:
+  - L2 bias decay for positive/negative biases
+  - L1 bias decay drives small biases to zero
+  - L1 snap-to-zero behaviour
+  - Elastic net for biases
+  - Defaults to disabled (0)

--- a/src/propagate/BackPropagation.ts
+++ b/src/propagate/BackPropagation.ts
@@ -79,6 +79,34 @@ export type BackPropagationArguments = {
    * Set to 1.0 to disable coordination (all changes pass through).
    */
   biasWeightCoordinationFactor: number;
+
+  /**
+   * Issue #1859: L1 weight regularisation strength (weight sparsity).
+   * Adds a penalty proportional to |w| that drives small weights to zero.
+   * 0 = disabled (default), higher values = stronger sparsity pressure.
+   */
+  l1WeightDecay: number;
+
+  /**
+   * Issue #1859: L2 weight regularisation strength (weight decay).
+   * Adds a penalty proportional to w² that shrinks all weights toward zero.
+   * 0 = disabled (default), higher values = stronger decay.
+   */
+  l2WeightDecay: number;
+
+  /**
+   * Issue #1859: L1 bias regularisation strength (bias sparsity).
+   * Adds a penalty proportional to |b| that drives small biases to zero.
+   * 0 = disabled (default), higher values = stronger sparsity pressure.
+   */
+  l1BiasDecay: number;
+
+  /**
+   * Issue #1859: L2 bias regularisation strength (bias decay).
+   * Adds a penalty proportional to b² that shrinks all biases toward zero.
+   * 0 = disabled (default), higher values = stronger decay.
+   */
+  l2BiasDecay: number;
 };
 
 export type BackPropagationOptions = Partial<BackPropagationArguments>;
@@ -168,6 +196,22 @@ export function createBackPropagationConfig(
         options?.biasWeightCoordinationFactor ?? 0.2,
         0,
       ),
+      1,
+    ),
+    l1WeightDecay: Math.min(
+      Math.max(options?.l1WeightDecay ?? 0, 0),
+      1,
+    ),
+    l2WeightDecay: Math.min(
+      Math.max(options?.l2WeightDecay ?? 0, 0),
+      1,
+    ),
+    l1BiasDecay: Math.min(
+      Math.max(options?.l1BiasDecay ?? 0, 0),
+      1,
+    ),
+    l2BiasDecay: Math.min(
+      Math.max(options?.l2BiasDecay ?? 0, 0),
       1,
     ),
   };

--- a/src/propagate/Bias.ts
+++ b/src/propagate/Bias.ts
@@ -132,11 +132,11 @@ export function limitBias(
   }
 
   if (Math.abs(targetBias) < config.plankConstant) {
-    return 0;
+    return applyBiasRegularisation(0, config);
   }
 
   if (Math.abs(targetBias - currentBias) < 0.000_000_001) {
-    return currentBias;
+    return applyBiasRegularisation(currentBias, config);
   }
 
   const difference = config.learningRate * (targetBias - currentBias);
@@ -159,7 +159,38 @@ export function limitBias(
     }
   }
 
-  return limitedBias;
+  return applyBiasRegularisation(limitedBias, config);
+}
+
+/**
+ * Issue #1859: Apply L1/L2 bias regularisation (bias decay).
+ *
+ * L2 shrinks biases proportionally to their magnitude: b *= (1 - lr * λ₂)
+ * L1 applies soft-thresholding to drive small biases to zero:
+ *   b -= lr * λ₁ * sign(b), snapping to zero if the penalty exceeds |b|.
+ */
+function applyBiasRegularisation(
+  bias: number,
+  config: BackPropagationConfig,
+): number {
+  let result = bias;
+
+  // L2 regularisation (bias decay)
+  if (config.l2BiasDecay > 0) {
+    result *= 1 - config.learningRate * config.l2BiasDecay;
+  }
+
+  // L1 regularisation (sparsity via soft-thresholding)
+  if (config.l1BiasDecay > 0 && result !== 0) {
+    const l1Penalty = config.learningRate * config.l1BiasDecay;
+    if (l1Penalty >= Math.abs(result)) {
+      result = 0;
+    } else {
+      result -= l1Penalty * Math.sign(result);
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/src/propagate/Weight.ts
+++ b/src/propagate/Weight.ts
@@ -177,11 +177,11 @@ export function limitWeight(
 
   // Prevent exceedingly small weights.
   if (Math.abs(targetWeight) < config.plankConstant) {
-    return 0;
+    return applyWeightRegularisation(0, config);
   }
 
   if (Math.abs(targetWeight - currentWeight) < config.plankConstant) {
-    return currentWeight;
+    return applyWeightRegularisation(currentWeight, config);
   }
 
   // Calculate and apply the difference with learning rate.
@@ -199,7 +199,38 @@ export function limitWeight(
     limitedWeight = Math.sign(limitedWeight) * config.limitWeightScale;
   }
 
-  return limitedWeight;
+  return applyWeightRegularisation(limitedWeight, config);
+}
+
+/**
+ * Issue #1859: Apply L1/L2 weight regularisation (weight decay).
+ *
+ * L2 shrinks weights proportionally to their magnitude: w *= (1 - lr * λ₂)
+ * L1 applies soft-thresholding to drive small weights to zero:
+ *   w -= lr * λ₁ * sign(w), snapping to zero if the penalty exceeds |w|.
+ */
+function applyWeightRegularisation(
+  weight: number,
+  config: BackPropagationConfig,
+): number {
+  let result = weight;
+
+  // L2 regularisation (weight decay)
+  if (config.l2WeightDecay > 0) {
+    result *= 1 - config.learningRate * config.l2WeightDecay;
+  }
+
+  // L1 regularisation (sparsity via soft-thresholding)
+  if (config.l1WeightDecay > 0 && result !== 0) {
+    const l1Penalty = config.learningRate * config.l1WeightDecay;
+    if (l1Penalty >= Math.abs(result)) {
+      result = 0;
+    } else {
+      result -= l1Penalty * Math.sign(result);
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/test/propagate/BiasRegularisation.ts
+++ b/test/propagate/BiasRegularisation.ts
@@ -1,0 +1,137 @@
+/**
+ * Issue #1859 - L1/L2 bias regularisation during backpropagation.
+ *
+ * Tests that L1 and L2 bias decay penalties are correctly applied
+ * during backpropagation bias updates.
+ */
+import { assertAlmostEquals, assertLess } from "@std/assert";
+import { limitBias } from "../../src/propagate/Bias.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+
+function makeConfig(
+  overrides?: Record<string, unknown>,
+) {
+  return createBackPropagationConfig({
+    disableRandomSamples: true,
+    learningRate: 0.1,
+    generations: 1,
+    maximumBiasAdjustmentScale: 10,
+    limitBiasScale: 10_000,
+    plankConstant: 1e-7,
+    batchSize: 1,
+    learningRateStrategy: "fixed",
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// L2 bias regularisation (bias decay)
+// ---------------------------------------------------------------------------
+
+Deno.test("L2 bias decay reduces positive bias magnitude", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l2BiasDecay: 0.1,
+  });
+  const currentBias = 5.0;
+  const result = limitBias(currentBias, currentBias, config);
+  assertLess(Math.abs(result), Math.abs(currentBias));
+});
+
+Deno.test("L2 bias decay reduces negative bias magnitude", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l2BiasDecay: 0.1,
+  });
+  const currentBias = -5.0;
+  const result = limitBias(currentBias, currentBias, config);
+  assertLess(Math.abs(result), Math.abs(currentBias));
+});
+
+Deno.test("L2 bias decay is zero when l2BiasDecay is 0", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l2BiasDecay: 0,
+  });
+  const currentBias = 5.0;
+  const result = limitBias(currentBias, currentBias, config);
+  assertAlmostEquals(result, currentBias, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// L1 bias regularisation (sparsity)
+// ---------------------------------------------------------------------------
+
+Deno.test("L1 bias decay drives small positive biases toward zero", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l1BiasDecay: 0.1,
+  });
+  const currentBias = 0.05;
+  const result = limitBias(currentBias, currentBias, config);
+  assertLess(Math.abs(result), Math.abs(currentBias));
+});
+
+Deno.test("L1 bias decay snaps to zero when penalty exceeds bias", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l1BiasDecay: 0.5,
+  });
+  const currentBias = 0.01;
+  const result = limitBias(currentBias, currentBias, config);
+  assertAlmostEquals(result, 0, 1e-9);
+});
+
+Deno.test("L1 bias decay is zero when l1BiasDecay is 0", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l1BiasDecay: 0,
+  });
+  const currentBias = 5.0;
+  const result = limitBias(currentBias, currentBias, config);
+  assertAlmostEquals(result, currentBias, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// Combined L1 + L2 for bias
+// ---------------------------------------------------------------------------
+
+Deno.test("Elastic net bias decay combines L1 and L2 penalties", () => {
+  const l2Only = makeConfig({
+    learningRate: 1,
+    l1BiasDecay: 0,
+    l2BiasDecay: 0.1,
+  });
+  const l1Only = makeConfig({
+    learningRate: 1,
+    l1BiasDecay: 0.1,
+    l2BiasDecay: 0,
+  });
+  const elastic = makeConfig({
+    learningRate: 1,
+    l1BiasDecay: 0.1,
+    l2BiasDecay: 0.1,
+  });
+
+  const currentBias = 5.0;
+  const l2Result = limitBias(currentBias, currentBias, l2Only);
+  const l1Result = limitBias(currentBias, currentBias, l1Only);
+  const elasticResult = limitBias(currentBias, currentBias, elastic);
+
+  assertLess(Math.abs(elasticResult), Math.abs(l2Result));
+  assertLess(Math.abs(elasticResult), Math.abs(l1Result));
+});
+
+// ---------------------------------------------------------------------------
+// Defaults (disabled)
+// ---------------------------------------------------------------------------
+
+Deno.test("L1/L2 bias decay defaults to 0 (disabled)", () => {
+  const config = createBackPropagationConfig({
+    learningRate: 1,
+    learningRateStrategy: "fixed",
+  });
+  const currentBias = 5.0;
+  const result = limitBias(currentBias, currentBias, config);
+  assertAlmostEquals(result, currentBias, 1e-9);
+});

--- a/test/propagate/WeightRegularisation.ts
+++ b/test/propagate/WeightRegularisation.ts
@@ -1,0 +1,268 @@
+/**
+ * Issue #1859 - L1/L2 weight regularisation during backpropagation.
+ *
+ * Tests that L1 and L2 weight decay penalties are correctly applied
+ * during backpropagation weight updates.
+ */
+import { assertAlmostEquals, assertGreater, assertLess } from "@std/assert";
+import { limitWeight } from "../../src/propagate/Weight.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+
+function makeConfig(
+  overrides?: Record<string, unknown>,
+) {
+  return createBackPropagationConfig({
+    disableRandomSamples: true,
+    learningRate: 0.1,
+    generations: 1,
+    maximumWeightAdjustmentScale: 10,
+    limitWeightScale: 100_000,
+    plankConstant: 1e-7,
+    batchSize: 1,
+    learningRateStrategy: "fixed",
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// L2 weight regularisation (weight decay)
+// ---------------------------------------------------------------------------
+
+Deno.test("L2 weight decay reduces positive weight magnitude", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l2WeightDecay: 0.1,
+  });
+  // Target equals current, so no gradient update. Only L2 decay applies.
+  const currentWeight = 5.0;
+  const result = limitWeight(currentWeight, currentWeight, config);
+  // L2 decay: w *= (1 - lr * lambda) = 5 * (1 - 1 * 0.1) = 4.5
+  assertLess(Math.abs(result), Math.abs(currentWeight));
+});
+
+Deno.test("L2 weight decay reduces negative weight magnitude", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l2WeightDecay: 0.1,
+  });
+  const currentWeight = -5.0;
+  const result = limitWeight(currentWeight, currentWeight, config);
+  // Magnitude should decrease
+  assertLess(Math.abs(result), Math.abs(currentWeight));
+});
+
+Deno.test("L2 weight decay strength controls decay rate", () => {
+  const weakConfig = makeConfig({
+    learningRate: 1,
+    l2WeightDecay: 0.01,
+  });
+  const strongConfig = makeConfig({
+    learningRate: 1,
+    l2WeightDecay: 0.5,
+  });
+  const currentWeight = 10.0;
+
+  const weakResult = limitWeight(currentWeight, currentWeight, weakConfig);
+  const strongResult = limitWeight(currentWeight, currentWeight, strongConfig);
+
+  // Stronger decay should result in smaller weight
+  assertLess(Math.abs(strongResult), Math.abs(weakResult));
+});
+
+Deno.test("L2 weight decay is zero when l2WeightDecay is 0", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l2WeightDecay: 0,
+  });
+  const currentWeight = 5.0;
+  // Target = current so no gradient. With L2=0, weight should stay the same.
+  const result = limitWeight(currentWeight, currentWeight, config);
+  assertAlmostEquals(result, currentWeight, 1e-9);
+});
+
+Deno.test("L2 weight decay works alongside gradient updates", () => {
+  const configNoDecay = makeConfig({
+    learningRate: 0.1,
+    l2WeightDecay: 0,
+  });
+  const configWithDecay = makeConfig({
+    learningRate: 0.1,
+    l2WeightDecay: 0.1,
+  });
+  const currentWeight = 5.0;
+  const targetWeight = 6.0;
+
+  const resultNoDecay = limitWeight(targetWeight, currentWeight, configNoDecay);
+  const resultWithDecay = limitWeight(
+    targetWeight,
+    currentWeight,
+    configWithDecay,
+  );
+
+  // With L2 decay, the result should be smaller than without
+  assertLess(resultWithDecay, resultNoDecay);
+});
+
+// ---------------------------------------------------------------------------
+// L1 weight regularisation (sparsity)
+// ---------------------------------------------------------------------------
+
+Deno.test("L1 weight decay drives small positive weights toward zero", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0.1,
+  });
+  // Small positive weight with no gradient update
+  const currentWeight = 0.05;
+  const result = limitWeight(currentWeight, currentWeight, config);
+  // L1 should push toward zero: w - lr * lambda * sign(w)
+  assertLess(Math.abs(result), Math.abs(currentWeight));
+});
+
+Deno.test("L1 weight decay drives small negative weights toward zero", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0.1,
+  });
+  const currentWeight = -0.05;
+  const result = limitWeight(currentWeight, currentWeight, config);
+  assertLess(Math.abs(result), Math.abs(currentWeight));
+});
+
+Deno.test("L1 weight decay snaps to zero when penalty exceeds weight", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0.5,
+  });
+  // Weight is very small, L1 penalty (0.5) exceeds it
+  const currentWeight = 0.01;
+  const result = limitWeight(currentWeight, currentWeight, config);
+  // Should snap to zero rather than crossing it
+  assertAlmostEquals(result, 0, 1e-9);
+});
+
+Deno.test("L1 weight decay strength controls sparsity pressure", () => {
+  const weakConfig = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0.01,
+  });
+  const strongConfig = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0.5,
+  });
+  const currentWeight = 5.0;
+
+  const weakResult = limitWeight(currentWeight, currentWeight, weakConfig);
+  const strongResult = limitWeight(currentWeight, currentWeight, strongConfig);
+
+  // Stronger L1 should result in smaller weight
+  assertLess(Math.abs(strongResult), Math.abs(weakResult));
+});
+
+Deno.test("L1 weight decay is zero when l1WeightDecay is 0", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0,
+  });
+  const currentWeight = 5.0;
+  const result = limitWeight(currentWeight, currentWeight, config);
+  assertAlmostEquals(result, currentWeight, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// Combined L1 + L2 (elastic net)
+// ---------------------------------------------------------------------------
+
+Deno.test("Elastic net combines L1 and L2 penalties", () => {
+  const l2Only = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0,
+    l2WeightDecay: 0.1,
+  });
+  const l1Only = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0.1,
+    l2WeightDecay: 0,
+  });
+  const elastic = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0.1,
+    l2WeightDecay: 0.1,
+  });
+
+  const currentWeight = 5.0;
+  const l2Result = limitWeight(currentWeight, currentWeight, l2Only);
+  const l1Result = limitWeight(currentWeight, currentWeight, l1Only);
+  const elasticResult = limitWeight(currentWeight, currentWeight, elastic);
+
+  // Elastic net should be more aggressive than either alone
+  assertLess(Math.abs(elasticResult), Math.abs(l2Result));
+  assertLess(Math.abs(elasticResult), Math.abs(l1Result));
+});
+
+// ---------------------------------------------------------------------------
+// Regularisation over multiple iterations reduces weight magnitudes
+// ---------------------------------------------------------------------------
+
+Deno.test("L2 weight decay progressively reduces weights over iterations", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l2WeightDecay: 0.1,
+  });
+
+  let weight = 10.0;
+  for (let i = 0; i < 10; i++) {
+    weight = limitWeight(weight, weight, config);
+  }
+
+  // After 10 iterations of decay, weight should be significantly reduced
+  assertLess(Math.abs(weight), 5.0);
+  assertGreater(Math.abs(weight), 0);
+});
+
+Deno.test("L1 weight decay progressively drives weights toward zero", () => {
+  const config = makeConfig({
+    learningRate: 1,
+    l1WeightDecay: 0.1,
+  });
+
+  let weight = 1.0;
+  for (let i = 0; i < 20; i++) {
+    weight = limitWeight(weight, weight, config);
+  }
+
+  // After many iterations, weight should be at or very near zero
+  assertAlmostEquals(weight, 0, 0.01);
+});
+
+// ---------------------------------------------------------------------------
+// Integration with sparse training (sparseRatio)
+// ---------------------------------------------------------------------------
+
+Deno.test("Weight regularisation config works with sparseRatio", () => {
+  // Verify that sparseRatio and regularisation can coexist in config
+  const config = makeConfig({
+    sparseRatio: 0.5,
+    l1WeightDecay: 0.01,
+    l2WeightDecay: 0.01,
+  });
+  const currentWeight = 5.0;
+  const result = limitWeight(currentWeight, currentWeight, config);
+  // Regularisation should still apply regardless of sparseRatio
+  assertLess(Math.abs(result), Math.abs(currentWeight));
+});
+
+// ---------------------------------------------------------------------------
+// Default values (disabled by default)
+// ---------------------------------------------------------------------------
+
+Deno.test("L1/L2 weight decay defaults to 0 (disabled)", () => {
+  const config = createBackPropagationConfig({
+    learningRate: 1,
+    learningRateStrategy: "fixed",
+  });
+  const currentWeight = 5.0;
+  const result = limitWeight(currentWeight, currentWeight, config);
+  // With defaults (0), no decay should be applied
+  assertAlmostEquals(result, currentWeight, 1e-9);
+});


### PR DESCRIPTION
## Summary

Add L1/L2 weight and bias regularisation (weight decay) during backpropagation.
Closes #1859.

Four new configurable parameters are added to `BackPropagationArguments`:

- `l1WeightDecay` / `l2WeightDecay` — L1 (sparsity) and L2 (decay) penalties for
  synapse weights
- `l1BiasDecay` / `l2BiasDecay` — L1 (sparsity) and L2 (decay) penalties for
  neuron biases

All default to 0 (disabled), preserving backward compatibility. When enabled:

- **L2** shrinks weights/biases proportionally to magnitude: `w *= (1 - lr * λ)`
- **L1** applies soft-thresholding, driving small values to zero and snapping to
  zero when the penalty exceeds the magnitude

Regularisation is applied via extracted helper functions
(`applyWeightRegularisation`, `applyBiasRegularisation`) on all return paths of
`limitWeight()` and `limitBias()`, ensuring it works both with and without
gradient updates, and integrates cleanly with sparse training (`sparseRatio`).

## Evidence

- 15 weight regularisation tests and 8 bias regularisation tests all pass
- Existing 4516 tests continue to pass with no regressions
- Quality gate (`./quality.sh`) passes cleanly

## Test Plan

- `test/propagate/WeightRegularisation.ts` — 15 tests covering:
  - L2 weight decay reduces positive/negative weight magnitudes
  - L2 strength controls decay rate
  - L2 disabled when strength is 0
  - L2 works alongside gradient updates
  - L1 drives small weights toward zero
  - L1 snaps to zero when penalty exceeds weight
  - L1 strength controls sparsity pressure
  - Elastic net (L1+L2) combines penalties
  - Progressive reduction over multiple iterations
  - Integration with sparseRatio
  - Defaults to disabled (0)
- `test/propagate/BiasRegularisation.ts` — 8 tests covering:
  - L2 bias decay for positive/negative biases
  - L1 bias decay drives small biases to zero
  - L1 snap-to-zero behaviour
  - Elastic net for biases
  - Defaults to disabled (0)

---

## Automated Fix Details
This PR addresses issue #1859: **Enhancement: Add L1/L2 weight regularisation support**

## Milestone
This PR is part of the **weaknesses** milestone and targets the `milestone/weaknesses` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1859
---

🤖 Processed by: stservice