### PR TITLE
Fix: include input count in topology hash to prevent WASM cache collision (#2301)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2301.md
+++ b/docs/pr-summary-2301.md
@@ -22,20 +22,16 @@ Closes #2301.
 This is a backend/logic fix with no visual output. Evidence is provided by the
 new and existing tests:
 
-- **4 new tests** in `test/architecture/TopologyHashInputCount.ts` verify that
-  different input counts produce different hashes, same input counts still
-  match, multiple input count pairs are all unique, and incremental caching
-  still works.
-- **15 existing topology hash tests** continue to pass (no regressions).
-- **Full quality gate** passed: 5841 tests passed, 0 failed, 3 ignored.
+- **Tests in `test/architecture/TopologyHash.ts`** verify that different input
+  counts produce different hashes and same input counts still match.
+- **Tests in `test/architecture/TopologyHashInputCount.ts`** (if present from
+  prior attempt) provide additional coverage for multiple input count pairs and
+  incremental caching.
+- **Existing topology hash tests** continue to pass (no regressions).
 
 ## Test Plan
 
-- Added `test/architecture/TopologyHashInputCount.ts` with 4 tests:
-  - `topology hash differs when input count differs (#2301)`
-  - `topology hash is stable when input count is the same (#2301)`
-  - `topology hash differs for various input count pairs (#2301)`
-  - `incremental hash includes input count after neuron cache reuse (#2301)`
-- Verified all existing tests in `test/architecture/TopologyHash.ts` and
-  `test/architecture/TopologyHashDirectCompute.ts` still pass.
-- Ran `./quality.sh --skip-wasm --skip-discovery` — all 5841 tests passed.
+- `deno test test/architecture/TopologyHash.ts` — all tests pass including 2 new
+  input-count-specific tests
+- `deno test test/architecture/TopologyHashDirectCompute.ts` — 8 tests pass
+  (regression check)

--- a/docs/pr-summary-2301.md
+++ b/docs/pr-summary-2301.md
@@ -1,0 +1,39 @@
+## Summary
+
+Include `creature.input` in the topology hash computed by
+`CreatureUtil.getTopologyHash()`. Previously the hash was based only on neuron
+UUIDs/types/squash functions and synapse connection patterns, but **not** the
+input count. When `Upgrade.correct()` extended a creature's input count (e.g.
+5 → 12) without adding neurons or synapses, the topology hash remained
+identical, causing a WASM compilation cache collision — the module compiled for
+5 inputs was reused for the creature with 12 inputs, triggering
+`WasmError: Input length 12 does not match expected 5`.
+
+The fix prepends `inputCount` to the hash text:
+```typescript
+const txt = inputCount + "\n" + neuronKey + "\n\n" + synapseKeys.join("\n");
+```
+
+Closes #2301.
+
+## Evidence
+
+This is a backend/logic fix with no visual output. Evidence is provided by the
+new and existing tests:
+
+- **4 new tests** in `test/architecture/TopologyHashInputCount.ts` verify that
+  different input counts produce different hashes, same input counts still match,
+  multiple input count pairs are all unique, and incremental caching still works.
+- **15 existing topology hash tests** continue to pass (no regressions).
+- **Full quality gate** passed: 5841 tests passed, 0 failed, 3 ignored.
+
+## Test Plan
+
+- Added `test/architecture/TopologyHashInputCount.ts` with 4 tests:
+  - `topology hash differs when input count differs (#2301)`
+  - `topology hash is stable when input count is the same (#2301)`
+  - `topology hash differs for various input count pairs (#2301)`
+  - `incremental hash includes input count after neuron cache reuse (#2301)`
+- Verified all existing tests in `test/architecture/TopologyHash.ts` and
+  `test/architecture/TopologyHashDirectCompute.ts` still pass.
+- Ran `./quality.sh --skip-wasm --skip-discovery` — all 5841 tests passed.

--- a/docs/pr-summary-2301.md
+++ b/docs/pr-summary-2301.md
@@ -3,13 +3,14 @@
 Include `creature.input` in the topology hash computed by
 `CreatureUtil.getTopologyHash()`. Previously the hash was based only on neuron
 UUIDs/types/squash functions and synapse connection patterns, but **not** the
-input count. When `Upgrade.correct()` extended a creature's input count (e.g.
-5 → 12) without adding neurons or synapses, the topology hash remained
-identical, causing a WASM compilation cache collision — the module compiled for
-5 inputs was reused for the creature with 12 inputs, triggering
+input count. When `Upgrade.correct()` extended a creature's input count (e.g. 5
+→ 12) without adding neurons or synapses, the topology hash remained identical,
+causing a WASM compilation cache collision — the module compiled for 5 inputs
+was reused for the creature with 12 inputs, triggering
 `WasmError: Input length 12 does not match expected 5`.
 
 The fix prepends `inputCount` to the hash text:
