### PR TITLE
Enhancement: Improve near-zero weight error propagation stability (#1873)

### DIFF
--- a/docs/pr-summary-1873.md
+++ b/docs/pr-summary-1873.md
@@ -1,39 +1,50 @@
 ## Summary
 
-Improve near-zero weight error propagation stability by clamping out-of-range
-targets to the squash function's range boundary instead of silently dropping
+Improved near-zero weight error propagation stability by clamping out-of-range
+target activations to the squash range boundary instead of silently dropping
 them. Closes #1873.
 
-When a synapse weight is near zero, dividing by the effective weight
-(plankConstant ≈ 1e-7) produces extreme `targetFromActivation` values that fall
-outside the upstream neuron's squash range. Previously these were silently
-dropped via an `outOfRange` check, creating dead gradient paths through
-near-zero-weight connections. In large creatures with many near-zero weight
-synapses, this prevented gradient signal from reaching significant portions of
-the network.
+When a synapse weight is near zero, dividing by the minimum effective weight
+(`plankConstant` = 1e-7) produces a target activation far outside the upstream
+neuron's squash range (e.g., TANH [-1, 1]). Previously, these out-of-range
+targets were dropped entirely, creating dead gradient paths through near-zero
+weight connections. Now they are clamped to the range boundary, propagating a
+reduced gradient instead.
 
-The fix replaces the drop-on-out-of-range behaviour with
-`Math.max(range.low,
-Math.min(range.high, targetFromActivation))`, so a reduced
-gradient always propagates through near-zero-weight connections. This preserves
-all existing finite value protections (Issue #1314) since
-`Number.isFinite(clampedTarget)` is still checked before accumulation.
+### Changes
+
+- **`src/propagate/TopologicalBackpropagation.ts`**: Replaced the out-of-range
+  drop logic with
+  `Math.max(range.low, Math.min(range.high, targetFromActivation))` clamping.
+  The `Number.isFinite()` guard is preserved to maintain Issue #1314 protections
+  against non-finite values.
+
+- **`test/propagate/TinyWeightRecursionAvoidance.ts`**: Updated to reflect the
+  new behaviour — gradient now propagates (clamped) through tiny weights instead
+  of being dropped. The test verifies the bias changes and remains finite.
+
+- **`test/propagate/NearZeroWeightClamping.ts`** (new): 5 tests verifying:
+  - Gradient reaches hidden neurons through near-zero outbound weights
+  - Hidden neuron bias updates via clamped gradient
+  - Gradient flows through deep near-zero weight chains
+  - No gradient explosion from clamped targets
+  - Large creature stability with near-zero weight paths
 
 ## Evidence
 
-- All 4678 tests pass including 573 propagate-specific tests
-- `./quality.sh` passes cleanly
-- No non-finite values introduced (verified by dedicated test)
-- Updated `TinyWeightRecursionAvoidance` test to verify finite bounds instead of
-  zero change, reflecting the intentional new behaviour
+All 4679 tests pass including the new and modified tests. The key tests that
+failed before the fix (proving the bug existed) and pass after:
+
+- `NearZeroWeightClamping - gradient reaches hidden neuron through near-zero outbound weight`
+- `NearZeroWeightClamping - hidden bias updates through near-zero outbound weight`
+- `NearZeroWeightClamping - gradient flows through deep near-zero chain`
 
 ## Test Plan
 
-- Added `test/propagate/NearZeroWeightGradientPropagation.ts` with 4 tests:
-  - Clamped gradient propagates through near-zero weight with TANH
-  - Upstream neuron receives gradient through near-zero weight
-  - No non-finite values from clamped propagation
-  - Multiple near-zero weights do not block all gradient paths
-- Updated `test/propagate/TinyWeightRecursionAvoidance.ts`: assertion changed
-  from exact-zero bias change to finite-value check, since clamped gradient now
-  correctly propagates a reduced signal (documented business logic change)
+- Added `test/propagate/NearZeroWeightClamping.ts` with 5 tests for clamped
+  gradient propagation
+- Modified `test/propagate/TinyWeightRecursionAvoidance.ts` to assert new
+  clamping behaviour (business logic change documented: gradient now propagates
+  through tiny weights instead of being dropped)
+- Existing `test/propagate/ZeroWeightRecovery.ts` tests continue to pass
+- Full `./quality.sh` passes (4679 tests, 0 failures)

--- a/test/propagate/NearZeroWeightClamping.ts
+++ b/test/propagate/NearZeroWeightClamping.ts
@@ -1,0 +1,334 @@
+/**
+ * Tests for near-zero weight error propagation stability.
+ *
+ * Issue #1873 - When a synapse weight is near zero and the upstream neuron
+ * uses a bounded squash function (e.g., TANH with range [-1, 1]), dividing
+ * by the minimum effective weight produces a target activation far outside
+ * the squash range. Previously, these out-of-range targets were silently
+ * dropped, creating dead gradient paths. Now they are clamped to the range
+ * boundary so a reduced gradient still propagates.
+ *
+ * Key topology for testing: the near-zero weight must connect FROM a hidden
+ * neuron with a bounded squash (TANH). When the output neuron processes this
+ * connection, targetFromActivation = targetFromValue / effectiveWeight
+ * produces a value outside TANH's [-1, 1] range. Without clamping, the
+ * gradient is silently dropped and the hidden neuron never receives a signal.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { createBackPropagationConfig } from "../../src/propagate/BackPropagation.ts";
+import { SparseConfig } from "../../src/propagate/sparse/SparseConfig.ts";
+
+Deno.test("NearZeroWeightClamping - gradient reaches hidden neuron through near-zero outbound weight", () => {
+  // Network: Input →[w=1]→ H1(TANH, bias=0) →[w=1e-10]→ Output(IDENTITY)
+  //
+  // When processing the output neuron, it looks at H1→Output (near-zero weight).
+  // Without clamping: targetFromActivation = value / 1e-7 ≈ huge, out of TANH
+  //   range [-1,1], gradient dropped, H1 never receives error signal.
+  // With clamping: targetFromActivation clamped to [-1,1], H1 receives signal.
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "TANH", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1.0 },
+      { fromUUID: "h1", toUUID: "output-0", weight: 1e-10 }, // Near-zero outbound
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  const config = createBackPropagationConfig({
+    generations: 1,
+    learningRate: 0.1,
+    plankConstant: 1e-7,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: 1,
+    trainingMutationRate: 1,
+  });
+  const sparseConfig = new SparseConfig(json, config);
+
+  const input = new Float32Array([1.0]);
+  const target = new Float32Array([0.5]);
+
+  // Run one propagation cycle.
+  creature.activateAndTrace(input, false, sparseConfig);
+  creature.propagate(target, config, sparseConfig);
+
+  // The hidden neuron H1 (index: creature.input = 1, since neurons[0] is h1
+  // after input neurons) should have received an error signal.
+  const h1Index = creature.input; // First hidden neuron index
+  const h1State = creature.state.node(h1Index);
+  assert(
+    h1State.totalErrorAbsolute > 0,
+    `H1 should receive gradient signal through near-zero outbound weight, ` +
+      `got totalErrorAbsolute=${h1State.totalErrorAbsolute}`,
+  );
+
+  // Verify all values remain finite (Issue #1314 protection).
+  const result = creature.activate(input);
+  assert(
+    Number.isFinite(result[0]),
+    `Output should be finite, got ${result[0]}`,
+  );
+});
+
+Deno.test("NearZeroWeightClamping - hidden bias updates through near-zero outbound weight", () => {
+  // Network: Input →[w=1]→ H1(TANH, bias=0) →[w=1e-10]→ Output(IDENTITY)
+  //
+  // After training, H1's bias should change — proving that gradient
+  // propagated through the near-zero weight and H1 was processed.
+  // Use multiple short apply cycles with conservative learning rate to
+  // avoid overflow when TANH unsquash (atanh) approaches the boundary.
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "TANH", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1.0 },
+      { fromUUID: "h1", toUUID: "output-0", weight: 1e-10 }, // Near-zero outbound
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  const config = createBackPropagationConfig({
+    generations: 1,
+    learningRate: 0.01,
+    plankConstant: 1e-7,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: 1,
+    trainingMutationRate: 1,
+  });
+  const sparseConfig = new SparseConfig(json, config);
+
+  const input = new Float32Array([1.0]);
+  const target = new Float32Array([0.5]);
+
+  const originalBias = creature.neurons[creature.input].bias;
+
+  // Single propagation + apply cycle to verify bias changes.
+  for (let i = 0; i < 10; i++) {
+    creature.activateAndTrace(input, false, sparseConfig);
+    creature.propagate(target, config, sparseConfig);
+  }
+  creature.applyLearnings(config, sparseConfig);
+
+  // H1's bias should have changed — gradient propagated through.
+  const updatedBias = creature.neurons[creature.input].bias;
+  assert(
+    updatedBias !== originalBias,
+    `H1 bias should change when gradient is clamped through near-zero weight: ` +
+      `original=${originalBias}, updated=${updatedBias}`,
+  );
+
+  // All non-input values should remain finite.
+  for (const neuron of creature.neurons) {
+    if (neuron.type !== "input" && neuron.type !== "constant") {
+      assert(
+        Number.isFinite(neuron.bias),
+        `Bias must be finite: ${neuron.bias}`,
+      );
+    }
+  }
+  for (const synapse of creature.synapses) {
+    assert(
+      Number.isFinite(synapse.weight),
+      `Weight must be finite: ${synapse.weight}`,
+    );
+  }
+});
+
+Deno.test("NearZeroWeightClamping - gradient flows through deep near-zero chain", () => {
+  // Network: Input →[w=1]→ H1(TANH) →[w=1e-10]→ H2(TANH) →[w=1]→ Output
+  //
+  // H1→H2 has near-zero weight. When processing H2:
+  //   targetFromActivation for H1 = value / 1e-7 ≈ huge → out of TANH range
+  // Without clamping: H1 gets no gradient.
+  // With clamping: H1 gets clamped gradient through H2.
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "TANH", bias: 0 },
+      { type: "hidden", uuid: "h2", squash: "TANH", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1.0 },
+      { fromUUID: "h1", toUUID: "h2", weight: 1e-10 }, // Near-zero between hidden
+      { fromUUID: "h2", toUUID: "output-0", weight: 1.0 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  const config = createBackPropagationConfig({
+    generations: 1,
+    learningRate: 0.1,
+    plankConstant: 1e-7,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: 1,
+    trainingMutationRate: 1,
+  });
+  const sparseConfig = new SparseConfig(json, config);
+
+  const input = new Float32Array([1.0]);
+  const target = new Float32Array([0.5]);
+
+  // Run one propagation cycle.
+  creature.activateAndTrace(input, false, sparseConfig);
+  creature.propagate(target, config, sparseConfig);
+
+  // H1 should receive gradient through the near-zero H1→H2 connection.
+  const h1Index = creature.input; // First hidden neuron
+  const h1State = creature.state.node(h1Index);
+  assert(
+    h1State.totalErrorAbsolute > 0,
+    `H1 should receive gradient through near-zero weight chain, ` +
+      `got totalErrorAbsolute=${h1State.totalErrorAbsolute}`,
+  );
+});
+
+Deno.test("NearZeroWeightClamping - no gradient explosion from clamped targets", () => {
+  // Ensure that clamping near-zero weight targets to the squash range
+  // boundary doesn't cause gradient explosion. The clamped delta should
+  // be bounded by (range.high - currentActivation) at most.
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "TANH", bias: 0 },
+      { type: "hidden", uuid: "h2", squash: "TANH", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1.0 },
+      { fromUUID: "h1", toUUID: "h2", weight: 1e-10 }, // Near-zero
+      { fromUUID: "h2", toUUID: "output-0", weight: 1.0 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  const config = createBackPropagationConfig({
+    generations: 1,
+    learningRate: 0.1,
+    plankConstant: 1e-7,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: 1,
+    trainingMutationRate: 1,
+  });
+  const sparseConfig = new SparseConfig(json, config);
+
+  const input = new Float32Array([1.0]);
+  const target = new Float32Array([0.5]);
+
+  // Train through the near-zero weight chain.
+  for (let cycle = 0; cycle < 3; cycle++) {
+    for (let i = 0; i < 50; i++) {
+      creature.activateAndTrace(input, false, sparseConfig);
+      creature.propagate(target, config, sparseConfig);
+    }
+    creature.applyLearnings(config, sparseConfig);
+  }
+
+  // All weights should remain finite and bounded.
+  for (const synapse of creature.synapses) {
+    assert(
+      Number.isFinite(synapse.weight),
+      `Weight must remain finite, got ${synapse.weight}`,
+    );
+    assert(
+      Math.abs(synapse.weight) < 1e6,
+      `Weight should not explode, got ${synapse.weight}`,
+    );
+  }
+
+  const result = creature.activate(input);
+  assert(
+    Number.isFinite(result[0]),
+    `Output must be finite after chain propagation, got ${result[0]}`,
+  );
+});
+
+Deno.test("NearZeroWeightClamping - large creature finite values with near-zero paths", () => {
+  // Verify that propagation through a large creature with near-zero weight
+  // connections remains stable and produces finite values.
+  const creatureJSON = JSON.parse(
+    Deno.readTextFileSync("test/propagate/large/creature.json"),
+  ) as CreatureExport;
+
+  const creature = Creature.fromJSON(creatureJSON);
+  const plankConstant = 1e-7;
+
+  // Count near-zero weight synapses.
+  let nearZeroCount = 0;
+  for (const synapse of creature.synapses) {
+    if (Math.abs(synapse.weight) < plankConstant) {
+      nearZeroCount++;
+    }
+  }
+
+  // Verify the creature has synapses (sanity check).
+  assert(
+    creature.synapses.length > 0,
+    `Large creature should have synapses`,
+  );
+
+  // Load training data.
+  const tdJSON = JSON.parse(
+    Deno.readTextFileSync("test/propagate/large/td.json"),
+  );
+
+  const config = createBackPropagationConfig({
+    generations: 1,
+    learningRate: 0.01,
+    plankConstant: plankConstant,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: 1,
+    trainingMutationRate: 1,
+  });
+  const sparseConfig = new SparseConfig(creatureJSON, config);
+
+  // Use first training sample.
+  const sample = tdJSON[0];
+  const input = new Float32Array(sample.input);
+  const target = new Float32Array(sample.output);
+
+  // Train one iteration — should not throw, all values should be finite.
+  creature.activateAndTrace(input, false, sparseConfig);
+  creature.propagate(target, config, sparseConfig);
+
+  // Verify all neuron states are finite after propagation.
+  const result = creature.activate(input);
+  for (let i = 0; i < result.length; i++) {
+    assert(
+      Number.isFinite(result[i]),
+      `Output ${i} should be finite after propagation with near-zero weights, got ${
+        result[i]
+      }`,
+    );
+  }
+
+  // Report coverage (informational — the key assertion is no crashes/NaN).
+  const totalSynapses = creature.synapses.length;
+  const nearZeroPercent = totalSynapses > 0
+    ? ((nearZeroCount / totalSynapses) * 100).toFixed(1)
+    : "0";
+  assertEquals(
+    typeof nearZeroPercent,
+    "string",
+    `Near-zero weight analysis: ${nearZeroCount}/${totalSynapses} (${nearZeroPercent}%) synapses have |weight| < ${plankConstant}`,
+  );
+});


### PR DESCRIPTION
## Summary

Improved near-zero weight error propagation stability by clamping out-of-range
target activations to the squash range boundary instead of silently dropping
them. Closes #1873.

When a synapse weight is near zero, dividing by the minimum effective weight
(`plankConstant` = 1e-7) produces a target activation far outside the upstream
neuron's squash range (e.g., TANH [-1, 1]). Previously, these out-of-range
targets were dropped entirely, creating dead gradient paths through near-zero
weight connections. Now they are clamped to the range boundary, propagating a
reduced gradient instead.

### Changes

- **`src/propagate/TopologicalBackpropagation.ts`**: Replaced the out-of-range
  drop logic with
  `Math.max(range.low, Math.min(range.high, targetFromActivation))` clamping.
  The `Number.isFinite()` guard is preserved to maintain Issue #1314 protections
  against non-finite values.

- **`test/propagate/TinyWeightRecursionAvoidance.ts`**: Updated to reflect the
  new behaviour — gradient now propagates (clamped) through tiny weights instead
  of being dropped. The test verifies the bias changes and remains finite.

- **`test/propagate/NearZeroWeightClamping.ts`** (new): 5 tests verifying:
  - Gradient reaches hidden neurons through near-zero outbound weights
  - Hidden neuron bias updates via clamped gradient
  - Gradient flows through deep near-zero weight chains
  - No gradient explosion from clamped targets
  - Large creature stability with near-zero weight paths

## Evidence

All 4679 tests pass including the new and modified tests. The key tests that
failed before the fix (proving the bug existed) and pass after:

- `NearZeroWeightClamping - gradient reaches hidden neuron through near-zero outbound weight`
- `NearZeroWeightClamping - hidden bias updates through near-zero outbound weight`
- `NearZeroWeightClamping - gradient flows through deep near-zero chain`

## Test Plan

- Added `test/propagate/NearZeroWeightClamping.ts` with 5 tests for clamped
  gradient propagation
- Modified `test/propagate/TinyWeightRecursionAvoidance.ts` to assert new
  clamping behaviour (business logic change documented: gradient now propagates
  through tiny weights instead of being dropped)
- Existing `test/propagate/ZeroWeightRecovery.ts` tests continue to pass
- Full `./quality.sh` passes (4679 tests, 0 failures)

---

## Automated Fix Details
This PR addresses issue #1873: **Enhancement: Improve near-zero weight error propagation stability**

## Milestone
This PR is part of the **weaknesses** milestone and targets the `milestone/weaknesses` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1873
---

🤖 Processed by: stservice