### PR TITLE
Performance: Replace JSON round-trip with shallowClone in evolveDir (#2276)

### DIFF
--- a/bench/BestCreatureClone.ts
+++ b/bench/BestCreatureClone.ts
@@ -1,0 +1,121 @@
+/**
+ * Benchmark for bestCreature clone performance in CreatureTraining.ts.
+ *
+ * Issue #2276: Eliminate JSON round-trip in evolveDir bestCreature tracking.
+ *
+ * The evolveDir loop (CreatureTraining.ts) clones the fittest creature each
+ * time a new best score is found. The original pattern:
+ *
+ *   bestCreature = CreatureClass.fromJSON(exportJSONWithRuntimeIds(fittest));
+ *   bestCreature.uuid = fittest.uuid;
+ *   bestCreature.score = bestScore;
+ *
+ * This performs a full JSON serialisation + deserialisation cycle. The
+ * optimised pattern uses shallowClone(), which is already proven faster
+ * (Issue #1025, Issue #1586):
+ *
+ *   bestCreature = fittest.shallowClone();
+ *   bestCreature.score = bestScore;
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write bench/BestCreatureClone.ts
+ */
+import { Creature } from "@creature";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+
+// Create creatures of varying sizes to mirror production workloads
+const smallCreature = new Creature(10, 5, {
+  layers: [{ count: 20 }],
+});
+smallCreature.uuid = "small-best-creature-test";
+smallCreature.score = 0.85;
+creatureValidate(smallCreature);
+
+const mediumCreature = new Creature(50, 10, {
+  layers: [{ count: 100 }, { count: 50 }],
+});
+mediumCreature.uuid = "medium-best-creature-test";
+mediumCreature.score = 0.92;
+creatureValidate(mediumCreature);
+
+const largeCreature = new Creature(100, 20, {
+  layers: [{ count: 200 }, { count: 100 }, { count: 50 }],
+});
+largeCreature.uuid = "large-best-creature-test";
+largeCreature.score = 0.97;
+creatureValidate(largeCreature);
+
+console.log("=== Creature Sizes ===");
+console.log(
+  `Small: ${smallCreature.neurons.length} neurons, ${smallCreature.synapses.length} synapses`,
+);
+console.log(
+  `Medium: ${mediumCreature.neurons.length} neurons, ${mediumCreature.synapses.length} synapses`,
+);
+console.log(
+  `Large: ${largeCreature.neurons.length} neurons, ${largeCreature.synapses.length} synapses`,
+);
+
+// Small creature benchmarks
+Deno.bench({
+  name: "Small creature - exportJSONWithRuntimeIds + fromJSON (baseline)",
+  group: "Small bestCreature clone",
+  baseline: true,
+  fn() {
+    const clone = Creature.fromJSON(exportJSONWithRuntimeIds(smallCreature));
+    clone.uuid = smallCreature.uuid;
+    clone.score = smallCreature.score;
+  },
+});
+
+Deno.bench({
+  name: "Small creature - shallowClone (optimised)",
+  group: "Small bestCreature clone",
+  fn() {
+    const clone = smallCreature.shallowClone();
+    clone.score = smallCreature.score;
+  },
+});
+
+// Medium creature benchmarks
+Deno.bench({
+  name: "Medium creature - exportJSONWithRuntimeIds + fromJSON (baseline)",
+  group: "Medium bestCreature clone",
+  baseline: true,
+  fn() {
+    const clone = Creature.fromJSON(exportJSONWithRuntimeIds(mediumCreature));
+    clone.uuid = mediumCreature.uuid;
+    clone.score = mediumCreature.score;
+  },
+});
+
+Deno.bench({
+  name: "Medium creature - shallowClone (optimised)",
+  group: "Medium bestCreature clone",
+  fn() {
+    const clone = mediumCreature.shallowClone();
+    clone.score = mediumCreature.score;
+  },
+});
+
+// Large creature benchmarks
+Deno.bench({
+  name: "Large creature - exportJSONWithRuntimeIds + fromJSON (baseline)",
+  group: "Large bestCreature clone",
+  baseline: true,
+  fn() {
+    const clone = Creature.fromJSON(exportJSONWithRuntimeIds(largeCreature));
+    clone.uuid = largeCreature.uuid;
+    clone.score = largeCreature.score;
+  },
+});
+
+Deno.bench({
+  name: "Large creature - shallowClone (optimised)",
+  group: "Large bestCreature clone",
+  fn() {
+    const clone = largeCreature.shallowClone();
+    clone.score = largeCreature.score;
+  },
+});

--- a/bench/ProcessCompletedResultsFromJSON.ts
+++ b/bench/ProcessCompletedResultsFromJSON.ts
@@ -1,0 +1,120 @@
+/**
+ * Benchmark for fromJSON construction in processCompletedResults.
+ *
+ * Issue #2276: Investigate whether fromJSON in processCompletedResults can
+ * be optimised.
+ *
+ * Context: processCompletedResults (NeatEvolution.ts) calls Creature.fromJSON()
+ * on CreatureExport objects received from workers. These are not round-trip
+ * clones (there is no in-memory Creature to clone from), so shallowClone()
+ * is not applicable. This benchmark documents the per-call cost for reference.
+ *
+ * Findings: The fromJSON calls are necessary since the data arrives as
+ * CreatureExport objects from worker threads. The debug=false path already
+ * skips validation, which is the optimal approach for trusted worker output.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write bench/ProcessCompletedResultsFromJSON.ts
+ */
+import { Creature } from "@creature";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+
+// Create creatures and export to simulate worker results
+const smallCreature = new Creature(10, 5, {
+  layers: [{ count: 20 }],
+});
+smallCreature.uuid = "small-worker-result";
+smallCreature.score = 0.85;
+creatureValidate(smallCreature);
+const smallJSON = smallCreature.exportJSON();
+
+const mediumCreature = new Creature(50, 10, {
+  layers: [{ count: 100 }, { count: 50 }],
+});
+mediumCreature.uuid = "medium-worker-result";
+mediumCreature.score = 0.92;
+creatureValidate(mediumCreature);
+const mediumJSON = mediumCreature.exportJSON();
+
+const largeCreature = new Creature(100, 20, {
+  layers: [{ count: 200 }, { count: 100 }, { count: 50 }],
+});
+largeCreature.uuid = "large-worker-result";
+largeCreature.score = 0.97;
+creatureValidate(largeCreature);
+const largeJSON = largeCreature.exportJSON();
+
+console.log("=== processCompletedResults fromJSON Benchmark ===");
+console.log(
+  `Small: ${smallCreature.neurons.length} neurons, ${smallCreature.synapses.length} synapses`,
+);
+console.log(
+  `Medium: ${mediumCreature.neurons.length} neurons, ${mediumCreature.synapses.length} synapses`,
+);
+console.log(
+  `Large: ${largeCreature.neurons.length} neurons, ${largeCreature.synapses.length} synapses`,
+);
+console.log(
+  "\nNote: These fromJSON calls reconstruct from worker CreatureExport objects.",
+);
+console.log(
+  "shallowClone() is NOT applicable here (no in-memory Creature to clone).",
+);
+console.log(
+  "debug=false already skips validation, which is optimal for trusted worker output.\n",
+);
+
+// Small creature: fromJSON with debug=false (production path)
+Deno.bench({
+  name: "Small creature - fromJSON (debug=false, production)",
+  group: "Small worker result reconstruction",
+  baseline: true,
+  fn() {
+    Creature.fromJSON(smallJSON, false);
+  },
+});
+
+// Small creature: fromJSON with debug=true (debug path)
+Deno.bench({
+  name: "Small creature - fromJSON (debug=true)",
+  group: "Small worker result reconstruction",
+  fn() {
+    Creature.fromJSON(smallJSON, true);
+  },
+});
+
+// Medium creature benchmarks
+Deno.bench({
+  name: "Medium creature - fromJSON (debug=false, production)",
+  group: "Medium worker result reconstruction",
+  baseline: true,
+  fn() {
+    Creature.fromJSON(mediumJSON, false);
+  },
+});
+
+Deno.bench({
+  name: "Medium creature - fromJSON (debug=true)",
+  group: "Medium worker result reconstruction",
+  fn() {
+    Creature.fromJSON(mediumJSON, true);
+  },
+});
+
+// Large creature benchmarks
+Deno.bench({
+  name: "Large creature - fromJSON (debug=false, production)",
+  group: "Large worker result reconstruction",
+  baseline: true,
+  fn() {
+    Creature.fromJSON(largeJSON, false);
+  },
+});
+
+Deno.bench({
+  name: "Large creature - fromJSON (debug=true)",
+  group: "Large worker result reconstruction",
+  fn() {
+    Creature.fromJSON(largeJSON, true);
+  },
+});

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2276.md
+++ b/docs/pr-summary-2276.md
@@ -1,0 +1,52 @@
+## Summary
+
+Replace the expensive `exportJSONWithRuntimeIds()` → `Creature.fromJSON()` round-trip in `evolveDir()` bestCreature tracking with `shallowClone()`, achieving a 5–7x speedup. Closes #2276.
+
+### bestCreature creation (CreatureTraining.ts) — **Optimised**
+
+The `evolveDir` loop clones the fittest creature each time a new best score is found. The old pattern serialised to JSON and deserialised back:
+
+```typescript
+bestCreature = CreatureClass.fromJSON(exportJSONWithRuntimeIds(fittest));
+bestCreature.uuid = fittest.uuid;
+bestCreature.score = bestScore;
+```
+
+Replaced with `shallowClone()` which directly copies neurons and synapses in-memory:
+
+```typescript
+bestCreature = fittest.shallowClone() as InstanceType<typeof CreatureClass>;
+bestCreature.score = bestScore;
+```
+
+### processCompletedResults (NeatEvolution.ts) — **Negative result (no change)**
+
+The `fromJSON()` calls in `processCompletedResults` reconstruct creatures from `CreatureExport` objects received from worker threads. There is no in-memory `Creature` instance to clone from, so `shallowClone()` is not applicable. The existing `debug=false` path already skips validation, which is optimal for trusted worker output.
+
+## Evidence
+
+### Benchmark results (bench/BestCreatureClone.ts)
+
+| Creature Size | Neurons | Synapses | JSON Round-trip | shallowClone | Speedup |
+|---|---|---|---|---|---|
+| Small | 35 | 300 | 47.9 µs | 9.0 µs | **5.31x** |
+| Medium | 210 | 10,500 | 2.2 ms | 292.1 µs | **7.42x** |
+| Large | 470 | 46,000 | 14.1 ms | 2.0 ms | **7.13x** |
+
+### processCompletedResults benchmark (bench/ProcessCompletedResultsFromJSON.ts)
+
+Documents that `fromJSON(debug=false)` is already 1.3–2.1x faster than `fromJSON(debug=true)`. No further optimisation possible without an in-memory Creature to clone.
+
+### Verification
+
+Tests confirm `shallowClone()` produces functionally identical creatures to the old JSON round-trip pattern — matching runtime IDs, neuron UUIDs, synapse structure, tags, scores, and activation outputs.
+
+## Test Plan
+
+- Added `test/creature/ShallowCloneRuntimeIds.ts` (3 tests) verifying:
+  - `shallowClone()` preserves runtime IDs equivalent to `exportJSONWithRuntimeIds + fromJSON`
+  - Multi-layer creature runtime ID and activation output equivalence
+  - Semantic version and `forwardOnly` flag preservation
+- All 5,751 existing tests pass (0 failures)
+- Added `bench/BestCreatureClone.ts` — benchmarks bestCreature clone patterns
+- Added `bench/ProcessCompletedResultsFromJSON.ts` — documents processCompletedResults findings

--- a/docs/pr-summary-2276.md
+++ b/docs/pr-summary-2276.md
@@ -1,10 +1,13 @@
 ## Summary
 
-Replace the expensive `exportJSONWithRuntimeIds()` → `Creature.fromJSON()` round-trip in `evolveDir()` bestCreature tracking with `shallowClone()`, achieving a 5–7x speedup. Closes #2276.
+Replace the expensive `exportJSONWithRuntimeIds()` → `Creature.fromJSON()`
+round-trip in `evolveDir()` bestCreature tracking with `shallowClone()`,
+achieving a 5–7x speedup. Closes #2276.
 
 ### bestCreature creation (CreatureTraining.ts) — **Optimised**
 
-The `evolveDir` loop clones the fittest creature each time a new best score is found. The old pattern serialised to JSON and deserialised back:
+The `evolveDir` loop clones the fittest creature each time a new best score is
+found. The old pattern serialised to JSON and deserialised back:
 
 ```typescript
 bestCreature = CreatureClass.fromJSON(exportJSONWithRuntimeIds(fittest));
@@ -12,7 +15,8 @@ bestCreature.uuid = fittest.uuid;
 bestCreature.score = bestScore;
 ```
 
-Replaced with `shallowClone()` which directly copies neurons and synapses in-memory:
+Replaced with `shallowClone()` which directly copies neurons and synapses
+in-memory:
 
 ```typescript
 bestCreature = fittest.shallowClone() as InstanceType<typeof CreatureClass>;
@@ -21,32 +25,42 @@ bestCreature.score = bestScore;
 
 ### processCompletedResults (NeatEvolution.ts) — **Negative result (no change)**
 
-The `fromJSON()` calls in `processCompletedResults` reconstruct creatures from `CreatureExport` objects received from worker threads. There is no in-memory `Creature` instance to clone from, so `shallowClone()` is not applicable. The existing `debug=false` path already skips validation, which is optimal for trusted worker output.
+The `fromJSON()` calls in `processCompletedResults` reconstruct creatures from
+`CreatureExport` objects received from worker threads. There is no in-memory
+`Creature` instance to clone from, so `shallowClone()` is not applicable. The
+existing `debug=false` path already skips validation, which is optimal for
+trusted worker output.
 
 ## Evidence
 
 ### Benchmark results (bench/BestCreatureClone.ts)
 
-| Creature Size | Neurons | Synapses | JSON Round-trip | shallowClone | Speedup |
-|---|---|---|---|---|---|
-| Small | 35 | 300 | 47.9 µs | 9.0 µs | **5.31x** |
-| Medium | 210 | 10,500 | 2.2 ms | 292.1 µs | **7.42x** |
-| Large | 470 | 46,000 | 14.1 ms | 2.0 ms | **7.13x** |
+| Creature Size | Neurons | Synapses | JSON Round-trip | shallowClone | Speedup   |
+| ------------- | ------- | -------- | --------------- | ------------ | --------- |
+| Small         | 35      | 300      | 47.9 µs         | 9.0 µs       | **5.31x** |
+| Medium        | 210     | 10,500   | 2.2 ms          | 292.1 µs     | **7.42x** |
+| Large         | 470     | 46,000   | 14.1 ms         | 2.0 ms       | **7.13x** |
 
 ### processCompletedResults benchmark (bench/ProcessCompletedResultsFromJSON.ts)
 
-Documents that `fromJSON(debug=false)` is already 1.3–2.1x faster than `fromJSON(debug=true)`. No further optimisation possible without an in-memory Creature to clone.
+Documents that `fromJSON(debug=false)` is already 1.3–2.1x faster than
+`fromJSON(debug=true)`. No further optimisation possible without an in-memory
+Creature to clone.
 
 ### Verification
 
-Tests confirm `shallowClone()` produces functionally identical creatures to the old JSON round-trip pattern — matching runtime IDs, neuron UUIDs, synapse structure, tags, scores, and activation outputs.
+Tests confirm `shallowClone()` produces functionally identical creatures to the
+old JSON round-trip pattern — matching runtime IDs, neuron UUIDs, synapse
+structure, tags, scores, and activation outputs.
 
 ## Test Plan
 
 - Added `test/creature/ShallowCloneRuntimeIds.ts` (3 tests) verifying:
-  - `shallowClone()` preserves runtime IDs equivalent to `exportJSONWithRuntimeIds + fromJSON`
+  - `shallowClone()` preserves runtime IDs equivalent to
+    `exportJSONWithRuntimeIds + fromJSON`
   - Multi-layer creature runtime ID and activation output equivalence
   - Semantic version and `forwardOnly` flag preservation
 - All 5,751 existing tests pass (0 failures)
 - Added `bench/BestCreatureClone.ts` — benchmarks bestCreature clone patterns
-- Added `bench/ProcessCompletedResultsFromJSON.ts` — documents processCompletedResults findings
+- Added `bench/ProcessCompletedResultsFromJSON.ts` — documents
+  processCompletedResults findings

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -409,8 +409,12 @@ export async function evolveDir(
         `Score (absolute) less than error (score=${fittestScore}, error=${error})`,
       );
       bestScore = fittestScore;
-      bestCreature = CreatureClass.fromJSON(exportJSONWithRuntimeIds(fittest));
-      bestCreature.uuid = fittest.uuid;
+      // Issue #2276: Use shallowClone() instead of exportJSONWithRuntimeIds +
+      // fromJSON round-trip. shallowClone() is 2.4–3.5x faster (Issue #1586)
+      // and preserves all necessary state including runtime IDs and UUIDs.
+      bestCreature = fittest.shallowClone() as InstanceType<
+        typeof CreatureClass
+      >;
       bestCreature.score = bestScore;
     }
 

--- a/test/creature/ShallowCloneRuntimeIds.ts
+++ b/test/creature/ShallowCloneRuntimeIds.ts
@@ -1,0 +1,257 @@
+/**
+ * Verify shallowClone() preserves all state that exportJSONWithRuntimeIds +
+ * fromJSON preserves, making it a safe replacement in CreatureTraining.ts.
+ *
+ * Issue #2276: Eliminate JSON round-trip in evolveDir bestCreature tracking.
+ *
+ * The old pattern:
+ *   bestCreature = CreatureClass.fromJSON(exportJSONWithRuntimeIds(fittest));
+ *   bestCreature.uuid = fittest.uuid;
+ *   bestCreature.score = bestScore;
+ *
+ * The new pattern:
+ *   bestCreature = fittest.shallowClone();
+ *   bestCreature.score = bestScore;
+ *
+ * This test confirms the two approaches produce functionally equivalent
+ * creatures with matching neuron UUIDs, runtime IDs, synapse structure,
+ * activation outputs, tags, and score.
+ */
+
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import { addTag, getTag } from "@stsoftware/tags/mod";
+import { Creature } from "@creature";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+Deno.test(
+  "shallowClone preserves runtime IDs equivalent to exportJSONWithRuntimeIds",
+  () => {
+    const original = new Creature(5, 3, {
+      layers: [{ count: 10, squash: "LOGISTIC" }],
+    });
+    original.uuid = "runtime-id-preservation-test";
+    original.score = 0.92;
+    addTag(original, "error", "0.08");
+    addTag(original, "approach", "trained");
+    creatureValidate(original);
+
+    // Old pattern: exportJSONWithRuntimeIds + fromJSON
+    const jsonClone = Creature.fromJSON(exportJSONWithRuntimeIds(original));
+    jsonClone.uuid = original.uuid;
+    jsonClone.score = original.score;
+
+    // New pattern: shallowClone
+    const shallowCloneResult = original.shallowClone();
+    shallowCloneResult.score = original.score;
+
+    // Verify both clones have the same uuid
+    assertEquals(
+      shallowCloneResult.uuid,
+      jsonClone.uuid,
+      "UUID should match between shallowClone and JSON clone",
+    );
+
+    // Verify both clones have the same score
+    assertEquals(
+      shallowCloneResult.score,
+      jsonClone.score,
+      "Score should match between shallowClone and JSON clone",
+    );
+
+    // Verify neuron runtime IDs match
+    assertEquals(
+      shallowCloneResult.neurons.length,
+      jsonClone.neurons.length,
+      "Neuron count should match",
+    );
+    for (let i = 0; i < shallowCloneResult.neurons.length; i++) {
+      assertEquals(
+        shallowCloneResult.neurons[i].id,
+        jsonClone.neurons[i].id,
+        `Neuron ${i} runtime ID should match`,
+      );
+      assertEquals(
+        shallowCloneResult.neurons[i].type,
+        jsonClone.neurons[i].type,
+        `Neuron ${i} type should match`,
+      );
+      if (shallowCloneResult.neurons[i].type !== "input") {
+        assertEquals(
+          shallowCloneResult.neurons[i].bias,
+          jsonClone.neurons[i].bias,
+          `Neuron ${i} bias should match`,
+        );
+        assertEquals(
+          shallowCloneResult.neurons[i].squash,
+          jsonClone.neurons[i].squash,
+          `Neuron ${i} squash should match`,
+        );
+      }
+    }
+
+    // Verify neuron UUIDs match for hidden neurons
+    for (let i = original.input; i < shallowCloneResult.neurons.length; i++) {
+      const shallowNeuron = shallowCloneResult.neurons[i];
+      const jsonNeuron = jsonClone.neurons[i];
+      if (
+        shallowNeuron.type === "hidden" || shallowNeuron.type === "constant"
+      ) {
+        assertEquals(
+          shallowNeuron.uuid,
+          jsonNeuron.uuid,
+          `Neuron ${i} UUID should match`,
+        );
+      }
+    }
+
+    // Verify synapse structure matches
+    assertEquals(
+      shallowCloneResult.synapses.length,
+      jsonClone.synapses.length,
+      "Synapse count should match",
+    );
+    for (let i = 0; i < shallowCloneResult.synapses.length; i++) {
+      assertEquals(
+        shallowCloneResult.synapses[i].from,
+        jsonClone.synapses[i].from,
+        `Synapse ${i} from should match`,
+      );
+      assertEquals(
+        shallowCloneResult.synapses[i].to,
+        jsonClone.synapses[i].to,
+        `Synapse ${i} to should match`,
+      );
+      assertEquals(
+        shallowCloneResult.synapses[i].weight,
+        jsonClone.synapses[i].weight,
+        `Synapse ${i} weight should match`,
+      );
+    }
+
+    // Verify tags are preserved
+    assertEquals(
+      getTag(shallowCloneResult, "error"),
+      getTag(jsonClone, "error"),
+      "Error tag should match",
+    );
+
+    // Verify activation outputs match
+    const input = new Float32Array([0.1, 0.5, 0.9, 0.3, 0.7]);
+    shallowCloneResult.clearState();
+    jsonClone.clearState();
+    const shallowOutput = shallowCloneResult.activate(input);
+    const jsonOutput = jsonClone.activate(input);
+
+    for (let j = 0; j < shallowOutput.length; j++) {
+      assertAlmostEquals(
+        shallowOutput[j],
+        jsonOutput[j],
+        1e-10,
+        `Output mismatch at index ${j}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "shallowClone preserves runtime IDs for multi-layer creature",
+  () => {
+    const original = new Creature(10, 5, {
+      layers: [
+        { count: 20, squash: "LOGISTIC" },
+        { count: 10, squash: "TANH" },
+      ],
+    });
+    original.uuid = "multi-layer-runtime-ids";
+    original.score = 0.75;
+    addTag(original, "error", "0.25");
+    creatureValidate(original);
+
+    // Old pattern
+    const jsonClone = Creature.fromJSON(exportJSONWithRuntimeIds(original));
+    jsonClone.uuid = original.uuid;
+    jsonClone.score = original.score;
+
+    // New pattern
+    const shallowCloneResult = original.shallowClone();
+    shallowCloneResult.score = original.score;
+
+    // Verify all neuron runtime IDs match
+    for (let i = 0; i < shallowCloneResult.neurons.length; i++) {
+      assertEquals(
+        shallowCloneResult.neurons[i].id,
+        jsonClone.neurons[i].id,
+        `Neuron ${i} runtime ID mismatch in multi-layer creature`,
+      );
+    }
+
+    // Verify all synapse from/to runtime IDs match
+    for (let i = 0; i < shallowCloneResult.synapses.length; i++) {
+      assertEquals(
+        shallowCloneResult.synapses[i].from,
+        jsonClone.synapses[i].from,
+        `Synapse ${i} from ID mismatch`,
+      );
+      assertEquals(
+        shallowCloneResult.synapses[i].to,
+        jsonClone.synapses[i].to,
+        `Synapse ${i} to ID mismatch`,
+      );
+    }
+
+    // Verify activation equivalence with multiple inputs
+    for (let trial = 0; trial < 5; trial++) {
+      const input = new Float32Array(10);
+      for (let j = 0; j < 10; j++) {
+        input[j] = Math.random();
+      }
+      shallowCloneResult.clearState();
+      jsonClone.clearState();
+      const shallowOutput = shallowCloneResult.activate(input);
+      const jsonOutput = jsonClone.activate(input);
+
+      for (let j = 0; j < shallowOutput.length; j++) {
+        assertAlmostEquals(
+          shallowOutput[j],
+          jsonOutput[j],
+          1e-10,
+          `Multi-layer output mismatch at trial ${trial}, index ${j}`,
+        );
+      }
+    }
+  },
+);
+
+Deno.test("shallowClone preserves semantic version and forwardOnly", () => {
+  const original = new Creature(3, 2, {
+    layers: [{ count: 5 }],
+  });
+  original.uuid = "version-fwd-test";
+  original.score = 0.9;
+  original.forwardOnly = true;
+  creatureValidate(original);
+
+  // Old pattern
+  const jsonClone = Creature.fromJSON(exportJSONWithRuntimeIds(original));
+  jsonClone.uuid = original.uuid;
+  jsonClone.score = original.score;
+
+  // New pattern
+  const shallowCloneResult = original.shallowClone();
+  shallowCloneResult.score = original.score;
+
+  assertEquals(
+    shallowCloneResult.semanticVersion,
+    jsonClone.semanticVersion,
+    "Semantic version should match",
+  );
+
+  assertEquals(
+    shallowCloneResult.forwardOnly,
+    jsonClone.forwardOnly,
+    "forwardOnly flag should match",
+  );
+});


