### PR TITLE
Cache non-expansion mutation candidates in Mutator (#2125)

### DIFF
--- a/bench/MutatorNonExpansionCache.ts
+++ b/bench/MutatorNonExpansionCache.ts
@@ -1,0 +1,48 @@
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { Creature } from "@creature";
+import { Mutator } from "@neat/Mutator.ts";
+import { Mutation } from "@neat/Mutation.ts";
+
+/**
+ * Benchmark for non-expansion mutation candidate caching.
+ *
+ * Issue #2125: Measures the performance of selectMutationMethod for large
+ * creatures where the non-expansion candidate filtering path is exercised.
+ * The optimisation pre-computes nonExpansionCandidates once per cache key
+ * instead of filtering on every call.
+ */
+
+const config = createNeatConfig({
+  mutation: Mutation.FFW,
+  adaptiveMutationThresholds: {
+    medium: 5,
+    large: 10,
+    largeTopologyWeight: 0.01,
+  },
+});
+const mutator = new Mutator(config);
+
+// Large creature that triggers non-expansion filtering path
+const largeCreature = new Creature(10, 5, { layers: [{ count: 50 }] });
+
+Deno.bench("selectMutationMethod (large creature, non-expansion path)", () => {
+  mutator.selectMutationMethod(largeCreature);
+});
+
+Deno.bench(
+  "selectMutationMethod x100 (large creature, non-expansion path)",
+  () => {
+    for (let i = 0; i < 100; i++) {
+      mutator.selectMutationMethod(largeCreature);
+    }
+  },
+);
+
+Deno.bench(
+  "selectMutationMethod x1000 (large creature, non-expansion path)",
+  () => {
+    for (let i = 0; i < 1000; i++) {
+      mutator.selectMutationMethod(largeCreature);
+    }
+  },
+);

--- a/docs/pr-summary-2125.md
+++ b/docs/pr-summary-2125.md
@@ -1,20 +1,27 @@
 ## Summary
 
-Cache non-expansion mutation candidates in `Mutator.ts` to eliminate per-call `.filter()` array allocations for large creatures. Closes #2125.
+Cache non-expansion mutation candidates in `Mutator.ts` to eliminate per-call
+`.filter()` array allocations for large creatures. Closes #2125.
 
-Added a `nonExpansionCandidates` field to `MutationCacheEntry` that is pre-computed once per cache key in `computeMutationCandidates()`. `selectMutationMethod()` now reads from the cached array instead of filtering candidates on every invocation.
+Added a `nonExpansionCandidates` field to `MutationCacheEntry` that is
+pre-computed once per cache key in `computeMutationCandidates()`.
+`selectMutationMethod()` now reads from the cached array instead of filtering
+candidates on every invocation.
 
 ## Evidence
 
-Benchmark results (`bench/MutatorNonExpansionCache.ts`) for large creatures (65 neurons):
+Benchmark results (`bench/MutatorNonExpansionCache.ts`) for large creatures (65
+neurons):
 
-| Benchmark | Time/iter |
-|---|---|
-| selectMutationMethod (single call) | 442 ns |
-| selectMutationMethod x100 | 44.6 us |
-| selectMutationMethod x1000 | 441.3 us |
+| Benchmark                          | Time/iter |
+| ---------------------------------- | --------- |
+| selectMutationMethod (single call) | 442 ns    |
+| selectMutationMethod x100          | 44.6 us   |
+| selectMutationMethod x1000         | 441.3 us  |
 
-The optimisation removes a per-call `.filter()` allocation. The cached array is computed once per unique cache key (creature size category), so repeated calls during evolution loops no longer create throwaway filtered arrays.
+The optimisation removes a per-call `.filter()` allocation. The cached array is
+computed once per unique cache key (creature size category), so repeated calls
+during evolution loops no longer create throwaway filtered arrays.
 
 ## Test Plan
 

--- a/docs/pr-summary-2125.md
+++ b/docs/pr-summary-2125.md
@@ -1,0 +1,27 @@
+## Summary
+
+Cache non-expansion mutation candidates in `Mutator.ts` to eliminate per-call `.filter()` array allocations for large creatures. Closes #2125.
+
+Added a `nonExpansionCandidates` field to `MutationCacheEntry` that is pre-computed once per cache key in `computeMutationCandidates()`. `selectMutationMethod()` now reads from the cached array instead of filtering candidates on every invocation.
+
+## Evidence
+
+Benchmark results (`bench/MutatorNonExpansionCache.ts`) for large creatures (65 neurons):
+
+| Benchmark | Time/iter |
+|---|---|
+| selectMutationMethod (single call) | 442 ns |
+| selectMutationMethod x100 | 44.6 us |
+| selectMutationMethod x1000 | 441.3 us |
+
+The optimisation removes a per-call `.filter()` allocation. The cached array is computed once per unique cache key (creature size category), so repeated calls during evolution loops no longer create throwaway filtered arrays.
+
+## Test Plan
+
+- Added `test/NEAT/MutatorNonExpansionCache.ts` with 4 tests:
+  - Large creatures never select expansion mutations via non-expansion path
+  - Cached non-expansion candidates are consistent across calls
+  - Different creature sizes produce correct cache entries
+  - `clearMutationCache` resets non-expansion candidates
+- All 85 existing Mutator tests pass with no modifications
+- Full quality gate passes (5191 tests, 0 failures)

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -37,6 +37,8 @@ interface MutationCacheEntry {
   candidates: ReadonlyArray<{ name: string }>;
   /** Count of weight/bias mutations in candidates (for weighted selection). */
   weightBiasCount: number;
+  /** Issue #2125: Pre-computed non-expansion candidates for large creature selection. */
+  nonExpansionCandidates: ReadonlyArray<{ name: string }>;
 }
 
 export class Mutator {
@@ -346,7 +348,14 @@ export class Mutator {
       }
     }
 
-    return { candidates, weightBiasCount };
+    // Issue #2125: Pre-compute non-expansion candidates once per cache key.
+    // This avoids repeated .filter() calls in selectMutationMethod() for large
+    // creatures, reducing per-call array allocations and GC pressure.
+    const nonExpansionCandidates = candidates.filter((c) =>
+      !this.isTopologyExpansionMutation(c.name)
+    );
+
+    return { candidates, weightBiasCount, nonExpansionCandidates };
   }
 
   /**
@@ -468,12 +477,11 @@ export class Mutator {
     }
 
     // For large creatures, further filter to exclude topology expansion mutations
-    // unless we explicitly pass the topology weight check above
+    // unless we explicitly pass the topology weight check above.
+    // Issue #2125: Use pre-computed nonExpansionCandidates from cache instead of
+    // filtering on every call.
     if (neuronCount >= large && largeTopologyWeight < 1.0) {
-      // Build list of non-expansion candidates
-      const nonExpansionCandidates = candidates.filter((c) =>
-        !this.isTopologyExpansionMutation(c.name)
-      );
+      const { nonExpansionCandidates } = cacheEntry;
       if (nonExpansionCandidates.length > 0) {
         return nonExpansionCandidates[
           Math.floor(rng.random() * nonExpansionCandidates.length)

--- a/test/NEAT/MutatorNonExpansionCache.ts
+++ b/test/NEAT/MutatorNonExpansionCache.ts
@@ -1,0 +1,191 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { Mutation } from "@neat/Mutation.ts";
+import { Mutator } from "@neat/Mutator.ts";
+
+/**
+ * Tests for cached non-expansion mutation candidates.
+ *
+ * Issue #2125: Verify that the pre-computed nonExpansionCandidates field
+ * in MutationCacheEntry correctly excludes topology expansion mutations
+ * (ADD_NODE, ADD_CONN) and is reused across calls.
+ */
+
+Deno.test(
+  "NonExpansionCache: large creatures never select expansion mutations via non-expansion path",
+  () => {
+    // Configure thresholds so our creature is "large"
+    const config = createNeatConfig({
+      mutation: Mutation.FFW,
+      adaptiveMutationThresholds: {
+        medium: 5,
+        large: 10,
+        largeTopologyWeight: 0,
+      },
+    });
+    const mutator = new Mutator(config);
+
+    // Create a creature above the large threshold (3 input + 10 hidden + 2 output = 15)
+    const creature = new Creature(3, 2, { layers: [{ count: 10 }] });
+    assertEquals(
+      creature.neurons.length,
+      15,
+      "Creature should have 15 neurons",
+    );
+
+    // With largeTopologyWeight=0, the non-expansion path should always be taken
+    // for large creatures when the weight/bias preference check is not hit.
+    // Run many iterations and verify no expansion mutations appear.
+    const selectedNames = new Set<string>();
+    for (let i = 0; i < 2000; i++) {
+      const method = mutator.selectMutationMethod(creature);
+      selectedNames.add(method.name);
+    }
+
+    // ADD_NODE and ADD_CONN are expansion mutations and should never be selected
+    // when largeTopologyWeight is 0
+    assert(
+      !selectedNames.has(Mutation.ADD_NODE.name),
+      "ADD_NODE should not be selected for large creatures with largeTopologyWeight=0",
+    );
+    assert(
+      !selectedNames.has(Mutation.ADD_CONN.name),
+      "ADD_CONN should not be selected for large creatures with largeTopologyWeight=0",
+    );
+
+    // Non-expansion mutations should still appear
+    assert(
+      selectedNames.has(Mutation.MOD_WEIGHT.name),
+      "MOD_WEIGHT should be available",
+    );
+    assert(
+      selectedNames.has(Mutation.MOD_BIAS.name),
+      "MOD_BIAS should be available",
+    );
+  },
+);
+
+Deno.test(
+  "NonExpansionCache: cached non-expansion candidates are consistent across calls",
+  () => {
+    const config = createNeatConfig({
+      mutation: Mutation.FFW,
+      adaptiveMutationThresholds: {
+        medium: 5,
+        large: 10,
+        largeTopologyWeight: 0,
+      },
+    });
+    const mutator = new Mutator(config);
+
+    const creature = new Creature(3, 2, { layers: [{ count: 10 }] });
+
+    // First batch of calls populates the cache
+    const firstBatch = new Set<string>();
+    for (let i = 0; i < 500; i++) {
+      firstBatch.add(mutator.selectMutationMethod(creature).name);
+    }
+
+    // Second batch should produce the same set of mutation names
+    const secondBatch = new Set<string>();
+    for (let i = 0; i < 500; i++) {
+      secondBatch.add(mutator.selectMutationMethod(creature).name);
+    }
+
+    // The mutation name sets should be identical (cache is stable)
+    assertEquals(
+      [...firstBatch].sort(),
+      [...secondBatch].sort(),
+      "Cached non-expansion candidates should produce consistent results",
+    );
+  },
+);
+
+Deno.test(
+  "NonExpansionCache: different creature sizes produce correct cache entries",
+  () => {
+    const config = createNeatConfig({
+      mutation: Mutation.FFW,
+      adaptiveMutationThresholds: {
+        medium: 5,
+        large: 10,
+        largeTopologyWeight: 0,
+      },
+    });
+    const mutator = new Mutator(config);
+
+    // Small creature (below medium threshold) - expansion mutations allowed
+    const smallCreature = new Creature(2, 1, { layers: [{ count: 1 }] });
+    // Large creature (above large threshold) - expansion mutations excluded
+    const largeCreature = new Creature(3, 2, { layers: [{ count: 10 }] });
+
+    const smallNames = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      smallNames.add(mutator.selectMutationMethod(smallCreature).name);
+    }
+
+    const largeNames = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      largeNames.add(mutator.selectMutationMethod(largeCreature).name);
+    }
+
+    // Small creature should have expansion mutations available
+    assert(
+      smallNames.has(Mutation.ADD_NODE.name) ||
+        smallNames.has(Mutation.ADD_CONN.name),
+      "Small creatures should have expansion mutations available",
+    );
+
+    // Large creature should NOT have expansion mutations
+    assert(
+      !largeNames.has(Mutation.ADD_NODE.name),
+      "Large creatures should not select ADD_NODE with largeTopologyWeight=0",
+    );
+    assert(
+      !largeNames.has(Mutation.ADD_CONN.name),
+      "Large creatures should not select ADD_CONN with largeTopologyWeight=0",
+    );
+  },
+);
+
+Deno.test(
+  "NonExpansionCache: clearMutationCache resets non-expansion candidates",
+  () => {
+    const config = createNeatConfig({
+      mutation: Mutation.FFW,
+      adaptiveMutationThresholds: {
+        medium: 5,
+        large: 10,
+        largeTopologyWeight: 0,
+      },
+    });
+    const mutator = new Mutator(config);
+
+    const creature = new Creature(3, 2, { layers: [{ count: 10 }] });
+
+    // Populate cache
+    for (let i = 0; i < 100; i++) {
+      mutator.selectMutationMethod(creature);
+    }
+
+    // Clear cache
+    mutator.clearMutationCache();
+
+    // Should still work correctly after cache clear
+    const selectedNames = new Set<string>();
+    for (let i = 0; i < 500; i++) {
+      selectedNames.add(mutator.selectMutationMethod(creature).name);
+    }
+
+    // Non-expansion candidates should still be correctly filtered
+    assert(
+      !selectedNames.has(Mutation.ADD_NODE.name),
+      "ADD_NODE should not appear after cache clear for large creatures",
+    );
+    assert(
+      selectedNames.has(Mutation.MOD_WEIGHT.name),
+      "MOD_WEIGHT should be available after cache clear",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Cache non-expansion mutation candidates in `Mutator.ts` to eliminate per-call
`.filter()` array allocations for large creatures. Closes #2125.

Added a `nonExpansionCandidates` field to `MutationCacheEntry` that is
pre-computed once per cache key in `computeMutationCandidates()`.
`selectMutationMethod()` now reads from the cached array instead of filtering
candidates on every invocation.

## Evidence

Benchmark results (`bench/MutatorNonExpansionCache.ts`) for large creatures (65
neurons):

| Benchmark                          | Time/iter |
| ---------------------------------- | --------- |
| selectMutationMethod (single call) | 442 ns    |
| selectMutationMethod x100          | 44.6 us   |
| selectMutationMethod x1000         | 441.3 us  |

The optimisation removes a per-call `.filter()` allocation. The cached array is
computed once per unique cache key (creature size category), so repeated calls
during evolution loops no longer create throwaway filtered arrays.

## Test Plan

- Added `test/NEAT/MutatorNonExpansionCache.ts` with 4 tests:
  - Large creatures never select expansion mutations via non-expansion path
  - Cached non-expansion candidates are consistent across calls
  - Different creature sizes produce correct cache entries
  - `clearMutationCache` resets non-expansion candidates
- All 85 existing Mutator tests pass with no modifications
- Full quality gate passes (5191 tests, 0 failures)

---

## Automated Fix Details
This PR addresses issue #2125: **Re-implement: Cache non-expansion mutation candidates in Mutator**

## Milestone
This PR is part of the **Performance V2** milestone and targets the `milestone/performance-v2` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2125
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2125 -->