### PR TITLE
Milestone: Ours vs standard NEAT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,19 @@ For deep dives on a single topic, follow the dedicated docs (full index in
 We keep the tone playful, but every nickname maps to a mainstream
 machine-learning idea:
 
+- **NEAT** — the original **NeuroEvolution of Augmenting Topologies** algorithm
+  published by
+  [Stanley & Miikkulainen (2002)](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf).
+  Use this term **only** when discussing the algorithm as defined in that paper
+  (speciation by historical markings, structure-mutation crossover, and so on).
+  Synonyms acceptable for emphasis: "standard NEAT", "pure NEAT", "the 2002 NEAT
+  algorithm".
+- **NEAT-AI** — **this project**. Started from pure NEAT but extends it well
+  beyond the 2002 algorithm with memetic evolution, error-guided **Discovery**,
+  MCMC mutation acceptance, synthetic synapses, predictive coding, Muon-style
+  orthogonalised gradients, and other modern algorithms (some published only
+  weeks before this entry was written). Use this term for **all** references to
+  features, behaviour, or APIs in this repository.
 - **Creatures** are individual neural networks/genomes inside a NEAT population,
   as described in the original NEAT paper by
   [Stanley & Miikkulainen (2002)](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf).
@@ -97,6 +110,28 @@ machine-learning idea:
 
 If you spot another fun label, expect it to be backed by a reference to the
 standard term the first time it appears.
+
+### 🆚 NEAT vs NEAT-AI — which term to use
+
+Because the project has extended far past the 2002 algorithm, mixing the two
+terms in docs and code comments has been a source of confusion. Use this rule of
+thumb:
+
+- ✅ Say **NEAT-AI** when discussing what **this repo** does — features,
+  behaviour, configuration, APIs, defaults, and roadmap.
+- ✅ Say **NEAT** (or "standard NEAT", "pure NEAT", "the 2002 NEAT algorithm")
+  **only** when contrasting with the original Stanley & Miikkulainen algorithm —
+  for example, "standard NEAT speciates by historical markings; NEAT-AI also
+  accepts mutations via an MCMC criterion".
+- ❌ Avoid using bare **NEAT** as shorthand for the implementation in
+  user-facing docs. If you mean "this codebase", write **NEAT-AI**.
+- 🧩 Inside historical-context paragraphs (e.g. the project's origin story or
+  the `src/NEAT/` folder name), bare "NEAT" is acceptable because the meaning is
+  clear from context, but prefer **NEAT-AI** when describing current behaviour.
+
+When a single sentence mentions both, name them explicitly to make the
+distinction unambiguous (e.g. "NEAT-AI inherits speciation from standard NEAT
+but replaces unconditional mutation acceptance with MCMC").
 
 ## 🏗️ Project Architecture
 

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,21 +1,37 @@
-# 📊 NEAT vs Traditional Neural Networks and Modern LLMs: A Comprehensive Comparison
+# 📊 NEAT-AI vs Traditional Neural Networks and Modern LLMs: A Comprehensive Comparison
 
 ## 🔍 Overview
 
-This document compares our NEAT-AI implementation with traditional neural
-network architectures (feedforward, CNN, RNN) and modern Large Language Models
-(Transformers). It clearly explains what we've implemented, the pros and cons of
-our approaches, our unique innovations, and identifies shortcomings that
-represent future work opportunities.
+This document compares **[NEAT-AI](./AGENTS.md#-terminology)** — the
+implementation in this repository — with traditional neural network
+architectures (feedforward, CNN, RNN) and modern Large Language Models
+(Transformers).
+
+NEAT-AI started from
+**[NEAT (NeuroEvolution of Augmenting Topologies)](./AGENTS.md#-terminology)**
+as published by
+[Stanley & Miikkulainen (2002)](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf),
+but has since incorporated many algorithms beyond the 2002 paper — some
+published only weeks before the latest revision of this document. Throughout
+this document, **NEAT** refers strictly to the standard 2002 algorithm and
+**NEAT-AI** refers to this project. See the
+[NEAT vs NEAT-AI terminology rule](./AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+in `AGENTS.md` for the full convention.
+
+The document explains what NEAT-AI has implemented (separating standard NEAT
+machinery from NEAT-AI extensions), the pros and cons of NEAT-AI's approaches,
+NEAT-AI's unique innovations, and the shortcomings that represent future work
+opportunities.
 
 > [!NOTE]
-> You don't need to be an expert in neural networks or the NEAT algorithm to get
-> value from this comparison. We start with a high-level introduction to NEAT
-> and only assume basic familiarity with ML concepts. It aims to stay accurate
-> and links to authoritative sources whenever new ideas are introduced.
+> You don't need to be an expert in neural networks or the original NEAT
+> algorithm to get value from this comparison. We start with a high-level
+> introduction and only assume basic familiarity with ML concepts. The text aims
+> to stay accurate and links to authoritative sources whenever new ideas are
+> introduced.
 
 For project terminology (Creatures, Memetic evolution, CRISPR injections,
-Grafting, etc.), see [AGENTS.md](./AGENTS.md#terminology).
+Grafting, etc.), see [AGENTS.md](./AGENTS.md#-terminology).
 
 ## 📋 Table of Contents
 
@@ -23,224 +39,252 @@ Grafting, etc.), see [AGENTS.md](./AGENTS.md#terminology).
 2. [Architectural Comparison](#architectural-comparison)
 3. [Training Paradigms](#training-paradigms)
 4. [Our Unique Approaches](#our-unique-approaches)
-5. [Ecosystem Comparison: What We've Built vs Standard Libraries](#ecosystem-comparison-what-weve-built-vs-standard-libraries)
+5. [Ecosystem Comparison: NEAT-AI vs Standard Libraries](#ecosystem-comparison-neat-ai-vs-standard-libraries)
 6. [Pros and Cons Analysis](#pros-and-cons-analysis)
 7. [Shortcomings and Future Work](#shortcomings-and-future-work)
 8. [References and Further Reading](#references-and-further-reading)
 
 ## 🧬 What We've Implemented
 
-### 🔬 Core NEAT Algorithm
+The features below are split into two groups so the line between **standard
+NEAT** (the 2002 algorithm) and the **NEAT-AI extensions** built on top is
+explicit.
 
-- ✅ **Evolutionary Topology Search**: Networks evolve their structure through
-  genetic operations (mutation, crossover)
-- ✅ **Speciation**: Networks grouped by similarity to protect innovation and
-  prevent premature convergence
-- ✅ **Historical Marking**: Tracks gene history for compatible crossover
-  between different topologies
-- ✅ **Genetic Operators**:
-  - Mutation: Add/remove neurons and connections, modify weights/biases
-  - Crossover: Breeding between compatible parents
-  - Selection: Multiple strategies (fitness proportionate, tournament, power)
+### 🔬 Standard NEAT machinery (Stanley & Miikkulainen, 2002)
 
-### 🎓 Training Methods
+These items come directly from the
+[original NEAT paper](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf).
+NEAT-AI inherits them as the evolutionary substrate.
 
-- ✅ **Backpropagation**: Full gradient-based weight optimisation implemented
-  with:
+- ✅ **Evolutionary Topology Search** _(standard NEAT)_: Networks evolve their
+  structure through genetic operations (mutation, crossover).
+- ✅ **Speciation** _(standard NEAT)_: Networks are grouped by similarity to
+  protect innovation and prevent premature convergence.
+- ✅ **Historical Marking** _(standard NEAT)_: Tracks gene history for
+  compatible crossover between different topologies.
+- ✅ **Genetic Operators** _(standard NEAT)_:
+  - Mutation: add/remove neurons and connections, modify weights/biases.
+  - Crossover: breeding between compatible parents.
+  - Selection: multiple strategies (fitness proportionate, tournament, power).
+- ✅ **Fitness Sharing** _(standard NEAT)_: Raw fitness is divided by species
+  size so dominant species don't starve smaller niches. NEAT-AI adds per-species
+  breeding quotas on top — see the NEAT-AI extensions list below.
+
+### 🚀 NEAT-AI extensions (beyond the 2002 paper)
+
+Everything below is a NEAT-AI extension added on top of standard NEAT — most of
+these have no counterpart in the original 2002 algorithm. Where a feature links
+to a dedicated guide, the contrast with standard NEAT is documented there.
+
+#### 🎓 Training methods (NEAT-AI extensions)
+
+- ✅ **Backpropagation** _(NEAT-AI extension)_: Full gradient-based weight
+  optimisation, which standard NEAT does not include. Implemented with:
   - Mini-batch gradient descent (configurable batch sizes)
   - Adaptive learning rate strategies (fixed, decay, adaptive)
   - Weight and bias adjustment with configurable limits
   - Sparse training with intelligent neuron selection
-- ✅ **Memetic Evolution**: Records successful weight patterns and reuses them
-  in later generations, following the
-  [memetic algorithm](https://en.wikipedia.org/wiki/Memetic_algorithm) approach;
-  we've observed this hybrid step improve convergence on our internal
-  benchmarks.
-- ✅ **Error-Guided Structural Evolution**: GPU-accelerated discovery of
-  beneficial structural changes
-- ✅ **Sparse Training**: Configurable neuron selection strategies (random,
-  output-distance, error-weighted) for efficiency
-- ✅ **Batch Processing**: Mini-batch gradient descent with configurable batch
-  sizes
-- ✅ **Early Stopping**: Enhanced early stopping with patience and improvement
-  thresholds
-- ✅ **Predictive Coding**: Optional training paradigm based on
-  [Rao & Ballard (1999)](https://www.nature.com/articles/nn0199_79) that uses
-  iterative inference settling and local Hebbian learning rules. Configurable
-  via `PredictiveCodingConfig` with inference steps, learning rate, and energy
-  convergence thresholds. See
-  [PREDICTIVE_CODING.md](./docs/PREDICTIVE_CODING.md) for architecture details.
-- ✅ **Dropout Regularisation**: True
-  [inverted dropout](https://arxiv.org/abs/1207.0580) during training—randomly
+- ✅ **Memetic Evolution** _(NEAT-AI extension)_: Records successful weight
+  patterns and reuses them in later generations, following the
+  [memetic algorithm](https://en.wikipedia.org/wiki/Memetic_algorithm) approach.
+  Standard NEAT has no memetic step; in NEAT-AI's internal benchmarks this
+  hybrid step improves convergence over evolution alone.
+- ✅ **Error-Guided Structural Evolution** _(NEAT-AI extension)_:
+  GPU-accelerated discovery of beneficial structural changes. Standard NEAT
+  performs structural mutation uniformly at random; NEAT-AI guides it with
+  measured error data — see [DISCOVERY_GUIDE.md](./docs/DISCOVERY_GUIDE.md).
+- ✅ **Sparse Training** _(NEAT-AI extension)_: Configurable neuron selection
+  strategies (random, output-distance, error-weighted) for efficiency.
+- ✅ **Batch Processing** _(NEAT-AI extension)_: Mini-batch gradient descent
+  with configurable batch sizes.
+- ✅ **Early Stopping** _(NEAT-AI extension)_: Enhanced early stopping with
+  patience and improvement thresholds.
+- ✅ **Predictive Coding** _(NEAT-AI extension)_: Optional training paradigm
+  based on [Rao & Ballard (1999)](https://www.nature.com/articles/nn0199_79)
+  that uses iterative inference settling and local Hebbian learning rules.
+  Configurable via `PredictiveCodingConfig` with inference steps, learning rate,
+  and energy convergence thresholds. See
+  [PREDICTIVE_CODING.md](./docs/PREDICTIVE_CODING.md) for architecture details
+  and the contrast with standard NEAT (which has no equivalent).
+- ✅ **Dropout Regularisation** _(NEAT-AI extension)_: True
+  [inverted dropout](https://arxiv.org/abs/1207.0580) during training — randomly
   disables a configurable fraction of hidden neurons per forward pass and scales
   remaining activations by 1/(1−p) so inference runs unchanged. Input and output
   neurons are never dropped.
-- ✅ **L1/L2 Weight & Bias Regularisation**: During backpropagation, applies L2
-  weight decay (`w *= (1 − lr·λ₂)`) and L1 soft-thresholding to drive small
-  weights to exactly zero, promoting sparsity. Mirrors the same decay for
-  biases.
-- ✅ **K-Fold Cross-Validation**: Splits training data into k folds, trains on
-  k−1 folds and validates on the held-out fold. Fitness is the average
-  validation error across all folds, reducing overfitting and producing more
-  robust fitness estimates. Configurable fold count (1–20) with automatic
-  fallback to single-split when data is insufficient.
-- ✅ **Gradient Accumulation Normalisation**: Optional sqrt-scaling for gradient
-  accumulation in high fan-out neurons, preventing neurons with many downstream
-  connections from receiving disproportionately large error signals.
-- ✅ **Synthetic Synapse Training**: Temporarily densifies inter-layer
-  connectivity during backpropagation by adding zero-weight synapses between
-  adjacent topological layers. After training, near-zero synapses are pruned and
-  only useful connections are retained — addressing NEAT's inherent weakness of
-  sparse connectivity compared to conventional
+- ✅ **L1/L2 Weight & Bias Regularisation** _(NEAT-AI extension)_: During
+  backpropagation, applies L2 weight decay (`w *= (1 − lr·λ₂)`) and L1
+  soft-thresholding to drive small weights to exactly zero, promoting sparsity.
+  Mirrors the same decay for biases. Standard NEAT has no gradient step at all
+  and therefore no weight decay.
+- ✅ **K-Fold Cross-Validation** _(NEAT-AI extension)_: Splits training data
+  into k folds, trains on k−1 folds and validates on the held-out fold. Fitness
+  is the average validation error across all folds, reducing overfitting and
+  producing more robust fitness estimates. Configurable fold count (1–20) with
+  automatic fallback to single-split when data is insufficient.
+- ✅ **Gradient Accumulation Normalisation** _(NEAT-AI extension)_: Optional
+  sqrt-scaling for gradient accumulation in high fan-out neurons, preventing
+  neurons with many downstream connections from receiving disproportionately
+  large error signals.
+- ✅ **Synthetic Synapse Training** _(NEAT-AI extension)_: Temporarily densifies
+  inter-layer connectivity during backpropagation by adding zero-weight synapses
+  between adjacent topological layers. After training, near-zero synapses are
+  pruned and only useful connections are retained — addressing the inherent
+  sparseness of NEAT-evolved networks compared to conventional
   [dense layers](https://en.wikipedia.org/wiki/Dense_layer). Opt-in via
   `syntheticSynapses: true` in the training configuration.
-- ✅ **MCMC Mutation Acceptance**: Uses the
+- ✅ **MCMC Mutation Acceptance** _(NEAT-AI extension)_: Uses the
   [Metropolis-Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)
-  criterion for mutation acceptance. Instead of unconditionally accepting all
-  mutations, worse-fitness moves are accepted with a probability that decreases
-  as temperature cools — enabling the population to escape local optima early
-  and converge later. Includes adaptive temperature tuning toward the
+  criterion for mutation acceptance. Standard NEAT accepts all mutations
+  unconditionally; NEAT-AI accepts worsening mutations only with a
+  temperature-dependent probability so the population can escape local optima
+  early and converge later. Includes adaptive temperature tuning toward the
   theoretically optimal acceptance rate (~23.4%, Roberts et al. 1997). The
   cooling schedule is also coupled to a live diversity signal: when species
   count collapses or within-species crowding rises, the temperature is reheated
   to restore exploration (`diversityAwareMCMC` block). Opt-in via
   `mcmc: { enabled: true }`.
-- ✅ **Muon-Style Orthogonalised Gradient Updates**: Optional Newton-Schulz
-  polynomial iteration applied to per-neuron gradient matrices during
-  backpropagation, decorrelating update directions for improved training
-  stability. Inspired by the DeepSeek V4 approach. Opt-in via
+- ✅ **Muon-Style Orthogonalised Gradient Updates** _(NEAT-AI extension)_:
+  Optional Newton-Schulz polynomial iteration applied to per-neuron gradient
+  matrices during backpropagation, decorrelating update directions for improved
+  training stability. Inspired by the DeepSeek V4 approach. Opt-in via
   `gradientOrthogonalisation: "muon"` in `BackPropagationArguments` (default
   `"none"`).
 
-### ✨ Unique Features
+#### ✨ Architecture, identity, and tooling (NEAT-AI extensions)
 
-- ✅ **UUID-Based Indexing**: Extensible observations without restarting
-  evolution—new input features can be added dynamically by extending NEAT's
-  historical-marking idea from
-  [Stanley & Miikkulainen (2002)](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf).
-- ✅ **Distributed Evolution**: Multi-node training with centralised combination
-  of best-of-breed creatures, similar to the
-  [island model](https://en.wikipedia.org/wiki/Island_model).
-- ✅ **Lifelong Learning**: Continuous adaptation via ongoing evolution and
-  backpropagation. In long-running deployments (for example, generating fresh
-  training data each day from many years of financial, market, or company
-  reporting data), the same population can keep training and adapting as new
-  samples and new features arrive. This supports continual learning in the
-  spirit of
+- ✅ **UUID-Based Indexing** _(NEAT-AI extension)_: Extensible observations
+  without restarting evolution — new input features can be added dynamically by
+  extending the historical-marking idea from
+  [Stanley & Miikkulainen (2002)](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf)
+  to UUID-keyed neuron identity. Standard NEAT identifies genes by integer
+  innovation numbers only.
+- ✅ **Distributed Evolution** _(NEAT-AI extension)_: Multi-node training with
+  centralised combination of best-of-breed creatures, similar to the
+  [island model](https://en.wikipedia.org/wiki/Island_model). Standard NEAT is
+  single-machine.
+- ✅ **Lifelong Learning** _(NEAT-AI extension)_: Continuous adaptation via
+  ongoing evolution and backpropagation. In long-running deployments (for
+  example, generating fresh training data each day from many years of financial,
+  market, or company reporting data), the same population can keep training and
+  adapting as new samples and new features arrive. This supports continual
+  learning in the spirit of
   [continual learning](https://en.wikipedia.org/wiki/Continual_learning) while
   still relying on your training data mix to keep past behaviour represented.
-- ✅ **CRISPR Gene Injection**: Targeted gene insertion during evolution to
-  introduce specific traits, inspired by
+- ✅ **CRISPR Gene Injection** _(NEAT-AI extension)_: Targeted gene insertion
+  during evolution to introduce specific traits, inspired by
   [CRISPR-Cas9 gene editing](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/).
-- ✅ **Grafting**: Cross-species breeding algorithm for genetically incompatible
-  parents that preserves diversity like cross-island migration in the
-  [island model](https://en.wikipedia.org/wiki/Island_model).
-- ✅ **Neuron Pruning**: Automatic removal of neurons whose activations don't
-  vary during training, echoing established
+- ✅ **Grafting** _(NEAT-AI extension)_: Cross-species breeding algorithm for
+  genetically incompatible parents that preserves diversity like cross-island
+  migration in the [island model](https://en.wikipedia.org/wiki/Island_model).
+  Standard NEAT does not breed across speciation boundaries.
+- ✅ **Neuron Pruning** _(NEAT-AI extension)_: Automatic removal of neurons
+  whose activations don't vary during training, echoing established
   [network pruning](https://en.wikipedia.org/wiki/Pruning_(neural_networks))
   practice.
-- ✅ **GPU-Accelerated Discovery**: Cross-platform GPU support via
-  [wgpu](https://wgpu.rs/) abstraction—Metal on macOS, Vulkan on Linux, DX12 on
-  Windows—with automatic CPU fallback when no compatible GPU is detected.
-- ✅ **Discovery Caching**: Success and failure caching for discovery candidates
-  with age-based and size-based eviction, cache-informed multi-neuron removal
-  candidates, and supplemental candidate building from historical data.
-- ✅ **Disk Space Monitoring**: Pre-flight and runtime disk space checks during
-  discovery to gracefully warn or abort when disk space is insufficient.
-- ✅ **Ensemble Diversity**: `EnsembleDiversityConfig` scores creatures within
-  species by weight variance, squash entropy, and topology diversity to reduce
-  reliance on brilliant-but-brittle solutions.
-- ✅ **Adaptive Quantum Steps**: `QuantumStepConfig` provides adaptive step
-  sizing during memetic fine-tuning—larger steps when far from the optimum and
-  smaller steps during convergence.
-- ✅ **Unique Activation Functions**: IF, MAX, MIN, and other non-standard
-  squashes that enable different network behaviours, akin to the broader family
-  of [activation functions](https://en.wikipedia.org/wiki/Activation_function).
-- ✅ **Improved Aggregate Gradient Flow**: MAXIMUM and MINIMUM aggregate
-  functions distribute partial error signals to runner-up connections within a
-  proximity threshold (15%), preventing dead gradient paths while preserving
-  dominance of the winning connection.
-- ✅ **Transfer Learning**: Checkpoint export/import system with UUID-based
-  neuron and synapse mapping between creatures with different input/output
-  configurations. Supports weight freezing for fine-tuning imported hidden
-  layers and population seeding with pre-trained creatures.
-- ✅ **ONNX Format Export**: Exports trained creatures to the
-  [ONNX](https://onnx.ai/) binary format for interoperability with standard ML
-  tooling. Converts creature topology to ONNX computational graphs with
+- ✅ **GPU-Accelerated Discovery** _(NEAT-AI extension)_: Cross-platform GPU
+  support via [wgpu](https://wgpu.rs/) abstraction — Metal on macOS, Vulkan on
+  Linux, DX12 on Windows — with automatic CPU fallback when no compatible GPU is
+  detected.
+- ✅ **Discovery Caching** _(NEAT-AI extension)_: Success and failure caching
+  for discovery candidates with age-based and size-based eviction,
+  cache-informed multi-neuron removal candidates, and supplemental candidate
+  building from historical data.
+- ✅ **Disk Space Monitoring** _(NEAT-AI extension)_: Pre-flight and runtime
+  disk space checks during discovery to gracefully warn or abort when disk space
+  is insufficient.
+- ✅ **Ensemble Diversity** _(NEAT-AI extension)_: `EnsembleDiversityConfig`
+  scores creatures within species by weight variance, squash entropy, and
+  topology diversity to reduce reliance on brilliant-but-brittle solutions.
+- ✅ **Adaptive Quantum Steps** _(NEAT-AI extension)_: `QuantumStepConfig`
+  provides adaptive step sizing during memetic fine-tuning — larger steps when
+  far from the optimum and smaller steps during convergence.
+- ✅ **Unique Activation Functions** _(NEAT-AI extension)_: IF, MAX, MIN, and
+  other non-standard squashes that enable different network behaviours, akin to
+  the broader family of
+  [activation functions](https://en.wikipedia.org/wiki/Activation_function).
+  Standard NEAT typically restricts itself to sigmoid.
+- ✅ **Improved Aggregate Gradient Flow** _(NEAT-AI extension)_: MAXIMUM and
+  MINIMUM aggregate functions distribute partial error signals to runner-up
+  connections within a proximity threshold (15%), preventing dead gradient paths
+  while preserving dominance of the winning connection.
+- ✅ **Transfer Learning** _(NEAT-AI extension)_: Checkpoint export/import
+  system with UUID-based neuron and synapse mapping between creatures with
+  different input/output configurations. Supports weight freezing for
+  fine-tuning imported hidden layers and population seeding with pre-trained
+  creatures. Standard NEAT has no transfer-learning concept.
+- ✅ **ONNX Format Export** _(NEAT-AI extension)_: Exports trained creatures to
+  the [ONNX](https://onnx.ai/) binary format for interoperability with standard
+  ML tooling. Converts creature topology to ONNX computational graphs with
   compatibility checking for unsupported features (aggregate functions,
   recurrent connections).
-- ✅ **Hyperparameter Self-Adaptation**: Per-creature evolvable hyperparameters
-  (learning rate, mutation rates, regularisation strength) subject to Gaussian
-  mutation and weighted-average crossover, reducing the need for manual
-  hyperparameter tuning.
-- ✅ **Adaptive Population Sizing**: Automatically adjusts population size based
-  on species diversity metrics—growing the population when diversity is low
-  (premature convergence) and shrinking it during high-diversity stagnation.
-- ✅ **Parallel Batch Creature Evaluation**: Topology-aware grouping clusters
-  same-structure creatures in the evaluation queue to maximise WASM compilation
-  cache hits across workers, with configurable concurrency limits.
-- ✅ **MCMC Mutation Acceptance**: Implements the
-  [Metropolis-Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)
-  criterion for mutation acceptance with adaptive temperature tuning toward the
-  theoretically optimal acceptance rate (~23.4%). Enables escape from local
-  optima early in evolution while promoting convergence later.
-- ✅ **Advanced Breeding Strategies**: Multiple breeding strategies for
-  genetically incompatible creatures, including input-weight cosine similarity
-  for neuron alignment, subgraph transplantation for
+- ✅ **Hyperparameter Self-Adaptation** _(NEAT-AI extension)_: Per-creature
+  evolvable hyperparameters (learning rate, mutation rates, regularisation
+  strength) subject to Gaussian mutation and weighted-average crossover,
+  reducing the need for manual hyperparameter tuning.
+- ✅ **Adaptive Population Sizing** _(NEAT-AI extension)_: Automatically adjusts
+  population size based on species diversity metrics — growing the population
+  when diversity is low (premature convergence) and shrinking it during
+  high-diversity stagnation.
+- ✅ **Parallel Batch Creature Evaluation** _(NEAT-AI extension)_:
+  Topology-aware grouping clusters same-structure creatures in the evaluation
+  queue to maximise WASM compilation cache hits across workers, with
+  configurable concurrency limits.
+- ✅ **Advanced Breeding Strategies** _(NEAT-AI extension)_: Multiple breeding
+  strategies for genetically incompatible creatures, including input-weight
+  cosine similarity for neuron alignment, subgraph transplantation for
   [horizontal gene transfer](https://en.wikipedia.org/wiki/Horizontal_gene_transfer),
-  and diversity-driven breeding for cross-population pairing.
-- ✅ **Synthetic Synapse Training**: Temporarily densifies inter-layer
-  connectivity during backpropagation by adding zero-weight synapses between
-  adjacent topological layers, then prunes near-zero connections after training
-  — addressing NEAT's inherent sparse connectivity weakness.
-- ✅ **WASM Panic Recovery**: Graceful handling of WASM unreachable panics
-  during evolution. Creatures that trigger WASM traps are excluded from the
-  population without crashing the worker or evolution loop, enabling robust
-  long-running training.
-- ✅ **Forward-Only Topology Enforcement**: Unconditional topology validation
-  after creature initialisation, with DEBUG-gated assertions after bulk neuron
-  remapping operations, ensuring backward synapses cannot silently corrupt
-  forward-only creatures.
-- ✅ **Numerical Stability**: Unbounded activation functions (TAN, SQUARE, CUBE)
-  are clamped to finite ranges in both TypeScript and Rust WASM implementations,
-  preventing numerical overflow from producing extreme scores.
-- ✅ **Fitness Sharing and Per-Species Breeding Quotas**: Standard NEAT fitness
-  sharing divides raw fitness by species size so dominant species don't starve
-  smaller niches. Per-species breeding quotas guarantee each surviving species a
-  minimum number of breeding slots (`FitnessSharingConfig`, enabled by default).
-- ✅ **Stagnant Species Detection and Retirement**: Species that fail to improve
-  their best raw fitness across a sliding window are first halted (50% breeding
-  reduction) and then made extinct, reclaiming breeding slots for progressing
-  species. Configurable via `SpeciesStagnationConfig` (`haltWindow`,
-  `extinctionWindow`).
-- ✅ **Soft Compatibility-Gated Cross-Species Breeding**: Replaces hard
-  lowest-compatibility father selection with a soft probabilistic gate that
-  accepts candidates with probability `compatibility ^ power`, preserving rare
-  exploratory hybrids while favouring similar architectures
+  and diversity-driven breeding for cross-population pairing. Standard NEAT
+  refuses crossover between incompatible parents.
+- ✅ **WASM Panic Recovery** _(NEAT-AI extension)_: Graceful handling of WASM
+  unreachable panics during evolution. Creatures that trigger WASM traps are
+  excluded from the population without crashing the worker or evolution loop,
+  enabling robust long-running training.
+- ✅ **Forward-Only Topology Enforcement** _(NEAT-AI extension)_: Unconditional
+  topology validation after creature initialisation, with DEBUG-gated assertions
+  after bulk neuron remapping operations, ensuring backward synapses cannot
+  silently corrupt forward-only creatures.
+- ✅ **Numerical Stability** _(NEAT-AI extension)_: Unbounded activation
+  functions (TAN, SQUARE, CUBE) are clamped to finite ranges in both TypeScript
+  and Rust WASM implementations, preventing numerical overflow from producing
+  extreme scores.
+- ✅ **Per-Species Breeding Quotas** _(NEAT-AI extension)_: On top of standard
+  NEAT fitness sharing, per-species breeding quotas guarantee each surviving
+  species a minimum number of breeding slots (`FitnessSharingConfig`, enabled by
+  default).
+- ✅ **Stagnant Species Detection and Retirement** _(NEAT-AI extension)_:
+  Species that fail to improve their best raw fitness across a sliding window
+  are first halted (50% breeding reduction) and then made extinct, reclaiming
+  breeding slots for progressing species. Configurable via
+  `SpeciesStagnationConfig` (`haltWindow`, `extinctionWindow`).
+- ✅ **Soft Compatibility-Gated Cross-Species Breeding** _(NEAT-AI extension)_:
+  Replaces hard lowest-compatibility father selection with a soft probabilistic
+  gate that accepts candidates with probability `compatibility ^ power`,
+  preserving rare exploratory hybrids while favouring similar architectures
   (`CompatibilityGatingConfig`, enabled by default).
-- ✅ **Fitness-Driven Squash Mutation**: Squash function selection during
-  mutation is biased toward activations that historically improved fitness in
-  similar neuron roles (layer depth + fan-in bucket). Uses EMA-smoothed fitness
-  deltas with Boltzmann-weighted selection (`SquashEffectivenessConfig`, enabled
-  by default).
-- ✅ **DNA-Sharing Primitives**: A bake-off harness compares strategies for
-  transferring useful structure between unrelated creatures. The current
-  recommended primitive is `PruningTemplateStrategy`, which uses an oracle
-  creature ("Europa") to identify and remove redundant production neurons via
-  activation-fingerprint correlation. Additional primitives include
-  `KnowledgeDistillation` (small student pathway trained to imitate donor
-  behaviour), `CompactModuleGraft` (graft 6–32 neuron dense modules preserving
-  donor UUIDs), and `KnobTuningStrategy` (baseline preset stamping). See
+- ✅ **Fitness-Driven Squash Mutation** _(NEAT-AI extension)_: Squash function
+  selection during mutation is biased toward activations that historically
+  improved fitness in similar neuron roles (layer depth + fan-in bucket). Uses
+  EMA-smoothed fitness deltas with Boltzmann-weighted selection
+  (`SquashEffectivenessConfig`, enabled by default).
+- ✅ **DNA-Sharing Primitives** _(NEAT-AI extension)_: A bake-off harness
+  compares strategies for transferring useful structure between unrelated
+  creatures. The current recommended primitive is `PruningTemplateStrategy`,
+  which uses an oracle creature ("Europa") to identify and remove redundant
+  production neurons via activation-fingerprint correlation. Additional
+  primitives include `KnowledgeDistillation` (small student pathway trained to
+  imitate donor behaviour), `CompactModuleGraft` (graft 6–32 neuron dense
+  modules preserving donor UUIDs), and `KnobTuningStrategy` (baseline preset
+  stamping). See
   [docs/dna-sharing-bake-off-results.md](./docs/dna-sharing-bake-off-results.md).
-- ✅ **Optional Rust CLI Scorer with WASM Fallback**: Generation scoring can be
-  delegated to an external `rust_scorer` binary for higher throughput
-  (directory/batch mode runs once per generation), with automatic fallback to
-  the in-process WASM scorer when the binary is unavailable or errors out
-  (`RustScorerConfig`, opt-in).
-- ✅ **NEAT-AI-core Pinning and Parity Gate**: Read-heavy and hot-path
-  computations (topology validation/scanning, reverse topological order, cycle
-  detection, the topological backprop loop, and elastic weight distribution) are
-  owned by the external
+- ✅ **Optional Rust CLI Scorer with WASM Fallback** _(NEAT-AI extension)_:
+  Generation scoring can be delegated to an external `rust_scorer` binary for
+  higher throughput (directory/batch mode runs once per generation), with
+  automatic fallback to the in-process WASM scorer when the binary is
+  unavailable or errors out (`RustScorerConfig`, opt-in).
+- ✅ **NEAT-AI-core Pinning and Parity Gate** _(NEAT-AI extension)_: Read-heavy
+  and hot-path computations (topology validation/scanning, reverse topological
+  order, cycle detection, the topological backprop loop, and elastic weight
+  distribution) are owned by the external
   [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) repository,
   pinned by full 40-character SHA in `deno.json`. A parity gate (Issue #2345)
   prevents drift between the in-tree wrappers and the pinned core. There are no
@@ -374,7 +418,7 @@ graph LR
 **Image Reference**:
 [Transformer (machine learning model)](https://en.wikipedia.org/wiki/Transformer_(machine_learning_model))
 
-### 🧬 NEAT Architecture (Our Implementation)
+### 🧬 NEAT-AI Architecture
 
 ```mermaid
 graph LR
@@ -393,10 +437,16 @@ graph LR
     style O fill:#50C878,stroke:#3A9A5C,color:#fff,stroke-width:2px
 ```
 
-> **Key differences:** ✓ Topology evolves during training · ✓ Connections can be
-> added/removed dynamically · ✓ Neurons can be added/pruned automatically · ✓
-> Structure adapts to problem complexity · ✓ No predetermined architecture · ✓
-> Can handle non-differentiable objectives
+> **NEAT-AI vs standard NEAT:** NEAT-AI inherits the evolving-topology core from
+> standard NEAT and adds UUID-keyed input/output neurons (so features can be
+> added without restarting), error-guided structural mutation, MCMC mutation
+> acceptance, gradient-based weight optimisation, and synthetic synapses for
+> temporary densification.
+>
+> **NEAT-AI vs fixed-architecture nets:** ✓ Topology evolves during training · ✓
+> Connections can be added/removed dynamically · ✓ Neurons can be added/pruned
+> automatically · ✓ Structure adapts to problem complexity · ✓ No predetermined
+> architecture · ✓ Can handle non-differentiable objectives.
 
 **Visualisation**: See our
 [interactive visualisation](https://stsoftwareau.github.io/NEAT-AI/index.html)
@@ -429,32 +479,39 @@ graph LR
 - Limited interpretability (black box)
 - Rigid input/output dimensions
 
-### 🧬 NEAT (Our Implementation)
+### 🧬 NEAT-AI
 
-**Training Approach**:
+**Training Approach** (standard NEAT contribution in italics; everything else is
+a NEAT-AI extension):
 
-- **Hybrid Approach**: Combines evolutionary search with backpropagation
-- **Dynamic Architecture**: Structure evolves during training
-- **Genetic Operations**: Mutation, crossover, speciation
-- **Backpropagation**: Gradient-based weight optimisation (fully implemented)
-- **Memetic Learning**: Records and reuses successful weight patterns; on our
-  internal workloads this hybrid step has often converged faster than pure
-  backpropagation in practice
+- _Genetic operations: mutation, crossover, speciation (standard NEAT)_
+- **Hybrid Approach**: combines evolutionary search with backpropagation —
+  standard NEAT has no gradient step
+- **Dynamic Architecture**: structure evolves during training (inherits standard
+  NEAT's evolving topology)
+- **Backpropagation**: gradient-based weight optimisation (fully implemented;
+  not present in standard NEAT)
+- **Memetic Learning**: records and reuses successful weight patterns; on
+  NEAT-AI's internal workloads this hybrid step has often converged faster than
+  pure backpropagation in practice
 - **Error-Guided Discovery**: GPU-accelerated structural hints based on error
-  analysis
-- **Population-Based**: Evolves multiple networks simultaneously
-- **Regularisation**: Dropout, L1/L2 weight & bias decay, sparse training,
+  analysis — standard NEAT mutates structure uniformly at random
+- **Population-Based**: evolves multiple networks simultaneously (inherited from
+  standard NEAT)
+- **Regularisation**: dropout, L1/L2 weight & bias decay, sparse training,
   neuron pruning, and cost-of-growth penalty
 - **Cross-Validation**: K-fold validation for robust fitness estimation
-- **Transfer Learning**: Checkpoint export/import with weight freezing for
+- **Transfer Learning**: checkpoint export/import with weight freezing for
   fine-tuning on related tasks
 - **MCMC Mutation Acceptance**: Metropolis-Hastings criterion with adaptive
-  temperature tuning for accepting/rejecting mutations
-- **Synthetic Synapses**: Temporary dense inter-layer connectivity during
+  temperature tuning for accepting/rejecting mutations — standard NEAT accepts
+  all mutations unconditionally
+- **Synthetic Synapses**: temporary dense inter-layer connectivity during
   backpropagation, pruned after training
-- **Advanced Breeding**: Input-weight crossover, subgraph transplantation
+- **Advanced Breeding**: input-weight crossover, subgraph transplantation
   (horizontal gene transfer), diversity-driven breeding, and cosine similarity
-  neuron alignment for genetically incompatible creatures
+  neuron alignment for genetically incompatible creatures — standard NEAT
+  refuses crossover between incompatible parents
 
 **Strengths**:
 
@@ -483,17 +540,18 @@ learning (RL): each creature is a candidate policy, and the rollout score
 (cumulative reward, optionally with shaping penalties) is its fitness. Compared
 to value-based RL ([DQN](https://www.nature.com/articles/nature14236)) and
 policy-gradient methods ([PPO](https://arxiv.org/abs/1707.06347), REINFORCE),
-NEAT does not learn a value function and does not differentiate through the
-policy — it evolves the network's topology and weights directly against a scalar
-episode score. This means the reward can be sparse, discontinuous, or provided
-only by a black-box simulator; the action decoder need not be differentiable;
-and the policy architecture grows with the task instead of being chosen up
-front. The cost is sample efficiency per environment step — when a dense,
-differentiable reward is available, DQN or PPO usually converge in fewer
-simulator steps. Where NEAT wins is in parallelism (rollouts are embarrassingly
-parallel across the population) and robustness to non-differentiable objectives.
-The streaming primitive is `Creature.activate`, called once per simulator tick;
-the canonical episode-rollout loop and worked-example link are documented in
+NEAT-AI (like standard NEAT) does not learn a value function and does not
+differentiate through the policy — both evolve the network's topology and
+weights directly against a scalar episode score. This means the reward can be
+sparse, discontinuous, or provided only by a black-box simulator; the action
+decoder need not be differentiable; and the policy architecture grows with the
+task instead of being chosen up front. The cost is sample efficiency per
+environment step — when a dense, differentiable reward is available, DQN or PPO
+usually converge in fewer simulator steps. Where NEAT-AI wins is in parallelism
+(rollouts are embarrassingly parallel across the population) and robustness to
+non-differentiable objectives. The streaming primitive is `Creature.activate`,
+called once per simulator tick; the canonical episode-rollout loop and
+worked-example link are documented in
 [`docs/REINFORCEMENT_LEARNING.md`](./docs/REINFORCEMENT_LEARNING.md).
 
 ## ✨ Our Unique Approaches
@@ -599,8 +657,9 @@ best-of-breed creatures combined on a central controller.
 - Controller combines populations and redistributes
 - Enables scaling beyond single-machine constraints
 
-**Why It's Unique**: Most NEAT implementations are single-machine. Our
-distributed approach enables larger populations and faster evolution.
+**Why It's Unique**: Standard NEAT and most NEAT-derived implementations are
+single-machine. NEAT-AI's distributed approach enables larger populations and
+faster evolution.
 
 **Reference**: See Feature #2 in [README.md](./README.md)
 
@@ -657,7 +716,7 @@ Hebbian learning rules.
    prediction weights
 
 **Why It's Unique**: Predictive coding uses only local information for learning
-(pre- and post-synaptic activity), which aligns naturally with NEAT's
+(pre- and post-synaptic activity), which aligns naturally with NEAT-AI's
 neuron-centric topology. It provides an alternative to standard backpropagation
 that may generalise differently on certain problem types.
 
@@ -710,10 +769,10 @@ acceptance of all mutations.
    optimal acceptance rate (~23.4%, Roberts et al. 1997) based on a
    rolling-window of recent acceptance decisions
 
-**Why It's Unique**: Standard NEAT implementations accept all mutations
-unconditionally or use simple fitness-based filtering. MCMC acceptance enables
-the population to explore broadly early in evolution (high temperature) and
-converge on good solutions later (low temperature), borrowing from the
+**Why It's Unique**: Standard NEAT accepts all mutations unconditionally; most
+NEAT derivatives use simple fitness-based filtering. NEAT-AI's MCMC acceptance
+enables the population to explore broadly early in evolution (high temperature)
+and converge on good solutions later (low temperature), borrowing from the
 well-studied Markov chain Monte Carlo framework.
 
 **Diversity-Aware Cooling**: Beyond simple cooling, the temperature is also
@@ -762,10 +821,11 @@ creatures that go beyond standard NEAT crossover.
   fitness over a sliding window are halted and ultimately made extinct,
   reclaiming breeding budget for progressing species
 
-**Why It's Unique**: Most NEAT implementations fall back to simple fitness-based
-selection when parents are incompatible. Our approach preserves meaningful
-genetic information across species boundaries, enabling the evolutionary
-benefits of cross-island migration without sacrificing structural integrity.
+**Why It's Unique**: Standard NEAT and most NEAT derivatives fall back to simple
+fitness-based selection when parents are incompatible. NEAT-AI's approach
+preserves meaningful genetic information across species boundaries, enabling the
+evolutionary benefits of cross-island migration without sacrificing structural
+integrity.
 
 **Reference**: See Feature #21 in [README.md](./README.md)
 
@@ -785,11 +845,12 @@ training stability. Inspired by the Muon optimiser used in DeepSeek V4.
 3. The orthogonalised update is then scaled and applied in place of the raw
    gradient.
 
-**Why It's Unique**: Standard backpropagation in NEAT applies raw gradient
-descent (with learning-rate decay and L1/L2 decay). Muon-style updates remove
-correlations between row directions of the per-neuron gradient, which can
-produce smoother, less drift-prone training, particularly for small batch sizes
-typical in evolutionary fitness evaluation.
+**Why It's Unique**: Standard NEAT has no gradient step at all; NEAT-AI's
+default backpropagation already applies raw gradient descent (with learning-rate
+decay and L1/L2 decay). Muon-style updates remove correlations between row
+directions of the per-neuron gradient, which can produce smoother, less
+drift-prone training, particularly for small batch sizes typical in evolutionary
+fitness evaluation.
 
 **Configuration**: Opt-in via `gradientOrthogonalisation: "muon"` in
 `BackPropagationArguments` (default `"none"`).
@@ -800,7 +861,7 @@ applicability notes in [docs/](./docs/).
 ### 12. 🔗 Synthetic Synapse Training
 
 **What It Is**: Temporary dense inter-layer connectivity during backpropagation
-that addresses NEAT's inherent sparse connectivity weakness.
+that addresses the inherent sparse connectivity of NEAT-evolved networks.
 
 **How It Works**:
 
@@ -811,10 +872,10 @@ that addresses NEAT's inherent sparse connectivity weakness.
 3. After training, near-zero synapses are pruned and only connections that
    developed meaningful weights are retained
 
-**Why It's Unique**: NEAT networks are naturally sparse — they start minimal and
-grow only through mutation. This sparsity can limit backpropagation's
-effectiveness because gradient descent can only optimise existing connections.
-Synthetic synapses provide a temporary
+**Why It's Unique**: Standard NEAT (and NEAT-AI before this step) produces
+naturally sparse networks — they start minimal and grow only through mutation.
+This sparsity can limit backpropagation's effectiveness because gradient descent
+can only optimise existing connections. Synthetic synapses provide a temporary
 [layer densification](https://en.wikipedia.org/wiki/Dense_layer) step that lets
 gradient descent discover useful connections that evolution hasn't found yet,
 without permanently inflating the network.
@@ -824,7 +885,7 @@ configuration.
 
 **Reference**: See Feature #22 in [README.md](./README.md)
 
-## 🔬 Ecosystem Comparison: What We've Built vs Standard Libraries
+## 🔬 Ecosystem Comparison: NEAT-AI vs Standard Libraries
 
 ### 📚 Standard ML Libraries (TensorFlow, PyTorch, etc.)
 
@@ -839,41 +900,42 @@ configuration.
 - Pre-trained models (ImageNet, BERT, GPT, etc.)
 - Large community and extensive documentation
 
-**What We've Built Instead**:
+**What NEAT-AI Provides Instead** (standard NEAT contribution noted in italics;
+everything else is a NEAT-AI extension):
 
-- **Evolutionary Architecture Search**: No need to design layers - structure
+- _Genetic operations: speciation, crossover, mutation with historical marking
+  (standard NEAT)_
+- **Evolutionary Architecture Search**: no need to design layers — structure
   evolves
-- **Dynamic Topology**: Networks grow/shrink during training
-- **UUID-Based Extensibility**: Add features without restarting
-- **Memetic Evolution**: Hybrid evolution + backpropagation
+- **Dynamic Topology**: networks grow/shrink during training
+- **UUID-Based Extensibility**: add features without restarting
+- **Memetic Evolution**: hybrid evolution + backpropagation
 - **Error-Guided Discovery**: GPU-accelerated structural hints
-- **Distributed Evolution**: Multi-machine evolution with centralised
+- **Distributed Evolution**: multi-machine evolution with centralised
   combination
 - **Unique Activations**: IF, MAX, MIN and other non-standard functions
-- **Genetic Operations**: Speciation, crossover, mutation with historical
-  marking
 - **MCMC Acceptance**: Metropolis-Hastings mutation acceptance with adaptive
   temperature
-- **Synthetic Synapses**: Temporary dense connectivity for gradient descent
-- **Advanced Breeding**: Multiple strategies for incompatible parent crossover
-- **WASM Resilience**: Graceful panic recovery in long-running evolution
+- **Synthetic Synapses**: temporary dense connectivity for gradient descent
+- **Advanced Breeding**: multiple strategies for incompatible parent crossover
+- **WASM Resilience**: graceful panic recovery in long-running evolution
 
 **Key Differences**:
 
-- **Standard Libraries**: You design the architecture, they handle training
-- **Our Library**: Architecture evolves automatically, we handle both structure
-  and training
-- **Standard Libraries**: Fixed architectures, transfer learning from
+- **Standard Libraries**: you design the architecture, they handle training
+- **NEAT-AI**: architecture evolves automatically; NEAT-AI handles both
+  structure and training
+- **Standard Libraries**: fixed architectures, transfer learning from
   pre-trained models
-- **Our Library**: Dynamic architectures with transfer learning via checkpoint
+- **NEAT-AI**: dynamic architectures with transfer learning via checkpoint
   export/import, and ONNX export for interoperability
 
 **When to Use Each**:
 
-- **Use Standard Libraries**: When you have a proven architecture (CNN for
+- **Use Standard Libraries**: when you have a proven architecture (CNN for
   images, Transformer for language), need pre-trained models, or want
   industry-standard tooling
-- **Use Our Library**: When you need automatic architecture search, have
+- **Use NEAT-AI**: when you need automatic architecture search, have
   non-differentiable objectives, want to add features incrementally, or need
   lifelong learning
 
@@ -886,7 +948,7 @@ configuration.
 
 ## ⚖️ Pros and Cons Analysis
 
-### 🧬 NEAT (Our Implementation) - Pros
+### 🧬 NEAT-AI - Pros
 
 1. **Automatic Architecture Search**: No need to manually design network
    topology
@@ -938,7 +1000,7 @@ configuration.
 20. **External Rust Scorer**: Optional `rust_scorer` CLI for higher
     generation-scoring throughput, with automatic WASM fallback
 
-### 🧬 NEAT (Our Implementation) - Cons
+### 🧬 NEAT-AI - Cons
 
 1. **Computational Cost**: Population-based training requires more resources
 2. **Slower Convergence**: Evolutionary search is slower than pure gradient
@@ -950,11 +1012,11 @@ configuration.
 4. **Sequential Processing**: Less efficient for pure parallel computation than
    fixed architectures, though topology-aware parallel batch evaluation helps
 5. **Limited Unsupervised Learning**: While evolution itself doesn't require
-   labelled data for the algorithm, NEAT is typically used for supervised
-   learning tasks where you need labelled data to compute fitness. True
-   unsupervised learning (clustering, autoencoders, generative models) is not
-   yet implemented. See [Unsupervised Learning](#unsupervised-learning) section
-   for clarification.
+   labelled data for the algorithm, NEAT-AI (like standard NEAT) is typically
+   used for supervised learning tasks where you need labelled data to compute
+   fitness. True unsupervised learning (clustering, autoencoders, generative
+   models) is not yet implemented. See
+   [Unsupervised Learning](#unsupervised-learning) section for clarification.
 6. **Hyperparameter Sensitivity**: Many parameters to tune, though our
    implementation now addresses this with per-creature hyperparameter
    self-adaptation (evolvable learning rate, mutation rates, and regularisation
@@ -1056,9 +1118,10 @@ across related tasks with different input/output configurations.
 #### 2. 🔓 Unsupervised Learning
 
 **Current State**: While evolution itself doesn't require labelled data for the
-algorithm to work, NEAT is typically used for supervised learning tasks where
-you need labelled data to compute fitness scores. True unsupervised learning
-(learning patterns from unlabelled data) is not yet implemented.
+algorithm to work, both standard NEAT and NEAT-AI are typically used for
+supervised learning tasks where you need labelled data to compute fitness
+scores. True unsupervised learning (learning patterns from unlabelled data) is
+not yet implemented in NEAT-AI.
 
 > [!NOTE]
 > Evolution is "unsupervised" in the sense that the algorithm doesn't need
@@ -1475,31 +1538,32 @@ support exists via the `feedbackLoop` configuration.
 
 ## 🏁 Conclusion
 
-NEAT offers unique advantages in automatic architecture search and adaptive
-learning, but historically suffered from computational inefficiency and
-scalability limitations. Our implementation addresses many of these through
-cross-platform GPU acceleration, memetic evolution, error-guided discovery with
-intelligent caching, predictive coding, per-creature hyperparameter
-self-adaptation, comprehensive regularisation (dropout, L1/L2 weight & bias
-decay), transfer learning via checkpoint export/import and DNA-sharing
-primitives (pruning template, knowledge distillation, compact module graft),
-ONNX format export, k-fold cross-validation, parallel batch creature evaluation,
-MCMC mutation acceptance with adaptive temperature tuning and diversity-aware
-reheating, optional Muon-style orthogonalised gradient updates, synthetic
-synapse training for temporary layer densification, advanced inter-species
-breeding strategies (input-weight crossover, subgraph transplantation,
-diversity-driven breeding, soft compatibility gating), fitness sharing with
-per-species breeding quotas and stagnant-species retirement, fitness-driven
-squash mutation, an optional external Rust CLI scorer with WASM fallback, a
-pinned NEAT-AI-core dependency with parity-gated WASM-only hot paths, graceful
-WASM panic recovery for resilient long-running training, and forward-only
-topology enforcement for structural integrity. Remaining gaps in unsupervised
-learning and attention mechanisms represent opportunities for future
-development.
+Standard NEAT offers unique advantages in automatic architecture search and
+adaptive learning, but historically suffered from computational inefficiency and
+scalability limitations. NEAT-AI inherits the standard-NEAT substrate
+(evolutionary topology search, speciation, historical marking, fitness sharing)
+and addresses many of those limitations through cross-platform GPU acceleration,
+memetic evolution, error-guided discovery with intelligent caching, predictive
+coding, per-creature hyperparameter self-adaptation, comprehensive
+regularisation (dropout, L1/L2 weight & bias decay), transfer learning via
+checkpoint export/import and DNA-sharing primitives (pruning template, knowledge
+distillation, compact module graft), ONNX format export, k-fold
+cross-validation, parallel batch creature evaluation, MCMC mutation acceptance
+with adaptive temperature tuning and diversity-aware reheating, optional
+Muon-style orthogonalised gradient updates, synthetic synapse training for
+temporary layer densification, advanced inter-species breeding strategies
+(input-weight crossover, subgraph transplantation, diversity-driven breeding,
+soft compatibility gating), per-species breeding quotas and stagnant-species
+retirement, fitness-driven squash mutation, an optional external Rust CLI scorer
+with WASM fallback, a pinned NEAT-AI-core dependency with parity-gated WASM-only
+hot paths, graceful WASM panic recovery for resilient long-running training, and
+forward-only topology enforcement for structural integrity. Remaining gaps in
+unsupervised learning and attention mechanisms represent opportunities for
+future development.
 
-The choice between NEAT and traditional neural networks depends on:
+The choice between NEAT-AI and traditional neural networks depends on:
 
-- **Use NEAT when**:
+- **Use NEAT-AI when**:
   - You need automatic architecture search
   - You have non-differentiable objectives
   - You require lifelong learning
@@ -1513,7 +1577,7 @@ The choice between NEAT and traditional neural networks depends on:
   - You need maximum scalability (billions of parameters)
   - You want industry-standard tooling
 
-Our implementation bridges these worlds, making NEAT more practical while
+NEAT-AI bridges these worlds, making the NEAT idea more practical while
 preserving its unique advantages. The hybrid approach of evolution +
 backpropagation, combined with memetic learning, error-guided discovery,
 transfer learning, ONNX interoperability, MCMC acceptance, synthetic synapse

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,15 @@
 # 🤝 Contributing to NEAT-AI
 
-Thank you for your interest in contributing to NEAT-AI (NeuroEvolution of
-Augmenting Topologies — Artificial Intelligence)! This guide covers everything
-you need to get started — from setting up your development environment to
-submitting a pull request.
+Thank you for your interest in contributing to
+[NEAT-AI](./AGENTS.md#-terminology) (NeuroEvolution of Augmenting Topologies —
+Artificial Intelligence)! This guide covers everything you need to get started —
+from setting up your development environment to submitting a pull request.
+
+> [!IMPORTANT]
+> **NEAT** refers to the original 2002 algorithm; **NEAT-AI** refers to this
+> project, which extends it. See the
+> [NEAT vs NEAT-AI rule](./AGENTS.md#-neat-vs-neat-ai--which-term-to-use) for
+> the convention used throughout this repository.
 
 ## 📌 Summary and where to go next
 
@@ -508,7 +514,7 @@ src/                    # Source code
   intelligentDesign/    # Intelligent Design squash optimisation
   methods/              # Activation functions (squash implementations)
   mutate/               # Mutation operators
-  NEAT/                 # Core NEAT algorithm
+  NEAT/                 # Core NEAT-AI evolutionary loop (selection, speciation)
   propagate/            # Backpropagation
   wasm/                 # WASM activation bridge
 test/                   # Tests (mirrors src/ structure)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
-# 🧬 NEAT Neural Network for DenoJS
+# 🧬 NEAT-AI Neural Network for DenoJS
 
 <p align="left">
   <img width="100" height="100" src="docs/logo.png" align="right" alt="NEAT-AI logo">
-This project is a practical implementation of a neural network based on the NEAT (NeuroEvolution of Augmenting Topologies) algorithm, written in DenoJS using TypeScript, with additional features such as error-guided discovery, memetic evolution, and distributed workflows.
+<strong>NEAT-AI</strong> started from <strong>NEAT</strong> — the
+NeuroEvolution of Augmenting Topologies algorithm published by
+<a href="http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf">Stanley &amp; Miikkulainen (2002)</a>
+— and has grown into a hybrid evolutionary plus gradient-based system, written
+in DenoJS using TypeScript. NEAT-AI keeps the speciation and structure-mutation
+ideas from standard NEAT but layers on much more recent research: memetic
+evolution, error-guided <strong>Discovery</strong>, Markov Chain Monte Carlo
+(MCMC) mutation acceptance, synthetic synapses, predictive coding, Muon-style
+orthogonalised gradients, and other algorithms (some published only weeks
+before this paragraph was written).
 </p>
+
+> [!IMPORTANT]
+> **NEAT** refers to the original 2002 algorithm. **NEAT-AI** refers to this
+> project — they are no longer the same thing. See the
+> [NEAT vs NEAT-AI terminology rule in AGENTS.md](./AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> for the convention used throughout this repository.
 
 For project terminology, coding conventions, and development guidelines, see
 [AGENTS.md](./AGENTS.md).
@@ -18,8 +33,8 @@ New here? Skim this section first; every topic guide is one link away.
   how to bump the pinned NEAT-AI-core revision.
 - **[AGENTS.md](./AGENTS.md)** — terminology and coding conventions for human
   and AI contributors.
-- **[COMPARISON.md](./COMPARISON.md)** — how NEAT compares to other AI
-  approaches.
+- **[COMPARISON.md](./COMPARISON.md)** — how NEAT-AI compares to other AI
+  approaches (and to standard NEAT).
 - **Topic guides** — quick jumps to the most-used docs:
   - Compute / WebAssembly (WASM):
     [Activation Functions](./docs/ACTIVATION_FUNCTIONS.md),
@@ -45,10 +60,10 @@ New here? Skim this section first; every topic guide is one link away.
 
 ## 🏗️ High-level architecture
 
-A creature is a NEAT genome that mutates and breeds in TypeScript, then runs its
-forward pass inside a vendored WebAssembly (WASM) module. When the optional Rust
-extension is present, error-guided structural proposals come back over a Foreign
-Function Interface (FFI) call.
+A creature is a NEAT-AI genome that mutates and breeds in TypeScript, then runs
+its forward pass inside a vendored WebAssembly (WASM) module. When the optional
+Rust extension is present, error-guided structural proposals come back over a
+Foreign Function Interface (FFI) call.
 
 ```mermaid
 flowchart LR
@@ -66,6 +81,11 @@ See [docs/DISCOVERY_ARCHITECTURE.md](./docs/DISCOVERY_ARCHITECTURE.md) for the
 full pipeline.
 
 ## ✨ Feature Highlights
+
+The list below describes **NEAT-AI** behaviour. Many entries — memetic
+evolution, error-guided Discovery, MCMC mutation acceptance, synthetic synapses,
+ONNX export — are extensions beyond the standard NEAT algorithm. See
+[COMPARISON.md](./COMPARISON.md) for the side-by-side picture.
 
 1. **Extendable Observations**: Input and output features are identified by
    stable UUIDs in the exported representation, rather than only by positional
@@ -246,8 +266,8 @@ For detailed documentation, see the [docs/](./docs/) directory:
 
 ### 🧠 Core Concepts
 
-- **[COMPARISON.md](./COMPARISON.md)**: How NEAT compares to traditional neural
-  networks, CNNs, RNNs, and modern LLMs
+- **[COMPARISON.md](./COMPARISON.md)**: How NEAT-AI compares to standard NEAT,
+  traditional neural networks, CNNs, RNNs, and modern LLMs
 - **[Discovery Guide](./docs/DISCOVERY_GUIDE.md)**: Complete guide to
   distributed, multi-machine discovery workflows, including failure/success
   caches, replay, candidate category limits, focus overrides, and the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## 📌 Summary
 
-This document describes how to **report a vulnerability** in NEAT-AI
-(NeuroEvolution of Augmenting Topologies — Artificial Intelligence) and what
-response you can expect. Routine code-review hygiene (input validation,
-parameterised queries, secret handling) is enforced via the **`/security-review`
-Claude Code skill** that contributors run before opening a PR (see the
-secure-coding principles section of [`AGENTS.md`](./AGENTS.md)) and the in-repo
-automation listed below:
+This document describes how to **report a vulnerability** in
+[NEAT-AI](./AGENTS.md#-terminology) (NeuroEvolution of Augmenting Topologies —
+Artificial Intelligence) and what response you can expect. Routine code-review
+hygiene (input validation, parameterised queries, secret handling) is enforced
+via the **`/security-review` Claude Code skill** that contributors run before
+opening a PR (see the secure-coding principles section of
+[`AGENTS.md`](./AGENTS.md)) and the in-repo automation listed below:
 
 - **Dependency review** — every PR is scanned by
   [`actions/dependency-review-action`](https://github.com/actions/dependency-review-action)

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/ACTIVATION_FUNCTIONS.md
+++ b/docs/ACTIVATION_FUNCTIONS.md
@@ -1,13 +1,13 @@
 # ⚡ Activation Functions Guide
 
-> **TL;DR** — A **squash** function (NEAT-AI's name for an activation function)
-> is the small per-neuron non-linearity that turns a neuron's pre-activation sum
-> `v = b + Σ(wᵢ·aᵢ)` into its output. NEAT-AI ships 32 standard squashes, 3
-> aggregate functions, and 3 deprecated squashes kept only for backward
-> compatibility — every name in the tables below resolves to a real export under
-> [`src/methods/activations/`](../src/methods/activations/) (or
-> [`src/deprecated/`](../src/deprecated/) for the deprecated set). This guide
-> explains how to pick one. Acronyms used here: **ReLU** (Rectified Linear
+> **TL;DR** — A **squash** function ([NEAT-AI](../AGENTS.md#-terminology)'s name
+> for an activation function) is the small per-neuron non-linearity that turns a
+> neuron's pre-activation sum `v = b + Σ(wᵢ·aᵢ)` into its output. NEAT-AI ships
+> 32 standard squashes, 3 aggregate functions, and 3 deprecated squashes kept
+> only for backward compatibility — every name in the tables below resolves to a
+> real export under [`src/methods/activations/`](../src/methods/activations/)
+> (or [`src/deprecated/`](../src/deprecated/) for the deprecated set). This
+> guide explains how to pick one. Acronyms used here: **ReLU** (Rectified Linear
 > Unit), **GELU** (Gaussian Error Linear Unit), **ELU** (Exponential Linear
 > Unit), **SELU** (Scaled ELU), **TANH** (hyperbolic tangent), **NaN** (Not a
 > Number).
@@ -38,8 +38,8 @@ introduce non-linearity, enabling the network to learn complex patterns.
 
 In NEAT-AI, each neuron can have its own activation function. This is more
 flexible than traditional neural networks, where all neurons in a layer
-typically share the same function. NEAT's topology evolution can discover which
-activation works best for each neuron's role in the network.
+typically share the same function. NEAT-AI's topology evolution can discover
+which activation works best for each neuron's role in the network.
 
 ### 📖 Key Terms
 
@@ -61,7 +61,7 @@ activation works best for each neuron's role in the network.
 ## 📊 Overview Table
 
 The table below lists every activation function available in NEAT-AI. **Mutation
-probability** controls how often NEAT's evolution selects a function when
+probability** controls how often NEAT-AI's evolution selects a function when
 mutating neurons — higher values mean the function is chosen more frequently.
 
 ### ⚡ Standard Activation Functions
@@ -114,15 +114,15 @@ activation functions that transform a single value.
 
 ### 🗄️ Deprecated Functions
 
-These functions have a mutation probability of **0**, meaning NEAT will never
+These functions have a mutation probability of **0**, meaning NEAT-AI will never
 select them for new neurons. They remain available for backward compatibility
 with existing trained models.
 
 > [!WARNING]
 > The deprecated functions below (HYPOT, HYPOTv2, MEAN) will never be assigned
-> to neurons by NEAT's evolution. If you load a model that uses them, they will
-> continue to function correctly, but you should plan to migrate away from them
-> in future training runs.
+> to neurons by NEAT-AI's evolution. If you load a model that uses them, they
+> will continue to function correctly, but you should plan to migrate away from
+> them in future training runs.
 
 | Name                                    | Output Range | Replacement                | Why Deprecated                                      |
 | :-------------------------------------- | :----------- | :------------------------- | :-------------------------------------------------- |
@@ -312,34 +312,34 @@ network while introducing useful non-linearity.
 | Exponential    | Output grows rapidly, can cause overflow            |
 | SQRT / SQUARE  | Limited applicability, can cause numerical issues   |
 
-### 🧬 Functions That Work Well with NEAT's Topology Evolution
+### 🧬 Functions That Work Well with NEAT-AI's Topology Evolution
 
-NEAT evolves both the network's structure (topology) and its weights
+NEAT-AI evolves both the network's structure (topology) and its weights
 simultaneously. Some activation functions are better suited to this evolutionary
 process than others.
 
-**Best for NEAT evolution:**
+**Best for NEAT-AI evolution:**
 
 - **LeakyReLU, GELU, Swish, ELU, SELU, Mish** — These have high mutation
-  probabilities (31-36), meaning NEAT's evolution naturally favours them. They
-  provide smooth gradients that help memetic learning (the gradient-based
+  probabilities (31-36), meaning NEAT-AI's evolution naturally favours them.
+  They provide smooth gradients that help memetic learning (the gradient-based
   fine-tuning that happens alongside evolution) while being robust enough to
-  handle the varied topologies that NEAT generates.
+  handle the varied topologies that NEAT-AI generates.
 
 - **TANH, LOGISTIC, Softplus** — Bounded functions that prevent activation
-  values from exploding as NEAT adds new connections. Useful when the network
+  values from exploding as NEAT-AI adds new connections. Useful when the network
   grows and you want stable activations.
 
-**Challenging for NEAT evolution:**
+**Challenging for NEAT-AI evolution:**
 
 - **STEP, BIPOLAR** — These have zero gradients almost everywhere, which means
   memetic learning (backpropagation) cannot improve weights. Evolution must rely
   entirely on mutation and crossover, which is slower.
 
 - **TAN, Exponential** — Can produce extreme values that destabilise the network
-  when NEAT adds unexpected connections.
+  when NEAT-AI adds unexpected connections.
 
-- **IDENTITY** — Provides no non-linearity, so NEAT cannot increase the
+- **IDENTITY** — Provides no non-linearity, so NEAT-AI cannot increase the
   network's expressiveness by adding neurons with this function.
 
 ---
@@ -374,7 +374,7 @@ tests alternatives and remembers what works.
 
 | Scenario                             | Approach                                                               |
 | :----------------------------------- | :--------------------------------------------------------------------- |
-| Starting a new project               | Let NEAT evolve freely, then run Intelligent Design to refine          |
+| Starting a new project               | Let NEAT-AI evolve freely, then run Intelligent Design to refine       |
 | Optimising a mature model            | Use Intelligent Design to squeeze out improvements                     |
 | You know the ideal output function   | Set output layer manually, let Intelligent Design handle hidden layers |
 | Distributed training across machines | Share tacit knowledge via hive files for consistent optimisation       |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,9 @@
 # 📖 NEAT-AI API Reference
 
-Comprehensive reference for the public API exported from `mod.ts`.
+Comprehensive reference for the public API exported from `mod.ts`. For project
+terminology — including the distinction between
+[NEAT and NEAT-AI](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) — see
+[`AGENTS.md`](../AGENTS.md#-terminology).
 
 All imports use the single entry point:
 
@@ -38,7 +41,7 @@ import { Costs, Creature, Mutation, Selection } from "@stsoftware/neat-ai";
 
 ### 🐛 Creature
 
-The central class representing a neural network (genome) in NEAT.
+The central class representing a neural network (genome) in NEAT-AI.
 
 ```typescript
 import { Creature } from "@stsoftware/neat-ai";
@@ -179,7 +182,7 @@ interface CrisprInterface {
 
 ### ⚙️ NeatOptions
 
-The primary configuration type for the NEAT algorithm. Passed to
+The primary configuration type for the NEAT-AI evolutionary loop. Passed to
 `Creature.evolveDir()`.
 
 ```typescript
@@ -527,7 +530,7 @@ creature.activate(input);
 
 ## 6. 🧬 Evolution API
 
-The main entry point for NEAT evolution.
+The main entry point for NEAT-AI evolution.
 
 ### 🔄 Creature.evolveDir()
 
@@ -1222,9 +1225,9 @@ const population = createSeededPopulation({
 
 ## 17. 📤 ONNX Export
 
-Issue #1866: Export trained NEAT creatures to the [ONNX](https://onnx.ai/) (Open
-Neural Network Exchange) format for deployment in standard ML pipelines. The
-exported model produces identical outputs to the original creature (within
+Issue #1866: Export trained NEAT-AI creatures to the [ONNX](https://onnx.ai/)
+(Open Neural Network Exchange) format for deployment in standard ML pipelines.
+The exported model produces identical outputs to the original creature (within
 floating-point precision).
 
 ```typescript
@@ -1275,11 +1278,12 @@ Deno.writeFileSync("model.onnx", onnxBytes);
 
 ## 18. 🧪 Synthetic Synapses
 
-Issue #1919: Synthetic synapses address a key weakness of NEAT's incremental
-topology growth — newly evolved networks often have sparse inter-layer
-connectivity compared to conventional dense neural networks. Synthetic synapses
-temporarily densify the network during backpropagation, giving gradient descent
-a richer search space to discover useful connections.
+Issue #1919: Synthetic synapses address a key weakness of standard NEAT's
+incremental topology growth — newly evolved networks often have sparse
+inter-layer connectivity compared to conventional dense neural networks. NEAT-AI
+adds synthetic synapses to temporarily densify the network during
+backpropagation, giving gradient descent a richer search space to discover
+useful connections.
 
 ### Lifecycle
 

--- a/docs/BACKPROP_ELASTICITY.md
+++ b/docs/BACKPROP_ELASTICITY.md
@@ -1,14 +1,15 @@
 # 🔄 Elastic Back Propagation
 
-> **TL;DR** — NEAT-AI's backpropagation does not blindly apply the chain rule
-> everywhere. It (a) computes a target pre-squash value for each neuron, (b)
-> distributes the required change across inbound weights using a minimum-change
-> heuristic weighted by `activationᵢ² × safeZoneFactorᵢ`, and (c) refuses to
-> push neurons that are already saturated further into saturation. The
-> topological backprop loop and the elastic distribution kernel both live in
-> WebAssembly (WASM) — there is no TypeScript fallback. Acronyms used here:
-> **WASM** (WebAssembly), **ReLU** (Rectified Linear Unit), **TANH** (hyperbolic
-> tangent), **MCMC** (Markov-chain Monte Carlo).
+> **TL;DR** — [NEAT-AI](../AGENTS.md#-terminology)'s backpropagation does not
+> blindly apply the chain rule everywhere. It (a) computes a target pre-squash
+> value for each neuron, (b) distributes the required change across inbound
+> weights using a minimum-change heuristic weighted by
+> `activationᵢ² × safeZoneFactorᵢ`, and (c) refuses to push neurons that are
+> already saturated further into saturation. The topological backprop loop and
+> the elastic distribution kernel both live in WebAssembly (WASM) — there is no
+> TypeScript fallback. Acronyms used here: **WASM** (WebAssembly), **ReLU**
+> (Rectified Linear Unit), **TANH** (hyperbolic tangent), **MCMC** (Markov-chain
+> Monte Carlo).
 
 ## 🔗 Sibling docs in the **Compute / WASM** cluster
 

--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -1,9 +1,10 @@
 # ⚙️ Configuration Guide
 
-This page is the topic index for NEAT-AI (NeuroEvolution of Augmenting
-Topologies — Artificial Intelligence) configuration. The full surface lives in
-topic detail docs under [`docs/config/`](./config/), grouped by configuration
-domain to mirror the structure of `src/config/`.
+This page is the topic index for [NEAT-AI](../AGENTS.md#-terminology)
+(NeuroEvolution of Augmenting Topologies — Artificial Intelligence)
+configuration. The full surface lives in topic detail docs under
+[`docs/config/`](./config/), grouped by configuration domain to mirror the
+structure of `src/config/`.
 
 Configuration is passed via `NeatOptionsInput` to `createNeatConfig()`, which
 validates, parses, and freezes the result into a read-only `NeatConfig`. Numeric

--- a/docs/CRISPR_GUIDE.md
+++ b/docs/CRISPR_GUIDE.md
@@ -4,12 +4,12 @@
 > real-world gene-editing technique
 > ([Wikipedia](https://en.wikipedia.org/wiki/CRISPR),
 > [Nature primer](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/)).
-> In NEAT-AI we borrow the name for **targeted, hand-crafted edits to a
-> creature's genome** — splicing in new neurons or wrapping existing outputs
-> with extra activation/aggregation layers — without disturbing the UUIDs of
-> neurons that survive the edit. The implementation lives in
-> [`src/reconstruct/CRISPR.ts`](../src/reconstruct/CRISPR.ts); the API surface
-> is summarised in [`docs/api/CREATURE.md`](api/CREATURE.md#-crispr).
+> In [NEAT-AI](../AGENTS.md#-terminology) we borrow the name for **targeted,
+> hand-crafted edits to a creature's genome** — splicing in new neurons or
+> wrapping existing outputs with extra activation/aggregation layers — without
+> disturbing the UUIDs of neurons that survive the edit. The implementation
+> lives in [`src/reconstruct/CRISPR.ts`](../src/reconstruct/CRISPR.ts); the API
+> surface is summarised in [`docs/api/CREATURE.md`](api/CREATURE.md#-crispr).
 
 This guide complements that API summary with the conventions and gotchas that
 catch out new authors. For the project-wide vocabulary that places CRISPR

--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -1,11 +1,11 @@
 # 🔍 Discovery: Continuous Incremental Improvement
 
-> **Summary** — Discovery is the user-facing entry point to NEAT-AI's
-> error-guided structural evolution. It runs as a continuous loop, fetching the
-> current best creature, asking the Rust extension via the Foreign Function
-> Interface (FFI) to propose small structural changes, and checking improvements
-> back into a shared pool. This guide covers configuration, distributed setup,
-> and best practices. For internals see
+> **Summary** — Discovery is the user-facing entry point to
+> [NEAT-AI](../AGENTS.md#-terminology)'s error-guided structural evolution. It
+> runs as a continuous loop, fetching the current best creature, asking the Rust
+> extension via the Foreign Function Interface (FFI) to propose small structural
+> changes, and checking improvements back into a shared pool. This guide covers
+> configuration, distributed setup, and best practices. For internals see
 > [DISCOVERY_ARCHITECTURE.md](DISCOVERY_ARCHITECTURE.md); for the
 > `discoveryDir()` Application Programming Interface (API) and on-disk layout
 > see [DISCOVERY_DIR.md](DISCOVERY_DIR.md); for Graphics Processing Unit (GPU)

--- a/docs/INTELLIGENT_DESIGN.md
+++ b/docs/INTELLIGENT_DESIGN.md
@@ -200,7 +200,7 @@ workers.forEach((w) => w.terminate());
 | `outputDir`       | string      | Required      | Directory to write improved creatures     |
 | `dataDir`         | string      | Required      | Directory containing scoring data         |
 | `bestScore`       | number      | Required      | Current best score of the creature        |
-| `options`         | NeatOptions | `{}`          | NEAT options (can include customCost)     |
+| `options`         | NeatOptions | `{}`          | NEAT-AI options (can include customCost)  |
 | `maxImprovements` | number      | 12            | Stop after finding this many improvements |
 | `maxPending`      | number      | Auto          | Maximum pending tasks per worker          |
 | `timeoutMs`       | number      | 3600000 (1hr) | Timeout in milliseconds                   |

--- a/docs/PERFORMANCE_RESEARCH.md
+++ b/docs/PERFORMANCE_RESEARCH.md
@@ -1,10 +1,11 @@
 # 🔬 Performance Optimisation Guide
 
-> **Brief**: A research log of every measured attempt to make NEAT-AI faster —
-> what worked, what didn't, and the underlying reasons. Use this guide to decide
-> whether a proposed optimisation (WASM migration, SIMD expansion, algorithmic
-> change) is worth pursuing **before** writing code. For day-to-day operational
-> tuning, see [PERFORMANCE_TUNING.md](./PERFORMANCE_TUNING.md).
+> **Brief**: A research log of every measured attempt to make
+> [NEAT-AI](../AGENTS.md#-terminology) faster — what worked, what didn't, and
+> the underlying reasons. Use this guide to decide whether a proposed
+> optimisation (WASM migration, SIMD expansion, algorithmic change) is worth
+> pursuing **before** writing code. For day-to-day operational tuning, see
+> [PERFORMANCE_TUNING.md](./PERFORMANCE_TUNING.md).
 
 ## 📑 In this cluster
 
@@ -275,7 +276,7 @@ yielded 9–12% improvement:
 | Large         | 2.3 ms   | 2.1 ms   | **9%**      |
 | Very Large    | 14.6 ms  | 13.2 ms  | **10%**     |
 
-**Lesson:** For sparse networks (the typical NEAT scenario), probabilistic
+**Lesson:** For sparse networks (the typical NEAT-AI scenario), probabilistic
 algorithms that exploit sparsity outperform exhaustive enumeration. The
 rejection sampling approach finds valid connections in 1–2 attempts, eliminating
 full list construction.
@@ -646,12 +647,12 @@ Per-element error loops (MSE, MAE, CrossEntropy) over output neurons.
 | >10 µs per call?      | ✗ NO — 6 ns (3 outputs) to 1.4 µs (100 CrossEntropy) |
 | Caching layer?        | ✗ NO                                                 |
 
-**Verdict: NOT SIMD-viable.** Typical NEAT creatures have 1–10 outputs, giving
-loop counts of 1–10 elements — far too small for SIMD to amortise setup cost.
-Even the worst case (100-output CrossEntropy at 1.4 µs) is well below the 10 µs
-threshold. Additionally, the batch loss functions in `loss.rs` already use SIMD
-for the activation step — the per-output error reduction is a tiny fraction of
-the total batch scoring time.
+**Verdict: NOT SIMD-viable.** Typical NEAT-AI creatures have 1–10 outputs,
+giving loop counts of 1–10 elements — far too small for SIMD to amortise setup
+cost. Even the worst case (100-output CrossEntropy at 1.4 µs) is well below the
+10 µs threshold. Additionally, the batch loss functions in `loss.rs` already use
+SIMD for the activation step — the per-output error reduction is a tiny fraction
+of the total batch scoring time.
 
 #### Candidate 2: Gradient Accumulation Arithmetic
 

--- a/docs/PERFORMANCE_TUNING.md
+++ b/docs/PERFORMANCE_TUNING.md
@@ -19,9 +19,10 @@
 
 See the [docs index](./README.md) for the full topic map.
 
-This guide explains how to tune NEAT-AI for large-scale training runs. It covers
-every configurable performance parameter, explains when to enable or disable
-features, and provides practical recommendations for different scenarios.
+This guide explains how to tune [NEAT-AI](../AGENTS.md#-terminology) for
+large-scale training runs. It covers every configurable performance parameter,
+explains when to enable or disable features, and provides practical
+recommendations for different scenarios.
 
 All configuration is passed via `NeatOptionsInput` to `createNeatConfig()`. See
 the [Configuration Guide](./CONFIGURATION_GUIDE.md) for the full reference of
@@ -624,7 +625,7 @@ training, near-zero connections are pruned and only useful ones are retained.
 
 ### When to Enable Synthetic Synapses
 
-- **Sparse early-evolution networks**: When NEAT has not yet evolved dense
+- **Sparse early-evolution networks**: When NEAT-AI has not yet evolved dense
   inter-layer connectivity, synthetic synapses give backpropagation more
   connections to optimise, often finding useful pathways that mutation alone
   would take many generations to discover.
@@ -723,7 +724,7 @@ best creatures.
 
 **How it works**:
 
-1. Each machine runs an independent NEAT population (an "island").
+1. Each machine runs an independent NEAT-AI population (an "island").
 2. Periodically, the best creatures from each island are exported and shared.
 3. Imported creatures are grafted into the receiving population, adding genetic
    diversity.

--- a/docs/PREDICTIVE_CODING.md
+++ b/docs/PREDICTIVE_CODING.md
@@ -24,7 +24,10 @@ See the [docs index](./README.md) for the full topic map.
 ## 🧪 Acronyms used in this guide
 
 - **PC** — Predictive Coding
-- **NEAT** — NeuroEvolution of Augmenting Topologies
+- **NEAT** — NeuroEvolution of Augmenting Topologies (the original 2002
+  algorithm); see [terminology](../AGENTS.md#-terminology)
+- **NEAT-AI** — this project, which extends standard NEAT (see
+  [NEAT vs NEAT-AI](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use))
 - **WASM** — WebAssembly
 - **FFI** — Foreign Function Interface
 - **MSE / MAE / RMSE / MAPE** — Mean Squared / Absolute / Root-Mean-Squared /
@@ -210,7 +213,7 @@ NEAT-AI's core architecture consists of:
 
 #### 🔢 How Layers Map
 
-NEAT networks are not strictly layered — they are arbitrary directed graphs
+NEAT-AI networks are not strictly layered — they are arbitrary directed graphs
 (with optional recurrent connections). For PC, we define a neuron's **depth** as
 its topological distance from the input layer:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,18 @@
 Welcome to the NEAT-AI documentation. This page is the topic-by-topic table of
 contents — every long-form guide in the repository has a home here.
 
+> [!IMPORTANT]
+> **NEAT-AI ≠ NEAT.** NEAT-AI started from the original NeuroEvolution of
+> Augmenting Topologies algorithm
+> ([Stanley & Miikkulainen 2002](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf))
+> but extends it with memetic evolution, error-guided Discovery, MCMC mutation
+> acceptance, synthetic synapses, predictive coding, Muon-style orthogonalised
+> gradients, and other modern algorithms. When this documentation describes what
+> **this repository** does, it says **NEAT-AI**. When it discusses the 2002
+> algorithm itself, it says **NEAT** (or "standard NEAT", "pure NEAT"). The
+> [NEAT vs NEAT-AI rule in AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> is the canonical entry.
+
 If you have not used NEAT-AI before, follow the **Where to start** reading path
 below; it walks from a zero-knowledge introduction through to the topic guides
 you are most likely to need next.
@@ -15,7 +27,10 @@ A new reader should follow the docs in this order:
    NEAT-AI is, the major features, and gives a working example.
 2. **[../AGENTS.md](../AGENTS.md)** — terminology and coding conventions. Read
    this if any of the playful names (Creature, Discovery, CRISPR, Grafting,
-   MCMC) are unfamiliar.
+   MCMC) are unfamiliar. In particular, see the
+   [**NEAT** and **NEAT-AI** terminology entries](../AGENTS.md#-terminology) and
+   the [NEAT vs NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+   for the convention used throughout this repository.
 3. **[../CONTRIBUTING.md](../CONTRIBUTING.md)** — development setup, how to run
    the quality gate, and how to bump the pinned NEAT-AI-core dependency.
 4. **This page (`docs/README.md`)** — pick a topic guide below for the feature
@@ -135,10 +150,10 @@ Project-level policies, audits, and release plumbing.
 
 ## 🔍 Comparison with other approaches
 
-- **[../COMPARISON.md](../COMPARISON.md)** — how NEAT compares to traditional
-  neural networks, CNNs (Convolutional Neural Networks), RNNs (Recurrent Neural
-  Networks), and modern LLMs (Large Language Models). Owned by Issue #2563 and
-  excluded from the index refresh.
+- **[../COMPARISON.md](../COMPARISON.md)** — how NEAT-AI compares to standard
+  NEAT, traditional neural networks, CNNs (Convolutional Neural Networks), RNNs
+  (Recurrent Neural Networks), and modern LLMs (Large Language Models). Owned by
+  Issue #2563 and excluded from the index refresh.
 
 ## 🚫 Out of scope for this index
 

--- a/docs/REINFORCEMENT_LEARNING.md
+++ b/docs/REINFORCEMENT_LEARNING.md
@@ -1,8 +1,9 @@
 # 🎮 Reinforcement Learning / Agent Rollouts
 
-> **Streaming-observation / agent-rollout** in NEAT-AI is the API pattern for
-> episode-based tasks (Snake, Cart-Pole, grid worlds, control tasks) where the
-> next observation depends on the creature's previous action.
+> **Streaming-observation / agent-rollout** in
+> [NEAT-AI](../AGENTS.md#-terminology) is the API pattern for episode-based
+> tasks (Snake, Cart-Pole, grid worlds, control tasks) where the next
+> observation depends on the creature's previous action.
 >
 > The library already supports this pattern out of the box — `Creature.activate`
 > is the streaming primitive — but until now there was no document on the
@@ -40,9 +41,9 @@ Use the streaming-observation pattern when:
   [agent-environment loop](https://en.wikipedia.org/wiki/Reinforcement_learning).
 - You can score a full episode after the fact — typically a sum of rewards, a
   survival proxy, or a shaping signal.
-- A differentiable loss is **not** available, or is expensive to construct. NEAT
-  optimises the network end-to-end against the episode score, so the reward
-  signal does not need to be differentiable.
+- A differentiable loss is **not** available, or is expensive to construct.
+  NEAT-AI optimises the network end-to-end against the episode score, so the
+  reward signal does not need to be differentiable.
 
 If your task is fully supervised — every observation comes with a target output
 and the data is independent — you do not need this pattern. Use
@@ -169,7 +170,7 @@ flowchart LR
 
 ## 📊 Scoring an episode
 
-The fitness score returned to NEAT is **a single scalar per creature, per
+The fitness score returned to NEAT-AI is **a single scalar per creature, per
 generation**. Common choices:
 
 | Score                   | When to use                                                                                    |
@@ -247,14 +248,14 @@ This puts it in a different family from the dominant deep-RL methods.
 | Policy-gradient                                                           | REINFORCE, PPO          | The policy `π(a \| s)` directly, via gradient on a stochastic objective.        | Yes — the policy must be differentiable, and we differentiate through it.                   | Continuous action spaces. Mature ecosystems (RLlib, Stable-Baselines3).                                                                        | Variance is high; needs careful baselines. Hyperparameter-sensitive.                                                                |
 | **Neuroevolution (NEAT-AI)**                                              | NEAT, CMA-ES, OpenAI ES | The policy network itself — both topology and weights — by evolutionary search. | **No.** The reward is a scalar produced by the simulator; nothing has to be differentiable. | Works with non-differentiable, sparse, or simulator-only rewards. Embarrassingly parallel across the population. Topology grows automatically. | Less sample-efficient per environment step than DQN/PPO when a good gradient signal exists. Computationally heavier per generation. |
 
-**When NEAT is the right choice for a streaming-observation task:**
+**When NEAT-AI is the right choice for a streaming-observation task:**
 
 - The reward is sparse, non-differentiable, or only available at the end of the
   episode (e.g. "did the agent win?").
 - The action space mixes discrete and continuous components, or the action
   decoder is itself non-differentiable.
 - You want the architecture to grow with the task — no manual layer sizing.
-- You have many CPU cores or distributed nodes — NEAT scales by spreading
+- You have many CPU cores or distributed nodes — NEAT-AI scales by spreading
   rollouts across them, not by one big GPU.
 
 **When DQN or PPO is the better choice:**

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,7 +1,7 @@
 # 🐛 Troubleshooting Guide
 
-Quick FAQ-style index of NEAT-AI failure modes. Each entry describes the symptom
-in one sentence and links to a detail doc under
+Quick FAQ-style index of [NEAT-AI](../AGENTS.md#-terminology) failure modes.
+Each entry describes the symptom in one sentence and links to a detail doc under
 [`troubleshooting/`](troubleshooting/) where the full diagnosis lives.
 
 If you have arrived here by Googling an error message, jump straight to the

--- a/docs/pr-summary-2599.md
+++ b/docs/pr-summary-2599.md
@@ -7,32 +7,32 @@ Closes #2599.
 
 Two new entries were added to the existing **Terminology** section:
 
-- **NEAT** — the original NeuroEvolution of Augmenting Topologies algorithm
-  from the 2002 paper. Reserved for discussions of that algorithm only.
+- **NEAT** — the original NeuroEvolution of Augmenting Topologies algorithm from
+  the 2002 paper. Reserved for discussions of that algorithm only.
 - **NEAT-AI** — this project. Started from pure NEAT but now extends it with
-  memetic evolution, error-guided Discovery, MCMC mutation acceptance,
-  synthetic synapses, predictive coding, Muon-style orthogonalised gradients,
-  and other modern algorithms.
+  memetic evolution, error-guided Discovery, MCMC mutation acceptance, synthetic
+  synapses, predictive coding, Muon-style orthogonalised gradients, and other
+  modern algorithms.
 
-A new **🆚 NEAT vs NEAT-AI — which term to use** subsection codifies the
-rule of thumb so contributors know which term belongs where:
+A new **🆚 NEAT vs NEAT-AI — which term to use** subsection codifies the rule of
+thumb so contributors know which term belongs where:
 
 - Say **NEAT-AI** for anything the repo does.
-- Say **NEAT** (or "standard NEAT" / "pure NEAT") only when contrasting with
-  the 2002 algorithm.
+- Say **NEAT** (or "standard NEAT" / "pure NEAT") only when contrasting with the
+  2002 algorithm.
 - Avoid bare "NEAT" as shorthand for the implementation in user-facing docs.
 
-This is foundational and unblocks the other sub-issues under #2598 — they
-can now reference this glossary entry instead of redefining the distinction
-in each file.
+This is foundational and unblocks the other sub-issues under #2598 — they can
+now reference this glossary entry instead of redefining the distinction in each
+file.
 
 ## Evidence
 
 Documentation-only change (no code, no UI, no benchmarks). Verified with:
 
 - `npx markdownlint-cli2 AGENTS.md` → 0 errors.
-- `./quality.sh --lint-only` → all four steps pass (deno fmt, deno lint,
-  bash check). `deno fmt` rewrapped a few lines in the new section.
+- `./quality.sh --lint-only` → all four steps pass (deno fmt, deno lint, bash
+  check). `deno fmt` rewrapped a few lines in the new section.
 - Manual inspection: links resolve to the same Stanley & Miikkulainen PDF
   already cited elsewhere in the file.
 
@@ -50,6 +50,6 @@ flowchart LR
 - [x] `AGENTS.md` Terminology section contains entries for both **NEAT** and
       **NEAT-AI** with the distinction described in the issue.
 - [x] Includes a contributor rule of thumb on which term to use where.
-- [x] Markdown renders cleanly (markdownlint-cli2 reports zero errors;
-      no broken links).
+- [x] Markdown renders cleanly (markdownlint-cli2 reports zero errors; no broken
+      links).
 - [x] `./quality.sh --lint-only` passes (formatting, linting, bash check).

--- a/docs/pr-summary-2599.md
+++ b/docs/pr-summary-2599.md
@@ -1,0 +1,55 @@
+## Summary
+
+Established a canonical distinction between **NEAT** (the standard 2002
+algorithm by Stanley & Miikkulainen) and **NEAT-AI** (this project) in
+`AGENTS.md`, so the rest of the documentation can reference it consistently.
+Closes #2599.
+
+Two new entries were added to the existing **Terminology** section:
+
+- **NEAT** — the original NeuroEvolution of Augmenting Topologies algorithm
+  from the 2002 paper. Reserved for discussions of that algorithm only.
+- **NEAT-AI** — this project. Started from pure NEAT but now extends it with
+  memetic evolution, error-guided Discovery, MCMC mutation acceptance,
+  synthetic synapses, predictive coding, Muon-style orthogonalised gradients,
+  and other modern algorithms.
+
+A new **🆚 NEAT vs NEAT-AI — which term to use** subsection codifies the
+rule of thumb so contributors know which term belongs where:
+
+- Say **NEAT-AI** for anything the repo does.
+- Say **NEAT** (or "standard NEAT" / "pure NEAT") only when contrasting with
+  the 2002 algorithm.
+- Avoid bare "NEAT" as shorthand for the implementation in user-facing docs.
+
+This is foundational and unblocks the other sub-issues under #2598 — they
+can now reference this glossary entry instead of redefining the distinction
+in each file.
+
+## Evidence
+
+Documentation-only change (no code, no UI, no benchmarks). Verified with:
+
+- `npx markdownlint-cli2 AGENTS.md` → 0 errors.
+- `./quality.sh --lint-only` → all four steps pass (deno fmt, deno lint,
+  bash check). `deno fmt` rewrapped a few lines in the new section.
+- Manual inspection: links resolve to the same Stanley & Miikkulainen PDF
+  already cited elsewhere in the file.
+
+```mermaid
+flowchart LR
+    A[AGENTS.md Terminology] --> B[NEAT entry<br/>2002 algorithm]
+    A --> C[NEAT-AI entry<br/>this project]
+    B --> D[NEAT vs NEAT-AI<br/>rule of thumb]
+    C --> D
+    D --> E[Sub-issues under #2598<br/>reference this glossary]
+```
+
+## Test Plan
+
+- [x] `AGENTS.md` Terminology section contains entries for both **NEAT** and
+      **NEAT-AI** with the distinction described in the issue.
+- [x] Includes a contributor rule of thumb on which term to use where.
+- [x] Markdown renders cleanly (markdownlint-cli2 reports zero errors;
+      no broken links).
+- [x] `./quality.sh --lint-only` passes (formatting, linting, bash check).

--- a/docs/pr-summary-2600.md
+++ b/docs/pr-summary-2600.md
@@ -1,13 +1,13 @@
 ## Summary
 
-Reworks `COMPARISON.md` so a reader cannot confuse the original NEAT
-algorithm (Stanley & Miikkulainen, 2002) with NEAT-AI's much-extended
-implementation. Closes #2600.
+Reworks `COMPARISON.md` so a reader cannot confuse the original NEAT algorithm
+(Stanley & Miikkulainen, 2002) with NEAT-AI's much-extended implementation.
+Closes #2600.
 
 The document now applies the terminology rule introduced in #2599
 ([AGENTS.md NEAT vs NEAT-AI section](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use))
-throughout: **NEAT** is reserved for the 2002 algorithm and **NEAT-AI** is
-used for everything in this repository.
+throughout: **NEAT** is reserved for the 2002 algorithm and **NEAT-AI** is used
+for everything in this repository.
 
 ### Key changes
 
@@ -16,25 +16,24 @@ used for everything in this repository.
   from pure NEAT but incorporates many algorithms beyond the 2002 paper. The
   first occurrences of NEAT and NEAT-AI link to the AGENTS.md terminology
   entries.
-- **"What We've Implemented"** — split into two clearly delimited
-  subsections:
+- **"What We've Implemented"** — split into two clearly delimited subsections:
   - "🔬 Standard NEAT machinery (Stanley & Miikkulainen, 2002)" — items
     inherited directly from the 2002 paper (evolutionary topology search,
     speciation, historical marking, genetic operators, fitness sharing).
-  - "🚀 NEAT-AI extensions (beyond the 2002 paper)" — every NEAT-AI
-    extension is annotated with `*(NEAT-AI extension)*` and, where
-    relevant, contrasts itself with standard NEAT. Predictive coding,
-    discovery, MCMC acceptance, and others link to their dedicated guides.
-- **Section renames** — "🧬 NEAT (Our Implementation)" → "🧬 NEAT-AI" in
-  the Architectural Comparison, Training Paradigms, Pros, and Cons
-  sections. The Ecosystem Comparison section heading and TOC entry now
-  read "NEAT-AI vs Standard Libraries". The Architectural Comparison
-  caption explicitly contrasts NEAT-AI with standard NEAT.
-- **Audited bare "NEAT" references** — sentences such as "NEAT does not
-  learn a value function" (RL section), "NEAT is typically used for
-  supervised learning", "Standard NEAT implementations accept all mutations
-  unconditionally", and similar were reworded to make clear whether the
-  claim is about pure NEAT, NEAT-AI, or both.
+  - "🚀 NEAT-AI extensions (beyond the 2002 paper)" — every NEAT-AI extension is
+    annotated with `*(NEAT-AI extension)*` and, where relevant, contrasts itself
+    with standard NEAT. Predictive coding, discovery, MCMC acceptance, and
+    others link to their dedicated guides.
+- **Section renames** — "🧬 NEAT (Our Implementation)" → "🧬 NEAT-AI" in the
+  Architectural Comparison, Training Paradigms, Pros, and Cons sections. The
+  Ecosystem Comparison section heading and TOC entry now read "NEAT-AI vs
+  Standard Libraries". The Architectural Comparison caption explicitly contrasts
+  NEAT-AI with standard NEAT.
+- **Audited bare "NEAT" references** — sentences such as "NEAT does not learn a
+  value function" (RL section), "NEAT is typically used for supervised
+  learning", "Standard NEAT implementations accept all mutations
+  unconditionally", and similar were reworded to make clear whether the claim is
+  about pure NEAT, NEAT-AI, or both.
 - **Conclusion and "Use NEAT when…"** — now use NEAT-AI throughout when
   describing this project, and "standard NEAT" when describing the 2002
   algorithm.
@@ -42,11 +41,11 @@ used for everything in this repository.
 ### Evidence
 
 This is a docs-only change. Markdownlint and the `--lint-only` portion of
-`./quality.sh` pass. Full `./quality.sh --skip-discovery --skip-wasm`
-shows two pre-existing FFI/dynamic-library leak failures in
-`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` that reproduce
-on the unmodified file (verified by stashing and running the test on the
-parent commit) and are unrelated to this docs change.
+`./quality.sh` pass. Full `./quality.sh --skip-discovery --skip-wasm` shows two
+pre-existing FFI/dynamic-library leak failures in
+`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` that reproduce on the
+unmodified file (verified by stashing and running the test on the parent commit)
+and are unrelated to this docs change.
 
 ```mermaid
 flowchart LR
@@ -56,15 +55,15 @@ flowchart LR
 
 ### Test plan
 
-- [x] `./quality.sh --lint-only < /dev/null` passes (markdown formatted,
-      bash scripts pass, lint clean).
-- [x] First mention of NEAT and NEAT-AI links to AGENTS.md terminology
-      entries (`#-terminology` and the rule section).
-- [x] Every list item under "What We've Implemented" is grouped or
-      annotated as "standard NEAT" or "NEAT-AI extension".
-- [x] No remaining bare "NEAT" references describe NEAT-AI's codebase,
-      features, or behaviour. `grep -nE '\bNEAT\b'` confirms remaining
-      bare uses refer to the 2002 algorithm, the original paper, or
+- [x] `./quality.sh --lint-only < /dev/null` passes (markdown formatted, bash
+      scripts pass, lint clean).
+- [x] First mention of NEAT and NEAT-AI links to AGENTS.md terminology entries
+      (`#-terminology` and the rule section).
+- [x] Every list item under "What We've Implemented" is grouped or annotated as
+      "standard NEAT" or "NEAT-AI extension".
+- [x] No remaining bare "NEAT" references describe NEAT-AI's codebase, features,
+      or behaviour. `grep -nE '\bNEAT\b'` confirms remaining bare uses refer to
+      the 2002 algorithm, the original paper, or
       "NEAT-derived"/"NEAT-style"/"NEAT-evolved" qualifiers.
 - [x] Pros/Cons, Training Paradigms, Conclusion, and Ecosystem Comparison
       sections consistently use NEAT-AI for this project.

--- a/docs/pr-summary-2600.md
+++ b/docs/pr-summary-2600.md
@@ -1,0 +1,70 @@
+## Summary
+
+Reworks `COMPARISON.md` so a reader cannot confuse the original NEAT
+algorithm (Stanley & Miikkulainen, 2002) with NEAT-AI's much-extended
+implementation. Closes #2600.
+
+The document now applies the terminology rule introduced in #2599
+([AGENTS.md NEAT vs NEAT-AI section](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use))
+throughout: **NEAT** is reserved for the 2002 algorithm and **NEAT-AI** is
+used for everything in this repository.
+
+### Key changes
+
+- **Title and Overview** — title rewritten to "NEAT-AI vs Traditional Neural
+  Networks and Modern LLMs"; Overview states explicitly that NEAT-AI started
+  from pure NEAT but incorporates many algorithms beyond the 2002 paper. The
+  first occurrences of NEAT and NEAT-AI link to the AGENTS.md terminology
+  entries.
+- **"What We've Implemented"** — split into two clearly delimited
+  subsections:
+  - "🔬 Standard NEAT machinery (Stanley & Miikkulainen, 2002)" — items
+    inherited directly from the 2002 paper (evolutionary topology search,
+    speciation, historical marking, genetic operators, fitness sharing).
+  - "🚀 NEAT-AI extensions (beyond the 2002 paper)" — every NEAT-AI
+    extension is annotated with `*(NEAT-AI extension)*` and, where
+    relevant, contrasts itself with standard NEAT. Predictive coding,
+    discovery, MCMC acceptance, and others link to their dedicated guides.
+- **Section renames** — "🧬 NEAT (Our Implementation)" → "🧬 NEAT-AI" in
+  the Architectural Comparison, Training Paradigms, Pros, and Cons
+  sections. The Ecosystem Comparison section heading and TOC entry now
+  read "NEAT-AI vs Standard Libraries". The Architectural Comparison
+  caption explicitly contrasts NEAT-AI with standard NEAT.
+- **Audited bare "NEAT" references** — sentences such as "NEAT does not
+  learn a value function" (RL section), "NEAT is typically used for
+  supervised learning", "Standard NEAT implementations accept all mutations
+  unconditionally", and similar were reworded to make clear whether the
+  claim is about pure NEAT, NEAT-AI, or both.
+- **Conclusion and "Use NEAT when…"** — now use NEAT-AI throughout when
+  describing this project, and "standard NEAT" when describing the 2002
+  algorithm.
+
+### Evidence
+
+This is a docs-only change. Markdownlint and the `--lint-only` portion of
+`./quality.sh` pass. Full `./quality.sh --skip-discovery --skip-wasm`
+shows two pre-existing FFI/dynamic-library leak failures in
+`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` that reproduce
+on the unmodified file (verified by stashing and running the test on the
+parent commit) and are unrelated to this docs change.
+
+```mermaid
+flowchart LR
+    A[#2599 AGENTS.md<br/>NEAT vs NEAT-AI rule] --> B[#2600 COMPARISON.md<br/>rework]
+    B --> C[Reader sees<br/>standard-NEAT items vs<br/>NEAT-AI extensions]
+```
+
+### Test plan
+
+- [x] `./quality.sh --lint-only < /dev/null` passes (markdown formatted,
+      bash scripts pass, lint clean).
+- [x] First mention of NEAT and NEAT-AI links to AGENTS.md terminology
+      entries (`#-terminology` and the rule section).
+- [x] Every list item under "What We've Implemented" is grouped or
+      annotated as "standard NEAT" or "NEAT-AI extension".
+- [x] No remaining bare "NEAT" references describe NEAT-AI's codebase,
+      features, or behaviour. `grep -nE '\bNEAT\b'` confirms remaining
+      bare uses refer to the 2002 algorithm, the original paper, or
+      "NEAT-derived"/"NEAT-style"/"NEAT-evolved" qualifiers.
+- [x] Pros/Cons, Training Paradigms, Conclusion, and Ecosystem Comparison
+      sections consistently use NEAT-AI for this project.

--- a/docs/pr-summary-2601.md
+++ b/docs/pr-summary-2601.md
@@ -1,0 +1,89 @@
+## Summary
+
+Updated the two highest-traffic landing pages — root [`README.md`](../README.md)
+and [`docs/README.md`](./README.md) — so first-time readers immediately
+understand that **NEAT-AI** extends well beyond the standard **NEAT** algorithm.
+The new framing uses the **NEAT** vs **NEAT-AI** distinction codified in
+[`AGENTS.md`](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) (Issue #2599).
+Closes #2601.
+
+## What changed
+
+### Root `README.md`
+
+- Renamed the heading from "🧬 NEAT Neural Network for DenoJS" to "🧬
+  **NEAT-AI** Neural Network for DenoJS".
+- Replaced the opening paragraph. The new paragraph names **NEAT-AI** as this
+  project, points to the original 2002 NEAT paper for the algorithm it grew
+  from, and lists the modern extensions (memetic evolution, Discovery, MCMC,
+  synthetic synapses, predictive coding, Muon-style orthogonalised gradients).
+- Added an `[!IMPORTANT]` callout linking to the
+  [NEAT vs NEAT-AI rule in AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+  so the distinction is visible from the very first screen.
+- Added a one-line preamble to **Feature Highlights** clarifying that the list
+  describes NEAT-AI behaviour and that several entries are extensions beyond
+  standard NEAT, with a pointer to `COMPARISON.md`.
+- Updated the **High-level architecture** sentence to refer to a "NEAT-AI
+  genome" (was "NEAT genome").
+- Updated the docs map and Core Concepts entries for `COMPARISON.md` to read
+  "how NEAT-AI compares…" instead of "how NEAT compares…", with an explicit
+  mention of standard NEAT.
+
+### `docs/README.md`
+
+- Added an `[!IMPORTANT]` framing callout at the top spelling out the NEAT ≠
+  NEAT-AI distinction and linking to the canonical entry in `AGENTS.md`.
+- Extended step 2 of the **Where to start** reading path to call out the
+  [terminology entries](../AGENTS.md#-terminology) and the
+  [NEAT vs NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) in
+  `AGENTS.md`, so newcomers see the distinction early.
+- Updated the COMPARISON entry to "how NEAT-AI compares to standard NEAT,
+  traditional neural networks, CNNs, RNNs, and modern LLMs".
+
+## Acceptance Criteria
+
+- [x] Opening paragraph of root `README.md` makes the NEAT vs NEAT-AI
+      distinction explicit on first use.
+- [x] Feature Highlights consistently use **NEAT-AI** when describing the
+      project's behaviour (added a framing preamble; the existing entries
+      already used NEAT-AI when referring to the project).
+- [x] `docs/README.md` references the AGENTS.md terminology entries as part of
+      the reading path.
+- [x] Internal links and Mermaid diagrams still render (no diagram or link
+      targets were touched).
+- [x] Markdownlint and `./quality.sh` pass for the doc changes (`deno fmt`,
+      `deno lint`, `deno check`, bash check all pass).
+
+## Evidence
+
+This change is purely documentation prose. There is no UI surface and no
+performance-affecting code path. The evidence is the diff itself plus the
+quality gate output:
+
+- `./quality.sh --lint-only < /dev/null` → all four steps pass (deps update,
+  fmt, lint, bash check).
+- `./quality.sh < /dev/null` → 6569 tests pass; the 2 failing tests
+  (`DiscoveryTimeout.ts: DiscoverDirectory returns partial results on timeout`
+  and `Timeout during file reading returns partial data`) are **pre-existing FFI
+  dynamic-library leak detector failures** on the
+  `milestone/ours-vs-standard-neat` base branch and are unrelated to this
+  doc-only change. Verified by stashing my edits and re-running — the same two
+  tests still fail on a clean base branch checkout.
+
+## Test Plan
+
+- Existing markdownlint / `deno fmt` checks via `quality.sh` cover prose
+  formatting.
+- No new code paths were introduced, so no new unit tests are required.
+- Reviewed the rendered Markdown locally: the `[!IMPORTANT]` callouts, the
+  Mermaid `flowchart LR` block, the docs map, and all internal anchors render
+  cleanly.
+
+## Notes
+
+- Issue #2600 (COMPARISON.md rework) is still open. The acceptance criteria for
+  #2601 say the docs map blurb for `COMPARISON.md` should reflect its new
+  framing "once #2600 lands". This PR makes a minimal, forward-compatible update
+  — the blurb now describes COMPARISON as "how NEAT-AI compares to standard NEAT
+  and other approaches" — which is consistent with the direction in #2600 and
+  does not need to be revisited when #2600 merges.

--- a/docs/pr-summary-2602.md
+++ b/docs/pr-summary-2602.md
@@ -1,0 +1,88 @@
+# Sweep remaining docs to clarify NEAT vs NEAT-AI references
+
+## Summary
+
+Closes #2602.
+
+This PR completes the long-tail sweep started by #2599 (terminology entry) and
+#2600/#2601 (README and COMPARISON updates). It audits every long-form topic
+guide under `docs/` (excluding historical `pr-summary-*.md` files) and the
+root-level `CONTRIBUTING.md` and `SECURITY.md`, replacing bare **NEAT**
+references that describe NEAT-AI behaviour with **NEAT-AI**, and adding a link
+to the AGENTS.md terminology entries on the first occurrence of NEAT/NEAT-AI in
+each updated file.
+
+`CHANGELOG.md` was reviewed but not edited — historical entries are preserved
+verbatim per the issue scope; the convention is enforced via the new AGENTS.md
+guidance for prospective entries.
+
+## Files changed
+
+| File                             | Edits                                                                                                                                                                                                   |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CONTRIBUTING.md`                | Linked first NEAT-AI; added IMPORTANT note about NEAT vs NEAT-AI; clarified `src/NEAT/` folder description                                                                                              |
+| `SECURITY.md`                    | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/INTELLIGENT_DESIGN.md`     | Renamed "NEAT options" → "NEAT-AI options" in NeatOptions row                                                                                                                                           |
+| `docs/DISCOVERY_GUIDE.md`        | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/CRISPR_GUIDE.md`           | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/BACKPROP_ELASTICITY.md`    | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/CONFIGURATION_GUIDE.md`    | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/API_REFERENCE.md`          | Linked first NEAT/NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI in Creature class, NeatOptions, evolveDir, ONNX export sections; clarified "standard NEAT" contrast in synthetic synapses paragraph |
+| `docs/PREDICTIVE_CODING.md`      | Added NEAT-AI acronym entry with terminology link; renamed "NEAT networks" → "NEAT-AI networks" in topology context                                                                                     |
+| `docs/REINFORCEMENT_LEARNING.md` | Linked first NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI in fitness/optimisation/scaling sentences                                                                                                |
+| `docs/ACTIVATION_FUNCTIONS.md`   | Linked first NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI throughout topology-evolution sections (mutation probability, evolution suitability, deprecated functions)                               |
+| `docs/PERFORMANCE_TUNING.md`     | Linked first NEAT-AI to AGENTS.md; renamed bare NEAT → NEAT-AI in synthetic-synapse and island-model sections                                                                                           |
+| `docs/PERFORMANCE_RESEARCH.md`   | Linked first NEAT-AI to AGENTS.md; renamed "typical NEAT scenario/creatures" → NEAT-AI                                                                                                                  |
+| `docs/TROUBLESHOOTING.md`        | Linked first NEAT-AI to AGENTS.md terminology                                                                                                                                                           |
+| `docs/pr-summary-2599.md`        | Incidental `deno fmt` re-wrap (no semantic change)                                                                                                                                                      |
+
+### Kinds of edits applied
+
+```mermaid
+flowchart LR
+    A[Audit each file] --> B{Bare NEAT means<br/>NEAT-AI behaviour?}
+    B -- yes --> C[Rename to NEAT-AI]
+    B -- no, contrasting<br/>2002 algorithm --> D[Keep / clarify as<br/>'standard NEAT']
+    C --> E{First NEAT/NEAT-AI<br/>linked to AGENTS.md?}
+    D --> E
+    E -- no --> F[Add link to<br/>AGENTS.md terminology]
+    E -- yes --> G[Done]
+    F --> G
+```
+
+Three classes of edit appear in this PR:
+
+- **Rename** — bare "NEAT" describing this repo's behaviour → "NEAT-AI".
+- **Clarify** — sentences that contrast with the 2002 algorithm now say
+  "standard NEAT" explicitly and name NEAT-AI as the contrasting party.
+- **Link added** — the first occurrence of NEAT/NEAT-AI in each updated file
+  links to the AGENTS.md terminology and "NEAT vs NEAT-AI" rule.
+
+## Out of scope
+
+- `docs/pr-summary-*.md` historical PR records (per issue scope) — only the
+  pre-existing `pr-summary-2599.md` was touched, and only by `deno fmt`
+  (whitespace re-wrap, no semantic change).
+- `CHANGELOG.md` historical entries — not rewritten. The convention applies to
+  new entries, enforced by AGENTS.md.
+
+## Evidence
+
+This is a pure documentation PR — there is no UI to screenshot and no runtime
+behaviour to benchmark. Verification is via the project quality gate:
+
+- `./quality.sh --lint-only` passes (formatting + linting + bash check).
+- `./quality.sh --check-only` passes (deno type-check).
+
+No source code or tests were modified.
+
+## Test Plan
+
+- [x] `deno fmt` passes on every modified file
+- [x] `deno lint` passes (markdownlint-cli2 + deno lint)
+- [x] `deno check` passes
+- [x] Spot-check: every updated file's first NEAT/NEAT-AI mention is a clickable
+      link to `AGENTS.md#-terminology` or
+      `AGENTS.md#-neat-vs-neat-ai--which-term-to-use`.
+- [x] No `pr-summary-NNNN.md` historical record has had its content semantically
+      changed.


### PR DESCRIPTION
## Milestone: Ours vs standard NEAT

This PR merges the completed milestone branch into Develop.
Closes #2607

### Issues addressed
- #2602: Sweep remaining docs to clarify NEAT vs NEAT-AI references
- #2601: Update root README.md and docs/README.md for consistent NEAT-AI branding
- #2600: Rework COMPARISON.md to clearly distinguish NEAT-AI from standard NEAT
- #2599: Add NEAT vs NEAT-AI terminology section to AGENTS.md

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.