### PR TITLE
docs: refresh activation, WASM & GPU compute cluster (#2568)

### DIFF
--- a/docs/ACTIVATION_FUNCTIONS.md
+++ b/docs/ACTIVATION_FUNCTIONS.md
@@ -1,5 +1,30 @@
 # ⚡ Activation Functions Guide
 
+> **TL;DR** — A **squash** function (NEAT-AI's name for an activation function)
+> is the small per-neuron non-linearity that turns a neuron's pre-activation sum
+> `v = b + Σ(wᵢ·aᵢ)` into its output. NEAT-AI ships 32 standard squashes, 3
+> aggregate functions, and 3 deprecated squashes kept only for backward
+> compatibility — every name in the tables below resolves to a real export under
+> [`src/methods/activations/`](../src/methods/activations/) (or
+> [`src/deprecated/`](../src/deprecated/) for the deprecated set). This guide
+> explains how to pick one. Acronyms used here: **ReLU** (Rectified Linear
+> Unit), **GELU** (Gaussian Error Linear Unit), **ELU** (Exponential Linear
+> Unit), **SELU** (Scaled ELU), **TANH** (hyperbolic tangent), **NaN** (Not a
+> Number).
+
+### 🔗 Sibling docs in the **Compute / WASM** cluster
+
+- [BACKPROP_ELASTICITY.md](./BACKPROP_ELASTICITY.md) — how saturated squashes
+  interact with elastic weight updates (where this guide ends, that one begins).
+- [WASM_RESIDENT_TOPOLOGY.md](./WASM_RESIDENT_TOPOLOGY.md) — what crosses the
+  TypeScript ↔ WebAssembly (WASM) boundary during activation.
+- [GPU_ACCELERATION.md](./GPU_ACCELERATION.md) — Graphics Processing Unit (GPU)
+  acceleration of activation/synapse evaluation in the Discovery Foreign
+  Function Interface (FFI).
+- [INTELLIGENT_DESIGN.md](./INTELLIGENT_DESIGN.md) — automated per-neuron squash
+  selection via `scanForSquashImprovements`.
+- [docs/README.md](./README.md) — full topic index.
+
 This guide covers all activation functions available in NEAT-AI, helps you
 understand their characteristics, and provides guidance on selecting the right
 function for your use case.
@@ -99,11 +124,33 @@ with existing trained models.
 > continue to function correctly, but you should plan to migrate away from them
 > in future training runs.
 
-| Name    | Output Range | Replacement                | Why Deprecated                                      |
-| :------ | :----------- | :------------------------- | :-------------------------------------------------- |
-| HYPOT   | (-inf, inf)  | Standard activation + bias | Expensive, unpredictable behaviour as a squash      |
-| HYPOTv2 | [0, inf)     | Standard activation + bias | Same issues as HYPOT                                |
-| MEAN    | (-inf, inf)  | Normal neuron with weights | A standard neuron can replicate averaging behaviour |
+| Name                                    | Output Range | Replacement                | Why Deprecated                                      |
+| :-------------------------------------- | :----------- | :------------------------- | :-------------------------------------------------- |
+| [HYPOT](../src/deprecated/HYPOT.ts)     | (-inf, inf)  | Standard activation + bias | Expensive, unpredictable behaviour as a squash      |
+| [HYPOTv2](../src/deprecated/HYPOTv2.ts) | [0, inf)     | Standard activation + bias | Same issues as HYPOT                                |
+| [MEAN](../src/deprecated/MEAN.ts)       | (-inf, inf)  | Normal neuron with weights | A standard neuron can replicate averaging behaviour |
+
+All three deprecated squashes still load and activate correctly so legacy models
+keep working — they are just excluded from the mutation pool. New training runs
+will never select them. See [`src/deprecated/`](../src/deprecated/) for the
+implementations.
+
+### 🔄 Where the Squash Sits in the Compute Pipeline
+
+```mermaid
+flowchart LR
+    Input[Inputs aᵢ] --> Sum["Pre-activation<br/>v = b + Σ(wᵢ·aᵢ)"]
+    Sum --> Squash["Squash function<br/>(this guide)"]
+    Squash --> Output[Output a]
+    Output --> Loss[Loss / error]
+    Loss --> Elastic["Elastic distribution<br/>(BACKPROP_ELASTICITY.md)"]
+    Elastic -.weight & bias updates.-> Sum
+    Squash -. safe-zone factor .-> Elastic
+```
+
+The squash function and its derivative/inverse jointly drive the elastic
+backpropagation step described in
+[BACKPROP_ELASTICITY.md](./BACKPROP_ELASTICITY.md).
 
 ---
 

--- a/docs/BACKPROP_ELASTICITY.md
+++ b/docs/BACKPROP_ELASTICITY.md
@@ -1,3 +1,26 @@
+# 🔄 Elastic Back Propagation
+
+> **TL;DR** — NEAT-AI's backpropagation does not blindly apply the chain rule
+> everywhere. It (a) computes a target pre-squash value for each neuron, (b)
+> distributes the required change across inbound weights using a minimum-change
+> heuristic weighted by `activationᵢ² × safeZoneFactorᵢ`, and (c) refuses to
+> push neurons that are already saturated further into saturation. The
+> topological backprop loop and the elastic distribution kernel both live in
+> WebAssembly (WASM) — there is no TypeScript fallback. Acronyms used here:
+> **WASM** (WebAssembly), **ReLU** (Rectified Linear Unit), **TANH** (hyperbolic
+> tangent), **MCMC** (Markov-chain Monte Carlo).
+
+### 🔗 Sibling docs in the **Compute / WASM** cluster
+
+- [ACTIVATION_FUNCTIONS.md](./ACTIVATION_FUNCTIONS.md) — squash catalogue and
+  saturation behaviour referenced throughout this doc.
+- [WASM_RESIDENT_TOPOLOGY.md](./WASM_RESIDENT_TOPOLOGY.md) — what data the WASM
+  backprop kernel reads from the typed-array topology.
+- [GPU_ACCELERATION.md](./GPU_ACCELERATION.md) — Discovery uses the same
+  per-neuron error attribution, accelerated on Graphics Processing Unit (GPU)
+  hardware.
+- [docs/README.md](./README.md) — full topic index.
+
 ## 🔄 Elastic Back Propagation (minimum-change + safe-zone aware)
 
 This project uses a value-solving form of back propagation.
@@ -15,6 +38,33 @@ immovable neurons.
 > preferring plastic (unsaturated) synapses over those that are already at their
 > activation boundary. This improves training stability and helps the network
 > avoid chasing meaningless error outliers.
+
+### 🧭 End-to-End Sequence
+
+The diagram below traces a single training iteration: forward pass, error
+computation, elastic distribution of that error across inbound links, and the
+resulting weight/bias update. The two highlighted steps are the WASM-only
+kernels described in `AGENTS.md` § "WASM-only operations".
+
+```mermaid
+sequenceDiagram
+    participant TS as TypeScript orchestrator
+    participant Topo as Typed-array topology
+    participant Wasm as WASM kernels (NEAT-AI-core)
+    participant Squash as Squash function
+
+    TS->>Topo: prepare typed arrays (weights, biases, activations)
+    TS->>Wasm: propagate_topological(forward pass)
+    Wasm->>Squash: apply per-neuron squash
+    Squash-->>Wasm: activation a, safeZoneFactor
+    Wasm-->>TS: per-neuron activations
+    TS->>TS: compute output error vs expected
+    Note over TS,Wasm: WASM-only — no TS fallback
+    TS->>Wasm: distribute_elastic_error(error, links)
+    Wasm-->>TS: per-link share = error · aᵢ² · sZFᵢ / Σ
+    TS->>Topo: apply weight & bias updates (adjustedWeight, adjustedBias)
+    Topo-->>TS: next iteration ready
+```
 
 ### 🧪 Training vs Recording (Explorer / Discovery)
 
@@ -156,7 +206,20 @@ With elastic backprop + safe-zones:
 
 ### 🗂️ Where to Look in Code
 
-- Elastic distribution helper: `src/propagate/ElasticDistribution.ts`
-- Back propagation application: `src/architecture/Neuron.ts`
+The TypeScript side is now a thin orchestration layer; the per-iteration
+topological loop and the elastic distribution kernel live exclusively in the
+NEAT-AI-core WASM bundle (Issue #2416). If the bundle cannot be loaded these
+operations fail fast with a `WasmError` — there is **no TypeScript fallback**.
+
+- Elastic distribution adapter (TS shim around the WASM kernel):
+  [`src/propagate/ElasticDistribution.ts`](../src/propagate/ElasticDistribution.ts)
+- Topological backprop wrapper (calls into WASM):
+  [`src/propagate/WasmTopologicalBackprop.ts`](../src/propagate/WasmTopologicalBackprop.ts)
+- Back-propagation application:
+  [`src/architecture/Neuron.ts`](../src/architecture/Neuron.ts)
   (`Neuron.propagate()`)
-- Example saturating squash: `src/methods/activations/types/ArcTan.ts`
+- Example saturating squash:
+  [`src/methods/activations/types/ArcTan.ts`](../src/methods/activations/types/ArcTan.ts)
+- WASM artefacts (vendored from the pinned NEAT-AI-core revision):
+  [`wasm_activation/pkg/`](../wasm_activation/pkg/) — see `AGENTS.md` for the
+  WASM-only operations list and core dependency policy.

--- a/docs/GPU_ACCELERATION.md
+++ b/docs/GPU_ACCELERATION.md
@@ -1,10 +1,35 @@
 # 🖥️ GPU Acceleration for Discovery
 
+> **TL;DR** — Discovery's heavy synapse/neuron analysis runs on a Graphics
+> Processing Unit (GPU) when one is available, via the cross-platform `wgpu`
+> abstraction. `wgpu` selects Metal on macOS, Vulkan on Linux, DirectX 12 (DX12)
+> on Windows, and falls back to a Central Processing Unit (CPU) path when no
+> compatible GPU is found. The acceleration is part of the **Discovery Foreign
+> Function Interface (FFI)** surface — see
+> [DISCOVERY_GUIDE.md](./DISCOVERY_GUIDE.md) for the end-to-end workflow.
+> Acronyms used here: **GPU** (Graphics Processing Unit), **CPU** (Central
+> Processing Unit), **FFI** (Foreign Function Interface), **WGSL** (WebGPU
+> Shading Language), **DX12** (Microsoft DirectX 12), **API** (Application
+> Programming Interface).
+
+### 🔗 Sibling docs
+
+- **Compute / WASM cluster**:
+  [ACTIVATION_FUNCTIONS.md](./ACTIVATION_FUNCTIONS.md) ·
+  [BACKPROP_ELASTICITY.md](./BACKPROP_ELASTICITY.md) ·
+  [WASM_RESIDENT_TOPOLOGY.md](./WASM_RESIDENT_TOPOLOGY.md).
+- **Discovery / FFI cluster**: [DISCOVERY_GUIDE.md](./DISCOVERY_GUIDE.md) ·
+  [DISCOVERY_ARCHITECTURE.md](./DISCOVERY_ARCHITECTURE.md) ·
+  [DISCOVERY_DIR.md](./DISCOVERY_DIR.md). GPU acceleration is part of the Rust
+  Discovery FFI surface — this document explains the compute layer underneath
+  those guides.
+- [docs/README.md](./README.md) — full topic index.
+
 ## 🔍 Overview
 
 The NEAT-AI Discovery Rust library supports **cross-platform GPU acceleration**
-via the `wgpu` crate. The wgpu abstraction layer automatically selects the best
-available GPU backend for the current platform:
+via the [`wgpu`](https://wgpu.rs/) crate. The wgpu abstraction layer
+automatically selects the best available GPU backend for the current platform:
 
 - **macOS**: Metal
 - **Linux**: Vulkan
@@ -13,10 +38,44 @@ available GPU backend for the current platform:
 When no compatible GPU is detected, discovery gracefully falls back to CPU
 computation. GPU accelerates analysis but is not required.
 
+### 🧭 Backend Compatibility Matrix
+
+The table below mirrors the backends advertised by the
+[NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) README
+and the `getGpuBackendInfo()` runtime probe.
+
+| Backend | Platform                         | Selected by `wgpu` when           | Status                            |
+| :------ | :------------------------------- | :-------------------------------- | :-------------------------------- |
+| Metal   | macOS (Apple Silicon, Intel)     | Default on macOS                  | ✅ Supported (primary dev target) |
+| Vulkan  | Linux (most distros)             | Default on Linux                  | ✅ Supported                      |
+| DX12    | Windows 10/11                    | Default on Windows                | ✅ Supported                      |
+| Gl      | Cross-platform (OpenGL fallback) | When no native API is usable      | ⚠️ Last-resort fallback           |
+| CPU     | All                              | No compatible GPU adapter present | ✅ Always available (slower)      |
+
+> [!NOTE]
+> The set of backends is determined entirely by the `wgpu` crate version pinned
+> in NEAT-AI-Discovery — there is no platform-specific code in this repository.
+> `getGpuBackendInfo()` reports the actual selection at runtime.
+
 > [!NOTE]
 > GPU acceleration is automatic and requires no platform-specific configuration.
 > The `wgpu` abstraction handles backend selection. Use `getGpuBackendInfo()` to
 > check which backend was selected.
+
+### 🛤️ Discovery → GPU Pipeline
+
+```mermaid
+flowchart LR
+    NEAT[NEAT-AI<br/>TypeScript] -->|Discovery FFI| Rust[NEAT-AI-Discovery<br/>Rust library]
+    Rust -->|wgpu adapter| Pick{wgpu backend<br/>selection}
+    Pick -->|macOS| Metal[Metal compute shaders]
+    Pick -->|Linux| Vulkan[Vulkan compute shaders]
+    Pick -->|Windows| DX12[DX12 compute shaders]
+    Pick -->|no GPU| CPUFallback[CPU fallback]
+    Metal & Vulkan & DX12 -->|WGSL kernels| Results[Helpful / harmful synapse<br/>+ neuron stats]
+    CPUFallback --> Results
+    Results -->|gpuUsed flag| NEAT
+```
 
 ## ⚡ Current GPU Implementation
 

--- a/docs/WASM_RESIDENT_TOPOLOGY.md
+++ b/docs/WASM_RESIDENT_TOPOLOGY.md
@@ -1,7 +1,74 @@
 # 🔲 WASM-Resident Creature Topology: Feasibility Analysis
 
+> **TL;DR** — Should the entire creature topology live inside WebAssembly (WASM)
+> linear memory? **No.** The amortisation ratio of mutable topology is far too
+> low to pay for the dual-state synchronisation cost. NEAT-AI instead landed on
+> a hybrid: TypeScript holds the source-of-truth typed-array topology, while a
+> curated set of read-heavy, hot-path operations runs **only** in WASM
+> (validation, scanning, reverse topological order, cycle detection, the
+> topological backprop loop, and elastic error distribution — see `AGENTS.md` §
+> "WASM-only operations"). This document is the original feasibility analysis
+> kept for the record. Acronyms used here: **WASM** (WebAssembly), **TS**
+> (TypeScript), **JS** (JavaScript), **GC** (garbage collector), **FFI**
+> (Foreign Function Interface), **UUID** (Universally Unique Identifier),
+> **LRU** (least recently used).
+
+### 🔗 Sibling docs in the **Compute / WASM** cluster
+
+- [ACTIVATION_FUNCTIONS.md](./ACTIVATION_FUNCTIONS.md) — squash catalogue
+  applied during activation.
+- [BACKPROP_ELASTICITY.md](./BACKPROP_ELASTICITY.md) — the WASM-only topological
+  backprop and elastic distribution kernels that read this topology.
+- [GPU_ACCELERATION.md](./GPU_ACCELERATION.md) — the same typed-array topology
+  shape is shipped over the Discovery FFI to the Graphics Processing Unit (GPU)
+  compute layer.
+- [PERFORMANCE_RESEARCH.md](./PERFORMANCE_RESEARCH.md) — broader WASM migration
+  learnings.
+- [docs/README.md](./README.md) — full topic index.
+
 Investigation for [#1642](https://github.com/stSoftwareAU/NEAT-AI/issues/1642),
 part of the WASM performance optimisation series (#1639).
+
+## 🧭 TypeScript ↔ WASM Boundary
+
+The diagram below summarises what crosses the boundary today (after
+#1957/#1959/#2415/#2416) versus what stays inside each side.
+
+```mermaid
+flowchart LR
+    subgraph TS["TypeScript (source of truth)"]
+        Creature[Creature object<br/>UUIDs, squash names]
+        Typed[TypedTopology<br/>Float64Array / Uint32Array / Uint8Array]
+        Mutate[Mutation & breeding operators]
+        Cache[TopologyCaches<br/>UUID → index, LRU compatibility]
+    end
+    subgraph WASM["WASM (NEAT-AI-core, hot path only)"]
+        Validate[validate_topology]
+        Scan[scan_available_connections]
+        Order[compute_reverse_topological_order]
+        Cycles[detect_cycles]
+        Activate[propagate_topological<br/>forward + backward]
+        Elastic[distribute_elastic_error]
+    end
+    Mutate --> Creature
+    Creature -->|sync| Typed
+    Typed -- typed-array slice (memcpy) --> Validate
+    Typed -- typed-array slice --> Scan
+    Typed -- typed-array slice --> Order
+    Typed -- typed-array slice --> Cycles
+    Typed -- header + payload --> Activate
+    Activate -- result buffer --> Typed
+    Typed -- error + links --> Elastic
+    Elastic -- per-link shares --> Mutate
+    Cache -. UUID-only wire format .- Creature
+```
+
+What **crosses** the boundary: typed-array payloads (weights, biases,
+activations, connectivity indices, squash IDs, error vectors) — never UUID
+strings, never JS objects. What **stays inside TS**: UUID identity,
+mutation/breeding logic, compatibility caches, and lifecycle management. What
+**stays inside WASM**: the validation/scanning/ordering/cycle kernels and the
+topological forward+backward loops with their elastic distribution step.
 
 ## 📋 Executive Summary
 
@@ -372,5 +439,11 @@ Implementation files:
 - #1644 — Breeding crossover allocation reduction
 - #1957 — Typed array topology implementation
 - #1959 — Selective WASM residency for read-heavy topology operations
+- #2415 — Removal of `*TS` fallbacks for the read-heavy topology operations
+  (WASM-only)
+- #2416 — Removal of TypeScript fallbacks for the topological backprop loop and
+  elastic distribution (WASM-only)
+- `AGENTS.md` § "WASM-only operations (no TS fallback)" — current canonical list
+  of operations that fail fast without the WASM bundle
 - `docs/PERFORMANCE_RESEARCH.md` — Performance research with WASM migration
   learnings

--- a/docs/pr-summary-2568.md
+++ b/docs/pr-summary-2568.md
@@ -1,0 +1,75 @@
+# PR Summary — Issue #2568
+
+## Summary
+
+Refreshed the four "compute cluster" docs so they read as a coherent group and
+match the code they describe. Each file now opens with a TL;DR, expands its
+acronyms (WASM, GPU, FFI, ReLU, GELU, ELU, SELU, etc.), cross-links the other
+three siblings plus the docs index, and gains at least one new Mermaid
+diagram. Closes #2568.
+
+Changed files:
+
+- `docs/ACTIVATION_FUNCTIONS.md` — TL;DR + sibling links; squash list verified
+  one-for-one against `src/methods/activations/types/`,
+  `src/methods/activations/aggregate/`, and `src/deprecated/`; deprecated rows
+  now link to source; new `flowchart` showing where the squash sits in the
+  forward/backprop pipeline.
+- `docs/BACKPROP_ELASTICITY.md` — TL;DR + sibling links; new `sequenceDiagram`
+  for forward → error → elastic distribution → weight update; "Where to Look
+  in Code" updated to call out that the topological backprop loop and elastic
+  distribution kernel are WASM-only (Issue #2416, no TS fallback) and to link
+  the WASM artefacts under `wasm_activation/pkg/`.
+- `docs/WASM_RESIDENT_TOPOLOGY.md` — TL;DR clarifying the analysis is "defer
+  full residency, ship selective WASM-only kernels" plus sibling links;
+  new `flowchart` of the TS ↔ WASM boundary (what crosses, what stays inside);
+  references updated to include #2415/#2416 and the `AGENTS.md` WASM-only
+  operations list.
+- `docs/GPU_ACCELERATION.md` — TL;DR with acronym expansions and a pointer to
+  `DISCOVERY_GUIDE.md`; backend compatibility table (Metal / Vulkan / DX12 /
+  Gl / CPU) matching the NEAT-AI-Discovery README and `getGpuBackendInfo()`
+  return shape; new Discovery → GPU pipeline `flowchart`.
+
+## Evidence
+
+This is a docs-only change — no source files modified, no UI surface to
+screenshot. The cluster reading map is unchanged in `docs/README.md`; this PR
+just deepens each leaf.
+
+```mermaid
+flowchart LR
+    Input --> Topology[WASM-resident topology]
+    Topology --> Squash[Activation/squash functions]
+    Squash --> Output
+    Squash --> Backprop[Backprop elasticity]
+    Topology --> GPU[GPU acceleration via Discovery FFI]
+```
+
+Squash audit — every name in `ACTIVATION_FUNCTIONS.md` resolves to a real
+export:
+
+- 32 standard squashes — match `src/methods/activations/types/*.ts`
+- 3 aggregate squashes — match `src/methods/activations/aggregate/*.ts`
+- 3 deprecated squashes (HYPOT, HYPOTv2, MEAN) — match `src/deprecated/*.ts`,
+  and the table now links each row to the file.
+
+`./quality.sh --lint-only < /dev/null` passes (formatting auto-applied to the
+four files, lint clean across 1540 files, all bash scripts ✅).
+
+## Test Plan
+
+- Docs-only change. No new code paths, so no new unit tests.
+- Verified all four files render Mermaid blocks with valid syntax (fenced
+  ` ```mermaid ` blocks; flowchart/sequenceDiagram only).
+- Verified no Liquid `{% ... %}` / `{{ ... }}` patterns appear in prose.
+- Re-read the issue's acceptance criteria:
+  - [x] Each file starts with a brief summary and links to siblings + Discovery
+        cluster (where relevant).
+  - [x] At least one new Mermaid diagram per file.
+  - [x] First use of each acronym (WASM, GPU, FFI, NaN, ReLU, GELU, ELU, SELU,
+        TANH, MCMC, UUID, LRU, GC, WGSL, DX12) is expanded.
+  - [x] All squash names in `ACTIVATION_FUNCTIONS.md` resolve to real exports.
+  - [x] Cross-references to `docs/README.md` and sibling docs added in all
+        four files.
+  - [x] Australian English spelling preserved.
+  - [x] `./quality.sh --lint-only` passes.


### PR DESCRIPTION
# PR Summary — Issue #2568

## Summary

Refreshed the four "compute cluster" docs so they read as a coherent group and
match the code they describe. Each file now opens with a TL;DR, expands its
acronyms (WASM, GPU, FFI, ReLU, GELU, ELU, SELU, etc.), cross-links the other
three siblings plus the docs index, and gains at least one new Mermaid
diagram. Closes #2568.

Changed files:

- `docs/ACTIVATION_FUNCTIONS.md` — TL;DR + sibling links; squash list verified
  one-for-one against `src/methods/activations/types/`,
  `src/methods/activations/aggregate/`, and `src/deprecated/`; deprecated rows
  now link to source; new `flowchart` showing where the squash sits in the
  forward/backprop pipeline.
- `docs/BACKPROP_ELASTICITY.md` — TL;DR + sibling links; new `sequenceDiagram`
  for forward → error → elastic distribution → weight update; "Where to Look
  in Code" updated to call out that the topological backprop loop and elastic
  distribution kernel are WASM-only (Issue #2416, no TS fallback) and to link
  the WASM artefacts under `wasm_activation/pkg/`.
- `docs/WASM_RESIDENT_TOPOLOGY.md` — TL;DR clarifying the analysis is "defer
  full residency, ship selective WASM-only kernels" plus sibling links;
  new `flowchart` of the TS ↔ WASM boundary (what crosses, what stays inside);
  references updated to include #2415/#2416 and the `AGENTS.md` WASM-only
  operations list.
- `docs/GPU_ACCELERATION.md` — TL;DR with acronym expansions and a pointer to
  `DISCOVERY_GUIDE.md`; backend compatibility table (Metal / Vulkan / DX12 /
  Gl / CPU) matching the NEAT-AI-Discovery README and `getGpuBackendInfo()`
  return shape; new Discovery → GPU pipeline `flowchart`.

## Evidence

This is a docs-only change — no source files modified, no UI surface to
screenshot. The cluster reading map is unchanged in `docs/README.md`; this PR
just deepens each leaf.

```mermaid
flowchart LR
    Input --> Topology[WASM-resident topology]
    Topology --> Squash[Activation/squash functions]
    Squash --> Output
    Squash --> Backprop[Backprop elasticity]
    Topology --> GPU[GPU acceleration via Discovery FFI]
```

Squash audit — every name in `ACTIVATION_FUNCTIONS.md` resolves to a real
export:

- 32 standard squashes — match `src/methods/activations/types/*.ts`
- 3 aggregate squashes — match `src/methods/activations/aggregate/*.ts`
- 3 deprecated squashes (HYPOT, HYPOTv2, MEAN) — match `src/deprecated/*.ts`,
  and the table now links each row to the file.

`./quality.sh --lint-only < /dev/null` passes (formatting auto-applied to the
four files, lint clean across 1540 files, all bash scripts ✅).

## Test Plan

- Docs-only change. No new code paths, so no new unit tests.
- Verified all four files render Mermaid blocks with valid syntax (fenced
  ` ```mermaid ` blocks; flowchart/sequenceDiagram only).
- Verified no Liquid `{% ... %}` / `{{ ... }}` patterns appear in prose.
- Re-read the issue's acceptance criteria:
  - [x] Each file starts with a brief summary and links to siblings + Discovery
        cluster (where relevant).
  - [x] At least one new Mermaid diagram per file.
  - [x] First use of each acronym (WASM, GPU, FFI, NaN, ReLU, GELU, ELU, SELU,
        TANH, MCMC, UUID, LRU, GC, WGSL, DX12) is expanded.
  - [x] All squash names in `ACTIVATION_FUNCTIONS.md` resolve to real exports.
  - [x] Cross-references to `docs/README.md` and sibling docs added in all
        four files.
  - [x] Australian English spelling preserved.
  - [x] `./quality.sh --lint-only` passes.



## Milestone
This PR is part of the **Documentation May 2026** milestone and targets the `milestone/documentation-may-2026` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2568 -->