### PR TITLE
Promote loadFrom recurrent-synapse strip to TopologyError (#2514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to `@stsoftware/neat-ai` are documented here.
+
+The format is loosely based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.2.0] - 2026-05-05
+
+### Changed (breaking-by-default)
+
+- **Issue #2514:** `Creature.loadFrom` and `Creature.fromJSON` now throw a
+  `TopologyError` by default when a forward-only creature carries a `from >= to`
+  synapse. The old strip-and-warn behaviour silently self-healed the topology on
+  every load and hid the producing pipeline's stack frame, so upstream
+  corruption became invisible. The new default surfaces the offending synapse,
+  depth, source tag, and structural-hash identifier so the producer can be
+  fixed.
+
+  A new option, `throwOnRecurrent: "always" | "forwardOnly" | "never"`, is
+  accepted on both `loadFrom` and `Creature.fromJSON` (defaults to
+  `"forwardOnly"`). Repair tools and diagnostic paths that intentionally process
+  corrupt input — `compactCreature`, the `applyChangeToCreature` family in
+  `discovery/CandidateApplicationOps`, the legacy v0/v1/v2 upgrade pipeline, and
+  the `compact:*` repair helpers — opt in to `"never"` explicitly with a code
+  comment naming the bypass.
+
+  Migration: callers that legitimately ingest corrupt forward-only JSON (e.g. a
+  repair tool reading historical genomes) should pass
+  `{ throwOnRecurrent: "never" }` to preserve the previous behaviour. Callers
+  that produce forward-only JSON should ensure no recurrent edge ever appears —
+  that is the whole point of the new default.

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.1.53",
+  "version": "3.2.0",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -325,6 +325,7 @@
     "unnormalised",
     "unpartitioned",
     "unpoisoned",
+    "upgrader",
     "unrecoverably",
     "unregularised",
     "unrepresentable",

--- a/docs/pr-summary-2514.md
+++ b/docs/pr-summary-2514.md
@@ -1,0 +1,112 @@
+## Summary
+
+Promote `Creature.loadFrom`'s recurrent-synapse strip from a silent warning to a
+`TopologyError` throw by default for forward-only creatures. The old
+strip-and-warn behaviour silently self-healed the runtime topology on every
+load, hiding the producing pipeline's stack frame so the upstream corruption
+that caused the 143 strip events on `@stsoftware/neat-ai 3.1.53`
+(GRQ-3-rocket.log, 5 May 2026) was invisible. The new default surfaces the
+offending edge so the producer can be fixed. Closes #2514.
+
+A new `throwOnRecurrent: "always" | "forwardOnly" | "never"` option on both
+`loadFrom` and `Creature.fromJSON` (default `"forwardOnly"`) gives repair tools
+an explicit opt-out — `compactCreature`, the `applyChangeToCreature` family, the
+legacy v0/v1/v2 upgrade pipeline, the `compact:*` repair helpers, and
+`Creature.fromPersistedJSON` (the disk-load path) all pass
+`throwOnRecurrent: "never"` with a code comment naming the bypass so they can
+keep ingesting historic on-disk JSON safely.
+
+The SemVer minor was bumped (`3.1.53 → 3.2.0`) and `CHANGELOG.md` was created
+with a migration note for the breaking-by-default change.
+
+## Evidence
+
+This is a backend/library change with no UI surface — coverage is via unit tests
+that exercise the throw default, the legacy strip path, and the message
+contents.
+
+```mermaid
+flowchart LR
+    A[Producer pipeline] -->|writes corrupt JSON| B[Creature.fromJSON]
+    B -->|forwardOnly + recurrent| C{throwOnRecurrent?}
+    C -->|forwardOnly default| D[TopologyError + stack]
+    C -->|never opt-in| E[strip + warn]
+    D --> F[fix producer]
+```
+
+Verified locally:
+
+- `deno fmt --check` and `deno lint` pass
+  (`./quality.sh
+  --skip-tests --skip-discovery --skip-wasm` exits 0).
+- `deno check mod.ts src/` passes (no type errors).
+- `deno test --allow-all "test/creature/**/*.ts"` → 249 passed, 0 failed.
+- `deno test --allow-all "test/discovery/**/*.ts" "test/compact/**/*.ts"
+  "test/upgrade/**/*.ts" "test/ErrorGuidedStructuralEvolution/**/*.ts"
+  "test/architecture/**/*.ts"`
+  → 1292 passed, 0 failed.
+- `deno test --allow-all "test/blackbox/**/*.ts" "test/breed/**/*.ts"
+  "test/transfer/**/*.ts" "test/multithreading/**/*.ts"
+  "test/intelligentDesign/**/*.ts" "test/optimize/**/*.ts"
+  "test/predictiveCoding/**/*.ts" "test/reconstruct/**/*.ts"
+  "test/fix/**/*.ts"`
+  → 718 passed, 0 failed.
+- The remaining test directories (`NEAT`, `cache`, `CRISPR`, `data`,
+  `feedForward`, `lifecycle`, `methods`, `mutate`, `neuron`, `onnx`,
+  `optimization`, `score`, `tag`, `utils`, `validate`, `wasm`, `workers`,
+  `errors`, `propagate`, `fixtures`, `config`, `constants`, `costs`, `scripts`)
+  → 4104 passed, 1 failed before reformat; failure was the `deno fmt --check`
+  smoke test which was resolved by running `deno fmt` on the two affected test
+  files. After reformat, `deno fmt --check` over all 2147 files passes cleanly.
+
+## Test Plan
+
+### New tests (this PR)
+
+- `test/creature/LoadFromForwardOnlyThrow.ts` — four tests:
+  - **Default behaviour throws on a forward-only creature with
+    `output-0 → output-0`** (mirrors GRQ-3-rocket.log signature: `depth=0`,
+    `fromUUID=output-0`).
+  - **`throwOnRecurrent: "never"` preserves the legacy strip+warn** (warning
+    emitted, no recurrent edge survives).
+  - **`throwOnRecurrent: "always"` throws on a non-forward-only recurrent
+    creature** (sanity-checks that the default lets recurrent creatures through
+    and `"always"` opts into stricter checks).
+  - **`loadFrom` throws synchronously and the error tags the source pipeline**
+    (the `TopologyError` message includes `source=unit-test:throw-source` and
+    the structural-hash fallback identifier).
+
+### Modified tests (business-logic change)
+
+The Issue #2514 default is by design _breaking_ — tests that were written around
+the old strip-and-warn contract opt back into `throwOnRecurrent: "never"` so
+they continue to verify the legacy path that repair tools still exercise:
+
+- `test/creature/LoadFromObservability.ts` (Issue #2500 strip-warning
+  observability — three tests).
+- `test/creature/ForwardOnlyOutputRoundTrip.ts` — the `depth=<to-from>`
+  warning-format test (one of five tests; the other four are unchanged).
+- `test/architecture/ForwardOnlyLoadRepair.ts` — four legacy strip-and-repair
+  tests (Issue #2090).
+- `test/architecture/ForwardOnlySynapseGuard.ts` — two legacy strip-and-keep
+  tests.
+
+Coverage of the new throw default lives in
+`test/creature/LoadFromForwardOnlyThrow.ts`.
+
+### Production callers updated
+
+These pipelines legitimately ingest corrupt input, so they pass
+`throwOnRecurrent: "never"` with a code comment justifying the bypass:
+
+- `src/compact/CompactCreature.ts`
+- `src/compact/OrphanedNeuronCleanup.ts`
+- `src/compact/DeadSubgraphPruning.ts`
+- `src/upgrade/Upgrade.ts` (v0/v1 upgrade paths)
+- `src/upgrade/UpgradeTwo.ts` (HYPOT/HYPOTv2 removal passes)
+- `src/discovery/CandidateApplicationOps.ts` (`applyAddSynapses` /
+  `applyAddNeurons` / `applyChangeSquash` / `applyRemoveSynapse` /
+  `applyRemoveNeuron`).
+- `src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts`
+- `src/Creature.ts`'s `fromPersistedJSON` (the disk-load path that may encounter
+  genuinely historic on-disk JSON from older releases).

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1064,20 +1064,23 @@ export class Creature implements CreatureInternal {
     json: CreatureInternal | CreatureExport,
     validate: boolean,
     source?: string,
+    options?: serialisation.LoadFromOptions,
   ) {
-    serialisation.loadFrom(this, json, validate, source);
+    serialisation.loadFrom(this, json, validate, source, options);
   }
 
   static fromJSON(
     json: CreatureInternal | CreatureExport,
     validate?: boolean,
     source?: string,
+    options?: serialisation.LoadFromOptions,
   ): Creature {
     return serialisation.fromJSON(
       json,
       validate ?? false,
       Creature,
       source,
+      options,
     ) as Creature;
   }
 
