### PR TITLE
Soft compatibility-gated cross-species breeding (#2455)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.36",
+  "version": "3.1.37",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2455.md
+++ b/docs/pr-summary-2455.md
@@ -1,0 +1,81 @@
+## Summary
+
+Replace the hard "lowest-compatibility father" pick on the diversity-driven
+breeding path with a soft probabilistic gate so cross-species pairings
+happen at a frequency that matches their compatibility — favouring
+similar architectures while still allowing rare exploratory hybrids.
+The previous behaviour (always pick the most genetically distant
+candidate) empirically produces weak hybrids; the soft gate accepts each
+candidate with probability `compatibility ^ power` and falls back to the
+lowest-compatibility candidate after `maxDraws` rejections so selection
+always terminates.
+
+Closes #2455.
+
+## Changes
+
+- **`src/config/CompatibilityGatingConfig.ts`** (new) — adds the
+  `CompatibilityGatingConfig` type, `RequiredCompatibilityGatingConfig`,
+  and `DEFAULT_COMPATIBILITY_GATING_CONFIG` (`enabled: true`,
+  `power: 1.5`, `maxDraws: 3`).
+- **`src/config/NeatArguments.ts`** — adds the `compatibilityGating`
+  field with documentation describing intent, defaults, and the
+  `power: 0` / `enabled: false` fallback semantics.
+- **`src/config/NeatOptions.ts`** — adds the partial-override input
+  type for `compatibilityGating` to both `NeatOptions` and
+  `NeatOptionsInput` (with `CoerceNumeric<>` for CLI string inputs).
+- **`src/config/parsers/PopulationParsers.ts`** — adds
+  `parseCompatibilityGating()` to merge user overrides over the
+  defaults with bounded numeric validation.
+- **`src/config/NeatConfigParsers.ts`** — re-exports the new parser.
+- **`src/config/NeatConfig.ts`** — wires the parser into
+  `createNeatConfig()`.
+- **`src/breed/ParentSelection.ts`** — adds `softCompatibilityGate()`
+  (the new probabilistic gate) and routes
+  `selectFatherFromCandidates()` through it on the diversity-driven
+  path when the gate is enabled and `power > 0`. When disabled or
+  `power === 0`, selection falls through to the legacy
+  `selectMostDiverseFather()` (lowest-compat pick) — exactly the prior
+  behaviour. A short comment next to the implementation explains why
+  the soft gate is preferred over a hard threshold.
+
+## Evidence
+
+This change is purely backend — no UI to screenshot. Verification is
+via the new unit tests plus the full quality gate.
+
+```mermaid
+flowchart LR
+    A[selectFatherFromCandidates] -->|diversity rate triggers| B{gate enabled<br/>and power > 0?}
+    B -->|no| C[selectMostDiverseFather<br/>legacy lowest-compat pick]
+    B -->|yes| D[softCompatibilityGate]
+    D --> E[draw candidate]
+    E --> F{accept with prob<br/>compatibility^power?}
+    F -->|yes| G[return candidate]
+    F -->|no, draws &lt; maxDraws| E
+    F -->|no, exhausted| C
+    A -->|fitness path| H[FitnessRanking selectParent]
+```
+
+## Test Plan
+
+- `test/breed/CompatibilityGating.ts` (new) covers the three scenarios
+  required by the issue:
+  - **`power: 0` regression** — with the gate active but `power: 0`,
+    diversity-driven selection falls through to the legacy lowest-compat
+    pick, exactly matching the prior selection distribution across 25
+    repeated draws on a candidate pool spanning the full compatibility
+    range.
+  - **`enabled: false` regression** — same legacy behaviour is restored
+    when the gate is disabled.
+  - **`power: 2` distribution** — across 600 seeded draws on a
+    16-candidate pool (8 high-compat, 8 low-compat), high-compat
+    fathers are selected ≥3× more often than low-compat fathers.
+  - **`maxDraws` fallback** — when every candidate has compatibility 0,
+    the gate exhausts `maxDraws` rejections and returns the
+    lowest-compat candidate (the bounded fallback path).
+  - Plus default-value sanity checks (`enabled: true`, `power: 1.5`,
+    `maxDraws: 3`).
+- `./quality.sh --skip-discovery --skip-wasm` passes (6271 tests).
+- Existing `test/breed/DiversityBreeding.ts` and `test/breed/ParentSelection.ts`
+  continue to pass — no behaviour change on the standard fitness path.

--- a/docs/pr-summary-2455.md
+++ b/docs/pr-summary-2455.md
@@ -1,48 +1,45 @@
 ## Summary
 
 Replace the hard "lowest-compatibility father" pick on the diversity-driven
-breeding path with a soft probabilistic gate so cross-species pairings
-happen at a frequency that matches their compatibility — favouring
-similar architectures while still allowing rare exploratory hybrids.
-The previous behaviour (always pick the most genetically distant
-candidate) empirically produces weak hybrids; the soft gate accepts each
-candidate with probability `compatibility ^ power` and falls back to the
-lowest-compatibility candidate after `maxDraws` rejections so selection
-always terminates.
+breeding path with a soft probabilistic gate so cross-species pairings happen at
+a frequency that matches their compatibility — favouring similar architectures
+while still allowing rare exploratory hybrids. The previous behaviour (always
+pick the most genetically distant candidate) empirically produces weak hybrids;
+the soft gate accepts each candidate with probability `compatibility ^ power`
+and falls back to the lowest-compatibility candidate after `maxDraws` rejections
+so selection always terminates.
 
 Closes #2455.
 
 ## Changes
 
 - **`src/config/CompatibilityGatingConfig.ts`** (new) — adds the
-  `CompatibilityGatingConfig` type, `RequiredCompatibilityGatingConfig`,
-  and `DEFAULT_COMPATIBILITY_GATING_CONFIG` (`enabled: true`,
-  `power: 1.5`, `maxDraws: 3`).
-- **`src/config/NeatArguments.ts`** — adds the `compatibilityGating`
-  field with documentation describing intent, defaults, and the
-  `power: 0` / `enabled: false` fallback semantics.
-- **`src/config/NeatOptions.ts`** — adds the partial-override input
-  type for `compatibilityGating` to both `NeatOptions` and
-  `NeatOptionsInput` (with `CoerceNumeric<>` for CLI string inputs).
+  `CompatibilityGatingConfig` type, `RequiredCompatibilityGatingConfig`, and
+  `DEFAULT_COMPATIBILITY_GATING_CONFIG` (`enabled: true`, `power: 1.5`,
+  `maxDraws: 3`).
+- **`src/config/NeatArguments.ts`** — adds the `compatibilityGating` field with
+  documentation describing intent, defaults, and the `power: 0` /
+  `enabled: false` fallback semantics.
+- **`src/config/NeatOptions.ts`** — adds the partial-override input type for
+  `compatibilityGating` to both `NeatOptions` and `NeatOptionsInput` (with
+  `CoerceNumeric<>` for CLI string inputs).
 - **`src/config/parsers/PopulationParsers.ts`** — adds
-  `parseCompatibilityGating()` to merge user overrides over the
-  defaults with bounded numeric validation.
+  `parseCompatibilityGating()` to merge user overrides over the defaults with
+  bounded numeric validation.
 - **`src/config/NeatConfigParsers.ts`** — re-exports the new parser.
-- **`src/config/NeatConfig.ts`** — wires the parser into
-  `createNeatConfig()`.
-- **`src/breed/ParentSelection.ts`** — adds `softCompatibilityGate()`
-  (the new probabilistic gate) and routes
-  `selectFatherFromCandidates()` through it on the diversity-driven
-  path when the gate is enabled and `power > 0`. When disabled or
-  `power === 0`, selection falls through to the legacy
+- **`src/config/NeatConfig.ts`** — wires the parser into `createNeatConfig()`.
+- **`src/breed/ParentSelection.ts`** — adds `softCompatibilityGate()` (the new
+  probabilistic gate) and routes `selectFatherFromCandidates()` through it on
+  the diversity-driven path when the gate is enabled and `power > 0`. When
+  disabled or `power === 0`, selection falls through to the legacy
   `selectMostDiverseFather()` (lowest-compat pick) — exactly the prior
-  behaviour. A short comment next to the implementation explains why
-  the soft gate is preferred over a hard threshold.
+  behaviour. A short comment next to the implementation explains why the soft
+  gate is preferred over a hard threshold.
 
 ## Evidence
 
-This change is purely backend — no UI to screenshot. Verification is
-via the new unit tests plus the full quality gate.
+This change is purely backend — no UI to screenshot. Verification is via the new
+unit tests plus the full quality gate.
 
 ```mermaid
 flowchart LR
@@ -59,21 +56,20 @@ flowchart LR
 
 ## Test Plan
 
-- `test/breed/CompatibilityGating.ts` (new) covers the three scenarios
-  required by the issue:
+- `test/breed/CompatibilityGating.ts` (new) covers the three scenarios required
+  by the issue:
   - **`power: 0` regression** — with the gate active but `power: 0`,
-    diversity-driven selection falls through to the legacy lowest-compat
-    pick, exactly matching the prior selection distribution across 25
-    repeated draws on a candidate pool spanning the full compatibility
-    range.
-  - **`enabled: false` regression** — same legacy behaviour is restored
-    when the gate is disabled.
-  - **`power: 2` distribution** — across 600 seeded draws on a
-    16-candidate pool (8 high-compat, 8 low-compat), high-compat
-    fathers are selected ≥3× more often than low-compat fathers.
-  - **`maxDraws` fallback** — when every candidate has compatibility 0,
-    the gate exhausts `maxDraws` rejections and returns the
-    lowest-compat candidate (the bounded fallback path).
+    diversity-driven selection falls through to the legacy lowest-compat pick,
+    exactly matching the prior selection distribution across 25 repeated draws
+    on a candidate pool spanning the full compatibility range.
+  - **`enabled: false` regression** — same legacy behaviour is restored when the
+    gate is disabled.
+  - **`power: 2` distribution** — across 600 seeded draws on a 16-candidate pool
+    (8 high-compat, 8 low-compat), high-compat fathers are selected ≥3× more
+    often than low-compat fathers.
+  - **`maxDraws` fallback** — when every candidate has compatibility 0, the gate
+    exhausts `maxDraws` rejections and returns the lowest-compat candidate (the
+    bounded fallback path).
   - Plus default-value sanity checks (`enabled: true`, `power: 1.5`,
     `maxDraws: 3`).
 - `./quality.sh --skip-discovery --skip-wasm` passes (6271 tests).

--- a/src/breed/ParentSelection.ts
+++ b/src/breed/ParentSelection.ts
@@ -205,11 +205,60 @@ function selectFatherFromCandidates(
     config.diversityBreedingRate > 0 &&
     config.diversityBreedingRate > getRandomNumberGenerator().random()
   ) {
+    // Issue #2455: Apply the soft compatibility gate when enabled. The
+    // soft gate keeps cross-species exploration possible while
+    // concentrating most pairings on compatible parents — a hard
+    // "always pick lowest compat" filter empirically produces weak
+    // hybrids. Disabling the gate (or `power: 0`) reverts to the
+    // legacy lowest-compatibility pick exactly as before this issue.
+    const gate = config.compatibilityGating;
+    if (gate.enabled && gate.power > 0) {
+      return softCompatibilityGate(mum, candidates, gate.power, gate.maxDraws);
+    }
     return selectMostDiverseFather(mum, candidates);
   }
 
   const fatherRanking = new FitnessRanking(candidates);
   return selectParent(fatherRanking, config);
+}
+
+/**
+ * Soft compatibility-gated father selection (Issue #2455).
+ *
+ * Samples up to `maxDraws` candidates uniformly at random and accepts
+ * each with probability `compatibility ^ power`. Compatibility is in
+ * [0, 1], so higher powers concentrate selection on similar
+ * architectures while leaving a small probability mass for exploratory
+ * cross-species pairings. After `maxDraws` rejections the gate falls
+ * back to the lowest-compatibility candidate (the prior behaviour) so
+ * the call always returns a father.
+ *
+ * @param mum - The mother creature
+ * @param candidates - Array of potential father creatures
+ * @param power - Exponent applied to compatibility for acceptance probability
+ * @param maxDraws - Maximum number of probabilistic draws before fallback
+ * @returns The selected father creature
+ */
+export function softCompatibilityGate(
+  mum: Creature,
+  candidates: Creature[],
+  power: number,
+  maxDraws: number,
+): Creature {
+  const rng = getRandomNumberGenerator();
+  for (let i = 0; i < maxDraws; i++) {
+    const idx = Math.floor(rng.random() * candidates.length);
+    const candidate = candidates[idx];
+    const compatibility = geneticCompatibility(mum, candidate);
+    const acceptance = Math.pow(compatibility, power);
+    if (rng.random() < acceptance) {
+      return candidate;
+    }
+  }
+  // Bounded fallback: return the lowest-compatibility (most diverse)
+  // candidate. This preserves the historical exploratory pick while
+  // ensuring the loop always terminates.
+  return selectMostDiverseFather(mum, candidates);
 }
 
 /**

--- a/src/config/CompatibilityGatingConfig.ts
+++ b/src/config/CompatibilityGatingConfig.ts
@@ -1,0 +1,67 @@
+/**
+ * CompatibilityGatingConfig.ts - Configuration for the soft
+ * compatibility-gated cross-species breeding probability (Issue #2455).
+ *
+ * Replaces the previous hard "lowest-compatibility father" pick used on
+ * the diversity-driven breeding path with a soft probabilistic gate.
+ * Each candidate father is accepted with probability
+ * `compatibility ^ power`, so similar architectures (high compatibility)
+ * dominate while rare exploratory hybrids still appear. After
+ * `maxDraws` rejections the gate falls back to the lowest-compatibility
+ * candidate (the prior selection behaviour) so the call always returns
+ * a father.
+ */
+
+/**
+ * Configuration for the soft compatibility gate applied to
+ * diversity-driven father selection.
+ */
+export interface CompatibilityGatingConfig {
+  /**
+   * Whether the soft gate is active. When `false`, diversity-driven
+   * father selection falls through to the legacy lowest-compatibility
+   * pick exactly as before this issue. Default: `true`.
+   */
+  enabled?: boolean;
+
+  /**
+   * Power applied to the compatibility score when computing the
+   * acceptance probability `compatibility ^ power`. Higher values bias
+   * selection more strongly toward similar architectures. `power: 0`
+   * disables the bias and recovers the prior selection distribution
+   * (the gate reverts to the legacy lowest-compatibility pick).
+   * Default: `1.5`.
+   */
+  power?: number;
+
+  /**
+   * Maximum number of probabilistic draws before the gate falls back
+   * to the lowest-compatibility candidate. Bounds the loop so
+   * selection always terminates. Default: `3`.
+   */
+  maxDraws?: number;
+}
+
+/**
+ * Required version of {@link CompatibilityGatingConfig} with all fields
+ * populated. Used internally by `createNeatConfig()` after defaults are
+ * applied.
+ */
+export type RequiredCompatibilityGatingConfig = Required<
+  CompatibilityGatingConfig
+>;
+
+/**
+ * Default values for compatibility gating.
+ *
+ * Issue #2455: enabled by default with `power: 1.5` and `maxDraws: 3`,
+ * tuned to favour compatible pairings while still allowing rare
+ * exploratory hybrids. Set `enabled: false` or `power: 0` to restore
+ * the prior lowest-compatibility selection behaviour.
+ */
+export const DEFAULT_COMPATIBILITY_GATING_CONFIG:
+  RequiredCompatibilityGatingConfig = {
+    enabled: true,
+    power: 1.5,
+    maxDraws: 3,
+  };

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -8,6 +8,7 @@ import type { SelectionInterface } from "@methods/Selection.ts";
 import type { MutationInterface } from "@neat/MutationInterface.ts";
 import type { RequiredPlateauDetectionConfig } from "@neat/PlateauDetector.ts";
 import type { RequiredAdaptiveMutationThresholds } from "@config/AdaptiveMutationThresholds.ts";
+import type { RequiredCompatibilityGatingConfig } from "@config/CompatibilityGatingConfig.ts";
 import type { DiscoveryMinCandidatesPerCategory } from "@config/DiscoveryMinCandidatesPerCategory.ts";
 import type { RequiredEnsembleDiversityConfig } from "@config/EnsembleDiversityConfig.ts";
 import type { RequiredFineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
@@ -884,4 +885,24 @@ export interface NeatArguments {
    * - extinctionWindow: Generations before zeroing breeding share (default: 25)
    */
   speciesStagnation: RequiredSpeciesStagnationConfig;
+
+  /**
+   * Soft compatibility-gated cross-species breeding probability
+   * (Issue #2455).
+   *
+   * Replaces the previous hard "lowest-compatibility father" pick on
+   * the diversity-driven breeding path with a soft gate that accepts
+   * each candidate with probability `compatibility ^ power`. Similar
+   * architectures dominate while rare exploratory hybrids still
+   * appear. After `maxDraws` rejections the gate falls back to the
+   * lowest-compatibility candidate so selection always terminates.
+   *
+   * Configuration options:
+   * - enabled: Whether the soft gate is active (default: true)
+   * - power: Compatibility power exponent (default: 1.5; 0 recovers
+   *   the prior lowest-compatibility behaviour)
+   * - maxDraws: Bounded number of probabilistic draws before
+   *   fallback (default: 3)
+   */
+  compatibilityGating: RequiredCompatibilityGatingConfig;
 }

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -40,6 +40,7 @@ import {
   parseAdaptiveMutationThresholds,
   parseAdaptivePopulation,
   parseBiasRegularisation,
+  parseCompatibilityGating,
   parseCrossValidation,
   parseDataFuzzing,
   parseDataQuantisation,
@@ -633,6 +634,10 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
     // Issue #2454: Parse species stagnation configuration
     speciesStagnation: parseSpeciesStagnation(
       opts.speciesStagnation as Record<string, unknown> | undefined,
+    ),
+    // Issue #2455: Parse compatibility gating configuration
+    compatibilityGating: parseCompatibilityGating(
+      opts.compatibilityGating as Record<string, unknown> | undefined,
     ),
     // Issue #1620: Parse and resolve output range constraints
     outputRanges: (() => {

--- a/src/config/NeatConfigParsers.ts
+++ b/src/config/NeatConfigParsers.ts
@@ -27,6 +27,7 @@ export {
 } from "@config/parsers/MutationParsers.ts";
 export {
   parseAdaptivePopulation,
+  parseCompatibilityGating,
   parseEnsembleDiversity,
   parseFineTunePopulation,
   parseFitnessSharing,

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -2,6 +2,7 @@ import type { Logger, LogLevel } from "@utils/Logger.ts";
 import type { RandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 import type { TrainingEventCallback } from "@config/TrainingEvent.ts";
 import type { AdaptiveMutationThresholds } from "@config/AdaptiveMutationThresholds.ts";
+import type { CompatibilityGatingConfig } from "@config/CompatibilityGatingConfig.ts";
 import type { DiscoveryMinCandidatesPerCategory } from "@config/DiscoveryMinCandidatesPerCategory.ts";
 import type { EnsembleDiversityConfig } from "@config/EnsembleDiversityConfig.ts";
 import type { FineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
@@ -119,6 +120,7 @@ export type NeatOptions =
     | "squashEffectiveness"
     | "fitnessSharing"
     | "speciesStagnation"
+    | "compatibilityGating"
     | "outputRanges"
     | "logger"
     | "rng"
@@ -175,6 +177,8 @@ export type NeatOptions =
     fitnessSharing?: FitnessSharingConfig;
     /** Partial overrides for species stagnation configuration (Issue #2454, defaults applied if not specified) */
     speciesStagnation?: SpeciesStagnationConfig;
+    /** Partial overrides for compatibility gating configuration (Issue #2455, defaults applied if not specified) */
+    compatibilityGating?: CompatibilityGatingConfig;
     /**
      * Optional per-output range constraints (Issue #1620).
      *
@@ -271,6 +275,7 @@ export type NeatOptionsInput =
     | "squashEffectiveness"
     | "fitnessSharing"
     | "speciesStagnation"
+    | "compatibilityGating"
     | "outputRanges"
     | "logger"
     | "logLevel"
@@ -319,6 +324,8 @@ export type NeatOptionsInput =
     fitnessSharing?: CoerceNumeric<FitnessSharingConfig>;
     /** Species stagnation configuration (Issue #2454). Numeric fields coerced from CLI. */
     speciesStagnation?: CoerceNumeric<SpeciesStagnationConfig>;
+    /** Compatibility gating configuration (Issue #2455). Numeric fields coerced from CLI. */
+    compatibilityGating?: CoerceNumeric<CompatibilityGatingConfig>;
     /** Per-output range constraints (Issue #1620). Numeric fields coerced from CLI. */
     outputRanges?: readonly CoerceNumeric<OutputRange>[];
     /** Custom logger instance (not coerced — functions cannot come from CLI). */

--- a/src/config/parsers/PopulationParsers.ts
+++ b/src/config/parsers/PopulationParsers.ts
@@ -12,6 +12,10 @@ import {
   type RequiredAdaptivePopulationConfig,
 } from "@config/AdaptivePopulationConfig.ts";
 import {
+  DEFAULT_COMPATIBILITY_GATING_CONFIG,
+  type RequiredCompatibilityGatingConfig,
+} from "@config/CompatibilityGatingConfig.ts";
+import {
   DEFAULT_ENSEMBLE_DIVERSITY_CONFIG,
   type RequiredEnsembleDiversityConfig,
 } from "@config/EnsembleDiversityConfig.ts";
@@ -126,6 +130,30 @@ export function parseFitnessSharing(
       { integer: true, min: 0 },
     ),
   } as RequiredFitnessSharingConfig;
+}
+
+/** Parse compatibility gating configuration (Issue #2455). */
+export function parseCompatibilityGating(
+  overrides: Record<string, unknown> | undefined,
+): RequiredCompatibilityGatingConfig {
+  const d = DEFAULT_COMPATIBILITY_GATING_CONFIG;
+  return {
+    enabled: typeof overrides?.enabled === "boolean"
+      ? overrides.enabled
+      : d.enabled,
+    power: parseNumber(
+      "Compatibility gating power",
+      overrides?.power,
+      d.power,
+      { min: 0 },
+    ),
+    maxDraws: parseNumber(
+      "Compatibility gating maxDraws",
+      overrides?.maxDraws,
+      d.maxDraws,
+      { integer: true, min: 1 },
+    ),
+  } as RequiredCompatibilityGatingConfig;
 }
 
 /** Parse species stagnation configuration (Issue #2454). */

--- a/test/breed/CompatibilityGating.ts
+++ b/test/breed/CompatibilityGating.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for the soft compatibility-gated cross-species breeding
+ * probability (Issue #2455).
+ *
+ * Verifies that diversity-driven father selection uses a soft
+ * probabilistic gate: candidates are accepted with probability
+ * `compatibility ^ power`, so similar architectures dominate while
+ * rare exploratory hybrids still pass through. After `maxDraws`
+ * rejections the gate falls back to the lowest-compatibility
+ * candidate.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import {
+  Creature,
+  type CreatureExport,
+  CreatureUtil,
+  Selection,
+} from "../../mod.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { Genus } from "@neat/Genus.ts";
+import { findFather, softCompatibilityGate } from "@breed/ParentSelection.ts";
+import { geneticCompatibility } from "@breed/GeneticCompatibility.ts";
+import { DEFAULT_COMPATIBILITY_GATING_CONFIG } from "@config/CompatibilityGatingConfig.ts";
+import {
+  createSeededRng,
+  setRandomNumberGenerator,
+} from "@utils/RandomNumberGenerator.ts";
+
+/**
+ * Builds a creature whose hidden-neuron set matches the given UUIDs.
+ * The shared UUIDs control the compatibility score with the mother.
+ */
+function createCreatureWithHidden(
+  score: number,
+  hiddenUUIDs: string[],
+): Creature {
+  const neurons: CreatureExport["neurons"] = hiddenUUIDs.map((uuid) => ({
+    type: "hidden" as const,
+    uuid,
+    squash: "LOGISTIC",
+    bias: 0.1,
+  }));
+  neurons.push({
+    type: "output",
+    uuid: "output-0",
+    squash: "IDENTITY",
+    bias: 0,
+  });
+
+  const synapses = [
+    { fromUUID: "input-0", toUUID: hiddenUUIDs[0], weight: 0.5 },
+  ];
+  for (let i = 0; i < hiddenUUIDs.length - 1; i++) {
+    synapses.push({
+      fromUUID: hiddenUUIDs[i],
+      toUUID: hiddenUUIDs[i + 1],
+      weight: 0.3,
+    });
+  }
+  synapses.push({
+    fromUUID: hiddenUUIDs[hiddenUUIDs.length - 1],
+    toUUID: "output-0",
+    weight: 0.8,
+  });
+
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons,
+    synapses,
+  };
+  const creature = Creature.fromJSON(json);
+  CreatureUtil.makeUUID(creature);
+  creature.score = score;
+  addTag(creature, "score", score.toString());
+  return creature;
+}
+
+function createGenus(creatures: Creature[]): Genus {
+  const genus = new Genus();
+  for (const creature of creatures) {
+    genus.addCreature(creature);
+  }
+  return genus;
+}
+
+Deno.test(
+  "compatibilityGating - default config has gate enabled with power 1.5 and maxDraws 3",
+  () => {
+    const config = createNeatConfig({ seed: 1 });
+    assertEquals(config.compatibilityGating.enabled, true);
+    assertEquals(config.compatibilityGating.power, 1.5);
+    assertEquals(config.compatibilityGating.maxDraws, 3);
+  },
+);
+
+Deno.test(
+  "compatibilityGating - exported defaults match NeatConfig defaults",
+  () => {
+    const config = createNeatConfig({ seed: 1 });
+    assertEquals(
+      config.compatibilityGating,
+      DEFAULT_COMPATIBILITY_GATING_CONFIG,
+    );
+  },
+);
+
+Deno.test(
+  "compatibilityGating - power: 0 distribution matches today's lowest-compat behaviour (regression)",
+  () => {
+    // Build a mother and a candidate pool whose compatibility scores
+    // span 0..1. With `power: 0` the soft gate is bypassed and
+    // diversity-driven selection falls back to the legacy
+    // lowest-compatibility pick — the prior selection distribution.
+    const motherHidden = [crypto.randomUUID(), crypto.randomUUID()];
+    const mother = createCreatureWithHidden(0.95, motherHidden);
+
+    const fullMatch = createCreatureWithHidden(0.9, [...motherHidden]);
+    const halfMatch = createCreatureWithHidden(0.6, [
+      motherHidden[0],
+      crypto.randomUUID(),
+    ]);
+    const lowestMatch = createCreatureWithHidden(0.4, [
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+    ]);
+    const candidates = [fullMatch, halfMatch, lowestMatch];
+
+    const genus = createGenus([mother, ...candidates]);
+
+    const config = createNeatConfig({
+      selection: Selection.POWER,
+      globalBreedingRate: 1,
+      diversityBreedingRate: 1,
+      compatibilityGating: { enabled: true, power: 0, maxDraws: 3 },
+      seed: 13,
+    });
+
+    // Run repeatedly — every call must select the lowest-compat
+    // candidate, exactly matching the prior behaviour.
+    for (let i = 0; i < 25; i++) {
+      const dad = findFather(mother, genus, config);
+      assert(dad, "Father should be found");
+      // The father returned by findFather is a re-aligned copy whose
+      // UUID may differ; assert by compatibility band instead.
+      const compat = geneticCompatibility(mother, dad);
+      assertEquals(
+        compat,
+        0,
+        `Iteration ${i}: power 0 must reproduce lowest-compat pick (compat=${compat})`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "compatibilityGating - enabled: false also restores prior lowest-compat behaviour",
+  () => {
+    const motherHidden = [crypto.randomUUID(), crypto.randomUUID()];
+    const mother = createCreatureWithHidden(0.95, motherHidden);
+
+    const fullMatch = createCreatureWithHidden(0.9, [...motherHidden]);
+    const lowestMatch = createCreatureWithHidden(0.4, [
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+    ]);
+
+    const genus = createGenus([mother, fullMatch, lowestMatch]);
+    const config = createNeatConfig({
+      selection: Selection.POWER,
+      globalBreedingRate: 1,
+      diversityBreedingRate: 1,
+      compatibilityGating: { enabled: false, power: 1.5, maxDraws: 3 },
+      seed: 21,
+    });
+
+    for (let i = 0; i < 20; i++) {
+      const dad = findFather(mother, genus, config);
+      assert(dad, "Father should be found");
+      const compat = geneticCompatibility(mother, dad);
+      assertEquals(
+        compat,
+        0,
+        `Disabled gate must reproduce legacy lowest-compat pick`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "compatibilityGating - power: 2 selects high-compatibility fathers ≥3× more often than low",
+  () => {
+    // Build a candidate pool covering the high band (compatibility = 1)
+    // and the low band (compatibility = 0). Use enough candidates per
+    // band that the empirical ratio is statistically meaningful.
+    const motherHidden = [
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+    ];
+    const mother = createCreatureWithHidden(0.95, motherHidden);
+
+    const highBand: Creature[] = [];
+    const lowBand: Creature[] = [];
+    for (let i = 0; i < 8; i++) {
+      // High-compat creatures share the mother's full hidden set
+      // (compatibility = 1.0 ≥ 0.7).
+      highBand.push(
+        createCreatureWithHidden(0.5 + i * 0.01, [...motherHidden]),
+      );
+      // Low-compat creatures use entirely fresh UUIDs
+      // (compatibility = 0 ≤ 0.3).
+      lowBand.push(
+        createCreatureWithHidden(0.5 + i * 0.01, [
+          crypto.randomUUID(),
+          crypto.randomUUID(),
+          crypto.randomUUID(),
+        ]),
+      );
+    }
+    const candidates = [...highBand, ...lowBand];
+
+    let highHits = 0;
+    let lowHits = 0;
+    const trials = 600;
+    // Seed the global RNG deterministically so the empirical ratio
+    // is reproducible across machines and runs.
+    setRandomNumberGenerator(createSeededRng(20455));
+    // Use the soft gate directly to isolate the gating distribution
+    // from upstream stochastic decisions in findFather.
+    for (let i = 0; i < trials; i++) {
+      const dad = softCompatibilityGate(mother, candidates, 2, 3);
+      const compat = geneticCompatibility(mother, dad);
+      if (compat >= 0.7) {
+        highHits++;
+      } else if (compat <= 0.3) {
+        lowHits++;
+      }
+    }
+
+    assert(
+      highHits >= 3 * Math.max(lowHits, 1),
+      `power: 2 should select high-compat fathers ≥3× more than low-compat. ` +
+        `highHits=${highHits} lowHits=${lowHits}`,
+    );
+  },
+);
+
+Deno.test(
+  "compatibilityGating - maxDraws fallback returns lowest-compat candidate when no high-compat exists",
+  () => {
+    // All candidates have compatibility 0 with the mother, so no draw
+    // can pass the gate (`0 ^ power = 0` for any power > 0). The gate
+    // must exhaust `maxDraws` and return the lowest-compat candidate.
+    const mother = createCreatureWithHidden(0.95, [
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+    ]);
+    const c1 = createCreatureWithHidden(0.5, [
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+    ]);
+    const c2 = createCreatureWithHidden(0.5, [
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+    ]);
+    const c3 = createCreatureWithHidden(0.5, [crypto.randomUUID()]);
+    const candidates = [c1, c2, c3];
+
+    // Sanity check: every candidate has compatibility 0
+    for (const c of candidates) {
+      assertEquals(
+        geneticCompatibility(mother, c),
+        0,
+        "Setup: every candidate must have compatibility 0",
+      );
+    }
+
+    setRandomNumberGenerator(createSeededRng(11));
+    const dad = softCompatibilityGate(mother, candidates, 2, 3);
+    // Fallback: must be one of the candidates (the lowest-compat
+    // pick — which here is whichever candidate selectMostDiverseFather
+    // returns when all compatibilities tie at 0).
+    assert(
+      candidates.some((c) => c.uuid === dad.uuid),
+      "Fallback should return one of the original candidates",
+    );
+    assertEquals(
+      geneticCompatibility(mother, dad),
+      0,
+      "Fallback must select a lowest-compat (compat=0) candidate",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Replace the hard "lowest-compatibility father" pick on the diversity-driven
breeding path with a soft probabilistic gate so cross-species pairings
happen at a frequency that matches their compatibility — favouring
similar architectures while still allowing rare exploratory hybrids.
The previous behaviour (always pick the most genetically distant
candidate) empirically produces weak hybrids; the soft gate accepts each
candidate with probability `compatibility ^ power` and falls back to the
lowest-compatibility candidate after `maxDraws` rejections so selection
always terminates.

Closes #2455.

## Changes

- **`src/config/CompatibilityGatingConfig.ts`** (new) — adds the
  `CompatibilityGatingConfig` type, `RequiredCompatibilityGatingConfig`,
  and `DEFAULT_COMPATIBILITY_GATING_CONFIG` (`enabled: true`,
  `power: 1.5`, `maxDraws: 3`).
- **`src/config/NeatArguments.ts`** — adds the `compatibilityGating`
  field with documentation describing intent, defaults, and the
  `power: 0` / `enabled: false` fallback semantics.
- **`src/config/NeatOptions.ts`** — adds the partial-override input
  type for `compatibilityGating` to both `NeatOptions` and
  `NeatOptionsInput` (with `CoerceNumeric<>` for CLI string inputs).
- **`src/config/parsers/PopulationParsers.ts`** — adds
  `parseCompatibilityGating()` to merge user overrides over the
  defaults with bounded numeric validation.
- **`src/config/NeatConfigParsers.ts`** — re-exports the new parser.
- **`src/config/NeatConfig.ts`** — wires the parser into
  `createNeatConfig()`.
- **`src/breed/ParentSelection.ts`** — adds `softCompatibilityGate()`
  (the new probabilistic gate) and routes
  `selectFatherFromCandidates()` through it on the diversity-driven
  path when the gate is enabled and `power > 0`. When disabled or
  `power === 0`, selection falls through to the legacy
  `selectMostDiverseFather()` (lowest-compat pick) — exactly the prior
  behaviour. A short comment next to the implementation explains why
  the soft gate is preferred over a hard threshold.

## Evidence

This change is purely backend — no UI to screenshot. Verification is
via the new unit tests plus the full quality gate.

```mermaid
flowchart LR
    A[selectFatherFromCandidates] -->|diversity rate triggers| B{gate enabled<br/>and power > 0?}
    B -->|no| C[selectMostDiverseFather<br/>legacy lowest-compat pick]
    B -->|yes| D[softCompatibilityGate]
    D --> E[draw candidate]
    E --> F{accept with prob<br/>compatibility^power?}
    F -->|yes| G[return candidate]
    F -->|no, draws &lt; maxDraws| E
    F -->|no, exhausted| C
    A -->|fitness path| H[FitnessRanking selectParent]
```

## Test Plan

- `test/breed/CompatibilityGating.ts` (new) covers the three scenarios
  required by the issue:
  - **`power: 0` regression** — with the gate active but `power: 0`,
    diversity-driven selection falls through to the legacy lowest-compat
    pick, exactly matching the prior selection distribution across 25
    repeated draws on a candidate pool spanning the full compatibility
    range.
  - **`enabled: false` regression** — same legacy behaviour is restored
    when the gate is disabled.
  - **`power: 2` distribution** — across 600 seeded draws on a
    16-candidate pool (8 high-compat, 8 low-compat), high-compat
    fathers are selected ≥3× more often than low-compat fathers.
  - **`maxDraws` fallback** — when every candidate has compatibility 0,
    the gate exhausts `maxDraws` rejections and returns the
    lowest-compat candidate (the bounded fallback path).
  - Plus default-value sanity checks (`enabled: true`, `power: 1.5`,
    `maxDraws: 3`).
- `./quality.sh --skip-discovery --skip-wasm` passes (6271 tests).
- Existing `test/breed/DiversityBreeding.ts` and `test/breed/ParentSelection.ts`
  continue to pass — no behaviour change on the standard fitness path.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2455 -->