### PR TITLE
Add CATEGORICAL_ERROR cost for one-hot multi-class targets (#2736)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Issue #2736:** New `"CATEGORICAL_ERROR"` built-in cost function for
+  multi-class one-hot targets. It reports the argmax misclassification rate
+  (`error = 1 - accuracy`) so `evolveDir` `error`/`score`, champion selection
+  and the `targetError` early-stop reflect real classification quality instead
+  of the trivial MSE floor (~`0.1` for ten balanced classes) that a chance-level
+  classifier can reach. Distance-based costs such as `"MSE"` can decouple from
+  argmax accuracy on one-hot layouts; documented in
+  [`docs/API_REFERENCE.md`](./docs/API_REFERENCE.md). The cost is
+  non-differentiable and intended for scoring/early-stop — gradients are derived
+  independently of `costName`, so training is unaffected.
+
 ### Security
 
 - **Issue #2704:** `CreatureSerialization.fromJSON` (the default JSON-load path)

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.29",
+  "version": "5.0.30",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -429,14 +429,34 @@ import type { CostInterface } from "@stsoftware/neat-ai";
 
 ### 📋 Built-in Cost Functions
 
-| Name              | Class                          | Best For                     | Formula                                 |
-| ----------------- | ------------------------------ | ---------------------------- | --------------------------------------- |
-| `"MSE"`           | Mean Squared Error             | General regression (default) | `(1/n) * Sum((y - y')^2)`               |
-| `"MAE"`           | Mean Absolute Error            | Regression with outliers     | `(1/n) * Sum(\|y - y'\|)`               |
-| `"MAPE"`          | Mean Absolute Percentage Error | Forecasting, relative error  | `(1/n) * Sum(\|(y' - y) / y\|)`         |
-| `"MSLE"`          | Mean Squared Logarithmic Error | Wide value ranges            | `(1/n) * Sum((log(y) - log(y'))^2)`     |
-| `"CROSS_ENTROPY"` | Cross Entropy                  | Classification               | `-Sum(y * log(y') + (1-y) * log(1-y'))` |
-| `"HINGE"`         | Hinge Loss                     | SVM / binary classification  | `max(0, 1 - y * y')`                    |
+| Name                  | Class                          | Best For                     | Formula                                        |
+| --------------------- | ------------------------------ | ---------------------------- | ---------------------------------------------- |
+| `"MSE"`               | Mean Squared Error             | General regression (default) | `(1/n) * Sum((y - y')^2)`                      |
+| `"MAE"`               | Mean Absolute Error            | Regression with outliers     | `(1/n) * Sum(\|y - y'\|)`                      |
+| `"MAPE"`              | Mean Absolute Percentage Error | Forecasting, relative error  | `(1/n) * Sum(\|(y' - y) / y\|)`                |
+| `"MSLE"`              | Mean Squared Logarithmic Error | Wide value ranges            | `(1/n) * Sum((log(y) - log(y'))^2)`            |
+| `"CROSS_ENTROPY"`     | Cross Entropy                  | Classification               | `-Sum(y * log(y') + (1-y) * log(1-y'))`        |
+| `"HINGE"`             | Hinge Loss                     | SVM / binary classification  | `max(0, 1 - y * y')`                           |
+| `"CATEGORICAL_ERROR"` | Categorical (argmax) error     | Multi-class one-hot targets  | `(1/n) * Sum(argmax(y) != argmax(y') ? 1 : 0)` |
+
+> [!IMPORTANT]
+> **Regression costs can decouple from classification accuracy on one-hot
+> targets.** For multi-class problems encoded as one-hot targets, `"MSE"` (and
+> the other distance-based costs) measure squared output distance, **not**
+> argmax accuracy. A constant classifier that emits one output near `1` and the
+> rest near `0` reaches a trivial MSE floor (~`0.1` for ten balanced classes),
+> so `evolveDir` can report a low `error`/high `score` and even satisfy
+> `targetError` while real argmax accuracy is stuck at chance. Because
+> `score = 1 - error - penalties`, the reported score then overstates task
+> quality.
+>
+> Use `"CATEGORICAL_ERROR"` when argmax accuracy is the real objective. It
+> reports the **misclassification rate** (`error = 1 - accuracy`), so the
+> scorer, champion selection and `targetError` early-stop all reflect the
+> classification task. It is **non-differentiable** and intended for
+> scoring/early-stop — NEAT-AI derives backpropagation gradients independently
+> of `costName`, so training still proceeds normally. It needs at least two
+> outputs; with a single output the argmax is always index `0`.
 
 ### 📐 CostInterface
 

--- a/docs/archive/pr-summaries/pr-summary-2736.md
+++ b/docs/archive/pr-summaries/pr-summary-2736.md
@@ -1,0 +1,73 @@
+# Add `CATEGORICAL_ERROR` cost for one-hot multi-class targets
+
+## Summary
+
+For multi-class problems encoded as **one-hot targets**, `evolveDir` could
+report a low `error` / high `score` (and even satisfy `targetError`) while real
+argmax classification accuracy stayed at chance. The cause is metric semantics,
+not training: distance-based costs such as `"MSE"` measure squared output
+distance, not argmax accuracy. A constant classifier that emits one output near
+`1` and the rest near `0` reaches a trivial MSE floor (~`0.1` for ten balanced
+classes) without learning any class structure. Because
+`score = 1 - error - penalties`, that decoupling lets the reported score
+overstate task quality.
+
+This PR adds a new built-in cost, **`"CATEGORICAL_ERROR"`**, that reports the
+**misclassification rate** (`error = 1 - accuracy`) by comparing
+`argmax(target)` with `argmax(output)` per record. Selecting it makes the
+scorer, champion selection and the `targetError` early-stop reflect the user's
+actual classification task. The cost is **non-differentiable** and intended for
+scoring/early-stop — NEAT-AI derives backpropagation gradients independently of
+`costName`, so training proceeds normally. The behaviour and the MSE-decoupling
+caveat are documented in `docs/API_REFERENCE.md`.
+
+This satisfies the issue's expected outcomes: it both **documents** the
+MSE/argmax decoupling and **offers an optional classification-aware metric** so
+champion selection / `targetError` can reflect the real task.
+
+Closes #2736
+
+## Evidence
+
+Backend/library change with no web interface to screenshot. Verified with unit
+tests that call the real cost function and the `Costs` registry.
+
+```mermaid
+flowchart LR
+    T[One-hot target] --> A[argmax target]
+    O[Creature output] --> B[argmax output]
+    A --> C{equal?}
+    B --> C
+    C -- yes --> Z[0 correct]
+    C -- no --> N[1 incorrect]
+    Z --> M[mean over dataset = 1 - accuracy]
+    N --> M
+    M --> S["score = 1 - error - penalties<br/>now reflects argmax accuracy"]
+```
+
+Key behaviours verified by tests:
+
+- A constant ten-class classifier yields `error = 0.9` (chance accuracy 10%),
+  versus the misleading ~`0.1` MSE floor.
+- A perfect classifier yields `error = 0`.
+- Correct/incorrect single-record predictions return `0` / `1`.
+- Ties resolve to the first index; empty arrays return `0`; a single output is
+  always counted correct (documented limitation).
+- `Costs.find("CATEGORICAL_ERROR")` resolves and the name appears in
+  `Costs.getAvailableCosts()` and `BUILT_IN_COST_NAMES`.
+
+## Test Plan
+
+- Added `test/costs/CategoricalError.ts` (9 tests) covering happy path, error
+  path, registry integration, the one-hot MSE-floor scenario, and edge cases
+  (ties, empty, single output).
+- Updated `test/costs/CostName.ts` so `BUILT_IN_COST_NAMES` stays in sync with
+  the new built-in cost.
+- All `test/costs/*.ts` tests pass (63 passed, 0 failed).
+- `./quality.sh --lint-only` passes; changed files type-check cleanly with
+  `deno check`.
+
+> Note: `./quality.sh --check-only` reports 3 pre-existing `TS2322`
+> `Timeout`/`number` errors in `DataRecorderAnalysis.ts`,
+> `DataRecorderRecording.ts` and `ImproveSquash.ts`. These exist on the base
+> branch (confirmed via `git stash`) and are unrelated to this change.

--- a/src/Costs.ts
+++ b/src/Costs.ts
@@ -5,6 +5,7 @@
 
 import type { CostInterface } from "@costs/CostInterface.ts";
 import { ValidationError } from "@errors/ValidationError.ts";
+import { CategoricalError } from "@costs/CategoricalError.ts";
 import { CrossEntropy } from "@costs/CrossEntropy.ts";
 import { HINGE } from "@costs/HINGE.ts";
 import { MAE } from "@costs/MAE.ts";
@@ -26,6 +27,7 @@ export const BUILT_IN_COST_NAMES = [
   MAPE.NAME,
   MSLE.NAME,
   HINGE.NAME,
+  CategoricalError.NAME,
 ] as const;
 
 /** Union of built-in cost name string literals. */
@@ -68,6 +70,7 @@ export class Costs {
     this.registerFromInstance(new MAPE());
     this.registerFromInstance(new MSLE());
     this.registerFromInstance(new HINGE());
+    this.registerFromInstance(new CategoricalError());
   }
 
   /**

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
@@ -571,7 +571,7 @@ export async function runAnalysisLoop(
         let analysisResults: AnalysisTuple | undefined;
         let timedOut = false;
         if (budgetMs > 0) {
-          let timeoutHandle: number | undefined;
+          let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
           const timeoutPromise = new Promise<RaceResult>((resolve) => {
             timeoutHandle = setTimeout(
               () => resolve({ kind: "timeout" }),

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts
@@ -365,7 +365,7 @@ export async function runRecordingPhase(
   const WRITE_TIMEOUT_MS = 60000;
   const promiseWaitStartTime = Date.now();
 
-  let timeoutId: number | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(() => {

--- a/src/costs/CategoricalError.ts
+++ b/src/costs/CategoricalError.ts
@@ -1,0 +1,103 @@
+import type { CostInterface } from "@costs/CostInterface.ts";
+
+/**
+ * Categorical (argmax) error cost function for multi-class one-hot targets.
+ *
+ * Standard regression-style costs such as {@link module:src/costs/MSE} measure
+ * the average squared distance between each output and its target. For
+ * **one-hot encoded multi-class** problems this can be badly misleading: a
+ * constant or near-constant classifier that always emits one output near `1`
+ * and the rest near `0` reaches a trivial MSE floor (~`0.1` for ten balanced
+ * classes) **without learning any class structure**. The recorded `error`
+ * looks good while real argmax classification accuracy is stuck at chance.
+ *
+ * `CategoricalError` closes that gap by measuring the metric users actually
+ * care about: the **misclassification rate**. For each record it compares the
+ * index of the largest target value (the true class) with the index of the
+ * largest output value (the predicted class) and contributes `0` for a correct
+ * prediction or `1` for an incorrect one. Averaged across a dataset by the
+ * scorer, the resulting `error` equals `1 - accuracy`, so:
+ *
+ * - `error = 0.0` → 100% argmax accuracy.
+ * - `error = 0.9` → 10% accuracy (chance for ten classes).
+ *
+ * Because `score = 1 - error - penalties`, a chance-level classifier now
+ * reports a low score (~`0.1`) instead of a misleadingly high one (~`0.9`),
+ * and a `targetError` stop condition reflects the user's real task.
+ *
+ * **Characteristics:**
+ * - Reports the true misclassification rate for one-hot multi-class targets.
+ * - Range is `[0, 1]`; lower is better, exactly like the MSE-based costs.
+ * - **Non-differentiable** — argmax has no useful gradient. This cost is
+ *   intended for **scoring, champion selection and early-stop** (`targetError`),
+ *   not as a backpropagation loss. Gradient descent in NEAT-AI derives its
+ *   gradients independently of `costName`, so selecting this cost still trains
+ *   normally while reporting a task-aligned error.
+ *
+ * **Use Cases:**
+ * - Multi-class classification with one-hot targets (e.g. MNIST digits).
+ * - Any task where argmax accuracy is the real objective and MSE/score can
+ *   decouple from it.
+ *
+ * **Limitations:**
+ * - Requires at least two outputs to be meaningful. With a single output the
+ *   argmax is always index `0`, so every record is counted "correct" and the
+ *   error is always `0`. Use a probability-threshold metric for binary tasks.
+ * - Ties (multiple equal maxima) resolve to the first index, matching the
+ *   common `argmax` convention.
+ *
+ * @example
+ * ```typescript
+ * const cost = new CategoricalError();
+ * const target = new Float32Array([0, 1, 0]); // true class = 1
+ * const output = new Float32Array([0.2, 0.7, 0.1]); // predicted class = 1
+ * cost.calculate(target, output); // 0 (correct)
+ *
+ * const wrong = new Float32Array([0.6, 0.3, 0.1]); // predicted class = 0
+ * cost.calculate(target, wrong); // 1 (incorrect)
+ * ```
+ */
+export class CategoricalError implements CostInterface {
+  static readonly NAME = "CATEGORICAL_ERROR";
+
+  /**
+   * Returns the name of this cost function.
+   * @returns The string "CATEGORICAL_ERROR"
+   */
+  getName(): string {
+    return CategoricalError.NAME;
+  }
+
+  /**
+   * Returns `0` when the predicted class (argmax of `output`) matches the true
+   * class (argmax of `target`), otherwise `1`.
+   *
+   * @param target - The one-hot encoded true labels.
+   * @param output - The predicted class scores/probabilities.
+   * @returns `0` for a correct argmax prediction, `1` for an incorrect one.
+   */
+  calculate(target: Float32Array, output: Float32Array): number {
+    const len = output.length;
+    if (len === 0) {
+      return 0;
+    }
+
+    let targetArgmax = 0;
+    let targetMax = target[0];
+    let outputArgmax = 0;
+    let outputMax = output[0];
+
+    for (let i = 1; i < len; i++) {
+      if (target[i] > targetMax) {
+        targetMax = target[i];
+        targetArgmax = i;
+      }
+      if (output[i] > outputMax) {
+        outputMax = output[i];
+        outputArgmax = i;
+      }
+    }
+
+    return targetArgmax === outputArgmax ? 0 : 1;
+  }
+}

--- a/src/intelligentDesign/ImproveSquash.ts
+++ b/src/intelligentDesign/ImproveSquash.ts
@@ -38,7 +38,7 @@ async function waitForAllSettledOrTimeout(
   const remainingMs = remainingTimeMs(deadlineMs);
   if (remainingMs === 0) return true;
 
-  let timeoutID: number | undefined;
+  let timeoutID: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<"timeout">((resolve) => {
     timeoutID = setTimeout(() => resolve("timeout"), remainingMs);
   });

--- a/test/costs/CategoricalError.ts
+++ b/test/costs/CategoricalError.ts
@@ -1,0 +1,87 @@
+import { assertEquals } from "@std/assert";
+import { CategoricalError } from "@costs/CategoricalError.ts";
+import { Costs } from "@costs";
+
+Deno.test("CategoricalError - getName returns CATEGORICAL_ERROR", () => {
+  const cost = new CategoricalError();
+  assertEquals(cost.getName(), "CATEGORICAL_ERROR");
+});
+
+Deno.test("CategoricalError - registered as a built-in cost", () => {
+  const cost = Costs.find("CATEGORICAL_ERROR");
+  assertEquals(cost.getName(), "CATEGORICAL_ERROR");
+  assertEquals(Costs.getAvailableCosts().includes("CATEGORICAL_ERROR"), true);
+});
+
+Deno.test("CategoricalError - correct argmax prediction scores 0", () => {
+  const cost = new CategoricalError();
+  const target = new Float32Array([0, 1, 0]); // true class = 1
+  const output = new Float32Array([0.2, 0.7, 0.1]); // predicted class = 1
+  assertEquals(cost.calculate(target, output), 0);
+});
+
+Deno.test("CategoricalError - incorrect argmax prediction scores 1", () => {
+  const cost = new CategoricalError();
+  const target = new Float32Array([0, 1, 0]); // true class = 1
+  const output = new Float32Array([0.6, 0.3, 0.1]); // predicted class = 0
+  assertEquals(cost.calculate(target, output), 1);
+});
+
+Deno.test("CategoricalError - trivial one-hot MSE floor is exposed as full error", () => {
+  // A constant classifier always predicts class 0 regardless of the true
+  // class. MSE would report a low ~0.1 floor; CategoricalError reports the
+  // true misclassification rate. Averaging the per-record 0/1 results over a
+  // balanced ten-class set gives 0.9 (chance accuracy = 10%).
+  const cost = new CategoricalError();
+  const classes = 10;
+  let total = 0;
+  for (let trueClass = 0; trueClass < classes; trueClass++) {
+    const target = new Float32Array(classes);
+    target[trueClass] = 1;
+    // Constant output: always strongest at index 0.
+    const output = new Float32Array(classes).fill(0.05);
+    output[0] = 0.55;
+    total += cost.calculate(target, output);
+  }
+  const averageError = total / classes;
+  assertEquals(averageError, 0.9); // 9 of 10 classes misclassified
+});
+
+Deno.test("CategoricalError - perfect classifier scores 0 across all classes", () => {
+  const cost = new CategoricalError();
+  const classes = 4;
+  let total = 0;
+  for (let trueClass = 0; trueClass < classes; trueClass++) {
+    const target = new Float32Array(classes);
+    target[trueClass] = 1;
+    const output = new Float32Array(classes).fill(0.1);
+    output[trueClass] = 0.9; // predicts the correct class
+    total += cost.calculate(target, output);
+  }
+  assertEquals(total / classes, 0);
+});
+
+Deno.test("CategoricalError - ties resolve to the first index", () => {
+  const cost = new CategoricalError();
+  const target = new Float32Array([1, 0, 0]); // true class = 0
+  // Outputs tie between index 0 and 2; argmax picks the first (index 0).
+  const output = new Float32Array([0.5, 0.0, 0.5]);
+  assertEquals(cost.calculate(target, output), 0);
+});
+
+Deno.test("CategoricalError - empty arrays return 0", () => {
+  const cost = new CategoricalError();
+  assertEquals(
+    cost.calculate(new Float32Array(0), new Float32Array(0)),
+    0,
+  );
+});
+
+Deno.test("CategoricalError - single output is always counted correct", () => {
+  // Documented limitation: with one output the argmax is always index 0.
+  const cost = new CategoricalError();
+  assertEquals(
+    cost.calculate(new Float32Array([1]), new Float32Array([0.0])),
+    0,
+  );
+});

--- a/test/costs/CostName.ts
+++ b/test/costs/CostName.ts
@@ -13,6 +13,7 @@ Deno.test("BUILT_IN_COST_NAMES - should stay in sync with supported costs", () =
     "MAPE",
     "MSLE",
     "HINGE",
+    "CATEGORICAL_ERROR",
   ]);
 });
 


