### PR TITLE
Enhancement: Implement true dropout regularisation (#1860)

### DIFF
--- a/docs/pr-summary-1860.md
+++ b/docs/pr-summary-1860.md
@@ -1,0 +1,55 @@
+## Summary
+
+Implements true dropout regularisation during training. During training, a
+configurable fraction of hidden neurons are randomly disabled (activations
+set to zero) and remaining activations are scaled by 1/(1-p) using inverted
+dropout. During inference, all neurons are active and no adjustment is
+needed. Closes #1860.
+
+### What was done
+
+1. **Forward-pass dropout** — After the WASM forward pass during training,
+   hidden neuron activations are randomly zeroed according to the configured
+   `dropoutRate`. This prevents co-adaptation of neurons and provides
+   regularisation against overfitting.
+
+2. **Inverted dropout** — Remaining (kept) activations are scaled by
+   `1/(1-dropoutRate)` during training so that expected activation magnitudes
+   remain consistent with inference, where all neurons are active.
+
+3. **Configuration** — Added a `dropoutRate` parameter (0.0 to 1.0) to
+   `BackPropagationArguments` (and therefore `TrainOptions`). Default is 0.0
+   (disabled) for backward compatibility.
+
+4. **Interaction with sparse training** — Dropout and `sparseRatio` coexist
+   independently. Dropout provides regularisation (prevents overfitting) while
+   sparse training provides efficiency (selects which neurons to update).
+
+### Files changed
+
+- `src/propagate/Dropout.ts` — New file implementing `applyDropout()` with
+  inverted dropout scaling
+- `src/propagate/BackPropagation.ts` — Added `dropoutRate` field to
+  `BackPropagationArguments` with default 0
+- `src/architecture/Training.ts` — Integrated dropout call in training loop
+  after `activateAndTrace` and before `propagate`
+- `test/propagate/DropoutRegularisation.ts` — 13 tests covering config,
+  unit behaviour, and training integration
+
+## Evidence
+
+All 4529 tests pass including 13 new dropout-specific tests.
+
+## Test Plan
+
+- **Config tests**: Verify default (0), clamping (negative/over), and
+  preservation of valid values
+- **Unit tests**: Verify `applyDropout()` zeroes hidden neurons, scales kept
+  neurons by 1/(1-p), and leaves input/output neurons untouched
+- **Boundary tests**: Rate 0 and rate 1 are no-ops
+- **Integration tests**: Training with dropout completes without errors and
+  produces valid finite outputs at inference
+- **Inference determinism**: After training with dropout, inference produces
+  identical results on repeated calls (no dropout applied)
+- **Coexistence**: Dropout config works alongside `sparseRatio` and L1/L2
+  weight regularisation

--- a/docs/pr-summary-1860.md
+++ b/docs/pr-summary-1860.md
@@ -1,10 +1,10 @@
 ## Summary
 
 Implements true dropout regularisation during training. During training, a
-configurable fraction of hidden neurons are randomly disabled (activations
-set to zero) and remaining activations are scaled by 1/(1-p) using inverted
-dropout. During inference, all neurons are active and no adjustment is
-needed. Closes #1860.
+configurable fraction of hidden neurons are randomly disabled (activations set
+to zero) and remaining activations are scaled by 1/(1-p) using inverted dropout.
+During inference, all neurons are active and no adjustment is needed. Closes
+#1860.
 
 ### What was done
 
@@ -33,8 +33,8 @@ needed. Closes #1860.
   `BackPropagationArguments` with default 0
 - `src/architecture/Training.ts` — Integrated dropout call in training loop
   after `activateAndTrace` and before `propagate`
-- `test/propagate/DropoutRegularisation.ts` — 13 tests covering config,
-  unit behaviour, and training integration
+- `test/propagate/DropoutRegularisation.ts` — 13 tests covering config, unit
+  behaviour, and training integration
 
 ## Evidence
 
@@ -51,5 +51,5 @@ All 4529 tests pass including 13 new dropout-specific tests.
   produces valid finite outputs at inference
 - **Inference determinism**: After training with dropout, inference produces
   identical results on repeated calls (no dropout applied)
-- **Coexistence**: Dropout config works alongside `sparseRatio` and L1/L2
-  weight regularisation
+- **Coexistence**: Dropout config works alongside `sparseRatio` and L1/L2 weight
+  regularisation

--- a/src/architecture/Training.ts
+++ b/src/architecture/Training.ts
@@ -22,6 +22,7 @@ import type { CreatureExport, CreatureTrace } from "./CreatureInterfaces.ts";
 import { CreatureUtil } from "./CreatureUtils.ts";
 import { trainWithPredictiveCoding } from "../predictiveCoding/PredictiveCodingTrainer.ts";
 import { DEFAULT_PREDICTIVE_CODING_CONFIG } from "../config/PredictiveCodingConfig.ts";
+import { applyDropout } from "../propagate/Dropout.ts";
 
 /**
  * Scans a data directory for binary training files.
@@ -365,6 +366,17 @@ function trainDirBinary(
             feedbackLoop,
             sparseConfig,
           );
+
+          // Issue #1860: Apply inverted dropout to hidden neuron activations
+          // during training. Dropout randomly disables neurons to prevent
+          // co-adaptation, providing regularisation against overfitting.
+          if (iterationConfig.dropoutRate > 0) {
+            applyDropout(
+              creature,
+              iterationConfig.dropoutRate,
+              getRandomNumberGenerator(),
+            );
+          }
 
           const sampleError = cost.calculate(
             targetsBuffer,

--- a/src/propagate/BackPropagation.ts
+++ b/src/propagate/BackPropagation.ts
@@ -107,6 +107,15 @@ export type BackPropagationArguments = {
    * 0 = disabled (default), higher values = stronger decay.
    */
   l2BiasDecay: number;
+
+  /**
+   * Issue #1860: Dropout regularisation rate (0.0 to 1.0).
+   * During training, this fraction of hidden neurons are randomly disabled
+   * (activations set to zero) with inverted scaling applied to the rest.
+   * During inference, all neurons are active and no dropout is applied.
+   * 0 = disabled (default), typical values 0.1 to 0.5.
+   */
+  dropoutRate: number;
 };
 
 export type BackPropagationOptions = Partial<BackPropagationArguments>;
