### PR TITLE
Include checkpoint writeCreatures wall time in training telemetry (#2251)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -173,6 +173,7 @@
     "nonzero",
     "nulled",
     "nulling",
+    "NVME",
     "Olah",
     "opset",
     "Ororbia",

--- a/docs/pr-summary-2251.md
+++ b/docs/pr-summary-2251.md
@@ -1,0 +1,26 @@
+## Summary
+
+Include checkpoint (writeCreatures) wall time in training telemetry. Extends `GenerationPhaseTiming` with an optional `checkpointWriteMs` field that is populated only when a checkpoint runs that generation, adding negligible overhead when checkpoints are disabled. Closes #2251.
+
+## Changes
+
+- **`src/config/TrainingEvent.ts`**: Added optional `checkpointWriteMs` to `GenerationPhaseTiming` interface.
+- **`src/creature/CreatureTraining.ts`**: Moved checkpoint write before event emission and wrapped it with `Date.now()` timing. The measured duration is attached to `phaseTiming.checkpointWriteMs` in the `generation_complete` event.
+- **`test/config/CheckpointWriteTiming.ts`**: New test file verifying:
+  - `checkpointWriteMs` is present and non-negative when `checkpointEveryGeneration` is enabled.
+  - `checkpointWriteMs` is `undefined` when checkpoints are not active.
+
+## Evidence
+
+This is a backend/telemetry change with no UI. Evidence is provided by passing tests:
+- `test/config/CheckpointWriteTiming.ts` — 2 tests verifying the timing field presence/absence
+- `test/NEAT/EvolvePhaseTiming.ts` — existing phase timing test continues to pass
+- `test/config/CheckpointEveryGeneration.ts` — existing checkpoint tests continue to pass
+- Full quality gate: 5716 passed, 0 failed
+
+## Test Plan
+
+- [x] `checkpointWriteMs` present and non-negative when `checkpointEveryGeneration: true`
+- [x] `checkpointWriteMs` undefined when `checkpointEveryGeneration: false`
+- [x] All existing phase timing and checkpoint tests pass unchanged
+- [x] Full quality gate passes cleanly

--- a/docs/pr-summary-2251.md
+++ b/docs/pr-summary-2251.md
@@ -1,26 +1,40 @@
 ## Summary
 
-Include checkpoint (writeCreatures) wall time in training telemetry. Extends `GenerationPhaseTiming` with an optional `checkpointWriteMs` field that is populated only when a checkpoint runs that generation, adding negligible overhead when checkpoints are disabled. Closes #2251.
+Include checkpoint (writeCreatures) wall time in training telemetry. Extends
+`GenerationPhaseTiming` with an optional `checkpointWriteMs` field that is
+populated only when a checkpoint runs that generation, adding negligible
+overhead when checkpoints are disabled. Closes #2251.
 
 ## Changes
 
-- **`src/config/TrainingEvent.ts`**: Added optional `checkpointWriteMs` to `GenerationPhaseTiming` interface.
-- **`src/creature/CreatureTraining.ts`**: Moved checkpoint write before event emission and wrapped it with `Date.now()` timing. The measured duration is attached to `phaseTiming.checkpointWriteMs` in the `generation_complete` event.
+- **`src/config/TrainingEvent.ts`**: Added optional `checkpointWriteMs` to
+  `GenerationPhaseTiming` interface.
+- **`src/creature/CreatureTraining.ts`**: Moved checkpoint write before event
+  emission and wrapped it with `Date.now()` timing. The measured duration is
+  attached to `phaseTiming.checkpointWriteMs` in the `generation_complete`
+  event.
 - **`test/config/CheckpointWriteTiming.ts`**: New test file verifying:
-  - `checkpointWriteMs` is present and non-negative when `checkpointEveryGeneration` is enabled.
+  - `checkpointWriteMs` is present and non-negative when
+    `checkpointEveryGeneration` is enabled.
   - `checkpointWriteMs` is `undefined` when checkpoints are not active.
 
 ## Evidence
 
-This is a backend/telemetry change with no UI. Evidence is provided by passing tests:
-- `test/config/CheckpointWriteTiming.ts` — 2 tests verifying the timing field presence/absence
-- `test/NEAT/EvolvePhaseTiming.ts` — existing phase timing test continues to pass
-- `test/config/CheckpointEveryGeneration.ts` — existing checkpoint tests continue to pass
+This is a backend/telemetry change with no UI. Evidence is provided by passing
+tests:
+
+- `test/config/CheckpointWriteTiming.ts` — 2 tests verifying the timing field
+  presence/absence
+- `test/NEAT/EvolvePhaseTiming.ts` — existing phase timing test continues to
+  pass
+- `test/config/CheckpointEveryGeneration.ts` — existing checkpoint tests
+  continue to pass
 - Full quality gate: 5716 passed, 0 failed
 
 ## Test Plan
 
-- [x] `checkpointWriteMs` present and non-negative when `checkpointEveryGeneration: true`
+- [x] `checkpointWriteMs` present and non-negative when
+      `checkpointEveryGeneration: true`
 - [x] `checkpointWriteMs` undefined when `checkpointEveryGeneration: false`
 - [x] All existing phase timing and checkpoint tests pass unchanged
 - [x] Full quality gate passes cleanly

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -22,6 +22,11 @@ export interface GenerationPhaseTiming {
   readonly resultProcessingMs: number;
   /** Total time for the entire evolve() call in ms. */
   readonly totalMs: number;
+  /**
+   * Time spent writing checkpoint files (writeCreatures) in ms.
+   * Issue #2251: Present only when a checkpoint ran that generation.
+   */
+  readonly checkpointWriteMs?: number;
 }
 
 /**

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -419,6 +419,17 @@ export async function evolveDir(
 
     generation++;
 
+    // Issue #2251: Time checkpoint write so it flows through onTrainingEvent
+    let phaseTiming = result.phaseTiming;
+    if (config.checkpointEveryGeneration && config.creatureStore) {
+      const checkpointStart = Date.now();
+      writeCreatures(neat, config.creatureStore);
+      phaseTiming = {
+        ...result.phaseTiming,
+        checkpointWriteMs: Date.now() - checkpointStart,
+      };
+    }
+
     // Issue #1615: Emit generation_complete event
     // Issue #2239: Include per-phase timing diagnostics from evolve()
     const generationElapsedMs = now -
@@ -431,7 +442,7 @@ export async function evolveDir(
       averageFitness: result.averageScore,
       populationSize: neat.population.length,
       elapsedMs: generationElapsedMs,
-      phaseTiming: result.phaseTiming,
+      phaseTiming,
     });
 
     // Issue #1615: Emit plateau_detected event when on plateau
@@ -489,12 +500,6 @@ export async function evolveDir(
       // or training to finish.
       // deno-lint-ignore no-await-in-loop
       await neat.awaitInFlightTasks();
-    }
-
-    if (
-      config.checkpointEveryGeneration && config.creatureStore
-    ) {
-      writeCreatures(neat, config.creatureStore);
     }
   }
 

--- a/test/config/CheckpointWriteTiming.ts
+++ b/test/config/CheckpointWriteTiming.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for checkpoint write timing in training telemetry.
+ *
+ * Issue #2251: Verifies that generation_complete events include
+ * checkpointWriteMs in phaseTiming when checkpointEveryGeneration is enabled,
+ * and that it is undefined when checkpoints are not active.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { emptyDirSync } from "@std/fs";
+import { Creature } from "@creature";
+import type {
+  GenerationCompleteEvent,
+  TrainingEvent,
+} from "@config/TrainingEvent.ts";
+
+Deno.test("checkpointWriteMs present when checkpointEveryGeneration enabled", async () => {
+  const events: GenerationCompleteEvent[] = [];
+
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([1]) },
+  ];
+
+  const creature = new Creature(2, 1);
+  const dir = ".creatures-checkpoint-timing-test";
+  emptyDirSync(dir);
+
+  try {
+    await creature.evolveDataSet(trainingSet, {
+      iterations: 3,
+      targetError: 0.001,
+      populationSize: 5,
+      threads: 1,
+      creatureStore: dir,
+      checkpointEveryGeneration: true,
+      onTrainingEvent: (event: TrainingEvent) => {
+        if (event.kind === "generation_complete") {
+          events.push(event);
+        }
+      },
+    });
+
+    assert(
+      events.length > 0,
+      "Should emit at least one generation_complete event",
+    );
+
+    for (const event of events) {
+      const timing = event.phaseTiming;
+      assert(
+        timing.checkpointWriteMs !== undefined,
+        "checkpointWriteMs should be present when checkpoints are enabled",
+      );
+      assertEquals(typeof timing.checkpointWriteMs, "number");
+      assert(
+        timing.checkpointWriteMs! >= 0,
+        `checkpointWriteMs should be non-negative, got ${timing.checkpointWriteMs}`,
+      );
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("checkpointWriteMs undefined when checkpointEveryGeneration disabled", async () => {
+  const events: GenerationCompleteEvent[] = [];
+
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([1]) },
+  ];
+
+  const creature = new Creature(2, 1);
+
+  await creature.evolveDataSet(trainingSet, {
+    iterations: 3,
+    targetError: 0.001,
+    populationSize: 5,
+    threads: 1,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        events.push(event);
+      }
+    },
+  });
+
+  assert(
+    events.length > 0,
+    "Should emit at least one generation_complete event",
+  );
+
+  for (const event of events) {
+    const timing = event.phaseTiming;
+    assertEquals(
+      timing.checkpointWriteMs,
+      undefined,
+      "checkpointWriteMs should be undefined when checkpoints are not active",
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Include checkpoint (writeCreatures) wall time in training telemetry. Extends `GenerationPhaseTiming` with an optional `checkpointWriteMs` field that is populated only when a checkpoint runs that generation, adding negligible overhead when checkpoints are disabled. Closes #2251.

## Changes

- **`src/config/TrainingEvent.ts`**: Added optional `checkpointWriteMs` to `GenerationPhaseTiming` interface.
- **`src/creature/CreatureTraining.ts`**: Moved checkpoint write before event emission and wrapped it with `Date.now()` timing. The measured duration is attached to `phaseTiming.checkpointWriteMs` in the `generation_complete` event.
- **`test/config/CheckpointWriteTiming.ts`**: New test file verifying:
  - `checkpointWriteMs` is present and non-negative when `checkpointEveryGeneration` is enabled.
  - `checkpointWriteMs` is `undefined` when checkpoints are not active.

## Evidence

This is a backend/telemetry change with no UI. Evidence is provided by passing tests:
- `test/config/CheckpointWriteTiming.ts` — 2 tests verifying the timing field presence/absence
- `test/NEAT/EvolvePhaseTiming.ts` — existing phase timing test continues to pass
- `test/config/CheckpointEveryGeneration.ts` — existing checkpoint tests continue to pass
- Full quality gate: 5716 passed, 0 failed

## Test Plan

- [x] `checkpointWriteMs` present and non-negative when `checkpointEveryGeneration: true`
- [x] `checkpointWriteMs` undefined when `checkpointEveryGeneration: false`
- [x] All existing phase timing and checkpoint tests pass unchanged
- [x] Full quality gate passes cleanly


<!-- vibe-worker-issue-2251 -->