### PR TITLE
docs: refresh AGENTS.md and parity gate for WASM-only topology/backprop (#2419)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ src/                    # Source code
   mutate/               # Mutation operators
   NEAT/                 # Core NEAT algorithm (selection, speciation)
   optimize/             # Optimisation passes
-  propagate/            # Backpropagation (elastic distribution)
+  propagate/            # Backpropagation (TS orchestration; topological loop and elastic distribution are WASM-only)
   reconstruct/          # Network reconstruction utilities
   upgrade/              # Version migration
   utils/                # Shared utilities
@@ -378,6 +378,30 @@ actionable error.
 > No manual WASM initialisation is required. The library handles this
 > automatically in all supported contexts.
 
+### WASM-only operations (no TS fallback)
+
+Several read-heavy and hot-path computations live exclusively in NEAT-AI-core
+(WASM) — there is **no TypeScript fallback**. If the WASM bundle cannot be
+loaded, these operations fail fast with an actionable error pointing at
+`./build.sh`.
+
+- **Topological helpers** (`src/wasm/WasmTopologyOps.ts`): `validateTopology`,
+  `scanAvailableConnections`, `computeReverseTopologicalOrder`,
+  `validateStructuralIntegrity`, `detectCycles`. Backed by
+  `neat-core/src/topology_ops.rs`. The previous `*TS` fallbacks were removed in
+  Issue #2415 once core stabilised.
+- **Topological backprop loop and elastic distribution**
+  (`src/propagate/WasmTopologicalBackprop.ts`,
+  `src/propagate/ElasticDistribution.ts`): the per-iteration backprop traversal
+  and elastic weight redistribution run inside core. The previous TypeScript
+  loop and elastic-distribution fallbacks were removed in Issue #2416.
+- **Topology export** (DOT / JSON): when available from core (Issue #2417), the
+  thin TS wrapper delegates formatting to core; there is no TS re-implementation
+  of the DOT or JSON formatter.
+
+If you add a new read-heavy or hot-path operation that lives in core, **do not
+re-implement a TypeScript fallback** — fail fast via `requireWasm(...)` instead.
+
 ## 🦀 Rust Discovery Module
 
 The Rust FFI extension shipped via
@@ -435,6 +459,14 @@ are:
    [NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer) must pin the
    **same core rev** as this workspace. When bumping the rev here, verify and
    update the scorer in the same coordinated change.
+8. **No TS fallbacks for core-owned operations:** once an operation moves into
+   NEAT-AI-core (e.g. topology validation/scanning, reverse topological order,
+   structural integrity, cycle detection, the topological backprop loop, and
+   elastic weight distribution), the TypeScript side does **not** keep a
+   parallel implementation. Wrappers in `src/wasm/` and `src/propagate/` call
+   into WASM and fail fast if the bundle is unavailable. Do not reintroduce
+   `*TS` fallbacks for these operations — the parity gate is the only alignment
+   check, and a divergent TS implementation would silently mask drift.
 
 ## 🔄 Feed-forward vs Recurrent Connections
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.24",
+  "version": "3.1.25",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/PARITY_GATE.md
+++ b/docs/PARITY_GATE.md
@@ -74,6 +74,15 @@ Runs the TypeScript-side tests that cross the native boundary:
 
 **Expected artefact:** `ok | N passed | 0 failed` in the Deno test summary.
 
+> [!NOTE]
+> After the topology / backprop / elastic-distribution TS fallbacks were removed
+> (Issues #2415, #2416), the parity gate's scope is unchanged. It still compares
+> the WASM scoring path (`WasmJsScoreParity.ts`) and MSE cost surface (`MSE.ts`)
+> against expected behaviour — these are the only TS-side surfaces that cross
+> the native boundary in a way that could drift independently. The removed
+> helpers had no remaining TS implementation to compare against, so excluding
+> them from the gate is correct.
+
 ## Release checklist
 
 Use this checklist for NEAT-AI-core repins:

--- a/docs/pr-summary-2419.md
+++ b/docs/pr-summary-2419.md
@@ -1,0 +1,68 @@
+# PR Summary — Issue #2419
+
+## Summary
+
+Refresh contributor-facing documentation to reflect the NEAT-AI-core integration
+changes adopted in Issues #2415 and #2416 — topology helpers, the topological
+backprop loop, and elastic distribution are all WASM-only with no TypeScript
+fallback. Also confirms the parity gate scope is unchanged after the fallback
+removals.
+
+Closes #2419 (partial — see "Deferred" below).
+
+## Changes
+
+- **AGENTS.md**
+  - "Project Architecture → Directory Structure": clarify that `src/propagate/`
+    keeps TS orchestration but the topological backprop loop and elastic
+    distribution live in WASM.
+  - Add a new "WASM-only operations (no TS fallback)" subsection under
+    "Activation / WASM" listing the WASM-backed surfaces and the
+    `requireWasm(...)` fail-fast contract.
+  - Extend the "NEAT-AI-core Dependency Policy" rules with rule 8: do not
+    reintroduce `*TS` fallbacks for core-owned operations — the parity gate is
+    the only alignment check.
+
+- **docs/PARITY_GATE.md**
+  - Add a note clarifying that the gate's scope is unchanged after the fallback
+    removals: `WasmJsScoreParity.ts` and `MSE.ts` remain the only TS-side
+    surfaces that cross the native boundary in a way that could drift
+    independently.
+
+- **docs/CORE_DEPENDENCY_POLICY.md** — confirmed unchanged. The artifact-based
+  sync flow described there still matches `build.sh` exactly after the rev bump
+  in #2414.
+
+## Deferred
+
+**README.md DOT/JSON section** — the issue's acceptance criterion to "mention
+the new DOT/JSON export capability with a minimal example" depends on the
+`exportTopologyDot` / `exportTopologyJson` wrappers added in **#2417**. That
+issue is still open, the upstream `to_dot` / `to_topology_json` exports are not
+yet present in `wasm_activation/pkg/wasm_activation.d.ts` (current pin
+`36ac4ea34fcd4e89d9fad3d6fae9efc5f02c8959`), and the TS wrappers do not exist.
+Adding a code snippet now would be either incorrect (referencing non-existent
+functions) or a no-op stub. The README section should land together with the
+wrapper implementation in #2417's PR so the example matches the public API.
+
+## Evidence
+
+This is a documentation-only change with no UI surface. Verified via:
+
+- `./quality.sh --lint-only < /dev/null` — passes (formatting, linting, bash
+  syntax check all clean).
+- Confirmed no remaining references to deleted TS symbols (`validateTopologyTS`,
+  `scanAvailableConnectionsTS`, `computeReverseTopologicalOrderTS`,
+  `validateStructuralIntegrityTS`, `detectCyclesTS`,
+  `src/propagate/TopologicalOrder.ts`) in active docs. The only matches are in
+  historical PR-summary files (`docs/pr-summary-2415.md`,
+  `docs/archive/pr-summaries/pr-summary-1641.md`) whose purpose is to record
+  those past changes — leaving them intact is correct.
+
+## Test Plan
+
+- [x] `./quality.sh --lint-only < /dev/null`
+- [x] Spot-check that `AGENTS.md` no longer implies a TS fallback for topology /
+      backprop / elastic distribution.
+- [x] Spot-check that the parity gate note does not change the gate's command
+      list — only adds context.


### PR DESCRIPTION
# PR Summary — Issue #2419

## Summary

Refresh contributor-facing documentation to reflect the NEAT-AI-core integration
changes adopted in Issues #2415 and #2416 — topology helpers, the topological
backprop loop, and elastic distribution are all WASM-only with no TypeScript
fallback. Also confirms the parity gate scope is unchanged after the fallback
removals.

Closes #2419 (partial — see "Deferred" below).

## Changes

- **AGENTS.md**
  - "Project Architecture → Directory Structure": clarify that `src/propagate/`
    keeps TS orchestration but the topological backprop loop and elastic
    distribution live in WASM.
  - Add a new "WASM-only operations (no TS fallback)" subsection under
    "Activation / WASM" listing the WASM-backed surfaces and the
    `requireWasm(...)` fail-fast contract.
  - Extend the "NEAT-AI-core Dependency Policy" rules with rule 8: do not
    reintroduce `*TS` fallbacks for core-owned operations — the parity gate is
    the only alignment check.

- **docs/PARITY_GATE.md**
  - Add a note clarifying that the gate's scope is unchanged after the fallback
    removals: `WasmJsScoreParity.ts` and `MSE.ts` remain the only TS-side
    surfaces that cross the native boundary in a way that could drift
    independently.

- **docs/CORE_DEPENDENCY_POLICY.md** — confirmed unchanged. The artifact-based
  sync flow described there still matches `build.sh` exactly after the rev bump
  in #2414.

## Deferred

**README.md DOT/JSON section** — the issue's acceptance criterion to "mention
the new DOT/JSON export capability with a minimal example" depends on the
`exportTopologyDot` / `exportTopologyJson` wrappers added in **#2417**. That
issue is still open, the upstream `to_dot` / `to_topology_json` exports are not
yet present in `wasm_activation/pkg/wasm_activation.d.ts` (current pin
`36ac4ea34fcd4e89d9fad3d6fae9efc5f02c8959`), and the TS wrappers do not exist.
Adding a code snippet now would be either incorrect (referencing non-existent
functions) or a no-op stub. The README section should land together with the
wrapper implementation in #2417's PR so the example matches the public API.

## Evidence

This is a documentation-only change with no UI surface. Verified via:

- `./quality.sh --lint-only < /dev/null` — passes (formatting, linting, bash
  syntax check all clean).
- Confirmed no remaining references to deleted TS symbols (`validateTopologyTS`,
  `scanAvailableConnectionsTS`, `computeReverseTopologicalOrderTS`,
  `validateStructuralIntegrityTS`, `detectCyclesTS`,
  `src/propagate/TopologicalOrder.ts`) in active docs. The only matches are in
  historical PR-summary files (`docs/pr-summary-2415.md`,
  `docs/archive/pr-summaries/pr-summary-1641.md`) whose purpose is to record
  those past changes — leaving them intact is correct.

## Test Plan

- [x] `./quality.sh --lint-only < /dev/null`
- [x] Spot-check that `AGENTS.md` no longer implies a TS fallback for topology /
      backprop / elastic distribution.
- [x] Spot-check that the parity gate note does not change the gate's command
      list — only adds context.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2419 -->