### PR TITLE
feat: add library-owned runEpisode() with termination guards (#2627)

### DIFF
--- a/docs/pr-summary-2627.md
+++ b/docs/pr-summary-2627.md
@@ -1,0 +1,82 @@
+# Issue #2627 — Library-owned `runEpisode()` wrapper with termination guards
+
+## Summary
+
+Adds the final, library-owned `runEpisode()` wrapper that drives an
+`EpisodeAdapter` end-to-end for one creature. The runner enforces both a
+wall-clock cap and a max-steps cap, returns a scalar `returnValue` plus
+rollout metadata, and never reaches for `Math.random()` — `rngSeed` is the
+only source of nondeterminism that crosses the seam. Termination semantics
+mirror Gym/Gymnasium (`terminated` for natural episode end, `truncated` for a
+guard firing). This protects the library against the failure modes called out
+in #2624 (a snake creature pressing left forever; a snake dying after three
+steps).
+
+Closes #2627.
+
+## Evidence
+
+```mermaid
+sequenceDiagram
+    participant R as runEpisode
+    participant A as EpisodeAdapter
+    participant C as Creature
+    R->>A: assertContract(seed)
+    R->>A: reset(seed)
+    A-->>R: { observation, state }
+    loop until terminated, maxSteps, or wallClockMs
+        R->>C: activate(observation, true)
+        C-->>R: output
+        R->>A: decodeAction(output, state)
+        A-->>R: action
+        R->>A: step(state, action)
+        A-->>R: { observation, reward, terminated, truncated, state }
+    end
+    R-->>R: EpisodeResult { returnValue, steps, terminated, truncated, ... }
+```
+
+Backend/library change with no UI surface — verified via the unit tests
+listed below. The wall-clock truncation test uses a `performance.now()` shim
+so the suite does not actually sleep for half a second per run.
+
+### Implementation notes
+
+- Caps (`maxSteps()`, `wallClockMs()`) and `t0` are captured once before the
+  hot loop, never read inside it.
+- `assertContract()` runs once before the first tick — the adapter caches
+  the result so subsequent episodes pay nothing.
+- `creature.activate(observation, true)` is invoked with `feedbackLoop = true`
+  per `docs/REINFORCEMENT_LEARNING.md`.
+- `result.terminated` exits cleanly with `terminated = true`; the step-cap
+  and wall-clock guards exit with `truncated = true` and the matching
+  `truncationReason`.
+- `performance.now()` is invoked once per tick. The syscall is on the order
+  of tens of nanoseconds — negligible next to a single `Creature.activate()`
+  call. A coarser modulo gate could be layered on later if profiling ever
+  shows the syscall dominating cost on trivial sims; the explicit
+  "between 5 and 7 steps" wall-clock test required per-tick granularity.
+
+## Test Plan
+
+Six co-located tests in `test/creature/EpisodeRunner_test.ts` covering each
+scenario from the issue:
+
+- `runEpisode: natural termination after 12 steps` — adapter ends after 12
+  steps; asserts `terminated = true, truncated = false, steps = 12`.
+- `runEpisode: default maxSteps guard truncates at 5000` — adapter never
+  sets `terminated`; asserts `truncated = true,
+  truncationReason = 'maxSteps', steps = 5000`.
+- `runEpisode: wall-clock truncation fires near the cap` — adapter advances a
+  virtual clock 100 ms per step with `wallClockMs() = 500`; asserts
+  truncation between 5 and 7 steps with `truncationReason = 'wallClock'`.
+- `runEpisode: subclass maxSteps override is honoured` — subclass with
+  `maxSteps() = 10` truncates at exactly 10.
+- `runEpisode: same seed produces identical results` — two runs with seed
+  `12345` produce byte-identical `returnValue`, `steps`, and
+  `truncationReason`.
+- `runEpisode: accumulates scalar rewards across the rollout` — five steps
+  of `reward = 1` followed by `terminated = true` yields `returnValue = 5`.
+
+All six new tests pass alongside the existing `EpisodeAdapter_test.ts`
+suite (10 tests). `./quality.sh --lint-only` and `./quality.sh --check-only`
+both pass cleanly.

