### PR TITLE
security: coverage.yaml / quality.yml / spellcheck.yaml lack top-level 'permissions:' block (least privilege) (Issue #2706)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -5,6 +5,14 @@ on:
     branches:
       - Develop
 
+# Least-privilege GITHUB_TOKEN scopes (Issue #2706). The workflow uploads
+# artifacts, posts check-run annotations via EnricoMi/publish-unit-test-result-action,
+# and uploads coverage/results to Codecov.
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,6 +6,12 @@ on:
       - Develop
   workflow_dispatch: # Allow manual trigger if needed
 
+# Least-privilege GITHUB_TOKEN scopes (Issue #2706). The push back to the PR
+# branch uses secrets.ACTIONS_PUSH (a PAT), not the default GITHUB_TOKEN, so the
+# default token only needs read access.
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -4,6 +4,11 @@ on:
     branches:
       - Develop
 
+# Least-privilege GITHUB_TOKEN scopes (Issue #2706). The cspell action only
+# reads files; no write access is required.
+permissions:
+  contents: read
+
 jobs:
   spellcheck: # run the action
     runs-on: ubuntu-latest

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.19",
+  "version": "5.0.20",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2706.md
+++ b/docs/pr-summary-2706.md
@@ -1,0 +1,52 @@
+# security: declare top-level `permissions:` on coverage / quality / spellcheck workflows
+
+## Summary
+
+Added a top-level least-privilege `permissions:` block to three workflows that
+previously inherited the repository's default `GITHUB_TOKEN` scopes. This is a
+defence-in-depth hardening change recommended by GitHub and the OpenSSF
+Scorecard, matching the pattern already in use by `markdown-lint.yml`,
+`semgrep.yml`, `shellcheck.yml`, `dependency-review.yml`, and
+`deno-outdated.yml`. Closes #2706.
+
+| Workflow | Scopes granted | Why |
+| --- | --- | --- |
+| `coverage.yaml` | `contents: read`, `checks: write`, `pull-requests: write` | Uploads artefacts, posts check-run annotations via `EnricoMi/publish-unit-test-result-action`, uploads to Codecov |
+| `quality.yml` | `contents: read` | Push back to the PR branch uses `secrets.ACTIONS_PUSH` (a PAT), not the default `GITHUB_TOKEN`, so the default token only needs read |
+| `spellcheck.yaml` | `contents: read` | `cspell-action` is read-only |
+
+## Evidence
+
+Backend / workflow-config change — no UI to screenshot. Verified by parsing
+each workflow YAML and asserting the structural shape of the new
+`permissions:` block:
+
+```text
+running 6 tests from ./test/scripts/WorkflowLeastPrivilegePermissions.ts
+coverage.yaml declares a top-level permissions block ... ok
+coverage.yaml grants only the scopes it needs ... ok
+quality.yml declares a top-level permissions block ... ok
+quality.yml grants only contents: read for GITHUB_TOKEN ... ok
+spellcheck.yaml declares a top-level permissions block ... ok
+spellcheck.yaml grants only contents: read (read-only) ... ok
+
+ok | 6 passed | 0 failed
+```
+
+```mermaid
+flowchart LR
+    Default[Repo-default GITHUB_TOKEN<br/>permissions] -. inherited .-> Old[Old workflow runs]
+    TopLevel[Top-level permissions:<br/>least-privilege block] --> New[New workflow runs]
+    Old -. could silently widen .-> Risk[Drift risk]
+    New --> Locked[Pinned scopes — drift-proof]
+```
+
+## Test Plan
+
+- Added `test/scripts/WorkflowLeastPrivilegePermissions.ts` with six tests
+  (one "declares a block" + one "grants only what is needed" per workflow).
+- Tests parse the workflow YAML with `@std/yaml` and assert on the parsed
+  structure — they are pure "what" tests that survive any internal refactor of
+  the workflow steps.
+- Verified that on a follow-up PR run, artefact upload, check-run annotations,
+  and the PR-branch push (via `ACTIONS_PUSH` PAT) all continue to succeed.

--- a/docs/pr-summary-2706.md
+++ b/docs/pr-summary-2706.md
@@ -9,17 +9,17 @@ Scorecard, matching the pattern already in use by `markdown-lint.yml`,
 `semgrep.yml`, `shellcheck.yml`, `dependency-review.yml`, and
 `deno-outdated.yml`. Closes #2706.
 
-| Workflow | Scopes granted | Why |
-| --- | --- | --- |
-| `coverage.yaml` | `contents: read`, `checks: write`, `pull-requests: write` | Uploads artefacts, posts check-run annotations via `EnricoMi/publish-unit-test-result-action`, uploads to Codecov |
-| `quality.yml` | `contents: read` | Push back to the PR branch uses `secrets.ACTIONS_PUSH` (a PAT), not the default `GITHUB_TOKEN`, so the default token only needs read |
-| `spellcheck.yaml` | `contents: read` | `cspell-action` is read-only |
+| Workflow          | Scopes granted                                            | Why                                                                                                                                  |
+| ----------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `coverage.yaml`   | `contents: read`, `checks: write`, `pull-requests: write` | Uploads artefacts, posts check-run annotations via `EnricoMi/publish-unit-test-result-action`, uploads to Codecov                    |
+| `quality.yml`     | `contents: read`                                          | Push back to the PR branch uses `secrets.ACTIONS_PUSH` (a PAT), not the default `GITHUB_TOKEN`, so the default token only needs read |
+| `spellcheck.yaml` | `contents: read`                                          | `cspell-action` is read-only                                                                                                         |
 
 ## Evidence
 
-Backend / workflow-config change — no UI to screenshot. Verified by parsing
-each workflow YAML and asserting the structural shape of the new
-`permissions:` block:
+Backend / workflow-config change — no UI to screenshot. Verified by parsing each
+workflow YAML and asserting the structural shape of the new `permissions:`
+block:
 
 ```text
 running 6 tests from ./test/scripts/WorkflowLeastPrivilegePermissions.ts
@@ -43,8 +43,8 @@ flowchart LR
 
 ## Test Plan
 
-- Added `test/scripts/WorkflowLeastPrivilegePermissions.ts` with six tests
-  (one "declares a block" + one "grants only what is needed" per workflow).
+- Added `test/scripts/WorkflowLeastPrivilegePermissions.ts` with six tests (one
+  "declares a block" + one "grants only what is needed" per workflow).
 - Tests parse the workflow YAML with `@std/yaml` and assert on the parsed
   structure — they are pure "what" tests that survive any internal refactor of
   the workflow steps.

--- a/src/utils/Version.ts
+++ b/src/utils/Version.ts
@@ -39,7 +39,7 @@ import { getLogger } from "@utils/Logger.ts";
  *
  * Must equal `deno.json` `version`. The version-sync test enforces this.
  */
-export const FALLBACK_NEAT_AI_VERSION = "5.0.19";
+export const FALLBACK_NEAT_AI_VERSION = "5.0.20";
 
 /**
  * Returns the running `@stsoftware/neat-ai` version.

--- a/test/scripts/WorkflowLeastPrivilegePermissions.ts
+++ b/test/scripts/WorkflowLeastPrivilegePermissions.ts
@@ -1,0 +1,95 @@
+import { assert, assertEquals } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verifies that the coverage.yaml, quality.yml, and spellcheck.yaml workflows
+ * declare a top-level `permissions:` block granting only the minimum scopes
+ * they need (Issue #2706 — least-privilege workflow hardening).
+ *
+ * Without a top-level `permissions:` block, the default GITHUB_TOKEN inherits
+ * whatever the repository's default permissions are, which means a drift in
+ * repository settings could silently grant write access to these workflows.
+ */
+
+interface Workflow {
+  name?: string;
+  permissions?: Record<string, string> | string;
+  jobs: Record<string, unknown>;
+}
+
+async function readWorkflow(path: string): Promise<Workflow> {
+  const text = await Deno.readTextFile(path);
+  return parse(text) as Workflow;
+}
+
+Deno.test("coverage.yaml declares a top-level permissions block", async () => {
+  const wf = await readWorkflow(".github/workflows/coverage.yaml");
+  assert(wf.permissions, "coverage.yaml must declare top-level permissions");
+});
+
+Deno.test("coverage.yaml grants only the scopes it needs", async () => {
+  const wf = await readWorkflow(".github/workflows/coverage.yaml");
+  const perms = wf.permissions as Record<string, string>;
+  // Coverage workflow uploads artifacts, posts check-run annotations via
+  // EnricoMi/publish-unit-test-result-action, and uploads to Codecov.
+  assertEquals(
+    perms.contents,
+    "read",
+    "coverage.yaml must grant contents: read",
+  );
+  assertEquals(
+    perms.checks,
+    "write",
+    "coverage.yaml must grant checks: write for check-run annotations",
+  );
+  assertEquals(
+    perms["pull-requests"],
+    "write",
+    "coverage.yaml must grant pull-requests: write for PR annotations",
+  );
+});
+
+Deno.test("quality.yml declares a top-level permissions block", async () => {
+  const wf = await readWorkflow(".github/workflows/quality.yml");
+  assert(wf.permissions, "quality.yml must declare top-level permissions");
+});
+
+Deno.test("quality.yml grants only contents: read for GITHUB_TOKEN", async () => {
+  const wf = await readWorkflow(".github/workflows/quality.yml");
+  const perms = wf.permissions as Record<string, string>;
+  // quality.yml pushes back to the PR branch but uses secrets.ACTIONS_PUSH
+  // (a PAT), not the default GITHUB_TOKEN, so the default token can be
+  // downgraded to contents: read.
+  assertEquals(
+    perms.contents,
+    "read",
+    "quality.yml must grant contents: read (push uses ACTIONS_PUSH PAT)",
+  );
+  const keys = Object.keys(perms);
+  assertEquals(
+    keys.length,
+    1,
+    `quality.yml must grant only contents: read, got ${keys.join(", ")}`,
+  );
+});
+
+Deno.test("spellcheck.yaml declares a top-level permissions block", async () => {
+  const wf = await readWorkflow(".github/workflows/spellcheck.yaml");
+  assert(wf.permissions, "spellcheck.yaml must declare top-level permissions");
+});
+
+Deno.test("spellcheck.yaml grants only contents: read (read-only)", async () => {
+  const wf = await readWorkflow(".github/workflows/spellcheck.yaml");
+  const perms = wf.permissions as Record<string, string>;
+  assertEquals(
+    perms.contents,
+    "read",
+    "spellcheck.yaml must grant contents: read",
+  );
+  const keys = Object.keys(perms);
+  assertEquals(
+    keys.length,
+    1,
+    `spellcheck.yaml must grant only contents: read, got ${keys.join(", ")}`,
+  );
+});


### PR DESCRIPTION
# security: declare top-level `permissions:` on coverage / quality / spellcheck workflows

## Summary

Added a top-level least-privilege `permissions:` block to three workflows that
previously inherited the repository's default `GITHUB_TOKEN` scopes. This is a
defence-in-depth hardening change recommended by GitHub and the OpenSSF
Scorecard, matching the pattern already in use by `markdown-lint.yml`,
`semgrep.yml`, `shellcheck.yml`, `dependency-review.yml`, and
`deno-outdated.yml`. Closes #2706.

| Workflow | Scopes granted | Why |
| --- | --- | --- |
| `coverage.yaml` | `contents: read`, `checks: write`, `pull-requests: write` | Uploads artefacts, posts check-run annotations via `EnricoMi/publish-unit-test-result-action`, uploads to Codecov |
| `quality.yml` | `contents: read` | Push back to the PR branch uses `secrets.ACTIONS_PUSH` (a PAT), not the default `GITHUB_TOKEN`, so the default token only needs read |
| `spellcheck.yaml` | `contents: read` | `cspell-action` is read-only |

## Evidence

Backend / workflow-config change — no UI to screenshot. Verified by parsing
each workflow YAML and asserting the structural shape of the new
`permissions:` block:

```text
running 6 tests from ./test/scripts/WorkflowLeastPrivilegePermissions.ts
coverage.yaml declares a top-level permissions block ... ok
coverage.yaml grants only the scopes it needs ... ok
quality.yml declares a top-level permissions block ... ok
quality.yml grants only contents: read for GITHUB_TOKEN ... ok
spellcheck.yaml declares a top-level permissions block ... ok
spellcheck.yaml grants only contents: read (read-only) ... ok

ok | 6 passed | 0 failed
```

```mermaid
flowchart LR
    Default[Repo-default GITHUB_TOKEN<br/>permissions] -. inherited .-> Old[Old workflow runs]
    TopLevel[Top-level permissions:<br/>least-privilege block] --> New[New workflow runs]
    Old -. could silently widen .-> Risk[Drift risk]
    New --> Locked[Pinned scopes — drift-proof]
```

## Test Plan

- Added `test/scripts/WorkflowLeastPrivilegePermissions.ts` with six tests
  (one "declares a block" + one "grants only what is needed" per workflow).
- Tests parse the workflow YAML with `@std/yaml` and assert on the parsed
  structure — they are pure "what" tests that survive any internal refactor of
  the workflow steps.
- Verified that on a follow-up PR run, artefact upload, check-run annotations,
  and the PR-branch push (via `ACTIONS_PUSH` PAT) all continue to succeed.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2706 -->