### PR TITLE
Use rust_scorer directory mode for generation scoring (#2422)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2422.md
+++ b/docs/pr-summary-2422.md
@@ -1,58 +1,56 @@
 ## Summary
 
-Use `rust_scorer` directory mode for generation scoring — one scorer process
-per generation instead of one per creature. Closes #2422.
+Use `rust_scorer` directory mode for generation scoring — one scorer process per
+generation instead of one per creature. Closes #2422.
 
 NEAT-AI-scorer (issue #17) now accepts either a single creature file or a
-creatures directory plus a data directory. The orchestration side now
-detects this contract: `Fitness.calculate` writes every unique creature in
-the generation into a temporary directory keyed by UUID, invokes
+creatures directory plus a data directory. The orchestration side now detects
+this contract: `Fitness.calculate` writes every unique creature in the
+generation into a temporary directory keyed by UUID, invokes
 `rust_scorer <creatures_dir> <data_dir>` exactly once, and reconciles the
-top-level JSON map back to in-memory creatures via filename stem. The
-existing per-creature path is preserved as a fallback when the scorer is
-disabled, unavailable, opts out of batch mode
-(`NEAT_AI_RUST_SCORER_BATCH=false`), or returns a payload that cannot be
-reconciled.
+top-level JSON map back to in-memory creatures via filename stem. The existing
+per-creature path is preserved as a fallback when the scorer is disabled,
+unavailable, opts out of batch mode (`NEAT_AI_RUST_SCORER_BATCH=false`), or
+returns a payload that cannot be reconciled.
 
 Changes:
 
 - **`src/score/BatchRustScorerBridge.ts`** (new) — spawns `rust_scorer` in
-  directory mode and maps entries back to their in-memory `Creature` by
-  UUID stem. Reuses `reconcileBatchScorerOutput` for strict key-set
-  validation so missing/extra keys surface as explicit `BatchScorerError`s.
+  directory mode and maps entries back to their in-memory `Creature` by UUID
+  stem. Reuses `reconcileBatchScorerOutput` for strict key-set validation so
+  missing/extra keys surface as explicit `BatchScorerError`s.
 - **`src/score/RustScorerBridgeInternal.ts`** (new) — shared probe cache,
-  child-env merge, and injected command runner so the per-creature bridge
-  and the new batch bridge agree on configuration and test hooks.
-- **`src/score/RustScorerBridge.ts`** — exports `getEnvRustScorerConfig()`
-  so `Fitness.calculate` can drive batch scoring from the same
-  environment-derived config. Reads `NEAT_AI_RUST_SCORER_BATCH` (default
-  `true`) into the resolved config.
-- **`src/config/RustScorerConfig.ts`** — adds `batch?: boolean`. Batch is
-  on by default when the scorer is enabled; operators can flip it off to
-  keep the per-creature behaviour.
-- **`src/architecture/Fitness.ts`** — when batch mode is enabled and a
-  dataset directory is available, scores the whole unique-creature queue
-  in one scorer call. Records `lastBatchScorerInvocations` alongside
-  existing scorer telemetry. On any batch failure, logs the reconciliation
-  reason and falls back to the per-creature worker path.
-- **`src/NEAT/Neat.ts`** — propagates `setDataDir` to `Fitness` so batch
-  scoring can invoke the scorer with the right data directory.
+  child-env merge, and injected command runner so the per-creature bridge and
+  the new batch bridge agree on configuration and test hooks.
+- **`src/score/RustScorerBridge.ts`** — exports `getEnvRustScorerConfig()` so
+  `Fitness.calculate` can drive batch scoring from the same environment-derived
+  config. Reads `NEAT_AI_RUST_SCORER_BATCH` (default `true`) into the resolved
+  config.
+- **`src/config/RustScorerConfig.ts`** — adds `batch?: boolean`. Batch is on by
+  default when the scorer is enabled; operators can flip it off to keep the
+  per-creature behaviour.
+- **`src/architecture/Fitness.ts`** — when batch mode is enabled and a dataset
+  directory is available, scores the whole unique-creature queue in one scorer
+  call. Records `lastBatchScorerInvocations` alongside existing scorer
+  telemetry. On any batch failure, logs the reconciliation reason and falls back
+  to the per-creature worker path.
+- **`src/NEAT/Neat.ts`** — propagates `setDataDir` to `Fitness` so batch scoring
+  can invoke the scorer with the right data directory.
 
 ## Evidence
 
-This is a backend/CLI change with no user interface. Verified via the new
-test suites below:
+This is a backend/CLI change with no user interface. Verified via the new test
+suites below:
 
-- `test/score/BatchRustScorerBridge.ts` — 10 tests covering the batch
-  bridge in isolation, including one-process-per-generation, stem
-  mapping, missing/extra key failures, probe fallback, non-zero exit, and
-  temp-directory cleanup.
-- `test/NEAT/FitnessBatchRustScorer.ts` — 2 tests covering the Fitness
-  wiring, including the "exactly one scorer process per generation" and
-  "falls back to per-creature scoring on reconciliation failure" cases.
+- `test/score/BatchRustScorerBridge.ts` — 10 tests covering the batch bridge in
+  isolation, including one-process-per-generation, stem mapping, missing/extra
+  key failures, probe fallback, non-zero exit, and temp-directory cleanup.
+- `test/NEAT/FitnessBatchRustScorer.ts` — 2 tests covering the Fitness wiring,
+  including the "exactly one scorer process per generation" and "falls back to
+  per-creature scoring on reconciliation failure" cases.
 
-Quality gate (`./quality.sh --skip-discovery --skip-wasm --skip-tests`)
-passes cleanly. Targeted test runs:
+Quality gate (`./quality.sh --skip-discovery --skip-wasm --skip-tests`) passes
+cleanly. Targeted test runs:
 
 ```
 deno test test/score/ test/NEAT/FitnessBatchRustScorer.ts \
@@ -64,17 +62,17 @@ deno test test/score/ test/NEAT/FitnessBatchRustScorer.ts \
 
 ## Test Plan
 
-- [x] `test/score/BatchRustScorerBridge.ts` — new file, 10 tests for the
-      batch scorer bridge contract.
+- [x] `test/score/BatchRustScorerBridge.ts` — new file, 10 tests for the batch
+      scorer bridge contract.
 - [x] `test/NEAT/FitnessBatchRustScorer.ts` — new file, 2 tests verifying
-      `Fitness.calculate` uses the batch scorer when enabled and falls
-      back cleanly on reconciliation failure.
-- [x] `test/score/RustScorerBridgeHardening.ts` — updated to include the
-      new `batch: false` field on config literals (existing per-creature
-      tests unchanged in intent).
+      `Fitness.calculate` uses the batch scorer when enabled and falls back
+      cleanly on reconciliation failure.
+- [x] `test/score/RustScorerBridgeHardening.ts` — updated to include the new
+      `batch: false` field on config literals (existing per-creature tests
+      unchanged in intent).
 - [x] `test/score/RustScorerIntegration.ts` — same field-only update.
 - [x] Existing `test/score/BatchScorerReconciler.ts` reconciliation tests
       continue to pass unchanged.
 - [x] Existing `test/NEAT/FitnessDeduplication.ts` and
-      `test/NEAT/FitnessQueueDequeue.ts` Fitness loop tests continue to
-      pass without modification.
+      `test/NEAT/FitnessQueueDequeue.ts` Fitness loop tests continue to pass
+      without modification.

--- a/docs/pr-summary-2422.md
+++ b/docs/pr-summary-2422.md
@@ -1,0 +1,80 @@
+## Summary
+
+Use `rust_scorer` directory mode for generation scoring — one scorer process
+per generation instead of one per creature. Closes #2422.
+
+NEAT-AI-scorer (issue #17) now accepts either a single creature file or a
+creatures directory plus a data directory. The orchestration side now
+detects this contract: `Fitness.calculate` writes every unique creature in
+the generation into a temporary directory keyed by UUID, invokes
+`rust_scorer <creatures_dir> <data_dir>` exactly once, and reconciles the
+top-level JSON map back to in-memory creatures via filename stem. The
+existing per-creature path is preserved as a fallback when the scorer is
+disabled, unavailable, opts out of batch mode
+(`NEAT_AI_RUST_SCORER_BATCH=false`), or returns a payload that cannot be
+reconciled.
+
+Changes:
+
+- **`src/score/BatchRustScorerBridge.ts`** (new) — spawns `rust_scorer` in
+  directory mode and maps entries back to their in-memory `Creature` by
+  UUID stem. Reuses `reconcileBatchScorerOutput` for strict key-set
+  validation so missing/extra keys surface as explicit `BatchScorerError`s.
+- **`src/score/RustScorerBridgeInternal.ts`** (new) — shared probe cache,
+  child-env merge, and injected command runner so the per-creature bridge
+  and the new batch bridge agree on configuration and test hooks.
+- **`src/score/RustScorerBridge.ts`** — exports `getEnvRustScorerConfig()`
+  so `Fitness.calculate` can drive batch scoring from the same
+  environment-derived config. Reads `NEAT_AI_RUST_SCORER_BATCH` (default
+  `true`) into the resolved config.
+- **`src/config/RustScorerConfig.ts`** — adds `batch?: boolean`. Batch is
+  on by default when the scorer is enabled; operators can flip it off to
+  keep the per-creature behaviour.
+- **`src/architecture/Fitness.ts`** — when batch mode is enabled and a
+  dataset directory is available, scores the whole unique-creature queue
+  in one scorer call. Records `lastBatchScorerInvocations` alongside
+  existing scorer telemetry. On any batch failure, logs the reconciliation
+  reason and falls back to the per-creature worker path.
+- **`src/NEAT/Neat.ts`** — propagates `setDataDir` to `Fitness` so batch
+  scoring can invoke the scorer with the right data directory.
+
+## Evidence
+
+This is a backend/CLI change with no user interface. Verified via the new
+test suites below:
+
+- `test/score/BatchRustScorerBridge.ts` — 10 tests covering the batch
+  bridge in isolation, including one-process-per-generation, stem
+  mapping, missing/extra key failures, probe fallback, non-zero exit, and
+  temp-directory cleanup.
+- `test/NEAT/FitnessBatchRustScorer.ts` — 2 tests covering the Fitness
+  wiring, including the "exactly one scorer process per generation" and
+  "falls back to per-creature scoring on reconciliation failure" cases.
+
+Quality gate (`./quality.sh --skip-discovery --skip-wasm --skip-tests`)
+passes cleanly. Targeted test runs:
+
+```
+deno test test/score/ test/NEAT/FitnessBatchRustScorer.ts \
+          test/NEAT/FitnessDeduplication.ts \
+          test/NEAT/FitnessQueueDequeue.ts \
+          test/NEAT/EvolveWasmPanicRecovery.ts
+→ all passing
+```
+
+## Test Plan
+
+- [x] `test/score/BatchRustScorerBridge.ts` — new file, 10 tests for the
+      batch scorer bridge contract.
+- [x] `test/NEAT/FitnessBatchRustScorer.ts` — new file, 2 tests verifying
+      `Fitness.calculate` uses the batch scorer when enabled and falls
+      back cleanly on reconciliation failure.
+- [x] `test/score/RustScorerBridgeHardening.ts` — updated to include the
+      new `batch: false` field on config literals (existing per-creature
+      tests unchanged in intent).
+- [x] `test/score/RustScorerIntegration.ts` — same field-only update.
+- [x] Existing `test/score/BatchScorerReconciler.ts` reconciliation tests
+      continue to pass unchanged.
+- [x] Existing `test/NEAT/FitnessDeduplication.ts` and
+      `test/NEAT/FitnessQueueDequeue.ts` Fitness loop tests continue to
+      pass without modification.

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -235,6 +235,9 @@ export class Neat {
 
   setDataDir(dataDir: string): void {
     this.dataDir = dataDir;
+    // Issue #2422: Propagate to Fitness so batch rust scoring can spawn
+    // `rust_scorer` once per generation with the dataset directory.
+    this.fitness.setDataDir(dataDir);
   }
 
   static deepCloneAndShuffle<T>(arr: T[]): T[] {

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -8,6 +8,9 @@ import { ValidationError } from "@errors/ValidationError.ts";
 import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { calculate as calculateScore } from "@architecture/Score.ts";
+import { tryBatchScoreWithRustScorer } from "../score/BatchRustScorerBridge.ts";
+import { getEnvRustScorerConfig } from "../score/RustScorerBridge.ts";
+import { BatchScorerError } from "../score/BatchScorerReconciler.ts";
 import { getLogger } from "@utils/Logger.ts";
 
 /**
@@ -69,16 +72,46 @@ export class Fitness {
    */
   lastScoredCreatureCount = 0;
 
+  /**
+   * Number of `rust_scorer` processes spawned during the most recent
+   * `calculate()` call.
+   *
+   * Issue #2422: In batch mode a generation with N creatures triggers
+   * exactly one scorer process. Zero means batch mode was disabled,
+   * unavailable, or fell back to the per-creature worker path.
+   */
+  lastBatchScorerInvocations = 0;
+
+  /**
+   * Data directory passed to the external `rust_scorer` binary in batch
+   * mode (Issue #2422). `undefined` disables batch scoring regardless of
+   * configuration, matching the behaviour of environments where no dataset
+   * is wired through to Fitness.
+   */
+  private dataDir: string | undefined;
+
   constructor(
     workers: WorkerHandler[],
     growth: number,
     feedbackLoop: boolean,
     evalConfig?: RequiredParallelEvaluationConfig,
+    dataDir?: string,
   ) {
     this.workers = workers;
     this.feedbackLoop = feedbackLoop;
     this.growth = growth;
     this.evalConfig = evalConfig ?? DEFAULT_PARALLEL_EVALUATION_CONFIG;
+    this.dataDir = dataDir;
+  }
+
+  /**
+   * Issue #2422: Provide the dataset directory so batch rust scoring can
+   * invoke the external `rust_scorer` binary with `(creatures_dir, data_dir)`
+   * arguments once per generation. Without a data directory, batch scoring
+   * is skipped and the per-creature worker path is used as before.
+   */
+  setDataDir(dataDir: string): void {
+    this.dataDir = dataDir;
   }
 
   /**
@@ -121,6 +154,7 @@ export class Fitness {
       this.lastQueueMaxDepth = 0;
       this.lastScorerMs = 0;
       this.lastScoredCreatureCount = 0;
+      this.lastBatchScorerInvocations = 0;
       return;
     }
 
@@ -135,6 +169,83 @@ export class Fitness {
     // call. Using bare numeric mutation keeps the hot path allocation-free.
     let scorerMsAccum = 0;
     let scoredCount = 0;
+    this.lastBatchScorerInvocations = 0;
+
+    // Issue #2422: When the external rust scorer is enabled in directory
+    // mode, invoke it once for the whole generation, map results back to
+    // creatures, and compute each creature's score on the main thread.
+    // This eliminates the per-creature `rust_scorer` process spawn on the
+    // worker side. Any reconciliation failure is logged and we fall back
+    // to the per-creature worker path so the generation still completes.
+    const rustScorerConfig = getEnvRustScorerConfig();
+    if (
+      rustScorerConfig.enabled && rustScorerConfig.batch && this.dataDir
+    ) {
+      try {
+        const batchRun = await tryBatchScoreWithRustScorer(
+          uniqueQueue,
+          this.dataDir,
+          rustScorerConfig,
+        );
+        this.lastBatchScorerInvocations = batchRun.invocations;
+        if (batchRun.results) {
+          for (const creature of uniqueQueue) {
+            const record = batchRun.results.get(creature);
+            if (!record) continue;
+            const error = record.error;
+            if (!Number.isFinite(error) || error < 0) {
+              addTag(creature, "error", "Infinity");
+              creature.score = -Infinity;
+            } else {
+              addTag(creature, "error", error.toString());
+              const scoreStart = performance.now();
+              creature.score = calculateScore(creature, error, this.growth);
+              scorerMsAccum += performance.now() - scoreStart;
+              scoredCount++;
+            }
+            addTag(creature, "score", creature.score.toString());
+
+            // Mirror the duplicate-fan-out from the per-creature path so
+            // population score invariants hold identically in batch mode.
+            const uuid = creature.uuid;
+            if (uuid) {
+              const dupes = duplicates.get(uuid);
+              if (dupes) {
+                const errorTag = getTag(creature, "error");
+                const scoreTag = getTag(creature, "score");
+                for (const duplicate of dupes) {
+                  if (duplicate !== creature) {
+                    duplicate.score = creature.score;
+                    if (errorTag) addTag(duplicate, "error", errorTag);
+                    if (scoreTag) addTag(duplicate, "score", scoreTag);
+                  }
+                }
+              }
+            }
+          }
+          this.lastScorerMs = scorerMsAccum;
+          this.lastScoredCreatureCount = scoredCount;
+          return;
+        }
+      } catch (err) {
+        // Surface batch reconciliation failures as explicit log errors per
+        // the acceptance criteria, then fall back to the per-creature path
+        // so the generation is not lost to a transient scorer issue.
+        const detail = err instanceof Error ? err.message : String(err);
+        if (err instanceof BatchScorerError) {
+          getLogger().error(
+            `[NEAT-AI] Batch rust scorer reconciliation failed ` +
+              `(${err.reason}): ${detail}; falling back to per-creature ` +
+              `scoring.`,
+          );
+        } else {
+          getLogger().error(
+            `[NEAT-AI] Batch rust scorer invocation failed: ${detail}; ` +
+              `falling back to per-creature scoring.`,
+          );
+        }
+      }
+    }
 
     // Issue #1862: Sort by topology hash to cluster same-topology creatures.
     // This improves WASM compilation cache hit rates because workers pull

--- a/src/config/RustScorerConfig.ts
+++ b/src/config/RustScorerConfig.ts
@@ -27,6 +27,13 @@ export interface RustScorerConfig {
    * Optional environment variables to inject into scorer process.
    */
   env?: Record<string, string>;
+  /**
+   * Issue #2422: Use directory/batch mode — invoke `rust_scorer` once per
+   * generation with a creatures directory rather than once per creature.
+   *
+   * Default: true (when `enabled` is true).
+   */
+  batch?: boolean;
 }
 
 /**
@@ -37,4 +44,5 @@ export interface RequiredRustScorerConfig {
   binaryPath: string;
   timeoutMs: number;
   env: Record<string, string>;
+  batch: boolean;
 }

--- a/src/score/BatchRustScorerBridge.ts
+++ b/src/score/BatchRustScorerBridge.ts
@@ -1,0 +1,198 @@
+/**
+ * Batch Rust scorer bridge (Issue #2422).
+ *
+ * Invokes the external `rust_scorer` binary in directory mode — one process
+ * per generation rather than one per creature — and reconciles the JSON map
+ * response back to the in-memory population by filename stem (creature UUID).
+ *
+ * Contract with `NEAT-AI-scorer` (issue #17):
+ *
+ *   rust_scorer <creature.json | creatures_dir> <data_dir>
+ *
+ * When a directory is passed as the first argument, the scorer writes a
+ * single JSON object to stdout keyed by the creature filename stem. Each
+ * value is a record validated by `BatchScorerReconciler` — `{score, error,
+ * recordCount, ...}`.
+ *
+ * Failures (missing keys, extra keys, malformed results, non-JSON stdout,
+ * non-zero exit) surface as {@link BatchScorerError} so generation scoring
+ * can fail fast rather than silently mis-score creatures. The caller can
+ * then choose to fall back to the per-creature scoring path.
+ *
+ * @module BatchRustScorerBridge
+ */
+
+import { join, resolve } from "@std/path";
+import type { Creature } from "@creature";
+import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import {
+  BatchScorerError,
+  type BatchScorerResult,
+  reconcileBatchScorerOutput,
+} from "./BatchScorerReconciler.ts";
+import {
+  __getBatchRunner,
+  buildChildEnv,
+  resolveProbeState,
+} from "./RustScorerBridgeInternal.ts";
+
+/**
+ * Outcome of a batch scorer invocation.
+ *
+ * On success: `results` is a `Map<Creature, BatchScorerResult>` — callers
+ * walk their population and apply the scorer output per creature.
+ *
+ * On a skip (disabled, unavailable, batch mode turned off): `results` is
+ * `undefined`. Callers should fall back to the per-creature scoring path.
+ */
+export interface BatchScorerRunResult {
+  results: Map<Creature, BatchScorerResult> | undefined;
+  /** Number of scorer processes spawned (0 when skipped, 1 on success). */
+  invocations: number;
+}
+
+/**
+ * Score an entire population in a single `rust_scorer` invocation.
+ *
+ * Writes every creature in `creatures` to a temporary directory (one file per
+ * creature named `<uuid>.json`), spawns the scorer once with `(creatures_dir,
+ * data_dir)`, parses the top-level JSON map, and maps each entry back to its
+ * in-memory creature via filename stem.
+ *
+ * The temporary directory and creature files are always cleaned up, even on
+ * failure.
+ *
+ * @throws {BatchScorerError} when the scorer process succeeds but its output
+ *   cannot be reconciled with the expected creature set (missing/extra keys,
+ *   malformed results, non-JSON stdout). Callers can catch this and decide
+ *   whether to abort the generation or retry with the per-creature path.
+ */
+export async function tryBatchScoreWithRustScorer(
+  creatures: readonly Creature[],
+  dataDir: string,
+  config: RequiredRustScorerConfig,
+): Promise<BatchScorerRunResult> {
+  if (!config.enabled || !config.batch) {
+    return { results: undefined, invocations: 0 };
+  }
+  if (creatures.length === 0) {
+    return { results: new Map(), invocations: 0 };
+  }
+
+  const probe = await resolveProbeState(config);
+  if (!probe.available) {
+    return { results: undefined, invocations: 0 };
+  }
+
+  // Map each creature to the filename stem used on disk. UUID is the stable,
+  // already-assigned identity (makeUUID is idempotent for creatures that
+  // already have one).
+  const creatureByStem = new Map<string, Creature>();
+  for (const creature of creatures) {
+    const uuid = creature.uuid ?? CreatureUtil.makeUUID(creature);
+    if (creatureByStem.has(uuid)) {
+      // Duplicate UUIDs in the input list are a caller bug — Fitness.calculate
+      // deduplicates upstream. Failing fast prevents silent stem collisions.
+      throw new Error(
+        `Batch scorer: duplicate creature UUID in input list: ${uuid}`,
+      );
+    }
+    creatureByStem.set(uuid, creature);
+  }
+
+  const expectedStems = Array.from(creatureByStem.keys());
+  const runCommand = __getBatchRunner();
+
+  const tmpBase = readEnvString("NEAT_AI_RUST_SCORER_TMP_DIR") ?? dataDir;
+  const creaturesDir = await Deno.makeTempDir({
+    dir: tmpBase,
+    prefix: "neat-rust-scorer-batch-",
+  });
+
+  try {
+    // Write every creature to `<uuid>.json` inside the batch directory.
+    // Using the UUID as the stem keeps the reconciliation unambiguous.
+    await Promise.all(
+      expectedStems.map(async (stem) => {
+        const creature = creatureByStem.get(stem)!;
+        const path = join(creaturesDir, `${stem}.json`);
+        await Deno.writeTextFile(
+          path,
+          JSON.stringify(creature.exportJSON()),
+        );
+      }),
+    );
+
+    const absoluteCreaturesDir = resolve(Deno.cwd(), creaturesDir);
+    const absoluteDataDir = resolve(Deno.cwd(), dataDir);
+
+    const result = await runCommand(
+      config.binaryPath,
+      [absoluteCreaturesDir, absoluteDataDir],
+      {
+        env: buildChildEnv(config.env),
+        timeoutMs: config.timeoutMs,
+      },
+    );
+
+    if (!result.success) {
+      throw new BatchScorerError(
+        `Rust scorer batch call failed (exit ${result.code}): ${
+          trimForLog(result.stderr)
+        }`,
+        "INVALID_JSON",
+      );
+    }
+
+    // `reconcileBatchScorerOutput` throws `BatchScorerError` on any parse or
+    // key-set mismatch, so missing/extra keys surface as explicit errors per
+    // the issue acceptance criteria.
+    const reconciled = reconcileBatchScorerOutput(
+      result.stdout,
+      expectedStems,
+    );
+
+    const byCreature = new Map<Creature, BatchScorerResult>();
+    for (const [stem, record] of reconciled) {
+      const creature = creatureByStem.get(stem);
+      if (!creature) {
+        // Defensive — reconcile already rejects extras, so this is unreachable
+        // unless the reconciler contract changes.
+        throw new BatchScorerError(
+          `Batch scorer returned result for unknown stem: ${stem}`,
+          "EXTRA_KEYS",
+          { extraKeys: [stem] },
+        );
+      }
+      byCreature.set(creature, record);
+    }
+
+    return { results: byCreature, invocations: 1 };
+  } finally {
+    try {
+      await Deno.remove(creaturesDir, { recursive: true });
+    } catch {
+      // Ignore cleanup errors — temp dir leak is less bad than masking the
+      // underlying failure.
+    }
+  }
+}
+
+function readEnvString(key: string): string | undefined {
+  try {
+    const v = Deno.env.get(key);
+    if (v === undefined || v.trim() === "") return undefined;
+    return v;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Matches the trim policy in `RustScorerBridge.ts` for consistent logs. */
+function trimForLog(value: string, limit: number = 2000): string {
+  if (!value) return "";
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= limit) return collapsed;
+  return collapsed.slice(0, limit) + "…";
+}

--- a/src/score/RustScorerBridge.ts
+++ b/src/score/RustScorerBridge.ts
@@ -2,38 +2,18 @@ import { join, resolve } from "@std/path";
 import type { Creature } from "@creature";
 import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
 import { getLogger } from "@utils/Logger.ts";
+import {
+  __getBatchRunner,
+  __resetInternal,
+  __setRunnerInternal,
+  buildChildEnv,
+  type CommandRunner,
+  resolveProbeState,
+} from "./RustScorerBridgeInternal.ts";
 
 interface RustScorerResult {
   error: number;
 }
-
-interface RustScorerProbeState {
-  available: boolean;
-  binaryPath: string;
-  warned: boolean;
-}
-
-type CommandRunner = (
-  command: string,
-  args: string[],
-  options: {
-    /**
-     * Environment variables to pass to the child process. When `undefined`,
-     * the child inherits the parent process environment. When provided, the
-     * mapping is passed verbatim to `Deno.Command` (callers are responsible
-     * for merging parent env if they want inheritance plus overrides).
-     */
-    env?: Record<string, string>;
-    timeoutMs: number;
-  },
-) => Promise<{
-  success: boolean;
-  code: number;
-  stdout: string;
-  stderr: string;
-}>;
-
-const probeCache = new Map<string, RustScorerProbeState>();
 
 let envRustScorerCache: RequiredRustScorerConfig | undefined;
 
@@ -82,8 +62,11 @@ function trimForLog(value: string, limit: number = LOG_TRIM_LIMIT): string {
 /**
  * Lazily resolved scorer config from environment (NEAT_AI_RUST_SCORER_*).
  * Cached for the lifetime of the process unless reset by tests.
+ *
+ * Issue #2422: Exposed so that `Fitness.calculate` can drive batch scoring
+ * from the same env-derived config as the per-creature call site.
  */
-function getEnvRustScorerConfig(): RequiredRustScorerConfig {
+export function getEnvRustScorerConfig(): RequiredRustScorerConfig {
   if (envRustScorerCache !== undefined) return envRustScorerCache;
 
   const enabled = parseBoolLike(readEnvString("NEAT_AI_RUST_SCORER_ENABLED")) ??
@@ -107,73 +90,15 @@ function getEnvRustScorerConfig(): RequiredRustScorerConfig {
     }
   }
 
-  envRustScorerCache = { enabled, binaryPath, timeoutMs, env };
+  // Issue #2422: Directory/batch mode is preferred when the external scorer
+  // is enabled. Operators can opt out with NEAT_AI_RUST_SCORER_BATCH=false to
+  // fall back to per-creature invocations.
+  const batch = parseBoolLike(readEnvString("NEAT_AI_RUST_SCORER_BATCH")) ??
+    true;
+
+  envRustScorerCache = { enabled, binaryPath, timeoutMs, env, batch };
   return envRustScorerCache;
 }
-
-/**
- * Build the env argument for a child process call.
- *
- * Returns `undefined` when no overrides are configured so the child inherits
- * the parent environment verbatim (avoids the `env: {}` foot-gun where the
- * child gets an empty environment). When overrides exist, merges them over
- * the parent env snapshot.
- */
-function buildChildEnv(
-  overrides: Record<string, string>,
-): Record<string, string> | undefined {
-  const keys = Object.keys(overrides);
-  if (keys.length === 0) return undefined;
-  let parent: Record<string, string> = {};
-  try {
-    parent = Deno.env.toObject();
-  } catch {
-    // Fall through with an empty parent snapshot; overrides still applied.
-  }
-  return { ...parent, ...overrides };
-}
-
-async function defaultRunner(
-  command: string,
-  args: string[],
-  options: {
-    env?: Record<string, string>;
-    timeoutMs: number;
-  },
-): Promise<{
-  success: boolean;
-  code: number;
-  stdout: string;
-  stderr: string;
-}> {
-  // Omit `env` from Deno.Command when the caller did not provide overrides so
-  // the child inherits the full parent environment (PATH, HOME, locale, etc.).
-  const cmdOptions: Deno.CommandOptions = options.env !== undefined
-    ? { args, env: options.env, stdout: "piped", stderr: "piped" }
-    : { args, stdout: "piped", stderr: "piped" };
-  const cmd = new Deno.Command(command, cmdOptions);
-
-  const output = options.timeoutMs > 0
-    ? await Promise.race([
-      cmd.output(),
-      new Promise<never>((_, reject) => {
-        setTimeout(
-          () => reject(new Error("rust scorer timeout")),
-          options.timeoutMs,
-        );
-      }),
-    ])
-    : await cmd.output();
-
-  return {
-    success: output.success,
-    code: output.code,
-    stdout: new TextDecoder().decode(output.stdout),
-    stderr: new TextDecoder().decode(output.stderr),
-  };
-}
-
-let runCommand: CommandRunner = defaultRunner;
 
 function getTmpDiagnostics(): string {
   let context: string;
@@ -205,39 +130,6 @@ async function getWritePermissionDiagnostics(path?: string): Promise<string> {
       error instanceof Error ? error.message : String(error)
     }>`;
   }
-}
-
-function makeProbeKey(config: RequiredRustScorerConfig): string {
-  const envKeys = Object.keys(config.env).sort();
-  const envPairs = envKeys.map((k) => `${k}=${config.env[k]}`);
-  return `${config.binaryPath}|${config.timeoutMs}|${envPairs.join(",")}`;
-}
-
-async function resolveProbeState(
-  config: RequiredRustScorerConfig,
-): Promise<RustScorerProbeState> {
-  const key = makeProbeKey(config);
-  const cached = probeCache.get(key);
-  if (cached) return cached;
-
-  let available = false;
-  try {
-    const probe = await runCommand(config.binaryPath, ["--help"], {
-      env: buildChildEnv(config.env),
-      timeoutMs: config.timeoutMs,
-    });
-    available = probe.success || probe.code === 0 || probe.code === 1;
-  } catch {
-    available = false;
-  }
-
-  const state = {
-    available,
-    binaryPath: config.binaryPath,
-    warned: false,
-  };
-  probeCache.set(key, state);
-  return state;
 }
 
 async function writeCreatureTempFile(
@@ -281,7 +173,7 @@ export async function tryScoreWithRustScorer(
     // rust_scorer resolves relative paths against its own process cwd, which
     // may not match the Deno/worker cwd. Always hand it absolute paths.
     const absoluteDataDir = resolve(Deno.cwd(), dataDir);
-    const result = await runCommand(
+    const result = await __getBatchRunner()(
       config.binaryPath,
       [creaturePath, absoluteDataDir],
       {
@@ -366,11 +258,10 @@ export async function tryScoreWithRustScorer(
 }
 
 export function __resetRustScorerBridgeForTests(): void {
-  probeCache.clear();
+  __resetInternal();
   envRustScorerCache = undefined;
-  runCommand = defaultRunner;
 }
 
 export function __setRustScorerRunnerForTests(runner: CommandRunner): void {
-  runCommand = runner;
+  __setRunnerInternal(runner);
 }

--- a/src/score/RustScorerBridgeInternal.ts
+++ b/src/score/RustScorerBridgeInternal.ts
@@ -1,0 +1,157 @@
+/**
+ * Internal helpers shared between the per-creature and batch rust scorer
+ * bridges (Issue #2422).
+ *
+ * This module owns the pieces that must be singletons for both call paths:
+ *
+ * - The injected command runner (tests swap this for a fake via
+ *   `__setRustScorerRunnerForTests` on `RustScorerBridge.ts`).
+ * - The probe cache — both bridges must share a single probe so the
+ *   `rust_scorer --help` check is only paid once per config.
+ * - Child-env construction so batch and single modes agree on how to merge
+ *   caller-supplied overrides with the parent environment.
+ *
+ * @module RustScorerBridgeInternal
+ */
+
+import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
+
+/** Signature of a subprocess runner used by the rust scorer bridges. */
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  options: {
+    env?: Record<string, string>;
+    timeoutMs: number;
+  },
+) => Promise<{
+  success: boolean;
+  code: number;
+  stdout: string;
+  stderr: string;
+}>;
+
+/** Shape of a probe result cached per configuration. */
+export interface RustScorerProbeState {
+  available: boolean;
+  binaryPath: string;
+  warned: boolean;
+}
+
+async function defaultRunner(
+  command: string,
+  args: string[],
+  options: {
+    env?: Record<string, string>;
+    timeoutMs: number;
+  },
+): Promise<{
+  success: boolean;
+  code: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const cmdOptions: Deno.CommandOptions = options.env !== undefined
+    ? { args, env: options.env, stdout: "piped", stderr: "piped" }
+    : { args, stdout: "piped", stderr: "piped" };
+  const cmd = new Deno.Command(command, cmdOptions);
+
+  const output = options.timeoutMs > 0
+    ? await Promise.race([
+      cmd.output(),
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () => reject(new Error("rust scorer timeout")),
+          options.timeoutMs,
+        );
+      }),
+    ])
+    : await cmd.output();
+
+  return {
+    success: output.success,
+    code: output.code,
+    stdout: new TextDecoder().decode(output.stdout),
+    stderr: new TextDecoder().decode(output.stderr),
+  };
+}
+
+let runCommand: CommandRunner = defaultRunner;
+
+const probeCache = new Map<string, RustScorerProbeState>();
+
+/**
+ * Build the env argument for a child process call.
+ *
+ * Returns `undefined` when no overrides are configured so the child inherits
+ * the parent environment verbatim (avoids the `env: {}` foot-gun where the
+ * child gets an empty environment). When overrides exist, merges them over
+ * the parent env snapshot.
+ */
+export function buildChildEnv(
+  overrides: Record<string, string>,
+): Record<string, string> | undefined {
+  const keys = Object.keys(overrides);
+  if (keys.length === 0) return undefined;
+  let parent: Record<string, string> = {};
+  try {
+    parent = Deno.env.toObject();
+  } catch {
+    // Fall through with an empty parent snapshot; overrides still applied.
+  }
+  return { ...parent, ...overrides };
+}
+
+function makeProbeKey(config: RequiredRustScorerConfig): string {
+  const envKeys = Object.keys(config.env).sort();
+  const envPairs = envKeys.map((k) => `${k}=${config.env[k]}`);
+  return `${config.binaryPath}|${config.timeoutMs}|${envPairs.join(",")}`;
+}
+
+/**
+ * Resolve the probe state for a given scorer configuration. Cached so the
+ * probe call is only paid once per config across both per-creature and batch
+ * scoring paths.
+ */
+export async function resolveProbeState(
+  config: RequiredRustScorerConfig,
+): Promise<RustScorerProbeState> {
+  const key = makeProbeKey(config);
+  const cached = probeCache.get(key);
+  if (cached) return cached;
+
+  let available = false;
+  try {
+    const probe = await runCommand(config.binaryPath, ["--help"], {
+      env: buildChildEnv(config.env),
+      timeoutMs: config.timeoutMs,
+    });
+    available = probe.success || probe.code === 0 || probe.code === 1;
+  } catch {
+    available = false;
+  }
+
+  const state: RustScorerProbeState = {
+    available,
+    binaryPath: config.binaryPath,
+    warned: false,
+  };
+  probeCache.set(key, state);
+  return state;
+}
+
+/** Access the current runner for both bridges. */
+export function __getBatchRunner(): CommandRunner {
+  return runCommand;
+}
+
+/** Replace the runner (test hook shared with `RustScorerBridge.ts`). */
+export function __setRunnerInternal(runner: CommandRunner): void {
+  runCommand = runner;
+}
+
+/** Reset internal state (test hook shared with `RustScorerBridge.ts`). */
+export function __resetInternal(): void {
+  probeCache.clear();
+  runCommand = defaultRunner;
+}

--- a/test/NEAT/FitnessBatchRustScorer.ts
+++ b/test/NEAT/FitnessBatchRustScorer.ts
@@ -1,0 +1,226 @@
+/**
+ * Fitness-level batch rust scorer tests (Issue #2422).
+ *
+ * Verifies that when the external `rust_scorer` binary is enabled in batch
+ * mode, `Fitness.calculate` invokes the scorer process exactly once per
+ * generation, maps the per-creature results back by UUID stem, and bypasses
+ * the per-creature worker evaluation path.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { Fitness } from "@architecture/Fitness.ts";
+import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import {
+  __resetRustScorerBridgeForTests,
+  __setRustScorerRunnerForTests,
+} from "../../src/score/RustScorerBridge.ts";
+
+class MockWorkerHandler {
+  public evaluateCallCount = 0;
+  private busy = false;
+  private idleListeners: (() => void)[] = [];
+
+  addIdleListener(callback: () => void): void {
+    this.idleListeners.push(callback);
+  }
+
+  isBusy(): boolean {
+    return this.busy;
+  }
+
+  // deno-lint-ignore require-await
+  async evaluate(
+    _creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<{ evaluate: { error: number } }> {
+    this.evaluateCallCount++;
+    return { evaluate: { error: 0.5 } };
+  }
+}
+
+function buildDataSet(): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < 4; i++) {
+    rows.push({
+      input: new Float32Array([i, 4 - i]),
+      output: new Float32Array([i > 2 ? 1 : -1]),
+    });
+  }
+  return rows;
+}
+
+function buildPopulation(count: number): Creature[] {
+  const base: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "TANH", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+  };
+  const creatures: Creature[] = [];
+  for (let i = 0; i < count; i++) {
+    // Distinct biases → distinct UUIDs so dedup does not collapse them.
+    const forked = structuredClone(base);
+    forked.neurons[0].bias = 0.1 * (i + 1);
+    creatures.push(Creature.fromJSON(forked));
+  }
+  return creatures;
+}
+
+Deno.test("Fitness.calculate batch rust scorer - one scorer process per generation", async () => {
+  __resetRustScorerBridgeForTests();
+  const prevEnabled = Deno.env.get("NEAT_AI_RUST_SCORER_ENABLED");
+  const prevBatch = Deno.env.get("NEAT_AI_RUST_SCORER_BATCH");
+  Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", "true");
+  Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", "true");
+
+  const population = buildPopulation(4);
+  const uuids = population.map((c) => CreatureUtil.makeUUID(c));
+
+  let scoreCalls = 0;
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    scoreCalls++;
+    const payload: Record<
+      string,
+      { score: number; error: number; recordCount: number }
+    > = {};
+    for (let i = 0; i < uuids.length; i++) {
+      payload[uuids[i]] = {
+        score: 0.9 - i * 0.1,
+        error: 0.1 + i * 0.05,
+        recordCount: 4,
+      };
+    }
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: JSON.stringify(payload),
+      stderr: "",
+    });
+  });
+
+  const worker = new MockWorkerHandler();
+  const dataDir = makeDataDir(buildDataSet(), 4);
+  try {
+    const fitness = new Fitness(
+      [worker as unknown as WorkerHandler],
+      0.0001,
+      false,
+      undefined,
+      dataDir,
+    );
+    await fitness.calculate(population);
+
+    // Exactly one scorer process for the whole generation.
+    assertEquals(scoreCalls, 1, "exactly one scorer process per generation");
+    assertEquals(fitness.lastBatchScorerInvocations, 1);
+    // Worker evaluate must not be called because batch mode owns scoring.
+    assertEquals(
+      worker.evaluateCallCount,
+      0,
+      "batch mode should bypass the per-creature worker path",
+    );
+    // All creatures scored.
+    for (const creature of population) {
+      assert(creature.score !== undefined, "every creature should be scored");
+    }
+  } finally {
+    if (prevEnabled === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_ENABLED");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", prevEnabled);
+    }
+    if (prevBatch === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_BATCH");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", prevBatch);
+    }
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("Fitness.calculate batch rust scorer - falls back to worker path on reconciliation failure", async () => {
+  __resetRustScorerBridgeForTests();
+  const prevEnabled = Deno.env.get("NEAT_AI_RUST_SCORER_ENABLED");
+  const prevBatch = Deno.env.get("NEAT_AI_RUST_SCORER_BATCH");
+  Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", "true");
+  Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", "true");
+
+  const population = buildPopulation(3);
+  // Generate UUIDs up-front so the reconciler knows what to expect.
+  for (const c of population) CreatureUtil.makeUUID(c);
+
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    // Return an empty object so every expected UUID is missing — reconciler
+    // throws a MISSING_KEYS BatchScorerError and Fitness.calculate falls
+    // back to the per-creature worker path.
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: "{}",
+      stderr: "",
+    });
+  });
+
+  const worker = new MockWorkerHandler();
+  const dataDir = makeDataDir(buildDataSet(), 4);
+  try {
+    const fitness = new Fitness(
+      [worker as unknown as WorkerHandler],
+      0.0001,
+      false,
+      undefined,
+      dataDir,
+    );
+    await fitness.calculate(population);
+
+    // Fallback engaged: every unique creature goes through the worker path.
+    assertEquals(
+      worker.evaluateCallCount,
+      population.length,
+      "per-creature worker fallback should score every creature",
+    );
+    // Still records the single batch invocation attempt.
+    assertEquals(fitness.lastBatchScorerInvocations, 0);
+  } finally {
+    if (prevEnabled === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_ENABLED");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", prevEnabled);
+    }
+    if (prevBatch === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_BATCH");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", prevBatch);
+    }
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});

--- a/test/score/BatchRustScorerBridge.ts
+++ b/test/score/BatchRustScorerBridge.ts
@@ -1,0 +1,462 @@
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { isAbsolute } from "@std/path";
+import { Creature } from "@creature";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import {
+  __resetRustScorerBridgeForTests,
+  __setRustScorerRunnerForTests,
+} from "../../src/score/RustScorerBridge.ts";
+import { tryBatchScoreWithRustScorer } from "../../src/score/BatchRustScorerBridge.ts";
+import { BatchScorerError } from "../../src/score/BatchScorerReconciler.ts";
+import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/**
+ * Tests for the batch rust scorer bridge (Issue #2422).
+ *
+ * These cover the directory-mode invocation contract: one scorer process per
+ * generation, results mapped back to in-memory creatures by filename stem,
+ * with explicit errors on missing/extra keys or malformed output.
+ */
+
+function buildDataSet(): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < 8; i++) {
+    const a = i / 8;
+    const b = (8 - i) / 8;
+    rows.push({
+      input: new Float32Array([a, b]),
+      output: new Float32Array([a > b ? 1 : -1]),
+    });
+  }
+  return rows;
+}
+
+function buildConfig(
+  overrides?: Partial<RequiredRustScorerConfig>,
+): RequiredRustScorerConfig {
+  return {
+    enabled: true,
+    binaryPath: "rust_scorer",
+    timeoutMs: 0,
+    env: {},
+    batch: true,
+    ...overrides,
+  };
+}
+
+function makeCreatureWithUuid(uuid: string): Creature {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  // Ensure a deterministic stem for reconciliation — the bridge relies on
+  // creature.uuid as the filename stem.
+  creature.uuid = uuid;
+  return creature;
+}
+
+function buildResultPayload(
+  entries: Record<
+    string,
+    { score: number; error: number; recordCount: number }
+  >,
+): string {
+  return JSON.stringify(entries);
+}
+
+Deno.test("BatchRustScorer - invokes scorer once for N creatures", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let scoreCalls = 0;
+  let seenArgs: string[] = [];
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    scoreCalls++;
+    seenArgs = args;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: buildResultPayload({
+        "creature-1": { score: 0.9, error: 0.1, recordCount: 8 },
+        "creature-2": { score: 0.8, error: 0.2, recordCount: 8 },
+        "creature-3": { score: 0.7, error: 0.3, recordCount: 8 },
+      }),
+      stderr: "",
+    });
+  });
+
+  const creatures = [
+    makeCreatureWithUuid("creature-1"),
+    makeCreatureWithUuid("creature-2"),
+    makeCreatureWithUuid("creature-3"),
+  ];
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const run = await tryBatchScoreWithRustScorer(
+      creatures,
+      dataDir,
+      buildConfig(),
+    );
+    assertEquals(
+      run.invocations,
+      1,
+      "exactly one scorer process per N creatures",
+    );
+    assertEquals(scoreCalls, 1, "scorer runner should be called once");
+    assert(run.results !== undefined, "results map should be populated");
+    assertEquals(run.results!.size, 3);
+    assertEquals(run.results!.get(creatures[0])!.error, 0.1);
+    assertEquals(run.results!.get(creatures[1])!.error, 0.2);
+    assertEquals(run.results!.get(creatures[2])!.error, 0.3);
+    // Directory and data-dir arguments must be absolute so child processes
+    // with a different cwd can resolve them.
+    assertEquals(seenArgs.length, 2);
+    assert(isAbsolute(seenArgs[0]), "creatures dir must be absolute");
+    assert(isAbsolute(seenArgs[1]), "data dir must be absolute");
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer - maps each entry back to its in-memory creature", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: buildResultPayload({
+        "alpha": { score: 0.5, error: 0.05, recordCount: 8 },
+        "beta": { score: 0.25, error: 0.75, recordCount: 8 },
+      }),
+      stderr: "",
+    });
+  });
+
+  const alpha = makeCreatureWithUuid("alpha");
+  const beta = makeCreatureWithUuid("beta");
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const run = await tryBatchScoreWithRustScorer(
+      [alpha, beta],
+      dataDir,
+      buildConfig(),
+    );
+    assert(run.results !== undefined);
+    assertEquals(run.results!.get(alpha)!.error, 0.05);
+    assertEquals(run.results!.get(beta)!.error, 0.75);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer - missing key surfaces BatchScorerError", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    // creature-b omitted — reconciliation must fail explicitly.
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: buildResultPayload({
+        "creature-a": { score: 0.5, error: 0.5, recordCount: 8 },
+      }),
+      stderr: "",
+    });
+  });
+
+  const a = makeCreatureWithUuid("creature-a");
+  const b = makeCreatureWithUuid("creature-b");
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const err = await assertRejects(
+      () => tryBatchScoreWithRustScorer([a, b], dataDir, buildConfig()),
+      BatchScorerError,
+    );
+    assertEquals(err.reason, "MISSING_KEYS");
+    assertEquals(err.missingKeys, ["creature-b"]);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer - extra key surfaces BatchScorerError", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: buildResultPayload({
+        "creature-a": { score: 0.5, error: 0.5, recordCount: 8 },
+        "creature-b": { score: 0.5, error: 0.5, recordCount: 8 },
+        "creature-ghost": { score: 0.5, error: 0.5, recordCount: 8 },
+      }),
+      stderr: "",
+    });
+  });
+
+  const a = makeCreatureWithUuid("creature-a");
+  const b = makeCreatureWithUuid("creature-b");
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const err = await assertRejects(
+      () => tryBatchScoreWithRustScorer([a, b], dataDir, buildConfig()),
+      BatchScorerError,
+    );
+    assertEquals(err.reason, "EXTRA_KEYS");
+    assertEquals(err.extraKeys, ["creature-ghost"]);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer - disabled config returns undefined results without invoking scorer", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let calls = 0;
+  __setRustScorerRunnerForTests(() => {
+    calls++;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+  });
+
+  const creature = makeCreatureWithUuid("creature-1");
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const run = await tryBatchScoreWithRustScorer(
+      [creature],
+      dataDir,
+      buildConfig({ enabled: false }),
+    );
+    assertEquals(run.results, undefined);
+    assertEquals(run.invocations, 0);
+    assertEquals(calls, 0);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer - batch flag off returns undefined results without invoking scorer", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let calls = 0;
+  __setRustScorerRunnerForTests(() => {
+    calls++;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+  });
+
+  const creature = makeCreatureWithUuid("creature-1");
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const run = await tryBatchScoreWithRustScorer(
+      [creature],
+      dataDir,
+      buildConfig({ batch: false }),
+    );
+    assertEquals(run.results, undefined);
+    assertEquals(run.invocations, 0);
+    assertEquals(calls, 0);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer - scorer unavailable falls back to per-creature path (undefined results)", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  __setRustScorerRunnerForTests(() => {
+    return Promise.reject(new Error("scorer binary missing"));
+  });
+
+  const creature = makeCreatureWithUuid("creature-1");
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const run = await tryBatchScoreWithRustScorer(
+      [creature],
+      dataDir,
+      buildConfig(),
+    );
+    assertEquals(run.results, undefined);
+    assertEquals(run.invocations, 0);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer - non-zero scorer exit raises BatchScorerError", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    return Promise.resolve({
+      success: false,
+      code: 2,
+      stdout: "",
+      stderr: "scorer failed",
+    });
+  });
+
+  const creature = makeCreatureWithUuid("creature-1");
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const err = await assertRejects(
+      () => tryBatchScoreWithRustScorer([creature], dataDir, buildConfig()),
+      BatchScorerError,
+    );
+    assert(
+      err.message.includes("scorer failed"),
+      `expected message to include stderr; got: ${err.message}`,
+    );
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer - cleans up temp creatures directory after run", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let creaturesDir: string | undefined;
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    creaturesDir = args[0];
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: buildResultPayload({
+        "creature-1": { score: 0.5, error: 0.5, recordCount: 8 },
+      }),
+      stderr: "",
+    });
+  });
+
+  const creature = makeCreatureWithUuid("creature-1");
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    await tryBatchScoreWithRustScorer([creature], dataDir, buildConfig());
+    assert(creaturesDir !== undefined);
+    assertEquals(
+      await Deno.stat(creaturesDir!).then(() => true).catch(() => false),
+      false,
+      "batch temp directory should be cleaned up after scoring",
+    );
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer - assigns UUID to creatures without one before batching", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const stem = CreatureUtil.makeUUID(creature);
+
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    const payload: Record<
+      string,
+      { score: number; error: number; recordCount: number }
+    > = {};
+    payload[stem] = { score: 0.42, error: 0.58, recordCount: 8 };
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: JSON.stringify(payload),
+      stderr: "",
+    });
+  });
+
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const run = await tryBatchScoreWithRustScorer(
+      [creature],
+      dataDir,
+      buildConfig(),
+    );
+    assert(run.results !== undefined);
+    assertEquals(run.results!.get(creature)!.error, 0.58);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});

