### PR TITLE
Docs: Document no-@std/log logging policy (#2480)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,58 @@ documentation:
 - Prefer smaller, focused files over large monolithic ones (Single
   Responsibility Principle)
 
+### 📝 Logging Policy
+
+NEAT-AI uses its own pluggable `Logger` abstraction in `src/utils/Logger.ts`
+(introduced in #1398, which removed ~350 scattered `console.*` calls). The
+project deliberately does **not** depend on `@std/log`.
+
+**Rules:**
+
+1. **All internal logging MUST go through `getLogger()`** from
+   `src/utils/Logger.ts`. Do not add new `console.*` calls in production code
+   under `src/`.
+2. **`@std/log` (`jsr:@std/log`) MUST NOT be added to `deno.json`'s `imports`**
+   and MUST NOT appear as a transitive dependency. Rationale: `@std/log` is
+   marked **unstable** on JSR (see [jsr.io/@std/log](https://jsr.io/@std/log))
+   and the existing `Logger` interface is consumer-pluggable, so there is no
+   benefit to taking on an unstable dependency.
+3. **Consumers wanting structured / external logging integration** (pino,
+   winston, cloud logging) inject a custom `Logger` via `NeatOptions.logger` or
+   call `setLogger()` directly:
+
+   ```typescript
+   import { Neat } from "@stsoftware/neat-ai";
+   import { setLogger } from "@stsoftware/neat-ai/utils/Logger";
+
+   // Option A — inject via NeatOptions
+   const neat = new Neat(input, output, fitness, {
+     logger: {
+       debug: (...a) => myPino.debug({ args: a }),
+       info: (...a) => myPino.info({ args: a }),
+       warn: (...a) => myPino.warn({ args: a }),
+       error: (...a) => myPino.error({ args: a }),
+     },
+   });
+
+   // Option B — set globally
+   setLogger(myCustomLogger);
+   ```
+
+4. **Missing logging features** (e.g. structured key/value pairs, async sinks)
+   should be raised as a separate issue against `src/utils/Logger.ts`. Do not
+   reach for `@std/log` to fill the gap.
+
+#### Audit
+
+The current tree contains zero `@std/log` references. Confirm with:
+
+```bash
+grep -r '@std/log\|jsr:@std/log' src test mod.ts deno.json
+deno info --json mod.ts | grep -o '"specifier": "[^"]*"' | grep '@std/log' \
+  || echo 'no @std/log dependency'
+```
+
 ### 🧪 Testing
 
 #### Unit Tests vs Benchmarks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -444,6 +444,16 @@ The project enforces these lint rules (configured in `deno.json`):
 
 For the complete set of conventions, see [AGENTS.md](./AGENTS.md).
 
+### 📝 Logging
+
+All internal logging MUST go through `getLogger()` from `src/utils/Logger.ts`.
+Do **not** add `@std/log` (`jsr:@std/log`) to `deno.json` or rely on it
+transitively — it is unstable on JSR and the in-tree `Logger` interface is
+already consumer-pluggable. See the
+[Logging Policy section in AGENTS.md](./AGENTS.md#-logging-policy) for the
+rationale, the audit command, and an example of injecting a custom `Logger` via
+`NeatOptions.logger` / `setLogger()`.
+
 ## 📁 Project Structure
 
 ```

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.39",
+  "version": "3.1.40",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2480.md
+++ b/docs/pr-summary-2480.md
@@ -1,0 +1,58 @@
+## Summary
+
+Documents the project's "no `@std/log`" logging policy. NEAT-AI uses its own
+pluggable `Logger` abstraction in `src/utils/Logger.ts` (introduced in #1398)
+and must never depend on `@std/log` — direct or transitive — because that
+package is marked unstable on JSR and the in-tree `Logger` interface is already
+consumer-pluggable. Closes #2480.
+
+Documentation-only — no code under `src/` was changed.
+
+## Changes
+
+- **`AGENTS.md`** — new `📝 Logging Policy` section (placed directly after the
+  Style section, before Testing) that:
+  - Names `@std/log` and explains why it must not be used.
+  - Lists four explicit rules (use `getLogger()`, no `@std/log` import, inject
+    custom `Logger` for external integrations, raise issues against
+    `src/utils/Logger.ts` for missing features).
+  - Includes a 5–10 line code example showing both injection paths
+    (`NeatOptions.logger` and `setLogger()`).
+  - Documents the audit commands so anyone can re-verify the zero-reference
+    state.
+- **`CONTRIBUTING.md`** — short cross-reference under `🎨 Code Style` linking to
+  the new AGENTS.md policy section, with the headline rule duplicated for
+  visibility.
+
+## Evidence — Audit (zero `@std/log` references)
+
+```
+$ grep -r '@std/log\|jsr:@std/log' src test mod.ts deno.json
+$ deno info --json mod.ts | grep -o '"specifier": "[^"]*"' | grep '@std/log' \
+    || echo 'no @std/log dependency'
+no @std/log dependency
+```
+
+Both commands return empty / "no @std/log dependency" — the current tree has
+zero `@std/log` references and this PR locks that state in via documentation.
+
+## Test Plan
+
+- Documentation-only change. No new tests required.
+- `./quality.sh --lint-only` passes — formatting, lint, and bash script syntax
+  checks succeed.
+- The companion sub-issue (referenced from #2479) covers the automated guardrail
+  test that locks the same state in via assertion.
+
+## Acceptance Criteria
+
+- [x] `AGENTS.md` contains a new "Logging Policy" section that names `@std/log`
+      and explains why it must not be used.
+- [x] The section includes a short code example showing how a consumer injects a
+      custom `Logger` via `NeatOptions` / `setLogger()`.
+- [x] `CONTRIBUTING.md` links to the new AGENTS.md section and duplicates the
+      headline rule for visibility.
+- [x] PR description includes the audit grep / `deno info` output proving zero
+      `@std/log` references exist today.
+- [x] `./quality.sh` lint pass succeeds.
+- [x] No source code under `src/` is changed — documentation-only PR.


### PR DESCRIPTION
## Summary

Documents the project's "no `@std/log`" logging policy. NEAT-AI uses its own
pluggable `Logger` abstraction in `src/utils/Logger.ts` (introduced in #1398)
and must never depend on `@std/log` — direct or transitive — because that
package is marked unstable on JSR and the in-tree `Logger` interface is already
consumer-pluggable. Closes #2480.

Documentation-only — no code under `src/` was changed.

## Changes

- **`AGENTS.md`** — new `📝 Logging Policy` section (placed directly after the
  Style section, before Testing) that:
  - Names `@std/log` and explains why it must not be used.
  - Lists four explicit rules (use `getLogger()`, no `@std/log` import, inject
    custom `Logger` for external integrations, raise issues against
    `src/utils/Logger.ts` for missing features).
  - Includes a 5–10 line code example showing both injection paths
    (`NeatOptions.logger` and `setLogger()`).
  - Documents the audit commands so anyone can re-verify the zero-reference
    state.
- **`CONTRIBUTING.md`** — short cross-reference under `🎨 Code Style` linking to
  the new AGENTS.md policy section, with the headline rule duplicated for
  visibility.

## Evidence — Audit (zero `@std/log` references)

```
$ grep -r '@std/log\|jsr:@std/log' src test mod.ts deno.json
$ deno info --json mod.ts | grep -o '"specifier": "[^"]*"' | grep '@std/log' \
    || echo 'no @std/log dependency'
no @std/log dependency
```

Both commands return empty / "no @std/log dependency" — the current tree has
zero `@std/log` references and this PR locks that state in via documentation.

## Test Plan

- Documentation-only change. No new tests required.
- `./quality.sh --lint-only` passes — formatting, lint, and bash script syntax
  checks succeed.
- The companion sub-issue (referenced from #2479) covers the automated guardrail
  test that locks the same state in via assertion.

## Acceptance Criteria

- [x] `AGENTS.md` contains a new "Logging Policy" section that names `@std/log`
      and explains why it must not be used.
- [x] The section includes a short code example showing how a consumer injects a
      custom `Logger` via `NeatOptions` / `setLogger()`.
- [x] `CONTRIBUTING.md` links to the new AGENTS.md section and duplicates the
      headline rule for visibility.
- [x] PR description includes the audit grep / `deno info` output proving zero
      `@std/log` references exist today.
- [x] `./quality.sh` lint pass succeeds.
- [x] No source code under `src/` is changed — documentation-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)