### PR TITLE
Docs: sweep remaining guides for NEAT vs NEAT-AI clarity (Issue #2602)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,15 @@
 # 🤝 Contributing to NEAT-AI
 
-Thank you for your interest in contributing to NEAT-AI (NeuroEvolution of
-Augmenting Topologies — Artificial Intelligence)! This guide covers everything
-you need to get started — from setting up your development environment to
-submitting a pull request.
+Thank you for your interest in contributing to
+[NEAT-AI](./AGENTS.md#-terminology) (NeuroEvolution of Augmenting Topologies —
+Artificial Intelligence)! This guide covers everything you need to get started —
+from setting up your development environment to submitting a pull request.
+
+> [!IMPORTANT]
+> **NEAT** refers to the original 2002 algorithm; **NEAT-AI** refers to this
+> project, which extends it. See the
+> [NEAT vs NEAT-AI rule](./AGENTS.md#-neat-vs-neat-ai--which-term-to-use) for
+> the convention used throughout this repository.
 
 ## 📌 Summary and where to go next
 
@@ -508,7 +514,7 @@ src/                    # Source code
   intelligentDesign/    # Intelligent Design squash optimisation
   methods/              # Activation functions (squash implementations)
   mutate/               # Mutation operators
-  NEAT/                 # Core NEAT algorithm
+  NEAT/                 # Core NEAT-AI evolutionary loop (selection, speciation)
   propagate/            # Backpropagation
   wasm/                 # WASM activation bridge
 test/                   # Tests (mirrors src/ structure)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## 📌 Summary
 
-This document describes how to **report a vulnerability** in NEAT-AI
-(NeuroEvolution of Augmenting Topologies — Artificial Intelligence) and what
-response you can expect. Routine code-review hygiene (input validation,
-parameterised queries, secret handling) is enforced via the **`/security-review`
-Claude Code skill** that contributors run before opening a PR (see the
-secure-coding principles section of [`AGENTS.md`](./AGENTS.md)) and the in-repo
-automation listed below:
+This document describes how to **report a vulnerability** in
+[NEAT-AI](./AGENTS.md#-terminology) (NeuroEvolution of Augmenting Topologies —
+Artificial Intelligence) and what response you can expect. Routine code-review
+hygiene (input validation, parameterised queries, secret handling) is enforced
+via the **`/security-review` Claude Code skill** that contributors run before
+opening a PR (see the secure-coding principles section of
+[`AGENTS.md`](./AGENTS.md)) and the in-repo automation listed below:
 
 - **Dependency review** — every PR is scanned by
   [`actions/dependency-review-action`](https://github.com/actions/dependency-review-action)

--- a/docs/ACTIVATION_FUNCTIONS.md
+++ b/docs/ACTIVATION_FUNCTIONS.md
@@ -1,13 +1,13 @@
 # ⚡ Activation Functions Guide
 
-> **TL;DR** — A **squash** function (NEAT-AI's name for an activation function)
-> is the small per-neuron non-linearity that turns a neuron's pre-activation sum
-> `v = b + Σ(wᵢ·aᵢ)` into its output. NEAT-AI ships 32 standard squashes, 3
-> aggregate functions, and 3 deprecated squashes kept only for backward
-> compatibility — every name in the tables below resolves to a real export under
-> [`src/methods/activations/`](../src/methods/activations/) (or
-> [`src/deprecated/`](../src/deprecated/) for the deprecated set). This guide
-> explains how to pick one. Acronyms used here: **ReLU** (Rectified Linear
+> **TL;DR** — A **squash** function ([NEAT-AI](../AGENTS.md#-terminology)'s name
+> for an activation function) is the small per-neuron non-linearity that turns a
+> neuron's pre-activation sum `v = b + Σ(wᵢ·aᵢ)` into its output. NEAT-AI ships
+> 32 standard squashes, 3 aggregate functions, and 3 deprecated squashes kept
+> only for backward compatibility — every name in the tables below resolves to a
+> real export under [`src/methods/activations/`](../src/methods/activations/)
+> (or [`src/deprecated/`](../src/deprecated/) for the deprecated set). This
+> guide explains how to pick one. Acronyms used here: **ReLU** (Rectified Linear
 > Unit), **GELU** (Gaussian Error Linear Unit), **ELU** (Exponential Linear
 > Unit), **SELU** (Scaled ELU), **TANH** (hyperbolic tangent), **NaN** (Not a
 > Number).
@@ -38,8 +38,8 @@ introduce non-linearity, enabling the network to learn complex patterns.
 
 In NEAT-AI, each neuron can have its own activation function. This is more
 flexible than traditional neural networks, where all neurons in a layer
-typically share the same function. NEAT's topology evolution can discover which
-activation works best for each neuron's role in the network.
+typically share the same function. NEAT-AI's topology evolution can discover
+which activation works best for each neuron's role in the network.
 
 ### 📖 Key Terms
 
@@ -61,7 +61,7 @@ activation works best for each neuron's role in the network.
 ## 📊 Overview Table
 
 The table below lists every activation function available in NEAT-AI. **Mutation
-probability** controls how often NEAT's evolution selects a function when
+probability** controls how often NEAT-AI's evolution selects a function when
 mutating neurons — higher values mean the function is chosen more frequently.
 
 ### ⚡ Standard Activation Functions
@@ -114,15 +114,15 @@ activation functions that transform a single value.
 
 ### 🗄️ Deprecated Functions
 
-These functions have a mutation probability of **0**, meaning NEAT will never
+These functions have a mutation probability of **0**, meaning NEAT-AI will never
 select them for new neurons. They remain available for backward compatibility
 with existing trained models.
 
 > [!WARNING]
 > The deprecated functions below (HYPOT, HYPOTv2, MEAN) will never be assigned
-> to neurons by NEAT's evolution. If you load a model that uses them, they will
-> continue to function correctly, but you should plan to migrate away from them
-> in future training runs.
+> to neurons by NEAT-AI's evolution. If you load a model that uses them, they
+> will continue to function correctly, but you should plan to migrate away from
+> them in future training runs.
 
 | Name                                    | Output Range | Replacement                | Why Deprecated                                      |
 | :-------------------------------------- | :----------- | :------------------------- | :-------------------------------------------------- |
@@ -312,34 +312,34 @@ network while introducing useful non-linearity.
 | Exponential    | Output grows rapidly, can cause overflow            |
 | SQRT / SQUARE  | Limited applicability, can cause numerical issues   |
 
-### 🧬 Functions That Work Well with NEAT's Topology Evolution
+### 🧬 Functions That Work Well with NEAT-AI's Topology Evolution
 
-NEAT evolves both the network's structure (topology) and its weights
+NEAT-AI evolves both the network's structure (topology) and its weights
 simultaneously. Some activation functions are better suited to this evolutionary
 process than others.
 
-**Best for NEAT evolution:**
+**Best for NEAT-AI evolution:**
 
 - **LeakyReLU, GELU, Swish, ELU, SELU, Mish** — These have high mutation
-  probabilities (31-36), meaning NEAT's evolution naturally favours them. They
-  provide smooth gradients that help memetic learning (the gradient-based
+  probabilities (31-36), meaning NEAT-AI's evolution naturally favours them.
+  They provide smooth gradients that help memetic learning (the gradient-based
   fine-tuning that happens alongside evolution) while being robust enough to
-  handle the varied topologies that NEAT generates.
+  handle the varied topologies that NEAT-AI generates.
 
 - **TANH, LOGISTIC, Softplus** — Bounded functions that prevent activation
-  values from exploding as NEAT adds new connections. Useful when the network
+  values from exploding as NEAT-AI adds new connections. Useful when the network
   grows and you want stable activations.
 
-**Challenging for NEAT evolution:**
+**Challenging for NEAT-AI evolution:**
 
 - **STEP, BIPOLAR** — These have zero gradients almost everywhere, which means
   memetic learning (backpropagation) cannot improve weights. Evolution must rely
   entirely on mutation and crossover, which is slower.
 
 - **TAN, Exponential** — Can produce extreme values that destabilise the network
-  when NEAT adds unexpected connections.
+  when NEAT-AI adds unexpected connections.
 
-- **IDENTITY** — Provides no non-linearity, so NEAT cannot increase the
+- **IDENTITY** — Provides no non-linearity, so NEAT-AI cannot increase the
   network's expressiveness by adding neurons with this function.
 
 ---
@@ -374,7 +374,7 @@ tests alternatives and remembers what works.
 
 | Scenario                             | Approach                                                               |
 | :----------------------------------- | :--------------------------------------------------------------------- |
-| Starting a new project               | Let NEAT evolve freely, then run Intelligent Design to refine          |
+| Starting a new project               | Let NEAT-AI evolve freely, then run Intelligent Design to refine       |
 | Optimising a mature model            | Use Intelligent Design to squeeze out improvements                     |
 | You know the ideal output function   | Set output layer manually, let Intelligent Design handle hidden layers |
 | Distributed training across machines | Share tacit knowledge via hive files for consistent optimisation       |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,9 @@
 # 📖 NEAT-AI API Reference
 
-Comprehensive reference for the public API exported from `mod.ts`.
+Comprehensive reference for the public API exported from `mod.ts`. For project
+terminology — including the distinction between
+[NEAT and NEAT-AI](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) — see
+[`AGENTS.md`](../AGENTS.md#-terminology).
 
 All imports use the single entry point:
 
@@ -38,7 +41,7 @@ import { Costs, Creature, Mutation, Selection } from "@stsoftware/neat-ai";
 
 ### 🐛 Creature
 
-The central class representing a neural network (genome) in NEAT.
+The central class representing a neural network (genome) in NEAT-AI.
 
 ```typescript
 import { Creature } from "@stsoftware/neat-ai";
@@ -179,7 +182,7 @@ interface CrisprInterface {
 
 ### ⚙️ NeatOptions
 
-The primary configuration type for the NEAT algorithm. Passed to
+The primary configuration type for the NEAT-AI evolutionary loop. Passed to
 `Creature.evolveDir()`.
 
 ```typescript
@@ -527,7 +530,7 @@ creature.activate(input);
 
 ## 6. 🧬 Evolution API
 
-The main entry point for NEAT evolution.
+The main entry point for NEAT-AI evolution.
 
 ### 🔄 Creature.evolveDir()
 
@@ -1222,9 +1225,9 @@ const population = createSeededPopulation({
 
 ## 17. 📤 ONNX Export
 
-Issue #1866: Export trained NEAT creatures to the [ONNX](https://onnx.ai/) (Open
-Neural Network Exchange) format for deployment in standard ML pipelines. The
-exported model produces identical outputs to the original creature (within
+Issue #1866: Export trained NEAT-AI creatures to the [ONNX](https://onnx.ai/)
+(Open Neural Network Exchange) format for deployment in standard ML pipelines.
+The exported model produces identical outputs to the original creature (within
 floating-point precision).
 
 ```typescript
@@ -1275,11 +1278,12 @@ Deno.writeFileSync("model.onnx", onnxBytes);
 
 ## 18. 🧪 Synthetic Synapses
 
-Issue #1919: Synthetic synapses address a key weakness of NEAT's incremental
-topology growth — newly evolved networks often have sparse inter-layer
-connectivity compared to conventional dense neural networks. Synthetic synapses
-temporarily densify the network during backpropagation, giving gradient descent
-a richer search space to discover useful connections.
+Issue #1919: Synthetic synapses address a key weakness of standard NEAT's
+incremental topology growth — newly evolved networks often have sparse
+inter-layer connectivity compared to conventional dense neural networks. NEAT-AI
+adds synthetic synapses to temporarily densify the network during
+backpropagation, giving gradient descent a richer search space to discover
+useful connections.
 
 ### Lifecycle
 

--- a/docs/BACKPROP_ELASTICITY.md
+++ b/docs/BACKPROP_ELASTICITY.md
@@ -1,14 +1,15 @@
 # 🔄 Elastic Back Propagation
 
-> **TL;DR** — NEAT-AI's backpropagation does not blindly apply the chain rule
-> everywhere. It (a) computes a target pre-squash value for each neuron, (b)
-> distributes the required change across inbound weights using a minimum-change
-> heuristic weighted by `activationᵢ² × safeZoneFactorᵢ`, and (c) refuses to
-> push neurons that are already saturated further into saturation. The
-> topological backprop loop and the elastic distribution kernel both live in
-> WebAssembly (WASM) — there is no TypeScript fallback. Acronyms used here:
-> **WASM** (WebAssembly), **ReLU** (Rectified Linear Unit), **TANH** (hyperbolic
-> tangent), **MCMC** (Markov-chain Monte Carlo).
+> **TL;DR** — [NEAT-AI](../AGENTS.md#-terminology)'s backpropagation does not
+> blindly apply the chain rule everywhere. It (a) computes a target pre-squash
+> value for each neuron, (b) distributes the required change across inbound
+> weights using a minimum-change heuristic weighted by
+> `activationᵢ² × safeZoneFactorᵢ`, and (c) refuses to push neurons that are
+> already saturated further into saturation. The topological backprop loop and
+> the elastic distribution kernel both live in WebAssembly (WASM) — there is no
+> TypeScript fallback. Acronyms used here: **WASM** (WebAssembly), **ReLU**
+> (Rectified Linear Unit), **TANH** (hyperbolic tangent), **MCMC** (Markov-chain
+> Monte Carlo).
 
 ## 🔗 Sibling docs in the **Compute / WASM** cluster
 

--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -1,9 +1,10 @@
 # ⚙️ Configuration Guide
 
-This page is the topic index for NEAT-AI (NeuroEvolution of Augmenting
-Topologies — Artificial Intelligence) configuration. The full surface lives in
-topic detail docs under [`docs/config/`](./config/), grouped by configuration
-domain to mirror the structure of `src/config/`.
+This page is the topic index for [NEAT-AI](../AGENTS.md#-terminology)
+(NeuroEvolution of Augmenting Topologies — Artificial Intelligence)
+configuration. The full surface lives in topic detail docs under
+[`docs/config/`](./config/), grouped by configuration domain to mirror the
+structure of `src/config/`.
 
 Configuration is passed via `NeatOptionsInput` to `createNeatConfig()`, which
 validates, parses, and freezes the result into a read-only `NeatConfig`. Numeric

--- a/docs/CRISPR_GUIDE.md
+++ b/docs/CRISPR_GUIDE.md
@@ -4,12 +4,12 @@
 > real-world gene-editing technique
 > ([Wikipedia](https://en.wikipedia.org/wiki/CRISPR),
 > [Nature primer](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/)).
-> In NEAT-AI we borrow the name for **targeted, hand-crafted edits to a
-> creature's genome** — splicing in new neurons or wrapping existing outputs
-> with extra activation/aggregation layers — without disturbing the UUIDs of
-> neurons that survive the edit. The implementation lives in
-> [`src/reconstruct/CRISPR.ts`](../src/reconstruct/CRISPR.ts); the API surface
-> is summarised in [`docs/api/CREATURE.md`](api/CREATURE.md#-crispr).
+> In [NEAT-AI](../AGENTS.md#-terminology) we borrow the name for **targeted,
+> hand-crafted edits to a creature's genome** — splicing in new neurons or
+> wrapping existing outputs with extra activation/aggregation layers — without
+> disturbing the UUIDs of neurons that survive the edit. The implementation
+> lives in [`src/reconstruct/CRISPR.ts`](../src/reconstruct/CRISPR.ts); the API
+> surface is summarised in [`docs/api/CREATURE.md`](api/CREATURE.md#-crispr).
 
 This guide complements that API summary with the conventions and gotchas that
 catch out new authors. For the project-wide vocabulary that places CRISPR

--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -1,11 +1,11 @@
 # 🔍 Discovery: Continuous Incremental Improvement
 
-> **Summary** — Discovery is the user-facing entry point to NEAT-AI's
-> error-guided structural evolution. It runs as a continuous loop, fetching the
-> current best creature, asking the Rust extension via the Foreign Function
-> Interface (FFI) to propose small structural changes, and checking improvements
-> back into a shared pool. This guide covers configuration, distributed setup,
-> and best practices. For internals see
+> **Summary** — Discovery is the user-facing entry point to
+> [NEAT-AI](../AGENTS.md#-terminology)'s error-guided structural evolution. It
+> runs as a continuous loop, fetching the current best creature, asking the Rust
+> extension via the Foreign Function Interface (FFI) to propose small structural
+> changes, and checking improvements back into a shared pool. This guide covers
+> configuration, distributed setup, and best practices. For internals see
 > [DISCOVERY_ARCHITECTURE.md](DISCOVERY_ARCHITECTURE.md); for the
 > `discoveryDir()` Application Programming Interface (API) and on-disk layout
 > see [DISCOVERY_DIR.md](DISCOVERY_DIR.md); for Graphics Processing Unit (GPU)

--- a/docs/INTELLIGENT_DESIGN.md
+++ b/docs/INTELLIGENT_DESIGN.md
@@ -200,7 +200,7 @@ workers.forEach((w) => w.terminate());
 | `outputDir`       | string      | Required      | Directory to write improved creatures     |
 | `dataDir`         | string      | Required      | Directory containing scoring data         |
 | `bestScore`       | number      | Required      | Current best score of the creature        |
-| `options`         | NeatOptions | `{}`          | NEAT options (can include customCost)     |
+| `options`         | NeatOptions | `{}`          | NEAT-AI options (can include customCost)  |
 | `maxImprovements` | number      | 12            | Stop after finding this many improvements |
 | `maxPending`      | number      | Auto          | Maximum pending tasks per worker          |
 | `timeoutMs`       | number      | 3600000 (1hr) | Timeout in milliseconds                   |

--- a/docs/PERFORMANCE_RESEARCH.md
+++ b/docs/PERFORMANCE_RESEARCH.md
@@ -1,10 +1,11 @@
 # 🔬 Performance Optimisation Guide
 
-> **Brief**: A research log of every measured attempt to make NEAT-AI faster —
-> what worked, what didn't, and the underlying reasons. Use this guide to decide
-> whether a proposed optimisation (WASM migration, SIMD expansion, algorithmic
-> change) is worth pursuing **before** writing code. For day-to-day operational
-> tuning, see [PERFORMANCE_TUNING.md](./PERFORMANCE_TUNING.md).
+> **Brief**: A research log of every measured attempt to make
+> [NEAT-AI](../AGENTS.md#-terminology) faster — what worked, what didn't, and
+> the underlying reasons. Use this guide to decide whether a proposed
+> optimisation (WASM migration, SIMD expansion, algorithmic change) is worth
+> pursuing **before** writing code. For day-to-day operational tuning, see
+> [PERFORMANCE_TUNING.md](./PERFORMANCE_TUNING.md).
 
 ## 📑 In this cluster
 
@@ -275,7 +276,7 @@ yielded 9–12% improvement:
 | Large         | 2.3 ms   | 2.1 ms   | **9%**      |
 | Very Large    | 14.6 ms  | 13.2 ms  | **10%**     |
 
-**Lesson:** For sparse networks (the typical NEAT scenario), probabilistic
+**Lesson:** For sparse networks (the typical NEAT-AI scenario), probabilistic
 algorithms that exploit sparsity outperform exhaustive enumeration. The
 rejection sampling approach finds valid connections in 1–2 attempts, eliminating
 full list construction.
@@ -646,12 +647,12 @@ Per-element error loops (MSE, MAE, CrossEntropy) over output neurons.
 | >10 µs per call?      | ✗ NO — 6 ns (3 outputs) to 1.4 µs (100 CrossEntropy) |
 | Caching layer?        | ✗ NO                                                 |
 
-**Verdict: NOT SIMD-viable.** Typical NEAT creatures have 1–10 outputs, giving
-loop counts of 1–10 elements — far too small for SIMD to amortise setup cost.
-Even the worst case (100-output CrossEntropy at 1.4 µs) is well below the 10 µs
-threshold. Additionally, the batch loss functions in `loss.rs` already use SIMD
-for the activation step — the per-output error reduction is a tiny fraction of
-the total batch scoring time.
+**Verdict: NOT SIMD-viable.** Typical NEAT-AI creatures have 1–10 outputs,
+giving loop counts of 1–10 elements — far too small for SIMD to amortise setup
+cost. Even the worst case (100-output CrossEntropy at 1.4 µs) is well below the
+10 µs threshold. Additionally, the batch loss functions in `loss.rs` already use
+SIMD for the activation step — the per-output error reduction is a tiny fraction
+of the total batch scoring time.
 
 #### Candidate 2: Gradient Accumulation Arithmetic
 

--- a/docs/PERFORMANCE_TUNING.md
+++ b/docs/PERFORMANCE_TUNING.md
@@ -19,9 +19,10 @@
 
 See the [docs index](./README.md) for the full topic map.
 
-This guide explains how to tune NEAT-AI for large-scale training runs. It covers
-every configurable performance parameter, explains when to enable or disable
-features, and provides practical recommendations for different scenarios.
+This guide explains how to tune [NEAT-AI](../AGENTS.md#-terminology) for
+large-scale training runs. It covers every configurable performance parameter,
+explains when to enable or disable features, and provides practical
+recommendations for different scenarios.
 
 All configuration is passed via `NeatOptionsInput` to `createNeatConfig()`. See
 the [Configuration Guide](./CONFIGURATION_GUIDE.md) for the full reference of
@@ -624,7 +625,7 @@ training, near-zero connections are pruned and only useful ones are retained.
 
 ### When to Enable Synthetic Synapses
 
-- **Sparse early-evolution networks**: When NEAT has not yet evolved dense
+- **Sparse early-evolution networks**: When NEAT-AI has not yet evolved dense
   inter-layer connectivity, synthetic synapses give backpropagation more
   connections to optimise, often finding useful pathways that mutation alone
   would take many generations to discover.
@@ -723,7 +724,7 @@ best creatures.
 
 **How it works**:
 
-1. Each machine runs an independent NEAT population (an "island").
+1. Each machine runs an independent NEAT-AI population (an "island").
 2. Periodically, the best creatures from each island are exported and shared.
 3. Imported creatures are grafted into the receiving population, adding genetic
    diversity.

--- a/docs/PREDICTIVE_CODING.md
+++ b/docs/PREDICTIVE_CODING.md
@@ -24,7 +24,10 @@ See the [docs index](./README.md) for the full topic map.
 ## 🧪 Acronyms used in this guide
 
 - **PC** — Predictive Coding
-- **NEAT** — NeuroEvolution of Augmenting Topologies
+- **NEAT** — NeuroEvolution of Augmenting Topologies (the original 2002
+  algorithm); see [terminology](../AGENTS.md#-terminology)
+- **NEAT-AI** — this project, which extends standard NEAT (see
+  [NEAT vs NEAT-AI](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use))
 - **WASM** — WebAssembly
 - **FFI** — Foreign Function Interface
 - **MSE / MAE / RMSE / MAPE** — Mean Squared / Absolute / Root-Mean-Squared /
@@ -210,7 +213,7 @@ NEAT-AI's core architecture consists of:
 
 #### 🔢 How Layers Map
 
-NEAT networks are not strictly layered — they are arbitrary directed graphs
+NEAT-AI networks are not strictly layered — they are arbitrary directed graphs
 (with optional recurrent connections). For PC, we define a neuron's **depth** as
 its topological distance from the input layer:
 

--- a/docs/REINFORCEMENT_LEARNING.md
+++ b/docs/REINFORCEMENT_LEARNING.md
@@ -1,8 +1,9 @@
 # 🎮 Reinforcement Learning / Agent Rollouts
 
-> **Streaming-observation / agent-rollout** in NEAT-AI is the API pattern for
-> episode-based tasks (Snake, Cart-Pole, grid worlds, control tasks) where the
-> next observation depends on the creature's previous action.
+> **Streaming-observation / agent-rollout** in
+> [NEAT-AI](../AGENTS.md#-terminology) is the API pattern for episode-based
+> tasks (Snake, Cart-Pole, grid worlds, control tasks) where the next
+> observation depends on the creature's previous action.
 >
 > The library already supports this pattern out of the box — `Creature.activate`
 > is the streaming primitive — but until now there was no document on the
@@ -40,9 +41,9 @@ Use the streaming-observation pattern when:
   [agent-environment loop](https://en.wikipedia.org/wiki/Reinforcement_learning).
 - You can score a full episode after the fact — typically a sum of rewards, a
   survival proxy, or a shaping signal.
-- A differentiable loss is **not** available, or is expensive to construct. NEAT
-  optimises the network end-to-end against the episode score, so the reward
-  signal does not need to be differentiable.
+- A differentiable loss is **not** available, or is expensive to construct.
+  NEAT-AI optimises the network end-to-end against the episode score, so the
+  reward signal does not need to be differentiable.
 
 If your task is fully supervised — every observation comes with a target output
 and the data is independent — you do not need this pattern. Use
@@ -169,7 +170,7 @@ flowchart LR
 
 ## 📊 Scoring an episode
 
-The fitness score returned to NEAT is **a single scalar per creature, per
+The fitness score returned to NEAT-AI is **a single scalar per creature, per
 generation**. Common choices:
 
 | Score                   | When to use                                                                                    |
@@ -247,14 +248,14 @@ This puts it in a different family from the dominant deep-RL methods.
 | Policy-gradient                                                           | REINFORCE, PPO          | The policy `π(a \| s)` directly, via gradient on a stochastic objective.        | Yes — the policy must be differentiable, and we differentiate through it.                   | Continuous action spaces. Mature ecosystems (RLlib, Stable-Baselines3).                                                                        | Variance is high; needs careful baselines. Hyperparameter-sensitive.                                                                |
 | **Neuroevolution (NEAT-AI)**                                              | NEAT, CMA-ES, OpenAI ES | The policy network itself — both topology and weights — by evolutionary search. | **No.** The reward is a scalar produced by the simulator; nothing has to be differentiable. | Works with non-differentiable, sparse, or simulator-only rewards. Embarrassingly parallel across the population. Topology grows automatically. | Less sample-efficient per environment step than DQN/PPO when a good gradient signal exists. Computationally heavier per generation. |
 
-**When NEAT is the right choice for a streaming-observation task:**
+**When NEAT-AI is the right choice for a streaming-observation task:**
 
 - The reward is sparse, non-differentiable, or only available at the end of the
   episode (e.g. "did the agent win?").
 - The action space mixes discrete and continuous components, or the action
   decoder is itself non-differentiable.
 - You want the architecture to grow with the task — no manual layer sizing.
-- You have many CPU cores or distributed nodes — NEAT scales by spreading
+- You have many CPU cores or distributed nodes — NEAT-AI scales by spreading
   rollouts across them, not by one big GPU.
 
 **When DQN or PPO is the better choice:**

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,7 +1,7 @@
 # 🐛 Troubleshooting Guide
 
-Quick FAQ-style index of NEAT-AI failure modes. Each entry describes the symptom
-in one sentence and links to a detail doc under
+Quick FAQ-style index of [NEAT-AI](../AGENTS.md#-terminology) failure modes.
+Each entry describes the symptom in one sentence and links to a detail doc under
 [`troubleshooting/`](troubleshooting/) where the full diagnosis lives.
 
 If you have arrived here by Googling an error message, jump straight to the

--- a/docs/pr-summary-2599.md
+++ b/docs/pr-summary-2599.md
@@ -7,32 +7,32 @@ Closes #2599.
 
 Two new entries were added to the existing **Terminology** section:
 
-- **NEAT** — the original NeuroEvolution of Augmenting Topologies algorithm
-  from the 2002 paper. Reserved for discussions of that algorithm only.
+- **NEAT** — the original NeuroEvolution of Augmenting Topologies algorithm from
+  the 2002 paper. Reserved for discussions of that algorithm only.
 - **NEAT-AI** — this project. Started from pure NEAT but now extends it with
-  memetic evolution, error-guided Discovery, MCMC mutation acceptance,
-  synthetic synapses, predictive coding, Muon-style orthogonalised gradients,
-  and other modern algorithms.
+  memetic evolution, error-guided Discovery, MCMC mutation acceptance, synthetic
+  synapses, predictive coding, Muon-style orthogonalised gradients, and other
+  modern algorithms.
 
-A new **🆚 NEAT vs NEAT-AI — which term to use** subsection codifies the
-rule of thumb so contributors know which term belongs where:
+A new **🆚 NEAT vs NEAT-AI — which term to use** subsection codifies the rule of
+thumb so contributors know which term belongs where:
 
 - Say **NEAT-AI** for anything the repo does.
-- Say **NEAT** (or "standard NEAT" / "pure NEAT") only when contrasting with
-  the 2002 algorithm.
+- Say **NEAT** (or "standard NEAT" / "pure NEAT") only when contrasting with the
+  2002 algorithm.
 - Avoid bare "NEAT" as shorthand for the implementation in user-facing docs.
 
-This is foundational and unblocks the other sub-issues under #2598 — they
-can now reference this glossary entry instead of redefining the distinction
-in each file.
+This is foundational and unblocks the other sub-issues under #2598 — they can
+now reference this glossary entry instead of redefining the distinction in each
+file.
 
 ## Evidence
 
 Documentation-only change (no code, no UI, no benchmarks). Verified with:
 
 - `npx markdownlint-cli2 AGENTS.md` → 0 errors.
-- `./quality.sh --lint-only` → all four steps pass (deno fmt, deno lint,
-  bash check). `deno fmt` rewrapped a few lines in the new section.
+- `./quality.sh --lint-only` → all four steps pass (deno fmt, deno lint, bash
+  check). `deno fmt` rewrapped a few lines in the new section.
 - Manual inspection: links resolve to the same Stanley & Miikkulainen PDF
   already cited elsewhere in the file.
 
@@ -50,6 +50,6 @@ flowchart LR
 - [x] `AGENTS.md` Terminology section contains entries for both **NEAT** and
       **NEAT-AI** with the distinction described in the issue.
 - [x] Includes a contributor rule of thumb on which term to use where.
-- [x] Markdown renders cleanly (markdownlint-cli2 reports zero errors;
-      no broken links).
+- [x] Markdown renders cleanly (markdownlint-cli2 reports zero errors; no broken
+      links).
 - [x] `./quality.sh --lint-only` passes (formatting, linting, bash check).

--- a/docs/pr-summary-2602.md
+++ b/docs/pr-summary-2602.md
@@ -1,0 +1,88 @@
+# Sweep remaining docs to clarify NEAT vs NEAT-AI references
+
+## Summary
+
+Closes #2602.
+
+This PR completes the long-tail sweep started by #2599 (terminology entry) and
+#2600/#2601 (README and COMPARISON updates). It audits every long-form topic
+guide under `docs/` (excluding historical `pr-summary-*.md` files) and the
+root-level `CONTRIBUTING.md` and `SECURITY.md`, replacing bare **NEAT**
+references that describe NEAT-AI behaviour with **NEAT-AI**, and adding a link
+to the AGENTS.md terminology entries on the first occurrence of NEAT/NEAT-AI in
+each updated file.
+
+`CHANGELOG.md` was reviewed but not edited — historical entries are preserved
+verbatim per the issue scope; the convention is enforced via the new AGENTS.md
+guidance for prospective entries.
+
+## Files changed
+
+| File                             | Edits                                                                                                                                                                                                   |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CONTRIBUTING.md`                | Linked first NEAT-AI; added IMPORTANT note about NEAT vs NEAT-AI; clarified `src/NEAT/` folder description                                                                                              |
+| `SECURITY.md`                    | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/INTELLIGENT_DESIGN.md`     | Renamed "NEAT options" → "NEAT-AI options" in NeatOptions row                                                                                                                                           |
+| `docs/DISCOVERY_GUIDE.md`        | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/CRISPR_GUIDE.md`           | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/BACKPROP_ELASTICITY.md`    | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/CONFIGURATION_GUIDE.md`    | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/API_REFERENCE.md`          | Linked first NEAT/NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI in Creature class, NeatOptions, evolveDir, ONNX export sections; clarified "standard NEAT" contrast in synthetic synapses paragraph |
+| `docs/PREDICTIVE_CODING.md`      | Added NEAT-AI acronym entry with terminology link; renamed "NEAT networks" → "NEAT-AI networks" in topology context                                                                                     |
+| `docs/REINFORCEMENT_LEARNING.md` | Linked first NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI in fitness/optimisation/scaling sentences                                                                                                |
+| `docs/ACTIVATION_FUNCTIONS.md`   | Linked first NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI throughout topology-evolution sections (mutation probability, evolution suitability, deprecated functions)                               |
+| `docs/PERFORMANCE_TUNING.md`     | Linked first NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI in synthetic-synapse and island-model sections                                                                                           |
+| `docs/PERFORMANCE_RESEARCH.md`   | Linked first NEAT-AI to AGENTS.md; renamed "typical NEAT scenario/creatures" → NEAT-AI                                                                                                                  |
+| `docs/TROUBLESHOOTING.md`        | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/pr-summary-2599.md`        | Incidental `deno fmt` re-wrap (no semantic change)                                                                                                                                                      |
+
+### Kinds of edits applied
+
+```mermaid
+flowchart LR
+    A[Audit each file] --> B{Bare NEAT means<br/>NEAT-AI behaviour?}
+    B -- yes --> C[Rename to NEAT-AI]
+    B -- no, contrasting<br/>2002 algorithm --> D[Keep / clarify as<br/>'standard NEAT']
+    C --> E{First NEAT/NEAT-AI<br/>linked to AGENTS.md?}
+    D --> E
+    E -- no --> F[Add link to<br/>AGENTS.md terminology]
+    E -- yes --> G[Done]
+    F --> G
+```
+
+Three classes of edit appear in this PR:
+
+- **Rename** — bare "NEAT" describing this repo's behaviour → "NEAT-AI".
+- **Clarify** — sentences that contrast with the 2002 algorithm now say
+  "standard NEAT" explicitly and name NEAT-AI as the contrasting party.
+- **Link added** — the first occurrence of NEAT/NEAT-AI in each updated file
+  links to the AGENTS.md terminology and "NEAT vs NEAT-AI" rule.
+
+## Out of scope
+
+- `docs/pr-summary-*.md` historical PR records (per issue scope) — only the
+  pre-existing `pr-summary-2599.md` was touched, and only by `deno fmt`
+  (whitespace re-wrap, no semantic change).
+- `CHANGELOG.md` historical entries — not rewritten. The convention applies to
+  new entries, enforced by AGENTS.md.
+
+## Evidence
+
+This is a pure documentation PR — there is no UI to screenshot and no runtime
+behaviour to benchmark. Verification is via the project quality gate:
+
+- `./quality.sh --lint-only` passes (formatting + linting + bash check).
+- `./quality.sh --check-only` passes (deno type-check).
+
+No source code or tests were modified.
+
+## Test Plan
+
+- [x] `deno fmt` passes on every modified file
+- [x] `deno lint` passes (markdownlint-cli2 + deno lint)
+- [x] `deno check` passes
+- [x] Spot-check: every updated file's first NEAT/NEAT-AI mention is a clickable
+      link to `AGENTS.md#-terminology` or
+      `AGENTS.md#-neat-vs-neat-ai--which-term-to-use`.
+- [x] No `pr-summary-NNNN.md` historical record has had its content semantically
+      changed.


### PR DESCRIPTION
# Sweep remaining docs to clarify NEAT vs NEAT-AI references

## Summary

Closes #2602.

This PR completes the long-tail sweep started by #2599 (terminology entry) and
#2600/#2601 (README and COMPARISON updates). It audits every long-form topic
guide under `docs/` (excluding historical `pr-summary-*.md` files) and the
root-level `CONTRIBUTING.md` and `SECURITY.md`, replacing bare **NEAT**
references that describe NEAT-AI behaviour with **NEAT-AI**, and adding a link
to the AGENTS.md terminology entries on the first occurrence of NEAT/NEAT-AI in
each updated file.

`CHANGELOG.md` was reviewed but not edited — historical entries are preserved
verbatim per the issue scope; the convention is enforced via the new AGENTS.md
guidance for prospective entries.

## Files changed

| File                             | Edits                                                                                                                                                                                                   |
| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `CONTRIBUTING.md`                | Linked first NEAT-AI; added IMPORTANT note about NEAT vs NEAT-AI; clarified `src/NEAT/` folder description                                                                                              |
| `SECURITY.md`                    | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
| `docs/INTELLIGENT_DESIGN.md`     | Renamed "NEAT options" → "NEAT-AI options" in NeatOptions row                                                                                                                                           |
| `docs/DISCOVERY_GUIDE.md`        | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
| `docs/CRISPR_GUIDE.md`           | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
| `docs/BACKPROP_ELASTICITY.md`    | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
| `docs/CONFIGURATION_GUIDE.md`    | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
| `docs/API_REFERENCE.md`          | Linked first NEAT/NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI in Creature class, NeatOptions, evolveDir, ONNX export sections; clarified "standard NEAT" contrast in synthetic synapses paragraph |
| `docs/PREDICTIVE_CODING.md`      | Added NEAT-AI acronym entry with terminology link; renamed "NEAT networks" → "NEAT-AI networks" in topology context                                                                                     |
| `docs/REINFORCEMENT_LEARNING.md` | Linked first NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI in fitness/optimisation/scaling sentences                                                                                                |
| `docs/ACTIVATION_FUNCTIONS.md`   | Linked first NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI throughout topology-evolution sections (mutation probability, evolution suitability, deprecated functions)                               |
| `docs/PERFORMANCE_TUNING.md`     | Linked first NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI in synthetic-synapse and island-model sections                                                                                           |
| `docs/PERFORMANCE_RESEARCH.md`   | Linked first NEAT-AI to AGENTS.md; renamed "typical NEAT scenario/creatures" → NEAT-AI                                                                                                                  |
| `docs/TROUBLESHOOTING.md`        | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
| `docs/pr-summary-2599.md`        | Incidental `deno fmt` re-wrap (no semantic change)                                                                                                                                                      |

### Kinds of edits applied

```mermaid
flowchart LR
    A[Audit each file] --> B{Bare NEAT means<br/>NEAT-AI behaviour?}
    B -- yes --> C[Rename to NEAT-AI]
    B -- no, contrasting<br/>2002 algorithm --> D[Keep / clarify as<br/>'standard NEAT']
    C --> E{First NEAT/NEAT-AI<br/>linked to AGENTS.md?}
    D --> E
    E -- no --> F[Add link to<br/>AGENTS.md terminology]
    E -- yes --> G[Done]
    F --> G
```

Three classes of edit appear in this PR:

- **Rename** — bare "NEAT" describing this repo's behaviour → "NEAT-AI".
- **Clarify** — sentences that contrast with the 2002 algorithm now say
  "standard NEAT" explicitly and name NEAT-AI as the contrasting party.
- **Link added** — the first occurrence of NEAT/NEAT-AI in each updated file
  links to the AGENTS.md terminology and "NEAT vs NEAT-AI" rule.

## Out of scope

- `docs/pr-summary-*.md` historical PR records (per issue scope) — only the
  pre-existing `pr-summary-2599.md` was touched, and only by `deno fmt`
  (whitespace re-wrap, no semantic change).
- `CHANGELOG.md` historical entries — not rewritten. The convention applies to
  new entries, enforced by AGENTS.md.

## Evidence

This is a pure documentation PR — there is no UI to screenshot and no runtime
behaviour to benchmark. Verification is via the project quality gate:

- `./quality.sh --lint-only` passes (formatting + linting + bash check).
- `./quality.sh --check-only` passes (deno type-check).

No source code or tests were modified.

## Test Plan

- [x] `deno fmt` passes on every modified file
- [x] `deno lint` passes (markdownlint-cli2 + deno lint)
- [x] `deno check` passes
- [x] Spot-check: every updated file's first NEAT/NEAT-AI mention is a clickable
      link to `AGENTS.md#-terminology` or
      `AGENTS.md#-neat-vs-neat-ai--which-term-to-use`.
- [x] No `pr-summary-NNNN.md` historical record has had its content semantically
      changed.



## Milestone
This PR is part of the **Ours vs standard NEAT** milestone and targets the `milestone/ours-vs-standard-neat` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2602 -->