### PR TITLE
Implement subgraph transplantation for horizontal gene transfer (#2177)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2177.md
+++ b/docs/pr-summary-2177.md
@@ -1,0 +1,53 @@
+## Summary
+
+Implement subgraph transplantation as a horizontal gene transfer breeding
+strategy for inter-species breeding. When two creatures have very low genetic
+compatibility, the system now randomly selects between input-weight crossover
+(Issue #2175) and subgraph transplantation, falling back to the other if the
+first strategy fails. Closes #2177.
+
+Subgraph transplantation extracts small, self-contained clusters of 2-5
+connected hidden neurons from a donor creature and transplants them (with new
+UUIDs) into the recipient's topology. This is inspired by horizontal gene
+transfer in prokaryotes and subtree crossover in genetic programming.
+
+### Algorithm
+
+1. **Extract subgraphs** from the donor: identify clusters of connected hidden
+   neurons, scored by modularity (internal vs external connections)
+2. **Select best subgraph** with slight randomisation among top candidates
+3. **Transplant** into the mother's topology with new UUIDs, preserving internal
+   connection weights
+4. **Connect boundaries**: link donor's input sources to transplanted entry
+   neurons; link transplanted exit neurons to mother's output neurons
+5. **Validate** with `creatureValidate` (including forward-only constraint)
+6. **Tag** transplanted neurons with `approach: "transplant"` for tracking
+
+### Files Changed
+
+- **New**: `src/breed/SubgraphTransplant.ts` — subgraph identification,
+  extraction, scoring, and transplantation logic
+- **New**: `test/breed/SubgraphTransplant.ts` — 12 unit tests
+- **Modified**: `src/architecture/Offspring.ts` — integrated as alternative
+  inter-species breeding path alongside input-weight crossover
+
+## Evidence
+
+All 5325 tests pass (0 failures, 3 ignored). The new module integrates
+seamlessly with the existing breeding pipeline without requiring new
+configuration options.
+
+## Test Plan
+
+- `extractSubgraphs finds connected hidden neuron clusters`
+- `extractSubgraphs returns subgraphs with internal connections`
+- `subgraphTransplant produces valid offspring`
+- `subgraphTransplant produces valid forward-only offspring`
+- `subgraphTransplant tags transplanted neurons with approach: transplant`
+- `subgraphTransplant gives new UUIDs to transplanted neurons`
+- `subgraphTransplant preserves mother's input/output structure`
+- `subgraphTransplant offspring has more hidden neurons than mother`
+- `subgraphTransplant works with incompatible parents`
+- `Offspring.breed can use subgraph transplant for very low compatibility`
+- `subgraphTransplant with single hidden neuron donor returns undefined`
+- `subgraphTransplant with larger networks`

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -14,6 +14,7 @@ import { prepareCreatureForBreeding } from "@upgrade/Upgrade.ts";
 import { writeDiagnostics } from "@utils/Diagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { inputWeightCrossover } from "@breed/InputWeightCrossover.ts";
+import { subgraphTransplant } from "@breed/SubgraphTransplant.ts";
 import { pruneOrphanMemeticReferences } from "@compact/CompactUtils.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { Neuron } from "@architecture/Neuron.ts";
@@ -78,10 +79,10 @@ export class Offspring {
 
     const compatibility = geneticCompatibility(mother, father);
 
-    // Issue #2175: When compatibility is very low (below interSpeciesCrossoverThreshold),
-    // use input-weight crossover which preserves the mother's topology and blends
-    // input/output weights. This produces more meaningful offspring than the standard
-    // neuron-grafting approach for genetically incompatible creatures.
+    // Issue #2175/#2177: When compatibility is very low (below
+    // interSpeciesCrossoverThreshold), use specialised inter-species breeding.
+    // Randomly selects between input-weight crossover (Issue #2175) and subgraph
+    // transplantation (Issue #2177), falling back to the other if the first fails.
     const interSpeciesThreshold = options.interSpeciesCrossoverThreshold ?? 0;
     if (
       interSpeciesThreshold > 0 &&
@@ -89,7 +90,16 @@ export class Offspring {
       options.geneticCompatibilityThreshold &&
       compatibility < options.geneticCompatibilityThreshold
     ) {
-      const child = inputWeightCrossover(mother, father);
+      let child: Creature | undefined;
+      if (rng.random() < 0.5) {
+        // Try subgraph transplantation first, fall back to input-weight crossover
+        child = subgraphTransplant(mother, father);
+        if (!child) child = inputWeightCrossover(mother, father);
+      } else {
+        // Try input-weight crossover first, fall back to subgraph transplantation
+        child = inputWeightCrossover(mother, father);
+        if (!child) child = subgraphTransplant(mother, father);
+      }
       if (child) {
         // Memetic update (same as standard crossover path)
         if (mother.memetic) {

--- a/src/breed/SubgraphTransplant.ts
+++ b/src/breed/SubgraphTransplant.ts
@@ -1,0 +1,471 @@
+/**
+ * Subgraph transplantation breeding strategy for horizontal gene transfer
+ * between species (Issue #2177).
+ *
+ * Inspired by horizontal gene transfer in prokaryotes and subtree crossover
+ * in genetic programming, this module extracts small, self-contained subgraphs
+ * (2–5 connected hidden neurons) from a donor creature and transplants them
+ * into a recipient creature.
+ *
+ * Algorithm:
+ * 1. Identify donor subgraphs — small clusters of connected hidden neurons
+ * 2. Score subgraphs by modularity (internal vs external connections)
+ * 3. Select the best subgraph and transplant it into the mother's topology
+ * 4. Connect boundary neurons using shared input indices and small random weights
+ * 5. Validate the result with creatureValidate
+ */
+
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import type { NeuronExport } from "@architecture/NeuronInterfaces.ts";
+import type { SynapseExport } from "@architecture/SynapseInterfaces.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
+
+/** Minimum number of neurons in a transplantable subgraph. */
+const MIN_SUBGRAPH_SIZE = 2;
+/** Maximum number of neurons in a transplantable subgraph. */
+const MAX_SUBGRAPH_SIZE = 5;
+
+/**
+ * A self-contained subgraph extracted from a donor creature.
+ */
+export interface Subgraph {
+  /** UUIDs of the hidden neurons in this subgraph. */
+  neuronUuids: string[];
+  /** Synapses that connect neurons within the subgraph. */
+  internalSynapses: SynapseExport[];
+  /** UUIDs of neurons that feed into the subgraph from outside (inputs or other hidden). */
+  inputBoundaryUuids: string[];
+  /** UUIDs of neurons that the subgraph feeds into (outputs or other hidden). */
+  outputBoundaryUuids: string[];
+  /** Modularity score: ratio of internal to total connections. Higher is better. */
+  modularity: number;
+}
+
+/**
+ * Extracts candidate subgraphs from a donor creature's exported JSON.
+ *
+ * Identifies clusters of 2–5 connected hidden neurons and scores them by
+ * modularity (ratio of internal connections to total connections involving
+ * the cluster's neurons).
+ */
+export function extractSubgraphs(donorExport: CreatureExport): Subgraph[] {
+  const hiddenNeurons = donorExport.neurons.filter(
+    (n) => n.type === "hidden" && typeof n.uuid === "string",
+  );
+
+  if (hiddenNeurons.length < MIN_SUBGRAPH_SIZE) {
+    return [];
+  }
+
+  const hiddenUuidSet = new Set(
+    hiddenNeurons.map((n) => n.uuid as string),
+  );
+
+  // Build adjacency: for each hidden neuron, which other hidden neurons
+  // does it connect to (forward direction)?
+  const forwardAdj = new Map<string, Set<string>>();
+  const backwardAdj = new Map<string, Set<string>>();
+  for (const uuid of hiddenUuidSet) {
+    forwardAdj.set(uuid, new Set());
+    backwardAdj.set(uuid, new Set());
+  }
+
+  for (const syn of donorExport.synapses) {
+    const from = syn.fromUUID;
+    const to = syn.toUUID;
+    if (from && to && hiddenUuidSet.has(from) && hiddenUuidSet.has(to)) {
+      forwardAdj.get(from)!.add(to);
+      backwardAdj.get(to)!.add(from);
+    }
+  }
+
+  // Generate candidate subgraphs using BFS from each hidden neuron
+  const subgraphs: Subgraph[] = [];
+  const seenSignatures = new Set<string>();
+
+  for (const startNeuron of hiddenNeurons) {
+    const startUuid = startNeuron.uuid as string;
+    const cluster = [startUuid];
+    const clusterSet = new Set(cluster);
+
+    // BFS to grow the cluster
+    const queue = [startUuid];
+    while (queue.length > 0 && cluster.length < MAX_SUBGRAPH_SIZE) {
+      const current = queue.shift()!;
+
+      // Add forward neighbours
+      for (const neighbour of forwardAdj.get(current) ?? []) {
+        if (!clusterSet.has(neighbour) && cluster.length < MAX_SUBGRAPH_SIZE) {
+          cluster.push(neighbour);
+          clusterSet.add(neighbour);
+          queue.push(neighbour);
+        }
+      }
+
+      // Add backward neighbours
+      for (const neighbour of backwardAdj.get(current) ?? []) {
+        if (!clusterSet.has(neighbour) && cluster.length < MAX_SUBGRAPH_SIZE) {
+          cluster.push(neighbour);
+          clusterSet.add(neighbour);
+          queue.push(neighbour);
+        }
+      }
+    }
+
+    if (cluster.length < MIN_SUBGRAPH_SIZE) continue;
+
+    // Try subgraphs of different sizes from this cluster
+    for (
+      let size = MIN_SUBGRAPH_SIZE;
+      size <= Math.min(cluster.length, MAX_SUBGRAPH_SIZE);
+      size++
+    ) {
+      const subCluster = cluster.slice(0, size);
+      const signature = [...subCluster].sort().join(",");
+      if (seenSignatures.has(signature)) continue;
+      seenSignatures.add(signature);
+
+      const subClusterSet = new Set(subCluster);
+      const subgraph = scoreSubgraph(
+        subCluster,
+        subClusterSet,
+        donorExport.synapses,
+      );
+      if (subgraph) {
+        subgraphs.push(subgraph);
+      }
+    }
+  }
+
+  // Sort by modularity (higher is better)
+  subgraphs.sort((a, b) => b.modularity - a.modularity);
+
+  return subgraphs;
+}
+
+/**
+ * Scores a candidate subgraph by its modularity and extracts boundary info.
+ */
+function scoreSubgraph(
+  neuronUuids: string[],
+  neuronSet: Set<string>,
+  synapses: SynapseExport[],
+): Subgraph | null {
+  const internalSynapses: SynapseExport[] = [];
+  const inputBoundarySet = new Set<string>();
+  const outputBoundarySet = new Set<string>();
+  let externalConnectionCount = 0;
+
+  for (const syn of synapses) {
+    const from = syn.fromUUID;
+    const to = syn.toUUID;
+    if (!from || !to) continue;
+
+    const fromInside = neuronSet.has(from);
+    const toInside = neuronSet.has(to);
+
+    if (fromInside && toInside) {
+      // Internal connection
+      internalSynapses.push(syn);
+    } else if (!fromInside && toInside) {
+      // Inbound from outside -> boundary input
+      inputBoundarySet.add(from);
+      externalConnectionCount++;
+    } else if (fromInside && !toInside) {
+      // Outbound to outside -> boundary output
+      outputBoundarySet.add(to);
+      externalConnectionCount++;
+    }
+  }
+
+  // Must have at least one internal connection
+  if (internalSynapses.length === 0) return null;
+
+  // Must have both input and output boundaries to be transplantable
+  if (inputBoundarySet.size === 0 || outputBoundarySet.size === 0) return null;
+
+  const totalConnections = internalSynapses.length + externalConnectionCount;
+  const modularity = totalConnections > 0
+    ? internalSynapses.length / totalConnections
+    : 0;
+
+  return {
+    neuronUuids,
+    internalSynapses,
+    inputBoundaryUuids: [...inputBoundarySet],
+    outputBoundaryUuids: [...outputBoundarySet],
+    modularity,
+  };
+}
+
+/**
+ * Performs subgraph transplantation: extracts a subgraph from the father
+ * (donor) and transplants it into the mother (recipient).
+ *
+ * @param mother - The recipient creature (topology base)
+ * @param father - The donor creature (subgraph source)
+ * @returns A new offspring creature, or undefined if transplantation fails
+ */
+export function subgraphTransplant(
+  mother: Creature,
+  father: Creature,
+): Creature | undefined {
+  const rng = getRandomNumberGenerator();
+  const fatherExport = father.exportJSON();
+  const motherExport = mother.exportJSON();
+
+  // 1. Find candidate subgraphs in the donor
+  const subgraphs = extractSubgraphs(fatherExport);
+  if (subgraphs.length === 0) return undefined;
+
+  // Select a subgraph — prefer higher modularity but add some randomness
+  const selectedIndex = Math.min(
+    Math.floor(rng.random() * Math.min(subgraphs.length, 3)),
+    subgraphs.length - 1,
+  );
+  const subgraph = subgraphs[selectedIndex];
+
+  // 2. Build the offspring from the mother's topology
+  const offspringNeurons: NeuronExport[] = motherExport.neurons.map((n) => ({
+    ...n,
+  }));
+  const offspringSynapses: SynapseExport[] = motherExport.synapses.map((
+    s,
+  ) => ({ ...s }));
+
+  // 3. Map old subgraph UUIDs to new UUIDs for the transplanted neurons
+  const uuidMap = new Map<string, string>();
+  for (const oldUuid of subgraph.neuronUuids) {
+    uuidMap.set(oldUuid, crypto.randomUUID());
+  }
+
+  // Find donor neuron data for transplanted neurons
+  const donorNeuronMap = new Map<string, NeuronExport>();
+  for (const n of fatherExport.neurons) {
+    if (n.uuid && subgraph.neuronUuids.includes(n.uuid)) {
+      donorNeuronMap.set(n.uuid, n);
+    }
+  }
+
+  // Determine insertion position: find the last hidden neuron position in
+  // the offspring before output neurons
+  let insertIndex = offspringNeurons.length;
+  for (let i = offspringNeurons.length - 1; i >= 0; i--) {
+    if (offspringNeurons[i].type === "output") {
+      insertIndex = i;
+    } else {
+      break;
+    }
+  }
+
+  // 4. Add transplanted neurons (with new UUIDs and transplant tags)
+  const transplantedNeurons: NeuronExport[] = [];
+  for (const oldUuid of subgraph.neuronUuids) {
+    const donorNeuron = donorNeuronMap.get(oldUuid);
+    if (!donorNeuron) continue;
+
+    const newUuid = uuidMap.get(oldUuid)!;
+    const newNeuron: NeuronExport = {
+      type: "hidden",
+      uuid: newUuid,
+      squash: donorNeuron.squash,
+      bias: donorNeuron.bias,
+    };
+    addTag(newNeuron, "approach", "transplant");
+    transplantedNeurons.push(newNeuron);
+  }
+
+  // Insert transplanted neurons before output neurons
+  offspringNeurons.splice(insertIndex, 0, ...transplantedNeurons);
+
+  // 5. Add internal subgraph synapses (with remapped UUIDs)
+  for (const syn of subgraph.internalSynapses) {
+    const fromUUID = syn.fromUUID ? uuidMap.get(syn.fromUUID) : undefined;
+    const toUUID = syn.toUUID ? uuidMap.get(syn.toUUID) : undefined;
+    if (fromUUID && toUUID) {
+      offspringSynapses.push({
+        fromUUID,
+        toUUID,
+        weight: syn.weight,
+        type: syn.type,
+      });
+    }
+  }
+
+  // 6. Connect boundary inputs: link mother's input neurons to the
+  // transplanted subgraph's entry points
+  // Find the first neuron in the subgraph (topologically) — the one that
+  // receives external input
+  const subgraphEntryUuids = findSubgraphEntries(subgraph, fatherExport);
+  const subgraphExitUuids = findSubgraphExits(subgraph, fatherExport);
+
+  // Connect inputs to subgraph entries
+  for (const entryOldUuid of subgraphEntryUuids) {
+    const entryNewUuid = uuidMap.get(entryOldUuid);
+    if (!entryNewUuid) continue;
+
+    // Find what inputs fed this neuron in the father
+    for (const syn of fatherExport.synapses) {
+      if (syn.toUUID !== entryOldUuid || !syn.fromUUID) continue;
+
+      // If the source is an input neuron (input-N), connect it directly
+      if (syn.fromUUID.startsWith("input-")) {
+        offspringSynapses.push({
+          fromUUID: syn.fromUUID,
+          toUUID: entryNewUuid,
+          weight: syn.weight * (0.3 + rng.random() * 0.4),
+        });
+      }
+    }
+  }
+
+  // 7. Connect subgraph exits to mother's output-feeding neurons
+  // Find a hidden neuron in the mother that connects to output, or directly
+  // connect to output neurons
+  const motherOutputFeedingUuids = findOutputFeedingNeurons(motherExport);
+
+  for (const exitOldUuid of subgraphExitUuids) {
+    const exitNewUuid = uuidMap.get(exitOldUuid);
+    if (!exitNewUuid) continue;
+
+    if (motherOutputFeedingUuids.length > 0) {
+      // Connect to a random output-feeding neuron in the mother
+      // Use output neurons directly since they come after hidden neurons
+      const targetUuid = motherOutputFeedingUuids[
+        Math.floor(rng.random() * motherOutputFeedingUuids.length)
+      ];
+      offspringSynapses.push({
+        fromUUID: exitNewUuid,
+        toUUID: targetUuid,
+        weight: boundaryRandomWeight(rng) * 0.5,
+      });
+    }
+  }
+
+  // 8. Build and validate the offspring
+  const offspringJson: CreatureExport = {
+    input: motherExport.input,
+    output: motherExport.output,
+    neurons: offspringNeurons,
+    synapses: offspringSynapses,
+    forwardOnly: motherExport.forwardOnly,
+  };
+
+  let offspring: Creature;
+  try {
+    offspring = Creature.fromJSON(offspringJson);
+    offspring.fix();
+  } catch {
+    return undefined;
+  }
+
+  // Validate the offspring
+  try {
+    if (mother.forwardOnly) {
+      creatureValidate(offspring, { forwardOnly: true });
+    } else {
+      creatureValidate(offspring);
+    }
+  } catch {
+    return undefined;
+  }
+
+  // Reject clones
+  delete offspring.uuid;
+  const childUUID = CreatureUtil.makeUUID(offspring);
+  if (!childUUID) return undefined;
+
+  CreatureUtil.makeUUID(mother);
+  CreatureUtil.makeUUID(father);
+  if (childUUID === mother.uuid || childUUID === father.uuid) {
+    return undefined;
+  }
+
+  return offspring;
+}
+
+/**
+ * Finds subgraph entry neurons — those that receive connections from outside.
+ */
+function findSubgraphEntries(
+  subgraph: Subgraph,
+  _donorExport: CreatureExport,
+): string[] {
+  // Entry neurons are those in the subgraph that have input boundary connections
+  const neuronSet = new Set(subgraph.neuronUuids);
+  const hasInternalInbound = new Set<string>();
+
+  for (const syn of subgraph.internalSynapses) {
+    if (syn.toUUID && neuronSet.has(syn.toUUID)) {
+      hasInternalInbound.add(syn.toUUID);
+    }
+  }
+
+  // Entries are neurons that don't have internal inbound connections
+  // (they receive input from outside the subgraph)
+  const entries = subgraph.neuronUuids.filter(
+    (uuid) => !hasInternalInbound.has(uuid),
+  );
+
+  // If all neurons have internal inbound, return the first one
+  return entries.length > 0 ? entries : [subgraph.neuronUuids[0]];
+}
+
+/**
+ * Finds subgraph exit neurons — those that send connections to outside.
+ */
+function findSubgraphExits(
+  subgraph: Subgraph,
+  _donorExport: CreatureExport,
+): string[] {
+  const neuronSet = new Set(subgraph.neuronUuids);
+  const hasInternalOutbound = new Set<string>();
+
+  for (const syn of subgraph.internalSynapses) {
+    if (syn.fromUUID && neuronSet.has(syn.fromUUID)) {
+      hasInternalOutbound.add(syn.fromUUID);
+    }
+  }
+
+  // Exits are neurons that don't feed other neurons inside the subgraph
+  const exits = subgraph.neuronUuids.filter(
+    (uuid) => !hasInternalOutbound.has(uuid),
+  );
+
+  return exits.length > 0
+    ? exits
+    : [subgraph.neuronUuids[subgraph.neuronUuids.length - 1]];
+}
+
+/**
+ * Finds output neuron UUIDs in the mother that can receive transplant connections.
+ */
+function findOutputFeedingNeurons(motherExport: CreatureExport): string[] {
+  const outputUuids: string[] = [];
+  for (const n of motherExport.neurons) {
+    if (n.type === "output" && typeof n.uuid === "string") {
+      outputUuids.push(n.uuid);
+    }
+  }
+  return outputUuids;
+}
+
+/**
+ * Generates a small random weight for boundary connections.
+ */
+function boundaryRandomWeight(
+  rng: { random: () => number },
+): number {
+  const scale = 0.5;
+  const rawWeight = rng.random() * scale - scale / 2;
+  const plank = 0.000_000_1;
+  const weightUnit = Math.max(
+    Math.round(Math.abs(rawWeight / plank)),
+    1,
+  );
+  return Math.sign(rawWeight || 1) * weightUnit * plank;
+}

--- a/test/breed/SubgraphTransplant.ts
+++ b/test/breed/SubgraphTransplant.ts
@@ -1,0 +1,393 @@
+/**
+ * Tests for subgraph transplantation breeding strategy (Issue #2177).
+ *
+ * Subgraph transplantation extracts small, self-contained clusters of
+ * hidden neurons from a donor creature and transplants them into a
+ * recipient creature. This is a biologically-inspired horizontal gene
+ * transfer mechanism for inter-species breeding.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature, type CreatureExport, CreatureUtil } from "../../mod.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import { geneticCompatibility } from "@breed/GeneticCompatibility.ts";
+import {
+  extractSubgraphs,
+  subgraphTransplant,
+} from "@breed/SubgraphTransplant.ts";
+import { Offspring } from "@architecture/Offspring.ts";
+import { getTag } from "@stsoftware/tags/mod";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/**
+ * Builds a creature with a specific set of hidden neurons and connections.
+ */
+function buildCreature(
+  inputCount: number,
+  hiddenUUIDs: string[],
+  outputCount: number,
+  connections: Array<{ from: string; to: string; weight: number }>,
+  squash = "LOGISTIC",
+): Creature {
+  const neurons: CreatureExport["neurons"] = hiddenUUIDs.map((uuid) => ({
+    type: "hidden" as const,
+    uuid,
+    squash,
+    bias: 0.1,
+  }));
+  for (let i = 0; i < outputCount; i++) {
+    neurons.push({
+      type: "output",
+      uuid: `output-${i}`,
+      squash: "IDENTITY",
+      bias: 0,
+    });
+  }
+
+  const synapses = connections.map((c) => ({
+    fromUUID: c.from,
+    toUUID: c.to,
+    weight: c.weight,
+  }));
+
+  const json: CreatureExport = {
+    input: inputCount,
+    output: outputCount,
+    neurons,
+    synapses,
+  };
+  return Creature.fromJSON(json);
+}
+
+/**
+ * Creates a donor (father) creature with a clear subgraph cluster.
+ */
+function createDonorWithSubgraph(): Creature {
+  // Father: 3 inputs, 4 hidden neurons forming a subgraph cluster (fA, fB)
+  // plus two other neurons (fC, fD)
+  return buildCreature(
+    3,
+    ["fA", "fB", "fC", "fD"],
+    1,
+    [
+      // Subgraph cluster: fA -> fB (internal)
+      { from: "input-0", to: "fA", weight: 0.5 },
+      { from: "input-1", to: "fA", weight: -0.3 },
+      { from: "fA", to: "fB", weight: 0.8 },
+      { from: "fB", to: "output-0", weight: 0.6 },
+      // Other neurons
+      { from: "input-2", to: "fC", weight: 0.4 },
+      { from: "fC", to: "fD", weight: -0.5 },
+      { from: "fD", to: "output-0", weight: 0.3 },
+    ],
+  );
+}
+
+/**
+ * Creates a recipient (mother) creature with simple topology.
+ */
+function createRecipient(): Creature {
+  return buildCreature(
+    3,
+    ["mH1", "mH2"],
+    1,
+    [
+      { from: "input-0", to: "mH1", weight: 0.5 },
+      { from: "input-1", to: "mH1", weight: -0.3 },
+      { from: "input-2", to: "mH2", weight: 0.8 },
+      { from: "mH1", to: "mH2", weight: 0.4 },
+      { from: "mH2", to: "output-0", weight: 0.9 },
+    ],
+  );
+}
+
+Deno.test(
+  "extractSubgraphs finds connected hidden neuron clusters",
+  () => {
+    const donor = createDonorWithSubgraph();
+    const donorExport = donor.exportJSON();
+
+    const subgraphs = extractSubgraphs(donorExport);
+    assert(subgraphs.length > 0, "Should find at least one subgraph");
+
+    // Each subgraph should have between 2 and 5 neurons
+    for (const sg of subgraphs) {
+      assert(
+        sg.neuronUuids.length >= 2 && sg.neuronUuids.length <= 5,
+        `Subgraph should have 2-5 neurons, got ${sg.neuronUuids.length}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "extractSubgraphs returns subgraphs with internal connections",
+  () => {
+    const donor = createDonorWithSubgraph();
+    const donorExport = donor.exportJSON();
+
+    const subgraphs = extractSubgraphs(donorExport);
+    assert(subgraphs.length > 0, "Should find at least one subgraph");
+
+    // Each subgraph should have at least one internal synapse
+    for (const sg of subgraphs) {
+      assert(
+        sg.internalSynapses.length > 0,
+        "Each subgraph must have at least one internal connection",
+      );
+    }
+  },
+);
+
+Deno.test(
+  "subgraphTransplant produces valid offspring",
+  () => {
+    const mother = createRecipient();
+    const father = createDonorWithSubgraph();
+
+    const offspring = subgraphTransplant(mother, father);
+    assert(offspring, "Offspring should be created");
+
+    // Should pass creatureValidate without errors
+    creatureValidate(offspring);
+  },
+);
+
+Deno.test(
+  "subgraphTransplant produces valid forward-only offspring",
+  () => {
+    const mother = createRecipient();
+    mother.forwardOnly = true;
+    const father = createDonorWithSubgraph();
+    father.forwardOnly = true;
+
+    const offspring = subgraphTransplant(mother, father);
+    assert(offspring, "Forward-only offspring should be created");
+
+    creatureValidate(offspring, { forwardOnly: true });
+  },
+);
+
+Deno.test(
+  "subgraphTransplant tags transplanted neurons with approach: transplant",
+  () => {
+    const mother = createRecipient();
+    const father = createDonorWithSubgraph();
+
+    const offspring = subgraphTransplant(mother, father);
+    assert(offspring, "Offspring should be created");
+
+    const exported = offspring.exportJSON();
+    const motherUuids = new Set(
+      mother.exportJSON().neurons.map((n) => n.uuid),
+    );
+
+    // At least one neuron should be tagged as transplanted
+    let hasTransplantTag = false;
+    for (const n of exported.neurons) {
+      if (n.uuid && !motherUuids.has(n.uuid)) {
+        const approach = getTag(n, "approach");
+        if (approach === "transplant") {
+          hasTransplantTag = true;
+        }
+      }
+    }
+    assert(
+      hasTransplantTag,
+      "At least one transplanted neuron should have approach: transplant tag",
+    );
+  },
+);
+
+Deno.test(
+  "subgraphTransplant gives new UUIDs to transplanted neurons",
+  () => {
+    const mother = createRecipient();
+    const father = createDonorWithSubgraph();
+
+    const offspring = subgraphTransplant(mother, father);
+    assert(offspring, "Offspring should be created");
+
+    const exported = offspring.exportJSON();
+    const fatherUuids = new Set(
+      father.exportJSON().neurons.map((n) => n.uuid),
+    );
+
+    // Transplanted neurons should have new UUIDs (not reuse father's)
+    for (const n of exported.neurons) {
+      if (n.type === "hidden" && n.uuid) {
+        assert(
+          !fatherUuids.has(n.uuid),
+          `Transplanted neuron should have a new UUID, not reuse father's ${n.uuid}`,
+        );
+      }
+    }
+  },
+);
+
+Deno.test(
+  "subgraphTransplant preserves mother's input/output structure",
+  () => {
+    const mother = createRecipient();
+    const father = createDonorWithSubgraph();
+
+    const offspring = subgraphTransplant(mother, father);
+    assert(offspring, "Offspring should be created");
+
+    assertEquals(
+      offspring.input,
+      mother.input,
+      "Offspring should have same input count as mother",
+    );
+    assertEquals(
+      offspring.output,
+      mother.output,
+      "Offspring should have same output count as mother",
+    );
+  },
+);
+
+Deno.test(
+  "subgraphTransplant offspring has more hidden neurons than mother",
+  () => {
+    const mother = createRecipient();
+    const father = createDonorWithSubgraph();
+
+    const offspring = subgraphTransplant(mother, father);
+    assert(offspring, "Offspring should be created");
+
+    const motherHidden = mother.exportJSON().neurons.filter(
+      (n) => n.type === "hidden",
+    ).length;
+    const offspringHidden = offspring.exportJSON().neurons.filter(
+      (n) => n.type === "hidden",
+    ).length;
+
+    assert(
+      offspringHidden > motherHidden,
+      `Offspring should have more hidden neurons (${offspringHidden}) than mother (${motherHidden})`,
+    );
+  },
+);
+
+Deno.test(
+  "subgraphTransplant works with incompatible parents",
+  () => {
+    const mother = createRecipient();
+    const father = createDonorWithSubgraph();
+    CreatureUtil.makeUUID(mother);
+    CreatureUtil.makeUUID(father);
+
+    const compat = geneticCompatibility(mother, father);
+    assertEquals(
+      compat,
+      0,
+      "Parents with no shared hidden UUIDs should have 0 compatibility",
+    );
+
+    const offspring = subgraphTransplant(mother, father);
+    assert(offspring, "Should produce offspring from incompatible parents");
+    creatureValidate(offspring);
+  },
+);
+
+Deno.test(
+  "Offspring.breed can use subgraph transplant for very low compatibility",
+  () => {
+    const mother = createRecipient();
+    const father = createDonorWithSubgraph();
+    CreatureUtil.makeUUID(mother);
+    CreatureUtil.makeUUID(father);
+
+    // When compatibility is below interSpeciesCrossoverThreshold,
+    // Offspring.breed may use either inputWeightCrossover or
+    // subgraphTransplant. Run enough times to get an offspring.
+    let offspring: Creature | undefined;
+    for (let i = 0; i < 30; i++) {
+      offspring = Offspring.breed(mother, father, {
+        geneticCompatibilityThreshold: 0.3,
+        interSpeciesCrossoverThreshold: 0.1,
+      });
+      if (offspring) break;
+    }
+
+    assert(
+      offspring,
+      "Offspring should be created via inter-species breeding",
+    );
+    creatureValidate(offspring);
+  },
+);
+
+Deno.test(
+  "subgraphTransplant with single hidden neuron donor returns undefined",
+  () => {
+    // Donor with only 1 hidden neuron — can't form a 2+ subgraph
+    const father = buildCreature(
+      3,
+      ["fH1"],
+      1,
+      [
+        { from: "input-0", to: "fH1", weight: 0.5 },
+        { from: "fH1", to: "output-0", weight: 0.9 },
+      ],
+    );
+    const mother = createRecipient();
+
+    const offspring = subgraphTransplant(mother, father);
+    assertEquals(
+      offspring,
+      undefined,
+      "Should return undefined when donor has no viable subgraph",
+    );
+  },
+);
+
+Deno.test(
+  "subgraphTransplant with larger networks",
+  () => {
+    // Mother with deeper topology
+    const mother = buildCreature(
+      4,
+      ["mA", "mB", "mC", "mD"],
+      2,
+      [
+        { from: "input-0", to: "mA", weight: 0.5 },
+        { from: "input-1", to: "mA", weight: -0.3 },
+        { from: "input-2", to: "mB", weight: 0.8 },
+        { from: "input-3", to: "mB", weight: 0.2 },
+        { from: "mA", to: "mC", weight: 0.4 },
+        { from: "mB", to: "mC", weight: -0.6 },
+        { from: "mC", to: "mD", weight: 0.7 },
+        { from: "mD", to: "output-0", weight: 0.9 },
+        { from: "mC", to: "output-1", weight: -0.5 },
+      ],
+    );
+
+    // Father with different topology but rich subgraph potential
+    const father = buildCreature(
+      4,
+      ["fA", "fB", "fC", "fD", "fE"],
+      2,
+      [
+        { from: "input-0", to: "fA", weight: -0.7 },
+        { from: "input-1", to: "fB", weight: 0.6 },
+        { from: "input-2", to: "fA", weight: 0.2 },
+        { from: "input-3", to: "fC", weight: 0.3 },
+        { from: "fA", to: "fB", weight: -0.5 },
+        { from: "fB", to: "fC", weight: 0.8 },
+        { from: "fC", to: "fD", weight: 0.4 },
+        { from: "fD", to: "fE", weight: -0.3 },
+        { from: "fE", to: "output-0", weight: 0.7 },
+        { from: "fD", to: "output-1", weight: -0.2 },
+      ],
+    );
+
+    const offspring = subgraphTransplant(mother, father);
+    assert(offspring, "Should create offspring from larger networks");
+    creatureValidate(offspring);
+
+    assertEquals(offspring.input, 4);
+    assertEquals(offspring.output, 2);
+  },
+);


### PR DESCRIPTION
## Summary

Implement subgraph transplantation as a horizontal gene transfer breeding
strategy for inter-species breeding. When two creatures have very low genetic
compatibility, the system now randomly selects between input-weight crossover
(Issue #2175) and subgraph transplantation, falling back to the other if the
first strategy fails. Closes #2177.

Subgraph transplantation extracts small, self-contained clusters of 2-5
connected hidden neurons from a donor creature and transplants them (with new
UUIDs) into the recipient's topology. This is inspired by horizontal gene
transfer in prokaryotes and subtree crossover in genetic programming.

### Algorithm

1. **Extract subgraphs** from the donor: identify clusters of connected hidden
   neurons, scored by modularity (internal vs external connections)
2. **Select best subgraph** with slight randomisation among top candidates
3. **Transplant** into the mother's topology with new UUIDs, preserving internal
   connection weights
4. **Connect boundaries**: link donor's input sources to transplanted entry
   neurons; link transplanted exit neurons to mother's output neurons
5. **Validate** with `creatureValidate` (including forward-only constraint)
6. **Tag** transplanted neurons with `approach: "transplant"` for tracking

### Files Changed

- **New**: `src/breed/SubgraphTransplant.ts` — subgraph identification,
  extraction, scoring, and transplantation logic
- **New**: `test/breed/SubgraphTransplant.ts` — 12 unit tests
- **Modified**: `src/architecture/Offspring.ts` — integrated as alternative
  inter-species breeding path alongside input-weight crossover

## Evidence

All 5325 tests pass (0 failures, 3 ignored). The new module integrates
seamlessly with the existing breeding pipeline without requiring new
configuration options.

## Test Plan

- `extractSubgraphs finds connected hidden neuron clusters`
- `extractSubgraphs returns subgraphs with internal connections`
- `subgraphTransplant produces valid offspring`
- `subgraphTransplant produces valid forward-only offspring`
- `subgraphTransplant tags transplanted neurons with approach: transplant`
- `subgraphTransplant gives new UUIDs to transplanted neurons`
- `subgraphTransplant preserves mother's input/output structure`
- `subgraphTransplant offspring has more hidden neurons than mother`
- `subgraphTransplant works with incompatible parents`
- `Offspring.breed can use subgraph transplant for very low compatibility`
- `subgraphTransplant with single hidden neuron donor returns undefined`
- `subgraphTransplant with larger networks`

---

## Automated Fix Details
This PR addresses issue #2177: **Implement subgraph transplantation for horizontal gene transfer between species**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2177
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2177 -->