### PR TITLE
docs: consolidate core dependency & parity audit cluster (#2570)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -581,9 +581,10 @@ In our production workloads, the default is feed-forward/forward-only.
   policy (ADR)
 - **docs/PARITY_GATE.md** - Parity gate checklist (Issue #2345) that must pass
   before removing in-tree duplicate native Rust
-- **docs/NEAT_AI_CORE_PARITY_AUDIT.md** - Parity audit (Issue #2367) mapping
-  every in-tree `neat-core/` pub item and test to its NEAT-AI-core equivalent at
-  the pinned rev
+- **docs/PARITY_AUDITS.md** - Consolidated archive of the three parity audits
+  (Issues #2367, #2368, #2369). Replaces the former
+  `NEAT_AI_CORE_PARITY_AUDIT.md`, `RUST_SCORER_PARITY_AUDIT.md` and
+  `WASM_ACTIVATION_PARITY_AUDIT.md` stubs
 - **docs/dna-sharing-bake-off-results.md** - Inter-island DNA-sharing primitive
   bake-off results (Issue #2496); `PruningTemplateStrategy` is the recommended
   primitive

--- a/docs/CI_EXTERNAL_NEAT_AI_CORE.md
+++ b/docs/CI_EXTERNAL_NEAT_AI_CORE.md
@@ -1,26 +1,54 @@
 # CI for the external NEAT-AI-core dependency
 
-CI in this repository no longer builds Rust. It always syncs prebuilt WASM
-artifacts from NEAT-AI-core using `./build.sh`.
+> **Brief:** Continuous Integration (CI) here never builds Rust or resolves
+> NEAT-AI-core HEAD. It only **verifies** that the vendored
+> `wasm_activation/pkg/**` matches the SHA pinned in `deno.json`. For the
+> cluster overview start at
+> [docs/EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md).
+
+## What the workflows do today
+
+The two workflows that touch the NEAT-AI-core dependency both call
+`./build.sh --verify-only`. The verify-only mode performs no network calls and
+no mutation — it simply checks that the on-disk `wasm_activation/pkg/**` matches
+`deno.json` `neatCore.rev`.
+
+| Workflow                                                            | Job       | Step                                                 | Command                    |
+| ------------------------------------------------------------------- | --------- | ---------------------------------------------------- | -------------------------- |
+| [`.github/workflows/quality.yml`](../.github/workflows/quality.yml) | `quality` | _Sync WASM package from NEAT-AI-core_                | `./build.sh --verify-only` |
+| [`.github/workflows/publish.yml`](../.github/workflows/publish.yml) | `publish` | _Verify WASM package matches deno.json neatCore.rev_ | `./build.sh --verify-only` |
+
+The publish workflow uses verify-only deliberately: the default `GITHUB_TOKEN`
+cannot read commits from `NEAT-AI-core`, so any attempt to resolve `Develop`
+HEAD from the publish job would fail (see
+[`docs/CORE_DEPENDENCY_POLICY.md`](CORE_DEPENDENCY_POLICY.md) and Issue #2439).
 
 ## Required workflow pattern
+
+If you add another workflow that needs the WASM bundle, follow this pattern —
+verify only, never resolve HEAD:
 
 ```yaml
 - name: Setup Deno
   uses: denoland/setup-deno@v2
 
-- name: Sync WASM package from NEAT-AI-core
-  run: ./build.sh
+- name: Verify WASM package matches deno.json neatCore.rev
+  run: ./build.sh --verify-only
 ```
 
-Add this before `deno check`, `deno test`, or publish.
+Place this step before any `deno check`, `deno test`, or publish step. Bumping
+`neatCore.rev` is an explicit human (or worker) action, not something CI does on
+its own.
 
 ## Sync policy enforcement
 
-CI should fail when `wasm_activation/pkg/**` changes without a paired change to
-`deno.json` `neatCore.rev`.
-
-Example guard:
+`wasm_activation/pkg/**` must change only in commits that also change
+`deno.json` `neatCore.rev`. The contributor-facing rule lives in
+[`docs/CORE_DEPENDENCY_POLICY.md`](CORE_DEPENDENCY_POLICY.md); the CI side is
+the _Report WASM sync changes_ step in
+[`.github/workflows/quality.yml`](../.github/workflows/quality.yml), which
+surfaces a notice when `wasm_activation/pkg/` has changed after the verify step.
+If you need a hard guard that fails the build, the following pattern works:
 
 ```yaml
 - name: Verify WASM sync policy
@@ -36,4 +64,16 @@ Example guard:
 ## Notes
 
 - No Cargo cache, `rustc`, or `wasm-pack` setup is needed in this repo.
-- `wasm_activation/pkg` remains committed and published with the package.
+- `wasm_activation/pkg` remains committed and published with the package via
+  [`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
+- The release-wide CI gate is `./quality.sh`, which calls
+  `./build.sh --verify-only` for the same reason the workflow does.
+
+## See also
+
+- [`docs/EXTERNAL_NEAT_AI_CORE.md`](EXTERNAL_NEAT_AI_CORE.md) — cluster overview
+  and day-to-day workflow.
+- [`docs/CORE_DEPENDENCY_POLICY.md`](CORE_DEPENDENCY_POLICY.md) — the ADR for
+  the pinning model and CI policy this workflow enforces.
+- [`docs/PARITY_GATE.md`](PARITY_GATE.md) — release checklist run after bumping
+  the pinned revision.

--- a/docs/CORE_DEPENDENCY_POLICY.md
+++ b/docs/CORE_DEPENDENCY_POLICY.md
@@ -47,11 +47,29 @@ flowchart LR
 
 | Invocation                 | Behaviour                                                                                                     |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `./build.sh`               | Resolve Develop HEAD, download artifact, refresh pkg, update `deno.json` `neatCore.rev`. No-op if up to date. |
+| `./build.sh`               | Resolve Develop HEAD, download artefact, refresh pkg, update `deno.json` `neatCore.rev`. No-op if up to date. |
 | `./build.sh --rev <SHA>`   | Same as above but pin to a specific 40-char SHA instead of resolving HEAD. Used for reproducible builds.      |
 | `./build.sh --verify-only` | Verify the vendored pkg matches `deno.json` `neatCore.rev`. No network. No mutation. Used by `quality.sh`.    |
 | `./build.sh --clean`       | Delete `wasm_activation/pkg` before download.                                                                 |
 | `./build.sh --help`        | Show usage.                                                                                                   |
+
+## Pre-PR auto-bump (`bump-deps.sh`)
+
+The Vibe Coder worker invokes [`./bump-deps.sh`](../bump-deps.sh) before
+`./quality.sh` on every PR run. Two dependency classes are handled separately:
+
+- **Internal (`stSoftwareAU/*`, including NEAT-AI-core):** advances `deno.json`
+  `neatCore.rev` to NEAT-AI-core `Develop` HEAD by re-running `./build.sh`. No
+  quarantine — internal deps bump immediately.
+- **External (jsr:@std/_, npm:_, https://deno.land/*):** runs
+  `deno outdated --update --latest --minimum-dependency-age=<min>` with a
+  quarantine window (default 24h, see `VIBE_BUMP_QUARANTINE_HOURS`). The
+  quarantine dodges fast-flagged supply-chain attacks.
+
+After bumping, the script runs a two-phase audit gate (a curated WASM smoke
+subset followed by `deno check`). If either phase fails the script exits
+non-zero and the bump is reverted. The behaviour is verified by
+[`test/scripts/BumpDepsScript.ts`](../test/scripts/BumpDepsScript.ts).
 
 The artifact-based flow depends on the per-commit GitHub Release published by
 NEAT-AI-core CI (issue stSoftwareAU/NEAT-AI-core#37). When the upstream artifact
@@ -96,6 +114,10 @@ used by this repo's `deno.json`.
 
 ## Related Documents
 
-- [docs/EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md)
-- [docs/CI_EXTERNAL_NEAT_AI_CORE.md](CI_EXTERNAL_NEAT_AI_CORE.md)
-- [docs/PARITY_GATE.md](PARITY_GATE.md)
+- [docs/EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md) — cluster overview
+  and day-to-day workflow.
+- [docs/CI_EXTERNAL_NEAT_AI_CORE.md](CI_EXTERNAL_NEAT_AI_CORE.md) — CI plumbing
+  for build.sh-driven WASM sync.
+- [docs/PARITY_GATE.md](PARITY_GATE.md) — release checklist for repins.
+- [docs/PARITY_AUDITS.md](PARITY_AUDITS.md) — archived parity audits.
+- [docs/README.md](README.md) — full documentation index.

--- a/docs/EXTERNAL_NEAT_AI_CORE.md
+++ b/docs/EXTERNAL_NEAT_AI_CORE.md
@@ -1,46 +1,77 @@
-# External NEAT-AI-core Dependency
+# External NEAT-AI-core Dependency — Cluster Overview
 
-Issue #2343 — this document explains how NEAT-AI consumes shared native Rust
-from the [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) repository
-and how contributors work with it locally.
+NEAT-AI no longer carries native Rust source. All shared compute lives in the
+[NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) repository and is
+consumed here as a vendored WebAssembly (WASM) bundle pinned by commit SHA in
+[`deno.json`](../deno.json) and refreshed by [`./build.sh`](../build.sh). This
+page is the **entry point** for the cluster of docs that govern that dependency
+— read it first, then follow the links into the detail docs you need.
+
+## 🗺️ Cluster map
+
+```mermaid
+flowchart LR
+  CORE["NEAT-AI-core<br/>upstream Rust"] -->|wasm-pack CI| REL["GitHub Release<br/>wasm-bundle-&lt;SHA&gt;"]
+  REL -->|build.sh| THIS["NEAT-AI<br/>this repo"]
+  THIS -->|JSR publish| EXT["GRQ / NEAT-AI-scorer<br/>downstream extensions"]
+  THIS -.pin update.-> THIS
+```
+
+This cluster has five docs. Use this overview to pick the one you need.
+
+| Doc                                                          | When to read                                                                                                 |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| **This page**                                                | Day-to-day workflow for bumping the pinned revision.                                                         |
+| [`CORE_DEPENDENCY_POLICY.md`](CORE_DEPENDENCY_POLICY.md)     | The pinning policy ADR — why we pin by SHA, semver bands, approval tiers, and the `build.sh` mode reference. |
+| [`PARITY_GATE.md`](PARITY_GATE.md)                           | Release checklist — what the parity gate runs and how to interpret its output.                               |
+| [`CI_EXTERNAL_NEAT_AI_CORE.md`](CI_EXTERNAL_NEAT_AI_CORE.md) | What the GitHub Actions workflows do for this dependency, and the sync-policy guard.                         |
+| [`PARITY_AUDITS.md`](PARITY_AUDITS.md)                       | Archived audits (#2367, #2368, #2369) for in-tree code that has since been removed.                          |
+
+## TL;DR
+
+- `deno.json` pins `neatCore.repo` and a 40-character `neatCore.rev`.
+- `./build.sh` is the single integration point — it downloads the matching WASM
+  bundle and refreshes [`wasm_activation/pkg`](../wasm_activation/pkg).
+- `./scripts/parity-gate.sh` cross-checks the pin against the live TypeScript ↔
+  WASM parity tests.
+- `./quality.sh` is the release-wide gate; it calls `./build.sh --verify-only`
+  so CI never silently advances the pin.
 
 ## Architecture
 
-```
+```text
 NEAT-AI (this repo)
 ├── deno.json           ← pins neatCore.repo + neatCore.rev
-├── build.sh            ← fetches wasm_activation/pkg from pinned NEAT-AI-core rev
-└── wasm_activation/pkg ← vendored runtime artifacts consumed by TS loaders
+├── build.sh            ← fetches wasm_activation/pkg from pinned SHA
+└── wasm_activation/pkg ← vendored runtime artefacts loaded by TS
 ```
 
-`neat-core` implementation lives fully in NEAT-AI-core. This repository consumes
-prebuilt WASM artifacts by pinning a commit SHA in `deno.json` and syncing via
-`./build.sh`.
+The full `(repo, ref, rev)` triple in `deno.json` is the single source of truth.
+See [`CORE_DEPENDENCY_POLICY.md`](CORE_DEPENDENCY_POLICY.md) for the full ADR
+including `build.sh` mode reference.
 
-## Bumping the Core Version
+## Bumping the core revision
 
-1. Identify the target commit or tag in NEAT-AI-core.
-2. Update `deno.json`:
+1. Run [`./build.sh`](../build.sh) — by default it resolves NEAT-AI-core
+   `Develop` HEAD, downloads the matching `wasm-bundle-<SHA>` artefact,
+   refreshes [`wasm_activation/pkg`](../wasm_activation/pkg), and updates
+   `deno.json` `neatCore.rev`. Use `./build.sh --rev <SHA>` to pin a specific
+   commit instead.
+2. Run [`./scripts/parity-gate.sh`](../scripts/parity-gate.sh) and paste the
+   output into the PR. The gate is a focused alignment check; the release-wide
+   gate is `./quality.sh`.
+3. Commit the updated `deno.json` and
+   [`wasm_activation/pkg`](../wasm_activation/pkg) **together** — the pin and
+   the artefact must move as one commit (see _Sync invariant_ below).
 
-   ```json
-   "neatCore": {
-     "repo": "stSoftwareAU/NEAT-AI-core",
-     "rev": "<new-40-char-sha>"
-   }
-   ```
+For the full release checklist see [`PARITY_GATE.md`](PARITY_GATE.md).
 
-3. Run `./build.sh` to refresh `wasm_activation/pkg`.
-4. Run `./scripts/parity-gate.sh` and `./quality.sh`.
+## NEAT-AI-scorer alignment
 
-## NEAT-AI-scorer Alignment
-
-Issue #2348 — [NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer)
-(or equivalent scorer tooling) should use the **same NEAT-AI-core revision** as
-this repository to avoid version skew. When the two repositories compile against
-different snapshots of core logic, shared types and scoring behaviour can
-silently diverge.
-
-### How to verify alignment
+[NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer) and any other
+downstream extension should pin the **same** NEAT-AI-core revision as this
+workspace. Skew between two consumers of the same core silently drifts shared
+types and scoring behaviour.
 
 After bumping `neatCore.rev` here, confirm the scorer is aligned:
 
@@ -53,12 +84,25 @@ deno eval 'const c = JSON.parse(Deno.readTextFileSync("../NEAT-AI-scorer/deno.js
 ```
 
 If the revisions differ, update the scorer pin and rerun its tests in the same
-coordinated bump.
+coordinated bump. The scorer alignment policy is verified by
+[`test/scripts/ScorerAlignmentPolicy.ts`](../test/scripts/ScorerAlignmentPolicy.ts).
 
-See [docs/CORE_DEPENDENCY_POLICY.md](CORE_DEPENDENCY_POLICY.md) for the full
-pinning policy and downstream consumer alignment requirements.
-
-## Sync Invariant
+## Sync invariant
 
 `wasm_activation/pkg/**` should change only in commits that also change
-`deno.json` `neatCore.rev`.
+`deno.json` `neatCore.rev`. The CI guard for this lives in
+[`.github/workflows/quality.yml`](../.github/workflows/quality.yml) and is
+documented in [`CI_EXTERNAL_NEAT_AI_CORE.md`](CI_EXTERNAL_NEAT_AI_CORE.md).
+
+## Related documents
+
+- [`docs/README.md`](README.md) — full documentation index for this repository.
+- [`docs/CORE_DEPENDENCY_POLICY.md`](CORE_DEPENDENCY_POLICY.md) — ADR for the
+  pinning model.
+- [`docs/PARITY_GATE.md`](PARITY_GATE.md) — release checklist.
+- [`docs/CI_EXTERNAL_NEAT_AI_CORE.md`](CI_EXTERNAL_NEAT_AI_CORE.md) — CI
+  integration.
+- [`docs/PARITY_AUDITS.md`](PARITY_AUDITS.md) — archived parity audits.
+- [`docs/DISCOVERY_ARCHITECTURE.md`](DISCOVERY_ARCHITECTURE.md) — the Discovery
+  / Foreign Function Interface (FFI) cluster, which sits alongside this
+  dependency.

--- a/docs/NEAT_AI_CORE_PARITY_AUDIT.md
+++ b/docs/NEAT_AI_CORE_PARITY_AUDIT.md
@@ -1,11 +1,8 @@
-# NEAT-AI-core Parity Audit (Issue #2367)
+# NEAT-AI-core Parity Audit (Issue #2367) — moved
 
-Historical summary:
+This stub has been consolidated. The archived audit content now lives in
+[docs/PARITY_AUDITS.md](PARITY_AUDITS.md) under the **NEAT-AI-core parity
+audit** section.
 
-- Earlier audits compared in-repo Rust sources with NEAT-AI-core.
-- This repository now carries no Rust source; parity is enforced through:
-  - `deno.json` `neatCore.rev` pinning
-  - `./build.sh` artifact sync into `wasm_activation/pkg`
-  - `./scripts/parity-gate.sh` regression checks
-
-Use the parity gate output as the authoritative evidence for current releases.
+For the live verification flow, see [docs/PARITY_GATE.md](PARITY_GATE.md) and
+[`./scripts/parity-gate.sh`](../scripts/parity-gate.sh).

--- a/docs/PARITY_AUDITS.md
+++ b/docs/PARITY_AUDITS.md
@@ -1,0 +1,95 @@
+# Parity Audits — Archived
+
+This document consolidates the three historical parity audits originally filed
+as separate stubs. They are retained for context — current verification flows
+through the live parity gate, not these audits.
+
+> **Looking for the live check?** Run
+> [`./scripts/parity-gate.sh`](../scripts/parity-gate.sh) — see
+> [docs/PARITY_GATE.md](PARITY_GATE.md) for the full release checklist.
+
+```mermaid
+flowchart LR
+    A[NEAT-AI-core<br/>audit #2367] -.archived.-> H[docs/PARITY_AUDITS.md]
+    B[rust_scorer<br/>audit #2368] -.archived.-> H
+    C[wasm_activation<br/>audit #2369] -.archived.-> H
+    H --> G[scripts/parity-gate.sh<br/>live check]
+    G --> P[docs/PARITY_GATE.md]
+```
+
+## Why these were archived
+
+All three audits were one-shot snapshots of in-tree native code that has since
+been removed:
+
+- The in-repo Rust sources under `neat-core/`, `rust_scorer/`, and
+  `wasm_activation/src/` were retired once
+  [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) became the single
+  home for native logic (Issue #2341).
+- This repository now consumes `wasm_activation/pkg/**` as a vendored artefact
+  synced from a pinned `neatCore.rev` in `deno.json` (see
+  [docs/CORE_DEPENDENCY_POLICY.md](CORE_DEPENDENCY_POLICY.md)).
+- Drift is caught by the live parity gate
+  ([`scripts/parity-gate.sh`](../scripts/parity-gate.sh)) running the
+  TypeScript-side parity tests
+  [`test/score/WasmJsScoreParity.ts`](../test/score/WasmJsScoreParity.ts) and
+  [`test/costs/MSE.ts`](../test/costs/MSE.ts).
+
+## NEAT-AI-core parity audit (Issue #2367)
+
+The `neat-core/` audit compared every public item and test in the in-repo crate
+with its NEAT-AI-core equivalent at the pinned `rev`. The in-repo crate has
+since been removed; only the pinned external dependency remains.
+
+Current alignment is enforced by:
+
+- [`deno.json`](../deno.json) — `neatCore.repo` plus a 40-character
+  `neatCore.rev` SHA.
+- [`./build.sh`](../build.sh) — fetches `wasm_activation/pkg/**` from the pinned
+  NEAT-AI-core release.
+- [`./scripts/parity-gate.sh`](../scripts/parity-gate.sh) — invokes
+  [`test/scripts/CoreDependencyPolicy.ts`](../test/scripts/CoreDependencyPolicy.ts)
+  and the cross-boundary parity tests.
+
+The original audit narrative lives in
+[`docs/pr-summary-2367.md`](pr-summary-2367.md) for historical reference.
+
+## rust_scorer parity audit (Issue #2368)
+
+The `rust_scorer/` experiment lived in this repository while we prototyped
+Rust-side scoring. It is no longer present — all native scoring code has moved
+into NEAT-AI-core, consumed via `wasm_activation/pkg/**`.
+
+Current scoring parity is verified by
+[`test/score/WasmJsScoreParity.ts`](../test/score/WasmJsScoreParity.ts): the
+test scores a deterministic synthetic creature end-to-end through the WASM
+activation module and asserts the score is finite, non-negative and bounded
+by 1.
+
+The original audit narrative lives in
+[`docs/pr-summary-2368.md`](pr-summary-2368.md).
+
+## wasm_activation parity audit (Issue #2369)
+
+`wasm_activation/src/` Rust sources have been removed. The runtime contract for
+callers is unchanged: `wasm_activation/pkg/**` is still shipped and loaded by
+TypeScript, and `deno.json` `neatCore.rev` remains the single source of truth
+for the bundled revision.
+
+Current activation parity is verified by the same WASM/JS score parity test plus
+[`test/costs/MSE.ts`](../test/costs/MSE.ts), which exercises the Mean Squared
+Error cost surface that crosses the WASM boundary.
+
+The original audit narrative lives in
+[`docs/pr-summary-2369.md`](pr-summary-2369.md).
+
+## See also
+
+- [docs/EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md) — cluster overview
+  for the NEAT-AI-core dependency.
+- [docs/CORE_DEPENDENCY_POLICY.md](CORE_DEPENDENCY_POLICY.md) — pinning, semver,
+  and approval policy.
+- [docs/PARITY_GATE.md](PARITY_GATE.md) — live parity gate runbook used today
+  instead of these snapshots.
+- [docs/CI_EXTERNAL_NEAT_AI_CORE.md](CI_EXTERNAL_NEAT_AI_CORE.md) — CI plumbing
+  that enforces the policy on every PR.

--- a/docs/PARITY_GATE.md
+++ b/docs/PARITY_GATE.md
@@ -112,9 +112,11 @@ If any step fails:
 
 - [AGENTS.md](../AGENTS.md) — contributor guide, including the quality gate
   overview.
+- [docs/EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md) — cluster overview
+  and day-to-day workflow for bumping the pinned revision.
 - [docs/CORE_DEPENDENCY_POLICY.md](CORE_DEPENDENCY_POLICY.md) — ADR for how
   NEAT-AI consumes NEAT-AI-core.
-- [docs/EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md) — day-to-day
-  workflow for bumping the pinned revision.
 - [docs/CI_EXTERNAL_NEAT_AI_CORE.md](CI_EXTERNAL_NEAT_AI_CORE.md) — CI plumbing
   for build.sh-driven WASM sync.
+- [docs/PARITY_AUDITS.md](PARITY_AUDITS.md) — archived audits (#2367, #2368,
+  #2369) for native code that has since been removed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,21 +109,19 @@ Project-level policies, audits, and release plumbing.
 - **[../CONTRIBUTING.md](../CONTRIBUTING.md)** — first-time contributor guide.
 - **[../SECURITY.md](../SECURITY.md)** — security disclosure policy.
 - **[../CHANGELOG.md](../CHANGELOG.md)** — release notes.
+- **[EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md)** — 🧭 cluster overview
+  for the NEAT-AI-core dependency. Day-to-day workflow for bumping the pinned
+  revision, plus links to every detail doc below.
 - **[CORE_DEPENDENCY_POLICY.md](CORE_DEPENDENCY_POLICY.md)** — how NEAT-AI pins
   and consumes [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) via
   `deno.json` + `build.sh` (rev pinning, semver, approval tiers).
-- **[EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md)** — day-to-day workflow
-  for bumping the pinned revision and refreshing `wasm_activation/pkg`.
 - **[CI_EXTERNAL_NEAT_AI_CORE.md](CI_EXTERNAL_NEAT_AI_CORE.md)** — CI plumbing
   for `build.sh`-driven artefact sync.
-- **[PARITY_GATE.md](PARITY_GATE.md)** — pre-removal verification checklist for
-  repin + artefact parity validation.
-- **[NEAT_AI_CORE_PARITY_AUDIT.md](NEAT_AI_CORE_PARITY_AUDIT.md)** — archived
-  parity audit (Issue #2367).
-- **[WASM_ACTIVATION_PARITY_AUDIT.md](WASM_ACTIVATION_PARITY_AUDIT.md)** —
-  archived activation parity audit (Issue #2369).
-- **[RUST_SCORER_PARITY_AUDIT.md](RUST_SCORER_PARITY_AUDIT.md)** — archived
-  rust\_scorer parity audit (Issue #2368).
+- **[PARITY_GATE.md](PARITY_GATE.md)** — release checklist run after every repin
+  to verify TypeScript ↔ WASM parity.
+- **[PARITY_AUDITS.md](PARITY_AUDITS.md)** — archived parity audits (Issues
+  #2367, #2368, #2369) consolidated into a single page. Replaces three former
+  stubs.
 - **[TS_RUST_MIGRATION.md](TS_RUST_MIGRATION.md)** — TypeScript → Rust migration
   milestone roadmap.
 

--- a/docs/RUST_SCORER_PARITY_AUDIT.md
+++ b/docs/RUST_SCORER_PARITY_AUDIT.md
@@ -1,13 +1,8 @@
-# rust_scorer Parity Audit (Issue #2368)
+# rust_scorer Parity Audit (Issue #2368) — moved
 
-Historical note:
+This stub has been consolidated. The archived audit content now lives in
+[docs/PARITY_AUDITS.md](PARITY_AUDITS.md) under the **rust_scorer parity audit**
+section.
 
-- The previous in-repo Rust scorer experiment is no longer part of this
-  repository structure.
-- Core native logic now lives in NEAT-AI-core and is consumed through pinned
-  artifact sync (`deno.json` + `./build.sh`).
-
-For current validation, rely on:
-
-- `./scripts/parity-gate.sh`
-- `./quality.sh`
+For the live verification flow, see [docs/PARITY_GATE.md](PARITY_GATE.md) and
+[`./scripts/parity-gate.sh`](../scripts/parity-gate.sh).

--- a/docs/WASM_ACTIVATION_PARITY_AUDIT.md
+++ b/docs/WASM_ACTIVATION_PARITY_AUDIT.md
@@ -1,22 +1,8 @@
-# WASM Activation Parity Audit (Issue #2369)
+# WASM Activation Parity Audit (Issue #2369) — moved
 
-This document is retained as historical context.
+This stub has been consolidated. The archived audit content now lives in
+[docs/PARITY_AUDITS.md](PARITY_AUDITS.md) under the **wasm_activation parity
+audit** section.
 
-## Current state
-
-- `wasm_activation/src/` Rust sources have been removed from this repository.
-- The runtime contract remains unchanged for callers: `wasm_activation/pkg/**`
-  is still shipped and loaded by TypeScript.
-- `deno.json` `neatCore.rev` is the single source of truth for core revision.
-- `./build.sh` refreshes `wasm_activation/pkg` from that pinned NEAT-AI-core
-  commit.
-
-## Ongoing parity checks
-
-Use:
-
-```bash
-./scripts/parity-gate.sh
-```
-
-This validates pin policy, artifact sync, and TypeScript/WASM parity tests.
+For the live verification flow, see [docs/PARITY_GATE.md](PARITY_GATE.md) and
+[`./scripts/parity-gate.sh`](../scripts/parity-gate.sh).

--- a/docs/pr-summary-2566.md
+++ b/docs/pr-summary-2566.md
@@ -4,26 +4,23 @@
 
 Lays the navigation foundation for the docs refresh. Closes #2566.
 
-- Adds **`docs/README.md`** — a topic-by-topic index covering Compute /
-  WASM, Discovery / FFI, Performance, Reference, Specialised, and
-  Governance, with one-line summaries for every long-form guide, a
-  "Where to start" reading path, and an explicit out-of-scope list
-  (`pr-summary-*.md`, `archive/`, `evidence/`, `research/`, etc.).
+- Adds **`docs/README.md`** — a topic-by-topic index covering Compute / WASM,
+  Discovery / FFI, Performance, Reference, Specialised, and Governance, with
+  one-line summaries for every long-form guide, a "Where to start" reading path,
+  and an explicit out-of-scope list (`pr-summary-*.md`, `archive/`, `evidence/`,
+  `research/`, etc.).
 - Refreshes **`README.md`**:
-  - new `📖 Docs map` section near the top linking to
-    `docs/README.md` and every major topic doc;
-  - new `🏗️ High-level architecture` Mermaid `flowchart` showing
-    Creature → mutate/breed → activate via WASM → optional Rust
-    Discovery FFI;
-  - acronyms expanded on first use — NEAT, WebAssembly (WASM),
-    Foreign Function Interface (FFI), Markov Chain Monte Carlo
-    (MCMC), CRISPR (Clustered Regularly Interspaced Short
-    Palindromic Repeats), graphics processing unit (GPU), and
-    JavaScript Registry (JSR).
-- Adds **`test/docs/DocsIndex.ts`** — a quality-gate test that the
-  index exists, every major topic doc is referenced, internal links
-  resolve, the Docs map is present in `README.md`, and acronyms are
-  expanded on first use.
+  - new `📖 Docs map` section near the top linking to `docs/README.md` and every
+    major topic doc;
+  - new `🏗️ High-level architecture` Mermaid `flowchart` showing Creature →
+    mutate/breed → activate via WASM → optional Rust Discovery FFI;
+  - acronyms expanded on first use — NEAT, WebAssembly (WASM), Foreign Function
+    Interface (FFI), Markov Chain Monte Carlo (MCMC), CRISPR (Clustered
+    Regularly Interspaced Short Palindromic Repeats), graphics processing unit
+    (GPU), and JavaScript Registry (JSR).
+- Adds **`test/docs/DocsIndex.ts`** — a quality-gate test that the index exists,
+  every major topic doc is referenced, internal links resolve, the Docs map is
+  present in `README.md`, and acronyms are expanded on first use.
 
 `COMPARISON.md` is intentionally untouched (owned by #2563).
 
@@ -40,14 +37,14 @@ flowchart LR
     I --> Gov[Governance]
 ```
 
-This is a documentation-only change with a new behaviour-asserting
-test. Verified via:
+This is a documentation-only change with a new behaviour-asserting test.
+Verified via:
 
-- `./quality.sh --lint-only` — pass (formatting, linting, bash
-  syntax all green).
+- `./quality.sh --lint-only` — pass (formatting, linting, bash syntax all
+  green).
 - `deno test test/docs/DocsIndex.ts` — 10/10 pass.
-- `deno test test/scripts/ContributorCoreDocs.ts` — 6/6 pass
-  (regression check for the existing core-dep doc references).
+- `deno test test/scripts/ContributorCoreDocs.ts` — 6/6 pass (regression check
+  for the existing core-dep doc references).
 
 ## Test plan
 
@@ -60,5 +57,5 @@ test. Verified via:
 - [x] `README.md has a Docs map section linking to docs/README.md`
 - [x] `README.md includes at least one Mermaid diagram`
 - [x] `README.md expands acronyms on first use`
-- [x] `README.md still references core dependency documentation`
-  (regression guard for `ContributorCoreDocs.ts`)
+- [x] `README.md still references core dependency documentation` (regression
+      guard for `ContributorCoreDocs.ts`)

--- a/docs/pr-summary-2570.md
+++ b/docs/pr-summary-2570.md
@@ -1,0 +1,111 @@
+# PR Summary — Issue #2570
+
+## Summary
+
+Consolidates the seven-doc core-dependency / parity-audit cluster so it follows
+the parent issue's "brief summary + link to detail" pattern. Closes #2570.
+
+The three small `*_PARITY_AUDIT.md` stubs (430, 360, 628 bytes — all under 1KB)
+merge into a single `docs/PARITY_AUDITS.md`. The originals become short redirect
+notes so historical PR-summary links keep working. `EXTERNAL_NEAT_AI_CORE.md` is
+promoted to the cluster overview with a Mermaid diagram of the dependency
+relationship and a table linking every detail doc. `CI_EXTERNAL_NEAT_AI_CORE.md`
+is reconciled against the actual GitHub Actions workflows
+(`.github/workflows/quality.yml` and `publish.yml`), which both use
+`./build.sh --verify-only` rather than the bare `./build.sh` shown in the
+previous draft.
+
+### Changes
+
+- **New:** `docs/PARITY_AUDITS.md` — the single home for the three archived
+  audits (Issues #2367, #2368, #2369), with a Mermaid diagram, cross-links into
+  the live parity gate and the original `pr-summary-*` narratives, plus links to
+  the implementing test files (`test/score/WasmJsScoreParity.ts`,
+  `test/costs/MSE.ts`).
+- **New:** `test/scripts/ParityAuditsConsolidation.ts` — quality-gate test that
+  verifies the consolidation: the new doc covers each audit, every stub
+  redirects, the cluster overview links every detail doc and carries a Mermaid
+  diagram, and the CI doc cites the real workflow files.
+- **Replaced:** `docs/NEAT_AI_CORE_PARITY_AUDIT.md`,
+  `docs/RUST_SCORER_PARITY_AUDIT.md`, `docs/WASM_ACTIVATION_PARITY_AUDIT.md` —
+  three short redirect notes pointing at the consolidated doc.
+- **Promoted:** `docs/EXTERNAL_NEAT_AI_CORE.md` to the cluster overview. Adds a
+  Mermaid `flowchart LR` of NEAT-AI-core → this repo → downstream extensions, a
+  TL;DR, a 5-row cluster map table, an explicit link to
+  `test/scripts/ScorerAlignmentPolicy.ts`, and a See-also entry linking to the
+  Discovery cluster (`DISCOVERY_ARCHITECTURE.md`).
+- **Reconciled:** `docs/CI_EXTERNAL_NEAT_AI_CORE.md` with the live workflow
+  files. Adds a workflow/job/step/command table that points at
+  `.github/workflows/quality.yml` and `publish.yml`, and notes the
+  `--verify-only` invariant.
+- **Cross-links:** `docs/CORE_DEPENDENCY_POLICY.md` gains a _Pre-PR auto-bump_
+  section describing `bump-deps.sh` and links to
+  `test/scripts/BumpDepsScript.ts`. `docs/PARITY_GATE.md` and
+  `docs/CORE_DEPENDENCY_POLICY.md` Related-Documents now reference the
+  consolidated audit doc.
+- **Index/AGENTS:** `docs/README.md` swaps the three stubs for the consolidated
+  `PARITY_AUDITS.md` entry plus an overview-marker on
+  `EXTERNAL_NEAT_AI_CORE.md`. `AGENTS.md` Related-Documents replaces the
+  per-stub entry with a single `PARITY_AUDITS.md` row.
+
+## Evidence
+
+```mermaid
+flowchart LR
+  subgraph Before["Before — 7 docs, 3 sub-1KB stubs"]
+    A1[EXTERNAL_NEAT_AI_CORE.md]
+    A2[CORE_DEPENDENCY_POLICY.md]
+    A3[CI_EXTERNAL_NEAT_AI_CORE.md]
+    A4[PARITY_GATE.md]
+    A5[NEAT_AI_CORE_PARITY_AUDIT.md ~430B]
+    A6[RUST_SCORER_PARITY_AUDIT.md ~360B]
+    A7[WASM_ACTIVATION_PARITY_AUDIT.md ~628B]
+  end
+  subgraph After["After — overview + 3 detail docs + 1 archive doc"]
+    B1["EXTERNAL_NEAT_AI_CORE.md<br/>cluster overview + Mermaid"]
+    B2[CORE_DEPENDENCY_POLICY.md]
+    B3["CI_EXTERNAL_NEAT_AI_CORE.md<br/>reconciled with workflows"]
+    B4[PARITY_GATE.md]
+    B5["PARITY_AUDITS.md<br/>consolidated #2367 + #2368 + #2369"]
+    R5[stub → redirect]
+    R6[stub → redirect]
+    R7[stub → redirect]
+  end
+  A5 --> R5 --> B5
+  A6 --> R6 --> B5
+  A7 --> R7 --> B5
+  A1 --> B1
+  A3 --> B3
+```
+
+Tests added/run for this change (all read-only, no flakes):
+
+```text
+running 5 tests from ./test/scripts/ParityAuditsConsolidation.ts
+docs/PARITY_AUDITS.md exists and covers each archived audit ... ok
+each audit stub redirects to the consolidated doc ... ok
+docs/EXTERNAL_NEAT_AI_CORE.md is the cluster overview ... ok
+docs/CI_EXTERNAL_NEAT_AI_CORE.md matches the real workflows ... ok
+docs/README.md links the consolidated audit doc ... ok
+ok | 27 passed | 0 failed
+```
+
+`./quality.sh --lint-only` exits 0 with no formatting or lint errors.
+
+This is a docs-only change with no UI surface; the evidence is the Mermaid
+diagram above and the new test file's assertions.
+
+## Test Plan
+
+- [x] **New test** — `test/scripts/ParityAuditsConsolidation.ts` (5 tests).
+- [x] **Existing related tests** still pass:
+      `test/scripts/CoreDependencyPolicy.ts` (4), `test/scripts/ParityGate.ts`
+      (8), `test/scripts/ContributorCoreDocs.ts` (6),
+      `test/scripts/ScorerAlignmentPolicy.ts` (4) — 22 total.
+- [x] **Quality gate** — `./quality.sh --lint-only < /dev/null` passes.
+- [x] **Inbound links audited** — the only inbound references to the three stub
+      paths are in `docs/pr-summary-2367.md`, `pr-summary-2368.md`,
+      `pr-summary-2369.md`, and `docs/README.md`. The pr-summary files keep
+      their original links because the stubs remain as redirect pages;
+      `docs/README.md` and `AGENTS.md` are updated to point at the consolidated
+      doc directly.

--- a/test/scripts/ParityAuditsConsolidation.ts
+++ b/test/scripts/ParityAuditsConsolidation.ts
@@ -1,0 +1,88 @@
+import { assert, assertStringIncludes } from "@std/assert";
+
+/**
+ * Issue #2570 — verifies the parity-audit doc consolidation.
+ *
+ * The three small `*_PARITY_AUDIT.md` stubs are merged into a single
+ * `docs/PARITY_AUDITS.md`. The originals are kept as short redirect
+ * notes so historical PR-summary links still resolve.
+ *
+ * The consolidated doc must cover all three audits (NEAT-AI-core,
+ * rust_scorer, wasm_activation) and link to the cluster overview.
+ */
+
+const CONSOLIDATED = "docs/PARITY_AUDITS.md";
+const STUBS = [
+  "docs/NEAT_AI_CORE_PARITY_AUDIT.md",
+  "docs/RUST_SCORER_PARITY_AUDIT.md",
+  "docs/WASM_ACTIVATION_PARITY_AUDIT.md",
+];
+const OVERVIEW = "docs/EXTERNAL_NEAT_AI_CORE.md";
+
+Deno.test("docs/PARITY_AUDITS.md exists and covers each archived audit", async () => {
+  const info = await Deno.stat(CONSOLIDATED);
+  assert(info.isFile, `${CONSOLIDATED} must exist`);
+
+  const content = await Deno.readTextFile(CONSOLIDATED);
+  // The consolidated doc is the single home for the three archived
+  // audits; each issue number must remain searchable.
+  assertStringIncludes(content, "#2367");
+  assertStringIncludes(content, "#2368");
+  assertStringIncludes(content, "#2369");
+  // Each audit subject area is named.
+  assertStringIncludes(content, "NEAT-AI-core");
+  assertStringIncludes(content, "rust_scorer");
+  assertStringIncludes(content, "wasm_activation");
+  // Links forward to the live verification surfaces.
+  assertStringIncludes(content, "scripts/parity-gate.sh");
+  assertStringIncludes(content, "PARITY_GATE.md");
+});
+
+Deno.test("each audit stub redirects to the consolidated doc", async () => {
+  const stubChecks = await Promise.all(
+    STUBS.map(async (stub) => ({
+      stub,
+      info: await Deno.stat(stub),
+      content: await Deno.readTextFile(stub),
+    })),
+  );
+  for (const { stub, info, content } of stubChecks) {
+    assert(info.isFile, `${stub} must remain as a redirect`);
+    assertStringIncludes(
+      content,
+      "PARITY_AUDITS.md",
+      `${stub} must point readers at the consolidated doc`,
+    );
+  }
+});
+
+Deno.test("docs/EXTERNAL_NEAT_AI_CORE.md is the cluster overview", async () => {
+  const content = await Deno.readTextFile(OVERVIEW);
+  // Cluster overview lists every detail doc in the cluster.
+  assertStringIncludes(content, "CORE_DEPENDENCY_POLICY.md");
+  assertStringIncludes(content, "PARITY_GATE.md");
+  assertStringIncludes(content, "CI_EXTERNAL_NEAT_AI_CORE.md");
+  assertStringIncludes(content, "PARITY_AUDITS.md");
+  // A Mermaid diagram showing core ↔ extension ↔ this repo.
+  assertStringIncludes(content, "```mermaid");
+});
+
+Deno.test("docs/CI_EXTERNAL_NEAT_AI_CORE.md matches the real workflows", async () => {
+  const content = await Deno.readTextFile("docs/CI_EXTERNAL_NEAT_AI_CORE.md");
+  // The actual CI command in .github/workflows/quality.yml and
+  // publish.yml is `./build.sh --verify-only`; documentation must
+  // not contradict the workflow.
+  assertStringIncludes(content, "./build.sh --verify-only");
+  // The doc points at the actual workflow files for evidence.
+  assertStringIncludes(content, ".github/workflows/quality.yml");
+  assertStringIncludes(content, ".github/workflows/publish.yml");
+});
+
+Deno.test("docs/README.md links the consolidated audit doc", async () => {
+  const content = await Deno.readTextFile("docs/README.md");
+  assertStringIncludes(
+    content,
+    "PARITY_AUDITS.md",
+    "docs/README.md must list the consolidated parity audits doc",
+  );
+});


### PR DESCRIPTION
# PR Summary — Issue #2570

## Summary

Consolidates the seven-doc core-dependency / parity-audit cluster so it follows
the parent issue's "brief summary + link to detail" pattern. Closes #2570.

The three small `*_PARITY_AUDIT.md` stubs (430, 360, 628 bytes — all under 1KB)
merge into a single `docs/PARITY_AUDITS.md`. The originals become short redirect
notes so historical PR-summary links keep working. `EXTERNAL_NEAT_AI_CORE.md` is
promoted to the cluster overview with a Mermaid diagram of the dependency
relationship and a table linking every detail doc. `CI_EXTERNAL_NEAT_AI_CORE.md`
is reconciled against the actual GitHub Actions workflows
(`.github/workflows/quality.yml` and `publish.yml`), which both use
`./build.sh --verify-only` rather than the bare `./build.sh` shown in the
previous draft.

### Changes

- **New:** `docs/PARITY_AUDITS.md` — the single home for the three archived
  audits (Issues #2367, #2368, #2369), with a Mermaid diagram, cross-links into
  the live parity gate and the original `pr-summary-*` narratives, plus links to
  the implementing test files (`test/score/WasmJsScoreParity.ts`,
  `test/costs/MSE.ts`).
- **New:** `test/scripts/ParityAuditsConsolidation.ts` — quality-gate test that
  verifies the consolidation: the new doc covers each audit, every stub
  redirects, the cluster overview links every detail doc and carries a Mermaid
  diagram, and the CI doc cites the real workflow files.
- **Replaced:** `docs/NEAT_AI_CORE_PARITY_AUDIT.md`,
  `docs/RUST_SCORER_PARITY_AUDIT.md`, `docs/WASM_ACTIVATION_PARITY_AUDIT.md` —
  three short redirect notes pointing at the consolidated doc.
- **Promoted:** `docs/EXTERNAL_NEAT_AI_CORE.md` to the cluster overview. Adds a
  Mermaid `flowchart LR` of NEAT-AI-core → this repo → downstream extensions, a
  TL;DR, a 5-row cluster map table, an explicit link to
  `test/scripts/ScorerAlignmentPolicy.ts`, and a See-also entry linking to the
  Discovery cluster (`DISCOVERY_ARCHITECTURE.md`).
- **Reconciled:** `docs/CI_EXTERNAL_NEAT_AI_CORE.md` with the live workflow
  files. Adds a workflow/job/step/command table that points at
  `.github/workflows/quality.yml` and `publish.yml`, and notes the
  `--verify-only` invariant.
- **Cross-links:** `docs/CORE_DEPENDENCY_POLICY.md` gains a _Pre-PR auto-bump_
  section describing `bump-deps.sh` and links to
  `test/scripts/BumpDepsScript.ts`. `docs/PARITY_GATE.md` and
  `docs/CORE_DEPENDENCY_POLICY.md` Related-Documents now reference the
  consolidated audit doc.
- **Index/AGENTS:** `docs/README.md` swaps the three stubs for the consolidated
  `PARITY_AUDITS.md` entry plus an overview-marker on
  `EXTERNAL_NEAT_AI_CORE.md`. `AGENTS.md` Related-Documents replaces the
  per-stub entry with a single `PARITY_AUDITS.md` row.

## Evidence

```mermaid
flowchart LR
  subgraph Before["Before — 7 docs, 3 sub-1KB stubs"]
    A1[EXTERNAL_NEAT_AI_CORE.md]
    A2[CORE_DEPENDENCY_POLICY.md]
    A3[CI_EXTERNAL_NEAT_AI_CORE.md]
    A4[PARITY_GATE.md]
    A5[NEAT_AI_CORE_PARITY_AUDIT.md ~430B]
    A6[RUST_SCORER_PARITY_AUDIT.md ~360B]
    A7[WASM_ACTIVATION_PARITY_AUDIT.md ~628B]
  end
  subgraph After["After — overview + 3 detail docs + 1 archive doc"]
    B1["EXTERNAL_NEAT_AI_CORE.md<br/>cluster overview + Mermaid"]
    B2[CORE_DEPENDENCY_POLICY.md]
    B3["CI_EXTERNAL_NEAT_AI_CORE.md<br/>reconciled with workflows"]
    B4[PARITY_GATE.md]
    B5["PARITY_AUDITS.md<br/>consolidated #2367 + #2368 + #2369"]
    R5[stub → redirect]
    R6[stub → redirect]
    R7[stub → redirect]
  end
  A5 --> R5 --> B5
  A6 --> R6 --> B5
  A7 --> R7 --> B5
  A1 --> B1
  A3 --> B3
```

Tests added/run for this change (all read-only, no flakes):

```text
running 5 tests from ./test/scripts/ParityAuditsConsolidation.ts
docs/PARITY_AUDITS.md exists and covers each archived audit ... ok
each audit stub redirects to the consolidated doc ... ok
docs/EXTERNAL_NEAT_AI_CORE.md is the cluster overview ... ok
docs/CI_EXTERNAL_NEAT_AI_CORE.md matches the real workflows ... ok
docs/README.md links the consolidated audit doc ... ok
ok | 27 passed | 0 failed
```

`./quality.sh --lint-only` exits 0 with no formatting or lint errors.

This is a docs-only change with no UI surface; the evidence is the Mermaid
diagram above and the new test file's assertions.

## Test Plan

- [x] **New test** — `test/scripts/ParityAuditsConsolidation.ts` (5 tests).
- [x] **Existing related tests** still pass:
      `test/scripts/CoreDependencyPolicy.ts` (4), `test/scripts/ParityGate.ts`
      (8), `test/scripts/ContributorCoreDocs.ts` (6),
      `test/scripts/ScorerAlignmentPolicy.ts` (4) — 22 total.
- [x] **Quality gate** — `./quality.sh --lint-only < /dev/null` passes.
- [x] **Inbound links audited** — the only inbound references to the three stub
      paths are in `docs/pr-summary-2367.md`, `pr-summary-2368.md`,
      `pr-summary-2369.md`, and `docs/README.md`. The pr-summary files keep
      their original links because the stubs remain as redirect pages;
      `docs/README.md` and `AGENTS.md` are updated to point at the consolidated
      doc directly.



## Milestone
This PR is part of the **Documentation May 2026** milestone and targets the `milestone/documentation-may-2026` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2570 -->