--- a/test/score/RustScorerBridgeHardening.ts
+++ b/test/score/RustScorerBridgeHardening.ts
@@ -84,6 +84,7 @@ Deno.test("RustScorerBridge: inherits parent env when no overrides configured", 
         binaryPath: "rust_scorer",
         timeoutMs: 0,
         env: {},
+        batch: false,
       },
     );
     // env should be undefined when no overrides exist → child inherits parent env.
@@ -138,6 +139,7 @@ Deno.test("RustScorerBridge: merges overrides with parent env when overrides exi
         binaryPath: "rust_scorer",
         timeoutMs: 0,
         env: { OVERRIDE_KEY: "override_value" },
+        batch: false,
       },
     );
     assert(scoreEnv !== undefined, "runner should receive merged env");
@@ -196,6 +198,7 @@ Deno.test("RustScorerBridge: resolves creature and data paths to absolute paths"
         binaryPath: "rust_scorer",
         timeoutMs: 0,
         env: {},
+        batch: false,
       },
     );
     assertEquals(seenArgs.length, 2);
@@ -250,6 +253,7 @@ Deno.test("RustScorerBridge: logs trimmed stderr on non-zero exit", async () => 
         binaryPath: "rust_scorer",
         timeoutMs: 0,
         env: {},
+        batch: false,
       },
     );
     const failureWarning = warnings.find((w) =>
@@ -308,6 +312,7 @@ Deno.test("RustScorerBridge: handles non-JSON stdout gracefully and includes std
         binaryPath: "rust_scorer",
         timeoutMs: 0,
         env: {},
+        batch: false,
       },
     );
     assert(Number.isFinite(result.error));

