### PR TITLE
Docs: escape Liquid inside fenced code blocks (#2592)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2344.md
+++ b/docs/pr-summary-2344.md
@@ -74,7 +74,11 @@ The follow-up workflow PR (by a user/token with `workflow` scope) should:
 2. Replace the inline `hashFiles(...)` cache key in `wasm-build.yml` with the
    shared helper:
 
+   {% raw %}
+
    ```bash
    scripts/rust-ci-cache-key.sh --prefix ${{ runner.os }}-cargo-wasm
    ```
+
+   {% endraw %}
 3. Leave the WASM job scope unchanged — it is already correct.

--- a/docs/pr-summary-2590.md
+++ b/docs/pr-summary-2590.md
@@ -6,10 +6,14 @@ Fixed the GitHub Pages (Jekyll) build failure caused by literal Liquid syntax in
 two PR-summary docs, and added a regression test that scans every Markdown file
 under `docs/` for the same class of mistake. The Pages build was crashing with:
 
+{% raw %}
+
 ```
 Liquid Exception: Liquid syntax error (line 64): Tag '{% ... %}' was not
 properly terminated with regexp: /\%\}/ in pr-summary-2568.md
 ```
+
+{% endraw %}
 
 Two files contained literal Liquid sequences in prose. Inline backticks do not
 protect Liquid under Jekyll, so wrapping in a Liquid raw block (or moving the
@@ -40,18 +44,10 @@ flowchart LR
     C --> F[Page rendered OK]
 ```
 
-Regression test output (the test fails before the docs fix and passes after):
-
-```
-running 6 tests from ./test/docs/JekyllLiquidSafety.ts
-docs/**/*.md contains no unescaped Liquid syntax (#2590) ... ok (70ms)
-findLiquidOffences flags bare {% in prose ... ok (0ms)
-findLiquidOffences flags bare {{ in prose ... ok (0ms)
-findLiquidOffences ignores Liquid inside fenced code blocks ... ok (0ms)
-findLiquidOffences ignores Liquid inside {% raw %} blocks ... ok (0ms)
-findLiquidOffences supports inline {% raw %}{% endraw %} on one line ... ok (0ms)
-ok | 6 passed | 0 failed (72ms)
-```
+Regression test output: all six tests in `test/docs/JekyllLiquidSafety.ts` pass
+— the docs walker test plus five helper tests covering prose with bare Liquid,
+fenced blocks, multi-line raw regions, and inline raw/endraw pairs. The walker
+fails (with file:line) before the docs fix and goes green after.
 
 Both `./quality.sh --lint-only < /dev/null` and
 `./quality.sh --check-only

--- a/docs/pr-summary-2592.md
+++ b/docs/pr-summary-2592.md
@@ -1,0 +1,75 @@
+# PR Summary — Issue #2592
+
+## Summary
+
+Fixed the GitHub Pages (Jekyll) build failure caused by literal Liquid sequences
+inside fenced code blocks in `docs/pr-summary-2590.md`, and corrected the
+regression gate added in #2590 to scan inside fenced blocks too. Closes #2592.
+
+The original #2590 fix assumed Liquid does not parse fenced code blocks. That
+assumption is wrong: Jekyll runs Liquid on the raw source **before** kramdown
+sees the fences, so any curly-percent or curly-curly sequence inside a fence is
+still parsed as a Liquid tag. The Pages build crashed with:
+
+{% raw %}
+
+```
+Liquid Exception: Liquid syntax error (line 10): Tag '{% ... %}' was not
+properly terminated with regexp: /\%\}/ in pr-summary-2590.md
+```
+
+{% endraw %}
+
+## Changes
+
+- `test/docs/JekyllLiquidSafety.ts` — dropped the previous in-fence skip; the
+  walker now flags curly-percent and curly-curly sequences anywhere outside a
+  Liquid raw region. Updated the helper test that previously asserted fenced
+  blocks were safe to assert the corrected behaviour and renamed it accordingly.
+  Added a new helper test that proves the fix pattern (wrapping a fenced block
+  in a raw region) is safe.
+- `docs/pr-summary-2590.md` — wrapped the fenced block that quotes the Liquid
+  error message in a raw region, and replaced the second fenced test-output dump
+  (which itself contained literal raw and endraw tag text and would prematurely
+  terminate any outer raw region) with a prose summary.
+- `docs/pr-summary-2344.md` — wrapped the fenced bash block that contains a
+  GitHub Actions expression in a raw region so Liquid does not consume the
+  expression.
+
+## Evidence
+
+This is a docs + test change with no UI surface.
+
+```mermaid
+flowchart LR
+    A[Jekyll Pages build] --> B{Markdown file}
+    B -->|inside a raw region| C[Liquid skipped]
+    B -->|fenced code block, NOT in raw| D[Liquid parses tag]
+    B -->|prose, NOT in raw| D
+    D -->|malformed| E[Build fails]
+    C --> F[Page rendered OK]
+```
+
+Before the fix the walker reported four offences across two files (the first of
+which was the actual build-breaking line at `docs/pr-summary-2590.md:10`). After
+the fix the walker reports zero offences, and all seven helper tests pass —
+including the new flags-Liquid-inside-fenced-blocks test and the new test that
+covers wrapping a fenced block in a raw region.
+
+`./quality.sh --lint-only < /dev/null` and
+`./quality.sh --check-only < /dev/null` both pass.
+
+## Test Plan
+
+- Updated `test/docs/JekyllLiquidSafety.ts`:
+  - `findLiquidOffences` no longer tracks fenced blocks; only Liquid raw regions
+    suppress flagging.
+  - Renamed and rewrote the helper test that previously asserted fenced blocks
+    were safe to assert the corrected behaviour and reflect that Jekyll parses
+    fences too (#2592).
+  - Added a new helper test covering the canonical fix pattern: wrapping a
+    fenced block in a raw region.
+  - The `docs/**/*.md` walker now fails on any unwrapped Liquid in any location
+    and reports each offence as `file:line`.
+- Verified: with the docs fix reverted, the walker reports the four offences
+  described above; with the fix applied, all seven tests pass.

--- a/test/docs/JekyllLiquidSafety.ts
+++ b/test/docs/JekyllLiquidSafety.ts
@@ -1,22 +1,26 @@
 /**
- * Issue #2590 — Jekyll/Liquid safety check for Markdown files under `docs/`.
+ * Issue #2590 / #2592 — Jekyll/Liquid safety check for Markdown files
+ * under `docs/`.
  *
  * The `docs/` tree is published via GitHub Pages, which runs every Markdown
- * file through Jekyll's Liquid templating engine. Any literal `{% ... %}` or
- * `{{ ... }}` outside a fenced code block — including inside inline code
- * spans (single backticks) — is parsed as Liquid and breaks the Pages build:
+ * file through Jekyll's Liquid templating engine. Liquid parses the **raw
+ * source** before kramdown converts it to HTML, so any literal
+ * `{% ... %}` or `{{ ... }}` sequence — *including inside fenced code
+ * blocks (triple backticks) and inline code spans* — is parsed as a Liquid
+ * tag and breaks the Pages build:
  *
- *   Liquid Exception: Liquid syntax error (line 64): Tag '{% ... %}' was
- *   not properly terminated with regexp: /\%\}/ in pr-summary-2568.md
+ *   Liquid Exception: Liquid syntax error (line 10): Tag '{% ... %}' was
+ *   not properly terminated with regexp: /\%\}/ in pr-summary-2590.md
  *
- * This test scans every Markdown file under `docs/` and asserts that any
- * Liquid-looking sequence is either:
- *   1. inside a fenced code block (``` ... ```), or
- *   2. inside a `{% raw %} ... {% endraw %}` region.
+ * Issue #2590 originally assumed fenced code blocks protected Liquid
+ * syntax. They do not — Liquid runs on the source before Markdown sees
+ * the fences. Issue #2592 corrects that assumption: this test now scans
+ * the entire file, regardless of fences, and only treats text inside a
+ * `{% raw %} ... {% endraw %}` region as safe.
  *
- * The check is "what" tested: it walks real files and reports the offending
- * file plus line so a recurrence is fixed in seconds rather than discovered
- * by a failing Pages deploy.
+ * The check is "what" tested: it walks real files and reports the
+ * offending file plus line so a recurrence is fixed in seconds rather
+ * than discovered by a failing Pages deploy.
  */
 
 import { assertEquals } from "@std/assert";
@@ -35,30 +39,22 @@ interface Offence {
 /**
  * Scan a single Markdown source for unescaped Liquid syntax.
  *
- * Tracks two pieces of nesting state:
- *   - `inFence`  — true while we are inside a triple-backtick fenced block.
- *   - `inRaw`    — true while we are inside a `{% raw %} ... {% endraw %}`
- *                  region.
+ * Tracks one piece of nesting state:
+ *   - `inRaw` — true while we are inside a `{% raw %} ... {% endraw %}`
+ *               region. This is the only construct that protects Liquid
+ *               syntax under Jekyll. Fenced code blocks do **not** protect
+ *               Liquid: Liquid runs on the raw source before kramdown
+ *               processes the fences.
  *
- * Liquid is only flagged when both flags are false.
+ * Liquid sequences (`{%` or `{{`) are flagged whenever `inRaw` is false.
  */
 export function findLiquidOffences(source: string): Offence[] {
   const offences: Offence[] = [];
   const lines = source.split("\n");
-  let inFence = false;
   let inRaw = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const trimmed = line.trimStart();
-
-    // Toggle fenced code block state on lines that open/close with ```.
-    if (trimmed.startsWith("```")) {
-      inFence = !inFence;
-      continue;
-    }
-
-    if (inFence) continue;
 
     // Walk the line and update inRaw / record offences.
     let j = 0;
@@ -95,7 +91,7 @@ export function findLiquidOffences(source: string): Offence[] {
   return offences;
 }
 
-Deno.test("docs/**/*.md contains no unescaped Liquid syntax (#2590)", async () => {
+Deno.test("docs/**/*.md contains no unescaped Liquid syntax (#2590, #2592)", async () => {
   const offences: Offence[] = [];
 
   for await (
@@ -121,7 +117,8 @@ Deno.test("docs/**/*.md contains no unescaped Liquid syntax (#2590)", async () =
     throw new Error(
       `Found ${offences.length} unescaped Liquid {% ... %} / {{ ... }} ` +
         `sequence(s) in docs/. Wrap each in {% raw %} ... {% endraw %} so ` +
-        `the GitHub Pages (Jekyll) build does not parse them as tags:\n` +
+        `the GitHub Pages (Jekyll) build does not parse them as tags. ` +
+        `Note: fenced code blocks do NOT protect Liquid — wrap them too:\n` +
         detail,
     );
   }
@@ -142,7 +139,12 @@ Deno.test("findLiquidOffences flags bare {{ in prose", () => {
   assertEquals(offences.length, 1);
 });
 
-Deno.test("findLiquidOffences ignores Liquid inside fenced code blocks", () => {
+Deno.test("findLiquidOffences flags Liquid inside fenced code blocks (Jekyll parses fences) (#2592)", () => {
+  // Pre-#2592 this test asserted offences.length === 0 on the assumption
+  // that fenced code blocks protected Liquid syntax. Issue #2592 proved
+  // that assumption wrong — Jekyll's Liquid parser runs on the raw source
+  // before kramdown sees the fence, so `{% if foo %}` inside ``` is still
+  // parsed as a tag and crashes the Pages build.
   const src = [
     "Some prose.",
     "",
@@ -155,7 +157,11 @@ Deno.test("findLiquidOffences ignores Liquid inside fenced code blocks", () => {
     "",
   ].join("\n");
   const offences = findLiquidOffences(src);
-  assertEquals(offences.length, 0);
+  // Two offences: the `{{` in `${{ runner.os }}` on line 4, and the first
+  // `{%` on line 5. The walker records one offence per line and breaks.
+  assertEquals(offences.length, 2);
+  assertEquals(offences[0].line, 4);
+  assertEquals(offences[1].line, 5);
 });
 
 Deno.test("findLiquidOffences ignores Liquid inside {% raw %} blocks", () => {
@@ -165,6 +171,25 @@ Deno.test("findLiquidOffences ignores Liquid inside {% raw %} blocks", () => {
     "literal `{% if foo %}` and `{{ x }}` here",
     "{% endraw %}",
     "More text.",
+    "",
+  ].join("\n");
+  const offences = findLiquidOffences(src);
+  assertEquals(offences.length, 0);
+});
+
+Deno.test("findLiquidOffences ignores Liquid inside {% raw %} wrapping a fenced block (#2592)", () => {
+  // Canonical fix pattern for fenced blocks that contain literal Liquid
+  // sequences: wrap the entire fence in raw/endraw so Liquid skips it.
+  const src = [
+    "Prose.",
+    "",
+    "{% raw %}",
+    "```",
+    "Tag '{% ... %}' was not properly terminated",
+    "```",
+    "{% endraw %}",
+    "",
+    "More prose.",
     "",
   ].join("\n");
   const offences = findLiquidOffences(src);


### PR DESCRIPTION
# PR Summary — Issue #2592

## Summary

Fixed the GitHub Pages (Jekyll) build failure caused by literal Liquid sequences
inside fenced code blocks in `docs/pr-summary-2590.md`, and corrected the
regression gate added in #2590 to scan inside fenced blocks too. Closes #2592.

The original #2590 fix assumed Liquid does not parse fenced code blocks. That
assumption is wrong: Jekyll runs Liquid on the raw source **before** kramdown
sees the fences, so any curly-percent or curly-curly sequence inside a fence is
still parsed as a Liquid tag. The Pages build crashed with:

{% raw %}

```
Liquid Exception: Liquid syntax error (line 10): Tag '{% ... %}' was not
properly terminated with regexp: /\%\}/ in pr-summary-2590.md
```

{% endraw %}

## Changes

- `test/docs/JekyllLiquidSafety.ts` — dropped the previous in-fence skip; the
  walker now flags curly-percent and curly-curly sequences anywhere outside a
  Liquid raw region. Updated the helper test that previously asserted fenced
  blocks were safe to assert the corrected behaviour and renamed it accordingly.
  Added a new helper test that proves the fix pattern (wrapping a fenced block
  in a raw region) is safe.
- `docs/pr-summary-2590.md` — wrapped the fenced block that quotes the Liquid
  error message in a raw region, and replaced the second fenced test-output dump
  (which itself contained literal raw and endraw tag text and would prematurely
  terminate any outer raw region) with a prose summary.
- `docs/pr-summary-2344.md` — wrapped the fenced bash block that contains a
  GitHub Actions expression in a raw region so Liquid does not consume the
  expression.

## Evidence

This is a docs + test change with no UI surface.

```mermaid
flowchart LR
    A[Jekyll Pages build] --> B{Markdown file}
    B -->|inside a raw region| C[Liquid skipped]
    B -->|fenced code block, NOT in raw| D[Liquid parses tag]
    B -->|prose, NOT in raw| D
    D -->|malformed| E[Build fails]
    C --> F[Page rendered OK]
```

Before the fix the walker reported four offences across two files (the first of
which was the actual build-breaking line at `docs/pr-summary-2590.md:10`). After
the fix the walker reports zero offences, and all seven helper tests pass —
including the new flags-Liquid-inside-fenced-blocks test and the new test that
covers wrapping a fenced block in a raw region.

`./quality.sh --lint-only < /dev/null` and
`./quality.sh --check-only < /dev/null` both pass.

## Test Plan

- Updated `test/docs/JekyllLiquidSafety.ts`:
  - `findLiquidOffences` no longer tracks fenced blocks; only Liquid raw regions
    suppress flagging.
  - Renamed and rewrote the helper test that previously asserted fenced blocks
    were safe to assert the corrected behaviour and reflect that Jekyll parses
    fences too (#2592).
  - Added a new helper test covering the canonical fix pattern: wrapping a
    fenced block in a raw region.
  - The `docs/**/*.md` walker now fails on any unwrapped Liquid in any location
    and reports each offence as `file:line`.
- Verified: with the docs fix reverted, the walker reports the four offences
  described above; with the fix applied, all seven tests pass.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2592 -->