### PR TITLE
Refactor: replace 32 @ts-ignore GC-cleanup directives with typed ReleasableRef helper (#2398)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2398.md
+++ b/docs/pr-summary-2398.md
@@ -1,21 +1,19 @@
 ## Summary
 
-Replaced the 32 scattered `// @ts-ignore - clearing to help GC` directives
-with a centralised, typed helper `clearForGc()` (plus companion
-`isReleased()`) exported from `src/utils/ReleasableRef.ts`. The helper
-expresses the GC-hint intent at the call site, contains no `any` casts,
-and a regression test ensures the unsafe pattern cannot reappear.
-Closes #2398.
+Replaced the 32 scattered `// @ts-ignore - clearing to help GC` directives with
+a centralised, typed helper `clearForGc()` (plus companion `isReleased()`)
+exported from `src/utils/ReleasableRef.ts`. The helper expresses the GC-hint
+intent at the call site, contains no `any` casts, and a regression test ensures
+the unsafe pattern cannot reappear. Closes #2398.
 
 ## Changes
 
-- **New helper**: `src/utils/ReleasableRef.ts` exposes
-  `clearForGc(host, key)` and `isReleased(host, key)`. The helpers use
-  `Reflect.set`/`Reflect.get` to avoid `any` casts; the key type
-  (`keyof T | (string & {})`) surfaces autocomplete for declared keys
-  while still accepting any string so the helper works on `this` inside
-  class methods (where polymorphic `keyof this` hides protected/private
-  fields).
+- **New helper**: `src/utils/ReleasableRef.ts` exposes `clearForGc(host, key)`
+  and `isReleased(host, key)`. The helpers use `Reflect.set`/`Reflect.get` to
+  avoid `any` casts; the key type (`keyof T | (string & {})`) surfaces
+  autocomplete for declared keys while still accepting any string so the helper
+  works on `this` inside class methods (where polymorphic `keyof this` hides
+  protected/private fields).
 
 - **Directive replacements (32 sites, 7 files)**:
   - `src/multithreading/workers/MockWorker.ts` — 1
@@ -23,16 +21,16 @@ Closes #2398.
   - `src/multithreading/workers/WorkerProcessor.ts` — 12
   - `src/NEAT/ProcessCompletedResults.ts` — 9
   - `src/intelligentDesign/workers/MockWorker.ts` — 1
-  - `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts` — 3
-  - `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts` — 1
+  - `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts` —
+    3
+  - `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts`
+    — 1
 
-- **Test site replacement**:
-  `test/multithreading/WorkerDirectObjectPassing.ts` also used the
-  pattern to simulate GC behaviour; updated to call `clearForGc`.
+- **Test site replacement**: `test/multithreading/WorkerDirectObjectPassing.ts`
+  also used the pattern to simulate GC behaviour; updated to call `clearForGc`.
 
-- **Regression guard**: `test/utils/ReleasableRef.ts` includes a test
-  that scans `src/` and fails if any `// @ts-ignore - clearing` directive
-  reappears.
+- **Regression guard**: `test/utils/ReleasableRef.ts` includes a test that scans
+  `src/` and fails if any `// @ts-ignore - clearing` directive reappears.
 
 ## Evidence
 
@@ -42,12 +40,12 @@ Backend/library change — no UI to screenshot. Verified via:
 - `deno fmt` + `deno lint --fix` clean (`./quality.sh --lint-only`).
 - 7 new unit tests in `test/utils/ReleasableRef.ts` (all pass).
 - Impacted test suites pass in full:
-  - `test/multithreading/` + `test/utils/` + `test/intelligentDesign/`
-    — 217 passed, 0 failed.
-  - `test/NEAT/` + `test/architecture/ErrorGuidedStructuralEvolution/`
-    — 649 passed, 0 failed.
-- Regression test confirms zero `@ts-ignore - clearing` directives
-  remain in `src/`.
+  - `test/multithreading/` + `test/utils/` + `test/intelligentDesign/` — 217
+    passed, 0 failed.
+  - `test/NEAT/` + `test/architecture/ErrorGuidedStructuralEvolution/` — 649
+    passed, 0 failed.
+- Regression test confirms zero `@ts-ignore - clearing` directives remain in
+  `src/`.
 
 ## Test Plan
 
@@ -58,8 +56,7 @@ Backend/library change — no UI to screenshot. Verified via:
   - `clearForGc - leaves sibling fields untouched`
   - `clearForGc - happy-path round-trip (set, clear, set)`
   - `clearForGc - works on nested objects (clears one level)`
-  - `no @ts-ignore GC-cleanup directives remain in src/` (regression
-    guard)
-- Existing `test/multithreading/WorkerDirectObjectPassing.ts` updated
-  to use `clearForGc`; its "GC cleanup uses null instead of empty
-  string" test still verifies the observable behaviour.
+  - `no @ts-ignore GC-cleanup directives remain in src/` (regression guard)
+- Existing `test/multithreading/WorkerDirectObjectPassing.ts` updated to use
+  `clearForGc`; its "GC cleanup uses null instead of empty string" test still
+  verifies the observable behaviour.

--- a/docs/pr-summary-2398.md
+++ b/docs/pr-summary-2398.md
@@ -1,0 +1,65 @@
+## Summary
+
+Replaced the 32 scattered `// @ts-ignore - clearing to help GC` directives
+with a centralised, typed helper `clearForGc()` (plus companion
+`isReleased()`) exported from `src/utils/ReleasableRef.ts`. The helper
+expresses the GC-hint intent at the call site, contains no `any` casts,
+and a regression test ensures the unsafe pattern cannot reappear.
+Closes #2398.
+
+## Changes
+
+- **New helper**: `src/utils/ReleasableRef.ts` exposes
+  `clearForGc(host, key)` and `isReleased(host, key)`. The helpers use
+  `Reflect.set`/`Reflect.get` to avoid `any` casts; the key type
+  (`keyof T | (string & {})`) surfaces autocomplete for declared keys
+  while still accepting any string so the helper works on `this` inside
+  class methods (where polymorphic `keyof this` hides protected/private
+  fields).
+
+- **Directive replacements (32 sites, 7 files)**:
+  - `src/multithreading/workers/MockWorker.ts` — 1
+  - `src/multithreading/workers/WorkerHandler.ts` — 5
+  - `src/multithreading/workers/WorkerProcessor.ts` — 12
+  - `src/NEAT/ProcessCompletedResults.ts` — 9
+  - `src/intelligentDesign/workers/MockWorker.ts` — 1
+  - `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts` — 3
+  - `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts` — 1
+
+- **Test site replacement**:
+  `test/multithreading/WorkerDirectObjectPassing.ts` also used the
+  pattern to simulate GC behaviour; updated to call `clearForGc`.
+
+- **Regression guard**: `test/utils/ReleasableRef.ts` includes a test
+  that scans `src/` and fails if any `// @ts-ignore - clearing` directive
+  reappears.
+
+## Evidence
+
+Backend/library change — no UI to screenshot. Verified via:
+
+- `deno check` passes (`./quality.sh --check-only`, exit 0).
+- `deno fmt` + `deno lint --fix` clean (`./quality.sh --lint-only`).
+- 7 new unit tests in `test/utils/ReleasableRef.ts` (all pass).
+- Impacted test suites pass in full:
+  - `test/multithreading/` + `test/utils/` + `test/intelligentDesign/`
+    — 217 passed, 0 failed.
+  - `test/NEAT/` + `test/architecture/ErrorGuidedStructuralEvolution/`
+    — 649 passed, 0 failed.
+- Regression test confirms zero `@ts-ignore - clearing` directives
+  remain in `src/`.
+
+## Test Plan
+
+- `test/utils/ReleasableRef.ts` (new):
+  - `clearForGc - clears a set reference to null`
+  - `clearForGc - clears an already-null reference (no-op)`
+  - `clearForGc - clears a required (non-nullable) field`
+  - `clearForGc - leaves sibling fields untouched`
+  - `clearForGc - happy-path round-trip (set, clear, set)`
+  - `clearForGc - works on nested objects (clears one level)`
+  - `no @ts-ignore GC-cleanup directives remain in src/` (regression
+    guard)
+- Existing `test/multithreading/WorkerDirectObjectPassing.ts` updated
+  to use `clearForGc`; its "GC cleanup uses null instead of empty
+  string" test still verifies the observable behaviour.

--- a/src/NEAT/ProcessCompletedResults.ts
+++ b/src/NEAT/ProcessCompletedResults.ts
@@ -20,6 +20,7 @@ import type { Neat } from "@neat/Neat.ts";
 import { logReplaySummary } from "@neat/NeatScheduling.ts";
 import { emitTrainingEvent } from "@neat/TrainingEventEmitter.ts";
 import { getLogger } from "@utils/Logger.ts";
+import { clearForGc } from "@utils/ReleasableRef.ts";
 
 /**
  * Process completed training, discovery, and replay results.
@@ -116,16 +117,11 @@ export function processCompletedResults(
     }
 
     // Immediately clear large objects to help GC
-    // @ts-ignore - clearing to help GC
-    r.train.creature = null;
-    // @ts-ignore - clearing to help GC
-    r.train.trace = null;
-    // @ts-ignore - clearing to help GC
-    r.train.compact = null;
-    // @ts-ignore - clearing to help GC
-    r.train.backtracked = null;
-    // @ts-ignore - clearing to help GC
-    r.train.forward = null;
+    clearForGc(r.train, "creature");
+    clearForGc(r.train, "trace");
+    clearForGc(r.train, "compact");
+    clearForGc(r.train, "backtracked");
+    clearForGc(r.train, "forward");
   }
   neat.trainingComplete.length = 0;
 
@@ -175,14 +171,10 @@ export function processCompletedResults(
       }
     }
 
-    // @ts-ignore - clearing to help GC
-    r.discover.addHelpfulSynapses = null;
-    // @ts-ignore - clearing to help GC
-    r.discover.removeHarmfulSynapse = null;
-    // @ts-ignore - clearing to help GC
-    r.discover.candidateSquashes = null;
-    // @ts-ignore - clearing to help GC
-    r.discover.improvedCreature = null;
+    clearForGc(r.discover, "addHelpfulSynapses");
+    clearForGc(r.discover, "removeHarmfulSynapse");
+    clearForGc(r.discover, "candidateSquashes");
+    clearForGc(r.discover, "improvedCreature");
   }
   neat.discoveryComplete.length = 0;
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
@@ -42,6 +42,7 @@ import {
   truncateForLogValue as truncateForLogValueImpl,
 } from "@architecture/ErrorGuidedStructuralEvolution/RustFlushDiagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
+import { clearForGc } from "@utils/ReleasableRef.ts";
 import { logDiscoveryDiskUsage } from "@discovery/DiskSpaceMonitor.ts";
 
 import { logDiscovery } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverLogging.ts";
@@ -382,12 +383,9 @@ export class DiscoverStructureBase {
 
     this.selectedIndices = {};
 
-    // @ts-ignore - clearing to help GC
-    this.creature = null;
-    // @ts-ignore - clearing to help GC
-    this.discoveries = null;
-    // @ts-ignore - clearing to help GC
-    this.neuronDiscoveries = null;
+    clearForGc(this, "creature");
+    clearForGc(this, "discoveries");
+    clearForGc(this, "neuronDiscoveries");
 
     try {
       const { closeRustLibrary } = await import("./RustDiscovery.ts");

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
@@ -25,6 +25,7 @@ import {
   observeRustTrainingRecord as observeRustTrainingRecordImpl,
 } from "@architecture/ErrorGuidedStructuralEvolution/RustFlushDiagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
+import { isReleased } from "@utils/ReleasableRef.ts";
 import { DiscoverStructureBase } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts";
 import {
   checkDiskSpace,
@@ -204,8 +205,9 @@ export class DiscoverStructureRecording extends DiscoverStructureBase {
   }
 
   private writeRustParquetChunk(tempDir: string): string | null {
-    // @ts-ignore - creature can be null after cleanUp()
-    if (!this.creature) {
+    // Issue #2398: creature may have been released by cleanUp() — the
+    // field is typed as non-nullable but is cleared to null for GC.
+    if (isReleased(this, "creature")) {
       getLogger().warn(
         `⚠️  Discovery recording skipped: creature has been cleaned up.`,
       );

--- a/src/intelligentDesign/workers/MockWorker.ts
+++ b/src/intelligentDesign/workers/MockWorker.ts
@@ -13,6 +13,7 @@ import type { RequestData } from "@intelligentDesign/workers/WorkerHandler.ts";
 import type { ResponseData } from "@intelligentDesign/workers/ResponseData.ts";
 import { WorkerProcessor } from "@intelligentDesign/workers/WorkerProcessor.ts";
 import { toError } from "@utils/ErrorSerialisation.ts";
+import { clearForGc } from "@utils/ReleasableRef.ts";
 
 export class MockWorker implements WorkerInterface<RequestData> {
   private callBack: EventListener | null = null;
@@ -53,7 +54,6 @@ export class MockWorker implements WorkerInterface<RequestData> {
 
   terminate(): void {
     this.callBack = null;
-    // @ts-ignore - clearing processor reference
-    this.processor = null;
+    clearForGc(this, "processor");
   }
 }

--- a/src/multithreading/workers/MockWorker.ts
+++ b/src/multithreading/workers/MockWorker.ts
@@ -7,6 +7,7 @@ import type {
 import { WorkerProcessor } from "@multithreading/workers/WorkerProcessor.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { toError, toErrorMessage } from "@utils/ErrorSerialisation.ts";
+import { clearForGc } from "@utils/ReleasableRef.ts";
 
 export class MockWorker implements WorkerInterface<RequestData> {
   private callBack: EventListener | null = null;
@@ -101,7 +102,6 @@ export class MockWorker implements WorkerInterface<RequestData> {
   terminate(): void {
     // Clean up references to prevent memory leaks
     this.callBack = null;
-    // @ts-ignore - clearing processor reference
-    this.processor = null;
+    clearForGc(this, "processor");
   }
 }

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -22,6 +22,7 @@ import type { RequiredOutputRange } from "@config/OutputRangeConfig.ts";
 import type { TrainOptions } from "@config/TrainOptions.ts";
 import type { WasmCacheConfig } from "@config/WasmCacheConfig.ts";
 import { getLogger } from "@utils/Logger.ts";
+import { clearForGc } from "@utils/ReleasableRef.ts";
 import {
   getInitTimeoutMs,
   WorkerHandlerBase,
@@ -453,8 +454,7 @@ export class WorkerHandler
       // Clear large creature data after structured clone completes.
       // The worker now has its own deep copy; the main thread no longer
       // needs the original export, so release it to reduce GC pressure.
-      // @ts-ignore - clearing to help GC after structured clone
-      data.evaluate!.creature = null;
+      clearForGc(data.evaluate!, "creature");
     });
   }
 
@@ -486,8 +486,7 @@ export class WorkerHandler
     this.incrementLongRunningTaskCount();
     return this.makePromiseDeferred(data, () => {
       // Clear large creature data after structured clone completes.
-      // @ts-ignore - clearing to help GC after structured clone
-      data.train!.creature = null;
+      clearForGc(data.train!, "creature");
     }).finally(() => {
       this.decrementLongRunningTaskCount();
     });
@@ -516,8 +515,7 @@ export class WorkerHandler
     this.incrementLongRunningTaskCount();
     return this.makePromiseDeferred(data, () => {
       // Clear large creature data after structured clone completes.
-      // @ts-ignore - clearing to help GC after structured clone
-      data.discover!.creature = null;
+      clearForGc(data.discover!, "creature");
     }).finally(() => {
       this.decrementLongRunningTaskCount();
     });
@@ -587,10 +585,8 @@ export class WorkerHandler
 
     return this.makePromiseDeferred(data, () => {
       // Clear large creature data after structured clone completes.
-      // @ts-ignore - clearing to help GC after structured clone
-      data.breed!.mother = null;
-      // @ts-ignore - clearing to help GC after structured clone
-      data.breed!.father = null;
+      clearForGc(data.breed!, "mother");
+      clearForGc(data.breed!, "father");
     });
   }
 }

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -26,6 +26,7 @@ import type {
   ResponseData,
 } from "@multithreading/workers/WorkerHandler.ts";
 import { getLogger } from "@utils/Logger.ts";
+import { clearForGc } from "@utils/ReleasableRef.ts";
 import { DatasetFileListCache } from "@architecture/DatasetFileListCache.ts";
 
 type DiscoverResponsePayload = NonNullable<ResponseData["discover"]>;
@@ -71,30 +72,14 @@ export function buildDiscoverResponsePayload(
  * long-running discovery workers.
  */
 export function clearDiscoverResultForGC(result: DiscoverResult): void {
-  if (result.addHelpfulSynapses) {
-    // @ts-ignore - clearing to help GC
-    result.addHelpfulSynapses = null;
-  }
-  if (result.addHelpfulNeurons) {
-    // @ts-ignore - clearing to help GC
-    result.addHelpfulNeurons = null;
-  }
+  if (result.addHelpfulSynapses) clearForGc(result, "addHelpfulSynapses");
+  if (result.addHelpfulNeurons) clearForGc(result, "addHelpfulNeurons");
   if (result.coordinatedStructuralCandidates) {
-    // @ts-ignore - clearing to help GC
-    result.coordinatedStructuralCandidates = null;
+    clearForGc(result, "coordinatedStructuralCandidates");
   }
-  if (result.removeHarmfulNeurons) {
-    // @ts-ignore - clearing to help GC
-    result.removeHarmfulNeurons = null;
-  }
-  if (result.removalCandidates) {
-    // @ts-ignore - clearing to help GC
-    result.removalCandidates = null;
-  }
-  if (result.candidateSquashes) {
-    // @ts-ignore - clearing to help GC
-    result.candidateSquashes = null;
-  }
+  if (result.removeHarmfulNeurons) clearForGc(result, "removeHarmfulNeurons");
+  if (result.removalCandidates) clearForGc(result, "removalCandidates");
+  if (result.candidateSquashes) clearForGc(result, "candidateSquashes");
 }
 
 export class WorkerProcessor {
@@ -243,8 +228,7 @@ export class WorkerProcessor {
       let creature: Creature | null = null;
       try {
         creature = Creature.fromJSON(data.evaluate.creature);
-        // @ts-ignore - clearing to help GC
-        data.evaluate.creature = null;
+        clearForGc(data.evaluate, "creature");
         // Issue #2260: Use cached file list to avoid repeated directory scans.
         const cachedFiles = this.datasetFileCache.getFiles(this.dataSetDir);
         const result = await creature.evaluateDir(
@@ -284,8 +268,7 @@ export class WorkerProcessor {
           data.train.creature,
           data.debug,
         );
-        // @ts-ignore - clearing to help GC
-        data.train.creature = null;
+        clearForGc(data.train, "creature");
 
         assert(this.dataSetDir, "No data dir");
         assert(this.cost, "No cost");
@@ -310,14 +293,8 @@ export class WorkerProcessor {
         };
 
         // Immediately clear large objects to help GC
-        if (result.trace) {
-          // @ts-ignore - clearing to help GC
-          result.trace = null;
-        }
-        if (result.compact) {
-          // @ts-ignore - clearing to help GC
-          result.compact = null;
-        }
+        if (result.trace) clearForGc(result, "trace");
+        if (result.compact) clearForGc(result, "compact");
 
         return response;
       } finally {
@@ -395,10 +372,8 @@ export class WorkerProcessor {
         father = Creature.fromJSON(data.breed.father, data.debug);
 
         // Release memory from request data
-        // @ts-ignore - clearing to help GC
-        data.breed.mother = null;
-        // @ts-ignore - clearing to help GC
-        data.breed.father = null;
+        clearForGc(data.breed, "mother");
+        clearForGc(data.breed, "father");
 
         // Import Offspring dynamically to avoid circular dependencies
         const { Offspring } = await import(

--- a/src/utils/ReleasableRef.ts
+++ b/src/utils/ReleasableRef.ts
@@ -1,0 +1,77 @@
+/**
+ * ReleasableRef.ts - Typed helpers for releasing object references to aid
+ * V8 garbage collection (Issue #2398).
+ *
+ * Replaces the scattered GC-cleanup `ts-ignore` directive pattern that
+ * previously suppressed type information when assigning `null` to
+ * non-nullable properties. The pattern appeared in long-running
+ * worker/discovery code paths where holding onto large payloads
+ * (creatures, traces, discovery results) after they had been cloned or
+ * serialised would needlessly grow the heap.
+ *
+ * Centralising the escape hatch here means:
+ *   - the intent ("release this field for GC") is expressed at the call
+ *     site as a named function, not an unsafe directive;
+ *   - refactors can change the implementation (e.g. swap `null` for
+ *     `undefined`, or add logging) in one place;
+ *   - a regression test can enforce that no new GC-cleanup `ts-ignore`
+ *     directives are introduced.
+ */
+
+/**
+ * A key accepted by the helpers below.
+ *
+ * Autocomplete surfaces the declared public keys of `T` (the typical case
+ * for plain data objects like `RequestData.evaluate`), while still
+ * accepting any `string` — this is required when the host is `this`
+ * inside a class method, because TypeScript's polymorphic `this` type
+ * does not expose protected/private fields via `keyof this`.
+ *
+ * The `(string & {})` intersection is the idiomatic TypeScript trick to
+ * widen a literal key union to `string` without losing autocomplete.
+ */
+// deno-lint-ignore ban-types
+type ReleasableKey<T> = keyof T | (string & {});
+
+/**
+ * Clears a property on `host` for garbage-collection purposes.
+ *
+ * The property is assigned `null` regardless of its declared type — this
+ * is deliberate. Call sites typically hold large payload objects whose
+ * fields are typed as non-nullable for safety elsewhere, but must be
+ * released once the payload has been cloned across a worker boundary or
+ * its subordinate data has been consumed.
+ *
+ * Uses `Reflect.set` rather than a `Record`/`any` cast so the helper
+ * itself remains fully typed — no `any` leaks through. Autocomplete
+ * works against the public keys of `T`; additionally, any string is
+ * accepted so the helper works on class `this` (whose polymorphic
+ * `keyof this` does not expose protected/private fields).
+ *
+ * @typeParam T - The host object type (must be an object).
+ * @param host - The object owning the reference.
+ * @param key - The property name to release.
+ */
+export function clearForGc<T extends object>(
+  host: T,
+  key: ReleasableKey<T>,
+): void {
+  Reflect.set(host, key as PropertyKey, null);
+}
+
+/**
+ * Returns `true` if `host[key]` has been released (i.e. the runtime
+ * value is `null`), `false` otherwise.
+ *
+ * Companion to {@link clearForGc}. Because `clearForGc` assigns `null`
+ * to a property typed as non-nullable, consumers that need to check
+ * whether the reference has already been released cannot rely on
+ * TypeScript's narrowing — this helper performs a typed runtime check
+ * without a `@ts-ignore` at the call site.
+ */
+export function isReleased<T extends object>(
+  host: T,
+  key: ReleasableKey<T>,
+): boolean {
+  return Reflect.get(host, key as PropertyKey) === null;
+}

--- a/test/multithreading/WorkerDirectObjectPassing.ts
+++ b/test/multithreading/WorkerDirectObjectPassing.ts
@@ -17,6 +17,7 @@ import type {
   RequestData,
   ResponseData,
 } from "@multithreading/workers/WorkerHandler.ts";
+import { clearForGc } from "@utils/ReleasableRef.ts";
 
 /**
  * Creates a small test creature for worker communication tests.
@@ -273,17 +274,12 @@ Deno.test("GC cleanup uses null instead of empty string for object fields", () =
     },
   };
 
-  // Simulate GC cleanup pattern used in NeatEvolution.ts
-  // @ts-ignore - clearing to help GC
-  response.train!.creature = null;
-  // @ts-ignore - clearing to help GC
-  response.train!.trace = null;
-  // @ts-ignore - clearing to help GC
-  response.train!.compact = null;
-  // @ts-ignore - clearing to help GC
-  response.train!.backtracked = null;
-  // @ts-ignore - clearing to help GC
-  response.train!.forward = null;
+  // Simulate GC cleanup pattern used in ProcessCompletedResults.ts
+  clearForGc(response.train!, "creature");
+  clearForGc(response.train!, "trace");
+  clearForGc(response.train!, "compact");
+  clearForGc(response.train!, "backtracked");
+  clearForGc(response.train!, "forward");
 
   // Verify fields are null (not empty string)
   // deno-lint-ignore no-explicit-any

--- a/test/utils/ReleasableRef.ts
+++ b/test/utils/ReleasableRef.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the ReleasableRef helper (Issue #2398).
+ *
+ * The helper replaces scattered `@ts-ignore - clearing to help GC`
+ * directives with a typed call that expresses the GC-hint intent at
+ * the type level.
+ */
+
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import { clearForGc } from "../../src/utils/ReleasableRef.ts";
+
+Deno.test("clearForGc - clears a set reference to null", () => {
+  const host: { creature: { id: string } | null } = {
+    creature: { id: "abc" },
+  };
+
+  clearForGc(host, "creature");
+
+  assertStrictEquals(host.creature, null);
+});
+
+Deno.test("clearForGc - clears an already-null reference (no-op)", () => {
+  const host: { creature: { id: string } | null } = { creature: null };
+
+  clearForGc(host, "creature");
+
+  assertStrictEquals(host.creature, null);
+});
+
+Deno.test("clearForGc - clears a required (non-nullable) field", () => {
+  // The whole point of the helper is that a required field typed as
+  // non-nullable can still be cleared for GC without a @ts-ignore.
+  interface Payload {
+    creature: { id: string };
+    trace: number[];
+  }
+
+  const host: Payload = {
+    creature: { id: "abc" },
+    trace: [1, 2, 3],
+  };
+
+  clearForGc(host, "creature");
+  clearForGc(host, "trace");
+
+  // After clearing, access via the typed reference returns null at runtime.
+  // deno-lint-ignore no-explicit-any
+  const raw = host as any;
+  assertStrictEquals(raw.creature, null);
+  assertStrictEquals(raw.trace, null);
+});
+
+Deno.test("clearForGc - leaves sibling fields untouched", () => {
+  const host: {
+    creature: { id: string } | null;
+    trace: number[];
+  } = {
+    creature: { id: "abc" },
+    trace: [1, 2, 3],
+  };
+
+  clearForGc(host, "creature");
+
+  assertStrictEquals(host.creature, null);
+  assertEquals(host.trace, [1, 2, 3]);
+});
+
+Deno.test("clearForGc - happy-path round-trip (set, clear, set)", () => {
+  const host: { value: string | null } = { value: "initial" };
+
+  assertStrictEquals(host.value, "initial");
+
+  clearForGc(host, "value");
+  assertStrictEquals(host.value, null);
+
+  host.value = "restored";
+  assertStrictEquals(host.value, "restored");
+
+  clearForGc(host, "value");
+  assertStrictEquals(host.value, null);
+});
+
+Deno.test("clearForGc - works on nested objects (clears one level)", () => {
+  const host: {
+    outer: { inner: { data: number[] } | null };
+  } = {
+    outer: { inner: { data: [1, 2, 3] } },
+  };
+
+  clearForGc(host.outer, "inner");
+
+  assertStrictEquals(host.outer.inner, null);
+});
+
+Deno.test(
+  "no @ts-ignore GC-cleanup directives remain in src/",
+  async () => {
+    // Regression guard for Issue #2398: any reintroduction of the
+    // scattered @ts-ignore GC-cleanup pattern must fail this test.
+    // Match only the directive form (starts with //), not the words as
+    // they appear in this file's own documentation.
+    const pattern = /\/\/\s*@ts-ignore\s*-\s*clearing/;
+    const hits: string[] = [];
+
+    async function scan(dir: string) {
+      for await (const entry of Deno.readDir(dir)) {
+        const path = `${dir}/${entry.name}`;
+        if (entry.isDirectory) {
+          await scan(path);
+        } else if (entry.isFile && path.endsWith(".ts")) {
+          const body = await Deno.readTextFile(path);
+          if (pattern.test(body)) hits.push(path);
+        }
+      }
+    }
+
+    await scan("src");
+
+    assertEquals(
+      hits,
+      [],
+      `Found forbidden '@ts-ignore - clearing' pattern in:\n${
+        hits.join("\n")
+      }\nUse clearForGc() from src/utils/ReleasableRef.ts instead.`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Replaced the 32 scattered `// @ts-ignore - clearing to help GC` directives
with a centralised, typed helper `clearForGc()` (plus companion
`isReleased()`) exported from `src/utils/ReleasableRef.ts`. The helper
expresses the GC-hint intent at the call site, contains no `any` casts,
and a regression test ensures the unsafe pattern cannot reappear.
Closes #2398.

## Changes

- **New helper**: `src/utils/ReleasableRef.ts` exposes
  `clearForGc(host, key)` and `isReleased(host, key)`. The helpers use
  `Reflect.set`/`Reflect.get` to avoid `any` casts; the key type
  (`keyof T | (string & {})`) surfaces autocomplete for declared keys
  while still accepting any string so the helper works on `this` inside
  class methods (where polymorphic `keyof this` hides protected/private
  fields).

- **Directive replacements (32 sites, 7 files)**:
  - `src/multithreading/workers/MockWorker.ts` — 1
  - `src/multithreading/workers/WorkerHandler.ts` — 5
  - `src/multithreading/workers/WorkerProcessor.ts` — 12
  - `src/NEAT/ProcessCompletedResults.ts` — 9
  - `src/intelligentDesign/workers/MockWorker.ts` — 1
  - `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts` — 3
  - `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts` — 1

- **Test site replacement**:
  `test/multithreading/WorkerDirectObjectPassing.ts` also used the
  pattern to simulate GC behaviour; updated to call `clearForGc`.

- **Regression guard**: `test/utils/ReleasableRef.ts` includes a test
  that scans `src/` and fails if any `// @ts-ignore - clearing` directive
  reappears.

## Evidence

Backend/library change — no UI to screenshot. Verified via:

- `deno check` passes (`./quality.sh --check-only`, exit 0).
- `deno fmt` + `deno lint --fix` clean (`./quality.sh --lint-only`).
- 7 new unit tests in `test/utils/ReleasableRef.ts` (all pass).
- Impacted test suites pass in full:
  - `test/multithreading/` + `test/utils/` + `test/intelligentDesign/`
    — 217 passed, 0 failed.
  - `test/NEAT/` + `test/architecture/ErrorGuidedStructuralEvolution/`
    — 649 passed, 0 failed.
- Regression test confirms zero `@ts-ignore - clearing` directives
  remain in `src/`.

## Test Plan

- `test/utils/ReleasableRef.ts` (new):
  - `clearForGc - clears a set reference to null`
  - `clearForGc - clears an already-null reference (no-op)`
  - `clearForGc - clears a required (non-nullable) field`
  - `clearForGc - leaves sibling fields untouched`
  - `clearForGc - happy-path round-trip (set, clear, set)`
  - `clearForGc - works on nested objects (clears one level)`
  - `no @ts-ignore GC-cleanup directives remain in src/` (regression
    guard)
- Existing `test/multithreading/WorkerDirectObjectPassing.ts` updated
  to use `clearForGc`; its "GC cleanup uses null instead of empty
  string" test still verifies the observable behaviour.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2398 -->