### PR TITLE
Pool Float64Array allocations in score extraction functions (#2126)

### DIFF
--- a/bench/ScorePooledBuffers.ts
+++ b/bench/ScorePooledBuffers.ts
@@ -1,0 +1,208 @@
+/**
+ * Benchmark for pooled Float64Array allocations in Score.ts.
+ * Issue #2126: Measures the performance improvement from pooling
+ * Float64Array allocations in extractWeights() and extractBiases().
+ *
+ * Usage:
+ *   deno run -A bench/ScorePooledBuffers.ts
+ */
+
+import { Creature } from "@creature";
+import {
+  calculate,
+  resetPoolBuffers,
+  updateScoreForBiasChange,
+} from "@architecture/Score.ts";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+
+interface CreatureSpec {
+  name: string;
+  inputs: number;
+  outputs: number;
+  layers: { count: number; squash: string }[];
+}
+
+const SPECS: CreatureSpec[] = [
+  {
+    name: "Small",
+    inputs: 10,
+    outputs: 5,
+    layers: [
+      { count: 25, squash: IDENTITY.NAME },
+      { count: 10, squash: IDENTITY.NAME },
+    ],
+  },
+  {
+    name: "Medium",
+    inputs: 25,
+    outputs: 5,
+    layers: [
+      { count: 50, squash: IDENTITY.NAME },
+      { count: 30, squash: IDENTITY.NAME },
+      { count: 15, squash: IDENTITY.NAME },
+    ],
+  },
+  {
+    name: "Large",
+    inputs: 50,
+    outputs: 10,
+    layers: [
+      { count: 100, squash: IDENTITY.NAME },
+      { count: 75, squash: IDENTITY.NAME },
+      { count: 50, squash: IDENTITY.NAME },
+      { count: 25, squash: IDENTITY.NAME },
+    ],
+  },
+];
+
+function createCreature(spec: CreatureSpec): Creature {
+  const creature = new Creature(spec.inputs, spec.outputs, {
+    layers: spec.layers,
+    outputLayer: { squash: IDENTITY.NAME },
+  });
+  // Set random weights/biases for realistic data
+  for (let i = 0; i < creature.synapses.length; i++) {
+    creature.synapses[i].weight = (Math.random() - 0.5) * 4;
+  }
+  for (let i = creature.input; i < creature.neurons.length; i++) {
+    creature.neurons[i].bias = (Math.random() - 0.5) * 2;
+  }
+  return creature;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1) {
+    return `${(ms * 1000).toFixed(2)} µs`;
+  }
+  return `${ms.toFixed(3)} ms`;
+}
+
+function benchmarkScoreCalculation(
+  creature: Creature,
+  iterations: number,
+): number {
+  const times: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    // Clear cache to force fresh extraction each time
+    creature.invalidateScoreCache();
+    const start = performance.now();
+    calculate(creature, Math.random() * 0.3, 0.0001);
+    times.push(performance.now() - start);
+  }
+  return times.reduce((a, b) => a + b, 0) / iterations;
+}
+
+function benchmarkBiasScan(
+  creature: Creature,
+  iterations: number,
+): number {
+  const times: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    // Set up a bias change scenario that triggers a full scan
+    const neuronIdx = creature.input;
+    const oldBias = creature.neurons[neuronIdx].bias;
+    const newBias = oldBias * 0.5;
+
+    // Clear cache and compute initial
+    creature.invalidateScoreCache();
+    calculate(creature, 0.1, 0.001);
+
+    // Force max to match oldBias so scan is triggered
+    creature.cachedScoreComponents!.maxWeightBias = Math.abs(oldBias);
+    creature.cachedScoreComponents!.secondMaxWeightBias = -1;
+
+    creature.neurons[neuronIdx].bias = newBias;
+
+    const start = performance.now();
+    updateScoreForBiasChange(creature, 0.1, 0.001, oldBias, newBias);
+    times.push(performance.now() - start);
+
+    // Restore for next iteration
+    creature.neurons[neuronIdx].bias = oldBias;
+    creature.invalidateScoreCache();
+  }
+  return times.reduce((a, b) => a + b, 0) / iterations;
+}
+
+function run() {
+  console.log("=".repeat(65));
+  console.log("Pooled Float64Array Allocation Benchmark (Issue #2126)");
+  console.log("=".repeat(65));
+  console.log();
+
+  const iterations = 500;
+  const warmupIterations = 50;
+
+  const results: {
+    name: string;
+    synapses: number;
+    neurons: number;
+    scoreCalcAvg: string;
+    biasScanAvg: string;
+  }[] = [];
+
+  for (const spec of SPECS) {
+    const creature = createCreature(spec);
+    const numSynapses = creature.synapses.length;
+    const numNeurons = creature.neurons.length;
+
+    console.log(
+      `${spec.name} (${numSynapses} synapses, ${numNeurons} neurons)`,
+    );
+    console.log("-".repeat(50));
+
+    // Warmup
+    resetPoolBuffers();
+    for (let i = 0; i < warmupIterations; i++) {
+      creature.invalidateScoreCache();
+      calculate(creature, Math.random() * 0.3, 0.0001);
+    }
+
+    // Benchmark score calculation (pools are warm)
+    const scoreAvg = benchmarkScoreCalculation(creature, iterations);
+    console.log(
+      `  Score calculation (${iterations} iterations): ${
+        formatDuration(scoreAvg)
+      }`,
+    );
+
+    // Benchmark bias scan (triggers extractWeights + extractBiases)
+    const biasAvg = benchmarkBiasScan(creature, iterations);
+    console.log(
+      `  Bias scan (${iterations} iterations):         ${
+        formatDuration(biasAvg)
+      }`,
+    );
+    console.log();
+
+    results.push({
+      name: spec.name,
+      synapses: numSynapses,
+      neurons: numNeurons,
+      scoreCalcAvg: formatDuration(scoreAvg),
+      biasScanAvg: formatDuration(biasAvg),
+    });
+  }
+
+  // Summary table
+  console.log("=".repeat(65));
+  console.log("Summary (with pooled buffers)");
+  console.log("=".repeat(65));
+  console.log();
+  console.log(
+    "| Scenario | Synapses | Score Calc | Bias Scan |",
+  );
+  console.log(
+    "|----------|----------|------------|-----------|",
+  );
+  for (const r of results) {
+    console.log(
+      `| ${r.name.padEnd(8)} | ${String(r.synapses).padEnd(8)} | ${
+        r.scoreCalcAvg.padEnd(10)
+      } | ${r.biasScanAvg.padEnd(9)} |`,
+    );
+  }
+  console.log();
+}
+
+run();

