### PR TITLE
Reduce allocations in ModWeight mutation focus filtering (#2124)

### DIFF
--- a/bench/mutate/ModWeightFocusFiltering.ts
+++ b/bench/mutate/ModWeightFocusFiltering.ts
@@ -1,0 +1,143 @@
+/**
+ * Benchmark: ModWeight focus filtering allocation reduction (Issue #2124)
+ *
+ * Compares the old triple-allocation approach (Set<Synapse> → Array.from → .filter)
+ * with the new single-pass approach (Set<number> dedup + inline frozen check).
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write --allow-env --allow-ffi bench/mutate/ModWeightFocusFiltering.ts
+ */
+import { Creature } from "@creature";
+import { ModWeight } from "@mutate/ModWeight.ts";
+
+/**
+ * Creates a test creature with a configurable number of hidden neurons
+ * and dense connectivity to exercise focus filtering.
+ */
+function createTestCreature(hiddenCount: number): Creature {
+  const neurons = [];
+  const synapses = [];
+
+  // Hidden layer
+  for (let i = 0; i < hiddenCount; i++) {
+    neurons.push({
+      type: "hidden" as const,
+      uuid: `hidden-${i}`,
+      bias: 0,
+      squash: "IDENTITY",
+    });
+  }
+
+  // Output neuron
+  neurons.push({
+    type: "output" as const,
+    uuid: "output-0",
+    bias: 0,
+    squash: "IDENTITY",
+  });
+
+  // Connect inputs to hidden neurons
+  for (let h = 0; h < hiddenCount; h++) {
+    for (let inp = 0; inp < 3; inp++) {
+      synapses.push({
+        fromUUID: `input-${inp}`,
+        toUUID: `hidden-${h}`,
+        weight: Math.random() - 0.5,
+        frozen: Math.random() < 0.2 ? true : undefined, // ~20% frozen
+      });
+    }
+  }
+
+  // Connect hidden neurons to output
+  for (let h = 0; h < hiddenCount; h++) {
+    synapses.push({
+      fromUUID: `hidden-${h}`,
+      toUUID: "output-0",
+      weight: Math.random() - 0.5,
+    });
+  }
+
+  // Some inter-hidden connections for overlap
+  for (let h = 0; h < hiddenCount - 1; h++) {
+    synapses.push({
+      fromUUID: `hidden-${h}`,
+      toUUID: `hidden-${h + 1}`,
+      weight: Math.random() - 0.5,
+    });
+  }
+
+  return Creature.fromJSON({ input: 3, output: 1, neurons, synapses }, true);
+}
+
+// --- Old approach: Set<Synapse> → Array.from → .filter ---
+
+function oldFocusFilter(creature: Creature, focusList: number[]) {
+  const seen = new Set<InstanceType<typeof Object>>();
+  for (const focusIndex of focusList) {
+    for (const syn of creature.outwardConnections(focusIndex)) {
+      seen.add(syn);
+    }
+    for (const syn of creature.inwardConnections(focusIndex)) {
+      seen.add(syn);
+    }
+  }
+  return Array.from(seen).filter((s) => !(s as { frozen?: boolean }).frozen);
+}
+
+// --- New approach: single-pass with Set<number> ---
+
+function newFocusFilter(creature: Creature, focusList: number[]) {
+  const seen = new Set<number>();
+  const neuronCount = creature.neurons.length;
+  const result: { from: number; to: number; frozen?: boolean }[] = [];
+  for (const focusIndex of focusList) {
+    for (const syn of creature.outwardConnections(focusIndex)) {
+      if (!syn.frozen) {
+        const key = syn.from * neuronCount + syn.to;
+        if (!seen.has(key)) {
+          seen.add(key);
+          result.push(syn);
+        }
+      }
+    }
+    for (const syn of creature.inwardConnections(focusIndex)) {
+      if (!syn.frozen) {
+        const key = syn.from * neuronCount + syn.to;
+        if (!seen.has(key)) {
+          seen.add(key);
+          result.push(syn);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+// Small creature (5 hidden neurons, typical focus size)
+const smallCreature = createTestCreature(5);
+const smallFocus = [0, 3, 4]; // 3 focus neurons
+
+// Medium creature (20 hidden neurons)
+const medCreature = createTestCreature(20);
+const medFocus = [0, 3, 5, 8, 12, 15]; // 6 focus neurons
+
+Deno.bench("Old: Set<Synapse> → Array.from → filter (small)", () => {
+  oldFocusFilter(smallCreature, smallFocus);
+});
+
+Deno.bench("New: single-pass Set<number> (small)", () => {
+  newFocusFilter(smallCreature, smallFocus);
+});
+
+Deno.bench("Old: Set<Synapse> → Array.from → filter (medium)", () => {
+  oldFocusFilter(medCreature, medFocus);
+});
+
+Deno.bench("New: single-pass Set<number> (medium)", () => {
+  newFocusFilter(medCreature, medFocus);
+});
+
+// End-to-end: full ModWeight mutation with focus (uses the new implementation)
+Deno.bench("ModWeight.mutate with focus (medium creature)", () => {
+  new ModWeight(medCreature).mutate(medFocus);
+});

--- a/docs/pr-summary-2124.md
+++ b/docs/pr-summary-2124.md
@@ -2,19 +2,19 @@
 
 Reduce allocations in ModWeight mutation focus filtering by replacing the
 triple-allocation pattern (Set<Synapse> → Array.from → .filter) with a
-single-pass approach that builds the result array directly. Deduplication
-uses a Set<number> keyed by synapse identity, and frozen-status checking
-is done inline. This eliminates 2 intermediate allocations per mutation
-call. Closes #2124.
+single-pass approach that builds the result array directly. Deduplication uses a
+Set<number> keyed by synapse identity, and frozen-status checking is done
+inline. This eliminates 2 intermediate allocations per mutation call. Closes
+#2124.
 
 ## Evidence
 
 Benchmark results (Apple M4, Deno 2.7.10):
 
-| Benchmark | Old (ns/iter) | New (ns/iter) | Improvement |
-|-----------|--------------|--------------|-------------|
-| Small creature (5 hidden, 3 focus) | 259.7 | 255.5 | ~1.6% |
-| Medium creature (20 hidden, 6 focus) | 812.0 | 751.1 | ~7.5% |
+| Benchmark                            | Old (ns/iter) | New (ns/iter) | Improvement |
+| ------------------------------------ | ------------- | ------------- | ----------- |
+| Small creature (5 hidden, 3 focus)   | 259.7         | 255.5         | ~1.6%       |
+| Medium creature (20 hidden, 6 focus) | 812.0         | 751.1         | ~7.5%       |
 
 The primary benefit is reduced GC pressure from eliminating short-lived
 intermediate arrays over thousands of mutations per generation.

--- a/docs/pr-summary-2124.md
+++ b/docs/pr-summary-2124.md
@@ -1,0 +1,29 @@
+## Summary
+
+Reduce allocations in ModWeight mutation focus filtering by replacing the
+triple-allocation pattern (Set<Synapse> → Array.from → .filter) with a
+single-pass approach that builds the result array directly. Deduplication
+uses a Set<number> keyed by synapse identity, and frozen-status checking
+is done inline. This eliminates 2 intermediate allocations per mutation
+call. Closes #2124.
+
+## Evidence
+
+Benchmark results (Apple M4, Deno 2.7.10):
+
+| Benchmark | Old (ns/iter) | New (ns/iter) | Improvement |
+|-----------|--------------|--------------|-------------|
+| Small creature (5 hidden, 3 focus) | 259.7 | 255.5 | ~1.6% |
+| Medium creature (20 hidden, 6 focus) | 812.0 | 751.1 | ~7.5% |
+
+The primary benefit is reduced GC pressure from eliminating short-lived
+intermediate arrays over thousands of mutations per generation.
+
+## Test Plan
+
+- Added `test/mutate/ModWeightFocusFiltering.ts` with 3 new tests:
+  - Frozen synapses excluded from focus filtering
+  - Deduplication when focus neurons share synapses (statistical verification)
+  - Frozen synapses excluded even with shared focus neurons
+- All 5187 existing tests pass (`./quality.sh`)
+- Benchmark at `bench/mutate/ModWeightFocusFiltering.ts`

--- a/src/mutate/ModWeight.ts
+++ b/src/mutate/ModWeight.ts
@@ -46,20 +46,32 @@ export class ModWeight extends AbstractMutationOperator {
       // No focus - use all non-frozen connections
       relevantConnections = this.creature.synapses.filter((s) => !s.frozen);
     } else {
-      // Collect synapses connected to focused neurons using indexed lookups
-      // This is O(focusList.length * (log n + k)) instead of O(synapses * focusList)
-      const seen = new Set<Synapse>();
+      // Single-pass: build result directly, deduplicate via Set<number>,
+      // and check frozen status inline. Eliminates 2 intermediate allocations
+      // (Set<Synapse> → Array.from → .filter) per mutation call. (Issue #2124)
+      const seen = new Set<number>();
+      const neuronCount = this.creature.neurons.length;
+      relevantConnections = [];
       for (const focusIndex of focusList) {
-        // Get outward connections from focus neuron
         for (const syn of this.creature.outwardConnections(focusIndex)) {
-          seen.add(syn);
+          if (!syn.frozen) {
+            const key = syn.from * neuronCount + syn.to;
+            if (!seen.has(key)) {
+              seen.add(key);
+              relevantConnections.push(syn);
+            }
+          }
         }
-        // Get inward connections to focus neuron
         for (const syn of this.creature.inwardConnections(focusIndex)) {
-          seen.add(syn);
+          if (!syn.frozen) {
+            const key = syn.from * neuronCount + syn.to;
+            if (!seen.has(key)) {
+              seen.add(key);
+              relevantConnections.push(syn);
+            }
+          }
         }
       }
-      relevantConnections = Array.from(seen).filter((s) => !s.frozen);
     }
 
     let changed = false;

--- a/test/mutate/ModWeightFocusFiltering.ts
+++ b/test/mutate/ModWeightFocusFiltering.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for ModWeight focus filtering correctness (Issue #2124).
+ *
+ * Verifies that:
+ * - Frozen synapses are excluded from focus filtering
+ * - Deduplication works when multiple focus neurons share synapses
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { ModWeight } from "@mutate/ModWeight.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+Deno.test("ModWeight - frozen synapses excluded from focus filtering", () => {
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden" as const,
+        uuid: "hidden-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5, frozen: true },
+      { fromUUID: "input-1", toUUID: "hidden-1", weight: 0.3 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.7 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Verify the frozen synapse is correctly loaded
+  const frozenSyn = creature.synapses.find(
+    (s) => s.from === 0 && s.to === 2,
+  );
+  assert(frozenSyn, "Should find the frozen synapse");
+  assertEquals(frozenSyn.frozen, true, "Synapse should be frozen");
+
+  // Focus on hidden-1 (index 2) — all 3 synapses connect to it,
+  // but the frozen one (input-0 → hidden-1) must be excluded
+  const focusList = [2];
+
+  // Track which synapses get modified over many iterations
+  const modifiedSynapseKeys = new Set<string>();
+  for (let i = 0; i < 500; i++) {
+    const initialWeights = creature.synapses.map((s) => s.weight);
+    new ModWeight(creature).mutate(focusList);
+    for (let j = 0; j < creature.synapses.length; j++) {
+      if (initialWeights[j] !== creature.synapses[j].weight) {
+        modifiedSynapseKeys.add(
+          `${creature.synapses[j].from}->${creature.synapses[j].to}`,
+        );
+      }
+    }
+  }
+
+  // The frozen synapse (0->2) must never be modified
+  assert(
+    !modifiedSynapseKeys.has("0->2"),
+    "Frozen synapse must not be modified during focus filtering",
+  );
+
+  // The non-frozen synapses connected to focus should be modified
+  assert(
+    modifiedSynapseKeys.has("1->2"),
+    "Non-frozen inward synapse should be modified",
+  );
+  assert(
+    modifiedSynapseKeys.has("2->3"),
+    "Non-frozen outward synapse should be modified",
+  );
+});
+
+Deno.test("ModWeight - deduplication when focus neurons share synapses", () => {
+  // Create a network where two focus neurons are connected by the same synapse
+  const json = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden" as const,
+        uuid: "hidden-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "hidden" as const,
+        uuid: "hidden-2",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-2", weight: 0.3 },
+      { fromUUID: "hidden-1", toUUID: "hidden-2", weight: 0.4 },
+      { fromUUID: "hidden-2", toUUID: "output-0", weight: 0.6 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Focus on both hidden-1 (index 2) and hidden-2 (index 3)
+  // The synapse hidden-1 → hidden-2 is both outward from hidden-1 AND inward to hidden-2
+  // It should appear only once in the relevant connections (deduplication)
+  const focusList = [2, 3];
+
+  // Run many mutations and count how often each synapse is picked
+  const modifiedCounts = new Map<string, number>();
+  const iterations = 2000;
+
+  for (let i = 0; i < iterations; i++) {
+    const initialWeights = creature.synapses.map((s) => s.weight);
+    new ModWeight(creature).mutate(focusList);
+    for (let j = 0; j < creature.synapses.length; j++) {
+      if (initialWeights[j] !== creature.synapses[j].weight) {
+        const key = `${creature.synapses[j].from}->${creature.synapses[j].to}`;
+        modifiedCounts.set(key, (modifiedCounts.get(key) ?? 0) + 1);
+      }
+    }
+  }
+
+  // All 4 synapses connect to at least one focus neuron, so all should be modified
+  assert(
+    modifiedCounts.has("0->2"),
+    "Synapse input-0 → hidden-1 should be modified",
+  );
+  assert(
+    modifiedCounts.has("1->3"),
+    "Synapse input-1 → hidden-2 should be modified",
+  );
+  assert(
+    modifiedCounts.has("2->3"),
+    "Synapse hidden-1 → hidden-2 should be modified",
+  );
+  assert(
+    modifiedCounts.has("3->4"),
+    "Synapse hidden-2 → output-0 should be modified",
+  );
+
+  // The shared synapse (hidden-1 → hidden-2, key "2->3") should NOT be
+  // picked more often than others due to duplication. With proper deduplication
+  // and 4 synapses, each should be picked ~25% of the time.
+  const sharedCount = modifiedCounts.get("2->3") ?? 0;
+  const totalModifications = [...modifiedCounts.values()].reduce(
+    (a, b) => a + b,
+    0,
+  );
+  const sharedRatio = sharedCount / totalModifications;
+
+  // If deduplication failed, the shared synapse would appear twice in the pool
+  // (5 entries instead of 4), giving it ~40% instead of ~25%.
+  // Allow a generous margin but catch gross duplication.
+  assert(
+    sharedRatio < 0.35,
+    `Shared synapse was selected ${
+      (sharedRatio * 100).toFixed(1)
+    }% of the time — ` +
+      `suggests deduplication failure (expected ~25%)`,
+  );
+});
+
+Deno.test("ModWeight - frozen synapses excluded even with shared focus", () => {
+  // Network where a frozen synapse connects two focus neurons
+  const json = {
+    input: 1,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden" as const,
+        uuid: "hidden-1",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "hidden" as const,
+        uuid: "hidden-2",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+      {
+        type: "output" as const,
+        uuid: "output-0",
+        bias: 0,
+        squash: "IDENTITY",
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "hidden-2", weight: 0.4, frozen: true },
+      { fromUUID: "hidden-2", toUUID: "output-0", weight: 0.6 },
+    ],
+  };
+
+  const creature = Creature.fromJSON(json, true);
+
+  // Focus on both hidden neurons — the synapse between them is frozen
+  const focusList = [1, 2];
+
+  for (let i = 0; i < 500; i++) {
+    const frozenWeight = creature.synapses[1].weight;
+    new ModWeight(creature).mutate(focusList);
+    assertEquals(
+      creature.synapses[1].weight,
+      frozenWeight,
+      "Frozen synapse weight must not change",
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Reduce allocations in ModWeight mutation focus filtering by replacing the
triple-allocation pattern (Set<Synapse> → Array.from → .filter) with a
single-pass approach that builds the result array directly. Deduplication uses a
Set<number> keyed by synapse identity, and frozen-status checking is done
inline. This eliminates 2 intermediate allocations per mutation call. Closes
#2124.

## Evidence

Benchmark results (Apple M4, Deno 2.7.10):

| Benchmark                            | Old (ns/iter) | New (ns/iter) | Improvement |
| ------------------------------------ | ------------- | ------------- | ----------- |
| Small creature (5 hidden, 3 focus)   | 259.7         | 255.5         | ~1.6%       |
| Medium creature (20 hidden, 6 focus) | 812.0         | 751.1         | ~7.5%       |

The primary benefit is reduced GC pressure from eliminating short-lived
intermediate arrays over thousands of mutations per generation.

## Test Plan

- Added `test/mutate/ModWeightFocusFiltering.ts` with 3 new tests:
  - Frozen synapses excluded from focus filtering
  - Deduplication when focus neurons share synapses (statistical verification)
  - Frozen synapses excluded even with shared focus neurons
- All 5187 existing tests pass (`./quality.sh`)
- Benchmark at `bench/mutate/ModWeightFocusFiltering.ts`

---

## Automated Fix Details
This PR addresses issue #2124: **Re-implement: Reduce allocations in ModWeight mutation focus filtering**

## Milestone
This PR is part of the **Performance V2** milestone and targets the `milestone/performance-v2` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2124
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2124 -->