### PR TITLE
docs: split API_REFERENCE.md into index + topic detail docs (#2572)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,7 +645,9 @@ governance / contributor documents:
 - **[CHANGELOG.md](./CHANGELOG.md)** — release notes (Keep a Changelog +
   Semantic Versioning).
 - **[COMPARISON.md](./COMPARISON.md)** — comparison with other AI approaches.
-- **docs/API_REFERENCE.md** - Comprehensive public API reference
+- **docs/API_REFERENCE.md** - Short index for the public API; per-surface detail
+  docs live under **docs/api/** (Creature, Evolution, Configuration, Costs &
+  Activations, Training, Discovery, Compute, Errors, Interop)
 - **docs/CRISPR_GUIDE.md** - CRISPR conventions, append+demote pattern, and
   validation rules
 - **docs/DISCOVERY_GUIDE.md** - Complete discovery workflow guide

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ For detailed documentation, see the [docs/](./docs/) directory:
 
 ### 🔧 API & Reference
 
-- **[API Reference](./docs/API_REFERENCE.md)**: Comprehensive public API
-  documentation
+- **[API Reference](./docs/API_REFERENCE.md)**: Short topic index linking to
+  per-surface detail docs under [`docs/api/`](./docs/api/)
 - **[DiscoveryDir API](./docs/DISCOVERY_DIR.md)**: Technical API reference for
   `Creature.discoveryDir()` and data preparation
 - **[Activation Functions Guide](./docs/ACTIVATION_FUNCTIONS.md)**: Complete

--- a/docs/CRISPR_GUIDE.md
+++ b/docs/CRISPR_GUIDE.md
@@ -3,8 +3,8 @@
 Targeted genetic modifications for NEAT-AI creatures, inspired by the
 [CRISPR gene-editing technique](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/).
 This guide complements the CRISPR API summary in
-[`docs/API_REFERENCE.md`](API_REFERENCE.md) with the conventions and gotchas
-that catch out new authors.
+[`docs/api/CREATURE.md`](api/CREATURE.md#-crispr) with the conventions and
+gotchas that catch out new authors.
 
 ## Modes
 

--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -513,8 +513,7 @@ Discovery will analyse these neurons first before doing weighted selection.
 ## 📚 See Also
 
 - [`docs/README.md`](README.md) — topic index for all NEAT-AI documentation.
-- [API Reference — Discovery](API_REFERENCE.md#7-discovery-api) — Programmatic
-  API reference.
+- [API Reference — Discovery](api/DISCOVERY.md) — Programmatic API reference.
 - [DiscoveryDir Integration Guide](DISCOVERY_DIR.md) — Technical API reference
   for `Creature.discoveryDir()` and the on-disk cache layout.
 - [Discovery Architecture](DISCOVERY_ARCHITECTURE.md) — Internal pipeline

--- a/docs/api/COMPUTE.md
+++ b/docs/api/COMPUTE.md
@@ -1,0 +1,147 @@
+# 🧵 Compute, WASM, and Multithreading
+
+Worker entry points, WASM (WebAssembly) preloading, and cache diagnostics for
+the compute layer that powers `Creature.activate()`.
+
+> **Acronyms:** API (Application Programming Interface), WASM (WebAssembly), JSR
+> (JavaScript Registry), LRU (Least Recently Used), GC (Garbage Collection).
+
+## 📦 Exports documented here
+
+- `fetchWasmForWorkers`, `loadWasmActivationInitPayloadAsync`,
+  `WasmActivationInitPayload`, `initialiseWasmActivationFromPayload`
+- `disposeAllCachedWasmActivations`, `getCachedWasmActivationCount`,
+  `getMaxCachedWasmCreatureActivations`, `setMaxCachedWasmCreatureActivations`,
+  `getWasmActivationLruStats`, `resetWasmActivationLruStats`
+- `CacheStats`, `getCacheStats`
+
+## ⚡ WASM preloading for workers
+
+Issue #1285 / Issue #2545: call `fetchWasmForWorkers()` in the main thread
+before spawning workers so WASM is fetched once and cached. Workers then receive
+the cached payload instead of each fetching separately.
+
+```typescript
+import { fetchWasmForWorkers } from "@stsoftware/neat-ai";
+
+// Main thread — call once before evolveDir() with threads > 1
+await fetchWasmForWorkers();
+```
+
+> [!TIP]
+> Call `fetchWasmForWorkers()` once before `evolveDir()` whenever `threads > 1`.
+> This avoids each worker independently fetching and compiling the WASM binary,
+> which can significantly reduce startup time in large-population runs.
+
+### Consumer-owned worker bootstrap
+
+For _consumer-owned_ Deno workers that import NEAT-AI from JSR (JavaScript
+Registry) and may not have `--allow-net` to `jsr.io` inside the worker scope:
+
+1. Fetch the payload with `loadWasmActivationInitPayloadAsync()` in the parent
+   thread.
+2. Send the resulting bytes to the worker via `postMessage`.
+3. Inside the worker, bootstrap WASM by calling
+   `initialiseWasmActivationFromPayload(payload)`.
+
+```typescript
+import {
+  initialiseWasmActivationFromPayload,
+  loadWasmActivationInitPayloadAsync,
+} from "@stsoftware/neat-ai";
+import type { WasmActivationInitPayload } from "@stsoftware/neat-ai";
+
+// Parent
+const payload: WasmActivationInitPayload =
+  await loadWasmActivationInitPayloadAsync();
+worker.postMessage({ type: "wasm-payload", payload });
+
+// Worker
+worker.addEventListener("message", (event) => {
+  if (event.data.type === "wasm-payload") {
+    initialiseWasmActivationFromPayload(event.data.payload);
+  }
+});
+```
+
+See [`docs/TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) for the full pattern.
+
+## 🔀 Using multiple threads
+
+Workers are managed automatically by `Creature.evolveDir()` when `threads > 1`:
+
+```typescript
+const result = await creature.evolveDir("./data", {
+  threads: 4, // Use 4 worker threads
+  costName: "MSE",
+  iterations: 100,
+});
+```
+
+Workers handle evaluation, training, discovery, and breeding in parallel. If a
+worker fails to initialise (e.g. in restricted environments), it falls back to
+direct (in-process) execution automatically.
+
+## 🗃️ WASM cache control
+
+Issues #1338, #1504, #1581: Control the WASM activation LRU (Least Recently
+Used) cache size, query occupancy, and flush all cached entries. Data-generation
+workloads that touch many creatures should lower the cache cap (e.g. 64–128) to
+reduce WASM heap retention, and call `disposeAllCachedWasmActivations()` between
+training runs to fully free WASM linear memory.
+
+```typescript
+import {
+  disposeAllCachedWasmActivations,
+  getCachedWasmActivationCount,
+  getMaxCachedWasmCreatureActivations,
+  getWasmActivationLruStats,
+  resetWasmActivationLruStats,
+  setMaxCachedWasmCreatureActivations,
+} from "@stsoftware/neat-ai";
+
+// Check current cache usage
+const count = getCachedWasmActivationCount();
+
+// Get the maximum cache size (default: 512)
+const max = getMaxCachedWasmCreatureActivations();
+
+// Reduce cache size if memory is tight
+setMaxCachedWasmCreatureActivations(256);
+
+// Inspect hit / miss / eviction counters
+const stats = getWasmActivationLruStats();
+resetWasmActivationLruStats();
+
+// Free all WASM linear memory between runs
+disposeAllCachedWasmActivations();
+```
+
+## 📊 Unified cache diagnostics
+
+Issue #1616: `getCacheStats()` returns hit/miss rates, eviction counts, and size
+metrics for every instrumented cache (WASM activation cache, distance cache,
+etc.). Use these metrics to tune cache configuration for your workload.
+
+```typescript
+import { getCacheStats } from "@stsoftware/neat-ai";
+import type { CacheStats } from "@stsoftware/neat-ai";
+
+const stats: CacheStats = getCacheStats();
+console.log(stats);
+```
+
+---
+
+## 🔗 Related topics
+
+- [Configuration reference](CONFIGURATION.md) — `threads` and
+  `parallelEvaluation` sub-config control how workers are spawned.
+- [Discovery](DISCOVERY.md) — discovery analysis runs through workers when
+  `threads > 1`.
+- [Creature](CREATURE.md) — `Creature.activate()` is the consumer of the WASM
+  activation cache.
+- [`docs/GPU_ACCELERATION.md`](../GPU_ACCELERATION.md) — GPU compute details.
+- [`docs/PERFORMANCE_TUNING.md`](../PERFORMANCE_TUNING.md) — operational tuning.
+- [`docs/TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) — worker-init failure
+  modes.

--- a/docs/api/CONFIGURATION.md
+++ b/docs/api/CONFIGURATION.md
@@ -1,0 +1,430 @@
+# ⚙️ Configuration reference
+
+`NeatOptions` is the primary configuration type for the NEAT (NeuroEvolution of
+Augmenting Topologies) algorithm. It is passed to `Creature.evolveDir()`. This
+page lists every field plus the optional sub-configuration objects.
+
+> **Acronyms:** API (Application Programming Interface), MCMC (Markov Chain
+> Monte Carlo), MSE (Mean Squared Error), L2 (squared-magnitude regularisation),
+> ONNX (Open Neural Network Exchange), JSON (JavaScript Object Notation), RNG
+> (Random Number Generator), CRISPR (Clustered Regularly Interspaced Short
+> Palindromic Repeats).
+
+For prose-level guidance on choosing values, see the long-form
+[Configuration Guide](../CONFIGURATION_GUIDE.md). This page is the
+field-by-field reference.
+
+## 📦 Exports documented here
+
+- `NeatOptions`, `NeatOptionsInput`
+- `OutputRange`, `RequiredOutputRange`, `DEFAULT_OUTPUT_RANGE_PENALTY_WEIGHT`,
+  `calculateOutputRangePenalty`
+- Hyperparameter evolution: `EvolvableHyperparameters`,
+  `HyperparameterEvolutionConfig`, `RequiredEvolvableHyperparameters`,
+  `RequiredHyperparameterEvolutionConfig`, `DEFAULT_EVOLVABLE_HYPERPARAMETERS`,
+  `DEFAULT_HYPERPARAMETER_EVOLUTION_CONFIG`
+- MCMC: `MCMCConfig`, `RequiredMCMCConfig`, `DiversityAwareMCMCConfig`,
+  `RequiredDiversityAwareMCMCConfig`, `DEFAULT_MCMC_CONFIG`,
+  `DEFAULT_DIVERSITY_AWARE_MCMC_CONFIG`
+- Adaptive population: `AdaptivePopulationConfig`,
+  `RequiredAdaptivePopulationConfig`, `DEFAULT_ADAPTIVE_POPULATION_CONFIG`
+- Parallel evaluation: `ParallelEvaluationConfig`,
+  `RequiredParallelEvaluationConfig`, `DEFAULT_PARALLEL_EVALUATION_CONFIG`
+- Data fuzzing: `DataFuzzingConfig`, `RequiredDataFuzzingConfig`,
+  `DEFAULT_DATA_FUZZING_CONFIG`
+- Disk space: `DiskSpaceConfig`, `RequiredDiskSpaceConfig`,
+  `DEFAULT_DISK_SPACE_CONFIG`
+- Specialist pipeline: `SpecialistConfig`, `RequiredSpecialistConfig`,
+  `SpecialistMode`, `DEFAULT_SPECIALIST_CONFIG`
+- Training events: `TrainingEvent`, `TrainingEventCallback`,
+  `GenerationCompleteEvent`, `PlateauDetectedEvent`, `DiscoveryCompleteEvent`,
+  `MemoryPressureEvent`, `SpeciesAdjustedEvent`
+- Logger and RNG: `Logger`, `LogLevel`, `createConsoleLogger`, `getLogger`,
+  `setLogger`, `SILENT_LOGGER`, `RandomNumberGenerator`, `createSeededRng`,
+  `createUnseededRng`, `getRandomNumberGenerator`, `setRandomNumberGenerator`
+
+## ⚙️ NeatOptions
+
+```typescript
+import type { NeatOptions, NeatOptionsInput } from "@stsoftware/neat-ai";
+```
+
+`NeatOptionsInput` is identical but accepts `string | number` for numeric fields
+(useful for command-line argument parsing).
+
+### 🎯 Core fields
+
+| Field            | Type                  | Default                         | Description                                                |
+| ---------------- | --------------------- | ------------------------------- | ---------------------------------------------------------- |
+| `costName`       | `CostName`            | `"MSE"`                         | Cost function name                                         |
+| `populationSize` | `number`              | `50`                            | Target population size (min: 2)                            |
+| `iterations`     | `number`              | `MAX_SAFE_INTEGER`              | Maximum evolution generations                              |
+| `targetError`    | `number`              | `0.05`                          | Stop when error falls below this (0–1)                     |
+| `mutationRate`   | `number`              | `0.3`                           | Probability of mutation (>0.001)                           |
+| `mutationAmount` | `number`              | `1`                             | Number of changes per gene during mutation (min: 1)        |
+| `elitism`        | `number`              | `1`                             | Top-performing creatures retained each generation (min: 1) |
+| `selection`      | `SelectionInterface`  | Random                          | Selection strategy (randomly chosen each run)              |
+| `mutation`       | `MutationInterface[]` | `Mutation.FFW`                  | Allowed mutation types                                     |
+| `threads`        | `number`              | `navigator.hardwareConcurrency` | Worker threads for parallel evaluation                     |
+| `verbose`        | `boolean`             | `false`                         | Enable debug logging                                       |
+| `log`            | `number`              | `0`                             | Log status every N generations (0 = off, 1 if verbose)     |
+
+### 🎓 Training fields
+
+| Field                          | Type     | Default           | Description                                |
+| ------------------------------ | -------- | ----------------- | ------------------------------------------ |
+| `trainPerGen`                  | `number` | `1`               | Backpropagation iterations per generation  |
+| `trainingBatchSize`            | `number` | `100`             | Samples per training batch                 |
+| `trainingSampleRate`           | `number` | `1.0`             | Fraction of data used per training pass    |
+| `maximumBiasAdjustmentScale`   | `number` | `1`               | Max bias change per backpropagation step   |
+| `maximumWeightAdjustmentScale` | `number` | `1`               | Max weight change per backpropagation step |
+| `sparseRatio`                  | `number` | `random * random` | Neuron selection ratio for sparse updates  |
+
+### 🔒 Network constraints
+
+| Field                  | Type      | Default       | Description                           |
+| ---------------------- | --------- | ------------- | ------------------------------------- |
+| `feedbackLoop`         | `boolean` | `false`       | Enable recurrent connections          |
+| `maxConns`             | `number`  | `Infinity`    | Maximum synapses allowed              |
+| `maximumNumberOfNodes` | `number`  | `Infinity`    | Maximum hidden neurons allowed        |
+| `costOfGrowth`         | `number`  | `0.000_000_1` | Complexity penalty per synapse/neuron |
+
+### 🔬 Discovery fields
+
+| Field                             | Type     | Default | Description                                  |
+| --------------------------------- | -------- | ------- | -------------------------------------------- |
+| `discoverySampleRate`             | `number` | `0.2`   | Fraction of data for discovery (20%)         |
+| `discoveryRecordTimeOutMinutes`   | `number` | `5`     | Minutes for discovery recording phase        |
+| `discoveryAnalysisTimeoutMinutes` | `number` | `10`    | Minutes for discovery analysis               |
+| `discoveryBatchSize`              | `number` | `128`   | Samples per discovery analysis batch         |
+| `discoveryMaxNeurons`             | `number` | `6`     | Max neurons analysed per discovery iteration |
+
+### 🧬 Evolution fields
+
+| Field                             | Type     | Default  | Description                                    |
+| --------------------------------- | -------- | -------- | ---------------------------------------------- |
+| `timeoutMinutes`                  | `number` | `0`      | Evolution timeout (0 = unlimited)              |
+| `focusRate`                       | `number` | `0.25`   | Attention weight for focus list observations   |
+| `globalBreedingRate`              | `number` | `random` | Cross-species vs within-species breeding ratio |
+| `geneticCompatibilityThreshold`   | `number` | `0.3`    | Genetic distance threshold for speciation      |
+| `creativeThinkingConnectionCount` | `number` | `1`      | New connections during creative thinking       |
+| `dataSetPartitionBreak`           | `number` | `2000`   | Records per dataset file partition             |
+
+### 🎲 Reproducibility fields
+
+| Field  | Type                    | Default     | Description                            |
+| ------ | ----------------------- | ----------- | -------------------------------------- |
+| `seed` | `number`                | `undefined` | PRNG seed for deterministic evolution  |
+| `rng`  | `RandomNumberGenerator` | `undefined` | Custom RNG instance (overrides `seed`) |
+
+---
+
+## 🗂️ Sub-configuration objects
+
+Each optional sub-config has a `Required*` companion type used internally after
+defaults are applied.
+
+### `plateauDetection` — PlateauDetectionConfig
+
+| Field                           | Type      | Default | Description                                       |
+| ------------------------------- | --------- | ------- | ------------------------------------------------- |
+| `enabled`                       | `boolean` | `false` | Enable plateau detection                          |
+| `windowSize`                    | `number`  | `10`    | Generations in the improvement window             |
+| `minImprovementRate`            | `number`  | `0.001` | Minimum improvement rate (0.1%)                   |
+| `rapidImprovementRate`          | `number`  | `0.01`  | Threshold for "rapid" improvement (1%)            |
+| `responseMutationMultiplier`    | `number`  | `2.0`   | Mutation rate multiplier on plateau               |
+| `responseImprovementMultiplier` | `number`  | `0.8`   | Mutation rate multiplier during rapid improvement |
+
+### `stabilityAdaptation` — StabilityAdaptationConfig
+
+| Field                                 | Type      | Default | Description                                       |
+| ------------------------------------- | --------- | ------- | ------------------------------------------------- |
+| `enabled`                             | `boolean` | `false` | Enable stability-based adaptation                 |
+| `stabilityWindowSize`                 | `number`  | `20`    | Window for stability measurement                  |
+| `brittlenessThreshold`                | `number`  | `0.3`   | Threshold below which a creature is "brittle"     |
+| `brittleReductionFactor`              | `number`  | `0.5`   | Mutation reduction for brittle creatures          |
+| `stableBoostFactor`                   | `number`  | `1.3`   | Mutation boost for stable creatures               |
+| `stableBoostThreshold`                | `number`  | `0.85`  | Stability score threshold for boost               |
+| `selectionStabilityWeight`            | `number`  | `0.2`   | Weight of stability in selection                  |
+| `adaptiveSelectionWeight`             | `boolean` | `false` | Auto-adjust selection weight                      |
+| `topologyMutationReductionForBrittle` | `number`  | `0.3`   | Topology mutation reduction for brittle creatures |
+| `trackPerMutationType`                | `boolean` | `false` | Track stability per mutation type                 |
+
+### `weightRegularisation` — WeightRegularisationConfig
+
+| Field                | Type      | Default | Description                        |
+| -------------------- | --------- | ------- | ---------------------------------- |
+| `enabled`            | `boolean` | `true`  | Enable weight regularisation       |
+| `maxAbsoluteWeight`  | `number`  | `100`   | Maximum absolute weight value      |
+| `maxWeightChange`    | `number`  | `10`    | Maximum weight change per mutation |
+| `l2Strength`         | `number`  | `0.1`   | L2 regularisation strength         |
+| `preferSmallChanges` | `boolean` | `true`  | Prefer small weight changes        |
+| `smallChangeScale`   | `number`  | `0.5`   | Scale for small changes            |
+
+### `biasRegularisation` — BiasRegularisationConfig
+
+| Field                | Type      | Default | Description                      |
+| -------------------- | --------- | ------- | -------------------------------- |
+| `enabled`            | `boolean` | `true`  | Enable bias regularisation       |
+| `maxAbsoluteBias`    | `number`  | `100`   | Maximum absolute bias value      |
+| `maxBiasChange`      | `number`  | `10`    | Maximum bias change per mutation |
+| `l2Strength`         | `number`  | `0.1`   | L2 regularisation strength       |
+| `preferSmallChanges` | `boolean` | `true`  | Prefer small bias changes        |
+| `smallChangeScale`   | `number`  | `0.5`   | Scale for small changes          |
+
+### `ensembleDiversity` — EnsembleDiversityConfig
+
+| Field                           | Type      | Default | Description                              |
+| ------------------------------- | --------- | ------- | ---------------------------------------- |
+| `enabled`                       | `boolean` | `false` | Enable diversity scoring                 |
+| `diversityWeight`               | `number`  | `0.15`  | Overall diversity weight in fitness      |
+| `weightVarianceWeight`          | `number`  | `0.4`   | Weight variance contribution             |
+| `squashEntropyWeight`           | `number`  | `0.3`   | Activation function entropy contribution |
+| `topologyDiversityWeight`       | `number`  | `0.3`   | Topology diversity contribution          |
+| `protectDiverseLowPerformers`   | `boolean` | `false` | Shield diverse but low-scoring creatures |
+| `diversityProtectionThreshold`  | `number`  | `0.7`   | Diversity threshold for protection       |
+| `crossSpeciesBreedingThreshold` | `number`  | `0.2`   | Threshold for cross-species breeding     |
+| `lowDiversityThreshold`         | `number`  | `0.3`   | Threshold below which diversity is "low" |
+| `diverseParentPreferenceWeight` | `number`  | `0.2`   | Preference weight for diverse parents    |
+
+### `quantumStep` — QuantumStepConfig
+
+| Field        | Type     | Default       | Description                   |
+| ------------ | -------- | ------------- | ----------------------------- |
+| `minStep`    | `number` | `0.000_000_1` | Minimum fine-tuning step size |
+| `maxStep`    | `number` | `0.001`       | Maximum fine-tuning step size |
+| `errorScale` | `number` | `10`          | Error scaling factor          |
+
+### `fineTunePopulation` — FineTunePopulationConfig
+
+| Field                    | Type     | Default | Description                                 |
+| ------------------------ | -------- | ------- | ------------------------------------------- |
+| `minPopulationFraction`  | `number` | `0.1`   | Minimum population fraction for fine-tuning |
+| `maxPopulationFraction`  | `number` | `0.4`   | Maximum population fraction for fine-tuning |
+| `basePopulationFraction` | `number` | `0.2`   | Base population fraction                    |
+| `successRateWindow`      | `number` | `10`    | Window for success rate tracking            |
+
+### `adaptiveMutationThresholds` — AdaptiveMutationThresholds
+
+| Field                 | Type     | Default | Description                                            |
+| --------------------- | -------- | ------- | ------------------------------------------------------ |
+| `medium`              | `number` | `100`   | Synapse count threshold for "medium" creatures         |
+| `large`               | `number` | `300`   | Synapse count threshold for "large" creatures          |
+| `largeTopologyWeight` | `number` | `0.1`   | Topology mutation weight reduction for large creatures |
+
+### `mcmc` — MCMCConfig
+
+Issue #2199: Markov Chain Monte Carlo (MCMC) temperature-based acceptance for
+the Metropolis-Hastings criterion. Worse-fitness moves are accepted with a
+probability that decreases as temperature cools, helping the population escape
+local optima early and converge later.
+
+```typescript
+import { DEFAULT_MCMC_CONFIG } from "@stsoftware/neat-ai";
+
+import type { MCMCConfig, RequiredMCMCConfig } from "@stsoftware/neat-ai";
+
+const options: NeatOptions = {
+  mcmc: {
+    enabled: true,
+    initialTemperature: 1.0,
+    coolingRate: 0.995,
+  },
+};
+```
+
+| Field                  | Type      | Default | Description                                                         |
+| ---------------------- | --------- | ------- | ------------------------------------------------------------------- |
+| `enabled`              | `boolean` | `false` | Whether MCMC acceptance is active                                   |
+| `initialTemperature`   | `number`  | `1.0`   | Starting temperature for Metropolis-Hastings acceptance             |
+| `minTemperature`       | `number`  | `0.01`  | Floor temperature to prevent acceptance probability reaching zero   |
+| `coolingRate`          | `number`  | `0.995` | Multiplicative cooling factor applied per generation                |
+| `targetAcceptanceRate` | `number`  | `0.234` | Optimal acceptance rate for high-dimensional MCMC                   |
+| `adjustmentRate`       | `number`  | `0.02`  | Rate at which temperature adapts toward the target acceptance rate  |
+| `toleranceRate`        | `number`  | `0.05`  | Tolerance band around target rate within which no adjustment occurs |
+
+`DEFAULT_MCMC_CONFIG` is a fully-populated `RequiredMCMCConfig`. Spread it and
+override individual fields:
+
+```typescript
+const myConfig: MCMCConfig = {
+  ...DEFAULT_MCMC_CONFIG,
+  enabled: true,
+  coolingRate: 0.99, // faster cooling
+};
+```
+
+**Acceptance behaviour:**
+
+- **Improving mutations** (lower cost) are always accepted.
+- **Worsening mutations** are accepted with probability
+  `exp(-deltaCost / temperature)`.
+- **Topology mutations** (add/remove node or connection, swap nodes, change
+  squash) are always accepted unconditionally.
+- **Adaptive tuning** (Issue #2201): temperature automatically adjusts toward
+  the target acceptance rate each generation.
+
+`DiversityAwareMCMCConfig` and `DEFAULT_DIVERSITY_AWARE_MCMC_CONFIG` extend MCMC
+acceptance with population-diversity-aware temperature scaling.
+
+### `outputRange` — OutputRange / RequiredOutputRange
+
+Issue #1620: per-output range constraints. Creatures producing outputs outside
+these ranges receive a fitness penalty proportional to the excess. Use
+`calculateOutputRangePenalty(creature, ranges)` to compute the penalty manually;
+`DEFAULT_OUTPUT_RANGE_PENALTY_WEIGHT` is the internal weighting applied during
+evolution.
+
+### `hyperparameterEvolution` — HyperparameterEvolutionConfig
+
+Issue #1863: per-creature evolvable hyperparameters (learning rate, mutation
+rates, regularisation strength) subject to mutation and crossover.
+`DEFAULT_HYPERPARAMETER_EVOLUTION_CONFIG` and
+`DEFAULT_EVOLVABLE_HYPERPARAMETERS` are the seed values.
+
+### `adaptivePopulation` — AdaptivePopulationConfig
+
+Issue #1863: automatically adjust population size based on diversity metrics and
+convergence progress. Defaults via `DEFAULT_ADAPTIVE_POPULATION_CONFIG`.
+
+### `parallelEvaluation` — ParallelEvaluationConfig
+
+Issue #1862: controls topology-aware grouping and concurrency limits for
+population fitness evaluation. Topology grouping clusters same-structure
+creatures to maximise WASM (WebAssembly) cache hits. Defaults via
+`DEFAULT_PARALLEL_EVALUATION_CONFIG`.
+
+### `dataFuzzing` — DataFuzzingConfig
+
+Issue #1900: training data fuzzing adds small random perturbations to prevent
+memorisation. Supports Gaussian and uniform noise. Defaults via
+`DEFAULT_DATA_FUZZING_CONFIG`.
+
+### `diskSpace` — DiskSpaceConfig
+
+Issue #1703: pre-flight disk-space check during discovery. Defaults via
+`DEFAULT_DISK_SPACE_CONFIG`.
+
+### `specialist` — SpecialistConfig
+
+Issue #2530: enable the specialist sub-population pipeline (see
+[Evolution API → Specialist Pipeline](EVOLUTION.md#-specialist-pipeline)).
+Defaults via `DEFAULT_SPECIALIST_CONFIG`. `SpecialistMode` enumerates the
+distillation modes available.
+
+---
+
+## 📡 Training events
+
+```typescript
+import type {
+  DiscoveryCompleteEvent,
+  GenerationCompleteEvent,
+  MemoryPressureEvent,
+  PlateauDetectedEvent,
+  SpeciesAdjustedEvent,
+  TrainingEvent,
+  TrainingEventCallback,
+} from "@stsoftware/neat-ai";
+```
+
+Issue #1615: register an `onTrainingEvent: TrainingEventCallback` callback in
+`NeatOptions` to receive typed events for generation completion, plateau
+detection, discovery outcomes, memory pressure, and species adjustments.
+
+---
+
+## 📝 Logger
+
+Structured logging abstraction. Consumers can inject a custom logger via
+`NeatOptions.logger` or call `setLogger()` globally.
+
+```typescript
+import {
+  createConsoleLogger,
+  getLogger,
+  setLogger,
+  SILENT_LOGGER,
+} from "@stsoftware/neat-ai";
+
+import type { Logger, LogLevel } from "@stsoftware/neat-ai";
+```
+
+```typescript
+interface Logger {
+  debug(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+
+type LogLevel = "debug" | "info" | "warn" | "error" | "none";
+```
+
+```typescript
+const logger = getLogger();
+logger.info("Training started");
+
+setLogger(createConsoleLogger("warn")); // Only warn and error
+setLogger(SILENT_LOGGER); // Silence all logging
+
+const options: NeatOptions = {
+  logger: createConsoleLogger("debug"),
+  logLevel: "warn", // or just set the level
+};
+```
+
+---
+
+## 🎲 Random Number Generator
+
+Reproducible random number generation with optional seeding.
+
+```typescript
+import {
+  createSeededRng,
+  createUnseededRng,
+  getRandomNumberGenerator,
+  setRandomNumberGenerator,
+} from "@stsoftware/neat-ai";
+
+import type { RandomNumberGenerator } from "@stsoftware/neat-ai";
+```
+
+```typescript
+interface RandomNumberGenerator {
+  random(): number; // [0, 1)
+  randomInt(min: number, max: number): number; // [min, max] inclusive
+  choice<T>(array: readonly T[]): T; // Random element from array
+  readonly seeded: boolean; // true if deterministic
+}
+```
+
+```typescript
+const rng = createSeededRng(42);
+setRandomNumberGenerator(rng);
+// All subsequent random calls are reproducible
+
+const options: NeatOptions = {
+  seed: 42, // Internally creates a seeded RNG
+};
+
+setRandomNumberGenerator(createUnseededRng()); // Reset to non-deterministic
+```
+
+Seeded RNG uses the xoshiro256** algorithm internally.
+
+---
+
+## 🔗 Related topics
+
+- [Evolution API](EVOLUTION.md) — `Creature.evolveDir()` consumes these options.
+- [Costs and activations](COSTS_AND_ACTIVATIONS.md) — values referenced by
+  `costName` and the activation menu.
+- [Training](TRAINING.md) — backpropagation options interact with the training
+  fields above.
+- [Discovery](DISCOVERY.md) — discovery sub-config fields detailed.
+- [Compute / multithreading](COMPUTE.md) — `threads`, WASM cache, and
+  worker-related fields.
+- [`CONFIGURATION_GUIDE.md`](../CONFIGURATION_GUIDE.md) — narrative
+  configuration guide.

--- a/docs/api/COSTS_AND_ACTIVATIONS.md
+++ b/docs/api/COSTS_AND_ACTIVATIONS.md
@@ -1,0 +1,145 @@
+# 💰 Costs and Activations
+
+Cost (fitness) functions and the activation function (squash) menu used by NEAT
+(NeuroEvolution of Augmenting Topologies) creatures.
+
+> **Acronyms:** API (Application Programming Interface), MSE (Mean Squared
+> Error), MAE (Mean Absolute Error), MAPE (Mean Absolute Percentage Error), MSLE
+> (Mean Squared Logarithmic Error), SVM (Support Vector Machine), ReLU
+> (Rectified Linear Unit), GELU (Gaussian Error Linear Unit), SELU (Scaled
+> Exponential Linear Unit), ELU (Exponential Linear Unit), WASM (WebAssembly).
+
+## 📦 Exports documented here
+
+- `Costs`, `CostInterface`
+- Activation function names (referenced in `NeuronExport.squash` and CRISPR DNA)
+
+## 💰 Cost Functions
+
+Cost functions measure the error between predicted and expected outputs.
+
+```typescript
+import { Costs } from "@stsoftware/neat-ai";
+import type { CostInterface } from "@stsoftware/neat-ai";
+```
+
+### 📋 Built-in cost functions
+
+| Name              | Class                          | Best For                     | Formula                                 |
+| ----------------- | ------------------------------ | ---------------------------- | --------------------------------------- |
+| `"MSE"`           | Mean Squared Error             | General regression (default) | `(1/n) * Sum((y - y')^2)`               |
+| `"MAE"`           | Mean Absolute Error            | Regression with outliers     | `(1/n) * Sum(\|y - y'\|)`               |
+| `"MAPE"`          | Mean Absolute Percentage Error | Forecasting, relative error  | `(1/n) * Sum(\|(y' - y) / y\|)`         |
+| `"MSLE"`          | Mean Squared Logarithmic Error | Wide value ranges            | `(1/n) * Sum((log(y) - log(y'))^2)`     |
+| `"CROSS_ENTROPY"` | Cross Entropy                  | Classification               | `-Sum(y * log(y') + (1-y) * log(1-y'))` |
+| `"HINGE"`         | Hinge Loss                     | SVM / binary classification  | `max(0, 1 - y * y')`                    |
+
+### 📐 CostInterface
+
+Custom cost functions implement this interface:
+
+```typescript
+interface CostInterface {
+  getName(): string;
+  calculate(target: Float32Array, output: Float32Array): number;
+}
+```
+
+### 🗂️ Costs registry
+
+```typescript
+// Find a cost function by name
+const mse = Costs.find("MSE");
+const error = mse.calculate(target, output);
+
+// List all available costs
+const names: string[] = Costs.getAvailableCosts();
+
+// Register a custom cost function
+Costs.registerCustomCost(myCustomCost);
+
+// Register a factory (creates new instances on demand)
+Costs.registerCostFactory("MY_COST", () => new MyCost());
+```
+
+---
+
+## ⚡ Activation Functions
+
+NEAT-AI provides 38 activation functions (called "squash" functions). The
+library uses WASM (WebAssembly) for all activation computation.
+
+```typescript
+// Activations are referenced by name in neuron definitions.
+// The library handles activation internally via WASM.
+```
+
+### 📊 Summary table
+
+Priority controls how often an activation is chosen during random mutation.
+Higher priority means more likely to be selected.
+
+> [!TIP]
+> When in doubt, **LeakyReLU** (priority 10) is the default choice and works
+> well for most general-purpose networks. For deeper architectures, consider
+> **GELU** or **Swish**.
+
+| Activation          | Priority | Range          | Best For                                  |
+| ------------------- | :------: | -------------- | ----------------------------------------- |
+| **LeakyReLU**       |    10    | (-Inf, +Inf)   | General purpose, default choice           |
+| **GELU**            |    9     | ~(-0.17, +Inf) | Deep networks, transformer-style          |
+| **Swish**           |    8     | ~(-0.28, +Inf) | Deep networks, smooth non-linearity       |
+| **TANH**            |    8     | (-1, 1)        | Bounded output, recurrent networks        |
+| **LOGISTIC**        |    7     | (0, 1)         | Binary classification, probability output |
+| **Softplus**        |    7     | (0, +Inf)      | Smooth approximation to ReLU              |
+| **Mish**            |    6     | ~(-0.31, +Inf) | Deep networks, stable gradients           |
+| **ELU**             |    6     | (-1, +Inf)     | Regression, avoids dead neurons           |
+| **SELU**            |    5     | ~(-1.76, +Inf) | Self-normalising networks                 |
+| **HARD_TANH**       |    5     | [-1, 1]        | Fast bounded output                       |
+| **ReLU**            |    5     | [0, +Inf)      | Simple, fast activation                   |
+| **BENT_IDENTITY**   |    4     | (-Inf, +Inf)   | Always smooth, no dead zones              |
+| **SOFTSIGN**        |    4     | (-1, 1)        | Soft alternative to TANH                  |
+| **ArcTan**          |    4     | (-pi/2, pi/2)  | Smooth, always nonzero slope              |
+| **ReLU6**           |    4     | [0, 6]         | Mobile/embedded applications              |
+| **SINE**            |    3     | [-1, 1]        | Periodic patterns                         |
+| **ABSOLUTE**        |    2     | [0, +Inf)      | Magnitude detection                       |
+| **Cosine**          |    2     | [-1, 1]        | Periodic patterns                         |
+| **Cube**            |    2     | (-Inf, +Inf)   | Non-linear, fast                          |
+| **Exponential**     |    2     | (0, +Inf)      | Exponential growth patterns               |
+| **GAUSSIAN**        |    2     | (0, 1]         | Radial basis patterns                     |
+| **ISRU**            |    2     | (-1, 1)        | Smooth, fades in tails                    |
+| **LogSigmoid**      |    2     | (-Inf, 0)      | Negative log-probability                  |
+| **TAN**             |    2     | (-Inf, +Inf)   | Unbounded periodic                        |
+| **BIPOLAR_SIGMOID** |    1     | (-1, 1)        | Symmetric sigmoid                         |
+| **StdInverse**      |    1     | (-Inf, +Inf)   | Inverse function                          |
+| **IDENTITY**        |    1     | (-Inf, +Inf)   | Pass-through (linear)                     |
+| **COMPLEMENT**      |    0     | (-Inf, +Inf)   | Inversion (1 - x)                         |
+| **STEP**            |    0     | {0, 1}         | Binary threshold                          |
+| **IF**              |    0     | Conditional    | Multi-input conditional                   |
+| **BIPOLAR**         |    0     | {-1, 1}        | Binary symmetric threshold                |
+| **HYPOT**           |    0     | Special        | Euclidean distance                        |
+| **HYPOTv2**         |    0     | Special        | Euclidean distance (variant)              |
+| **SQRT**            |    1     | [0, +Inf)      | Square root transform                     |
+| **SQUARE**          |    1     | [0, +Inf)      | Quadratic transform                       |
+| **MAXIMUM**         |    0     | Special        | Max of inputs                             |
+| **MEAN**            |    0     | (-Inf, +Inf)   | Mean of inputs (deprecated)               |
+| **MINIMUM**         |    0     | Special        | Min of inputs                             |
+
+For detailed backpropagation strategy notes, see
+[`src/methods/activations/README.md`](../../src/methods/activations/README.md)
+and the user-facing [`docs/ACTIVATION_FUNCTIONS.md`](../ACTIVATION_FUNCTIONS.md)
+selection guide.
+
+---
+
+## 🔗 Related topics
+
+- [Configuration reference](CONFIGURATION.md) — `costName` field on
+  `NeatOptions`.
+- [Training](TRAINING.md) — backpropagation uses cost functions to score each
+  batch.
+- [Interop](INTEROP.md) — `checkOnnxCompatibility()` rejects creatures that use
+  aggregate activations (IF, MIN, MAX) or deprecated activations (HYPOT,
+  HYPOTv2, MEAN).
+- [`docs/ACTIVATION_FUNCTIONS.md`](../ACTIVATION_FUNCTIONS.md) — narrative
+  selection guide for the 30+ built-in squash functions.

--- a/docs/api/CREATURE.md
+++ b/docs/api/CREATURE.md
@@ -1,0 +1,317 @@
+# 🐛 Creature API
+
+Creature lifecycle, hand-edited gene modification, and serialisation types.
+
+> **Acronyms:** API (Application Programming Interface), JSON (JavaScript Object
+> Notation), UUID (Universally Unique Identifier), CRISPR (Clustered Regularly
+> Interspaced Short Palindromic Repeats), WASM (WebAssembly), DNA
+> (Deoxyribonucleic Acid).
+
+## 📦 Exports documented here
+
+- `Creature`, `CURRENT_CREATURE_SEMANTIC_VERSION`
+- `CreatureUtil`
+- `CRISPR`, `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX`,
+  `FROM_RELATIVE_DEMOTED_OUTPUT`, `validateDNA`, `CrisprInterface`
+- `randomConnectMissing`
+- `CreatureExport`, `CreatureTrace`, `NeuronExport`, `SynapseExport`
+- `exportSnapshotJSON`, `normaliseCreatureExport`, `normalised`
+- `Upgrade`, `upgradeTwo`
+- `TypedTopology`
+
+## 🐛 Creature
+
+The central class representing a neural network (genome) in NEAT (NeuroEvolution
+of Augmenting Topologies).
+
+```typescript
+import { Creature } from "@stsoftware/neat-ai";
+```
+
+### 🏗️ Constructor
+
+```typescript
+new Creature(input: number, output: number, options?: {
+  lazyInitialization?: boolean;
+  semanticVersion?: string;
+})
+```
+
+| Parameter                    | Type      | Description                           |
+| ---------------------------- | --------- | ------------------------------------- |
+| `input`                      | `number`  | Number of input neurons               |
+| `output`                     | `number`  | Number of output neurons              |
+| `options.lazyInitialization` | `boolean` | Skip default wiring (used internally) |
+| `options.semanticVersion`    | `string`  | Version tag for the creature format   |
+
+### 📋 Properties
+
+| Property          | Type                            | Description                                       |
+| ----------------- | ------------------------------- | ------------------------------------------------- |
+| `input`           | `number`                        | Number of input neurons                           |
+| `output`          | `number`                        | Number of output neurons                          |
+| `neurons`         | `Neuron[]`                      | All neurons in the network                        |
+| `synapses`        | `Synapse[]`                     | All synapses (connections)                        |
+| `score`           | `number \| undefined`           | Fitness score after evaluation                    |
+| `uuid`            | `string \| undefined`           | Unique identifier                                 |
+| `memetic`         | `MemeticInterface \| undefined` | Origin tracking metadata                          |
+| `tags`            | `TagInterface[] \| undefined`   | User-defined metadata tags                        |
+| `semanticVersion` | `string`                        | Creature format version                           |
+| `forwardOnly`     | `boolean \| undefined`          | When `true`, no recurrent connections are allowed |
+
+### 🔧 Key Methods
+
+| Method               | Signature                                                                                   | Description                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `activate`           | `(input: Float32Array, feedbackLoop?: boolean): Float32Array`                               | Forward pass through the network using WASM. Returns output values.                                |
+| `activateAndTrace`   | `(input: Float32Array, feedbackLoop: boolean, sparseConfig: SparseConfig): Float32Array`    | Activation with tracing enabled for analysis.                                                      |
+| `propagate`          | `(expected: Float32Array, config: BackPropagationConfig, sparseConfig: SparseConfig): void` | Backpropagation — propagates errors backwards through the network.                                 |
+| `propagateUpdate`    | `(config: BackPropagationConfig, sparseConfig: SparseConfig): void`                         | Updates weights/biases based on propagated errors.                                                 |
+| `record`             | `(expected: Float32Array): Map<string, DiscoverRecord>`                                     | Records expected outputs for discovery analysis.                                                   |
+| `exportJSON`         | `(): CreatureExport`                                                                        | Canonical serialisation: wire UUIDs plus resolved runtime ids (`id` / `fromId` / `toId`).          |
+| `exportSnapshotJSON` | `(): CreatureExport`                                                                        | Wire-only snapshot: same topology as `exportJSON` but omits numeric ids (sharing / schema checks). |
+| `traceJSON`          | `(): CreatureTrace`                                                                         | Exports with detailed trace information from last activation.                                      |
+| `loadFrom`           | `(json: CreatureInternal \| CreatureExport, validate: boolean): void`                       | Loads creature structure from a JSON object.                                                       |
+| `connect`            | `(from: number, to: number, weight: number, type?: SynapseType): Synapse`                   | Creates a synapse between two neurons.                                                             |
+| `getSynapse`         | `(from: number, to: number): Synapse \| null`                                               | Gets the synapse between two neurons, or `null`.                                                   |
+| `shallowClone`       | `(): Creature`                                                                              | Fast clone without JSON serialisation overhead.                                                    |
+| `dispose`            | `(): void`                                                                                  | Releases all resources and memory.                                                                 |
+| `clearCache`         | `(from?: number, to?: number): void`                                                        | Clears internal synapse connection caches.                                                         |
+
+### ⚡ Static Methods
+
+| Method     | Signature                                                                  | Description                                                                          |
+| ---------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `fromJSON` | `(json: CreatureInternal \| CreatureExport, validate?: boolean): Creature` | Creates a creature from a JSON object. Handles legacy format upgrades automatically. |
+
+`Creature.evolveDir()` is documented in the [Evolution API](EVOLUTION.md) topic.
+
+### 💡 Example
+
+```typescript
+const creature = new Creature(2, 1);
+const output = creature.activate(new Float32Array([0.5, 0.3]));
+console.log(output); // Float32Array with 1 element
+
+const json = creature.exportJSON();
+const clone = Creature.fromJSON(json);
+```
+
+`CURRENT_CREATURE_SEMANTIC_VERSION` is the canonical version string written into
+freshly-exported creatures.
+
+---
+
+## ✂️ CRISPR
+
+Targeted genetic modifications inspired by CRISPR (Clustered Regularly
+Interspaced Short Palindromic Repeats) gene-editing technology. Allows
+hand-crafted injection of neurons and synapses.
+
+For the conventions, append+demote pattern, and full validation rules, see
+[`docs/CRISPR_GUIDE.md`](../CRISPR_GUIDE.md).
+
+```typescript
+import {
+  CRISPR,
+  CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX,
+  FROM_RELATIVE_DEMOTED_OUTPUT,
+  validateDNA,
+} from "@stsoftware/neat-ai";
+import type { CrisprInterface } from "@stsoftware/neat-ai";
+```
+
+### 📐 Constants
+
+| Constant                                | Value     | Description                                                                                     |
+| --------------------------------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| `CRISPR_DEFAULT_FIRST_DNA_OUTPUT_INDEX` | `100_000` | Recommended `index` for the first output neuron in append-mode DNA.                             |
+| `FROM_RELATIVE_DEMOTED_OUTPUT`          | `99_999`  | `fromRelative` value that resolves to the demoted previous `output-0` under the default anchor. |
+
+### 🏗️ Constructor & Methods
+
+```typescript
+new CRISPR(creature: Creature)
+```
+
+| Method                 | Signature                                                                  | Description                                            |
+| ---------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `cleaveDNA`            | `(dna: CrisprInterface): Creature`                                         | Applies modifications and returns the edited creature. |
+| `editAliases` (static) | `(dna: CrisprInterface, aliases: Record<string, string>): CrisprInterface` | Replaces neuron UUID aliases in DNA.                   |
+
+### 📐 CrisprInterface
+
+```typescript
+interface CrisprInterface {
+  id: string; // Unique modification ID
+  mode: "insert" | "append"; // insert: replace topology; append: add to existing
+  neurons?: {
+    uuid?: string;
+    index?: number;
+    type: "output" | "hidden";
+    squash: string; // Activation function name
+    bias: number;
+  }[];
+  synapses: {
+    fromUUID?: string;
+    toUUID?: string;
+    weight: number;
+    type?: "positive" | "negative" | "condition";
+  }[];
+}
+```
+
+`validateDNA(dna)` checks a `CrisprInterface` for structural issues and throws
+`CrisprError` (see [Errors](ERRORS.md)) if the DNA is malformed.
+
+---
+
+## 🛠️ CreatureUtil and randomConnectMissing
+
+```typescript
+import { CreatureUtil, randomConnectMissing } from "@stsoftware/neat-ai";
+```
+
+- `CreatureUtil` — utility class with helpers for working with creatures (UUID
+  assignment, structural normalisation).
+- `randomConnectMissing(creature)` — connects neurons that lack required inward
+  or outward connections by inserting random synapses. Used during topology
+  repair after structural mutation.
+
+---
+
+## 💾 Serialisation types
+
+### 📤 CreatureExport
+
+The JSON format for serialising and deserialising creatures.
+
+```typescript
+import type {
+  CreatureExport,
+  CreatureTrace,
+  NeuronExport,
+  SynapseExport,
+} from "@stsoftware/neat-ai";
+```
+
+```typescript
+interface CreatureExport {
+  input: number; // Number of input neurons
+  output: number; // Number of output neurons
+  neurons: NeuronExport[]; // Hidden and output neurons
+  synapses: SynapseExport[]; // All connections
+  forwardOnly?: boolean; // No recurrent connections
+  memetic?: MemeticInterface; // Origin tracking
+  semanticVersion?: string; // Format version
+  tags?: TagInterface[]; // User-defined metadata
+}
+```
+
+### 🧠 NeuronExport
+
+```typescript
+interface NeuronExport {
+  uuid: string; // Unique neuron identifier
+  type: "hidden" | "output" | "constant";
+  bias: number; // Neuron bias value
+  squash?: string; // Activation function name
+  tags?: TagInterface[]; // User-defined metadata
+}
+```
+
+Input neurons are implicit (defined by `input` count) and not included in the
+`neurons` array.
+
+### 🔗 SynapseExport
+
+```typescript
+interface SynapseExport {
+  fromUUID: string; // Source neuron UUID
+  toUUID: string; // Target neuron UUID
+  weight: number; // Connection weight
+  type?: "positive" | "negative" | "condition";
+  tags?: TagInterface[]; // User-defined metadata
+}
+```
+
+### 🔍 CreatureTrace
+
+Extends `CreatureExport` with per-neuron and per-synapse trace information from
+the last activation, useful for debugging and analysis.
+
+```typescript
+interface CreatureTrace extends CreatureExport {
+  neurons: NeuronTrace[]; // Neurons with activation trace
+  synapses: SynapseTrace[]; // Synapses with trace
+}
+```
+
+### 🔧 Helpers
+
+```typescript
+import {
+  exportSnapshotJSON,
+  normaliseCreatureExport,
+  normalised,
+  TypedTopology,
+} from "@stsoftware/neat-ai";
+```
+
+- `exportSnapshotJSON(creature)` — module-level helper equivalent to
+  `creature.exportSnapshotJSON()` (wire-only snapshot used for sharing and
+  schema checks).
+- `normaliseCreatureExport(json)` / `normalised(json)` — Issue #1958: ensure
+  legacy `CreatureExport` objects (with UUID strings) have integer `id`,
+  `fromId`, and `toId` fields populated.
+- `TypedTopology` — Issue #1957: typed-array representation of creature topology
+  for reduced GC (Garbage Collection) pressure.
+
+### 💡 Round-trip example
+
+```typescript
+import { Creature } from "@stsoftware/neat-ai";
+
+const creature = new Creature(2, 1);
+const json = creature.exportJSON();
+const jsonString = JSON.stringify(json, null, 2);
+
+const restored = Creature.fromJSON(JSON.parse(jsonString));
+
+creature.activate(new Float32Array([0.5, 0.5]));
+const trace = creature.traceJSON();
+```
+
+---
+
+## 🔄 Upgrade and version migration
+
+Legacy creature formats (v0.x, v1.x) are automatically upgraded when loaded via
+`Creature.fromJSON()`. Use `upgradeTwo()` for explicit v2.0.0 migration.
+
+```typescript
+import { Upgrade, upgradeTwo } from "@stsoftware/neat-ai";
+
+// Correct a creature export (fixes missing/incorrect data)
+const corrected = Upgrade.correct(creatureJson, inputCount);
+
+// Upgrade legacy CRISPR format
+const upgradedDna = Upgrade.CRISPR(legacyDna);
+```
+
+`upgradeTwo(json)` migrates a v1.x creature in-place to the current v2 wire
+format.
+
+---
+
+## 🔗 Related topics
+
+- [Evolution API](EVOLUTION.md) — `Creature.evolveDir()`, selection, and
+  mutation strategies.
+- [Configuration reference](CONFIGURATION.md) — `NeatOptions` consumed by
+  `Creature.evolveDir()`.
+- [Errors](ERRORS.md) — `CrisprError` thrown by `validateDNA()`.
+- [Compute / multithreading](COMPUTE.md) — WASM cache controls that affect
+  `Creature.activate()`.
+- [Discovery](DISCOVERY.md) — error-pattern-driven structural growth.
+- [`CRISPR_GUIDE.md`](../CRISPR_GUIDE.md) — full DNA conventions.

--- a/docs/api/DISCOVERY.md
+++ b/docs/api/DISCOVERY.md
@@ -1,0 +1,160 @@
+# 🔬 Discovery API
+
+Programmatic entry points for error-pattern-driven structural growth via the
+NEAT-AI-Discovery FFI (Foreign Function Interface) extension.
+
+> **Acronyms:** API (Application Programming Interface), FFI (Foreign Function
+> Interface), GPU (Graphics Processing Unit), MB (Megabyte), JSON (JavaScript
+> Object Notation).
+
+Discovery uses the Rust FFI extension
+([NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery)) for
+GPU-accelerated structural analysis. It analyses error patterns and suggests
+neurons/synapses to add.
+
+## 📦 Exports documented here
+
+- `formatErrorDelta`, `formatPercentWithSignificantDigits`
+- `DiscoveryEvaluationSummary`
+- `cleanOrphanedDiscoveryDirs`, `forceCleanAllDiscoveryDirs`
+- `checkDiskSpace`, `estimateRequiredDiskSpaceMB`, `getAvailableDiskSpaceMB`,
+  `logDiscoveryDiskUsage`, `measureDirectorySize`, `preFlightDiskSpaceCheck`
+- `DirectorySizeResult`, `DiskSpaceCheckResult`
+- `DiskSpaceConfig`, `RequiredDiskSpaceConfig`, `DEFAULT_DISK_SPACE_CONFIG`
+
+```typescript
+import {
+  cleanOrphanedDiscoveryDirs,
+  formatErrorDelta,
+  formatPercentWithSignificantDigits,
+  preFlightDiskSpaceCheck,
+} from "@stsoftware/neat-ai";
+import type { DiscoveryEvaluationSummary } from "@stsoftware/neat-ai";
+```
+
+## 🔍 How discovery works
+
+1. The creature records expected vs actual outputs during evaluation.
+2. Error data is streamed to the Rust discovery library via FFI.
+3. The Rust module (using GPU compute shaders via Metal/wgpu) analyses error
+   patterns and proposes structural changes.
+4. Proposed candidates are evaluated and the best improvement is kept.
+
+## ⚙️ Configuration
+
+Discovery is configured via `NeatOptions` fields (full definitions in the
+[Configuration reference](CONFIGURATION.md#-discovery-fields)):
+
+> [!NOTE]
+> The Discovery API requires the optional
+> [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) Rust
+> FFI extension. Without it, the discovery phase is skipped gracefully and
+> evolution continues normally.
+
+- `discoverySampleRate` (default `0.2`) — fraction of training data used.
+- `discoveryRecordTimeOutMinutes` (default `5`) — recording phase timeout.
+- `discoveryAnalysisTimeoutMinutes` (default `10`) — analysis phase timeout.
+- `discoveryBatchSize` (default `128`) — samples per batch.
+- `discoveryMaxNeurons` (default `6`) — max neurons per iteration.
+
+## 📊 DiscoveryEvaluationSummary
+
+```typescript
+interface DiscoveryEvaluationSummary {
+  kind: "original" | "candidate";
+  changeType?: string;
+  description?: string;
+  score: number;
+  error: number;
+  scoreDelta?: number;
+  improved: boolean;
+  archivePath?: string;
+  errorDelta?: number;
+  errorDeltaPct?: number;
+}
+```
+
+## 🛠️ Formatting utilities
+
+```typescript
+// Format an error delta for display
+const text = formatErrorDelta(0.0523);
+
+// Format a percentage with significant digits
+const pct = formatPercentWithSignificantDigits(0.0523);
+```
+
+These utilities format discovery evaluation summaries consistently. Use them
+when logging evaluation results yourself after disabling the library's internal
+logging with `discoveryDisableEvaluationSummaryLogging: true`.
+
+## 🧹 Discovery cleanup
+
+Issue #1702: Detect and clean up orphaned discovery temp directories left behind
+by crashed or killed processes.
+
+```typescript
+import {
+  cleanOrphanedDiscoveryDirs,
+  forceCleanAllDiscoveryDirs,
+} from "@stsoftware/neat-ai";
+
+// Conservative: remove only directories whose pid is no longer alive.
+await cleanOrphanedDiscoveryDirs();
+
+// Aggressive: remove every discovery temp directory regardless of pid.
+await forceCleanAllDiscoveryDirs();
+```
+
+## 💽 Disk space monitoring
+
+Issue #1703: Pre-flight and in-flight disk-space checks during discovery.
+
+```typescript
+import {
+  checkDiskSpace,
+  estimateRequiredDiskSpaceMB,
+  getAvailableDiskSpaceMB,
+  logDiscoveryDiskUsage,
+  measureDirectorySize,
+  preFlightDiskSpaceCheck,
+} from "@stsoftware/neat-ai";
+
+import type {
+  DirectorySizeResult,
+  DiskSpaceCheckResult,
+  DiskSpaceConfig,
+  RequiredDiskSpaceConfig,
+} from "@stsoftware/neat-ai";
+
+import { DEFAULT_DISK_SPACE_CONFIG } from "@stsoftware/neat-ai";
+```
+
+| Function                               | Purpose                                                              |
+| -------------------------------------- | -------------------------------------------------------------------- |
+| `checkDiskSpace(dir, config)`          | Returns `DiskSpaceCheckResult` with available/required MB and flags. |
+| `estimateRequiredDiskSpaceMB(opts)`    | Estimate required space for a discovery run before it starts.        |
+| `getAvailableDiskSpaceMB(dir)`         | Plain query for free space on the filesystem hosting `dir`.          |
+| `logDiscoveryDiskUsage(dir, logger)`   | Logs current discovery directory usage at the configured log level.  |
+| `measureDirectorySize(dir)`            | Recursive size measurement, returns `DirectorySizeResult`.           |
+| `preFlightDiskSpaceCheck(dir, config)` | Runs the gate that aborts evolution when free space is insufficient. |
+
+`DiskSpaceConfig` controls warning and critical thresholds; defaults are exposed
+as `DEFAULT_DISK_SPACE_CONFIG`.
+
+For a full guide, see [`docs/DISCOVERY_GUIDE.md`](../DISCOVERY_GUIDE.md) and
+[`docs/GPU_ACCELERATION.md`](../GPU_ACCELERATION.md).
+
+---
+
+## 🔗 Related topics
+
+- [Configuration reference](CONFIGURATION.md) — discovery fields and `diskSpace`
+  sub-config.
+- [Compute / multithreading](COMPUTE.md) — WASM (WebAssembly) cache controls
+  referenced when discovery proposes new topology.
+- [Errors](ERRORS.md) — discovery operations may surface `BreedExhaustionError`.
+- [`docs/DISCOVERY_GUIDE.md`](../DISCOVERY_GUIDE.md) — operator workflow.
+- [`docs/DISCOVERY_DIR.md`](../DISCOVERY_DIR.md) — `Creature.discoveryDir()`
+  contract and on-disk layout.
+- [`docs/DISCOVERY_ARCHITECTURE.md`](../DISCOVERY_ARCHITECTURE.md) — internals.

--- a/docs/api/ERRORS.md
+++ b/docs/api/ERRORS.md
@@ -1,0 +1,109 @@
+# ⚠️ Errors and validation
+
+Typed errors thrown by NEAT-AI's public API (Application Programming Interface),
+and the validation patterns the library expects callers to follow.
+
+> **Acronyms:** API (Application Programming Interface), CRISPR (Clustered
+> Regularly Interspaced Short Palindromic Repeats), DNA (Deoxyribonucleic Acid),
+> JSON (JavaScript Object Notation).
+
+## 📦 Exports documented here
+
+- `CrisprError`, `CrisprErrorCode`
+- `BreedExhaustionError`, `BreedExhaustionReason`
+- `ValidationError` (internal — thrown by creature validation but not
+  re-exported from `mod.ts`; documented here so callers know what to catch)
+
+## 🧬 CrisprError
+
+```typescript
+import { CrisprError } from "@stsoftware/neat-ai";
+import type { CrisprErrorCode } from "@stsoftware/neat-ai";
+
+try {
+  validateDNA(dna);
+} catch (err) {
+  if (err instanceof CrisprError) {
+    console.error(err.code, err.message);
+  }
+}
+```
+
+`CrisprError.code` is one of the `CrisprErrorCode` values (e.g.
+`"INVALID_DNA"`). Thrown by `validateDNA()` and by the internal CRISPR
+(Clustered Regularly Interspaced Short Palindromic Repeats) cleavage pipeline.
+
+## 🍼 BreedExhaustionError
+
+```typescript
+import { BreedExhaustionError } from "@stsoftware/neat-ai";
+import type { BreedExhaustionReason } from "@stsoftware/neat-ai";
+```
+
+Thrown by the breeding pipeline when no viable child can be produced after the
+configured retry budget. `BreedExhaustionReason` enumerates the underlying
+causes (e.g. all candidate parents excluded, every attempted topology rejected
+by validation).
+
+## 🔒 ValidationError
+
+`ValidationError` is **not** re-exported from `mod.ts`, but
+`Creature.fromJSON(..., true)` and other validation paths throw it. Its shape is
+documented here so callers can `catch` it without importing internal modules.
+
+```typescript
+type ValidationErrorName =
+  | "OTHER"
+  | "NO_OUTWARD_CONNECTIONS" // Neuron has no outgoing synapses
+  | "NO_INWARD_CONNECTIONS" // Neuron has no incoming synapses
+  | "IF_CONDITIONS" // IF neuron validation failed
+  | "RECURSIVE_SYNAPSE" // Backward connection in forward-only mode
+  | "SELF_CONNECTION" // Self-loop in forward-only mode
+  | "MEMETIC"; // Memetic (origin) tracking error
+
+class ValidationError extends Error {
+  name: ValidationErrorName;
+  constructor(message: string, name: ValidationErrorName);
+}
+```
+
+> [!WARNING]
+> Always pass `validate: true` to `Creature.fromJSON()` when loading untrusted
+> or user-supplied creature data. Skipping validation may result in silent
+> failures or corrupt network behaviour during evolution.
+
+## 🛡️ Error handling patterns
+
+```typescript
+import { Creature } from "@stsoftware/neat-ai";
+
+try {
+  const creature = Creature.fromJSON(jsonData, true); // validate = true
+} catch (error) {
+  // ValidationError is not re-exported — match by name + shape.
+  if (
+    error instanceof Error &&
+    error.name === "RECURSIVE_SYNAPSE"
+  ) {
+    console.error("Network has backward connections in forward-only mode");
+  }
+  throw error;
+}
+```
+
+For programmatic discrimination of CRISPR and breeding failures, prefer
+`instanceof CrisprError` and `instanceof BreedExhaustionError` respectively —
+both classes are stable public exports.
+
+---
+
+## 🔗 Related topics
+
+- [Creature](CREATURE.md) — `Creature.fromJSON()`, the main caller of
+  validation.
+- [Evolution API](EVOLUTION.md) — breeding paths that throw
+  `BreedExhaustionError`.
+- [`docs/CRISPR_GUIDE.md`](../CRISPR_GUIDE.md) — DNA conventions whose
+  violations surface as `CrisprError`.
+- [`docs/TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) — common error signatures
+  and remediation.

--- a/docs/api/EVOLUTION.md
+++ b/docs/api/EVOLUTION.md
@@ -1,0 +1,280 @@
+# 🧬 Evolution API
+
+The evolution loop, selection strategies, mutation operators, configuration
+presets, and plateau detection.
+
+> **Acronyms:** API (Application Programming Interface), NEAT (NeuroEvolution of
+> Augmenting Topologies), JSON (JavaScript Object Notation), FFW (Feed-Forward),
+> MCMC (Markov Chain Monte Carlo).
+
+## 📦 Exports documented here
+
+- `Creature.evolveDir()` (method on `Creature`)
+- `Selection`
+- `Mutation`
+- `QUICK_START_PRESET`, `LARGE_NETWORK_PRESET`, `MEMORY_CONSTRAINED_PRESET`,
+  `DISCOVERY_FOCUSED_PRESET`
+- `PlateauDetector`, `detectPlateau`, `DEFAULT_PLATEAU_DETECTION`,
+  `PlateauDetectionConfig`, `RequiredPlateauDetectionConfig`
+- `Species`, `Genus`
+- `SpecialistPipeline`, `DEFAULT_SPECIALIST_CONFIG`, `SpecialistConfig`,
+  `RequiredSpecialistConfig`, `SpecialistMode`, `DistillationResult`,
+  `SubTaskScores`
+
+## 🔄 Creature.evolveDir()
+
+The main entry point for NEAT evolution.
+
+```typescript
+async evolveDir(
+  dataSetDir: string,
+  options: NeatOptions,
+): Promise<{
+  error: number;
+  score: number;
+  time: number;
+  generation: number;
+}>
+```
+
+| Parameter    | Type          | Description                                           |
+| ------------ | ------------- | ----------------------------------------------------- |
+| `dataSetDir` | `string`      | Path to directory containing training data JSON files |
+| `options`    | `NeatOptions` | Evolution configuration                               |
+
+**Returns** an object with:
+
+- `error` — Final best error
+- `score` — Final best score (negative error minus complexity penalty)
+- `time` — Elapsed milliseconds
+- `generation` — Number of generations completed
+
+### 📁 Dataset Format
+
+Training data is stored as JSON files in `dataSetDir`, each containing an array
+of samples:
+
+```json
+[
+  { "input": [0, 0], "output": [0] },
+  { "input": [0, 1], "output": [1] },
+  { "input": [1, 0], "output": [1] },
+  { "input": [1, 1], "output": [0] }
+]
+```
+
+### 💡 Example
+
+```typescript
+import { Creature } from "@stsoftware/neat-ai";
+import type { NeatOptions } from "@stsoftware/neat-ai";
+
+const creature = new Creature(2, 1);
+
+const options: NeatOptions = {
+  costName: "MSE",
+  populationSize: 100,
+  iterations: 500,
+  targetError: 0.01,
+  mutationRate: 0.3,
+  elitism: 2,
+  threads: 4,
+  seed: 42, // Reproducible evolution
+};
+
+const result = await creature.evolveDir("./training-data", options);
+console.log(`Error: ${result.error}, Generations: ${result.generation}`);
+```
+
+`NeatOptions` and every sub-config are documented in the
+[Configuration reference](CONFIGURATION.md).
+
+---
+
+## 🎯 Selection strategies
+
+```typescript
+import { Selection } from "@stsoftware/neat-ai";
+```
+
+| Strategy                          | Description                                          | Parameters                    |
+| --------------------------------- | ---------------------------------------------------- | ----------------------------- |
+| `Selection.FITNESS_PROPORTIONATE` | Roulette wheel selection based on fitness proportion | —                             |
+| `Selection.POWER`                 | Fitness raised to a power before selection           | `power: 4`                    |
+| `Selection.TOURNAMENT`            | Best of random subset is selected                    | `size: 5`, `probability: 0.5` |
+
+Pick a strategy through `NeatOptions.selection`. If left unset, the evolution
+loop chooses one at random each run.
+
+---
+
+## 🧬 Mutation operators
+
+```typescript
+import { Mutation } from "@stsoftware/neat-ai";
+```
+
+| Mutation        | Description                                   |
+| --------------- | --------------------------------------------- |
+| `ADD_NODE`      | Add a new hidden neuron                       |
+| `SUB_NODE`      | Remove a hidden neuron                        |
+| `ADD_CONN`      | Add a new forward connection                  |
+| `SUB_CONN`      | Remove a connection                           |
+| `MOD_WEIGHT`    | Modify a synapse weight                       |
+| `MOD_BIAS`      | Modify a neuron bias                          |
+| `MOD_SQUASH`    | Change a neuron's activation function         |
+| `SWAP_NODES`    | Swap two neurons                              |
+| `ADD_SELF_CONN` | Add a self-loop (recurrent only)              |
+| `SUB_SELF_CONN` | Remove a self-loop (recurrent only)           |
+| `ADD_BACK_CONN` | Add a backward connection (recurrent only)    |
+| `SUB_BACK_CONN` | Remove a backward connection (recurrent only) |
+
+**Preset groups:**
+
+- `Mutation.FFW` — Forward-feed mutations only (default): `ADD_NODE`,
+  `SUB_NODE`, `ADD_CONN`, `SUB_CONN`, `MOD_WEIGHT`, `MOD_BIAS`, `MOD_SQUASH`,
+  `SWAP_NODES`.
+- `Mutation.ALL` — All mutations including recurrent connections.
+
+---
+
+## 📦 Configuration presets
+
+Issue #1619: pre-built `NeatOptions` shapes for common training scenarios. Each
+preset can be spread into user configuration.
+
+```typescript
+import {
+  DISCOVERY_FOCUSED_PRESET,
+  LARGE_NETWORK_PRESET,
+  MEMORY_CONSTRAINED_PRESET,
+  QUICK_START_PRESET,
+} from "@stsoftware/neat-ai";
+
+const options = {
+  ...QUICK_START_PRESET,
+  populationSize: 25, // override preset value
+};
+```
+
+| Preset                      | Best For                                                |
+| --------------------------- | ------------------------------------------------------- |
+| `QUICK_START_PRESET`        | First-run smoke tests on a small dataset                |
+| `LARGE_NETWORK_PRESET`      | Topology growth on large input/output dimensions        |
+| `MEMORY_CONSTRAINED_PRESET` | Reduced WASM cache and worker counts for tight machines |
+| `DISCOVERY_FOCUSED_PRESET`  | Heavier discovery cadence for error-pattern exploration |
+
+---
+
+## 📉 Plateau detection
+
+Detects when evolution stagnates and adjusts mutation rates to help escape local
+optima.
+
+```typescript
+import {
+  DEFAULT_PLATEAU_DETECTION,
+  detectPlateau,
+  PlateauDetector,
+} from "@stsoftware/neat-ai";
+
+import type {
+  PlateauDetectionConfig,
+  RequiredPlateauDetectionConfig,
+} from "@stsoftware/neat-ai";
+```
+
+### PlateauDetector
+
+```typescript
+class PlateauDetector {
+  constructor(config: RequiredPlateauDetectionConfig);
+
+  recordFitness(fitness: number): void;
+  isOnPlateau(): boolean;
+  isRapidlyImproving(): boolean;
+  getMutationMultiplier(): number;
+  getGenerationsOnPlateau(): number;
+}
+```
+
+### 💡 Example
+
+```typescript
+const detector = new PlateauDetector({
+  ...DEFAULT_PLATEAU_DETECTION,
+  enabled: true,
+});
+
+detector.recordFitness(-0.5);
+detector.recordFitness(-0.49);
+
+if (detector.isOnPlateau()) {
+  const multiplier = detector.getMutationMultiplier();
+  // multiplier > 1.0 when on plateau (increase mutations)
+}
+```
+
+`detectPlateau(values, config)` is the stateless variant: it inspects a fitness
+history slice and returns the same diagnostic shape.
+
+Plateau detection is also available as a `NeatOptions.plateauDetection`
+sub-config (see [Configuration](CONFIGURATION.md#plateaudetection)) and applied
+automatically during evolution when enabled.
+
+---
+
+## 🌱 Speciation primitives
+
+```typescript
+import { Genus, Species } from "@stsoftware/neat-ai";
+```
+
+- `Species` — a cluster of genetically-similar creatures with shared fitness
+  sharing and speciation thresholds.
+- `Genus` — collection of `Species` instances tracked across the population.
+
+These are exposed for advanced users embedding NEAT-AI inside a custom
+orchestrator. The default `Creature.evolveDir()` loop manages them internally.
+
+---
+
+## 🧪 Specialist Pipeline
+
+Issue #2530: two-stage post-training pipeline that mirrors specialist /
+generalist distillation. Stage 1 seeds dedicated specialist species per declared
+sub-task; Stage 2 periodically distils the elites into a generalist via the OPD
+breed operator. Disabled by default.
+
+```typescript
+import {
+  DEFAULT_SPECIALIST_CONFIG,
+  type DistillationResult,
+  SpecialistPipeline,
+  type SubTaskScores,
+} from "@stsoftware/neat-ai";
+
+import type {
+  RequiredSpecialistConfig,
+  SpecialistConfig,
+  SpecialistMode,
+} from "@stsoftware/neat-ai";
+```
+
+`SpecialistConfig` is consumed via `NeatOptions.specialist` and documented
+alongside other sub-configs in [Configuration](CONFIGURATION.md).
+
+---
+
+## 🔗 Related topics
+
+- [Configuration reference](CONFIGURATION.md) — every `NeatOptions` field
+  consumed here.
+- [Costs and activations](COSTS_AND_ACTIVATIONS.md) — fitness functions and
+  squash menu used during evolution.
+- [Training](TRAINING.md) — backpropagation runs each generation before
+  selection.
+- [Discovery](DISCOVERY.md) — error-pattern-driven structural growth that hooks
+  into the evolution loop.
+- [Compute / multithreading](COMPUTE.md) — `threads` and WASM cache controls
+  used by `evolveDir()`.

--- a/docs/api/INTEROP.md
+++ b/docs/api/INTEROP.md
@@ -1,0 +1,245 @@
+# 📤 Interop and Specialised Tooling
+
+Transfer learning, ONNX export, topology export, and the Intelligent Design
+squash optimiser — entry points that connect NEAT-AI to external
+machine-learning pipelines and tooling.
+
+> **Acronyms:** API (Application Programming Interface), ONNX (Open Neural
+> Network Exchange), JSON (JavaScript Object Notation), DOT (Graphviz
+> description language), UUID (Universally Unique Identifier), ML (Machine
+> Learning).
+
+## 📦 Exports documented here
+
+- Transfer learning: `exportCheckpoint`, `importCheckpoint`,
+  `createSeededPopulation`, `CheckpointInterface`, `CheckpointMetadata`,
+  `CheckpointExportOptions`, `CheckpointImportOptions`,
+  `PopulationSeedingOptions`
+- ONNX: `exportToOnnx`, `checkOnnxCompatibility`, `isSquashSupported`,
+  `OnnxCompatibilityResult`, `OnnxExportOptions`
+- Topology export: `exportTopologyDot`, `exportTopologyJson`,
+  `TopologyExportJson`, `TopologyExportNode`, `TopologyExportSynapse`
+- Intelligent Design: `alternativeSquashes`, `cleanKnowledge`,
+  `combineImprovements`, `combineKnowledge`, `getNeuronsToTest`,
+  `getValidNeuronSquashes`, `makeModifiedCreature`,
+  `makeModifiedCreatureWithPrevious`, `safeWriteJson`, `safeWriteJsonSync`,
+  `scanForSquashImprovements`, `shuffle`, `IntelligentDesignWorkerHandler`,
+  `BestNeuronSquash`, `TacitKnowledgeMap`
+
+---
+
+## 📦 Transfer Learning
+
+Issue #1861: reuse trained creatures across related tasks. Export a creature as
+a checkpoint with metadata, then import it into a new task — optionally freezing
+weights and mapping UUIDs between different input/output configurations.
+
+```typescript
+import {
+  createSeededPopulation,
+  exportCheckpoint,
+  importCheckpoint,
+} from "@stsoftware/neat-ai";
+
+import type {
+  CheckpointExportOptions,
+  CheckpointImportOptions,
+  CheckpointInterface,
+  CheckpointMetadata,
+  PopulationSeedingOptions,
+} from "@stsoftware/neat-ai";
+```
+
+### `exportCheckpoint(creature, options?)`
+
+Exports a trained creature as a checkpoint with transfer learning metadata.
+
+```typescript
+const checkpoint = exportCheckpoint(creature, {
+  sourceTask: "price-prediction",
+  description: "Trained on 6 months of market data",
+  generations: 5000,
+  frozenNeuronUUIDs: ["uuid-1", "uuid-2"], // freeze learned features
+});
+
+// Save to disk
+Deno.writeTextFileSync("checkpoint.json", JSON.stringify(checkpoint));
+```
+
+| Parameter                   | Type       | Description                                     |
+| --------------------------- | ---------- | ----------------------------------------------- |
+| `creature`                  | `Creature` | The trained creature to export                  |
+| `options.sourceTask`        | `string`   | Human-readable name for the source task         |
+| `options.description`       | `string`   | Description of what the creature was trained on |
+| `options.generations`       | `number`   | Number of generations trained                   |
+| `options.frozenNeuronUUIDs` | `string[]` | Neuron UUIDs to mark as frozen                  |
+| `options.frozenSynapseKeys` | `string[]` | Synapse keys to mark as frozen                  |
+
+**Returns:** `CheckpointInterface` — serialisable checkpoint object.
+
+### `importCheckpoint(checkpoint, inputCount, outputCount)`
+
+Imports a checkpoint to create a creature for a new task, handling UUID mapping
+when input/output dimensions differ from the source task.
+
+```typescript
+const checkpoint = JSON.parse(Deno.readTextFileSync("checkpoint.json"));
+const creature = importCheckpoint(checkpoint, 8, 3); // new task: 8 inputs, 3 outputs
+```
+
+### `createSeededPopulation(options)`
+
+Creates an initial population mixing pre-trained creatures with randomly
+initialised ones.
+
+```typescript
+const population = createSeededPopulation({
+  inputCount: 8,
+  outputCount: 3,
+  populationSize: 50,
+  seeds: [checkpointA.creature, checkpointB.creature],
+  layers: [{ count: 5, squash: "TANH" }],
+});
+```
+
+| Parameter        | Type               | Description                                |
+| ---------------- | ------------------ | ------------------------------------------ |
+| `inputCount`     | `number`           | Number of inputs for the target task       |
+| `outputCount`    | `number`           | Number of outputs for the target task      |
+| `populationSize` | `number`           | Total population size (including seeds)    |
+| `seeds`          | `CreatureExport[]` | Pre-trained creatures to include as seeds  |
+| `layers`         | `object[]`         | Optional layer config for random creatures |
+
+**Returns:** `CreatureExport[]` — array of creature exports ready for evolution.
+
+---
+
+## 📤 ONNX Export
+
+Issue #1866: Export trained NEAT (NeuroEvolution of Augmenting Topologies)
+creatures to the [ONNX](https://onnx.ai/) (Open Neural Network Exchange) format
+for deployment in standard ML (Machine Learning) pipelines. The exported model
+produces identical outputs to the original creature (within floating-point
+precision).
+
+```typescript
+import {
+  checkOnnxCompatibility,
+  exportToOnnx,
+  isSquashSupported,
+} from "@stsoftware/neat-ai";
+
+import type {
+  OnnxCompatibilityResult,
+  OnnxExportOptions,
+} from "@stsoftware/neat-ai";
+```
+
+### `checkOnnxCompatibility(creature)`
+
+Checks whether a creature can be exported to ONNX format. Aggregate functions
+(IF, MINIMUM, MAXIMUM) and deprecated functions (HYPOT, HYPOTv2, MEAN) are not
+supported.
+
+```typescript
+const compat: OnnxCompatibilityResult = checkOnnxCompatibility(creature);
+if (!compat.compatible) {
+  console.log("Unsupported squashes:", compat.unsupportedSquashes);
+}
+```
+
+| Field                 | Type       | Description                                |
+| --------------------- | ---------- | ------------------------------------------ |
+| `compatible`          | `boolean`  | Whether the creature can be exported       |
+| `unsupportedSquashes` | `string[]` | List of unsupported squash functions found |
+
+`isSquashSupported(name)` is the per-squash predicate used internally to build
+that list.
+
+### `exportToOnnx(creature, options?)`
+
+Converts a creature to an ONNX binary model.
+
+```typescript
+const onnxBytes = exportToOnnx(creature, { graphName: "my-model" });
+Deno.writeFileSync("model.onnx", onnxBytes);
+```
+
+| Parameter           | Type       | Description                                          |
+| ------------------- | ---------- | ---------------------------------------------------- |
+| `creature`          | `Creature` | The creature to export                               |
+| `options.graphName` | `string`   | Name for the ONNX graph (default: `"neat_creature"`) |
+
+**Returns:** `Uint8Array` — binary ONNX model.
+
+> [!WARNING]
+> Recurrent connections (feedback loops) are not supported in ONNX export.
+> Creatures must use feed-forward topology only.
+
+---
+
+## 🗺️ Topology export (DOT / JSON)
+
+Issue #2417: Thin wrappers over the NEAT-AI-core `CompiledNetwork.to_dot` and
+`CompiledNetwork.to_topology_json` bindings. Returns Graphviz DOT or structured
+JSON for external tooling (renderers, snapshots, viewers) without
+re-implementing the formatter on the TypeScript side.
+
+```typescript
+import { exportTopologyDot, exportTopologyJson } from "@stsoftware/neat-ai";
+
+import type {
+  TopologyExportJson,
+  TopologyExportNode,
+  TopologyExportSynapse,
+} from "@stsoftware/neat-ai";
+
+const dot = exportTopologyDot(creature); // Graphviz string
+const json: TopologyExportJson = exportTopologyJson(creature);
+```
+
+`TopologyExportNode` and `TopologyExportSynapse` describe the shape of the
+entries inside `TopologyExportJson.nodes` and `.synapses`.
+
+---
+
+## 🧠 Intelligent Design (squash optimiser)
+
+Systematic optimisation of activation functions per neuron via brute-force
+search. Tests alternative squash functions and applies the best combination.
+
+```typescript
+import {
+  alternativeSquashes,
+  cleanKnowledge,
+  combineImprovements,
+  combineKnowledge,
+  getNeuronsToTest,
+  getValidNeuronSquashes,
+  IntelligentDesignWorkerHandler,
+  makeModifiedCreature,
+  makeModifiedCreatureWithPrevious,
+  safeWriteJson,
+  safeWriteJsonSync,
+  scanForSquashImprovements,
+  shuffle,
+} from "@stsoftware/neat-ai";
+
+import type { BestNeuronSquash, TacitKnowledgeMap } from "@stsoftware/neat-ai";
+```
+
+For the complete narrative guide, see
+[`docs/INTELLIGENT_DESIGN.md`](../INTELLIGENT_DESIGN.md).
+
+---
+
+## 🔗 Related topics
+
+- [Creature](CREATURE.md) — `Creature.exportJSON()` produces the
+  `CreatureExport` consumed by transfer learning and ONNX paths.
+- [Costs and activations](COSTS_AND_ACTIVATIONS.md) — squash names that
+  determine ONNX compatibility.
+- [Evolution API](EVOLUTION.md) — `createSeededPopulation()` integrates with
+  `Creature.evolveDir()`.
+- [`docs/INTELLIGENT_DESIGN.md`](../INTELLIGENT_DESIGN.md) — squash optimisation
+  guide.

--- a/docs/api/TRAINING.md
+++ b/docs/api/TRAINING.md
@@ -1,0 +1,203 @@
+# 🎓 Training API
+
+Backpropagation options, sparse training controls, and the synthetic synapse
+densification step.
+
+> **Acronyms:** API (Application Programming Interface), MSE (Mean Squared
+> Error), DRY (Don't Repeat Yourself), WASM (WebAssembly), GC (Garbage
+> Collection).
+
+NEAT-AI uses elastic backpropagation to train creatures within each generation.
+Training is typically invoked internally by `evolveDir()`, but the configuration
+types are documented here for fine-grained control and for callers wiring their
+own training loop.
+
+## 📦 Exports referenced here
+
+These types are consumed via `NeatOptions` and (when training is invoked
+directly) via `Creature.propagate()` / `Creature.propagateUpdate()`.
+
+- `BackPropagationOptions` (interface; configures elastic backprop)
+- `TrainOptions` (extends `BackPropagationOptions`)
+- Synthetic synapse helpers (internal — documented here for architectural
+  reference)
+
+## ⚙️ BackPropagationOptions
+
+```typescript
+interface BackPropagationOptions {
+  generations?: number; // Training iterations (default: random 1–100)
+  learningRate?: number; // 0–1 (default: random low value)
+  batchSize?: number; // Samples per batch (default: 64)
+  sparseRatio?: number; // Neuron selection ratio (default: 1.0)
+  trainingMutationRate?: number; // Gene change probability (default: random)
+  plankConstant?: number; // Minimum unit of change (default: 0.000_000_1)
+  maximumBiasAdjustmentScale?: number; // Max bias delta (default: 1)
+  maximumWeightAdjustmentScale?: number; // Max weight delta (default: 1)
+  limitBiasScale?: number; // Absolute bias cap (default: 10_000)
+  limitWeightScale?: number; // Absolute weight cap (default: 100_000)
+  disableBiasAdjustment?: boolean; // Skip bias updates (default: false)
+  disableWeightAdjustment?: boolean; // Skip weight updates (default: false)
+  disableRandomSamples?: boolean; // Use sequential sampling (default: false)
+  learningRateStrategy?: "fixed" | "decay" | "adaptive"; // Default: random
+  initialLearningRate?: number; // For decay/adaptive (default: 0.01)
+  learningRateDecay?: number; // Decay factor (default: 0.95)
+}
+```
+
+### 🧬 TrainOptions — additional training fields
+
+`TrainOptions` extends `BackPropagationOptions` with these optional fields:
+
+| Field               | Type                     | Default  | Description                                                                           |
+| ------------------- | ------------------------ | -------- | ------------------------------------------------------------------------------------- |
+| `syntheticSynapses` | `boolean`                | `false`  | Generate dense inter-layer synapses before backprop, then prune near-zero ones after. |
+| `predictiveCoding`  | `PredictiveCodingConfig` | disabled | Use local Hebbian learning rules instead of standard backpropagation.                 |
+| `crossValidation`   | `CrossValidationConfig`  | disabled | Split data into k folds for cross-validated training.                                 |
+| `dataFuzzing`       | `DataFuzzingConfig`      | disabled | Inject noise into training data each iteration to prevent memorisation.               |
+| `dataQuantisation`  | `DataQuantisationConfig` | disabled | Quantise training data values to discrete levels.                                     |
+| `feedbackLoop`      | `boolean`                | `false`  | Feed previous output back as input for time-series tasks.                             |
+
+### 💡 Direct training example
+
+```typescript
+import { Creature } from "@stsoftware/neat-ai";
+
+const creature = new Creature(2, 1);
+
+// Activate, then propagate errors
+const input = new Float32Array([1.0, 0.0]);
+const expected = new Float32Array([1.0]);
+
+creature.activate(input);
+// Propagation is handled internally by evolveDir() during evolution.
+```
+
+For backprop strategy details (minimum-change updates, saturation avoidance,
+plank constant), see [`docs/BACKPROP_ELASTICITY.md`](../BACKPROP_ELASTICITY.md).
+
+---
+
+## 🧪 Synthetic Synapses
+
+Issue #1919: synthetic synapses address a key weakness of NEAT's incremental
+topology growth — newly evolved networks often have sparse inter-layer
+connectivity compared to conventional dense neural networks. Synthetic synapses
+temporarily densify the network during backpropagation, giving gradient descent
+a richer search space to discover useful connections.
+
+### Lifecycle
+
+The synthetic synapse lifecycle has three phases, all handled automatically when
+`syntheticSynapses: true` is set in the training options:
+
+1. **Generation** — Before backpropagation begins, `generateSyntheticSynapses()`
+   computes a topological layer assignment for every neuron and adds zero-weight
+   synapses between each pair of adjacent layers. Existing connections, constant
+   neurons, and frozen neurons are skipped.
+2. **Training** — Standard backpropagation runs with the additional synthetic
+   synapses present. Useful connections are trained to non-trivial weights;
+   unhelpful ones remain near zero.
+3. **Pruning** — After training completes, `removeSyntheticSynapses()` removes
+   any synthetic synapse whose absolute weight remains below a threshold
+   (default: `plankConstant`, 1e-7). Synthetic synapses trained to meaningful
+   weights are retained as permanent connections. Orphaned neurons are cleaned
+   up automatically.
+
+### Enabling synthetic synapses
+
+Synthetic synapses are opt-in. Set `syntheticSynapses: true` in the training
+options passed to `evolveDir()`:
+
+```typescript
+const result = await creature.evolveDir(dataDir, {
+  costName: "MSE",
+  iterations: 100,
+  syntheticSynapses: true, // Enable synthetic synapse generation
+});
+```
+
+### Internal functions
+
+These functions are used internally by the training pipeline and are **not**
+exported from `mod.ts`. They are documented here for architectural reference.
+
+#### `generateSyntheticSynapses(creature, options?)`
+
+Adds zero-weight synapses between neurons in adjacent topological layers.
+
+| Parameter  | Type                       | Description                               |
+| ---------- | -------------------------- | ----------------------------------------- |
+| `creature` | `Creature`                 | The creature to modify (mutated in place) |
+| `options`  | `SyntheticSynapsesOptions` | Optional generation limits                |
+
+**`SyntheticSynapsesOptions`**:
+
+| Field          | Type     | Default | Description                                                                                                      |
+| -------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `maxPerTarget` | `number` | `50`    | Maximum synthetic connections per target neuron per layer pair. Prevents combinatorial explosion on wide layers. |
+
+**Returns:** `SyntheticSynapsesResult`
+
+| Field           | Type          | Description                                         |
+| --------------- | ------------- | --------------------------------------------------- |
+| `addedCount`    | `number`      | Number of synthetic synapses added                  |
+| `syntheticKeys` | `Set<string>` | Set of `"fromIndex-toIndex"` keys for later cleanup |
+| `skippedCount`  | `number`      | Connections skipped due to the per-target cap       |
+
+#### `removeSyntheticSynapses(creature, syntheticKeys, threshold?)`
+
+Prunes near-zero synthetic synapses after training. Synthetic synapses that have
+been trained to non-trivial weights are retained as permanent connections.
+
+| Parameter       | Type          | Default | Description                                     |
+| --------------- | ------------- | ------- | ----------------------------------------------- |
+| `creature`      | `Creature`    |         | The creature to prune (mutated in place)        |
+| `syntheticKeys` | `Set<string>` |         | Keys returned by `generateSyntheticSynapses()`  |
+| `threshold`     | `number`      | `1e-7`  | Maximum absolute weight to consider "near zero" |
+
+**Safety rules:**
+
+- Typed synapses (IF condition/positive/negative) are never removed.
+- Output neurons always retain at least one inward connection.
+- Orphaned neurons are handled by the standard compact function (DRY).
+
+**Returns:** `RemoveSyntheticSynapsesResult`
+
+| Field     | Type     | Description                                              |
+| --------- | -------- | -------------------------------------------------------- |
+| `removed` | `number` | Number of synthetic synapses zeroed (removed by compact) |
+
+#### `computeLayerAssignments(creature)`
+
+Computes topological layer assignments for all neurons using longest-path
+distance from input neurons.
+
+| Parameter  | Type       | Description                            |
+| ---------- | ---------- | -------------------------------------- |
+| `creature` | `Creature` | The creature whose topology to analyse |
+
+**Returns:** `Map<number, number[]>` — maps layer number to an array of neuron
+indices in that layer.
+
+**Layer assignment rules:**
+
+- Input and constant neurons → layer 0.
+- Hidden neurons → layer based on longest path from inputs.
+- Output neurons → always placed in the final layer.
+- Recurrent connections and self-loops are ignored.
+
+---
+
+## 🔗 Related topics
+
+- [Configuration reference](CONFIGURATION.md) — training fields on `NeatOptions`
+  (`trainPerGen`, `trainingBatchSize`, etc.).
+- [Costs and activations](COSTS_AND_ACTIVATIONS.md) — cost functions used inside
+  the training loop.
+- [Evolution API](EVOLUTION.md) — `Creature.evolveDir()` invokes training each
+  generation.
+- [`docs/BACKPROP_ELASTICITY.md`](../BACKPROP_ELASTICITY.md) — narrative on
+  minimum-change weight updates.
+- [`docs/PREDICTIVE_CODING.md`](../PREDICTIVE_CODING.md) — predictive coding
+  training mode.

--- a/docs/pr-summary-2572.md
+++ b/docs/pr-summary-2572.md
@@ -1,0 +1,99 @@
+# PR 2572 — split API_REFERENCE.md into index + topic detail docs
+
+## Summary
+
+Split the 1466-line `docs/API_REFERENCE.md` monolith into a short topic
+index (~131 lines) plus nine topic detail docs under `docs/api/`, one per
+major API (Application Programming Interface) surface. Each detail doc
+starts with a one-sentence summary, lists the exports it documents,
+expands acronyms on first use, and cross-references related topics.
+Inbound links from `README.md`, `AGENTS.md`, `docs/README.md`,
+`docs/CRISPR_GUIDE.md`, `docs/DISCOVERY_GUIDE.md`, and the
+`test/architecture/PublicAPI.ts` / `test/config/MCMCConfigDocumentation.ts`
+header comments were updated to point at the new homes. Closes #2572.
+
+## Topic split
+
+```mermaid
+flowchart LR
+    Index[docs/API_REFERENCE.md<br/>topic index] --> Creature[api/CREATURE.md]
+    Index --> Evolution[api/EVOLUTION.md]
+    Index --> Configuration[api/CONFIGURATION.md]
+    Index --> Costs[api/COSTS_AND_ACTIVATIONS.md]
+    Index --> Training[api/TRAINING.md]
+    Index --> Discovery[api/DISCOVERY.md]
+    Index --> Compute[api/COMPUTE.md]
+    Index --> Errors[api/ERRORS.md]
+    Index --> Interop[api/INTEROP.md]
+```
+
+| File                                     | Approx. lines | Surface                                                                             |
+| ---------------------------------------- | ------------: | ----------------------------------------------------------------------------------- |
+| `docs/API_REFERENCE.md`                  |          ~131 | Short index + Mermaid topic map                                                     |
+| `docs/api/CREATURE.md`                   |          ~318 | `Creature`, CRISPR, serialisation types, `Upgrade`, `randomConnectMissing`          |
+| `docs/api/EVOLUTION.md`                  |          ~282 | `Creature.evolveDir()`, `Selection`, `Mutation`, presets, `PlateauDetector`         |
+| `docs/api/CONFIGURATION.md`              |          ~441 | `NeatOptions`, sub-configs, MCMC, training events, Logger, RNG                      |
+| `docs/api/COSTS_AND_ACTIVATIONS.md`      |          ~147 | Cost functions and the 38-function activation menu                                  |
+| `docs/api/TRAINING.md`                   |          ~211 | `BackPropagationOptions`, `TrainOptions`, synthetic synapses                        |
+| `docs/api/DISCOVERY.md`                  |          ~168 | Discovery FFI helpers, cleanup, disk-space monitoring                               |
+| `docs/api/COMPUTE.md`                    |          ~159 | WASM preload, worker bootstrap, LRU cache, `getCacheStats`                          |
+| `docs/api/ERRORS.md`                     |          ~114 | `CrisprError`, `BreedExhaustionError`, `ValidationError`                            |
+| `docs/api/INTEROP.md`                    |          ~256 | Transfer learning, ONNX, topology export, Intelligent Design                        |
+
+## Acceptance criteria
+
+- [x] `docs/API_REFERENCE.md` is now a short index (under ~300 lines).
+- [x] One topic detail doc per API cluster lives under `docs/api/`.
+- [x] Every export documented matches a real export in `mod.ts` — verified
+      against `mod.ts` while writing each doc; the existing
+      `test/architecture/PublicAPI.ts` exercise continues to pass.
+- [x] Each topic detail doc starts with a brief summary and
+      cross-references related topics.
+- [x] First use of each acronym (API, JSON, UUID, FFI, JSR, etc.) expanded
+      in each detail doc independently.
+- [x] All inbound links to the old monolithic doc were updated:
+  - `README.md` — bullet text now mentions `docs/api/`.
+  - `AGENTS.md` — bullet now mentions the per-surface detail docs.
+  - `docs/README.md` — index entry mentions the topic split.
+  - `docs/CRISPR_GUIDE.md` — link now points at `api/CREATURE.md#-crispr`.
+  - `docs/DISCOVERY_GUIDE.md` — link now points at `api/DISCOVERY.md`.
+  - `test/architecture/PublicAPI.ts` and
+    `test/config/MCMCConfigDocumentation.ts` — header comments updated.
+- [x] `docs/README.md` index entry updated.
+- [x] Australian English spelling throughout (organisation,
+      regularisation, behaviour, optimise).
+- [x] `./quality.sh --lint-only` passes; no broken relative links.
+
+## Evidence
+
+This is a documentation-only change (no UI, no behaviour change). Verified
+by:
+
+1. **`./quality.sh --lint-only` passes** — formatter and linter clean,
+   2228 files checked, no errors.
+2. **`test/docs/DocsIndex.ts` passes** — 10/10 tests, including the
+   `docs/README.md internal links resolve` check that walks every
+   markdown link in `docs/README.md` and asserts the target exists.
+3. **`test/architecture/PublicAPI.ts` passes** — 20/20 tests, confirming
+   every exercised symbol from the docs is still a real `mod.ts` export.
+4. **Manual relative-link audit** of every `[text](path)` in each
+   `docs/api/*.md` file — all targets resolve (script run during
+   review).
+
+## Test plan
+
+- `./quality.sh --lint-only < /dev/null`
+- `deno test --no-check --allow-read test/docs/DocsIndex.ts < /dev/null`
+- `deno test --no-check --allow-read --allow-net --allow-env
+  test/architecture/PublicAPI.ts < /dev/null`
+
+No new tests were added because:
+
+- Link resolution is already covered by the existing
+  `test/docs/DocsIndex.ts::docs/README.md internal links resolve` test
+  (which now also walks the new `api/` link added to `docs/README.md`).
+- API export presence is already covered by
+  `test/architecture/PublicAPI.ts`.
+- The new `docs/api/*.md` files are docs-only — adding bespoke
+  per-file link tests would duplicate `quality.sh`'s formatter/linter
+  pass.

--- a/test/architecture/PublicAPI.ts
+++ b/test/architecture/PublicAPI.ts
@@ -1,9 +1,10 @@
 /**
  * Issue #1401: Verify the public API surface exported from mod.ts.
  *
- * This test ensures every symbol documented in docs/API_REFERENCE.md is
- * actually exported and usable. It exercises real code (constructors,
- * static methods, constants) rather than grepping documentation text.
+ * This test ensures every symbol documented in docs/API_REFERENCE.md and
+ * its per-surface detail docs under docs/api/ is actually exported and
+ * usable. It exercises real code (constructors, static methods, constants)
+ * rather than grepping documentation text.
  */
 import { assert, assertEquals } from "@std/assert";
 

--- a/test/config/MCMCConfigDocumentation.ts
+++ b/test/config/MCMCConfigDocumentation.ts
@@ -2,7 +2,7 @@
  * Tests that verify MCMC configuration documentation accuracy.
  *
  * Issue #2210: These tests ensure the MCMC defaults documented in
- * CONFIGURATION_GUIDE.md and API_REFERENCE.md match the actual code,
+ * CONFIGURATION_GUIDE.md and api/CONFIGURATION.md match the actual code,
  * and that MCMCConfig is properly exported from the public API.
  */
 


### PR DESCRIPTION
# PR 2572 — split API_REFERENCE.md into index + topic detail docs

## Summary

Split the 1466-line `docs/API_REFERENCE.md` monolith into a short topic
index (~131 lines) plus nine topic detail docs under `docs/api/`, one per
major API (Application Programming Interface) surface. Each detail doc
starts with a one-sentence summary, lists the exports it documents,
expands acronyms on first use, and cross-references related topics.
Inbound links from `README.md`, `AGENTS.md`, `docs/README.md`,
`docs/CRISPR_GUIDE.md`, `docs/DISCOVERY_GUIDE.md`, and the
`test/architecture/PublicAPI.ts` / `test/config/MCMCConfigDocumentation.ts`
header comments were updated to point at the new homes. Closes #2572.

## Topic split

```mermaid
flowchart LR
    Index[docs/API_REFERENCE.md<br/>topic index] --> Creature[api/CREATURE.md]
    Index --> Evolution[api/EVOLUTION.md]
    Index --> Configuration[api/CONFIGURATION.md]
    Index --> Costs[api/COSTS_AND_ACTIVATIONS.md]
    Index --> Training[api/TRAINING.md]
    Index --> Discovery[api/DISCOVERY.md]
    Index --> Compute[api/COMPUTE.md]
    Index --> Errors[api/ERRORS.md]
    Index --> Interop[api/INTEROP.md]
```

| File                                     | Approx. lines | Surface                                                                             |
| ---------------------------------------- | ------------: | ----------------------------------------------------------------------------------- |
| `docs/API_REFERENCE.md`                  |          ~131 | Short index + Mermaid topic map                                                     |
| `docs/api/CREATURE.md`                   |          ~318 | `Creature`, CRISPR, serialisation types, `Upgrade`, `randomConnectMissing`          |
| `docs/api/EVOLUTION.md`                  |          ~282 | `Creature.evolveDir()`, `Selection`, `Mutation`, presets, `PlateauDetector`         |
| `docs/api/CONFIGURATION.md`              |          ~441 | `NeatOptions`, sub-configs, MCMC, training events, Logger, RNG                      |
| `docs/api/COSTS_AND_ACTIVATIONS.md`      |          ~147 | Cost functions and the 38-function activation menu                                  |
| `docs/api/TRAINING.md`                   |          ~211 | `BackPropagationOptions`, `TrainOptions`, synthetic synapses                        |
| `docs/api/DISCOVERY.md`                  |          ~168 | Discovery FFI helpers, cleanup, disk-space monitoring                               |
| `docs/api/COMPUTE.md`                    |          ~159 | WASM preload, worker bootstrap, LRU cache, `getCacheStats`                          |
| `docs/api/ERRORS.md`                     |          ~114 | `CrisprError`, `BreedExhaustionError`, `ValidationError`                            |
| `docs/api/INTEROP.md`                    |          ~256 | Transfer learning, ONNX, topology export, Intelligent Design                        |

## Acceptance criteria

- [x] `docs/API_REFERENCE.md` is now a short index (under ~300 lines).
- [x] One topic detail doc per API cluster lives under `docs/api/`.
- [x] Every export documented matches a real export in `mod.ts` — verified
      against `mod.ts` while writing each doc; the existing
      `test/architecture/PublicAPI.ts` exercise continues to pass.
- [x] Each topic detail doc starts with a brief summary and
      cross-references related topics.
- [x] First use of each acronym (API, JSON, UUID, FFI, JSR, etc.) expanded
      in each detail doc independently.
- [x] All inbound links to the old monolithic doc were updated:
  - `README.md` — bullet text now mentions `docs/api/`.
  - `AGENTS.md` — bullet now mentions the per-surface detail docs.
  - `docs/README.md` — index entry mentions the topic split.
  - `docs/CRISPR_GUIDE.md` — link now points at `api/CREATURE.md#-crispr`.
  - `docs/DISCOVERY_GUIDE.md` — link now points at `api/DISCOVERY.md`.
  - `test/architecture/PublicAPI.ts` and
    `test/config/MCMCConfigDocumentation.ts` — header comments updated.
- [x] `docs/README.md` index entry updated.
- [x] Australian English spelling throughout (organisation,
      regularisation, behaviour, optimise).
- [x] `./quality.sh --lint-only` passes; no broken relative links.

## Evidence

This is a documentation-only change (no UI, no behaviour change). Verified
by:

1. **`./quality.sh --lint-only` passes** — formatter and linter clean,
   2228 files checked, no errors.
2. **`test/docs/DocsIndex.ts` passes** — 10/10 tests, including the
   `docs/README.md internal links resolve` check that walks every
   markdown link in `docs/README.md` and asserts the target exists.
3. **`test/architecture/PublicAPI.ts` passes** — 20/20 tests, confirming
   every exercised symbol from the docs is still a real `mod.ts` export.
4. **Manual relative-link audit** of every `[text](path)` in each
   `docs/api/*.md` file — all targets resolve (script run during
   review).

## Test plan

- `./quality.sh --lint-only < /dev/null`
- `deno test --no-check --allow-read test/docs/DocsIndex.ts < /dev/null`
- `deno test --no-check --allow-read --allow-net --allow-env
  test/architecture/PublicAPI.ts < /dev/null`

No new tests were added because:

- Link resolution is already covered by the existing
  `test/docs/DocsIndex.ts::docs/README.md internal links resolve` test
  (which now also walks the new `api/` link added to `docs/README.md`).
- API export presence is already covered by
  `test/architecture/PublicAPI.ts`.
- The new `docs/api/*.md` files are docs-only — adding bespoke
  per-file link tests would duplicate `quality.sh`'s formatter/linter
  pass.



## Milestone
This PR is part of the **Documentation May 2026** milestone and targets the `milestone/documentation-may-2026` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2572 -->