### PR DESCRIPTION
# Add `CATEGORICAL_ERROR` cost for one-hot multi-class targets

## Summary

For multi-class problems encoded as **one-hot targets**, `evolveDir` could
report a low `error` / high `score` (and even satisfy `targetError`) while real
argmax classification accuracy stayed at chance. The cause is metric semantics,
not training: distance-based costs such as `"MSE"` measure squared output
distance, not argmax accuracy. A constant classifier that emits one output near
`1` and the rest near `0` reaches a trivial MSE floor (~`0.1` for ten balanced
classes) without learning any class structure. Because
`score = 1 - error - penalties`, that decoupling lets the reported score
overstate task quality.

This PR adds a new built-in cost, **`"CATEGORICAL_ERROR"`**, that reports the
**misclassification rate** (`error = 1 - accuracy`) by comparing
`argmax(target)` with `argmax(output)` per record. Selecting it makes the
scorer, champion selection and the `targetError` early-stop reflect the user's
actual classification task. The cost is **non-differentiable** and intended for
scoring/early-stop — NEAT-AI derives backpropagation gradients independently of
`costName`, so training proceeds normally. The behaviour and the MSE-decoupling
caveat are documented in `docs/API_REFERENCE.md`.

This satisfies the issue's expected outcomes: it both **documents** the
MSE/argmax decoupling and **offers an optional classification-aware metric** so
champion selection / `targetError` can reflect the real task.

