### PR TITLE
Exclude discovery/training-busy workers from fitness evaluation (#2162)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2162.md
+++ b/docs/pr-summary-2162.md
@@ -1,0 +1,35 @@
+## Summary
+
+Exclude workers running long-running tasks (discovery/training) from the fitness
+evaluation pool in `Fitness.calculate()`. When a worker has an active long task,
+`Promise.all` would stall waiting for it while other workers sat idle. Now only
+available workers participate, and work-stealing distributes all creatures among
+them. If all workers are busy, falls back to using all workers to avoid deadlock.
+
+Closes #2162
+
+## Changes
+
+- **`src/architecture/Fitness.ts`**: Filter `activeWorkers` via
+  `isRunningLongTask()` before `Promise.all`. Guard ensures at least one worker
+  always participates. Debug logging when workers are excluded.
+- **`test/architecture/FitnessExcludeBusyWorkers.ts`**: New test suite with 5
+  tests covering: busy worker exclusion, all-busy fallback, normal operation,
+  and single-worker configurations.
+- **Existing test mocks updated**: Added `isRunningLongTask()` to mock workers
+  in `FitnessTopologyGrouping.ts`, `FitnessTypedErrors.ts`,
+  `BatchCreatureEvaluation.ts`, `ParallelFitnessEvaluation.ts`,
+  `FitnessDeduplication.ts`, and `FitnessQueueDequeue.ts`.
+
+## Evidence
+
+All 5279 tests pass, including the 5 new tests for this feature.
+
+## Test Plan
+
+- `test/architecture/FitnessExcludeBusyWorkers.ts`:
+  - Workers with active long tasks are excluded from evaluation
+  - Falls back to all workers when every worker is busy (no deadlock)
+  - All workers used normally when none are running long tasks
+  - Single busy worker still evaluates (fallback)
+  - Single available worker evaluates normally

--- a/docs/pr-summary-2162.md
+++ b/docs/pr-summary-2162.md
@@ -4,7 +4,8 @@ Exclude workers running long-running tasks (discovery/training) from the fitness
 evaluation pool in `Fitness.calculate()`. When a worker has an active long task,
 `Promise.all` would stall waiting for it while other workers sat idle. Now only
 available workers participate, and work-stealing distributes all creatures among
-them. If all workers are busy, falls back to using all workers to avoid deadlock.
+them. If all workers are busy, falls back to using all workers to avoid
+deadlock.
 
 Closes #2162
 

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -8,6 +8,7 @@ import { ValidationError } from "@errors/ValidationError.ts";
 import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { calculate as calculateScore } from "@architecture/Score.ts";
+import { getLogger } from "@utils/Logger.ts";
 
 /**
  * Evaluates fitness scores for a population of creatures.
@@ -104,9 +105,34 @@ export class Fitness {
 
     // Issue #1862: Cap the number of concurrent workers if configured.
     const maxConcurrent = this.evalConfig.maxConcurrentEvaluations;
-    const activeWorkers = maxConcurrent > 0
+    const cappedWorkers = maxConcurrent > 0
       ? this.workers.slice(0, maxConcurrent)
       : this.workers;
+
+    // Issue #2162: Exclude workers running long tasks (discovery/training)
+    // so that Promise.all does not stall waiting for them.
+    const availableWorkers = cappedWorkers.filter(
+      (w) => !w.isRunningLongTask(),
+    );
+
+    // Guard: if ALL workers are busy, fall back to using all of them
+    // to avoid deadlock — at least one worker must evaluate.
+    const activeWorkers = availableWorkers.length > 0
+      ? availableWorkers
+      : cappedWorkers;
+
+    if (availableWorkers.length < cappedWorkers.length) {
+      const excluded = cappedWorkers.length - activeWorkers.length;
+      if (excluded > 0) {
+        getLogger().debug(
+          `Fitness: excluded ${excluded} worker(s) running long tasks`,
+        );
+      } else {
+        getLogger().debug(
+          "Fitness: all workers running long tasks, using all as fallback",
+        );
+      }
+    }
 
     const processNext = async (worker: WorkerHandler): Promise<void> => {
       if (front >= queue.length) return;

--- a/test/NEAT/FitnessDeduplication.ts
+++ b/test/NEAT/FitnessDeduplication.ts
@@ -30,6 +30,10 @@ class MockWorkerHandler {
     return this.busy;
   }
 
+  isRunningLongTask(): boolean {
+    return false;
+  }
+
   async evaluate(
     creature: Creature,
     _feedbackLoop: boolean,

--- a/test/NEAT/FitnessQueueDequeue.ts
+++ b/test/NEAT/FitnessQueueDequeue.ts
@@ -21,6 +21,10 @@ import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 class MockQueueWorker {
   public evaluatedUUIDs: string[] = [];
 
+  isRunningLongTask(): boolean {
+    return false;
+  }
+
   async evaluate(
     creature: Creature,
     _feedbackLoop: boolean,

--- a/test/architecture/BatchCreatureEvaluation.ts
+++ b/test/architecture/BatchCreatureEvaluation.ts
@@ -33,6 +33,10 @@ class MockWorkerHandler {
     return this.busyCount > 0;
   }
 
+  isRunningLongTask(): boolean {
+    return false;
+  }
+
   addIdleListener(_callback: (worker: MockWorkerHandler) => void): void {
     // Not used in these tests
   }

--- a/test/architecture/FitnessExcludeBusyWorkers.ts
+++ b/test/architecture/FitnessExcludeBusyWorkers.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for excluding discovery/training-busy workers from fitness evaluation.
+ *
+ * Issue #2162: Workers running long-running tasks (discovery or training)
+ * should be excluded from the active evaluation pool so that
+ * Promise.all does not stall waiting for them.
+ *
+ * Verifies:
+ * - Workers with active long tasks are excluded from evaluation
+ * - Fallback to all workers when every worker is busy (no deadlock)
+ * - Normal operation when no workers have long tasks
+ * - Single-worker configurations still work correctly
+ */
+import { assertEquals, assertGreater } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Fitness } from "@architecture/Fitness.ts";
+import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/**
+ * Mock worker that tracks evaluations and supports isRunningLongTask().
+ */
+class MockWorker {
+  public evaluationCount = 0;
+  public runningLongTask = false;
+
+  isRunningLongTask(): boolean {
+    return this.runningLongTask;
+  }
+
+  async evaluate(
+    _creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<{ evaluate: { error: number } }> {
+    this.evaluationCount++;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    return { evaluate: { error: 0.05 } };
+  }
+}
+
+/** Create a simple creature for testing. */
+function makeCreature(bias: number): Creature {
+  const data: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: `hidden-${bias}`, squash: "TANH", bias },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: `hidden-${bias}`, weight: 0.5 },
+      { fromUUID: `hidden-${bias}`, toUUID: "output-0", weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+  };
+  return Creature.fromJSON(data);
+}
+
+Deno.test("Fitness excludes workers running long tasks from evaluation", async () => {
+  const availableWorker = new MockWorker();
+  const busyWorker = new MockWorker();
+  busyWorker.runningLongTask = true;
+
+  const fitness = new Fitness(
+    [availableWorker, busyWorker] as unknown[] as WorkerHandler[],
+    0.0001,
+    false,
+  );
+
+  const population = [makeCreature(0.1), makeCreature(0.2), makeCreature(0.3)];
+
+  await fitness.calculate(population);
+
+  // The available worker should have handled all evaluations
+  assertGreater(
+    availableWorker.evaluationCount,
+    0,
+    "Available worker should have evaluated creatures",
+  );
+  assertEquals(
+    busyWorker.evaluationCount,
+    0,
+    "Busy worker should not have evaluated any creatures",
+  );
+});
+
+Deno.test("Fitness falls back to all workers when all are running long tasks", async () => {
+  const worker1 = new MockWorker();
+  const worker2 = new MockWorker();
+  worker1.runningLongTask = true;
+  worker2.runningLongTask = true;
+
+  const fitness = new Fitness(
+    [worker1, worker2] as unknown[] as WorkerHandler[],
+    0.0001,
+    false,
+  );
+
+  const population = [makeCreature(0.1), makeCreature(0.2)];
+
+  await fitness.calculate(population);
+
+  // Both workers should have participated (fallback — no deadlock)
+  const totalEvaluations = worker1.evaluationCount + worker2.evaluationCount;
+  assertEquals(
+    totalEvaluations,
+    2,
+    "All creatures should be evaluated even when all workers are busy",
+  );
+});
+
+Deno.test("Fitness uses all workers normally when none are running long tasks", async () => {
+  const worker1 = new MockWorker();
+  const worker2 = new MockWorker();
+
+  const fitness = new Fitness(
+    [worker1, worker2] as unknown[] as WorkerHandler[],
+    0.0001,
+    false,
+  );
+
+  const population = [
+    makeCreature(0.1),
+    makeCreature(0.2),
+    makeCreature(0.3),
+    makeCreature(0.4),
+  ];
+
+  await fitness.calculate(population);
+
+  const totalEvaluations = worker1.evaluationCount + worker2.evaluationCount;
+  assertEquals(
+    totalEvaluations,
+    4,
+    "All creatures should be evaluated across both workers",
+  );
+  // Both workers should have participated via work-stealing
+  assertGreater(
+    worker1.evaluationCount,
+    0,
+    "Worker 1 should have evaluated some creatures",
+  );
+  assertGreater(
+    worker2.evaluationCount,
+    0,
+    "Worker 2 should have evaluated some creatures",
+  );
+});
+
+Deno.test("Fitness works with single worker running long task (fallback)", async () => {
+  const worker = new MockWorker();
+  worker.runningLongTask = true;
+
+  const fitness = new Fitness(
+    [worker] as unknown[] as WorkerHandler[],
+    0.0001,
+    false,
+  );
+
+  const population = [makeCreature(0.1), makeCreature(0.2)];
+
+  await fitness.calculate(population);
+
+  assertEquals(
+    worker.evaluationCount,
+    2,
+    "Single busy worker should still evaluate all creatures (fallback)",
+  );
+});
+
+Deno.test("Fitness works with single worker not running long task", async () => {
+  const worker = new MockWorker();
+
+  const fitness = new Fitness(
+    [worker] as unknown[] as WorkerHandler[],
+    0.0001,
+    false,
+  );
+
+  const population = [makeCreature(0.1), makeCreature(0.2)];
+
+  await fitness.calculate(population);
+
+  assertEquals(
+    worker.evaluationCount,
+    2,
+    "Single available worker should evaluate all creatures",
+  );
+});

