### PR TITLE
Add permanent regression test for wasmPropagateTopological traps (#2466)

### DIFF
--- a/docs/pr-summary-2466.md
+++ b/docs/pr-summary-2466.md
@@ -1,0 +1,123 @@
+# Add permanent regression test for `wasmPropagateTopological` traps
+
+Closes #2466.
+
+## Summary
+
+Adds a focused, deterministic regression test that drives the WASM-only
+`propagate_topological` path end-to-end and asserts that no
+`RuntimeError: unreachable` trap occurs and that the returned accumulation state
+has the expected shape and finite values. This is the TS-side guard test
+promised by Issue #2460 — `propagate_topological` is on the AGENTS.md "WASM-only
+operations (no TS fallback)" list, so a TypeScript-side guard is the only line
+of defence against an ABI regression sneaking in via a `neatCore.rev` bump.
+
+The new test is `test/wasm/WasmPropagateTopologicalTrapGuard.ts`. It:
+
+- Builds the same 5-input / 4-hidden (IDENTITY) / 2-output (MAXIMUM) creature
+  shape from the original repro (`docs/evidence/2461-repro.ts`) — the smallest
+  topology known to reliably surface the bounds-check panic on a bad pin.
+- Drives 100 deterministic samples (seeded LCG, no `Math.random()` outside that
+  helper) through `creature.activateAndTrace(...)` → `creature.propagate(...)` →
+  `creature.propagateUpdate(...)`.
+- Asserts the call returns without throwing.
+- Asserts the per-neuron and per-synapse accumulation state contains only finite
+  values (no `NaN`/`Infinity` outside the documented `Infinity` sentinel that
+  lives in the raw WASM result buffer, not in the deserialised state).
+- Asserts at least one neuron and one synapse received non-zero accumulation,
+  proving the WASM result buffer was actually written back into creature state
+  (not just silently no-oping).
+
+## Acceptance criteria
+
+- [x] New test file in `test/wasm/` covers the failure mode.
+- [x] Test is deterministic (seeded LCG) and completes in **~11 ms** locally —
+      well under the 5 s budget.
+- [x] Test passes against the fixed pin recorded in `deno.json`
+      (`925d4b7fb8381ad1e162e2b76f4c4d2ec11b52f3`).
+- [x] Test fails against the bad pin `1d45e52bc4d15ed1f4c0435ca8bbdd20b78a64c4`
+      — verified by temporarily pinning. The trap stack matches the field
+      telemetry exactly:
+      `wasm_activation_bg.wasm:1:184056 → propagate_topological →
+      wasmPropagateTopological → wasmTopologicalBackprop → propagateTopological
+      → Creature.propagate → test`.
+- [ ] Wiring into the smoke list set up in #2465 is intentionally left to that
+      issue's follow-up (called out in the issue's "Dependencies" section).
+
+## Evidence
+
+### Test passes against the good pin
+
+```
+running 1 test from ./test/wasm/WasmPropagateTopologicalTrapGuard.ts
+WasmPropagateTopologicalTrapGuard: backprop loop does not trap (Issue #2460) ... ok (11ms)
+
+ok | 1 passed | 0 failed (16ms)
+```
+
+### Test fails against the bad pin (`1d45e52b`) with the expected trap
+
+```
+running 1 test from ./test/wasm/WasmPropagateTopologicalTrapGuard.ts
+WasmPropagateTopologicalTrapGuard: backprop loop does not trap (Issue #2460) ... FAILED (7ms)
+
+error: RuntimeError: unreachable
+    at <anonymous> (.../wasm_activation_bg.wasm:1:184056)
+    at <anonymous> (.../wasm_activation_bg.wasm:1:198533)
+    at <anonymous> (.../wasm_activation_bg.wasm:1:314079)
+    at propagate_topological (.../wasm_activation.js:1299:22)
+    at wasmPropagateTopological (src/wasm/WasmStandaloneFunctions.ts:601)
+    at wasmTopologicalBackprop (src/propagate/WasmTopologicalBackprop.ts:289)
+    at propagateTopological (src/propagate/TopologicalBackpropagation.ts:40)
+    at Module.propagate (src/creature/CreatureTraining.ts:68)
+    at Creature.propagate (src/Creature.ts:939)
+    at .../test/wasm/WasmPropagateTopologicalTrapGuard.ts:135
+```
+
+The offset (`1:184056`) and the full stack match the original Issue #2460 trap
+report — the test exercises exactly the failure mode it was written to guard
+against.
+
+### Sequence of the WASM ABI guard
+
+```mermaid
+sequenceDiagram
+    participant Test as WasmPropagateTopologicalTrapGuard
+    participant Creature
+    participant TS as wasmTopologicalBackprop (TS encoder)
+    participant WASM as propagate_topological (Rust decoder)
+
+    Test->>Creature: build 5/4/2 creature (MAXIMUM outputs)
+    loop 100 deterministic samples (seeded LCG)
+        Test->>Creature: activateAndTrace(input)
+        Test->>Creature: propagate(target)
+        Creature->>TS: byte-pack creature + config
+        TS->>WASM: byte buffer (header / neurons / synapses / order)
+        alt ABI in sync (good pin)
+            WASM-->>TS: result buffer
+            TS-->>Creature: deserialise into state
+        else ABI mismatch (bad pin 1d45e52b)
+            WASM--xTest: RuntimeError: unreachable @ 1:184056
+        end
+    end
+    Test->>Creature: propagateUpdate
+    Test->>Test: assert state shape + finite values
+```
+
+## Test plan
+
+- Added: `test/wasm/WasmPropagateTopologicalTrapGuard.ts` — one Deno test
+  (`WasmPropagateTopologicalTrapGuard: backprop loop does
+  not trap (Issue #2460)`)
+  covering the trap, the state shape, and finite-value assertions.
+- Verified the new test passes against the current pin.
+- Verified the new test fails with the expected `RuntimeError: unreachable`
+  stack against pin `1d45e52bc4d15ed1f4c0435ca8bbdd20b78a64c4`, then restored
+  the original pin.
+- `./quality.sh < /dev/null` — the new test passes. Two pre-existing failures on
+  `milestone/wasm-regression` are unrelated to this change
+  (`test/scripts/BuildFingerprint.ts` expects `wasm_activation/pkg/.gitignore`
+  to contain `!build-fingerprint` but the vendored bundle ships `*`;
+  `test/wasm/WasmPublishIncluded.ts` flags the same `wasm_activation/pkg`
+  exclusion). Both reproduce on a clean checkout of the branch with no edits to
+  this PR's scope and are out of scope for #2466.