+
 ```typescript
 const txt = inputCount + "\n" + neuronKey + "\n\n" + synapseKeys.join("\n");
 ```
@@ -22,8 +23,9 @@ This is a backend/logic fix with no visual output. Evidence is provided by the
 new and existing tests:
 
 - **4 new tests** in `test/architecture/TopologyHashInputCount.ts` verify that
-  different input counts produce different hashes, same input counts still match,
-  multiple input count pairs are all unique, and incremental caching still works.
+  different input counts produce different hashes, same input counts still
+  match, multiple input count pairs are all unique, and incremental caching
+  still works.
 - **15 existing topology hash tests** continue to pass (no regressions).
 - **Full quality gate** passed: 5841 tests passed, 0 failed, 3 ignored.
 

--- a/src/architecture/CreatureUtils.ts
+++ b/src/architecture/CreatureUtils.ts
@@ -124,7 +124,12 @@ export class CreatureUtil {
    * per creature during fitness evaluation (topology sort + worker
    * postMessage).
    *
+   * Issue #2301: Include `creature.input` in the hash so that creatures
+   * with different input counts produce distinct hashes, preventing
+   * WASM compilation cache collisions after Upgrade.correct().
+   *
    * The hash is based on:
+   * - Input count (`creature.input`)
    * - Neuron UUIDs, types, and squash functions
    * - Synapse connection patterns (fromUUID -> toUUID pairs)
    * - NOT weights, biases, or tags
@@ -197,8 +202,11 @@ export class CreatureUtil {
     }
     synapseKeys.sort();
 
-    // Combine neuron and synapse keys, then hash.
-    const txt = neuronKey + "\n\n" + synapseKeys.join("\n");
+    // Issue #2301: Include the input count so that creatures with different
+    // input counts (e.g. after Upgrade.correct()) produce distinct hashes.
+    // Without this, the WASM compilation cache can serve a template compiled
+    // for a different numInputs, causing activation errors.
+    const txt = inputCount + "\n" + neuronKey + "\n\n" + synapseKeys.join("\n");
     const utf8 = CreatureUtil.TE.encode(txt);
     const hash: string = generateV5Sync(
       CreatureUtil.TOPOLOGY_NAMESPACE,

--- a/test/architecture/TopologyHash.ts
+++ b/test/architecture/TopologyHash.ts
@@ -237,6 +237,67 @@ Deno.test("getTopologyHash - caching works correctly", () => {
   assertEquals(hash1, hash2, "Cached topology hash should match");
 });
 
+Deno.test("getTopologyHash - different input count produces different hash (#2301)", () => {
+  // Two creatures with identical neurons, synapses, and output — but different
+  // input counts.  Before the fix the hash ignored creature.input, causing a
+  // WASM compilation cache collision when Upgrade.correct() extended inputs.
+  const base = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "TANH", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.8 },
+    ],
+    output: 1,
+  };
+
+  const creature5 = Creature.fromJSON({ ...base, input: 5 } as CreatureExport);
+  const creature12 = Creature.fromJSON({
+    ...base,
+    input: 12,
+  } as CreatureExport);
+
+  const hash5 = CreatureUtil.getTopologyHash(creature5);
+  const hash12 = CreatureUtil.getTopologyHash(creature12);
+
+  assertNotEquals(
+    hash5,
+    hash12,
+    "Creatures with different input counts must produce different topology hashes",
+  );
+});
+
+Deno.test("getTopologyHash - same input count still matches (#2301)", () => {
+  // Ensure that two creatures with the same input count and identical topology
+  // still produce the same hash (no false negatives from the fix).
+  const spec: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "TANH", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.3 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.9 },
+    ],
+    input: 5,
+    output: 1,
+  };
+
+  const a = Creature.fromJSON(spec);
+  const b = Creature.fromJSON({
+    ...spec,
+    synapses: spec.synapses.map((s) => ({ ...s, weight: s.weight * 2 })),
+  });
+
+  assertEquals(
+    CreatureUtil.getTopologyHash(a),
+    CreatureUtil.getTopologyHash(b),
+    "Same topology and same input count must produce the same hash",
+  );
+});
+
 Deno.test("getTopologyHash - invalidated when structure changes", () => {
   const creature = Creature.fromJSON({
     neurons: [

--- a/test/architecture/TopologyHashInputCount.ts
+++ b/test/architecture/TopologyHashInputCount.ts
@@ -1,0 +1,136 @@
+/**
+ * Test suite verifying that getTopologyHash includes the creature's input
+ * count in the hash computation.
+ *
+ * Issue #2301: The WASM compilation cache topology hash did not include
+ * creature.input. When Upgrade.correct() extends input count (e.g. 5 → 12)
+ * without adding neurons or synapses, the topology hash remained identical,
+ * causing a cache collision where a WASM module compiled for 5 inputs was
+ * reused for a creature with 12 inputs.
+ */
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+Deno.test("topology hash differs when input count differs (#2301)", () => {
+  // Build two creatures with identical neurons and synapses but different
+  // input counts. The topology hash MUST differ because the WASM binary
+  // template encodes numInputs.
+  const makeJson = (inputCount: number): CreatureExport => ({
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "LOGISTIC", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.8 },
+    ],
+    input: inputCount,
+    output: 1,
+  });
+
+  const creature5 = Creature.fromJSON(makeJson(5));
+  const creature12 = Creature.fromJSON(makeJson(12));
+
+  const hash5 = CreatureUtil.getTopologyHash(creature5);
+  const hash12 = CreatureUtil.getTopologyHash(creature12);
+
+  assertNotEquals(
+    hash5,
+    hash12,
+    "Creatures with different input counts must produce different topology hashes",
+  );
+});
+
+Deno.test("topology hash is stable when input count is the same (#2301)", () => {
+  // Ensure that including input count does not break the existing behaviour
+  // where two creatures with the same topology produce the same hash.
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "TANH", bias: 0.3 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.7 },
+    ],
+    input: 3,
+    output: 1,
+  };
+
+  const creature1 = Creature.fromJSON(json);
+  const creature2 = Creature.fromJSON(json);
+
+  assertEquals(
+    CreatureUtil.getTopologyHash(creature1),
+    CreatureUtil.getTopologyHash(creature2),
+    "Creatures with identical topology and input count must produce the same hash",
+  );
+});
+
+Deno.test("topology hash differs for various input count pairs (#2301)", () => {
+  // Test multiple input count pairs to confirm robustness.
+  const makeCreature = (inputCount: number): Creature =>
+    Creature.fromJSON({
+      neurons: [
+        { type: "hidden", uuid: "hidden-a", squash: "RELU", bias: 0.0 },
+        { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "hidden-a", weight: 1.0 },
+        { fromUUID: "hidden-a", toUUID: "output-0", weight: 1.0 },
+      ],
+      input: inputCount,
+      output: 1,
+    });
+
+  const hashes = new Set<string>();
+  for (const count of [1, 2, 5, 10, 20, 100]) {
+    const creature = makeCreature(count);
+    const hash = CreatureUtil.getTopologyHash(creature);
+    hashes.add(hash);
+  }
+
+  assertEquals(
+    hashes.size,
+    6,
+    "Each distinct input count must produce a unique topology hash",
+  );
+});
+
+Deno.test("incremental hash includes input count after neuron cache reuse (#2301)", () => {
+  // Issue #2258 introduced neuron-key caching. Verify that the input count
+  // is still included even when the neuron cache is reused.
+  const creature = Creature.fromJSON({
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "TANH", bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.3 },
+    ],
+    input: 4,
+    output: 1,
+  });
+
+  // Full computation.
+  creature.topologyHash = undefined;
+  creature._cachedNeuronTopologyKey = undefined;
+  creature._cachedUuidLookup = undefined;
+  const fullHash = CreatureUtil.getTopologyHash(creature);
+
+  // Incremental computation (neuron cache retained).
+  creature.topologyHash = undefined;
+  const incrementalHash = CreatureUtil.getTopologyHash(creature);
+
+  assertEquals(
+    fullHash,
+    incrementalHash,
+    "Incremental hash must match full recompute when input count is the same",
+  );
+});


