### PR TITLE
Enhance batch scorer failure diagnostics: identify offending creature UUIDs, source tags, and population composition (Issue #2518)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2518.md
+++ b/docs/pr-summary-2518.md
@@ -3,13 +3,13 @@
 Enriches batch rust scorer failure log lines with structured diagnostics so the
 producer of a bad creature can be traced from a single log entry. When
 `tryBatchScoreWithRustScorer` fails, the `Fitness.calculate` catch block now
-extracts every offending creature UUID from the rust scorer's stderr (and
-from the typed `BatchScorerError`'s `missingKeys` / `extraKeys` /
-`malformedKeys`), cross-references each one against the in-memory population to
-attach the `source` tag, `forwardOnly` flag, and neuron / synapse counts, and
-emits one consolidated `error` line that also includes the population's
-`forwardOnly` composition. The per-creature detail list is capped at 10 entries
-with a `+N more` suffix to keep logs readable on large generations.
+extracts every offending creature UUID from the rust scorer's stderr (and from
+the typed `BatchScorerError`'s `missingKeys` / `extraKeys` / `malformedKeys`),
+cross-references each one against the in-memory population to attach the
+`source` tag, `forwardOnly` flag, and neuron / synapse counts, and emits one
+consolidated `error` line that also includes the population's `forwardOnly`
+composition. The per-creature detail list is capped at 10 entries with a
+`+N more` suffix to keep logs readable on large generations.
 
 Closes #2518.
 
@@ -33,8 +33,8 @@ Backend / CLI change — no UI to screenshot. Verified by:
     falling back to per-creature scoring.
   ```
 
-- Full `./quality.sh --skip-discovery --skip-wasm` run: **6414 passed, 0
-  failed, 4 ignored**.
+- Full `./quality.sh --skip-discovery --skip-wasm` run: **6414 passed, 0 failed,
+  4 ignored**.
 
 ```mermaid
 flowchart LR
@@ -67,20 +67,20 @@ Added `test/score/BatchScorerDiagnostics.ts` covering:
 - Composition is always emitted even when no offenders can be identified.
 
 Existing tests in `test/score/BatchRustScorerBridge.ts`,
-`test/score/BatchScorerReconciler.ts`, and
-`test/NEAT/FitnessBatchRustScorer.ts` continue to pass.
+`test/score/BatchScorerReconciler.ts`, and `test/NEAT/FitnessBatchRustScorer.ts`
+continue to pass.
 
 ## Pre-PR Security Self-Check
 
-- [x] Input validation: stderr regex anchors on the canonical UUID shape and
-  the `.json` extension; no shell or SQL surface introduced.
+- [x] Input validation: stderr regex anchors on the canonical UUID shape and the
+      `.json` extension; no shell or SQL surface introduced.
 - [x] Secrets: no credentials staged; only UUIDs, tags, and topology counts in
-  log output.
+      log output.
 - [x] Injection surface: none — diagnostics consume strings, not commands or
-  queries.
+      queries.
 - [x] Output encoding: log line is plain text emitted via the project `Logger`
-  abstraction.
+      abstraction.
 - [x] Authentication / authorisation: no new privileged operations.
 - [x] Error handling: enriched diagnostic does not leak file paths or stack
-  traces; falls back gracefully when stderr has no UUID reference.
+      traces; falls back gracefully when stderr has no UUID reference.
 - [x] Dependencies: no new third-party deps.

