### PR TITLE
Define NEAT-AI-core release and pinning policy (#2342)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,6 +414,24 @@ GPU-accelerated structural hints used by `discoveryDir()`.
 > skipped gracefully and discovery is disabled — no environment variable is
 > required.
 
+## 🦀 NEAT-AI-core Dependency Policy
+
+NEAT-AI consumes shared Rust computation from the external
+[NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) repository. The
+full policy is in
+[docs/CORE_DEPENDENCY_POLICY.md](docs/CORE_DEPENDENCY_POLICY.md); the key rules
+are:
+
+1. **Crate name:** `neat-core` (hyphenated). Not `neat_ai_core` or
+   `neat-ai-core`.
+2. **Pinning:** git dependency with `rev = "<full-40-char-SHA>"` in the root
+   `Cargo.toml`. Never use `branch` pinning.
+3. **Single source of truth:** workspace members use
+   `neat-core = { workspace = true }`.
+4. **Local dev:** use `.cargo/config.toml` path override (git-ignored).
+5. **Semver:** NEAT-AI-core tags follow `v<MAJOR>.<MINOR>.<PATCH>`. Patch bumps
+   need CI green; minor bumps need one review; major bumps need owner approval.
+
 ## 🔄 Feed-forward vs Recurrent Connections
 
 NEAT-AI supports two topology styles:
@@ -447,6 +465,8 @@ In our production workloads, the default is feed-forward/forward-only.
 - **docs/INTELLIGENT_DESIGN.md** - Intelligent Design squash optimisation guide
 - **docs/PREDICTIVE_CODING.md** - Predictive Coding architecture design
 - **docs/TS_RUST_MIGRATION.md** - TypeScript to Rust migration milestone roadmap
+- **docs/CORE_DEPENDENCY_POLICY.md** - NEAT-AI-core release, pinning, and semver
+  policy (ADR)
 - **docs/TROUBLESHOOTING.md** - Common issues and solutions
 - **docs/archive/pr-summaries/** - Archived PR summary files (historical)
 - **src/methods/activations/README.md** - Activation function strategy reference

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.12.17",
+  "version": "2.12.18",
   "publish": {
     "include": [
       "README.md",

--- a/docs/CORE_DEPENDENCY_POLICY.md
+++ b/docs/CORE_DEPENDENCY_POLICY.md
@@ -1,0 +1,136 @@
+# NEAT-AI-core Release and Pinning Policy
+
+Issue #2342 — Architecture Decision Record (ADR) for how NEAT-AI consumes the
+shared Rust library from
+[NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core).
+
+## Decision Summary
+
+NEAT-AI pins `neat-core` as a **git dependency with an explicit `rev`** (full
+40-character SHA). This gives reproducible builds, instant availability on push,
+and no external registry dependency. crates.io publication is **not required**
+at this stage but remains an option for the future.
+
+## Crate Name
+
+| Repository          | Crate name                         | Cargo dependency key               |
+| ------------------- | ---------------------------------- | ---------------------------------- |
+| NEAT-AI-core        | `neat-core`                        | `neat-core`                        |
+| NEAT-AI (this repo) | `wasm_activation` (in-tree member) | inherits `neat-core` via workspace |
+
+The crate is named `neat-core` (hyphenated). Do **not** use `neat_ai_core` or
+`neat-ai-core` — those refer to the repository, not the crate.
+
+## Workspace Layout
+
+```
+NEAT-AI (this repo)
+├── Cargo.toml              ← workspace root; single source of truth for the neat-core rev
+├── wasm_activation/        ← in-tree WASM crate; uses `neat-core = { workspace = true }`
+│   └── Cargo.toml
+└── (future workspace members inherit the same pinned rev)
+```
+
+Every workspace member that depends on `neat-core` **must** use
+`{ workspace = true }` so the rev is controlled in exactly one place.
+
+## Pinning Model
+
+### Default: git + rev
+
+```toml
+# Root Cargo.toml — the only place the rev is declared
+[workspace.dependencies]
+neat-core = { git = "https://github.com/stSoftwareAU/NEAT-AI-core.git", rev = "<full-40-char-sha>" }
+```
+
+**Why rev, not tag or branch?**
+
+- A `rev` is **immutable** — the build is identical regardless of when or where
+  it runs.
+- A `branch` tracks a moving target and can silently break consumers.
+- A `tag` is safer than a branch but can be force-pushed. A rev cannot.
+
+Tags are used in NEAT-AI-core for human reference (see semver policy below) but
+the consumer always pins the underlying commit SHA.
+
+### Local Development Override
+
+When iterating on `neat-core` locally, add a **path override** in
+`.cargo/config.toml` at the repository root:
+
+```toml
+# .cargo/config.toml  (DO NOT commit — listed in .gitignore)
+[patch."https://github.com/stSoftwareAU/NEAT-AI-core.git"]
+neat-core = { path = "../NEAT-AI-core/neat-core" }
+```
+
+Remove the override before committing. The file is git-ignored by the `.*` rule.
+
+### CI Authentication
+
+Set `CARGO_NET_GIT_FETCH_WITH_CLI=true` so Cargo uses the system `git` binary
+and inherits the `GITHUB_TOKEN` credential injected by `actions/checkout`. See
+`scripts/rust-ci-git-auth.sh` for the helper and
+[docs/CI_EXTERNAL_NEAT_AI_CORE.md](CI_EXTERNAL_NEAT_AI_CORE.md) for full CI
+details.
+
+## Semver and Tagging Policy
+
+NEAT-AI-core follows [Semantic Versioning 2.0.0](https://semver.org/):
+
+| Change type                      | Version bump      | Examples                            |
+| -------------------------------- | ----------------- | ----------------------------------- |
+| Bug fix, docs, internal refactor | **patch** (0.1.x) | Fix rounding, update comments       |
+| New public API, new feature      | **minor** (0.x.0) | Add new activation helper           |
+| Breaking API change              | **major** (x.0.0) | Rename public function, remove type |
+
+### Tag Format
+
+Tags on NEAT-AI-core use the format `v<MAJOR>.<MINOR>.<PATCH>`, e.g. `v0.1.1`.
+Every tagged release must have a corresponding commit on the `Develop` branch.
+
+### When to Bump the Core Dependency in NEAT-AI
+
+1. **Identify the need** — a NEAT-AI PR requires a new feature or fix from
+   `neat-core`.
+2. **Verify the target** — the required commit must be merged to `Develop` in
+   NEAT-AI-core and (for non-trivial changes) tagged with a semver release.
+3. **Update the rev** — change the `rev` in the root `Cargo.toml` to the new
+   full SHA.
+4. **Refresh the lock** — run `cargo update -p neat-core`.
+5. **Run tests** — `cargo test` in the workspace root and the full
+   `./quality.sh` gate.
+6. **Commit** — include the tag (if any) in the commit message, e.g.
+   `bump neat-core to v0.2.0 (abc1234...)`.
+
+### Approval Requirements
+
+- **Patch bumps** (bug fixes): any contributor may bump after CI passes.
+- **Minor bumps** (new features): require at least one approving review on the
+  NEAT-AI PR.
+- **Major bumps** (breaking changes): require repository-owner approval and must
+  be coordinated so all workspace members are updated atomically.
+
+The `Develop` branch on NEAT-AI-core is protected; all changes reach it via pull
+request.
+
+## Future: crates.io Publication
+
+If `neat-core` is published to [crates.io](https://crates.io/) in the future:
+
+1. Replace the `git` dependency with a version requirement:
+   ```toml
+   neat-core = "0.2"
+   ```
+2. Update this policy to reflect the new pinning model.
+3. Continue tagging releases on GitHub for traceability.
+
+Until then, git + rev pinning is the default and sole supported model.
+
+## Related Documents
+
+- [docs/EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md) — architecture and
+  day-to-day workflow for bumping the core dependency.
+- [docs/CI_EXTERNAL_NEAT_AI_CORE.md](CI_EXTERNAL_NEAT_AI_CORE.md) — CI plumbing
+  for auth, caching, and WASM builds.

--- a/docs/pr-summary-2342.md
+++ b/docs/pr-summary-2342.md
@@ -22,8 +22,8 @@ approval requirements for bumping the core dependency. Closes #2342.
 
 This is a documentation/policy change with no runtime code modifications. The
 tests validate that `Cargo.toml` conforms to the documented policy (rev pinning,
-correct crate name, workspace inheritance). All 5961 tests pass, including the
-8 new policy tests.
+correct crate name, workspace inheritance). All 5961 tests pass, including the 8
+new policy tests.
 
 ## Test Plan
 

--- a/docs/pr-summary-2342.md
+++ b/docs/pr-summary-2342.md
@@ -1,0 +1,38 @@
+## Summary
+
+Define the NEAT-AI-core release and pinning policy as an Architecture Decision
+Record. Confirms crate names, workspace layout, semver tagging conventions, and
+approval requirements for bumping the core dependency. Closes #2342.
+
+## Changes
+
+- **docs/CORE_DEPENDENCY_POLICY.md** — full ADR covering:
+  - Pinning model: git dependency with `rev` (full 40-char SHA), not branch
+  - Crate name: `neat-core` (hyphenated), not `neat_ai_core` or `neat-ai-core`
+  - Workspace layout: single `rev` in root `Cargo.toml`, members inherit via
+    `{ workspace = true }`
+  - Local dev: `.cargo/config.toml` path override (git-ignored)
+  - Semver/tag policy: `v<MAJOR>.<MINOR>.<PATCH>` on NEAT-AI-core
+  - Approval tiers: patch = CI green, minor = one review, major = owner
+  - Future crates.io path documented
+- **AGENTS.md** — added summary section and documentation layout entry
+- **test/scripts/CoreDependencyPolicy.ts** — 8 policy-enforcement tests
+
+## Evidence
+
+This is a documentation/policy change with no runtime code modifications. The
+tests validate that `Cargo.toml` conforms to the documented policy (rev pinning,
+correct crate name, workspace inheritance). All 5961 tests pass, including the
+8 new policy tests.
+
+## Test Plan
+
+- `test/scripts/CoreDependencyPolicy.ts` — 8 tests:
+  - `workspace Cargo.toml pins neat-core via git with a rev`
+  - `workspace Cargo.toml rev is a valid 40-char hex SHA`
+  - `wasm_activation uses workspace dependency for neat-core`
+  - `workspace does not use branch pinning for neat-core`
+  - `core dependency policy document exists`
+  - `policy document covers required sections`
+  - `AGENTS.md references the core dependency policy`
+  - `workspace crate name matches policy (neat-core not neat_ai_core)`

--- a/test/scripts/CoreDependencyPolicy.ts
+++ b/test/scripts/CoreDependencyPolicy.ts
@@ -1,0 +1,131 @@
+import { assert, assertEquals } from "@std/assert";
+
+/**
+ * Tests that the workspace Cargo.toml conforms to the NEAT-AI-core
+ * dependency pinning policy defined in docs/CORE_DEPENDENCY_POLICY.md.
+ *
+ * Issue #2342 — verifies crate name, rev-pinning, and semver tag format.
+ */
+
+const WORKSPACE_CARGO = "Cargo.toml";
+const MEMBER_CARGO = "wasm_activation/Cargo.toml";
+const POLICY_DOC = "docs/CORE_DEPENDENCY_POLICY.md";
+
+Deno.test("workspace Cargo.toml pins neat-core via git with a rev", async () => {
+  const content = await Deno.readTextFile(WORKSPACE_CARGO);
+
+  // Must use `neat-core` as the dependency name.
+  assert(
+    content.includes("neat-core"),
+    "workspace Cargo.toml must declare a neat-core dependency",
+  );
+
+  // Must pin to a specific commit via `rev = "..."`.
+  const revPattern = /neat-core\s*=\s*\{[^}]*rev\s*=/;
+  assert(
+    revPattern.test(content),
+    'neat-core dependency must be pinned with rev = "<sha>"',
+  );
+
+  // Must point to the stSoftwareAU/NEAT-AI-core repository.
+  assert(
+    content.includes("stSoftwareAU/NEAT-AI-core"),
+    "neat-core git URL must reference stSoftwareAU/NEAT-AI-core",
+  );
+});
+
+Deno.test("workspace Cargo.toml rev is a valid 40-char hex SHA", async () => {
+  const content = await Deno.readTextFile(WORKSPACE_CARGO);
+  const match = content.match(/rev\s*=\s*"([^"]+)"/);
+  assert(match, "could not extract rev value from Cargo.toml");
+
+  const rev = match![1];
+  assert(
+    /^[0-9a-f]{40}$/.test(rev),
+    `rev must be a full 40-character hex SHA, got: "${rev}"`,
+  );
+});
+
+Deno.test("wasm_activation uses workspace dependency for neat-core", async () => {
+  const content = await Deno.readTextFile(MEMBER_CARGO);
+
+  // The member crate must inherit neat-core from the workspace,
+  // not declare its own git/path dependency.
+  assert(
+    content.includes("neat-core"),
+    "wasm_activation/Cargo.toml must depend on neat-core",
+  );
+
+  const workspacePattern = /neat-core\s*=\s*\{\s*workspace\s*=\s*true\s*\}/;
+  assert(
+    workspacePattern.test(content),
+    "wasm_activation must use `neat-core = { workspace = true }` (inherited)",
+  );
+});
+
+Deno.test("workspace does not use branch pinning for neat-core", async () => {
+  const content = await Deno.readTextFile(WORKSPACE_CARGO);
+
+  // Branch pinning tracks a moving target — policy requires rev pinning.
+  const branchPattern = /neat-core\s*=\s*\{[^}]*branch\s*=/;
+  assert(
+    !branchPattern.test(content),
+    "neat-core must not use branch pinning; use rev pinning instead",
+  );
+});
+
+Deno.test("core dependency policy document exists", async () => {
+  const info = await Deno.stat(POLICY_DOC);
+  assert(info.isFile, `${POLICY_DOC} must exist`);
+});
+
+Deno.test("policy document covers required sections", async () => {
+  const content = await Deno.readTextFile(POLICY_DOC);
+  const lower = content.toLowerCase();
+
+  const requiredTopics = [
+    "semver",
+    "crate name",
+    "rev",
+    "local dev",
+    "approval",
+  ];
+
+  for (const topic of requiredTopics) {
+    assert(
+      lower.includes(topic),
+      `policy document must cover "${topic}"`,
+    );
+  }
+});
+
+Deno.test("AGENTS.md references the core dependency policy", async () => {
+  const content = await Deno.readTextFile("AGENTS.md");
+  assert(
+    content.includes("CORE_DEPENDENCY_POLICY"),
+    "AGENTS.md must reference docs/CORE_DEPENDENCY_POLICY.md",
+  );
+});
+
+Deno.test("workspace crate name matches policy (neat-core not neat_ai_core)", async () => {
+  const content = await Deno.readTextFile(WORKSPACE_CARGO);
+
+  // The Cargo dependency name is `neat-core` (hyphenated).
+  // The crate on NEAT-AI-core publishes as `neat-core`.
+  // Verify we do not accidentally use the old root crate name.
+  const lines = content.split("\n");
+  const depLine = lines.find((l) => l.includes("neat-core"));
+  assert(depLine, "must have a neat-core dependency line");
+
+  // Must NOT reference an old name like `neat_ai_core` or `neat-ai-core`.
+  assertEquals(
+    content.includes("neat_ai_core"),
+    false,
+    "must use neat-core, not neat_ai_core",
+  );
+  assertEquals(
+    content.includes("neat-ai-core"),
+    false,
+    "must use neat-core, not neat-ai-core (that is the repo name, not the crate)",
+  );
+});


