### PR TITLE
Split breeding wall-time from overlapped main-thread work (#2323)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.12.9",
+  "version": "2.12.10",
   "publish": {
     "include": [
       "README.md",

--- a/docs/pr-summary-2323.md
+++ b/docs/pr-summary-2323.md
@@ -1,0 +1,27 @@
+## Summary
+
+Split breeding wall-time from overlapped main-thread work to clarify phase timing semantics. Closes #2323.
+
+With phase pipelining (#2314), `breedingMs` measures wall-clock time from starting `breedBatch()` until `await breedingPromise` resolves — which includes concurrent main-thread work (result processing, plateau/MCMC configuration, mutator/deduplicator setup). This made it impossible to distinguish pure crossover cost from overlapped work.
+
+**New fields on `GenerationPhaseTiming`:**
+- `breedingWorkerMs` — actual worker/breeding duration (promise start to promise resolution)
+- `mainThreadOverlapMs` — main-thread work done concurrently with worker breeding
+
+The existing `breedingMs` field is preserved unchanged for backward compatibility with dashboards and scripts.
+
+## Evidence
+
+This is a backend/timing instrumentation change with no visual output. Verified via:
+- All 5896 tests pass (0 failures, 3 ignored)
+- New test file `test/NEAT/BreedingTimingSplit.ts` validates presence, types, non-negativity, semantic invariants, backward compatibility, and timing invariant consistency
+- Existing timing tests (`EvolvePhaseTiming.ts`, `EvolvePhaseTiming_Extended.ts`, `PhasePipelining.ts`) continue to pass
+
+## Test Plan
+
+- Added `test/NEAT/BreedingTimingSplit.ts` with 4 tests:
+  - `breedingWorkerMs and mainThreadOverlapMs are present` — verifies both fields exist and are non-negative numbers
+  - `semantic invariants hold between timing fields` — checks `breedingMs >= breedingWorkerMs` and `breedingMs >= mainThreadOverlapMs`
+  - `fields are optional for backward compatibility` — type-level verification that `GenerationPhaseTiming` accepts objects without the new fields
+  - `timing invariant holds with new fields included` — confirms `totalMs >= sum(phases) - overlap` still holds
+- Updated `test/NEAT/EvolvePhaseTiming_Extended.ts` to include new fields in the optional-fields validation loop

--- a/docs/pr-summary-2323.md
+++ b/docs/pr-summary-2323.md
@@ -1,27 +1,46 @@
 ## Summary
 
-Split breeding wall-time from overlapped main-thread work to clarify phase timing semantics. Closes #2323.
+Split breeding wall-time from overlapped main-thread work to clarify phase
+timing semantics. Closes #2323.
 
-With phase pipelining (#2314), `breedingMs` measures wall-clock time from starting `breedBatch()` until `await breedingPromise` resolves — which includes concurrent main-thread work (result processing, plateau/MCMC configuration, mutator/deduplicator setup). This made it impossible to distinguish pure crossover cost from overlapped work.
+With phase pipelining (#2314), `breedingMs` measures wall-clock time from
+starting `breedBatch()` until `await breedingPromise` resolves — which includes
+concurrent main-thread work (result processing, plateau/MCMC configuration,
+mutator/deduplicator setup). This made it impossible to distinguish pure
+crossover cost from overlapped work.
 
 **New fields on `GenerationPhaseTiming`:**
-- `breedingWorkerMs` — actual worker/breeding duration (promise start to promise resolution)
-- `mainThreadOverlapMs` — main-thread work done concurrently with worker breeding
 
-The existing `breedingMs` field is preserved unchanged for backward compatibility with dashboards and scripts.
+- `breedingWorkerMs` — actual worker/breeding duration (promise start to promise
+  resolution)
+- `mainThreadOverlapMs` — main-thread work done concurrently with worker
+  breeding
+
+The existing `breedingMs` field is preserved unchanged for backward
+compatibility with dashboards and scripts.
 
 ## Evidence
 
-This is a backend/timing instrumentation change with no visual output. Verified via:
+This is a backend/timing instrumentation change with no visual output. Verified
+via:
+
 - All 5896 tests pass (0 failures, 3 ignored)
-- New test file `test/NEAT/BreedingTimingSplit.ts` validates presence, types, non-negativity, semantic invariants, backward compatibility, and timing invariant consistency
-- Existing timing tests (`EvolvePhaseTiming.ts`, `EvolvePhaseTiming_Extended.ts`, `PhasePipelining.ts`) continue to pass
+- New test file `test/NEAT/BreedingTimingSplit.ts` validates presence, types,
+  non-negativity, semantic invariants, backward compatibility, and timing
+  invariant consistency
+- Existing timing tests (`EvolvePhaseTiming.ts`,
+  `EvolvePhaseTiming_Extended.ts`, `PhasePipelining.ts`) continue to pass
 
 ## Test Plan
 
 - Added `test/NEAT/BreedingTimingSplit.ts` with 4 tests:
-  - `breedingWorkerMs and mainThreadOverlapMs are present` — verifies both fields exist and are non-negative numbers
-  - `semantic invariants hold between timing fields` — checks `breedingMs >= breedingWorkerMs` and `breedingMs >= mainThreadOverlapMs`
-  - `fields are optional for backward compatibility` — type-level verification that `GenerationPhaseTiming` accepts objects without the new fields
-  - `timing invariant holds with new fields included` — confirms `totalMs >= sum(phases) - overlap` still holds
-- Updated `test/NEAT/EvolvePhaseTiming_Extended.ts` to include new fields in the optional-fields validation loop
+  - `breedingWorkerMs and mainThreadOverlapMs are present` — verifies both
+    fields exist and are non-negative numbers
+  - `semantic invariants hold between timing fields` — checks
+    `breedingMs >= breedingWorkerMs` and `breedingMs >= mainThreadOverlapMs`
+  - `fields are optional for backward compatibility` — type-level verification
+    that `GenerationPhaseTiming` accepts objects without the new fields
+  - `timing invariant holds with new fields included` — confirms
+    `totalMs >= sum(phases) - overlap` still holds
+- Updated `test/NEAT/EvolvePhaseTiming_Extended.ts` to include new fields in the
+  optional-fields validation loop

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -519,9 +519,20 @@ export async function evolve(
   // while workers breed. These phases are independent: result processing reads
   // completed task queues from the previous generation; plateau/MCMC reads
   // neat-level state that breeding does not modify.
-  const breedingPromise = parallelBreeding.breedBatch(newPopSize);
+  // Issue #2323: Wrap the promise to capture when workers actually complete,
+  // distinguishing pure breeding duration from wall-clock breedingMs.
+  let breedingWorkerEndMs = 0;
+  const rawBreedingPromise = parallelBreeding.breedBatch(newPopSize);
+  const breedingPromise = rawBreedingPromise.then((result) => {
+    breedingWorkerEndMs = Date.now();
+    return result;
+  });
 
   const breed = new Breed(genus, neat.config);
+
+  // Issue #2323: Start timing main-thread overlap work (runs concurrently
+  // with worker breeding).
+  const overlapStartMs = Date.now();
 
   // Issue #2314: Process completed results while workers breed.
   // Issue #2239: Time result processing phase
@@ -568,11 +579,20 @@ export async function evolve(
   // when needed after mutation, without waiting for breeding to complete).
   const deDuplicator = new DeDuplicator(breed, mutator);
 
+  // Issue #2323: End main-thread overlap measurement before awaiting workers.
+  const mainThreadOverlapMs = Date.now() - overlapStartMs;
+
   // Issue #2314: Await breeding results now that all overlapped main-thread
   // work is complete.
   const offspringBatch = await breedingPromise;
   newPopulation.push(...offspringBatch);
   const breedingMs = Date.now() - breedingStartMs;
+  // Issue #2323: Compute pure worker breeding duration. If the .then()
+  // callback has not fired yet (breedingWorkerEndMs is still 0), the worker
+  // completed synchronously with the await — use the current time.
+  const breedingWorkerMs =
+    (breedingWorkerEndMs > 0 ? breedingWorkerEndMs : Date.now()) -
+    breedingStartMs;
   // Issue #2312: Snapshot after breeding — fast workers should be active
   const breedingUtilisation = captureUtilisationSnapshot(fastPool, heavyPool);
 
@@ -739,6 +759,9 @@ export async function evolve(
   const phaseTiming: GenerationPhaseTiming = {
     fitnessMs,
     breedingMs,
+    // Issue #2323: Split breeding timing into worker vs main-thread overlap
+    breedingWorkerMs,
+    mainThreadOverlapMs,
     resultProcessingMs,
     totalMs,
     memoryEvictionMs: memoryEvictionMs > 0 ? memoryEvictionMs : undefined,
@@ -769,8 +792,10 @@ export async function evolve(
       ? ` pipelineOverlap=${pipelineOverlapMs}ms`
       : "";
     getLogger().info(
-      `[Timing] fitness=${fitnessMs}ms breeding=${breedingMs}ms ` +
-        `resultProcessing=${resultProcessingMs}ms${memTag}${preWarmTag}` +
+      `[Timing] fitness=${fitnessMs}ms breeding=${breedingMs}ms` +
+        ` breedingWorker=${breedingWorkerMs}ms` +
+        ` mainThreadOverlap=${mainThreadOverlapMs}ms` +
+        ` resultProcessing=${resultProcessingMs}ms${memTag}${preWarmTag}` +
         `${overlapTag}` +
         ` sort=${sortMs}ms writeScores=${writeScoresMs}ms` +
         ` mutation=${mutationMs}ms deduplication=${deduplicationMs}ms` +

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -93,6 +93,20 @@ export interface GenerationPhaseTiming {
   readonly fitnessMs: number;
   /** Time spent on parallel breeding (parallelBreeding.breedBatch) in ms. */
   readonly breedingMs: number;
+  /**
+   * Actual worker/breeding duration in ms, measured from when breedBatch()
+   * was called to when its promise resolved.
+   * Issue #2323: Distinguishes pure crossover/alignment cost from the
+   * wall-clock breedingMs which includes overlapped main-thread work.
+   */
+  readonly breedingWorkerMs?: number;
+  /**
+   * Main-thread work done concurrently with worker breeding in ms.
+   * Issue #2323: Captures result processing, plateau detection, MCMC
+   * configuration, and mutator/deduplicator setup that run while workers
+   * breed. This is the overlap duration before the breeding await.
+   */
+  readonly mainThreadOverlapMs?: number;
   /** Time spent processing completed training/discovery results in ms. */
   readonly resultProcessingMs: number;
   /** Total time for the entire evolve() call in ms. */

--- a/test/NEAT/BreedingTimingSplit.ts
+++ b/test/NEAT/BreedingTimingSplit.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for Issue #2323: Split breeding wall-time from overlapped main-thread work.
+ *
+ * Verifies that generation_complete timing includes unambiguous fields that
+ * distinguish worker breeding time from overlapped main-thread time:
+ *   - breedingMs: wall-clock interval (backward compatible)
+ *   - breedingWorkerMs: actual worker/breeding duration
+ *   - mainThreadOverlapMs: main-thread work done concurrently with breeding
+ *
+ * The semantic invariant is:
+ *   breedingMs >= breedingWorkerMs (wall-clock >= worker time because
+ *     the wall-clock measurement includes the time before/after workers)
+ *   breedingMs >= mainThreadOverlapMs (overlap cannot exceed wall-clock)
+ *   breedingWorkerMs + mainThreadOverlapMs >= breedingMs (combined work
+ *     covers the wall-clock window, possibly exceeding it when both run
+ *     concurrently)
+ */
+import { assert, assertEquals, assertGreater } from "@std/assert";
+import { Creature } from "@creature";
+import { Mutation } from "@neat/Mutation.ts";
+import type {
+  GenerationCompleteEvent,
+  GenerationPhaseTiming,
+  TrainingEvent,
+} from "@config/TrainingEvent.ts";
+
+Deno.test("BreedingTimingSplit: breedingWorkerMs and mainThreadOverlapMs are present", async () => {
+  const events: GenerationCompleteEvent[] = [];
+
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+  ];
+
+  const creature = new Creature(2, 1);
+
+  await creature.evolveDataSet(trainingSet, {
+    mutation: Mutation.FFW,
+    iterations: 5,
+    targetError: 0.001,
+    populationSize: 20,
+    threads: 1,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        events.push(event);
+      }
+    },
+  });
+
+  assertGreater(
+    events.length,
+    0,
+    "Should emit at least one generation_complete event",
+  );
+
+  for (const event of events) {
+    assert(event.phaseTiming, "Event should include phaseTiming");
+    const timing = event.phaseTiming;
+
+    // Issue #2323: breedingWorkerMs should be present and non-negative
+    assert(
+      timing.breedingWorkerMs !== undefined,
+      "breedingWorkerMs should be present",
+    );
+    assertEquals(typeof timing.breedingWorkerMs, "number");
+    assertGreater(
+      timing.breedingWorkerMs!,
+      -1,
+      "breedingWorkerMs should be non-negative",
+    );
+
+    // Issue #2323: mainThreadOverlapMs should be present and non-negative
+    assert(
+      timing.mainThreadOverlapMs !== undefined,
+      "mainThreadOverlapMs should be present",
+    );
+    assertEquals(typeof timing.mainThreadOverlapMs, "number");
+    assertGreater(
+      timing.mainThreadOverlapMs!,
+      -1,
+      "mainThreadOverlapMs should be non-negative",
+    );
+
+    // Backward compatibility: breedingMs is still present
+    assertEquals(typeof timing.breedingMs, "number");
+    assertGreater(timing.breedingMs, -1, "breedingMs should be non-negative");
+  }
+});
+
+Deno.test("BreedingTimingSplit: semantic invariants hold between timing fields", async () => {
+  const timings: GenerationPhaseTiming[] = [];
+
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+  ];
+
+  const creature = new Creature(2, 1);
+
+  await creature.evolveDataSet(trainingSet, {
+    mutation: Mutation.FFW,
+    iterations: 5,
+    targetError: 0.001,
+    populationSize: 20,
+    threads: 1,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        timings.push(event.phaseTiming);
+      }
+    },
+  });
+
+  assertGreater(timings.length, 0, "Should capture at least one timing");
+
+  for (const timing of timings) {
+    const workerMs = timing.breedingWorkerMs ?? 0;
+    const overlapMs = timing.mainThreadOverlapMs ?? 0;
+
+    // Issue #2323: Wall-clock breedingMs >= worker time (with 1ms tolerance
+    // for timer resolution).
+    assert(
+      timing.breedingMs >= workerMs - 1,
+      `breedingMs (${timing.breedingMs}) should be >= breedingWorkerMs (${workerMs})`,
+    );
+
+    // Issue #2323: Wall-clock breedingMs >= overlap time (with tolerance).
+    assert(
+      timing.breedingMs >= overlapMs - 1,
+      `breedingMs (${timing.breedingMs}) should be >= mainThreadOverlapMs (${overlapMs})`,
+    );
+  }
+});
+
+Deno.test("BreedingTimingSplit: fields are optional for backward compatibility", () => {
+  // Verify that GenerationPhaseTiming still accepts objects without the new fields
+  const timingWithout: GenerationPhaseTiming = {
+    fitnessMs: 100,
+    breedingMs: 50,
+    resultProcessingMs: 20,
+    totalMs: 170,
+  };
+  assertEquals(timingWithout.breedingWorkerMs, undefined);
+  assertEquals(timingWithout.mainThreadOverlapMs, undefined);
+
+  // Verify the type accepts objects with the new fields
+  const timingWith: GenerationPhaseTiming = {
+    fitnessMs: 100,
+    breedingMs: 50,
+    resultProcessingMs: 20,
+    totalMs: 170,
+    breedingWorkerMs: 35,
+    mainThreadOverlapMs: 18,
+  };
+  assertEquals(timingWith.breedingWorkerMs, 35);
+  assertEquals(timingWith.mainThreadOverlapMs, 18);
+});
+
+Deno.test("BreedingTimingSplit: timing invariant holds with new fields included", async () => {
+  const timings: GenerationPhaseTiming[] = [];
+
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+  ];
+
+  const creature = new Creature(2, 1);
+
+  await creature.evolveDataSet(trainingSet, {
+    mutation: Mutation.FFW,
+    iterations: 5,
+    targetError: 0.001,
+    populationSize: 20,
+    threads: 1,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        timings.push(event.phaseTiming);
+      }
+    },
+  });
+
+  assertGreater(timings.length, 0, "Should capture at least one timing");
+
+  for (const timing of timings) {
+    // The existing timing invariant should still hold
+    const measuredPhases = timing.fitnessMs + timing.breedingMs +
+      timing.resultProcessingMs +
+      (timing.mutationMs ?? 0) +
+      (timing.deduplicationMs ?? 0) +
+      (timing.speciationMs ?? 0) +
+      (timing.sortMs ?? 0) +
+      (timing.writeScoresMs ?? 0) +
+      (timing.memoryEvictionMs ?? 0) +
+      (timing.preWarmMs ?? 0);
+    const overlap = timing.pipelineOverlapMs ?? 0;
+    assert(
+      timing.totalMs >= measuredPhases - overlap - 1,
+      `totalMs (${timing.totalMs}) should be >= sum (${measuredPhases}) - overlap (${overlap})`,
+    );
+  }
+});

--- a/test/NEAT/EvolvePhaseTiming_Extended.ts
+++ b/test/NEAT/EvolvePhaseTiming_Extended.ts
@@ -220,6 +220,9 @@ Deno.test("EvolvePhaseTiming: all timing fields are numbers or undefined", async
       "checkpointWriteMs",
       "preWarmMs",
       "pipelineOverlapMs",
+      // Issue #2323: Breeding timing split fields
+      "breedingWorkerMs",
+      "mainThreadOverlapMs",
     ];
     for (const field of optionalFields) {
       const value = timing[field];


### PR DESCRIPTION
## Summary

Split breeding wall-time from overlapped main-thread work to clarify phase timing semantics. Closes #2323.

With phase pipelining (#2314), `breedingMs` measures wall-clock time from starting `breedBatch()` until `await breedingPromise` resolves — which includes concurrent main-thread work (result processing, plateau/MCMC configuration, mutator/deduplicator setup). This made it impossible to distinguish pure crossover cost from overlapped work.

**New fields on `GenerationPhaseTiming`:**
- `breedingWorkerMs` — actual worker/breeding duration (promise start to promise resolution)
- `mainThreadOverlapMs` — main-thread work done concurrently with worker breeding

The existing `breedingMs` field is preserved unchanged for backward compatibility with dashboards and scripts.

## Evidence

This is a backend/timing instrumentation change with no visual output. Verified via:
- All 5896 tests pass (0 failures, 3 ignored)
- New test file `test/NEAT/BreedingTimingSplit.ts` validates presence, types, non-negativity, semantic invariants, backward compatibility, and timing invariant consistency
- Existing timing tests (`EvolvePhaseTiming.ts`, `EvolvePhaseTiming_Extended.ts`, `PhasePipelining.ts`) continue to pass

## Test Plan

- Added `test/NEAT/BreedingTimingSplit.ts` with 4 tests:
  - `breedingWorkerMs and mainThreadOverlapMs are present` — verifies both fields exist and are non-negative numbers
  - `semantic invariants hold between timing fields` — checks `breedingMs >= breedingWorkerMs` and `breedingMs >= mainThreadOverlapMs`
  - `fields are optional for backward compatibility` — type-level verification that `GenerationPhaseTiming` accepts objects without the new fields
  - `timing invariant holds with new fields included` — confirms `totalMs >= sum(phases) - overlap` still holds
- Updated `test/NEAT/EvolvePhaseTiming_Extended.ts` to include new fields in the optional-fields validation loop



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2323 -->