### PR TITLE
Perf: Cache non-expansion mutation candidates in Mutator (#2045)

### DIFF
--- a/bench/MutatorNonExpansionCache.ts
+++ b/bench/MutatorNonExpansionCache.ts
@@ -1,0 +1,85 @@
+import { createNeatConfig } from "../src/config/NeatConfig.ts";
+import { Creature } from "../src/Creature.ts";
+import { Mutator } from "../src/NEAT/Mutator.ts";
+import { Mutation } from "../src/NEAT/Mutation.ts";
+
+/**
+ * Benchmark for non-expansion candidate caching in mutation selection.
+ *
+ * Issue #2045: Cache non-expansion mutation candidates for large creatures.
+ *
+ * For large creatures (>= large threshold, default 300 neurons), the
+ * selectMutationMethod() function filters candidates to exclude topology
+ * expansion mutations (ADD_NODE, ADD_CONN). This benchmark measures the
+ * performance of this filtering with cached vs uncached approaches.
+ */
+
+const config = createNeatConfig({
+  mutation: Mutation.FFW,
+  adaptiveMutationThresholds: {
+    medium: 100,
+    large: 300,
+    largeTopologyWeight: 0.1,
+  },
+});
+const mutator = new Mutator(config);
+
+// Large creature (>= 300 neurons) — exercises the non-expansion candidate path
+const largeCreature = new Creature(10, 5, {
+  layers: [{ count: 150 }, { count: 150 }],
+});
+
+// Very large creature (500+ neurons) — as specified in the issue
+const veryLargeCreature = new Creature(20, 10, {
+  layers: [{ count: 250 }, { count: 250 }],
+});
+
+// Small creature (below thresholds) — for comparison baseline
+const smallCreature = new Creature(3, 2, { layers: [{ count: 2 }] });
+
+Deno.bench("selectMutationMethod: small creature (baseline) x1000", () => {
+  for (let i = 0; i < 1000; i++) {
+    mutator.selectMutationMethod(smallCreature);
+  }
+});
+
+Deno.bench(
+  "selectMutationMethod: large creature (300+ neurons) x1000",
+  () => {
+    for (let i = 0; i < 1000; i++) {
+      mutator.selectMutationMethod(largeCreature);
+    }
+  },
+);
+
+Deno.bench(
+  "selectMutationMethod: very large creature (500+ neurons) x1000",
+  () => {
+    for (let i = 0; i < 1000; i++) {
+      mutator.selectMutationMethod(veryLargeCreature);
+    }
+  },
+);
+
+// Simulate real evolution loop: multiple mutations per creature
+Deno.bench(
+  "selectMutationMethod: large creature mutationAmount=5 x100 creatures",
+  () => {
+    for (let c = 0; c < 100; c++) {
+      for (let m = 0; m < 5; m++) {
+        mutator.selectMutationMethod(largeCreature);
+      }
+    }
+  },
+);
+
+Deno.bench(
+  "selectMutationMethod: very large creature mutationAmount=5 x100 creatures",
+  () => {
+    for (let c = 0; c < 100; c++) {
+      for (let m = 0; m < 5; m++) {
+        mutator.selectMutationMethod(veryLargeCreature);
+      }
+    }
+  },
+);

--- a/docs/pr-summary-2045.md
+++ b/docs/pr-summary-2045.md
@@ -1,0 +1,41 @@
+## Summary
+
+Cache non-expansion mutation candidates in `Mutator.selectMutationMethod()` for large creatures. Previously, a new filtered array was created on every call via `candidates.filter()`. Now the filtered result is pre-computed in `computeMutationCandidates()` and stored in the `MutationCacheEntry` alongside existing cached data. Closes #2045.
+
+## Evidence
+
+### Benchmark Results (Apple M4 Pro, Deno 2.7.8)
+
+**Baseline (before change) — `bench/MutatorCacheValidMutations.ts`:**
+| Benchmark | time/iter (avg) |
+|---|---|
+| large creature x1 (cached) | 481.6 ns |
+| large creature x100 (cached) | 48.5 µs |
+| large creature x1000 (cached) | 473.0 µs |
+
+**After change — `bench/MutatorNonExpansionCache.ts`:**
+| Benchmark | time/iter (avg) |
+|---|---|
+| large creature (300+ neurons) x1000 | 484.0 µs |
+| very large creature (500+ neurons) x1000 | 481.2 µs |
+| large creature mutationAmount=5 x100 creatures | 245.1 µs |
+| very large creature mutationAmount=5 x100 creatures | 245.6 µs |
+
+Performance is consistent with no regression. The primary benefit is eliminating per-call array allocations (`.filter()` creating a new array on every `selectMutationMethod()` invocation) for large creatures, reducing GC pressure during evolution loops.
+
+### What changed
+
+- Added `nonExpansionCandidates` field to `MutationCacheEntry` interface
+- Pre-compute the filtered array in `computeMutationCandidates()` once per cache key
+- Use cached `nonExpansionCandidates` in `selectMutationMethod()` instead of filtering inline
+
+## Test Plan
+
+- Added `test/NEAT/MutatorNonExpansionCache.ts` with 5 tests:
+  - Large creatures never select ADD_NODE/ADD_CONN from non-expansion path
+  - Cached results are consistent across repeated calls
+  - Cache invalidation works when cache is cleared
+  - Different creature sizes use separate cache entries
+  - Non-expansion candidates exclude only ADD_NODE and ADD_CONN
+- Added `bench/MutatorNonExpansionCache.ts` benchmarking 300+ and 500+ neuron creatures
+- All 5055 existing tests pass

--- a/docs/pr-summary-2045.md
+++ b/docs/pr-summary-2045.md
@@ -1,33 +1,44 @@
 ## Summary
 
-Cache non-expansion mutation candidates in `Mutator.selectMutationMethod()` for large creatures. Previously, a new filtered array was created on every call via `candidates.filter()`. Now the filtered result is pre-computed in `computeMutationCandidates()` and stored in the `MutationCacheEntry` alongside existing cached data. Closes #2045.
+Cache non-expansion mutation candidates in `Mutator.selectMutationMethod()` for
+large creatures. Previously, a new filtered array was created on every call via
+`candidates.filter()`. Now the filtered result is pre-computed in
+`computeMutationCandidates()` and stored in the `MutationCacheEntry` alongside
+existing cached data. Closes #2045.
 
 ## Evidence
 
 ### Benchmark Results (Apple M4 Pro, Deno 2.7.8)
 
 **Baseline (before change) — `bench/MutatorCacheValidMutations.ts`:**
-| Benchmark | time/iter (avg) |
-|---|---|
-| large creature x1 (cached) | 481.6 ns |
-| large creature x100 (cached) | 48.5 µs |
-| large creature x1000 (cached) | 473.0 µs |
+
+| Benchmark                     | time/iter (avg) |
+| ----------------------------- | --------------- |
+| large creature x1 (cached)    | 481.6 ns        |
+| large creature x100 (cached)  | 48.5 µs         |
+| large creature x1000 (cached) | 473.0 µs        |
 
 **After change — `bench/MutatorNonExpansionCache.ts`:**
-| Benchmark | time/iter (avg) |
-|---|---|
-| large creature (300+ neurons) x1000 | 484.0 µs |
-| very large creature (500+ neurons) x1000 | 481.2 µs |
-| large creature mutationAmount=5 x100 creatures | 245.1 µs |
-| very large creature mutationAmount=5 x100 creatures | 245.6 µs |
 
-Performance is consistent with no regression. The primary benefit is eliminating per-call array allocations (`.filter()` creating a new array on every `selectMutationMethod()` invocation) for large creatures, reducing GC pressure during evolution loops.
+| Benchmark                                           | time/iter (avg) |
+| --------------------------------------------------- | --------------- |
+| large creature (300+ neurons) x1000                 | 484.0 µs        |
+| very large creature (500+ neurons) x1000            | 481.2 µs        |
+| large creature mutationAmount=5 x100 creatures      | 245.1 µs        |
+| very large creature mutationAmount=5 x100 creatures | 245.6 µs        |
+
+Performance is consistent with no regression. The primary benefit is eliminating
+per-call array allocations (`.filter()` creating a new array on every
+`selectMutationMethod()` invocation) for large creatures, reducing GC pressure
+during evolution loops.
 
 ### What changed
 
 - Added `nonExpansionCandidates` field to `MutationCacheEntry` interface
-- Pre-compute the filtered array in `computeMutationCandidates()` once per cache key
-- Use cached `nonExpansionCandidates` in `selectMutationMethod()` instead of filtering inline
+- Pre-compute the filtered array in `computeMutationCandidates()` once per cache
+  key
+- Use cached `nonExpansionCandidates` in `selectMutationMethod()` instead of
+  filtering inline
 
 ## Test Plan
 
@@ -37,5 +48,6 @@ Performance is consistent with no regression. The primary benefit is eliminating
   - Cache invalidation works when cache is cleared
   - Different creature sizes use separate cache entries
   - Non-expansion candidates exclude only ADD_NODE and ADD_CONN
-- Added `bench/MutatorNonExpansionCache.ts` benchmarking 300+ and 500+ neuron creatures
+- Added `bench/MutatorNonExpansionCache.ts` benchmarking 300+ and 500+ neuron
+  creatures
 - All 5055 existing tests pass

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -37,12 +37,15 @@ import {
 /**
  * Cache entry for valid mutation candidates.
  * Stores both the filtered candidates and pre-computed weight/bias count.
+ * Issue #2045: Also caches non-expansion candidates for large creatures.
  */
 interface MutationCacheEntry {
   /** Filtered mutation methods that are valid for this creature state. */
   candidates: ReadonlyArray<{ name: string }>;
   /** Count of weight/bias mutations in candidates (for weighted selection). */
   weightBiasCount: number;
+  /** Candidates excluding topology expansion mutations (ADD_NODE, ADD_CONN). */
+  nonExpansionCandidates: ReadonlyArray<{ name: string }>;
 }
 
 export class Mutator {
@@ -351,7 +354,12 @@ export class Mutator {
       }
     }
 
-    return { candidates, weightBiasCount };
+    // Issue #2045: Pre-filter non-expansion candidates for large creature path.
+    const nonExpansionCandidates = candidates.filter((c) =>
+      !this.isTopologyExpansionMutation(c.name)
+    );
+
+    return { candidates, weightBiasCount, nonExpansionCandidates };
   }
 
   /**
@@ -416,7 +424,7 @@ export class Mutator {
       this.mutationCache.set(cacheKey, cacheEntry);
     }
 
-    const { candidates, weightBiasCount } = cacheEntry;
+    const { candidates, weightBiasCount, nonExpansionCandidates } = cacheEntry;
 
     if (candidates.length === 0) {
       throw new ValidationError(
@@ -473,13 +481,10 @@ export class Mutator {
       }
     }
 
-    // For large creatures, further filter to exclude topology expansion mutations
-    // unless we explicitly pass the topology weight check above
+    // For large creatures, use cached non-expansion candidates to avoid
+    // topology expansion unless we explicitly passed the topology weight check above.
+    // Issue #2045: Use pre-filtered cache instead of filtering on every call.
     if (neuronCount >= large && largeTopologyWeight < 1.0) {
-      // Build list of non-expansion candidates
-      const nonExpansionCandidates = candidates.filter((c) =>
-        !this.isTopologyExpansionMutation(c.name)
-      );
       if (nonExpansionCandidates.length > 0) {
         return nonExpansionCandidates[
           Math.floor(rng.random() * nonExpansionCandidates.length)

--- a/test/NEAT/MutatorNonExpansionCache.ts
+++ b/test/NEAT/MutatorNonExpansionCache.ts
@@ -1,0 +1,250 @@
+import { assert, assertEquals } from "@std/assert";
+import { createNeatConfig } from "../../src/config/NeatConfig.ts";
+import { Creature } from "../../src/Creature.ts";
+import { Mutator } from "../../src/NEAT/Mutator.ts";
+import { Mutation } from "../../src/NEAT/Mutation.ts";
+
+/**
+ * Tests for caching non-expansion mutation candidates for large creatures.
+ *
+ * Issue #2045: The selectMutationMethod() function creates a new filtered array
+ * of non-expansion candidates on every call for large creatures. Since the
+ * candidate list for a given creature size category doesn't change, this
+ * filtered result should be cached alongside the existing candidates cache.
+ */
+
+Deno.test(
+  "NonExpansionCache: large creatures never select ADD_NODE/ADD_CONN from non-expansion path",
+  () => {
+    const config = createNeatConfig({
+      mutation: Mutation.FFW,
+      adaptiveMutationThresholds: {
+        medium: 100,
+        large: 300,
+        largeTopologyWeight: 0, // Disable topology expansion completely
+      },
+    });
+    const mutator = new Mutator(config);
+
+    // Create a large creature (>= 300 neurons)
+    const creature = new Creature(10, 5, {
+      layers: [{ count: 150 }, { count: 150 }],
+    });
+    assert(
+      creature.neurons.length >= 300,
+      `Creature should have >= 300 neurons, has ${creature.neurons.length}`,
+    );
+
+    // With largeTopologyWeight=0, should never get ADD_NODE or ADD_CONN
+    for (let i = 0; i < 1000; i++) {
+      const method = mutator.selectMutationMethod(creature);
+      assert(
+        method.name !== Mutation.ADD_NODE.name &&
+          method.name !== Mutation.ADD_CONN.name,
+        `Should not select topology expansion mutation ${method.name} for large creature`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "NonExpansionCache: cached results are consistent across repeated calls",
+  () => {
+    const config = createNeatConfig({
+      mutation: Mutation.FFW,
+      adaptiveMutationThresholds: {
+        medium: 100,
+        large: 300,
+        largeTopologyWeight: 0.1,
+      },
+    });
+    const mutator = new Mutator(config);
+
+    // Create a large creature
+    const creature = new Creature(10, 5, {
+      layers: [{ count: 150 }, { count: 150 }],
+    });
+
+    // Collect mutation distributions over two separate runs
+    // Both should produce valid mutations from the same cached candidates
+    const collectDistribution = (iterations: number) => {
+      const counts: Record<string, number> = {};
+      for (let i = 0; i < iterations; i++) {
+        const method = mutator.selectMutationMethod(creature);
+        counts[method.name] = (counts[method.name] || 0) + 1;
+      }
+      return counts;
+    };
+
+    const dist1 = collectDistribution(5000);
+    const dist2 = collectDistribution(5000);
+
+    // Both distributions should have the same set of mutation types
+    const types1 = new Set(Object.keys(dist1));
+    const types2 = new Set(Object.keys(dist2));
+
+    // All types from dist2 should appear in dist1 (with enough samples)
+    for (const type of types2) {
+      assert(
+        types1.has(type),
+        `Mutation type ${type} appeared in second run but not first`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "NonExpansionCache: cache invalidation works when cache is cleared",
+  () => {
+    const config = createNeatConfig({
+      mutation: Mutation.FFW,
+      adaptiveMutationThresholds: {
+        medium: 100,
+        large: 300,
+        largeTopologyWeight: 0,
+      },
+    });
+    const mutator = new Mutator(config);
+
+    // Create a large creature
+    const creature = new Creature(10, 5, {
+      layers: [{ count: 150 }, { count: 150 }],
+    });
+
+    // First call populates cache
+    const method1 = mutator.selectMutationMethod(creature);
+    assertEquals(typeof method1.name, "string", "Should return valid mutation");
+
+    // Clear cache
+    mutator.clearMutationCache();
+
+    // Second call should repopulate cache and still work
+    const method2 = mutator.selectMutationMethod(creature);
+    assertEquals(
+      typeof method2.name,
+      "string",
+      "Should return valid mutation after cache clear",
+    );
+
+    // Both should be non-expansion mutations (largeTopologyWeight=0)
+    assert(
+      method1.name !== Mutation.ADD_NODE.name &&
+        method1.name !== Mutation.ADD_CONN.name,
+      `Pre-clear mutation should not be topology expansion: ${method1.name}`,
+    );
+    assert(
+      method2.name !== Mutation.ADD_NODE.name &&
+        method2.name !== Mutation.ADD_CONN.name,
+      `Post-clear mutation should not be topology expansion: ${method2.name}`,
+    );
+  },
+);
+
+Deno.test(
+  "NonExpansionCache: different creature sizes use separate cache entries",
+  () => {
+    const config = createNeatConfig({
+      mutation: Mutation.FFW,
+      adaptiveMutationThresholds: {
+        medium: 100,
+        large: 300,
+        largeTopologyWeight: 0,
+      },
+    });
+    const mutator = new Mutator(config);
+
+    // Small creature — should still get topology expansion mutations
+    const smallCreature = new Creature(3, 2, { layers: [{ count: 2 }] });
+    assert(
+      smallCreature.neurons.length < 100,
+      `Small creature should have < 100 neurons`,
+    );
+
+    // Large creature — should never get topology expansion
+    const largeCreature = new Creature(10, 5, {
+      layers: [{ count: 150 }, { count: 150 }],
+    });
+    assert(
+      largeCreature.neurons.length >= 300,
+      `Large creature should have >= 300 neurons`,
+    );
+
+    // Interleave calls to both creatures
+    let smallTopologyExpansion = 0;
+    for (let i = 0; i < 1000; i++) {
+      const smallMethod = mutator.selectMutationMethod(smallCreature);
+      const largeMethod = mutator.selectMutationMethod(largeCreature);
+
+      if (
+        smallMethod.name === Mutation.ADD_NODE.name ||
+        smallMethod.name === Mutation.ADD_CONN.name
+      ) {
+        smallTopologyExpansion++;
+      }
+
+      // Large creature should never get expansion mutations
+      assert(
+        largeMethod.name !== Mutation.ADD_NODE.name &&
+          largeMethod.name !== Mutation.ADD_CONN.name,
+        `Large creature should not get topology expansion: ${largeMethod.name}`,
+      );
+    }
+
+    // Small creature should get some topology expansion mutations
+    assert(
+      smallTopologyExpansion > 0,
+      "Small creature should occasionally get topology expansion mutations",
+    );
+  },
+);
+
+Deno.test(
+  "NonExpansionCache: non-expansion candidates exclude only ADD_NODE and ADD_CONN",
+  () => {
+    // Use largeTopologyWeight=0.1 so 90% of the time we get weight/bias preference,
+    // but the remaining 10% exercises the non-expansion fallback path.
+    // With enough iterations, non-expansion structural mutations will appear.
+    const config = createNeatConfig({
+      mutation: Mutation.FFW,
+      adaptiveMutationThresholds: {
+        medium: 100,
+        large: 300,
+        largeTopologyWeight: 0.1,
+      },
+    });
+    const mutator = new Mutator(config);
+
+    // Create a large creature with hidden neurons
+    const creature = new Creature(10, 5, {
+      layers: [{ count: 150 }, { count: 150 }],
+    });
+
+    // Collect all mutation types selected over many iterations
+    const selectedTypes = new Set<string>();
+    for (let i = 0; i < 10_000; i++) {
+      const method = mutator.selectMutationMethod(creature);
+      selectedTypes.add(method.name);
+    }
+
+    // Should include weight/bias mutations
+    assert(
+      selectedTypes.has(Mutation.MOD_WEIGHT.name),
+      "Should select MOD_WEIGHT",
+    );
+    assert(
+      selectedTypes.has(Mutation.MOD_BIAS.name),
+      "Should select MOD_BIAS",
+    );
+
+    // Other structural mutations (SUB_NODE, SUB_CONN, SWAP_NODES, MOD_SQUASH)
+    // should still appear via the non-expansion fallback path
+    assert(
+      selectedTypes.has(Mutation.SUB_NODE.name),
+      "Should still select SUB_NODE (not a topology expansion mutation)",
+    );
+    assert(
+      selectedTypes.has(Mutation.SUB_CONN.name),
+      "Should still select SUB_CONN (not a topology expansion mutation)",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Cache non-expansion mutation candidates in `Mutator.selectMutationMethod()` for
large creatures. Previously, a new filtered array was created on every call via
`candidates.filter()`. Now the filtered result is pre-computed in
`computeMutationCandidates()` and stored in the `MutationCacheEntry` alongside
existing cached data. Closes #2045.

## Evidence

### Benchmark Results (Apple M4 Pro, Deno 2.7.8)

**Baseline (before change) — `bench/MutatorCacheValidMutations.ts`:**

| Benchmark                     | time/iter (avg) |
| ----------------------------- | --------------- |
| large creature x1 (cached)    | 481.6 ns        |
| large creature x100 (cached)  | 48.5 µs         |
| large creature x1000 (cached) | 473.0 µs        |

**After change — `bench/MutatorNonExpansionCache.ts`:**

| Benchmark                                           | time/iter (avg) |
| --------------------------------------------------- | --------------- |
| large creature (300+ neurons) x1000                 | 484.0 µs        |
| very large creature (500+ neurons) x1000            | 481.2 µs        |
| large creature mutationAmount=5 x100 creatures      | 245.1 µs        |
| very large creature mutationAmount=5 x100 creatures | 245.6 µs        |

Performance is consistent with no regression. The primary benefit is eliminating
per-call array allocations (`.filter()` creating a new array on every
`selectMutationMethod()` invocation) for large creatures, reducing GC pressure
during evolution loops.

### What changed

- Added `nonExpansionCandidates` field to `MutationCacheEntry` interface
- Pre-compute the filtered array in `computeMutationCandidates()` once per cache
  key
- Use cached `nonExpansionCandidates` in `selectMutationMethod()` instead of
  filtering inline

## Test Plan

- Added `test/NEAT/MutatorNonExpansionCache.ts` with 5 tests:
  - Large creatures never select ADD_NODE/ADD_CONN from non-expansion path
  - Cached results are consistent across repeated calls
  - Cache invalidation works when cache is cleared
  - Different creature sizes use separate cache entries
  - Non-expansion candidates exclude only ADD_NODE and ADD_CONN
- Added `bench/MutatorNonExpansionCache.ts` benchmarking 300+ and 500+ neuron
  creatures
- All 5055 existing tests pass

---

## Automated Fix Details
This PR addresses issue #2045: **Perf: Cache non-expansion mutation candidates in Mutator**

## Milestone
This PR is part of the **Performance Improvements** milestone and targets the `milestone/performance-improvements` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2045
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2045 -->