### PR TITLE
Bridge: harden RustScorerBridge env, paths, diagnostics (#2410)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2410.md
+++ b/docs/pr-summary-2410.md
@@ -1,0 +1,52 @@
+## Summary
+
+Harden `src/score/RustScorerBridge.ts` so the external `rust_scorer` binary is
+invoked reliably from Deno and failures are diagnosable. Closes #2410.
+
+Three behaviours changed:
+
+1. **Subprocess environment.** The bridge no longer passes `env: {}` to
+   `Deno.Command`, which left the child with an empty environment and broke
+   PATH-resolved binaries. When no overrides are configured the `env` option
+   is omitted entirely so the child inherits the parent environment. When
+   `NEAT_AI_RUST_SCORER_ENV` overrides exist, they are merged over
+   `Deno.env.toObject()` rather than replacing it.
+2. **Absolute paths.** The temp creature file path and `dataDir` are both
+   resolved against `Deno.cwd()` before being handed to `rust_scorer`, so
+   relative callers (e.g. `.trainData-binary_115`) work even when the child
+   process runs with a different cwd.
+3. **Diagnostics.** On non-zero exit or non-JSON stdout, the warning line now
+   includes a trimmed `stderr` (and `stdout` for parse failures) so operators
+   can see messages like `Error: …` from the Rust CLI instead of only
+   `exit 1`. Parsing is wrapped in `try/catch` so invalid stdout no longer
+   throws — the scorer gracefully falls back to WASM scoring.
+
+## Evidence
+
+Backend-only change. Verified via unit tests in
+`test/score/RustScorerBridgeHardening.ts`:
+
+- `inherits parent env when no overrides configured` — runner receives
+  `env: undefined` so the child inherits the parent env.
+- `merges overrides with parent env when overrides exist` — runner receives
+  a merged map containing a parent-set sentinel plus the override.
+- `resolves creature and data paths to absolute paths` — both args passed to
+  the runner satisfy `isAbsolute()` even when `dataDir` is supplied relative.
+- `logs trimmed stderr on non-zero exit` — warn line includes the stderr
+  snippet.
+- `handles non-JSON stdout gracefully and includes stderr in warning` — no
+  throw, warn line records the parse failure, result falls back to WASM.
+
+Full suite green via `./quality.sh --skip-discovery --skip-wasm`:
+`6148 passed | 0 failed | 3 ignored`.
+
+## Test Plan
+
+- [x] Added `test/score/RustScorerBridgeHardening.ts` with five new tests
+  covering env inheritance, env merging, absolute-path resolution, stderr
+  trimming on failure, and graceful handling of non-JSON stdout.
+- [x] Existing `test/score/RustScorerIntegration.ts` tests continue to pass
+  unchanged — the CommandRunner `env` option is now optional but compatible
+  with existing call sites.
+- [x] `./quality.sh --skip-discovery --skip-wasm` runs fmt, lint, type-check,
+  and the full parallel test suite cleanly.

--- a/docs/pr-summary-2410.md
+++ b/docs/pr-summary-2410.md
@@ -7,8 +7,8 @@ Three behaviours changed:
 
 1. **Subprocess environment.** The bridge no longer passes `env: {}` to
    `Deno.Command`, which left the child with an empty environment and broke
-   PATH-resolved binaries. When no overrides are configured the `env` option
-   is omitted entirely so the child inherits the parent environment. When
+   PATH-resolved binaries. When no overrides are configured the `env` option is
+   omitted entirely so the child inherits the parent environment. When
    `NEAT_AI_RUST_SCORER_ENV` overrides exist, they are merged over
    `Deno.env.toObject()` rather than replacing it.
 2. **Absolute paths.** The temp creature file path and `dataDir` are both
@@ -17,9 +17,9 @@ Three behaviours changed:
    process runs with a different cwd.
 3. **Diagnostics.** On non-zero exit or non-JSON stdout, the warning line now
    includes a trimmed `stderr` (and `stdout` for parse failures) so operators
-   can see messages like `Error: …` from the Rust CLI instead of only
-   `exit 1`. Parsing is wrapped in `try/catch` so invalid stdout no longer
-   throws — the scorer gracefully falls back to WASM scoring.
+   can see messages like `Error: …` from the Rust CLI instead of only `exit 1`.
+   Parsing is wrapped in `try/catch` so invalid stdout no longer throws — the
+   scorer gracefully falls back to WASM scoring.
 
 ## Evidence
 
@@ -28,10 +28,10 @@ Backend-only change. Verified via unit tests in
 
 - `inherits parent env when no overrides configured` — runner receives
   `env: undefined` so the child inherits the parent env.
-- `merges overrides with parent env when overrides exist` — runner receives
-  a merged map containing a parent-set sentinel plus the override.
-- `resolves creature and data paths to absolute paths` — both args passed to
-  the runner satisfy `isAbsolute()` even when `dataDir` is supplied relative.
+- `merges overrides with parent env when overrides exist` — runner receives a
+  merged map containing a parent-set sentinel plus the override.
+- `resolves creature and data paths to absolute paths` — both args passed to the
+  runner satisfy `isAbsolute()` even when `dataDir` is supplied relative.
 - `logs trimmed stderr on non-zero exit` — warn line includes the stderr
   snippet.
 - `handles non-JSON stdout gracefully and includes stderr in warning` — no
@@ -43,10 +43,10 @@ Full suite green via `./quality.sh --skip-discovery --skip-wasm`:
 ## Test Plan
 
 - [x] Added `test/score/RustScorerBridgeHardening.ts` with five new tests
-  covering env inheritance, env merging, absolute-path resolution, stderr
-  trimming on failure, and graceful handling of non-JSON stdout.
+      covering env inheritance, env merging, absolute-path resolution, stderr
+      trimming on failure, and graceful handling of non-JSON stdout.
 - [x] Existing `test/score/RustScorerIntegration.ts` tests continue to pass
-  unchanged — the CommandRunner `env` option is now optional but compatible
-  with existing call sites.
+      unchanged — the CommandRunner `env` option is now optional but compatible
+      with existing call sites.
 - [x] `./quality.sh --skip-discovery --skip-wasm` runs fmt, lint, type-check,
-  and the full parallel test suite cleanly.
+      and the full parallel test suite cleanly.

--- a/src/score/RustScorerBridge.ts
+++ b/src/score/RustScorerBridge.ts
@@ -1,4 +1,4 @@
-import { join } from "@std/path";
+import { join, resolve } from "@std/path";
 import type { Creature } from "@creature";
 import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
 import { getLogger } from "@utils/Logger.ts";
@@ -17,7 +17,13 @@ type CommandRunner = (
   command: string,
   args: string[],
   options: {
-    env: Record<string, string>;
+    /**
+     * Environment variables to pass to the child process. When `undefined`,
+     * the child inherits the parent process environment. When provided, the
+     * mapping is passed verbatim to `Deno.Command` (callers are responsible
+     * for merging parent env if they want inheritance plus overrides).
+     */
+    env?: Record<string, string>;
     timeoutMs: number;
   },
 ) => Promise<{
@@ -30,6 +36,9 @@ type CommandRunner = (
 const probeCache = new Map<string, RustScorerProbeState>();
 
 let envRustScorerCache: RequiredRustScorerConfig | undefined;
+
+/** Maximum characters of stdout/stderr preserved in a warning log line. */
+const LOG_TRIM_LIMIT = 2000;
 
 function readEnvString(key: string): string | undefined {
   try {
@@ -56,6 +65,18 @@ function parseEnvTimeoutMs(): number {
   if (raw === undefined) return 0;
   const n = Number(raw);
   return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
+}
+
+/**
+ * Trim untrusted child-process output for safe inclusion in a log line.
+ * Collapses whitespace and caps total length so large diagnostics do not
+ * overwhelm the log.
+ */
+function trimForLog(value: string, limit: number = LOG_TRIM_LIMIT): string {
+  if (!value) return "";
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= limit) return collapsed;
+  return collapsed.slice(0, limit) + "…";
 }
 
 /**
@@ -90,11 +111,33 @@ function getEnvRustScorerConfig(): RequiredRustScorerConfig {
   return envRustScorerCache;
 }
 
+/**
+ * Build the env argument for a child process call.
+ *
+ * Returns `undefined` when no overrides are configured so the child inherits
+ * the parent environment verbatim (avoids the `env: {}` foot-gun where the
+ * child gets an empty environment). When overrides exist, merges them over
+ * the parent env snapshot.
+ */
+function buildChildEnv(
+  overrides: Record<string, string>,
+): Record<string, string> | undefined {
+  const keys = Object.keys(overrides);
+  if (keys.length === 0) return undefined;
+  let parent: Record<string, string> = {};
+  try {
+    parent = Deno.env.toObject();
+  } catch {
+    // Fall through with an empty parent snapshot; overrides still applied.
+  }
+  return { ...parent, ...overrides };
+}
+
 async function defaultRunner(
   command: string,
   args: string[],
   options: {
-    env: Record<string, string>;
+    env?: Record<string, string>;
     timeoutMs: number;
   },
 ): Promise<{
@@ -103,12 +146,12 @@ async function defaultRunner(
   stdout: string;
   stderr: string;
 }> {
-  const cmd = new Deno.Command(command, {
-    args,
-    env: options.env,
-    stdout: "piped",
-    stderr: "piped",
-  });
+  // Omit `env` from Deno.Command when the caller did not provide overrides so
+  // the child inherits the full parent environment (PATH, HOME, locale, etc.).
+  const cmdOptions: Deno.CommandOptions = options.env !== undefined
+    ? { args, env: options.env, stdout: "piped", stderr: "piped" }
+    : { args, stdout: "piped", stderr: "piped" };
+  const cmd = new Deno.Command(command, cmdOptions);
 
   const output = options.timeoutMs > 0
     ? await Promise.race([
@@ -180,7 +223,7 @@ async function resolveProbeState(
   let available = false;
   try {
     const probe = await runCommand(config.binaryPath, ["--help"], {
-      env: config.env,
+      env: buildChildEnv(config.env),
       timeoutMs: config.timeoutMs,
     });
     available = probe.success || probe.code === 0 || probe.code === 1;
@@ -208,7 +251,9 @@ async function writeCreatureTempFile(
     // Ensure explicit scorer temp dirs are created in worker contexts.
     await Deno.mkdir(baseDir, { recursive: true });
     await Deno.writeTextFile(tmpPath, JSON.stringify(creature.exportJSON()));
-    return tmpPath;
+    // Return an absolute path so callers can hand it to subprocesses that may
+    // run with a different cwd (e.g. worker pools).
+    return resolve(Deno.cwd(), tmpPath);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     const perm = await getWritePermissionDiagnostics(baseDir);
@@ -233,31 +278,66 @@ export async function tryScoreWithRustScorer(
   try {
     const tmpDir = readEnvString("NEAT_AI_RUST_SCORER_TMP_DIR") ?? dataDir;
     creaturePath = await writeCreatureTempFile(creature, tmpDir);
+    // rust_scorer resolves relative paths against its own process cwd, which
+    // may not match the Deno/worker cwd. Always hand it absolute paths.
+    const absoluteDataDir = resolve(Deno.cwd(), dataDir);
     const result = await runCommand(
       config.binaryPath,
-      [creaturePath, dataDir],
+      [creaturePath, absoluteDataDir],
       {
-        env: config.env,
+        env: buildChildEnv(config.env),
         timeoutMs: config.timeoutMs,
       },
     );
 
     if (!result.success) {
       if (!probe.warned) {
+        const stderrSnippet = trimForLog(result.stderr);
+        const suffix = stderrSnippet.length > 0
+          ? `; stderr: ${stderrSnippet}`
+          : "";
         getLogger().warn(
-          `[NEAT-AI] Rust scorer call failed (exit ${result.code}); falling back to WASM scoring.`,
+          `[NEAT-AI] Rust scorer call failed (exit ${result.code})${suffix}; falling back to WASM scoring.`,
         );
         probe.warned = true;
       }
       return undefined;
     }
 
-    const parsed = JSON.parse(result.stdout) as { error?: unknown };
+    let parsed: { error?: unknown };
+    try {
+      parsed = JSON.parse(result.stdout) as { error?: unknown };
+    } catch (parseError) {
+      if (!probe.warned) {
+        const stdoutSnippet = trimForLog(result.stdout);
+        const stderrSnippet = trimForLog(result.stderr);
+        const detail = parseError instanceof Error
+          ? parseError.message
+          : String(parseError);
+        const parts = [
+          `parse error: ${detail}`,
+          stdoutSnippet.length > 0 ? `stdout: ${stdoutSnippet}` : "",
+          stderrSnippet.length > 0 ? `stderr: ${stderrSnippet}` : "",
+        ].filter((p) => p.length > 0);
+        getLogger().warn(
+          `[NEAT-AI] Rust scorer returned invalid (non-JSON) output; ${
+            parts.join("; ")
+          }; falling back to WASM scoring.`,
+        );
+        probe.warned = true;
+      }
+      return undefined;
+    }
+
     const error = Number(parsed.error);
     if (!Number.isFinite(error)) {
       if (!probe.warned) {
+        const stderrSnippet = trimForLog(result.stderr);
+        const suffix = stderrSnippet.length > 0
+          ? `; stderr: ${stderrSnippet}`
+          : "";
         getLogger().warn(
-          "[NEAT-AI] Rust scorer returned invalid error; falling back to WASM scoring.",
+          `[NEAT-AI] Rust scorer returned invalid error${suffix}; falling back to WASM scoring.`,
         );
         probe.warned = true;
       }

--- a/test/score/RustScorerBridgeHardening.ts
+++ b/test/score/RustScorerBridgeHardening.ts
@@ -1,0 +1,326 @@
+import { assert, assertEquals } from "@std/assert";
+import { isAbsolute } from "@std/path";
+import { Creature } from "@creature";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import { Costs } from "@costs";
+import {
+  __resetRustScorerBridgeForTests,
+  __setRustScorerRunnerForTests,
+} from "../../src/score/RustScorerBridge.ts";
+import {
+  createConsoleLogger,
+  getLogger,
+  type Logger,
+  setLogger,
+} from "@utils/Logger.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+function captureWarnings(): { warnings: string[]; restore: () => void } {
+  const warnings: string[] = [];
+  const previous = getLogger();
+  const capturing: Logger = {
+    debug: () => {},
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(" "));
+    },
+    error: () => {},
+  };
+  setLogger(capturing);
+  return {
+    warnings,
+    restore: () => setLogger(previous ?? createConsoleLogger("info")),
+  };
+}
+
+function buildDataSet(): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < 24; i++) {
+    const a = i / 24;
+    const b = (24 - i) / 24;
+    rows.push({
+      input: new Float32Array([a, b]),
+      output: new Float32Array([a > b ? 1 : -1]),
+    });
+  }
+  return rows;
+}
+
+Deno.test("RustScorerBridge: inherits parent env when no overrides configured", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let scoreEnv: Record<string, string> | undefined = { SENTINEL: "unset" };
+  __setRustScorerRunnerForTests((_command, args, options) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    scoreEnv = options.env;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: '{"error":0.1}',
+      stderr: "",
+    });
+  });
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 24);
+  try {
+    await creature.evaluateDir(
+      dataDir,
+      Costs.find("MSE"),
+      false,
+      undefined,
+      undefined,
+      {
+        enabled: true,
+        binaryPath: "rust_scorer",
+        timeoutMs: 0,
+        env: {},
+      },
+    );
+    // env should be undefined when no overrides exist → child inherits parent env.
+    assertEquals(
+      scoreEnv,
+      undefined,
+      "runner should be invoked without env when no overrides are provided",
+    );
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("RustScorerBridge: merges overrides with parent env when overrides exist", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  const sentinelKey = "NEAT_AI_RUST_SCORER_TEST_PARENT_SENTINEL";
+  Deno.env.set(sentinelKey, "present");
+
+  let scoreEnv: Record<string, string> | undefined;
+  __setRustScorerRunnerForTests((_command, args, options) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    scoreEnv = options.env;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: '{"error":0.1}',
+      stderr: "",
+    });
+  });
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 24);
+  try {
+    await creature.evaluateDir(
+      dataDir,
+      Costs.find("MSE"),
+      false,
+      undefined,
+      undefined,
+      {
+        enabled: true,
+        binaryPath: "rust_scorer",
+        timeoutMs: 0,
+        env: { OVERRIDE_KEY: "override_value" },
+      },
+    );
+    assert(scoreEnv !== undefined, "runner should receive merged env");
+    assertEquals(scoreEnv!.OVERRIDE_KEY, "override_value");
+    assertEquals(
+      scoreEnv![sentinelKey],
+      "present",
+      "merged env should include the parent process env",
+    );
+  } finally {
+    Deno.env.delete(sentinelKey);
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("RustScorerBridge: resolves creature and data paths to absolute paths", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let seenArgs: string[] = [];
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    seenArgs = args;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: '{"error":0.5}',
+      stderr: "",
+    });
+  });
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  // makeDataDir returns an absolute path - make a relative alias for the test.
+  const dataDir = makeDataDir(buildDataSet(), 24);
+  const cwd = Deno.cwd();
+  const relative = dataDir.startsWith(cwd + "/")
+    ? dataDir.slice(cwd.length + 1)
+    : dataDir;
+  try {
+    await creature.evaluateDir(
+      relative,
+      Costs.find("MSE"),
+      false,
+      undefined,
+      undefined,
+      {
+        enabled: true,
+        binaryPath: "rust_scorer",
+        timeoutMs: 0,
+        env: {},
+      },
+    );
+    assertEquals(seenArgs.length, 2);
+    assert(
+      isAbsolute(seenArgs[0]),
+      `creature path should be absolute; got ${seenArgs[0]}`,
+    );
+    assert(
+      isAbsolute(seenArgs[1]),
+      `data dir should be absolute; got ${seenArgs[1]}`,
+    );
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("RustScorerBridge: logs trimmed stderr on non-zero exit", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    return Promise.resolve({
+      success: false,
+      code: 2,
+      stdout: "",
+      stderr: "Error: synthetic scorer failure for test",
+    });
+  });
+
+  const { warnings, restore } = captureWarnings();
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 24);
+  try {
+    await creature.evaluateDir(
+      dataDir,
+      Costs.find("MSE"),
+      false,
+      undefined,
+      undefined,
+      {
+        enabled: true,
+        binaryPath: "rust_scorer",
+        timeoutMs: 0,
+        env: {},
+      },
+    );
+    const failureWarning = warnings.find((w) =>
+      w.includes("Rust scorer call failed")
+    );
+    assert(
+      failureWarning !== undefined,
+      "warn log should include failure message",
+    );
+    assert(
+      failureWarning!.includes("synthetic scorer failure for test"),
+      `warn should contain trimmed stderr; got: ${failureWarning}`,
+    );
+  } finally {
+    restore();
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("RustScorerBridge: handles non-JSON stdout gracefully and includes stderr in warning", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: "not valid json at all",
+      stderr: "Warning: deprecated flag",
+    });
+  });
+
+  const { warnings, restore } = captureWarnings();
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 24);
+  try {
+    // Must not throw - should fall back to WASM scoring.
+    const result = await creature.evaluateDir(
+      dataDir,
+      Costs.find("MSE"),
+      false,
+      undefined,
+      undefined,
+      {
+        enabled: true,
+        binaryPath: "rust_scorer",
+        timeoutMs: 0,
+        env: {},
+      },
+    );
+    assert(Number.isFinite(result.error));
+    const parseWarning = warnings.find((w) =>
+      w.includes("Rust scorer") && w.includes("invalid")
+    );
+    assert(
+      parseWarning !== undefined,
+      `should warn on invalid stdout; got warnings: ${warnings.join("\n")}`,
+    );
+  } finally {
+    restore();
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});


