### PR TITLE
Auto-sync NEAT-AI with NEAT-AI-core Develop via release artifact (#2433)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: denoland/setup-deno@v2
 
       - name: Sync WASM package from NEAT-AI-core
-        run: ./build.sh
+        run: ./build.sh --verify-only
 
       - id: create_coverage_files
         name: Create coverage files

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -169,7 +169,7 @@ jobs:
         run: deno outdated --update --latest
 
       - name: Sync WASM package from NEAT-AI-core
-        run: ./build.sh
+        run: ./build.sh --verify-only
 
       - name: Report WASM sync changes
         run: |

--- a/build.sh
+++ b/build.sh
@@ -4,31 +4,81 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# build.sh — refresh wasm_activation/pkg from upstream NEAT-AI-core.
+#
+# Issue #2433 / #2434: NEAT-AI is pure TypeScript. The WASM bundle is
+# produced by NEAT-AI-core CI and published per-commit on the Develop
+# branch as a GitHub Release tagged `wasm-bundle-<SHA>` carrying the
+# asset `wasm_activation-pkg.tar.gz`. This script either advances the
+# vendored bundle to the upstream Develop HEAD (default) or verifies
+# the existing bundle matches the pin in deno.json (--verify-only).
+
 CLEAN=false
+VERIFY_ONLY=false
+EXPLICIT_REV=""
 
 show_help() {
   cat <<'HELP'
 Usage: ./build.sh [OPTIONS]
 
-Verify wasm_activation/pkg matches deno.json neatCore.rev (vendored artifacts).
+Sync wasm_activation/pkg with NEAT-AI-core.
+
+Default behaviour (no flags):
+  1. Resolve NEAT-AI-core Develop HEAD via the GitHub API.
+  2. If HEAD == deno.json neatCore.rev and the vendored pkg matches,
+     do nothing.
+  3. Otherwise download wasm_activation-pkg.tar.gz from the matching
+     `wasm-bundle-<SHA>` Release, unpack it into wasm_activation/, and
+     update deno.json neatCore.rev to <SHA>.
 
 Options:
-  --clean       Delete wasm_activation/pkg before build
-  --help, -h    Show this help and exit
+  --rev <SHA>     Pin to a specific 40-char NEAT-AI-core revision instead
+                  of resolving Develop HEAD. Useful for reproducing an
+                  old build.
+  --verify-only   Do not contact the network or modify deno.json. Just
+                  verify wasm_activation/pkg matches deno.json neatCore.rev.
+                  Used by quality.sh and CI.
+  --clean         Delete wasm_activation/pkg before download.
+  --help, -h      Show this help and exit.
 HELP
 }
 
-for arg in "$@"; do
-  case "$arg" in
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     --clean)
       CLEAN=true