@@ -1099,11 +1102,24 @@ export class Creature implements CreatureInternal {
    * `forwardOnly: true`. When any strip occurred, it also runs orphan cleanup
    * so stranded hiddens are not left invalid; {@link Creature.fix} and
    * `creatureValidate()` then complete normalisation for this ingest path.
+   *
+   * Issue #2514: `loadFrom` now throws by default for forward-only
+   * recurrent edges so in-process producers can be traced. This
+   * persisted-disk path is one of the explicit repair tools that
+   * legitimately needs to load historically corrupt JSON, so it opts
+   * into `throwOnRecurrent: "never"` to keep the strip+warn behaviour
+   * for genuine on-disk genomes from older releases.
    */
   static fromPersistedJSON(
     json: CreatureInternal | CreatureExport,
   ): Creature {
-    const creature = serialisation.fromJSON(json, false, Creature) as Creature;
+    const creature = serialisation.fromJSON(
+      json,
+      false,
+      Creature,
+      "fromPersistedJSON",
+      { throwOnRecurrent: "never" },
+    ) as Creature;
     creature.fix({ forwardOnly: creature.forwardOnly });
     creatureValidate(creature, { forwardOnly: creature.forwardOnly });
     return creature;

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -331,7 +331,18 @@ export function applyCoordinatedStructuralCandidate(
   // fix() as a side effect, which can bump semanticVersion for forward-only creatures.
   cleanupOrphanedNeurons(next);
 
-  const updated = Creature.fromJSON(next);
+  // Issue #2514: coordinated structural candidates may still hold
+  // residual recurrent hints when ingested here; the validate/fix block
+  // below is the authority on what survives. Opt out of the load-side
+  // throw so that final repair pass still runs.
+  const updated = Creature.fromJSON(
+    next,
+    false,
+    "discovery:coordinatedStructural",
+    {
+      throwOnRecurrent: "never",
+    },
+  );
   delete updated.uuid;
   try {
     if (updated.forwardOnly === true) {

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -388,7 +388,14 @@ export function compactCreature(
       "before Creature.fromJSON in compactCreature",
     );
 
-    const c = Creature.fromJSON(compactCreature);
+    // Issue #2514: compaction may carry residual backward synapses on
+    // a forward-only candidate so the load-side cleanup
+    // (`mergeDuplicateSynapses` + `cleanupOrphanedNeurons` etc.) can
+    // strip them. Opt out of the load-side throw so this repair path
+    // can keep ingesting corrupt input on purpose.
+    const c = Creature.fromJSON(compactCreature, false, "compactCreature", {
+      throwOnRecurrent: "never",
+    });
 
     return c;
   }

--- a/src/compact/DeadSubgraphPruning.ts
+++ b/src/compact/DeadSubgraphPruning.ts
@@ -113,7 +113,12 @@ export function pruneDeadSubgraphsInCreature(
 
   const result = pruneDeadSubgraphs(exportJSON);
   if (result.removedNeurons > 0 || result.removedSynapses > 0) {
-    creature.loadFrom(exportJSON, true, "compact:deadSubgraphPruning");
+    // Issue #2514: dead-subgraph pruning runs in compaction repair
+    // paths that may still hold transient recurrent edges before the
+    // outer flow finishes repairs. Opt out of the load-side throw.
+    creature.loadFrom(exportJSON, true, "compact:deadSubgraphPruning", {
+      throwOnRecurrent: "never",
+    });
   }
 
   return result;

--- a/src/compact/OrphanedNeuronCleanup.ts
+++ b/src/compact/OrphanedNeuronCleanup.ts
@@ -351,7 +351,12 @@ export function cleanupOrphanedNeuronsInCreature(
     // This helper is used from repair paths (`fix()`), where the export may be
     // in an intermediate state until the caller finishes all repair steps.
     // Let the outer repair/validation flow perform the final strict validate.
-    creature.loadFrom(exportJSON, false, "compact:orphanCleanup");
+    // Issue #2514: this is an in-flight repair pass that may still
+    // hold transient recurrent edges; opt out of the load-side throw
+    // so the surrounding cleanup can finish repairing the topology.
+    creature.loadFrom(exportJSON, false, "compact:orphanCleanup", {
+      throwOnRecurrent: "never",
+    });
   }
 
   return result;

--- a/src/creature/CreatureSerialization.ts
+++ b/src/creature/CreatureSerialization.ts
@@ -44,6 +44,7 @@ import {
 } from "@utils/WeightBiasClamp.ts";
 import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
 import { assertNoRecurrentSynapseOnForwardOnly } from "@architecture/ForwardOnlyAssertion.ts";
+import { TopologyError } from "@errors/TopologyError.ts";
 import { computeCreatureStructuralHash } from "@utils/CreatureStructuralHash.ts";
 import { cleanupOrphanedNeuronsInCreature } from "@compact/OrphanedNeuronCleanup.ts";
 import { pruneOrphanMemeticReferences } from "@compact/MemeticCleanup.ts";
@@ -374,20 +375,60 @@ function forwardOnlyHiddenLacksInbound(creature: Creature): boolean {
 }
 
 /**
+ * Strictness gate for the load-side recurrent-synapse check.
+ *
+ * Issue #2514: promoted from a silent strip+warn to a `TopologyError`
+ * throw by default for `forwardOnly` creatures so the producer's stack
+ * frame surfaces the corruption source instead of self-healing on every
+ * load.
+ *
+ *  - `"forwardOnly"` (default): throw `TopologyError` when the loaded
+ *    creature is `forwardOnly === true` and any synapse has
+ *    `from >= to`. Recurrent creatures are unaffected.
+ *  - `"always"`: throw `TopologyError` on any `from >= to` regardless
+ *    of `forwardOnly`. Use sparingly — most legitimate recurrent
+ *    creatures legitimately carry such edges.
+ *  - `"never"`: legacy strip-and-warn. Reserved for repair tools and
+ *    diagnostic paths that intentionally process corrupt input
+ *    (`compactCreature`, `applyChangeToCreature`, `Upgrade`,
+ *    Diagnostics).
+ */
+export type ThrowOnRecurrent = "always" | "forwardOnly" | "never";
+
+/** Optional second-tier configuration for {@link loadFrom}. */
+export interface LoadFromOptions {
+  /**
+   * Controls how the load-side recurrent-synapse gate behaves.
+   * Defaults to `"forwardOnly"` (Issue #2514).
+   */
+  throwOnRecurrent?: ThrowOnRecurrent;
+}
+
+/**
  * Load the creature from a JSON object.
  *
  * @param source Optional tag describing the calling site (e.g.
  *   `"breed"`, `"discovery"`, `"fromJSON"`). Included in any
- *   `[loadFrom] Stripping recurrent synapse` warning so production
- *   logs can identify the upstream pipeline that produced corrupt
- *   JSON. See Issue #2500.
+ *   `[loadFrom] Stripping recurrent synapse` warning or
+ *   `TopologyError` so production logs and stack traces can identify
+ *   the upstream pipeline that produced corrupt JSON. See Issue #2500
+ *   and #2514.
+ * @param options.throwOnRecurrent Strictness for the recurrent-synapse
+ *   gate. Defaults to `"forwardOnly"` — a forward-only creature with
+ *   any `from >= to` synapse throws {@link TopologyError} so the
+ *   producing pipeline's stack frame is preserved rather than silently
+ *   stripped (Issue #2514).
  */
 export function loadFrom(
   creature: Creature,
   json: CreatureInternal | CreatureExport,
   validate: boolean,
-  source: string = "loadFrom",
+  source?: string,
+  options?: LoadFromOptions,
 ): void {
+  const sourceTag = source ?? "loadFrom";
+  const throwOnRecurrent: ThrowOnRecurrent = options?.throwOnRecurrent ??
+    "forwardOnly";
   creature.uuid = (json as CreatureInternal).uuid;
   if (json.semanticVersion) {
     creature.semanticVersion = json.semanticVersion;
@@ -541,7 +582,12 @@ export function loadFrom(
       );
     }
 
-    if (isForwardOnly && from! >= to!) {
+    const recurrentGateFires = throwOnRecurrent === "always"
+      ? from! >= to!
+      : (throwOnRecurrent === "forwardOnly" && isForwardOnly && from! >= to!);
+    const stripGateFires = throwOnRecurrent === "never" && isForwardOnly &&
+      from! >= to!;
+    if (recurrentGateFires || stripGateFires) {
       // Issue #2500: include a usable identifier (uuid OR structural
       // hash) and a `source=...` tag so corrupt-creature events from a
       // single offending pipeline can be correlated across log lines.
@@ -550,12 +596,27 @@ export function loadFrom(
       // distinguishable at a glance in production logs.
       const uuidLabel = creature.uuid ?? `hash:${getStructuralHash()}`;
       const depth = to - from;
+      const fromIdLabel = se.fromUUID ?? se.fromId;
+      const toIdLabel = se.toUUID ?? se.toId;
+      if (recurrentGateFires) {
+        // Issue #2514: promote the silent strip to a TopologyError so
+        // the caller's stack frame surfaces the corruption source.
+        // `new Error().stack` is captured on the thrown error so logs
+        // can attribute the offending pipeline.
+        const message = `🚨 [loadFrom] Recurrent synapse ${from}->${to} ` +
+          `(fromUUID=${fromIdLabel}, toUUID=${toIdLabel}, depth=${depth}) ` +
+          `on forward-only creature (UUID: ${uuidLabel}, source=${sourceTag}). ` +
+          `This indicates upstream corruption (Issue #2514).`;
+        throw new TopologyError(message, "INVALID_CONNECTION");
+      }
+      // throwOnRecurrent === "never": legacy strip + warn path,
+      // reserved for repair tools that intentionally ingest corrupt
+      // input (compactCreature, applyChangeToCreature, Upgrade,
+      // Diagnostics).
       getLogger().error(
         `🚨 [loadFrom] Stripping recurrent synapse ${from}->${to} ` +
-          `(fromUUID=${se.fromUUID ?? se.fromId}, toUUID=${
-            se.toUUID ?? se.toId
-          }, depth=${depth}) ` +
-          `from forward-only creature (UUID: ${uuidLabel}, source=${source}). ` +
+          `(fromUUID=${fromIdLabel}, toUUID=${toIdLabel}, depth=${depth}) ` +
+          `from forward-only creature (UUID: ${uuidLabel}, source=${sourceTag}). ` +
           `This indicates upstream corruption.`,
       );
       continue;
@@ -671,7 +732,7 @@ export function loadFrom(
     const uuidLabel = creature.uuid ?? `hash:${getStructuralHash()}`;
     getLogger().warn(
       "🗜️ [loadFrom] Clamped overflowing weights/biases to " +
-        `±${MAX_SAFE_WEIGHT_BIAS} on creature ${uuidLabel} (source=${source}): ` +
+        `±${MAX_SAFE_WEIGHT_BIAS} on creature ${uuidLabel} (source=${sourceTag}): ` +
         `${clampedWeightCount} weight(s) (max |w|=${maxObservedWeight}), ` +
         `${clampedBiasCount} bias(es) (max |b|=${maxObservedBias}).`,
     );
@@ -697,8 +758,10 @@ export function fromJSON(
       options: { lazyInitialization: boolean; semanticVersion?: string },
     ): Creature;
   },
-  source: string = "fromJSON",
+  source?: string,
+  options?: LoadFromOptions,
 ): Creature {
+  const sourceTag = source ?? "fromJSON";
   // Issue #2349: treat empty/falsy semanticVersion the same as missing.
   // An empty version is NOT a genuine "0.x" legacy creature — it's a
   // lost/corrupt version field. Only run upgradeOne for real 0.x versions.
@@ -721,7 +784,7 @@ export function fromJSON(
     raw.synapses = raw.connections;
     delete raw.connections;
   }
-  loadFrom(creature, json, validate, source);
+  loadFrom(creature, json, validate, sourceTag, options);
 
   return creature;
 }

--- a/src/discovery/CandidateApplicationOps.ts
+++ b/src/discovery/CandidateApplicationOps.ts
@@ -61,7 +61,18 @@ export function applyAddSynapses(
   if (newSynapses.length === 0) return undefined;
 
   creatureJSON.synapses.push(...newSynapses);
-  const result = Creature.fromJSON(creatureJSON);
+  // Issue #2514: candidate creatures may carry intentionally illegal
+  // hints (forward-only filter happens here, but also above on a
+  // best-effort basis). Opt out of the load-side throw so the
+  // combiner is still the place that decides what to keep.
+  const result = Creature.fromJSON(
+    creatureJSON,
+    false,
+    "discovery:addSynapses",
+    {
+      throwOnRecurrent: "never",
+    },
+  );
   delete result.uuid;
   validateAndFixCreatureSync(result, "add-synapses");
   CreatureUtil.makeUUID(result);
@@ -180,7 +191,17 @@ export function applyAddNeurons(
   );
   creatureJSON.synapses.push(...newSynapses);
 
-  const result = Creature.fromJSON(creatureJSON);
+  // Issue #2514: candidate creatures may still hold filtered-but-not-yet-pruned
+  // recurrent hints. Opt out of the load-side throw — the combiner is the
+  // authority on what survives.
+  const result = Creature.fromJSON(
+    creatureJSON,
+    false,
+    "discovery:addNeurons",
+    {
+      throwOnRecurrent: "never",
+    },
+  );
   delete result.uuid;
   validateAndFixCreatureSync(result, "add-neurons");
   CreatureUtil.makeUUID(result);
@@ -224,7 +245,16 @@ export function applyChangeSquash(
     if (!changed) return creature;
   }
 
-  const result = Creature.fromJSON(creatureJSON);
+  // Issue #2514: candidate creatures may still hold filtered-but-not-yet-pruned
+  // recurrent hints. Opt out of the load-side throw.
+  const result = Creature.fromJSON(
+    creatureJSON,
+    false,
+    "discovery:changeSquash",
+    {
+      throwOnRecurrent: "never",
+    },
+  );
   delete result.uuid;
   validateAndFixCreatureSync(result, "change-squash");
   CreatureUtil.makeUUID(result);
@@ -286,7 +316,16 @@ export function applyRemoveSynapse(
 
   creatureJSON.synapses.push(...toAdd);
 
-  const result = Creature.fromJSON(creatureJSON);
+  // Issue #2514: candidate creatures may still hold filtered-but-not-yet-pruned
+  // recurrent hints. Opt out of the load-side throw.
+  const result = Creature.fromJSON(
+    creatureJSON,
+    false,
+    "discovery:removeSynapse",
+    {
+      throwOnRecurrent: "never",
+    },
+  );
   delete result.uuid;
   validateAndFixCreatureSync(result, "remove-synapse");
   CreatureUtil.makeUUID(result);
@@ -373,7 +412,16 @@ export function applyRemoveNeuron(
 
   creatureJSON.synapses.push(...toAdd);
 
-  const result = Creature.fromJSON(creatureJSON);
+  // Issue #2514: candidate creatures may still hold filtered-but-not-yet-pruned
+  // recurrent hints. Opt out of the load-side throw.
+  const result = Creature.fromJSON(
+    creatureJSON,
+    false,
+    "discovery:removeNeuron",
+    {
+      throwOnRecurrent: "never",
+    },
+  );
   delete result.uuid;
   validateAndFixCreatureSync(result, changeType);
   CreatureUtil.makeUUID(result);

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -254,7 +254,13 @@ export function upgrade(creature: Creature): Creature {
   // Upgrade from 1.x → 2.x, then try 4.x
   if (majorVersion === 1) {
     const v2 = upgradeTwo(exportJSONWithRuntimeIds(creature));
-    const upgraded = Creature.fromJSON(v2);
+    // Issue #2514: legacy 1.x creatures pre-date forward-only enforcement
+    // and may legitimately carry recurrent edges through the upgrade
+    // pipeline. Opt out of the load-side throw so the upgrader can finish
+    // its pass without aborting on still-to-be-fixed topology.
+    const upgraded = Creature.fromJSON(v2, false, "upgrade:oneToTwo", {
+      throwOnRecurrent: "never",
+    });
     return tryUpgradeToFour(upgraded);
   }
 
@@ -264,7 +270,10 @@ export function upgrade(creature: Creature): Creature {
     const json = exportJSONWithRuntimeIds(creature);
     json.semanticVersion = "1.0.0"; // Set to 1.0.0 so upgradeTwo can process it
     const v2 = upgradeTwo(json);
-    const upgraded = Creature.fromJSON(v2);
+    // Issue #2514: see above — same rationale for the v0 → v2 upgrade path.
+    const upgraded = Creature.fromJSON(v2, false, "upgrade:zeroToTwo", {
+      throwOnRecurrent: "never",
+    });
     return tryUpgradeToFour(upgraded);
   }
 

--- a/src/upgrade/UpgradeTwo.ts
+++ b/src/upgrade/UpgradeTwo.ts
@@ -142,7 +142,12 @@ function removeHYPOT(json: CreatureExport) {
     return removeHYPOT(json);
   }
 
-  const tempCreature = Creature.fromJSON(json);
+  // Issue #2514: legacy upgrade JSON may carry residual recurrent edges
+  // before `fix()` runs. Opt out of the load-side throw so the upgrader
+  // can complete its repair pass.
+  const tempCreature = Creature.fromJSON(json, false, "upgrade:removeHYPOT", {
+    throwOnRecurrent: "never",
+  });
   try {
     tempCreature.validate();
   } catch (e) {
@@ -203,7 +208,12 @@ function removeHYPOTv2(json: CreatureExport) {
     return removeHYPOTv2(json);
   }
 
-  const tempCreature = Creature.fromJSON(json);
+  // Issue #2514: legacy upgrade JSON may carry residual recurrent edges
+  // before `fix()` runs. Opt out of the load-side throw so the upgrader
+  // can complete its repair pass.
+  const tempCreature = Creature.fromJSON(json, false, "upgrade:removeHYPOTv2", {
+    throwOnRecurrent: "never",
+  });
   try {
     tempCreature.validate();
   } catch (e) {

--- a/test/architecture/ForwardOnlyLoadRepair.ts
+++ b/test/architecture/ForwardOnlyLoadRepair.ts
@@ -19,7 +19,16 @@ import { Creature } from "@creature";
  * repaired via merge + orphan cleanup in `loadFrom` (see test/fix/Grq25*.ts).
  * NO_INWARD-only repair runs when `validate` is true on load so discovery
  * replay can still use `fromJSON(..., false)` for intermediate topologies.
+ *
+ * Issue #2514: the load-side throw is now the default for forward-only
+ * recurrent edges. These tests intentionally exercise the legacy
+ * strip+repair path that keeps loading historic on-disk JSON safely, so
+ * they opt back into `throwOnRecurrent: "never"`. Coverage of the new
+ * throw default lives in `test/creature/LoadFromForwardOnlyThrow.ts`.
  */
+const REPAIR_LOAD: { throwOnRecurrent: "never" } = {
+  throwOnRecurrent: "never",
+};
 
 Deno.test(
   "forward-only: fromJSON strips self-connections instead of crashing",
@@ -40,7 +49,7 @@ Deno.test(
       ],
     };
 
-    const creature = Creature.fromJSON(json, false);
+    const creature = Creature.fromJSON(json, false, "fromJSON", REPAIR_LOAD);
 
     assertEquals(creature.forwardOnly, true);
     assertEquals(
@@ -78,7 +87,7 @@ Deno.test(
       },
     };
 
-    const creature = Creature.fromJSON(json, true);
+    const creature = Creature.fromJSON(json, true, "fromJSON", REPAIR_LOAD);
 
     assertEquals(creature.forwardOnly, true);
     assertEquals(
@@ -121,7 +130,7 @@ Deno.test(
       ],
     };
 
-    const creature = Creature.fromJSON(json, false);
+    const creature = Creature.fromJSON(json, false, "fromJSON", REPAIR_LOAD);
 
     assertEquals(creature.forwardOnly, true);
     assertEquals(
@@ -160,7 +169,7 @@ Deno.test(
       ],
     };
 
-    const creature = Creature.fromJSON(json, false);
+    const creature = Creature.fromJSON(json, false, "fromJSON", REPAIR_LOAD);
 
     assertEquals(creature.forwardOnly, true);
     assertEquals(

--- a/test/architecture/ForwardOnlySynapseGuard.ts
+++ b/test/architecture/ForwardOnlySynapseGuard.ts
@@ -42,6 +42,16 @@ Deno.test("forward-only: connectBatch() rejects backward connection", () => {
   );
 });
 
+// Issue #2514: the load-side throw is now the default for forward-only
+// recurrent edges. The two strip-and-keep tests below intentionally
+// exercise the legacy strip path (which still must work for repair
+// tools), so they opt back into `throwOnRecurrent: "never"`. New
+// throw-default coverage lives in
+// `test/creature/LoadFromForwardOnlyThrow.ts`.
+const REPAIR_LOAD: { throwOnRecurrent: "never" } = {
+  throwOnRecurrent: "never",
+};
+
 Deno.test(
   "forward-only: loadFrom strips backward synapse when json.forwardOnly is true",
   () => {
@@ -62,7 +72,7 @@ Deno.test(
       ],
     };
 
-    const creature = Creature.fromJSON(json, false);
+    const creature = Creature.fromJSON(json, false, "fromJSON", REPAIR_LOAD);
     assertEquals(creature.synapses.length, 3);
     for (const s of creature.synapses) {
       if (s.from >= s.to) {
@@ -90,7 +100,7 @@ Deno.test(
       ],
     };
 
-    const creature = Creature.fromJSON(json, false);
+    const creature = Creature.fromJSON(json, false, "fromJSON", REPAIR_LOAD);
     assertEquals(creature.synapses.length, 2);
   },
 );

--- a/test/creature/ForwardOnlyOutputRoundTrip.ts
+++ b/test/creature/ForwardOnlyOutputRoundTrip.ts
@@ -165,7 +165,12 @@ Deno.test("Issue #2511: loadFrom strip warning includes depth=<to-from>", async 
     captured.push(args.map(String).join(" "));
   };
   try {
-    Creature.fromJSON(json);
+    // Issue #2514: the load-side throw is the new default. Opt back
+    // into the legacy strip+warn path to keep exercising the depth
+    // label assertions below (this test is specifically about the
+    // warning emission, not about the throw default which has its
+    // own coverage in `LoadFromForwardOnlyThrow.ts`).
+    Creature.fromJSON(json, false, "fromJSON", { throwOnRecurrent: "never" });
   } finally {
     logger.error = originalError;
   }

--- a/test/creature/LoadFromForwardOnlyThrow.ts
+++ b/test/creature/LoadFromForwardOnlyThrow.ts
@@ -1,0 +1,211 @@
+/**
+ * Issue #2514: promote `loadFrom`'s recurrent-synapse strip from a silent
+ * warning to a `TopologyError` throw by default for forward-only
+ * creatures. The strip used to self-heal the topology on every load,
+ * which hid the producing pipeline's stack frame and made the upstream
+ * corruption invisible. The new default surfaces the offending edge so
+ * the producer can be fixed.
+ *
+ * This suite covers the three asks from the issue:
+ *  1. Default behaviour throws on a forward-only creature with
+ *     `output-0 -> output-0`.
+ *  2. `throwOnRecurrent: "never"` preserves the legacy strip+warn
+ *     behaviour for repair tools.
+ *  3. The thrown `TopologyError` contains the offending synapse, depth,
+ *     source tag, and a stack frame pointing at the call site.
+ */
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import { fromJSON, loadFrom } from "@creature/CreatureSerialization.ts";
+import { TopologyError } from "@errors/TopologyError.ts";
+import { getLogger } from "@utils/Logger.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = false;
+
+/**
+ * Build an export-shaped JSON for a forward-only creature with a
+ * poisoned `output-0 -> output-0` recurrent self-loop. Mirrors the
+ * production GRQ-3-rocket.log signature (depth=0, fromUUID=output-0).
+ */
+function makeForwardOnlyExportWithOutputSelfLoop(): CreatureExport {
+  return {
+    semanticVersion: "4.0.0",
+    forwardOnly: true,
+    input: 2,
+    output: 1,
+    neurons: [
+      // hidden at index 2
+      { type: "hidden", uuid: "h-1", squash: "IDENTITY", bias: 0 },
+      // output at index 3 (id resolved at load time)
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h-1", weight: 0.1 },
+      { fromUUID: "h-1", toUUID: "output-0", weight: 0.2 },
+      // The corrupt edge: forward-only creature with a self-loop on output-0.
+      { fromUUID: "output-0", toUUID: "output-0", weight: 0.3 },
+    ],
+  } as unknown as CreatureExport;
+}
+
+/** Same shape, but a recurrent creature (no `forwardOnly` flag set) so
+ *  recurrent synapses are legitimate. */
+function makeRecurrentExport(): CreatureExport {
+  return {
+    semanticVersion: "4.0.0",
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h-1", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "o-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h-1", weight: 0.1 },
+      { fromUUID: "h-1", toUUID: "o-0", weight: 0.2 },
+      { fromUUID: "o-0", toUUID: "o-0", weight: 0.3 },
+    ],
+  } as unknown as CreatureExport;
+}
+
+Deno.test("Issue #2514: loadFrom default throws on forward-only output-0 self-loop", async () => {
+  await initWasmForTests();
+
+  const error = assertThrows(
+    () => fromJSON(makeForwardOnlyExportWithOutputSelfLoop(), false, Creature),
+    TopologyError,
+  );
+
+  assertEquals(
+    error.reason,
+    "INVALID_CONNECTION",
+    "TopologyError must carry reason=INVALID_CONNECTION",
+  );
+
+  // The message names the offending edge endpoints (UUIDs) and depth=0.
+  assert(
+    /fromUUID=output-0/.test(error.message),
+    `expected fromUUID=output-0 in message, got: ${error.message}`,
+  );
+  assert(
+    /toUUID=output-0/.test(error.message),
+    `expected toUUID=output-0 in message, got: ${error.message}`,
+  );
+  assert(
+    /depth=0/.test(error.message),
+    `expected depth=0 in message, got: ${error.message}`,
+  );
+
+  // The source tag identifies the calling pipeline so logs can attribute
+  // the offending producer.
+  assert(
+    /source=fromJSON/.test(error.message),
+    `expected source=fromJSON in message, got: ${error.message}`,
+  );
+
+  // The thrown error carries a stack frame pointing at the call site.
+  assert(
+    typeof error.stack === "string" && error.stack.length > 0,
+    "TopologyError.stack must be present and non-empty",
+  );
+});
+
+Deno.test("Issue #2514: throwOnRecurrent=never preserves legacy strip+warn", async () => {
+  await initWasmForTests();
+
+  const logger = getLogger();
+  const original = logger.error.bind(logger);
+  const captured: string[] = [];
+  logger.error = (...args: unknown[]) => {
+    captured.push(args.map(String).join(" "));
+  };
+
+  let creature: Creature | undefined;
+  try {
+    creature = fromJSON(
+      makeForwardOnlyExportWithOutputSelfLoop(),
+      false,
+      Creature,
+      "fromJSON",
+      { throwOnRecurrent: "never" },
+    );
+  } finally {
+    logger.error = original;
+  }
+
+  assert(
+    creature,
+    "fromJSON with throwOnRecurrent=never must produce a creature",
+  );
+
+  // The legacy warning is still emitted on the error logger.
+  const stripWarnings = captured.filter((m) =>
+    m.includes("Stripping recurrent synapse")
+  );
+  assert(
+    stripWarnings.length > 0,
+    `expected at least one strip warning, got: ${captured.join("\n")}`,
+  );
+
+  // No recurrent edge survives the load — the strip path is what kept
+  // the runtime topology valid.
+  for (const synapse of creature.synapses) {
+    assert(
+      synapse.from < synapse.to,
+      `expected from<to in forward-only creature, got ${synapse.from}->${synapse.to}`,
+    );
+  }
+});
+
+Deno.test("Issue #2514: throwOnRecurrent=always throws on recurrent (non-forward-only) creature", async () => {
+  await initWasmForTests();
+
+  // Recurrent creature loads fine by default — the gate only fires for
+  // forward-only — but `always` opts into stricter checks regardless.
+  // Sanity-check the default behaviour first.
+  const ok = fromJSON(makeRecurrentExport(), false, Creature);
+  assert(ok, "recurrent creature must load by default");
+  assert(
+    ok.synapses.some((s) => s.from >= s.to),
+    "recurrent creature must keep its self-loop under the default gate",
+  );
+
+  // Now opt into `always` and verify it throws.
+  assertThrows(
+    () =>
+      fromJSON(makeRecurrentExport(), false, Creature, "fromJSON", {
+        throwOnRecurrent: "always",
+      }),
+    TopologyError,
+  );
+});
+
+Deno.test("Issue #2514: loadFrom throws synchronously and the error tags the source pipeline", async () => {
+  await initWasmForTests();
+
+  const target = new Creature(2, 1, { feedbackEnabled: false });
+  target.forwardOnly = true;
+
+  const error = assertThrows(
+    () =>
+      loadFrom(
+        target,
+        makeForwardOnlyExportWithOutputSelfLoop(),
+        false,
+        "unit-test:throw-source",
+      ),
+    TopologyError,
+  );
+
+  assert(
+    /source=unit-test:throw-source/.test(error.message),
+    `expected source tag in TopologyError message, got: ${error.message}`,
+  );
+  // The thrown error includes the structural-hash fallback identifier,
+  // because the source JSON omits a creature uuid.
+  assert(
+    /UUID:\s*hash:[0-9a-f]{8}/i.test(error.message),
+    `expected hash:<8hex> uuid label in TopologyError message, got: ${error.message}`,
+  );
+});

--- a/test/creature/LoadFromObservability.ts
+++ b/test/creature/LoadFromObservability.ts
@@ -53,10 +53,15 @@ Deno.test("loadFrom strip warning: no longer says 'UUID: unknown'", async () => 
     captured.push(args.map(String).join(" "));
   };
   try {
+    // Issue #2514: the load-side throw is the new default. To keep
+    // exercising the legacy strip+warn path verified by this test,
+    // opt back into the legacy behaviour explicitly.
     const creature = fromJSON(
       makeForwardOnlyExportWithRecurrent(),
       false,
       Creature,
+      "fromJSON",
+      { throwOnRecurrent: "never" },
     );
     assert(creature, "fromJSON must still produce a creature");
   } finally {
@@ -95,11 +100,14 @@ Deno.test("loadFrom strip warning: source=... reflects caller tag", async () => 
   try {
     const target = new Creature(2, 1, { feedbackEnabled: false });
     target.forwardOnly = true;
+    // Issue #2514: opt into the legacy strip+warn path so the source
+    // tag assertion below continues to exercise warning emission.
     loadFrom(
       target,
       makeForwardOnlyExportWithRecurrent(),
       false,
       "unit-test:custom-source",
+      { throwOnRecurrent: "never" },
     );
   } finally {
     logger.error = original;
@@ -129,8 +137,11 @@ Deno.test("loadFrom strip warning: same JSON yields the same hash twice", async 
   try {
     const j1 = makeForwardOnlyExportWithRecurrent();
     const j2 = makeForwardOnlyExportWithRecurrent();
-    fromJSON(j1, false, Creature);
-    fromJSON(j2, false, Creature);
+    // Issue #2514: opt into the legacy strip+warn path so the
+    // structural-hash assertion below continues to exercise warning
+    // emission for identical JSON.
+    fromJSON(j1, false, Creature, "fromJSON", { throwOnRecurrent: "never" });
+    fromJSON(j2, false, Creature, "fromJSON", { throwOnRecurrent: "never" });
   } finally {
     logger.error = original;
   }


### PR DESCRIPTION
## Summary

Promote `Creature.loadFrom`'s recurrent-synapse strip from a silent warning to a
`TopologyError` throw by default for forward-only creatures. The old
strip-and-warn behaviour silently self-healed the runtime topology on every
load, hiding the producing pipeline's stack frame so the upstream corruption
that caused the 143 strip events on `@stsoftware/neat-ai 3.1.53`
(GRQ-3-rocket.log, 5 May 2026) was invisible. The new default surfaces the
offending edge so the producer can be fixed. Closes #2514.

A new `throwOnRecurrent: "always" | "forwardOnly" | "never"` option on both
`loadFrom` and `Creature.fromJSON` (default `"forwardOnly"`) gives repair tools
an explicit opt-out — `compactCreature`, the `applyChangeToCreature` family, the
legacy v0/v1/v2 upgrade pipeline, the `compact:*` repair helpers, and
`Creature.fromPersistedJSON` (the disk-load path) all pass
`throwOnRecurrent: "never"` with a code comment naming the bypass so they can
keep ingesting historic on-disk JSON safely.

The SemVer minor was bumped (`3.1.53 → 3.2.0`) and `CHANGELOG.md` was created
with a migration note for the breaking-by-default change.

## Evidence

This is a backend/library change with no UI surface — coverage is via unit tests
that exercise the throw default, the legacy strip path, and the message
contents.

```mermaid
flowchart LR
    A[Producer pipeline] -->|writes corrupt JSON| B[Creature.fromJSON]
    B -->|forwardOnly + recurrent| C{throwOnRecurrent?}
    C -->|forwardOnly default| D[TopologyError + stack]
    C -->|never opt-in| E[strip + warn]
    D --> F[fix producer]
```

Verified locally:

- `deno fmt --check` and `deno lint` pass
  (`./quality.sh
  --skip-tests --skip-discovery --skip-wasm` exits 0).
- `deno check mod.ts src/` passes (no type errors).
- `deno test --allow-all "test/creature/**/*.ts"` → 249 passed, 0 failed.
- `deno test --allow-all "test/discovery/**/*.ts" "test/compact/**/*.ts"
  "test/upgrade/**/*.ts" "test/ErrorGuidedStructuralEvolution/**/*.ts"
  "test/architecture/**/*.ts"`
  → 1292 passed, 0 failed.
- `deno test --allow-all "test/blackbox/**/*.ts" "test/breed/**/*.ts"
  "test/transfer/**/*.ts" "test/multithreading/**/*.ts"
  "test/intelligentDesign/**/*.ts" "test/optimize/**/*.ts"
  "test/predictiveCoding/**/*.ts" "test/reconstruct/**/*.ts"
  "test/fix/**/*.ts"`
  → 718 passed, 0 failed.
- The remaining test directories (`NEAT`, `cache`, `CRISPR`, `data`,
  `feedForward`, `lifecycle`, `methods`, `mutate`, `neuron`, `onnx`,
  `optimization`, `score`, `tag`, `utils`, `validate`, `wasm`, `workers`,
  `errors`, `propagate`, `fixtures`, `config`, `constants`, `costs`, `scripts`)
  → 4104 passed, 1 failed before reformat; failure was the `deno fmt --check`
  smoke test which was resolved by running `deno fmt` on the two affected test
  files. After reformat, `deno fmt --check` over all 2147 files passes cleanly.

## Test Plan

### New tests (this PR)

- `test/creature/LoadFromForwardOnlyThrow.ts` — four tests:
  - **Default behaviour throws on a forward-only creature with
    `output-0 → output-0`** (mirrors GRQ-3-rocket.log signature: `depth=0`,
    `fromUUID=output-0`).
  - **`throwOnRecurrent: "never"` preserves the legacy strip+warn** (warning
    emitted, no recurrent edge survives).
  - **`throwOnRecurrent: "always"` throws on a non-forward-only recurrent
    creature** (sanity-checks that the default lets recurrent creatures through
    and `"always"` opts into stricter checks).
  - **`loadFrom` throws synchronously and the error tags the source pipeline**
    (the `TopologyError` message includes `source=unit-test:throw-source` and
    the structural-hash fallback identifier).

### Modified tests (business-logic change)

The Issue #2514 default is by design _breaking_ — tests that were written around
the old strip-and-warn contract opt back into `throwOnRecurrent: "never"` so
they continue to verify the legacy path that repair tools still exercise:

- `test/creature/LoadFromObservability.ts` (Issue #2500 strip-warning
  observability — three tests).
- `test/creature/ForwardOnlyOutputRoundTrip.ts` — the `depth=<to-from>`
  warning-format test (one of five tests; the other four are unchanged).
- `test/architecture/ForwardOnlyLoadRepair.ts` — four legacy strip-and-repair
  tests (Issue #2090).
- `test/architecture/ForwardOnlySynapseGuard.ts` — two legacy strip-and-keep
  tests.

Coverage of the new throw default lives in
`test/creature/LoadFromForwardOnlyThrow.ts`.

### Production callers updated

These pipelines legitimately ingest corrupt input, so they pass
`throwOnRecurrent: "never"` with a code comment justifying the bypass:

- `src/compact/CompactCreature.ts`
- `src/compact/OrphanedNeuronCleanup.ts`
- `src/compact/DeadSubgraphPruning.ts`
- `src/upgrade/Upgrade.ts` (v0/v1 upgrade paths)
- `src/upgrade/UpgradeTwo.ts` (HYPOT/HYPOTv2 removal passes)
- `src/discovery/CandidateApplicationOps.ts` (`applyAddSynapses` /
  `applyAddNeurons` / `applyChangeSquash` / `applyRemoveSynapse` /
  `applyRemoveNeuron`).
- `src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts`
- `src/Creature.ts`'s `fromPersistedJSON` (the disk-load path that may encounter
  genuinely historic on-disk JSON from older releases).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2514 -->