### PR TITLE
Remove hardcoded requireGpu: false with GPU-aware guard (#2142)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2142.md
+++ b/docs/pr-summary-2142.md
@@ -1,0 +1,29 @@
+## Summary
+
+Remove hardcoded `requireGpu: false` from `RustAnalysisCache.ts` so the GPU
+guard in `analyzeParallel()` can properly block FFI calls when no GPU is
+available. Previously, the hardcoded `false` bypassed the guard, allowing the
+Rust library to be called without a GPU, which caused a panic at
+`src/analysis/neuron/mod.rs:99:5`. With this fix, `requireGpu` is omitted
+(undefined), so `analyzeParallel()` returns a graceful
+`{ success: false, error: "GPU adapter not available" }` on machines without a
+GPU. Closes #2142.
+
+## Evidence
+
+- Before fix: `requireGpu: false` bypassed the GPU guard, causing Rust panic on
+  no-GPU machines.
+- After fix: `requireGpu` is omitted, so the guard
+  `input.requireGpu !== false && !isRustGpuAvailable()` activates and returns a
+  graceful failure.
+- All 5212 tests pass (0 failures, 3 ignored).
+
+## Test Plan
+
+- Added `test/ErrorGuidedStructuralEvolution/RustAnalysisCacheGpuGuard.ts` -
+  verifies `ensureRustCombinedAnalysis` does not pass `requireGpu: false` to
+  `analyzeParallel()`.
+- Updated `test/discovery/CrossPlatformGpuSupport.ts` - two tests updated to
+  assert `requireGpu` is `undefined` (omitted) rather than `false`.
+- Existing `test/ErrorGuidedStructuralEvolution/AnalyzeParallelGpuGuard.ts`
+  continues to pass unchanged.

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts
@@ -147,7 +147,6 @@ export function ensureRustCombinedAnalysis(
     maxNeuronCandidates: includeNeuron
       ? Math.max(25, focusList.length * 5)
       : undefined,
-    requireGpu: false,
     analysisDeadlineMs,
     focusNeuronErrorShares,
   };

--- a/test/ErrorGuidedStructuralEvolution/RustAnalysisCacheGpuGuard.ts
+++ b/test/ErrorGuidedStructuralEvolution/RustAnalysisCacheGpuGuard.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for RustAnalysisCache GPU-aware guard (Issue #2142).
+ *
+ * Validates that ensureRustCombinedAnalysis does NOT hardcode
+ * requireGpu: false, allowing the GPU guard in analyzeParallel()
+ * to properly block calls when GPU is unavailable.
+ */
+import { assertEquals } from "@std/assert";
+import { ensureRustCombinedAnalysis } from "@architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts";
+import { Creature } from "@creature";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+
+/**
+ * Builds a minimal creature for testing.
+ */
+function buildMinimalCreature(): Creature {
+  return Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  });
+}
+
+Deno.test({
+  name:
+    "ensureRustCombinedAnalysis omits requireGpu so GPU guard can protect FFI calls (Issue #2142)",
+  sanitizeResources: false,
+  fn: () => {
+    // Capture what analyzeParallel receives to verify requireGpu is not false
+    let capturedInput: Record<string, unknown> | undefined;
+    const creature = buildMinimalCreature();
+
+    const deps = {
+      isRustDiscoveryEnabled: () => true,
+      analyzeParallel: (
+        input: Record<string, unknown>,
+      ): { success: boolean; error?: string } => {
+        capturedInput = input;
+        return { success: false, error: "test stub" };
+      },
+    };
+
+    const logCalls: Array<{ scope: string; reason: string }> = [];
+
+    ensureRustCombinedAnalysis(
+      creature,
+      "/tmp/test.parquet",
+      deps as unknown as Parameters<typeof ensureRustCombinedAnalysis>[2],
+      undefined, // no cache
+      undefined, // no deadline
+      [], // empty focus list
+      true, // includeSynapse
+      false, // includeNeuron
+      (scope, _focusList, reason) => {
+        logCalls.push({ scope, reason });
+      },
+    );
+
+    // The key assertion: requireGpu must NOT be explicitly false.
+    // It should be undefined (omitted) so the GPU guard in analyzeParallel()
+    // can block the call when no GPU is available.
+    assertEquals(
+      capturedInput !== undefined,
+      true,
+      "analyzeParallel should have been called",
+    );
+    assertEquals(
+      capturedInput!.requireGpu !== false,
+      true,
+      `requireGpu should not be false, got: ${capturedInput!.requireGpu}`,
+    );
+  },
+});

