### PR TITLE
feat(diagnostics): enrich producer-gate WASM compile dumps for replay

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -47,6 +47,11 @@ WASM activation is mandatory; there is no JavaScript fallback. See
 - **WASM panic during fitness evaluation** — handled gracefully since Issues
   #2207 / #2212; root cause is usually numerical overflow. →
   [WASM panic recovery](troubleshooting/WASM.md#-wasm-panic-recovery).
+- **`[Offspring] dropping offspring that fails WASM compile`** or
+  **`[Mutator] reverting mutation that fails WASM compile`** — the producer gate
+  trapped on a bred or mutated topology and wrote a replay-ready dump under
+  `.diagnostics/` (Issue #2672). →
+  [Producer-gate WASM compile rejects](troubleshooting/WASM.md#-producer-gate-wasm-compile-rejects-issue-2672).
 
 ## 🦀 Discovery / Rust FFI — build, load, and GPU backend selection
 

--- a/docs/pr-summary-2672.md
+++ b/docs/pr-summary-2672.md
@@ -1,0 +1,88 @@
+# PR Summary — Issue #2672
+
+## Summary
+
+Enriches the producer-gate diagnostic dumps written by `Offspring.breed` and
+`Mutator.repairAfterMutation` so a WASM-compile rejection can be replayed
+offline. Each dump now carries the active PRNG seed, the trap message from
+`WasmBinaryValidator`, the post-splice/pre-fix snapshot, and (for the mutator
+path) the pre-mutation creature plus the operator name. Dump filenames are
+standardised so post-mortem tooling can grep `.diagnostics/` for
+`offspring-wasm-compile-trap-<uuid>-*` and
+`mutator-wasm-compile-trap-<operator>-<uuid>-*`. Closes #2672.
+
+## Changes
+
+- `src/utils/RandomNumberGenerator.ts` — adds a `seed: number | null` property
+  to `RandomNumberGenerator` (and the seeded/unseeded implementations) so the
+  diagnostic dump can record the exact value needed to reconstruct the RNG.
+- `src/wasm/ProducerCompileGuard.ts` — adds `runProducerCompileProbe()`, a
+  test-seam-aware delegate over `producerCompileProbe`. Direct producer
+  callers (`Offspring.breed` and `Mutator.repairAfterMutation`) now go
+  through this helper so the existing
+  `__setProducerCompileGateProbeForTesting` mechanism can deterministically
+  force a rejection.
+- `src/architecture/Offspring.ts` — captures the post-splice/pre-fix offspring
+  via `exportJSONUnchecked`, then on producer-gate rejection writes a
+  diagnostic dump with the standardised
+  `offspring-wasm-compile-trap-<childUuid>` prefix and a `context` block
+  containing `motherUuid`, `fatherUuid`, `offspringUuid`, `breedSeed`,
+  `prngSeeded`, `trapMessage`, `preFixOffspring`, and shape metadata.
+- `src/NEAT/Mutator.ts` — extends `repairAfterMutation` with an optional
+  diagnostic context (`{ preMutationSnapshot, mutationName }`). The caller
+  (`Mutator.mutate`) takes a `shallowClone` of the creature before applying
+  the mutation batch and threads the last applied operator name into the
+  diagnostic context. On producer-gate rejection the dump now lands as
+  `mutator-wasm-compile-trap-<operator>-<creatureUuid>-*` with the operator
+  name, PRNG seed, trap message, pre-mutation snapshot, and pre-fix snapshot
+  embedded in `context`.
+- `docs/troubleshooting/WASM.md` — adds the new section
+  `🧪 Producer-gate WASM compile rejects (Issue #2672)` documenting dump
+  locations, the context fields, and a step-by-step offline replay recipe.
+- `docs/TROUBLESHOOTING.md` — adds a top-level FAQ entry pointing at the new
+  section.
+
+## Evidence
+
+Backend/CLI change with no UI surface.
+
+```mermaid
+sequenceDiagram
+    participant Mutate as Mutator.mutate
+    participant Repair as repairAfterMutation
+    participant Probe as runProducerCompileProbe
+    participant Dump as writeDiagnostics
+
+    Mutate->>Mutate: shallowClone(creature) → preMutationSnapshot
+    Mutate->>Mutate: mutateCreature(...) (records lastAppliedMutationName)
+    Mutate->>Repair: { preMutationSnapshot, mutationName }
+    Repair->>Repair: exportJSONUnchecked → preFixCreature
+    Repair->>Repair: fix({ forwardOnly })
+    Repair->>Probe: ensureProducerOutputCompiles
+    Probe-->>Repair: { ok: false, trapMessage }
+    Repair->>Dump: prefix=mutator-wasm-compile-trap-<op>-<uuid><br/>context: { mutationName, prngSeed,<br/>trapMessage, preMutationCreature, preFixCreature, ... }
+    Repair-->>Mutate: false (revert)
+```
+
+- New test file `test/wasm/ProducerGateDiagnosticDumps.ts` exercises both
+  paths against a stubbed reject probe and asserts the standardised
+  filename prefix is used and that the new context fields are present.
+- `quality.sh --skip-discovery` — 6363 passed, 0 failed, 4 ignored
+  (53 s test step).
+
+## Test Plan
+
+- [x] New: `test/wasm/ProducerGateDiagnosticDumps.ts::Issue #2672:
+  Offspring.breed dump uses standardised prefix and embeds replay metadata`
+- [x] New: `test/wasm/ProducerGateDiagnosticDumps.ts::Issue #2672:
+  Mutator.repairAfterMutation dump uses standardised prefix and embeds
+  replay metadata`
+- [x] Regression: existing
+  `test/wasm/ProducerCompileGuard.ts`,
+  `test/wasm/ProducerCompileGateWiring.ts`,
+  `test/feedForward/ForwardOnlyRepairAfterMutation.ts`,
+  `test/feedForward/ForwardOnlySemanticVersion.ts`,
+  `test/feedForward/ForwardOnlyViolationLogging.ts`,
+  `test/utils/RandomNumberGenerator.ts`,
+  `test/utils/Diagnostics.ts` — all pass unchanged.
+- [x] Full `quality.sh --skip-discovery` clean.

--- a/docs/troubleshooting/WASM.md
+++ b/docs/troubleshooting/WASM.md
@@ -200,6 +200,78 @@ supported workaround.
   ```
 - Reduce parallel creature count or population size.
 
+## 🧪 Producer-gate WASM compile rejects (Issue #2672)
+
+**Symptoms:**
+
+- Log lines that begin with
+  `[Offspring] dropping offspring that fails WASM
+  compile` or
+  `[Mutator] reverting mutation that fails WASM compile`.
+- New files appearing under `.diagnostics/` with the prefixes
+  `offspring-wasm-compile-trap-<uuid>-*` or
+  `mutator-wasm-compile-trap-<operator>-<uuid>-*`.
+
+**Cause:** the producer-gate
+([`ensureProducerOutputCompiles`](../../src/wasm/ProducerCompileGuard.ts))
+attempted to build a `CompiledNetwork` from a freshly bred or mutated creature
+and the WASM constructor trapped (typically `RuntimeError: unreachable`). Rather
+than letting the bad topology contaminate training, the producers drop the
+offspring (`Offspring.breed`) or revert the mutation
+(`Mutator.repairAfterMutation`) and write a diagnostic dump.
+
+**Where the dumps land:**
+
+- `.diagnostics/offspring-wasm-compile-trap-<childUuid>-*` — written by
+  `src/architecture/Offspring.ts` when the gate rejects an offspring after
+  breeding.
+- `.diagnostics/mutator-wasm-compile-trap-<mutationOperator>-<creatureUuid>-*` —
+  written by `src/NEAT/Mutator.ts` when the gate rejects a mutated creature.
+
+Each dump consists of several files sharing the same timestamp suffix:
+
+- `*-error-*.txt` — the typed error message with stack trace.
+- `*-mother-*.json` / `*-father-*.json` — parent exports (offspring path only).
+- `*-offspring-*.json` / `*-creature-*.json` — the post-fix creature export.
+- `*-context-*.json` — the replay metadata described below.
+
+**Replay metadata** (`*-context-*.json`):
+
+| Field                                | Path      | Meaning                                                |
+| ------------------------------------ | --------- | ------------------------------------------------------ |
+| `motherUuid` / `fatherUuid`          | offspring | parent stable identifiers                              |
+| `offspringUuid`                      | offspring | child stable identifier                                |
+| `breedSeed`                          | offspring | active PRNG seed at the time of the breed, or `"n/a"`  |
+| `mutationName`                       | mutator   | the operator that was just applied (e.g. `ADD_NODE`)   |
+| `creatureUuid`                       | mutator   | creature stable identifier                             |
+| `prngSeed`                           | mutator   | active PRNG seed, or `"n/a"` when the RNG was unseeded |
+| `prngSeeded`                         | both      | whether the active RNG was deterministic               |
+| `trapMessage`                        | both      | the `WasmBinaryValidator` trap message                 |
+| `preFixOffspring` / `preFixCreature` | both      | post-splice/post-mutation export _before_ `fix()` ran  |
+| `preMutationCreature`                | mutator   | shallow clone of the creature _before_ `mutate()` ran  |
+| `neuronCount` etc.                   | both      | shape summary at the time of rejection                 |
+
+**Replaying offline:**
+
+1. Pull the four files out of `.diagnostics/` for a single timestamp.
+2. Re-seed the RNG (`createSeededRng(breedSeed)` / `createSeededRng(prngSeed)`)
+   so any RNG-dependent repair step replays.
+3. For offspring: load the parent JSONs with `Creature.fromJSON` and call
+   `Offspring.breed(mother, father, …)`; the same combination of seed + parents
+   reproduces the failure.
+4. For mutator: load `preMutationCreature` with `Creature.fromJSON`, call
+   `mutator.mutateCreature(creature, Mutation[mutationName])`, then
+   `mutator.repairAfterMutation(creature)` — the gate should reject again,
+   confirming the dump is replay-ready.
+
+> [!TIP]
+> The dump filename prefixes are intentionally greppable. To list every
+> producer-gate rejection in a run:
+>
+> ```bash
+> ls .diagnostics/ | grep -E '^(offspring|mutator)-wasm-compile-trap-'
+> ```
+
 ## 💥 WASM panic recovery
 
 **Symptoms:**

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -37,7 +37,10 @@ import {
 } from "@neat/MetropolisHastings.ts";
 import type { MCMCDiagnostics } from "@neat/MCMCDiagnostics.ts";
 import { SquashEffectivenessTracker } from "@neat/SquashEffectivenessTracker.ts";
-import { ensureProducerOutputCompiles } from "@wasm/ProducerCompileGuard.ts";
+import { runProducerCompileProbe } from "@wasm/ProducerCompileGuard.ts";
+import { writeDiagnostics } from "@utils/Diagnostics.ts";
+import { exportJSONUnchecked } from "@creature/CreatureSerialization.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 
 /**
  * Cache entry for valid mutation candidates.
@@ -279,10 +282,21 @@ export class Mutator {
 
         let changed = false;
 
+        // Issue #2672: Capture a pre-mutation snapshot exclusively for the
+        // producer-gate diagnostic dump. The MCMC/original snapshots are
+        // only populated under specific conditions; we always need this one
+        // when the gate later rejects so the dump can replay the failure.
+        const diagnosticPreMutationSnapshot = creature.shallowClone();
+
         // Issue #2200: Track whether any topology mutations were applied.
         // Topology mutations are always accepted; M-H only applies to
         // weight/bias-only mutation batches.
         let hasTopologyMutation = false;
+
+        // Issue #2672: Record the last mutation method name applied during
+        // the batch so the diagnostic dump can attribute the WASM trap to a
+        // specific operator.
+        let lastAppliedMutationName: string | undefined;
 
         // Issue #1100: Track focus list across mutations to preserve focus cache.
         // Only clear focus cache when the focus list changes between mutations.
@@ -318,6 +332,7 @@ export class Mutator {
           );
           if (flag) {
             changed = true;
+            lastAppliedMutationName = mutationMethod.name;
             // Issue #2200: Track topology mutations for M-H gating
             if (isTopologyMutation(mutationMethod.name)) {
               hasTopologyMutation = true;
@@ -333,7 +348,10 @@ export class Mutator {
         // creature still fails to compile to WASM. Revert to the pre-mutation
         // snapshot so the bad topology does not propagate into evolution.
         if (changed) {
-          const repairOk = this.repairAfterMutation(creature);
+          const repairOk = this.repairAfterMutation(creature, {
+            preMutationSnapshot: diagnosticPreMutationSnapshot,
+            mutationName: lastAppliedMutationName,
+          });
           if (!repairOk) {
             const snapshot = mcmcSnapshot ?? original;
             if (snapshot) {
@@ -760,9 +778,28 @@ export class Mutator {
    * mutation. Structural validation is not run here; mutations must preserve a
    * valid creature.
    */
-  public repairAfterMutation(creature: Creature): boolean {
+  public repairAfterMutation(
+    creature: Creature,
+    diagnosticContext?: {
+      /** Issue #2672: snapshot of the creature taken **before** mutate() ran. */
+      preMutationSnapshot?: Creature;
+      /** Issue #2672: name of the mutation operator that was just applied. */
+      mutationName?: string;
+    },
+  ): boolean {
     const enforceForwardOnly = creature.forwardOnly === true ||
       (this.config.feedbackLoop !== true && creature.forwardOnly !== false);
+
+    // Issue #2672: Capture the post-mutation creature JSON *before* fix()
+    // runs so the diagnostic dump records the raw mutation output, not the
+    // repaired-but-still-broken intermediate.
+    let preFixCreatureExport: CreatureExport | string | undefined;
+    try {
+      preFixCreatureExport = exportJSONUnchecked(creature);
+    } catch {
+      preFixCreatureExport =
+        "(pre-fix export failed — creature too corrupted to serialise)";
+    }
 
     if (enforceForwardOnly) {
       creature.fix({ forwardOnly: true });
@@ -777,14 +814,64 @@ export class Mutator {
     // outputs=3). The probe attempts a real compile and one fix-retry; on
     // failure callers should revert the creature to its pre-mutation snapshot
     // rather than letting the bad topology contaminate training.
-    const compileResult = ensureProducerOutputCompiles(creature);
+    const compileResult = runProducerCompileProbe(creature);
     if (!compileResult.ok) {
+      const trapMessage = compileResult.trapMessage ?? "unknown trap";
+      // Issue #2672: enrich diagnostic dump for replay-ready debugging.
+      const rng = getRandomNumberGenerator();
+      const mutationName = diagnosticContext?.mutationName ?? "unknown";
+      const creatureUuid = creature.uuid ?? "no-uuid";
+      let preMutationExport: CreatureExport | string | undefined;
+      if (diagnosticContext?.preMutationSnapshot) {
+        try {
+          preMutationExport = exportJSONUnchecked(
+            diagnosticContext.preMutationSnapshot,
+          );
+        } catch {
+          preMutationExport =
+            "(pre-mutation export failed — snapshot too corrupted to serialise)";
+        }
+      }
+      let postRepairExport: CreatureExport | string;
+      try {
+        postRepairExport = exportJSONUnchecked(creature);
+      } catch {
+        postRepairExport =
+          "(post-repair export failed — creature too corrupted to serialise)";
+      }
+      writeDiagnostics({
+        error: new Error(
+          `WASM compile failed after ${mutationName} mutation: ${trapMessage}`,
+        ),
+        // Standardised dump prefix so post-mortem tooling can grep
+        // `.diagnostics/` for `mutator-wasm-compile-trap-*` files.
+        prefix: `mutator-wasm-compile-trap-${mutationName}-${creatureUuid}`,
+        creature: typeof postRepairExport === "string"
+          ? undefined
+          : postRepairExport,
+        context: {
+          mutationName,
+          creatureUuid,
+          prngSeed: rng.seed ?? "n/a (unseeded RNG)",
+          prngSeeded: rng.seeded,
+          trapMessage,
+          preMutationCreature: preMutationExport,
+          preFixCreature: preFixCreatureExport,
+          postRepairSerialisationError: typeof postRepairExport === "string"
+            ? postRepairExport
+            : undefined,
+          neuronCount: creature.neurons.length,
+          synapseCount: creature.synapses.length,
+          inputCount: creature.input,
+          outputCount: creature.output,
+          forwardOnly: creature.forwardOnly,
+        },
+      });
       getLogger().warn(
         `[Mutator] reverting mutation that fails WASM compile (` +
+          `mutation=${mutationName}, ` +
           `neurons=${creature.neurons.length}, inputs=${creature.input}, ` +
-          `outputs=${creature.output}): ${
-            compileResult.trapMessage ?? "unknown trap"
-          }`,
+          `outputs=${creature.output}): ${trapMessage}`,
       );
       return false;
     }

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -28,7 +28,9 @@ import type {
 } from "@architecture/SynapseInterfaces.ts";
 import { creatureValidate } from "@architecture/CreatureValidate.ts";
 import { assertForwardOnlyTopologyAfterBulkRemap } from "@architecture/ForwardOnlySynapseGuard.ts";
-import { ensureProducerOutputCompiles } from "@wasm/ProducerCompileGuard.ts";
+import { runProducerCompileProbe } from "@wasm/ProducerCompileGuard.ts";
+import { exportJSONUnchecked } from "@creature/CreatureSerialization.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 
 class OffspringError extends Error {
   constructor(message: string) {
@@ -566,6 +568,18 @@ export class Offspring {
     delete offspring.uuid;
     const childUUID = CreatureUtil.makeUUID(offspring);
 
+    // Issue #2672: Capture the post-splice/pre-fix offspring snapshot so the
+    // producer-gate diagnostic dump can include both the raw cross-over
+    // output and the post-fix output. Use the unchecked exporter — the
+    // creature has not been repaired yet and may not pass `creatureValidate`.
+    let preFixOffspringExport: CreatureExport | string;
+    try {
+      preFixOffspringExport = exportJSONUnchecked(offspring);
+    } catch {
+      preFixOffspringExport =
+        "(pre-fix export failed — offspring too corrupted to serialise)";
+    }
+
     assert(childUUID, "Failed to make UUID for offspring");
     assert(mother.uuid, "Failed to make UUID for mother");
     assert(father.uuid, "Failed to make UUID for father");
@@ -681,20 +695,53 @@ export class Offspring {
     // inputs=2054, outputs=3). Run a one-shot compile probe here so a bad
     // topology is repaired or dropped at the producer rather than leaking into
     // training and only being caught by the call-site recovery (#2483).
-    const compileResult = ensureProducerOutputCompiles(offspring);
+    const compileResult = runProducerCompileProbe(offspring);
     if (!compileResult.ok) {
       offspring.DEBUG = false;
+      // Issue #2672: Capture post-fix offspring even when `exportJSON()`
+      // could throw (the compile gate has already declared this topology
+      // bad). The diagnostic dump must always land.
+      let postFixOffspringExport: CreatureExport | string;
+      try {
+        postFixOffspringExport = exportJSONUnchecked(offspring);
+      } catch {
+        postFixOffspringExport =
+          "(post-fix export failed — offspring too corrupted to serialise)";
+      }
+      const trapMessage = compileResult.trapMessage ?? "unknown trap";
+      const activeSeed = rng.seed;
       writeDiagnostics({
         error: new TopologyError(
-          `WASM compile failed for offspring: ${
-            compileResult.trapMessage ?? "unknown trap"
-          }`,
+          `WASM compile failed for offspring: ${trapMessage}`,
           "INVALID_CONNECTION",
         ),
-        prefix: "offspring-wasm-compile-trap",
+        // Issue #2672: standardised dump prefix so post-mortem tooling can
+        // grep `.diagnostics/` for `offspring-wasm-compile-trap-*` files.
+        prefix: `offspring-wasm-compile-trap-${childUUID}`,
         mother: mother.exportJSON(),
         father: father.exportJSON(),
-        offspring: offspring.exportJSON(),
+        offspring: typeof postFixOffspringExport === "string"
+          ? undefined
+          : postFixOffspringExport,
+        context: {
+          // Replay metadata for offline reproduction (Issue #2672).
+          motherUuid: mother.uuid ?? "n/a",
+          fatherUuid: father.uuid ?? "n/a",
+          offspringUuid: childUUID,
+          breedSeed: activeSeed ?? "n/a (unseeded RNG)",
+          prngSeeded: rng.seeded,
+          trapMessage,
+          preFixOffspring: preFixOffspringExport,
+          postFixOffspringSerialisationError:
+            typeof postFixOffspringExport === "string"
+              ? postFixOffspringExport
+              : undefined,
+          neuronCount: offspring.neurons.length,
+          synapseCount: offspring.synapses.length,
+          inputCount: offspring.input,
+          outputCount: offspring.output,
+          forwardOnly: offspring.forwardOnly,
+        },
       });
       getLogger().warn(
         `[Offspring] dropping offspring that fails WASM compile (` +

--- a/src/utils/RandomNumberGenerator.ts
+++ b/src/utils/RandomNumberGenerator.ts
@@ -42,6 +42,13 @@ export interface RandomNumberGenerator {
    * Whether this RNG was created with a deterministic seed.
    */
   readonly seeded: boolean;
+
+  /**
+   * Issue #2672: The seed value used to initialise this RNG, when seeded.
+   * Returns `null` for unseeded RNGs so diagnostic dumps can record the
+   * exact value needed to replay a producer-gate failure offline.
+   */
+  readonly seed: number | null;
 }
 
 // ─── xoshiro256** implementation ────────────────────────────────────────────
@@ -191,9 +198,11 @@ function initState(seed: number): Xoshiro256State {
 
 class SeededRng implements RandomNumberGenerator {
   readonly seeded = true;
+  readonly seed: number;
   private state: Xoshiro256State;
 
   constructor(seed: number) {
+    this.seed = seed;
     this.state = initState(seed);
   }
 
@@ -215,6 +224,7 @@ class SeededRng implements RandomNumberGenerator {
 
 class UnseededRng implements RandomNumberGenerator {
   readonly seeded = false;
+  readonly seed = null;
 
   random(): number {
     // Use crypto.getRandomValues for a secure random float in [0, 1).

--- a/src/wasm/ProducerCompileGuard.ts
+++ b/src/wasm/ProducerCompileGuard.ts
@@ -150,8 +150,8 @@ let producerCompileProbe: (creature: Creature) => ProducerCompileResult =
 
 /**
  * Issue #2671: Test-only — replace the underlying compile probe used by
- * `passesProducerCompileGate`. Returns a disposer that restores the real
- * probe.
+ * `passesProducerCompileGate` AND `runProducerCompileProbe`. Returns a
+ * disposer that restores the real probe.
  *
  * Intentionally not re-exported through `@wasm/mod.ts` — production code
  * must always use the real `ensureProducerOutputCompiles`.
@@ -164,6 +164,24 @@ export function __setProducerCompileGateProbeForTesting(
   return () => {
     producerCompileProbe = previous;
   };
+}
+
+/**
+ * Issue #2672: Internal helper that delegates to the (possibly stubbed)
+ * compile probe. Direct callers in `Offspring.breed` and
+ * `Mutator.repairAfterMutation` use this instead of the raw
+ * `ensureProducerOutputCompiles` so the existing test seam
+ * (`__setProducerCompileGateProbeForTesting`) can deterministically force
+ * a gate rejection without engineering a WASM-tripping topology — the same
+ * pattern already used by `passesProducerCompileGate`.
+ *
+ * Production behaviour is identical: when no test stub is installed the
+ * call is exactly `ensureProducerOutputCompiles(creature)`.
+ */
+export function runProducerCompileProbe(
+  creature: Creature,
+): ProducerCompileResult {
+  return producerCompileProbe(creature);
 }
 
 /**

--- a/test/wasm/ProducerGateDiagnosticDumps.ts
+++ b/test/wasm/ProducerGateDiagnosticDumps.ts
@@ -1,0 +1,362 @@
+/**
+ * Issue #2672 — Producer-gate diagnostic dump enrichment.
+ *
+ * When the producer-side WASM compile gate rejects a freshly bred or mutated
+ * creature, the diagnostic dump must contain enough metadata to replay the
+ * failure offline. These tests force a rejection via the test seam
+ * `__setProducerCompileGateProbeForTesting`, run the producer path, and
+ * assert that the resulting files under `.diagnostics/`:
+ *
+ *  - Use the standardised file-name prefix
+ *    (`offspring-wasm-compile-trap-<uuid>` / `mutator-wasm-compile-trap-<op>-<uuid>`).
+ *  - Carry the new replay-ready context fields: parent UUIDs, breed/PRNG
+ *    seed, trap message, pre-fix snapshot, and (for the mutator path) the
+ *    pre-mutation creature plus the operator name.
+ */
+
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { Mutator } from "@neat/Mutator.ts";
+import { Mutation } from "@neat/Mutation.ts";
+import { AddNeuron } from "@mutate/AddNeuron.ts";
+import { Offspring } from "@architecture/Offspring.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import {
+  __setProducerCompileGateProbeForTesting,
+} from "@wasm/ProducerCompileGuard.ts";
+import { DIAGNOSTICS_DIR } from "@utils/Diagnostics.ts";
+import {
+  createSeededRng,
+  setRandomNumberGenerator,
+} from "@utils/RandomNumberGenerator.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+const REJECT_PROBE = () => ({
+  ok: false as const,
+  trapMessage: "test-forced trap (issue #2672)",
+});
+
+interface DumpFiles {
+  errorPath: string;
+  errorText: string;
+  contextPath: string;
+  context: Record<string, unknown>;
+  motherPath?: string;
+  fatherPath?: string;
+  offspringPath?: string;
+  creaturePath?: string;
+}
+
+/**
+ * Snapshot the file names already in `.diagnostics/` so the test can grep
+ * for files written by *this* run only.
+ */
+function snapshotExisting(): Set<string> {
+  const seen = new Set<string>();
+  try {
+    for (const entry of Deno.readDirSync(DIAGNOSTICS_DIR)) {
+      seen.add(entry.name);
+    }
+  } catch {
+    // Directory does not exist yet — first run.
+  }
+  return seen;
+}
+
+/** Find dump files created since the snapshot whose name starts with prefix. */
+function findDumpsByPrefix(
+  prefix: string,
+  existing: Set<string>,
+): {
+  error: string[];
+  context: string[];
+  mother: string[];
+  father: string[];
+  offspring: string[];
+  creature: string[];
+} {
+  const result = {
+    error: [] as string[],
+    context: [] as string[],
+    mother: [] as string[],
+    father: [] as string[],
+    offspring: [] as string[],
+    creature: [] as string[],
+  };
+  try {
+    for (const entry of Deno.readDirSync(DIAGNOSTICS_DIR)) {
+      if (existing.has(entry.name)) continue;
+      if (!entry.name.startsWith(prefix)) continue;
+      if (entry.name.includes("-error-")) result.error.push(entry.name);
+      else if (entry.name.includes("-context-")) {
+        result.context.push(entry.name);
+      } else if (entry.name.includes("-mother-")) {
+        result.mother.push(entry.name);
+      } else if (entry.name.includes("-father-")) {
+        result.father.push(entry.name);
+      } else if (entry.name.includes("-offspring-")) {
+        result.offspring.push(entry.name);
+      } else if (entry.name.includes("-creature-")) {
+        result.creature.push(entry.name);
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return result;
+}
+
+function readDump(prefix: string, existing: Set<string>): DumpFiles {
+  const dumps = findDumpsByPrefix(prefix, existing);
+  assert(
+    dumps.error.length > 0,
+    `expected an error dump with prefix '${prefix}', got nothing (existing=${existing.size})`,
+  );
+  assert(
+    dumps.context.length > 0,
+    `expected a context dump with prefix '${prefix}', got nothing`,
+  );
+  const errorPath = `${DIAGNOSTICS_DIR}/${dumps.error[0]}`;
+  const contextPath = `${DIAGNOSTICS_DIR}/${dumps.context[0]}`;
+  return {
+    errorPath,
+    errorText: Deno.readTextFileSync(errorPath),
+    contextPath,
+    context: JSON.parse(Deno.readTextFileSync(contextPath)),
+    motherPath: dumps.mother[0]
+      ? `${DIAGNOSTICS_DIR}/${dumps.mother[0]}`
+      : undefined,
+    fatherPath: dumps.father[0]
+      ? `${DIAGNOSTICS_DIR}/${dumps.father[0]}`
+      : undefined,
+    offspringPath: dumps.offspring[0]
+      ? `${DIAGNOSTICS_DIR}/${dumps.offspring[0]}`
+      : undefined,
+    creaturePath: dumps.creature[0]
+      ? `${DIAGNOSTICS_DIR}/${dumps.creature[0]}`
+      : undefined,
+  };
+}
+
+function cleanupByPrefix(prefix: string, existing: Set<string>): void {
+  try {
+    for (const entry of Deno.readDirSync(DIAGNOSTICS_DIR)) {
+      if (existing.has(entry.name)) continue;
+      if (entry.name.startsWith(prefix)) {
+        try {
+          Deno.removeSync(`${DIAGNOSTICS_DIR}/${entry.name}`);
+        } catch {
+          // best effort
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function buildHealthyCreature(): Creature {
+  const c = new Creature(2, 1, {
+    layers: [{ count: 2, squash: "TANH" }],
+  });
+  c.fix();
+  CreatureUtil.makeUUID(c);
+  return c;
+}
+
+/**
+ * Build a structurally rich, deterministically seeded creature suitable for
+ * the offspring path. Two creatures built with different seeds combine via
+ * `Offspring.breed` to produce a child whose UUID differs from both parents
+ * — needed so the breed reaches the producer-gate instead of short-
+ * circuiting at the "child is a clone of a parent" guard.
+ */
+function buildBreedingParent(seed: number): Creature {
+  setRandomNumberGenerator(createSeededRng(seed));
+  const c = new Creature(4, 2);
+  c.fix();
+  const op = new AddNeuron(c);
+  for (let i = 0; i < 5; i++) op.mutate();
+  c.fix();
+  delete c.uuid;
+  CreatureUtil.makeUUID(c);
+  return c;
+}
+
+Deno.test(
+  "Issue #2672: Offspring.breed dump uses standardised prefix and embeds replay metadata",
+  async () => {
+    await initWasmForTests();
+
+    // Use a deterministic RNG so the dump records a concrete `breedSeed`.
+    setRandomNumberGenerator(createSeededRng(20260515));
+
+    const existing = snapshotExisting();
+    const restore = __setProducerCompileGateProbeForTesting(REJECT_PROBE);
+    try {
+      const mother = buildBreedingParent(100);
+      const father = buildBreedingParent(999);
+      const motherUuid = mother.uuid;
+      const fatherUuid = father.uuid;
+      assert(motherUuid, "mother must have a uuid");
+      assert(fatherUuid, "father must have a uuid");
+      assertNotEquals(
+        motherUuid,
+        fatherUuid,
+        "test parents must have distinct uuids",
+      );
+
+      // Reset RNG *after* construction (Creature ctor consumes randomness)
+      // so the recorded breedSeed reflects the seeded RNG at gate time.
+      // Seed 2 reliably produces an offspring whose UUID differs from both
+      // parents and therefore reaches the producer-gate.
+      const BREED_SEED = 2;
+      setRandomNumberGenerator(createSeededRng(BREED_SEED));
+
+      const result = Offspring.breed(mother, father, { forwardOnly: true });
+      assertEquals(
+        result,
+        undefined,
+        "Offspring.breed must drop the offspring when the producer gate rejects",
+      );
+
+      const dump = readDump("offspring-wasm-compile-trap-", existing);
+
+      // Trap message threaded through to the error file.
+      assert(
+        dump.errorText.includes("test-forced trap (issue #2672)"),
+        `error file should include trap message, got: ${dump.errorText}`,
+      );
+
+      // Replay context fields (Issue #2672).
+      assertEquals(
+        dump.context.motherUuid,
+        motherUuid,
+        "context.motherUuid must match the mother creature uuid",
+      );
+      assertEquals(
+        dump.context.fatherUuid,
+        fatherUuid,
+        "context.fatherUuid must match the father creature uuid",
+      );
+      assertEquals(
+        typeof dump.context.offspringUuid,
+        "string",
+        "context.offspringUuid must be a string",
+      );
+      assertEquals(
+        dump.context.breedSeed,
+        BREED_SEED,
+        "context.breedSeed must record the active PRNG seed",
+      );
+      assertEquals(
+        dump.context.prngSeeded,
+        true,
+        "context.prngSeeded must reflect the active RNG",
+      );
+      assertEquals(
+        dump.context.trapMessage,
+        "test-forced trap (issue #2672)",
+        "context.trapMessage must include the validator output",
+      );
+      assert(
+        dump.context.preFixOffspring,
+        "context.preFixOffspring must be present",
+      );
+
+      // Per-creature dumps still land alongside the context.
+      assert(dump.motherPath, "mother dump file must exist");
+      assert(dump.fatherPath, "father dump file must exist");
+      assert(dump.offspringPath, "offspring dump file must exist");
+    } finally {
+      restore();
+      cleanupByPrefix("offspring-wasm-compile-trap-", existing);
+    }
+  },
+);
+
+Deno.test(
+  "Issue #2672: Mutator.repairAfterMutation dump uses standardised prefix and embeds replay metadata",
+  async () => {
+    await initWasmForTests();
+
+    const existing = snapshotExisting();
+    const restore = __setProducerCompileGateProbeForTesting(REJECT_PROBE);
+    try {
+      const creature = buildHealthyCreature();
+      const preMutation = creature.shallowClone();
+      const mutator = new Mutator(
+        createNeatConfig({
+          feedbackLoop: false,
+          mutationRate: 1,
+          mutationAmount: 1,
+          mutation: [Mutation.MOD_WEIGHT],
+          log: 0,
+        }),
+      );
+      // createNeatConfig replaces the global RNG with an unseeded one. Set
+      // a deterministic seed *after* the config is built so the diagnostic
+      // dump records a concrete `prngSeed` value.
+      setRandomNumberGenerator(createSeededRng(20260516));
+
+      // Mimic the call pattern from Mutator.mutate() — apply, then repair
+      // with diagnostic context.
+      const changed = mutator.mutateCreature(creature, Mutation.MOD_WEIGHT);
+      assert(changed, "MOD_WEIGHT must report a change for the test creature");
+      const repairOk = mutator.repairAfterMutation(creature, {
+        preMutationSnapshot: preMutation,
+        mutationName: Mutation.MOD_WEIGHT.name,
+      });
+      assertEquals(
+        repairOk,
+        false,
+        "repairAfterMutation must return false when the gate rejects",
+      );
+
+      const dump = readDump(
+        `mutator-wasm-compile-trap-${Mutation.MOD_WEIGHT.name}-`,
+        existing,
+      );
+
+      assert(
+        dump.errorText.includes("test-forced trap (issue #2672)"),
+        `error file should include trap message, got: ${dump.errorText}`,
+      );
+
+      assertEquals(
+        dump.context.mutationName,
+        Mutation.MOD_WEIGHT.name,
+        "context.mutationName must record the operator that was applied",
+      );
+      assertEquals(
+        dump.context.prngSeed,
+        20260516,
+        "context.prngSeed must record the active PRNG seed",
+      );
+      assertEquals(
+        dump.context.prngSeeded,
+        true,
+        "context.prngSeeded must reflect the active RNG",
+      );
+      assertEquals(
+        dump.context.trapMessage,
+        "test-forced trap (issue #2672)",
+        "context.trapMessage must surface the validator output",
+      );
+      assert(
+        dump.context.preMutationCreature,
+        "context.preMutationCreature must capture the snapshot taken before mutate()",
+      );
+      assert(
+        dump.context.preFixCreature,
+        "context.preFixCreature must capture the snapshot taken before fix()",
+      );
+
+      assert(dump.creaturePath, "creature dump file must exist");
+    } finally {
+      restore();
+      cleanupByPrefix("mutator-wasm-compile-trap-", existing);
+    }
+  },
+);


### PR DESCRIPTION
# PR Summary — Issue #2672

## Summary

Enriches the producer-gate diagnostic dumps written by `Offspring.breed` and
`Mutator.repairAfterMutation` so a WASM-compile rejection can be replayed
offline. Each dump now carries the active PRNG seed, the trap message from
`WasmBinaryValidator`, the post-splice/pre-fix snapshot, and (for the mutator
path) the pre-mutation creature plus the operator name. Dump filenames are
standardised so post-mortem tooling can grep `.diagnostics/` for
`offspring-wasm-compile-trap-<uuid>-*` and
`mutator-wasm-compile-trap-<operator>-<uuid>-*`. Closes #2672.

## Changes

- `src/utils/RandomNumberGenerator.ts` — adds a `seed: number | null` property
  to `RandomNumberGenerator` (and the seeded/unseeded implementations) so the
  diagnostic dump can record the exact value needed to reconstruct the RNG.
- `src/wasm/ProducerCompileGuard.ts` — adds `runProducerCompileProbe()`, a
  test-seam-aware delegate over `producerCompileProbe`. Direct producer
  callers (`Offspring.breed` and `Mutator.repairAfterMutation`) now go
  through this helper so the existing
  `__setProducerCompileGateProbeForTesting` mechanism can deterministically
  force a rejection.
- `src/architecture/Offspring.ts` — captures the post-splice/pre-fix offspring
  via `exportJSONUnchecked`, then on producer-gate rejection writes a
  diagnostic dump with the standardised
  `offspring-wasm-compile-trap-<childUuid>` prefix and a `context` block
  containing `motherUuid`, `fatherUuid`, `offspringUuid`, `breedSeed`,
  `prngSeeded`, `trapMessage`, `preFixOffspring`, and shape metadata.
- `src/NEAT/Mutator.ts` — extends `repairAfterMutation` with an optional
  diagnostic context (`{ preMutationSnapshot, mutationName }`). The caller
  (`Mutator.mutate`) takes a `shallowClone` of the creature before applying
  the mutation batch and threads the last applied operator name into the
  diagnostic context. On producer-gate rejection the dump now lands as
  `mutator-wasm-compile-trap-<operator>-<creatureUuid>-*` with the operator
  name, PRNG seed, trap message, pre-mutation snapshot, and pre-fix snapshot
  embedded in `context`.
- `docs/troubleshooting/WASM.md` — adds the new section
  `🧪 Producer-gate WASM compile rejects (Issue #2672)` documenting dump
  locations, the context fields, and a step-by-step offline replay recipe.
- `docs/TROUBLESHOOTING.md` — adds a top-level FAQ entry pointing at the new
  section.

## Evidence

Backend/CLI change with no UI surface.

```mermaid
sequenceDiagram
    participant Mutate as Mutator.mutate
    participant Repair as repairAfterMutation
    participant Probe as runProducerCompileProbe
    participant Dump as writeDiagnostics

    Mutate->>Mutate: shallowClone(creature) → preMutationSnapshot
    Mutate->>Mutate: mutateCreature(...) (records lastAppliedMutationName)
    Mutate->>Repair: { preMutationSnapshot, mutationName }
    Repair->>Repair: exportJSONUnchecked → preFixCreature
    Repair->>Repair: fix({ forwardOnly })
    Repair->>Probe: ensureProducerOutputCompiles
    Probe-->>Repair: { ok: false, trapMessage }
    Repair->>Dump: prefix=mutator-wasm-compile-trap-<op>-<uuid><br/>context: { mutationName, prngSeed,<br/>trapMessage, preMutationCreature, preFixCreature, ... }
    Repair-->>Mutate: false (revert)
```

- New test file `test/wasm/ProducerGateDiagnosticDumps.ts` exercises both
  paths against a stubbed reject probe and asserts the standardised
  filename prefix is used and that the new context fields are present.
- `quality.sh --skip-discovery` — 6363 passed, 0 failed, 4 ignored
  (53 s test step).

## Test Plan

- [x] New: `test/wasm/ProducerGateDiagnosticDumps.ts::Issue #2672:
  Offspring.breed dump uses standardised prefix and embeds replay metadata`
- [x] New: `test/wasm/ProducerGateDiagnosticDumps.ts::Issue #2672:
  Mutator.repairAfterMutation dump uses standardised prefix and embeds
  replay metadata`
- [x] Regression: existing
  `test/wasm/ProducerCompileGuard.ts`,
  `test/wasm/ProducerCompileGateWiring.ts`,
  `test/feedForward/ForwardOnlyRepairAfterMutation.ts`,
  `test/feedForward/ForwardOnlySemanticVersion.ts`,
  `test/feedForward/ForwardOnlyViolationLogging.ts`,
  `test/utils/RandomNumberGenerator.ts`,
  `test/utils/Diagnostics.ts` — all pass unchanged.
- [x] Full `quality.sh --skip-discovery` clean.



## Milestone
This PR is part of the **WASM for RL** milestone and targets the `milestone/wasm-for-rl` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2672 -->