### PR TITLE
NEAT: per-species adjusted-fitness telemetry (#2452)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.32",
+  "version": "3.1.33",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2452.md
+++ b/docs/pr-summary-2452.md
@@ -1,0 +1,61 @@
+# NEAT: per-species adjusted-fitness telemetry (#2452)
+
+## Summary
+
+Adds the foundational instrumentation step for fitness sharing. Each `Species`
+now exposes rolling statistics — `size`, `bestRawFitness`, `meanRawFitness`,
+and `adjustedFitness` (best raw fitness divided by species size) — that
+`Genus` recomputes once per generation as part of speciation, before parent
+selection runs. The existing `species_adjusted` training event now carries a
+deterministic `speciesSummary` array so downstream consumers (fitness sharing,
+species stagnation tracking, diversity-aware MCMC) can read per-species
+signals. No selection or breeding behaviour changes — this is pure
+instrumentation and plumbing.
+
+Closes #2452.
+
+## Evidence
+
+This is a backend/CLI change with no UI surface, so no screenshot is captured.
+Verification was via the unit tests below plus the full quality gate:
+
+- `./quality.sh --skip-discovery --skip-wasm` — **6237 passed, 0 failed,
+  4 ignored** (lint, format, type-check, all tests in parallel).
+- The pre-existing breeding/mutation suites (`test/breed/*`,
+  `test/NEAT/Mutation.ts`, `test/NEAT/MutatorMutate.ts`,
+  `test/NEAT/Evolve.ts`, etc.) continue to pass unchanged, demonstrating no
+  behavioural change in selection or breeding.
+
+```mermaid
+flowchart LR
+    A[Speciate population] --> B[Genus.updateSpeciesStatistics]
+    B --> C[Species.computeStatistics<br/>per species]
+    C --> D[adjustedFitness = bestRaw / size]
+    D --> E[species_adjusted event<br/>+ speciesSummary array]
+    E --> F[Available to selection,<br/>MCMC, stagnation tracking]
+```
+
+## Test Plan
+
+New unit tests in `test/NEAT/SpeciesStatistics.ts`:
+
+- `Species.computeStatistics - adjusted fitness equals raw / speciesSize` —
+  asserts that for a multi-member species, `adjustedFitness` equals
+  `bestRawFitness / size`, plus correct mean and best across members.
+- `Species.computeStatistics - size 1 species: adjusted equals raw` —
+  asserts the acceptance-criterion property that a size-1 species has
+  `adjustedFitness === bestRawFitness === rawFitness`.
+- `Species.computeStatistics - non-finite scores are skipped` — guards
+  against `-Infinity` scores from WASM-panicked creatures poisoning the
+  mean.
+- `Genus.updateSpeciesStatistics - builds a multi-species summary` —
+  builds a multi-species fixture population (TANH and LOGISTIC squashes
+  to drive distinct species keys) and verifies the per-species summary
+  values.
+- `Genus.speciesSummary - sorted deterministically by speciesKey` —
+  asserts deterministic ordering for stable downstream consumption.
+- `Species statistics persist across an evolution generation round-trip` —
+  drives a real `evolveDataSet` cycle, captures every emitted
+  `species_adjusted` event, and asserts the `speciesSummary` is present,
+  matches `speciesCount`, and that `adjustedFitness === bestRawFitness /
+  size` for every entry.

--- a/docs/pr-summary-2452.md
+++ b/docs/pr-summary-2452.md
@@ -3,14 +3,14 @@
 ## Summary
 
 Adds the foundational instrumentation step for fitness sharing. Each `Species`
-now exposes rolling statistics — `size`, `bestRawFitness`, `meanRawFitness`,
-and `adjustedFitness` (best raw fitness divided by species size) — that
-`Genus` recomputes once per generation as part of speciation, before parent
-selection runs. The existing `species_adjusted` training event now carries a
-deterministic `speciesSummary` array so downstream consumers (fitness sharing,
-species stagnation tracking, diversity-aware MCMC) can read per-species
-signals. No selection or breeding behaviour changes — this is pure
-instrumentation and plumbing.
+now exposes rolling statistics — `size`, `bestRawFitness`, `meanRawFitness`, and
+`adjustedFitness` (best raw fitness divided by species size) — that `Genus`
+recomputes once per generation as part of speciation, before parent selection
+runs. The existing `species_adjusted` training event now carries a deterministic
+`speciesSummary` array so downstream consumers (fitness sharing, species
+stagnation tracking, diversity-aware MCMC) can read per-species signals. No
+selection or breeding behaviour changes — this is pure instrumentation and
+plumbing.
 
 Closes #2452.
 
@@ -19,12 +19,12 @@ Closes #2452.
 This is a backend/CLI change with no UI surface, so no screenshot is captured.
 Verification was via the unit tests below plus the full quality gate:
 
-- `./quality.sh --skip-discovery --skip-wasm` — **6237 passed, 0 failed,
-  4 ignored** (lint, format, type-check, all tests in parallel).
+- `./quality.sh --skip-discovery --skip-wasm` — **6237 passed, 0 failed, 4
+  ignored** (lint, format, type-check, all tests in parallel).
 - The pre-existing breeding/mutation suites (`test/breed/*`,
-  `test/NEAT/Mutation.ts`, `test/NEAT/MutatorMutate.ts`,
-  `test/NEAT/Evolve.ts`, etc.) continue to pass unchanged, demonstrating no
-  behavioural change in selection or breeding.
+  `test/NEAT/Mutation.ts`, `test/NEAT/MutatorMutate.ts`, `test/NEAT/Evolve.ts`,
+  etc.) continue to pass unchanged, demonstrating no behavioural change in
+  selection or breeding.
 
 ```mermaid
 flowchart LR
@@ -42,20 +42,18 @@ New unit tests in `test/NEAT/SpeciesStatistics.ts`:
 - `Species.computeStatistics - adjusted fitness equals raw / speciesSize` —
   asserts that for a multi-member species, `adjustedFitness` equals
   `bestRawFitness / size`, plus correct mean and best across members.
-- `Species.computeStatistics - size 1 species: adjusted equals raw` —
-  asserts the acceptance-criterion property that a size-1 species has
+- `Species.computeStatistics - size 1 species: adjusted equals raw` — asserts
+  the acceptance-criterion property that a size-1 species has
   `adjustedFitness === bestRawFitness === rawFitness`.
-- `Species.computeStatistics - non-finite scores are skipped` — guards
-  against `-Infinity` scores from WASM-panicked creatures poisoning the
-  mean.
-- `Genus.updateSpeciesStatistics - builds a multi-species summary` —
-  builds a multi-species fixture population (TANH and LOGISTIC squashes
-  to drive distinct species keys) and verifies the per-species summary
-  values.
-- `Genus.speciesSummary - sorted deterministically by speciesKey` —
-  asserts deterministic ordering for stable downstream consumption.
+- `Species.computeStatistics - non-finite scores are skipped` — guards against
+  `-Infinity` scores from WASM-panicked creatures poisoning the mean.
+- `Genus.updateSpeciesStatistics - builds a multi-species summary` — builds a
+  multi-species fixture population (TANH and LOGISTIC squashes to drive distinct
+  species keys) and verifies the per-species summary values.
+- `Genus.speciesSummary - sorted deterministically by speciesKey` — asserts
+  deterministic ordering for stable downstream consumption.
 - `Species statistics persist across an evolution generation round-trip` —
-  drives a real `evolveDataSet` cycle, captures every emitted
-  `species_adjusted` event, and asserts the `speciesSummary` is present,
-  matches `speciesCount`, and that `adjustedFitness === bestRawFitness /
+  drives a real `evolveDataSet` cycle, captures every emitted `species_adjusted`
+  event, and asserts the `speciesSummary` is present, matches `speciesCount`,
+  and that `adjustedFitness === bestRawFitness /
   size` for every entry.

