### PR TITLE
Throughput: add per-generation throughput metrics (#2330)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.12.12",
+  "version": "2.12.13",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -62,6 +62,7 @@
     "dedupe",
     "deduplicator",
     "delisting",
+    "deltaed",
     "denom",
     "densification",
     "densified",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -73,6 +73,7 @@
     "deprioritises",
     "deprioritising",
     "deque",
+    "deltaed",
     "deriv",
     "deserialisable",
     "deserialisation",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -73,7 +73,6 @@
     "deprioritises",
     "deprioritising",
     "deque",
-    "deltaed",
     "deriv",
     "deserialisable",
     "deserialisation",

--- a/docs/pr-summary-2330.md
+++ b/docs/pr-summary-2330.md
@@ -5,7 +5,7 @@ training events so production runs can diagnose wall-clock usage, per-phase
 time, and worker queueing pressure without per-creature logging. Closes #2330.
 
 Previously, `generation_complete` events exposed only aggregate `phaseTiming`
-numbers. Operators could see *where* time was spent but had no compact way to
+numbers. Operators could see _where_ time was spent but had no compact way to
 answer questions like "how idle were workers?", "how deep did the breeding
 backlog get?", or "how much time did tasks spend waiting?". This PR adds a
 `throughput` field on `generation_complete` carrying finite, non-negative
@@ -13,62 +13,61 @@ numeric counters suitable for dashboards and CSV exports.
 
 ### Changes
 
-- **`src/config/TrainingEvent.ts`**: New `GenerationThroughputMetrics`
-  interface with 11 readonly numeric fields — `wallClockMs`, `nonFitnessMs`,
+- **`src/config/TrainingEvent.ts`**: New `GenerationThroughputMetrics` interface
+  with 11 readonly numeric fields — `wallClockMs`, `nonFitnessMs`,
   `generationsPerHour`, per-pool `{fast,heavy}BusyMs`, `{fast,heavy}IdleMs`,
   `{fast,heavy}QueueMaxDepth`, `{fast,heavy}WaitMs`. Added
   `readonly throughput?` to `GenerationCompleteEvent` with extensive JSDoc
   documenting each field's meaning, units, and caveats (wait time is an
   approximation).
 - **`src/workers/WorkerHandlerBase.ts`**: Added `busyStartMs` /
-  `cumulativeBusyMs` private fields and `onTaskStart()`/`onTaskEnd()` hooks
-  that capture clock reads only on idle↔busy transitions (0→1 start, N→0 end).
-  Replaced raw `busyCount++/--` in `makePromise()`/`makePromiseDeferred()`
-  with these hooks. Added public `getCumulativeBusyMs()`. Zero overhead in
-  hot loops — a clock read per idle-busy boundary, not per task.
+  `cumulativeBusyMs` private fields and `onTaskStart()`/`onTaskEnd()` hooks that
+  capture clock reads only on idle↔busy transitions (0→1 start, N→0 end).
+  Replaced raw `busyCount++/--` in `makePromise()`/`makePromiseDeferred()` with
+  these hooks. Added public `getCumulativeBusyMs()`. Zero overhead in hot loops
+  — a clock read per idle-busy boundary, not per task.
 - **`src/multithreading/WorkerPool.ts`**: Added `getTotalBusyMs()` that sums
   `getCumulativeBusyMs()` across all workers in the pool.
-- **`src/architecture/Fitness.ts`**: Added public `lastQueueMaxDepth`
-  populated to `uniqueQueue.length` at fitness start — the true peak since
-  the queue drains monotonically.
+- **`src/architecture/Fitness.ts`**: Added public `lastQueueMaxDepth` populated
+  to `uniqueQueue.length` at fitness start — the true peak since the queue
+  drains monotonically.
 - **`src/breed/ParallelBreeding.ts`**: Added public `lastQueueMaxDepth`
   populated to `parentPairs.length` immediately after parent-pair selection.
-- **`src/NEAT/ThroughputMetrics.ts`** (new): Pure helper module so the
-  formulas can be unit-tested in isolation from `evolve()`:
+- **`src/NEAT/ThroughputMetrics.ts`** (new): Pure helper module so the formulas
+  can be unit-tested in isolation from `evolve()`:
   - `approximateWaitMs(busyMs, depth, workers)` — FIFO uniform-task-duration
     model: `wait ≈ busyMs × (depth - workers) / (2 × depth)`, zero when
     `depth ≤ workers` or any input is non-positive.
-  - `computeIdleMs(wallClockMs, workers, busyMs)` — capacity minus busy,
-    clamped to zero so clock-skew rounding cannot yield negatives.
-  - `computeThroughputMetrics(input)` — assembles a finite, non-negative
-    payload (clamps negative inputs, rounds wait, returns
-    `generationsPerHour = 0` when `wallClockMs = 0`).
+  - `computeIdleMs(wallClockMs, workers, busyMs)` — capacity minus busy, clamped
+    to zero so clock-skew rounding cannot yield negatives.
+  - `computeThroughputMetrics(input)` — assembles a finite, non-negative payload
+    (clamps negative inputs, rounds wait, returns `generationsPerHour = 0` when
+    `wallClockMs = 0`).
 - **`src/NEAT/NeatEvolution.ts`**: Captures `fastBusyStartMs`/`heavyBusyStartMs`
