### PR TITLE
Handle git merge conflict markers in persisted model JSON (#2103)

### DIFF
--- a/docs/pr-summary-2103.md
+++ b/docs/pr-summary-2103.md
@@ -1,0 +1,41 @@
+## Summary
+
+GRQ v1 model `USDGBP.json.unfixable` contains unresolved git merge/stash
+conflict markers (`<<<<<<< Updated upstream` / `=======` / `>>>>>>> Stashed
+changes`), causing `JSON.parse()` to fail with a `JSONParseError` before any
+creature loading or `fix()` can run.
+
+This PR adds:
+
+1. **`stripMergeConflictMarkers(text)`** (`src/utils/MergeConflictCleaner.ts`) -
+   a utility that resolves git merge conflict markers by keeping the "theirs"
+   side (the section between `=======` and `>>>>>>>`), which typically contains
+   the newer format with UUIDs. Throws if a conflict block is opened but never
+   closed.
+
+2. **`Creature.fromPersistedText(text)`** - a new static method on `Creature`
+   that cleans raw JSON text via `stripMergeConflictMarkers`, parses it, and
+   feeds it through `fromPersistedJSON`. This is the recommended entry point for
+   loading model files from disk or git checkouts that may have unresolved
+   conflicts.
+
+3. Public export of `stripMergeConflictMarkers` from `mod.ts` so external tools
+   (e.g. the GRQ `.fix-grq-unfixable-models.ts` script) can use it directly.
+
+Closes #2103.
+
+## Evidence
+
+All 5176 existing tests pass. 8 new tests cover the merge conflict handling.
+
+## Test Plan
+
+- `test/fix/MergeConflictJSON.ts` (8 tests):
+  - `stripMergeConflictMarkers: resolves git conflict markers keeping theirs side`
+  - `stripMergeConflictMarkers: handles multiple conflict blocks`
+  - `stripMergeConflictMarkers: returns unchanged text when no markers present`
+  - `stripMergeConflictMarkers: handles real GRQ model conflict (issue #2103)`
+  - `stripMergeConflictMarkers: handles conflict with differing values`
+  - `fromPersistedText: loads creature from conflicted JSON text (issue #2103)`
+  - `fromPersistedText: works with clean JSON too`
+  - `stripMergeConflictMarkers: throws on unclosed conflict marker`

--- a/mod.ts
+++ b/mod.ts
@@ -27,6 +27,7 @@
  */
 export { Creature, CURRENT_CREATURE_SEMANTIC_VERSION } from "@creature";
 export { exportSnapshotJSON } from "@creature/CreatureSerialization.ts";
+export { stripMergeConflictMarkers } from "@utils/MergeConflictCleaner.ts";
 
 /**
  * Creature Interfaces

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -45,6 +45,7 @@ import { ActivationError } from "@errors/ActivationError.ts";
 import { TopologyError } from "@errors/TopologyError.ts";
 import { rejectRecurrentSynapseIfForwardOnlyCreature } from "@architecture/ForwardOnlySynapseGuard.ts";
 import { TypedTopology } from "@architecture/TypedTopology.ts";
+import { stripMergeConflictMarkers } from "@utils/MergeConflictCleaner.ts";
 
 // Extracted modules
 import * as activation from "@creature/CreatureActivation.ts";
@@ -1041,6 +1042,22 @@ export class Creature implements CreatureInternal {
     creature.fix({ forwardOnly: creature.forwardOnly });
     creatureValidate(creature, { forwardOnly: creature.forwardOnly });
     return creature;
+  }
+
+  /**
+   * Load a creature from raw JSON text that may contain git merge conflict
+   * markers (`<<<<<<< ... ======= ... >>>>>>>`). Conflict markers are resolved
+   * by keeping the "theirs" side, then the cleaned text is parsed and fed
+   * through {@link Creature.fromPersistedJSON}.
+   *
+   * This is the recommended entry point for loading model files from disk or
+   * git checkouts that may have been left with unresolved merge/stash conflicts
+   * (see Issue #2103).
+   */
+  static fromPersistedText(text: string): Creature {
+    const cleaned = stripMergeConflictMarkers(text);
+    const json = JSON.parse(cleaned) as CreatureExport;
+    return Creature.fromPersistedJSON(json);
   }
 
   shallowClone(): Creature {

--- a/src/utils/MergeConflictCleaner.ts
+++ b/src/utils/MergeConflictCleaner.ts
@@ -1,0 +1,56 @@
+/**
+ * Strips git merge conflict markers from text, keeping the "theirs" side
+ * (the section between `=======` and `>>>>>>>`) for each conflict block.
+ *
+ * This is useful for loading model JSON files that were left with unresolved
+ * git merge/stash conflicts. The "theirs" side typically contains the newer
+ * version (e.g. with UUIDs added).
+ *
+ * @param text - Raw text that may contain merge conflict markers
+ * @returns Cleaned text with conflict markers resolved
+ * @throws {Error} If a conflict marker is opened but never closed
+ */
+export function stripMergeConflictMarkers(text: string): string {
+  const OURS_START = /^<{7}\s/;
+  const SEPARATOR = /^={7}$/;
+  const THEIRS_END = /^>{7}\s/;
+
+  const lines = text.split("\n");
+  const result: string[] = [];
+
+  let inConflict = false;
+  let inTheirsSection = false;
+
+  for (const line of lines) {
+    if (!inConflict) {
+      if (OURS_START.test(line)) {
+        inConflict = true;
+        inTheirsSection = false;
+        continue;
+      }
+      result.push(line);
+    } else {
+      if (SEPARATOR.test(line)) {
+        inTheirsSection = true;
+        continue;
+      }
+      if (THEIRS_END.test(line)) {
+        inConflict = false;
+        inTheirsSection = false;
+        continue;
+      }
+      if (inTheirsSection) {
+        result.push(line);
+      }
+      // Skip "ours" lines (between <<<<<<< and =======)
+    }
+  }
+
+  if (inConflict) {
+    throw new Error(
+      "Unclosed merge conflict marker found — missing ======= or >>>>>>> line",
+    );
+  }
+
+  return result.join("\n");
+}

--- a/test/fix/MergeConflictJSON.ts
+++ b/test/fix/MergeConflictJSON.ts
@@ -1,0 +1,198 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { stripMergeConflictMarkers } from "@utils/MergeConflictCleaner.ts";
+import { Creature } from "@creature";
+
+Deno.test(
+  "stripMergeConflictMarkers: resolves git conflict markers keeping theirs side",
+  () => {
+    const conflicted = `{
+ "key": "before",
+<<<<<<< Updated upstream
+ "value": "ours"
+=======
+ "value": "theirs"
+>>>>>>> Stashed changes
+}`;
+
+    const cleaned = stripMergeConflictMarkers(conflicted);
+    const parsed = JSON.parse(cleaned);
+    assertEquals(parsed.value, "theirs");
+  },
+);
+
+Deno.test(
+  "stripMergeConflictMarkers: handles multiple conflict blocks",
+  () => {
+    const conflicted = `{
+ "a": 1,
+<<<<<<< Updated upstream
+ "b": 2
+=======
+ "b": 3
+>>>>>>> Stashed changes
+,
+<<<<<<< HEAD
+ "c": 4
+=======
+ "c": 5
+>>>>>>> main
+}`;
+
+    const cleaned = stripMergeConflictMarkers(conflicted);
+    const parsed = JSON.parse(cleaned);
+    assertEquals(parsed.b, 3);
+    assertEquals(parsed.c, 5);
+  },
+);
+
+Deno.test(
+  "stripMergeConflictMarkers: returns unchanged text when no markers present",
+  () => {
+    const clean = `{"key": "value"}`;
+    assertEquals(stripMergeConflictMarkers(clean), clean);
+  },
+);
+
+Deno.test(
+  "stripMergeConflictMarkers: handles real GRQ model conflict (issue #2103)",
+  () => {
+    const conflicted = `{
+ "semanticVersion": "4.0.0",
+ "forwardOnly": true,
+ "neurons": [
+  {
+   "type": "output",
+   "id": -1,
+   "bias": -0.05564856795471758,
+<<<<<<< Updated upstream
+   "squash": "LeakyReLU"
+=======
+   "squash": "LeakyReLU",
+   "uuid": "output-0"
+>>>>>>> Stashed changes
+  },
+  {
+   "type": "output",
+   "id": -2,
+   "bias": -0.3331931459113623,
+<<<<<<< Updated upstream
+   "squash": "Cube"
+=======
+   "squash": "Cube",
+   "uuid": "output-1"
+>>>>>>> Stashed changes
+  }
+ ],
+ "synapses": [
+  {
+   "weight": 0.1,
+   "fromId": 0,
+   "toId": -1
+  }
+ ]
+}`;
+
+    const cleaned = stripMergeConflictMarkers(conflicted);
+    const parsed = JSON.parse(cleaned);
+    assertEquals(parsed.neurons[0].uuid, "output-0");
+    assertEquals(parsed.neurons[1].uuid, "output-1");
+    assertEquals(parsed.neurons[0].squash, "LeakyReLU");
+    assertEquals(parsed.neurons[1].squash, "Cube");
+  },
+);
+
+Deno.test(
+  "stripMergeConflictMarkers: handles conflict with differing values",
+  () => {
+    const conflicted = `{
+<<<<<<< Updated upstream
+ "bias": 0.003535602735860919,
+=======
+ "bias": 0.0035363019429889395,
+>>>>>>> Stashed changes
+ "squash": "Swish"
+}`;
+
+    const cleaned = stripMergeConflictMarkers(conflicted);
+    const parsed = JSON.parse(cleaned);
+    assertEquals(parsed.bias, 0.0035363019429889395);
+  },
+);
+
+Deno.test(
+  "fromPersistedText: loads creature from conflicted JSON text (issue #2103)",
+  () => {
+    const conflicted = `{
+ "semanticVersion": "4.0.0",
+ "forwardOnly": true,
+ "input": 1,
+ "output": 1,
+ "neurons": [
+  {
+   "type": "output",
+   "id": -1,
+   "bias": 0.1,
+<<<<<<< Updated upstream
+   "squash": "IDENTITY"
+=======
+   "squash": "IDENTITY",
+   "uuid": "output-0"
+>>>>>>> Stashed changes
+  }
+ ],
+ "synapses": [
+  {
+   "weight": 1.0,
+   "fromId": 0,
+   "toId": -1
+  }
+ ]
+}`;
+
+    const creature = Creature.fromPersistedText(conflicted);
+    assertEquals(creature.forwardOnly, true);
+    assertEquals(creature.input, 1);
+    assertEquals(creature.output, 1);
+    creature.validate({ forwardOnly: true });
+  },
+);
+
+Deno.test(
+  "fromPersistedText: works with clean JSON too",
+  () => {
+    const clean = JSON.stringify({
+      semanticVersion: "4.0.0",
+      forwardOnly: true,
+      input: 2,
+      output: 1,
+      neurons: [
+        { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "input-1", toUUID: "output-0", weight: 0.3 },
+      ],
+    });
+
+    const creature = Creature.fromPersistedText(clean);
+    assertEquals(creature.input, 2);
+    assertEquals(creature.output, 1);
+    creature.validate({ forwardOnly: true });
+  },
+);
+
+Deno.test(
+  "stripMergeConflictMarkers: throws on unclosed conflict marker",
+  () => {
+    const malformed = `{
+<<<<<<< Updated upstream
+ "key": "value"
+}`;
+
+    assertThrows(
+      () => stripMergeConflictMarkers(malformed),
+      Error,
+      "Unclosed merge conflict",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

GRQ v1 model `USDGBP.json.unfixable` contains unresolved git merge/stash
conflict markers (`<<<<<<< Updated upstream` / `=======` / `>>>>>>> Stashed
changes`), causing `JSON.parse()` to fail with a `JSONParseError` before any
creature loading or `fix()` can run.

This PR adds:

1. **`stripMergeConflictMarkers(text)`** (`src/utils/MergeConflictCleaner.ts`) —
   a utility that resolves git merge conflict markers by keeping the "theirs"
   side (the section between `=======` and `>>>>>>>`), which typically contains
   the newer format with UUIDs. Throws if a conflict block is opened but never
   closed.

2. **`Creature.fromPersistedText(text)`** — a new static method on `Creature`
   that cleans raw JSON text via `stripMergeConflictMarkers`, parses it, and
   feeds it through `fromPersistedJSON`. This is the recommended entry point for
   loading model files from disk or git checkouts that may have unresolved
   conflicts.

3. Public export of `stripMergeConflictMarkers` from `mod.ts` so external tools
   (e.g. the GRQ `.fix-grq-unfixable-models.ts` script) can use it directly.

Closes #2103.

## Evidence

All 5176 existing tests pass. 8 new tests cover the merge conflict handling.

## Test Plan

- `test/fix/MergeConflictJSON.ts` (8 tests):
  - `stripMergeConflictMarkers: resolves git conflict markers keeping theirs side`
  - `stripMergeConflictMarkers: handles multiple conflict blocks`
  - `stripMergeConflictMarkers: returns unchanged text when no markers present`
  - `stripMergeConflictMarkers: handles real GRQ model conflict (issue #2103)`
  - `stripMergeConflictMarkers: handles conflict with differing values`
  - `fromPersistedText: loads creature from conflicted JSON text (issue #2103)`
  - `fromPersistedText: works with clean JSON too`
  - `stripMergeConflictMarkers: throws on unclosed conflict marker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)