### PR TITLE
Improve neuron alignment in inter-species breeding using input-weight similarity

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2174.md
+++ b/docs/pr-summary-2174.md
@@ -1,0 +1,45 @@
+## Summary
+
+Improved neuron alignment in inter-species breeding by replacing the sequential
+positional mapping in `editParentByIndex` with input-weight cosine
+similarity-based alignment. Closes #2174.
+
+When breeding creatures from different islands, UUID matching and connectivity
+key matching both fail completely due to different neuron ID formats and
+drastically different topologies. Previously, the sequential fallback in
+`editParentByIndex` mapped father neurons to mother neurons by array position,
+which has no semantic meaning.
+
+Now, unmatched hidden neurons are compared by their incoming weight vectors from
+shared input neurons using cosine similarity. A greedy best-match algorithm
+picks the highest-similarity pairs first, ensuring neurons with similar
+functional roles are aligned. Neurons without meaningful input connections
+(e.g., deep hidden neurons) fall back to the original sequential mapping.
+
+### New files
+- `src/breed/NeuronAlignment.ts` — input-weight vector construction, cosine
+  similarity computation, and greedy similarity-based alignment algorithm
+- `test/breed/NeuronAlignment.ts` — 14 tests covering unit and integration
+  scenarios
+
+### Modified files
+- `src/breed/EditParentByIndex.ts` — integrated similarity-based alignment
+  before the sequential fallback
+
+## Evidence
+
+All 5300 existing tests pass, confirming no regressions. The new tests
+specifically verify that:
+- Neurons with reversed functional order are correctly aligned by similarity
+  (not sequential position)
+- Asymmetric creature sizes are handled correctly
+- Deep neurons without input connections fall back gracefully
+
+## Test Plan
+
+- `test/breed/NeuronAlignment.ts` — 14 new tests:
+  - 3 unit tests for `buildInputWeightVector`
+  - 5 unit tests for `cosineSimilarity`
+  - 3 unit tests for `computeSimilarityAlignment`
+  - 3 integration tests for `editParentByIndex` with similarity alignment
+- `test/breed/EditParentByIndex.ts` — all 11 existing tests continue to pass

--- a/docs/pr-summary-2174.md
+++ b/docs/pr-summary-2174.md
@@ -17,12 +17,14 @@ functional roles are aligned. Neurons without meaningful input connections
 (e.g., deep hidden neurons) fall back to the original sequential mapping.
 
 ### New files
+
 - `src/breed/NeuronAlignment.ts` — input-weight vector construction, cosine
   similarity computation, and greedy similarity-based alignment algorithm
 - `test/breed/NeuronAlignment.ts` — 14 tests covering unit and integration
   scenarios
 
 ### Modified files
+
 - `src/breed/EditParentByIndex.ts` — integrated similarity-based alignment
   before the sequential fallback
 
@@ -30,6 +32,7 @@ functional roles are aligned. Neurons without meaningful input connections
 
 All 5300 existing tests pass, confirming no regressions. The new tests
 specifically verify that:
+
 - Neurons with reversed functional order are correctly aligned by similarity
   (not sequential position)
 - Asymmetric creature sizes are handled correctly

--- a/src/breed/EditParentByIndex.ts
+++ b/src/breed/EditParentByIndex.ts
@@ -1,7 +1,21 @@
 import { addTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
 import { ValidationError } from "@errors/ValidationError.ts";
+import { computeSimilarityAlignment } from "@breed/NeuronAlignment.ts";
 
+/**
+ * Edits a target creature's hidden neuron UUIDs to align with a parent creature,
+ * using input-weight cosine similarity to find functionally similar neurons.
+ *
+ * Issue #2174: Replaced sequential positional mapping with similarity-based
+ * alignment. Neurons are matched by comparing their incoming weight vectors
+ * from shared input neurons, so neurons with similar functional roles are
+ * aligned even across different island topologies.
+ *
+ * Falls back to sequential mapping for neurons that have no meaningful
+ * input connections (e.g., deep hidden neurons with only hidden-to-hidden
+ * connections).
+ */
 export function editParentByIndex(
   parent: Creature,
   target: Creature,
@@ -16,14 +30,26 @@ export function editParentByIndex(
     }
   });
 
