### PR TITLE
Add Deno Dependency Updates workflow (#2362)

### DIFF
--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -1,0 +1,47 @@
+# Deno Dependency Updates (Issue #2362)
+#
+# Runs `deno outdated --update --latest` on a weekly schedule (and on demand)
+# and opens a pull request with any version bumps via
+# peter-evans/create-pull-request. Keeps the dedicated automation that the
+# detection patterns expect under the `deno-outdated` name, complementing the
+# inline `deno outdated` step in `quality.yml` which only runs on PR.
+name: Deno Dependency Updates
+
+on:
+  schedule:
+    # 06:00 UTC every Monday — outside Australian business hours so any
+    # resulting PR is ready for review at the start of the week.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  outdated:
+    name: Run deno outdated and raise PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Update Deno dependencies
+        run: deno outdated --update --latest
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update Deno dependencies"
+          title: "chore: update Deno dependencies"
+          branch: chore/deno-outdated
+          delete-branch: true
+          body: |
+            Automated Deno dependency update via `deno outdated --update --latest`.
+
+            Raised by `.github/workflows/deno-outdated.yml` (Issue #2362).

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "2.12.22",
+  "version": "2.12.23",
   "publish": {
     "include": [
       "README.md",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -74,6 +74,7 @@
     "deprioritised",
     "deprioritises",
     "deprioritising",
+    "denoland",
     "deque",
     "deriv",
     "deserialisable",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -65,6 +65,7 @@
     "delisting",
     "deltaed",
     "denom",
+    "denoland",
     "densification",
     "densified",
     "densifies",

--- a/docs/pr-summary-2362.md
+++ b/docs/pr-summary-2362.md
@@ -1,0 +1,37 @@
+## Summary
+
+Adds the dedicated **Deno Dependency Updates** workflow at
+`.github/workflows/deno-outdated.yml` so the workflow-sync detector finds the
+expected `deno-outdated` automation in addition to the existing inline
+`deno outdated` step in `quality.yml`. The new workflow runs
+`deno outdated --update --latest` on a weekly cron (06:00 UTC every Monday) and
+on manual dispatch, then opens a PR via `peter-evans/create-pull-request@v7` on
+the `chore/deno-outdated` branch with `contents: write` and
+`pull-requests: write` permissions, matching the template in the issue.
+
+Closes #2362.
+
+## Evidence
+
+This is a CI/automation change with no UI surface, so no screenshot is
+attached. Evidence of correctness:
+
+- `deno test --allow-read test/scripts/DenoOutdatedWorkflow.ts` passes all six
+  cases against the new workflow file (file presence, schedule + dispatch
+  triggers, write permissions, checkout + setup-deno steps, the
+  `deno outdated --update --latest` invocation, and the
+  `peter-evans/create-pull-request` step on the `chore/deno-outdated` branch).
+- `./quality.sh --lint-only` passes (deno fmt, deno lint, bash syntax all
+  green).
+- `./quality.sh --check-only` passes (deno check across the workspace).
+
+## Test Plan
+
+- Added `test/scripts/DenoOutdatedWorkflow.ts` with six cases covering:
+  - workflow file exists at `.github/workflows/deno-outdated.yml`
+  - triggers on `schedule` (cron) and `workflow_dispatch`
+  - grants `contents: write` and `pull-requests: write`
+  - uses `actions/checkout` and `denoland/setup-deno`
+  - runs `deno outdated --update --latest`
+  - opens a PR via `peter-evans/create-pull-request` on the
+    `chore/deno-outdated` branch

--- a/docs/pr-summary-2362.md
+++ b/docs/pr-summary-2362.md
@@ -13,8 +13,8 @@ Closes #2362.
 
 ## Evidence
 
-This is a CI/automation change with no UI surface, so no screenshot is
-attached. Evidence of correctness:
+This is a CI/automation change with no UI surface, so no screenshot is attached.
+Evidence of correctness:
 
 - `deno test --allow-read test/scripts/DenoOutdatedWorkflow.ts` passes all six
   cases against the new workflow file (file presence, schedule + dispatch

--- a/test/scripts/DenoOutdatedWorkflow.ts
+++ b/test/scripts/DenoOutdatedWorkflow.ts
@@ -1,0 +1,79 @@
+import { assert } from "@std/assert";
+
+/**
+ * Validates the Deno Dependency Updates workflow
+ * (`.github/workflows/deno-outdated.yml`) added for Issue #2362.
+ *
+ * The workflow runs `deno outdated --update --latest` on a weekly cron and
+ * raises a pull request via `peter-evans/create-pull-request`. These tests
+ * verify the workflow exists and is configured with the required triggers,
+ * permissions, and steps so the dependency-update gate cannot silently
+ * regress.
+ */
+
+const WORKFLOW_PATH = ".github/workflows/deno-outdated.yml";
+
+async function readWorkflow(): Promise<string> {
+  return await Deno.readTextFile(WORKFLOW_PATH);
+}
+
+Deno.test("deno-outdated workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH).catch(() => null);
+  assert(stat?.isFile, `${WORKFLOW_PATH} must exist`);
+});
+
+Deno.test("deno-outdated workflow runs on schedule and supports manual dispatch", async () => {
+  const body = await readWorkflow();
+  assert(
+    body.includes("schedule:") && /-\s*cron:\s*"/.test(body),
+    "workflow must trigger on a schedule",
+  );
+  assert(
+    body.includes("workflow_dispatch"),
+    "workflow must support manual dispatch",
+  );
+});
+
+Deno.test("deno-outdated workflow has write permissions for contents and pull-requests", async () => {
+  const body = await readWorkflow();
+  assert(
+    /contents:\s*write/.test(body),
+    "workflow must grant contents: write",
+  );
+  assert(
+    /pull-requests:\s*write/.test(body),
+    "workflow must grant pull-requests: write",
+  );
+});
+
+Deno.test("deno-outdated workflow checks out repo and sets up Deno", async () => {
+  const body = await readWorkflow();
+  assert(
+    body.includes("actions/checkout@"),
+    "workflow must use actions/checkout",
+  );
+  assert(
+    body.includes("denoland/setup-deno@"),
+    "workflow must set up Deno via denoland/setup-deno",
+  );
+});
+
+Deno.test("deno-outdated workflow runs `deno outdated --update --latest`", async () => {
+  const body = await readWorkflow();
+  assert(
+    body.includes("deno outdated --update --latest"),
+    "workflow must run `deno outdated --update --latest`",
+  );
+});
+
+Deno.test("deno-outdated workflow opens a pull request via peter-evans/create-pull-request", async () => {
+  const body = await readWorkflow();
+  assert(
+    body.includes("peter-evans/create-pull-request@"),
+    "workflow must use peter-evans/create-pull-request to raise the PR",
+  );
+  assert(
+    body.includes("chore/deno-outdated"),
+    "workflow must target the chore/deno-outdated branch",
+  );
+});


### PR DESCRIPTION
## Summary

Adds the dedicated **Deno Dependency Updates** workflow at
`.github/workflows/deno-outdated.yml` so the workflow-sync detector finds the
expected `deno-outdated` automation in addition to the existing inline
`deno outdated` step in `quality.yml`. The new workflow runs
`deno outdated --update --latest` on a weekly cron (06:00 UTC every Monday) and
on manual dispatch, then opens a PR via `peter-evans/create-pull-request@v7` on
the `chore/deno-outdated` branch with `contents: write` and
`pull-requests: write` permissions, matching the template in the issue.

Closes #2362.

## Evidence

This is a CI/automation change with no UI surface, so no screenshot is
attached. Evidence of correctness:

- `deno test --allow-read test/scripts/DenoOutdatedWorkflow.ts` passes all six
  cases against the new workflow file (file presence, schedule + dispatch
  triggers, write permissions, checkout + setup-deno steps, the
  `deno outdated --update --latest` invocation, and the
  `peter-evans/create-pull-request` step on the `chore/deno-outdated` branch).
- `./quality.sh --lint-only` passes (deno fmt, deno lint, bash syntax all
  green).
- `./quality.sh --check-only` passes (deno check across the workspace).

## Test Plan

- Added `test/scripts/DenoOutdatedWorkflow.ts` with six cases covering:
  - workflow file exists at `.github/workflows/deno-outdated.yml`
  - triggers on `schedule` (cron) and `workflow_dispatch`
  - grants `contents: write` and `pull-requests: write`
  - uses `actions/checkout` and `denoland/setup-deno`
  - runs `deno outdated --update --latest`
  - opens a PR via `peter-evans/create-pull-request` on the
    `chore/deno-outdated` branch



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2362 -->