### PR TITLE
Fix CRISPR append-mode wire-format UUID collision (Issue #2618)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2618.md
+++ b/docs/pr-summary-2618.md
@@ -4,22 +4,22 @@
 
 Fixes the multi-output regression where `CRISPR.cleaveDNA` in append-mode
 emitted one `output-N → output-N` self-loop per appended output. The cleaved
-creature passed positional forward-only validation but exported as a
-wire-format self-loop because the demoted previous output kept the literal
+creature passed positional forward-only validation but exported as a wire-format
+self-loop because the demoted previous output kept the literal
 `uuid: "output-N"` string it had been re-loaded with, colliding with the new
 output neuron's canonical `output-N` wire identity.
 
 The fix is two-part and addresses both acceptance criteria from the issue:
 
-1. **Producer fix** — in `CRISPR.append()`, the demotion path now mints a
-   fresh stable UUID for any demoted neuron whose stored `uuid` matches the
+1. **Producer fix** — in `CRISPR.append()`, the demotion path now mints a fresh
+   stable UUID for any demoted neuron whose stored `uuid` matches the
    wire-format pattern `^output-\d+$`. Non-`output-N` UUIDs are preserved to
    honour the neuron-uuid-stability invariant (AGENTS.md).
-2. **Producer-side assertion** — `assertNoWireSelfLoopOnForwardOnly()` is a
-   new defence-in-depth check that compares wire UUIDs of every synapse's
-   endpoints. `CRISPR.cleaveDNA` now invokes it on the
-   `enforceForwardOnly` path so any future regression is caught at the
-   producer with the upstream stack frame named — not silently downstream.
+2. **Producer-side assertion** — `assertNoWireSelfLoopOnForwardOnly()` is a new
+   defence-in-depth check that compares wire UUIDs of every synapse's endpoints.
+   `CRISPR.cleaveDNA` now invokes it on the `enforceForwardOnly` path so any
+   future regression is caught at the producer with the upstream stack frame
+   named — not silently downstream.
 
 Closes #2618.
 
@@ -29,15 +29,15 @@ Backend-only change with no UI surface — verified via unit tests.
 
 ### Regression test added
 
-`test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - demoted previous outputs with wire-format `output-N` uuids do not collide with new outputs (Issue #2618, multi-output)`
+`test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - demoted previous outputs with wire-format`output-N`uuids do not collide with new outputs (Issue #2618, multi-output)`
 
-The test loads the project's existing `test/data/CRISPR/DNA-SANE.json`
-(3-output append-mode DNA: IDENTITY + MINIMUM + MAXIMUM) into a forward-only
-creature whose original output neurons carry the wire-format UUIDs
-`output-0`, `output-1`, `output-2` — the exact shape `Creature.fromJSON()`
-restores from a previously-exported JSON file. Without the fix, three
-`output-N → output-N` self-loops appear in the exported wire format. With
-the fix, the exported synapses have unique wire UUIDs at every endpoint.
+The test loads the project's existing `test/data/CRISPR/DNA-SANE.json` (3-output
+append-mode DNA: IDENTITY + MINIMUM + MAXIMUM) into a forward-only creature
+whose original output neurons carry the wire-format UUIDs `output-0`,
+`output-1`, `output-2` — the exact shape `Creature.fromJSON()` restores from a
+previously-exported JSON file. Without the fix, three `output-N → output-N`
+self-loops appear in the exported wire format. With the fix, the exported
+synapses have unique wire UUIDs at every endpoint.
 
 ### Failure reproduced before the fix
 
@@ -63,10 +63,10 @@ Post-fix the demoted neurons carry fresh UUIDs and no synapse has
 ### Quality gate
 
 `./quality.sh` passes the relevant test files (`test/CRISPR/*.ts`,
-`test/architecture/ForwardOnlyAssertion.ts`). The single pre-existing
-Discovery FFI dynamic-library leak detection failure
-(`DiscoverDirectory returns partial results on timeout`) is unrelated to
-this change — it reproduces on the unmodified branch as well.
+`test/architecture/ForwardOnlyAssertion.ts`). The single pre-existing Discovery
+FFI dynamic-library leak detection failure
+(`DiscoverDirectory returns partial results on timeout`) is unrelated to this
+change — it reproduces on the unmodified branch as well.
 
 ### Flow diagram
 
@@ -88,24 +88,26 @@ flowchart LR
 
 Added:
 
