### PR TITLE
Benchmark: Production-scale backpropagation baseline (1,164 neurons, 19,500 synapses)

### DIFF
--- a/bench/ProductionScaleBackprop.ts
+++ b/bench/ProductionScaleBackprop.ts
@@ -1,0 +1,295 @@
+/**
+ * Issue #1952 - Benchmark: Production-scale backpropagation baseline
+ *
+ * Measures the full backpropagation pass (forward trace + backward propagation)
+ * for a production-scale network: 1,164+ hidden neurons and 19,039+ synapses.
+ * This establishes the baseline for evaluating whether further TS → Rust/WASM
+ * migration yields meaningful gains (part of #1951).
+ *
+ * Network size:
+ * - Production: ~1,164 hidden neurons across multiple layers, ~19,039 synapses
+ *   with realistic sparse connectivity
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-env bench/ProductionScaleBackprop.ts
+ */
+
+import { Creature } from "../src/Creature.ts";
+import type { CreatureExport } from "../src/architecture/CreatureInterfaces.ts";
+import { createBackPropagationConfig } from "../src/propagate/BackPropagation.ts";
+import { SparseConfig } from "../src/propagate/sparse/SparseConfig.ts";
+
+// Seeded random for reproducibility
+function seededRandom(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return (state / 0x7fffffff) * 2 - 1;
+  };
+}
+
+const random = seededRandom(1952);
+
+const SQUASH_NAMES = [
+  "ReLU",
+  "TANH",
+  "LOGISTIC",
+  "IDENTITY",
+  "GELU",
+  "LeakyReLU",
+];
+
+/**
+ * Build a sparsely connected feed-forward network.
+ * Each neuron connects to a limited number of neurons in the next layer
+ * (controlled by maxFanOut), simulating realistic NEAT topology.
+ */
+function buildNetwork(
+  inputCount: number,
+  outputCount: number,
+  hiddenLayers: number[],
+  maxFanOut: number,
+): CreatureExport {
+  const neurons: CreatureExport["neurons"] = [];
+  const synapses: CreatureExport["synapses"] = [];
+
+  const layerUUIDs: string[][] = [];
+
+  // Input layer UUIDs
+  const inputUUIDs = Array.from(
+    { length: inputCount },
+    (_, i) => `input-${i}`,
+  );
+  layerUUIDs.push(inputUUIDs);
+
+  // Hidden layers
+  for (let layerIdx = 0; layerIdx < hiddenLayers.length; layerIdx++) {
+    const layerSize = hiddenLayers[layerIdx];
+    const uuids: string[] = [];
+    for (let i = 0; i < layerSize; i++) {
+      const uuid = `hidden-${layerIdx}-${i}`;
+      uuids.push(uuid);
+      neurons.push({
+        type: "hidden",
+        uuid,
+        squash: SQUASH_NAMES[
+          Math.floor(Math.abs(random()) * SQUASH_NAMES.length)
+        ],
+        bias: random() * 0.5,
+      });
+    }
+    layerUUIDs.push(uuids);
+  }
+
+  // Output layer
+  const outputUUIDs: string[] = [];
+  for (let i = 0; i < outputCount; i++) {
+    const uuid = `output-${i}`;
+    outputUUIDs.push(uuid);
+    neurons.push({
+      type: "output",
+      uuid,
+      squash: "IDENTITY",
+      bias: random() * 0.1,
+    });
+  }
+  layerUUIDs.push(outputUUIDs);
+
+  // Connect consecutive layers with sparse connectivity
+  for (let l = 0; l < layerUUIDs.length - 1; l++) {
+    const fromLayer = layerUUIDs[l];
+    const toLayer = layerUUIDs[l + 1];
+    for (const fromUUID of fromLayer) {
+      // Each source connects to at most maxFanOut targets
+      const fanOut = Math.min(maxFanOut, toLayer.length);
+      const connected = new Set<number>();
+      // Always connect to at least one target
+      while (connected.size < fanOut) {
+        const targetIdx = Math.floor(
+          Math.abs(random()) * toLayer.length,
+        );
+        if (!connected.has(targetIdx)) {
+          connected.add(targetIdx);
+          synapses.push({
+            fromUUID,
+            toUUID: toLayer[targetIdx],
+            weight: random() * 0.5,
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    input: inputCount,
+    output: outputCount,
+    neurons,
+    synapses,
+  };
+}
+
+// ============================================================================
+// Production-scale network definition
+// Target: ~1,164 hidden neurons, ~19,039 synapses
+//
+// Layer sizes: [200, 250, 250, 200, 150, 114] = 1,164 hidden neurons
+// With 8 inputs, 4 outputs, and maxFanOut=16, this produces ~19,000+ synapses
+// ============================================================================
+
+const INPUT_COUNT = 8;
+const OUTPUT_COUNT = 4;
+const HIDDEN_LAYERS = [200, 250, 250, 200, 150, 114];
+const MAX_FAN_OUT = 18;
+
+const productionJSON = buildNetwork(
+  INPUT_COUNT,
+  OUTPUT_COUNT,
+  HIDDEN_LAYERS,
+  MAX_FAN_OUT,
+);
+
+const productionCreature = Creature.fromJSON(productionJSON);
+
+const totalHidden =
+  productionCreature.neurons.filter((n) => n.type === "hidden").length;
+const totalNeurons = productionCreature.neurons.length;
+const totalSynapses = productionCreature.synapses.length;
+
+console.log("\n" + "=".repeat(70));
+console.log("Issue #1952: Production-scale Backpropagation Baseline");
+console.log("=".repeat(70));
+console.log(`Network: ${totalNeurons} neurons (${totalHidden} hidden)`);
+console.log(`Synapses: ${totalSynapses}`);
+console.log(
+  `Layers: input(${INPUT_COUNT}) → ${
+    HIDDEN_LAYERS.join(" → ")
+  } → output(${OUTPUT_COUNT})`,
+);
+console.log("=".repeat(70));
+
+// Pre-generate input and target data
+const productionInput = new Float32Array(
+  Array.from({ length: INPUT_COUNT }, () => random() * 0.5 + 0.5),
+);
+const productionTarget = new Float32Array(
+  Array.from({ length: OUTPUT_COUNT }, () => random() * 0.5),
+);
+
+// Create backprop config
+const config = createBackPropagationConfig({
+  generations: 5,
+  learningRate: 0.01,
+  plankConstant: 0.000_000_1,
+  maximumWeightAdjustmentScale: 1,
+  maximumBiasAdjustmentScale: 1,
+  disableRandomSamples: true,
+  batchSize: 64,
+});
+
+const productionSparse = new SparseConfig(productionJSON, config);
+
+// ============================================================================
+// Benchmark: Full backprop pass (activate + trace + propagate) per sample
+// ============================================================================
+
+Deno.bench({
+  name: `Full backprop - production (${totalNeurons}N/${totalSynapses}S)`,
+  group: "production-full-backprop",
+  baseline: true,
+}, () => {
+  productionCreature.activateAndTrace(
+    productionInput,
+    false,
+    productionSparse,
+  );
+  productionCreature.propagate(productionTarget, config, productionSparse);
+});
+
+// ============================================================================
+// Benchmark: Propagation only (backward pass)
+// ============================================================================
+
+const propagateCreature = Creature.fromJSON(productionJSON);
+propagateCreature.activateAndTrace(
+  productionInput,
+  false,
+  productionSparse,
+);
+
+Deno.bench({
+  name: `Propagate only - production (${totalNeurons}N/${totalSynapses}S)`,
+  group: "production-propagate-only",
+  baseline: true,
+}, () => {
+  propagateCreature.propagate(productionTarget, config, productionSparse);
+});
+
+// ============================================================================
+// Benchmark: Activation only (forward pass)
+// ============================================================================
+
+const activateCreature = Creature.fromJSON(productionJSON);
+
+Deno.bench({
+  name: `Activate only - production (${totalNeurons}N/${totalSynapses}S)`,
+  group: "production-activate-only",
+  baseline: true,
+}, () => {
+  activateCreature.activateAndTrace(
+    productionInput,
+    false,
+    productionSparse,
+  );
+});
+
+// ============================================================================
+// Benchmark: Propagation breakdown (error only vs full accumulation)
+// ============================================================================
+
+const noAccumulateConfig = createBackPropagationConfig({
+  generations: 5,
+  learningRate: 0.01,
+  plankConstant: 0.000_000_1,
+  maximumWeightAdjustmentScale: 1,
+  maximumBiasAdjustmentScale: 1,
+  disableRandomSamples: true,
+  disableWeightAdjustment: true,
+  disableBiasAdjustment: true,
+  batchSize: 64,
+});
+
+const errorOnlyCreature = Creature.fromJSON(productionJSON);
+const errorOnlySparse = new SparseConfig(productionJSON, noAccumulateConfig);
+errorOnlyCreature.activateAndTrace(
+  productionInput,
+  false,
+  errorOnlySparse,
+);
+
+Deno.bench({
+  name:
+    `Propagate (error only) - production (${totalNeurons}N/${totalSynapses}S)`,
+  group: "production-propagate-breakdown",
+  baseline: true,
+}, () => {
+  errorOnlyCreature.propagate(
+    productionTarget,
+    noAccumulateConfig,
+    errorOnlySparse,
+  );
+});
+
+Deno.bench({
+  name: `Propagate (full) - production (${totalNeurons}N/${totalSynapses}S)`,
+  group: "production-propagate-breakdown",
+}, () => {
+  propagateCreature.propagate(productionTarget, config, productionSparse);
+});
+
+console.log(
+  "\nMeasuring production-scale backprop pass.",
+);
+console.log(
+  "This establishes the baseline for evaluating Rust/WASM migration gains.",
+);
+console.log("Lower is better.\n");

--- a/bench/results/production-scale-baseline.md
+++ b/bench/results/production-scale-baseline.md
@@ -1,0 +1,70 @@
+# Production-scale Backpropagation Baseline
+
+Issue #1952 — baseline results for evaluating TS → Rust/WASM migration gains.
+
+## Network Configuration
+
+| Parameter      | Value                                |
+| -------------- | ------------------------------------ |
+| Inputs         | 8                                    |
+| Outputs        | 4                                    |
+| Hidden layers  | 200 → 250 → 250 → 200 → 150 → 114    |
+| Hidden neurons | 1,164                                |
+| Total neurons  | 1,176                                |
+| Synapses       | 19,500                               |
+| Max fan-out    | 18                                   |
+| Connectivity   | Sparse (seeded random, reproducible) |
+
+## Environment
+
+| Property | Value                             |
+| -------- | --------------------------------- |
+| CPU      | Apple M4                          |
+| Runtime  | Deno 2.7.7 (aarch64-apple-darwin) |
+| Date     | 2026-03-23                        |
+
+## Baseline Results
+
+### Full Backprop Pass (activate + trace + propagate)
+
+| Benchmark                    | avg/iter | iter/s | min    | max     | p75    | p99     |
+| ---------------------------- | -------- | ------ | ------ | ------- | ------ | ------- |
+| Full backprop (1176N/19500S) | 6.0 ms   | 166.6  | 5.4 ms | 12.0 ms | 5.9 ms | 12.0 ms |
+
+### Propagation Only (backward pass)
+
+| Benchmark                     | avg/iter | iter/s | min    | max    | p75    | p99    |
+| ----------------------------- | -------- | ------ | ------ | ------ | ------ | ------ |
+| Propagate only (1176N/19500S) | 5.1 ms   | 194.9  | 4.9 ms | 6.2 ms | 5.2 ms | 5.9 ms |
+
+### Activation Only (forward pass)
+
+| Benchmark                    | avg/iter | iter/s | min      | max      | p75      | p99      |
+| ---------------------------- | -------- | ------ | -------- | -------- | -------- | -------- |
+| Activate only (1176N/19500S) | 716.4 µs | 1,396  | 698.0 µs | 950.5 µs | 720.2 µs | 781.8 µs |
+
+### Propagation Breakdown (error only vs full accumulation)
+
+| Benchmark              | avg/iter | iter/s | min    | max    | p75    | p99    |
+| ---------------------- | -------- | ------ | ------ | ------ | ------ | ------ |
+| Propagate (error only) | 3.7 ms   | 270.7  | 3.5 ms | 5.1 ms | 3.7 ms | 4.3 ms |
+| Propagate (full)       | 5.1 ms   | 194.5  | 4.8 ms | 8.7 ms | 5.2 ms | 8.1 ms |
+
+**Summary:** Error-only propagation is ~1.39x faster than full propagation.
+
+## Key Observations
+
+1. **Propagation dominates**: The backward pass (~5.1 ms) accounts for ~85% of
+   total backprop time (~6.0 ms), making it the primary optimisation target.
+2. **Activation is fast**: The forward pass (~716 µs) is roughly 7x faster than
+   propagation, suggesting WASM migration effort is better directed at the
+   backward pass.
+3. **Weight/bias accumulation overhead**: Full propagation is ~1.39x slower than
+   error-only propagation, indicating that gradient accumulation adds meaningful
+   overhead.
+
+## How to Reproduce
+
+```bash
+deno bench --allow-read --allow-env bench/ProductionScaleBackprop.ts
+```

--- a/docs/pr-summary-1952.md
+++ b/docs/pr-summary-1952.md
@@ -1,0 +1,33 @@
+## Summary
+
+Add production-scale backpropagation benchmark (1,164 hidden neurons, 19,500 synapses)
+to establish the baseline for evaluating TS → Rust/WASM migration gains. Closes #1952.
+
+## Evidence
+
+### Network Configuration
+- 1,176 total neurons (1,164 hidden across 6 layers: 200 → 250 → 250 → 200 → 150 → 114)
+- 19,500 synapses with sparse connectivity (maxFanOut=18)
+- Seeded random generator for reproducibility
+
+### Benchmark Results (Apple M4, Deno 2.7.7)
+
+| Benchmark                | avg/iter | iter/s |
+| ------------------------ | -------- | ------ |
+| Full backprop            | 6.0 ms   | 166.6  |
+| Propagate only           | 5.1 ms   | 194.9  |
+| Activate only            | 716.4 µs | 1,396  |
+| Propagate (error only)   | 3.7 ms   | 270.7  |
+| Propagate (full)         | 5.1 ms   | 194.5  |
+
+### Key Findings
+- Propagation (backward pass) accounts for ~85% of total backprop time — primary optimisation target
+- Forward activation is ~7x faster than backward propagation
+- Error-only propagation is ~1.39x faster than full propagation with gradient accumulation
+
+## Test Plan
+
+- Benchmark runs with `deno bench --allow-read --allow-env bench/ProductionScaleBackprop.ts`
+- Produces stable, reproducible timing results via seeded random generator
+- Completes in under 2 minutes
+- Baseline results documented in `bench/results/production-scale-baseline.md`


### PR DESCRIPTION
## Summary

Add production-scale backpropagation benchmark (1,164 hidden neurons, 19,500 synapses)
to establish the baseline for evaluating TS → Rust/WASM migration gains. Closes #1952.

## Evidence

### Network Configuration
- 1,176 total neurons (1,164 hidden across 6 layers: 200 → 250 → 250 → 200 → 150 → 114)
- 19,500 synapses with sparse connectivity (maxFanOut=18)
- Seeded random generator for reproducibility

### Benchmark Results (Apple M4, Deno 2.7.7)

| Benchmark                | avg/iter | iter/s |
| ------------------------ | -------- | ------ |
| Full backprop            | 6.0 ms   | 166.6  |
| Propagate only           | 5.1 ms   | 194.9  |
| Activate only            | 716.4 µs | 1,396  |
| Propagate (error only)   | 3.7 ms   | 270.7  |
| Propagate (full)         | 5.1 ms   | 194.5  |

### Key Findings
- Propagation (backward pass) accounts for ~85% of total backprop time — primary optimisation target
- Forward activation is ~7x faster than backward propagation
- Error-only propagation is ~1.39x faster than full propagation with gradient accumulation

## Test Plan

- Benchmark runs with `deno bench --allow-read --allow-env bench/ProductionScaleBackprop.ts`
- Produces stable, reproducible timing results via seeded random generator
- Completes in under 2 minutes
- Baseline results documented in `bench/results/production-scale-baseline.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)