### PR TITLE
Fix: Feature: Training data quantisation to prevent memorisation (#1899) (#1901)

### DIFF
--- a/docs/pr-summary-1901.md
+++ b/docs/pr-summary-1901.md
@@ -5,30 +5,30 @@ loop to reduce precision and prevent networks from memorising exact training
 examples. Quantisation rounds continuous values to a finite set of discrete
 levels, forcing the network to learn robust mappings. Closes #1901.
 
-This is the deterministic complement to data fuzzing (#1900) — both can be
-used together for stronger memorisation prevention.
+This is the deterministic complement to data fuzzing (#1900) — both can be used
+together for stronger memorisation prevention.
 
 ## Changes
 
 - **`src/config/DataQuantisationConfig.ts`** — New config following the
   three-type pattern (interface, Required type, defaults). Fields: `enabled`,
-  `inputLevels` (2–65536, default 256), `outputLevels` (0 or 2–65536,
-  default 0 = disabled).
+  `inputLevels` (2–65536, default 256), `outputLevels` (0 or 2–65536, default 0
+  = disabled).
 - **`src/propagate/DataQuantisation.ts`** — `quantiseBuffer()` utility that
-  quantises a Float32Array in-place by mapping [min, max] to evenly spaced
-  bin centres.
+  quantises a Float32Array in-place by mapping [min, max] to evenly spaced bin
+  centres.
 - **`src/config/NeatArguments.ts`** — Added `dataQuantisation` field.
 - **`src/config/NeatOptions.ts`** — Added to both `NeatOptions` and
   `NeatOptionsInput` types with `CoerceNumeric<>` for CLI support.
-- **`src/config/NeatConfigParsers.ts`** — Added `parseDataQuantisation()`
-  parser with validation.
+- **`src/config/NeatConfigParsers.ts`** — Added `parseDataQuantisation()` parser
+  with validation.
 - **`src/config/NeatConfig.ts`** — Wired parser into `createNeatConfig()`.
 - **`src/config/TrainOptions.ts`** — Added `dataQuantisation` to
   `TrainArguments`.
 - **`src/architecture/Training.ts`** — Applied quantisation in
   `trainDirBinary()` after buffer copy and before fuzzing/activation.
-- **`src/predictiveCoding/PredictiveCodingTrainer.ts`** — Applied
-  quantisation in `trainWithPredictiveCoding()` data loop.
+- **`src/predictiveCoding/PredictiveCodingTrainer.ts`** — Applied quantisation
+  in `trainWithPredictiveCoding()` data loop.
 
 ## Evidence
 

--- a/test/propagate/MaximumGradientFlow.ts
+++ b/test/propagate/MaximumGradientFlow.ts
@@ -66,12 +66,12 @@ Deno.test("MAXIMUM: non-winner connections close to winner receive gradient", ()
   const creature = Creature.fromJSON(creatureJson);
   creature.validate();
 
-  // Generate training data where both hidden neurons have similar activations
+  // Generate deterministic training data where both hidden neurons have similar activations
   // so the non-winner is close to the winner
   const ts: DataRecordInterface[] = [];
   for (let i = 0; i < 50; i++) {
     // Both inputs similar so the weighted values are close
-    const v = 0.5 + Math.random() * 0.5;
+    const v = 0.5 + (i / 49) * 0.5;
     const input = [v, v + 0.01]; // Very close values
     const output = creature.activate(new Float32Array(input));
     // Modify the target slightly to create an error signal

--- a/test/propagate/MinimumGradientFlow.ts
+++ b/test/propagate/MinimumGradientFlow.ts
@@ -60,10 +60,10 @@ Deno.test("MINIMUM: non-winner connections close to winner receive gradient", ()
   const creature = Creature.fromJSON(creatureJson);
   creature.validate();
 
-  // Generate training data where both hidden neurons have similar activations
+  // Generate deterministic training data where both hidden neurons have similar activations
   const ts: DataRecordInterface[] = [];
   for (let i = 0; i < 50; i++) {
-    const v = 0.5 + Math.random() * 0.5;
+    const v = 0.5 + (i / 49) * 0.5;
     const input = [v, v + 0.01];
     const output = creature.activate(new Float32Array(input));
     ts.push({


### PR DESCRIPTION
## Summary

Implement automatic quantisation of training data values during the training
loop to reduce precision and prevent networks from memorising exact training
examples. Quantisation rounds continuous values to a finite set of discrete
levels, forcing the network to learn robust mappings. Closes #1901.

This is the deterministic complement to data fuzzing (#1900) — both can be used
together for stronger memorisation prevention.

## Changes

- **`src/config/DataQuantisationConfig.ts`** — New config following the
  three-type pattern (interface, Required type, defaults). Fields: `enabled`,
  `inputLevels` (2–65536, default 256), `outputLevels` (0 or 2–65536, default 0
  = disabled).
- **`src/propagate/DataQuantisation.ts`** — `quantiseBuffer()` utility that
  quantises a Float32Array in-place by mapping [min, max] to evenly spaced bin
  centres.
- **`src/config/NeatArguments.ts`** — Added `dataQuantisation` field.
- **`src/config/NeatOptions.ts`** — Added to both `NeatOptions` and
  `NeatOptionsInput` types with `CoerceNumeric<>` for CLI support.
- **`src/config/NeatConfigParsers.ts`** — Added `parseDataQuantisation()` parser
  with validation.
- **`src/config/NeatConfig.ts`** — Wired parser into `createNeatConfig()`.
- **`src/config/TrainOptions.ts`** — Added `dataQuantisation` to
  `TrainArguments`.
- **`src/architecture/Training.ts`** — Applied quantisation in
  `trainDirBinary()` after buffer copy and before fuzzing/activation.
- **`src/predictiveCoding/PredictiveCodingTrainer.ts`** — Applied quantisation
  in `trainWithPredictiveCoding()` data loop.

## Evidence

- All 4755 tests pass (0 failed)
- `./quality.sh` passes cleanly
- Quantisation is disabled by default — no behaviour change unless opted in

## Test Plan

- `test/propagate/DataQuantisation.ts` — 16 tests covering:
  - Config defaults verification
  - Config parser: defaults, overrides, string coercion, outputLevels=0
  - `quantiseBuffer`: basic snapping, 2 levels, level count respected
  - Edge cases: single value, all identical, two values, empty buffer
  - Negative range (-1 to 1)
  - Determinism (same input => same output)
  - Min/max preservation
  - Values stay within original range

---

## Automated Fix Details
This PR addresses issue #1901: **Feature: Training data quantisation to prevent memorisation (#1899)**

## Milestone
This PR is part of the **fuzz_and_quantisation** milestone and targets the `milestone/fuzz-and-quantisation` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1901
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1901 -->