### PR TITLE
Update version to 2.9.0 and enhance CRISPR error logging

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.8.15",
+  "version": "2.9.0",
   "publish": {
     "include": [
       "README.md",

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -237,7 +237,7 @@ export async function evolve(
       } catch (error) {
         if (error instanceof CrisprError) {
           getLogger().warn(
-            `Skipping invalid CRISPR '${dna.id}': ${error.message}`,
+            `Skipping invalid CRISPR '${dna.id}' (${error.code}): ${error.message}`,
           );
           continue;
         }

--- a/src/reconstruct/CRISPR.ts
+++ b/src/reconstruct/CRISPR.ts
@@ -8,6 +8,24 @@ import { TopologyError } from "@errors/TopologyError.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { validateDNA } from "@reconstruct/validateDNA.ts";
 
+function formatCrisprDnaIdForLog(dna: unknown): string {
+  if (dna !== null && typeof dna === "object" && "id" in dna) {
+    const id = (dna as Record<string, unknown>).id;
+    if (typeof id === "string" && id.trim().length > 0) return id;
+  }
+  return "<missing-or-invalid id>";
+}
+
+function warnSkippedCrisprDNA(
+  dna: unknown,
+  code: string,
+  message: string,
+): void {
+  getLogger().warn(
+    `CRISPR '${formatCrisprDnaIdForLog(dna)}' skipped (${code}): ${message}`,
+  );
+}
+
 /**
  * Interface representing the structure of the CRISPR modification data.
  */
@@ -563,7 +581,15 @@ export class CRISPR {
    * @returns The modified creature or undefined if no modifications were applied.
    */
   cleaveDNA(dna: CrisprInterface): Creature {
-    validateDNA(dna);
+    try {
+      validateDNA(dna);
+    } catch (e) {
+      if (e instanceof CrisprError) {
+        warnSkippedCrisprDNA(dna, e.code, e.message);
+        return this.creature;
+      }
+      throw e;
+    }
 
     let alreadyProcessed = false;
 
@@ -607,11 +633,11 @@ export class CRISPR {
       }
     } catch (e) {
       if (e instanceof CrisprError) {
-        getLogger().warn(`CRISPR ${dna.id}: ${e.code} — ${e.message}`);
+        warnSkippedCrisprDNA(dna, e.code, e.message);
         return this.creature;
       }
       if (e instanceof TopologyError && e.reason === "INVALID_CONNECTION") {
-        getLogger().warn(`CRISPR ${dna.id}: INVALID_CONNECTION — ${e.message}`);
+        warnSkippedCrisprDNA(dna, "INVALID_CONNECTION", e.message);
         return this.creature;
       }
       throw e;
@@ -633,10 +659,7 @@ export class CRISPR {
       }
     } catch (e) {
       if (e instanceof CrisprError) {
-        // Expected operational errors — log and return the original creature.
-        getLogger().warn(
-          `CRISPR ${dna.id}: ${e.code} — ${e.message}`,
-        );
+        warnSkippedCrisprDNA(dna, e.code, e.message);
         return this.creature;
       }
 
@@ -649,7 +672,7 @@ export class CRISPR {
         1,
       );
       getLogger().warn(
-        `CRISPR ${dna.id}: unexpected error during validation.\n` +
+        `CRISPR '${dna.id}' skipped: unexpected error during validation.\n` +
           `Creature JSON:\n${creatureJSON}`,
         e,
       );

--- a/src/reconstruct/validateDNA.ts
+++ b/src/reconstruct/validateDNA.ts
@@ -74,7 +74,9 @@ function validateNeuron(
 ): void {
   if (neuron === null || typeof neuron !== "object") {
     throw new CrisprError(
-      `Neuron at index ${index} must be a non-null object`,
+      `Neuron at index ${index} must be a non-null object — neuron: ${
+        JSON.stringify(neuron)
+      }`,
       "INVALID_DNA",
     );
   }
@@ -85,28 +87,34 @@ function validateNeuron(
     throw new CrisprError(
       `Neuron at index ${index}: 'type' must be "output" or "hidden", got: ${
         JSON.stringify(n.type)
-      }`,
+      } — neuron: ${JSON.stringify(n)}`,
       "INVALID_DNA",
     );
   }
 
   if (mode === "insert" && n.type === "output") {
     throw new CrisprError(
-      `Neuron at index ${index}: insert-mode DNA must not contain output neurons`,
+      `Neuron at index ${index}: insert-mode DNA must not contain output neurons — neuron: ${
+        JSON.stringify(n)
+      }`,
       "INVALID_DNA",
     );
   }
 
   if (typeof n.squash !== "string" || n.squash.trim().length === 0) {
     throw new CrisprError(
-      `Neuron at index ${index}: 'squash' must be a non-empty string`,
+      `Neuron at index ${index}: 'squash' must be a non-empty string — neuron: ${
+        JSON.stringify(n)
+      }`,
       "INVALID_DNA",
     );
   }
 
   if (typeof n.bias !== "number" || !Number.isFinite(n.bias)) {
     throw new CrisprError(
-      `Neuron at index ${index}: 'bias' must be a finite number`,
+      `Neuron at index ${index}: 'bias' must be a finite number — neuron: ${
+        JSON.stringify(n)
+      }`,
       "INVALID_DNA",
     );
   }
@@ -119,7 +127,9 @@ function validateSynapse(
 ): void {
   if (synapse === null || typeof synapse !== "object") {
     throw new CrisprError(
-      `Synapse at index ${index} must be a non-null object`,
+      `Synapse at index ${index} must be a non-null object — synapse: ${
+        JSON.stringify(synapse)
+      }`,
       "INVALID_DNA",
     );
   }
@@ -128,7 +138,9 @@ function validateSynapse(
 
   if (typeof s.weight !== "number" || !Number.isFinite(s.weight)) {
     throw new CrisprError(
-      `Synapse at index ${index}: 'weight' must be a finite number`,
+      `Synapse at index ${index}: 'weight' must be a finite number — synapse: ${
+        JSON.stringify(s)
+      }`,
       "INVALID_DNA",
     );
   }
@@ -136,25 +148,33 @@ function validateSynapse(
   if (mode === "insert") {
     if (s.from !== undefined) {
       throw new CrisprError(
-        `Synapse at index ${index}: insert-mode DNA must not use 'from' (static index); use 'fromId' instead`,
+        `Synapse at index ${index}: insert-mode DNA must not use 'from' (static index); use 'fromId' instead — synapse: ${
+          JSON.stringify(s)
+        }`,
         "INVALID_DNA",
       );
     }
     if (s.to !== undefined) {
       throw new CrisprError(
-        `Synapse at index ${index}: insert-mode DNA must not use 'to' (static index); use 'toId' instead`,
+        `Synapse at index ${index}: insert-mode DNA must not use 'to' (static index); use 'toId' instead — synapse: ${
+          JSON.stringify(s)
+        }`,
         "INVALID_DNA",
       );
     }
     if (s.fromRelative !== undefined) {
       throw new CrisprError(
-        `Synapse at index ${index}: insert-mode DNA must not use 'fromRelative'; use 'fromId' instead`,
+        `Synapse at index ${index}: insert-mode DNA must not use 'fromRelative'; use 'fromId' instead — synapse: ${
+          JSON.stringify(s)
+        }`,
         "INVALID_DNA",
       );
     }
     if (s.toRelative !== undefined) {
       throw new CrisprError(
-        `Synapse at index ${index}: insert-mode DNA must not use 'toRelative'; use 'toId' instead`,
+        `Synapse at index ${index}: insert-mode DNA must not use 'toRelative'; use 'toId' instead — synapse: ${
+          JSON.stringify(s)
+        }`,
         "INVALID_DNA",
       );
     }
@@ -164,7 +184,9 @@ function validateSynapse(
       s.fromRelative !== undefined;
     if (!hasSource) {
       throw new CrisprError(
-        `Synapse at index ${index}: append-mode synapse must have at least one source reference ('from', 'fromId', or 'fromRelative')`,
+        `Synapse at index ${index}: append-mode synapse must have at least one source reference ('from', 'fromId', or 'fromRelative') — synapse: ${
+          JSON.stringify(s)
+        }`,
         "INVALID_DNA",
       );
     }
@@ -173,7 +195,9 @@ function validateSynapse(
       s.toRelative !== undefined;
     if (!hasTarget) {
       throw new CrisprError(
-        `Synapse at index ${index}: append-mode synapse must have at least one target reference ('to', 'toId', or 'toRelative')`,
+        `Synapse at index ${index}: append-mode synapse must have at least one target reference ('to', 'toId', or 'toRelative') — synapse: ${
+          JSON.stringify(s)
+        }`,
         "INVALID_DNA",
       );
     }

--- a/test/CRISPR/CRISPRUntestedPaths.ts
+++ b/test/CRISPR/CRISPRUntestedPaths.ts
@@ -8,7 +8,6 @@ import {
   assertEquals,
   assertExists,
   assertNotEquals,
-  assertThrows,
 } from "@std/assert";
 import { addTag, getTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
@@ -192,7 +191,7 @@ Deno.test(
 // ---------------------------------------------------------------------------
 
 Deno.test(
-  "cleaveDNA - insert with output neurons throws validation error",
+  "cleaveDNA - insert with output neurons skips invalid DNA (warn, return original)",
   () => {
     const h1Id = getH1Id();
     const creature = makeCreature();
@@ -209,13 +208,11 @@ Deno.test(
       ],
     };
 
-    // validateDNA rejects insert-mode DNA containing output neurons with a
-    // clear error message before insert() is ever called.
-    assertThrows(
-      () => crispr.cleaveDNA(dna),
-      Error,
-      "insert-mode DNA must not contain output neurons",
-    );
+    // validateDNA rejects insert-mode DNA containing output neurons before
+    // insert(); cleaveDNA logs and returns the unmodified clone (#2167).
+    const result = crispr.cleaveDNA(dna);
+    assertEquals(result.input, creature.input);
+    assertEquals(result.output, creature.output);
   },
 );
 


### PR DESCRIPTION
- Bump package version in deno.json to 2.9.0.
- Improve error logging in CRISPR class by introducing helper functions to format and log warnings for skipped CRISPR DNA, including error codes.
- Update validation error messages in validateDNA.ts to include more context about the invalid neuron and synapse structures.
- Modify tests to reflect changes in error handling, ensuring that invalid DNA is logged and the original creature is returned instead of throwing an error.