### PR TITLE
Bound discovery analysis heap with in-loop CRITICAL guard (Issue #2735)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.30",
+  "version": "5.0.31",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2735.md
+++ b/docs/archive/pr-summaries/pr-summary-2735.md
@@ -33,10 +33,10 @@ Closes #2735.
 
 ## Evidence
 
-Backend/CLI change — no web interface to screenshot. Verified by unit tests
-that drive `runAnalysisLoop` with an injected heap sample and assert the loop
-aborts gracefully (no chunk submitted, no neurons analysed) on CRITICAL heap,
-runs normally on low heap, and never aborts when `memory.enabled === false`.
+Backend/CLI change — no web interface to screenshot. Verified by unit tests that
+drive `runAnalysisLoop` with an injected heap sample and assert the loop aborts
+gracefully (no chunk submitted, no neurons analysed) on CRITICAL heap, runs
+normally on low heap, and never aborts when `memory.enabled === false`.
 
 ```mermaid
 flowchart TD
@@ -59,7 +59,8 @@ ok | 33 passed | 0 failed   # all ErrorGuidedStructuralEvolution analysis specs
 
 - Added `test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts`:
   - CRITICAL heap aborts the loop before any chunk runs
-    (`analysisHeapAborted === true`, `chunkCalls === 0`, `neuronsAnalyzed === 0`).
+    (`analysisHeapAborted === true`, `chunkCalls === 0`,
+    `neuronsAnalyzed === 0`).
   - Normal heap runs the loop without aborting.
   - `memory.enabled === false` never aborts even when heap is CRITICAL.
 - Updated existing loop harnesses (`DiscoverAnalysisStallWarmup`,

--- a/docs/archive/pr-summaries/pr-summary-2735.md
+++ b/docs/archive/pr-summaries/pr-summary-2735.md
@@ -1,0 +1,70 @@
+# Bound discovery analysis heap with an in-loop CRITICAL guard
+
+## Summary
+
+`Creature.evolveDir()` fatally ran out of heap when evolving a large layered
+feed-forward seed (e.g. 986 neurons / ~109k synapses) over a large supervised
+`.bin` training directory. The extension-boundary heap guard added in Issue
+#2594 samples the heap **once**, just before analysis is given more time. But
+the analysis itself (`runAnalysisLoop`) then processes many chunks across up to
+ten retry iterations, and the per-chunk squash analysis allocates aggressively
+(Issue #2642). Heap therefore climbs back to `MemoryMonitor` CRITICAL **during**
+the loop, where no further guard existed — and the worker OOMed with
+`Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit`.
+
+This change adds an **in-loop heap-critical guard** that re-samples heap
+pressure at the start of each retry iteration and before each chunk submission.
+On CRITICAL pressure the loop stops submitting work and returns the candidates
+accumulated so far (graceful degradation — option 3 in the issue), recording
+`perfStats.analysisHeapAborted = true` and logging a grep-friendly line:
+
+```
+[Neat] Discovery <id> analysis aborted: heap CRITICAL during analysis loop ...
+```
+
+The guard reuses the existing `isHeapCritical(config.memory)` probe, so it
+honours `memory.enabled` and the shared `criticalThreshold`. The heap probe is
+injectable via the new optional `AnalysisLoopContext.heapCriticalProbe` so
+behaviour-focused loop tests (stall guard, chunking, cache release, per-chunk
+timeout) opt out of the real heap sample — necessary because a small Deno test
+process naturally reports `heapUsed/heapTotal` ≈ 0.9, above the 0.85 threshold.
+
+Closes #2735.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified by unit tests
+that drive `runAnalysisLoop` with an injected heap sample and assert the loop
+aborts gracefully (no chunk submitted, no neurons analysed) on CRITICAL heap,
+runs normally on low heap, and never aborts when `memory.enabled === false`.
+
+```mermaid
+flowchart TD
+    R[Recording phase done] --> B{Heap CRITICAL at\nextension boundary?\n#2594}
+    B -- yes --> S1[Skip analysis, return partial]
+    B -- no --> L[Analysis loop]
+    L --> C{Heap CRITICAL before\niteration / chunk?\n#2735}
+    C -- yes --> S2[Stop, return\naccumulated candidates]
+    C -- no --> P[Process chunk]
+    P --> C
+```
+
+Test run:
+
+```
+ok | 33 passed | 0 failed   # all ErrorGuidedStructuralEvolution analysis specs
+```
+
+## Test Plan
+
+- Added `test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts`:
+  - CRITICAL heap aborts the loop before any chunk runs
+    (`analysisHeapAborted === true`, `chunkCalls === 0`, `neuronsAnalyzed === 0`).
+  - Normal heap runs the loop without aborting.
+  - `memory.enabled === false` never aborts even when heap is CRITICAL.
+- Updated existing loop harnesses (`DiscoverAnalysisStallWarmup`,
+  `DiscoverAnalysisChunking`, `AnalysisCacheRelease`,
+  `DiscoverAnalysisPerChunkTimeout`) to inject `heapCriticalProbe: () => false`,
+  isolating their behaviour-under-test from the test process's high heap ratio.
+  No assertions were changed.
+- Documented both guards in `docs/troubleshooting/MEMORY.md`.

--- a/docs/troubleshooting/MEMORY.md
+++ b/docs/troubleshooting/MEMORY.md
@@ -195,6 +195,45 @@ For discovery workloads, tune these options to control peak memory:
 
 Lower values reduce peak memory at the cost of more I/O.
 
+### Heap guards around discovery analysis
+
+Two `MemoryMonitor`-driven guards keep discovery analysis from fatally OOMing
+when a large layered seed (e.g. 986 neurons / ~109k synapses) is evolved over a
+large supervised `.bin` stream:
+
+1. **Extension-boundary guard** (Issue #2594): before the recording phase
+   extends the timeout to make room for analysis, it samples the heap once. If
+   pressure is already CRITICAL it skips analysis and returns a partial result,
+   logging
+   `[Neat] Discovery <id> analysis aborted: heap CRITICAL at extension boundary`.
+
+2. **In-loop guard** (Issue #2735): analysis itself runs many chunks across up
+   to ten retry iterations, and the per-chunk squash analysis allocates
+   aggressively (Issue #2642). The loop now re-samples the heap at the start of
+   each retry iteration and before each chunk; on CRITICAL pressure it stops
+   submitting work and returns the candidates accumulated so far, logging
+   `[Neat] Discovery <id> analysis aborted: heap CRITICAL during analysis loop`.
+   This degrades gracefully instead of pressing on into
+   `Fatal JavaScript out of memory`.
+
+Both guards honour `memory.enabled` and the shared `criticalThreshold`, so
+raising the V8 heap (Step 5) or lowering `criticalThreshold` (Step 2) changes
+when they fire. A graceful abort means analysis produced no (or partial)
+structural candidates for that cycle — evolution continues; it does not crash.
+
+```mermaid
+flowchart TD
+    classDef ok fill:#1e8449,stroke:#196f3d,color:#fff
+    classDef warn fill:#d68910,stroke:#b7770d,color:#fff
+    R[Recording phase done] --> B{Heap CRITICAL at\nextension boundary?}
+    B -- yes --> S1[Skip analysis,\nreturn partial]:::warn
+    B -- no --> L[Analysis loop]:::ok
+    L --> C{Heap CRITICAL before\niteration / chunk?}
+    C -- yes --> S2[Stop, return\naccumulated candidates]:::warn
+    C -- no --> P[Process chunk]:::ok
+    P --> C
+```
+
 ## See also
 
 - [WASM troubleshooting](WASM.md) for WASM cache sizing context and

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
@@ -19,6 +19,7 @@ import type { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolu
 import type { DiscoveryPerformanceStats } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts";
 import { shouldLogDiscovery } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts";
 import type { PhaseDiagnostics } from "@architecture/ErrorGuidedStructuralEvolution/PhaseDiagnostics.ts";
+import { isHeapCritical } from "@architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts";
 import { getLogger } from "@utils/Logger.ts";
 
 /**
@@ -136,6 +137,15 @@ export interface AnalysisLoopContext {
    * this.
    */
   readonly runParallelAnalysis?: ParallelAnalysisFn;
+  /**
+   * Optional probe for the in-loop heap-critical guard (Issue #2735).
+   * Defaults to sampling the real heap via `isHeapCritical(config.memory)`.
+   * Tests that exercise unrelated loop behaviour (stall guard, chunking)
+   * inject `() => false` so the small test process's naturally high
+   * `heapUsed/heapTotal` ratio does not trip the guard. Production code
+   * should not set this.
+   */
+  readonly heapCriticalProbe?: () => boolean;
 }
 
 /**
@@ -302,8 +312,27 @@ export async function runAnalysisLoop(
   // Retry loop: try different neurons if no candidates found and time remains
   // Sequential execution is intentional - we check results after each attempt
   const analysisPhaseStartTime = now();
+  const heapCritical = ctx.heapCriticalProbe ??
+    (() => isHeapCritical(config.memory));
   let stalledFlag = false;
+  let heapAbortedFlag = false;
   while (retryAttempt <= maxRetries) {
+    // Issue #2735: in-loop heap guard. The extension-boundary guard
+    // (Issue #2594) only samples heap once, before analysis starts. With a
+    // large layered seed the per-chunk squash analysis allocates aggressively
+    // (Issue #2642), so heap can climb back to CRITICAL across retry
+    // iterations and fatally OOM the worker. Sample at the top of each
+    // iteration and abort gracefully with whatever candidates we have rather
+    // than pressing on into OOM.
+    if (heapCritical()) {
+      heapAbortedFlag = true;
+      getLogger().warn(
+        `[Neat] Discovery ${
+          blue(ID)
+        } analysis aborted: heap CRITICAL during analysis loop after ${attemptedNeurons.size} neuron(s) [${formatStallMemoryDiagnostics()}]`,
+      );
+      break;
+    }
     // Allow callers (especially tests) to explicitly skip the analysis phase by
     // setting discoveryMaxNeurons to 0. This keeps record/flush coverage (FFI)
     // while avoiding long-running Rust analysis on GPU-backed machines.
@@ -377,6 +406,7 @@ export async function runAnalysisLoop(
       : 0;
     let chunkIdx = 0;
     let iterationStalled = false;
+    let iterationHeapAborted = false;
     // Track completed chunks and cumulative chunk time for the warm-up
     // gate and rate-of-change check (Issue #2513). A "completed" chunk is
     // one whose Rust FFI call returned (whether fast or slow) — chunks
@@ -386,6 +416,20 @@ export async function runAnalysisLoop(
     let totalChunkElapsedMs = 0;
     for (const chunk of chunks) {
       chunkIdx++;
+      // Issue #2735: in-loop heap guard, per chunk. Each chunk's combined
+      // analysis plus squash analysis allocates aggressively (Issue #2642),
+      // so heap can cross CRITICAL part-way through a multi-chunk iteration.
+      // Stop submitting further chunks and return the partial result instead
+      // of OOMing the worker.
+      if (heapCritical()) {
+        iterationHeapAborted = true;
+        getLogger().warn(
+          `[Neat] Discovery ${
+            blue(ID)
+          } analysis aborted: heap CRITICAL during analysis loop before chunk ${chunkIdx}/${chunks.length} [${formatStallMemoryDiagnostics()}]`,
+        );
+        break;
+      }
       // Defence-in-depth: check cumulative wall-clock before submitting each
       // new chunk (Issue #2420). If earlier chunks have already burned the
       // overall budget, stop — the per-chunk check below would only fire
@@ -784,6 +828,11 @@ export async function runAnalysisLoop(
       );
     }
 
+    if (iterationHeapAborted) {
+      heapAbortedFlag = true;
+      break;
+    }
+
     if (iterationStalled) {
       stalledFlag = true;
       if (shouldLogDiscovery(config)) {
@@ -823,6 +872,9 @@ export async function runAnalysisLoop(
   perfStats.analysisPhaseTime = now() - analysisPhaseStartTime;
   // Surface throughput stall so callers can inspect after the loop returns.
   perfStats.analysisStalled = stalledFlag;
+  // Surface the in-loop heap abort (Issue #2735) so callers can distinguish a
+  // graceful memory-pressure bail-out from normal completion.
+  perfStats.analysisHeapAborted = heapAbortedFlag;
 
   // Collect low-impact removal candidates from Rust focus ranking
   const removalCandidates = discoverStructure.getRemovalCandidates();

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts
@@ -52,6 +52,14 @@ export class DiscoveryPerformanceStats {
    * budget). See Issue #2380.
    */
   analysisStalled = false;
+  /**
+   * Set to true when the analysis loop aborted early because heap pressure
+   * reached the `MemoryMonitor` CRITICAL threshold mid-loop (Issue #2735).
+   * The extension-boundary guard (Issue #2594) only samples heap once; this
+   * flag records that the in-loop guard tripped and returned partial results
+   * rather than pressing on into a fatal OOM.
+   */
+  analysisHeapAborted = false;
 
   // Candidate counts (final arrays returned to the caller).
   // Note (29-Dec-2025): Counts are taken from the result arrays (not per-retry

--- a/test/ErrorGuidedStructuralEvolution/AnalysisCacheRelease.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisCacheRelease.ts
@@ -240,6 +240,9 @@ Deno.test("runAnalysisLoop releases the combined analysis cache after every chun
         perChunkMaxMs: 0,
         getTimeoutTS: () => deadlineMs,
         refreshAnalysisTimeout: () => {},
+        // Issue #2735: exercises cache release, not the heap guard; opt out so
+        // the test process heap ratio does not trip the in-loop heap abort.
+        heapCriticalProbe: () => false,
       },
       structure,
       perfStats,

--- a/test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for the in-loop heap-critical guard in `runAnalysisLoop` (Issue #2735).
+ *
+ * Background: Issue #2594 added `AnalysisHeapGuard`, which samples the heap
+ * once at the analysis-extension boundary and skips the extension when heap
+ * is already CRITICAL. However, once analysis is under way, `runAnalysisLoop`
+ * processes many chunks across up to ten retry iterations with no further
+ * heap check. With a large layered seed (e.g. 986 neurons / ~109k synapses
+ * over a ~60k-record supervised `.bin` stream) the per-chunk squash analysis
+ * allocates aggressively (Issue #2642), so heap can climb back to CRITICAL
+ * mid-loop and fatally OOM the worker.
+ *
+ * The fix: sample heap pressure at the start of each retry iteration and
+ * before each chunk submission. When CRITICAL, abort the loop gracefully,
+ * returning whatever candidates have accumulated so far and recording
+ * `perfStats.analysisHeapAborted = true`, instead of pressing on into OOM.
+ */
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { DiscoverStructureDeps } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+import { DiscoveryPerformanceStats } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts";
+import { PhaseDiagnostics } from "@architecture/ErrorGuidedStructuralEvolution/PhaseDiagnostics.ts";
+import { runAnalysisLoop } from "@architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts";
+import { _setHeapGuardProviderForTests } from "@architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import type { MemoryUsageSample } from "@neat/MemoryMonitor.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+function makeTestCreature(): Creature {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { uuid: "hidden-a", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "hidden-b", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "hidden-c", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "input-0", toUUID: "hidden-b", weight: 0.25 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: -0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-c", weight: 0.75 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: -0.25 },
+      { fromUUID: "hidden-c", toUUID: "output-0", weight: 0.3 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+function makeTrainingData(): DataRecordInterface[] {
+  const samples: DataRecordInterface[] = [];
+  for (let i = 0; i < 20; i++) {
+    samples.push({
+      input: Float32Array.from([i / 20, (i + 1) / 20]),
+      output: Float32Array.from([i / 10]),
+    });
+  }
+  return samples;
+}
+
+interface RunOptions {
+  /** Heap sample returned by the injected provider for every check. */
+  readonly heapSample: MemoryUsageSample;
+  /** Whether heap monitoring is enabled in the config. */
+  readonly memoryEnabled?: boolean;
+}
+
+async function runWith(
+  options: RunOptions,
+): Promise<{ perfStats: DiscoveryPerformanceStats; chunkCalls: number }> {
+  await initWasmForTests();
+
+  const creature = makeTestCreature();
+  let chunkCalls = 0;
+
+  const tempParquetPath = await Deno.makeTempFile({
+    prefix: "analysis-loop-heap-guard-",
+    suffix: ".parquet",
+  });
+
+  const deps: Partial<DiscoverStructureDeps> = {
+    isRustDiscoveryEnabled: () => true,
+    isRustLibraryAvailable: () => true,
+    recordDiscovery: () => ({ success: true, file: tempParquetPath }),
+    mergeDiscoveryParquet: () => ({
+      success: true,
+      outputFile: tempParquetPath,
+    }),
+    analyzeParallel: (input) => {
+      chunkCalls += input.focusNeurons.length > 0 ? 1 : 0;
+      return {
+        success: true,
+        helpfulNeurons: [],
+        helpfulSynapses: [],
+        harmfulSynapses: [],
+      };
+    },
+    readDiscoveryRecords: () => ({ success: true, records: [] }),
+  };
+
+  const structure = new DiscoverStructure(creature, 600, 100, deps);
+  const neuronPromises = new Map<number, Promise<void>>();
+  structure.initialize(neuronPromises);
+  structure.record(makeTrainingData(), neuronPromises);
+  structure.flushRustRecording();
+
+  const config = createNeatConfig({
+    discoveryAnalysisTimeoutMinutes: 10,
+    discoveryMaxNeurons: 6,
+    discoveryAnalysisChunkSize: 1,
+    discoveryAnalysisPerChunkMaxMs: 60_000,
+    memory: { enabled: options.memoryEnabled ?? true },
+  });
+
+  const perfStats = new DiscoveryPerformanceStats();
+  const phaseDiagnostics = new PhaseDiagnostics("analysis");
+  const deadlineMs = Date.now() + 10 * 60 * 1000;
+  structure.extendTimeoutForAnalysis(600);
+
+  _setHeapGuardProviderForTests(() => options.heapSample);
+  try {
+    await runAnalysisLoop(
+      {
+        ID: "T-2735",
+        config,
+        discoveryMaxNeurons: 6,
+        costOfGrowth: 0,
+        analysisChunkSize: 1,
+        perChunkMaxMs: 60_000,
+        getTimeoutTS: () => deadlineMs,
+        refreshAnalysisTimeout: () => {},
+      },
+      structure,
+      perfStats,
+      phaseDiagnostics,
+    );
+  } finally {
+    _setHeapGuardProviderForTests(undefined);
+    await structure.cleanUp();
+    try {
+      await Deno.remove(tempParquetPath);
+    } catch {
+      // ignore
+    }
+  }
+
+  return { perfStats, chunkCalls };
+}
+
+Deno.test(
+  "in-loop heap guard: CRITICAL heap aborts the analysis loop before any chunk runs",
+  async () => {
+    const { perfStats, chunkCalls } = await runWith({
+      heapSample: { heapUsed: 95, heapTotal: 100 },
+    });
+
+    assert(
+      perfStats.analysisHeapAborted,
+      "CRITICAL heap must set perfStats.analysisHeapAborted",
+    );
+    assertFalse(
+      perfStats.analysisStalled,
+      "a heap abort is not a throughput stall",
+    );
+    assertEquals(
+      chunkCalls,
+      0,
+      "no chunk should be submitted once heap is CRITICAL",
+    );
+    assertEquals(
+      perfStats.neuronsAnalyzed,
+      0,
+      "no neurons analysed when aborting before the first chunk",
+    );
+  },
+);
+
+Deno.test(
+  "in-loop heap guard: normal heap runs the loop without aborting",
+  async () => {
+    const { perfStats, chunkCalls } = await runWith({
+      heapSample: { heapUsed: 10, heapTotal: 100 },
+    });
+
+    assertFalse(
+      perfStats.analysisHeapAborted,
+      "normal heap must not trip the heap-abort guard",
+    );
+    assert(
+      chunkCalls > 0,
+      "chunks should run normally when heap is not under pressure",
+    );
+  },
+);
+
+Deno.test(
+  "in-loop heap guard: monitoring disabled never aborts even if heap CRITICAL",
+  async () => {
+    const { perfStats, chunkCalls } = await runWith({
+      heapSample: { heapUsed: 99, heapTotal: 100 },
+      memoryEnabled: false,
+    });
+
+    assertFalse(
+      perfStats.analysisHeapAborted,
+      "guard must honour memory.enabled === false (legacy behaviour)",
+    );
+    assert(
+      chunkCalls > 0,
+      "with monitoring disabled the loop must run chunks as before",
+    );
+  },
+);

--- a/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisChunking.ts
@@ -180,6 +180,9 @@ async function runWithMockedAnalyzeParallel(
         now: options.now,
         getTimeoutTS: () => deadlineMs,
         refreshAnalysisTimeout: () => {},
+        // Issue #2735: exercises chunking/stall, not the heap guard; opt out so
+        // the test process heap ratio does not trip the in-loop heap abort.
+        heapCriticalProbe: () => false,
       },
       structure,
       perfStats,

--- a/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts
@@ -143,6 +143,9 @@ async function runAnalysisLoopWithStub(
         getTimeoutTS: () => deadlineMs,
         refreshAnalysisTimeout: () => {},
         runParallelAnalysis: wrapped,
+        // Issue #2735: exercises the per-chunk timeout, not the heap guard; opt
+        // out so the test process heap ratio does not trip the in-loop abort.
+        heapCriticalProbe: () => false,
       },
       structure,
       perfStats,

--- a/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisStallWarmup.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisStallWarmup.ts
@@ -146,6 +146,10 @@ async function runWith(
         now: options.now,
         getTimeoutTS: () => deadlineMs,
         refreshAnalysisTimeout: () => {},
+        // Issue #2735: this harness exercises the stall guard, not the heap
+        // guard. Opt out so the small test process's high heapUsed/heapTotal
+        // ratio does not trip the in-loop heap-critical abort.
+        heapCriticalProbe: () => false,
       },
       structure,
       perfStats,


### PR DESCRIPTION
# Bound discovery analysis heap with an in-loop CRITICAL guard

## Summary

`Creature.evolveDir()` fatally ran out of heap when evolving a large layered
feed-forward seed (e.g. 986 neurons / ~109k synapses) over a large supervised
`.bin` training directory. The extension-boundary heap guard added in Issue
#2594 samples the heap **once**, just before analysis is given more time. But
the analysis itself (`runAnalysisLoop`) then processes many chunks across up to
ten retry iterations, and the per-chunk squash analysis allocates aggressively
(Issue #2642). Heap therefore climbs back to `MemoryMonitor` CRITICAL **during**
the loop, where no further guard existed — and the worker OOMed with
`Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit`.

This change adds an **in-loop heap-critical guard** that re-samples heap
pressure at the start of each retry iteration and before each chunk submission.
On CRITICAL pressure the loop stops submitting work and returns the candidates
accumulated so far (graceful degradation — option 3 in the issue), recording
`perfStats.analysisHeapAborted = true` and logging a grep-friendly line:

```
[Neat] Discovery <id> analysis aborted: heap CRITICAL during analysis loop ...
```

The guard reuses the existing `isHeapCritical(config.memory)` probe, so it
honours `memory.enabled` and the shared `criticalThreshold`. The heap probe is
injectable via the new optional `AnalysisLoopContext.heapCriticalProbe` so
behaviour-focused loop tests (stall guard, chunking, cache release, per-chunk
timeout) opt out of the real heap sample — necessary because a small Deno test
process naturally reports `heapUsed/heapTotal` ≈ 0.9, above the 0.85 threshold.

Closes #2735.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified by unit tests
that drive `runAnalysisLoop` with an injected heap sample and assert the loop
aborts gracefully (no chunk submitted, no neurons analysed) on CRITICAL heap,
runs normally on low heap, and never aborts when `memory.enabled === false`.

```mermaid
flowchart TD
    R[Recording phase done] --> B{Heap CRITICAL at\nextension boundary?\n#2594}
    B -- yes --> S1[Skip analysis, return partial]
    B -- no --> L[Analysis loop]
    L --> C{Heap CRITICAL before\niteration / chunk?\n#2735}
    C -- yes --> S2[Stop, return\naccumulated candidates]
    C -- no --> P[Process chunk]
    P --> C
```

Test run:

```
ok | 33 passed | 0 failed   # all ErrorGuidedStructuralEvolution analysis specs
```

## Test Plan

- Added `test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts`:
  - CRITICAL heap aborts the loop before any chunk runs
    (`analysisHeapAborted === true`, `chunkCalls === 0`, `neuronsAnalyzed === 0`).
  - Normal heap runs the loop without aborting.
  - `memory.enabled === false` never aborts even when heap is CRITICAL.
- Updated existing loop harnesses (`DiscoverAnalysisStallWarmup`,
  `DiscoverAnalysisChunking`, `AnalysisCacheRelease`,
  `DiscoverAnalysisPerChunkTimeout`) to inject `heapCriticalProbe: () => false`,
  isolating their behaviour-under-test from the test process's high heap ratio.
  No assertions were changed.
- Documented both guards in `docs/troubleshooting/MEMORY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)