### PR TITLE
E2E breed test: synthetic-UUID alignment of incompatible parents (#2615)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2615.md
+++ b/docs/pr-summary-2615.md
@@ -7,8 +7,8 @@ alignment fallback delivered by Issue #2614. The test loads two genetically
 incompatible parents (modelled on the GRQ-cluster mother and GRQ-teams Europa
 father from Issue #2609), proves the fallback aligns more father neurons than
 the disabled-pass baseline, breeds a child via `Offspring.breed`, validates the
-child, and asserts that no synthetic UUIDs ever leak into the exported
-genome. Closes #2615.
+child, and asserts that no synthetic UUIDs ever leak into the exported genome.
+Closes #2615.
 
 ## Evidence
 
@@ -38,8 +38,8 @@ flowchart LR
 
 ## Test Plan
 
-- [x] `Synthetic-alignment E2E: GRQ-style incompatible parents (Issue #2615)`
-      — single test in `test/breed/SyntheticLocationE2E.ts` that:
+- [x] `Synthetic-alignment E2E: GRQ-style incompatible parents (Issue #2615)` —
+      single test in `test/breed/SyntheticLocationE2E.ts` that:
   1. Loads `parent-mother.json` and `parent-father.json` via
      `Creature.fromJSON`.
   2. Asserts real-UUID overlap < 0.2 (actual: 0.0 — fully disjoint hidden
@@ -47,18 +47,19 @@ flowchart LR
   3. Calls `createCompatibleFatherFromCreatures(mother, father, 0)` for the
      baseline (synthetic pass disabled) and counts father neurons remapped to
      mother UUIDs.
-  4. Calls `createCompatibleFatherFromCreatures(mother, father)` at the
-     default threshold (0.2) and asserts the synthetic pass remaps strictly
-     more neurons than the baseline.
-  5. Asserts neither intermediate export contains synthetic UUIDs
-     (regex `^(input|output)-\d+-\d+-(pos|neg)-\d+$`).
-  6. Calls `Offspring.breed(mother, father, { geneticCompatibilityThreshold: 1 })`
-     and asserts the child is non-undefined and passes `creatureValidate`.
+  4. Calls `createCompatibleFatherFromCreatures(mother, father)` at the default
+     threshold (0.2) and asserts the synthetic pass remaps strictly more neurons
+     than the baseline.
+  5. Asserts neither intermediate export contains synthetic UUIDs (regex
+     `^(input|output)-\d+-\d+-(pos|neg)-\d+$`).
+  6. Calls
+     `Offspring.breed(mother, father, { geneticCompatibilityThreshold: 1 })` and
+     asserts the child is non-undefined and passes `creatureValidate`.
   7. Asserts the child's `exportJSON()` contains zero synthetic UUID strings on
      any `uuid`, `fromUUID`, or `toUUID` field.
 - [x] Fixtures committed:
       `test/breed/fixtures/synthetic-alignment/parent-mother.json` (~1.7 KB),
       `parent-father.json` (~1.7 KB), and a short `README.md` documenting
       provenance and licence — both fixtures well under the 200 KB cap.
-- [x] Test runtime: 8 ms — comfortably within the 30 s acceptance budget and
-      the 120 s per-test cap.
+- [x] Test runtime: 8 ms — comfortably within the 30 s acceptance budget and the
+      120 s per-test cap.

--- a/docs/pr-summary-2615.md
+++ b/docs/pr-summary-2615.md
@@ -1,0 +1,64 @@
+## Summary
+
+Adds an end-to-end regression test (`test/breed/SyntheticLocationE2E.ts`) and
+hand-crafted production-shape parent fixtures under
+`test/breed/fixtures/synthetic-alignment/` that exercise the synthetic-UUID
+alignment fallback delivered by Issue #2614. The test loads two genetically
+incompatible parents (modelled on the GRQ-cluster mother and GRQ-teams Europa
+father from Issue #2609), proves the fallback aligns more father neurons than
+the disabled-pass baseline, breeds a child via `Offspring.breed`, validates the
+child, and asserts that no synthetic UUIDs ever leak into the exported
+genome. Closes #2615.
+
+## Evidence
+
+The change is test-only — no library code changed. Verification:
+
+- New test passes: `deno test test/breed/SyntheticLocationE2E.ts` →
+  `1 passed (8ms)`, well under the 30-second budget required by the issue.
+- Lint, format, and type-check pass cleanly via `./quality.sh --lint-only`.
+- The 3 pre-existing failures in
+  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` are dynamic-library
+  leak-detection failures unrelated to this PR (verified by running that test
+  file alone with no local modifications).
+
+```mermaid
+flowchart LR
+    F1[(parent-mother.json)] --> L[Creature.fromJSON]
+    F2[(parent-father.json)] --> L
+    L --> O{real-UUID overlap}
+    O -- "= 0.0 < 0.2" --> SA[synthetic-UUID alignment]
+    O -- "baseline run<br/>(threshold = 0)" --> NB[no synthetic alignment]
+    SA --> CB[breed -> child]
+    NB --> BB[baseline father export]
+    CB --> A1{aligned > baseline?}
+    CB --> A2{validate ok?}
+    CB --> A3{export has<br/>no synthetic uuids?}
+```
+
+## Test Plan
+
+- [x] `Synthetic-alignment E2E: GRQ-style incompatible parents (Issue #2615)`
+      — single test in `test/breed/SyntheticLocationE2E.ts` that:
+  1. Loads `parent-mother.json` and `parent-father.json` via
+     `Creature.fromJSON`.
+  2. Asserts real-UUID overlap < 0.2 (actual: 0.0 — fully disjoint hidden
+     UUIDs).
+  3. Calls `createCompatibleFatherFromCreatures(mother, father, 0)` for the
+     baseline (synthetic pass disabled) and counts father neurons remapped to
+     mother UUIDs.
+  4. Calls `createCompatibleFatherFromCreatures(mother, father)` at the
+     default threshold (0.2) and asserts the synthetic pass remaps strictly
+     more neurons than the baseline.
+  5. Asserts neither intermediate export contains synthetic UUIDs
+     (regex `^(input|output)-\d+-\d+-(pos|neg)-\d+$`).
+  6. Calls `Offspring.breed(mother, father, { geneticCompatibilityThreshold: 1 })`
+     and asserts the child is non-undefined and passes `creatureValidate`.
+  7. Asserts the child's `exportJSON()` contains zero synthetic UUID strings on
+     any `uuid`, `fromUUID`, or `toUUID` field.
+- [x] Fixtures committed:
+      `test/breed/fixtures/synthetic-alignment/parent-mother.json` (~1.7 KB),
+      `parent-father.json` (~1.7 KB), and a short `README.md` documenting
+      provenance and licence — both fixtures well under the 200 KB cap.
+- [x] Test runtime: 8 ms — comfortably within the 30 s acceptance budget and
+      the 120 s per-test cap.

--- a/test/breed/SyntheticLocationE2E.ts
+++ b/test/breed/SyntheticLocationE2E.ts
@@ -1,0 +1,194 @@
+/**
+ * End-to-end regression for the synthetic-UUID alignment fallback wired into
+ * `createCompatibleFatherFromCreatures` by Issue #2614.
+ *
+ * Loads two production-shape, genetically incompatible parent fixtures
+ * (mother modelled on the GRQ-cluster `network.json`, father modelled on the
+ * GRQ-teams Europa creature) and proves that:
+ *
+ *  1. Real-UUID overlap is below the configured `syntheticAlignmentThreshold`.
+ *  2. The synthetic-UUID alignment pass produces strictly more aligned
+ *     father→mother id mappings than a baseline run with the pass disabled
+ *     (`syntheticAlignmentThreshold: 0`).
+ *  3. `Offspring.breed` returns a non-undefined child that passes
+ *     `creatureValidate`.
+ *  4. The child's `exportJSON()` contains zero synthetic UUID strings on any
+ *     `uuid`, `fromUUID`, or `toUUID` field — alignment is ephemeral and
+ *     never persisted.
+ *
+ * Fixtures live under `test/breed/fixtures/synthetic-alignment/`. See the
+ * `README.md` in that folder for provenance and licence notes (Issue #2615).
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "../../mod.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { createCompatibleFatherFromCreatures } from "@breed/Father.ts";
+import { Offspring } from "@architecture/Offspring.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+
+const FIXTURE_DIR = new URL(
+  "./fixtures/synthetic-alignment/",
+  import.meta.url,
+);
+const MOTHER_PATH = new URL("parent-mother.json", FIXTURE_DIR);
+const FATHER_PATH = new URL("parent-father.json", FIXTURE_DIR);
+
+/**
+ * Synthetic UUIDs are formatted `${anchor}-${steps}-${sign}-${rank}` where
+ * `anchor` is `input-N` or `output-N`, `steps >= 1`, `sign ∈ {pos, neg}`,
+ * and `rank >= 0`. Issue #2615 acceptance criterion 5: this regex must
+ * never match anything in the bred child's export.
+ */
+const SYNTHETIC_UUID_REGEX = /^(input|output)-\d+-\d+-(pos|neg)-\d+$/;
+
+function loadFixture(path: URL): CreatureExport {
+  const text = Deno.readTextFileSync(path);
+  return JSON.parse(text) as CreatureExport;
+}
+
+function realUuidOverlap(a: Set<string>, b: Set<string>): number {
+  const smaller = a.size <= b.size ? a : b;
+  const larger = a.size <= b.size ? b : a;
+  if (smaller.size === 0) return 1;
+  let matches = 0;
+  for (const u of smaller) {
+    if (larger.has(u)) matches++;
+  }
+  return matches / smaller.size;
+}
+
+/**
+ * Counts the number of father hidden/constant neurons that ended up
+ * remapped to the mother — i.e. the resulting export's `uuid` is a
+ * known mother hidden/constant UUID. Each remapped father neuron
+ * inherits the mother's real UUID.
+ */
+function countRemappedToMother(
+  adjusted: CreatureExport,
+  motherHiddenUuids: Set<string>,
+): number {
+  let n = 0;
+  for (const neuron of adjusted.neurons) {
+    if (neuron.type !== "hidden" && neuron.type !== "constant") continue;
+    if (typeof neuron.uuid === "string" && motherHiddenUuids.has(neuron.uuid)) {
+      n++;
+    }
+  }
+  return n;
+}
+
+function motherHiddenUuidSet(motherExport: CreatureExport): Set<string> {
+  const out = new Set<string>();
+  for (const n of motherExport.neurons) {
+    if (
+      (n.type === "hidden" || n.type === "constant") &&
+      typeof n.uuid === "string"
+    ) {
+      out.add(n.uuid);
+    }
+  }
+  return out;
+}
+
+function assertNoSyntheticUuids(exported: CreatureExport, where: string) {
+  for (const neuron of exported.neurons) {
+    if (typeof neuron.uuid === "string") {
+      assert(
+        !SYNTHETIC_UUID_REGEX.test(neuron.uuid),
+        `synthetic UUID leaked into ${where} neuron.uuid: ${neuron.uuid}`,
+      );
+    }
+  }
+  for (const synapse of exported.synapses) {
+    if (typeof synapse.fromUUID === "string") {
+      assert(
+        !SYNTHETIC_UUID_REGEX.test(synapse.fromUUID),
+        `synthetic UUID leaked into ${where} synapse.fromUUID: ${synapse.fromUUID}`,
+      );
+    }
+    if (typeof synapse.toUUID === "string") {
+      assert(
+        !SYNTHETIC_UUID_REGEX.test(synapse.toUUID),
+        `synthetic UUID leaked into ${where} synapse.toUUID: ${synapse.toUUID}`,
+      );
+    }
+  }
+}
+
+Deno.test(
+  "Synthetic-alignment E2E: GRQ-style incompatible parents (Issue #2615)",
+  () => {
+    const motherExport = loadFixture(MOTHER_PATH);
+    const fatherExport = loadFixture(FATHER_PATH);
+
+    const mother = Creature.fromJSON(motherExport);
+    const father = Creature.fromJSON(fatherExport);
+
+    // (1) Pre-test sanity: real-UUID overlap is below 0.2.
+    const motherKeys = mother.getHiddenNeuronWireKeys();
+    const fatherKeys = father.getHiddenNeuronWireKeys();
+    const overlap = realUuidOverlap(motherKeys, fatherKeys);
+    assert(
+      overlap < 0.2,
+      `expected real-UUID overlap < 0.2 to exercise the synthetic fallback, got ${overlap}`,
+    );
+
+    // (2) Baseline: disable the synthetic pass via threshold = 0 and
+    //     count how many father neurons get remapped to mother ids.
+    const baselineFather = createCompatibleFatherFromCreatures(
+      mother,
+      father,
+      0, // disables the synthetic-alignment pass — internal-only override
+    );
+    const motherHidden = motherHiddenUuidSet(motherExport);
+    const baselineCount = countRemappedToMother(baselineFather, motherHidden);
+
+    // (3) Synthetic pass: default threshold (0.2) — fires because overlap < 0.2.
+    const syntheticFather = createCompatibleFatherFromCreatures(mother, father);
+    const syntheticCount = countRemappedToMother(syntheticFather, motherHidden);
+
+    assert(
+      syntheticCount > baselineCount,
+      `expected synthetic-UUID pass to remap strictly more father neurons than baseline; got synthetic=${syntheticCount} baseline=${baselineCount}`,
+    );
+
+    // (4) Both intermediate exports must be free of synthetic UUIDs —
+    //     synthetic UUIDs are alignment-only and must never be persisted.
+    assertNoSyntheticUuids(
+      syntheticFather,
+      "createCompatibleFatherFromCreatures result",
+    );
+    assertNoSyntheticUuids(
+      baselineFather,
+      "baseline createCompatibleFatherFromCreatures result",
+    );
+
+    // (5) Breed via Offspring.breed and assert the child is valid.
+    //     Pass `geneticCompatibilityThreshold` so the standard crossover
+    //     path runs (the parents are intentionally incompatible).
+    const child = Offspring.breed(mother, father, {
+      geneticCompatibilityThreshold: 1,
+    });
+    assert(
+      child !== undefined,
+      "Offspring.breed must return a non-undefined child for incompatible parents with synthetic alignment",
+    );
+    // creatureValidate throws on failure; a successful return = pass.
+    creatureValidate(child);
+
+    // (6) Child's exportJSON must not contain any synthetic UUID strings.
+    const childExport = child.exportJSON();
+    assertEquals(
+      childExport.input,
+      mother.input,
+      "child must have the parents' input arity",
+    );
+    assertEquals(
+      childExport.output,
+      mother.output,
+      "child must have the parents' output arity",
+    );
+    assertNoSyntheticUuids(childExport, "child.exportJSON()");
+  },
+);

--- a/test/breed/fixtures/synthetic-alignment/README.md
+++ b/test/breed/fixtures/synthetic-alignment/README.md
@@ -1,0 +1,33 @@
+# Synthetic-alignment fixtures (Issue #2615)
+
+Hand-minimised parent fixtures used by
+[`test/breed/SyntheticLocationE2E.ts`](../../SyntheticLocationE2E.ts) to drive
+the end-to-end regression for the synthetic-UUID alignment fallback wired into
+`createCompatibleFatherFromCreatures` (delivered by Issue #2614).
+
+## Provenance
+
+The fixtures are inspired by the production cross-island breed problem first
+reported in Issue #2609:
+
+- `parent-mother.json` — modelled on the GRQ-cluster `network.json` shape
+  (cascading layered topology, fan-in to a deep hidden neuron, a shortcut hidden
+  neuron from `input-0` directly to `output-1`).
+- `parent-father.json` — modelled on the GRQ-teams Europa creature shape (same
+  overall layered topology, deliberately disjoint hidden-neuron real UUIDs).
+
+Both creatures expose the same alignment problem the production crossover hit on
+the GitHub fleet: real-UUID overlap of `0.0` (well below the
+`syntheticAlignmentThreshold` of `0.2`), but a topology similar enough that
+location-anchored synthetic UUIDs match across all hidden neurons.
+
+## Licence
+
+These fixtures are **hand-crafted** for the regression test. They are NOT a copy
+of the original production creatures (which are licence-encumbered and
+considerably larger). The synapse weights, biases, and squash functions are
+deliberately small and deterministic — the test asserts on alignment counts and
+export hygiene, not on inference values.
+
+The two files are intentionally < 200 KB each (each is well under 5 KB) so the
+test stays hermetic and quick to load.

--- a/test/breed/fixtures/synthetic-alignment/parent-father.json
+++ b/test/breed/fixtures/synthetic-alignment/parent-father.json
@@ -1,0 +1,95 @@
+{
+  "input": 2,
+  "output": 2,
+  "neurons": [
+    {
+      "type": "hidden",
+      "uuid": "f1e2d3c4-0001-4001-8000-000000000001",
+      "bias": 0.06,
+      "squash": "TANH"
+    },
+    {
+      "type": "hidden",
+      "uuid": "f1e2d3c4-0001-4001-8000-000000000002",
+      "bias": -0.03,
+      "squash": "TANH"
+    },
+    {
+      "type": "hidden",
+      "uuid": "f1e2d3c4-0001-4001-8000-000000000003",
+      "bias": 0.015,
+      "squash": "RELU"
+    },
+    {
+      "type": "hidden",
+      "uuid": "f1e2d3c4-0001-4001-8000-000000000004",
+      "bias": 0.005,
+      "squash": "TANH"
+    },
+    {
+      "type": "hidden",
+      "uuid": "f1e2d3c4-0001-4001-8000-000000000005",
+      "bias": -0.045,
+      "squash": "RELU"
+    },
+    {
+      "type": "output",
+      "uuid": "output-0",
+      "bias": 0.01,
+      "squash": "LOGISTIC"
+    },
+    {
+      "type": "output",
+      "uuid": "output-1",
+      "bias": 0.0,
+      "squash": "LOGISTIC"
+    }
+  ],
+  "synapses": [
+    {
+      "fromUUID": "input-0",
+      "toUUID": "f1e2d3c4-0001-4001-8000-000000000001",
+      "weight": 0.55
+    },
+    {
+      "fromUUID": "input-0",
+      "toUUID": "f1e2d3c4-0001-4001-8000-000000000005",
+      "weight": -0.65
+    },
+    {
+      "fromUUID": "input-1",
+      "toUUID": "f1e2d3c4-0001-4001-8000-000000000002",
+      "weight": 0.7
+    },
+    {
+      "fromUUID": "f1e2d3c4-0001-4001-8000-000000000001",
+      "toUUID": "f1e2d3c4-0001-4001-8000-000000000003",
+      "weight": 0.45
+    },
+    {
+      "fromUUID": "f1e2d3c4-0001-4001-8000-000000000002",
+      "toUUID": "f1e2d3c4-0001-4001-8000-000000000003",
+      "weight": 0.35
+    },
+    {
+      "fromUUID": "f1e2d3c4-0001-4001-8000-000000000003",
+      "toUUID": "f1e2d3c4-0001-4001-8000-000000000004",
+      "weight": 0.55
+    },
+    {
+      "fromUUID": "f1e2d3c4-0001-4001-8000-000000000004",
+      "toUUID": "output-0",
+      "weight": 0.85
+    },
+    {
+      "fromUUID": "f1e2d3c4-0001-4001-8000-000000000005",
+      "toUUID": "output-1",
+      "weight": 0.45
+    },
+    {
+      "fromUUID": "f1e2d3c4-0001-4001-8000-000000000003",
+      "toUUID": "output-1",
+      "weight": 0.25
+    }
+  ]
+}

--- a/test/breed/fixtures/synthetic-alignment/parent-mother.json
+++ b/test/breed/fixtures/synthetic-alignment/parent-mother.json
@@ -1,0 +1,95 @@
+{
+  "input": 2,
+  "output": 2,
+  "neurons": [
+    {
+      "type": "hidden",
+      "uuid": "a1b2c3d4-0001-4001-8000-000000000001",
+      "bias": 0.05,
+      "squash": "TANH"
+    },
+    {
+      "type": "hidden",
+      "uuid": "a1b2c3d4-0001-4001-8000-000000000002",
+      "bias": -0.02,
+      "squash": "TANH"
+    },
+    {
+      "type": "hidden",
+      "uuid": "a1b2c3d4-0001-4001-8000-000000000003",
+      "bias": 0.01,
+      "squash": "RELU"
+    },
+    {
+      "type": "hidden",
+      "uuid": "a1b2c3d4-0001-4001-8000-000000000004",
+      "bias": 0.0,
+      "squash": "TANH"
+    },
+    {
+      "type": "hidden",
+      "uuid": "a1b2c3d4-0001-4001-8000-000000000005",
+      "bias": -0.04,
+      "squash": "RELU"
+    },
+    {
+      "type": "output",
+      "uuid": "output-0",
+      "bias": 0.0,
+      "squash": "LOGISTIC"
+    },
+    {
+      "type": "output",
+      "uuid": "output-1",
+      "bias": 0.0,
+      "squash": "LOGISTIC"
+    }
+  ],
+  "synapses": [
+    {
+      "fromUUID": "input-0",
+      "toUUID": "a1b2c3d4-0001-4001-8000-000000000001",
+      "weight": 0.5
+    },
+    {
+      "fromUUID": "input-0",
+      "toUUID": "a1b2c3d4-0001-4001-8000-000000000005",
+      "weight": -0.7
+    },
+    {
+      "fromUUID": "input-1",
+      "toUUID": "a1b2c3d4-0001-4001-8000-000000000002",
+      "weight": 0.6
+    },
+    {
+      "fromUUID": "a1b2c3d4-0001-4001-8000-000000000001",
+      "toUUID": "a1b2c3d4-0001-4001-8000-000000000003",
+      "weight": 0.4
+    },
+    {
+      "fromUUID": "a1b2c3d4-0001-4001-8000-000000000002",
+      "toUUID": "a1b2c3d4-0001-4001-8000-000000000003",
+      "weight": 0.3
+    },
+    {
+      "fromUUID": "a1b2c3d4-0001-4001-8000-000000000003",
+      "toUUID": "a1b2c3d4-0001-4001-8000-000000000004",
+      "weight": 0.5
+    },
+    {
+      "fromUUID": "a1b2c3d4-0001-4001-8000-000000000004",
+      "toUUID": "output-0",
+      "weight": 0.8
+    },
+    {
+      "fromUUID": "a1b2c3d4-0001-4001-8000-000000000005",
+      "toUUID": "output-1",
+      "weight": 0.4
+    },
+    {
+      "fromUUID": "a1b2c3d4-0001-4001-8000-000000000003",
+      "toUUID": "output-1",
+      "weight": 0.2
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end regression test (`test/breed/SyntheticLocationE2E.ts`) and
hand-crafted production-shape parent fixtures under
`test/breed/fixtures/synthetic-alignment/` that exercise the synthetic-UUID
alignment fallback delivered by Issue #2614. The test loads two genetically
incompatible parents (modelled on the GRQ-cluster mother and GRQ-teams Europa
father from Issue #2609), proves the fallback aligns more father neurons than
the disabled-pass baseline, breeds a child via `Offspring.breed`, validates the
child, and asserts that no synthetic UUIDs ever leak into the exported
genome. Closes #2615.

## Evidence

The change is test-only — no library code changed. Verification:

- New test passes: `deno test test/breed/SyntheticLocationE2E.ts` →
  `1 passed (8ms)`, well under the 30-second budget required by the issue.
- Lint, format, and type-check pass cleanly via `./quality.sh --lint-only`.
- The 3 pre-existing failures in
  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` are dynamic-library
  leak-detection failures unrelated to this PR (verified by running that test
  file alone with no local modifications).

```mermaid
flowchart LR
    F1[(parent-mother.json)] --> L[Creature.fromJSON]
    F2[(parent-father.json)] --> L
    L --> O{real-UUID overlap}
    O -- "= 0.0 < 0.2" --> SA[synthetic-UUID alignment]
    O -- "baseline run<br/>(threshold = 0)" --> NB[no synthetic alignment]
    SA --> CB[breed -> child]
    NB --> BB[baseline father export]
    CB --> A1{aligned > baseline?}
    CB --> A2{validate ok?}
    CB --> A3{export has<br/>no synthetic uuids?}
```

## Test Plan

- [x] `Synthetic-alignment E2E: GRQ-style incompatible parents (Issue #2615)`
      — single test in `test/breed/SyntheticLocationE2E.ts` that:
  1. Loads `parent-mother.json` and `parent-father.json` via
     `Creature.fromJSON`.
  2. Asserts real-UUID overlap < 0.2 (actual: 0.0 — fully disjoint hidden
     UUIDs).
  3. Calls `createCompatibleFatherFromCreatures(mother, father, 0)` for the
     baseline (synthetic pass disabled) and counts father neurons remapped to
     mother UUIDs.
  4. Calls `createCompatibleFatherFromCreatures(mother, father)` at the
     default threshold (0.2) and asserts the synthetic pass remaps strictly
     more neurons than the baseline.
  5. Asserts neither intermediate export contains synthetic UUIDs
     (regex `^(input|output)-\d+-\d+-(pos|neg)-\d+$`).
  6. Calls `Offspring.breed(mother, father, { geneticCompatibilityThreshold: 1 })`
     and asserts the child is non-undefined and passes `creatureValidate`.
  7. Asserts the child's `exportJSON()` contains zero synthetic UUID strings on
     any `uuid`, `fromUUID`, or `toUUID` field.
- [x] Fixtures committed:
      `test/breed/fixtures/synthetic-alignment/parent-mother.json` (~1.7 KB),
      `parent-father.json` (~1.7 KB), and a short `README.md` documenting
      provenance and licence — both fixtures well under the 200 KB cap.
- [x] Test runtime: 8 ms — comfortably within the 30 s acceptance budget and
      the 120 s per-test cap.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2615 -->