--- a/src/creature/EpisodeRunner.ts
+++ b/src/creature/EpisodeRunner.ts
@@ -1,0 +1,154 @@
+/**
+ * EpisodeRunner.ts — Library-owned `runEpisode()` wrapper that drives an
+ * {@link EpisodeAdapter} end-to-end for a single creature (Issue #2627, part
+ * of #2624).
+ *
+ * The runner is final and library-owned: callers do not reimplement it. It
+ * solves the failure modes called out in #2624 (a snake creature pressing
+ * left forever, a snake dying after three steps) by enforcing both a
+ * wall-clock cap and a max-steps cap. Termination semantics mirror
+ * Gym/Gymnasium: `terminated` is a natural episode end (death, goal),
+ * `truncated` is a guard firing.
+ *
+ * The hot loop is intentionally lean — caps and `t0` are captured once, the
+ * runner allocates no per-tick objects beyond the {@link StepResult} the
+ * adapter itself returns, and `Math.random()` is never consulted (`rngSeed`
+ * is the only source of nondeterminism that crosses the seam).
+ *
+ * Wall-clock cost note: `performance.now()` is invoked once per tick. The
+ * call costs roughly tens of nanoseconds, which is negligible next to a
+ * single `Creature.activate()` invocation. A coarser modulo gate could be
+ * layered on later if profiling ever shows the syscall dominating cost on
+ * trivial sims.
+ */
+
+import type { Creature } from "@creature";
+import type { EpisodeAdapter } from "@creature/EpisodeAdapter.ts";
+
+/**
+ * Why a {@link runEpisode} call exited.
+ *
+ * - `'maxSteps'` — the per-episode step cap fired.
+ * - `'wallClock'` — the wall-clock cap fired.
+ *
+ * Only set when `truncated === true`.
+ */
+export type TruncationReason = "maxSteps" | "wallClock";
+
+/**
+ * Outcome of a single episode rollout.
+ *
+ * Determinism contract: with the same `rngSeed`, the same creature, and the
+ * same adapter, two `runEpisode()` calls MUST produce identical
+ * `returnValue`, `steps`, `terminated`, `truncated`, and `truncationReason`.
+ * `elapsedMs` is wall-clock and therefore inherently nondeterministic.
+ */
+export interface EpisodeResult {
+  /** Sum of step rewards across the rollout. */
+  readonly returnValue: number;
+  /** Number of `step()` calls before exit. */
+  readonly steps: number;
+  /** Adapter signalled a natural episode end (death, goal, terminal state). */
+  readonly terminated: boolean;
+  /** A guard fired (step cap or wall-clock cap). */
+  readonly truncated: boolean;
+  /** Which guard fired, when `truncated === true`. */
+  readonly truncationReason?: TruncationReason;
+  /** Wall-clock duration of the rollout in milliseconds. */
+  readonly elapsedMs: number;
+  /** Seed that was passed to {@link EpisodeAdapter.reset}. */
+  readonly seed: number;
+}
+
+/**
+ * Drive an {@link EpisodeAdapter} end-to-end for one creature. Returns the
+ * scalar return plus rollout metadata.
+ *
+ * Loop semantics, in order, on each tick:
+ *
+ * 1. `output = creature.activate(observation, true)` (feedback loop on, per
+ *    `docs/REINFORCEMENT_LEARNING.md`).
+ * 2. `action = adapter.decodeAction(output, state)`.
+ * 3. `result = adapter.step(state, action)`.
+ * 4. Accumulate `returnValue += result.reward`; advance `state` and
+ *    `observation`.
+ * 5. Exit cleanly with `terminated = true` when `result.terminated`.
+ * 6. Exit with `truncated = true, truncationReason = 'maxSteps'` when
+ *    `steps >= maxSteps`.
+ * 7. Exit with `truncated = true, truncationReason = 'wallClock'` when
+ *    `(performance.now() - t0) >= wallClockMs`.
+ *
+ * @param adapter — Adapter wrapping the simulator. {@link EpisodeAdapter.assertContract}
+ *   is invoked once before the first tick.
+ * @param creature — The genome whose `activate()` produces actions.
+ * @param rngSeed — Deterministic seed forwarded to `adapter.reset(rngSeed)`.
+ *   The runner itself never reads from `Math.random()`.
+ */
+export function runEpisode<S, A>(
+  adapter: EpisodeAdapter<S, A>,
+  creature: Creature,
+  rngSeed: number,
+): Promise<EpisodeResult> {
+  // Validate the adapter contract on first use. Subsequent calls are no-ops
+  // (the adapter caches the check internally), so paying once per episode is
+  // fine.
+  adapter.assertContract(rngSeed);
+
+  // Capture caps once. `maxSteps()` and `wallClockMs()` are virtual calls;
+  // the hot loop must not pay for them on every tick.
+  const maxSteps = adapter.maxSteps();
+  const wallClockMs = adapter.wallClockMs();
+
+  // Capture `t0` once — every later wall-clock check measures against this.
+  const t0 = performance.now();
+
+  const initial = adapter.reset(rngSeed);
+  let observation: Float32Array = initial.observation;
+  let state: S = initial.state;
+
+  let returnValue = 0;
+  let steps = 0;
+  let terminated = false;
+  let truncated = false;
+  let truncationReason: TruncationReason | undefined;
+
+  while (true) {
+    const output = creature.activate(observation, true);
+    const action = adapter.decodeAction(output, state);
+    const result = adapter.step(state, action);
+
+    returnValue += result.reward;
+    state = result.state;
+    observation = result.observation;
+    steps++;
+
+    if (result.terminated) {
+      terminated = true;
+      break;
+    }
+
+    if (steps >= maxSteps) {
+      truncated = true;
+      truncationReason = "maxSteps";
+      break;
+    }
+
+    if (performance.now() - t0 >= wallClockMs) {
+      truncated = true;
+      truncationReason = "wallClock";
+      break;
+    }
+  }
+
+  const elapsedMs = performance.now() - t0;
+
+  return Promise.resolve({
+    returnValue,
+    steps,
+    terminated,
+    truncated,
+    truncationReason,
+    elapsedMs,
+    seed: rngSeed,
+  });
+}