-- `test/CRISPR/AppendDemoteOutput.ts` — multi-output Issue #2618 regression
-  test covering the 3-output `DNA-SANE.json` append+demote scenario with
-  wire-format UUIDs on the previous outputs.
+- `test/CRISPR/AppendDemoteOutput.ts` — multi-output Issue #2618 regression test
+  covering the 3-output `DNA-SANE.json` append+demote scenario with wire-format
+  UUIDs on the previous outputs.
 - `test/architecture/ForwardOnlyAssertion.ts` — three new unit tests for
-  `assertNoWireSelfLoopOnForwardOnly`: no-op when not forward-only, passes
-  on distinct wire UUIDs, throws on UUID collision.
+  `assertNoWireSelfLoopOnForwardOnly`: no-op when not forward-only, passes on
+  distinct wire UUIDs, throws on UUID collision.
 
 Existing tests preserved (no test modifications):
 
-- `test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - DNA-SANE.json reproduces the multi-output demote pattern with relative anchors` — confirms the 3-output append+demote arithmetic still resolves correctly.
-- `test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT wires the demoted previous output into the new output (Issue #2509)` — confirms the single-output GRQ #2237 reproducer continues to pass.
+- `test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - DNA-SANE.json reproduces the multi-output demote pattern with relative anchors`
+  — confirms the 3-output append+demote arithmetic still resolves correctly.
+- `test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT wires the demoted previous output into the new output (Issue #2509)`
+  — confirms the single-output GRQ #2237 reproducer continues to pass.
 - All other 94 CRISPR tests pass unchanged.
 
 ## Files changed
 
-- `src/reconstruct/CRISPR.ts` — `append()` mints a fresh UUID for any
-  demoted neuron whose stored `uuid` matches `^output-\d+$`; `cleaveDNA()`
-  invokes the new wire-self-loop assertion on the forward-only path.
+- `src/reconstruct/CRISPR.ts` — `append()` mints a fresh UUID for any demoted
+  neuron whose stored `uuid` matches `^output-\d+$`; `cleaveDNA()` invokes the
+  new wire-self-loop assertion on the forward-only path.
 - `src/architecture/ForwardOnlyAssertion.ts` — new
   `assertNoWireSelfLoopOnForwardOnly()` helper.
 - `test/CRISPR/AppendDemoteOutput.ts` — new regression test.

