### PR TITLE
Chunk discovery Rust analysis with per-chunk stall guard (#2380)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop"

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -329,6 +329,7 @@
     "intree",
     "INTREE",
     "pathlib",
+    "preempt",
     "rglob",
     "splitlines",
     "stdlib"

--- a/docs/pr-summary-2380.md
+++ b/docs/pr-summary-2380.md
@@ -8,11 +8,10 @@ Closes #2380
 `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts`
 submitted the entire focus list (up to `discoveryMaxNeurons`, default 6) to
 `DiscoverStructure.ensureRustCombinedAnalysis(...)` as a single FFI call. That
-call is synchronous — once Rust starts the combined analysis TS cannot
-preempt it. When one of the neurons stalls (CPU fallback, pathological
-topology, etc.), the whole 10-minute analysis budget is consumed by one
-uninterruptible Rust call, producing exactly the pattern in
-`GRQ-22-sloth.log`:
+call is synchronous — once Rust starts the combined analysis TS cannot preempt
+it. When one of the neurons stalls (CPU fallback, pathological topology, etc.),
+the whole 10-minute analysis budget is consumed by one uninterruptible Rust
+call, producing exactly the pattern in `GRQ-22-sloth.log`:
 
 ```
 Rust combined analysis: 9m 56s 236ms
@@ -31,23 +30,23 @@ between chunks the loop checks:
 
 1. **Per-chunk budget** — if a single chunk exceeded
    `discoveryAnalysisPerChunkMaxMs` (default 120 000 ms), set
-   `analysisStalled=true` and break out of the retry loop. This is the
-   adaptive early-exit required by the acceptance criteria.
+   `analysisStalled=true` and break out of the retry loop. This is the adaptive
+   early-exit required by the acceptance criteria.
 2. **Deadline** — the existing `getTimeoutTS()` check now runs after every
    chunk, not just after the whole focus list.
 
-With defaults (`chunkSize=2`, `perChunkMaxMs=120 000`), 6 focus neurons
-become three FFI calls; a single 2-minute stall aborts the remainder of the
-cycle instead of burning the full 10 minutes on one call.
+With defaults (`chunkSize=2`, `perChunkMaxMs=120 000`), 6 focus neurons become
+three FFI calls; a single 2-minute stall aborts the remainder of the cycle
+instead of burning the full 10 minutes on one call.
 
 ## Changes
 
 - **New config fields** (defaults preserve "at most a 6-minute budget burn
   before bailing out"):
-  - `discoveryAnalysisChunkSize` — default `2`; `0` submits the whole focus
-    list in one call (the pre-#2380 behaviour).
-  - `discoveryAnalysisPerChunkMaxMs` — default `120000`; `0` disables the
-    stall guard.
+  - `discoveryAnalysisChunkSize` — default `2`; `0` submits the whole focus list
+    in one call (the pre-#2380 behaviour).
+  - `discoveryAnalysisPerChunkMaxMs` — default `120000`; `0` disables the stall
+    guard.
 - **`DataRecorderAnalysis.ts`**
   - New exported helper `chunkFocusList(focusList, chunkSize)` — small, pure,
     easy to unit-test.
@@ -70,19 +69,23 @@ New `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts`:
 - `runAnalysisLoop submits the focus list in chunks of analysisChunkSize` —
   every captured FFI call carries at most `analysisChunkSize` neurons.
 - `runAnalysisLoop submits whole focus list in one call when chunking
-  disabled` — backwards-compat path still works when chunking is off.
+  disabled`
+  — backwards-compat path still works when chunking is off.
 - `runAnalysisLoop aborts retries when a single chunk exceeds perChunkMaxMs
-  (stall guard)` — uses an injected clock that advances 5 000 ms per call,
-  asserts the loop bails after at most 2 FFI calls and sets
-  `analysisStalled=true`. **Fails against the pre-#2380 code.**
+  (stall guard)`
+  — uses an injected clock that advances 5 000 ms per call, asserts the loop
+  bails after at most 2 FFI calls and sets `analysisStalled=true`. **Fails
+  against the pre-#2380 code.**
 - `runAnalysisLoop does not mark analysisStalled when all chunks finish
-  within budget` — sanity check: no false positives with a generous budget.
+  within budget`
+  — sanity check: no false positives with a generous budget.
 
 ## Test plan
 
-- [x] `deno test --allow-all test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` → 7 passed, 0 failed.
+- [x] `deno test --allow-all test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts`
+      → 7 passed, 0 failed.
 - [x] `./quality.sh --skip-wasm` (full test suite, WASM skipped because the
-      local `build.sh` sync pulled a truncated WASM pkg on this workstation)
-      → 6002 passed, 0 failed.
+      local `build.sh` sync pulled a truncated WASM pkg on this workstation) →
+      6002 passed, 0 failed.
 - [ ] CI re-runs the full `./quality.sh` (including WASM sync) on a clean
       runner.

