### PR TITLE
Typed array topology: replace JS object topology with typed arrays (#1957)

### DIFF
--- a/docs/pr-summary-1957.md
+++ b/docs/pr-summary-1957.md
@@ -1,21 +1,31 @@
 ## Summary
 
-Replace JS object-based topology representation with typed arrays for WASM-compatible serialisation. Closes #1957.
+Replace JS object-based topology representation with typed arrays for
+WASM-compatible serialisation. Closes #1957.
 
-Introduces `TypedTopology` — a typed array snapshot of a creature's topology using:
+Introduces `TypedTopology` — a typed array snapshot of a creature's topology
+using:
+
 - `Float64Array` for weights and biases
 - `Uint32Array` for connectivity (from/to indices)
 - `Uint8Array` for squash types, synapse types, and constant flags
 
-The WASM activation path (`WasmActivation.fromCreature`) now uses `TypedTopology.toWasmBinary()` instead of field-by-field object traversal, making serialisation closer to a bulk copy. The typed topology is cached on the Creature instance and invalidated on structural changes.
+The WASM activation path (`WasmActivation.fromCreature`) now uses
+`TypedTopology.toWasmBinary()` instead of field-by-field object traversal,
+making serialisation closer to a bulk copy. The typed topology is cached on the
+Creature instance and invalidated on structural changes.
 
-This is the recommended intermediate step from the WASM-resident topology feasibility analysis (#1642, `docs/WASM_RESIDENT_TOPOLOGY.md` Section 5.2) and the first prerequisite of the TS-Rust migration milestone.
+This is the recommended intermediate step from the WASM-resident topology
+feasibility analysis (#1642, `docs/WASM_RESIDENT_TOPOLOGY.md` Section 5.2) and
+the first prerequisite of the TS-Rust migration milestone.
 
 ## Evidence
 
-- `toWasmBinary()` output is byte-identical to the legacy `compileCreatureToWasm()` — verified by direct comparison tests
+- `toWasmBinary()` output is byte-identical to the legacy
+  `compileCreatureToWasm()` — verified by direct comparison tests
 - All 4849 existing tests pass with the typed topology integration
-- WASM activation path updated to use typed topology without any behavioural changes
+- WASM activation path updated to use typed topology without any behavioural
+  changes
 
 ## Test Plan
 
@@ -25,5 +35,6 @@ This is the recommended intermediate step from the WASM-resident topology feasib
   - Bias, squash type, weight, connectivity, and synapse type correctness
   - Constant neuron handling
   - Multiple topologies (empty hidden layer, multi-hidden, IF aggregate)
-  - `toWasmBinary()` byte-identical comparison with legacy `compileCreatureToWasm()`
+  - `toWasmBinary()` byte-identical comparison with legacy
+    `compileCreatureToWasm()`
   - `Creature.buildTypedTopology()` caching and invalidation

--- a/docs/pr-summary-1957.md
+++ b/docs/pr-summary-1957.md
@@ -1,0 +1,29 @@
+## Summary
+
+Replace JS object-based topology representation with typed arrays for WASM-compatible serialisation. Closes #1957.
+
+Introduces `TypedTopology` — a typed array snapshot of a creature's topology using:
+- `Float64Array` for weights and biases
+- `Uint32Array` for connectivity (from/to indices)
+- `Uint8Array` for squash types, synapse types, and constant flags
+
+The WASM activation path (`WasmActivation.fromCreature`) now uses `TypedTopology.toWasmBinary()` instead of field-by-field object traversal, making serialisation closer to a bulk copy. The typed topology is cached on the Creature instance and invalidated on structural changes.
+
+This is the recommended intermediate step from the WASM-resident topology feasibility analysis (#1642, `docs/WASM_RESIDENT_TOPOLOGY.md` Section 5.2) and the first prerequisite of the TS-Rust migration milestone.
+
+## Evidence
+
+- `toWasmBinary()` output is byte-identical to the legacy `compileCreatureToWasm()` — verified by direct comparison tests
+- All 4849 existing tests pass with the typed topology integration
+- WASM activation path updated to use typed topology without any behavioural changes
+
+## Test Plan
+
+- Added 17 tests in `test/architecture/TypedTopology.ts`:
+  - Array type verification (Float64Array, Uint32Array, Uint8Array instances)
+  - Metadata dimensions match creature
+  - Bias, squash type, weight, connectivity, and synapse type correctness
+  - Constant neuron handling
+  - Multiple topologies (empty hidden layer, multi-hidden, IF aggregate)
+  - `toWasmBinary()` byte-identical comparison with legacy `compileCreatureToWasm()`
+  - `Creature.buildTypedTopology()` caching and invalidation

--- a/mod.ts
+++ b/mod.ts
@@ -203,6 +203,16 @@ export { Upgrade } from "./src/reconstruct/Upgrade.ts";
 export { randomConnectMissing } from "./src/reconstruct/ConnectMissing.ts";
 
 /**
+ * Typed Array Topology
+ *
+ * Issue #1957: Typed array representation of creature topology for reduced
+ * GC pressure and WASM-compatible memcpy serialisation.
+ *
+ * @see {@link module:src/architecture/TypedTopology}
+ */
+export { TypedTopology } from "./src/architecture/TypedTopology.ts";
+
+/**
  * Neuron Class
  */
 export { type NeuronExport } from "./src/architecture/NeuronInterfaces.ts";

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -38,6 +38,7 @@ import type { WasmCreatureActivation } from "./wasm/mod.ts";
 import { getRandomNumberGenerator } from "./utils/RandomNumberGenerator.ts";
 import { ActivationError } from "./errors/ActivationError.ts";
 import { TopologyError } from "./errors/TopologyError.ts";
+import { TypedTopology } from "./architecture/TypedTopology.ts";
 
 // Extracted modules
 import * as activation from "./creature/CreatureActivation.ts";
@@ -153,6 +154,13 @@ export class Creature implements CreatureInternal {
   /** @internal */
   wasmEligibilityCache?: boolean;
 
+  /**
+   * Cached typed array topology snapshot.
+   * Issue #1957: Invalidated on any structural change (clearCache).
+   * @internal
+   */
+  private cachedTypedTopology?: TypedTopology;
+
   DEBUG: boolean = getGlobalDebug();
 
   /**
@@ -213,6 +221,9 @@ export class Creature implements CreatureInternal {
    * does not change the set of neurons.
    */
   public clearCache(from: number = -1, to: number = -1) {
+    // Issue #1957: Invalidate typed topology cache on any structural change
+    this.cachedTypedTopology = undefined;
+
     if (from === -1 || to === -1) {
       // Full invalidation: clears everything including hiddenNeuronUUIDs.
       // Used when neurons are added/removed or structure is fully rebuilt.
@@ -249,6 +260,8 @@ export class Creature implements CreatureInternal {
    * rebuilds of the hiddenNeuronUUIDs set.
    */
   private clearConnectionCaches() {
+    // Issue #1957: Invalidate typed topology on connection changes
+    this.cachedTypedTopology = undefined;
     this._topoCaches.cacheTo = [];
     this._topoCaches.cacheFrom = [];
     this._topoCaches.cacheSelf = [];
@@ -513,6 +526,19 @@ export class Creature implements CreatureInternal {
   }
 
   // ── Topology ───────────────────────────────────────────────────────────
+
+  /**
+   * Build (or return cached) typed array topology snapshot.
+   *
+   * Issue #1957: Typed array topology for reduced GC pressure and
+   * WASM-compatible memcpy serialisation.
+   */
+  buildTypedTopology(): TypedTopology {
+    if (!this.cachedTypedTopology) {
+      this.cachedTypedTopology = TypedTopology.fromCreature(this);
+    }
+    return this.cachedTypedTopology;
+  }
 
   selfConnection(indx: number): SynapseInternal | null {
     return topology.selfConnection(this, this._topoCaches, indx);

--- a/src/architecture/TypedTopology.ts
+++ b/src/architecture/TypedTopology.ts
@@ -1,0 +1,239 @@
+/**
+ * TypedTopology — typed array representation of creature topology.
+ *
+ * Issue #1957: Replace JS object topology with typed arrays for:
+ * - Reduced GC pressure (fewer small objects)
+ * - WASM serialisation as memcpy instead of field-by-field marshalling
+ * - Single source of truth (JS typed arrays)
+ * - Incremental adoption alongside existing object-based topology
+ *
+ * Arrays are parallel — index `i` across neuron arrays refers to the same
+ * neuron, and index `j` across synapse arrays refers to the same synapse.
+ */
+
+import type { Creature } from "../Creature.ts";
+import { getSquashType } from "../wasm/SquashType.ts";
+import { getSynapseTypeCode } from "../wasm/CompileToWasm.ts";
+
+/**
+ * Immutable typed array snapshot of a creature's topology.
+ *
+ * Neuron arrays are indexed by neuron position (0..numNeurons-1).
+ * Synapse arrays are indexed by synapse position (0..numSynapses-1),
+ * matching the creature's sorted synapse order (ascending from, then to).
+ */
+export class TypedTopology {
+  /** Bias for each neuron. Input neurons store 0 (not Infinity). */
+  readonly biases: Float64Array;
+
+  /** WASM squash type enum for each neuron (see SquashType). */
+  readonly squashTypes: Uint8Array;
+
+  /** Source neuron index for each synapse. */
+  readonly fromIndices: Uint32Array;
+
+  /** Destination neuron index for each synapse. */
+  readonly toIndices: Uint32Array;
+
+  /** Weight for each synapse. */
+  readonly weights: Float64Array;
+
+  /** WASM synapse type code for each synapse (see SynapseTypeCode). */
+  readonly synapseTypes: Uint8Array;
+
+  /**
+   * Per-neuron constant flag: 1 if the neuron is a constant, 0 otherwise.
+   * Required for WASM binary compilation which encodes isConstant per neuron.
+   */
+  readonly isConstant: Uint8Array;
+
+  /** Total number of neurons (input + hidden + output + constant). */
+  readonly numNeurons: number;
+
+  /** Number of input neurons. */
+  readonly numInputs: number;
+
+  /** Number of output neurons. */
+  readonly numOutputs: number;
+
+  /** Total number of synapses. */
+  readonly numSynapses: number;
+
+  private constructor(
+    biases: Float64Array,
+    squashTypes: Uint8Array,
+    fromIndices: Uint32Array,
+    toIndices: Uint32Array,
+    weights: Float64Array,
+    synapseTypes: Uint8Array,
+    isConstant: Uint8Array,
+    numNeurons: number,
+    numInputs: number,
+    numOutputs: number,
+    numSynapses: number,
+  ) {
+    this.biases = biases;
+    this.squashTypes = squashTypes;
+    this.fromIndices = fromIndices;
+    this.toIndices = toIndices;
+    this.weights = weights;
+    this.synapseTypes = synapseTypes;
+    this.isConstant = isConstant;
+    this.numNeurons = numNeurons;
+    this.numInputs = numInputs;
+    this.numOutputs = numOutputs;
+    this.numSynapses = numSynapses;
+  }
+
+  /**
+   * Build a TypedTopology snapshot from a Creature's current state.
+   *
+   * The creature's neurons and synapses are read once and packed into
+   * typed arrays. The resulting object is a frozen snapshot — subsequent
+   * mutations to the creature are not reflected.
+   */
+  static fromCreature(creature: Creature): TypedTopology {
+    const numNeurons = creature.neurons.length;
+    const numSynapses = creature.synapses.length;
+    const numInputs = creature.input;
+    const numOutputs = creature.output;
+
+    // Neuron arrays
+    const biases = new Float64Array(numNeurons);
+    const squashTypes = new Uint8Array(numNeurons);
+    const isConstant = new Uint8Array(numNeurons);
+
+    for (let i = 0; i < numNeurons; i++) {
+      const neuron = creature.neurons[i];
+      biases[i] = neuron.type === "input" ? 0 : neuron.bias;
+      squashTypes[i] = getSquashType(neuron.squash);
+      isConstant[i] = neuron.type === "constant" ? 1 : 0;
+    }
+
+    // Synapse arrays
+    const fromIndices = new Uint32Array(numSynapses);
+    const toIndices = new Uint32Array(numSynapses);
+    const weights = new Float64Array(numSynapses);
+    const synapseTypesArr = new Uint8Array(numSynapses);
+
+    for (let i = 0; i < numSynapses; i++) {
+      const synapse = creature.synapses[i];
+      fromIndices[i] = synapse.from;
+      toIndices[i] = synapse.to;
+      weights[i] = synapse.weight;
+      synapseTypesArr[i] = getSynapseTypeCode(synapse.type);
+    }
+
+    return new TypedTopology(
+      biases,
+      squashTypes,
+      fromIndices,
+      toIndices,
+      weights,
+      synapseTypesArr,
+      isConstant,
+      numNeurons,
+      numInputs,
+      numOutputs,
+      numSynapses,
+    );
+  }
+
+  /**
+   * Compile this typed topology to the WASM activation binary format.
+   *
+   * The output is byte-identical to `compileCreatureToWasm()` but avoids
+   * the field-by-field object traversal — typed array data is copied in
+   * bulk where possible.
+   *
+   * Binary layout (little-endian):
+   * - Header: u32 numNeurons, u32 numInputs
+   * - Per non-input neuron: f64 bias, u8 squashType, u8 isConstant, u16 numSynapses
+   *   - Per inward synapse: u16 fromIndex, u8 synapseType, u8 padding, f64 weight
+   */
+  toWasmBinary(): Uint8Array {
+    // Build inward connection index: for each non-input neuron,
+    // collect synapse indices that connect TO that neuron.
+    const inward: number[][] = new Array(this.numNeurons - this.numInputs);
+    for (let i = 0; i < inward.length; i++) {
+      inward[i] = [];
+    }
+
+    for (let s = 0; s < this.numSynapses; s++) {
+      const to = this.toIndices[s];
+      if (to >= this.numInputs) {
+        inward[to - this.numInputs].push(s);
+      }
+    }
+
+    // Sort each inward list by fromIndex (matches CompileToWasm behaviour)
+    for (const list of inward) {
+      list.sort((a, b) => this.fromIndices[a] - this.fromIndices[b]);
+    }
+
+    // Calculate total inward synapses
+    let totalInward = 0;
+    for (const list of inward) {
+      totalInward += list.length;
+    }
+
+    // Calculate buffer size
+    const headerSize = 8;
+    const neuronsSize = (this.numNeurons - this.numInputs) * 12;
+    const synapsesSize = totalInward * 12;
+    const totalSize = headerSize + neuronsSize + synapsesSize;
+
+    const buffer = new ArrayBuffer(totalSize);
+    const view = new DataView(buffer);
+    let offset = 0;
+
+    // Header
+    view.setUint32(offset, this.numNeurons, true);
+    offset += 4;
+    view.setUint32(offset, this.numInputs, true);
+    offset += 4;
+
+    // Non-input neurons
+    for (let ni = 0; ni < this.numNeurons - this.numInputs; ni++) {
+      const neuronIdx = ni + this.numInputs;
+      const synapseList = inward[ni];
+
+      // f64 bias
+      view.setFloat64(offset, this.biases[neuronIdx], true);
+      offset += 8;
+
+      // u8 squash type
+      view.setUint8(offset, this.squashTypes[neuronIdx]);
+      offset += 1;
+
+      // u8 is_constant
+      view.setUint8(offset, this.isConstant[neuronIdx]);
+      offset += 1;
+
+      // u16 num_synapses
+      view.setUint16(offset, synapseList.length, true);
+      offset += 2;
+
+      // Synapses
+      for (const si of synapseList) {
+        // u16 from_index
+        view.setUint16(offset, this.fromIndices[si], true);
+        offset += 2;
+
+        // u8 synapse_type
+        view.setUint8(offset, this.synapseTypes[si]);
+        offset += 1;
+
+        // u8 padding
+        view.setUint8(offset, 0);
+        offset += 1;
+
+        // f64 weight
+        view.setFloat64(offset, this.weights[si], true);
+        offset += 8;
+      }
+    }
+
+    return new Uint8Array(buffer);
+  }
+}

--- a/src/wasm/CompileToWasm.ts
+++ b/src/wasm/CompileToWasm.ts
@@ -40,7 +40,7 @@ export enum SynapseTypeCode {
 /**
  * Map synapse type string to SynapseTypeCode
  */
-function getSynapseTypeCode(
+export function getSynapseTypeCode(
   synapseType: "positive" | "negative" | "condition" | undefined,
 ): SynapseTypeCode {
   switch (synapseType) {

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -14,7 +14,6 @@
 import type { Creature } from "../Creature.ts";
 import { WasmError } from "../errors/WasmError.ts";
 import { getLogger } from "../utils/Logger.ts";
-import { compileCreatureToWasm } from "./CompileToWasm.ts";
 import type { CompiledCreatureData } from "./CompileToWasm.ts";
 import type { WasmCompiledNetwork } from "./WasmCompiledNetwork.ts";
 import {
@@ -120,10 +119,21 @@ export class WasmCreatureActivation {
   }
 
   /**
-   * Create a WASM activation wrapper directly from a Creature
+   * Create a WASM activation wrapper directly from a Creature.
+   *
+   * Issue #1957: Uses TypedTopology when available for efficient
+   * typed-array-based WASM binary compilation.
    */
   static fromCreature(creature: Creature): WasmCreatureActivation | null {
-    const compiled = compileCreatureToWasm(creature);
+    const topo = creature.buildTypedTopology();
+    const binaryData = topo.toWasmBinary();
+    const compiled: CompiledCreatureData = {
+      data: binaryData,
+      numNeurons: topo.numNeurons,
+      numInputs: topo.numInputs,
+      numOutputs: topo.numOutputs,
+      numSynapses: topo.numSynapses,
+    };
     return WasmCreatureActivation.create(compiled);
   }
 

--- a/test/architecture/TypedTopology.ts
+++ b/test/architecture/TypedTopology.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for TypedTopology — typed array representation of creature topology.
+ *
+ * Issue #1957: Replace JS object topology with typed arrays.
+ */
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { Creature } from "../../src/Creature.ts";
+import { TypedTopology } from "../../src/architecture/TypedTopology.ts";
+import { getSquashType, SquashType } from "../../src/wasm/SquashType.ts";
+import { SynapseTypeCode } from "../../src/wasm/CompileToWasm.ts";
+import { CreatureUtil } from "../../src/architecture/CreatureUtils.ts";
+
+/** Helper: create a simple 2-input, 1-hidden, 1-output creature. */
+function makeTestCreature(): Creature {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "TANH", bias: -0.3 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.7 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.5 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+Deno.test("TypedTopology: arrays are correct typed array instances", () => {
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+
+  assertInstanceOf(topo.biases, Float64Array);
+  assertInstanceOf(topo.squashTypes, Uint8Array);
+  assertInstanceOf(topo.fromIndices, Uint32Array);
+  assertInstanceOf(topo.toIndices, Uint32Array);
+  assertInstanceOf(topo.weights, Float64Array);
+  assertInstanceOf(topo.synapseTypes, Uint8Array);
+});
+
+Deno.test("TypedTopology: metadata matches creature dimensions", () => {
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+
+  assertEquals(topo.numNeurons, creature.neurons.length);
+  assertEquals(topo.numInputs, creature.input);
+  assertEquals(topo.numOutputs, creature.output);
+  assertEquals(topo.numSynapses, creature.synapses.length);
+});
+
+Deno.test("TypedTopology: array lengths match dimensions", () => {
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+
+  assertEquals(topo.biases.length, topo.numNeurons);
+  assertEquals(topo.squashTypes.length, topo.numNeurons);
+  assertEquals(topo.fromIndices.length, topo.numSynapses);
+  assertEquals(topo.toIndices.length, topo.numSynapses);
+  assertEquals(topo.weights.length, topo.numSynapses);
+  assertEquals(topo.synapseTypes.length, topo.numSynapses);
+});
+
+Deno.test("TypedTopology: biases match creature neurons", () => {
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+
+  for (let i = 0; i < creature.neurons.length; i++) {
+    const neuron = creature.neurons[i];
+    if (neuron.type === "input") {
+      // Input neurons store Infinity bias in JS; typed array stores 0
+      assertEquals(topo.biases[i], 0);
+    } else {
+      assertEquals(topo.biases[i], neuron.bias);
+    }
+  }
+});
+
+Deno.test("TypedTopology: squash types match creature neurons", () => {
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+
+  for (let i = 0; i < creature.neurons.length; i++) {
+    const neuron = creature.neurons[i];
+    const expected = getSquashType(neuron.squash);
+    assertEquals(topo.squashTypes[i], expected);
+  }
+});
+
+Deno.test("TypedTopology: connectivity matches creature synapses", () => {
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+
+  for (let i = 0; i < creature.synapses.length; i++) {
+    assertEquals(topo.fromIndices[i], creature.synapses[i].from);
+    assertEquals(topo.toIndices[i], creature.synapses[i].to);
+  }
+});
+
+Deno.test("TypedTopology: weights match creature synapses", () => {
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+
+  for (let i = 0; i < creature.synapses.length; i++) {
+    assertEquals(topo.weights[i], creature.synapses[i].weight);
+  }
+});
+
+Deno.test("TypedTopology: synapse types encoded correctly", () => {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IF", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-0",
+        weight: 1,
+        type: "condition",
+      },
+      {
+        fromUUID: "input-1",
+        toUUID: "hidden-0",
+        weight: 1,
+        type: "negative",
+      },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1, type: "positive" },
+    ],
+  });
+  creature.validate();
+
+  const topo = TypedTopology.fromCreature(creature);
+
+  assertEquals(topo.synapseTypes[0], SynapseTypeCode.Condition);
+  assertEquals(topo.synapseTypes[1], SynapseTypeCode.Negative);
+  assertEquals(topo.synapseTypes[2], SynapseTypeCode.Positive);
+});
+
+Deno.test("TypedTopology: standard synapse type for undefined", () => {
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+
+  // makeTestCreature has no explicit synapse types → Standard (0)
+  for (let i = 0; i < topo.numSynapses; i++) {
+    assertEquals(topo.synapseTypes[i], SynapseTypeCode.Standard);
+  }
+});
+
+Deno.test("TypedTopology: constant neuron has Identity squash", () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "constant", uuid: "const-0", bias: 1.0 },
+      { type: "output", uuid: "output-0", squash: "TANH", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "const-0", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  creature.validate();
+
+  const topo = TypedTopology.fromCreature(creature);
+
+  // Constant neuron is at index 1 (after 1 input neuron)
+  assertEquals(topo.squashTypes[1], SquashType.Identity);
+  assertEquals(topo.biases[1], 1.0);
+});
+
+Deno.test("TypedTopology: empty hidden layer creature", () => {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.3 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 0.4 },
+    ],
+  });
+  creature.validate();
+
+  const topo = TypedTopology.fromCreature(creature);
+
+  assertEquals(topo.numNeurons, 3); // 2 inputs + 1 output
+  assertEquals(topo.numInputs, 2);
+  assertEquals(topo.numOutputs, 1);
+  assertEquals(topo.numSynapses, 2);
+});
+
+Deno.test("TypedTopology: larger creature with multiple hidden neurons", () => {
+  const creature = Creature.fromJSON({
+    input: 3,
+    output: 2,
+    neurons: [
+      { type: "hidden", uuid: "h-0", squash: "ReLU", bias: 0.1 },
+      { type: "hidden", uuid: "h-1", squash: "LOGISTIC", bias: -0.5 },
+      { type: "hidden", uuid: "h-2", squash: "TANH", bias: 0.0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.2 },
+      { type: "output", uuid: "output-1", squash: "LOGISTIC", bias: -0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "h-1", weight: -0.3 },
+      { fromUUID: "input-2", toUUID: "h-2", weight: 0.8 },
+      { fromUUID: "h-0", toUUID: "output-0", weight: 1.0 },
+      { fromUUID: "h-1", toUUID: "output-0", weight: -0.7 },
+      { fromUUID: "h-2", toUUID: "output-1", weight: 0.9 },
+    ],
+  });
+  creature.validate();
+
+  const topo = TypedTopology.fromCreature(creature);
+
+  assertEquals(topo.numNeurons, 8); // 3 inputs + 3 hidden + 2 output
+  assertEquals(topo.numInputs, 3);
+  assertEquals(topo.numOutputs, 2);
+  assertEquals(topo.numSynapses, 6);
+
+  // Verify squash types for hidden neurons
+  assertEquals(topo.squashTypes[3], getSquashType("ReLU")); // h-0 at index 3
+  assertEquals(topo.squashTypes[4], getSquashType("LOGISTIC")); // h-1 at index 4
+  assertEquals(topo.squashTypes[5], getSquashType("TANH")); // h-2 at index 5
+});
+
+Deno.test("TypedTopology: toWasmBinary produces valid binary data", () => {
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+  const binary = topo.toWasmBinary();
+
+  assertInstanceOf(binary, Uint8Array);
+
+  // Verify header
+  const view = new DataView(
+    binary.buffer,
+    binary.byteOffset,
+    binary.byteLength,
+  );
+  assertEquals(view.getUint32(0, true), topo.numNeurons);
+  assertEquals(view.getUint32(4, true), topo.numInputs);
+});
+
+Deno.test("TypedTopology: toWasmBinary matches CompileToWasm output", async () => {
+  // Deferred import to avoid circular dependency at module level
+  const { compileCreatureToWasm } = await import(
+    "../../src/wasm/CompileToWasm.ts"
+  );
+
+  const creature = makeTestCreature();
+  const topo = TypedTopology.fromCreature(creature);
+  const typedBinary = topo.toWasmBinary();
+  const legacyCompiled = compileCreatureToWasm(creature);
+
+  // Both should produce identical binary output
+  assertEquals(typedBinary.length, legacyCompiled.data.length);
+  for (let i = 0; i < typedBinary.length; i++) {
+    assertEquals(
+      typedBinary[i],
+      legacyCompiled.data[i],
+      `Mismatch at byte ${i}`,
+    );
+  }
+});
+
+Deno.test("TypedTopology: toWasmBinary matches for IF creature", async () => {
+  const { compileCreatureToWasm } = await import(
+    "../../src/wasm/CompileToWasm.ts"
+  );
+
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IF", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      {
+        fromUUID: "input-0",
+        toUUID: "hidden-0",
+        weight: 1,
+        type: "condition",
+      },
+      {
+        fromUUID: "input-1",
+        toUUID: "hidden-0",
+        weight: 1,
+        type: "negative",
+      },
+      {
+        fromUUID: "hidden-0",
+        toUUID: "output-0",
+        weight: 1,
+        type: "positive",
+      },
+    ],
+  });
+  creature.validate();
+
+  const topo = TypedTopology.fromCreature(creature);
+  const typedBinary = topo.toWasmBinary();
+  const legacyCompiled = compileCreatureToWasm(creature);
+
+  assertEquals(typedBinary.length, legacyCompiled.data.length);
+  for (let i = 0; i < typedBinary.length; i++) {
+    assertEquals(
+      typedBinary[i],
+      legacyCompiled.data[i],
+      `Mismatch at byte ${i}`,
+    );
+  }
+});
+
+Deno.test("TypedTopology: Creature.buildTypedTopology returns cached instance", () => {
+  const creature = makeTestCreature();
+  const topo1 = creature.buildTypedTopology();
+  const topo2 = creature.buildTypedTopology();
+
+  // Should return the same cached instance
+  assertEquals(topo1, topo2);
+});
+
+Deno.test("TypedTopology: cache invalidated on clearCache", () => {
+  const creature = makeTestCreature();
+  const topo1 = creature.buildTypedTopology();
+  creature.clearCache();
+  const topo2 = creature.buildTypedTopology();
+
+  // After clearCache, should build a new instance
+  assertEquals(topo1 !== topo2, true);
+  // But values should still match
+  assertEquals(topo2.numNeurons, topo1.numNeurons);
+});


### PR DESCRIPTION
## Summary

Replace JS object-based topology representation with typed arrays for
WASM-compatible serialisation. Closes #1957.

Introduces `TypedTopology` — a typed array snapshot of a creature's topology
using:

- `Float64Array` for weights and biases
- `Uint32Array` for connectivity (from/to indices)
- `Uint8Array` for squash types, synapse types, and constant flags

The WASM activation path (`WasmActivation.fromCreature`) now uses
`TypedTopology.toWasmBinary()` instead of field-by-field object traversal,
making serialisation closer to a bulk copy. The typed topology is cached on the
Creature instance and invalidated on structural changes.

This is the recommended intermediate step from the WASM-resident topology
feasibility analysis (#1642, `docs/WASM_RESIDENT_TOPOLOGY.md` Section 5.2) and
the first prerequisite of the TS-Rust migration milestone.

## Evidence

- `toWasmBinary()` output is byte-identical to the legacy
  `compileCreatureToWasm()` — verified by direct comparison tests
- All 4849 existing tests pass with the typed topology integration
- WASM activation path updated to use typed topology without any behavioural
  changes

## Test Plan

- Added 17 tests in `test/architecture/TypedTopology.ts`:
  - Array type verification (Float64Array, Uint32Array, Uint8Array instances)
  - Metadata dimensions match creature
  - Bias, squash type, weight, connectivity, and synapse type correctness
  - Constant neuron handling
  - Multiple topologies (empty hidden layer, multi-hidden, IF aggregate)
  - `toWasmBinary()` byte-identical comparison with legacy
    `compileCreatureToWasm()`
  - `Creature.buildTypedTopology()` caching and invalidation

---

## Automated Fix Details
This PR addresses issue #1957: **Typed array topology: replace JS object topology with typed arrays**

## Milestone
This PR is part of the **ts-rust-migration** milestone and targets the `milestone/ts-rust-migration` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1957
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1957 -->