--- a/test/discovery/CrossPlatformGpuSupport.ts
+++ b/test/discovery/CrossPlatformGpuSupport.ts
@@ -49,7 +49,7 @@ function output0Id(creature: Creature): number {
   return id;
 }
 
-Deno.test("requireGpu is false in ensureRustCombinedAnalysis (cross-platform)", async () => {
+Deno.test("requireGpu is omitted in ensureRustCombinedAnalysis so GPU guard is active (Issue #2142)", async () => {
   await initWasmForTests();
   const creature = makeCreature();
   const focusId = output0Id(creature);
@@ -88,8 +88,8 @@ Deno.test("requireGpu is false in ensureRustCombinedAnalysis (cross-platform)", 
   assertExists(capturedInput, "analyzeParallel should have been called");
   assertEquals(
     capturedInput!.requireGpu,
-    false,
-    "requireGpu should be false for cross-platform CPU fallback support",
+    undefined,
+    "requireGpu should be omitted so the GPU guard in analyzeParallel() can block calls when GPU is unavailable (Issue #2142)",
   );
   assertExists(result.result, "Result should be returned");
 });
@@ -259,11 +259,12 @@ Deno.test("GpuBackendInfo type represents CPU-fallback state", () => {
   assertEquals(info.backendName, undefined);
 });
 
-Deno.test("discovery enabled without GPU: analysis uses CPU fallback", async () => {
+Deno.test("discovery enabled: analysis called with requireGpu omitted (Issue #2142)", async () => {
   await initWasmForTests();
   const creature = makeCreature();
   const focusId = output0Id(creature);
   let analysisCalled = false;
+  let capturedRequireGpu: boolean | undefined;
 
   const result = ensureRustCombinedAnalysis(
     creature,
@@ -278,11 +279,7 @@ Deno.test("discovery enabled without GPU: analysis uses CPU fallback", async () 
       }),
       analyzeParallel: (input: RustParallelAnalysisInput) => {
         analysisCalled = true;
-        assertEquals(
-          input.requireGpu,
-          false,
-          "Should not require GPU (allows CPU fallback)",
-        );
+        capturedRequireGpu = input.requireGpu;
         return {
           success: true,
           synapseGpuUsed: false,
@@ -302,8 +299,13 @@ Deno.test("discovery enabled without GPU: analysis uses CPU fallback", async () 
     () => {},
   );
 
-  assertEquals(analysisCalled, true, "Analysis should proceed without GPU");
-  assertExists(result.result, "Should return result from CPU fallback");
+  assertEquals(analysisCalled, true, "Analysis should be called");
+  assertEquals(
+    capturedRequireGpu,
+    undefined,
+    "requireGpu should be omitted so the GPU guard can protect the FFI call (Issue #2142)",
+  );
+  assertExists(result.result, "Should return analysis result");
 });
 
 Deno.test("ensureRustCombinedAnalysis skips unresolved focus neurons", async () => {


### PR DESCRIPTION
## Summary

Remove hardcoded `requireGpu: false` from `RustAnalysisCache.ts` so the GPU
guard in `analyzeParallel()` can properly block FFI calls when no GPU is
available. Previously, the hardcoded `false` bypassed the guard, allowing the
Rust library to be called without a GPU, which caused a panic at
`src/analysis/neuron/mod.rs:99:5`. With this fix, `requireGpu` is omitted
(undefined), so `analyzeParallel()` returns a graceful
`{ success: false, error: "GPU adapter not available" }` on machines without a
GPU. Closes #2142.

## Evidence

- Before fix: `requireGpu: false` bypassed the GPU guard, causing Rust panic on
  no-GPU machines.
- After fix: `requireGpu` is omitted, so the guard
  `input.requireGpu !== false && !isRustGpuAvailable()` activates and returns a
  graceful failure.
- All 5212 tests pass (0 failures, 3 ignored).

## Test Plan

- Added `test/ErrorGuidedStructuralEvolution/RustAnalysisCacheGpuGuard.ts` -
  verifies `ensureRustCombinedAnalysis` does not pass `requireGpu: false` to
  `analyzeParallel()`.
- Updated `test/discovery/CrossPlatformGpuSupport.ts` - two tests updated to
  assert `requireGpu` is `undefined` (omitted) rather than `false`.
- Existing `test/ErrorGuidedStructuralEvolution/AnalyzeParallelGpuGuard.ts`
  continues to pass unchanged.

---

## Automated Fix Details
This PR addresses issue #2142: **Replace hardcoded requireGpu: false with GPU-aware guard in RustAnalysisCache**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2142
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2142 -->