--- a/docs/pr-summary-2618.md
+++ b/docs/pr-summary-2618.md
@@ -1,0 +1,113 @@
+# CRISPR append-mode wire-format UUID collision (Issue #2618)
+
+## Summary
+
+Fixes the multi-output regression where `CRISPR.cleaveDNA` in append-mode
+emitted one `output-N → output-N` self-loop per appended output. The cleaved
+creature passed positional forward-only validation but exported as a
+wire-format self-loop because the demoted previous output kept the literal
+`uuid: "output-N"` string it had been re-loaded with, colliding with the new
+output neuron's canonical `output-N` wire identity.
+
+The fix is two-part and addresses both acceptance criteria from the issue:
+
+1. **Producer fix** — in `CRISPR.append()`, the demotion path now mints a
+   fresh stable UUID for any demoted neuron whose stored `uuid` matches the
+   wire-format pattern `^output-\d+$`. Non-`output-N` UUIDs are preserved to
+   honour the neuron-uuid-stability invariant (AGENTS.md).
+2. **Producer-side assertion** — `assertNoWireSelfLoopOnForwardOnly()` is a
+   new defence-in-depth check that compares wire UUIDs of every synapse's
+   endpoints. `CRISPR.cleaveDNA` now invokes it on the
+   `enforceForwardOnly` path so any future regression is caught at the
+   producer with the upstream stack frame named — not silently downstream.
+
+Closes #2618.
+
+## Evidence
+
+Backend-only change with no UI surface — verified via unit tests.
+
+### Regression test added
+
+`test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - demoted previous outputs with wire-format `output-N` uuids do not collide with new outputs (Issue #2618, multi-output)`
+
+The test loads the project's existing `test/data/CRISPR/DNA-SANE.json`
+(3-output append-mode DNA: IDENTITY + MINIMUM + MAXIMUM) into a forward-only
+creature whose original output neurons carry the wire-format UUIDs
+`output-0`, `output-1`, `output-2` — the exact shape `Creature.fromJSON()`
+restores from a previously-exported JSON file. Without the fix, three
+`output-N → output-N` self-loops appear in the exported wire format. With
+the fix, the exported synapses have unique wire UUIDs at every endpoint.
+
+### Failure reproduced before the fix
+
+Pre-fix run output (3 self-loops, exactly the GRQ scorer trace):
+
+```
+Exported synapses:
+  ...
+  output-0 -> output-0
+  output-0 -> output-1
+  output-0 -> output-2
+  output-1 -> output-0
+  output-1 -> output-1
+  output-1 -> output-2
+  output-2 -> output-0
+  output-2 -> output-1
+  output-2 -> output-2
+```
+
+Post-fix the demoted neurons carry fresh UUIDs and no synapse has
+`fromUUID === toUUID`.
+
+### Quality gate
+
+`./quality.sh` passes the relevant test files (`test/CRISPR/*.ts`,
+`test/architecture/ForwardOnlyAssertion.ts`). The single pre-existing
+Discovery FFI dynamic-library leak detection failure
+(`DiscoverDirectory returns partial results on timeout`) is unrelated to
+this change — it reproduces on the unmodified branch as well.
+
+### Flow diagram
+
+```mermaid
+flowchart LR
+    A[Creature with output-N uuids<br/>loaded from disk] --> B[CRISPR.append]
+    B --> C{Demoted output<br/>uuid matches output-N?}
+    C -- "yes (Issue #2618)" --> D[Mint fresh crypto.randomUUID]
+    C -- "no" --> E[Keep stable uuid]
+    D --> F[Append new output-N]
+    E --> F
+    F --> G[validate forwardOnly]
+    G --> H[assertNoWireSelfLoopOnForwardOnly]
+    H -- "pass" --> I[Return cleaved creature]
+    H -- "fail" --> J[TopologyError → DNA skipped]
+```
+
+## Test Plan
+
+Added:
+
+- `test/CRISPR/AppendDemoteOutput.ts` — multi-output Issue #2618 regression
+  test covering the 3-output `DNA-SANE.json` append+demote scenario with
+  wire-format UUIDs on the previous outputs.
+- `test/architecture/ForwardOnlyAssertion.ts` — three new unit tests for
+  `assertNoWireSelfLoopOnForwardOnly`: no-op when not forward-only, passes
+  on distinct wire UUIDs, throws on UUID collision.
+
+Existing tests preserved (no test modifications):
+
+- `test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - DNA-SANE.json reproduces the multi-output demote pattern with relative anchors` — confirms the 3-output append+demote arithmetic still resolves correctly.
+- `test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT wires the demoted previous output into the new output (Issue #2509)` — confirms the single-output GRQ #2237 reproducer continues to pass.
+- All other 94 CRISPR tests pass unchanged.
+
+## Files changed
+
+- `src/reconstruct/CRISPR.ts` — `append()` mints a fresh UUID for any
+  demoted neuron whose stored `uuid` matches `^output-\d+$`; `cleaveDNA()`
+  invokes the new wire-self-loop assertion on the forward-only path.
+- `src/architecture/ForwardOnlyAssertion.ts` — new
+  `assertNoWireSelfLoopOnForwardOnly()` helper.
+- `test/CRISPR/AppendDemoteOutput.ts` — new regression test.
+- `test/architecture/ForwardOnlyAssertion.ts` — new unit tests for the
+  wire-self-loop assertion.

--- a/src/architecture/ForwardOnlyAssertion.ts
+++ b/src/architecture/ForwardOnlyAssertion.ts
@@ -10,6 +10,7 @@
  */
 import type { Creature } from "@creature";
 import { TopologyError } from "@errors/TopologyError.ts";
