### PR TITLE
security: pin ludeeus/action-shellcheck to a commit SHA (#2695)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,8 +16,9 @@ jobs:
       - uses: actions/checkout@v4
       # Runs koalaman/shellcheck (https://github.com/koalaman/shellcheck) via the
       # ludeeus/action-shellcheck wrapper to lint shell scripts in the repository.
+      # ludeeus/action-shellcheck@2.0.0
       - name: Run ShellCheck (koalaman/shellcheck)
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
         with:
           scandir: .
           severity: warning

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.20",
+  "version": "5.0.21",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -462,6 +462,18 @@
     "Abramowitz",
     "Stegun",
     "Wilcoxon",
-    "stddev"
+    "stddev",
+    "AJSON",
+    "BJSON",
+    "coef",
+    "COEF",
+    "gelu",
+    "Gelu",
+    "isru",
+    "Isru",
+    "selu",
+    "Selu",
+    "ünter",
+    "XNOR"
   ]
 }

--- a/docs/pr-summary-2695.md
+++ b/docs/pr-summary-2695.md
@@ -1,0 +1,64 @@
+# Pin `ludeeus/action-shellcheck` to a commit SHA
+
+## Summary
+
+`.github/workflows/shellcheck.yml` previously referenced
+`ludeeus/action-shellcheck@master` — a moving ref that would execute any
+new commit on the upstream branch inside our CI on the next run. This is
+the highest-severity supply-chain class of pinning issue.
+
+The pin has been replaced with the 40-character commit SHA of the
+upstream `2.0.0` release tag, matching the pattern already in use in
+`markdown-lint.yml`. A nearby comment names the resolved tag so
+reviewers can verify provenance against the upstream release page.
+
+Closes #2695.
+
+## Evidence
+
+Backend/CI-only change — no UI to screenshot. The change is verifiable
+by reading the workflow file and running the new tests under
+`test/ci/ShellcheckWorkflowPinning.ts`.
+
+Before:
+
+```yaml
+uses: ludeeus/action-shellcheck@master
+```
+
+After:
+
+```yaml
+# ludeeus/action-shellcheck@2.0.0
+uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
+```
+
+The SHA `00cae500b08a931fb5698e11e79bfbd38e612a38` resolves to the
+upstream `2.0.0` tag on `ludeeus/action-shellcheck`, confirmed via
+`gh api repos/ludeeus/action-shellcheck/git/refs/tags/2.0.0`.
+
+## Test Plan
+
+New regression tests added in `test/ci/ShellcheckWorkflowPinning.ts`:
+
+- `extractUses parses a uses line` — unit test of the helper.
+- `extractUses returns empty for no uses lines` — unit test boundary.
+- `extractUses captures multiple actions` — unit test of multi-match.
+- `shellcheck.yml pins ludeeus/action-shellcheck to a 40-char commit SHA (Issue #2695)` —
+  reads the real workflow and asserts the ref matches `^[0-9a-f]{40}$`
+  and is not `master`/`main`.
+- `shellcheck.yml records the resolved tag in a comment for reviewer provenance (Issue #2695)` —
+  asserts a `# ludeeus/action-shellcheck@<tag>` provenance comment is
+  present.
+
+Verified the test set fails against the unfixed file (when restoring
+`@master`, both pinning tests fail) and passes against the fix.
+
+The pre-existing `DiscoveryTimeout` test failure observed in
+`./quality.sh` is unrelated to this change — it reproduces on a clean
+checkout of `Develop` without these edits.
+
+## Acceptance criteria
+
+- [x] `shellcheck.yml` no longer references `@master` (or any other moving ref).
+- [x] The pin is a 40-character commit SHA, with a comment naming the resolved tag (`2.0.0`).

--- a/docs/pr-summary-2695.md
+++ b/docs/pr-summary-2695.md
@@ -3,21 +3,21 @@
 ## Summary
 
 `.github/workflows/shellcheck.yml` previously referenced
-`ludeeus/action-shellcheck@master` — a moving ref that would execute any
-new commit on the upstream branch inside our CI on the next run. This is
-the highest-severity supply-chain class of pinning issue.
+`ludeeus/action-shellcheck@master` — a moving ref that would execute any new
+commit on the upstream branch inside our CI on the next run. This is the
+highest-severity supply-chain class of pinning issue.
 
-The pin has been replaced with the 40-character commit SHA of the
-upstream `2.0.0` release tag, matching the pattern already in use in
-`markdown-lint.yml`. A nearby comment names the resolved tag so
-reviewers can verify provenance against the upstream release page.
+The pin has been replaced with the 40-character commit SHA of the upstream
+`2.0.0` release tag, matching the pattern already in use in `markdown-lint.yml`.
+A nearby comment names the resolved tag so reviewers can verify provenance
+against the upstream release page.
 
 Closes #2695.
 
 ## Evidence
 
