### PR TITLE
Extract computeNeuronDependencyIndex to reduce nesting in Offspring.ts (#2223)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.9.25",
+  "version": "2.9.26",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2223.md
+++ b/docs/pr-summary-2223.md
@@ -1,0 +1,19 @@
+## Summary
+
+Extract `computeNeuronDependencyIndex()` helper from `Offspring.sortNeurons()` to reduce nesting depth from 8+ levels to 4. The new function encapsulates the synapse iteration logic that determines a neuron's dependency-aware sort index. No behavioural change — all existing breeding/offspring tests pass. Closes #2223.
+
+## Evidence
+
+- `./quality.sh` passes cleanly: 5684 tests passed, 0 failed
+- Existing `OffspringSortNeurons.ts` test continues to pass unchanged
+- New `ComputeNeuronDependencyIndex.ts` tests verify the extracted function in isolation
+
+## Test Plan
+
+- Added `test/breed/ComputeNeuronDependencyIndex.ts` with 5 tests covering:
+  - Returns base index when no connections exist
+  - Returns base index when all source neurons are inputs
+  - Bumps index when a dependency has a higher index
+  - Returns -1 when a non-input dependency is unresolved
+  - Keeps base index when dependency index is lower
+- All existing breeding tests pass without modification

--- a/docs/pr-summary-2223.md
+++ b/docs/pr-summary-2223.md
@@ -1,12 +1,17 @@
 ## Summary
 
-Extract `computeNeuronDependencyIndex()` helper from `Offspring.sortNeurons()` to reduce nesting depth from 8+ levels to 4. The new function encapsulates the synapse iteration logic that determines a neuron's dependency-aware sort index. No behavioural change — all existing breeding/offspring tests pass. Closes #2223.
+Extract `computeNeuronDependencyIndex()` helper from `Offspring.sortNeurons()`
+to reduce nesting depth from 8+ levels to 4. The new function encapsulates the
+synapse iteration logic that determines a neuron's dependency-aware sort index.
+No behavioural change — all existing breeding/offspring tests pass. Closes
+#2223.
 
 ## Evidence
 
 - `./quality.sh` passes cleanly: 5684 tests passed, 0 failed
 - Existing `OffspringSortNeurons.ts` test continues to pass unchanged
-- New `ComputeNeuronDependencyIndex.ts` tests verify the extracted function in isolation
+- New `ComputeNeuronDependencyIndex.ts` tests verify the extracted function in
+  isolation
 
 ## Test Plan
 

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -45,6 +45,37 @@ export interface ConnectionRef {
   synapses: SynapseInternal[];
 }
 
+/**
+ * Compute the dependency-aware sort index for a neuron based on its inward
+ * synapses. Returns the adjusted index (≥ 0) when all non-input dependencies
+ * are resolved in `childMap`, or -1 when at least one dependency is still
+ * unresolved.
+ */
+export function computeNeuronDependencyIndex(
+  baseIndex: number,
+  ref: ConnectionRef | undefined,
+  childMap: Map<number, number>,
+): number {
+  if (!ref) return baseIndex;
+
+  let indx = baseIndex;
+  const parentNeurons = ref.parent.neurons;
+  for (const synapse of ref.synapses) {
+    if (indx < 0) break;
+
+    const fromNeuron = parentNeurons[synapse.from];
+    if (fromNeuron.type === "input") continue;
+
+    const dependantIndx = childMap.get(fromNeuron.id);
+    if (dependantIndx === undefined) {
+      indx = -1;
+    } else if (dependantIndx >= indx) {
+      indx = dependantIndx + 1;
+    }
+  }
+  return indx;
+}
+
 export class Offspring {
   /**
    * Create an offspring from two parent networks.
@@ -779,22 +810,7 @@ export class Offspring {
               );
             }
             const ref = connectionsMap.get(nId);
-            if (ref) {
-              const parentNeurons = ref.parent.neurons;
-              for (const synapse of ref.synapses) {
-                if (indx >= 0) {
-                  const fromNeuron = parentNeurons[synapse.from];
-                  if (fromNeuron.type !== "input") {
-                    const dependantIndx = childMap.get(fromNeuron.id);
-                    if (dependantIndx === undefined) {
-                      indx = -1;
-                    } else if (dependantIndx >= indx) {
-                      indx = dependantIndx + 1;
-                    }
-                  }
-                }
-              }
-            }
+            indx = computeNeuronDependencyIndex(indx, ref, childMap);
             if (indx >= 0) {
               if (usedIndx.has(indx)) {
                 childMap.forEach((childIndx, nid) => {

--- a/test/breed/ComputeNeuronDependencyIndex.ts
+++ b/test/breed/ComputeNeuronDependencyIndex.ts
@@ -1,0 +1,106 @@
+import { assertEquals } from "@std/assert";
+import { Creature, type CreatureExport } from "../../mod.ts";
+import type { ConnectionRef } from "@architecture/Offspring.ts";
+import { computeNeuronDependencyIndex } from "@architecture/Offspring.ts";
+
+/**
+ * Build a small creature and extract a ConnectionRef for a specific neuron,
+ * so we can unit-test the dependency index computation in isolation.
+ */
+function makeTestCreature(): Creature {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-a", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "hidden-b", squash: "IDENTITY", bias: 0 },
+      { type: "hidden", uuid: "hidden-c", squash: "IDENTITY", bias: 0 },
+      { type: "output", squash: "IDENTITY", uuid: "output-0", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 1 },
+      { fromUUID: "hidden-a", toUUID: "hidden-b", weight: 1 },
+      { fromUUID: "hidden-b", toUUID: "hidden-c", weight: 1 },
+      { fromUUID: "hidden-c", toUUID: "output-0", weight: 1 },
+    ],
+    input: 2,
+    output: 1,
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  return creature;
+}
+
+Deno.test(
+  "computeNeuronDependencyIndex returns baseIndex when no connections exist",
+  () => {
+    const childMap = new Map<number, number>();
+    const result = computeNeuronDependencyIndex(5, undefined, childMap);
+    assertEquals(result, 5);
+  },
+);
+
+Deno.test(
+  "computeNeuronDependencyIndex returns baseIndex when all source neurons are inputs",
+  () => {
+    const creature = makeTestCreature();
+    const hiddenA = creature.neurons.find((n) => n.uuid === "hidden-a")!;
+    const connections = creature.inwardConnections(hiddenA.index);
+    const ref: ConnectionRef = { parent: creature, synapses: connections };
+
+    const childMap = new Map<number, number>();
+    // input neurons are not checked, so childMap doesn't need their entries
+    const result = computeNeuronDependencyIndex(3, ref, childMap);
+    assertEquals(result, 3);
+  },
+);
+
+Deno.test(
+  "computeNeuronDependencyIndex bumps index when dependency has higher index",
+  () => {
+    const creature = makeTestCreature();
+    const hiddenB = creature.neurons.find((n) => n.uuid === "hidden-b")!;
+    const hiddenA = creature.neurons.find((n) => n.uuid === "hidden-a")!;
+    const connections = creature.inwardConnections(hiddenB.index);
+    const ref: ConnectionRef = { parent: creature, synapses: connections };
+
+    const childMap = new Map<number, number>();
+    // hidden-a is resolved at index 7
+    childMap.set(hiddenA.id, 7);
+
+    // baseIndex is 5, but hidden-a is at 7 so result should be 7 + 1 = 8
+    const result = computeNeuronDependencyIndex(5, ref, childMap);
+    assertEquals(result, 8);
+  },
+);
+
+Deno.test(
+  "computeNeuronDependencyIndex returns -1 when a non-input dependency is unresolved",
+  () => {
+    const creature = makeTestCreature();
+    const hiddenB = creature.neurons.find((n) => n.uuid === "hidden-b")!;
+    const connections = creature.inwardConnections(hiddenB.index);
+    const ref: ConnectionRef = { parent: creature, synapses: connections };
+
+    // childMap is empty — hidden-a dependency is unresolved
+    const childMap = new Map<number, number>();
+    const result = computeNeuronDependencyIndex(5, ref, childMap);
+    assertEquals(result, -1);
+  },
+);
+
+Deno.test(
+  "computeNeuronDependencyIndex keeps baseIndex when dependency index is lower",
+  () => {
+    const creature = makeTestCreature();
+    const hiddenB = creature.neurons.find((n) => n.uuid === "hidden-b")!;
+    const hiddenA = creature.neurons.find((n) => n.uuid === "hidden-a")!;
+    const connections = creature.inwardConnections(hiddenB.index);
+    const ref: ConnectionRef = { parent: creature, synapses: connections };
+
+    const childMap = new Map<number, number>();
+    // hidden-a is at index 2, which is less than baseIndex 5
+    childMap.set(hiddenA.id, 2);
+
+    const result = computeNeuronDependencyIndex(5, ref, childMap);
+    assertEquals(result, 5);
+  },
+);


### PR DESCRIPTION
## Summary

Extract `computeNeuronDependencyIndex()` helper from `Offspring.sortNeurons()`
to reduce nesting depth from 8+ levels to 4. The new function encapsulates the
synapse iteration logic that determines a neuron's dependency-aware sort index.
No behavioural change — all existing breeding/offspring tests pass. Closes
#2223.

## Evidence

- `./quality.sh` passes cleanly: 5684 tests passed, 0 failed
- Existing `OffspringSortNeurons.ts` test continues to pass unchanged
- New `ComputeNeuronDependencyIndex.ts` tests verify the extracted function in
  isolation

## Test Plan

- Added `test/breed/ComputeNeuronDependencyIndex.ts` with 5 tests covering:
  - Returns base index when no connections exist
  - Returns base index when all source neurons are inputs
  - Bumps index when a dependency has a higher index
  - Returns -1 when a non-input dependency is unresolved
  - Keeps base index when dependency index is lower
- All existing breeding tests pass without modification

---

## Automated Fix Details
This PR addresses issue #2223: **Reduce nesting depth in Offspring.ts neuron sorting logic**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #2223
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-2223 -->