### PR TITLE
Bump library to 5.0.0 and finalise evolveRL API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,42 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.0]
+
 ### Added
+
+- **Issue #2630 (closes milestone #2624):** First-class reinforcement-learning
+  evolution surface. Wires `Creature.evolveRL(adapter, options)` and the
+  class-shaped `EpisodeAdapter` contract through the public entry point and the
+  reference documentation.
+  - **`Creature.evolveRL(adapter, options)`** — library-supplied way to evolve a
+    population against an `EpisodeAdapter`. Reuses the population manager,
+    plateau detector, lifecycle events, and stop conditions from `evolveDir()`;
+    the only difference is the scorer.
+  - **`EpisodeAdapter` base class** — abstract `reset`, `step`,
+    `observationLength`, and `decodeAction`; overridable termination guards
+    (`maxSteps`, `wallClockMs`). Contract is validated lazily on first use via
+    `assertContract()`.
+  - **Default termination guards** — 60 s wall-clock and 5000 steps per episode.
+    Whichever guard fires first truncates the episode (Gym/Gymnasium
+    `terminated` vs `truncated` semantics).
+  - **3 episodes per creature** averaged for fitness, with per-generation seed
+    rotation so within-generation comparisons stay fair and the population
+    cannot over-fit a single seed.
+  - **Opt-in evolution statistics** — when `EvolveRLOptions.statistics === true`
+    the run collects a per-milestone payload (best score, neuron/synapse counts,
+    mean episode steps, wall-clock) at generations
+    `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000` and beyond at powers of ten.
+    Payloads ship on the existing `onTrainingEvent` channel as
+    `EvolveRLMilestoneEvent` and are returned as `milestones` on the run
+    summary.
+  - **Public re-exports from `mod.ts`** — `EpisodeAdapter`, `StepResult`,
+    `EpisodeResult`, `EvolveRLOptions`, and `EvolveRLMilestone` are now
+    importable from the package root so downstream consumers (notably
+    NEAT-AI-Examples) do not have to reach into `src/`.
+  - **Docs** — `docs/REINFORCEMENT_LEARNING.md` gains a "Driving evolution with
+    `evolveRL`" worked example, and `docs/API_REFERENCE.md` lists `evolveRL`
+    alongside `evolveDir` / `evolveDataSet`.
 
 - **Issue #2529:** Optional Muon-inspired orthogonalised gradient update step in
   the local backprop pass. New module `src/propagate/MuonOrthogonalisation.ts`
@@ -94,6 +129,11 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Issue #2630:** Library version bumped to `5.0.0`. The change is additive —
+  no existing 4.x APIs were removed or modified — but the new `evolveRL` surface
+  and the `EpisodeAdapter` contract are large enough that consumers should
+  consciously adopt them. The UUID-stability and semantic-version-stability
+  invariants from `AGENTS.md` are unaffected.
 - **Issue #2513:** Discovery throughput-stall guard in
   `DataRecorderAnalysis.runAnalysisLoop` is deferred until a warm-up window of
   two completed chunks has elapsed, and only trips when the average per-chunk

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "4.1.4",
+  "version": "5.0.0",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -572,6 +572,81 @@ of samples:
 ]
 ```
 
+### 🎮 Creature.evolveRL()
+
+`evolveRL` is the reinforcement-learning sibling of `evolveDir`: instead of
+reading a static dataset directory, it asks the caller for an
+[`EpisodeAdapter`](#episodeadapter) wrapping a streaming-observation simulator,
+then runs `episodesPerCreature` episode rollouts per creature per generation
+against that adapter. Population management, mutation, plateau detection,
+lifecycle events, and stop conditions match `evolveDir()`.
+
+```typescript
+async evolveRL<S, A>(
+  adapter: EpisodeAdapter<S, A>,
+  options: EvolveRLOptions,
+): Promise<{
+  error: number;
+  score: number;
+  time: number;
+  generation: number;
+  milestones?: EvolveRLMilestone[];
+}>
+```
+
+| Parameter | Type                   | Description                                               |
+| --------- | ---------------------- | --------------------------------------------------------- |
+| `adapter` | `EpisodeAdapter<S, A>` | Simulator wrapper (see [EpisodeAdapter](#episodeadapter)) |
+| `options` | `EvolveRLOptions`      | Evolution configuration (extends `NeatOptions`)           |
+
+`EvolveRLOptions` extends `NeatOptions` with:
+
+| Field                 | Type                 | Default    | Description                                                                                                              |
+| --------------------- | -------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `episodesPerCreature` | `number`             | `3`        | Episodes per creature per generation; per-creature fitness is the mean return across these episodes                      |
+| `seed`                | `number`             | time-based | Base seed mixed into the per-generation seed set; pin for reproducibility                                                |
+| `fixedSeedSet`        | `boolean`            | `false`    | Lock `seedSet(0)` for every generation (tests / regression only)                                                         |
+| `statistics`          | `boolean`            | `false`    | Opt-in geometric milestone payloads at generations `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000`, then powers of ten beyond |
+| `onEpisodeTrials`     | `(event) => void`    | —          | Per-creature per-generation reward breakdown for variance charts                                                         |
+| `signal`              | `AbortSignal`        | —          | External interrupt signal                                                                                                |
+| `adapterDescription`  | `AdapterDescription` | —          | Importable adapter URL + JSON config used by the parallel worker pool when `threads > 1`                                 |
+
+#### EpisodeAdapter
+
+```typescript
+abstract class EpisodeAdapter<S = unknown, A = unknown> {
+  abstract reset(rngSeed: number): { observation: Float32Array; state: S };
+  abstract step(state: S, action: A): StepResult<Float32Array> & { state: S };
+  abstract get observationLength(): number;
+  abstract decodeAction(creatureOutput: Float32Array, state: S): A;
+
+  // Overridable termination guards (library defaults shown):
+  maxSteps(): number; // DEFAULT_MAX_STEPS = 5000
+  wallClockMs(): number; // DEFAULT_WALL_CLOCK_MS = 60_000
+
+  // Library plumbing — invoked once by the runner on first use:
+  assertContract(rngSeed?: number): void;
+}
+
+interface StepResult<O> {
+  readonly observation: O;
+  readonly reward: number;
+  readonly terminated: boolean; // natural episode end (death / goal)
+  readonly truncated: boolean; // a guard fired (step or wall-clock cap)
+  readonly info?: Readonly<Record<string, unknown>>;
+}
+```
+
+The class-shaped contract mirrors Gym/Gymnasium semantics: `terminated` and
+`truncated` are distinct, never collapsed into a single `done` flag.
+
+For the full reinforcement-learning guide and a worked `CountingAdapter`
+example, see
+[`docs/REINFORCEMENT_LEARNING.md`](REINFORCEMENT_LEARNING.md#-driving-evolution-with-evolverl).
+For the full contract — termination guards, seed cadence, opt-in milestone
+statistics, worker-pool semantics, and the migration path — see
+[`docs/event-driven-evolution.md`](event-driven-evolution.md).
+
 ### 💡 Evolution Example
 
 ```typescript

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,8 @@ Subsystems that only some users need.
 - **[REINFORCEMENT_LEARNING.md](REINFORCEMENT_LEARNING.md)** — streaming-
   observation / agent-rollout pattern for episode-based tasks (Snake,
   Cart-Pole). Names the use case, documents the `Creature.activate` contract,
