### PR TITLE
Add batch scorer result reconciliation with typed error semantics (#2423)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2423.md
+++ b/docs/pr-summary-2423.md
@@ -1,0 +1,75 @@
+## Summary
+
+Adds strict reconciliation for batch scorer output so NEAT-AI never silently
+mis-scores a generation. Introduces `src/score/BatchScorerReconciler.ts` and
+the typed `BatchScorerError` so callers can parse a single-JSON batch scorer
+payload, verify the result key set exactly matches the expected creature
+filename stems, and validate every result carries finite numeric `score`,
+`error`, and non-negative integer `recordCount` fields. Any key mismatch or
+malformed result fails fast with an actionable diagnostic that names the
+offending stems and fields. Closes #2423.
+
+The module is deliberately scoped to parser/reconciliation hardening per the
+issue's note — no process orchestration is changed.
+
+### Error semantics
+
+`BatchScorerError.reason` distinguishes:
+
+- `INVALID_JSON` — raw payload string could not be parsed.
+- `NOT_AN_OBJECT` — parsed value is not a JSON object (e.g. array, null).
+- `MISSING_KEYS` — one or more expected creature stems were absent.
+- `EXTRA_KEYS` — scorer returned stems not in the expected set.
+- `MALFORMED_RESULT` — one or more results failed numeric-field validation.
+
+`missingKeys`, `extraKeys`, and `malformedKeys` are populated on the error so
+callers can emit structured telemetry in addition to the human-readable
+message.
+
+## Evidence
+
+Backend/CLI change with no UI surface. Verified via the new integration test
+suite:
+
+```
+running 20 tests from ./test/score/BatchScorerReconciler.ts
+BatchScorerReconciler - happy path parses and returns a map ... ok
+BatchScorerReconciler - accepts pre-parsed object payload ... ok
+BatchScorerReconciler - fails fast on invalid JSON string ... ok
+BatchScorerReconciler - rejects non-object payloads ... ok
+BatchScorerReconciler - rejects null payload ... ok
+BatchScorerReconciler - fails fast when a key is missing ... ok
+BatchScorerReconciler - fails fast when an extra key is present ... ok
+BatchScorerReconciler - reports both missing and extra keys together ... ok
+BatchScorerReconciler - rejects result that is not an object ... ok
+BatchScorerReconciler - rejects missing numeric field ... ok
+BatchScorerReconciler - rejects NaN for a numeric field ... ok
+BatchScorerReconciler - rejects infinite error field ... ok
+BatchScorerReconciler - rejects negative recordCount ... ok
+BatchScorerReconciler - rejects non-integer recordCount ... ok
+BatchScorerReconciler - empty expected set with empty payload is accepted ... ok
+BatchScorerReconciler - duplicate expected stems are deduplicated ... ok
+BatchScorerReconciler - reports all malformed creatures in one pass ... ok
+BatchScorerReconciler - preserves extra optional numeric fields ... ok
+BatchScorerReconciler - rejects array-typed result ... ok
+BatchScorerError exposes reason for programmatic handling ... ok
+
+ok | 20 passed | 0 failed
+```
+
+Full quality gate: `./quality.sh --skip-discovery --skip-wasm` →
+`6185 passed | 0 failed | 3 ignored` (5m39s).
+
+## Test Plan
+
+- `test/score/BatchScorerReconciler.ts` (new) — 20 tests covering every
+  acceptance criterion:
+  - **Happy path** — string and pre-parsed object payloads both return a map.
+  - **Mismatch path** — missing keys, extra keys, combined mismatch (both
+    surfaced in the same message), and deduplication of expected stems.
+  - **Malformed path** — non-object result, missing numeric field, NaN,
+    infinite, negative, and non-integer `recordCount`, array-typed result,
+    and a multi-creature malformed case that reports every offender in one
+    pass.
+  - **Error type** — `BatchScorerError.reason` is exposed for programmatic
+    handling and `instanceof Error` holds.

--- a/docs/pr-summary-2423.md
+++ b/docs/pr-summary-2423.md
@@ -1,8 +1,8 @@
 ## Summary
 
 Adds strict reconciliation for batch scorer output so NEAT-AI never silently
-mis-scores a generation. Introduces `src/score/BatchScorerReconciler.ts` and
-the typed `BatchScorerError` so callers can parse a single-JSON batch scorer
+mis-scores a generation. Introduces `src/score/BatchScorerReconciler.ts` and the
+typed `BatchScorerError` so callers can parse a single-JSON batch scorer
 payload, verify the result key set exactly matches the expected creature
 filename stems, and validate every result carries finite numeric `score`,
 `error`, and non-negative integer `recordCount` fields. Any key mismatch or
@@ -23,8 +23,7 @@ issue's note — no process orchestration is changed.
 - `MALFORMED_RESULT` — one or more results failed numeric-field validation.
 
 `missingKeys`, `extraKeys`, and `malformedKeys` are populated on the error so
-callers can emit structured telemetry in addition to the human-readable
-message.
+callers can emit structured telemetry in addition to the human-readable message.
 
 ## Evidence
 
@@ -68,8 +67,7 @@ Full quality gate: `./quality.sh --skip-discovery --skip-wasm` →
   - **Mismatch path** — missing keys, extra keys, combined mismatch (both
     surfaced in the same message), and deduplication of expected stems.
   - **Malformed path** — non-object result, missing numeric field, NaN,
-    infinite, negative, and non-integer `recordCount`, array-typed result,
-    and a multi-creature malformed case that reports every offender in one
-    pass.
+    infinite, negative, and non-integer `recordCount`, array-typed result, and a
+    multi-creature malformed case that reports every offender in one pass.
   - **Error type** — `BatchScorerError.reason` is exposed for programmatic
     handling and `instanceof Error` holds.

--- a/src/score/BatchScorerReconciler.ts
+++ b/src/score/BatchScorerReconciler.ts
@@ -1,0 +1,264 @@
+/**
+ * Batch scorer result reconciliation (Issue #2423).
+ *
+ * The external batch scorer returns a single JSON object keyed by creature
+ * filename stem, with each value being a result object containing numeric
+ * fields (`score`, `error`, `recordCount`, …). This module provides strict
+ * reconciliation so NEAT-AI never silently mis-scores a generation:
+ *
+ * - parses the payload (string or pre-parsed object) and fails fast on invalid
+ *   JSON or non-object shapes;
+ * - validates that the result key set exactly matches the expected set of
+ *   creature filename stems (missing or extra keys both fail fast);
+ * - validates that every result carries the required numeric fields with
+ *   finite, sensible values (including integer, non-negative `recordCount`);
+ * - emits actionable diagnostics naming the offending keys/fields.
+ *
+ * Failures are reported via {@link BatchScorerError} whose `reason` field
+ * allows callers to branch on specific failure modes.
+ *
+ * @module BatchScorerReconciler
+ */
+
+export type BatchScorerErrorReason =
+  | "INVALID_JSON"
+  | "NOT_AN_OBJECT"
+  | "MISSING_KEYS"
+  | "EXTRA_KEYS"
+  | "MALFORMED_RESULT";
+
+/**
+ * Typed error raised by {@link reconcileBatchScorerOutput} on any reconciliation
+ * failure. Callers can catch and inspect `reason`, `missingKeys`, `extraKeys`,
+ * and `malformedKeys` to emit structured diagnostics.
+ */
+export class BatchScorerError extends Error {
+  override readonly name = "BatchScorerError";
+  readonly reason: BatchScorerErrorReason;
+  readonly missingKeys?: readonly string[];
+  readonly extraKeys?: readonly string[];
+  readonly malformedKeys?: readonly string[];
+
+  constructor(
+    message: string,
+    reason: BatchScorerErrorReason,
+    details?: {
+      missingKeys?: readonly string[];
+      extraKeys?: readonly string[];
+      malformedKeys?: readonly string[];
+    },
+  ) {
+    super(message);
+    this.reason = reason;
+    if (details?.missingKeys) this.missingKeys = details.missingKeys;
+    if (details?.extraKeys) this.extraKeys = details.extraKeys;
+    if (details?.malformedKeys) this.malformedKeys = details.malformedKeys;
+  }
+}
+
+/**
+ * Validated result for a single creature returned by the batch scorer.
+ *
+ * Additional numeric diagnostics emitted by the scorer are passed through
+ * untouched so downstream consumers can surface them without modification.
+ */
+export interface BatchScorerResult {
+  /** Fitness score the scorer assigned to this creature. */
+  score: number;
+  /** Aggregate cost/error value (finite). */
+  error: number;
+  /** Number of records the scorer evaluated against (non-negative integer). */
+  recordCount: number;
+  /** Passthrough for any additional fields the scorer chose to emit. */
+  [extraField: string]: unknown;
+}
+
+/** Required numeric fields on each creature result. */
+const REQUIRED_NUMERIC_FIELDS = ["score", "error", "recordCount"] as const;
+
+/**
+ * Reconcile raw batch scorer output against the expected set of creature
+ * filename stems. Returns a `Map<stem, BatchScorerResult>` on success.
+ * Throws a {@link BatchScorerError} on any reconciliation failure.
+ *
+ * @param raw - Either the raw JSON string emitted by the scorer or the already
+ *   parsed value (e.g. from an in-process scorer).
+ * @param expectedStems - The creature filename stems that must appear in the
+ *   result. Duplicates are deduplicated before comparison.
+ */
+export function reconcileBatchScorerOutput(
+  raw: unknown,
+  expectedStems: Iterable<string>,
+): Map<string, BatchScorerResult> {
+  const parsed = parsePayload(raw);
+  const expected = new Set(expectedStems);
+
+  const actualKeys = Object.keys(parsed);
+  checkKeySet(actualKeys, expected);
+
+  const results = new Map<string, BatchScorerResult>();
+  const malformedKeys: string[] = [];
+  const malformedDetails: string[] = [];
+
+  // Preserve the expected-stem iteration order so diagnostics are
+  // deterministic for operators reading logs.
+  for (const stem of expected) {
+    const rawResult = parsed[stem];
+    const validation = validateResult(rawResult);
+    if (!validation.ok) {
+      malformedKeys.push(stem);
+      malformedDetails.push(`${stem}: ${validation.detail}`);
+      continue;
+    }
+    results.set(stem, validation.value);
+  }
+
+  if (malformedKeys.length > 0) {
+    throw new BatchScorerError(
+      `Batch scorer returned malformed result(s) for ${malformedKeys.length} creature(s): ${
+        malformedDetails.join("; ")
+      }`,
+      "MALFORMED_RESULT",
+      { malformedKeys },
+    );
+  }
+
+  return results;
+}
+
+/** Parse the raw payload (string or object) into a plain JSON object. */
+function parsePayload(raw: unknown): Record<string, unknown> {
+  let value: unknown;
+  if (typeof raw === "string") {
+    try {
+      value = JSON.parse(raw);
+    } catch (cause) {
+      const detail = cause instanceof Error ? cause.message : String(cause);
+      throw new BatchScorerError(
+        `Batch scorer output is not valid JSON: ${detail}`,
+        "INVALID_JSON",
+      );
+    }
+  } else {
+    value = raw;
+  }
+
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value)
+  ) {
+    throw new BatchScorerError(
+      `Batch scorer output must be a JSON object keyed by creature stem; got ${
+        describeType(value)
+      }`,
+      "NOT_AN_OBJECT",
+    );
+  }
+
+  return value as Record<string, unknown>;
+}
+
+/** Fail fast when the actual key set does not exactly match the expected. */
+function checkKeySet(actualKeys: string[], expected: Set<string>): void {
+  const actual = new Set(actualKeys);
+  const missing: string[] = [];
+  for (const stem of expected) {
+    if (!actual.has(stem)) missing.push(stem);
+  }
+  const extra: string[] = [];
+  for (const stem of actual) {
+    if (!expected.has(stem)) extra.push(stem);
+  }
+
+  if (missing.length === 0 && extra.length === 0) return;
+
+  // Build a single actionable message surfacing both problems when they co-occur
+  // so operators can fix the scorer in one pass.
+  const parts: string[] = [];
+  if (missing.length > 0) {
+    parts.push(
+      `missing ${missing.length} expected result(s): ${missing.join(", ")}`,
+    );
+  }
+  if (extra.length > 0) {
+    parts.push(`${extra.length} unexpected result key(s): ${extra.join(", ")}`);
+  }
+  const message = `Batch scorer key set does not match expected creatures — ${
+    parts.join("; ")
+  }`;
+
+  // Prefer MISSING_KEYS when any expected stem is absent because that is the
+  // hard failure for generation scoring; extras alone are still a failure.
+  const reason: BatchScorerErrorReason = missing.length > 0
+    ? "MISSING_KEYS"
+    : "EXTRA_KEYS";
+
+  throw new BatchScorerError(message, reason, {
+    missingKeys: missing.length > 0 ? missing : undefined,
+    extraKeys: extra.length > 0 ? extra : undefined,
+  });
+}
+
+/** Validate a single creature result object. Returns structured detail on failure. */
+function validateResult(
+  raw: unknown,
+): { ok: true; value: BatchScorerResult } | {
+  ok: false;
+  detail: string;
+  value?: never;
+} {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      ok: false,
+      detail: `result must be a JSON object, got ${describeType(raw)}`,
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+  const problems: string[] = [];
+
+  for (const field of REQUIRED_NUMERIC_FIELDS) {
+    const value = obj[field];
+    if (value === undefined) {
+      problems.push(`missing numeric field \"${field}\"`);
+      continue;
+    }
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      problems.push(
+        `field \"${field}\" must be a finite number, got ${
+          describeType(value)
+        }`,
+      );
+      continue;
+    }
+    if (field === "recordCount") {
+      if (!Number.isInteger(value)) {
+        problems.push(`field \"recordCount\" must be an integer, got ${value}`);
+      } else if (value < 0) {
+        problems.push(
+          `field \"recordCount\" must be non-negative, got ${value}`,
+        );
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    return { ok: false, detail: problems.join("; ") };
+  }
+
+  // Build a new plain object so the passthrough `[extra]` values are preserved
+  // but the mandatory numeric fields are narrowed to `number`.
+  const result: BatchScorerResult = {
+    ...obj,
+    score: obj.score as number,
+    error: obj.error as number,
+    recordCount: obj.recordCount as number,
+  };
+  return { ok: true, value: result };
+}
+
+function describeType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}