+import { neuronUuid } from "@neuron/NeuronSerialization.ts";
 
 /**
  * Throws a {@link TopologyError} when `creature.forwardOnly === true`
@@ -39,5 +40,69 @@ export function assertNoRecurrentSynapseOnForwardOnly(
         "INVALID_CONNECTION",
       );
     }
+  }
+}
+
+/**
+ * Throws a {@link TopologyError} when any synapse on `creature` resolves to
+ * the same wire UUID on both endpoints — i.e. a self-loop in the exported
+ * wire format that would survive `exportJSON()`.
+ *
+ * Issue #2618: positional `from < to` validation passes when two distinct
+ * neurons (e.g. a demoted previous output and a freshly appended output)
+ * share the same wire UUID (`output-N`). Once the creature is exported the
+ * wire-format synapse collapses to `output-N -> output-N`, which downstream
+ * pipelines (GRQ scorer, `loadFrom`) reject. Detect the collision at the
+ * producer so the upstream stack frame is named.
+ *
+ * @param creature The creature to check.
+ * @param source Short tag identifying the calling pipeline.
+ */
+export function assertNoWireSelfLoopOnForwardOnly(
+  creature: Creature,
+  source: string,
+): void {
+  if (creature.forwardOnly !== true) return;
+  const synapses = creature.synapses;
+  if (!synapses || synapses.length === 0) return;
+  const neurons = creature.neurons;
+  // Build wire uuid by position once. Inputs use `input-N`, outputs use
+  // `output-N` (canonical), hidden/constant use their stored `uuid`.
+  const wire = new Array<string | undefined>(neurons.length);
+  for (let i = 0; i < neurons.length; i++) {
+    const n = neurons[i];
+    if (n.type === "input") {
+      wire[i] = `input-${i}`;
+    } else {
+      try {
+        wire[i] = neuronUuid(n);
+      } catch {
+        wire[i] = undefined;
+      }
+    }
+  }
+
+  const offending: string[] = [];
+  for (let i = 0; i < synapses.length; i++) {
+    const s = synapses[i];
+    const f = wire[s.from];
+    const t = wire[s.to];
+    if (f !== undefined && t !== undefined && f === t) {
+      offending.push(
+        `${f}(${neurons[s.from].type})->${t}(${neurons[s.to].type})`,
+      );
+    }
+  }
+  if (offending.length > 0) {
+    throw new TopologyError(
+      `[${source}] Forward-only creature ${
+        creature.uuid ?? "(no-uuid)"
+      } has ${offending.length} wire-format self-loop synapse(s): ${
+        offending.join("; ")
+      }. Two distinct neurons share the same wire uuid; the cleaved or ` +
+        `mutated creature will export as a self-loop and be rejected ` +
+        `downstream (Issue #2618).`,
+      "INVALID_CONNECTION",
+    );
   }
 }

--- a/src/reconstruct/CRISPR.ts
+++ b/src/reconstruct/CRISPR.ts
@@ -2,6 +2,7 @@ import { addTag, getTag, type TagsInterface } from "@stsoftware/tags/mod";
 import { CreatureUtil, Upgrade } from "../../mod.ts";
 import { Neuron } from "@architecture/Neuron.ts";
 import { nextNeuronId, outputNeuronId } from "@architecture/NeuronId.ts";
+import { assertNoWireSelfLoopOnForwardOnly } from "@architecture/ForwardOnlyAssertion.ts";
 import type { Creature } from "@creature";
 import { CrisprError } from "@errors/CrisprError.ts";
 import { TopologyError } from "@errors/TopologyError.ts";
@@ -357,7 +358,22 @@ export class CRISPR {
             firstNetworkOutputIndex = indx;
           }
           neuron.type = "hidden";
-          if (neuron.uuid === undefined) {
+          // Issue #2618: ALWAYS mint a fresh stable uuid on demotion. The
+          // previous uuid is the wire-format label (`output-N`) that
+          // `exportJSON()` produced for the original output role; once the
+          // neuron is demoted to hidden, that label collides with the wire
+          // uuid the freshly appended output will produce for the same
+          // index N. Without this rewrite, the cleaved creature emits
+          // `output-N -> output-N` self-loops on export — one per appended
+          // output (multi-output regression of GRQ #2237).
+          //
+          // Only `output-N`-shaped strings are unsafe — any other previously
+          // assigned uuid is genuinely stable and must be preserved to
+          // honour the neuron-uuid-stability invariant (AGENTS.md).
+          if (
+            neuron.uuid === undefined ||
+            /^output-\d+$/.test(neuron.uuid)
+          ) {
             neuron.uuid = crypto.randomUUID();
           }
           if (neuron.id !== undefined && neuron.id < 0) {
@@ -689,6 +705,12 @@ export class CRISPR {
         // fix() here — reject the DNA and return the original (Issue #2086).
         modifiedCreature.validate({ forwardOnly: true });
         modifiedCreature.forwardOnly = true;
+        // Issue #2618: defence-in-depth wire-format check. Positional
+        // validation cannot detect synapses where two distinct neurons
+        // share the same wire uuid (e.g. a demoted `output-N` previous
+        // output and a freshly appended `output-N`). Catch any such
+        // collision before the cleaved creature leaves CRISPR.
+        assertNoWireSelfLoopOnForwardOnly(modifiedCreature, "CRISPR.cleaveDNA");
       } else {
         modifiedCreature.validate();
       }

--- a/test/CRISPR/AppendDemoteOutput.ts
+++ b/test/CRISPR/AppendDemoteOutput.ts
@@ -161,3 +161,118 @@ Deno.test("CRISPR append+demote - DNA-SANE.json reproduces the multi-output demo
     }
   }
 });
