### PR TITLE
Reference koalaman/shellcheck in ShellCheck workflow (#2430)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run ShellCheck
+      # Runs koalaman/shellcheck (https://github.com/koalaman/shellcheck) via the
+      # ludeeus/action-shellcheck wrapper to lint shell scripts in the repository.
+      - name: Run ShellCheck (koalaman/shellcheck)
         uses: ludeeus/action-shellcheck@master
         with:
           scandir: .

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.15",
+  "version": "3.1.16",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -146,6 +146,7 @@
     "Kingma",
     "Klambauer",
     "klass",
+    "koalaman",
     "knowably",
     "Krasnogor",
     "labeled",

--- a/docs/pr-summary-2430.md
+++ b/docs/pr-summary-2430.md
@@ -1,15 +1,27 @@
 ## Summary
 
-Completed the ShellCheck Lint workflow by adding a comment that explicitly references the upstream `koalaman/shellcheck` project. The workflow already invoked the `ludeeus/action-shellcheck` wrapper, but the VibeCoding workflow-sync detector additionally looks for a `koalaman/shellcheck` reference to confirm the lint gate is wired correctly. Closes #2430.
+Completed the ShellCheck Lint workflow by adding a comment that explicitly
+references the upstream `koalaman/shellcheck` project. The workflow already
+invoked the `ludeeus/action-shellcheck` wrapper, but the VibeCoding
+workflow-sync detector additionally looks for a `koalaman/shellcheck` reference
+to confirm the lint gate is wired correctly. Closes #2430.
 
 ## Evidence
 
 This is a CI/workflow change with no UI surface. Verified by:
 
-- `deno test --allow-read --allow-run test/scripts/ShellCheckLint.ts` — both tests pass, including the new assertion that the workflow references `koalaman/shellcheck`.
-- `./quality.sh --lint-only` — formatting, linting, and bash script checks all pass.
+- `deno test --allow-read --allow-run test/scripts/ShellCheckLint.ts` — both
+  tests pass, including the new assertion that the workflow references
+  `koalaman/shellcheck`.
+- `./quality.sh --lint-only` — formatting, linting, and bash script checks all
+  pass.
 
 ## Test Plan
 
-- Extended `test/scripts/ShellCheckLint.ts::shellcheck workflow file exists and is well-formed` with an assertion that `.github/workflows/shellcheck.yml` contains the literal string `koalaman/shellcheck`. The test fails on the unfixed workflow and passes after the comment was added.
-- Existing `all shell scripts pass shellcheck --severity=warning` test continues to pass, confirming no shell scripts regressed.
+- Extended
+  `test/scripts/ShellCheckLint.ts::shellcheck workflow file exists and is well-formed`
+  with an assertion that `.github/workflows/shellcheck.yml` contains the literal
+  string `koalaman/shellcheck`. The test fails on the unfixed workflow and
+  passes after the comment was added.
+- Existing `all shell scripts pass shellcheck --severity=warning` test continues
+  to pass, confirming no shell scripts regressed.

--- a/docs/pr-summary-2430.md
+++ b/docs/pr-summary-2430.md
@@ -1,0 +1,15 @@
+## Summary
+
+Completed the ShellCheck Lint workflow by adding a comment that explicitly references the upstream `koalaman/shellcheck` project. The workflow already invoked the `ludeeus/action-shellcheck` wrapper, but the VibeCoding workflow-sync detector additionally looks for a `koalaman/shellcheck` reference to confirm the lint gate is wired correctly. Closes #2430.
+
+## Evidence
+
+This is a CI/workflow change with no UI surface. Verified by:
+
+- `deno test --allow-read --allow-run test/scripts/ShellCheckLint.ts` — both tests pass, including the new assertion that the workflow references `koalaman/shellcheck`.
+- `./quality.sh --lint-only` — formatting, linting, and bash script checks all pass.
+
+## Test Plan
+
+- Extended `test/scripts/ShellCheckLint.ts::shellcheck workflow file exists and is well-formed` with an assertion that `.github/workflows/shellcheck.yml` contains the literal string `koalaman/shellcheck`. The test fails on the unfixed workflow and passes after the comment was added.
+- Existing `all shell scripts pass shellcheck --severity=warning` test continues to pass, confirming no shell scripts regressed.

--- a/test/scripts/ShellCheckLint.ts
+++ b/test/scripts/ShellCheckLint.ts
@@ -98,4 +98,10 @@ Deno.test("shellcheck workflow file exists and is well-formed", async () => {
     /severity:\s*warning/.test(body),
     "workflow must set severity: warning",
   );
+  // Must reference the upstream koalaman/shellcheck project so the workflow
+  // sync detector recognises the lint gate (Issue #2430).
+  assert(
+    body.includes("koalaman/shellcheck"),
+    "workflow must reference koalaman/shellcheck (the upstream tool)",
+  );
 });


### PR DESCRIPTION
## Summary

Completed the ShellCheck Lint workflow by adding a comment that explicitly references the upstream `koalaman/shellcheck` project. The workflow already invoked the `ludeeus/action-shellcheck` wrapper, but the VibeCoding workflow-sync detector additionally looks for a `koalaman/shellcheck` reference to confirm the lint gate is wired correctly. Closes #2430.

## Evidence

This is a CI/workflow change with no UI surface. Verified by:

- `deno test --allow-read --allow-run test/scripts/ShellCheckLint.ts` — both tests pass, including the new assertion that the workflow references `koalaman/shellcheck`.
- `./quality.sh --lint-only` — formatting, linting, and bash script checks all pass.

## Test Plan

- Extended `test/scripts/ShellCheckLint.ts::shellcheck workflow file exists and is well-formed` with an assertion that `.github/workflows/shellcheck.yml` contains the literal string `koalaman/shellcheck`. The test fails on the unfixed workflow and passes after the comment was added.
- Existing `all shell scripts pass shellcheck --severity=warning` test continues to pass, confirming no shell scripts regressed.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2430 -->