### PR TITLE
Detect and retire stagnant species to reclaim breeding budget

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.35",
+  "version": "3.1.36",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -242,6 +242,7 @@
     "rescore",
     "rescored",
     "rescoring",
+    "reseen",
     "retryable",
     "rlib",
     "rotl",

--- a/docs/pr-summary-2454.md
+++ b/docs/pr-summary-2454.md
@@ -1,0 +1,55 @@
+## Summary
+
+Adds per-species stagnation detection so evolution can reclaim breeding
+budget from species that have stopped improving and redirect it to
+species that are still progressing. Closes #2454.
+
+A new `SpeciesPlateauDetector` tracks the high-water best raw fitness
+per species across generations. When a species fails to improve for
+`haltWindow` generations (default 15) it is classified as **halted**
+and its breeding share is halved. After `extinctionWindow` generations
+(default 25) it is classified as **extinct** and dropped from the
+breeding pool entirely; its members may still survive via elitism but
+contribute no offspring. Reclaimed slots are redistributed
+proportionally to the remaining (still-progressing) species using the
+largest-fractional-part rule from `BreedingQuotas`, preserving the
+total breeding budget.
+
+```mermaid
+flowchart LR
+  A[Fitness eval] --> B[updateSpeciesStatistics]
+  B --> C[recordGeneration]
+  C --> D[allocateBreedingQuotas]
+  D --> E{stagnation enabled?}
+  E -- no --> G[breed]
+  E -- yes --> F[applyStagnationToQuotas]
+  F --> G
+```
+
+## Evidence
+
+CLI/library change with no UI surface — verified via unit tests in
+`test/NEAT/SpeciesPlateauDetector.ts` and the full
+`./quality.sh --skip-discovery --skip-wasm` suite (6265 passed, 0
+failed). New tests cover the three issue scenarios (halve at
+`haltWindow`, drop at `extinctionWindow`, disabled flag is a no-op)
+plus pruning and non-finite-fitness edge cases.
+
+## Test Plan
+
+- [x] `test/NEAT/SpeciesPlateauDetector.ts` — 10 new tests:
+  - active when fitness improves each generation
+  - status flips to halted at `haltWindow`
+  - status flips to extinct at `extinctionWindow`
+  - improvement resets the stagnant counter
+  - `applyStagnationToQuotas` halves a halted species' breeding share
+  - extinct species lose all slots; survivors absorb the share
+  - extinct slots split proportionally across multiple active species
+  - disabled flag is a no-op (regression test)
+  - `pruneAbsent` drops history for species missing from the genus
+  - non-finite fitness does not advance stagnation
+- [x] Existing `test/NEAT/SpeciesStatistics.ts`, `Genus.ts`, `Species.ts`,
+  `PlateauDetection.ts`, `NeatConfig.ts`, `NeatEvolve.ts` — all pass
+  unchanged.
+- [x] `./quality.sh --skip-discovery --skip-wasm` — 6265 passed,
+  0 failed.

--- a/docs/pr-summary-2454.md
+++ b/docs/pr-summary-2454.md
@@ -1,19 +1,18 @@
 ## Summary
 
-Adds per-species stagnation detection so evolution can reclaim breeding
-budget from species that have stopped improving and redirect it to
-species that are still progressing. Closes #2454.
+Adds per-species stagnation detection so evolution can reclaim breeding budget
+from species that have stopped improving and redirect it to species that are
+still progressing. Closes #2454.
 