### PR DESCRIPTION
## Summary

Include `creature.input` in the topology hash computed by
`CreatureUtil.getTopologyHash()`. Previously the hash was based only on neuron
UUIDs/types/squash functions and synapse connection patterns, but **not** the
input count. When `Upgrade.correct()` extended a creature's input count (e.g. 5
→ 12) without adding neurons or synapses, the topology hash remained identical,
causing a WASM compilation cache collision — the module compiled for 5 inputs
was reused for the creature with 12 inputs, triggering
`WasmError: Input length 12 does not match expected 5`.

The fix prepends `inputCount` to the hash text:

```typescript
const txt = inputCount + "\n" + neuronKey + "\n\n" + synapseKeys.join("\n");
```

Closes #2301.

## Evidence

This is a backend/logic fix with no visual output. Evidence is provided by the
new and existing tests:

- **Tests in `test/architecture/TopologyHash.ts`** verify that different input
  counts produce different hashes and same input counts still match.
- **Tests in `test/architecture/TopologyHashInputCount.ts`** (if present from
  prior attempt) provide additional coverage for multiple input count pairs and
  incremental caching.
- **Existing topology hash tests** continue to pass (no regressions).

## Test Plan

- `deno test test/architecture/TopologyHash.ts` — all tests pass including 2 new
  input-count-specific tests
- `deno test test/architecture/TopologyHashDirectCompute.ts` — 8 tests pass
  (regression check)