### PR TITLE
Update all documentation for MCMC, breeding, and WASM recovery (#2210)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,16 @@ machine-learning idea:
 - **Layer assignment** is the topological ordering of neurons into discrete
   layers based on longest-path distance from input neurons, used by synthetic
   synapse generation to determine which neuron pairs are in adjacent layers.
+- **MCMC acceptance** refers to the
+  [Metropolis-Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)
+  criterion applied to mutation acceptance. Instead of accepting all mutations
+  unconditionally, worsening mutations are accepted with a temperature-dependent
+  probability, enabling escape from local optima early and convergence later.
+- **Horizontal gene transfer** describes the subgraph transplantation breeding
+  strategy that copies connected subgraphs between genetically incompatible
+  creatures, inspired by
+  [horizontal gene transfer](https://en.wikipedia.org/wiki/Horizontal_gene_transfer)
+  in microbiology.
 
 If you spot another fun label, expect it to be backed by a reference to the
 standard term the first time it appears.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,25 @@ For project terminology, coding conventions, and development guidelines, see
     inference pipelines, bridging the gap between neuroevolution and production
     deployment.
 
-20. **Synthetic Synapse Training**: Temporarily densifies inter-layer
+20. **MCMC Mutation Acceptance**: Uses the
+    [Metropolis-Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)
+    criterion for mutation acceptance. Instead of unconditionally accepting all
+    mutations, worse-fitness moves are accepted with a probability that
+    decreases as temperature cools — enabling the population to escape local
+    optima early and converge later. Includes adaptive temperature tuning toward
+    the theoretically optimal acceptance rate (~23.4%, Roberts et al. 1997).
+    Opt-in via `mcmc: { enabled: true }` in the configuration.
+
+21. **Advanced Breeding Strategies**: Multiple breeding strategies for
+    genetically incompatible creatures, including input-weight cosine similarity
+    for neuron alignment, subgraph transplantation for horizontal gene transfer,
+    and diversity-driven breeding for cross-population pairing. These strategies
+    preserve genetic diversity while enabling meaningful crossover between
+    structurally different creatures, inspired by
+    [horizontal gene transfer](https://en.wikipedia.org/wiki/Horizontal_gene_transfer)
+    in biology.
+
+22. **Synthetic Synapse Training**: Temporarily densifies inter-layer
     connectivity during backpropagation by adding zero-weight synapses between
     adjacent topological layers. After training, near-zero synapses are pruned
     and only the useful connections are retained — addressing NEAT's inherent

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.9.16",
+  "version": "2.9.17",
   "publish": {
     "include": [
       "README.md",

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -30,6 +30,7 @@ import { Costs, Creature, Mutation, Selection } from "@stsoftware/neat-ai";
 16. [Transfer Learning](#16-transfer-learning)
 17. [ONNX Export](#17-onnx-export)
 18. [Synthetic Synapses](#18-synthetic-synapses)
+19. [MCMC Acceptance Criterion](#19-mcmc-acceptance-criterion)
 
 ---
 
@@ -1365,6 +1366,74 @@ indices in that layer.
 - Hidden neurons → layer based on longest path from inputs
 - Output neurons → always placed in the final layer
 - Recurrent connections and self-loops are ignored
+
+---
+
+## 19. 🎲 MCMC Acceptance Criterion
+
+Issue #2199: Markov Chain Monte Carlo (MCMC) temperature-based acceptance for
+the Metropolis-Hastings criterion. Instead of unconditionally accepting all
+mutations, MCMC acceptance allows worse-fitness moves with a probability that
+decreases as temperature cools, enabling the population to escape local optima
+early and converge later.
+
+```typescript
+import { DEFAULT_MCMC_CONFIG } from "@stsoftware/neat-ai";
+
+import type { MCMCConfig, RequiredMCMCConfig } from "@stsoftware/neat-ai";
+```
+
+### Configuration
+
+Pass as `mcmc` in `NeatOptions`:
+
+```typescript
+const options: NeatOptions = {
+  mcmc: {
+    enabled: true,
+    initialTemperature: 1.0,
+    coolingRate: 0.995,
+  },
+};
+```
+
+### `MCMCConfig`
+
+| Field                  | Type      | Default | Description                                                         |
+| ---------------------- | --------- | ------- | ------------------------------------------------------------------- |
+| `enabled`              | `boolean` | `false` | Whether MCMC acceptance is active                                   |
+| `initialTemperature`   | `number`  | `1.0`   | Starting temperature for Metropolis-Hastings acceptance             |
+| `minTemperature`       | `number`  | `0.01`  | Floor temperature to prevent acceptance probability reaching zero   |
+| `coolingRate`          | `number`  | `0.995` | Multiplicative cooling factor applied per generation                |
+| `targetAcceptanceRate` | `number`  | `0.234` | Optimal acceptance rate for high-dimensional MCMC                   |
+| `adjustmentRate`       | `number`  | `0.02`  | Rate at which temperature adapts toward the target acceptance rate  |
+| `toleranceRate`        | `number`  | `0.05`  | Tolerance band around target rate within which no adjustment occurs |
+
+### `DEFAULT_MCMC_CONFIG`
+
+Pre-populated `RequiredMCMCConfig` with all defaults. Spread it and override
+individual fields:
+
+```typescript
+const myConfig: MCMCConfig = {
+  ...DEFAULT_MCMC_CONFIG,
+  enabled: true,
+  coolingRate: 0.99, // faster cooling
+};
+```
+
+### Acceptance Behaviour
+
+- **Improving mutations** (lower cost) are always accepted
+- **Worsening mutations** are accepted with probability
+  `exp(-deltaCost / temperature)`
+- **Topology mutations** (add/remove node or connection, swap nodes, change
+  squash) are always accepted unconditionally
+- **Adaptive tuning** (Issue #2201): temperature automatically adjusts toward
+  the target acceptance rate each generation
+
+For configuration details, see
+[Configuration Guide — MCMC](CONFIGURATION_GUIDE.md#mcmc-acceptance-criterion).
 
 ---
 

--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -37,6 +37,7 @@ CLI arguments or environment variables without pre-parsing.
 - [Data Fuzzing](#data-fuzzing)
 - [Cross-Validation](#cross-validation)
 - [Hyperparameter Evolution](#hyperparameter-evolution)
+- [MCMC Acceptance Criterion](#mcmc-acceptance-criterion)
 - [Adaptive Population Sizing](#adaptive-population-sizing)
 - [Parallel Evaluation](#parallel-evaluation)
 - [Logging and Reproducibility](#logging-and-reproducibility)
@@ -1021,6 +1022,66 @@ Each creature evolves these values within the configured bounds:
 | `weightPerturbationScale`  | `1.0`   | Weight perturbation magnitude scaling factor       |
 | `l1RegularisationStrength` | `0`     | L1 regularisation strength for backpropagation     |
 | `l2RegularisationStrength` | `0`     | L2 regularisation strength for backpropagation     |
+
+---
+
+## 🎲 MCMC Acceptance Criterion
+
+Issue #2199: Markov Chain Monte Carlo (MCMC) acceptance applies the
+[Metropolis-Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)
+criterion to mutation acceptance. Instead of unconditionally accepting all
+mutations, worse-fitness moves are accepted with a probability that decreases as
+temperature cools. This enables the population to escape local optima early in
+evolution and converge to precise solutions later.
+
+The acceptance probability follows:
+
+```
+P(accept) = min(1, exp(-deltaCost / temperature))
+```
+
+Temperature follows an exponential cooling schedule with adaptive tuning (Issue
+#2201) that adjusts temperature toward the theoretically optimal acceptance rate
+of ~23.4% (Roberts et al. 1997).
+
+Pass as `mcmc` in options.
+
+```ts
+const config = createNeatConfig({
+  mcmc: {
+    enabled: true,
+    initialTemperature: 1.0,
+    coolingRate: 0.995,
+  },
+});
+```
+
+| Option                 | Type      | Default | Description                                                         |
+| ---------------------- | --------- | ------- | ------------------------------------------------------------------- |
+| `enabled`              | `boolean` | `false` | Whether MCMC acceptance is active                                   |
+| `initialTemperature`   | `number`  | `1.0`   | Starting temperature for Metropolis-Hastings acceptance             |
+| `minTemperature`       | `number`  | `0.01`  | Floor temperature to prevent acceptance probability reaching zero   |
+| `coolingRate`          | `number`  | `0.995` | Multiplicative cooling factor applied per generation                |
+| `targetAcceptanceRate` | `number`  | `0.234` | Optimal acceptance rate for high-dimensional MCMC                   |
+| `adjustmentRate`       | `number`  | `0.02`  | Rate at which temperature adapts toward the target acceptance rate  |
+| `toleranceRate`        | `number`  | `0.05`  | Tolerance band around target rate within which no adjustment occurs |
+
+**How it works:**
+
+- **Improving mutations** (lower cost) are always accepted
+- **Worsening mutations** are accepted with probability
+  `exp(-deltaCost / temperature)`
+- **Topology mutations** (add/remove nodes or connections) are always accepted
+  unconditionally, since discrete structural changes do not lend themselves to
+  continuous cost comparison
+- **Adaptive tuning** (Issue #2201): after each generation, the smoothed
+  acceptance rate is compared to the target. If acceptance is too high the
+  temperature decreases; if too low it increases
+
+> [!TIP]
+> MCMC works well alongside plateau detection. Plateau detection adjusts _how
+> much_ mutation happens, while MCMC temperature adjusts _which mutations
+> stick_. Enable both for robust exploration-exploitation balance.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -648,6 +648,36 @@ and/or `--allow-net` permissions.
   ```
 - Reduce parallel creature count or population size.
 
+### 💥 WASM Panic Recovery
+
+**Symptoms:**
+
+- `RuntimeError: unreachable` thrown from within WASM activation
+- Subsequent activation or dispose calls fail with ownership errors
+
+**Cause:** A WASM panic (e.g., from an assertion failure in the Rust activation
+code) leaves the WASM instance in an unrecoverable state. Prior to Issue #2207
+and #2212, attempting to dispose a creature after a WASM panic would throw a
+second error, and fitness evaluation would propagate the panic as an
+unrecoverable crash.
+
+**Current behaviour (Issue #2207, #2212):**
+
+- **Fitness evaluation** now catches WASM panics gracefully and assigns the
+  worst possible fitness score to the affected creature, allowing evolution to
+  continue with the rest of the population.
+- **Disposal after panic** detects the corrupted WASM state and skips the normal
+  disposal path, preventing secondary errors from masking the original panic.
+- **Logging** records the panic details so the root cause can be investigated.
+
+**What you should do:**
+
+- If panics are frequent, check for numerical overflow in your training data or
+  extreme weight/bias values. Enable weight and bias regularisation to prevent
+  extreme values.
+- WASM panics are non-deterministic in multi-threaded workloads — a single panic
+  does not indicate a systematic problem.
+
 ---
 
 ## 🦀 Discovery Library

--- a/docs/pr-summary-2210.md
+++ b/docs/pr-summary-2210.md
@@ -1,8 +1,9 @@
 ## Summary
 
-Updated all documentation to reflect recent improvements, primarily covering
-the MCMC acceptance criterion (Issues #2199–#2202), advanced breeding strategies
-(Issues #2175–#2183), and WASM panic recovery (Issues #2207, #2212). Closes #2210.
+Updated all documentation to reflect recent improvements, primarily covering the
+MCMC acceptance criterion (Issues #2199–#2202), advanced breeding strategies
+(Issues #2175–#2183), and WASM panic recovery (Issues #2207, #2212). Closes
+#2210.
 
 ### Changes
 

--- a/docs/pr-summary-2210.md
+++ b/docs/pr-summary-2210.md
@@ -1,0 +1,32 @@
+## Summary
+
+Updated all documentation to reflect recent improvements, primarily covering
+the MCMC acceptance criterion (Issues #2199–#2202), advanced breeding strategies
+(Issues #2175–#2183), and WASM panic recovery (Issues #2207, #2212). Closes #2210.
+
+### Changes
+
+- **mod.ts**: Export `MCMCConfig`, `RequiredMCMCConfig`, and
+  `DEFAULT_MCMC_CONFIG` from the public API
+- **docs/CONFIGURATION_GUIDE.md**: Add MCMC Acceptance Criterion section with
+  all configuration options, defaults, and usage examples
+- **docs/API_REFERENCE.md**: Add section 19 (MCMC Acceptance Criterion) with
+  type references, configuration table, and usage patterns
+- **README.md**: Add feature highlights for MCMC Mutation Acceptance (#20) and
+  Advanced Breeding Strategies (#21)
+- **AGENTS.md**: Add MCMC acceptance and horizontal gene transfer to the
+  terminology glossary
+- **docs/TROUBLESHOOTING.md**: Add WASM Panic Recovery section documenting
+  graceful panic handling in fitness evaluation and disposal
+
+## Evidence
+
+All 5457 tests pass, including new documentation accuracy tests that verify
+documented defaults match actual code values.
+
+## Test Plan
+
+- Added `test/config/MCMCConfigDocumentation.ts` — verifies MCMCConfig is
+  properly exported from mod.ts and defaults match documentation
+- Added MCMC defaults test to `test/config/ConfigurationGuideDefaults.ts` —
+  verifies CONFIGURATION_GUIDE.md default values match code

--- a/mod.ts
+++ b/mod.ts
@@ -94,6 +94,20 @@ export {
 } from "@config/HyperparameterConfig.ts";
 
 /**
+ * MCMC Acceptance Criterion
+ *
+ * Issue #2199: Markov Chain Monte Carlo (MCMC) temperature-based acceptance
+ * for Metropolis-Hastings mutation acceptance. Instead of unconditionally
+ * accepting all mutations, MCMC acceptance allows worse-fitness moves with
+ * a probability that decreases as temperature cools, enabling the population
+ * to escape local optima early and converge later.
+ *
+ * @see {@link module:src/config/MCMCConfig}
+ */
+export type { MCMCConfig, RequiredMCMCConfig } from "@config/MCMCConfig.ts";
+export { DEFAULT_MCMC_CONFIG } from "@config/MCMCConfig.ts";
+
+/**
  * Adaptive Population Sizing
  *
  * Issue #1863: Automatically adjust population size based on

--- a/test/config/ConfigurationGuideDefaults.ts
+++ b/test/config/ConfigurationGuideDefaults.ts
@@ -28,6 +28,7 @@ import {
   DEFAULT_RUST_FLUSH_BYTES,
   DEFAULT_RUST_FLUSH_RECORDS,
 } from "@architecture/ErrorGuidedStructuralEvolution/constants.ts";
+import { DEFAULT_MCMC_CONFIG } from "@config/MCMCConfig.ts";
 
 Deno.test("Configuration guide - core evolution defaults match code", () => {
   const config = createNeatConfig({});
@@ -160,6 +161,17 @@ Deno.test("Configuration guide - fine-tune population defaults match code", () =
   assertEquals(defaults.maxPopulationFraction, 0.4);
   assertEquals(defaults.basePopulationFraction, 0.2);
   assertEquals(defaults.successRateWindow, 10);
+});
+
+Deno.test("Configuration guide - MCMC defaults match code", () => {
+  const defaults = DEFAULT_MCMC_CONFIG;
+  assertEquals(defaults.enabled, false);
+  assertEquals(defaults.initialTemperature, 1.0);
+  assertEquals(defaults.minTemperature, 0.01);
+  assertEquals(defaults.coolingRate, 0.995);
+  assertEquals(defaults.targetAcceptanceRate, 0.234);
+  assertEquals(defaults.adjustmentRate, 0.02);
+  assertEquals(defaults.toleranceRate, 0.05);
 });
 
 Deno.test("Configuration guide - discovery replay defaults match code", () => {

--- a/test/config/MCMCConfigDocumentation.ts
+++ b/test/config/MCMCConfigDocumentation.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests that verify MCMC configuration documentation accuracy.
+ *
+ * Issue #2210: These tests ensure the MCMC defaults documented in
+ * CONFIGURATION_GUIDE.md and API_REFERENCE.md match the actual code,
+ * and that MCMCConfig is properly exported from the public API.
+ */
+
+import { assertEquals } from "@std/assert";
+import { DEFAULT_MCMC_CONFIG } from "@config/MCMCConfig.ts";
+import type { MCMCConfig, RequiredMCMCConfig } from "@config/MCMCConfig.ts";
+
+// Verify public API exports work
+import { DEFAULT_MCMC_CONFIG as PUBLIC_DEFAULT } from "../../mod.ts";
+import type {
+  MCMCConfig as PublicMCMCConfig,
+  RequiredMCMCConfig as PublicRequiredMCMCConfig,
+} from "../../mod.ts";
+
+Deno.test("MCMC documentation - defaults match CONFIGURATION_GUIDE values", () => {
+  // These values are documented in docs/CONFIGURATION_GUIDE.md
+  assertEquals(DEFAULT_MCMC_CONFIG.enabled, false);
+  assertEquals(DEFAULT_MCMC_CONFIG.initialTemperature, 1.0);
+  assertEquals(DEFAULT_MCMC_CONFIG.minTemperature, 0.01);
+  assertEquals(DEFAULT_MCMC_CONFIG.coolingRate, 0.995);
+  assertEquals(DEFAULT_MCMC_CONFIG.targetAcceptanceRate, 0.234);
+  assertEquals(DEFAULT_MCMC_CONFIG.adjustmentRate, 0.02);
+  assertEquals(DEFAULT_MCMC_CONFIG.toleranceRate, 0.05);
+});
+
+Deno.test("MCMC documentation - public API exports match internal defaults", () => {
+  // Verify mod.ts re-exports the same DEFAULT_MCMC_CONFIG
+  assertEquals(PUBLIC_DEFAULT, DEFAULT_MCMC_CONFIG);
+  assertEquals(PUBLIC_DEFAULT.enabled, false);
+  assertEquals(PUBLIC_DEFAULT.initialTemperature, 1.0);
+  assertEquals(PUBLIC_DEFAULT.coolingRate, 0.995);
+  assertEquals(PUBLIC_DEFAULT.targetAcceptanceRate, 0.234);
+});
+
+Deno.test("MCMC documentation - MCMCConfig type is usable from public API", () => {
+  // Verify the type is properly exported and usable
+  const config: PublicMCMCConfig = {
+    enabled: true,
+    initialTemperature: 2.0,
+  };
+  assertEquals(config.enabled, true);
+  assertEquals(config.initialTemperature, 2.0);
+});
+
+Deno.test("MCMC documentation - RequiredMCMCConfig type is usable from public API", () => {
+  // Verify the required type is properly exported and all fields are present
+  const config: PublicRequiredMCMCConfig = {
+    enabled: true,
+    initialTemperature: 1.5,
+    minTemperature: 0.01,
+    coolingRate: 0.99,
+    targetAcceptanceRate: 0.234,
+    adjustmentRate: 0.02,
+    toleranceRate: 0.05,
+  };
+  assertEquals(config.enabled, true);
+  assertEquals(config.initialTemperature, 1.5);
+  assertEquals(config.coolingRate, 0.99);
+});
+
+Deno.test("MCMC documentation - internal and public types are compatible", () => {
+  // Verify the internal and public types are the same
+  const internal: MCMCConfig = { enabled: true };
+  const external: PublicMCMCConfig = internal;
+  assertEquals(external.enabled, true);
+
+  const internalRequired: RequiredMCMCConfig = { ...DEFAULT_MCMC_CONFIG };
+  const externalRequired: PublicRequiredMCMCConfig = internalRequired;
+  assertEquals(externalRequired.enabled, DEFAULT_MCMC_CONFIG.enabled);
+});


### PR DESCRIPTION
## Summary

Updated all documentation to reflect recent improvements, primarily covering the
MCMC acceptance criterion (Issues #2199–#2202), advanced breeding strategies
(Issues #2175–#2183), and WASM panic recovery (Issues #2207, #2212). Closes
#2210.

### Changes

- **mod.ts**: Export `MCMCConfig`, `RequiredMCMCConfig`, and
  `DEFAULT_MCMC_CONFIG` from the public API
- **docs/CONFIGURATION_GUIDE.md**: Add MCMC Acceptance Criterion section with
  all configuration options, defaults, and usage examples
- **docs/API_REFERENCE.md**: Add section 19 (MCMC Acceptance Criterion) with
  type references, configuration table, and usage patterns
- **README.md**: Add feature highlights for MCMC Mutation Acceptance (#20) and
  Advanced Breeding Strategies (#21)
- **AGENTS.md**: Add MCMC acceptance and horizontal gene transfer to the
  terminology glossary
- **docs/TROUBLESHOOTING.md**: Add WASM Panic Recovery section documenting
  graceful panic handling in fitness evaluation and disposal

## Evidence

All 5457 tests pass, including new documentation accuracy tests that verify
documented defaults match actual code values.

## Test Plan

- Added `test/config/MCMCConfigDocumentation.ts` — verifies MCMCConfig is
  properly exported from mod.ts and defaults match documentation
- Added MCMC defaults test to `test/config/ConfigurationGuideDefaults.ts` —
  verifies CONFIGURATION_GUIDE.md default values match code

---

## Automated Fix Details
This PR addresses issue #2210: **Please update all documentation**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2210
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2210 -->