### PR TITLE
Add forward-only synapse guard to DiscoveryNeuronAddition (#2152)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2152.md
+++ b/docs/pr-summary-2152.md
@@ -1,0 +1,34 @@
+## Summary
+
+Add forward-only synapse guard to `addHelpfulNeurons()` in `DiscoveryNeuronAddition.ts` to prevent backward connections when inserting new neurons into forward-only creatures. This is the same class of issue as #2150 — discovery operations that add synapses without forward-only guards, leading to recurrent synapses being stripped during `loadFrom()`. Closes #2152.
+
+## Changes
+
+- **`src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronAddition.ts`**:
+  - Built a UUID-to-index map (same pattern as `DiscoverySynapseOps.ts`) for forward-only creatures
+  - Added pre-insertion forward-only guard that rejects candidates where the source neuron index >= target neuron index using UUID-based resolution (avoids runtime ID mis-resolution)
+  - Added post-insertion verification ensuring the new neuron sits between its incoming source and outgoing target indices
+  - Rebuilt the UUID-to-index map after each neuron insertion so subsequent candidates see correct indices
+  - Added diagnostic logging and `recordDiscoveryIssue` calls for rejected candidates
+
+## Evidence
+
+Before the fix, the mixed-candidate test showed `loadFrom()` stripping a backward synapse at load time:
+```
+🚨 [loadFrom] Stripping recurrent synapse 6->2 (fromUUID=output-0, toUUID=...) from forward-only creature
+```
+
+After the fix, the backward candidate is rejected at the source with a clear diagnostic:
+```
+[Discovery TEST-MIXED] addHelpfulNeurons: Skipping candidate output-0 -> hidden-1: violates forward-only constraint (fromIdx=5, toIdx=2)
+```
+
+## Test Plan
+
+- Added `test/ErrorGuidedStructuralEvolution/ForwardOnlyNeuronAdditionGuard.ts` with 5 tests:
+  - Valid forward neuron addition produces no backward synapses
+  - Backward candidate (hidden-2 -> hidden-1) is rejected
+  - Neuron addition with output target maintains forward-only
+  - Mixed candidates filtered correctly (only forward ones kept)
+  - Self-referencing candidate (hidden-1 -> hidden-1) is rejected
+- All 5239 existing tests pass with no regressions

--- a/docs/pr-summary-2152.md
+++ b/docs/pr-summary-2152.md
@@ -1,31 +1,46 @@
 ## Summary
 
-Add forward-only synapse guard to `addHelpfulNeurons()` in `DiscoveryNeuronAddition.ts` to prevent backward connections when inserting new neurons into forward-only creatures. This is the same class of issue as #2150 — discovery operations that add synapses without forward-only guards, leading to recurrent synapses being stripped during `loadFrom()`. Closes #2152.
+Add forward-only synapse guard to `addHelpfulNeurons()` in
+`DiscoveryNeuronAddition.ts` to prevent backward connections when inserting new
+neurons into forward-only creatures. This is the same class of issue as #2150 —
+discovery operations that add synapses without forward-only guards, leading to
+recurrent synapses being stripped during `loadFrom()`. Closes #2152.
 
 ## Changes
 
 - **`src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronAddition.ts`**:
-  - Built a UUID-to-index map (same pattern as `DiscoverySynapseOps.ts`) for forward-only creatures
-  - Added pre-insertion forward-only guard that rejects candidates where the source neuron index >= target neuron index using UUID-based resolution (avoids runtime ID mis-resolution)
-  - Added post-insertion verification ensuring the new neuron sits between its incoming source and outgoing target indices
-  - Rebuilt the UUID-to-index map after each neuron insertion so subsequent candidates see correct indices
-  - Added diagnostic logging and `recordDiscoveryIssue` calls for rejected candidates
+  - Built a UUID-to-index map (same pattern as `DiscoverySynapseOps.ts`) for
+    forward-only creatures
+  - Added pre-insertion forward-only guard that rejects candidates where the
+    source neuron index >= target neuron index using UUID-based resolution
+    (avoids runtime ID mis-resolution)
+  - Added post-insertion verification ensuring the new neuron sits between its
+    incoming source and outgoing target indices
+  - Rebuilt the UUID-to-index map after each neuron insertion so subsequent
+    candidates see correct indices
+  - Added diagnostic logging and `recordDiscoveryIssue` calls for rejected
+    candidates
 
 ## Evidence
 
-Before the fix, the mixed-candidate test showed `loadFrom()` stripping a backward synapse at load time:
+Before the fix, the mixed-candidate test showed `loadFrom()` stripping a
+backward synapse at load time:
+
 ```
 🚨 [loadFrom] Stripping recurrent synapse 6->2 (fromUUID=output-0, toUUID=...) from forward-only creature
 ```
 
-After the fix, the backward candidate is rejected at the source with a clear diagnostic:
+After the fix, the backward candidate is rejected at the source with a clear
+diagnostic:
+
 ```
 [Discovery TEST-MIXED] addHelpfulNeurons: Skipping candidate output-0 -> hidden-1: violates forward-only constraint (fromIdx=5, toIdx=2)
 ```
 
 ## Test Plan
 
-- Added `test/ErrorGuidedStructuralEvolution/ForwardOnlyNeuronAdditionGuard.ts` with 5 tests:
+- Added `test/ErrorGuidedStructuralEvolution/ForwardOnlyNeuronAdditionGuard.ts`
+  with 5 tests:
   - Valid forward neuron addition produces no backward synapses
   - Backward candidate (hidden-2 -> hidden-1) is rejected
   - Neuron addition with output target maintains forward-only

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronAddition.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronAddition.ts
@@ -54,6 +54,24 @@ export function addHelpfulNeurons(
   for (let i = 0; i < creature.input; i++) {
     existingNeuronIds.add(i);
   }
+
+  // Build UUID-to-index map for forward-only guard (Issue #2152).
+  // Input neurons occupy indices 0..input-1; exported neurons follow sequentially.
+  const isForwardOnly = exportJSON.forwardOnly === true;
+  const uuidToIndexMap = new Map<string, number>();
+  if (isForwardOnly) {
+    const inputCount = exportJSON.input ?? 0;
+    for (let i = 0; i < inputCount; i++) {
+      uuidToIndexMap.set(`input-${i}`, i);
+    }
+    for (let i = 0; i < exportJSON.neurons.length; i++) {
+      const uuid = exportJSON.neurons[i].uuid;
+      if (uuid) {
+        uuidToIndexMap.set(uuid, inputCount + i);
+      }
+    }
+  }
+
   const processedKeys = new Set<string>();
   const addedNeuronIds: number[] = [];
   const appliedCandidates: CandidateNeuron[] = [];
@@ -119,6 +137,41 @@ export function addHelpfulNeurons(
         );
       }
       return;
+    }
+
+    // Forward-only guard: reject candidates whose incoming or outgoing synapse
+    // would create a backward connection (Issue #2152).
+    // Uses UUID-based index map instead of runtime IDs to avoid mis-resolution.
+    if (isForwardOnly) {
+      const fromIdx = uuidToIndexMap.get(candidate.fromNeuronUuid);
+      const toIdx = uuidToIndexMap.get(candidate.toNeuronUuid);
+      if (
+        fromIdx === undefined || toIdx === undefined || fromIdx >= toIdx
+      ) {
+        getLogger().warn(
+          `[Discovery ${ID}] addHelpfulNeurons: Skipping candidate ${candidate.fromNeuronUuid} -> ${candidate.toNeuronUuid}: violates forward-only constraint (fromIdx=${fromIdx}, toIdx=${toIdx})`,
+        );
+
+        if (discoveryFailureCacheDir) {
+          recordDiscoveryIssue(
+            creature,
+            ID,
+            "add-neurons",
+            "forward-only",
+            {
+              message:
+                `Forward-only constraint violated (fromIdx=${fromIdx}, toIdx=${toIdx})`,
+              fromNeuronUuid: candidate.fromNeuronUuid,
+              toNeuronUuid: candidate.toNeuronUuid,
+              fromIdx,
+              toIdx,
+              candidate,
+            },
+            discoveryFailureCacheDir,
+          );
+        }
+        return;
+      }
     }
 
     const newNeuronId = nextNeuronId();