-A new `SpeciesPlateauDetector` tracks the high-water best raw fitness
-per species across generations. When a species fails to improve for
-`haltWindow` generations (default 15) it is classified as **halted**
-and its breeding share is halved. After `extinctionWindow` generations
-(default 25) it is classified as **extinct** and dropped from the
-breeding pool entirely; its members may still survive via elitism but
-contribute no offspring. Reclaimed slots are redistributed
-proportionally to the remaining (still-progressing) species using the
-largest-fractional-part rule from `BreedingQuotas`, preserving the
-total breeding budget.
+A new `SpeciesPlateauDetector` tracks the high-water best raw fitness per
+species across generations. When a species fails to improve for `haltWindow`
+generations (default 15) it is classified as **halted** and its breeding share
+is halved. After `extinctionWindow` generations (default 25) it is classified as
+**extinct** and dropped from the breeding pool entirely; its members may still
+survive via elitism but contribute no offspring. Reclaimed slots are
+redistributed proportionally to the remaining (still-progressing) species using
+the largest-fractional-part rule from `BreedingQuotas`, preserving the total
+breeding budget.
 
 ```mermaid
 flowchart LR
@@ -30,10 +29,10 @@ flowchart LR
 
 CLI/library change with no UI surface — verified via unit tests in
 `test/NEAT/SpeciesPlateauDetector.ts` and the full
-`./quality.sh --skip-discovery --skip-wasm` suite (6265 passed, 0
-failed). New tests cover the three issue scenarios (halve at
-`haltWindow`, drop at `extinctionWindow`, disabled flag is a no-op)
-plus pruning and non-finite-fitness edge cases.
+`./quality.sh --skip-discovery --skip-wasm` suite (6265 passed, 0 failed). New
+tests cover the three issue scenarios (halve at `haltWindow`, drop at
+`extinctionWindow`, disabled flag is a no-op) plus pruning and
+non-finite-fitness edge cases.
 
 ## Test Plan
 
@@ -49,7 +48,6 @@ plus pruning and non-finite-fitness edge cases.
   - `pruneAbsent` drops history for species missing from the genus
   - non-finite fitness does not advance stagnation
 - [x] Existing `test/NEAT/SpeciesStatistics.ts`, `Genus.ts`, `Species.ts`,
-  `PlateauDetection.ts`, `NeatConfig.ts`, `NeatEvolve.ts` — all pass
-  unchanged.
-- [x] `./quality.sh --skip-discovery --skip-wasm` — 6265 passed,
-  0 failed.
+      `PlateauDetection.ts`, `NeatConfig.ts`, `NeatEvolve.ts` — all pass
+      unchanged.
+- [x] `./quality.sh --skip-discovery --skip-wasm` — 6265 passed, 0 failed.

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -26,6 +26,7 @@ import { Genus } from "@neat/Genus.ts";
 import { Mutator } from "@neat/Mutator.ts";
 import { MCMCState } from "@neat/MCMCState.ts";
 import { PlateauDetector } from "@neat/PlateauDetector.ts";
+import { SpeciesPlateauDetector } from "@neat/SpeciesPlateauDetector.ts";
 import { TrainingRegressionTracker } from "@neat/TrainingRegressionTracker.ts";
 import { SquashEffectivenessTracker } from "@neat/SquashEffectivenessTracker.ts";
 import {
@@ -86,6 +87,14 @@ export class Neat {
   crisprIndex = 0;
   /** Plateau detector for fitness stagnation detection (Issue #1039) */
   readonly plateauDetector: PlateauDetector;
+
+  /**
+   * Per-species plateau detector for stagnant-species retirement
+   * (Issue #2454). Tracks each species' best raw fitness across
+   * generations so stalled species can be halved or dropped from
+   * breeding-quota allocation.
+   */
+  readonly speciesPlateauDetector: SpeciesPlateauDetector;
 
   /** Issue #2200: MCMC temperature state for Metropolis-Hastings acceptance */
   readonly mcmcState: MCMCState;
@@ -216,6 +225,12 @@ export class Neat {
     this.CRISPRs = Neat.deepCloneAndShuffle(this.config.CRISPRs);
 
     this.plateauDetector = new PlateauDetector(this.config.plateauDetection);
+
+    // Issue #2454: Per-species stagnation detector. The detector is a
+    // no-op when `speciesStagnation.enabled` is false.
+    this.speciesPlateauDetector = new SpeciesPlateauDetector(
+      this.config.speciesStagnation,
+    );
 
     // Issue #2200: Initialise MCMC temperature state
     this.mcmcState = new MCMCState(this.config.mcmc);

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -18,6 +18,7 @@ import { Breed } from "@breed/Breed.ts";
 import { ParallelBreeding } from "@breed/ParallelBreeding.ts";
 import { AddConnection } from "@mutate/AddConnection.ts";
 import { allocateBreedingQuotas } from "@neat/BreedingQuotas.ts";
+import { applyStagnationToQuotas } from "@neat/SpeciesPlateauDetector.ts";
 import { Genus } from "@neat/Genus.ts";
 import { checkMemoryAndEvict, logMemoryUsage } from "@neat/MemoryMonitor.ts";
 import { Mutator } from "@neat/Mutator.ts";
@@ -222,6 +223,13 @@ export async function evolve(
   // so downstream consumers can see size, best/mean raw fitness, and
   // adjusted (fitness-shared) fitness for every species.
   genus.updateSpeciesStatistics();
+
+  // Issue #2454: Record per-species best fitness for stagnation
+  // detection. The detector is a no-op when
+  // `speciesStagnation.enabled` is false. Prune history for species
+  // that have disappeared so memory does not leak across long runs.
+  neat.speciesPlateauDetector.recordGeneration(genus);
+  neat.speciesPlateauDetector.pruneAbsent(genus.speciesMap.keys());
 
   // Issue #1615 / #2452: Emit species_adjusted event with per-species
   // summary for diversity-aware features and external observability.
@@ -540,13 +548,25 @@ export async function evolve(
   // breeding quotas in proportion to summed adjusted fitness. The
   // species_adjusted statistics computed earlier this generation are
   // the inputs.
-  const speciesQuotas = neat.config.fitnessSharing.enabled && newPopSize > 0
+  let speciesQuotas = neat.config.fitnessSharing.enabled && newPopSize > 0
     ? allocateBreedingQuotas(
       genus,
       newPopSize,
       neat.config.fitnessSharing.minSpeciesSlots,
     )
     : undefined;
+
+  // Issue #2454: Reduce or zero out breeding quotas for species that
+  // are flat across the configured windows; reclaimed slots are
+  // redistributed proportionally to species that are still
+  // progressing. The transformation preserves the total quota count
+  // so the breeding budget is unchanged.
+  if (speciesQuotas && neat.config.speciesStagnation.enabled) {
+    speciesQuotas = applyStagnationToQuotas(
+      speciesQuotas,
+      neat.speciesPlateauDetector,
+    );
+  }
   const rawBreedingPromise = parallelBreeding.breedBatch(
     newPopSize,
     speciesQuotas,

--- a/src/NEAT/SpeciesPlateauDetector.ts
+++ b/src/NEAT/SpeciesPlateauDetector.ts
@@ -1,0 +1,295 @@
+/**
+ * SpeciesPlateauDetector.ts - Per-species fitness stagnation tracking
+ * (Issue #2454).
+ *
+ * Tracks the high-water-mark best raw fitness for every species across
+ * generations. When a species fails to improve for `haltWindow`
+ * generations it is considered "halted" and its breeding share is
+ * halved; when it stays flat for `extinctionWindow` generations it is
+ * considered "extinct" and dropped from the breeding pool entirely.
+ * Reclaimed breeding slots are redistributed proportionally to the
+ * remaining (still-progressing) species so the global breeding budget
+ * is preserved.
+ */
+
+import type { Genus } from "@neat/Genus.ts";
+import type { RequiredSpeciesStagnationConfig } from "@config/SpeciesStagnationConfig.ts";
+
+/** Stagnation classification for a species. */
+export type SpeciesStagnationStatus = "active" | "halted" | "extinct";
+
+/**
+ * Per-species rolling state used to determine stagnation classification.
+ *
+ * `bestEverFitness` is the high-water mark across every generation
+ * recorded so far for this species. `generationsSinceImprovement` is
+ * the count of consecutive generations whose best raw fitness did not
+ * exceed the high-water mark — i.e. the size of the current flat window.
+ */
+interface SpeciesHistoryEntry {
+  bestEverFitness: number;
+  generationsSinceImprovement: number;
+}
+
+/**
+ * Tracks per-species best-fitness history and classifies each species
+ * as `active`, `halted`, or `extinct` based on the configured windows.
+ */
+export class SpeciesPlateauDetector {
+  private readonly config: RequiredSpeciesStagnationConfig;
+  private readonly history = new Map<string, SpeciesHistoryEntry>();
+
+  constructor(config: RequiredSpeciesStagnationConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Record one generation worth of best-fitness statistics for every
+   * species in the genus. Call after `genus.updateSpeciesStatistics()`
+   * each generation. A non-finite `bestRawFitness` (e.g. an unscored or
+   * panicked species) is skipped — it neither resets nor advances the
+   * counter so that transient evaluation issues do not poison the
+   * stagnation signal.
+   */
+  recordGeneration(genus: Genus): void {
+    if (!this.config.enabled) return;
+    genus.speciesMap.forEach((species) => {
+      const best = species.bestRawFitness;
+      if (!Number.isFinite(best)) return;
+      this.recordSpecies(species.speciesKey, best);
+    });
+  }
+
+  /**
+   * Record a single species observation. Exposed for testing and so
+   * callers can drive the detector without a full Genus when only the
+   * stagnation logic matters.
+   */
+  recordSpecies(speciesKey: string, bestRawFitness: number): void {
+    if (!this.config.enabled) return;
+    if (!Number.isFinite(bestRawFitness)) return;
+
+    const prior = this.history.get(speciesKey);
+    if (!prior) {
+      this.history.set(speciesKey, {
+        bestEverFitness: bestRawFitness,
+        generationsSinceImprovement: 0,
+      });
+      return;
+    }
+
+    if (bestRawFitness > prior.bestEverFitness) {
+      prior.bestEverFitness = bestRawFitness;
+      prior.generationsSinceImprovement = 0;
+    } else {
+      prior.generationsSinceImprovement += 1;
+    }
+  }
+
+  /**
+   * Number of consecutive generations the named species has spent at
+   * or below its high-water mark. Returns 0 for species that have
+   * never been recorded (a fresh species starts fully active).
+   */
+  getStagnantGenerations(speciesKey: string): number {
+    const entry = this.history.get(speciesKey);
+    return entry ? entry.generationsSinceImprovement : 0;
+  }
+
+  /**
+   * Classify a species as `active`, `halted`, or `extinct` using the
+   * configured windows. When stagnation detection is disabled, every
+   * species is reported as `active`.
+   */
+  getStatus(speciesKey: string): SpeciesStagnationStatus {
+    if (!this.config.enabled) return "active";
+    const stagnant = this.getStagnantGenerations(speciesKey);
+    if (stagnant >= this.config.extinctionWindow) return "extinct";
+    if (stagnant >= this.config.haltWindow) return "halted";
+    return "active";
+  }
+
+  /**
+   * Drop history for any species not present in the supplied set.
+   * Useful when a species has gone extinct in the population sense
+   * (no surviving members) so its history would otherwise leak.
+   */
+  pruneAbsent(activeSpeciesKeys: Iterable<string>): void {
+    const keep = new Set(activeSpeciesKeys);
+    for (const key of [...this.history.keys()]) {
+      if (!keep.has(key)) this.history.delete(key);
+    }
+  }
+
+  /** Reset all per-species history. */
+  reset(): void {
+    this.history.clear();
+  }
+}
+
+/**
+ * Apply stagnation-based reductions to a per-species breeding quota
+ * map. Halted species lose half their slots (rounded down); extinct
+ * species lose all of them. Reclaimed slots are redistributed
+ * proportionally to the remaining `active` species using the largest-
+ * fractional-part rule for determinism. When no `active` species
+ * remain, slots are redistributed to `halted` species in the same way
+ * so the population still receives offspring. Quotas for species that
+ * are not present in the input map are not introduced.
+ *
+ * The total of the returned map equals the total of the input map
+ * exactly. When stagnation detection is disabled (or every species is
+ * `active`), the input map is returned as-is without modification.
+ *
+ * @param quotas - Per-species quotas from `allocateBreedingQuotas`
+ * @param detector - Per-species stagnation tracker
+ * @returns A new quota map with stagnation reductions applied
+ */
+export function applyStagnationToQuotas(
+  quotas: ReadonlyMap<string, number>,
+  detector: SpeciesPlateauDetector,
+): Map<string, number> {
+  const result = new Map<string, number>();
+  if (quotas.size === 0) return result;
+
+  let totalIn = 0;
+  let reclaimed = 0;
+  // Active recipients keep full quota and become candidates for redistribution.
+  const activeKeys: string[] = [];
+  // Halted recipients keep half quota and become fallback recipients
+  // when no active species are available.
+  const haltedKeys: string[] = [];
+
+  for (const [speciesKey, quota] of quotas) {
+    totalIn += quota;
+    const status = detector.getStatus(speciesKey);
+    if (status === "extinct") {
+      result.set(speciesKey, 0);
+      reclaimed += quota;
+      continue;
+    }
+    if (status === "halted") {
+      const kept = Math.floor(quota / 2);
+      const lost = quota - kept;
+      result.set(speciesKey, kept);
+      reclaimed += lost;
+      haltedKeys.push(speciesKey);
+      continue;
+    }
+    // active
+    result.set(speciesKey, quota);
+    activeKeys.push(speciesKey);
+  }
+
+  if (reclaimed <= 0) {
+    // Defensive: total must round-trip even when nothing is reclaimed.
+    return result;
+  }
+
+  const recipients = activeKeys.length > 0 ? activeKeys : haltedKeys;
+  if (recipients.length === 0) {
+    // Nowhere to send the reclaimed slots — return them to the
+    // largest input-quota species so the global budget is preserved.
+    let bestKey: string | undefined;
+    let bestQuota = -1;
+    for (const [speciesKey, quota] of quotas) {
+      if (quota > bestQuota) {
+        bestQuota = quota;
+        bestKey = speciesKey;
+      }
+    }
+    if (bestKey !== undefined) {
+      result.set(bestKey, (result.get(bestKey) ?? 0) + reclaimed);
+    }
+    // Sanity: total preserved.
+    return enforceTotal(result, totalIn);
+  }
+
+  // Proportional redistribution by current quota share among recipients.
+  const recipientShareTotal = recipients.reduce(
+    (sum, key) => sum + (result.get(key) ?? 0),
+    0,
+  );
+
+  interface AllocationRow {
+    speciesKey: string;
+    integerPart: number;
+    fractionalPart: number;
+  }
+  const rows: AllocationRow[] = [];
+  let assigned = 0;
+
+  if (recipientShareTotal > 0) {
+    for (const key of recipients) {
+      const share = (result.get(key) ?? 0) / recipientShareTotal;
+      const exact = share * reclaimed;
+      const integerPart = Math.floor(exact);
+      const fractionalPart = exact - integerPart;
+      rows.push({ speciesKey: key, integerPart, fractionalPart });
+      assigned += integerPart;
+    }
+  } else {
+    // Even split when current shares are all zero (edge case where
+    // every active recipient already had quota 0 — possible when a
+    // small minSpeciesSlots floor was zero and proportional allocation
+    // rounded everyone down).
+    const even = Math.floor(reclaimed / recipients.length);
+    for (const key of recipients) {
+      rows.push({ speciesKey: key, integerPart: even, fractionalPart: 0 });
+      assigned += even;
+    }
+  }
+
+  let leftover = reclaimed - assigned;
+  if (leftover > 0) {
+    const ordered = [...rows].sort((a, b) => {
+      if (b.fractionalPart !== a.fractionalPart) {
+        return b.fractionalPart - a.fractionalPart;
+      }
+      return a.speciesKey.localeCompare(b.speciesKey);
+    });
+    for (const row of ordered) {
+      if (leftover === 0) break;
+      row.integerPart += 1;
+      leftover -= 1;
+    }
+  }
+
+  for (const row of rows) {
+    result.set(
+      row.speciesKey,
+      (result.get(row.speciesKey) ?? 0) + row.integerPart,
+    );
+  }
+
+  return enforceTotal(result, totalIn);
+}
+
+/**
+ * Defensive helper: if integer rounding has introduced any drift from
+ * the input total, push or pull a single slot from the largest entry
+ * so callers can rely on the round-trip invariant.
+ */
+function enforceTotal(
+  result: Map<string, number>,
+  expectedTotal: number,
+): Map<string, number> {
+  let actual = 0;
+  for (const v of result.values()) actual += v;
+  const drift = expectedTotal - actual;
+  if (drift === 0) return result;
+
+  // Find the entry with the largest current value to absorb drift.
+  let bestKey: string | undefined;
+  let bestQuota = -Infinity;
+  for (const [k, v] of result) {
+    if (v > bestQuota) {
+      bestQuota = v;
+      bestKey = k;
+    }
+  }
+  if (bestKey !== undefined) {
+    result.set(bestKey, Math.max(0, (result.get(bestKey) ?? 0) + drift));
+  }
+  return result;
+}

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -12,6 +12,7 @@ import type { DiscoveryMinCandidatesPerCategory } from "@config/DiscoveryMinCand
 import type { RequiredEnsembleDiversityConfig } from "@config/EnsembleDiversityConfig.ts";
 import type { RequiredFineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
 import type { RequiredFitnessSharingConfig } from "@config/FitnessSharingConfig.ts";
+import type { RequiredSpeciesStagnationConfig } from "@config/SpeciesStagnationConfig.ts";
 import type { RequiredStabilityAdaptationConfig } from "@config/StabilityAdaptationConfig.ts";
 import type { RequiredQuantumStepConfig } from "@config/QuantumStepConfig.ts";
 import type { RequiredSquashEffectivenessConfig } from "@config/SquashEffectivenessConfig.ts";
@@ -866,4 +867,21 @@ export interface NeatArguments {
    * - minSpeciesSlots: Floor for per-species breeding slots (default: 1)
    */
   fitnessSharing: RequiredFitnessSharingConfig;
+
+  /**
+   * Species stagnation detection and breeding-budget reclamation
+   * configuration.
+   *
+   * Issue #2454: Tracks per-species best raw fitness across generations.
+   * Species that fail to improve over `haltWindow` generations have their
+   * breeding share halved; species flat for `extinctionWindow` generations
+   * are dropped from the breeding pool entirely. Reclaimed slots are
+   * redistributed proportionally to the remaining species.
+   *
+   * Configuration options:
+   * - enabled: Whether species stagnation detection is active (default: true)
+   * - haltWindow: Generations before halving breeding share (default: 15)
+   * - extinctionWindow: Generations before zeroing breeding share (default: 25)
+   */
+  speciesStagnation: RequiredSpeciesStagnationConfig;
 }

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -56,6 +56,7 @@ import {
   parsePlateauDetection,
   parsePredictiveCoding,
   parseQuantumStep,
+  parseSpeciesStagnation,
   parseSquashEffectiveness,
   parseStabilityAdaptation,
   parseWasmCache,
@@ -628,6 +629,10 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
     // Issue #2453: Parse fitness sharing configuration
     fitnessSharing: parseFitnessSharing(
       opts.fitnessSharing as Record<string, unknown> | undefined,
+    ),
+    // Issue #2454: Parse species stagnation configuration
+    speciesStagnation: parseSpeciesStagnation(
+      opts.speciesStagnation as Record<string, unknown> | undefined,
     ),
     // Issue #1620: Parse and resolve output range constraints
     outputRanges: (() => {

--- a/src/config/NeatConfigParsers.ts
+++ b/src/config/NeatConfigParsers.ts
@@ -30,6 +30,7 @@ export {
   parseEnsembleDiversity,
   parseFineTunePopulation,
   parseFitnessSharing,
+  parseSpeciesStagnation,
 } from "@config/parsers/PopulationParsers.ts";
 export {
   parseCrossValidation,

--- a/src/config/NeatConfigValidation.ts
+++ b/src/config/NeatConfigValidation.ts
@@ -203,6 +203,19 @@ export function validateNeatConfig(config: NeatArguments): void {
     );
   }
 
+  // Issue #2454: Species stagnation extinctionWindow must exceed haltWindow
+  if (
+    config.speciesStagnation.extinctionWindow <=
+      config.speciesStagnation.haltWindow
+  ) {
+    throw new ConfigurationError(
+      `speciesStagnation.extinctionWindow must be greater than haltWindow. ` +
+        `extinctionWindow: ${config.speciesStagnation.extinctionWindow}, ` +
+        `haltWindow: ${config.speciesStagnation.haltWindow}`,
+      "CROSS_FIELD_VALIDATION",
+    );
+  }
+
   // Discovery focus neuron UUID validation
   if (!Array.isArray(config.discoveryFocusNeuronUUIDs)) {
     throw new ConfigurationError(

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -6,6 +6,7 @@ import type { DiscoveryMinCandidatesPerCategory } from "@config/DiscoveryMinCand
 import type { EnsembleDiversityConfig } from "@config/EnsembleDiversityConfig.ts";
 import type { FineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
 import type { FitnessSharingConfig } from "@config/FitnessSharingConfig.ts";
+import type { SpeciesStagnationConfig } from "@config/SpeciesStagnationConfig.ts";
 import type { NeatArguments } from "@config/NeatArguments.ts";
 import type { PlateauDetectionConfig } from "@neat/PlateauDetector.ts";
 import type { PredictiveCodingConfig } from "@config/PredictiveCodingConfig.ts";
@@ -117,6 +118,7 @@ export type NeatOptions =
     | "parallelEvaluation"
     | "squashEffectiveness"
     | "fitnessSharing"
+    | "speciesStagnation"
     | "outputRanges"
     | "logger"
     | "rng"
@@ -171,6 +173,8 @@ export type NeatOptions =
     squashEffectiveness?: SquashEffectivenessConfig;
     /** Partial overrides for fitness sharing configuration (Issue #2453, defaults applied if not specified) */
     fitnessSharing?: FitnessSharingConfig;
+    /** Partial overrides for species stagnation configuration (Issue #2454, defaults applied if not specified) */
+    speciesStagnation?: SpeciesStagnationConfig;
     /**
      * Optional per-output range constraints (Issue #1620).
      *
@@ -266,6 +270,7 @@ export type NeatOptionsInput =
     | "parallelEvaluation"
     | "squashEffectiveness"
     | "fitnessSharing"
+    | "speciesStagnation"
     | "outputRanges"
     | "logger"
     | "logLevel"
@@ -312,6 +317,8 @@ export type NeatOptionsInput =
     squashEffectiveness?: CoerceNumeric<SquashEffectivenessConfig>;
     /** Fitness sharing configuration (Issue #2453). Numeric fields coerced from CLI. */
     fitnessSharing?: CoerceNumeric<FitnessSharingConfig>;
+    /** Species stagnation configuration (Issue #2454). Numeric fields coerced from CLI. */
+    speciesStagnation?: CoerceNumeric<SpeciesStagnationConfig>;
     /** Per-output range constraints (Issue #1620). Numeric fields coerced from CLI. */
     outputRanges?: readonly CoerceNumeric<OutputRange>[];
     /** Custom logger instance (not coerced — functions cannot come from CLI). */

--- a/src/config/SpeciesStagnationConfig.ts
+++ b/src/config/SpeciesStagnationConfig.ts
@@ -1,0 +1,63 @@
+/**
+ * SpeciesStagnationConfig.ts - Configuration for per-species stagnation
+ * detection and breeding-budget reclamation (Issue #2454).
+ *
+ * Builds on per-species rolling statistics (Issue #2452) and per-species
+ * breeding quotas (Issue #2453). Each generation, the best raw fitness
+ * for every species is recorded. Species that fail to improve their best
+ * raw fitness over a sliding window have their breeding share halved
+ * (`haltWindow`); species flat for an even longer window are dropped
+ * from the breeding pool entirely (`extinctionWindow`). Their members
+ * may still survive via elitism but contribute no offspring. Reclaimed
+ * slots are redistributed proportionally to the remaining species.
+ */
+
+/**
+ * Configuration for species stagnation detection and breeding budget
+ * reclamation.
+ */
+export interface SpeciesStagnationConfig {
+  /**
+   * Whether species stagnation detection is active. When `false`, breeding
+   * quotas pass through unchanged (the previous Issue #2453 behaviour).
+   * Default: `true`.
+   */
+  enabled?: boolean;
+
+  /**
+   * Number of consecutive generations without an improvement in best raw
+   * fitness after which a species is considered stagnant ("halted") and
+   * its breeding share is reduced by 50%. Must be >= 1.
+   * Default: 15.
+   */
+  haltWindow?: number;
+
+  /**
+   * Number of consecutive generations without an improvement in best raw
+   * fitness after which a species is considered "extinct" and dropped
+   * from the breeding pool entirely for the next generation. Must be
+   * greater than `haltWindow`.
+   * Default: 25.
+   */
+  extinctionWindow?: number;
+}
+
+/**
+ * Required version of {@link SpeciesStagnationConfig} with all fields
+ * populated. Used internally by `createNeatConfig()` after defaults are
+ * applied.
+ */
+export type RequiredSpeciesStagnationConfig = Required<SpeciesStagnationConfig>;
+
+/**
+ * Default values for species stagnation detection.
+ *
+ * Issue #2454: enabled by default so a stagnant species' breeding budget
+ * is naturally reclaimed by species that are still progressing.
+ */
+export const DEFAULT_SPECIES_STAGNATION_CONFIG:
+  RequiredSpeciesStagnationConfig = {
+    enabled: true,
+    haltWindow: 15,
+    extinctionWindow: 25,
+  };

--- a/src/config/parsers/PopulationParsers.ts
+++ b/src/config/parsers/PopulationParsers.ts
@@ -23,6 +23,10 @@ import {
   DEFAULT_FITNESS_SHARING_CONFIG,
   type RequiredFitnessSharingConfig,
 } from "@config/FitnessSharingConfig.ts";
+import {
+  DEFAULT_SPECIES_STAGNATION_CONFIG,
+  type RequiredSpeciesStagnationConfig,
+} from "@config/SpeciesStagnationConfig.ts";
 import { parseNumber } from "@config/ParseOptions.ts";
 
 /** Parse fine-tune population configuration (Issue #1323). */
@@ -122,6 +126,30 @@ export function parseFitnessSharing(
       { integer: true, min: 0 },
     ),
   } as RequiredFitnessSharingConfig;
+}
+
+/** Parse species stagnation configuration (Issue #2454). */
+export function parseSpeciesStagnation(
+  overrides: Record<string, unknown> | undefined,
+): RequiredSpeciesStagnationConfig {
+  const d = DEFAULT_SPECIES_STAGNATION_CONFIG;
+  return {
+    enabled: typeof overrides?.enabled === "boolean"
+      ? overrides.enabled
+      : d.enabled,
+    haltWindow: parseNumber(
+      "Species stagnation haltWindow",
+      overrides?.haltWindow,
+      d.haltWindow,
+      { integer: true, min: 1 },
+    ),
+    extinctionWindow: parseNumber(
+      "Species stagnation extinctionWindow",
+      overrides?.extinctionWindow,
+      d.extinctionWindow,
+      { integer: true, min: 1 },
+    ),
+  } as RequiredSpeciesStagnationConfig;
 }
 
 /** Parse ensemble diversity configuration (Issue #1310). */

--- a/test/NEAT/SpeciesPlateauDetector.ts
+++ b/test/NEAT/SpeciesPlateauDetector.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for per-species stagnation detection and breeding-budget
+ * reclamation (Issue #2454).
+ *
+ * Verifies:
+ *  - A species held flat for `haltWindow` generations has its breeding
+ *    share halved on the next quota allocation.
+ *  - The same species held flat for `extinctionWindow` generations is
+ *    dropped from the breeding pool entirely; the remaining species
+ *    absorb its share so the global breeding budget is preserved.
+ *  - Disabling the flag is a no-op (regression: previous behaviour).
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  applyStagnationToQuotas,
+  SpeciesPlateauDetector,
+} from "@neat/SpeciesPlateauDetector.ts";
+import { DEFAULT_SPECIES_STAGNATION_CONFIG } from "@config/SpeciesStagnationConfig.ts";
+
+const HALT_WINDOW = DEFAULT_SPECIES_STAGNATION_CONFIG.haltWindow;
+const EXTINCTION_WINDOW = DEFAULT_SPECIES_STAGNATION_CONFIG.extinctionWindow;
+
+/** Drive a species' best-fitness history by repeating a fixed value. */
+function recordFlatGenerations(
+  detector: SpeciesPlateauDetector,
+  speciesKey: string,
+  fitness: number,
+  generations: number,
+): void {
+  for (let i = 0; i < generations; i++) {
+    detector.recordSpecies(speciesKey, fitness);
+  }
+}
+
+/** Sum the values of a quota map. */
+function totalQuota(quotas: ReadonlyMap<string, number>): number {
+  let sum = 0;
+  for (const v of quotas.values()) sum += v;
+  return sum;
+}
+
+Deno.test(
+  "SpeciesPlateauDetector - active when fitness improves each generation",
+  () => {
+    const detector = new SpeciesPlateauDetector(
+      DEFAULT_SPECIES_STAGNATION_CONFIG,
+    );
+
+    for (let i = 0; i < EXTINCTION_WINDOW + 5; i++) {
+      detector.recordSpecies("species-progressing", 0.1 + i * 0.01);
+    }
+
+    assertEquals(detector.getStagnantGenerations("species-progressing"), 0);
+    assertEquals(detector.getStatus("species-progressing"), "active");
+  },
+);
+
+Deno.test(
+  "SpeciesPlateauDetector - status flips to halted at haltWindow",
+  () => {
+    const detector = new SpeciesPlateauDetector(
+      DEFAULT_SPECIES_STAGNATION_CONFIG,
+    );
+
+    detector.recordSpecies("flat", 1.0);
+    // After the initial recording, run haltWindow more flat generations.
+    recordFlatGenerations(detector, "flat", 1.0, HALT_WINDOW - 1);
+    assertEquals(
+      detector.getStatus("flat"),
+      "active",
+      "Just below haltWindow should still be active",
+    );
+    detector.recordSpecies("flat", 1.0);
+    assertEquals(
+      detector.getStagnantGenerations("flat"),
+      HALT_WINDOW,
+      "Stagnant counter should equal haltWindow exactly",
+    );
+    assertEquals(detector.getStatus("flat"), "halted");
+  },
+);
+
+Deno.test(
+  "SpeciesPlateauDetector - status flips to extinct at extinctionWindow",
+  () => {
+    const detector = new SpeciesPlateauDetector(
+      DEFAULT_SPECIES_STAGNATION_CONFIG,
+    );
+
+    detector.recordSpecies("flat", 2.0);
+    recordFlatGenerations(detector, "flat", 2.0, EXTINCTION_WINDOW);
+    assertEquals(
+      detector.getStagnantGenerations("flat"),
+      EXTINCTION_WINDOW,
+    );
+    assertEquals(detector.getStatus("flat"), "extinct");
+  },
+);
+
+Deno.test(
+  "SpeciesPlateauDetector - improvement resets the stagnant counter",
+  () => {
+    const detector = new SpeciesPlateauDetector(
+      DEFAULT_SPECIES_STAGNATION_CONFIG,
+    );
+
+    detector.recordSpecies("late-bloomer", 1.0);
+    recordFlatGenerations(detector, "late-bloomer", 1.0, HALT_WINDOW);
+    assertEquals(detector.getStatus("late-bloomer"), "halted");
+
+    detector.recordSpecies("late-bloomer", 1.5); // Improvement
+    assertEquals(detector.getStagnantGenerations("late-bloomer"), 0);
+    assertEquals(detector.getStatus("late-bloomer"), "active");
+  },
+);
+
+Deno.test(
+  "applyStagnationToQuotas - halts halve a species' breeding share",
+  () => {
+    const detector = new SpeciesPlateauDetector(
+      DEFAULT_SPECIES_STAGNATION_CONFIG,
+    );
+
+    // Two-species fixture. Species "stagnant" is held flat for the
+    // halt window; species "progressing" improves every generation.
+    for (let i = 0; i < HALT_WINDOW + 1; i++) {
+      detector.recordSpecies("stagnant", 1.0);
+      detector.recordSpecies("progressing", 1.0 + i * 0.05);
+    }
+
+    assertEquals(detector.getStatus("stagnant"), "halted");
+    assertEquals(detector.getStatus("progressing"), "active");
+
+    // The pre-stagnation quota — derived from any allocator. We use a
+    // fixed 50/50 split to make the halving signal unambiguous.
+    const quotas = new Map<string, number>([
+      ["stagnant", 20],
+      ["progressing", 20],
+    ]);
+
+    const adjusted = applyStagnationToQuotas(quotas, detector);
+
+    // Stagnant species lost half: 20 → 10. The 10 reclaimed slots are
+    // redistributed to the only active recipient (progressing), which
+    // grows from 20 → 30. Total budget preserved.
+    assertEquals(adjusted.get("stagnant"), 10);
+    assertEquals(adjusted.get("progressing"), 30);
+    assertEquals(totalQuota(adjusted), totalQuota(quotas));
+  },
+);
+
+Deno.test(
+  "applyStagnationToQuotas - extinction zeroes the species and surviving species absorb its share",
+  () => {
+    const detector = new SpeciesPlateauDetector(
+      DEFAULT_SPECIES_STAGNATION_CONFIG,
+    );
+
+    for (let i = 0; i < EXTINCTION_WINDOW + 1; i++) {
+      detector.recordSpecies("doomed", 1.0);
+      detector.recordSpecies("survivor", 1.0 + i * 0.05);
+    }
+
+    assertEquals(detector.getStatus("doomed"), "extinct");
+    assertEquals(detector.getStatus("survivor"), "active");
+
+    const quotas = new Map<string, number>([
+      ["doomed", 12],
+      ["survivor", 28],
+    ]);
+
+    const adjusted = applyStagnationToQuotas(quotas, detector);
+
+    assertEquals(
+      adjusted.get("doomed"),
+      0,
+      "Extinct species must receive zero breeding slots",
+    );
+    assertEquals(
+      adjusted.get("survivor"),
+      40,
+      "Survivor should absorb the full 12 reclaimed slots",
+    );
+    assertEquals(
+      totalQuota(adjusted),
+      totalQuota(quotas),
+      "Total breeding budget must be preserved",
+    );
+  },
+);
+
+Deno.test(
+  "applyStagnationToQuotas - extinct slots split proportionally across active species",
+  () => {
+    const detector = new SpeciesPlateauDetector(
+      DEFAULT_SPECIES_STAGNATION_CONFIG,
+    );
+
+    for (let i = 0; i < EXTINCTION_WINDOW + 1; i++) {
+      detector.recordSpecies("doomed", 0.2);
+      detector.recordSpecies("active-large", 1.0 + i * 0.1);
+      detector.recordSpecies("active-small", 0.5 + i * 0.05);
+    }
+
+    const quotas = new Map<string, number>([
+      ["doomed", 8],
+      ["active-large", 18],
+      ["active-small", 6],
+    ]);
+
+    const adjusted = applyStagnationToQuotas(quotas, detector);
+
+    assertEquals(adjusted.get("doomed"), 0);
+    // Reclaimed 8 slots are split 18:6 between the two active species
+    // (proportional to their pre-stagnation quotas). The proportional
+    // allocation gives ~6 to active-large and ~2 to active-small.
+    assertEquals(
+      totalQuota(adjusted),
+      totalQuota(quotas),
+      "Total breeding budget must be preserved across redistribution",
+    );
+    assert(
+      (adjusted.get("active-large") ?? 0) > 18,
+      "Active-large should grow after absorbing reclaimed slots",
+    );
+    assert(
+      (adjusted.get("active-small") ?? 0) > 6,
+      "Active-small should grow after absorbing reclaimed slots",
+    );
+  },
+);
+
+Deno.test(
+  "applyStagnationToQuotas - disabled flag is a no-op (regression test)",
+  () => {
+    const detector = new SpeciesPlateauDetector({
+      enabled: false,
+      haltWindow: HALT_WINDOW,
+      extinctionWindow: EXTINCTION_WINDOW,
+    });
+
+    // Even when fed enough flat generations to trip both windows,
+    // the detector reports every species as active when disabled.
+    for (let i = 0; i < EXTINCTION_WINDOW + 5; i++) {
+      detector.recordSpecies("would-be-extinct", 0.1);
+    }
+    assertEquals(detector.getStatus("would-be-extinct"), "active");
+
+    const quotas = new Map<string, number>([
+      ["would-be-extinct", 15],
+      ["other", 25],
+    ]);
+
+    const adjusted = applyStagnationToQuotas(quotas, detector);
+
+    // The quota map round-trips unchanged when nothing is reclaimed.
+    assertEquals(adjusted.get("would-be-extinct"), 15);
+    assertEquals(adjusted.get("other"), 25);
+    assertEquals(totalQuota(adjusted), totalQuota(quotas));
+  },
+);
+
+Deno.test(
+  "SpeciesPlateauDetector - pruneAbsent drops history for missing species",
+  () => {
+    const detector = new SpeciesPlateauDetector(
+      DEFAULT_SPECIES_STAGNATION_CONFIG,
+    );
+
+    detector.recordSpecies("alpha", 1.0);
+    detector.recordSpecies("beta", 1.0);
+    detector.recordSpecies("gamma", 1.0);
+
+    // Only alpha and beta remain in the genus; gamma should be pruned.
+    detector.pruneAbsent(["alpha", "beta"]);
+
+    // Following stagnation generations should accumulate only for
+    // alpha/beta — gamma is treated as a fresh species when reseen.
+    recordFlatGenerations(detector, "alpha", 1.0, HALT_WINDOW + 1);
+    detector.recordSpecies("gamma", 1.0);
+
+    assertEquals(detector.getStatus("alpha"), "halted");
+    assertEquals(
+      detector.getStagnantGenerations("gamma"),
+      0,
+      "gamma should restart its history after pruning",
+    );
+  },
+);
+
+Deno.test(
+  "applyStagnationToQuotas - non-finite fitness does not advance stagnation",
+  () => {
+    const detector = new SpeciesPlateauDetector(
+      DEFAULT_SPECIES_STAGNATION_CONFIG,
+    );
+
+    detector.recordSpecies("species", 1.0);
+    // Non-finite samples are skipped — the stagnation counter stays put.
+    for (let i = 0; i < HALT_WINDOW + 5; i++) {
+      detector.recordSpecies("species", -Infinity);
+    }
+    assertEquals(detector.getStatus("species"), "active");
+  },
+);


### PR DESCRIPTION
## Summary

Adds per-species stagnation detection so evolution can reclaim breeding
budget from species that have stopped improving and redirect it to
species that are still progressing. Closes #2454.

A new `SpeciesPlateauDetector` tracks the high-water best raw fitness
per species across generations. When a species fails to improve for
`haltWindow` generations (default 15) it is classified as **halted**
and its breeding share is halved. After `extinctionWindow` generations
(default 25) it is classified as **extinct** and dropped from the
breeding pool entirely; its members may still survive via elitism but
contribute no offspring. Reclaimed slots are redistributed
proportionally to the remaining (still-progressing) species using the
largest-fractional-part rule from `BreedingQuotas`, preserving the
total breeding budget.

```mermaid
flowchart LR
  A[Fitness eval] --> B[updateSpeciesStatistics]
  B --> C[recordGeneration]
  C --> D[allocateBreedingQuotas]
  D --> E{stagnation enabled?}
  E -- no --> G[breed]
  E -- yes --> F[applyStagnationToQuotas]
  F --> G
