### PR TITLE
Wire synthetic-UUID alignment fallback into createCompatibleFather (Issue #2614)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NEAT_RUST_DISCOVERY_OPTIONAL: "true"
+      # Enable per-process discovery directory isolation so parallel test
+      # workers don't collide on the same creature-UUID subdirectory.
+      DENO_TEST: "1"
 
     steps:
       # Checkout the code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,11 +297,20 @@ boundary, disk write, or cross-machine handoff.
 
 - **Grafting / `createCompatibleFather`**: Hidden and constant neurons are
   aligned to the mother’s id scheme **by matching stable wire `uuid` first**,
-  then by a connectivity fingerprint (integer neighbour ids) for any remaining
-  neurons. **Cross-machine**: the same saved genome should carry the same uuids;
-  alignment does not depend on neuron array position. When genetic compatibility
-  is below threshold, `editParentByIndex` may still reassign ids by **scan
-  order** — that path is a deliberate fallback for badly mismatched topologies.
+  then — when the real-UUID overlap is below `syntheticAlignmentThreshold`
+  (default `0.2`, Issue #2614) — by **location-based synthetic UUIDs** computed
+  on demand from `computeSyntheticLocationUuids` (Issue #2613), and finally by a
+  connectivity fingerprint (integer neighbour ids) for any remaining neurons.
+  Synthetic UUIDs follow a loose-match rule (either anchor — input-side OR
+  output-side — wins on first match) so structurally similar but genetically
+  incompatible parents pick up real crossover anchor points. They are **never
+  persisted**: aligned father neurons inherit the mother's real UUID, and the
+  resulting `CreatureExport` only ever carries real UUIDs (no
+  `${anchor}-${steps}-${sign}-${rank}` strings). **Cross-machine**: the same
+  saved genome should carry the same uuids; alignment does not depend on neuron
+  array position. When genetic compatibility is below threshold,
+  `editParentByIndex` may still reassign ids by **scan order** — that path is a
+  deliberate fallback for badly mismatched topologies.
 
 ### 🔢 Semantic version is immutable after upgrade (CRITICAL INVARIANT)
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2614.md
+++ b/docs/pr-summary-2614.md
@@ -1,0 +1,77 @@
+# PR Summary — Issue #2614
+
+## Summary
+
+Wire the synthetic location-based UUID alignment fallback (delivered as a
+pure function in #2613) into `createCompatibleFather` and
+`createCompatibleFatherFromCreatures` so genetically incompatible parents
+gain real crossover anchor points without persisting any synthetic
+identifiers. The new pass runs **after** the existing stable-UUID
+alignment and **before** the connectivity-key fallback, gated on a
+configurable threshold (default `0.2`). Aligned father neurons inherit
+the mother's real UUID; the resulting `CreatureExport` only ever carries
+real UUIDs.
+
+Closes #2614.
+
+## Evidence
+
+This is a backend / library change with no UI surface. Verified via:
+
+- 6 new unit tests in `test/breed/SyntheticLocationFatherAlignment.ts`
+  cover the above-threshold no-op, below-threshold synthetic alignment,
+  loose-match behaviour, double-claim guard, the `createCompatibleFatherFromCreatures`
+  variant, and the regression that no synthetic-UUID strings appear in
+  the resulting export (including a `Creature.fromJSON` → `exportJSON`
+  round-trip).
+- The full quality gate (`./quality.sh`) was run; 6,590 tests pass. The
+  three pre-existing FFI-leak failures in
+  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` reproduce on
+  the unmodified `Develop` branch and are unrelated to this change.
+
+### Alignment flow
+
+```mermaid
+flowchart TD
+    A[mother + father] --> B{real-UUID overlap}
+    B -- ">= syntheticAlignmentThreshold" --> C[stable-uuid pass]
+    B -- "< syntheticAlignmentThreshold" --> D[stable-uuid pass]
+    D --> E[synthetic-UUID pass<br/>compute for both parents]
+    E --> F{either synthetic<br/>UUID matches?}
+    F -- "yes" --> G[claim mother id,<br/>adopt mother real uuid]
+    F -- "no" --> H[connectivity-key fallback]
+    C --> I[gene swap uses<br/>real UUIDs only]
+    G --> I
+    H --> I
+```
+
+## Test Plan
+
+New tests added in `test/breed/SyntheticLocationFatherAlignment.ts`:
+
+- `createCompatibleFather: above-threshold case is a no-op` — overlap = 1
+  leaves the existing alignment untouched.
+- `createCompatibleFather: below-threshold case aligns at least one
+  neuron via synthetic UUID` — disjoint-UUID linear chains pick up the
+  mother's real UUIDs via the synthetic pass, with a baseline run at
+  `threshold = 0` confirming the alignment depended on the new pass.
+- `createCompatibleFather: loose match — input-anchor only also aligns`
+  — output-anchor mismatch still yields alignment via the input anchor.
+- `createCompatibleFather: stable-UUID alignment is not double-claimed
+  by synthetic pass` — a mother neuron already claimed by the
+  stable-UUID pass is not re-bound by the synthetic pass.
+- `createCompatibleFatherFromCreatures: below-threshold case aligns via
+  synthetic UUID and exports cleanly` — Creatures input path aligns and
+  the round-trip `exportJSON` contains zero `-pos-` / `-neg-` strings.
+- `createCompatibleFatherFromCreatures: threshold = 0 disables synthetic
+  pass` — explicit opt-out.
+
+Modified tests (documented in-line):
+
+- `test/breed/CompatibilityGating.ts`: two tests previously asserted
+  `geneticCompatibility(mother, dad) == 0` after `findFather` to verify
+  the lowest-compat candidate was selected. With the synthetic-UUID
+  fallback in place, the returned father inherits the mother's UUIDs so
+  post-alignment compatibility is no longer a stable proxy. The tests
+  now identify the chosen candidate by hidden-neuron count, preserving
+  the original intent.

--- a/docs/pr-summary-2614.md
+++ b/docs/pr-summary-2614.md
@@ -2,15 +2,14 @@
 
 ## Summary
 
-Wire the synthetic location-based UUID alignment fallback (delivered as a
-pure function in #2613) into `createCompatibleFather` and
-`createCompatibleFatherFromCreatures` so genetically incompatible parents
-gain real crossover anchor points without persisting any synthetic
-identifiers. The new pass runs **after** the existing stable-UUID
-alignment and **before** the connectivity-key fallback, gated on a
-configurable threshold (default `0.2`). Aligned father neurons inherit
-the mother's real UUID; the resulting `CreatureExport` only ever carries
-real UUIDs.
+Wire the synthetic location-based UUID alignment fallback (delivered as a pure
+function in #2613) into `createCompatibleFather` and
+`createCompatibleFatherFromCreatures` so genetically incompatible parents gain
+real crossover anchor points without persisting any synthetic identifiers. The
+new pass runs **after** the existing stable-UUID alignment and **before** the
+connectivity-key fallback, gated on a configurable threshold (default `0.2`).
+Aligned father neurons inherit the mother's real UUID; the resulting
+`CreatureExport` only ever carries real UUIDs.
 
 Closes #2614.
 
@@ -18,16 +17,15 @@ Closes #2614.
 
 This is a backend / library change with no UI surface. Verified via:
 
-- 6 new unit tests in `test/breed/SyntheticLocationFatherAlignment.ts`
-  cover the above-threshold no-op, below-threshold synthetic alignment,
-  loose-match behaviour, double-claim guard, the `createCompatibleFatherFromCreatures`
-  variant, and the regression that no synthetic-UUID strings appear in
-  the resulting export (including a `Creature.fromJSON` → `exportJSON`
-  round-trip).
-- The full quality gate (`./quality.sh`) was run; 6,590 tests pass. The
-  three pre-existing FFI-leak failures in
-  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` reproduce on
-  the unmodified `Develop` branch and are unrelated to this change.
+- 6 new unit tests in `test/breed/SyntheticLocationFatherAlignment.ts` cover the
+  above-threshold no-op, below-threshold synthetic alignment, loose-match
+  behaviour, double-claim guard, the `createCompatibleFatherFromCreatures`
+  variant, and the regression that no synthetic-UUID strings appear in the
+  resulting export (including a `Creature.fromJSON` → `exportJSON` round-trip).
+- The full quality gate (`./quality.sh`) was run; 6,590 tests pass. The three
+  pre-existing FFI-leak failures in
+  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` reproduce on the
+  unmodified `Develop` branch and are unrelated to this change.
 
 ### Alignment flow
 
@@ -49,29 +47,32 @@ flowchart TD
 
 New tests added in `test/breed/SyntheticLocationFatherAlignment.ts`:
 
-- `createCompatibleFather: above-threshold case is a no-op` — overlap = 1
-  leaves the existing alignment untouched.
+- `createCompatibleFather: above-threshold case is a no-op` — overlap = 1 leaves
+  the existing alignment untouched.
 - `createCompatibleFather: below-threshold case aligns at least one
-  neuron via synthetic UUID` — disjoint-UUID linear chains pick up the
-  mother's real UUIDs via the synthetic pass, with a baseline run at
-  `threshold = 0` confirming the alignment depended on the new pass.
-- `createCompatibleFather: loose match — input-anchor only also aligns`
-  — output-anchor mismatch still yields alignment via the input anchor.
+  neuron via synthetic UUID`
+  — disjoint-UUID linear chains pick up the mother's real UUIDs via the
+  synthetic pass, with a baseline run at `threshold = 0` confirming the
+  alignment depended on the new pass.
+- `createCompatibleFather: loose match — input-anchor only also aligns` —
+  output-anchor mismatch still yields alignment via the input anchor.
 - `createCompatibleFather: stable-UUID alignment is not double-claimed
-  by synthetic pass` — a mother neuron already claimed by the
-  stable-UUID pass is not re-bound by the synthetic pass.
+  by synthetic pass`
+  — a mother neuron already claimed by the stable-UUID pass is not re-bound by
+  the synthetic pass.
 - `createCompatibleFatherFromCreatures: below-threshold case aligns via
-  synthetic UUID and exports cleanly` — Creatures input path aligns and
-  the round-trip `exportJSON` contains zero `-pos-` / `-neg-` strings.
+  synthetic UUID and exports cleanly`
+  — Creatures input path aligns and the round-trip `exportJSON` contains zero
+  `-pos-` / `-neg-` strings.
 - `createCompatibleFatherFromCreatures: threshold = 0 disables synthetic
-  pass` — explicit opt-out.
+  pass`
+  — explicit opt-out.
 
 Modified tests (documented in-line):
 
 - `test/breed/CompatibilityGating.ts`: two tests previously asserted
-  `geneticCompatibility(mother, dad) == 0` after `findFather` to verify
-  the lowest-compat candidate was selected. With the synthetic-UUID
-  fallback in place, the returned father inherits the mother's UUIDs so
-  post-alignment compatibility is no longer a stable proxy. The tests
-  now identify the chosen candidate by hidden-neuron count, preserving
-  the original intent.
+  `geneticCompatibility(mother, dad) == 0` after `findFather` to verify the
+  lowest-compat candidate was selected. With the synthetic-UUID fallback in
+  place, the returned father inherits the mother's UUIDs so post-alignment
+  compatibility is no longer a stable proxy. The tests now identify the chosen
+  candidate by hidden-neuron count, preserving the original intent.

--- a/src/breed/Father.ts
+++ b/src/breed/Father.ts
@@ -6,6 +6,17 @@ import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.t
 import { isOutputNeuronId, outputIndexFromId } from "@architecture/NeuronId.ts";
 import type { NeuronExport } from "@architecture/NeuronInterfaces.ts";
 import { neuronUuid } from "@neuron/NeuronSerialization.ts";
+import {
+  computeSyntheticLocationUuids,
+  computeSyntheticLocationUuidsExport,
+} from "@breed/SyntheticLocationUuid.ts";
+
+/**
+ * Default threshold for the synthetic-UUID alignment fallback (Issue #2614).
+ * Mirrors `NeatArguments.syntheticAlignmentThreshold` so callers that omit
+ * the option get the same behaviour as the configured pipeline default.
+ */
+export const DEFAULT_SYNTHETIC_ALIGNMENT_THRESHOLD = 0.2;
 
 /**
  * Lightweight neuron info needed for compatibility check.
@@ -194,6 +205,112 @@ function applyStableUuidAlignmentExport(
   }
 }
 
+/**
+ * Collects hidden-neuron wire UUIDs from a `CreatureExport` for the
+ * real-UUID overlap pre-check (Issue #2614). Mirrors the behaviour of
+ * `Creature.getHiddenNeuronWireKeys()` for the export shape.
+ */
+function collectHiddenWireUuidsFromExport(
+  creature: CreatureExport,
+): Set<string> {
+  const out = new Set<string>();
+  for (const n of creature.neurons) {
+    if (n.type !== "hidden") continue;
+    if (typeof n.uuid === "string" && n.uuid.length > 0) {
+      out.add(n.uuid);
+    } else if ((n as { id?: number }).id !== undefined) {
+      out.add(String((n as { id: number }).id));
+    }
+  }
+  return out;
+}
+
+/**
+ * Computes the real-UUID overlap ratio used to gate the synthetic-UUID
+ * alignment fallback (Issue #2614). The numerator is the number of
+ * hidden-neuron UUIDs shared between the two sets; the denominator is the
+ * smaller of the two set sizes — matching the ratio used by
+ * `geneticCompatibility`. Returns `1` when both sets are empty so empty
+ * topologies are treated as fully compatible (the fallback never fires).
+ */
+function realUuidOverlapRatio(
+  motherUuids: Set<string>,
+  fatherUuids: Set<string>,
+): number {
+  const smallest = motherUuids.size < fatherUuids.size
+    ? motherUuids
+    : fatherUuids;
+  const other = motherUuids.size < fatherUuids.size ? fatherUuids : motherUuids;
+  if (smallest.size === 0) return 1;
+  let matches = 0;
+  for (const u of smallest) {
+    if (other.has(u)) matches++;
+  }
+  return matches / smallest.size;
+}
+
+/**
+ * Synthetic-UUID alignment fallback (Issue #2614).
+ *
+ * Builds `Map<syntheticUUID, motherNeuronId>` from the mother's hidden
+ * neurons, then walks each father hidden/constant neuron and aligns it
+ * to a mother id if **either** of its two synthetic UUIDs matches a key
+ * in the map (loose match — first match wins, input anchor preferred).
+ *
+ * Existing usage guards still apply: an alignment is only recorded when
+ * `motherId` is not already present in the father's id space, when no
+ * other father neuron has already claimed the mother id, and when the
+ * father neuron itself has not already been aligned by an earlier pass.
+ *
+ * Aligned neurons inherit the mother's real UUID via the existing
+ * remap step in `createCompatibleFather*`. Synthetic UUIDs are never
+ * written into a neuron, the `idMapping`, or the resulting export.
+ */
+function applySyntheticUuidAlignment(
+  motherSynthByMotherId: Map<number, Set<string>>,
+  fatherSynthByFatherId: Map<number, Set<string>>,
+  idMapping: Map<number, number>,
+  usedMotherIds: Set<number>,
+  usedFatherIds: Set<number>,
+  fatherIds: Set<number>,
+): void {
+  if (
+    motherSynthByMotherId.size === 0 ||
+    fatherSynthByFatherId.size === 0
+  ) {
+    return;
+  }
+
+  // Build synthetic→mother-id index. When a synthetic UUID is shared by
+  // multiple mother neurons (rare but possible at the same anchor/steps/sign
+  // bucket once any mother neuron is bias-only and skipped above), keep the
+  // smallest mother id for deterministic behaviour.
+  const motherBySynthetic = new Map<string, number>();
+  for (const [motherId, synthSet] of motherSynthByMotherId) {
+    for (const synth of synthSet) {
+      const existing = motherBySynthetic.get(synth);
+      if (existing === undefined || motherId < existing) {
+        motherBySynthetic.set(synth, motherId);
+      }
+    }
+  }
+
+  for (const [fatherId, synthSet] of fatherSynthByFatherId) {
+    if (usedFatherIds.has(fatherId)) continue;
+    for (const synth of synthSet) {
+      const motherId = motherBySynthetic.get(synth);
+      if (motherId === undefined) continue;
+      if (fatherIds.has(motherId)) continue;
+      if (usedMotherIds.has(motherId)) continue;
+      // First match wins (loose match rule, Issue #2614).
+      idMapping.set(fatherId, motherId);
+      usedMotherIds.add(motherId);
+      usedFatherIds.add(fatherId);
+      break;
+    }
+  }
+}
+
 function applyStableUuidAlignmentCreatures(
   motherNeurons: Neuron[],
   fatherNeurons: Neuron[],
@@ -228,6 +345,7 @@ function applyStableUuidAlignmentCreatures(
 export function createCompatibleFather(
   mother: CreatureExport,
   father: CreatureExport,
+  syntheticAlignmentThreshold: number = DEFAULT_SYNTHETIC_ALIGNMENT_THRESHOLD,
 ): CreatureExport {
   normaliseCreatureExport(mother);
   normaliseCreatureExport(father);
@@ -253,6 +371,30 @@ export function createCompatibleFather(
     usedFatherIds,
     fatherIds,
   );
+
+  // Issue #2614: When the real-UUID overlap between mother and father is
+  // below `syntheticAlignmentThreshold`, fall back to location-based
+  // synthetic UUIDs (loose-match — either anchor) so structurally similar
+  // but genetically incompatible parents pick up real crossover anchors.
+  // The synthetic UUIDs are only consulted here; real UUIDs continue to
+  // drive the gene swap below and the resulting export.
+  if (syntheticAlignmentThreshold > 0) {
+    const motherWireUuids = collectHiddenWireUuidsFromExport(mother);
+    const fatherWireUuids = collectHiddenWireUuidsFromExport(father);
+    const overlap = realUuidOverlapRatio(motherWireUuids, fatherWireUuids);
+    if (overlap < syntheticAlignmentThreshold) {
+      const motherSynth = computeSyntheticLocationUuidsExport(mother);
+      const fatherSynth = computeSyntheticLocationUuidsExport(father);
+      applySyntheticUuidAlignment(
+        motherSynth,
+        fatherSynth,
+        idMapping,
+        usedMotherIds,
+        usedFatherIds,
+        fatherIds,
+      );
+    }
+  }
 
   // Generate neuron key maps for both mother and father, using sorted synapses
   const motherKeyMap = generateNeuronKeyMap(mother);
@@ -367,6 +509,7 @@ export function createCompatibleFather(
 export function createCompatibleFatherFromCreatures(
   mother: Creature,
   father: Creature,
+  syntheticAlignmentThreshold: number = DEFAULT_SYNTHETIC_ALIGNMENT_THRESHOLD,
 ): CreatureExport {
   const idMapping = new Map<number, number>();
   const usedMotherIds = new Set<number>();
@@ -390,6 +533,27 @@ export function createCompatibleFatherFromCreatures(
     usedFatherIds,
     fatherIds,
   );
+
+  // Issue #2614: synthetic-UUID alignment fallback for genetically
+  // incompatible parents — same gating and rules as the export path.
+  if (syntheticAlignmentThreshold > 0) {
+    const overlap = realUuidOverlapRatio(
+      mother.getHiddenNeuronWireKeys(),
+      father.getHiddenNeuronWireKeys(),
+    );
+    if (overlap < syntheticAlignmentThreshold) {
+      const motherSynth = computeSyntheticLocationUuids(mother);
+      const fatherSynth = computeSyntheticLocationUuids(father);
+      applySyntheticUuidAlignment(
+        motherSynth,
+        fatherSynth,
+        idMapping,
+        usedMotherIds,
+        usedFatherIds,
+        fatherIds,
+      );
+    }
+  }
 
   // Generate neuron key maps for both mother and father, using Creature objects directly
   const motherKeyMap = generateNeuronKeyMapFromCreature(mother);

--- a/src/breed/ParentSelection.ts
+++ b/src/breed/ParentSelection.ts
@@ -334,7 +334,14 @@ export function findFather(
 
     // Issue #1034: Avoid JSON exports in parent selection compatibility check.
     // Uses optimised function that works directly with Creature objects.
-    const fatherExport = createCompatibleFatherFromCreatures(mum, father);
+    // Issue #2614: pass through the configured synthetic-UUID alignment
+    // threshold so genetically incompatible parents can pick up real
+    // crossover anchor points via location-based synthetic UUIDs.
+    const fatherExport = createCompatibleFatherFromCreatures(
+      mum,
+      father,
+      config.syntheticAlignmentThreshold,
+    );
     try {
       return Creature.fromJSON(fatherExport);
     } catch (e) {

--- a/src/breed/SyntheticLocationUuid.ts
+++ b/src/breed/SyntheticLocationUuid.ts
@@ -30,6 +30,7 @@
 
 import type { Creature } from "@creature";
 import type { Neuron } from "@architecture/Neuron.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import { isOutputNeuronId, outputIndexFromId } from "@architecture/NeuronId.ts";
 import type { Synapse } from "@architecture/Synapse.ts";
 
@@ -287,6 +288,229 @@ export function computeSyntheticLocationUuids(
     for (let rank = 0; rank < arr.length; rank++) {
       addToResult(
         arr[rank].runtimeId,
+        `${anchor}-${stepsStr}-${sign}-${rank}`,
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Export-shape variant of {@link computeSyntheticLocationUuids} used by
+ * the export-only `createCompatibleFather` path (Issue #2614).
+ *
+ * Operates on a `CreatureExport` whose neurons carry numeric `id` fields
+ * and whose synapses carry `fromId` / `toId` fields. Callers must invoke
+ * `normaliseCreatureExport` first so those fields are populated.
+ *
+ * The output is keyed by `neuron.id` (the export-side integer id) so it
+ * lines up with the rest of the alignment passes in `Father.ts`.
+ *
+ * Bias-only hidden neurons are skipped exactly as in the runtime variant.
+ */
+export function computeSyntheticLocationUuidsExport(
+  creature: CreatureExport,
+): Map<number, Set<string>> {
+  const neurons = creature.neurons;
+  const synapses = creature.synapses;
+  const N = neurons.length;
+  const inputCount = creature.input;
+
+  // Build id → array index map. Inputs occupy the first `input` indices and
+  // are not present in the export's `neurons` array — they are addressed by
+  // their canonical id `0..input-1`. We extend the index space by mapping
+  // each input id back to itself (so BFS source iteration stays simple) and
+  // map every non-input neuron's id to its position in the neurons array
+  // (offset by `input`).
+  const idToIndex = new Map<number, number>();
+  for (let i = 0; i < inputCount; i++) idToIndex.set(i, i);
+  for (let i = 0; i < N; i++) {
+    const id = (neurons[i] as { id?: number }).id;
+    if (id !== undefined) idToIndex.set(id, inputCount + i);
+  }
+
+  const totalNodes = inputCount + N;
+
+  // 1. Resolve canonical wire UUID per index. Inputs use `input-N`, outputs
+  // use `output-N` (derived from id), hidden/constant use the export uuid.
+  const wireUuid: string[] = new Array(totalNodes);
+  for (let i = 0; i < inputCount; i++) wireUuid[i] = `input-${i}`;
+  for (let i = 0; i < N; i++) {
+    const n = neurons[i];
+    const id = (n as { id?: number }).id;
+    if (n.type === "output" && id !== undefined && isOutputNeuronId(id)) {
+      wireUuid[inputCount + i] = `output-${outputIndexFromId(id)}`;
+    } else if (typeof n.uuid === "string" && n.uuid.length > 0) {
+      wireUuid[inputCount + i] = n.uuid;
+    } else {
+      wireUuid[inputCount + i] = `neuron-${inputCount + i}`;
+    }
+  }
+
+  // 2. Build incoming/outgoing adjacency by index. Synapses unresolved
+  // against the index map (e.g. dangling fromId) are silently skipped.
+  interface SyntheticEdge {
+    from: number;
+    to: number;
+    weight: number;
+  }
+  const incoming: SyntheticEdge[][] = new Array(totalNodes);
+  const outgoing: SyntheticEdge[][] = new Array(totalNodes);
+  for (let i = 0; i < totalNodes; i++) {
+    incoming[i] = [];
+    outgoing[i] = [];
+  }
+  for (let i = 0; i < synapses.length; i++) {
+    const s = synapses[i];
+    if (s.fromId === undefined || s.toId === undefined) continue;
+    const fromIdx = idToIndex.get(s.fromId);
+    const toIdx = idToIndex.get(s.toId);
+    if (fromIdx === undefined || toIdx === undefined) continue;
+    const edge: SyntheticEdge = {
+      from: fromIdx,
+      to: toIdx,
+      weight: s.weight,
+    };
+    incoming[toIdx].push(edge);
+    outgoing[fromIdx].push(edge);
+  }
+
+  // 3. Source index lists for the two BFS sweeps.
+  const inputIdxs: number[] = [];
+  for (let i = 0; i < inputCount; i++) inputIdxs.push(i);
+  const outputIdxs: number[] = [];
+  for (let i = 0; i < N; i++) {
+    if (neurons[i].type === "output") outputIdxs.push(inputCount + i);
+  }
+  outputIdxs.sort((a, b) => {
+    const ai = (neurons[a - inputCount] as { id?: number }).id ?? 0;
+    const bi = (neurons[b - inputCount] as { id?: number }).id ?? 0;
+    if (!isOutputNeuronId(ai) || !isOutputNeuronId(bi)) return ai - bi;
+    return outputIndexFromId(ai) - outputIndexFromId(bi);
+  });
+
+  const inputAnchorByIdx = multiSourceBfs(
+    inputIdxs,
+    wireUuid,
+    (idx) => outgoing[idx].map((e) => e.to),
+  );
+  const outputAnchorByIdx = multiSourceBfs(
+    outputIdxs,
+    wireUuid,
+    (idx) => incoming[idx].map((e) => e.from),
+  );
+
+  // 4. Per-hidden-neuron primary edge metadata.
+  interface ExportInfo {
+    idx: number;
+    exportId: number;
+    sign: "pos" | "neg";
+    primaryAbsWeight: number;
+    primaryFromUuid: string;
+  }
+  const hiddenInfos: ExportInfo[] = [];
+  for (let i = 0; i < N; i++) {
+    const n = neurons[i];
+    if (n.type !== "hidden" && n.type !== "constant") continue;
+    const idx = inputCount + i;
+    const inc = incoming[idx];
+    if (inc.length === 0) continue;
+    const exportId = (n as { id?: number }).id;
+    if (exportId === undefined) continue;
+    let primary = inc[0];
+    let primaryAbs = Math.abs(primary.weight);
+    let primaryFrom = wireUuid[primary.from];
+    for (let k = 1; k < inc.length; k++) {
+      const e = inc[k];
+      const aw = Math.abs(e.weight);
+      const fu = wireUuid[e.from];
+      if (aw > primaryAbs || (aw === primaryAbs && fu < primaryFrom)) {
+        primary = e;
+        primaryAbs = aw;
+        primaryFrom = fu;
+      }
+    }
+    hiddenInfos.push({
+      idx,
+      exportId,
+      sign: primary.weight >= 0 ? "pos" : "neg",
+      primaryAbsWeight: primaryAbs,
+      primaryFromUuid: primaryFrom,
+    });
+  }
+
+  // 5. Bucket and rank — same shape as the runtime variant.
+  type Bucket = ExportInfo[];
+  const inputBuckets = new Map<string, Bucket>();
+  const outputBuckets = new Map<string, Bucket>();
+  for (const info of hiddenInfos) {
+    const ia = inputAnchorByIdx.get(info.idx);
+    if (ia && ia.steps >= 1) {
+      const key = `${ia.anchor}|${ia.steps}|${info.sign}`;
+      let arr = inputBuckets.get(key);
+      if (!arr) {
+        arr = [];
+        inputBuckets.set(key, arr);
+      }
+      arr.push(info);
+    }
+    const oa = outputAnchorByIdx.get(info.idx);
+    if (oa && oa.steps >= 1) {
+      const key = `${oa.anchor}|${oa.steps}|${info.sign}`;
+      let arr = outputBuckets.get(key);
+      if (!arr) {
+        arr = [];
+        outputBuckets.set(key, arr);
+      }
+      arr.push(info);
+    }
+  }
+  const sortBucket = (arr: Bucket): void => {
+    arr.sort((a, b) => {
+      if (b.primaryAbsWeight !== a.primaryAbsWeight) {
+        return b.primaryAbsWeight - a.primaryAbsWeight;
+      }
+      if (a.primaryFromUuid < b.primaryFromUuid) return -1;
+      if (a.primaryFromUuid > b.primaryFromUuid) return 1;
+      return a.exportId - b.exportId;
+    });
+  };
+
+  const result = new Map<number, Set<string>>();
+  const addToResult = (exportId: number, uuid: string): void => {
+    let set = result.get(exportId);
+    if (!set) {
+      set = new Set<string>();
+      result.set(exportId, set);
+    }
+    set.add(uuid);
+  };
+
+  for (const [key, arr] of inputBuckets) {
+    sortBucket(arr);
+    const sep1 = key.indexOf("|");
+    const sep2 = key.indexOf("|", sep1 + 1);
+    const anchor = key.slice(0, sep1);
+    const stepsStr = key.slice(sep1 + 1, sep2);
+    const sign = key.slice(sep2 + 1);
+    for (let rank = 0; rank < arr.length; rank++) {
+      addToResult(
+        arr[rank].exportId,
+        `${anchor}-${stepsStr}-${sign}-${rank}`,
+      );
+    }
+  }
+  for (const [key, arr] of outputBuckets) {
+    sortBucket(arr);
+    const sep1 = key.indexOf("|");
+    const sep2 = key.indexOf("|", sep1 + 1);
+    const anchor = key.slice(0, sep1);
+    const stepsStr = key.slice(sep1 + 1, sep2);
+    const sign = key.slice(sep2 + 1);
+    for (let rank = 0; rank < arr.length; rank++) {
+      addToResult(
+        arr[rank].exportId,
         `${anchor}-${stepsStr}-${sign}-${rank}`,
       );
     }

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -274,6 +274,26 @@ export interface NeatArguments {
   interSpeciesCrossoverThreshold: number;
 
   /**
+   * Threshold for the synthetic-UUID alignment fallback in
+   * `createCompatibleFather*` (Issues #2609, #2613, #2614).
+   *
+   * When the real-UUID overlap between mother and father (computed via
+   * `getHiddenNeuronWireKeys()`) is **below** this value, the father's
+   * hidden/constant neurons are aligned to the mother by recomputing
+   * location-based synthetic UUIDs and matching either anchor. This gives
+   * structurally similar but genetically incompatible parents real
+   * crossover anchor points without persisting any synthetic identifiers.
+   * When overlap is at or above the threshold, the new pass is a no-op
+   * and the existing stable-UUID + connectivity-key alignment runs alone.
+   *
+   * Synthetic UUIDs are recomputed on demand and never written into a
+   * `CreatureExport` — the gene swap continues to use real UUIDs only.
+   *
+   * Range 0..1. Default: 0.2. Set to 0 to disable the fallback.
+   */
+  syntheticAlignmentThreshold: number;
+
+  /**
    * Discovery sample rate: the fraction of training records sampled for structural analysis.
    * Defaults to 0.2 (20%) — increased from 0.05 in #1386 for better statistical coverage.
    * Set to -1 to disable discovery entirely.

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -446,6 +446,12 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
       dnaPreset.interSpeciesCrossoverThreshold,
       { min: 0, max: 1 },
     ),
+    syntheticAlignmentThreshold: parseNumber(
+      "Synthetic Alignment Threshold",
+      opts.syntheticAlignmentThreshold,
+      0.2,
+      { min: 0, max: 1 },
+    ),
     discoverySampleRate: parseDiscoverySampleRate(
       opts.discoverySampleRate,
       DEFAULT_DISCOVERY_SAMPLE_RATE,

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -65,6 +65,7 @@ type NumericOptionKeys =
   | "diversityBreedingRate"
   | "geneticCompatibilityThreshold"
   | "interSpeciesCrossoverThreshold"
+  | "syntheticAlignmentThreshold"
   | "discoverySampleRate"
   | "discoveryRecordTimeOutMinutes"
   | "discoveryAnalysisTimeoutMinutes"

--- a/test/breed/CompatibilityGating.ts
+++ b/test/breed/CompatibilityGating.ts
@@ -140,16 +140,23 @@ Deno.test(
 
     // Run repeatedly — every call must select the lowest-compat
     // candidate, exactly matching the prior behaviour.
+    //
+    // Issue #2614: createCompatibleFatherFromCreatures now applies
+    // synthetic-UUID alignment when the real-UUID overlap is below
+    // `syntheticAlignmentThreshold` (default 0.2). For the lowest-compat
+    // candidate (3 hidden neurons, 0 shared UUIDs) this aligns father
+    // neurons to mother UUIDs, so post-alignment compatibility is no
+    // longer a stable proxy. We therefore identify the chosen candidate
+    // by hidden-neuron count (lowestMatch has 3; others have 2).
+    const lowestMatchHiddenCount = 3;
     for (let i = 0; i < 25; i++) {
       const dad = findFather(mother, genus, config);
       assert(dad, "Father should be found");
-      // The father returned by findFather is a re-aligned copy whose
-      // UUID may differ; assert by compatibility band instead.
-      const compat = geneticCompatibility(mother, dad);
+      const hiddenCount = dad.neurons.filter((n) => n.type === "hidden").length;
       assertEquals(
-        compat,
-        0,
-        `Iteration ${i}: power 0 must reproduce lowest-compat pick (compat=${compat})`,
+        hiddenCount,
+        lowestMatchHiddenCount,
+        `Iteration ${i}: power 0 must pick lowestMatch (hidden=${hiddenCount})`,
       );
     }
   },
@@ -177,13 +184,16 @@ Deno.test(
       seed: 21,
     });
 
+    // Issue #2614: see note on the previous test — identify the chosen
+    // candidate by hidden-neuron count rather than post-alignment compat.
+    const lowestMatchHiddenCount = 3;
     for (let i = 0; i < 20; i++) {
       const dad = findFather(mother, genus, config);
       assert(dad, "Father should be found");
-      const compat = geneticCompatibility(mother, dad);
+      const hiddenCount = dad.neurons.filter((n) => n.type === "hidden").length;
       assertEquals(
-        compat,
-        0,
+        hiddenCount,
+        lowestMatchHiddenCount,
         `Disabled gate must reproduce legacy lowest-compat pick`,
       );
     }

--- a/test/breed/SyntheticLocationFatherAlignment.ts
+++ b/test/breed/SyntheticLocationFatherAlignment.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for the synthetic-UUID alignment fallback wired into
+ * `createCompatibleFather*` (Issue #2614).
+ *
+ * The fallback runs only when the real-UUID overlap between mother and
+ * father is below the configured threshold. Aligned father neurons
+ * inherit the mother's real UUID — synthetic UUIDs are never written
+ * into the resulting `CreatureExport`.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import {
+  createCompatibleFather,
+  createCompatibleFatherFromCreatures,
+} from "@breed/Father.ts";
+import { Creature } from "../../mod.ts";
+
+/**
+ * Linear-chain mother: input-0 → m-A → m-B → output-0.
+ * Hidden uuids are deliberately distinct from any father below.
+ */
+function makeLinearMother(): CreatureExport {
+  return {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "m-A", bias: 0, squash: "IDENTITY" },
+      { type: "hidden", uuid: "m-B", bias: 0, squash: "IDENTITY" },
+      { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "m-A", weight: 0.5 },
+      { fromUUID: "m-A", toUUID: "m-B", weight: 0.7 },
+      { fromUUID: "m-B", toUUID: "output-0", weight: 0.9 },
+    ],
+  };
+}
+
+/**
+ * Linear-chain father with the same shape but disjoint hidden uuids.
+ */
+function makeLinearFather(): CreatureExport {
+  return {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "f-A", bias: 0, squash: "IDENTITY" },
+      { type: "hidden", uuid: "f-B", bias: 0, squash: "IDENTITY" },
+      { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "f-A", weight: 0.5 },
+      { fromUUID: "f-A", toUUID: "f-B", weight: 0.7 },
+      { fromUUID: "f-B", toUUID: "output-0", weight: 0.9 },
+    ],
+  };
+}
+
+function hiddenUuidsOf(adjusted: CreatureExport): string[] {
+  return adjusted.neurons
+    .filter((n) => n.type === "hidden")
+    .map((n) => n.uuid as string);
+}
+
+function hasSyntheticSuffix(s: string): boolean {
+  // Synthetic UUIDs are formatted `${anchor}-${steps}-${sign}-${rank}`
+  // where sign is one of `pos` / `neg`. Anchors are real
+  // canonical wire UUIDs (`input-N`, `output-N`) so the discriminator is
+  // the `-pos-` / `-neg-` infix.
+  return s.includes("-pos-") || s.includes("-neg-");
+}
+
+Deno.test(
+  "createCompatibleFather: above-threshold case is a no-op (Issue #2614)",
+  () => {
+    // Parents share both hidden uuids → real overlap is 1.0 (>> 0.2).
+    // The synthetic fallback must not run; behaviour equals the existing
+    // stable-UUID + connectivity-key alignment.
+    const mother: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        { type: "hidden", uuid: "shared-A", bias: 0, squash: "IDENTITY" },
+        { type: "hidden", uuid: "shared-B", bias: 0, squash: "IDENTITY" },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "shared-A", weight: 0.5 },
+        { fromUUID: "shared-A", toUUID: "shared-B", weight: 0.7 },
+        { fromUUID: "shared-B", toUUID: "output-0", weight: 0.9 },
+      ],
+    };
+    const father: CreatureExport = structuredClone(mother);
+
+    const adjusted = createCompatibleFather(mother, father);
+    const uuids = hiddenUuidsOf(adjusted);
+    assertEquals(uuids.sort(), ["shared-A", "shared-B"]);
+    for (const uuid of uuids) {
+      assert(
+        !hasSyntheticSuffix(uuid),
+        `unexpected synthetic suffix in ${uuid}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "createCompatibleFather: below-threshold case aligns at least one neuron via synthetic UUID (Issue #2614)",
+  () => {
+    // Mother and father share zero hidden UUIDs → real overlap is 0 (< 0.2).
+    // Both are linear chains — synthetic location UUIDs match exactly.
+    const mother = makeLinearMother();
+    const father = makeLinearFather();
+
+    // Baseline: with the synthetic fallback disabled (threshold = 0),
+    // the existing alignment passes leave the father's hidden UUIDs intact.
+    const baseline = createCompatibleFather(
+      structuredClone(mother),
+      structuredClone(father),
+      0,
+    );
+    const baselineHidden = hiddenUuidsOf(baseline);
+    // No mother UUID should appear in the baseline.
+    assertEquals(baselineHidden.includes("m-A"), false);
+    assertEquals(baselineHidden.includes("m-B"), false);
+
+    // With the synthetic fallback at the default 0.2 threshold, both
+    // father hidden neurons inherit the mother's real UUID.
+    const adjusted = createCompatibleFather(mother, father);
+    const adjustedHidden = hiddenUuidsOf(adjusted);
+    assert(
+      adjustedHidden.includes("m-A") || adjustedHidden.includes("m-B"),
+      `expected at least one mother UUID after synthetic alignment, got ${
+        JSON.stringify(adjustedHidden)
+      }`,
+    );
+
+    // Regression: the resulting export contains zero synthetic-UUID strings.
+    for (const uuid of adjustedHidden) {
+      assert(
+        !hasSyntheticSuffix(uuid),
+        `synthetic UUID leaked into export: ${uuid}`,
+      );
+    }
+    for (const synapse of adjusted.synapses) {
+      const from = synapse.fromUUID ?? "";
+      const to = synapse.toUUID ?? "";
+      assert(!hasSyntheticSuffix(from), `synthetic in fromUUID: ${from}`);
+      assert(!hasSyntheticSuffix(to), `synthetic in toUUID: ${to}`);
+    }
+  },
+);
+
+Deno.test(
+  "createCompatibleFather: loose match — input-anchor only also aligns (Issue #2614)",
+  () => {
+    // The mother has an extra output dimension on its B-neuron, so the
+    // (output-0, steps=1) anchor for the father's f-B neuron does NOT
+    // match any mother neuron. Only the input-anchor matches. The loose
+    // match rule (either anchor) must still align f-B → m-B.
+    const mother: CreatureExport = {
+      input: 1,
+      output: 2,
+      neurons: [
+        { type: "hidden", uuid: "m-A", bias: 0, squash: "IDENTITY" },
+        { type: "hidden", uuid: "m-B", bias: 0, squash: "IDENTITY" },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+        { type: "output", uuid: "output-1", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "m-A", weight: 0.5 },
+        { fromUUID: "m-A", toUUID: "m-B", weight: 0.7 },
+        { fromUUID: "m-B", toUUID: "output-0", weight: 0.9 },
+        { fromUUID: "m-B", toUUID: "output-1", weight: 0.3 },
+      ],
+    };
+    const father: CreatureExport = {
+      input: 1,
+      output: 2,
+      neurons: [
+        { type: "hidden", uuid: "f-A", bias: 0, squash: "IDENTITY" },
+        { type: "hidden", uuid: "f-B", bias: 0, squash: "IDENTITY" },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+        { type: "output", uuid: "output-1", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "f-A", weight: 0.5 },
+        { fromUUID: "f-A", toUUID: "f-B", weight: 0.7 },
+        { fromUUID: "f-B", toUUID: "output-0", weight: 0.9 },
+        // Note: father is missing the output-1 connection from f-B.
+        // This is intentional — output-1 must still exist on father, so
+        // wire it from f-A directly so f-B's nearest-output anchor differs.
+        { fromUUID: "f-A", toUUID: "output-1", weight: 0.4 },
+      ],
+    };
+
+    const adjusted = createCompatibleFather(mother, father);
+    const adjustedHidden = hiddenUuidsOf(adjusted);
+    assert(
+      adjustedHidden.includes("m-B") || adjustedHidden.includes("m-A"),
+      `expected loose-match alignment, got ${JSON.stringify(adjustedHidden)}`,
+    );
+    for (const uuid of adjustedHidden) {
+      assert(
+        !hasSyntheticSuffix(uuid),
+        `synthetic UUID leaked into export: ${uuid}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "createCompatibleFather: stable-UUID alignment is not double-claimed by synthetic pass (Issue #2614)",
+  () => {
+    // f-A is bound to mother-A by stable UUID (`shared-A`) before the
+    // synthetic pass runs. The synthetic pass must NOT re-bind f-A to a
+    // different mother neuron and must NOT claim mother-A's id again.
+    const mother: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        { type: "hidden", uuid: "shared-A", bias: 0, squash: "IDENTITY" },
+        { type: "hidden", uuid: "m-B", bias: 0, squash: "IDENTITY" },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "shared-A", weight: 0.5 },
+        { fromUUID: "shared-A", toUUID: "m-B", weight: 0.7 },
+        { fromUUID: "m-B", toUUID: "output-0", weight: 0.9 },
+      ],
+    };
+    const father: CreatureExport = {
+      input: 1,
+      output: 1,
+      neurons: [
+        { type: "hidden", uuid: "shared-A", bias: 0, squash: "IDENTITY" },
+        { type: "hidden", uuid: "f-B", bias: 0, squash: "IDENTITY" },
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "shared-A", weight: 0.5 },
+        { fromUUID: "shared-A", toUUID: "f-B", weight: 0.7 },
+        { fromUUID: "f-B", toUUID: "output-0", weight: 0.9 },
+      ],
+    };
+
+    const adjusted = createCompatibleFather(mother, father);
+    const adjustedHidden = hiddenUuidsOf(adjusted);
+    // shared-A must remain shared-A, no double-claim.
+    assertEquals(
+      adjustedHidden.filter((u) => u === "shared-A").length,
+      1,
+      "shared-A must appear exactly once after alignment",
+    );
+    for (const uuid of adjustedHidden) {
+      assert(
+        !hasSyntheticSuffix(uuid),
+        `synthetic UUID leaked into export: ${uuid}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "createCompatibleFatherFromCreatures: below-threshold case aligns via synthetic UUID and exports cleanly (Issue #2614)",
+  () => {
+    const mother = Creature.fromJSON(makeLinearMother());
+    const father = Creature.fromJSON(makeLinearFather());
+
+    const adjusted = createCompatibleFatherFromCreatures(mother, father);
+    const adjustedHidden = hiddenUuidsOf(adjusted);
+    assert(
+      adjustedHidden.includes("m-A") || adjustedHidden.includes("m-B"),
+      `expected at least one mother UUID after synthetic alignment, got ${
+        JSON.stringify(adjustedHidden)
+      }`,
+    );
+
+    // Build a child via fromJSON and re-export — confirm round-trip
+    // produces zero synthetic UUID strings.
+    const child = Creature.fromJSON(adjusted);
+    const reExported = child.exportJSON();
+    for (const n of reExported.neurons) {
+      const uuid = n.uuid;
+      if (typeof uuid === "string") {
+        assert(
+          !hasSyntheticSuffix(uuid),
+          `synthetic UUID leaked into exportJSON: ${uuid}`,
+        );
+      }
+    }
+    for (const s of reExported.synapses) {
+      const f = s.fromUUID ?? "";
+      const t = s.toUUID ?? "";
+      assert(
+        !hasSyntheticSuffix(f),
+        `synthetic UUID leaked into exportJSON synapse fromUUID: ${f}`,
+      );
+      assert(
+        !hasSyntheticSuffix(t),
+        `synthetic UUID leaked into exportJSON synapse toUUID: ${t}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "createCompatibleFatherFromCreatures: threshold = 0 disables synthetic pass (Issue #2614)",
+  () => {
+    const mother = Creature.fromJSON(makeLinearMother());
+    const father = Creature.fromJSON(makeLinearFather());
+
+    const adjusted = createCompatibleFatherFromCreatures(mother, father, 0);
+    const adjustedHidden = hiddenUuidsOf(adjusted);
+    // Without synthetic alignment the father's UUIDs survive unchanged.
+    assertEquals(adjustedHidden.includes("m-A"), false);
+    assertEquals(adjustedHidden.includes("m-B"), false);
+  },
+);


### PR DESCRIPTION
# PR Summary — Issue #2614

## Summary

Wire the synthetic location-based UUID alignment fallback (delivered as a
pure function in #2613) into `createCompatibleFather` and
`createCompatibleFatherFromCreatures` so genetically incompatible parents
gain real crossover anchor points without persisting any synthetic
identifiers. The new pass runs **after** the existing stable-UUID
alignment and **before** the connectivity-key fallback, gated on a
configurable threshold (default `0.2`). Aligned father neurons inherit
the mother's real UUID; the resulting `CreatureExport` only ever carries
real UUIDs.

Closes #2614.

## Evidence

This is a backend / library change with no UI surface. Verified via:

- 6 new unit tests in `test/breed/SyntheticLocationFatherAlignment.ts`
  cover the above-threshold no-op, below-threshold synthetic alignment,
  loose-match behaviour, double-claim guard, the `createCompatibleFatherFromCreatures`
  variant, and the regression that no synthetic-UUID strings appear in
  the resulting export (including a `Creature.fromJSON` → `exportJSON`
  round-trip).
- The full quality gate (`./quality.sh`) was run; 6,590 tests pass. The
  three pre-existing FFI-leak failures in
  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` reproduce on
  the unmodified `Develop` branch and are unrelated to this change.

### Alignment flow

```mermaid
flowchart TD
    A[mother + father] --> B{real-UUID overlap}
    B -- ">= syntheticAlignmentThreshold" --> C[stable-uuid pass]
    B -- "< syntheticAlignmentThreshold" --> D[stable-uuid pass]
    D --> E[synthetic-UUID pass<br/>compute for both parents]
    E --> F{either synthetic<br/>UUID matches?}
    F -- "yes" --> G[claim mother id,<br/>adopt mother real uuid]
    F -- "no" --> H[connectivity-key fallback]
    C --> I[gene swap uses<br/>real UUIDs only]
    G --> I
    H --> I
```

## Test Plan

New tests added in `test/breed/SyntheticLocationFatherAlignment.ts`:

- `createCompatibleFather: above-threshold case is a no-op` — overlap = 1
  leaves the existing alignment untouched.
- `createCompatibleFather: below-threshold case aligns at least one
  neuron via synthetic UUID` — disjoint-UUID linear chains pick up the
  mother's real UUIDs via the synthetic pass, with a baseline run at
  `threshold = 0` confirming the alignment depended on the new pass.
- `createCompatibleFather: loose match — input-anchor only also aligns`
  — output-anchor mismatch still yields alignment via the input anchor.
- `createCompatibleFather: stable-UUID alignment is not double-claimed
  by synthetic pass` — a mother neuron already claimed by the
  stable-UUID pass is not re-bound by the synthetic pass.
- `createCompatibleFatherFromCreatures: below-threshold case aligns via
  synthetic UUID and exports cleanly` — Creatures input path aligns and
  the round-trip `exportJSON` contains zero `-pos-` / `-neg-` strings.
- `createCompatibleFatherFromCreatures: threshold = 0 disables synthetic
  pass` — explicit opt-out.

Modified tests (documented in-line):

- `test/breed/CompatibilityGating.ts`: two tests previously asserted
  `geneticCompatibility(mother, dad) == 0` after `findFather` to verify
  the lowest-compat candidate was selected. With the synthetic-UUID
  fallback in place, the returned father inherits the mother's UUIDs so
  post-alignment compatibility is no longer a stable proxy. The tests
  now identify the chosen candidate by hidden-neuron count, preserving
  the original intent.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2614 -->