### PR TITLE
Test: Add @std/log guardrail (#2481)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.40",
+  "version": "3.1.41",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.41",
+  "version": "3.1.42",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/evidence/issue-2481-guardrail-failure.txt
+++ b/docs/evidence/issue-2481-guardrail-failure.txt
@@ -1,0 +1,48 @@
+=== Scenario 1: src file contains @std/log import ===
+
+    [Diff] Actual / Expected
+
+
+-   [
+-     {
+-       file: "src/utils/__FakeStdLogProbe.ts",
+-       line: 2,
+-       text: 'import { getLogger } from "@std/log";',
+-     },
+-   ]
++   []
+
+  throw new AssertionError(message);
+        ^
+    at assertEquals (https://jsr.io/@std/assert/1.0.19/equals.ts:67:9)
+    at file:///Users/nigelleck/auto-issue-work/NEAT-AI/test/utils/NoStdLogDependency.ts:183:3
+
+ FAILURES 
+
+no source file imports @std/log => ./test/utils/NoStdLogDependency.ts:167:6
+
+FAILED | 7 passed | 1 failed (134ms)
+
+error: Test failed
+
+=== Scenario 2: deno.json imports include @std/log ===
+
+
+-   [
+-     'key "@std/log"',
+-     'value "jsr:@std/log@^0.224" (key "@std/log")',
+-   ]
++   []
+
+  throw new AssertionError(message);
+        ^
+    at assertEquals (https://jsr.io/@std/assert/1.0.19/equals.ts:67:9)
+    at file:///Users/nigelleck/auto-issue-work/NEAT-AI/test/utils/NoStdLogDependency.ts:125:3
+
+ FAILURES 
+
+deno.json imports do not include @std/log => ./test/utils/NoStdLogDependency.ts:110:6
+
+FAILED | 7 passed | 1 failed (137ms)
+
+error: Test failed

--- a/docs/pr-summary-2481.md
+++ b/docs/pr-summary-2481.md
@@ -2,20 +2,20 @@
 
 ## Summary
 
-Adds `test/utils/NoStdLogDependency.ts`, a guardrail unit test that fails
-the build if `@std/log` (or `jsr:@std/log`) is ever introduced as a
-direct dependency of NEAT-AI. The check has two layers:
+Adds `test/utils/NoStdLogDependency.ts`, a guardrail unit test that fails the
+build if `@std/log` (or `jsr:@std/log`) is ever introduced as a direct
+dependency of NEAT-AI. The check has two layers:
 
 1. Parses `deno.json` and asserts no `imports` key or value resolves to
    `@std/log`.
 2. Walks `src/**/*.ts`, `test/**/*.ts`, and `mod.ts` and asserts no file
-   contains a banned `import` statement, using a specifier-anchored
-   regex so benign substrings (`getLogger`, `LogLevel`, `console.log`,
-   JSDoc prose) do not trigger false positives.
+   contains a banned `import` statement, using a specifier-anchored regex so
+   benign substrings (`getLogger`, `LogLevel`, `console.log`, JSDoc prose) do
+   not trigger false positives.
 
-The "richer" `deno info --json` layer described as *optional* in the
-issue was skipped — the deno.json + source-walk check is sufficient and
-keeps the test under 5 seconds locally (~140 ms in practice).
+The "richer" `deno info --json` layer described as _optional_ in the issue was
+skipped — the deno.json + source-walk check is sufficient and keeps the test
+under 5 seconds locally (~140 ms in practice).
 
 Closes #2481.
 
@@ -58,8 +58,7 @@ FAILED | 7 passed | 1 failed
 
 ### Failure scenario 2 — fake `deno.json` entry
 
-Adding `"@std/log": "jsr:@std/log@^0.224"` to `deno.json` `imports`
-produces:
+Adding `"@std/log": "jsr:@std/log@^0.224"` to `deno.json` `imports` produces:
 
 ```
 -   [
@@ -93,16 +92,15 @@ Tests added in `test/utils/NoStdLogDependency.ts`:
 - `BANNED_LOG_IMPORT_RE flags 'from "jsr:@std/log"'` — positive with JSR prefix
 - `BANNED_LOG_IMPORT_RE flags submodule imports` — `@std/log/levels`
 - `BANNED_LOG_IMPORT_RE flags side-effect imports` — bare `import "@std/log"`
-- `BANNED_LOG_IMPORT_RE does not false-positive on benign 'log' usages` —
-  covers `getLogger`, `LogLevel`, `console.log`, JSDoc/comments, and the
-  hypothetical sibling specifier `@std/logger-shim`
-- `findBannedLogImports reports line numbers for offending sources` —
-  asserts the helper returns the matching line number
-- `deno.json imports do not include @std/log` — happy path against
-  current `deno.json`
-- `no source file imports @std/log` — happy path scan of `src/`,
-  `test/`, and `mod.ts`
+- `BANNED_LOG_IMPORT_RE does not false-positive on benign 'log' usages` — covers
+  `getLogger`, `LogLevel`, `console.log`, JSDoc/comments, and the hypothetical
+  sibling specifier `@std/logger-shim`
+- `findBannedLogImports reports line numbers for offending sources` — asserts
+  the helper returns the matching line number
+- `deno.json imports do not include @std/log` — happy path against current
+  `deno.json`
+- `no source file imports @std/log` — happy path scan of `src/`, `test/`, and
+  `mod.ts`
 
-Failure behaviour was verified manually by injecting a fake source file
-and a fake `deno.json` entry; both reverted before commit (see Evidence
-above).
+Failure behaviour was verified manually by injecting a fake source file and a
+fake `deno.json` entry; both reverted before commit (see Evidence above).

--- a/docs/pr-summary-2481.md
+++ b/docs/pr-summary-2481.md
@@ -1,0 +1,108 @@
+# Issue #2481 — Guardrail test: no `@std/log` dependency
+
+## Summary
+
+Adds `test/utils/NoStdLogDependency.ts`, a guardrail unit test that fails
+the build if `@std/log` (or `jsr:@std/log`) is ever introduced as a
+direct dependency of NEAT-AI. The check has two layers:
+
+1. Parses `deno.json` and asserts no `imports` key or value resolves to
+   `@std/log`.
+2. Walks `src/**/*.ts`, `test/**/*.ts`, and `mod.ts` and asserts no file
+   contains a banned `import` statement, using a specifier-anchored
+   regex so benign substrings (`getLogger`, `LogLevel`, `console.log`,
+   JSDoc prose) do not trigger false positives.
+
+The "richer" `deno info --json` layer described as *optional* in the
+issue was skipped — the deno.json + source-walk check is sufficient and
+keeps the test under 5 seconds locally (~140 ms in practice).
+
+Closes #2481.
+
+## Evidence
+
+### Happy-path run against current tree
+
+```
+running 8 tests from ./test/utils/NoStdLogDependency.ts
+BANNED_LOG_IMPORT_RE flags `from "@std/log"` ... ok (0ms)
+BANNED_LOG_IMPORT_RE flags `from "jsr:@std/log"` ... ok (0ms)
+BANNED_LOG_IMPORT_RE flags submodule imports ... ok (0ms)
+BANNED_LOG_IMPORT_RE flags side-effect imports ... ok (0ms)
+BANNED_LOG_IMPORT_RE does not false-positive on benign 'log' usages ... ok (0ms)
+findBannedLogImports reports line numbers for offending sources ... ok (0ms)
+deno.json imports do not include @std/log ... ok (0ms)
+no source file imports @std/log ... ok (126ms)
+
+ok | 8 passed | 0 failed (136ms)
+```
+
+### Failure scenario 1 — fake source import
+
+Adding `src/utils/__FakeStdLogProbe.ts` containing
+`import { getLogger } from "@std/log";` produces:
+
+```
+-   [
+-     {
+-       file: "src/utils/__FakeStdLogProbe.ts",
+-       line: 2,
+-       text: 'import { getLogger } from "@std/log";',
+-     },
+-   ]
++   []
+
+no source file imports @std/log => ./test/utils/NoStdLogDependency.ts:167:6
+FAILED | 7 passed | 1 failed
+```
+
+### Failure scenario 2 — fake `deno.json` entry
+
+Adding `"@std/log": "jsr:@std/log@^0.224"` to `deno.json` `imports`
+produces:
+
+```
+-   [
+-     'key "@std/log"',
+-     'value "jsr:@std/log@^0.224" (key "@std/log")',
+-   ]
++   []
+
+deno.json imports do not include @std/log => ./test/utils/NoStdLogDependency.ts:110:6
+FAILED | 7 passed | 1 failed
+```
+
+Full failure output is preserved in
+`docs/evidence/issue-2481-guardrail-failure.txt`.
+
+### Architecture
+
+```mermaid
+flowchart LR
+    A[deno.json imports] --> C[NoStdLogDependency.ts]
+    B[src/**, test/**, mod.ts] --> C
+    C -->|fail if match| D[Build fails]
+    C -->|no match| E[Build passes]
+```
+
+## Test Plan
+
+Tests added in `test/utils/NoStdLogDependency.ts`:
+
+- `BANNED_LOG_IMPORT_RE flags 'from "@std/log"'` — positive happy path
+- `BANNED_LOG_IMPORT_RE flags 'from "jsr:@std/log"'` — positive with JSR prefix
+- `BANNED_LOG_IMPORT_RE flags submodule imports` — `@std/log/levels`
+- `BANNED_LOG_IMPORT_RE flags side-effect imports` — bare `import "@std/log"`
+- `BANNED_LOG_IMPORT_RE does not false-positive on benign 'log' usages` —
+  covers `getLogger`, `LogLevel`, `console.log`, JSDoc/comments, and the
+  hypothetical sibling specifier `@std/logger-shim`
+- `findBannedLogImports reports line numbers for offending sources` —
+  asserts the helper returns the matching line number
+- `deno.json imports do not include @std/log` — happy path against
+  current `deno.json`
+- `no source file imports @std/log` — happy path scan of `src/`,
+  `test/`, and `mod.ts`
+
+Failure behaviour was verified manually by injecting a fake source file
+and a fake `deno.json` entry; both reverted before commit (see Evidence
+above).

--- a/test/utils/NoStdLogDependency.ts
+++ b/test/utils/NoStdLogDependency.ts
@@ -1,0 +1,191 @@
+/**
+ * Guardrail test for Issue #2481.
+ *
+ * NEAT-AI deliberately does **not** depend on `@std/log` (it is marked
+ * unstable on JSR; the project ships its own pluggable Logger in
+ * `src/utils/Logger.ts`). This test fails the build if `@std/log` is
+ * ever introduced as a direct dependency — either via `deno.json`'s
+ * `imports` map or via an `import` statement anywhere under `src/`,
+ * `test/`, or `mod.ts`.
+ *
+ * See AGENTS.md > Logging Policy for the rationale and consumer
+ * extension points (`NeatOptions.logger`, `setLogger`).
+ */
+
+import { assertEquals, assertMatch, assertNotMatch } from "@std/assert";
+import { walk } from "@std/fs";
+import { fromFileUrl, join, relative } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const SELF_PATH = fromFileUrl(import.meta.url);
+
+/**
+ * Specifier-anchored regex matching banned `@std/log` imports.
+ *
+ * Matches both `import "..."` and `import ... from "..."` forms, with
+ * an optional `jsr:` prefix. The `from`/`import` anchor prevents
+ * false-positive substring matches against benign identifiers like
+ * `getLogger`, `LogLevel`, `console.log`, or JSDoc prose containing
+ * the string `@std/log`.
+ */
+export const BANNED_LOG_IMPORT_RE =
+  /(?:from|import)\s+["']\s*(?:jsr:)?@std\/log(?:["'/@]|$)/;
+
+/** Match deno.json import keys/values that resolve to `@std/log`. */
+const BANNED_LOG_SPECIFIER_RE = /^(?:jsr:)?@std\/log(?:[/@"']|$)/;
+
+/**
+ * Scan source text for banned `@std/log` imports. Returns one entry
+ * per matched line.
+ */
+export function findBannedLogImports(
+  source: string,
+): { line: number; text: string }[] {
+  const offences: { line: number; text: string }[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (BANNED_LOG_IMPORT_RE.test(lines[i])) {
+      offences.push({ line: i + 1, text: lines[i] });
+    }
+  }
+  return offences;
+}
+
+Deno.test('BANNED_LOG_IMPORT_RE flags `from "@std/log"`', () => {
+  // Built by concatenation so this fixture itself does not show up as a
+  // banned import when the test file is scanned.
+  const positive = 'import { getLogger } from "' + "@std" + '/log";';
+  assertMatch(positive, BANNED_LOG_IMPORT_RE);
+});
+
+Deno.test('BANNED_LOG_IMPORT_RE flags `from "jsr:@std/log"`', () => {
+  const positive = 'import { getLogger } from "jsr:' + "@std" + '/log";';
+  assertMatch(positive, BANNED_LOG_IMPORT_RE);
+});
+
+Deno.test("BANNED_LOG_IMPORT_RE flags submodule imports", () => {
+  const positive = 'import { LevelName } from "' + "@std" + '/log/levels";';
+  assertMatch(positive, BANNED_LOG_IMPORT_RE);
+});
+
+Deno.test("BANNED_LOG_IMPORT_RE flags side-effect imports", () => {
+  const positive = 'import "' + "@std" + '/log";';
+  assertMatch(positive, BANNED_LOG_IMPORT_RE);
+});
+
+Deno.test("BANNED_LOG_IMPORT_RE does not false-positive on benign 'log' usages", () => {
+  const benign = [
+    // Local Logger import — different module path entirely.
+    'import { getLogger } from "@utils/Logger.ts";',
+    // Identifier that happens to contain "Log".
+    'const level: LogLevel = "info";',
+    // String literal logged to the console — no `from`/`import` anchor.
+    'console.log("@std/log");',
+    // Hyperlink-style mention in a comment.
+    "// see jsr.io/@std/log for the unstable marker",
+    // JSDoc paragraph mentioning the package by name.
+    "/** Reference: @std/log is unstable, do not use. */",
+    // Hypothetical sibling package — must not be flagged by the boundary.
+    'import { foo } from "@std/logger-shim";',
+  ];
+  for (const line of benign) {
+    assertNotMatch(line, BANNED_LOG_IMPORT_RE);
+  }
+});
+
+Deno.test("findBannedLogImports reports line numbers for offending sources", () => {
+  const source = [
+    "// header",
+    'import { x } from "@utils/Logger.ts";',
+    "",
+    'import { getLogger } from "' + "@std" + '/log";',
+    "console.log('done');",
+  ].join("\n");
+
+  const hits = findBannedLogImports(source);
+  assertEquals(hits.length, 1);
+  assertEquals(hits[0].line, 4);
+});
+
+Deno.test("deno.json imports do not include @std/log", async () => {
+  const denoJsonPath = join(REPO_ROOT, "deno.json");
+  const config = JSON.parse(await Deno.readTextFile(denoJsonPath)) as {
+    imports?: Record<string, string>;
+  };
+  const imports = config.imports ?? {};
+  const offences: string[] = [];
+  for (const [key, value] of Object.entries(imports)) {
+    if (BANNED_LOG_SPECIFIER_RE.test(key)) {
+      offences.push(`key "${key}"`);
+    }
+    if (BANNED_LOG_SPECIFIER_RE.test(String(value))) {
+      offences.push(`value "${value}" (key "${key}")`);
+    }
+  }
+  assertEquals(
+    offences,
+    [],
+    `deno.json imports must not reference @std/log: ${offences.join(", ")}`,
+  );
+});
+
+async function collectScanTargets(): Promise<string[]> {
+  const roots = ["src", "test", "mod.ts"];
+  const stats = await Promise.all(
+    roots.map(async (root) => {
+      const fullPath = join(REPO_ROOT, root);
+      try {
+        const stat = await Deno.stat(fullPath);
+        return { fullPath, stat };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const fileLists = await Promise.all(
+    stats.map(async (entry) => {
+      if (entry === null) return [];
+      if (entry.stat.isFile) return [entry.fullPath];
+      const paths: string[] = [];
+      for await (
+        const walked of walk(entry.fullPath, {
+          exts: [".ts"],
+          includeDirs: false,
+          followSymlinks: false,
+        })
+      ) {
+        paths.push(walked.path);
+      }
+      return paths;
+    }),
+  );
+
+  return fileLists.flat().filter((path) => path !== SELF_PATH);
+}
+
+Deno.test("no source file imports @std/log", async () => {
+  const targets = await collectScanTargets();
+
+  const perFile = await Promise.all(
+    targets.map(async (absPath) => {
+      const text = await Deno.readTextFile(absPath);
+      return findBannedLogImports(text).map((hit) => ({
+        file: relative(REPO_ROOT, absPath),
+        line: hit.line,
+        text: hit.text,
+      }));
+    }),
+  );
+
+  const offences = perFile.flat();
+
+  assertEquals(
+    offences,
+    [],
+    "Forbidden @std/log imports found:\n" +
+      offences
+        .map((o) => `  ${o.file}:${o.line}: ${o.text.trim()}`)
+        .join("\n"),
+  );
+});


### PR DESCRIPTION
# Issue #2481 — Guardrail test: no `@std/log` dependency

## Summary

Adds `test/utils/NoStdLogDependency.ts`, a guardrail unit test that fails
the build if `@std/log` (or `jsr:@std/log`) is ever introduced as a
direct dependency of NEAT-AI. The check has two layers:

1. Parses `deno.json` and asserts no `imports` key or value resolves to
   `@std/log`.
2. Walks `src/**/*.ts`, `test/**/*.ts`, and `mod.ts` and asserts no file
   contains a banned `import` statement, using a specifier-anchored
   regex so benign substrings (`getLogger`, `LogLevel`, `console.log`,
   JSDoc prose) do not trigger false positives.

The "richer" `deno info --json` layer described as *optional* in the
issue was skipped — the deno.json + source-walk check is sufficient and
keeps the test under 5 seconds locally (~140 ms in practice).

Closes #2481.

## Evidence

### Happy-path run against current tree

```
running 8 tests from ./test/utils/NoStdLogDependency.ts
BANNED_LOG_IMPORT_RE flags `from "@std/log"` ... ok (0ms)
BANNED_LOG_IMPORT_RE flags `from "jsr:@std/log"` ... ok (0ms)
BANNED_LOG_IMPORT_RE flags submodule imports ... ok (0ms)
BANNED_LOG_IMPORT_RE flags side-effect imports ... ok (0ms)
BANNED_LOG_IMPORT_RE does not false-positive on benign 'log' usages ... ok (0ms)
findBannedLogImports reports line numbers for offending sources ... ok (0ms)
deno.json imports do not include @std/log ... ok (0ms)
no source file imports @std/log ... ok (126ms)

ok | 8 passed | 0 failed (136ms)
```

### Failure scenario 1 — fake source import

Adding `src/utils/__FakeStdLogProbe.ts` containing
`import { getLogger } from "@std/log";` produces:

```
-   [
-     {
-       file: "src/utils/__FakeStdLogProbe.ts",
-       line: 2,
-       text: 'import { getLogger } from "@std/log";',
-     },
-   ]
+   []

no source file imports @std/log => ./test/utils/NoStdLogDependency.ts:167:6
FAILED | 7 passed | 1 failed
```

### Failure scenario 2 — fake `deno.json` entry

Adding `"@std/log": "jsr:@std/log@^0.224"` to `deno.json` `imports`
produces:

```
-   [
-     'key "@std/log"',
-     'value "jsr:@std/log@^0.224" (key "@std/log")',
-   ]
+   []

deno.json imports do not include @std/log => ./test/utils/NoStdLogDependency.ts:110:6
FAILED | 7 passed | 1 failed
```

Full failure output is preserved in
`docs/evidence/issue-2481-guardrail-failure.txt`.

### Architecture

```mermaid
flowchart LR
    A[deno.json imports] --> C[NoStdLogDependency.ts]
    B[src/**, test/**, mod.ts] --> C
    C -->|fail if match| D[Build fails]
    C -->|no match| E[Build passes]
```

## Test Plan

Tests added in `test/utils/NoStdLogDependency.ts`:

- `BANNED_LOG_IMPORT_RE flags 'from "@std/log"'` — positive happy path
- `BANNED_LOG_IMPORT_RE flags 'from "jsr:@std/log"'` — positive with JSR prefix
- `BANNED_LOG_IMPORT_RE flags submodule imports` — `@std/log/levels`
- `BANNED_LOG_IMPORT_RE flags side-effect imports` — bare `import "@std/log"`
- `BANNED_LOG_IMPORT_RE does not false-positive on benign 'log' usages` —
  covers `getLogger`, `LogLevel`, `console.log`, JSDoc/comments, and the
  hypothetical sibling specifier `@std/logger-shim`
- `findBannedLogImports reports line numbers for offending sources` —
  asserts the helper returns the matching line number
- `deno.json imports do not include @std/log` — happy path against
  current `deno.json`
- `no source file imports @std/log` — happy path scan of `src/`,
  `test/`, and `mod.ts`

Failure behaviour was verified manually by injecting a fake source file
and a fake `deno.json` entry; both reverted before commit (see Evidence
above).