### PR TITLE
Tighten Rust FFI per-chunk deadline so a chunk cannot over-spend budget (#2501)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.49",
+  "version": "3.1.50",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2501.md
+++ b/docs/pr-summary-2501.md
@@ -1,0 +1,71 @@
+# Tighten Rust FFI per-chunk deadline so a single chunk cannot over-spend the budget
+
+## Summary
+
+The synchronous Rust combined-analysis FFI used to receive the full
+**overall** discovery deadline (e.g. 10 minutes) and could happily run for
+nearly twice the per-chunk budget before returning. Issue #2420's
+`Promise.race` only protected the asynchronous `runParallelAnalysis`
+fallback path — it cannot interrupt a blocking FFI call, because the JS
+event loop is suspended while Rust is running. As a result, GRQ-3-sloth
+saw chunk 1/3 take **3m 49s** against a **2m** per-chunk budget, then
+chunks 2 and 3 were skipped after the budget had already been violated.
+
+This change forwards a **per-chunk** `analysisDeadlineMs` to Rust. Rust
+already self-aborts on this deadline; we now compute it as
+`chunkStart + perChunkMaxMs + grace` so a single chunk cannot consume far
+more than its allotted budget regardless of how much overall analysis
+window remains. The Rust-side deadline is the only mechanism that can
+actually bound a synchronous FFI call's wall-clock — the existing JS-side
+post-call check fires too late by definition.
+
+Closes #2501.
+
+## Evidence
+
+Backend / CLI change — no UI. Verified by:
+
+- New regression test
+  `runAnalysisLoop forwards a tight per-chunk deadline to Rust (Issue #2501)`
+  asserts the spy on `analyzeParallel` receives
+  `analysisDeadlineMs === chunkStart + perChunkMaxMs + grace`. Confirmed
+  the test **fails** before the production change is applied (verified by
+  stashing `DataRecorderAnalysis.ts`, `DiscoverStructureAnalysis.ts`, and
+  `RustAnalysisCache.ts`, then running the suite — the new test then
+  reports `Values are not equal: ... got 1777576109855, expected 5121000`).
+  After restoring the change, all 9 tests in the suite pass.
+- Companion test
+  `runAnalysisLoop omits per-chunk deadline tightening when stall guard disabled (Issue #2501)`
+  guards the negative case: when `perChunkMaxMs <= 0`, no chunk-level
+  tightening is applied and the overall analysis deadline is forwarded
+  unchanged.
+- All 113 tests under `test/ErrorGuidedStructuralEvolution/` pass.
+- `./quality.sh --skip-tests --skip-discovery --skip-wasm` (lint, fmt,
+  bash check, type-check) is green.
+
+```mermaid
+flowchart LR
+  subgraph "Before"
+    A1[chunk i] --> B1["ensureRustCombinedAnalysis<br/>(deadline = overall, e.g. 10 min)"]
+    B1 -->|"Rust runs ~2x budget,<br/>blocks event loop"| C1["chunkElapsed<br/>check fires late"]
+  end
+  subgraph "After (Issue #2501)"
+    A2[chunk i] --> B2["ensureRustCombinedAnalysis<br/>(deadline = chunkStart +<br/>perChunkMaxMs + grace)"]
+    B2 -->|"Rust self-aborts<br/>near per-chunk budget"| C2["chunkElapsed ≤<br/>perChunkMaxMs + grace"]
+  end
+```
+
+## Test Plan
+
+- Added: `runAnalysisLoop forwards a tight per-chunk deadline to Rust (Issue #2501)`
+  in `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` —
+  asserts the deadline forwarded to the `analyzeParallel` spy equals
+  `chunkStart + perChunkMaxMs + perChunkGraceMs`.
+- Added: `runAnalysisLoop omits per-chunk deadline tightening when stall guard disabled (Issue #2501)` —
+  asserts that with `perChunkMaxMs = 0` the deadline is **not** tightened
+  below the overall analysis deadline.
+- Extended `runWithMockedAnalyzeParallel` to capture each call's
+  `analysisDeadlineMs` and the time it was captured at, plus a new
+  `perChunkGraceMs` knob plumbed through to the loop context.
+- Existing chunking, stall-guard, and defence-in-depth iteration-cap
+  tests continue to pass.

--- a/docs/pr-summary-2501.md
+++ b/docs/pr-summary-2501.md
@@ -2,22 +2,22 @@
 
 ## Summary
 
-The synchronous Rust combined-analysis FFI used to receive the full
-**overall** discovery deadline (e.g. 10 minutes) and could happily run for
-nearly twice the per-chunk budget before returning. Issue #2420's
-`Promise.race` only protected the asynchronous `runParallelAnalysis`
-fallback path — it cannot interrupt a blocking FFI call, because the JS
-event loop is suspended while Rust is running. As a result, GRQ-3-sloth
-saw chunk 1/3 take **3m 49s** against a **2m** per-chunk budget, then
-chunks 2 and 3 were skipped after the budget had already been violated.
+The synchronous Rust combined-analysis FFI used to receive the full **overall**
+discovery deadline (e.g. 10 minutes) and could happily run for nearly twice the
+per-chunk budget before returning. Issue #2420's `Promise.race` only protected
+the asynchronous `runParallelAnalysis` fallback path — it cannot interrupt a
+blocking FFI call, because the JS event loop is suspended while Rust is running.
+As a result, GRQ-3-sloth saw chunk 1/3 take **3m 49s** against a **2m**
+per-chunk budget, then chunks 2 and 3 were skipped after the budget had already
+been violated.
 
-This change forwards a **per-chunk** `analysisDeadlineMs` to Rust. Rust
-already self-aborts on this deadline; we now compute it as
-`chunkStart + perChunkMaxMs + grace` so a single chunk cannot consume far
-more than its allotted budget regardless of how much overall analysis
-window remains. The Rust-side deadline is the only mechanism that can
-actually bound a synchronous FFI call's wall-clock — the existing JS-side
-post-call check fires too late by definition.
+This change forwards a **per-chunk** `analysisDeadlineMs` to Rust. Rust already
+self-aborts on this deadline; we now compute it as
+`chunkStart + perChunkMaxMs + grace` so a single chunk cannot consume far more
+than its allotted budget regardless of how much overall analysis window remains.
+The Rust-side deadline is the only mechanism that can actually bound a
+synchronous FFI call's wall-clock — the existing JS-side post-call check fires
+too late by definition.
 
 Closes #2501.
 
@@ -28,20 +28,19 @@ Backend / CLI change — no UI. Verified by:
 - New regression test
   `runAnalysisLoop forwards a tight per-chunk deadline to Rust (Issue #2501)`
   asserts the spy on `analyzeParallel` receives
-  `analysisDeadlineMs === chunkStart + perChunkMaxMs + grace`. Confirmed
-  the test **fails** before the production change is applied (verified by
-  stashing `DataRecorderAnalysis.ts`, `DiscoverStructureAnalysis.ts`, and
-  `RustAnalysisCache.ts`, then running the suite — the new test then
-  reports `Values are not equal: ... got 1777576109855, expected 5121000`).
-  After restoring the change, all 9 tests in the suite pass.
+  `analysisDeadlineMs === chunkStart + perChunkMaxMs + grace`. Confirmed the
+  test **fails** before the production change is applied (verified by stashing
+  `DataRecorderAnalysis.ts`, `DiscoverStructureAnalysis.ts`, and
+  `RustAnalysisCache.ts`, then running the suite — the new test then reports
+  `Values are not equal: ... got 1777576109855, expected 5121000`). After
+  restoring the change, all 9 tests in the suite pass.
 - Companion test
   `runAnalysisLoop omits per-chunk deadline tightening when stall guard disabled (Issue #2501)`
-  guards the negative case: when `perChunkMaxMs <= 0`, no chunk-level
-  tightening is applied and the overall analysis deadline is forwarded
-  unchanged.
+  guards the negative case: when `perChunkMaxMs <= 0`, no chunk-level tightening
+  is applied and the overall analysis deadline is forwarded unchanged.
 - All 113 tests under `test/ErrorGuidedStructuralEvolution/` pass.
-- `./quality.sh --skip-tests --skip-discovery --skip-wasm` (lint, fmt,
-  bash check, type-check) is green.
+- `./quality.sh --skip-tests --skip-discovery --skip-wasm` (lint, fmt, bash
+  check, type-check) is green.
 
 ```mermaid
 flowchart LR
@@ -57,15 +56,17 @@ flowchart LR
 
 ## Test Plan
 
-- Added: `runAnalysisLoop forwards a tight per-chunk deadline to Rust (Issue #2501)`
-  in `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` —
-  asserts the deadline forwarded to the `analyzeParallel` spy equals
+- Added:
+  `runAnalysisLoop forwards a tight per-chunk deadline to Rust (Issue #2501)` in
+  `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` — asserts
+  the deadline forwarded to the `analyzeParallel` spy equals
   `chunkStart + perChunkMaxMs + perChunkGraceMs`.
-- Added: `runAnalysisLoop omits per-chunk deadline tightening when stall guard disabled (Issue #2501)` —
-  asserts that with `perChunkMaxMs = 0` the deadline is **not** tightened
+- Added:
+  `runAnalysisLoop omits per-chunk deadline tightening when stall guard disabled (Issue #2501)`
+  — asserts that with `perChunkMaxMs = 0` the deadline is **not** tightened
   below the overall analysis deadline.
 - Extended `runWithMockedAnalyzeParallel` to capture each call's
   `analysisDeadlineMs` and the time it was captured at, plus a new
   `perChunkGraceMs` knob plumbed through to the loop context.
-- Existing chunking, stall-guard, and defence-in-depth iteration-cap
-  tests continue to pass.
+- Existing chunking, stall-guard, and defence-in-depth iteration-cap tests
+  continue to pass.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
@@ -356,10 +356,23 @@ export async function runAnalysisLoop(
         }
       }
       const chunkStart = now();
+      // Issue #2501: tighten the deadline forwarded to Rust per chunk so a
+      // single synchronous FFI call cannot burn far more than its budget.
+      // JS cannot interrupt the blocking FFI; the Rust-side deadline is the
+      // only mechanism that actually bounds a chunk's wall-clock. We add a
+      // small grace so well-behaved chunks finish without being clipped.
+      const chunkGraceMs = Math.max(
+        0,
+        ctx.perChunkGraceMs ?? DEFAULT_PER_CHUNK_GRACE_MS,
+      );
+      const chunkDeadlineMs = ctx.perChunkMaxMs > 0
+        ? chunkStart + ctx.perChunkMaxMs + chunkGraceMs
+        : undefined;
       const combinedResult = discoverStructure.ensureRustCombinedAnalysis(
         chunk,
         true, // includeSynapse
         true, // includeNeuron
+        chunkDeadlineMs,
       );
       const chunkElapsed = now() - chunkStart;
       perfStats.rustCombinedAnalysisTime += chunkElapsed;

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureAnalysis.ts
@@ -192,6 +192,13 @@ export class DiscoverStructureAnalysis extends DiscoverStructureRecording {
     focusList: number[],
     includeSynapse: boolean,
     includeNeuron: boolean,
+    /**
+     * Optional tighter per-chunk deadline (Issue #2501). Forwarded to Rust
+     * via `RustParallelAnalysisInput.analysisDeadlineMs` so the synchronous
+     * FFI call self-aborts close to the per-chunk budget instead of running
+     * for the full analysis window.
+     */
+    chunkDeadlineMs?: number,
   ): RustAnalyzeAllResult | undefined {
     const result = ensureRustCombinedAnalysisImpl(
       this.creature,
@@ -203,6 +210,7 @@ export class DiscoverStructureAnalysis extends DiscoverStructureRecording {
       includeSynapse,
       includeNeuron,
       (scope, fl, reason) => this.logRustAnalysisUnavailable(scope, fl, reason),
+      chunkDeadlineMs,
     );
     this.combinedRustAnalysis = result.cache;
     return result.result;

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts
@@ -85,6 +85,13 @@ export function ensureRustCombinedAnalysis(
     focusList: number[],
     reason: string,
   ) => void,
+  /**
+   * Optional tighter per-chunk deadline (Issue #2501). When set, the smaller
+   * of `chunkDeadlineMs` and `analysisDeadlineMs` is forwarded to Rust so a
+   * single chunk cannot burn more than its allotted budget plus grace, even
+   * when the overall analysis deadline is far in the future.
+   */
+  chunkDeadlineMs?: number,
 ): {
   result: RustAnalyzeAllResult | undefined;
   cache: CombinedAnalysisCache | undefined;
@@ -137,6 +144,18 @@ export function ensureRustCombinedAnalysis(
     );
   }
 
+  // Issue #2501: when a per-chunk deadline is supplied, give Rust the tighter
+  // of the two so the synchronous FFI call self-aborts close to the per-chunk
+  // budget instead of running for the full analysis window. JS cannot
+  // interrupt the blocking FFI, so the Rust-side deadline is the only path
+  // to bound a single chunk's wall-clock.
+  const effectiveDeadlineMs = chunkDeadlineMs !== undefined &&
+      Number.isFinite(chunkDeadlineMs)
+    ? (analysisDeadlineMs !== undefined && Number.isFinite(analysisDeadlineMs)
+      ? Math.min(analysisDeadlineMs, chunkDeadlineMs)
+      : chunkDeadlineMs)
+    : analysisDeadlineMs;
+
   const parallelInput: RustParallelAnalysisInput = {
     parquetFile: parquetFilePath,
     creature: rustCreature,
@@ -147,7 +166,7 @@ export function ensureRustCombinedAnalysis(
     maxNeuronCandidates: includeNeuron
       ? Math.max(25, focusList.length * 5)
       : undefined,
-    analysisDeadlineMs,
+    analysisDeadlineMs: effectiveDeadlineMs,
     focusNeuronErrorShares,
   };
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts
@@ -94,18 +94,28 @@ interface SpyRunOptions {
   readonly perChunkMaxMs: number;
   readonly discoveryMaxNeurons?: number;
   readonly now?: () => number;
+  readonly perChunkGraceMs?: number;
+}
+
+interface CapturedCall {
+  readonly focusSize: number;
+  readonly analysisDeadlineMs: number | undefined;
+  readonly capturedAtMs: number;
 }
 
 async function runWithMockedAnalyzeParallel(
   options: SpyRunOptions,
 ): Promise<{
   capturedFocusSizes: number[];
+  capturedCalls: CapturedCall[];
   perfStats: DiscoveryPerformanceStats;
 }> {
   await initWasmForTests();
 
   const creature = makeTestCreature();
   const capturedFocusSizes: number[] = [];
+  const capturedCalls: CapturedCall[] = [];
+  const nowFn = options.now ?? Date.now;
 
   // Create a real on-disk "parquet" stand-in so the existence check in
   // loadNeuronRecords passes. The mocked readDiscoveryRecords returns an
@@ -125,6 +135,11 @@ async function runWithMockedAnalyzeParallel(
     }),
     analyzeParallel: (input) => {
       capturedFocusSizes.push(input.focusNeurons.length);
+      capturedCalls.push({
+        focusSize: input.focusNeurons.length,
+        analysisDeadlineMs: input.analysisDeadlineMs,
+        capturedAtMs: nowFn(),
+      });
       return options.analyzeParallel(input);
     },
     readDiscoveryRecords: () => ({ success: true, records: [] }),
@@ -161,6 +176,7 @@ async function runWithMockedAnalyzeParallel(
         costOfGrowth: 0,
         analysisChunkSize: options.analysisChunkSize,
         perChunkMaxMs: options.perChunkMaxMs,
+        perChunkGraceMs: options.perChunkGraceMs,
         now: options.now,
         getTimeoutTS: () => deadlineMs,
         refreshAnalysisTimeout: () => {},
@@ -178,7 +194,7 @@ async function runWithMockedAnalyzeParallel(
     }
   }
 
-  return { capturedFocusSizes, perfStats };
+  return { capturedFocusSizes, capturedCalls, perfStats };
 }
 
 Deno.test("chunkFocusList splits into fixed-size sublists", () => {
@@ -279,6 +295,84 @@ Deno.test("runAnalysisLoop aborts retries when a single chunk exceeds perChunkMa
     perfStats.analysisStalled,
     "performance stats should record analysisStalled=true when stall guard trips",
   );
+});
+
+Deno.test("runAnalysisLoop forwards a tight per-chunk deadline to Rust (Issue #2501)", async () => {
+  // Use a fake clock that does NOT advance, so the chunk start observed
+  // inside the loop equals the time captured when analyzeParallel is invoked.
+  // That lets us assert the deadline forwarded to Rust is exactly
+  // chunkStart + perChunkMaxMs + grace, regardless of how long the overall
+  // discovery analysis window is.
+  const fixedTick = 5_000_000;
+  const fakeNow = () => fixedTick;
+  const perChunkMaxMs = 120_000; // 2 minutes — same shape as the production bug
+  const perChunkGraceMs = 1_000;
+
+  const { capturedCalls } = await runWithMockedAnalyzeParallel({
+    analyzeParallel: () => ({
+      success: true,
+      helpfulNeurons: [],
+      helpfulSynapses: [],
+      harmfulSynapses: [],
+    }),
+    analysisChunkSize: 1,
+    perChunkMaxMs,
+    perChunkGraceMs,
+    discoveryMaxNeurons: 6,
+    now: fakeNow,
+  });
+
+  assert(
+    capturedCalls.length >= 1,
+    `expected at least one Rust analysis call, got ${capturedCalls.length}`,
+  );
+  for (const call of capturedCalls) {
+    assert(
+      call.analysisDeadlineMs !== undefined,
+      "Rust analysis input must carry an analysisDeadlineMs when perChunkMaxMs > 0",
+    );
+    const expected = call.capturedAtMs + perChunkMaxMs + perChunkGraceMs;
+    assertEquals(
+      call.analysisDeadlineMs,
+      expected,
+      `per-chunk deadline forwarded to Rust must equal chunkStart + perChunkMaxMs + grace; got ${call.analysisDeadlineMs}, expected ${expected}`,
+    );
+  }
+});
+
+Deno.test("runAnalysisLoop omits per-chunk deadline tightening when stall guard disabled (Issue #2501)", async () => {
+  const fixedTick = 5_000_000;
+  const fakeNow = () => fixedTick;
+  // 10-minute analysis window from the helper.
+  const overallDeadlineMs = fixedTick + 10 * 60 * 1000;
+
+  const { capturedCalls } = await runWithMockedAnalyzeParallel({
+    analyzeParallel: () => ({
+      success: true,
+      helpfulNeurons: [],
+      helpfulSynapses: [],
+      harmfulSynapses: [],
+    }),
+    analysisChunkSize: 2,
+    perChunkMaxMs: 0, // stall guard disabled
+    discoveryMaxNeurons: 6,
+    now: fakeNow,
+  });
+
+  assert(
+    capturedCalls.length >= 1,
+    "expected at least one Rust analysis call",
+  );
+  for (const call of capturedCalls) {
+    // With perChunkMaxMs=0, no chunk-level tightening is applied; the overall
+    // analysis deadline (or undefined) is forwarded to Rust unchanged.
+    if (call.analysisDeadlineMs !== undefined) {
+      assert(
+        call.analysisDeadlineMs >= overallDeadlineMs - 1_000,
+        `analysisDeadlineMs must not be tightened when perChunkMaxMs=0; got ${call.analysisDeadlineMs}, overall deadline ${overallDeadlineMs}`,
+      );
+    }
+  }
 });
 
 Deno.test("runAnalysisLoop does not mark analysisStalled when all chunks finish within budget", async () => {


### PR DESCRIPTION
# Tighten Rust FFI per-chunk deadline so a single chunk cannot over-spend the budget

## Summary

The synchronous Rust combined-analysis FFI used to receive the full
**overall** discovery deadline (e.g. 10 minutes) and could happily run for
nearly twice the per-chunk budget before returning. Issue #2420's
`Promise.race` only protected the asynchronous `runParallelAnalysis`
fallback path — it cannot interrupt a blocking FFI call, because the JS
event loop is suspended while Rust is running. As a result, GRQ-3-sloth
saw chunk 1/3 take **3m 49s** against a **2m** per-chunk budget, then
chunks 2 and 3 were skipped after the budget had already been violated.

This change forwards a **per-chunk** `analysisDeadlineMs` to Rust. Rust
already self-aborts on this deadline; we now compute it as
`chunkStart + perChunkMaxMs + grace` so a single chunk cannot consume far
more than its allotted budget regardless of how much overall analysis
window remains. The Rust-side deadline is the only mechanism that can
actually bound a synchronous FFI call's wall-clock — the existing JS-side
post-call check fires too late by definition.

Closes #2501.

## Evidence

Backend / CLI change — no UI. Verified by:

- New regression test
  `runAnalysisLoop forwards a tight per-chunk deadline to Rust (Issue #2501)`
  asserts the spy on `analyzeParallel` receives
  `analysisDeadlineMs === chunkStart + perChunkMaxMs + grace`. Confirmed
  the test **fails** before the production change is applied (verified by
  stashing `DataRecorderAnalysis.ts`, `DiscoverStructureAnalysis.ts`, and
  `RustAnalysisCache.ts`, then running the suite — the new test then
  reports `Values are not equal: ... got 1777576109855, expected 5121000`).
  After restoring the change, all 9 tests in the suite pass.
- Companion test
  `runAnalysisLoop omits per-chunk deadline tightening when stall guard disabled (Issue #2501)`
  guards the negative case: when `perChunkMaxMs <= 0`, no chunk-level
  tightening is applied and the overall analysis deadline is forwarded
  unchanged.
- All 113 tests under `test/ErrorGuidedStructuralEvolution/` pass.
- `./quality.sh --skip-tests --skip-discovery --skip-wasm` (lint, fmt,
  bash check, type-check) is green.

```mermaid
flowchart LR
  subgraph "Before"
    A1[chunk i] --> B1["ensureRustCombinedAnalysis<br/>(deadline = overall, e.g. 10 min)"]
    B1 -->|"Rust runs ~2x budget,<br/>blocks event loop"| C1["chunkElapsed<br/>check fires late"]
  end
  subgraph "After (Issue #2501)"
    A2[chunk i] --> B2["ensureRustCombinedAnalysis<br/>(deadline = chunkStart +<br/>perChunkMaxMs + grace)"]
    B2 -->|"Rust self-aborts<br/>near per-chunk budget"| C2["chunkElapsed ≤<br/>perChunkMaxMs + grace"]
  end
```

## Test Plan

- Added: `runAnalysisLoop forwards a tight per-chunk deadline to Rust (Issue #2501)`
  in `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` —
  asserts the deadline forwarded to the `analyzeParallel` spy equals
  `chunkStart + perChunkMaxMs + perChunkGraceMs`.
- Added: `runAnalysisLoop omits per-chunk deadline tightening when stall guard disabled (Issue #2501)` —
  asserts that with `perChunkMaxMs = 0` the deadline is **not** tightened
  below the overall analysis deadline.
- Extended `runWithMockedAnalyzeParallel` to capture each call's
  `analysisDeadlineMs` and the time it was captured at, plus a new
  `perChunkGraceMs` knob plumbed through to the loop context.
- Existing chunking, stall-guard, and defence-in-depth iteration-cap
  tests continue to pass.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2501 -->