--- a/docs/pr-summary-2518.md
+++ b/docs/pr-summary-2518.md
@@ -1,0 +1,86 @@
+## Summary
+
+Enriches batch rust scorer failure log lines with structured diagnostics so the
+producer of a bad creature can be traced from a single log entry. When
+`tryBatchScoreWithRustScorer` fails, the `Fitness.calculate` catch block now
+extracts every offending creature UUID from the rust scorer's stderr (and
+from the typed `BatchScorerError`'s `missingKeys` / `extraKeys` /
+`malformedKeys`), cross-references each one against the in-memory population to
+attach the `source` tag, `forwardOnly` flag, and neuron / synapse counts, and
+emits one consolidated `error` line that also includes the population's
+`forwardOnly` composition. The per-creature detail list is capped at 10 entries
+with a `+N more` suffix to keep logs readable on large generations.
+
+Closes #2518.
+
+## Evidence
+
+Backend / CLI change — no UI to screenshot. Verified by:
+
+- New unit suite `test/score/BatchScorerDiagnostics.ts` (11 cases) exercises
+  every helper directly against synthesised stderr blobs and creature
+  populations.
+- Existing integration test `test/NEAT/FitnessBatchRustScorer.ts` confirms the
+  enriched log line is emitted from `Fitness.calculate`'s catch block. Sample
+  output captured during the run:
+
+  ```
+  [NEAT-AI] Batch rust scorer reconciliation failed (MISSING_KEYS): … ;
+  Batch scorer rejected 3 creature(s) (forwardOnly=true=0, forwardOnly=false=3):
+    [uuid=a58ef313-… forwardOnly=false neurons=4 synapses=2,
+     uuid=348d6af7-… forwardOnly=false neurons=4 synapses=2,
+     uuid=d548c2dd-… forwardOnly=false neurons=4 synapses=2];
+    falling back to per-creature scoring.
+  ```
+
+- Full `./quality.sh --skip-discovery --skip-wasm` run: **6414 passed, 0
+  failed, 4 ignored**.
+
+```mermaid
+flowchart LR
+    A[uniqueQueue] --> B[tryBatchScoreWithRustScorer]
+    B -- BatchScorerError --> C[buildBatchScorerDiagnostic]
+    C --> D[summariseForwardOnlyComposition]
+    C --> E[extractOffendingStems<br/>stderr regex]
+    C --> F[describeCreature<br/>uuid, source, forwardOnly,<br/>neurons, synapses, hash]
+    D & E & F --> G[Consolidated error log line<br/>+ structured payload]
+    G --> H[Fall back to per-creature scoring]
+```
+
+## Test Plan
+
+Added `test/score/BatchScorerDiagnostics.ts` covering:
+
+- Single-offender UUID extraction from a synthesised rust stderr blob.
+- Multiple-offender extraction with deduplication and order preservation.
+- Empty / undefined / non-matching stderr returning `[]`.
+- Composition counters for all-forwardOnly, mixed, and all-recurrent
+  populations.
+- End-to-end `buildBatchScorerDiagnostic` enrichment from stderr (with `source`
+  tag).
+- End-to-end enrichment from typed `BatchScorerError` keys (`missingKeys` +
+  `malformedKeys`).
+- Cap-at-10 truncation with `+N more` suffix and verification that the 11th
+  onwards stems are not embedded as detail entries.
+- Unknown stem fallback when stderr names a UUID not in the in-memory
+  population.
+- Composition is always emitted even when no offenders can be identified.
+
+Existing tests in `test/score/BatchRustScorerBridge.ts`,
+`test/score/BatchScorerReconciler.ts`, and
+`test/NEAT/FitnessBatchRustScorer.ts` continue to pass.
+
+## Pre-PR Security Self-Check
+
+- [x] Input validation: stderr regex anchors on the canonical UUID shape and
+  the `.json` extension; no shell or SQL surface introduced.
+- [x] Secrets: no credentials staged; only UUIDs, tags, and topology counts in
+  log output.
+- [x] Injection surface: none — diagnostics consume strings, not commands or
+  queries.
+- [x] Output encoding: log line is plain text emitted via the project `Logger`
+  abstraction.
+- [x] Authentication / authorisation: no new privileged operations.
+- [x] Error handling: enriched diagnostic does not leak file paths or stack
+  traces; falls back gracefully when stderr has no UUID reference.
+- [x] Dependencies: no new third-party deps.

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -11,6 +11,7 @@ import { calculate as calculateScore } from "@architecture/Score.ts";
 import { tryBatchScoreWithRustScorer } from "../score/BatchRustScorerBridge.ts";
 import { getEnvRustScorerConfig } from "../score/RustScorerBridge.ts";
 import { BatchScorerError } from "../score/BatchScorerReconciler.ts";