+
+// Regression test for Issue #2618: when the previous outputs already carry
+// canonical wire-format uuids (`output-0`, `output-1`, ...), as produced by
+// `exportJSON()` and faithfully restored by `Creature.fromJSON()`, the demoted
+// neurons must NOT keep those wire labels. Otherwise the cleaved creature
+// emits `output-N -> output-N` self-loops once exported (because both the
+// demoted hidden neuron and the freshly appended output collapse to the same
+// wire UUID).
+//
+// This is the multi-output variant of GRQ #2237 / NEAT-AI #2618. The single-
+// output reproducer is the same scenario with one output.
+Deno.test("CRISPR append+demote - demoted previous outputs with wire-format `output-N` uuids do not collide with new outputs (Issue #2618, multi-output)", () => {
+  const json: CreatureInternal = {
+    input: 3,
+    output: 3,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", squash: "LOGISTIC", bias: 0, index: 3, uuid: "h1" },
+      // Wire-format uuids ("output-N") as produced by exportJSON and re-loaded.
+      {
+        type: "output",
+        squash: "IDENTITY",
+        bias: 0,
+        index: 4,
+        uuid: "output-0",
+      },
+      {
+        type: "output",
+        squash: "IDENTITY",
+        bias: 0,
+        index: 5,
+        uuid: "output-1",
+      },
+      {
+        type: "output",
+        squash: "LOGISTIC",
+        bias: 0,
+        index: 6,
+        uuid: "output-2",
+      },
+    ],
+    synapses: [
+      { from: 0, to: 3, weight: 0.1 },
+      { from: 3, to: 4, weight: 0.2 },
+      { from: 1, to: 5, weight: 0.3 },
+      { from: 2, to: 6, weight: 0.4 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  // Mark forward-only so the cleaveDNA path enforces the strict invariant.
+  creature.forwardOnly = true;
+
+  const dnaTXT = Deno.readTextFileSync("test/data/CRISPR/DNA-SANE.json");
+  const modified = new CRISPR(creature).cleaveDNA(
+    JSON.parse(dnaTXT),
+  ) as Creature;
+  // Forward-only must be preserved through cleaveDNA.
+  assertEquals(modified.forwardOnly, true);
+
+  // The cleaved creature must export cleanly (no recurrent synapses) — this
+  // is the contract enforced by the post-cleave forward-only assertion in
+  // GRQ's pipeline.
+  const exported = modified.exportJSON();
+
+  // Wire-format invariant 1: every neuron in the export must have a UNIQUE
+  // wire UUID. The demoted previous outputs must not collide on `output-N`
+  // with the freshly appended outputs.
+  const seenUuids = new Set<string>();
+  for (const n of exported.neurons) {
+    const id = n.uuid ?? "(no-uuid)";
+    assert(
+      !seenUuids.has(id),
+      `Duplicate neuron wire uuid in exported creature: ${id}`,
+    );
+    seenUuids.add(id);
+  }
+
+  // Wire-format invariant 2: no synapse may be a self-loop in the wire
+  // format (fromUUID === toUUID). This is exactly the failure GRQ's
+  // `assertCleavedCreatureForwardOnly` reports.
+  for (const s of exported.synapses) {
+    const from = (s as { fromUUID?: string }).fromUUID;
+    const to = (s as { toUUID?: string }).toUUID;
+    assert(
+      from !== undefined && to !== undefined,
+      `Exported synapse missing fromUUID/toUUID: ${JSON.stringify(s)}`,
+    );
+    assert(
+      from !== to,
+      `Wire-format self-loop in cleaved creature: ${from} -> ${to}`,
+    );
+  }
+
+  // Acceptance criterion: the three new outputs are still distinct and the
+  // demoted previous outputs survive as hidden neurons (with fresh, unique
+  // wire uuids).
+  const outputs = modified.neurons.filter((n) => n.type === "output");
+  assertEquals(outputs.length, 3);
+  const demoted = modified.neurons.filter((n) =>
+    n.type === "hidden" && n.id !== undefined && n.id >= 1_000_000 &&
+    n.uuid !== "h1"
+  );
+  assertEquals(
+    demoted.length,
+    3,
+    "Three previous outputs must survive as hidden neurons",
+  );
+  // None of the demoted neurons may carry a wire-format `output-N` uuid.
+  for (const d of demoted) {
+    assert(
+      typeof d.uuid === "string" && !/^output-\d+$/.test(d.uuid),
+      `Demoted previous output must have a fresh non-wire uuid; got ${d.uuid}`,
+    );
+  }
+});

--- a/test/architecture/ForwardOnlyAssertion.ts
+++ b/test/architecture/ForwardOnlyAssertion.ts
@@ -10,7 +10,10 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { Creature } from "@creature";
 import { Synapse } from "@architecture/Synapse.ts";
-import { assertNoRecurrentSynapseOnForwardOnly } from "@architecture/ForwardOnlyAssertion.ts";
+import {
+  assertNoRecurrentSynapseOnForwardOnly,
+  assertNoWireSelfLoopOnForwardOnly,
+} from "@architecture/ForwardOnlyAssertion.ts";
 import { TopologyError } from "@errors/TopologyError.ts";
 import { initWasmForTests } from "../_initWasm.ts";
 
@@ -62,4 +65,42 @@ Deno.test("assertNoRecurrentSynapseOnForwardOnly: throws on backward edge", asyn
     TopologyError,
     "breed:test",
   );
+});
+
+// Issue #2618: wire-format UUID collision detection.
+Deno.test("assertNoWireSelfLoopOnForwardOnly: no-op when forwardOnly false", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { feedbackEnabled: true });
+  c.forwardOnly = false;
+  assertNoWireSelfLoopOnForwardOnly(c, "unit-test");
+});
+
+Deno.test("assertNoWireSelfLoopOnForwardOnly: passes for distinct wire uuids", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { layers: [{ count: 2 }] });
+  c.forwardOnly = true;
+  // Default constructor produces neurons with distinct wire uuids.
+  assertNoWireSelfLoopOnForwardOnly(c, "unit-test");
+});
+
+Deno.test("assertNoWireSelfLoopOnForwardOnly: throws when two neurons share a wire uuid (Issue #2618)", async () => {
+  await initWasmForTests();
+  const c = new Creature(2, 1, { layers: [{ count: 2 }] });
+  c.forwardOnly = true;
+  // Force a collision: a hidden neuron whose stored uuid matches the
+  // canonical wire label of the output. Synapse from hidden -> output
+  // exports as `output-0 -> output-0`.
+  const hidden = c.neurons.find((n) => n.type === "hidden");
+  if (!hidden) throw new Error("expected hidden neuron in fixture");
+  hidden.uuid = "output-0";
+  c.synapses.push(new Synapse(hidden.index, c.neurons.length - 1, 0.1));
+
+  const err = assertThrows(
+    () => assertNoWireSelfLoopOnForwardOnly(c, "CRISPR.cleaveDNA"),
+    TopologyError,
+  );
+  const msg = String((err as Error).message);
+  assertEquals(msg.includes("CRISPR.cleaveDNA"), true);
+  assertEquals(msg.includes("wire-format self-loop"), true);
+  assertEquals(msg.includes("output-0"), true);
 });


