### PR TITLE
test(wasm): add lunar_lander-shape producer-gate reproducer (#2668)

### DIFF
--- a/docs/pr-summary-2668.md
+++ b/docs/pr-summary-2668.md
@@ -1,0 +1,117 @@
+# Reproducer test for lunar_lander-shape WASM compile trap
+
+## Summary
+
+Adds an in-tree, deterministic regression test that drives `Mutator.mutate` and
+`Offspring.breed` against a population of lunar_lander-shaped creatures (7
+inputs, 3 outputs, seeded to 30 neurons) and asserts the producer-side WASM
+compile gate fires no more often than a small baseline allowance.
+
+The test is the gate that the diagnose-and-fix work in #2666 must clear: today
+the seeded loop records exactly **1 producer-gate reject** on a 37-neuron
+offspring (shape `inputs=7, outputs=3` — the exact shape from the production
+warnings in the bug report); once #2666 lands the count should drop to zero and
+the allowance can be tightened to 0.
+
+The reproducer:
+
+1. Builds `POPULATION_SIZE=4` lunar_lander-shaped creatures and grows each to 30
+   total neurons via `AddNeuron`.
+2. Runs a fixed-seed (`seed=2668`), 200-iteration mutate/breed loop.
+3. Hooks the global logger to count every `[Mutator]` and `[Offspring]` warn
+   line whose body contains `WASM compile` (the two producer-gate reject
+   messages emitted by `Mutator.repairAfterMutation` and `Offspring.breed`).
+4. Calls `ensureProducerOutputCompiles` on every post-mutate creature and every
+   successful offspring as a gate-escape guard rail.
+5. Writes the first offending creature and reject context to
+   `.diagnostics/issue-2668-lunar-lander-shape-*` via the existing
+   `writeDiagnostics` path so the diagnosis sub-issue has an artefact.
+6. Asserts `count <= BASELINE_REJECT_ALLOWANCE` (5 today, 0 once #2666 lands).
+
+A second test runs the entire reproducer three times back-to-back at the same
+seed and asserts both the reject count and the reject-source sequence match
+across all three runs — pinning the determinism requirement called out in the
+issue.
+
+Closes #2668.
+
+## Evidence
+
+Backend-only change — no UI surface to screenshot. Test results:
+
+```text
+running 2 tests from ./test/wasm/LunarLanderShapeProducerGate.ts
+Issue #2668: lunar_lander-shape mutation/breed loop keeps producer-gate
+  rejects under the baseline ... ok (111ms)
+Issue #2668: reproducer is deterministic across three consecutive runs
+  at the same seed ... ok (249ms)
+
+ok | 2 passed | 0 failed (381ms)
+```
+
+Recorded baseline in
+`.diagnostics/issue-2668-lunar-lander-shape-context-*.json`:
+
+```json
+{
+  "seed": 2668,
+  "iterations": 200,
+  "populationSize": 4,
+  "lunarInputs": 7,
+  "lunarOutputs": 3,
+  "lunarSeedNeurons": 30,
+  "rejectCount": 1,
+  "mutatorRejects": 0,
+  "offspringRejects": 1,
+  "firstFiveMessages": [
+    "[Offspring] dropping offspring that fails WASM compile (neurons=37, inputs=7, outputs=3): unreachable"
+  ]
+}
+```
+
+The captured shape (`neurons=37, inputs=7, outputs=3, trap=unreachable`) is
+exactly one of the three warnings the bug report quotes from the lunar_lander
+overnight run.
+
+Full `test/wasm/` suite still passes:
+
+```text
+ok | 539 passed | 0 failed | 1 ignored (16s)
+```
+
+```mermaid
+flowchart LR
+  A["new Creature(7,3)"] --> B["AddNeuron loop<br/>→ 30 neurons"]
+  B --> C["Population<br/>(4 creatures)"]
+  C -->|"seed=2668<br/>200 iter"| D{"rng &lt; 0.5?"}
+  D -->|yes| E["Mutator.mutate"]
+  D -->|no| F["Offspring.breed"]
+  E --> G["ensureProducerOutputCompiles<br/>post-mutate"]
+  F --> H["ensureProducerOutputCompiles<br/>post-breed"]
+  E -.->|"[Mutator] revert<br/>WASM compile"| L["captureGateRejects<br/>(warn logger)"]
+  F -.->|"[Offspring] drop<br/>WASM compile"| L
+  L --> M{"count ≤<br/>BASELINE_REJECT_<br/>ALLOWANCE?"}
+  M -->|yes| N["writeDiagnostics<br/>(.diagnostics/issue-2668-*)"]
+  M -->|no| X["FAIL — investigate #2666"]
+```
+
+## Test Plan
+
+Added test file: `test/wasm/LunarLanderShapeProducerGate.ts`.
+
+Tests verify:
+
+- **Baseline reject count is bounded.** Running the seeded mutate/breed loop
+  produces at most `BASELINE_REJECT_ALLOWANCE` (5) producer-gate rejects, and
+  writes the offending creature context to `.diagnostics/` for the diagnosis
+  sub-issue.
+- **Gate escape guard rail.** Every post-mutate creature and every returned
+  offspring still passes `ensureProducerOutputCompiles`. If any creature ever
+  escapes the gate with a compile failure, the test fails immediately with the
+  offending iteration.
+- **Determinism.** Three back-to-back runs at the same seed produce the same
+  reject count AND the same sequence of reject sources (mutator vs offspring). A
+  drift in either pins a non-determinism bug rather than a gate-fire bug.
+
+The test runs in ~400 ms total — well under the 30-second budget from the
+issue's acceptance criteria.

--- a/test/wasm/LunarLanderShapeProducerGate.ts
+++ b/test/wasm/LunarLanderShapeProducerGate.ts
@@ -1,0 +1,308 @@
+/**
+ * Issue #2668 — Reproducer test for lunar_lander-shape WASM compile traps.
+ *
+ * Background:
+ *
+ *   The lunar_lander example in NEAT-AI-Examples (7 inputs, 3 outputs,
+ *   ~36–37 total neurons) reproducibly logs three producer-gate warnings
+ *   during evolution:
+ *
+ *     [Offspring] dropping offspring that fails WASM compile
+ *       (neurons=37, inputs=7, outputs=3): unreachable
+ *     WASM compile failed for creature 72609101-...
+ *       (neurons=36, inputs=7, outputs=3): unreachable.
+ *     [Offspring] dropping offspring that fails WASM compile
+ *       (neurons=36, inputs=7, outputs=3): unreachable
+ *
+ *   These shapes are tiny — well below the 2156-neuron #2636 reproducer —
+ *   so the underlying bug is a different failure mode from the one #2636
+ *   addressed. This file is the in-tree reproducer that the diagnose-and-fix
+ *   work in #2666 must drive to zero rejects.
+ *
+ *   The test drives `Mutator.mutate` and `Offspring.breed` against a small
+ *   population of lunar_lander-shaped creatures with a fixed PRNG seed,
+ *   captures every producer-gate reject (both the in-Mutator revert and the
+ *   in-Offspring drop), writes diagnostics for the first offending creature,
+ *   and asserts the count is bounded by `BASELINE_REJECT_ALLOWANCE`.
+ *
+ *   The allowance is a small non-zero number today so the test passes against
+ *   the existing buggy producers; #2666 will drive it to zero. Bumping the
+ *   allowance is NOT how to "fix" this test — root-cause the trap and bring
+ *   the count down instead.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { AddNeuron } from "@mutate/AddNeuron.ts";
+import { Mutator } from "@neat/Mutator.ts";
+import { Offspring } from "@architecture/Offspring.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { ensureProducerOutputCompiles } from "@wasm/ProducerCompileGuard.ts";
+import {
+  createSeededRng,
+  getRandomNumberGenerator,
+  setRandomNumberGenerator,
+} from "@utils/RandomNumberGenerator.ts";
+import { getLogger, setLogger } from "@utils/Logger.ts";
+import { writeDiagnostics } from "@utils/Diagnostics.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+// ---------------------------------------------------------------------------
+// Shape constants — match the lunar_lander example.
+// ---------------------------------------------------------------------------
+
+const LUNAR_INPUTS = 7;
+const LUNAR_OUTPUTS = 3;
+/** Target total neuron count after the AddNeuron seed loop. */
+const LUNAR_SEED_NEURONS = 30;
+/** Bounded mutation/breed iterations driven against the population. */
+const ITERATIONS = 200;
+/** Population size — small enough to keep the test under 30 seconds. */
+const POPULATION_SIZE = 4;
+/** Fixed seed — change only with a deliberate baseline-recapture commit. */
+const SEED = 2668;
+/**
+ * Maximum producer-gate rejects we tolerate today. The fix in #2666 will
+ * drive this to zero; do NOT raise it to make the test pass.
+ *
+ * Observed baseline at seed 2668: 1 reject (a single `[Offspring]` drop on
+ * a 28-neuron offspring with shape inputs=7/outputs=3 — exactly the
+ * lunar_lander shape from the bug report). The 5-reject allowance leaves a
+ * small margin for unrelated mutator-cache state changes; if the count
+ * drifts UP, the producer is emitting MORE bad topologies — investigate
+ * #2666 rather than raising the allowance.
+ */
+const BASELINE_REJECT_ALLOWANCE = 5;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+interface RejectEvent {
+  readonly source: "mutator" | "offspring";
+  readonly message: string;
+}
+
+/**
+ * Hook the global logger so we can count producer-gate warn lines emitted
+ * by `Mutator.repairAfterMutation` (which logs `[Mutator] reverting
+ * mutation that fails WASM compile`) and `Offspring.breed` (which logs
+ * `[Offspring] dropping offspring that fails WASM compile`). Returns the
+ * capture and a disposer that restores the previous logger.
+ */
+function captureGateRejects(): {
+  events: RejectEvent[];
+  dispose: () => void;
+} {
+  const events: RejectEvent[] = [];
+  const previous = getLogger();
+  setLogger({
+    debug() {},
+    info() {},
+    warn(...args: unknown[]) {
+      const line = args.map((a) => String(a)).join(" ");
+      if (line.includes("WASM compile")) {
+        if (line.startsWith("[Mutator]")) {
+          events.push({ source: "mutator", message: line });
+        } else if (line.startsWith("[Offspring]")) {
+          events.push({ source: "offspring", message: line });
+        }
+      }
+    },
+    error() {},
+  });
+  return { events, dispose: () => setLogger(previous) };
+}
+
+/**
+ * Build a single lunar_lander-shaped creature: 7 inputs, 3 outputs,
+ * grown to `LUNAR_SEED_NEURONS` total neurons via repeated `AddNeuron`.
+ *
+ * The AddNeuron operator can no-op when the draw lands on an
+ * inappropriate edge, so the loop retries up to 5x the needed count.
+ */
+function buildLunarShape(): Creature {
+  const creature = new Creature(LUNAR_INPUTS, LUNAR_OUTPUTS);
+  creature.fix();
+  const need = LUNAR_SEED_NEURONS - creature.neurons.length;
+  let added = 0;
+  for (let attempt = 0; attempt < need * 5 && added < need; attempt++) {
+    const op = new AddNeuron(creature);
+    if (op.mutate()) {
+      added++;
+    }
+  }
+  assertEquals(
+    creature.neurons.length,
+    LUNAR_SEED_NEURONS,
+    `failed to seed ${LUNAR_SEED_NEURONS} neurons in bounded attempts`,
+  );
+  // Re-validate compile-cleanness of the seed before the loop runs.
+  const baseline = ensureProducerOutputCompiles(creature);
+  assert(
+    baseline.ok,
+    `seed creature must compile before the loop runs; trap=${baseline.trapMessage}`,
+  );
+  return creature;
+}
+
+/**
+ * Run the bounded mutation/breed loop with a fixed PRNG seed and return
+ * the captured reject events. The function is self-contained: it sets the
+ * RNG, installs the warn-capturing logger, runs the loop, and restores
+ * the previous global state before returning.
+ *
+ * Two consecutive calls with the same seed MUST return arrays of equal
+ * length — that property is what makes the test deterministic.
+ */
+function runReproducer(seed: number): RejectEvent[] {
+  const previousRng = getRandomNumberGenerator();
+  setRandomNumberGenerator(createSeededRng(seed));
+
+  // Build a small population of lunar-shaped creatures BEFORE installing the
+  // capture logger — `buildLunarShape` does not emit gate-reject warns.
+  const population: Creature[] = [];
+  for (let i = 0; i < POPULATION_SIZE; i++) {
+    population.push(buildLunarShape());
+  }
+
+  // `createNeatConfig` calls `setLogger()` to install the default console
+  // logger (see NeatConfig.ts), so the capture logger MUST be installed
+  // AFTER the config is built — otherwise the gate-reject warns fall back
+  // to the console and the assertion below sees zero events.
+  //
+  // We also explicitly pass `rng: getRandomNumberGenerator()` so the
+  // config does NOT replace our seeded RNG with a fresh unseeded one
+  // (NeatConfig.ts line 190 calls `setRandomNumberGenerator(rng)` and
+  // would otherwise wipe the seed we just installed, making the
+  // mutation/breed loop non-deterministic across consecutive runs).
+  const config = createNeatConfig({
+    populationSize: POPULATION_SIZE,
+    // High rate so every iteration exercises the gate; the test is
+    // about gate fire-rate, not the production mutation rate.
+    mutationRate: 1.0,
+    mutationAmount: 3,
+    rng: getRandomNumberGenerator(),
+  });
+  const mutator = new Mutator(config);
+
+  const capture = captureGateRejects();
+  try {
+    const rng = getRandomNumberGenerator();
+
+    for (let iter = 0; iter < ITERATIONS; iter++) {
+      // Half mutate, half breed. Both paths go through the producer gate.
+      if (rng.random() < 0.5) {
+        const idx = rng.randomInt(0, population.length - 1);
+        mutator.mutate([population[idx]]);
+        // After mutate (which auto-reverts on gate failure) the creature
+        // must still pass the probe — the gate is the contract this test
+        // pins. If the post-mutate creature ever fails compile, that is a
+        // gate escape and must surface immediately.
+        const probe = ensureProducerOutputCompiles(population[idx]);
+        assert(
+          probe.ok,
+          `[iter ${iter}] post-mutate creature failed WASM compile — ` +
+            `gate escape: ${probe.trapMessage}`,
+        );
+      } else {
+        const i = rng.randomInt(0, population.length - 1);
+        let j = rng.randomInt(0, population.length - 1);
+        if (j === i) j = (j + 1) % population.length;
+        const child = Offspring.breed(population[i], population[j]);
+        if (child !== undefined) {
+          const probe = ensureProducerOutputCompiles(child);
+          assert(
+            probe.ok,
+            `[iter ${iter}] post-breed offspring failed WASM compile — ` +
+              `gate escape: ${probe.trapMessage}`,
+          );
+        }
+      }
+    }
+
+    return capture.events.slice();
+  } finally {
+    capture.dispose();
+    setRandomNumberGenerator(previousRng);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "Issue #2668: lunar_lander-shape mutation/breed loop keeps producer-gate rejects under the baseline",
+  async () => {
+    await initWasmForTests();
+    const events = runReproducer(SEED);
+
+    // Record the baseline so #2666 has a concrete number to drive to zero.
+    // The first offending creature is dumped via writeDiagnostics so the
+    // diagnosis sub-issue has an in-tree artefact.
+    if (events.length > 0) {
+      writeDiagnostics({
+        error: new Error(
+          `Issue #2668 reproducer recorded ${events.length} producer-gate ` +
+            `rejects on lunar_lander shape (seed=${SEED}, iterations=${ITERATIONS}).`,
+        ),
+        prefix: "issue-2668-lunar-lander-shape",
+        context: {
+          seed: SEED,
+          iterations: ITERATIONS,
+          populationSize: POPULATION_SIZE,
+          lunarInputs: LUNAR_INPUTS,
+          lunarOutputs: LUNAR_OUTPUTS,
+          lunarSeedNeurons: LUNAR_SEED_NEURONS,
+          rejectCount: events.length,
+          mutatorRejects: events.filter((e) => e.source === "mutator").length,
+          offspringRejects: events.filter((e) => e.source === "offspring")
+            .length,
+          firstFiveMessages: events.slice(0, 5).map((e) => e.message),
+        },
+      });
+    }
+
+    assert(
+      events.length <= BASELINE_REJECT_ALLOWANCE,
+      `Producer-gate rejects exceeded baseline allowance: ` +
+        `${events.length} > ${BASELINE_REJECT_ALLOWANCE}. ` +
+        `If this rose, the producer is emitting MORE bad topologies, ` +
+        `not fewer — investigate #2666 rather than raising the allowance. ` +
+        `First message: ${events[0]?.message ?? "(none)"}`,
+    );
+  },
+);
+
+Deno.test(
+  "Issue #2668: reproducer is deterministic across three consecutive runs at the same seed",
+  async () => {
+    await initWasmForTests();
+    const run1 = runReproducer(SEED);
+    const run2 = runReproducer(SEED);
+    const run3 = runReproducer(SEED);
+
+    assertEquals(
+      run1.length,
+      run2.length,
+      `run1 (${run1.length}) and run2 (${run2.length}) must match — ` +
+        `the seeded reproducer is not deterministic`,
+    );
+    assertEquals(
+      run2.length,
+      run3.length,
+      `run2 (${run2.length}) and run3 (${run3.length}) must match — ` +
+        `the seeded reproducer is not deterministic`,
+    );
+
+    // Stronger check: the sequence of reject sources must also match,
+    // not just the count. If the count matches but the order differs, the
+    // PRNG is reused but a downstream call is non-deterministic.
+    const sources1 = run1.map((e) => e.source).join(",");
+    const sources2 = run2.map((e) => e.source).join(",");
+    const sources3 = run3.map((e) => e.source).join(",");
+    assertEquals(sources1, sources2);
+    assertEquals(sources2, sources3);
+  },
+);


### PR DESCRIPTION
# Reproducer test for lunar_lander-shape WASM compile trap

## Summary

Adds an in-tree, deterministic regression test that drives `Mutator.mutate` and
`Offspring.breed` against a population of lunar_lander-shaped creatures (7
inputs, 3 outputs, seeded to 30 neurons) and asserts the producer-side WASM
compile gate fires no more often than a small baseline allowance.

The test is the gate that the diagnose-and-fix work in #2666 must clear: today
the seeded loop records exactly **1 producer-gate reject** on a 37-neuron
offspring (shape `inputs=7, outputs=3` — the exact shape from the production
warnings in the bug report); once #2666 lands the count should drop to zero and
the allowance can be tightened to 0.

The reproducer:

1. Builds `POPULATION_SIZE=4` lunar_lander-shaped creatures and grows each to 30
   total neurons via `AddNeuron`.
2. Runs a fixed-seed (`seed=2668`), 200-iteration mutate/breed loop.
3. Hooks the global logger to count every `[Mutator]` and `[Offspring]` warn
   line whose body contains `WASM compile` (the two producer-gate reject
   messages emitted by `Mutator.repairAfterMutation` and `Offspring.breed`).
4. Calls `ensureProducerOutputCompiles` on every post-mutate creature and every
   successful offspring as a gate-escape guard rail.
5. Writes the first offending creature and reject context to
   `.diagnostics/issue-2668-lunar-lander-shape-*` via the existing
   `writeDiagnostics` path so the diagnosis sub-issue has an artefact.
6. Asserts `count <= BASELINE_REJECT_ALLOWANCE` (5 today, 0 once #2666 lands).

A second test runs the entire reproducer three times back-to-back at the same
seed and asserts both the reject count and the reject-source sequence match
across all three runs — pinning the determinism requirement called out in the
issue.

Closes #2668.

## Evidence

Backend-only change — no UI surface to screenshot. Test results:

```text
running 2 tests from ./test/wasm/LunarLanderShapeProducerGate.ts
Issue #2668: lunar_lander-shape mutation/breed loop keeps producer-gate
  rejects under the baseline ... ok (111ms)
Issue #2668: reproducer is deterministic across three consecutive runs
  at the same seed ... ok (249ms)

ok | 2 passed | 0 failed (381ms)
```

Recorded baseline in
`.diagnostics/issue-2668-lunar-lander-shape-context-*.json`:

```json
{
  "seed": 2668,
  "iterations": 200,
  "populationSize": 4,
  "lunarInputs": 7,
  "lunarOutputs": 3,
  "lunarSeedNeurons": 30,
  "rejectCount": 1,
  "mutatorRejects": 0,
  "offspringRejects": 1,
  "firstFiveMessages": [
    "[Offspring] dropping offspring that fails WASM compile (neurons=37, inputs=7, outputs=3): unreachable"
  ]
}
```

The captured shape (`neurons=37, inputs=7, outputs=3, trap=unreachable`) is
exactly one of the three warnings the bug report quotes from the lunar_lander
overnight run.

Full `test/wasm/` suite still passes:

```text
ok | 539 passed | 0 failed | 1 ignored (16s)
```

```mermaid
flowchart LR
  A["new Creature(7,3)"] --> B["AddNeuron loop<br/>→ 30 neurons"]
  B --> C["Population<br/>(4 creatures)"]
  C -->|"seed=2668<br/>200 iter"| D{"rng &lt; 0.5?"}
  D -->|yes| E["Mutator.mutate"]
  D -->|no| F["Offspring.breed"]
  E --> G["ensureProducerOutputCompiles<br/>post-mutate"]
  F --> H["ensureProducerOutputCompiles<br/>post-breed"]
  E -.->|"[Mutator] revert<br/>WASM compile"| L["captureGateRejects<br/>(warn logger)"]
  F -.->|"[Offspring] drop<br/>WASM compile"| L
  L --> M{"count ≤<br/>BASELINE_REJECT_<br/>ALLOWANCE?"}
  M -->|yes| N["writeDiagnostics<br/>(.diagnostics/issue-2668-*)"]
  M -->|no| X["FAIL — investigate #2666"]
```

## Test Plan

Added test file: `test/wasm/LunarLanderShapeProducerGate.ts`.

Tests verify:

- **Baseline reject count is bounded.** Running the seeded mutate/breed loop
  produces at most `BASELINE_REJECT_ALLOWANCE` (5) producer-gate rejects, and
  writes the offending creature context to `.diagnostics/` for the diagnosis
  sub-issue.
- **Gate escape guard rail.** Every post-mutate creature and every returned
  offspring still passes `ensureProducerOutputCompiles`. If any creature ever
  escapes the gate with a compile failure, the test fails immediately with the
  offending iteration.
- **Determinism.** Three back-to-back runs at the same seed produce the same
  reject count AND the same sequence of reject sources (mutator vs offspring). A
  drift in either pins a non-determinism bug rather than a gate-fire bug.

The test runs in ~400 ms total — well under the 30-second budget from the
issue's acceptance criteria.



## Milestone
This PR is part of the **WASM for RL** milestone and targets the `milestone/wasm-for-rl` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2668 -->