### PR TITLE
Document scorer alignment policy for NEAT-AI-core (#2348)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,10 @@ are:
 6. **Parity gate:** before **removing** any in-tree duplicate native Rust (or
    after bumping the pinned `rev`), run `./scripts/parity-gate.sh` and include
    the output in the PR. See [docs/PARITY_GATE.md](docs/PARITY_GATE.md).
+7. **Scorer alignment:** downstream consumers such as
+   [NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer) must pin the
+   **same `neat-core` rev** as this workspace. When bumping the rev here, verify
+   and update the scorer in the same coordinated change.
 
 ## 🔄 Feed-forward vs Recurrent Connections
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.12.19",
+  "version": "2.12.20",
   "publish": {
     "include": [
       "README.md",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.12.20",
+  "version": "2.12.21",
   "publish": {
     "include": [
       "README.md",

--- a/docs/CORE_DEPENDENCY_POLICY.md
+++ b/docs/CORE_DEPENDENCY_POLICY.md
@@ -115,6 +115,37 @@ Every tagged release must have a corresponding commit on the `Develop` branch.
 The `Develop` branch on NEAT-AI-core is protected; all changes reach it via pull
 request.
 
+## Downstream Consumer Alignment (Scorer)
+
+Issue #2348 — any downstream consumer of `neat-core` that shares types or
+behaviour with NEAT-AI **must** pin the **same `rev`** as the NEAT-AI workspace
+root `Cargo.toml`. This prevents version skew where two repositories compile
+against different snapshots of the shared crate.
+
+### NEAT-AI-scorer
+
+[NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer) (or any future
+equivalent scorer tooling) is the primary downstream consumer. Its workspace
+`Cargo.toml` must:
+
+1. Use `neat-core` as the dependency name (not `neat_ai_core` or
+   `neat-ai-core`).
+2. Pin via `git` + `rev` to the **same 40-character SHA** used in NEAT-AI.
+3. Use `{ workspace = true }` for all workspace members that depend on
+   `neat-core`.
+
+### Verification checklist
+
+When bumping `neat-core` in NEAT-AI, also:
+
+1. **Check** the scorer workspace `Cargo.toml` — confirm the `rev` matches.
+2. **Update** the scorer `rev` in the same coordinated change if it has drifted.
+3. **Run** `cargo test` in the scorer workspace to verify parity.
+
+Bench scripts (e.g. `BENCH_RUST_SCORER`) and any tooling that references the
+crate layout must be updated to reflect the current workspace structure when new
+members are added or the scorer crate is restructured.
+
 ## Future: crates.io Publication
 
 If `neat-core` is published to [crates.io](https://crates.io/) in the future:

--- a/docs/EXTERNAL_NEAT_AI_CORE.md
+++ b/docs/EXTERNAL_NEAT_AI_CORE.md
@@ -11,7 +11,7 @@ NEAT-AI (this repo)
 ├── Cargo.toml          ← workspace root; pins neat-core rev
 ├── wasm_activation/    ← in-tree WASM crate (stays here)
 │   └── Cargo.toml      ← depends on neat-core via workspace
-└── (future members)    ← e.g. rust_scorer; share the same core pin
+└── (future members)    ← e.g. rust_scorer from NEAT-AI-scorer; share the same core pin
 ```
 
 `neat-core` is the shared computation library extracted from `wasm_activation`.
@@ -61,6 +61,33 @@ inherits the `GITHUB_TOKEN` credential from `actions/checkout`).
 
 See `scripts/rust-ci-git-auth.sh` (when available) for the helper that
 configures this automatically.
+
+## NEAT-AI-scorer Alignment
+
+Issue #2348 — [NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer)
+(or equivalent scorer tooling) must pin the **same `neat-core` rev** as this
+repository to avoid version skew. When the two repositories compile against
+different snapshots of `neat-core`, shared types and scoring behaviour can
+silently diverge.
+
+### How to verify alignment
+
+After bumping `neat-core` here, confirm the scorer is aligned:
+
+```bash
+# Extract the rev from NEAT-AI:
+grep 'rev =' Cargo.toml
+
+# Compare against the scorer workspace:
+grep 'rev =' ../NEAT-AI-scorer/Cargo.toml
+```
+
+If the revisions differ, update the scorer `Cargo.toml` to match, run
+`cargo update -p neat-core` and `cargo test` in the scorer workspace, and commit
+the change as part of the same coordinated bump.
+
+See [docs/CORE_DEPENDENCY_POLICY.md](CORE_DEPENDENCY_POLICY.md) for the full
+pinning policy and downstream consumer alignment requirements.
 
 ## Cache Key Invalidation
 

--- a/docs/pr-summary-2348.md
+++ b/docs/pr-summary-2348.md
@@ -1,0 +1,39 @@
+## Summary
+
+Document the scorer alignment policy ensuring NEAT-AI-scorer (and equivalent
+downstream consumers) pin the same `neat-core` rev as NEAT-AI, preventing
+version skew. Closes #2348.
+
+### Changes
+
+- **`docs/CORE_DEPENDENCY_POLICY.md`** — added "Downstream Consumer Alignment
+  (Scorer)" section with NEAT-AI-scorer requirements, verification checklist,
+  and bench script guidance.
+- **`docs/EXTERNAL_NEAT_AI_CORE.md`** — added "NEAT-AI-scorer Alignment"
+  section with concrete verification commands; updated architecture diagram to
+  reference NEAT-AI-scorer by name.
+- **`AGENTS.md`** — added rule 7 (scorer alignment) to the NEAT-AI-core
+  dependency policy section.
+
+### Confirmed
+
+- No `BENCH_RUST_SCORER` scripts exist yet — the policy now documents the
+  expectation that bench scripts referencing crate layout are updated when the
+  scorer crate is added or restructured.
+- The NEAT-AI-scorer repository does not yet exist publicly; the policy is
+  forward-looking and ready to enforce alignment once it does.
+
+## Evidence
+
+This is a documentation and policy change with no runtime code. Verified via:
+- All 5990 tests pass (0 failed) including new policy tests
+- Quality gate (`./quality.sh --skip-discovery --skip-wasm`) passes cleanly
+
+## Test Plan
+
+- Added `test/scripts/ScorerAlignmentPolicy.ts` (4 tests):
+  - `core dependency policy documents scorer alignment requirement`
+  - `external core doc covers scorer workspace alignment`
+  - `policy documents the same-rev requirement for scorer`
+  - `external core doc explains how to verify scorer alignment`
+- All 8 existing `test/scripts/CoreDependencyPolicy.ts` tests continue to pass

--- a/docs/pr-summary-2348.md
+++ b/docs/pr-summary-2348.md
@@ -9,9 +9,9 @@ version skew. Closes #2348.
 - **`docs/CORE_DEPENDENCY_POLICY.md`** — added "Downstream Consumer Alignment
   (Scorer)" section with NEAT-AI-scorer requirements, verification checklist,
   and bench script guidance.
-- **`docs/EXTERNAL_NEAT_AI_CORE.md`** — added "NEAT-AI-scorer Alignment"
-  section with concrete verification commands; updated architecture diagram to
-  reference NEAT-AI-scorer by name.
+- **`docs/EXTERNAL_NEAT_AI_CORE.md`** — added "NEAT-AI-scorer Alignment" section
+  with concrete verification commands; updated architecture diagram to reference
+  NEAT-AI-scorer by name.
 - **`AGENTS.md`** — added rule 7 (scorer alignment) to the NEAT-AI-core
   dependency policy section.
 
@@ -26,6 +26,7 @@ version skew. Closes #2348.
 ## Evidence
 
 This is a documentation and policy change with no runtime code. Verified via:
+
 - All 5990 tests pass (0 failed) including new policy tests
 - Quality gate (`./quality.sh --skip-discovery --skip-wasm`) passes cleanly
 

--- a/test/scripts/ScorerAlignmentPolicy.ts
+++ b/test/scripts/ScorerAlignmentPolicy.ts
@@ -1,0 +1,78 @@
+import { assert } from "@std/assert";
+
+/**
+ * Tests that the NEAT-AI-core dependency policy and external dependency
+ * documentation explicitly address scorer alignment — ensuring that
+ * NEAT-AI-scorer (or equivalent downstream consumers) must pin the same
+ * neat-core rev as NEAT-AI.
+ *
+ * Issue #2348 — avoid version skew between NEAT-AI and NEAT-AI-scorer.
+ */
+
+const POLICY_DOC = "docs/CORE_DEPENDENCY_POLICY.md";
+const EXTERNAL_DOC = "docs/EXTERNAL_NEAT_AI_CORE.md";
+
+Deno.test(
+  "core dependency policy documents scorer alignment requirement",
+  async () => {
+    const content = await Deno.readTextFile(POLICY_DOC);
+    const lower = content.toLowerCase();
+
+    assert(
+      lower.includes("scorer") || lower.includes("neat-ai-scorer"),
+      "CORE_DEPENDENCY_POLICY.md must mention the scorer alignment requirement",
+    );
+
+    assert(
+      lower.includes("downstream") || lower.includes("consumer"),
+      "CORE_DEPENDENCY_POLICY.md must address downstream consumer alignment",
+    );
+  },
+);
+
+Deno.test(
+  "external core doc covers scorer workspace alignment",
+  async () => {
+    const content = await Deno.readTextFile(EXTERNAL_DOC);
+    const lower = content.toLowerCase();
+
+    assert(
+      lower.includes("scorer"),
+      "EXTERNAL_NEAT_AI_CORE.md must reference the scorer",
+    );
+
+    assert(
+      lower.includes("neat-ai-scorer"),
+      "EXTERNAL_NEAT_AI_CORE.md must reference NEAT-AI-scorer by name",
+    );
+  },
+);
+
+Deno.test(
+  "policy documents the same-rev requirement for scorer",
+  async () => {
+    const content = await Deno.readTextFile(POLICY_DOC);
+    const lower = content.toLowerCase();
+
+    // The policy must explicitly state that downstream consumers pin the same rev.
+    assert(
+      lower.includes("same") && lower.includes("rev"),
+      "CORE_DEPENDENCY_POLICY.md must state the same-rev pinning requirement",
+    );
+  },
+);
+
+Deno.test(
+  "external core doc explains how to verify scorer alignment",
+  async () => {
+    const content = await Deno.readTextFile(EXTERNAL_DOC);
+    const lower = content.toLowerCase();
+
+    // Must explain the verification step for downstream alignment.
+    assert(
+      lower.includes("verify") || lower.includes("confirm") ||
+        lower.includes("check"),
+      "EXTERNAL_NEAT_AI_CORE.md must explain how to verify scorer alignment",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Document the scorer alignment policy ensuring NEAT-AI-scorer (and equivalent
downstream consumers) pin the same `neat-core` rev as NEAT-AI, preventing
version skew. Closes #2348.

### Changes

- **`docs/CORE_DEPENDENCY_POLICY.md`** — added "Downstream Consumer Alignment
  (Scorer)" section with NEAT-AI-scorer requirements, verification checklist,
  and bench script guidance.
- **`docs/EXTERNAL_NEAT_AI_CORE.md`** — added "NEAT-AI-scorer Alignment"
  section with concrete verification commands; updated architecture diagram to
  reference NEAT-AI-scorer by name.
- **`AGENTS.md`** — added rule 7 (scorer alignment) to the NEAT-AI-core
  dependency policy section.

### Confirmed

- No `BENCH_RUST_SCORER` scripts exist yet — the policy now documents the
  expectation that bench scripts referencing crate layout are updated when the
  scorer crate is added or restructured.
- The NEAT-AI-scorer repository does not yet exist publicly; the policy is
  forward-looking and ready to enforce alignment once it does.

## Evidence

This is a documentation and policy change with no runtime code. Verified via:
- All 5990 tests pass (0 failed) including new policy tests
- Quality gate (`./quality.sh --skip-discovery --skip-wasm`) passes cleanly

## Test Plan

- Added `test/scripts/ScorerAlignmentPolicy.ts` (4 tests):
  - `core dependency policy documents scorer alignment requirement`
  - `external core doc covers scorer workspace alignment`
  - `policy documents the same-rev requirement for scorer`
  - `external core doc explains how to verify scorer alignment`
- All 8 existing `test/scripts/CoreDependencyPolicy.ts` tests continue to pass



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2348 -->