### PR TITLE
Always validate forward-only topology after creature initialisation (#2190)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2190.md
+++ b/docs/pr-summary-2190.md
@@ -1,20 +1,34 @@
 ## Summary
 
-Added a lightweight forward-only topology assertion that runs unconditionally after `initialize()`, not gated by `DEBUG`. This ensures all synapses in a forward-only creature satisfy `from < to` in production builds. If the invariant is violated, a `TopologyError` is thrown immediately rather than silently continuing with a corrupt topology. Closes #2190.
+Added a lightweight forward-only topology assertion that runs unconditionally
+after `initialize()`, not gated by `DEBUG`. This ensures all synapses in a
+forward-only creature satisfy `from < to` in production builds. If the invariant
+is violated, a `TopologyError` is thrown immediately rather than silently
+continuing with a corrupt topology. Closes #2190.
 
 ## Changes
 
-- **`src/Creature.ts`**: Added `assertForwardOnlyTopology()` public method that iterates over all synapses and verifies `from < to` when `forwardOnly === true`. Called unconditionally after `initialize()`.
-- **`test/architecture/ForwardOnlyInitValidation.ts`**: New test file with 4 tests covering backward synapse detection, self-connection detection, valid creature pass-through, and feedback creature no-op behaviour.
+- **`src/Creature.ts`**: Added `assertForwardOnlyTopology()` public method that
+  iterates over all synapses and verifies `from < to` when
+  `forwardOnly === true`. Called unconditionally after `initialize()`.
+- **`test/architecture/ForwardOnlyInitValidation.ts`**: New test file with 4
+  tests covering backward synapse detection, self-connection detection, valid
+  creature pass-through, and feedback creature no-op behaviour.
 
 ## Evidence
 
-The assertion is a single loop over synapses with no allocations — O(n) where n is the number of synapses. It adds negligible overhead to creature initialisation compared to the existing synapse sort and neuron fix operations.
+The assertion is a single loop over synapses with no allocations — O(n) where n
+is the number of synapses. It adds negligible overhead to creature
+initialisation compared to the existing synapse sort and neuron fix operations.
 
 ## Test Plan
 
-- `forward-only: initialisation assertion catches backward synapse` — confirms TopologyError is thrown when a backward synapse exists
-- `forward-only: initialisation assertion catches self-connection` — confirms TopologyError is thrown for self-connections
-- `forward-only: valid creature passes initialisation assertion` — confirms no error for correctly constructed creatures
-- `feedback creature: initialisation assertion is a no-op` — confirms the check is skipped for non-forward-only creatures
+- `forward-only: initialisation assertion catches backward synapse` — confirms
+  TopologyError is thrown when a backward synapse exists
+- `forward-only: initialisation assertion catches self-connection` — confirms
+  TopologyError is thrown for self-connections
+- `forward-only: valid creature passes initialisation assertion` — confirms no
+  error for correctly constructed creatures
+- `feedback creature: initialisation assertion is a no-op` — confirms the check
+  is skipped for non-forward-only creatures
 - All 5356 existing tests continue to pass

--- a/docs/pr-summary-2190.md
+++ b/docs/pr-summary-2190.md
@@ -1,0 +1,20 @@
+## Summary
+
+Added a lightweight forward-only topology assertion that runs unconditionally after `initialize()`, not gated by `DEBUG`. This ensures all synapses in a forward-only creature satisfy `from < to` in production builds. If the invariant is violated, a `TopologyError` is thrown immediately rather than silently continuing with a corrupt topology. Closes #2190.
+
+## Changes
+
+- **`src/Creature.ts`**: Added `assertForwardOnlyTopology()` public method that iterates over all synapses and verifies `from < to` when `forwardOnly === true`. Called unconditionally after `initialize()`.
+- **`test/architecture/ForwardOnlyInitValidation.ts`**: New test file with 4 tests covering backward synapse detection, self-connection detection, valid creature pass-through, and feedback creature no-op behaviour.
+
+## Evidence
+
+The assertion is a single loop over synapses with no allocations — O(n) where n is the number of synapses. It adds negligible overhead to creature initialisation compared to the existing synapse sort and neuron fix operations.
+
+## Test Plan
+
+- `forward-only: initialisation assertion catches backward synapse` — confirms TopologyError is thrown when a backward synapse exists
+- `forward-only: initialisation assertion catches self-connection` — confirms TopologyError is thrown for self-connections
+- `forward-only: valid creature passes initialisation assertion` — confirms no error for correctly constructed creatures
+- `feedback creature: initialisation assertion is a no-op` — confirms the check is skipped for non-forward-only creatures
+- All 5356 existing tests continue to pass

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -232,8 +232,42 @@ export class Creature implements CreatureInternal {
     if (!lazy) {
       this.initialize(options);
 
+      // Issue #2190: Always validate forward-only topology after initialisation,
+      // not just in DEBUG builds. This is a lightweight check that verifies
+      // all synapses satisfy `from < to`.
+      this.assertForwardOnlyTopology();
+
       if (this.DEBUG) {
         creatureValidate(this);
+      }
+    }
+  }
+
+  // ── Forward-only topology assertion ─────────────────────────────────
+
+  /**
+   * Lightweight assertion that all synapses satisfy `from < to` in
+   * forward-only creatures. Runs unconditionally (not gated by DEBUG)
+   * after initialisation to catch topology violations early.
+   *
+   * Issue #2190: Production builds previously skipped validation of
+   * freshly created creatures. This targeted check replaces the full
+   * `creatureValidate()` on the hot path.
+   *
+   * @throws {TopologyError} if any synapse has `from >= to` in a
+   *   forward-only creature.
+   */
+  assertForwardOnlyTopology(): void {
+    if (!this.forwardOnly) return;
+
+    for (let i = 0; i < this.synapses.length; i++) {
+      const s = this.synapses[i];
+      if (s.from >= s.to) {
+        throw new TopologyError(
+          `Synapse ${i} violates forward-only topology: ` +
+            `from ${s.from} must be < to ${s.to} (from < to)`,
+          "INVALID_CONNECTION",
+        );
       }
     }
   }

--- a/test/architecture/ForwardOnlyInitValidation.ts
+++ b/test/architecture/ForwardOnlyInitValidation.ts
@@ -1,0 +1,87 @@
+import { assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import { Synapse } from "@architecture/Synapse.ts";
+import { TopologyError } from "@errors/TopologyError.ts";
+
+/**
+ * Validates that forward-only topology assertion fires unconditionally
+ * after creature initialisation — not gated by DEBUG.
+ *
+ * Issue #2190: Production builds must verify that all synapses satisfy
+ * `from < to` in forward-only creatures immediately after initialisation.
+ */
+
+Deno.test(
+  "forward-only: initialisation assertion catches backward synapse",
+  () => {
+    // Create a valid forward-only creature, then tamper with a synapse
+    // to simulate a backward connection that slipped through initialisation.
+    const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+
+    // Creature should be forward-only by default
+    if (!creature.forwardOnly) {
+      throw new Error("Expected creature to be forward-only by default");
+    }
+
+    // Directly inject a backward synapse to simulate a bug in initialisation.
+    // We bypass connect() (which has its own guard) and push directly into
+    // the synapses array, then call the validation method.
+    const backwardSynapse = new Synapse(
+      creature.input + 1, // from: second hidden neuron
+      creature.input, // to: first hidden neuron (backward!)
+      0.5,
+    );
+
+    creature.synapses.push(backwardSynapse);
+
+    assertThrows(
+      () => creature.assertForwardOnlyTopology(),
+      TopologyError,
+      "from < to",
+    );
+  },
+);
+
+Deno.test(
+  "forward-only: initialisation assertion catches self-connection",
+  () => {
+    const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+
+    const selfSynapse = new Synapse(
+      creature.input, // from: first hidden neuron
+      creature.input, // to: same neuron (self-connection!)
+      0.5,
+    );
+
+    creature.synapses.push(selfSynapse);
+
+    assertThrows(
+      () => creature.assertForwardOnlyTopology(),
+      TopologyError,
+      "from < to",
+    );
+  },
+);
+
+Deno.test(
+  "forward-only: valid creature passes initialisation assertion",
+  () => {
+    // A normally constructed creature should not throw
+    const creature = new Creature(3, 2, { layers: [{ count: 3 }] });
+    creature.assertForwardOnlyTopology(); // should not throw
+  },
+);
+
+Deno.test(
+  "feedback creature: initialisation assertion is a no-op",
+  () => {
+    const creature = new Creature(2, 1, {
+      layers: [{ count: 1 }],
+      feedbackEnabled: true,
+    });
+
+    // For non-forward-only creatures, the assertion should not throw
+    // even if backward synapses exist
+    creature.assertForwardOnlyTopology(); // should be a no-op
+  },
+);


### PR DESCRIPTION
## Summary

Added a lightweight forward-only topology assertion that runs unconditionally after `initialize()`, not gated by `DEBUG`. This ensures all synapses in a forward-only creature satisfy `from < to` in production builds. If the invariant is violated, a `TopologyError` is thrown immediately rather than silently continuing with a corrupt topology. Closes #2190.

## Changes

- **`src/Creature.ts`**: Added `assertForwardOnlyTopology()` public method that iterates over all synapses and verifies `from < to` when `forwardOnly === true`. Called unconditionally after `initialize()`.
- **`test/architecture/ForwardOnlyInitValidation.ts`**: New test file with 4 tests covering backward synapse detection, self-connection detection, valid creature pass-through, and feedback creature no-op behaviour.

## Evidence

The assertion is a single loop over synapses with no allocations — O(n) where n is the number of synapses. It adds negligible overhead to creature initialisation compared to the existing synapse sort and neuron fix operations.

## Test Plan

- `forward-only: initialisation assertion catches backward synapse` — confirms TopologyError is thrown when a backward synapse exists
- `forward-only: initialisation assertion catches self-connection` — confirms TopologyError is thrown for self-connections
- `forward-only: valid creature passes initialisation assertion` — confirms no error for correctly constructed creatures
- `feedback creature: initialisation assertion is a no-op` — confirms the check is skipped for non-forward-only creatures
- All 5356 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)