@@ -212,6 +221,10 @@ export function createBackPropagationConfig(
     ),
     l2BiasDecay: Math.min(
       Math.max(options?.l2BiasDecay ?? 0, 0),
+      1,
+    ),
+    dropoutRate: Math.min(
+      Math.max(options?.dropoutRate ?? 0, 0),
       1,
     ),
   };

--- a/src/propagate/Dropout.ts
+++ b/src/propagate/Dropout.ts
@@ -1,0 +1,62 @@
+/**
+ * Dropout.ts - Inverted dropout regularisation for training.
+ *
+ * Issue #1860: Implements true dropout regularisation during the forward pass.
+ * During training, a configurable fraction of hidden neurons are randomly
+ * disabled (their activations set to zero) and remaining activations are
+ * scaled by 1/(1-p) (inverted dropout). During inference, all neurons are
+ * active and no scaling is needed.
+ *
+ * Reference: Srivastava et al. (2014), "Dropout: A Simple Way to Prevent
+ * Neural Networks from Overfitting", https://arxiv.org/abs/1207.0580
+ */
+
+import type { Creature } from "../Creature.ts";
+import type { RandomNumberGenerator } from "../utils/RandomNumberGenerator.ts";
+
+/**
+ * Apply inverted dropout to hidden neuron activations during training.
+ *
+ * For each hidden neuron, with probability `dropoutRate`, the activation
+ * is set to zero. Remaining activations are scaled by `1 / (1 - dropoutRate)`
+ * so that expected activation magnitudes remain consistent with inference
+ * (where all neurons are active without scaling).
+ *
+ * Input and output neurons are never dropped.
+ *
+ * @param creature - The creature whose activations will be modified in place
+ * @param dropoutRate - Probability of disabling each hidden neuron (0.0 to 1.0)
+ * @param rng - Random number generator for reproducibility
+ * @returns The number of neurons that were dropped out
+ */
+export function applyDropout(
+  creature: Creature,
+  dropoutRate: number,
+  rng: RandomNumberGenerator,
+): number {
+  if (dropoutRate <= 0 || dropoutRate >= 1) {
+    return 0;
+  }
+
+  const neurons = creature.neurons;
+  const inputCount = creature.input;
+  const outputCount = creature.output;
+  const hiddenStart = inputCount;
+  const hiddenEnd = neurons.length - outputCount;
+  const activations = creature.state.activations;
+  const scale = 1 / (1 - dropoutRate);
+  let droppedCount = 0;
+
+  for (let i = hiddenStart; i < hiddenEnd; i++) {
+    if (rng.random() < dropoutRate) {
+      // Drop this neuron: set activation to zero
+      activations[i] = 0;
+      droppedCount++;
+    } else {
+      // Keep this neuron: scale activation by 1/(1-p)
+      activations[i] *= scale;
+    }
+  }
+
+  return droppedCount;
+}

