### PR TITLE
Add bump-deps.sh: refresh deno deps + neatCore.rev with audit gate (#2435)

### DIFF
--- a/bump-deps.sh
+++ b/bump-deps.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# bump-deps.sh — pre-PR dependency refresh, invoked by the Vibe Coder
+# worker before quality.sh (see VibeCoding#1613, #1614).
+#
+# Internal (NEAT-AI-core, stSoftwareAU/*):
+#   Advances deno.json neatCore.rev to NEAT-AI-core Develop HEAD by
+#   re-running ./build.sh, which downloads the matching wasm bundle
+#   and updates the pin atomically. No quarantine — internal deps
+#   bump immediately.
+#
+# External (jsr:@std/*, npm:*, https://deno.land/*):
+#   Bumps Deno imports in deno.json to the latest version published
+#   more than VIBE_BUMP_QUARANTINE_HOURS hours ago (default 24h).
+#   The quarantine dodges fast-flagged supply-chain attacks. Runs via
+#   `deno outdated --update --latest --minimum-dependency-age=<min>`.
+#
+# Audit gate:
+#   After bumping, runs `deno check` — any new type error attributable
+#   to the bump fails the script with a non-zero exit code. The worker
+#   then reverts per the VibeCoding#1613 contract.
+#
+# Output:
+#   Prints a one-line summary of what was bumped (or "no bumps" when
+#   already current).
+
+QUARANTINE_HOURS="${VIBE_BUMP_QUARANTINE_HOURS:-24}"
+SKIP_INTERNAL=false
+SKIP_EXTERNAL=false
+DRY_RUN=false
+
+show_help() {
+  cat <<'HELP'
+Usage: ./bump-deps.sh [OPTIONS]
+
+Refresh NEAT-AI-core (internal) and Deno (external) dependencies for
+the Vibe Coder pre-PR worker hook, then run `deno check` as the audit
+gate.
+
+Internal bump: advances deno.json neatCore.rev to NEAT-AI-core Develop
+HEAD by invoking ./build.sh. No quarantine for stSoftwareAU/* deps.
+
+External bump: runs `deno outdated --update --latest` with
+`--minimum-dependency-age` set from VIBE_BUMP_QUARANTINE_HOURS
+(default 24h) to skip too-recent registry versions.
+
+Options:
+  --no-internal             Skip the NEAT-AI-core neatCore.rev bump.
+  --no-external             Skip the external Deno dep bump.
+  --quarantine-hours <H>    Override VIBE_BUMP_QUARANTINE_HOURS.
+                            Must be a non-negative integer (default 24).
+  --dry-run                 Print what would be bumped without writing
+                            anything. Does not contact the network and
+                            does not mutate deno.json.
+  --help, -h                Show this help and exit.
+
+Exit codes:
+  0   No-op or successful bump; `deno check` is green.
+  1   Bump attempted but rejected (audit gate failed, invalid flag,
+      or upstream lookup failed). The worker should revert.
+HELP
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-internal)
+      SKIP_INTERNAL=true
+      shift
+      ;;
+    --no-external)
+      SKIP_EXTERNAL=true
+      shift
+      ;;
+    --quarantine-hours)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --quarantine-hours requires a non-negative integer" >&2
+        exit 1
+      fi
+      QUARANTINE_HOURS="$2"
+      shift 2
+      ;;
+    --quarantine-hours=*)
+      QUARANTINE_HOURS="${1#--quarantine-hours=}"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Run './bump-deps.sh --help' for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$QUARANTINE_HOURS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: quarantine hours must be a non-negative integer, got '$QUARANTINE_HOURS'" >&2
+  exit 1
+fi
+
+if ! command -v deno >/dev/null 2>&1; then
+  echo "ERROR: deno is required" >&2
+  exit 1
+fi
+
+read_neat_core_rev() {
+  deno eval '
+const cfg = JSON.parse(Deno.readTextFileSync("deno.json"));
+console.log(cfg.neatCore?.rev ?? "");
+' 2>/dev/null || echo ""
+}
+
+write_imports_to_file() {
+  # Read deno.json imports and write them as JSON to "$1". Pass the
+  # destination path through the environment so we never need bash's
+  # ${var@Q} (bash 4.4+) — macOS still ships bash 3.2.
+  BUMP_DEPS_OUT_PATH="$1" deno eval '
+const out = Deno.env.get("BUMP_DEPS_OUT_PATH");
+if (!out) { console.error("BUMP_DEPS_OUT_PATH unset"); Deno.exit(2); }
+const cfg = JSON.parse(Deno.readTextFileSync("deno.json"));
+Deno.writeTextFileSync(out, JSON.stringify(cfg.imports ?? {}, null, 2));
+'
+}
+
+compute_imports_diff() {
+  # Print "key: before -> after" lines for any key whose value differs
+  # between the JSON files at $1 (before) and $2 (after).
+  BUMP_DEPS_BEFORE_PATH="$1" BUMP_DEPS_AFTER_PATH="$2" deno eval '
+const beforePath = Deno.env.get("BUMP_DEPS_BEFORE_PATH");
+const afterPath = Deno.env.get("BUMP_DEPS_AFTER_PATH");
+if (!beforePath || !afterPath) {
+  console.error("diff paths unset");
+  Deno.exit(2);
+}
+const a = JSON.parse(Deno.readTextFileSync(beforePath));
+const b = JSON.parse(Deno.readTextFileSync(afterPath));
+const out = [];
+for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) {
+  if (a[k] !== b[k]) {
+    out.push(`${k}: ${a[k] ?? "<new>"} -> ${b[k] ?? "<removed>"}`);
+  }
+}
+console.log(out.join("\n"));
+'
+}
+
+INTERNAL_BEFORE="$(read_neat_core_rev)"
+INTERNAL_AFTER="$INTERNAL_BEFORE"
+
+# --- Internal: NEAT-AI-core neatCore.rev --------------------------------
+if [[ "$SKIP_INTERNAL" == true ]]; then
+  echo "Skipping internal bump (NEAT-AI-core neatCore.rev)."
+elif [[ "$DRY_RUN" == true ]]; then
+  echo "[dry-run] would invoke ./build.sh to advance neatCore.rev to Develop HEAD"
+else
+  echo "Bumping internal: NEAT-AI-core neatCore.rev -> Develop HEAD via ./build.sh"
+  if ! ./build.sh; then
+    echo "ERROR: ./build.sh failed; internal bump aborted." >&2
+    exit 1
+  fi
+  INTERNAL_AFTER="$(read_neat_core_rev)"
+fi
+
+# --- External: Deno deps via `deno outdated` ----------------------------
+EXTERNAL_DIFF=""
+EXTERNAL_BUMPED_COUNT=0
+
+if [[ "$SKIP_EXTERNAL" == true ]]; then
+  echo "Skipping external bump (Deno imports)."
+elif [[ "$DRY_RUN" == true ]]; then
+  echo "[dry-run] would run: deno outdated --update --latest" \
+       "--minimum-dependency-age=$((QUARANTINE_HOURS * 60))"
+else
+  QUARANTINE_MINUTES=$((QUARANTINE_HOURS * 60))
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+  before_file="$tmp_dir/imports.before.json"
+  after_file="$tmp_dir/imports.after.json"
+  write_imports_to_file "$before_file"
+
+  echo "Bumping external: deno outdated --update --latest" \
+       "--minimum-dependency-age=${QUARANTINE_MINUTES} (= ${QUARANTINE_HOURS}h)"
+  outdated_log="$tmp_dir/outdated.log"
+  if ! deno outdated --update --latest \
+      "--minimum-dependency-age=${QUARANTINE_MINUTES}" \
+      >"$outdated_log" 2>&1; then
+    cat "$outdated_log" >&2 || true
+    echo "ERROR: 'deno outdated' failed; external bump aborted." >&2
+    exit 1
+  fi
+
+  write_imports_to_file "$after_file"
+  if ! diff -q "$before_file" "$after_file" >/dev/null 2>&1; then
+    EXTERNAL_DIFF="$(compute_imports_diff "$before_file" "$after_file" || true)"
+    if [[ -n "$EXTERNAL_DIFF" ]]; then
+      EXTERNAL_BUMPED_COUNT="$(printf '%s\n' "$EXTERNAL_DIFF" | wc -l | tr -d ' ')"
+    fi
+  fi
+fi
+
+# --- Audit gate: deno check ---------------------------------------------
+if [[ "$DRY_RUN" != true ]]; then
+  echo "Audit gate: running 'deno check'..."
+  audit_log="$(mktemp)"
+  trap 'rm -f "$audit_log"' EXIT
+  if ! deno check >"$audit_log" 2>&1; then
+    cat "$audit_log" >&2 || true
+    echo "" >&2
+    echo "ERROR: 'deno check' failed after dependency bumps." >&2
+    if [[ -n "$EXTERNAL_DIFF" ]]; then
+      echo "Offending external bump(s):" >&2
+      printf '%s\n' "$EXTERNAL_DIFF" | sed 's/^/  /' >&2
+    fi
+    if [[ "$INTERNAL_BEFORE" != "$INTERNAL_AFTER" ]]; then
+      echo "Internal neatCore.rev advanced: ${INTERNAL_BEFORE:0:7} -> ${INTERNAL_AFTER:0:7}" >&2
+    fi
+    echo "Worker should revert per VibeCoding#1613." >&2
+    exit 1
+  fi
+fi
+
+# --- Summary ------------------------------------------------------------
+parts=()
+if [[ "$INTERNAL_BEFORE" != "$INTERNAL_AFTER" ]]; then
+  parts+=("neatCore.rev ${INTERNAL_BEFORE:0:7} -> ${INTERNAL_AFTER:0:7}")
+fi
+if [[ "$EXTERNAL_BUMPED_COUNT" -gt 0 ]]; then
+  parts+=("${EXTERNAL_BUMPED_COUNT} external dep(s)")
+fi
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "✅ dry-run complete (no changes written)"
+elif [[ ${#parts[@]} -eq 0 ]]; then
+  echo "✅ no bumps — dependencies already current"
+else
+  # Cross-platform safe array join (bash 3.2 lacks "${arr[*]/IFS}" idioms).
+  joined="${parts[0]}"
+  for ((i = 1; i < ${#parts[@]}; i++)); do
+    joined+="; ${parts[i]}"
+  done
+  echo "✅ bumped: ${joined}"
+  if [[ -n "$EXTERNAL_DIFF" ]]; then
+    printf '%s\n' "$EXTERNAL_DIFF" | sed 's/^/  /'
+  fi
+fi

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.26",
+  "version": "3.1.27",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2435.md
+++ b/docs/pr-summary-2435.md
@@ -1,0 +1,84 @@
+## Summary
+
+Adds `bump-deps.sh` at the repo root for the Vibe Coder pre-PR worker
+hook (VibeCoding#1613). The script refreshes both internal and external
+Deno dependencies, runs `deno check` as the audit gate, and prints a
+one-line summary of what was bumped. Closes #2435.
+
+- **Internal** (`stSoftwareAU/*`, no quarantine): re-runs `./build.sh`,
+  which advances `deno.json` `neatCore.rev` to `NEAT-AI-core` Develop
+  HEAD and downloads the matching `wasm_activation-pkg.tar.gz` artifact
+  (the existing flow added in #2433).
+- **External** (jsr/npm/https): runs
+  `deno outdated --update --latest --minimum-dependency-age=<minutes>`
+  with the quarantine derived from `VIBE_BUMP_QUARANTINE_HOURS`
+  (default 24h), so versions published more recently than the quarantine
+  are skipped.
+- **Audit gate**: runs `deno check` after bumping. On failure the
+  script exits non-zero with the offending external diff and the
+  internal SHA delta so the worker can revert per VibeCoding#1613.
+- **Lockfile**: `deno.json` has `"lock": false` in this repo, so there
+  is no `deno.lock` to verify; the audit relies on `deno check`.
+
+## Evidence
+
+This is a pure shell/CI utility — there is no UI to screenshot. The
+new script was exercised through the targeted Deno test suite below.
+Network paths (Develop HEAD lookup, registry queries) are intentionally
+not exercised by tests; they will be hit by the worker in real runs.
+
+```
+$ ./bump-deps.sh --help
+Usage: ./bump-deps.sh [OPTIONS]
+... (prints flag matrix)
+
+$ ./bump-deps.sh --dry-run --no-internal --no-external
+Skipping internal bump (NEAT-AI-core neatCore.rev).
+Skipping external bump (Deno imports).
+✅ dry-run complete (no changes written)
+
+$ ./bump-deps.sh --quarantine-hours abc
+ERROR: quarantine hours must be a non-negative integer, got 'abc'
+exit=1
+```
+
+```mermaid
+flowchart LR
+    W[Vibe Coder worker] --> B[./bump-deps.sh]
+    B --> I[Internal: ./build.sh\nneatCore.rev → Develop HEAD]
+    B --> E[External: deno outdated\n--minimum-dependency-age=Hh]
+    I --> A[Audit: deno check]
+    E --> A
+    A -->|pass| S[Summary printed]
+    A -->|fail| X[Exit 1 — worker reverts]
+    S --> Q[./quality.sh]
+```
+
+## Test Plan
+
+Added `test/scripts/BumpDepsScript.ts` (8 cases, all hermetic — no
+network):
+
+- `--help` / `-h` print usage and document `--no-internal`,
+  `--no-external`, and the quarantine env var.
+- Unknown flags exit non-zero with an `Unknown option` error.
+- `--quarantine-hours abc` is rejected with a clear quarantine message.
+- Bare `--quarantine-hours` (no value) is rejected.
+- `--dry-run --no-internal --no-external` is a true no-op:
+  `deno.json` is byte-identical before and after, summary is printed.
+- `VIBE_BUMP_QUARANTINE_HOURS` is read from the environment.
+- `bump-deps.sh` exists, is a regular file, and has the owner-execute
+  bit set so the worker can invoke it directly.
+
+Verified locally:
+
+```
+deno test ... test/scripts/BumpDepsScript.ts
+ok | 8 passed | 0 failed (192ms)
+
+deno test ... test/scripts/{BumpDepsScript,BuildScript,BuildFingerprint}.ts
+ok | 23 passed | 0 failed (465ms)
+```
+
+`./quality.sh --lint-only` and `./quality.sh --check-only` both pass
+with the new files in place.

--- a/docs/pr-summary-2435.md
+++ b/docs/pr-summary-2435.md
@@ -1,31 +1,30 @@
 ## Summary
 
-Adds `bump-deps.sh` at the repo root for the Vibe Coder pre-PR worker
-hook (VibeCoding#1613). The script refreshes both internal and external
-Deno dependencies, runs `deno check` as the audit gate, and prints a
-one-line summary of what was bumped. Closes #2435.
+Adds `bump-deps.sh` at the repo root for the Vibe Coder pre-PR worker hook
+(VibeCoding#1613). The script refreshes both internal and external Deno
+dependencies, runs `deno check` as the audit gate, and prints a one-line summary
+of what was bumped. Closes #2435.
 
-- **Internal** (`stSoftwareAU/*`, no quarantine): re-runs `./build.sh`,
-  which advances `deno.json` `neatCore.rev` to `NEAT-AI-core` Develop
-  HEAD and downloads the matching `wasm_activation-pkg.tar.gz` artifact
-  (the existing flow added in #2433).
+- **Internal** (`stSoftwareAU/*`, no quarantine): re-runs `./build.sh`, which
+  advances `deno.json` `neatCore.rev` to `NEAT-AI-core` Develop HEAD and
+  downloads the matching `wasm_activation-pkg.tar.gz` artifact (the existing
+  flow added in #2433).
 - **External** (jsr/npm/https): runs
-  `deno outdated --update --latest --minimum-dependency-age=<minutes>`
-  with the quarantine derived from `VIBE_BUMP_QUARANTINE_HOURS`
-  (default 24h), so versions published more recently than the quarantine
-  are skipped.
-- **Audit gate**: runs `deno check` after bumping. On failure the
-  script exits non-zero with the offending external diff and the
-  internal SHA delta so the worker can revert per VibeCoding#1613.
-- **Lockfile**: `deno.json` has `"lock": false` in this repo, so there
-  is no `deno.lock` to verify; the audit relies on `deno check`.
+  `deno outdated --update --latest --minimum-dependency-age=<minutes>` with the
+  quarantine derived from `VIBE_BUMP_QUARANTINE_HOURS` (default 24h), so
+  versions published more recently than the quarantine are skipped.
+- **Audit gate**: runs `deno check` after bumping. On failure the script exits
+  non-zero with the offending external diff and the internal SHA delta so the
+  worker can revert per VibeCoding#1613.
+- **Lockfile**: `deno.json` has `"lock": false` in this repo, so there is no
+  `deno.lock` to verify; the audit relies on `deno check`.
 
 ## Evidence
 
-This is a pure shell/CI utility — there is no UI to screenshot. The
-new script was exercised through the targeted Deno test suite below.
-Network paths (Develop HEAD lookup, registry queries) are intentionally
-not exercised by tests; they will be hit by the worker in real runs.
+This is a pure shell/CI utility — there is no UI to screenshot. The new script
+was exercised through the targeted Deno test suite below. Network paths (Develop
+HEAD lookup, registry queries) are intentionally not exercised by tests; they
+will be hit by the worker in real runs.
 
 ```
 $ ./bump-deps.sh --help
@@ -56,19 +55,18 @@ flowchart LR
 
 ## Test Plan
 
-Added `test/scripts/BumpDepsScript.ts` (8 cases, all hermetic — no
-network):
+Added `test/scripts/BumpDepsScript.ts` (8 cases, all hermetic — no network):
 
-- `--help` / `-h` print usage and document `--no-internal`,
-  `--no-external`, and the quarantine env var.
+- `--help` / `-h` print usage and document `--no-internal`, `--no-external`, and
+  the quarantine env var.
 - Unknown flags exit non-zero with an `Unknown option` error.
 - `--quarantine-hours abc` is rejected with a clear quarantine message.
 - Bare `--quarantine-hours` (no value) is rejected.
-- `--dry-run --no-internal --no-external` is a true no-op:
-  `deno.json` is byte-identical before and after, summary is printed.
+- `--dry-run --no-internal --no-external` is a true no-op: `deno.json` is
+  byte-identical before and after, summary is printed.
 - `VIBE_BUMP_QUARANTINE_HOURS` is read from the environment.
-- `bump-deps.sh` exists, is a regular file, and has the owner-execute
-  bit set so the worker can invoke it directly.
+- `bump-deps.sh` exists, is a regular file, and has the owner-execute bit set so
+  the worker can invoke it directly.
 
 Verified locally:
 
@@ -80,5 +78,5 @@ deno test ... test/scripts/{BumpDepsScript,BuildScript,BuildFingerprint}.ts
 ok | 23 passed | 0 failed (465ms)
 ```
 
-`./quality.sh --lint-only` and `./quality.sh --check-only` both pass
-with the new files in place.
+`./quality.sh --lint-only` and `./quality.sh --check-only` both pass with the
+new files in place.

--- a/test/scripts/BumpDepsScript.ts
+++ b/test/scripts/BumpDepsScript.ts
@@ -1,0 +1,167 @@
+import { assert, assertEquals } from "@std/assert";
+
+/**
+ * Tests bump-deps.sh flag parsing and behaviour.
+ *
+ * Issue #2435 — add bump-deps.sh: refresh deno deps + neatCore.rev with
+ * audit gate. The Vibe Coder worker invokes this script before
+ * quality.sh on every PR (see VibeCoding#1613).
+ *
+ * These tests deliberately avoid the network paths (Develop HEAD
+ * resolution, artifact download, registry lookups). They verify:
+ *   - flag parsing / help / unknown-option handling
+ *   - quarantine value validation
+ *   - --dry-run is a true no-op (does not touch deno.json or call out)
+ *   - the executable bit is set so the worker can run it directly
+ */
+
+async function runBump(
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command("bash", {
+    args: ["./bump-deps.sh", ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: Deno.cwd(),
+    env: { PATH: Deno.env.get("PATH") ?? "", ...env },
+  });
+  const output = await command.output();
+  return {
+    stdout: new TextDecoder().decode(output.stdout),
+    stderr: new TextDecoder().decode(output.stderr),
+    code: output.code,
+  };
+}
+
+Deno.test({
+  name:
+    "bump-deps.sh --help prints usage with internal/external/quarantine sections",
+  permissions: { run: true, read: true, env: true },
+  fn: async () => {
+    const result = await runBump(["--help"]);
+    assertEquals(result.code, 0, `Expected exit 0; stderr=${result.stderr}`);
+    assert(result.stdout.includes("Usage:"), "expected 'Usage:' in help");
+    assert(
+      result.stdout.includes("--no-internal"),
+      "expected --no-internal in help",
+    );
+    assert(
+      result.stdout.includes("--no-external"),
+      "expected --no-external in help",
+    );
+    assert(
+      result.stdout.includes("--quarantine-hours") ||
+        result.stdout.includes("VIBE_BUMP_QUARANTINE_HOURS"),
+      "expected quarantine docs in help",
+    );
+  },
+});
+
+Deno.test({
+  name: "bump-deps.sh -h prints usage and exits 0",
+  permissions: { run: true, read: true, env: true },
+  fn: async () => {
+    const result = await runBump(["-h"]);
+    assertEquals(result.code, 0);
+    assert(result.stdout.includes("Usage:"));
+  },
+});
+
+Deno.test({
+  name: "bump-deps.sh rejects unknown flags",
+  permissions: { run: true, read: true, env: true },
+  fn: async () => {
+    const result = await runBump(["--no-such-flag"]);
+    assert(result.code !== 0, "expected non-zero exit for unknown flag");
+    assert(
+      result.stderr.includes("Unknown option") ||
+        result.stderr.includes("--no-such-flag"),
+      `expected Unknown option message; got: ${result.stderr}`,
+    );
+  },
+});
+
+Deno.test({
+  name: "bump-deps.sh rejects non-numeric --quarantine-hours",
+  permissions: { run: true, read: true, env: true },
+  fn: async () => {
+    const result = await runBump(["--quarantine-hours", "abc"]);
+    assert(result.code !== 0, "expected non-zero exit for non-numeric value");
+    assert(
+      result.stderr.toLowerCase().includes("quarantine"),
+      `expected message to mention quarantine; got: ${result.stderr}`,
+    );
+  },
+});
+
+Deno.test({
+  name: "bump-deps.sh requires a value for --quarantine-hours",
+  permissions: { run: true, read: true, env: true },
+  fn: async () => {
+    const result = await runBump(["--quarantine-hours"]);
+    assert(result.code !== 0, "expected non-zero exit when value missing");
+  },
+});
+
+Deno.test({
+  name:
+    "bump-deps.sh --dry-run --no-internal --no-external is a true no-op (no deno.json mutation)",
+  permissions: { run: true, read: true, write: true, env: true },
+  fn: async () => {
+    const before = await Deno.readTextFile("deno.json");
+    const result = await runBump([
+      "--dry-run",
+      "--no-internal",
+      "--no-external",
+    ]);
+    assertEquals(
+      result.code,
+      0,
+      `expected exit 0 for full no-op; stderr=${result.stderr}`,
+    );
+    assert(
+      result.stdout.includes("no bumps") ||
+        result.stdout.includes("dry-run") ||
+        result.stdout.includes("dry run"),
+      `expected dry-run / no-bumps summary; stdout=${result.stdout}`,
+    );
+    const after = await Deno.readTextFile("deno.json");
+    assertEquals(before, after, "dry-run must not mutate deno.json");
+  },
+});
+
+Deno.test({
+  name: "bump-deps.sh accepts VIBE_BUMP_QUARANTINE_HOURS env override",
+  permissions: { run: true, read: true, env: true, write: true },
+  fn: async () => {
+    const before = await Deno.readTextFile("deno.json");
+    // Pass an absurdly large quarantine via env to prove the script reads
+    // the env var without erroring; combine with --no-internal/--no-external
+    // to keep the run hermetic.
+    const result = await runBump([
+      "--dry-run",
+      "--no-internal",
+      "--no-external",
+    ], {
+      VIBE_BUMP_QUARANTINE_HOURS: "168",
+    });
+    assertEquals(result.code, 0, `stderr=${result.stderr}`);
+    const after = await Deno.readTextFile("deno.json");
+    assertEquals(before, after, "must not mutate deno.json under --dry-run");
+  },
+});
+
+Deno.test({
+  name: "bump-deps.sh exists and is executable",
+  permissions: { read: true },
+  fn: async () => {
+    const stat = await Deno.stat("bump-deps.sh");
+    assert(stat.isFile, "bump-deps.sh must be a regular file");
+    // mode is null on some platforms; only assert when present.
+    if (stat.mode !== null) {
+      const ownerExec = (stat.mode & 0o100) !== 0;
+      assert(ownerExec, "bump-deps.sh must be executable by the owner");
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Adds `bump-deps.sh` at the repo root for the Vibe Coder pre-PR worker
hook (VibeCoding#1613). The script refreshes both internal and external
Deno dependencies, runs `deno check` as the audit gate, and prints a
one-line summary of what was bumped. Closes #2435.

- **Internal** (`stSoftwareAU/*`, no quarantine): re-runs `./build.sh`,
  which advances `deno.json` `neatCore.rev` to NEAT-AI-core Develop
  HEAD and downloads the matching `wasm_activation-pkg.tar.gz` artifact
  (the existing flow added in #2433).
- **External** (jsr/npm/https): runs
  `deno outdated --update --latest --minimum-dependency-age=<minutes>`
  with the quarantine derived from `VIBE_BUMP_QUARANTINE_HOURS`
  (default 24h), so versions published more recently than the
  quarantine are skipped.
- **Audit gate**: runs `deno check` after bumping. On failure the
  script exits non-zero with the offending external diff and the
  internal SHA delta so the worker can revert per VibeCoding#1613.
- **Lockfile**: `deno.json` has `"lock": false` in this repo, so there
  is no `deno.lock` to verify; the audit relies on `deno check`.

```mermaid
flowchart LR
    W[Vibe Coder worker] --> B[./bump-deps.sh]
    B --> I[Internal: ./build.sh<br/>neatCore.rev to Develop HEAD]
    B --> E[External: deno outdated<br/>--minimum-dependency-age=Hh]
    I --> A[Audit: deno check]
    E --> A
    A -->|pass| S[Summary printed]
    A -->|fail| X[Exit 1 — worker reverts]
    S --> Q[./quality.sh]
```

## Test plan

- [x] `deno test test/scripts/BumpDepsScript.ts` — 8 hermetic cases pass (no network).
- [x] `deno test test/scripts/{BumpDepsScript,BuildScript,BuildFingerprint}.ts` — 23 passed.
- [x] `./quality.sh --lint-only` passes (incl. `bash -n bump-deps.sh`).
- [x] `./quality.sh --check-only` passes.
- [x] `./bump-deps.sh --help`, `--dry-run --no-internal --no-external`,
      and invalid-flag rejection verified by hand.