--- a/test/architecture/FitnessTopologyGrouping.ts
+++ b/test/architecture/FitnessTopologyGrouping.ts
@@ -29,6 +29,10 @@ class OrderTrackingWorker {
     return false;
   }
 
+  isRunningLongTask(): boolean {
+    return false;
+  }
+
   async evaluate(
     creature: Creature,
     _feedbackLoop: boolean,

--- a/test/architecture/FitnessTypedErrors.ts
+++ b/test/architecture/FitnessTypedErrors.ts
@@ -16,6 +16,7 @@ Deno.test("Fitness calculate - throws ValidationError for invalid worker respons
   // Create a mock worker that returns an invalid response
   const mockWorker = {
     evaluate: () => Promise.resolve({ evaluate: undefined }),
+    isRunningLongTask: () => false,
   };
 
   const fitness = new Fitness(

--- a/test/architecture/ParallelFitnessEvaluation.ts
+++ b/test/architecture/ParallelFitnessEvaluation.ts
@@ -37,6 +37,10 @@ class MockWorkerHandler {
     return this.busyCount > 0;
   }
 
+  isRunningLongTask(): boolean {
+    return false;
+  }
+
   async evaluate(
     creature: Creature,
     _feedbackLoop: boolean,


### PR DESCRIPTION
## Summary

Exclude workers running long-running tasks (discovery/training) from the fitness
evaluation pool in `Fitness.calculate()`. When a worker has an active long task,
`Promise.all` would stall waiting for it while other workers sat idle. Now only
available workers participate, and work-stealing distributes all creatures among
them. If all workers are busy, falls back to using all workers to avoid
deadlock.

Closes #2162

## Changes

- **`src/architecture/Fitness.ts`**: Filter `activeWorkers` via
  `isRunningLongTask()` before `Promise.all`. Guard ensures at least one worker
  always participates. Debug logging when workers are excluded.
- **`test/architecture/FitnessExcludeBusyWorkers.ts`**: New test suite with 5
  tests covering: busy worker exclusion, all-busy fallback, normal operation,
  and single-worker configurations.
- **Existing test mocks updated**: Added `isRunningLongTask()` to mock workers
  in `FitnessTopologyGrouping.ts`, `FitnessTypedErrors.ts`,
  `BatchCreatureEvaluation.ts`, `ParallelFitnessEvaluation.ts`,
  `FitnessDeduplication.ts`, and `FitnessQueueDequeue.ts`.

## Evidence

All 5279 tests pass, including the 5 new tests for this feature.

## Test Plan

- `test/architecture/FitnessExcludeBusyWorkers.ts`:
  - Workers with active long tasks are excluded from evaluation
  - Falls back to all workers when every worker is busy (no deadlock)
  - All workers used normally when none are running long tasks
  - Single busy worker still evaluates (fallback)
  - Single available worker evaluates normally

---

## Automated Fix Details
This PR addresses issue #2162: **Exclude discovery/training-busy workers from fitness evaluation (#2159)**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2162
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2162 -->