### PR TITLE
Add removeSyntheticSynapses() for near-zero synapse pruning (#1922)

### DIFF
--- a/docs/pr-summary-1922.md
+++ b/docs/pr-summary-1922.md
@@ -1,0 +1,34 @@
+## Summary
+
+Add `removeSyntheticSynapses()` to prune near-zero weight synthetic synapses
+after training and clean up orphaned neurons that result from the removal.
+Closes #1922.
+
+Synthetic synapses that have been trained to meaningful weights (above a
+configurable threshold) are retained as permanent connections. The function
+leverages existing `disconnectBatch()` for efficient batch removal and
+`cleanupOrphanedNeuronsInCreature()` for orphan handling (cascade-safe).
+
+Safety rules enforced:
+- Typed synapses (IF condition/positive/negative) are never removed
+- Output neurons always retain at least one inward connection
+- Orphaned hidden neurons are converted to constants or removed entirely
+
+## Evidence
+
+All 10 new tests pass. The pre-existing `Genus.ts` test failure is confirmed
+unrelated (reproduces on the base branch without changes).
+
+## Test Plan
+
+- `test/propagate/RemoveSyntheticSynapses.ts` — 10 tests covering:
+  - All near-zero synthetic synapses removed
+  - Trained synthetic synapses retained
+  - Orphaned hidden neuron converted to constant
+  - Orphaned neuron removed (no outward connections)
+  - Cascade removal
+  - Output neuron protection (last inward connection preserved)
+  - Typed synapse protection (IF condition/positive/negative)
+  - Empty synthetic keys (no-op)
+  - Custom threshold controls near-zero detection
+  - Creature remains valid after removal

--- a/src/propagate/RemoveSyntheticSynapses.ts
+++ b/src/propagate/RemoveSyntheticSynapses.ts
@@ -1,0 +1,129 @@
+/**
+ * RemoveSyntheticSynapses.ts - Prune near-zero synthetic synapses after training.
+ *
+ * Issue #1922 - After backpropagation, removes synthetic synapses whose weights
+ * remain near zero. Retains synthetic synapses that have been trained to
+ * meaningful weights (these become permanent). Handles orphaned neurons that
+ * result from the removal.
+ *
+ * Leverages existing:
+ * - disconnectBatch() for efficient batch removal
+ * - cleanupOrphanedNeuronsInCreature() for orphan handling (cascade-safe)
+ * - pruneZeroWeightSynapses logic for output-neuron protection
+ */
+
+import type { Creature } from "../Creature.ts";
+import { cleanupOrphanedNeuronsInCreature } from "../compact/OrphanedNeuronCleanup.ts";
+
+/** Default threshold: same as the backpropagation plankConstant. */
+const DEFAULT_THRESHOLD = 0.000_000_1;
+
+/** Result of removing synthetic synapses. */
+export interface RemoveSyntheticSynapsesResult {
+  /** Number of synthetic synapses removed. */
+  removed: number;
+  /** Number of orphaned neurons removed entirely. */
+  orphansRemoved: number;
+  /** Number of orphaned hidden neurons converted to constants. */
+  orphansConverted: number;
+}
+
+/**
+ * Remove synthetic synapses whose weights remain near zero after training.
+ *
+ * Synthetic synapses that have been trained to non-trivial weights are
+ * retained as permanent connections. After removal, any orphaned neurons
+ * are cleaned up (converted to constant or removed entirely).
+ *
+ * Safety rules:
+ * - Typed synapses (IF condition/positive/negative) are never removed
+ * - Output neurons always retain at least one inward connection
+ * - Cascade orphan removal is handled iteratively
+ *
+ * @param creature The creature to prune (modified in place)
+ * @param syntheticKeys Set of "from-to" keys identifying synthetic synapses
+ * @param threshold Maximum absolute weight to consider "near zero" (default: 1e-7)
+ * @returns Counts of removed synapses and handled orphans
+ */
+export function removeSyntheticSynapses(
+  creature: Creature,
+  syntheticKeys: Set<string>,
+  threshold: number = DEFAULT_THRESHOLD,
+): RemoveSyntheticSynapsesResult {
+  if (syntheticKeys.size === 0) {
+    return { removed: 0, orphansRemoved: 0, orphansConverted: 0 };
+  }
+
+  // Build a set of output neuron indices for protection.
+  const outputIndices = new Set<number>();
+  for (let i = 0; i < creature.neurons.length; i++) {
+    if (creature.neurons[i].type === "output") {
+      outputIndices.add(i);
+    }
+  }
+
+  // Count how many non-synthetic (or retained) inward connections each
+  // output neuron will keep, so we can protect the last one.
+  const outputInwardKept = new Map<number, number>();
+  for (const outputIdx of outputIndices) {
+    outputInwardKept.set(outputIdx, 0);
+  }
+
+  // First pass: count inward connections to outputs that will survive.
+  for (const synapse of creature.synapses) {
+    if (!outputIndices.has(synapse.to)) continue;
+
+    const key = `${synapse.from}-${synapse.to}`;
+    const isSynthetic = syntheticKeys.has(key);
+    const isNearZero = Math.abs(synapse.weight) <= threshold;
+
+    // This synapse survives if it's not synthetic, or if it's synthetic
+    // but trained to a meaningful weight, or if it's typed.
+    if (!isSynthetic || !isNearZero || synapse.type) {
+      outputInwardKept.set(
+        synapse.to,
+        (outputInwardKept.get(synapse.to) ?? 0) + 1,
+      );
+    }
+  }
+
+  // Second pass: identify synthetic synapses to remove.
+  const toDisconnect: Array<{ from: number; to: number }> = [];
+  const preservedForOutput = new Set<number>();
+
+  for (const synapse of creature.synapses) {
+    const key = `${synapse.from}-${synapse.to}`;
+    if (!syntheticKeys.has(key)) continue;
+
+    // Never remove typed synapses (IF condition/positive/negative).
+    if (synapse.type) continue;
+
+    // Only remove near-zero weights.
+    if (Math.abs(synapse.weight) > threshold) continue;
+
+    // Protect last inward connection to output neurons.
+    if (outputIndices.has(synapse.to)) {
+      const kept = outputInwardKept.get(synapse.to) ?? 0;
+      if (kept === 0 && !preservedForOutput.has(synapse.to)) {
+        preservedForOutput.add(synapse.to);
+        continue;
+      }
+    }
+
+    toDisconnect.push({ from: synapse.from, to: synapse.to });
+  }
+
+  // Batch remove the identified synapses.
+  if (toDisconnect.length > 0) {
+    creature.disconnectBatch(toDisconnect);
+  }
+
+  // Run orphaned neuron cleanup (handles cascade removal).
+  const orphanResult = cleanupOrphanedNeuronsInCreature(creature);
+
+  return {
+    removed: toDisconnect.length,
+    orphansRemoved: orphanResult.removed,
+    orphansConverted: orphanResult.converted,
+  };
+}

--- a/test/propagate/RemoveSyntheticSynapses.ts
+++ b/test/propagate/RemoveSyntheticSynapses.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for removeSyntheticSynapses()
+ *
+ * Issue #1922 - Verifies that near-zero weight synthetic synapses are pruned
+ * after training, meaningful-weight synapses are retained, and orphaned neurons
+ * are properly handled.
+ */
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { generateSyntheticSynapses } from "../../src/propagate/SyntheticSynapses.ts";
+import { removeSyntheticSynapses } from "../../src/propagate/RemoveSyntheticSynapses.ts";
+
+Deno.test("removeSyntheticSynapses - removes all near-zero synthetic synapses", () => {
+  // 2 inputs, 2 hidden, 1 output — sparse initial wiring
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "h2", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1 },
+      { fromUUID: "input-1", toUUID: "h2", weight: 1 },
+      { fromUUID: "h1", toUUID: "output-0", weight: 1 },
+      { fromUUID: "h2", toUUID: "output-0", weight: 1 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  const originalSynapseCount = creature.synapses.length;
+
+  // Generate synthetic synapses (zero-weight)
+  const { syntheticKeys } = generateSyntheticSynapses(creature);
+  assertNotEquals(
+    syntheticKeys.size,
+    0,
+    "Should have added synthetic synapses",
+  );
+
+  // All synthetic synapses remain at zero weight (simulate no training effect)
+  const result = removeSyntheticSynapses(creature, syntheticKeys);
+
+  // All synthetic synapses should be removed
+  assertEquals(result.removed, syntheticKeys.size);
+  assertEquals(creature.synapses.length, originalSynapseCount);
+});
+
+Deno.test("removeSyntheticSynapses - retains trained synthetic synapses", () => {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "h2", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1 },
+      { fromUUID: "input-1", toUUID: "h2", weight: 1 },
+      { fromUUID: "h1", toUUID: "output-0", weight: 1 },
+      { fromUUID: "h2", toUUID: "output-0", weight: 1 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+
+  const { syntheticKeys } = generateSyntheticSynapses(creature);
+  assertNotEquals(syntheticKeys.size, 0);
+
+  // Simulate training: set one synthetic synapse to a meaningful weight
+  const firstKey = [...syntheticKeys][0];
+  const [fromStr, toStr] = firstKey.split("-");
+  const synapse = creature.getSynapse(parseInt(fromStr), parseInt(toStr));
+  assertNotEquals(synapse, null);
+  synapse!.weight = 0.5; // Trained to meaningful value
+
+  const result = removeSyntheticSynapses(creature, syntheticKeys);
+
+  // One synapse retained, rest removed
+  assertEquals(result.removed, syntheticKeys.size - 1);
+
+  // The trained synapse should still exist
+  const retained = creature.getSynapse(parseInt(fromStr), parseInt(toStr));
+  assertNotEquals(
+    retained,
+    null,
+    "Trained synthetic synapse should be retained",
+  );
+  assertEquals(retained!.weight, 0.5);
+});
+
+Deno.test("removeSyntheticSynapses - handles orphaned hidden neuron (converts to constant)", () => {
+  // h2 has only one inward connection which is synthetic.
+  // After removal, h2 has no inward connections but has outward → converted to constant.
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "h2", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1 },
+      { fromUUID: "h1", toUUID: "output-0", weight: 1 },
+      { fromUUID: "h2", toUUID: "output-0", weight: 1 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+
+  // Manually add a synthetic synapse from input-0 to h2
+  const h2Idx = creature.neurons.findIndex((n) => n.uuid === "h2");
+  creature.connect(0, h2Idx, 0); // zero-weight synthetic
+  const syntheticKeys = new Set<string>([`0-${h2Idx}`]);
+
+  const result = removeSyntheticSynapses(creature, syntheticKeys);
+
+  assertEquals(result.removed, 1);
+  assertEquals(result.orphansConverted, 1);
+
+  // h2 should now be a constant neuron
+  const h2 = creature.neurons.find((n) => n.uuid === "h2");
+  assertNotEquals(h2, undefined);
+  assertEquals(h2!.type, "constant");
+});
+
+Deno.test("removeSyntheticSynapses - handles orphaned neuron removal (no outward connections)", () => {
+  // h2 has one inward (synthetic) and no outward connections.
+  // After removal, h2 becomes fully orphaned → removed entirely.
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "h2", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1 },
+      { fromUUID: "h1", toUUID: "output-0", weight: 1 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  const neuronCountBefore = creature.neurons.length;
+
+  // Add synthetic synapse to h2 (which has no outward connections)
+  const h2Idx = creature.neurons.findIndex((n) => n.uuid === "h2");
+  creature.connect(0, h2Idx, 0);
+  const syntheticKeys = new Set<string>([`0-${h2Idx}`]);
+
+  const result = removeSyntheticSynapses(creature, syntheticKeys);
+
+  assertEquals(result.removed, 1);
+  assertEquals(result.orphansRemoved, 1);
+  // h2 should be completely removed
+  assertEquals(
+    creature.neurons.length,
+    neuronCountBefore - 1,
+    "Orphaned neuron should be removed",
+  );
+  assertEquals(
+    creature.neurons.some((n) => n.uuid === "h2"),
+    false,
+    "h2 should not exist any more",
+  );
+});
+
+Deno.test("removeSyntheticSynapses - cascade removal", () => {
+  // h1 → h2 → output. h1 has only a synthetic inward connection.
+  // Removing it orphans h1 (convert to constant), which may then orphan h2
+  // if h2's only other inward is also synthetic.
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "h2", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "h1", toUUID: "h2", weight: 1 },
+      { fromUUID: "h2", toUUID: "output-0", weight: 1 },
+      // Direct input to output so output keeps a connection
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+
+  // Add synthetic synapse: input-0 → h1
+  const h1Idx = creature.neurons.findIndex((n) => n.uuid === "h1");
+  creature.connect(0, h1Idx, 0);
+  const syntheticKeys = new Set<string>([`0-${h1Idx}`]);
+
+  const result = removeSyntheticSynapses(creature, syntheticKeys);
+
+  assertEquals(result.removed, 1);
+  // h1 loses its only inward → orphaned. The cleanup should handle cascade.
+  const totalOrphansHandled = result.orphansRemoved + result.orphansConverted;
+  assertNotEquals(
+    totalOrphansHandled,
+    0,
+    "Should handle orphaned neurons from cascade",
+  );
+});
+
+Deno.test("removeSyntheticSynapses - output neurons always retain at least one connection", () => {
+  // Output has only one inward connection which is synthetic.
+  // It should NOT be removed (output must keep ≥1 inward).
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+
+  // The existing synapse is the only one to output. Add synthetic key for it
+  // but pretend it's synthetic and near-zero.
+  const outputIdx = creature.neurons.findIndex((n) => n.type === "output");
+  // Replace existing weight with zero to simulate untrained synthetic
+  creature.synapses[0].weight = 0;
+  const syntheticKeys = new Set<string>([`0-${outputIdx}`]);
+
+  const result = removeSyntheticSynapses(creature, syntheticKeys);
+
+  // Should NOT remove the last connection to an output
+  assertEquals(result.removed, 0);
+  assertEquals(creature.synapses.length, 1);
+});
+
+Deno.test("removeSyntheticSynapses - typed synapses are never removed", () => {
+  // IF neuron with typed synapses marked as synthetic should be preserved
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h-if", squash: "IF", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "h-if",
+        weight: 0,
+        type: "condition",
+      },
+      {
+        fromUUID: "input-0",
+        toUUID: "h-if",
+        weight: 0,
+        type: "positive",
+      },
+      {
+        fromUUID: "input-1",
+        toUUID: "h-if",
+        weight: 0,
+        type: "negative",
+      },
+      { fromUUID: "h-if", toUUID: "output-0", weight: 1 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+
+  // Mark all connections as synthetic (even typed ones)
+  const syntheticKeys = new Set<string>();
+  for (const s of creature.synapses) {
+    syntheticKeys.add(`${s.from}-${s.to}`);
+  }
+
+  const result = removeSyntheticSynapses(creature, syntheticKeys);
+
+  // Typed synapses should NOT be removed even though they have zero weight
+  // The h-if→output-0 has weight=1 so it's also retained
+  assertEquals(result.removed, 0);
+});
+
+Deno.test("removeSyntheticSynapses - empty synthetic keys returns zero changes", () => {
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+
+  const result = removeSyntheticSynapses(creature, new Set());
+
+  assertEquals(result.removed, 0);
+  assertEquals(result.orphansRemoved, 0);
+  assertEquals(result.orphansConverted, 0);
+});
+
+Deno.test("removeSyntheticSynapses - custom threshold controls near-zero detection", () => {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1 },
+      { fromUUID: "h1", toUUID: "output-0", weight: 1 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+
+  // Add a synthetic synapse with small but non-trivial weight
+  const h1Idx = creature.neurons.findIndex((n) => n.uuid === "h1");
+  creature.connect(1, h1Idx, 0.01); // weight = 0.01
+  const syntheticKeys = new Set<string>([`1-${h1Idx}`]);
+
+  // Default threshold (plankConstant = 1e-7) should NOT remove it
+  const result1 = removeSyntheticSynapses(creature, syntheticKeys);
+  assertEquals(
+    result1.removed,
+    0,
+    "Default threshold should retain 0.01 weight",
+  );
+
+  // Custom large threshold should remove it
+  const result2 = removeSyntheticSynapses(creature, syntheticKeys, 0.05);
+  assertEquals(result2.removed, 1, "Threshold 0.05 should remove 0.01 weight");
+});
+
+Deno.test("removeSyntheticSynapses - creature remains valid after removal", () => {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "h2", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 1 },
+      { fromUUID: "input-1", toUUID: "h2", weight: 1 },
+      { fromUUID: "h1", toUUID: "output-0", weight: 1 },
+      { fromUUID: "h2", toUUID: "output-0", weight: 1 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+
+  const { syntheticKeys } = generateSyntheticSynapses(creature);
+  removeSyntheticSynapses(creature, syntheticKeys);
+
+  // Creature should still be structurally valid
+  creature.validate();
+});


