### PR TITLE
Defer throughput-stall guard until warm-up; rate-of-change check (#2513)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2513.md
+++ b/docs/pr-summary-2513.md
@@ -3,44 +3,43 @@
 ## Summary
 
 Defers the per-chunk throughput-stall guard in
-`DataRecorderAnalysis.runAnalysisLoop` until a warm-up window of two
-completed chunks has elapsed, and only trips the stall once the average
-per-chunk elapsed time across all completed chunks still exceeds
-`perChunkMaxMs`. The defence-in-depth iteration wall-clock cap is
-re-anchored at the end of warm-up so warm-up time is no longer counted
-against subsequent chunks. The throughput-stalled abort log line now
-carries a heap / RSS diagnostic so future stalls can be correlated with
-memory pressure. Closes #2513.
+`DataRecorderAnalysis.runAnalysisLoop` until a warm-up window of two completed
+chunks has elapsed, and only trips the stall once the average per-chunk elapsed
+time across all completed chunks still exceeds `perChunkMaxMs`. The
+defence-in-depth iteration wall-clock cap is re-anchored at the end of warm-up
+so warm-up time is no longer counted against subsequent chunks. The
+throughput-stalled abort log line now carries a heap / RSS diagnostic so future
+stalls can be correlated with memory pressure. Closes #2513.
 
-Production GRQ-10 runs were tearing down the entire retry loop after a
-single 6-neuron warm-up chunk because the first Rust FFI call pays for
-parquet loading, GPU initialisation, and module dispatch warm-up. Under
-the new behaviour the warm-up overshoot is logged but the loop keeps
-running; the stall guard fires only on sustained slowness past warm-up.
+Production GRQ-10 runs were tearing down the entire retry loop after a single
+6-neuron warm-up chunk because the first Rust FFI call pays for parquet loading,
+GPU initialisation, and module dispatch warm-up. Under the new behaviour the
+warm-up overshoot is logged but the loop keeps running; the stall guard fires
+only on sustained slowness past warm-up.
 
 ## Evidence
 
-This is a backend (TypeScript / FFI orchestration) change — no UI to
-screenshot. New unit tests assert the behaviour change directly:
+This is a backend (TypeScript / FFI orchestration) change — no UI to screenshot.
+New unit tests assert the behaviour change directly:
 
 - `warm-up gate: a single slow first chunk does NOT trip iterationStalled`
-  reproduces the GRQ-10 pattern (chunk 1 = 5,000 ms, chunks 2–3 = 1 ms
-  each, `perChunkMaxMs = 100 ms`) and confirms `analysisStalled` stays
-  `false`. This test fails against the unfixed code with
-  `analysisStalled === true` and passes after the fix.
+  reproduces the GRQ-10 pattern (chunk 1 = 5,000 ms, chunks 2–3 = 1 ms each,
+  `perChunkMaxMs = 100 ms`) and confirms `analysisStalled` stays `false`. This
+  test fails against the unfixed code with `analysisStalled === true` and passes
+  after the fix.
 - `warm-up gate: sustained slow chunks past warm-up DO trip iterationStalled`
-  drives an always-slow fake clock and confirms the stall still fires
-  once warm-up has elapsed and the rolling average stays above budget.
+  drives an always-slow fake clock and confirms the stall still fires once
+  warm-up has elapsed and the rolling average stays above budget.
 - `warm-up gate: stall guard never fires when chunks complete within budget`
   confirms the unhappy path (no stall) on a normal-paced run.
-- `formatStallMemoryDiagnostics returns a non-empty diagnostic string`
-  exercises the new helper that annotates the abort log.
+- `formatStallMemoryDiagnostics returns a non-empty diagnostic string` exercises
+  the new helper that annotates the abort log.
 
 Pre-existing tests under
 `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` and
 `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`
-continue to pass — sustained slow chunks still trip the stall guard
-under the new logic, and the mid-flight FFI hang timeout is unchanged.
+continue to pass — sustained slow chunks still trip the stall guard under the
+new logic, and the mid-flight FFI hang timeout is unchanged.
 
 `./quality.sh` passed end-to-end (6,446 tests, 0 failed, 4 ignored).
 
@@ -59,26 +58,27 @@ flowchart TD
 
 ## Test Plan
 
-- [x] New file `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisStallWarmup.ts`
-  covers the four cases above.
+- [x] New file
+      `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisStallWarmup.ts`
+      covers the four cases above.
 - [x] Existing `DiscoverAnalysisChunking.ts` and
-  `DiscoverAnalysisPerChunkTimeout.ts` suites pass unchanged.
+      `DiscoverAnalysisPerChunkTimeout.ts` suites pass unchanged.
 - [x] Full `./quality.sh` run (lint, format, deno check, all tests) is green.
 
 ## Implementation notes
 
-- `STALL_WARMUP_MIN_COMPLETED_CHUNKS = 2` — minimum completed chunks
-  before the per-chunk guard may trip.
+- `STALL_WARMUP_MIN_COMPLETED_CHUNKS = 2` — minimum completed chunks before the
+  per-chunk guard may trip.
 - `iterationStart` and `iterationCapMs` are now mutable inside
-  `runAnalysisLoop`. When the warm-up window closes (i.e. the second
-  chunk completes), both are re-anchored: `iterationStart = now()` and
-  `iterationCapMs = perChunkMaxMs * remainingChunks`. This bounds
-  post-warm-up wall-clock time without counting the slow warm-up call.
+  `runAnalysisLoop`. When the warm-up window closes (i.e. the second chunk
+  completes), both are re-anchored: `iterationStart = now()` and
+  `iterationCapMs = perChunkMaxMs * remainingChunks`. This bounds post-warm-up
+  wall-clock time without counting the slow warm-up call.
 - `formatStallMemoryDiagnostics()` returns a one-line diagnostic
   `heap=usedMB/totalMB rss=rssMB external=externalMB`, falling back to
-  `heap=unavailable rss=unavailable` when `Deno.memoryUsage()` is not
-  present (e.g. non-Deno test runners). The result is appended in
-  square brackets to the `analysis throughput stalled …` log line.
-- The mid-flight FFI timeout path (Issue #2420) is intentionally
-  unchanged — that path defends against a hung Rust call, which is a
-  different failure mode from a slow-but-completed warm-up chunk.
+  `heap=unavailable rss=unavailable` when `Deno.memoryUsage()` is not present
+  (e.g. non-Deno test runners). The result is appended in square brackets to the
+  `analysis throughput stalled …` log line.
+- The mid-flight FFI timeout path (Issue #2420) is intentionally unchanged —
+  that path defends against a hung Rust call, which is a different failure mode
+  from a slow-but-completed warm-up chunk.

--- a/docs/pr-summary-2513.md
+++ b/docs/pr-summary-2513.md
@@ -1,0 +1,84 @@
+# Discovery throughput-stall detector: warm-up gate + rate-of-change check
+
+## Summary
+
+Defers the per-chunk throughput-stall guard in
+`DataRecorderAnalysis.runAnalysisLoop` until a warm-up window of two
+completed chunks has elapsed, and only trips the stall once the average
+per-chunk elapsed time across all completed chunks still exceeds
+`perChunkMaxMs`. The defence-in-depth iteration wall-clock cap is
+re-anchored at the end of warm-up so warm-up time is no longer counted
+against subsequent chunks. The throughput-stalled abort log line now
+carries a heap / RSS diagnostic so future stalls can be correlated with
+memory pressure. Closes #2513.
+
+Production GRQ-10 runs were tearing down the entire retry loop after a
+single 6-neuron warm-up chunk because the first Rust FFI call pays for
+parquet loading, GPU initialisation, and module dispatch warm-up. Under
+the new behaviour the warm-up overshoot is logged but the loop keeps
+running; the stall guard fires only on sustained slowness past warm-up.
+
+## Evidence
+
+This is a backend (TypeScript / FFI orchestration) change — no UI to
+screenshot. New unit tests assert the behaviour change directly:
+
+- `warm-up gate: a single slow first chunk does NOT trip iterationStalled`
+  reproduces the GRQ-10 pattern (chunk 1 = 5,000 ms, chunks 2–3 = 1 ms
+  each, `perChunkMaxMs = 100 ms`) and confirms `analysisStalled` stays
+  `false`. This test fails against the unfixed code with
+  `analysisStalled === true` and passes after the fix.
+- `warm-up gate: sustained slow chunks past warm-up DO trip iterationStalled`
+  drives an always-slow fake clock and confirms the stall still fires
+  once warm-up has elapsed and the rolling average stays above budget.
+- `warm-up gate: stall guard never fires when chunks complete within budget`
+  confirms the unhappy path (no stall) on a normal-paced run.
+- `formatStallMemoryDiagnostics returns a non-empty diagnostic string`
+  exercises the new helper that annotates the abort log.
+
+Pre-existing tests under
+`test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` and
+`test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`
+continue to pass — sustained slow chunks still trip the stall guard
+under the new logic, and the mid-flight FFI hang timeout is unchanged.
+
+`./quality.sh` passed end-to-end (6,446 tests, 0 failed, 4 ignored).
+
+```mermaid
+flowchart TD
+    A[chunk completes] --> B{chunkElapsed >= perChunkMaxMs?}
+    B -- no --> Z[continue]
+    B -- yes --> C{completedChunks < 2?}
+    C -- yes --> D[warm-up: log overshoot, continue]
+    D --> Z
+    C -- no --> E{avg chunk elapsed >= perChunkMaxMs?}
+    E -- no --> F[amortised by fast chunks: log, continue]
+    F --> Z
+    E -- yes --> G[trip iterationStalled<br/>log abort + heap/RSS diagnostic]
+```
+
+## Test Plan
+
+- [x] New file `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisStallWarmup.ts`
+  covers the four cases above.
+- [x] Existing `DiscoverAnalysisChunking.ts` and
+  `DiscoverAnalysisPerChunkTimeout.ts` suites pass unchanged.
+- [x] Full `./quality.sh` run (lint, format, deno check, all tests) is green.
+
+## Implementation notes
+
+- `STALL_WARMUP_MIN_COMPLETED_CHUNKS = 2` — minimum completed chunks
+  before the per-chunk guard may trip.
+- `iterationStart` and `iterationCapMs` are now mutable inside
+  `runAnalysisLoop`. When the warm-up window closes (i.e. the second
+  chunk completes), both are re-anchored: `iterationStart = now()` and
+  `iterationCapMs = perChunkMaxMs * remainingChunks`. This bounds
+  post-warm-up wall-clock time without counting the slow warm-up call.
+- `formatStallMemoryDiagnostics()` returns a one-line diagnostic
+  `heap=usedMB/totalMB rss=rssMB external=externalMB`, falling back to
+  `heap=unavailable rss=unavailable` when `Deno.memoryUsage()` is not
+  present (e.g. non-Deno test runners). The result is appended in
+  square brackets to the `analysis throughput stalled …` log line.
+- The mid-flight FFI timeout path (Issue #2420) is intentionally
+  unchanged — that path defends against a hung Rust call, which is a
+  different failure mode from a slow-but-completed warm-up chunk.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
@@ -47,6 +47,52 @@ export type ParallelAnalysisFn = (
 export const DEFAULT_PER_CHUNK_GRACE_MS = 1_000;
 
 /**
+ * Minimum number of completed chunks before the per-chunk stall guard may
+ * fire (Issue #2513). The first Rust FFI chunk pays for parquet loading,
+ * GPU initialisation, and module dispatch warm-up; a single overshoot here
+ * is expected, not a real stall. Allowing a slow first chunk to be
+ * amortised against a fast second chunk avoids tearing down the retry loop
+ * after evaluating only one chunk's worth of neurons.
+ */
+export const STALL_WARMUP_MIN_COMPLETED_CHUNKS = 2;
+
+/**
+ * Returns a one-line diagnostic of the current Deno heap / RSS state.
+ *
+ * Used to annotate the throughput-stall abort log so future occurrences
+ * can be correlated with memory pressure (Issue #2513). Falls back to an
+ * "unavailable" marker when `Deno.memoryUsage()` is not present (e.g.
+ * non-Deno test runners).
+ */
+export function formatStallMemoryDiagnostics(): string {
+  // Deno.memoryUsage may be unavailable when this module is loaded under a
+  // non-Deno runtime. Guard the lookup so the diagnostic stays a
+  // best-effort annotation rather than a hard dependency.
+  const memFn = (globalThis as { Deno?: { memoryUsage?: () => unknown } })
+    ?.Deno?.memoryUsage;
+  if (typeof memFn !== "function") {
+    return "heap=unavailable rss=unavailable";
+  }
+  try {
+    const mem = memFn() as {
+      rss?: number;
+      heapUsed?: number;
+      heapTotal?: number;
+      external?: number;
+    };
+    const mb = (b: number | undefined) =>
+      typeof b === "number" && Number.isFinite(b)
+        ? `${(b / (1024 * 1024)).toFixed(0)}MB`
+        : "?";
+    return `heap=${mb(mem.heapUsed)}/${mb(mem.heapTotal)} rss=${
+      mb(mem.rss)
+    } external=${mb(mem.external)}`;
+  } catch {
+    return "heap=unavailable rss=unavailable";
+  }
+}
+
+/**
  * Context required by the analysis loop, provided by the DataRecorder.
  */
 export interface AnalysisLoopContext {
@@ -325,19 +371,33 @@ export async function runAnalysisLoop(
     // `perChunkMaxMs * chunks.length` on chunk processing for one retry
     // iteration (Issue #2420). Prevents a single slow FFI call from burning
     // the entire discovery cycle before the per-chunk check fires.
-    const iterationStart = now();
-    const iterationCapMs = ctx.perChunkMaxMs > 0
+    let iterationStart = now();
+    let iterationCapMs = ctx.perChunkMaxMs > 0
       ? ctx.perChunkMaxMs * chunks.length
       : 0;
     let chunkIdx = 0;
     let iterationStalled = false;
+    // Track completed chunks and cumulative chunk time for the warm-up
+    // gate and rate-of-change check (Issue #2513). A "completed" chunk is
+    // one whose Rust FFI call returned (whether fast or slow) — chunks
+    // that timed out mid-flight are not counted, so a hung FFI on chunk 1
+    // still aborts via the timeout path.
+    let completedChunks = 0;
+    let totalChunkElapsedMs = 0;
     for (const chunk of chunks) {
       chunkIdx++;
       // Defence-in-depth: check cumulative wall-clock before submitting each
       // new chunk (Issue #2420). If earlier chunks have already burned the
       // overall budget, stop — the per-chunk check below would only fire
       // after yet another slow call returns.
-      if (iterationCapMs > 0) {
+      //
+      // Issue #2513: do not enforce the iteration cap during warm-up — a
+      // single slow warm-up chunk must not block subsequent chunks from
+      // running so the warm-up cost can be amortised.
+      if (
+        iterationCapMs > 0 &&
+        completedChunks >= STALL_WARMUP_MIN_COMPLETED_CHUNKS
+      ) {
         const iterationElapsed = now() - iterationStart;
         if (iterationElapsed >= iterationCapMs) {
           if (shouldLogDiscovery(config)) {
@@ -589,24 +649,84 @@ export async function runAnalysisLoop(
         removeHarmfulNeurons,
       );
 
+      // The chunk completed (the Rust FFI call returned). Record it for
+      // the warm-up gate and rate-of-change check (Issue #2513).
+      completedChunks++;
+      totalChunkElapsedMs += chunkElapsed;
+      // When the warm-up window has just closed, re-anchor the iteration
+      // wall-clock cap so warm-up time is not counted against subsequent
+      // chunks. The defence-in-depth cap then bounds only post-warm-up
+      // work (Issue #2513).
+      if (completedChunks === STALL_WARMUP_MIN_COMPLETED_CHUNKS) {
+        iterationStart = now();
+        iterationCapMs = ctx.perChunkMaxMs > 0
+          ? ctx.perChunkMaxMs * Math.max(1, chunks.length - completedChunks)
+          : 0;
+      }
+
       // Adaptive early-exit: if the Rust FFI chunk stalled beyond the
       // per-chunk budget, stop submitting further chunks for this cycle
       // (Issue #2380). Throughput is effectively zero so additional chunks
       // would likely consume the rest of the budget without returning.
+      //
+      // Issue #2513: defer the per-chunk stall guard until a warm-up
+      // budget has been spent (a minimum of two completed chunks) and
+      // confirm sustained slowness via a rate-of-change check on the
+      // average per-chunk elapsed. The first Rust FFI chunk pays for
+      // parquet loading, GPU initialisation, and module dispatch warm-up,
+      // so a single-chunk overshoot here is expected, not a real stall.
       if (ctx.perChunkMaxMs > 0 && chunkElapsed >= ctx.perChunkMaxMs) {
-        if (shouldLogDiscovery(config)) {
-          getLogger().info(
-            `Discovery ${
-              blue(ID)
-            } rust combined analysis chunk ${chunkIdx}/${chunks.length} exceeded per-chunk budget ${
-              yellow(format(ctx.perChunkMaxMs, { ignoreZero: true }))
-            } (elapsed ${
-              yellow(format(chunkElapsed, { ignoreZero: true }))
-            }); aborting remaining chunks`,
-          );
+        if (completedChunks < STALL_WARMUP_MIN_COMPLETED_CHUNKS) {
+          // Warm-up: record the overshoot but do not trip the stall guard.
+          if (shouldLogDiscovery(config)) {
+            getLogger().info(
+              `Discovery ${
+                blue(ID)
+              } rust combined analysis chunk ${chunkIdx}/${chunks.length} exceeded per-chunk budget ${
+                yellow(format(ctx.perChunkMaxMs, { ignoreZero: true }))
+              } (elapsed ${
+                yellow(format(chunkElapsed, { ignoreZero: true }))
+              }); within warm-up window (${completedChunks}/${STALL_WARMUP_MIN_COMPLETED_CHUNKS} chunks completed), continuing`,
+            );
+          }
+        } else {
+          // Past warm-up: rate-of-change check. Only trip if the average
+          // per-chunk elapsed across all completed chunks still exceeds the
+          // budget — a slow first chunk amortised by faster ones must not
+          // abort the loop.
+          const avgChunkMs = totalChunkElapsedMs / completedChunks;
+          if (avgChunkMs >= ctx.perChunkMaxMs) {
+            if (shouldLogDiscovery(config)) {
+              getLogger().info(
+                `Discovery ${
+                  blue(ID)
+                } rust combined analysis chunk ${chunkIdx}/${chunks.length} exceeded per-chunk budget ${
+                  yellow(format(ctx.perChunkMaxMs, { ignoreZero: true }))
+                } (elapsed ${
+                  yellow(format(chunkElapsed, { ignoreZero: true }))
+                }, avg ${
+                  yellow(format(avgChunkMs, { ignoreZero: true }))
+                } over ${completedChunks} chunks); aborting remaining chunks`,
+              );
+            }
+            iterationStalled = true;
+            break;
+          }
+          // Slow chunk amortised by earlier fast chunks — keep going.
+          if (shouldLogDiscovery(config)) {
+            getLogger().info(
+              `Discovery ${
+                blue(ID)
+              } rust combined analysis chunk ${chunkIdx}/${chunks.length} exceeded per-chunk budget ${
+                yellow(format(ctx.perChunkMaxMs, { ignoreZero: true }))
+              } (elapsed ${
+                yellow(format(chunkElapsed, { ignoreZero: true }))
+              }) but average ${
+                yellow(format(avgChunkMs, { ignoreZero: true }))
+              } over ${completedChunks} chunks remains within budget; continuing`,
+            );
+          }
         }
-        iterationStalled = true;
-        break;
       }
 
       // Overall deadline check between chunks so we don't start a new chunk
@@ -638,10 +758,12 @@ export async function runAnalysisLoop(
     if (iterationStalled) {
       stalledFlag = true;
       if (shouldLogDiscovery(config)) {
+        // Issue #2513: attach heap/RSS state to the abort log so future
+        // occurrences can be correlated with memory pressure.
         getLogger().info(
           `Discovery ${
             blue(ID)
-          } analysis throughput stalled after evaluating ${attemptedNeurons.size} neuron(s); aborting retry loop`,
+          } analysis throughput stalled after evaluating ${attemptedNeurons.size} neuron(s); aborting retry loop [${formatStallMemoryDiagnostics()}]`,
         );
       }
       break;

--- a/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisStallWarmup.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisStallWarmup.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for the throughput-stall warm-up gate and rate-of-change check
+ * (Issue #2513).
+ *
+ * Background: Issue #2380 added a per-chunk stall guard that aborted the
+ * retry loop when a single Rust FFI chunk exceeded `perChunkMaxMs`. In
+ * production this fired after only the first chunk (the warm-up chunk that
+ * pays for parquet loading, GPU initialisation, and module dispatch),
+ * tearing down the entire retry loop after evaluating just 6 neurons.
+ *
+ * The fix:
+ *
+ *   1. Defer the per-chunk stall guard until a warm-up budget has been
+ *      spent (a minimum of two completed chunks).
+ *   2. Once warm-up has elapsed, the average per-chunk elapsed must still
+ *      exceed the per-chunk budget — a slow first chunk amortised by a
+ *      fast second chunk must NOT abort.
+ *   3. Surface heap / RSS state on the abort log line so future stalls can
+ *      be correlated with memory pressure.
+ */
+import { assert, assertFalse } from "@std/assert";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { DiscoverStructureDeps } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+import { DiscoveryPerformanceStats } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts";
+import { PhaseDiagnostics } from "@architecture/ErrorGuidedStructuralEvolution/PhaseDiagnostics.ts";
+import {
+  formatStallMemoryDiagnostics,
+  runAnalysisLoop,
+} from "@architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import type { RustParallelAnalysisInput } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+function makeTestCreature(): Creature {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { uuid: "hidden-a", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "hidden-b", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "hidden-c", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "input-0", toUUID: "hidden-b", weight: 0.25 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: -0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-c", weight: 0.75 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: -0.25 },
+      { fromUUID: "hidden-c", toUUID: "output-0", weight: 0.3 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+function makeTrainingData(): DataRecordInterface[] {
+  const samples: DataRecordInterface[] = [];
+  for (let i = 0; i < 20; i++) {
+    samples.push({
+      input: Float32Array.from([i / 20, (i + 1) / 20]),
+      output: Float32Array.from([i / 10]),
+    });
+  }
+  return samples;
+}
+
+interface SpyOptions {
+  readonly analyzeParallel: (
+    input: RustParallelAnalysisInput,
+  ) => ReturnType<DiscoverStructureDeps["analyzeParallel"]>;
+  readonly analysisChunkSize: number;
+  readonly perChunkMaxMs: number;
+  readonly discoveryMaxNeurons?: number;
+  readonly now?: () => number;
+  readonly perChunkGraceMs?: number;
+}
+
+async function runWith(
+  options: SpyOptions,
+): Promise<{
+  capturedFocusSizes: number[];
+  perfStats: DiscoveryPerformanceStats;
+}> {
+  await initWasmForTests();
+
+  const creature = makeTestCreature();
+  const capturedFocusSizes: number[] = [];
+
+  const tempParquetPath = await Deno.makeTempFile({
+    prefix: "discover-analysis-stall-warmup-",
+    suffix: ".parquet",
+  });
+
+  const deps: Partial<DiscoverStructureDeps> = {
+    isRustDiscoveryEnabled: () => true,
+    isRustLibraryAvailable: () => true,
+    recordDiscovery: () => ({ success: true, file: tempParquetPath }),
+    mergeDiscoveryParquet: () => ({
+      success: true,
+      outputFile: tempParquetPath,
+    }),
+    analyzeParallel: (input) => {
+      capturedFocusSizes.push(input.focusNeurons.length);
+      return options.analyzeParallel(input);
+    },
+    readDiscoveryRecords: () => ({ success: true, records: [] }),
+  };
+
+  const structure = new DiscoverStructure(creature, 600, 100, deps);
+  const neuronPromises = new Map<number, Promise<void>>();
+  structure.initialize(neuronPromises);
+  structure.record(makeTrainingData(), neuronPromises);
+  structure.flushRustRecording();
+
+  const config = createNeatConfig({
+    discoveryAnalysisTimeoutMinutes: 10,
+    discoveryMaxNeurons: options.discoveryMaxNeurons ?? 6,
+    discoveryAnalysisChunkSize: options.analysisChunkSize,
+    discoveryAnalysisPerChunkMaxMs: options.perChunkMaxMs,
+  });
+
+  const perfStats = new DiscoveryPerformanceStats();
+  const phaseDiagnostics = new PhaseDiagnostics("analysis");
+  const deadlineMs = (options.now ?? Date.now)() + 10 * 60 * 1000;
+  structure.extendTimeoutForAnalysis(600);
+
+  try {
+    await runAnalysisLoop(
+      {
+        ID: "T-2513",
+        config,
+        discoveryMaxNeurons: options.discoveryMaxNeurons ?? 6,
+        costOfGrowth: 0,
+        analysisChunkSize: options.analysisChunkSize,
+        perChunkMaxMs: options.perChunkMaxMs,
+        perChunkGraceMs: options.perChunkGraceMs,
+        now: options.now,
+        getTimeoutTS: () => deadlineMs,
+        refreshAnalysisTimeout: () => {},
+      },
+      structure,
+      perfStats,
+      phaseDiagnostics,
+    );
+  } finally {
+    await structure.cleanUp();
+    try {
+      await Deno.remove(tempParquetPath);
+    } catch {
+      // ignore
+    }
+  }
+
+  return { capturedFocusSizes, perfStats };
+}
+
+Deno.test(
+  "warm-up gate: a single slow first chunk does NOT trip iterationStalled",
+  async () => {
+    // Drive the loop with an explicit mock clock that only advances when
+    // analyzeParallel is invoked. Chunk 1 simulates a slow warm-up call;
+    // subsequent chunks return promptly. With the warm-up gate in place
+    // the slow first chunk must NOT abort the retry loop.
+    let tick = 1_000_000;
+    const fakeNow = () => tick;
+    const chunkDurationsMs = [5_000, 1, 1, 1];
+    let chunkCallIdx = 0;
+
+    const { perfStats } = await runWith({
+      analyzeParallel: () => {
+        const dur = chunkDurationsMs[chunkCallIdx++] ?? 1;
+        tick += dur;
+        return {
+          success: true,
+          helpfulNeurons: [],
+          helpfulSynapses: [],
+          harmfulSynapses: [],
+        };
+      },
+      analysisChunkSize: 1,
+      perChunkMaxMs: 100,
+      discoveryMaxNeurons: 6,
+      now: fakeNow,
+    });
+
+    assertFalse(
+      perfStats.analysisStalled,
+      "warm-up chunk overshoot must not trip analysisStalled when subsequent chunks are fast",
+    );
+  },
+);
+
+Deno.test(
+  "warm-up gate: sustained slow chunks past warm-up DO trip iterationStalled",
+  async () => {
+    // Fake clock that advances 5_000ms on every read — every chunk will
+    // appear to take much longer than the 100ms per-chunk budget. After the
+    // warm-up window passes, the stall guard MUST fire.
+    let tick = 1_000_000;
+    const advanceNow = () => {
+      tick += 5_000;
+      return tick;
+    };
+
+    const { perfStats } = await runWith({
+      analyzeParallel: () => ({
+        success: true,
+        helpfulNeurons: [],
+        helpfulSynapses: [],
+        harmfulSynapses: [],
+      }),
+      analysisChunkSize: 1,
+      perChunkMaxMs: 100,
+      discoveryMaxNeurons: 6,
+      now: advanceNow,
+    });
+
+    assert(
+      perfStats.analysisStalled,
+      "sustained per-chunk overshoot past warm-up must set analysisStalled",
+    );
+  },
+);
+
+Deno.test(
+  "warm-up gate: stall guard never fires when chunks complete within budget",
+  async () => {
+    const { perfStats } = await runWith({
+      analyzeParallel: () => ({
+        success: true,
+        helpfulNeurons: [],
+        helpfulSynapses: [],
+        harmfulSynapses: [],
+      }),
+      analysisChunkSize: 2,
+      perChunkMaxMs: 60_000,
+      discoveryMaxNeurons: 6,
+    });
+
+    assertFalse(
+      perfStats.analysisStalled,
+      "all-fast chunks must never trip analysisStalled",
+    );
+  },
+);
+
+Deno.test(
+  "formatStallMemoryDiagnostics returns a non-empty diagnostic string",
+  () => {
+    const text = formatStallMemoryDiagnostics();
+    // The function must produce something useful so the abort log can be
+    // correlated with memory pressure.
+    assert(
+      typeof text === "string" && text.length > 0,
+      "formatStallMemoryDiagnostics must return a non-empty string",
+    );
+    // The diagnostic should include heap and rss labels.
+    assert(
+      /heap=/i.test(text),
+      `expected diagnostic to mention heap, got: ${text}`,
+    );
+    assert(
+      /rss=/i.test(text),
+      `expected diagnostic to mention rss, got: ${text}`,
+    );
+  },
+);


### PR DESCRIPTION
# Discovery throughput-stall detector: warm-up gate + rate-of-change check

## Summary

Defers the per-chunk throughput-stall guard in
`DataRecorderAnalysis.runAnalysisLoop` until a warm-up window of two
completed chunks has elapsed, and only trips the stall once the average
per-chunk elapsed time across all completed chunks still exceeds
`perChunkMaxMs`. The defence-in-depth iteration wall-clock cap is
re-anchored at the end of warm-up so warm-up time is no longer counted
against subsequent chunks. The throughput-stalled abort log line now
carries a heap / RSS diagnostic so future stalls can be correlated with
memory pressure. Closes #2513.

Production GRQ-10 runs were tearing down the entire retry loop after a
single 6-neuron warm-up chunk because the first Rust FFI call pays for
parquet loading, GPU initialisation, and module dispatch warm-up. Under
the new behaviour the warm-up overshoot is logged but the loop keeps
running; the stall guard fires only on sustained slowness past warm-up.

## Evidence

This is a backend (TypeScript / FFI orchestration) change — no UI to
screenshot. New unit tests assert the behaviour change directly:

- `warm-up gate: a single slow first chunk does NOT trip iterationStalled`
  reproduces the GRQ-10 pattern (chunk 1 = 5,000 ms, chunks 2–3 = 1 ms
  each, `perChunkMaxMs = 100 ms`) and confirms `analysisStalled` stays
  `false`. This test fails against the unfixed code with
  `analysisStalled === true` and passes after the fix.
- `warm-up gate: sustained slow chunks past warm-up DO trip iterationStalled`
  drives an always-slow fake clock and confirms the stall still fires
  once warm-up has elapsed and the rolling average stays above budget.
- `warm-up gate: stall guard never fires when chunks complete within budget`
  confirms the unhappy path (no stall) on a normal-paced run.
- `formatStallMemoryDiagnostics returns a non-empty diagnostic string`
  exercises the new helper that annotates the abort log.

Pre-existing tests under
`test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts` and
`test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`
continue to pass — sustained slow chunks still trip the stall guard
under the new logic, and the mid-flight FFI hang timeout is unchanged.

`./quality.sh` passed end-to-end (6,446 tests, 0 failed, 4 ignored).

```mermaid
flowchart TD
    A[chunk completes] --> B{chunkElapsed >= perChunkMaxMs?}
    B -- no --> Z[continue]
    B -- yes --> C{completedChunks < 2?}
    C -- yes --> D[warm-up: log overshoot, continue]
    D --> Z
    C -- no --> E{avg chunk elapsed >= perChunkMaxMs?}
    E -- no --> F[amortised by fast chunks: log, continue]
    F --> Z
    E -- yes --> G[trip iterationStalled<br/>log abort + heap/RSS diagnostic]
```

## Test Plan

- [x] New file `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisStallWarmup.ts`
  covers the four cases above.
- [x] Existing `DiscoverAnalysisChunking.ts` and
  `DiscoverAnalysisPerChunkTimeout.ts` suites pass unchanged.
- [x] Full `./quality.sh` run (lint, format, deno check, all tests) is green.

## Implementation notes

- `STALL_WARMUP_MIN_COMPLETED_CHUNKS = 2` — minimum completed chunks
  before the per-chunk guard may trip.
- `iterationStart` and `iterationCapMs` are now mutable inside
  `runAnalysisLoop`. When the warm-up window closes (i.e. the second
  chunk completes), both are re-anchored: `iterationStart = now()` and
  `iterationCapMs = perChunkMaxMs * remainingChunks`. This bounds
  post-warm-up wall-clock time without counting the slow warm-up call.
- `formatStallMemoryDiagnostics()` returns a one-line diagnostic
  `heap=usedMB/totalMB rss=rssMB external=externalMB`, falling back to
  `heap=unavailable rss=unavailable` when `Deno.memoryUsage()` is not
  present (e.g. non-Deno test runners). The result is appended in
  square brackets to the `analysis throughput stalled …` log line.
- The mid-flight FFI timeout path (Issue #2420) is intentionally
  unchanged — that path defends against a hung Rust call, which is a
  different failure mode from a slow-but-completed warm-up chunk.