### PR TITLE
Split NeatEvolution.ts into focused CpuUtilisation + ProcessCompletedResults modules

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2395.md
+++ b/docs/pr-summary-2395.md
@@ -1,50 +1,52 @@
 ## Summary
+
 Split `src/NEAT/NeatEvolution.ts` into three focused modules so the evolution
 loop is easier to read and its helpers can be tested in isolation. Closes #2395.
 
-- `src/NEAT/CpuUtilisation.ts` — new module owning
-  `captureUtilisationSnapshot` and `computeOverallCpuUtilisation` (Issue #2312
-  utilisation helpers).
+- `src/NEAT/CpuUtilisation.ts` — new module owning `captureUtilisationSnapshot`
+  and `computeOverallCpuUtilisation` (Issue #2312 utilisation helpers).
 - `src/NEAT/ProcessCompletedResults.ts` — new module owning
-  `processCompletedResults`, the training/discovery/replay drain that
-  previously dominated the bottom of `NeatEvolution.ts`.
+  `processCompletedResults`, the training/discovery/replay drain that previously
+  dominated the bottom of `NeatEvolution.ts`.
 - `src/NEAT/NeatEvolution.ts` — now imports from the two new modules. `evolve`
   stays put as the top-level orchestrator, as required by the issue. Removed
-  imports that only supported the extracted code (`blue`, `format`,
-  `removeTag`, `CreatureUtil`, `validateAfterDiscoveryOrThrow`, `Approach`,
+  imports that only supported the extracted code (`blue`, `format`, `removeTag`,
+  `CreatureUtil`, `validateAfterDiscoveryOrThrow`, `Approach`,
   `logReplaySummary`, `WorkerPool`).
 
-No behavioural change — the extracted functions keep their signatures and
-call sites.
+No behavioural change — the extracted functions keep their signatures and call
+sites.
 
 ### File sizes
 
-| File | Before | After |
-| --- | --- | --- |
-| `src/NEAT/NeatEvolution.ts` | 1141 | 868 |
-| `src/NEAT/CpuUtilisation.ts` | — | 75 |
-| `src/NEAT/ProcessCompletedResults.ts` | — | 228 |
+| File                                  | Before | After |
+| ------------------------------------- | ------ | ----- |
+| `src/NEAT/NeatEvolution.ts`           | 1141   | 868   |
+| `src/NEAT/CpuUtilisation.ts`          | —      | 75    |
+| `src/NEAT/ProcessCompletedResults.ts` | —      | 228   |
 
-Note on the `~500` target: the issue acceptance criterion names `~500` lines
-for `NeatEvolution.ts` but also requires `evolve` to remain the top-level
+Note on the `~500` target: the issue acceptance criterion names `~500` lines for
+`NeatEvolution.ts` but also requires `evolve` to remain the top-level
 orchestrator in the same file. `evolve` itself is ~725 lines and was not in
-scope to refactor further, so the 23% reduction here is the full gain
-available from the two named extractions. Further reductions would require
-splitting `evolve` itself, which is an explicit non-goal of this issue.
+scope to refactor further, so the 23% reduction here is the full gain available
+from the two named extractions. Further reductions would require splitting
+`evolve` itself, which is an explicit non-goal of this issue.
 
 ## Evidence
+
 Backend refactor with no UI change. Verified via the quality gate:
 
-- `./quality.sh --skip-discovery --skip-wasm` — **6041 passed, 0 failed, 3 ignored**.
+- `./quality.sh --skip-discovery --skip-wasm` — **6041 passed, 0 failed, 3
+  ignored**.
 - New unit test file `test/NEAT/CpuUtilisation.ts` — **7 passed, 0 failed**.
 - Existing `test/NEAT/Evolve.ts` and `test/NEAT/EvolvePhaseTiming.ts` — pass
   unchanged, confirming no behavioural regression in the evolution loop.
 
 ## Test Plan
+
 - Added `test/NEAT/CpuUtilisation.ts` with 7 tests exercising
-  `computeOverallCpuUtilisation` (weighting, zero-duration phases, empty
-  pools, non-positive total) and `captureUtilisationSnapshot` (pct
-  calculation, zero-worker pools). These helpers previously had no direct
-  coverage because they were file-private inside `NeatEvolution.ts`.
-- All existing `test/NEAT/*` evolve tests continue to pass without
-  modification.
+  `computeOverallCpuUtilisation` (weighting, zero-duration phases, empty pools,
+  non-positive total) and `captureUtilisationSnapshot` (pct calculation,
+  zero-worker pools). These helpers previously had no direct coverage because
+  they were file-private inside `NeatEvolution.ts`.
+- All existing `test/NEAT/*` evolve tests continue to pass without modification.

--- a/docs/pr-summary-2395.md
+++ b/docs/pr-summary-2395.md
@@ -1,0 +1,50 @@
+## Summary
+Split `src/NEAT/NeatEvolution.ts` into three focused modules so the evolution
+loop is easier to read and its helpers can be tested in isolation. Closes #2395.
+
+- `src/NEAT/CpuUtilisation.ts` — new module owning
+  `captureUtilisationSnapshot` and `computeOverallCpuUtilisation` (Issue #2312
+  utilisation helpers).
+- `src/NEAT/ProcessCompletedResults.ts` — new module owning
+  `processCompletedResults`, the training/discovery/replay drain that
+  previously dominated the bottom of `NeatEvolution.ts`.
+- `src/NEAT/NeatEvolution.ts` — now imports from the two new modules. `evolve`
+  stays put as the top-level orchestrator, as required by the issue. Removed
+  imports that only supported the extracted code (`blue`, `format`,
+  `removeTag`, `CreatureUtil`, `validateAfterDiscoveryOrThrow`, `Approach`,
+  `logReplaySummary`, `WorkerPool`).
+
+No behavioural change — the extracted functions keep their signatures and
+call sites.
+
+### File sizes
+
+| File | Before | After |
+| --- | --- | --- |
+| `src/NEAT/NeatEvolution.ts` | 1141 | 868 |
+| `src/NEAT/CpuUtilisation.ts` | — | 75 |
+| `src/NEAT/ProcessCompletedResults.ts` | — | 228 |
+
+Note on the `~500` target: the issue acceptance criterion names `~500` lines
+for `NeatEvolution.ts` but also requires `evolve` to remain the top-level
+orchestrator in the same file. `evolve` itself is ~725 lines and was not in
+scope to refactor further, so the 23% reduction here is the full gain
+available from the two named extractions. Further reductions would require
+splitting `evolve` itself, which is an explicit non-goal of this issue.
+
+## Evidence
+Backend refactor with no UI change. Verified via the quality gate:
+
+- `./quality.sh --skip-discovery --skip-wasm` — **6041 passed, 0 failed, 3 ignored**.
+- New unit test file `test/NEAT/CpuUtilisation.ts` — **7 passed, 0 failed**.
+- Existing `test/NEAT/Evolve.ts` and `test/NEAT/EvolvePhaseTiming.ts` — pass
+  unchanged, confirming no behavioural regression in the evolution loop.
+
+## Test Plan
+- Added `test/NEAT/CpuUtilisation.ts` with 7 tests exercising
+  `computeOverallCpuUtilisation` (weighting, zero-duration phases, empty
+  pools, non-positive total) and `captureUtilisationSnapshot` (pct
+  calculation, zero-worker pools). These helpers previously had no direct
+  coverage because they were file-private inside `NeatEvolution.ts`.
+- All existing `test/NEAT/*` evolve tests continue to pass without
+  modification.

--- a/src/NEAT/CpuUtilisation.ts
+++ b/src/NEAT/CpuUtilisation.ts
@@ -1,0 +1,75 @@
+/**
+ * CpuUtilisation.ts - Worker pool utilisation helpers.
+ *
+ * Extracted from `NeatEvolution.ts` (Issue #2395) so the evolution loop stays
+ * focused on orchestration while utilisation sampling/weighting has its own
+ * small, testable module.
+ */
+
+import type { WorkerUtilisationSnapshot } from "@config/TrainingEvent.ts";
+import type { WorkerPool } from "@multithreading/WorkerPool.ts";
+
+/**
+ * Captures a point-in-time worker utilisation snapshot from the fast and heavy
+ * worker pools.
+ *
+ * Issue #2312: Lightweight helper used at phase boundaries to record how many
+ * workers are active vs idle. Because a single snapshot cannot capture the
+ * full utilisation curve across a phase, this deliberately samples at the *end*
+ * of each phase — the point most indicative of sustained utilisation.
+ */
+export function captureUtilisationSnapshot(
+  fastPool: WorkerPool,
+  heavyPool: WorkerPool,
+): WorkerUtilisationSnapshot {
+  const fastActive = fastPool.getActiveWorkerCount();
+  const fastTotal = fastPool.getWorkerCount();
+  const heavyActive = heavyPool.getActiveWorkerCount();
+  const heavyTotal = heavyPool.getWorkerCount();
+  return {
+    fastActive,
+    fastTotal,
+    fastUtilisationPct: fastTotal > 0
+      ? Math.round((fastActive / fastTotal) * 100)
+      : 0,
+    heavyActive,
+    heavyTotal,
+    heavyUtilisationPct: heavyTotal > 0
+      ? Math.round((heavyActive / heavyTotal) * 100)
+      : 0,
+  };
+}
+
+/**
+ * Computes an overall CPU utilisation estimate from per-phase snapshots
+ * weighted by their duration.
+ *
+ * Issue #2312: Each phase's utilisation is weighted by the fraction of total
+ * generation time it consumed. Phases with no snapshot are treated as 0%
+ * utilisation (main-thread-only work).
+ */
+export function computeOverallCpuUtilisation(
+  phases: Array<{
+    durationMs: number;
+    snapshot?: WorkerUtilisationSnapshot;
+  }>,
+  totalMs: number,
+): number {
+  if (totalMs <= 0) return 0;
+
+  let weightedSum = 0;
+  for (const phase of phases) {
+    if (phase.snapshot && phase.durationMs > 0) {
+      const totalActive = phase.snapshot.fastActive +
+        phase.snapshot.heavyActive;
+      const totalWorkers = phase.snapshot.fastTotal +
+        phase.snapshot.heavyTotal;
+      const phaseUtilisation = totalWorkers > 0
+        ? totalActive / totalWorkers
+        : 0;
+      weightedSum += phaseUtilisation * phase.durationMs;
+    }
+    // Phases without snapshots contribute 0 (main-thread-only).
+  }
+  return Math.round((weightedSum / totalMs) * 100);
+}

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -6,11 +6,8 @@
  */
 
 import { assert } from "@std/assert";
-import { blue } from "@std/fmt/colors";
-import { format } from "@std/fmt/duration";
-import { addTag, getTag, removeTag } from "@stsoftware/tags/mod";
-import { Creature } from "@creature";
-import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { addTag, getTag } from "@stsoftware/tags/mod";
+import type { Creature } from "@creature";
 import { DeDuplicator } from "@architecture/DeDuplicator.ts";
 import {
   makeElitists,
@@ -19,10 +16,8 @@ import {
 import { FindTunePopulation } from "@blackbox/FineTunePopulation.ts";
 import { Breed } from "@breed/Breed.ts";
 import { ParallelBreeding } from "@breed/ParallelBreeding.ts";
-import { validateAfterDiscoveryOrThrow } from "@discovery/DiscoveryPostValidate.ts";
 import { AddConnection } from "@mutate/AddConnection.ts";
 import { Genus } from "@neat/Genus.ts";
-import type { Approach } from "@neat/LogApproach.ts";
 import { checkMemoryAndEvict, logMemoryUsage } from "@neat/MemoryMonitor.ts";
 import { Mutator } from "@neat/Mutator.ts";
 import { CRISPR } from "@reconstruct/CRISPR.ts";
@@ -38,77 +33,15 @@ import type {
   WorkerUtilisationSnapshot,
 } from "@config/TrainingEvent.ts";
 import type { Neat } from "@neat/Neat.ts";
-import { logReplaySummary } from "@neat/NeatScheduling.ts";
 import { computeThroughputMetrics } from "@neat/ThroughputMetrics.ts";
 import { emitTrainingEvent } from "@neat/TrainingEventEmitter.ts";
 import { preWarmWasmCache } from "@wasm/WasmCachePreWarmer.ts";
-import type { WorkerPool } from "@multithreading/WorkerPool.ts";
 import { computeAdaptivePopulationSize } from "@neat/AdaptivePopulationSizer.ts";
-
-/**
- * Captures a point-in-time worker utilisation snapshot from the fast and heavy
- * worker pools.
- *
- * Issue #2312: Lightweight helper used at phase boundaries to record how many
- * workers are active vs idle. Because a single snapshot cannot capture the
- * full utilisation curve across a phase, this deliberately samples at the *end*
- * of each phase — the point most indicative of sustained utilisation.
- */
-function captureUtilisationSnapshot(
-  fastPool: WorkerPool,
-  heavyPool: WorkerPool,
-): WorkerUtilisationSnapshot {
-  const fastActive = fastPool.getActiveWorkerCount();
-  const fastTotal = fastPool.getWorkerCount();
-  const heavyActive = heavyPool.getActiveWorkerCount();
-  const heavyTotal = heavyPool.getWorkerCount();
-  return {
-    fastActive,
-    fastTotal,
-    fastUtilisationPct: fastTotal > 0
-      ? Math.round((fastActive / fastTotal) * 100)
-      : 0,
-    heavyActive,
-    heavyTotal,
-    heavyUtilisationPct: heavyTotal > 0
-      ? Math.round((heavyActive / heavyTotal) * 100)
-      : 0,
-  };
-}
-
-/**
- * Computes an overall CPU utilisation estimate from per-phase snapshots
- * weighted by their duration.
- *
- * Issue #2312: Each phase's utilisation is weighted by the fraction of total
- * generation time it consumed. Phases with no snapshot are treated as 0%
- * utilisation (main-thread-only work).
- */
-function computeOverallCpuUtilisation(
-  phases: Array<{
-    durationMs: number;
-    snapshot?: WorkerUtilisationSnapshot;
-  }>,
-  totalMs: number,
-): number {
-  if (totalMs <= 0) return 0;
-
-  let weightedSum = 0;
-  for (const phase of phases) {
-    if (phase.snapshot && phase.durationMs > 0) {
-      const totalActive = phase.snapshot.fastActive +
-        phase.snapshot.heavyActive;
-      const totalWorkers = phase.snapshot.fastTotal +
-        phase.snapshot.heavyTotal;
-      const phaseUtilisation = totalWorkers > 0
-        ? totalActive / totalWorkers
-        : 0;
-      weightedSum += phaseUtilisation * phase.durationMs;
-    }
-    // Phases without snapshots contribute 0 (main-thread-only).
-  }
-  return Math.round((weightedSum / totalMs) * 100);
-}
+import {
+  captureUtilisationSnapshot,
+  computeOverallCpuUtilisation,
+} from "@neat/CpuUtilisation.ts";
+import { processCompletedResults } from "@neat/ProcessCompletedResults.ts";
 
 /**
  * The result returned by a single call to `evolve()`.
@@ -932,210 +865,4 @@ export async function evolve(
     phaseTiming,
     throughput,
   };
-}
-
-/**
- * Process completed training, discovery, and replay results.
- * Returns an array of creatures to add to the population.
- */
-function processCompletedResults(
-  neat: Neat,
-  fittest: Creature,
-  _genus: Genus,
-): Creature[] {
-  const trainedPopulation: Creature[] = [];
-
-  for (let i = neat.trainingComplete.length; i--;) {
-    const r = neat.trainingComplete[i];
-    assert(r.train, "No train found");
-    if (!Number.isFinite(r.train.error)) {
-      continue;
-    }
-
-    const json = r.train.creature;
-    if (neat.config.verbose) {
-      getLogger().info(
-        `Training ${blue(r.train.ID)} completed ${
-          r.duration ? "after " + format(r.duration, { ignoreZero: true }) : ""
-        }`,
-      );
-    }
-
-    // Issue #1913: Preserve PC approach tag from trace if present.
-    const traceJSON = r.train.trace ? r.train.trace : null;
-    const pcApproach = traceJSON ? getTag(traceJSON, "approach") : null;
-    const isPC = pcApproach === "predictive-coding";
-
-    addTag(
-      json,
-      "approach",
-      (isPC ? "predictive-coding" : "trained") as Approach,
-    );
-    if (isPC && traceJSON) {
-      const pcEnergy = getTag(traceJSON, "pc-energy");
-      const pcSteps = getTag(traceJSON, "pc-inference-steps");
-      const pcChanged = getTag(traceJSON, "pc-changed");
-      if (pcEnergy) addTag(json, "pc-energy", pcEnergy);
-      if (pcSteps) addTag(json, "pc-inference-steps", pcSteps);
-      if (pcChanged) addTag(json, "pc-changed", pcChanged);
-    }
-    delete json.memetic;
-    removeTag(json, "approach-logged");
-    addTag(json, "trainID", r.train.ID);
-    addTag(json, "trained", "YES");
-
-    trainedPopulation.push(Creature.fromJSON(json, neat.config.debug));
-    if (r.train.backtracked) {
-      trainedPopulation.push(
-        Creature.fromJSON(r.train.backtracked, neat.config.debug),
-      );
-    }
-    if (r.train.forward) {
-      trainedPopulation.push(
-        Creature.fromJSON(r.train.forward, neat.config.debug),
-      );
-    }
-    const compactJSON = r.train.compact ?? undefined;
-
-    if (compactJSON) {
-      if (neat.config.verbose) {
-        getLogger().info(
-          `Training ${blue(r.train.ID)} compacted`,
-        );
-      }
-
-      // Issue #1913: Preserve PC approach on compact variant too.
-      addTag(
-        compactJSON,
-        "approach",
-        (isPC ? "predictive-coding-compact" : "compact") as Approach,
-      );
-      if (isPC && traceJSON) {
-        const pcEnergy = getTag(traceJSON, "pc-energy");
-        const pcSteps = getTag(traceJSON, "pc-inference-steps");
-        const pcChanged = getTag(traceJSON, "pc-changed");
-        if (pcEnergy) addTag(compactJSON, "pc-energy", pcEnergy);
-        if (pcSteps) addTag(compactJSON, "pc-inference-steps", pcSteps);
-        if (pcChanged) addTag(compactJSON, "pc-changed", pcChanged);
-      }
-      delete compactJSON.memetic;
-      removeTag(compactJSON, "approach-logged");
-      addTag(compactJSON, "trainID", r.train.ID);
-      addTag(compactJSON, "trained", "YES");
-
-      trainedPopulation.push(
-        Creature.fromJSON(compactJSON, neat.config.debug),
-      );
-    }
-
-    // Immediately clear large objects to help GC
-    // @ts-ignore - clearing to help GC
-    r.train.creature = null;
-    // @ts-ignore - clearing to help GC
-    r.train.trace = null;
-    // @ts-ignore - clearing to help GC
-    r.train.compact = null;
-    // @ts-ignore - clearing to help GC
-    r.train.backtracked = null;
-    // @ts-ignore - clearing to help GC
-    r.train.forward = null;
-  }
-  neat.trainingComplete.length = 0;
-
-  // Issue #1020: Process discovery results
-  for (let i = neat.discoveryComplete.length; i--;) {
-    const r = neat.discoveryComplete[i];
-    assert(r.discover, "No discovery found");
-
-    // Issue #1615: Emit discovery_complete event
-    const outcome = r.discover.improvedCreature ? "improved" : "no_change";
-    emitTrainingEvent(neat.config.onTrainingEvent, {
-      kind: "discovery_complete",
-      timestamp: new Date().toISOString(),
-      outcome: outcome as "improved" | "no_change" | "timeout",
-      candidateCount: (r.discover.addHelpfulSynapses?.length ?? 0) +
-        (r.discover.removeHarmfulSynapse ? 1 : 0) +
-        (r.discover.candidateSquashes?.length ?? 0),
-      elapsedMs: r.duration ?? 0,
-    });
-
-    if (r.discover.improvedCreature) {
-      const discoveredCreature = Creature.fromJSON(
-        r.discover.improvedCreature,
-      );
-      CreatureUtil.makeUUID(discoveredCreature);
-
-      validateAfterDiscoveryOrThrow({
-        baseCreature: fittest,
-        discoveredCreature: discoveredCreature,
-        discoveryID: r.discover.ID,
-        operation: "discovered-creature-addition",
-        feedbackLoop: neat.config.feedbackLoop,
-      });
-
-      trainedPopulation.push(discoveredCreature);
-
-      if (neat.config.verbose) {
-        getLogger().info(
-          `[Neat] Added discovered creature ${
-            blue(discoveredCreature.uuid?.substring(0, 8) ?? "unknown")
-          } to population (from discovery ${
-            blue(
-              r.discover.ID.substring(Math.max(0, r.discover.ID.length - 8)),
-            )
-          })`,
-        );
-      }
-    }
-
-    // @ts-ignore - clearing to help GC
-    r.discover.addHelpfulSynapses = null;
-    // @ts-ignore - clearing to help GC
-    r.discover.removeHarmfulSynapse = null;
-    // @ts-ignore - clearing to help GC
-    r.discover.candidateSquashes = null;
-    // @ts-ignore - clearing to help GC
-    r.discover.improvedCreature = null;
-  }
-  neat.discoveryComplete.length = 0;
-
-  // Issue #997: Process completed background replay results
-  const replayResults = neat.discoveryReplayQueue.getCompletedResults();
-  for (const result of replayResults) {
-    logReplaySummary(neat.config, result);
-
-    if (result.improvement?.creature) {
-      const replayedCreature = Creature.fromJSON(
-        result.improvement.creature as Parameters<
-          typeof Creature.fromJSON
-        >[0],
-      );
-      CreatureUtil.makeUUID(replayedCreature);
-
-      addTag(replayedCreature, "approach", "discovery-replay");
-
-      validateAfterDiscoveryOrThrow({
-        baseCreature: fittest,
-        discoveredCreature: replayedCreature,
-        discoveryID: result.improvement.key ?? "replay",
-        operation: "discovery-replay-addition",
-        feedbackLoop: neat.config.feedbackLoop,
-      });
-
-      trainedPopulation.push(replayedCreature);
-
-      if (neat.config.verbose) {
-        getLogger().info(
-          `[Neat] Added replayed creature ${
-            blue(replayedCreature.uuid?.substring(0, 8) ?? "unknown")
-          } to population (score improvement: ${
-            result.improvement.scoreDelta?.toFixed(4) ?? "N/A"
-          })`,
-        );
-      }
-    }
-  }
-  neat.discoveryReplayQueue.clearCompletedResults();
-
-  return trainedPopulation;
 }

--- a/src/NEAT/ProcessCompletedResults.ts
+++ b/src/NEAT/ProcessCompletedResults.ts
@@ -1,0 +1,228 @@
+/**
+ * ProcessCompletedResults.ts - Drain completed training, discovery, and replay
+ * results into a population of new/updated creatures.
+ *
+ * Extracted from `NeatEvolution.ts` (Issue #2395) so the main evolution loop
+ * stays focused on orchestration. Behaviour is unchanged.
+ */
+
+import { assert } from "@std/assert";
+import { blue } from "@std/fmt/colors";
+import { format } from "@std/fmt/duration";
+import { addTag, getTag, removeTag } from "@stsoftware/tags/mod";
+
+import { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { validateAfterDiscoveryOrThrow } from "@discovery/DiscoveryPostValidate.ts";
+import type { Genus } from "@neat/Genus.ts";
+import type { Approach } from "@neat/LogApproach.ts";
+import type { Neat } from "@neat/Neat.ts";
+import { logReplaySummary } from "@neat/NeatScheduling.ts";
+import { emitTrainingEvent } from "@neat/TrainingEventEmitter.ts";
+import { getLogger } from "@utils/Logger.ts";
+
+/**
+ * Process completed training, discovery, and replay results.
+ * Returns an array of creatures to add to the population.
+ */
+export function processCompletedResults(
+  neat: Neat,
+  fittest: Creature,
+  _genus: Genus,
+): Creature[] {
+  const trainedPopulation: Creature[] = [];
+
+  for (let i = neat.trainingComplete.length; i--;) {
+    const r = neat.trainingComplete[i];
+    assert(r.train, "No train found");
+    if (!Number.isFinite(r.train.error)) {
+      continue;
+    }
+
+    const json = r.train.creature;
+    if (neat.config.verbose) {
+      getLogger().info(
+        `Training ${blue(r.train.ID)} completed ${
+          r.duration ? "after " + format(r.duration, { ignoreZero: true }) : ""
+        }`,
+      );
+    }
+
+    // Issue #1913: Preserve PC approach tag from trace if present.
+    const traceJSON = r.train.trace ? r.train.trace : null;
+    const pcApproach = traceJSON ? getTag(traceJSON, "approach") : null;
+    const isPC = pcApproach === "predictive-coding";
+
+    addTag(
+      json,
+      "approach",
+      (isPC ? "predictive-coding" : "trained") as Approach,
+    );
+    if (isPC && traceJSON) {
+      const pcEnergy = getTag(traceJSON, "pc-energy");
+      const pcSteps = getTag(traceJSON, "pc-inference-steps");
+      const pcChanged = getTag(traceJSON, "pc-changed");
+      if (pcEnergy) addTag(json, "pc-energy", pcEnergy);
+      if (pcSteps) addTag(json, "pc-inference-steps", pcSteps);
+      if (pcChanged) addTag(json, "pc-changed", pcChanged);
+    }
+    delete json.memetic;
+    removeTag(json, "approach-logged");
+    addTag(json, "trainID", r.train.ID);
+    addTag(json, "trained", "YES");
+
+    trainedPopulation.push(Creature.fromJSON(json, neat.config.debug));
+    if (r.train.backtracked) {
+      trainedPopulation.push(
+        Creature.fromJSON(r.train.backtracked, neat.config.debug),
+      );
+    }
+    if (r.train.forward) {
+      trainedPopulation.push(
+        Creature.fromJSON(r.train.forward, neat.config.debug),
+      );
+    }
+    const compactJSON = r.train.compact ?? undefined;
+
+    if (compactJSON) {
+      if (neat.config.verbose) {
+        getLogger().info(
+          `Training ${blue(r.train.ID)} compacted`,
+        );
+      }
+
+      // Issue #1913: Preserve PC approach on compact variant too.
+      addTag(
+        compactJSON,
+        "approach",
+        (isPC ? "predictive-coding-compact" : "compact") as Approach,
+      );
+      if (isPC && traceJSON) {
+        const pcEnergy = getTag(traceJSON, "pc-energy");
+        const pcSteps = getTag(traceJSON, "pc-inference-steps");
+        const pcChanged = getTag(traceJSON, "pc-changed");
+        if (pcEnergy) addTag(compactJSON, "pc-energy", pcEnergy);
+        if (pcSteps) addTag(compactJSON, "pc-inference-steps", pcSteps);
+        if (pcChanged) addTag(compactJSON, "pc-changed", pcChanged);
+      }
+      delete compactJSON.memetic;
+      removeTag(compactJSON, "approach-logged");
+      addTag(compactJSON, "trainID", r.train.ID);
+      addTag(compactJSON, "trained", "YES");
+
+      trainedPopulation.push(
+        Creature.fromJSON(compactJSON, neat.config.debug),
+      );
+    }
+
+    // Immediately clear large objects to help GC
+    // @ts-ignore - clearing to help GC
+    r.train.creature = null;
+    // @ts-ignore - clearing to help GC
+    r.train.trace = null;
+    // @ts-ignore - clearing to help GC
+    r.train.compact = null;
+    // @ts-ignore - clearing to help GC
+    r.train.backtracked = null;
+    // @ts-ignore - clearing to help GC
+    r.train.forward = null;
+  }
+  neat.trainingComplete.length = 0;
+
+  // Issue #1020: Process discovery results
+  for (let i = neat.discoveryComplete.length; i--;) {
+    const r = neat.discoveryComplete[i];
+    assert(r.discover, "No discovery found");
+
+    // Issue #1615: Emit discovery_complete event
+    const outcome = r.discover.improvedCreature ? "improved" : "no_change";
+    emitTrainingEvent(neat.config.onTrainingEvent, {
+      kind: "discovery_complete",
+      timestamp: new Date().toISOString(),
+      outcome: outcome as "improved" | "no_change" | "timeout",
+      candidateCount: (r.discover.addHelpfulSynapses?.length ?? 0) +
+        (r.discover.removeHarmfulSynapse ? 1 : 0) +
+        (r.discover.candidateSquashes?.length ?? 0),
+      elapsedMs: r.duration ?? 0,
+    });
+
+    if (r.discover.improvedCreature) {
+      const discoveredCreature = Creature.fromJSON(
+        r.discover.improvedCreature,
+      );
+      CreatureUtil.makeUUID(discoveredCreature);
+
+      validateAfterDiscoveryOrThrow({
+        baseCreature: fittest,
+        discoveredCreature: discoveredCreature,
+        discoveryID: r.discover.ID,
+        operation: "discovered-creature-addition",
+        feedbackLoop: neat.config.feedbackLoop,
+      });
+
+      trainedPopulation.push(discoveredCreature);
+
+      if (neat.config.verbose) {
+        getLogger().info(
+          `[Neat] Added discovered creature ${
+            blue(discoveredCreature.uuid?.substring(0, 8) ?? "unknown")
+          } to population (from discovery ${
+            blue(
+              r.discover.ID.substring(Math.max(0, r.discover.ID.length - 8)),
+            )
+          })`,
+        );
+      }
+    }
+
+    // @ts-ignore - clearing to help GC
+    r.discover.addHelpfulSynapses = null;
+    // @ts-ignore - clearing to help GC
+    r.discover.removeHarmfulSynapse = null;
+    // @ts-ignore - clearing to help GC
+    r.discover.candidateSquashes = null;
+    // @ts-ignore - clearing to help GC
+    r.discover.improvedCreature = null;
+  }
+  neat.discoveryComplete.length = 0;
+
+  // Issue #997: Process completed background replay results
+  const replayResults = neat.discoveryReplayQueue.getCompletedResults();
+  for (const result of replayResults) {
+    logReplaySummary(neat.config, result);
+
+    if (result.improvement?.creature) {
+      const replayedCreature = Creature.fromJSON(
+        result.improvement.creature as Parameters<
+          typeof Creature.fromJSON
+        >[0],
+      );
+      CreatureUtil.makeUUID(replayedCreature);
+
+      addTag(replayedCreature, "approach", "discovery-replay");
+
+      validateAfterDiscoveryOrThrow({
+        baseCreature: fittest,
+        discoveredCreature: replayedCreature,
+        discoveryID: result.improvement.key ?? "replay",
+        operation: "discovery-replay-addition",
+        feedbackLoop: neat.config.feedbackLoop,
+      });
+
+      trainedPopulation.push(replayedCreature);
+
+      if (neat.config.verbose) {
+        getLogger().info(
+          `[Neat] Added replayed creature ${
+            blue(replayedCreature.uuid?.substring(0, 8) ?? "unknown")
+          } to population (score improvement: ${
+            result.improvement.scoreDelta?.toFixed(4) ?? "N/A"
+          })`,
+        );
+      }
+    }
+  }
+  neat.discoveryReplayQueue.clearCompletedResults();
+
+  return trainedPopulation;
+}

--- a/test/NEAT/CpuUtilisation.ts
+++ b/test/NEAT/CpuUtilisation.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the CpuUtilisation module (Issue #2395).
+ *
+ * Exercises `computeOverallCpuUtilisation` and `captureUtilisationSnapshot`
+ * now that they are exposed as named exports of their own module. These
+ * were previously file-private helpers inside NeatEvolution.ts.
+ */
+import { assertEquals } from "@std/assert";
+import {
+  captureUtilisationSnapshot,
+  computeOverallCpuUtilisation,
+} from "@neat/CpuUtilisation.ts";
+import type { WorkerUtilisationSnapshot } from "@config/TrainingEvent.ts";
+import type { WorkerPool } from "@multithreading/WorkerPool.ts";
+
+/** Minimal fake implementing the subset of WorkerPool used by the helper. */
+function fakePool(active: number, total: number): WorkerPool {
+  return {
+    getActiveWorkerCount: () => active,
+    getWorkerCount: () => total,
+  } as unknown as WorkerPool;
+}
+
+Deno.test("computeOverallCpuUtilisation: returns 0 when totalMs is non-positive", () => {
+  assertEquals(computeOverallCpuUtilisation([], 0), 0);
+  assertEquals(computeOverallCpuUtilisation([], -10), 0);
+});
+
+Deno.test("computeOverallCpuUtilisation: weights each phase by its duration", () => {
+  // 100% utilisation over half the generation, 0% over the other half → 50%.
+  const fullyBusy: WorkerUtilisationSnapshot = {
+    fastActive: 4,
+    fastTotal: 4,
+    fastUtilisationPct: 100,
+    heavyActive: 0,
+    heavyTotal: 0,
+    heavyUtilisationPct: 0,
+  };
+  const result = computeOverallCpuUtilisation(
+    [
+      { durationMs: 100, snapshot: fullyBusy },
+      { durationMs: 100 }, // No snapshot → 0% (main thread only)
+    ],
+    200,
+  );
+  assertEquals(result, 50);
+});
+
+Deno.test("computeOverallCpuUtilisation: combines fast and heavy pool workers", () => {
+  // 2 of 4 fast busy + 1 of 2 heavy busy = 3 of 6 = 50%.
+  const partlyBusy: WorkerUtilisationSnapshot = {
+    fastActive: 2,
+    fastTotal: 4,
+    fastUtilisationPct: 50,
+    heavyActive: 1,
+    heavyTotal: 2,
+    heavyUtilisationPct: 50,
+  };
+  const result = computeOverallCpuUtilisation(
+    [{ durationMs: 100, snapshot: partlyBusy }],
+    100,
+  );
+  assertEquals(result, 50);
+});
+
+Deno.test("computeOverallCpuUtilisation: zero-duration phases contribute nothing", () => {
+  const busy: WorkerUtilisationSnapshot = {
+    fastActive: 4,
+    fastTotal: 4,
+    fastUtilisationPct: 100,
+    heavyActive: 0,
+    heavyTotal: 0,
+    heavyUtilisationPct: 0,
+  };
+  const result = computeOverallCpuUtilisation(
+    [
+      { durationMs: 0, snapshot: busy },
+      { durationMs: 100, snapshot: busy },
+    ],
+    100,
+  );
+  assertEquals(result, 100);
+});
+
+Deno.test("computeOverallCpuUtilisation: snapshot with zero workers yields 0", () => {
+  const emptySnapshot: WorkerUtilisationSnapshot = {
+    fastActive: 0,
+    fastTotal: 0,
+    fastUtilisationPct: 0,
+    heavyActive: 0,
+    heavyTotal: 0,
+    heavyUtilisationPct: 0,
+  };
+  const result = computeOverallCpuUtilisation(
+    [{ durationMs: 100, snapshot: emptySnapshot }],
+    100,
+  );
+  assertEquals(result, 0);
+});
+
+Deno.test("captureUtilisationSnapshot: reports fast and heavy utilisation percentages", () => {
+  const snapshot = captureUtilisationSnapshot(
+    fakePool(3, 4),
+    fakePool(1, 2),
+  );
+  assertEquals(snapshot.fastActive, 3);
+  assertEquals(snapshot.fastTotal, 4);
+  assertEquals(snapshot.fastUtilisationPct, 75);
+  assertEquals(snapshot.heavyActive, 1);
+  assertEquals(snapshot.heavyTotal, 2);
+  assertEquals(snapshot.heavyUtilisationPct, 50);
+});
+
+Deno.test("captureUtilisationSnapshot: handles pools with zero workers", () => {
+  const snapshot = captureUtilisationSnapshot(
+    fakePool(0, 0),
+    fakePool(0, 0),
+  );
+  assertEquals(snapshot.fastUtilisationPct, 0);
+  assertEquals(snapshot.heavyUtilisationPct, 0);
+});


### PR DESCRIPTION
## Summary
Split `src/NEAT/NeatEvolution.ts` into three focused modules so the evolution
loop is easier to read and its helpers can be tested in isolation. Closes #2395.

- `src/NEAT/CpuUtilisation.ts` — new module owning
  `captureUtilisationSnapshot` and `computeOverallCpuUtilisation` (Issue #2312
  utilisation helpers).
- `src/NEAT/ProcessCompletedResults.ts` — new module owning
  `processCompletedResults`, the training/discovery/replay drain that
  previously dominated the bottom of `NeatEvolution.ts`.
- `src/NEAT/NeatEvolution.ts` — now imports from the two new modules. `evolve`
  stays put as the top-level orchestrator, as required by the issue. Removed
  imports that only supported the extracted code (`blue`, `format`,
  `removeTag`, `CreatureUtil`, `validateAfterDiscoveryOrThrow`, `Approach`,
  `logReplaySummary`, `WorkerPool`).

No behavioural change — the extracted functions keep their signatures and
call sites.

### File sizes

| File | Before | After |
| --- | --- | --- |
| `src/NEAT/NeatEvolution.ts` | 1141 | 868 |
| `src/NEAT/CpuUtilisation.ts` | — | 75 |
| `src/NEAT/ProcessCompletedResults.ts` | — | 228 |

Note on the `~500` target: the issue acceptance criterion names `~500` lines
for `NeatEvolution.ts` but also requires `evolve` to remain the top-level
orchestrator in the same file. `evolve` itself is ~725 lines and was not in
scope to refactor further, so the 23% reduction here is the full gain
available from the two named extractions. Further reductions would require
splitting `evolve` itself, which is an explicit non-goal of this issue.

## Evidence
Backend refactor with no UI change. Verified via the quality gate:

- `./quality.sh --skip-discovery --skip-wasm` — **6041 passed, 0 failed, 3 ignored**.
- New unit test file `test/NEAT/CpuUtilisation.ts` — **7 passed, 0 failed**.
- Existing `test/NEAT/Evolve.ts` and `test/NEAT/EvolvePhaseTiming.ts` — pass
  unchanged, confirming no behavioural regression in the evolution loop.

## Test Plan
- Added `test/NEAT/CpuUtilisation.ts` with 7 tests exercising
  `computeOverallCpuUtilisation` (weighting, zero-duration phases, empty
  pools, non-positive total) and `captureUtilisationSnapshot` (pct
  calculation, zero-worker pools). These helpers previously had no direct
  coverage because they were file-private inside `NeatEvolution.ts`.
- All existing `test/NEAT/*` evolve tests continue to pass without
  modification.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2395 -->