### PR TITLE
fix(rl): drop creatures on WasmError instead of crashing worker (#2669)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.12",
+  "version": "5.0.13",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2669.md
+++ b/docs/pr-summary-2669.md
@@ -3,39 +3,38 @@
 ## Summary
 
 Fixes #2669. When a creature's topology traps the WASM loader, the WASM
-compilation cache already logs a single deduplicated line per offending
-uuid asking callers to *"drop the creature or repair its topology before
-retrying"* (Issue #2483 / #2649). The RL and legacy episodic fitness
-scorers were not honouring that contract — they only caught
-`ActivationError` in their per-trial loops, so a `WasmError` propagated
-all the way out of `RLEpisodeFitness.calculate` → `Neat.evolve` → the
-host script, killing the worker with an uncaught promise rejection
-(stack trace in the issue).
+compilation cache already logs a single deduplicated line per offending uuid
+asking callers to _"drop the creature or repair its topology before retrying"_
+(Issue #2483 / #2649). The RL and legacy episodic fitness scorers were not
+honouring that contract — they only caught `ActivationError` in their per-trial
+loops, so a `WasmError` propagated all the way out of
+`RLEpisodeFitness.calculate` → `Neat.evolve` → the host script, killing the
+worker with an uncaught promise rejection (stack trace in the issue).
 
-This change folds `WasmError` into the existing `ActivationError` catch
-branch in both scorers (`RLEpisodeFitness.collectTrialsInline`, the
-worker-pool path inside `RLEpisodeFitness.calculate`, and
-`EpisodicFitness.calculate`). The offending creature is dropped with
-`-Infinity` reward so natural selection removes it from the next
-generation. Non-typed errors (programming bugs) still propagate so they
-surface in CI.
+This change folds `WasmError` into the existing `ActivationError` catch branch
+in both scorers (`RLEpisodeFitness.collectTrialsInline`, the worker-pool path
+inside `RLEpisodeFitness.calculate`, and `EpisodicFitness.calculate`). The
+offending creature is dropped with `-Infinity` reward so natural selection
+removes it from the next generation. Non-typed errors (programming bugs) still
+propagate so they surface in CI.
 
-The pre-fix log line from the issue — `WASM compile failed for creature
-… Drop the creature or repair its topology before retrying` — is now
-followed by the scorer reporting the drop rather than the worker
+The pre-fix log line from the issue —
+`WASM compile failed for creature
+… Drop the creature or repair its topology before retrying`
+— is now followed by the scorer reporting the drop rather than the worker
 crashing.
 
 ## Evidence
 
-This is a CLI / library change with no UI surface. Behaviour is verified
-by three new tests that stub `creature.activate` to throw the exact
-`WasmError` reported in the issue, then assert that `calculate()`
-returns normally and the creature ends up with a non-finite score.
+This is a CLI / library change with no UI surface. Behaviour is verified by
+three new tests that stub `creature.activate` to throw the exact `WasmError`
+reported in the issue, then assert that `calculate()` returns normally and the
+creature ends up with a non-finite score.
 
-Verified the regression by running the new RL test against the
-unmodified `Develop` branch — it fails with an uncaught `WasmError` at
-`RLEpisodeFitness_WasmErrorRecovery_test.ts:82:7`, matching the issue
-stack trace. With the fix applied, all three new tests pass.
+Verified the regression by running the new RL test against the unmodified
+`Develop` branch — it fails with an uncaught `WasmError` at
+`RLEpisodeFitness_WasmErrorRecovery_test.ts:82:7`, matching the issue stack
+trace. With the fix applied, all three new tests pass.
 
 ```mermaid
 flowchart LR
@@ -51,25 +50,24 @@ flowchart LR
 
 - `test/creature/RLEpisodeFitness_WasmErrorRecovery_test.ts`
   - `RLEpisodeFitness.calculate: WasmError from activate drops the creature (inline path)`
-    — reproduces the exact `WasmError("WASM activation was selected but
-    failed to instantiate CompiledNetwork", "ACTIVATION_FAILED")` from
-    the issue; asserts `calculate()` returns and the creature score is
+    — reproduces the exact
+    `WasmError("WASM activation was selected but
+    failed to instantiate CompiledNetwork", "ACTIVATION_FAILED")`
+    from the issue; asserts `calculate()` returns and the creature score is
     non-finite.
   - `RLEpisodeFitness.calculate: ActivationError from activate still drops the creature (inline path)`
-    — regression guard for the existing `ActivationError` branch after
-    folding both error types into one catch.
-  - `RLEpisodeFitness.calculate: non-typed errors still propagate` —
-    confirms a generic `TypeError` is *not* swallowed so programming
-    bugs still surface in CI.
+    — regression guard for the existing `ActivationError` branch after folding
+    both error types into one catch.
+  - `RLEpisodeFitness.calculate: non-typed errors still propagate` — confirms a
+    generic `TypeError` is _not_ swallowed so programming bugs still surface in
+    CI.
 - `test/creature/EpisodicFitness_WasmErrorRecovery_test.ts`
-  - `EpisodicFitness.calculate: WasmError from activate drops the creature`
-    — same regression scenario for the legacy `evolveEnv` scorer.
+  - `EpisodicFitness.calculate: WasmError from activate drops the creature` —
+    same regression scenario for the legacy `evolveEnv` scorer.
   - `EpisodicFitness.calculate: ActivationError from activate still drops the creature`
     — regression guard for the legacy `ActivationError` branch.
 
-All five new tests pass. The full `./quality.sh` run was clean for lint,
-format, type-check, WASM sync, and 6 719 unit tests; one unrelated
-flaky leak in
-`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` (FFI dynamic
-library tracking, fails the same way without this PR's changes) was
-ignored.
+All five new tests pass. The full `./quality.sh` run was clean for lint, format,
+type-check, WASM sync, and 6 719 unit tests; one unrelated flaky leak in
+`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` (FFI dynamic library
+tracking, fails the same way without this PR's changes) was ignored.

--- a/docs/pr-summary-2669.md
+++ b/docs/pr-summary-2669.md
@@ -1,0 +1,75 @@
+# Drop corrupt creatures instead of crashing the worker (Issue #2669)
+
+## Summary
+
+Fixes #2669. When a creature's topology traps the WASM loader, the WASM
+compilation cache already logs a single deduplicated line per offending
+uuid asking callers to *"drop the creature or repair its topology before
+retrying"* (Issue #2483 / #2649). The RL and legacy episodic fitness
+scorers were not honouring that contract — they only caught
+`ActivationError` in their per-trial loops, so a `WasmError` propagated
+all the way out of `RLEpisodeFitness.calculate` → `Neat.evolve` → the
+host script, killing the worker with an uncaught promise rejection
+(stack trace in the issue).
+
+This change folds `WasmError` into the existing `ActivationError` catch
+branch in both scorers (`RLEpisodeFitness.collectTrialsInline`, the
+worker-pool path inside `RLEpisodeFitness.calculate`, and
+`EpisodicFitness.calculate`). The offending creature is dropped with
+`-Infinity` reward so natural selection removes it from the next
+generation. Non-typed errors (programming bugs) still propagate so they
+surface in CI.
+
+The pre-fix log line from the issue — `WASM compile failed for creature
+… Drop the creature or repair its topology before retrying` — is now
+followed by the scorer reporting the drop rather than the worker
+crashing.
+
+## Evidence
+
+This is a CLI / library change with no UI surface. Behaviour is verified
+by three new tests that stub `creature.activate` to throw the exact
+`WasmError` reported in the issue, then assert that `calculate()`
+returns normally and the creature ends up with a non-finite score.
+
+Verified the regression by running the new RL test against the
+unmodified `Develop` branch — it fails with an uncaught `WasmError` at
+`RLEpisodeFitness_WasmErrorRecovery_test.ts:82:7`, matching the issue
+stack trace. With the fix applied, all three new tests pass.
+
+```mermaid
+flowchart LR
+    A[Corrupt creature reaches scorer] --> B[creature.activate]
+    B -->|"WASM compile cache returns null"| C[activateWasm throws WasmError]
+    C --> D{Scorer catch}
+    D -->|"Before #2669: ActivationError only"| E["Re-throw → worker crashes"]
+    D -->|"After #2669: ActivationError OR WasmError"| F["Reward = -Infinity"]
+    F --> G[Natural selection drops creature next generation]
+```
+
+## Test Plan
+
+- `test/creature/RLEpisodeFitness_WasmErrorRecovery_test.ts`
+  - `RLEpisodeFitness.calculate: WasmError from activate drops the creature (inline path)`
+    — reproduces the exact `WasmError("WASM activation was selected but
+    failed to instantiate CompiledNetwork", "ACTIVATION_FAILED")` from
+    the issue; asserts `calculate()` returns and the creature score is
+    non-finite.
+  - `RLEpisodeFitness.calculate: ActivationError from activate still drops the creature (inline path)`
+    — regression guard for the existing `ActivationError` branch after
+    folding both error types into one catch.
+  - `RLEpisodeFitness.calculate: non-typed errors still propagate` —
+    confirms a generic `TypeError` is *not* swallowed so programming
+    bugs still surface in CI.
+- `test/creature/EpisodicFitness_WasmErrorRecovery_test.ts`
+  - `EpisodicFitness.calculate: WasmError from activate drops the creature`
+    — same regression scenario for the legacy `evolveEnv` scorer.
+  - `EpisodicFitness.calculate: ActivationError from activate still drops the creature`
+    — regression guard for the legacy `ActivationError` branch.
+
+All five new tests pass. The full `./quality.sh` run was clean for lint,
+format, type-check, WASM sync, and 6 719 unit tests; one unrelated
+flaky leak in
+`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` (FFI dynamic
+library tracking, fails the same way without this PR's changes) was
+ignored.

--- a/src/creature/EpisodicFitness.ts
+++ b/src/creature/EpisodicFitness.ts
@@ -17,6 +17,7 @@ import { Fitness } from "@architecture/Fitness.ts";
 import { calculate as calculateScore } from "@architecture/Score.ts";
 import { ActivationError } from "@errors/ActivationError.ts";
 import { ValidationError } from "@errors/ValidationError.ts";
+import { WasmError } from "@errors/WasmError.ts";
 import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import { getLogger } from "@utils/Logger.ts";
 import type {
@@ -163,9 +164,17 @@ export class EpisodicFitness<S, A> extends Fitness {
         try {
           reward = this.runEpisode(creature, trialSeed);
         } catch (err) {
-          if (err instanceof ActivationError) {
+          // Issue #2669: A WasmError surfaced from `creature.activate`
+          // signals an unrepairable topology — the WASM compile cache
+          // already logged the offending uuid and asked callers to drop
+          // the creature. Treat it the same as ActivationError so the
+          // surrounding evolve loop drops the creature via natural
+          // selection instead of crashing the worker.
+          if (err instanceof ActivationError || err instanceof WasmError) {
             getLogger().warn(
-              `[EpisodicFitness] Activation failure on creature ` +
+              `[EpisodicFitness] ${
+                err instanceof WasmError ? "WASM" : "Activation"
+              } failure on creature ` +
                 `${creature.uuid?.substring(0, 8) ?? "unknown"}: ` +
                 `${err.message}`,
             );

--- a/src/creature/RLEpisodeFitness.ts
+++ b/src/creature/RLEpisodeFitness.ts
@@ -25,6 +25,7 @@ import { Fitness } from "@architecture/Fitness.ts";
 import { calculate as calculateScore } from "@architecture/Score.ts";
 import { ActivationError } from "@errors/ActivationError.ts";
 import { ValidationError } from "@errors/ValidationError.ts";
+import { WasmError } from "@errors/WasmError.ts";
 import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import { getLogger } from "@utils/Logger.ts";
 import type { EpisodeAdapter } from "@creature/EpisodeAdapter.ts";
@@ -278,9 +279,17 @@ export class RLEpisodeFitness<S, A> extends Fitness {
             trialsPerCreature[i] = trials;
           })
           .catch((err) => {
-            if (err instanceof ActivationError) {
+            // Issue #2669: A WasmError surfaced from `creature.activate`
+            // signals an unrepairable topology — the WASM compile cache
+            // already logged the offending uuid and asked callers to drop
+            // the creature. Treat it the same as ActivationError so the
+            // surrounding evolve loop drops the creature via natural
+            // selection instead of crashing the worker.
+            if (err instanceof ActivationError || err instanceof WasmError) {
               getLogger().warn(
-                `[RLEpisodeFitness] Activation failure on creature ` +
+                `[RLEpisodeFitness] ${
+                  err instanceof WasmError ? "WASM" : "Activation"
+                } failure on creature ` +
                   `${creature.uuid?.substring(0, 8) ?? "unknown"}: ` +
                   `${err.message}`,
               );
@@ -337,9 +346,17 @@ export class RLEpisodeFitness<S, A> extends Fitness {
         const result = await runEpisode(this.adapter, creature, seed);
         trials[t] = { reward: result.returnValue, steps: result.steps };
       } catch (err) {
-        if (err instanceof ActivationError) {
+        // Issue #2669: A WasmError surfaced from `creature.activate`
+        // signals an unrepairable topology — the WASM compile cache
+        // already logged the offending uuid and asked callers to drop
+        // the creature. Treat it the same as ActivationError so the
+        // surrounding evolve loop drops the creature via natural
+        // selection instead of crashing the worker.
+        if (err instanceof ActivationError || err instanceof WasmError) {
           getLogger().warn(
-            `[RLEpisodeFitness] Activation failure on creature ` +
+            `[RLEpisodeFitness] ${
+              err instanceof WasmError ? "WASM" : "Activation"
+            } failure on creature ` +
               `${creature.uuid?.substring(0, 8) ?? "unknown"}: ` +
               `${err.message}`,
           );

--- a/test/creature/EpisodicFitness_WasmErrorRecovery_test.ts
+++ b/test/creature/EpisodicFitness_WasmErrorRecovery_test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression test for Issue #2669 — legacy `EpisodicFitness` scorer
+ * counterpart.
+ *
+ * When `creature.activate` throws a {@link WasmError} (the cached WASM
+ * compile returned `null` because the topology trapped the WASM loader),
+ * the legacy episodic scorer MUST drop the creature with `-Infinity`
+ * reward instead of crashing the surrounding evolve loop. The WASM
+ * compile cache already logged the offending uuid and asked callers to
+ * "drop the creature or repair its topology before retrying"; this test
+ * verifies the legacy scorer honours that contract.
+ */
+
+import { assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { EpisodicFitness } from "@creature/EpisodicFitness.ts";
+import type { LegacyEpisodeAdapter } from "@creature/EpisodicFitnessTypes.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { WasmError } from "@errors/WasmError.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+const trivialAdapter: LegacyEpisodeAdapter<{ step: number }, number> = {
+  inputCount: 1,
+  outputCount: 1,
+  maxSteps: 5,
+  reset(_seed?: number) {
+    return { step: 0 };
+  },
+  observe(_state) {
+    return new Float32Array([0]);
+  },
+  decode(_output) {
+    return 0;
+  },
+  step(state, _action) {
+    const next = { step: state.step + 1 };
+    return { state: next, reward: 1, done: next.step >= 3 };
+  },
+};
+
+function makeCreature(): Creature {
+  return new Creature(1, 1, { layers: [{ count: 2 }] });
+}
+
+function patchActivateToThrow(creature: Creature, error: Error): void {
+  creature.activate = ((_input: Float32Array, _feedbackLoop?: boolean) => {
+    throw error;
+  }) as Creature["activate"];
+}
+
+Deno.test(
+  "EpisodicFitness.calculate: WasmError from activate drops the creature",
+  async () => {
+    await initWasmForTests();
+
+    const creature = makeCreature();
+    patchActivateToThrow(
+      creature,
+      new WasmError(
+        "WASM activation was selected but failed to instantiate CompiledNetwork",
+        "ACTIVATION_FAILED",
+      ),
+    );
+
+    const fitness = new EpisodicFitness({
+      adapter: trivialAdapter,
+      growth: 0,
+      trialsPerScore: 2,
+      initialPerturbation: 0,
+      baseSeed: 1,
+      rewardToError: (reward) => Math.max(0, -reward),
+    });
+
+    // Before #2669 this propagated the WasmError out of `calculate()` and
+    // crashed the surrounding `evolve` loop. After the fix it must drop
+    // the creature with a non-finite score and return normally.
+    await fitness.calculate([creature]);
+
+    assertEquals(typeof creature.score, "number");
+    assertEquals(Number.isFinite(creature.score!), false);
+  },
+);
+
+Deno.test(
+  "EpisodicFitness.calculate: ActivationError from activate still drops the creature",
+  async () => {
+    await initWasmForTests();
+
+    const creature = makeCreature();
+    patchActivateToThrow(
+      creature,
+      new ActivationError(
+        "non-finite result from RELU",
+        "NON_FINITE_RESULT",
+        "RELU",
+        Number.NaN,
+      ),
+    );
+
+    const fitness = new EpisodicFitness({
+      adapter: trivialAdapter,
+      growth: 0,
+      trialsPerScore: 1,
+      initialPerturbation: 0,
+      baseSeed: 1,
+      rewardToError: (reward) => Math.max(0, -reward),
+    });
+
+    await fitness.calculate([creature]);
+
+    assertEquals(typeof creature.score, "number");
+    assertEquals(Number.isFinite(creature.score!), false);
+  },
+);

--- a/test/creature/RLEpisodeFitness_WasmErrorRecovery_test.ts
+++ b/test/creature/RLEpisodeFitness_WasmErrorRecovery_test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression test for Issue #2669: when `creature.activate` throws a
+ * {@link WasmError} mid-episode (the cached WASM compile cache returned
+ * `null` because the topology trapped the WASM loader), the RL fitness
+ * scorer MUST drop the creature with `-Infinity` reward instead of
+ * crashing the surrounding evolve loop.
+ *
+ * The compile cache already logged the offending uuid and asked callers to
+ * "drop the creature or repair its topology before retrying"; this test
+ * verifies the RL scorer honours that contract.
+ */
+
+import { assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { EpisodeAdapter, type StepResult } from "@creature/EpisodeAdapter.ts";
+import { RLEpisodeFitness } from "@creature/RLEpisodeFitness.ts";
+import { WasmError } from "@errors/WasmError.ts";
+import { ActivationError } from "@errors/ActivationError.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+// ---------------------------------------------------------------------------
+// Minimal adapter — single input, single output, one step then terminate.
+// The body never runs because the creature traps on the very first activate.
+// ---------------------------------------------------------------------------
+
+class TrivialAdapter extends EpisodeAdapter<{ step: number }, number> {
+  override reset(
+    _rngSeed: number,
+  ): { observation: Float32Array; state: { step: number } } {
+    return { observation: new Float32Array([0]), state: { step: 0 } };
+  }
+
+  override step(
+    state: { step: number },
+    _action: number,
+  ): StepResult<Float32Array> & { state: { step: number } } {
+    const next = { step: state.step + 1 };
+    return {
+      observation: new Float32Array([next.step]),
+      reward: 1,
+      terminated: next.step >= 3,
+      truncated: false,
+      state: next,
+    };
+  }
+
+  override get observationLength(): number {
+    return 1;
+  }
+
+  override decodeAction(_creatureOutput: Float32Array): number {
+    return 0;
+  }
+}
+
+function makeCreature(): Creature {
+  return new Creature(1, 1, { layers: [{ count: 2 }] });
+}
+
+/**
+ * Replace `creature.activate` with a stub that throws the supplied error on
+ * every call. Simulates the "WASM compile cache returned null" trap path
+ * observed in Issue #2669 without requiring an actually-malformed creature.
+ */
+function patchActivateToThrow(creature: Creature, error: Error): void {
+  // The runtime only requires `(input, feedbackLoop) => Float32Array`; throw
+  // synchronously to mirror `activateWasm`'s behaviour when the cached WASM
+  // module fails to instantiate.
+  creature.activate = ((_input: Float32Array, _feedbackLoop?: boolean) => {
+    throw error;
+  }) as Creature["activate"];
+}
+
+Deno.test(
+  "RLEpisodeFitness.calculate: WasmError from activate drops the creature (inline path)",
+  async () => {
+    await initWasmForTests();
+
+    const creature = makeCreature();
+    patchActivateToThrow(
+      creature,
+      new WasmError(
+        "WASM activation was selected but failed to instantiate CompiledNetwork",
+        "ACTIVATION_FAILED",
+      ),
+    );
+
+    const fitness = new RLEpisodeFitness({
+      adapter: new TrivialAdapter(),
+      growth: 0,
+    });
+    fitness.setSeedSet([1, 2, 3]);
+
+    // The whole point of #2669: this must not throw. Before the fix the
+    // WasmError propagated out of `collectTrialsInline` and crashed the
+    // worker with an uncaught promise rejection.
+    await fitness.calculate([creature]);
+
+    // The creature was scored and dropped (score < 0 because reward is
+    // -Infinity for every seed → error is +Infinity → score is heavily
+    // penalised). Specifically: not `undefined` and not `+Infinity`.
+    assertEquals(typeof creature.score, "number");
+    assertEquals(Number.isFinite(creature.score!), false);
+  },
+);
+
+Deno.test(
+  "RLEpisodeFitness.calculate: ActivationError from activate still drops the creature (inline path)",
+  async () => {
+    // Regression guard: the existing ActivationError branch must keep
+    // working after the #2669 fix folded both error types into one catch.
+    await initWasmForTests();
+
+    const creature = makeCreature();
+    patchActivateToThrow(
+      creature,
+      new ActivationError(
+        "non-finite result from RELU",
+        "NON_FINITE_RESULT",
+        "RELU",
+        Number.NaN,
+      ),
+    );
+
+    const fitness = new RLEpisodeFitness({
+      adapter: new TrivialAdapter(),
+      growth: 0,
+    });
+    fitness.setSeedSet([42]);
+
+    await fitness.calculate([creature]);
+
+    assertEquals(typeof creature.score, "number");
+    assertEquals(Number.isFinite(creature.score!), false);
+  },
+);
+
+Deno.test(
+  "RLEpisodeFitness.calculate: non-typed errors still propagate",
+  async () => {
+    // Generic errors (programming bugs) must keep crashing the run so they
+    // surface in CI instead of being silently swallowed.
+    await initWasmForTests();
+
+    const creature = makeCreature();
+    patchActivateToThrow(creature, new TypeError("unexpected bug"));
+
+    const fitness = new RLEpisodeFitness({
+      adapter: new TrivialAdapter(),
+      growth: 0,
+    });
+    fitness.setSeedSet([1]);
+
+    let caught: Error | undefined;
+    try {
+      await fitness.calculate([creature]);
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    assertEquals(caught instanceof TypeError, true);
+    assertEquals(caught?.message, "unexpected bug");
+  },
+);


### PR DESCRIPTION
# Drop corrupt creatures instead of crashing the worker (Issue #2669)

## Summary

Fixes #2669. When a creature's topology traps the WASM loader, the WASM
compilation cache already logs a single deduplicated line per offending
uuid asking callers to *"drop the creature or repair its topology before
retrying"* (Issue #2483 / #2649). The RL and legacy episodic fitness
scorers were not honouring that contract — they only caught
`ActivationError` in their per-trial loops, so a `WasmError` propagated
all the way out of `RLEpisodeFitness.calculate` → `Neat.evolve` → the
host script, killing the worker with an uncaught promise rejection
(stack trace in the issue).

This change folds `WasmError` into the existing `ActivationError` catch
branch in both scorers (`RLEpisodeFitness.collectTrialsInline`, the
worker-pool path inside `RLEpisodeFitness.calculate`, and
`EpisodicFitness.calculate`). The offending creature is dropped with
`-Infinity` reward so natural selection removes it from the next
generation. Non-typed errors (programming bugs) still propagate so they
surface in CI.

The pre-fix log line from the issue — `WASM compile failed for creature
… Drop the creature or repair its topology before retrying` — is now
followed by the scorer reporting the drop rather than the worker
crashing.

## Evidence

This is a CLI / library change with no UI surface. Behaviour is verified
by three new tests that stub `creature.activate` to throw the exact
`WasmError` reported in the issue, then assert that `calculate()`
returns normally and the creature ends up with a non-finite score.

Verified the regression by running the new RL test against the
unmodified `Develop` branch — it fails with an uncaught `WasmError` at
`RLEpisodeFitness_WasmErrorRecovery_test.ts:82:7`, matching the issue
stack trace. With the fix applied, all three new tests pass.

```mermaid
flowchart LR
    A[Corrupt creature reaches scorer] --> B[creature.activate]
    B -->|"WASM compile cache returns null"| C[activateWasm throws WasmError]
    C --> D{Scorer catch}
    D -->|"Before #2669: ActivationError only"| E["Re-throw → worker crashes"]
    D -->|"After #2669: ActivationError OR WasmError"| F["Reward = -Infinity"]
    F --> G[Natural selection drops creature next generation]
```

## Test Plan

- `test/creature/RLEpisodeFitness_WasmErrorRecovery_test.ts`
  - `RLEpisodeFitness.calculate: WasmError from activate drops the creature (inline path)`
    — reproduces the exact `WasmError("WASM activation was selected but
    failed to instantiate CompiledNetwork", "ACTIVATION_FAILED")` from
    the issue; asserts `calculate()` returns and the creature score is
    non-finite.
  - `RLEpisodeFitness.calculate: ActivationError from activate still drops the creature (inline path)`
    — regression guard for the existing `ActivationError` branch after
    folding both error types into one catch.
  - `RLEpisodeFitness.calculate: non-typed errors still propagate` —
    confirms a generic `TypeError` is *not* swallowed so programming
    bugs still surface in CI.
- `test/creature/EpisodicFitness_WasmErrorRecovery_test.ts`
  - `EpisodicFitness.calculate: WasmError from activate drops the creature`
    — same regression scenario for the legacy `evolveEnv` scorer.
  - `EpisodicFitness.calculate: ActivationError from activate still drops the creature`
    — regression guard for the legacy `ActivationError` branch.

All five new tests pass. The full `./quality.sh` run was clean for lint,
format, type-check, WASM sync, and 6 719 unit tests; one unrelated
flaky leak in
`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` (FFI dynamic
library tracking, fails the same way without this PR's changes) was
ignored.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2669 -->