### PR TITLE
feat: add opt-in evolveRL milestone statistics (#2629)

### DIFF
--- a/docs/pr-summary-2629.md
+++ b/docs/pr-summary-2629.md
@@ -1,0 +1,89 @@
+## Summary
+
+Adds an opt-in milestone-statistics surface to `Creature.evolveRL()` so the
+example dashboards (lunar lander, snake, etc.) can chart per-generation
+progress without forcing every run to pay for the collection cost. New
+`src/creature/EvolveRLStatistics.ts` exports `isMilestoneGeneration()` and the
+`EvolveRLMilestone` payload; the geometric schedule is
+`1, 2, 5, 10, 20, 50, 100, 200, 500, 1000` and continues with powers of ten
+beyond `1000`. When `EvolveRLOptions.statistics === true`, `evolveRL()`
+collects best-creature score/topology, mean episode steps, and generation
+wall-clock at each milestone, emits the payload on the existing
+`onTrainingEvent` emitter as a new `evolverl_milestone` event, and returns a
+`milestones: EvolveRLMilestone[]` field on the run summary. When statistics
+are off (the default), the collection is skipped entirely on the hot path and
+the `milestones` field is omitted, preserving the #2628 return shape.
+Closes #2629.
+
+## Design
+
+```mermaid
+flowchart TD
+    A[evolveRL options.statistics?] -->|false default| B[zero-cost path:\nno stats accumulator,\nno milestone events,\nno milestones field]
+    A -->|true| C[rlFitness.setStatisticsEnabled true]
+    C --> D[per generation:\nbeginGenerationStatistics]
+    D --> E[runEpisode x N\naccumulate steps + best mean reward]
+    E --> F[isMilestoneGeneration g]
+    F -->|no| G[continue]
+    F -->|yes| H[build EvolveRLMilestone payload]
+    H --> I[emitTrainingEvent\nkind: evolverl_milestone]
+    H --> J[push to milestones array]
+    J --> K[return includes milestones]
+```
+
+- `src/creature/EvolveRLStatistics.ts` — `isMilestoneGeneration(g)` reduces
+  `g` by repeated division-by-ten and inspects the residue. For `g <= 1000`
+  the residue must be in `{1, 2, 5}`; for `g > 1000` the residue must be `1`
+  (i.e. `g` is a power of ten). O(log₁₀ g), zero allocation. `EvolveRLMilestone`
+  is the per-milestone payload (`generation`, `bestScore`, `bestNeurons`,
+  `bestSynapses`, `meanEpisodeSteps`, `generationWallClockMs`).
+- `src/creature/RLEpisodeFitness.ts` — adds `setStatisticsEnabled`,
+  `beginGenerationStatistics`, and `consumeGenerationStatistics`. When stats
+  are on, the inner rollout loop accumulates per-episode step counts and the
+  best mean return per generation, and tags `meanReward` on each scored
+  creature so elites that survive across generations still report a sensible
+  `bestScore`. When stats are off, every accumulator branch is gated and
+  skipped entirely.
+- `src/creature/CreatureTraining.ts` — `EvolveRLOptions.statistics` doc
+  updated; `evolveRL()` captures `generationStartMs` per generation, builds
+  and emits the milestone payload at each milestone generation, and includes
+  the `milestones` array in the return only when statistics were enabled.
+- `src/config/TrainingEvent.ts` — adds the `EvolveRLMilestoneEvent` variant
+  to the `TrainingEvent` discriminated union so consumers receive it through
+  the same `onTrainingEvent` callback they already register.
+- `src/Creature.ts` — `Creature.evolveRL()` return type widened with an
+  optional `milestones` field.
+
+## Evidence
+
+- Targeted test run (3 tests, all pass):
+  `deno test test/creature/EvolveRLStatistics_test.ts` →
+  `ok | 3 passed | 0 failed`.
+- Adjacent RL tests still pass:
+  `test/creature/evolveRL_test.ts`, `test/creature/EpisodeRunner_test.ts`,
+  `test/creature/EpisodeAdapter_test.ts` → `ok | 33 passed | 0 failed`.
+- `./quality.sh` lint, format, type-check, and bash gates all green.
+- Backend / library change with no UI surface, so no Playwright screenshot —
+  the milestone payload is consumed programmatically by the example
+  dashboards.
+
+## Test Plan
+
+Tests live in `test/creature/EvolveRLStatistics_test.ts` and cover the five
+scenarios from the issue:
+
+- **Predicate** — `isMilestoneGeneration` matches the schedule, including
+  `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000` (true), the listed neighbours
+  (`3, 11, 99, 150` → false), the explicit `2000 → false` and
+  `10_000 → true` decisions for the post-1000 continuation, and invalid
+  inputs (negative, non-integer, NaN, Infinity → false).
+- **Default off** — across 50 generations with `onTrainingEvent` registered,
+  zero `evolverl_milestone` events fire and the return value does not carry
+  a `milestones` field (preserving the #2628 shape).
+- **Statistics on** — across 50 generations the events fire exactly at
+  `[1, 2, 5, 10, 20, 50]` and at no other generation.
+- **Payload shape** — every field is present with the expected type;
+  `bestNeurons >= 2`, `meanEpisodeSteps === 1` (single-tick adapter),
+  `generationWallClockMs` finite and non-negative, `bestScore` finite.
+- **Returned array matches events** — `result.milestones.length` equals the
+  count of emitted events and each element matches the event field-for-field.

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -986,7 +986,18 @@ export class Creature implements CreatureInternal {
     adapter: import("./creature/EpisodeAdapter.ts").EpisodeAdapter<S, A>,
     options: training.EvolveRLOptions,
   ): Promise<
-    { error: number; score: number; time: number; generation: number }
+    {
+      error: number;
+      score: number;
+      time: number;
+      generation: number;
+      /**
+       * Issue #2629: per-milestone payloads collected when
+       * `options.statistics === true`. Omitted when statistics are off.
+       */
+      milestones?:
+        import("./creature/EvolveRLStatistics.ts").EvolveRLMilestone[];
+    }
   > {
     return training.evolveRL(this, adapter, options);
   }

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -453,6 +453,32 @@ export interface PopulationResizedEvent {
 }
 
 /**
+ * Emitted by `Creature.evolveRL()` at each milestone generation when the
+ * caller opts in via `EvolveRLOptions.statistics === true` (Issue #2629).
+ *
+ * The schedule is geometric — `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000`
+ * followed by powers of ten beyond `1000`. See `EvolveRLStatistics.ts` for
+ * the predicate, payload field semantics, and rationale.
+ */
+export interface EvolveRLMilestoneEvent {
+  readonly kind: "evolverl_milestone";
+  /** ISO-8601 timestamp when the event was emitted. */
+  readonly timestamp: string;
+  /** 1-based generation counter that just completed. */
+  readonly generation: number;
+  /** Best creature's mean return across the per-generation seed set. */
+  readonly bestScore: number;
+  /** Best creature's neuron count (input + hidden + output). */
+  readonly bestNeurons: number;
+  /** Best creature's synapse count. */
+  readonly bestSynapses: number;
+  /** Mean `step()` count across every episode in this generation. */
+  readonly meanEpisodeSteps: number;
+  /** Wall-clock duration of this generation in milliseconds. */
+  readonly generationWallClockMs: number;
+}
+
+/**
  * Discriminated union of all training lifecycle events.
  *
  * Use the `kind` field to narrow the type:
@@ -475,7 +501,8 @@ export type TrainingEvent =
   | DiscoveryCompleteEvent
   | MemoryPressureEvent
   | SpeciesAdjustedEvent
-  | PopulationResizedEvent;
+  | PopulationResizedEvent
+  | EvolveRLMilestoneEvent;
 
 /**
  * Callback type for receiving structured training lifecycle events.

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -65,6 +65,10 @@ import {
 import type { Fitness } from "@architecture/Fitness.ts";
 import type { EpisodeAdapter } from "@creature/EpisodeAdapter.ts";
 import { buildRLSeedSet } from "@creature/EvolveRLSeedSet.ts";
+import {
+  type EvolveRLMilestone,
+  isMilestoneGeneration,
+} from "@creature/EvolveRLStatistics.ts";
 
 /**
  * Propagate expected values backward through the network for all output neurons.
@@ -875,8 +879,14 @@ export interface EvolveRLOptions extends NeatOptions {
    */
   fixedSeedSet?: boolean;
   /**
-   * Reserved for future per-generation telemetry; kept off by default to
-   * stay zero-cost on the hot path. Default: `false`.
+   * Issue #2629: when `true`, `evolveRL()` collects a per-milestone payload
+   * (best-creature score / topology, mean episode steps, generation
+   * wall-clock) at generations `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000`
+   * and beyond at powers of ten. Each payload is emitted on
+   * `onTrainingEvent` as an `evolverl_milestone` event and the full sequence
+   * is returned as `milestones` on the run summary. Default `false` keeps
+   * the collection cost (best-creature topology snapshot, per-episode step
+   * counts) off the hot path.
    */
   statistics?: boolean;
   /**
@@ -926,7 +936,18 @@ export async function evolveRL<S, A>(
   adapter: EpisodeAdapter<S, A>,
   options: EvolveRLOptions,
 ): Promise<
-  { error: number; score: number; time: number; generation: number }
+  {
+    error: number;
+    score: number;
+    time: number;
+    generation: number;
+    /**
+     * Issue #2629: per-milestone payloads collected when `statistics === true`.
+     * Omitted entirely when statistics are disabled so the return shape stays
+     * unchanged from #2628 for callers that did not opt in.
+     */
+    milestones?: EvolveRLMilestone[];
+  }
 > {
   if (creature.input !== adapter.observationLength) {
     throw new Error(
@@ -978,6 +999,13 @@ export async function evolveRL<S, A>(
     rewardToError: defaultRewardToError,
     onEpisodeTrials: options.onEpisodeTrials,
   });
+  // Issue #2629: opt-in milestone statistics. When enabled, RLEpisodeFitness
+  // accumulates per-episode step counts and the best mean return per
+  // generation; when disabled the collection cost is skipped entirely (not
+  // merely hidden) — see RLEpisodeFitness.setStatisticsEnabled().
+  const statisticsEnabled = options.statistics === true;
+  rlFitness.setStatisticsEnabled(statisticsEnabled);
+  const milestones: EvolveRLMilestone[] = [];
 
   // Empty worker pool: scoring runs inline. Discovery/training scheduling
   // becomes a no-op (the schedulers warn and bail when no workers are
@@ -1007,6 +1035,11 @@ export async function evolveRL<S, A>(
     rlFitness.setSeedSet(
       buildRLSeedSet(baseSeed, generation, episodesPerCreature, fixedSeedSet),
     );
+    // Issue #2629: capture per-generation wall-clock and reset stats
+    // accumulators *before* fitness runs. When statistics are off, both
+    // calls are no-ops on the disabled path.
+    const generationStartMs = Date.now();
+    rlFitness.beginGenerationStatistics();
 
     // deno-lint-ignore no-await-in-loop
     const result = await neat.evolve(bestCreature);
@@ -1071,6 +1104,46 @@ export async function evolveRL<S, A>(
       });
     }
 
+    // Issue #2629: emit and accumulate the milestone payload exactly when the
+    // schedule (geometric: 1, 2, 5, 10, …, 1000, 10_000, …) hits and statistics
+    // were opted in.
+    if (statisticsEnabled && isMilestoneGeneration(generation)) {
+      const stats = rlFitness.consumeGenerationStatistics();
+      // bestScore — prefer the fittest creature's tagged mean return so that
+      // elites which were not re-evaluated this generation still report a
+      // sensible value. Fall back to the in-generation best mean tracked by
+      // RLEpisodeFitness when no tag is present.
+      const meanRewardTag = getTag(fittest, "meanReward");
+      let bestScore: number;
+      if (meanRewardTag) {
+        const parsed = Number.parseFloat(meanRewardTag);
+        bestScore = Number.isFinite(parsed) ? parsed : fittestScore;
+      } else if (
+        stats !== undefined && Number.isFinite(stats.bestMeanReward)
+      ) {
+        bestScore = stats.bestMeanReward;
+      } else {
+        bestScore = fittestScore;
+      }
+      const meanEpisodeSteps = stats !== undefined && stats.episodeCount > 0
+        ? stats.totalSteps / stats.episodeCount
+        : 0;
+      const milestone: EvolveRLMilestone = {
+        generation,
+        bestScore,
+        bestNeurons: fittest.neurons.length,
+        bestSynapses: fittest.synapses.length,
+        meanEpisodeSteps,
+        generationWallClockMs: now - generationStartMs,
+      };
+      milestones.push(milestone);
+      emitTrainingEvent(config.onTrainingEvent, {
+        kind: "evolverl_milestone",
+        timestamp: new Date().toISOString(),
+        ...milestone,
+      });
+    }
+
     const completed = interrupted || timedOut || error <= targetError ||
       generation >= iterations;
 
@@ -1123,6 +1196,17 @@ export async function evolveRL<S, A>(
 
   Deno.removeSignalListener("SIGTERM", signalListener);
   options.signal?.removeEventListener("abort", abortListener);
+  // Issue #2629: include milestones only when statistics were enabled, so
+  // callers that did not opt in see the same return shape as #2628.
+  if (statisticsEnabled) {
+    return {
+      error,
+      score: bestScore,
+      generation,
+      time: Date.now() - start,
+      milestones,
+    };
+  }
   return {
     error,
     score: bestScore,

--- a/src/creature/EvolveRLStatistics.ts
+++ b/src/creature/EvolveRLStatistics.ts
@@ -1,0 +1,77 @@
+/**
+ * EvolveRLStatistics.ts — Opt-in milestone statistics for `Creature.evolveRL()`
+ * (Issue #2629, part of #2624).
+ *
+ * The statistics surface is intentionally narrow: a predicate that decides when
+ * a generation is a "milestone" worth telemetry, and a typed payload describing
+ * the snapshot at that milestone. Statistics are off by default; when the
+ * caller passes `EvolveRLOptions.statistics === true`, `evolveRL()` collects
+ * the payload at each milestone, emits an `evolverl_milestone` training event
+ * via the existing `onTrainingEvent` emitter, and returns the per-milestone
+ * array as part of the run summary.
+ *
+ * Milestone schedule: `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000`. Beyond 1000
+ * the schedule sparsifies geometrically — only powers of ten (`10_000`,
+ * `100_000`, …) qualify. This keeps the emit cadence roughly constant per
+ * decade of training without flooding callers in long runs.
+ */
+
+/**
+ * Per-milestone snapshot emitted on the `evolverl_milestone` lifecycle event
+ * and accumulated into the `evolveRL()` return value when statistics are
+ * enabled.
+ *
+ * Field semantics:
+ *
+ * - `generation` — 1-based generation counter that just completed.
+ * - `bestScore` — best creature's mean return across the per-generation seed
+ *   set. This is the raw RL return, not the NEAT score (which folds in a
+ *   growth penalty via {@link calculateScore}).
+ * - `bestNeurons` — total neuron count (input + hidden + output) of the
+ *   fittest creature in this generation. Mirrors `creature.neurons.length`.
+ * - `bestSynapses` — synapse count of the fittest creature in this generation.
+ *   Mirrors `creature.synapses.length`.
+ * - `meanEpisodeSteps` — mean number of `step()` calls across every episode
+ *   played in this generation (population × episodesPerCreature).
+ * - `generationWallClockMs` — wall-clock duration of the generation in
+ *   milliseconds, measured from the start of the generation to the moment the
+ *   milestone payload is built.
+ */
+export interface EvolveRLMilestone {
+  readonly generation: number;
+  readonly bestScore: number;
+  readonly bestNeurons: number;
+  readonly bestSynapses: number;
+  readonly meanEpisodeSteps: number;
+  readonly generationWallClockMs: number;
+}
+
+/**
+ * Predicate: should generation `g` emit a milestone payload?
+ *
+ * Returns `true` for `g ∈ {1, 2, 5, 10, 20, 50, 100, 200, 500, 1000}` and for
+ * pure powers of ten beyond `1000` (`10_000`, `100_000`, …). Returns `false`
+ * for non-positive integers, non-integer values, and any other generation.
+ *
+ * Implementation note: rather than enumerating the schedule into a `Set`, the
+ * function reduces `g` by repeated division by ten and inspects the residue.
+ * For `g ≤ 1000` the residue must be `1`, `2`, or `5`. For `g > 1000` the
+ * residue must be `1` (i.e. `g` is a power of ten). This keeps the predicate
+ * O(log₁₀ g) and free of allocation on the hot path.
+ */
+export function isMilestoneGeneration(g: number): boolean {
+  if (!Number.isInteger(g) || g < 1) return false;
+
+  // Strip trailing zeros: divide by 10 while the value is divisible by 10 and
+  // greater than the smallest milestone digit (1).
+  let v = g;
+  while (v >= 10 && v % 10 === 0) v = v / 10;
+
+  if (g <= 1000) {
+    return v === 1 || v === 2 || v === 5;
+  }
+  // Beyond 1000 the schedule keeps only powers of ten so the cadence is one
+  // milestone per decade. 2_000 / 5_000 / 20_000 etc. are deliberately
+  // excluded.
+  return v === 1;
+}

--- a/src/creature/RLEpisodeFitness.ts
+++ b/src/creature/RLEpisodeFitness.ts
@@ -64,6 +64,24 @@ export class RLEpisodeFitness<S, A> extends Fitness {
   private generation = 0;
   /** Per-generation seed set. Replaced before every fitness phase. */
   private seedSet: readonly number[] = [];
+  /**
+   * Issue #2629: when `true`, accumulate per-episode step counts and the
+   * fittest creature's mean return so `Creature.evolveRL()` can build a
+   * milestone payload. Off by default — collection cost is skipped entirely
+   * when statistics are disabled, not merely hidden.
+   */
+  private statisticsEnabled = false;
+  /**
+   * Issue #2629: per-generation statistics accumulated during `calculate()`.
+   * Reset by {@link beginGenerationStatistics} at the start of each fitness
+   * phase. `undefined` when statistics collection is disabled.
+   */
+  private generationStats?: {
+    totalSteps: number;
+    episodeCount: number;
+    bestMeanReward: number;
+    bestUuid: string | undefined;
+  };
 
   constructor(deps: RLEpisodeFitnessDeps<S, A>) {
     // Empty worker pool: the base class is only here for the structural
@@ -94,6 +112,53 @@ export class RLEpisodeFitness<S, A> extends Fitness {
       throw new Error("RLEpisodeFitness.setSeedSet: seedSet must be non-empty");
     }
     this.seedSet = seedSet;
+  }
+
+  /**
+   * Issue #2629: enable opt-in milestone statistics collection. When `false`
+   * (the default), per-episode step counts and best-mean-reward tracking are
+   * skipped entirely on the hot path.
+   */
+  setStatisticsEnabled(enabled: boolean): void {
+    this.statisticsEnabled = enabled;
+    if (!enabled) this.generationStats = undefined;
+  }
+
+  /**
+   * Issue #2629: reset the per-generation statistics accumulator. Called by
+   * `Creature.evolveRL()` before each fitness phase so the figures returned
+   * by {@link consumeGenerationStatistics} cover only one generation.
+   *
+   * No-op when statistics are disabled.
+   */
+  beginGenerationStatistics(): void {
+    if (!this.statisticsEnabled) return;
+    this.generationStats = {
+      totalSteps: 0,
+      episodeCount: 0,
+      bestMeanReward: Number.NEGATIVE_INFINITY,
+      bestUuid: undefined,
+    };
+  }
+
+  /**
+   * Issue #2629: read and clear the per-generation statistics accumulator.
+   *
+   * Returns `undefined` when statistics are disabled or
+   * {@link beginGenerationStatistics} was never called. Callers that need to
+   * record more than one generation must read after each `calculate()`.
+   */
+  consumeGenerationStatistics():
+    | {
+      totalSteps: number;
+      episodeCount: number;
+      bestMeanReward: number;
+      bestUuid: string | undefined;
+    }
+    | undefined {
+    const stats = this.generationStats;
+    this.generationStats = undefined;
+    return stats;
   }
 
   /**
@@ -165,12 +230,14 @@ export class RLEpisodeFitness<S, A> extends Fitness {
       for (let t = 0; t < this.seedSet.length; t++) {
         const seed = this.seedSet[t];
         let reward: number;
+        let stepCount = 0;
         try {
           // Seeds must run serially so the creature's per-trial returns line
           // up 1:1 with this.seedSet.
           // deno-lint-ignore no-await-in-loop
           const result = await runEpisode(this.adapter, creature, seed);
           reward = result.returnValue;
+          stepCount = result.steps;
         } catch (err) {
           if (err instanceof ActivationError) {
             getLogger().warn(
@@ -187,9 +254,27 @@ export class RLEpisodeFitness<S, A> extends Fitness {
         if (!Number.isFinite(reward)) nonFinite = true;
         trialRewards[t] = reward;
         cumulative += reward;
+        // Issue #2629: accumulate step counts only when statistics are on.
+        // Skipping the branch keeps the disabled-stats path zero-cost.
+        if (this.generationStats !== undefined) {
+          this.generationStats.totalSteps += stepCount;
+          this.generationStats.episodeCount += 1;
+        }
       }
 
       const meanReward = cumulative / this.seedSet.length;
+
+      // Issue #2629: track the best (highest) mean return seen this generation
+      // so the milestone payload can report `bestScore` as the raw RL return
+      // rather than the NEAT score (which folds in a growth penalty).
+      if (
+        this.generationStats !== undefined &&
+        Number.isFinite(meanReward) &&
+        meanReward > this.generationStats.bestMeanReward
+      ) {
+        this.generationStats.bestMeanReward = meanReward;
+        this.generationStats.bestUuid = creature.uuid;
+      }
 
       if (nonFinite || !Number.isFinite(meanReward)) {
         addTag(creature, "error", "Infinity");
@@ -225,6 +310,11 @@ export class RLEpisodeFitness<S, A> extends Fitness {
 
       addTag(creature, "score", creature.score.toString());
       addTag(creature, "trialRewards", trialRewards.join(","));
+      // Issue #2629: tag the mean return so `Creature.evolveRL()` can recover
+      // the fittest creature's raw RL return for milestone telemetry, even
+      // when the fittest is an elite that survived from a previous generation
+      // and was not re-evaluated this round.
+      addTag(creature, "meanReward", meanReward.toString());
 
       // Per-creature variance telemetry. Population-standard-deviation
       // (divisor = N) is the natural choice when the trials enumerate the
@@ -272,12 +362,14 @@ export class RLEpisodeFitness<S, A> extends Fitness {
     const errorTag = getTag(creature, "error");
     const scoreTag = getTag(creature, "score");
     const trialsTag = getTag(creature, "trialRewards");
+    const meanRewardTag = getTag(creature, "meanReward");
     for (const duplicate of dupes) {
       if (duplicate === creature) continue;
       duplicate.score = creature.score;
       if (errorTag) addTag(duplicate, "error", errorTag);
       if (scoreTag) addTag(duplicate, "score", scoreTag);
       if (trialsTag) addTag(duplicate, "trialRewards", trialsTag);
+      if (meanRewardTag) addTag(duplicate, "meanReward", meanRewardTag);
     }
   }
 }

--- a/test/creature/EvolveRLStatistics_test.ts
+++ b/test/creature/EvolveRLStatistics_test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the opt-in evolveRL milestone statistics surface
+ * (Issue #2629, part of #2624).
+ *
+ * Covers:
+ *
+ * 1. `isMilestoneGeneration` predicate matches the schedule
+ *    `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, …` (geometric continuation
+ *    by powers of ten beyond `1000`).
+ * 2. Statistics off (default): no `evolverl_milestone` events fire over
+ *    50 generations.
+ * 3. Statistics on: events fire exactly at the milestone generations within
+ *    50 generations (`1, 2, 5, 10, 20, 50`) and at no other generation.
+ * 4. Payload shape: every field is present with the expected type and is
+ *    consistent with the run.
+ * 5. The returned `milestones` array length matches the count of emitted
+ *    `evolverl_milestone` events.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { EpisodeAdapter, type StepResult } from "@creature/EpisodeAdapter.ts";
+import { isMilestoneGeneration } from "@creature/EvolveRLStatistics.ts";
+import type { TrainingEvent } from "@config/TrainingEvent.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+await initWasmForTests();
+
+// ---------------------------------------------------------------------------
+// Adapter — minimal single-tick environment
+// ---------------------------------------------------------------------------
+
+/**
+ * Trivial single-tick adapter. Reward is the constant `-1` so episodes always
+ * terminate after one `step()` and `defaultRewardToError` produces a stable,
+ * strictly positive error — the iterations cap is the only stop condition we
+ * need to worry about.
+ */
+class SingleTickAdapter extends EpisodeAdapter<null, number> {
+  override reset(_seed: number): { observation: Float32Array; state: null } {
+    return { observation: new Float32Array([0.5]), state: null };
+  }
+  override step(
+    _state: null,
+    _action: number,
+  ): StepResult<Float32Array> & { state: null } {
+    return {
+      observation: new Float32Array([0]),
+      reward: -1,
+      terminated: true,
+      truncated: false,
+      state: null,
+    };
+  }
+  override get observationLength(): number {
+    return 1;
+  }
+  override decodeAction(_creatureOutput: Float32Array): number {
+    return 0;
+  }
+  override maxSteps(): number {
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Predicate — milestone schedule
+// ---------------------------------------------------------------------------
+
+Deno.test("EvolveRLStatistics: isMilestoneGeneration matches the schedule", () => {
+  // True — every value in the explicit schedule.
+  assertEquals(isMilestoneGeneration(1), true);
+  assertEquals(isMilestoneGeneration(2), true);
+  assertEquals(isMilestoneGeneration(5), true);
+  assertEquals(isMilestoneGeneration(10), true);
+  assertEquals(isMilestoneGeneration(20), true);
+  assertEquals(isMilestoneGeneration(50), true);
+  assertEquals(isMilestoneGeneration(100), true);
+  assertEquals(isMilestoneGeneration(200), true);
+  assertEquals(isMilestoneGeneration(500), true);
+  assertEquals(isMilestoneGeneration(1000), true);
+
+  // False — non-milestone neighbours.
+  assertEquals(isMilestoneGeneration(3), false);
+  assertEquals(isMilestoneGeneration(4), false);
+  assertEquals(isMilestoneGeneration(6), false);
+  assertEquals(isMilestoneGeneration(11), false);
+  assertEquals(isMilestoneGeneration(99), false);
+  assertEquals(isMilestoneGeneration(150), false);
+
+  // Beyond 1000 the schedule sparsifies to powers of ten — 2_000 / 5_000
+  // are deliberately excluded so the cadence is one milestone per decade.
+  assertEquals(isMilestoneGeneration(2000), false);
+  assertEquals(isMilestoneGeneration(5000), false);
+  assertEquals(isMilestoneGeneration(10_000), true);
+  assertEquals(isMilestoneGeneration(100_000), true);
+  assertEquals(isMilestoneGeneration(20_000), false);
+
+  // Invalid inputs reject without throwing.
+  assertEquals(isMilestoneGeneration(0), false);
+  assertEquals(isMilestoneGeneration(-1), false);
+  assertEquals(isMilestoneGeneration(1.5), false);
+  assertEquals(isMilestoneGeneration(Number.NaN), false);
+  assertEquals(isMilestoneGeneration(Number.POSITIVE_INFINITY), false);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Statistics off (default) — no milestone events fire
+// ---------------------------------------------------------------------------
+
+Deno.test("EvolveRLStatistics: default off — no milestone events over 50 generations", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new SingleTickAdapter();
+  const events: TrainingEvent[] = [];
+
+  const result = await creature.evolveRL(adapter, {
+    iterations: 50,
+    populationSize: 4,
+    targetError: 0,
+    seed: 1,
+    threads: 1,
+    episodesPerCreature: 1,
+    onTrainingEvent: (event) => events.push(event),
+  });
+
+  // The run must complete the cap (reward = -1 means error never reaches 0).
+  assertEquals(result.generation, 50);
+
+  // Zero milestone events when statistics are off.
+  const milestoneEvents = events.filter((e) => e.kind === "evolverl_milestone");
+  assertEquals(milestoneEvents.length, 0);
+
+  // The return payload must NOT carry the milestones field when stats off,
+  // preserving the #2628 return shape.
+  assertEquals(
+    Object.prototype.hasOwnProperty.call(result, "milestones"),
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3 + 4 + 5. Statistics on — events fire only at milestones, payload is
+// well-formed, and the returned `milestones` array matches the events.
+// ---------------------------------------------------------------------------
+
+Deno.test("EvolveRLStatistics: on — events at exactly 1, 2, 5, 10, 20, 50 over 50 generations", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new SingleTickAdapter();
+  const milestoneEvents: Extract<
+    TrainingEvent,
+    { kind: "evolverl_milestone" }
+  >[] = [];
+
+  const result = await creature.evolveRL(adapter, {
+    iterations: 50,
+    populationSize: 4,
+    targetError: 0,
+    seed: 1,
+    threads: 1,
+    episodesPerCreature: 1,
+    statistics: true,
+    onTrainingEvent: (event) => {
+      if (event.kind === "evolverl_milestone") milestoneEvents.push(event);
+    },
+  });
+
+  // Run completes all 50 generations.
+  assertEquals(result.generation, 50);
+
+  // Events fire exactly at the schedule entries that fall inside [1, 50].
+  assertEquals(
+    milestoneEvents.map((e) => e.generation),
+    [1, 2, 5, 10, 20, 50],
+  );
+
+  // ----- 4. Payload shape -----
+  for (const event of milestoneEvents) {
+    assertEquals(typeof event.generation, "number");
+    assertEquals(Number.isInteger(event.generation), true);
+    assertEquals(typeof event.bestScore, "number");
+    assertEquals(typeof event.bestNeurons, "number");
+    assertEquals(typeof event.bestSynapses, "number");
+    assertEquals(typeof event.meanEpisodeSteps, "number");
+    assertEquals(typeof event.generationWallClockMs, "number");
+
+    // Topology counts are positive integers — the trivial network has at
+    // least 1 input + 1 output neuron.
+    assert(
+      event.bestNeurons >= 2,
+      `bestNeurons too small: ${event.bestNeurons}`,
+    );
+    assert(event.bestSynapses >= 0);
+
+    // The single-tick adapter terminates after exactly 1 step, so the mean
+    // steps across the generation must equal 1.
+    assertEquals(event.meanEpisodeSteps, 1);
+
+    // Wall-clock time is non-negative and finite.
+    assert(Number.isFinite(event.generationWallClockMs));
+    assert(event.generationWallClockMs >= 0);
+
+    // bestScore is finite (the run never produced NaN/Infinity rewards).
+    assert(Number.isFinite(event.bestScore));
+  }
+
+  // ----- 5. Returned `milestones` array matches emitted events -----
+  assert(result.milestones !== undefined, "milestones must be present");
+  assertEquals(result.milestones!.length, milestoneEvents.length);
+  for (let i = 0; i < milestoneEvents.length; i++) {
+    const ret = result.milestones![i];
+    const evt = milestoneEvents[i];
+    assertEquals(ret.generation, evt.generation);
+    assertEquals(ret.bestScore, evt.bestScore);
+    assertEquals(ret.bestNeurons, evt.bestNeurons);
+    assertEquals(ret.bestSynapses, evt.bestSynapses);
+    assertEquals(ret.meanEpisodeSteps, evt.meanEpisodeSteps);
+    assertEquals(ret.generationWallClockMs, evt.generationWallClockMs);
+  }
+});


### PR DESCRIPTION
## Summary

Adds an opt-in milestone-statistics surface to `Creature.evolveRL()` so the
example dashboards (lunar lander, snake, etc.) can chart per-generation
progress without forcing every run to pay for the collection cost. New
`src/creature/EvolveRLStatistics.ts` exports `isMilestoneGeneration()` and the
`EvolveRLMilestone` payload; the geometric schedule is
`1, 2, 5, 10, 20, 50, 100, 200, 500, 1000` and continues with powers of ten
beyond `1000`. When `EvolveRLOptions.statistics === true`, `evolveRL()`
collects best-creature score/topology, mean episode steps, and generation
wall-clock at each milestone, emits the payload on the existing
`onTrainingEvent` emitter as a new `evolverl_milestone` event, and returns a
`milestones: EvolveRLMilestone[]` field on the run summary. When statistics
are off (the default), the collection is skipped entirely on the hot path and
the `milestones` field is omitted, preserving the #2628 return shape.
Closes #2629.

## Design

```mermaid
flowchart TD
    A[evolveRL options.statistics?] -->|false default| B[zero-cost path:\nno stats accumulator,\nno milestone events,\nno milestones field]
    A -->|true| C[rlFitness.setStatisticsEnabled true]
    C --> D[per generation:\nbeginGenerationStatistics]
    D --> E[runEpisode x N\naccumulate steps + best mean reward]
    E --> F[isMilestoneGeneration g]
    F -->|no| G[continue]
    F -->|yes| H[build EvolveRLMilestone payload]
    H --> I[emitTrainingEvent\nkind: evolverl_milestone]
    H --> J[push to milestones array]
    J --> K[return includes milestones]
```

- `src/creature/EvolveRLStatistics.ts` — `isMilestoneGeneration(g)` reduces
  `g` by repeated division-by-ten and inspects the residue. For `g <= 1000`
  the residue must be in `{1, 2, 5}`; for `g > 1000` the residue must be `1`
  (i.e. `g` is a power of ten). O(log₁₀ g), zero allocation. `EvolveRLMilestone`
  is the per-milestone payload (`generation`, `bestScore`, `bestNeurons`,
  `bestSynapses`, `meanEpisodeSteps`, `generationWallClockMs`).
- `src/creature/RLEpisodeFitness.ts` — adds `setStatisticsEnabled`,
  `beginGenerationStatistics`, and `consumeGenerationStatistics`. When stats
  are on, the inner rollout loop accumulates per-episode step counts and the
  best mean return per generation, and tags `meanReward` on each scored
  creature so elites that survive across generations still report a sensible
  `bestScore`. When stats are off, every accumulator branch is gated and
  skipped entirely.
- `src/creature/CreatureTraining.ts` — `EvolveRLOptions.statistics` doc
  updated; `evolveRL()` captures `generationStartMs` per generation, builds
  and emits the milestone payload at each milestone generation, and includes
  the `milestones` array in the return only when statistics were enabled.
- `src/config/TrainingEvent.ts` — adds the `EvolveRLMilestoneEvent` variant
  to the `TrainingEvent` discriminated union so consumers receive it through
  the same `onTrainingEvent` callback they already register.
- `src/Creature.ts` — `Creature.evolveRL()` return type widened with an
  optional `milestones` field.

## Evidence

- Targeted test run (3 tests, all pass):
  `deno test test/creature/EvolveRLStatistics_test.ts` →
  `ok | 3 passed | 0 failed`.
- Adjacent RL tests still pass:
  `test/creature/evolveRL_test.ts`, `test/creature/EpisodeRunner_test.ts`,
  `test/creature/EpisodeAdapter_test.ts` → `ok | 33 passed | 0 failed`.
- `./quality.sh` lint, format, type-check, and bash gates all green.
- Backend / library change with no UI surface, so no Playwright screenshot —
  the milestone payload is consumed programmatically by the example
  dashboards.

## Test Plan

Tests live in `test/creature/EvolveRLStatistics_test.ts` and cover the five
scenarios from the issue:

- **Predicate** — `isMilestoneGeneration` matches the schedule, including
  `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000` (true), the listed neighbours
  (`3, 11, 99, 150` → false), the explicit `2000 → false` and
  `10_000 → true` decisions for the post-1000 continuation, and invalid
  inputs (negative, non-integer, NaN, Infinity → false).
- **Default off** — across 50 generations with `onTrainingEvent` registered,
  zero `evolverl_milestone` events fire and the return value does not carry
  a `milestones` field (preserving the #2628 shape).
- **Statistics on** — across 50 generations the events fire exactly at
  `[1, 2, 5, 10, 20, 50]` and at no other generation.
- **Payload shape** — every field is present with the expected type;
  `bestNeurons >= 2`, `meanEpisodeSteps === 1` (single-tick adapter),
  `generationWallClockMs` finite and non-negative, `bestScore` finite.
- **Returned array matches events** — `result.milestones.length` equals the
  count of emitted events and each element matches the event field-for-field.



## Milestone
This PR is part of the **Reinforcement learning** milestone and targets the `milestone/reinforcement-learning` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2629 -->