### PR TITLE
Wire forward-only post-conditions into apply* combiners (#2515)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/issue-2515-forward-only-apply-audit.md
+++ b/docs/issue-2515-forward-only-apply-audit.md
@@ -1,0 +1,89 @@
+# Issue #2515 — Forward-only audit of `applyChangeToCreature` and `normaliseCreatureExport`
+
+## Summary
+
+This note records the audit that wired `assertNoRecurrentSynapseOnForwardOnly`
+into every combiner that produces a candidate creature in the discovery
+pipeline, so a recurrent synapse on a forward-only creature now throws a
+`TopologyError` at the producer site instead of being silently stripped at
+`loadFrom` time.
+
+## Why the audit was needed
+
+`exportJSONUnchecked(...)` is intentionally called from four sites because the
+input may legitimately carry illegal hints:
+
+- `compact/CompactCreature.ts` — backward synapses are stripped during
+  compaction.
+- `discovery/CandidateApplication.ts::applyChangeToCreature(...)` — candidate
+  creatures may carry recurrent hints that the combiner is meant to filter.
+- `utils/Diagnostics.ts` — post-validation-failure capture.
+- `upgrade/Upgrade.ts` — legacy capture.
+
+Of these, the discovery combiner was the most likely producer of the
+GRQ-3-rocket.log signature (output-0 self-loops). The combiner already filtered
+illegal hints in best-effort fashion, but if any branch ever let a recurrent
+edge through, it surfaced only as a `[loadFrom] Stripping recurrent synapse`
+warning on the receiving worker — which named the wrong stack frame.
+
+## What changed
+
+The producer-site post-condition `assertNoRecurrentSynapseOnForwardOnly` is now
+called immediately before the combiner returns a candidate creature, at each of
+these introduction sites:
+
+| Site                                  | Source tag in the thrown error                  |
+| ------------------------------------- | ----------------------------------------------- |
+| `applyAddSynapses`                    | `discovery:applyAddSynapses`                    |
+| `applyAddNeurons`                     | `discovery:applyAddNeurons`                     |
+| `applyChangeSquash`                   | `discovery:applyChangeSquash`                   |
+| `applyRemoveSynapse`                  | `discovery:applyRemoveSynapse`                  |
+| `applyRemoveNeuron`                   | `discovery:applyRemoveNeuron(<changeType>)`     |
+| `applyCoordinatedStructuralCandidate` | `discovery:applyCoordinatedStructuralCandidate` |
+
+If any of these tags ever appears in a `TopologyError` message in production,
+the producer is named directly in the stack frame.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+    A[Discovery candidate] --> B[applyChangeToCreature]
+    B --> C[normaliseCreatureExport]
+    C --> D[apply* combiner]
+    D --> E[validateAndFixCreatureSync]
+    E --> F[assertNoRecurrentSynapse<br/>OnForwardOnly]
+    F -->|fails| G[TopologyError<br/>names producer]
+    F -->|ok| H[return candidate]
+```
+
+## Tests added
+
+- `test/architecture/NormaliseCreatureExportForwardOnly.ts` — pins the
+  forward-only invariant on `normaliseCreatureExport`. Round-trip exports,
+  idempotent re-normalisation, output-id remapping, and UUID-keyed wire inputs
+  are all checked against `buildIdToIndexMap` to confirm that no synapse leaves
+  the function violating `from < to`.
+- `test/lifecycle/ForwardOnlyApplyChangeLifecycle.ts` — exercises every branch
+  of `applyChangeToCreature` (`add-synapses`, `add-neurons`, `change-squash`,
+  `remove-synapse`, `remove-neuron`, `coordinated-structural`) on a forward-only
+  base and asserts the result is still forward-only. Includes adversarial cases
+  that feed deliberately illegal candidate hints to confirm the combiner filters
+  them rather than passing the corruption through.
+
+## Outcome
+
+- `normaliseCreatureExport` does not introduce back-edges: it remaps wrong
+  output IDs to their canonical `outputNeuronId(i)` values and re-points
+  synapses, but it does not reorder neurons or invert edge direction. The pinned
+  test (`output-id remap without flipping edges`) is the canonical check.
+- The producer-side assertions are now load-bearing. The downstream GRQ-side
+  defences (#2099, #2100) become true defence-in-depth — if a recurrent edge
+  ever reaches `loadFrom` again, the upstream `TopologyError` will name the
+  responsible combiner.
+
+## Related
+
+- Builds on #2511 (save-side assertion in `exportJSON`) and #2514 (load-side
+  throw in `loadFrom`).
+- Closes the producer-side audit requested in stSoftwareAU/GRQ#2109.

--- a/docs/pr-summary-2515.md
+++ b/docs/pr-summary-2515.md
@@ -1,0 +1,59 @@
+## Summary
+
+Audit of `applyChangeToCreature` and `normaliseCreatureExport` for back-edge
+introduction on forward-only creatures, per issue #2515. Wires
+`assertNoRecurrentSynapseOnForwardOnly(...)` as a post-condition at every
+combiner producer site so that any future corruption throws a `TopologyError`
+naming the producing pipeline rather than surfacing as a downstream
+`[loadFrom] Stripping recurrent synapse` warning. Closes #2515.
+
+## Evidence
+
+Backend-only change — no UI to screenshot. Verified via:
+
+- Unit tests for `normaliseCreatureExport` (4 tests) covering round-trip
+  exports, idempotent re-normalisation, output-id remapping, and UUID-keyed wire
+  inputs. All assert the forward-only invariant (`from < to` against
+  `buildIdToIndexMap`).
+- Lifecycle integration tests covering every branch of `applyChangeToCreature`
+  (8 tests): `add-synapses` (legal + adversarial), `add-neurons`,
+  `change-squash`, `remove-synapse`, `remove-neuron`, and
+  `coordinated-structural` (legal + adversarial).
+- All 525 discovery tests and 158 lifecycle/ErrorGuidedStructuralEvolution tests
+  still pass.
+- `./quality.sh --lint-only` and `./quality.sh --check-only` are clean.
+
+```mermaid
+flowchart LR
+    A[Discovery candidate] --> B[applyChangeToCreature]
+    B --> C[normaliseCreatureExport]
+    C --> D[apply* combiner]
+    D --> E[validateAndFixCreatureSync]
+    E --> F[assertNoRecurrentSynapse<br/>OnForwardOnly]
+    F -->|fails| G[TopologyError<br/>names producer]
+    F -->|ok| H[return candidate]
+```
+
+Producer tags wired in:
+
+| Site                                  | Source tag in `TopologyError`                   |
+| ------------------------------------- | ----------------------------------------------- |
+| `applyAddSynapses`                    | `discovery:applyAddSynapses`                    |
+| `applyAddNeurons`                     | `discovery:applyAddNeurons`                     |
+| `applyChangeSquash`                   | `discovery:applyChangeSquash`                   |
+| `applyRemoveSynapse`                  | `discovery:applyRemoveSynapse`                  |
+| `applyRemoveNeuron`                   | `discovery:applyRemoveNeuron(<changeType>)`     |
+| `applyCoordinatedStructuralCandidate` | `discovery:applyCoordinatedStructuralCandidate` |
+
+## Test Plan
+
+- `test/architecture/NormaliseCreatureExportForwardOnly.ts` — 4 tests.
+- `test/lifecycle/ForwardOnlyApplyChangeLifecycle.ts` — 8 tests.
+- Existing tests unchanged: `ForwardOnlyAssertion`, `ForwardOnlyLifecycle`,
+  `CandidateApplicationOps`, `DiscoveryCandidatesForwardOnlyVersionBump`, all
+  green.
+
+Diagnostic note: `docs/issue-2515-forward-only-apply-audit.md` summarises the
+audit, the producer tags, and the path that was confirmed (no current
+introduction site found — the post-conditions are the load-bearing
+defence-in-depth that names the producer if a regression ever lands).

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -1,5 +1,6 @@
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { assertNoRecurrentSynapseOnForwardOnly } from "@architecture/ForwardOnlyAssertion.ts";
 import { nextNeuronId } from "@architecture/NeuronId.ts";
 import { populateRuntimeIdsFromCreature } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
 import { Creature } from "@creature";
@@ -361,6 +362,15 @@ export function applyCoordinatedStructuralCandidate(
       updated.validate();
     }
   }
+
+  // Issue #2515: post-condition fail-fast — if this combiner ever leaves
+  // a forward-only base with a recurrent edge, throw a TopologyError that
+  // names this producer rather than letting the corruption surface only
+  // as a "Stripping recurrent synapse" warning at loadFrom time.
+  assertNoRecurrentSynapseOnForwardOnly(
+    updated,
+    "discovery:applyCoordinatedStructuralCandidate",
+  );
 
   CreatureUtil.makeUUID(updated);
   return updated;

--- a/src/discovery/CandidateApplicationOps.ts
+++ b/src/discovery/CandidateApplicationOps.ts
@@ -10,6 +10,7 @@
 
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { assertNoRecurrentSynapseOnForwardOnly } from "@architecture/ForwardOnlyAssertion.ts";
 import {
   cleanupMemeticForRemovedNeuron,
   cleanupMemeticForRemovedSynapse,
@@ -75,6 +76,12 @@ export function applyAddSynapses(
   );
   delete result.uuid;
   validateAndFixCreatureSync(result, "add-synapses");
+  // Issue #2515: post-condition fail-fast — name the producer if a
+  // forward-only base ever leaves this combiner with a recurrent edge.
+  assertNoRecurrentSynapseOnForwardOnly(
+    result,
+    "discovery:applyAddSynapses",
+  );
   CreatureUtil.makeUUID(result);
   return result;
 }
@@ -204,6 +211,11 @@ export function applyAddNeurons(
   );
   delete result.uuid;
   validateAndFixCreatureSync(result, "add-neurons");
+  // Issue #2515: post-condition fail-fast — name the producer.
+  assertNoRecurrentSynapseOnForwardOnly(
+    result,
+    "discovery:applyAddNeurons",
+  );
   CreatureUtil.makeUUID(result);
   return result;
 }
@@ -257,6 +269,11 @@ export function applyChangeSquash(
   );
   delete result.uuid;
   validateAndFixCreatureSync(result, "change-squash");
+  // Issue #2515: post-condition fail-fast — name the producer.
+  assertNoRecurrentSynapseOnForwardOnly(
+    result,
+    "discovery:applyChangeSquash",
+  );
   CreatureUtil.makeUUID(result);
   return result;
 }
@@ -328,6 +345,11 @@ export function applyRemoveSynapse(
   );
   delete result.uuid;
   validateAndFixCreatureSync(result, "remove-synapse");
+  // Issue #2515: post-condition fail-fast — name the producer.
+  assertNoRecurrentSynapseOnForwardOnly(
+    result,
+    "discovery:applyRemoveSynapse",
+  );
   CreatureUtil.makeUUID(result);
   return result;
 }
@@ -424,6 +446,13 @@ export function applyRemoveNeuron(
   );
   delete result.uuid;
   validateAndFixCreatureSync(result, changeType);
+  // Issue #2515: post-condition fail-fast — name the producer.
+  // changeType differentiates remove-neuron / remove-low-impact /
+  // cache-informed-removal so the offending branch is identifiable.
+  assertNoRecurrentSynapseOnForwardOnly(
+    result,
+    `discovery:applyRemoveNeuron(${changeType})`,
+  );
   CreatureUtil.makeUUID(result);
   return result;
 }

--- a/test/architecture/NormaliseCreatureExportForwardOnly.ts
+++ b/test/architecture/NormaliseCreatureExportForwardOnly.ts
@@ -1,0 +1,153 @@
+/**
+ * NormaliseCreatureExport forward-only invariant test (Issue #2515).
+ *
+ * `normaliseCreatureExport` renumbers neuron IDs (especially for output
+ * neurons whose IDs may be re-pointed when a candidate carries the wrong
+ * ID) and back-propagates those renames to the synapses' `fromId` /
+ * `toId` fields.
+ *
+ * The audit in #2515 calls out this function as a place where back-edges
+ * could be introduced if the renumbering ever pointed a synapse at a
+ * lower-indexed neuron. This test pins the invariant: for a forward-only
+ * creature, no synapse leaves `normaliseCreatureExport` violating
+ * `from < to` when measured against the canonical neuron index built by
+ * `buildIdToIndexMap` (input neurons first, then `neurons` array order).
+ */
+
+import { assert } from "@std/assert";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { buildIdToIndexMap } from "@discovery/CandidateApplication.ts";
+import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+function assertSynapsesForwardOnly(
+  json: CreatureExport,
+  context: string,
+): void {
+  const idToIndex = buildIdToIndexMap(json);
+  for (let i = 0; i < json.synapses.length; i++) {
+    const s = json.synapses[i];
+    const fromIndex = idToIndex.get(s.fromId!);
+    const toIndex = idToIndex.get(s.toId!);
+    assert(
+      fromIndex !== undefined && toIndex !== undefined,
+      `${context}: synapse[${i}] endpoint missing from idToIndex map ` +
+        `(fromId=${s.fromId}, toId=${s.toId})`,
+    );
+    assert(
+      fromIndex! < toIndex!,
+      `${context}: synapse[${i}] violates forward-only ` +
+        `(${s.fromId}@${fromIndex} -> ${s.toId}@${toIndex})`,
+    );
+  }
+}
+
+Deno.test("normaliseCreatureExport: preserves forward-only invariant on round-trip", async () => {
+  await initWasmForTests();
+
+  // Build a forward-only creature with two hidden layers and verify
+  // that exporting + normalising preserves the forward-only invariant.
+  const creature = new Creature(3, 2, {
+    layers: [{ count: 4 }, { count: 3 }],
+  });
+  const json = creature.exportJSON();
+  normaliseCreatureExport(json);
+  assertSynapsesForwardOnly(json, "round-trip exportJSON");
+});
+
+Deno.test("normaliseCreatureExport: idempotent on already-resolved IDs", async () => {
+  await initWasmForTests();
+
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+  const json = creature.exportJSON();
+  normaliseCreatureExport(json);
+  // Run again — idempotent, so the invariant must still hold.
+  normaliseCreatureExport(json);
+  assertSynapsesForwardOnly(json, "second normalise call");
+});
+
+Deno.test("normaliseCreatureExport: remaps output neuron with wrong ID without flipping edges", () => {
+  // Construct an export where the output neuron carries a wrong ID
+  // (positive integer instead of -1). The hidden→output synapse uses
+  // UUID identity, so normaliseCreatureExport runs the renumbering
+  // branch (instead of short-circuiting on already-resolved IDs) and
+  // must rewrite the output neuron to outputNeuronId(0) = -1, then
+  // update the synapse's `toId` to -1. The resulting topology must
+  // still be forward-only.
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        id: 1_000_005,
+        uuid: "hidden-1",
+        type: "hidden",
+        squash: "IDENTITY",
+        bias: 0,
+      },
+      {
+        id: 999_999_999, // wrong: should be remapped to -1
+        uuid: "output-0",
+        type: "output",
+        squash: "IDENTITY",
+        bias: 0,
+      },
+    ],
+    synapses: [
+      // Force the renumbering branch to run by leaving fromId/toId
+      // unresolved on at least one synapse — `isResolvedIds` returns
+      // false, so the function does not short-circuit.
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromId: 1_000_005, toId: 999_999_999, weight: 0.4 },
+    ],
+  };
+
+  normaliseCreatureExport(json);
+
+  // Output neuron must be remapped to -1.
+  const out = json.neurons.find((n) => n.type === "output");
+  assert(out, "expected output neuron to be present");
+  assert(out!.id === -1, `output id should be -1, got ${out!.id}`);
+  // Synapse should now point to -1.
+  const remapped = json.synapses.find((s) => s.fromId === 1_000_005);
+  assert(remapped, "expected the hidden->output synapse to remain");
+  assert(
+    remapped!.toId === -1,
+    `synapse toId should be remapped to -1, got ${remapped!.toId}`,
+  );
+  // Forward-only invariant: input(0) -> hidden(2) -> output(3).
+  assertSynapsesForwardOnly(json, "wrong-output-id remap");
+});
+
+Deno.test("normaliseCreatureExport: UUID-keyed memetic input survives normalise without back-edges", () => {
+  // Simulates a wire-format candidate (UUID-keyed, no integer IDs) — the
+  // exact pattern used by discovery/breeding before normalisation. The
+  // invariant must hold once IDs are resolved.
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { uuid: "hidden-A", type: "hidden", squash: "IDENTITY", bias: 0 },
+      { uuid: "hidden-B", type: "hidden", squash: "IDENTITY", bias: 0 },
+      { uuid: "output-0", type: "output", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-A", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-B", weight: 0.5 },
+      { fromUUID: "hidden-A", toUUID: "hidden-B", weight: 0.4 },
+      { fromUUID: "hidden-B", toUUID: "output-0", weight: 0.3 },
+    ],
+  };
+
+  normaliseCreatureExport(json);
+
+  // Every synapse should now have integer fromId/toId.
+  for (const s of json.synapses) {
+    assert(
+      s.fromId !== undefined && s.toId !== undefined,
+      `synapse missing resolved IDs: ${JSON.stringify(s)}`,
+    );
+  }
+  assertSynapsesForwardOnly(json, "UUID-keyed wire format");
+});

--- a/test/lifecycle/ForwardOnlyApplyChangeLifecycle.ts
+++ b/test/lifecycle/ForwardOnlyApplyChangeLifecycle.ts
@@ -1,0 +1,345 @@
+/**
+ * Lifecycle integration tests for `applyChangeToCreature` (Issue #2515).
+ *
+ * Each test exercises one branch of `applyChangeToCreature` on a
+ * forward-only base creature. The producer side asserts that the
+ * resulting creature is still forward-only via
+ * `assertNoRecurrentSynapseOnForwardOnly` — without it, the corruption
+ * would only surface as a `[loadFrom] Stripping recurrent synapse`
+ * warning much later in the pipeline.
+ *
+ * Branches covered:
+ *  - add-synapses
+ *  - add-neurons
+ *  - change-squash
+ *  - remove-synapse
+ *  - remove-neuron
+ *  - coordinated-structural
+ *
+ * For each branch we also feed an *intentionally illegal* candidate (one
+ * that carries a backward synapse) and verify the combiner filters it
+ * rather than letting it leak through. This is the behaviour the audit
+ * in #2515 was set up to lock in: candidate creatures may legitimately
+ * carry recurrent hints, but the combiner is the authority on what
+ * survives.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { applyChangeToCreature } from "@discovery/CandidateApplication.ts";
+import type { DiscoveryCandidate } from "@discovery/DiscoveryCandidates.ts";
+import { applyCoordinatedStructuralCandidate } from "@architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts";
+import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/** Build a small forward-only creature: 2 input → 1 hidden → 1 output. */
+async function makeForwardOnlyBase(): Promise<Creature> {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { layers: [{ count: 1 }] });
+  assertEquals(c.forwardOnly, true);
+  c.validate({ forwardOnly: true });
+  CreatureUtil.makeUUID(c);
+  return c;
+}
+
+/** Assert every synapse is forward (from < to) on a runtime creature. */
+function assertForwardOnly(creature: Creature, context: string): void {
+  assertEquals(
+    creature.forwardOnly,
+    true,
+    `${context}: forwardOnly flag should remain true`,
+  );
+  for (let i = 0; i < creature.synapses.length; i++) {
+    const s = creature.synapses[i];
+    assert(
+      s.from < s.to,
+      `${context}: synapse[${i}] violates forward-only ` +
+        `(from=${s.from}, to=${s.to})`,
+    );
+  }
+}
+
+/**
+ * Helper: build a candidate creature from a JSON export, opting out of
+ * the load-side throw so we can intentionally feed illegal hints.
+ *
+ * Normalises the JSON first so callers can mix UUID and integer-ID
+ * synapse references (`exportJSON` returns UUID-keyed synapses).
+ */
+function candidateFromJSON(json: CreatureExport): Creature {
+  normaliseCreatureExport(json);
+  const c = Creature.fromJSON(json, false, "test:candidate", {
+    throwOnRecurrent: "never",
+  });
+  CreatureUtil.makeUUID(c);
+  return c;
+}
+
+// ---------------------------------------------------------------------------
+// add-synapses
+// ---------------------------------------------------------------------------
+Deno.test("Lifecycle apply: add-synapses preserves forward-only", async () => {
+  const base = await makeForwardOnlyBase();
+  const baseJSON = base.exportJSON();
+
+  // Candidate adds an input → output synapse (forward, UUID-keyed).
+  const candidateJSON: CreatureExport = structuredClone(baseJSON);
+  candidateJSON.synapses.push({
+    fromUUID: "input-1",
+    toUUID: "output-0",
+    weight: 0.2,
+  });
+  const candidateCreature = candidateFromJSON(candidateJSON);
+
+  const candidate: DiscoveryCandidate = {
+    creature: candidateCreature,
+    change: { type: "add-synapses", description: "add forward synapse" },
+  };
+
+  const result = applyChangeToCreature(base, candidate, base);
+  assert(result, "expected applyChangeToCreature to return a creature");
+  assertForwardOnly(result!, "add-synapses forward");
+});
+
+Deno.test("Lifecycle apply: add-synapses filters backward-edge candidate hint", async () => {
+  const base = await makeForwardOnlyBase();
+  const baseJSON = base.exportJSON();
+
+  // Candidate carries an *illegal* backward synapse: output → hidden.
+  const candidateJSON: CreatureExport = structuredClone(baseJSON);
+  const hiddenUuid = candidateJSON.neurons.find((n) => n.type === "hidden")!
+    .uuid!;
+  candidateJSON.synapses.push({
+    fromUUID: "output-0",
+    toUUID: hiddenUuid,
+    weight: 0.2,
+  });
+  const candidateCreature = candidateFromJSON(candidateJSON);
+
+  const candidate: DiscoveryCandidate = {
+    creature: candidateCreature,
+    change: {
+      type: "add-synapses",
+      description: "candidate carries illegal back-edge",
+    },
+  };
+
+  // The combiner should either filter the illegal hint (returning undefined
+  // because no legal synapses remained) or return a creature without it.
+  const result = applyChangeToCreature(base, candidate, base);
+  if (result) {
+    assertForwardOnly(result, "add-synapses backward filtered");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// add-neurons
+// ---------------------------------------------------------------------------
+Deno.test("Lifecycle apply: add-neurons preserves forward-only", async () => {
+  const base = await makeForwardOnlyBase();
+  const baseJSON = base.exportJSON();
+
+  // Candidate adds a new hidden neuron between input and output, with
+  // forward synapses only.
+  const candidateJSON: CreatureExport = structuredClone(baseJSON);
+  const outputIdx = candidateJSON.neurons.findIndex((n) => n.type === "output");
+  candidateJSON.neurons.splice(outputIdx, 0, {
+    uuid: "hidden-new-A",
+    type: "hidden",
+    squash: "IDENTITY",
+    bias: 0.0,
+  });
+  candidateJSON.synapses.push(
+    { fromUUID: "input-0", toUUID: "hidden-new-A", weight: 0.3 },
+    { fromUUID: "hidden-new-A", toUUID: "output-0", weight: 0.4 },
+  );
+  const candidateCreature = candidateFromJSON(candidateJSON);
+
+  const candidate: DiscoveryCandidate = {
+    creature: candidateCreature,
+    change: { type: "add-neurons", description: "add hidden neuron" },
+  };
+
+  const result = applyChangeToCreature(base, candidate, base);
+  assert(result, "expected applyChangeToCreature to return a creature");
+  assertForwardOnly(result!, "add-neurons forward");
+});
+
+// ---------------------------------------------------------------------------
+// change-squash
+// ---------------------------------------------------------------------------
+Deno.test("Lifecycle apply: change-squash preserves forward-only", async () => {
+  const base = await makeForwardOnlyBase();
+  const baseJSON = base.exportJSON();
+  const hidden = baseJSON.neurons.find((n) => n.type === "hidden")!;
+  const altSquash = hidden.squash === "TANH" ? "IDENTITY" : "TANH";
+
+  // Candidate flips the hidden neuron's squash.
+  const candidateJSON: CreatureExport = structuredClone(baseJSON);
+  candidateJSON.neurons.find((n) => n.type === "hidden")!.squash = altSquash;
+  const candidateCreature = candidateFromJSON(candidateJSON);
+
+  const candidate: DiscoveryCandidate = {
+    creature: candidateCreature,
+    change: {
+      type: "change-squash",
+      description: "flip squash",
+      squashCandidate: {
+        neuronUuid: hidden.uuid!,
+        previousSquash: hidden.squash!,
+        squash: altSquash,
+        expectedCreatureScoreGain: 0.0,
+        improvedError: 0.0,
+        currentError: 0.0,
+      },
+    },
+  };
+
+  const result = applyChangeToCreature(base, candidate, base);
+  assert(result, "expected applyChangeToCreature to return a creature");
+  assertForwardOnly(result!, "change-squash");
+});
+
+// ---------------------------------------------------------------------------
+// remove-synapse
+// ---------------------------------------------------------------------------
+Deno.test("Lifecycle apply: remove-synapse preserves forward-only", async () => {
+  const base = await makeForwardOnlyBase();
+  const baseJSON = base.exportJSON();
+
+  // Add an extra forward synapse to the base so removal has a target.
+  baseJSON.synapses.push({
+    fromUUID: "input-0",
+    toUUID: "output-0",
+    weight: 0.1,
+  });
+  const baseWithExtra = candidateFromJSON(baseJSON);
+  baseWithExtra.validate({ forwardOnly: true });
+
+  // Candidate omits the extra synapse.
+  const candidateJSON: CreatureExport = baseWithExtra.exportJSON();
+  candidateJSON.synapses = candidateJSON.synapses.filter(
+    (s) => !(s.fromUUID === "input-0" && s.toUUID === "output-0"),
+  );
+  const candidateCreature = candidateFromJSON(candidateJSON);
+
+  const candidate: DiscoveryCandidate = {
+    creature: candidateCreature,
+    change: { type: "remove-synapse", description: "drop extra synapse" },
+  };
+
+  const result = applyChangeToCreature(
+    baseWithExtra,
+    candidate,
+    baseWithExtra,
+  );
+  assert(result, "expected applyChangeToCreature to return a creature");
+  assertForwardOnly(result!, "remove-synapse");
+});
+
+// ---------------------------------------------------------------------------
+// remove-neuron
+// ---------------------------------------------------------------------------
+Deno.test("Lifecycle apply: remove-neuron preserves forward-only", async () => {
+  await initWasmForTests();
+
+  // Base has 2 hidden neurons so removing one still leaves a path.
+  const baseJSON: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-X", type: "hidden", squash: "IDENTITY", bias: 0 },
+      { uuid: "hidden-Y", type: "hidden", squash: "IDENTITY", bias: 0 },
+      { uuid: "output-0", type: "output", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-X", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-Y", weight: 0.5 },
+      { fromUUID: "hidden-X", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "hidden-Y", toUUID: "output-0", weight: 0.5 },
+    ],
+  };
+  const base = candidateFromJSON(baseJSON);
+  base.validate({ forwardOnly: true });
+  CreatureUtil.makeUUID(base);
+
+  // Candidate removes hidden-Y and reconnects input-1 → output-0 directly.
+  const candidateJSON: CreatureExport = {
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { uuid: "hidden-X", type: "hidden", squash: "IDENTITY", bias: 0 },
+      { uuid: "output-0", type: "output", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-X", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "hidden-X", toUUID: "output-0", weight: 0.5 },
+    ],
+  };
+  const candidateCreature = candidateFromJSON(candidateJSON);
+
+  const candidate: DiscoveryCandidate = {
+    creature: candidateCreature,
+    change: { type: "remove-neuron", description: "drop hidden-Y" },
+  };
+
+  const result = applyChangeToCreature(base, candidate, base);
+  assert(result, "expected applyChangeToCreature to return a creature");
+  assertForwardOnly(result!, "remove-neuron");
+});
+
+// ---------------------------------------------------------------------------
+// coordinated-structural
+// ---------------------------------------------------------------------------
+Deno.test("Lifecycle apply: coordinated-structural preserves forward-only", async () => {
+  const base = await makeForwardOnlyBase();
+  const hiddenUuid = base.neurons.find((n) => n.type === "hidden")!.uuid!;
+  const outputUuid = base.neurons.find((n) => n.type === "output")!.uuid!;
+
+  // Coordinated op: change the squash of the hidden neuron only.
+  const result = applyCoordinatedStructuralCandidate(
+    base,
+    {
+      operations: [
+        { type: "changeSquash", neuronUuid: hiddenUuid, squash: "TANH" },
+      ],
+    } as Parameters<typeof applyCoordinatedStructuralCandidate>[1],
+  );
+  assertForwardOnly(result, "coordinated-structural changeSquash");
+  // Sanity: hidden squash actually changed.
+  const newHidden = result.neurons.find((n) => n.uuid === hiddenUuid)!;
+  assertEquals(newHidden.squash, "TANH");
+  // Output still present.
+  assert(
+    result.neurons.find((n) => n.uuid === outputUuid),
+    "output neuron should still be present",
+  );
+});
+
+Deno.test("Lifecycle apply: coordinated-structural filters back-edge addSynapse", async () => {
+  const base = await makeForwardOnlyBase();
+  const hiddenUuid = base.neurons.find((n) => n.type === "hidden")!.uuid!;
+  const outputUuid = base.neurons.find((n) => n.type === "output")!.uuid!;
+
+  // Attempt to add a backward synapse output → hidden. The combiner
+  // must reject this rather than corrupt the forward-only invariant.
+  const result = applyCoordinatedStructuralCandidate(
+    base,
+    {
+      operations: [
+        {
+          type: "addSynapse",
+          fromNeuronUuid: outputUuid,
+          toNeuronUuid: hiddenUuid,
+          weight: 0.1,
+        },
+      ],
+    } as Parameters<typeof applyCoordinatedStructuralCandidate>[1],
+  );
+  assertForwardOnly(result, "coordinated-structural backward filter");
+});


### PR DESCRIPTION
## Summary

Audit of `applyChangeToCreature` and `normaliseCreatureExport` for back-edge
introduction on forward-only creatures, per issue #2515. Wires
`assertNoRecurrentSynapseOnForwardOnly(...)` as a post-condition at every
combiner producer site so that any future corruption throws a `TopologyError`
naming the producing pipeline rather than surfacing as a downstream
`[loadFrom] Stripping recurrent synapse` warning. Closes #2515.

## Evidence

Backend-only change — no UI to screenshot. Verified via:

- Unit tests for `normaliseCreatureExport` (4 tests) covering round-trip
  exports, idempotent re-normalisation, output-id remapping, and UUID-keyed wire
  inputs. All assert the forward-only invariant (`from < to` against
  `buildIdToIndexMap`).
- Lifecycle integration tests covering every branch of `applyChangeToCreature`
  (8 tests): `add-synapses` (legal + adversarial), `add-neurons`,
  `change-squash`, `remove-synapse`, `remove-neuron`, and
  `coordinated-structural` (legal + adversarial).
- All 525 discovery tests and 158 lifecycle/ErrorGuidedStructuralEvolution tests
  still pass.
- `./quality.sh --lint-only` and `./quality.sh --check-only` are clean.

```mermaid
flowchart LR
    A[Discovery candidate] --> B[applyChangeToCreature]
    B --> C[normaliseCreatureExport]
    C --> D[apply* combiner]
    D --> E[validateAndFixCreatureSync]
    E --> F[assertNoRecurrentSynapse<br/>OnForwardOnly]
    F -->|fails| G[TopologyError<br/>names producer]
    F -->|ok| H[return candidate]
```

Producer tags wired in:

| Site                                  | Source tag in `TopologyError`                   |
| ------------------------------------- | ----------------------------------------------- |
| `applyAddSynapses`                    | `discovery:applyAddSynapses`                    |
| `applyAddNeurons`                     | `discovery:applyAddNeurons`                     |
| `applyChangeSquash`                   | `discovery:applyChangeSquash`                   |
| `applyRemoveSynapse`                  | `discovery:applyRemoveSynapse`                  |
| `applyRemoveNeuron`                   | `discovery:applyRemoveNeuron(<changeType>)`     |
| `applyCoordinatedStructuralCandidate` | `discovery:applyCoordinatedStructuralCandidate` |

## Test Plan

- `test/architecture/NormaliseCreatureExportForwardOnly.ts` — 4 tests.
- `test/lifecycle/ForwardOnlyApplyChangeLifecycle.ts` — 8 tests.
- Existing tests unchanged: `ForwardOnlyAssertion`, `ForwardOnlyLifecycle`,
  `CandidateApplicationOps`, `DiscoveryCandidatesForwardOnlyVersionBump`, all
  green.

Diagnostic note: `docs/issue-2515-forward-only-apply-audit.md` summarises the
audit, the producer tags, and the path that was confirmed (no current
introduction site found — the post-conditions are the load-bearing
defence-in-depth that names the producer if a regression ever lands).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2515 -->