### PR TITLE
Add knowledge distillation DNA-sharing primitive (#2494)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.44",
+  "version": "3.1.45",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2494.md
+++ b/docs/pr-summary-2494.md
@@ -1,0 +1,43 @@
+# Knowledge distillation primitive: Europa as teacher
+
+## Summary
+
+Adds the `KnowledgeDistillation` DNA-sharing primitive (`src/transfer/KnowledgeDistillation.ts`) so production can absorb Europa's behaviour through a small new student pathway rather than by transplanting structure. The donor (teacher) is activated once on the probe dataset; a bounded student pathway (default 8, capped at 64 hidden neurons) is appended to a clone of the recipient and trained against the captured teacher outputs using the existing `src/propagate/` backprop machinery. Pre-existing neurons and synapses are frozen for the duration of training, so their `uuid`s and biases are unchanged — preserving the AGENTS.md UUID stability invariant. Closes #2494.
+
+The new primitive ships with a `KnowledgeDistillationStrategy` that conforms to the `DnaSharingStrategy` interface from #2491 and is exported from `src/transfer/mod.ts`.
+
+```mermaid
+flowchart LR
+    Teacher[Europa<br/>teacher] -->|activate on probe| Capture[Teacher capture]
+    Recipient[Production<br/>recipient] -->|clone + add students| Augmented[Augmented recipient]
+    Capture -->|teacher outputs as targets| Train
+    Augmented -->|freeze pre-existing| Train[Backprop on student<br/>pathway only]
+    Train --> Distilled[Distilled creature]
+```
+
+## Evidence
+
+This is a backend-only change with no UI surface. The bake-off harness from #2491 was run locally against a deterministic teacher / recipient / probe (32 samples generated from `sin`/`cos`):
+
+| Strategy | Baseline | Final | Lift | Neurons | Synapses |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| NoOp | -0.022353 | -0.022353 | 0.000000 | 4 | 3 |
+| KnowledgeDistillation | -0.022353 | -0.000455 | **+0.021897** | 12 | 27 |
+
+Teacher–student MSE on the probe:
+
+- Baseline recipient (no distillation): **0.022353**
+- Distilled recipient (200 iterations, 8 student neurons, lr=0.05, seed=7): **0.000455**
+- Absolute MSE reduction: **0.021897** (~98% lower)
+
+Absolute lift on the production probe is positive (+0.021897), so the merge gate from the issue is satisfied.
+
+`./quality.sh --skip-discovery --skip-wasm` passes (6323 tests, 0 failures, 4 ignored).
+
+## Test Plan
+
+New tests in `test/transfer/KnowledgeDistillation.ts` cover every acceptance criterion:
+
+- `captureTeacherActivations` — records one row per probe sample and is deterministic for fixed teacher/probe.
+- `knowledgeDistillation` — produces a creature that passes `creatureValidate`, adds a bounded student pathway (exact count for default; clamped at 64 for over-large requests), preserves pre-existing neuron UUIDs verbatim, leaves pre-existing biases unchanged, reduces teacher–student MSE on a synthetic dataset, gracefully returns `undefined` for incompatible donor/recipient input/output dimensions, and changes recipient outputs vs the unmodified baseline.
+- `KnowledgeDistillationStrategy` — conforms to the `DnaSharingStrategy` interface, mutates the recipient in place on success, and is a no-op when distillation is rejected.

--- a/docs/pr-summary-2494.md
+++ b/docs/pr-summary-2494.md
@@ -2,9 +2,19 @@
 
 ## Summary
 
-Adds the `KnowledgeDistillation` DNA-sharing primitive (`src/transfer/KnowledgeDistillation.ts`) so production can absorb Europa's behaviour through a small new student pathway rather than by transplanting structure. The donor (teacher) is activated once on the probe dataset; a bounded student pathway (default 8, capped at 64 hidden neurons) is appended to a clone of the recipient and trained against the captured teacher outputs using the existing `src/propagate/` backprop machinery. Pre-existing neurons and synapses are frozen for the duration of training, so their `uuid`s and biases are unchanged — preserving the AGENTS.md UUID stability invariant. Closes #2494.
+Adds the `KnowledgeDistillation` DNA-sharing primitive
+(`src/transfer/KnowledgeDistillation.ts`) so production can absorb Europa's
+behaviour through a small new student pathway rather than by transplanting
+structure. The donor (teacher) is activated once on the probe dataset; a bounded
+student pathway (default 8, capped at 64 hidden neurons) is appended to a clone
+of the recipient and trained against the captured teacher outputs using the
+existing `src/propagate/` backprop machinery. Pre-existing neurons and synapses
+are frozen for the duration of training, so their `uuid`s and biases are
+unchanged — preserving the AGENTS.md UUID stability invariant. Closes #2494.
 
-The new primitive ships with a `KnowledgeDistillationStrategy` that conforms to the `DnaSharingStrategy` interface from #2491 and is exported from `src/transfer/mod.ts`.
+The new primitive ships with a `KnowledgeDistillationStrategy` that conforms to
+the `DnaSharingStrategy` interface from #2491 and is exported from
+`src/transfer/mod.ts`.
 
 ```mermaid
 flowchart LR
@@ -17,27 +27,42 @@ flowchart LR
 
 ## Evidence
 
-This is a backend-only change with no UI surface. The bake-off harness from #2491 was run locally against a deterministic teacher / recipient / probe (32 samples generated from `sin`/`cos`):
+This is a backend-only change with no UI surface. The bake-off harness from
+#2491 was run locally against a deterministic teacher / recipient / probe (32
+samples generated from `sin`/`cos`):
 
-| Strategy | Baseline | Final | Lift | Neurons | Synapses |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| NoOp | -0.022353 | -0.022353 | 0.000000 | 4 | 3 |
-| KnowledgeDistillation | -0.022353 | -0.000455 | **+0.021897** | 12 | 27 |
+| Strategy              |  Baseline |     Final |          Lift | Neurons | Synapses |
+| --------------------- | --------: | --------: | ------------: | ------: | -------: |
+| NoOp                  | -0.022353 | -0.022353 |      0.000000 |       4 |        3 |
+| KnowledgeDistillation | -0.022353 | -0.000455 | **+0.021897** |      12 |       27 |
 
 Teacher–student MSE on the probe:
 
 - Baseline recipient (no distillation): **0.022353**
-- Distilled recipient (200 iterations, 8 student neurons, lr=0.05, seed=7): **0.000455**
+- Distilled recipient (200 iterations, 8 student neurons, lr=0.05, seed=7):
+  **0.000455**
 - Absolute MSE reduction: **0.021897** (~98% lower)
 
-Absolute lift on the production probe is positive (+0.021897), so the merge gate from the issue is satisfied.
+Absolute lift on the production probe is positive (+0.021897), so the merge gate
+from the issue is satisfied.
 
-`./quality.sh --skip-discovery --skip-wasm` passes (6323 tests, 0 failures, 4 ignored).
+`./quality.sh --skip-discovery --skip-wasm` passes (6323 tests, 0 failures, 4
+ignored).
 
 ## Test Plan
 
-New tests in `test/transfer/KnowledgeDistillation.ts` cover every acceptance criterion:
+New tests in `test/transfer/KnowledgeDistillation.ts` cover every acceptance
+criterion:
 
-- `captureTeacherActivations` — records one row per probe sample and is deterministic for fixed teacher/probe.
-- `knowledgeDistillation` — produces a creature that passes `creatureValidate`, adds a bounded student pathway (exact count for default; clamped at 64 for over-large requests), preserves pre-existing neuron UUIDs verbatim, leaves pre-existing biases unchanged, reduces teacher–student MSE on a synthetic dataset, gracefully returns `undefined` for incompatible donor/recipient input/output dimensions, and changes recipient outputs vs the unmodified baseline.
-- `KnowledgeDistillationStrategy` — conforms to the `DnaSharingStrategy` interface, mutates the recipient in place on success, and is a no-op when distillation is rejected.
+- `captureTeacherActivations` — records one row per probe sample and is
+  deterministic for fixed teacher/probe.
+- `knowledgeDistillation` — produces a creature that passes `creatureValidate`,
+  adds a bounded student pathway (exact count for default; clamped at 64 for
+  over-large requests), preserves pre-existing neuron UUIDs verbatim, leaves
+  pre-existing biases unchanged, reduces teacher–student MSE on a synthetic
+  dataset, gracefully returns `undefined` for incompatible donor/recipient
+  input/output dimensions, and changes recipient outputs vs the unmodified
+  baseline.
+- `KnowledgeDistillationStrategy` — conforms to the `DnaSharingStrategy`
+  interface, mutates the recipient in place on success, and is a no-op when
+  distillation is rejected.

--- a/src/transfer/KnowledgeDistillation.ts
+++ b/src/transfer/KnowledgeDistillation.ts
@@ -1,0 +1,390 @@
+/**
+ * KnowledgeDistillation.ts — Knowledge distillation primitive (Issue #2494).
+ *
+ * Distinct from `CompactModuleGraft` (#2493): instead of moving Europa's
+ * structure across, we move its **behaviour** across by giving production a
+ * small new student pathway trained to imitate Europa on the probe dataset.
+ * The student pathway captures the bits of Europa's behaviour that the
+ * recipient most needs.
+ *
+ * Procedure:
+ *
+ *   1. Activate the donor (teacher) on the probe dataset and record output
+ *      activations.
+ *   2. Add a small student pathway in the recipient: hidden neurons (default
+ *      8, capped at 64) wired to every input and every output with small
+ *      seed weights.
+ *   3. Freeze every pre-existing neuron and synapse so the existing topology
+ *      is not disturbed.
+ *   4. Train the student pathway against the teacher's outputs using the
+ *      existing backprop machinery.
+ *   5. Validate the resulting recipient and return it.
+ *
+ * Pre-existing neuron `uuid`s and biases are unchanged — verified by the
+ * regression tests in `test/transfer/KnowledgeDistillation.ts`. This is the
+ * same UUID stability invariant the rest of the pipeline relies on
+ * (AGENTS.md).
+ */
+
+import { Creature } from "@creature";
+import { addTag } from "@stsoftware/tags/mod";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import type { NeuronExport } from "@architecture/NeuronInterfaces.ts";
+import type { SynapseExport } from "@architecture/SynapseInterfaces.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+import { createBackPropagationConfig } from "@propagate/BackPropagation.ts";
+import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
+import { createSeededRng } from "@utils/RandomNumberGenerator.ts";
+import type {
+  DnaSharingPrepareOptions,
+  DnaSharingStrategy,
+} from "./DnaSharingStrategy.ts";
+
+/** Default number of student hidden neurons to add. */
+const DEFAULT_STUDENT_NEURONS = 8;
+/** Hard cap on the student pathway size — keeps the diff and inference cost bounded. */
+const MAX_STUDENT_NEURONS = 64;
+/** Default backprop iterations per student-pathway training run. */
+const DEFAULT_ITERATIONS = 50;
+/** Default learning rate for student-pathway backprop. */
+const DEFAULT_LEARNING_RATE = 0.05;
+/** Default RNG seed when none is supplied. */
+const DEFAULT_SEED = 42;
+/**
+ * Default activation function for student hidden neurons. TANH gives a
+ * smooth gradient and a [-1, 1] range that pairs well with IDENTITY-style
+ * outputs and also avoids the vanishing-gradient problems of LOGISTIC for
+ * large probe inputs.
+ */
+const DEFAULT_STUDENT_SQUASH = "TANH";
+/** Initial weight magnitude for input → student edges (small but non-zero). */
+const STUDENT_INPUT_WEIGHT = 0.1;
+/**
+ * Initial weight magnitude for student → output edges. Kept small enough that
+ * the student pathway is near-zero contribution at iteration zero — backprop
+ * grows it as the student learns.
+ */
+const STUDENT_OUTPUT_WEIGHT = 0.001;
+
+/** Captured teacher inputs/outputs for one probe pass. */
+export interface TeacherCapture {
+  inputs: Float32Array[];
+  outputs: Float32Array[];
+}
+
+/** Options for {@link knowledgeDistillation}. */
+export interface KnowledgeDistillationOptions {
+  /** Probe dataset; the teacher's outputs on this dataset are the training target. */
+  probe: DataRecordInterface[];
+  /**
+   * Number of student hidden neurons to add. Default
+   * {@link DEFAULT_STUDENT_NEURONS}; clamped to [1, {@link MAX_STUDENT_NEURONS}].
+   */
+  studentNeurons?: number;
+  /** Backprop iterations on the student pathway. Default {@link DEFAULT_ITERATIONS}. */
+  iterations?: number;
+  /** Learning rate for the student backprop. Default {@link DEFAULT_LEARNING_RATE}. */
+  learningRate?: number;
+  /** Deterministic RNG seed for student weight initialisation. */
+  seed?: number;
+  /** Activation function for the student hidden neurons. Default `TANH`. */
+  squash?: string;
+}
+
+/**
+ * Activate `teacher` on each `probe` sample and return the captured inputs
+ * and outputs. The capture is reused for every student-pathway training step
+ * so the teacher is never re-activated mid-training.
+ */
+export function captureTeacherActivations(
+  teacher: Creature,
+  probe: DataRecordInterface[],
+): TeacherCapture {
+  const inputs: Float32Array[] = [];
+  const outputs: Float32Array[] = [];
+  for (const sample of probe) {
+    const inputCopy = new Float32Array(sample.input);
+    const out = teacher.activate(inputCopy, false);
+    inputs.push(inputCopy);
+    outputs.push(new Float32Array(out));
+  }
+  return { inputs, outputs };
+}
+
+/**
+ * Add a student pathway of `count` hidden neurons to `recipientExport`. Each
+ * student neuron is wired from every input and to every output with small
+ * seed weights so backprop has gradients to follow.
+ *
+ * Returns the new export plus the set of student neuron UUIDs (so the caller
+ * can freeze every pre-existing neuron/synapse but leave the student
+ * pathway trainable).
+ */
+export function addStudentPathway(
+  recipientExport: CreatureExport,
+  count: number,
+  seed: number,
+  squash: string = DEFAULT_STUDENT_SQUASH,
+): { offspring: CreatureExport; studentUuids: Set<string> } {
+  const rng = createSeededRng(seed);
+  const offspringNeurons: NeuronExport[] = recipientExport.neurons.map((n) => ({
+    ...n,
+  }));
+  const offspringSynapses: SynapseExport[] = recipientExport.synapses.map(
+    (s) => ({ ...s }),
+  );
+
+  // Insert students before the first output neuron — keeps output indices
+  // contiguous at the tail, matching the rest of the pipeline.
+  let insertIndex = offspringNeurons.length;
+  for (let i = offspringNeurons.length - 1; i >= 0; i--) {
+    if (offspringNeurons[i].type === "output") insertIndex = i;
+    else break;
+  }
+
+  const studentUuids = new Set<string>();
+  const studentExports: NeuronExport[] = [];
+  for (let i = 0; i < count; i++) {
+    const uuid = `student-${seed}-${i}-${crypto.randomUUID()}`;
+    studentUuids.add(uuid);
+    const neuron: NeuronExport = {
+      type: "hidden",
+      uuid,
+      squash,
+      // Seeded random bias in [-0.1, 0.1] — small enough to be near-neutral
+      // at initialisation, large enough to break symmetry between students.
+      bias: (rng.random() - 0.5) * 0.2,
+    };
+    addTag(neuron, "approach", "knowledge-distillation");
+    studentExports.push(neuron);
+  }
+  offspringNeurons.splice(insertIndex, 0, ...studentExports);
+
+  const inputCount = recipientExport.input;
+  const outputUuids = recipientExport.neurons
+    .filter((n) => n.type === "output" && typeof n.uuid === "string")
+    .map((n) => n.uuid as string);
+
+  // Wire input → student. Small but non-zero so backprop has a starting
+  // gradient signal.
+  for (const studentUuid of studentUuids) {
+    for (let i = 0; i < inputCount; i++) {
+      offspringSynapses.push({
+        fromUUID: `input-${i}`,
+        toUUID: studentUuid,
+        // Seeded random in [-STUDENT_INPUT_WEIGHT, +STUDENT_INPUT_WEIGHT].
+        weight: (rng.random() - 0.5) * 2 * STUDENT_INPUT_WEIGHT,
+      });
+    }
+  }
+
+  // Wire student → output. Near-zero seed so the student pathway is roughly
+  // score-neutral at iteration zero — training grows it as needed.
+  for (const studentUuid of studentUuids) {
+    for (const outUuid of outputUuids) {
+      offspringSynapses.push({
+        fromUUID: studentUuid,
+        toUUID: outUuid,
+        weight: (rng.random() - 0.5) * 2 * STUDENT_OUTPUT_WEIGHT,
+      });
+    }
+  }
+
+  const offspring: CreatureExport = {
+    input: recipientExport.input,
+    output: recipientExport.output,
+    neurons: offspringNeurons,
+    synapses: offspringSynapses,
+    forwardOnly: recipientExport.forwardOnly,
+  };
+  return { offspring, studentUuids };
+}
+
+/**
+ * Distil teacher behaviour into a clone of `recipient` by adding and
+ * training a small student pathway. Returns the new Creature, or
+ * `undefined` when input/output dims are incompatible or the resulting
+ * topology fails {@link creatureValidate}.
+ *
+ * Pre-existing neuron `uuid`s and biases are preserved — every pre-existing
+ * neuron and synapse is frozen for the duration of training.
+ */
+export function knowledgeDistillation(
+  recipient: Creature,
+  teacher: Creature,
+  options: KnowledgeDistillationOptions,
+): Creature | undefined {
+  // Compatibility: teacher outputs are the training target, so output and
+  // input dimensions must match.
+  if (recipient.input !== teacher.input) return undefined;
+  if (recipient.output !== teacher.output) return undefined;
+  if (options.probe.length === 0) return undefined;
+
+  const studentNeurons = clampStudentNeurons(
+    options.studentNeurons ?? DEFAULT_STUDENT_NEURONS,
+  );
+  const iterations = Math.max(0, options.iterations ?? DEFAULT_ITERATIONS);
+  const learningRate = options.learningRate ?? DEFAULT_LEARNING_RATE;
+  const seed = options.seed ?? DEFAULT_SEED;
+  const squash = options.squash ?? DEFAULT_STUDENT_SQUASH;
+
+  // 1. Capture teacher outputs once — reused across every training step.
+  const capture = captureTeacherActivations(teacher, options.probe);
+
+  // 2. Build the offspring topology with the student pathway.
+  const recipientExport = recipient.exportJSON();
+  const { offspring: offspringExport, studentUuids } = addStudentPathway(
+    recipientExport,
+    studentNeurons,
+    seed,
+    squash,
+  );
+
+  let offspring: Creature;
+  try {
+    offspring = Creature.fromJSON(offspringExport);
+    offspring.fix(
+      offspringExport.forwardOnly ? { forwardOnly: true } : undefined,
+    );
+  } catch {
+    return undefined;
+  }
+
+  // 3. Freeze every pre-existing neuron and every synapse that has no
+  //    student endpoint — the student pathway is the only part we train.
+  freezeNonStudent(offspring, studentUuids);
+
+  // 4. Train the student pathway against the teacher's outputs.
+  if (iterations > 0) {
+    trainStudentPathway(offspring, capture, {
+      iterations,
+      learningRate,
+      seed,
+    });
+  }
+
+  // 5. Final validation. A failed graft is a no-op for the harness.
+  try {
+    if (offspringExport.forwardOnly) {
+      creatureValidate(offspring, { forwardOnly: true });
+    } else {
+      creatureValidate(offspring);
+    }
+  } catch {
+    return undefined;
+  }
+  return offspring;
+}
+
+/** Clamp the requested student count into [1, {@link MAX_STUDENT_NEURONS}]. */
+function clampStudentNeurons(requested: number): number {
+  if (!Number.isFinite(requested) || requested <= 0) {
+    return DEFAULT_STUDENT_NEURONS;
+  }
+  return Math.min(MAX_STUDENT_NEURONS, Math.max(1, Math.floor(requested)));
+}
+
+/**
+ * Freeze every neuron not in `studentUuids` and every synapse with no
+ * student endpoint, so backprop only updates the student pathway.
+ */
+function freezeNonStudent(
+  creature: Creature,
+  studentUuids: Set<string>,
+): void {
+  // Map runtime indices to UUIDs once.
+  const indexIsStudent = new Set<number>();
+  for (const n of creature.neurons) {
+    if (typeof n.uuid === "string" && studentUuids.has(n.uuid)) {
+      if (typeof n.index === "number") indexIsStudent.add(n.index);
+    }
+  }
+
+  for (const n of creature.neurons) {
+    if (n.type === "input") continue; // Inputs have no bias to freeze.
+    const isStudent = typeof n.uuid === "string" &&
+      studentUuids.has(n.uuid);
+    n.frozen = isStudent ? undefined : true;
+  }
+
+  for (const syn of creature.synapses) {
+    const fromStudent = indexIsStudent.has(syn.from);
+    const toStudent = indexIsStudent.has(syn.to);
+    // A synapse is part of the student pathway if at least one endpoint is
+    // a student neuron — input→student, student→student, student→output
+    // are all trainable; existing→existing edges are frozen.
+    syn.frozen = (fromStudent || toStudent) ? undefined : true;
+  }
+}
+
+/**
+ * Train `student` against the teacher capture using the existing backprop
+ * machinery. Pre-existing neurons/synapses must already be frozen — only
+ * student-pathway weights and biases will move.
+ */
+export function trainStudentPathway(
+  student: Creature,
+  capture: TeacherCapture,
+  options: {
+    iterations: number;
+    learningRate: number;
+    seed?: number;
+  },
+): void {
+  if (capture.inputs.length === 0 || options.iterations <= 0) return;
+
+  const config = createBackPropagationConfig({
+    generations: 1,
+    learningRate: options.learningRate,
+    plankConstant: 1e-7,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: Math.max(2, capture.inputs.length),
+    learningRateStrategy: "fixed",
+    trainingMutationRate: 1,
+  });
+
+  const json = exportJSONWithRuntimeIds(student);
+  const sparseConfig = new SparseConfig(json, config);
+
+  for (let iter = 0; iter < options.iterations; iter++) {
+    for (let i = 0; i < capture.inputs.length; i++) {
+      student.activateAndTrace(capture.inputs[i], false, sparseConfig);
+      student.propagate(capture.outputs[i], config, sparseConfig);
+    }
+    student.applyLearnings(config, sparseConfig);
+  }
+}
+
+/**
+ * `DnaSharingStrategy` adapter for the bake-off harness.
+ *
+ * `prepare(recipient, teacher)` runs {@link knowledgeDistillation} and, on
+ * success, mutates the recipient in place via `loadFrom`. On rejection
+ * (incompatible dims or `creatureValidate` failure) the recipient is left
+ * untouched.
+ */
+export class KnowledgeDistillationStrategy implements DnaSharingStrategy {
+  readonly name = "KnowledgeDistillation";
+
+  constructor(private readonly opts: KnowledgeDistillationOptions) {}
+
+  prepare(
+    recipient: Creature,
+    donor: Creature,
+    options: DnaSharingPrepareOptions,
+  ): Promise<void> {
+    const merged: KnowledgeDistillationOptions = {
+      ...this.opts,
+      seed: this.opts.seed ?? options.seed,
+    };
+    const distilled = knowledgeDistillation(recipient, donor, merged);
+    if (distilled) {
+      recipient.loadFrom(distilled.exportJSON(), false);
+    }
+    return Promise.resolve();
+  }
+}

--- a/src/transfer/mod.ts
+++ b/src/transfer/mod.ts
@@ -68,3 +68,24 @@ export type {
   DenseModule,
   DenseModuleDetectionOptions,
 } from "@transfer/CompactModuleGraft.ts";
+
+/**
+ * Knowledge distillation primitive (Issue #2494).
+ *
+ * Treats Europa as a teacher network and adds a small new student pathway
+ * in the production recipient, trained to imitate the teacher's outputs on
+ * the probe dataset. Pre-existing neuron `uuid`s and biases are unchanged
+ * (AGENTS.md UUID stability invariant) — only the new student pathway
+ * trains.
+ */
+export {
+  addStudentPathway,
+  captureTeacherActivations,
+  knowledgeDistillation,
+  KnowledgeDistillationStrategy,
+  trainStudentPathway,
+} from "@transfer/KnowledgeDistillation.ts";
+export type {
+  KnowledgeDistillationOptions,
+  TeacherCapture,
+} from "@transfer/KnowledgeDistillation.ts";

--- a/test/transfer/KnowledgeDistillation.ts
+++ b/test/transfer/KnowledgeDistillation.ts
@@ -1,0 +1,450 @@
+/**
+ * Tests for KnowledgeDistillation (Issue #2494).
+ *
+ * Knowledge distillation is the orthogonal-to-graft DNA-sharing primitive:
+ * instead of transplanting Europa's structure into the production creature,
+ * we add a small new student pathway in production and train it (using the
+ * existing backprop machinery) to imitate Europa's outputs on a probe
+ * dataset.
+ *
+ * The pre-existing topology must be left untouched — UUIDs and biases of
+ * pre-existing neurons must not drift, per the AGENTS.md neuron UUID
+ * stability invariant.
+ */
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import {
+  captureTeacherActivations,
+  knowledgeDistillation,
+  KnowledgeDistillationStrategy,
+} from "@transfer/KnowledgeDistillation.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/** Build a simple creature from raw neuron uuids and connection triples. */
+function buildCreature(
+  inputCount: number,
+  hiddenUUIDs: string[],
+  outputCount: number,
+  connections: Array<{ from: string; to: string; weight: number }>,
+  biases: Record<string, number> = {},
+): Creature {
+  const neurons: CreatureExport["neurons"] = hiddenUUIDs.map((uuid) => ({
+    type: "hidden" as const,
+    uuid,
+    squash: "TANH",
+    bias: biases[uuid] ?? 0.1,
+  }));
+  for (let i = 0; i < outputCount; i++) {
+    const uuid = `output-${i}`;
+    neurons.push({
+      type: "output",
+      uuid,
+      squash: "IDENTITY",
+      bias: biases[uuid] ?? 0,
+    });
+  }
+  const synapses = connections.map((c) => ({
+    fromUUID: c.from,
+    toUUID: c.to,
+    weight: c.weight,
+  }));
+  const json: CreatureExport = {
+    input: inputCount,
+    output: outputCount,
+    neurons,
+    synapses,
+  };
+  return Creature.fromJSON(json);
+}
+
+/**
+ * Build a "Europa-style" teacher with a noticeable non-linear behaviour the
+ * student pathway can learn to imitate.
+ */
+function createTeacher(): Creature {
+  return buildCreature(
+    2,
+    ["t0", "t1", "t2"],
+    1,
+    [
+      { from: "input-0", to: "t0", weight: 0.7 },
+      { from: "input-1", to: "t0", weight: -0.3 },
+      { from: "input-0", to: "t1", weight: -0.5 },
+      { from: "input-1", to: "t1", weight: 0.6 },
+      { from: "t0", to: "t2", weight: 0.4 },
+      { from: "t1", to: "t2", weight: 0.5 },
+      { from: "t2", to: "output-0", weight: 0.8 },
+    ],
+  );
+}
+
+/** Build a smaller "production-style" recipient with a different topology. */
+function createRecipient(): Creature {
+  return buildCreature(
+    2,
+    ["pA"],
+    1,
+    [
+      { from: "input-0", to: "pA", weight: 0.2 },
+      { from: "input-1", to: "pA", weight: 0.1 },
+      { from: "pA", to: "output-0", weight: 0.3 },
+    ],
+  );
+}
+
+function buildProbe(): DataRecordInterface[] {
+  const probe: DataRecordInterface[] = [];
+  const points = [
+    [0.1, 0.9],
+    [0.4, 0.6],
+    [0.5, 0.5],
+    [0.7, 0.2],
+    [0.9, 0.1],
+    [0.2, 0.4],
+    [0.6, 0.8],
+    [0.3, 0.3],
+  ];
+  for (const [a, b] of points) {
+    probe.push({
+      input: new Float32Array([a, b]),
+      // Output is a placeholder — distillation overrides with teacher output.
+      output: new Float32Array([0]),
+    });
+  }
+  return probe;
+}
+
+Deno.test("captureTeacherActivations - records one output row per probe sample", async () => {
+  await initWasmForTests();
+  const teacher = createTeacher();
+  const probe = buildProbe();
+
+  const capture = captureTeacherActivations(teacher, probe);
+
+  assertEquals(capture.outputs.length, probe.length);
+  assertEquals(capture.inputs.length, probe.length);
+  for (let i = 0; i < probe.length; i++) {
+    assertEquals(capture.outputs[i].length, teacher.output);
+    assertEquals(capture.inputs[i].length, teacher.input);
+    for (const v of capture.outputs[i]) {
+      assert(Number.isFinite(v), `teacher output must be finite, got ${v}`);
+    }
+  }
+});
+
+Deno.test("captureTeacherActivations - is deterministic for fixed teacher and probe", async () => {
+  await initWasmForTests();
+  const teacher = createTeacher();
+  const probe = buildProbe();
+
+  const a = captureTeacherActivations(teacher, probe);
+  const b = captureTeacherActivations(teacher, probe);
+
+  for (let i = 0; i < probe.length; i++) {
+    assertEquals(
+      Array.from(a.outputs[i]),
+      Array.from(b.outputs[i]),
+      `teacher capture must be deterministic for sample ${i}`,
+    );
+  }
+});
+
+Deno.test("knowledgeDistillation - returns a distilled creature that passes creatureValidate", async () => {
+  await initWasmForTests();
+  const teacher = createTeacher();
+  const recipient = createRecipient();
+  const probe = buildProbe();
+
+  const distilled = knowledgeDistillation(recipient, teacher, {
+    probe,
+    studentNeurons: 4,
+    iterations: 20,
+    learningRate: 0.05,
+    seed: 7,
+  });
+
+  assert(distilled, "knowledgeDistillation must produce a creature");
+  creatureValidate(distilled);
+});
+
+Deno.test("knowledgeDistillation - adds a bounded student pathway", async () => {
+  await initWasmForTests();
+  const teacher = createTeacher();
+  const recipient = createRecipient();
+  const before = recipient.neurons.length;
+  const studentNeurons = 4;
+
+  const distilled = knowledgeDistillation(recipient, teacher, {
+    probe: buildProbe(),
+    studentNeurons,
+    iterations: 5,
+    learningRate: 0.05,
+    seed: 1,
+  });
+  assert(distilled);
+  const after = distilled.neurons.length;
+  assertEquals(
+    after - before,
+    studentNeurons,
+    `expected exactly ${studentNeurons} new neurons, got ${after - before}`,
+  );
+});
+
+Deno.test("knowledgeDistillation - clamps studentNeurons to the safety cap of 64", async () => {
+  await initWasmForTests();
+  const teacher = createTeacher();
+  const recipient = createRecipient();
+  const before = recipient.neurons.length;
+
+  const distilled = knowledgeDistillation(recipient, teacher, {
+    probe: buildProbe(),
+    studentNeurons: 1024,
+    iterations: 1,
+    learningRate: 0.05,
+    seed: 1,
+  });
+  assert(distilled);
+  const added = distilled.neurons.length - before;
+  assert(added <= 64, `student pathway must be capped at 64, got ${added}`);
+});
+
+Deno.test("knowledgeDistillation - preserves pre-existing neuron UUIDs verbatim", async () => {
+  await initWasmForTests();
+  const teacher = createTeacher();
+  const recipient = createRecipient();
+  const recipientUuidsBefore = new Set(
+    recipient.exportJSON().neurons
+      .map((n) => n.uuid)
+      .filter((u): u is string => typeof u === "string"),
+  );
+
+  const distilled = knowledgeDistillation(recipient, teacher, {
+    probe: buildProbe(),
+    studentNeurons: 4,
+    iterations: 5,
+    learningRate: 0.05,
+    seed: 1,
+  });
+  assert(distilled);
+  const distilledUuids = new Set(
+    distilled.exportJSON().neurons
+      .map((n) => n.uuid)
+      .filter((u): u is string => typeof u === "string"),
+  );
+  for (const u of recipientUuidsBefore) {
+    assert(
+      distilledUuids.has(u),
+      `recipient UUID ${u} must survive distillation (UUID stability invariant)`,
+    );
+  }
+});
+
+Deno.test("knowledgeDistillation - leaves pre-existing biases unchanged", async () => {
+  await initWasmForTests();
+  const teacher = createTeacher();
+  const recipient = createRecipient();
+  const beforeBiases = new Map<string, number>();
+  for (const n of recipient.exportJSON().neurons) {
+    if (typeof n.uuid === "string") beforeBiases.set(n.uuid, n.bias);
+  }
+
+  const distilled = knowledgeDistillation(recipient, teacher, {
+    probe: buildProbe(),
+    studentNeurons: 4,
+    iterations: 20,
+    learningRate: 0.1,
+    seed: 1,
+  });
+  assert(distilled);
+  for (const n of distilled.exportJSON().neurons) {
+    if (typeof n.uuid === "string" && beforeBiases.has(n.uuid)) {
+      assertEquals(
+        n.bias,
+        beforeBiases.get(n.uuid),
+        `bias of pre-existing neuron ${n.uuid} must not change during distillation`,
+      );
+    }
+  }
+});
+
+Deno.test("knowledgeDistillation - reduces teacher-student MSE on the probe", async () => {
+  await initWasmForTests();
+  const teacher = createTeacher();
+  const recipient = createRecipient();
+  const probe = buildProbe();
+  const teacherCapture = captureTeacherActivations(teacher, probe);
+
+  const initialDistilled = knowledgeDistillation(recipient, teacher, {
+    probe,
+    studentNeurons: 6,
+    iterations: 0,
+    learningRate: 0.05,
+    seed: 3,
+  });
+  assert(initialDistilled);
+  const initialMse = computeMse(initialDistilled, teacherCapture);
+
+  const recipient2 = createRecipient();
+  const trained = knowledgeDistillation(recipient2, teacher, {
+    probe,
+    studentNeurons: 6,
+    iterations: 200,
+    learningRate: 0.05,
+    seed: 3,
+  });
+  assert(trained);
+  const trainedMse = computeMse(trained, teacherCapture);
+
+  assert(
+    trainedMse < initialMse,
+    `training must reduce teacher-student MSE: initial=${initialMse}, trained=${trainedMse}`,
+  );
+});
+
+Deno.test("knowledgeDistillation - returns undefined when input/output dims do not match", async () => {
+  await initWasmForTests();
+  const teacher = createTeacher();
+  // Recipient with 3 inputs, but teacher has 2 — incompatible.
+  const recipient = buildCreature(
+    3,
+    ["pA"],
+    1,
+    [
+      { from: "input-0", to: "pA", weight: 0.2 },
+      { from: "input-1", to: "pA", weight: 0.1 },
+      { from: "input-2", to: "pA", weight: 0.1 },
+      { from: "pA", to: "output-0", weight: 0.3 },
+    ],
+  );
+  const result = knowledgeDistillation(recipient, teacher, {
+    probe: buildProbe(),
+    studentNeurons: 4,
+    iterations: 5,
+    learningRate: 0.05,
+    seed: 1,
+  });
+  assertEquals(
+    result,
+    undefined,
+    "incompatible donor/recipient must be a graceful no-op",
+  );
+});
+
+Deno.test(
+  "KnowledgeDistillationStrategy - conforms to DnaSharingStrategy and adds a student pathway",
+  async () => {
+    await initWasmForTests();
+    const recipient = createRecipient();
+    const teacher = createTeacher();
+    const before = recipient.neurons.length;
+
+    const strategy = new KnowledgeDistillationStrategy({
+      probe: buildProbe(),
+      studentNeurons: 4,
+      iterations: 5,
+      learningRate: 0.05,
+    });
+    assertEquals(strategy.name, "KnowledgeDistillation");
+
+    await strategy.prepare(recipient, teacher, { seed: 1, generations: 1 });
+    assert(
+      recipient.neurons.length > before,
+      `recipient must grow after distillation (was ${before}, now ${recipient.neurons.length})`,
+    );
+    creatureValidate(recipient);
+  },
+);
+
+Deno.test(
+  "KnowledgeDistillationStrategy - is a no-op when distillation is rejected",
+  async () => {
+    await initWasmForTests();
+    // 3-input recipient, 2-input teacher — incompatible.
+    const recipient = buildCreature(
+      3,
+      ["pA"],
+      1,
+      [
+        { from: "input-0", to: "pA", weight: 0.2 },
+        { from: "input-1", to: "pA", weight: 0.1 },
+        { from: "input-2", to: "pA", weight: 0.1 },
+        { from: "pA", to: "output-0", weight: 0.3 },
+      ],
+    );
+    const teacher = createTeacher();
+    const before = recipient.neurons.length;
+    const strategy = new KnowledgeDistillationStrategy({
+      probe: buildProbe(),
+      studentNeurons: 4,
+      iterations: 1,
+      learningRate: 0.05,
+    });
+    await strategy.prepare(recipient, teacher, { seed: 1, generations: 1 });
+    assertEquals(
+      recipient.neurons.length,
+      before,
+      "recipient must be unchanged when distillation is rejected",
+    );
+  },
+);
+
+Deno.test(
+  "knowledgeDistillation - student pathway changes recipient outputs vs baseline",
+  async () => {
+    await initWasmForTests();
+    const teacher = createTeacher();
+    const recipient = createRecipient();
+    const baselineOutputs: number[] = [];
+    for (const sample of buildProbe()) {
+      baselineOutputs.push(recipient.activate(sample.input, false)[0]);
+    }
+
+    const distilled = knowledgeDistillation(recipient, teacher, {
+      probe: buildProbe(),
+      studentNeurons: 6,
+      iterations: 100,
+      learningRate: 0.1,
+      seed: 5,
+    });
+    assert(distilled);
+    let differs = false;
+    const probe = buildProbe();
+    for (let i = 0; i < probe.length; i++) {
+      const out = distilled.activate(probe[i].input, false)[0];
+      if (Math.abs(out - baselineOutputs[i]) > 1e-6) {
+        differs = true;
+        break;
+      }
+    }
+    assert(
+      differs,
+      "distilled creature outputs must differ from the unmodified recipient",
+    );
+    // And per the bias-preservation test, this must be due to the student
+    // pathway only — the asserts in other tests guarantee no UUID/bias drift.
+    assertNotEquals(distilled.neurons.length, recipient.neurons.length);
+  },
+);
+
+/** Mean-squared-error between a creature's outputs and a teacher capture. */
+function computeMse(
+  creature: Creature,
+  capture: { inputs: Float32Array[]; outputs: Float32Array[] },
+): number {
+  let total = 0;
+  let count = 0;
+  for (let i = 0; i < capture.inputs.length; i++) {
+    const out = creature.activate(capture.inputs[i], false);
+    for (let j = 0; j < out.length; j++) {
+      const diff = out[j] - capture.outputs[i][j];
+      total += diff * diff;
+      count++;
+    }
+  }
+  return count === 0 ? 0 : total / count;
+}


### PR DESCRIPTION
# Knowledge distillation primitive: Europa as teacher

## Summary

Adds the `KnowledgeDistillation` DNA-sharing primitive (`src/transfer/KnowledgeDistillation.ts`) so production can absorb Europa's behaviour through a small new student pathway rather than by transplanting structure. The donor (teacher) is activated once on the probe dataset; a bounded student pathway (default 8, capped at 64 hidden neurons) is appended to a clone of the recipient and trained against the captured teacher outputs using the existing `src/propagate/` backprop machinery. Pre-existing neurons and synapses are frozen for the duration of training, so their `uuid`s and biases are unchanged — preserving the AGENTS.md UUID stability invariant. Closes #2494.

The new primitive ships with a `KnowledgeDistillationStrategy` that conforms to the `DnaSharingStrategy` interface from #2491 and is exported from `src/transfer/mod.ts`.

```mermaid
flowchart LR
    Teacher[Europa<br/>teacher] -->|activate on probe| Capture[Teacher capture]
    Recipient[Production<br/>recipient] -->|clone + add students| Augmented[Augmented recipient]
    Capture -->|teacher outputs as targets| Train
    Augmented -->|freeze pre-existing| Train[Backprop on student<br/>pathway only]
    Train --> Distilled[Distilled creature]
```

## Evidence

This is a backend-only change with no UI surface. The bake-off harness from #2491 was run locally against a deterministic teacher / recipient / probe (32 samples generated from `sin`/`cos`):

| Strategy | Baseline | Final | Lift | Neurons | Synapses |
| --- | ---: | ---: | ---: | ---: | ---: |
| NoOp | -0.022353 | -0.022353 | 0.000000 | 4 | 3 |
| KnowledgeDistillation | -0.022353 | -0.000455 | **+0.021897** | 12 | 27 |

Teacher–student MSE on the probe:

- Baseline recipient (no distillation): **0.022353**
- Distilled recipient (200 iterations, 8 student neurons, lr=0.05, seed=7): **0.000455**
- Absolute MSE reduction: **0.021897** (~98% lower)

Absolute lift on the production probe is positive (+0.021897), so the merge gate from the issue is satisfied.

`./quality.sh --skip-discovery --skip-wasm` passes (6323 tests, 0 failures, 4 ignored).

## Test Plan

New tests in `test/transfer/KnowledgeDistillation.ts` cover every acceptance criterion:

- `captureTeacherActivations` — records one row per probe sample and is deterministic for fixed teacher/probe.
- `knowledgeDistillation` — produces a creature that passes `creatureValidate`, adds a bounded student pathway (exact count for default; clamped at 64 for over-large requests), preserves pre-existing neuron UUIDs verbatim, leaves pre-existing biases unchanged, reduces teacher–student MSE on a synthetic dataset, gracefully returns `undefined` for incompatible donor/recipient input/output dimensions, and changes recipient outputs vs the unmodified baseline.
- `KnowledgeDistillationStrategy` — conforms to the `DnaSharingStrategy` interface, mutates the recipient in place on success, and is a no-op when distillation is rejected.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2494 -->