### PR TITLE
Forward-only post-condition on exportJSONWithRuntimeIds (#2546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `[loadFrom] Recurrent synapse … source=fromJSON` `TopologyError` throws on
   every load even after Issue #2515 wired
   `assertNoRecurrentSynapseOnForwardOnly` into the discovery combiners and the
-  public `exportJSON` save path. The audit missed `exportJSONWithRuntimeIds`:
-  it is the internal export that worker training (`WorkerProcessor`),
-  evolution scheduling (`NeatScheduling`), training teardown / outcome /
-  setup, compaction (`CompactUnused`), discovery replay
-  (`ReplayEntryApplication`), knowledge distillation, and the legacy upgrade
-  pipeline all route through. A forward-only creature that gained a
-  recurrent synapse upstream could be persisted by any of those paths and
-  surfaced only as a load-side throw on the next worker. Mirroring the
-  assertion in `exportJSONWithRuntimeIds` pins the producer's stack frame so
-  the offending pipeline is named directly. Pre-4.x upgrade paths are
-  unaffected because the `forwardOnly` flag was introduced with 4.x — the
-  assertion is a no-op when `creature.forwardOnly !== true`.
+  public `exportJSON` save path. The audit missed `exportJSONWithRuntimeIds`: it
+  is the internal export that worker training (`WorkerProcessor`), evolution
+  scheduling (`NeatScheduling`), training teardown / outcome / setup, compaction
+  (`CompactUnused`), discovery replay (`ReplayEntryApplication`), knowledge
+  distillation, and the legacy upgrade pipeline all route through. A
+  forward-only creature that gained a recurrent synapse upstream could be
+  persisted by any of those paths and surfaced only as a load-side throw on the
+  next worker. Mirroring the assertion in `exportJSONWithRuntimeIds` pins the
+  producer's stack frame so the offending pipeline is named directly. Pre-4.x
+  upgrade paths are unaffected because the `forwardOnly` flag was introduced
+  with 4.x — the assertion is a no-op when `creature.forwardOnly !== true`.
 - **Issue #2523:** Breed-time fail-soft for corrupt parents. `findFather` now
   wraps the per-candidate `Creature.fromJSON(...)` call in a
   `try/catch (TopologyError)` block: a single corrupt parent is skipped with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Issue #2546:** Forward-only post-condition on `exportJSONWithRuntimeIds`.
+  Production GRQ logs continued to show
+  `[loadFrom] Recurrent synapse … source=fromJSON` `TopologyError` throws on
+  every load even after Issue #2515 wired
+  `assertNoRecurrentSynapseOnForwardOnly` into the discovery combiners and the
+  public `exportJSON` save path. The audit missed `exportJSONWithRuntimeIds`:
+  it is the internal export that worker training (`WorkerProcessor`),
+  evolution scheduling (`NeatScheduling`), training teardown / outcome /
+  setup, compaction (`CompactUnused`), discovery replay
+  (`ReplayEntryApplication`), knowledge distillation, and the legacy upgrade
+  pipeline all route through. A forward-only creature that gained a
+  recurrent synapse upstream could be persisted by any of those paths and
+  surfaced only as a load-side throw on the next worker. Mirroring the
+  assertion in `exportJSONWithRuntimeIds` pins the producer's stack frame so
+  the offending pipeline is named directly. Pre-4.x upgrade paths are
+  unaffected because the `forwardOnly` flag was introduced with 4.x — the
+  assertion is a no-op when `creature.forwardOnly !== true`.
 - **Issue #2523:** Breed-time fail-soft for corrupt parents. `findFather` now
   wraps the per-candidate `Creature.fromJSON(...)` call in a
   `try/catch (TopologyError)` block: a single corrupt parent is skipped with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **Issue #2546:** Forward-only post-condition on `exportJSONWithRuntimeIds`.
-  Production GRQ logs continued to show
+- **Issue #2546:** Writer-side forward-only assertion for
+  `exportJSONWithRuntimeIds()`. Production GRQ logs continued to show
   `[loadFrom] Recurrent synapse … source=fromJSON` `TopologyError` throws on
   every load even after Issue #2515 wired
   `assertNoRecurrentSynapseOnForwardOnly` into the discovery combiners and the
-  public `exportJSON` save path. The audit missed `exportJSONWithRuntimeIds`: it
-  is the internal export that worker training (`WorkerProcessor`), evolution
+  public `exportJSON` save path. The audit missed `exportJSONWithRuntimeIds` —
+  the internal export that worker training (`WorkerProcessor`), evolution
   scheduling (`NeatScheduling`), training teardown / outcome / setup, compaction
   (`CompactUnused`), discovery replay (`ReplayEntryApplication`), knowledge
-  distillation, and the legacy upgrade pipeline all route through. A
-  forward-only creature that gained a recurrent synapse upstream could be
-  persisted by any of those paths and surfaced only as a load-side throw on the
-  next worker. Mirroring the assertion in `exportJSONWithRuntimeIds` pins the
-  producer's stack frame so the offending pipeline is named directly. Pre-4.x
-  upgrade paths are unaffected because the `forwardOnly` flag was introduced
-  with 4.x — the assertion is a no-op when `creature.forwardOnly !== true`.
+  distillation, and the worker→main wire all route through. A forward-only
+  creature that gained a recurrent synapse upstream could be persisted by any of
+  those paths and surfaced only as a load-side throw on the next worker.
+  Mirroring the assertion at `exportJSONWithRuntimeIds()` pins the producer's
+  stack frame so the offending pipeline is named directly. Repair tools and
+  legacy upgrade paths that legitimately need to serialise a not-yet-repaired
+  creature use the new `exportJSONWithRuntimeIdsUnchecked()` companion (the
+  `upgrade()` / `upgradeTwo()` legacy 1.x/2.x repair pipeline, and the
+  `NeatScheduling` training-failure diagnostic write that already runs after a
+  thrown training error and must not chain a second throw that masks the root
+  cause), each with a code comment naming the bypass.
+
 - **Issue #2523:** Breed-time fail-soft for corrupt parents. `findFather` now
   wraps the per-candidate `Creature.fromJSON(...)` call in a
   `try/catch (TopologyError)` block: a single corrupt parent is skipped with a

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -151,6 +151,7 @@
     "Graphviz",
     "groupinstall",
     "Günter",
+    "HYPOT",
     "headerless",
     "heapify",
     "Hebbian",

--- a/docs/pr-summary-2546.md
+++ b/docs/pr-summary-2546.md
@@ -1,0 +1,80 @@
+## Summary
+
+Wires the existing `assertNoRecurrentSynapseOnForwardOnly` post-condition
+into `exportJSONWithRuntimeIds` — the internal export path that the
+Issue #2515 audit missed. Production GRQ logs (per #2113, #2546)
+continued to throw `[loadFrom] Recurrent synapse … source=fromJSON`
+`TopologyError` on every load even after #2515 wired the assertion into
+the discovery combiners and the public `exportJSON` save path. Worker
+training, evolution scheduling, training teardown / outcome / setup,
+compaction, discovery replay, knowledge distillation, and the legacy
+upgrade pipeline all route their internal saves through
+`exportJSONWithRuntimeIds`, which had no save-side assertion. A
+forward-only creature that gained a recurrent synapse upstream could
+therefore be persisted by any of those paths and surface only as a
+load-side throw on the next worker that ingested the JSON. Mirroring
+the assertion here pins the producer's stack frame so the offending
+pipeline is named directly. Closes #2546.
+
+## Evidence
+
+Backend-only change — no UI to screenshot. Verified via:
+
+- `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` (4 new
+  tests): pins both production patterns from the issue —
+  `synapse=2057->2057 fromUUID=output-0 toUUID=output-0 depth=0`
+  (self-loop on output-0) and `synapse=4145->4143 fromUUID=output-0
+  depth=-2` (backward output→hidden). Tests fail against the unfixed
+  code (no throw) and pass after the fix (`TopologyError` named
+  `exportJSONWithRuntimeIds`).
+- All 6450 existing tests pass under `./quality.sh --skip-discovery
+  --skip-wasm`.
+- `./quality.sh --lint-only` and `deno check mod.ts` are clean.
+
+```mermaid
+flowchart LR
+    A[forward-only creature] --> B{export path}
+    B -->|public save| C[exportJSON]
+    B -->|internal save| D[exportJSONWithRuntimeIds]
+    C --> E[assertNoRecurrentSynapse<br/>OnForwardOnly]
+    D --> E
+    E -->|recurrent edge| F[TopologyError<br/>names producer]
+    E -->|ok| G[CreatureExport]
+```
+
+Producer paths now covered (already routed through
+`exportJSONWithRuntimeIds`):
+
+| Site                                        | Source tag in `TopologyError` |
+| ------------------------------------------- | ----------------------------- |
+| `WorkerProcessor` (returning trained)       | `exportJSONWithRuntimeIds`    |
+| `NeatScheduling` (backtracked / forward)    | `exportJSONWithRuntimeIds`    |
+| `CreatureTraining` (training round-trip)    | `exportJSONWithRuntimeIds`    |
+| `TrainingOutcome` / `TrainingTeardown`      | `exportJSONWithRuntimeIds`    |
+| `TrainingSetup` (best snapshot)             | `exportJSONWithRuntimeIds`    |
+| `CompactUnused` (compaction snapshots)      | `exportJSONWithRuntimeIds`    |
+| `ReplayEntryApplication` (discovery replay) | `exportJSONWithRuntimeIds`    |
+| `KnowledgeDistillation` (distilled student) | `exportJSONWithRuntimeIds`    |
+| `Upgrade` / `UpgradeTwo` (pre-4.x repair)   | no-op (forwardOnly is 4.x+)   |
+
+## Test Plan
+
+- `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` — 4 new
+  tests:
+  - passes for a valid forward-only creature.
+  - passes for a non-forward-only creature even with a recurrent edge
+    (assertion only fires on `forwardOnly === true`).
+  - throws `TopologyError` named `exportJSONWithRuntimeIds` for the
+    self-loop on output-0 pattern (issue evidence: `2057->2057
+    fromUUID=output-0 toUUID=output-0 depth=0`).
+  - throws `TopologyError` named `exportJSONWithRuntimeIds` for the
+    backward output→hidden pattern (issue evidence: `4145->4143
+    fromUUID=output-0 depth=-2`).
+- Existing tests unchanged: `ForwardOnlyAssertion`,
+  `ForwardOnlyApplyChangeLifecycle`, `NormaliseCreatureExportForwardOnly`,
+  `ForwardOnlyOutputRoundTrip`, `LoadFromObservability` — all green.
+- Full upgrade test suite (`test/upgrade/**/*.ts`) — all 49 tests green
+  (pre-4.x upgrade paths legitimately ingest corrupt input but the
+  `forwardOnly` flag is 4.x+, so the assertion is a no-op for them).
+- Full compact (`test/compact/**/*.ts`) and discovery
+  (`test/discovery/**/*.ts`) suites — 667 tests green.

--- a/docs/pr-summary-2546.md
+++ b/docs/pr-summary-2546.md
@@ -1,47 +1,78 @@
 ## Summary
 
-Wires the existing `assertNoRecurrentSynapseOnForwardOnly` post-condition into
-`exportJSONWithRuntimeIds` — the internal export path that the Issue #2515 audit
-missed. Production GRQ logs (per #2113, #2546) continued to throw
-`[loadFrom] Recurrent synapse … source=fromJSON` `TopologyError` on every load
-even after #2515 wired the assertion into the discovery combiners and the public
-`exportJSON` save path. Worker training, evolution scheduling, training teardown
-/ outcome / setup, compaction, discovery replay, knowledge distillation, and the
-legacy upgrade pipeline all route their internal saves through
-`exportJSONWithRuntimeIds`, which had no save-side assertion. A forward-only
-creature that gained a recurrent synapse upstream could therefore be persisted
-by any of those paths and surface only as a load-side throw on the next worker
-that ingested the JSON. Mirroring the assertion here pins the producer's stack
-frame so the offending pipeline is named directly. Closes #2546.
+Closes #2546.
 
-## Evidence
+Production GRQ-3/13 logs (2026-05-05/06) showed `TopologyError` firing on every
+load with `source=fromJSON` for forward-only creatures carrying the canonical
+recurrent-output signatures (`output-0 -> output-0` self-loops and backward
+`output -> hidden` edges). The Issue #2515 audit wired the forward-only
+post-condition into the `applyChangeToCreature` / `normaliseCreatureExport`
+combiners and the public `exportJSON` save path, but missed
+`exportJSONWithRuntimeIds()` — the internal export used by training, NEAT
+scheduling, knowledge distillation, discovery replay, and the worker→main wire.
+That variant historically bypassed the Issue #2511 save-side gate, so a corrupt
+forward-only creature produced anywhere in those pipelines serialised cleanly
+and only blew up at the next disk load.
 
-Backend-only change — no UI to screenshot. Verified via:
+This PR closes that producer surface:
 
-- `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` (4 new tests): pins
-  both production patterns from the issue —
-  `synapse=2057->2057 fromUUID=output-0 toUUID=output-0 depth=0` (self-loop on
-  output-0) and `synapse=4145->4143 fromUUID=output-0
-  depth=-2` (backward
-  output→hidden). Tests fail against the unfixed code (no throw) and pass after
-  the fix (`TopologyError` named `exportJSONWithRuntimeIds`).
-- All 6450 existing tests pass under
-  `./quality.sh --skip-discovery
-  --skip-wasm`.
-- `./quality.sh --lint-only` and `deno check mod.ts` are clean.
+- `exportJSONWithRuntimeIds()` now runs
+  `assertNoRecurrentSynapseOnForwardOnly(creature, "exportJSONWithRuntimeIds")`
+  as a save-side post-condition, naming itself in the thrown `TopologyError`'s
+  message. Pre-4.x upgrade callers are unaffected — `forwardOnly` was introduced
+  with 4.x, so the assertion is a no-op when `creature.forwardOnly !== true`.
+- A new sibling, `exportJSONWithRuntimeIdsUnchecked()`, mirrors
+  `exportJSONUnchecked()` for the small set of legitimate bypass cases:
+  - The `upgrade()` legacy v0/v1 path and `upgradeTwo()`'s `removeHYPOT*` passes
+    that operate on creatures pre-`fix()` (recurrent edges may still be present
+    and are repaired by the upgrader).
+  - The `NeatScheduling` training-failure diagnostic write that already runs
+    after a thrown training error and must not chain a second throw that masks
+    the root cause.
+- All other call sites (`WorkerProcessor` train wire response, `NeatScheduling`
+  fine-tune backtrack/forward variants, `KnowledgeDistillation`,
+  `TrainingOutcome`/`TrainingTeardown`/`TrainingSetup`, `CreatureTraining`,
+  `ReplayEntryApplication`, `CompactUnused`) now flow through the checked
+  variant — any future regression that builds a recurrent forward-only synapse
+  will be caught at the export site, with the producing pipeline's stack frame
+  intact.
+- `CHANGELOG.md` documents the writer-side gate and version is bumped to
+  `3.3.6`.
 
 ```mermaid
 flowchart LR
-    A[forward-only creature] --> B{export path}
-    B -->|public save| C[exportJSON]
-    B -->|internal save| D[exportJSONWithRuntimeIds]
-    C --> E[assertNoRecurrentSynapse<br/>OnForwardOnly]
-    D --> E
-    E -->|recurrent edge| F[TopologyError<br/>names producer]
-    E -->|ok| G[CreatureExport]
+    P[Producer pipeline<br/>training / scheduling /<br/>replay / KD / worker]
+    --> E[exportJSONWithRuntimeIds]
+    E -->|forwardOnly + recurrent| T[TopologyError<br/>names producer<br/>+ stack frame]
+    E -->|ok| W[wire / disk JSON]
+    R[Repair tool<br/>upgrade / diagnostic write]
+    --> U[exportJSONWithRuntimeIdsUnchecked]
+    U --> W
+    W --> L[Creature.fromJSON<br/>load-side gate]
+    L -->|forwardOnly + recurrent| T
 ```
 
-Producer paths now covered (already routed through `exportJSONWithRuntimeIds`):
+## Evidence
+
+Backend-only library change — no UI to screenshot. Verified via:
+
+- Unit tests in `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts`
+  covering both production-observed signatures (output-0 self-loop and backward
+  output→hidden) plus the two no-op cases (valid forward-only, and
+  feedback-enabled with a legitimate recurrent edge). Tests fail against the
+  unfixed code (no throw) and pass after the fix (`TopologyError` named
+  `exportJSONWithRuntimeIds`).
+- Touched test suites pass cleanly:
+  - `test/architecture/` — 425 tests pass.
+  - `test/upgrade/`, `test/compact/`, `test/creature/`, `test/discovery/`
+    combined — 965 tests pass (covers the rerouted upgrade and compaction bypass
+    paths and the load-side throw).
+  - `./quality.sh --skip-discovery --skip-wasm` — 6453 passed, 0 failed, 4
+    ignored.
+  - `./quality.sh --lint-only` and `--check-only` — clean.
+
+Producer paths now covered (already routed through the checked
+`exportJSONWithRuntimeIds`):
 
 | Site                                        | Source tag in `TopologyError` |
 | ------------------------------------------- | ----------------------------- |
@@ -53,27 +84,34 @@ Producer paths now covered (already routed through `exportJSONWithRuntimeIds`):
 | `CompactUnused` (compaction snapshots)      | `exportJSONWithRuntimeIds`    |
 | `ReplayEntryApplication` (discovery replay) | `exportJSONWithRuntimeIds`    |
 | `KnowledgeDistillation` (distilled student) | `exportJSONWithRuntimeIds`    |
-| `Upgrade` / `UpgradeTwo` (pre-4.x repair)   | no-op (forwardOnly is 4.x+)   |
+
+Bypass paths now routed to the unchecked sibling (with a code comment naming the
+bypass):
+
+| Site                                         | Reason                           |
+| -------------------------------------------- | -------------------------------- |
+| `Upgrade.upgrade` (1.x → 2.x, 0.x → 1.0.0)   | legacy genome pre-`fix()` repair |
+| `UpgradeTwo.removeHYPOT` / `removeHYPOTv2`   | legacy HYPOT removal pre-`fix()` |
+| `NeatScheduling` training-failure diagnostic | already on a thrown error path   |
 
 ## Test Plan
 
-- `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` — 4 new tests:
+- [x] `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` — 4 cases:
   - passes for a valid forward-only creature.
   - passes for a non-forward-only creature even with a recurrent edge (assertion
     only fires on `forwardOnly === true`).
   - throws `TopologyError` named `exportJSONWithRuntimeIds` for the self-loop on
     output-0 pattern (issue evidence:
-    `2057->2057
-    fromUUID=output-0 toUUID=output-0 depth=0`).
+    `2057->2057 fromUUID=output-0
+    toUUID=output-0 depth=0`).
   - throws `TopologyError` named `exportJSONWithRuntimeIds` for the backward
     output→hidden pattern (issue evidence:
-    `4145->4143
-    fromUUID=output-0 depth=-2`).
-- Existing tests unchanged: `ForwardOnlyAssertion`,
-  `ForwardOnlyApplyChangeLifecycle`, `NormaliseCreatureExportForwardOnly`,
-  `ForwardOnlyOutputRoundTrip`, `LoadFromObservability` — all green.
-- Full upgrade test suite (`test/upgrade/**/*.ts`) — all 49 tests green (pre-4.x
-  upgrade paths legitimately ingest corrupt input but the `forwardOnly` flag is
-  4.x+, so the assertion is a no-op for them).
-- Full compact (`test/compact/**/*.ts`) and discovery (`test/discovery/**/*.ts`)
-  suites — 667 tests green.
+    `4145->4143 fromUUID=output-0
+    depth=-2`).
+- [x] Existing `ForwardOnlyAssertion` and `LoadFromForwardOnlyThrow` suites
+      unchanged and still pass.
+- [x] `ShallowCloneRuntimeIds` (legacy round-trip via
+      `exportJSONWithRuntimeIds + fromJSON`) unchanged and still passes —
+      confirms the new gate does not regress valid forward-only round-trips.
+- [x] Full upgrade and compact suites pass — confirms the rerouted bypass paths
+      still serialise legacy/in-repair creatures.

