### PR TITLE
Replace try-catch masking with assertions (#2017)

### DIFF
--- a/docs/pr-summary-2017.md
+++ b/docs/pr-summary-2017.md
@@ -1,0 +1,24 @@
+## Summary
+
+Replace defensive try-catch wrappers around `Creature.fromJSON()` in all 6 discovery operations with direct calls, now that root causes of invalid creatures have been fixed (#2013, #2014, #2015, #2016). Pre-validation via `assertValidSynapseReferences()` (already in place) catches any structural issues before `fromJSON()` is called, so invalid creatures will cause immediate assertion failures with diagnostics rather than being silently discarded. Closes #2017.
+
+## Changes
+
+- **DiscoverySynapseOps.ts**: Removed try-catch from `removeSynapse()` and `addHelpfulSynapses()`
+- **DiscoveryNeuronRemoval.ts**: Removed try-catch from `removeHarmfulNeuron()` and `removeLowImpactNeuron()`
+- **DiscoveryNeuronAddition.ts**: Removed try-catch from `addHelpfulNeurons()` and `changeSquash()`
+- **DiscoveryFromJSONRobustness.ts**: Updated test descriptions and added 6 new tests verifying each operation produces structurally valid creatures
+
+## Evidence
+
+All 5018 tests pass including 16 tests in the updated robustness test file and 7 in the integrity test file.
+
+## Test Plan
+
+- Existing tests for invalid candidate handling (non-existent neurons) retained and passing
+- Added `removeSynapse produces a structurally valid creature`
+- Added `addHelpfulSynapses produces a structurally valid creature`
+- Added `removeHarmfulNeuron produces a structurally valid creature`
+- Added `removeLowImpactNeuron produces a structurally valid creature`
+- Added `addHelpfulNeurons produces a structurally valid creature`
+- Added `changeSquash produces a structurally valid creature`

--- a/docs/pr-summary-2017.md
+++ b/docs/pr-summary-2017.md
@@ -1,21 +1,33 @@
 ## Summary
 
-Replace defensive try-catch wrappers around `Creature.fromJSON()` in all 6 discovery operations with direct calls, now that root causes of invalid creatures have been fixed (#2013, #2014, #2015, #2016). Pre-validation via `assertValidSynapseReferences()` (already in place) catches any structural issues before `fromJSON()` is called, so invalid creatures will cause immediate assertion failures with diagnostics rather than being silently discarded. Closes #2017.
+Replace defensive try-catch wrappers around `Creature.fromJSON()` in all 6
+discovery operations with direct calls, now that root causes of invalid
+creatures have been fixed (#2013, #2014, #2015, #2016). Pre-validation via
+`assertValidSynapseReferences()` (already in place) catches any structural
+issues before `fromJSON()` is called, so invalid creatures will cause immediate
+assertion failures with diagnostics rather than being silently discarded. Closes
+#2017.
 
 ## Changes
 
-- **DiscoverySynapseOps.ts**: Removed try-catch from `removeSynapse()` and `addHelpfulSynapses()`
-- **DiscoveryNeuronRemoval.ts**: Removed try-catch from `removeHarmfulNeuron()` and `removeLowImpactNeuron()`
-- **DiscoveryNeuronAddition.ts**: Removed try-catch from `addHelpfulNeurons()` and `changeSquash()`
-- **DiscoveryFromJSONRobustness.ts**: Updated test descriptions and added 6 new tests verifying each operation produces structurally valid creatures
+- **DiscoverySynapseOps.ts**: Removed try-catch from `removeSynapse()` and
+  `addHelpfulSynapses()`
+- **DiscoveryNeuronRemoval.ts**: Removed try-catch from `removeHarmfulNeuron()`
+  and `removeLowImpactNeuron()`
+- **DiscoveryNeuronAddition.ts**: Removed try-catch from `addHelpfulNeurons()`
+  and `changeSquash()`
+- **DiscoveryFromJSONRobustness.ts**: Updated test descriptions and added 6 new
+  tests verifying each operation produces structurally valid creatures
 
 ## Evidence
 
-All 5018 tests pass including 16 tests in the updated robustness test file and 7 in the integrity test file.
+All 5018 tests pass including 16 tests in the updated robustness test file and 7
+in the integrity test file.
 
 ## Test Plan
 
-- Existing tests for invalid candidate handling (non-existent neurons) retained and passing
+- Existing tests for invalid candidate handling (non-existent neurons) retained
+  and passing
 - Added `removeSynapse produces a structurally valid creature`
 - Added `addHelpfulSynapses produces a structurally valid creature`
 - Added `removeHarmfulNeuron produces a structurally valid creature`

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronAddition.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronAddition.ts
@@ -220,16 +220,7 @@ export function addHelpfulNeurons(
   // Integrity check: verify no dangling references before constructing creature
   assertValidSynapseReferences(exportJSON, "addHelpfulNeurons before fromJSON");
 
-  let tmpCreature: Creature;
-  try {
-    tmpCreature = Creature.fromJSON(exportJSON);
-  } catch (error) {
-    getLogger().warn(
-      `[Discovery ${ID}] addHelpfulNeurons: Creature.fromJSON failed:`,
-      error,
-    );
-    return;
-  }
+  const tmpCreature = Creature.fromJSON(exportJSON);
   // We added neurons and synapses to the structure, so we must delete UUID to get a new one
   delete tmpCreature.uuid;
 
@@ -335,16 +326,7 @@ export function changeSquash(
   // Integrity check: verify no dangling references before constructing creature
   assertValidSynapseReferences(exportJSON, "changeSquash before fromJSON");
 
-  let tmpCreature: Creature;
-  try {
-    tmpCreature = Creature.fromJSON(exportJSON);
-  } catch (error) {
-    getLogger().warn(
-      `[Discovery ${ID}] changeSquash: Creature.fromJSON failed:`,
-      error,
-    );
-    return;
-  }
+  const tmpCreature = Creature.fromJSON(exportJSON);
   // We changed squash functions, so we must delete UUID to get a new one
   delete tmpCreature.uuid;
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts
@@ -119,16 +119,7 @@ export function removeHarmfulNeuron(
     "removeHarmfulNeuron after cleanup",
   );
 
-  let tmpCreature: Creature;
-  try {
-    tmpCreature = Creature.fromJSON(simplifiedExport);
-  } catch (error) {
-    getLogger().warn(
-      `[Discovery ${ID}] removeHarmfulNeuron: Creature.fromJSON failed for neuron ${harmfulNeuron.neuronId}:`,
-      error,
-    );
-    return undefined;
-  }
+  const tmpCreature = Creature.fromJSON(simplifiedExport);
   // We modified the structure, so we must delete UUID
   delete tmpCreature.uuid;
 
@@ -280,16 +271,7 @@ export function removeLowImpactNeuron(
   const removedNeuronCount = originalNeuronCount -
     simplifiedExport.neurons.length;
 
-  let tmpCreature: Creature;
-  try {
-    tmpCreature = Creature.fromJSON(simplifiedExport);
-  } catch (error) {
-    getLogger().warn(
-      `[Discovery ${ID}] removeLowImpactNeuron: Creature.fromJSON failed for neuron ${removalCandidate.neuronId}:`,
-      error,
-    );
-    return undefined;
-  }
+  const tmpCreature = Creature.fromJSON(simplifiedExport);
   // We modified the structure, so we must delete UUID
   delete tmpCreature.uuid;
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverySynapseOps.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverySynapseOps.ts
@@ -77,16 +77,7 @@ export function removeSynapse(
   // Integrity check: after orphan cleanup, verify no dangling references
   assertValidSynapseReferences(exportJSON, "removeSynapse after cleanup");
 
-  let tmpCreature: Creature;
-  try {
-    tmpCreature = Creature.fromJSON(exportJSON);
-  } catch (error) {
-    getLogger().warn(
-      `[DiscoverStructure] removeSynapse: Creature.fromJSON failed for ${worseCandidate.fromNeuronId} -> ${worseCandidate.toNeuronId}:`,
-      error,
-    );
-    return null;
-  }
+  const tmpCreature = Creature.fromJSON(exportJSON);
   // We modified the structure by filtering synapses, so we must delete UUID
   delete tmpCreature.uuid;
   delete tmpCreature.memetic;
@@ -216,16 +207,7 @@ export function addHelpfulSynapses(
     "addHelpfulSynapses before fromJSON",
   );
 
-  let tmpCreature: Creature;
-  try {
-    tmpCreature = Creature.fromJSON(exportJSON);
-  } catch (error) {
-    getLogger().warn(
-      `[Discovery ${ID}] addHelpfulSynapses: Creature.fromJSON failed:`,
-      error,
-    );
-    return;
-  }
+  const tmpCreature = Creature.fromJSON(exportJSON);
   // We added synapses to the structure, so we must delete UUID to get a new one
   delete tmpCreature.uuid;
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryFromJSONRobustness.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryFromJSONRobustness.ts
@@ -1,16 +1,17 @@
 /**
- * Issue #2005: Discovery operations must not crash when Creature.fromJSON
- * encounters an unresolvable neuron ID.
+ * Issue #2017: Discovery operations must produce structurally valid creatures.
  *
- * The discovery pipeline modifies exported JSON (adding/removing neurons and
- * synapses) before calling Creature.fromJSON. If the modified JSON is invalid
- * (e.g., a synapse references a neuron ID that doesn't exist), the operation
- * should return undefined/null gracefully instead of crashing the process with
- * an uncaught AssertionError.
+ * Pre-validation via assertValidSynapseReferences() catches dangling synapse
+ * references before Creature.fromJSON() is called, so invalid JSON is never
+ * silently swallowed. These tests verify:
+ * 1. Operations correctly skip invalid candidates (non-existent neurons).
+ * 2. Operations produce valid creatures when given valid input.
+ * 3. Creature.fromJSON still provides diagnostics for invalid JSON.
  */
 
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
 import type { CreatureExport } from "../../src/architecture/CreatureInterfaces.ts";
+import { assertValidSynapseReferences } from "../../src/architecture/AssertValidSynapseReferences.ts";
 import { Creature } from "../../src/Creature.ts";
 import { IDENTITY } from "../../src/methods/activations/types/IDENTITY.ts";
 import {
@@ -74,15 +75,24 @@ function makeTestCreature(): Creature {
   return Creature.fromJSON(exportJSON);
 }
 
+/**
+ * Asserts that a creature has no dangling synapse references.
+ */
+function assertCreatureIntegrity(creature: Creature, context: string): void {
+  const exported = creature.exportJSON();
+  assertValidSynapseReferences(exported, context);
+}
+
+// ===== Invalid candidate tests (early-exit validation) =====
+
 Deno.test(
   "addHelpfulSynapses returns undefined for non-existent source neuron ID",
   async () => {
     await initWasmForTests();
     const creature = makeTestCreature();
 
-    // Candidate references a neuron ID that doesn't exist in the creature
     const candidate: CandidateSynapse = {
-      fromNeuronId: 9999999, // Non-existent neuron
+      fromNeuronId: 9999999,
       toNeuronId: -1,
       weight: 0.5,
       targetNeuronImpact: 1.0,
@@ -107,10 +117,9 @@ Deno.test(
     await initWasmForTests();
     const creature = makeTestCreature();
 
-    // Candidate references a target neuron ID that doesn't exist
     const candidate: CandidateSynapse = {
-      fromNeuronId: 0, // Valid input neuron
-      toNeuronId: 9999999, // Non-existent target neuron
+      fromNeuronId: 0,
+      toNeuronId: 9999999,
       weight: 0.5,
       targetNeuronImpact: 1.0,
       expectedCreatureErrorReduction: 0.01,
@@ -135,7 +144,7 @@ Deno.test(
     const creature = makeTestCreature();
 
     const candidate: CandidateNeuron = {
-      fromNeuronId: 9999999, // Non-existent neuron
+      fromNeuronId: 9999999,
       toNeuronId: -1,
       squash: IDENTITY.NAME,
       bias: 0.1,
@@ -253,12 +262,13 @@ Deno.test(
   },
 );
 
+// ===== Diagnostic test =====
+
 Deno.test(
   "Creature.fromJSON provides diagnostic info when synapse references missing neuron",
   async () => {
     await initWasmForTests();
 
-    // Create a CreatureExport with a synapse referencing a non-existent neuron
     const badExport: CreatureExport = {
       input: 2,
       output: 1,
@@ -279,7 +289,6 @@ Deno.test(
       synapses: [
         { fromId: 0, toId: 1000000, weight: 0.5 },
         { fromId: 1000000, toId: -1, weight: 0.75 },
-        // This synapse references a neuron (9999999) that doesn't exist
         { fromId: 9999999, toId: -1, weight: 0.5 },
       ],
     };
@@ -291,7 +300,6 @@ Deno.test(
       errorMessage = (error as Error).message;
     }
 
-    // Verify the error message includes diagnostic info (fromId value)
     assertEquals(
       errorMessage.includes("FROM is undefined"),
       true,
@@ -305,6 +313,8 @@ Deno.test(
   },
 );
 
+// ===== Candidate builder tests =====
+
 Deno.test(
   "buildSingleSynapseCandidates gracefully skips invalid candidates",
   async () => {
@@ -313,7 +323,7 @@ Deno.test(
 
     const candidates: CandidateSynapse[] = [
       {
-        fromNeuronId: 9999999, // Non-existent — should be skipped
+        fromNeuronId: 9999999,
         toNeuronId: -1,
         weight: 0.5,
         targetNeuronImpact: 1.0,
@@ -323,7 +333,7 @@ Deno.test(
         totalCount: 10,
       },
       {
-        fromNeuronId: 0, // Valid — but target doesn't exist
+        fromNeuronId: 0,
         toNeuronId: 9999999,
         weight: 0.5,
         targetNeuronImpact: 1.0,
@@ -334,7 +344,6 @@ Deno.test(
       },
     ];
 
-    // This should NOT throw — it should skip invalid candidates gracefully
     const results = buildSingleSynapseCandidates(
       "test-id",
       creature,
@@ -352,7 +361,7 @@ Deno.test(
 
     const candidates: CandidateNeuron[] = [
       {
-        fromNeuronId: 9999999, // Non-existent — should be skipped
+        fromNeuronId: 9999999,
         toNeuronId: -1,
         squash: IDENTITY.NAME,
         bias: 0.1,
@@ -366,12 +375,219 @@ Deno.test(
       },
     ];
 
-    // This should NOT throw — it should skip invalid candidates gracefully
     const results = buildSingleNeuronCandidates(
       "test-id",
       creature,
       candidates,
     );
     assertEquals(results.length, 0, "All invalid candidates should be skipped");
+  },
+);
+
+// ===== Valid creature output tests (issue #2017) =====
+
+Deno.test(
+  "removeSynapse produces a structurally valid creature",
+  async () => {
+    await initWasmForTests();
+    const creature = makeTestCreature();
+
+    // Remove the synapse from input(0) -> hidden(1000000)
+    const candidate: CandidateSynapse = {
+      fromNeuronId: 0,
+      toNeuronId: 1000000,
+      weight: 0.5,
+      targetNeuronImpact: 1.0,
+      expectedCreatureErrorReduction: 0.01,
+      expectedCreatureScoreGain: 0.01,
+      improvedCount: 5,
+      totalCount: 10,
+    };
+
+    const result = removeSynapse("test-valid", creature, candidate);
+
+    if (result !== null) {
+      assertCreatureIntegrity(result, "removeSynapse valid output");
+
+      // The removed synapse should no longer exist
+      const exported = result.exportJSON();
+      const hasSynapse = exported.synapses.some(
+        (s) => s.fromId === 0 && s.toId === 1000000,
+      );
+      assertEquals(hasSynapse, false, "Removed synapse should not exist");
+    }
+  },
+);
+
+Deno.test(
+  "addHelpfulSynapses produces a structurally valid creature",
+  async () => {
+    await initWasmForTests();
+    const creature = makeTestCreature();
+
+    // Add a synapse from input(1) -> hidden(1000000)
+    const candidate: CandidateSynapse = {
+      fromNeuronId: 1,
+      toNeuronId: 1000000,
+      weight: 0.4,
+      targetNeuronImpact: 1.0,
+      expectedCreatureErrorReduction: 0.01,
+      expectedCreatureScoreGain: 0.01,
+      improvedCount: 5,
+      totalCount: 10,
+    };
+
+    const result = addHelpfulSynapses("test-valid", creature, [candidate]);
+
+    assert(result !== undefined, "Should produce a creature for valid input");
+    assertCreatureIntegrity(result, "addHelpfulSynapses valid output");
+
+    // The new synapse should exist
+    const exported = result.exportJSON();
+    const hasNewSynapse = exported.synapses.some(
+      (s) => s.fromId === 1 && s.toId === 1000000,
+    );
+    assertEquals(hasNewSynapse, true, "New synapse should exist in output");
+  },
+);
+
+Deno.test(
+  "removeHarmfulNeuron produces a structurally valid creature",
+  async () => {
+    await initWasmForTests();
+    const creature = makeTestCreature();
+
+    const candidate: CandidateHarmfulNeuron = {
+      neuronId: 1000000,
+      errorMagnitude: 1e11,
+      averageActivation: 0.1,
+      sampleCount: 100,
+      expectedCreatureScoreGain: 0.05,
+    };
+
+    const result = removeHarmfulNeuron("test-valid", creature, candidate);
+
+    if (result !== undefined) {
+      assertCreatureIntegrity(result, "removeHarmfulNeuron valid output");
+
+      // The removed neuron should not exist as hidden
+      const exported = result.exportJSON();
+      const hasNeuron = exported.neurons.some(
+        (n) => n.id === 1000000 && n.type === "hidden",
+      );
+      assertEquals(
+        hasNeuron,
+        false,
+        "Removed neuron should not exist as hidden",
+      );
+
+      // No synapse should reference the removed neuron
+      for (const synapse of exported.synapses) {
+        assertNotEquals(
+          synapse.fromId,
+          1000000,
+          "No synapse should source from removed neuron",
+        );
+        assertNotEquals(
+          synapse.toId,
+          1000000,
+          "No synapse should target removed neuron",
+        );
+      }
+    }
+  },
+);
+
+Deno.test(
+  "removeLowImpactNeuron produces a structurally valid creature",
+  async () => {
+    await initWasmForTests();
+    const creature = makeTestCreature();
+
+    const candidate = {
+      neuronId: 1000001,
+      totalError: 0.001,
+      impact: 0.001,
+      reason: "low_impact",
+      meanActivation: 0.2,
+    };
+
+    const result = removeLowImpactNeuron("test-valid", creature, candidate);
+
+    if (result !== undefined) {
+      assertCreatureIntegrity(result, "removeLowImpactNeuron valid output");
+
+      const exported = result.exportJSON();
+      const hasNeuron = exported.neurons.some(
+        (n) => n.id === 1000001 && n.type === "hidden",
+      );
+      assertEquals(
+        hasNeuron,
+        false,
+        "Removed neuron should not exist as hidden",
+      );
+    }
+  },
+);
+
+Deno.test(
+  "addHelpfulNeurons produces a structurally valid creature",
+  async () => {
+    await initWasmForTests();
+    const creature = makeTestCreature();
+
+    const candidate: CandidateNeuron = {
+      fromNeuronId: 0,
+      toNeuronId: -1,
+      squash: IDENTITY.NAME,
+      bias: 0.1,
+      incomingWeight: 0.5,
+      outgoingWeight: 0.5,
+      targetNeuronImpact: 1.0,
+      expectedCreatureErrorReduction: 0.01,
+      expectedCreatureScoreGain: 0.01,
+      improvedCount: 5,
+      totalCount: 10,
+    };
+
+    const result = addHelpfulNeurons("test-valid", creature, [candidate]);
+
+    assert(result !== undefined, "Should produce a creature for valid input");
+    assertCreatureIntegrity(result, "addHelpfulNeurons valid output");
+
+    // The result should have more neurons than the original
+    const originalNeuronCount = creature.exportJSON().neurons.length;
+    const resultNeuronCount = result.exportJSON().neurons.length;
+    assert(
+      resultNeuronCount > originalNeuronCount,
+      "Result should have more neurons than original",
+    );
+  },
+);
+
+Deno.test(
+  "changeSquash produces a structurally valid creature",
+  async () => {
+    await initWasmForTests();
+    const creature = makeTestCreature();
+
+    const candidate: CandidateSquash = {
+      neuronId: 1000000,
+      previousSquash: IDENTITY.NAME,
+      squash: "LOGISTIC",
+      expectedCreatureScoreGain: 0.01,
+      improvedError: 0.005,
+      currentError: 0.01,
+    };
+
+    const result = changeSquash("test-valid", creature, [candidate]);
+
+    assert(result !== undefined, "Should produce a creature for valid input");
+    assertCreatureIntegrity(result, "changeSquash valid output");
+
+    // Verify the squash was actually changed
+    const exported = result.exportJSON();
+    const neuron = exported.neurons.find((n) => n.id === 1000000);
+    assertEquals(neuron?.squash, "LOGISTIC", "Squash should be changed");
   },
 );


### PR DESCRIPTION
## Summary

Replace defensive try-catch wrappers around `Creature.fromJSON()` in all 6
discovery operations with direct calls, now that root causes of invalid
creatures have been fixed (#2013, #2014, #2015, #2016). Pre-validation via
`assertValidSynapseReferences()` (already in place) catches any structural
issues before `fromJSON()` is called, so invalid creatures will cause immediate
assertion failures with diagnostics rather than being silently discarded. Closes
#2017.

## Changes

- **DiscoverySynapseOps.ts**: Removed try-catch from `removeSynapse()` and
  `addHelpfulSynapses()`
- **DiscoveryNeuronRemoval.ts**: Removed try-catch from `removeHarmfulNeuron()`
  and `removeLowImpactNeuron()`
- **DiscoveryNeuronAddition.ts**: Removed try-catch from `addHelpfulNeurons()`
  and `changeSquash()`
- **DiscoveryFromJSONRobustness.ts**: Updated test descriptions and added 6 new
  tests verifying each operation produces structurally valid creatures

## Evidence

All 5018 tests pass including 16 tests in the updated robustness test file and 7
in the integrity test file.

## Test Plan

- Existing tests for invalid candidate handling (non-existent neurons) retained
  and passing
- Added `removeSynapse produces a structurally valid creature`
- Added `addHelpfulSynapses produces a structurally valid creature`
- Added `removeHarmfulNeuron produces a structurally valid creature`
- Added `removeLowImpactNeuron produces a structurally valid creature`
- Added `addHelpfulNeurons produces a structurally valid creature`
- Added `changeSquash produces a structurally valid creature`

---

## Automated Fix Details
This PR addresses issue #2017: **Replace try-catch masking with assertions after root cause is fixed**

## Milestone
This PR is part of the **Discovery/Compact Structural Integrity** milestone and targets the `milestone/discovery-compact-structural-integrity` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2017
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2017 -->