### PR TITLE
Extract shared numeric validation helper to reduce repeated assertions (#2222)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.9.23",
+  "version": "2.9.24",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2222.md
+++ b/docs/pr-summary-2222.md
@@ -2,14 +2,15 @@
 
 Extract shared numeric validation helpers (`assertFiniteNonNegative` and
 `assertFiniteNumber`) into `src/utils/NumericValidation.ts` to eliminate
-repeated NaN/finite/non-negative assertion patterns across `Score.ts`.
-Closes #2222.
+repeated NaN/finite/non-negative assertion patterns across `Score.ts`. Closes
+#2222.
 
 ## Changes
 
 - **New file `src/utils/NumericValidation.ts`**: Two helpers:
   - `assertFiniteNonNegative(value, name)` — asserts not NaN, finite, and >= 0
-  - `assertFiniteNumber(value, name)` — asserts not NaN and finite (allows negative)
+  - `assertFiniteNumber(value, name)` — asserts not NaN and finite (allows
+    negative)
 - **`src/architecture/Score.ts`**: Replaced 15 individual assertion calls with
   helper calls across `calculate()`, `calculatePenalty()`,
   `computeAndCacheScoreComponents()`, `updateScoreForWeightChange()`, and
@@ -25,8 +26,10 @@ All 5527 existing tests pass. `./quality.sh` passes cleanly.
 ## Test Plan
 
 - Added 15 unit tests in `test/utils/NumericValidation.ts` covering:
-  - Valid inputs (zero, positive, small positive, negative for `assertFiniteNumber`)
+  - Valid inputs (zero, positive, small positive, negative for
+    `assertFiniteNumber`)
   - NaN rejection with correct error message
   - Positive/negative Infinity rejection with correct error message
-  - Negative number rejection with correct error message (for `assertFiniteNonNegative`)
+  - Negative number rejection with correct error message (for
+    `assertFiniteNonNegative`)
   - Value inclusion in error messages

--- a/docs/pr-summary-2222.md
+++ b/docs/pr-summary-2222.md
@@ -1,0 +1,32 @@
+## Summary
+
+Extract shared numeric validation helpers (`assertFiniteNonNegative` and
+`assertFiniteNumber`) into `src/utils/NumericValidation.ts` to eliminate
+repeated NaN/finite/non-negative assertion patterns across `Score.ts`.
+Closes #2222.
+
+## Changes
+
+- **New file `src/utils/NumericValidation.ts`**: Two helpers:
+  - `assertFiniteNonNegative(value, name)` — asserts not NaN, finite, and >= 0
+  - `assertFiniteNumber(value, name)` — asserts not NaN and finite (allows negative)
+- **`src/architecture/Score.ts`**: Replaced 15 individual assertion calls with
+  helper calls across `calculate()`, `calculatePenalty()`,
+  `computeAndCacheScoreComponents()`, `updateScoreForWeightChange()`, and
+  `updateScoreForBiasChange()`
+- **`test/architecture/Score.ts`**: Updated one test expectation from
+  `"not finite"` to `"is NaN"` since the helper now provides a more specific
+  error message for NaN values (NaN is distinguished from Infinity)
+
+## Evidence
+
+All 5527 existing tests pass. `./quality.sh` passes cleanly.
+
+## Test Plan
+
+- Added 15 unit tests in `test/utils/NumericValidation.ts` covering:
+  - Valid inputs (zero, positive, small positive, negative for `assertFiniteNumber`)
+  - NaN rejection with correct error message
+  - Positive/negative Infinity rejection with correct error message
+  - Negative number rejection with correct error message (for `assertFiniteNonNegative`)
+  - Value inclusion in error messages

--- a/src/architecture/Score.ts
+++ b/src/architecture/Score.ts
@@ -3,6 +3,10 @@ import type { CachedScoreComponents, Creature } from "@creature";
 import { SEMANTIC_MAJOR_VERSION } from "@upgrade/Upgrade.ts";
 import { getLogger } from "@utils/Logger.ts";
 import {
+  assertFiniteNonNegative,
+  assertFiniteNumber,
+} from "@utils/NumericValidation.ts";
+import {
   wasmComputeScoreComponents,
   wasmScanMaxBias,
   wasmScanMaxWeight,
@@ -35,22 +39,20 @@ export function calculate(
   error: number,
   growthCost: number,
 ): number {
-  assert(!Number.isNaN(error), `Error is NaN`);
-  assert(Number.isFinite(error), `Error is not finite`);
-  assert(error >= 0, `Error: ${error} is negative`);
+  assertFiniteNonNegative(error, "Error");
 
   // Get cached weight/bias statistics (Issue #1011)
   const cached = computeAndCacheScoreComponents(creature);
   const max = cached.maxWeightBias;
   const avg = cached.avgWeightBias;
 
-  assert(Number.isFinite(max), `Max: ${max} is not finite`);
-  assert(Number.isFinite(avg), `Avg: ${avg} is not finite`);
+  assertFiniteNumber(max, "Max");
+  assertFiniteNumber(avg, "Avg");
   const penalty = calculatePenalty(max, avg);
-  assert(Number.isFinite(penalty), `Penalty: ${penalty} is not finite`);
+  assertFiniteNumber(penalty, "Penalty");
   const score = calculateScore(error, creature, penalty, growthCost);
 
-  assert(Number.isFinite(score), `Score: ${score} is not finite`);
+  assertFiniteNumber(score, "Score");
   return score;
 }
 
@@ -100,11 +102,7 @@ export function valuePenalty(value: number): number {
 function calculatePenalty(max: number, avg: number): number {
   const penalty = (valuePenalty(max) + valuePenalty(avg)) / 2;
 
-  assert(
-    Number.isFinite(penalty),
-    `Penalty: ${penalty} is not finite`,
-  );
-  assert(penalty >= 0, `Penalty: ${penalty} is negative`);
+  assertFiniteNonNegative(penalty, "Penalty");
   assert(
     penalty < 1,
     `Penalty: ${penalty} is greater than or equal to 1`,
@@ -244,10 +242,7 @@ function computeAndCacheScoreComponents(
     const synapses = creature.synapses;
     for (let i = 0, len = synapses.length; i < len; i++) {
       const synapse = synapses[i];
-      assert(
-        Number.isFinite(synapse.weight),
-        `Weight: ${synapse.weight} is not finite`,
-      );
+      assertFiniteNumber(synapse.weight, "Weight");
       const w = Math.abs(synapse.weight);
       if (w > maxWeightBias) {
         secondMaxWeightBias = maxWeightBias;
@@ -262,10 +257,7 @@ function computeAndCacheScoreComponents(
     // Iterate over non-input neurons to gather bias statistics
     for (let indx = creature.input; indx < endIndex; indx++) {
       const neuron = neurons[indx];
-      assert(
-        Number.isFinite(neuron.bias),
-        `Bias: ${neuron.bias} is not finite`,
-      );
+      assertFiniteNumber(neuron.bias, "Bias");
       const b = Math.abs(neuron.bias);
       if (b > maxWeightBias) {
         secondMaxWeightBias = maxWeightBias;
@@ -290,8 +282,8 @@ function computeAndCacheScoreComponents(
     totalWeightBias = Number.MAX_SAFE_INTEGER;
   }
 
-  assert(maxWeightBias >= 0, `Max: ${maxWeightBias} is negative`);
-  assert(totalWeightBias >= 0, `Total: ${totalWeightBias} is negative`);
+  assertFiniteNonNegative(maxWeightBias, "Max");
+  assertFiniteNonNegative(totalWeightBias, "Total");
 
   const avgWeightBias = countWeightBias > 0
     ? totalWeightBias / countWeightBias
@@ -365,11 +357,9 @@ export function updateScoreForWeightChange(
   oldWeight: number,
   newWeight: number,
 ): number {
-  assert(!Number.isNaN(error), `Error is NaN`);
-  assert(Number.isFinite(error), `Error is not finite`);
-  assert(error >= 0, `Error: ${error} is negative`);
-  assert(Number.isFinite(oldWeight), `Old weight is not finite`);
-  assert(Number.isFinite(newWeight), `New weight is not finite`);
+  assertFiniteNonNegative(error, "Error");
+  assertFiniteNumber(oldWeight, "Old weight");
+  assertFiniteNumber(newWeight, "New weight");
 
   // Ensure we have cached values; if not, compute them
   if (!creature.cachedScoreComponents) {
@@ -459,11 +449,9 @@ export function updateScoreForBiasChange(
   oldBias: number,
   newBias: number,
 ): number {
-  assert(!Number.isNaN(error), `Error is NaN`);
-  assert(Number.isFinite(error), `Error is not finite`);
-  assert(error >= 0, `Error: ${error} is negative`);
-  assert(Number.isFinite(oldBias), `Old bias is not finite`);
-  assert(Number.isFinite(newBias), `New bias is not finite`);
+  assertFiniteNonNegative(error, "Error");
+  assertFiniteNumber(oldBias, "Old bias");
+  assertFiniteNumber(newBias, "New bias");
 
   // Ensure we have cached values; if not, compute them
   if (!creature.cachedScoreComponents) {

--- a/src/utils/NumericValidation.ts
+++ b/src/utils/NumericValidation.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared numeric validation helpers.
+ *
+ * Issue #2222: Extracted from repeated assertion patterns in Score.ts and
+ * other modules to reduce duplication and ensure consistent error messages.
+ *
+ * @module
+ */
+
+import { assert } from "@std/assert";
+
+/**
+ * Asserts that a value is a finite, non-negative number.
+ *
+ * Checks, in order: not NaN, finite, and >= 0. Throws with a clear,
+ * consistent error message including the field name and offending value.
+ *
+ * @param value - The number to validate
+ * @param name - A human-readable label included in error messages
+ * @throws {Error} When the value is NaN, non-finite, or negative
+ */
+export function assertFiniteNonNegative(value: number, name: string): void {
+  assert(!Number.isNaN(value), `${name} is NaN`);
+  assert(Number.isFinite(value), `${name} is not finite: ${value}`);
+  assert(value >= 0, `${name} is negative: ${value}`);
+}
+
+/**
+ * Asserts that a value is a finite number (may be negative).
+ *
+ * Checks, in order: not NaN and finite. Useful for values like weights
+ * and biases that can legitimately be negative but must still be finite.
+ *
+ * @param value - The number to validate
+ * @param name - A human-readable label included in error messages
+ * @throws {Error} When the value is NaN or non-finite
+ */
+export function assertFiniteNumber(value: number, name: string): void {
+  assert(!Number.isNaN(value), `${name} is NaN`);
+  assert(Number.isFinite(value), `${name} is not finite: ${value}`);
+}

--- a/test/architecture/Score.ts
+++ b/test/architecture/Score.ts
@@ -374,7 +374,7 @@ Deno.test("updateScoreForBiasChange - throws for non-finite bias", () => {
   assertThrows(
     () => updateScoreForBiasChange(creature, 0.1, 0.001, 0.5, NaN),
     Error,
-    "not finite",
+    "is NaN",
   );
 });
 

--- a/test/utils/NumericValidation.ts
+++ b/test/utils/NumericValidation.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for numeric validation helpers.
+ *
+ * Issue #2222: Shared helper to reduce repeated NaN/finite/non-negative
+ * assertion patterns.
+ *
+ * @module
+ */
+
+import { assertThrows } from "@std/assert";
+import {
+  assertFiniteNonNegative,
+  assertFiniteNumber,
+} from "@utils/NumericValidation.ts";
+
+// --- assertFiniteNonNegative ---
+
+Deno.test("assertFiniteNonNegative accepts zero", () => {
+  assertFiniteNonNegative(0, "value");
+});
+
+Deno.test("assertFiniteNonNegative accepts positive number", () => {
+  assertFiniteNonNegative(42, "value");
+});
+
+Deno.test("assertFiniteNonNegative accepts small positive number", () => {
+  assertFiniteNonNegative(0.000001, "value");
+});
+
+Deno.test("assertFiniteNonNegative rejects NaN", () => {
+  assertThrows(
+    () => assertFiniteNonNegative(NaN, "testVal"),
+    Error,
+    "testVal is NaN",
+  );
+});
+
+Deno.test("assertFiniteNonNegative rejects positive Infinity", () => {
+  assertThrows(
+    () => assertFiniteNonNegative(Infinity, "testVal"),
+    Error,
+    "testVal is not finite",
+  );
+});
+
+Deno.test("assertFiniteNonNegative rejects negative Infinity", () => {
+  assertThrows(
+    () => assertFiniteNonNegative(-Infinity, "testVal"),
+    Error,
+    "testVal is not finite",
+  );
+});
+
+Deno.test("assertFiniteNonNegative rejects negative number", () => {
+  assertThrows(
+    () => assertFiniteNonNegative(-1, "testVal"),
+    Error,
+    "testVal is negative",
+  );
+});
+
+Deno.test("assertFiniteNonNegative includes value in negative message", () => {
+  assertThrows(
+    () => assertFiniteNonNegative(-5.5, "myField"),
+    Error,
+    "myField is negative: -5.5",
+  );
+});
+
+Deno.test("assertFiniteNonNegative includes value in not-finite message", () => {
+  assertThrows(
+    () => assertFiniteNonNegative(Infinity, "myField"),
+    Error,
+    "myField is not finite: Infinity",
+  );
+});
+
+// --- assertFiniteNumber ---
+
+Deno.test("assertFiniteNumber accepts zero", () => {
+  assertFiniteNumber(0, "value");
+});
+
+Deno.test("assertFiniteNumber accepts positive number", () => {
+  assertFiniteNumber(42, "value");
+});
+
+Deno.test("assertFiniteNumber accepts negative number", () => {
+  assertFiniteNumber(-7.5, "value");
+});
+
+Deno.test("assertFiniteNumber rejects NaN", () => {
+  assertThrows(
+    () => assertFiniteNumber(NaN, "testVal"),
+    Error,
+    "testVal is NaN",
+  );
+});
+
+Deno.test("assertFiniteNumber rejects positive Infinity", () => {
+  assertThrows(
+    () => assertFiniteNumber(Infinity, "testVal"),
+    Error,
+    "testVal is not finite",
+  );
+});
+
+Deno.test("assertFiniteNumber rejects negative Infinity", () => {
+  assertThrows(
+    () => assertFiniteNumber(-Infinity, "testVal"),
+    Error,
+    "testVal is not finite",
+  );
+});


### PR DESCRIPTION
## Summary

Extract shared numeric validation helpers (`assertFiniteNonNegative` and
`assertFiniteNumber`) into `src/utils/NumericValidation.ts` to eliminate
repeated NaN/finite/non-negative assertion patterns across `Score.ts`. Closes
#2222.

## Changes

- **New file `src/utils/NumericValidation.ts`**: Two helpers:
  - `assertFiniteNonNegative(value, name)` — asserts not NaN, finite, and >= 0
  - `assertFiniteNumber(value, name)` — asserts not NaN and finite (allows
    negative)
- **`src/architecture/Score.ts`**: Replaced 15 individual assertion calls with
  helper calls across `calculate()`, `calculatePenalty()`,
  `computeAndCacheScoreComponents()`, `updateScoreForWeightChange()`, and
  `updateScoreForBiasChange()`
- **`test/architecture/Score.ts`**: Updated one test expectation from
  `"not finite"` to `"is NaN"` since the helper now provides a more specific
  error message for NaN values (NaN is distinguished from Infinity)

## Evidence

All 5527 existing tests pass. `./quality.sh` passes cleanly.

## Test Plan

- Added 15 unit tests in `test/utils/NumericValidation.ts` covering:
  - Valid inputs (zero, positive, small positive, negative for
    `assertFiniteNumber`)
  - NaN rejection with correct error message
  - Positive/negative Infinity rejection with correct error message
  - Negative number rejection with correct error message (for
    `assertFiniteNonNegative`)
  - Value inclusion in error messages

---

## Automated Fix Details
This PR addresses issue #2222: **Extract shared numeric validation helper to reduce repeated assertions**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2222
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2222 -->