+import { buildBatchScorerDiagnostic } from "../score/BatchScorerDiagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
 
 /**
@@ -231,12 +232,25 @@ export class Fitness {
         // Surface batch reconciliation failures as explicit log errors per
         // the acceptance criteria, then fall back to the per-creature path
         // so the generation is not lost to a transient scorer issue.
+        // Issue #2518: enrich the log line with population composition
+        // counters and per-creature metadata for any UUID we can extract
+        // from the rust scorer's stderr or the typed error itself, so
+        // operators can trace the producer of the offending creature(s)
+        // without re-running the workload.
         const detail = err instanceof Error ? err.message : String(err);
+        const diagnostic = err instanceof Error
+          ? buildBatchScorerDiagnostic(err, uniqueQueue)
+          : undefined;
         if (err instanceof BatchScorerError) {
           getLogger().error(
             `[NEAT-AI] Batch rust scorer reconciliation failed ` +
-              `(${err.reason}): ${detail}; falling back to per-creature ` +
-              `scoring.`,
+              `(${err.reason}): ${detail}; ${diagnostic!.message}; ` +
+              `falling back to per-creature scoring.`,
+          );
+        } else if (diagnostic) {
+          getLogger().error(
+            `[NEAT-AI] Batch rust scorer invocation failed: ${detail}; ` +
+              `${diagnostic.message}; falling back to per-creature scoring.`,
           );
         } else {
           getLogger().error(

--- a/src/score/BatchScorerDiagnostics.ts
+++ b/src/score/BatchScorerDiagnostics.ts
@@ -1,0 +1,219 @@
+/**
+ * Batch scorer failure diagnostics (Issue #2518).
+ *
+ * When the rust batch scorer rejects a generation, the raw stderr message is
+ * not actionable on its own — it embeds an ephemeral temp directory path,
+ * names at most a single offender, and does not surface the population's
+ * `forwardOnly` composition. These helpers enrich a {@link BatchScorerError}
+ * (or any wrapped scorer failure) with:
+ *
+ * - the offending creature UUIDs extracted from the rust scorer stderr;
+ * - the same UUIDs cross-referenced against the in-memory population to add
+ *   the `source` tag, `forwardOnly` flag, neuron/synapse counts, and the
+ *   structural hash;
+ * - population composition counters (`forwardOnly=true` vs `forwardOnly=false`)
+ *   so any failure mode (INVALID_JSON, MISSING_KEYS, EXTRA_KEYS, etc.) carries
+ *   the breadcrumb operators need to trace the producer of the bad creature(s).
+ *
+ * The output is a structured `BatchScorerDiagnostic` that callers can both
+ * format into a single consolidated `error` log line and emit as a structured
+ * payload to a log aggregator.
+ *
+ * @module BatchScorerDiagnostics
+ */
+import { getTag } from "@stsoftware/tags/mod";
+import type { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import type { BatchScorerError } from "./BatchScorerReconciler.ts";
+
+/** Default cap for the per-creature detail list emitted in the log line. */
+export const DEFAULT_OFFENDER_DETAIL_CAP = 10;
+
+/**
+ * `forwardOnly` composition counters for a population. Any creature whose
+ * `forwardOnly` flag is anything other than the literal `true` is counted as
+ * recurrent — this matches the rust scorer's directory-mode contract which
+ * requires `forwardOnly === true` on every creature.
+ */
+export interface PopulationComposition {
+  forwardOnlyCount: number;
+  recurrentCount: number;
+}
+
+/**
+ * Compact metadata the diagnostic emits per offending creature. Only
+ * non-PII identifiers and topology sizes are included so the log line stays
+ * safe to emit on production aggregators.
+ */
+export interface OffenderMetadata {
+  uuid: string;
+  source?: string;
+  forwardOnly: boolean;
+  neuronCount: number;
+  synapseCount: number;
+  structuralHash: string;
+  /** True when the UUID was extracted from stderr but not found in the population. */
+  unknown: boolean;
+}
+
+/** Structured payload suitable for emission to a log aggregator. */
+export interface BatchScorerDiagnostic {
+  reason: string;
+  composition: PopulationComposition;
+  offendingStems: string[];
+  offenders: OffenderMetadata[];
+  truncated: number;
+  message: string;
+}
+
+/**
+ * Count `forwardOnly=true` vs `forwardOnly=false` (or unset) creatures in the
+ * population. Cheap enough to call before invoking the rust scorer.
+ */
+export function summariseForwardOnlyComposition(
+  creatures: readonly Creature[],
+): PopulationComposition {
+  let forwardOnlyCount = 0;
+  let recurrentCount = 0;
+  for (const creature of creatures) {
+    if (creature.forwardOnly === true) forwardOnlyCount++;
+    else recurrentCount++;
+  }
+  return { forwardOnlyCount, recurrentCount };
+}
+
+// Match a UUID stem inside a `Creature '...<uuid>.json'` reference. The path
+// in front of the stem is ephemeral (per-invocation temp dir) so we anchor on
+// the file extension and capture the immediately preceding stem segment. We
+// allow either single or double quotes — and no quotes at all — because the
+// rust scorer wording has shifted historically. Stems are lower-case
+// canonical UUIDs (8-4-4-4-12); we accept upper-case as well to be lenient.
+const CREATURE_STEM_REGEX =
+  /Creature\s+['"]?[^'"\s]*?([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.json['"]?/g;
+
+/**
+ * Extract every creature UUID referenced by the rust scorer's stderr or
+ * stdout. Duplicates are removed but the original order is preserved so
+ * operators can trace which creature was reported first.
+ */
+export function extractOffendingStems(text: string | undefined): string[] {
+  if (!text) return [];
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const match of text.matchAll(CREATURE_STEM_REGEX)) {
+    const stem = match[1];
+    if (!seen.has(stem)) {
+      seen.add(stem);
+      ordered.push(stem);
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Look up a creature in the population and capture diagnostic metadata.
+ * Falls back to a sparse record (`unknown: true`) when the UUID was reported
+ * by stderr but is not present in the in-memory list — this can happen if a
+ * caller passes a different population to the diagnostic builder than was
+ * passed to the bridge.
+ */
+function describeCreature(
+  stem: string,
+  byUuid: Map<string, Creature>,
+): OffenderMetadata {
+  const creature = byUuid.get(stem);
+  if (!creature) {
+    return {
+      uuid: stem,
+      source: undefined,
+      forwardOnly: false,
+      neuronCount: 0,
+      synapseCount: 0,
+      structuralHash: stem,
+      unknown: true,
+    };
+  }
+  const source = getTag(creature, "source");
+  return {
+    uuid: creature.uuid ?? stem,
+    source: source ?? undefined,
+    forwardOnly: creature.forwardOnly === true,
+    neuronCount: creature.neurons.length,
+    synapseCount: creature.synapses.length,
+    structuralHash: CreatureUtil.makeUUID(creature),
+    unknown: false,
+  };
+}
+
+/** Render a single offender as `uuid=<stem> source=<tag> forwardOnly=<bool>...`. */
+function formatOffender(meta: OffenderMetadata): string {
+  const parts: string[] = [`uuid=${meta.uuid}`];
+  if (meta.source) parts.push(`source=${meta.source}`);
+  parts.push(`forwardOnly=${meta.forwardOnly}`);
+  parts.push(`neurons=${meta.neuronCount}`);
+  parts.push(`synapses=${meta.synapseCount}`);
+  if (meta.unknown) parts.push("unknown=true");
+  return parts.join(" ");
+}
+
+/**
+ * Build a consolidated diagnostic for a batch scorer failure. Combines the
+ * stems carried on the typed error (missing/extra/malformed) with any UUIDs
+ * embedded in the stderr-bearing message, then enriches each one against the
+ * supplied population.
+ */
+export function buildBatchScorerDiagnostic(
+  error: BatchScorerError | Error,
+  creatures: readonly Creature[],
+  options: { detailCap?: number } = {},
+): BatchScorerDiagnostic {
+  const cap = options.detailCap ?? DEFAULT_OFFENDER_DETAIL_CAP;
+  const composition = summariseForwardOnlyComposition(creatures);
+
+  const stems = new Set<string>();
+  const ordered: string[] = [];
+  const pushStem = (stem: string) => {
+    if (!stem) return;
+    if (stems.has(stem)) return;
+    stems.add(stem);
+    ordered.push(stem);
+  };
+
+  const errAny = error as BatchScorerError;
+  if (Array.isArray(errAny.missingKeys)) {
+    for (const k of errAny.missingKeys) pushStem(k);
+  }
+  if (Array.isArray(errAny.extraKeys)) {
+    for (const k of errAny.extraKeys) pushStem(k);
+  }
+  if (Array.isArray(errAny.malformedKeys)) {
+    for (const k of errAny.malformedKeys) pushStem(k);
+  }
+  for (const stem of extractOffendingStems(error.message)) {
+    pushStem(stem);
+  }
+
+  const byUuid = new Map<string, Creature>();
+  for (const creature of creatures) {
+    if (creature.uuid) byUuid.set(creature.uuid, creature);
+  }
+
+  const offenders = ordered.map((stem) => describeCreature(stem, byUuid));
+  const detail = offenders.slice(0, cap).map(formatOffender);
+  const truncated = Math.max(0, offenders.length - cap);
+  if (truncated > 0) detail.push(`+${truncated} more`);
+
+  const reason = (errAny.reason as string | undefined) ?? "UNKNOWN";
+  const message = `Batch scorer rejected ${offenders.length} creature(s) ` +
+    `(forwardOnly=true=${composition.forwardOnlyCount}, ` +
+    `forwardOnly=false=${composition.recurrentCount}): [${detail.join(", ")}]`;
+
+  return {
+    reason,
+    composition,
+    offendingStems: ordered,
+    offenders,
+    truncated,
+    message,
+  };
+}

--- a/test/score/BatchScorerDiagnostics.ts
+++ b/test/score/BatchScorerDiagnostics.ts
@@ -1,0 +1,217 @@
+import { assert, assertEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature } from "@creature";
+import { BatchScorerError } from "../../src/score/BatchScorerReconciler.ts";
+import {
+  buildBatchScorerDiagnostic,
+  extractOffendingStems,
+  summariseForwardOnlyComposition,
+} from "../../src/score/BatchScorerDiagnostics.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/**
+ * Tests for batch scorer failure diagnostics (Issue #2518).
+ *
+ * These cover the helpers used by the Fitness.calculate catch block to
+ * enrich a BatchScorerError log line with offending creature UUIDs, source
+ * tags, topology sizes, and population composition counters.
+ */
+
+function makeCreature(uuid: string, forwardOnly: boolean): Creature {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.uuid = uuid;
+  creature.forwardOnly = forwardOnly;
+  return creature;
+}
+
+Deno.test("BatchScorerDiagnostics - extractOffendingStems extracts a single UUID from rust stderr", () => {
+  const stderr = "Error: Creature " +
+    "'/tmp/neat-rust-scorer-batch-7d05/106b96b6-1d76-5752-9cbc-fc826d4f8cbf.json' " +
+    "has forwardOnly=false; multi-creature directory mode requires forwardOnly=true.";
+  const stems = extractOffendingStems(stderr);
+  assertEquals(stems, ["106b96b6-1d76-5752-9cbc-fc826d4f8cbf"]);
+});
+
+Deno.test("BatchScorerDiagnostics - extractOffendingStems extracts multiple UUIDs", () => {
+  const stderr =
+    "Creature '/tmp/x/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.json' bad. " +
+    "Creature '/tmp/x/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.json' also bad. " +
+    "Creature '/tmp/x/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.json' duplicate.";
+  const stems = extractOffendingStems(stderr);
+  // Duplicates removed, original order preserved.
+  assertEquals(stems, [
+    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  ]);
+});
+
+Deno.test("BatchScorerDiagnostics - extractOffendingStems returns empty array for empty/undefined input", () => {
+  assertEquals(extractOffendingStems(""), []);
+  assertEquals(extractOffendingStems(undefined), []);
+  assertEquals(extractOffendingStems("no creature reference here"), []);
+});
+
+Deno.test("BatchScorerDiagnostics - summariseForwardOnlyComposition counts all-forwardOnly population", async () => {
+  await initWasmForTests();
+  const creatures = [
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", true),
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", true),
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3", true),
+  ];
+  const composition = summariseForwardOnlyComposition(creatures);
+  assertEquals(composition.forwardOnlyCount, 3);
+  assertEquals(composition.recurrentCount, 0);
+});
+
+Deno.test("BatchScorerDiagnostics - summariseForwardOnlyComposition counts mixed population", async () => {
+  await initWasmForTests();
+  const creatures = [
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", true),
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", false),
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3", true),
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa4", false),
+  ];
+  const composition = summariseForwardOnlyComposition(creatures);
+  assertEquals(composition.forwardOnlyCount, 2);
+  assertEquals(composition.recurrentCount, 2);
+});
+
+Deno.test("BatchScorerDiagnostics - summariseForwardOnlyComposition counts all-recurrent population", async () => {
+  await initWasmForTests();
+  const creatures = [
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", false),
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", false),
+  ];
+  const composition = summariseForwardOnlyComposition(creatures);
+  assertEquals(composition.forwardOnlyCount, 0);
+  assertEquals(composition.recurrentCount, 2);
+});
+
+Deno.test("BatchScorerDiagnostics - buildBatchScorerDiagnostic enriches single offender from stderr", async () => {
+  await initWasmForTests();
+  const offenderUuid = "106b96b6-1d76-5752-9cbc-fc826d4f8cbf";
+  const otherUuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1";
+  const offender = makeCreature(offenderUuid, false);
+  addTag(offender, "source", "horizontal-gene-transfer");
+  const other = makeCreature(otherUuid, true);
+
+  const stderrMessage =
+    `Rust scorer batch call failed (exit 1): Error: Creature ` +
+    `'/home/n/.tmp/neat-rust-scorer-batch-7d05/${offenderUuid}.json' ` +
+    `has forwardOnly=false; multi-creature directory mode requires forwardOnly=true`;
+  const err = new BatchScorerError(stderrMessage, "INVALID_JSON");
+
+  const diag = buildBatchScorerDiagnostic(err, [offender, other]);
+  assertEquals(diag.reason, "INVALID_JSON");
+  assertEquals(diag.composition.forwardOnlyCount, 1);
+  assertEquals(diag.composition.recurrentCount, 1);
+  assertEquals(diag.offendingStems, [offenderUuid]);
+  assertEquals(diag.offenders.length, 1);
+  assertEquals(diag.offenders[0].uuid, offenderUuid);
+  assertEquals(diag.offenders[0].source, "horizontal-gene-transfer");
+  assertEquals(diag.offenders[0].forwardOnly, false);
+  assertEquals(diag.offenders[0].unknown, false);
+  assert(diag.message.includes("forwardOnly=true=1"));
+  assert(diag.message.includes("forwardOnly=false=1"));
+  assert(diag.message.includes(`uuid=${offenderUuid}`));
+  assert(diag.message.includes("source=horizontal-gene-transfer"));
+});
+
+Deno.test("BatchScorerDiagnostics - buildBatchScorerDiagnostic enriches multiple offenders from typed error keys", async () => {
+  await initWasmForTests();
+  const aUuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1";
+  const bUuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb2";
+  const cUuid = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+  const a = makeCreature(aUuid, true);
+  const b = makeCreature(bUuid, false);
+  const c = makeCreature(cUuid, true);
+
+  const err = new BatchScorerError(
+    "Batch scorer key set mismatch — missing 1, malformed 1",
+    "MISSING_KEYS",
+    { missingKeys: [aUuid], malformedKeys: [bUuid] },
+  );
+
+  const diag = buildBatchScorerDiagnostic(err, [a, b, c]);
+  assertEquals(diag.composition.forwardOnlyCount, 2);
+  assertEquals(diag.composition.recurrentCount, 1);
+  assertEquals(diag.offendingStems, [aUuid, bUuid]);
+  assertEquals(diag.offenders.length, 2);
+  assertEquals(diag.offenders[0].forwardOnly, true);
+  assertEquals(diag.offenders[1].forwardOnly, false);
+  assertEquals(diag.truncated, 0);
+});
+
+Deno.test("BatchScorerDiagnostics - buildBatchScorerDiagnostic caps detail at 10 with +N more suffix", async () => {
+  await initWasmForTests();
+  const creatures: Creature[] = [];
+  const stems: string[] = [];
+  for (let i = 0; i < 13; i++) {
+    const stem = `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa${
+      i.toString().padStart(2, "0")
+    }`;
+    stems.push(stem);
+    creatures.push(makeCreature(stem, false));
+  }
+  const err = new BatchScorerError(
+    "missing many",
+    "MISSING_KEYS",
+    { missingKeys: stems },
+  );
+
+  const diag = buildBatchScorerDiagnostic(err, creatures);
+  assertEquals(diag.offenders.length, 13);
+  assertEquals(diag.truncated, 3);
+  assert(
+    diag.message.includes("+3 more"),
+    `expected message to include "+3 more"; got: ${diag.message}`,
+  );
+  // The detail list embedded in the message should only include the first 10.
+  const firstTen = stems.slice(0, 10);
+  for (const stem of firstTen) {
+    assert(
+      diag.message.includes(stem),
+      `expected message to include first-ten stem ${stem}`,
+    );
+  }
+  // The 11th onwards should not be embedded as detail entries.
+  for (const stem of stems.slice(10)) {
+    assert(
+      !diag.message.includes(`uuid=${stem}`),
+      `expected message NOT to embed truncated stem detail for ${stem}`,
+    );
+  }
+});
+
+Deno.test("BatchScorerDiagnostics - buildBatchScorerDiagnostic marks unknown stems when not in population", async () => {
+  await initWasmForTests();
+  const knownUuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1";
+  const unknownUuid = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+  const known = makeCreature(knownUuid, true);
+
+  const err = new BatchScorerError(
+    `Creature '/tmp/x/${unknownUuid}.json' bad`,
+    "INVALID_JSON",
+  );
+
+  const diag = buildBatchScorerDiagnostic(err, [known]);
+  assertEquals(diag.offenders.length, 1);
+  assertEquals(diag.offenders[0].uuid, unknownUuid);
+  assertEquals(diag.offenders[0].unknown, true);
+  assert(diag.message.includes("unknown=true"));
+});
+
+Deno.test("BatchScorerDiagnostics - buildBatchScorerDiagnostic always includes composition even with no offenders", async () => {
+  await initWasmForTests();
+  const creatures = [
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1", true),
+    makeCreature("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2", false),
+  ];
+  const err = new Error("scorer crashed with no UUID reference");
+  const diag = buildBatchScorerDiagnostic(err, creatures);
+  assertEquals(diag.offendingStems, []);
+  assertEquals(diag.offenders.length, 0);
+  assert(diag.message.includes("forwardOnly=true=1"));
+  assert(diag.message.includes("forwardOnly=false=1"));
+  assertEquals(diag.reason, "UNKNOWN");
+});


### PR DESCRIPTION
## Summary

Enriches batch rust scorer failure log lines with structured diagnostics so the
producer of a bad creature can be traced from a single log entry. When
`tryBatchScoreWithRustScorer` fails, the `Fitness.calculate` catch block now
extracts every offending creature UUID from the rust scorer's stderr (and
from the typed `BatchScorerError`'s `missingKeys` / `extraKeys` /
`malformedKeys`), cross-references each one against the in-memory population to
attach the `source` tag, `forwardOnly` flag, and neuron / synapse counts, and
emits one consolidated `error` line that also includes the population's
`forwardOnly` composition. The per-creature detail list is capped at 10 entries
with a `+N more` suffix to keep logs readable on large generations.

Closes #2518.

## Evidence

Backend / CLI change — no UI to screenshot. Verified by:

- New unit suite `test/score/BatchScorerDiagnostics.ts` (11 cases) exercises
  every helper directly against synthesised stderr blobs and creature
  populations.
- Existing integration test `test/NEAT/FitnessBatchRustScorer.ts` confirms the
  enriched log line is emitted from `Fitness.calculate`'s catch block. Sample
  output captured during the run:

  ```
  [NEAT-AI] Batch rust scorer reconciliation failed (MISSING_KEYS): … ;
  Batch scorer rejected 3 creature(s) (forwardOnly=true=0, forwardOnly=false=3):
    [uuid=a58ef313-… forwardOnly=false neurons=4 synapses=2,
     uuid=348d6af7-… forwardOnly=false neurons=4 synapses=2,
     uuid=d548c2dd-… forwardOnly=false neurons=4 synapses=2];
    falling back to per-creature scoring.
  ```

- Full `./quality.sh --skip-discovery --skip-wasm` run: **6414 passed, 0
  failed, 4 ignored**.

```mermaid
flowchart LR
    A[uniqueQueue] --> B[tryBatchScoreWithRustScorer]
    B -- BatchScorerError --> C[buildBatchScorerDiagnostic]
    C --> D[summariseForwardOnlyComposition]
    C --> E[extractOffendingStems<br/>stderr regex]
    C --> F[describeCreature<br/>uuid, source, forwardOnly,<br/>neurons, synapses, hash]
    D & E & F --> G[Consolidated error log line<br/>+ structured payload]
    G --> H[Fall back to per-creature scoring]
```

## Test Plan

Added `test/score/BatchScorerDiagnostics.ts` covering:

- Single-offender UUID extraction from a synthesised rust stderr blob.
- Multiple-offender extraction with deduplication and order preservation.
- Empty / undefined / non-matching stderr returning `[]`.
- Composition counters for all-forwardOnly, mixed, and all-recurrent
  populations.
- End-to-end `buildBatchScorerDiagnostic` enrichment from stderr (with `source`
  tag).
- End-to-end enrichment from typed `BatchScorerError` keys (`missingKeys` +
  `malformedKeys`).
- Cap-at-10 truncation with `+N more` suffix and verification that the 11th
  onwards stems are not embedded as detail entries.
- Unknown stem fallback when stderr names a UUID not in the in-memory
  population.
- Composition is always emitted even when no offenders can be identified.

Existing tests in `test/score/BatchRustScorerBridge.ts`,
`test/score/BatchScorerReconciler.ts`, and
`test/NEAT/FitnessBatchRustScorer.ts` continue to pass.

## Pre-PR Security Self-Check

- [x] Input validation: stderr regex anchors on the canonical UUID shape and
  the `.json` extension; no shell or SQL surface introduced.
- [x] Secrets: no credentials staged; only UUIDs, tags, and topology counts in
  log output.
- [x] Injection surface: none — diagnostics consume strings, not commands or
  queries.
- [x] Output encoding: log line is plain text emitted via the project `Logger`
  abstraction.
- [x] Authentication / authorisation: no new privileged operations.
- [x] Error handling: enriched diagnostic does not leak file paths or stack
  traces; falls back gracefully when stderr has no UUID reference.
- [x] Dependencies: no new third-party deps.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2518 -->