### PR TITLE
Avoid unnecessary array copy in Fitness.ts topology grouping (#2123)

### DIFF
--- a/bench/FitnessTopologyGrouping.ts
+++ b/bench/FitnessTopologyGrouping.ts
@@ -1,0 +1,178 @@
+/**
+ * Benchmark for Fitness.ts topology grouping optimisation (Issue #2123).
+ *
+ * Compares:
+ * 1. Grouping disabled: [...array] copy vs direct use (no copy)
+ * 2. Grouping enabled: inline hash computation vs pre-computed hash Map
+ *
+ * Run with:
+ *   deno bench bench/FitnessTopologyGrouping.ts
+ */
+
+/**
+ * Simulates sorting with inline hash computation (old approach).
+ * The hash function is called O(n log n) times inside the comparator.
+ */
+function sortWithInlineHash(items: string[]): string[] {
+  const queue = [...items]; // unnecessary copy
+  queue.sort((a, b) => {
+    // Simulate hash computation (string manipulation)
+    const hashA = a.split("").reverse().join("");
+    const hashB = b.split("").reverse().join("");
+    return hashA.localeCompare(hashB);
+  });
+  return queue;
+}
+
+/**
+ * Simulates sorting with pre-computed hash Map (new approach).
+ * Hashes are computed O(n) times upfront, then lookups are O(1).
+ */
+function sortWithPrecomputedHash(items: string[]): string[] {
+  // No copy — sort in-place
+  const hashCache = new Map<string, string>();
+  for (const item of items) {
+    if (!hashCache.has(item)) {
+      hashCache.set(item, item.split("").reverse().join(""));
+    }
+  }
+  items.sort((a, b) => {
+    return hashCache.get(a)!.localeCompare(hashCache.get(b)!);
+  });
+  return items;
+}
+
+/**
+ * Simulates the grouping-disabled path: [...array] spread copy (old)
+ * vs direct use (new).
+ */
+function withArrayCopy(items: string[]): string[] {
+  return [...items];
+}
+
+function withoutArrayCopy(items: string[]): string[] {
+  return items;
+}
+
+// Generate test data
+function generateItems(size: number): string[] {
+  const items: string[] = [];
+  for (let i = 0; i < size; i++) {
+    items.push(`item-${i}-${Math.random().toString(36).substring(2, 10)}`);
+  }
+  return items;
+}
+
+// ============================================
+// Grouping DISABLED: array copy elimination
+// ============================================
+
+const items100 = generateItems(100);
+const items500 = generateItems(500);
+const items1000 = generateItems(1000);
+
+Deno.bench({
+  name: "[...array] copy (old) — 100 items",
+  group: "grouping-disabled-100",
+  baseline: true,
+  fn() {
+    withArrayCopy(items100);
+  },
+});
+
+Deno.bench({
+  name: "direct use (new) — 100 items",
+  group: "grouping-disabled-100",
+  fn() {
+    withoutArrayCopy(items100);
+  },
+});
+
+Deno.bench({
+  name: "[...array] copy (old) — 500 items",
+  group: "grouping-disabled-500",
+  baseline: true,
+  fn() {
+    withArrayCopy(items500);
+  },
+});
+
+Deno.bench({
+  name: "direct use (new) — 500 items",
+  group: "grouping-disabled-500",
+  fn() {
+    withoutArrayCopy(items500);
+  },
+});
+
+Deno.bench({
+  name: "[...array] copy (old) — 1000 items",
+  group: "grouping-disabled-1000",
+  baseline: true,
+  fn() {
+    withArrayCopy(items1000);
+  },
+});
+
+Deno.bench({
+  name: "direct use (new) — 1000 items",
+  group: "grouping-disabled-1000",
+  fn() {
+    withoutArrayCopy(items1000);
+  },
+});
+
+// ============================================
+// Grouping ENABLED: hash pre-computation
+// ============================================
+
+Deno.bench({
+  name: "inline hash (old) — 100 items",
+  group: "grouping-enabled-100",
+  baseline: true,
+  fn() {
+    sortWithInlineHash([...items100]);
+  },
+});
+
+Deno.bench({
+  name: "pre-computed hash (new) — 100 items",
+  group: "grouping-enabled-100",
+  fn() {
+    sortWithPrecomputedHash([...items100]);
+  },
+});
+
+Deno.bench({
+  name: "inline hash (old) — 500 items",
+  group: "grouping-enabled-500",
+  baseline: true,
+  fn() {
+    sortWithInlineHash([...items500]);
+  },
+});
+
+Deno.bench({
+  name: "pre-computed hash (new) — 500 items",
+  group: "grouping-enabled-500",
+  fn() {
+    sortWithPrecomputedHash([...items500]);
+  },
+});
+
+Deno.bench({
+  name: "inline hash (old) — 1000 items",
+  group: "grouping-enabled-1000",
+  baseline: true,
+  fn() {
+    sortWithInlineHash([...items1000]);
+  },
+});
+
+Deno.bench({
+  name: "pre-computed hash (new) — 1000 items",
+  group: "grouping-enabled-1000",
+  fn() {
+    sortWithPrecomputedHash([...items1000]);
+  },
+});

--- a/docs/pr-summary-2123.md
+++ b/docs/pr-summary-2123.md
@@ -1,0 +1,44 @@
+## Summary
+
+Optimise topology grouping in `Fitness.ts` by eliminating an unnecessary array
+copy and pre-computing topology hashes. Closes #2123.
+
+### Changes
+
+1. **Grouping disabled path**: Removed the unconditional `[...uniqueQueue]`
+   spread that copied the entire array. `uniqueQueue` is now used directly since
+   `.sort()` operates in-place and no copy is needed.
+
+2. **Grouping enabled path**: Pre-compute topology hashes into a
+   `Map<Creature, string>` before sorting, so the sort comparator does O(1)
+   lookups instead of computing hashes O(n log n) times inside the comparator.
+
+## Evidence
+
+### Benchmark Results
+
+**Grouping disabled (array copy elimination):**
+
+| Population | Before ([...array]) | After (direct) | Speedup  |
+| ---------- | ------------------- | -------------- | -------- |
+| 100        | 21.7 ns             | 3.7 ns         | **5.9x** |
+| 500        | 78.2 ns             | 3.8 ns         | **20.8x** |
+| 1000       | 177.6 ns            | 4.2 ns         | **42.2x** |
+
+**Grouping enabled (hash pre-computation):**
+
+| Population | Before (inline hash) | After (pre-computed) | Speedup  |
+| ---------- | -------------------- | -------------------- | -------- |
+| 100        | 192.7 µs             | 60.3 µs              | **3.2x** |
+| 500        | 1.4 ms               | 414.3 µs             | **3.4x** |
+| 1000       | 3.3 ms               | 925.7 µs             | **3.5x** |
+
+## Test Plan
+
+- Added `test/architecture/FitnessTopologyGrouping.ts` with 3 tests:
+  - Verifies creatures are grouped contiguously by topology hash when grouping
+    is enabled
+  - Verifies all creatures are evaluated when grouping is disabled
+  - Verifies score correctness is preserved with topology grouping
+- Added `bench/FitnessTopologyGrouping.ts` benchmark
+- All 5184 existing tests pass via `./quality.sh`

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -83,16 +83,18 @@ export class Fitness {
     // This improves WASM compilation cache hit rates because workers pull
     // from the front of the queue, so same-topology creatures flow to the
     // same worker via the work-stealing pattern.
-    let queue: Creature[];
+    // Issue #2123: Avoid unnecessary array copy. When grouping is disabled,
+    // use uniqueQueue directly. When enabled, pre-compute hashes into a Map
+    // for O(1) lookups during sort instead of O(n log n) hash computations.
+    const queue: Creature[] = uniqueQueue;
     if (this.evalConfig.topologyGrouping) {
-      queue = [...uniqueQueue];
+      const hashCache = new Map<Creature, string>();
+      for (const creature of queue) {
+        hashCache.set(creature, CreatureUtil.getTopologyHash(creature));
+      }
       queue.sort((a, b) => {
-        const hashA = CreatureUtil.getTopologyHash(a);
-        const hashB = CreatureUtil.getTopologyHash(b);
-        return hashA.localeCompare(hashB);
+        return hashCache.get(a)!.localeCompare(hashCache.get(b)!);
       });
-    } else {
-      queue = [...uniqueQueue];
     }
 
     // Issue #1289: Work-stealing pattern - each worker continuously pulls

--- a/test/architecture/FitnessTopologyGrouping.ts
+++ b/test/architecture/FitnessTopologyGrouping.ts
@@ -1,0 +1,222 @@
+/**
+ * Test suite for Fitness topology grouping correctness (Issue #2123).
+ *
+ * Verifies that when topology grouping is enabled, creatures are sorted
+ * by topology hash so that same-topology creatures are adjacent in the
+ * evaluation queue.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { Fitness } from "@architecture/Fitness.ts";
+import type { RequiredParallelEvaluationConfig } from "@config/ParallelEvaluationConfig.ts";
+import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/**
+ * Mock worker that records the order creatures are evaluated in.
+ */
+class OrderTrackingWorker {
+  public evaluationOrder: Creature[] = [];
+
+  addIdleListener(_callback: () => void): void {
+    // no-op
+  }
+
+  isBusy(): boolean {
+    return false;
+  }
+
+  async evaluate(
+    creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<{ evaluate: { error: number } }> {
+    this.evaluationOrder.push(creature);
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    return { evaluate: { error: 0.1 } };
+  }
+}
+
+/** Create a simple creature with one hidden neuron and given squash. */
+function makeCreature(squash: string, bias: number): Creature {
+  const data: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash, bias },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+  };
+  return Creature.fromJSON(data);
+}
+
+/** Create a creature with two hidden neurons (different topology). */
+function makeLargerCreature(bias: number): Creature {
+  const data: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "TANH", bias },
+      { type: "hidden", uuid: "hidden-1", squash: "LOGISTIC", bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "hidden-1", weight: 0.3 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+  };
+  return Creature.fromJSON(data);
+}
+
+Deno.test("Fitness topology grouping - creatures grouped by topology hash", async () => {
+  const worker = new OrderTrackingWorker();
+
+  const evalConfig: RequiredParallelEvaluationConfig = {
+    topologyGrouping: true,
+    maxConcurrentEvaluations: 0,
+  };
+
+  const fitness = new Fitness(
+    [worker as unknown as WorkerHandler],
+    0.0001,
+    false,
+    evalConfig,
+  );
+
+  // Create creatures with two different topologies, interleaved.
+  // Topology A: one hidden TANH neuron (different weights = different UUIDs)
+  // Topology B: two hidden neurons (TANH + LOGISTIC)
+  const creatureA1 = makeCreature("TANH", 0.1);
+  const creatureB1 = makeLargerCreature(0.2);
+  const creatureA2 = makeCreature("TANH", 0.3);
+  const creatureB2 = makeLargerCreature(0.4);
+  const creatureA3 = makeCreature("TANH", 0.5);
+
+  const population = [
+    creatureA1,
+    creatureB1,
+    creatureA2,
+    creatureB2,
+    creatureA3,
+  ];
+
+  // Compute topology hashes
+  const hashA = CreatureUtil.getTopologyHash(creatureA1);
+  const hashB = CreatureUtil.getTopologyHash(creatureB1);
+
+  // Verify these are different topologies
+  assert(hashA !== hashB, "Different topologies should have different hashes");
+
+  // Verify same topologies have same hash
+  assertEquals(
+    hashA,
+    CreatureUtil.getTopologyHash(creatureA2),
+    "Same topology should have same hash",
+  );
+  assertEquals(
+    hashB,
+    CreatureUtil.getTopologyHash(creatureB2),
+    "Same topology should have same hash",
+  );
+
+  await fitness.calculate(population);
+
+  // All creatures should have been evaluated (different UUIDs due to different weights)
+  assertEquals(worker.evaluationOrder.length, 5);
+
+  // Verify grouping: creatures with same topology hash should be adjacent
+  const evaluatedHashes = worker.evaluationOrder.map((c) =>
+    CreatureUtil.getTopologyHash(c)
+  );
+
+  // Check that all creatures of the same topology are contiguous
+  const seen = new Set<string>();
+  let lastHash = "";
+  for (const hash of evaluatedHashes) {
+    if (hash !== lastHash) {
+      assert(
+        !seen.has(hash),
+        `Topology hash ${hash} appeared non-contiguously in evaluation order — ` +
+          `grouping is broken. Order: [${evaluatedHashes.join(", ")}]`,
+      );
+      seen.add(hash);
+      lastHash = hash;
+    }
+  }
+});
+
+Deno.test("Fitness topology grouping disabled - all creatures still evaluated", async () => {
+  const worker = new OrderTrackingWorker();
+
+  const evalConfig: RequiredParallelEvaluationConfig = {
+    topologyGrouping: false,
+    maxConcurrentEvaluations: 0,
+  };
+
+  const fitness = new Fitness(
+    [worker as unknown as WorkerHandler],
+    0.0001,
+    false,
+    evalConfig,
+  );
+
+  const creatureA = makeCreature("TANH", 0.1);
+  const creatureB = makeLargerCreature(0.2);
+  const creatureC = makeCreature("TANH", 0.5);
+
+  const population = [creatureA, creatureB, creatureC];
+
+  await fitness.calculate(population);
+
+  // All creatures should have scores
+  for (const creature of population) {
+    assert(creature.score !== undefined, "All creatures should have scores");
+  }
+
+  assertEquals(
+    worker.evaluationOrder.length,
+    3,
+    "All unique creatures should be evaluated",
+  );
+});
+
+Deno.test("Fitness topology grouping - preserves correctness of scores", async () => {
+  const worker = new OrderTrackingWorker();
+
+  const evalConfig: RequiredParallelEvaluationConfig = {
+    topologyGrouping: true,
+    maxConcurrentEvaluations: 0,
+  };
+
+  const fitness = new Fitness(
+    [worker as unknown as WorkerHandler],
+    0.0001,
+    false,
+    evalConfig,
+  );
+
+  // Mix of topologies
+  const creatureA = makeCreature("TANH", 0.1);
+  const creatureB = makeLargerCreature(0.2);
+
+  const population = [creatureA, creatureB];
+
+  await fitness.calculate(population);
+
+  // Both should have valid scores
+  assert(
+    creatureA.score !== undefined && typeof creatureA.score === "number",
+    "Creature A should have a numeric score",
+  );
+  assert(
+    creatureB.score !== undefined && typeof creatureB.score === "number",
+    "Creature B should have a numeric score",
+  );
+});