### PR DESCRIPTION
## Summary

Harden `src/score/RustScorerBridge.ts` so the external `rust_scorer` binary is
invoked reliably from Deno and failures are diagnosable. Closes #2410.

Three behaviours changed:

1. **Subprocess environment.** The bridge no longer passes `env: {}` to
   `Deno.Command`, which left the child with an empty environment and broke
   PATH-resolved binaries. When no overrides are configured the `env` option
   is omitted entirely so the child inherits the parent environment. When
   `NEAT_AI_RUST_SCORER_ENV` overrides exist, they are merged over
   `Deno.env.toObject()` rather than replacing it.
2. **Absolute paths.** The temp creature file path and `dataDir` are both
   resolved against `Deno.cwd()` before being handed to `rust_scorer`, so
   relative callers (e.g. `.trainData-binary_115`) work even when the child
   process runs with a different cwd.
3. **Diagnostics.** On non-zero exit or non-JSON stdout, the warning line now
   includes a trimmed `stderr` (and `stdout` for parse failures) so operators
   can see messages like `Error: …` from the Rust CLI instead of only
   `exit 1`. Parsing is wrapped in `try/catch` so invalid stdout no longer
   throws — the scorer gracefully falls back to WASM scoring.

## Evidence

Backend-only change. Verified via unit tests in
`test/score/RustScorerBridgeHardening.ts`:

- `inherits parent env when no overrides configured` — runner receives
  `env: undefined` so the child inherits the parent env.
- `merges overrides with parent env when overrides exist` — runner receives
  a merged map containing a parent-set sentinel plus the override.
- `resolves creature and data paths to absolute paths` — both args passed to
  the runner satisfy `isAbsolute()` even when `dataDir` is supplied relative.
- `logs trimmed stderr on non-zero exit` — warn line includes the stderr
  snippet.
- `handles non-JSON stdout gracefully and includes stderr in warning` — no
  throw, warn line records the parse failure, result falls back to WASM.

Full suite green via `./quality.sh --skip-discovery --skip-wasm`:
`6148 passed | 0 failed | 3 ignored`.

## Test Plan

- [x] Added `test/score/RustScorerBridgeHardening.ts` with five new tests
  covering env inheritance, env merging, absolute-path resolution, stderr
  trimming on failure, and graceful handling of non-JSON stdout.
- [x] Existing `test/score/RustScorerIntegration.ts` tests continue to pass
  unchanged — the CommandRunner `env` option is now optional but compatible
  with existing call sites.
- [x] `./quality.sh --skip-discovery --skip-wasm` runs fmt, lint, type-check,
  and the full parallel test suite cleanly.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2410 -->