### PR TITLE
Add sub-phase timing instrumentation within the breeding phase (#2284)

### DIFF
--- a/bench/BreedingSubPhaseProfile.ts
+++ b/bench/BreedingSubPhaseProfile.ts
@@ -25,9 +25,7 @@
  */
 
 import { Creature } from "@creature";
-import { Offspring } from "@architecture/Offspring.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
-import { BreedingSubPhaseAccumulator } from "@breed/BreedingSubPhaseAccumulator.ts";
 import { ParallelBreeding } from "@breed/ParallelBreeding.ts";
 import { Genus } from "@neat/Genus.ts";
 import { createNeatConfig } from "@config/NeatConfig.ts";
@@ -297,7 +295,10 @@ for (const cfg of configurations) {
 
       const timings: BreedingSubPhaseTiming[] = [];
 
+      // Sequential batches are intentional — each batch must complete before
+      // the next to get accurate per-batch sub-phase timing data.
       for (let batch = 0; batch < cfg.breedingBatches; batch++) {
+        // deno-lint-ignore no-await-in-loop
         await parallelBreeding.breedBatch(cfg.batchSize);
         if (parallelBreeding.lastBreedingSubPhases) {
           timings.push(parallelBreeding.lastBreedingSubPhases);

--- a/bench/BreedingSubPhaseProfile.ts
+++ b/bench/BreedingSubPhaseProfile.ts
@@ -1,0 +1,310 @@
+/**
+ * Issue #2284 — Profile breeding sub-phase timing.
+ *
+ * Dedicated benchmark that directly measures sub-phase timing within
+ * `Offspring.breed()` using the `BreedingSubPhaseAccumulator`. This
+ * bypasses the worker pool to capture internal algorithm timings
+ * (workers run `Offspring.breed()` in a separate thread without
+ * accumulator access).
+ *
+ * Profiles six sub-operations:
+ *   1. Parent selection (via FitnessRanking)
+ *   2. Genetic compatibility calculation
+ *   3. Genome alignment & crossover (neuron map building)
+ *   4. sortNeurons (dependency-aware ordering)
+ *   5. Batch connection building (dedup)
+ *   6. Post-breeding repair (forward-only, UUID uniqueness)
+ *
+ * Configurations match PR #2281 methodology:
+ *   - Small:  ~10 neurons
+ *   - Medium: ~30 neurons
+ *   - Large:  ~80 neurons
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write --allow-env --allow-ffi bench/BreedingSubPhaseProfile.ts
+ */
+
+import { Creature } from "@creature";
+import { Offspring } from "@architecture/Offspring.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { BreedingSubPhaseAccumulator } from "@breed/BreedingSubPhaseAccumulator.ts";
+import { ParallelBreeding } from "@breed/ParallelBreeding.ts";
+import { Genus } from "@neat/Genus.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { AddNeuron } from "@mutate/AddNeuron.ts";
+import { AddConnection } from "@mutate/AddConnection.ts";
+import type { BreedingSubPhaseTiming } from "@config/TrainingEvent.ts";
+
+// ──────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a creature of a specified size using mutation operators
+ * from a minimal base. Produces valid forward-only creatures
+ * with realistic topology.
+ */
+function buildCreatureOfSize(
+  inputCount: number,
+  outputCount: number,
+  hiddenNeuronTarget: number,
+): Creature {
+  const creature = new Creature(inputCount, outputCount);
+
+  let attempts = 0;
+  while (
+    creature.neurons.length - inputCount - outputCount < hiddenNeuronTarget &&
+    attempts < hiddenNeuronTarget * 10
+  ) {
+    try {
+      const addNeuron = new AddNeuron(creature);
+      addNeuron.mutate();
+      creature.fix();
+    } catch {
+      // Some mutations may fail — expected
+    }
+    attempts++;
+  }
+
+  const targetSynapses = Math.min(
+    hiddenNeuronTarget * 4,
+    creature.neurons.length * (creature.neurons.length - 1) / 4,
+  );
+  attempts = 0;
+  while (creature.synapses.length < targetSynapses && attempts < 5000) {
+    try {
+      const addConn = new AddConnection(creature);
+      addConn.mutate();
+      creature.fix();
+    } catch {
+      // Connection already exists or otherwise invalid
+    }
+    attempts++;
+  }
+
+  return creature;
+}
+
+/**
+ * Create a diverse population by building multiple creatures of varied sizes.
+ * Each creature has unique topology to ensure breeding produces viable offspring.
+ */
+function createDiversePopulation(
+  inputCount: number,
+  outputCount: number,
+  baseHiddenNeurons: number,
+  size: number,
+): Creature[] {
+  const population: Creature[] = [];
+  for (let i = 0; i < size; i++) {
+    // Vary hidden neuron count for topological diversity
+    const hiddenTarget = Math.max(
+      2,
+      baseHiddenNeurons + (i % 5) - 2,
+    );
+    const creature = buildCreatureOfSize(inputCount, outputCount, hiddenTarget);
+    creature.score = -0.5 + (i / size) * 0.4;
+    CreatureUtil.makeUUID(creature);
+    population.push(creature);
+  }
+  return population;
+}
+
+/** Format a number with fixed decimal places. */
+function fmt(n: number, decimals = 1): string {
+  return n.toFixed(decimals);
+}
+
+/** Aggregate timing statistics for a sub-phase. */
+interface SubPhaseStats {
+  name: string;
+  totalMs: number;
+  meanMs: number;
+  pctOfBreeding: number;
+}
+
+/**
+ * Print the breeding sub-phase results table.
+ */
+function printSubPhaseTable(
+  label: string,
+  timings: BreedingSubPhaseTiming[],
+): void {
+  if (timings.length === 0) {
+    console.log(`\n  ${label}: no successful breedings`);
+    return;
+  }
+
+  const fields: { key: keyof BreedingSubPhaseTiming; label: string }[] = [
+    { key: "parentSelectionMs", label: "parentSelection" },
+    { key: "geneticCompatibilityMs", label: "geneticCompatibility" },
+    { key: "alignmentCrossoverMs", label: "alignmentCrossover" },
+    { key: "sortNeuronsMs", label: "sortNeurons" },
+    { key: "batchConnectionMs", label: "batchConnection" },
+    { key: "postBreedingRepairMs", label: "postBreedingRepair" },
+  ];
+
+  // Sum all sub-phase times to get total breeding time
+  let totalBreedingMs = 0;
+  const sums: Record<string, number> = {};
+  for (const f of fields) {
+    sums[f.label] = 0;
+  }
+
+  let totalOffspring = 0;
+  for (const t of timings) {
+    for (const f of fields) {
+      const val = t[f.key] as number;
+      sums[f.label] += val;
+      totalBreedingMs += val;
+    }
+    totalOffspring += t.offspringCount;
+  }
+
+  const stats: SubPhaseStats[] = fields.map((f) => ({
+    name: f.label,
+    totalMs: sums[f.label],
+    meanMs: sums[f.label] / timings.length,
+    pctOfBreeding: totalBreedingMs > 0
+      ? (sums[f.label] / totalBreedingMs) * 100
+      : 0,
+  }));
+
+  // Sort by percentage descending
+  stats.sort((a, b) => b.pctOfBreeding - a.pctOfBreeding);
+
+  console.log(`\n${"═".repeat(72)}`);
+  console.log(
+    `  ${label}  (${timings.length} batches, ${totalOffspring} offspring)`,
+  );
+  console.log(`${"═".repeat(72)}`);
+  console.log(
+    `  ${"Sub-phase".padEnd(24)} ${"Mean(ms)".padStart(10)} ${
+      "Total(ms)".padStart(10)
+    } ${"% Breed".padStart(10)}`,
+  );
+  console.log(`  ${"─".repeat(56)}`);
+
+  for (const s of stats) {
+    console.log(
+      `  ${s.name.padEnd(24)} ${fmt(s.meanMs).padStart(10)} ${
+        fmt(s.totalMs).padStart(10)
+      } ${fmt(s.pctOfBreeding).padStart(9)}%`,
+    );
+  }
+
+  const avgBreedingMs = totalBreedingMs / timings.length;
+  console.log(`  ${"─".repeat(56)}`);
+  console.log(
+    `  ${"Total (avg)".padEnd(24)} ${fmt(avgBreedingMs).padStart(10)} ${
+      fmt(totalBreedingMs).padStart(10)
+    }`,
+  );
+  console.log(
+    `  ${"Offspring (avg)".padEnd(24)} ${
+      fmt(totalOffspring / timings.length, 0).padStart(10)
+    }`,
+  );
+
+  // Identify top 2–3 hotspots
+  console.log(`\n  Top breeding hotspots:`);
+  for (let i = 0; i < Math.min(3, stats.length); i++) {
+    if (stats[i].pctOfBreeding > 0) {
+      console.log(
+        `    ${i + 1}. ${stats[i].name} — ${
+          fmt(stats[i].pctOfBreeding)
+        }% of breeding time`,
+      );
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Benchmark configurations
+// ──────────────────────────────────────────────────────────────────
+
+interface BenchConfig {
+  label: string;
+  inputCount: number;
+  outputCount: number;
+  hiddenNeurons: number;
+  populationSize: number;
+  breedingBatches: number;
+  batchSize: number;
+}
+
+const configurations: BenchConfig[] = [
+  // Small creatures
+  {
+    label: "Small (~10 neurons) × pop 50",
+    inputCount: 3,
+    outputCount: 1,
+    hiddenNeurons: 6,
+    populationSize: 50,
+    breedingBatches: 10,
+    batchSize: 30,
+  },
+  // Medium creatures
+  {
+    label: "Medium (~30 neurons) × pop 50",
+    inputCount: 5,
+    outputCount: 2,
+    hiddenNeurons: 23,
+    populationSize: 50,
+    breedingBatches: 10,
+    batchSize: 30,
+  },
+  // Large creatures
+  {
+    label: "Large (~80 neurons) × pop 50",
+    inputCount: 8,
+    outputCount: 3,
+    hiddenNeurons: 69,
+    populationSize: 50,
+    breedingBatches: 10,
+    batchSize: 30,
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────
+// Benchmark runner
+// ──────────────────────────────────────────────────────────────────
+
+for (const cfg of configurations) {
+  Deno.bench({
+    name: `Breeding sub-phases: ${cfg.label}`,
+    n: 1,
+    warmup: 0,
+    fn: async () => {
+      const population = createDiversePopulation(
+        cfg.inputCount,
+        cfg.outputCount,
+        cfg.hiddenNeurons,
+        cfg.populationSize,
+      );
+      const genus = new Genus();
+      for (const creature of population) {
+        genus.addCreature(creature);
+      }
+
+      const config = createNeatConfig({
+        populationSize: cfg.populationSize,
+        geneticCompatibilityThreshold: 0.3,
+      });
+
+      // Use ParallelBreeding without workers to capture sub-phase timing
+      const parallelBreeding = new ParallelBreeding(genus, config);
+
+      const timings: BreedingSubPhaseTiming[] = [];
+
+      for (let batch = 0; batch < cfg.breedingBatches; batch++) {
+        await parallelBreeding.breedBatch(cfg.batchSize);
+        if (parallelBreeding.lastBreedingSubPhases) {
+          timings.push(parallelBreeding.lastBreedingSubPhases);
+        }
+      }
+
+      printSubPhaseTable(cfg.label, timings);
+    },
+  });
+}

--- a/bench/EvolveDirPhaseProfile.ts
+++ b/bench/EvolveDirPhaseProfile.ts
@@ -158,7 +158,19 @@ function printResultsTable(
     memoryEviction: [],
   };
 
+  // Issue #2284: Collect breeding sub-phase data
+  const breedingSubPhases: Record<string, number[]> = {
+    parentSelection: [],
+    geneticCompatibility: [],
+    alignmentCrossover: [],
+    sortNeurons: [],
+    batchConnection: [],
+    postBreedingRepair: [],
+  };
+  const offspringCounts: number[] = [];
+
   let totalMsSum = 0;
+  let totalBreedingMs = 0;
 
   for (const event of events) {
     const t = event.phaseTiming;
@@ -171,6 +183,19 @@ function printResultsTable(
     phases.writeScores.push(t.writeScoresMs ?? 0);
     phases.memoryEviction.push(t.memoryEvictionMs ?? 0);
     totalMsSum += t.totalMs;
+    totalBreedingMs += t.breedingMs;
+
+    // Issue #2284: Collect breeding sub-phase timing
+    if (t.breedingSubPhases) {
+      const bp = t.breedingSubPhases;
+      breedingSubPhases.parentSelection.push(bp.parentSelectionMs);
+      breedingSubPhases.geneticCompatibility.push(bp.geneticCompatibilityMs);
+      breedingSubPhases.alignmentCrossover.push(bp.alignmentCrossoverMs);
+      breedingSubPhases.sortNeurons.push(bp.sortNeuronsMs);
+      breedingSubPhases.batchConnection.push(bp.batchConnectionMs);
+      breedingSubPhases.postBreedingRepair.push(bp.postBreedingRepairMs);
+      offspringCounts.push(bp.offspringCount);
+    }
   }
 
   const stats: PhaseStats[] = [];
@@ -211,6 +236,71 @@ function printResultsTable(
     console.log(
       `    ${i + 1}. ${stats[i].name} — ${fmt(stats[i].pctOfTotal)}% of total`,
     );
+  }
+
+  // Issue #2284: Print breeding sub-phase breakdown
+  printBreedingSubPhases(breedingSubPhases, offspringCounts, totalBreedingMs);
+}
+
+/**
+ * Issue #2284: Print breeding sub-phase timing breakdown.
+ * Shows where time is spent within the breeding phase.
+ */
+function printBreedingSubPhases(
+  subPhases: Record<string, number[]>,
+  offspringCounts: number[],
+  totalBreedingMs: number,
+): void {
+  const hasData = Object.values(subPhases).some((v) => v.length > 0);
+  if (!hasData) {
+    console.log(
+      `\n  Breeding sub-phases: no data (workers may bypass instrumentation)`,
+    );
+    return;
+  }
+
+  const subStats: PhaseStats[] = [];
+  for (const [name, values] of Object.entries(subPhases)) {
+    subStats.push(computePhaseStats(name, values, totalBreedingMs));
+  }
+
+  // Sort by percentage descending
+  subStats.sort((a, b) => b.pctOfTotal - a.pctOfTotal);
+
+  const avgOffspring = offspringCounts.length > 0
+    ? offspringCounts.reduce((a, b) => a + b, 0) / offspringCounts.length
+    : 0;
+
+  console.log(`\n  ${"─".repeat(62)}`);
+  console.log(
+    `  Breeding sub-phases (avg ${fmt(avgOffspring, 0)} offspring/gen)`,
+  );
+  console.log(`  ${"─".repeat(62)}`);
+  console.log(
+    `  ${"Sub-phase".padEnd(22)} ${"Mean(ms)".padStart(10)} ${
+      "Min(ms)".padStart(10)
+    } ${"Max(ms)".padStart(10)} ${"% Breed".padStart(10)}`,
+  );
+  console.log(`  ${"─".repeat(62)}`);
+
+  for (const s of subStats) {
+    console.log(
+      `  ${s.name.padEnd(22)} ${fmt(s.meanMs).padStart(10)} ${
+        fmt(s.minMs).padStart(10)
+      } ${fmt(s.maxMs).padStart(10)} ${fmt(s.pctOfTotal).padStart(9)}%`,
+    );
+  }
+
+  // Identify top 2–3 breeding sub-phase hotspots
+  console.log(`\n  Top breeding hotspots:`);
+  for (let i = 0; i < Math.min(3, subStats.length); i++) {
+    if (subStats[i].pctOfTotal > 0) {
+      console.log(
+        `    ${i + 1}. ${subStats[i].name} — ${
+          fmt(subStats[i].pctOfTotal)
+        }% of breeding time`,
+      );
+    }
   }
 }
 

--- a/docs/pr-summary-2284.md
+++ b/docs/pr-summary-2284.md
@@ -1,0 +1,98 @@
+## Summary
+
+Add sub-phase timing instrumentation within the breeding phase to identify
+the actual hotspot within the 50–60% wall-clock time consumed by breeding.
+Closes #2284.
+
+PR #2281 identified breeding as the dominant bottleneck, but timing was at
+the phase level only. This PR adds finer-grained instrumentation around
+six sub-operations within `Offspring.breed()` and
+`ParallelBreeding.breedBatch()`:
+
+- **parentSelection** — selecting parent pairs via FitnessRanking
+- **geneticCompatibility** — computing compatibility between parents
+- **alignmentCrossover** — genome alignment, neuron map building, crossover
+- **sortNeurons** — dependency-aware topological sorting
+- **batchConnection** — batch synapse building with deduplication
+- **postBreedingRepair** — forward-only enforcement, UUID uniqueness, validation
+
+### Changes
+
+- `BreedingSubPhaseTiming` interface added to `TrainingEvent.ts`
+- `BreedingSubPhaseAccumulator` class for aggregating timing across offspring
+- `Offspring.breed()` instrumented with accumulator (zero-cost when not provided)
+- `ParallelBreeding.breedBatch()` creates accumulator, times parent selection,
+  exposes `lastBreedingSubPhases`
+- `NeatEvolution.ts` wires sub-phase timing into `GenerationPhaseTiming`
+- `EvolveDirPhaseProfile.ts` extended to report breeding sub-phase percentages
+- New `BreedingSubPhaseProfile.ts` benchmark for direct sub-phase profiling
+
+## Evidence
+
+### Benchmark Results (Apple M2 Ultra)
+
+**Small (~10 neurons) × pop 50** — 10 batches, ~15 offspring/batch:
+
+| Sub-phase | % of Breeding |
+|---|---|
+| postBreedingRepair | 34–44% |
+| parentSelection | 34–38% |
+| alignmentCrossover | 12–28% |
+| batchConnection | 0–8% |
+| sortNeurons | 0–2% |
+| geneticCompatibility | 0–3% |
+
+**Medium (~30 neurons) × pop 50** — 10 batches, ~23 offspring/batch:
+
+| Sub-phase | % of Breeding |
+|---|---|
+| postBreedingRepair | 52–55% |
+| parentSelection | 16–21% |
+| sortNeurons | 8–13% |
+| alignmentCrossover | 7–9% |
+| batchConnection | 7–11% |
+| geneticCompatibility | 0–1% |
+
+**Large (~80 neurons) × pop 50** — 10 batches, ~26 offspring/batch:
+
+| Sub-phase | % of Breeding |
+|---|---|
+| postBreedingRepair | 56–59% |
+| parentSelection | 13–15% |
+| sortNeurons | 12–14% |
+| batchConnection | 8–10% |
+| alignmentCrossover | 4–6% |
+| geneticCompatibility | 0–1% |
+
+### Key Findings
+
+**Top 3 sub-operations by wall-clock percentage:**
+
+1. **postBreedingRepair** (34–59%) — The dominant hotspot across all sizes.
+   Includes forward-only topology enforcement, `creatureValidate()`,
+   `ensureUniqueNeuronUuids()`, and `fixAliases` export/import round-trip.
+   Grows in proportion as creature size increases.
+
+2. **parentSelection** (13–38%) — Significant overhead from fitness ranking
+   and parent pair selection. Decreases proportionally as creature size
+   grows (algorithm complexity is O(1) per selection).
+
+3. **sortNeurons** (0–14%) — Becomes material for medium/large creatures.
+   The O(n²) nested loop in dependency resolution scales poorly.
+
+**geneticCompatibility** is negligible (<3%) thanks to the distance cache.
+
+## Test Plan
+
+- 9 new tests in `test/breed/BreedingSubPhaseTiming.ts`:
+  - `BreedingSubPhaseAccumulator - toTiming returns all fields`
+  - `BreedingSubPhaseAccumulator - toTiming returns frozen object`
+  - `BreedingSubPhaseAccumulator - accumulates across multiple calls`
+  - `Offspring.breed - populates sub-phase accumulator when provided`
+  - `Offspring.breed - accumulator is additive across multiple breedings`
+  - `Offspring.breed - works without accumulator (backward compatible)`
+  - `ParallelBreeding - breedBatch populates lastBreedingSubPhases`
+  - `ParallelBreeding - empty batch clears lastBreedingSubPhases`
+  - `BreedingSubPhaseTiming - included in GenerationPhaseTiming via evolveDataSet`
+- All 5791 existing tests pass without regression
+- New benchmark `bench/BreedingSubPhaseProfile.ts` run on 3 configuration sizes

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -359,6 +359,9 @@ export async function evolve(
   newPopulation.push(...offspringBatch);
   const breedingMs = Date.now() - breedingStartMs;
 
+  // Issue #2284: Capture breeding sub-phase timing (non-worker path only)
+  const breedingSubPhases = parallelBreeding.lastBreedingSubPhases;
+
   const breed = new Breed(genus, neat.config);
 
   // Issue #1039: Apply plateau stagnation response - increase mutation rate
@@ -496,6 +499,8 @@ export async function evolve(
     deduplicationMs,
     speciationMs,
     sortMs,
+    // Issue #2284: Breeding sub-phase breakdown (non-worker path only)
+    breedingSubPhases,
   };
 
   // Issue #2239: Log per-phase timing when verbose is enabled

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -16,6 +16,7 @@ import { getLogger } from "@utils/Logger.ts";
 import { inputWeightCrossover } from "@breed/InputWeightCrossover.ts";
 import { subgraphTransplant } from "@breed/SubgraphTransplant.ts";
 import { pruneOrphanMemeticReferences } from "@compact/CompactUtils.ts";
+import type { BreedingSubPhaseAccumulator } from "@breed/BreedingSubPhaseAccumulator.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { Neuron } from "@architecture/Neuron.ts";
 import { outputIndexFromId, outputNeuronId } from "@architecture/NeuronId.ts";
@@ -93,8 +94,11 @@ export class Offspring {
       interSpeciesCrossoverThreshold?: number;
       forwardOnly?: boolean;
       hyperparameterEvolution?: RequiredHyperparameterEvolutionConfig;
+      /** Issue #2284: Optional accumulator for sub-phase timing instrumentation. */
+      subPhaseAccumulator?: BreedingSubPhaseAccumulator;
     } = {},
   ): Creature | undefined {
+    const acc = options.subPhaseAccumulator;
     const rng = getRandomNumberGenerator();
     // Issue #1095: Use shallowClone() instead of JSON serialisation/deserialisation
     // for parent preparation. shallowClone() is 3-4x faster as it:
@@ -109,7 +113,10 @@ export class Offspring {
       "Parents aren't the same species",
     );
 
+    // Issue #2284: Time genetic compatibility sub-phase
+    const compatStartMs = acc ? Date.now() : 0;
     const compatibility = geneticCompatibility(mother, father);
+    if (acc) acc.geneticCompatibilityMs += Date.now() - compatStartMs;
 
     // Issue #2175/#2177: When compatibility is very low (below
     // interSpeciesCrossoverThreshold), use specialised inter-species breeding.
@@ -176,6 +183,9 @@ export class Offspring {
 
       fixAliases = true;
     }
+
+    // Issue #2284: Time alignment/crossover sub-phase (neuron maps → clone nodes)
+    const alignStartMs = acc ? Date.now() : 0;
 
     // Pre-build Maps for O(1) neuron lookup by integer ID.
     // This replaces O(n) linear .find() searches, improving breeding performance
@@ -336,6 +346,10 @@ export class Offspring {
       }
     }
 
+    // Issue #2284: End alignment/crossover, start sortNeurons sub-phase
+    if (acc) acc.alignmentCrossoverMs += Date.now() - alignStartMs;
+    const sortStartMs = acc ? Date.now() : 0;
+
     try {
       Offspring.sortNeurons(
         tmpNodes,
@@ -349,6 +363,9 @@ export class Offspring {
       }
       throw e;
     }
+
+    // Issue #2284: End sortNeurons sub-phase
+    if (acc) acc.sortNeuronsMs += Date.now() - sortStartMs;
 
     const tmpNodesLen = tmpNodes.length;
     offspring.neurons.length = tmpNodesLen;
@@ -370,6 +387,9 @@ export class Offspring {
       offspring.neurons[indx] = newNode;
       indxMap.set(neuron.id, indx);
     }
+
+    // Issue #2284: Time batch connection sub-phase
+    const batchStartMs = acc ? Date.now() : 0;
 
     // Issue #1102: Collect all connections first, then batch connect
     // This reduces cache invalidation overhead from O(n) to O(1)
@@ -450,6 +470,10 @@ export class Offspring {
         }
       }
     }
+
+    // Issue #2284: End batch connection, start post-breeding repair sub-phase
+    if (acc) acc.batchConnectionMs += Date.now() - batchStartMs;
+    const repairStartMs = acc ? Date.now() : 0;
 
     // Issue #1097: Prebuild inward index for large offspring.
     // This optimises subsequent inward connection lookups and memetic updates
@@ -591,6 +615,12 @@ export class Offspring {
           "INVALID_CONNECTION",
         );
       }
+    }
+
+    // Issue #2284: End post-breeding repair sub-phase, record successful offspring
+    if (acc) {
+      acc.postBreedingRepairMs += Date.now() - repairStartMs;
+      acc.offspringCount++;
     }
 
     return offspring;

--- a/src/breed/BreedingSubPhaseAccumulator.ts
+++ b/src/breed/BreedingSubPhaseAccumulator.ts
@@ -1,0 +1,42 @@
+/**
+ * BreedingSubPhaseAccumulator.ts — Mutable accumulator for breeding sub-phase timing.
+ *
+ * Issue #2284: Collects sub-phase timing from individual `Offspring.breed()` calls
+ * and parent selection in `ParallelBreeding.breedBatch()`, then freezes the result
+ * into a `BreedingSubPhaseTiming` snapshot for the training event.
+ *
+ * Thread safety: This accumulator is only used on the main thread (non-worker path).
+ * The microtask-based `Promise.all` in `breedBatch()` runs sequentially on the
+ * main thread, so concurrent mutation is not possible.
+ */
+
+import type { BreedingSubPhaseTiming } from "@config/TrainingEvent.ts";
+
+/**
+ * Mutable accumulator that aggregates sub-phase timing across all offspring
+ * bred in a single generation.
+ */
+export class BreedingSubPhaseAccumulator {
+  parentSelectionMs = 0;
+  geneticCompatibilityMs = 0;
+  alignmentCrossoverMs = 0;
+  sortNeuronsMs = 0;
+  batchConnectionMs = 0;
+  postBreedingRepairMs = 0;
+  offspringCount = 0;
+
+  /**
+   * Freeze the accumulated timings into an immutable snapshot.
+   */
+  toTiming(): BreedingSubPhaseTiming {
+    return Object.freeze({
+      parentSelectionMs: this.parentSelectionMs,
+      geneticCompatibilityMs: this.geneticCompatibilityMs,
+      alignmentCrossoverMs: this.alignmentCrossoverMs,
+      sortNeuronsMs: this.sortNeuronsMs,
+      batchConnectionMs: this.batchConnectionMs,
+      postBreedingRepairMs: this.postBreedingRepairMs,
+      offspringCount: this.offspringCount,
+    });
+  }
+}

--- a/src/breed/ParallelBreeding.ts
+++ b/src/breed/ParallelBreeding.ts
@@ -2,8 +2,10 @@ import { Creature } from "../../mod.ts";
 import { Offspring } from "@architecture/Offspring.ts";
 import { discover } from "@blackbox/Discover.ts";
 import type { NeatConfig } from "@config/NeatConfig.ts";
+import type { BreedingSubPhaseTiming } from "@config/TrainingEvent.ts";
 import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import type { Genus } from "@neat/Genus.ts";
+import { BreedingSubPhaseAccumulator } from "@breed/BreedingSubPhaseAccumulator.ts";
 import { FitnessRanking } from "@breed/FitnessRanking.ts";
 import { findFather, selectParent } from "@breed/ParentSelection.ts";
 import { getLogger } from "@utils/Logger.ts";
@@ -58,6 +60,12 @@ export class ParallelBreeding {
   private readonly workers?: WorkerHandler[];
 
   /**
+   * Issue #2284: Sub-phase timing from the most recent `breedBatch()` call.
+   * Only populated for non-worker breeding (main thread path).
+   */
+  lastBreedingSubPhases?: BreedingSubPhaseTiming;
+
+  /**
    * Creates a new ParallelBreeding instance.
    *
    * @param genus - The genus containing the population
@@ -83,13 +91,20 @@ export class ParallelBreeding {
    */
   async breedBatch(count: number): Promise<Creature[]> {
     if (count <= 0) {
+      this.lastBreedingSubPhases = undefined;
       return [];
     }
 
     const config = this.config;
 
+    // Issue #2284: Create sub-phase accumulator for timing instrumentation
+    const acc = new BreedingSubPhaseAccumulator();
+
     // Pre-compute fitness ranking once for the entire batch
     const populationRanking = new FitnessRanking(this.genus.population);
+
+    // Issue #2284: Time parent selection sub-phase
+    const selectionStartMs = Date.now();
 
     // Step 1: Select all parent pairs (main thread, fast)
     const parentPairs: ParentPair[] = [];
@@ -99,20 +114,26 @@ export class ParallelBreeding {
         parentPairs.push(pair);
       }
     }
+    acc.parentSelectionMs = Date.now() - selectionStartMs;
 
     // Step 2: Create offspring in parallel
     let results: (Creature | undefined)[];
 
     if (this.workers && this.workers.length > 0) {
       // Use worker pool for true parallelism
+      // Note: Sub-phase timing within workers is not captured because
+      // Offspring.breed() runs in a separate thread without accumulator access.
       results = await this.breedWithWorkers(parentPairs, config);
     } else {
       // Fallback to main thread with microtask scheduling
       const breedingPromises = parentPairs.map((pair) =>
-        this.breedSingle(pair.mother, pair.father, config)
+        this.breedSingle(pair.mother, pair.father, config, acc)
       );
       results = await Promise.all(breedingPromises);
     }
+
+    // Issue #2284: Freeze accumulated timing
+    this.lastBreedingSubPhases = acc.toTiming();
 
     // Step 3: Filter out failed breeding attempts (undefined results)
     const offspring: Creature[] = [];
@@ -244,6 +265,7 @@ export class ParallelBreeding {
     mother: Creature,
     father: Creature,
     config: NeatConfig,
+    acc?: BreedingSubPhaseAccumulator,
   ): Promise<Creature | undefined> {
     // Use queueMicrotask to yield to the event loop
     return new Promise((resolve) => {
@@ -257,6 +279,7 @@ export class ParallelBreeding {
                 config.geneticCompatibilityThreshold,
               forwardOnly: config.feedbackLoop !== true,
               hyperparameterEvolution: config.hyperparameterEvolution,
+              subPhaseAccumulator: acc,
             },
           );
 

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -8,6 +8,32 @@
  */
 
 /**
+ * Sub-phase timing breakdown within the breeding phase.
+ *
+ * Issue #2284: Finer-grained instrumentation within `ParallelBreeding`
+ * and `Offspring.breed()` to measure where time is spent within the
+ * dominant breeding bottleneck (50–60% of wall-clock time).
+ *
+ * Times are aggregated across all offspring produced in a generation.
+ */
+export interface BreedingSubPhaseTiming {
+  /** Time spent selecting parent pairs via FitnessRanking in ms. */
+  readonly parentSelectionMs: number;
+  /** Time spent computing genetic compatibility in ms. */
+  readonly geneticCompatibilityMs: number;
+  /** Time spent on genome alignment and crossover (neuron map building, population) in ms. */
+  readonly alignmentCrossoverMs: number;
+  /** Time spent in sortNeurons() dependency-aware ordering in ms. */
+  readonly sortNeuronsMs: number;
+  /** Time spent building batch connections with dedup in ms. */
+  readonly batchConnectionMs: number;
+  /** Time spent on post-breeding topology repair (forward-only, UUID uniqueness) in ms. */
+  readonly postBreedingRepairMs: number;
+  /** Number of offspring successfully produced. */
+  readonly offspringCount: number;
+}
+
+/**
  * Per-phase timing breakdown for a single generation.
  *
  * Issue #2239: Lightweight timing diagnostics to identify slow phases
@@ -57,6 +83,11 @@ export interface GenerationPhaseTiming {
    * Issue #2274: O(n log n) sort after fitness evaluation.
    */
   readonly sortMs?: number;
+  /**
+   * Sub-phase timing breakdown within the breeding phase.
+   * Issue #2284: Identifies which sub-operation within breeding is the hotspot.
+   */
+  readonly breedingSubPhases?: BreedingSubPhaseTiming;
 }
 
 /**

--- a/test/breed/BreedingSubPhaseTiming.ts
+++ b/test/breed/BreedingSubPhaseTiming.ts
@@ -1,0 +1,410 @@
+/**
+ * Tests for breeding sub-phase timing instrumentation.
+ *
+ * Issue #2284: Verifies that sub-phase timing data is correctly collected
+ * and structured when breeding offspring. These are "what" tests — they
+ * verify the shape and population of timing data, not actual timing values
+ * (which are unreliable in parallel test execution).
+ */
+
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { Creature } from "@creature";
+import { Offspring } from "@architecture/Offspring.ts";
+import { BreedingSubPhaseAccumulator } from "@breed/BreedingSubPhaseAccumulator.ts";
+import { ParallelBreeding } from "@breed/ParallelBreeding.ts";
+import { Genus } from "@neat/Genus.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import type { BreedingSubPhaseTiming } from "@config/TrainingEvent.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/**
+ * Simple seeded random number generator for reproducible test creatures.
+ */
+function seededRandom(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
+/**
+ * Creates a test creature with a valid chain topology.
+ */
+function createTestCreature(
+  inputCount: number,
+  outputCount: number,
+  hiddenCount: number,
+  prefix: string,
+  seed: number,
+): Creature {
+  const neurons: CreatureExport["neurons"] = [];
+  const synapses: CreatureExport["synapses"] = [];
+  const random = seededRandom(seed);
+
+  const squashOptions = ["TANH", "IDENTITY", "LeakyReLU", "LOGISTIC", "RELU"];
+  for (let i = 0; i < hiddenCount; i++) {
+    neurons.push({
+      type: "hidden",
+      uuid: `${prefix}-hidden-${i}`,
+      squash: squashOptions[Math.floor(random() * squashOptions.length)],
+      bias: (random() - 0.5) * 2,
+    });
+  }
+
+  for (let i = 0; i < outputCount; i++) {
+    neurons.push({
+      type: "output",
+      uuid: `output-${i}`,
+      squash: "IDENTITY",
+      bias: (random() - 0.5) * 0.5,
+    });
+  }
+
+  for (let i = 0; i < inputCount; i++) {
+    for (let j = 0; j < Math.min(hiddenCount, 3); j++) {
+      synapses.push({
+        fromUUID: `input-${i}`,
+        toUUID: `${prefix}-hidden-${j}`,
+        weight: (random() - 0.5) * 2,
+      });
+    }
+  }
+
+  for (let i = 0; i < hiddenCount - 1; i++) {
+    synapses.push({
+      fromUUID: `${prefix}-hidden-${i}`,
+      toUUID: `${prefix}-hidden-${i + 1}`,
+      weight: (random() - 0.5) * 2,
+    });
+  }
+
+  if (hiddenCount > 0) {
+    for (let j = 0; j < outputCount; j++) {
+      synapses.push({
+        fromUUID: `${prefix}-hidden-${hiddenCount - 1}`,
+        toUUID: `output-${j}`,
+        weight: (random() - 0.5) * 2,
+      });
+    }
+  } else {
+    for (let i = 0; i < inputCount; i++) {
+      for (let j = 0; j < outputCount; j++) {
+        synapses.push({
+          fromUUID: `input-${i}`,
+          toUUID: `output-${j}`,
+          weight: (random() - 0.5) * 2,
+        });
+      }
+    }
+  }
+
+  const creature = Creature.fromJSON({
+    neurons,
+    synapses,
+    input: inputCount,
+    output: outputCount,
+  });
+
+  creature.validate();
+  return creature;
+}
+
+/**
+ * Creates a population for testing with scored creatures.
+ */
+function createTestPopulation(
+  size: number,
+  inputCount: number,
+  outputCount: number,
+): { genus: Genus } {
+  const genus = new Genus();
+
+  for (let i = 0; i < size; i++) {
+    const hiddenCount = 5 + (i % 8);
+    const seed = 42 + i * 7919;
+    const creature = createTestCreature(
+      inputCount,
+      outputCount,
+      hiddenCount,
+      `creature-${i}`,
+      seed,
+    );
+    creature.score = -0.5 + (i / size) * 0.3;
+    CreatureUtil.makeUUID(creature);
+    genus.addCreature(creature);
+  }
+
+  return { genus };
+}
+
+Deno.test("BreedingSubPhaseAccumulator - toTiming returns all fields", () => {
+  const acc = new BreedingSubPhaseAccumulator();
+  acc.parentSelectionMs = 10;
+  acc.geneticCompatibilityMs = 20;
+  acc.alignmentCrossoverMs = 30;
+  acc.sortNeuronsMs = 15;
+  acc.batchConnectionMs = 5;
+  acc.postBreedingRepairMs = 8;
+  acc.offspringCount = 3;
+
+  const timing = acc.toTiming();
+
+  assertEquals(timing.parentSelectionMs, 10);
+  assertEquals(timing.geneticCompatibilityMs, 20);
+  assertEquals(timing.alignmentCrossoverMs, 30);
+  assertEquals(timing.sortNeuronsMs, 15);
+  assertEquals(timing.batchConnectionMs, 5);
+  assertEquals(timing.postBreedingRepairMs, 8);
+  assertEquals(timing.offspringCount, 3);
+});
+
+Deno.test("BreedingSubPhaseAccumulator - toTiming returns frozen object", () => {
+  const acc = new BreedingSubPhaseAccumulator();
+  const timing = acc.toTiming();
+
+  // The returned object should be frozen (immutable)
+  assert(Object.isFrozen(timing), "Timing snapshot should be frozen");
+});
+
+Deno.test("BreedingSubPhaseAccumulator - accumulates across multiple calls", () => {
+  const acc = new BreedingSubPhaseAccumulator();
+
+  // Simulate two offspring contributions
+  acc.geneticCompatibilityMs += 5;
+  acc.alignmentCrossoverMs += 10;
+  acc.sortNeuronsMs += 3;
+  acc.batchConnectionMs += 2;
+  acc.postBreedingRepairMs += 1;
+  acc.offspringCount++;
+
+  acc.geneticCompatibilityMs += 7;
+  acc.alignmentCrossoverMs += 12;
+  acc.sortNeuronsMs += 4;
+  acc.batchConnectionMs += 3;
+  acc.postBreedingRepairMs += 2;
+  acc.offspringCount++;
+
+  const timing = acc.toTiming();
+  assertEquals(timing.geneticCompatibilityMs, 12);
+  assertEquals(timing.alignmentCrossoverMs, 22);
+  assertEquals(timing.sortNeuronsMs, 7);
+  assertEquals(timing.batchConnectionMs, 5);
+  assertEquals(timing.postBreedingRepairMs, 3);
+  assertEquals(timing.offspringCount, 2);
+});
+
+Deno.test("Offspring.breed - populates sub-phase accumulator when provided", () => {
+  const mother = createTestCreature(4, 2, 6, "mum", 100);
+  const father = createTestCreature(4, 2, 6, "dad", 200);
+
+  const acc = new BreedingSubPhaseAccumulator();
+
+  const child = Offspring.breed(mother, father, {
+    subPhaseAccumulator: acc,
+  });
+
+  if (child) {
+    // Successful breeding should increment offspring count
+    assertEquals(acc.offspringCount, 1, "Offspring count should be 1");
+
+    // All sub-phase fields should be non-negative numbers
+    assert(
+      acc.geneticCompatibilityMs >= 0,
+      "geneticCompatibilityMs should be >= 0",
+    );
+    assert(
+      acc.alignmentCrossoverMs >= 0,
+      "alignmentCrossoverMs should be >= 0",
+    );
+    assert(acc.sortNeuronsMs >= 0, "sortNeuronsMs should be >= 0");
+    assert(acc.batchConnectionMs >= 0, "batchConnectionMs should be >= 0");
+    assert(
+      acc.postBreedingRepairMs >= 0,
+      "postBreedingRepairMs should be >= 0",
+    );
+  }
+  // If child is undefined (breeding failed), offspring count should be 0
+  // Either outcome is valid — we're testing the instrumentation, not breeding success
+});
+
+Deno.test("Offspring.breed - accumulator is additive across multiple breedings", () => {
+  const acc = new BreedingSubPhaseAccumulator();
+  let successCount = 0;
+
+  // Breed multiple offspring with the same accumulator
+  for (let i = 0; i < 5; i++) {
+    const mother = createTestCreature(3, 1, 4 + i, `mum-${i}`, 300 + i * 10);
+    const father = createTestCreature(3, 1, 4 + i, `dad-${i}`, 400 + i * 10);
+
+    const child = Offspring.breed(mother, father, {
+      subPhaseAccumulator: acc,
+    });
+    if (child) successCount++;
+  }
+
+  // The accumulator should reflect the number of successful breedings
+  assertEquals(
+    acc.offspringCount,
+    successCount,
+    "Offspring count should match successful breedings",
+  );
+});
+
+Deno.test("Offspring.breed - works without accumulator (backward compatible)", () => {
+  const mother = createTestCreature(4, 2, 6, "compat-mum", 500);
+  const father = createTestCreature(4, 2, 6, "compat-dad", 600);
+
+  // Should work without providing subPhaseAccumulator
+  const child = Offspring.breed(mother, father, {});
+
+  // No assertion on child success — just verifying no errors thrown
+  if (child) {
+    child.validate();
+  }
+});
+
+Deno.test("ParallelBreeding - breedBatch populates lastBreedingSubPhases", async () => {
+  const { genus } = createTestPopulation(30, 4, 2);
+  const config = createNeatConfig({
+    populationSize: 30,
+    geneticCompatibilityThreshold: 0.3,
+  });
+
+  const parallelBreeding = new ParallelBreeding(genus, config);
+
+  // Initially undefined
+  assertEquals(
+    parallelBreeding.lastBreedingSubPhases,
+    undefined,
+    "Should be undefined before first breedBatch",
+  );
+
+  const offspring = await parallelBreeding.breedBatch(10);
+
+  // After breeding, sub-phase timing should be populated
+  const subPhases = parallelBreeding.lastBreedingSubPhases;
+  assertExists(
+    subPhases,
+    "lastBreedingSubPhases should exist after breedBatch",
+  );
+
+  // Validate the shape of the timing data
+  assertExists(subPhases.parentSelectionMs, "Should have parentSelectionMs");
+  assert(
+    typeof subPhases.parentSelectionMs === "number",
+    "parentSelectionMs should be a number",
+  );
+  assert(
+    typeof subPhases.geneticCompatibilityMs === "number",
+    "geneticCompatibilityMs should be a number",
+  );
+  assert(
+    typeof subPhases.alignmentCrossoverMs === "number",
+    "alignmentCrossoverMs should be a number",
+  );
+  assert(
+    typeof subPhases.sortNeuronsMs === "number",
+    "sortNeuronsMs should be a number",
+  );
+  assert(
+    typeof subPhases.batchConnectionMs === "number",
+    "batchConnectionMs should be a number",
+  );
+  assert(
+    typeof subPhases.postBreedingRepairMs === "number",
+    "postBreedingRepairMs should be a number",
+  );
+  assert(
+    typeof subPhases.offspringCount === "number",
+    "offspringCount should be a number",
+  );
+
+  // Offspring count should match actual offspring produced
+  assertEquals(
+    subPhases.offspringCount,
+    offspring.length,
+    "offspringCount should match actual offspring produced",
+  );
+
+  // All timing values should be non-negative
+  assert(subPhases.parentSelectionMs >= 0, "parentSelectionMs >= 0");
+  assert(subPhases.geneticCompatibilityMs >= 0, "geneticCompatibilityMs >= 0");
+  assert(subPhases.alignmentCrossoverMs >= 0, "alignmentCrossoverMs >= 0");
+  assert(subPhases.sortNeuronsMs >= 0, "sortNeuronsMs >= 0");
+  assert(subPhases.batchConnectionMs >= 0, "batchConnectionMs >= 0");
+  assert(subPhases.postBreedingRepairMs >= 0, "postBreedingRepairMs >= 0");
+  assert(subPhases.offspringCount >= 0, "offspringCount >= 0");
+});
+
+Deno.test("ParallelBreeding - empty batch clears lastBreedingSubPhases", async () => {
+  const { genus } = createTestPopulation(10, 3, 1);
+  const config = createNeatConfig({ populationSize: 10 });
+
+  const parallelBreeding = new ParallelBreeding(genus, config);
+  await parallelBreeding.breedBatch(0);
+
+  assertEquals(
+    parallelBreeding.lastBreedingSubPhases,
+    undefined,
+    "Empty batch should clear sub-phases",
+  );
+});
+
+Deno.test("BreedingSubPhaseTiming - included in GenerationPhaseTiming via evolveDataSet", async () => {
+  // Build a small creature and evolve for one generation to capture the event
+  const creature = new Creature(3, 1);
+
+  const trainingSet = [
+    { input: new Float32Array([0, 0, 1]), output: new Float32Array([0]) },
+    { input: new Float32Array([1, 0, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([0, 1, 0]), output: new Float32Array([0.5]) },
+  ];
+
+  let capturedSubPhases: BreedingSubPhaseTiming | undefined;
+
+  await creature.evolveDataSet(trainingSet, {
+    iterations: 2,
+    targetError: 0,
+    populationSize: 20,
+    threads: 1,
+    onTrainingEvent: (event) => {
+      if (event.kind === "generation_complete") {
+        if (event.phaseTiming.breedingSubPhases) {
+          capturedSubPhases = event.phaseTiming.breedingSubPhases;
+        }
+      }
+    },
+  });
+
+  // Sub-phase timing should have been captured from at least one generation
+  assertExists(
+    capturedSubPhases,
+    "breedingSubPhases should be present in phaseTiming",
+  );
+
+  // Verify all fields are present and are numbers
+  const fields: (keyof BreedingSubPhaseTiming)[] = [
+    "parentSelectionMs",
+    "geneticCompatibilityMs",
+    "alignmentCrossoverMs",
+    "sortNeuronsMs",
+    "batchConnectionMs",
+    "postBreedingRepairMs",
+    "offspringCount",
+  ];
+
+  for (const field of fields) {
+    assert(
+      typeof capturedSubPhases[field] === "number",
+      `${field} should be a number, got ${typeof capturedSubPhases[field]}`,
+    );
+    assert(
+      capturedSubPhases[field] >= 0,
+      `${field} should be >= 0`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Add sub-phase timing instrumentation within the breeding phase to identify
the actual hotspot within the 50–60% wall-clock time consumed by breeding.
Closes #2284.

PR #2281 identified breeding as the dominant bottleneck, but timing was at
the phase level only. This PR adds finer-grained instrumentation around
six sub-operations within `Offspring.breed()` and
`ParallelBreeding.breedBatch()`:

- **parentSelection** — selecting parent pairs via FitnessRanking
- **geneticCompatibility** — computing compatibility between parents
- **alignmentCrossover** — genome alignment, neuron map building, crossover
- **sortNeurons** — dependency-aware topological sorting
- **batchConnection** — batch synapse building with deduplication
- **postBreedingRepair** — forward-only enforcement, UUID uniqueness, validation

### Changes

- `BreedingSubPhaseTiming` interface added to `TrainingEvent.ts`
- `BreedingSubPhaseAccumulator` class for aggregating timing across offspring
- `Offspring.breed()` instrumented with accumulator (zero-cost when not provided)
- `ParallelBreeding.breedBatch()` creates accumulator, times parent selection,
  exposes `lastBreedingSubPhases`
- `NeatEvolution.ts` wires sub-phase timing into `GenerationPhaseTiming`
- `EvolveDirPhaseProfile.ts` extended to report breeding sub-phase percentages
- New `BreedingSubPhaseProfile.ts` benchmark for direct sub-phase profiling

## Evidence

### Benchmark Results (Apple M2 Ultra)

**Small (~10 neurons) × pop 50** — 10 batches, ~15 offspring/batch:

| Sub-phase | % of Breeding |
|---|---|
| postBreedingRepair | 34–44% |
| parentSelection | 34–38% |
| alignmentCrossover | 12–28% |
| batchConnection | 0–8% |
| sortNeurons | 0–2% |
| geneticCompatibility | 0–3% |

**Medium (~30 neurons) × pop 50** — 10 batches, ~23 offspring/batch:

| Sub-phase | % of Breeding |
|---|---|
| postBreedingRepair | 52–55% |
| parentSelection | 16–21% |
| sortNeurons | 8–13% |
| alignmentCrossover | 7–9% |
| batchConnection | 7–11% |
| geneticCompatibility | 0–1% |

**Large (~80 neurons) × pop 50** — 10 batches, ~26 offspring/batch:

| Sub-phase | % of Breeding |
|---|---|
| postBreedingRepair | 56–59% |
| parentSelection | 13–15% |
| sortNeurons | 12–14% |
| batchConnection | 8–10% |
| alignmentCrossover | 4–6% |
| geneticCompatibility | 0–1% |

### Key Findings

**Top 3 sub-operations by wall-clock percentage:**

1. **postBreedingRepair** (34–59%) — The dominant hotspot across all sizes.
   Includes forward-only topology enforcement, `creatureValidate()`,
   `ensureUniqueNeuronUuids()`, and `fixAliases` export/import round-trip.
   Grows in proportion as creature size increases.

2. **parentSelection** (13–38%) — Significant overhead from fitness ranking
   and parent pair selection. Decreases proportionally as creature size
   grows (algorithm complexity is O(1) per selection).

3. **sortNeurons** (0–14%) — Becomes material for medium/large creatures.
   The O(n²) nested loop in dependency resolution scales poorly.

**geneticCompatibility** is negligible (<3%) thanks to the distance cache.

## Test Plan

- 9 new tests in `test/breed/BreedingSubPhaseTiming.ts`:
  - `BreedingSubPhaseAccumulator - toTiming returns all fields`
  - `BreedingSubPhaseAccumulator - toTiming returns frozen object`
  - `BreedingSubPhaseAccumulator - accumulates across multiple calls`
  - `Offspring.breed - populates sub-phase accumulator when provided`
  - `Offspring.breed - accumulator is additive across multiple breedings`
  - `Offspring.breed - works without accumulator (backward compatible)`
  - `ParallelBreeding - breedBatch populates lastBreedingSubPhases`
  - `ParallelBreeding - empty batch clears lastBreedingSubPhases`
  - `BreedingSubPhaseTiming - included in GenerationPhaseTiming via evolveDataSet`
- All 5791 existing tests pass without regression
- New benchmark `bench/BreedingSubPhaseProfile.ts` run on 3 configuration sizes



## Milestone
This PR is part of the **Speed up** milestone and targets the `milestone/speed-up` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2284 -->