### PR TITLE
Replace GPU assert! panics with graceful error returns (#2116)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -234,6 +234,7 @@
     "Schmidhuber",
     "sech",
     "seedable",
+    "serde",
     "Sepp",
     "segfault",
     "segfaulting",

--- a/docs/pr-summary-2116.md
+++ b/docs/pr-summary-2116.md
@@ -1,0 +1,51 @@
+## Summary
+
+Replace GPU `assert!` panics with graceful error returns in NEAT-AI-Discovery,
+and add the `requireGpu` field to the Rust `AnalyzeParallelInput` struct.
+Closes #2116.
+
+### Rust changes (NEAT-AI-Discovery)
+
+- **`src/ffi_types/requests.rs`**: Added `require_gpu: bool` field to
+  `AnalyzeParallelInput` with `#[serde(default = "default_true")]` for
+  backwards compatibility. The field is renamed from `requireGpu` via the
+  existing `#[serde(rename_all = "camelCase")]` attribute.
+
+- **`src/ffi_internal/analysis.rs`**: Added GPU availability check at the top
+  of `analyze_parallel_internal()`. When GPU is unavailable, returns a
+  structured JSON error with `success: false`, `errorKind: "GpuPermanent"`,
+  and a descriptive message — instead of letting downstream `assert!` calls
+  panic.
+
+- **`src/analysis/neuron/mod.rs`**: Replaced `assert!(gpu_is_available())`
+  with `anyhow::bail!()` that returns an error through the `Result` chain.
+
+- **`src/analysis/synapse/orchestration.rs`**: Same treatment as neuron — 
+  replaced `assert!` with `anyhow::bail!()`.
+
+### TypeScript changes (NEAT-AI)
+
+- **`src/.../RustDiscoveryTypes.ts`**: Added `errorKind?: string` to
+  `RustParallelAnalysisResult` interface to surface Rust error classification.
+
+- **`test/.../AnalyzeParallelGpuGuard.ts`**: Added test verifying that the
+  Rust layer returns `errorKind: "GpuPermanent"` when GPU is unavailable
+  and `requireGpu: false` is passed.
+
+## Evidence
+
+- All 643 Rust library tests pass (`cargo test --lib`)
+- All 5174 TypeScript tests pass (`./quality.sh`)
+- `cargo clippy` and `cargo fmt` clean
+- Defence-in-depth: three layers of GPU protection:
+  1. TypeScript guard in `analyzeParallel()` (Issue #2115)
+  2. Rust `analyze_parallel_internal()` GPU check (this PR)
+  3. Rust analysis functions return `anyhow::bail!()` instead of panicking
+
+## Test Plan
+
+- Added `require_gpu_defaults_to_true_when_omitted` — verifies backwards compatibility
+- Added `require_gpu_false_is_deserialised_from_camel_case` — verifies serde rename
+- Added `analyze_parallel_internal_returns_gpu_error_when_unavailable` — verifies
+  structured error response on GPU-less machines
+- Added TypeScript test for Rust `errorKind: "GpuPermanent"` classification

--- a/docs/pr-summary-2116.md
+++ b/docs/pr-summary-2116.md
@@ -1,26 +1,25 @@
 ## Summary
 
 Replace GPU `assert!` panics with graceful error returns in NEAT-AI-Discovery,
-and add the `requireGpu` field to the Rust `AnalyzeParallelInput` struct.
-Closes #2116.
+and add the `requireGpu` field to the Rust `AnalyzeParallelInput` struct. Closes
+#2116.
 
 ### Rust changes (NEAT-AI-Discovery)
 
 - **`src/ffi_types/requests.rs`**: Added `require_gpu: bool` field to
-  `AnalyzeParallelInput` with `#[serde(default = "default_true")]` for
-  backwards compatibility. The field is renamed from `requireGpu` via the
-  existing `#[serde(rename_all = "camelCase")]` attribute.
+  `AnalyzeParallelInput` with `#[serde(default = "default_true")]` for backwards
+  compatibility. The field is renamed from `requireGpu` via the existing
+  `#[serde(rename_all = "camelCase")]` attribute.
 
-- **`src/ffi_internal/analysis.rs`**: Added GPU availability check at the top
-  of `analyze_parallel_internal()`. When GPU is unavailable, returns a
-  structured JSON error with `success: false`, `errorKind: "GpuPermanent"`,
-  and a descriptive message — instead of letting downstream `assert!` calls
-  panic.
+- **`src/ffi_internal/analysis.rs`**: Added GPU availability check at the top of
+  `analyze_parallel_internal()`. When GPU is unavailable, returns a structured
+  JSON error with `success: false`, `errorKind: "GpuPermanent"`, and a
+  descriptive message — instead of letting downstream `assert!` calls panic.
 
-- **`src/analysis/neuron/mod.rs`**: Replaced `assert!(gpu_is_available())`
-  with `anyhow::bail!()` that returns an error through the `Result` chain.
+- **`src/analysis/neuron/mod.rs`**: Replaced `assert!(gpu_is_available())` with
+  `anyhow::bail!()` that returns an error through the `Result` chain.
 
-- **`src/analysis/synapse/orchestration.rs`**: Same treatment as neuron — 
+- **`src/analysis/synapse/orchestration.rs`**: Same treatment as neuron —
   replaced `assert!` with `anyhow::bail!()`.
 
 ### TypeScript changes (NEAT-AI)
@@ -28,9 +27,9 @@ Closes #2116.
 - **`src/.../RustDiscoveryTypes.ts`**: Added `errorKind?: string` to
   `RustParallelAnalysisResult` interface to surface Rust error classification.
 
-- **`test/.../AnalyzeParallelGpuGuard.ts`**: Added test verifying that the
-  Rust layer returns `errorKind: "GpuPermanent"` when GPU is unavailable
-  and `requireGpu: false` is passed.
+- **`test/.../AnalyzeParallelGpuGuard.ts`**: Added test verifying that the Rust
+  layer returns `errorKind: "GpuPermanent"` when GPU is unavailable and
+  `requireGpu: false` is passed.
 
 ## Evidence
 
@@ -44,8 +43,10 @@ Closes #2116.
 
 ## Test Plan
 
-- Added `require_gpu_defaults_to_true_when_omitted` — verifies backwards compatibility
-- Added `require_gpu_false_is_deserialised_from_camel_case` — verifies serde rename
-- Added `analyze_parallel_internal_returns_gpu_error_when_unavailable` — verifies
-  structured error response on GPU-less machines
+- Added `require_gpu_defaults_to_true_when_omitted` — verifies backwards
+  compatibility
+- Added `require_gpu_false_is_deserialised_from_camel_case` — verifies serde
+  rename
+- Added `analyze_parallel_internal_returns_gpu_error_when_unavailable` —
+  verifies structured error response on GPU-less machines
 - Added TypeScript test for Rust `errorKind: "GpuPermanent"` classification

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryTypes.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryTypes.ts
@@ -268,6 +268,8 @@ export interface RustParallelAnalysisResult {
   neuronDiagnostics?: RustNeuronDiagnostic[];
   neuronGpuUsed?: boolean;
   error?: string;
+  /** Typed error classification from Rust (Issue #2116). */
+  errorKind?: string;
 }
 
 /**

--- a/test/ErrorGuidedStructuralEvolution/AnalyzeParallelGpuGuard.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalyzeParallelGpuGuard.ts
@@ -85,6 +85,40 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "analyzeParallel with requireGpu=false returns structured Rust error when GPU unavailable (Issue #2116)",
+  ignore: !isRustLibraryAvailable() || isRustGpuAvailable(),
+  sanitizeResources: false,
+  fn: () => {
+    // Issue #2116: When requireGpu is false and GPU is unavailable, the Rust
+    // FFI layer should return a structured error with errorKind "GpuPermanent"
+    // instead of panicking via assert!.
+    const input = buildStubInput({ requireGpu: false });
+    const result = analyzeParallel(input);
+
+    // The TypeScript guard allows this through (requireGpu === false),
+    // so the call reaches the Rust layer which returns a structured error.
+    if (result !== null) {
+      assertEquals(
+        result.success,
+        false,
+        "Should fail because GPU is unavailable",
+      );
+      assertEquals(
+        typeof result.error,
+        "string",
+        "Error message should be present from Rust layer",
+      );
+      assertEquals(
+        result.errorKind,
+        "GpuPermanent",
+        "Rust should classify GPU unavailability as GpuPermanent",
+      );
+    }
+  },
+});
+
+Deno.test({
   name: "analyzeParallel returns null when library is unavailable",
   ignore: isRustLibraryAvailable(),
   fn: () => {


### PR DESCRIPTION
## Summary

Replace GPU `assert!` panics with graceful error returns in NEAT-AI-Discovery,
and add the `requireGpu` field to the Rust `AnalyzeParallelInput` struct. Closes
#2116.

### Rust changes (NEAT-AI-Discovery)

- **`src/ffi_types/requests.rs`**: Added `require_gpu: bool` field to
  `AnalyzeParallelInput` with `#[serde(default = "default_true")]` for backwards
  compatibility. The field is renamed from `requireGpu` via the existing
  `#[serde(rename_all = "camelCase")]` attribute.

- **`src/ffi_internal/analysis.rs`**: Added GPU availability check at the top of
  `analyze_parallel_internal()`. When GPU is unavailable, returns a structured
  JSON error with `success: false`, `errorKind: "GpuPermanent"`, and a
  descriptive message — instead of letting downstream `assert!` calls panic.

- **`src/analysis/neuron/mod.rs`**: Replaced `assert!(gpu_is_available())` with
  `anyhow::bail!()` that returns an error through the `Result` chain.

- **`src/analysis/synapse/orchestration.rs`**: Same treatment as neuron —
  replaced `assert!` with `anyhow::bail!()`.

### TypeScript changes (NEAT-AI)

- **`src/.../RustDiscoveryTypes.ts`**: Added `errorKind?: string` to
  `RustParallelAnalysisResult` interface to surface Rust error classification.

- **`test/.../AnalyzeParallelGpuGuard.ts`**: Added test verifying that the Rust
  layer returns `errorKind: "GpuPermanent"` when GPU is unavailable and
  `requireGpu: false` is passed.

## Evidence

- All 643 Rust library tests pass (`cargo test --lib`)
- All 5174 TypeScript tests pass (`./quality.sh`)
- `cargo clippy` and `cargo fmt` clean
- Defence-in-depth: three layers of GPU protection:
  1. TypeScript guard in `analyzeParallel()` (Issue #2115)
  2. Rust `analyze_parallel_internal()` GPU check (this PR)
  3. Rust analysis functions return `anyhow::bail!()` instead of panicking

## Test Plan

- Added `require_gpu_defaults_to_true_when_omitted` — verifies backwards
  compatibility
- Added `require_gpu_false_is_deserialised_from_camel_case` — verifies serde
  rename
- Added `analyze_parallel_internal_returns_gpu_error_when_unavailable` —
  verifies structured error response on GPU-less machines
- Added TypeScript test for Rust `errorKind: "GpuPermanent"` classification

---

## Automated Fix Details
This PR addresses issue #2116: **Replace GPU assert! panics with graceful error returns in NEAT-AI-Discovery**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2116
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2116 -->