Closes #2736

## Evidence

Backend/library change with no web interface to screenshot. Verified with unit
tests that call the real cost function and the `Costs` registry.

```mermaid
flowchart LR
    T[One-hot target] --> A[argmax target]
    O[Creature output] --> B[argmax output]
    A --> C{equal?}
    B --> C
    C -- yes --> Z[0 correct]
    C -- no --> N[1 incorrect]
    Z --> M[mean over dataset = 1 - accuracy]
    N --> M
    M --> S["score = 1 - error - penalties<br/>now reflects argmax accuracy"]
```

Key behaviours verified by tests:

- A constant ten-class classifier yields `error = 0.9` (chance accuracy 10%),
  versus the misleading ~`0.1` MSE floor.
- A perfect classifier yields `error = 0`.
- Correct/incorrect single-record predictions return `0` / `1`.
- Ties resolve to the first index; empty arrays return `0`; a single output is
  always counted correct (documented limitation).
- `Costs.find("CATEGORICAL_ERROR")` resolves and the name appears in
  `Costs.getAvailableCosts()` and `BUILT_IN_COST_NAMES`.

## Test Plan

- Added `test/costs/CategoricalError.ts` (9 tests) covering happy path, error
  path, registry integration, the one-hot MSE-floor scenario, and edge cases
  (ties, empty, single output).
- Updated `test/costs/CostName.ts` so `BUILT_IN_COST_NAMES` stays in sync with
  the new built-in cost.
- All `test/costs/*.ts` tests pass (63 passed, 0 failed).
- `./quality.sh --lint-only` passes; changed files type-check cleanly with
  `deno check`.

> Note: `./quality.sh --check-only` reports 3 pre-existing `TS2322`
> `Timeout`/`number` errors in `DataRecorderAnalysis.ts`,
> `DataRecorderRecording.ts` and `ImproveSquash.ts`. These exist on the base
> branch (confirmed via `git stash`) and are unrelated to this change.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2736 -->