### PR TITLE
fix(wasm): preserve neuron position order in topology hash (#2670)

### DIFF
--- a/docs/pr-summary-2670.md
+++ b/docs/pr-summary-2670.md
@@ -1,0 +1,109 @@
+# PR Summary — Issue #2670
+
+## Summary
+
+Fix the lunar_lander-shape producer-gate reject by closing a position-blind
+topology-hash collision in the WASM compilation cache. Closes #2670.
+
+`CreatureUtil.getTopologyHash` sorted its non-input neuron keys before
+hashing, making the hash independent of the order in which UUIDs appeared
+inside `creature.neurons`. But `WasmCompilationCache.buildTemplate` encodes
+each synapse's `from_index` and each neuron's `squash`/`is_constant` bytes
+**by integer position** in that same array. The result: two creatures with
+the same UUID-set + same UUID→UUID synapse-set but a different valid
+topological ordering shared a cache key. The second creature was served the
+first creature's stale template, mis-mapping `from_index` and `squash` bytes
+to neurons that no longer matched, and tripping `RuntimeError: unreachable`
+inside `CompiledNetwork::new`.
+
+The producer-gate's fix-and-retry path could not repair this — the offending
+creature was a perfectly valid forward-only DAG; the corruption lived inside
+the cached binary, not the creature.
+
+The fix preserves neuron **position order** inside the topology hash. The
+hash now distinguishes two creatures that differ only in their neuron
+positions, so the cache always rebuilds a template for the new ordering
+instead of serving a stale one.
+
+## Evidence
+
+### Root-cause confirmation
+
+A targeted reproducer replayed `LunarLanderShapeProducerGate` up to iter 47
+(the failing breed at seed 2668) and captured the offspring inside the
+gate:
+
+| Probe                                          | Result                           |
+|------------------------------------------------|----------------------------------|
+| Gate on captured creature, polluted cache      | `{ ok: false, trapMessage: "unreachable" }` |
+| Gate on same creature after `clearWasmCompilationCache()` | `{ ok: true }`                   |
+| Gate on creature exported→imported, fresh cache | `{ ok: true }`                   |
+
+The topology hash was identical in all three cases — confirming a stale
+cached template, not a defective topology, was the failure.
+
+Tracing every gate-bound creature found another offspring earlier in the
+loop with the same `topologyHash` but its hidden neurons in a **different
+positional order** (UUIDs `70065ccc...` and `d7eabea4...` swapped, plus
+`8218af45...` and `048cde34...` swapped). That earlier offspring populated
+the cache; the later one hit the stale template.
+
+### Producer-gate reproducer
+
+`test/wasm/LunarLanderShapeProducerGate.ts` (Issue #2668) goes from
+1 producer-gate reject (allowance 5) to **0 rejects** (allowance 0).
+The diagnostic dump directory is empty after the run.
+
+### Mermaid: how the collision arose
+
+```mermaid
+flowchart LR
+    A[Creature A<br/>positions: hidden-a, hidden-b] -->|getTopologyHash| H[(Same hash<br/>e9cd5014-...)]
+    B[Creature B<br/>positions: hidden-b, hidden-a<br/>same UUID set] -->|getTopologyHash| H
+    H --> C{WASM cache lookup}
+    C -->|miss for A| T1[Template built from A's positions<br/>from_index, squash bytes]
+    C -->|hit for B| T1
+    T1 -->|served to B| X[B's WASM build mixes<br/>A's positional from_index<br/>with B's neuron content<br/>→ RuntimeError: unreachable]
+```
+
+After the fix, A and B hash to different values, so B builds its own
+template:
+
+```mermaid
+flowchart LR
+    A2[Creature A] -->|getTopologyHash<br/>incl. position order| HA[(hash_A)]
+    B2[Creature B] -->|getTopologyHash<br/>incl. position order| HB[(hash_B)]
+    HA --> CA[Template for A] --> OK1[A compiles OK]
+    HB --> CB[Template for B] --> OK2[B compiles OK]
+```
+
+### Diagnostic dump from #2668
+
+Pre-fix dumps are still present in the working tree (e.g.
+`.diagnostics/offspring-wasm-compile-trap-47cf0f07-...-context-*.json`)
+demonstrating the original failure mode. After the fix the suite produces
+no dumps for the same seed.
+
+## Test Plan
+
+- `test/architecture/TopologyHash.ts`:
+  - Renamed the historic "order independent" test to
+    `synapse-array order independent (#2670)` (the WASM template is built
+    via `inwardConnections` which sorts internally — synapse-array order
+    genuinely doesn't matter) and tightened its construction so it only
+    varies the synapse array order.
+  - Added `neuron position order is significant (#2670)` — two creatures
+    with the same UUID-set but a hidden-neuron position swap must hash to
+    different values.
+- `test/wasm/TopologyHashPositionOrderingIssue2670.ts` (new):
+  - Asserts the hash distinguishes the two valid topological orderings.
+  - Compiles both via `getOrCompileWasmModule` from a freshly cleared
+    cache; pre-fix the second compile would trap with
+    `RuntimeError: unreachable`.
+- `test/wasm/LunarLanderShapeProducerGate.ts`:
+  - `BASELINE_REJECT_ALLOWANCE` lowered from 5 to 0 — the reproducer must
+    show zero gate rejects.
+- All 22 topology-hash tests pass; all 30 WASM cache / pre-warmer / template
+  tests pass; 6 734 tests pass overall on `quality.sh`. Two unrelated
+  `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` leaks fail on
+  the base branch too and are out of scope.

--- a/src/architecture/CreatureUtils.ts
+++ b/src/architecture/CreatureUtils.ts
@@ -154,9 +154,18 @@ export class CreatureUtil {
    * with different input counts produce distinct hashes, preventing
    * WASM compilation cache collisions after Upgrade.correct().
    *
+   * Issue #2670: Preserve neuron position order in the hash. The WASM
+   * compilation cache template encodes synapse `from_index` and per-neuron
+   * `squash` byte by integer position in `creature.neurons`, so two
+   * creatures that share the same UUID-set + UUID→UUID synapse-set but
+   * differ in topological ordering would previously collide in the hash
+   * and have one creature's stale template served to the other — tripping
+   * a `RuntimeError: unreachable` inside `CompiledNetwork::new`. Including
+   * the position order makes the hash one-to-one with the binary template.
+   *
    * The hash is based on:
    * - Input count (`creature.input`)
-   * - Neuron UUIDs, types, and squash functions
+   * - Neuron UUIDs, types, and squash functions **in position order**
    * - Synapse connection patterns (fromUUID -> toUUID pairs)
    * - NOT weights, biases, or tags
    *
@@ -205,14 +214,18 @@ export class CreatureUtil {
         }
       }
 
-      // Build sorted neuron topology key strings (non-input only).
+      // Build neuron topology key strings in position order (non-input only).
+      // Issue #2670: Position order is intentional — see the docstring above.
+      // The WASM template encodes by integer position, so two creatures with
+      // the same UUID-set but a different topological ordering must hash to
+      // different values to avoid stale cached templates trapping the WASM
+      // constructor with `RuntimeError: unreachable`.
       const neuronKeys = new Array<string>(neuronsLength - inputCount);
       for (let i = inputCount; i < neuronsLength; i++) {
         const neuron = neurons[i];
         neuronKeys[i - inputCount] = uuids[i] + "\t" + neuron.type + "\t" +
           (neuron.squash || "");
       }
-      neuronKeys.sort();
       neuronKey = neuronKeys.join("\n");
 
       // Cache for reuse across connection-only changes.

--- a/test/architecture/TopologyHash.ts
+++ b/test/architecture/TopologyHash.ts
@@ -166,8 +166,12 @@ Deno.test("getTopologyHash - different connection pattern should produce differe
   );
 });
 
-Deno.test("getTopologyHash - order independent", () => {
-  // Neurons and synapses in different order but same topology
+Deno.test("getTopologyHash - synapse-array order independent (#2670)", () => {
+  // Same neuron positions and same UUID→UUID synapse set, but the
+  // `synapses` array is supplied in a different order. The WASM template
+  // is built via `inwardConnections(i)` which sorts by `to` then `from`,
+  // so the order of `creature.synapses` does NOT affect the binary —
+  // the hash must therefore stay the same.
   const creature1: CreatureExport = {
     neurons: [
       { type: "hidden", uuid: "hidden-a", squash: "TANH", bias: 0.1 },
@@ -184,13 +188,13 @@ Deno.test("getTopologyHash - order independent", () => {
     output: 1,
   };
 
-  // Same structure, different ordering
   const creature2: CreatureExport = {
     neurons: [
-      { type: "hidden", uuid: "hidden-b", squash: "LOGISTIC", bias: 0.2 },
       { type: "hidden", uuid: "hidden-a", squash: "TANH", bias: 0.1 },
+      { type: "hidden", uuid: "hidden-b", squash: "LOGISTIC", bias: 0.2 },
       { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.3 },
     ],
+    // Same UUID pairs, shuffled.
     synapses: [
       { fromUUID: "hidden-b", toUUID: "output-0", weight: 0.4 },
       { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.3 },
@@ -204,13 +208,63 @@ Deno.test("getTopologyHash - order independent", () => {
   const c1 = Creature.fromJSON(creature1);
   const c2 = Creature.fromJSON(creature2);
 
-  const hash1 = CreatureUtil.getTopologyHash(c1);
-  const hash2 = CreatureUtil.getTopologyHash(c2);
-
   assertEquals(
-    hash1,
-    hash2,
-    "Topology hash should be order-independent",
+    CreatureUtil.getTopologyHash(c1),
+    CreatureUtil.getTopologyHash(c2),
+    "Topology hash must be independent of synapse-array order",
+  );
+});
+
+Deno.test("getTopologyHash - neuron position order is significant (#2670)", () => {
+  // Same UUID set + same UUID→UUID synapses, but the hidden neurons are
+  // listed in different positional orders. The WASM compilation cache
+  // template encodes synapse `from_index` and per-neuron `squash` byte by
+  // integer position in `creature.neurons`, so serving a cached template
+  // built for one ordering to a creature with a different ordering trips
+  // `RuntimeError: unreachable` inside `CompiledNetwork::new`. The hash
+  // MUST distinguish these two creatures so the cache treats them as
+  // distinct topologies.
+  const creature1: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-a", squash: "TANH", bias: 0.1 },
+      { type: "hidden", uuid: "hidden-b", squash: "LOGISTIC", bias: 0.2 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.3 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: 0.2 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.3 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: 0.4 },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  // Hidden neurons swapped — both orderings are valid topological orders.
+  const creature2: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-b", squash: "LOGISTIC", bias: 0.2 },
+      { type: "hidden", uuid: "hidden-a", squash: "TANH", bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.3 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: 0.2 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.3 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: 0.4 },
+    ],
+    input: 2,
+    output: 1,
+  };
+
+  const c1 = Creature.fromJSON(creature1);
+  const c2 = Creature.fromJSON(creature2);
+
+  assertNotEquals(
+    CreatureUtil.getTopologyHash(c1),
+    CreatureUtil.getTopologyHash(c2),
+    "Neuron position swap must change the topology hash so the WASM " +
+      "compilation cache cannot serve a stale template across orderings",
   );
 });
 

--- a/test/wasm/LunarLanderShapeProducerGate.ts
+++ b/test/wasm/LunarLanderShapeProducerGate.ts
@@ -62,17 +62,14 @@ const POPULATION_SIZE = 4;
 /** Fixed seed — change only with a deliberate baseline-recapture commit. */
 const SEED = 2668;
 /**
- * Maximum producer-gate rejects we tolerate today. The fix in #2666 will
- * drive this to zero; do NOT raise it to make the test pass.
- *
- * Observed baseline at seed 2668: 1 reject (a single `[Offspring]` drop on
- * a 28-neuron offspring with shape inputs=7/outputs=3 — exactly the
- * lunar_lander shape from the bug report). The 5-reject allowance leaves a
- * small margin for unrelated mutator-cache state changes; if the count
- * drifts UP, the producer is emitting MORE bad topologies — investigate
- * #2666 rather than raising the allowance.
+ * Maximum producer-gate rejects we tolerate. Issue #2670 drove this to
+ * zero by fixing the topology-hash collision that let the WASM
+ * compilation cache serve a stale template across two valid topological
+ * orderings of the same UUID set (causing the `RuntimeError: unreachable`
+ * inside `CompiledNetwork::new`). Do NOT raise this — a non-zero count
+ * means a NEW producer defect is leaking past the gate.
  */
-const BASELINE_REJECT_ALLOWANCE = 5;
+const BASELINE_REJECT_ALLOWANCE = 0;
 
 // ---------------------------------------------------------------------------
 // Test helpers

--- a/test/wasm/TopologyHashPositionOrderingIssue2670.ts
+++ b/test/wasm/TopologyHashPositionOrderingIssue2670.ts
@@ -1,0 +1,148 @@
+/**
+ * Issue #2670 — Regression test for the WASM compilation cache stale-template
+ * trap caused by position-independent topology hashing.
+ *
+ * Background:
+ *
+ *   `WasmCompilationCache` keys cached binary templates by
+ *   `CreatureUtil.getTopologyHash`. Before this fix the hash sorted neuron
+ *   keys before hashing, so two creatures with the same UUID-set + same
+ *   UUID→UUID synapse-set but different neuron positional orderings would
+ *   share a hash. The template buffer, however, encodes synapse
+ *   `from_index` and per-neuron `squash` by INTEGER POSITION in
+ *   `creature.neurons`. Serving a cached template built for one ordering
+ *   to a creature with a different ordering tripped a
+ *   `RuntimeError: unreachable` inside `CompiledNetwork::new`.
+ *
+ *   The fix preserves neuron position order inside the topology hash.
+ *   This test pins that invariant by:
+ *
+ *     1. Constructing two creatures with the same UUID-set + same
+ *        UUID→UUID synapse-set, but with the hidden neurons in different
+ *        positional orders (both orderings are valid topological orders).
+ *     2. Asserting that their `getTopologyHash` values differ.
+ *     3. Compiling both via `getOrCompileWasmModule` from a freshly cleared
+ *        cache and confirming both compile cleanly — the second creature
+ *        must NOT hit a stale template from the first.
+ */
+
+import { assert, assertNotEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import {
+  clearWasmCompilationCache,
+  getOrCompileWasmModule,
+} from "@wasm/WasmCompilationCache.ts";
+import { isWasmActivationAvailable } from "@wasm/WasmModuleLoader.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/**
+ * Two valid topological orderings of the same DAG. Both creatures have:
+ *
+ *   inputs 0,1 → hidden-a (TANH)
+ *   inputs 0,1 → hidden-b (LOGISTIC)
+ *   hidden-a, hidden-b → output-0 (IDENTITY)
+ *
+ * `creatureWithOrder` lists hidden-a before hidden-b; `creatureWithSwap`
+ * swaps them. Both are valid topological orders — the only edges among
+ * hidden neurons go from {input-0,input-1} to {hidden-a, hidden-b}, so
+ * either ordering satisfies forward-only constraints.
+ */
+function creatureWithOrder(): CreatureExport {
+  return {
+    neurons: [
+      { type: "hidden", uuid: "hidden-a", squash: "TANH", bias: 0.1 },
+      { type: "hidden", uuid: "hidden-b", squash: "LOGISTIC", bias: 0.2 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.3 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.11 },
+      { fromUUID: "input-1", toUUID: "hidden-a", weight: 0.12 },
+      { fromUUID: "input-0", toUUID: "hidden-b", weight: 0.21 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: 0.22 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.31 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: 0.32 },
+    ],
+    input: 2,
+    output: 1,
+  };
+}
+
+function creatureWithSwap(): CreatureExport {
+  return {
+    neurons: [
+      // Swap hidden-a and hidden-b. Same UUID-set; different positions.
+      { type: "hidden", uuid: "hidden-b", squash: "LOGISTIC", bias: 0.2 },
+      { type: "hidden", uuid: "hidden-a", squash: "TANH", bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.3 },
+    ],
+    // Same UUID→UUID synapse set (order in the array does not matter to
+    // the WASM template — `inwardConnections` sorts internally).
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.11 },
+      { fromUUID: "input-1", toUUID: "hidden-a", weight: 0.12 },
+      { fromUUID: "input-0", toUUID: "hidden-b", weight: 0.21 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: 0.22 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.31 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: 0.32 },
+    ],
+    input: 2,
+    output: 1,
+  };
+}
+
+Deno.test(
+  "Issue #2670: topology hash distinguishes valid topological orderings of the same UUID set",
+  () => {
+    const c1 = Creature.fromJSON(creatureWithOrder());
+    const c2 = Creature.fromJSON(creatureWithSwap());
+
+    const hash1 = CreatureUtil.getTopologyHash(c1);
+    const hash2 = CreatureUtil.getTopologyHash(c2);
+
+    assertNotEquals(
+      hash1,
+      hash2,
+      "Two creatures with the same UUID-set but different neuron position " +
+        "orderings must produce different topology hashes so the WASM " +
+        "compilation cache cannot serve a stale template across orderings.",
+    );
+  },
+);
+
+Deno.test(
+  "Issue #2670: WASM compile gate succeeds for both orderings sharing a UUID-set",
+  async () => {
+    await initWasmForTests();
+    if (!isWasmActivationAvailable()) {
+      // The compile gate is a no-op without WASM; the hash check above
+      // is the load-bearing assertion in that environment.
+      return;
+    }
+
+    // Clear cache so the first creature populates a fresh entry; the
+    // second creature must NOT collide on that entry.
+    clearWasmCompilationCache();
+
+    const c1 = Creature.fromJSON(creatureWithOrder());
+    const a1 = getOrCompileWasmModule(c1);
+    assert(
+      a1 !== null,
+      "creatureWithOrder must compile cleanly from an empty cache",
+    );
+    a1?.free();
+
+    const c2 = Creature.fromJSON(creatureWithSwap());
+    const a2 = getOrCompileWasmModule(c2);
+    assert(
+      a2 !== null,
+      "creatureWithSwap must compile cleanly — pre-fix it would have hit " +
+        "the cached template for creatureWithOrder and trapped with " +
+        "`RuntimeError: unreachable`.",
+    );
+    a2?.free();
+  },
+);


### PR DESCRIPTION
## Summary

Fix the lunar_lander-shape producer-gate reject by closing a position-blind
topology-hash collision in the WASM compilation cache. Closes #2670.

`CreatureUtil.getTopologyHash` sorted its non-input neuron keys before
hashing, making the hash independent of the order in which UUIDs appeared
inside `creature.neurons`. But `WasmCompilationCache.buildTemplate` encodes
each synapse's `from_index` and each neuron's `squash`/`is_constant` bytes
**by integer position** in that same array. Two creatures with the same
UUID-set + same UUID→UUID synapse-set but a different valid topological
ordering therefore shared a cache key — and the second creature was served
the first creature's stale template, tripping `RuntimeError: unreachable`
inside `CompiledNetwork::new`.

The producer-gate's fix-and-retry path could not repair this — the
offspring was a perfectly valid forward-only DAG; the corruption lived
inside the cached binary, not the creature.

The fix preserves neuron **position order** in the topology hash so the
hash is one-to-one with the binary template.

## Evidence

A targeted reproducer replayed the failing seed-2668 iter-47 breed and
captured the offspring inside the gate:

| Probe                                          | Result                           |
|------------------------------------------------|----------------------------------|
| Gate on captured creature, polluted cache      | `{ ok: false, trapMessage: "unreachable" }` |
| Gate on same creature after `clearWasmCompilationCache()` | `{ ok: true }`                   |
| Gate on creature exported→imported, fresh cache | `{ ok: true }`                   |

Tracing every gate-bound creature found a second offspring with the same
`topologyHash` but its hidden neurons in a different positional order
(UUIDs `70065ccc...` and `d7eabea4...` swapped, plus `8218af45...` and
`048cde34...` swapped). That earlier offspring populated the cache; the
later one hit the stale template.

The `test/wasm/LunarLanderShapeProducerGate.ts` reproducer goes from
1 producer-gate reject (allowance 5) to **0 rejects** (allowance 0).

Pre-fix diagnostic dumps (e.g.
`.diagnostics/offspring-wasm-compile-trap-47cf0f07-...-context-*.json`)
remain in the working tree as traceability artefacts; the post-fix run
produces no dumps.

```mermaid
flowchart LR
    A[Creature A<br/>positions: hidden-a, hidden-b] -->|getTopologyHash| H[(Same hash<br/>e9cd5014-...)]
    B[Creature B<br/>positions: hidden-b, hidden-a<br/>same UUID set] -->|getTopologyHash| H
    H --> C{WASM cache lookup}
    C -->|miss for A| T1[Template built from A's positions]
    C -->|hit for B| T1
    T1 -->|served to B| X[B's binary mixes A's positional<br/>from_index with B's neurons<br/>→ RuntimeError: unreachable]
```

## Test plan

- [x] `test/architecture/TopologyHash.ts` — renamed historic "order
      independent" test to `synapse-array order independent (#2670)` and
      added `neuron position order is significant (#2670)`.
- [x] `test/wasm/TopologyHashPositionOrderingIssue2670.ts` (new) — pins
      the cache regression: two valid orderings of the same UUID-set
      both compile cleanly from an empty cache.
- [x] `test/wasm/LunarLanderShapeProducerGate.ts` — allowance dropped from
      5 to 0; suite passes deterministically.
- [x] 22 topology-hash tests, 30 WASM cache / pre-warmer / template
      tests, and 6 734 tests overall pass on `./quality.sh`. Two unrelated
      pre-existing `test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`
      dynamic-library leaks remain on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)