--- a/docs/pr-summary-2546.md
+++ b/docs/pr-summary-2546.md
@@ -1,33 +1,32 @@
 ## Summary
 
-Wires the existing `assertNoRecurrentSynapseOnForwardOnly` post-condition
-into `exportJSONWithRuntimeIds` — the internal export path that the
-Issue #2515 audit missed. Production GRQ logs (per #2113, #2546)
-continued to throw `[loadFrom] Recurrent synapse … source=fromJSON`
-`TopologyError` on every load even after #2515 wired the assertion into
-the discovery combiners and the public `exportJSON` save path. Worker
-training, evolution scheduling, training teardown / outcome / setup,
-compaction, discovery replay, knowledge distillation, and the legacy
-upgrade pipeline all route their internal saves through
-`exportJSONWithRuntimeIds`, which had no save-side assertion. A
-forward-only creature that gained a recurrent synapse upstream could
-therefore be persisted by any of those paths and surface only as a
-load-side throw on the next worker that ingested the JSON. Mirroring
-the assertion here pins the producer's stack frame so the offending
-pipeline is named directly. Closes #2546.
+Wires the existing `assertNoRecurrentSynapseOnForwardOnly` post-condition into
+`exportJSONWithRuntimeIds` — the internal export path that the Issue #2515 audit
+missed. Production GRQ logs (per #2113, #2546) continued to throw
+`[loadFrom] Recurrent synapse … source=fromJSON` `TopologyError` on every load
+even after #2515 wired the assertion into the discovery combiners and the public
+`exportJSON` save path. Worker training, evolution scheduling, training teardown
+/ outcome / setup, compaction, discovery replay, knowledge distillation, and the
+legacy upgrade pipeline all route their internal saves through
+`exportJSONWithRuntimeIds`, which had no save-side assertion. A forward-only
+creature that gained a recurrent synapse upstream could therefore be persisted
+by any of those paths and surface only as a load-side throw on the next worker
+that ingested the JSON. Mirroring the assertion here pins the producer's stack
+frame so the offending pipeline is named directly. Closes #2546.
 
 ## Evidence
 
 Backend-only change — no UI to screenshot. Verified via:
 
-- `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` (4 new
-  tests): pins both production patterns from the issue —
-  `synapse=2057->2057 fromUUID=output-0 toUUID=output-0 depth=0`
-  (self-loop on output-0) and `synapse=4145->4143 fromUUID=output-0
-  depth=-2` (backward output→hidden). Tests fail against the unfixed
-  code (no throw) and pass after the fix (`TopologyError` named
-  `exportJSONWithRuntimeIds`).
-- All 6450 existing tests pass under `./quality.sh --skip-discovery
+- `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` (4 new tests): pins
+  both production patterns from the issue —
+  `synapse=2057->2057 fromUUID=output-0 toUUID=output-0 depth=0` (self-loop on
+  output-0) and `synapse=4145->4143 fromUUID=output-0
+  depth=-2` (backward
+  output→hidden). Tests fail against the unfixed code (no throw) and pass after
+  the fix (`TopologyError` named `exportJSONWithRuntimeIds`).
+- All 6450 existing tests pass under
+  `./quality.sh --skip-discovery
   --skip-wasm`.
 - `./quality.sh --lint-only` and `deno check mod.ts` are clean.
 
@@ -42,8 +41,7 @@ flowchart LR
     E -->|ok| G[CreatureExport]
 ```
 
-Producer paths now covered (already routed through
-`exportJSONWithRuntimeIds`):
+Producer paths now covered (already routed through `exportJSONWithRuntimeIds`):
 
 | Site                                        | Source tag in `TopologyError` |
 | ------------------------------------------- | ----------------------------- |
@@ -59,22 +57,23 @@ Producer paths now covered (already routed through
 
 ## Test Plan
 
-- `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` — 4 new
-  tests:
+- `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` — 4 new tests:
   - passes for a valid forward-only creature.
-  - passes for a non-forward-only creature even with a recurrent edge
-    (assertion only fires on `forwardOnly === true`).
-  - throws `TopologyError` named `exportJSONWithRuntimeIds` for the
-    self-loop on output-0 pattern (issue evidence: `2057->2057
+  - passes for a non-forward-only creature even with a recurrent edge (assertion
+    only fires on `forwardOnly === true`).
+  - throws `TopologyError` named `exportJSONWithRuntimeIds` for the self-loop on
+    output-0 pattern (issue evidence:
+    `2057->2057
     fromUUID=output-0 toUUID=output-0 depth=0`).
-  - throws `TopologyError` named `exportJSONWithRuntimeIds` for the
-    backward output→hidden pattern (issue evidence: `4145->4143
+  - throws `TopologyError` named `exportJSONWithRuntimeIds` for the backward
+    output→hidden pattern (issue evidence:
+    `4145->4143
     fromUUID=output-0 depth=-2`).
 - Existing tests unchanged: `ForwardOnlyAssertion`,
   `ForwardOnlyApplyChangeLifecycle`, `NormaliseCreatureExportForwardOnly`,
   `ForwardOnlyOutputRoundTrip`, `LoadFromObservability` — all green.
-- Full upgrade test suite (`test/upgrade/**/*.ts`) — all 49 tests green
-  (pre-4.x upgrade paths legitimately ingest corrupt input but the
-  `forwardOnly` flag is 4.x+, so the assertion is a no-op for them).
-- Full compact (`test/compact/**/*.ts`) and discovery
-  (`test/discovery/**/*.ts`) suites — 667 tests green.
+- Full upgrade test suite (`test/upgrade/**/*.ts`) — all 49 tests green (pre-4.x
+  upgrade paths legitimately ingest corrupt input but the `forwardOnly` flag is
+  4.x+, so the assertion is a no-op for them).
+- Full compact (`test/compact/**/*.ts`) and discovery (`test/discovery/**/*.ts`)
+  suites — 667 tests green.

--- a/src/NEAT/NeatScheduling.ts
+++ b/src/NEAT/NeatScheduling.ts
@@ -12,7 +12,10 @@ import { addTag, getTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
-import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+import {
+  exportJSONWithRuntimeIds,
+  exportJSONWithRuntimeIdsUnchecked,
+} from "@architecture/PopulateRuntimeIdsFromCreature.ts";
 import { isRustDiscoveryEnabled } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import { calculate as calculateScore } from "@architecture/Score.ts";
 import { fineTuneImprovement } from "@blackbox/FineTune.ts";
@@ -397,9 +400,14 @@ export function scheduleTraining(
 
     neat.trainingInProgress.delete(uuid);
 
+    // Issue #2546: training has already failed for this creature; serialise
+    // it for the diagnostic record without re-running the writer-side
+    // forward-only assertion, so a corrupt forward-only topology surfaces
+    // here as the original training error rather than a chained
+    // TopologyError that masks the root cause.
     let creatureExport: ReturnType<typeof exportJSONWithRuntimeIds>;
     try {
-      creatureExport = exportJSONWithRuntimeIds(creature);
+      creatureExport = exportJSONWithRuntimeIdsUnchecked(creature);
     } catch {
       creatureExport = {
         neurons: [],

--- a/src/architecture/PopulateRuntimeIdsFromCreature.ts
+++ b/src/architecture/PopulateRuntimeIdsFromCreature.ts
@@ -1,6 +1,7 @@
 import type { Creature } from "@creature";
 import { convertMemeticExportToWireJson } from "@creature/MemeticWireExport.ts";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { assertNoRecurrentSynapseOnForwardOnly } from "@architecture/ForwardOnlyAssertion.ts";
 import { neuronUuid } from "@neuron/NeuronSerialization.ts";
 import { CreatureExportBuilder } from "@utils/CreatureExportBuilder.ts";
 
@@ -49,7 +50,29 @@ export function populateRuntimeIdsFromCreature(
   }
 }
 
+/**
+ * Internal export with runtime integer ids on neurons and synapses.
+ *
+ * **Issue #2546 — forward-only post-condition.** This is the producer
+ * gap that #2515 missed: worker training (`WorkerProcessor`), evolution
+ * scheduling (`NeatScheduling`), training teardown / outcome / setup,
+ * compaction (`CompactUnused`), discovery replay
+ * (`ReplayEntryApplication`), knowledge distillation, and the legacy
+ * upgrade pipeline all route through this function. The public
+ * {@link exportJSON} already calls
+ * {@link assertNoRecurrentSynapseOnForwardOnly}; this internal export
+ * did not, and so any forward-only creature that gained a recurrent
+ * synapse upstream could be persisted to disk and only surface as a
+ * `[loadFrom] Recurrent synapse … source=fromJSON` `TopologyError` on
+ * the next worker that ingested the JSON. Mirroring the assertion here
+ * pins the producer's stack frame.
+ *
+ * Pre-4.x upgrade paths are not affected: the `forwardOnly` flag was
+ * introduced with 4.x, so 1.x/2.x/3.x creatures arriving in the upgrade
+ * pipeline have `forwardOnly !== true` and the assertion is a no-op.
+ */
 export function exportJSONWithRuntimeIds(creature: Creature): CreatureExport {
+  assertNoRecurrentSynapseOnForwardOnly(creature, "exportJSONWithRuntimeIds");
   const json = new CreatureExportBuilder(creature).build(true);
   if (json.memetic) {
     json.memetic = convertMemeticExportToWireJson(creature, json.memetic);

--- a/src/architecture/PopulateRuntimeIdsFromCreature.ts
+++ b/src/architecture/PopulateRuntimeIdsFromCreature.ts
@@ -53,26 +53,50 @@ export function populateRuntimeIdsFromCreature(
 /**
  * Internal export with runtime integer ids on neurons and synapses.
  *
- * **Issue #2546 — forward-only post-condition.** This is the producer
- * gap that #2515 missed: worker training (`WorkerProcessor`), evolution
+ * **Issue #2546 — forward-only post-condition.** This is the producer gap
+ * that #2515 missed: worker training (`WorkerProcessor`), evolution
  * scheduling (`NeatScheduling`), training teardown / outcome / setup,
  * compaction (`CompactUnused`), discovery replay
- * (`ReplayEntryApplication`), knowledge distillation, and the legacy
- * upgrade pipeline all route through this function. The public
- * {@link exportJSON} already calls
- * {@link assertNoRecurrentSynapseOnForwardOnly}; this internal export
- * did not, and so any forward-only creature that gained a recurrent
- * synapse upstream could be persisted to disk and only surface as a
- * `[loadFrom] Recurrent synapse … source=fromJSON` `TopologyError` on
+ * (`ReplayEntryApplication`), knowledge distillation, and the worker→main
+ * wire all route through this function. The public {@link exportJSON}
+ * already calls {@link assertNoRecurrentSynapseOnForwardOnly}; this
+ * internal export did not, and so any forward-only creature that gained a
+ * recurrent synapse upstream could be persisted to disk and only surface
+ * as a `[loadFrom] Recurrent synapse … source=fromJSON` `TopologyError` on
  * the next worker that ingested the JSON. Mirroring the assertion here
  * pins the producer's stack frame.
  *
- * Pre-4.x upgrade paths are not affected: the `forwardOnly` flag was
- * introduced with 4.x, so 1.x/2.x/3.x creatures arriving in the upgrade
- * pipeline have `forwardOnly !== true` and the assertion is a no-op.
+ * Repair tools and legacy upgrade paths that legitimately need to
+ * serialise a not-yet-repaired creature must call
+ * {@link exportJSONWithRuntimeIdsUnchecked} (with a code comment naming
+ * the bypass) so the gate's intent is preserved.
  */
 export function exportJSONWithRuntimeIds(creature: Creature): CreatureExport {
   assertNoRecurrentSynapseOnForwardOnly(creature, "exportJSONWithRuntimeIds");
+  return buildExportWithRuntimeIds(creature);
+}
+
+/**
+ * Internal-only runtime-ids export that **bypasses** the Issue #2546
+ * forward-only assertion. Use only on paths that legitimately need to
+ * serialise a potentially-corrupt creature for further processing
+ * (e.g. the legacy `upgrade()` / `upgradeTwo()` pipeline before `fix()`
+ * finishes its repair pass on residual recurrent edges from 1.x/2.x
+ * genomes, and the `NeatScheduling` training-failure diagnostic write
+ * already on an error path that must not be masked by another throw).
+ *
+ * Always pair the call with a code comment naming the bypass — when in
+ * doubt, prefer {@link exportJSONWithRuntimeIds}; the assertion is the
+ * only thing that names the producing pipeline when corruption escapes
+ * onto the worker→main wire or onto disk.
+ */
+export function exportJSONWithRuntimeIdsUnchecked(
+  creature: Creature,
+): CreatureExport {
+  return buildExportWithRuntimeIds(creature);
+}
+
+function buildExportWithRuntimeIds(creature: Creature): CreatureExport {
   const json = new CreatureExportBuilder(creature).build(true);
   if (json.memetic) {
     json.memetic = convertMemeticExportToWireJson(creature, json.memetic);

--- a/src/upgrade/Upgrade.ts
+++ b/src/upgrade/Upgrade.ts
@@ -3,7 +3,7 @@ import { exportJSONUnchecked } from "@creature/CreatureSerialization.ts";
 import { repairInvalidIfNeuronsInCreature } from "@architecture/RepairInvalidIfNeurons.ts";
 import { creatureValidate } from "@architecture/CreatureValidate.ts";
 import { pruneOrphanMemeticReferences } from "@compact/CompactUtils.ts";
-import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+import { exportJSONWithRuntimeIdsUnchecked } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
 import type { ValidationError } from "@errors/ValidationError.ts";
 import { writeDiagnostics } from "@utils/Diagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
@@ -253,7 +253,11 @@ export function upgrade(creature: Creature): Creature {
 
   // Upgrade from 1.x → 2.x, then try 4.x
   if (majorVersion === 1) {
-    const v2 = upgradeTwo(exportJSONWithRuntimeIds(creature));
+    // Issue #2546: legacy 1.x creatures pre-date forward-only enforcement and
+    // may carry recurrent edges that the upgrade's `fix()` pass repairs. Use
+    // the unchecked export so the upgrader can serialise the not-yet-repaired
+    // creature without tripping the writer-side forward-only assertion.
+    const v2 = upgradeTwo(exportJSONWithRuntimeIdsUnchecked(creature));
     // Issue #2514: legacy 1.x creatures pre-date forward-only enforcement
     // and may legitimately carry recurrent edges through the upgrade
     // pipeline. Opt out of the load-side throw so the upgrader can finish
@@ -267,7 +271,10 @@ export function upgrade(creature: Creature): Creature {
   // Version 0 or unknown - set to 1.0.0 first, then upgrade to 2.x, then try 4.x
   // This handles undefined versions, invalid formats, and "0.x" versions
   if (majorVersion === 0) {
-    const json = exportJSONWithRuntimeIds(creature);
+    // Issue #2546: see major-1 branch — legacy v0 creatures pre-date the
+    // forward-only invariant; bypass the writer-side assertion until the
+    // upgrade's `fix()` pass runs.
+    const json = exportJSONWithRuntimeIdsUnchecked(creature);
     json.semanticVersion = "1.0.0"; // Set to 1.0.0 so upgradeTwo can process it
     const v2 = upgradeTwo(json);
     // Issue #2514: see above — same rationale for the v0 → v2 upgrade path.

--- a/src/upgrade/UpgradeTwo.ts
+++ b/src/upgrade/UpgradeTwo.ts
@@ -7,7 +7,7 @@ import type {
 } from "@architecture/CreatureInterfaces.ts";
 import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
 import { nextNeuronId } from "@architecture/NeuronId.ts";
-import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+import { exportJSONWithRuntimeIdsUnchecked } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
 import type { NeuronExport } from "@architecture/NeuronInterfaces.ts";
 import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
 import { SQRT } from "@methods/activations/types/SQRT.ts";
@@ -154,7 +154,10 @@ function removeHYPOT(json: CreatureExport) {
     getLogger().info("Creature is not valid", e);
     tempCreature.fix();
   }
-  return exportJSONWithRuntimeIds(tempCreature);
+  // Issue #2546: legacy upgrade may have stripped recurrent edges via the
+  // `throwOnRecurrent: "never"` load above; the unchecked export keeps the
+  // upgrader from re-tripping on a creature that is already in mid-repair.
+  return exportJSONWithRuntimeIdsUnchecked(tempCreature);
 }
 
 function removeHYPOTv2(json: CreatureExport) {
@@ -222,5 +225,8 @@ function removeHYPOTv2(json: CreatureExport) {
     tempCreature.fix();
   }
 
-  return exportJSONWithRuntimeIds(tempCreature);
+  // Issue #2546: legacy upgrade may have stripped recurrent edges via the
+  // `throwOnRecurrent: "never"` load above; the unchecked export keeps the
+  // upgrader from re-tripping on a creature that is already in mid-repair.
+  return exportJSONWithRuntimeIdsUnchecked(tempCreature);
 }

--- a/test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts
+++ b/test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the forward-only post-condition on `exportJSONWithRuntimeIds`
+ * (Issue #2546).
+ *
+ * Production GRQ logs (per Issue #2546) showed `[loadFrom] Recurrent
+ * synapse … source=fromJSON` throws on every load even after Issue #2515
+ * wired the `assertNoRecurrentSynapseOnForwardOnly` post-condition into
+ * the discovery combiners and the public `exportJSON` save path. The
+ * audit missed `exportJSONWithRuntimeIds`: it is the internal export
+ * that worker training, scheduling, knowledge-distillation, replay, and
+ * compaction route through and was therefore the only remaining
+ * producer that could persist a forward-only creature with a recurrent
+ * synapse to disk.
+ *
+ * These tests pin the new post-condition: a forward-only creature with
+ * `from >= to` synapses must throw a `TopologyError` named
+ * `exportJSONWithRuntimeIds` rather than letting the corruption escape
+ * and trip the load-side throw on the next worker that ingests the
+ * resulting JSON.
+ */
+import { assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import { Synapse } from "@architecture/Synapse.ts";
+import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+import { TopologyError } from "@errors/TopologyError.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+Deno.test("exportJSONWithRuntimeIds: passes for valid forward-only creature", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { layers: [{ count: 2 }] });
+  c.forwardOnly = true;
+  const json = exportJSONWithRuntimeIds(c);
+  // Sanity check: still a valid round-trip (every synapse has from < to
+  // when resolved against the wire neuron order).
+  assertEquals(json.forwardOnly, true);
+  assertEquals(json.synapses.length > 0, true);
+});
+
+Deno.test("exportJSONWithRuntimeIds: passes when forwardOnly is false even with recurrent edges", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { feedbackEnabled: true });
+  c.forwardOnly = false;
+  // Inject a self-loop. Should not throw because forwardOnly is not
+  // enforced on this creature.
+  const outIdx = c.neurons.length - 1;
+  c.synapses.push(new Synapse(outIdx, outIdx, 0.1));
+  // Should not throw — the post-condition only fires on forwardOnly
+  // creatures.
+  exportJSONWithRuntimeIds(c);
+});
+
+Deno.test("exportJSONWithRuntimeIds: throws TopologyError on self-loop on output-0 (Issue #2546)", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { layers: [{ count: 2 }] });
+  c.forwardOnly = true;
+  // GRQ-3 production signature: synapse=2057->2057 fromUUID=output-0
+  // toUUID=output-0 depth=0 (self-loop on output-0).
+  const outIdx = c.neurons.length - 1;
+  c.synapses.push(new Synapse(outIdx, outIdx, 0.1));
+
+  const err = assertThrows(
+    () => exportJSONWithRuntimeIds(c),
+    TopologyError,
+  );
+  const msg = String((err as Error).message);
+  // Confirm the producer is named so the offending stack frame is
+  // identifiable from the production log line alone.
+  assertEquals(msg.includes("exportJSONWithRuntimeIds"), true);
+  assertEquals(msg.includes("recurrent synapse"), true);
+});
+
+Deno.test("exportJSONWithRuntimeIds: throws TopologyError on backward output→hidden edge (Issue #2546)", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { layers: [{ count: 2 }] });
+  c.forwardOnly = true;
+  // GRQ-3 production signature: synapse=4145->4143 fromUUID=output-0
+  // depth=-2 (backward edge from output back into hidden).
+  const outIdx = c.neurons.length - 1;
+  const hiddenIdx = outIdx - 1;
+  c.synapses.push(new Synapse(outIdx, hiddenIdx, 0.1));
+
+  assertThrows(
+    () => exportJSONWithRuntimeIds(c),
+    TopologyError,
+    "exportJSONWithRuntimeIds",
+  );
+});


### PR DESCRIPTION
## Summary

Closes #2546.

Production GRQ-3/13 logs (2026-05-05/06) showed `TopologyError` firing on every
load with `source=fromJSON` for forward-only creatures carrying the canonical
recurrent-output signatures (`output-0 -> output-0` self-loops and backward
`output -> hidden` edges). The Issue #2515 audit wired the forward-only
post-condition into the `applyChangeToCreature` / `normaliseCreatureExport`
combiners and the public `exportJSON` save path, but missed
`exportJSONWithRuntimeIds()` — the internal export used by training, NEAT
scheduling, knowledge distillation, discovery replay, and the worker→main wire.
That variant historically bypassed the Issue #2511 save-side gate, so a corrupt
forward-only creature produced anywhere in those pipelines serialised cleanly
and only blew up at the next disk load.

This PR closes that producer surface:

- `exportJSONWithRuntimeIds()` now runs
  `assertNoRecurrentSynapseOnForwardOnly(creature, "exportJSONWithRuntimeIds")`
  as a save-side post-condition, naming itself in the thrown `TopologyError`'s
  message. Pre-4.x upgrade callers are unaffected — `forwardOnly` was introduced
  with 4.x, so the assertion is a no-op when `creature.forwardOnly !== true`.
- A new sibling, `exportJSONWithRuntimeIdsUnchecked()`, mirrors
  `exportJSONUnchecked()` for the small set of legitimate bypass cases:
  - The `upgrade()` legacy v0/v1 path and `upgradeTwo()`'s `removeHYPOT*` passes
    that operate on creatures pre-`fix()` (recurrent edges may still be present
    and are repaired by the upgrader).
  - The `NeatScheduling` training-failure diagnostic write that already runs
    after a thrown training error and must not chain a second throw that masks
    the root cause.
- All other call sites (`WorkerProcessor` train wire response, `NeatScheduling`
  fine-tune backtrack/forward variants, `KnowledgeDistillation`,
  `TrainingOutcome`/`TrainingTeardown`/`TrainingSetup`, `CreatureTraining`,
  `ReplayEntryApplication`, `CompactUnused`) now flow through the checked
  variant — any future regression that builds a recurrent forward-only synapse
  will be caught at the export site, with the producing pipeline's stack frame
  intact.
- `CHANGELOG.md` documents the writer-side gate and version is bumped to
  `3.3.6`.

```mermaid
flowchart LR
    P[Producer pipeline<br/>training / scheduling /<br/>replay / KD / worker]
    --> E[exportJSONWithRuntimeIds]
    E -->|forwardOnly + recurrent| T[TopologyError<br/>names producer<br/>+ stack frame]
    E -->|ok| W[wire / disk JSON]
    R[Repair tool<br/>upgrade / diagnostic write]
    --> U[exportJSONWithRuntimeIdsUnchecked]
    U --> W
    W --> L[Creature.fromJSON<br/>load-side gate]
    L -->|forwardOnly + recurrent| T
```

## Evidence

Backend-only library change — no UI to screenshot. Verified via:

- Unit tests in `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts`
  covering both production-observed signatures (output-0 self-loop and backward
  output→hidden) plus the two no-op cases (valid forward-only, and
  feedback-enabled with a legitimate recurrent edge). Tests fail against the
  unfixed code (no throw) and pass after the fix (`TopologyError` named
  `exportJSONWithRuntimeIds`).
- Touched test suites pass cleanly:
  - `test/architecture/` — 425 tests pass.
  - `test/upgrade/`, `test/compact/`, `test/creature/`, `test/discovery/`
    combined — 965 tests pass (covers the rerouted upgrade and compaction bypass
    paths and the load-side throw).
  - `./quality.sh --skip-discovery --skip-wasm` — 6453 passed, 0 failed, 4
    ignored.
  - `./quality.sh --lint-only` and `--check-only` — clean.

Producer paths now covered (already routed through the checked
`exportJSONWithRuntimeIds`):

| Site                                        | Source tag in `TopologyError` |
| ------------------------------------------- | ----------------------------- |
| `WorkerProcessor` (returning trained)       | `exportJSONWithRuntimeIds`    |
| `NeatScheduling` (backtracked / forward)    | `exportJSONWithRuntimeIds`    |
| `CreatureTraining` (training round-trip)    | `exportJSONWithRuntimeIds`    |
| `TrainingOutcome` / `TrainingTeardown`      | `exportJSONWithRuntimeIds`    |
| `TrainingSetup` (best snapshot)             | `exportJSONWithRuntimeIds`    |
| `CompactUnused` (compaction snapshots)      | `exportJSONWithRuntimeIds`    |
| `ReplayEntryApplication` (discovery replay) | `exportJSONWithRuntimeIds`    |
| `KnowledgeDistillation` (distilled student) | `exportJSONWithRuntimeIds`    |

Bypass paths now routed to the unchecked sibling (with a code comment naming the
bypass):

| Site                                         | Reason                           |
| -------------------------------------------- | -------------------------------- |
| `Upgrade.upgrade` (1.x → 2.x, 0.x → 1.0.0)   | legacy genome pre-`fix()` repair |
| `UpgradeTwo.removeHYPOT` / `removeHYPOTv2`   | legacy HYPOT removal pre-`fix()` |
| `NeatScheduling` training-failure diagnostic | already on a thrown error path   |

## Test Plan

- [x] `test/architecture/ExportJSONWithRuntimeIdsForwardOnly.ts` — 4 cases:
  - passes for a valid forward-only creature.
  - passes for a non-forward-only creature even with a recurrent edge (assertion
    only fires on `forwardOnly === true`).
  - throws `TopologyError` named `exportJSONWithRuntimeIds` for the self-loop on
    output-0 pattern (issue evidence:
    `2057->2057 fromUUID=output-0
    toUUID=output-0 depth=0`).
  - throws `TopologyError` named `exportJSONWithRuntimeIds` for the backward
    output→hidden pattern (issue evidence:
    `4145->4143 fromUUID=output-0
    depth=-2`).
- [x] Existing `ForwardOnlyAssertion` and `LoadFromForwardOnlyThrow` suites
      unchanged and still pass.
- [x] `ShallowCloneRuntimeIds` (legacy round-trip via
      `exportJSONWithRuntimeIds + fromJSON`) unchanged and still passes —
      confirms the new gate does not regress valid forward-only round-trips.
- [x] Full upgrade and compact suites pass — confirms the rerouted bypass paths
      still serialise legacy/in-repair creatures.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2546 -->