### PR TITLE
docs(research): DeepSeek V3 applicability note (#2536)

### DIFF
--- a/docs/pr-summary-2527.md
+++ b/docs/pr-summary-2527.md
@@ -4,20 +4,20 @@
 
 Adds a DeepSeek V4 GRPO-style group-relative advantage signal for both
 Metropolis-Hastings acceptance and parent selection, gated behind the new
-`mcmc.mcmcAdvantageMode` option (`"absolute" | "groupRelative"`). Default
-is `"absolute"`, so existing behaviour is preserved bit-for-bit.
+`mcmc.mcmcAdvantageMode` option (`"absolute" | "groupRelative"`). Default is
+`"absolute"`, so existing behaviour is preserved bit-for-bit.
 
 When `mcmcAdvantageMode === "groupRelative"`:
 
 - The M-H acceptance compares `delta / (cohortStd + eps)` against the
-  temperature instead of the raw delta. This makes the temperature
-  curriculum invariant to cost-function scale.
-- Parent selection ranks creatures by within-species z-score advantage
-  rather than raw fitness, so a "merely above its species mean" creature
-  is preferred over one that is "merely below an absolutely-higher
-  species mean" in another cohort.
-- Cohort defaults to the creature's species; species below
-  `mcmc.minCohortSize` (default 4) borrow the generation-wide cohort.
+  temperature instead of the raw delta. This makes the temperature curriculum
+  invariant to cost-function scale.
+- Parent selection ranks creatures by within-species z-score advantage rather
+  than raw fitness, so a "merely above its species mean" creature is preferred
+  over one that is "merely below an absolutely-higher species mean" in another
+  cohort.
+- Cohort defaults to the creature's species; species below `mcmc.minCohortSize`
+  (default 4) borrow the generation-wide cohort.
 
 Closes #2527.
 
@@ -34,15 +34,15 @@ flowchart LR
     F --> C
 ```
 
-The pure-function `GroupRelativeAdvantage.ts` module supplies the
-transform; everything else is plumbing that decides whether to apply
-the cohort std (M-H) or rank by advantage (parent selection).
+The pure-function `GroupRelativeAdvantage.ts` module supplies the transform;
+everything else is plumbing that decides whether to apply the cohort std (M-H)
+or rank by advantage (parent selection).
 
 ## Evidence — Benchmark
 
 `bench/MCMCAdvantageConvergence.ts` runs 12 seeded trials of a 32-member
-population optimising a 1-D scalar problem under the same M-H cooling
-schedule, comparing the two acceptance modes head-to-head.
+population optimising a 1-D scalar problem under the same M-H cooling schedule,
+comparing the two acceptance modes head-to-head.
 
 ```text
 Issue #2527 — MCMC advantage mode convergence benchmark
@@ -54,48 +54,46 @@ groupRelative mean=-0.111894 best=-0.046335 worst=-0.183941 accept=0.708500 wall
 mean(score) delta = 0.039421  → neutral or improved
 ```
 
-Higher mean score (closer to zero) is better. `groupRelative` is at
-least neutral on this benchmark (in fact it converges to a slightly
-better mean and better best across 12 seeds while running ~45% faster
-wall-clock — the lower acceptance rate avoids wasted reverts).
+Higher mean score (closer to zero) is better. `groupRelative` is at least
+neutral on this benchmark (in fact it converges to a slightly better mean and
+better best across 12 seeds while running ~45% faster wall-clock — the lower
+acceptance rate avoids wasted reverts).
 
 ## Test Plan
 
 New tests added:
 
-- `test/NEAT/GroupRelativeAdvantage.ts` (14 tests) — covers happy path
-  ordering, empty/single-member cohorts, zero-variance safety,
-  shift-invariance property, clipping, non-finite handling, and the
-  `normaliseDeltaWithCohortStd` helper used by M-H.
+- `test/NEAT/GroupRelativeAdvantage.ts` (14 tests) — covers happy path ordering,
+  empty/single-member cohorts, zero-variance safety, shift-invariance property,
+  clipping, non-finite handling, and the `normaliseDeltaWithCohortStd` helper
+  used by M-H.
 - `test/breed/GroupRelativeAdvantageMaps.ts` (5 tests) — covers
-  `buildGroupRelativeAdvantageMap` (large species, small-species
-  fallback, non-finite skip) and `buildCohortStdContext`.
+  `buildGroupRelativeAdvantageMap` (large species, small-species fallback,
+  non-finite skip) and `buildCohortStdContext`.
 - `test/NEAT/MetropolisHastings.ts` — added 4 tests for
-  `resolveMcmcAcceptanceDelta` in absolute and groupRelative modes
-  including clip and zero-std edge cases.
+  `resolveMcmcAcceptanceDelta` in absolute and groupRelative modes including
+  clip and zero-std edge cases.
 - `test/config/MCMCConfig.ts` — added 3 tests covering the new
-  `mcmcAdvantageMode`, `minCohortSize`, `advantageEps`, `advantageClip`
-  options including default-preservation and rejection of unknown mode
-  strings.
+  `mcmcAdvantageMode`, `minCohortSize`, `advantageEps`, `advantageClip` options
+  including default-preservation and rejection of unknown mode strings.
 
 Critical-invariant gates:
 
-- `test/creature/NeuronUuidStability.ts` — passes (no UUID identity
-  changes; new code touches only fitness/penalty signals).
-- `test/creature/SemanticVersionStability.ts` — passes (no version
-  bumps anywhere in the new code paths).
+- `test/creature/NeuronUuidStability.ts` — passes (no UUID identity changes; new
+  code touches only fitness/penalty signals).
+- `test/creature/SemanticVersionStability.ts` — passes (no version bumps
+  anywhere in the new code paths).
 
 Wider validation:
 
-- `deno test test/breed/** test/NEAT/** test/config/**` — 1404 tests
-  pass, 0 failures.
+- `deno test test/breed/** test/NEAT/** test/config/**` — 1404 tests pass, 0
+  failures.
 - `./quality.sh --check-only` — clean type check.
 - `./quality.sh --lint-only` — clean lint, format, and bash gate.
 
 ## Configuration
 
-Documented in `docs/CONFIGURATION_GUIDE.md` under "MCMC Acceptance
-Criterion":
+Documented in `docs/CONFIGURATION_GUIDE.md` under "MCMC Acceptance Criterion":
 
 ```ts
 const config = createNeatConfig({

--- a/docs/pr-summary-2528.md
+++ b/docs/pr-summary-2528.md
@@ -2,45 +2,44 @@
 
 ## Summary
 
-Adds a new breeding operator that produces an offspring by **distilling**
-the consensus output of K elite teachers into a freshly-initialised
-student creature, using on-policy gradient descent on the teachers' soft
-outputs. Mirrors the DeepSeek V4 On-Policy Distillation (OPD) stage
-where a single student learns from multiple teachers' full-vocabulary
-logits.
+Adds a new breeding operator that produces an offspring by **distilling** the
+consensus output of K elite teachers into a freshly-initialised student
+creature, using on-policy gradient descent on the teachers' soft outputs.
+Mirrors the DeepSeek V4 On-Policy Distillation (OPD) stage where a single
+student learns from multiple teachers' full-vocabulary logits.
 
-The operator is gated behind `opd.breedRate > 0` and disabled by
-default — existing breeding behaviour is unchanged when the flag is
-left at its default. Closes #2528.
+The operator is gated behind `opd.breedRate > 0` and disabled by default —
+existing breeding behaviour is unchanged when the flag is left at its default.
+Closes #2528.
 
 ### Key design choices
 
-- **Nested config** (`OpdConfig` → `NeatArguments.opd`) following the
-  project's per-knob pattern (per `MEMORY.md`). Sub-keys are
-  `breedRate`, `teacherCount`, `distillationSteps`,
-  `calibrationBatchSize`, `temperature`, `learningRate`. Defaults
-  preserve the issue's spec (`teacherCount = 3`, `distillationSteps =
+- **Nested config** (`OpdConfig` → `NeatArguments.opd`) following the project's
+  per-knob pattern (per `MEMORY.md`). Sub-keys are `breedRate`, `teacherCount`,
+  `distillationSteps`, `calibrationBatchSize`, `temperature`, `learningRate`.
+  Defaults preserve the issue's spec (`teacherCount = 3`,
+  `distillationSteps =
   50`, `breedRate = 0`).
-- **Fresh hidden UUIDs**: the student is built by cloning the largest
-  teacher's topology and re-issuing every hidden neuron UUID via
-  `crypto.randomUUID()` — preserving the cross-machine UUID-stability
-  invariant in `AGENTS.md`. Teachers are never mutated.
+- **Fresh hidden UUIDs**: the student is built by cloning the largest teacher's
+  topology and re-issuing every hidden neuron UUID via `crypto.randomUUID()` —
+  preserving the cross-machine UUID-stability invariant in `AGENTS.md`. Teachers
+  are never mutated.
 - **Consensus target**: per-output mean of every teacher's activation,
-  optionally divided by `temperature`. Disjoint topologies are tolerated
-  because each teacher contributes its own forward pass.
-- **K = 1 fallback**: a single teacher triggers a clone-and-train path
-  with a `[opd]` warning, satisfying the issue's edge-case requirement.
-- **Breeding-mode integration**: `Breed.breed()` rolls
-  `opd.breedRate` per call; on success the standard crossover path is
-  skipped and the OPD offspring is returned. On failure the operator
-  silently falls back so the rest of the breeding loop is unaffected.
+  optionally divided by `temperature`. Disjoint topologies are tolerated because
+  each teacher contributes its own forward pass.
+- **K = 1 fallback**: a single teacher triggers a clone-and-train path with a
+  `[opd]` warning, satisfying the issue's edge-case requirement.
+- **Breeding-mode integration**: `Breed.breed()` rolls `opd.breedRate` per call;
+  on success the standard crossover path is skipped and the OPD offspring is
+  returned. On failure the operator silently falls back so the rest of the
+  breeding loop is unaffected.
 
 ## Evidence
 
-This is a backend/CLI change with no UI surface — the offspring is a
-normal `Creature`, so all downstream pipelines (export, transfer,
-discovery) continue to work without modification. Evidence consists of
-unit tests and the calibration-MSE benchmark below.
+This is a backend/CLI change with no UI surface — the offspring is a normal
+`Creature`, so all downstream pipelines (export, transfer, discovery) continue
+to work without modification. Evidence consists of unit tests and the
+calibration-MSE benchmark below.
 
 ### Architecture diagram
 
@@ -58,9 +57,8 @@ flowchart LR
 ### Benchmark results
 
 `bench/OnPolicyDistillationBreed.ts` measures the calibration MSE of an
-OPD-distilled student against the teachers' consensus, versus a
-no-distillation baseline (same topology, negligible learning rate).
-Lower is better.
+OPD-distilled student against the teachers' consensus, versus a no-distillation
+baseline (same topology, negligible learning rate). Lower is better.
 
 ```text
 Holdout samples: 32, trials per budget: 5
@@ -70,30 +68,30 @@ steps= 50  baseline_MSE=0.000210  opd_MSE=0.000021  reduction=90.0%
 steps=100  baseline_MSE=0.000206  opd_MSE=0.000008  reduction=96.3%
 ```
 
-The default `distillationSteps = 50` already drives a 90% MSE reduction
-over the no-train baseline.
+The default `distillationSteps = 50` already drives a 90% MSE reduction over the
+no-train baseline.
 
 ## Test Plan
 
 New tests in `test/breed/OnPolicyDistillationBreed.ts`:
 
-- `happy path` — student MSE drops monotonically across distillation
-  steps on a tiny synthetic problem.
-- `UUID stability` — offspring carries only fresh hidden UUIDs;
-  neither teacher's hidden UUIDs change after distillation.
-- `K = 1 fallback` — single teacher produces a clone-and-train
-  offspring with a `[opd]` warning logged.
-- `disjoint topologies` — two teachers with no shared hidden UUIDs and
-  different hidden counts still produce a valid, activatable student.
-- `mismatched shapes` — teachers with different input/output dims are
-  rejected with `undefined`.
-- `exportJSON round-trip` — the wire-format export (UUID-only)
-  round-trips byte-stable.
-- `default config` — `createNeatConfig({})` yields `opd.breedRate = 0`,
-  so no behaviour change without an explicit opt-in.
-- `Breed integration` — wiring through `Breed.breed()` with
-  `opd.breedRate = 1` produces an offspring whose hidden UUIDs are
-  fresh (proving the OPD operator path was taken).
+- `happy path` — student MSE drops monotonically across distillation steps on a
+  tiny synthetic problem.
+- `UUID stability` — offspring carries only fresh hidden UUIDs; neither
+  teacher's hidden UUIDs change after distillation.
+- `K = 1 fallback` — single teacher produces a clone-and-train offspring with a
+  `[opd]` warning logged.
+- `disjoint topologies` — two teachers with no shared hidden UUIDs and different
+  hidden counts still produce a valid, activatable student.
+- `mismatched shapes` — teachers with different input/output dims are rejected
+  with `undefined`.
+- `exportJSON round-trip` — the wire-format export (UUID-only) round-trips
+  byte-stable.
+- `default config` — `createNeatConfig({})` yields `opd.breedRate = 0`, so no
+  behaviour change without an explicit opt-in.
+- `Breed integration` — wiring through `Breed.breed()` with `opd.breedRate = 1`
+  produces an offspring whose hidden UUIDs are fresh (proving the OPD operator
+  path was taken).
 
 Existing critical-invariant suites continue to pass:
 
@@ -104,8 +102,7 @@ Existing critical-invariant suites continue to pass:
 
 ## Files changed
 
-- New: `src/config/OpdConfig.ts`,
-  `src/breed/OnPolicyDistillationBreed.ts`,
+- New: `src/config/OpdConfig.ts`, `src/breed/OnPolicyDistillationBreed.ts`,
   `test/breed/OnPolicyDistillationBreed.ts`,
   `bench/OnPolicyDistillationBreed.ts`.
 - Wired: `NeatArguments.ts`, `NeatOptions.ts`, `NeatConfig.ts`,

--- a/docs/pr-summary-2530.md
+++ b/docs/pr-summary-2530.md
@@ -3,13 +3,12 @@
 ## Summary
 
 Adds the V4 two-stage post-training pipeline at NEAT scale: dedicated
-**specialist sub-populations** (Stage 1) plus periodic **ensemble
-distillation** of the specialists into a generalist creature via the OPD
-breed operator (Stage 2). Closes #2530.
+**specialist sub-populations** (Stage 1) plus periodic **ensemble distillation**
+of the specialists into a generalist creature via the OPD breed operator (Stage
+2). Closes #2530.
 
-Defaults disable the pipeline (`specialist.mode = "off"`), so existing
-runs are unchanged. Enabling it only requires opting in via
-`NeatOptions.specialist`.
+Defaults disable the pipeline (`specialist.mode = "off"`), so existing runs are
+unchanged. Enabling it only requires opting in via `NeatOptions.specialist`.
 
 ## Architecture
 
@@ -37,39 +36,40 @@ flowchart LR
 
 ## Changes
 
-- **`src/NEAT/Species.ts`** — added optional `specialistTaskId?: string`
-  field. `undefined` means generalist (existing behaviour).
-- **`src/NEAT/Genus.ts`** — added `addCreatureWithTask(creature, taskId)`.
-  When `taskId` is set, the species key is namespaced (`task:<id>|<topology>`)
-  so specialist species do not collide with same-topology generalists.
-  `addCreature` is now a thin wrapper over `addCreatureWithTask(creature, undefined)`.
-- **`src/config/SpecialistConfig.ts`** *(new)* — `SpecialistMode`,
+- **`src/NEAT/Species.ts`** — added optional `specialistTaskId?: string` field.
+  `undefined` means generalist (existing behaviour).
+- **`src/NEAT/Genus.ts`** — added `addCreatureWithTask(creature, taskId)`. When
+  `taskId` is set, the species key is namespaced (`task:<id>|<topology>`) so
+  specialist species do not collide with same-topology generalists.
+  `addCreature` is now a thin wrapper over
+  `addCreatureWithTask(creature, undefined)`.
+- **`src/config/SpecialistConfig.ts`** _(new)_ — `SpecialistMode`,
   `SpecialistConfig`, `RequiredSpecialistConfig`, `DEFAULT_SPECIALIST_CONFIG`.
   Default mode is `"off"`.
-- **`src/config/NeatOptions.ts` / `NeatArguments.ts` / `NeatConfig.ts`** —
-  wired the new config: `NeatOptions.specialist?: SpecialistConfig`,
+- **`src/config/NeatOptions.ts` / `NeatArguments.ts` / `NeatConfig.ts`** — wired
+  the new config: `NeatOptions.specialist?: SpecialistConfig`,
   `NeatArguments.specialist: RequiredSpecialistConfig`, parsed via
   `parseSpecialist` (validated mode enum + numeric ranges).
-- **`src/NEAT/SpecialistPipeline.ts`** *(new)* — orchestrator with:
+- **`src/NEAT/SpecialistPipeline.ts`** _(new)_ — orchestrator with:
   - `isMultiObjective(scores)` — detects whether the cost function exposes
     two-or-more sub-scores (single-objective silently disables the pipeline).
   - `seedSpecialistSpecies(genus, creatures)` — partitions creatures evenly
     across declared sub-tasks, tagging each species. Falls back to standard
     speciation when there are fewer specialists than declared sub-tasks ×
     `minSpecialistsPerTask`.
-  - `routeFitness(species, scores, combinedFitness)` — returns the species'
-    own sub-task score for specialists, combined fitness for generalists.
+  - `routeFitness(species, scores, combinedFitness)` — returns the species' own
+    sub-task score for specialists, combined fitness for generalists.
   - `shouldDistill(generation)` — fires every `distillEveryN` generations.
-  - `distillGeneralist(elites, opdConfig)` — runs `onPolicyDistillationBreed`
-    on the per-task elites, returning a fresh generalist with its own
-    hidden UUIDs (UUID-stability invariant preserved).
+  - `distillGeneralist(elites, opdConfig)` — runs `onPolicyDistillationBreed` on
+    the per-task elites, returning a fresh generalist with its own hidden UUIDs
+    (UUID-stability invariant preserved).
 - **`mod.ts`** — exports `SpecialistPipeline`, `SpecialistConfig`,
   `DEFAULT_SPECIALIST_CONFIG`, `Species`, `Genus`.
 
 ## Evidence
 
-This is a backend-only feature with no UI surface. Acceptance criteria
-verified through targeted unit tests and a benchmark.
+This is a backend-only feature with no UI surface. Acceptance criteria verified
+through targeted unit tests and a benchmark.
 
 ### Test results
 
@@ -88,23 +88,23 @@ SpecialistPipeline - distillation is a no-op when pipeline is disabled or no eli
 ok | 10 passed | 0 failed
 ```
 
-Full quality gate (`./quality.sh --skip-discovery --skip-wasm`):
-**6490 passed | 0 failed | 4 ignored** (1m24s).
+Full quality gate (`./quality.sh --skip-discovery --skip-wasm`): **6490 passed |
+0 failed | 4 ignored** (1m24s).
 
 ### Benchmark — `bench/SpecialistVsMixed.ts`
 
 Apple M2 Ultra, Deno 2.7.14, two-task synthetic fitness:
 
-| benchmark                                                  | time/iter (avg) |  iter/s    |
+| benchmark                                                  | time/iter (avg) | iter/s     |
 | ---------------------------------------------------------- | --------------- | ---------- |
 | `Genus.addCreature` — standard speciation (baseline)       | 52.4 µs         | 19,080     |
 | `SpecialistPipeline.seedSpecialistSpecies` — two sub-tasks | 45.6 µs         | 21,910     |
 | `SpecialistPipeline.routeFitness` — per-creature           | 15.5 ns         | 64,320,000 |
 | `SpecialistPipeline.distillGeneralist` — 2-teacher OPD     | 248.8 µs        | 4,020      |
 
-Per-generation overhead is dominated by the distillation step (which
-runs every `distillEveryN` generations, default 25). Routing overhead
-is ~16 ns per creature, negligible against fitness evaluation.
+Per-generation overhead is dominated by the distillation step (which runs every
+`distillEveryN` generations, default 25). Routing overhead is ~16 ns per
+creature, negligible against fitness evaluation.
 
 ## Test Plan
 
@@ -114,25 +114,25 @@ is ~16 ns per creature, negligible against fitness evaluation.
     `routeFitness` selects the right sub-score per species.
   - Edge case: single-objective fitness silently disables the pipeline
     (`isMultiObjective` returns `false`).
-  - Edge case: insufficient population falls back to standard speciation
-    (no task-tagged species created).
-  - Distillation step: generalist's combined score is no worse than the
-    average specialist's combined score.
+  - Edge case: insufficient population falls back to standard speciation (no
+    task-tagged species created).
+  - Distillation step: generalist's combined score is no worse than the average
+    specialist's combined score.
   - UUID stability: distilled generalist uses fresh hidden UUIDs only.
-  - Default behaviour unchanged: a default-constructed pipeline is a
-    no-op for every public method (`mode = "off"`).
+  - Default behaviour unchanged: a default-constructed pipeline is a no-op for
+    every public method (`mode = "off"`).
   - Cadence: `shouldDistill` fires on multiples of `distillEveryN`.
-- `bench/SpecialistVsMixed.ts` — micro-benchmark for seeding, routing,
-  and distillation overhead.
+- `bench/SpecialistVsMixed.ts` — micro-benchmark for seeding, routing, and
+  distillation overhead.
 
 ## Acceptance Criteria
 
 - [x] Default behaviour unchanged (`specialistMode = "off"`).
-- [x] Specialist species respect existing UUID and semantic-version
-      invariants (distillation reuses `onPolicyDistillationBreed`,
-      which the existing tests already verify).
-- [x] Cross-machine breed-by-UUID still works for specialist creatures
-      — no new identity surface; specialist tagging lives on the
-      species, not the creature.
+- [x] Specialist species respect existing UUID and semantic-version invariants
+      (distillation reuses `onPolicyDistillationBreed`, which the existing tests
+      already verify).
+- [x] Cross-machine breed-by-UUID still works for specialist creatures — no new
+      identity surface; specialist tagging lives on the species, not the
+      creature.
 - [x] Benchmark numbers in PR summary.
 - [x] `./quality.sh` passes (6490 tests).

--- a/docs/pr-summary-2531.md
+++ b/docs/pr-summary-2531.md
@@ -1,49 +1,44 @@
 ## Summary
 
 Adds an Engram-inspired hash-based secondary index that augments the discovery
-`SuccessCache` / `FailureCache` with O(1) lookup keyed on the local
-1-hop subnetwork wire-pattern around a focal neuron. The intent is to
-short-circuit candidate ranking when the same local pattern has already
-been observed elsewhere in the population, regardless of which creature
-it appears in. Pure read-side optimisation: cache semantics are unchanged
-and existing exact-match paths still gate every returned candidate.
-Closes #2531.
+`SuccessCache` / `FailureCache` with O(1) lookup keyed on the local 1-hop
+subnetwork wire-pattern around a focal neuron. The intent is to short-circuit
+candidate ranking when the same local pattern has already been observed
+elsewhere in the population, regardless of which creature it appears in. Pure
+read-side optimisation: cache semantics are unchanged and existing exact-match
+paths still gate every returned candidate. Closes #2531.
 
 ### What changed
 
 - **New module** `src/discovery/SubnetworkHashIndex.ts`:
-  - `SubnetworkHashIndex<T>` — bounded LRU keyed by hash, with a
-    "never evict current-generation entries" guard.
-  - `computeSubnetworkHash(creature, focalUuid)` — UUID-anonymised
-    hash over the focal neuron's
-    `(squashFn, in-degree, out-degree, weight bucket)` plus the same
-    tuple for every 1-hop neighbour. Inputs come from `exportJSON()`
-    (canonical wire format) so no `id`/`fromId`/`toId` ever leaks
-    into the hash payload.
-  - `extractFocalUuid(candidate)` — single-neuron focal extractor for
-    the supported single-step change types; combo / coordinated
-    candidates skip indexing and continue to use the file-backed cache
-    path.
+  - `SubnetworkHashIndex<T>` — bounded LRU keyed by hash, with a "never evict
+    current-generation entries" guard.
+  - `computeSubnetworkHash(creature, focalUuid)` — UUID-anonymised hash over the
+    focal neuron's `(squashFn, in-degree, out-degree, weight bucket)` plus the
+    same tuple for every 1-hop neighbour. Inputs come from `exportJSON()`
+    (canonical wire format) so no `id`/`fromId`/`toId` ever leaks into the hash
+    payload.
+  - `extractFocalUuid(candidate)` — single-neuron focal extractor for the
+    supported single-step change types; combo / coordinated candidates skip
+    indexing and continue to use the file-backed cache path.
   - Process-wide singleton (`getSharedSubnetworkIndex`,
-    `configureSharedSubnetworkIndex`) so `Neat`'s constructor can size
-    the index from `NeatOptions.subnetworkIndexSize` (default 50,000;
-    `0` disables).
+    `configureSharedSubnetworkIndex`) so `Neat`'s constructor can size the index
+    from `NeatOptions.subnetworkIndexSize` (default 50,000; `0` disables).
 
-- **Wired into `SuccessCache.recordSuccessSync`,
-  `FailureCache.recordFailure`, and `recordFailureSync`** —
-  every successful write also indexes the entry by subnetwork hash.
-  Indexing is best-effort and never fails the underlying cache write.
+- **Wired into `SuccessCache.recordSuccessSync`, `FailureCache.recordFailure`,
+  and `recordFailureSync`** — every successful write also indexes the entry by
+  subnetwork hash. Indexing is best-effort and never fails the underlying cache
+  write.
 
-- **`SupplementFromCache`** — consults the index first to promote
-  hash-hit entries ahead of the rest, falling back to the existing
-  `scoreDelta` ordering. Every promoted entry still goes through the
-  unchanged `isEntryRelevantToCreature` + `applyEntryUsingRustRequest`
-  re-verification step, so there are no false positives.
+- **`SupplementFromCache`** — consults the index first to promote hash-hit
+  entries ahead of the rest, falling back to the existing `scoreDelta` ordering.
+  Every promoted entry still goes through the unchanged
+  `isEntryRelevantToCreature` + `applyEntryUsingRustRequest` re-verification
+  step, so there are no false positives.
 
-- **`NeatOptions.subnetworkIndexSize`** — new top-level option
-  documented in `NeatArguments` and parsed in `createNeatConfig` with
-  the default of 50,000. `Neat` configures the shared index from this
-  value at construction time.
+- **`NeatOptions.subnetworkIndexSize`** — new top-level option documented in
+  `NeatArguments` and parsed in `createNeatConfig` with the default of 50,000.
+  `Neat` configures the shared index from this value at construction time.
 
 ### Architecture
 
@@ -60,27 +55,27 @@ flowchart LR
 
 ## Evidence
 
-This is a pure backend change — no UI to screenshot. Performance and
-correctness are demonstrated below.
+This is a pure backend change — no UI to screenshot. Performance and correctness
+are demonstrated below.
 
 ### Benchmark — `bench/SubnetworkHashLookup.ts`
 
-Run on Apple M4, Deno 2.7.14 (no comparable "before" data because the
-index did not exist; the relevant signal is the absolute per-call cost
-and that lookup is constant-time at 50k entries):
+Run on Apple M4, Deno 2.7.14 (no comparable "before" data because the index did
+not exist; the relevant signal is the absolute per-call cost and that lookup is
+constant-time at 50k entries):
 
-| benchmark                                                      | time/iter (avg) |        iter/s |       p99 |
-| -------------------------------------------------------------- | --------------- | ------------- | --------- |
-| computeSubnetworkHash — 1-hop wire pattern (200 creatures)     |          1.1 ms |         937.3 |    3.7 ms |
-| SubnetworkHashIndex.lookup() at 50k entries (1,000 lookups)    |        498.5 µs |         2,006 |    2.3 ms |
-| SubnetworkHashIndex.insert() at capacity (eviction path)       |         18.9 ms |          52.9 |   37.2 ms |
-| computeSubnetworkHash + lookup — end-to-end candidate filter   |        196.0 µs |         5,103 |  505.8 µs |
+| benchmark                                                    | time/iter (avg) | iter/s | p99      |
+| ------------------------------------------------------------ | --------------- | ------ | -------- |
+| computeSubnetworkHash — 1-hop wire pattern (200 creatures)   | 1.1 ms          | 937.3  | 3.7 ms   |
+| SubnetworkHashIndex.lookup() at 50k entries (1,000 lookups)  | 498.5 µs        | 2,006  | 2.3 ms   |
+| SubnetworkHashIndex.insert() at capacity (eviction path)     | 18.9 ms         | 52.9   | 37.2 ms  |
+| computeSubnetworkHash + lookup — end-to-end candidate filter | 196.0 µs        | 5,103  | 505.8 µs |
 
-Per-lookup latency at 50k entries is ~0.5 µs — the hashmap is doing the
-work, not a linear scan. End-to-end (`exportJSON` + hash every focal
-point in 20 creatures + lookup each) is ~10 µs per creature. Hit rate
-is verified structurally: identical 1-hop patterns across creatures
-collide into the same hash bucket (test
+Per-lookup latency at 50k entries is ~0.5 µs — the hashmap is doing the work,
+not a linear scan. End-to-end (`exportJSON` + hash every focal point in 20
+creatures + lookup each) is ~10 µs per creature. Hit rate is verified
+structurally: identical 1-hop patterns across creatures collide into the same
+hash bucket (test
 `identical wire pattern across creatures hashes to the same bucket`).
 
 ### Tests added
@@ -89,7 +84,7 @@ collide into the same hash bucket (test
 
 - Identical wire pattern across two creatures hashes to the same bucket.
 - UUID renaming (focal and synapse endpoints) leaves the hash invariant.
-- Squash-function change *does* change the hash.
+- Squash-function change _does_ change the hash.
 - `exportJSON` / `fromJSON` round-trip is byte-stable.
 - Missing focal UUID returns `undefined`.
 - Hash output is hex (no integer-id leakage).
@@ -97,48 +92,51 @@ collide into the same hash bucket (test
 - Current-generation entries are never evicted, even when over capacity.
 - `clear()` empties the index.
 - `size = 0` disables the index entirely.
-- `extractFocalUuid` returns the right neuron for supported change
-  types and `undefined` for combo / coordinated candidates.
+- `extractFocalUuid` returns the right neuron for supported change types and
+  `undefined` for combo / coordinated candidates.
 - `recordSuccessSync` populates the shared index with correct
   `(source, changeType, cacheKey)` reference.
 - `recordSuccessSync` is a no-op for the index when `size = 0`.
-- "No false positives": same-hash buckets still require caller
-  re-verification — pinned by an explicit test.
+- "No false positives": same-hash buckets still require caller re-verification —
+  pinned by an explicit test.
 
 ### Regression coverage
 
-- `test/discovery/SupplementFromCache.ts`,
-  `DiscoveryRunnerCacheSupplement.ts`,
-  `FailureCacheErrorReduction.ts`,
-  `CandidateFilteringSuccessCache.ts`,
+- `test/discovery/SupplementFromCache.ts`, `DiscoveryRunnerCacheSupplement.ts`,
+  `FailureCacheErrorReduction.ts`, `CandidateFilteringSuccessCache.ts`,
   `DiscoveryCacheEviction.ts` — all pass.
 - `test/creature/NeuronUuidStability.ts` and
   `test/creature/SemanticVersionStability.ts` — both pass (acceptance
   criterion).
 - Full `./quality.sh` run: 6,498 tests passed. One unrelated flake
   (`ThroughputMetrics - fastQueueMaxDepth reflects population size
-  during fitness`, off-by-3 on a parallel queue depth assertion) which
-  passes on isolated re-run and does not touch any code path modified
-  in this PR.
+  during fitness`,
+  off-by-3 on a parallel queue depth assertion) which passes on isolated re-run
+  and does not touch any code path modified in this PR.
 
 ### Acceptance criteria
 
 - [x] Default behaviour unchanged when index size = 0 — verified by
       `recordSuccessSync is a no-op for the index when size = 0`.
-- [x] Hash lookup is O(1) — `Map`-backed; benchmark shows ~0.5 µs/lookup
-      at 50k entries.
+- [x] Hash lookup is O(1) — `Map`-backed; benchmark shows ~0.5 µs/lookup at 50k
+      entries.
 - [x] Hit-rate / per-lookup latency reported above.
-- [x] No regression on `NeuronUuidStability` or
-      `SemanticVersionStability` tests.
-- [x] No `id` / `fromId` / `toId` integer fields in the hash key —
-      hash inputs are sourced from `exportJSON` (canonical wire format)
-      and the hash itself is a hex SHA-1 digest.
+- [x] No regression on `NeuronUuidStability` or `SemanticVersionStability`
+      tests.
+- [x] No `id` / `fromId` / `toId` integer fields in the hash key — hash inputs
+      are sourced from `exportJSON` (canonical wire format) and the hash itself
+      is a hex SHA-1 digest.
 - [x] `./quality.sh` passes (modulo the pre-existing flake noted above).
 
 ## Test Plan
 
-- [x] `deno test --no-check --allow-all test/discovery/SubnetworkHashIndex.ts` — 19/19 pass.
-- [x] `deno test --no-check --allow-all test/discovery/SupplementFromCache.ts test/discovery/DiscoveryRunnerCacheSupplement.ts test/discovery/FailureCacheErrorReduction.ts test/discovery/CandidateFilteringSuccessCache.ts test/discovery/DiscoveryCacheEviction.ts` — 36/36 pass.
-- [x] `deno test --no-check --allow-all test/creature/NeuronUuidStability.ts test/creature/SemanticVersionStability.ts` — 24/24 pass.
-- [x] `deno bench --no-check --allow-all bench/SubnetworkHashLookup.ts` — confirms O(1) lookup latency at 50k entries.
-- [x] `./quality.sh --skip-discovery --skip-wasm` — full suite pass (single unrelated flake noted above).
+- [x] `deno test --no-check --allow-all test/discovery/SubnetworkHashIndex.ts` —
+      19/19 pass.
+- [x] `deno test --no-check --allow-all test/discovery/SupplementFromCache.ts test/discovery/DiscoveryRunnerCacheSupplement.ts test/discovery/FailureCacheErrorReduction.ts test/discovery/CandidateFilteringSuccessCache.ts test/discovery/DiscoveryCacheEviction.ts`
+      — 36/36 pass.
+- [x] `deno test --no-check --allow-all test/creature/NeuronUuidStability.ts test/creature/SemanticVersionStability.ts`
+      — 24/24 pass.
+- [x] `deno bench --no-check --allow-all bench/SubnetworkHashLookup.ts` —
+      confirms O(1) lookup latency at 50k entries.
+- [x] `./quality.sh --skip-discovery --skip-wasm` — full suite pass (single
+      unrelated flake noted above).

--- a/docs/pr-summary-2536.md
+++ b/docs/pr-summary-2536.md
@@ -1,0 +1,49 @@
+# PR Summary — Issue #2536
+
+## Summary
+
+Adds the DeepSeek V3 applicability research note at
+`docs/research/deepseek-v3-applicability.md`. The note maps each notable V3
+technique (Multi-Token Prediction, node-limited routing, sequence-wise
+auxiliary-loss-free balancing, FP8 mixed precision, DualPipe, shared-output-head
+ensemble) onto its closest NEAT-AI surface, records GO / NO-GO with a
+one-paragraph rationale, names a proposed experimental sub-issue title and
+outline for each GO, and explicitly distinguishes V3 additions from V2 (covered
+in #2535). Documentation only; no source-code changes. Closes #2536.
+
+## Evidence
+
+This is a documentation-only change. The note includes a Mermaid diagram
+mapping V3 ideas to NEAT-AI modules, a summary table with effort sizing, and
+per-idea risk screens against the UUID-stability and semantic-version
+invariants from `AGENTS.md`.
+
+```mermaid
+flowchart LR
+    Issue[Issue #2536] --> Note[docs/research/deepseek-v3-applicability.md]
+    Note --> Mapping[6 V3 ideas → NEAT-AI modules]
+    Mapping --> GO[4 GO recommendations<br/>with sub-issue outlines]
+    Mapping --> NOGO[2 NO-GO with rationale<br/>FP8 + sequence-wise aux-loss-free]
+```
+
+`./quality.sh --lint-only` runs cleanly (formatting + lint + bash check pass).
+The note covers all six items required by the issue's acceptance criteria:
+
+- [x] `docs/research/deepseek-v3-applicability.md` exists and covers all six
+  ideas.
+- [x] Each idea has GO or NO-GO with a one-paragraph rationale.
+- [x] Each GO recommendation includes a proposed experimental sub-issue title
+  and outline (not yet created).
+- [x] Differences vs V2 (covered in #2535) are explicit so the reader knows
+  which paper introduced what.
+- [x] FP8 entry checks WASM toolchain status before recommending NO-GO.
+- [x] Mermaid diagram of V3 idea → NEAT-AI module mapping.
+- [x] No source-code changes; documentation-only PR.
+- [x] `./quality.sh --lint-only` passes.
+
+## Test Plan
+
+- Documentation-only change; no new tests added.
+- Quality gate: `./quality.sh --lint-only < /dev/null` — passes (formatting,
+  lint, bash check all green).
+- Mermaid blocks render in GitHub Pages; no Liquid syntax in prose.

--- a/docs/research/deepseek-v3-applicability.md
+++ b/docs/research/deepseek-v3-applicability.md
@@ -1,0 +1,348 @@
+# DeepSeek V3 Applicability to NEAT-AI (Issue #2536)
+
+This research note maps each notable DeepSeek V3 technique onto NEAT-AI's
+existing architecture (memetic evolution, MCMC acceptance, speciation, breeding,
+backprop, multi-threading) and records a GO / NO-GO recommendation with a
+one-paragraph rationale per item. It complements the V4 note (#2526) and the
+MoE/V2 note (#2535), and is the foundation document for any experimental
+sub-issues spawned from #2536.
+
+> **Source.** DeepSeek-AI, _DeepSeek-V3 Technical Report_, December 2024.
+> [`arXiv:2412.19437`](https://arxiv.org/abs/2412.19437). Citations below use
+> the form _(V3 §x.y)_ and refer to that PDF.
+>
+> **Scope.** Documentation only. No source-code changes. Each GO recommendation
+> is paired with a proposed experimental sub-issue title and outline; this note
+> does not pre-empt those experiments.
+>
+> **Prior art.** V2-introduced auxiliary-loss-free expert balancing is covered
+> in the MoE note (#2535). This note focuses on what V3 adds **on top of V2** so
+> the reader knows which paper introduced what.
+
+## Summary table
+
+| # | V3 idea                                                 | Closest NEAT-AI surface                              | Recommendation | Effort | Proposed sub-issue title                                                        |
+| - | ------------------------------------------------------- | ---------------------------------------------------- | -------------- | ------ | ------------------------------------------------------------------------------- |
+| 1 | Multi-Token Prediction (MTP)                            | `src/costs/`, `src/propagate/BackPropagation.ts`     | **GO**         | M      | "MTP-style multi-step auxiliary cost head for sequence/regression creatures"    |
+| 2 | Node-limited routing                                    | `src/breed/ParallelBreeding.ts`, `BreedingQuotas.ts` | **GO**         | S      | "Per-generation cross-species partner quota (node-limited cross-breeding)"      |
+| 3 | Sequence-wise auxiliary-loss-free balancing (V3 add-on) | `src/NEAT/Species.ts`, `Genus.ts`                    | **NO-GO**      | M      | —                                                                               |
+| 4 | FP8 mixed-precision training                            | `src/propagate/`, `wasm_activation/pkg/`             | **NO-GO**      | L      | —                                                                               |
+| 5 | DualPipe (overlapping compute & communication)          | `src/multithreading/WorkerPool.ts`                   | **GO**         | M      | "Overlap backprop and discovery dispatch on the same creature (DualPipe-style)" |
+| 6 | Shared-output-head ensemble                             | Canonical `output-N` UUIDs                           | **GO** (audit) | S      | "Audit shared `output-N` UUID identity across MTP-style ensemble heads"         |
+
+## Idea → Module mapping diagram
+
+```mermaid
+flowchart LR
+    V3[DeepSeek V3 ideas] --> Doc[deepseek-v3-applicability.md]
+
+    Doc --> MTP[Multi-Token Prediction<br/>= multi-step aux cost head]
+    Doc --> NLR[Node-limited routing<br/>= partner quota per generation]
+    Doc --> DP[DualPipe overlap<br/>= worker-thread pipeline]
+    Doc --> Share[Shared output head<br/>= canonical output-N UUID]
+
+    Doc -. NO-GO .-> SeqAux[Sequence-wise aux-loss-free<br/>extension of V2 #2535]
+    Doc -. NO-GO .-> FP8[FP8 mixed precision]
+
+    MTP --> Costs[src/costs/]
+    MTP --> Prop[src/propagate/BackPropagation.ts]
+    NLR --> Breed[src/breed/ParallelBreeding.ts<br/>src/NEAT/BreedingQuotas.ts]
+    DP --> Workers[src/multithreading/WorkerPool.ts]
+    Share --> Neuron[src/neuron/NeuronSerialization.ts<br/>output-N canonical UUID]
+```
+
+## 1. Multi-Token Prediction (MTP) — **GO**
+
+**Technical summary.** MTP (V3 §2.2) augments next-token prediction with an
+auxiliary objective that predicts the next _D_ tokens jointly during training.
+Each future-step head shares a backbone with the primary head; the aggregate
+loss is the primary cross-entropy plus a weighted sum of the _D-1_ auxiliary
+cross-entropies. The win is denser supervisory signal per training step and a
+modest measured improvement on standard benchmarks. At inference, the auxiliary
+heads are dropped (or repurposed for speculative decoding) — they exist purely
+to enrich the gradient.
+
+**Closest NEAT-AI surface.** The cost surface
+([`src/costs/CostInterface.ts`](../../src/costs/CostInterface.ts) and concrete
+costs MAE/MSE/MSLE/MAPE/CrossEntropy/HINGE) currently provides a single scalar
+loss against a single target vector. Backprop in
+[`src/propagate/BackPropagation.ts`](../../src/propagate/BackPropagation.ts)
+runs one local gradient pass per training row.
+
+**Rationale (GO).** For sequence and regression problems with multi-step
+horizons, training each creature to also predict t+2, t+3 in parallel as an
+auxiliary cost head gives the same denser supervision benefit MTP does for
+language models, without changing the forward-only creature topology. The
+existing canonical `output-N` UUID scheme (see §6 below) means a creature can
+expose K logical output channels and the trainer can ask the dataset for K
+shifted target columns; the auxiliary contributions are weighted into the same
+scalar loss the existing cost interface returns. The experiment in the proposed
+sub-issue will measure whether the auxiliary signal accelerates per-iteration
+error decay on regression benchmarks where multi-step targets are available.
+
+**Risk.** Low for the UUID invariant (no new neuron rewrites), and low for
+`semanticVersion` (training does not change the version field). The principal
+risk is **target-column availability** — many existing datasets have only a
+single target horizon, so the experiment must be gated on dataset shape and must
+default off. A second risk is loss-weighting pathology: if the auxiliary weights
+are too high, primary-target accuracy degrades; the experiment must sweep
+auxiliary-loss weight and report primary-only metrics.
+
+**Effort.** **M.** New `MultiTargetCostInterface` extension, plumbing through
+the per-row training loop, and a target-column adapter for `DataSet.ts`.
+
+**Proposed experimental sub-issue.** _"MTP-style multi-step auxiliary cost head
+for sequence/regression creatures"_ — implement an opt-in auxiliary-target cost
+wrapper, sweep auxiliary weight ∈ {0.05, 0.1, 0.2, 0.5}, and report
+primary-target error and convergence-iteration count on the standard ED-fold
+benchmarks. Acceptance gates on a measurable improvement in primary-target error
+per iteration with auxiliary weight ≤ 0.5.
+
+## 2. Node-limited routing — **GO**
+
+**Technical summary.** Node-limited routing (V3 §2.1.2) restricts each input
+token to route to at most _M_ nodes (devices) per step, where typically _M_ ≪
+total experts. The constraint bounds cross-device communication during MoE
+training and inference, trading a small accuracy delta for a large
+communication-cost reduction.
+
+**Closest NEAT-AI surface.** Cross-species breeding in
+[`src/breed/ParallelBreeding.ts`](../../src/breed/ParallelBreeding.ts) and the
+quota machinery in
+[`src/NEAT/BreedingQuotas.ts`](../../src/NEAT/BreedingQuotas.ts) already enforce
+**how many** offspring each species produces per generation; what is missing is
+a budget on **how many distinct partner species** each species can pair with per
+generation.
+
+**Rationale (GO).** Mapping V3's per-token node budget onto NEAT-AI's
+per-generation breeding budget is direct: cap the number of partner species a
+given species may breed across in a single generation at _M_. This bounds the
+fan-out of cross-species breeding (which is the noisiest crossover path in
+NEAT-AI) and gives the population a stable, configurable "communication
+diameter" without losing the long-range diversity benefit cross-species breeding
+provides. The experiment will measure species count, Shannon diversity, and
+best-fitness convergence under _M_ ∈ {1, 2, 4, ∞} (∞ being the current
+behaviour).
+
+**Risk.** Low. UUIDs and semantic versions are not touched — this is a quota,
+not a topology change. The realistic risk is **diversity collapse** when _M_ is
+too small: the experiment must report Shannon diversity time series and
+species-count time series alongside fitness, not fitness alone.
+
+**Effort.** **S.** Quota table extension and a counter in the parallel-breeding
+loop.
+
+**Proposed experimental sub-issue.** _"Per-generation cross-species partner
+quota (node-limited cross-breeding)"_ — add a `maxCrossSpeciesPartnersPerGen`
+config knob (default ∞), sweep _M_ ∈ {1, 2, 4, ∞}, and compare fitness and
+diversity trajectories across 50 generations on the standard ED-fold harness.
+Acceptance gates on diversity preservation at _M_ = 4 within 5 % of the _M_ = ∞
+baseline while reducing total breeding work by ≥ 25 %.
+
+## 3. Sequence-wise auxiliary-loss-free balancing — **NO-GO**
+
+**Technical summary.** V3 (§2.1.3) extends the V2 auxiliary-loss-free balancing
+mechanism by adding a **sequence-level** rebalancing layer on top of V2's
+**expert-level** bias-only correction. V2 nudges the routing bias for each
+expert based on **its** running selection rate; V3 additionally tracks the
+distribution **across an entire input sequence** and applies a small extra
+correction so that no single sequence is monopolised by a small subset of
+experts. The expert-level mechanism is doing most of the work; the sequence-
+level addition is reported in V3 as a small, measurable accuracy boost.
+
+**What V3 adds beyond V2.** V2 = per-expert bias correction (covered in #2535).
+V3 = same plus per-sequence rebalancing, applied at a different time scale (per
+sequence rather than per training step).
+
+**Closest NEAT-AI surface.** [`src/NEAT/Species.ts`](../../src/NEAT/Species.ts)
+and [`src/NEAT/Genus.ts`](../../src/NEAT/Genus.ts), where #2535's V2 expert-
+level bias-only correction would land.
+
+**Rationale (NO-GO).** NEAT-AI does not have a "sequence" abstraction. The V2
+expert-level mechanism maps onto species selection rates, which is a useful and
+well-defined target (#2535). The V3 sequence-level addition presupposes a
+contiguous run of correlated routing decisions inside a single training example
+— there is no analogue to that in NEAT-AI's per-row training loop or in its
+breeding step (each breeding event is independent and has no sequential
+neighbour). Forcing one would require inventing a synthetic "sequence" (e.g. a
+mini-batch of training rows) and then proving that mini-batch correlations
+matter, which is speculative without prior evidence. Revisit only if NEAT-AI
+adopts mini-batch training where intra-batch correlations are observed to skew
+species-selection.
+
+**Risk.** N/A (not adopted).
+
+**Effort.** **M** if pursued; would need a synthetic sequence definition plus a
+counter on top of #2535's bias-correction work.
+
+## 4. FP8 mixed-precision training — **NO-GO**
+
+**Technical summary.** V3 (§3.3) trains with FP8 weights and activations using
+fine-grained tile-wise scaling and fallback FP32 accumulation for sensitive ops.
+The win is roughly 2× memory bandwidth and 1.5–2× throughput on hardware with
+native FP8 matmul (NVIDIA Hopper / Blackwell). The cost is quantisation-aware
+engineering (per-channel scales, stochastic rounding, sensitivity profiling).
+
+**Closest NEAT-AI surface.**
+[`src/propagate/BackPropagation.ts`](../../src/propagate/BackPropagation.ts)
+weights are FP64 (TypeScript `number`); WASM-side activation buffers are FP32 or
+FP64 depending on path.
+
+**WASM toolchain check.** The vendored runtime under `wasm_activation/pkg/`
+exposes `Float32Array` / `Float64Array` import/export typed-array bridges only.
+There is no FP8 type in the WebAssembly core spec (the WASM SIMD proposal covers
+`i8x16` / `f32x4` / `f64x2`), and no FP8 backend is exposed from NEAT-AI-core at
+the pinned rev. A grep over the vendored runtime confirms no FP8 path is
+present. This matches the V4 note's earlier dismissal (#2526).
+
+**Rationale (NO-GO).** Two independent reasons: **(a) scale** — NEAT-AI
+populations are typically hundreds-to-thousands of small networks, and per-
+creature memory is dwarfed by per-creature bookkeeping (UUID strings, mutation
+history, discovery cache entries); **(b) toolchain** — WASM has no native FP8
+type, NEAT-AI-core does not expose one at the pinned rev, and emulating FP8 with
+int8 storage plus per-channel scales would pay the quantisation tax (per-neuron
+scale tracking, stochastic-round RNG state) without recovering it on small
+genomes. Revisit only if (i) WASM gains an FP8 type, **and** (ii) a
+single-creature regime emerges where one frozen genome dominates RAM (e.g. a
+distilled generalist served at scale).
+
+**Risk.** N/A (not adopted).
+
+**Effort.** **L** if pursued; would need a parity-gate workstream in
+NEAT-AI-core (per `docs/PARITY_GATE.md`) before any TS-side changes.
+
+## 5. DualPipe — overlapping compute & communication — **GO**
+
+**Technical summary.** DualPipe (V3 §3.2.2) is a parallel-pipeline schedule in
+which forward and backward passes for adjacent micro-batches are **interleaved
+across pipeline stages** so that compute on stage _i_ overlaps with
+communication between stages _i_ and _i+1_. The win is reduced pipeline-bubble
+time at large pipeline-depth × micro-batch counts.
+
+**Closest NEAT-AI surface.**
+[`src/multithreading/WorkerPool.ts`](../../src/multithreading/WorkerPool.ts) and
+the workers under `src/multithreading/workers/` already split per-creature work
+(activation, scoring, backprop, discovery dispatch) across worker threads. Today
+these are serialised per creature: backprop completes, then discovery is
+dispatched.
+
+**Rationale (GO).** The DualPipe principle — overlap **compute** with
+**communication** — applies cleanly to NEAT-AI's worker-thread model: while
+backprop runs on a creature's incoming-weight matrices, the orchestrator can
+already prepare the **discovery rustRequest** payload (UUID-only wire format per
+AGENTS.md "Discovery/cache/FFI wire contract"), serialise it, and ship it to the
+discovery worker so that when backprop completes the discovery hint is already
+in flight. The gain is wall-clock latency per creature, which compounds across
+the population. The proposed sub-issue is a benchmark-first task per the
+Performance Task Workflow: instrument the per-creature pipeline, measure
+backprop / discovery / serialisation wall-clock components, and only adopt the
+overlap if the measured saving is ≥ 10 % of total per-creature cost.
+
+**Risk.** Low for UUIDs / semver — no creature topology change. Higher for
+**concurrency hazards**: if the discovery payload references intermediate
+backprop state (e.g. running gradient norms), the overlap would race; the
+experiment must enumerate the payload's data dependencies and prove the overlap
+is sound before measuring speedup. See AGENTS.md "Discovery/cache/FFI wire
+contract" — payloads must be UUID-only, and any runtime-integer-id resolution
+must happen at the last internal step, **after** backprop has released the
+integer-id table.
+
+**Effort.** **M.** Per-creature pipeline instrumentation (a benchmark in
+`bench/`), a feature-flagged overlap implementation in `WorkerPool.ts`, and a
+tighter wire-format check on the discovery payload.
+
+**Proposed experimental sub-issue.** _"Overlap backprop and discovery dispatch
+on the same creature (DualPipe-style)"_ — instrument first, implement only if
+the measured saving is ≥ 10 % of per-creature wall-clock; report before/after
+benchmark numbers in the PR per the Performance Task Workflow.
+
+## 6. Shared-output-head ensemble — **GO** (audit-only)
+
+**Technical summary.** V3 (§2.2) shares the **output projection** across MTP
+heads — i.e. the final linear layer that produces logits is shared between the
+primary next-token head and the auxiliary _D-1_ future-token heads. The benefit
+is parameter sharing and consistent output-distribution geometry across the
+auxiliary heads.
+
+**Closest NEAT-AI surface.** Canonical output-neuron identity in
+[`src/neuron/NeuronSerialization.ts`](../../src/neuron/NeuronSerialization.ts):
+output neurons are addressed by the canonical wire UUID `output-N` (where N is
+the output index). This identity is shared **across all creatures** in a
+population by construction — every creature's _N_-th output neuron carries the
+same `output-N` wire UUID, regardless of which species or generation it
+originated from.
+
+**Rationale (GO — audit-only).** The shared-output-head property V3 needs is
+**already true** in NEAT-AI by virtue of the canonical `output-N` UUID contract.
+Two creatures' _N_-th output channels are aligned by UUID at every boundary that
+matters (export JSON, breeding, discovery FFI). The "GO" here is therefore not
+an experimental sub-issue that adds new behaviour — it is a **confirmation
+audit** that should be folded into the MTP sub-issue (§1) so that, when
+MTP-style auxiliary heads are introduced, the audit explicitly verifies that the
+auxiliary heads continue to use canonical `output-N` UUIDs for cross-creature
+alignment and do **not** mint fresh UUIDs per head per creature.
+
+**Risk.** Low — this is the existing invariant. The risk is **regression**: if
+the MTP experiment accidentally mints a new UUID per auxiliary head, breeding
+across machines would fail to align auxiliary outputs. The audit test must fail
+loudly in that case.
+
+**Effort.** **S.** A single audit test under `test/neuron/` that builds two
+sibling creatures, exposes _D_ output channels each, and asserts that the _N_-th
+channel carries the same `output-N` wire UUID across both. Folded into the MTP
+sub-issue's test plan.
+
+**Proposed experimental sub-issue.** _"Audit shared `output-N` UUID identity
+across MTP-style ensemble heads"_ — folded into the MTP sub-issue (§1) as a
+test-only acceptance gate; not a standalone experiment.
+
+## Cross-cutting invariants
+
+Every GO recommendation has been screened against the two critical invariants in
+AGENTS.md:
+
+- **Neuron UUID stability.** None of the GO experiments rewrite an existing
+  neuron's UUID. MTP (§1) reuses the canonical `output-N` UUID; node-limited
+  routing (§2) is a quota and does not touch topology; DualPipe (§5) is a
+  scheduling change; the shared-output-head audit (§6) is the existing
+  invariant.
+- **Semantic version immutability.** None of the GO experiments add a pipeline
+  step that re-bumps `semanticVersion`. Training loop changes, quota changes,
+  and worker-pool scheduling changes do not interact with the version field.
+
+Every payload that crosses a process, machine, disk, cache, or FFI boundary in
+the experiments above must continue to use **UUID-only wire formats** (per
+AGENTS.md "Discovery/cache/FFI wire contract"). The DualPipe overlap (§5) is the
+most likely place to slip on this rule and so its sub-issue must include a
+wire-format test that asserts no runtime integer ids appear in the discovery
+payload.
+
+## Differences vs the V2 / MoE note (#2535)
+
+For the reader switching between notes:
+
+- **V2 (#2535) introduces** auxiliary-loss-free expert balancing at the **expert
+  level** (per-expert bias-only routing correction) and fine-grained
+  - shared experts.
+- **V3 (this note) introduces** Multi-Token Prediction, FP8 mixed-precision
+  training, node-limited routing, DualPipe pipeline overlap, and shared
+  output-head MTP ensembles. V3 also **extends** V2's aux-loss-free balancing
+  with a **sequence-level** correction (§3 here, **NO-GO**); the expert-level V2
+  mechanism is the part that maps cleanly onto NEAT-AI speciation and is owned
+  by #2535.
+
+When a sub-issue cites "aux-loss-free balancing" without qualification, it means
+the V2 expert-level mechanism owned by #2535. The V3 sequence-level extension is
+explicitly out of scope.
+
+## What this note does not do
+
+- It does not prescribe implementation — each GO experiment owns its own design
+  in its sub-issue.
+- It does not commit to merging any experiment to `Develop`. Sub-issues must
+  produce benchmark evidence (per the Performance Task Workflow in AGENTS.md)
+  before adoption.
+- It does not re-open V3 ideas marked NO-GO. If circumstances change (e.g. WASM
+  gains an FP8 type, or NEAT-AI adopts mini-batch training where intra- batch
+  correlations skew species selection), open a new follow-up issue rather than
+  re-litigating here.


### PR DESCRIPTION
# PR Summary — Issue #2536

## Summary

Adds the DeepSeek V3 applicability research note at
`docs/research/deepseek-v3-applicability.md`. The note maps each notable V3
technique (Multi-Token Prediction, node-limited routing, sequence-wise
auxiliary-loss-free balancing, FP8 mixed precision, DualPipe, shared-output-head
ensemble) onto its closest NEAT-AI surface, records GO / NO-GO with a
one-paragraph rationale, names a proposed experimental sub-issue title and
outline for each GO, and explicitly distinguishes V3 additions from V2 (covered
in #2535). Documentation only; no source-code changes. Closes #2536.

## Evidence

This is a documentation-only change. The note includes a Mermaid diagram
mapping V3 ideas to NEAT-AI modules, a summary table with effort sizing, and
per-idea risk screens against the UUID-stability and semantic-version
invariants from `AGENTS.md`.

```mermaid
flowchart LR
    Issue[Issue #2536] --> Note[docs/research/deepseek-v3-applicability.md]
    Note --> Mapping[6 V3 ideas → NEAT-AI modules]
    Mapping --> GO[4 GO recommendations<br/>with sub-issue outlines]
    Mapping --> NOGO[2 NO-GO with rationale<br/>FP8 + sequence-wise aux-loss-free]
```

`./quality.sh --lint-only` runs cleanly (formatting + lint + bash check pass).
The note covers all six items required by the issue's acceptance criteria:

- [x] `docs/research/deepseek-v3-applicability.md` exists and covers all six
  ideas.
- [x] Each idea has GO or NO-GO with a one-paragraph rationale.
- [x] Each GO recommendation includes a proposed experimental sub-issue title
  and outline (not yet created).
- [x] Differences vs V2 (covered in #2535) are explicit so the reader knows
  which paper introduced what.
- [x] FP8 entry checks WASM toolchain status before recommending NO-GO.
- [x] Mermaid diagram of V3 idea → NEAT-AI module mapping.
- [x] No source-code changes; documentation-only PR.
- [x] `./quality.sh --lint-only` passes.

## Test Plan

- Documentation-only change; no new tests added.
- Quality gate: `./quality.sh --lint-only < /dev/null` — passes (formatting,
  lint, bash check all green).
- Mermaid blocks render in GitHub Pages; no Liquid syntax in prose.



## Milestone
This PR is part of the **Research DeepSeek** milestone and targets the `milestone/research-deepseek` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2536 -->