--- a/test/score/BatchScorerReconciler.ts
+++ b/test/score/BatchScorerReconciler.ts
@@ -1,0 +1,286 @@
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import {
+  BatchScorerError,
+  reconcileBatchScorerOutput,
+} from "../../src/score/BatchScorerReconciler.ts";
+
+/**
+ * Integration-style tests for batch scorer reconciliation (Issue #2423).
+ *
+ * These tests exercise the reconciler against realistic scorer payloads to
+ * cover the happy-path, key-mismatch path, and malformed-result path required
+ * by the issue's acceptance criteria.
+ */
+
+/** Typed wrapper: `assertThrows` returns `unknown` in this std version. */
+function expectBatchError(fn: () => unknown): BatchScorerError {
+  return assertThrows(fn, BatchScorerError) as BatchScorerError;
+}
+
+const expectedStems = ["creature-a", "creature-b", "creature-c"];
+
+function validPayload(): string {
+  return JSON.stringify({
+    "creature-a": { score: 0.92, error: 0.08, recordCount: 128 },
+    "creature-b": { score: 0.81, error: 0.19, recordCount: 128 },
+    "creature-c": { score: 0.77, error: 0.23, recordCount: 128 },
+  });
+}
+
+Deno.test("BatchScorerReconciler - happy path parses and returns a map", () => {
+  const results = reconcileBatchScorerOutput(validPayload(), expectedStems);
+  assertEquals(results.size, 3);
+  const a = results.get("creature-a");
+  assert(a !== undefined, "creature-a should be present");
+  assertEquals(a.score, 0.92);
+  assertEquals(a.error, 0.08);
+  assertEquals(a.recordCount, 128);
+});
+
+Deno.test("BatchScorerReconciler - accepts pre-parsed object payload", () => {
+  const parsed = {
+    "creature-a": { score: 1, error: 0, recordCount: 10 },
+    "creature-b": { score: 2, error: 0.5, recordCount: 10 },
+    "creature-c": { score: 3, error: 1, recordCount: 10 },
+  };
+  const results = reconcileBatchScorerOutput(parsed, expectedStems);
+  assertEquals(results.size, 3);
+  assertEquals(results.get("creature-b")?.error, 0.5);
+});
+
+Deno.test("BatchScorerReconciler - fails fast on invalid JSON string", () => {
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput("not json at all", expectedStems)
+  );
+  assertEquals(err.reason, "INVALID_JSON");
+  assert(
+    err.message.toLowerCase().includes("json"),
+    `message should mention JSON; got: ${err.message}`,
+  );
+});
+
+Deno.test("BatchScorerReconciler - rejects non-object payloads", () => {
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput("[1,2,3]", expectedStems)
+  );
+  assertEquals(err.reason, "NOT_AN_OBJECT");
+});
+
+Deno.test("BatchScorerReconciler - rejects null payload", () => {
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput("null", expectedStems)
+  );
+  assertEquals(err.reason, "NOT_AN_OBJECT");
+});
+
+Deno.test("BatchScorerReconciler - fails fast when a key is missing", () => {
+  const payload = JSON.stringify({
+    "creature-a": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    // creature-c missing
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  assertEquals(err.reason, "MISSING_KEYS");
+  assertEquals(err.missingKeys, ["creature-c"]);
+  assert(
+    err.message.includes("creature-c"),
+    `message should include missing key; got: ${err.message}`,
+  );
+});
+
+Deno.test("BatchScorerReconciler - fails fast when an extra key is present", () => {
+  const payload = JSON.stringify({
+    "creature-a": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-ghost": { score: 0.5, error: 0.5, recordCount: 10 },
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  assertEquals(err.reason, "EXTRA_KEYS");
+  assertEquals(err.extraKeys, ["creature-ghost"]);
+  assert(
+    err.message.includes("creature-ghost"),
+    `message should include extra key; got: ${err.message}`,
+  );
+});
+
+Deno.test("BatchScorerReconciler - reports both missing and extra keys together", () => {
+  const payload = JSON.stringify({
+    "creature-a": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-zombie": { score: 0.5, error: 0.5, recordCount: 10 },
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  // Missing-keys check runs first; either reason is acceptable but the message
+  // must surface both problems so operators can fix them in one pass.
+  assert(
+    err.reason === "MISSING_KEYS" || err.reason === "EXTRA_KEYS",
+    `unexpected reason ${err.reason}`,
+  );
+  assert(
+    err.message.includes("creature-c") &&
+      err.message.includes("creature-zombie"),
+    `message should mention both mismatched keys; got: ${err.message}`,
+  );
+});
+
+Deno.test("BatchScorerReconciler - rejects result that is not an object", () => {
+  const payload = JSON.stringify({
+    "creature-a": 0.5,
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 10 },
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  assertEquals(err.reason, "MALFORMED_RESULT");
+  assert(err.malformedKeys?.includes("creature-a"));
+});
+
+Deno.test("BatchScorerReconciler - rejects missing numeric field", () => {
+  const payload = JSON.stringify({
+    "creature-a": { score: 0.5, error: 0.5 }, // missing recordCount
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 10 },
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  assertEquals(err.reason, "MALFORMED_RESULT");
+  assert(err.malformedKeys?.includes("creature-a"));
+  assert(
+    err.message.includes("recordCount"),
+    `message should name missing field; got: ${err.message}`,
+  );
+});
+
+Deno.test("BatchScorerReconciler - rejects NaN for a numeric field", () => {
+  // JSON doesn't support NaN literally; use a string that won't parse to a number.
+  const payload = JSON.stringify({
+    "creature-a": { score: "not-a-number", error: 0.5, recordCount: 10 },
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 10 },
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  assertEquals(err.reason, "MALFORMED_RESULT");
+  assert(err.malformedKeys?.includes("creature-a"));
+});
+
+Deno.test("BatchScorerReconciler - rejects infinite error field", () => {
+  // Build pre-parsed input because JSON can't represent Infinity.
+  const parsed = {
+    "creature-a": {
+      score: 0.5,
+      error: Number.POSITIVE_INFINITY,
+      recordCount: 10,
+    },
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 10 },
+  };
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(parsed, expectedStems)
+  );
+  assertEquals(err.reason, "MALFORMED_RESULT");
+  assert(err.malformedKeys?.includes("creature-a"));
+});
+
+Deno.test("BatchScorerReconciler - rejects negative recordCount", () => {
+  const payload = JSON.stringify({
+    "creature-a": { score: 0.5, error: 0.5, recordCount: -1 },
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 10 },
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  assertEquals(err.reason, "MALFORMED_RESULT");
+  assert(err.malformedKeys?.includes("creature-a"));
+});
+
+Deno.test("BatchScorerReconciler - rejects non-integer recordCount", () => {
+  const payload = JSON.stringify({
+    "creature-a": { score: 0.5, error: 0.5, recordCount: 10.5 },
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 10 },
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  assertEquals(err.reason, "MALFORMED_RESULT");
+  assert(err.malformedKeys?.includes("creature-a"));
+});
+
+Deno.test("BatchScorerReconciler - empty expected set with empty payload is accepted", () => {
+  const results = reconcileBatchScorerOutput("{}", []);
+  assertEquals(results.size, 0);
+});
+
+Deno.test("BatchScorerReconciler - duplicate expected stems are deduplicated", () => {
+  const results = reconcileBatchScorerOutput(validPayload(), [
+    "creature-a",
+    "creature-a",
+    "creature-b",
+    "creature-c",
+  ]);
+  assertEquals(results.size, 3);
+});
+
+Deno.test("BatchScorerReconciler - reports all malformed creatures in one pass", () => {
+  const payload = JSON.stringify({
+    "creature-a": { score: 0.5, error: 0.5 }, // missing recordCount
+    "creature-b": { score: "bad", error: 0.5, recordCount: 10 }, // bad score
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 10 },
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  assertEquals(err.reason, "MALFORMED_RESULT");
+  assertEquals(err.malformedKeys?.slice().sort(), ["creature-a", "creature-b"]);
+});
+
+Deno.test("BatchScorerReconciler - preserves extra optional numeric fields", () => {
+  const payload = JSON.stringify({
+    "creature-a": {
+      score: 0.9,
+      error: 0.1,
+      recordCount: 50,
+      durationMs: 123,
+    },
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 50 },
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 50 },
+  });
+  const results = reconcileBatchScorerOutput(payload, expectedStems);
+  const a = results.get("creature-a");
+  assert(a !== undefined);
+  assertEquals((a as unknown as Record<string, unknown>).durationMs, 123);
+});
+
+Deno.test("BatchScorerReconciler - rejects array-typed result", () => {
+  const payload = JSON.stringify({
+    "creature-a": [0.5, 0.5, 10],
+    "creature-b": { score: 0.5, error: 0.5, recordCount: 10 },
+    "creature-c": { score: 0.5, error: 0.5, recordCount: 10 },
+  });
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput(payload, expectedStems)
+  );
+  assertEquals(err.reason, "MALFORMED_RESULT");
+  assert(err.malformedKeys?.includes("creature-a"));
+});
+
+Deno.test("BatchScorerError exposes reason for programmatic handling", () => {
+  const err = expectBatchError(() =>
+    reconcileBatchScorerOutput("not json", expectedStems)
+  );
+  assertEquals(err.name, "BatchScorerError");
+  assertEquals(err.reason, "INVALID_JSON");
+  assert(err instanceof Error, "BatchScorerError extends Error");
+});


### PR DESCRIPTION
## Summary

Adds strict reconciliation for batch scorer output so NEAT-AI never silently
mis-scores a generation. Introduces `src/score/BatchScorerReconciler.ts` and
the typed `BatchScorerError` so callers can parse a single-JSON batch scorer
payload, verify the result key set exactly matches the expected creature
filename stems, and validate every result carries finite numeric `score`,
`error`, and non-negative integer `recordCount` fields. Any key mismatch or
malformed result fails fast with an actionable diagnostic that names the
offending stems and fields. Closes #2423.

The module is deliberately scoped to parser/reconciliation hardening per the
issue's note — no process orchestration is changed.

### Error semantics

`BatchScorerError.reason` distinguishes:

- `INVALID_JSON` — raw payload string could not be parsed.
- `NOT_AN_OBJECT` — parsed value is not a JSON object (e.g. array, null).
- `MISSING_KEYS` — one or more expected creature stems were absent.
- `EXTRA_KEYS` — scorer returned stems not in the expected set.
- `MALFORMED_RESULT` — one or more results failed numeric-field validation.

`missingKeys`, `extraKeys`, and `malformedKeys` are populated on the error so
callers can emit structured telemetry in addition to the human-readable
message.

## Evidence

Backend/CLI change with no UI surface. Verified via the new integration test
suite:

```
running 20 tests from ./test/score/BatchScorerReconciler.ts
BatchScorerReconciler - happy path parses and returns a map ... ok
BatchScorerReconciler - accepts pre-parsed object payload ... ok
BatchScorerReconciler - fails fast on invalid JSON string ... ok
BatchScorerReconciler - rejects non-object payloads ... ok
BatchScorerReconciler - rejects null payload ... ok
BatchScorerReconciler - fails fast when a key is missing ... ok
BatchScorerReconciler - fails fast when an extra key is present ... ok
BatchScorerReconciler - reports both missing and extra keys together ... ok
BatchScorerReconciler - rejects result that is not an object ... ok
BatchScorerReconciler - rejects missing numeric field ... ok
BatchScorerReconciler - rejects NaN for a numeric field ... ok
BatchScorerReconciler - rejects infinite error field ... ok
BatchScorerReconciler - rejects negative recordCount ... ok
BatchScorerReconciler - rejects non-integer recordCount ... ok
BatchScorerReconciler - empty expected set with empty payload is accepted ... ok
BatchScorerReconciler - duplicate expected stems are deduplicated ... ok
BatchScorerReconciler - reports all malformed creatures in one pass ... ok
BatchScorerReconciler - preserves extra optional numeric fields ... ok
BatchScorerReconciler - rejects array-typed result ... ok
BatchScorerError exposes reason for programmatic handling ... ok

ok | 20 passed | 0 failed
```

Full quality gate: `./quality.sh --skip-discovery --skip-wasm` →
`6185 passed | 0 failed | 3 ignored` (5m39s).

## Test Plan

- `test/score/BatchScorerReconciler.ts` (new) — 20 tests covering every
  acceptance criterion:
  - **Happy path** — string and pre-parsed object payloads both return a map.
  - **Mismatch path** — missing keys, extra keys, combined mismatch (both
    surfaced in the same message), and deduplication of expected stems.
  - **Malformed path** — non-object result, missing numeric field, NaN,
    infinite, negative, and non-integer `recordCount`, array-typed result,
    and a multi-creature malformed case that reports every offender in one
    pass.
  - **Error type** — `BatchScorerError.reason` is exposed for programmatic
    handling and `instanceof Error` holds.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2423 -->