### PR TITLE
Partition population by forwardOnly before batch rust scorer (#2517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is loosely based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Issue #2517:** `Fitness.calculate` now partitions the unique creature queue
+  by `forwardOnly` before invoking the external `rust_scorer` in batch
+  (directory) mode. The scorer rejects directory inputs containing any
+  `forwardOnly=false` creature, so a single recurrent creature in a generation
+  previously poisoned the batch and forced a per-creature fallback for the whole
+  population — collapsing the once-per-generation performance benefit from Issue
+  #2422.
+
+  The new flow:
+
+  - Forward-only creatures take the batch path (one `rust_scorer` process per
+    generation, as before).
+  - Recurrent creatures take the per-creature worker path directly.
+  - When the forward-only subset is empty, the batch is skipped entirely (no
+    temp dir, no spawn).
+  - Scorer telemetry (`lastBatchScorerInvocations`, `lastScorerMs`,
+    `lastScoredCreatureCount`) aggregates across both paths so observability
+    remains accurate.
+  - One INFO log line per generation summarises the partition, e.g.
+    `Batch scorer partition: 49 forwardOnly batched, 1 recurrent
+    per-creature`.
+
 ## [3.2.0] - 2026-05-05
 
 ### Changed (breaking-by-default)

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2517.md
+++ b/docs/pr-summary-2517.md
@@ -15,8 +15,8 @@ batch attempt:
 - Forward-only creatures take the batch path (one `rust_scorer` process per
   generation).
 - Recurrent creatures take the per-creature worker path directly.
-- When the forward-only subset is empty, the batch is skipped entirely (no
-  temp dir, no spawn).
+- When the forward-only subset is empty, the batch is skipped entirely (no temp
+  dir, no spawn).
 - A single INFO log line per generation summarises the partition.
 
 Telemetry (`lastBatchScorerInvocations`, `lastScorerMs`,
@@ -27,13 +27,13 @@ Closes #2517.
 
 ## Evidence
 
-Backend-only change. The fix is verified by unit tests that exercise the
-real `Fitness.calculate()` with a mocked `rust_scorer` runner and an
-in-memory worker stub, asserting:
+Backend-only change. The fix is verified by unit tests that exercise the real
+`Fitness.calculate()` with a mocked `rust_scorer` runner and an in-memory worker
+stub, asserting:
 
 - The correct number of scorer processes spawned (or none at all).
-- The exact UUID set written into the batch directory (recurrent UUIDs must
-  not appear).
+- The exact UUID set written into the batch directory (recurrent UUIDs must not
+  appear).
 - The exact set of creatures the worker stub saw.
 - That every creature in the population received a final score.
 
@@ -53,30 +53,29 @@ New tests (`test/architecture/FitnessForwardOnlyPartition.ts`):
 
 - `Fitness partition - all forwardOnly population batches every creature` —
   every creature reaches the batch directory, no worker calls.
-- `Fitness partition - all recurrent population skips batch entirely` —
-  scorer never spawned (`invocations === 0`), every creature scored via
-  workers.
+- `Fitness partition - all recurrent population skips batch entirely` — scorer
+  never spawned (`invocations === 0`), every creature scored via workers.
 - `Fitness partition - mixed population batches forwardOnly only, recurrent
-  via worker` — the batch directory contains exactly the forwardOnly UUIDs;
-  workers see only the recurrent UUIDs; combined `lastScoredCreatureCount`
-  covers the full population.
+  via worker`
+  — the batch directory contains exactly the forwardOnly UUIDs; workers see only
+  the recurrent UUIDs; combined `lastScoredCreatureCount` covers the full
+  population.
 - `Fitness partition - batch failure on forwardOnly subset still scores
-  recurrent via worker` — when batch reconciliation fails, the worker path
-  re-scores everything (forwardOnly fallback + recurrent).
+  recurrent via worker`
+  — when batch reconciliation fails, the worker path re-scores everything
+  (forwardOnly fallback + recurrent).
 
 Updated test (`test/NEAT/FitnessBatchRustScorer.ts`):
 
-- `buildPopulation()` now sets `forwardOnly: true` on the synthetic
-  creatures so the existing "one scorer process per generation" test
-  exercises the batch path under the new partition contract. Documented in
-  the test file.
+- `buildPopulation()` now sets `forwardOnly: true` on the synthetic creatures so
+  the existing "one scorer process per generation" test exercises the batch path
+  under the new partition contract. Documented in the test file.
 
 Existing tests unchanged and still passing:
 
 - `test/score/BatchRustScorerBridge.ts` (full batch bridge contract)
-- `test/architecture/Fitness*.ts` (telemetry, dynamic pool, busy-wait,
-  topology grouping, WASM-panic recovery, typed errors, fast-pool
-  evaluation)
+- `test/architecture/Fitness*.ts` (telemetry, dynamic pool, busy-wait, topology
+  grouping, WASM-panic recovery, typed errors, fast-pool evaluation)
 
 Full quality gate (`./quality.sh --skip-discovery --skip-wasm`) passes:
 `6418 passed | 0 failed | 4 ignored`.

--- a/docs/pr-summary-2517.md
+++ b/docs/pr-summary-2517.md
@@ -1,0 +1,82 @@
+# Partition population by forwardOnly before invoking batch rust scorer
+
+## Summary
+
+`Fitness.calculate()` previously sent the entire deduplicated population to
+`tryBatchScoreWithRustScorer()` in one call. The external `rust_scorer`
+(NEAT-AI-scorer) rejects directory-mode batches that contain any
+`forwardOnly=false` creature, so a single recurrent creature in a generation
+poisoned the whole batch and forced the per-creature fallback for everything —
+collapsing the once-per-generation performance benefit from Issue #2422.
+
+This change partitions the unique creature queue by `forwardOnly` before the
+batch attempt:
+
+- Forward-only creatures take the batch path (one `rust_scorer` process per
+  generation).
+- Recurrent creatures take the per-creature worker path directly.
+- When the forward-only subset is empty, the batch is skipped entirely (no
+  temp dir, no spawn).
+- A single INFO log line per generation summarises the partition.
+
+Telemetry (`lastBatchScorerInvocations`, `lastScorerMs`,
+`lastScoredCreatureCount`) accumulates across both paths so observability
+remains accurate.
+
+Closes #2517.
+
+## Evidence
+
+Backend-only change. The fix is verified by unit tests that exercise the
+real `Fitness.calculate()` with a mocked `rust_scorer` runner and an
+in-memory worker stub, asserting:
+
+- The correct number of scorer processes spawned (or none at all).
+- The exact UUID set written into the batch directory (recurrent UUIDs must
+  not appear).
+- The exact set of creatures the worker stub saw.
+- That every creature in the population received a final score.
+
+```mermaid
+flowchart LR
+    A[uniqueQueue] --> B{partition by forwardOnly}
+    B -->|forwardOnly=true| C[tryBatchScoreWithRustScorer]
+    B -->|forwardOnly=false| D[per-creature worker path]
+    C --> E[reconciled scores]
+    D --> E
+    E --> F[populated population]
+```
+
+## Test Plan
+
+New tests (`test/architecture/FitnessForwardOnlyPartition.ts`):
+
+- `Fitness partition - all forwardOnly population batches every creature` —
+  every creature reaches the batch directory, no worker calls.
+- `Fitness partition - all recurrent population skips batch entirely` —
+  scorer never spawned (`invocations === 0`), every creature scored via
+  workers.
+- `Fitness partition - mixed population batches forwardOnly only, recurrent
+  via worker` — the batch directory contains exactly the forwardOnly UUIDs;
+  workers see only the recurrent UUIDs; combined `lastScoredCreatureCount`
+  covers the full population.
+- `Fitness partition - batch failure on forwardOnly subset still scores
+  recurrent via worker` — when batch reconciliation fails, the worker path
+  re-scores everything (forwardOnly fallback + recurrent).
+
+Updated test (`test/NEAT/FitnessBatchRustScorer.ts`):
+
+- `buildPopulation()` now sets `forwardOnly: true` on the synthetic
+  creatures so the existing "one scorer process per generation" test
+  exercises the batch path under the new partition contract. Documented in
+  the test file.
+
+Existing tests unchanged and still passing:
+
+- `test/score/BatchRustScorerBridge.ts` (full batch bridge contract)
+- `test/architecture/Fitness*.ts` (telemetry, dynamic pool, busy-wait,
+  topology grouping, WASM-panic recovery, typed errors, fast-pool
+  evaluation)
+
+Full quality gate (`./quality.sh --skip-discovery --skip-wasm`) passes:
+`6418 passed | 0 failed | 4 ignored`.

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -178,87 +178,125 @@ export class Fitness {
     // This eliminates the per-creature `rust_scorer` process spawn on the
     // worker side. Any reconciliation failure is logged and we fall back
     // to the per-creature worker path so the generation still completes.
+    //
+    // Issue #2517: The external `rust_scorer` rejects directory-mode
+    // batches that contain any `forwardOnly=false` creature. Partition the
+    // population so only the forwardOnly subset enters the batch path —
+    // recurrent creatures take the per-creature worker path directly. This
+    // prevents one "poison" creature from collapsing the whole batch and
+    // losing the once-per-generation performance benefit.
     const rustScorerConfig = getEnvRustScorerConfig();
-    if (
-      rustScorerConfig.enabled && rustScorerConfig.batch && this.dataDir
-    ) {
-      try {
-        const batchRun = await tryBatchScoreWithRustScorer(
-          uniqueQueue,
-          this.dataDir,
-          rustScorerConfig,
-        );
-        this.lastBatchScorerInvocations = batchRun.invocations;
-        if (batchRun.results) {
-          for (const creature of uniqueQueue) {
-            const record = batchRun.results.get(creature);
-            if (!record) continue;
-            const error = record.error;
-            if (!Number.isFinite(error) || error < 0) {
-              addTag(creature, "error", "Infinity");
-              creature.score = -Infinity;
-            } else {
-              addTag(creature, "error", error.toString());
-              const scoreStart = performance.now();
-              creature.score = calculateScore(creature, error, this.growth);
-              scorerMsAccum += performance.now() - scoreStart;
-              scoredCount++;
-            }
-            addTag(creature, "score", creature.score.toString());
+    const batchEnabled = rustScorerConfig.enabled && rustScorerConfig.batch &&
+      this.dataDir !== undefined;
 
-            // Mirror the duplicate-fan-out from the per-creature path so
-            // population score invariants hold identically in batch mode.
-            const uuid = creature.uuid;
-            if (uuid) {
-              const dupes = duplicates.get(uuid);
-              if (dupes) {
-                const errorTag = getTag(creature, "error");
-                const scoreTag = getTag(creature, "score");
-                for (const duplicate of dupes) {
-                  if (duplicate !== creature) {
-                    duplicate.score = creature.score;
-                    if (errorTag) addTag(duplicate, "error", errorTag);
-                    if (scoreTag) addTag(duplicate, "score", scoreTag);
+    // After any batch attempt (success, skip, or failure), this list
+    // holds the creatures still needing the per-creature worker path.
+    let creaturesForWorkerPath: Creature[] = uniqueQueue;
+
+    if (batchEnabled) {
+      const forwardOnlyCreatures: Creature[] = [];
+      const recurrentCreatures: Creature[] = [];
+      for (const creature of uniqueQueue) {
+        if (creature.forwardOnly === true) {
+          forwardOnlyCreatures.push(creature);
+        } else {
+          recurrentCreatures.push(creature);
+        }
+      }
+
+      // One INFO line per generation summarising the partition. Operators
+      // need this to see at a glance how often "poison" recurrent creatures
+      // shrink the batch — per-creature logging would be far too noisy.
+      getLogger().info(
+        `[NEAT-AI] Batch scorer partition: ${forwardOnlyCreatures.length} ` +
+          `forwardOnly batched, ${recurrentCreatures.length} recurrent ` +
+          `per-creature`,
+      );
+
+      if (forwardOnlyCreatures.length > 0) {
+        try {
+          const batchRun = await tryBatchScoreWithRustScorer(
+            forwardOnlyCreatures,
+            this.dataDir!,
+            rustScorerConfig,
+          );
+          this.lastBatchScorerInvocations = batchRun.invocations;
+          if (batchRun.results) {
+            for (const creature of forwardOnlyCreatures) {
+              const record = batchRun.results.get(creature);
+              if (!record) continue;
+              const error = record.error;
+              if (!Number.isFinite(error) || error < 0) {
+                addTag(creature, "error", "Infinity");
+                creature.score = -Infinity;
+              } else {
+                addTag(creature, "error", error.toString());
+                const scoreStart = performance.now();
+                creature.score = calculateScore(creature, error, this.growth);
+                scorerMsAccum += performance.now() - scoreStart;
+                scoredCount++;
+              }
+              addTag(creature, "score", creature.score.toString());
+
+              // Mirror the duplicate-fan-out from the per-creature path so
+              // population score invariants hold identically in batch mode.
+              const uuid = creature.uuid;
+              if (uuid) {
+                const dupes = duplicates.get(uuid);
+                if (dupes) {
+                  const errorTag = getTag(creature, "error");
+                  const scoreTag = getTag(creature, "score");
+                  for (const duplicate of dupes) {
+                    if (duplicate !== creature) {
+                      duplicate.score = creature.score;
+                      if (errorTag) addTag(duplicate, "error", errorTag);
+                      if (scoreTag) addTag(duplicate, "score", scoreTag);
+                    }
                   }
                 }
               }
             }
+            // Batch handled the forwardOnly subset — workers only need to
+            // score the recurrent remainder.
+            creaturesForWorkerPath = recurrentCreatures;
           }
-          this.lastScorerMs = scorerMsAccum;
-          this.lastScoredCreatureCount = scoredCount;
-          return;
-        }
-      } catch (err) {
-        // Surface batch reconciliation failures as explicit log errors per
-        // the acceptance criteria, then fall back to the per-creature path
-        // so the generation is not lost to a transient scorer issue.
-        // Issue #2518: enrich the log line with population composition
-        // counters and per-creature metadata for any UUID we can extract
-        // from the rust scorer's stderr or the typed error itself, so
-        // operators can trace the producer of the offending creature(s)
-        // without re-running the workload.
-        const detail = err instanceof Error ? err.message : String(err);
-        const diagnostic = err instanceof Error
-          ? buildBatchScorerDiagnostic(err, uniqueQueue)
-          : undefined;
-        if (err instanceof BatchScorerError) {
-          getLogger().error(
-            `[NEAT-AI] Batch rust scorer reconciliation failed ` +
-              `(${err.reason}): ${detail}; ${diagnostic!.message}; ` +
-              `falling back to per-creature scoring.`,
-          );
-        } else if (diagnostic) {
-          getLogger().error(
-            `[NEAT-AI] Batch rust scorer invocation failed: ${detail}; ` +
-              `${diagnostic.message}; falling back to per-creature scoring.`,
-          );
-        } else {
-          getLogger().error(
-            `[NEAT-AI] Batch rust scorer invocation failed: ${detail}; ` +
-              `falling back to per-creature scoring.`,
-          );
+        } catch (err) {
+          // Surface batch reconciliation failures as explicit log errors per
+          // the acceptance criteria, then fall back to the per-creature path
+          // so the generation is not lost to a transient scorer issue.
+          // Issue #2518: enrich the log line with population composition
+          // counters and per-creature metadata for any UUID we can extract
+          // from the rust scorer's stderr or the typed error itself, so
+          // operators can trace the producer of the offending creature(s)
+          // without re-running the workload.
+          const detail = err instanceof Error ? err.message : String(err);
+          const diagnostic = err instanceof Error
+            ? buildBatchScorerDiagnostic(err, forwardOnlyCreatures)
+            : undefined;
+          if (err instanceof BatchScorerError) {
+            getLogger().error(
+              `[NEAT-AI] Batch rust scorer reconciliation failed ` +
+                `(${err.reason}): ${detail}; ${diagnostic!.message}; ` +
+                `falling back to per-creature scoring.`,
+            );
+          } else if (diagnostic) {
+            getLogger().error(
+              `[NEAT-AI] Batch rust scorer invocation failed: ${detail}; ` +
+                `${diagnostic.message}; falling back to per-creature scoring.`,
+            );
+          } else {
+            getLogger().error(
+              `[NEAT-AI] Batch rust scorer invocation failed: ${detail}; ` +
+                `falling back to per-creature scoring.`,
+            );
+          }
+          // creaturesForWorkerPath stays at uniqueQueue so the worker path
+          // re-scores everything, including the forwardOnly creatures the
+          // batch attempt failed to score.
         }
       }
+      // forwardOnlyCreatures.length === 0 — no temp dir, no spawn. The
+      // worker path already covers every recurrent creature.
     }
 
     // Issue #1862: Sort by topology hash to cluster same-topology creatures.
@@ -266,9 +304,13 @@ export class Fitness {
     // from the front of the queue, so same-topology creatures flow to the
     // same worker via the work-stealing pattern.
     // Issue #2123: Avoid unnecessary array copy. When grouping is disabled,
-    // use uniqueQueue directly. When enabled, pre-compute hashes into a Map
-    // for O(1) lookups during sort instead of O(n log n) hash computations.
-    const queue: Creature[] = uniqueQueue;
+    // use the worker queue directly. When enabled, pre-compute hashes into a
+    // Map for O(1) lookups during sort instead of O(n log n) hash
+    // computations.
+    // Issue #2517: `creaturesForWorkerPath` excludes any creatures already
+    // scored by the batch path; it is identical to `uniqueQueue` whenever
+    // batch is disabled, the forwardOnly subset is empty, or batch failed.
+    const queue: Creature[] = creaturesForWorkerPath;
     if (this.evalConfig.topologyGrouping) {
       const hashCache = new Map<Creature, string>();
       for (const creature of queue) {

--- a/test/NEAT/FitnessBatchRustScorer.ts
+++ b/test/NEAT/FitnessBatchRustScorer.ts
@@ -55,6 +55,9 @@ function buildDataSet(): DataRecordInterface[] {
 }
 
 function buildPopulation(count: number): Creature[] {
+  // Issue #2517: Mark creatures as forwardOnly so they are eligible for the
+  // batch path. The Fitness partition routes only forwardOnly=true creatures
+  // into the rust scorer batch directory; recurrent creatures bypass it.
   const base: CreatureExport = {
     neurons: [
       { type: "hidden", uuid: "hidden-0", squash: "TANH", bias: 0.5 },
@@ -66,6 +69,7 @@ function buildPopulation(count: number): Creature[] {
     ],
     input: 2,
     output: 1,
+    forwardOnly: true,
   };
   const creatures: Creature[] = [];
   for (let i = 0; i < count; i++) {

--- a/test/architecture/FitnessForwardOnlyPartition.ts
+++ b/test/architecture/FitnessForwardOnlyPartition.ts
@@ -1,0 +1,396 @@
+/**
+ * Fitness forwardOnly partition tests (Issue #2517).
+ *
+ * Verifies that mixed populations (forwardOnly + recurrent) are partitioned
+ * before the batch rust scorer is invoked. The scorer rejects directories
+ * containing any `forwardOnly=false` creature, so passing a mixed batch
+ * poisons the entire generation. The partition routes only forwardOnly
+ * creatures into the batch path and lets recurrent creatures take the
+ * per-creature worker path.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { Fitness } from "@architecture/Fitness.ts";
+import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import {
+  __resetRustScorerBridgeForTests,
+  __setRustScorerRunnerForTests,
+} from "../../src/score/RustScorerBridge.ts";
+
+class MockWorkerHandler {
+  public evaluateCallCount = 0;
+  public seenUuids: string[] = [];
+
+  addIdleListener(_callback: () => void): void {}
+  isBusy(): boolean {
+    return false;
+  }
+  // deno-lint-ignore require-await
+  async evaluate(
+    creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<{ evaluate: { error: number } }> {
+    this.evaluateCallCount++;
+    this.seenUuids.push(creature.uuid ?? "<no-uuid>");
+    return { evaluate: { error: 0.5 } };
+  }
+}
+
+function buildDataSet(): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < 4; i++) {
+    rows.push({
+      input: new Float32Array([i, 4 - i]),
+      output: new Float32Array([i > 2 ? 1 : -1]),
+    });
+  }
+  return rows;
+}
+
+function buildCreature(bias: number, forwardOnly: boolean): Creature {
+  const data: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: `hidden-${bias}`, squash: "TANH", bias },
+      { type: "output", uuid: `output-${bias}`, squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: `hidden-${bias}`, weight: 0.5 },
+      { fromUUID: `hidden-${bias}`, toUUID: `output-${bias}`, weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+    forwardOnly,
+  };
+  return Creature.fromJSON(data);
+}
+
+interface BatchEnvSnapshot {
+  enabled: string | undefined;
+  batch: string | undefined;
+}
+
+function enableBatchEnv(): BatchEnvSnapshot {
+  const snapshot: BatchEnvSnapshot = {
+    enabled: Deno.env.get("NEAT_AI_RUST_SCORER_ENABLED"),
+    batch: Deno.env.get("NEAT_AI_RUST_SCORER_BATCH"),
+  };
+  Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", "true");
+  Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", "true");
+  return snapshot;
+}
+
+function restoreBatchEnv(snapshot: BatchEnvSnapshot): void {
+  if (snapshot.enabled === undefined) {
+    Deno.env.delete("NEAT_AI_RUST_SCORER_ENABLED");
+  } else {
+    Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", snapshot.enabled);
+  }
+  if (snapshot.batch === undefined) {
+    Deno.env.delete("NEAT_AI_RUST_SCORER_BATCH");
+  } else {
+    Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", snapshot.batch);
+  }
+}
+
+Deno.test("Fitness partition - all forwardOnly population batches every creature", async () => {
+  __resetRustScorerBridgeForTests();
+  const envSnapshot = enableBatchEnv();
+
+  const population = [
+    buildCreature(0.1, true),
+    buildCreature(0.2, true),
+    buildCreature(0.3, true),
+  ];
+  const uuids = population.map((c) => CreatureUtil.makeUUID(c));
+
+  let scoreCalls = 0;
+  let seenStems: string[] = [];
+  __setRustScorerRunnerForTests(async (_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return { success: true, code: 0, stdout: "usage", stderr: "" };
+    }
+    scoreCalls++;
+    // Inspect the directory to capture the stems the scorer would see — this
+    // is what the rust scorer's pre-check inspects.
+    const entries: string[] = [];
+    for await (const entry of Deno.readDir(args[0])) {
+      if (entry.isFile && entry.name.endsWith(".json")) {
+        entries.push(entry.name.replace(/\.json$/, ""));
+      }
+    }
+    seenStems = entries.sort();
+    const payload: Record<
+      string,
+      { score: number; error: number; recordCount: number }
+    > = {};
+    for (let i = 0; i < uuids.length; i++) {
+      payload[uuids[i]] = {
+        score: 0.9 - i * 0.1,
+        error: 0.1 + i * 0.05,
+        recordCount: 4,
+      };
+    }
+    return {
+      success: true,
+      code: 0,
+      stdout: JSON.stringify(payload),
+      stderr: "",
+    };
+  });
+
+  const worker = new MockWorkerHandler();
+  const dataDir = makeDataDir(buildDataSet(), 4);
+  try {
+    const fitness = new Fitness(
+      [worker as unknown as WorkerHandler],
+      0.0001,
+      false,
+      undefined,
+      dataDir,
+    );
+    await fitness.calculate(population);
+
+    assertEquals(
+      scoreCalls,
+      1,
+      "exactly one scorer process for all-forwardOnly population",
+    );
+    assertEquals(fitness.lastBatchScorerInvocations, 1);
+    assertEquals(
+      worker.evaluateCallCount,
+      0,
+      "all forwardOnly creatures must take the batch path",
+    );
+    assertEquals(seenStems.sort().join(","), [...uuids].sort().join(","));
+    for (const creature of population) {
+      assert(creature.score !== undefined, "every creature should be scored");
+    }
+  } finally {
+    restoreBatchEnv(envSnapshot);
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("Fitness partition - all recurrent population skips batch entirely", async () => {
+  __resetRustScorerBridgeForTests();
+  const envSnapshot = enableBatchEnv();
+
+  const population = [
+    buildCreature(0.1, false),
+    buildCreature(0.2, false),
+    buildCreature(0.3, false),
+  ];
+
+  let scoreCalls = 0;
+  __setRustScorerRunnerForTests(async (_command, args) => {
+    // Even the probe must not be needed when there is nothing to batch.
+    // Allow probe for safety, but count any actual scoring call.
+    if (args.length === 1 && args[0] === "--help") {
+      return await Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    scoreCalls++;
+    return await Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: "{}",
+      stderr: "",
+    });
+  });
+
+  const worker = new MockWorkerHandler();
+  const dataDir = makeDataDir(buildDataSet(), 4);
+  try {
+    const fitness = new Fitness(
+      [worker as unknown as WorkerHandler],
+      0.0001,
+      false,
+      undefined,
+      dataDir,
+    );
+    await fitness.calculate(population);
+
+    assertEquals(
+      scoreCalls,
+      0,
+      "no scorer process should spawn when no creature is forwardOnly",
+    );
+    assertEquals(fitness.lastBatchScorerInvocations, 0);
+    assertEquals(
+      worker.evaluateCallCount,
+      population.length,
+      "every recurrent creature should score via the per-creature worker path",
+    );
+    for (const creature of population) {
+      assert(creature.score !== undefined, "every creature should be scored");
+    }
+  } finally {
+    restoreBatchEnv(envSnapshot);
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("Fitness partition - mixed population batches forwardOnly only, recurrent via worker", async () => {
+  __resetRustScorerBridgeForTests();
+  const envSnapshot = enableBatchEnv();
+
+  const fwd1 = buildCreature(0.11, true);
+  const fwd2 = buildCreature(0.12, true);
+  const rec1 = buildCreature(0.21, false);
+  const rec2 = buildCreature(0.22, false);
+  const population = [fwd1, rec1, fwd2, rec2];
+  const fwdUuids = [
+    CreatureUtil.makeUUID(fwd1),
+    CreatureUtil.makeUUID(fwd2),
+  ].sort();
+  const recUuids = new Set([
+    CreatureUtil.makeUUID(rec1),
+    CreatureUtil.makeUUID(rec2),
+  ]);
+
+  let scoreCalls = 0;
+  let seenStems: string[] = [];
+  __setRustScorerRunnerForTests(async (_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return { success: true, code: 0, stdout: "usage", stderr: "" };
+    }
+    scoreCalls++;
+    const entries: string[] = [];
+    for await (const entry of Deno.readDir(args[0])) {
+      if (entry.isFile && entry.name.endsWith(".json")) {
+        entries.push(entry.name.replace(/\.json$/, ""));
+      }
+    }
+    seenStems = entries.sort();
+    const payload: Record<
+      string,
+      { score: number; error: number; recordCount: number }
+    > = {};
+    for (const stem of entries) {
+      payload[stem] = { score: 0.5, error: 0.25, recordCount: 4 };
+    }
+    return {
+      success: true,
+      code: 0,
+      stdout: JSON.stringify(payload),
+      stderr: "",
+    };
+  });
+
+  const worker = new MockWorkerHandler();
+  const dataDir = makeDataDir(buildDataSet(), 4);
+  try {
+    const fitness = new Fitness(
+      [worker as unknown as WorkerHandler],
+      0.0001,
+      false,
+      undefined,
+      dataDir,
+    );
+    await fitness.calculate(population);
+
+    assertEquals(
+      scoreCalls,
+      1,
+      "one scorer process for the forwardOnly subset",
+    );
+    assertEquals(fitness.lastBatchScorerInvocations, 1);
+    assertEquals(
+      seenStems,
+      fwdUuids,
+      "scorer must see forwardOnly stems only — recurrent creatures must not appear in the batch directory",
+    );
+    assertEquals(
+      worker.evaluateCallCount,
+      2,
+      "only the recurrent creatures should travel the per-creature worker path",
+    );
+    for (const seen of worker.seenUuids) {
+      assert(
+        recUuids.has(seen),
+        `worker should only score recurrent creatures, saw ${seen}`,
+      );
+    }
+    for (const creature of population) {
+      assert(
+        creature.score !== undefined,
+        `every creature should be scored, missed ${creature.uuid}`,
+      );
+    }
+    // Telemetry: scored count covers both paths (4 unique creatures).
+    assertEquals(fitness.lastScoredCreatureCount, 4);
+  } finally {
+    restoreBatchEnv(envSnapshot);
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("Fitness partition - batch failure on forwardOnly subset still scores recurrent via worker", async () => {
+  __resetRustScorerBridgeForTests();
+  const envSnapshot = enableBatchEnv();
+
+  const fwd = buildCreature(0.31, true);
+  const rec = buildCreature(0.32, false);
+  const population = [fwd, rec];
+  for (const c of population) CreatureUtil.makeUUID(c);
+
+  __setRustScorerRunnerForTests(async (_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return await Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    // Empty payload triggers MISSING_KEYS reconciliation failure for the
+    // forwardOnly creature in the batch — the recurrent creature is never
+    // sent and should still be scored by the worker path.
+    return await Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: "{}",
+      stderr: "",
+    });
+  });
+
+  const worker = new MockWorkerHandler();
+  const dataDir = makeDataDir(buildDataSet(), 4);
+  try {
+    const fitness = new Fitness(
+      [worker as unknown as WorkerHandler],
+      0.0001,
+      false,
+      undefined,
+      dataDir,
+    );
+    await fitness.calculate(population);
+
+    // Worker scores both creatures (recurrent always; forwardOnly because
+    // batch fell back).
+    assertEquals(
+      worker.evaluateCallCount,
+      2,
+      "worker fallback must score both forwardOnly and recurrent creatures",
+    );
+    for (const creature of population) {
+      assert(creature.score !== undefined, "every creature should be scored");
+    }
+  } finally {
+    restoreBatchEnv(envSnapshot);
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});


### PR DESCRIPTION
# Partition population by forwardOnly before invoking batch rust scorer

## Summary

`Fitness.calculate()` previously sent the entire deduplicated population to
`tryBatchScoreWithRustScorer()` in one call. The external `rust_scorer`
(NEAT-AI-scorer) rejects directory-mode batches that contain any
`forwardOnly=false` creature, so a single recurrent creature in a generation
poisoned the whole batch and forced the per-creature fallback for everything —
collapsing the once-per-generation performance benefit from Issue #2422.

This change partitions the unique creature queue by `forwardOnly` before the
batch attempt:

- Forward-only creatures take the batch path (one `rust_scorer` process per
  generation).
- Recurrent creatures take the per-creature worker path directly.
- When the forward-only subset is empty, the batch is skipped entirely (no
  temp dir, no spawn).
- A single INFO log line per generation summarises the partition.

Telemetry (`lastBatchScorerInvocations`, `lastScorerMs`,
`lastScoredCreatureCount`) accumulates across both paths so observability
remains accurate.

Closes #2517.

## Evidence

Backend-only change. The fix is verified by unit tests that exercise the
real `Fitness.calculate()` with a mocked `rust_scorer` runner and an
in-memory worker stub, asserting:

- The correct number of scorer processes spawned (or none at all).
- The exact UUID set written into the batch directory (recurrent UUIDs must
  not appear).
- The exact set of creatures the worker stub saw.
- That every creature in the population received a final score.

```mermaid
flowchart LR
    A[uniqueQueue] --> B{partition by forwardOnly}
    B -->|forwardOnly=true| C[tryBatchScoreWithRustScorer]
    B -->|forwardOnly=false| D[per-creature worker path]
    C --> E[reconciled scores]
    D --> E
    E --> F[populated population]
```

## Test Plan

New tests (`test/architecture/FitnessForwardOnlyPartition.ts`):

- `Fitness partition - all forwardOnly population batches every creature` —
  every creature reaches the batch directory, no worker calls.
- `Fitness partition - all recurrent population skips batch entirely` —
  scorer never spawned (`invocations === 0`), every creature scored via
  workers.
- `Fitness partition - mixed population batches forwardOnly only, recurrent
  via worker` — the batch directory contains exactly the forwardOnly UUIDs;
  workers see only the recurrent UUIDs; combined `lastScoredCreatureCount`
  covers the full population.
- `Fitness partition - batch failure on forwardOnly subset still scores
  recurrent via worker` — when batch reconciliation fails, the worker path
  re-scores everything (forwardOnly fallback + recurrent).

Updated test (`test/NEAT/FitnessBatchRustScorer.ts`):

- `buildPopulation()` now sets `forwardOnly: true` on the synthetic
  creatures so the existing "one scorer process per generation" test
  exercises the batch path under the new partition contract. Documented in
  the test file.

Existing tests unchanged and still passing:

- `test/score/BatchRustScorerBridge.ts` (full batch bridge contract)
- `test/architecture/Fitness*.ts` (telemetry, dynamic pool, busy-wait,
  topology grouping, WASM-panic recovery, typed errors, fast-pool
  evaluation)

Full quality gate (`./quality.sh --skip-discovery --skip-wasm`) passes:
`6418 passed | 0 failed | 4 ignored`.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2517 -->