--- a/test/wasm/WasmPropagateTopologicalTrapGuard.ts
+++ b/test/wasm/WasmPropagateTopologicalTrapGuard.ts
@@ -1,0 +1,213 @@
+/**
+ * Issue #2466 — Permanent regression test for `wasmPropagateTopological` traps.
+ *
+ * Background (Issue #2460):
+ *
+ *   Bumping the pinned `neatCore.rev` to commits in the range
+ *   `142860e..1d45e52b` introduced a `RuntimeError: unreachable` trap inside
+ *   the WASM `propagate_topological` shim — caused by a byte-packed ABI
+ *   mismatch between the TypeScript encoder
+ *   (`src/propagate/WasmTopologicalBackprop.ts`) and the Rust decoder
+ *   (`neat-core/src/wasm_exports.rs`). The trap surfaced indirectly as ~120
+ *   downstream convergence assertions failing with what looked like ordinary
+ *   numerical noise; the real cause was only visible in the trap stack.
+ *
+ *   `propagate_topological` is on the AGENTS.md "WASM-only operations (no
+ *   TS fallback)" list, so a TypeScript-side guard test is the only line of
+ *   defence against an ABI regression. This test drives the WASM path
+ *   end-to-end with the exact creature shape from the original repro
+ *   (`docs/evidence/2461-repro.ts`) — 5 inputs / 4 hidden (IDENTITY) /
+ *   2 outputs (MAXIMUM) — and asserts that:
+ *
+ *     1. The backprop call returns without throwing a `RuntimeError`.
+ *     2. The accumulation state has the expected shape and contains finite
+ *        values (no `NaN`/`Infinity` outside the documented `Infinity`
+ *        sentinel for the special-neuron fallback path).
+ *
+ *   The test is deterministic — inputs are produced by a seeded LCG, no
+ *   `Math.random()` outside that helper — and finishes well under five
+ *   seconds on local hardware.
+ *
+ *   Verified manually that this test FAILS against the bad pin
+ *   `1d45e52bc4d15ed1f4c0435ca8bbdd20b78a64c4` (the trap is thrown from
+ *   `creature.propagate(...)`) and PASSES against the fixed pin currently
+ *   recorded in `deno.json`.
+ */
+
+import { assert } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { createBackPropagationConfig } from "@propagate/BackPropagation.ts";
+import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
+import { ensureWasmActivation } from "@wasm/EnsureWasmActivation.ts";
+import { isWasmActivationAvailable } from "@wasm/WasmModuleLoader.ts";
+
+/**
+ * Seeded linear congruential generator — keeps the regression test
+ * deterministic without depending on `Math.random()`. Values returned in
+ * `[-1.5, 1.5)` to mirror the original repro's input distribution.
+ */
+function makeSeededRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    // Numerical Recipes LCG constants — adequate for deterministic test data.
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return ((state / 0x1_0000_0000) * 3) - 1.5;
+  };
+}
+
+/**
+ * Network shape from the original `1d45e52b` reproducer — 5 inputs through
+ * 4 IDENTITY hidden neurons into 2 MAXIMUM outputs, with a synthetic-style
+ * cross-layer synapse (`h-B → h-D`, `h-C → h-D`) so the reverse-topological
+ * loop has something deeper than a single layer to walk.
+ */
+function buildTrapGuardCreature(): Creature {
+  const json: CreatureExport = {
+    input: 5,
+    output: 2,
+    neurons: [
+      { type: "hidden", uuid: "h-A", bias: -0.2, squash: "IDENTITY" },
+      { type: "hidden", uuid: "h-B", bias: -0.1, squash: "IDENTITY" },
+      { type: "hidden", uuid: "h-C", bias: 0.3, squash: "IDENTITY" },
+      { type: "hidden", uuid: "h-D", bias: -0.3, squash: "IDENTITY" },
+      { type: "output", uuid: "output-0", bias: 0.4, squash: "MAXIMUM" },
+      { type: "output", uuid: "output-1", bias: 0.3, squash: "MAXIMUM" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h-A", weight: -0.7 },
+      { fromUUID: "input-1", toUUID: "h-A", weight: 0.7 },
+      { fromUUID: "input-1", toUUID: "h-C", weight: 0.4 },
+      { fromUUID: "input-2", toUUID: "h-C", weight: 0.3 },
+      { fromUUID: "input-3", toUUID: "h-B", weight: 0.6 },
+      { fromUUID: "input-3", toUUID: "h-C", weight: 1.1 },
+      { fromUUID: "input-4", toUUID: "h-B", weight: -0.6 },
+      { fromUUID: "h-A", toUUID: "output-0", weight: 1.0 },
+      // Synthetic-style cross-layer hop — `h-D` sits between hidden and output.
+      { fromUUID: "h-B", toUUID: "h-D", weight: -1.1 },
+      { fromUUID: "h-C", toUUID: "h-D", weight: -0.8 },
+      { fromUUID: "h-C", toUUID: "output-1", weight: 0.2 },
+      { fromUUID: "h-D", toUUID: "output-0", weight: -0.5 },
+      { fromUUID: "h-D", toUUID: "output-1", weight: -0.4 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  return creature;
+}
+
+Deno.test("WasmPropagateTopologicalTrapGuard: backprop loop does not trap (Issue #2460)", async () => {
+  await ensureWasmActivation();
+  assert(
+    isWasmActivationAvailable(),
+    "WASM must be available for this regression test — the trap can only be " +
+      "observed via the WASM-only `propagate_topological` path.",
+  );
+
+  const creature = buildTrapGuardCreature();
+  const config = createBackPropagationConfig({
+    generations: 0,
+    learningRate: 0.1,
+    plankConstant: 1e-7,
+    disableRandomSamples: true,
+    batchSize: 64,
+  });
+  const sparseConfig = new SparseConfig(creature.exportJSON(), config);
+
+  // 100 deterministic samples — enough depth in the reverse-topological loop
+  // to consistently surface the bounds-check panic on a bad pin.
+  const rng = makeSeededRng(0xC0FFEE);
+  const samples: Float32Array[] = [];
+  for (let i = 0; i < 100; i++) {
+    samples.push(
+      new Float32Array([rng(), rng(), rng(), rng(), rng()]),
+    );
+  }
+
+  // Fixed target distinct from the network's natural output so the WASM
+  // backprop path actually accumulates non-zero error into per-neuron state.
+  const target = new Float32Array([0.42, -0.31]);
+
+  for (const inFloat of samples) {
+    creature.activateAndTrace(inFloat, false, sparseConfig);
+    // The function under guard. Throws `RuntimeError: unreachable` on a
+    // bad pin; returns normally on a good pin.
+    creature.propagate(target, config, sparseConfig);
+  }
+  creature.propagateUpdate(config, sparseConfig);
+
+  // ---- Shape & finite-value assertions on the accumulation state. ----
+  const state = creature.state;
+
+  // Every neuron's accumulator floats must be finite. The only documented
+  // `Infinity` sentinel lives in the raw WASM result buffer (`cachedAct` for
+  // the special-neuron fallback path) — by the time WasmTopologicalBackprop
+  // returns, every `state.node(i)` accumulator must hold a real number.
+  // Note: MAXIMUM/IF/MINIMUM output neurons take the TS-fallback path and so
+  // do not accumulate `totalErrorAbsolute` directly; we therefore look for
+  // accumulated error on *any* neuron, not specifically outputs.
+  let sawNeuronError = false;
+  for (let i = 0; i < creature.neurons.length; i++) {
+    const ns = state.node(i);
+    if (ns.totalErrorAbsolute > 0) sawNeuronError = true;
+    assert(
+      Number.isFinite(ns.totalErrorAbsolute),
+      `node(${i}).totalErrorAbsolute must be finite, got ${ns.totalErrorAbsolute}`,
+    );
+    assert(
+      Number.isFinite(ns.totalBias),
+      `node(${i}).totalBias must be finite, got ${ns.totalBias}`,
+    );
+    assert(
+      Number.isFinite(ns.totalAdjustedBias),
+      `node(${i}).totalAdjustedBias must be finite, got ${ns.totalAdjustedBias}`,
+    );
+  }
+  assert(
+    sawNeuronError,
+    "At least one neuron should have totalErrorAbsolute > 0 after 100 " +
+      "training samples — if all neurons report zero error, the WASM result " +
+      "buffer was not written back into creature state.",
+  );
+
+  // Synapse-level state shape: at least one connection must have been
+  // touched (count > 0) and every recorded accumulator must be finite.
+  let sawSynapseUpdate = false;
+  for (const syn of creature.synapses) {
+    const cs = state.connection(syn.from, syn.to);
+    if (cs.count > 0) sawSynapseUpdate = true;
+    assert(
+      Number.isFinite(cs.totalPositiveActivation),
+      `connection(${syn.from},${syn.to}).totalPositiveActivation must be finite`,
+    );
+    assert(
+      Number.isFinite(cs.totalNegativeActivation),
+      `connection(${syn.from},${syn.to}).totalNegativeActivation must be finite`,
+    );
+    assert(
+      Number.isFinite(cs.totalPositiveAdjustedValue),
+      `connection(${syn.from},${syn.to}).totalPositiveAdjustedValue must be finite`,
+    );
+    assert(
+      Number.isFinite(cs.totalNegativeAdjustedValue),
+      `connection(${syn.from},${syn.to}).totalNegativeAdjustedValue must be finite`,
+    );
+  }
+  assert(
+    sawSynapseUpdate,
+    "At least one synapse must show count > 0 after 100 samples — otherwise " +
+      "the WASM accumulation state was not deserialised back into creature state.",
+  );
+
+  // Cached activations populated by the WASM result must also be finite.
+  // `cacheAdjustedActivation` is a `DenseNumberMap` keyed by neuron index, so
+  // iterate over the neuron range and probe by `has(...)`.
+  for (let i = 0; i < creature.neurons.length; i++) {
+    if (!state.cacheAdjustedActivation.has(i)) continue;
+    const value = state.cacheAdjustedActivation.get(i)!;
+    assert(
+      Number.isFinite(value),
+      `cacheAdjustedActivation[${i}] must be finite, got ${value}`,
+    );
+  }
+});


### PR DESCRIPTION
# Add permanent regression test for `wasmPropagateTopological` traps

Closes #2466.

## Summary

Adds a focused, deterministic regression test that drives the WASM-only
`propagate_topological` path end-to-end and asserts that no
`RuntimeError: unreachable` trap occurs and that the returned accumulation state
has the expected shape and finite values. This is the TS-side guard test
promised by Issue #2460 — `propagate_topological` is on the AGENTS.md "WASM-only
operations (no TS fallback)" list, so a TypeScript-side guard is the only line
of defence against an ABI regression sneaking in via a `neatCore.rev` bump.

The new test is `test/wasm/WasmPropagateTopologicalTrapGuard.ts`. It:

- Builds the same 5-input / 4-hidden (IDENTITY) / 2-output (MAXIMUM) creature
  shape from the original repro (`docs/evidence/2461-repro.ts`) — the smallest
  topology known to reliably surface the bounds-check panic on a bad pin.
- Drives 100 deterministic samples (seeded LCG, no `Math.random()` outside that
  helper) through `creature.activateAndTrace(...)` → `creature.propagate(...)` →
  `creature.propagateUpdate(...)`.
- Asserts the call returns without throwing.
- Asserts the per-neuron and per-synapse accumulation state contains only finite
  values (no `NaN`/`Infinity` outside the documented `Infinity` sentinel that
  lives in the raw WASM result buffer, not in the deserialised state).
- Asserts at least one neuron and one synapse received non-zero accumulation,
  proving the WASM result buffer was actually written back into creature state
  (not just silently no-oping).

## Acceptance criteria

- [x] New test file in `test/wasm/` covers the failure mode.
- [x] Test is deterministic (seeded LCG) and completes in **~11 ms** locally —
      well under the 5 s budget.
- [x] Test passes against the fixed pin recorded in `deno.json`
      (`925d4b7fb8381ad1e162e2b76f4c4d2ec11b52f3`).
- [x] Test fails against the bad pin `1d45e52bc4d15ed1f4c0435ca8bbdd20b78a64c4`
      — verified by temporarily pinning. The trap stack matches the field
      telemetry exactly:
      `wasm_activation_bg.wasm:1:184056 → propagate_topological →
      wasmPropagateTopological → wasmTopologicalBackprop → propagateTopological
      → Creature.propagate → test`.
- [ ] Wiring into the smoke list set up in #2465 is intentionally left to that
      issue's follow-up (called out in the issue's "Dependencies" section).

## Evidence

### Test passes against the good pin

```
running 1 test from ./test/wasm/WasmPropagateTopologicalTrapGuard.ts
WasmPropagateTopologicalTrapGuard: backprop loop does not trap (Issue #2460) ... ok (11ms)

ok | 1 passed | 0 failed (16ms)
```

### Test fails against the bad pin (`1d45e52b`) with the expected trap

```
running 1 test from ./test/wasm/WasmPropagateTopologicalTrapGuard.ts
WasmPropagateTopologicalTrapGuard: backprop loop does not trap (Issue #2460) ... FAILED (7ms)

error: RuntimeError: unreachable
    at <anonymous> (.../wasm_activation_bg.wasm:1:184056)
    at <anonymous> (.../wasm_activation_bg.wasm:1:198533)
    at <anonymous> (.../wasm_activation_bg.wasm:1:314079)
    at propagate_topological (.../wasm_activation.js:1299:22)
    at wasmPropagateTopological (src/wasm/WasmStandaloneFunctions.ts:601)
    at wasmTopologicalBackprop (src/propagate/WasmTopologicalBackprop.ts:289)
    at propagateTopological (src/propagate/TopologicalBackpropagation.ts:40)
    at Module.propagate (src/creature/CreatureTraining.ts:68)
    at Creature.propagate (src/Creature.ts:939)
    at .../test/wasm/WasmPropagateTopologicalTrapGuard.ts:135
```

The offset (`1:184056`) and the full stack match the original Issue #2460 trap
report — the test exercises exactly the failure mode it was written to guard
against.

### Sequence of the WASM ABI guard

```mermaid
sequenceDiagram
    participant Test as WasmPropagateTopologicalTrapGuard
    participant Creature
    participant TS as wasmTopologicalBackprop (TS encoder)
    participant WASM as propagate_topological (Rust decoder)

    Test->>Creature: build 5/4/2 creature (MAXIMUM outputs)
    loop 100 deterministic samples (seeded LCG)
        Test->>Creature: activateAndTrace(input)
        Test->>Creature: propagate(target)
        Creature->>TS: byte-pack creature + config
        TS->>WASM: byte buffer (header / neurons / synapses / order)
        alt ABI in sync (good pin)
            WASM-->>TS: result buffer
            TS-->>Creature: deserialise into state
        else ABI mismatch (bad pin 1d45e52b)
            WASM--xTest: RuntimeError: unreachable @ 1:184056
        end
    end
    Test->>Creature: propagateUpdate
    Test->>Test: assert state shape + finite values
```

## Test plan

- Added: `test/wasm/WasmPropagateTopologicalTrapGuard.ts` — one Deno test
  (`WasmPropagateTopologicalTrapGuard: backprop loop does
  not trap (Issue #2460)`)
  covering the trap, the state shape, and finite-value assertions.
- Verified the new test passes against the current pin.
- Verified the new test fails with the expected `RuntimeError: unreachable`
  stack against pin `1d45e52bc4d15ed1f4c0435ca8bbdd20b78a64c4`, then restored
  the original pin.
- `./quality.sh < /dev/null` — the new test passes. Two pre-existing failures on
  `milestone/wasm-regression` are unrelated to this change
  (`test/scripts/BuildFingerprint.ts` expects `wasm_activation/pkg/.gitignore`
  to contain `!build-fingerprint` but the vendored bundle ships `*`;
  `test/wasm/WasmPublishIncluded.ts` flags the same `wasm_activation/pkg`
  exclusion). Both reproduce on a clean checkout of the branch with no edits to
  this PR's scope and are out of scope for #2466.



## Milestone
This PR is part of the **WASM regression** milestone and targets the `milestone/wasm-regression` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2466 -->