--- a/docs/pr-summary-2126.md
+++ b/docs/pr-summary-2126.md
@@ -1,0 +1,29 @@
+## Summary
+
+Pool Float64Array allocations in `extractWeights()` and `extractBiases()` within `src/architecture/Score.ts`. Module-level buffers grow as needed (never shrink) and return subarray views, eliminating per-call `Float64Array` allocations in the score update hot path. Closes #2126.
+
+## Evidence
+
+Benchmark results (500 iterations per scenario, pooled buffers):
+
+| Scenario | Synapses | Score Calc | Bias Scan |
+|----------|----------|------------|-----------|
+| Small    | 550      | 4.22 µs    | 5.20 µs   |
+| Medium   | 3,275    | 6.86 µs    | 3.86 µs   |
+| Large    | 17,750   | 31.77 µs   | 19.11 µs  |
+
+The pooled buffer pattern eliminates repeated `Float64Array` constructor calls, which is the same pre-allocated buffer approach already used in `WasmStandaloneFunctions.ts`. The original PR #2060 demonstrated 10–18% improvement across scenarios.
+
+## Test Plan
+
+- Added `test/architecture/ScorePooledBuffers.ts` with 8 tests verifying:
+  - Pool buffers grow when creature size increases
+  - Pool buffers do not shrink when creature size decreases
+  - Pool buffers are reused across multiple calculate calls
+  - Extraction correctness verified via score consistency
+  - Correct results after pool growth (small → large → small)
+  - Incremental weight update correctness with pooled buffers
+  - Incremental bias update correctness with pooled buffers
+  - Reset clears pool capacity
+- All 5,199 existing tests continue to pass
+- Added `bench/ScorePooledBuffers.ts` benchmark

--- a/docs/pr-summary-2126.md
+++ b/docs/pr-summary-2126.md
@@ -1,18 +1,24 @@
 ## Summary
 
-Pool Float64Array allocations in `extractWeights()` and `extractBiases()` within `src/architecture/Score.ts`. Module-level buffers grow as needed (never shrink) and return subarray views, eliminating per-call `Float64Array` allocations in the score update hot path. Closes #2126.
+Pool Float64Array allocations in `extractWeights()` and `extractBiases()` within
+`src/architecture/Score.ts`. Module-level buffers grow as needed (never shrink)
+and return subarray views, eliminating per-call `Float64Array` allocations in
+the score update hot path. Closes #2126.
 
 ## Evidence
 
 Benchmark results (500 iterations per scenario, pooled buffers):
 
 | Scenario | Synapses | Score Calc | Bias Scan |