@@ -188,6 +241,48 @@ export function addHelpfulNeurons(
     existingNeuronIds.add(newNeuronId);
     addedNeuronIds.push(newNeuronId);
     appliedCandidates.push(candidate);
+
+    // Rebuild UUID-to-index map after insertion so subsequent candidates
+    // see correct indices (Issue #2152).
+    if (isForwardOnly) {
+      const inputCount = exportJSON.input ?? 0;
+      uuidToIndexMap.clear();
+      for (let i = 0; i < inputCount; i++) {
+        uuidToIndexMap.set(`input-${i}`, i);
+      }
+      for (let i = 0; i < exportJSON.neurons.length; i++) {
+        const uuid = exportJSON.neurons[i].uuid;
+        if (uuid) {
+          uuidToIndexMap.set(uuid, inputCount + i);
+        }
+      }
+    }
+
+    // Post-insertion forward-only verification: confirm the new neuron sits
+    // between its incoming source and outgoing target (Issue #2152).
+    if (isForwardOnly) {
+      const fromIdx = uuidToIndexMap.get(candidate.fromNeuronUuid);
+      const newIdx = uuidToIndexMap.get(newNeuronUuid);
+      const toIdx = uuidToIndexMap.get(candidate.toNeuronUuid);
+      if (
+        fromIdx === undefined || newIdx === undefined ||
+        toIdx === undefined || fromIdx >= newIdx || newIdx >= toIdx
+      ) {
+        getLogger().warn(
+          `[Discovery ${ID}] addHelpfulNeurons: Removing inserted neuron ${newNeuronUuid}: position violates forward-only (from=${fromIdx}, new=${newIdx}, to=${toIdx})`,
+        );
+        // Remove the incorrectly positioned neuron
+        const removeIdx = exportJSON.neurons.findIndex((n) =>
+          n.uuid === newNeuronUuid
+        );
+        if (removeIdx >= 0) {
+          exportJSON.neurons.splice(removeIdx, 1);
+        }
+        addedNeuronIds.pop();
+        appliedCandidates.pop();
+        return;
+      }
+    }
 
     const incomingSynapse = {
       fromUUID: candidate.fromNeuronUuid,

--- a/test/ErrorGuidedStructuralEvolution/ForwardOnlyNeuronAdditionGuard.ts
+++ b/test/ErrorGuidedStructuralEvolution/ForwardOnlyNeuronAdditionGuard.ts
@@ -1,0 +1,225 @@
+/**
+ * Verifies that addHelpfulNeurons() enforces forward-only synapse constraints
+ * when adding new neurons to forward-only creatures (Issue #2152).
+ */
+import { assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import type { CandidateNeuron } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts";
+import { addHelpfulNeurons } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronAddition.ts";
+import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
+
+/**
+ * Build a minimal forward-only creature:
+ *   input-0 (idx 0)
+ *   input-1 (idx 1)
+ *   hidden-1 (idx 2)
+ *   hidden-2 (idx 3)
+ *   output-0 (idx 4)
+ *
+ * Synapses: input-0 -> hidden-1, hidden-1 -> hidden-2, hidden-2 -> output-0
+ */
+function makeForwardOnlyCreature(): Creature {
+  const json: Parameters<typeof normaliseCreatureExport>[0] = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "hidden-2", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "hidden-2", weight: 0.3 },
+      { fromUUID: "hidden-2", toUUID: "output-0", weight: 0.4 },
+    ],
+  } as Parameters<typeof normaliseCreatureExport>[0];
+  normaliseCreatureExport(json);
+  const creature = Creature.fromJSON(
+    json as Parameters<typeof Creature.fromJSON>[0],
+  );
+  creature.validate({ forwardOnly: true });
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+function makeCandidateNeuron(
+  fromUuid: string,
+  toUuid: string,
+  squash = "IDENTITY",
+): CandidateNeuron {
+  return {
+    fromNeuronUuid: fromUuid,
+    toNeuronUuid: toUuid,
+    incomingWeight: 0.5,
+    outgoingWeight: 0.3,
+    squash,
+    bias: 0,
+    targetNeuronImpact: 1.0,
+    expectedCreatureErrorReduction: 0,
+    expectedCreatureScoreGain: 0.2,
+    improvedCount: 5,
+    totalCount: 10,
+  };
+}
+
+Deno.test(
+  "addHelpfulNeurons: valid forward neuron addition in forward-only creature produces no backward synapses",
+  () => {
+    const creature = makeForwardOnlyCreature();
+
+    // Add a neuron between input-0 and hidden-2 (forward direction)
+    const candidate = makeCandidateNeuron("input-0", "hidden-2");
+    const result = addHelpfulNeurons("TEST-FORWARD", creature, [candidate]);
+
+    if (result) {
+      const exported = result.exportJSON();
+      assertEquals(
+        exported.forwardOnly,
+        true,
+        "Result should still be forward-only",
+      );
+
+      // Verify no backward synapses exist
+      const inputCount = exported.input ?? 0;
+      const uuidToIndex = new Map<string, number>();
+      for (let i = 0; i < inputCount; i++) {
+        uuidToIndex.set(`input-${i}`, i);
+      }
+      for (let i = 0; i < exported.neurons.length; i++) {
+        const uuid = exported.neurons[i].uuid;
+        if (uuid) uuidToIndex.set(uuid, inputCount + i);
+      }
+
+      for (const synapse of exported.synapses) {
+        const fromIdx = uuidToIndex.get(synapse.fromUUID!);
+        const toIdx = uuidToIndex.get(synapse.toUUID!);
+        if (fromIdx !== undefined && toIdx !== undefined) {
+          assertEquals(
+            fromIdx < toIdx,
+            true,
+            `Synapse ${synapse.fromUUID} -> ${synapse.toUUID} violates forward-only (fromIdx=${fromIdx}, toIdx=${toIdx})`,
+          );
+        }
+      }
+    }
+  },
+);
+
+Deno.test(
+  "addHelpfulNeurons: backward candidate is rejected for forward-only creature",
+  () => {
+    const creature = makeForwardOnlyCreature();
+
+    // Attempt to add a neuron from hidden-2 to hidden-1 (backward direction)
+    const backward = makeCandidateNeuron("hidden-2", "hidden-1");
+    const result = addHelpfulNeurons("TEST-BACKWARD", creature, [backward]);
+
+    assertEquals(
+      result,
+      undefined,
+      "Backward neuron addition should be rejected for forward-only creature",
+    );
+  },
+);
+
+Deno.test(
+  "addHelpfulNeurons: neuron addition with output target in forward-only creature creates no backward synapses",
+  () => {
+    const creature = makeForwardOnlyCreature();
+
+    // Add a neuron between hidden-1 and output-0 (forward direction)
+    const candidate = makeCandidateNeuron("hidden-1", "output-0");
+    const result = addHelpfulNeurons("TEST-OUTPUT", creature, [candidate]);
+
+    if (result) {
+      const exported = result.exportJSON();
+
+      // Verify no backward synapses
+      const inputCount = exported.input ?? 0;
+      const uuidToIndex = new Map<string, number>();
+      for (let i = 0; i < inputCount; i++) {
+        uuidToIndex.set(`input-${i}`, i);
+      }
+      for (let i = 0; i < exported.neurons.length; i++) {
+        const uuid = exported.neurons[i].uuid;
+        if (uuid) uuidToIndex.set(uuid, inputCount + i);
+      }
+
+      for (const synapse of exported.synapses) {
+        const fromIdx = uuidToIndex.get(synapse.fromUUID!);
+        const toIdx = uuidToIndex.get(synapse.toUUID!);
+        if (fromIdx !== undefined && toIdx !== undefined) {
+          assertEquals(
+            fromIdx < toIdx,
+            true,
+            `Synapse ${synapse.fromUUID} -> ${synapse.toUUID} violates forward-only (fromIdx=${fromIdx}, toIdx=${toIdx})`,
+          );
+        }
+      }
+    }
+  },
+);
+
+Deno.test(
+  "addHelpfulNeurons: mixed candidates filtered correctly for forward-only creature",
+  () => {
+    const creature = makeForwardOnlyCreature();
+
+    const candidates: CandidateNeuron[] = [
+      // Valid forward: input-1 -> hidden-2
+      makeCandidateNeuron("input-1", "hidden-2"),
+      // Invalid backward: output-0 -> hidden-1
+      makeCandidateNeuron("output-0", "hidden-1"),
+      // Invalid: hidden-2 -> hidden-1 (backward)
+      makeCandidateNeuron("hidden-2", "hidden-1"),
+    ];
+
+    const result = addHelpfulNeurons("TEST-MIXED", creature, candidates);
+
+    if (result) {
+      const exported = result.exportJSON();
+
+      // Verify all synapses are forward
+      const inputCount = exported.input ?? 0;
+      const uuidToIndex = new Map<string, number>();
+      for (let i = 0; i < inputCount; i++) {
+        uuidToIndex.set(`input-${i}`, i);
+      }
+      for (let i = 0; i < exported.neurons.length; i++) {
+        const uuid = exported.neurons[i].uuid;
+        if (uuid) uuidToIndex.set(uuid, inputCount + i);
+      }
+
+      for (const synapse of exported.synapses) {
+        const fromIdx = uuidToIndex.get(synapse.fromUUID!);
+        const toIdx = uuidToIndex.get(synapse.toUUID!);
+        if (fromIdx !== undefined && toIdx !== undefined) {
+          assertEquals(
+            fromIdx < toIdx,
+            true,
+            `Synapse ${synapse.fromUUID} -> ${synapse.toUUID} violates forward-only`,
+          );
+        }
+      }
+    }
+  },
+);
+
+Deno.test(
+  "addHelpfulNeurons: self-referencing neuron candidate rejected for forward-only creature",
+  () => {
+    const creature = makeForwardOnlyCreature();
+
+    // Self-reference: hidden-1 -> hidden-1
+    const selfRef = makeCandidateNeuron("hidden-1", "hidden-1");
+    const result = addHelpfulNeurons("TEST-SELF", creature, [selfRef]);
+
+    assertEquals(
+      result,
+      undefined,
+      "Self-referencing neuron candidate should be rejected for forward-only creature",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Add forward-only synapse guard to `addHelpfulNeurons()` in
`DiscoveryNeuronAddition.ts` to prevent backward connections when inserting new
neurons into forward-only creatures. This is the same class of issue as #2150 —
discovery operations that add synapses without forward-only guards, leading to
recurrent synapses being stripped during `loadFrom()`. Closes #2152.

## Changes

- **`src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronAddition.ts`**:
  - Built a UUID-to-index map (same pattern as `DiscoverySynapseOps.ts`) for
    forward-only creatures
  - Added pre-insertion forward-only guard that rejects candidates where the
    source neuron index >= target neuron index using UUID-based resolution
    (avoids runtime ID mis-resolution)
  - Added post-insertion verification ensuring the new neuron sits between its
    incoming source and outgoing target indices
  - Rebuilt the UUID-to-index map after each neuron insertion so subsequent
    candidates see correct indices
  - Added diagnostic logging and `recordDiscoveryIssue` calls for rejected
    candidates

## Evidence

Before the fix, the mixed-candidate test showed `loadFrom()` stripping a
backward synapse at load time:

```
🚨 [loadFrom] Stripping recurrent synapse 6->2 (fromUUID=output-0, toUUID=...) from forward-only creature
```

After the fix, the backward candidate is rejected at the source with a clear
diagnostic:

```
[Discovery TEST-MIXED] addHelpfulNeurons: Skipping candidate output-0 -> hidden-1: violates forward-only constraint (fromIdx=5, toIdx=2)
```

## Test Plan

- Added `test/ErrorGuidedStructuralEvolution/ForwardOnlyNeuronAdditionGuard.ts`
  with 5 tests:
  - Valid forward neuron addition produces no backward synapses
  - Backward candidate (hidden-2 -> hidden-1) is rejected
  - Neuron addition with output target maintains forward-only
  - Mixed candidates filtered correctly (only forward ones kept)
  - Self-referencing candidate (hidden-1 -> hidden-1) is rejected
- All 5239 existing tests pass with no regressions

---

## Automated Fix Details
This PR addresses issue #2152: **Add forward-only synapse guard to DiscoveryNeuronAddition**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2152
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2152 -->