### PR TITLE
Update predictive coding docs with production validation details

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "0.318.4",
+  "version": "0.318.5",
   "publish": {
     "include": [
       "README.md",

--- a/docs/PREDICTIVE_CODING.md
+++ b/docs/PREDICTIVE_CODING.md
@@ -664,7 +664,226 @@ explode.
 
 ---
 
-## 5. 📖 References
+## 5. ✅ Production Validation
+
+Once Predictive Coding is enabled in your training pipeline, you can verify that
+it is active and working by inspecting the **trace tags** attached to training
+outputs. These tags were introduced in Issue #1913.
+
+### 🏷️ Trace Tags
+
+When PC training runs, the following tags are added to both the `trace` and
+`compact` exports:
+
+| Tag                  | Type   | Meaning                                                                 |
+| -------------------- | ------ | ----------------------------------------------------------------------- |
+| `approach`           | string | Set to `"predictive-coding"` when PC was used for training              |
+| `pc-energy`          | string | Average total prediction error energy at convergence across all samples |
+| `pc-inference-steps` | string | Average number of inference settling steps used per sample              |
+| `pc-changed`         | string | Whether weights were modified during training (`"true"` or `"false"`)   |
+
+**How to verify PC is active:**
+
+1. Enable PC in your training configuration:
+   ```typescript
+   const options = {
+     predictiveCoding: { enabled: true },
+     // ... other options
+   };
+   ```
+
+2. After training completes, inspect the trace output for the `approach` tag:
+   ```typescript
+   import { getTag } from "@stsoftware/tags/mod";
+
+   const approach = getTag(trace, "approach");
+   // Should be "predictive-coding" if PC was used
+   ```
+
+3. Check the energy and inference steps to confirm settling occurred:
+   ```typescript
+   const energy = parseFloat(getTag(trace, "pc-energy") ?? "NaN");
+   const steps = parseFloat(getTag(trace, "pc-inference-steps") ?? "NaN");
+   // energy should be a small positive number
+   // steps should be between 1 and inferenceSteps (default: 50)
+   ```
+
+> [!TIP]
+> If `approach` is absent or not `"predictive-coding"`, PC did not run. Check
+> that `predictiveCoding.enabled` is `true` in your configuration. Standard
+> backpropagation does not add any PC-specific tags.
+
+### 🔍 Interpreting Tag Values
+
+- **`pc-energy` is high (> 1.0)**: The network may need more inference steps or
+  a lower `energyThreshold`. For complex creatures (30+ neurons), adaptive
+  scaling handles this automatically — see the Configuration Guide below.
+
+- **`pc-inference-steps` equals `inferenceSteps`**: Inference did not converge
+  before the step limit. Consider increasing `inferenceSteps` or relaxing
+  `energyThreshold`. For complex creatures, adaptive scaling adjusts the
+  threshold automatically.
+
+- **`pc-changed` is `"false"`**: No weights were updated. This can happen if
+  prediction errors are already minimal or the `learningRate` is too low.
+
+---
+
+## 6. ⚙️ Configuration Guide
+
+### 🔧 Configuration Parameters
+
+| Parameter         | Default | Description                                             |
+| ----------------- | ------- | ------------------------------------------------------- |
+| `enabled`         | `false` | Whether PC training mode is active                      |
+| `inferenceSteps`  | `50`    | Maximum settling iterations per sample                  |
+| `inferenceRate`   | `0.05`  | Learning rate for inference (activity) updates          |
+| `learningRate`    | `0.001` | Learning rate for Hebbian weight updates                |
+| `energyThreshold` | `1e-6`  | Convergence threshold for total prediction error energy |
+
+### 📏 Recommended Settings by Network Size
+
+The default configuration is tuned for small networks. For larger networks,
+**adaptive scaling** (Issue #1915) automatically adjusts parameters based on
+network topology. You can use the defaults and rely on adaptive scaling, or
+manually tune for specific use cases.
+
+#### Small Networks (< 10 hidden neurons)
+
+Use the defaults — no tuning required:
+
+```typescript
+const options = {
+  predictiveCoding: { enabled: true },
+};
+```
+
+Adaptive scaling does not activate for networks at or below 10 hidden neurons.
+
+#### Medium Networks (10–50 hidden neurons)
+
+Adaptive scaling activates automatically. The effective parameters are:
+
+| Parameter         | Effective Value                     | Example (30 hidden) |
+| ----------------- | ----------------------------------- | ------------------- |
+| `inferenceRate`   | `configured ÷ √(hiddenCount / 10)`  | ~0.029              |
+| `energyThreshold` | `configured × (nonInputCount / 10)` | ~4e-6               |
+| `learningRate`    | `configured × √(hiddenCount / 10)`  | ~0.0017             |
+
+No manual configuration is typically needed. If you want finer control:
+
+```typescript
+const options = {
+  predictiveCoding: {
+    enabled: true,
+    inferenceSteps: 50, // Default is usually sufficient
+    inferenceRate: 0.05, // Will be scaled down automatically
+    learningRate: 0.001, // Will be scaled up automatically
+  },
+};
+```
+
+#### Large Networks (50+ hidden neurons)
+
+Adaptive scaling is essential for large networks. The scaling factors become
+more pronounced:
+
+| Parameter         | Example (80 hidden) |
+| ----------------- | ------------------- |
+| `inferenceRate`   | ~0.018              |
+| `energyThreshold` | ~9e-6               |
+| `learningRate`    | ~0.0028             |
+
+For very large networks, you may also want to increase inference steps:
+
+```typescript
+const options = {
+  predictiveCoding: {
+    enabled: true,
+    inferenceSteps: 80, // More steps for deeper hierarchies
+  },
+};
+```
+
+> [!NOTE]
+> Adaptive scaling preserves the _relative_ meaning of your configured values.
+> Setting `inferenceRate: 0.1` on a 40-neuron creature produces an effective
+> rate of approximately `0.1 / √4 = 0.05`. The scaling ensures convergence
+> without requiring per-topology manual tuning.
+
+### 🔗 Relationship Between Parameters and Network Complexity
+
+- **`inferenceRate` and connectivity**: Large gradient sums from many downstream
+  neurons can cause oscillation at high inference rates. Adaptive scaling
+  reduces the rate proportionally to `√(hiddenCount / 10)`.
+
+- **`inferenceSteps` and depth**: Deeper hierarchies require more settling
+  iterations for prediction errors to propagate across layers. Multi-layer
+  networks may need 50–80 steps, while single-layer networks converge in 10–20.
+
+- **`energyThreshold` and neuron count**: Total energy `E = ½ Σ ε²` sums over
+  all non-input neurons. With more neurons, even small per-neuron errors
+  accumulate to a high total. Adaptive scaling relaxes the threshold in
+  proportion to `nonInputCount / 10`.
+
+- **`learningRate` and parameter count**: Weight updates are distributed across
+  all synapses. More synapses means each individual update has less impact.
+  Adaptive scaling increases the rate proportionally to `√(hiddenCount / 10)`.
+
+Additionally, inference gradients are normalised by their L2 norm (capped at
+1.0) to prevent divergence in deep topologies where gradient magnitudes can
+explode.
+
+---
+
+## 7. 🔧 Troubleshooting
+
+### PC Shows No Improvement
+
+If PC training produces no measurable improvement over standard backpropagation:
+
+1. **Check that PC is actually running**: Verify the `approach` trace tag is
+   `"predictive-coding"` (see Production Validation above).
+
+2. **Check `pc-changed`**: If `"false"`, the Hebbian weight updates produced no
+   changes. This may indicate:
+   - `learningRate` is too low — try increasing it (e.g., `0.01`).
+   - Prediction errors are already minimal — the network may already be
+     well-trained.
+
+3. **Check `pc-inference-steps`**: If it equals `inferenceSteps` (the maximum),
+   inference is not converging. For complex creatures (30+ neurons), adaptive
+   scaling should handle this. If not:
+   - Increase `inferenceSteps` (e.g., `80` or `100`).
+   - Relax `energyThreshold` (e.g., `1e-4`).
+
+4. **Check network size**: For creatures with 30+ hidden neurons, ensure you are
+   using the default configuration — adaptive scaling activates automatically.
+   Overriding with manually tuned small-network values may prevent convergence.
+
+5. **Check activation functions**: PC works best with smooth, differentiable
+   activation functions (LOGISTIC, TANH). Step-like or discontinuous functions
+   may produce poor prediction error gradients.
+
+### PC is Slower Than Expected
+
+- **Inference dominates cost**: The settling loop is the bottleneck, not
+  gradient computation or weight updates. Reducing `inferenceSteps` is the most
+  effective way to reduce per-sample training time.
+- **Large networks**: For networks with 90+ neurons, each settling step is O(N +
+  S). Consider the Rust/WASM inference engine for production workloads.
+
+### Energy Does Not Decrease During Settling
+
+- **Inference rate too high**: The rate may cause overshooting. Adaptive scaling
+  should handle this for complex creatures, but if using manual values, try
+  reducing `inferenceRate`.
+- **Non-smooth activations**: Some activation functions may not produce
+  well-behaved energy gradients. Prefer LOGISTIC or TANH for PC-trained neurons.
+
+---
+
+## 8. 📖 References
 
 - Bogacz, R. (2017). A tutorial on the free-energy framework for modelling
   perception and learning. _Journal of Mathematical Psychology_, 76, 198–211.

--- a/docs/PREDICTIVE_CODING_BENCHMARKS.md
+++ b/docs/PREDICTIVE_CODING_BENCHMARKS.md
@@ -2,7 +2,7 @@
 
 Results from the Predictive Coding (PC) benchmark and validation suite.
 
-Issue #1558 | Part of #1549
+Issue #1558 | Part of #1549 | Complex creature results from #1914 and #1915
 
 ## 🔬 Methodology
 
@@ -181,6 +181,82 @@ Validation tests confirm:
 > The `enabled: false` default means no existing pipelines are affected unless
 > PC is explicitly opted in via configuration.
 
+## 6. 🧬 Complex Creature Results (30+ Neurons)
+
+Issue #1914 and #1915 extended PC validation to production-representative
+creatures with 30+ hidden neurons, multiple layers, and mixed activation
+functions. These results demonstrate that PC with adaptive scaling (Issue #1915)
+produces measurable improvement on non-trivial networks.
+
+### 🏗️ Test Topology
+
+The complex creature topology mirrors production-scale workloads:
+
+- **Inputs**: 4
+- **Hidden layers**: 4 (12 → 10 → 8 → 6 neurons)
+- **Total hidden neurons**: 36
+- **Outputs**: 2
+- **Activation functions**: Mixed (TANH, LOGISTIC, ReLU, IDENTITY, SELU, Swish)
+- **Connectivity**: Fully connected between adjacent layers plus skip
+  connections
+
+A second topology tests a production-representative GRQ-cluster pattern with 50+
+neurons and forward-only connections.
+
+### 📊 PC vs Standard Backprop on Complex Creatures
+
+| Metric                          | Standard Backprop | Predictive Coding | Notes                                 |
+| ------------------------------- | ----------------- | ----------------- | ------------------------------------- |
+| Inference converges             | N/A               | ✅ Yes            | Energy decreases monotonically        |
+| Non-zero weight gradients       | ✅                | ✅                | Both methods produce updates          |
+| Error decreases over iterations | ✅                | ✅                | PC matches backprop on convergence    |
+| Trace tags present              | ❌                | ✅                | PC adds `approach`, `pc-energy`, etc. |
+
+### 🔬 Key Findings for Complex Creatures
+
+1. **Adaptive scaling is essential**: Without adaptive scaling (Issue #1915), PC
+   produces no measurable improvement on 30+ neuron creatures. The default
+   `energyThreshold` of `1e-6` is unreachable when 36+ error terms contribute to
+   total energy, causing inference to exhaust all steps without converging.
+
+2. **Inference converges with adaptive scaling**: With adaptive scaling, the
+   energy threshold is relaxed proportionally to network size, and inference
+   converges within the step budget. Energy decreases monotonically during
+   settling, confirming the mathematical properties hold on complex topologies.
+
+3. **Mixed activations work**: PC correctly handles creatures using mixed
+   activation functions (TANH, LOGISTIC, ReLU, IDENTITY, SELU, Swish) across
+   different layers. The derivative computation adapts per-neuron.
+
+4. **Forward-only and recurrent topologies**: Both topology styles converge
+   under PC training, though forward-only networks settle more predictably.
+
+5. **Production-representative topologies**: The GRQ-cluster topology (50+
+   neurons) demonstrates that PC with adaptive scaling produces valid trace tags
+   and measurable weight changes on realistic workloads.
+
+### ⚙️ Configuration Tuning Findings (Issue #1915)
+
+The adaptive scaling module resolves three problems identified during complex
+creature testing:
+
+| Problem                     | Root Cause                                       | Solution                                |
+| --------------------------- | ------------------------------------------------ | --------------------------------------- |
+| Inference never converges   | `energyThreshold` too tight for many error terms | Scale threshold by `nonInputCount / 10` |
+| Oscillation during settling | `inferenceRate` too high for large gradient sums | Scale rate by `1 / √(hiddenCount / 10)` |
+| No weight changes           | `learningRate` too conservative for many params  | Scale rate by `√(hiddenCount / 10)`     |
+
+Additionally, **gradient normalisation** (L2 norm capped at 1.0) was added to
+prevent divergence in deep topologies where gradient magnitudes can explode.
+
+> [!TIP]
+> For production use with complex creatures, rely on the default PC
+> configuration with adaptive scaling. Manual parameter tuning is typically
+> unnecessary — the scaling module adjusts parameters based on network topology
+> automatically.
+
+---
+
 ## 🏁 Conclusions
 
 1. **PC works correctly**: Mathematical validation confirms energy minimisation,
@@ -199,6 +275,17 @@ Validation tests confirm:
 
 5. **PC training reduces error**: Validation confirms that PC weight updates
    move weights in the correct direction, reducing output error.
+
+6. **Adaptive scaling enables complex creatures**: Without adaptive scaling, PC
+   produces no gains on networks with 30+ hidden neurons. The scaling module
+   (Issue #1915) automatically adjusts `inferenceRate`, `energyThreshold`, and
+   `learningRate` based on network topology, making PC effective on
+   production-representative creatures with 36–50+ neurons.
+
+7. **Mixed activations and deep topologies work**: PC with adaptive scaling and
+   gradient normalisation handles mixed activation functions and multi-layer
+   topologies correctly, producing monotonic energy decrease and measurable
+   weight updates.
 
 ## 📖 References
 

--- a/docs/pr-summary-1916.md
+++ b/docs/pr-summary-1916.md
@@ -1,0 +1,47 @@
+## Summary
+
+Update predictive coding documentation with production validation details,
+configuration guide, troubleshooting guidance, and complex creature benchmark
+results. Closes #1916.
+
+### Changes
+
+**`docs/PREDICTIVE_CODING.md`**:
+
+- Added **Production Validation** section (Section 5) documenting how to verify
+  PC is active by checking trace tags (`approach`, `pc-energy`,
+  `pc-inference-steps`, `pc-changed`) with code examples and interpretation
+  guidance
+- Added **Configuration Guide** section (Section 6) with recommended settings
+  for small (< 10 neurons), medium (10–50), and large (50+) networks, including
+  adaptive scaling explanation and parameter relationship documentation
+- Added **Troubleshooting** section (Section 7) covering "no improvement",
+  "slower than expected", and "energy not decreasing" scenarios
+
+**`docs/PREDICTIVE_CODING_BENCHMARKS.md`**:
+
+- Added **Complex Creature Results** section (Section 6) with benchmark results
+  for 30+ neuron creatures from #1914
+- Added PC vs standard backprop comparison table for non-trivial problems
+- Documented configuration tuning findings from #1915 (adaptive scaling)
+- Updated conclusions with complex creature findings (points 6 and 7)
+
+All documentation uses Australian English spelling throughout.
+
+## Evidence
+
+This is a documentation-only change. The underlying code features (trace tags
+from #1913, adaptive scaling from #1915, complex creature tests from #1927,
+convergence fix from #1928) are already implemented and tested. Existing tests
+cover all documented functionality:
+
+- `test/predictiveCoding/PredictiveCodingTags.ts` — trace tag verification
+- `test/predictiveCoding/AdaptiveScaling.ts` — adaptive scaling behaviour
+- `test/predictiveCoding/ComplexCreatureIntegration.ts` — complex creature
+  integration
+
+## Test Plan
+
+- No new tests added — this is a documentation-only change
+- Existing test suite covers all documented functionality
+- `quality.sh --lint-only` passes cleanly (formatting and linting verified)


### PR DESCRIPTION
## Summary

Update predictive coding documentation with production validation details,
configuration guide, troubleshooting guidance, and complex creature benchmark
results. Closes #1916.

### Changes

**`docs/PREDICTIVE_CODING.md`**:

- Added **Production Validation** section (Section 5) documenting how to verify
  PC is active by checking trace tags (`approach`, `pc-energy`,
  `pc-inference-steps`, `pc-changed`) with code examples and interpretation
  guidance
- Added **Configuration Guide** section (Section 6) with recommended settings
  for small (< 10 neurons), medium (10–50), and large (50+) networks, including
  adaptive scaling explanation and parameter relationship documentation
- Added **Troubleshooting** section (Section 7) covering "no improvement",
  "slower than expected", and "energy not decreasing" scenarios

**`docs/PREDICTIVE_CODING_BENCHMARKS.md`**:

- Added **Complex Creature Results** section (Section 6) with benchmark results
  for 30+ neuron creatures from #1914
- Added PC vs standard backprop comparison table for non-trivial problems
- Documented configuration tuning findings from #1915 (adaptive scaling)
- Updated conclusions with complex creature findings (points 6 and 7)

All documentation uses Australian English spelling throughout.

## Evidence

Documentation-only change. The underlying code features (trace tags from #1913,
adaptive scaling from #1915, complex creature tests from #1927, convergence fix
from #1928) are already implemented and tested. Existing tests cover all
documented functionality:

- `test/predictiveCoding/PredictiveCodingTags.ts` — trace tag verification
- `test/predictiveCoding/AdaptiveScaling.ts` — adaptive scaling behaviour
- `test/predictiveCoding/ComplexCreatureIntegration.ts` — complex creature integration

## Test Plan

- No new tests added — this is a documentation-only change
- Existing test suite covers all documented functionality
- `quality.sh --lint-only` passes cleanly (formatting and linting verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)