--- a/test/creature/EpisodeRunner_test.ts
+++ b/test/creature/EpisodeRunner_test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for the library-owned {@link runEpisode} runner introduced in
+ * Issue #2627 (part of #2624).
+ *
+ * Covers the six scenarios listed in the issue:
+ *
+ * 1. Natural termination — adapter signals `terminated = true` after N steps.
+ * 2. Max-steps truncation — adapter never sets `terminated`; runner caps it.
+ * 3. Wall-clock truncation — adapter step takes 100 ms with a 500 ms cap;
+ *    runner truncates between 5 and 7 steps. Uses a `performance.now()` shim
+ *    to keep the unit test fast.
+ * 4. Override caps — subclass with `maxSteps() = 10` truncates at 10.
+ * 5. Determinism — same seed twice produces identical results.
+ * 6. Reward accumulation — five `reward = 1` steps then `terminated = true`
+ *    yields `returnValue = 5`.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { EpisodeAdapter, type StepResult } from "@creature/EpisodeAdapter.ts";
+import { runEpisode } from "@creature/EpisodeRunner.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+// ---------------------------------------------------------------------------
+// Shared shim: replace `performance.now` with a virtual clock for tests that
+// must measure wall-clock behaviour without sleeping for real seconds.
+// ---------------------------------------------------------------------------
+
+function withVirtualClock<T>(
+  fn: (advance: (ms: number) => void) => T,
+): T {
+  const original = performance.now.bind(performance);
+  let virtualMs = 0;
+  performance.now = () => virtualMs;
+  try {
+    return fn((ms) => {
+      virtualMs += ms;
+    });
+  } finally {
+    performance.now = original;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal creature with one input, one output. Activation does not
+// matter for runner semantics; the runner forwards bytes between adapter and
+// creature.
+// ---------------------------------------------------------------------------
+
+function makeCreature(inputs = 1, outputs = 1): Creature {
+  return new Creature(inputs, outputs, {
+    layers: [{ count: 2 }],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Natural termination after 12 steps
+// ---------------------------------------------------------------------------
+
+class FixedLengthAdapter extends EpisodeAdapter<{ step: number }, number> {
+  constructor(private readonly endAt: number, private readonly reward = 0) {
+    super();
+  }
+
+  override reset(
+    _rngSeed: number,
+  ): { observation: Float32Array; state: { step: number } } {
+    return { observation: new Float32Array([0]), state: { step: 0 } };
+  }
+
+  override step(
+    state: { step: number },
+    _action: number,
+  ): StepResult<Float32Array> & { state: { step: number } } {
+    const next = { step: state.step + 1 };
+    return {
+      observation: new Float32Array([next.step]),
+      reward: this.reward,
+      terminated: next.step >= this.endAt,
+      truncated: false,
+      state: next,
+    };
+  }
+
+  override get observationLength(): number {
+    return 1;
+  }
+
+  override decodeAction(_creatureOutput: Float32Array): number {
+    return 0;
+  }
+}
+
+Deno.test("runEpisode: natural termination after 12 steps", async () => {
+  await initWasmForTests();
+  const adapter = new FixedLengthAdapter(12);
+  const creature = makeCreature();
+
+  const result = await runEpisode(adapter, creature, 7);
+
+  assertEquals(result.terminated, true);
+  assertEquals(result.truncated, false);
+  assertEquals(result.steps, 12);
+  assertEquals(result.truncationReason, undefined);
+  assertEquals(result.seed, 7);
+  assert(result.elapsedMs >= 0);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Max-steps truncation with default guard (5000)
+// ---------------------------------------------------------------------------
+
+class NeverEndingAdapter extends EpisodeAdapter<null, number> {
+  override reset(
+    _rngSeed: number,
+  ): { observation: Float32Array; state: null } {
+    return { observation: new Float32Array([0]), state: null };
+  }
+
+  override step(
+    _state: null,
+    _action: number,
+  ): StepResult<Float32Array> & { state: null } {
+    return {
+      observation: new Float32Array([0]),
+      reward: 0,
+      terminated: false,
+      truncated: false,
+      state: null,
+    };
+  }
+
+  override get observationLength(): number {
+    return 1;
+  }
+
+  override decodeAction(_creatureOutput: Float32Array): number {
+    return 0;
+  }
+}
+
+Deno.test("runEpisode: default maxSteps guard truncates at 5000", async () => {
+  await initWasmForTests();
+  const adapter = new NeverEndingAdapter();
+  const creature = makeCreature();
+
+  const result = await runEpisode(adapter, creature, 0);
+
+  assertEquals(result.terminated, false);
+  assertEquals(result.truncated, true);
+  assertEquals(result.truncationReason, "maxSteps");
+  assertEquals(result.steps, 5000);
+});
+
+// ---------------------------------------------------------------------------
+// 3. Wall-clock truncation — uses the virtual-clock shim so the test does
+//    not actually sleep for half a second.
+// ---------------------------------------------------------------------------
+
+class SlowAdapter extends EpisodeAdapter<null, number> {
+  // Advances the shared virtual clock 100 ms per step.
+  constructor(private readonly advance: (ms: number) => void) {
+    super();
+  }
+
+  override reset(
+    _rngSeed: number,
+  ): { observation: Float32Array; state: null } {
+    return { observation: new Float32Array([0]), state: null };
+  }
+
+  override step(
+    _state: null,
+    _action: number,
+  ): StepResult<Float32Array> & { state: null } {
+    this.advance(100);
+    return {
+      observation: new Float32Array([0]),
+      reward: 0,
+      terminated: false,
+      truncated: false,
+      state: null,
+    };
+  }
+
+  override get observationLength(): number {
+    return 1;
+  }
+
+  override decodeAction(_creatureOutput: Float32Array): number {
+    return 0;
+  }
+
+  override wallClockMs(): number {
+    return 500;
+  }
+
+  override maxSteps(): number {
+    // Lift the steps cap so the wall-clock guard is the binding one.
+    return 10_000;
+  }
+}
+
+Deno.test("runEpisode: wall-clock truncation fires near the cap", async () => {
+  await initWasmForTests();
+  const creature = makeCreature();
+
+  const result = await withVirtualClock((advance) => {
+    const adapter = new SlowAdapter(advance);
+    return runEpisode(adapter, creature, 0);
+  });
+
+  assertEquals(result.truncated, true);
+  assertEquals(result.truncationReason, "wallClock");
+  assertEquals(result.terminated, false);
+  // Each step advances the virtual clock 100 ms; the 500 ms cap should fire
+  // somewhere between steps 5 and 7 inclusive.
+  assert(
+    result.steps >= 5 && result.steps <= 7,
+    `expected 5–7 steps, got ${result.steps}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 4. Override caps — subclass returning maxSteps() = 10
+// ---------------------------------------------------------------------------
+
+class TightStepsAdapter extends NeverEndingAdapter {
+  override maxSteps(): number {
+    return 10;
+  }
+}
+
+Deno.test("runEpisode: subclass maxSteps override is honoured", async () => {
+  await initWasmForTests();
+  const adapter = new TightStepsAdapter();
+  const creature = makeCreature();
+
+  const result = await runEpisode(adapter, creature, 0);
+
+  assertEquals(result.truncated, true);
+  assertEquals(result.truncationReason, "maxSteps");
+  assertEquals(result.steps, 10);
+});
+
+// ---------------------------------------------------------------------------
+// 5. Determinism — same seed twice produces identical results
+// ---------------------------------------------------------------------------
+
+interface SeededState {
+  step: number;
+  rng: number;
+}
+
+/**
+ * Adapter whose step transitions are seeded by `rngSeed` so two runs with the
+ * same seed produce identical reward streams. Uses a tiny LCG seeded by the
+ * passed-in seed; no `Math.random()` calls.
+ */
+class SeededAdapter extends EpisodeAdapter<SeededState, number> {
+  override reset(
+    rngSeed: number,
+  ): { observation: Float32Array; state: SeededState } {
+    return {
+      observation: new Float32Array([rngSeed % 1]),
+      state: { step: 0, rng: rngSeed | 0 },
+    };
+  }
+
+  override step(
+    state: SeededState,
+    _action: number,
+  ): StepResult<Float32Array> & { state: SeededState } {
+    // Park-Miller LCG
+    const nextRng = (state.rng * 16807) % 2147483647;
+    const next: SeededState = { step: state.step + 1, rng: nextRng };
+    return {
+      observation: new Float32Array([nextRng / 2147483647]),
+      reward: nextRng / 2147483647,
+      terminated: next.step >= 20,
+      truncated: false,
+      state: next,
+    };
+  }
+
+  override get observationLength(): number {
+    return 1;
+  }
+
+  override decodeAction(_creatureOutput: Float32Array): number {
+    return 0;
+  }
+}
+
+Deno.test("runEpisode: same seed produces identical results", async () => {
+  await initWasmForTests();
+  const creature = makeCreature();
+
+  const a = await runEpisode(new SeededAdapter(), creature, 12345);
+  const b = await runEpisode(new SeededAdapter(), creature, 12345);
+
+  assertEquals(a.returnValue, b.returnValue);
+  assertEquals(a.steps, b.steps);
+  assertEquals(a.terminated, b.terminated);
+  assertEquals(a.truncated, b.truncated);
+  assertEquals(a.truncationReason, b.truncationReason);
+  assertEquals(a.seed, 12345);
+});
+
+// ---------------------------------------------------------------------------
+// 6. Reward accumulation — five reward=1 steps then terminated
+// ---------------------------------------------------------------------------
+
+class FiveRewardsAdapter extends EpisodeAdapter<{ step: number }, number> {
+  override reset(
+    _rngSeed: number,
+  ): { observation: Float32Array; state: { step: number } } {
+    return { observation: new Float32Array([0]), state: { step: 0 } };
+  }
+
+  override step(
+    state: { step: number },
+    _action: number,
+  ): StepResult<Float32Array> & { state: { step: number } } {
+    const next = { step: state.step + 1 };
+    return {
+      observation: new Float32Array([next.step]),
+      reward: 1,
+      terminated: next.step >= 5,
+      truncated: false,
+      state: next,
+    };
+  }
+
+  override get observationLength(): number {
+    return 1;
+  }
+
+  override decodeAction(_creatureOutput: Float32Array): number {
+    return 0;
+  }
+}
+
+Deno.test("runEpisode: accumulates scalar rewards across the rollout", async () => {
+  await initWasmForTests();
+  const adapter = new FiveRewardsAdapter();
+  const creature = makeCreature();
+
+  const result = await runEpisode(adapter, creature, 0);
+
+  assertEquals(result.steps, 5);
+  assertEquals(result.terminated, true);
+  assertEquals(result.truncated, false);
+  assertEquals(result.returnValue, 5);
+});


### PR DESCRIPTION
# Issue #2627 — Library-owned `runEpisode()` wrapper with termination guards

## Summary

Adds the final, library-owned `runEpisode()` wrapper that drives an
`EpisodeAdapter` end-to-end for one creature. The runner enforces both a
wall-clock cap and a max-steps cap, returns a scalar `returnValue` plus
rollout metadata, and never reaches for `Math.random()` — `rngSeed` is the
only source of nondeterminism that crosses the seam. Termination semantics
mirror Gym/Gymnasium (`terminated` for natural episode end, `truncated` for a
guard firing). This protects the library against the failure modes called out
in #2624 (a snake creature pressing left forever; a snake dying after three
steps).

Closes #2627.

## Evidence

```mermaid
sequenceDiagram
    participant R as runEpisode
    participant A as EpisodeAdapter
    participant C as Creature
    R->>A: assertContract(seed)
    R->>A: reset(seed)
    A-->>R: { observation, state }
    loop until terminated, maxSteps, or wallClockMs
        R->>C: activate(observation, true)
        C-->>R: output
        R->>A: decodeAction(output, state)
        A-->>R: action
        R->>A: step(state, action)
        A-->>R: { observation, reward, terminated, truncated, state }
    end
    R-->>R: EpisodeResult { returnValue, steps, terminated, truncated, ... }
```

Backend/library change with no UI surface — verified via the unit tests
listed below. The wall-clock truncation test uses a `performance.now()` shim
so the suite does not actually sleep for half a second per run.

### Implementation notes

- Caps (`maxSteps()`, `wallClockMs()`) and `t0` are captured once before the
  hot loop, never read inside it.
- `assertContract()` runs once before the first tick — the adapter caches
  the result so subsequent episodes pay nothing.
- `creature.activate(observation, true)` is invoked with `feedbackLoop = true`
  per `docs/REINFORCEMENT_LEARNING.md`.
- `result.terminated` exits cleanly with `terminated = true`; the step-cap
  and wall-clock guards exit with `truncated = true` and the matching
  `truncationReason`.
- `performance.now()` is invoked once per tick. The syscall is on the order
  of tens of nanoseconds — negligible next to a single `Creature.activate()`
  call. A coarser modulo gate could be layered on later if profiling ever
  shows the syscall dominating cost on trivial sims; the explicit
  "between 5 and 7 steps" wall-clock test required per-tick granularity.

## Test Plan

Six co-located tests in `test/creature/EpisodeRunner_test.ts` covering each
scenario from the issue:

- `runEpisode: natural termination after 12 steps` — adapter ends after 12
  steps; asserts `terminated = true, truncated = false, steps = 12`.
- `runEpisode: default maxSteps guard truncates at 5000` — adapter never
  sets `terminated`; asserts `truncated = true,
  truncationReason = 'maxSteps', steps = 5000`.
- `runEpisode: wall-clock truncation fires near the cap` — adapter advances a
  virtual clock 100 ms per step with `wallClockMs() = 500`; asserts
  truncation between 5 and 7 steps with `truncationReason = 'wallClock'`.
- `runEpisode: subclass maxSteps override is honoured` — subclass with
  `maxSteps() = 10` truncates at exactly 10.
- `runEpisode: same seed produces identical results` — two runs with seed
  `12345` produce byte-identical `returnValue`, `steps`, and
  `truncationReason`.
- `runEpisode: accumulates scalar rewards across the rollout` — five steps
  of `reward = 1` followed by `terminated = true` yields `returnValue = 5`.

All six new tests pass alongside the existing `EpisodeAdapter_test.ts`
suite (10 tests). `./quality.sh --lint-only` and `./quality.sh --check-only`
both pass cleanly.



## Milestone
This PR is part of the **Reinforcement learning** milestone and targets the `milestone/reinforcement-learning` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2627 -->