### PR TITLE
Surface heap-pressure discovery skips as structured discovery_complete outcome (#2737)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.31",
+  "version": "5.0.32",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2737.md
+++ b/docs/archive/pr-summaries/pr-summary-2737.md
@@ -2,44 +2,43 @@
 
 ## Summary
 
-`DataRecorder.recordFiles()` already aborts the analysis phase when the V8
-heap is at MemoryMonitor CRITICAL pressure at the analysis-extension boundary
-(PR #2594), and #2642 reduced peak analysis heap. The remaining gap reported
-in #2737 is **observability**: the abort emits a single `warn` log line, but
-the upstream `discovery_complete` training event still reports `"no_change"`,
-so callers can't distinguish a memory-pressure skip from a clean "found
-nothing" pass — and they keep concluding Discovery "doesn't add hidden
-neurons" when in fact the library prevented the analysis from running.
+`DataRecorder.recordFiles()` already aborts the analysis phase when the V8 heap
+is at MemoryMonitor CRITICAL pressure at the analysis-extension boundary (PR
+#2594), and #2642 reduced peak analysis heap. The remaining gap reported in
+#2737 is **observability**: the abort emits a single `warn` log line, but the
+upstream `discovery_complete` training event still reports `"no_change"`, so
+callers can't distinguish a memory-pressure skip from a clean "found nothing"
+pass — and they keep concluding Discovery "doesn't add hidden neurons" when in
+fact the library prevented the analysis from running.
 
 This PR surfaces the skip as a structured, machine-readable signal end-to-end:
 
-- `DiscoverResult` carries a new optional `heapAbortedAtExtensionBoundary`
-  flag. `DataRecorder.recordFiles()` sets it on the empty result it returns
-  when the heap guard trips.
+- `DiscoverResult` carries a new optional `heapAbortedAtExtensionBoundary` flag.
+  `DataRecorder.recordFiles()` sets it on the empty result it returns when the
+  heap guard trips.
 - `buildDiscoverResponsePayload` in the worker copies the flag across the
-  worker/parent thread boundary so the parent thread sees the same signal as
-  the worker thread. `ResponseData.discover` adds the same field.
-- `DiscoveryCompleteEvent.outcome` now includes a `"heap_critical_skip"`
-  member alongside `"improved" | "no_change" | "timeout"`.
+  worker/parent thread boundary so the parent thread sees the same signal as the
+  worker thread. `ResponseData.discover` adds the same field.
+- `DiscoveryCompleteEvent.outcome` now includes a `"heap_critical_skip"` member
+  alongside `"improved" | "no_change" | "timeout"`.
 - A small pure helper `chooseDiscoveryCompleteOutcome` in
   `src/NEAT/DiscoveryOutcome.ts` centralises the precedence rule: heap-abort
-  wins over `"improved"` and `"no_change"` so a stale
-  `improvedCreature` reference can't mask a memory-pressure skip.
-- `processCompletedResults` calls the helper instead of inlining the
-  outcome ternary.
+  wins over `"improved"` and `"no_change"` so a stale `improvedCreature`
+  reference can't mask a memory-pressure skip.
+- `processCompletedResults` calls the helper instead of inlining the outcome
+  ternary.
 
-Callers wiring `onTrainingEvent` can now `switch` on the outcome and surface
-the skip as a milestone in their UI / dashboards / showcase narrative,
-addressing the second of the three options listed in the issue's "Expected"
-section.
+Callers wiring `onTrainingEvent` can now `switch` on the outcome and surface the
+skip as a milestone in their UI / dashboards / showcase narrative, addressing
+the second of the three options listed in the issue's "Expected" section.
 
 Closes #2737.
 
 ## Evidence
 
 This is a backend/library change with no UI surface. Behaviour is verified by
-deterministic unit tests on the pure outcome helper, the worker-payload
-mapper, and the existing heap-guard tests (unchanged and still passing).
+deterministic unit tests on the pure outcome helper, the worker-payload mapper,
+and the existing heap-guard tests (unchanged and still passing).
 
 ```mermaid
 sequenceDiagram
@@ -76,8 +75,8 @@ ok | 33 passed | 0 failed (1s)
 Of the three options the issue offers — **budget**, **surface**, or **adapt** —
 this PR delivers **surface**. Budgeting and adaptive scope reduction require
 deeper changes to the recording-phase batch sizing and to NEAT-AI-Discovery's
-FFI cache lifecycle, and would not fit the "minimal scope" rule for one
-issue. With the structured outcome in place, callers (and a follow-up
+FFI cache lifecycle, and would not fit the "minimal scope" rule for one issue.
+With the structured outcome in place, callers (and a follow-up
 adaptive-recording PR) can now measure how often the skip fires and gate
 adaptive logic on that signal.
 
@@ -90,9 +89,10 @@ adaptive logic on that signal.
 - `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts:371`
 - `src/intelligentDesign/ImproveSquash.ts:43`
 
-Verified by stashing this PR's changes and re-running `./quality.sh
---check-only` — the same three errors fire on `origin/Develop`. Per the
-project's "Change Scope" rule these are left for a separate fix; the new
+Verified by stashing this PR's changes and re-running
+`./quality.sh
+--check-only` — the same three errors fire on `origin/Develop`.
+Per the project's "Change Scope" rule these are left for a separate fix; the new
 code in this PR type-checks cleanly in isolation
 (`deno check src/NEAT/DiscoveryOutcome.ts` passes).
 
@@ -104,17 +104,19 @@ code in this PR type-checks cleanly in isolation
   - `chooseDiscoveryCompleteOutcome: heap abort wins over no improvement →
     heap_critical_skip`.
   - `chooseDiscoveryCompleteOutcome: heap abort wins over improvedCreature
-    → heap_critical_skip` (defends precedence even if both signals appear).
+    → heap_critical_skip`
+    (defends precedence even if both signals appear).
   - `chooseDiscoveryCompleteOutcome: heapAbortedAtExtensionBoundary=false
     preserves the regular precedence`.
 - Extended `test/multithreading/WorkerProcessor.ts`:
   - `buildDiscoverResponsePayload: propagates heapAbortedAtExtensionBoundary
-    =true` — confirms the flag survives the worker→parent wire copy.
+    =true`
+    — confirms the flag survives the worker→parent wire copy.
   - `buildDiscoverResponsePayload: leaves heapAbortedAtExtensionBoundary
     undefined for happy-path results`.
   - `buildDiscoverResponsePayload: propagates heapAbortedAtExtensionBoundary
     =false`.
 - Existing `test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts` and
   `test/NEAT/TrainingEventEmitter.ts` continue to pass — the guard's abort
-  signal and the discovery_complete event delivery path are unchanged apart
-  from the new outcome member.
+  signal and the discovery_complete event delivery path are unchanged apart from
+  the new outcome member.

--- a/docs/archive/pr-summaries/pr-summary-2737.md
+++ b/docs/archive/pr-summaries/pr-summary-2737.md
@@ -1,0 +1,120 @@
+# Surface heap-pressure discovery skips as a structured training event
+
+## Summary
+
+`DataRecorder.recordFiles()` already aborts the analysis phase when the V8
+heap is at MemoryMonitor CRITICAL pressure at the analysis-extension boundary
+(PR #2594), and #2642 reduced peak analysis heap. The remaining gap reported
+in #2737 is **observability**: the abort emits a single `warn` log line, but
+the upstream `discovery_complete` training event still reports `"no_change"`,
+so callers can't distinguish a memory-pressure skip from a clean "found
+nothing" pass — and they keep concluding Discovery "doesn't add hidden
+neurons" when in fact the library prevented the analysis from running.
+
+This PR surfaces the skip as a structured, machine-readable signal end-to-end:
+
+- `DiscoverResult` carries a new optional `heapAbortedAtExtensionBoundary`
+  flag. `DataRecorder.recordFiles()` sets it on the empty result it returns
+  when the heap guard trips.
+- `buildDiscoverResponsePayload` in the worker copies the flag across the
+  worker/parent thread boundary so the parent thread sees the same signal as
+  the worker thread. `ResponseData.discover` adds the same field.
+- `DiscoveryCompleteEvent.outcome` now includes a `"heap_critical_skip"`
+  member alongside `"improved" | "no_change" | "timeout"`.
+- A small pure helper `chooseDiscoveryCompleteOutcome` in
+  `src/NEAT/DiscoveryOutcome.ts` centralises the precedence rule: heap-abort
+  wins over `"improved"` and `"no_change"` so a stale
+  `improvedCreature` reference can't mask a memory-pressure skip.
+- `processCompletedResults` calls the helper instead of inlining the
+  outcome ternary.
+
+Callers wiring `onTrainingEvent` can now `switch` on the outcome and surface
+the skip as a milestone in their UI / dashboards / showcase narrative,
+addressing the second of the three options listed in the issue's "Expected"
+section.
+
+Closes #2737.
+
+## Evidence
+
+This is a backend/library change with no UI surface. Behaviour is verified by
+deterministic unit tests on the pure outcome helper, the worker-payload
+mapper, and the existing heap-guard tests (unchanged and still passing).
+
+```mermaid
+sequenceDiagram
+    participant DR as DataRecorder.recordFiles
+    participant Guard as checkAnalysisHeapAbort
+    participant WP as buildDiscoverResponsePayload
+    participant PCR as processCompletedResults
+    participant Cb as onTrainingEvent
+
+    DR->>Guard: sample heap at extension boundary
+    Guard-->>DR: { abort: true } (heap CRITICAL)
+    Note over DR: set heapAbortedAtExtensionBoundary = true<br/>on the empty DiscoverResult
+    DR-->>WP: DiscoverResult
+    WP-->>PCR: ResponseData.discover (flag propagated)
+    PCR->>PCR: chooseDiscoveryCompleteOutcome(...)
+    Note over PCR: heapAbortedAtExtensionBoundary === true<br/>=> outcome = "heap_critical_skip"
+    PCR-->>Cb: { kind: "discovery_complete",<br/>outcome: "heap_critical_skip", ... }
+```
+
+Targeted test run:
+
+```
+$ deno test --no-check --allow-all \
+    test/multithreading/WorkerProcessor.ts \
+    test/NEAT/DiscoveryOutcome.ts \
+    test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts \
+    test/NEAT/TrainingEventEmitter.ts \
+    test/ErrorGuidedStructuralEvolution/AnalysisCacheRelease.ts
+ok | 33 passed | 0 failed (1s)
+```
+
+### Why scope stops here
+
+Of the three options the issue offers — **budget**, **surface**, or **adapt** —
+this PR delivers **surface**. Budgeting and adaptive scope reduction require
+deeper changes to the recording-phase batch sizing and to NEAT-AI-Discovery's
+FFI cache lifecycle, and would not fit the "minimal scope" rule for one
+issue. With the structured outcome in place, callers (and a follow-up
+adaptive-recording PR) can now measure how often the skip fires and gate
+adaptive logic on that signal.
+
+### Pre-existing quality.sh failures
+
+`./quality.sh` currently fails the type-check step on three pre-existing
+`setTimeout` typing errors that are unrelated to this PR:
+
+- `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts:576`
+- `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts:371`
+- `src/intelligentDesign/ImproveSquash.ts:43`
+
+Verified by stashing this PR's changes and re-running `./quality.sh
+--check-only` — the same three errors fire on `origin/Develop`. Per the
+project's "Change Scope" rule these are left for a separate fix; the new
+code in this PR type-checks cleanly in isolation
+(`deno check src/NEAT/DiscoveryOutcome.ts` passes).
+
+## Test Plan
+
+- Added `test/NEAT/DiscoveryOutcome.ts`:
+  - `chooseDiscoveryCompleteOutcome: no inputs → no_change`.
+  - `chooseDiscoveryCompleteOutcome: improvedCreature present → improved`.
+  - `chooseDiscoveryCompleteOutcome: heap abort wins over no improvement →
+    heap_critical_skip`.
+  - `chooseDiscoveryCompleteOutcome: heap abort wins over improvedCreature
+    → heap_critical_skip` (defends precedence even if both signals appear).
+  - `chooseDiscoveryCompleteOutcome: heapAbortedAtExtensionBoundary=false
+    preserves the regular precedence`.
+- Extended `test/multithreading/WorkerProcessor.ts`:
+  - `buildDiscoverResponsePayload: propagates heapAbortedAtExtensionBoundary
+    =true` — confirms the flag survives the worker→parent wire copy.
+  - `buildDiscoverResponsePayload: leaves heapAbortedAtExtensionBoundary
+    undefined for happy-path results`.
+  - `buildDiscoverResponsePayload: propagates heapAbortedAtExtensionBoundary
+    =false`.
+- Existing `test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts` and
+  `test/NEAT/TrainingEventEmitter.ts` continue to pass — the guard's abort
+  signal and the discovery_complete event delivery path are unchanged apart
+  from the new outcome member.

--- a/src/NEAT/DiscoveryOutcome.ts
+++ b/src/NEAT/DiscoveryOutcome.ts
@@ -1,0 +1,62 @@
+/**
+ * DiscoveryOutcome.ts — pure decision helper for the `discovery_complete`
+ * training event's `outcome` field.
+ *
+ * Issue #2737: Centralises the rule that picks `"heap_critical_skip"` over
+ * `"no_change"` when `DataRecorder.recordFiles()` aborted at the
+ * analysis-extension boundary because the V8 heap was at MemoryMonitor
+ * CRITICAL pressure. Extracted out of `ProcessCompletedResults.ts` so the
+ * mapping can be unit-tested without standing up a full `Neat` instance.
+ */
+
+import type { DiscoveryCompleteEvent } from "@config/TrainingEvent.ts";
+
+/**
+ * Minimal projection of a `DiscoverResult` needed to choose an outcome.
+ *
+ * Defined as an interface (not a re-export of `DiscoverResult`) so callers
+ * can pass any shape that carries the two relevant fields — including the
+ * wire-cloned payload produced by `buildDiscoverResponsePayload` in the
+ * worker thread.
+ */
+export interface DiscoveryOutcomeInputs {
+  /**
+   * `true` when discovery skipped the analysis phase because the V8 heap
+   * was at MemoryMonitor CRITICAL pressure at the analysis-extension
+   * boundary (Issue #2737).
+   */
+  readonly heapAbortedAtExtensionBoundary?: boolean;
+  /**
+   * Truthy when discovery built an improved creature ready to add to the
+   * population.
+   */
+  readonly improvedCreature?: unknown;
+}
+
+/**
+ * Choose the `discovery_complete` outcome label for a finished discovery
+ * result.
+ *
+ * The order of precedence is deliberate:
+ *
+ * 1. `"heap_critical_skip"` — memory pressure pre-empted analysis. This
+ *    must win over `"no_change"` so callers can tell a memory-pressure
+ *    skip apart from a clean "found nothing" run (Issue #2737).
+ * 2. `"improved"` — discovery built an improved creature.
+ * 3. `"no_change"` — discovery ran to completion but found no improvement.
+ *
+ * Note: `"timeout"` is part of the `DiscoveryCompleteEvent.outcome` union
+ * but is not selectable from these inputs; the upstream worker reports
+ * timeouts via a separate path. We narrow the return type to the labels
+ * this helper can actually emit so callers get an exhaustive switch hint.
+ */
+export function chooseDiscoveryCompleteOutcome(
+  inputs: DiscoveryOutcomeInputs,
+): Extract<
+  DiscoveryCompleteEvent["outcome"],
+  "improved" | "no_change" | "heap_critical_skip"
+> {
+  if (inputs.heapAbortedAtExtensionBoundary) return "heap_critical_skip";
+  if (inputs.improvedCreature) return "improved";
+  return "no_change";
+}

--- a/src/NEAT/ProcessCompletedResults.ts
+++ b/src/NEAT/ProcessCompletedResults.ts
@@ -14,6 +14,7 @@ import { addTag, getTag, removeTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { validateAfterDiscoveryOrThrow } from "@discovery/DiscoveryPostValidate.ts";
+import { chooseDiscoveryCompleteOutcome } from "@neat/DiscoveryOutcome.ts";
 import type { Genus } from "@neat/Genus.ts";
 import type { Approach } from "@neat/LogApproach.ts";
 import type { Neat } from "@neat/Neat.ts";
@@ -130,12 +131,17 @@ export function processCompletedResults(
     const r = neat.discoveryComplete[i];
     assert(r.discover, "No discovery found");
 
-    // Issue #1615: Emit discovery_complete event
-    const outcome = r.discover.improvedCreature ? "improved" : "no_change";
+    // Issue #1615: Emit discovery_complete event.
+    // Issue #2737: Outcome selection is delegated to
+    // `chooseDiscoveryCompleteOutcome` so the memory-pressure skip path
+    // (`"heap_critical_skip"`) is picked over the silent
+    // `"no_change"` fallback when `DataRecorder.recordFiles()` aborted at
+    // the analysis-extension boundary.
+    const outcome = chooseDiscoveryCompleteOutcome(r.discover);
     emitTrainingEvent(neat.config.onTrainingEvent, {
       kind: "discovery_complete",
       timestamp: new Date().toISOString(),
-      outcome: outcome as "improved" | "no_change" | "timeout",
+      outcome,
       candidateCount: (r.discover.addHelpfulSynapses?.length ?? 0) +
         (r.discover.removeHarmfulSynapse ? 1 : 0) +
         (r.discover.candidateSquashes?.length ?? 0),

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
@@ -343,6 +343,11 @@ class DataRecorder {
         getLogger(),
       );
       if (heapAbort.abort) {
+        // Issue #2737: Surface the heap-driven abort as a structured field on
+        // the DiscoverResult so the upstream training event pipeline can emit
+        // a `"heap_critical_skip"` outcome instead of indistinguishably
+        // reporting `"no_change"`. The candidate arrays are still `undefined`
+        // because the analysis loop never ran.
         return {
           ID: this.ID,
           addHelpfulSynapses: undefined,
@@ -352,6 +357,7 @@ class DataRecorder {
           removeHarmfulNeurons: undefined,
           removalCandidates: undefined,
           candidateSquashes: undefined,
+          heapAbortedAtExtensionBoundary: true,
         };
       }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
@@ -63,4 +63,19 @@ export interface DiscoverResult {
 
   candidateSquashes: CandidateSquash[] | undefined;
   reScoringTime?: number; // Time spent re-scoring candidates (ms)
+
+  /**
+   * Issue #2737: Set to `true` when `DataRecorder.recordFiles()` aborted at the
+   * analysis-extension boundary because the V8 heap was at MemoryMonitor
+   * CRITICAL pressure. When `true`, every candidate field above is `undefined`
+   * — the analysis loop never ran — but the empty result still carries this
+   * structured signal so the upstream training event pipeline can surface a
+   * `"heap_critical_skip"` outcome instead of silently reporting
+   * `"no_change"`.
+   *
+   * Consumers should treat `heapAbortedAtExtensionBoundary === true` as
+   * evidence that structural search was prevented by memory pressure, not as
+   * evidence that no structural improvement exists.
+   */
+  heapAbortedAtExtensionBoundary?: boolean;
 }

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -353,8 +353,24 @@ export interface DiscoveryCompleteEvent {
   readonly kind: "discovery_complete";
   /** ISO-8601 timestamp when the event was emitted. */
   readonly timestamp: string;
-  /** Outcome of the discovery: whether it improved the creature or not. */
-  readonly outcome: "improved" | "no_change" | "timeout";
+  /**
+   * Outcome of the discovery operation.
+   *
+   * - `"improved"` — discovery found and applied an improvement.
+   * - `"no_change"` — discovery ran to completion but found no improvement.
+   * - `"timeout"` — discovery exceeded its wall-clock budget.
+   * - `"heap_critical_skip"` (Issue #2737) — the analysis phase was skipped
+   *   because the V8 heap was at MemoryMonitor CRITICAL pressure at the
+   *   analysis-extension boundary. The recording phase completed but no
+   *   structural search was performed; callers should treat this as a
+   *   surfaced warning that memory pressure prevented analysis, not as
+   *   evidence that no structural improvement exists.
+   */
+  readonly outcome:
+    | "improved"
+    | "no_change"
+    | "timeout"
+    | "heap_critical_skip";
   /** Number of discovery candidates that were evaluated. */
   readonly candidateCount: number;
   /** Time elapsed for the discovery operation in milliseconds. */

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -249,6 +249,16 @@ export interface ResponseData {
      * the current fittest (which may have evolved during the discovery process).
      */
     improvedCreature?: CreatureExport;
+    /**
+     * Issue #2737: Set to `true` when the worker's discovery run aborted at
+     * the analysis-extension boundary because the V8 heap was at
+     * MemoryMonitor CRITICAL pressure. The candidate fields above are
+     * `undefined` in this case. The parent thread translates this signal
+     * into a `"heap_critical_skip"` `discovery_complete` outcome so callers
+     * can distinguish a memory-pressure skip from a genuine `"no_change"`
+     * result.
+     */
+    heapAbortedAtExtensionBoundary?: boolean;
   };
   /**
    * Issue #1567: Response after applying cache configuration.

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -62,6 +62,10 @@ export function buildDiscoverResponsePayload(
     candidateSquashes: result.candidateSquashes
       ? [...result.candidateSquashes]
       : undefined,
+    // Issue #2737: Propagate the structured heap-abort signal across the
+    // worker boundary so the parent thread can surface it via the
+    // `discovery_complete` event.
+    heapAbortedAtExtensionBoundary: result.heapAbortedAtExtensionBoundary,
   };
 }
 

--- a/test/NEAT/DiscoveryOutcome.ts
+++ b/test/NEAT/DiscoveryOutcome.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for `chooseDiscoveryCompleteOutcome` (Issue #2737).
+ *
+ * The mapping picks the `discovery_complete` event's `outcome` label from a
+ * minimal projection of `DiscoverResult`. The critical guarantee is that a
+ * heap-driven analysis-extension abort surfaces as `"heap_critical_skip"`,
+ * not the catch-all `"no_change"` — otherwise callers cannot tell a
+ * memory-pressure skip apart from a clean "found nothing" run.
+ */
+import { assertEquals } from "@std/assert";
+import { chooseDiscoveryCompleteOutcome } from "@neat/DiscoveryOutcome.ts";
+
+Deno.test("chooseDiscoveryCompleteOutcome: no inputs → no_change", () => {
+  assertEquals(chooseDiscoveryCompleteOutcome({}), "no_change");
+});
+
+Deno.test(
+  "chooseDiscoveryCompleteOutcome: improvedCreature present → improved",
+  () => {
+    assertEquals(
+      chooseDiscoveryCompleteOutcome({ improvedCreature: { foo: "bar" } }),
+      "improved",
+    );
+  },
+);
+
+Deno.test(
+  "chooseDiscoveryCompleteOutcome: heap abort wins over no improvement → heap_critical_skip",
+  () => {
+    assertEquals(
+      chooseDiscoveryCompleteOutcome({
+        heapAbortedAtExtensionBoundary: true,
+      }),
+      "heap_critical_skip",
+    );
+  },
+);
+
+Deno.test(
+  "chooseDiscoveryCompleteOutcome: heap abort wins over improvedCreature → heap_critical_skip",
+  () => {
+    // In practice DataRecorder will not set both fields, but the helper
+    // must defend the precedence so a stale `improvedCreature` from a
+    // previous run cannot mask a memory-pressure skip.
+    assertEquals(
+      chooseDiscoveryCompleteOutcome({
+        heapAbortedAtExtensionBoundary: true,
+        improvedCreature: { foo: "bar" },
+      }),
+      "heap_critical_skip",
+    );
+  },
+);
+
+Deno.test(
+  "chooseDiscoveryCompleteOutcome: heapAbortedAtExtensionBoundary=false preserves the regular precedence",
+  () => {
+    assertEquals(
+      chooseDiscoveryCompleteOutcome({
+        heapAbortedAtExtensionBoundary: false,
+        improvedCreature: { foo: "bar" },
+      }),
+      "improved",
+    );
+    assertEquals(
+      chooseDiscoveryCompleteOutcome({
+        heapAbortedAtExtensionBoundary: false,
+      }),
+      "no_change",
+    );
+  },
+);

--- a/test/multithreading/WorkerProcessor.ts
+++ b/test/multithreading/WorkerProcessor.ts
@@ -94,3 +94,38 @@ Deno.test("clearDiscoverResultForGC: skips undefined arrays safely", () => {
   clearDiscoverResultForGC(result);
   assertEquals(result.ID, "test-discovery-123");
 });
+
+// ============================================================================
+// Issue #2737: heapAbortedAtExtensionBoundary signalling
+// ============================================================================
+
+Deno.test(
+  "buildDiscoverResponsePayload: propagates heapAbortedAtExtensionBoundary=true",
+  () => {
+    const result = makeMinimalDiscoverResult();
+    result.heapAbortedAtExtensionBoundary = true;
+
+    const payload = buildDiscoverResponsePayload(result);
+    assertEquals(payload.heapAbortedAtExtensionBoundary, true);
+  },
+);
+
+Deno.test(
+  "buildDiscoverResponsePayload: leaves heapAbortedAtExtensionBoundary undefined for happy-path results",
+  () => {
+    const result = makeMinimalDiscoverResult();
+    const payload = buildDiscoverResponsePayload(result);
+    assertEquals(payload.heapAbortedAtExtensionBoundary, undefined);
+  },
+);
+
+Deno.test(
+  "buildDiscoverResponsePayload: propagates heapAbortedAtExtensionBoundary=false",
+  () => {
+    const result = makeMinimalDiscoverResult();
+    result.heapAbortedAtExtensionBoundary = false;
+
+    const payload = buildDiscoverResponsePayload(result);
+    assertEquals(payload.heapAbortedAtExtensionBoundary, false);
+  },
+);


### PR DESCRIPTION
# Surface heap-pressure discovery skips as a structured training event

## Summary

`DataRecorder.recordFiles()` already aborts the analysis phase when the V8
heap is at MemoryMonitor CRITICAL pressure at the analysis-extension boundary
(PR #2594), and #2642 reduced peak analysis heap. The remaining gap reported
in #2737 is **observability**: the abort emits a single `warn` log line, but
the upstream `discovery_complete` training event still reports `"no_change"`,
so callers can't distinguish a memory-pressure skip from a clean "found
nothing" pass — and they keep concluding Discovery "doesn't add hidden
neurons" when in fact the library prevented the analysis from running.

This PR surfaces the skip as a structured, machine-readable signal end-to-end:

- `DiscoverResult` carries a new optional `heapAbortedAtExtensionBoundary`
  flag. `DataRecorder.recordFiles()` sets it on the empty result it returns
  when the heap guard trips.
- `buildDiscoverResponsePayload` in the worker copies the flag across the
  worker/parent thread boundary so the parent thread sees the same signal as
  the worker thread. `ResponseData.discover` adds the same field.
- `DiscoveryCompleteEvent.outcome` now includes a `"heap_critical_skip"`
  member alongside `"improved" | "no_change" | "timeout"`.
- A small pure helper `chooseDiscoveryCompleteOutcome` in
  `src/NEAT/DiscoveryOutcome.ts` centralises the precedence rule: heap-abort
  wins over `"improved"` and `"no_change"` so a stale
  `improvedCreature` reference can't mask a memory-pressure skip.
- `processCompletedResults` calls the helper instead of inlining the
  outcome ternary.

Callers wiring `onTrainingEvent` can now `switch` on the outcome and surface
the skip as a milestone in their UI / dashboards / showcase narrative,
addressing the second of the three options listed in the issue's "Expected"
section.

Closes #2737.

## Evidence

This is a backend/library change with no UI surface. Behaviour is verified by
deterministic unit tests on the pure outcome helper, the worker-payload
mapper, and the existing heap-guard tests (unchanged and still passing).

```mermaid
sequenceDiagram
    participant DR as DataRecorder.recordFiles
    participant Guard as checkAnalysisHeapAbort
    participant WP as buildDiscoverResponsePayload
    participant PCR as processCompletedResults
    participant Cb as onTrainingEvent

    DR->>Guard: sample heap at extension boundary
    Guard-->>DR: { abort: true } (heap CRITICAL)
    Note over DR: set heapAbortedAtExtensionBoundary = true<br/>on the empty DiscoverResult
    DR-->>WP: DiscoverResult
    WP-->>PCR: ResponseData.discover (flag propagated)
    PCR->>PCR: chooseDiscoveryCompleteOutcome(...)
    Note over PCR: heapAbortedAtExtensionBoundary === true<br/>=> outcome = "heap_critical_skip"
    PCR-->>Cb: { kind: "discovery_complete",<br/>outcome: "heap_critical_skip", ... }
```

Targeted test run:

```
$ deno test --no-check --allow-all \
    test/multithreading/WorkerProcessor.ts \
    test/NEAT/DiscoveryOutcome.ts \
    test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts \
    test/NEAT/TrainingEventEmitter.ts \
    test/ErrorGuidedStructuralEvolution/AnalysisCacheRelease.ts
ok | 33 passed | 0 failed (1s)
```

### Why scope stops here

Of the three options the issue offers — **budget**, **surface**, or **adapt** —
this PR delivers **surface**. Budgeting and adaptive scope reduction require
deeper changes to the recording-phase batch sizing and to NEAT-AI-Discovery's
FFI cache lifecycle, and would not fit the "minimal scope" rule for one
issue. With the structured outcome in place, callers (and a follow-up
adaptive-recording PR) can now measure how often the skip fires and gate
adaptive logic on that signal.

### Pre-existing quality.sh failures

`./quality.sh` currently fails the type-check step on three pre-existing
`setTimeout` typing errors that are unrelated to this PR:

- `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts:576`
- `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts:371`
- `src/intelligentDesign/ImproveSquash.ts:43`

Verified by stashing this PR's changes and re-running `./quality.sh
--check-only` — the same three errors fire on `origin/Develop`. Per the
project's "Change Scope" rule these are left for a separate fix; the new
code in this PR type-checks cleanly in isolation
(`deno check src/NEAT/DiscoveryOutcome.ts` passes).

## Test Plan

- Added `test/NEAT/DiscoveryOutcome.ts`:
  - `chooseDiscoveryCompleteOutcome: no inputs → no_change`.
  - `chooseDiscoveryCompleteOutcome: improvedCreature present → improved`.
  - `chooseDiscoveryCompleteOutcome: heap abort wins over no improvement →
    heap_critical_skip`.
  - `chooseDiscoveryCompleteOutcome: heap abort wins over improvedCreature
    → heap_critical_skip` (defends precedence even if both signals appear).
  - `chooseDiscoveryCompleteOutcome: heapAbortedAtExtensionBoundary=false
    preserves the regular precedence`.
- Extended `test/multithreading/WorkerProcessor.ts`:
  - `buildDiscoverResponsePayload: propagates heapAbortedAtExtensionBoundary
    =true` — confirms the flag survives the worker→parent wire copy.
  - `buildDiscoverResponsePayload: leaves heapAbortedAtExtensionBoundary
    undefined for happy-path results`.
  - `buildDiscoverResponsePayload: propagates heapAbortedAtExtensionBoundary
    =false`.
- Existing `test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts` and
  `test/NEAT/TrainingEventEmitter.ts` continue to pass — the guard's abort
  signal and the discovery_complete event delivery path are unchanged apart
  from the new outcome member.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2737 -->