### PR DESCRIPTION
## Summary

Replace the expensive `exportJSONWithRuntimeIds()` → `Creature.fromJSON()` round-trip in `evolveDir()` bestCreature tracking with `shallowClone()`, achieving a 5–7x speedup. Closes #2276.

### bestCreature creation (CreatureTraining.ts) — **Optimised**

The `evolveDir` loop clones the fittest creature each time a new best score is found. The old pattern serialised to JSON and deserialised back:

```typescript
bestCreature = CreatureClass.fromJSON(exportJSONWithRuntimeIds(fittest));
bestCreature.uuid = fittest.uuid;
bestCreature.score = bestScore;
```

Replaced with `shallowClone()` which directly copies neurons and synapses in-memory:

```typescript
bestCreature = fittest.shallowClone() as InstanceType<typeof CreatureClass>;
bestCreature.score = bestScore;
```

### processCompletedResults (NeatEvolution.ts) — **Negative result (no change)**

The `fromJSON()` calls in `processCompletedResults` reconstruct creatures from `CreatureExport` objects received from worker threads. There is no in-memory `Creature` instance to clone from, so `shallowClone()` is not applicable. The existing `debug=false` path already skips validation, which is optimal for trusted worker output.

## Evidence

### Benchmark results (bench/BestCreatureClone.ts)

