### PR TITLE
fix: remove per-test permissions from BumpDepsScript.ts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.27",
+  "version": "3.1.28",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/test/scripts/BumpDepsScript.ts
+++ b/test/scripts/BumpDepsScript.ts
@@ -37,7 +37,6 @@ async function runBump(
 Deno.test({
   name:
     "bump-deps.sh --help prints usage with internal/external/quarantine sections",
-  permissions: { run: true, read: true, env: true },
   fn: async () => {
     const result = await runBump(["--help"]);
     assertEquals(result.code, 0, `Expected exit 0; stderr=${result.stderr}`);
@@ -60,7 +59,6 @@ Deno.test({
 
 Deno.test({
   name: "bump-deps.sh -h prints usage and exits 0",
-  permissions: { run: true, read: true, env: true },
   fn: async () => {
     const result = await runBump(["-h"]);
     assertEquals(result.code, 0);
@@ -70,7 +68,6 @@ Deno.test({
 
 Deno.test({
   name: "bump-deps.sh rejects unknown flags",
-  permissions: { run: true, read: true, env: true },
   fn: async () => {
     const result = await runBump(["--no-such-flag"]);
     assert(result.code !== 0, "expected non-zero exit for unknown flag");
@@ -84,7 +81,6 @@ Deno.test({
 
 Deno.test({
   name: "bump-deps.sh rejects non-numeric --quarantine-hours",
-  permissions: { run: true, read: true, env: true },
   fn: async () => {
     const result = await runBump(["--quarantine-hours", "abc"]);
     assert(result.code !== 0, "expected non-zero exit for non-numeric value");
@@ -97,7 +93,6 @@ Deno.test({
 
 Deno.test({
   name: "bump-deps.sh requires a value for --quarantine-hours",
-  permissions: { run: true, read: true, env: true },
   fn: async () => {
     const result = await runBump(["--quarantine-hours"]);
     assert(result.code !== 0, "expected non-zero exit when value missing");
@@ -107,7 +102,6 @@ Deno.test({
 Deno.test({
   name:
     "bump-deps.sh --dry-run --no-internal --no-external is a true no-op (no deno.json mutation)",
-  permissions: { run: true, read: true, write: true, env: true },
   fn: async () => {
     const before = await Deno.readTextFile("deno.json");
     const result = await runBump([
@@ -133,7 +127,6 @@ Deno.test({
 
 Deno.test({
   name: "bump-deps.sh accepts VIBE_BUMP_QUARANTINE_HOURS env override",
-  permissions: { run: true, read: true, env: true, write: true },
   fn: async () => {
     const before = await Deno.readTextFile("deno.json");
     // Pass an absurdly large quarantine via env to prove the script reads
@@ -154,7 +147,6 @@ Deno.test({
 
 Deno.test({
   name: "bump-deps.sh exists and is executable",
-  permissions: { read: true },
   fn: async () => {
     const stat = await Deno.stat("bump-deps.sh");
     assert(stat.isFile, "bump-deps.sh must be a regular file");


### PR DESCRIPTION
## Summary

Fixes the test failure reported in PR #2447 review.

- Removed per-test `permissions` objects from all `Deno.test()` calls in `test/scripts/BumpDepsScript.ts`

## Root cause

Deno's per-test `permissions` field can only *restrict* permissions to a subset of what the parent process already has — it cannot escalate beyond the parent's permission set. Running `deno test test/scripts/BumpDepsScript.ts` without permission flags caused all 8 tests to fail immediately with:

```
error: NotCapable: Can't escalate parent thread permissions
```

## Fix

Removing the `permissions` objects lets tests inherit the parent's permissions. They pass as before through `quality.sh` (which grants `--allow-run --allow-read --allow-write --allow-env`) and via `deno test -A`.

## Test plan

- [x] `deno test --allow-run --allow-read --allow-write --allow-env test/scripts/BumpDepsScript.ts` — 8 passed
- [x] `./quality.sh --lint-only` passes
- [x] `./quality.sh --check-only` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)