+      shift
+      ;;
+    --verify-only)
+      VERIFY_ONLY=true
+      shift
+      ;;
+    --rev)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --rev requires a 40-character hex SHA argument" >&2
+        exit 1
+      fi
+      EXPLICIT_REV="$2"
+      if ! [[ "$EXPLICIT_REV" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "ERROR: --rev must be a 40-character lowercase hex SHA, got '$EXPLICIT_REV'" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --rev=*)
+      EXPLICIT_REV="${1#--rev=}"
+      if ! [[ "$EXPLICIT_REV" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "ERROR: --rev must be a 40-character lowercase hex SHA, got '$EXPLICIT_REV'" >&2
+        exit 1
+      fi
+      shift
       ;;
     --help|-h)
       show_help
       exit 0
       ;;
     *)
-      echo "Unknown option: $arg" >&2
+      echo "Unknown option: $1" >&2
       echo "Run './build.sh --help' for usage." >&2
       exit 1
       ;;
@@ -69,29 +119,7 @@ NEAT_CORE_REV_DEFAULT="$(printf '%s\n' "$cfg_output" | sed -n '3p')"
 
 NEAT_CORE_REPO="${NEAT_CORE_REPO:-$NEAT_CORE_REPO_DEFAULT}"
 NEAT_CORE_REF="${NEAT_CORE_REF:-$NEAT_CORE_REF_DEFAULT}"
-NEAT_CORE_REV="${NEAT_CORE_REV:-$NEAT_CORE_REV_DEFAULT}"
-
-curl_args=(-fsSL)
-if [[ -n "${NEAT_CORE_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}" ]]; then
-  token="${NEAT_CORE_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
-  curl_args+=(-H "Authorization: Bearer ${token}")
-fi
-
-if ! [[ "$NEAT_CORE_REV" =~ ^[0-9a-f]{40}$ ]]; then
-  if [[ -z "$NEAT_CORE_REF" ]]; then
-    echo "ERROR: NEAT_CORE_REF is required when NEAT_CORE_REV is unset" >&2
-    exit 1
-  fi
-  api_url="https://api.github.com/repos/${NEAT_CORE_REPO}/commits/${NEAT_CORE_REF}"
-  echo "Resolving latest commit for ${NEAT_CORE_REPO}@${NEAT_CORE_REF}..."
-  commit_json="$(curl "${curl_args[@]}" "$api_url")"
-  resolved_rev="$(printf '%s\n' "$commit_json" | sed -nE 's/.*"sha":[[:space:]]*"([0-9a-f]{40})".*/\1/p' | sed -n '1p')"
-  if ! [[ "$resolved_rev" =~ ^[0-9a-f]{40}$ ]]; then
-    echo "ERROR: Could not resolve commit SHA for ${NEAT_CORE_REPO}@${NEAT_CORE_REF}" >&2
-    exit 1
-  fi
-  NEAT_CORE_REV="$resolved_rev"
-fi
+PINNED_REV="$NEAT_CORE_REV_DEFAULT"
 
 DEST_DIR="wasm_activation/pkg"
 required=(
@@ -101,47 +129,181 @@ required=(
   "wasm_activation_bg.wasm.d.ts"
 )
 
-has_valid_pkg=false
-if [[ -f "$DEST_DIR/neat_core_rev.txt" ]]; then
-  current_rev="$(tr -d '\n\r' < "$DEST_DIR/neat_core_rev.txt")"
-  if [[ "$current_rev" == "$NEAT_CORE_REV" ]]; then
-    has_all=true
-    for file in "${required[@]}"; do
-      if [[ ! -f "$DEST_DIR/$file" ]]; then
-        has_all=false
-        break
-      fi
-    done
-    if [[ "$has_all" == true ]]; then
-      has_valid_pkg=true
-    fi
-  fi
-fi
+# WASM bundle size sanity threshold — issue #2389 found that the old
+# in-repo wasm-pack wrapper produced a ~30 KiB stub with no
+# CompiledNetwork bindings; a real bundle is two orders of magnitude
+# larger.
+MIN_WASM_BYTES=131072
 
-if [ "$CLEAN" = true ]; then
-  echo "Cleaning $DEST_DIR before build..."
-  rm -rf "$DEST_DIR"
-elif [[ "$has_valid_pkg" == true ]]; then
-  wasm_bytes="$(wc -c <"$DEST_DIR/wasm_activation_bg.wasm" | tr -d ' ')"
-  # The previous wasm-pack wrapper path produced a ~30KiB stub with no
-  # CompiledNetwork bindings; a real pkg is two orders of magnitude larger.
-  if [[ "${wasm_bytes:-0}" -lt 131072 ]]; then
-    echo "ERROR: $DEST_DIR/wasm_activation_bg.wasm is too small (${wasm_bytes} bytes)." >&2
-    echo "This usually means a stub WASM replaced the vendored activation package." >&2
-    echo "Restore from git, e.g.: git checkout Develop -- $DEST_DIR/" >&2
-    exit 1
+verify_pkg_matches() {
+  local expected_rev="$1"
+  if [[ ! -f "$DEST_DIR/neat_core_rev.txt" ]]; then
+    return 1
   fi
+  local current_rev
+  current_rev="$(tr -d '\n\r' < "$DEST_DIR/neat_core_rev.txt")"
+  if [[ "$current_rev" != "$expected_rev" ]]; then
+    return 1
+  fi
+  for file in "${required[@]}"; do
+    if [[ ! -f "$DEST_DIR/$file" ]]; then
+      return 1
+    fi
+  done
+  local wasm_bytes
+  wasm_bytes="$(wc -c <"$DEST_DIR/wasm_activation_bg.wasm" | tr -d ' ')"
+  if [[ "${wasm_bytes:-0}" -lt $MIN_WASM_BYTES ]]; then
+    return 1
+  fi
+  return 0
+}
+
+refresh_fingerprint() {
+  local rev="$1"
   if command -v shasum >/dev/null 2>&1; then
-    fingerprint_input="${NEAT_CORE_REPO}@${NEAT_CORE_REV}"
+    local fingerprint_input="${NEAT_CORE_REPO}@${rev}"
     printf '%s' "$fingerprint_input" | shasum -a 256 | awk '{print $1}' \
       > "$DEST_DIR/build-fingerprint"
   fi
-  echo "Skipping build: $DEST_DIR already matches ${NEAT_CORE_REPO}@${NEAT_CORE_REV}"
+}
+
+# --- Verify-only path ----------------------------------------------------
+# No network. No deno.json mutation. Just check the vendored bundle
+# matches the pinned rev. Used by quality.sh and CI.
+if [[ "$VERIFY_ONLY" == true ]]; then
+  if [[ -z "$PINNED_REV" ]]; then
+    echo "ERROR: --verify-only requires deno.json neatCore.rev to be set" >&2
+    exit 1
+  fi
+  if verify_pkg_matches "$PINNED_REV"; then
+    # Verify-only is a read-only check; do not refresh the fingerprint
+    # (the fingerprint reflects the last successful download, not a
+    # verification, and may legitimately be missing on fresh clones).
+    echo "Skipping build: $DEST_DIR already matches ${NEAT_CORE_REPO_DEFAULT}@${PINNED_REV}"
+    exit 0
+  fi
+  echo "ERROR: $DEST_DIR does not match deno.json neatCore.rev (${PINNED_REV})." >&2
+  echo "Run './build.sh' (without --verify-only) to refresh the bundle from upstream." >&2
+  exit 1
+fi
+
+# --- Resolve target rev --------------------------------------------------
+TARGET_REV=""
+if [[ -n "$EXPLICIT_REV" ]]; then
+  TARGET_REV="$EXPLICIT_REV"
+elif [[ -n "${NEAT_CORE_REV:-}" ]]; then
+  if ! [[ "$NEAT_CORE_REV" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: NEAT_CORE_REV env override must be a 40-char hex SHA" >&2
+    exit 1
+  fi
+  TARGET_REV="$NEAT_CORE_REV"
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: gh (GitHub CLI) is required to resolve Develop HEAD." >&2
+    echo "Install gh, set NEAT_CORE_REV explicitly, or pass --rev <SHA>." >&2
+    exit 1
+  fi
+  echo "Resolving ${NEAT_CORE_REPO}@${NEAT_CORE_REF} HEAD..."
+  resolved_rev="$(gh api "repos/${NEAT_CORE_REPO}/commits/${NEAT_CORE_REF}" --jq .sha 2>/dev/null || true)"
+  if ! [[ "$resolved_rev" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: Could not resolve commit SHA for ${NEAT_CORE_REPO}@${NEAT_CORE_REF}" >&2
+    echo "Ensure 'gh auth status' is authenticated, or pass --rev <SHA>." >&2
+    exit 1
+  fi
+  TARGET_REV="$resolved_rev"
+fi
+
+echo "Target NEAT-AI-core revision: ${TARGET_REV}"
+
+# --- No-op fast path: pin matches and pkg is intact ---------------------
+if [[ "$CLEAN" != true ]] && [[ "$PINNED_REV" == "$TARGET_REV" ]] \
+  && verify_pkg_matches "$TARGET_REV"; then
+  # No download performed, so leave build-fingerprint as last build wrote it.
+  echo "Skipping build: $DEST_DIR already matches ${NEAT_CORE_REPO}@${TARGET_REV}"
   exit 0
 fi
 
-echo "ERROR: wasm_activation/pkg is missing or does not match pinned NEAT-AI-core revision." >&2
-echo "  Expected ${NEAT_CORE_REPO}@${NEAT_CORE_REV} (see deno.json neatCore.rev and $DEST_DIR/neat_core_rev.txt)." >&2
-echo "Automated rebuild was removed: the wasm-pack wrapper produced a non-functional stub." >&2
-echo "Restore the in-repo WASM package from git (same rev as neatCore.rev), then re-run ./build.sh." >&2
-exit 1
+# --- Download artifact --------------------------------------------------
+if [[ "$CLEAN" == true ]]; then
+  echo "Cleaning $DEST_DIR before download..."
+  rm -rf "$DEST_DIR"
+fi
+
+ASSET_NAME="wasm_activation-pkg.tar.gz"
+RELEASE_TAG="wasm-bundle-${TARGET_REV}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+echo "Downloading ${ASSET_NAME} from ${NEAT_CORE_REPO} release ${RELEASE_TAG}..."
+download_ok=false
+if command -v gh >/dev/null 2>&1; then
+  if gh release download "$RELEASE_TAG" \
+    --repo "$NEAT_CORE_REPO" \
+    --pattern "$ASSET_NAME" \
+    --dir "$tmp_dir" 2>"$tmp_dir/gh.err"; then
+    download_ok=true
+  else
+    cat "$tmp_dir/gh.err" >&2 || true
+  fi
+fi
+
+if [[ "$download_ok" != true ]]; then
+  # Fall back to direct release-asset download via curl. Allows running
+  # without gh on CI runners that only have curl.
+  curl_args=(-fsSL)
+  if [[ -n "${NEAT_CORE_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}" ]]; then
+    token="${NEAT_CORE_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
+    curl_args+=(-H "Authorization: Bearer ${token}")
+  fi
+  asset_url="https://github.com/${NEAT_CORE_REPO}/releases/download/${RELEASE_TAG}/${ASSET_NAME}"
+  if ! curl "${curl_args[@]}" -o "$tmp_dir/$ASSET_NAME" "$asset_url"; then
+    echo "ERROR: Could not download ${ASSET_NAME} from ${NEAT_CORE_REPO} release ${RELEASE_TAG}." >&2
+    echo "  - Confirm the release exists: https://github.com/${NEAT_CORE_REPO}/releases/tag/${RELEASE_TAG}" >&2
+    echo "  - The per-commit Release is published by NEAT-AI-core CI; for very recent commits it may not be available yet." >&2
+    echo "  - For private repos, set NEAT_CORE_GITHUB_TOKEN or GITHUB_TOKEN with read access." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "wasm_activation"
+echo "Extracting ${ASSET_NAME} into wasm_activation/..."
+tar -xzf "$tmp_dir/$ASSET_NAME" -C "wasm_activation/"
+
+# Ensure neat_core_rev.txt is consistent with the requested SHA. CI
+# writes this file, but we re-stamp it defensively in case someone
+# repackages the bundle without it.
+echo "$TARGET_REV" > "$DEST_DIR/neat_core_rev.txt"
+
+# --- Verify the freshly-extracted bundle --------------------------------
+for file in "${required[@]}"; do
+  if [[ ! -f "$DEST_DIR/$file" ]]; then
+    echo "ERROR: expected $DEST_DIR/$file in extracted bundle" >&2
+    exit 1
+  fi
+done
+
+wasm_bytes="$(wc -c <"$DEST_DIR/wasm_activation_bg.wasm" | tr -d ' ')"
+if [[ "${wasm_bytes:-0}" -lt $MIN_WASM_BYTES ]]; then
+  echo "ERROR: $DEST_DIR/wasm_activation_bg.wasm is too small (${wasm_bytes} bytes)." >&2
+  echo "This usually means the bundle is a stub and not a real CompiledNetwork build." >&2
+  exit 1
+fi
+
+# --- Update deno.json neatCore.rev --------------------------------------
+if [[ "$PINNED_REV" != "$TARGET_REV" ]]; then
+  echo "Updating deno.json neatCore.rev: ${PINNED_REV:-<unset>} -> ${TARGET_REV}"
+  deno eval "
+const path = 'deno.json';
+const config = JSON.parse(Deno.readTextFileSync(path));
+config.neatCore = config.neatCore ?? {};
+config.neatCore.rev = '${TARGET_REV}';
+Deno.writeTextFileSync(path, JSON.stringify(config, null, 2) + '\n');
+"
+fi
+
+refresh_fingerprint "$TARGET_REV"
+
+echo ""
+echo "✅ wasm_activation/pkg refreshed to ${NEAT_CORE_REPO}@${TARGET_REV}"
+echo "   Commit deno.json AND wasm_activation/pkg/** together to advance the pin."

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.17",
+  "version": "3.1.18",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/CORE_DEPENDENCY_POLICY.md
+++ b/docs/CORE_DEPENDENCY_POLICY.md
@@ -2,7 +2,8 @@
 
 Issue #2342 — ADR for how NEAT-AI consumes native computation from
 [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) after removing all
-in-repo Rust source.
+in-repo Rust source. Issue #2433 / #2434 extended this to an artifact-based
+auto-sync flow that mirrors the GRQ ← NEAT-AI pattern.
 
 ## Decision Summary
 
@@ -11,32 +12,68 @@ NEAT-AI tracks NEAT-AI-core in `deno.json`:
 ```json
 "neatCore": {
   "repo": "stSoftwareAU/NEAT-AI-core",
-  "ref": "Develop"
+  "ref": "Develop",
+  "rev": "<40-char SHA>"
 }
 ```
 
-`build.sh` is the single integration point. It resolves latest commit for
-`repo@ref`, downloads that archive, extracts `wasm_activation/pkg`, and writes
-`wasm_activation/pkg/neat_core_rev.txt`.
+`build.sh` is the single integration point. By default it resolves NEAT-AI-core
+`Develop` HEAD via the GitHub API, downloads the matching
+`wasm_activation-pkg.tar.gz` asset from the per-commit Release tagged
+`wasm-bundle-<SHA>`, unpacks it into `wasm_activation/`, and updates `deno.json`
+`neatCore.rev` to the new SHA. The maintainer (or worker) running `./build.sh`
+commits the updated `deno.json` and `wasm_activation/pkg/**` together.
+
+```mermaid
+flowchart LR
+  CORE["NEAT-AI-core Develop"] -- "wasm-pack CI" --> REL["GitHub Release<br/>wasm-bundle-&lt;SHA&gt;"]
+  REL -- "wasm_activation-pkg.tar.gz" --> BUILD["./build.sh"]
+  BUILD -- "extract" --> PKG["wasm_activation/pkg/**"]
+  BUILD -- "bump rev" --> DENO["deno.json neatCore.rev"]
+  PKG -- "import (unchanged)" --> GRQ["GRQ / downstream clients"]
+```
 
 ## Why This Model
 
 - Release control happens at PR approval and merge timing.
 - No Rust toolchain required in NEAT-AI CI or local contributor setup.
-- External API stays unchanged (`wasm_activation/pkg/**` is still published).
+- External API stays unchanged (`wasm_activation/pkg/**` is still published to
+  JSR exactly as before), so GRQ and other downstream consumers do not change
+  their imports.
+- The full `(repo, ref, rev)` triple is still recorded in `deno.json`, so any
+  past build is reproducible by passing `--rev <SHA>` to `build.sh`.
+
+## `build.sh` Modes
+
+| Invocation                 | Behaviour                                                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `./build.sh`               | Resolve Develop HEAD, download artifact, refresh pkg, update `deno.json` `neatCore.rev`. No-op if up to date. |
+| `./build.sh --rev <SHA>`   | Same as above but pin to a specific 40-char SHA instead of resolving HEAD. Used for reproducible builds.      |
+| `./build.sh --verify-only` | Verify the vendored pkg matches `deno.json` `neatCore.rev`. No network. No mutation. Used by `quality.sh`.    |
+| `./build.sh --clean`       | Delete `wasm_activation/pkg` before download.                                                                 |
+| `./build.sh --help`        | Show usage.                                                                                                   |
+
+The artifact-based flow depends on the per-commit GitHub Release published by
+NEAT-AI-core CI (issue stSoftwareAU/NEAT-AI-core#37). When the upstream artifact
+is missing for a given SHA, `build.sh` exits with an actionable error pointing
+at the expected release URL.
 
 ## Bumping NEAT-AI-core
 
-1. Keep `deno.json` `neatCore.ref` set to the desired tracked branch (typically
-   `Develop`).
-2. Run `./build.sh` to refresh `wasm_activation/pkg` from latest core commit.
-3. Run `./scripts/parity-gate.sh` and `./quality.sh`.
-4. Commit updated `wasm_activation/pkg/**` in the PR.
+1. Run `./build.sh` to resolve HEAD, download the matching artifact, and bump
+   `deno.json` `neatCore.rev`.
+2. Run `./scripts/parity-gate.sh` and include the output in the PR.
+3. Run `./quality.sh` (which calls `./build.sh --verify-only` to confirm the
+   refreshed pkg is in sync).
+4. Commit the updated `deno.json` and `wasm_activation/pkg/**` together.
 
 ## CI Policy
 
-- CI must run `./build.sh` before quality/test/publish.
-- `wasm_activation/pkg` may change whenever NEAT-AI-core `ref` advances.
+- CI runs `./quality.sh`, which calls `./build.sh --verify-only`. CI MUST NOT
+  advance `deno.json` `neatCore.rev` automatically — bumps are explicit human
+  (or worker) actions, mirroring the GRQ ← NEAT-AI flow.
+- `wasm_activation/pkg` may change whenever a maintainer (or worker) runs
+  `./build.sh` and commits the result.
 - No Cargo, `rustc`, or `wasm-pack` steps run in this repo.
 
 ## Semver and Approvals
@@ -50,7 +87,7 @@ NEAT-AI-core tags continue to follow `v<MAJOR>.<MINOR>.<PATCH>`.
 ## Downstream Alignment (NEAT-AI-scorer)
 
 Downstream consumers should align to the same NEAT-AI-core branch/ref policy
-used by this repo’s `deno.json`.
+used by this repo's `deno.json`.
 
 ## Related Documents
 

--- a/docs/pr-summary-2433.md
+++ b/docs/pr-summary-2433.md
@@ -1,0 +1,89 @@
+# Auto-sync NEAT-AI with NEAT-AI-core Develop (zero Rust in NEAT-AI)
+
+## Summary
+
+Reworked `./build.sh` so each invocation resolves the `NEAT-AI-core` `Develop`
+HEAD, downloads the per-commit `wasm_activation-pkg.tar.gz` artifact from the
+matching `wasm-bundle-<SHA>` GitHub Release, refreshes `wasm_activation/pkg/`,
+and advances `deno.json` `neatCore.rev`. Added a `--verify-only` mode (used by
+`quality.sh` and CI) that asserts the vendored bundle matches the pinned rev
+without contacting the network or mutating `deno.json`, and a `--rev <SHA>` flag
+for reproducing builds at a specific historical revision. Updated
+`docs/CORE_DEPENDENCY_POLICY.md` to document the new artifact-based flow. Closes
+#2433.
+
+This PR delivers the NEAT-AI side of the auto-sync epic. The end-to-end "advance
+the pin" path activates once NEAT-AI-core CI starts publishing per-commit
+Releases (sub-issues stSoftwareAU/NEAT-AI-core#36 and #37). Until then,
+`./build.sh` exits with a clear, actionable error pointing at the expected
+release URL when the upstream artifact does not exist.
+
+## Evidence
+
+```mermaid
+flowchart LR
+  CORE["NEAT-AI-core Develop"] -- "wasm-pack CI<br/>(NEAT-AI-core#37)" --> REL["GitHub Release<br/>wasm-bundle-&lt;SHA&gt;"]
+  REL -- "wasm_activation-pkg.tar.gz" --> BUILD["./build.sh"]
+  BUILD -- "extract" --> PKG["wasm_activation/pkg/**"]
+  BUILD -- "bump rev" --> DENO["deno.json neatCore.rev"]
+  PKG -- "import (unchanged)" --> GRQ["GRQ / downstream clients"]
+  QS["./quality.sh"] -- "--verify-only" --> BUILD
+```
+
+Manual smoke checks:
+
+- `./build.sh --verify-only` against in-sync repo →
+  `Skipping build: wasm_activation/pkg already matches stSoftwareAU/NEAT-AI-core@36ac4ea34fcd4e89d9fad3d6fae9efc5f02c8959`
+- `./build.sh --rev 36ac4ea34fcd4e89d9fad3d6fae9efc5f02c8959` → no-op fast path
+  against the matching pin.
+- `./build.sh` (default) resolves Develop HEAD to `2d0582ae…`, attempts
+  `gh release download wasm-bundle-2d0582ae…`, fails with the documented
+  actionable error because NEAT-AI-core#37 has not yet landed.
+- `./build.sh --no-such-flag` → `Unknown option`, non-zero exit.
+- `./build.sh --rev not-a-sha` → SHA validation error, non-zero exit.
+
+This is a CLI / build-tooling change with no UI surface, so no Playwright
+screenshots are attached. Verified with the test plan below.
+
+## Test Plan
+
+- Added `test/scripts/BuildScript.ts` covering:
+  - `--help` lists the new `--verify-only` and `--rev` flags.
+  - `-h` short alias.
+  - Unknown flag rejection.
+  - `--rev` rejects non-hex / wrong-length values and requires a value.
+  - `--verify-only` succeeds when pkg matches the pinned rev.
+  - `--verify-only` does not resolve HEAD over the network (proven by pointing
+    `NEAT_CORE_REPO` and `NEAT_CORE_REF` at non-existent values and asserting
+    the script still exits 0).
+  - `build.sh` references the `wasm-bundle-<SHA>` tag pattern and
+    `wasm_activation-pkg.tar.gz` asset.
+  - `docs/CORE_DEPENDENCY_POLICY.md` describes the new artifact flow,
+    `--verify-only`, and `--rev <SHA>`.
+- Existing `test/scripts/CoreDependencyPolicy.ts`,
+  `test/scripts/BuildFingerprint.ts`, `test/scripts/BashScriptSyntax.ts`,
+  `test/scripts/ShellCheckLint.ts`, and `test/scripts/QualityScript.ts` continue
+  to pass against the new `build.sh` and updated policy doc.
+
+```
+$ deno test --config ./deno.json test/scripts/ ...
+ok | 59 passed | 0 failed
+```
+
+`./quality.sh --lint-only` and `./quality.sh --check-only` were both run locally
+and pass; the full test suite is unchanged in scope by this build-tooling
+change.
+
+## Acceptance Criteria
+
+- [x] No Rust source in NEAT-AI (only the vendored `wasm_activation/pkg/`
+      artifact remains tracked in git).
+- [x] `./build.sh` produces `wasm_activation/pkg/` purely from upstream
+      artifacts — no local Rust toolchain required.
+- [x] Running `./build.sh` always advances `neatCore.rev` to the current
+      NEAT-AI-core Develop HEAD (or is a no-op if already current); the
+      end-to-end advance activates once NEAT-AI-core#37 lands.
+- [x] GRQ continues to consume NEAT-AI without changes — public
+      `wasm_activation/pkg/**` API and JSR `publish.include` are unchanged.
+- [x] `docs/CORE_DEPENDENCY_POLICY.md` updated to describe the new
+      artifact-based flow.

--- a/quality.sh
+++ b/quality.sh
@@ -248,7 +248,10 @@ fi
 
 if [ "$RUN_WASM" = true ]; then
   progress "Syncing WASM package from NEAT-AI-core..."
-  ./build.sh
+  # Use --verify-only: CI must not auto-advance neatCore.rev. Bumping is
+  # an explicit ./build.sh invocation by a human or worker (see
+  # docs/CORE_DEPENDENCY_POLICY.md, issue #2433).
+  ./build.sh --verify-only
 fi
 
 if [ "$RUN_TESTS" = true ]; then

--- a/test/scripts/BuildScript.ts
+++ b/test/scripts/BuildScript.ts
@@ -1,0 +1,230 @@
+import { assert, assertEquals } from "@std/assert";
+
+/**
+ * Tests build.sh flag parsing and behaviour.
+ *
+ * Issue #2433 — auto-sync NEAT-AI with NEAT-AI-core Develop:
+ * verifies that ./build.sh now exposes --verify-only and --rev <SHA>
+ * flags, has the expected help text, and rejects malformed input
+ * without making any network calls.
+ *
+ * These tests deliberately avoid invoking the network paths
+ * (HEAD resolution / artifact download). They focus on:
+ *   - flag parsing / help / unknown-option handling
+ *   - --verify-only no-op when the vendored bundle matches deno.json
+ *   - --rev validation (must be 40-char hex)
+ */
+
+async function runBuild(
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command("bash", {
+    args: ["./build.sh", ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: Deno.cwd(),
+    env,
+  });
+  const output = await command.output();
+  return {
+    stdout: new TextDecoder().decode(output.stdout),
+    stderr: new TextDecoder().decode(output.stderr),
+    code: output.code,
+  };
+}
+
+Deno.test({
+  name: "build.sh --help prints usage and lists new flags",
+  permissions: { run: true, read: true },
+  fn: async () => {
+    const result = await runBuild(["--help"]);
+    assertEquals(result.code, 0, "Expected exit code 0 for --help");
+    assert(
+      result.stdout.includes("Usage:"),
+      "Expected help output to contain 'Usage:'",
+    );
+    assert(
+      result.stdout.includes("--verify-only"),
+      "Expected help to mention --verify-only flag",
+    );
+    assert(
+      result.stdout.includes("--rev"),
+      "Expected help to mention --rev flag",
+    );
+    assert(
+      result.stdout.includes("--clean"),
+      "Expected help to retain --clean flag",
+    );
+  },
+});
+
+Deno.test({
+  name: "build.sh -h prints usage and exits 0",
+  permissions: { run: true, read: true },
+  fn: async () => {
+    const result = await runBuild(["-h"]);
+    assertEquals(result.code, 0, "Expected exit code 0 for -h");
+    assert(
+      result.stdout.includes("Usage:"),
+      "Expected help output to contain 'Usage:'",
+    );
+  },
+});
+
+Deno.test({
+  name: "build.sh rejects unknown flags",
+  permissions: { run: true, read: true },
+  fn: async () => {
+    const result = await runBuild(["--no-such-flag"]);
+    assert(result.code !== 0, "Expected non-zero exit code for unknown flag");
+    assert(
+      result.stderr.includes("Unknown option"),
+      "Expected error message about unknown option",
+    );
+  },
+});
+
+Deno.test({
+  name: "build.sh --rev rejects non-hex / wrong-length values",
+  permissions: { run: true, read: true },
+  fn: async () => {
+    const result = await runBuild(["--rev", "not-a-sha"]);
+    assert(
+      result.code !== 0,
+      "Expected non-zero exit for invalid --rev",
+    );
+    assert(
+      result.stderr.includes("--rev"),
+      "Expected error to mention --rev",
+    );
+  },
+});
+
+Deno.test({
+  name: "build.sh --rev requires a value",
+  permissions: { run: true, read: true },
+  fn: async () => {
+    const result = await runBuild(["--rev"]);
+    assert(
+      result.code !== 0,
+      "Expected non-zero exit when --rev has no value",
+    );
+  },
+});
+
+Deno.test({
+  name: "build.sh --verify-only is a no-op when vendored bundle matches pin",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    // Sanity: the repo state at the start of the test should already
+    // satisfy the verify-only contract (pkg matches deno.json rev).
+    const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+    const pinnedRev: string = denoConfig.neatCore?.rev ?? "";
+    let pkgRev = "";
+    try {
+      pkgRev = (await Deno.readTextFile(
+        "wasm_activation/pkg/neat_core_rev.txt",
+      )).trim();
+    } catch {
+      // pkg missing — skip rather than fail (handled by other tests)
+      return;
+    }
+    if (pinnedRev !== pkgRev) {
+      // Repo isn't in sync — skip; not what this test is checking.
+      return;
+    }
+
+    const result = await runBuild(["--verify-only"]);
+    assertEquals(
+      result.code,
+      0,
+      `Expected --verify-only to succeed for in-sync repo; stderr=${result.stderr}`,
+    );
+    assert(
+      result.stdout.includes("Skipping build") ||
+        result.stdout.includes("matches"),
+      "Expected --verify-only to print a no-op message",
+    );
+  },
+});
+
+Deno.test({
+  name: "build.sh --verify-only does not resolve HEAD over the network",
+  permissions: { run: true, read: true, write: true, env: true },
+  fn: async () => {
+    // If build.sh tried to call gh / curl in verify-only mode and the
+    // bundle is in sync, this would fail offline. Test it succeeds with
+    // a clearly-bogus repo and ref env override, proving network is not
+    // contacted on the verify-only path.
+    const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+    const pinnedRev: string = denoConfig.neatCore?.rev ?? "";
+    let pkgRev = "";
+    try {
+      pkgRev = (await Deno.readTextFile(
+        "wasm_activation/pkg/neat_core_rev.txt",
+      )).trim();
+    } catch {
+      return;
+    }
+    if (pinnedRev !== pkgRev) {
+      return;
+    }
+
+    const result = await runBuild(["--verify-only"], {
+      // PATH is required so deno/bash resolve.
+      PATH: Deno.env.get("PATH") ?? "",
+      HOME: Deno.env.get("HOME") ?? "",
+      // Force resolution code-path to obvious failure if it ran.
+      NEAT_CORE_REPO: "stSoftwareAU/does-not-exist-zzz",
+      NEAT_CORE_REF: "no-such-branch",
+    });
+    assertEquals(
+      result.code,
+      0,
+      `--verify-only must skip network lookup; stderr=${result.stderr}`,
+    );
+  },
+});
+
+Deno.test({
+  name: "build.sh exposes a --rev option for explicit historical pins",
+  permissions: { read: true },
+  fn: async () => {
+    const buildScript = await Deno.readTextFile("build.sh");
+    assert(
+      buildScript.includes("--rev"),
+      "build.sh should accept --rev <SHA> for explicit pinning",
+    );
+    assert(
+      /wasm-bundle-/.test(buildScript),
+      "build.sh should reference per-commit Release tag pattern wasm-bundle-<SHA>",
+    );
+    assert(
+      buildScript.includes("wasm_activation-pkg.tar.gz"),
+      "build.sh should reference the wasm_activation-pkg.tar.gz asset",
+    );
+  },
+});
+
+Deno.test({
+  name: "CORE_DEPENDENCY_POLICY documents the new artifact-based flow",
+  permissions: { read: true },
+  fn: async () => {
+    const policy = await Deno.readTextFile("docs/CORE_DEPENDENCY_POLICY.md");
+    const lower = policy.toLowerCase();
+    assert(
+      lower.includes("wasm_activation-pkg.tar.gz") ||
+        lower.includes("wasm-bundle-"),
+      "Policy must describe the per-commit Release artifact",
+    );
+    assert(
+      lower.includes("--verify-only") || lower.includes("verify-only"),
+      "Policy must describe the verify-only mode",
+    );
+    assert(
+      lower.includes("--rev") || lower.includes("rev <sha>"),
+      "Policy must describe the --rev <SHA> override",
+    );
+  },
+});


### PR DESCRIPTION
# Auto-sync NEAT-AI with NEAT-AI-core Develop (zero Rust in NEAT-AI)

## Summary

Reworked `./build.sh` so each invocation resolves the `NEAT-AI-core` `Develop`
HEAD, downloads the per-commit `wasm_activation-pkg.tar.gz` artifact from the
matching `wasm-bundle-<SHA>` GitHub Release, refreshes `wasm_activation/pkg/`,
and advances `deno.json` `neatCore.rev`. Added a `--verify-only` mode (used by
`quality.sh` and CI) that asserts the vendored bundle matches the pinned rev
without contacting the network or mutating `deno.json`, and a `--rev <SHA>` flag
for reproducing builds at a specific historical revision. Updated
`docs/CORE_DEPENDENCY_POLICY.md` to document the new artifact-based flow. Closes
#2433.

This PR delivers the NEAT-AI side of the auto-sync epic. The end-to-end "advance
the pin" path activates once NEAT-AI-core CI starts publishing per-commit
Releases (sub-issues stSoftwareAU/NEAT-AI-core#36 and #37). Until then,
`./build.sh` exits with a clear, actionable error pointing at the expected
release URL when the upstream artifact does not exist.

## Evidence

```mermaid
flowchart LR
  CORE["NEAT-AI-core Develop"] -- "wasm-pack CI<br/>(NEAT-AI-core#37)" --> REL["GitHub Release<br/>wasm-bundle-&lt;SHA&gt;"]
  REL -- "wasm_activation-pkg.tar.gz" --> BUILD["./build.sh"]
  BUILD -- "extract" --> PKG["wasm_activation/pkg/**"]
  BUILD -- "bump rev" --> DENO["deno.json neatCore.rev"]
  PKG -- "import (unchanged)" --> GRQ["GRQ / downstream clients"]
  QS["./quality.sh"] -- "--verify-only" --> BUILD
```

Manual smoke checks:

- `./build.sh --verify-only` against in-sync repo →
  `Skipping build: wasm_activation/pkg already matches stSoftwareAU/NEAT-AI-core@36ac4ea34fcd4e89d9fad3d6fae9efc5f02c8959`
- `./build.sh --rev 36ac4ea34fcd4e89d9fad3d6fae9efc5f02c8959` → no-op fast path
  against the matching pin.
- `./build.sh` (default) resolves Develop HEAD to `2d0582ae…`, attempts
  `gh release download wasm-bundle-2d0582ae…`, fails with the documented
  actionable error because NEAT-AI-core#37 has not yet landed.
- `./build.sh --no-such-flag` → `Unknown option`, non-zero exit.
- `./build.sh --rev not-a-sha` → SHA validation error, non-zero exit.

This is a CLI / build-tooling change with no UI surface, so no Playwright
screenshots are attached. Verified with the test plan below.

## Test Plan

- Added `test/scripts/BuildScript.ts` covering:
  - `--help` lists the new `--verify-only` and `--rev` flags.
  - `-h` short alias.
  - Unknown flag rejection.
  - `--rev` rejects non-hex / wrong-length values and requires a value.
  - `--verify-only` succeeds when pkg matches the pinned rev.
  - `--verify-only` does not resolve HEAD over the network (proven by pointing
    `NEAT_CORE_REPO` and `NEAT_CORE_REF` at non-existent values and asserting
    the script still exits 0).
  - `build.sh` references the `wasm-bundle-<SHA>` tag pattern and
    `wasm_activation-pkg.tar.gz` asset.
  - `docs/CORE_DEPENDENCY_POLICY.md` describes the new artifact flow,
    `--verify-only`, and `--rev <SHA>`.
- Existing `test/scripts/CoreDependencyPolicy.ts`,
  `test/scripts/BuildFingerprint.ts`, `test/scripts/BashScriptSyntax.ts`,
  `test/scripts/ShellCheckLint.ts`, and `test/scripts/QualityScript.ts` continue
  to pass against the new `build.sh` and updated policy doc.

```
$ deno test --config ./deno.json test/scripts/ ...
ok | 59 passed | 0 failed
```

`./quality.sh --lint-only` and `./quality.sh --check-only` were both run locally
and pass; the full test suite is unchanged in scope by this build-tooling
change.

## Acceptance Criteria

- [x] No Rust source in NEAT-AI (only the vendored `wasm_activation/pkg/`
      artifact remains tracked in git).
- [x] `./build.sh` produces `wasm_activation/pkg/` purely from upstream
      artifacts — no local Rust toolchain required.
- [x] Running `./build.sh` always advances `neatCore.rev` to the current
      NEAT-AI-core Develop HEAD (or is a no-op if already current); the
      end-to-end advance activates once NEAT-AI-core#37 lands.
- [x] GRQ continues to consume NEAT-AI without changes — public
      `wasm_activation/pkg/**` API and JSR `publish.include` are unchanged.
- [x] `docs/CORE_DEPENDENCY_POLICY.md` updated to describe the new
      artifact-based flow.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2433 -->