### PR TITLE
fix(wasm): wrap raw activation traps as typed WasmError (#2658)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2658.md
+++ b/docs/pr-summary-2658.md
@@ -5,44 +5,44 @@
 Closes #2658.
 
 Long `Creature.evolveRL()` runs could still abort with a raw
-`RuntimeError: memory access out of bounds` after #2650 because the
-**topology** trap guard landed in `WasmTopologyOps.ts` did not cover the
-**activation** entry point. Calls into `WasmCreatureActivation.activate`,
-`activate_view`, `activate_into`, `activate_and_trace`, and the batch loss
-kernels sit behind `invalidateAfterWasmPanic`, which previously re-threw
-the raw WASM trap verbatim. That trap then propagated out of
+`RuntimeError: memory access out of bounds` after #2650 because the **topology**
+trap guard landed in `WasmTopologyOps.ts` did not cover the **activation** entry
+point. Calls into `WasmCreatureActivation.activate`, `activate_view`,
+`activate_into`, `activate_and_trace`, and the batch loss kernels sit behind
+`invalidateAfterWasmPanic`, which previously re-threw the raw WASM trap
+verbatim. That trap then propagated out of
 `creature.activate(observation, true)` inside the lunar-lander overnight
-driver's episode rollout, killing the whole `evolveRL` attempt instead of
-the single offending creature.
+driver's episode rollout, killing the whole `evolveRL` attempt instead of the
+single offending creature.
 
-This PR pushes the same trap-guard pattern down into
-`invalidateAfterWasmPanic`: a non-`WasmError` throwable is now converted
-into a typed `WasmError("ACTIVATION_FAILED")` with the original trap
-attached via `Error.cause`. Pre-existing `WasmError`s (the `freed`
-check, input/output length checks) still propagate untouched, so the
-existing recovery paths in `activateWasm` / `activateAndTraceWasm`
-(Issue #2146) keep their fine-grained messages. The wrapper means
-`activateEphemeral` and any other caller that talks to
-`WasmCreatureActivation` directly is now also protected — defence in
-depth at the WASM boundary.
+This PR pushes the same trap-guard pattern down into `invalidateAfterWasmPanic`:
+a non-`WasmError` throwable is now converted into a typed
+`WasmError("ACTIVATION_FAILED")` with the original trap attached via
+`Error.cause`. Pre-existing `WasmError`s (the `freed` check, input/output length
+checks) still propagate untouched, so the existing recovery paths in
+`activateWasm` / `activateAndTraceWasm` (Issue #2146) keep their fine-grained
+messages. The wrapper means `activateEphemeral` and any other caller that talks
+to `WasmCreatureActivation` directly is now also protected — defence in depth at
+the WASM boundary.
 
-The `WasmError` constructor was widened to accept the standard
-`ErrorOptions` (specifically `cause`) so diagnostics can still inspect
-the underlying `RuntimeError`.
+The `WasmError` constructor was widened to accept the standard `ErrorOptions`
+(specifically `cause`) so diagnostics can still inspect the underlying
+`RuntimeError`.
 
 ## Evidence
 
 Backend / library change — no UI to screenshot. Verified by:
 
-- 8 new TDD tests in `test/wasm/WasmActivationTrapGuardIssue2658.ts`
-  exercising the trap surface for each public `WasmCreatureActivation`
-  entry point plus the `activateEphemeral` wrapper. Pre-fix, all 7 trap
-  cases failed with `Expected error to be instance of "WasmError", but
-  was "RuntimeError"`; post-fix, all 8 pass.
-- 528 tests across `test/wasm/` and 391 tests across
-  `test/breed/` + `test/errors/` continue to pass with the change in
-  place, confirming no regression to existing `WasmError`
-  surfaces (`freed`, input-length, output-length, MODULE_NOT_LOADED).
+- 8 new TDD tests in `test/wasm/WasmActivationTrapGuardIssue2658.ts` exercising
+  the trap surface for each public `WasmCreatureActivation` entry point plus the
+  `activateEphemeral` wrapper. Pre-fix, all 7 trap cases failed with
+  `Expected error to be instance of "WasmError", but
+  was "RuntimeError"`;
+  post-fix, all 8 pass.
+- 528 tests across `test/wasm/` and 391 tests across `test/breed/` +
+  `test/errors/` continue to pass with the change in place, confirming no
+  regression to existing `WasmError` surfaces (`freed`, input-length,
+  output-length, MODULE_NOT_LOADED).
 - `./quality.sh --lint-only` and `./quality.sh --check-only` both pass.
 
 Trap-flow before / after:
@@ -59,21 +59,20 @@ flowchart LR
 
 ## Test Plan
 
-- Added `test/wasm/WasmActivationTrapGuardIssue2658.ts` with the
-  following tests, each driving a real WASM trap via a creature whose
-  synapses point at a non-existent `from` neuron index:
+- Added `test/wasm/WasmActivationTrapGuardIssue2658.ts` with the following
+  tests, each driving a real WASM trap via a creature whose synapses point at a
+  non-existent `from` neuron index:
   - `activate() surfaces WASM trap as typed WasmError`
   - `activateView() surfaces WASM trap as typed WasmError`
   - `activateInto() surfaces WASM trap as typed WasmError`
   - `activateWithState() surfaces WASM trap as typed WasmError`
   - `activateAndTrace() surfaces WASM trap as typed WasmError`
   - `wrapped WasmError preserves the original trap via Error.cause`
-  - `input-length WasmError still propagates with original reason`
-    (regression guard: pre-flight `WasmError`s must not be re-wrapped)
-  - `activateEphemeral surfaces WASM trap as typed WasmError`
-    (covers the higher-level wrapper that previously bypassed the
-    `activateWasm` try/catch)
+  - `input-length WasmError still propagates with original reason` (regression
+    guard: pre-flight `WasmError`s must not be re-wrapped)
+  - `activateEphemeral surfaces WASM trap as typed WasmError` (covers the
+    higher-level wrapper that previously bypassed the `activateWasm` try/catch)
 - Existing `test/wasm/WasmActivationErrors.ts`,
   `test/wasm/EphemeralActivation.ts`, and
-  `test/wasm/WasmCompileFailureRecovery.ts` continue to pass —
-  `freed` / length-mismatch `WasmError`s are preserved.
+  `test/wasm/WasmCompileFailureRecovery.ts` continue to pass — `freed` /
+  length-mismatch `WasmError`s are preserved.

--- a/docs/pr-summary-2658.md
+++ b/docs/pr-summary-2658.md
@@ -1,0 +1,79 @@
+# PR Summary — Issue #2658
+
+## Summary
+
+Closes #2658.
+
+Long `Creature.evolveRL()` runs could still abort with a raw
+`RuntimeError: memory access out of bounds` after #2650 because the
+**topology** trap guard landed in `WasmTopologyOps.ts` did not cover the
+**activation** entry point. Calls into `WasmCreatureActivation.activate`,
+`activate_view`, `activate_into`, `activate_and_trace`, and the batch loss
+kernels sit behind `invalidateAfterWasmPanic`, which previously re-threw
+the raw WASM trap verbatim. That trap then propagated out of
+`creature.activate(observation, true)` inside the lunar-lander overnight
+driver's episode rollout, killing the whole `evolveRL` attempt instead of
+the single offending creature.
+
+This PR pushes the same trap-guard pattern down into
+`invalidateAfterWasmPanic`: a non-`WasmError` throwable is now converted
+into a typed `WasmError("ACTIVATION_FAILED")` with the original trap
+attached via `Error.cause`. Pre-existing `WasmError`s (the `freed`
+check, input/output length checks) still propagate untouched, so the
+existing recovery paths in `activateWasm` / `activateAndTraceWasm`
+(Issue #2146) keep their fine-grained messages. The wrapper means
+`activateEphemeral` and any other caller that talks to
+`WasmCreatureActivation` directly is now also protected — defence in
+depth at the WASM boundary.
+
+The `WasmError` constructor was widened to accept the standard
+`ErrorOptions` (specifically `cause`) so diagnostics can still inspect
+the underlying `RuntimeError`.
+
+## Evidence
+
+Backend / library change — no UI to screenshot. Verified by:
+
+- 8 new TDD tests in `test/wasm/WasmActivationTrapGuardIssue2658.ts`
+  exercising the trap surface for each public `WasmCreatureActivation`
+  entry point plus the `activateEphemeral` wrapper. Pre-fix, all 7 trap
+  cases failed with `Expected error to be instance of "WasmError", but
+  was "RuntimeError"`; post-fix, all 8 pass.
+- 528 tests across `test/wasm/` and 391 tests across
+  `test/breed/` + `test/errors/` continue to pass with the change in
+  place, confirming no regression to existing `WasmError`
+  surfaces (`freed`, input-length, output-length, MODULE_NOT_LOADED).
+- `./quality.sh --lint-only` and `./quality.sh --check-only` both pass.
+
+Trap-flow before / after:
+
+```mermaid
+flowchart LR
+    A[Creature.activate] --> B[activateWasm / activateEphemeral]
+    B --> C[WasmCreatureActivation.activate]
+    C --> D{WASM kernel}
+    D -->|trap| E[invalidateAfterWasmPanic]
+    E -->|before #2658| F[raw RuntimeError<br/>memory access out of bounds<br/>aborts evolveRL]
+    E -->|after #2658| G[WasmError ACTIVATION_FAILED<br/>drop or repair creature<br/>evolveRL continues]
+```
+
+## Test Plan
+
+- Added `test/wasm/WasmActivationTrapGuardIssue2658.ts` with the
+  following tests, each driving a real WASM trap via a creature whose
+  synapses point at a non-existent `from` neuron index:
+  - `activate() surfaces WASM trap as typed WasmError`
+  - `activateView() surfaces WASM trap as typed WasmError`
+  - `activateInto() surfaces WASM trap as typed WasmError`
+  - `activateWithState() surfaces WASM trap as typed WasmError`
+  - `activateAndTrace() surfaces WASM trap as typed WasmError`
+  - `wrapped WasmError preserves the original trap via Error.cause`
+  - `input-length WasmError still propagates with original reason`
+    (regression guard: pre-flight `WasmError`s must not be re-wrapped)
+  - `activateEphemeral surfaces WASM trap as typed WasmError`
+    (covers the higher-level wrapper that previously bypassed the
+    `activateWasm` try/catch)
+- Existing `test/wasm/WasmActivationErrors.ts`,
+  `test/wasm/EphemeralActivation.ts`, and
+  `test/wasm/WasmCompileFailureRecovery.ts` continue to pass —
+  `freed` / length-mismatch `WasmError`s are preserved.

--- a/src/errors/WasmError.ts
+++ b/src/errors/WasmError.ts
@@ -16,8 +16,19 @@ export class WasmError extends Error {
   override readonly name = "WasmError";
   readonly reason: WasmErrorReason;
 
-  constructor(message: string, reason: WasmErrorReason) {
-    super(message);
+  /**
+   * @param message Human-readable description of the failure.
+   * @param reason Programmatic discriminator for the failure mode.
+   * @param options Optional standard `ErrorOptions`; `cause` is preserved so
+   *   downstream diagnostics can still inspect the underlying trap (Issue
+   *   #2658).
+   */
+  constructor(
+    message: string,
+    reason: WasmErrorReason,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
     this.reason = reason;
   }
 }

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -115,15 +115,37 @@ export class WasmCreatureActivation {
   /**
    * Issue #2207: Invalidate this activation after a WASM panic.
    *
-   * When WASM traps (RuntimeError: unreachable), the Rust borrow counter
-   * may not be decremented, leaving the CompiledNetwork in a permanently
-   * borrowed state. Mark the activation as freed so no further operations
-   * are attempted, and release the JS reference for GC.
+   * When WASM traps (RuntimeError: unreachable, RuntimeError: memory access
+   * out of bounds), the Rust borrow counter may not be decremented, leaving
+   * the CompiledNetwork in a permanently borrowed state. Mark the activation
+   * as freed so no further operations are attempted, and release the JS
+   * reference for GC.
+   *
+   * Issue #2658: Convert any non-`WasmError` throwable (typically a raw
+   * `RuntimeError` produced by the WASM kernel) into a typed
+   * `WasmError("ACTIVATION_FAILED")`. This mirrors the
+   * `withWasmTrapGuard` pattern landed in #2648/#2650 for the topology
+   * entry points: a long `evolveRL` run should drop the offending creature
+   * via a typed error instead of crashing the whole run with an unhandled
+   * WASM trap surfacing from `creature.activate`. Existing `WasmError`s
+   * (pre-flight `freed` / input-length checks) propagate untouched.
    */
   private invalidateAfterWasmPanic(error: unknown): never {
     this.network = undefined as unknown as WasmCompiledNetwork;
     this.freed = true;
-    throw error;
+    if (error instanceof WasmError) {
+      throw error;
+    }
+    const message = error instanceof Error
+      ? `${error.name}: ${error.message}`
+      : String(error);
+    throw new WasmError(
+      `WASM activation trapped (${message}). The creature is malformed; ` +
+        `the caller should drop or repair it instead of crashing the ` +
+        `evolution run.`,
+      "ACTIVATION_FAILED",
+      { cause: error },
+    );
   }
 
   /**

--- a/test/wasm/WasmActivationTrapGuardIssue2658.ts
+++ b/test/wasm/WasmActivationTrapGuardIssue2658.ts
@@ -1,0 +1,228 @@
+/**
+ * Issue #2658 — Activation-path WASM trap guard.
+ *
+ * Background:
+ *
+ *   Issue #2648/#2650 wrapped the WASM **topology** entry points
+ *   (`validateTopology`, `validateStructuralIntegrity`, ...) in
+ *   `withWasmTrapGuard`, so a malformed creature surfaces as a typed
+ *   `TopologyError` during breeding instead of crashing `evolveRL` with a
+ *   raw `RuntimeError: memory access out of bounds`.
+ *
+ *   Issue #2658 audits the remaining WASM entry points reached from
+ *   `evolveRL` — specifically the **activation** path
+ *   (`WasmCreatureActivation.activate`, `activate_view`, `activate_into`,
+ *   `activate_and_trace`, the standalone batch loss kernels). Those calls
+ *   sit behind `invalidateAfterWasmPanic`, which currently re-throws the
+ *   raw `RuntimeError` verbatim. Production logs from the lunar-lander
+ *   overnight driver still see `RuntimeError: memory access out of bounds`
+ *   surface from inside an `evolveRL` run, terminating the run before the
+ *   next generation can be scored.
+ *
+ *   These tests pin the contract: every `WasmCreatureActivation.activate*`
+ *   call MUST surface a WASM trap as a typed `WasmError` with reason
+ *   `ACTIVATION_FAILED` so the surrounding training loop can drop the
+ *   creature instead of crashing the whole run. The same guarantee must
+ *   hold for the higher-level `activateEphemeral` wrapper, because it
+ *   bypasses the `activateWasm` try/catch (Issue #2146) by talking to
+ *   `WasmCreatureActivation` directly.
+ *
+ *   The trap is reproduced by feeding `WasmCreatureActivation` a creature
+ *   whose synapses point at a non-existent `from` neuron index — the
+ *   binary compiles cleanly but the WASM activation kernel traps the
+ *   moment it tries to read past the activation array. This is the same
+ *   technique `WasmCompileFailureRecovery.ts` (Issue #2483) uses to drive
+ *   `activateWasm` into its existing recovery path; here we drive the
+ *   raw `WasmCreatureActivation` API directly to prove the guard sits at
+ *   the right layer.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import { WasmError } from "@errors/WasmError.ts";
+import { activateEphemeral } from "@creature/CreatureActivation.ts";
+import { WasmCreatureActivation } from "@wasm/WasmActivation.ts";
+import { compileCreatureToWasm } from "@wasm/CompileToWasm.ts";
+import { initWasmActivation } from "@wasm/WasmModuleLoader.ts";
+
+await initWasmActivation();
+
+/**
+ * Build a 2-input / 1-output creature whose synapses all point at neuron
+ * index 9999. Compilation succeeds (the binary is structurally well-formed
+ * — the indices fit in a `u16`) but every activation traps in the WASM
+ * kernel when it tries to read past the activation array.
+ */
+function createTrappingCreature(): Creature {
+  const creature = new Creature(2, 1);
+  creature.fix();
+  for (const synapse of creature.synapses) {
+    synapse.from = 9999;
+  }
+  creature.clearCache();
+  creature.cachedWasmActivation = undefined;
+  return creature;
+}
+
+function createTrappingActivation(): WasmCreatureActivation {
+  const creature = createTrappingCreature();
+  const compiled = compileCreatureToWasm(creature);
+  const activation = WasmCreatureActivation.create(compiled);
+  if (!activation) {
+    throw new Error(
+      "Test setup: trapping creature should still compile cleanly; " +
+        "the activation kernel — not the constructor — is the trap site.",
+    );
+  }
+  return activation;
+}
+
+// ---------------------------------------------------------------------------
+// WasmCreatureActivation direct API — the lowest WASM-bridge layer.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "Issue #2658: activate() surfaces WASM trap as typed WasmError",
+  () => {
+    const activation = createTrappingActivation();
+    const err = assertThrows(
+      () => activation.activate(new Float32Array([0.1, 0.2])),
+      WasmError,
+      undefined,
+      "WasmCreatureActivation.activate must convert WASM trap to WasmError, " +
+        "not propagate the raw RuntimeError",
+    );
+    assertEquals((err as WasmError).reason, "ACTIVATION_FAILED");
+  },
+);
+
+Deno.test(
+  "Issue #2658: activateView() surfaces WASM trap as typed WasmError",
+  () => {
+    const activation = createTrappingActivation();
+    const err = assertThrows(
+      () => activation.activateView(new Float32Array([0.1, 0.2])),
+      WasmError,
+    );
+    assertEquals((err as WasmError).reason, "ACTIVATION_FAILED");
+  },
+);
+
+Deno.test(
+  "Issue #2658: activateInto() surfaces WASM trap as typed WasmError",
+  () => {
+    const activation = createTrappingActivation();
+    const err = assertThrows(
+      () =>
+        activation.activateInto(
+          new Float32Array([0.1, 0.2]),
+          new Float32Array(1),
+        ),
+      WasmError,
+    );
+    assertEquals((err as WasmError).reason, "ACTIVATION_FAILED");
+  },
+);
+
+Deno.test(
+  "Issue #2658: activateWithState() surfaces WASM trap as typed WasmError",
+  () => {
+    const activation = createTrappingActivation();
+    const err = assertThrows(
+      () => activation.activateWithState(new Float32Array([0.1, 0.2]), false),
+      WasmError,
+    );
+    assertEquals((err as WasmError).reason, "ACTIVATION_FAILED");
+  },
+);
+
+Deno.test(
+  "Issue #2658: activateAndTrace() surfaces WASM trap as typed WasmError",
+  () => {
+    const activation = createTrappingActivation();
+    const err = assertThrows(
+      () => activation.activateAndTrace(new Float32Array([0.1, 0.2])),
+      WasmError,
+    );
+    assertEquals((err as WasmError).reason, "ACTIVATION_FAILED");
+  },
+);
+
+Deno.test(
+  "Issue #2658: wrapped WasmError preserves the original trap via Error.cause",
+  () => {
+    const activation = createTrappingActivation();
+    let caught: unknown;
+    try {
+      activation.activate(new Float32Array([0.1, 0.2]));
+    } catch (e) {
+      caught = e;
+    }
+    if (!(caught instanceof WasmError)) {
+      throw new Error("expected WasmError");
+    }
+    // The cause is the original RuntimeError trap; the message preserves
+    // the trap text so diagnostics remain observable.
+    if (caught.cause === undefined) {
+      throw new Error(
+        "WasmError must attach the original trap as .cause so diagnostics " +
+          "can inspect the underlying RuntimeError",
+      );
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Pre-existing WasmError surfaces (input length, freed) keep propagating
+// untouched — we are only converting raw RuntimeError traps.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "Issue #2658: input-length WasmError still propagates with original reason",
+  () => {
+    const activation = createTrappingActivation();
+    try {
+      // Wrong input length — pre-flight check throws WasmError before the
+      // WASM call. The trap guard must not stomp on the message.
+      const err = assertThrows(
+        () => activation.activate(new Float32Array([0.5])),
+        WasmError,
+      );
+      // The pre-flight error message describes the length mismatch.
+      // It must not be replaced with a generic "WASM activation failed" wrap.
+      if (!(err as WasmError).message.includes("Input length")) {
+        throw new Error(
+          `expected pre-flight length message, got: ${
+            (err as WasmError).message
+          }`,
+        );
+      }
+    } finally {
+      activation.free();
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// activateEphemeral — the CreatureActivation.ts wrapper that previously
+// did NOT wrap the underlying activate call (only activateWasm did).
+// With the trap guard pushed down into WasmCreatureActivation, ephemeral
+// activation now also drops the offending creature cleanly.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "Issue #2658: activateEphemeral surfaces WASM trap as typed WasmError",
+  () => {
+    const creature = createTrappingCreature();
+    const err = assertThrows(
+      () => activateEphemeral(creature, new Float32Array([0.1, 0.2]), false),
+      WasmError,
+    );
+    assertEquals(
+      (err as WasmError).reason,
+      "ACTIVATION_FAILED",
+      "activateEphemeral must drop the creature via WasmError, " +
+        "not crash the surrounding evolveRL run with a raw RuntimeError",
+    );
+  },
+);


### PR DESCRIPTION
# PR Summary — Issue #2658

## Summary

Closes #2658.

Long `Creature.evolveRL()` runs could still abort with a raw
`RuntimeError: memory access out of bounds` after #2650 because the
**topology** trap guard landed in `WasmTopologyOps.ts` did not cover the
**activation** entry point. Calls into `WasmCreatureActivation.activate`,
`activate_view`, `activate_into`, `activate_and_trace`, and the batch loss
kernels sit behind `invalidateAfterWasmPanic`, which previously re-threw
the raw WASM trap verbatim. That trap then propagated out of
`creature.activate(observation, true)` inside the lunar-lander overnight
driver's episode rollout, killing the whole `evolveRL` attempt instead of
the single offending creature.

This PR pushes the same trap-guard pattern down into
`invalidateAfterWasmPanic`: a non-`WasmError` throwable is now converted
into a typed `WasmError("ACTIVATION_FAILED")` with the original trap
attached via `Error.cause`. Pre-existing `WasmError`s (the `freed`
check, input/output length checks) still propagate untouched, so the
existing recovery paths in `activateWasm` / `activateAndTraceWasm`
(Issue #2146) keep their fine-grained messages. The wrapper means
`activateEphemeral` and any other caller that talks to
`WasmCreatureActivation` directly is now also protected — defence in
depth at the WASM boundary.

The `WasmError` constructor was widened to accept the standard
`ErrorOptions` (specifically `cause`) so diagnostics can still inspect
the underlying `RuntimeError`.

## Evidence

Backend / library change — no UI to screenshot. Verified by:

- 8 new TDD tests in `test/wasm/WasmActivationTrapGuardIssue2658.ts`
  exercising the trap surface for each public `WasmCreatureActivation`
  entry point plus the `activateEphemeral` wrapper. Pre-fix, all 7 trap
  cases failed with `Expected error to be instance of "WasmError", but
  was "RuntimeError"`; post-fix, all 8 pass.
- 528 tests across `test/wasm/` and 391 tests across
  `test/breed/` + `test/errors/` continue to pass with the change in
  place, confirming no regression to existing `WasmError`
  surfaces (`freed`, input-length, output-length, MODULE_NOT_LOADED).
- `./quality.sh --lint-only` and `./quality.sh --check-only` both pass.

Trap-flow before / after:

```mermaid
flowchart LR
    A[Creature.activate] --> B[activateWasm / activateEphemeral]
    B --> C[WasmCreatureActivation.activate]
    C --> D{WASM kernel}
    D -->|trap| E[invalidateAfterWasmPanic]
    E -->|before #2658| F[raw RuntimeError<br/>memory access out of bounds<br/>aborts evolveRL]
    E -->|after #2658| G[WasmError ACTIVATION_FAILED<br/>drop or repair creature<br/>evolveRL continues]
```

## Test Plan

- Added `test/wasm/WasmActivationTrapGuardIssue2658.ts` with the
  following tests, each driving a real WASM trap via a creature whose
  synapses point at a non-existent `from` neuron index:
  - `activate() surfaces WASM trap as typed WasmError`
  - `activateView() surfaces WASM trap as typed WasmError`
  - `activateInto() surfaces WASM trap as typed WasmError`
  - `activateWithState() surfaces WASM trap as typed WasmError`
  - `activateAndTrace() surfaces WASM trap as typed WasmError`
  - `wrapped WasmError preserves the original trap via Error.cause`
  - `input-length WasmError still propagates with original reason`
    (regression guard: pre-flight `WasmError`s must not be re-wrapped)
  - `activateEphemeral surfaces WASM trap as typed WasmError`
    (covers the higher-level wrapper that previously bypassed the
    `activateWasm` try/catch)
- Existing `test/wasm/WasmActivationErrors.ts`,
  `test/wasm/EphemeralActivation.ts`, and
  `test/wasm/WasmCompileFailureRecovery.ts` continue to pass —
  `freed` / length-mismatch `WasmError`s are preserved.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2658 -->