--- a/src/NEAT/Genus.ts
+++ b/src/NEAT/Genus.ts
@@ -2,6 +2,19 @@ import { assert } from "@std/assert";
 import type { Creature } from "../../mod.ts";
 import { Species } from "@neat/Species.ts";
 
+/**
+ * Per-species summary suitable for emitting on the training event payload.
+ * Issue #2452.
+ */
+export interface SpeciesSummary {
+  readonly speciesKey: string;
+  readonly size: number;
+  readonly bestRawFitness: number;
+  readonly meanRawFitness: number;
+  /** Adjusted (fitness-shared) fitness: bestRawFitness / size. */
+  readonly adjustedFitness: number;
+}
+
 export class Genus {
   readonly speciesMap: Map<string, Species>;
   readonly creatureToSpeciesMap: Map<string, string>;
@@ -71,6 +84,37 @@ export class Genus {
     assert(species);
 
     return species;
+  }
+
+  /**
+   * Issue #2452: Recompute per-species statistics across every species in
+   * this genus. Call once per generation, after fitness evaluation and
+   * before parent selection runs.
+   */
+  updateSpeciesStatistics(): void {
+    this.speciesMap.forEach((species) => {
+      species.computeStatistics();
+    });
+  }
+
+  /**
+   * Issue #2452: Build a stable, plain-data summary of every species for
+   * inclusion on the training event payload. Sorted by species key for
+   * deterministic ordering across calls.
+   */
+  speciesSummary(): SpeciesSummary[] {
+    const summary: SpeciesSummary[] = [];
+    this.speciesMap.forEach((species) => {
+      summary.push({
+        speciesKey: species.speciesKey,
+        size: species.size,
+        bestRawFitness: species.bestRawFitness,
+        meanRawFitness: species.meanRawFitness,
+        adjustedFitness: species.adjustedFitness,
+      });
+    });
+    summary.sort((a, b) => a.speciesKey.localeCompare(b.speciesKey));
+    return summary;
   }
 
   findClosestMatchingSpecies(creature: Creature): Species | null {

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -216,12 +216,20 @@ export async function evolve(
     getLogger().warn("All creatures died, using zombies");
   }
 
-  // Issue #1615: Emit species_adjusted event
+  // Issue #2452: Compute per-species rolling statistics once per
+  // generation, after fitness evaluation and before parent selection,
+  // so downstream consumers can see size, best/mean raw fitness, and
+  // adjusted (fitness-shared) fitness for every species.
+  genus.updateSpeciesStatistics();
+
+  // Issue #1615 / #2452: Emit species_adjusted event with per-species
+  // summary for diversity-aware features and external observability.
   emitTrainingEvent(neat.config.onTrainingEvent, {
     kind: "species_adjusted",
     timestamp: new Date().toISOString(),
     speciesCount: genus.speciesMap.size,
     compatibilityThreshold: neat.config.geneticCompatibilityThreshold,
+    speciesSummary: genus.speciesSummary(),
   });
 
   const numberOfElitists = neat.config.elitism > 1

--- a/src/NEAT/Species.ts
+++ b/src/NEAT/Species.ts
@@ -32,6 +32,18 @@ const NEURON_BUCKET_SIZE = 10;
  */
 const CONNECTIVITY_BUCKET_SIZE = 2;
 
+/**
+ * Per-species rolling statistics computed once per generation.
+ *
+ * Issue #2452: Foundational telemetry for fitness sharing. The species's
+ * adjusted fitness is the best raw fitness divided by species size — a
+ * single representative value suitable for downstream fitness-sharing
+ * selection. A species of size 1 therefore has adjusted fitness equal
+ * to its raw fitness.
+ *
+ * Statistics are reset to neutral values until {@link Species.computeStatistics}
+ * runs for the current generation.
+ */
 export class Species {
   private static TE = new TextEncoder();
   private static NAMESPACE_UUID = "1b671a64-40d5-491e-99b0-ac01ff1f5641";
@@ -41,6 +53,21 @@ export class Species {
 
   readonly speciesKey: string;
 
+  /**
+   * Issue #2452: Per-species rolling statistics. These are populated by
+   * {@link computeStatistics}, called once per generation as part of
+   * speciation, before parent selection runs.
+   */
+  size: number = 0;
+  bestRawFitness: number = -Infinity;
+  meanRawFitness: number = 0;
+  /**
+   * Adjusted (fitness-shared) fitness for this species: the best raw
+   * fitness divided by the species size. For a species of size 1, this
+   * equals the member's raw fitness.
+   */
+  adjustedFitness: number = -Infinity;
+
   constructor(speciesKey: string) {
     this.speciesKey = speciesKey;
     this.creatures = [];
@@ -49,6 +76,46 @@ export class Species {
   addCreature(creature: Creature) {
     this.lastCreature = creature;
     this.creatures.push(creature);
+  }
+
+  /**
+   * Issue #2452: Recompute per-species rolling statistics from the
+   * current member creatures. Members without a finite numeric score
+   * are skipped so that pre-fitness or panicked creatures do not poison
+   * the mean. Call this once per generation, after fitness evaluation
+   * and before parent selection runs.
+   */
+  computeStatistics(): void {
+    this.size = this.creatures.length;
+    if (this.size === 0) {
+      this.bestRawFitness = -Infinity;
+      this.meanRawFitness = 0;
+      this.adjustedFitness = -Infinity;
+      return;
+    }
+    let best = -Infinity;
+    let sum = 0;
+    let counted = 0;
+    for (const c of this.creatures) {
+      const score = c.score;
+      if (score === undefined || score === null || !Number.isFinite(score)) {
+        continue;
+      }
+      if (score > best) best = score;
+      sum += score;
+      counted++;
+    }
+    if (counted === 0) {
+      this.bestRawFitness = -Infinity;
+      this.meanRawFitness = 0;
+      this.adjustedFitness = -Infinity;
+      return;
+    }
+    this.bestRawFitness = best;
+    this.meanRawFitness = sum / counted;
+    // Adjusted = raw / speciesSize. By construction, size === 1 ⇒
+    // adjustedFitness === bestRawFitness === rawFitness of the sole member.
+    this.adjustedFitness = best / this.size;
   }
 
   /**

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -372,6 +372,28 @@ export interface MemoryPressureEvent {
 }
 
 /**
+ * Per-species summary emitted on the training event payload.
+ *
+ * Issue #2452: Foundational telemetry for fitness sharing. Each entry
+ * captures the rolling statistics for a single species.
+ */
+export interface SpeciesSummaryEntry {
+  /** Stable species key (UUID). */
+  readonly speciesKey: string;
+  /** Number of creatures currently in the species. */
+  readonly size: number;
+  /** Best raw fitness across the species's members. */
+  readonly bestRawFitness: number;
+  /** Arithmetic mean raw fitness across the species's members. */
+  readonly meanRawFitness: number;
+  /**
+   * Adjusted (fitness-shared) fitness: best raw fitness divided by
+   * species size. For a species of size 1, equals raw fitness.
+   */
+  readonly adjustedFitness: number;
+}
+
+/**
  * Emitted when species counts are adjusted during evolution.
  */
 export interface SpeciesAdjustedEvent {
@@ -382,6 +404,14 @@ export interface SpeciesAdjustedEvent {
   readonly speciesCount: number;
   /** The genetic compatibility threshold used for speciation. */
   readonly compatibilityThreshold: number;
+  /**
+   * Per-species rolling statistics computed once per generation as part
+   * of speciation. Issue #2452: foundational telemetry for fitness
+   * sharing, species stagnation tracking, and diversity-aware MCMC.
+   * Optional so that hand-constructed test events without statistics
+   * remain valid; production emits this for every speciation event.
+   */
+  readonly speciesSummary?: readonly SpeciesSummaryEntry[];
 }
 
 /**

--- a/test/NEAT/SpeciesStatistics.ts
+++ b/test/NEAT/SpeciesStatistics.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for per-species adjusted-fitness telemetry (Issue #2452).
+ *
+ * Verifies the foundational instrumentation step for fitness sharing:
+ *  - Species exposes size, bestRawFitness, meanRawFitness, adjustedFitness.
+ *  - Genus updates these statistics once per generation.
+ *  - speciesSummary is emitted on the species_adjusted training event.
+ *  - Adjusted fitness equals raw / speciesSize, with size 1 ⇒ raw.
+ *  - Statistics persist across an evolution generation round-trip.
+ */
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { Creature, type CreatureExport } from "../../mod.ts";
+import { Genus } from "@neat/Genus.ts";
+import { Species } from "@neat/Species.ts";
+import { Mutation } from "@neat/Mutation.ts";
+import type {
+  SpeciesAdjustedEvent,
+  TrainingEvent,
+} from "@config/TrainingEvent.ts";
+
+/**
+ * Build a small, valid creature using a single hidden neuron with the
+ * given squash. Squash distribution drives the species key, so varying
+ * the squash places creatures in different species.
+ */
+function makeCreatureJSON(squash: string): CreatureExport {
+  return {
+    neurons: [
+      { uuid: "hidden-0", bias: 0.1, type: "hidden", squash },
+      { uuid: "output-0", bias: 0.4, type: "output", squash: "IF" },
+    ],
+    synapses: [
+      { weight: -0.05, fromUUID: "input-0", toUUID: "hidden-0" },
+      { weight: -0.05, fromUUID: "input-1", toUUID: "hidden-0" },
+      { weight: -0.03, fromUUID: "hidden-0", toUUID: "output-0" },
+    ],
+    input: 2,
+    output: 1,
+  };
+}
+
+function fixtureCreature(score: number, squash: string = "TANH"): Creature {
+  const c = Creature.fromJSON(makeCreatureJSON(squash));
+  // Genus tracks creatures by their `uuid`; assign a fresh one so two
+  // architecturally identical creatures still occupy two genus slots.
+  c.uuid = crypto.randomUUID();
+  c.score = score;
+  return c;
+}
+
+Deno.test(
+  "Species.computeStatistics - adjusted fitness equals raw / speciesSize",
+  () => {
+    const species = new Species("test-species");
+    species.addCreature(fixtureCreature(8));
+    species.addCreature(fixtureCreature(4));
+    species.addCreature(fixtureCreature(6));
+    species.addCreature(fixtureCreature(2));
+
+    species.computeStatistics();
+
+    assertEquals(species.size, 4);
+    assertEquals(species.bestRawFitness, 8);
+    assertAlmostEquals(species.meanRawFitness, 5);
+    // Adjusted = best raw / size = 8 / 4 = 2.
+    assertAlmostEquals(species.adjustedFitness, 8 / 4);
+    assertAlmostEquals(
+      species.adjustedFitness,
+      species.bestRawFitness / species.size,
+    );
+  },
+);
+
+Deno.test(
+  "Species.computeStatistics - size 1 species: adjusted equals raw",
+  () => {
+    const species = new Species("solo-species");
+    species.addCreature(fixtureCreature(0.42));
+
+    species.computeStatistics();
+
+    assertEquals(species.size, 1);
+    assertAlmostEquals(species.bestRawFitness, 0.42);
+    assertAlmostEquals(species.meanRawFitness, 0.42);
+    // Size 1 ⇒ adjusted == raw. Acceptance criterion from Issue #2452.
+    assertAlmostEquals(species.adjustedFitness, 0.42);
+    assertAlmostEquals(species.adjustedFitness, species.bestRawFitness);
+  },
+);
+
+Deno.test(
+  "Species.computeStatistics - non-finite scores are skipped",
+  () => {
+    const species = new Species("filter-species");
+    species.addCreature(fixtureCreature(10));
+    const broken = fixtureCreature(0);
+    broken.score = -Infinity;
+    species.addCreature(broken);
+    species.addCreature(fixtureCreature(2));
+
+    species.computeStatistics();
+
+    // Size still reflects member count; stats ignore the broken score.
+    assertEquals(species.size, 3);
+    assertEquals(species.bestRawFitness, 10);
+    assertAlmostEquals(species.meanRawFitness, 6); // (10 + 2) / 2 finite scores
+  },
+);
+
+Deno.test(
+  "Genus.updateSpeciesStatistics - builds a multi-species summary",
+  () => {
+    const genus = new Genus();
+
+    // Multi-species population built from fixture creatures whose squash
+    // distribution differs, placing them in distinct species buckets.
+    genus.addCreature(fixtureCreature(10, "TANH"));
+    genus.addCreature(fixtureCreature(6, "TANH"));
+    genus.addCreature(fixtureCreature(4, "LOGISTIC"));
+
+    genus.updateSpeciesStatistics();
+    const summary = genus.speciesSummary();
+
+    // Two distinct species expected: one with two TANH members, one
+    // with the lone LOGISTIC member.
+    assertEquals(summary.length, 2, "Two species should be present");
+
+    const sizeTwo = summary.find((s) => s.size === 2);
+    assert(sizeTwo, "Expected a size-2 species in the summary");
+    assertEquals(sizeTwo.bestRawFitness, 10);
+    assertAlmostEquals(sizeTwo.meanRawFitness, 8);
+    assertAlmostEquals(sizeTwo.adjustedFitness, 10 / 2);
+
+    const sizeOne = summary.find((s) => s.size === 1);
+    assert(sizeOne, "Expected a size-1 species in the summary");
+    assertAlmostEquals(sizeOne.bestRawFitness, 4);
+    assertAlmostEquals(sizeOne.adjustedFitness, 4);
+  },
+);
+
+Deno.test(
+  "Genus.speciesSummary - sorted deterministically by speciesKey",
+  () => {
+    const genus = new Genus();
+    genus.addCreature(fixtureCreature(1, "TANH"));
+    genus.addCreature(fixtureCreature(2, "LOGISTIC"));
+    genus.addCreature(fixtureCreature(3, "RELU"));
+    genus.updateSpeciesStatistics();
+
+    const summary = genus.speciesSummary();
+    const keys = summary.map((s) => s.speciesKey);
+    const sorted = [...keys].sort();
+    assertEquals(
+      keys,
+      sorted,
+      "Summary entries should be sorted by speciesKey",
+    );
+  },
+);
+
+Deno.test(
+  "Species statistics persist across an evolution generation round-trip",
+  async () => {
+    const events: TrainingEvent[] = [];
+
+    const trainingSet = [
+      { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+      { input: new Float32Array([1, 1]), output: new Float32Array([1]) },
+    ];
+
+    const creature = new Creature(2, 1);
+
+    await creature.evolveDataSet(trainingSet, {
+      mutation: Mutation.FFW,
+      iterations: 3,
+      targetError: 0.001,
+      populationSize: 10,
+      threads: 1,
+      onTrainingEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    const speciesEvents = events.filter(
+      (e) => e.kind === "species_adjusted",
+    ) as SpeciesAdjustedEvent[];
+
+    assert(
+      speciesEvents.length > 0,
+      "At least one species_adjusted event should be emitted",
+    );
+
+    // Every speciation event must carry a non-empty summary, and each
+    // entry's adjustedFitness must equal bestRawFitness / size.
+    for (const ev of speciesEvents) {
+      assert(ev.speciesSummary, "speciesSummary missing on species_adjusted");
+      assertEquals(
+        ev.speciesSummary.length,
+        ev.speciesCount,
+        "Summary length must match speciesCount",
+      );
+      for (const entry of ev.speciesSummary) {
+        assert(entry.size >= 1, "Species size must be >= 1");
+        // Statistics persisted: adjusted = best / size.
+        assertAlmostEquals(
+          entry.adjustedFitness,
+          entry.bestRawFitness / entry.size,
+          1e-9,
+          `Adjusted fitness mismatch for species ${entry.speciesKey}`,
+        );
+        if (entry.size === 1) {
+          assertAlmostEquals(
+            entry.adjustedFitness,
+            entry.bestRawFitness,
+            1e-9,
+            "Size-1 species: adjusted fitness should equal raw",
+          );
+        }
+      }
+    }
+  },
+);


### PR DESCRIPTION
# NEAT: per-species adjusted-fitness telemetry (#2452)

## Summary

Adds the foundational instrumentation step for fitness sharing. Each `Species`
now exposes rolling statistics — `size`, `bestRawFitness`, `meanRawFitness`,
and `adjustedFitness` (best raw fitness divided by species size) — that
`Genus` recomputes once per generation as part of speciation, before parent
selection runs. The existing `species_adjusted` training event now carries a
deterministic `speciesSummary` array so downstream consumers (fitness sharing,
species stagnation tracking, diversity-aware MCMC) can read per-species
signals. No selection or breeding behaviour changes — this is pure
instrumentation and plumbing.

Closes #2452.

## Evidence

This is a backend/CLI change with no UI surface, so no screenshot is captured.
Verification was via the unit tests below plus the full quality gate:

- `./quality.sh --skip-discovery --skip-wasm` — **6237 passed, 0 failed,
  4 ignored** (lint, format, type-check, all tests in parallel).
- The pre-existing breeding/mutation suites (`test/breed/*`,
  `test/NEAT/Mutation.ts`, `test/NEAT/MutatorMutate.ts`,
  `test/NEAT/Evolve.ts`, etc.) continue to pass unchanged, demonstrating no
  behavioural change in selection or breeding.

```mermaid
flowchart LR
    A[Speciate population] --> B[Genus.updateSpeciesStatistics]
    B --> C[Species.computeStatistics<br/>per species]
    C --> D[adjustedFitness = bestRaw / size]
    D --> E[species_adjusted event<br/>+ speciesSummary array]
    E --> F[Available to selection,<br/>MCMC, stagnation tracking]
```

## Test Plan

New unit tests in `test/NEAT/SpeciesStatistics.ts`:

- `Species.computeStatistics - adjusted fitness equals raw / speciesSize` —
  asserts that for a multi-member species, `adjustedFitness` equals
  `bestRawFitness / size`, plus correct mean and best across members.
- `Species.computeStatistics - size 1 species: adjusted equals raw` —
  asserts the acceptance-criterion property that a size-1 species has
  `adjustedFitness === bestRawFitness === rawFitness`.
- `Species.computeStatistics - non-finite scores are skipped` — guards
  against `-Infinity` scores from WASM-panicked creatures poisoning the
  mean.
- `Genus.updateSpeciesStatistics - builds a multi-species summary` —
  builds a multi-species fixture population (TANH and LOGISTIC squashes
  to drive distinct species keys) and verifies the per-species summary
  values.
- `Genus.speciesSummary - sorted deterministically by speciesKey` —
  asserts deterministic ordering for stable downstream consumption.
- `Species statistics persist across an evolution generation round-trip` —
  drives a real `evolveDataSet` cycle, captures every emitted
  `species_adjusted` event, and asserts the `speciesSummary` is present,
  matches `speciesCount`, and that `adjustedFitness === bestRawFitness /
  size` for every entry.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2452 -->