--- a/test/score/RustScorerIntegration.ts
+++ b/test/score/RustScorerIntegration.ts
@@ -51,6 +51,7 @@ Deno.test("Rust scorer integration: disabled path does not invoke scorer", async
         binaryPath: "rust_scorer",
         timeoutMs: 0,
         env: {},
+        batch: false,
       },
     );
     assert(Number.isFinite(result.error));
@@ -81,6 +82,7 @@ Deno.test("Rust scorer integration: unavailable scorer probes once then falls ba
       binaryPath: "rust_scorer_missing",
       timeoutMs: 0,
       env: {},
+      batch: false,
     };
     const a = await creature.evaluateDir(
       dataDir,
@@ -143,6 +145,7 @@ Deno.test("Rust scorer integration: uses scorer error when available", async () 
         binaryPath: "rust_scorer",
         timeoutMs: 0,
         env: {},
+        batch: false,
       },
     );
     assertEquals(result.error, 0.12345);
@@ -194,6 +197,7 @@ Deno.test("Rust scorer integration: writes temp creature JSON in configured tmp 
         binaryPath: "rust_scorer",
         timeoutMs: 0,
         env: {},
+        batch: false,
       },
     );
     assertEquals(result.error, 0.25);


### PR DESCRIPTION
## Summary