-|----------|----------|------------|-----------|
+| -------- | -------- | ---------- | --------- |
 | Small    | 550      | 4.22 µs    | 5.20 µs   |
 | Medium   | 3,275    | 6.86 µs    | 3.86 µs   |
 | Large    | 17,750   | 31.77 µs   | 19.11 µs  |
 
-The pooled buffer pattern eliminates repeated `Float64Array` constructor calls, which is the same pre-allocated buffer approach already used in `WasmStandaloneFunctions.ts`. The original PR #2060 demonstrated 10–18% improvement across scenarios.
+The pooled buffer pattern eliminates repeated `Float64Array` constructor calls,
+which is the same pre-allocated buffer approach already used in
+`WasmStandaloneFunctions.ts`. The original PR #2060 demonstrated 10–18%
+improvement across scenarios.
 
 ## Test Plan
 

--- a/src/architecture/Score.ts
+++ b/src/architecture/Score.ts
@@ -113,31 +113,67 @@ function calculatePenalty(max: number, avg: number): number {
   return penalty;
 }
 
+// Issue #2126: Module-level pooled buffers for extractWeights/extractBiases.
+// Buffers grow as needed (never shrink) and return subarray views, avoiding
+// per-call Float64Array allocations in the score update hot path.
+let _weightPool = new Float64Array(0);
+let _biasPool = new Float64Array(0);
+
 /**
  * Extracts flat Float64Array of synapse weights from a creature.
  * Issue #1521: Helper for WASM score scan functions.
+ * Issue #2126: Uses pooled buffer to avoid per-call allocations.
  */
 function extractWeights(creature: Creature): Float64Array {
   const synapses = creature.synapses;
-  const weights = new Float64Array(synapses.length);
-  for (let i = 0, len = synapses.length; i < len; i++) {
-    weights[i] = synapses[i].weight;
+  const len = synapses.length;
+  if (_weightPool.length < len) {
+    _weightPool = new Float64Array(len);
   }
-  return weights;
+  for (let i = 0; i < len; i++) {
+    _weightPool[i] = synapses[i].weight;
+  }
+  return _weightPool.subarray(0, len);
 }
 
 /**
  * Extracts flat Float64Array of non-input neuron biases from a creature.
  * Issue #1521: Helper for WASM score scan functions.
+ * Issue #2126: Uses pooled buffer to avoid per-call allocations.
  */
 function extractBiases(creature: Creature): Float64Array {
   const neurons = creature.neurons;
   const numBiases = neurons.length - creature.input;
-  const biases = new Float64Array(numBiases);
-  for (let i = 0; i < numBiases; i++) {
-    biases[i] = neurons[creature.input + i].bias;
+  if (_biasPool.length < numBiases) {
+    _biasPool = new Float64Array(numBiases);
   }
-  return biases;
+  for (let i = 0; i < numBiases; i++) {
+    _biasPool[i] = neurons[creature.input + i].bias;
+  }
+  return _biasPool.subarray(0, numBiases);
+}
+
+/**
+ * Returns the current capacity of the pooled weight and bias buffers.
+ * Issue #2126: Exported for testing pool growth and reuse behaviour.
+ */
+export function getPoolCapacities(): {
+  weightCapacity: number;
+  biasCapacity: number;
+} {
+  return {
+    weightCapacity: _weightPool.length,
+    biasCapacity: _biasPool.length,
+  };
+}
+
+/**
+ * Resets the pooled buffers to zero capacity.
+ * Issue #2126: Exported for testing pool growth behaviour.
+ */
+export function resetPoolBuffers(): void {
+  _weightPool = new Float64Array(0);
+  _biasPool = new Float64Array(0);
 }
 
 /**

--- a/test/architecture/ScorePooledBuffers.ts
+++ b/test/architecture/ScorePooledBuffers.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for pooled Float64Array buffers in Score.ts extraction functions.
+ *
+ * Issue #2126: Verifies that the module-level pooled buffers grow as needed,
+ * are reused across calls, and produce correct extraction results.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../mod.ts";
+import {
+  calculate,
+  getPoolCapacities,
+  resetPoolBuffers,
+  updateScoreForBiasChange,
+  updateScoreForWeightChange,
+} from "@architecture/Score.ts";
+
+/**
+ * Helper to create a creature with specified hidden neuron count.
+ */
+function makeCreature(hiddenCount: number): Creature {
+  const creature = new Creature(2, 1, {
+    layers: [{ count: hiddenCount, squash: "IDENTITY" }],
+  });
+  // Set distinct weights so extraction correctness is verifiable
+  for (let i = 0; i < creature.synapses.length; i++) {
+    creature.synapses[i].weight = (i + 1) * 0.1;
+  }
+  for (let i = creature.input; i < creature.neurons.length; i++) {
+    creature.neurons[i].bias = (i + 1) * 0.05;
+  }
+  delete creature.cachedScoreComponents;
+  return creature;
+}
+
+// --- Pool growth tests ---
+
+Deno.test("pooled buffers - grow when creature size increases", () => {
+  resetPoolBuffers();
+
+  // Start with a small creature
+  const small = makeCreature(2);
+  calculate(small, 0.1, 0.001);
+
+  const afterSmall = getPoolCapacities();
+  assert(
+    afterSmall.weightCapacity >= small.synapses.length,
+    "Weight pool should accommodate small creature synapses",
+  );
+  assert(
+    afterSmall.biasCapacity >= small.neurons.length - small.input,
+    "Bias pool should accommodate small creature biases",
+  );
+
+  // Now use a larger creature — pools should grow
+  const large = makeCreature(10);
+  delete large.cachedScoreComponents;
+  calculate(large, 0.1, 0.001);
+
+  const afterLarge = getPoolCapacities();
+  assert(
+    afterLarge.weightCapacity >= large.synapses.length,
+    "Weight pool should grow for larger creature",
+  );
+  assert(
+    afterLarge.biasCapacity >= large.neurons.length - large.input,
+    "Bias pool should grow for larger creature",
+  );
+  assert(
+    afterLarge.weightCapacity >= afterSmall.weightCapacity,
+    "Weight pool should never shrink",
+  );
+  assert(
+    afterLarge.biasCapacity >= afterSmall.biasCapacity,
+    "Bias pool should never shrink",
+  );
+});
+
+Deno.test("pooled buffers - do not shrink when creature size decreases", () => {
+  resetPoolBuffers();
+
+  // Use a large creature first
+  const large = makeCreature(10);
+  calculate(large, 0.1, 0.001);
+  const afterLarge = getPoolCapacities();
+
+  // Now use a smaller creature — pools should NOT shrink
+  const small = makeCreature(2);
+  delete small.cachedScoreComponents;
+  calculate(small, 0.1, 0.001);
+  const afterSmall = getPoolCapacities();
+
+  assertEquals(
+    afterSmall.weightCapacity,
+    afterLarge.weightCapacity,
+    "Weight pool should not shrink for smaller creature",
+  );
+  assertEquals(
+    afterSmall.biasCapacity,
+    afterLarge.biasCapacity,
+    "Bias pool should not shrink for smaller creature",
+  );
+});
+
+Deno.test("pooled buffers - reused across multiple calculate calls", () => {
+  resetPoolBuffers();
+
+  const creature = makeCreature(5);
+
+  // First call allocates
+  calculate(creature, 0.1, 0.001);
+  const firstCapacity = getPoolCapacities();
+
+  // Subsequent calls with same-sized creature should not change capacity
+  for (let i = 0; i < 5; i++) {
+    delete creature.cachedScoreComponents;
+    calculate(creature, 0.1 + i * 0.01, 0.001);
+  }
+
+  const laterCapacity = getPoolCapacities();
+  assertEquals(
+    laterCapacity.weightCapacity,
+    firstCapacity.weightCapacity,
+    "Weight pool capacity should stay stable across repeated calls",
+  );
+  assertEquals(
+    laterCapacity.biasCapacity,
+    firstCapacity.biasCapacity,
+    "Bias pool capacity should stay stable across repeated calls",
+  );
+});
+
+// --- Extraction correctness tests ---
+
+Deno.test("pooled buffers - extraction correctness verified via score consistency", () => {
+  resetPoolBuffers();
+
+  const creature = makeCreature(5);
+
+  // Calculate with pooled buffers
+  const pooledScore = calculate(creature, 0.1, 0.001);
+
+  // Clear cache and recalculate — should produce identical result
+  // (verifies that pooled extraction produces correct values)
+  delete creature.cachedScoreComponents;
+  const secondScore = calculate(creature, 0.1, 0.001);
+
+  assertEquals(
+    pooledScore,
+    secondScore,
+    "Pooled extraction should produce consistent scores",
+  );
+});
+
+Deno.test("pooled buffers - correct results after pool growth", () => {
+  resetPoolBuffers();
+
+  // Use small creature to initialise pool
+  const small = makeCreature(2);
+  const smallScore = calculate(small, 0.1, 0.001);
+
+  // Use large creature — forces pool growth
+  const large = makeCreature(10);
+  const largeScore = calculate(large, 0.1, 0.001);
+
+  // Go back to small creature — uses subarray of larger pool
+  const small2 = makeCreature(2);
+  const small2Score = calculate(small2, 0.1, 0.001);
+
+  assertEquals(
+    smallScore,
+    small2Score,
+    "Small creature score should be identical before and after pool growth",
+  );
+
+  // Large creature should have a different score (different topology)
+  assert(
+    largeScore !== smallScore,
+    "Different sized creatures should produce different scores",
+  );
+});
+
+Deno.test("pooled buffers - incremental weight update still correct after pooling", () => {
+  resetPoolBuffers();
+
+  const creature = makeCreature(5);
+  calculate(creature, 0.1, 0.001);
+
+  const oldWeight = creature.synapses[0].weight;
+  const newWeight = 2.5;
+  creature.synapses[0].weight = newWeight;
+
+  const incrementalScore = updateScoreForWeightChange(
+    creature,
+    0.1,
+    0.001,
+    oldWeight,
+    newWeight,
+  );
+
+  // Verify against full recalculation
+  delete creature.cachedScoreComponents;
+  const fullScore = calculate(creature, 0.1, 0.001);
+
+  assertEquals(
+    incrementalScore,
+    fullScore,
+    "Incremental weight update should match full recalculation with pooled buffers",
+  );
+});
+
+Deno.test("pooled buffers - incremental bias update still correct after pooling", () => {
+  resetPoolBuffers();
+
+  const creature = makeCreature(5);
+  calculate(creature, 0.1, 0.001);
+
+  const neuronIdx = creature.input;
+  const oldBias = creature.neurons[neuronIdx].bias;
+  const newBias = 1.5;
+  creature.neurons[neuronIdx].bias = newBias;
+
+  const incrementalScore = updateScoreForBiasChange(
+    creature,
+    0.1,
+    0.001,
+    oldBias,
+    newBias,
+  );
+
+  // Verify against full recalculation
+  delete creature.cachedScoreComponents;
+  const fullScore = calculate(creature, 0.1, 0.001);
+
+  assertEquals(
+    incrementalScore,
+    fullScore,
+    "Incremental bias update should match full recalculation with pooled buffers",
+  );
+});
+
+Deno.test("pooled buffers - reset clears capacity", () => {
+  // Ensure pools have some capacity
+  const creature = makeCreature(5);
+  calculate(creature, 0.1, 0.001);
+
+  const before = getPoolCapacities();
+  assert(
+    before.weightCapacity > 0,
+    "Weight pool should have capacity before reset",
+  );
+
+  resetPoolBuffers();
+
+  const after = getPoolCapacities();
+  assertEquals(
+    after.weightCapacity,
+    0,
+    "Weight pool should be empty after reset",
+  );
+  assertEquals(after.biasCapacity, 0, "Bias pool should be empty after reset");
+});


### PR DESCRIPTION
## Summary

Pool Float64Array allocations in `extractWeights()` and `extractBiases()` within
`src/architecture/Score.ts`. Module-level buffers grow as needed (never shrink)
and return subarray views, eliminating per-call `Float64Array` allocations in
the score update hot path. Closes #2126.

## Evidence

Benchmark results (500 iterations per scenario, pooled buffers):

| Scenario | Synapses | Score Calc | Bias Scan |
| -------- | -------- | ---------- | --------- |
| Small    | 550      | 4.22 µs    | 5.20 µs   |
| Medium   | 3,275    | 6.86 µs    | 3.86 µs   |
| Large    | 17,750   | 31.77 µs   | 19.11 µs  |

The pooled buffer pattern eliminates repeated `Float64Array` constructor calls,
which is the same pre-allocated buffer approach already used in
`WasmStandaloneFunctions.ts`. The original PR #2060 demonstrated 10–18%
improvement across scenarios.

## Test Plan

- Added `test/architecture/ScorePooledBuffers.ts` with 8 tests verifying:
  - Pool buffers grow when creature size increases
  - Pool buffers do not shrink when creature size decreases
  - Pool buffers are reused across multiple calculate calls
  - Extraction correctness verified via score consistency
  - Correct results after pool growth (small → large → small)
  - Incremental weight update correctness with pooled buffers
  - Incremental bias update correctness with pooled buffers
  - Reset clears pool capacity
- All 5,199 existing tests continue to pass
- Added `bench/ScorePooledBuffers.ts` benchmark

---

## Automated Fix Details
This PR addresses issue #2126: **Re-implement: Pool Float64Array allocations in score extraction functions**

## Milestone
This PR is part of the **Performance V2** milestone and targets the `milestone/performance-v2` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2126
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2126 -->