### PR TITLE
security: Strengthen Semgrep config beyond p/default (add p/security-audit and p/owasp-top-ten) (Issue #2698)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - run: semgrep ci --config p/default
+      - run: semgrep ci --config p/default --config p/security-audit --config p/owasp-top-ten
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.24",
+  "version": "5.0.25",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2698.md
+++ b/docs/pr-summary-2698.md
@@ -1,13 +1,12 @@
 ## Summary
 
-Strengthened the Semgrep SAST workflow by adding two explicitly
-security-focused rule packs (`p/security-audit` and `p/owasp-top-ten`)
-alongside the existing broad `p/default` pack. `SECURITY.md` already
-advertises Semgrep as the project's SAST gate, but `p/default` only
-lightly overlaps with security rules — the additional packs materially
-raise the bar without adding noise to pre-existing code (`semgrep ci`
-suppresses pre-existing findings; only *new* code that introduces a
-violation will fail).
+Strengthened the Semgrep SAST workflow by adding two explicitly security-focused
+rule packs (`p/security-audit` and `p/owasp-top-ten`) alongside the existing
+broad `p/default` pack. `SECURITY.md` already advertises Semgrep as the
+project's SAST gate, but `p/default` only lightly overlaps with security rules —
+the additional packs materially raise the bar without adding noise to
+pre-existing code (`semgrep ci` suppresses pre-existing findings; only _new_
+code that introduces a violation will fail).
 
 Closes #2698.
 
@@ -19,10 +18,9 @@ Closes #2698.
 - run: semgrep ci --config p/default --config p/security-audit --config p/owasp-top-ten
 ```
 
-This is a CI configuration change with no runtime/web interface to
-screenshot. Verification is via the new regression test
-`test/ci/SemgrepRulePacks.ts`, which parses the workflow YAML and
-asserts the configured rule packs:
+This is a CI configuration change with no runtime/web interface to screenshot.
+Verification is via the new regression test `test/ci/SemgrepRulePacks.ts`, which
+parses the workflow YAML and asserts the configured rule packs:
 
 ```text
 running 5 tests from ./test/ci/SemgrepRulePacks.ts
@@ -38,12 +36,11 @@ ok | 5 passed | 0 failed
 ## Test Plan
 
 - Added `test/ci/SemgrepRulePacks.ts` covering:
-  - Parser unit tests (`extractSemgrepConfigs`): single pack, multiple
-    packs, and zero packs.
+  - Parser unit tests (`extractSemgrepConfigs`): single pack, multiple packs,
+    and zero packs.
   - Regression test asserting `p/default` is retained in
     `.github/workflows/semgrep.yml`.
   - Regression test asserting at least one of `p/security-audit` or
-    `p/owasp-top-ten` is present, satisfying the issue's acceptance
-    criterion.
-- `./quality.sh --lint-only` and `./quality.sh --check-only` both pass
-  cleanly with the new file.
+    `p/owasp-top-ten` is present, satisfying the issue's acceptance criterion.
+- `./quality.sh --lint-only` and `./quality.sh --check-only` both pass cleanly
+  with the new file.

--- a/docs/pr-summary-2698.md
+++ b/docs/pr-summary-2698.md
@@ -1,0 +1,49 @@
+## Summary
+
+Strengthened the Semgrep SAST workflow by adding two explicitly
+security-focused rule packs (`p/security-audit` and `p/owasp-top-ten`)
+alongside the existing broad `p/default` pack. `SECURITY.md` already
+advertises Semgrep as the project's SAST gate, but `p/default` only
+lightly overlaps with security rules — the additional packs materially
+raise the bar without adding noise to pre-existing code (`semgrep ci`
+suppresses pre-existing findings; only *new* code that introduces a
+violation will fail).
+
+Closes #2698.
+
+## Evidence
+
+`.github/workflows/semgrep.yml` now runs:
+
+```yaml
+- run: semgrep ci --config p/default --config p/security-audit --config p/owasp-top-ten
+```
+
+This is a CI configuration change with no runtime/web interface to
+screenshot. Verification is via the new regression test
+`test/ci/SemgrepRulePacks.ts`, which parses the workflow YAML and
+asserts the configured rule packs:
+
+```text
+running 5 tests from ./test/ci/SemgrepRulePacks.ts
+extractSemgrepConfigs parses a single --config flag ... ok
+extractSemgrepConfigs captures multiple packs ... ok
+extractSemgrepConfigs returns empty for no --config flags ... ok
+semgrep.yml retains the p/default rule pack (Issue #2698) ... ok
+semgrep.yml runs a security-focused rule pack (Issue #2698) ... ok
+
+ok | 5 passed | 0 failed
+```
+
+## Test Plan
+
+- Added `test/ci/SemgrepRulePacks.ts` covering:
+  - Parser unit tests (`extractSemgrepConfigs`): single pack, multiple
+    packs, and zero packs.
+  - Regression test asserting `p/default` is retained in
+    `.github/workflows/semgrep.yml`.
+  - Regression test asserting at least one of `p/security-audit` or
+    `p/owasp-top-ten` is present, satisfying the issue's acceptance
+    criterion.
+- `./quality.sh --lint-only` and `./quality.sh --check-only` both pass
+  cleanly with the new file.

--- a/src/utils/Version.ts
+++ b/src/utils/Version.ts
@@ -39,7 +39,7 @@ import { getLogger } from "@utils/Logger.ts";
  *
  * Must equal `deno.json` `version`. The version-sync test enforces this.
  */
-export const FALLBACK_NEAT_AI_VERSION = "5.0.24";
+export const FALLBACK_NEAT_AI_VERSION = "5.0.25";
 
 /**
  * Returns the running `@stsoftware/neat-ai` version.

--- a/test/ci/SemgrepRulePacks.ts
+++ b/test/ci/SemgrepRulePacks.ts
@@ -1,0 +1,81 @@
+/**
+ * Issue #2698 — `.github/workflows/semgrep.yml` must run at least one
+ * explicitly security-focused rule pack in addition to the broad
+ * correctness-oriented `p/default` pack.
+ *
+ * SECURITY.md advertises Semgrep as the project's SAST gate, but
+ * `p/default` only lightly overlaps with security rules. Adding
+ * `p/security-audit` and `p/owasp-top-ten` materially raises the bar.
+ * This test guards against regression by scanning the workflow file
+ * directly.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const WORKFLOW = join(REPO_ROOT, ".github/workflows/semgrep.yml");
+
+/**
+ * Extract every `--config <pack>` argument from a workflow source. Returns the
+ * raw pack name (e.g. `p/security-audit`) for each occurrence in document
+ * order.
+ */
+export function extractSemgrepConfigs(source: string): string[] {
+  const packs: string[] = [];
+  const re = /--config\s+(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    packs.push(match[1]);
+  }
+  return packs;
+}
+
+Deno.test("extractSemgrepConfigs parses a single --config flag", () => {
+  const packs = extractSemgrepConfigs("semgrep ci --config p/default");
+  assert(packs.length === 1, `expected 1 pack, got ${packs.length}`);
+  assert(packs[0] === "p/default");
+});
+
+Deno.test("extractSemgrepConfigs captures multiple packs", () => {
+  const packs = extractSemgrepConfigs(
+    "semgrep ci --config p/default --config p/security-audit --config p/owasp-top-ten",
+  );
+  assert(packs.length === 3, `expected 3 packs, got ${packs.length}`);
+  assert(packs.includes("p/default"));
+  assert(packs.includes("p/security-audit"));
+  assert(packs.includes("p/owasp-top-ten"));
+});
+
+Deno.test("extractSemgrepConfigs returns empty for no --config flags", () => {
+  const packs = extractSemgrepConfigs("semgrep ci");
+  assert(packs.length === 0);
+});
+
+Deno.test(
+  "semgrep.yml retains the p/default rule pack (Issue #2698)",
+  async () => {
+    const source = await Deno.readTextFile(WORKFLOW);
+    const packs = extractSemgrepConfigs(source);
+    assert(
+      packs.includes("p/default"),
+      `expected p/default to remain in semgrep.yml, got: ${packs.join(", ")}`,
+    );
+  },
+);
+
+Deno.test(
+  "semgrep.yml runs a security-focused rule pack (Issue #2698)",
+  async () => {
+    const source = await Deno.readTextFile(WORKFLOW);
+    const packs = extractSemgrepConfigs(source);
+    const securityPacks = ["p/security-audit", "p/owasp-top-ten"];
+    const present = securityPacks.filter((p) => packs.includes(p));
+    assert(
+      present.length >= 1,
+      `expected at least one of ${
+        securityPacks.join(", ")
+      } in semgrep.yml, got: ${packs.join(", ")}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Strengthened the Semgrep SAST workflow by adding two explicitly
security-focused rule packs (`p/security-audit` and `p/owasp-top-ten`)
alongside the existing broad `p/default` pack. `SECURITY.md` already
advertises Semgrep as the project's SAST gate, but `p/default` only
lightly overlaps with security rules — the additional packs materially
raise the bar without adding noise to pre-existing code (`semgrep ci`
suppresses pre-existing findings; only *new* code that introduces a
violation will fail).

Closes #2698.

## Evidence

`.github/workflows/semgrep.yml` now runs:

```yaml
- run: semgrep ci --config p/default --config p/security-audit --config p/owasp-top-ten
```

This is a CI configuration change with no runtime/web interface to
screenshot. Verification is via the new regression test
`test/ci/SemgrepRulePacks.ts`, which parses the workflow YAML and
asserts the configured rule packs:

```text
running 5 tests from ./test/ci/SemgrepRulePacks.ts
extractSemgrepConfigs parses a single --config flag ... ok
extractSemgrepConfigs captures multiple packs ... ok
extractSemgrepConfigs returns empty for no --config flags ... ok
semgrep.yml retains the p/default rule pack (Issue #2698) ... ok
semgrep.yml runs a security-focused rule pack (Issue #2698) ... ok

ok | 5 passed | 0 failed
```

## Test Plan

- Added `test/ci/SemgrepRulePacks.ts` covering:
  - Parser unit tests (`extractSemgrepConfigs`): single pack, multiple
    packs, and zero packs.
  - Regression test asserting `p/default` is retained in
    `.github/workflows/semgrep.yml`.
  - Regression test asserting at least one of `p/security-audit` or
    `p/owasp-top-ten` is present, satisfying the issue's acceptance
    criterion.
- `./quality.sh --lint-only` and `./quality.sh --check-only` both pass
  cleanly with the new file.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2698 -->