### PR TITLE
docs: refresh specialised concepts + archive investigation/research artefacts (#2575)

### DIFF
--- a/docs/ACTIVATION_FUNCTIONS.md
+++ b/docs/ACTIVATION_FUNCTIONS.md
@@ -432,3 +432,8 @@ Some activation functions have alternative names for convenience:
   weight updates near saturated activation functions
 - [Activation Backpropagation Strategy](../src/methods/activations/README.md) —
   Technical details on derivative vs inversion-based error propagation
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1464,3 +1464,8 @@ For configuration details, see
 - [Intelligent Design](INTELLIGENT_DESIGN.md) — Squash optimisation guide
 - [Activation Functions](../src/methods/activations/README.md) — Detailed
   activation function reference
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/BACKPROP_ELASTICITY.md
+++ b/docs/BACKPROP_ELASTICITY.md
@@ -223,3 +223,8 @@ operations fail fast with a `WasmError` — there is **no TypeScript fallback**.
 - WASM artefacts (vendored from the pinned NEAT-AI-core revision):
   [`wasm_activation/pkg/`](../wasm_activation/pkg/) — see `AGENTS.md` for the
   WASM-only operations list and core dependency policy.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/CI_EXTERNAL_NEAT_AI_CORE.md
+++ b/docs/CI_EXTERNAL_NEAT_AI_CORE.md
@@ -77,3 +77,8 @@ If you need a hard guard that fails the build, the following pattern works:
   the pinning model and CI policy this workflow enforces.
 - [`docs/PARITY_GATE.md`](PARITY_GATE.md) — release checklist run after bumping
   the pinned revision.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -90,3 +90,8 @@ Per-domain rules also appear in each topic detail doc.
   distributed, multi-machine discovery.
 - [API_REFERENCE.md](./API_REFERENCE.md) — types and exported helpers referenced
   throughout the configuration surface.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/CORE_DEPENDENCY_POLICY.md
+++ b/docs/CORE_DEPENDENCY_POLICY.md
@@ -121,3 +121,8 @@ used by this repo's `deno.json`.
 - [docs/PARITY_GATE.md](PARITY_GATE.md) — release checklist for repins.
 - [docs/PARITY_AUDITS.md](PARITY_AUDITS.md) — archived parity audits.
 - [docs/README.md](README.md) — full documentation index.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/CRISPR_GUIDE.md
+++ b/docs/CRISPR_GUIDE.md
@@ -1,10 +1,34 @@
-# CRISPR Guide
+# 🧬 CRISPR Guide
 
-Targeted genetic modifications for NEAT-AI creatures, inspired by the
-[CRISPR gene-editing technique](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/).
-This guide complements the CRISPR API summary in
-[`docs/api/CREATURE.md`](api/CREATURE.md#-crispr) with the conventions and
-gotchas that catch out new authors.
+> **CRISPR (Clustered Regularly Interspaced Short Palindromic Repeats)** is a
+> real-world gene-editing technique
+> ([Wikipedia](https://en.wikipedia.org/wiki/CRISPR),
+> [Nature primer](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/)).
+> In NEAT-AI we borrow the name for **targeted, hand-crafted edits to a
+> creature's genome** — splicing in new neurons or wrapping existing outputs
+> with extra activation/aggregation layers — without disturbing the UUIDs of
+> neurons that survive the edit. The implementation lives in
+> [`src/reconstruct/CRISPR.ts`](../src/reconstruct/CRISPR.ts); the API surface
+> is summarised in [`docs/api/CREATURE.md`](api/CREATURE.md#-crispr).
+
+This guide complements that API summary with the conventions and gotchas that
+catch out new authors. For the project-wide vocabulary that places CRISPR
+alongside Grafting, Discovery, and Intelligent Design, see
+[`AGENTS.md`](../AGENTS.md#-terminology); the documentation index is in
+[`docs/README.md`](README.md).
+
+## 🧪 What a CRISPR injection looks like
+
+```mermaid
+flowchart LR
+    DNA[📜 Hand-crafted DNA<br/>neurons + synapses] --> Validate[validateDNA<br/>structural checks]
+    Validate --> Upgrade[Upgrade.CRISPR<br/>UUID → id resolution]
+    Upgrade --> Inject[CRISPR.cleaveDNA<br/>insert or append + demote]
+    Inject --> Pop[🧬 Target creature<br/>UUIDs preserved]
+    Pop --> Score[📐 Score against probe dataset]
+    Score -->|fitness lift| Keep[✅ Keep edit]
+    Score -->|no lift| Drop[🗑️ Reject edit]
+```
 
 ## Modes
 
@@ -197,9 +221,17 @@ const resolved = CRISPR.editAliases(dna, {
 
 ## Related
 
-- `src/reconstruct/CRISPR.ts` — implementation
+- [`src/reconstruct/CRISPR.ts`](../src/reconstruct/CRISPR.ts) — implementation
 - `src/reconstruct/validateDNA.ts` — DNA structural validation
 - `src/reconstruct/Upgrade.ts` — legacy field rename + UUID→id resolution
-- `test/CRISPR/AppendDemoteOutput.ts` — append+demote regression tests
+- [`test/CRISPR/AppendDemoteOutput.ts`](../test/CRISPR/AppendDemoteOutput.ts) —
+  append+demote regression tests
 - `test/data/CRISPR/DNA-SANE.json`, `DNA-VOLUME.json` — multi-output demote
   examples
+- [`docs/INTELLIGENT_DESIGN.md`](INTELLIGENT_DESIGN.md) — sibling specialised
+  topic; the systematic squash-function search that complements hand-crafted
+  CRISPR edits.
+- [`docs/api/CREATURE.md`](api/CREATURE.md#-crispr) — public API surface for
+  CRISPR.
+- [`README.md`](../README.md) and [`docs/README.md`](README.md) — entry point
+  and topic index.

--- a/docs/DISCOVERY_ARCHITECTURE.md
+++ b/docs/DISCOVERY_ARCHITECTURE.md
@@ -731,3 +731,8 @@ candidates rather than analysis targets.
   including discovery parameters.
 - [`AGENTS.md`](../AGENTS.md) §"Neuron UUID stability" — wire-format invariant
   enforced across the FFI boundary.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/DISCOVERY_DIR.md
+++ b/docs/DISCOVERY_DIR.md
@@ -464,3 +464,8 @@ multiple times.
   workflow.
 - [`AGENTS.md`](../AGENTS.md) §"Neuron UUID stability" — wire-format invariant
   and the `loadFrom` UUID-first resolution rule.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -528,3 +528,8 @@ Discovery will analyse these neurons first before doing weighted selection.
   workflow.
 - `src/config/NeatOptions.ts` — All configuration options (source of truth).
 - `src/discovery/` — Pipeline orchestration source.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/EXTERNAL_NEAT_AI_CORE.md
+++ b/docs/EXTERNAL_NEAT_AI_CORE.md
@@ -106,3 +106,8 @@ documented in [`CI_EXTERNAL_NEAT_AI_CORE.md`](CI_EXTERNAL_NEAT_AI_CORE.md).
 - [`docs/DISCOVERY_ARCHITECTURE.md`](DISCOVERY_ARCHITECTURE.md) — the Discovery
   / Foreign Function Interface (FFI) cluster, which sits alongside this
   dependency.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/GPU_ACCELERATION.md
+++ b/docs/GPU_ACCELERATION.md
@@ -296,3 +296,8 @@ Data is transferred to GPU as:
 - **2 Jan 2025**: Initial GPU batching improvements for synapse evaluation.
 - GPU acceleration is actively maintained as part of the NEAT-AI-Discovery Rust
   module.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/INTELLIGENT_DESIGN.md
+++ b/docs/INTELLIGENT_DESIGN.md
@@ -1,14 +1,44 @@
 # 🧠 Intelligent Design
 
-Intelligent Design is a technique for optimising neural network creatures by
-systematically testing different squash (activation) functions for each hidden
-neuron. Unlike random mutation, Intelligent Design methodically explores the
-activation function space and remembers successful substitutions for future use.
+> **Intelligent Design** in NEAT-AI is the systematic per-neuron search over
+> squash (activation) functions. For each hidden neuron, it tries the candidate
+> squash, scores the modified creature, and keeps the substitution if it
+> improves fitness. Successful substitutions are persisted as **tacit
+> knowledge** so future runs can replay them without re-discovering them. The
+> implementation lives in
+> [`src/intelligentDesign/`](../src/intelligentDesign/mod.ts); the project-wide
+> vocabulary is in [`AGENTS.md`](../AGENTS.md#-terminology) and the doc index is
+> [`docs/README.md`](README.md).
 
 > [!NOTE]
 > Intelligent Design is distinct from random mutation — it performs a
 > systematic, exhaustive scan of the activation function space and persists its
 > discoveries as tacit knowledge for reuse across future runs.
+
+## 🆚 Random search vs Intelligent Design
+
+```mermaid
+flowchart LR
+    subgraph Random["🎲 Random mutation"]
+        R1[Pick random neuron] --> R2[Pick random squash]
+        R2 --> R3[Score]
+        R3 -->|"discard most edits"| R1
+    end
+    subgraph ID["🧠 Intelligent Design"]
+        I1[For each hidden neuron] --> I2[Try target squash]
+        I2 --> I3{"Improves<br/>score?"}
+        I3 -->|yes| I4[Try alternatives<br/>tier 1 → 3]
+        I3 -->|no| I5[Skip neuron]
+        I4 --> I6[Persist as<br/>tacit knowledge]
+        I5 --> I1
+        I6 --> I1
+    end
+```
+
+The random path explores the search space uniformly and rejects most edits.
+Intelligent Design walks every hidden neuron once per pass, escalates promising
+neurons through the alternative-squash tiers, and writes successful
+substitutions to disk so the next run skips re-discovery.
 
 ## 📋 Overview
 
@@ -230,3 +260,15 @@ flowchart TD
 
 5. **Handle timeouts gracefully**: The scan returns partial results if timed
    out, which can still be valuable.
+
+## 🔗 Related
+
+- [`src/intelligentDesign/`](../src/intelligentDesign/mod.ts) — implementation
+  (`ImproveSquash.ts`, `BestNeuronSquash.ts`, `TacitKnowledge.ts`,
+  `AlternativeSquashes.ts`, `SafeWrite.ts`, and the worker pool).
+- [`docs/ACTIVATION_FUNCTIONS.md`](ACTIVATION_FUNCTIONS.md) — selection guide
+  for the 30+ built-in squash functions Intelligent Design searches over.
+- [`docs/CRISPR_GUIDE.md`](CRISPR_GUIDE.md) — sibling specialised topic;
+  hand-crafted DNA injection that complements the systematic squash search.
+- [`README.md`](../README.md) and [`docs/README.md`](README.md) — entry point
+  and topic index.

--- a/docs/NEAT_AI_CORE_PARITY_AUDIT.md
+++ b/docs/NEAT_AI_CORE_PARITY_AUDIT.md
@@ -6,3 +6,8 @@ audit** section.
 
 For the live verification flow, see [docs/PARITY_GATE.md](PARITY_GATE.md) and
 [`./scripts/parity-gate.sh`](../scripts/parity-gate.sh).
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/PARITY_AUDITS.md
+++ b/docs/PARITY_AUDITS.md
@@ -93,3 +93,8 @@ The original audit narrative lives in
   instead of these snapshots.
 - [docs/CI_EXTERNAL_NEAT_AI_CORE.md](CI_EXTERNAL_NEAT_AI_CORE.md) — CI plumbing
   that enforces the policy on every PR.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/PARITY_GATE.md
+++ b/docs/PARITY_GATE.md
@@ -120,3 +120,8 @@ If any step fails:
   for build.sh-driven WASM sync.
 - [docs/PARITY_AUDITS.md](PARITY_AUDITS.md) — archived audits (#2367, #2368,
   #2369) for native code that has since been removed.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/PERFORMANCE_RESEARCH.md
+++ b/docs/PERFORMANCE_RESEARCH.md
@@ -825,3 +825,8 @@ matters for negative-result investigations.
 - [GPU_ACCELERATION.md](./GPU_ACCELERATION.md) — GPU compute layer details
   (Metal / Vulkan / DX12 via `wgpu`) referenced from the discovery pipeline.
 - [docs/README.md](./README.md) — Topic index for the full documentation set.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/PERFORMANCE_TUNING.md
+++ b/docs/PERFORMANCE_TUNING.md
@@ -930,3 +930,8 @@ pressure event.
   details referenced from the memetic evolution section.
 - [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) — Common issues and solutions.
 - [docs/README.md](./README.md) — Topic index for the full documentation set.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/PREDICTIVE_CODING.md
+++ b/docs/PREDICTIVE_CODING.md
@@ -1061,3 +1061,8 @@ If PC training produces no measurable improvement over standard backpropagation:
   [Predictive coding](https://en.wikipedia.org/wiki/Predictive_coding)
 - NEAT-AI-Discovery repository:
   [stSoftwareAU/NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery)
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/PREDICTIVE_CODING_BENCHMARKS.md
+++ b/docs/PREDICTIVE_CODING_BENCHMARKS.md
@@ -379,3 +379,8 @@ prevent divergence in deep topologies where gradient magnitudes can explode.
 - [BACKPROP_ELASTICITY.md](./BACKPROP_ELASTICITY.md) — elastic backpropagation,
   the standard-backprop comparison baseline used above.
 - [docs/README.md](./README.md) — topic index for the full documentation set.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/README.md
+++ b/docs/README.md
@@ -144,18 +144,19 @@ above:
 - **`pr-summary-*.md`** — per-PR summary files. They are write-once release
   notes for a single change, not topic documentation. Browse them via `git log`
   or the merged PR.
-- **`archive/`** — historical material kept for context (e.g. archived PR
-  summaries). Read on demand, not as part of the topic flow.
+- **`archive/`** — historical material kept for context. Read on demand, not as
+  part of the topic flow. Now includes:
+  - `archive/pr-summaries/` — archived PR summaries.
+  - `archive/research/` — DeepSeek applicability surveys
+    ([`deepseek-papers-index.md`](archive/research/deepseek-papers-index.md) is
+    the catalogue entry point; sibling applicability notes link from there).
+  - `archive/investigations/` — closed per-issue investigation notes (e.g.
+    [`issue-2418-training-bin-stream-investigation.md`](archive/investigations/issue-2418-training-bin-stream-investigation.md),
+    [`issue-2515-forward-only-apply-audit.md`](archive/investigations/issue-2515-forward-only-apply-audit.md)).
 - **`evidence/`** — captured artefacts referenced by individual PR summaries
   (logs, screenshots, repro scripts).
-- **`research/`** — experimental research notes (e.g. DeepSeek applicability
-  surveys) that pre-date or sit outside the production roadmap.
 - **`models/`** — sample exported creature JSON used by the visualisation app.
 - **`visualize/`, `index.html`, `index.js`, `server.ts`,
   `snapshot-schema.json`** — assets for the GitHub Pages visualisation app, not
   prose documentation.
-- **`issue-*-*.md`** — per-issue investigation notes (e.g.
-  `issue-2418-training-bin-stream-investigation.md`). They record a closed line
-  of work and graduate into a topic doc only if the work becomes a long-lived
-  feature.
 - **`logo.png`, `cspell.json`** — brand asset and spell-check dictionary.

--- a/docs/RUST_SCORER_PARITY_AUDIT.md
+++ b/docs/RUST_SCORER_PARITY_AUDIT.md
@@ -6,3 +6,8 @@ section.
 
 For the live verification flow, see [docs/PARITY_GATE.md](PARITY_GATE.md) and
 [`./scripts/parity-gate.sh`](../scripts/parity-gate.sh).
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -166,3 +166,8 @@ If your symptom is not listed above:
 2. Open a new issue with reproduction steps and error output.
 3. For development questions, see [`../AGENTS.md`](../AGENTS.md) for coding
    conventions and architecture details.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/TS_RUST_MIGRATION.md
+++ b/docs/TS_RUST_MIGRATION.md
@@ -187,3 +187,8 @@ The performance research established that these categories are unsuitable:
 - [PERFORMANCE_TUNING.md](PERFORMANCE_TUNING.md) — operational tuning guide.
 - #1639 — Parent tracking issue for the WASM performance series.
 - #1642 — WASM-resident topology investigation.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/WASM_ACTIVATION_PARITY_AUDIT.md
+++ b/docs/WASM_ACTIVATION_PARITY_AUDIT.md
@@ -6,3 +6,8 @@ audit** section.
 
 For the live verification flow, see [docs/PARITY_GATE.md](PARITY_GATE.md) and
 [`./scripts/parity-gate.sh`](../scripts/parity-gate.sh).
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/WASM_RESIDENT_TOPOLOGY.md
+++ b/docs/WASM_RESIDENT_TOPOLOGY.md
@@ -447,3 +447,8 @@ Implementation files:
   of operations that fail fast without the WASM bundle
 - `docs/PERFORMANCE_RESEARCH.md` — Performance research with WASM migration
   learnings
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/api/COMPUTE.md
+++ b/docs/api/COMPUTE.md
@@ -146,3 +146,8 @@ console.log(stats);
 - [`docs/PERFORMANCE_TUNING.md`](../PERFORMANCE_TUNING.md) — operational tuning.
 - [`docs/troubleshooting/WASM.md`](../troubleshooting/WASM.md) — worker-init
   failure modes.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/api/CONFIGURATION.md
+++ b/docs/api/CONFIGURATION.md
@@ -428,3 +428,8 @@ Seeded RNG uses the xoshiro256** algorithm internally.
   worker-related fields.
 - [`CONFIGURATION_GUIDE.md`](../CONFIGURATION_GUIDE.md) — narrative
   configuration guide.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/api/COSTS_AND_ACTIVATIONS.md
+++ b/docs/api/COSTS_AND_ACTIVATIONS.md
@@ -143,3 +143,8 @@ selection guide.
   HYPOTv2, MEAN).
 - [`docs/ACTIVATION_FUNCTIONS.md`](../ACTIVATION_FUNCTIONS.md) — narrative
   selection guide for the 30+ built-in squash functions.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/api/CREATURE.md
+++ b/docs/api/CREATURE.md
@@ -315,3 +315,8 @@ format.
   `Creature.activate()`.
 - [Discovery](DISCOVERY.md) — error-pattern-driven structural growth.
 - [`CRISPR_GUIDE.md`](../CRISPR_GUIDE.md) — full DNA conventions.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/api/DISCOVERY.md
+++ b/docs/api/DISCOVERY.md
@@ -158,3 +158,8 @@ For a full guide, see [`docs/DISCOVERY_GUIDE.md`](../DISCOVERY_GUIDE.md) and
 - [`docs/DISCOVERY_DIR.md`](../DISCOVERY_DIR.md) — `Creature.discoveryDir()`
   contract and on-disk layout.
 - [`docs/DISCOVERY_ARCHITECTURE.md`](../DISCOVERY_ARCHITECTURE.md) — internals.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/api/ERRORS.md
+++ b/docs/api/ERRORS.md
@@ -107,3 +107,8 @@ both classes are stable public exports.
   violations surface as `CrisprError`.
 - [`docs/TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) — common error signatures
   and remediation.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/api/EVOLUTION.md
+++ b/docs/api/EVOLUTION.md
@@ -278,3 +278,8 @@ alongside other sub-configs in [Configuration](CONFIGURATION.md).
   into the evolution loop.
 - [Compute / multithreading](COMPUTE.md) — `threads` and WASM cache controls
   used by `evolveDir()`.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/api/INTEROP.md
+++ b/docs/api/INTEROP.md
@@ -243,3 +243,8 @@ For the complete narrative guide, see
   `Creature.evolveDir()`.
 - [`docs/INTELLIGENT_DESIGN.md`](../INTELLIGENT_DESIGN.md) — squash optimisation
   guide.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/api/TRAINING.md
+++ b/docs/api/TRAINING.md
@@ -201,3 +201,8 @@ indices in that layer.
   minimum-change weight updates.
 - [`docs/PREDICTIVE_CODING.md`](../PREDICTIVE_CODING.md) — predictive coding
   training mode.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/archive/investigations/issue-2418-training-bin-stream-investigation.md
+++ b/docs/archive/investigations/issue-2418-training-bin-stream-investigation.md
@@ -1,5 +1,12 @@
 # Issue #2418 — Delegating TS training binary readers to NEAT-AI-core `training_bin_stream`
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> investigation note was moved from `docs/` to `docs/archive/investigations/`.
+> The line of work has closed — read on demand for historical context. Topic
+> index: [`docs/README.md`](../../README.md); entry point:
+> [`README.md`](../../../README.md).
+
 > **Status:** Investigation closed as `negative-result` — **no action**.
 >
 > **Summary:** The TypeScript per-record `seekSync` + `readSync` path in

--- a/docs/archive/investigations/issue-2515-forward-only-apply-audit.md
+++ b/docs/archive/investigations/issue-2515-forward-only-apply-audit.md
@@ -1,5 +1,12 @@
 # Issue #2515 — Forward-only audit of `applyChangeToCreature` and `normaliseCreatureExport`
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> investigation note was moved from `docs/` to `docs/archive/investigations/`.
+> The line of work has closed — read on demand for historical context. Topic
+> index: [`docs/README.md`](../../README.md); entry point:
+> [`README.md`](../../../README.md).
+
 ## Summary
 
 This note records the audit that wired `assertNoRecurrentSynapseOnForwardOnly`

--- a/docs/archive/research/deepseek-coder-applicability.md
+++ b/docs/archive/research/deepseek-coder-applicability.md
@@ -1,5 +1,13 @@
 # DeepSeek Coder Applicability to NEAT-AI (Issue #2539)
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> research note was moved from `docs/research/` to `docs/archive/research/`. Its
+> conclusions have landed (or been triaged out) — see the
+> [`deepseek-papers-index.md`](deepseek-papers-index.md) catalogue for the
+> consolidated implementation status. Topic index:
+> [`docs/README.md`](../../README.md).
+
 This research note maps the six headline ideas from DeepSeek-Coder and
 DeepSeek-Coder-V2 onto NEAT-AI's mutation, speciation, training-augmentation,
 and discovery surfaces and records a GO / NO-GO recommendation with a

--- a/docs/archive/research/deepseek-math-applicability.md
+++ b/docs/archive/research/deepseek-math-applicability.md
@@ -1,5 +1,13 @@
 # DeepSeekMath Applicability to NEAT-AI (Issue #2537)
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> research note was moved from `docs/research/` to `docs/archive/research/`. Its
+> conclusions have landed (or been triaged out) — see the
+> [`deepseek-papers-index.md`](deepseek-papers-index.md) catalogue for the
+> consolidated implementation status. Topic index:
+> [`docs/README.md`](../../README.md).
+
 This research note revisits the original DeepSeekMath paper — the paper that
 introduced **GRPO** — for techniques that extend beyond what the V4 note
 [#2526](https://github.com/stSoftwareAU/NEAT-AI/issues/2526) captured and that

--- a/docs/archive/research/deepseek-moe-applicability.md
+++ b/docs/archive/research/deepseek-moe-applicability.md
@@ -1,5 +1,13 @@
 # DeepSeek MoE (V1 + V2) Applicability to NEAT-AI (Issue #2535)
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> research note was moved from `docs/research/` to `docs/archive/research/`. Its
+> conclusions have landed (or been triaged out) — see the
+> [`deepseek-papers-index.md`](deepseek-papers-index.md) catalogue for the
+> consolidated implementation status. Topic index:
+> [`docs/README.md`](../../README.md).
+
 This research note maps the headline ideas from the DeepSeek MoE family —
 fine-grained expert segmentation and shared-expert isolation from **DeepSeekMoE
 (V1)**, plus auxiliary-loss-free load balancing, Multi-head Latent Attention
@@ -151,7 +159,7 @@ compute.
 
 **Closest NEAT-AI surface.** The cleanest analogue is an **immutable shared-seed
 subnetwork** injected into every species via CRISPR (see AGENTS.md "CRISPR
-injections" terminology and [`docs/CRISPR_GUIDE.md`](../CRISPR_GUIDE.md)).
+injections" terminology and [`docs/CRISPR_GUIDE.md`](../../CRISPR_GUIDE.md)).
 Today, CRISPR templates can inject hand-crafted synapses/neurons into individual
 creatures, but there is no concept of a "core" sub-graph that every species must
 contain and that mutation/breeding must preserve. Such a core would be the
@@ -426,7 +434,7 @@ normal `exportJSON()` payload and reject any seed that contains numeric `id` /
   those routed specialists; the two compose, they do not duplicate.
 - AGENTS.md — "CRISPR injections" terminology and the two critical invariants
   quoted above.
-- [`docs/CRISPR_GUIDE.md`](../CRISPR_GUIDE.md) — append+demote pattern and
+- [`docs/CRISPR_GUIDE.md`](../../CRISPR_GUIDE.md) — append+demote pattern and
   validation rules that any shared-seed loader (Idea 2) must respect.
 
 ## What this note does not do

--- a/docs/archive/research/deepseek-not-applicable.md
+++ b/docs/archive/research/deepseek-not-applicable.md
@@ -1,5 +1,13 @@
 # DeepSeek Papers Not Applicable to NEAT-AI (Issue #2540)
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> research note was moved from `docs/research/` to `docs/archive/research/`. Its
+> conclusions have landed (or been triaged out) — see the
+> [`deepseek-papers-index.md`](deepseek-papers-index.md) catalogue for the
+> consolidated implementation status. Topic index:
+> [`docs/README.md`](../../README.md).
+
 This note is the single negative-results triage record for DeepSeek papers that
 do **not** apply to NEAT-AI. It exists so that the next planning round does not
 re-investigate these papers from scratch — recording NO-GO with a clear

--- a/docs/archive/research/deepseek-papers-index.md
+++ b/docs/archive/research/deepseek-papers-index.md
@@ -1,5 +1,16 @@
 # DeepSeek Paper Catalogue — NEAT-AI Applicability Index
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> catalogue and its companion applicability notes were moved from
+> `docs/research/` to `docs/archive/research/`. The conclusions have already
+> landed (see the **Implementation Status** section below); the catalogue is
+> kept for historical reference and is exercised by
+> [`test/docs/DeepseekPapersIndex.ts`](../../../test/docs/DeepseekPapersIndex.ts)
+> so the linked artefacts cannot silently rot. Topic index:
+> [`docs/README.md`](../../README.md). Sibling archived applicability notes are
+> in this same directory.
+
 This document is the navigation hub for the broader DeepSeek-applicability
 investigation tracked under
 [#2532](https://github.com/stSoftwareAU/NEAT-AI/issues/2532). It catalogues

--- a/docs/archive/research/deepseek-prover-applicability.md
+++ b/docs/archive/research/deepseek-prover-applicability.md
@@ -1,5 +1,13 @@
 # DeepSeek Prover Applicability to NEAT-AI (Issue #2538)
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> research note was moved from `docs/research/` to `docs/archive/research/`. Its
+> conclusions have landed (or been triaged out) — see the
+> [`deepseek-papers-index.md`](deepseek-papers-index.md) catalogue for the
+> consolidated implementation status. Topic index:
+> [`docs/README.md`](../../README.md).
+
 This research note maps the six headline ideas from DeepSeek-Prover and
 DeepSeek-Prover-V2 onto NEAT-AI's discovery + breeding + backprop pipeline and
 records a GO / NO-GO recommendation with a one-paragraph rationale per idea. For

--- a/docs/archive/research/deepseek-r1-applicability.md
+++ b/docs/archive/research/deepseek-r1-applicability.md
@@ -1,5 +1,13 @@
 # DeepSeek R1 Applicability to NEAT-AI (Issue #2534)
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> research note was moved from `docs/research/` to `docs/archive/research/`. Its
+> conclusions have landed (or been triaged out) — see the
+> [`deepseek-papers-index.md`](deepseek-papers-index.md) catalogue for the
+> consolidated implementation status. Topic index:
+> [`docs/README.md`](../../README.md).
+
 This research note maps the six headline ideas from DeepSeek R1 onto NEAT-AI's
 evolution + breeding + backprop pipeline and records a GO / NO-GO recommendation
 with a one-paragraph rationale per idea. For every GO it proposes an

--- a/docs/archive/research/deepseek-v3-applicability.md
+++ b/docs/archive/research/deepseek-v3-applicability.md
@@ -1,5 +1,13 @@
 # DeepSeek V3 Applicability to NEAT-AI (Issue #2536)
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> research note was moved from `docs/research/` to `docs/archive/research/`. Its
+> conclusions have landed (or been triaged out) — see the
+> [`deepseek-papers-index.md`](deepseek-papers-index.md) catalogue for the
+> consolidated implementation status. Topic index:
+> [`docs/README.md`](../../README.md).
+
 This research note maps each notable DeepSeek V3 technique onto NEAT-AI's
 existing architecture (memetic evolution, MCMC acceptance, speciation, breeding,
 backprop, multi-threading) and records a GO / NO-GO recommendation with a
@@ -63,10 +71,10 @@ heads are dropped (or repurposed for speculative decoding) — they exist purely
 to enrich the gradient.
 
 **Closest NEAT-AI surface.** The cost surface
-([`src/costs/CostInterface.ts`](../../src/costs/CostInterface.ts) and concrete
-costs MAE/MSE/MSLE/MAPE/CrossEntropy/HINGE) currently provides a single scalar
-loss against a single target vector. Backprop in
-[`src/propagate/BackPropagation.ts`](../../src/propagate/BackPropagation.ts)
+([`src/costs/CostInterface.ts`](../../../src/costs/CostInterface.ts) and
+concrete costs MAE/MSE/MSLE/MAPE/CrossEntropy/HINGE) currently provides a single
+scalar loss against a single target vector. Backprop in
+[`src/propagate/BackPropagation.ts`](../../../src/propagate/BackPropagation.ts)
 runs one local gradient pass per training row.
 
 **Rationale (GO).** For sequence and regression problems with multi-step
@@ -107,12 +115,12 @@ training and inference, trading a small accuracy delta for a large
 communication-cost reduction.
 
 **Closest NEAT-AI surface.** Cross-species breeding in
-[`src/breed/ParallelBreeding.ts`](../../src/breed/ParallelBreeding.ts) and the
-quota machinery in
-[`src/NEAT/BreedingQuotas.ts`](../../src/NEAT/BreedingQuotas.ts) already enforce
-**how many** offspring each species produces per generation; what is missing is
-a budget on **how many distinct partner species** each species can pair with per
-generation.
+[`src/breed/ParallelBreeding.ts`](../../../src/breed/ParallelBreeding.ts) and
+the quota machinery in
+[`src/NEAT/BreedingQuotas.ts`](../../../src/NEAT/BreedingQuotas.ts) already
+enforce **how many** offspring each species produces per generation; what is
+missing is a budget on **how many distinct partner species** each species can
+pair with per generation.
 
 **Rationale (GO).** Mapping V3's per-token node budget onto NEAT-AI's
 per-generation breeding budget is direct: cap the number of partner species a
@@ -154,8 +162,9 @@ level addition is reported in V3 as a small, measurable accuracy boost.
 V3 = same plus per-sequence rebalancing, applied at a different time scale (per
 sequence rather than per training step).
 
-**Closest NEAT-AI surface.** [`src/NEAT/Species.ts`](../../src/NEAT/Species.ts)
-and [`src/NEAT/Genus.ts`](../../src/NEAT/Genus.ts), where #2535's V2 expert-
+**Closest NEAT-AI surface.**
+[`src/NEAT/Species.ts`](../../../src/NEAT/Species.ts) and
+[`src/NEAT/Genus.ts`](../../../src/NEAT/Genus.ts), where #2535's V2 expert-
 level bias-only correction would land.
 
 **Rationale (NO-GO).** NEAT-AI does not have a "sequence" abstraction. The V2
@@ -184,7 +193,7 @@ native FP8 matmul (NVIDIA Hopper / Blackwell). The cost is quantisation-aware
 engineering (per-channel scales, stochastic rounding, sensitivity profiling).
 
 **Closest NEAT-AI surface.**
-[`src/propagate/BackPropagation.ts`](../../src/propagate/BackPropagation.ts)
+[`src/propagate/BackPropagation.ts`](../../../src/propagate/BackPropagation.ts)
 weights are FP64 (TypeScript `number`); WASM-side activation buffers are FP32 or
 FP64 depending on path.
 
@@ -220,10 +229,10 @@ communication between stages _i_ and _i+1_. The win is reduced pipeline-bubble
 time at large pipeline-depth × micro-batch counts.
 
 **Closest NEAT-AI surface.**
-[`src/multithreading/WorkerPool.ts`](../../src/multithreading/WorkerPool.ts) and
-the workers under `src/multithreading/workers/` already split per-creature work
-(activation, scoring, backprop, discovery dispatch) across worker threads. Today
-these are serialised per creature: backprop completes, then discovery is
+[`src/multithreading/WorkerPool.ts`](../../../src/multithreading/WorkerPool.ts)
+and the workers under `src/multithreading/workers/` already split per-creature
+work (activation, scoring, backprop, discovery dispatch) across worker threads.
+Today these are serialised per creature: backprop completes, then discovery is
 dispatched.
 
 **Rationale (GO).** The DualPipe principle — overlap **compute** with
@@ -265,7 +274,7 @@ is parameter sharing and consistent output-distribution geometry across the
 auxiliary heads.
 
 **Closest NEAT-AI surface.** Canonical output-neuron identity in
-[`src/neuron/NeuronSerialization.ts`](../../src/neuron/NeuronSerialization.ts):
+[`src/neuron/NeuronSerialization.ts`](../../../src/neuron/NeuronSerialization.ts):
 output neurons are addressed by the canonical wire UUID `output-N` (where N is
 the output index). This identity is shared **across all creatures** in a
 population by construction — every creature's _N_-th output neuron carries the

--- a/docs/archive/research/deepseek-v4-applicability.md
+++ b/docs/archive/research/deepseek-v4-applicability.md
@@ -1,5 +1,13 @@
 # DeepSeek V4 Applicability to NEAT-AI (Issue #2526)
 
+> **📦 Archived under
+> [Issue #2575](https://github.com/stSoftwareAU/NEAT-AI/issues/2575).** This
+> research note was moved from `docs/research/` to `docs/archive/research/`. Its
+> conclusions have landed (or been triaged out) — see the
+> [`deepseek-papers-index.md`](deepseek-papers-index.md) catalogue for the
+> consolidated implementation status. Topic index:
+> [`docs/README.md`](../../README.md).
+
 This research note maps each notable DeepSeek V4 technique onto NEAT-AI's
 existing architecture (memetic evolution, MCMC acceptance, speciation, discovery
 cache, backprop, breeding) and records a GO / NO-GO recommendation with a

--- a/docs/config/CORE_EVOLUTION.md
+++ b/docs/config/CORE_EVOLUTION.md
@@ -223,3 +223,8 @@ iteration). See [Logging](./LOGGING.md).
   fine-tune population fractions.
 - [PERFORMANCE_TUNING.md](../PERFORMANCE_TUNING.md) — practical guidance on
   picking population sizes and training schedules at scale.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/config/DISCOVERY.md
+++ b/docs/config/DISCOVERY.md
@@ -225,3 +225,8 @@ logging using the exported formatting utilities.
   tasks.
 - [PERFORMANCE_TUNING.md](../PERFORMANCE_TUNING.md) — operational tuning for
   discovery throughput and memory.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/config/LOGGING.md
+++ b/docs/config/LOGGING.md
@@ -103,3 +103,8 @@ surface:
   reproducibility pitfalls.
 - [PERFORMANCE_TUNING.md](../PERFORMANCE_TUNING.md) — log cadence and
   per-iteration overhead.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/config/MUTATION_ADAPTATION.md
+++ b/docs/config/MUTATION_ADAPTATION.md
@@ -182,3 +182,8 @@ Each creature evolves these values within the configured bounds:
   naturally with plateau detection.
 - [PERFORMANCE_TUNING.md](../PERFORMANCE_TUNING.md) — when MCMC and plateau
   detection are worth the per-generation overhead.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/config/POPULATION.md
+++ b/docs/config/POPULATION.md
@@ -92,3 +92,8 @@ Pass as `fineTunePopulation` in options.
   with adaptive population sizing during stagnation.
 - [PERFORMANCE_TUNING.md](../PERFORMANCE_TUNING.md) — picking population sizes
   for large CPU clusters.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/config/PRESETS.md
+++ b/docs/config/PRESETS.md
@@ -124,3 +124,8 @@ const config = createNeatConfig({
   caching.
 - [PERFORMANCE_TUNING.md](../PERFORMANCE_TUNING.md) — operational guide for
   picking thread counts, batch sizes, and memory budgets.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/config/RECIPES.md
+++ b/docs/config/RECIPES.md
@@ -151,3 +151,8 @@ const config = createNeatConfig({
   picking thread counts, batch sizes, and memory budgets.
 - [PERFORMANCE_RESEARCH.md](../PERFORMANCE_RESEARCH.md) — benchmark learnings
   behind these defaults.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/config/REGULARISATION.md
+++ b/docs/config/REGULARISATION.md
@@ -134,3 +134,8 @@ effectiveStep = baseStep × (1 + errorScale × normalisedError)
   weight updates are preferred and how saturated activations are protected.
 - [PERFORMANCE_TUNING.md](../PERFORMANCE_TUNING.md) — when ensemble diversity is
   worth its evaluation cost.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/config/TRAINING.md
+++ b/docs/config/TRAINING.md
@@ -174,3 +174,8 @@ const config = createNeatConfig({
   evolution can override `learningRate` and similar values.
 - [PERFORMANCE_TUNING.md](../PERFORMANCE_TUNING.md) — picking batch sizes for
   large datasets and CPU/GPU (Graphics Processing Unit) targets.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/config/WORKERS.md
+++ b/docs/config/WORKERS.md
@@ -136,3 +136,8 @@ const config = createNeatConfig({
   WASM caches, thread pools, memory management, and scaling.
 - [PERFORMANCE_RESEARCH.md](../PERFORMANCE_RESEARCH.md) — WASM migration
   research and benchmark learnings.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/dna-sharing-bake-off-results.md
+++ b/docs/dna-sharing-bake-off-results.md
@@ -1,13 +1,39 @@
-# DNA Sharing Bake-Off Results (Issue #2496)
+# 🥧 DNA Sharing Bake-Off Results (Issue #2496)
+
+> **Summary.** Five DNA-sharing strategies were measured under
+> [`bench/DnaSharingBakeOff.ts`](../bench/DnaSharingBakeOff.ts) across three
+> seeds. Only **`PruningTemplateStrategy`** produced a strictly positive lift on
+> every seed, so it is the recommended default — exported as
+> `recommendedDnaSharingStrategy` from `src/transfer/mod.ts`. The
+> `dnaSharingMode` knob is intentionally **not** flipped to `aggressive`,
+> because `KnobTuningStrategy("aggressive")` produced zero lift in this
+> bake-off. Numbers below are **current** (Issue #2496); a real-evolve-step
+> rerun is tracked separately on #2490 and will be linked here when it lands.
 
 This document captures the bake-off comparison of the four DNA-sharing
 primitives (Issues #2492 – #2495) plus the `NoOpStrategy` baseline run through
-the harness from #2491 (`bench/DnaSharingBakeOff.ts`).
+the harness from #2491
+([`bench/DnaSharingBakeOff.ts`](../bench/DnaSharingBakeOff.ts)).
 
 The bake-off is part of the parent investigation in #2490 — "what is the
 cheapest way to share useful behaviour between a small Europa island and a
 larger production cluster without violating the AGENTS.md UUID stability
 invariant?".
+
+## 📊 Lift at a glance
+
+```mermaid
+%%{init: {'theme': 'default'}}%%
+xychart-beta
+    title "Mean lift across 3 seeds (higher = better)"
+    x-axis ["NoOp", "KnobTuning", "CompactGraft", "KnowDistill", "PruningTpl"]
+    y-axis "Mean lift (units of -MSE)" -0.0002 --> 0.0003
+    bar [0, 0, 0, -0.000121, 0.000279]
+```
+
+The chart visualises the table below — only `PruningTemplate` lands a positive
+bar; `KnowledgeDistillation` regresses on every seed; the rest are neutral on
+this fixture.
 
 ## Method
 
@@ -151,3 +177,18 @@ opt-in matches the way the four primitives were designed.
   tracked in #2490.
 - 50 generations is intentionally short to keep CI runtime under 100 ms per row.
   Longer-budget bake-offs are tracked separately on #2490.
+
+## 🔗 Related
+
+- [`bench/DnaSharingBakeOff.ts`](../bench/DnaSharingBakeOff.ts) — the harness
+  that produced these numbers.
+- `src/transfer/mod.ts` — exports `recommendedDnaSharingStrategy` and the four
+  strategy classes.
+- [`docs/INTELLIGENT_DESIGN.md`](INTELLIGENT_DESIGN.md) — sibling specialised
+  topic; per-neuron squash search that reads/writes tacit knowledge in a similar
+  shared-knowledge style.
+- [`docs/CRISPR_GUIDE.md`](CRISPR_GUIDE.md) — sibling specialised topic;
+  hand-crafted DNA edits that operate on a single creature rather than across
+  islands.
+- [`README.md`](../README.md) and [`docs/README.md`](README.md) — entry point
+  and topic index.

--- a/docs/pr-summary-2567.md
+++ b/docs/pr-summary-2567.md
@@ -2,23 +2,23 @@
 
 ## Summary
 
-Refreshes the four contributor- and governance-facing documents
-(`AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`) so they read
-consistently with the recently refreshed `README.md` and `docs/README.md`,
-expand acronyms on first use, link out to topic-specific deeper docs, and back
-their claims with verifiable references. Adds Mermaid diagrams for the two
-non-obvious flows (neuron-UUID lifecycle and the semantic-version invariant)
-and for the contribution pipeline. Updates the `quality.sh` flag list to match
-the script's actual `--help` output, and seeds the `[Unreleased]` block in
-`CHANGELOG.md` with merged work that had no entry yet (#2513, #2529, #2545,
-#2565, #2566, #2569, #2570). Closes #2567.
+Refreshes the four contributor- and governance-facing documents (`AGENTS.md`,
+`CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`) so they read consistently with
+the recently refreshed `README.md` and `docs/README.md`, expand acronyms on
+first use, link out to topic-specific deeper docs, and back their claims with
+verifiable references. Adds Mermaid diagrams for the two non-obvious flows
+(neuron-UUID lifecycle and the semantic-version invariant) and for the
+contribution pipeline. Updates the `quality.sh` flag list to match the script's
+actual `--help` output, and seeds the `[Unreleased]` block in `CHANGELOG.md`
+with merged work that had no entry yet (#2513, #2529, #2545, #2565, #2566,
+#2569, #2570). Closes #2567.
 
 ## Evidence
 
 This is a documentation-only change — no UI, no runtime behaviour. The new
 diagrams and cross-links are validated by `./quality.sh --lint-only` (Deno fmt,
-Deno lint, bash syntax) and by `markdownlint-cli2` over the whole repo, both
-of which pass.
+Deno lint, bash syntax) and by `markdownlint-cli2` over the whole repo, both of
+which pass.
 
 ```mermaid
 flowchart LR
@@ -36,13 +36,13 @@ flowchart LR
 
 - **`AGENTS.md`** — added a top-level "Summary and where to go next" paragraph
   with links to topic docs (activation, neuron UUID, semantic version,
-  Discovery, NEAT-AI-core dependency, contributing, security, changelog);
-  added a `stateDiagram-v2` Mermaid diagram for the neuron-UUID lifecycle and a
-  `flowchart` for the semantic-version invariant; expanded WASM, FFI, GPU,
-  CPU, DX12, and MCMC on first use; replaced the dead "scattered
+  Discovery, NEAT-AI-core dependency, contributing, security, changelog); added
+  a `stateDiagram-v2` Mermaid diagram for the neuron-UUID lifecycle and a
+  `flowchart` for the semantic-version invariant; expanded WASM, FFI, GPU, CPU,
+  DX12, and MCMC on first use; replaced the dead "scattered
   `bumpToFourIfForwardOnlyConfirmed` helper calls" past-tense reference with a
-  cleaner historical note; turned the trailing Documentation Layout section
-  into a sibling-link list.
+  cleaner historical note; turned the trailing Documentation Layout section into
+  a sibling-link list.
 - **`CONTRIBUTING.md`** — added a top-level summary linking out to `AGENTS.md`,
   `docs/README.md`, `docs/DISCOVERY_GUIDE.md`, `docs/CORE_DEPENDENCY_POLICY.md`,
   `SECURITY.md`, and `CHANGELOG.md`; added a `flowchart LR` Mermaid of the
@@ -57,23 +57,23 @@ flowchart LR
   versions wording to refer to the published JSR release; added a sibling-link
   section.
 - **`CHANGELOG.md`** — added a "Sibling docs" line under the format note;
-  appended `[Unreleased]` entries for #2529 (Muon-style orthogonalised
-  gradient updates), #2545 (JSR-hosted-worker WASM bootstrap), #2513
-  (throughput-stall warm-up gate), and a Documentation block covering #2566,
-  #2569, #2570, and #2565. Historical entries were not rewritten.
+  appended `[Unreleased]` entries for #2529 (Muon-style orthogonalised gradient
+  updates), #2545 (JSR-hosted-worker WASM bootstrap), #2513 (throughput-stall
+  warm-up gate), and a Documentation block covering #2566, #2569, #2570, and
+  #2565. Historical entries were not rewritten.
 
 ### Verifying the references
 
 Every cited path/test resolves on disk:
 
-- `test/creature/NeuronUuidStability.ts`, `test/creature/SemanticVersionStability.ts`,
+- `test/creature/NeuronUuidStability.ts`,
+  `test/creature/SemanticVersionStability.ts`,
   `test/creature/CreatureSerializationPolicy.ts`
 - `src/architecture/NeuronId.ts`, `src/utils/Logger.ts`,
   `src/wasm/WasmTopologyOps.ts`, `src/propagate/WasmTopologicalBackprop.ts`,
   `src/propagate/ElasticDistribution.ts`
 - `bench/ParallelBreeding.ts`, `bench/GeneticCompatibilitySetIntersection.ts`
-- `.github/workflows/dependency-review.yml`,
-  `.github/workflows/semgrep.yml`,
+- `.github/workflows/dependency-review.yml`, `.github/workflows/semgrep.yml`,
   `.github/workflows/deno-outdated.yml`, `.gitleaks.toml`
 - `docs/README.md`, `docs/DISCOVERY_GUIDE.md`, `docs/CORE_DEPENDENCY_POLICY.md`,
   `docs/PARITY_GATE.md`, `docs/ACTIVATION_FUNCTIONS.md`,
@@ -83,8 +83,8 @@ Every cited path/test resolves on disk:
 
 - [x] `./quality.sh --lint-only` (Deno fmt, Deno lint, bash syntax) passes
       cleanly.
-- [x] `npx markdownlint-cli2 ...` passes with `0 error(s)` over all 603
-      Markdown files.
+- [x] `npx markdownlint-cli2 ...` passes with `0 error(s)` over all 603 Markdown
+      files.
 - [x] All Mermaid blocks use the GitHub-supported syntax (`flowchart`,
       `stateDiagram-v2`) — they render natively on the GitHub PR view.
 - [x] Every cited file path / test path / workflow path resolves on disk
@@ -93,18 +93,18 @@ Every cited path/test resolves on disk:
 
 ## Acceptance Criteria
 
-- [x] All four files have a brief summary at the top with links to deeper
-      topic docs.
+- [x] All four files have a brief summary at the top with links to deeper topic
+      docs.
 - [x] Every acronym used is expanded or linked on first use within each file
       (NEAT, WASM, FFI, GPU, CPU, DX12, MCMC, UUID, JSR, PR, SAST).
-- [x] At least one Mermaid diagram has been added or refreshed
-      (`AGENTS.md` gets two; `CONTRIBUTING.md` gets one).
-- [x] No stale code references — every cited file path / line number / PR
-      number resolves on disk.
+- [x] At least one Mermaid diagram has been added or refreshed (`AGENTS.md` gets
+      two; `CONTRIBUTING.md` gets one).
+- [x] No stale code references — every cited file path / line number / PR number
+      resolves on disk.
 - [x] `CHANGELOG.md`'s `[Unreleased]` block reflects merged changes since the
       last release (3.2.0, 2026-05-05).
-- [x] Cross-references link these docs to `README.md`, `docs/README.md`, and
-      at least one topic detail doc per file where relevant.
+- [x] Cross-references link these docs to `README.md`, `docs/README.md`, and at
+      least one topic detail doc per file where relevant.
 - [x] Australian English spelling throughout (`organisation`, `behaviour`,
       `optimise`, `centre`, `licence`).
 - [x] `./quality.sh --lint-only` passes.

--- a/docs/pr-summary-2568.md
+++ b/docs/pr-summary-2568.md
@@ -5,8 +5,8 @@
 Refreshed the four "compute cluster" docs so they read as a coherent group and
 match the code they describe. Each file now opens with a TL;DR, expands its
 acronyms (WASM, GPU, FFI, ReLU, GELU, ELU, SELU, etc.), cross-links the other
-three siblings plus the docs index, and gains at least one new Mermaid
-diagram. Closes #2568.
+three siblings plus the docs index, and gains at least one new Mermaid diagram.
+Closes #2568.
 
 Changed files:
 
@@ -16,19 +16,19 @@ Changed files:
   now link to source; new `flowchart` showing where the squash sits in the
   forward/backprop pipeline.
 - `docs/BACKPROP_ELASTICITY.md` — TL;DR + sibling links; new `sequenceDiagram`
-  for forward → error → elastic distribution → weight update; "Where to Look
-  in Code" updated to call out that the topological backprop loop and elastic
+  for forward → error → elastic distribution → weight update; "Where to Look in
+  Code" updated to call out that the topological backprop loop and elastic
   distribution kernel are WASM-only (Issue #2416, no TS fallback) and to link
   the WASM artefacts under `wasm_activation/pkg/`.
 - `docs/WASM_RESIDENT_TOPOLOGY.md` — TL;DR clarifying the analysis is "defer
-  full residency, ship selective WASM-only kernels" plus sibling links;
-  new `flowchart` of the TS ↔ WASM boundary (what crosses, what stays inside);
+  full residency, ship selective WASM-only kernels" plus sibling links; new
+  `flowchart` of the TS ↔ WASM boundary (what crosses, what stays inside);
   references updated to include #2415/#2416 and the `AGENTS.md` WASM-only
   operations list.
 - `docs/GPU_ACCELERATION.md` — TL;DR with acronym expansions and a pointer to
-  `DISCOVERY_GUIDE.md`; backend compatibility table (Metal / Vulkan / DX12 /
-  Gl / CPU) matching the NEAT-AI-Discovery README and `getGpuBackendInfo()`
-  return shape; new Discovery → GPU pipeline `flowchart`.
+  `DISCOVERY_GUIDE.md`; backend compatibility table (Metal / Vulkan / DX12 / Gl
+  / CPU) matching the NEAT-AI-Discovery README and `getGpuBackendInfo()` return
+  shape; new Discovery → GPU pipeline `flowchart`.
 
 ## Evidence
 
@@ -60,7 +60,7 @@ four files, lint clean across 1540 files, all bash scripts ✅).
 
 - Docs-only change. No new code paths, so no new unit tests.
 - Verified all four files render Mermaid blocks with valid syntax (fenced
-  ` ```mermaid ` blocks; flowchart/sequenceDiagram only).
+  `` ```mermaid `` blocks; flowchart/sequenceDiagram only).
 - Verified no Liquid `{% ... %}` / `{{ ... }}` patterns appear in prose.
 - Re-read the issue's acceptance criteria:
   - [x] Each file starts with a brief summary and links to siblings + Discovery
@@ -69,7 +69,7 @@ four files, lint clean across 1540 files, all bash scripts ✅).
   - [x] First use of each acronym (WASM, GPU, FFI, NaN, ReLU, GELU, ELU, SELU,
         TANH, MCMC, UUID, LRU, GC, WGSL, DX12) is expanded.
   - [x] All squash names in `ACTIVATION_FUNCTIONS.md` resolve to real exports.
-  - [x] Cross-references to `docs/README.md` and sibling docs added in all
-        four files.
+  - [x] Cross-references to `docs/README.md` and sibling docs added in all four
+        files.
   - [x] Australian English spelling preserved.
   - [x] `./quality.sh --lint-only` passes.

--- a/docs/pr-summary-2571.md
+++ b/docs/pr-summary-2571.md
@@ -20,9 +20,9 @@ Mermaid flowchart:
   doc, the PC cluster, the GPU acceleration doc, and the docs index. The doc is
   retained as a single file (the largest section is well below the ~400-line
   threshold from the issue).
-- `PREDICTIVE_CODING.md` — added the brief, cluster index, acronyms, a
-  numbered Table of Contents covering the eight existing top-level sections, a
-  new "predictive-coding loop at a glance" Mermaid flowchart that summarises the
+- `PREDICTIVE_CODING.md` — added the brief, cluster index, acronyms, a numbered
+  Table of Contents covering the eight existing top-level sections, a new
+  "predictive-coding loop at a glance" Mermaid flowchart that summarises the
   fast settling and slow learning loops in one picture, and replaced the legacy
   Further Reading list with cross-references to all sibling docs.
 - `PREDICTIVE_CODING_BENCHMARKS.md` — added the brief, cluster index, acronyms,
@@ -32,8 +32,8 @@ Mermaid flowchart:
   performance docs.
 
 Numbers are kept verbatim with their existing issue / PR references; the issue
-explicitly requested that historical results be preserved with date / PR
-markers rather than overwritten. The Methodology and Note callouts in
+explicitly requested that historical results be preserved with date / PR markers
+rather than overwritten. The Methodology and Note callouts in
 `PREDICTIVE_CODING_BENCHMARKS.md` make the "append, do not overwrite" policy
 explicit. The dates and `iter/s` figures originate from issues
 [#1558](https://github.com/stSoftwareAU/NEAT-AI/issues/1558),
@@ -45,8 +45,8 @@ explicit. The dates and `iter/s` figures originate from issues
 This is a documentation-only change with no code or behaviour modifications.
 Verification:
 
-- `./quality.sh --lint-only < /dev/null` — passes (formatting, linting, and
-  bash syntax check all clean).
+- `./quality.sh --lint-only < /dev/null` — passes (formatting, linting, and bash
+  syntax check all clean).
 - The four files retain all existing benchmark numbers, callouts, and
   references; only structural framing (briefs, ToCs, cross-refs, Mermaid
   diagrams) was added.
@@ -66,13 +66,13 @@ flowchart LR
 ## Test Plan
 
 - [x] `./quality.sh --lint-only < /dev/null` passes.
-- [x] Each refreshed file opens with a Brief, links to the other three
-      companion docs, and includes at least one new Mermaid diagram.
+- [x] Each refreshed file opens with a Brief, links to the other three companion
+      docs, and includes at least one new Mermaid diagram.
 - [x] Acronyms (CPU, GPU, FFI, RMSE, MAPE, etc.) are expanded on first use in
       each file.
 - [x] Cross-references to `docs/README.md` index appear in each file.
 - [x] Australian English spellings preserved throughout (no introduced
       Americanisms).
-- [x] No claim was added without an evidence link — the new prose either
-      points at an existing benchmark issue, an existing PR, or a script under
+- [x] No claim was added without an evidence link — the new prose either points
+      at an existing benchmark issue, an existing PR, or a script under
       `bench/`.

--- a/docs/pr-summary-2572.md
+++ b/docs/pr-summary-2572.md
@@ -2,15 +2,15 @@
 
 ## Summary
 
-Split the 1466-line `docs/API_REFERENCE.md` monolith into a short topic
-index (~131 lines) plus nine topic detail docs under `docs/api/`, one per
-major API (Application Programming Interface) surface. Each detail doc
-starts with a one-sentence summary, lists the exports it documents,
-expands acronyms on first use, and cross-references related topics.
-Inbound links from `README.md`, `AGENTS.md`, `docs/README.md`,
-`docs/CRISPR_GUIDE.md`, `docs/DISCOVERY_GUIDE.md`, and the
-`test/architecture/PublicAPI.ts` / `test/config/MCMCConfigDocumentation.ts`
-header comments were updated to point at the new homes. Closes #2572.
+Split the 1466-line `docs/API_REFERENCE.md` monolith into a short topic index
+(~131 lines) plus nine topic detail docs under `docs/api/`, one per major API
+(Application Programming Interface) surface. Each detail doc starts with a
+one-sentence summary, lists the exports it documents, expands acronyms on first
+use, and cross-references related topics. Inbound links from `README.md`,
+`AGENTS.md`, `docs/README.md`, `docs/CRISPR_GUIDE.md`,
+`docs/DISCOVERY_GUIDE.md`, and the `test/architecture/PublicAPI.ts` /
+`test/config/MCMCConfigDocumentation.ts` header comments were updated to point
+at the new homes. Closes #2572.
 
 ## Topic split
 
@@ -27,18 +27,18 @@ flowchart LR
     Index --> Interop[api/INTEROP.md]
 ```
 
-| File                                     | Approx. lines | Surface                                                                             |
-| ---------------------------------------- | ------------: | ----------------------------------------------------------------------------------- |
-| `docs/API_REFERENCE.md`                  |          ~131 | Short index + Mermaid topic map                                                     |
-| `docs/api/CREATURE.md`                   |          ~318 | `Creature`, CRISPR, serialisation types, `Upgrade`, `randomConnectMissing`          |
-| `docs/api/EVOLUTION.md`                  |          ~282 | `Creature.evolveDir()`, `Selection`, `Mutation`, presets, `PlateauDetector`         |
-| `docs/api/CONFIGURATION.md`              |          ~441 | `NeatOptions`, sub-configs, MCMC, training events, Logger, RNG                      |
-| `docs/api/COSTS_AND_ACTIVATIONS.md`      |          ~147 | Cost functions and the 38-function activation menu                                  |
-| `docs/api/TRAINING.md`                   |          ~211 | `BackPropagationOptions`, `TrainOptions`, synthetic synapses                        |
-| `docs/api/DISCOVERY.md`                  |          ~168 | Discovery FFI helpers, cleanup, disk-space monitoring                               |
-| `docs/api/COMPUTE.md`                    |          ~159 | WASM preload, worker bootstrap, LRU cache, `getCacheStats`                          |
-| `docs/api/ERRORS.md`                     |          ~114 | `CrisprError`, `BreedExhaustionError`, `ValidationError`                            |
-| `docs/api/INTEROP.md`                    |          ~256 | Transfer learning, ONNX, topology export, Intelligent Design                        |
+| File                                | Approx. lines | Surface                                                                     |
+| ----------------------------------- | ------------: | --------------------------------------------------------------------------- |
+| `docs/API_REFERENCE.md`             |          ~131 | Short index + Mermaid topic map                                             |
+| `docs/api/CREATURE.md`              |          ~318 | `Creature`, CRISPR, serialisation types, `Upgrade`, `randomConnectMissing`  |
+| `docs/api/EVOLUTION.md`             |          ~282 | `Creature.evolveDir()`, `Selection`, `Mutation`, presets, `PlateauDetector` |
+| `docs/api/CONFIGURATION.md`         |          ~441 | `NeatOptions`, sub-configs, MCMC, training events, Logger, RNG              |
+| `docs/api/COSTS_AND_ACTIVATIONS.md` |          ~147 | Cost functions and the 38-function activation menu                          |
+| `docs/api/TRAINING.md`              |          ~211 | `BackPropagationOptions`, `TrainOptions`, synthetic synapses                |
+| `docs/api/DISCOVERY.md`             |          ~168 | Discovery FFI helpers, cleanup, disk-space monitoring                       |
+| `docs/api/COMPUTE.md`               |          ~159 | WASM preload, worker bootstrap, LRU cache, `getCacheStats`                  |
+| `docs/api/ERRORS.md`                |          ~114 | `CrisprError`, `BreedExhaustionError`, `ValidationError`                    |
+| `docs/api/INTEROP.md`               |          ~256 | Transfer learning, ONNX, topology export, Intelligent Design                |
 
 ## Acceptance criteria
 
@@ -47,10 +47,10 @@ flowchart LR
 - [x] Every export documented matches a real export in `mod.ts` — verified
       against `mod.ts` while writing each doc; the existing
       `test/architecture/PublicAPI.ts` exercise continues to pass.
-- [x] Each topic detail doc starts with a brief summary and
-      cross-references related topics.
-- [x] First use of each acronym (API, JSON, UUID, FFI, JSR, etc.) expanded
-      in each detail doc independently.
+- [x] Each topic detail doc starts with a brief summary and cross-references
+      related topics.
+- [x] First use of each acronym (API, JSON, UUID, FFI, JSR, etc.) expanded in
+      each detail doc independently.
 - [x] All inbound links to the old monolithic doc were updated:
   - `README.md` — bullet text now mentions `docs/api/`.
   - `AGENTS.md` — bullet now mentions the per-surface detail docs.
@@ -60,25 +60,23 @@ flowchart LR
   - `test/architecture/PublicAPI.ts` and
     `test/config/MCMCConfigDocumentation.ts` — header comments updated.
 - [x] `docs/README.md` index entry updated.
-- [x] Australian English spelling throughout (organisation,
-      regularisation, behaviour, optimise).
+- [x] Australian English spelling throughout (organisation, regularisation,
+      behaviour, optimise).
 - [x] `./quality.sh --lint-only` passes; no broken relative links.
 
 ## Evidence
 
-This is a documentation-only change (no UI, no behaviour change). Verified
-by:
+This is a documentation-only change (no UI, no behaviour change). Verified by:
 
-1. **`./quality.sh --lint-only` passes** — formatter and linter clean,
-   2228 files checked, no errors.
+1. **`./quality.sh --lint-only` passes** — formatter and linter clean, 2228
+   files checked, no errors.
 2. **`test/docs/DocsIndex.ts` passes** — 10/10 tests, including the
-   `docs/README.md internal links resolve` check that walks every
-   markdown link in `docs/README.md` and asserts the target exists.
-3. **`test/architecture/PublicAPI.ts` passes** — 20/20 tests, confirming
-   every exercised symbol from the docs is still a real `mod.ts` export.
+   `docs/README.md internal links resolve` check that walks every markdown link
+   in `docs/README.md` and asserts the target exists.
+3. **`test/architecture/PublicAPI.ts` passes** — 20/20 tests, confirming every
+   exercised symbol from the docs is still a real `mod.ts` export.
 4. **Manual relative-link audit** of every `[text](path)` in each
-   `docs/api/*.md` file — all targets resolve (script run during
-   review).
+   `docs/api/*.md` file — all targets resolve (script run during review).
 
 ## Test plan
 
@@ -90,10 +88,8 @@ by:
 No new tests were added because:
 
 - Link resolution is already covered by the existing
-  `test/docs/DocsIndex.ts::docs/README.md internal links resolve` test
-  (which now also walks the new `api/` link added to `docs/README.md`).
-- API export presence is already covered by
-  `test/architecture/PublicAPI.ts`.
-- The new `docs/api/*.md` files are docs-only — adding bespoke
-  per-file link tests would duplicate `quality.sh`'s formatter/linter
-  pass.
+  `test/docs/DocsIndex.ts::docs/README.md internal links resolve` test (which
+  now also walks the new `api/` link added to `docs/README.md`).
+- API export presence is already covered by `test/architecture/PublicAPI.ts`.
+- The new `docs/api/*.md` files are docs-only — adding bespoke per-file link
+  tests would duplicate `quality.sh`'s formatter/linter pass.

--- a/docs/pr-summary-2573.md
+++ b/docs/pr-summary-2573.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-Split the 1,416-line `docs/CONFIGURATION_GUIDE.md` into a 92-line topic
-index plus ten focused topic detail docs under `docs/config/`, grouped by
-configuration domain to mirror the structure of `src/config/`. Each detail
-doc documents every option (name, type, default, valid range, "what
-happens when you change it") and cross-references the performance cluster.
-Inbound links from `DISCOVERY_GUIDE.md`, `API_REFERENCE.md`, and
-`docs/README.md` were updated to point at the new structure. Closes #2573.
+Split the 1,416-line `docs/CONFIGURATION_GUIDE.md` into a 92-line topic index
+plus ten focused topic detail docs under `docs/config/`, grouped by
+configuration domain to mirror the structure of `src/config/`. Each detail doc
+documents every option (name, type, default, valid range, "what happens when you
+change it") and cross-references the performance cluster. Inbound links from
+`DISCOVERY_GUIDE.md`, `API_REFERENCE.md`, and `docs/README.md` were updated to
+point at the new structure. Closes #2573.
 
 ## Topic map
 
@@ -30,9 +30,9 @@ flowchart LR
 
 ## What changed
 
-- `docs/CONFIGURATION_GUIDE.md` — now a 92-line topic index linking to
-  every detail doc, with a Mermaid topic map and a See-also block pointing
-  at the performance cluster and discovery guide.
+- `docs/CONFIGURATION_GUIDE.md` — now a 92-line topic index linking to every
+  detail doc, with a Mermaid topic map and a See-also block pointing at the
+  performance cluster and discovery guide.
 - New `docs/config/` directory with ten topic detail docs:
   - `PRESETS.md` — `QUICK_START_PRESET`, `LARGE_NETWORK_PRESET`,
     `MEMORY_CONSTRAINED_PRESET`, `DISCOVERY_FOCUSED_PRESET`, composition.
@@ -42,15 +42,15 @@ flowchart LR
     synapses, data fuzzing, k-fold cross-validation.
   - `DISCOVERY.md` — Rust FFI discovery: sample rate, recording/analysis
     timeouts, caching, replay, debug options, min candidates per category.
-  - `MUTATION_ADAPTATION.md` — adaptive mutation thresholds, plateau
-    detection, stability adaptation, MCMC, hyperparameter evolution.
-  - `REGULARISATION.md` — weight/bias regularisation, ensemble diversity,
-    output range constraints, quantum step.
+  - `MUTATION_ADAPTATION.md` — adaptive mutation thresholds, plateau detection,
+    stability adaptation, MCMC, hyperparameter evolution.
+  - `REGULARISATION.md` — weight/bias regularisation, ensemble diversity, output
+    range constraints, quantum step.
   - `POPULATION.md` — adaptive population sizing, fine-tune population.
-  - `WORKERS.md` — thread count, worker thread cap, fast/heavy
-    partitioning, parallel evaluation.
-  - `LOGGING.md` — log cadence, log level, custom loggers, deterministic
-    seeds, and the cross-cutting validation rules.
+  - `WORKERS.md` — thread count, worker thread cap, fast/heavy partitioning,
+    parallel evaluation.
+  - `LOGGING.md` — log cadence, log level, custom loggers, deterministic seeds,
+    and the cross-cutting validation rules.
   - `RECIPES.md` — fast prototyping, production training,
     research/reproducibility, time-series, minimal complexity, max
     generalisation, self-tuning evolution.
@@ -67,26 +67,22 @@ This is a documentation-only change with no UI surface. Verification:
 - New regression suite `test/docs/ConfigurationGuideSplit.ts` (7 tests):
   - asserts the index is ≤ 300 lines (currently 92);
   - asserts every detail doc is linked from the index;
-  - asserts every detail doc exists, is substantive (>500 chars), starts
-    with a heading, and cross-references the performance cluster;
-  - asserts every relative link in the index and detail docs resolves on
-    disk;
-  - asserts `docs/README.md` continues to reference the configuration
-    guide.
+  - asserts every detail doc exists, is substantive (>500 chars), starts with a
+    heading, and cross-references the performance cluster;
+  - asserts every relative link in the index and detail docs resolves on disk;
+  - asserts `docs/README.md` continues to reference the configuration guide.
 - Existing `test/docs/DocsIndex.ts` (10 tests),
   `test/config/ConfigurationGuideDefaults.ts` (12 tests), and
   `test/config/MCMCConfigDocumentation.ts` (5 tests) all pass — the code
   defaults referenced by the documentation remain accurate.
-- `./quality.sh --lint-only` passes cleanly (formatter + linter +
-  bash-check).
+- `./quality.sh --lint-only` passes cleanly (formatter + linter + bash-check).
 
 ## Test plan
 
-- [x] `deno test --allow-read test/docs/ConfigurationGuideSplit.ts` — 7/7
-      pass.
+- [x] `deno test --allow-read test/docs/ConfigurationGuideSplit.ts` — 7/7 pass.
 - [x] `deno test --allow-read test/docs/DocsIndex.ts` — 10/10 pass.
-- [x] `deno test --allow-read test/config/ConfigurationGuideDefaults.ts` —
-      12/12 pass.
-- [x] `deno test --allow-read test/config/MCMCConfigDocumentation.ts` —
-      5/5 pass.
+- [x] `deno test --allow-read test/config/ConfigurationGuideDefaults.ts` — 12/12
+      pass.
+- [x] `deno test --allow-read test/config/MCMCConfigDocumentation.ts` — 5/5
+      pass.
 - [x] `./quality.sh --lint-only` — passes; no broken relative links.

--- a/docs/pr-summary-2575.md
+++ b/docs/pr-summary-2575.md
@@ -1,0 +1,87 @@
+# PR Summary — Issue #2575
+
+## Summary
+
+Final cleanup pass for the May 2026 documentation milestone. Refreshes the three
+specialised "fun but factual" concept docs, archives the one-off investigation
+and DeepSeek research artefacts, and adds a uniform "Up to" cross-reference
+footer so every in-scope topic doc links back to [`README.md`](../README.md) and
+[`docs/README.md`](README.md). Closes #2575.
+
+What changed:
+
+- **Specialised concepts refreshed** with a brief summary header at the top plus
+  a Mermaid diagram or chart:
+  - [`docs/CRISPR_GUIDE.md`](CRISPR_GUIDE.md) — explains CRISPR (Clustered
+    Regularly Interspaced Short Palindromic Repeats), links to Wikipedia and
+    `src/reconstruct/CRISPR.ts`, adds a flowchart of a CRISPR injection (DNA →
+    validate → upgrade → cleave → score → keep/drop).
+  - [`docs/INTELLIGENT_DESIGN.md`](INTELLIGENT_DESIGN.md) — explains Intelligent
+    Design as the systematic squash-function search, links to
+    `src/intelligentDesign/`, adds a side-by-side flowchart contrasting random
+    mutation vs Intelligent Design.
+  - [`docs/dna-sharing-bake-off-results.md`](dna-sharing-bake-off-results.md) —
+    confirms the bake-off numbers are still current (Issue #2496), adds a
+    Mermaid `xychart-beta` chart of the lift across strategies, and a follow-up
+    note pointing at #2490 for the real-evolve-step rerun.
+- **Archived** 11 one-off investigation/research artefacts under
+  `docs/archive/`:
+  - `docs/issue-2418-…investigation.md` and `docs/issue-2515-…audit.md` →
+    `docs/archive/investigations/`.
+  - All nine `docs/research/deepseek-*.md` → `docs/archive/research/`. The
+    cluster moved together so internal cross-links still resolve; the few
+    outbound links to repo source paths and to `CRISPR_GUIDE.md` were rebased by
+    one level.
+  - Each archived file received a banner explaining the move and pointing back
+    to [`docs/README.md`](README.md). The `deepseek-papers-index` catalogue
+    keeps its banner and remains exercised by `test/docs/DeepseekPapersIndex.ts`
+    (path comment updated).
+- **Cross-reference and link-health pass**:
+  - Walked all 670 relative links across the in-scope docs tree — **zero
+    broken**.
+  - Appended a small `**Up to:**` footer to every in-scope topic doc (top-level
+    `docs/*.md`, plus the detail docs under `docs/api/`, `docs/config/`,
+    `docs/troubleshooting/`) that lacked an explicit link back to `README.md`
+    and `docs/README.md`.
+- **Updated `docs/README.md`** "Out of scope" section so the archive map
+  reflects the new `archive/research/` and `archive/investigations/`
+  subdirectories and removes the standalone `research/` and `issue-*-*.md`
+  references.
+
+## Evidence
+
+Documentation-only change. `./quality.sh --lint-only` (Deno fmt, Deno lint,
+markdownlint, bash syntax) passes.
+
+```mermaid
+flowchart LR
+    Issue[#2575] --> A[Refresh<br/>specialised docs]
+    Issue --> B[Archive 11<br/>investigation +<br/>research files]
+    Issue --> C[Cross-ref &<br/>link-health pass]
+    A --> CR[CRISPR_GUIDE.md]
+    A --> ID[INTELLIGENT_DESIGN.md]
+    A --> DNA[dna-sharing-bake-off-results.md]
+    B --> Inv[archive/investigations/]
+    B --> Res[archive/research/]
+    C --> Links[670 relative links<br/>0 broken]
+    C --> Foot[Up-to footer on<br/>50 topic docs]
+```
+
+Verification commands run locally:
+
+```bash
+./quality.sh --lint-only < /dev/null   # exit 0
+# Custom Python sweep — all 670 relative links resolve, 0 broken.
+```
+
+## Test Plan
+
+- [x] `./quality.sh --lint-only` passes (Deno fmt, Deno lint, markdownlint, bash
+      syntax).
+- [x] All 670 relative links across the in-scope docs tree resolve (custom
+      sweep).
+- [x] Internal cross-links inside the moved DeepSeek cluster still resolve (the
+      cluster moved as a unit).
+- [x] `test/docs/DeepseekPapersIndex.ts` continues to point at the existing
+      catalogue (path comment updated to `docs/archive/research/…`).
+- [x] Australian English spelling spot-checked across modified files.

--- a/docs/troubleshooting/CI.md
+++ b/docs/troubleshooting/CI.md
@@ -54,3 +54,8 @@ provides diagnostic guidance. See
   when the discovery library is broken.
 - [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) — full quality-gate workflow
   for contributors.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/troubleshooting/CONFIGURATION.md
+++ b/docs/troubleshooting/CONFIGURATION.md
@@ -110,3 +110,8 @@ whether your creature topology matches the configured mode.
 - [API errors reference](../api/ERRORS.md) — programmatic error catalogue.
 - [Training troubleshooting](TRAINING.md) — when invalid config manifests as
   divergence rather than a thrown `ValidationError`.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/troubleshooting/DISCOVERY.md
+++ b/docs/troubleshooting/DISCOVERY.md
@@ -225,3 +225,8 @@ small, too noisy, or not representative of the problem domain:
 - [Discovery architecture](../DISCOVERY_ARCHITECTURE.md) for FFI internals.
 - [Memory troubleshooting](MEMORY.md) for discovery-specific memory tuning.
 - [GPU acceleration](../GPU_ACCELERATION.md) for backend selection details.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/troubleshooting/MEMORY.md
+++ b/docs/troubleshooting/MEMORY.md
@@ -202,3 +202,8 @@ Lower values reduce peak memory at the cost of more I/O.
 - [Discovery troubleshooting](DISCOVERY.md) for the discovery-side knobs.
 - [Performance tuning guide](../PERFORMANCE_TUNING.md) for end-to-end memory and
   throughput tuning.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/troubleshooting/ONNX.md
+++ b/docs/troubleshooting/ONNX.md
@@ -30,3 +30,8 @@ connections — ONNX export does not support feedback loops.
   highlighting ONNX-compatible options.
 - [Intelligent Design](../INTELLIGENT_DESIGN.md) — systematic per-neuron squash
   optimisation.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/troubleshooting/PERFORMANCE.md
+++ b/docs/troubleshooting/PERFORMANCE.md
@@ -101,3 +101,8 @@ discoveryAnalysisTimeoutMinutes: 5, // Reduce from default 10
   cache eviction under memory pressure.
 - [Performance tuning guide](../PERFORMANCE_TUNING.md) — operational tuning
   beyond the symptom-driven flow above.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/troubleshooting/TRAINING.md
+++ b/docs/troubleshooting/TRAINING.md
@@ -293,3 +293,8 @@ is a concern, reduce `folds` from the default of 5 to 3, or increase
   recovery details when NaN cascades into a panic.
 - [Configuration guide](../CONFIGURATION_GUIDE.md) for the full configuration
   surface.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/docs/troubleshooting/WASM.md
+++ b/docs/troubleshooting/WASM.md
@@ -237,3 +237,8 @@ unrecoverable crash.
 - [Memory troubleshooting](MEMORY.md) for WASM cache sizing and OOM
   (out-of-memory) recovery.
 - [Performance troubleshooting](PERFORMANCE.md) when WASM appears slow.
+
+---
+
+**Up to:** [`README.md`](../../README.md) (entry point) ·
+[`docs/README.md`](../README.md) (topic index).

--- a/test/docs/DeepseekPapersIndex.ts
+++ b/test/docs/DeepseekPapersIndex.ts
@@ -1,6 +1,7 @@
 /**
  * Issue #2584: tests verifying that the implementations referenced in the
- * "Implementation Status" section of `docs/research/deepseek-papers-index.md`
+ * "Implementation Status" section of
+ * `docs/archive/research/deepseek-papers-index.md` (archived under #2575).
  * actually exist and remain configurable.
  *
  * The catalogue in that file points readers at five landed sub-issues


### PR DESCRIPTION
# PR Summary — Issue #2575

## Summary

Final cleanup pass for the May 2026 documentation milestone. Refreshes the three
specialised "fun but factual" concept docs, archives the one-off investigation
and DeepSeek research artefacts, and adds a uniform "Up to" cross-reference
footer so every in-scope topic doc links back to [`README.md`](../README.md) and
[`docs/README.md`](README.md). Closes #2575.

What changed:

- **Specialised concepts refreshed** with a brief summary header at the top plus
  a Mermaid diagram or chart:
  - [`docs/CRISPR_GUIDE.md`](CRISPR_GUIDE.md) — explains CRISPR (Clustered
    Regularly Interspaced Short Palindromic Repeats), links to Wikipedia and
    `src/reconstruct/CRISPR.ts`, adds a flowchart of a CRISPR injection (DNA →
    validate → upgrade → cleave → score → keep/drop).
  - [`docs/INTELLIGENT_DESIGN.md`](INTELLIGENT_DESIGN.md) — explains Intelligent
    Design as the systematic squash-function search, links to
    `src/intelligentDesign/`, adds a side-by-side flowchart contrasting random
    mutation vs Intelligent Design.
  - [`docs/dna-sharing-bake-off-results.md`](dna-sharing-bake-off-results.md) —
    confirms the bake-off numbers are still current (Issue #2496), adds a
    Mermaid `xychart-beta` chart of the lift across strategies, and a follow-up
    note pointing at #2490 for the real-evolve-step rerun.
- **Archived** 11 one-off investigation/research artefacts under
  `docs/archive/`:
  - `docs/issue-2418-…investigation.md` and `docs/issue-2515-…audit.md` →
    `docs/archive/investigations/`.
  - All nine `docs/research/deepseek-*.md` → `docs/archive/research/`. The
    cluster moved together so internal cross-links still resolve; the few
    outbound links to repo source paths and to `CRISPR_GUIDE.md` were rebased by
    one level.
  - Each archived file received a banner explaining the move and pointing back
    to [`docs/README.md`](README.md). The `deepseek-papers-index` catalogue
    keeps its banner and remains exercised by `test/docs/DeepseekPapersIndex.ts`
    (path comment updated).
- **Cross-reference and link-health pass**:
  - Walked all 670 relative links across the in-scope docs tree — **zero
    broken**.
  - Appended a small `**Up to:**` footer to every in-scope topic doc (top-level
    `docs/*.md`, plus the detail docs under `docs/api/`, `docs/config/`,
    `docs/troubleshooting/`) that lacked an explicit link back to `README.md`
    and `docs/README.md`.
- **Updated `docs/README.md`** "Out of scope" section so the archive map
  reflects the new `archive/research/` and `archive/investigations/`
  subdirectories and removes the standalone `research/` and `issue-*-*.md`
  references.

## Evidence

Documentation-only change. `./quality.sh --lint-only` (Deno fmt, Deno lint,
markdownlint, bash syntax) passes.

```mermaid
flowchart LR
    Issue[#2575] --> A[Refresh<br/>specialised docs]
    Issue --> B[Archive 11<br/>investigation +<br/>research files]
    Issue --> C[Cross-ref &<br/>link-health pass]
    A --> CR[CRISPR_GUIDE.md]
    A --> ID[INTELLIGENT_DESIGN.md]
    A --> DNA[dna-sharing-bake-off-results.md]
    B --> Inv[archive/investigations/]
    B --> Res[archive/research/]
    C --> Links[670 relative links<br/>0 broken]
    C --> Foot[Up-to footer on<br/>50 topic docs]
```

Verification commands run locally:

```bash
./quality.sh --lint-only < /dev/null   # exit 0
# Custom Python sweep — all 670 relative links resolve, 0 broken.
```

## Test Plan

- [x] `./quality.sh --lint-only` passes (Deno fmt, Deno lint, markdownlint, bash
      syntax).
- [x] All 670 relative links across the in-scope docs tree resolve (custom
      sweep).
- [x] Internal cross-links inside the moved DeepSeek cluster still resolve (the
      cluster moved as a unit).
- [x] `test/docs/DeepseekPapersIndex.ts` continues to point at the existing
      catalogue (path comment updated to `docs/archive/research/…`).
- [x] Australian English spelling spot-checked across modified files.



## Milestone
This PR is part of the **Documentation May 2026** milestone and targets the `milestone/documentation-may-2026` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2575 -->