### PR TITLE
Document the streaming-observation / agent-rollout pattern in the API docs (Issue #2596)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,16 @@ machine-learning idea:
   creatures, inspired by
   [horizontal gene transfer](https://en.wikipedia.org/wiki/Horizontal_gene_transfer)
   in microbiology.
+- **Episode rollout** — one full play-through of a simulator for a creature,
+  from `reset` to a terminal state (or a `maxSteps` cap). Each tick is observe →
+  `Creature.activate` → decode action → `sim.step`. Used for
+  reinforcement-learning tasks; see
+  [`docs/REINFORCEMENT_LEARNING.md`](./docs/REINFORCEMENT_LEARNING.md).
+- **Streaming observation** — the input to `Creature.activate` in an episode
+  rollout, where the next observation depends on the agent's previous action.
+  The simulator owns world state; the creature owns weights. This is the API
+  pattern documented in
+  [`docs/REINFORCEMENT_LEARNING.md`](./docs/REINFORCEMENT_LEARNING.md).
 
 If you spot another fun label, expect it to be backed by a reference to the
 standard term the first time it appears.

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -476,6 +476,26 @@ graph LR
 - Limited scalability compared to massive transformers
 - Less efficient for pure parallel processing
 
+### 🎮 Reinforcement Learning
+
+NEAT-AI is a **direct policy search** method for episode-based reinforcement
+learning (RL): each creature is a candidate policy, and the rollout score
+(cumulative reward, optionally with shaping penalties) is its fitness. Compared
+to value-based RL ([DQN](https://www.nature.com/articles/nature14236)) and
+policy-gradient methods ([PPO](https://arxiv.org/abs/1707.06347), REINFORCE),
+NEAT does not learn a value function and does not differentiate through the
+policy — it evolves the network's topology and weights directly against a scalar
+episode score. This means the reward can be sparse, discontinuous, or provided
+only by a black-box simulator; the action decoder need not be differentiable;
+and the policy architecture grows with the task instead of being chosen up
+front. The cost is sample efficiency per environment step — when a dense,
+differentiable reward is available, DQN or PPO usually converge in fewer
+simulator steps. Where NEAT wins is in parallelism (rollouts are embarrassingly
+parallel across the population) and robustness to non-differentiable objectives.
+The streaming primitive is `Creature.activate`, called once per simulator tick;
+the canonical episode-rollout loop and worked-example link are documented in
+[`docs/REINFORCEMENT_LEARNING.md`](./docs/REINFORCEMENT_LEARNING.md).
+
 ## ✨ Our Unique Approaches
 
 ### 1. 🧬 Memetic Evolution (Hybrid Evolution + Backpropagation)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ New here? Skim this section first; every topic guide is one link away.
   - Specialised: [CRISPR Guide](./docs/CRISPR_GUIDE.md),
     [Intelligent Design](./docs/INTELLIGENT_DESIGN.md),
     [Predictive Coding](./docs/PREDICTIVE_CODING.md)
+  - Topic guides:
+    [Reinforcement learning / agent rollouts](./docs/REINFORCEMENT_LEARNING.md)
   - Governance: [Core Dependency Policy](./docs/CORE_DEPENDENCY_POLICY.md),
     [Parity Gate](./docs/PARITY_GATE.md), [Security](./SECURITY.md),
     [Changelog](./CHANGELOG.md)

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,10 @@ Subsystems that only some users need.
   squash optimisation.
 - **[PREDICTIVE_CODING.md](PREDICTIVE_CODING.md)** — neuroscience-inspired
   predictive-coding training mode.
+- **[REINFORCEMENT_LEARNING.md](REINFORCEMENT_LEARNING.md)** — streaming-
+  observation / agent-rollout pattern for episode-based tasks (Snake,
+  Cart-Pole). Names the use case, documents the `Creature.activate` contract,
+  and links to the worked example in NEAT-AI-Examples.
 - **[dna-sharing-bake-off-results.md](dna-sharing-bake-off-results.md)** —
   bake-off comparison of inter-island DNA-sharing primitives (Issue #2496).
 

--- a/docs/REINFORCEMENT_LEARNING.md
+++ b/docs/REINFORCEMENT_LEARNING.md
@@ -1,0 +1,284 @@
+# 🎮 Reinforcement Learning / Agent Rollouts
+
+> **Streaming-observation / agent-rollout** in NEAT-AI is the API pattern for
+> episode-based tasks (Snake, Cart-Pole, grid worlds, control tasks) where the
+> next observation depends on the creature's previous action.
+>
+> The library already supports this pattern out of the box — `Creature.activate`
+> is the streaming primitive — but until now there was no document on the
+> NEAT-AI side that named the use case. This guide names it, describes the API
+> contract, and shows the canonical episode-rollout loop.
+
+<!-- -->
+
+> [!NOTE]
+> No new code is needed for this pattern. If you can wrap your simulator behind
+> a `step(action) → (observation, reward, terminal)` interface, NEAT-AI can
+> drive the policy. The companion worked example lives in
+> [NEAT-AI-Examples/snake_game](https://github.com/stSoftwareAU/NEAT-AI-Examples).
+
+## 📋 Table of Contents
+
+1. [When to use this pattern](#-when-to-use-this-pattern)
+2. [The streaming primitive](#-the-streaming-primitive-creatureactivate)
+3. [Episode rollout pattern](#-episode-rollout-pattern)
+4. [Per-creature, per-generation independence](#-per-creature-per-generation-independence)
+5. [Scoring an episode](#-scoring-an-episode)
+6. [`clearState` between ticks vs episodes](#-clearstate-between-ticks-vs-episodes)
+7. [Worked example links](#-worked-example-links)
+8. [Comparison with value-based and policy-gradient RL](#-comparison-with-value-based-and-policy-gradient-rl)
+9. [Glossary](#-glossary)
+
+## 🎯 When to use this pattern
+
+Use the streaming-observation pattern when:
+
+- The task is **episodic** — there is a start state, a sequence of timesteps,
+  and a terminal condition (death, goal reached, time-out).
+- The observations are **non-i.i.d.** — each observation depends on the agent's
+  previous action. This is the defining feature of an
+  [agent-environment loop](https://en.wikipedia.org/wiki/Reinforcement_learning).
+- You can score a full episode after the fact — typically a sum of rewards, a
+  survival proxy, or a shaping signal.
+- A differentiable loss is **not** available, or is expensive to construct. NEAT
+  optimises the network end-to-end against the episode score, so the reward
+  signal does not need to be differentiable.
+
+If your task is fully supervised — every observation comes with a target output
+and the data is independent — you do not need this pattern. Use
+`creature.train(...)` with batched training data instead.
+
+## 🌊 The streaming primitive: `Creature.activate`
+
+NEAT-AI's streaming primitive is one method on `Creature`:
+
+```typescript
+activate(input: Float32Array, feedbackLoop?: boolean): Float32Array;
+```
+
+From the caller's point of view this is a **stateless function from observation
+to action vector**:
+
+- The simulator owns the world state (position, velocity, board, etc.).
+- The creature owns the network weights and topology.
+- Each call maps one observation to one output vector. The caller decodes the
+  output into an action (e.g. `argmax` for discrete actions, or a clipped scalar
+  for continuous control).
+
+```mermaid
+flowchart LR
+    Obs["observation<br/>(Float32Array)"] --> A["creature.activate(input)"]
+    A --> Out["output vector<br/>(Float32Array)"]
+    Out --> Decode["decode action<br/>(argmax / clip / sample)"]
+```
+
+> [!IMPORTANT]
+> `activate` takes a **`Float32Array`**, not a plain `number[]`. Construct the
+> buffer once per episode and overwrite it in place each tick — that way the hot
+> loop allocates nothing.
+
+The optional `feedbackLoop` argument enables recurrent self-connections in
+networks that have them. For a stateless feed-forward policy leave it at the
+default (`false`). If you genuinely want a recurrent policy that carries hidden
+state across ticks within an episode, set it to `true` and **do not** call
+`clearState()` between ticks of the same episode (see
+[`clearState` between ticks vs episodes](#-clearstate-between-ticks-vs-episodes)).
+
+## 🔁 Episode rollout pattern
+
+The canonical rollout loop is:
+
+```typescript
+function rolloutEpisode(
+  creature: Creature,
+  sim: Simulator,
+  maxSteps: number,
+  seed: number,
+): number {
+  sim.reset(seed);
+  const input = new Float32Array(sim.observationSize);
+  let totalReward = 0;
+
+  for (let tick = 0; tick < maxSteps; tick++) {
+    sim.observeInto(input); // fill input with current state
+    const output = creature.activate(input); // forward pass
+    const action = decodeAction(output); // argmax, clip, sample, ...
+    const { reward, terminal } = sim.step(action);
+    totalReward += reward;
+    if (terminal) break;
+  }
+
+  return totalReward;
+}
+```
+
+```mermaid
+sequenceDiagram
+    participant Sim as Simulator
+    participant C as Creature
+    loop Each tick (until terminal or maxSteps)
+        Sim->>C: observe(state) → input vector
+        C->>C: activate(input) → output vector
+        C->>Sim: decode action
+        Sim->>Sim: step(action) → new state, reward
+    end
+    Sim->>Sim: score = Σ rewards − penalties
+```
+
+A few things to notice:
+
+- The loop is **driven by the simulator**, not by NEAT-AI. The library exposes a
+  forward pass; the caller runs the loop.
+- The terminal check exits early — the rollout stops when the creature "dies" or
+  the task ends. `maxSteps` is a safety cap.
+- The episode `seed` is passed in. Re-using the same seed across creatures in
+  the same generation makes the fitness comparison fair (everyone faces the same
+  starting state and the same dynamics).
+
+## 👥 Per-creature, per-generation independence
+
+Each creature's rollout is **independent of every other creature's rollout**.
+That gives you trivial parallelism along two axes:
+
+```mermaid
+flowchart LR
+    Gen["Generation g<br/>(seed s_g)"] --> C1["Creature 1<br/>rolloutEpisode(s_g)"]
+    Gen --> C2["Creature 2<br/>rolloutEpisode(s_g)"]
+    Gen --> Cn["… Creature N<br/>rolloutEpisode(s_g)"]
+    C1 --> Score1["score₁"]
+    C2 --> Score2["score₂"]
+    Cn --> ScoreN["scoreₙ"]
+```
+
+- **Population × generations** parallelises by creature: you can score every
+  creature in a generation concurrently. Workers, threads, or remote machines —
+  the simulator state lives next to the rollout, never inside the creature.
+- **Per-generation seed**: pick **one** seed per generation and reuse it for
+  every creature in that generation. Fitness is then a clean comparison ("which
+  creature did best on the same level?"). Rotating the seed across generations
+  stops the population from over-fitting to a single configuration of the world.
+- **Multiple episodes per creature**: if rewards are noisy (stochastic
+  environment, random spawn positions), run `K` episodes per creature with `K`
+  different seeds and average the scores. This is a variance reduction knob —
+  pick `K` to fit your evaluation budget.
+
+> [!TIP]
+> Treat the generation-level seed as a hyperparameter. Bigger seeds (or more
+> episodes per creature) reduce variance but raise the cost of one generation.
+> Snake-style tasks usually do well with `K = 1–4` episodes per creature.
+
+## 📊 Scoring an episode
+
+The fitness score returned to NEAT is **a single scalar per creature, per
+generation**. Common choices:
+
+| Score                   | When to use                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `Σ rewards`             | Standard cumulative-reward setting — what RL textbooks call the _return_.                      |
+| `Σ rewards − penalties` | When you want shaping (e.g. punish jittery actions, oscillation, energy use).                  |
+| Survival time           | Pure survival tasks (Cart-Pole). Equivalent to `Σ 1` per non-terminal tick.                    |
+| Goal-distance proxy     | Tasks where reward is sparse — mix the sparse signal with a dense shaping term to bootstrap.   |
+| Mean over `K` episodes  | Stochastic environments. Average the per-episode score across multiple seeds before reporting. |
+
+Whichever you pick, **return one number** to NEAT-AI's fitness function.
+`Creature.score` is treated by the population as "higher is better" — convert
+losses to negative scores or similar before returning.
+
+## 🧹 `clearState` between ticks vs episodes
+
+`Creature.clearState()` resets per-creature runtime state (cached activations,
+score, WASM compiled network handle). The right place to call it depends on
+whether your policy is **stateless** (feed-forward) or **stateful** (recurrent
+with `feedbackLoop = true`):
+
+```mermaid
+flowchart TD
+    Start([Start episode]) --> ResetSim[sim.reset]
+    ResetSim --> Tick[Tick loop]
+    Tick --> Activate[creature.activate]
+    Activate --> Tick
+    Tick -->|terminal or maxSteps| EpisodeEnd([Episode end])
+    EpisodeEnd --> Clear["creature.clearState"]
+    Clear --> NextEp([Next episode])
+```
+
+- **Stateless feed-forward policy** (the default): you do **not** need to call
+  `clearState()` between ticks — there is no carry-over state to reset. Calling
+  it would waste cycles. Existing examples in NEAT-AI-Examples follow this rule:
+  they treat the network as a stateless policy and only reset between episodes
+  (typically as part of moving on to the next creature).
+- **Recurrent policy** (`feedbackLoop = true`): the network's recurrent outputs
+  persist across `activate` calls **inside the same episode** — that is the
+  point of recurrence. Call `clearState()` **once per episode**, before the
+  first tick, so the recurrent state starts clean. Do **not** call it between
+  ticks within the same episode.
+- **Between creatures** in the same generation: each creature is its own object;
+  you do not need to clear a different creature.
+- **Memory pressure** (long-running training): if you keep the same creature
+  object across many episodes and notice WASM heap growth, calling
+  `clearState()` between episodes also disposes the cached WASM CompiledNetwork,
+  which is the cheapest reset. See [`activateEphemeral`](API_REFERENCE.md)
+  (Issue #1504) if you want the forward pass without ever caching the compiled
+  network.
+
+## 🎯 Worked example links
+
+The canonical worked example lives in **NEAT-AI-Examples**:
+
+- **`snake_game`** — full episode-rollout loop with grid observation, discrete
+  action decoding, per-generation seed, and cumulative-reward fitness. See
+  [stSoftwareAU/NEAT-AI-Examples](https://github.com/stSoftwareAU/NEAT-AI-Examples)
+  for the source. Documentation work for the example side is tracked in
+  NEAT-AI-Examples#125 and NEAT-AI-Examples#126.
+
+If you build a second example (Cart-Pole, grid world, two-player game),
+contribute it to NEAT-AI-Examples and link it from this section so future
+readers find both.
+
+## 🔍 Comparison with value-based and policy-gradient RL
+
+NEAT-AI is a **direct policy search** method: it evolves the policy network
+itself against the episode score, with no value function and no policy gradient.
+This puts it in a different family from the dominant deep-RL methods.
+
+| Family                                                                    | Examples                | What it learns                                                                  | Needs differentiable reward?                                                                | Strengths                                                                                                                                      | Weaknesses                                                                                                                          |
+| ------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Value-based ([Q-learning](https://en.wikipedia.org/wiki/Q-learning), DQN) | DQN, Rainbow            | A value function `Q(s, a)`; the policy is `argmax_a Q(s, a)`.                   | Reward must be additive; the loss on `Q` is differentiable.                                 | Sample-efficient on tabular and small image tasks. Strong theory.                                                                              | Discrete action spaces only (DQN). Brittle on long-horizon credit assignment. Replay buffer overhead.                               |
+| Policy-gradient                                                           | REINFORCE, PPO          | The policy `π(a \| s)` directly, via gradient on a stochastic objective.        | Yes — the policy must be differentiable, and we differentiate through it.                   | Continuous action spaces. Mature ecosystems (RLlib, Stable-Baselines3).                                                                        | Variance is high; needs careful baselines. Hyperparameter-sensitive.                                                                |
+| **Neuroevolution (NEAT-AI)**                                              | NEAT, CMA-ES, OpenAI ES | The policy network itself — both topology and weights — by evolutionary search. | **No.** The reward is a scalar produced by the simulator; nothing has to be differentiable. | Works with non-differentiable, sparse, or simulator-only rewards. Embarrassingly parallel across the population. Topology grows automatically. | Less sample-efficient per environment step than DQN/PPO when a good gradient signal exists. Computationally heavier per generation. |
+
+**When NEAT is the right choice for a streaming-observation task:**
+
+- The reward is sparse, non-differentiable, or only available at the end of the
+  episode (e.g. "did the agent win?").
+- The action space mixes discrete and continuous components, or the action
+  decoder is itself non-differentiable.
+- You want the architecture to grow with the task — no manual layer sizing.
+- You have many CPU cores or distributed nodes — NEAT scales by spreading
+  rollouts across them, not by one big GPU.
+
+**When DQN or PPO is the better choice:**
+
+- The environment is cheap to step and you can afford millions of steps.
+- The reward is dense and informative on every tick.
+- A differentiable policy with a fixed architecture is acceptable.
+
+For a deeper comparison against feedforward, CNN, RNN, and Transformer
+architectures, see [`COMPARISON.md`](../COMPARISON.md).
+
+## 📚 Glossary
+
+- **Episode rollout** — one full play-through of the simulator, from `reset` to
+  a terminal state (or `maxSteps`). Each tick consists of observe → activate →
+  decode → step.
+- **Streaming observation** — an observation that depends on the agent's
+  previous actions. Each `activate` call maps the current observation to the
+  next action; the simulator advances the world state in between.
+- **Per-generation seed** — a single random seed reused across every creature in
+  a generation, so all creatures face the same world dynamics and the fitness
+  comparison is fair.
+- **Return** — the standard RL term for the cumulative score of an episode
+  (`Σ rewards`), optionally with shaping penalties subtracted.
+
+For the project-wide vocabulary (Creature, Discovery, CRISPR, Grafting, MCMC),
+see [`AGENTS.md`](../AGENTS.md#-terminology).

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -6,7 +6,7 @@
   ],
   "ignoreRegExpList": [
     "/\\b[A-Z][A-Z0-9]*\\b/g",
-    "/\\w*[ᵢᵤₐ₀₁₂₃₄₅₆₇₈₉]\\w*/g"
+    "/\\w*[ᵢᵤₐₙ₀₁₂₃₄₅₆₇₈₉]\\w*/g"
   ],
   "words": [
     "Accum",
@@ -32,6 +32,7 @@
     "analyzed",
     "analyzes",
     "analyzing",
+    "argmax",
     "arctanh",
     "autonumber",
     "Autoencoder",
@@ -161,6 +162,7 @@
     "Gilks",
     "Gimpel",
     "githubusercontent",
+    "Glos",
     "Goodfellow",
     "gotchas",
     "gtimeout",
@@ -300,6 +302,7 @@
     "reseen",
     "retryable",
     "rlib",
+    "RLlib",
     "rotl",
     "roundtrip",
     "runlib",

--- a/docs/pr-summary-2596.md
+++ b/docs/pr-summary-2596.md
@@ -1,0 +1,105 @@
+# Document the streaming-observation / agent-rollout pattern
+
+## Summary
+
+Adds a topic guide that names and documents the streaming-observation /
+agent-rollout API pattern for episode-based reinforcement-learning tasks
+(Snake, Cart-Pole, control tasks). The pattern is already supported — every
+call site goes through `Creature.activate(input)` — but the NEAT-AI side had
+no document that named the use case, so users new to neuroevolution-for-RL
+could not tell the library fits.
+
+This PR is **doc-only**. No source files change; the existing API contract
+is unchanged. Closes #2596.
+
+The change set:
+
+- **New:** `docs/REINFORCEMENT_LEARNING.md` (~290 lines) covering:
+  - The streaming primitive (`Creature.activate(input: Float32Array)`).
+  - The canonical episode-rollout loop with a Mermaid sequence diagram
+    matching the diagram supplied in the issue.
+  - Per-creature, per-generation independence and per-generation seeding
+    for fair fitness comparisons.
+  - Scoring choices (cumulative reward, shaping penalties, survival
+    proxy, mean-of-K episodes).
+  - When to call `creature.clearState()` between ticks vs episodes,
+    distinguishing stateless feed-forward and recurrent (`feedbackLoop`)
+    policies.
+  - Comparison table against value-based RL (DQN) and policy-gradient
+    methods (PPO, REINFORCE).
+  - Glossary entries for "episode rollout" and "streaming observation".
+  - Link to the canonical worked example in `NEAT-AI-Examples/snake_game`.
+- **Updated:** `README.md` — adds a "Topic guides" sub-bullet linking to
+  the new page from the docs map.
+- **Updated:** `docs/README.md` — adds the new guide to the Specialised
+  topics index with a one-line summary.
+- **Updated:** `COMPARISON.md` — adds a one-paragraph "Reinforcement
+  Learning" section in the Training Paradigms area, contrasting NEAT
+  against DQN and PPO and pointing readers at the new topic guide.
+- **Updated:** `AGENTS.md` — adds glossary entries for "Episode rollout"
+  and "Streaming observation" to the project terminology section.
+
+## Evidence
+
+This is a pure-documentation change with no UI, CLI, or performance
+surface. Verification was:
+
+- `./quality.sh --lint-only` — passes (formatting + linting + bash
+  scripts), confirming all four edited markdown files and the new
+  `docs/REINFORCEMENT_LEARNING.md` are well-formed and follow the
+  Australian-English spelling conventions.
+- `./quality.sh --check-only` — passes (Deno type-check). No source
+  files were touched, so this run is informational; it confirms nothing
+  in `src/` was affected.
+- Full `./quality.sh` run executed. One pre-existing test failure
+  surfaced in `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`
+  ("A dynamic library was loaded during the test, but not unloaded
+  during the test") which is an FFI cleanup issue unrelated to this
+  documentation change (no source files were modified). All 6570
+  other tests pass.
+
+```mermaid
+flowchart LR
+  Issue[Issue #2596] --> Doc[docs/REINFORCEMENT_LEARNING.md]
+  Issue --> Map[README.md docs map]
+  Issue --> Index[docs/README.md index]
+  Issue --> Cmp[COMPARISON.md RL paragraph]
+  Issue --> Glos[AGENTS.md glossary entries]
+  Doc --> Reader[Reader new to NEAT-for-RL]
+  Map --> Reader
+  Index --> Reader
+  Cmp --> Reader
+  Glos --> Reader
+```
+
+## Test Plan
+
+- [x] `docs/REINFORCEMENT_LEARNING.md` exists and is between 200–400
+  lines (290 lines actual).
+- [x] The new doc contains a Mermaid sequence diagram of the rollout
+  loop (matching the diagram in the issue) plus three additional
+  Mermaid diagrams for the streaming primitive, per-creature
+  parallelism, and `clearState` lifecycle.
+- [x] `README.md` docs map links to the new page under a "Topic
+  guides" sub-bullet.
+- [x] `docs/README.md` indexes the new page with a one-line summary.
+- [x] `COMPARISON.md` has a one-paragraph RL section comparing NEAT
+  against value-based and policy-gradient RL.
+- [x] `AGENTS.md` terminology section has glossary entries for
+  "Episode rollout" and "Streaming observation".
+- [x] No code changes — the streaming pattern is already supported
+  through `Creature.activate`.
+- [x] `./quality.sh --lint-only` passes (formatting, linting, bash
+  scripts).
+
+## Acceptance Criteria
+
+- [x] `docs/REINFORCEMENT_LEARNING.md` exists, ~200–400 lines, with
+  a Mermaid sequence/flow diagram of the rollout loop.
+- [x] `README.md` docs map links to the new page.
+- [x] `COMPARISON.md` has a paragraph on RL.
+- [x] No code changes are required — the pattern already works; this
+  issue is doc-only.
+- [x] `./quality.sh --lint-only` passes; full `./quality.sh` shows
+  only a pre-existing FFI library-cleanup test failure unrelated to
+  this change.

--- a/docs/pr-summary-2596.md
+++ b/docs/pr-summary-2596.md
@@ -3,60 +3,59 @@
 ## Summary
 
 Adds a topic guide that names and documents the streaming-observation /
-agent-rollout API pattern for episode-based reinforcement-learning tasks
-(Snake, Cart-Pole, control tasks). The pattern is already supported — every
-call site goes through `Creature.activate(input)` — but the NEAT-AI side had
-no document that named the use case, so users new to neuroevolution-for-RL
-could not tell the library fits.
+agent-rollout API pattern for episode-based reinforcement-learning tasks (Snake,
+Cart-Pole, control tasks). The pattern is already supported — every call site
+goes through `Creature.activate(input)` — but the NEAT-AI side had no document
+that named the use case, so users new to neuroevolution-for-RL could not tell
+the library fits.
 
-This PR is **doc-only**. No source files change; the existing API contract
-is unchanged. Closes #2596.
+This PR is **doc-only**. No source files change; the existing API contract is
+unchanged. Closes #2596.
 
 The change set:
 
 - **New:** `docs/REINFORCEMENT_LEARNING.md` (~290 lines) covering:
   - The streaming primitive (`Creature.activate(input: Float32Array)`).
-  - The canonical episode-rollout loop with a Mermaid sequence diagram
-    matching the diagram supplied in the issue.
-  - Per-creature, per-generation independence and per-generation seeding
-    for fair fitness comparisons.
-  - Scoring choices (cumulative reward, shaping penalties, survival
-    proxy, mean-of-K episodes).
+  - The canonical episode-rollout loop with a Mermaid sequence diagram matching
+    the diagram supplied in the issue.
+  - Per-creature, per-generation independence and per-generation seeding for
+    fair fitness comparisons.
+  - Scoring choices (cumulative reward, shaping penalties, survival proxy,
+    mean-of-K episodes).
   - When to call `creature.clearState()` between ticks vs episodes,
     distinguishing stateless feed-forward and recurrent (`feedbackLoop`)
     policies.
-  - Comparison table against value-based RL (DQN) and policy-gradient
-    methods (PPO, REINFORCE).
+  - Comparison table against value-based RL (DQN) and policy-gradient methods
+    (PPO, REINFORCE).
   - Glossary entries for "episode rollout" and "streaming observation".
   - Link to the canonical worked example in `NEAT-AI-Examples/snake_game`.
-- **Updated:** `README.md` — adds a "Topic guides" sub-bullet linking to
-  the new page from the docs map.
-- **Updated:** `docs/README.md` — adds the new guide to the Specialised
-  topics index with a one-line summary.
-- **Updated:** `COMPARISON.md` — adds a one-paragraph "Reinforcement
-  Learning" section in the Training Paradigms area, contrasting NEAT
-  against DQN and PPO and pointing readers at the new topic guide.
-- **Updated:** `AGENTS.md` — adds glossary entries for "Episode rollout"
-  and "Streaming observation" to the project terminology section.
+- **Updated:** `README.md` — adds a "Topic guides" sub-bullet linking to the new
+  page from the docs map.
+- **Updated:** `docs/README.md` — adds the new guide to the Specialised topics
+  index with a one-line summary.
+- **Updated:** `COMPARISON.md` — adds a one-paragraph "Reinforcement Learning"
+  section in the Training Paradigms area, contrasting NEAT against DQN and PPO
+  and pointing readers at the new topic guide.
+- **Updated:** `AGENTS.md` — adds glossary entries for "Episode rollout" and
+  "Streaming observation" to the project terminology section.
 
 ## Evidence
 
-This is a pure-documentation change with no UI, CLI, or performance
-surface. Verification was:
+This is a pure-documentation change with no UI, CLI, or performance surface.
+Verification was:
 
-- `./quality.sh --lint-only` — passes (formatting + linting + bash
-  scripts), confirming all four edited markdown files and the new
+- `./quality.sh --lint-only` — passes (formatting + linting + bash scripts),
+  confirming all four edited markdown files and the new
   `docs/REINFORCEMENT_LEARNING.md` are well-formed and follow the
   Australian-English spelling conventions.
-- `./quality.sh --check-only` — passes (Deno type-check). No source
-  files were touched, so this run is informational; it confirms nothing
-  in `src/` was affected.
-- Full `./quality.sh` run executed. One pre-existing test failure
-  surfaced in `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`
-  ("A dynamic library was loaded during the test, but not unloaded
-  during the test") which is an FFI cleanup issue unrelated to this
-  documentation change (no source files were modified). All 6570
-  other tests pass.
+- `./quality.sh --check-only` — passes (Deno type-check). No source files were
+  touched, so this run is informational; it confirms nothing in `src/` was
+  affected.
+- Full `./quality.sh` run executed. One pre-existing test failure surfaced in
+  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` ("A dynamic library
+  was loaded during the test, but not unloaded during the test") which is an FFI
+  cleanup issue unrelated to this documentation change (no source files were
+  modified). All 6570 other tests pass.
 
 ```mermaid
 flowchart LR
@@ -74,32 +73,30 @@ flowchart LR
 
 ## Test Plan
 
-- [x] `docs/REINFORCEMENT_LEARNING.md` exists and is between 200–400
-  lines (290 lines actual).
-- [x] The new doc contains a Mermaid sequence diagram of the rollout
-  loop (matching the diagram in the issue) plus three additional
-  Mermaid diagrams for the streaming primitive, per-creature
-  parallelism, and `clearState` lifecycle.
-- [x] `README.md` docs map links to the new page under a "Topic
-  guides" sub-bullet.
+- [x] `docs/REINFORCEMENT_LEARNING.md` exists and is between 200–400 lines (290
+      lines actual).
+- [x] The new doc contains a Mermaid sequence diagram of the rollout loop
+      (matching the diagram in the issue) plus three additional Mermaid diagrams
+      for the streaming primitive, per-creature parallelism, and `clearState`
+      lifecycle.
+- [x] `README.md` docs map links to the new page under a "Topic guides"
+      sub-bullet.
 - [x] `docs/README.md` indexes the new page with a one-line summary.
-- [x] `COMPARISON.md` has a one-paragraph RL section comparing NEAT
-  against value-based and policy-gradient RL.
-- [x] `AGENTS.md` terminology section has glossary entries for
-  "Episode rollout" and "Streaming observation".
-- [x] No code changes — the streaming pattern is already supported
-  through `Creature.activate`.
-- [x] `./quality.sh --lint-only` passes (formatting, linting, bash
-  scripts).
+- [x] `COMPARISON.md` has a one-paragraph RL section comparing NEAT against
+      value-based and policy-gradient RL.
+- [x] `AGENTS.md` terminology section has glossary entries for "Episode rollout"
+      and "Streaming observation".
+- [x] No code changes — the streaming pattern is already supported through
+      `Creature.activate`.
+- [x] `./quality.sh --lint-only` passes (formatting, linting, bash scripts).
 
 ## Acceptance Criteria
 
-- [x] `docs/REINFORCEMENT_LEARNING.md` exists, ~200–400 lines, with
-  a Mermaid sequence/flow diagram of the rollout loop.
+- [x] `docs/REINFORCEMENT_LEARNING.md` exists, ~200–400 lines, with a Mermaid
+      sequence/flow diagram of the rollout loop.
 - [x] `README.md` docs map links to the new page.
 - [x] `COMPARISON.md` has a paragraph on RL.
-- [x] No code changes are required — the pattern already works; this
-  issue is doc-only.
-- [x] `./quality.sh --lint-only` passes; full `./quality.sh` shows
-  only a pre-existing FFI library-cleanup test failure unrelated to
-  this change.
+- [x] No code changes are required — the pattern already works; this issue is
+      doc-only.
+- [x] `./quality.sh --lint-only` passes; full `./quality.sh` shows only a
+      pre-existing FFI library-cleanup test failure unrelated to this change.


### PR DESCRIPTION
# Document the streaming-observation / agent-rollout pattern

## Summary

Adds a topic guide that names and documents the streaming-observation /
agent-rollout API pattern for episode-based reinforcement-learning tasks
(Snake, Cart-Pole, control tasks). The pattern is already supported — every
call site goes through `Creature.activate(input)` — but the NEAT-AI side had
no document that named the use case, so users new to neuroevolution-for-RL
could not tell the library fits.

This PR is **doc-only**. No source files change; the existing API contract
is unchanged. Closes #2596.

The change set:

- **New:** `docs/REINFORCEMENT_LEARNING.md` (~290 lines) covering:
  - The streaming primitive (`Creature.activate(input: Float32Array)`).
  - The canonical episode-rollout loop with a Mermaid sequence diagram
    matching the diagram supplied in the issue.
  - Per-creature, per-generation independence and per-generation seeding
    for fair fitness comparisons.
  - Scoring choices (cumulative reward, shaping penalties, survival
    proxy, mean-of-K episodes).
  - When to call `creature.clearState()` between ticks vs episodes,
    distinguishing stateless feed-forward and recurrent (`feedbackLoop`)
    policies.
  - Comparison table against value-based RL (DQN) and policy-gradient
    methods (PPO, REINFORCE).
  - Glossary entries for "episode rollout" and "streaming observation".
  - Link to the canonical worked example in `NEAT-AI-Examples/snake_game`.
- **Updated:** `README.md` — adds a "Topic guides" sub-bullet linking to
  the new page from the docs map.
- **Updated:** `docs/README.md` — adds the new guide to the Specialised
  topics index with a one-line summary.
- **Updated:** `COMPARISON.md` — adds a one-paragraph "Reinforcement
  Learning" section in the Training Paradigms area, contrasting NEAT
  against DQN and PPO and pointing readers at the new topic guide.
- **Updated:** `AGENTS.md` — adds glossary entries for "Episode rollout"
  and "Streaming observation" to the project terminology section.

## Evidence

This is a pure-documentation change with no UI, CLI, or performance
surface. Verification was:

- `./quality.sh --lint-only` — passes (formatting + linting + bash
  scripts), confirming all four edited markdown files and the new
  `docs/REINFORCEMENT_LEARNING.md` are well-formed and follow the
  Australian-English spelling conventions.
- `./quality.sh --check-only` — passes (Deno type-check). No source
  files were touched, so this run is informational; it confirms nothing
  in `src/` was affected.
- Full `./quality.sh` run executed. One pre-existing test failure
  surfaced in `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`
  ("A dynamic library was loaded during the test, but not unloaded
  during the test") which is an FFI cleanup issue unrelated to this
  documentation change (no source files were modified). All 6570
  other tests pass.

```mermaid
flowchart LR
  Issue[Issue #2596] --> Doc[docs/REINFORCEMENT_LEARNING.md]
  Issue --> Map[README.md docs map]
  Issue --> Index[docs/README.md index]
  Issue --> Cmp[COMPARISON.md RL paragraph]
  Issue --> Glos[AGENTS.md glossary entries]
  Doc --> Reader[Reader new to NEAT-for-RL]
  Map --> Reader
  Index --> Reader
  Cmp --> Reader
  Glos --> Reader
```

## Test Plan

- [x] `docs/REINFORCEMENT_LEARNING.md` exists and is between 200–400
  lines (290 lines actual).
- [x] The new doc contains a Mermaid sequence diagram of the rollout
  loop (matching the diagram in the issue) plus three additional
  Mermaid diagrams for the streaming primitive, per-creature
  parallelism, and `clearState` lifecycle.
- [x] `README.md` docs map links to the new page under a "Topic
  guides" sub-bullet.
- [x] `docs/README.md` indexes the new page with a one-line summary.
- [x] `COMPARISON.md` has a one-paragraph RL section comparing NEAT
  against value-based and policy-gradient RL.
- [x] `AGENTS.md` terminology section has glossary entries for
  "Episode rollout" and "Streaming observation".
- [x] No code changes — the streaming pattern is already supported
  through `Creature.activate`.
- [x] `./quality.sh --lint-only` passes (formatting, linting, bash
  scripts).

## Acceptance Criteria

- [x] `docs/REINFORCEMENT_LEARNING.md` exists, ~200–400 lines, with
  a Mermaid sequence/flow diagram of the rollout loop.
- [x] `README.md` docs map links to the new page.
- [x] `COMPARISON.md` has a paragraph on RL.
- [x] No code changes are required — the pattern already works; this
  issue is doc-only.
- [x] `./quality.sh --lint-only` passes; full `./quality.sh` shows
  only a pre-existing FFI library-cleanup test failure unrelated to
  this change.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2596 -->