### PR TITLE
Strengthen bump-deps.sh audit gate with WASM smoke test (#2465)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,6 +402,28 @@ loaded, these operations fail fast with an actionable error pointing at
 If you add a new read-heavy or hot-path operation that lives in core, **do not
 re-implement a TypeScript fallback** — fail fast via `requireWasm(...)` instead.
 
+### WASM smoke audit gate in `bump-deps.sh` (Issue #2465)
+
+Because the WASM-only operations above have no TS fallback, a freshly bumped
+WASM bundle that traps at runtime (e.g. `RuntimeError: unreachable` inside
+`propagate_topological`) cannot be detected by `deno check` — the static
+type-check still passes. Issue #2460 demonstrated 120 silent test failures
+landing on `main` from exactly this class of regression.
+
+`bump-deps.sh` therefore runs a two-phase audit gate after the bumps:
+
+1. **WASM smoke gate** — a curated subset of `deno test` specs covering the
+   `propagate_topological`, `wasmTopologicalBackprop`, and
+   `compute_score_components` paths. The list is intentionally small so the
+   total wall-clock stays under ~120 seconds; the gate is hard-capped via
+   `$TIMEOUT_CMD` (`gtimeout` on macOS, `timeout` on Linux).
+2. **`deno check`** — the existing static type-check.
+
+Either gate failing fails the script with exit 1, and the Vibe Coder worker
+reverts per the VibeCoding#1613 contract. Use `--skip-smoke` only when running
+the full `./quality.sh` immediately afterwards (which exercises the same paths
+and more).
+
 ## 🦀 Rust Discovery Module
 
 The Rust FFI extension shipped via

--- a/bump-deps.sh
+++ b/bump-deps.sh
@@ -19,10 +19,17 @@ cd "$SCRIPT_DIR"
 #   The quarantine dodges fast-flagged supply-chain attacks. Runs via
 #   `deno outdated --update --latest --minimum-dependency-age=<min>`.
 #
-# Audit gate:
-#   After bumping, runs `deno check` — any new type error attributable
-#   to the bump fails the script with a non-zero exit code. The worker
-#   then reverts per the VibeCoding#1613 contract.
+# Audit gate (two-phase, Issue #2465):
+#   1. WASM smoke tests — runs a small, fast subset of `deno test`
+#      specs that exercise the WASM `propagate_topological`,
+#      `wasmTopologicalBackprop`, and `compute_score_components` paths.
+#      This catches runtime traps (e.g. `RuntimeError: unreachable`) in
+#      a freshly bumped WASM bundle that `deno check` cannot detect,
+#      which was the root cause of Issue #2460's 120 silent failures.
+#   2. `deno check` — static type-check, catches type errors introduced
+#      by external dep bumps.
+#   Either gate failing fails the script with a non-zero exit code.
+#   The worker then reverts per the VibeCoding#1613 contract.
 #
 # Output:
 #   Prints a one-line summary of what was bumped (or "no bumps" when
@@ -31,15 +38,41 @@ cd "$SCRIPT_DIR"
 QUARANTINE_HOURS="${VIBE_BUMP_QUARANTINE_HOURS:-24}"
 SKIP_INTERNAL=false
 SKIP_EXTERNAL=false
+SKIP_SMOKE=false
 DRY_RUN=false
+
+# Resolve a portable timeout binary. macOS ships no native `timeout`; the
+# coreutils variant is named `gtimeout` there. Empty string means "no
+# timeout available" — in that case the smoke step still runs but cannot
+# be hard-capped, which is acceptable for a local developer machine.
+TIMEOUT_CMD="${TIMEOUT_CMD:-}"
+if [[ -z "$TIMEOUT_CMD" ]]; then
+  if command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="gtimeout"
+  elif command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="timeout"
+  fi
+fi
+
+# Curated WASM smoke specs (Issue #2465). Kept small so the gate stays
+# under ~120 seconds on a slow runner. Each entry must exercise the
+# WASM propagate_topological / wasmTopologicalBackprop /
+# compute_score_components hot paths so a trapping bundle fails here
+# instead of in main.
+WASM_SMOKE_SPECS=(
+  "test/propagate/WasmTopologicalBackprop.ts"
+  "test/propagate/SingleNeuron.ts"
+  "test/propagate/TopologicalBackpropagation.ts"
+)
+WASM_SMOKE_TIMEOUT_SECONDS="${BUMP_DEPS_SMOKE_TIMEOUT_SECONDS:-120}"
 
 show_help() {
   cat <<'HELP'
 Usage: ./bump-deps.sh [OPTIONS]
 
 Refresh NEAT-AI-core (internal) and Deno (external) dependencies for
-the Vibe Coder pre-PR worker hook, then run `deno check` as the audit
-gate.
+the Vibe Coder pre-PR worker hook, then run a two-phase audit gate:
+a fast WASM smoke test followed by `deno check`.
 
 Internal bump: advances deno.json neatCore.rev to NEAT-AI-core Develop
 HEAD by invoking ./build.sh. No quarantine for stSoftwareAU/* deps.
@@ -48,9 +81,19 @@ External bump: runs `deno outdated --update --latest` with
 `--minimum-dependency-age` set from VIBE_BUMP_QUARANTINE_HOURS
 (default 24h) to skip too-recent registry versions.
 
+Audit gate (Issue #2465):
+  1. WASM smoke tests — runs a small `deno test` subset against the
+     WASM topological backprop + scoring hot paths. Catches runtime
+     traps in a fresh WASM bundle that `deno check` cannot detect.
+     Capped at BUMP_DEPS_SMOKE_TIMEOUT_SECONDS (default 120s).
+  2. `deno check` — static type-check.
+
 Options:
   --no-internal             Skip the NEAT-AI-core neatCore.rev bump.
   --no-external             Skip the external Deno dep bump.
+  --skip-smoke              Skip the WASM smoke audit gate. Use only
+                            for hermetic dry-runs or when running the
+                            full quality gate immediately afterwards.
   --quarantine-hours <H>    Override VIBE_BUMP_QUARANTINE_HOURS.
                             Must be a non-negative integer (default 24).
   --dry-run                 Print what would be bumped without writing
@@ -59,9 +102,10 @@ Options:
   --help, -h                Show this help and exit.
 
 Exit codes:
-  0   No-op or successful bump; `deno check` is green.
-  1   Bump attempted but rejected (audit gate failed, invalid flag,
-      or upstream lookup failed). The worker should revert.
+  0   No-op or successful bump; both audit gates are green.
+  1   Bump attempted but rejected (smoke gate or `deno check` failed,
+      invalid flag, or upstream lookup failed). The worker should
+      revert.
 HELP
 }
 
@@ -73,6 +117,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-external)
       SKIP_EXTERNAL=true
+      shift
+      ;;
+    --skip-smoke)
+      SKIP_SMOKE=true
       shift
       ;;
     --quarantine-hours)
@@ -209,9 +257,56 @@ else
   fi
 fi
 
-# --- Audit gate: deno check ---------------------------------------------
+# --- Audit gate (1/2): WASM smoke tests (Issue #2465) -------------------
+# Catches runtime traps in a freshly bumped WASM bundle that `deno check`
+# cannot see (root cause of Issue #2460's 120 silent failures).
+if [[ "$DRY_RUN" == true ]]; then
+  if [[ "$SKIP_SMOKE" == true ]]; then
+    echo "[dry-run] would skip WASM smoke audit gate (--skip-smoke)"
+  else
+    echo "[dry-run] would run WASM smoke audit gate:" \
+         "${WASM_SMOKE_SPECS[*]}" \
+         "(timeout ${WASM_SMOKE_TIMEOUT_SECONDS}s)"
+  fi
+elif [[ "$SKIP_SMOKE" == true ]]; then
+  echo "Skipping WASM smoke audit gate (--skip-smoke)."
+else
+  echo "Audit gate (1/2): WASM smoke tests..."
+  smoke_log="$(mktemp)"
+  trap 'rm -f "$smoke_log"' EXIT
+  smoke_cmd=(deno test --config ./deno.json --allow-all
+    "${WASM_SMOKE_SPECS[@]}")
+  if [[ -n "$TIMEOUT_CMD" ]]; then
+    smoke_cmd=("$TIMEOUT_CMD" "$WASM_SMOKE_TIMEOUT_SECONDS" "${smoke_cmd[@]}")
+  fi
+  smoke_exit=0
+  "${smoke_cmd[@]}" </dev/null >"$smoke_log" 2>&1 || smoke_exit=$?
+  if [[ "$smoke_exit" -ne 0 ]]; then
+    cat "$smoke_log" >&2 || true
+    echo "" >&2
+    echo "ERROR: WASM smoke audit gate failed (exit ${smoke_exit})." >&2
+    echo "       Specs:" >&2
+    for spec in "${WASM_SMOKE_SPECS[@]}"; do
+      echo "         - $spec" >&2
+    done
+    if [[ "$smoke_exit" == 124 ]]; then
+      echo "       Smoke gate timed out after ${WASM_SMOKE_TIMEOUT_SECONDS}s." >&2
+    fi
+    if [[ -n "$EXTERNAL_DIFF" ]]; then
+      echo "Offending external bump(s):" >&2
+      printf '%s\n' "$EXTERNAL_DIFF" | sed 's/^/  /' >&2
+    fi
+    if [[ "$INTERNAL_BEFORE" != "$INTERNAL_AFTER" ]]; then
+      echo "Internal neatCore.rev advanced: ${INTERNAL_BEFORE:0:7} -> ${INTERNAL_AFTER:0:7}" >&2
+    fi
+    echo "Worker should revert per VibeCoding#1613." >&2
+    exit 1
+  fi
+fi
+
+# --- Audit gate (2/2): deno check ---------------------------------------
 if [[ "$DRY_RUN" != true ]]; then
-  echo "Audit gate: running 'deno check'..."
+  echo "Audit gate (2/2): running 'deno check'..."
   audit_log="$(mktemp)"
   trap 'rm -f "$audit_log"' EXIT
   if ! deno check >"$audit_log" 2>&1; then

--- a/docs/pr-summary-2465.md
+++ b/docs/pr-summary-2465.md
@@ -1,0 +1,108 @@
+# PR Summary — Issue #2465
+
+## Summary
+
+Strengthen the `bump-deps.sh` audit gate with a WASM smoke test step so a
+freshly bumped WASM bundle that traps at runtime (e.g.
+`RuntimeError: unreachable` inside `propagate_topological`) cannot reach `main`
+silently. The previous single-phase gate ran only `deno check`, which catches
+type errors but not runtime traps — the root cause of Issue #2460's 120 silent
+test failures.
+
+The gate is now two-phase: first a small, fast `deno test` subset over the WASM
+hot paths, then the existing `deno check`. Either failing fails the script with
+exit 1 so the worker reverts per the VibeCoding#1613 contract.
+
+Closes #2465.
+
+## Evidence
+
+This is a backend / shell change with no UI surface.
+
+### Audit gate flow
+
+```mermaid
+flowchart TD
+    A[bump-deps.sh start] --> B[Internal: ./build.sh<br/>advance neatCore.rev]
+    B --> C[External: deno outdated --update --latest<br/>with quarantine]
+    C --> D{Audit gate 1/2:<br/>WASM smoke tests}
+    D -->|fail| X[Exit 1<br/>worker reverts]
+    D -->|pass| E{Audit gate 2/2:<br/>deno check}
+    E -->|fail| X
+    E -->|pass| F[Print summary, exit 0]
+```
+
+The smoke specs cover the WASM `propagate_topological`,
+`wasmTopologicalBackprop`, and `compute_score_components` paths:
+
+- `test/propagate/WasmTopologicalBackprop.ts`
+- `test/propagate/SingleNeuron.ts`
+- `test/propagate/TopologicalBackpropagation.ts`
+
+### Acceptance evidence
+
+- `bump-deps.sh --help` documents the new gate and the `--skip-smoke` escape
+  hatch.
+- A live run with both bumps skipped completes within the documented time
+  budget:
+
+  ```
+  Skipping internal bump (NEAT-AI-core neatCore.rev).
+  Skipping external bump (Deno imports).
+  Audit gate (1/2): WASM smoke tests...
+  Audit gate (2/2): running 'deno check'...
+  ✅ no bumps — dependencies already current
+  ```
+
+- A run against a deliberately-broken smoke spec list exits non-zero with a
+  clear message identifying the smoke gate as the cause:
+
+  ```
+  Audit gate (1/2): WASM smoke tests...
+  error: Import 'file:///.../test/propagate/_DOES_NOT_EXIST.ts' failed, not found.
+
+  ERROR: WASM smoke audit gate failed (exit 1).
+         Specs:
+           - test/propagate/_DOES_NOT_EXIST.ts
+           - test/propagate/SingleNeuron.ts
+           - test/propagate/TopologicalBackpropagation.ts
+  Worker should revert per VibeCoding#1613.
+  exit: 1
+  ```
+
+  This same code path fires when a WASM bundle traps at runtime — the
+  `deno test` invocation returns non-zero and is reported as a smoke-gate
+  failure, not a `deno check` failure.
+
+- `AGENTS.md` documents the gate alongside the existing WASM-only operations
+  section.
+
+## Test Plan
+
+Tests added to `test/scripts/BumpDepsScript.ts`:
+
+- `bump-deps.sh --help documents the WASM smoke audit gate (Issue #2465)` —
+  asserts `--help` mentions "smoke", "WASM", and `--skip-smoke`.
+- `bump-deps.sh accepts --skip-smoke under --dry-run (Issue #2465)` — confirms
+  the flag is parsed and is a no-op under `--dry-run`.
+- `bump-deps.sh --dry-run announces the smoke audit gate (Issue #2465)` —
+  confirms dry-run output mentions the smoke gate.
+
+All 11 tests in `BumpDepsScript.ts` pass:
+
+```
+ok | 11 passed | 0 failed (285ms)
+```
+
+The existing 8 tests are untouched; existing behaviour (flag parsing, quarantine
+validation, dry-run hermetic) is preserved.
+
+### Manual verification
+
+| Scenario                                | Expected                             | Observed |
+| --------------------------------------- | ------------------------------------ | -------- |
+| `--help`                                | mentions smoke, WASM, `--skip-smoke` | ✅       |
+| `--dry-run --no-internal --no-external` | announces smoke gate                 | ✅       |
+| `--dry-run --skip-smoke`                | announces skip                       | ✅       |
+| Live run, no bumps                      | both gates run, exit 0               | ✅       |
+| Live run, broken smoke spec             | exits 1, names smoke gate            | ✅       |

--- a/test/scripts/BumpDepsScript.ts
+++ b/test/scripts/BumpDepsScript.ts
@@ -146,6 +146,58 @@ Deno.test({
 });
 
 Deno.test({
+  name: "bump-deps.sh --help documents the WASM smoke audit gate (Issue #2465)",
+  fn: async () => {
+    const result = await runBump(["--help"]);
+    assertEquals(result.code, 0, `stderr=${result.stderr}`);
+    assert(
+      /smoke/i.test(result.stdout),
+      `expected --help to mention the smoke gate; got: ${result.stdout}`,
+    );
+    assert(
+      /wasm/i.test(result.stdout),
+      `expected --help to mention WASM in the smoke gate; got: ${result.stdout}`,
+    );
+    assert(
+      result.stdout.includes("--skip-smoke"),
+      `expected --help to document --skip-smoke; got: ${result.stdout}`,
+    );
+  },
+});
+
+Deno.test({
+  name: "bump-deps.sh accepts --skip-smoke under --dry-run (Issue #2465)",
+  fn: async () => {
+    const before = await Deno.readTextFile("deno.json");
+    const result = await runBump([
+      "--dry-run",
+      "--no-internal",
+      "--no-external",
+      "--skip-smoke",
+    ]);
+    assertEquals(result.code, 0, `stderr=${result.stderr}`);
+    const after = await Deno.readTextFile("deno.json");
+    assertEquals(before, after, "dry-run must not mutate deno.json");
+  },
+});
+
+Deno.test({
+  name: "bump-deps.sh --dry-run announces the smoke audit gate (Issue #2465)",
+  fn: async () => {
+    const result = await runBump([
+      "--dry-run",
+      "--no-internal",
+      "--no-external",
+    ]);
+    assertEquals(result.code, 0, `stderr=${result.stderr}`);
+    assert(
+      /smoke/i.test(result.stdout),
+      `expected --dry-run output to mention smoke gate; got: ${result.stdout}`,
+    );
+  },
+});
+
+Deno.test({
   name: "bump-deps.sh exists and is executable",
   fn: async () => {
     const stat = await Deno.stat("bump-deps.sh");


### PR DESCRIPTION
# PR Summary — Issue #2465

## Summary

Strengthen the `bump-deps.sh` audit gate with a WASM smoke test step so a
freshly bumped WASM bundle that traps at runtime (e.g.
`RuntimeError: unreachable` inside `propagate_topological`) cannot reach `main`
silently. The previous single-phase gate ran only `deno check`, which catches
type errors but not runtime traps — the root cause of Issue #2460's 120 silent
test failures.

The gate is now two-phase: first a small, fast `deno test` subset over the WASM
hot paths, then the existing `deno check`. Either failing fails the script with
exit 1 so the worker reverts per the VibeCoding#1613 contract.

Closes #2465.

## Evidence

This is a backend / shell change with no UI surface.

### Audit gate flow

```mermaid
flowchart TD
    A[bump-deps.sh start] --> B[Internal: ./build.sh<br/>advance neatCore.rev]
    B --> C[External: deno outdated --update --latest<br/>with quarantine]
    C --> D{Audit gate 1/2:<br/>WASM smoke tests}
    D -->|fail| X[Exit 1<br/>worker reverts]
    D -->|pass| E{Audit gate 2/2:<br/>deno check}
    E -->|fail| X
    E -->|pass| F[Print summary, exit 0]
```

The smoke specs cover the WASM `propagate_topological`,
`wasmTopologicalBackprop`, and `compute_score_components` paths:

- `test/propagate/WasmTopologicalBackprop.ts`
- `test/propagate/SingleNeuron.ts`
- `test/propagate/TopologicalBackpropagation.ts`

### Acceptance evidence

- `bump-deps.sh --help` documents the new gate and the `--skip-smoke` escape
  hatch.
- A live run with both bumps skipped completes within the documented time
  budget:

  ```
  Skipping internal bump (NEAT-AI-core neatCore.rev).
  Skipping external bump (Deno imports).
  Audit gate (1/2): WASM smoke tests...
  Audit gate (2/2): running 'deno check'...
  ✅ no bumps — dependencies already current
  ```

- A run against a deliberately-broken smoke spec list exits non-zero with a
  clear message identifying the smoke gate as the cause:

  ```
  Audit gate (1/2): WASM smoke tests...
  error: Import 'file:///.../test/propagate/_DOES_NOT_EXIST.ts' failed, not found.

  ERROR: WASM smoke audit gate failed (exit 1).
         Specs:
           - test/propagate/_DOES_NOT_EXIST.ts
           - test/propagate/SingleNeuron.ts
           - test/propagate/TopologicalBackpropagation.ts
  Worker should revert per VibeCoding#1613.
  exit: 1
  ```

  This same code path fires when a WASM bundle traps at runtime — the
  `deno test` invocation returns non-zero and is reported as a smoke-gate
  failure, not a `deno check` failure.

- `AGENTS.md` documents the gate alongside the existing WASM-only operations
  section.

## Test Plan

Tests added to `test/scripts/BumpDepsScript.ts`:

- `bump-deps.sh --help documents the WASM smoke audit gate (Issue #2465)` —
  asserts `--help` mentions "smoke", "WASM", and `--skip-smoke`.
- `bump-deps.sh accepts --skip-smoke under --dry-run (Issue #2465)` — confirms
  the flag is parsed and is a no-op under `--dry-run`.
- `bump-deps.sh --dry-run announces the smoke audit gate (Issue #2465)` —
  confirms dry-run output mentions the smoke gate.

All 11 tests in `BumpDepsScript.ts` pass:

```
ok | 11 passed | 0 failed (285ms)
```

The existing 8 tests are untouched; existing behaviour (flag parsing, quarantine
validation, dry-run hermetic) is preserved.

### Manual verification

| Scenario                                | Expected                             | Observed |
| --------------------------------------- | ------------------------------------ | -------- |
| `--help`                                | mentions smoke, WASM, `--skip-smoke` | ✅       |
| `--dry-run --no-internal --no-external` | announces smoke gate                 | ✅       |
| `--dry-run --skip-smoke`                | announces skip                       | ✅       |
| Live run, no bumps                      | both gates run, exit 0               | ✅       |
| Live run, broken smoke spec             | exits 1, names smoke gate            | ✅       |



## Milestone
This PR is part of the **WASM regression** milestone and targets the `milestone/wasm-regression` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2465 -->