### PR DESCRIPTION
## Summary

Define the NEAT-AI-core release and pinning policy as an Architecture Decision
Record. Confirms crate names, workspace layout, semver tagging conventions, and
approval requirements for bumping the core dependency. Closes #2342.

## Changes

- **docs/CORE_DEPENDENCY_POLICY.md** — full ADR covering:
  - Pinning model: git dependency with `rev` (full 40-char SHA), not branch
  - Crate name: `neat-core` (hyphenated), not `neat_ai_core` or `neat-ai-core`
  - Workspace layout: single `rev` in root `Cargo.toml`, members inherit via
    `{ workspace = true }`
  - Local dev: `.cargo/config.toml` path override (git-ignored)
  - Semver/tag policy: `v<MAJOR>.<MINOR>.<PATCH>` on NEAT-AI-core
  - Approval tiers: patch = CI green, minor = one review, major = owner
  - Future crates.io path documented
- **AGENTS.md** — added summary section and documentation layout entry
- **test/scripts/CoreDependencyPolicy.ts** — 8 policy-enforcement tests

## Evidence

This is a documentation/policy change with no runtime code modifications. The
tests validate that `Cargo.toml` conforms to the documented policy (rev pinning,
correct crate name, workspace inheritance). All 5961 tests pass, including the
8 new policy tests.

## Test Plan

- `test/scripts/CoreDependencyPolicy.ts` — 8 tests:
  - `workspace Cargo.toml pins neat-core via git with a rev`
  - `workspace Cargo.toml rev is a valid 40-char hex SHA`
  - `wasm_activation uses workspace dependency for neat-core`
  - `workspace does not use branch pinning for neat-core`
  - `core dependency policy document exists`
  - `policy document covers required sections`
  - `AGENTS.md references the core dependency policy`
  - `workspace crate name matches policy (neat-core not neat_ai_core)`



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2342 -->