### PR TITLE
evolveRL milestones should include the final generation even when it falls between milestones (Issue #2647)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -49,6 +49,7 @@
     "Behavior",
     "Behavioral",
     "Bengio",
+    "Sched",
     "bootstrappable",
     "Bergstra",
     "Birkhoff",

--- a/docs/pr-summary-2647.md
+++ b/docs/pr-summary-2647.md
@@ -1,11 +1,10 @@
 ## Summary
 
 `Creature.evolveRL()` (with `statistics: true`) now appends a synthetic
-final-generation milestone whenever a run terminates between two
-scheduled milestones (e.g. `targetError` met at generation 47, or
-`iterations = 7`). The synthetic milestone carries the same payload
-shape as the scheduled ones — no new fields — so callers, charts, and
-resume helpers can rely on
+final-generation milestone whenever a run terminates between two scheduled
+milestones (e.g. `targetError` met at generation 47, or `iterations = 7`). The
+synthetic milestone carries the same payload shape as the scheduled ones — no
+new fields — so callers, charts, and resume helpers can rely on
 `result.milestones[result.milestones.length - 1].generation === result.generation`.
 Closes #2647.
 
@@ -14,10 +13,10 @@ Closes #2647.
 Backend-only change with no UI. Verified by two new unit tests under
 `test/creature/EvolveRLStatistics_test.ts`:
 
-- `iterations = 7` → milestones at generations `[1, 2, 5, 7]` (synthetic
-  final milestone appended).
-- `iterations = 10` → milestones at `[1, 2, 5, 10]` (terminal generation
-  already on the schedule — no duplicate appended).
+- `iterations = 7` → milestones at generations `[1, 2, 5, 7]` (synthetic final
+  milestone appended).
+- `iterations = 10` → milestones at `[1, 2, 5, 10]` (terminal generation already
+  on the schedule — no duplicate appended).
 
 ```mermaid
 flowchart LR
@@ -45,18 +44,18 @@ flowchart LR
 
 - `test/creature/EvolveRLStatistics_test.ts` — added:
   - `EvolveRLStatistics: on — synthetic final milestone when termination
-    falls between schedule entries` — drives `iterations = 7`, asserts the
-    milestone sequence is `[1, 2, 5, 7]`, the final milestone's
-    `generation` equals `result.generation`, and the payload shape is
-    intact (`bestNeurons ≥ 2`, finite `bestScore`, `meanEpisodeSteps = 1`,
-    finite non-negative `generationWallClockMs`). Also asserts the
-    synthetic milestone is emitted as an `evolverl_milestone` training
-    event with values matching the returned array entry.
+    falls between schedule entries`
+    — drives `iterations = 7`, asserts the milestone sequence is `[1, 2, 5, 7]`,
+    the final milestone's `generation` equals `result.generation`, and the
+    payload shape is intact (`bestNeurons ≥ 2`, finite `bestScore`,
+    `meanEpisodeSteps = 1`, finite non-negative `generationWallClockMs`). Also
+    asserts the synthetic milestone is emitted as an `evolverl_milestone`
+    training event with values matching the returned array entry.
   - `EvolveRLStatistics: on — no duplicate milestone when termination
-    lands on a schedule entry` — drives `iterations = 10`, asserts the
-    schedule entries `[1, 2, 5, 10]` are emitted exactly once and no
-    duplicate synthetic milestone is appended.
+    lands on a schedule entry`
+    — drives `iterations = 10`, asserts the schedule entries `[1, 2, 5, 10]` are
+    emitted exactly once and no duplicate synthetic milestone is appended.
 - Existing tests under `test/creature/EvolveRLStatistics_test.ts`,
   `test/creature/evolveRL_test.ts`, and
-  `test/creature/evolveRL_parallel_test.ts` continue to pass (22 passed,
-  0 failed in the evolveRL suites).
+  `test/creature/evolveRL_parallel_test.ts` continue to pass (22 passed, 0
+  failed in the evolveRL suites).

--- a/docs/pr-summary-2647.md
+++ b/docs/pr-summary-2647.md
@@ -1,0 +1,62 @@
+## Summary
+
+`Creature.evolveRL()` (with `statistics: true`) now appends a synthetic
+final-generation milestone whenever a run terminates between two
+scheduled milestones (e.g. `targetError` met at generation 47, or
+`iterations = 7`). The synthetic milestone carries the same payload
+shape as the scheduled ones — no new fields — so callers, charts, and
+resume helpers can rely on
+`result.milestones[result.milestones.length - 1].generation === result.generation`.
+Closes #2647.
+
+## Evidence
+
+Backend-only change with no UI. Verified by two new unit tests under
+`test/creature/EvolveRLStatistics_test.ts`:
+
+- `iterations = 7` → milestones at generations `[1, 2, 5, 7]` (synthetic
+  final milestone appended).
+- `iterations = 10` → milestones at `[1, 2, 5, 10]` (terminal generation
+  already on the schedule — no duplicate appended).
+
+```mermaid
+flowchart LR
+    Loop["per-generation loop<br/>(consumes stats on schedule hits)"]
+    Sched["schedule hit?<br/>(1, 2, 5, 10, …)"]
+    Emit["emit milestone +<br/>training event"]
+    Cache["cache final<br/>generation snapshot<br/>(fittest, startMs, now)"]
+    Exit["loop exits<br/>(targetError / timeout /<br/>iterations / SIGTERM)"]
+    Tail["last milestone.generation<br/>== result.generation?"]
+    Synthetic["append synthetic<br/>final milestone +<br/>training event"]
+    Done["return milestones"]
+
+    Loop --> Cache
+    Loop --> Sched
+    Sched -- "yes" --> Emit
+    Emit --> Loop
+    Sched -- "no" --> Loop
+    Loop --> Exit
+    Exit --> Tail
+    Tail -- "yes" --> Done
+    Tail -- "no" --> Synthetic --> Done
+```
+
+## Test Plan
+
+- `test/creature/EvolveRLStatistics_test.ts` — added:
+  - `EvolveRLStatistics: on — synthetic final milestone when termination
+    falls between schedule entries` — drives `iterations = 7`, asserts the
+    milestone sequence is `[1, 2, 5, 7]`, the final milestone's
+    `generation` equals `result.generation`, and the payload shape is
+    intact (`bestNeurons ≥ 2`, finite `bestScore`, `meanEpisodeSteps = 1`,
+    finite non-negative `generationWallClockMs`). Also asserts the
+    synthetic milestone is emitted as an `evolverl_milestone` training
+    event with values matching the returned array entry.
+  - `EvolveRLStatistics: on — no duplicate milestone when termination
+    lands on a schedule entry` — drives `iterations = 10`, asserts the
+    schedule entries `[1, 2, 5, 10]` are emitted exactly once and no
+    duplicate synthetic milestone is appended.
+- Existing tests under `test/creature/EvolveRLStatistics_test.ts`,
+  `test/creature/evolveRL_test.ts`, and
+  `test/creature/evolveRL_parallel_test.ts` continue to pass (22 passed,
+  0 failed in the evolveRL suites).

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -887,6 +887,10 @@ export interface EvolveRLOptions extends NeatOptions {
    * is returned as `milestones` on the run summary. Default `false` keeps
    * the collection cost (best-creature topology snapshot, per-episode step
    * counts) off the hot path.
+   *
+   * Issue #2647: when the run terminates between two scheduled milestones,
+   * a synthetic final-generation milestone is appended so the last entry of
+   * `milestones` always matches `result.generation`.
    */
   statistics?: boolean;
   /**
@@ -1053,6 +1057,58 @@ export async function evolveRL<S, A>(
   rlFitness.setStatisticsEnabled(statisticsEnabled);
   const milestones: EvolveRLMilestone[] = [];
 
+  /**
+   * Issue #2629 / #2647: build the milestone payload for the current
+   * generation, consuming and clearing the per-generation statistics
+   * accumulator. Hoisted into a closure so the loop body can emit on the
+   * geometric schedule and the post-loop tail can append a synthetic
+   * final-generation milestone using the same field semantics.
+   */
+  const buildMilestonePayload = (
+    fittest: Creature,
+    fittestScore: number,
+    generationStartMs: number,
+    nowMs: number,
+    gen: number,
+  ): EvolveRLMilestone => {
+    const stats = rlFitness.consumeGenerationStatistics();
+    // bestScore — prefer the fittest creature's tagged mean return so that
+    // elites which were not re-evaluated this generation still report a
+    // sensible value. Fall back to the in-generation best mean tracked by
+    // RLEpisodeFitness when no tag is present.
+    const meanRewardTag = getTag(fittest, "meanReward");
+    let milestoneBestScore: number;
+    if (meanRewardTag) {
+      const parsed = Number.parseFloat(meanRewardTag);
+      milestoneBestScore = Number.isFinite(parsed) ? parsed : fittestScore;
+    } else if (
+      stats !== undefined && Number.isFinite(stats.bestMeanReward)
+    ) {
+      milestoneBestScore = stats.bestMeanReward;
+    } else {
+      milestoneBestScore = fittestScore;
+    }
+    const meanEpisodeSteps = stats !== undefined && stats.episodeCount > 0
+      ? stats.totalSteps / stats.episodeCount
+      : 0;
+    return {
+      generation: gen,
+      bestScore: milestoneBestScore,
+      bestNeurons: fittest.neurons.length,
+      bestSynapses: fittest.synapses.length,
+      meanEpisodeSteps,
+      generationWallClockMs: nowMs - generationStartMs,
+    };
+  };
+
+  // Issue #2647: track the most recent generation's snapshot inputs so the
+  // post-loop tail can append a synthetic final-generation milestone when the
+  // run terminates between two scheduled milestones (e.g. iterations = 7).
+  let lastFittest: Creature | undefined;
+  let lastFittestScore = 0;
+  let lastGenerationStartMs = 0;
+  let lastNowMs = 0;
+
   // Empty worker pool: scoring runs inline. Discovery/training scheduling
   // becomes a no-op (the schedulers warn and bail when no workers are
   // available); breeding falls back to the main-thread path.
@@ -1150,38 +1206,28 @@ export async function evolveRL<S, A>(
       });
     }
 
+    // Issue #2647: remember the most recent generation's snapshot inputs so a
+    // synthetic final milestone can be built after the loop exits between
+    // scheduled milestones. Captured before the scheduled-milestone block
+    // because that block consumes the per-generation statistics accumulator.
+    if (statisticsEnabled) {
+      lastFittest = fittest;
+      lastFittestScore = fittestScore;
+      lastGenerationStartMs = generationStartMs;
+      lastNowMs = now;
+    }
+
     // Issue #2629: emit and accumulate the milestone payload exactly when the
     // schedule (geometric: 1, 2, 5, 10, …, 1000, 10_000, …) hits and statistics
     // were opted in.
     if (statisticsEnabled && isMilestoneGeneration(generation)) {
-      const stats = rlFitness.consumeGenerationStatistics();
-      // bestScore — prefer the fittest creature's tagged mean return so that
-      // elites which were not re-evaluated this generation still report a
-      // sensible value. Fall back to the in-generation best mean tracked by
-      // RLEpisodeFitness when no tag is present.
-      const meanRewardTag = getTag(fittest, "meanReward");
-      let bestScore: number;
-      if (meanRewardTag) {
-        const parsed = Number.parseFloat(meanRewardTag);
-        bestScore = Number.isFinite(parsed) ? parsed : fittestScore;
-      } else if (
-        stats !== undefined && Number.isFinite(stats.bestMeanReward)
-      ) {
-        bestScore = stats.bestMeanReward;
-      } else {
-        bestScore = fittestScore;
-      }
-      const meanEpisodeSteps = stats !== undefined && stats.episodeCount > 0
-        ? stats.totalSteps / stats.episodeCount
-        : 0;
-      const milestone: EvolveRLMilestone = {
+      const milestone = buildMilestonePayload(
+        fittest,
+        fittestScore,
+        generationStartMs,
+        now,
         generation,
-        bestScore,
-        bestNeurons: fittest.neurons.length,
-        bestSynapses: fittest.synapses.length,
-        meanEpisodeSteps,
-        generationWallClockMs: now - generationStartMs,
-      };
+      );
       milestones.push(milestone);
       emitTrainingEvent(config.onTrainingEvent, {
         kind: "evolverl_milestone",
@@ -1227,6 +1273,33 @@ export async function evolveRL<S, A>(
       // deno-lint-ignore no-await-in-loop
       await neat.awaitInFlightTasks();
     }
+  }
+
+  // Issue #2647: append a synthetic final-generation milestone when the run
+  // terminated between two scheduled milestones (e.g. `targetError` met or
+  // `timeoutMinutes` elapsed at a non-power-of-ten generation). Charts and
+  // resume helpers driven by `milestones` need the rightmost point to track
+  // `result.generation`; otherwise the last visible point is the previous
+  // scheduled milestone and downstream consumers see drift.
+  if (
+    statisticsEnabled &&
+    lastFittest !== undefined &&
+    (milestones.length === 0 ||
+      milestones[milestones.length - 1].generation !== generation)
+  ) {
+    const milestone = buildMilestonePayload(
+      lastFittest,
+      lastFittestScore,
+      lastGenerationStartMs,
+      lastNowMs,
+      generation,
+    );
+    milestones.push(milestone);
+    emitTrainingEvent(config.onTrainingEvent, {
+      kind: "evolverl_milestone",
+      timestamp: new Date().toISOString(),
+      ...milestone,
+    });
   }
 
   // Issue #2612: Terminate the parallel rollout pool, if any. When no

--- a/src/creature/EvolveRLStatistics.ts
+++ b/src/creature/EvolveRLStatistics.ts
@@ -14,6 +14,13 @@
  * the schedule sparsifies geometrically — only powers of ten (`10_000`,
  * `100_000`, …) qualify. This keeps the emit cadence roughly constant per
  * decade of training without flooding callers in long runs.
+ *
+ * Issue #2647: when a run terminates between two scheduled milestones (e.g.
+ * `targetError` met at generation 47, or `iterations = 7`), `evolveRL()`
+ * appends a synthetic final-generation milestone using the same payload shape
+ * so `result.milestones[result.milestones.length - 1].generation` always
+ * equals `result.generation`. Chart-builders and resume helpers can therefore
+ * trust the rightmost milestone to track the actual termination generation.
  */
 
 /**

--- a/test/creature/EvolveRLStatistics_test.ts
+++ b/test/creature/EvolveRLStatistics_test.ts
@@ -217,3 +217,112 @@ Deno.test("EvolveRLStatistics: on — events at exactly 1, 2, 5, 10, 20, 50 over
     assertEquals(ret.generationWallClockMs, evt.generationWallClockMs);
   }
 });
+
+// ---------------------------------------------------------------------------
+// 6. Issue #2647: synthetic final-generation milestone when the run terminates
+// between two scheduled milestones.
+// ---------------------------------------------------------------------------
+
+Deno.test("EvolveRLStatistics: on — synthetic final milestone when termination falls between schedule entries", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new SingleTickAdapter();
+  const milestoneEvents: Extract<
+    TrainingEvent,
+    { kind: "evolverl_milestone" }
+  >[] = [];
+
+  const result = await creature.evolveRL(adapter, {
+    iterations: 7,
+    populationSize: 4,
+    targetError: 0,
+    seed: 1,
+    threads: 1,
+    episodesPerCreature: 1,
+    statistics: true,
+    onTrainingEvent: (event) => {
+      if (event.kind === "evolverl_milestone") milestoneEvents.push(event);
+    },
+  });
+
+  // Run completes its iteration cap. Generation 7 is not on the geometric
+  // schedule (1, 2, 5, 10, …) but must still appear as the terminal milestone.
+  assertEquals(result.generation, 7);
+  assertEquals(
+    milestoneEvents.map((e) => e.generation),
+    [1, 2, 5, 7],
+  );
+
+  // Invariant from Issue #2647: the last milestone tracks the terminal
+  // generation for every run that produced at least one milestone.
+  assert(result.milestones !== undefined, "milestones must be present");
+  assertEquals(result.milestones!.length, milestoneEvents.length);
+  const finalMilestone = result.milestones![result.milestones!.length - 1];
+  assertEquals(finalMilestone.generation, result.generation);
+
+  // Synthetic milestone carries the same payload shape as the scheduled ones —
+  // no new fields, all values finite, topology counts sane.
+  assertEquals(typeof finalMilestone.bestScore, "number");
+  assert(Number.isFinite(finalMilestone.bestScore));
+  assert(
+    finalMilestone.bestNeurons >= 2,
+    `bestNeurons too small: ${finalMilestone.bestNeurons}`,
+  );
+  assert(finalMilestone.bestSynapses >= 0);
+  assertEquals(finalMilestone.meanEpisodeSteps, 1);
+  assert(Number.isFinite(finalMilestone.generationWallClockMs));
+  assert(finalMilestone.generationWallClockMs >= 0);
+
+  // The synthetic milestone is also emitted as an `evolverl_milestone`
+  // training event so chart-builders driven by the event stream see the
+  // terminal generation too.
+  const lastEvent = milestoneEvents[milestoneEvents.length - 1];
+  assertEquals(lastEvent.generation, result.generation);
+  assertEquals(lastEvent.bestScore, finalMilestone.bestScore);
+  assertEquals(lastEvent.bestNeurons, finalMilestone.bestNeurons);
+  assertEquals(lastEvent.bestSynapses, finalMilestone.bestSynapses);
+  assertEquals(lastEvent.meanEpisodeSteps, finalMilestone.meanEpisodeSteps);
+  assertEquals(
+    lastEvent.generationWallClockMs,
+    finalMilestone.generationWallClockMs,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 7. Issue #2647: when the terminal generation IS already a scheduled
+// milestone (e.g. iterations = 10), no duplicate is appended.
+// ---------------------------------------------------------------------------
+
+Deno.test("EvolveRLStatistics: on — no duplicate milestone when termination lands on a schedule entry", async () => {
+  const creature = new Creature(1, 1);
+  const adapter = new SingleTickAdapter();
+  const milestoneEvents: Extract<
+    TrainingEvent,
+    { kind: "evolverl_milestone" }
+  >[] = [];
+
+  const result = await creature.evolveRL(adapter, {
+    iterations: 10,
+    populationSize: 4,
+    targetError: 0,
+    seed: 1,
+    threads: 1,
+    episodesPerCreature: 1,
+    statistics: true,
+    onTrainingEvent: (event) => {
+      if (event.kind === "evolverl_milestone") milestoneEvents.push(event);
+    },
+  });
+
+  assertEquals(result.generation, 10);
+  // Schedule entries in [1, 10] only — no duplicate 10 appended.
+  assertEquals(
+    milestoneEvents.map((e) => e.generation),
+    [1, 2, 5, 10],
+  );
+  assert(result.milestones !== undefined);
+  assertEquals(result.milestones!.length, 4);
+  assertEquals(
+    result.milestones![result.milestones!.length - 1].generation,
+    result.generation,
+  );
+});


### PR DESCRIPTION
## Summary

`Creature.evolveRL()` (with `statistics: true`) now appends a synthetic
final-generation milestone whenever a run terminates between two
scheduled milestones (e.g. `targetError` met at generation 47, or
`iterations = 7`). The synthetic milestone carries the same payload
shape as the scheduled ones — no new fields — so callers, charts, and
resume helpers can rely on
`result.milestones[result.milestones.length - 1].generation === result.generation`.
Closes #2647.

## Evidence

Backend-only change with no UI. Verified by two new unit tests under
`test/creature/EvolveRLStatistics_test.ts`:

- `iterations = 7` → milestones at generations `[1, 2, 5, 7]` (synthetic
  final milestone appended).
- `iterations = 10` → milestones at `[1, 2, 5, 10]` (terminal generation
  already on the schedule — no duplicate appended).

```mermaid
flowchart LR
    Loop["per-generation loop<br/>(consumes stats on schedule hits)"]
    Sched["schedule hit?<br/>(1, 2, 5, 10, …)"]
    Emit["emit milestone +<br/>training event"]
    Cache["cache final<br/>generation snapshot<br/>(fittest, startMs, now)"]
    Exit["loop exits<br/>(targetError / timeout /<br/>iterations / SIGTERM)"]
    Tail["last milestone.generation<br/>== result.generation?"]
    Synthetic["append synthetic<br/>final milestone +<br/>training event"]
    Done["return milestones"]

    Loop --> Cache
    Loop --> Sched
    Sched -- "yes" --> Emit
    Emit --> Loop
    Sched -- "no" --> Loop
    Loop --> Exit
    Exit --> Tail
    Tail -- "yes" --> Done
    Tail -- "no" --> Synthetic --> Done
```

## Test Plan

- `test/creature/EvolveRLStatistics_test.ts` — added:
  - `EvolveRLStatistics: on — synthetic final milestone when termination
    falls between schedule entries` — drives `iterations = 7`, asserts the
    milestone sequence is `[1, 2, 5, 7]`, the final milestone's
    `generation` equals `result.generation`, and the payload shape is
    intact (`bestNeurons ≥ 2`, finite `bestScore`, `meanEpisodeSteps = 1`,
    finite non-negative `generationWallClockMs`). Also asserts the
    synthetic milestone is emitted as an `evolverl_milestone` training
    event with values matching the returned array entry.
  - `EvolveRLStatistics: on — no duplicate milestone when termination
    lands on a schedule entry` — drives `iterations = 10`, asserts the
    schedule entries `[1, 2, 5, 10]` are emitted exactly once and no
    duplicate synthetic milestone is appended.
- Existing tests under `test/creature/EvolveRLStatistics_test.ts`,
  `test/creature/evolveRL_test.ts`, and
  `test/creature/evolveRL_parallel_test.ts` continue to pass (22 passed,
  0 failed in the evolveRL suites).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2647 -->