-  and links to the worked example in NEAT-AI-Examples.
+  shows a worked `CountingAdapter` + `Creature.evolveRL` example, and links to
+  the full episode-rollout example in NEAT-AI-Examples.
 - **[event-driven-evolution.md](event-driven-evolution.md)** — RFC for the
   first-class reinforcement-learning evolution API (`Creature.evolveRL`). Names
   the paradigm split between supervised batch (`evolveDir`/`evolveDataSet`) and

--- a/docs/REINFORCEMENT_LEARNING.md
+++ b/docs/REINFORCEMENT_LEARNING.md
@@ -37,7 +37,8 @@
 6. [`clearState` between ticks vs episodes](#-clearstate-between-ticks-vs-episodes)
 7. [Worked example links](#-worked-example-links)
 8. [Comparison with value-based and policy-gradient RL](#-comparison-with-value-based-and-policy-gradient-rl)
-9. [Glossary](#-glossary)
+9. [Driving evolution with `evolveRL`](#-driving-evolution-with-evolverl)
+10. [Glossary](#-glossary)
 
 ## 🎯 When to use this pattern
 
@@ -278,6 +279,63 @@ This puts it in a different family from the dominant deep-RL methods.
 
 For a deeper comparison against feedforward, CNN, RNN, and Transformer
 architectures, see [`COMPARISON.md`](../COMPARISON.md).
+
+## 🚀 Driving evolution with `evolveRL`
+
+`Creature.evolveRL(adapter, options)` is the library-supplied way to evolve a
+population against an [`EpisodeAdapter`](#-glossary). It runs the rollout
+pattern documented above for every creature in every generation and reuses the
+same population manager, plateau detector, lifecycle events, and stop conditions
+as `evolveDir()`. Cross-link:
+[`event-driven-evolution.md`](event-driven-evolution.md) is the full contract —
+termination guards, seed cadence, opt-in milestone statistics, worker-pool
+semantics, and the migration path for the episodic examples in NEAT-AI-Examples.
+
+A 15-line worked example — a `CountingAdapter` that rewards every step until the
+agent's first output is positive:
+
+```typescript
+import { Creature, EpisodeAdapter } from "@stsoftware/neat-ai";
+
+class CountingAdapter extends EpisodeAdapter<number, number> {
+  observationLength = 2;
+  reset() {
+    return { observation: new Float32Array([0, 1]), state: 0 };
+  }
+  step(state: number, action: number) {
+    const next = state + 1;
+    return {
+      observation: new Float32Array([next / 100, 1]),
+      state: next,
+      reward: 1,
+      terminated: action > 0 || next >= 100,
+      truncated: false,
+    };
+  }
+  decodeAction(out: Float32Array) {
+    return out[0];
+  }
+}
+
+const creature = new Creature(2, 1);
+await creature.evolveRL(new CountingAdapter(), { iterations: 10 });
+```
+
+Things to notice:
+
+- The adapter owns the simulator state (`number` here); the creature owns the
+  weights. They never share mutable references.
+- `observationLength = 2` matches `new Creature(2, 1)`. `evolveRL` validates
+  this on first use via `EpisodeAdapter.assertContract()`.
+- `iterations: 10` caps the run at 10 generations. All other `NeatOptions`
+  fields are accepted via the `EvolveRLOptions` extension type — for example,
+  `episodesPerCreature: 3` (the default) averages three rollouts per creature
+  per generation, and `statistics: true` opts into the geometric milestone
+  schedule.
+
+For the full `EvolveRLOptions` and `EvolveRLMilestone` reference see
+[`docs/API_REFERENCE.md`](API_REFERENCE.md#-creatureevolverl) and the contract
+in [`event-driven-evolution.md`](event-driven-evolution.md).
 
 ## 📚 Glossary
 

--- a/docs/pr-summary-2625.md
+++ b/docs/pr-summary-2625.md
@@ -17,22 +17,24 @@ The doc now covers, in order:
   Gym/Gymnasium-style `terminated` vs `truncated` semantics.
 - Seed cadence: per-generation seed set shared by every creature, deterministic
   per-generation rotation, opt-in fixed seeds for tests.
-- Per-creature averaging at `episodesPerCreature = 3`, with the mapping back
-  to NEAT-AI's `error` for `targetError` and plateau detection.
+- Per-creature averaging at `episodesPerCreature = 3`, with the mapping back to
+  NEAT-AI's `error` for `targetError` and plateau detection.
 - Opt-in geometric milestone statistics
-  (`1, 2, 5, 10, 20, 50, 100, 200, 500, 1 000, …`) and the per-milestone
-  payload (best score, best neuron / synapse counts, mean episode steps,
-  generation wall-clock).
+  (`1, 2, 5, 10, 20, 50, 100, 200, 500, 1 000, …`) and the per-milestone payload
+  (best score, best neuron / synapse counts, mean episode steps, generation
+  wall-clock).
 - Cross-reference to #2612 with the serialisable adapter descriptor (Option A).
 
-`docs/REINFORCEMENT_LEARNING.md` now cross-references `evolveRL` in three
-places (top tip, parallelism section, glossary), and `docs/README.md` updates
-the index entry to describe the renamed API.
+`docs/REINFORCEMENT_LEARNING.md` now cross-references `evolveRL` in three places
+(top tip, parallelism section, glossary), and `docs/README.md` updates the index
+entry to describe the renamed API.
 
 ## Evidence
 
-Documentation-only change. `./quality.sh --skip-tests --skip-discovery
---skip-wasm` (formatting, lint, bash check, type-check) passes cleanly.
+Documentation-only change.
+`./quality.sh --skip-tests --skip-discovery
+--skip-wasm` (formatting, lint, bash
+check, type-check) passes cleanly.
 
 ```mermaid
 classDiagram
@@ -54,14 +56,13 @@ classDiagram
 
 ## Test Plan
 
-This is a design-doc refresh — no executable code changes, so no new unit
-tests. The acceptance criteria from #2625 are verified by reading the doc:
+This is a design-doc refresh — no executable code changes, so no new unit tests.
+The acceptance criteria from #2625 are verified by reading the doc:
 
 - [x] No `evolveEnv` references outside the rename note.
 - [x] `evolveRL` justified against `evolveEnv` / `evolveOnline` /
       `evolveInteractive`.
-- [x] Class-shaped adapter contract documented (abstract / overridable /
-      final).
+- [x] Class-shaped adapter contract documented (abstract / overridable / final).
 - [x] Default termination guards (60 s wall-clock, 5 000 steps, truncated
       semantics) documented.
 - [x] Seed-cadence rules (per-generation rotation, fixed-seed opt-in)

--- a/docs/pr-summary-2626.md
+++ b/docs/pr-summary-2626.md
@@ -6,24 +6,24 @@ Adds the class-shaped `EpisodeAdapter<S, A>` base class in
 `src/creature/EpisodeAdapter.ts` — the single seam between NEAT-AI and a
 caller's reinforcement-learning environment. Closes #2626.
 
-The new contract follows Gym/Gymnasium return-shape semantics
-(`terminated` vs `truncated` are distinct fields on `StepResult`) and uses a
-Java-style abstract / overridable split:
+The new contract follows Gym/Gymnasium return-shape semantics (`terminated` vs
+`truncated` are distinct fields on `StepResult`) and uses a Java-style abstract
+/ overridable split:
 
 - **MUST override** — `reset(rngSeed)`, `step(state, action)`,
   `observationLength`, `decodeAction(creatureOutput, state)`.
-- **MAY override** — `maxSteps()` (default `5000`) and `wallClockMs()`
-  (default `60_000`).
+- **MAY override** — `maxSteps()` (default `5000`) and `wallClockMs()` (default
+  `60_000`).
 
-Contract violations surface lazily on first use via
-`adapter.assertContract()` as the new typed `AdapterContractError`. Lazy
-validation lets subclasses defer their own initialisation; library code
-calls `assertContract()` once before driving the adapter.
+Contract violations surface lazily on first use via `adapter.assertContract()`
+as the new typed `AdapterContractError`. Lazy validation lets subclasses defer
+their own initialisation; library code calls `assertContract()` once before
+driving the adapter.
 
 The legacy `EpisodeAdapter` interface from #2611 (used by the still-shipping
-`evolveEnv()` flow) is preserved unchanged as `LegacyEpisodeAdapter` in a
-new `EpisodicFitnessTypes.ts` so the runner-replacement sub-issue can
-migrate it to the new contract independently.
+`evolveEnv()` flow) is preserved unchanged as `LegacyEpisodeAdapter` in a new
+`EpisodicFitnessTypes.ts` so the runner-replacement sub-issue can migrate it to
+the new contract independently.
 
 ## Evidence
 
@@ -44,10 +44,10 @@ EpisodeAdapter: argmax decodeAction picks the largest .. ok
 EpisodeAdapter: assertContract() is idempotent ......... ok
 ```
 
-`./quality.sh --skip-discovery --skip-wasm` passes lint, format,
-type-check, and 6611 tests. The two `DiscoveryTimeout` failures observed
-are pre-existing on the milestone branch base (reproduced with
-`git stash`) and unrelated to this change.
+`./quality.sh --skip-discovery --skip-wasm` passes lint, format, type-check, and
+6611 tests. The two `DiscoveryTimeout` failures observed are pre-existing on the
+milestone branch base (reproduced with `git stash`) and unrelated to this
+change.
 
 ```mermaid
 classDiagram
@@ -78,15 +78,14 @@ classDiagram
 
 ## Test Plan
 
-- **Added** `test/creature/EpisodeAdapter_test.ts` — covers the five
-  scenarios listed in #2626 (counting happy path, default guards, override
-  guards, contract failure on `observationLength = 0`, argmax
-  `decodeAction`) plus three additional contract-failure cases
-  (`maxSteps`, `wallClockMs`, observation type / size mismatch) and an
-  idempotency check on `assertContract()`.
+- **Added** `test/creature/EpisodeAdapter_test.ts` — covers the five scenarios
+  listed in #2626 (counting happy path, default guards, override guards,
+  contract failure on `observationLength = 0`, argmax `decodeAction`) plus three
+  additional contract-failure cases (`maxSteps`, `wallClockMs`, observation type
+  / size mismatch) and an idempotency check on `assertContract()`.
 - **Updated** `test/creature/EvolveEnv.ts` — type imports retargeted to
   `LegacyEpisodeAdapter` from `EpisodicFitnessTypes.ts`. All existing
   `evolveEnv()` tests still pass.
-- **Quality gate**: `./quality.sh --skip-discovery --skip-wasm` runs
-  lint + format + type-check + 6611 tests in parallel. New tests pass;
-  no regressions introduced.
+- **Quality gate**: `./quality.sh --skip-discovery --skip-wasm` runs lint +
+  format + type-check + 6611 tests in parallel. New tests pass; no regressions
+  introduced.

--- a/docs/pr-summary-2627.md
+++ b/docs/pr-summary-2627.md
@@ -4,13 +4,12 @@
 
 Adds the final, library-owned `runEpisode()` wrapper that drives an
 `EpisodeAdapter` end-to-end for one creature. The runner enforces both a
-wall-clock cap and a max-steps cap, returns a scalar `returnValue` plus
-rollout metadata, and never reaches for `Math.random()` — `rngSeed` is the
-only source of nondeterminism that crosses the seam. Termination semantics
-mirror Gym/Gymnasium (`terminated` for natural episode end, `truncated` for a
-guard firing). This protects the library against the failure modes called out
-in #2624 (a snake creature pressing left forever; a snake dying after three
-steps).
+wall-clock cap and a max-steps cap, returns a scalar `returnValue` plus rollout
+metadata, and never reaches for `Math.random()` — `rngSeed` is the only source
+of nondeterminism that crosses the seam. Termination semantics mirror
+Gym/Gymnasium (`terminated` for natural episode end, `truncated` for a guard
+firing). This protects the library against the failure modes called out in #2624
+(a snake creature pressing left forever; a snake dying after three steps).
 
 Closes #2627.
 
@@ -35,26 +34,26 @@ sequenceDiagram
     R-->>R: EpisodeResult { returnValue, steps, terminated, truncated, ... }
 ```
 
-Backend/library change with no UI surface — verified via the unit tests
-listed below. The wall-clock truncation test uses a `performance.now()` shim
-so the suite does not actually sleep for half a second per run.
+Backend/library change with no UI surface — verified via the unit tests listed
+below. The wall-clock truncation test uses a `performance.now()` shim so the
+suite does not actually sleep for half a second per run.
 
 ### Implementation notes
 
-- Caps (`maxSteps()`, `wallClockMs()`) and `t0` are captured once before the
-  hot loop, never read inside it.
-- `assertContract()` runs once before the first tick — the adapter caches
-  the result so subsequent episodes pay nothing.
+- Caps (`maxSteps()`, `wallClockMs()`) and `t0` are captured once before the hot
+  loop, never read inside it.
+- `assertContract()` runs once before the first tick — the adapter caches the
+  result so subsequent episodes pay nothing.
 - `creature.activate(observation, true)` is invoked with `feedbackLoop = true`
   per `docs/REINFORCEMENT_LEARNING.md`.
-- `result.terminated` exits cleanly with `terminated = true`; the step-cap
-  and wall-clock guards exit with `truncated = true` and the matching
+- `result.terminated` exits cleanly with `terminated = true`; the step-cap and
+  wall-clock guards exit with `truncated = true` and the matching
   `truncationReason`.
-- `performance.now()` is invoked once per tick. The syscall is on the order
-  of tens of nanoseconds — negligible next to a single `Creature.activate()`
-  call. A coarser modulo gate could be layered on later if profiling ever
-  shows the syscall dominating cost on trivial sims; the explicit
-  "between 5 and 7 steps" wall-clock test required per-tick granularity.
+- `performance.now()` is invoked once per tick. The syscall is on the order of
+  tens of nanoseconds — negligible next to a single `Creature.activate()` call.
+  A coarser modulo gate could be layered on later if profiling ever shows the
+  syscall dominating cost on trivial sims; the explicit "between 5 and 7 steps"
+  wall-clock test required per-tick granularity.
 
 ## Test Plan
 
@@ -63,20 +62,20 @@ scenario from the issue:
 
 - `runEpisode: natural termination after 12 steps` — adapter ends after 12
   steps; asserts `terminated = true, truncated = false, steps = 12`.
-- `runEpisode: default maxSteps guard truncates at 5000` — adapter never
-  sets `terminated`; asserts `truncated = true,
+- `runEpisode: default maxSteps guard truncates at 5000` — adapter never sets
+  `terminated`; asserts
+  `truncated = true,
   truncationReason = 'maxSteps', steps = 5000`.
 - `runEpisode: wall-clock truncation fires near the cap` — adapter advances a
-  virtual clock 100 ms per step with `wallClockMs() = 500`; asserts
-  truncation between 5 and 7 steps with `truncationReason = 'wallClock'`.
+  virtual clock 100 ms per step with `wallClockMs() = 500`; asserts truncation
+  between 5 and 7 steps with `truncationReason = 'wallClock'`.
 - `runEpisode: subclass maxSteps override is honoured` — subclass with
   `maxSteps() = 10` truncates at exactly 10.
 - `runEpisode: same seed produces identical results` — two runs with seed
-  `12345` produce byte-identical `returnValue`, `steps`, and
-  `truncationReason`.
-- `runEpisode: accumulates scalar rewards across the rollout` — five steps
-  of `reward = 1` followed by `terminated = true` yields `returnValue = 5`.
+  `12345` produce byte-identical `returnValue`, `steps`, and `truncationReason`.
+- `runEpisode: accumulates scalar rewards across the rollout` — five steps of
+  `reward = 1` followed by `terminated = true` yields `returnValue = 5`.
 
-All six new tests pass alongside the existing `EpisodeAdapter_test.ts`
-suite (10 tests). `./quality.sh --lint-only` and `./quality.sh --check-only`
-both pass cleanly.
+All six new tests pass alongside the existing `EpisodeAdapter_test.ts` suite (10
+tests). `./quality.sh --lint-only` and `./quality.sh --check-only` both pass
+cleanly.

--- a/docs/pr-summary-2628.md
+++ b/docs/pr-summary-2628.md
@@ -1,7 +1,7 @@
 ## Summary
 
-Adds `Creature.evolveRL()` — the public reinforcement-learning API on top of
-the new class-shaped `EpisodeAdapter` (Issue #2626) and the library-owned
+Adds `Creature.evolveRL()` — the public reinforcement-learning API on top of the
+new class-shaped `EpisodeAdapter` (Issue #2626) and the library-owned
 `runEpisode()` runner (Issue #2627). Per-creature fitness is the **mean return
 across `episodesPerCreature` episodes** (default 3) played against a
 **per-generation rotating seed set** so every creature in a generation is
@@ -30,32 +30,30 @@ flowchart TD
     N -->|targetError / timeoutMinutes / iterations / SIGTERM| O[restore best + return]
 ```
 
-- `src/creature/EvolveRLSeedSet.ts` — `deriveRLSeed(baseSeed, generation, trial)`
-  is a 32-bit MurmurHash3-style mixer; `buildRLSeedSet` produces the seed set
-  for one generation. `fixedSeedSet` collapses the generation index to `0` so
-  every generation uses the same seed set (tests / regression only).
+- `src/creature/EvolveRLSeedSet.ts` —
+  `deriveRLSeed(baseSeed, generation, trial)` is a 32-bit MurmurHash3-style
+  mixer; `buildRLSeedSet` produces the seed set for one generation.
+  `fixedSeedSet` collapses the generation index to `0` so every generation uses
+  the same seed set (tests / regression only).
 - `src/creature/RLEpisodeFitness.ts` — `Fitness` subclass that runs episode
-  rollouts inline via `runEpisode` (no worker pool yet — multi-threaded
-  rollouts remain tracked under #2612). The seed set is replaced before every
-  fitness phase so all creatures in a generation play the same seeds.
+  rollouts inline via `runEpisode` (no worker pool yet — multi-threaded rollouts
+  remain tracked under #2612). The seed set is replaced before every fitness
+  phase so all creatures in a generation play the same seeds.
 - `src/creature/CreatureTraining.ts` — adds `EvolveRLOptions` and `evolveRL()`,
-  reusing the same outer shape as `evolveDir()`/`evolveEnv()`. `Creature.evolveRL()`
-  is exposed on the `Creature` class.
+  reusing the same outer shape as `evolveDir()`/`evolveEnv()`.
+  `Creature.evolveRL()` is exposed on the `Creature` class.
 
 ## Evidence
 
 - Targeted test run (14 tests, all pass):
-  `deno test test/creature/evolveRL_test.ts`
-  → `ok | 14 passed | 0 failed`
-- Adjacent RL tests still pass:
-  `EpisodeRunner_test.ts`, `EpisodeAdapter_test.ts`, `EvolveEnv.ts` →
-  `ok | 39 passed | 0 failed`
-- Invariant gates pass:
-  `SemanticVersionStability.ts`, `NeuronUuidStability.ts` →
-  `ok | 24 passed | 0 failed`
-- `./quality.sh` lint, format, type-check, and bash gates all green; full
-  suite reports `6631 passed | 2 failed` where the **2 failures are
-  pre-existing FFI dynamic-library leaks in
+  `deno test test/creature/evolveRL_test.ts` → `ok | 14 passed | 0 failed`
+- Adjacent RL tests still pass: `EpisodeRunner_test.ts`,
+  `EpisodeAdapter_test.ts`, `EvolveEnv.ts` → `ok | 39 passed | 0 failed`
+- Invariant gates pass: `SemanticVersionStability.ts`, `NeuronUuidStability.ts`
+  → `ok | 24 passed | 0 failed`
+- `./quality.sh` lint, format, type-check, and bash gates all green; full suite
+  reports `6631 passed | 2 failed` where the **2 failures are pre-existing FFI
+  dynamic-library leaks in
   `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`** — verified by
   re-running on baseline (`git stash` → same failures), so unrelated to this
   change.
@@ -63,24 +61,24 @@ flowchart TD
 
 ## Test Plan
 
-- `test/creature/evolveRL_test.ts` covers the nine scenarios called out in
-  the issue:
+- `test/creature/evolveRL_test.ts` covers the nine scenarios called out in the
+  issue:
   1. Happy path — converges within 10 generations.
   2. `targetError` stop fires when reached.
-  3. `timeoutMinutes` accepted; iterations cap acts as the verifiable
-     secondary stop (the same approach as `EvolveEnv.ts`).
+  3. `timeoutMinutes` accepted; iterations cap acts as the verifiable secondary
+     stop (the same approach as `EvolveEnv.ts`).
   4. `iterations` cap is respected.
   5. Episode averaging — `episodesPerCreature = 3` with a seeded stochastic
      adapter returns the arithmetic mean of the seed set's per-trial rewards.
   6. Seed rotation — across 5 generations every seed set differs and is
      reproducible from the base seed.
   7. `fixedSeedSet = true` — every generation uses identical seeds.
-  8. Determinism — two runs with the same seed agree on `generation` exactly
-     and on `error`/`score` to within 1e-6 (matching `EvolveEnv.ts`'s
-     epsilon — neuron UUIDs are `crypto.randomUUID()` and downstream Maps
-     iterate in insertion order).
-  9. AbortSignal interrupt parity (used in place of OS SIGTERM in tests for
-     the same reason as `EvolveEnv.ts`: sending SIGTERM from a worker
-     propagates to the parallel test runner).
+  8. Determinism — two runs with the same seed agree on `generation` exactly and
+     on `error`/`score` to within 1e-6 (matching `EvolveEnv.ts`'s epsilon —
+     neuron UUIDs are `crypto.randomUUID()` and downstream Maps iterate in
+     insertion order).
+  9. AbortSignal interrupt parity (used in place of OS SIGTERM in tests for the
+     same reason as `EvolveEnv.ts`: sending SIGTERM from a worker propagates to
+     the parallel test runner).
 - Plus seed-helper unit tests covering determinism, rotation, fixed-set
   collapse, and the invalid-`episodesPerCreature` guard.

--- a/docs/pr-summary-2629.md
+++ b/docs/pr-summary-2629.md
@@ -1,19 +1,18 @@
 ## Summary
 
 Adds an opt-in milestone-statistics surface to `Creature.evolveRL()` so the
-example dashboards (lunar lander, snake, etc.) can chart per-generation
-progress without forcing every run to pay for the collection cost. New
+example dashboards (lunar lander, snake, etc.) can chart per-generation progress
+without forcing every run to pay for the collection cost. New
 `src/creature/EvolveRLStatistics.ts` exports `isMilestoneGeneration()` and the
 `EvolveRLMilestone` payload; the geometric schedule is
 `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000` and continues with powers of ten
-beyond `1000`. When `EvolveRLOptions.statistics === true`, `evolveRL()`
-collects best-creature score/topology, mean episode steps, and generation
-wall-clock at each milestone, emits the payload on the existing
-`onTrainingEvent` emitter as a new `evolverl_milestone` event, and returns a
-`milestones: EvolveRLMilestone[]` field on the run summary. When statistics
-are off (the default), the collection is skipped entirely on the hot path and
-the `milestones` field is omitted, preserving the #2628 return shape.
-Closes #2629.
+beyond `1000`. When `EvolveRLOptions.statistics === true`, `evolveRL()` collects
+best-creature score/topology, mean episode steps, and generation wall-clock at
+each milestone, emits the payload on the existing `onTrainingEvent` emitter as a
+new `evolverl_milestone` event, and returns a `milestones: EvolveRLMilestone[]`
+field on the run summary. When statistics are off (the default), the collection
+is skipped entirely on the hot path and the `milestones` field is omitted,
+preserving the #2628 return shape. Closes #2629.
 
 ## Design
 
@@ -31,41 +30,39 @@ flowchart TD
     J --> K[return includes milestones]
 ```
 
-- `src/creature/EvolveRLStatistics.ts` — `isMilestoneGeneration(g)` reduces
-  `g` by repeated division-by-ten and inspects the residue. For `g <= 1000`
-  the residue must be in `{1, 2, 5}`; for `g > 1000` the residue must be `1`
-  (i.e. `g` is a power of ten). O(log₁₀ g), zero allocation. `EvolveRLMilestone`
-  is the per-milestone payload (`generation`, `bestScore`, `bestNeurons`,
+- `src/creature/EvolveRLStatistics.ts` — `isMilestoneGeneration(g)` reduces `g`
+  by repeated division-by-ten and inspects the residue. For `g <= 1000` the
+  residue must be in `{1, 2, 5}`; for `g > 1000` the residue must be `1` (i.e.
+  `g` is a power of ten). O(log₁₀ g), zero allocation. `EvolveRLMilestone` is
+  the per-milestone payload (`generation`, `bestScore`, `bestNeurons`,
   `bestSynapses`, `meanEpisodeSteps`, `generationWallClockMs`).
 - `src/creature/RLEpisodeFitness.ts` — adds `setStatisticsEnabled`,
-  `beginGenerationStatistics`, and `consumeGenerationStatistics`. When stats
-  are on, the inner rollout loop accumulates per-episode step counts and the
-  best mean return per generation, and tags `meanReward` on each scored
-  creature so elites that survive across generations still report a sensible
-  `bestScore`. When stats are off, every accumulator branch is gated and
-  skipped entirely.
-- `src/creature/CreatureTraining.ts` — `EvolveRLOptions.statistics` doc
-  updated; `evolveRL()` captures `generationStartMs` per generation, builds
-  and emits the milestone payload at each milestone generation, and includes
-  the `milestones` array in the return only when statistics were enabled.
-- `src/config/TrainingEvent.ts` — adds the `EvolveRLMilestoneEvent` variant
-  to the `TrainingEvent` discriminated union so consumers receive it through
-  the same `onTrainingEvent` callback they already register.
-- `src/Creature.ts` — `Creature.evolveRL()` return type widened with an
-  optional `milestones` field.
+  `beginGenerationStatistics`, and `consumeGenerationStatistics`. When stats are
+  on, the inner rollout loop accumulates per-episode step counts and the best
+  mean return per generation, and tags `meanReward` on each scored creature so
+  elites that survive across generations still report a sensible `bestScore`.
+  When stats are off, every accumulator branch is gated and skipped entirely.
+- `src/creature/CreatureTraining.ts` — `EvolveRLOptions.statistics` doc updated;
+  `evolveRL()` captures `generationStartMs` per generation, builds and emits the
+  milestone payload at each milestone generation, and includes the `milestones`
+  array in the return only when statistics were enabled.
+- `src/config/TrainingEvent.ts` — adds the `EvolveRLMilestoneEvent` variant to
+  the `TrainingEvent` discriminated union so consumers receive it through the
+  same `onTrainingEvent` callback they already register.
+- `src/Creature.ts` — `Creature.evolveRL()` return type widened with an optional
+  `milestones` field.
 
 ## Evidence
 
 - Targeted test run (3 tests, all pass):
   `deno test test/creature/EvolveRLStatistics_test.ts` →
   `ok | 3 passed | 0 failed`.
-- Adjacent RL tests still pass:
-  `test/creature/evolveRL_test.ts`, `test/creature/EpisodeRunner_test.ts`,
-  `test/creature/EpisodeAdapter_test.ts` → `ok | 33 passed | 0 failed`.
+- Adjacent RL tests still pass: `test/creature/evolveRL_test.ts`,
+  `test/creature/EpisodeRunner_test.ts`, `test/creature/EpisodeAdapter_test.ts`
+  → `ok | 33 passed | 0 failed`.
 - `./quality.sh` lint, format, type-check, and bash gates all green.
-- Backend / library change with no UI surface, so no Playwright screenshot —
-  the milestone payload is consumed programmatically by the example
-  dashboards.
+- Backend / library change with no UI surface, so no Playwright screenshot — the
+  milestone payload is consumed programmatically by the example dashboards.
 
 ## Test Plan
 
@@ -74,12 +71,12 @@ scenarios from the issue:
 
 - **Predicate** — `isMilestoneGeneration` matches the schedule, including
   `1, 2, 5, 10, 20, 50, 100, 200, 500, 1000` (true), the listed neighbours
-  (`3, 11, 99, 150` → false), the explicit `2000 → false` and
-  `10_000 → true` decisions for the post-1000 continuation, and invalid
-  inputs (negative, non-integer, NaN, Infinity → false).
+  (`3, 11, 99, 150` → false), the explicit `2000 → false` and `10_000 → true`
+  decisions for the post-1000 continuation, and invalid inputs (negative,
+  non-integer, NaN, Infinity → false).
 - **Default off** — across 50 generations with `onTrainingEvent` registered,
-  zero `evolverl_milestone` events fire and the return value does not carry
-  a `milestones` field (preserving the #2628 shape).
+  zero `evolverl_milestone` events fire and the return value does not carry a
+  `milestones` field (preserving the #2628 shape).
 - **Statistics on** — across 50 generations the events fire exactly at
   `[1, 2, 5, 10, 20, 50]` and at no other generation.
 - **Payload shape** — every field is present with the expected type;

--- a/docs/pr-summary-2630.md
+++ b/docs/pr-summary-2630.md
@@ -1,0 +1,88 @@
+# Bump library major version + finalise evolveRL API docs / cross-references
+
+## Summary
+
+Final release-readiness change for milestone #2624: bump `@stsoftware/neat-ai`
+to **5.0.0**, re-export the reinforcement-learning surface from `mod.ts`, and
+complete the docs/cross-reference work so downstream consumers (notably
+NEAT-AI-Examples) can discover `Creature.evolveRL` and `EpisodeAdapter` from the
+canonical entry points. No runtime behaviour changes — this is purely an
+additive public-API surface and documentation pass. Closes #2630.
+
+## Changes
+
+- **`deno.json`** — version bumped `4.1.4 → 5.0.0`. The change is additive;
+  UUID-stability and semantic-version-stability invariants from `AGENTS.md` are
+  unaffected.
+- **`mod.ts`** — re-exports `EpisodeResult`, `TruncationReason`,
+  `EvolveRLOptions`, and `EvolveRLMilestone` alongside the previously exported
+  `EpisodeAdapter`, `StepResult`, `DEFAULT_MAX_STEPS`, and
+  `DEFAULT_WALL_CLOCK_MS`. Downstream consumers no longer need to reach into
+  `src/`.
+- **`docs/REINFORCEMENT_LEARNING.md`** — adds a "Driving evolution with
+  `evolveRL`" section with a 15-line `CountingAdapter` worked example and a
+  cross-link to `event-driven-evolution.md` for the full contract.
+- **`docs/API_REFERENCE.md`** — adds a `Creature.evolveRL()` subsection in §6
+  (Evolution API) alongside `evolveDir`, documenting the `EvolveRLOptions`
+  extension fields, the `EpisodeAdapter` contract, and the `StepResult` shape.
+- **`docs/README.md`** — index entry for `REINFORCEMENT_LEARNING.md` updated to
+  mention the `CountingAdapter` + `Creature.evolveRL` worked example.
+- **`CHANGELOG.md`** — `## [5.0.0]` section listing the reinforcement-learning
+  surface (evolveRL, EpisodeAdapter, default guards, 3-episodes-per-creature
+  averaging, opt-in geometric milestone statistics, public re-exports), plus a
+  `### Changed` entry recording the version bump.
+- **NEAT-AI-Examples issues #236–#240** — titles and bodies updated from
+  `Creature.evolveEnv()` → `Creature.evolveRL()`, with acceptance-criteria
+  entries that name the `EpisodeAdapter` subclassing contract and the
+  `EvolveRLOptions.episodesPerCreature` replacement for the legacy
+  `trialsPerScore`.
+- **`test/PublicExports_RL_test.ts`** — new test that compiles + runs the five
+  re-exported symbols (`EpisodeAdapter`, `StepResult`, `EpisodeResult`,
+  `EvolveRLOptions`, `EvolveRLMilestone`) through `mod.ts`, plus a runtime
+  assertion that `Creature#evolveRL` is exposed.
+
+## Evidence
+
+CLI / docs change — no UI to screenshot. Evidence comes from:
+
+- The new test (`test/PublicExports_RL_test.ts`) passes locally:
+
+  ```text
+  ok | 3 passed | 0 failed (10ms)
+  ```
+
+- `deno check mod.ts` is clean after the new re-exports.
+- `./quality.sh --lint-only` is clean (format, lint, bash-check).
+
+```mermaid
+flowchart LR
+    Consumer["Downstream consumer<br/>(NEAT-AI-Examples)"]
+    Consumer --> Mod["@stsoftware/neat-ai<br/>(mod.ts)"]
+    Mod --> EA["EpisodeAdapter"]
+    Mod --> SR["StepResult / EpisodeResult"]
+    Mod --> Opts["EvolveRLOptions"]
+    Mod --> Ms["EvolveRLMilestone"]
+    Mod --> C[Creature]
+    C --> ERL["evolveRL(adapter, options)"]
+    ERL --> RL["episode rollout loop<br/>(streaming observation)"]
+```
+
+The `quality.sh` full-test run reproduces a pre-existing FFI library leak in
+`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`
+(`A dynamic library was loaded during the test, but not unloaded`). That test is
+unchanged by this PR and the leak reproduces on
+`milestone/reinforcement-learning` without any of these edits applied — it is
+not a regression introduced here.
+
+## Test Plan
+
+- [x] `test/PublicExports_RL_test.ts` — verifies all five re-exports load
+      through `mod.ts` and that `Creature#evolveRL` exists at the public
+      surface.
+- [x] `deno check mod.ts` — type-check of the new re-exports.
+- [x] `deno fmt` clean after the docs / changelog edits.
+- [x] `deno lint` clean.
+- [x] Existing `test/creature/EpisodeAdapter_test.ts`, `EpisodeRunner_test.ts`,
+      `evolveRL_test.ts`, `evolveRL_parallel_test.ts`, and
+      `EvolveRLStatistics_test.ts` continue to pass (no behaviour changes in
+      `src/`).

--- a/mod.ts
+++ b/mod.ts
@@ -47,6 +47,12 @@ export {
   DEFAULT_WALL_CLOCK_MS,
 } from "@creature/EpisodeAdapter.ts";
 export type {
+  EpisodeResult,
+  TruncationReason,
+} from "@creature/EpisodeRunner.ts";
+export type { EvolveRLOptions } from "@creature/CreatureTraining.ts";
+export type { EvolveRLMilestone } from "@creature/EvolveRLStatistics.ts";
+export type {
   EpisodeTrialsEvent,
   EpisodicOptions,
   LegacyEpisodeAdapter,

--- a/test/PublicExports_RL_test.ts
+++ b/test/PublicExports_RL_test.ts
@@ -1,0 +1,92 @@
+/**
+ * Issue #2630 — Verify the reinforcement-learning surface is re-exported from
+ * the public entry point (`mod.ts`).
+ *
+ * The five symbols below are the contract NEAT-AI-Examples and any other
+ * downstream consumer relies on. Importing them from the package root must
+ * succeed (compile + runtime), otherwise consumers are forced back into
+ * `src/...` paths that break across release boundaries.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  Creature,
+  DEFAULT_MAX_STEPS,
+  DEFAULT_WALL_CLOCK_MS,
+  EpisodeAdapter,
+  type EpisodeResult,
+  type EvolveRLMilestone,
+  type EvolveRLOptions,
+  type StepResult,
+} from "../mod.ts";
+
+Deno.test("mod.ts re-exports EpisodeAdapter as a constructable abstract class", () => {
+  // The base class is abstract; subclassing must work.
+  class Trivial extends EpisodeAdapter<number, number> {
+    observationLength = 1;
+    reset() {
+      return { observation: new Float32Array([0]), state: 0 };
+    }
+    step(state: number) {
+      return {
+        observation: new Float32Array([0]),
+        state,
+        reward: 0,
+        terminated: true,
+        truncated: false,
+      };
+    }
+    decodeAction() {
+      return 0;
+    }
+  }
+  const adapter: EpisodeAdapter<number, number> = new Trivial();
+  assertEquals(adapter.observationLength, 1);
+  assertEquals(adapter.maxSteps(), DEFAULT_MAX_STEPS);
+  assertEquals(adapter.wallClockMs(), DEFAULT_WALL_CLOCK_MS);
+});
+
+Deno.test("mod.ts re-exports StepResult, EpisodeResult, EvolveRLOptions, EvolveRLMilestone types", () => {
+  // Compile-time only: assigning literals to the imported types must
+  // type-check. The runtime assertion below pins the values so the test does
+  // real work (rather than being a "how" test that inspects source text).
+  const step: StepResult<Float32Array> = {
+    observation: new Float32Array([1, 2]),
+    reward: 0.5,
+    terminated: false,
+    truncated: false,
+  };
+  const ep: EpisodeResult = {
+    returnValue: 1.5,
+    steps: 10,
+    terminated: true,
+    truncated: false,
+    elapsedMs: 12,
+    seed: 7,
+  };
+  const opts: EvolveRLOptions = {
+    iterations: 1,
+    episodesPerCreature: 2,
+    statistics: false,
+  };
+  const milestone: EvolveRLMilestone = {
+    generation: 5,
+    bestScore: 1.0,
+    bestNeurons: 4,
+    bestSynapses: 6,
+    meanEpisodeSteps: 17.5,
+    generationWallClockMs: 42,
+  };
+  assertEquals(step.reward, 0.5);
+  assertEquals(ep.returnValue, 1.5);
+  assertEquals(opts.episodesPerCreature, 2);
+  assertEquals(milestone.bestScore, 1.0);
+});
+
+Deno.test("Creature exposes evolveRL accepting the re-exported EpisodeAdapter", () => {
+  const c = new Creature(1, 1);
+  // The method exists at the public entry point; we do not invoke it (the
+  // full run is exercised by `test/creature/evolveRL_test.ts`).
+  assertExists(c.evolveRL);
+  assertEquals(typeof c.evolveRL, "function");
+});


### PR DESCRIPTION
# Bump library major version + finalise evolveRL API docs / cross-references

## Summary

Final release-readiness change for milestone #2624: bump `@stsoftware/neat-ai`
to **5.0.0**, re-export the reinforcement-learning surface from `mod.ts`, and
complete the docs/cross-reference work so downstream consumers (notably
NEAT-AI-Examples) can discover `Creature.evolveRL` and `EpisodeAdapter` from the
canonical entry points. No runtime behaviour changes — this is purely an
additive public-API surface and documentation pass. Closes #2630.

## Changes

- **`deno.json`** — version bumped `4.1.4 → 5.0.0`. The change is additive;
  UUID-stability and semantic-version-stability invariants from `AGENTS.md` are
  unaffected.
- **`mod.ts`** — re-exports `EpisodeResult`, `TruncationReason`,
  `EvolveRLOptions`, and `EvolveRLMilestone` alongside the previously exported
  `EpisodeAdapter`, `StepResult`, `DEFAULT_MAX_STEPS`, and
  `DEFAULT_WALL_CLOCK_MS`. Downstream consumers no longer need to reach into
  `src/`.
- **`docs/REINFORCEMENT_LEARNING.md`** — adds a "Driving evolution with
  `evolveRL`" section with a 15-line `CountingAdapter` worked example and a
  cross-link to `event-driven-evolution.md` for the full contract.
- **`docs/API_REFERENCE.md`** — adds a `Creature.evolveRL()` subsection in §6
  (Evolution API) alongside `evolveDir`, documenting the `EvolveRLOptions`
  extension fields, the `EpisodeAdapter` contract, and the `StepResult` shape.
- **`docs/README.md`** — index entry for `REINFORCEMENT_LEARNING.md` updated to
  mention the `CountingAdapter` + `Creature.evolveRL` worked example.
- **`CHANGELOG.md`** — `## [5.0.0]` section listing the reinforcement-learning
  surface (evolveRL, EpisodeAdapter, default guards, 3-episodes-per-creature
  averaging, opt-in geometric milestone statistics, public re-exports), plus a
  `### Changed` entry recording the version bump.
- **NEAT-AI-Examples issues #236–#240** — titles and bodies updated from
  `Creature.evolveEnv()` → `Creature.evolveRL()`, with acceptance-criteria
  entries that name the `EpisodeAdapter` subclassing contract and the
  `EvolveRLOptions.episodesPerCreature` replacement for the legacy
  `trialsPerScore`.
- **`test/PublicExports_RL_test.ts`** — new test that compiles + runs the five
  re-exported symbols (`EpisodeAdapter`, `StepResult`, `EpisodeResult`,
  `EvolveRLOptions`, `EvolveRLMilestone`) through `mod.ts`, plus a runtime
  assertion that `Creature#evolveRL` is exposed.

## Evidence

CLI / docs change — no UI to screenshot. Evidence comes from:

- The new test (`test/PublicExports_RL_test.ts`) passes locally:

  ```text
  ok | 3 passed | 0 failed (10ms)
  ```

- `deno check mod.ts` is clean after the new re-exports.
- `./quality.sh --lint-only` is clean (format, lint, bash-check).

```mermaid
flowchart LR
    Consumer["Downstream consumer<br/>(NEAT-AI-Examples)"]
    Consumer --> Mod["@stsoftware/neat-ai<br/>(mod.ts)"]
    Mod --> EA["EpisodeAdapter"]
    Mod --> SR["StepResult / EpisodeResult"]
    Mod --> Opts["EvolveRLOptions"]
    Mod --> Ms["EvolveRLMilestone"]
    Mod --> C[Creature]
    C --> ERL["evolveRL(adapter, options)"]
    ERL --> RL["episode rollout loop<br/>(streaming observation)"]
```

The `quality.sh` full-test run reproduces a pre-existing FFI library leak in
`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`
(`A dynamic library was loaded during the test, but not unloaded`). That test is
unchanged by this PR and the leak reproduces on
`milestone/reinforcement-learning` without any of these edits applied — it is
not a regression introduced here.

## Test Plan

- [x] `test/PublicExports_RL_test.ts` — verifies all five re-exports load
      through `mod.ts` and that `Creature#evolveRL` exists at the public
      surface.
- [x] `deno check mod.ts` — type-check of the new re-exports.
- [x] `deno fmt` clean after the docs / changelog edits.
- [x] `deno lint` clean.
- [x] Existing `test/creature/EpisodeAdapter_test.ts`, `EpisodeRunner_test.ts`,
      `evolveRL_test.ts`, `evolveRL_parallel_test.ts`, and
      `EvolveRLStatistics_test.ts` continue to pass (no behaviour changes in
      `src/`).



## Milestone
This PR is part of the **Reinforcement learning** milestone and targets the `milestone/reinforcement-learning` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2630 -->