-  let parentIndx = 0;
-
   const parentNeuronSet = new Set<string>();
   parentExport.neurons.forEach((n) => {
     if (n.type === "hidden" && typeof n.uuid === "string") {
       parentNeuronSet.add(n.uuid);
     }
   });
+
+  // Issue #2174: Compute similarity-based alignment for unmatched neurons
+  const similarityResult = computeSimilarityAlignment(
+    parentExport,
+    targetExport,
+    parentNeuronSet,
+    targetSet,
+  );
+
+  // Track which parent UUIDs have been consumed by similarity alignment
+  const usedParentUuids = new Set<string>(similarityResult.mapping.values());
+
+  // Sequential fallback index for neurons not matched by similarity
+  let parentIndx = 0;
 
   for (let index = 0; index < targetExport.neurons.length; index++) {
     const targetNeuron = targetExport.neurons[index];
@@ -32,13 +58,33 @@ export function editParentByIndex(
       if (
         typeof targetUuid === "string" && !parentNeuronSet.has(targetUuid)
       ) {
+        // Check similarity-based alignment first
+        const similarParentUuid = similarityResult.mapping.get(targetUuid);
+        if (similarParentUuid) {
+          targetNeuron.uuid = similarParentUuid;
+          targetSet.add(similarParentUuid);
+          addTag(targetNeuron, "alias", targetUuid);
+          addTag(targetNeuron, "approach", "graft");
+          targetExport.synapses.forEach((synapse) => {
+            if (synapse.fromUUID === targetUuid) {
+              synapse.fromUUID = similarParentUuid;
+            }
+            if (synapse.toUUID === targetUuid) {
+              synapse.toUUID = similarParentUuid;
+            }
+          });
+          continue;
+        }
+
+        // Sequential fallback for neurons without meaningful similarity
         while (parentIndx < parentExport.neurons.length) {
           const parentNeuron = parentExport.neurons[parentIndx];
           parentIndx++;
           if (
             parentNeuron.type === "hidden" &&
             typeof parentNeuron.uuid === "string" &&
-            !targetSet.has(parentNeuron.uuid)
+            !targetSet.has(parentNeuron.uuid) &&
+            !usedParentUuids.has(parentNeuron.uuid)
           ) {
             targetNeuron.uuid = parentNeuron.uuid;
             targetSet.add(parentNeuron.uuid);
@@ -46,10 +92,10 @@ export function editParentByIndex(
             addTag(targetNeuron, "approach", "graft");
             targetExport.synapses.forEach((synapse) => {
               if (synapse.fromUUID === targetUuid) {
-                synapse.fromUUID = parentNeuron.uuid;
+                synapse.fromUUID = parentNeuron.uuid!;
               }
               if (synapse.toUUID === targetUuid) {
-                synapse.toUUID = parentNeuron.uuid;
+                synapse.toUUID = parentNeuron.uuid!;
               }
             });
             break;

--- a/src/breed/NeuronAlignment.ts
+++ b/src/breed/NeuronAlignment.ts
@@ -1,0 +1,201 @@
+/**
+ * Input-weight cosine similarity-based neuron alignment for inter-species breeding.
+ *
+ * Issue #2174: When breeding creatures from different islands, UUID matching
+ * and connectivity key matching both fail completely. This module replaces the
+ * sequential fallback with a functional similarity-based alignment that
+ * considers each neuron's actual role via its input connection weight vectors.
+ *
+ * Since both creatures share the same input neurons, hidden neurons can be
+ * compared by their incoming weight vectors from those shared inputs. Cosine
+ * similarity measures how similar two neurons' input weight patterns are,
+ * regardless of magnitude differences.
+ */
+
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+
+/**
+ * Sparse input weight vector for a hidden neuron.
+ * Maps input neuron UUID to connection weight.
+ */
+type InputWeightVector = Map<string, number>;
+
+/**
+ * Builds a sparse input weight vector for a neuron based on its incoming
+ * connections from input neurons.
+ *
+ * @param neuronUuid - UUID of the target neuron
+ * @param synapses - All synapses in the creature export
+ * @param inputCount - Number of input neurons in the creature
+ * @returns Sparse vector mapping input UUIDs to weights
+ */
+export function buildInputWeightVector(
+  neuronUuid: string,
+  synapses: CreatureExport["synapses"],
+  inputCount: number,
+): InputWeightVector {
+  const vector: InputWeightVector = new Map();
+
+  for (const synapse of synapses) {
+    if (synapse.toUUID !== neuronUuid) continue;
+
+    const fromUUID = synapse.fromUUID;
+    if (typeof fromUUID !== "string") continue;
+
+    // Only consider connections from input neurons
+    if (fromUUID.startsWith("input-")) {
+      const inputIndex = parseInt(fromUUID.substring(6), 10);
+      if (inputIndex >= 0 && inputIndex < inputCount) {
+        vector.set(fromUUID, synapse.weight);
+      }
+    }
+  }
+
+  return vector;
+}
+
+/**
+ * Computes cosine similarity between two sparse input weight vectors.
+ *
+ * cosine_similarity = dot(a, b) / (|a| * |b|)
+ *
+ * Returns 0 if either vector is empty or has zero magnitude.
+ * Returns a value in [-1, 1] where 1 means identical direction.
+ *
+ * @param a - First sparse vector
+ * @param b - Second sparse vector
+ * @returns Cosine similarity score
+ */
+export function cosineSimilarity(
+  a: InputWeightVector,
+  b: InputWeightVector,
+): number {
+  if (a.size === 0 || b.size === 0) return 0;
+
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+
+  // Compute dot product over shared keys
+  for (const [key, valueA] of a) {
+    const valueB = b.get(key);
+    if (valueB !== undefined) {
+      dot += valueA * valueB;
+    }
+    magA += valueA * valueA;
+  }
+
+  for (const valueB of b.values()) {
+    magB += valueB * valueB;
+  }
+
+  const denominator = Math.sqrt(magA) * Math.sqrt(magB);
+  if (denominator === 0) return 0;
+
+  return dot / denominator;
+}
+
+/**
+ * Result of neuron alignment: maps target neuron index to parent neuron index.
+ */
+export interface AlignmentResult {
+  /** Maps target hidden neuron UUID to matched parent hidden neuron UUID */
+  mapping: Map<string, string>;
+}
+
+/**
+ * Computes a similarity-based neuron alignment between parent and target
+ * creatures using input-weight cosine similarity.
+ *
+ * Uses a greedy best-match approach: iteratively picks the highest-similarity
+ * pair from the remaining unmatched neurons until no more meaningful matches
+ * exist.
+ *
+ * @param parentExport - Exported parent creature
+ * @param targetExport - Exported target creature
+ * @param parentNeuronSet - Set of parent hidden neuron UUIDs
+ * @param targetSet - Set of all target neuron UUIDs (used to skip already-matched)
+ * @returns Alignment mapping from target UUIDs to parent UUIDs
+ */
+export function computeSimilarityAlignment(
+  parentExport: CreatureExport,
+  targetExport: CreatureExport,
+  parentNeuronSet: Set<string>,
+  targetSet: Set<string>,
+): AlignmentResult {
+  const mapping = new Map<string, string>();
+
+  // Collect unmatched hidden neurons from parent
+  const unmatchedParent: string[] = [];
+  for (const n of parentExport.neurons) {
+    if (
+      n.type === "hidden" &&
+      typeof n.uuid === "string" &&
+      !targetSet.has(n.uuid)
+    ) {
+      unmatchedParent.push(n.uuid);
+    }
+  }
+
+  // Collect unmatched hidden neurons from target
+  const unmatchedTarget: string[] = [];
+  for (const n of targetExport.neurons) {
+    if (
+      n.type === "hidden" &&
+      typeof n.uuid === "string" &&
+      !parentNeuronSet.has(n.uuid)
+    ) {
+      unmatchedTarget.push(n.uuid);
+    }
+  }
+
+  if (unmatchedParent.length === 0 || unmatchedTarget.length === 0) {
+    return { mapping };
+  }
+
+  // Build input weight vectors for all unmatched neurons
+  const parentVectors = new Map<string, InputWeightVector>();
+  for (const uuid of unmatchedParent) {
+    parentVectors.set(
+      uuid,
+      buildInputWeightVector(uuid, parentExport.synapses, parentExport.input),
+    );
+  }
+
+  const targetVectors = new Map<string, InputWeightVector>();
+  for (const uuid of unmatchedTarget) {
+    targetVectors.set(
+      uuid,
+      buildInputWeightVector(uuid, targetExport.synapses, targetExport.input),
+    );
+  }
+
+  // Build similarity matrix as a flat list of scored pairs
+  const pairs: { targetUuid: string; parentUuid: string; score: number }[] = [];
+  for (const [targetUuid, targetVec] of targetVectors) {
+    for (const [parentUuid, parentVec] of parentVectors) {
+      const score = cosineSimilarity(targetVec, parentVec);
+      if (score > 0) {
+        pairs.push({ targetUuid, parentUuid, score });
+      }
+    }
+  }
+
+  // Sort by descending similarity for greedy matching
+  pairs.sort((a, b) => b.score - a.score);
+
+  // Greedy best-match: pick highest similarity pairs first
+  const usedParent = new Set<string>();
+  const usedTarget = new Set<string>();
+
+  for (const pair of pairs) {
+    if (usedTarget.has(pair.targetUuid) || usedParent.has(pair.parentUuid)) {
+      continue;
+    }
+    mapping.set(pair.targetUuid, pair.parentUuid);
+    usedTarget.add(pair.targetUuid);
+    usedParent.add(pair.parentUuid);
+  }
+
+  return { mapping };
+}

--- a/test/breed/NeuronAlignment.ts
+++ b/test/breed/NeuronAlignment.ts
@@ -1,0 +1,600 @@
+/**
+ * Tests for input-weight cosine similarity neuron alignment.
+ *
+ * Issue #2174: Verifies that:
+ * 1. Input weight vectors are correctly built from creature synapses
+ * 2. Cosine similarity is computed correctly for sparse vectors
+ * 3. Similarity-based alignment correctly matches functionally similar neurons
+ * 4. Neurons with no meaningful input connections fall back gracefully
+ * 5. The alignment integrates correctly with editParentByIndex
+ */
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { getTag } from "@stsoftware/tags/mod";
+import { Creature, type CreatureExport } from "../../mod.ts";
+import { editParentByIndex } from "@breed/EditParentByIndex.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import {
+  buildInputWeightVector,
+  computeSimilarityAlignment,
+  cosineSimilarity,
+} from "@breed/NeuronAlignment.ts";
+
+// --- Unit tests for buildInputWeightVector ---
+
+Deno.test(
+  "buildInputWeightVector: extracts input connections for a hidden neuron",
+  () => {
+    const synapses: CreatureExport["synapses"] = [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-a", weight: -0.3 },
+      { fromUUID: "input-2", toUUID: "hidden-b", weight: 0.7 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 1.0 },
+    ];
+
+    const vec = buildInputWeightVector("hidden-a", synapses, 3);
+
+    assertEquals(vec.size, 2);
+    assertEquals(vec.get("input-0"), 0.5);
+    assertEquals(vec.get("input-1"), -0.3);
+  },
+);
+
+Deno.test(
+  "buildInputWeightVector: returns empty map for neuron with no input connections",
+  () => {
+    const synapses: CreatureExport["synapses"] = [
+      { fromUUID: "hidden-a", toUUID: "hidden-b", weight: 0.5 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: 1.0 },
+    ];
+
+    const vec = buildInputWeightVector("hidden-b", synapses, 2);
+
+    assertEquals(vec.size, 0);
+  },
+);
+
+Deno.test(
+  "buildInputWeightVector: ignores connections from non-input neurons",
+  () => {
+    const synapses: CreatureExport["synapses"] = [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "hidden-x", toUUID: "hidden-a", weight: 0.9 },
+    ];
+
+    const vec = buildInputWeightVector("hidden-a", synapses, 2);
+
+    assertEquals(vec.size, 1);
+    assertEquals(vec.get("input-0"), 0.5);
+  },
+);
+
+// --- Unit tests for cosineSimilarity ---
+
+Deno.test("cosineSimilarity: identical vectors return 1", () => {
+  const a = new Map([["input-0", 1.0], ["input-1", 2.0]]);
+  const b = new Map([["input-0", 1.0], ["input-1", 2.0]]);
+
+  const sim = cosineSimilarity(a, b);
+  assertAlmostEquals(sim, 1.0, 1e-10);
+});
+
+Deno.test("cosineSimilarity: opposite vectors return -1", () => {
+  const a = new Map([["input-0", 1.0], ["input-1", 2.0]]);
+  const b = new Map([["input-0", -1.0], ["input-1", -2.0]]);
+
+  const sim = cosineSimilarity(a, b);
+  assertAlmostEquals(sim, -1.0, 1e-10);
+});
+
+Deno.test("cosineSimilarity: orthogonal vectors return 0", () => {
+  const a = new Map([["input-0", 1.0]]);
+  const b = new Map([["input-1", 1.0]]);
+
+  const sim = cosineSimilarity(a, b);
+  assertEquals(sim, 0);
+});
+
+Deno.test("cosineSimilarity: empty vectors return 0", () => {
+  const a = new Map<string, number>();
+  const b = new Map([["input-0", 1.0]]);
+
+  assertEquals(cosineSimilarity(a, b), 0);
+  assertEquals(cosineSimilarity(b, a), 0);
+  assertEquals(cosineSimilarity(a, a), 0);
+});
+
+Deno.test("cosineSimilarity: proportional vectors return 1", () => {
+  const a = new Map([["input-0", 1.0], ["input-1", 2.0]]);
+  const b = new Map([["input-0", 3.0], ["input-1", 6.0]]);
+
+  const sim = cosineSimilarity(a, b);
+  assertAlmostEquals(sim, 1.0, 1e-10);
+});
+
+// --- Unit tests for computeSimilarityAlignment ---
+
+Deno.test(
+  "computeSimilarityAlignment: matches neurons with similar input weights",
+  () => {
+    // Parent has two hidden neurons with distinct input weight patterns
+    const parentExport: CreatureExport = {
+      input: 3,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "parent-A",
+          bias: 0,
+          squash: "LOGISTIC",
+        },
+        {
+          type: "hidden",
+          uuid: "parent-B",
+          bias: 0,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        // parent-A gets input-0 strongly, input-1 weakly
+        { fromUUID: "input-0", toUUID: "parent-A", weight: 0.9 },
+        { fromUUID: "input-1", toUUID: "parent-A", weight: 0.1 },
+        // parent-B gets input-1 strongly, input-2 weakly
+        { fromUUID: "input-1", toUUID: "parent-B", weight: 0.8 },
+        { fromUUID: "input-2", toUUID: "parent-B", weight: 0.2 },
+        { fromUUID: "parent-A", toUUID: "output-0", weight: 1.0 },
+        { fromUUID: "parent-B", toUUID: "output-0", weight: 1.0 },
+      ],
+    };
+
+    // Target has two hidden neurons — target-X is similar to parent-A,
+    // target-Y is similar to parent-B
+    const targetExport: CreatureExport = {
+      input: 3,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "target-X",
+          bias: 0,
+          squash: "LOGISTIC",
+        },
+        {
+          type: "hidden",
+          uuid: "target-Y",
+          bias: 0,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        // target-X has similar pattern to parent-A
+        { fromUUID: "input-0", toUUID: "target-X", weight: 0.85 },
+        { fromUUID: "input-1", toUUID: "target-X", weight: 0.15 },
+        // target-Y has similar pattern to parent-B
+        { fromUUID: "input-1", toUUID: "target-Y", weight: 0.75 },
+        { fromUUID: "input-2", toUUID: "target-Y", weight: 0.25 },
+        { fromUUID: "target-X", toUUID: "output-0", weight: 1.0 },
+        { fromUUID: "target-Y", toUUID: "output-0", weight: 1.0 },
+      ],
+    };
+
+    const parentSet = new Set(["parent-A", "parent-B"]);
+    const targetSet = new Set([
+      "target-X",
+      "target-Y",
+      "output-0",
+    ]);
+
+    const result = computeSimilarityAlignment(
+      parentExport,
+      targetExport,
+      parentSet,
+      targetSet,
+    );
+
+    // target-X should align with parent-A (both weight input-0 heavily)
+    assertEquals(result.mapping.get("target-X"), "parent-A");
+    // target-Y should align with parent-B (both weight input-1 heavily)
+    assertEquals(result.mapping.get("target-Y"), "parent-B");
+  },
+);
+
+Deno.test(
+  "computeSimilarityAlignment: returns empty mapping when no unmatched neurons",
+  () => {
+    const creature: CreatureExport = {
+      input: 2,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "shared-1",
+          bias: 0,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "shared-1", weight: 0.5 },
+        { fromUUID: "shared-1", toUUID: "output-0", weight: 1.0 },
+      ],
+    };
+
+    // All neurons already matched
+    const parentSet = new Set(["shared-1"]);
+    const targetSet = new Set(["shared-1", "output-0"]);
+
+    const result = computeSimilarityAlignment(
+      creature,
+      creature,
+      parentSet,
+      targetSet,
+    );
+
+    assertEquals(result.mapping.size, 0);
+  },
+);
+
+Deno.test(
+  "computeSimilarityAlignment: handles neurons with no input connections gracefully",
+  () => {
+    const parentExport: CreatureExport = {
+      input: 2,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "parent-deep",
+          bias: 0,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        // parent-deep has no direct input connections
+        { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "parent-deep", toUUID: "output-0", weight: 1.0 },
+      ],
+    };
+
+    const targetExport: CreatureExport = {
+      input: 2,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "target-deep",
+          bias: 0,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "target-deep", toUUID: "output-0", weight: 1.0 },
+      ],
+    };
+
+    const parentSet = new Set(["parent-deep"]);
+    const targetSet = new Set(["target-deep", "output-0"]);
+
+    const result = computeSimilarityAlignment(
+      parentExport,
+      targetExport,
+      parentSet,
+      targetSet,
+    );
+
+    // No similarity can be computed — mapping should be empty
+    assertEquals(result.mapping.size, 0);
+  },
+);
+
+// --- Integration test: editParentByIndex uses similarity-based alignment ---
+
+Deno.test(
+  "editParentByIndex: aligns neurons by input-weight similarity, not sequential order",
+  () => {
+    // Create parent with 3 inputs, 2 hidden neurons, 1 output
+    // parent-A connects strongly to input-0
+    // parent-B connects strongly to input-2
+    const parentJson: CreatureExport = {
+      input: 3,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "parent-A",
+          bias: 0.1,
+          squash: "LOGISTIC",
+        },
+        {
+          type: "hidden",
+          uuid: "parent-B",
+          bias: 0.2,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "parent-A", weight: 0.9 },
+        { fromUUID: "input-1", toUUID: "parent-A", weight: 0.1 },
+        { fromUUID: "input-1", toUUID: "parent-B", weight: 0.1 },
+        { fromUUID: "input-2", toUUID: "parent-B", weight: 0.9 },
+        { fromUUID: "parent-A", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "parent-B", toUUID: "output-0", weight: 0.5 },
+      ],
+    };
+
+    // Target has 2 hidden neurons in REVERSE functional order:
+    // target-1 (listed first) connects strongly to input-2 (like parent-B)
+    // target-2 (listed second) connects strongly to input-0 (like parent-A)
+    //
+    // Sequential mapping would incorrectly map:
+    //   target-1 -> parent-A (WRONG: target-1 is functionally similar to parent-B)
+    //   target-2 -> parent-B (WRONG: target-2 is functionally similar to parent-A)
+    //
+    // Similarity-based mapping should correctly map:
+    //   target-1 -> parent-B (both weight input-2)
+    //   target-2 -> parent-A (both weight input-0)
+    const targetJson: CreatureExport = {
+      input: 3,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "target-1",
+          bias: 0.1,
+          squash: "LOGISTIC",
+        },
+        {
+          type: "hidden",
+          uuid: "target-2",
+          bias: 0.2,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-1", toUUID: "target-1", weight: 0.1 },
+        { fromUUID: "input-2", toUUID: "target-1", weight: 0.9 },
+        { fromUUID: "input-0", toUUID: "target-2", weight: 0.9 },
+        { fromUUID: "input-1", toUUID: "target-2", weight: 0.1 },
+        { fromUUID: "target-1", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "target-2", toUUID: "output-0", weight: 0.5 },
+      ],
+    };
+
+    const parent = Creature.fromJSON(parentJson);
+    const target = Creature.fromJSON(targetJson);
+
+    const child = editParentByIndex(parent, target);
+    creatureValidate(child);
+
+    const childExport = child.exportJSON();
+    const hiddenNeurons = childExport.neurons.filter((n) =>
+      n.type === "hidden"
+    );
+
+    // Verify the similarity-based alignment occurred
+    // target-1 (input-2 heavy) should be remapped to parent-B (input-2 heavy)
+    // target-2 (input-0 heavy) should be remapped to parent-A (input-0 heavy)
+    const neuronUuids = new Set(hiddenNeurons.map((n) => n.uuid));
+    assert(
+      neuronUuids.has("parent-A"),
+      "Should contain parent-A UUID",
+    );
+    assert(
+      neuronUuids.has("parent-B"),
+      "Should contain parent-B UUID",
+    );
+
+    // Check that the neuron mapped from target-1 got parent-B's UUID
+    // (not parent-A, which would be the sequential fallback)
+    for (const neuron of hiddenNeurons) {
+      const alias = getTag(neuron, "alias");
+      if (alias === "target-1") {
+        assertEquals(
+          neuron.uuid,
+          "parent-B",
+          "target-1 (input-2 heavy) should align with parent-B (input-2 heavy)",
+        );
+      }
+      if (alias === "target-2") {
+        assertEquals(
+          neuron.uuid,
+          "parent-A",
+          "target-2 (input-0 heavy) should align with parent-A (input-0 heavy)",
+        );
+      }
+    }
+  },
+);
+
+Deno.test(
+  "editParentByIndex: falls back to sequential for neurons without input connections",
+  () => {
+    // Parent has a deep hidden neuron with no direct input connections
+    const parentJson: CreatureExport = {
+      input: 2,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "parent-layer1",
+          bias: 0.1,
+          squash: "LOGISTIC",
+        },
+        {
+          type: "hidden",
+          uuid: "parent-deep",
+          bias: 0.2,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "parent-layer1", weight: 0.5 },
+        { fromUUID: "input-1", toUUID: "parent-layer1", weight: 0.5 },
+        // parent-deep has no direct input connections
+        { fromUUID: "parent-layer1", toUUID: "parent-deep", weight: 0.5 },
+        { fromUUID: "parent-deep", toUUID: "output-0", weight: 1.0 },
+      ],
+    };
+
+    const targetJson: CreatureExport = {
+      input: 2,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "target-layer1",
+          bias: 0.1,
+          squash: "LOGISTIC",
+        },
+        {
+          type: "hidden",
+          uuid: "target-deep",
+          bias: 0.2,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "target-layer1", weight: 0.5 },
+        { fromUUID: "input-1", toUUID: "target-layer1", weight: 0.5 },
+        { fromUUID: "target-layer1", toUUID: "target-deep", weight: 0.5 },
+        { fromUUID: "target-deep", toUUID: "output-0", weight: 1.0 },
+      ],
+    };
+
+    const parent = Creature.fromJSON(parentJson);
+    const target = Creature.fromJSON(targetJson);
+
+    const child = editParentByIndex(parent, target);
+    creatureValidate(child);
+
+    const childExport = child.exportJSON();
+    const hiddenNeurons = childExport.neurons.filter((n) =>
+      n.type === "hidden"
+    );
+
+    // Both neurons should be remapped (one by similarity, one by fallback)
+    assertEquals(hiddenNeurons.length, 2, "Should have 2 hidden neurons");
+
+    // The layer1 neurons have matching input weights, so they should align
+    // The deep neurons have no input connections, so they fall back to sequential
+    const neuronUuids = new Set(hiddenNeurons.map((n) => n.uuid));
+    assert(
+      neuronUuids.has("parent-layer1"),
+      "Layer-1 neuron should be aligned by similarity",
+    );
+    assert(
+      neuronUuids.has("parent-deep"),
+      "Deep neuron should be aligned by sequential fallback",
+    );
+  },
+);
+
+Deno.test(
+  "editParentByIndex: similarity alignment produces valid creature with asymmetric sizes",
+  () => {
+    // Parent has 3 hidden neurons, target has 2 — simulates inter-species size mismatch
+    const parentJson: CreatureExport = {
+      input: 3,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "parent-1",
+          bias: 0.1,
+          squash: "LOGISTIC",
+        },
+        {
+          type: "hidden",
+          uuid: "parent-2",
+          bias: 0.2,
+          squash: "LOGISTIC",
+        },
+        {
+          type: "hidden",
+          uuid: "parent-3",
+          bias: 0.3,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "parent-1", weight: 0.9 },
+        { fromUUID: "input-1", toUUID: "parent-2", weight: 0.9 },
+        { fromUUID: "input-2", toUUID: "parent-3", weight: 0.9 },
+        { fromUUID: "parent-1", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "parent-2", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "parent-3", toUUID: "output-0", weight: 0.5 },
+      ],
+    };
+
+    // Target has only 2 hidden neurons that match parent-1 and parent-3
+    const targetJson: CreatureExport = {
+      input: 3,
+      output: 1,
+      neurons: [
+        {
+          type: "hidden",
+          uuid: "target-A",
+          bias: 0.1,
+          squash: "LOGISTIC",
+        },
+        {
+          type: "hidden",
+          uuid: "target-B",
+          bias: 0.2,
+          squash: "LOGISTIC",
+        },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        // target-A is similar to parent-3 (input-2)
+        { fromUUID: "input-2", toUUID: "target-A", weight: 0.85 },
+        // target-B is similar to parent-1 (input-0)
+        { fromUUID: "input-0", toUUID: "target-B", weight: 0.85 },
+        { fromUUID: "target-A", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "target-B", toUUID: "output-0", weight: 0.5 },
+      ],
+    };
+
+    const parent = Creature.fromJSON(parentJson);
+    const target = Creature.fromJSON(targetJson);
+
+    const child = editParentByIndex(parent, target);
+    creatureValidate(child);
+
+    const childExport = child.exportJSON();
+    const hiddenNeurons = childExport.neurons.filter((n) =>
+      n.type === "hidden"
+    );
+
+    // target has 2 hidden neurons; parent has 3 — child should still have 2
+    assertEquals(hiddenNeurons.length, 2, "Child should have 2 hidden neurons");
+
+    // Check similarity-based alignment
+    for (const neuron of hiddenNeurons) {
+      const alias = getTag(neuron, "alias");
+      if (alias === "target-A") {
+        assertEquals(
+          neuron.uuid,
+          "parent-3",
+          "target-A (input-2 heavy) should align with parent-3 (input-2 heavy)",
+        );
+      }
+      if (alias === "target-B") {
+        assertEquals(
+          neuron.uuid,
+          "parent-1",
+          "target-B (input-0 heavy) should align with parent-1 (input-0 heavy)",
+        );
+      }
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Improved neuron alignment in inter-species breeding by replacing the sequential
positional mapping in `editParentByIndex` with input-weight cosine
similarity-based alignment. Closes #2174.

When breeding creatures from different islands, UUID matching and connectivity
key matching both fail completely due to different neuron ID formats and
drastically different topologies. Previously, the sequential fallback in
`editParentByIndex` mapped father neurons to mother neurons by array position,
which has no semantic meaning.

Now, unmatched hidden neurons are compared by their incoming weight vectors from
shared input neurons using cosine similarity. A greedy best-match algorithm
picks the highest-similarity pairs first, ensuring neurons with similar
functional roles are aligned. Neurons without meaningful input connections
(e.g., deep hidden neurons) fall back to the original sequential mapping.

### New files
- `src/breed/NeuronAlignment.ts` — input-weight vector construction, cosine
  similarity computation, and greedy similarity-based alignment algorithm
- `test/breed/NeuronAlignment.ts` — 14 tests covering unit and integration
  scenarios

### Modified files
- `src/breed/EditParentByIndex.ts` — integrated similarity-based alignment
  before the sequential fallback

## Evidence

All 5300 existing tests pass, confirming no regressions. The new tests
specifically verify that:
- Neurons with reversed functional order are correctly aligned by similarity
  (not sequential position)
- Asymmetric creature sizes are handled correctly
- Deep neurons without input connections fall back gracefully

## Test Plan

- `test/breed/NeuronAlignment.ts` — 14 new tests:
  - 3 unit tests for `buildInputWeightVector`
  - 5 unit tests for `cosineSimilarity`
  - 3 unit tests for `computeSimilarityAlignment`
  - 3 integration tests for `editParentByIndex` with similarity alignment
- `test/breed/EditParentByIndex.ts` — all 11 existing tests continue to pass