### PR TITLE
Remove FALLBACK_NEAT_AI_VERSION footgun — single source of truth for version (Issue #2720)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.27",
+  "version": "5.0.28",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/VERSION_VISIBILITY.md
+++ b/docs/VERSION_VISIBILITY.md
@@ -21,7 +21,8 @@ Every worker now emits a single line at startup so the running version is
 unambiguous from the first log line of any run:
 
 ```
-[neat-ai] running version 5.0.14
+[neat-ai] running version 5.0.14            # published JSR build
+[neat-ai] running version 5.0.27 (local)    # local file:// dev/test load
 ```
 
 ## Convention
@@ -32,8 +33,10 @@ unambiguous from the first log line of any run:
   ([`src/utils/Logger.ts`](../src/utils/Logger.ts)) at `info` severity. Hosts
   that inject a custom logger via `NeatOptions.logger` or `setLogger()` see the
   line through their own sink.
-- The format is fixed: `[neat-ai] running version X.Y.Z`. Tools that grep log
-  streams for fleet-wide version audits depend on the prefix.
+- The prefix is fixed: `[neat-ai] running version X.Y.Z`. Tools that grep log
+  streams for fleet-wide version audits depend on the prefix. A trailing
+  `(local)` suffix marks dev/test runs so they are not counted as JSR
+  deployments.
 
 ## Implementation
 
@@ -41,16 +44,14 @@ unambiguous from the first log line of any run:
   - `getNeatAiVersion()` returns the running version. When the module is loaded
     from JSR (`https://jsr.io/@stsoftware/neat-ai/<X.Y.Z>/...`) the version is
     parsed from `import.meta.url` — no filesystem I/O. For local `file://` loads
-    during development, the function returns the `FALLBACK_NEAT_AI_VERSION`
-    constant.
+    during development the version is read once from `deno.json` at module load
+    (Issue #2720); `deno.json` is the single source of truth.
   - `logNeatAiVersionOnce()` is the idempotent emit. A module-level boolean
-    guards subsequent calls.
+    guards subsequent calls. The local load path appends a `(local)` suffix so
+    dev/test log lines are distinguishable from JSR builds.
 - The `Creature` constructor ([`src/Creature.ts`](../src/Creature.ts)) calls
   `logNeatAiVersionOnce()` as its first statement, so any worker that constructs
   a Creature (i.e. every production worker) gets the log for free.
-- The fallback constant is kept in sync with `deno.json` `version` by
-  [`test/creature/VersionStartupLog.ts`](../test/creature/VersionStartupLog.ts).
-  A drift fails `quality.sh`.
 
 ```mermaid
 flowchart LR
@@ -72,9 +73,10 @@ entry points stay quiet.
 
 ## Fleet rollout
 
-When the version constant is bumped (typically by `bump-deps.sh` or the
-`update-package-version.yml` workflow), the sync test enforces that the fallback
-constant in `src/utils/Version.ts` matches the new `deno.json` `version`. Update
-both in the same commit. Downstream consumers (GRQ and sibling repos) need to
-refresh their `@stsoftware/neat-ai` pin to the new JSR version so they pick up
-the fix; verify the line in their logs after the restart.
+When `deno.json` `version` is bumped (typically by `bump-deps.sh` or the
+`update-package-version.yml` workflow), no extra change is needed in
+`src/utils/Version.ts` — `deno.json` is the single source of truth on the local
+load path, and JSR consumers derive the version from `import.meta.url` after
+publish. Downstream consumers (GRQ and sibling repos) need to refresh their
+`@stsoftware/neat-ai` pin to the new JSR version so they pick up the fix; verify
+the line in their logs after the restart.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -158,6 +158,7 @@
     "flamegraph",
     "Flogel",
     "Floreano",
+    "footgun",
     "footguns",
     "frob",
     "Frobenius",

--- a/docs/pr-summary-2720.md
+++ b/docs/pr-summary-2720.md
@@ -1,0 +1,72 @@
+## Summary
+
+Removed the `FALLBACK_NEAT_AI_VERSION` constant from `src/utils/Version.ts`. The
+constant duplicated `deno.json` `version` and required a dedicated sync test in
+`test/creature/VersionStartupLog.ts` to police drift — a classic
+two-sources-of-truth footgun. Per KISS, the `file://` (local dev/test) load path
+now reads `deno.json` once at module load and treats it as the single source of
+truth. JSR consumers still derive the version from `import.meta.url` and see no
+behaviour change. The local-dev startup log line now carries a `(local)` suffix
+so it cannot be confused with the JSR-derived line. Closes #2720.
+
+## Evidence
+
+This is a backend-only change with no UI; the evidence is the test suite for
+`src/utils/Version.ts`, which exercises the real `getNeatAiVersion()` and
+`logNeatAiVersionOnce()` functions and asserts on their outputs.
+
+```
+$ deno test --allow-all test/creature/VersionStartupLog.ts
+running 5 tests from ./test/creature/VersionStartupLog.ts
+Version: getNeatAiVersion returns a valid semver string ... ok (0ms)
+Version: local load path resolves the version from deno.json ... ok (0ms)
+Version: logNeatAiVersionOnce emits exactly once per process ... ok (0ms)
+Version: local file:// startup log carries the (local) suffix ... ok (0ms)
+Version: first Creature construction logs version, subsequent do not ... ok (3ms)
+
+ok | 5 passed | 0 failed (13ms)
+```
+
+Other quality output observed during the full test run confirms the new log
+format on the local path (e.g. `[neat-ai] running version 5.0.27 (local)`
+emitted by worker tests).
+
+### Version-resolution flow
+
+```mermaid
+flowchart LR
+  Mod["src/utils/Version.ts loads"] --> Check{"import.meta.url<br/>matches JSR pattern?"}
+  Check -- "yes (https://jsr.io/...)" --> Parse["parse version from URL<br/>(no file I/O)"]
+  Check -- "no (file://)" --> Read["read deno.json once<br/>(single source of truth)"]
+  Parse --> Cache[("VERSION_INFO cached<br/>at module load")]
+  Read --> Cache
+  Cache --> Get["getNeatAiVersion()"]
+  Cache --> Log["logNeatAiVersionOnce()<br/>appends ' (local)' on file:// path"]
+```
+
+## Test Plan
+
+Modified `test/creature/VersionStartupLog.ts`:
+
+- **Removed** the sync test
+  `Version: FALLBACK_NEAT_AI_VERSION matches deno.json version` — the constant
+  it policed no longer exists, so there is nothing to sync.
+- **Replaced** with
+  `Version: local load path resolves the version from deno.json`, which asserts
+  that `getNeatAiVersion()` on the local (`file://`) load path agrees with
+  `deno.json` `version`. This locks in the single-source-of-truth contract
+  end-to-end (read path + parse + cache).
+- **Added** `Version: local file:// startup log carries the (local) suffix` to
+  lock in the new log-line format on the local path.
+- **Updated** the existing
+  `Version: first Creature construction logs version, subsequent do not` test to
+  assert the new `[neat-ai] running version X.Y.Z (local)` format when running
+  from a `file://` load.
+- The remaining tests (`Version: getNeatAiVersion returns a valid semver string`
+  and `Version: logNeatAiVersionOnce emits exactly once per process`) are
+  unchanged in intent.
+
+The 4 unrelated failures observed during the full `quality.sh` run
+(`DiscoveryTimeout` dynamic-library leaks; `evolveRL_heapStability_test`
+heap-growth threshold) reproduce on `Develop` before this change and are out of
+scope for this issue.

--- a/src/utils/Version.ts
+++ b/src/utils/Version.ts
@@ -8,7 +8,14 @@
  * stack trace. Every NEAT-AI worker now emits a single line at startup so
  * the running version is always visible:
  *
- *     [neat-ai] running version X.Y.Z
+ *     [neat-ai] running version X.Y.Z          (JSR consumers)
+ *     [neat-ai] running version X.Y.Z (local)  (local file:// dev/test load)
+ *
+ * Issue #2720: the previous `FALLBACK_NEAT_AI_VERSION` constant duplicated
+ * `deno.json` `version` and required a sync test to police drift. Per KISS,
+ * the `file://` (local dev/test) load path now reads `deno.json` once at
+ * module load and treats it as the single source of truth. JSR consumers
+ * still derive the version from `import.meta.url` — no file I/O.
  *
  * ## Convention
  *
@@ -17,47 +24,69 @@
  * does this automatically — sub-workers that build creatures get the log
  * for free. The function is idempotent (a module-level flag), so the line
  * fires at most once per worker process even across many constructions.
- *
- * ## Version derivation
- *
- * The version comes from {@link import.meta.url}: when this module is
- * loaded from JSR the URL embeds the version (e.g.
- * `https://jsr.io/@stsoftware/neat-ai/5.0.14/src/utils/Version.ts`). For
- * local `file://` loads during development the {@link FALLBACK_NEAT_AI_VERSION}
- * constant is used. No runtime file I/O.
- *
- * The fallback constant is kept in sync with `deno.json`'s `version` by the
- * test in `test/creature/VersionStartupLog.ts` — a mismatch fails the
- * quality gate.
  */
 
 import { getLogger } from "@utils/Logger.ts";
 
 /**
- * Fallback version string used when `import.meta.url` is not a JSR URL
- * (e.g. local `file://` loads during development and tests).
- *
- * Must equal `deno.json` `version`. The version-sync test enforces this.
+ * Source of the resolved version string. `"jsr"` means the version was
+ * parsed from `import.meta.url`; `"local"` means it was read from
+ * `deno.json` (i.e. the module was loaded over a `file://` URL during
+ * development or tests).
  */
-export const FALLBACK_NEAT_AI_VERSION = "5.0.27";
+type VersionSource = "jsr" | "local";
+
+interface VersionInfo {
+  readonly version: string;
+  readonly source: VersionSource;
+}
+
+/**
+ * Reads `deno.json` (relative to this module) and returns its `version`.
+ * Only invoked on the local `file://` load path — JSR consumers never
+ * reach this code path.
+ */
+function readLocalVersionFromDenoJson(): string {
+  // src/utils/Version.ts → ../../deno.json
+  const denoJsonUrl = new URL("../../deno.json", import.meta.url);
+  const parsed = JSON.parse(Deno.readTextFileSync(denoJsonUrl));
+  if (typeof parsed.version !== "string") {
+    throw new Error(
+      "deno.json must define a string `version` for the local load path",
+    );
+  }
+  return parsed.version;
+}
+
+function resolveVersionInfo(): VersionInfo {
+  const match = import.meta.url.match(
+    /@stsoftware\/neat-ai\/(\d+\.\d+\.\d+)/,
+  );
+  if (match) return { version: match[1], source: "jsr" };
+  return { version: readLocalVersionFromDenoJson(), source: "local" };
+}
+
+// Module-level read: happens at most once per worker process and only on
+// the local load path. JSR consumers skip the file I/O entirely.
+const VERSION_INFO: VersionInfo = resolveVersionInfo();
 
 /**
  * Returns the running `@stsoftware/neat-ai` version.
  *
  * Derived from `import.meta.url` when this module is loaded from JSR
- * (the URL embeds the version), or {@link FALLBACK_NEAT_AI_VERSION}
- * otherwise. No filesystem I/O is performed.
+ * (the URL embeds the version), or from `deno.json` `version` when loaded
+ * locally over `file://`. The result is cached at module load.
  */
 export function getNeatAiVersion(): string {
-  const url = import.meta.url;
-  const match = url.match(/@stsoftware\/neat-ai\/(\d+\.\d+\.\d+)/);
-  return match ? match[1] : FALLBACK_NEAT_AI_VERSION;
+  return VERSION_INFO.version;
 }
 
 let versionLogged = false;
 
 /**
  * Emits a single `[neat-ai] running version X.Y.Z` line per worker process.
+ * Local file:// loads append a ` (local)` suffix so a dev/test log line
+ * cannot be confused with a published JSR build.
  *
  * Idempotent: subsequent calls are no-ops. The first call (typically from
  * the `Creature` constructor) triggers the log via the configured
@@ -67,11 +96,13 @@ let versionLogged = false;
  *          first call), so callers can also surface it elsewhere if needed.
  */
 export function logNeatAiVersionOnce(): string {
-  const version = getNeatAiVersion();
-  if (versionLogged) return version;
+  if (versionLogged) return VERSION_INFO.version;
   versionLogged = true;
-  getLogger().info(`[neat-ai] running version ${version}`);
-  return version;
+  const suffix = VERSION_INFO.source === "local" ? " (local)" : "";
+  getLogger().info(
+    `[neat-ai] running version ${VERSION_INFO.version}${suffix}`,
+  );
+  return VERSION_INFO.version;
 }
 
 /**

--- a/test/creature/VersionStartupLog.ts
+++ b/test/creature/VersionStartupLog.ts
@@ -5,22 +5,22 @@
  *
  * The first Creature constructed in a process must emit exactly one
  *
- *     [neat-ai] running version X.Y.Z
+ *     [neat-ai] running version X.Y.Z[ (local)]
  *
  * line via the configured NEAT-AI Logger. Subsequent constructions in the
  * same process must NOT re-log.
  *
- * The test also asserts the fallback constant in `src/utils/Version.ts`
- * matches `deno.json` `version` — the constant is only used when this
- * module is loaded over a non-JSR URL (e.g. local file://), but having it
- * drift from `deno.json` would mean the dev log lies about the version.
+ * Issue #2720: the previous `FALLBACK_NEAT_AI_VERSION` constant duplicated
+ * `deno.json` `version` and required a sync test to police drift. The
+ * `file://` (local dev/test) load path now reads `deno.json` once instead,
+ * giving a single source of truth — and the log line carries a `(local)`
+ * suffix so it cannot be confused with the JSR-derived line.
  */
 
 import { assert, assertEquals, assertMatch } from "@std/assert";
 import { Creature } from "@creature";
 import { getLogger, type Logger, setLogger } from "@utils/Logger.ts";
 import {
-  FALLBACK_NEAT_AI_VERSION,
   getNeatAiVersion,
   logNeatAiVersionOnce,
   resetNeatAiVersionLogForTest,
@@ -61,8 +61,11 @@ Deno.test("Version: getNeatAiVersion returns a valid semver string", () => {
 });
 
 Deno.test(
-  "Version: FALLBACK_NEAT_AI_VERSION matches deno.json version",
+  "Version: local load path resolves the version from deno.json",
   async () => {
+    // The test suite always runs from a local file:// load, so
+    // getNeatAiVersion() must agree with deno.json `version` — that is the
+    // single source of truth on the local path (Issue #2720).
     const denoJson = JSON.parse(await Deno.readTextFile("deno.json"));
     assertEquals(
       typeof denoJson.version,
@@ -70,10 +73,10 @@ Deno.test(
       "deno.json must define a string `version`",
     );
     assertEquals(
-      FALLBACK_NEAT_AI_VERSION,
+      getNeatAiVersion(),
       denoJson.version,
-      "FALLBACK_NEAT_AI_VERSION in src/utils/Version.ts must equal " +
-        "deno.json `version`. Update the constant after bumping deno.json.",
+      "getNeatAiVersion() on the local file:// load path must read " +
+        "`version` from deno.json (the single source of truth).",
     );
   },
 );
@@ -96,14 +99,38 @@ Deno.test("Version: logNeatAiVersionOnce emits exactly once per process", () => 
         JSON.stringify(logs),
     );
     assertEquals(versionLines[0].level, "info");
+    // Local file:// load path appends the " (local)" suffix; JSR loads do not.
     assertMatch(
       versionLines[0].message,
-      /^\[neat-ai\] running version \d+\.\d+\.\d+$/,
+      /^\[neat-ai\] running version \d+\.\d+\.\d+( \(local\))?$/,
     );
   } finally {
     restore();
   }
 });
+
+Deno.test(
+  "Version: local file:// startup log carries the (local) suffix",
+  () => {
+    resetNeatAiVersionLogForTest();
+    const { logs, restore } = captureLogs();
+    try {
+      logNeatAiVersionOnce();
+      const versionLines = logs.filter((l) =>
+        l.message.startsWith("[neat-ai] running version ")
+      );
+      assertEquals(versionLines.length, 1);
+      // The test harness always loads modules via file://, so the log line
+      // produced here must include the " (local)" disambiguator.
+      assertEquals(
+        versionLines[0].message,
+        `[neat-ai] running version ${getNeatAiVersion()} (local)`,
+      );
+    } finally {
+      restore();
+    }
+  },
+);
 
 Deno.test(
   "Version: first Creature construction logs version, subsequent do not",
@@ -131,13 +158,14 @@ Deno.test(
       );
       assertMatch(
         versionLines[0].message,
-        /^\[neat-ai\] running version \d+\.\d+\.\d+$/,
+        /^\[neat-ai\] running version \d+\.\d+\.\d+( \(local\))?$/,
         `unexpected log format: ${versionLines[0].message}`,
       );
-      // The logged version must match what getNeatAiVersion() returns.
+      // The logged version must match what getNeatAiVersion() returns. The
+      // test harness loads modules via file://, so the suffix is present.
       assertEquals(
         versionLines[0].message,
-        `[neat-ai] running version ${getNeatAiVersion()}`,
+        `[neat-ai] running version ${getNeatAiVersion()} (local)`,
       );
     } finally {
       restore();


### PR DESCRIPTION
## Summary

Removed the `FALLBACK_NEAT_AI_VERSION` constant from `src/utils/Version.ts`. The
constant duplicated `deno.json` `version` and required a dedicated sync test in
`test/creature/VersionStartupLog.ts` to police drift — a classic
two-sources-of-truth footgun. Per KISS, the `file://` (local dev/test) load path
now reads `deno.json` once at module load and treats it as the single source of
truth. JSR consumers still derive the version from `import.meta.url` and see no
behaviour change. The local-dev startup log line now carries a `(local)` suffix
so it cannot be confused with the JSR-derived line. Closes #2720.

## Evidence

This is a backend-only change with no UI; the evidence is the test suite for
`src/utils/Version.ts`, which exercises the real `getNeatAiVersion()` and
`logNeatAiVersionOnce()` functions and asserts on their outputs.

```
$ deno test --allow-all test/creature/VersionStartupLog.ts
running 5 tests from ./test/creature/VersionStartupLog.ts
Version: getNeatAiVersion returns a valid semver string ... ok (0ms)
Version: local load path resolves the version from deno.json ... ok (0ms)
Version: logNeatAiVersionOnce emits exactly once per process ... ok (0ms)
Version: local file:// startup log carries the (local) suffix ... ok (0ms)
Version: first Creature construction logs version, subsequent do not ... ok (3ms)

ok | 5 passed | 0 failed (13ms)
```

Other quality output observed during the full test run confirms the new log
format on the local path (e.g. `[neat-ai] running version 5.0.27 (local)`
emitted by worker tests).

### Version-resolution flow

```mermaid
flowchart LR
  Mod["src/utils/Version.ts loads"] --> Check{"import.meta.url<br/>matches JSR pattern?"}
  Check -- "yes (https://jsr.io/...)" --> Parse["parse version from URL<br/>(no file I/O)"]
  Check -- "no (file://)" --> Read["read deno.json once<br/>(single source of truth)"]
  Parse --> Cache[("VERSION_INFO cached<br/>at module load")]
  Read --> Cache
  Cache --> Get["getNeatAiVersion()"]
  Cache --> Log["logNeatAiVersionOnce()<br/>appends ' (local)' on file:// path"]
```

## Test Plan

Modified `test/creature/VersionStartupLog.ts`:

- **Removed** the sync test
  `Version: FALLBACK_NEAT_AI_VERSION matches deno.json version` — the constant
  it policed no longer exists, so there is nothing to sync.
- **Replaced** with
  `Version: local load path resolves the version from deno.json`, which asserts
  that `getNeatAiVersion()` on the local (`file://`) load path agrees with
  `deno.json` `version`. This locks in the single-source-of-truth contract
  end-to-end (read path + parse + cache).
- **Added** `Version: local file:// startup log carries the (local) suffix` to
  lock in the new log-line format on the local path.
- **Updated** the existing
  `Version: first Creature construction logs version, subsequent do not` test to
  assert the new `[neat-ai] running version X.Y.Z (local)` format when running
  from a `file://` load.
- The remaining tests (`Version: getNeatAiVersion returns a valid semver string`
  and `Version: logNeatAiVersionOnce emits exactly once per process`) are
  unchanged in intent.

The 4 unrelated failures observed during the full `quality.sh` run
(`DiscoveryTimeout` dynamic-library leaks; `evolveRL_heapStability_test`
heap-growth threshold) reproduce on `Develop` before this change and are out of
scope for this issue.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2720 -->