Use `rust_scorer` directory mode for generation scoring — one scorer process
per generation instead of one per creature. Closes #2422.

NEAT-AI-scorer (issue #17) now accepts either a single creature file or a
creatures directory plus a data directory. The orchestration side now
detects this contract: `Fitness.calculate` writes every unique creature in
the generation into a temporary directory keyed by UUID, invokes
`rust_scorer <creatures_dir> <data_dir>` exactly once, and reconciles the
top-level JSON map back to in-memory creatures via filename stem. The
existing per-creature path is preserved as a fallback when the scorer is
disabled, unavailable, opts out of batch mode
(`NEAT_AI_RUST_SCORER_BATCH=false`), or returns a payload that cannot be
reconciled.

Changes:

- **`src/score/BatchRustScorerBridge.ts`** (new) — spawns `rust_scorer` in
  directory mode and maps entries back to their in-memory `Creature` by
  UUID stem. Reuses `reconcileBatchScorerOutput` for strict key-set
  validation so missing/extra keys surface as explicit `BatchScorerError`s.
- **`src/score/RustScorerBridgeInternal.ts`** (new) — shared probe cache,
  child-env merge, and injected command runner so the per-creature bridge
  and the new batch bridge agree on configuration and test hooks.
- **`src/score/RustScorerBridge.ts`** — exports `getEnvRustScorerConfig()`
  so `Fitness.calculate` can drive batch scoring from the same
  environment-derived config. Reads `NEAT_AI_RUST_SCORER_BATCH` (default
  `true`) into the resolved config.
- **`src/config/RustScorerConfig.ts`** — adds `batch?: boolean`. Batch is
  on by default when the scorer is enabled; operators can flip it off to
  keep the per-creature behaviour.
- **`src/architecture/Fitness.ts`** — when batch mode is enabled and a
  dataset directory is available, scores the whole unique-creature queue
  in one scorer call. Records `lastBatchScorerInvocations` alongside
  existing scorer telemetry. On any batch failure, logs the reconciliation
  reason and falls back to the per-creature worker path.
- **`src/NEAT/Neat.ts`** — propagates `setDataDir` to `Fitness` so batch
  scoring can invoke the scorer with the right data directory.

## Evidence

This is a backend/CLI change with no user interface. Verified via the new
test suites below:

- `test/score/BatchRustScorerBridge.ts` — 10 tests covering the batch
  bridge in isolation, including one-process-per-generation, stem
  mapping, missing/extra key failures, probe fallback, non-zero exit, and
  temp-directory cleanup.
- `test/NEAT/FitnessBatchRustScorer.ts` — 2 tests covering the Fitness
  wiring, including the "exactly one scorer process per generation" and
  "falls back to per-creature scoring on reconciliation failure" cases.

Quality gate (`./quality.sh --skip-discovery --skip-wasm --skip-tests`)
passes cleanly. Targeted test runs:

```
deno test test/score/ test/NEAT/FitnessBatchRustScorer.ts \
          test/NEAT/FitnessDeduplication.ts \
          test/NEAT/FitnessQueueDequeue.ts \
          test/NEAT/EvolveWasmPanicRecovery.ts
→ all passing
```

## Test Plan

- [x] `test/score/BatchRustScorerBridge.ts` — new file, 10 tests for the
      batch scorer bridge contract.
- [x] `test/NEAT/FitnessBatchRustScorer.ts` — new file, 2 tests verifying
      `Fitness.calculate` uses the batch scorer when enabled and falls
      back cleanly on reconciliation failure.
- [x] `test/score/RustScorerBridgeHardening.ts` — updated to include the
      new `batch: false` field on config literals (existing per-creature
      tests unchanged in intent).
- [x] `test/score/RustScorerIntegration.ts` — same field-only update.
- [x] Existing `test/score/BatchScorerReconciler.ts` reconciliation tests
      continue to pass unchanged.
- [x] Existing `test/NEAT/FitnessDeduplication.ts` and
      `test/NEAT/FitnessQueueDequeue.ts` Fitness loop tests continue to
      pass without modification.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2422 -->