### PR TITLE
feat: implement Creature.evolveRL with seed rotation and 3-episode averaging (#2628)

### DIFF
--- a/docs/pr-summary-2628.md
+++ b/docs/pr-summary-2628.md
@@ -1,0 +1,86 @@
+## Summary
+
+Adds `Creature.evolveRL()` — the public reinforcement-learning API on top of
+the new class-shaped `EpisodeAdapter` (Issue #2626) and the library-owned
+`runEpisode()` runner (Issue #2627). Per-creature fitness is the **mean return
+across `episodesPerCreature` episodes** (default 3) played against a
+**per-generation rotating seed set** so every creature in a generation is
+compared on the same maps and over-fitting one map is avoided. Reuses the
+existing `Neat` population manager, `createNeatConfig`, mutation, crossover,
+elitism, plateau detection, telemetry, lifecycle events, and SIGTERM/abort
+handling — only the scorer changes. Closes #2628.
+
+## Design
+
+```mermaid
+flowchart TD
+    A[Caller] --> B[creature.evolveRL]
+    B --> C[createNeatConfig]
+    B --> D[new Neat]
+    D --> E[populatePopulation]
+    B --> F{generation loop}
+    F --> G[buildRLSeedSet g]
+    G --> H[neat.evolve]
+    H --> I[per-creature fitness]
+    I --> J[runEpisode x N]
+    J --> K[mean return]
+    H --> L[mutate / crossover / elite]
+    F --> M[generation_complete event]
+    F --> N{stop?}
+    N -->|targetError / timeoutMinutes / iterations / SIGTERM| O[restore best + return]
+```
+
+- `src/creature/EvolveRLSeedSet.ts` — `deriveRLSeed(baseSeed, generation, trial)`
+  is a 32-bit MurmurHash3-style mixer; `buildRLSeedSet` produces the seed set
+  for one generation. `fixedSeedSet` collapses the generation index to `0` so
+  every generation uses the same seed set (tests / regression only).
+- `src/creature/RLEpisodeFitness.ts` — `Fitness` subclass that runs episode
+  rollouts inline via `runEpisode` (no worker pool yet — multi-threaded
+  rollouts remain tracked under #2612). The seed set is replaced before every
+  fitness phase so all creatures in a generation play the same seeds.
+- `src/creature/CreatureTraining.ts` — adds `EvolveRLOptions` and `evolveRL()`,
+  reusing the same outer shape as `evolveDir()`/`evolveEnv()`. `Creature.evolveRL()`
+  is exposed on the `Creature` class.
+
+## Evidence
+
+- Targeted test run (14 tests, all pass):
+  `deno test test/creature/evolveRL_test.ts`
+  → `ok | 14 passed | 0 failed`
+- Adjacent RL tests still pass:
+  `EpisodeRunner_test.ts`, `EpisodeAdapter_test.ts`, `EvolveEnv.ts` →
+  `ok | 39 passed | 0 failed`
+- Invariant gates pass:
+  `SemanticVersionStability.ts`, `NeuronUuidStability.ts` →
+  `ok | 24 passed | 0 failed`
+- `./quality.sh` lint, format, type-check, and bash gates all green; full
+  suite reports `6631 passed | 2 failed` where the **2 failures are
+  pre-existing FFI dynamic-library leaks in
+  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`** — verified by
+  re-running on baseline (`git stash` → same failures), so unrelated to this
+  change.
+- Backend / CLI change with no UI, so no Playwright screenshot.
+
+## Test Plan
+
+- `test/creature/evolveRL_test.ts` covers the nine scenarios called out in
+  the issue:
+  1. Happy path — converges within 10 generations.
+  2. `targetError` stop fires when reached.
+  3. `timeoutMinutes` accepted; iterations cap acts as the verifiable
+     secondary stop (the same approach as `EvolveEnv.ts`).
+  4. `iterations` cap is respected.
+  5. Episode averaging — `episodesPerCreature = 3` with a seeded stochastic
+     adapter returns the arithmetic mean of the seed set's per-trial rewards.
+  6. Seed rotation — across 5 generations every seed set differs and is
+     reproducible from the base seed.
+  7. `fixedSeedSet = true` — every generation uses identical seeds.
+  8. Determinism — two runs with the same seed agree on `generation` exactly
+     and on `error`/`score` to within 1e-6 (matching `EvolveEnv.ts`'s
+     epsilon — neuron UUIDs are `crypto.randomUUID()` and downstream Maps
+     iterate in insertion order).
+  9. AbortSignal interrupt parity (used in place of OS SIGTERM in tests for
+     the same reason as `EvolveEnv.ts`: sending SIGTERM from a worker
+     propagates to the parallel test runner).
+- Plus seed-helper unit tests covering determinism, rotation, fixed-set
+  collapse, and the invalid-`episodesPerCreature` guard.

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -974,6 +974,23 @@ export class Creature implements CreatureInternal {
     return training.evolveEnv(this, adapter, options);
   }
 
+  /**
+   * Evolve the creature against a streaming-observation simulator using the
+   * class-shaped {@link import("./creature/EpisodeAdapter.ts").EpisodeAdapter}
+   * contract (Issue #2628). Per-creature fitness is the mean return across
+   * `episodesPerCreature` (default 3) episodes played against a per-generation
+   * rotating seed set so all creatures in a generation are compared fairly.
+   * See {@link training.evolveRL}.
+   */
+  evolveRL<S, A>(
+    adapter: import("./creature/EpisodeAdapter.ts").EpisodeAdapter<S, A>,
+    options: training.EvolveRLOptions,
+  ): Promise<
+    { error: number; score: number; time: number; generation: number }
+  > {
+    return training.evolveRL(this, adapter, options);
+  }
+
   evolveDataSet(
     dataSet: DataRecordInterface[],
     options: NeatOptions,

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -58,10 +58,13 @@ import { setWasmCompilationCacheSize } from "@wasm/WasmCompilationCache.ts";
 import { emitTrainingEvent } from "@neat/TrainingEventEmitter.ts";
 import {
   defaultRewardToError,
+  type EpisodeTrialsEvent,
   type EpisodicOptions,
   type LegacyEpisodeAdapter,
 } from "@creature/EpisodicFitnessTypes.ts";
 import type { Fitness } from "@architecture/Fitness.ts";
+import type { EpisodeAdapter } from "@creature/EpisodeAdapter.ts";
+import { buildRLSeedSet } from "@creature/EvolveRLSeedSet.ts";
 
 /**
  * Propagate expected values backward through the network for all output neurons.
@@ -831,6 +834,287 @@ export async function evolveEnv<S, A>(
 
   if (bestCreature) {
     creature.loadFrom(bestCreature, config.debug, "evolveEnv:restoreBest");
+  }
+
+  if (config.creatureStore) {
+    await writeCreatures(neat, config.creatureStore);
+  }
+
+  Deno.removeSignalListener("SIGTERM", signalListener);
+  options.signal?.removeEventListener("abort", abortListener);
+  return {
+    error,
+    score: bestScore,
+    generation,
+    time: Date.now() - start,
+  };
+}
+
+/**
+ * Caller-tunable options for {@link evolveRL} (Issue #2628).
+ *
+ * Layered on top of {@link NeatOptions} so the same evolutionary stop
+ * conditions and lifecycle events used by `evolveDir()` apply here too.
+ */
+export interface EvolveRLOptions extends NeatOptions {
+  /**
+   * Number of episodes per creature per generation; per-creature fitness is
+   * the mean return across these episodes. Default: `3`.
+   */
+  episodesPerCreature?: number;
+  /**
+   * Base seed mixed into the per-generation seed set. When omitted, a
+   * time-based default is used so the seed set still rotates between
+   * generations and across runs. Pin this when you need reproducibility.
+   */
+  seed?: number;
+  /**
+   * When `true`, every generation uses `seedSet(0)` instead of rotating with
+   * the generation counter. Tests / regression only — real evolution should
+   * keep this `false` so creatures cannot over-fit one map. Default: `false`.
+   */
+  fixedSeedSet?: boolean;
+  /**
+   * Reserved for future per-generation telemetry; kept off by default to
+   * stay zero-cost on the hot path. Default: `false`.
+   */
+  statistics?: boolean;
+  /**
+   * Optional callback fired once per scored creature per generation with the
+   * per-trial reward breakdown so callers can chart variance. Mirrors the
+   * `evolveEnv` hook of the same name.
+   */
+  onEpisodeTrials?: (event: EpisodeTrialsEvent) => void;
+  /**
+   * Optional {@link AbortSignal} that allows the caller to interrupt the
+   * evolution run externally without sending an OS signal. Mirrors the
+   * `evolveEnv` hook of the same name.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Evolve the creature against a streaming-observation simulator using the
+ * class-shaped {@link EpisodeAdapter} contract from Issue #2626 and the
+ * library-owned {@link runEpisode} runner from Issue #2627 (Issue #2628).
+ *
+ * Reuses the same outer shape as {@link evolveDir}: a single `Neat` instance
+ * drives population management, mutation, crossover, elitism, plateau
+ * detection, and lifecycle events. The only difference is the scorer — the
+ * worker-based dataset {@link Fitness} is swapped for an
+ * {@link RLEpisodeFitness} that runs `episodesPerCreature` episode rollouts
+ * per creature inline.
+ *
+ * Per-generation seed set: every creature in generation `g` plays the same
+ * seeds derived from `seedSet(g) = [hash(seed, g, 0), …, hash(seed, g, N-1)]`,
+ * so within-generation comparisons are fair and the set rotates each
+ * generation to avoid one-map over-fit. Pass `fixedSeedSet = true` to lock
+ * `seedSet(0)` for every generation (tests / regression only).
+ *
+ * Stop conditions (`targetError`, `timeoutMinutes`, `iterations`, SIGTERM)
+ * and lifecycle events (`generation_complete`, `plateau_detected`) match
+ * `evolveDir()` so existing consumers do not need a new event handler.
+ * Cumulative episode reward is mapped to the non-negative `error` slot via
+ * `defaultRewardToError` (`error = max(0, -reward)`), so `targetError`
+ * semantics are preserved.
+ *
+ * Multi-threaded worker rollouts are deliberately deferred to #2612; today
+ * every episode runs on the main thread.
+ */
+export async function evolveRL<S, A>(
+  creature: Creature,
+  adapter: EpisodeAdapter<S, A>,
+  options: EvolveRLOptions,
+): Promise<
+  { error: number; score: number; time: number; generation: number }
+> {
+  if (creature.input !== adapter.observationLength) {
+    throw new Error(
+      `Creature input ${creature.input} does not match adapter ` +
+        `observationLength ${adapter.observationLength}`,
+    );
+  }
+
+  const episodesPerCreature = options.episodesPerCreature !== undefined
+    ? Math.max(1, Math.floor(options.episodesPerCreature))
+    : 3;
+  const fixedSeedSet = options.fixedSeedSet === true;
+  // Default base seed is time-based so independent runs differ. Callers that
+  // need reproducibility pin `seed` explicitly. The mask keeps it inside the
+  // 32-bit unsigned range expected by `deriveRLSeed`.
+  const baseSeed = options.seed !== undefined && options.seed !== null
+    ? Math.floor(options.seed) >>> 0
+    : Date.now() >>> 0;
+
+  let interrupted = false;
+  const signalListener = () => {
+    getLogger().info("SIGTERM received, stopping evolveRL...");
+    interrupted = true;
+  };
+  Deno.addSignalListener("SIGTERM", signalListener);
+
+  const abortListener = () => {
+    getLogger().info("AbortSignal received, stopping evolveRL...");
+    interrupted = true;
+  };
+  options.signal?.addEventListener("abort", abortListener);
+
+  const start = Date.now();
+  const config = createNeatConfig(options);
+
+  setMaxCachedWasmCreatureActivations(config.wasmCache.maxCachedActivations);
+  setWasmCompilationCacheSize(config.wasmCache.compilationCacheSize);
+
+  const endTimeMS = config.timeoutMinutes
+    ? start + Math.max(1, config.timeoutMinutes) * 60000
+    : 0;
+
+  // Lazy import avoids a circular module graph (Neat.ts → Creature.ts →
+  // CreatureTraining.ts → RLEpisodeFitness.ts → Fitness.ts vs Neat.ts → Fitness.ts).
+  const { RLEpisodeFitness } = await import("@creature/RLEpisodeFitness.ts");
+  const rlFitness = new RLEpisodeFitness({
+    adapter,
+    growth: config.costOfGrowth,
+    rewardToError: defaultRewardToError,
+    onEpisodeTrials: options.onEpisodeTrials,
+  });
+
+  // Empty worker pool: scoring runs inline. Discovery/training scheduling
+  // becomes a no-op (the schedulers warn and bail when no workers are
+  // available); breeding falls back to the main-thread path.
+  const neat = new Neat(creature.input, creature.output, config, []);
+  // Swap in the RL scorer. The `fitness` property is `readonly` at the type
+  // level for ergonomics, but this is the documented seam for alternative
+  // scoring strategies.
+  (neat as unknown as { fitness: Fitness }).fitness = rlFitness;
+
+  await neat.populatePopulation(creature);
+
+  let error = Infinity;
+  let bestScore = -Infinity;
+
+  const { Creature: CreatureClass } = await import("../Creature.ts");
+  let bestCreature: InstanceType<typeof CreatureClass> | undefined;
+
+  let iterationStartMS = Date.now();
+  let generation = 0;
+  const targetError = config.targetError;
+  const iterations = config.iterations;
+
+  while (true) {
+    generation++;
+    rlFitness.setGeneration(generation);
+    rlFitness.setSeedSet(
+      buildRLSeedSet(baseSeed, generation, episodesPerCreature, fixedSeedSet),
+    );
+
+    // deno-lint-ignore no-await-in-loop
+    const result = await neat.evolve(bestCreature);
+
+    const fittest = result.fittest;
+    const fittestScore = fittest.score!;
+    assert(fittestScore >= bestScore, "Score is less than best score");
+    if (fittestScore > bestScore) {
+      const errorTmp = getTag(fittest, "error");
+      assert(errorTmp, "No error tag found");
+
+      const parsedError = errorTmp === "Infinity"
+        ? Number.POSITIVE_INFINITY
+        : Number.parseFloat(errorTmp);
+      assert(Number.isFinite(parsedError), "Error is not finite");
+      assert(parsedError >= 0, "Error is negative");
+      error = parsedError;
+      bestScore = fittestScore;
+      bestCreature = fittest.shallowClone() as InstanceType<
+        typeof CreatureClass
+      >;
+      bestCreature.score = bestScore;
+    }
+
+    const now = Date.now();
+    const timedOut = endTimeMS ? now > endTimeMS : false;
+
+    let phaseTiming = result.phaseTiming;
+    if (config.checkpointEveryGeneration && config.creatureStore) {
+      const checkpointStart = Date.now();
+      // deno-lint-ignore no-await-in-loop
+      await writeCreatures(neat, config.creatureStore);
+      phaseTiming = {
+        ...result.phaseTiming,
+        checkpointWriteMs: Date.now() - checkpointStart,
+      };
+    }
+
+    const generationElapsedMs = now -
+      (generation === 1 ? start : iterationStartMS);
+    emitTrainingEvent(config.onTrainingEvent, {
+      kind: "generation_complete",
+      timestamp: new Date().toISOString(),
+      generation,
+      bestFitness: fittestScore,
+      averageFitness: result.averageScore,
+      populationSize: neat.population.length,
+      elapsedMs: generationElapsedMs,
+      phaseTiming,
+      throughput: result.throughput,
+    });
+
+    if (result.plateau.onPlateau) {
+      emitTrainingEvent(config.onTrainingEvent, {
+        kind: "plateau_detected",
+        timestamp: new Date().toISOString(),
+        generation,
+        stagnationCount: result.plateau.generationsOnPlateau,
+        plateauThreshold: config.plateauDetection.windowSize,
+        improvementRate: result.plateau.improvementRate,
+        mutationMultiplier: result.plateau.mutationMultiplier,
+      });
+    }
+
+    const completed = interrupted || timedOut || error <= targetError ||
+      generation >= iterations;
+
+    if (
+      config.log &&
+      (generation % config.log === 0 || completed)
+    ) {
+      let avgTxt = "";
+      if (Number.isFinite(result.averageScore)) {
+        avgTxt = `(avg: ${yellow(result.averageScore.toFixed(4))})`;
+      }
+      getLogger().info(
+        "Generation",
+        generation,
+        "score",
+        fittest.score,
+        avgTxt,
+        "error",
+        error,
+        (config.log > 1 ? "avg " : "") + "time",
+        yellow(
+          format(Math.round((now - iterationStartMS) / config.log), {
+            ignoreZero: true,
+          }),
+        ),
+      );
+      iterationStartMS = now;
+    }
+
+    if (completed) {
+      if (interrupted) break;
+      if (neat.finishUp(iterations, endTimeMS, start, generation)) {
+        break;
+      }
+      // deno-lint-ignore no-await-in-loop
+      await neat.awaitInFlightTasks();
+    }
+  }
+
+  // No worker pool to terminate — episode rollouts ran inline.
+  await neat.discoveryReplayQueue.waitForCompletion();
+
+  if (bestCreature) {
+    creature.loadFrom(bestCreature, config.debug, "evolveRL:restoreBest");
   }
 
   if (config.creatureStore) {

--- a/src/creature/EvolveRLSeedSet.ts
+++ b/src/creature/EvolveRLSeedSet.ts
@@ -1,0 +1,78 @@
+/**
+ * EvolveRLSeedSet.ts — Deterministic seed-set helper for `Creature.evolveRL()`
+ * (Issue #2628, part of #2624).
+ *
+ * Per-generation seed set: every creature in generation `g` plays the same
+ * `seedSet(g) = [hash(baseSeed, g, 0), …, hash(baseSeed, g, episodes - 1)]`,
+ * so per-creature fitness comparisons inside the generation are fair. The
+ * seed set rotates between generations because `g` is mixed into the hash.
+ *
+ * When `fixedSeedSet === true` the seed set is collapsed to `seedSet(0)` for
+ * every generation — useful only for tests / regression checks where the
+ * caller wants deterministic, non-rotating seeds. Real evolution should
+ * always rotate, otherwise creatures over-fit one map.
+ *
+ * The hash uses a small MurmurHash3-style 32-bit mixer: each input is
+ * combined with prime multipliers and xorshifts so changing any one input
+ * — base, generation, or trial — flips most output bits. This keeps adjacent
+ * generations / trials uncorrelated in seed space without dragging in a
+ * heavyweight RNG dependency.
+ */
+
+/**
+ * Mix `baseSeed`, `generation`, and `trial` into a 32-bit unsigned integer.
+ *
+ * The function is pure and deterministic: identical inputs always return
+ * the same output across runs, processes, and machines. Adjacent
+ * generations or trials produce uncorrelated outputs — useful when an
+ * adapter keys observations off the seed.
+ */
+export function deriveRLSeed(
+  baseSeed: number,
+  generation: number,
+  trial: number,
+): number {
+  // Coerce inputs to 32-bit unsigned. Math.imul gives consistent 32-bit
+  // multiplication semantics under JavaScript's 64-bit floats.
+  let h = (baseSeed | 0) >>> 0;
+  h = Math.imul(h ^ ((generation | 0) >>> 0), 0x85ebca6b) >>> 0;
+  h = (h ^ (h >>> 13)) >>> 0;
+  h = Math.imul(h ^ ((trial | 0) >>> 0), 0xc2b2ae35) >>> 0;
+  h = (h ^ (h >>> 16)) >>> 0;
+  return h;
+}
+
+/**
+ * Build the seed set for generation `generation`.
+ *
+ * @param baseSeed — Base seed supplied via `EvolveRLOptions.seed`.
+ * @param generation — 1-based generation counter. Pass `0` for both
+ *   generations when `fixedSeedSet === true`.
+ * @param episodesPerCreature — Length of the returned seed set; must be a
+ *   positive integer.
+ * @param fixedSeedSet — When `true`, ignore `generation` and always use
+ *   generation `0` so every generation uses the same seed set. Default
+ *   `false` (rotation enabled).
+ */
+export function buildRLSeedSet(
+  baseSeed: number,
+  generation: number,
+  episodesPerCreature: number,
+  fixedSeedSet = false,
+): number[] {
+  if (
+    !Number.isFinite(episodesPerCreature) ||
+    !Number.isInteger(episodesPerCreature) ||
+    episodesPerCreature <= 0
+  ) {
+    throw new Error(
+      `episodesPerCreature must be a positive integer, got ${episodesPerCreature}`,
+    );
+  }
+  const effectiveGeneration = fixedSeedSet ? 0 : generation;
+  const seeds: number[] = new Array(episodesPerCreature);
+  for (let i = 0; i < episodesPerCreature; i++) {
+    seeds[i] = deriveRLSeed(baseSeed, effectiveGeneration, i);
+  }
+  return seeds;
+}

--- a/src/creature/RLEpisodeFitness.ts
+++ b/src/creature/RLEpisodeFitness.ts
@@ -1,0 +1,283 @@
+/**
+ * RLEpisodeFitness.ts — In-process episode-rollout scorer for
+ * `Creature.evolveRL()` (Issue #2628, part of #2624).
+ *
+ * Counterpart to {@link EpisodicFitness} but speaks the new class-shaped
+ * {@link EpisodeAdapter} contract from Issue #2626 and drives the
+ * library-owned {@link runEpisode} runner from Issue #2627. The shared
+ * per-generation seed set (see `EvolveRLSeedSet.ts`) is set by
+ * `Creature.evolveRL()` before each fitness phase so every creature in
+ * generation `g` is evaluated against the same seeds.
+ *
+ * Like {@link EpisodicFitness}, this scorer extends {@link Fitness} so it
+ * satisfies the structural contract used by `NeatEvolution.ts`. The base
+ * constructor is invoked with an empty worker pool; multi-threaded rollouts
+ * via the worker pool are tracked in #2612 and slot in here later — this
+ * implementation runs every episode inline.
+ */
+
+import { addTag, getTag } from "@stsoftware/tags/mod";
+import type { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { Fitness } from "@architecture/Fitness.ts";
+import { calculate as calculateScore } from "@architecture/Score.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { ValidationError } from "@errors/ValidationError.ts";
+import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import { getLogger } from "@utils/Logger.ts";
+import type { EpisodeAdapter } from "@creature/EpisodeAdapter.ts";
+import { runEpisode } from "@creature/EpisodeRunner.ts";
+import type { EpisodeTrialsEvent } from "@creature/EpisodicFitnessTypes.ts";
+import { defaultRewardToError } from "@creature/EpisodicFitnessTypes.ts";
+
+/**
+ * Constructor dependencies for {@link RLEpisodeFitness}. Mirrors the
+ * caller-tunable surface of `EvolveRLOptions` plus the `growth` cost factor
+ * pulled from {@link NeatConfig}.
+ */
+export interface RLEpisodeFitnessDeps<S, A> {
+  readonly adapter: EpisodeAdapter<S, A>;
+  readonly growth: number;
+  readonly rewardToError?: (reward: number) => number;
+  readonly onEpisodeTrials?: (event: EpisodeTrialsEvent) => void;
+}
+
+/**
+ * Fitness scorer that runs episode rollouts inline using the new class-shaped
+ * {@link EpisodeAdapter} and the library-owned {@link runEpisode} runner.
+ *
+ * The per-generation seed set is supplied by `Creature.evolveRL()` before each
+ * fitness phase via {@link RLEpisodeFitness.setSeedSet}, so every creature in
+ * the same generation plays the same seeds. The mean return across the seed
+ * set becomes the creature's fitness; that mean is mapped to the non-negative
+ * `error` slot via {@link RLEpisodeFitnessDeps.rewardToError} (default
+ * `error = max(0, -reward)`) and finally to a NEAT score via
+ * {@link calculateScore}.
+ */
+export class RLEpisodeFitness<S, A> extends Fitness {
+  private readonly adapter: EpisodeAdapter<S, A>;
+  private readonly episodicGrowth: number;
+  private readonly rewardToError: (reward: number) => number;
+  private readonly onEpisodeTrials?: (event: EpisodeTrialsEvent) => void;
+
+  /** 1-based generation counter used in {@link EpisodeTrialsEvent.generation}. */
+  private generation = 0;
+  /** Per-generation seed set. Replaced before every fitness phase. */
+  private seedSet: readonly number[] = [];
+
+  constructor(deps: RLEpisodeFitnessDeps<S, A>) {
+    // Empty worker pool: the base class is only here for the structural
+    // contract; episode rollouts run on the main thread.
+    super([], deps.growth, false);
+    this.adapter = deps.adapter;
+    this.episodicGrowth = deps.growth;
+    this.rewardToError = deps.rewardToError ?? defaultRewardToError;
+    this.onEpisodeTrials = deps.onEpisodeTrials;
+  }
+
+  /**
+   * Update the generation counter. Called from `Creature.evolveRL()` after
+   * each `neat.evolve()` so the next fitness phase emits the correct
+   * generation number on per-creature trial events.
+   */
+  setGeneration(generation: number): void {
+    this.generation = generation;
+  }
+
+  /**
+   * Replace the per-generation seed set. The same set is used for every
+   * creature scored in the next `calculate()` call so within-generation
+   * comparisons are fair.
+   */
+  setSeedSet(seedSet: readonly number[]): void {
+    if (seedSet.length === 0) {
+      throw new Error("RLEpisodeFitness.setSeedSet: seedSet must be non-empty");
+    }
+    this.seedSet = seedSet;
+  }
+
+  /**
+   * Score every creature in `population` whose `creature.score` is undefined.
+   *
+   * Mirrors {@link Fitness.calculate} semantics: deduplicates by UUID, scores
+   * each unique creature once across the configured seed set, then fans the
+   * score and tags out to duplicates. The `additionalWorkers` argument is
+   * accepted for API parity but ignored — episode rollouts run inline.
+   */
+  override async calculate(
+    population: Creature[],
+    _additionalWorkers?: WorkerHandler[],
+  ): Promise<void> {
+    // Reset telemetry counters consumed by NeatEvolution.ts after every
+    // generation. These are read once per generation so it is safe to do this
+    // unconditionally.
+    this.lastQueueMaxDepth = 0;
+    this.lastScorerMs = 0;
+    this.lastScoredCreatureCount = 0;
+    this.lastBatchScorerInvocations = 0;
+
+    if (this.seedSet.length === 0) {
+      throw new Error(
+        "RLEpisodeFitness.calculate invoked before setSeedSet — " +
+          "Creature.evolveRL() must seed each generation",
+      );
+    }
+
+    const needsEvaluation = population.filter((c) => c.score === undefined);
+
+    // Deduplicate by UUID so two pointers to the same genome cost a single
+    // rollout. The duplicate fan-out at the end of the loop mirrors the
+    // dataset path so downstream code that relies on `score`/`error` tags
+    // being present on every creature still works.
+    const duplicates = new Map<string, Creature[]>();
+    const uniqueQueue: Creature[] = [];
+
+    for (const creature of needsEvaluation) {
+      const uuid = CreatureUtil.makeUUID(creature);
+      if (!duplicates.has(uuid)) {
+        duplicates.set(uuid, [creature]);
+        uniqueQueue.push(creature);
+      } else {
+        duplicates.get(uuid)!.push(creature);
+      }
+    }
+
+    if (uniqueQueue.length === 0) return;
+
+    this.lastQueueMaxDepth = uniqueQueue.length;
+
+    let scorerMsAccum = 0;
+    let scoredCount = 0;
+
+    for (const creature of uniqueQueue) {
+      if (creature.input !== this.adapter.observationLength) {
+        throw new ValidationError(
+          `Creature input ${creature.input} does not match adapter ` +
+            `observationLength ${this.adapter.observationLength}`,
+          "OTHER",
+        );
+      }
+
+      const trialRewards: number[] = new Array(this.seedSet.length);
+      let cumulative = 0;
+      let nonFinite = false;
+
+      for (let t = 0; t < this.seedSet.length; t++) {
+        const seed = this.seedSet[t];
+        let reward: number;
+        try {
+          // Seeds must run serially so the creature's per-trial returns line
+          // up 1:1 with this.seedSet.
+          // deno-lint-ignore no-await-in-loop
+          const result = await runEpisode(this.adapter, creature, seed);
+          reward = result.returnValue;
+        } catch (err) {
+          if (err instanceof ActivationError) {
+            getLogger().warn(
+              `[RLEpisodeFitness] Activation failure on creature ` +
+                `${creature.uuid?.substring(0, 8) ?? "unknown"}: ` +
+                `${err.message}`,
+            );
+            reward = Number.NEGATIVE_INFINITY;
+          } else {
+            throw err;
+          }
+        }
+
+        if (!Number.isFinite(reward)) nonFinite = true;
+        trialRewards[t] = reward;
+        cumulative += reward;
+      }
+
+      const meanReward = cumulative / this.seedSet.length;
+
+      if (nonFinite || !Number.isFinite(meanReward)) {
+        addTag(creature, "error", "Infinity");
+        addTag(creature, "trialRewards", trialRewards.join(","));
+        creature.score = -Infinity;
+        addTag(creature, "score", creature.score.toString());
+        this.fanOutToDuplicates(creature, duplicates);
+        continue;
+      }
+
+      let error = this.rewardToError(meanReward);
+      if (!Number.isFinite(error) || error < 0) {
+        // Fail safe: a misbehaving rewardToError must not corrupt the
+        // population. Treat as worst case so natural selection drops the
+        // creature instead of crashing the run.
+        getLogger().warn(
+          `[RLEpisodeFitness] rewardToError returned non-positive-finite ` +
+            `(${error}) for reward ${meanReward}; mapping to Infinity.`,
+        );
+        error = Number.POSITIVE_INFINITY;
+      }
+
+      if (Number.isFinite(error)) {
+        addTag(creature, "error", error.toString());
+        const scoreStart = performance.now();
+        creature.score = calculateScore(creature, error, this.episodicGrowth);
+        scorerMsAccum += performance.now() - scoreStart;
+        scoredCount++;
+      } else {
+        addTag(creature, "error", "Infinity");
+        creature.score = -Infinity;
+      }
+
+      addTag(creature, "score", creature.score.toString());
+      addTag(creature, "trialRewards", trialRewards.join(","));
+
+      // Per-creature variance telemetry. Population-standard-deviation
+      // (divisor = N) is the natural choice when the trials enumerate the
+      // entire sample (no bias correction needed).
+      let stdReward = 0;
+      if (this.seedSet.length > 1) {
+        let variance = 0;
+        for (let t = 0; t < this.seedSet.length; t++) {
+          const d = trialRewards[t] - meanReward;
+          variance += d * d;
+        }
+        variance /= this.seedSet.length;
+        stdReward = Math.sqrt(variance);
+      }
+
+      this.onEpisodeTrials?.({
+        generation: this.generation,
+        creatureUuid: creature.uuid,
+        trialRewards,
+        meanReward,
+        stdReward,
+        error,
+      });
+
+      this.fanOutToDuplicates(creature, duplicates);
+    }
+
+    this.lastScorerMs = scorerMsAccum;
+    this.lastScoredCreatureCount = scoredCount;
+  }
+
+  /**
+   * Mirror score and tags from `creature` to every duplicate-by-UUID entry.
+   * Identical to the duplicate fan-out in {@link Fitness.calculate} so the
+   * population invariants downstream code relies on still hold.
+   */
+  private fanOutToDuplicates(
+    creature: Creature,
+    duplicates: Map<string, Creature[]>,
+  ): void {
+    const uuid = creature.uuid;
+    if (!uuid) return;
+    const dupes = duplicates.get(uuid);
+    if (!dupes) return;
+    const errorTag = getTag(creature, "error");
+    const scoreTag = getTag(creature, "score");
+    const trialsTag = getTag(creature, "trialRewards");
+    for (const duplicate of dupes) {
+      if (duplicate === creature) continue;
+      duplicate.score = creature.score;
+      if (errorTag) addTag(duplicate, "error", errorTag);
+      if (scoreTag) addTag(duplicate, "score", scoreTag);
+      if (trialsTag) addTag(duplicate, "trialRewards", trialsTag);
+    }
+  }
+}

--- a/test/creature/evolveRL_test.ts
+++ b/test/creature/evolveRL_test.ts
@@ -1,0 +1,478 @@
+/**
+ * Tests for `Creature.evolveRL()` and supporting seed-set helper
+ * (Issue #2628, part of #2624).
+ *
+ * Covers the nine scenarios listed in the issue:
+ *
+ * 1. Happy path — trivial 1-input/1-output adapter converges in <10
+ *    generations.
+ * 2. `targetError` stop fires when reached.
+ * 3. `timeoutMinutes` stop is respected.
+ * 4. `iterations` cap is respected.
+ * 5. Episode averaging — `episodesPerCreature = 3` returns the mean of the
+ *    seed set with a known-stochastic adapter.
+ * 6. Seed rotation — across 5 generations, every generation's seed set
+ *    differs and is reproducible from the base seed.
+ * 7. `fixedSeedSet = true` — every generation uses the same seed set.
+ * 8. Determinism — two runs with the same `seed` and `EpisodeAdapter` return
+ *    matching `{ error, score, generation }`.
+ * 9. AbortSignal interrupts the run (parity with `evolveEnv`'s SIGTERM
+ *    handling — sending an OS signal from a worker would abort the parallel
+ *    test runner, see `EvolveEnv.ts`).
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { EpisodeAdapter, type StepResult } from "@creature/EpisodeAdapter.ts";
+import { buildRLSeedSet, deriveRLSeed } from "@creature/EvolveRLSeedSet.ts";
+import type { EpisodeTrialsEvent } from "@creature/EpisodicFitnessTypes.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+await initWasmForTests();
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal adapters
+// ---------------------------------------------------------------------------
+
+/**
+ * Trivial single-tick adapter where the network must produce an output close
+ * to `target`. Reward = `-|action - target|` so a perfect output gives
+ * `reward = 0` (which the default mapping flattens to `error = 0`).
+ */
+class TargetAdapter extends EpisodeAdapter<null, number> {
+  constructor(private readonly target: number) {
+    super();
+  }
+  override reset(_seed: number): { observation: Float32Array; state: null } {
+    return { observation: new Float32Array([1.0]), state: null };
+  }
+  override step(
+    _state: null,
+    action: number,
+  ): StepResult<Float32Array> & { state: null } {
+    return {
+      observation: new Float32Array([0]),
+      reward: -Math.abs(action - this.target),
+      terminated: true,
+      truncated: false,
+      state: null,
+    };
+  }
+  override get observationLength(): number {
+    return 1;
+  }
+  override decodeAction(creatureOutput: Float32Array): number {
+    return creatureOutput[0];
+  }
+  override maxSteps(): number {
+    return 1;
+  }
+}
+
+/**
+ * Seed-sensitive adapter. Returns a reward determined entirely by the seed
+ * passed into `reset()` so duplicate runs reproduce and the per-trial
+ * breakdown is fully predictable from the seed set.
+ */
+class SeedRewardAdapter extends EpisodeAdapter<{ seed: number }, number> {
+  override reset(
+    seed: number,
+  ): { observation: Float32Array; state: { seed: number } } {
+    return { observation: new Float32Array([0.5]), state: { seed } };
+  }
+  override step(
+    state: { seed: number },
+    _action: number,
+  ): StepResult<Float32Array> & { state: { seed: number } } {
+    return {
+      observation: new Float32Array([0]),
+      // Reward depends only on the seed so each trial is distinct yet
+      // reproducible. The `+1` makes the reward strictly negative for every
+      // seed (range `[-1.000, -0.001]`), so `defaultRewardToError` always
+      // produces a strictly positive error and tests that loop until the
+      // iterations cap fires never accidentally hit `targetError = 0`.
+      reward: -(((state.seed >>> 0) % 1000) + 1) / 1001,
+      terminated: true,
+      truncated: false,
+      state,
+    };
+  }
+  override get observationLength(): number {
+    return 1;
+  }
+  override decodeAction(_creatureOutput: Float32Array): number {
+    return 0;
+  }
+  override maxSteps(): number {
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Seed-set helper unit tests
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL seed helper: deriveRLSeed is deterministic", () => {
+  assertEquals(deriveRLSeed(42, 1, 0), deriveRLSeed(42, 1, 0));
+  assert(deriveRLSeed(42, 1, 0) !== deriveRLSeed(42, 1, 1));
+  assert(deriveRLSeed(42, 1, 0) !== deriveRLSeed(42, 2, 0));
+  assert(deriveRLSeed(42, 1, 0) !== deriveRLSeed(43, 1, 0));
+});
+
+Deno.test("evolveRL seed helper: buildRLSeedSet length and rotation", () => {
+  const a = buildRLSeedSet(7, 1, 3);
+  const b = buildRLSeedSet(7, 2, 3);
+  assertEquals(a.length, 3);
+  assertEquals(b.length, 3);
+  // Every entry should differ between adjacent generations.
+  for (let i = 0; i < a.length; i++) assert(a[i] !== b[i]);
+  // Reproducible.
+  const aAgain = buildRLSeedSet(7, 1, 3);
+  assertEquals(a, aAgain);
+});
+
+Deno.test("evolveRL seed helper: fixedSeedSet collapses to generation 0", () => {
+  const a = buildRLSeedSet(11, 1, 3, true);
+  const b = buildRLSeedSet(11, 5, 3, true);
+  const c = buildRLSeedSet(11, 99, 3, true);
+  assertEquals(a, b);
+  assertEquals(a, c);
+});
+
+Deno.test("evolveRL seed helper: rejects invalid episodesPerCreature", () => {
+  let threw = false;
+  try {
+    buildRLSeedSet(1, 1, 0);
+  } catch (e) {
+    threw = true;
+    assert(e instanceof Error);
+  }
+  assert(threw, "Expected non-positive episodesPerCreature to throw");
+});
+
+// ---------------------------------------------------------------------------
+// 1. Happy path — convergence within 10 generations
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: happy path converges within 10 generations", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new TargetAdapter(0.0);
+  const result = await creature.evolveRL(adapter, {
+    iterations: 10,
+    populationSize: 12,
+    targetError: 0.1,
+    seed: 42,
+    threads: 1,
+    episodesPerCreature: 3,
+  });
+  assert(
+    result.error <= 0.1,
+    `expected error <= 0.1, got ${result.error} (gen=${result.generation})`,
+  );
+  assert(result.generation >= 1 && result.generation <= 10);
+});
+
+// ---------------------------------------------------------------------------
+// 2. targetError stop
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: targetError stop fires when reached", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new TargetAdapter(0.0);
+  const result = await creature.evolveRL(adapter, {
+    iterations: 50,
+    populationSize: 12,
+    targetError: 0.5, // generously loose so it fires fast
+    seed: 17,
+    threads: 1,
+    episodesPerCreature: 2,
+  });
+  assert(
+    result.error <= 0.5,
+    `expected error <= 0.5, got ${result.error}`,
+  );
+  // Must not have run all 50 iterations.
+  assert(result.generation < 50);
+});
+
+// ---------------------------------------------------------------------------
+// 3. timeoutMinutes is respected
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: timeoutMinutes option is accepted and run completes", async () => {
+  // The internal config clamps `timeoutMinutes * 60000` with `Math.max(1, …)`
+  // so the smallest realistic timeout is one minute. We verify the option is
+  // accepted and the run still honours the iterations cap as a secondary
+  // stop. Real timeout behaviour shares the identical stop-condition code
+  // path with `evolveDir()`/`evolveEnv()`.
+  const creature = new Creature(1, 1);
+  const adapter = new TargetAdapter(99); // unreachable target
+  const result = await creature.evolveRL(adapter, {
+    iterations: 2,
+    populationSize: 4,
+    targetError: 0,
+    timeoutMinutes: 1,
+    seed: 1,
+    threads: 1,
+    episodesPerCreature: 1,
+  });
+  assertEquals(result.generation, 2);
+});
+
+// ---------------------------------------------------------------------------
+// 4. iterations cap
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: iterations cap stops the run", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new TargetAdapter(99); // unreachable so only cap fires
+  const result = await creature.evolveRL(adapter, {
+    iterations: 3,
+    populationSize: 5,
+    targetError: 0,
+    seed: 1,
+    threads: 1,
+    episodesPerCreature: 1,
+  });
+  assertEquals(result.generation, 3);
+});
+
+// ---------------------------------------------------------------------------
+// 5. Episode averaging — mean of trial rewards matches mean(reward(seed))
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: episodesPerCreature=3 returns the mean of the seed set", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new SeedRewardAdapter();
+  const trials: EpisodeTrialsEvent[] = [];
+
+  await creature.evolveRL(adapter, {
+    iterations: 1,
+    populationSize: 4,
+    targetError: 0,
+    seed: 12345,
+    threads: 1,
+    episodesPerCreature: 3,
+    onEpisodeTrials: (e) => trials.push(e),
+  });
+
+  assert(trials.length > 0, "Expected onEpisodeTrials to fire");
+
+  // Generation 1 seeds are deterministic from baseSeed=12345.
+  const expectedSeeds = buildRLSeedSet(12345, 1, 3);
+  const expectedRewards = expectedSeeds.map((s) =>
+    -(((s >>> 0) % 1000) + 1) / 1001
+  );
+  const expectedMean = (expectedRewards[0] + expectedRewards[1] +
+    expectedRewards[2]) / 3;
+
+  for (const event of trials) {
+    assertEquals(event.trialRewards.length, 3);
+    // Adapter reward is purely a function of seed, so every creature gets
+    // the same trial-reward triple.
+    assertEquals(event.trialRewards[0], expectedRewards[0]);
+    assertEquals(event.trialRewards[1], expectedRewards[1]);
+    assertEquals(event.trialRewards[2], expectedRewards[2]);
+    assert(Math.abs(event.meanReward - expectedMean) < 1e-9);
+    assert(event.stdReward >= 0);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. Seed rotation across 5 generations
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: seed set rotates per generation and is reproducible", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new SeedRewardAdapter();
+  const seedsByGeneration = new Map<number, readonly number[]>();
+
+  await creature.evolveRL(adapter, {
+    iterations: 5,
+    populationSize: 4,
+    // SeedRewardAdapter returns strictly-negative reward for every seed, so
+    // error stays strictly above 0 and the iterations cap is the only stop.
+    targetError: 0,
+    seed: 999,
+    threads: 1,
+    episodesPerCreature: 3,
+    onEpisodeTrials: (e) => {
+      // Recover the seed set used for this creature from the deterministic
+      // reward function: reward(seed) = -(((seed >>> 0) % 1000) + 1)/1001.
+      // We compare against the helper directly using the generation we are
+      // told rather than inverting the reward function.
+      const expected = buildRLSeedSet(999, e.generation, 3);
+      const expectedRewards = expected.map((s) =>
+        -(((s >>> 0) % 1000) + 1) / 1001
+      );
+      // Every per-trial reward must match the helper-derived seed set.
+      for (let i = 0; i < 3; i++) {
+        assertEquals(e.trialRewards[i], expectedRewards[i]);
+      }
+      seedsByGeneration.set(e.generation, expected);
+    },
+  });
+
+  // 5 generations covered.
+  for (let g = 1; g <= 5; g++) {
+    assert(
+      seedsByGeneration.has(g),
+      `Expected onEpisodeTrials event for generation ${g}`,
+    );
+  }
+  // Every pair of distinct generations must have a different seed set.
+  const allSets = Array.from(seedsByGeneration.entries());
+  for (let i = 0; i < allSets.length; i++) {
+    for (let j = i + 1; j < allSets.length; j++) {
+      const [gi, si] = allSets[i];
+      const [gj, sj] = allSets[j];
+      const same = si.length === sj.length && si.every((v, k) => v === sj[k]);
+      assert(
+        !same,
+        `Seed set for generation ${gi} should differ from ${gj}`,
+      );
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. fixedSeedSet — every generation uses the same seed set
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: fixedSeedSet=true uses identical seeds every generation", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new SeedRewardAdapter();
+  const rewardsByGeneration = new Map<number, readonly number[]>();
+
+  await creature.evolveRL(adapter, {
+    iterations: 4,
+    populationSize: 4,
+    // SeedRewardAdapter reward is strictly negative — error stays > 0,
+    // so only the iterations cap can stop the run.
+    targetError: 0,
+    seed: 5,
+    threads: 1,
+    episodesPerCreature: 3,
+    fixedSeedSet: true,
+    onEpisodeTrials: (e) => {
+      // Record the first event we see per generation.
+      if (!rewardsByGeneration.has(e.generation)) {
+        rewardsByGeneration.set(
+          e.generation,
+          [...e.trialRewards],
+        );
+      }
+    },
+  });
+
+  // Every generation's reward triple must equal generation 1's triple
+  // because the seed set is locked at seedSet(0) for all generations and
+  // the adapter reward is a pure function of the seed.
+  const ref = rewardsByGeneration.get(1);
+  assert(ref, "Expected generation 1 trial event");
+  for (const [g, r] of rewardsByGeneration.entries()) {
+    assertEquals(
+      r,
+      ref,
+      `Generation ${g} trial rewards should equal generation 1 with fixedSeedSet`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 8. Determinism — same seed produces matching results
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: deterministic given the same seed", async () => {
+  // Determinism test uses an adapter whose reward is purely a function of the
+  // seed (`SeedRewardAdapter`). Since every creature in a generation plays the
+  // same seed set and the reward ignores creature output, `error` is the
+  // exact same value for every creature — independent of structural map
+  // iteration order from `crypto.randomUUID()`. That keeps the determinism
+  // assertion byte-exact.
+  const adapter = new SeedRewardAdapter();
+  const runOnce = async () => {
+    const creature = new Creature(1, 1);
+    return await creature.evolveRL(adapter, {
+      iterations: 4,
+      populationSize: 6,
+      targetError: 0, // strictly negative reward never hits 0
+      seed: 12345,
+      threads: 1,
+      episodesPerCreature: 3,
+    });
+  };
+
+  const a = await runOnce();
+  const b = await runOnce();
+
+  // Byte-identical on the integer field (iterations cap fires
+  // deterministically). `error` and `score` may carry a sub-ULP drift driven
+  // by floating-point ordering inside `Score.calculate`'s growth penalty —
+  // creature size varies by a neuron or two across runs because neuron
+  // UUIDs use `crypto.randomUUID()` and downstream Maps iterate in
+  // insertion order. The tight epsilon mirrors `EvolveEnv.ts`.
+  assertEquals(a.generation, b.generation);
+  assert(
+    Math.abs(a.error - b.error) <= 1e-6,
+    `error drift too large: ${a.error} vs ${b.error}`,
+  );
+  assert(
+    Math.abs(a.score - b.score) <= 1e-6,
+    `score drift too large: ${a.score} vs ${b.score}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 9. AbortSignal interrupts the run (parity with evolveEnv SIGTERM behaviour)
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: abort signal interrupts the run", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new TargetAdapter(99);
+  const controller = new AbortController();
+
+  // Schedule an abort after the first generation has had time to start.
+  // Using AbortSignal instead of Deno.kill(Deno.pid, "SIGTERM") because
+  // sending an actual OS signal from a worker thread propagates to the main
+  // Deno process and aborts the entire test runner.
+  const interrupt = setTimeout(() => controller.abort(), 50);
+
+  try {
+    const result = await creature.evolveRL(adapter, {
+      iterations: 1_000_000,
+      populationSize: 4,
+      targetError: 0,
+      seed: 9,
+      threads: 1,
+      episodesPerCreature: 1,
+      signal: controller.signal,
+    });
+    assert(result.generation >= 1);
+  } finally {
+    clearTimeout(interrupt);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// I/O sanity check — adapter mismatch must throw before any rollout
+// ---------------------------------------------------------------------------
+
+Deno.test("evolveRL: rejects creature whose input does not match adapter", async () => {
+  const creature = new Creature(2, 1);
+  const adapter = new TargetAdapter(0);
+  let threw = false;
+  try {
+    await creature.evolveRL(adapter, {
+      iterations: 1,
+      populationSize: 4,
+      threads: 1,
+      episodesPerCreature: 1,
+    });
+  } catch (err) {
+    threw = true;
+    assert(err instanceof Error);
+    assert(/observationLength/.test(err.message));
+  }
+  assert(threw, "Expected I/O mismatch error");
+});


### PR DESCRIPTION
## Summary

Adds `Creature.evolveRL()` — the public reinforcement-learning API on top of
the new class-shaped `EpisodeAdapter` (Issue #2626) and the library-owned
`runEpisode()` runner (Issue #2627). Per-creature fitness is the **mean return
across `episodesPerCreature` episodes** (default 3) played against a
**per-generation rotating seed set** so every creature in a generation is
compared on the same maps and over-fitting one map is avoided. Reuses the
existing `Neat` population manager, `createNeatConfig`, mutation, crossover,
elitism, plateau detection, telemetry, lifecycle events, and SIGTERM/abort
handling — only the scorer changes. Closes #2628.

## Design

```mermaid
flowchart TD
    A[Caller] --> B[creature.evolveRL]
    B --> C[createNeatConfig]
    B --> D[new Neat]
    D --> E[populatePopulation]
    B --> F{generation loop}
    F --> G[buildRLSeedSet g]
    G --> H[neat.evolve]
    H --> I[per-creature fitness]
    I --> J[runEpisode x N]
    J --> K[mean return]
    H --> L[mutate / crossover / elite]
    F --> M[generation_complete event]
    F --> N{stop?}
    N -->|targetError / timeoutMinutes / iterations / SIGTERM| O[restore best + return]
```

- `src/creature/EvolveRLSeedSet.ts` — `deriveRLSeed(baseSeed, generation, trial)`
  is a 32-bit MurmurHash3-style mixer; `buildRLSeedSet` produces the seed set
  for one generation. `fixedSeedSet` collapses the generation index to `0` so
  every generation uses the same seed set (tests / regression only).
- `src/creature/RLEpisodeFitness.ts` — `Fitness` subclass that runs episode
  rollouts inline via `runEpisode` (no worker pool yet — multi-threaded
  rollouts remain tracked under #2612). The seed set is replaced before every
  fitness phase so all creatures in a generation play the same seeds.
- `src/creature/CreatureTraining.ts` — adds `EvolveRLOptions` and `evolveRL()`,
  reusing the same outer shape as `evolveDir()`/`evolveEnv()`. `Creature.evolveRL()`
  is exposed on the `Creature` class.

## Evidence

- Targeted test run (14 tests, all pass):
  `deno test test/creature/evolveRL_test.ts`
  → `ok | 14 passed | 0 failed`
- Adjacent RL tests still pass:
  `EpisodeRunner_test.ts`, `EpisodeAdapter_test.ts`, `EvolveEnv.ts` →
  `ok | 39 passed | 0 failed`
- Invariant gates pass:
  `SemanticVersionStability.ts`, `NeuronUuidStability.ts` →
  `ok | 24 passed | 0 failed`
- `./quality.sh` lint, format, type-check, and bash gates all green; full
  suite reports `6631 passed | 2 failed` where the **2 failures are
  pre-existing FFI dynamic-library leaks in
  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`** — verified by
  re-running on baseline (`git stash` → same failures), so unrelated to this
  change.
- Backend / CLI change with no UI, so no Playwright screenshot.

## Test Plan

- `test/creature/evolveRL_test.ts` covers the nine scenarios called out in
  the issue:
  1. Happy path — converges within 10 generations.
  2. `targetError` stop fires when reached.
  3. `timeoutMinutes` accepted; iterations cap acts as the verifiable
     secondary stop (the same approach as `EvolveEnv.ts`).
  4. `iterations` cap is respected.
  5. Episode averaging — `episodesPerCreature = 3` with a seeded stochastic
     adapter returns the arithmetic mean of the seed set's per-trial rewards.
  6. Seed rotation — across 5 generations every seed set differs and is
     reproducible from the base seed.
  7. `fixedSeedSet = true` — every generation uses identical seeds.
  8. Determinism — two runs with the same seed agree on `generation` exactly
     and on `error`/`score` to within 1e-6 (matching `EvolveEnv.ts`'s
     epsilon — neuron UUIDs are `crypto.randomUUID()` and downstream Maps
     iterate in insertion order).
  9. AbortSignal interrupt parity (used in place of OS SIGTERM in tests for
     the same reason as `EvolveEnv.ts`: sending SIGTERM from a worker
     propagates to the parallel test runner).
- Plus seed-helper unit tests covering determinism, rotation, fixed-set
  collapse, and the invalid-`episodesPerCreature` guard.



## Milestone
This PR is part of the **Reinforcement learning** milestone and targets the `milestone/reinforcement-learning` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2628 -->