### PR TITLE
security: drop inline deno outdated --update --latest from quality.yml (#2697)

### DIFF
--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -1,10 +1,11 @@
-# Deno Dependency Updates (Issue #2362)
+# Deno Dependency Updates (Issue #2362, Issue #2697)
 #
 # Runs `deno outdated --update --latest` on a weekly schedule (and on demand)
 # and opens a pull request with any version bumps via
-# peter-evans/create-pull-request. Keeps the dedicated automation that the
-# detection patterns expect under the `deno-outdated` name, complementing the
-# inline `deno outdated` step in `quality.yml` which only runs on PR.
+# peter-evans/create-pull-request. This is the single source of truth for
+# Deno dep bumps — the previous inline step in `quality.yml` was removed by
+# Issue #2697 because it pulled fresh external versions onto every PR with
+# no quarantine and auto-committed the lockfile changes under the bot.
 name: Deno Dependency Updates
 
 on:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -193,9 +193,13 @@ jobs:
         # denoland/setup-deno@v2.0.4
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
 
-      # Update Deno
-      - name: Update Deno
-        run: deno outdated --update --latest
+      # Note: dep bumps flow through the scheduled
+      # `.github/workflows/deno-outdated.yml` workflow, which raises a
+      # reviewable PR via peter-evans/create-pull-request. The previous
+      # inline `Update Deno` step on every PR pulled whatever version
+      # was newest at run-time and auto-committed the lockfile changes
+      # under the bot's signature, bypassing contributor review and the
+      # bump quarantine for external deps (Issue #2697).
 
       - name: Sync WASM package from NEAT-AI-core
         run: ./build.sh --verify-only

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.26",
+  "version": "5.0.27",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/pr-summary-2697.md
+++ b/docs/pr-summary-2697.md
@@ -1,0 +1,81 @@
+# security: drop inline `deno outdated --update --latest` from quality.yml
+
+## Summary
+
+Removed the inline `Update Deno` step from `.github/workflows/quality.yml`
+that ran `deno outdated --update --latest` on every pull request and then
+auto-committed/pushed the resulting lockfile changes back to the PR branch
+using `secrets.ACTIONS_PUSH`.
+
+The step pulled whatever version was newest at PR run-time, with no
+quarantine window for newly-published external (non-`stSoftwareAU/*`)
+dependencies. A malicious JSR or npm release going live shortly before a
+PR run would be merged into the PR branch automatically under the bot's
+signature, bypassing contributor review.
+
+Dep bumps now flow exclusively through the existing scheduled workflow
+`.github/workflows/deno-outdated.yml`, which already runs
+`deno outdated --update --latest` weekly and raises a separate
+reviewable PR via `peter-evans/create-pull-request`. The auto-commit /
+push pipeline in `quality.yml` is preserved for genuine fmt/lint fixes —
+without the inline update step, the only diff that can reach the commit
+step is fmt/lint output, which is safe.
+
+Closes #2697.
+
+## Evidence
+
+This is a CI workflow change with no UI surface. The fix is verified by
+new behavioural tests in `test/ci/QualityWorkflowDepBumpQuarantine.ts`
+that read the workflow files and assert on their content.
+
+### Before / after
+
+```mermaid
+flowchart LR
+    subgraph Before["Before #2697"]
+        PR1[PR opened] --> Q1[quality.yml]
+        Q1 -->|deno outdated --update --latest| Lock1[lockfile rewritten]
+        Lock1 -->|auto-commit + push| PR1
+        Cron1[weekly cron] --> DO1[deno-outdated.yml] --> PR2[reviewable PR]
+    end
+    subgraph After["After #2697"]
+        PR3[PR opened] --> Q2[quality.yml — fmt/lint only]
+        Cron2[weekly cron] --> DO2[deno-outdated.yml] --> PR4[reviewable PR]
+    end
+```
+
+Before: two channels for dep bumps — the inline PR-time channel pulled
+fresh external versions with no quarantine and committed them under the
+bot. After: a single reviewable channel via the scheduled workflow.
+
+### Test results
+
+```
+ok | 115 passed | 0 failed (5s)
+```
+
+(All `test/ci/` and `test/scripts/` tests, including the three new
+ones for this issue.)
+
+## Test Plan
+
+Added `test/ci/QualityWorkflowDepBumpQuarantine.ts`:
+
+- `quality.yml does not run \`deno outdated --update --latest\` inline (Issue #2697)` —
+  fails against the old workflow, passes after the inline step is removed.
+- `quality.yml does not auto-commit \`deno fmt and lint fixes\` containing fresh dep versions (Issue #2697)` —
+  guards against re-introducing the bug by combining any future
+  lockfile-writing Deno step with the existing push-back step.
+- `deno-outdated.yml still owns the scheduled dep-update channel (Issue #2697)` —
+  pins the dedicated weekly workflow so the reviewable channel cannot
+  silently disappear.
+
+Existing tests that continued to pass after the change:
+
+- `test/scripts/DenoOutdatedWorkflow.ts` — verifies the scheduled
+  workflow still runs `deno outdated --update --latest` and raises a PR.
+- `test/ci/QualityWorkflowScriptInjection.ts` — Issue #2709 guards on
+  `quality.yml` still pass after the edit.
+- `test/scripts/WorkflowLeastPrivilegePermissions.ts` — `quality.yml`'s
+  `permissions:` block is unchanged.

--- a/docs/pr-summary-2697.md
+++ b/docs/pr-summary-2697.md
@@ -2,32 +2,32 @@
 
 ## Summary
 
-Removed the inline `Update Deno` step from `.github/workflows/quality.yml`
-that ran `deno outdated --update --latest` on every pull request and then
-auto-committed/pushed the resulting lockfile changes back to the PR branch
-using `secrets.ACTIONS_PUSH`.
+Removed the inline `Update Deno` step from `.github/workflows/quality.yml` that
+ran `deno outdated --update --latest` on every pull request and then
+auto-committed/pushed the resulting lockfile changes back to the PR branch using
+`secrets.ACTIONS_PUSH`.
 
-The step pulled whatever version was newest at PR run-time, with no
-quarantine window for newly-published external (non-`stSoftwareAU/*`)
-dependencies. A malicious JSR or npm release going live shortly before a
-PR run would be merged into the PR branch automatically under the bot's
-signature, bypassing contributor review.
+The step pulled whatever version was newest at PR run-time, with no quarantine
+window for newly-published external (non-`stSoftwareAU/*`) dependencies. A
+malicious JSR or npm release going live shortly before a PR run would be merged
+into the PR branch automatically under the bot's signature, bypassing
+contributor review.
 
 Dep bumps now flow exclusively through the existing scheduled workflow
 `.github/workflows/deno-outdated.yml`, which already runs
-`deno outdated --update --latest` weekly and raises a separate
-reviewable PR via `peter-evans/create-pull-request`. The auto-commit /
-push pipeline in `quality.yml` is preserved for genuine fmt/lint fixes —
-without the inline update step, the only diff that can reach the commit
-step is fmt/lint output, which is safe.
+`deno outdated --update --latest` weekly and raises a separate reviewable PR via
+`peter-evans/create-pull-request`. The auto-commit / push pipeline in
+`quality.yml` is preserved for genuine fmt/lint fixes — without the inline
+update step, the only diff that can reach the commit step is fmt/lint output,
+which is safe.
 
 Closes #2697.
 
 ## Evidence
 
-This is a CI workflow change with no UI surface. The fix is verified by
-new behavioural tests in `test/ci/QualityWorkflowDepBumpQuarantine.ts`
-that read the workflow files and assert on their content.
+This is a CI workflow change with no UI surface. The fix is verified by new
+behavioural tests in `test/ci/QualityWorkflowDepBumpQuarantine.ts` that read the
+workflow files and assert on their content.
 
 ### Before / after
 
@@ -45,9 +45,9 @@ flowchart LR
     end
 ```
 
-Before: two channels for dep bumps — the inline PR-time channel pulled
-fresh external versions with no quarantine and committed them under the
-bot. After: a single reviewable channel via the scheduled workflow.
+Before: two channels for dep bumps — the inline PR-time channel pulled fresh
+external versions with no quarantine and committed them under the bot. After: a
+single reviewable channel via the scheduled workflow.
 
 ### Test results
 
@@ -55,26 +55,28 @@ bot. After: a single reviewable channel via the scheduled workflow.
 ok | 115 passed | 0 failed (5s)
 ```
 
-(All `test/ci/` and `test/scripts/` tests, including the three new
-ones for this issue.)
+(All `test/ci/` and `test/scripts/` tests, including the three new ones for this
+issue.)
 
 ## Test Plan
 
 Added `test/ci/QualityWorkflowDepBumpQuarantine.ts`:
 
-- `quality.yml does not run \`deno outdated --update --latest\` inline (Issue #2697)` —
-  fails against the old workflow, passes after the inline step is removed.
-- `quality.yml does not auto-commit \`deno fmt and lint fixes\` containing fresh dep versions (Issue #2697)` —
-  guards against re-introducing the bug by combining any future
-  lockfile-writing Deno step with the existing push-back step.
-- `deno-outdated.yml still owns the scheduled dep-update channel (Issue #2697)` —
-  pins the dedicated weekly workflow so the reviewable channel cannot
-  silently disappear.
+- `quality.yml does not run \`deno outdated --update --latest\` inline (Issue
+  #2697)` — fails against the old workflow, passes after the inline step is
+  removed.
+- `quality.yml does not auto-commit \`deno fmt and lint fixes\` containing fresh
+  dep versions (Issue #2697)` — guards against re-introducing the bug by
+  combining any future lockfile-writing Deno step with the existing push-back
+  step.
+- `deno-outdated.yml still owns the scheduled dep-update channel (Issue #2697)`
+  — pins the dedicated weekly workflow so the reviewable channel cannot silently
+  disappear.
 
 Existing tests that continued to pass after the change:
 
-- `test/scripts/DenoOutdatedWorkflow.ts` — verifies the scheduled
-  workflow still runs `deno outdated --update --latest` and raises a PR.
+- `test/scripts/DenoOutdatedWorkflow.ts` — verifies the scheduled workflow still
+  runs `deno outdated --update --latest` and raises a PR.
 - `test/ci/QualityWorkflowScriptInjection.ts` — Issue #2709 guards on
   `quality.yml` still pass after the edit.
 - `test/scripts/WorkflowLeastPrivilegePermissions.ts` — `quality.yml`'s

--- a/src/utils/Version.ts
+++ b/src/utils/Version.ts
@@ -39,7 +39,7 @@ import { getLogger } from "@utils/Logger.ts";
  *
  * Must equal `deno.json` `version`. The version-sync test enforces this.
  */
-export const FALLBACK_NEAT_AI_VERSION = "5.0.26";
+export const FALLBACK_NEAT_AI_VERSION = "5.0.27";
 
 /**
  * Returns the running `@stsoftware/neat-ai` version.

--- a/test/ci/QualityWorkflowDepBumpQuarantine.ts
+++ b/test/ci/QualityWorkflowDepBumpQuarantine.ts
@@ -1,0 +1,87 @@
+/**
+ * Issue #2697 — `.github/workflows/quality.yml` must not auto-update
+ * external Deno dependencies on every pull request. The previous
+ * inline `deno outdated --update --latest` step pulled whatever
+ * version was newest at PR run-time and then auto-committed/pushed the
+ * resulting lockfile changes back to the PR branch via
+ * `secrets.ACTIONS_PUSH`. A malicious JSR/npm release published shortly
+ * before a PR run would be merged in automatically, bypassing
+ * contributor review and the quarantine window described in the
+ * repo-wide secure-coding guideline (`VIBE_BUMP_QUARANTINE_HOURS`,
+ * default 24h).
+ *
+ * The dedicated weekly workflow `.github/workflows/deno-outdated.yml`
+ * already runs `deno outdated --update --latest` on a scheduled cadence
+ * and raises a separate reviewable PR. That dedicated workflow is the
+ * correct single source of truth for opportunistic dep bumps.
+ *
+ * These tests pin the fix: quality.yml must not contain the inline
+ * `deno outdated --update --latest` step, and the dedicated weekly
+ * workflow must still exist.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const QUALITY_WORKFLOW = join(REPO_ROOT, ".github/workflows/quality.yml");
+const DENO_OUTDATED_WORKFLOW = join(
+  REPO_ROOT,
+  ".github/workflows/deno-outdated.yml",
+);
+
+Deno.test(
+  "quality.yml does not run `deno outdated --update --latest` inline (Issue #2697)",
+  async () => {
+    const body = await Deno.readTextFile(QUALITY_WORKFLOW);
+    assert(
+      !/deno\s+outdated\s+--update\s+--latest/.test(body),
+      "quality.yml must not run `deno outdated --update --latest` inline — " +
+        "dep bumps must flow through the scheduled deno-outdated.yml workflow " +
+        "so external versions are reviewed and respect the bump quarantine.",
+    );
+  },
+);
+
+Deno.test(
+  "quality.yml does not auto-commit `deno fmt and lint fixes` containing fresh dep versions (Issue #2697)",
+  async () => {
+    const body = await Deno.readTextFile(QUALITY_WORKFLOW);
+    // The auto-commit/push step was only dangerous because it captured
+    // the lockfile changes from the inline `deno outdated --update
+    // --latest` step. Once the inline update step is removed, the only
+    // diff that can reach the commit step is fmt/lint output — that's
+    // fine. But if anyone re-adds an "update" verb anywhere in this
+    // workflow that also writes to the lockfile (`deno.lock`,
+    // `deno.json`), the commit-and-push pipeline becomes a silent dep
+    // bump channel again. Guard against that combination.
+    const writesLock = /deno\s+(outdated|add|install|cache)\s+[^\n]*--/.test(
+      body,
+    ) &&
+      /(deno\.lock|deno\.json)/.test(body);
+    const pushesBack = /git push origin/.test(body);
+    assert(
+      !(writesLock && pushesBack),
+      "quality.yml combines a Deno step that writes to the lockfile with a " +
+        "push-back step — this re-introduces the unreviewed dep-bump channel " +
+        "that Issue #2697 closed.",
+    );
+  },
+);
+
+Deno.test(
+  "deno-outdated.yml still owns the scheduled dep-update channel (Issue #2697)",
+  async () => {
+    const body = await Deno.readTextFile(DENO_OUTDATED_WORKFLOW);
+    assert(
+      /deno\s+outdated\s+--update\s+--latest/.test(body),
+      "deno-outdated.yml must keep running `deno outdated --update --latest` — " +
+        "it is the reviewable single source of truth for dep bumps.",
+    );
+    assert(
+      /peter-evans\/create-pull-request@/.test(body),
+      "deno-outdated.yml must continue to raise a reviewable PR via " +
+        "peter-evans/create-pull-request.",
+    );
+  },
+);


### PR DESCRIPTION
# security: drop inline `deno outdated --update --latest` from quality.yml

## Summary

Removed the inline `Update Deno` step from `.github/workflows/quality.yml`
that ran `deno outdated --update --latest` on every pull request and then
auto-committed/pushed the resulting lockfile changes back to the PR branch
using `secrets.ACTIONS_PUSH`.

The step pulled whatever version was newest at PR run-time, with no
quarantine window for newly-published external (non-`stSoftwareAU/*`)
dependencies. A malicious JSR or npm release going live shortly before a
PR run would be merged into the PR branch automatically under the bot's
signature, bypassing contributor review.

Dep bumps now flow exclusively through the existing scheduled workflow
`.github/workflows/deno-outdated.yml`, which already runs
`deno outdated --update --latest` weekly and raises a separate
reviewable PR via `peter-evans/create-pull-request`. The auto-commit /
push pipeline in `quality.yml` is preserved for genuine fmt/lint fixes —
without the inline update step, the only diff that can reach the commit
step is fmt/lint output, which is safe.

Closes #2697.

## Evidence

This is a CI workflow change with no UI surface. The fix is verified by
new behavioural tests in `test/ci/QualityWorkflowDepBumpQuarantine.ts`
that read the workflow files and assert on their content.

### Before / after

```mermaid
flowchart LR
    subgraph Before["Before #2697"]
        PR1[PR opened] --> Q1[quality.yml]
        Q1 -->|deno outdated --update --latest| Lock1[lockfile rewritten]
        Lock1 -->|auto-commit + push| PR1
        Cron1[weekly cron] --> DO1[deno-outdated.yml] --> PR2[reviewable PR]
    end
    subgraph After["After #2697"]
        PR3[PR opened] --> Q2[quality.yml — fmt/lint only]
        Cron2[weekly cron] --> DO2[deno-outdated.yml] --> PR4[reviewable PR]
    end
```

Before: two channels for dep bumps — the inline PR-time channel pulled
fresh external versions with no quarantine and committed them under the
bot. After: a single reviewable channel via the scheduled workflow.

### Test results

```
ok | 115 passed | 0 failed (5s)
```

(All `test/ci/` and `test/scripts/` tests, including the three new
ones for this issue.)

## Test Plan

Added `test/ci/QualityWorkflowDepBumpQuarantine.ts`:

- `quality.yml does not run \`deno outdated --update --latest\` inline (Issue #2697)` —
  fails against the old workflow, passes after the inline step is removed.
- `quality.yml does not auto-commit \`deno fmt and lint fixes\` containing fresh dep versions (Issue #2697)` —
  guards against re-introducing the bug by combining any future
  lockfile-writing Deno step with the existing push-back step.
- `deno-outdated.yml still owns the scheduled dep-update channel (Issue #2697)` —
  pins the dedicated weekly workflow so the reviewable channel cannot
  silently disappear.

Existing tests that continued to pass after the change:

- `test/scripts/DenoOutdatedWorkflow.ts` — verifies the scheduled
  workflow still runs `deno outdated --update --latest` and raises a PR.
- `test/ci/QualityWorkflowScriptInjection.ts` — Issue #2709 guards on
  `quality.yml` still pass after the edit.
- `test/scripts/WorkflowLeastPrivilegePermissions.ts` — `quality.yml`'s
  `permissions:` block is unchanged.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2697 -->