### PR TITLE
Docs: clarify NEAT vs NEAT-AI in root and docs READMEs (#2601)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
-# 🧬 NEAT Neural Network for DenoJS
+# 🧬 NEAT-AI Neural Network for DenoJS
 
 <p align="left">
   <img width="100" height="100" src="docs/logo.png" align="right" alt="NEAT-AI logo">
-This project is a practical implementation of a neural network based on the NEAT (NeuroEvolution of Augmenting Topologies) algorithm, written in DenoJS using TypeScript, with additional features such as error-guided discovery, memetic evolution, and distributed workflows.
+<strong>NEAT-AI</strong> started from <strong>NEAT</strong> — the
+NeuroEvolution of Augmenting Topologies algorithm published by
+<a href="http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf">Stanley &amp; Miikkulainen (2002)</a>
+— and has grown into a hybrid evolutionary plus gradient-based system, written
+in DenoJS using TypeScript. NEAT-AI keeps the speciation and structure-mutation
+ideas from standard NEAT but layers on much more recent research: memetic
+evolution, error-guided <strong>Discovery</strong>, Markov Chain Monte Carlo
+(MCMC) mutation acceptance, synthetic synapses, predictive coding, Muon-style
+orthogonalised gradients, and other algorithms (some published only weeks
+before this paragraph was written).
 </p>
+
+> [!IMPORTANT]
+> **NEAT** refers to the original 2002 algorithm. **NEAT-AI** refers to this
+> project — they are no longer the same thing. See the
+> [NEAT vs NEAT-AI terminology rule in AGENTS.md](./AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> for the convention used throughout this repository.
 
 For project terminology, coding conventions, and development guidelines, see
 [AGENTS.md](./AGENTS.md).
@@ -18,8 +33,8 @@ New here? Skim this section first; every topic guide is one link away.
   how to bump the pinned NEAT-AI-core revision.
 - **[AGENTS.md](./AGENTS.md)** — terminology and coding conventions for human
   and AI contributors.
-- **[COMPARISON.md](./COMPARISON.md)** — how NEAT compares to other AI
-  approaches.
+- **[COMPARISON.md](./COMPARISON.md)** — how NEAT-AI compares to other AI
+  approaches (and to standard NEAT).
 - **Topic guides** — quick jumps to the most-used docs:
   - Compute / WebAssembly (WASM):
     [Activation Functions](./docs/ACTIVATION_FUNCTIONS.md),
@@ -45,10 +60,10 @@ New here? Skim this section first; every topic guide is one link away.
 
 ## 🏗️ High-level architecture
 
-A creature is a NEAT genome that mutates and breeds in TypeScript, then runs its
-forward pass inside a vendored WebAssembly (WASM) module. When the optional Rust
-extension is present, error-guided structural proposals come back over a Foreign
-Function Interface (FFI) call.
+A creature is a NEAT-AI genome that mutates and breeds in TypeScript, then runs
+its forward pass inside a vendored WebAssembly (WASM) module. When the optional
+Rust extension is present, error-guided structural proposals come back over a
+Foreign Function Interface (FFI) call.
 
 ```mermaid
 flowchart LR
@@ -66,6 +81,11 @@ See [docs/DISCOVERY_ARCHITECTURE.md](./docs/DISCOVERY_ARCHITECTURE.md) for the
 full pipeline.
 
 ## ✨ Feature Highlights
+
+The list below describes **NEAT-AI** behaviour. Many entries — memetic
+evolution, error-guided Discovery, MCMC mutation acceptance, synthetic synapses,
+ONNX export — are extensions beyond the standard NEAT algorithm. See
+[COMPARISON.md](./COMPARISON.md) for the side-by-side picture.
 
 1. **Extendable Observations**: Input and output features are identified by
    stable UUIDs in the exported representation, rather than only by positional
@@ -246,8 +266,8 @@ For detailed documentation, see the [docs/](./docs/) directory:
 
 ### 🧠 Core Concepts
 
-- **[COMPARISON.md](./COMPARISON.md)**: How NEAT compares to traditional neural
-  networks, CNNs, RNNs, and modern LLMs
+- **[COMPARISON.md](./COMPARISON.md)**: How NEAT-AI compares to standard NEAT,
+  traditional neural networks, CNNs, RNNs, and modern LLMs
 - **[Discovery Guide](./docs/DISCOVERY_GUIDE.md)**: Complete guide to
   distributed, multi-machine discovery workflows, including failure/success
   caches, replay, candidate category limits, focus overrides, and the

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,18 @@
 Welcome to the NEAT-AI documentation. This page is the topic-by-topic table of
 contents — every long-form guide in the repository has a home here.
 
+> [!IMPORTANT]
+> **NEAT-AI ≠ NEAT.** NEAT-AI started from the original NeuroEvolution of
+> Augmenting Topologies algorithm
+> ([Stanley & Miikkulainen 2002](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf))
+> but extends it with memetic evolution, error-guided Discovery, MCMC mutation
+> acceptance, synthetic synapses, predictive coding, Muon-style orthogonalised
+> gradients, and other modern algorithms. When this documentation describes what
+> **this repository** does, it says **NEAT-AI**. When it discusses the 2002
+> algorithm itself, it says **NEAT** (or "standard NEAT", "pure NEAT"). The
+> [NEAT vs NEAT-AI rule in AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> is the canonical entry.
+
 If you have not used NEAT-AI before, follow the **Where to start** reading path
 below; it walks from a zero-knowledge introduction through to the topic guides
 you are most likely to need next.
@@ -15,7 +27,10 @@ A new reader should follow the docs in this order:
    NEAT-AI is, the major features, and gives a working example.
 2. **[../AGENTS.md](../AGENTS.md)** — terminology and coding conventions. Read
    this if any of the playful names (Creature, Discovery, CRISPR, Grafting,
-   MCMC) are unfamiliar.
+   MCMC) are unfamiliar. In particular, see the
+   [**NEAT** and **NEAT-AI** terminology entries](../AGENTS.md#-terminology) and
+   the [NEAT vs NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+   for the convention used throughout this repository.
 3. **[../CONTRIBUTING.md](../CONTRIBUTING.md)** — development setup, how to run
    the quality gate, and how to bump the pinned NEAT-AI-core dependency.
 4. **This page (`docs/README.md`)** — pick a topic guide below for the feature
@@ -135,10 +150,10 @@ Project-level policies, audits, and release plumbing.
 
 ## 🔍 Comparison with other approaches
 
-- **[../COMPARISON.md](../COMPARISON.md)** — how NEAT compares to traditional
-  neural networks, CNNs (Convolutional Neural Networks), RNNs (Recurrent Neural
-  Networks), and modern LLMs (Large Language Models). Owned by Issue #2563 and
-  excluded from the index refresh.
+- **[../COMPARISON.md](../COMPARISON.md)** — how NEAT-AI compares to standard
+  NEAT, traditional neural networks, CNNs (Convolutional Neural Networks), RNNs
+  (Recurrent Neural Networks), and modern LLMs (Large Language Models). Owned by
+  Issue #2563 and excluded from the index refresh.
 
 ## 🚫 Out of scope for this index
 

--- a/docs/pr-summary-2601.md
+++ b/docs/pr-summary-2601.md
@@ -1,0 +1,89 @@
+## Summary
+
+Updated the two highest-traffic landing pages — root [`README.md`](../README.md)
+and [`docs/README.md`](./README.md) — so first-time readers immediately
+understand that **NEAT-AI** extends well beyond the standard **NEAT** algorithm.
+The new framing uses the **NEAT** vs **NEAT-AI** distinction codified in
+[`AGENTS.md`](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) (Issue #2599).
+Closes #2601.
+
+## What changed
+
+### Root `README.md`
+
+- Renamed the heading from "🧬 NEAT Neural Network for DenoJS" to "🧬
+  **NEAT-AI** Neural Network for DenoJS".
+- Replaced the opening paragraph. The new paragraph names **NEAT-AI** as this
+  project, points to the original 2002 NEAT paper for the algorithm it grew
+  from, and lists the modern extensions (memetic evolution, Discovery, MCMC,
+  synthetic synapses, predictive coding, Muon-style orthogonalised gradients).
+- Added an `[!IMPORTANT]` callout linking to the
+  [NEAT vs NEAT-AI rule in AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+  so the distinction is visible from the very first screen.
+- Added a one-line preamble to **Feature Highlights** clarifying that the list
+  describes NEAT-AI behaviour and that several entries are extensions beyond
+  standard NEAT, with a pointer to `COMPARISON.md`.
+- Updated the **High-level architecture** sentence to refer to a "NEAT-AI
+  genome" (was "NEAT genome").
+- Updated the docs map and Core Concepts entries for `COMPARISON.md` to read
+  "how NEAT-AI compares…" instead of "how NEAT compares…", with an explicit
+  mention of standard NEAT.
+
+### `docs/README.md`
+
+- Added an `[!IMPORTANT]` framing callout at the top spelling out the NEAT ≠
+  NEAT-AI distinction and linking to the canonical entry in `AGENTS.md`.
+- Extended step 2 of the **Where to start** reading path to call out the
+  [terminology entries](../AGENTS.md#-terminology) and the
+  [NEAT vs NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) in
+  `AGENTS.md`, so newcomers see the distinction early.
+- Updated the COMPARISON entry to "how NEAT-AI compares to standard NEAT,
+  traditional neural networks, CNNs, RNNs, and modern LLMs".
+
+## Acceptance Criteria
+
+- [x] Opening paragraph of root `README.md` makes the NEAT vs NEAT-AI
+      distinction explicit on first use.
+- [x] Feature Highlights consistently use **NEAT-AI** when describing the
+      project's behaviour (added a framing preamble; the existing entries
+      already used NEAT-AI when referring to the project).
+- [x] `docs/README.md` references the AGENTS.md terminology entries as part of
+      the reading path.
+- [x] Internal links and Mermaid diagrams still render (no diagram or link
+      targets were touched).
+- [x] Markdownlint and `./quality.sh` pass for the doc changes (`deno fmt`,
+      `deno lint`, `deno check`, bash check all pass).
+
+## Evidence
+
+This change is purely documentation prose. There is no UI surface and no
+performance-affecting code path. The evidence is the diff itself plus the
+quality gate output:
+
+- `./quality.sh --lint-only < /dev/null` → all four steps pass (deps update,
+  fmt, lint, bash check).
+- `./quality.sh < /dev/null` → 6569 tests pass; the 2 failing tests
+  (`DiscoveryTimeout.ts: DiscoverDirectory returns partial results on timeout`
+  and `Timeout during file reading returns partial data`) are **pre-existing FFI
+  dynamic-library leak detector failures** on the
+  `milestone/ours-vs-standard-neat` base branch and are unrelated to this
+  doc-only change. Verified by stashing my edits and re-running — the same two
+  tests still fail on a clean base branch checkout.
+
+## Test Plan
+
+- Existing markdownlint / `deno fmt` checks via `quality.sh` cover prose
+  formatting.
+- No new code paths were introduced, so no new unit tests are required.
+- Reviewed the rendered Markdown locally: the `[!IMPORTANT]` callouts, the
+  Mermaid `flowchart LR` block, the docs map, and all internal anchors render
+  cleanly.
+
+## Notes
+
+- Issue #2600 (COMPARISON.md rework) is still open. The acceptance criteria for
+  #2601 say the docs map blurb for `COMPARISON.md` should reflect its new
+  framing "once #2600 lands". This PR makes a minimal, forward-compatible update
+  — the blurb now describes COMPARISON as "how NEAT-AI compares to standard NEAT
+  and other approaches" — which is consistent with the direction in #2600 and
+  does not need to be revisited when #2600 merges.


### PR DESCRIPTION
## Summary

Updated the two highest-traffic landing pages — root [`README.md`](../README.md)
and [`docs/README.md`](./README.md) — so first-time readers immediately
understand that **NEAT-AI** extends well beyond the standard **NEAT** algorithm.
The new framing uses the **NEAT** vs **NEAT-AI** distinction codified in
[`AGENTS.md`](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) (Issue #2599).
Closes #2601.

## What changed

### Root `README.md`

- Renamed the heading from "🧬 NEAT Neural Network for DenoJS" to "🧬
  **NEAT-AI** Neural Network for DenoJS".
- Replaced the opening paragraph. The new paragraph names **NEAT-AI** as this
  project, points to the original 2002 NEAT paper for the algorithm it grew
  from, and lists the modern extensions (memetic evolution, Discovery, MCMC,
  synthetic synapses, predictive coding, Muon-style orthogonalised gradients).
- Added an `[!IMPORTANT]` callout linking to the
  [NEAT vs NEAT-AI rule in AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
  so the distinction is visible from the very first screen.
- Added a one-line preamble to **Feature Highlights** clarifying that the list
  describes NEAT-AI behaviour and that several entries are extensions beyond
  standard NEAT, with a pointer to `COMPARISON.md`.
- Updated the **High-level architecture** sentence to refer to a "NEAT-AI
  genome" (was "NEAT genome").
- Updated the docs map and Core Concepts entries for `COMPARISON.md` to read
  "how NEAT-AI compares…" instead of "how NEAT compares…", with an explicit
  mention of standard NEAT.

### `docs/README.md`

- Added an `[!IMPORTANT]` framing callout at the top spelling out the NEAT ≠
  NEAT-AI distinction and linking to the canonical entry in `AGENTS.md`.
- Extended step 2 of the **Where to start** reading path to call out the
  [terminology entries](../AGENTS.md#-terminology) and the
  [NEAT vs NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) in
  `AGENTS.md`, so newcomers see the distinction early.
- Updated the COMPARISON entry to "how NEAT-AI compares to standard NEAT,
  traditional neural networks, CNNs, RNNs, and modern LLMs".

## Acceptance Criteria

- [x] Opening paragraph of root `README.md` makes the NEAT vs NEAT-AI
      distinction explicit on first use.
- [x] Feature Highlights consistently use **NEAT-AI** when describing the
      project's behaviour (added a framing preamble; the existing entries
      already used NEAT-AI when referring to the project).
- [x] `docs/README.md` references the AGENTS.md terminology entries as part of
      the reading path.
- [x] Internal links and Mermaid diagrams still render (no diagram or link
      targets were touched).
- [x] Markdownlint and `./quality.sh` pass for the doc changes (`deno fmt`,
      `deno lint`, `deno check`, bash check all pass).

## Evidence

This change is purely documentation prose. There is no UI surface and no
performance-affecting code path. The evidence is the diff itself plus the
quality gate output:

- `./quality.sh --lint-only < /dev/null` → all four steps pass (deps update,
  fmt, lint, bash check).
- `./quality.sh < /dev/null` → 6569 tests pass; the 2 failing tests
  (`DiscoveryTimeout.ts: DiscoverDirectory returns partial results on timeout`
  and `Timeout during file reading returns partial data`) are **pre-existing FFI
  dynamic-library leak detector failures** on the
  `milestone/ours-vs-standard-neat` base branch and are unrelated to this
  doc-only change. Verified by stashing my edits and re-running — the same two
  tests still fail on a clean base branch checkout.

## Test Plan

- Existing markdownlint / `deno fmt` checks via `quality.sh` cover prose
  formatting.
- No new code paths were introduced, so no new unit tests are required.
- Reviewed the rendered Markdown locally: the `[!IMPORTANT]` callouts, the
  Mermaid `flowchart LR` block, the docs map, and all internal anchors render
  cleanly.

## Notes

- Issue #2600 (COMPARISON.md rework) is still open. The acceptance criteria for
  #2601 say the docs map blurb for `COMPARISON.md` should reflect its new
  framing "once #2600 lands". This PR makes a minimal, forward-compatible update
  — the blurb now describes COMPARISON as "how NEAT-AI compares to standard NEAT
  and other approaches" — which is consistent with the direction in #2600 and
  does not need to be revisited when #2600 merges.



## Milestone
This PR is part of the **Ours vs standard NEAT** milestone and targets the `milestone/ours-vs-standard-neat` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2601 -->