| Creature Size | Neurons | Synapses | JSON Round-trip | shallowClone | Speedup |
|---|---|---|---|---|---|
| Small | 35 | 300 | 47.9 µs | 9.0 µs | **5.31x** |
| Medium | 210 | 10,500 | 2.2 ms | 292.1 µs | **7.42x** |
| Large | 470 | 46,000 | 14.1 ms | 2.0 ms | **7.13x** |

### processCompletedResults benchmark (bench/ProcessCompletedResultsFromJSON.ts)

Documents that `fromJSON(debug=false)` is already 1.3–2.1x faster than `fromJSON(debug=true)`. No further optimisation possible without an in-memory Creature to clone.

### Verification

Tests confirm `shallowClone()` produces functionally identical creatures to the old JSON round-trip pattern — matching runtime IDs, neuron UUIDs, synapse structure, tags, scores, and activation outputs.

## Test Plan

- Added `test/creature/ShallowCloneRuntimeIds.ts` (3 tests) verifying:
  - `shallowClone()` preserves runtime IDs equivalent to `exportJSONWithRuntimeIds + fromJSON`
  - Multi-layer creature runtime ID and activation output equivalence
  - Semantic version and `forwardOnly` flag preservation
- All 5,751 existing tests pass (0 failures)
- Added `bench/BestCreatureClone.ts` — benchmarks bestCreature clone patterns
- Added `bench/ProcessCompletedResultsFromJSON.ts` — documents processCompletedResults findings



## Milestone
This PR is part of the **Speed up** milestone and targets the `milestone/speed-up` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2276 -->