### PR TITLE
Docs: add NEAT vs NEAT-AI terminology section to AGENTS.md (#2599)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,19 @@ For deep dives on a single topic, follow the dedicated docs (full index in
 We keep the tone playful, but every nickname maps to a mainstream
 machine-learning idea:
 
+- **NEAT** — the original **NeuroEvolution of Augmenting Topologies** algorithm
+  published by
+  [Stanley & Miikkulainen (2002)](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf).
+  Use this term **only** when discussing the algorithm as defined in that paper
+  (speciation by historical markings, structure-mutation crossover, and so on).
+  Synonyms acceptable for emphasis: "standard NEAT", "pure NEAT", "the 2002 NEAT
+  algorithm".
+- **NEAT-AI** — **this project**. Started from pure NEAT but extends it well
+  beyond the 2002 algorithm with memetic evolution, error-guided **Discovery**,
+  MCMC mutation acceptance, synthetic synapses, predictive coding, Muon-style
+  orthogonalised gradients, and other modern algorithms (some published only
+  weeks before this entry was written). Use this term for **all** references to
+  features, behaviour, or APIs in this repository.
 - **Creatures** are individual neural networks/genomes inside a NEAT population,
   as described in the original NEAT paper by
   [Stanley & Miikkulainen (2002)](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf).
@@ -97,6 +110,28 @@ machine-learning idea:
 
 If you spot another fun label, expect it to be backed by a reference to the
 standard term the first time it appears.
+
+### 🆚 NEAT vs NEAT-AI — which term to use
+
+Because the project has extended far past the 2002 algorithm, mixing the two
+terms in docs and code comments has been a source of confusion. Use this rule of
+thumb:
+
+- ✅ Say **NEAT-AI** when discussing what **this repo** does — features,
+  behaviour, configuration, APIs, defaults, and roadmap.
+- ✅ Say **NEAT** (or "standard NEAT", "pure NEAT", "the 2002 NEAT algorithm")
+  **only** when contrasting with the original Stanley & Miikkulainen algorithm —
+  for example, "standard NEAT speciates by historical markings; NEAT-AI also
+  accepts mutations via an MCMC criterion".
+- ❌ Avoid using bare **NEAT** as shorthand for the implementation in
+  user-facing docs. If you mean "this codebase", write **NEAT-AI**.
+- 🧩 Inside historical-context paragraphs (e.g. the project's origin story or
+  the `src/NEAT/` folder name), bare "NEAT" is acceptable because the meaning is
+  clear from context, but prefer **NEAT-AI** when describing current behaviour.
+
+When a single sentence mentions both, name them explicitly to make the
+distinction unambiguous (e.g. "NEAT-AI inherits speciation from standard NEAT
+but replaces unconditional mutation acceptance with MCMC").
 
 ## 🏗️ Project Architecture
 

--- a/docs/pr-summary-2599.md
+++ b/docs/pr-summary-2599.md
@@ -1,0 +1,55 @@
+## Summary
+
+Established a canonical distinction between **NEAT** (the standard 2002
+algorithm by Stanley & Miikkulainen) and **NEAT-AI** (this project) in
+`AGENTS.md`, so the rest of the documentation can reference it consistently.
+Closes #2599.
+
+Two new entries were added to the existing **Terminology** section:
+
+- **NEAT** — the original NeuroEvolution of Augmenting Topologies algorithm
+  from the 2002 paper. Reserved for discussions of that algorithm only.
+- **NEAT-AI** — this project. Started from pure NEAT but now extends it with
+  memetic evolution, error-guided Discovery, MCMC mutation acceptance,
+  synthetic synapses, predictive coding, Muon-style orthogonalised gradients,
+  and other modern algorithms.
+
+A new **🆚 NEAT vs NEAT-AI — which term to use** subsection codifies the
+rule of thumb so contributors know which term belongs where:
+
+- Say **NEAT-AI** for anything the repo does.
+- Say **NEAT** (or "standard NEAT" / "pure NEAT") only when contrasting with
+  the 2002 algorithm.
+- Avoid bare "NEAT" as shorthand for the implementation in user-facing docs.
+
+This is foundational and unblocks the other sub-issues under #2598 — they
+can now reference this glossary entry instead of redefining the distinction
+in each file.
+
+## Evidence
+
+Documentation-only change (no code, no UI, no benchmarks). Verified with:
+
+- `npx markdownlint-cli2 AGENTS.md` → 0 errors.
+- `./quality.sh --lint-only` → all four steps pass (deno fmt, deno lint,
+  bash check). `deno fmt` rewrapped a few lines in the new section.
+- Manual inspection: links resolve to the same Stanley & Miikkulainen PDF
+  already cited elsewhere in the file.
+
+```mermaid
+flowchart LR
+    A[AGENTS.md Terminology] --> B[NEAT entry<br/>2002 algorithm]
+    A --> C[NEAT-AI entry<br/>this project]
+    B --> D[NEAT vs NEAT-AI<br/>rule of thumb]
+    C --> D
+    D --> E[Sub-issues under #2598<br/>reference this glossary]
+```
+
+## Test Plan
+
+- [x] `AGENTS.md` Terminology section contains entries for both **NEAT** and
+      **NEAT-AI** with the distinction described in the issue.
+- [x] Includes a contributor rule of thumb on which term to use where.
+- [x] Markdown renders cleanly (markdownlint-cli2 reports zero errors;
+      no broken links).
+- [x] `./quality.sh --lint-only` passes (formatting, linting, bash check).


### PR DESCRIPTION
## Summary

Established a canonical distinction between **NEAT** (the standard 2002
algorithm by Stanley & Miikkulainen) and **NEAT-AI** (this project) in
`AGENTS.md`, so the rest of the documentation can reference it consistently.
Closes #2599.

Two new entries were added to the existing **Terminology** section:

- **NEAT** — the original NeuroEvolution of Augmenting Topologies algorithm
  from the 2002 paper. Reserved for discussions of that algorithm only.
- **NEAT-AI** — this project. Started from pure NEAT but now extends it with
  memetic evolution, error-guided Discovery, MCMC mutation acceptance,
  synthetic synapses, predictive coding, Muon-style orthogonalised gradients,
  and other modern algorithms.

A new **🆚 NEAT vs NEAT-AI — which term to use** subsection codifies the
rule of thumb so contributors know which term belongs where:

- Say **NEAT-AI** for anything the repo does.
- Say **NEAT** (or "standard NEAT" / "pure NEAT") only when contrasting with
  the 2002 algorithm.
- Avoid bare "NEAT" as shorthand for the implementation in user-facing docs.

This is foundational and unblocks the other sub-issues under #2598 — they
can now reference this glossary entry instead of redefining the distinction
in each file.

## Evidence

Documentation-only change (no code, no UI, no benchmarks). Verified with:

- `npx markdownlint-cli2 AGENTS.md` → 0 errors.
- `./quality.sh --lint-only` → all four steps pass (deno fmt, deno lint,
  bash check). `deno fmt` rewrapped a few lines in the new section.
- Manual inspection: links resolve to the same Stanley & Miikkulainen PDF
  already cited elsewhere in the file.

```mermaid
flowchart LR
    A[AGENTS.md Terminology] --> B[NEAT entry<br/>2002 algorithm]
    A --> C[NEAT-AI entry<br/>this project]
    B --> D[NEAT vs NEAT-AI<br/>rule of thumb]
    C --> D
    D --> E[Sub-issues under #2598<br/>reference this glossary]
```

## Test Plan

- [x] `AGENTS.md` Terminology section contains entries for both **NEAT** and
      **NEAT-AI** with the distinction described in the issue.
- [x] Includes a contributor rule of thumb on which term to use where.
- [x] Markdown renders cleanly (markdownlint-cli2 reports zero errors;
      no broken links).
- [x] `./quality.sh --lint-only` passes (formatting, linting, bash check).



## Milestone
This PR is part of the **Ours vs standard NEAT** milestone and targets the `milestone/ours-vs-standard-neat` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2599 -->