### PR TITLE
Bug: stamp creature uuid/hash and source in loadFrom warnings (#2500)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.45",
+  "version": "3.1.46",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2500.md
+++ b/docs/pr-summary-2500.md
@@ -2,42 +2,42 @@
 
 ## Summary
 
-Production logs were repeatedly emitting `🚨 [loadFrom] Stripping
+Production logs were repeatedly emitting
+`🚨 [loadFrom] Stripping
 recurrent synapse … from forward-only creature (UUID: unknown). This
-indicates upstream corruption.` 50 times in a single GRQ-3 run. The
-`UUID: unknown` text made it impossible to correlate corrupt-creature
-events or trace the upstream pipeline that produced them — a regression
-of GRQ#1497 / GRQ#1906.
+indicates upstream corruption.`
+50 times in a single GRQ-3 run. The `UUID: unknown` text made it impossible to
+correlate corrupt-creature events or trace the upstream pipeline that produced
+them — a regression of GRQ#1497 / GRQ#1906.
 
-The root cause is that `CreatureExport` JSON deliberately omits the
-creature `uuid` (it is wire-only), so `loadFrom` had no identifier to
-report when the synapse-strip warning fired.
+The root cause is that `CreatureExport` JSON deliberately omits the creature
+`uuid` (it is wire-only), so `loadFrom` had no identifier to report when the
+synapse-strip warning fired.
 
 This change makes the warning genuinely diagnostic:
 
-- **Stable identifier**: when `creature.uuid` is missing, `loadFrom`
-  computes a deterministic `hash:<8hex>` from the JSON payload (input/
-  output sizes, neuron uuids/types, sorted synapse `fromUUID->toUUID`
-  pairs). The same poisoned creature now produces the same hash on
-  every machine, so events can be correlated.
-- **`source=...` tag**: every caller of `loadFrom` now passes a short
-  string identifying the upstream pipeline (`breed:fixAliases`,
+- **Stable identifier**: when `creature.uuid` is missing, `loadFrom` computes a
+  deterministic `hash:<8hex>` from the JSON payload (input/ output sizes, neuron
+  uuids/types, sorted synapse `fromUUID->toUUID` pairs). The same poisoned
+  creature now produces the same hash on every machine, so events can be
+  correlated.
+- **`source=...` tag**: every caller of `loadFrom` now passes a short string
+  identifying the upstream pipeline (`breed:fixAliases`,
   `transfer:compactGraft`, `training:teardownRestore`,
-  `compact:deadSubgraphPruning`, `predictiveCoding:restoreBest`, etc.).
-  The tag is included in the strip warning so the offending pipeline
-  is visible from a single log line.
+  `compact:deadSubgraphPruning`, `predictiveCoding:restoreBest`, etc.). The tag
+  is included in the strip warning so the offending pipeline is visible from a
+  single log line.
 - **Assertion helper**: a new
-  `assertNoRecurrentSynapseOnForwardOnly(creature, source)` lets
-  pipelines that produce structures fail fast at the corruption
-  introduction point instead of leaving the silent-strip in `loadFrom`
-  as the only signal.
+  `assertNoRecurrentSynapseOnForwardOnly(creature, source)` lets pipelines that
+  produce structures fail fast at the corruption introduction point instead of
+  leaving the silent-strip in `loadFrom` as the only signal.
 
 Closes #2500.
 
 ## Evidence
 
-This is a backend / CLI change with no UI to screenshot. Behaviour is
-verified by three new test files (see Test Plan).
+This is a backend / CLI change with no UI to screenshot. Behaviour is verified
+by three new test files (see Test Plan).
 
 ```mermaid
 flowchart LR
@@ -64,30 +64,29 @@ Sample warning before and after:
 ## Test Plan
 
 - `test/utils/CreatureStructuralHash.ts` — verifies the hash is stable,
-  hex-only, insensitive to synapse order, and changes when topology /
-  input / output changes.
-- `test/creature/LoadFromObservability.ts` — verifies that
-  `loadFrom` warnings (a) never contain `UUID: unknown`, (b) always
-  contain a uuid or `hash:<8hex>` identifier, (c) reflect the caller's
-  `source=…` tag, and (d) assign the same hash to identical JSON twice.
+  hex-only, insensitive to synapse order, and changes when topology / input /
+  output changes.
+- `test/creature/LoadFromObservability.ts` — verifies that `loadFrom` warnings
+  (a) never contain `UUID: unknown`, (b) always contain a uuid or `hash:<8hex>`
+  identifier, (c) reflect the caller's `source=…` tag, and (d) assign the same
+  hash to identical JSON twice.
 - `test/architecture/ForwardOnlyAssertion.ts` — verifies the new
   `assertNoRecurrentSynapseOnForwardOnly` helper is a no-op for valid
-  forward-only creatures and throws a `TopologyError` (with `source`
-  tag) for self-loops and backward edges.
+  forward-only creatures and throws a `TopologyError` (with `source` tag) for
+  self-loops and backward edges.
 
 All 6335 tests pass via `./quality.sh --skip-discovery --skip-wasm`.
 
 ## Files changed
 
-- `src/utils/CreatureStructuralHash.ts` *(new)* — FNV-1a 32-bit hash
-  helper.
-- `src/architecture/ForwardOnlyAssertion.ts` *(new)* — corruption
+- `src/utils/CreatureStructuralHash.ts` _(new)_ — FNV-1a 32-bit hash helper.
+- `src/architecture/ForwardOnlyAssertion.ts` _(new)_ — corruption
   introduction-point assertion.
-- `src/creature/CreatureSerialization.ts` — `loadFrom` and `fromJSON`
-  accept an optional `source` parameter; strip and clamp warnings now
-  include uuid-or-hash and `source=…`.
-- `src/Creature.ts` — `Creature.loadFrom` and `Creature.fromJSON`
-  forward the new `source` parameter.
+- `src/creature/CreatureSerialization.ts` — `loadFrom` and `fromJSON` accept an
+  optional `source` parameter; strip and clamp warnings now include uuid-or-hash
+  and `source=…`.
+- `src/Creature.ts` — `Creature.loadFrom` and `Creature.fromJSON` forward the
+  new `source` parameter.
 - `src/architecture/Offspring.ts`, `src/transfer/CompactModuleGraft.ts`,
   `src/transfer/KnowledgeDistillation.ts`,
   `src/architecture/training/TrainingOutcome.ts`,
@@ -96,10 +95,9 @@ All 6335 tests pass via `./quality.sh --skip-discovery --skip-wasm`.
   `src/predictiveCoding/PredictiveCodingTrainer.ts`,
   `src/creature/CreatureTraining.ts`,
   `src/propagate/RemoveSyntheticSynapses.ts`,
-  `src/compact/DeadSubgraphPruning.ts`,
-  `src/compact/OrphanedNeuronCleanup.ts` — pass meaningful `source`
-  tags.
-- `test/utils/CreatureStructuralHash.ts` *(new)*,
-  `test/creature/LoadFromObservability.ts` *(new)*,
-  `test/architecture/ForwardOnlyAssertion.ts` *(new)* — coverage for
-  the new behaviour.
+  `src/compact/DeadSubgraphPruning.ts`, `src/compact/OrphanedNeuronCleanup.ts` —
+  pass meaningful `source` tags.
+- `test/utils/CreatureStructuralHash.ts` _(new)_,
+  `test/creature/LoadFromObservability.ts` _(new)_,
+  `test/architecture/ForwardOnlyAssertion.ts` _(new)_ — coverage for the new
+  behaviour.

--- a/docs/pr-summary-2500.md
+++ b/docs/pr-summary-2500.md
@@ -1,0 +1,105 @@
+# Stamp creature UUID before loadFrom strips recurrent synapses (#2500)
+
+## Summary
+
+Production logs were repeatedly emitting `🚨 [loadFrom] Stripping
+recurrent synapse … from forward-only creature (UUID: unknown). This
+indicates upstream corruption.` 50 times in a single GRQ-3 run. The
+`UUID: unknown` text made it impossible to correlate corrupt-creature
+events or trace the upstream pipeline that produced them — a regression
+of GRQ#1497 / GRQ#1906.
+
+The root cause is that `CreatureExport` JSON deliberately omits the
+creature `uuid` (it is wire-only), so `loadFrom` had no identifier to
+report when the synapse-strip warning fired.
+
+This change makes the warning genuinely diagnostic:
+
+- **Stable identifier**: when `creature.uuid` is missing, `loadFrom`
+  computes a deterministic `hash:<8hex>` from the JSON payload (input/
+  output sizes, neuron uuids/types, sorted synapse `fromUUID->toUUID`
+  pairs). The same poisoned creature now produces the same hash on
+  every machine, so events can be correlated.
+- **`source=...` tag**: every caller of `loadFrom` now passes a short
+  string identifying the upstream pipeline (`breed:fixAliases`,
+  `transfer:compactGraft`, `training:teardownRestore`,
+  `compact:deadSubgraphPruning`, `predictiveCoding:restoreBest`, etc.).
+  The tag is included in the strip warning so the offending pipeline
+  is visible from a single log line.
+- **Assertion helper**: a new
+  `assertNoRecurrentSynapseOnForwardOnly(creature, source)` lets
+  pipelines that produce structures fail fast at the corruption
+  introduction point instead of leaving the silent-strip in `loadFrom`
+  as the only signal.
+
+Closes #2500.
+
+## Evidence
+
+This is a backend / CLI change with no UI to screenshot. Behaviour is
+verified by three new test files (see Test Plan).
+
+```mermaid
+flowchart LR
+  A[Mutation / Breeding / Discovery]
+  A -->|introduces recurrent synapse| B[Creature with no UUID]
+  B --> C[saved to disk as CreatureExport]
+  C --> D[loadFrom strips synapse]
+  D -->|before #2500| E[warning: UUID=unknown — useless]
+  D -->|after #2500| F["warning: UUID=hash:abcd1234, source=breed:fixAliases"]
+  A -.->|optional| G[assertNoRecurrentSynapseOnForwardOnly]
+  G -->|throws TopologyError| H[useful stack trace at source]
+```
+
+Sample warning before and after:
+
+```
+# before
+🚨 [loadFrom] Stripping recurrent synapse 2738->2736 (fromUUID=output-0, toUUID=d276ed0d-…) from forward-only creature (UUID: unknown). This indicates upstream corruption.
+
+# after
+🚨 [loadFrom] Stripping recurrent synapse 2738->2736 (fromUUID=output-0, toUUID=d276ed0d-…) from forward-only creature (UUID: hash:1a2b3c4d, source=breed:fixAliases). This indicates upstream corruption.
+```
+
+## Test Plan
+
+- `test/utils/CreatureStructuralHash.ts` — verifies the hash is stable,
+  hex-only, insensitive to synapse order, and changes when topology /
+  input / output changes.
+- `test/creature/LoadFromObservability.ts` — verifies that
+  `loadFrom` warnings (a) never contain `UUID: unknown`, (b) always
+  contain a uuid or `hash:<8hex>` identifier, (c) reflect the caller's
+  `source=…` tag, and (d) assign the same hash to identical JSON twice.
+- `test/architecture/ForwardOnlyAssertion.ts` — verifies the new
+  `assertNoRecurrentSynapseOnForwardOnly` helper is a no-op for valid
+  forward-only creatures and throws a `TopologyError` (with `source`
+  tag) for self-loops and backward edges.
+
+All 6335 tests pass via `./quality.sh --skip-discovery --skip-wasm`.
+
+## Files changed
+
+- `src/utils/CreatureStructuralHash.ts` *(new)* — FNV-1a 32-bit hash
+  helper.
+- `src/architecture/ForwardOnlyAssertion.ts` *(new)* — corruption
+  introduction-point assertion.
+- `src/creature/CreatureSerialization.ts` — `loadFrom` and `fromJSON`
+  accept an optional `source` parameter; strip and clamp warnings now
+  include uuid-or-hash and `source=…`.
+- `src/Creature.ts` — `Creature.loadFrom` and `Creature.fromJSON`
+  forward the new `source` parameter.
+- `src/architecture/Offspring.ts`, `src/transfer/CompactModuleGraft.ts`,
+  `src/transfer/KnowledgeDistillation.ts`,
+  `src/architecture/training/TrainingOutcome.ts`,
+  `src/architecture/training/TrainingTeardown.ts`,
+  `src/architecture/CrossValidationTrainer.ts`,
+  `src/predictiveCoding/PredictiveCodingTrainer.ts`,
+  `src/creature/CreatureTraining.ts`,
+  `src/propagate/RemoveSyntheticSynapses.ts`,
+  `src/compact/DeadSubgraphPruning.ts`,
+  `src/compact/OrphanedNeuronCleanup.ts` — pass meaningful `source`
+  tags.
+- `test/utils/CreatureStructuralHash.ts` *(new)*,
+  `test/creature/LoadFromObservability.ts` *(new)*,
+  `test/architecture/ForwardOnlyAssertion.ts` *(new)* — coverage for
+  the new behaviour.

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1060,15 +1060,25 @@ export class Creature implements CreatureInternal {
     return serialisation.traceJSON(this);
   }
 
-  loadFrom(json: CreatureInternal | CreatureExport, validate: boolean) {
-    serialisation.loadFrom(this, json, validate);
+  loadFrom(
+    json: CreatureInternal | CreatureExport,
+    validate: boolean,
+    source?: string,
+  ) {
+    serialisation.loadFrom(this, json, validate, source);
   }
 
   static fromJSON(
     json: CreatureInternal | CreatureExport,
-    validate = false,
+    validate?: boolean,
+    source?: string,
   ): Creature {
-    return serialisation.fromJSON(json, validate, Creature) as Creature;
+    return serialisation.fromJSON(
+      json,
+      validate ?? false,
+      Creature,
+      source,
+    ) as Creature;
   }
 
   /**

--- a/src/architecture/CrossValidationTrainer.ts
+++ b/src/architecture/CrossValidationTrainer.ts
@@ -222,7 +222,7 @@ export function trainWithCrossValidation(
 
   // Load the best-performing fold's weights into the original creature
   if (bestFoldCreatureJSON) {
-    creature.loadFrom(bestFoldCreatureJSON, false);
+    creature.loadFrom(bestFoldCreatureJSON, false, "training:crossValidation");
   }
 
   if (options.log) {

--- a/src/architecture/ForwardOnlyAssertion.ts
+++ b/src/architecture/ForwardOnlyAssertion.ts
@@ -1,0 +1,43 @@
+/**
+ * Forward-only assertion helper (Issue #2500).
+ *
+ * Centralises the check that no recurrent synapse (`from >= to`) appears
+ * on a creature flagged `forwardOnly === true`. Pipelines that produce
+ * structures (mutation, breeding, discovery, coordinated structural
+ * application) should call this helper at the corruption introduction
+ * point so failures are caught **before** the creature reaches
+ * `loadFrom`, where the synapse is silently stripped.
+ */
+import type { Creature } from "@creature";
+import { TopologyError } from "@errors/TopologyError.ts";
+
+/**
+ * Throws a {@link TopologyError} when `creature.forwardOnly === true`
+ * and any synapse violates `from < to`.
+ *
+ * @param creature The creature to check.
+ * @param source Short tag identifying the calling pipeline. Included in
+ *   the thrown error message so the upstream stack frame can be
+ *   identified from the message alone (e.g. logs, replays).
+ */
+export function assertNoRecurrentSynapseOnForwardOnly(
+  creature: Creature,
+  source: string,
+): void {
+  if (creature.forwardOnly !== true) return;
+  const synapses = creature.synapses;
+  if (!synapses || synapses.length === 0) return;
+  for (let i = 0; i < synapses.length; i++) {
+    const s = synapses[i];
+    if (s.from >= s.to) {
+      throw new TopologyError(
+        `[${source}] Forward-only creature ${
+          creature.uuid ?? "(no-uuid)"
+        } has recurrent synapse at index ${i}: ${s.from}->${s.to}. ` +
+          `This is the upstream corruption that produces ` +
+          `'[loadFrom] Stripping recurrent synapse' warnings (Issue #2500).`,
+        "INVALID_CONNECTION",
+      );
+    }
+  }
+}

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -513,7 +513,7 @@ export class Offspring {
         }
       }
 