```

## Evidence

CLI/library change with no UI surface — verified via unit tests in
`test/NEAT/SpeciesPlateauDetector.ts` and the full
`./quality.sh --skip-discovery --skip-wasm` suite (6265 passed, 0
failed). New tests cover the three issue scenarios (halve at
`haltWindow`, drop at `extinctionWindow`, disabled flag is a no-op)
plus pruning and non-finite-fitness edge cases.

## Test Plan

- [x] `test/NEAT/SpeciesPlateauDetector.ts` — 10 new tests:
  - active when fitness improves each generation
  - status flips to halted at `haltWindow`
  - status flips to extinct at `extinctionWindow`
  - improvement resets the stagnant counter
  - `applyStagnationToQuotas` halves a halted species' breeding share
  - extinct species lose all slots; survivors absorb the share
  - extinct slots split proportionally across multiple active species
  - disabled flag is a no-op (regression test)
  - `pruneAbsent` drops history for species missing from the genus
  - non-finite fitness does not advance stagnation
- [x] Existing `test/NEAT/SpeciesStatistics.ts`, `Genus.ts`, `Species.ts`,
  `PlateauDetection.ts`, `NeatConfig.ts`, `NeatEvolve.ts` — all pass
  unchanged.
- [x] `./quality.sh --skip-discovery --skip-wasm` — 6265 passed,
  0 failed.