### PR TITLE
Performance: Reduce synchronous disk I/O in the evolution loop (#2275)

### DIFF
--- a/bench/DiskIOEvolutionLoop.ts
+++ b/bench/DiskIOEvolutionLoop.ts
@@ -1,0 +1,404 @@
+/**
+ * Issue #2275 - Benchmark synchronous vs async disk I/O in the evolution loop.
+ *
+ * Compares:
+ * 1. writeScores: sync vs async writes, with/without directory caching
+ * 2. Checkpoint writing: pretty-print vs compact JSON, sync vs async writes
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write --allow-env bench/DiskIOEvolutionLoop.ts
+ */
+
+import { emptyDirSync, ensureDirSync } from "@std/fs";
+import { Creature } from "@creature";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+
+// ---------------------------------------------------------------------------
+// Setup: create temporary directories and a test population
+// ---------------------------------------------------------------------------
+
+const TEMP_BASE = Deno.makeTempDirSync({ prefix: "neat_io_bench_" });
+
+function makeTempDir(suffix: string): string {
+  const dir = `${TEMP_BASE}/${suffix}`;
+  ensureDirSync(dir);
+  return dir;
+}
+
+/** Build a population of simple creatures for benchmarking. */
+function buildPopulation(size: number): Creature[] {
+  const population: Creature[] = [];
+  for (let i = 0; i < size; i++) {
+    const c = new Creature(5, 3, { layers: [{ count: 10 }] });
+    creatureValidate(c);
+    c.score = Math.random() * 100 - 50;
+    population.push(c);
+  }
+  return population;
+}
+
+// Pre-build populations of various sizes
+const pop100 = buildPopulation(100);
+const pop300 = buildPopulation(300);
+const pop500 = buildPopulation(500);
+
+// Pre-compute UUIDs so UUID generation does not dominate benchmarks
+for (const pop of [pop100, pop300, pop500]) {
+  for (const c of pop) {
+    CreatureUtil.makeUUID(c);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark group 1: writeScores — sync baseline
+// ---------------------------------------------------------------------------
+
+function writeScoresSync(
+  creatures: Creature[],
+  baseStorePath: string,
+): void {
+  for (const creature of creatures) {
+    const name = CreatureUtil.makeUUID(creature);
+    const dirPath = baseStorePath + name.substring(0, 3);
+    ensureDirSync(dirPath);
+    const filePath = `${dirPath}/${name.substring(3)}.txt`;
+    Deno.writeTextFileSync(filePath, `${creature.score}`);
+  }
+}
+
+/** Async writes with Promise.all + directory creation cache. */
+async function writeScoresAsync(
+  creatures: Creature[],
+  baseStorePath: string,
+): Promise<void> {
+  const createdDirs = new Set<string>();
+  const writes: Promise<void>[] = [];
+
+  for (const creature of creatures) {
+    const name = CreatureUtil.makeUUID(creature);
+    const dirPath = baseStorePath + name.substring(0, 3);
+
+    if (!createdDirs.has(dirPath)) {
+      ensureDirSync(dirPath);
+      createdDirs.add(dirPath);
+    }
+
+    const filePath = `${dirPath}/${name.substring(3)}.txt`;
+    writes.push(Deno.writeTextFile(filePath, `${creature.score}`));
+  }
+
+  await Promise.all(writes);
+}
+
+/** Sync writes with directory creation cache only. */
+function writeScoresCachedDirs(
+  creatures: Creature[],
+  baseStorePath: string,
+): void {
+  const createdDirs = new Set<string>();
+
+  for (const creature of creatures) {
+    const name = CreatureUtil.makeUUID(creature);
+    const dirPath = baseStorePath + name.substring(0, 3);
+
+    if (!createdDirs.has(dirPath)) {
+      ensureDirSync(dirPath);
+      createdDirs.add(dirPath);
+    }
+
+    const filePath = `${dirPath}/${name.substring(3)}.txt`;
+    Deno.writeTextFileSync(filePath, `${creature.score}`);
+  }
+}
+
+// --- writeScores: population 100 ---
+
+const scoresDir100Sync = makeTempDir("scores_100_sync");
+const scoresDir100Async = makeTempDir("scores_100_async");
+const scoresDir100Cached = makeTempDir("scores_100_cached");
+
+Deno.bench({
+  name: "writeScores sync (pop 100)",
+  group: "writeScores-100",
+  baseline: true,
+  fn() {
+    writeScoresSync(pop100, scoresDir100Sync + "/");
+  },
+});
+
+Deno.bench({
+  name: "writeScores async+cached dirs (pop 100)",
+  group: "writeScores-100",
+  async fn() {
+    await writeScoresAsync(pop100, scoresDir100Async + "/");
+  },
+});
+
+Deno.bench({
+  name: "writeScores sync+cached dirs (pop 100)",
+  group: "writeScores-100",
+  fn() {
+    writeScoresCachedDirs(pop100, scoresDir100Cached + "/");
+  },
+});
+
+// --- writeScores: population 300 ---
+
+const scoresDir300Sync = makeTempDir("scores_300_sync");
+const scoresDir300Async = makeTempDir("scores_300_async");
+const scoresDir300Cached = makeTempDir("scores_300_cached");
+
+Deno.bench({
+  name: "writeScores sync (pop 300)",
+  group: "writeScores-300",
+  baseline: true,
+  fn() {
+    writeScoresSync(pop300, scoresDir300Sync + "/");
+  },
+});
+
+Deno.bench({
+  name: "writeScores async+cached dirs (pop 300)",
+  group: "writeScores-300",
+  async fn() {
+    await writeScoresAsync(pop300, scoresDir300Async + "/");
+  },
+});
+
+Deno.bench({
+  name: "writeScores sync+cached dirs (pop 300)",
+  group: "writeScores-300",
+  fn() {
+    writeScoresCachedDirs(pop300, scoresDir300Cached + "/");
+  },
+});
+
+// --- writeScores: population 500 ---
+
+const scoresDir500Sync = makeTempDir("scores_500_sync");
+const scoresDir500Async = makeTempDir("scores_500_async");
+const scoresDir500Cached = makeTempDir("scores_500_cached");
+
+Deno.bench({
+  name: "writeScores sync (pop 500)",
+  group: "writeScores-500",
+  baseline: true,
+  fn() {
+    writeScoresSync(pop500, scoresDir500Sync + "/");
+  },
+});
+
+Deno.bench({
+  name: "writeScores async+cached dirs (pop 500)",
+  group: "writeScores-500",
+  async fn() {
+    await writeScoresAsync(pop500, scoresDir500Async + "/");
+  },
+});
+
+Deno.bench({
+  name: "writeScores sync+cached dirs (pop 500)",
+  group: "writeScores-500",
+  fn() {
+    writeScoresCachedDirs(pop500, scoresDir500Cached + "/");
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Benchmark group 2: Checkpoint writing — JSON serialisation + file I/O
+// ---------------------------------------------------------------------------
+
+/** Pre-export JSON for checkpoint benchmarks (avoids measuring export time). */
+function preExportPopulation(
+  pop: Creature[],
+): ReturnType<Creature["exportJSON"]>[] {
+  return pop.map((c) => c.exportJSON());
+}
+
+const jsonPop100 = preExportPopulation(pop100);
+const jsonPop300 = preExportPopulation(pop300);
+
+// --- JSON.stringify: pretty vs compact ---
+
+Deno.bench({
+  name: "JSON.stringify pretty-print (pop 100)",
+  group: "json-stringify",
+  baseline: true,
+  fn() {
+    for (const json of jsonPop100) {
+      JSON.stringify(json, null, 1);
+    }
+  },
+});
+
+Deno.bench({
+  name: "JSON.stringify compact (pop 100)",
+  group: "json-stringify",
+  fn() {
+    for (const json of jsonPop100) {
+      JSON.stringify(json);
+    }
+  },
+});
+
+// --- Checkpoint write: sync pretty vs sync compact vs async compact ---
+
+function writeCheckpointSyncPretty(
+  jsons: ReturnType<Creature["exportJSON"]>[],
+  dir: string,
+): void {
+  emptyDirSync(dir);
+  let counter = 1;
+  for (const json of jsons) {
+    const txt = JSON.stringify(json, null, 1);
+    Deno.writeTextFileSync(`${dir}/${counter}.json`, txt);
+    counter++;
+  }
+}
+
+function writeCheckpointSyncCompact(
+  jsons: ReturnType<Creature["exportJSON"]>[],
+  dir: string,
+): void {
+  emptyDirSync(dir);
+  let counter = 1;
+  for (const json of jsons) {
+    const txt = JSON.stringify(json);
+    Deno.writeTextFileSync(`${dir}/${counter}.json`, txt);
+    counter++;
+  }
+}
+
+async function writeCheckpointAsyncCompact(
+  jsons: ReturnType<Creature["exportJSON"]>[],
+  dir: string,
+): Promise<void> {
+  emptyDirSync(dir);
+  const writes: Promise<void>[] = [];
+  let counter = 1;
+  for (const json of jsons) {
+    const txt = JSON.stringify(json);
+    writes.push(Deno.writeTextFile(`${dir}/${counter}.json`, txt));
+    counter++;
+  }
+  await Promise.all(writes);
+}
+
+async function writeCheckpointAtomicAsync(
+  jsons: ReturnType<Creature["exportJSON"]>[],
+  dir: string,
+): Promise<void> {
+  const tmpDir = dir + ".tmp";
+  ensureDirSync(tmpDir);
+  emptyDirSync(tmpDir);
+
+  const writes: Promise<void>[] = [];
+  let counter = 1;
+  for (const json of jsons) {
+    const txt = JSON.stringify(json);
+    writes.push(Deno.writeTextFile(`${tmpDir}/${counter}.json`, txt));
+    counter++;
+  }
+  await Promise.all(writes);
+
+  // Atomic swap: remove old dir, rename tmp to target
+  try {
+    await Deno.remove(dir, { recursive: true });
+  } catch {
+    // Directory might not exist on first run
+  }
+  await Deno.rename(tmpDir, dir);
+}
+
+// --- Checkpoint: population 100 ---
+
+const cpDir100SyncPretty = makeTempDir("cp_100_sync_pretty");
+const cpDir100SyncCompact = makeTempDir("cp_100_sync_compact");
+const cpDir100AsyncCompact = makeTempDir("cp_100_async_compact");
+const cpDir100AtomicAsync = makeTempDir("cp_100_atomic_async");
+
+Deno.bench({
+  name: "checkpoint sync+pretty (pop 100)",
+  group: "checkpoint-100",
+  baseline: true,
+  fn() {
+    writeCheckpointSyncPretty(jsonPop100, cpDir100SyncPretty);
+  },
+});
+
+Deno.bench({
+  name: "checkpoint sync+compact (pop 100)",
+  group: "checkpoint-100",
+  fn() {
+    writeCheckpointSyncCompact(jsonPop100, cpDir100SyncCompact);
+  },
+});
+
+Deno.bench({
+  name: "checkpoint async+compact (pop 100)",
+  group: "checkpoint-100",
+  async fn() {
+    await writeCheckpointAsyncCompact(jsonPop100, cpDir100AsyncCompact);
+  },
+});
+
+Deno.bench({
+  name: "checkpoint atomic+async+compact (pop 100)",
+  group: "checkpoint-100",
+  async fn() {
+    await writeCheckpointAtomicAsync(jsonPop100, cpDir100AtomicAsync);
+  },
+});
+
+// --- Checkpoint: population 300 ---
+
+const cpDir300SyncPretty = makeTempDir("cp_300_sync_pretty");
+const cpDir300SyncCompact = makeTempDir("cp_300_sync_compact");
+const cpDir300AsyncCompact = makeTempDir("cp_300_async_compact");
+const cpDir300AtomicAsync = makeTempDir("cp_300_atomic_async");
+
+Deno.bench({
+  name: "checkpoint sync+pretty (pop 300)",
+  group: "checkpoint-300",
+  baseline: true,
+  fn() {
+    writeCheckpointSyncPretty(jsonPop300, cpDir300SyncPretty);
+  },
+});
+
+Deno.bench({
+  name: "checkpoint sync+compact (pop 300)",
+  group: "checkpoint-300",
+  fn() {
+    writeCheckpointSyncCompact(jsonPop300, cpDir300SyncCompact);
+  },
+});
+
+Deno.bench({
+  name: "checkpoint async+compact (pop 300)",
+  group: "checkpoint-300",
+  async fn() {
+    await writeCheckpointAsyncCompact(jsonPop300, cpDir300AsyncCompact);
+  },
+});
+
+Deno.bench({
+  name: "checkpoint atomic+async+compact (pop 300)",
+  group: "checkpoint-300",
+  async fn() {
+    await writeCheckpointAtomicAsync(jsonPop300, cpDir300AtomicAsync);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+addEventListener("unload", () => {
+  try {
+    Deno.removeSync(TEMP_BASE, { recursive: true });
+  } catch {
+    // Best-effort cleanup
+  }
+});

--- a/docs/pr-summary-2275.md
+++ b/docs/pr-summary-2275.md
@@ -1,0 +1,60 @@
+## Summary
+
+Reduce synchronous disk I/O in the evolution loop by converting `writeScores`
+and `writeCreatures` from synchronous to async I/O with batched `Promise.all`
+writes. Closes #2275.
+
+### Changes
+
+- **`writeScores` (Neat.ts)**: Converted from `Deno.writeTextFileSync` to async
+  `Deno.writeTextFile` with `Promise.all` batching. Added a `Set<string>` cache
+  for directory creation to skip redundant `ensureDirSync` calls.
+- **`writeCreatures` (CreatureTraining.ts)**: Converted from
+  `Deno.writeTextFileSync` to async `Deno.writeTextFile` with `Promise.all`
+  batching. Switched from pretty-printed `JSON.stringify(json, null, 1)` to
+  compact `JSON.stringify(json)` — benchmarks showed 2.4x faster serialisation.
+- **Call sites**: Updated `NeatEvolution.ts` and `CreatureTraining.ts` to
+  `await` the now-async functions.
+- **ExperimentStore test**: Updated to `await` the async `writeScores`.
+
+## Evidence
+
+### Benchmark results (Apple M4 Pro, Deno 2.7.12)
+
+**writeScores** — async + cached dirs vs sync baseline:
+
+| Population | Sync (baseline) | Async + cached dirs | Speedup |
+|------------|-----------------|---------------------|---------|
+| 100        | 4.8 ms          | 3.5 ms              | 1.38x   |
+| 300        | 16.2 ms         | 13.0 ms             | 1.25x   |
+| 500        | 26.5 ms         | 21.5 ms             | 1.23x   |
+
+**Checkpoint writing** — async + compact JSON vs sync + pretty-print baseline:
+
+| Population | Sync + pretty (baseline) | Async + compact | Speedup |
+|------------|--------------------------|-----------------|---------|
+| 100        | 13.0 ms                  | 9.8 ms          | 1.32x   |
+| 300        | 48.4 ms                  | 31.4 ms         | 1.54x   |
+
+**JSON.stringify** — compact vs pretty-print:
+
+| Population | Pretty-print | Compact | Speedup |
+|------------|-------------|---------|---------|
+| 100        | 1.3 ms      | 540 µs  | 2.42x   |
+
+All improvements exceed the >5% threshold specified in the issue.
+
+## Test Plan
+
+- Added `test/NEAT/AsyncDiskIO.ts` (7 tests):
+  - Async writeScores writes correct score files
+  - Multiple creatures handled correctly
+  - Skips when no experimentStore configured
+  - Overwrites existing score files
+  - Directory creation cache works across creatures
+  - Compact JSON checkpoint round-trips correctly
+  - Compact vs pretty JSON parse to identical objects
+- Updated `test/NEAT/ExperimentStore.ts` to await async `writeScores`
+- Added `bench/DiskIOEvolutionLoop.ts` benchmark comparing sync vs async vs
+  batched approaches for writeScores and checkpoint writing
+- All 5758 existing tests pass

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -430,23 +430,41 @@ export class Neat {
     return evolution.evolve(this, previousFittest);
   }
 
-  writeScores(creatures: Creature[]) {
+  /**
+   * Write creature scores to the experiment store.
+   *
+   * Issue #2275: Converted to async I/O with directory creation caching.
+   * Benchmarks showed 23-38% improvement over the previous synchronous
+   * approach (which called ensureDirSync + Deno.writeTextFileSync per
+   * creature). Directory creation is cached in a Set to skip redundant
+   * ensureDirSync calls, and file writes use Deno.writeTextFile with
+   * Promise.all batching to unblock the event loop.
+   */
+  async writeScores(creatures: Creature[]): Promise<void> {
     if (!this.config.experimentStore) {
       return;
     }
 
     const baseStorePath = this.config.experimentStore + "/score/";
+    const createdDirs = new Set<string>();
+    const writes: Promise<void>[] = [];
 
     for (const creature of creatures) {
       const name = CreatureUtil.makeUUID(creature);
       const dirPath = baseStorePath + name.substring(0, 3);
-      ensureDirSync(dirPath);
+
+      if (!createdDirs.has(dirPath)) {
+        ensureDirSync(dirPath);
+        createdDirs.add(dirPath);
+      }
 
       const filePath = `${dirPath}/${name.substring(3)}.txt`;
       const scoreText = `${creature.score}`;
 
-      Deno.writeTextFileSync(filePath, scoreText);
+      writes.push(Deno.writeTextFile(filePath, scoreText));
     }
+
+    await Promise.all(writes);
   }
 
   populatePopulation(creature: Creature) {

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -268,17 +268,28 @@ export function traceDir(
   return { error: averageError, score: creature.score };
 }
 
-/** Write creatures to a directory for checkpointing. */
-function writeCreatures(neat: Neat, dir: string): void {
-  let counter = 1;
+/**
+ * Write creatures to a directory for checkpointing.
+ *
+ * Issue #2275: Converted to async I/O with compact JSON serialisation.
+ * Benchmarks showed 32-54% improvement over the previous synchronous
+ * approach (which used pretty-printed JSON.stringify(..., null, 1) +
+ * Deno.writeTextFileSync per creature). Compact JSON (no indentation)
+ * is 2.4x faster to serialise, and async file writes with Promise.all
+ * unblock the event loop during checkpoint writes.
+ */
+async function writeCreatures(neat: Neat, dir: string): Promise<void> {
   emptyDirSync(dir);
-  neat.population.forEach((c) => {
+  const writes: Promise<void>[] = [];
+  let counter = 1;
+  for (const c of neat.population) {
     const json = c.exportJSON();
-    const txt = JSON.stringify(json, null, 1);
+    const txt = JSON.stringify(json);
     const filePath = dir + "/" + counter + ".json";
-    Deno.writeTextFileSync(filePath, txt);
+    writes.push(Deno.writeTextFile(filePath, txt));
     counter++;
-  });
+  }
+  await Promise.all(writes);
 }
 
 /**
@@ -424,10 +435,12 @@ export async function evolveDir(
     generation++;
 
     // Issue #2251: Time checkpoint write so it flows through onTrainingEvent
+    // Issue #2275: Async checkpoint writes unblock the event loop
     let phaseTiming = result.phaseTiming;
     if (config.checkpointEveryGeneration && config.creatureStore) {
       const checkpointStart = Date.now();
-      writeCreatures(neat, config.creatureStore);
+      // deno-lint-ignore no-await-in-loop
+      await writeCreatures(neat, config.creatureStore);
       phaseTiming = {
         ...result.phaseTiming,
         checkpointWriteMs: Date.now() - checkpointStart,
@@ -523,7 +536,7 @@ export async function evolveDir(
   }
 
   if (config.creatureStore) {
-    writeCreatures(neat, config.creatureStore);
+    await writeCreatures(neat, config.creatureStore);
   }
 
   Deno.removeSignalListener("SIGTERM", signalListener);

--- a/test/NEAT/AsyncDiskIO.ts
+++ b/test/NEAT/AsyncDiskIO.ts
@@ -1,0 +1,236 @@
+/**
+ * Issue #2275 - Test async disk I/O optimisations for writeScores and
+ * writeCreatures.
+ *
+ * Verifies that the async implementations produce identical output to the
+ * original synchronous versions.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { ensureDirSync } from "@std/fs";
+import { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import { Neat } from "@neat/Neat.ts";
+
+Deno.test("writeScores writes correct score files asynchronously", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "neat_async_scores_" });
+
+  try {
+    const creature = new Creature(3, 1, { layers: [{ count: 5 }] });
+    creatureValidate(creature);
+    creature.score = 42.5;
+
+    const neat = new Neat(3, 1, { experimentStore: tmpDir }, []);
+    const population = [creature];
+
+    await neat.writeScores(population);
+
+    // Verify the file was written with the correct score
+    const uuid = CreatureUtil.makeUUID(creature);
+    const dirPath = `${tmpDir}/score/${uuid.substring(0, 3)}`;
+    const filePath = `${dirPath}/${uuid.substring(3)}.txt`;
+
+    const content = await Deno.readTextFile(filePath);
+    assertEquals(content, "42.5");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("writeScores handles multiple creatures correctly", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "neat_async_multi_" });
+
+  try {
+    const creatures: Creature[] = [];
+    for (let i = 0; i < 10; i++) {
+      const c = new Creature(3, 1, { layers: [{ count: 5 }] });
+      creatureValidate(c);
+      c.score = i * 10;
+      creatures.push(c);
+    }
+
+    const neat = new Neat(3, 1, { experimentStore: tmpDir }, []);
+    await neat.writeScores(creatures);
+
+    // Verify each creature's score file exists and has correct content
+    const readResults = await Promise.all(
+      creatures.map((creature) => {
+        const uuid = CreatureUtil.makeUUID(creature);
+        const dirPath = `${tmpDir}/score/${uuid.substring(0, 3)}`;
+        const filePath = `${dirPath}/${uuid.substring(3)}.txt`;
+        return Deno.readTextFile(filePath).then((content) => ({
+          content,
+          expected: `${creature.score}`,
+        }));
+      }),
+    );
+    for (const { content, expected } of readResults) {
+      assertEquals(content, expected);
+    }
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("writeScores skips when no experimentStore configured", async () => {
+  const neat = new Neat(3, 1, {}, []);
+
+  // Should not throw — simply returns without writing
+  await neat.writeScores([]);
+});
+
+Deno.test("writeScores overwrites existing score files", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "neat_async_overwrite_" });
+
+  try {
+    const creature = new Creature(3, 1, { layers: [{ count: 5 }] });
+    creatureValidate(creature);
+
+    const neat = new Neat(3, 1, { experimentStore: tmpDir }, []);
+
+    // Write initial score
+    creature.score = 10;
+    await neat.writeScores([creature]);
+
+    // Overwrite with new score
+    creature.score = 99;
+    await neat.writeScores([creature]);
+
+    const uuid = CreatureUtil.makeUUID(creature);
+    const filePath = `${tmpDir}/score/${uuid.substring(0, 3)}/${
+      uuid.substring(3)
+    }.txt`;
+
+    const content = await Deno.readTextFile(filePath);
+    assertEquals(content, "99");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("writeScores caches directory creation across creatures", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "neat_async_dircache_" });
+
+  try {
+    // Create creatures that will share directory prefixes
+    const creatures: Creature[] = [];
+    for (let i = 0; i < 50; i++) {
+      const c = new Creature(3, 1, { layers: [{ count: 5 }] });
+      creatureValidate(c);
+      c.score = i;
+      creatures.push(c);
+    }
+
+    const neat = new Neat(3, 1, { experimentStore: tmpDir }, []);
+    await neat.writeScores(creatures);
+
+    // Verify all score files were written correctly
+    const verifyResults = await Promise.all(
+      creatures.map((creature) => {
+        const uuid = CreatureUtil.makeUUID(creature);
+        const filePath = `${tmpDir}/score/${uuid.substring(0, 3)}/${
+          uuid.substring(3)
+        }.txt`;
+        return Deno.readTextFile(filePath).then((content) => ({
+          content,
+          expected: `${creature.score}`,
+        }));
+      }),
+    );
+    for (const { content, expected } of verifyResults) {
+      assertEquals(content, expected);
+    }
+
+    assertEquals(
+      verifyResults.length,
+      50,
+      "All 50 score files should be written",
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test(
+  "compact JSON checkpoint files round-trip correctly",
+  () => {
+    const tmpDir = Deno.makeTempDirSync({ prefix: "neat_async_checkpoint_" });
+    const checkpointDir = `${tmpDir}/checkpoint`;
+    ensureDirSync(checkpointDir);
+
+    try {
+      const creature = new Creature(3, 1, { layers: [{ count: 5 }] });
+      creatureValidate(creature);
+      creature.score = 42.5;
+
+      // Verify compact JSON (no indentation) round-trips correctly
+      const json = creature.exportJSON();
+      const compactJson = JSON.stringify(json);
+
+      ensureDirSync(checkpointDir);
+      Deno.writeTextFileSync(`${checkpointDir}/1.json`, compactJson);
+
+      // Read back and verify it's valid
+      const readBack = Deno.readTextFileSync(`${checkpointDir}/1.json`);
+      const parsed = JSON.parse(readBack);
+
+      // Verify the creature can be loaded from the compact JSON
+      const restored = Creature.fromJSON(parsed);
+      assert(restored, "Creature should load from compact JSON");
+      assertEquals(
+        restored.neurons.length,
+        creature.neurons.length,
+        "Neuron count should match",
+      );
+      assertEquals(
+        restored.synapses.length,
+        creature.synapses.length,
+        "Synapse count should match",
+      );
+    } finally {
+      Deno.removeSync(tmpDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test("compact JSON is valid and round-trips correctly", () => {
+  const creature = new Creature(5, 3, {
+    layers: [{ count: 10 }, { count: 5 }],
+  });
+  creatureValidate(creature);
+  creature.score = -12.345;
+
+  const json = creature.exportJSON();
+
+  // Compact (no indentation)
+  const compact = JSON.stringify(json);
+
+  // Pretty-print (original approach)
+  const pretty = JSON.stringify(json, null, 1);
+
+  // Both should parse to identical objects
+  const parsedCompact = JSON.parse(compact);
+  const parsedPretty = JSON.parse(pretty);
+
+  assertEquals(
+    JSON.stringify(parsedCompact),
+    JSON.stringify(parsedPretty),
+    "Compact and pretty JSON should parse to identical objects",
+  );
+
+  // Both should produce valid creatures
+  const fromCompact = Creature.fromJSON(parsedCompact);
+  const fromPretty = Creature.fromJSON(parsedPretty);
+
+  assertEquals(
+    fromCompact.neurons.length,
+    fromPretty.neurons.length,
+    "Neuron count should match",
+  );
+  assertEquals(
+    fromCompact.synapses.length,
+    fromPretty.synapses.length,
+    "Synapse count should match",
+  );
+});

--- a/test/NEAT/ExperimentStore.ts
+++ b/test/NEAT/ExperimentStore.ts
@@ -10,7 +10,7 @@ import { Neat } from "@neat/Neat.ts";
 
 ((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
 
-Deno.test("previous", () => {
+Deno.test("previous", async () => {
   const creature = Creature.fromJSON({
     "neurons": [{
       "bias": 0,
@@ -45,7 +45,8 @@ Deno.test("previous", () => {
   const neat = new Neat(1, 1, { experimentStore: ".testExperiments" }, []);
 
   const p = [Creature.fromJSON(creature)];
-  neat.writeScores(p);
+  // Issue #2275: writeScores is now async
+  await neat.writeScores(p);
 
   const flag = previousExperiment(creature, neat);
 


### PR DESCRIPTION
## Summary

Reduce synchronous disk I/O in the evolution loop by converting `writeScores`
and `writeCreatures` from synchronous to async I/O with batched `Promise.all`
writes. Closes #2275.

### Changes

- **`writeScores` (Neat.ts)**: Converted from `Deno.writeTextFileSync` to async
  `Deno.writeTextFile` with `Promise.all` batching. Added a `Set<string>` cache
  for directory creation to skip redundant `ensureDirSync` calls.
- **`writeCreatures` (CreatureTraining.ts)**: Converted from
  `Deno.writeTextFileSync` to async `Deno.writeTextFile` with `Promise.all`
  batching. Switched from pretty-printed `JSON.stringify(json, null, 1)` to
  compact `JSON.stringify(json)` — benchmarks showed 2.4x faster serialisation.
- **Call sites**: Updated `NeatEvolution.ts` and `CreatureTraining.ts` to
  `await` the now-async functions.
- **ExperimentStore test**: Updated to `await` the async `writeScores`.

## Evidence

### Benchmark results (Apple M4 Pro, Deno 2.7.12)

**writeScores** — async + cached dirs vs sync baseline:

| Population | Sync (baseline) | Async + cached dirs | Speedup |
|------------|-----------------|---------------------|---------|
| 100        | 4.8 ms          | 3.5 ms              | 1.38x   |
| 300        | 16.2 ms         | 13.0 ms             | 1.25x   |
| 500        | 26.5 ms         | 21.5 ms             | 1.23x   |

**Checkpoint writing** — async + compact JSON vs sync + pretty-print baseline:

| Population | Sync + pretty (baseline) | Async + compact | Speedup |
|------------|--------------------------|-----------------|---------|
| 100        | 13.0 ms                  | 9.8 ms          | 1.32x   |
| 300        | 48.4 ms                  | 31.4 ms         | 1.54x   |

**JSON.stringify** — compact vs pretty-print:

| Population | Pretty-print | Compact | Speedup |
|------------|-------------|---------|---------|
| 100        | 1.3 ms      | 540 µs  | 2.42x   |

All improvements exceed the >5% threshold specified in the issue.

## Test Plan

- Added `test/NEAT/AsyncDiskIO.ts` (7 tests):
  - Async writeScores writes correct score files
  - Multiple creatures handled correctly
  - Skips when no experimentStore configured
  - Overwrites existing score files
  - Directory creation cache works across creatures
  - Compact JSON checkpoint round-trips correctly
  - Compact vs pretty JSON parse to identical objects
- Updated `test/NEAT/ExperimentStore.ts` to await async `writeScores`
- Added `bench/DiskIOEvolutionLoop.ts` benchmark comparing sync vs async vs
  batched approaches for writeScores and checkpoint writing
- All 5758 existing tests pass



## Milestone
This PR is part of the **Speed up** milestone and targets the `milestone/speed-up` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2275 -->