### PR TITLE
Fix: use 🗜️ clamp emoji for non-fatal clamp warnings (#2392)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2392.md
+++ b/docs/pr-summary-2392.md
@@ -4,23 +4,24 @@ Warn-level clamp logs were using the 🚨 alarm emoji, which the external
 GRQ-health monitor detects as an error. Clamping overflowing weights/biases is
 not a genuine error — the pipeline is successfully capping the magnitude to
 `MAX_SAFE_WEIGHT_BIAS`. Switched those two warnings to the 🗜️ clamp emoji so
-operators can still find them quickly in logs without the dashboard flagging
-the worker as `errors`. Error-level diagnostics (validation failure, topology
+operators can still find them quickly in logs without the dashboard flagging the
+worker as `errors`. Error-level diagnostics (validation failure, topology
 corruption) keep 🚨 — they remain genuine errors.
 
 Closes #2392.
 
 ## Evidence
 
-This is a backend logging change; the "UI" is the GRQ-health dashboard shown
-in the issue screenshots, which classifies any log line containing 🚨 as an
-error. Manual verification with the new tests:
+This is a backend logging change; the "UI" is the GRQ-health dashboard shown in
+the issue screenshots, which classifies any log line containing 🚨 as an error.
+Manual verification with the new tests:
 
 ```
 🗜️ [loadFrom] Clamped overflowing weights/biases to ±9007199254740991 on creature unknown: 1 weight(s) (max |w|=1.1559466326634707e+195), 0 bias(es) (max |b|=0).
 ```
 
-Quality gate result: `ok | 6034 passed (2 steps) | 0 failed | 3 ignored (3m18s)`.
+Quality gate result:
+`ok | 6034 passed (2 steps) | 0 failed | 3 ignored (3m18s)`.
 
 ## Changes
 
@@ -38,4 +39,5 @@ Quality gate result: `ok | 6034 passed (2 steps) | 0 failed | 3 ignored (3m18s)`
 - Existing `test/creature/WeightBiasOverflowClamp.ts` (4 tests) and
   `test/score/WeightBiasOverflowWarning.ts` (1 test) still pass — clamp
   behaviour and UUID inclusion are unchanged.
-- Full `./quality.sh --skip-discovery --skip-wasm` run: **6034 passed, 0 failed**.
+- Full `./quality.sh --skip-discovery --skip-wasm` run: **6034 passed, 0
+  failed**.

--- a/docs/pr-summary-2392.md
+++ b/docs/pr-summary-2392.md
@@ -1,0 +1,41 @@
+## Summary
+
+Warn-level clamp logs were using the 🚨 alarm emoji, which the external
+GRQ-health monitor detects as an error. Clamping overflowing weights/biases is
+not a genuine error — the pipeline is successfully capping the magnitude to
+`MAX_SAFE_WEIGHT_BIAS`. Switched those two warnings to the 🗜️ clamp emoji so
+operators can still find them quickly in logs without the dashboard flagging
+the worker as `errors`. Error-level diagnostics (validation failure, topology
+corruption) keep 🚨 — they remain genuine errors.
+
+Closes #2392.
+
+## Evidence
+
+This is a backend logging change; the "UI" is the GRQ-health dashboard shown
+in the issue screenshots, which classifies any log line containing 🚨 as an
+error. Manual verification with the new tests:
+
+```
+🗜️ [loadFrom] Clamped overflowing weights/biases to ±9007199254740991 on creature unknown: 1 weight(s) (max |w|=1.1559466326634707e+195), 0 bias(es) (max |b|=0).
+```
+
+Quality gate result: `ok | 6034 passed (2 steps) | 0 failed | 3 ignored (3m18s)`.
+
+## Changes
+
+- `src/creature/CreatureSerialization.ts` — load-time clamp warning now uses 🗜️.
+- `src/architecture/Score.ts` — score-path overflow clamp warning now uses 🗜️.
+- `src/utils/Diagnostics.ts` — documented the convention: reserve 🚨 for
+  error-level logs (detected by GRQ-health), use 🗜️ for non-fatal clamp
+  warnings.
+
+## Test Plan
+
+- Added `test/creature/ClampEmojiNotAlarm.ts` with two tests:
+  - `Issue #2392: loadFrom clamp warning does not use 🚨 alarm emoji`
+  - `Issue #2392: Score overflow clamp warning does not use 🚨 alarm emoji`
+- Existing `test/creature/WeightBiasOverflowClamp.ts` (4 tests) and
+  `test/score/WeightBiasOverflowWarning.ts` (1 test) still pass — clamp
+  behaviour and UUID inclusion are unchanged.
+- Full `./quality.sh --skip-discovery --skip-wasm` run: **6034 passed, 0 failed**.

--- a/src/architecture/Score.ts
+++ b/src/architecture/Score.ts
@@ -282,7 +282,7 @@ function computeAndCacheScoreComponents(
     totalWeightBias > Number.MAX_SAFE_INTEGER
   ) {
     getLogger().warn(
-      `🚨 [Score] Weight/bias magnitude overflow on creature ` +
+      `🗜️ [Score] Weight/bias magnitude overflow on creature ` +
         `${creature.uuid ?? "unknown"}: ` +
         `max=${maxWeightBias}, total=${totalWeightBias}. ` +
         `Clamping to ±${Number.MAX_SAFE_INTEGER}.`,

--- a/src/creature/CreatureSerialization.ts
+++ b/src/creature/CreatureSerialization.ts
@@ -606,7 +606,7 @@ export function loadFrom(
   // per-value info lines in Score.ts).
   if (clampedWeightCount > 0 || clampedBiasCount > 0) {
     getLogger().warn(
-      "🚨 [loadFrom] Clamped overflowing weights/biases to " +
+      "🗜️ [loadFrom] Clamped overflowing weights/biases to " +
         `±${MAX_SAFE_WEIGHT_BIAS} on creature ${creature.uuid ?? "unknown"}: ` +
         `${clampedWeightCount} weight(s) (max |w|=${maxObservedWeight}), ` +
         `${clampedBiasCount} bias(es) (max |b|=${maxObservedBias}).`,

--- a/src/utils/Diagnostics.ts
+++ b/src/utils/Diagnostics.ts
@@ -115,6 +115,10 @@ export function writeDiagnostics(options: DiagnosticsOptions): void {
  * and `fix()` is called as a last resort to avoid a hard crash.
  *
  * The 🚨 emoji in the log line is detected by ../GRQ-health as an error.
+ * Reserve 🚨 for genuine errors like this one (corruption, validation
+ * failure). Non-fatal warnings — e.g. clamping overflowing weights — use
+ * the 🗜️ clamp emoji instead so they do not trip the error monitor
+ * (Issue #2392).
  *
  * @param creature - The creature to validate
  * @param operation - Which pipeline stage produced this creature (e.g. "breed", "mutate")

--- a/test/creature/ClampEmojiNotAlarm.ts
+++ b/test/creature/ClampEmojiNotAlarm.ts
@@ -1,0 +1,140 @@
+/**
+ * Issue #2392: the 🚨 alarm emoji in log lines is detected by the external
+ * GRQ-health monitor as an error. The warn-level "clamp" messages emitted
+ * when overflowing weights/biases are reduced to safe magnitudes are NOT
+ * genuine errors — they are informational guards that the pipeline handled
+ * the overflow safely. Using 🚨 for those warnings caused false-positive
+ * worker-error alerts on the dashboard.
+ *
+ * These tests lock in the contract:
+ *   - Warn-level clamp messages MUST NOT contain 🚨.
+ *   - Warn-level clamp messages MUST contain the clamp emoji 🗜️ so
+ *     operators can still find them quickly in logs.
+ *   - Error-level diagnostics (corruption, validation failures) are
+ *     unaffected and still use 🚨 (covered by their existing tests).
+ *
+ * @module
+ */
+
+import { assert } from "@std/assert";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { calculate } from "@architecture/Score.ts";
+import { getLogger, type Logger, setLogger } from "@utils/Logger.ts";
+
+const ALARM_EMOJI = "\u{1F6A8}"; // 🚨
+const CLAMP_EMOJI = "\u{1F5DC}"; // 🗜️
+
+type LoggedCall = { level: string; args: unknown[] };
+
+function captureLogs(run: () => void): LoggedCall[] {
+  const calls: LoggedCall[] = [];
+  const testLogger: Logger = {
+    debug: () => {},
+    info: (...args: unknown[]) => calls.push({ level: "info", args }),
+    warn: (...args: unknown[]) => calls.push({ level: "warn", args }),
+    error: (...args: unknown[]) => calls.push({ level: "error", args }),
+  };
+  const previous = getLogger();
+  setLogger(testLogger);
+  try {
+    run();
+  } finally {
+    setLogger(previous);
+  }
+  return calls;
+}
+
+function findWarnContaining(
+  calls: LoggedCall[],
+  needle: string,
+): LoggedCall | undefined {
+  return calls.find((c) =>
+    c.level === "warn" &&
+    c.args.some((a) => typeof a === "string" && a.includes(needle))
+  );
+}
+
+Deno.test(
+  "Issue #2392: loadFrom clamp warning does not use 🚨 alarm emoji",
+  () => {
+    const json: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+      ],
+      synapses: [
+        {
+          fromUUID: "input-0",
+          toUUID: "output-0",
+          weight: 1.1559466326634707e+195,
+        },
+      ],
+    };
+
+    const calls = captureLogs(() => {
+      Creature.fromJSON(json);
+    });
+
+    const clampWarn = findWarnContaining(calls, "Clamped overflowing");
+    assert(
+      clampWarn !== undefined,
+      `Expected a warn-level "Clamped overflowing" log. Got: ${
+        JSON.stringify(calls)
+      }`,
+    );
+
+    const text = clampWarn.args.filter((a) => typeof a === "string").join(" ");
+    assert(
+      !text.includes(ALARM_EMOJI),
+      `loadFrom clamp warning must not contain the 🚨 alarm emoji ` +
+        `(triggers GRQ-health false-positive errors). Got: ${text}`,
+    );
+    assert(
+      text.includes(CLAMP_EMOJI),
+      `loadFrom clamp warning should contain the 🗜️ clamp emoji ` +
+        `so operators can find it in logs. Got: ${text}`,
+    );
+  },
+);
+
+Deno.test(
+  "Issue #2392: Score overflow clamp warning does not use 🚨 alarm emoji",
+  () => {
+    const creature = new Creature(1, 1);
+    creature.uuid = "00000000-0000-4000-8000-000000002392";
+    if (creature.synapses.length === 0) return;
+    creature.synapses[0].weight = 1.1559466326634707e+195;
+    creature.invalidateScoreCache();
+
+    const calls = captureLogs(() => {
+      calculate(creature, 0.1, 0.000_1);
+    });
+
+    const overflowWarn = findWarnContaining(
+      calls,
+      "Weight/bias magnitude overflow",
+    );
+    assert(
+      overflowWarn !== undefined,
+      `Expected a warn-level "Weight/bias magnitude overflow" log. Got: ${
+        JSON.stringify(calls)
+      }`,
+    );
+
+    const text = overflowWarn.args
+      .filter((a) => typeof a === "string")
+      .join(" ");
+    assert(
+      !text.includes(ALARM_EMOJI),
+      `Score clamp warning must not contain the 🚨 alarm emoji ` +
+        `(triggers GRQ-health false-positive errors). Got: ${text}`,
+    );
+    assert(
+      text.includes(CLAMP_EMOJI),
+      `Score clamp warning should contain the 🗜️ clamp emoji ` +
+        `so operators can find it in logs. Got: ${text}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Warn-level clamp logs were using the 🚨 alarm emoji, which the external
GRQ-health monitor detects as an error. Clamping overflowing weights/biases is
not a genuine error — the pipeline is successfully capping the magnitude to
`MAX_SAFE_WEIGHT_BIAS`. Switched those two warnings to the 🗜️ clamp emoji so
operators can still find them quickly in logs without the dashboard flagging
the worker as `errors`. Error-level diagnostics (validation failure, topology
corruption) keep 🚨 — they remain genuine errors.

Closes #2392.

## Evidence

This is a backend logging change; the "UI" is the GRQ-health dashboard shown
in the issue screenshots, which classifies any log line containing 🚨 as an
error. Manual verification with the new tests:

```
🗜️ [loadFrom] Clamped overflowing weights/biases to ±9007199254740991 on creature unknown: 1 weight(s) (max |w|=1.1559466326634707e+195), 0 bias(es) (max |b|=0).
```

Quality gate result: `ok | 6034 passed (2 steps) | 0 failed | 3 ignored (3m18s)`.

## Changes

- `src/creature/CreatureSerialization.ts` — load-time clamp warning now uses 🗜️.
- `src/architecture/Score.ts` — score-path overflow clamp warning now uses 🗜️.
- `src/utils/Diagnostics.ts` — documented the convention: reserve 🚨 for
  error-level logs (detected by GRQ-health), use 🗜️ for non-fatal clamp
  warnings.

## Test Plan

- Added `test/creature/ClampEmojiNotAlarm.ts` with two tests:
  - `Issue #2392: loadFrom clamp warning does not use 🚨 alarm emoji`
  - `Issue #2392: Score overflow clamp warning does not use 🚨 alarm emoji`
- Existing `test/creature/WeightBiasOverflowClamp.ts` (4 tests) and
  `test/score/WeightBiasOverflowWarning.ts` (1 test) still pass — clamp
  behaviour and UUID inclusion are unchanged.
- Full `./quality.sh --skip-discovery --skip-wasm` run: **6034 passed, 0 failed**.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2392 -->