### PR DESCRIPTION
## Summary

Add `removeSyntheticSynapses()` to prune near-zero weight synthetic synapses
after training and clean up orphaned neurons that result from the removal.
Closes #1922.

Synthetic synapses that have been trained to meaningful weights (above a
configurable threshold) are retained as permanent connections. The function
leverages existing `disconnectBatch()` for efficient batch removal and
`cleanupOrphanedNeuronsInCreature()` for orphan handling (cascade-safe).

Safety rules enforced:
- Typed synapses (IF condition/positive/negative) are never removed
- Output neurons always retain at least one inward connection
- Orphaned hidden neurons are converted to constants or removed entirely

## Evidence

All 10 new tests pass. The pre-existing `Genus.ts` test failure is confirmed
unrelated (reproduces on the base branch without changes).

## Test Plan

- `test/propagate/RemoveSyntheticSynapses.ts` — 10 tests covering:
  - All near-zero synthetic synapses removed
  - Trained synthetic synapses retained
  - Orphaned hidden neuron converted to constant
  - Orphaned neuron removed (no outward connections)
  - Cascade removal
  - Output neuron protection (last inward connection preserved)
  - Typed synapse protection (IF condition/positive/negative)
  - Empty synthetic keys (no-op)
  - Custom threshold controls near-zero detection
  - Creature remains valid after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)