### PR TITLE
Perf: Reduce allocations in ModWeight mutation focus filtering (#2044)

### DIFF
--- a/bench/ModWeightFocusFiltering.ts
+++ b/bench/ModWeightFocusFiltering.ts
@@ -1,0 +1,228 @@
+/**
+ * Benchmark: ModWeight focus filtering allocation reduction (Issue #2044)
+ *
+ * Measures the performance of focus-based connection filtering in ModWeight
+ * mutation with creatures of varying sizes and focus list lengths.
+ *
+ * The optimisation:
+ * - Previously: Set<Synapse> → Array.from(seen) → .filter(!frozen) (3 allocations)
+ * - Now: Single-pass building result array directly with inline dedup + frozen check
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write --allow-env --allow-ffi bench/ModWeightFocusFiltering.ts
+ */
+import { Creature } from "../src/Creature.ts";
+import { ModWeight } from "../src/mutate/ModWeight.ts";
+import type { CreatureInternal } from "../src/architecture/CreatureInterfaces.ts";
+
+/**
+ * Creates a creature with a specified number of hidden neurons and dense
+ * connectivity, simulating creatures with 100-500 synapses.
+ */
+function createCreature(hiddenCount: number): Creature {
+  const inputCount = 5;
+  const outputCount = 3;
+
+  const neurons: CreatureInternal["neurons"] = [];
+
+  // Hidden neurons
+  for (let i = 0; i < hiddenCount; i++) {
+    neurons.push({
+      bias: Math.random() * 0.2 - 0.1,
+      index: inputCount + i,
+      type: "hidden",
+      squash: "TANH",
+    });
+  }
+
+  // Output neurons
+  for (let i = 0; i < outputCount; i++) {
+    neurons.push({
+      bias: Math.random() * 0.2 - 0.1,
+      index: inputCount + hiddenCount + i,
+      type: "output",
+      squash: "IDENTITY",
+    });
+  }
+
+  const synapses: CreatureInternal["synapses"] = [];
+
+  // Connect inputs to first layer of hidden neurons
+  const firstLayerSize = Math.min(hiddenCount, 10);
+  for (let i = 0; i < inputCount; i++) {
+    for (let h = 0; h < firstLayerSize; h++) {
+      synapses.push({
+        weight: Math.random() * 2 - 1,
+        from: i,
+        to: inputCount + h,
+      });
+    }
+  }
+
+  // Connect hidden neurons in a feed-forward pattern
+  for (let h = 0; h < hiddenCount - 1; h++) {
+    const fromIdx = inputCount + h;
+    // Connect to next few hidden neurons
+    for (let j = 1; j <= Math.min(3, hiddenCount - h - 1); j++) {
+      synapses.push({
+        weight: Math.random() * 2 - 1,
+        from: fromIdx,
+        to: inputCount + h + j,
+      });
+    }
+  }
+
+  // Connect last hidden neurons to outputs
+  const lastLayerStart = Math.max(0, hiddenCount - 5);
+  for (let h = lastLayerStart; h < hiddenCount; h++) {
+    for (let o = 0; o < outputCount; o++) {
+      synapses.push({
+        weight: Math.random() * 2 - 1,
+        from: inputCount + h,
+        to: inputCount + hiddenCount + o,
+      });
+    }
+  }
+
+  // Freeze some synapses to exercise the frozen filtering
+  const frozenCount = Math.floor(synapses.length * 0.1);
+  for (let i = 0; i < frozenCount; i++) {
+    const idx = Math.floor(Math.random() * synapses.length);
+    synapses[idx].frozen = true;
+  }
+
+  const json: CreatureInternal = {
+    neurons,
+    synapses,
+    input: inputCount,
+    output: outputCount,
+  };
+
+  return Creature.fromJSON(json);
+}
+
+/**
+ * Creates a focus list of neuron indices centred around hidden neurons.
+ */
+function createFocusList(
+  creature: Creature,
+  focusSize: number,
+): number[] {
+  const inputCount = creature.input;
+  const totalNeurons = creature.neurons.length;
+  const focusList: number[] = [];
+
+  for (let i = 0; i < focusSize && i < totalNeurons; i++) {
+    // Spread focus across hidden and output neurons
+    const idx = inputCount + (i * 3) % (totalNeurons - inputCount);
+    if (!focusList.includes(idx)) {
+      focusList.push(idx);
+    }
+  }
+
+  return focusList;
+}
+
+// --- Small creature (~100 synapses) ---
+const smallCreature = createCreature(20);
+const smallFocus3 = createFocusList(smallCreature, 3);
+const smallFocus10 = createFocusList(smallCreature, 10);
+
+console.log("=== ModWeight Focus Filtering Benchmark (Issue #2044) ===");
+console.log(
+  `Small creature: ${smallCreature.neurons.length} neurons, ${smallCreature.synapses.length} synapses`,
+);
+
+Deno.bench({
+  name: "Small creature (~100 syn), focus=3",
+  group: "ModWeight focus filtering",
+  fn() {
+    new ModWeight(smallCreature).mutate(smallFocus3);
+  },
+});
+
+Deno.bench({
+  name: "Small creature (~100 syn), focus=10",
+  group: "ModWeight focus filtering",
+  fn() {
+    new ModWeight(smallCreature).mutate(smallFocus10);
+  },
+});
+
+// --- Medium creature (~250 synapses) ---
+const mediumCreature = createCreature(60);
+const mediumFocus3 = createFocusList(mediumCreature, 3);
+const mediumFocus10 = createFocusList(mediumCreature, 10);
+const mediumFocus20 = createFocusList(mediumCreature, 20);
+
+console.log(
+  `Medium creature: ${mediumCreature.neurons.length} neurons, ${mediumCreature.synapses.length} synapses`,
+);
+
+Deno.bench({
+  name: "Medium creature (~250 syn), focus=3",
+  group: "ModWeight focus filtering",
+  fn() {
+    new ModWeight(mediumCreature).mutate(mediumFocus3);
+  },
+});
+
+Deno.bench({
+  name: "Medium creature (~250 syn), focus=10",
+  group: "ModWeight focus filtering",
+  fn() {
+    new ModWeight(mediumCreature).mutate(mediumFocus10);
+  },
+});
+
+Deno.bench({
+  name: "Medium creature (~250 syn), focus=20",
+  group: "ModWeight focus filtering",
+  fn() {
+    new ModWeight(mediumCreature).mutate(mediumFocus20);
+  },
+});
+
+// --- Large creature (~500 synapses) ---
+const largeCreature = createCreature(130);
+const largeFocus5 = createFocusList(largeCreature, 5);
+const largeFocus15 = createFocusList(largeCreature, 15);
+const largeFocus30 = createFocusList(largeCreature, 30);
+
+console.log(
+  `Large creature: ${largeCreature.neurons.length} neurons, ${largeCreature.synapses.length} synapses`,
+);
+
+Deno.bench({
+  name: "Large creature (~500 syn), focus=5",
+  group: "ModWeight focus filtering",
+  fn() {
+    new ModWeight(largeCreature).mutate(largeFocus5);
+  },
+});
+
+Deno.bench({
+  name: "Large creature (~500 syn), focus=15",
+  group: "ModWeight focus filtering",
+  fn() {
+    new ModWeight(largeCreature).mutate(largeFocus15);
+  },
+});
+
+Deno.bench({
+  name: "Large creature (~500 syn), focus=30",
+  group: "ModWeight focus filtering",
+  fn() {
+    new ModWeight(largeCreature).mutate(largeFocus30);
+  },
+});
+
+// --- Baseline: No focus list (all synapses) ---
+Deno.bench({
+  name: "Large creature (~500 syn), no focus (baseline)",
+  group: "ModWeight focus filtering",
+  baseline: true,
+  fn() {
+    new ModWeight(largeCreature).mutate();
+  },
+});

--- a/docs/pr-summary-2044.md
+++ b/docs/pr-summary-2044.md
@@ -1,27 +1,41 @@
 ## Summary
 
-Reduce intermediate allocations in ModWeight focus-based connection filtering from 3 to 2 by replacing the `Set<Synapse>` → `Array.from(seen)` → `.filter(!frozen)` chain with a single-pass approach that builds the result array directly while deduplicating and checking frozen status inline. Closes #2044.
+Reduce intermediate allocations in ModWeight focus-based connection filtering
+from 3 to 2 by replacing the `Set<Synapse>` → `Array.from(seen)` →
+`.filter(!frozen)` chain with a single-pass approach that builds the result
+array directly while deduplicating and checking frozen status inline. Closes
+#2044.
 
 ## Evidence
 
 ### Benchmark results (Apple M4 Pro, Deno 2.7.8)
 
-| Scenario | Before (avg) | After (avg) | Change |
-|---|---|---|---|
-| Small (~119 syn), focus=3 | 1.1 µs | 1.1 µs | ~same |
-| Small (~119 syn), focus=10 | 2.1 µs | 2.2 µs | ~same |
-| Medium (~239 syn), focus=3 | 1.1 µs | 1.1 µs | ~same |
-| Medium (~239 syn), focus=10 | 2.0 µs | 1.8 µs | ~10% faster |
-| Medium (~239 syn), focus=20 | 2.7 µs | 2.8 µs | ~same |
-| Large (~449 syn), focus=5 | 1.4 µs | 1.4 µs | ~same |
-| Large (~449 syn), focus=15 | 2.3 µs | 2.4 µs | ~same |
-| Large (~449 syn), focus=30 | 4.1 µs | 4.1 µs | ~same |
+| Scenario                    | Before (avg) | After (avg) | Change      |
+| --------------------------- | ------------ | ----------- | ----------- |
+| Small (~119 syn), focus=3   | 1.1 µs       | 1.1 µs      | ~same       |
+| Small (~119 syn), focus=10  | 2.1 µs       | 2.2 µs      | ~same       |
+| Medium (~239 syn), focus=3  | 1.1 µs       | 1.1 µs      | ~same       |
+| Medium (~239 syn), focus=10 | 2.0 µs       | 1.8 µs      | ~10% faster |
+| Medium (~239 syn), focus=20 | 2.7 µs       | 2.8 µs      | ~same       |
+| Large (~449 syn), focus=5   | 1.4 µs       | 1.4 µs      | ~same       |
+| Large (~449 syn), focus=15  | 2.3 µs       | 2.4 µs      | ~same       |
+| Large (~449 syn), focus=30  | 4.1 µs       | 4.1 µs      | ~same       |
 
-The throughput improvement is modest (~10% at medium focus sizes) since these operations are already sub-microsecond. The primary benefit is reduced GC pressure: eliminating the `Array.from()` and `.filter()` intermediate arrays means fewer short-lived allocations per mutation call, which compounds over thousands of mutations per generation.
+The throughput improvement is modest (~10% at medium focus sizes) since these
+operations are already sub-microsecond. The primary benefit is reduced GC
+pressure: eliminating the `Array.from()` and `.filter()` intermediate arrays
+means fewer short-lived allocations per mutation call, which compounds over
+thousands of mutations per generation.
 
 ## Test Plan
 
 - Existing tests: All 20 ModWeight tests pass unchanged
-- New test: `ModWeight - focus filtering excludes frozen synapses` — verifies frozen synapses are correctly excluded in the single-pass approach
-- New test: `ModWeight - focus with overlapping connections deduplicates correctly` — verifies shared synapses between multiple focus neurons are not over-represented
-- New benchmark: `bench/ModWeightFocusFiltering.ts` — measures focus filtering performance across creature sizes (100-500 synapses) and focus list sizes (3-30)
+- New test: `ModWeight - focus filtering excludes frozen synapses` — verifies
+  frozen synapses are correctly excluded in the single-pass approach
+- New test:
+  `ModWeight - focus with overlapping connections deduplicates correctly` —
+  verifies shared synapses between multiple focus neurons are not
+  over-represented
+- New benchmark: `bench/ModWeightFocusFiltering.ts` — measures focus filtering
+  performance across creature sizes (100-500 synapses) and focus list sizes
+  (3-30)

--- a/docs/pr-summary-2044.md
+++ b/docs/pr-summary-2044.md
@@ -1,0 +1,27 @@
+## Summary
+
+Reduce intermediate allocations in ModWeight focus-based connection filtering from 3 to 2 by replacing the `Set<Synapse>` → `Array.from(seen)` → `.filter(!frozen)` chain with a single-pass approach that builds the result array directly while deduplicating and checking frozen status inline. Closes #2044.
+
+## Evidence
+
+### Benchmark results (Apple M4 Pro, Deno 2.7.8)
+
+| Scenario | Before (avg) | After (avg) | Change |
+|---|---|---|---|
+| Small (~119 syn), focus=3 | 1.1 µs | 1.1 µs | ~same |
+| Small (~119 syn), focus=10 | 2.1 µs | 2.2 µs | ~same |
+| Medium (~239 syn), focus=3 | 1.1 µs | 1.1 µs | ~same |
+| Medium (~239 syn), focus=10 | 2.0 µs | 1.8 µs | ~10% faster |
+| Medium (~239 syn), focus=20 | 2.7 µs | 2.8 µs | ~same |
+| Large (~449 syn), focus=5 | 1.4 µs | 1.4 µs | ~same |
+| Large (~449 syn), focus=15 | 2.3 µs | 2.4 µs | ~same |
+| Large (~449 syn), focus=30 | 4.1 µs | 4.1 µs | ~same |
+
+The throughput improvement is modest (~10% at medium focus sizes) since these operations are already sub-microsecond. The primary benefit is reduced GC pressure: eliminating the `Array.from()` and `.filter()` intermediate arrays means fewer short-lived allocations per mutation call, which compounds over thousands of mutations per generation.
+
+## Test Plan
+
+- Existing tests: All 20 ModWeight tests pass unchanged
+- New test: `ModWeight - focus filtering excludes frozen synapses` — verifies frozen synapses are correctly excluded in the single-pass approach
+- New test: `ModWeight - focus with overlapping connections deduplicates correctly` — verifies shared synapses between multiple focus neurons are not over-represented
+- New benchmark: `bench/ModWeightFocusFiltering.ts` — measures focus filtering performance across creature sizes (100-500 synapses) and focus list sizes (3-30)

--- a/src/mutate/ModWeight.ts
+++ b/src/mutate/ModWeight.ts
@@ -46,20 +46,24 @@ export class ModWeight extends AbstractMutationOperator {
       // No focus - use all non-frozen connections
       relevantConnections = this.creature.synapses.filter((s) => !s.frozen);
     } else {
-      // Collect synapses connected to focused neurons using indexed lookups
-      // This is O(focusList.length * (log n + k)) instead of O(synapses * focusList)
+      // Single-pass: collect non-frozen, deduplicated synapses directly
+      // Issue #2044: Avoids triple allocation (Set → Array.from → .filter)
+      relevantConnections = [];
       const seen = new Set<Synapse>();
       for (const focusIndex of focusList) {
-        // Get outward connections from focus neuron
         for (const syn of this.creature.outwardConnections(focusIndex)) {
-          seen.add(syn);
+          if (!syn.frozen && !seen.has(syn)) {
+            seen.add(syn);
+            relevantConnections.push(syn);
+          }
         }
-        // Get inward connections to focus neuron
         for (const syn of this.creature.inwardConnections(focusIndex)) {
-          seen.add(syn);
+          if (!syn.frozen && !seen.has(syn)) {
+            seen.add(syn);
+            relevantConnections.push(syn);
+          }
         }
       }
-      relevantConnections = Array.from(seen).filter((s) => !s.frozen);
     }
 
     let changed = false;

--- a/test/mutate/ModWeightFocus.ts
+++ b/test/mutate/ModWeightFocus.ts
@@ -211,3 +211,130 @@ Deno.test("ModWeight - collects synapses from both inward and outward connection
     "Should NOT modify synapse not connected to focused neuron",
   );
 });