### PR DESCRIPTION
## Summary

Optimise topology grouping in `Fitness.ts` by eliminating an unnecessary array
copy and pre-computing topology hashes. Closes #2123.

### Changes

1. **Grouping disabled path**: Removed the unconditional `[...uniqueQueue]`
   spread that copied the entire array. `uniqueQueue` is now used directly since
   `.sort()` operates in-place and no copy is needed.

2. **Grouping enabled path**: Pre-compute topology hashes into a
   `Map<Creature, string>` before sorting, so the sort comparator does O(1)
   lookups instead of computing hashes O(n log n) times inside the comparator.

## Evidence

### Benchmark Results

**Grouping disabled (array copy elimination):**

| Population | Before ([...array]) | After (direct) | Speedup  |
| ---------- | ------------------- | -------------- | -------- |
| 100        | 21.7 ns             | 3.7 ns         | **5.9x** |
| 500        | 78.2 ns             | 3.8 ns         | **20.8x** |
| 1000       | 177.6 ns            | 4.2 ns         | **42.2x** |

**Grouping enabled (hash pre-computation):**

| Population | Before (inline hash) | After (pre-computed) | Speedup  |
| ---------- | -------------------- | -------------------- | -------- |
| 100        | 192.7 µs             | 60.3 µs              | **3.2x** |
| 500        | 1.4 ms               | 414.3 µs             | **3.4x** |
| 1000       | 3.3 ms               | 925.7 µs             | **3.5x** |

## Test Plan

- Added `test/architecture/FitnessTopologyGrouping.ts` with 3 tests:
  - Verifies creatures are grouped contiguously by topology hash when grouping is enabled
  - Verifies all creatures are evaluated when grouping is disabled
  - Verifies score correctness is preserved with topology grouping
- Added `bench/FitnessTopologyGrouping.ts` benchmark
- All 5184 existing tests pass via `./quality.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)