### PR TITLE
Document append+demote with fromRelative=99999 in CRISPR validateDNA (Issue #2509)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,6 +561,8 @@ In our production workloads, the default is feed-forward/forward-only.
 - **AGENTS.md** (this file) - Coding guidelines and development reference
 - **COMPARISON.md** - Comparison with other AI approaches
 - **docs/API_REFERENCE.md** - Comprehensive public API reference
+- **docs/CRISPR_GUIDE.md** - CRISPR conventions, append+demote pattern, and
+  validation rules
 - **docs/DISCOVERY_GUIDE.md** - Complete discovery workflow guide
 - **docs/DISCOVERY_ARCHITECTURE.md** - Discovery pipeline internal architecture
 - **docs/DISCOVERY_DIR.md** - Technical API reference for `discoveryDir()`

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.51",
+  "version": "3.1.52",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -118,10 +118,25 @@ const clone = Creature.fromJSON(json);
 Targeted genetic modifications inspired by CRISPR gene-editing technology.
 Allows hand-crafted injection of neurons and synapses.
 
+For the conventions, append+demote pattern, and full validation rules see
+[`docs/CRISPR_GUIDE.md`](CRISPR_GUIDE.md).
+
 ```typescript
-import { CRISPR } from "@stsoftware/neat-ai";
+import {
+  CRISPR,
+  CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX,
+  FROM_RELATIVE_DEMOTED_OUTPUT,
+  validateDNA,
+} from "@stsoftware/neat-ai";
 import type { CrisprInterface } from "@stsoftware/neat-ai";
 ```
+
+#### 📐 Constants
+
+| Constant                                | Value     | Description                                                                                     |
+| --------------------------------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX` | `100_000` | Recommended `index` for the first output neuron in append-mode DNA.                             |
+| `FROM_RELATIVE_DEMOTED_OUTPUT`          | `99_999`  | `fromRelative` value that resolves to the demoted previous `output-0` under the default anchor. |
 
 #### 🏗️ Constructor
 

--- a/docs/CRISPR_GUIDE.md
+++ b/docs/CRISPR_GUIDE.md
@@ -1,0 +1,205 @@
+# CRISPR Guide
+
+Targeted genetic modifications for NEAT-AI creatures, inspired by the
+[CRISPR gene-editing technique](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/).
+This guide complements the CRISPR API summary in
+[`docs/API_REFERENCE.md`](API_REFERENCE.md) with the conventions and gotchas
+that catch out new authors.
+
+## Modes
+
+| Mode     | Purpose                                                                                                          |
+| -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `insert` | Splice new hidden neurons in front of the existing outputs without changing the output count or output squash.   |
+| `append` | Add new neurons (including new outputs) on top of the existing topology. The previous outputs become **hidden**. |
+
+This guide focuses on `append` because that is where the bulk of the
+hand-crafted DNA in production lives — and where the implicit conventions around
+relative indexing live.
+
+## The append + demote pattern
+
+When append-mode DNA defines new output neurons, every previously-existing
+output is **demoted to hidden** and a new output is added in its place. The
+demoted neurons keep their UUIDs and their topological position, so any
+downstream synapse that referenced them by integer `id` continues to resolve.
+The new output, however, is a fresh neuron with its own UUID.
+
+The intended use case is **wrapping** the previous output: the new output reads
+from the demoted previous output via a synapse and applies an extra
+transformation (e.g. a `TANH` clamp or a `MINIMUM` aggregator). This is how the
+GRQ DNA files build per-creature output ensembles on top of an already-trained
+creature.
+
+### Index arithmetic
+
+Inside `CRISPR.append()` (`src/reconstruct/CRISPR.ts`):
+
+```ts
+adjustIndx = firstNetworkOutputIndex - firstDnaOutputIndex + dna.neurons.length;
+```
+
+Every `fromRelative` / `toRelative` value `R` resolves to network index
+`R + adjustIndx`. So picking a large, conventional anchor for
+`firstDnaOutputIndex` keeps `R` values readable.
+
+NEAT-AI exposes two constants for the recommended anchor:
+
+```ts
+import {
+  CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX, // 100_000
+  FROM_RELATIVE_DEMOTED_OUTPUT, //  99_999  (= ANCHOR - 1)
+} from "@stsoftware/neat-ai";
+```
+
+With `firstDnaOutputIndex = CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX`:
+
+| `fromRelative` value                    | Resolves to                                                      |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX` | The first new output (the new `output-0`).                       |
+| `FROM_RELATIVE_DEMOTED_OUTPUT` (99_999) | The **last** previously-existing output, just demoted to hidden. |
+| `99_998`                                | The second-last demoted previous output.                         |
+| `99_997`                                | The third-last demoted previous output.                          |
+| ...                                     | ...                                                              |
+
+The DNA fixtures `test/data/CRISPR/DNA-SANE.json` and `DNA-VOLUME.json` use a
+smaller anchor (`1000`) for compactness. They are equivalent — the only thing
+that matters is `firstDnaOutputIndex - K`, not the absolute value of either
+side.
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant cleaveDNA as CRISPR.cleaveDNA
+    participant validate as validateDNA
+    participant upgrade as Upgrade.CRISPR
+    participant append as CRISPR.append
+
+    Caller->>cleaveDNA: dna (mode=append)
+    cleaveDNA->>validate: structural validation
+    validate-->>cleaveDNA: OK
+    cleaveDNA->>upgrade: legacy field rename + UUID→id resolution
+    upgrade-->>cleaveDNA: dnaClean
+    cleaveDNA->>append: dnaClean
+    note over append: Demote existing outputs to hidden\ncompute adjustIndx\ninstantiate new neurons at\nadjustIndx + dnaNeuron.index\nresolve fromRelative/toRelative
+    append-->>cleaveDNA: modified creature
+    cleaveDNA-->>Caller: modified creature
+```
+
+### Worked example: wrap the previous `output-0` with a `TANH`
+
+```ts
+import {
+  CRISPR,
+  CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX,
+  type CrisprInterface,
+  FROM_RELATIVE_DEMOTED_OUTPUT,
+} from "@stsoftware/neat-ai";
+
+const dna: CrisprInterface = {
+  id: "wrap-output-0-with-tanh",
+  mode: "append",
+  neurons: [
+    {
+      type: "output",
+      squash: "TANH",
+      bias: 0,
+      index: CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX,
+    },
+  ],
+  synapses: [
+    // Demoted previous output → new TANH output.
+    {
+      fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT,
+      toRelative: CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX,
+      weight: 1,
+    },
+  ],
+};
+
+const modified = new CRISPR(creature).cleaveDNA(dna);
+```
+
+After `cleaveDNA`:
+
+- The original `output-0` is now a hidden neuron with the same UUID and internal
+  `id` as before.
+- A new `TANH` neuron is the sole output (`output-0`).
+- A single synapse with weight `1` carries the demoted neuron's activation into
+  the new output.
+
+### Caveats
+
+1. **`firstDnaOutputIndex` is implicit, not declared.** `append()` derives it as
+   `min(neuron.index)` over all `type: "output"` neurons in the DNA. Pick a
+   large anchor (`100_000` is the recommended value via
+   `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX`) so `fromRelative` / `toRelative`
+   values cannot collide with real network indices.
+2. **`output-0` literal labels are shadowed.** Once the new outputs land, the
+   canonical `output-N` labels point at the **new** outputs. There is no
+   canonical label for "the previous `output-0`" — use
+   `fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT` (or the demoted neuron's real
+   UUID, if you happen to know it).
+3. **Multiple new neurons shift the anchor.** If `dna.neurons.length > 1`, the
+   new outputs occupy `firstDnaOutputIndex .. firstDnaOutputIndex +
+   N - 1`.
+   The demoted previous outputs sit immediately _before_ them in the post-append
+   topology. `FROM_RELATIVE_DEMOTED_OUTPUT` still resolves to the last demoted
+   output regardless of how many DNA neurons you add, because `adjustIndx` rolls
+   them into the same relative offset.
+4. **Synapses are deduplicated.** `append()` skips a synapse if one already
+   exists between the resolved `from` and `to` indices. You will not get a
+   duplicate, but you will not get an exception either.
+
+## Validation: `validateDNA`
+
+`cleaveDNA` runs `validateDNA` before `Upgrade.CRISPR`, so the synapse fields it
+sees are the raw DNA fields. As of Issue #2509, append-mode synapses are
+accepted with **any** of the following endpoint references:
+
+- `from` / `to` — absolute network index
+- `fromId` / `toId` — runtime integer neuron `id`
+- `fromRelative` / `toRelative` — relative to `firstDnaOutputIndex` after
+  `adjustIndx` is applied
+- `fromUUID` / `toUUID` — stable UUID string (or canonical `input-N` /
+  `output-N` label). `Upgrade.CRISPR` resolves these to `fromId` / `toId` before
+  `append()` consumes the DNA.
+
+Insert-mode synapses are stricter: they must use `fromId` / `toId` only (or
+`fromUUID` / `toUUID`, since those are resolved to ids by `Upgrade.CRISPR`).
+Static `from` / `to` indices and `fromRelative` / `toRelative` are rejected —
+those references are meaningless when neurons are being inserted into an
+existing topology.
+
+> [!NOTE]
+> Prior to Issue #2509, `validateDNA` did not recognise `fromUUID` / `toUUID` as
+> endpoint references. Callers worked around this by inserting placeholder
+> `fromRelative: 0` / `toRelative: 0` entries before validation. That workaround
+> is no longer required.
+
+## Aliasing
+
+`CRISPR.editAliases(dna, aliases)` rewrites neuron and synapse references
+without mutating the original DNA. It supports both numeric and UUID alias maps:
+
+```ts
+// Numeric: remap fromId/toId/neuron.id
+const remapped = CRISPR.editAliases(dna, { 100: 200 });
+
+// UUID: remap fromUUID/toUUID/neuron.uuid (e.g. promote a placeholder
+// label to the real UUID of an in-creature neuron)
+const resolved = CRISPR.editAliases(dna, {
+  "demoted-output-0": "5a47061e-9c90-4126-93ed-abdfd27a1dae",
+});
+```
+
+## Related
+
+- `src/reconstruct/CRISPR.ts` — implementation
+- `src/reconstruct/validateDNA.ts` — DNA structural validation
+- `src/reconstruct/Upgrade.ts` — legacy field rename + UUID→id resolution
+- `test/CRISPR/AppendDemoteOutput.ts` — append+demote regression tests
+- `test/data/CRISPR/DNA-SANE.json`, `DNA-VOLUME.json` — multi-output demote
+  examples

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -130,6 +130,7 @@
     "Gimpel",
     "githubusercontent",
     "Goodfellow",
+    "gotchas",
     "gtimeout",
     "Graphviz",
     "groupinstall",

--- a/docs/pr-summary-2509.md
+++ b/docs/pr-summary-2509.md
@@ -1,29 +1,27 @@
 ## Summary
 
-Documents and supports the CRISPR `append + demote` pattern that GRQ relies
-on, and removes one workaround that the gap forced GRQ to carry. Closes
-#2509.
+Documents and supports the CRISPR `append + demote` pattern that GRQ relies on,
+and removes one workaround that the gap forced GRQ to carry. Closes #2509.
 
 Three deliverables:
 
-1. **`validateDNA` recognises UUID-only synapses.** Append-mode synapses
-   may now reference endpoints with `fromUUID` / `toUUID` alone, without
-   the `fromRelative: 0` / `toRelative: 0` placeholder workaround that
-   GRQ's `prepareAppendCrisprDnaForValidate.ts` currently injects. Insert
-   mode is unchanged (it already accepted UUID-only).
+1. **`validateDNA` recognises UUID-only synapses.** Append-mode synapses may now
+   reference endpoints with `fromUUID` / `toUUID` alone, without the
+   `fromRelative: 0` / `toRelative: 0` placeholder workaround that GRQ's
+   `prepareAppendCrisprDnaForValidate.ts` currently injects. Insert mode is
+   unchanged (it already accepted UUID-only).
 2. **Named constants for the convention.** New exports:
    `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX` (`100_000`) and
-   `FROM_RELATIVE_DEMOTED_OUTPUT` (`99_999`). These replace the magic
-   numbers used throughout the GRQ DNA files and document the
+   `FROM_RELATIVE_DEMOTED_OUTPUT` (`99_999`). These replace the magic numbers
+   used throughout the GRQ DNA files and document the
    `firstDnaOutputIndex - 1 == 99999` relationship.
-3. **`docs/CRISPR_GUIDE.md`** — new guide covering the append+demote
-   pattern, the index arithmetic inside `CRISPR.append()`, the
-   constants, the validation rules, and the caveats (shadowed
-   `output-N` labels, multi-neuron anchor shifts, synapse dedup).
-   Linked from `docs/API_REFERENCE.md` and `AGENTS.md`.
+3. **`docs/CRISPR_GUIDE.md`** — new guide covering the append+demote pattern,
+   the index arithmetic inside `CRISPR.append()`, the constants, the validation
+   rules, and the caveats (shadowed `output-N` labels, multi-neuron anchor
+   shifts, synapse dedup). Linked from `docs/API_REFERENCE.md` and `AGENTS.md`.
 
-GRQ can now drop `prepareAppendCrisprDnaForValidate.ts` after upgrading
-to a NEAT-AI release containing this change.
+GRQ can now drop `prepareAppendCrisprDnaForValidate.ts` after upgrading to a
+NEAT-AI release containing this change.
 
 ## Evidence
 
@@ -57,28 +55,25 @@ test/CRISPR/{others}                61 tests, all passing
 ```
 
 Full quality suite: 6381 passed / 1 unrelated flaky failure
-(`ThroughputMetrics - fastQueueMaxDepth`, passes on rerun and is
-unrelated to CRISPR).
+(`ThroughputMetrics - fastQueueMaxDepth`, passes on rerun and is unrelated to
+CRISPR).
 
 ## Test Plan
 
 - **Added** `test/CRISPR/AppendDemoteOutput.ts` (3 tests):
-  - Constants relationship: `FROM_RELATIVE_DEMOTED_OUTPUT == CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX - 1`.
+  - Constants relationship:
+    `FROM_RELATIVE_DEMOTED_OUTPUT == CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX - 1`.
   - End-to-end `cleaveDNA` with `fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT`
     wires the demoted previous output into the new TANH output.
-  - `DNA-SANE.json` regression: 3 demoted outputs all wired to 3 new
-    outputs via `fromRelative: 997/998/999` (smaller-anchor variant of
-    the same arithmetic).
+  - `DNA-SANE.json` regression: 3 demoted outputs all wired to 3 new outputs via
+    `fromRelative: 997/998/999` (smaller-anchor variant of the same arithmetic).
 - **Added** to `test/CRISPR/ValidateDNA.ts` (4 tests):
   - Append-mode synapse with `fromUUID` + `toUUID` alone passes.
-  - Append-mode synapse with only `fromUUID` still rejected (target
-    missing).
-  - Append-mode synapse with only `toUUID` still rejected (source
-    missing).
+  - Append-mode synapse with only `fromUUID` still rejected (target missing).
+  - Append-mode synapse with only `toUUID` still rejected (source missing).
   - Insert-mode regression: `fromUUID`/`toUUID` continues to pass.
 - **Modified** files:
-  - `src/reconstruct/validateDNA.ts` — UUID acceptance + updated error
-    messages.
+  - `src/reconstruct/validateDNA.ts` — UUID acceptance + updated error messages.
   - `src/reconstruct/CRISPR.ts` — constants with JSDoc.
   - `mod.ts` — re-export the constants.
   - `docs/API_REFERENCE.md` — link to new guide + constants table.

--- a/docs/pr-summary-2509.md
+++ b/docs/pr-summary-2509.md
@@ -1,0 +1,86 @@
+## Summary
+
+Documents and supports the CRISPR `append + demote` pattern that GRQ relies
+on, and removes one workaround that the gap forced GRQ to carry. Closes
+#2509.
+
+Three deliverables:
+
+1. **`validateDNA` recognises UUID-only synapses.** Append-mode synapses
+   may now reference endpoints with `fromUUID` / `toUUID` alone, without
+   the `fromRelative: 0` / `toRelative: 0` placeholder workaround that
+   GRQ's `prepareAppendCrisprDnaForValidate.ts` currently injects. Insert
+   mode is unchanged (it already accepted UUID-only).
+2. **Named constants for the convention.** New exports:
+   `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX` (`100_000`) and
+   `FROM_RELATIVE_DEMOTED_OUTPUT` (`99_999`). These replace the magic
+   numbers used throughout the GRQ DNA files and document the
+   `firstDnaOutputIndex - 1 == 99999` relationship.
+3. **`docs/CRISPR_GUIDE.md`** — new guide covering the append+demote
+   pattern, the index arithmetic inside `CRISPR.append()`, the
+   constants, the validation rules, and the caveats (shadowed
+   `output-N` labels, multi-neuron anchor shifts, synapse dedup).
+   Linked from `docs/API_REFERENCE.md` and `AGENTS.md`.
+
+GRQ can now drop `prepareAppendCrisprDnaForValidate.ts` after upgrading
+to a NEAT-AI release containing this change.
+
+## Evidence
+
+CLI/library change with no UI surface — verification is via tests.
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant cleaveDNA as CRISPR.cleaveDNA
+    participant validate as validateDNA
+    participant upgrade as Upgrade.CRISPR
+    participant append as CRISPR.append
+
+    Caller->>cleaveDNA: dna (mode=append, UUID-only synapse)
+    cleaveDNA->>validate: structural validation
+    note right of validate: BEFORE #2509: rejects UUID-only<br/>AFTER  #2509: accepts UUID-only
+    validate-->>cleaveDNA: OK
+    cleaveDNA->>upgrade: legacy field rename + UUID→id resolution
+    upgrade-->>cleaveDNA: dnaClean (fromId/toId populated)
+    cleaveDNA->>append: dnaClean
+    append-->>cleaveDNA: modified creature
+    cleaveDNA-->>Caller: modified creature
+```
+
+All 93 CRISPR tests pass:
+
+```
+test/CRISPR/ValidateDNA.ts          29 tests, all passing
+test/CRISPR/AppendDemoteOutput.ts    3 tests, all passing (new)
+test/CRISPR/{others}                61 tests, all passing
+```
+
+Full quality suite: 6381 passed / 1 unrelated flaky failure
+(`ThroughputMetrics - fastQueueMaxDepth`, passes on rerun and is
+unrelated to CRISPR).
+
+## Test Plan
+
+- **Added** `test/CRISPR/AppendDemoteOutput.ts` (3 tests):
+  - Constants relationship: `FROM_RELATIVE_DEMOTED_OUTPUT == CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX - 1`.
+  - End-to-end `cleaveDNA` with `fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT`
+    wires the demoted previous output into the new TANH output.
+  - `DNA-SANE.json` regression: 3 demoted outputs all wired to 3 new
+    outputs via `fromRelative: 997/998/999` (smaller-anchor variant of
+    the same arithmetic).
+- **Added** to `test/CRISPR/ValidateDNA.ts` (4 tests):
+  - Append-mode synapse with `fromUUID` + `toUUID` alone passes.
+  - Append-mode synapse with only `fromUUID` still rejected (target
+    missing).
+  - Append-mode synapse with only `toUUID` still rejected (source
+    missing).
+  - Insert-mode regression: `fromUUID`/`toUUID` continues to pass.
+- **Modified** files:
+  - `src/reconstruct/validateDNA.ts` — UUID acceptance + updated error
+    messages.
+  - `src/reconstruct/CRISPR.ts` — constants with JSDoc.
+  - `mod.ts` — re-export the constants.
+  - `docs/API_REFERENCE.md` — link to new guide + constants table.
+  - `docs/CRISPR_GUIDE.md` — new (full guide).
+  - `AGENTS.md` — added the guide to the docs layout list.

--- a/mod.ts
+++ b/mod.ts
@@ -202,7 +202,12 @@ export { Mutation } from "@neat/Mutation.ts";
  *
  * @see {@link module:src/reconstruct/CRISPR}
  */
-export { CRISPR, type CrisprInterface } from "@reconstruct/CRISPR.ts";
+export {
+  CRISPR,
+  CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX,
+  type CrisprInterface,
+  FROM_RELATIVE_DEMOTED_OUTPUT,
+} from "@reconstruct/CRISPR.ts";
 export { CrisprError } from "@errors/CrisprError.ts";
 export type { CrisprErrorCode } from "@errors/CrisprError.ts";
 export { validateDNA } from "@reconstruct/validateDNA.ts";

--- a/src/reconstruct/CRISPR.ts
+++ b/src/reconstruct/CRISPR.ts
@@ -8,6 +8,41 @@ import { TopologyError } from "@errors/TopologyError.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { validateDNA } from "@reconstruct/validateDNA.ts";
 
+/**
+ * Recommended `index` for the first output neuron in append-mode CRISPR DNA
+ * (Issue #2509).
+ *
+ * `append()` computes `adjustIndx = firstNetworkOutputIndex - firstDnaOutputIndex +
+ * dna.neurons.length` so any `fromRelative` / `toRelative` value `R` resolves
+ * to network index `R + adjustIndx`. Picking a large, conventional anchor for
+ * `firstDnaOutputIndex` keeps `R` values readable: with the recommended
+ * `100000`, `fromRelative: 99999` reaches one slot below the first new
+ * neuron — i.e. the **last** previously-existing output that has just been
+ * demoted to hidden — and `fromRelative: 99998` reaches the second-last,
+ * and so on.
+ *
+ * Authors are free to use any anchor (`DNA-SANE.json` and `DNA-VOLUME.json`
+ * use `1000`), but new DNA should prefer `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX`
+ * for consistency.
+ */
+export const CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX = 100_000;
+
+/**
+ * Convenience constant: `fromRelative` value that resolves to the demoted
+ * previous `output-0` neuron when the DNA uses the recommended
+ * `firstDnaOutputIndex = CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX` (Issue #2509).
+ *
+ * Equivalent to `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX - 1`. To reference the
+ * second-last demoted output use `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX - 2`,
+ * and so on.
+ *
+ * Use this in append-mode DNA where exactly one previous output is being
+ * demoted and you want the new `output-0` to read from it. See
+ * `docs/CRISPR_GUIDE.md` for the full append+demote pattern.
+ */
+export const FROM_RELATIVE_DEMOTED_OUTPUT =
+  CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX - 1;
+
 function formatCrisprDnaIdForLog(dna: unknown): string {
   if (dna !== null && typeof dna === "object" && "id" in dna) {
     const id = (dna as Record<string, unknown>).id;

--- a/src/reconstruct/validateDNA.ts
+++ b/src/reconstruct/validateDNA.ts
@@ -179,12 +179,15 @@ function validateSynapse(
       );
     }
   } else {
-    // Append mode: each synapse must have at least one resolvable source and target reference
+    // Append mode: each synapse must have at least one resolvable source and
+    // target reference. `fromUUID` / `toUUID` are accepted alongside the
+    // legacy numeric/relative fields — `Upgrade.CRISPR` resolves them to
+    // `fromId` / `toId` after this validation runs (Issue #2509).
     const hasSource = s.from !== undefined || s.fromId !== undefined ||
-      s.fromRelative !== undefined;
+      s.fromRelative !== undefined || typeof s.fromUUID === "string";
     if (!hasSource) {
       throw new CrisprError(
-        `Synapse at index ${index}: append-mode synapse must have at least one source reference ('from', 'fromId', or 'fromRelative') — synapse: ${
+        `Synapse at index ${index}: append-mode synapse must have at least one source reference ('from', 'fromId', 'fromRelative', or 'fromUUID') — synapse: ${
           JSON.stringify(s)
         }`,
         "INVALID_DNA",
@@ -192,10 +195,10 @@ function validateSynapse(
     }
 
     const hasTarget = s.to !== undefined || s.toId !== undefined ||
-      s.toRelative !== undefined;
+      s.toRelative !== undefined || typeof s.toUUID === "string";
     if (!hasTarget) {
       throw new CrisprError(
-        `Synapse at index ${index}: append-mode synapse must have at least one target reference ('to', 'toId', or 'toRelative') — synapse: ${
+        `Synapse at index ${index}: append-mode synapse must have at least one target reference ('to', 'toId', 'toRelative', or 'toUUID') — synapse: ${
           JSON.stringify(s)
         }`,
         "INVALID_DNA",

--- a/test/CRISPR/AppendDemoteOutput.ts
+++ b/test/CRISPR/AppendDemoteOutput.ts
@@ -1,0 +1,163 @@
+// Tests for the append+demote CRISPR pattern documented in Issue #2509.
+//
+// The pattern: append-mode CRISPR DNA defines a new `output-0` and wires
+// the previously-existing `output-0` (which is demoted to hidden at append
+// time) into the new output via a relative synapse. The convention uses
+// `firstDnaOutputIndex = CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX` (100000) so
+// that `fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT` (99999) reaches the
+// demoted previous output.
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureInternal } from "@architecture/CreatureInterfaces.ts";
+import {
+  CRISPR,
+  CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX,
+  type CrisprInterface,
+  FROM_RELATIVE_DEMOTED_OUTPUT,
+} from "@reconstruct/CRISPR.ts";
+
+Deno.test("CRISPR constants - FROM_RELATIVE_DEMOTED_OUTPUT is one less than the default first DNA output index", () => {
+  assertEquals(CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX, 100_000);
+  assertEquals(FROM_RELATIVE_DEMOTED_OUTPUT, 99_999);
+  assertEquals(
+    FROM_RELATIVE_DEMOTED_OUTPUT,
+    CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX - 1,
+  );
+});
+
+Deno.test("CRISPR append+demote - fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT wires the demoted previous output into the new output (Issue #2509)", () => {
+  // Network: 2 inputs, 1 hidden, 1 output. After append the previous output
+  // becomes hidden and a new tanh output is appended on top of it.
+  const json: CreatureInternal = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0, index: 2, uuid: "h1" },
+      {
+        type: "output",
+        squash: "IDENTITY",
+        bias: 0,
+        index: 3,
+        uuid: "old-output-0",
+      },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 0.5 },
+      { from: 2, to: 3, weight: 0.6 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+
+  const dna: CrisprInterface = {
+    id: "append-demote-tanh",
+    mode: "append",
+    neurons: [
+      {
+        type: "output",
+        squash: "TANH",
+        bias: 0,
+        index: CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX,
+      },
+    ],
+    synapses: [
+      // Demoted previous output → new output
+      {
+        fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT,
+        toRelative: CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX,
+        weight: 1,
+      },
+    ],
+  };
+
+  const modified = new CRISPR(creature).cleaveDNA(dna) as Creature;
+  modified.validate();
+
+  // The original output is now hidden; a single new TANH output exists.
+  assertEquals(modified.output, 1, "Should still have exactly 1 output");
+  const outputs = modified.neurons.filter((n) => n.type === "output");
+  assertEquals(outputs.length, 1);
+  assertEquals(outputs[0].squash, "TANH");
+
+  // The demoted previous output keeps its position and has been wired into
+  // the new TANH output.
+  const demoted = modified.neurons.find((n) => n.uuid === "old-output-0");
+  assert(demoted, "Demoted previous output must be retained");
+  assertEquals(
+    demoted!.type,
+    "hidden",
+    "Previous output must be demoted to hidden",
+  );
+
+  const wiring = modified.synapses.find((s) =>
+    s.from === demoted!.index && s.to === outputs[0].index
+  );
+  assert(
+    wiring,
+    `Expected synapse from demoted previous output (${
+      demoted!.index
+    }) to new TANH output (${outputs[0].index})`,
+  );
+  assertEquals(wiring!.weight, 1);
+});
+
+Deno.test("CRISPR append+demote - DNA-SANE.json reproduces the multi-output demote pattern with relative anchors", () => {
+  // DNA-SANE.json uses `firstDnaOutputIndex = 1000` and references the three
+  // demoted previous outputs via `fromRelative: 997, 998, 999`. This test
+  // exercises the same arithmetic used by the GRQ DNA files but with the
+  // smaller anchor — confirming that `fromRelative = firstDnaOutputIndex - K`
+  // resolves to "K-th-last demoted previous output" regardless of which
+  // anchor convention the DNA chooses.
+  const json: CreatureInternal = {
+    input: 3,
+    output: 3,
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0, index: 3, uuid: "h1" },
+      { type: "output", squash: "IDENTITY", bias: 0, index: 4, uuid: "o1" },
+      { type: "output", squash: "IDENTITY", bias: 0, index: 5, uuid: "o2" },
+      { type: "output", squash: "LOGISTIC", bias: 0, index: 6, uuid: "o3" },
+    ],
+    synapses: [
+      { from: 0, to: 3, weight: 0.1 },
+      { from: 3, to: 4, weight: 0.2 },
+      { from: 1, to: 5, weight: 0.3 },
+      { from: 2, to: 6, weight: 0.4 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+
+  const dnaTXT = Deno.readTextFileSync("test/data/CRISPR/DNA-SANE.json");
+  const modified = new CRISPR(creature).cleaveDNA(
+    JSON.parse(dnaTXT),
+  ) as Creature;
+  modified.validate();
+
+  // Three demoted previous outputs are now hidden; three new outputs exist.
+  const demoted = ["o1", "o2", "o3"].map((u) =>
+    modified.neurons.find((n) => n.uuid === u)
+  );
+  for (const d of demoted) {
+    assert(d, "Each previous output must survive demotion");
+    assertEquals(d!.type, "hidden");
+  }
+  const outputs = modified.neurons.filter((n) => n.type === "output");
+  assertEquals(outputs.length, 3);
+
+  // Each new output must be wired to all three demoted previous outputs —
+  // i.e. the `fromRelative: 997/998/999` anchors all resolved correctly.
+  for (const out of outputs) {
+    for (const d of demoted) {
+      const wiring = modified.synapses.find((s) =>
+        s.from === d!.index && s.to === out.index
+      );
+      assert(
+        wiring,
+        `Expected synapse from demoted output ${d!.uuid} (index ${
+          d!.index
+        }) to new output (index ${out.index})`,
+      );
+    }
+  }
+});

--- a/test/CRISPR/ValidateDNA.ts
+++ b/test/CRISPR/ValidateDNA.ts
@@ -307,6 +307,66 @@ Deno.test("validateDNA - append-mode synapse with fromId/toId passes", () => {
   }
 });
 
+Deno.test("validateDNA - append-mode synapse with fromUUID/toUUID alone passes (Issue #2509)", () => {
+  // UUID-only synapses are valid — Upgrade.CRISPR resolves fromUUID/toUUID
+  // to fromId/toId after validateDNA runs, so validateDNA must recognise
+  // UUID-only references without requiring a placeholder fromRelative.
+  const result = validateDNA({
+    id: "test-dna",
+    mode: "append",
+    synapses: [{
+      fromUUID: "output-0",
+      toUUID: "5a47061e-9c90-4126-93ed-abdfd27a1dae",
+      weight: 0.5,
+    }],
+  });
+  if (!result.id) {
+    throw new Error("Expected validated DNA to be returned");
+  }
+});
+
+Deno.test("validateDNA - append-mode synapse with only fromUUID still requires a target reference", () => {
+  assertThrows(
+    () =>
+      validateDNA({
+        id: "test-dna",
+        mode: "append",
+        synapses: [{ fromUUID: "output-0", weight: 0.5 }],
+      }),
+    Error,
+    "must have at least one target reference",
+  );
+});
+
+Deno.test("validateDNA - append-mode synapse with only toUUID still requires a source reference", () => {
+  assertThrows(
+    () =>
+      validateDNA({
+        id: "test-dna",
+        mode: "append",
+        synapses: [{ toUUID: "output-0", weight: 0.5 }],
+      }),
+    Error,
+    "must have at least one source reference",
+  );
+});
+
+Deno.test("validateDNA - insert-mode synapse with fromUUID/toUUID still passes", () => {
+  // Regression: insert-mode already accepted UUID-only synapses; ensure
+  // adding UUID recognition to append-mode does not break insert-mode.
+  const result = validateDNA({
+    id: "test-insert",
+    mode: "insert",
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0 },
+    ],
+    synapses: [{ fromUUID: "a", toUUID: "b", weight: 0.5 }],
+  });
+  if (!result.id) {
+    throw new Error("Expected validated DNA to be returned");
+  }
+});
+
 Deno.test("validateDNA - default mode synapse missing source reference throws", () => {
   // When mode is omitted it defaults to "append", so the same validation applies
   assertThrows(


### PR DESCRIPTION
## Summary

Documents and supports the CRISPR `append + demote` pattern that GRQ relies
on, and removes one workaround that the gap forced GRQ to carry. Closes
#2509.

Three deliverables:

1. **`validateDNA` recognises UUID-only synapses.** Append-mode synapses
   may now reference endpoints with `fromUUID` / `toUUID` alone, without
   the `fromRelative: 0` / `toRelative: 0` placeholder workaround that
   GRQ's `prepareAppendCrisprDnaForValidate.ts` currently injects. Insert
   mode is unchanged (it already accepted UUID-only).
2. **Named constants for the convention.** New exports:
   `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX` (`100_000`) and
   `FROM_RELATIVE_DEMOTED_OUTPUT` (`99_999`). These replace the magic
   numbers used throughout the GRQ DNA files and document the
   `firstDnaOutputIndex - 1 == 99999` relationship.
3. **`docs/CRISPR_GUIDE.md`** — new guide covering the append+demote
   pattern, the index arithmetic inside `CRISPR.append()`, the
   constants, the validation rules, and the caveats (shadowed
   `output-N` labels, multi-neuron anchor shifts, synapse dedup).
   Linked from `docs/API_REFERENCE.md` and `AGENTS.md`.

GRQ can now drop `prepareAppendCrisprDnaForValidate.ts` after upgrading
to a NEAT-AI release containing this change.

## Evidence

CLI/library change with no UI surface — verification is via tests.

```mermaid
sequenceDiagram
    participant Caller
    participant cleaveDNA as CRISPR.cleaveDNA
    participant validate as validateDNA
    participant upgrade as Upgrade.CRISPR
    participant append as CRISPR.append

    Caller->>cleaveDNA: dna (mode=append, UUID-only synapse)
    cleaveDNA->>validate: structural validation
    note right of validate: BEFORE #2509: rejects UUID-only<br/>AFTER  #2509: accepts UUID-only
    validate-->>cleaveDNA: OK
    cleaveDNA->>upgrade: legacy field rename + UUID→id resolution
    upgrade-->>cleaveDNA: dnaClean (fromId/toId populated)
    cleaveDNA->>append: dnaClean
    append-->>cleaveDNA: modified creature
    cleaveDNA-->>Caller: modified creature
```

All 93 CRISPR tests pass:

```
test/CRISPR/ValidateDNA.ts          29 tests, all passing
test/CRISPR/AppendDemoteOutput.ts    3 tests, all passing (new)
test/CRISPR/{others}                61 tests, all passing
```

Full quality suite: 6381 passed / 1 unrelated flaky failure
(`ThroughputMetrics - fastQueueMaxDepth`, passes on rerun and is
unrelated to CRISPR).

## Test Plan

- **Added** `test/CRISPR/AppendDemoteOutput.ts` (3 tests):
  - Constants relationship: `FROM_RELATIVE_DEMOTED_OUTPUT == CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX - 1`.
  - End-to-end `cleaveDNA` with `fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT`
    wires the demoted previous output into the new TANH output.
  - `DNA-SANE.json` regression: 3 demoted outputs all wired to 3 new
    outputs via `fromRelative: 997/998/999` (smaller-anchor variant of
    the same arithmetic).
- **Added** to `test/CRISPR/ValidateDNA.ts` (4 tests):
  - Append-mode synapse with `fromUUID` + `toUUID` alone passes.
  - Append-mode synapse with only `fromUUID` still rejected (target
    missing).
  - Append-mode synapse with only `toUUID` still rejected (source
    missing).
  - Insert-mode regression: `fromUUID`/`toUUID` continues to pass.
- **Modified** files:
  - `src/reconstruct/validateDNA.ts` — UUID acceptance + updated error
    messages.
  - `src/reconstruct/CRISPR.ts` — constants with JSDoc.
  - `mod.ts` — re-export the constants.
  - `docs/API_REFERENCE.md` — link to new guide + constants table.
  - `docs/CRISPR_GUIDE.md` — new (full guide).
  - `AGENTS.md` — added the guide to the docs layout list.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2509 -->