### PR DESCRIPTION
# CRISPR append-mode wire-format UUID collision (Issue #2618)

## Summary

Fixes the multi-output regression where `CRISPR.cleaveDNA` in append-mode
emitted one `output-N → output-N` self-loop per appended output. The cleaved
creature passed positional forward-only validation but exported as a
wire-format self-loop because the demoted previous output kept the literal
`uuid: "output-N"` string it had been re-loaded with, colliding with the new
output neuron's canonical `output-N` wire identity.

The fix is two-part and addresses both acceptance criteria from the issue:

1. **Producer fix** — in `CRISPR.append()`, the demotion path now mints a
   fresh stable UUID for any demoted neuron whose stored `uuid` matches the
   wire-format pattern `^output-\d+$`. Non-`output-N` UUIDs are preserved to
   honour the neuron-uuid-stability invariant (AGENTS.md).
2. **Producer-side assertion** — `assertNoWireSelfLoopOnForwardOnly()` is a
   new defence-in-depth check that compares wire UUIDs of every synapse's
   endpoints. `CRISPR.cleaveDNA` now invokes it on the
   `enforceForwardOnly` path so any future regression is caught at the
   producer with the upstream stack frame named — not silently downstream.

Closes #2618.

## Evidence

Backend-only change with no UI surface — verified via unit tests.