-  at generation start, samples `heavyQueueMaxDepth` from in-flight discovery
-  and training sets (since heavy-pool work isn't a single-shot queue), builds
-  the `GenerationThroughputMetrics` object via `computeThroughputMetrics()`,
-  emits a `[Throughput]` verbose log line, and returns it alongside
-  `phaseTiming` from `evolve()`.
-- **`src/creature/CreatureTraining.ts`**: Forwards `result.throughput` into
-  the `generation_complete` event payload.
+  at generation start, samples `heavyQueueMaxDepth` from in-flight discovery and
+  training sets (since heavy-pool work isn't a single-shot queue), builds the
+  `GenerationThroughputMetrics` object via `computeThroughputMetrics()`, emits a
+  `[Throughput]` verbose log line, and returns it alongside `phaseTiming` from
+  `evolve()`.
+- **`src/creature/CreatureTraining.ts`**: Forwards `result.throughput` into the
+  `generation_complete` event payload.
 
 ### Design notes
 
 - **Wait time is deliberately an approximation.** Exact per-task wait would
-  require per-submission timestamps, which the issue explicitly rules out
-  ("no per-creature logging in hot paths"). The FIFO uniform-task-duration
-  model is transparent, cheap to compute, and signposted as approximate in
-  JSDoc.
-- **Queue depth is measured at the true peak.** Both hot paths enqueue all
-  tasks before workers start draining them, so `queue.length` at creation
-  time is the peak — no need to sample during execution.
+  require per-submission timestamps, which the issue explicitly rules out ("no
+  per-creature logging in hot paths"). The FIFO uniform-task-duration model is
+  transparent, cheap to compute, and signposted as approximate in JSDoc.
+- **Queue depth is measured at the true peak.** Both hot paths enqueue all tasks
+  before workers start draining them, so `queue.length` at creation time is the
+  peak — no need to sample during execution.
 - **Zero overhead on the per-task hot path.** Busy-ms accumulates via
   transitions on the existing `busyCount`, not via timestamps per task.
 
 ## Evidence
 
-Backend/telemetry change with no UI. Evidence is provided via the test
-results below and the `[Throughput]` verbose log line emitted per generation.
+Backend/telemetry change with no UI. Evidence is provided via the test results
+below and the `[Throughput]` verbose log line emitted per generation.
 
 ## Test Plan
 
@@ -90,5 +89,5 @@ results below and the `[Throughput]` verbose log line emitted per generation.
   - `generationsPerHour === 3_600_000 / wallClockMs` (when wallClock > 0)
   - `fastQueueMaxDepth ≥ 1` and `≤ population size` on fitness path
   - Heavy-pool fields present even when heavy-pool is idle
-- Full quality gate passes: `./quality.sh --skip-discovery --skip-wasm`
-  reports `5922 passed | 0 failed | 3 ignored`.
+- Full quality gate passes: `./quality.sh --skip-discovery --skip-wasm` reports
+  `5922 passed | 0 failed | 3 ignored`.

--- a/docs/pr-summary-2330.md
+++ b/docs/pr-summary-2330.md
@@ -1,0 +1,94 @@
+## Summary
+
+Add a compact per-generation throughput metrics payload to `generation_complete`
+training events so production runs can diagnose wall-clock usage, per-phase
+time, and worker queueing pressure without per-creature logging. Closes #2330.
+
+Previously, `generation_complete` events exposed only aggregate `phaseTiming`
+numbers. Operators could see *where* time was spent but had no compact way to
+answer questions like "how idle were workers?", "how deep did the breeding
+backlog get?", or "how much time did tasks spend waiting?". This PR adds a
+`throughput` field on `generation_complete` carrying finite, non-negative
+numeric counters suitable for dashboards and CSV exports.
+
+### Changes
+
+- **`src/config/TrainingEvent.ts`**: New `GenerationThroughputMetrics`
+  interface with 11 readonly numeric fields — `wallClockMs`, `nonFitnessMs`,
+  `generationsPerHour`, per-pool `{fast,heavy}BusyMs`, `{fast,heavy}IdleMs`,
+  `{fast,heavy}QueueMaxDepth`, `{fast,heavy}WaitMs`. Added
+  `readonly throughput?` to `GenerationCompleteEvent` with extensive JSDoc
+  documenting each field's meaning, units, and caveats (wait time is an
+  approximation).
+- **`src/workers/WorkerHandlerBase.ts`**: Added `busyStartMs` /
+  `cumulativeBusyMs` private fields and `onTaskStart()`/`onTaskEnd()` hooks
+  that capture clock reads only on idle↔busy transitions (0→1 start, N→0 end).
+  Replaced raw `busyCount++/--` in `makePromise()`/`makePromiseDeferred()`
+  with these hooks. Added public `getCumulativeBusyMs()`. Zero overhead in
+  hot loops — a clock read per idle-busy boundary, not per task.
+- **`src/multithreading/WorkerPool.ts`**: Added `getTotalBusyMs()` that sums
+  `getCumulativeBusyMs()` across all workers in the pool.
+- **`src/architecture/Fitness.ts`**: Added public `lastQueueMaxDepth`
+  populated to `uniqueQueue.length` at fitness start — the true peak since
+  the queue drains monotonically.
+- **`src/breed/ParallelBreeding.ts`**: Added public `lastQueueMaxDepth`
+  populated to `parentPairs.length` immediately after parent-pair selection.
+- **`src/NEAT/ThroughputMetrics.ts`** (new): Pure helper module so the
+  formulas can be unit-tested in isolation from `evolve()`:
+  - `approximateWaitMs(busyMs, depth, workers)` — FIFO uniform-task-duration
+    model: `wait ≈ busyMs × (depth - workers) / (2 × depth)`, zero when
+    `depth ≤ workers` or any input is non-positive.
+  - `computeIdleMs(wallClockMs, workers, busyMs)` — capacity minus busy,
+    clamped to zero so clock-skew rounding cannot yield negatives.
+  - `computeThroughputMetrics(input)` — assembles a finite, non-negative
+    payload (clamps negative inputs, rounds wait, returns
+    `generationsPerHour = 0` when `wallClockMs = 0`).
+- **`src/NEAT/NeatEvolution.ts`**: Captures `fastBusyStartMs`/`heavyBusyStartMs`
+  at generation start, samples `heavyQueueMaxDepth` from in-flight discovery
+  and training sets (since heavy-pool work isn't a single-shot queue), builds
+  the `GenerationThroughputMetrics` object via `computeThroughputMetrics()`,
+  emits a `[Throughput]` verbose log line, and returns it alongside
+  `phaseTiming` from `evolve()`.
+- **`src/creature/CreatureTraining.ts`**: Forwards `result.throughput` into
+  the `generation_complete` event payload.
+
+### Design notes
+
+- **Wait time is deliberately an approximation.** Exact per-task wait would
+  require per-submission timestamps, which the issue explicitly rules out
+  ("no per-creature logging in hot paths"). The FIFO uniform-task-duration
+  model is transparent, cheap to compute, and signposted as approximate in
+  JSDoc.
+- **Queue depth is measured at the true peak.** Both hot paths enqueue all
+  tasks before workers start draining them, so `queue.length` at creation
+  time is the peak — no need to sample during execution.
+- **Zero overhead on the per-task hot path.** Busy-ms accumulates via
+  transitions on the existing `busyCount`, not via timestamps per task.
+
+## Evidence
+
+Backend/telemetry change with no UI. Evidence is provided via the test
+results below and the `[Throughput]` verbose log line emitted per generation.
+
+## Test Plan
+
+- Added `test/NEAT/ThroughputMetrics.ts` (11 unit tests on the pure helpers):
+  - `approximateWaitMs` returns zero for non-positive inputs and when
+    `depth ≤ workers`
+  - FIFO formula: `busyMs=1000, depth=10, workers=2 → 400`
+  - Monotonicity with queue depth
+  - `computeIdleMs` capacity calculation and clamping on busy > capacity
+  - `computeThroughputMetrics` full payload, zero wall-clock yields
+    `generationsPerHour = 0` (finite), negative input clamping,
+    `fitnessMs > totalMs` yields `nonFitnessMs = 0`
+- Added `test/config/ThroughputMetrics.ts` (10 integration tests via
+  `Creature.evolveDataSet` with `onTrainingEvent`):
+  - `throughput` is present on every `generation_complete` event
+  - All 11 fields are finite non-negative numbers
+  - `wallClockMs === phaseTiming.totalMs`
+  - `nonFitnessMs === max(0, totalMs - fitnessMs)`
+  - `generationsPerHour === 3_600_000 / wallClockMs` (when wallClock > 0)
+  - `fastQueueMaxDepth ≥ 1` and `≤ population size` on fitness path
+  - Heavy-pool fields present even when heavy-pool is idle
+- Full quality gate passes: `./quality.sh --skip-discovery --skip-wasm`
+  reports `5922 passed | 0 failed | 3 ignored`.

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -35,6 +35,7 @@ import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 
 // Extracted modules
 import * as evolution from "@neat/NeatEvolution.ts";
+import type { EvolveResult } from "@neat/NeatEvolution.ts";
 import * as scheduling from "@neat/NeatScheduling.ts";
 
 /**
@@ -439,7 +440,7 @@ export class Neat {
 
   evolve(
     previousFittest?: Creature,
-  ): ReturnType<typeof evolution.evolve> {
+  ): Promise<EvolveResult> {
     return evolution.evolve(this, previousFittest);
   }
 

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -33,11 +33,13 @@ import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 import type {
   GenerationPhaseTiming,
+  GenerationThroughputMetrics,
   PhaseWorkerUtilisation,
   WorkerUtilisationSnapshot,
 } from "@config/TrainingEvent.ts";
 import type { Neat } from "@neat/Neat.ts";
 import { logReplaySummary } from "@neat/NeatScheduling.ts";
+import { computeThroughputMetrics } from "@neat/ThroughputMetrics.ts";
 import { emitTrainingEvent } from "@neat/TrainingEventEmitter.ts";
 import { preWarmWasmCache } from "@wasm/WasmCachePreWarmer.ts";
 import type { WorkerPool } from "@multithreading/WorkerPool.ts";
@@ -109,16 +111,13 @@ function computeOverallCpuUtilisation(
 }
 
 /**
- * Evaluates, selects, breeds and mutates the population.
+ * The result returned by a single call to `evolve()`.
  *
- * @param neat - The Neat instance to evolve
- * @param previousFittest - The fittest creature from the previous generation
- * @returns Evolution results including fittest creature, average score, and plateau status
+ * Issue #2330: Named export so that `Neat.ts` can reference it explicitly,
+ * avoiding potential circular-type-resolution issues that arise from using
+ * `ReturnType<typeof evolution.evolve>` across a circular module boundary.
  */
-export async function evolve(
-  neat: Neat,
-  previousFittest?: Creature,
-): Promise<{
+export interface EvolveResult {
   fittest: Creature;
   averageScore: number;
   plateau: {
@@ -128,7 +127,21 @@ export async function evolve(
     mutationMultiplier: number;
   };
   phaseTiming: GenerationPhaseTiming;
-}> {
+  /** Compact throughput counters for this generation. Issue #2330. */
+  throughput: GenerationThroughputMetrics;
+}
+
+/**
+ * Evaluates, selects, breeds and mutates the population.
+ *
+ * @param neat - The Neat instance to evolve
+ * @param previousFittest - The fittest creature from the previous generation
+ * @returns Evolution results including fittest creature, average score, and plateau status
+ */
+export async function evolve(
+  neat: Neat,
+  previousFittest?: Creature,
+): Promise<EvolveResult> {
   // Issue #2239: Per-generation timing diagnostics
   const evolveStartMs = Date.now();
 
@@ -159,6 +172,19 @@ export async function evolve(
   const fastPool = neat.fastWorkerPool;
   const heavyPool = neat.heavyWorkerPool;
 
+  // Issue #2330: Snapshot cumulative worker busy time so we can derive the
+  // per-generation delta without per-task hooks in hot paths.
+  const fastBusyStartMs = fastPool.getTotalBusyMs();
+  const heavyBusyStartMs = heavyPool === fastPool
+    ? fastBusyStartMs
+    : heavyPool.getTotalBusyMs();
+
+  // Issue #2330: Track peak heavy-pool backlog across the generation. The
+  // backlog is the sum of in-flight discovery and training tasks, which are
+  // long-running and may persist across generations.
+  let heavyQueueMaxDepth = neat.discoveryInProgress.size +
+    neat.trainingInProgress.size;
+
   // Issue #2313: Borrow idle heavy workers for fitness evaluation.
   // Heavy workers that have no pending discovery or training tasks can
   // temporarily assist the fast pool, improving CPU utilisation. This is
@@ -180,6 +206,13 @@ export async function evolve(
   const fitnessMs = Date.now() - fitnessStartMs;
   // Issue #2312: Snapshot after fitness — workers should be heavily utilised
   const fitnessUtilisation = captureUtilisationSnapshot(fastPool, heavyPool);
+
+  // Issue #2330: Heavy pool may have picked up new discovery/training tasks
+  // scheduled from previous generations during fitness; refresh the peak.
+  heavyQueueMaxDepth = Math.max(
+    heavyQueueMaxDepth,
+    neat.discoveryInProgress.size + neat.trainingInProgress.size,
+  );
 
   // Issue #2274: Time score sorting phase
   const sortStartMs = Date.now();
@@ -812,6 +845,40 @@ export async function evolve(
     workerUtilisation,
   };
 
+  // Issue #2330: Compute per-generation throughput metrics. All inputs are
+  // cheap aggregates captured at phase/generation boundaries — there is no
+  // per-creature hook in the hot path.
+  const fastBusyEndMs = fastPool.getTotalBusyMs();
+  const heavyBusyEndMs = heavyPool === fastPool
+    ? fastBusyEndMs
+    : heavyPool.getTotalBusyMs();
+  const fastBusyDeltaMs = Math.max(0, fastBusyEndMs - fastBusyStartMs);
+  const heavyBusyDeltaMs = Math.max(0, heavyBusyEndMs - heavyBusyStartMs);
+
+  // Peak fast-pool backlog is the larger of fitness or breeding queues —
+  // both use the same handler set, so the max is representative of the pool.
+  const fastQueueMaxDepth = Math.max(
+    neat.fitness.lastQueueMaxDepth,
+    parallelBreeding.lastQueueMaxDepth,
+  );
+
+  // Final heavy-backlog sample after any late scheduling events.
+  heavyQueueMaxDepth = Math.max(
+    heavyQueueMaxDepth,
+    neat.discoveryInProgress.size + neat.trainingInProgress.size,
+  );
+
+  const throughput = computeThroughputMetrics({
+    wallClockMs: totalMs,
+    fitnessMs,
+    fastWorkerCount: fastPool.getWorkerCount(),
+    heavyWorkerCount: heavyPool.getWorkerCount(),
+    fastBusyMs: fastBusyDeltaMs,
+    heavyBusyMs: heavyBusyDeltaMs,
+    fastQueueMaxDepth,
+    heavyQueueMaxDepth,
+  });
+
   // Issue #2239: Log per-phase timing when verbose is enabled
   if (neat.config.verbose) {
     const memTag = memoryEvictionMs > 0
@@ -837,6 +904,16 @@ export async function evolve(
         ` breeding=${breedingUtilisation.fastUtilisationPct}%fast/${breedingUtilisation.heavyUtilisationPct}%heavy` +
         ` overall=${workerUtilisation.overallCpuUtilisationPct}%`,
     );
+    // Issue #2330: Log throughput summary
+    getLogger().info(
+      `[Throughput] wall=${throughput.wallClockMs}ms` +
+        ` nonFitness=${throughput.nonFitnessMs}ms` +
+        ` gensPerHour=${throughput.generationsPerHour.toFixed(1)}` +
+        ` fast=busy${throughput.fastBusyMs}ms/idle${throughput.fastIdleMs}ms` +
+        `/depth${throughput.fastQueueMaxDepth}/wait${throughput.fastWaitMs}ms` +
+        ` heavy=busy${throughput.heavyBusyMs}ms/idle${throughput.heavyIdleMs}ms` +
+        `/depth${throughput.heavyQueueMaxDepth}/wait${throughput.heavyWaitMs}ms`,
+    );
   }
 
   return {
@@ -849,6 +926,7 @@ export async function evolve(
       mutationMultiplier: neat.plateauDetector.getMutationMultiplier(),
     },
     phaseTiming,
+    throughput,
   };
 }
 

--- a/src/NEAT/ThroughputMetrics.ts
+++ b/src/NEAT/ThroughputMetrics.ts
@@ -1,0 +1,138 @@
+/**
+ * ThroughputMetrics.ts - Compute per-generation throughput metrics.
+ *
+ * Issue #2330: Builds the `GenerationThroughputMetrics` payload from
+ * lightweight aggregates captured at phase/generation boundaries in
+ * `NeatEvolution.evolve()`. Keeps the computation isolated from the
+ * already-long evolution module so the formulas can be unit-tested and
+ * reasoned about in one place.
+ */
+
+import type { GenerationThroughputMetrics } from "@config/TrainingEvent.ts";
+
+/**
+ * Inputs required to build a throughput metrics payload for a single
+ * generation. All fields are either raw wall-clock durations or cumulative
+ * counters that have already been deltaed over the generation window.
+ */
+export interface ThroughputMetricsInput {
+  /** Total wall-clock duration of the generation in ms. */
+  readonly wallClockMs: number;
+  /** Wall-clock spent in the fitness evaluation phase in ms. */
+  readonly fitnessMs: number;
+  /** Number of workers in the fast pool. */
+  readonly fastWorkerCount: number;
+  /** Number of workers in the heavy pool. */
+  readonly heavyWorkerCount: number;
+  /** Delta of fast-pool cumulative busy-ms over this generation. */
+  readonly fastBusyMs: number;
+  /** Delta of heavy-pool cumulative busy-ms over this generation. */
+  readonly heavyBusyMs: number;
+  /** Peak pending-task depth observed on the fast pool this generation. */
+  readonly fastQueueMaxDepth: number;
+  /** Peak in-flight task count observed on the heavy pool this generation. */
+  readonly heavyQueueMaxDepth: number;
+}
+
+/**
+ * Computes the approximate cumulative FIFO queue wait time for a pool.
+ *
+ * Uses a uniform-task-duration FIFO model:
+ *
+ *   wait ≈ busyMs × (depth - workers) / (2 × depth)
+ *
+ * Intuition: the first `workers` tasks start immediately (zero wait); each
+ * subsequent task waits for roughly the average task duration multiplied by
+ * how deep into the queue it sits. Summed across all tasks and simplified
+ * this is `busyMs × (N - W) / (2 × N)` for `N > W`, else zero.
+ *
+ * This is deliberately an *approximation*. Exact per-task wait would
+ * require per-submission timestamps, which the acceptance criteria
+ * explicitly discourage ("no per-creature logging in hot paths").
+ *
+ * @param busyMs aggregate worker-ms spent executing tasks in the window
+ * @param depth peak pending-task count observed in the window
+ * @param workers worker count in the pool
+ * @returns approximate cumulative wait time in ms (non-negative)
+ */
+export function approximateWaitMs(
+  busyMs: number,
+  depth: number,
+  workers: number,
+): number {
+  if (busyMs <= 0 || depth <= 0 || workers <= 0) return 0;
+  if (depth <= workers) return 0;
+  const wait = (busyMs * (depth - workers)) / (2 * depth);
+  return wait > 0 ? Math.round(wait) : 0;
+}
+
+/**
+ * Computes idle worker-ms for a pool.
+ *
+ * Idle = pool capacity during the window minus aggregate busy time, clamped
+ * to zero. Capacity = `workers × wallClockMs`. Returned value is capped at
+ * capacity so small rounding glitches in Date.now() deltas cannot yield
+ * negative values.
+ */
+export function computeIdleMs(
+  wallClockMs: number,
+  workers: number,
+  busyMs: number,
+): number {
+  if (wallClockMs <= 0 || workers <= 0) return 0;
+  const capacity = workers * wallClockMs;
+  const idle = capacity - Math.max(0, busyMs);
+  return idle > 0 ? idle : 0;
+}
+
+/**
+ * Builds a complete `GenerationThroughputMetrics` payload.
+ *
+ * All fields are guaranteed to be finite and non-negative. `wallClockMs`
+ * of zero yields `generationsPerHour = 0` (rather than infinity) so
+ * downstream consumers can safely forward the value to logging or
+ * dashboards.
+ */
+export function computeThroughputMetrics(
+  input: ThroughputMetricsInput,
+): GenerationThroughputMetrics {
+  const wallClockMs = Math.max(0, input.wallClockMs);
+  const fitnessMs = Math.max(0, input.fitnessMs);
+  const fastBusyMs = Math.max(0, input.fastBusyMs);
+  const heavyBusyMs = Math.max(0, input.heavyBusyMs);
+  const fastQueueMaxDepth = Math.max(0, Math.floor(input.fastQueueMaxDepth));
+  const heavyQueueMaxDepth = Math.max(0, Math.floor(input.heavyQueueMaxDepth));
+  const fastWorkerCount = Math.max(0, input.fastWorkerCount);
+  const heavyWorkerCount = Math.max(0, input.heavyWorkerCount);
+
+  const nonFitnessMs = Math.max(0, wallClockMs - fitnessMs);
+  const generationsPerHour = wallClockMs > 0 ? 3_600_000 / wallClockMs : 0;
+
+  const fastIdleMs = computeIdleMs(wallClockMs, fastWorkerCount, fastBusyMs);
+  const heavyIdleMs = computeIdleMs(wallClockMs, heavyWorkerCount, heavyBusyMs);
+
+  const fastWaitMs = approximateWaitMs(
+    fastBusyMs,
+    fastQueueMaxDepth,
+    fastWorkerCount,
+  );
+  const heavyWaitMs = approximateWaitMs(
+    heavyBusyMs,
+    heavyQueueMaxDepth,
+    heavyWorkerCount,
+  );
+
+  return {
+    wallClockMs,
+    nonFitnessMs,
+    generationsPerHour,
+    fastBusyMs,
+    fastIdleMs,
+    fastQueueMaxDepth,
+    fastWaitMs,
+    heavyBusyMs,
+    heavyIdleMs,
+    heavyQueueMaxDepth,
+    heavyWaitMs,
+  };
+}

--- a/src/NEAT/ThroughputMetrics.ts
+++ b/src/NEAT/ThroughputMetrics.ts
@@ -13,7 +13,7 @@ import type { GenerationThroughputMetrics } from "@config/TrainingEvent.ts";
 /**
  * Inputs required to build a throughput metrics payload for a single
  * generation. All fields are either raw wall-clock durations or cumulative
- * counters that have been computed as deltas over the generation window.
+ * counters with deltas computed over the generation window.
  */
 export interface ThroughputMetricsInput {
   /** Total wall-clock duration of the generation in ms. */

--- a/src/NEAT/ThroughputMetrics.ts
+++ b/src/NEAT/ThroughputMetrics.ts
@@ -13,7 +13,7 @@ import type { GenerationThroughputMetrics } from "@config/TrainingEvent.ts";
 /**
  * Inputs required to build a throughput metrics payload for a single
  * generation. All fields are either raw wall-clock durations or cumulative
- * counters that have already been deltaed over the generation window.
+ * counters that have been computed as deltas over the generation window.
  */
 export interface ThroughputMetricsInput {
   /** Total wall-clock duration of the generation in ms. */

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -37,6 +37,16 @@ export class Fitness {
   private feedbackLoop: boolean;
   private evalConfig: RequiredParallelEvaluationConfig;
 
+  /**
+   * Peak pending-task depth observed on the fast pool during the most recent
+   * `calculate()` call.
+   *
+   * Issue #2330: Captured at fitness start — when the shared work-stealing
+   * queue has its maximum depth — so throughput diagnostics can report how
+   * deep the backlog became without adding overhead inside the hot loop.
+   */
+  lastQueueMaxDepth = 0;
+
   constructor(
     workers: WorkerHandler[],
     growth: number,
@@ -86,8 +96,15 @@ export class Fitness {
     }
 
     if (uniqueQueue.length === 0) {
+      this.lastQueueMaxDepth = 0;
       return;
     }
+
+    // Issue #2330: Record peak pending-task depth before workers drain the
+    // queue. The shared work-stealing queue starts at its maximum size and
+    // shrinks monotonically, so the initial `uniqueQueue.length` is the
+    // peak backlog for the fast pool during this fitness phase.
+    this.lastQueueMaxDepth = uniqueQueue.length;
 
     // Issue #1862: Sort by topology hash to cluster same-topology creatures.
     // This improves WASM compilation cache hit rates because workers pull

--- a/src/breed/ParallelBreeding.ts
+++ b/src/breed/ParallelBreeding.ts
@@ -66,6 +66,17 @@ export class ParallelBreeding {
   lastBreedingSubPhases?: BreedingSubPhaseTiming;
 
   /**
+   * Peak pending parent-pair depth observed during the most recent
+   * `breedBatch()` call.
+   *
+   * Issue #2330: Captured immediately after parent-pair selection — the
+   * point at which the breeding queue has its maximum depth — so throughput
+   * diagnostics can report how deep the fast-pool breeding backlog became
+   * without inserting Date.now() calls in the per-pair worker loop.
+   */
+  lastQueueMaxDepth = 0;
+
+  /**
    * Creates a new ParallelBreeding instance.
    *
    * @param genus - The genus containing the population
@@ -92,6 +103,7 @@ export class ParallelBreeding {
   async breedBatch(count: number): Promise<Creature[]> {
     if (count <= 0) {
       this.lastBreedingSubPhases = undefined;
+      this.lastQueueMaxDepth = 0;
       return [];
     }
 
@@ -115,6 +127,10 @@ export class ParallelBreeding {
       }
     }
     acc.parentSelectionMs = Date.now() - selectionStartMs;
+
+    // Issue #2330: Parent pairs are enqueued in one go before workers start
+    // pulling, so the peak breeding backlog is `parentPairs.length`.
+    this.lastQueueMaxDepth = parentPairs.length;
 
     // Step 2: Create offspring in parallel
     let results: (Creature | undefined)[];

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -173,6 +173,94 @@ export interface GenerationPhaseTiming {
 }
 
 /**
+ * Compact throughput counters for a single generation.
+ *
+ * Issue #2330: Makes it possible to reason about *why* a generation is slow
+ * without relying on coarse external signals (host CPU %, load average). All
+ * fields are cheap aggregates — no per-creature logging in hot paths — so
+ * enabling them has negligible cost.
+ *
+ * Metric definitions (field-by-field):
+ *
+ * - `wallClockMs`: Total wall-clock duration of the generation in ms.
+ *   Matches `phaseTiming.totalMs` and is repeated here for convenience when
+ *   consumers work with a flat throughput object.
+ *
+ * - `nonFitnessMs`: Wall-clock milliseconds spent outside `fitnessMs`
+ *   (breeding, mutation, dedup, sort, writeScores, speciation, pre-warming,
+ *   checkpoint writes, etc.). Quantifies overhead beyond the actual
+ *   evaluation work. Equals `max(0, wallClockMs - fitnessMs)`.
+ *
+ * - `generationsPerHour`: Instantaneous throughput projected from this
+ *   generation, computed as `3_600_000 / wallClockMs` when `wallClockMs > 0`.
+ *   Useful for capacity planning and comparing tuning experiments.
+ *
+ * - `fastBusyMs`: Aggregate worker-milliseconds that fast-pool workers spent
+ *   executing tasks during this generation. Summed across all fast workers.
+ *
+ * - `fastIdleMs`: Approximate worker-milliseconds that fast-pool workers
+ *   were idle during this generation. Computed as
+ *   `max(0, fastWorkerCount × wallClockMs - fastBusyMs)`. High values
+ *   indicate the fast pool is under-utilised.
+ *
+ * - `fastQueueMaxDepth`: Peak observed number of pending tasks queued for
+ *   the fast pool during this generation. Captured at fitness-start and
+ *   breeding-start. A depth greater than `fastWorkerCount` means tasks had
+ *   to wait.
+ *
+ * - `fastWaitMs`: Approximate cumulative time that fast-pool tasks spent
+ *   waiting for a free worker in ms. Uses a FIFO uniform-task-duration
+ *   model: `fastWaitMs ≈ fastBusyMs × (depth - workers) / (2 × depth)`
+ *   when `depth > workers`, else 0. This is an *approximate* signal for
+ *   queue back-pressure, not an exact per-task measurement.
+ *
+ * - `heavyBusyMs`: Aggregate worker-milliseconds heavy-pool workers spent
+ *   executing tasks (discovery, training) during this generation.
+ *
+ * - `heavyIdleMs`: Approximate heavy-pool idle worker-milliseconds,
+ *   computed analogously to `fastIdleMs`. When the pool is not partitioned
+ *   (`threads <= 2`), the heavy and fast pools share workers, so these
+ *   counters may reflect the same underlying handlers.
+ *
+ * - `heavyQueueMaxDepth`: Peak observed backlog of heavy-pool tasks
+ *   (`discoveryInProgress.size + trainingInProgress.size`) during this
+ *   generation.
+ *
+ * - `heavyWaitMs`: Approximate cumulative heavy-pool task wait time in ms,
+ *   using the same FIFO model as `fastWaitMs`.
+ */
+export interface GenerationThroughputMetrics {
+  /** Total wall-clock duration of this generation in ms. */
+  readonly wallClockMs: number;
+  /**
+   * Wall-clock time spent outside the fitness phase (ms).
+   * Equals `max(0, wallClockMs - phaseTiming.fitnessMs)`.
+   */
+  readonly nonFitnessMs: number;
+  /**
+   * Instantaneous throughput projection: `3_600_000 / wallClockMs` when
+   * `wallClockMs > 0`, else `0`.
+   */
+  readonly generationsPerHour: number;
+  /** Aggregate worker-ms fast-pool workers were executing tasks. */
+  readonly fastBusyMs: number;
+  /** Approximate fast-pool idle worker-ms (capacity minus busy). */
+  readonly fastIdleMs: number;
+  /** Peak observed fast-pool pending-task count this generation. */
+  readonly fastQueueMaxDepth: number;
+  /** Approximate cumulative fast-pool task wait time (ms). */
+  readonly fastWaitMs: number;
+  /** Aggregate worker-ms heavy-pool workers were executing tasks. */
+  readonly heavyBusyMs: number;
+  /** Approximate heavy-pool idle worker-ms (capacity minus busy). */
+  readonly heavyIdleMs: number;
+  /** Peak observed heavy-pool in-flight task count this generation. */
+  readonly heavyQueueMaxDepth: number;
+  /** Approximate cumulative heavy-pool task wait time (ms). */
+  readonly heavyWaitMs: number;
+}
+
+/**
  * Emitted when a generation completes evaluation and selection.
  */
 export interface GenerationCompleteEvent {
@@ -194,6 +282,12 @@ export interface GenerationCompleteEvent {
    * Issue #2239: Identifies which phase of evolution consumed the most time.
    */
   readonly phaseTiming: GenerationPhaseTiming;
+  /**
+   * Compact throughput metrics for this generation.
+   * Issue #2330: Wall-clock, worker busy/idle, and approximate queue
+   * depth/wait counters that explain *why* a generation is fast or slow.
+   */
+  readonly throughput?: GenerationThroughputMetrics;
 }
 
 /**

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -453,6 +453,8 @@ export async function evolveDir(
 
     // Issue #1615: Emit generation_complete event
     // Issue #2239: Include per-phase timing diagnostics from evolve()
+    // Issue #2330: Forward compact throughput counters (wall-clock, queue
+    // depths, approximate worker wait) on the same event.
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
     emitTrainingEvent(config.onTrainingEvent, {
@@ -464,6 +466,7 @@ export async function evolveDir(
       populationSize: neat.population.length,
       elapsedMs: generationElapsedMs,
       phaseTiming,
+      throughput: result.throughput,
     });
 
     // Issue #1615: Emit plateau_detected event when on plateau

--- a/src/multithreading/WorkerPool.ts
+++ b/src/multithreading/WorkerPool.ts
@@ -106,6 +106,23 @@ export class WorkerPool<T = unknown> {
   }
 
   /**
+   * Returns the aggregate cumulative busy time (ms) across all workers in
+   * the pool.
+   *
+   * Issue #2330: Callers snapshot this value at the start and end of each
+   * generation to compute per-generation busy/idle throughput metrics with
+   * zero per-task overhead. The underlying counter is maintained by
+   * `WorkerHandlerBase` via idle↔busy transitions.
+   */
+  getTotalBusyMs(): number {
+    let total = 0;
+    for (const worker of this.workers) {
+      total += worker.getCumulativeBusyMs();
+    }
+    return total;
+  }
+
+  /**
    * Selects the best worker for a new task.
    *
    * Selection strategy:

--- a/src/workers/WorkerHandlerBase.ts
+++ b/src/workers/WorkerHandlerBase.ts
@@ -69,6 +69,23 @@ export abstract class WorkerHandlerBase<
    * long-running operations from those doing quick evaluations.
    */
   private longRunningTaskCount = 0;
+  /**
+   * Timestamp (ms since epoch) when this worker most recently transitioned
+   * from idle (busyCount === 0) to busy (busyCount > 0). Zero when idle.
+   *
+   * Issue #2330: Used to measure cumulative busy intervals so per-generation
+   * throughput metrics can report worker utilisation without per-task hooks
+   * in hot paths.
+   */
+  private busyStartMs = 0;
+  /**
+   * Cumulative milliseconds this worker has spent busy (i.e. with one or
+   * more in-flight tasks). Incremented only on busy→idle transitions.
+   *
+   * Issue #2330: Low-overhead aggregate used by `WorkerPool.getTotalBusyMs()`
+   * to drive the `generation_complete.throughput` counters.
+   */
+  private cumulativeBusyMs = 0;
   /** Map of task IDs to their callback functions */
   private callbacks = new Map<number, CallableFunction>();
   /** Listeners to notify when worker becomes idle */
@@ -258,16 +275,56 @@ export abstract class WorkerHandlerBase<
   }
 
   /**
+   * Records that a task has begun; if this is the first in-flight task,
+   * capture the busy-interval start timestamp.
+   *
+   * Issue #2330: Cheap transitions keep throughput accounting out of hot
+   * paths — only idle↔busy edges read the clock, not every task.
+   */
+  private onTaskStart(): void {
+    if (this.busyCount === 0) {
+      this.busyStartMs = Date.now();
+    }
+    this.busyCount++;
+  }
+
+  /**
+   * Records that a task has ended; if the worker just became idle, fold
+   * the elapsed interval into `cumulativeBusyMs`.
+   *
+   * Issue #2330: Called from both the success callback and the deferred
+   * reject path so failed tasks still contribute to busy accounting.
+   */
+  private onTaskEnd(): void {
+    this.busyCount--;
+    if (this.busyCount === 0 && this.busyStartMs > 0) {
+      this.cumulativeBusyMs += Date.now() - this.busyStartMs;
+      this.busyStartMs = 0;
+    }
+  }
+
+  /**
+   * Returns cumulative milliseconds this worker has spent busy since it
+   * was created.
+   *
+   * Issue #2330: Callers snapshot this at phase/generation boundaries and
+   * subtract to compute per-window busy time with zero per-task overhead.
+   */
+  getCumulativeBusyMs(): number {
+    return this.cumulativeBusyMs;
+  }
+
+  /**
    * Creates a promise for a request and posts it immediately.
    *
    * @param data - The request data to send
    * @returns Promise resolving to the worker's response
    */
   protected makePromise(data: TRequest): Promise<TResponse> {
-    this.busyCount++;
+    this.onTaskStart();
     const p = new Promise<TResponse>((resolve) => {
       const call = (result: TResponse) => {
-        this.busyCount--;
+        this.onTaskEnd();
         resolve(result);
 
         if (!this.isBusy()) {
@@ -299,11 +356,11 @@ export abstract class WorkerHandlerBase<
     data: TRequest,
     afterPost?: () => void,
   ): Promise<TResponse> {
-    this.busyCount++;
+    this.onTaskStart();
 
     const p = new Promise<TResponse>((resolve, reject) => {
       const call = (result: TResponse) => {
-        this.busyCount--;
+        this.onTaskEnd();
         resolve(result);
 
         if (!this.isBusy()) {
@@ -318,7 +375,7 @@ export abstract class WorkerHandlerBase<
         afterPost?.();
       }).catch((err) => {
         this.callbacks.delete(data.taskID);
-        this.busyCount--;
+        this.onTaskEnd();
 
         if (!this.isBusy()) {
           this.idleListeners.forEach((listener) => listener(this));

--- a/test/NEAT/ThroughputMetrics.ts
+++ b/test/NEAT/ThroughputMetrics.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the pure throughput metric helpers.
+ *
+ * Issue #2330: Validates the FIFO-approximation wait formula, the
+ * idle-time clamp, and the assembled `GenerationThroughputMetrics`
+ * payload in isolation from the evolve() pipeline.
+ */
+import { assert, assertEquals } from "@std/assert";
+import {
+  approximateWaitMs,
+  computeIdleMs,
+  computeThroughputMetrics,
+} from "@neat/ThroughputMetrics.ts";
+
+Deno.test("approximateWaitMs - zero when no queueing pressure", () => {
+  // depth <= workers → no task ever waited.
+  assertEquals(approximateWaitMs(1000, 4, 4), 0);
+  assertEquals(approximateWaitMs(1000, 2, 4), 0);
+  assertEquals(approximateWaitMs(1000, 0, 4), 0);
+});
+
+Deno.test("approximateWaitMs - zero when inputs are non-positive", () => {
+  assertEquals(approximateWaitMs(0, 100, 4), 0);
+  assertEquals(approximateWaitMs(-1, 100, 4), 0);
+  assertEquals(approximateWaitMs(1000, 100, 0), 0);
+});
+
+Deno.test("approximateWaitMs - follows FIFO uniform-task-duration formula", () => {
+  // busyMs=1000, depth=10, workers=2
+  // Expected ≈ 1000 × (10 - 2) / (2 × 10) = 400
+  assertEquals(approximateWaitMs(1000, 10, 2), 400);
+});
+
+Deno.test("approximateWaitMs - grows with queue depth", () => {
+  const shallow = approximateWaitMs(1000, 6, 4);
+  const deep = approximateWaitMs(1000, 60, 4);
+  assert(deep > shallow, "deeper queue should imply more wait");
+});
+
+Deno.test("computeIdleMs - capacity minus busy", () => {
+  // 4 workers × 1000 ms = 4000 capacity; 2500 busy → 1500 idle.
+  assertEquals(computeIdleMs(1000, 4, 2500), 1500);
+});
+
+Deno.test("computeIdleMs - clamps to zero when busy exceeds capacity", () => {
+  // Shouldn't happen physically but guard against clock skew.
+  assertEquals(computeIdleMs(1000, 4, 5000), 0);
+});
+
+Deno.test("computeIdleMs - zero when wall-clock or workers are zero", () => {
+  assertEquals(computeIdleMs(0, 4, 100), 0);
+  assertEquals(computeIdleMs(1000, 0, 100), 0);
+});
+
+Deno.test("computeThroughputMetrics - assembled payload has required fields", () => {
+  const metrics = computeThroughputMetrics({
+    wallClockMs: 1000,
+    fitnessMs: 600,
+    fastWorkerCount: 4,
+    heavyWorkerCount: 2,
+    fastBusyMs: 2000,
+    heavyBusyMs: 800,
+    fastQueueMaxDepth: 20,
+    heavyQueueMaxDepth: 3,
+  });
+
+  assertEquals(metrics.wallClockMs, 1000);
+  assertEquals(metrics.nonFitnessMs, 400); // 1000 - 600
+  assertEquals(metrics.generationsPerHour, 3_600_000 / 1000);
+  assertEquals(metrics.fastBusyMs, 2000);
+  assertEquals(metrics.fastIdleMs, 2000); // 4 × 1000 - 2000
+  assertEquals(metrics.fastQueueMaxDepth, 20);
+  // 2000 × (20 - 4) / (2 × 20) = 800
+  assertEquals(metrics.fastWaitMs, 800);
+  assertEquals(metrics.heavyBusyMs, 800);
+  assertEquals(metrics.heavyIdleMs, 1200); // 2 × 1000 - 800
+  assertEquals(metrics.heavyQueueMaxDepth, 3);
+  // 800 × (3 - 2) / (2 × 3) ≈ 133
+  assertEquals(metrics.heavyWaitMs, Math.round(800 * 1 / 6));
+});
+
+Deno.test("computeThroughputMetrics - handles zero wall-clock gracefully", () => {
+  const metrics = computeThroughputMetrics({
+    wallClockMs: 0,
+    fitnessMs: 0,
+    fastWorkerCount: 4,
+    heavyWorkerCount: 2,
+    fastBusyMs: 0,
+    heavyBusyMs: 0,
+    fastQueueMaxDepth: 0,
+    heavyQueueMaxDepth: 0,
+  });
+
+  assertEquals(metrics.wallClockMs, 0);
+  assertEquals(metrics.nonFitnessMs, 0);
+  assertEquals(metrics.generationsPerHour, 0);
+  assertEquals(metrics.fastIdleMs, 0);
+  assertEquals(metrics.heavyIdleMs, 0);
+  assert(Number.isFinite(metrics.generationsPerHour));
+});
+
+Deno.test("computeThroughputMetrics - clamps negative inputs to zero", () => {
+  const metrics = computeThroughputMetrics({
+    wallClockMs: -5,
+    fitnessMs: -10,
+    fastWorkerCount: -2,
+    heavyWorkerCount: -1,
+    fastBusyMs: -100,
+    heavyBusyMs: -50,
+    fastQueueMaxDepth: -3,
+    heavyQueueMaxDepth: -1,
+  });
+
+  assertEquals(metrics.wallClockMs, 0);
+  assertEquals(metrics.nonFitnessMs, 0);
+  assertEquals(metrics.fastBusyMs, 0);
+  assertEquals(metrics.fastIdleMs, 0);
+  assertEquals(metrics.fastQueueMaxDepth, 0);
+  assertEquals(metrics.fastWaitMs, 0);
+});
+
+Deno.test("computeThroughputMetrics - fitnessMs greater than totalMs produces zero nonFitnessMs", () => {
+  // Possible if per-phase timing accumulates differently due to overlap.
+  const metrics = computeThroughputMetrics({
+    wallClockMs: 500,
+    fitnessMs: 600,
+    fastWorkerCount: 4,
+    heavyWorkerCount: 2,
+    fastBusyMs: 1000,
+    heavyBusyMs: 0,
+    fastQueueMaxDepth: 10,
+    heavyQueueMaxDepth: 0,
+  });
+
+  assertEquals(metrics.nonFitnessMs, 0);
+});

--- a/test/config/ThroughputMetrics.ts
+++ b/test/config/ThroughputMetrics.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for generation throughput metrics.
+ *
+ * Issue #2330: Verifies that `generation_complete` events expose compact
+ * throughput counters — wall-clock, non-fitness time, generations/hour,
+ * fast/heavy queue max depth, approximate worker wait time, and worker
+ * busy/idle aggregates — with low overhead, correct types, and sensible
+ * invariants.
+ */
+import { assert, assertEquals, assertGreater } from "@std/assert";
+import { Creature } from "@creature";
+import { Mutation } from "@neat/Mutation.ts";
+import type {
+  GenerationCompleteEvent,
+  GenerationThroughputMetrics,
+  TrainingEvent,
+} from "@config/TrainingEvent.ts";
+
+async function collectGenerationEvents(
+  threads = 1,
+  populationSize = 10,
+  iterations = 3,
+): Promise<GenerationCompleteEvent[]> {
+  const events: GenerationCompleteEvent[] = [];
+
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([1]) },
+  ];
+
+  const creature = new Creature(2, 1);
+  await creature.evolveDataSet(trainingSet, {
+    mutation: Mutation.FFW,
+    iterations,
+    targetError: 0.001,
+    populationSize,
+    threads,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        events.push(event);
+      }
+    },
+  });
+  return events;
+}
+
+Deno.test("ThroughputMetrics - generation events include throughput field", async () => {
+  const events = await collectGenerationEvents();
+  assertGreater(
+    events.length,
+    0,
+    "Should emit at least one generation_complete event",
+  );
+
+  const throughput = events[0].throughput;
+  assert(
+    throughput !== undefined,
+    "throughput metrics should be present on generation_complete",
+  );
+});
+
+Deno.test("ThroughputMetrics - all numeric fields are finite, non-negative numbers", async () => {
+  const events = await collectGenerationEvents();
+  assertGreater(events.length, 0);
+
+  const throughput = events[0].throughput as GenerationThroughputMetrics;
+
+  const numericFields: Array<keyof GenerationThroughputMetrics> = [
+    "wallClockMs",
+    "nonFitnessMs",
+    "generationsPerHour",
+    "fastBusyMs",
+    "fastIdleMs",
+    "fastQueueMaxDepth",
+    "fastWaitMs",
+    "heavyBusyMs",
+    "heavyIdleMs",
+    "heavyQueueMaxDepth",
+    "heavyWaitMs",
+  ];
+
+  for (const field of numericFields) {
+    const value = throughput[field];
+    assertEquals(
+      typeof value,
+      "number",
+      `throughput.${String(field)} should be a number`,
+    );
+    assert(
+      Number.isFinite(value),
+      `throughput.${String(field)} should be finite, got ${value}`,
+    );
+    assert(
+      value >= 0,
+      `throughput.${String(field)} should be non-negative, got ${value}`,
+    );
+  }
+});
+
+Deno.test("ThroughputMetrics - wallClockMs matches phaseTiming.totalMs", async () => {
+  const events = await collectGenerationEvents();
+  assertGreater(events.length, 0);
+
+  for (const event of events) {
+    const throughput = event.throughput as GenerationThroughputMetrics;
+    assertEquals(
+      throughput.wallClockMs,
+      event.phaseTiming.totalMs,
+      "throughput.wallClockMs must equal phaseTiming.totalMs",
+    );
+  }
+});
+
+Deno.test("ThroughputMetrics - nonFitnessMs = totalMs - fitnessMs", async () => {
+  const events = await collectGenerationEvents();
+  assertGreater(events.length, 0);
+
+  for (const event of events) {
+    const throughput = event.throughput as GenerationThroughputMetrics;
+    const expected = Math.max(
+      0,
+      event.phaseTiming.totalMs - event.phaseTiming.fitnessMs,
+    );
+    assertEquals(
+      throughput.nonFitnessMs,
+      expected,
+      `nonFitnessMs should be totalMs (${event.phaseTiming.totalMs}) - ` +
+        `fitnessMs (${event.phaseTiming.fitnessMs}) = ${expected}, ` +
+        `got ${throughput.nonFitnessMs}`,
+    );
+  }
+});
+
+Deno.test("ThroughputMetrics - generationsPerHour is 3_600_000 / wallClockMs when positive", async () => {
+  const events = await collectGenerationEvents();
+  assertGreater(events.length, 0);
+
+  for (const event of events) {
+    const throughput = event.throughput as GenerationThroughputMetrics;
+    if (throughput.wallClockMs > 0) {
+      const expected = 3_600_000 / throughput.wallClockMs;
+      // Allow small floating point tolerance (should be exact in practice).
+      const diff = Math.abs(throughput.generationsPerHour - expected);
+      assert(
+        diff < 1e-6,
+        `generationsPerHour should be 3_600_000 / wallClockMs (~${expected}), ` +
+          `got ${throughput.generationsPerHour}`,
+      );
+    }
+  }
+});
+
+Deno.test("ThroughputMetrics - fastQueueMaxDepth reflects population size during fitness", async () => {
+  const populationSize = 15;
+  const events = await collectGenerationEvents(1, populationSize);
+  assertGreater(events.length, 0);
+
+  // On the first generation, every creature needs evaluation, so the fast
+  // queue should have at least one pending task when measured.
+  // The peak should be at most the population size (after dedup).
+  const first = events[0].throughput as GenerationThroughputMetrics;
+  assert(
+    first.fastQueueMaxDepth >= 1,
+    `fastQueueMaxDepth should be >= 1 on first generation, got ${first.fastQueueMaxDepth}`,
+  );
+  assert(
+    first.fastQueueMaxDepth <= populationSize,
+    `fastQueueMaxDepth should be <= population size (${populationSize}), got ${first.fastQueueMaxDepth}`,
+  );
+});
+
+Deno.test("ThroughputMetrics - fastIdleMs <= fastWorkers × wallClockMs", async () => {
+  const events = await collectGenerationEvents();
+  assertGreater(events.length, 0);
+
+  for (const event of events) {
+    const throughput = event.throughput as GenerationThroughputMetrics;
+    // fastIdleMs is capped by worker capacity. We don't know the exact worker
+    // count from the event, but we can check that idle is at least non-negative
+    // and that busy + idle relation holds.
+    assert(
+      throughput.fastIdleMs >= 0,
+      "fastIdleMs must be non-negative",
+    );
+    assert(
+      throughput.heavyIdleMs >= 0,
+      "heavyIdleMs must be non-negative",
+    );
+  }
+});
+
+Deno.test("ThroughputMetrics - heavy pool metrics present even when no heavy tasks ran", async () => {
+  // With iterations=3 the heavy pool may be idle. Metrics must still be
+  // populated with valid zero-or-positive values.
+  const events = await collectGenerationEvents();
+  assertGreater(events.length, 0);
+
+  for (const event of events) {
+    const throughput = event.throughput as GenerationThroughputMetrics;
+    assertEquals(typeof throughput.heavyBusyMs, "number");
+    assertEquals(typeof throughput.heavyIdleMs, "number");
+    assertEquals(typeof throughput.heavyQueueMaxDepth, "number");
+    assertEquals(typeof throughput.heavyWaitMs, "number");
+  }
+});
+
+Deno.test("ThroughputMetrics - fastBusyMs is non-decreasing across generations for same instance", async () => {
+  // The cumulative busy aggregator is reset per generation (delta), so we
+  // cannot assert monotonicity of the delta itself — only that each delta
+  // is non-negative.
+  const events = await collectGenerationEvents(1, 10, 5);
+  assertGreater(events.length, 1);
+
+  for (const event of events) {
+    const throughput = event.throughput as GenerationThroughputMetrics;
+    assert(
+      throughput.fastBusyMs >= 0,
+      `fastBusyMs should be non-negative, got ${throughput.fastBusyMs}`,
+    );
+    assert(
+      throughput.heavyBusyMs >= 0,
+      `heavyBusyMs should be non-negative, got ${throughput.heavyBusyMs}`,
+    );
+  }
+});
+
+Deno.test("ThroughputMetrics - callback still fires without throughput field access crashing", async () => {
+  // Guard against future regressions where throughput may be optional.
+  const events = await collectGenerationEvents();
+  assertGreater(events.length, 0);
+
+  // Accessing .throughput on every event must not throw.
+  for (const event of events) {
+    const throughput = event.throughput;
+    assert(
+      throughput === undefined || typeof throughput === "object",
+      "throughput should be an object or undefined",
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Add a compact per-generation throughput metrics payload to `generation_complete`
training events so production runs can diagnose wall-clock usage, per-phase
time, and worker queueing pressure without per-creature logging. Closes #2330.

Previously, `generation_complete` events exposed only aggregate `phaseTiming`
numbers. Operators could see *where* time was spent but had no compact way to
answer questions like "how idle were workers?", "how deep did the breeding
backlog get?", or "how much time did tasks spend waiting?". This PR adds a
`throughput` field on `generation_complete` carrying finite, non-negative
numeric counters suitable for dashboards and CSV exports.

### Changes

- **`src/config/TrainingEvent.ts`**: New `GenerationThroughputMetrics`
  interface with 11 readonly numeric fields — `wallClockMs`, `nonFitnessMs`,
  `generationsPerHour`, per-pool `{fast,heavy}BusyMs`, `{fast,heavy}IdleMs`,
  `{fast,heavy}QueueMaxDepth`, `{fast,heavy}WaitMs`. Added
  `readonly throughput?` to `GenerationCompleteEvent` with extensive JSDoc
  documenting each field's meaning, units, and caveats (wait time is an
  approximation).
- **`src/workers/WorkerHandlerBase.ts`**: Added `busyStartMs` /
  `cumulativeBusyMs` private fields and `onTaskStart()`/`onTaskEnd()` hooks
  that capture clock reads only on idle↔busy transitions (0→1 start, N→0 end).
  Replaced raw `busyCount++/--` in `makePromise()`/`makePromiseDeferred()`
  with these hooks. Added public `getCumulativeBusyMs()`. Zero overhead in
  hot loops — a clock read per idle-busy boundary, not per task.
- **`src/multithreading/WorkerPool.ts`**: Added `getTotalBusyMs()` that sums
  `getCumulativeBusyMs()` across all workers in the pool.
- **`src/architecture/Fitness.ts`**: Added public `lastQueueMaxDepth`
  populated to `uniqueQueue.length` at fitness start — the true peak since
  the queue drains monotonically.
- **`src/breed/ParallelBreeding.ts`**: Added public `lastQueueMaxDepth`
  populated to `parentPairs.length` immediately after parent-pair selection.
- **`src/NEAT/ThroughputMetrics.ts`** (new): Pure helper module so the
  formulas can be unit-tested in isolation from `evolve()`:
  - `approximateWaitMs(busyMs, depth, workers)` — FIFO uniform-task-duration
    model: `wait ≈ busyMs × (depth - workers) / (2 × depth)`, zero when
    `depth ≤ workers` or any input is non-positive.
  - `computeIdleMs(wallClockMs, workers, busyMs)` — capacity minus busy,
    clamped to zero so clock-skew rounding cannot yield negatives.
  - `computeThroughputMetrics(input)` — assembles a finite, non-negative
    payload (clamps negative inputs, rounds wait, returns
    `generationsPerHour = 0` when `wallClockMs = 0`).
- **`src/NEAT/NeatEvolution.ts`**: Captures `fastBusyStartMs`/`heavyBusyStartMs`
  at generation start, samples `heavyQueueMaxDepth` from in-flight discovery
  and training sets (since heavy-pool work isn't a single-shot queue), builds
  the `GenerationThroughputMetrics` object via `computeThroughputMetrics()`,
  emits a `[Throughput]` verbose log line, and returns it alongside
  `phaseTiming` from `evolve()`.
- **`src/creature/CreatureTraining.ts`**: Forwards `result.throughput` into
  the `generation_complete` event payload.

### Design notes

- **Wait time is deliberately an approximation.** Exact per-task wait would
  require per-submission timestamps, which the issue explicitly rules out
  ("no per-creature logging in hot paths"). The FIFO uniform-task-duration
  model is transparent, cheap to compute, and signposted as approximate in
  JSDoc.
- **Queue depth is measured at the true peak.** Both hot paths enqueue all
  tasks before workers start draining them, so `queue.length` at creation
  time is the peak — no need to sample during execution.
- **Zero overhead on the per-task hot path.** Busy-ms accumulates via
  transitions on the existing `busyCount`, not via timestamps per task.

## Evidence

Backend/telemetry change with no UI. Evidence is provided via the test
results below and the `[Throughput]` verbose log line emitted per generation.

## Test Plan

- Added `test/NEAT/ThroughputMetrics.ts` (11 unit tests on the pure helpers):
  - `approximateWaitMs` returns zero for non-positive inputs and when
    `depth ≤ workers`
  - FIFO formula: `busyMs=1000, depth=10, workers=2 → 400`
  - Monotonicity with queue depth
  - `computeIdleMs` capacity calculation and clamping on busy > capacity
  - `computeThroughputMetrics` full payload, zero wall-clock yields
    `generationsPerHour = 0` (finite), negative input clamping,
    `fitnessMs > totalMs` yields `nonFitnessMs = 0`
- Added `test/config/ThroughputMetrics.ts` (10 integration tests via
  `Creature.evolveDataSet` with `onTrainingEvent`):
  - `throughput` is present on every `generation_complete` event
  - All 11 fields are finite non-negative numbers
  - `wallClockMs === phaseTiming.totalMs`
  - `nonFitnessMs === max(0, totalMs - fitnessMs)`
  - `generationsPerHour === 3_600_000 / wallClockMs` (when wallClock > 0)
  - `fastQueueMaxDepth ≥ 1` and `≤ population size` on fitness path
  - Heavy-pool fields present even when heavy-pool is idle
- Full quality gate passes: `./quality.sh --skip-discovery --skip-wasm`
  reports `5922 passed | 0 failed | 3 ignored`.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2330 -->