-Backend/CI-only change — no UI to screenshot. The change is verifiable
-by reading the workflow file and running the new tests under
+Backend/CI-only change — no UI to screenshot. The change is verifiable by
+reading the workflow file and running the new tests under
 `test/ci/ShellcheckWorkflowPinning.ts`.
 
 Before:
@@ -33,8 +33,8 @@ After:
 uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
 ```
 
-The SHA `00cae500b08a931fb5698e11e79bfbd38e612a38` resolves to the
-upstream `2.0.0` tag on `ludeeus/action-shellcheck`, confirmed via
+The SHA `00cae500b08a931fb5698e11e79bfbd38e612a38` resolves to the upstream
+`2.0.0` tag on `ludeeus/action-shellcheck`, confirmed via
 `gh api repos/ludeeus/action-shellcheck/git/refs/tags/2.0.0`.
 
 ## Test Plan
@@ -44,21 +44,21 @@ New regression tests added in `test/ci/ShellcheckWorkflowPinning.ts`:
 - `extractUses parses a uses line` — unit test of the helper.
 - `extractUses returns empty for no uses lines` — unit test boundary.
 - `extractUses captures multiple actions` — unit test of multi-match.
-- `shellcheck.yml pins ludeeus/action-shellcheck to a 40-char commit SHA (Issue #2695)` —
-  reads the real workflow and asserts the ref matches `^[0-9a-f]{40}$`
-  and is not `master`/`main`.
-- `shellcheck.yml records the resolved tag in a comment for reviewer provenance (Issue #2695)` —
-  asserts a `# ludeeus/action-shellcheck@<tag>` provenance comment is
-  present.
+- `shellcheck.yml pins ludeeus/action-shellcheck to a 40-char commit SHA (Issue #2695)`
+  — reads the real workflow and asserts the ref matches `^[0-9a-f]{40}$` and is
+  not `master`/`main`.
+- `shellcheck.yml records the resolved tag in a comment for reviewer provenance (Issue #2695)`
+  — asserts a `# ludeeus/action-shellcheck@<tag>` provenance comment is present.
 
-Verified the test set fails against the unfixed file (when restoring
-`@master`, both pinning tests fail) and passes against the fix.
+Verified the test set fails against the unfixed file (when restoring `@master`,
+both pinning tests fail) and passes against the fix.
 
-The pre-existing `DiscoveryTimeout` test failure observed in
-`./quality.sh` is unrelated to this change — it reproduces on a clean
-checkout of `Develop` without these edits.
+The pre-existing `DiscoveryTimeout` test failure observed in `./quality.sh` is
+unrelated to this change — it reproduces on a clean checkout of `Develop`
+without these edits.
 
 ## Acceptance criteria
 
 - [x] `shellcheck.yml` no longer references `@master` (or any other moving ref).
-- [x] The pin is a 40-character commit SHA, with a comment naming the resolved tag (`2.0.0`).
+- [x] The pin is a 40-character commit SHA, with a comment naming the resolved
+      tag (`2.0.0`).

--- a/src/utils/Version.ts
+++ b/src/utils/Version.ts
@@ -39,7 +39,7 @@ import { getLogger } from "@utils/Logger.ts";
  *
  * Must equal `deno.json` `version`. The version-sync test enforces this.
  */
-export const FALLBACK_NEAT_AI_VERSION = "5.0.20";
+export const FALLBACK_NEAT_AI_VERSION = "5.0.21";
 
 /**
  * Returns the running `@stsoftware/neat-ai` version.

--- a/test/ci/ShellcheckWorkflowPinning.ts
+++ b/test/ci/ShellcheckWorkflowPinning.ts
@@ -1,0 +1,100 @@
+/**
+ * Issue #2695 — `.github/workflows/shellcheck.yml` must pin
+ * `ludeeus/action-shellcheck` to a 40-character commit SHA rather than a
+ * moving ref such as `@master`, `@main`, or `@vN`.
+ *
+ * A moving ref means any commit pushed to the upstream branch executes
+ * inside our CI on the next run — a supply-chain attack vector with full
+ * `GITHUB_TOKEN` blast radius. This test guards against regression by
+ * scanning the workflow file directly.
+ */
+
+import { assert, assertEquals, assertMatch } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const WORKFLOW = join(REPO_ROOT, ".github/workflows/shellcheck.yml");
+
+/**
+ * Extract every `uses: <owner>/<repo>@<ref>` reference from a workflow.
+ */
+export function extractUses(
+  source: string,
+): { action: string; ref: string; line: number }[] {
+  const refs: { action: string; ref: string; line: number }[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(
+      /uses:\s*([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)@(\S+)/,
+    );
+    if (match) {
+      refs.push({ action: match[1], ref: match[2], line: i + 1 });
+    }
+  }
+  return refs;
+}
+
+Deno.test("extractUses parses a uses line", () => {
+  const src = "      - uses: foo/bar@abc123\n";
+  const refs = extractUses(src);
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].action, "foo/bar");
+  assertEquals(refs[0].ref, "abc123");
+});
+
+Deno.test("extractUses returns empty for no uses lines", () => {
+  assertEquals(extractUses("name: foo\nrun: echo hi\n").length, 0);
+});
+
+Deno.test("extractUses captures multiple actions", () => {
+  const src = [
+    "      - uses: actions/checkout@abc",
+    "      - uses: ludeeus/action-shellcheck@def",
+    "",
+  ].join("\n");
+  const refs = extractUses(src);
+  assertEquals(refs.length, 2);
+  assertEquals(refs[0].action, "actions/checkout");
+  assertEquals(refs[1].action, "ludeeus/action-shellcheck");
+});
+
+Deno.test(
+  "shellcheck.yml pins ludeeus/action-shellcheck to a 40-char commit SHA (Issue #2695)",
+  async () => {
+    const source = await Deno.readTextFile(WORKFLOW);
+    const refs = extractUses(source).filter(
+      (r) => r.action === "ludeeus/action-shellcheck",
+    );
+    assert(
+      refs.length > 0,
+      "expected at least one ludeeus/action-shellcheck reference in shellcheck.yml",
+    );
+    for (const r of refs) {
+      // Reject moving refs.
+      assert(
+        r.ref !== "master" && r.ref !== "main",
+        `ludeeus/action-shellcheck pinned to moving ref '${r.ref}' on line ${r.line}`,
+      );
+      // Require a 40-character lowercase hex commit SHA.
+      assertMatch(
+        r.ref,
+        /^[0-9a-f]{40}$/,
+        `ludeeus/action-shellcheck must be pinned to a 40-char commit SHA on line ${r.line}, got '${r.ref}'`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "shellcheck.yml records the resolved tag in a comment for reviewer provenance (Issue #2695)",
+  async () => {
+    const source = await Deno.readTextFile(WORKFLOW);
+    // A nearby comment naming the action and its tag lets reviewers verify
+    // the SHA resolves to a real release.
+    assertMatch(
+      source,
+      /#\s*ludeeus\/action-shellcheck@\S+/,
+      "expected a '# ludeeus/action-shellcheck@<tag>' comment near the pinned SHA",
+    );
+  },
+);


### PR DESCRIPTION
# Pin `ludeeus/action-shellcheck` to a commit SHA

## Summary

`.github/workflows/shellcheck.yml` previously referenced
`ludeeus/action-shellcheck@master` — a moving ref that would execute any
new commit on the upstream branch inside our CI on the next run. This is
the highest-severity supply-chain class of pinning issue.

The pin has been replaced with the 40-character commit SHA of the
upstream `2.0.0` release tag, matching the pattern already in use in
`markdown-lint.yml`. A nearby comment names the resolved tag so
reviewers can verify provenance against the upstream release page.

Closes #2695.

## Evidence

Backend/CI-only change — no UI to screenshot. The change is verifiable
by reading the workflow file and running the new tests under
`test/ci/ShellcheckWorkflowPinning.ts`.

Before:

```yaml
uses: ludeeus/action-shellcheck@master
```

After:

```yaml
# ludeeus/action-shellcheck@2.0.0
uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
```

The SHA `00cae500b08a931fb5698e11e79bfbd38e612a38` resolves to the
upstream `2.0.0` tag on `ludeeus/action-shellcheck`, confirmed via
`gh api repos/ludeeus/action-shellcheck/git/refs/tags/2.0.0`.

## Test Plan

New regression tests added in `test/ci/ShellcheckWorkflowPinning.ts`:

- `extractUses parses a uses line` — unit test of the helper.
- `extractUses returns empty for no uses lines` — unit test boundary.
- `extractUses captures multiple actions` — unit test of multi-match.
- `shellcheck.yml pins ludeeus/action-shellcheck to a 40-char commit SHA (Issue #2695)` —
  reads the real workflow and asserts the ref matches `^[0-9a-f]{40}$`
  and is not `master`/`main`.
- `shellcheck.yml records the resolved tag in a comment for reviewer provenance (Issue #2695)` —
  asserts a `# ludeeus/action-shellcheck@<tag>` provenance comment is
  present.

Verified the test set fails against the unfixed file (when restoring
`@master`, both pinning tests fail) and passes against the fix.

The pre-existing `DiscoveryTimeout` test failure observed in
`./quality.sh` is unrelated to this change — it reproduces on a clean
checkout of `Develop` without these edits.

## Acceptance criteria

- [x] `shellcheck.yml` no longer references `@master` (or any other moving ref).
- [x] The pin is a 40-character commit SHA, with a comment naming the resolved tag (`2.0.0`).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2695 -->