### Regression test added

`test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - demoted previous outputs with wire-format output-N uuids do not collide with new outputs (Issue #2618, multi-output)`

The test loads the project's existing `test/data/CRISPR/DNA-SANE.json`
(3-output append-mode DNA: IDENTITY + MINIMUM + MAXIMUM) into a forward-only
creature whose original output neurons carry the wire-format UUIDs
`output-0`, `output-1`, `output-2` — the exact shape `Creature.fromJSON()`
restores from a previously-exported JSON file. Without the fix, three
`output-N → output-N` self-loops appear in the exported wire format. With
the fix, the exported synapses have unique wire UUIDs at every endpoint.

### Failure reproduced before the fix

Pre-fix run output (3 self-loops, exactly the GRQ scorer trace):

```
Exported synapses:
  ...
  output-0 -> output-0
  output-0 -> output-1
  output-0 -> output-2
  output-1 -> output-0
  output-1 -> output-1
  output-1 -> output-2
  output-2 -> output-0
  output-2 -> output-1
  output-2 -> output-2
```

Post-fix the demoted neurons carry fresh UUIDs and no synapse has
`fromUUID === toUUID`.

### Quality gate

`./quality.sh` passes the relevant test files (`test/CRISPR/*.ts`,
`test/architecture/ForwardOnlyAssertion.ts`). The single pre-existing
Discovery FFI dynamic-library leak detection failure
(`DiscoverDirectory returns partial results on timeout`) is unrelated to
this change — it reproduces on the unmodified branch as well.

### Flow diagram

```mermaid
flowchart LR
    A[Creature with output-N uuids<br/>loaded from disk] --> B[CRISPR.append]
    B --> C{Demoted output<br/>uuid matches output-N?}
    C -- "yes (Issue #2618)" --> D[Mint fresh crypto.randomUUID]
    C -- "no" --> E[Keep stable uuid]
    D --> F[Append new output-N]
    E --> F
    F --> G[validate forwardOnly]
    G --> H[assertNoWireSelfLoopOnForwardOnly]
    H -- "pass" --> I[Return cleaved creature]
    H -- "fail" --> J[TopologyError → DNA skipped]
```

## Test Plan

Added:

- `test/CRISPR/AppendDemoteOutput.ts` — multi-output Issue #2618 regression
  test covering the 3-output `DNA-SANE.json` append+demote scenario with
  wire-format UUIDs on the previous outputs.
- `test/architecture/ForwardOnlyAssertion.ts` — three new unit tests for
  `assertNoWireSelfLoopOnForwardOnly`: no-op when not forward-only, passes
  on distinct wire UUIDs, throws on UUID collision.

Existing tests preserved (no test modifications):

- `test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - DNA-SANE.json reproduces the multi-output demote pattern with relative anchors` — confirms the 3-output append+demote arithmetic still resolves correctly.
- `test/CRISPR/AppendDemoteOutput.ts::CRISPR append+demote - fromRelative: FROM_RELATIVE_DEMOTED_OUTPUT wires the demoted previous output into the new output (Issue #2509)` — confirms the single-output GRQ #2237 reproducer continues to pass.
- All other 94 CRISPR tests pass unchanged.

## Files changed

- `src/reconstruct/CRISPR.ts` — `append()` mints a fresh UUID for any
  demoted neuron whose stored `uuid` matches `^output-\d+$`; `cleaveDNA()`
  invokes the new wire-self-loop assertion on the forward-only path.
- `src/architecture/ForwardOnlyAssertion.ts` — new
  `assertNoWireSelfLoopOnForwardOnly()` helper.
- `test/CRISPR/AppendDemoteOutput.ts` — new regression test.
- `test/architecture/ForwardOnlyAssertion.ts` — new unit tests for the
  wire-self-loop assertion.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2618 -->