-      offspring.loadFrom(fixed, false);
+      offspring.loadFrom(fixed, false, "breed:fixAliases");
     }
 
     offspring.clearState();

--- a/src/architecture/training/TrainingOutcome.ts
+++ b/src/architecture/training/TrainingOutcome.ts
@@ -94,7 +94,7 @@ export function applyEpochOutcome(
         JSON.stringify(creature.traceJSON()),
       );
     }
-    creature.loadFrom(state.bestCreatureJSON, false);
+    creature.loadFrom(state.bestCreatureJSON, false, "training:outcomeRestore");
     return;
   }
 

--- a/src/architecture/training/TrainingTeardown.ts
+++ b/src/architecture/training/TrainingTeardown.ts
@@ -168,7 +168,7 @@ export function finaliseTraining(
   let { bestCreatureJSON, bestTraceJSON } = loop;
 
   if (iterations > 1) {
-    creature.loadFrom(bestCreatureJSON, false); // If not called via the worker.
+    creature.loadFrom(bestCreatureJSON, false, "training:teardownRestore"); // If not called via the worker.
   }
 
   const pruned = pruneSyntheticSynapses(

--- a/src/compact/DeadSubgraphPruning.ts
+++ b/src/compact/DeadSubgraphPruning.ts
@@ -113,7 +113,7 @@ export function pruneDeadSubgraphsInCreature(
 
   const result = pruneDeadSubgraphs(exportJSON);
   if (result.removedNeurons > 0 || result.removedSynapses > 0) {
-    creature.loadFrom(exportJSON, true);
+    creature.loadFrom(exportJSON, true, "compact:deadSubgraphPruning");
   }
 
   return result;

--- a/src/compact/OrphanedNeuronCleanup.ts
+++ b/src/compact/OrphanedNeuronCleanup.ts
@@ -351,7 +351,7 @@ export function cleanupOrphanedNeuronsInCreature(
     // This helper is used from repair paths (`fix()`), where the export may be
     // in an intermediate state until the caller finishes all repair steps.
     // Let the outer repair/validation flow perform the final strict validate.
-    creature.loadFrom(exportJSON, false);
+    creature.loadFrom(exportJSON, false, "compact:orphanCleanup");
   }
 
   return result;

--- a/src/creature/CreatureSerialization.ts
+++ b/src/creature/CreatureSerialization.ts
@@ -43,6 +43,7 @@ import {
   MAX_SAFE_WEIGHT_BIAS,
 } from "@utils/WeightBiasClamp.ts";
 import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
+import { computeCreatureStructuralHash } from "@utils/CreatureStructuralHash.ts";
 import { cleanupOrphanedNeuronsInCreature } from "@compact/OrphanedNeuronCleanup.ts";
 import { pruneOrphanMemeticReferences } from "@compact/MemeticCleanup.ts";
 import { mergeDuplicateSynapsesInCreature } from "@compact/SynapsePruning.ts";
@@ -337,11 +338,18 @@ function forwardOnlyHiddenLacksInbound(creature: Creature): boolean {
 
 /**
  * Load the creature from a JSON object.
+ *
+ * @param source Optional tag describing the calling site (e.g.
+ *   `"breed"`, `"discovery"`, `"fromJSON"`). Included in any
+ *   `[loadFrom] Stripping recurrent synapse` warning so production
+ *   logs can identify the upstream pipeline that produced corrupt
+ *   JSON. See Issue #2500.
  */
 export function loadFrom(
   creature: Creature,
   json: CreatureInternal | CreatureExport,
   validate: boolean,
+  source: string = "loadFrom",
 ): void {
   creature.uuid = (json as CreatureInternal).uuid;
   if (json.semanticVersion) {
@@ -444,6 +452,16 @@ export function loadFrom(
   let lastTo = -1;
   const isForwardOnly = creature.forwardOnly === true;
   let validSynapseCount = 0;
+  // Issue #2500: lazily compute a structural hash on first strip so we
+  // always emit a usable identifier even when the creature has no UUID
+  // (CreatureExport JSON omits creature uuid).
+  let cachedStructuralHash: string | undefined;
+  const getStructuralHash = (): string => {
+    if (cachedStructuralHash === undefined) {
+      cachedStructuralHash = computeCreatureStructuralHash(json);
+    }
+    return cachedStructuralHash;
+  };
   for (let i = 0; i < synapseCount; i++) {
     const synapse = synapses[i];
     const se = synapse as SynapseExport;
@@ -487,12 +505,16 @@ export function loadFrom(
     }
 
     if (isForwardOnly && from! >= to!) {
+      // Issue #2500: include a usable identifier (uuid OR structural
+      // hash) and a `source=...` tag so corrupt-creature events from a
+      // single offending pipeline can be correlated across log lines.
+      const uuidLabel = creature.uuid ?? `hash:${getStructuralHash()}`;
       getLogger().error(
         `🚨 [loadFrom] Stripping recurrent synapse ${from}->${to} ` +
           `(fromUUID=${se.fromUUID ?? se.fromId}, toUUID=${
             se.toUUID ?? se.toId
           }) ` +
-          `from forward-only creature (UUID: ${creature.uuid ?? "unknown"}). ` +
+          `from forward-only creature (UUID: ${uuidLabel}, source=${source}). ` +
           `This indicates upstream corruption.`,
       );
       continue;
@@ -605,9 +627,10 @@ export function loadFrom(
   // lineage can be traced in production logs (rather than thousands of
   // per-value info lines in Score.ts).
   if (clampedWeightCount > 0 || clampedBiasCount > 0) {
+    const uuidLabel = creature.uuid ?? `hash:${getStructuralHash()}`;
     getLogger().warn(
       "🗜️ [loadFrom] Clamped overflowing weights/biases to " +
-        `±${MAX_SAFE_WEIGHT_BIAS} on creature ${creature.uuid ?? "unknown"}: ` +
+        `±${MAX_SAFE_WEIGHT_BIAS} on creature ${uuidLabel} (source=${source}): ` +
         `${clampedWeightCount} weight(s) (max |w|=${maxObservedWeight}), ` +
         `${clampedBiasCount} bias(es) (max |b|=${maxObservedBias}).`,
     );
@@ -633,6 +656,7 @@ export function fromJSON(
       options: { lazyInitialization: boolean; semanticVersion?: string },
     ): Creature;
   },
+  source: string = "fromJSON",
 ): Creature {
   // Issue #2349: treat empty/falsy semanticVersion the same as missing.
   // An empty version is NOT a genuine "0.x" legacy creature — it's a
@@ -656,7 +680,7 @@ export function fromJSON(
     raw.synapses = raw.connections;
     delete raw.connections;
   }
-  loadFrom(creature, json, validate);
+  loadFrom(creature, json, validate, source);
 
   return creature;
 }

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -552,7 +552,7 @@ export async function evolveDir(
   await neat.discoveryReplayQueue.waitForCompletion();
 
   if (bestCreature) {
-    creature.loadFrom(bestCreature, config.debug);
+    creature.loadFrom(bestCreature, config.debug, "training:restoreBest");
   }
 
   if (config.creatureStore) {

--- a/src/predictiveCoding/PredictiveCodingTrainer.ts
+++ b/src/predictiveCoding/PredictiveCodingTrainer.ts
@@ -290,7 +290,7 @@ export function trainWithPredictiveCoding(
 
   // Restore best creature if last iteration was worse.
   const finalError = bestError ?? Infinity;
-  creature.loadFrom(bestCreatureJSON, false);
+  creature.loadFrom(bestCreatureJSON, false, "predictiveCoding:restoreBest");
 
   return {
     error: finalError,

--- a/src/propagate/RemoveSyntheticSynapses.ts
+++ b/src/propagate/RemoveSyntheticSynapses.ts
@@ -69,7 +69,11 @@ export function removeSyntheticSynapses(
     // removal, orphan cleanup, and dead subgraph pruning (DRY).
     const compacted = creature.compact(false);
     if (compacted) {
-      creature.loadFrom(compacted.exportJSON(), false);
+      creature.loadFrom(
+        compacted.exportJSON(),
+        false,
+        "compact:removeSynthetic",
+      );
     }
   }
 

--- a/src/transfer/CompactModuleGraft.ts
+++ b/src/transfer/CompactModuleGraft.ts
@@ -542,7 +542,7 @@ export class CompactModuleGraftStrategy implements DnaSharingStrategy {
   ): Promise<void> {
     const grafted = compactModuleGraft(recipient, donor, this.opts);
     if (grafted) {
-      recipient.loadFrom(grafted.exportJSON(), false);
+      recipient.loadFrom(grafted.exportJSON(), false, "transfer:compactGraft");
     }
     return Promise.resolve();
   }

--- a/src/transfer/KnowledgeDistillation.ts
+++ b/src/transfer/KnowledgeDistillation.ts
@@ -383,7 +383,11 @@ export class KnowledgeDistillationStrategy implements DnaSharingStrategy {
     };
     const distilled = knowledgeDistillation(recipient, donor, merged);
     if (distilled) {
-      recipient.loadFrom(distilled.exportJSON(), false);
+      recipient.loadFrom(
+        distilled.exportJSON(),
+        false,
+        "transfer:distillation",
+      );
     }
     return Promise.resolve();
   }

--- a/src/utils/CreatureStructuralHash.ts
+++ b/src/utils/CreatureStructuralHash.ts
@@ -1,0 +1,86 @@
+/**
+ * Structural hash helper used by loadFrom warnings (Issue #2500).
+ *
+ * Production logs were repeatedly showing
+ * `[loadFrom] Stripping recurrent synapse ... (UUID: unknown)` because
+ * `CreatureExport` JSON omits the creature's `uuid` field. Without a
+ * stable identifier the warnings cannot be correlated and the upstream
+ * corruption source remains unknown.
+ *
+ * This module computes a short deterministic hash of the creature JSON
+ * (input/output sizes, neuron uuids/types, and synapse uuid endpoints)
+ * so that two corrupt copies of the same creature share a hash even
+ * when no `uuid` is present.
+ */
+import type {
+  CreatureExport,
+  CreatureInternal,
+} from "@architecture/CreatureInterfaces.ts";
+import type {
+  SynapseExport,
+  SynapseInternal,
+} from "@architecture/SynapseInterfaces.ts";
+
+/** FNV-1a 32-bit hash (deterministic, dependency-free). */
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    // Equivalent to multiplying by the FNV prime (16777619) modulo 2^32.
+    hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) +
+      (hash << 24))) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Compute a stable 8-character hex hash from a creature JSON payload.
+ *
+ * The hash is intentionally cheap — it is only used for log correlation,
+ * not security. Inputs:
+ *  - input/output neuron counts
+ *  - per-neuron `type:uuid` (sorted by uuid for synapse-order independence
+ *    only on the synapse list; neurons keep their array order so creatures
+ *    with reordered hidden layers do not collide)
+ *  - sorted list of `fromUUID->toUUID` (or numeric fallbacks) per synapse
+ */
+export function computeCreatureStructuralHash(
+  json: CreatureExport | CreatureInternal,
+): string {
+  const parts: string[] = [];
+  parts.push(`i${json.input ?? 0}`);
+  parts.push(`o${json.output ?? 0}`);
+  parts.push(`fo:${(json as CreatureExport).forwardOnly === true ? 1 : 0}`);
+
+  const neurons = Array.isArray(json.neurons) ? json.neurons : [];
+  parts.push(`n${neurons.length}`);
+  for (const n of neurons) {
+    if (!n) continue;
+    const uuid = typeof (n as { uuid?: unknown }).uuid === "string"
+      ? (n as { uuid: string }).uuid
+      : "";
+    parts.push(`${n.type ?? "?"}:${uuid}`);
+  }
+
+  const synapses = Array.isArray(json.synapses) ? json.synapses : [];
+  parts.push(`s${synapses.length}`);
+  const synEntries: string[] = new Array(synapses.length);
+  for (let i = 0; i < synapses.length; i++) {
+    const s = synapses[i] as SynapseExport & SynapseInternal;
+    if (!s) {
+      synEntries[i] = "";
+      continue;
+    }
+    const fromKey = typeof s.fromUUID === "string"
+      ? s.fromUUID
+      : `#${s.fromId ?? s.from ?? "?"}`;
+    const toKey = typeof s.toUUID === "string"
+      ? s.toUUID
+      : `#${s.toId ?? s.to ?? "?"}`;
+    synEntries[i] = `${fromKey}->${toKey}`;
+  }
+  synEntries.sort();
+  for (const entry of synEntries) parts.push(entry);
+
+  return fnv1a32(parts.join("|")).toString(16).padStart(8, "0");
+}

--- a/test/architecture/ForwardOnlyAssertion.ts
+++ b/test/architecture/ForwardOnlyAssertion.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for assertNoRecurrentSynapseOnForwardOnly (Issue #2500).
+ *
+ * The assertion is intended to be called at the corruption introduction
+ * point (mutation, breeding, discovery, coordinated structural
+ * application) so a forward-only creature that gains a recurrent synapse
+ * fails fast with a useful stack trace, instead of being silently
+ * stripped by `loadFrom`.
+ */
+import { assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import { Synapse } from "@architecture/Synapse.ts";
+import { assertNoRecurrentSynapseOnForwardOnly } from "@architecture/ForwardOnlyAssertion.ts";
+import { TopologyError } from "@errors/TopologyError.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+Deno.test("assertNoRecurrentSynapseOnForwardOnly: no-op when forwardOnly false", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { feedbackEnabled: true });
+  c.forwardOnly = false;
+  // Should not throw even with no synapses or with mixed shapes.
+  assertNoRecurrentSynapseOnForwardOnly(c, "unit-test");
+});
+
+Deno.test("assertNoRecurrentSynapseOnForwardOnly: passes for valid forward-only creature", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { layers: [{ count: 2 }] });
+  c.forwardOnly = true;
+  // The default constructor gives a valid forward-only topology.
+  assertNoRecurrentSynapseOnForwardOnly(c, "unit-test");
+});
+
+Deno.test("assertNoRecurrentSynapseOnForwardOnly: throws on self-loop", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { layers: [{ count: 2 }] });
+  c.forwardOnly = true;
+  // Inject a forbidden self-loop on the output neuron.
+  const outIdx = c.neurons.length - 1;
+  c.synapses.push(new Synapse(outIdx, outIdx, 0.1));
+
+  const err = assertThrows(
+    () => assertNoRecurrentSynapseOnForwardOnly(c, "mutation:test"),
+    TopologyError,
+  );
+  // Confirm useful diagnostics.
+  const msg = String((err as Error).message);
+  assertEquals(msg.includes("mutation:test"), true);
+  assertEquals(msg.includes("recurrent synapse"), true);
+});
+
+Deno.test("assertNoRecurrentSynapseOnForwardOnly: throws on backward edge", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { layers: [{ count: 2 }] });
+  c.forwardOnly = true;
+  const outIdx = c.neurons.length - 1;
+  const hiddenIdx = outIdx - 1;
+  // Backward edge output -> hidden (from > to).
+  c.synapses.push(new Synapse(outIdx, hiddenIdx, 0.1));
+
+  assertThrows(
+    () => assertNoRecurrentSynapseOnForwardOnly(c, "breed:test"),
+    TopologyError,
+    "breed:test",
+  );
+});

--- a/test/creature/LoadFromObservability.ts
+++ b/test/creature/LoadFromObservability.ts
@@ -1,0 +1,151 @@
+/**
+ * Issue #2500: when `loadFrom` strips a recurrent synapse from a
+ * forward-only creature, the warning must include
+ *  - a usable creature identifier (uuid OR `hash:<8hex>` fallback)
+ *  - a `source=...` tag describing the upstream pipeline
+ *
+ * Without these, GRQ logs show `UUID: unknown` for every event and the
+ * upstream corruption source cannot be traced (regression of GRQ#1497,
+ * GRQ#1906).
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { fromJSON, loadFrom } from "@creature/CreatureSerialization.ts";
+import { getLogger } from "@utils/Logger.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = false;
+
+/** Build an export-shaped JSON for a forward-only creature with a
+ *  poisoned recurrent synapse (output -> hidden self-loop is forward-only
+ *  invalid). The `uuid` field is intentionally omitted so the test
+ *  exercises the structural-hash fallback path. */
+function makeForwardOnlyExportWithRecurrent(): CreatureExport {
+  return {
+    semanticVersion: "4.0.0",
+    forwardOnly: true,
+    input: 2,
+    output: 1,
+    neurons: [
+      // hidden at index 2
+      { type: "hidden", uuid: "h-1", squash: "IDENTITY", bias: 0 },
+      // output at index 3
+      { type: "output", uuid: "o-0", squash: "IDENTITY", bias: 0 },
+    ],
+    // input-0 (idx 0) -> hidden (idx 2),
+    // hidden -> output, plus a recurrent output -> output self-loop.
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h-1", weight: 0.1 },
+      { fromUUID: "h-1", toUUID: "o-0", weight: 0.2 },
+      { fromUUID: "o-0", toUUID: "o-0", weight: 0.3 },
+    ],
+  } as unknown as CreatureExport;
+}
+
+Deno.test("loadFrom strip warning: no longer says 'UUID: unknown'", async () => {
+  await initWasmForTests();
+
+  const logger = getLogger();
+  const original = logger.error.bind(logger);
+  const captured: string[] = [];
+  logger.error = (...args: unknown[]) => {
+    captured.push(args.map(String).join(" "));
+  };
+  try {
+    const creature = fromJSON(
+      makeForwardOnlyExportWithRecurrent(),
+      false,
+      Creature,
+    );
+    assert(creature, "fromJSON must still produce a creature");
+  } finally {
+    logger.error = original;
+  }
+
+  const stripWarnings = captured.filter((m) =>
+    m.includes("Stripping recurrent synapse")
+  );
+  assert(stripWarnings.length > 0, "expected at least one strip warning");
+  for (const w of stripWarnings) {
+    assert(
+      !/UUID:\s*unknown/.test(w),
+      `Issue #2500: warning must not include 'UUID: unknown'; got: ${w}`,
+    );
+    assert(
+      /UUID:\s*(?:[0-9a-f-]{8,}|hash:[0-9a-f]{8})/i.test(w),
+      `Issue #2500: warning must include uuid or hash:<8hex>; got: ${w}`,
+    );
+    assert(
+      /source=/.test(w),
+      `Issue #2500: warning must include source=...; got: ${w}`,
+    );
+  }
+});
+
+Deno.test("loadFrom strip warning: source=... reflects caller tag", async () => {
+  await initWasmForTests();
+
+  const logger = getLogger();
+  const original = logger.error.bind(logger);
+  const captured: string[] = [];
+  logger.error = (...args: unknown[]) => {
+    captured.push(args.map(String).join(" "));
+  };
+  try {
+    const target = new Creature(2, 1, { feedbackEnabled: false });
+    target.forwardOnly = true;
+    loadFrom(
+      target,
+      makeForwardOnlyExportWithRecurrent(),
+      false,
+      "unit-test:custom-source",
+    );
+  } finally {
+    logger.error = original;
+  }
+
+  const stripWarnings = captured.filter((m) =>
+    m.includes("Stripping recurrent synapse")
+  );
+  assert(stripWarnings.length > 0, "expected strip warnings");
+  for (const w of stripWarnings) {
+    assert(
+      w.includes("source=unit-test:custom-source"),
+      `expected source tag in warning, got: ${w}`,
+    );
+  }
+});
+
+Deno.test("loadFrom strip warning: same JSON yields the same hash twice", async () => {
+  await initWasmForTests();
+
+  const logger = getLogger();
+  const original = logger.error.bind(logger);
+  const captured: string[] = [];
+  logger.error = (...args: unknown[]) => {
+    captured.push(args.map(String).join(" "));
+  };
+  try {
+    const j1 = makeForwardOnlyExportWithRecurrent();
+    const j2 = makeForwardOnlyExportWithRecurrent();
+    fromJSON(j1, false, Creature);
+    fromJSON(j2, false, Creature);
+  } finally {
+    logger.error = original;
+  }
+
+  const hashes = new Set<string>();
+  const re = /hash:([0-9a-f]{8})/;
+  for (const w of captured) {
+    const m = w.match(re);
+    if (m) hashes.add(m[1]);
+  }
+  assertEquals(
+    hashes.size,
+    1,
+    `expected the same structural hash for identical JSON, got ${
+      [...hashes].join(", ")
+    }`,
+  );
+});

--- a/test/utils/CreatureStructuralHash.ts
+++ b/test/utils/CreatureStructuralHash.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the structural-hash helper used by loadFrom warnings (Issue #2500).
+ */
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { computeCreatureStructuralHash } from "@utils/CreatureStructuralHash.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+
+function makeExport(): CreatureExport {
+  return {
+    semanticVersion: "4.0.0",
+    forwardOnly: true,
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h-1", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "o-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h-1", weight: 0.1 },
+      { fromUUID: "h-1", toUUID: "o-0", weight: 0.2 },
+    ],
+  } as unknown as CreatureExport;
+}
+
+Deno.test("computeCreatureStructuralHash: stable for the same JSON", () => {
+  const a = makeExport();
+  const b = makeExport();
+  assertEquals(
+    computeCreatureStructuralHash(a),
+    computeCreatureStructuralHash(b),
+  );
+});
+
+Deno.test("computeCreatureStructuralHash: hex digits only, length 8", () => {
+  const hash = computeCreatureStructuralHash(makeExport());
+  assert(/^[0-9a-f]{8}$/.test(hash), `hash must be 8 hex chars, got ${hash}`);
+});
+
+Deno.test("computeCreatureStructuralHash: insensitive to synapse order", () => {
+  const a = makeExport();
+  const b = makeExport();
+  b.synapses = [b.synapses[1], b.synapses[0]];
+  assertEquals(
+    computeCreatureStructuralHash(a),
+    computeCreatureStructuralHash(b),
+  );
+});
+
+Deno.test("computeCreatureStructuralHash: differs when topology changes", () => {
+  const a = makeExport();
+  const b = makeExport();
+  // Add a recurrent self-loop on the output neuron.
+  b.synapses.push({ fromUUID: "o-0", toUUID: "o-0", weight: 0.3 } as never);
+  assertNotEquals(
+    computeCreatureStructuralHash(a),
+    computeCreatureStructuralHash(b),
+  );
+});
+
+Deno.test("computeCreatureStructuralHash: differs when input/output change", () => {
+  const a = makeExport();
+  const b = makeExport();
+  b.input = 3;
+  assertNotEquals(
+    computeCreatureStructuralHash(a),
+    computeCreatureStructuralHash(b),
+  );
+});


### PR DESCRIPTION
# Stamp creature UUID before loadFrom strips recurrent synapses (#2500)

## Summary

Production logs were repeatedly emitting `🚨 [loadFrom] Stripping
recurrent synapse … from forward-only creature (UUID: unknown). This
indicates upstream corruption.` 50 times in a single GRQ-3 run. The
`UUID: unknown` text made it impossible to correlate corrupt-creature
events or trace the upstream pipeline that produced them — a regression
of GRQ#1497 / GRQ#1906.

The root cause is that `CreatureExport` JSON deliberately omits the
creature `uuid` (it is wire-only), so `loadFrom` had no identifier to
report when the synapse-strip warning fired.

This change makes the warning genuinely diagnostic:

- **Stable identifier**: when `creature.uuid` is missing, `loadFrom`
  computes a deterministic `hash:<8hex>` from the JSON payload (input/
  output sizes, neuron uuids/types, sorted synapse `fromUUID->toUUID`
  pairs). The same poisoned creature now produces the same hash on
  every machine, so events can be correlated.
- **`source=...` tag**: every caller of `loadFrom` now passes a short
  string identifying the upstream pipeline (`breed:fixAliases`,
  `transfer:compactGraft`, `training:teardownRestore`,
  `compact:deadSubgraphPruning`, `predictiveCoding:restoreBest`, etc.).
  The tag is included in the strip warning so the offending pipeline
  is visible from a single log line.
- **Assertion helper**: a new
  `assertNoRecurrentSynapseOnForwardOnly(creature, source)` lets
  pipelines that produce structures fail fast at the corruption
  introduction point instead of leaving the silent-strip in `loadFrom`
  as the only signal.

Closes #2500.

## Evidence

This is a backend / CLI change with no UI to screenshot. Behaviour is
verified by three new test files (see Test Plan).

```mermaid
flowchart LR
  A[Mutation / Breeding / Discovery]
  A -->|introduces recurrent synapse| B[Creature with no UUID]
  B --> C[saved to disk as CreatureExport]
  C --> D[loadFrom strips synapse]
  D -->|before #2500| E[warning: UUID=unknown — useless]
  D -->|after #2500| F["warning: UUID=hash:abcd1234, source=breed:fixAliases"]
  A -.->|optional| G[assertNoRecurrentSynapseOnForwardOnly]
  G -->|throws TopologyError| H[useful stack trace at source]
```

Sample warning before and after:

```
# before
🚨 [loadFrom] Stripping recurrent synapse 2738->2736 (fromUUID=output-0, toUUID=d276ed0d-…) from forward-only creature (UUID: unknown). This indicates upstream corruption.

# after
🚨 [loadFrom] Stripping recurrent synapse 2738->2736 (fromUUID=output-0, toUUID=d276ed0d-…) from forward-only creature (UUID: hash:1a2b3c4d, source=breed:fixAliases). This indicates upstream corruption.
```

## Test Plan

- `test/utils/CreatureStructuralHash.ts` — verifies the hash is stable,
  hex-only, insensitive to synapse order, and changes when topology /
  input / output changes.
- `test/creature/LoadFromObservability.ts` — verifies that
  `loadFrom` warnings (a) never contain `UUID: unknown`, (b) always
  contain a uuid or `hash:<8hex>` identifier, (c) reflect the caller's
  `source=…` tag, and (d) assign the same hash to identical JSON twice.
- `test/architecture/ForwardOnlyAssertion.ts` — verifies the new
  `assertNoRecurrentSynapseOnForwardOnly` helper is a no-op for valid
  forward-only creatures and throws a `TopologyError` (with `source`
  tag) for self-loops and backward edges.

All 6335 tests pass via `./quality.sh --skip-discovery --skip-wasm`.

## Files changed

- `src/utils/CreatureStructuralHash.ts` *(new)* — FNV-1a 32-bit hash
  helper.
- `src/architecture/ForwardOnlyAssertion.ts` *(new)* — corruption
  introduction-point assertion.
- `src/creature/CreatureSerialization.ts` — `loadFrom` and `fromJSON`
  accept an optional `source` parameter; strip and clamp warnings now
  include uuid-or-hash and `source=…`.
- `src/Creature.ts` — `Creature.loadFrom` and `Creature.fromJSON`
  forward the new `source` parameter.
- `src/architecture/Offspring.ts`, `src/transfer/CompactModuleGraft.ts`,
  `src/transfer/KnowledgeDistillation.ts`,
  `src/architecture/training/TrainingOutcome.ts`,
  `src/architecture/training/TrainingTeardown.ts`,
  `src/architecture/CrossValidationTrainer.ts`,
  `src/predictiveCoding/PredictiveCodingTrainer.ts`,
  `src/creature/CreatureTraining.ts`,
  `src/propagate/RemoveSyntheticSynapses.ts`,
  `src/compact/DeadSubgraphPruning.ts`,
  `src/compact/OrphanedNeuronCleanup.ts` — pass meaningful `source`
  tags.
- `test/utils/CreatureStructuralHash.ts` *(new)*,
  `test/creature/LoadFromObservability.ts` *(new)*,
  `test/architecture/ForwardOnlyAssertion.ts` *(new)* — coverage for
  the new behaviour.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2500 -->