### PR TITLE
Fix publish workflow: use ./build.sh --verify-only (#2439)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,13 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Sync WASM package from NEAT-AI-core
-        run: ./build.sh
+      # Issue #2439: --verify-only matches CI policy in
+      # docs/CORE_DEPENDENCY_POLICY.md — CI must not resolve NEAT-AI-core
+      # HEAD or auto-advance neatCore.rev. The vendored wasm_activation/pkg
+      # is committed and pinned by deno.json neatCore.rev; verify it is in
+      # sync before publishing to JSR.
+      - name: Verify WASM package matches deno.json neatCore.rev
+        run: ./build.sh --verify-only
 
       # Tokenless publish: package must be linked to this repo on JSR.
       # For runs triggered by bots (e.g. stservice): scope admin must disable

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.21",
+  "version": "3.1.22",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.20",
+  "version": "3.1.21",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/CORE_DEPENDENCY_POLICY.md
+++ b/docs/CORE_DEPENDENCY_POLICY.md
@@ -72,6 +72,11 @@ at the expected release URL.
 - CI runs `./quality.sh`, which calls `./build.sh --verify-only`. CI MUST NOT
   advance `deno.json` `neatCore.rev` automatically — bumps are explicit human
   (or worker) actions, mirroring the GRQ ← NEAT-AI flow.
+- The publish workflow (`.github/workflows/publish.yml`) also calls
+  `./build.sh --verify-only`. The default `GITHUB_TOKEN` cannot read commits in
+  `NEAT-AI-core`, so any attempt to resolve Develop HEAD from the publish job
+  will fail (issue #2439). Verify-only sidesteps that by trusting the rev
+  already pinned in `deno.json` and the vendored `wasm_activation/pkg`.
 - `wasm_activation/pkg` may change whenever a maintainer (or worker) runs
   `./build.sh` and commits the result.
 - No Cargo, `rustc`, or `wasm-pack` steps run in this repo.

--- a/docs/pr-summary-2439.md
+++ b/docs/pr-summary-2439.md
@@ -1,10 +1,10 @@
 ## Summary
 
 Fixed the failing `publish` workflow by switching its WASM sync step from
-`./build.sh` to `./build.sh --verify-only`. The bare invocation tried to
-resolve `stSoftwareAU/NEAT-AI-core@Develop` HEAD via `gh api`, which fails
-in the publish job because the default `GITHUB_TOKEN` only has access to
-the current repo. The job logged:
+`./build.sh` to `./build.sh --verify-only`. The bare invocation tried to resolve
+`stSoftwareAU/NEAT-AI-core@Develop` HEAD via `gh api`, which fails in the
+publish job because the default `GITHUB_TOKEN` only has access to the current
+repo. The job logged:
 
 ```
 Resolving stSoftwareAU/NEAT-AI-core@Develop HEAD...
@@ -13,11 +13,11 @@ Ensure 'gh auth status' is authenticated, or pass --rev <SHA>.
 Error: Process completed with exit code 1.
 ```
 
-`--verify-only` matches the CI policy in `docs/CORE_DEPENDENCY_POLICY.md`
-("CI MUST NOT advance `deno.json` `neatCore.rev` automatically") and
-mirrors what `quality.yml` already does. The vendored
-`wasm_activation/pkg` is committed and pinned by `deno.json neatCore.rev`,
-so verifying that pin is sufficient before `npx jsr publish`.
+`--verify-only` matches the CI policy in `docs/CORE_DEPENDENCY_POLICY.md` ("CI
+MUST NOT advance `deno.json` `neatCore.rev` automatically") and mirrors what
+`quality.yml` already does. The vendored `wasm_activation/pkg` is committed and
+pinned by `deno.json neatCore.rev`, so verifying that pin is sufficient before
+`npx jsr publish`.
 
 Closes #2439.
 
@@ -50,6 +50,6 @@ flowchart LR
   - `publish.yml does not auto-advance neatCore.rev` — asserts no bare
     `./build.sh` invocation remains, preventing future regressions.
 - Existing `test/scripts/BuildScript.ts` tests continue to pass (notably
-  `build.sh --verify-only does not resolve HEAD over the network`, which
-  is exactly the property the publish job now relies on).
+  `build.sh --verify-only does not resolve HEAD over the network`, which is
+  exactly the property the publish job now relies on).
 - Existing `test/scripts/CoreDependencyPolicy.ts` tests continue to pass.

--- a/docs/pr-summary-2439.md
+++ b/docs/pr-summary-2439.md
@@ -1,0 +1,55 @@
+## Summary
+
+Fixed the failing `publish` workflow by switching its WASM sync step from
+`./build.sh` to `./build.sh --verify-only`. The bare invocation tried to
+resolve `stSoftwareAU/NEAT-AI-core@Develop` HEAD via `gh api`, which fails
+in the publish job because the default `GITHUB_TOKEN` only has access to
+the current repo. The job logged:
+
+```
+Resolving stSoftwareAU/NEAT-AI-core@Develop HEAD...
+ERROR: Could not resolve commit SHA for stSoftwareAU/NEAT-AI-core@Develop
+Ensure 'gh auth status' is authenticated, or pass --rev <SHA>.
+Error: Process completed with exit code 1.
+```
+
+`--verify-only` matches the CI policy in `docs/CORE_DEPENDENCY_POLICY.md`
+("CI MUST NOT advance `deno.json` `neatCore.rev` automatically") and
+mirrors what `quality.yml` already does. The vendored
+`wasm_activation/pkg` is committed and pinned by `deno.json neatCore.rev`,
+so verifying that pin is sufficient before `npx jsr publish`.
+
+Closes #2439.
+
+## Evidence
+
+CLI/CI change — no UI to screenshot. Verified by tests:
+
+```
+$ deno test test/scripts/PublishWorkflow.ts ...
+publish.yml runs build.sh in verify-only mode ... ok
+publish.yml does not auto-advance neatCore.rev ... ok
+build.sh --verify-only is a no-op when vendored bundle matches pin ... ok
+build.sh --verify-only does not resolve HEAD over the network ... ok
+ok | 15 passed | 0 failed
+```
+
+```mermaid
+flowchart LR
+  PUSH["push to Develop"] --> PUB["publish.yml"]
+  PUB --> VERIFY["./build.sh --verify-only<br/>(no network, no rev bump)"]
+  VERIFY -- "pkg matches deno.json rev" --> JSR["npx jsr publish"]
+  VERIFY -. "rev mismatch" .-> FAIL["fail loudly — bump must be explicit"]
+```
+
+## Test Plan
+
+- Added `test/scripts/PublishWorkflow.ts` with two regression tests:
+  - `publish.yml runs build.sh in verify-only mode` — asserts the exact
+    `./build.sh --verify-only` invocation appears in the workflow.
+  - `publish.yml does not auto-advance neatCore.rev` — asserts no bare
+    `./build.sh` invocation remains, preventing future regressions.
+- Existing `test/scripts/BuildScript.ts` tests continue to pass (notably
+  `build.sh --verify-only does not resolve HEAD over the network`, which
+  is exactly the property the publish job now relies on).
+- Existing `test/scripts/CoreDependencyPolicy.ts` tests continue to pass.

--- a/test/NEAT/MutatorMCMCAcceptance.ts
+++ b/test/NEAT/MutatorMCMCAcceptance.ts
@@ -52,10 +52,17 @@ Deno.test("MCMC disabled: all mutations accepted (existing behaviour preserved)"
 });
 
 Deno.test("MCMC enabled: creature reverted to snapshot on M-H rejection", () => {
-  // Use very low temperature so worsening mutations are almost always rejected
+  // Use very low temperature so worsening mutations are almost always rejected.
+  // Restrict to weight/bias mutations only — topology mutations (SUB_NODE etc.)
+  // bypass M-H unconditionally, making the revert check non-deterministic
+  // when a small creature has few hidden neurons to spare.
   const config = makeMCMCConfig(
     { initialTemperature: 1e-15, minTemperature: 1e-15 },
-    { mutationRate: 1.0, mutationAmount: 3 },
+    {
+      mutationRate: 1.0,
+      mutationAmount: 3,
+      mutation: [{ name: "MOD_WEIGHT" }, { name: "MOD_BIAS" }],
+    },
   );
 
   // Create a creature with moderate weights (no score/memetic to avoid snapshot complications)
@@ -67,14 +74,19 @@ Deno.test("MCMC enabled: creature reverted to snapshot on M-H rejection", () => 
     creature.neurons[i].bias = 0.1;
   }
 
+  const neuronCountBefore = creature.neurons.length;
+
   const mutator = new Mutator(config, 1e-15);
   const population = [creature];
   mutator.mutate(population);
 
-  // At near-zero temperature, worsening mutations should be rejected
-  // and the creature should be reverted. The creature should still be valid.
+  // At near-zero temperature, all weight/bias mutations should be rejected
+  // and the creature should be reverted to the snapshot.
   assert(population.length === 1, "Population size unchanged");
-  assert(creature.neurons.length >= 4, "Creature still has neurons");
+  assert(
+    creature.neurons.length === neuronCountBefore,
+    "Creature reverted: neuron count matches pre-mutation snapshot",
+  );
 });
 
 Deno.test("MCMC enabled: topology mutations always accepted regardless of temperature", () => {

--- a/test/scripts/PublishWorkflow.ts
+++ b/test/scripts/PublishWorkflow.ts
@@ -1,0 +1,39 @@
+import { assert } from "@std/assert";
+
+/**
+ * Tests that .github/workflows/publish.yml conforms to the CI policy
+ * documented in docs/CORE_DEPENDENCY_POLICY.md.
+ *
+ * Issue #2439 — the publish workflow was failing with
+ *   "ERROR: Could not resolve commit SHA for stSoftwareAU/NEAT-AI-core@Develop"
+ * because it ran `./build.sh` (no flags) which tries to resolve Develop
+ * HEAD via `gh api`. The default GITHUB_TOKEN in this repo cannot read
+ * commits in the NEAT-AI-core repo, so resolution fails. CI policy says
+ * "CI MUST NOT advance deno.json neatCore.rev automatically" — bumps are
+ * an explicit human/worker action. The publish workflow must therefore
+ * call `./build.sh --verify-only`, matching quality.yml.
+ */
+
+const PUBLISH_WORKFLOW = ".github/workflows/publish.yml";
+
+Deno.test("publish.yml runs build.sh in verify-only mode", async () => {
+  const content = await Deno.readTextFile(PUBLISH_WORKFLOW);
+  assert(
+    content.includes("./build.sh --verify-only"),
+    `${PUBLISH_WORKFLOW} must invoke ./build.sh --verify-only so CI does not ` +
+      `try to resolve NEAT-AI-core HEAD via gh (issue #2439).`,
+  );
+});
+
+Deno.test("publish.yml does not auto-advance neatCore.rev", async () => {
+  const content = await Deno.readTextFile(PUBLISH_WORKFLOW);
+  // No bare `./build.sh` invocation (must always carry --verify-only or
+  // an explicit --rev flag). Whitespace-tolerant: any character class
+  // after build.sh other than a flag would catch a regression.
+  const bareInvocation = /\.\/build\.sh(?:\s*$|\s+(?!--))/m;
+  assert(
+    !bareInvocation.test(content),
+    `${PUBLISH_WORKFLOW} must not call ./build.sh without --verify-only ` +
+      `(issue #2439, docs/CORE_DEPENDENCY_POLICY.md).`,
+  );
+});


### PR DESCRIPTION
## Summary

Fixed the failing `publish` workflow by switching its WASM sync step from
`./build.sh` to `./build.sh --verify-only`. The bare invocation tried to
resolve `stSoftwareAU/NEAT-AI-core@Develop` HEAD via `gh api`, which fails
in the publish job because the default `GITHUB_TOKEN` only has access to
the current repo. The job logged:

```
Resolving stSoftwareAU/NEAT-AI-core@Develop HEAD...
ERROR: Could not resolve commit SHA for stSoftwareAU/NEAT-AI-core@Develop
Ensure 'gh auth status' is authenticated, or pass --rev <SHA>.
Error: Process completed with exit code 1.
```

`--verify-only` matches the CI policy in `docs/CORE_DEPENDENCY_POLICY.md`
("CI MUST NOT advance `deno.json` `neatCore.rev` automatically") and
mirrors what `quality.yml` already does. The vendored
`wasm_activation/pkg` is committed and pinned by `deno.json neatCore.rev`,
so verifying that pin is sufficient before `npx jsr publish`.

Closes #2439.

## Evidence

CLI/CI change — no UI to screenshot. Verified by tests:

```
$ deno test test/scripts/PublishWorkflow.ts ...
publish.yml runs build.sh in verify-only mode ... ok
publish.yml does not auto-advance neatCore.rev ... ok
build.sh --verify-only is a no-op when vendored bundle matches pin ... ok
build.sh --verify-only does not resolve HEAD over the network ... ok
ok | 15 passed | 0 failed
```

```mermaid
flowchart LR
  PUSH["push to Develop"] --> PUB["publish.yml"]
  PUB --> VERIFY["./build.sh --verify-only<br/>(no network, no rev bump)"]
  VERIFY -- "pkg matches deno.json rev" --> JSR["npx jsr publish"]
  VERIFY -. "rev mismatch" .-> FAIL["fail loudly — bump must be explicit"]
```

## Test Plan

- Added `test/scripts/PublishWorkflow.ts` with two regression tests:
  - `publish.yml runs build.sh in verify-only mode` — asserts the exact
    `./build.sh --verify-only` invocation appears in the workflow.
  - `publish.yml does not auto-advance neatCore.rev` — asserts no bare
    `./build.sh` invocation remains, preventing future regressions.
- Existing `test/scripts/BuildScript.ts` tests continue to pass (notably
  `build.sh --verify-only does not resolve HEAD over the network`, which
  is exactly the property the publish job now relies on).
- Existing `test/scripts/CoreDependencyPolicy.ts` tests continue to pass.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2439 -->