### PR TITLE
Attribute producer-gate rejections to the originating mutate operator / breed path (Issue #2685)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.14",
+  "version": "5.0.15",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2685.md
+++ b/docs/pr-summary-2685.md
@@ -1,0 +1,64 @@
+## Summary
+
+Attribute producer-gate rejections to the originating mutate operator or
+breed sub-step. Producers (`Mutator`, `Offspring.breed`, `DeDuplicator`,
+`CRISPR`, `ApplyCoordinatedStructuralCandidate`) now set a
+`currentProducerStep` label before applying a mutation; the gate captures
+it on rejection and threads it through the diagnostic dump's `context`
+block, the single-line warning, and a rate-limited histogram summary.
+Closes #2685.
+
+The implementation follows the cheapest path the issue calls for: a
+module-local string in `ProducerCompileGuard.ts` plus thin
+`setProducerStep` / `withProducerStep` wrappers around the existing
+producer code paths. No per-call argument plumbing.
+
+## Evidence
+
+This is a CLI/library change with no UI. The behaviour is verified by:
+
+- New unit tests in `test/wasm/ProducerCompileGateAttribution.ts` that
+  exercise the seven acceptance criteria:
+  1. `setProducerStep` / `getProducerStep` / `withProducerStep` round-trip.
+  2. `runProducerCompileProbe` surfaces the active step on rejection.
+  3. `passesProducerCompileGate` emits `step=...` in the warn line and
+     records the rejection in the histogram.
+  4. The histogram falls back to the producer name when no step is set.
+  5. `flushProducerStepHistogram` emits a sorted summary info line and
+     clears the histogram.
+  6. `Offspring.breed` diagnostic dump includes `producerStep` in the
+     `context` block.
+  7. `Mutator.repairAfterMutation` diagnostic dump includes
+     `producerStep` in the `context` block.
+- The full test suite passes (`./quality.sh --skip-discovery --skip-wasm`
+  → 6743 passed, 0 failed, 4 ignored).
+- Existing producer-gate tests (`ProducerCompileGuard.ts`,
+  `ProducerCompileGateWiring.ts`, `ProducerGateDiagnosticDumps.ts`) all
+  continue to pass against the enriched warning format.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    Op[Mutate operator<br/>e.g. AddNeuron] -->|setProducerStep| State[currentProducerStep]
+    Op --> Probe[runProducerCompileProbe]
+    State --> Probe
+    Probe -->|ok: false| Result[ProducerCompileResult<br/>+ producerStep]
+    Result --> Warn[warn line<br/>step=AddNeuron]
+    Result --> Dump[.diagnostics/context-*.json<br/>producerStep field]
+    Result --> Hist[step histogram]
+    Hist -->|every 60s| Summary[info line<br/>sorted by frequency]
+```
+
+## Test Plan
+
+- [x] `test/wasm/ProducerCompileGateAttribution.ts` — seven new tests
+  covering the acceptance criteria.
+- [x] `test/wasm/ProducerCompileGuard.ts` — existing tests unchanged and
+  passing.
+- [x] `test/wasm/ProducerCompileGateWiring.ts` — existing tests pass; the
+  warning format change is backward compatible (`[<producer>] dropping
+  output …` still matches when no step is set).
+- [x] `test/wasm/ProducerGateDiagnosticDumps.ts` — existing tests pass
+  unchanged; new `producerStep` field is additive.
+- [x] `./quality.sh --skip-discovery --skip-wasm` clean: 6743 tests pass.

--- a/docs/pr-summary-2685.md
+++ b/docs/pr-summary-2685.md
@@ -1,40 +1,39 @@
 ## Summary
 
-Attribute producer-gate rejections to the originating mutate operator or
-breed sub-step. Producers (`Mutator`, `Offspring.breed`, `DeDuplicator`,
-`CRISPR`, `ApplyCoordinatedStructuralCandidate`) now set a
-`currentProducerStep` label before applying a mutation; the gate captures
-it on rejection and threads it through the diagnostic dump's `context`
-block, the single-line warning, and a rate-limited histogram summary.
-Closes #2685.
+Attribute producer-gate rejections to the originating mutate operator or breed
+sub-step. Producers (`Mutator`, `Offspring.breed`, `DeDuplicator`, `CRISPR`,
+`ApplyCoordinatedStructuralCandidate`) now set a `currentProducerStep` label
+before applying a mutation; the gate captures it on rejection and threads it
+through the diagnostic dump's `context` block, the single-line warning, and a
+rate-limited histogram summary. Closes #2685.
 
-The implementation follows the cheapest path the issue calls for: a
-module-local string in `ProducerCompileGuard.ts` plus thin
-`setProducerStep` / `withProducerStep` wrappers around the existing
-producer code paths. No per-call argument plumbing.
+The implementation follows the cheapest path the issue calls for: a module-local
+string in `ProducerCompileGuard.ts` plus thin `setProducerStep` /
+`withProducerStep` wrappers around the existing producer code paths. No per-call
+argument plumbing.
 
 ## Evidence
 
 This is a CLI/library change with no UI. The behaviour is verified by:
 
-- New unit tests in `test/wasm/ProducerCompileGateAttribution.ts` that
-  exercise the seven acceptance criteria:
+- New unit tests in `test/wasm/ProducerCompileGateAttribution.ts` that exercise
+  the seven acceptance criteria:
   1. `setProducerStep` / `getProducerStep` / `withProducerStep` round-trip.
   2. `runProducerCompileProbe` surfaces the active step on rejection.
-  3. `passesProducerCompileGate` emits `step=...` in the warn line and
-     records the rejection in the histogram.
+  3. `passesProducerCompileGate` emits `step=...` in the warn line and records
+     the rejection in the histogram.
   4. The histogram falls back to the producer name when no step is set.
-  5. `flushProducerStepHistogram` emits a sorted summary info line and
-     clears the histogram.
-  6. `Offspring.breed` diagnostic dump includes `producerStep` in the
-     `context` block.
-  7. `Mutator.repairAfterMutation` diagnostic dump includes
-     `producerStep` in the `context` block.
-- The full test suite passes (`./quality.sh --skip-discovery --skip-wasm`
-  → 6743 passed, 0 failed, 4 ignored).
+  5. `flushProducerStepHistogram` emits a sorted summary info line and clears
+     the histogram.
+  6. `Offspring.breed` diagnostic dump includes `producerStep` in the `context`
+     block.
+  7. `Mutator.repairAfterMutation` diagnostic dump includes `producerStep` in
+     the `context` block.
+- The full test suite passes (`./quality.sh --skip-discovery --skip-wasm` → 6743
+  passed, 0 failed, 4 ignored).
 - Existing producer-gate tests (`ProducerCompileGuard.ts`,
-  `ProducerCompileGateWiring.ts`, `ProducerGateDiagnosticDumps.ts`) all
-  continue to pass against the enriched warning format.
+  `ProducerCompileGateWiring.ts`, `ProducerGateDiagnosticDumps.ts`) all continue
+  to pass against the enriched warning format.
 
 ### Data flow
 
@@ -52,13 +51,14 @@ flowchart LR
 
 ## Test Plan
 
-- [x] `test/wasm/ProducerCompileGateAttribution.ts` — seven new tests
-  covering the acceptance criteria.
+- [x] `test/wasm/ProducerCompileGateAttribution.ts` — seven new tests covering
+      the acceptance criteria.
 - [x] `test/wasm/ProducerCompileGuard.ts` — existing tests unchanged and
-  passing.
+      passing.
 - [x] `test/wasm/ProducerCompileGateWiring.ts` — existing tests pass; the
-  warning format change is backward compatible (`[<producer>] dropping
+      warning format change is backward compatible
+      (`[<producer>] dropping
   output …` still matches when no step is set).
 - [x] `test/wasm/ProducerGateDiagnosticDumps.ts` — existing tests pass
-  unchanged; new `producerStep` field is additive.
+      unchanged; new `producerStep` field is additive.
 - [x] `./quality.sh --skip-discovery --skip-wasm` clean: 6743 tests pass.

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -37,7 +37,10 @@ import {
 } from "@neat/MetropolisHastings.ts";
 import type { MCMCDiagnostics } from "@neat/MCMCDiagnostics.ts";
 import { SquashEffectivenessTracker } from "@neat/SquashEffectivenessTracker.ts";
-import { runProducerCompileProbe } from "@wasm/ProducerCompileGuard.ts";
+import {
+  runProducerCompileProbe,
+  setProducerStep,
+} from "@wasm/ProducerCompileGuard.ts";
 import { writeDiagnostics } from "@utils/Diagnostics.ts";
 import { exportJSONUnchecked } from "@creature/CreatureSerialization.ts";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
@@ -801,11 +804,19 @@ export class Mutator {
         "(pre-fix export failed — creature too corrupted to serialise)";
     }
 
-    if (enforceForwardOnly) {
-      creature.fix({ forwardOnly: true });
-      creature.forwardOnly = true;
-    } else {
-      creature.fix();
+    // Issue #2685: Attribute any gate rejection arising from the fix() pass
+    // to the `Mutator.repairAfterMutation:fix` step. The `mutationName` (set
+    // by the caller in `mutate()`) is still recorded in the dump context.
+    setProducerStep("Mutator.repairAfterMutation:fix");
+    try {
+      if (enforceForwardOnly) {
+        creature.fix({ forwardOnly: true });
+        creature.forwardOnly = true;
+      } else {
+        creature.fix();
+      }
+    } finally {
+      setProducerStep(undefined);
     }
 
     // Issue #2636: WASM compile sanity gate. The mutation loop has historically
@@ -814,9 +825,24 @@ export class Mutator {
     // outputs=3). The probe attempts a real compile and one fix-retry; on
     // failure callers should revert the creature to its pre-mutation snapshot
     // rather than letting the bad topology contaminate training.
-    const compileResult = runProducerCompileProbe(creature);
+    //
+    // Issue #2685: Re-set the step around the probe itself so the rejection
+    // record names the gate sub-step rather than leaving `currentProducerStep`
+    // unset between the fix() pass and the probe.
+    setProducerStep("Mutator.repairAfterMutation:gate");
+    let compileResult: ReturnType<typeof runProducerCompileProbe>;
+    try {
+      compileResult = runProducerCompileProbe(creature);
+    } finally {
+      setProducerStep(undefined);
+    }
     if (!compileResult.ok) {
       const trapMessage = compileResult.trapMessage ?? "unknown trap";
+      // Issue #2685: prefer the operator name supplied by the caller as the
+      // attributable step; fall back to whatever the gate captured.
+      const producerStep = diagnosticContext?.mutationName
+        ? `Mutator.${diagnosticContext.mutationName}`
+        : compileResult.producerStep ?? "Mutator.repairAfterMutation";
       // Issue #2672: enrich diagnostic dump for replay-ready debugging.
       const rng = getRandomNumberGenerator();
       const mutationName = diagnosticContext?.mutationName ?? "unknown";
@@ -851,6 +877,9 @@ export class Mutator {
           : postRepairExport,
         context: {
           mutationName,
+          // Issue #2685: surface the attributable producer step in the
+          // diagnostic context block.
+          producerStep,
           creatureUuid,
           prngSeed: rng.seed ?? "n/a (unseeded RNG)",
           prngSeeded: rng.seeded,
@@ -868,7 +897,7 @@ export class Mutator {
         },
       });
       getLogger().warn(
-        `[Mutator] reverting mutation that fails WASM compile (` +
+        `[Mutator] reverting mutation from step=${producerStep} that fails WASM compile (` +
           `mutation=${mutationName}, ` +
           `neurons=${creature.neurons.length}, inputs=${creature.input}, ` +
           `outputs=${creature.output}): ${trapMessage}`,
@@ -905,7 +934,17 @@ export class Mutator {
     // significantly reducing object allocations during evolution.
     const mutator = this.getMutatorInstance(creature, method.name);
 
-    const changed = mutator.mutate(focusList, mutationBias);
+    // Issue #2685: Tag the mutate operator so the producer gate, on
+    // rejection, can attribute the bad topology to the specific operator
+    // (e.g. `AddNeuron`, `ModWeight`). Clear on success/failure so the
+    // surrounding repair phase reports its own step.
+    setProducerStep(`Mutator.${method.name}`);
+    let changed: boolean;
+    try {
+      changed = mutator.mutate(focusList, mutationBias);
+    } finally {
+      setProducerStep(undefined);
+    }
 
     // Issue #2383: Demote the "didn't mutate" diagnostic. An unfocused
     // mutation that cannot produce a change (e.g. every draw is clamped at

--- a/src/architecture/DeDuplicator.ts
+++ b/src/architecture/DeDuplicator.ts
@@ -8,7 +8,10 @@ import { getLogger } from "@utils/Logger.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { TopologyError } from "@errors/TopologyError.ts";
 import { ValidationError } from "@errors/ValidationError.ts";
-import { passesProducerCompileGate } from "@wasm/ProducerCompileGuard.ts";
+import {
+  passesProducerCompileGate,
+  withProducerStep,
+} from "@wasm/ProducerCompileGuard.ts";
 
 /**
  * DeDuplicator - Removes duplicate creatures from a population.
@@ -274,7 +277,12 @@ export class DeDuplicator {
             // already runs the producer-compile gate, re-check the bred
             // child at the dedup commit seam so a stray bad topology cannot
             // reach the WASM cache via the replacement path.
-            if (!passesProducerCompileGate(child, "DeDuplicator/breed")) {
+            if (
+              !withProducerStep(
+                "DeDuplicator.replaceDuplicate:breed",
+                () => passesProducerCompileGate(child!, "DeDuplicator/breed"),
+              )
+            ) {
               continue;
             }
             unique.add(key2);
@@ -301,7 +309,13 @@ export class DeDuplicator {
         }
         if (!duplicate3) {
           // Issue #2671: gate the mutate-clone replacement at the commit seam.
-          if (!passesProducerCompileGate(tmpCreature, "DeDuplicator/mutate")) {
+          if (
+            !withProducerStep(
+              "DeDuplicator.replaceDuplicate:mutate",
+              () =>
+                passesProducerCompileGate(tmpCreature, "DeDuplicator/mutate"),
+            )
+          ) {
             continue;
           }
           this.breed.genus.addCreature(tmpCreature);
@@ -334,9 +348,13 @@ export class DeDuplicator {
           // duplicate instead of seeding a broken topology into the
           // population).
           if (
-            !passesProducerCompileGate(
-              fallbackCreature,
-              "DeDuplicator/fallback",
+            !withProducerStep(
+              "DeDuplicator.replaceDuplicate:fallback",
+              () =>
+                passesProducerCompileGate(
+                  fallbackCreature,
+                  "DeDuplicator/fallback",
+                ),
             )
           ) {
             if (isLastAttempt) {

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -18,7 +18,10 @@ import {
   resolveCoordinatedEdgeEndpoints,
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
 import { clampAndTrack } from "@utils/OverflowGuardStats.ts";
-import { passesProducerCompileGate } from "@wasm/ProducerCompileGuard.ts";
+import {
+  passesProducerCompileGate,
+  withProducerStep,
+} from "@wasm/ProducerCompileGuard.ts";
 
 function buildIdToIndexMap(creature: CreatureExport): Map<number, number> {
   const idToIndex = new Map<number, number>();
@@ -377,8 +380,22 @@ export function applyCoordinatedStructuralCandidate(
   // emit topologies that pass `validate()` yet trap inside the WASM
   // constructor. On gate failure revert to the pre-application creature so
   // the bad topology never leaves the producer.
+  //
+  // Issue #2685: Tag the rejection with the candidate's primary operation
+  // type when one is available; otherwise fall back to the candidate type.
+  const operationTypes = candidate.operations.map((op) => op.type);
+  const stepLabel = operationTypes.length > 0
+    ? `Discovery.applyCoordinatedStructural:${operationTypes.join("+")}`
+    : "Discovery.applyCoordinatedStructural";
   if (
-    !passesProducerCompileGate(updated, "Discovery/applyCoordinatedStructural")
+    !withProducerStep(
+      stepLabel,
+      () =>
+        passesProducerCompileGate(
+          updated,
+          "Discovery/applyCoordinatedStructural",
+        ),
+    )
   ) {
     return creature;
   }

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -28,7 +28,10 @@ import type {
 } from "@architecture/SynapseInterfaces.ts";
 import { creatureValidate } from "@architecture/CreatureValidate.ts";
 import { assertForwardOnlyTopologyAfterBulkRemap } from "@architecture/ForwardOnlySynapseGuard.ts";
-import { runProducerCompileProbe } from "@wasm/ProducerCompileGuard.ts";
+import {
+  runProducerCompileProbe,
+  setProducerStep,
+} from "@wasm/ProducerCompileGuard.ts";
 import { exportJSONUnchecked } from "@creature/CreatureSerialization.ts";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 
@@ -616,12 +619,26 @@ export class Offspring {
     }
 
     if (shouldBeForwardOnly) {
-      Offspring.repairForwardOnlyComputationalInbounds(
-        offspring,
-        mother,
-        father,
-      );
-      Offspring.repairOrphanedConstants(offspring, mother, father);
+      // Issue #2685: Attribute any producer-gate rejection that arises from
+      // these repair steps to the specific sub-step that emitted the bad
+      // topology, rather than reporting the generic `Offspring/breed`
+      // producer name only.
+      setProducerStep("Offspring.repairForwardOnlyComputationalInbounds");
+      try {
+        Offspring.repairForwardOnlyComputationalInbounds(
+          offspring,
+          mother,
+          father,
+        );
+      } finally {
+        setProducerStep(undefined);
+      }
+      setProducerStep("Offspring.repairOrphanedConstants");
+      try {
+        Offspring.repairOrphanedConstants(offspring, mother, father);
+      } finally {
+        setProducerStep(undefined);
+      }
     }
 
     if (offspring.memetic) {
@@ -695,9 +712,22 @@ export class Offspring {
     // inputs=2054, outputs=3). Run a one-shot compile probe here so a bad
     // topology is repaired or dropped at the producer rather than leaking into
     // training and only being caught by the call-site recovery (#2483).
-    const compileResult = runProducerCompileProbe(offspring);
+    // Issue #2685: Default the step to `Offspring.breed:splice-repair` so
+    // an offspring that survives the earlier sub-steps but still fails the
+    // compile gate is attributed to the breed phase as a whole. Sub-step
+    // labels set above are cleared once those steps finish; on rejection
+    // here we capture the gate's own label.
+    setProducerStep("Offspring.breed:splice-repair");
+    let compileResult: ReturnType<typeof runProducerCompileProbe>;
+    try {
+      compileResult = runProducerCompileProbe(offspring);
+    } finally {
+      setProducerStep(undefined);
+    }
     if (!compileResult.ok) {
       offspring.DEBUG = false;
+      const producerStep = compileResult.producerStep ??
+        "Offspring.breed:splice-repair";
       // Issue #2672: Capture post-fix offspring even when `exportJSON()`
       // could throw (the compile gate has already declared this topology
       // bad). The diagnostic dump must always land.
@@ -730,6 +760,8 @@ export class Offspring {
           offspringUuid: childUUID,
           breedSeed: activeSeed ?? "n/a (unseeded RNG)",
           prngSeeded: rng.seeded,
+          // Issue #2685: surface the originating producer step.
+          producerStep,
           trapMessage,
           preFixOffspring: preFixOffspringExport,
           postFixOffspringSerialisationError:
@@ -744,7 +776,7 @@ export class Offspring {
         },
       });
       getLogger().warn(
-        `[Offspring] dropping offspring that fails WASM compile (` +
+        `[Offspring/breed] dropping offspring from step=${producerStep} that fails WASM compile (` +
           `neurons=${offspring.neurons.length}, inputs=${offspring.input}, ` +
           `outputs=${offspring.output}): ${
             compileResult.trapMessage ?? "unknown trap"

--- a/src/reconstruct/CRISPR.ts
+++ b/src/reconstruct/CRISPR.ts
@@ -8,7 +8,10 @@ import { CrisprError } from "@errors/CrisprError.ts";
 import { TopologyError } from "@errors/TopologyError.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { validateDNA } from "@reconstruct/validateDNA.ts";
-import { passesProducerCompileGate } from "@wasm/ProducerCompileGuard.ts";
+import {
+  passesProducerCompileGate,
+  withProducerStep,
+} from "@wasm/ProducerCompileGuard.ts";
 
 /**
  * Recommended `index` for the first output neuron in append-mode CRISPR DNA
@@ -742,7 +745,16 @@ export class CRISPR {
     // WASM constructor. On gate failure log a single line and return the
     // unmodified original creature so the bad topology never leaves the
     // producer.
-    if (!passesProducerCompileGate(modifiedCreature, "CRISPR")) {
+    // Issue #2685: Attribute the rejection to the CRISPR sub-step the
+    // injection used (`append`, `replace`, etc.) so the histogram tracks
+    // the specific operator.
+    const crisprStep = `CRISPR.${dna.mode ?? "default"}:${dna.id ?? "no-id"}`;
+    if (
+      !withProducerStep(
+        crisprStep,
+        () => passesProducerCompileGate(modifiedCreature, "CRISPR"),
+      )
+    ) {
       warnSkippedCrisprDNA(
         dna,
         "WASM_COMPILE_FAILED",

--- a/src/wasm/ProducerCompileGuard.ts
+++ b/src/wasm/ProducerCompileGuard.ts
@@ -24,6 +24,12 @@
  *    reuse keeps allocations bounded.
  *  - When WASM activation is unavailable the probe is a no-op (returns
  *    `{ ok: true, skipped: true }`).
+ *
+ * Issue #2685: Producers thread a `producerStep` label through the gate so
+ * the rejection diagnostic dump, warning line, and periodic histogram can
+ * attribute a bad topology to the specific operator (e.g. `AddNeuron.split`,
+ * `repairForwardOnlyComputationalInbounds`, `crisprInsertSubgraph`) rather
+ * than just the surrounding producer name.
  */
 
 import type { Creature } from "@creature";
@@ -45,6 +51,54 @@ export interface ProducerCompileResult {
   repaired?: boolean;
   /** The trap message recorded by `WasmCreatureActivation.create`, if any. */
   trapMessage?: string;
+  /**
+   * Issue #2685: The last producer-step label set via `setProducerStep` at
+   * the moment the gate fired. `undefined` when no producer set a step
+   * (e.g. legacy call sites). Used by callers to enrich the diagnostic dump
+   * and warning line.
+   */
+  producerStep?: string;
+}
+
+/**
+ * Issue #2685: Module-local label naming the operator/sub-step currently
+ * executing inside a producer. Producers call `setProducerStep("AddNeuron")`
+ * before applying their mutation and clear it on success; if the producer
+ * gate fires while the label is set, the rejection record names that step.
+ */
+let currentProducerStep: string | undefined;
+
+/**
+ * Issue #2685: Set the label naming the operator/sub-step currently
+ * executing inside a producer. Pass `undefined` to clear. This is the
+ * cheapest threading the issue calls for — no per-call argument plumbing
+ * through every producer code path.
+ */
+export function setProducerStep(label: string | undefined): void {
+  currentProducerStep = label;
+}
+
+/**
+ * Issue #2685: Read the currently-active producer step label. Returns
+ * `undefined` when no producer has set one.
+ */
+export function getProducerStep(): string | undefined {
+  return currentProducerStep;
+}
+
+/**
+ * Issue #2685: Run `fn` with `label` installed as the current producer step,
+ * restoring the previous label (or clearing it) when `fn` returns. The label
+ * is preserved on error so the gate diagnostic still records the right step.
+ */
+export function withProducerStep<T>(label: string, fn: () => T): T {
+  const previous = currentProducerStep;
+  currentProducerStep = label;
+  try {
+    return fn();
+  } finally {
+    currentProducerStep = previous;
+  }
 }
 
 /**
@@ -125,7 +179,11 @@ export function ensureProducerOutputCompiles(
   } catch (_err) {
     // A repair failure means the creature is too broken to recover —
     // surface the original trap message and let the caller drop it.
-    return { ok: false, trapMessage: first.trapMessage };
+    return {
+      ok: false,
+      trapMessage: first.trapMessage,
+      producerStep: currentProducerStep,
+    };
   }
 
   const second = tryCompile(creature);
@@ -136,6 +194,7 @@ export function ensureProducerOutputCompiles(
   return {
     ok: false,
     trapMessage: second.trapMessage ?? first.trapMessage,
+    producerStep: currentProducerStep,
   };
 }
 
@@ -177,11 +236,102 @@ export function __setProducerCompileGateProbeForTesting(
  *
  * Production behaviour is identical: when no test stub is installed the
  * call is exactly `ensureProducerOutputCompiles(creature)`.
+ *
+ * Issue #2685: The result is enriched with the current producer step
+ * label (`producerStep`) when the probe failed without supplying one, so
+ * test stubs do not need to know about the threading.
  */
 export function runProducerCompileProbe(
   creature: Creature,
 ): ProducerCompileResult {
-  return producerCompileProbe(creature);
+  const result = producerCompileProbe(creature);
+  if (!result.ok && result.producerStep === undefined && currentProducerStep) {
+    return { ...result, producerStep: currentProducerStep };
+  }
+  return result;
+}
+
+/**
+ * Issue #2685: Histogram of producer-step rejection counts, flushed
+ * periodically by `passesProducerCompileGate`. The key is the producer
+ * step (or producer name when no step was set). Tests reset the histogram
+ * via `__resetProducerStepHistogramForTesting`.
+ */
+const producerStepHistogram = new Map<string, number>();
+let lastHistogramFlushMs = 0;
+let producerStepLogIntervalMs = 60_000;
+
+/**
+ * Issue #2685: Test-only — reset the rejection histogram and last-flush
+ * timestamp so a single test can observe its own counts.
+ */
+export function __resetProducerStepHistogramForTesting(): void {
+  producerStepHistogram.clear();
+  lastHistogramFlushMs = 0;
+}
+
+/**
+ * Issue #2685: Override the periodic summary interval. Used by tests to
+ * force or suppress a flush. Returns a disposer that restores the
+ * previous value (default 60 000 ms).
+ */
+export function __setProducerStepLogIntervalMsForTesting(
+  intervalMs: number,
+): () => void {
+  const previous = producerStepLogIntervalMs;
+  producerStepLogIntervalMs = intervalMs;
+  return () => {
+    producerStepLogIntervalMs = previous;
+  };
+}
+
+/**
+ * Issue #2685: Snapshot the histogram. Test helper.
+ */
+export function __getProducerStepHistogramSnapshotForTesting(): Map<
+  string,
+  number
+> {
+  return new Map(producerStepHistogram);
+}
+
+/**
+ * Issue #2685: Record a rejection for `key` (producer step label, or the
+ * producer name when no step was set). When at least
+ * `producerStepLogIntervalMs` has elapsed since the previous flush, emit
+ * a single info line containing a histogram sorted by frequency
+ * descending.
+ */
+function recordRejection(key: string): void {
+  producerStepHistogram.set(key, (producerStepHistogram.get(key) ?? 0) + 1);
+
+  const now = Date.now();
+  if (lastHistogramFlushMs === 0) {
+    // First rejection in this process; arm the timer but do not flush yet.
+    lastHistogramFlushMs = now;
+    return;
+  }
+  if (now - lastHistogramFlushMs < producerStepLogIntervalMs) {
+    return;
+  }
+  flushProducerStepHistogram();
+  lastHistogramFlushMs = now;
+}
+
+/**
+ * Issue #2685: Emit the current histogram as a single info line, then
+ * clear it. Public so other producer paths can trigger a flush when they
+ * notice an end-of-generation boundary. Tests use this to assert the
+ * sorted format.
+ */
+export function flushProducerStepHistogram(): void {
+  if (producerStepHistogram.size === 0) return;
+  const sorted = [...producerStepHistogram.entries()].sort((a, b) =>
+    b[1] - a[1]
+  );
+  const summary = sorted.map(([k, v]) => `${k}=${v}`).join(", ");
+  getLogger().info(`[ProducerCompileGate] step rejects: ${summary}`);
+  producerStepHistogram.clear();
 }
 
 /**
@@ -192,6 +342,9 @@ export function runProducerCompileProbe(
  * Producers should branch on the boolean to drop (`Offspring.breed` style),
  * revert (`Mutator.repairAfterMutation` style), or skip
  * (`DeDuplicator.replaceDuplicateCreature` style) the candidate.
+ *
+ * Issue #2685: The warning line includes the producer step label when
+ * known, and the rejection is recorded in a rate-limited histogram.
  */
 export function passesProducerCompileGate(
   creature: Creature,
@@ -201,12 +354,15 @@ export function passesProducerCompileGate(
   if (result.ok) {
     return true;
   }
+  const step = result.producerStep ?? currentProducerStep;
+  const stepSuffix = step ? ` from step=${step}` : "";
   getLogger().warn(
-    `[${producerName}] dropping output that fails WASM compile (` +
+    `[${producerName}] dropping output${stepSuffix} that fails WASM compile (` +
       `neurons=${creature.neurons.length}, inputs=${creature.input}, ` +
       `outputs=${creature.output}): ${
         result.trapMessage ?? "unknown trap"
       }. Drop the creature or repair its topology before retrying.`,
   );
+  recordRejection(step ?? producerName);
   return false;
 }

--- a/src/wasm/mod.ts
+++ b/src/wasm/mod.ts
@@ -160,9 +160,14 @@ export {
 } from "@wasm/WasmTopologyExport.ts";
 
 // Issue #2636 - Producer-side compile gate (mutate/breed reject bad topologies)
+// Issue #2685 - Producer-step attribution helpers
 export {
   ensureProducerOutputCompiles,
+  flushProducerStepHistogram,
+  getProducerStep,
   type ProducerCompileResult,
+  setProducerStep,
+  withProducerStep,
 } from "@wasm/ProducerCompileGuard.ts";
 
 // Issue #2643 - Serialiser self-consistency check for the WASM binary format

--- a/test/wasm/ProducerCompileGateAttribution.ts
+++ b/test/wasm/ProducerCompileGateAttribution.ts
@@ -1,0 +1,372 @@
+/**
+ * Issue #2685 — Producer-step attribution for the WASM compile gate.
+ *
+ * The producer-side compile gate now threads a `producerStep` label so the
+ * rejection diagnostic dump, the single-line warning, and the periodic
+ * histogram all attribute a bad topology to the specific mutate operator
+ * or breed sub-step that emitted it.
+ *
+ * These tests engineer a deterministic gate rejection via the existing
+ * `__setProducerCompileGateProbeForTesting` seam and assert that:
+ *
+ *  - `runProducerCompileProbe` surfaces `producerStep` when a producer set
+ *    one before invoking the gate.
+ *  - `passesProducerCompileGate` includes `step=...` in its warning line
+ *    and records the rejection in the histogram.
+ *  - `Offspring.breed` and `Mutator.repairAfterMutation` include
+ *    `producerStep` in their diagnostic dumps written to `.diagnostics/`.
+ *  - The histogram is flushed as a sorted summary log line.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { Creature } from "@creature";
+import { AddNeuron } from "@mutate/AddNeuron.ts";
+import { Mutator } from "@neat/Mutator.ts";
+import { Offspring } from "@architecture/Offspring.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import {
+  createSeededRng,
+  setRandomNumberGenerator,
+} from "@utils/RandomNumberGenerator.ts";
+import {
+  __getProducerStepHistogramSnapshotForTesting,
+  __resetProducerStepHistogramForTesting,
+  __setProducerCompileGateProbeForTesting,
+  __setProducerStepLogIntervalMsForTesting,
+  flushProducerStepHistogram,
+  getProducerStep,
+  passesProducerCompileGate,
+  type ProducerCompileResult,
+  runProducerCompileProbe,
+  setProducerStep,
+  withProducerStep,
+} from "@wasm/ProducerCompileGuard.ts";
+import { getLogger, setLogger } from "@utils/Logger.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+const REJECT_PROBE = (): ProducerCompileResult => ({
+  ok: false,
+  trapMessage: "test-forced rejection (issue #2685)",
+});
+
+function captureLogs(): {
+  warnings: string[];
+  infos: string[];
+  dispose: () => void;
+} {
+  const warnings: string[] = [];
+  const infos: string[] = [];
+  const previous = getLogger();
+  setLogger({
+    debug() {},
+    info(...args: unknown[]) {
+      infos.push(args.map((a) => String(a)).join(" "));
+    },
+    warn(...args: unknown[]) {
+      warnings.push(args.map((a) => String(a)).join(" "));
+    },
+    error(...args: unknown[]) {
+      warnings.push(args.map((a) => String(a)).join(" "));
+    },
+  });
+  return {
+    warnings,
+    infos,
+    dispose() {
+      setLogger(previous);
+    },
+  };
+}
+
+function buildHealthyCreature(): Creature {
+  const c = new Creature(2, 1, {
+    layers: [{ count: 2, squash: "TANH" }],
+  });
+  c.fix();
+  return c;
+}
+
+/**
+ * Mirrors `buildBreedingParent` from ProducerGateDiagnosticDumps.ts — two
+ * differently-seeded parents combine via Offspring.breed to produce a child
+ * whose UUID differs from both parents, so the breed reaches the gate.
+ */
+function buildBreedingParent(seed: number): Creature {
+  setRandomNumberGenerator(createSeededRng(seed));
+  const c = new Creature(4, 2);
+  c.fix();
+  const op = new AddNeuron(c);
+  for (let i = 0; i < 5; i++) op.mutate();
+  c.fix();
+  delete c.uuid;
+  CreatureUtil.makeUUID(c);
+  return c;
+}
+
+/**
+ * Read the latest `context-` file emitted by `writeDiagnostics`. The
+ * diagnostic dump for a producer-gate rejection always includes a
+ * `context-*.json` file. We just return its parsed JSON.
+ */
+function readLatestDiagnosticContext(
+  prefix: string,
+): Record<string, unknown> | undefined {
+  let latest: { name: string; mtime: number } | undefined;
+  try {
+    for (const entry of Deno.readDirSync(".diagnostics")) {
+      if (!entry.isFile) continue;
+      if (!entry.name.startsWith(prefix)) continue;
+      if (!entry.name.includes("context-")) continue;
+      const stat = Deno.statSync(`.diagnostics/${entry.name}`);
+      const mtime = stat.mtime?.getTime() ?? 0;
+      if (latest === undefined || mtime > latest.mtime) {
+        latest = { name: entry.name, mtime };
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  if (!latest) return undefined;
+  try {
+    return JSON.parse(
+      Deno.readTextFileSync(`.diagnostics/${latest.name}`),
+    ) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+Deno.test(
+  "Issue #2685: setProducerStep / getProducerStep round-trip and withProducerStep restores the previous label",
+  () => {
+    setProducerStep(undefined);
+    assertEquals(getProducerStep(), undefined);
+    setProducerStep("Outer");
+    assertEquals(getProducerStep(), "Outer");
+    const result = withProducerStep("Inner", () => {
+      assertEquals(getProducerStep(), "Inner");
+      return 42;
+    });
+    assertEquals(result, 42);
+    assertEquals(getProducerStep(), "Outer");
+    setProducerStep(undefined);
+  },
+);
+
+Deno.test(
+  "Issue #2685: runProducerCompileProbe surfaces the active producerStep on rejection",
+  async () => {
+    await initWasmForTests();
+    const restore = __setProducerCompileGateProbeForTesting(REJECT_PROBE);
+    setProducerStep("AddNeuron.split");
+    try {
+      const healthy = buildHealthyCreature();
+      const result = runProducerCompileProbe(healthy);
+      assertEquals(result.ok, false);
+      assertEquals(
+        result.producerStep,
+        "AddNeuron.split",
+        "probe must surface the active producer step",
+      );
+    } finally {
+      setProducerStep(undefined);
+      restore();
+    }
+  },
+);
+
+Deno.test(
+  "Issue #2685: passesProducerCompileGate warns with step=... and records a histogram entry",
+  async () => {
+    await initWasmForTests();
+    __resetProducerStepHistogramForTesting();
+    const restore = __setProducerCompileGateProbeForTesting(REJECT_PROBE);
+    const capture = captureLogs();
+    try {
+      const healthy = buildHealthyCreature();
+      const accepted = withProducerStep(
+        "crisprInsertSubgraph",
+        () => passesProducerCompileGate(healthy, "CRISPR"),
+      );
+      assertEquals(accepted, false);
+      const warn = capture.warnings.find((w) =>
+        w.includes("[CRISPR]") && w.includes("step=crisprInsertSubgraph")
+      );
+      assert(
+        warn !== undefined,
+        `expected warn line tagged with step, got: ${
+          capture.warnings.join("\n")
+        }`,
+      );
+      const hist = __getProducerStepHistogramSnapshotForTesting();
+      assertEquals(hist.get("crisprInsertSubgraph"), 1);
+    } finally {
+      capture.dispose();
+      restore();
+      __resetProducerStepHistogramForTesting();
+    }
+  },
+);
+
+Deno.test(
+  "Issue #2685: passesProducerCompileGate falls back to producer name in the histogram when no step is set",
+  async () => {
+    await initWasmForTests();
+    __resetProducerStepHistogramForTesting();
+    const restore = __setProducerCompileGateProbeForTesting(REJECT_PROBE);
+    const capture = captureLogs();
+    try {
+      const healthy = buildHealthyCreature();
+      setProducerStep(undefined);
+      const accepted = passesProducerCompileGate(healthy, "Discovery/legacy");
+      assertEquals(accepted, false);
+      const hist = __getProducerStepHistogramSnapshotForTesting();
+      assertEquals(hist.get("Discovery/legacy"), 1);
+    } finally {
+      capture.dispose();
+      restore();
+      __resetProducerStepHistogramForTesting();
+    }
+  },
+);
+
+Deno.test(
+  "Issue #2685: flushProducerStepHistogram emits a single sorted info line then clears the histogram",
+  async () => {
+    await initWasmForTests();
+    __resetProducerStepHistogramForTesting();
+    const restore = __setProducerCompileGateProbeForTesting(REJECT_PROBE);
+    // Set a very long interval so auto-flush never fires during the test;
+    // we trigger the flush explicitly below to assert the sorted shape.
+    const restoreInterval = __setProducerStepLogIntervalMsForTesting(
+      60 * 60 * 1000,
+    );
+    const capture = captureLogs();
+    try {
+      const healthy = buildHealthyCreature();
+      withProducerStep(
+        "AddNeuron",
+        () => passesProducerCompileGate(healthy, "Mutator"),
+      );
+      withProducerStep(
+        "AddNeuron",
+        () => passesProducerCompileGate(healthy, "Mutator"),
+      );
+      withProducerStep(
+        "ModWeight",
+        () => passesProducerCompileGate(healthy, "Mutator"),
+      );
+      flushProducerStepHistogram();
+      const summary = capture.infos.find((i) =>
+        i.includes("[ProducerCompileGate]") && i.includes("step rejects")
+      );
+      assert(
+        summary !== undefined,
+        `expected a summary info line, got: ${capture.infos.join("\n")}`,
+      );
+      assertStringIncludes(summary, "AddNeuron=2");
+      assertStringIncludes(summary, "ModWeight=1");
+      // Ensure AddNeuron appears before ModWeight (sorted by frequency).
+      const idxAdd = summary.indexOf("AddNeuron=2");
+      const idxMod = summary.indexOf("ModWeight=1");
+      assert(idxAdd >= 0 && idxMod >= 0 && idxAdd < idxMod);
+      const histAfter = __getProducerStepHistogramSnapshotForTesting();
+      assertEquals(histAfter.size, 0, "flush must clear the histogram");
+    } finally {
+      capture.dispose();
+      restoreInterval();
+      restore();
+      __resetProducerStepHistogramForTesting();
+    }
+  },
+);
+
+Deno.test(
+  "Issue #2685: Offspring.breed diagnostic dump includes producerStep in the context block",
+  async () => {
+    await initWasmForTests();
+    __resetProducerStepHistogramForTesting();
+    const restore = __setProducerCompileGateProbeForTesting(REJECT_PROBE);
+    const capture = captureLogs();
+    try {
+      // Use the same parent-building pattern as the diagnostic-dump test so
+      // breed reaches the producer gate rather than short-circuiting at the
+      // "child is a clone of a parent" guard.
+      setRandomNumberGenerator(createSeededRng(20260601));
+      const mum = buildBreedingParent(100);
+      const dad = buildBreedingParent(999);
+      setRandomNumberGenerator(createSeededRng(2));
+      const child = Offspring.breed(mum, dad, { forwardOnly: true });
+      assertEquals(
+        child,
+        undefined,
+        "stub probe must surface as a drop in Offspring.breed",
+      );
+      const warn = capture.warnings.find((w) =>
+        w.includes("[Offspring/breed]") && w.includes("step=")
+      );
+      assert(
+        warn !== undefined,
+        `expected Offspring/breed warn line with step=, got: ${
+          capture.warnings.join("\n")
+        }`,
+      );
+      const ctx = readLatestDiagnosticContext("offspring-wasm-compile-trap-");
+      assert(
+        ctx !== undefined,
+        "expected a context-*.json diagnostic dump to exist",
+      );
+      assert(
+        typeof ctx.producerStep === "string" && ctx.producerStep.length > 0,
+        `expected producerStep in dump context, got: ${JSON.stringify(ctx)}`,
+      );
+    } finally {
+      capture.dispose();
+      restore();
+      __resetProducerStepHistogramForTesting();
+    }
+  },
+);
+
+Deno.test(
+  "Issue #2685: Mutator.repairAfterMutation diagnostic dump includes producerStep in the context block",
+  async () => {
+    await initWasmForTests();
+    __resetProducerStepHistogramForTesting();
+    const restore = __setProducerCompileGateProbeForTesting(REJECT_PROBE);
+    // createNeatConfig() calls setLogger() with the default console logger,
+    // so build the config first and install the capture logger after.
+    const mutator = new Mutator(createNeatConfig({ populationSize: 10 }));
+    const capture = captureLogs();
+    try {
+      const healthy = buildHealthyCreature();
+      const ok = mutator.repairAfterMutation(healthy, {
+        mutationName: "ADD_NODE",
+      });
+      assertEquals(ok, false, "stub probe must surface as a Mutator revert");
+      const warn = capture.warnings.find((w) =>
+        w.includes("[Mutator]") && w.includes("step=Mutator.ADD_NODE") &&
+        w.includes("mutation=ADD_NODE")
+      );
+      assert(
+        warn !== undefined,
+        `expected Mutator warn line with step=Mutator.ADD_NODE, got: ${
+          capture.warnings.join("\n")
+        }`,
+      );
+      const ctx = readLatestDiagnosticContext("mutator-wasm-compile-trap-");
+      assert(
+        ctx !== undefined,
+        "expected a context-*.json diagnostic dump to exist",
+      );
+      assertEquals(ctx.producerStep, "Mutator.ADD_NODE");
+    } finally {
+      capture.dispose();
+      restore();
+      __resetProducerStepHistogramForTesting();
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Attribute producer-gate rejections to the originating mutate operator or
breed sub-step. Producers (`Mutator`, `Offspring.breed`, `DeDuplicator`,
`CRISPR`, `ApplyCoordinatedStructuralCandidate`) now set a
`currentProducerStep` label before applying a mutation; the gate captures
it on rejection and threads it through the diagnostic dump's `context`
block, the single-line warning, and a rate-limited histogram summary.
Closes #2685.

The implementation follows the cheapest path the issue calls for: a
module-local string in `ProducerCompileGuard.ts` plus thin
`setProducerStep` / `withProducerStep` wrappers around the existing
producer code paths. No per-call argument plumbing.

## Evidence

This is a CLI/library change with no UI. The behaviour is verified by:

- New unit tests in `test/wasm/ProducerCompileGateAttribution.ts` that
  exercise the seven acceptance criteria:
  1. `setProducerStep` / `getProducerStep` / `withProducerStep` round-trip.
  2. `runProducerCompileProbe` surfaces the active step on rejection.
  3. `passesProducerCompileGate` emits `step=...` in the warn line and
     records the rejection in the histogram.
  4. The histogram falls back to the producer name when no step is set.
  5. `flushProducerStepHistogram` emits a sorted summary info line and
     clears the histogram.
  6. `Offspring.breed` diagnostic dump includes `producerStep` in the
     `context` block.
  7. `Mutator.repairAfterMutation` diagnostic dump includes
     `producerStep` in the `context` block.
- The full test suite passes (`./quality.sh --skip-discovery --skip-wasm`
  → 6743 passed, 0 failed, 4 ignored).
- Existing producer-gate tests (`ProducerCompileGuard.ts`,
  `ProducerCompileGateWiring.ts`, `ProducerGateDiagnosticDumps.ts`) all
  continue to pass against the enriched warning format.

### Data flow

```mermaid
flowchart LR
    Op[Mutate operator<br/>e.g. AddNeuron] -->|setProducerStep| State[currentProducerStep]
    Op --> Probe[runProducerCompileProbe]
    State --> Probe
    Probe -->|ok: false| Result[ProducerCompileResult<br/>+ producerStep]
    Result --> Warn[warn line<br/>step=AddNeuron]
    Result --> Dump[.diagnostics/context-*.json<br/>producerStep field]
    Result --> Hist[step histogram]
    Hist -->|every 60s| Summary[info line<br/>sorted by frequency]
```

## Test Plan

- [x] `test/wasm/ProducerCompileGateAttribution.ts` — seven new tests
  covering the acceptance criteria.
- [x] `test/wasm/ProducerCompileGuard.ts` — existing tests unchanged and
  passing.
- [x] `test/wasm/ProducerCompileGateWiring.ts` — existing tests pass; the
  warning format change is backward compatible (`[<producer>] dropping
  output …` still matches when no step is set).
- [x] `test/wasm/ProducerGateDiagnosticDumps.ts` — existing tests pass
  unchanged; new `producerStep` field is additive.
- [x] `./quality.sh --skip-discovery --skip-wasm` clean: 6743 tests pass.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2685 -->