### PR TITLE
Handle WASM panic errors gracefully in Fitness evaluation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.9.15",
+  "version": "2.9.16",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2211.md
+++ b/docs/pr-summary-2211.md
@@ -7,15 +7,16 @@ memory pressure at 95.9% heap), it returns `POSITIVE_INFINITY` as the evaluation
 error value. Previously, `Score.calculate()` would crash with
 `AssertionError: Error is not finite`, terminating the entire evolution process.
 
-Now `Fitness.processNext()` detects non-finite or negative error values and assigns
-`-Infinity` score to the affected creature, allowing natural selection to remove it
-gracefully without crashing. Worker error details are logged as warnings for
-diagnostics.
+Now `Fitness.processNext()` detects non-finite or negative error values and
+assigns `-Infinity` score to the affected creature, allowing natural selection
+to remove it gracefully without crashing. Worker error details are logged as
+warnings for diagnostics.
 
 ## Evidence
 
 The fix handles the exact crash path observed in the production log
 (`GRQ-12-nigel.log`):
+
 1. `[MemoryMonitor] Critical-level response: cleared all WASM caches`
 2. `RuntimeError: unreachable` in `mse_sum_batch_packed`
 3. Previously: `AssertionError: Error is not finite` (process crash)

--- a/docs/pr-summary-2211.md
+++ b/docs/pr-summary-2211.md
@@ -1,0 +1,31 @@
+## Summary
+
+Handle WASM panic errors gracefully in Fitness evaluation. Closes #2211.
+
+When a worker encounters a WASM `RuntimeError: unreachable` (e.g. under critical
+memory pressure at 95.9% heap), it returns `POSITIVE_INFINITY` as the evaluation
+error value. Previously, `Score.calculate()` would crash with
+`AssertionError: Error is not finite`, terminating the entire evolution process.
+
+Now `Fitness.processNext()` detects non-finite or negative error values and assigns
+`-Infinity` score to the affected creature, allowing natural selection to remove it
+gracefully without crashing. Worker error details are logged as warnings for
+diagnostics.
+
+## Evidence
+
+The fix handles the exact crash path observed in the production log
+(`GRQ-12-nigel.log`):
+1. `[MemoryMonitor] Critical-level response: cleared all WASM caches`
+2. `RuntimeError: unreachable` in `mse_sum_batch_packed`
+3. Previously: `AssertionError: Error is not finite` (process crash)
+4. Now: creature gets `-Infinity` score and is removed by selection
+
+## Test Plan
+
+- Added `test/architecture/FitnessWasmPanicRecovery.ts` with 4 tests:
+  - WASM panic (`POSITIVE_INFINITY` error) returns `-Infinity` score
+  - `NaN` error returns `-Infinity` score
+  - Negative error returns `-Infinity` score
+  - Valid error values still score normally (regression guard)
+- All 5451 existing tests continue to pass

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -145,9 +145,25 @@ export class Fitness {
 
       const error = responseData.evaluate.error;
       delete responseData.evaluate;
-      addTag(creature, "error", error.toString());
 
-      creature.score = calculateScore(creature, error, this.growth);
+      // Issue #2211: When a worker encounters a WASM panic (RuntimeError:
+      // unreachable), it returns POSITIVE_INFINITY as the error value.
+      // Rather than crashing the entire evolution with an assertion failure
+      // in Score.calculate(), assign the worst possible score so natural
+      // selection removes the creature gracefully.
+      if (!Number.isFinite(error) || error < 0) {
+        if (responseData.error) {
+          getLogger().warn(
+            `Worker error for creature ${creature.uuid ?? "unknown"}: ` +
+              `${responseData.error.name}: ${responseData.error.message}`,
+          );
+        }
+        addTag(creature, "error", "Infinity");
+        creature.score = -Infinity;
+      } else {
+        addTag(creature, "error", error.toString());
+        creature.score = calculateScore(creature, error, this.growth);
+      }
       addTag(creature, "score", creature.score.toString());
 
       // Issue #1016: Copy score and tags to duplicate creatures

--- a/test/architecture/FitnessWasmPanicRecovery.ts
+++ b/test/architecture/FitnessWasmPanicRecovery.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests verifying Fitness handles WASM panic errors gracefully.
+ *
+ * Issue #2211: When a worker encounters a WASM RuntimeError: unreachable
+ * (e.g. under memory pressure), the worker returns POSITIVE_INFINITY as the
+ * error value. Fitness must assign the worst possible score (-Infinity) to
+ * such creatures instead of crashing the entire evolution with an assertion
+ * failure in Score.calculate().
+ */
+import { assertEquals } from "@std/assert";
+import { getTag } from "@stsoftware/tags/mod";
+import { Fitness } from "@architecture/Fitness.ts";
+import { Creature } from "@creature";
+
+Deno.test("Fitness calculate - WASM panic returns -Infinity score instead of crashing", async () => {
+  const creature = new Creature(2, 1);
+  creature.score = undefined;
+
+  // Simulate a worker that returns POSITIVE_INFINITY error (as the real
+  // worker does when WASM panics with RuntimeError: unreachable).
+  const mockWorker = {
+    evaluate: () =>
+      Promise.resolve({
+        taskID: 1,
+        duration: 10,
+        error: {
+          name: "RuntimeError",
+          message: "unreachable",
+          stack: "at wasm://...",
+        },
+        evaluate: { error: Number.POSITIVE_INFINITY },
+      }),
+    isRunningLongTask: () => false,
+  };
+
+  const fitness = new Fitness(
+    // deno-lint-ignore no-explicit-any
+    [mockWorker as any],
+    0.0001,
+    false,
+  );
+
+  // Should NOT throw — the creature gets the worst score gracefully.
+  await fitness.calculate([creature]);
+
+  assertEquals(creature.score, -Infinity);
+  assertEquals(getTag(creature, "error"), "Infinity");
+  assertEquals(getTag(creature, "score"), "-Infinity");
+});
+
+Deno.test("Fitness calculate - NaN error returns -Infinity score instead of crashing", async () => {
+  const creature = new Creature(2, 1);
+  creature.score = undefined;
+
+  const mockWorker = {
+    evaluate: () =>
+      Promise.resolve({
+        taskID: 1,
+        duration: 10,
+        evaluate: { error: Number.NaN },
+      }),
+    isRunningLongTask: () => false,
+  };
+
+  const fitness = new Fitness(
+    // deno-lint-ignore no-explicit-any
+    [mockWorker as any],
+    0.0001,
+    false,
+  );
+
+  await fitness.calculate([creature]);
+
+  assertEquals(creature.score, -Infinity);
+});
+
+Deno.test("Fitness calculate - negative error returns -Infinity score instead of crashing", async () => {
+  const creature = new Creature(2, 1);
+  creature.score = undefined;
+
+  const mockWorker = {
+    evaluate: () =>
+      Promise.resolve({
+        taskID: 1,
+        duration: 10,
+        evaluate: { error: -1 },
+      }),
+    isRunningLongTask: () => false,
+  };
+
+  const fitness = new Fitness(
+    // deno-lint-ignore no-explicit-any
+    [mockWorker as any],
+    0.0001,
+    false,
+  );
+
+  await fitness.calculate([creature]);
+
+  assertEquals(creature.score, -Infinity);
+});
+
+Deno.test("Fitness calculate - valid error still scores normally", async () => {
+  const creature = new Creature(2, 1);
+  creature.score = undefined;
+
+  const mockWorker = {
+    evaluate: () =>
+      Promise.resolve({
+        taskID: 1,
+        duration: 10,
+        evaluate: { error: 0.5 },
+      }),
+    isRunningLongTask: () => false,
+  };
+
+  const fitness = new Fitness(
+    // deno-lint-ignore no-explicit-any
+    [mockWorker as any],
+    0.0001,
+    false,
+  );
+
+  await fitness.calculate([creature]);
+
+  // Score should be finite and less than 1 (since error = 0.5)
+  assertEquals(typeof creature.score, "number");
+  assertEquals(Number.isFinite(creature.score!), true);
+  assertEquals(creature.score! < 1, true);
+});


### PR DESCRIPTION
## Summary

Handle WASM panic errors gracefully in Fitness evaluation. Closes #2211.

When a worker encounters a WASM `RuntimeError: unreachable` (e.g. under critical
memory pressure at 95.9% heap), it returns `POSITIVE_INFINITY` as the evaluation
error value. Previously, `Score.calculate()` would crash with
`AssertionError: Error is not finite`, terminating the entire evolution process.

Now `Fitness.processNext()` detects non-finite or negative error values and
assigns `-Infinity` score to the affected creature, allowing natural selection
to remove it gracefully without crashing. Worker error details are logged as
warnings for diagnostics.

## Evidence

The fix handles the exact crash path observed in the production log
(`GRQ-12-nigel.log`):

1. `[MemoryMonitor] Critical-level response: cleared all WASM caches`
2. `RuntimeError: unreachable` in `mse_sum_batch_packed`
3. Previously: `AssertionError: Error is not finite` (process crash)
4. Now: creature gets `-Infinity` score and is removed by selection

## Test Plan

- Added `test/architecture/FitnessWasmPanicRecovery.ts` with 4 tests:
  - WASM panic (`POSITIVE_INFINITY` error) returns `-Infinity` score
  - `NaN` error returns `-Infinity` score
  - Negative error returns `-Infinity` score
  - Valid error values still score normally (regression guard)
- All 5451 existing tests continue to pass

---

## Automated Fix Details
This PR addresses issue #2211: **Rust/WASM not reachable**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2211
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2211 -->