--- a/test/propagate/DropoutRegularisation.ts
+++ b/test/propagate/DropoutRegularisation.ts
@@ -1,0 +1,338 @@
+/**
+ * Issue #1860 - True dropout regularisation during training.
+ *
+ * Tests that inverted dropout is correctly applied to hidden neuron
+ * activations during training, and that inference uses all neurons.
+ */
+import {
+  assert,
+  assertAlmostEquals,
+  assertEquals,
+  assertGreater,
+  assertLess,
+} from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import type { DataRecordInterface } from "../../src/architecture/DataSet.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+import { applyDropout } from "../../src/propagate/Dropout.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+import { train } from "../TrainTestOnlyUtil.ts";
+import {
+  createSeededRng,
+  setRandomNumberGenerator,
+} from "../../src/utils/RandomNumberGenerator.ts";
+
+await initWasmForTests();
+
+/**
+ * Helper: create a creature and populate its state.activations manually
+ * so that applyDropout can be tested in isolation.
+ */
+function makeCreatureWithActivations(
+  inputCount: number,
+  hiddenCount: number,
+  outputCount: number,
+): Creature {
+  const creature = new Creature(inputCount, outputCount, {
+    layers: [{ count: hiddenCount }],
+  });
+
+  // Manually initialise the activations array with known values
+  const totalNeurons = creature.neurons.length;
+  creature.state.makeActivation(
+    new Float32Array(inputCount).fill(1),
+    false,
+  );
+
+  // Set hidden neuron activations to non-zero values
+  for (let i = inputCount; i < totalNeurons - outputCount; i++) {
+    creature.state.activations[i] = 0.5 + i * 0.1;
+  }
+  // Set output neuron activations
+  for (let i = totalNeurons - outputCount; i < totalNeurons; i++) {
+    creature.state.activations[i] = 0.8;
+  }
+
+  return creature;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration defaults
+// ---------------------------------------------------------------------------
+
+Deno.test("Dropout rate defaults to 0 (disabled)", () => {
+  const config = createBackPropagationConfig({
+    learningRate: 0.1,
+    learningRateStrategy: "fixed",
+  });
+  assertEquals(config.dropoutRate, 0);
+});
+
+Deno.test("Dropout rate is clamped between 0 and 1", () => {
+  const negativeConfig = createBackPropagationConfig({
+    dropoutRate: -0.5,
+  });
+  assertEquals(negativeConfig.dropoutRate, 0);
+
+  const overConfig = createBackPropagationConfig({
+    dropoutRate: 1.5,
+  });
+  assertEquals(overConfig.dropoutRate, 1);
+});
+
+Deno.test("Dropout rate of 0.5 is preserved in config", () => {
+  const config = createBackPropagationConfig({
+    dropoutRate: 0.5,
+  });
+  assertAlmostEquals(config.dropoutRate, 0.5, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// applyDropout unit tests
+// ---------------------------------------------------------------------------
+
+Deno.test("applyDropout with rate 0 does not change activations", () => {
+  const rng = createSeededRng(42);
+  const creature = makeCreatureWithActivations(2, 4, 1);
+
+  const before = Float32Array.from(creature.state.activations);
+  const dropped = applyDropout(creature, 0, rng);
+  assertEquals(dropped, 0);
+
+  for (let i = 0; i < before.length; i++) {
+    assertAlmostEquals(creature.state.activations[i], before[i], 1e-6);
+  }
+});
+
+Deno.test("applyDropout with rate 1 is a no-op (boundary)", () => {
+  const rng = createSeededRng(42);
+  const creature = makeCreatureWithActivations(2, 4, 1);
+
+  const before = Float32Array.from(creature.state.activations);
+  const dropped = applyDropout(creature, 1.0, rng);
+  assertEquals(dropped, 0);
+
+  for (let i = 0; i < before.length; i++) {
+    assertAlmostEquals(creature.state.activations[i], before[i], 1e-6);
+  }
+});
+
+Deno.test("applyDropout zeroes some hidden neurons with rate 0.5", () => {
+  const rng = createSeededRng(42);
+  const creature = makeCreatureWithActivations(2, 10, 1);
+
+  const inputCount = creature.input;
+  const outputCount = creature.output;
+  const hiddenEnd = creature.neurons.length - outputCount;
+
+  const dropped = applyDropout(creature, 0.5, rng);
+
+  // With 10 hidden neurons and rate 0.5, expect some dropped
+  assertGreater(dropped, 0);
+  assertLess(dropped, 10);
+
+  // Check that dropped neurons have activation 0
+  let zeroCount = 0;
+  for (let i = inputCount; i < hiddenEnd; i++) {
+    if (creature.state.activations[i] === 0) {
+      zeroCount++;
+    }
+  }
+  assertEquals(zeroCount, dropped);
+});
+
+Deno.test("applyDropout applies inverted scaling to kept neurons", () => {
+  const rng = createSeededRng(123);
+  const creature = makeCreatureWithActivations(2, 20, 1);
+
+  const inputCount = creature.input;
+  const outputCount = creature.output;
+  const hiddenEnd = creature.neurons.length - outputCount;
+  const dropoutRate = 0.3;
+  const scale = 1 / (1 - dropoutRate);
+
+  const originalActivations = Float32Array.from(creature.state.activations);
+
+  applyDropout(creature, dropoutRate, rng);
+
+  // For kept neurons, activation should be original * scale
+  let keptCount = 0;
+  for (let i = inputCount; i < hiddenEnd; i++) {
+    const current = creature.state.activations[i];
+    if (current !== 0) {
+      const expected = originalActivations[i] * scale;
+      assertAlmostEquals(current, expected, 1e-5);
+      keptCount++;
+    }
+  }
+  // At least some should be kept
+  assertGreater(keptCount, 0);
+});
+
+Deno.test("applyDropout does not modify input neurons", () => {
+  const rng = createSeededRng(42);
+  const creature = makeCreatureWithActivations(3, 5, 1);
+
+  const inputBefore = Float32Array.from(
+    creature.state.activations.subarray(0, creature.input),
+  );
+
+  applyDropout(creature, 0.5, rng);
+
+  for (let i = 0; i < creature.input; i++) {
+    assertAlmostEquals(
+      creature.state.activations[i],
+      inputBefore[i],
+      1e-6,
+    );
+  }
+});
+
+Deno.test("applyDropout does not modify output neurons", () => {
+  const rng = createSeededRng(42);
+  const creature = makeCreatureWithActivations(2, 5, 2);
+
+  const outputStart = creature.neurons.length - creature.output;
+  const outputBefore = Float32Array.from(
+    creature.state.activations.subarray(outputStart),
+  );
+
+  applyDropout(creature, 0.5, rng);
+
+  for (let i = 0; i < creature.output; i++) {
+    assertAlmostEquals(
+      creature.state.activations[outputStart + i],
+      outputBefore[i],
+      1e-6,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Inference uses all neurons (no dropout)
+// ---------------------------------------------------------------------------
+
+Deno.test("Inference produces deterministic results without dropout", () => {
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 5 }],
+  });
+
+  const input = new Float32Array([0.7, 0.3]);
+
+  // Multiple activations should produce the same result (no dropout)
+  const result1 = creature.activate(input);
+  const result2 = creature.activate(input);
+
+  assertAlmostEquals(result1[0], result2[0], 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// Dropout config coexists with sparseRatio and L1/L2
+// ---------------------------------------------------------------------------
+
+Deno.test("Dropout config coexists with sparseRatio and L1/L2", () => {
+  const config = createBackPropagationConfig({
+    sparseRatio: 0.5,
+    l1WeightDecay: 0.01,
+    l2WeightDecay: 0.01,
+    dropoutRate: 0.3,
+  });
+
+  assertAlmostEquals(config.sparseRatio, 0.5, 1e-9);
+  assertAlmostEquals(config.l1WeightDecay, 0.01, 1e-9);
+  assertAlmostEquals(config.l2WeightDecay, 0.01, 1e-9);
+  assertAlmostEquals(config.dropoutRate, 0.3, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// Training integration: dropout completes without errors
+// ---------------------------------------------------------------------------
+
+Deno.test("Dropout training completes and produces valid outputs", () => {
+  const rng = createSeededRng(42);
+  setRandomNumberGenerator(rng);
+
+  const dataSet: DataRecordInterface[] = [];
+  const noiseRng = createSeededRng(99);
+
+  // XOR-like patterns with noise to encourage overfitting
+  const patterns = [
+    { input: [0, 0], output: [0] },
+    { input: [0, 1], output: [1] },
+    { input: [1, 0], output: [1] },
+    { input: [1, 1], output: [0] },
+  ];
+
+  for (let repeat = 0; repeat < 5; repeat++) {
+    for (const p of patterns) {
+      const noise = (noiseRng.random() - 0.5) * 0.1;
+      dataSet.push({
+        input: new Float32Array(
+          p.input.map((v) => v + (noiseRng.random() - 0.5) * 0.05),
+        ),
+        output: new Float32Array([
+          Math.max(0, Math.min(1, p.output[0] + noise)),
+        ]),
+      });
+    }
+  }
+
+  // Train WITH dropout
+  const creatureDropout = new Creature(2, 1, {
+    layers: [{ count: 8 }],
+  });
+
+  const dropoutResult = train(creatureDropout, dataSet, {
+    iterations: 10,
+    targetError: 0.001,
+    learningRate: 0.1,
+    learningRateStrategy: "fixed",
+    disableRandomSamples: true,
+    dropoutRate: 0.3,
+  });
+
+  // Should complete training (not crash) and produce finite error
+  assert(Number.isFinite(dropoutResult.error));
+
+  // Verify inference produces valid outputs after training with dropout
+  for (const p of patterns) {
+    const input = new Float32Array(p.input);
+    const output = creatureDropout.activate(input);
+    assert(Number.isFinite(output[0]), "Dropout creature output is not finite");
+  }
+});
+
+Deno.test(
+  "Inference uses all neurons regardless of training dropout setting",
+  () => {
+    const rng = createSeededRng(42);
+    setRandomNumberGenerator(rng);
+
+    const creature = new Creature(2, 1, {
+      layers: [{ count: 6 }],
+    });
+
+    const dataSet: DataRecordInterface[] = [
+      { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+      { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+      { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+      { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+    ];
+
+    train(creature, dataSet, {
+      iterations: 5,
+      targetError: 0.01,
+      learningRate: 0.1,
+      learningRateStrategy: "fixed",
+      disableRandomSamples: true,
+      dropoutRate: 0.5,
+    });
+
+    // After training, inference should be deterministic (no dropout applied)
+    const input = new Float32Array([0.5, 0.5]);
+    const result1 = creature.activate(input);
+    const result2 = creature.activate(input);
+
+    assertAlmostEquals(result1[0], result2[0], 1e-9);
+  },
+);


### PR DESCRIPTION
## Summary

Implements true dropout regularisation during training. During training, a
configurable fraction of hidden neurons are randomly disabled (activations set
to zero) and remaining activations are scaled by 1/(1-p) using inverted dropout.
During inference, all neurons are active and no adjustment is needed. Closes
#1860.

### What was done

1. **Forward-pass dropout** — After the WASM forward pass during training,
   hidden neuron activations are randomly zeroed according to the configured
   `dropoutRate`. This prevents co-adaptation of neurons and provides
   regularisation against overfitting.

2. **Inverted dropout** — Remaining (kept) activations are scaled by
   `1/(1-dropoutRate)` during training so that expected activation magnitudes
   remain consistent with inference, where all neurons are active.

3. **Configuration** — Added a `dropoutRate` parameter (0.0 to 1.0) to
   `BackPropagationArguments` (and therefore `TrainOptions`). Default is 0.0
   (disabled) for backward compatibility.

4. **Interaction with sparse training** — Dropout and `sparseRatio` coexist
   independently. Dropout provides regularisation (prevents overfitting) while
   sparse training provides efficiency (selects which neurons to update).

### Files changed

- `src/propagate/Dropout.ts` — New file implementing `applyDropout()` with
  inverted dropout scaling
- `src/propagate/BackPropagation.ts` — Added `dropoutRate` field to
  `BackPropagationArguments` with default 0
- `src/architecture/Training.ts` — Integrated dropout call in training loop
  after `activateAndTrace` and before `propagate`
- `test/propagate/DropoutRegularisation.ts` — 13 tests covering config, unit
  behaviour, and training integration

## Evidence

All 4529 tests pass including 13 new dropout-specific tests.

## Test Plan

- **Config tests**: Verify default (0), clamping (negative/over), and
  preservation of valid values
- **Unit tests**: Verify `applyDropout()` zeroes hidden neurons, scales kept
  neurons by 1/(1-p), and leaves input/output neurons untouched
- **Boundary tests**: Rate 0 and rate 1 are no-ops
- **Integration tests**: Training with dropout completes without errors and
  produces valid finite outputs at inference
- **Inference determinism**: After training with dropout, inference produces
  identical results on repeated calls (no dropout applied)
- **Coexistence**: Dropout config works alongside `sparseRatio` and L1/L2 weight
  regularisation

---

## Automated Fix Details
This PR addresses issue #1860: **Enhancement: Implement true dropout regularisation**

## Milestone
This PR is part of the **weaknesses** milestone and targets the `milestone/weaknesses` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1860
---

🤖 Processed by: stservice