+
+Deno.test("ModWeight - focus filtering excludes frozen synapses", () => {
+  // Issue #2044: Verify frozen synapses are excluded during single-pass filtering
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden" as const,
+        uuid: "hidden-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5, frozen: true },
+      { fromUUID: "input-1", toUUID: "hidden-1", weight: 0.6 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.7, frozen: true },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Focus on hidden-1 (index 2) — all 3 synapses connect to it,
+  // but 2 are frozen so only input-1→hidden-1 should be modifiable
+  const focusList = [2];
+
+  const initialFrozenWeights = creature.synapses
+    .filter((s) => s.frozen)
+    .map((s) => s.weight);
+
+  for (let i = 0; i < 100; i++) {
+    new ModWeight(creature).mutate(focusList);
+  }
+
+  // Frozen synapses must remain unchanged
+  const frozenSynapses = creature.synapses.filter((s) => s.frozen);
+  for (let i = 0; i < frozenSynapses.length; i++) {
+    assertEquals(
+      frozenSynapses[i].weight,
+      initialFrozenWeights[i],
+      `Frozen synapse ${frozenSynapses[i].from}->${
+        frozenSynapses[i].to
+      } weight should not change`,
+    );
+  }
+});
+
+Deno.test("ModWeight - focus with overlapping connections deduplicates correctly", () => {
+  // Issue #2044: When multiple focus neurons share a synapse, it should
+  // only appear once in the candidate list (not be over-represented)
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden" as const,
+        uuid: "hidden-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 0.6 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.7 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Focus on both hidden-1 (index 2) and output-0 (index 3)
+  // The synapse hidden-1→output-0 is both outward from 2 and inward to 3
+  // It should not be double-counted
+  const focusList = [2, 3];
+
+  // Run many mutations and track modification distribution
+  const modCounts = new Map<string, number>();
+  for (const syn of creature.synapses) {
+    modCounts.set(`${syn.from}->${syn.to}`, 0);
+  }
+
+  const iterations = 3000;
+  for (let i = 0; i < iterations; i++) {
+    const initialWeights = creature.synapses.map((s) => s.weight);
+    new ModWeight(creature).mutate(focusList);
+
+    for (let j = 0; j < creature.synapses.length; j++) {
+      if (initialWeights[j] !== creature.synapses[j].weight) {
+        const key = `${creature.synapses[j].from}->${creature.synapses[j].to}`;
+        modCounts.set(key, (modCounts.get(key) ?? 0) + 1);
+      }
+    }
+  }
+
+  // All three synapses connect to the focus list, so all should be modified
+  for (const [key, count] of modCounts) {
+    assert(count > 0, `Synapse ${key} should have been modified at least once`);
+  }
+
+  // If deduplication is broken, the shared synapse (2->3) would be picked
+  // roughly twice as often. With correct dedup, each of the 3 synapses should
+  // be picked approximately 1/3 of the time. Allow a wide tolerance but check
+  // that no single synapse dominates more than 60% of modifications.
+  const totalMods = [...modCounts.values()].reduce((a, b) => a + b, 0);
+  for (const [key, count] of modCounts) {
+    const ratio = count / totalMods;
+    assert(
+      ratio < 0.6,
+      `Synapse ${key} was modified ${
+        (ratio * 100).toFixed(1)
+      }% of the time — possible deduplication failure`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Reduce intermediate allocations in ModWeight focus-based connection filtering
from 3 to 2 by replacing the `Set<Synapse>` → `Array.from(seen)` →
`.filter(!frozen)` chain with a single-pass approach that builds the result
array directly while deduplicating and checking frozen status inline. Closes
#2044.

## Evidence

### Benchmark results (Apple M4 Pro, Deno 2.7.8)

| Scenario                    | Before (avg) | After (avg) | Change      |
| --------------------------- | ------------ | ----------- | ----------- |
| Small (~119 syn), focus=3   | 1.1 µs       | 1.1 µs      | ~same       |
| Small (~119 syn), focus=10  | 2.1 µs       | 2.2 µs      | ~same       |
| Medium (~239 syn), focus=3  | 1.1 µs       | 1.1 µs      | ~same       |
| Medium (~239 syn), focus=10 | 2.0 µs       | 1.8 µs      | ~10% faster |
| Medium (~239 syn), focus=20 | 2.7 µs       | 2.8 µs      | ~same       |
| Large (~449 syn), focus=5   | 1.4 µs       | 1.4 µs      | ~same       |
| Large (~449 syn), focus=15  | 2.3 µs       | 2.4 µs      | ~same       |
| Large (~449 syn), focus=30  | 4.1 µs       | 4.1 µs      | ~same       |

The throughput improvement is modest (~10% at medium focus sizes) since these
operations are already sub-microsecond. The primary benefit is reduced GC
pressure: eliminating the `Array.from()` and `.filter()` intermediate arrays
means fewer short-lived allocations per mutation call, which compounds over
thousands of mutations per generation.

## Test Plan

- Existing tests: All 20 ModWeight tests pass unchanged
- New test: `ModWeight - focus filtering excludes frozen synapses` — verifies
  frozen synapses are correctly excluded in the single-pass approach
- New test:
  `ModWeight - focus with overlapping connections deduplicates correctly` —
  verifies shared synapses between multiple focus neurons are not
  over-represented
- New benchmark: `bench/ModWeightFocusFiltering.ts` — measures focus filtering
  performance across creature sizes (100-500 synapses) and focus list sizes
  (3-30)

---

## Automated Fix Details
This PR addresses issue #2044: **Perf: Reduce allocations in ModWeight mutation focus filtering**

## Milestone
This PR is part of the **Performance Improvements** milestone and targets the `milestone/performance-improvements` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2044
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2044 -->