--- a/docs/pr-summary-2380.md
+++ b/docs/pr-summary-2380.md
@@ -1,0 +1,88 @@
+# Discovery Rust combined analysis — chunking + adaptive stall guard
+
+Closes #2380
+
+## Root cause
+
+`runAnalysisLoop` in
+`src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts`
+submitted the entire focus list (up to `discoveryMaxNeurons`, default 6) to
+`DiscoverStructure.ensureRustCombinedAnalysis(...)` as a single FFI call. That
+call is synchronous — once Rust starts the combined analysis TS cannot
+preempt it. When one of the neurons stalls (CPU fallback, pathological
+topology, etc.), the whole 10-minute analysis budget is consumed by one
+uninterruptible Rust call, producing exactly the pattern in
+`GRQ-22-sloth.log`:
+
+```
+Rust combined analysis: 9m 56s 236ms
+Neurons analyzed: 6
+Neurons/sec: 0
+```
+
+The TS layer had no checkpoint between the call starting and the 10-minute
+deadline firing.
+
+## Fix
+
+Break the single Rust FFI call into **chunks**. Each chunk runs the full
+pipeline (combined analysis → candidate collection → squash analysis), and
+between chunks the loop checks:
+
+1. **Per-chunk budget** — if a single chunk exceeded
+   `discoveryAnalysisPerChunkMaxMs` (default 120 000 ms), set
+   `analysisStalled=true` and break out of the retry loop. This is the
+   adaptive early-exit required by the acceptance criteria.
+2. **Deadline** — the existing `getTimeoutTS()` check now runs after every
+   chunk, not just after the whole focus list.
+
+With defaults (`chunkSize=2`, `perChunkMaxMs=120 000`), 6 focus neurons
+become three FFI calls; a single 2-minute stall aborts the remainder of the
+cycle instead of burning the full 10 minutes on one call.
+
+## Changes
+
+- **New config fields** (defaults preserve "at most a 6-minute budget burn
+  before bailing out"):
+  - `discoveryAnalysisChunkSize` — default `2`; `0` submits the whole focus
+    list in one call (the pre-#2380 behaviour).
+  - `discoveryAnalysisPerChunkMaxMs` — default `120000`; `0` disables the
+    stall guard.
+- **`DataRecorderAnalysis.ts`**
+  - New exported helper `chunkFocusList(focusList, chunkSize)` — small, pure,
+    easy to unit-test.
+  - Inner analysis body restructured into a per-chunk `for` loop.
+  - After each chunk: per-chunk elapsed time + GPU usage logged
+    (`[synapse=gpu neuron=cpu]`), deadline and stall-guard both checked.
+  - Optional `now` injection on `AnalysisLoopContext` so tests can drive
+    deterministic elapsed-time scenarios.
+- **`DiscoveryPerformanceStats`** — added `analysisStalled` boolean so the
+  caller can observe when the stall guard fired.
+- **`DataRecorder.ts`** — passes the two new config values through to
+  `runAnalysisLoop`.
+
+## Tests
+
+New `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts`:
+
+- `chunkFocusList` — splits fixed-size sublists, treats `<=0` as disabled,
+  returns `[]` for empty input.
+- `runAnalysisLoop submits the focus list in chunks of analysisChunkSize` —
+  every captured FFI call carries at most `analysisChunkSize` neurons.
+- `runAnalysisLoop submits whole focus list in one call when chunking
+  disabled` — backwards-compat path still works when chunking is off.
+- `runAnalysisLoop aborts retries when a single chunk exceeds perChunkMaxMs
+  (stall guard)` — uses an injected clock that advances 5 000 ms per call,
+  asserts the loop bails after at most 2 FFI calls and sets
+  `analysisStalled=true`. **Fails against the pre-#2380 code.**
+- `runAnalysisLoop does not mark analysisStalled when all chunks finish
+  within budget` — sanity check: no false positives with a generous budget.
+
+## Test plan
+
+- [x] `deno test --allow-all test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` → 7 passed, 0 failed.
+- [x] `./quality.sh --skip-wasm` (full test suite, WASM skipped because the
+      local `build.sh` sync pulled a truncated WASM pkg on this workstation)
+      → 6002 passed, 0 failed.
+- [ ] CI re-runs the full `./quality.sh` (including WASM sync) on a clean
+      runner.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
@@ -351,6 +351,8 @@ class DataRecorder {
           config: this.config,
           discoveryMaxNeurons: this.discoveryMaxNeurons,
           costOfGrowth: this.config.costOfGrowth,
+          analysisChunkSize: this.config.discoveryAnalysisChunkSize,
+          perChunkMaxMs: this.config.discoveryAnalysisPerChunkMaxMs,
           getTimeoutTS: () => this.timeoutTS,
           refreshAnalysisTimeout: (ds) => this.refreshAnalysisTimeout(ds),
         },

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
@@ -29,10 +29,51 @@ export interface AnalysisLoopContext {
   readonly config: NeatConfig;
   readonly discoveryMaxNeurons: number;
   readonly costOfGrowth: number;
+  /**
+   * Maximum number of neurons submitted to one Rust combined-analysis FFI
+   * call. The analysis loop splits the focus list into chunks of at most this
+   * size. Values <= 0 or >= focus list length submit the whole list at once
+   * (Issue #2380).
+   */
+  readonly analysisChunkSize: number;
+  /**
+   * Maximum milliseconds a single Rust combined-analysis chunk may take
+   * before the analysis loop stops submitting further chunks and skips the
+   * remaining retry iterations for this discovery cycle (Issue #2380). Set
+   * to 0 to disable the stall guard.
+   */
+  readonly perChunkMaxMs: number;
   /** Current analysis deadline timestamp in ms. */
   getTimeoutTS(): number;
   /** Refresh the analysis timeout on the DiscoverStructure instance. */
   refreshAnalysisTimeout(discoverStructure: DiscoverStructure): void;
+  /**
+   * Optional clock injection for deterministic tests (Issue #2380). Defaults
+   * to Date.now. Production code should not set this.
+   */
+  readonly now?: () => number;
+}
+
+/**
+ * Split a focus list into chunks of at most `chunkSize` neurons.
+ *
+ * `chunkSize <= 0` returns a single chunk containing the whole list
+ * (chunking disabled). This is exported for tests (Issue #2380).
+ */
+export function chunkFocusList(
+  focusList: readonly number[],
+  chunkSize: number,
+): number[][] {
+  if (focusList.length === 0) return [];
+  if (!Number.isFinite(chunkSize) || chunkSize <= 0) {
+    return [Array.from(focusList)];
+  }
+  const size = Math.max(1, Math.floor(chunkSize));
+  const chunks: number[][] = [];
+  for (let i = 0; i < focusList.length; i += size) {
+    chunks.push(Array.from(focusList.slice(i, i + size)));
+  }
+  return chunks;
 }
 
 function classifyCandidateTag(
@@ -172,10 +213,12 @@ export async function runAnalysisLoop(
   const attemptedNeurons = new Set<number>();
   let retryAttempt = 0;
   const maxRetries = 10; // Reasonable limit to prevent infinite loops
+  const now = ctx.now ?? Date.now;
 
   // Retry loop: try different neurons if no candidates found and time remains
   // Sequential execution is intentional - we check results after each attempt
-  const analysisPhaseStartTime = Date.now();
+  const analysisPhaseStartTime = now();
+  let stalledFlag = false;
   while (retryAttempt <= maxRetries) {
     // Allow callers (especially tests) to explicitly skip the analysis phase by
     // setting discoveryMaxNeurons to 0. This keeps record/flush coverage (FFI)
@@ -190,14 +233,14 @@ export async function runAnalysisLoop(
       }
       break;
     }
-    const focusSelectStart = Date.now();
+    const focusSelectStart = now();
     // deno-lint-ignore no-await-in-loop
     const focusList = await discoverStructure.selectNeuronsWeightedByError(
       ctx.discoveryMaxNeurons,
       ctx.costOfGrowth,
       retryAttempt > 0 ? retryAttempt : undefined,
     );
-    perfStats.focusSelectionTime += Date.now() - focusSelectStart;
+    perfStats.focusSelectionTime += now() - focusSelectStart;
 
     // Filter out neurons we've already tried
     const newFocusList = focusList.filter((uuid) =>
@@ -205,7 +248,7 @@ export async function runAnalysisLoop(
     );
 
     if (shouldLogDiscovery(config)) {
-      const selectTime = Date.now() - focusSelectStart;
+      const selectTime = now() - focusSelectStart;
       const retryMsg = retryAttempt > 0
         ? ` (retry ${retryAttempt}, ${attemptedNeurons.size} already tried)`
         : "";
@@ -234,125 +277,176 @@ export async function runAnalysisLoop(
       break;
     }
 
-    const rustAnalysisStart = Date.now();
-    const combinedResult = discoverStructure.ensureRustCombinedAnalysis(
-      newFocusList,
-      true, // includeSynapse
-      true, // includeNeuron
-    );
-    const rustAnalysisTime = Date.now() - rustAnalysisStart;
-    perfStats.rustCombinedAnalysisTime += rustAnalysisTime;
-    if (combinedResult) {
-      ctx.refreshAnalysisTimeout(discoverStructure);
-    }
-
-    phaseDiagnostics.enterPhase("analysis_parallel");
-    let addHelpfulNeurons: CandidateNeuron[] | undefined;
-    let coordinatedStructuralCandidates:
-      | import("./CoordinatedStructuralCandidate.ts").CoordinatedStructuralCandidate[]
-      | undefined;
-    let addHelpfulSynapse: CandidateSynapse[] | undefined;
-    let removeHarmfulSynapse: CandidateSynapse | undefined;
-    let removeHarmfulNeurons: CandidateHarmfulNeuron[] | undefined;
-    let candidateSquashes: CandidateSquash[] | undefined;
-
-    const parallelStartTime = Date.now();
-    const candidateBundle = discoverStructure.collectRustAnalysisCandidates(
-      newFocusList,
-    );
-    const candidateCollectionTime = Date.now() - parallelStartTime;
-
-    if (candidateBundle) {
-      phaseDiagnostics.enterPhase("analysis_loop");
-      addHelpfulSynapse = candidateBundle.helpfulSynapses;
-      removeHarmfulSynapse = candidateBundle.harmfulSynapse;
-      addHelpfulNeurons = candidateBundle.helpfulNeurons;
-      coordinatedStructuralCandidates =
-        candidateBundle.coordinatedStructuralCandidates;
-      ctx.refreshAnalysisTimeout(discoverStructure);
-
-      if (shouldLogDiscovery(config)) {
-        const helpfulSynapseCount = addHelpfulSynapse?.length ?? 0;
-        const helpfulNeuronCount = addHelpfulNeurons?.length ?? 0;
-        const coordinatedCount = coordinatedStructuralCandidates?.length ?? 0;
-        const harmfulSynapseCount = removeHarmfulSynapse ? 1 : 0;
-        const fallbackSynapses = countFallbackCandidates(addHelpfulSynapse);
-        const fallbackNeurons = countFallbackCandidates(addHelpfulNeurons);
-
-        const synapseMeta = candidateBundle.synapseMetadata;
-        const neuronMeta = candidateBundle.neuronMetadata;
-        const synapseMetaText = synapseMeta
-          ? `, synapse meta: found=${synapseMeta.candidatesFound} returned=${synapseMeta.candidatesReturned}`
-          : "";
-        const neuronMetaText = neuronMeta
-          ? `, neuron meta: found=${neuronMeta.candidatesFound} returned=${neuronMeta.candidatesReturned}`
-          : "";
-
-        getLogger().info(
-          `Discovery ${blue(ID)} candidate collection ${
-            yellow(format(candidateCollectionTime, {
-              ignoreZero: true,
-            }))
-          } helpful synapses: ${helpfulSynapseCount} (fallback ${fallbackSynapses}), helpful neurons: ${helpfulNeuronCount} (fallback ${fallbackNeurons}), coordinated-structural: ${coordinatedCount}, harmful synapse removals: ${harmfulSynapseCount}${synapseMetaText}${neuronMetaText}`,
-        );
-
-        logAllCandidates(
-          ID,
-          addHelpfulSynapse,
-          addHelpfulNeurons,
-          removeHarmfulSynapse,
-          undefined,
-        );
-      }
-
-      const squashStartTime = Date.now();
-      // deno-lint-ignore no-await-in-loop
-      candidateSquashes = await discoverStructure
-        .analyzeSelectedNeuronsSquashes(newFocusList);
-      ctx.refreshAnalysisTimeout(discoverStructure);
-      const squashTime = Date.now() - squashStartTime;
-      perfStats.squashAnalysisTime += squashTime;
-      if (shouldLogDiscovery(config)) {
-        logSquashResults(ID, squashTime, candidateSquashes);
-      }
-    } else {
-      // deno-lint-ignore no-await-in-loop
-      const analysisResults = await runParallelAnalysis(
-        ctx,
-        discoverStructure,
-        perfStats,
-        phaseDiagnostics,
-        newFocusList,
+    // Chunk the focus list so each Rust combined-analysis FFI call is
+    // bounded in scope. This allows the loop to log per-chunk elapsed time,
+    // detect stalls, and bail out before the full analysis budget is burned
+    // on a single slow call (Issue #2380).
+    const chunks = chunkFocusList(newFocusList, ctx.analysisChunkSize);
+    let chunkIdx = 0;
+    let iterationStalled = false;
+    for (const chunk of chunks) {
+      chunkIdx++;
+      const chunkStart = now();
+      const combinedResult = discoverStructure.ensureRustCombinedAnalysis(
+        chunk,
+        true, // includeSynapse
+        true, // includeNeuron
       );
-      phaseDiagnostics.enterPhase("analysis_loop");
-      [
+      const chunkElapsed = now() - chunkStart;
+      perfStats.rustCombinedAnalysisTime += chunkElapsed;
+      if (combinedResult) {
+        ctx.refreshAnalysisTimeout(discoverStructure);
+      }
+
+      if (shouldLogDiscovery(config)) {
+        const gpuInfo = describeGpuUsage(combinedResult);
+        getLogger().info(
+          `Discovery ${
+            blue(ID)
+          } rust combined analysis chunk ${chunkIdx}/${chunks.length} (${chunk.length} neuron${
+            chunk.length === 1 ? "" : "s"
+          }) in ${
+            yellow(format(chunkElapsed, { ignoreZero: true }))
+          }${gpuInfo}`,
+        );
+      }
+
+      phaseDiagnostics.enterPhase("analysis_parallel");
+      let addHelpfulNeurons: CandidateNeuron[] | undefined;
+      let coordinatedStructuralCandidates:
+        | import("./CoordinatedStructuralCandidate.ts").CoordinatedStructuralCandidate[]
+        | undefined;
+      let addHelpfulSynapse: CandidateSynapse[] | undefined;
+      let removeHarmfulSynapse: CandidateSynapse | undefined;
+      let removeHarmfulNeurons: CandidateHarmfulNeuron[] | undefined;
+      let candidateSquashes: CandidateSquash[] | undefined;
+
+      const parallelStartTime = now();
+      const candidateBundle = discoverStructure.collectRustAnalysisCandidates(
+        chunk,
+      );
+      const candidateCollectionTime = now() - parallelStartTime;
+
+      if (candidateBundle) {
+        phaseDiagnostics.enterPhase("analysis_loop");
+        addHelpfulSynapse = candidateBundle.helpfulSynapses;
+        removeHarmfulSynapse = candidateBundle.harmfulSynapse;
+        addHelpfulNeurons = candidateBundle.helpfulNeurons;
+        coordinatedStructuralCandidates =
+          candidateBundle.coordinatedStructuralCandidates;
+        ctx.refreshAnalysisTimeout(discoverStructure);
+
+        if (shouldLogDiscovery(config)) {
+          const helpfulSynapseCount = addHelpfulSynapse?.length ?? 0;
+          const helpfulNeuronCount = addHelpfulNeurons?.length ?? 0;
+          const coordinatedCount = coordinatedStructuralCandidates?.length ?? 0;
+          const harmfulSynapseCount = removeHarmfulSynapse ? 1 : 0;
+          const fallbackSynapses = countFallbackCandidates(addHelpfulSynapse);
+          const fallbackNeurons = countFallbackCandidates(addHelpfulNeurons);
+
+          const synapseMeta = candidateBundle.synapseMetadata;
+          const neuronMeta = candidateBundle.neuronMetadata;
+          const synapseMetaText = synapseMeta
+            ? `, synapse meta: found=${synapseMeta.candidatesFound} returned=${synapseMeta.candidatesReturned}`
+            : "";
+          const neuronMetaText = neuronMeta
+            ? `, neuron meta: found=${neuronMeta.candidatesFound} returned=${neuronMeta.candidatesReturned}`
+            : "";
+
+          getLogger().info(
+            `Discovery ${blue(ID)} candidate collection ${
+              yellow(format(candidateCollectionTime, {
+                ignoreZero: true,
+              }))
+            } helpful synapses: ${helpfulSynapseCount} (fallback ${fallbackSynapses}), helpful neurons: ${helpfulNeuronCount} (fallback ${fallbackNeurons}), coordinated-structural: ${coordinatedCount}, harmful synapse removals: ${harmfulSynapseCount}${synapseMetaText}${neuronMetaText}`,
+          );
+
+          logAllCandidates(
+            ID,
+            addHelpfulSynapse,
+            addHelpfulNeurons,
+            removeHarmfulSynapse,
+            undefined,
+          );
+        }
+
+        const squashStartTime = now();
+        // deno-lint-ignore no-await-in-loop
+        candidateSquashes = await discoverStructure
+          .analyzeSelectedNeuronsSquashes(chunk);
+        ctx.refreshAnalysisTimeout(discoverStructure);
+        const squashTime = now() - squashStartTime;
+        perfStats.squashAnalysisTime += squashTime;
+        if (shouldLogDiscovery(config)) {
+          logSquashResults(ID, squashTime, candidateSquashes);
+        }
+      } else {
+        // deno-lint-ignore no-await-in-loop
+        const analysisResults = await runParallelAnalysis(
+          ctx,
+          discoverStructure,
+          perfStats,
+          phaseDiagnostics,
+          chunk,
+        );
+        phaseDiagnostics.enterPhase("analysis_loop");
+        [
+          addHelpfulNeurons,
+          addHelpfulSynapse,
+          removeHarmfulSynapse,
+          candidateSquashes,
+          removeHarmfulNeurons,
+        ] = analysisResults;
+
+        if (shouldLogDiscovery(config)) {
+          logAllCandidates(
+            ID,
+            addHelpfulSynapse,
+            addHelpfulNeurons,
+            removeHarmfulSynapse,
+            removeHarmfulNeurons,
+          );
+        }
+      }
+
+      accumulateResults(
+        discoverResult,
         addHelpfulNeurons,
+        coordinatedStructuralCandidates,
         addHelpfulSynapse,
         removeHarmfulSynapse,
         candidateSquashes,
         removeHarmfulNeurons,
-      ] = analysisResults;
+      );
 
-      if (shouldLogDiscovery(config)) {
-        logAllCandidates(
-          ID,
-          addHelpfulSynapse,
-          addHelpfulNeurons,
-          removeHarmfulSynapse,
-          removeHarmfulNeurons,
-        );
+      // Adaptive early-exit: if the Rust FFI chunk stalled beyond the
+      // per-chunk budget, stop submitting further chunks for this cycle
+      // (Issue #2380). Throughput is effectively zero so additional chunks
+      // would likely consume the rest of the budget without returning.
+      if (ctx.perChunkMaxMs > 0 && chunkElapsed >= ctx.perChunkMaxMs) {
+        if (shouldLogDiscovery(config)) {
+          getLogger().info(
+            `Discovery ${
+              blue(ID)
+            } rust combined analysis chunk ${chunkIdx}/${chunks.length} exceeded per-chunk budget ${
+              yellow(format(ctx.perChunkMaxMs, { ignoreZero: true }))
+            } (elapsed ${
+              yellow(format(chunkElapsed, { ignoreZero: true }))
+            }); aborting remaining chunks`,
+          );
+        }
+        iterationStalled = true;
+        break;
+      }
+
+      // Overall deadline check between chunks so we don't start a new chunk
+      // when there is effectively no budget remaining.
+      const chunkTimeRemaining = ctx.getTimeoutTS() - now();
+      if (chunkTimeRemaining <= 0) {
+        iterationStalled = true;
+        break;
       }
     }
-
-    accumulateResults(
-      discoverResult,
-      addHelpfulNeurons,
-      coordinatedStructuralCandidates,
-      addHelpfulSynapse,
-      removeHarmfulSynapse,
-      candidateSquashes,
-      removeHarmfulNeurons,
-    );
 
     // Check if we found any candidates
     const foundCandidates = Boolean(
@@ -371,7 +465,19 @@ export async function runAnalysisLoop(
       );
     }
 
-    const timeRemaining = ctx.getTimeoutTS() - Date.now();
+    if (iterationStalled) {
+      stalledFlag = true;
+      if (shouldLogDiscovery(config)) {
+        getLogger().info(
+          `Discovery ${
+            blue(ID)
+          } analysis throughput stalled after evaluating ${attemptedNeurons.size} neuron(s); aborting retry loop`,
+        );
+      }
+      break;
+    }
+
+    const timeRemaining = ctx.getTimeoutTS() - now();
     if (timeRemaining <= 0) {
       if (shouldLogDiscovery(config)) {
         getLogger().info(
@@ -393,7 +499,9 @@ export async function runAnalysisLoop(
       );
     }
   }
-  perfStats.analysisPhaseTime = Date.now() - analysisPhaseStartTime;
+  perfStats.analysisPhaseTime = now() - analysisPhaseStartTime;
+  // Surface throughput stall so callers can inspect after the loop returns.
+  perfStats.analysisStalled = stalledFlag;
 
   // Collect low-impact removal candidates from Rust focus ranking
   const removalCandidates = discoverStructure.getRemovalCandidates();
@@ -411,6 +519,29 @@ export async function runAnalysisLoop(
   }
 
   return discoverResult;
+}
+
+/**
+ * Renders a short suffix describing which scopes used the GPU for a combined
+ * analysis result. Used for per-chunk logging (Issue #2380).
+ */
+function describeGpuUsage(
+  combinedResult:
+    | import("./RustDiscovery.ts").RustAnalyzeAllResult
+    | undefined,
+): string {
+  if (!combinedResult) return "";
+  const synapseGpu = combinedResult.synapse?.gpuUsed;
+  const neuronGpu = combinedResult.neuron?.gpuUsed;
+  if (synapseGpu === undefined && neuronGpu === undefined) return "";
+  const parts: string[] = [];
+  if (synapseGpu !== undefined) {
+    parts.push(`synapse=${synapseGpu ? "gpu" : "cpu"}`);
+  }
+  if (neuronGpu !== undefined) {
+    parts.push(`neuron=${neuronGpu ? "gpu" : "cpu"}`);
+  }
+  return ` [${parts.join(" ")}]`;
 }
 
 function logSquashResults(

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts
@@ -46,6 +46,12 @@ export class DiscoveryPerformanceStats {
   harmfulSynapseAnalysisTime = 0;
   harmfulNeuronAnalysisTime = 0;
   squashAnalysisTime = 0;
+  /**
+   * Set to true when the analysis loop aborted early due to a throughput
+   * stall (a single Rust combined-analysis chunk exceeded the per-chunk
+   * budget). See Issue #2380.
+   */
+  analysisStalled = false;
 
   // Candidate counts (final arrays returned to the caller).
   // Note (29-Dec-2025): Counts are taken from the result arrays (not per-retry

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -294,6 +294,29 @@ export interface NeatArguments {
    */
   discoveryMaxNeurons: number;
 
+  /**
+   * Maximum number of neurons submitted to the Rust combined analysis in a
+   * single FFI call. The analysis loop splits the focus list into chunks of
+   * at most this size so progress can be checkpointed and logged between
+   * chunks, and so a stall in Rust cannot consume the full analysis budget.
+   *
+   * Defaults to 2 (see Issue #2380). Set to 0 or a very large number to
+   * disable chunking and submit the whole focus list in a single call (the
+   * historical pre-#2380 behaviour).
+   */
+  discoveryAnalysisChunkSize: number;
+
+  /**
+   * Maximum milliseconds a single Rust combined-analysis chunk may take
+   * before the analysis loop stops submitting further chunks for this
+   * discovery cycle. Prevents one slow Rust call from consuming the full
+   * analysis budget when per-neuron throughput has effectively stalled
+   * (Issue #2380).
+   *
+   * Defaults to 120000 (2 minutes). Set to 0 to disable the stall guard.
+   */
+  discoveryAnalysisPerChunkMaxMs: number;
+
   /** Drain promise chains every N batches during discovery recording to prevent memory buildup. Default: 10 */
   discoveryDrainEveryNBatches: number;
 

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -426,6 +426,18 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
       6,
       { integer: true, min: 0 },
     ),
+    discoveryAnalysisChunkSize: parseNumber(
+      "Discovery analysis chunk size",
+      opts.discoveryAnalysisChunkSize,
+      2,
+      { integer: true, min: 0 },
+    ),
+    discoveryAnalysisPerChunkMaxMs: parseNumber(
+      "Discovery analysis per-chunk max milliseconds",
+      opts.discoveryAnalysisPerChunkMaxMs,
+      120_000,
+      { min: 0 },
+    ),
     discoveryDrainEveryNBatches: parseNumber(
       "Discovery drain every N batches",
       opts.discoveryDrainEveryNBatches,

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -67,6 +67,8 @@ type NumericOptionKeys =
   | "discoveryRustFlushRecords"
   | "discoveryRustFlushBytes"
   | "discoveryMaxNeurons"
+  | "discoveryAnalysisChunkSize"
+  | "discoveryAnalysisPerChunkMaxMs"
   | "discoveryDrainEveryNBatches"
   | "discoveryReplayMaxSingles"
   | "discoveryReplayMaxPairwise"

--- a/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for chunked Rust combined-analysis with adaptive throughput
+ * early-exit (Issue #2380).
+ *
+ * These tests verify that the analysis loop:
+ * 1. Splits the focus list into chunks of `analysisChunkSize` neurons so
+ *    each Rust FFI call is bounded in scope.
+ * 2. Aborts the loop when a single chunk exceeds `perChunkMaxMs` — the
+ *    "throughput stalled" adaptive early-exit required by the issue.
+ * 3. Records the stall in `DiscoveryPerformanceStats.analysisStalled`.
+ * 4. Falls back to a single unbatched call when chunking is disabled
+ *    (backwards-compatible path).
+ */
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { DiscoverStructureDeps } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+import { DiscoveryPerformanceStats } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts";
+import { PhaseDiagnostics } from "@architecture/ErrorGuidedStructuralEvolution/PhaseDiagnostics.ts";
+import {
+  chunkFocusList,
+  runAnalysisLoop,
+} from "@architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import type { RustParallelAnalysisInput } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+function makeTestCreature(): Creature {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        uuid: "hidden-a",
+        type: "hidden",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+      {
+        uuid: "hidden-b",
+        type: "hidden",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+      {
+        uuid: "hidden-c",
+        type: "hidden",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+      {
+        uuid: "output-0",
+        type: "output",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "input-0", toUUID: "hidden-b", weight: 0.25 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: -0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-c", weight: 0.75 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: -0.25 },
+      { fromUUID: "hidden-c", toUUID: "output-0", weight: 0.3 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+function makeTrainingData(): DataRecordInterface[] {
+  const samples: DataRecordInterface[] = [];
+  for (let i = 0; i < 20; i++) {
+    samples.push({
+      input: Float32Array.from([i / 20, (i + 1) / 20]),
+      output: Float32Array.from([i / 10]),
+    });
+  }
+  return samples;
+}
+
+interface SpyRunOptions {
+  readonly analyzeParallel: (
+    input: RustParallelAnalysisInput,
+  ) => ReturnType<DiscoverStructureDeps["analyzeParallel"]>;
+  readonly analysisChunkSize: number;
+  readonly perChunkMaxMs: number;
+  readonly discoveryMaxNeurons?: number;
+  readonly now?: () => number;
+}
+
+async function runWithMockedAnalyzeParallel(
+  options: SpyRunOptions,
+): Promise<{
+  capturedFocusSizes: number[];
+  perfStats: DiscoveryPerformanceStats;
+}> {
+  await initWasmForTests();
+
+  const creature = makeTestCreature();
+  const capturedFocusSizes: number[] = [];
+
+  // Create a real on-disk "parquet" stand-in so the existence check in
+  // loadNeuronRecords passes. The mocked readDiscoveryRecords returns an
+  // empty record set, so the content of the file is irrelevant.
+  const tempParquetPath = await Deno.makeTempFile({
+    prefix: "discover-analysis-chunking-",
+    suffix: ".parquet",
+  });
+
+  const deps: Partial<DiscoverStructureDeps> = {
+    isRustDiscoveryEnabled: () => true,
+    isRustLibraryAvailable: () => true,
+    recordDiscovery: () => ({ success: true, file: tempParquetPath }),
+    mergeDiscoveryParquet: () => ({
+      success: true,
+      outputFile: tempParquetPath,
+    }),
+    analyzeParallel: (input) => {
+      capturedFocusSizes.push(input.focusNeurons.length);
+      return options.analyzeParallel(input);
+    },
+    readDiscoveryRecords: () => ({ success: true, records: [] }),
+  };
+
+  const structure = new DiscoverStructure(creature, 600, 100, deps);
+  const neuronPromises = new Map<number, Promise<void>>();
+  structure.initialize(neuronPromises);
+
+  // Force a parquetFilePath so ensureRustCombinedAnalysis proceeds.
+  structure.record(makeTrainingData(), neuronPromises);
+  structure.flushRustRecording();
+
+  const config = createNeatConfig({
+    discoveryAnalysisTimeoutMinutes: 10,
+    discoveryMaxNeurons: options.discoveryMaxNeurons ?? 6,
+    discoveryAnalysisChunkSize: options.analysisChunkSize,
+    discoveryAnalysisPerChunkMaxMs: options.perChunkMaxMs,
+  });
+
+  const perfStats = new DiscoveryPerformanceStats();
+  const phaseDiagnostics = new PhaseDiagnostics("analysis");
+
+  const deadlineMs = (options.now ?? Date.now)() + 10 * 60 * 1000;
+  // Give the DiscoverStructure a matching deadline
+  structure.extendTimeoutForAnalysis(600);
+
+  try {
+    await runAnalysisLoop(
+      {
+        ID: "T-2380",
+        config,
+        discoveryMaxNeurons: options.discoveryMaxNeurons ?? 6,
+        costOfGrowth: 0,
+        analysisChunkSize: options.analysisChunkSize,
+        perChunkMaxMs: options.perChunkMaxMs,
+        now: options.now,
+        getTimeoutTS: () => deadlineMs,
+        refreshAnalysisTimeout: () => {},
+      },
+      structure,
+      perfStats,
+      phaseDiagnostics,
+    );
+  } finally {
+    await structure.cleanUp();
+    try {
+      await Deno.remove(tempParquetPath);
+    } catch {
+      // Ignore cleanup failures
+    }
+  }
+
+  return { capturedFocusSizes, perfStats };
+}
+
+Deno.test("chunkFocusList splits into fixed-size sublists", () => {
+  assertEquals(chunkFocusList([1, 2, 3, 4, 5, 6], 2), [[1, 2], [3, 4], [5, 6]]);
+  assertEquals(chunkFocusList([1, 2, 3, 4, 5], 2), [[1, 2], [3, 4], [5]]);
+  assertEquals(chunkFocusList([1, 2, 3], 1), [[1], [2], [3]]);
+});
+
+Deno.test("chunkFocusList treats chunkSize<=0 as chunking-disabled", () => {
+  assertEquals(chunkFocusList([1, 2, 3], 0), [[1, 2, 3]]);
+  assertEquals(chunkFocusList([1, 2, 3], -5), [[1, 2, 3]]);
+});
+
+Deno.test("chunkFocusList returns [] for empty input", () => {
+  assertEquals(chunkFocusList([], 4), []);
+});
+
+Deno.test("runAnalysisLoop submits the focus list in chunks of analysisChunkSize", async () => {
+  const { capturedFocusSizes } = await runWithMockedAnalyzeParallel({
+    analyzeParallel: () => ({
+      success: true,
+      helpfulNeurons: [],
+      helpfulSynapses: [],
+      harmfulSynapses: [],
+    }),
+    analysisChunkSize: 2,
+    perChunkMaxMs: 0, // disable stall guard
+    discoveryMaxNeurons: 6,
+  });
+
+  assert(
+    capturedFocusSizes.length >= 1,
+    `analyzeParallel should be called at least once, got ${capturedFocusSizes.length}`,
+  );
+  for (const size of capturedFocusSizes) {
+    assert(
+      size <= 2,
+      `each Rust FFI call must carry at most analysisChunkSize neurons (got ${size})`,
+    );
+    assert(size >= 1, "each chunk must have at least one neuron");
+  }
+});
+
+Deno.test("runAnalysisLoop submits whole focus list in one call when chunking disabled", async () => {
+  const { capturedFocusSizes } = await runWithMockedAnalyzeParallel({
+    analyzeParallel: () => ({
+      success: true,
+      helpfulNeurons: [],
+      helpfulSynapses: [],
+      harmfulSynapses: [],
+    }),
+    analysisChunkSize: 0, // disabled
+    perChunkMaxMs: 0,
+    discoveryMaxNeurons: 6,
+  });
+
+  // With chunking disabled, each retry iteration should submit the whole
+  // focus list in a single call (sizes > 1 expected on the first attempt).
+  assert(
+    capturedFocusSizes.some((size) => size > 1),
+    `expected at least one batched call when chunking disabled, got sizes ${
+      capturedFocusSizes.join(",")
+    }`,
+  );
+});
+
+Deno.test("runAnalysisLoop aborts retries when a single chunk exceeds perChunkMaxMs (stall guard)", async () => {
+  // Fake clock that advances by 5_000ms every call — each chunk will appear
+  // to take much longer than a 100ms per-chunk budget, so the very first
+  // chunk should trip the stall guard.
+  let tick = 1_000_000;
+  const advanceNow = () => {
+    tick += 5_000;
+    return tick;
+  };
+
+  const { capturedFocusSizes, perfStats } = await runWithMockedAnalyzeParallel({
+    analyzeParallel: () => ({
+      success: true,
+      helpfulNeurons: [],
+      helpfulSynapses: [],
+      harmfulSynapses: [],
+    }),
+    analysisChunkSize: 1,
+    perChunkMaxMs: 100,
+    discoveryMaxNeurons: 6,
+    now: advanceNow,
+  });
+
+  // Stall guard should have fired; at most a small number of chunks
+  // should have been submitted (one to trip the guard, and we break
+  // out immediately afterwards).
+  assert(
+    capturedFocusSizes.length <= 2,
+    `stall guard should abort further chunks, got ${capturedFocusSizes.length} calls`,
+  );
+  assert(
+    perfStats.analysisStalled,
+    "performance stats should record analysisStalled=true when stall guard trips",
+  );
+});
+
+Deno.test("runAnalysisLoop does not mark analysisStalled when all chunks finish within budget", async () => {
+  const { perfStats } = await runWithMockedAnalyzeParallel({
+    analyzeParallel: () => ({
+      success: true,
+      helpfulNeurons: [],
+      helpfulSynapses: [],
+      harmfulSynapses: [],
+    }),
+    analysisChunkSize: 2,
+    // Large per-chunk budget so real elapsed time won't exceed it.
+    perChunkMaxMs: 60_000,
+    discoveryMaxNeurons: 6,
+  });
+
+  assertFalse(
+    perfStats.analysisStalled,
+    "analysisStalled must stay false when chunks complete within per-chunk budget",
+  );
+});


### PR DESCRIPTION
# Discovery Rust combined analysis — chunking + adaptive stall guard

Closes #2380

## Root cause

`runAnalysisLoop` in
`src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts`
submitted the entire focus list (up to `discoveryMaxNeurons`, default 6) to
`DiscoverStructure.ensureRustCombinedAnalysis(...)` as a single FFI call. That
call is synchronous — once Rust starts the combined analysis TS cannot
preempt it. When one of the neurons stalls (CPU fallback, pathological
topology, etc.), the whole 10-minute analysis budget is consumed by one
uninterruptible Rust call, producing exactly the pattern in
`GRQ-22-sloth.log`:

```
Rust combined analysis: 9m 56s 236ms
Neurons analyzed: 6
Neurons/sec: 0
```

The TS layer had no checkpoint between the call starting and the 10-minute
deadline firing.

## Fix

Break the single Rust FFI call into **chunks**. Each chunk runs the full
pipeline (combined analysis → candidate collection → squash analysis), and
between chunks the loop checks:

1. **Per-chunk budget** — if a single chunk exceeded
   `discoveryAnalysisPerChunkMaxMs` (default 120 000 ms), set
   `analysisStalled=true` and break out of the retry loop. This is the
   adaptive early-exit required by the acceptance criteria.
2. **Deadline** — the existing `getTimeoutTS()` check now runs after every
   chunk, not just after the whole focus list.

With defaults (`chunkSize=2`, `perChunkMaxMs=120 000`), 6 focus neurons
become three FFI calls; a single 2-minute stall aborts the remainder of the
cycle instead of burning the full 10 minutes on one call.

## Changes

- **New config fields** (defaults preserve "at most a 6-minute budget burn
  before bailing out"):
  - `discoveryAnalysisChunkSize` — default `2`; `0` submits the whole focus
    list in one call (the pre-#2380 behaviour).
  - `discoveryAnalysisPerChunkMaxMs` — default `120000`; `0` disables the
    stall guard.
- **`DataRecorderAnalysis.ts`**
  - New exported helper `chunkFocusList(focusList, chunkSize)` — small, pure,
    easy to unit-test.
  - Inner analysis body restructured into a per-chunk `for` loop.
  - After each chunk: per-chunk elapsed time + GPU usage logged
    (`[synapse=gpu neuron=cpu]`), deadline and stall-guard both checked.
  - Optional `now` injection on `AnalysisLoopContext` so tests can drive
    deterministic elapsed-time scenarios.
- **`DiscoveryPerformanceStats`** — added `analysisStalled` boolean so the
  caller can observe when the stall guard fired.
- **`DataRecorder.ts`** — passes the two new config values through to
  `runAnalysisLoop`.

## Tests

New `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts`:

- `chunkFocusList` — splits fixed-size sublists, treats `<=0` as disabled,
  returns `[]` for empty input.
- `runAnalysisLoop submits the focus list in chunks of analysisChunkSize` —
  every captured FFI call carries at most `analysisChunkSize` neurons.
- `runAnalysisLoop submits whole focus list in one call when chunking
  disabled` — backwards-compat path still works when chunking is off.
- `runAnalysisLoop aborts retries when a single chunk exceeds perChunkMaxMs
  (stall guard)` — uses an injected clock that advances 5 000 ms per call,
  asserts the loop bails after at most 2 FFI calls and sets
  `analysisStalled=true`. **Fails against the pre-#2380 code.**
- `runAnalysisLoop does not mark analysisStalled when all chunks finish
  within budget` — sanity check: no false positives with a generous budget.

## Test plan

- [x] `deno test --allow-all test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` → 7 passed, 0 failed.
- [x] `./quality.sh --skip-wasm` (full test suite, WASM skipped because the
      local `build.sh` sync pulled a truncated WASM pkg on this workstation)
      → 6002 passed, 0 failed.
- [ ] CI re-runs the full `./quality.sh` (including WASM sync) on a clean
      runner.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2380 -->