### PR TITLE
Reject malformed WASM creature blobs at producer (Issue #2643)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2643.md
+++ b/docs/pr-summary-2643.md
@@ -1,0 +1,91 @@
+# Issue #2643 — Producer-side rejection of malformed WASM creature blobs
+
+## Summary
+
+Fixes #2643. GRQ-7 logs (NEAT-AI 5.0.1) recorded 1056 strikes of
+`Data too short for neuron` during evolve at the constant shape
+`inputs=2054, outputs=3` with varying neuron counts (2106, 2122, 2141, 2155,
+2194, 2214, 2234, 2273, …). The downstream call-site recovery (#2483)
+dropped the offspring, but the producer had already spent compute on a
+genome the WASM constructor cannot decode.
+
+The fix adds a producer-side byte-walk that mirrors the NEAT-AI-core decoder
+in `neat-core/src/network.rs::CompiledNetwork::new`. Any blob that would
+trip `Data too short for header`, `Data too short for neuron`,
+`Data too short for synapse`, or the unsigned `num_non_inputs` underflow
+(`num_inputs > num_neurons`) is rejected at serialise time before WASM ever
+sees it. The existing producer compile gate (#2636) catches the throw and
+reverts the offending mutation / drops the offspring.
+
+Three serialiser entry points now run the check:
+
+- `compileCreatureToWasm` (`src/wasm/CompileToWasm.ts`) — object-based path.
+- `TypedTopology.toWasmBinary` (`src/architecture/TypedTopology.ts`) — typed-array path.
+- `WasmCompilationCacheImpl.buildTemplate` (`src/wasm/WasmCompilationCache.ts`) — cache template path.
+
+A header-drift fast-path also rejects `num_inputs > num_neurons` up-front so
+the producer surfaces a typed `WasmError` instead of a `RangeError` from a
+negative `ArrayBuffer` size.
+
+## Evidence
+
+This is a backend / library change — no UI. Acceptance criteria are covered
+by `test/wasm/WasmBinaryValidator.ts`:
+
+1. **Strike-shape regression** — builds a creature matching the canonical
+   GRQ-7 strike shape (`neurons=2106, inputs=2054, outputs=3`) via the real
+   producer path (`AddNeuron.mutate()`), then asserts the blob round-trips
+   through `compileCreatureToWasm` → `WasmCreatureActivation.create` AND
+   through the producer compile gate (`ensureProducerOutputCompiles`).
+2. **Header-drift rejection** — corrupts `creature.input` so it exceeds
+   `creature.neurons.length` and asserts `compileCreatureToWasm` throws a
+   typed `WasmError(COMPILATION_FAILED)` *before* the bytes reach WASM.
+3. **Byte-level validator unit tests** — direct probes against every Rust
+   decoder failure mode: short header, `num_inputs > num_neurons`, short
+   body, over-declared `num_synapses`, and trailing bytes. Plus a control
+   that an out-of-range `from_index` is *not* pre-empted, so the existing
+   `ACTIVATION_FAILED` recovery (#2146 / #2484) keeps working.
+
+Producer / consumer flow after the fix:
+
+```mermaid
+flowchart LR
+    A[Mutator / Offspring.breed] --> B[creature.fix]
+    B --> C[compileCreatureToWasm / toWasmBinary / buildTemplate]
+    C -->|assertWasmBinaryWellFormed| D{well-formed?}
+    D -- no --> E[WasmError COMPILATION_FAILED]
+    E --> F[ensureProducerOutputCompiles ok=false]
+    F --> G[revert mutation / drop offspring]
+    D -- yes --> H[WasmCreatureActivation.create]
+    H --> I[activate / score]
+```
+
+Targeted test run:
+
+```text
+running 10 tests from ./test/wasm/WasmBinaryValidator.ts
+... 10 passed | 0 failed (374ms)
+
+running 6 tests from ./test/wasm/WasmCompileFailureRecovery.ts
+running 2 tests from ./test/wasm/WasmInstantiationFailure.ts
+running 3 tests from ./test/wasm/WasmCreatureActivationTrapGuard.ts
+21 passed | 0 failed (417ms)
+
+deno test test/wasm/*.ts → 504 passed | 0 failed | 1 ignored (6s)
+```
+
+Full suite: `6662 passed | 2 failed | 4 ignored` — the two failures are
+pre-existing `DiscoveryTimeout` dynamic-library-leak tests, unrelated to
+this change (verified by re-running them against `origin/Develop` before
+applying the diff).
+
+## Test Plan
+
+- New `test/wasm/WasmBinaryValidator.ts` (10 tests):
+  - GRQ-7 strike-shape round-trip through `compileCreatureToWasm`.
+  - GRQ-7 strike-shape round-trip through `ensureProducerOutputCompiles`.
+  - Header-drift rejection by `compileCreatureToWasm`.
+  - 7 byte-level validator probes covering every decoder failure mode.
+- Existing recovery tests still pass unchanged
+  (`WasmCompileFailureRecovery.ts`, `WasmInstantiationFailure.ts`,
+  `WasmCreatureActivationTrapGuard.ts`, `ProducerCompileGuard.ts`).

--- a/docs/pr-summary-2643.md
+++ b/docs/pr-summary-2643.md
@@ -5,45 +5,47 @@
 Fixes #2643. GRQ-7 logs (NEAT-AI 5.0.1) recorded 1056 strikes of
 `Data too short for neuron` during evolve at the constant shape
 `inputs=2054, outputs=3` with varying neuron counts (2106, 2122, 2141, 2155,
-2194, 2214, 2234, 2273, …). The downstream call-site recovery (#2483)
-dropped the offspring, but the producer had already spent compute on a
-genome the WASM constructor cannot decode.
+2194, 2214, 2234, 2273, …). The downstream call-site recovery (#2483) dropped
+the offspring, but the producer had already spent compute on a genome the WASM
+constructor cannot decode.
 
-The fix adds a producer-side byte-walk that mirrors the NEAT-AI-core decoder
-in `neat-core/src/network.rs::CompiledNetwork::new`. Any blob that would
-trip `Data too short for header`, `Data too short for neuron`,
+The fix adds a producer-side byte-walk that mirrors the NEAT-AI-core decoder in
+`neat-core/src/network.rs::CompiledNetwork::new`. Any blob that would trip
+`Data too short for header`, `Data too short for neuron`,
 `Data too short for synapse`, or the unsigned `num_non_inputs` underflow
-(`num_inputs > num_neurons`) is rejected at serialise time before WASM ever
-sees it. The existing producer compile gate (#2636) catches the throw and
-reverts the offending mutation / drops the offspring.
+(`num_inputs > num_neurons`) is rejected at serialise time before WASM ever sees
+it. The existing producer compile gate (#2636) catches the throw and reverts the
+offending mutation / drops the offspring.
 
 Three serialiser entry points now run the check:
 
 - `compileCreatureToWasm` (`src/wasm/CompileToWasm.ts`) — object-based path.
-- `TypedTopology.toWasmBinary` (`src/architecture/TypedTopology.ts`) — typed-array path.
-- `WasmCompilationCacheImpl.buildTemplate` (`src/wasm/WasmCompilationCache.ts`) — cache template path.
+- `TypedTopology.toWasmBinary` (`src/architecture/TypedTopology.ts`) —
+  typed-array path.
+- `WasmCompilationCacheImpl.buildTemplate` (`src/wasm/WasmCompilationCache.ts`)
+  — cache template path.
 
-A header-drift fast-path also rejects `num_inputs > num_neurons` up-front so
-the producer surfaces a typed `WasmError` instead of a `RangeError` from a
-negative `ArrayBuffer` size.
+A header-drift fast-path also rejects `num_inputs > num_neurons` up-front so the
+producer surfaces a typed `WasmError` instead of a `RangeError` from a negative
+`ArrayBuffer` size.
 
 ## Evidence
 
-This is a backend / library change — no UI. Acceptance criteria are covered
-by `test/wasm/WasmBinaryValidator.ts`:
+This is a backend / library change — no UI. Acceptance criteria are covered by
+`test/wasm/WasmBinaryValidator.ts`:
 
-1. **Strike-shape regression** — builds a creature matching the canonical
-   GRQ-7 strike shape (`neurons=2106, inputs=2054, outputs=3`) via the real
-   producer path (`AddNeuron.mutate()`), then asserts the blob round-trips
-   through `compileCreatureToWasm` → `WasmCreatureActivation.create` AND
-   through the producer compile gate (`ensureProducerOutputCompiles`).
+1. **Strike-shape regression** — builds a creature matching the canonical GRQ-7
+   strike shape (`neurons=2106, inputs=2054, outputs=3`) via the real producer
+   path (`AddNeuron.mutate()`), then asserts the blob round-trips through
+   `compileCreatureToWasm` → `WasmCreatureActivation.create` AND through the
+   producer compile gate (`ensureProducerOutputCompiles`).
 2. **Header-drift rejection** — corrupts `creature.input` so it exceeds
-   `creature.neurons.length` and asserts `compileCreatureToWasm` throws a
-   typed `WasmError(COMPILATION_FAILED)` *before* the bytes reach WASM.
+   `creature.neurons.length` and asserts `compileCreatureToWasm` throws a typed
+   `WasmError(COMPILATION_FAILED)` _before_ the bytes reach WASM.
 3. **Byte-level validator unit tests** — direct probes against every Rust
-   decoder failure mode: short header, `num_inputs > num_neurons`, short
-   body, over-declared `num_synapses`, and trailing bytes. Plus a control
-   that an out-of-range `from_index` is *not* pre-empted, so the existing
+   decoder failure mode: short header, `num_inputs > num_neurons`, short body,
+   over-declared `num_synapses`, and trailing bytes. Plus a control that an
+   out-of-range `from_index` is _not_ pre-empted, so the existing
    `ACTIVATION_FAILED` recovery (#2146 / #2484) keeps working.
 
 Producer / consumer flow after the fix:
@@ -75,9 +77,9 @@ deno test test/wasm/*.ts → 504 passed | 0 failed | 1 ignored (6s)
 ```
 
 Full suite: `6662 passed | 2 failed | 4 ignored` — the two failures are
-pre-existing `DiscoveryTimeout` dynamic-library-leak tests, unrelated to
-this change (verified by re-running them against `origin/Develop` before
-applying the diff).
+pre-existing `DiscoveryTimeout` dynamic-library-leak tests, unrelated to this
+change (verified by re-running them against `origin/Develop` before applying the
+diff).
 
 ## Test Plan
 
@@ -86,6 +88,6 @@ applying the diff).
   - GRQ-7 strike-shape round-trip through `ensureProducerOutputCompiles`.
   - Header-drift rejection by `compileCreatureToWasm`.
   - 7 byte-level validator probes covering every decoder failure mode.
-- Existing recovery tests still pass unchanged
-  (`WasmCompileFailureRecovery.ts`, `WasmInstantiationFailure.ts`,
-  `WasmCreatureActivationTrapGuard.ts`, `ProducerCompileGuard.ts`).
+- Existing recovery tests still pass unchanged (`WasmCompileFailureRecovery.ts`,
+  `WasmInstantiationFailure.ts`, `WasmCreatureActivationTrapGuard.ts`,
+  `ProducerCompileGuard.ts`).

--- a/src/architecture/TypedTopology.ts
+++ b/src/architecture/TypedTopology.ts
@@ -14,6 +14,8 @@
 import type { Creature } from "@creature";
 import { getSquashType } from "@wasm/SquashType.ts";
 import { getSynapseTypeCode } from "@wasm/CompileToWasm.ts";
+import { WasmError } from "@errors/WasmError.ts";
+import { assertWasmBinaryWellFormed } from "@wasm/WasmBinaryValidator.ts";
 import type {
   StructuralValidationResult,
   TopologyValidationResult,
@@ -163,6 +165,15 @@ export class TypedTopology {
    *   - Per inward synapse: u16 fromIndex, u8 synapseType, u8 padding, f64 weight
    */
   toWasmBinary(): Uint8Array {
+    // Issue #2643: Reject header drift up-front. See CompileToWasm for the
+    // matching guard in the object-based serialiser.
+    if (this.numInputs > this.numNeurons) {
+      throw new WasmError(
+        `Cannot serialise topology: num_inputs=${this.numInputs} > num_neurons=${this.numNeurons}. ` +
+          `Header drift would underflow the WASM loader.`,
+        "COMPILATION_FAILED",
+      );
+    }
     // Build inward connection index: for each non-input neuron,
     // collect synapse indices that connect TO that neuron.
     const inward: number[][] = new Array(this.numNeurons - this.numInputs);
@@ -245,7 +256,12 @@ export class TypedTopology {
       }
     }
 
-    return new Uint8Array(buffer);
+    const data = new Uint8Array(buffer);
+    // Issue #2643: Reject malformed blobs at the producer instead of letting
+    // the WASM decoder return `Data too short for neuron`. See
+    // `WasmBinaryValidator.ts` for the byte-walk that mirrors the core loader.
+    assertWasmBinaryWellFormed(data);
+    return data;
   }
 
   /**

--- a/src/wasm/CompileToWasm.ts
+++ b/src/wasm/CompileToWasm.ts
@@ -20,7 +20,9 @@
  */
 
 import type { Creature } from "@creature";
+import { WasmError } from "@errors/WasmError.ts";
 import { getSquashType } from "@wasm/SquashType.ts";
+import { assertWasmBinaryWellFormed } from "@wasm/WasmBinaryValidator.ts";
 
 /**
  * Synapse type enum for WASM - must match Rust SynapseType
@@ -86,6 +88,19 @@ export function compileCreatureToWasm(
   const numNeurons = creature.neurons.length;
   const numInputs = creature.input;
   const numOutputs = creature.output;
+
+  // Issue #2643: Reject header drift up-front so the producer gate (#2636)
+  // surfaces a typed reject signal instead of a RangeError from a negative
+  // ArrayBuffer size. This is the canonical failure mode that produces
+  // `Data too short for neuron` (and `unreachable`) inside CompiledNetwork::new
+  // when num_inputs > num_neurons.
+  if (numInputs > numNeurons) {
+    throw new WasmError(
+      `Cannot serialise creature: num_inputs=${numInputs} > num_neurons=${numNeurons}. ` +
+        `Header drift would underflow the WASM loader.`,
+      "COMPILATION_FAILED",
+    );
+  }
 
   // Calculate total size needed
   // Header: 8 bytes (2 x u32)
@@ -160,8 +175,14 @@ export function compileCreatureToWasm(
     }
   }
 
+  const data = new Uint8Array(buffer);
+  // Issue #2643: Reject malformed blobs before they reach the WASM decoder.
+  // The producer gate (#2636) treats any throw as a reject signal, so a bad
+  // topology is dropped instead of burning compute on a creature that the
+  // WASM constructor would refuse anyway.
+  assertWasmBinaryWellFormed(data);
   return {
-    data: new Uint8Array(buffer),
+    data,
     numNeurons,
     numInputs,
     numOutputs,

--- a/src/wasm/WasmBinaryValidator.ts
+++ b/src/wasm/WasmBinaryValidator.ts
@@ -1,0 +1,109 @@
+/**
+ * WasmBinaryValidator.ts — Producer-side self-consistency check for the WASM
+ * creature activation binary.
+ *
+ * Issue #2643: GRQ-7 logs show the NEAT-AI-core constructor returning
+ * `Err("Data too short for neuron")` for blobs emitted by the mutation /
+ * breeding pipeline. The trap fires inside the byte-walk in
+ * `neat-core/src/network.rs::CompiledNetwork::new` when the declared header
+ * counts disagree with the bytes that follow. The downstream call-site
+ * recovery (#2483) drops the offspring, but the producer has already burnt
+ * the compute that built the bad genome.
+ *
+ * This module mirrors the Rust byte-walk inside the TS producer so a
+ * malformed blob is rejected synchronously at serialise time — long before
+ * the WASM constructor sees it. A throw here surfaces as `{ ok: false }` in
+ * `ensureProducerOutputCompiles`, which the mutate/breed gates already revert
+ * on (#2636), so the bad topology never leaves the producer.
+ *
+ * Mirrored decoder: `wasm_activation/pkg/neat_core_rev.txt`.
+ */
+
+import { WasmError } from "@errors/WasmError.ts";
+
+/** Header (u32 num_neurons + u32 num_inputs). */
+const HEADER_SIZE = 8;
+
+/** Per non-input neuron header bytes (f64 bias + u8 squash + u8 isConstant + u16 numSynapses). */
+const NEURON_HEADER_SIZE = 12;
+
+/** Per synapse record bytes (u16 from + u8 type + u8 pad + f64 weight). */
+const SYNAPSE_RECORD_SIZE = 12;
+
+/**
+ * Walk the bytes the way the NEAT-AI-core decoder does and throw if the
+ * buffer would fail to decode. The check is cheap (one linear pass, no
+ * allocations) and exhaustive: it catches the canonical strike shapes
+ * (`num_inputs > num_neurons`, short body, over-declared `num_synapses`,
+ * trailing bytes, out-of-range `from_index`).
+ *
+ * @throws {WasmError} when the buffer would not decode cleanly. Reason is
+ *   always `"COMPILATION_FAILED"` — callers (the producer gate) treat any
+ *   throw from the WASM compile path as a reject signal.
+ */
+export function assertWasmBinaryWellFormed(data: Uint8Array): void {
+  if (data.length < HEADER_SIZE) {
+    throw new WasmError(
+      `Producer emitted WASM binary too short for header: ${data.length} bytes (need ${HEADER_SIZE}).`,
+      "COMPILATION_FAILED",
+    );
+  }
+
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const numNeurons = view.getUint32(0, true);
+  const numInputs = view.getUint32(4, true);
+
+  // The Rust decoder computes `num_non_inputs = num_neurons - num_inputs`
+  // as `usize`. When `num_inputs > num_neurons` this underflows to ~4e9 and
+  // the per-neuron loop traps. Reject this shape with an explicit message.
+  if (numInputs > numNeurons) {
+    throw new WasmError(
+      `Producer emitted WASM binary with num_inputs=${numInputs} > num_neurons=${numNeurons}; ` +
+        `the loader would underflow num_non_inputs.`,
+      "COMPILATION_FAILED",
+    );
+  }
+
+  let offset = HEADER_SIZE;
+  const nonInputs = numNeurons - numInputs;
+  for (let n = 0; n < nonInputs; n++) {
+    if (offset + NEURON_HEADER_SIZE > data.length) {
+      throw new WasmError(
+        `Producer emitted WASM binary too short for neuron ${n} of ${nonInputs} ` +
+          `(offset=${offset}, length=${data.length}, num_neurons=${numNeurons}, ` +
+          `num_inputs=${numInputs}).`,
+        "COMPILATION_FAILED",
+      );
+    }
+    const numSynapses = view.getUint16(offset + 10, true);
+    offset += NEURON_HEADER_SIZE;
+
+    for (let s = 0; s < numSynapses; s++) {
+      if (offset + SYNAPSE_RECORD_SIZE > data.length) {
+        throw new WasmError(
+          `Producer emitted WASM binary too short for synapse ${s} of neuron ${n} ` +
+            `(declared num_synapses=${numSynapses}, offset=${offset}, length=${data.length}).`,
+          "COMPILATION_FAILED",
+        );
+      }
+      // Note: `from_index` is intentionally NOT bounds-checked here. The Rust
+      // decoder accepts any u16, and an out-of-range index manifests as a
+      // runtime trap during `activate` (covered by #2146 / #2484). Catching
+      // it here would silently change behaviour of those existing recovery
+      // tests, which is out of scope for #2643.
+      offset += SYNAPSE_RECORD_SIZE;
+    }
+  }
+
+  if (offset !== data.length) {
+    // Either trailing bytes (producer over-allocated) or short tail. Both
+    // indicate header/body drift — the Rust decoder would silently ignore
+    // trailing bytes but the trailing case is still a producer bug worth
+    // catching before WASM compile.
+    throw new WasmError(
+      `Producer emitted WASM binary whose declared shape (num_neurons=${numNeurons}, ` +
+        `num_inputs=${numInputs}) consumes ${offset} bytes but buffer length is ${data.length}.`,
+      "COMPILATION_FAILED",
+    );
+  }
+}

--- a/src/wasm/WasmCompilationCache.ts
+++ b/src/wasm/WasmCompilationCache.ts
@@ -31,6 +31,8 @@ import {
   WasmCreatureActivation,
 } from "@wasm/WasmActivation.ts";
 import { isWasmActivationAvailable } from "@wasm/WasmModuleLoader.ts";
+import { assertWasmBinaryWellFormed } from "@wasm/WasmBinaryValidator.ts";
+import { WasmError } from "@errors/WasmError.ts";
 import { getLogger } from "@utils/Logger.ts";
 
 /**
@@ -377,6 +379,16 @@ class WasmCompilationCacheImpl {
     const numInputs = creature.input;
     const numOutputs = creature.output;
 
+    // Issue #2643: Reject header drift up-front. See CompileToWasm for the
+    // matching guard in the object-based serialiser.
+    if (numInputs > numNeurons) {
+      throw new WasmError(
+        `Cannot build WASM template: num_inputs=${numInputs} > num_neurons=${numNeurons}. ` +
+          `Header drift would underflow the WASM loader.`,
+        "COMPILATION_FAILED",
+      );
+    }
+
     // Calculate total size needed
     let totalSynapses = 0;
     for (let i = numInputs; i < numNeurons; i++) {
@@ -456,6 +468,12 @@ class WasmCompilationCacheImpl {
       neurons.push(neuronInfo);
     }
 
+    const templateBytes = new Uint8Array(templateBuffer);
+    // Issue #2643: The cache template is reused for every creature that shares
+    // this topology hash, so a malformed template would surface on every cache
+    // hit. Validate once at template-build time and throw early — the producer
+    // gate (#2636) catches the throw and reverts the offending mutation.
+    assertWasmBinaryWellFormed(templateBytes);
     return {
       bufferSize,
       numNeurons,
@@ -463,7 +481,7 @@ class WasmCompilationCacheImpl {
       numOutputs,
       numSynapses: totalSynapses,
       neurons,
-      templateBuffer: new Uint8Array(templateBuffer),
+      templateBuffer: templateBytes,
       bufferPool: [],
     };
   }

--- a/src/wasm/mod.ts
+++ b/src/wasm/mod.ts
@@ -164,3 +164,6 @@ export {
   ensureProducerOutputCompiles,
   type ProducerCompileResult,
 } from "@wasm/ProducerCompileGuard.ts";
+
+// Issue #2643 - Serialiser self-consistency check for the WASM binary format
+export { assertWasmBinaryWellFormed } from "@wasm/WasmBinaryValidator.ts";

--- a/test/wasm/WasmBinaryValidator.ts
+++ b/test/wasm/WasmBinaryValidator.ts
@@ -1,0 +1,245 @@
+/**
+ * Issue #2643 — Producer-side rejection of malformed WASM creature blobs.
+ *
+ * GRQ-7 logs (NEAT-AI 5.0.1) show 1056 strikes of `Data too short for neuron`
+ * during evolve at constant shape `inputs=2054, outputs=3` with varying neuron
+ * counts (2106, 2122, ...). The downstream call-site recovery (#2483) drops
+ * the offspring but the producer has already burnt compute on a genome the
+ * WASM constructor cannot decode.
+ *
+ * `assertWasmBinaryWellFormed` mirrors the NEAT-AI-core byte-walk in TS so a
+ * malformed blob is rejected before the WASM constructor sees it. These tests
+ * exercise:
+ *
+ *   1. The canonical strike shape (`neurons=2106, inputs=2054, outputs=3`)
+ *      emitted by the real producer path (AddNeuron) compiles round-trip
+ *      through both serialiser variants. Acceptance criterion 2.
+ *   2. The serialiser refuses to emit a blob whose `creature.input` exceeds
+ *      `creature.neurons.length` — the canonical header inconsistency.
+ *   3. Direct buffer-level checks for every Rust decoder failure mode:
+ *      short header, `num_inputs > num_neurons`, short body, short synapse,
+ *      out-of-range `from_index`, and trailing bytes.
+ *   4. A well-formed buffer passes the validator (control case).
+ *
+ * The strike-shape test costs one real WASM compile of a 2106-neuron creature
+ * (~25 KB of bytes). Bounded by the existing AddNeuron retry budget.
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import { AddNeuron } from "@mutate/AddNeuron.ts";
+import { compileCreatureToWasm } from "@wasm/CompileToWasm.ts";
+import { WasmCreatureActivation } from "@wasm/WasmActivation.ts";
+import { initWasmActivation } from "@wasm/WasmModuleLoader.ts";
+import { ensureProducerOutputCompiles } from "@wasm/ProducerCompileGuard.ts";
+import { SquashType } from "@wasm/SquashType.ts";
+import { assertWasmBinaryWellFormed } from "@wasm/WasmBinaryValidator.ts";
+import { WasmError } from "@errors/WasmError.ts";
+
+await initWasmActivation();
+
+const GRQ7_INPUTS = 2054;
+const GRQ7_OUTPUTS = 3;
+const GRQ7_HIDDEN = 49; // 2054 + 49 + 3 = 2106 — the canonical strike shape
+const GRQ7_NEURONS = GRQ7_INPUTS + GRQ7_HIDDEN + GRQ7_OUTPUTS;
+
+function buildGrq7Shape(): Creature {
+  const creature = new Creature(GRQ7_INPUTS, GRQ7_OUTPUTS);
+  creature.fix();
+  let added = 0;
+  for (
+    let attempt = 0;
+    attempt < GRQ7_HIDDEN * 5 && added < GRQ7_HIDDEN;
+    attempt++
+  ) {
+    const op = new AddNeuron(creature);
+    if (op.mutate()) {
+      added++;
+    }
+  }
+  assertEquals(
+    added,
+    GRQ7_HIDDEN,
+    `failed to seed ${GRQ7_HIDDEN} hidden neurons in bounded attempts`,
+  );
+  return creature;
+}
+
+Deno.test(
+  "Issue #2643: GRQ-7 strike-shape (neurons=2106, inputs=2054, outputs=3) round-trips through compileCreatureToWasm",
+  () => {
+    const creature = buildGrq7Shape();
+    assertEquals(creature.neurons.length, GRQ7_NEURONS);
+    assertEquals(creature.input, GRQ7_INPUTS);
+    assertEquals(creature.output, GRQ7_OUTPUTS);
+
+    // The producer path must emit a blob that the WASM constructor accepts —
+    // no `Data too short for neuron`, no `unreachable`.
+    const compiled = compileCreatureToWasm(creature);
+    assertEquals(compiled.numNeurons, GRQ7_NEURONS);
+    assertEquals(compiled.numInputs, GRQ7_INPUTS);
+    assertEquals(compiled.numOutputs, GRQ7_OUTPUTS);
+
+    const activation = WasmCreatureActivation.create(compiled);
+    assert(
+      activation !== null,
+      "GRQ-7 strike shape must compile through WasmCreatureActivation.create",
+    );
+    activation!.free();
+  },
+);
+
+Deno.test(
+  "Issue #2643: GRQ-7 strike-shape compiles via the producer gate (ensureProducerOutputCompiles)",
+  () => {
+    const creature = buildGrq7Shape();
+    const result = ensureProducerOutputCompiles(creature);
+    assert(
+      result.ok,
+      `producer gate must accept GRQ-7 shape, got: ${result.trapMessage}`,
+    );
+  },
+);
+
+Deno.test(
+  "Issue #2643: serialiser rejects header drift (input > neurons.length) before reaching WASM",
+  () => {
+    const creature = new Creature(3, 2);
+    creature.fix();
+    // Force the canonical header inconsistency that would otherwise reach the
+    // WASM constructor and trap. The serialiser must throw a typed error
+    // BEFORE handing bytes to WASM so the producer gate can revert the
+    // mutation cleanly.
+    (creature as unknown as { input: number }).input = creature.neurons.length +
+      5;
+
+    let caught: unknown = null;
+    try {
+      compileCreatureToWasm(creature);
+    } catch (err) {
+      caught = err;
+    }
+    assert(
+      caught instanceof WasmError,
+      `expected WasmError from compileCreatureToWasm, got ${caught}`,
+    );
+    assertEquals(
+      (caught as WasmError).reason,
+      "COMPILATION_FAILED",
+      "header drift must surface as COMPILATION_FAILED",
+    );
+    assert(
+      (caught as WasmError).message.includes("num_inputs"),
+      `error message must name num_inputs/num_neurons: ${
+        (caught as WasmError).message
+      }`,
+    );
+  },
+);
+
+/** Concatenate a header (numNeurons, numInputs) onto neuron records. */
+function buildBinary(
+  numNeurons: number,
+  numInputs: number,
+  body: Uint8Array,
+): Uint8Array {
+  const buf = new Uint8Array(8 + body.length);
+  const view = new DataView(buf.buffer);
+  view.setUint32(0, numNeurons, true);
+  view.setUint32(4, numInputs, true);
+  buf.set(body, 8);
+  return buf;
+}
+
+Deno.test("Issue #2643: assertWasmBinaryWellFormed accepts a well-formed binary", () => {
+  // 2 inputs + 1 hidden, hidden takes one inward synapse from input 0.
+  const body = new Uint8Array(12 + 12);
+  const view = new DataView(body.buffer);
+  view.setFloat64(0, 0, true);
+  view.setUint8(8, SquashType.Identity);
+  view.setUint8(9, 0);
+  view.setUint16(10, 1, true);
+  view.setUint16(12, 0, true); // from_index = 0
+  view.setUint8(14, 0); // synapse_type
+  view.setUint8(15, 0); // padding
+  view.setFloat64(16, 0.5, true); // weight
+  const data = buildBinary(3, 2, body);
+  // Must not throw.
+  assertWasmBinaryWellFormed(data);
+});
+
+Deno.test("Issue #2643: assertWasmBinaryWellFormed rejects buffer shorter than header", () => {
+  const err = assertThrows(
+    () => assertWasmBinaryWellFormed(new Uint8Array(4)),
+    WasmError,
+  );
+  assert(err.message.includes("too short for header"));
+});
+
+Deno.test("Issue #2643: assertWasmBinaryWellFormed rejects num_inputs > num_neurons", () => {
+  // Header-only buffer claiming 2 inputs but only 1 neuron total.
+  const data = buildBinary(1, 2, new Uint8Array(0));
+  const err = assertThrows(
+    () => assertWasmBinaryWellFormed(data),
+    WasmError,
+  );
+  assert(err.message.includes("num_inputs=2"));
+  assert(err.message.includes("num_neurons=1"));
+});
+
+Deno.test("Issue #2643: assertWasmBinaryWellFormed rejects body short of declared neurons", () => {
+  // Header declares 1 non-input neuron, but body has 0 bytes.
+  const data = buildBinary(3, 2, new Uint8Array(0));
+  const err = assertThrows(
+    () => assertWasmBinaryWellFormed(data),
+    WasmError,
+  );
+  assert(
+    err.message.includes("too short for neuron"),
+    `expected short-neuron message, got: ${err.message}`,
+  );
+});
+
+Deno.test("Issue #2643: assertWasmBinaryWellFormed rejects over-declared num_synapses", () => {
+  // Neuron header declares 5 synapses but body has none.
+  const body = new Uint8Array(12);
+  const view = new DataView(body.buffer);
+  view.setUint16(10, 5, true); // num_synapses = 5
+  const data = buildBinary(3, 2, body);
+  const err = assertThrows(
+    () => assertWasmBinaryWellFormed(data),
+    WasmError,
+  );
+  assert(
+    err.message.includes("too short for synapse"),
+    `expected short-synapse message, got: ${err.message}`,
+  );
+});
+
+Deno.test("Issue #2643: assertWasmBinaryWellFormed tolerates out-of-range from_index (runtime trap path)", () => {
+  // Synapse from_index = 99 but num_neurons = 3. The Rust decoder accepts
+  // this and lets the trap surface at activate time — see Issue #2146/#2484
+  // (`ACTIVATION_FAILED` recovery). The validator must not pre-empt that
+  // path, otherwise those tests change semantics.
+  const body = new Uint8Array(12 + 12);
+  const view = new DataView(body.buffer);
+  view.setUint16(10, 1, true); // num_synapses = 1
+  view.setUint16(12, 99, true); // from_index = 99 (out of range)
+  const data = buildBinary(3, 2, body);
+  // Must NOT throw.
+  assertWasmBinaryWellFormed(data);
+});
+
+Deno.test("Issue #2643: assertWasmBinaryWellFormed rejects trailing bytes after declared shape", () => {
+  // Declared shape consumes 8 + 12 = 20 bytes, but buffer is 24.
+  const body = new Uint8Array(12 + 4); // one neuron header + 4 stray bytes
+  const data = buildBinary(3, 2, body);
+  const err = assertThrows(
+    () => assertWasmBinaryWellFormed(data),
+    WasmError,
+  );
+  assert(
+    err.message.includes("consumes 20 bytes"),
+    `expected trailing-byte message, got: ${err.message}`,
+  );
+});


### PR DESCRIPTION
# Issue #2643 — Producer-side rejection of malformed WASM creature blobs

## Summary

Fixes #2643. GRQ-7 logs (NEAT-AI 5.0.1) recorded 1056 strikes of
`Data too short for neuron` during evolve at the constant shape
`inputs=2054, outputs=3` with varying neuron counts (2106, 2122, 2141, 2155,
2194, 2214, 2234, 2273, …). The downstream call-site recovery (#2483)
dropped the offspring, but the producer had already spent compute on a
genome the WASM constructor cannot decode.

The fix adds a producer-side byte-walk that mirrors the NEAT-AI-core decoder
in `neat-core/src/network.rs::CompiledNetwork::new`. Any blob that would
trip `Data too short for header`, `Data too short for neuron`,
`Data too short for synapse`, or the unsigned `num_non_inputs` underflow
(`num_inputs > num_neurons`) is rejected at serialise time before WASM ever
sees it. The existing producer compile gate (#2636) catches the throw and
reverts the offending mutation / drops the offspring.

Three serialiser entry points now run the check:

- `compileCreatureToWasm` (`src/wasm/CompileToWasm.ts`) — object-based path.
- `TypedTopology.toWasmBinary` (`src/architecture/TypedTopology.ts`) — typed-array path.
- `WasmCompilationCacheImpl.buildTemplate` (`src/wasm/WasmCompilationCache.ts`) — cache template path.

A header-drift fast-path also rejects `num_inputs > num_neurons` up-front so
the producer surfaces a typed `WasmError` instead of a `RangeError` from a
negative `ArrayBuffer` size.

## Evidence

This is a backend / library change — no UI. Acceptance criteria are covered
by `test/wasm/WasmBinaryValidator.ts`:

1. **Strike-shape regression** — builds a creature matching the canonical
   GRQ-7 strike shape (`neurons=2106, inputs=2054, outputs=3`) via the real
   producer path (`AddNeuron.mutate()`), then asserts the blob round-trips
   through `compileCreatureToWasm` → `WasmCreatureActivation.create` AND
   through the producer compile gate (`ensureProducerOutputCompiles`).
2. **Header-drift rejection** — corrupts `creature.input` so it exceeds
   `creature.neurons.length` and asserts `compileCreatureToWasm` throws a
   typed `WasmError(COMPILATION_FAILED)` *before* the bytes reach WASM.
3. **Byte-level validator unit tests** — direct probes against every Rust
   decoder failure mode: short header, `num_inputs > num_neurons`, short
   body, over-declared `num_synapses`, and trailing bytes. Plus a control
   that an out-of-range `from_index` is *not* pre-empted, so the existing
   `ACTIVATION_FAILED` recovery (#2146 / #2484) keeps working.

Producer / consumer flow after the fix:

```mermaid
flowchart LR
    A[Mutator / Offspring.breed] --> B[creature.fix]
    B --> C[compileCreatureToWasm / toWasmBinary / buildTemplate]
    C -->|assertWasmBinaryWellFormed| D{well-formed?}
    D -- no --> E[WasmError COMPILATION_FAILED]
    E --> F[ensureProducerOutputCompiles ok=false]
    F --> G[revert mutation / drop offspring]
    D -- yes --> H[WasmCreatureActivation.create]
    H --> I[activate / score]
```

Targeted test run:

```text
running 10 tests from ./test/wasm/WasmBinaryValidator.ts
... 10 passed | 0 failed (374ms)

running 6 tests from ./test/wasm/WasmCompileFailureRecovery.ts
running 2 tests from ./test/wasm/WasmInstantiationFailure.ts
running 3 tests from ./test/wasm/WasmCreatureActivationTrapGuard.ts
21 passed | 0 failed (417ms)

deno test test/wasm/*.ts → 504 passed | 0 failed | 1 ignored (6s)
```

Full suite: `6662 passed | 2 failed | 4 ignored` — the two failures are
pre-existing `DiscoveryTimeout` dynamic-library-leak tests, unrelated to
this change (verified by re-running them against `origin/Develop` before
applying the diff).

## Test Plan

- New `test/wasm/WasmBinaryValidator.ts` (10 tests):
  - GRQ-7 strike-shape round-trip through `compileCreatureToWasm`.
  - GRQ-7 strike-shape round-trip through `ensureProducerOutputCompiles`.
  - Header-drift rejection by `compileCreatureToWasm`.
  - 7 byte-level validator probes covering every decoder failure mode.
- Existing recovery tests still pass unchanged
  (`WasmCompileFailureRecovery.ts`, `WasmInstantiationFailure.ts`,
  `WasmCreatureActivationTrapGuard.ts`, `ProducerCompileGuard.ts`).



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2643 -->