### PR TITLE
docs(readme): add Related Repositories section (#2402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,47 @@ For detailed documentation, see the [docs/](./docs/) directory:
 - **[Discovery Architecture](./docs/DISCOVERY_ARCHITECTURE.md)**: Internal
   discovery pipeline architecture
 
+## 🌐 Related Repositories
+
+NEAT-AI is the primary Deno/TypeScript library at the centre of a small family
+of repositories. Each repo has a focused role; together they form the full
+training, discovery, scoring, visualisation, and example surface.
+
+| Repository                                                                 | Role                                                                                                                                     |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **[NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI)** (this repo)         | Deno/TypeScript NEAT library — the main library that orchestrates evolution, training, discovery, breeding, and serialisation.           |
+| **[NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core)**           | Shared Rust computation crate (`neat-core`) consumed by NEAT-AI as vendored WASM in `wasm_activation/pkg`, pinned by SHA in `deno.json`. |
+| **[NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery)** | Rust FFI extension providing GPU-accelerated structural analysis; called from NEAT-AI via Deno FFI by `discoveryDir()`.                  |
+| **[NEAT-AI-Snapshot](https://github.com/stSoftwareAU/NEAT-AI-Snapshot)**   | Snapshot artefacts produced by NEAT-AI training/discovery runs and shared between machines for distributed evolution.                    |
+| **[NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer)**       | Rust scoring application; depends on NEAT-AI-core via a path dependency and must pin the same core revision as NEAT-AI.                  |
+| **[NEAT-AI-Explore](https://github.com/stSoftwareAU/NEAT-AI-Explore)**     | TypeScript visualisation tool that consumes NEAT-AI-Snapshot data to inspect creature topology and behaviour.                            |
+| **[NEAT-AI-Examples](https://github.com/stSoftwareAU/NEAT-AI-Examples)**   | TypeScript example projects showing how to use NEAT-AI for real tasks.                                                                   |
+
+### Dependency graph
+
+```mermaid
+flowchart LR
+  core["NEAT-AI-core<br/>(Rust crate)"]
+  discovery["NEAT-AI-Discovery<br/>(Rust FFI)"]
+  neat["NEAT-AI<br/>(Deno/TypeScript)"]
+  snapshot["NEAT-AI-Snapshot<br/>(snapshot data)"]
+  scorer["NEAT-AI-scorer<br/>(Rust app)"]
+  explore["NEAT-AI-Explore<br/>(TypeScript UI)"]
+  examples["NEAT-AI-Examples<br/>(TypeScript)"]
+
+  core -- "vendored WASM (pinned rev)" --> neat
+  core -- "path dependency" --> scorer
+  discovery -- "Deno FFI" --> neat
+  neat -- "produces snapshots" --> snapshot
+  snapshot -- "consumed by" --> explore
+  neat -- "used by" --> examples
+```
+
+> [!NOTE]
+> NEAT-AI and NEAT-AI-scorer must pin the **same** NEAT-AI-core revision. See
+> [docs/CORE_DEPENDENCY_POLICY.md](./docs/CORE_DEPENDENCY_POLICY.md) for the
+> rev-pinning and semver policy.
+
 ## 🤝 Contributions
 
 Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2402.md
+++ b/docs/pr-summary-2402.md
@@ -1,9 +1,9 @@
 ## Summary
 
-Added a `## 🌐 Related Repositories` section to `README.md` that lists all
-seven public NEAT-AI-* repositories with one-line descriptions and includes a
-Mermaid dependency diagram framed from NEAT-AI's perspective. The block follows
-the canonical structure described in stSoftwareAU/NEAT-AI-core#18 (all 7 repos,
+Added a `## 🌐 Related Repositories` section to `README.md` that lists all seven
+public NEAT-AI-* repositories with one-line descriptions and includes a Mermaid
+dependency diagram framed from NEAT-AI's perspective. The block follows the
+canonical structure described in stSoftwareAU/NEAT-AI-core#18 (all 7 repos,
 brief role descriptions, dependency-direction notes, and a Mermaid graph).
 Closes #2402.
 
@@ -11,9 +11,9 @@ Closes #2402.
 
 This is a documentation-only change. No code, types, or tests are affected.
 
-- `./quality.sh --lint-only < /dev/null` — passes (formatting + linting +
-  bash check). The new section was reformatted by `deno fmt` to align table
-  columns; structure and content are unchanged.
+- `./quality.sh --lint-only < /dev/null` — passes (formatting + linting + bash
+  check). The new section was reformatted by `deno fmt` to align table columns;
+  structure and content are unchanged.
 - README rendered correctly: section placed between `## 📚 Documentation` and
   `## 🤝 Contributions`, consistent with the existing top-level structure.
 

--- a/docs/pr-summary-2402.md
+++ b/docs/pr-summary-2402.md
@@ -1,0 +1,35 @@
+## Summary
+
+Added a `## 🌐 Related Repositories` section to `README.md` that lists all
+seven public NEAT-AI-* repositories with one-line descriptions and includes a
+Mermaid dependency diagram framed from NEAT-AI's perspective. The block follows
+the canonical structure described in stSoftwareAU/NEAT-AI-core#18 (all 7 repos,
+brief role descriptions, dependency-direction notes, and a Mermaid graph).
+Closes #2402.
+
+## Evidence
+
+This is a documentation-only change. No code, types, or tests are affected.
+
+- `./quality.sh --lint-only < /dev/null` — passes (formatting + linting +
+  bash check). The new section was reformatted by `deno fmt` to align table
+  columns; structure and content are unchanged.
+- README rendered correctly: section placed between `## 📚 Documentation` and
+  `## 🤝 Contributions`, consistent with the existing top-level structure.
+
+## Test Plan
+
+- [x] `deno fmt` clean.
+- [x] `deno lint` clean.
+- [x] `bash` syntax check clean.
+- [x] All 7 repo links use the canonical `stSoftwareAU/<repo>` URLs.
+- [x] Mermaid block uses `flowchart LR` and renders the dependency arrows
+      described in NEAT-AI-core#18.
+- [x] No code changes — type-check and unit tests are unaffected by this PR.
+
+## Acceptance Criteria
+
+- [x] README gains a `## Related Repositories` section listing all 7 public
+      NEAT-AI-* repos with one-line descriptions and links.
+- [x] Section includes a Mermaid dependency diagram.
+- [x] Quality gate (lint/format/bash check) still passes.


### PR DESCRIPTION
## Summary

Added a `## 🌐 Related Repositories` section to `README.md` that lists all
seven public NEAT-AI-* repositories with one-line descriptions and includes a
Mermaid dependency diagram framed from NEAT-AI's perspective. The block follows
the canonical structure described in stSoftwareAU/NEAT-AI-core#18 (all 7 repos,
brief role descriptions, dependency-direction notes, and a Mermaid graph).
Closes #2402.

## Evidence

This is a documentation-only change. No code, types, or tests are affected.

- `./quality.sh --lint-only < /dev/null` — passes (formatting + linting +
  bash check). The new section was reformatted by `deno fmt` to align table
  columns; structure and content are unchanged.
- README rendered correctly: section placed between `## 📚 Documentation` and
  `## 🤝 Contributions`, consistent with the existing top-level structure.

## Test Plan

- [x] `deno fmt` clean.
- [x] `deno lint` clean.
- [x] `bash` syntax check clean.
- [x] All 7 repo links use the canonical `stSoftwareAU/<repo>` URLs.
- [x] Mermaid block uses `flowchart LR` and renders the dependency arrows
      described in NEAT-AI-core#18.
- [x] No code changes — type-check and unit tests are unaffected by this PR.

## Acceptance Criteria

- [x] README gains a `## Related Repositories` section listing all 7 public
      NEAT-AI-* repos with one-line descriptions and links.
- [x] Section includes a Mermaid dependency diagram.
- [x] Quality gate (lint/format/bash check) still passes.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2402 -->