### PR TITLE
Fix graft-alias UUID collision corrupting forward-only offspring (#2746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Issue #2746:** Incompatible (graft) crossover no longer corrupts
+  forward-only offspring. When `editParentByIndex` renamed a parent's hidden
+  neuron onto the other parent's UUID, the post-breed `breed:fixAliases`
+  round-trip blindly restored the original UUID even when it collided with a
+  UUID already present in the offspring. The collision made `loadFrom` re-point
+  another neuron's synapses, turning a forward edge into a recurrent one
+  (`from >= to`) and tripping the `breed:fixAliases` recurrent-synapse
+  `TopologyError` (plus a downstream
+  `RangeError: Maximum call stack size
+  exceeded`) — the regression that forced
+  NEAT-AI-Examples to pin back to 5.0.29. Alias restoration is now
+  collision-aware (extracted to `src/breed/RestoreGraftAliases.ts`): an alias is
+  only restored when it does not duplicate an existing UUID, otherwise the
+  neuron keeps its deduplicated identity.
+
 ### Added
 
 - **Issue #2736:** New `"CATEGORICAL_ERROR"` built-in cost function for

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.32",
+  "version": "5.0.33",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2746.md
+++ b/docs/archive/pr-summaries/pr-summary-2746.md
@@ -1,0 +1,72 @@
+# Fix graft-alias UUID collision that corrupts forward-only offspring (Issue #2746)
+
+## Summary
+
+5.0.30 introduced a regression in incompatible (graft) crossover that forced
+NEAT-AI-Examples to pin back to 5.0.29
+([PR #473 comment](https://github.com/stSoftwareAU/NEAT-AI-Examples/pull/473#issuecomment-4526352714)).
+Breeding failed with
+`TopologyError: 🚨 [loadFrom] Recurrent synapse … source=breed:fixAliases` and a
+downstream `RangeError: Maximum call stack size exceeded`.
+
+**Root cause:** When parents are genetically incompatible, `editParentByIndex`
+renames a parent's unmatched hidden neurons onto the other parent's UUIDs and
+records the original UUID in an `alias` tag. After breeding, the
+`breed:fixAliases` round-trip restored that original UUID. The restore was **not
+collision-aware** — it blindly set `neuron.uuid = alias` even when the alias was
+already used by another neuron in the offspring. The duplicate UUID made
+`loadFrom` map that UUID to a single index and re-point the other neuron's
+synapses at it, turning a forward edge into a recurrent one (`from >= to`) on a
+forward-only creature, which trips the recurrent-synapse `TopologyError`.
+
+**Fix:** Extracted the restore into `src/breed/RestoreGraftAliases.ts` and made
+it collision-aware — an alias is only restored when it does not duplicate a UUID
+already present in the offspring; otherwise the neuron keeps its deduplicated
+identity (the alias tag is consumed either way). `Offspring.breed` now calls
+`restoreGraftAliases(fixed)`.
+
+Closes #2746.
+
+## Evidence
+
+This is a backend/library change with no web interface, so no screenshot
+applies. Evidence is the regression reproduction and unit tests.
+
+Running the **pre-fix** restore logic against the minimal collision graph
+reproduces the exact error from the bug report:
+
+```
+🚨 [loadFrom] Recurrent synapse 2->2 (fromUUID=A, toUUID=A, depth=0)
+on forward-only creature (... source=fromJSON). This indicates upstream
+corruption (Issue #2514).
+```
+
+After the fix the same graph loads as a valid forward-only creature.
+
+```mermaid
+flowchart LR
+  subgraph before["Naive restore (5.0.30)"]
+    B1["idx0 uuid=A"]
+    B2["idx1 uuid=B, alias=A"]
+    B2 -->|"restore B→A"| BD["two neurons share A → loadFrom\nre-points A→A: recurrent from>=to"]
+  end
+  subgraph after["Collision-aware restore (fix)"]
+    A1["idx0 uuid=A"]
+    A2["idx1 uuid=B, alias=A"]
+    A2 -->|"alias A already taken → keep B"| AD["UUIDs stay unique → forward-only valid"]
+  end
+```
+
+## Test Plan
+
+- Added `test/breed/RestoreGraftAliases.ts`:
+  - `restores a non-colliding alias` — happy path: alias restored, tag removed,
+    synapse endpoints rewritten.
+  - `skips alias that collides with an existing UUID` — regression test for the
+    recurrent-synapse scenario; asserts UUIDs stay unique and the export loads
+    and validates as forward-only.
+- Re-ran existing breed/serialisation suites
+  (`OffspringForwardOnlyChildAlwaysValidates`,
+  `OffspringEnsureUniqueUuidRoundTrip`, `OffspringBreed`, `Breed`,
+  `EditParentByIndex`) — all pass.
+- `./quality.sh` passes (fmt, lint, type-check, tests).

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -1,5 +1,5 @@
 import { assert } from "@std/assert";
-import { addTags, getTag, removeTag } from "@stsoftware/tags/mod";
+import { addTags } from "@stsoftware/tags/mod";
 import { memeticUpdate } from "@blackbox/MemeticUpdate.ts";
 import { editParentByIndex } from "@breed/EditParentByIndex.ts";
 import { geneticCompatibility } from "@breed/GeneticCompatibility.ts";
@@ -16,6 +16,7 @@ import { writeDiagnostics } from "@utils/Diagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { inputWeightCrossover } from "@breed/InputWeightCrossover.ts";
 import { subgraphTransplant } from "@breed/SubgraphTransplant.ts";
+import { restoreGraftAliases } from "@breed/RestoreGraftAliases.ts";
 import { pruneOrphanMemeticReferences } from "@compact/CompactUtils.ts";
 import type { BreedingSubPhaseAccumulator } from "@breed/BreedingSubPhaseAccumulator.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
@@ -550,19 +551,7 @@ export class Offspring {
 
     if (fixAliases) {
       const fixed = offspring.exportJSON();
-      for (const n of fixed.neurons) {
-        const alias = getTag(n, "alias");
-        if (alias && typeof n.uuid === "string") {
-          removeTag(n, "alias");
-          const oldUuid = n.uuid;
-          n.uuid = alias;
-          fixed.synapses.forEach((s) => {
-            if (s.fromUUID === oldUuid) s.fromUUID = alias;
-            if (s.toUUID === oldUuid) s.toUUID = alias;
-          });
-        }
-      }
-
+      restoreGraftAliases(fixed);
       offspring.loadFrom(fixed, false, "breed:fixAliases");
     }
 

--- a/src/breed/RestoreGraftAliases.ts
+++ b/src/breed/RestoreGraftAliases.ts
@@ -1,0 +1,53 @@
+import { getTag, removeTag } from "@stsoftware/tags/mod";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+
+/**
+ * Restore grafted neuron identities on a freshly bred offspring export.
+ *
+ * During incompatible crossover, {@link editParentByIndex} renames a parent's
+ * unmatched hidden neurons to the *other* parent's UUIDs and records the
+ * original UUID in an `alias` tag. After breeding we reverse that rename so the
+ * offspring keeps its own neuron identities rather than colliding with the
+ * grafted-onto parent.
+ *
+ * Issue #2746: the naive rewrite blindly set `neuron.uuid = alias`. When the
+ * restored alias collided with a UUID already present elsewhere in the
+ * offspring, `loadFrom` mapped that UUID to a single index and re-pointed the
+ * other neuron's synapses at it. On a forward-only creature this turned a
+ * forward edge into a recurrent one (`from >= to`), tripping the
+ * `breed:fixAliases` recurrent-synapse `TopologyError` (and a downstream stack
+ * overflow). We now only restore an alias when it does not collide with an
+ * existing UUID, keeping the deduplicated identity otherwise.
+ *
+ * Mutates `fixed` in place.
+ */
+export function restoreGraftAliases(fixed: CreatureExport): void {
+  // UUIDs that will remain after restoration: every neuron's current UUID,
+  // seeded so collision checks see the full graph. As aliases are restored we
+  // swap the old UUID out for the alias.
+  const occupied = new Set<string>();
+  for (const n of fixed.neurons) {
+    if (typeof n.uuid === "string") occupied.add(n.uuid);
+  }
+
+  for (const n of fixed.neurons) {
+    const alias = getTag(n, "alias");
+    if (!alias || typeof n.uuid !== "string") continue;
+
+    removeTag(n, "alias");
+    const oldUuid = n.uuid;
+    if (alias === oldUuid) continue;
+
+    // Skip restoration when the alias is already taken by another neuron.
+    // Restoring it would create a duplicate UUID and mis-wire synapses.
+    if (occupied.has(alias)) continue;
+
+    occupied.delete(oldUuid);
+    occupied.add(alias);
+    n.uuid = alias;
+    for (const s of fixed.synapses) {
+      if (s.fromUUID === oldUuid) s.fromUUID = alias;
+      if (s.toUUID === oldUuid) s.toUUID = alias;
+    }
+  }
+}

--- a/test/breed/RestoreGraftAliases.ts
+++ b/test/breed/RestoreGraftAliases.ts
@@ -1,0 +1,90 @@
+import { assert, assertEquals } from "@std/assert";
+import { getTag } from "@stsoftware/tags/mod";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { restoreGraftAliases } from "@breed/RestoreGraftAliases.ts";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+
+/**
+ * Issue #2746: restoring a graft alias must never reintroduce a duplicate
+ * UUID. A collided UUID makes `loadFrom` re-point another neuron's synapses,
+ * which on a forward-only creature turns a forward edge into a recurrent one
+ * and trips the `breed:fixAliases` TopologyError.
+ */
+Deno.test("restoreGraftAliases: restores a non-colliding alias", () => {
+  const fixed: CreatureExport = {
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      {
+        type: "hidden",
+        uuid: "mum-h",
+        squash: IDENTITY.NAME,
+        bias: 0,
+        tags: [{ name: "alias", value: "dad-h" }],
+      },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "mum-h", weight: 0.5 },
+      { fromUUID: "mum-h", toUUID: "output-0", weight: 0.5 },
+    ],
+  };
+
+  restoreGraftAliases(fixed);
+
+  assertEquals(fixed.neurons[0].uuid, "dad-h");
+  assertEquals(getTag(fixed.neurons[0], "alias"), null);
+  assertEquals(fixed.synapses[0].toUUID, "dad-h");
+  assertEquals(fixed.synapses[1].fromUUID, "dad-h");
+});
+
+Deno.test(
+  "restoreGraftAliases: skips alias that collides with an existing UUID",
+  () => {
+    // Forward-only sorted graph:
+    //   idx0 hidden "A"  →  idx1 hidden "B" (grafted, alias "A")  →  output
+    // Naively restoring "B" → "A" duplicates "A": loadFrom maps "A" to idx1
+    // and rewrites the A->B edge to A->A (from 1 -> to 1), a recurrent synapse
+    // that trips the breed:fixAliases TopologyError. The collision must be
+    // left untouched so the offspring stays forward-only.
+    const fixed: CreatureExport = {
+      input: 1,
+      output: 1,
+      forwardOnly: true,
+      neurons: [
+        { type: "hidden", uuid: "A", squash: IDENTITY.NAME, bias: 0 },
+        {
+          type: "hidden",
+          uuid: "B",
+          squash: IDENTITY.NAME,
+          bias: 0,
+          tags: [{ name: "alias", value: "A" }],
+        },
+        { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "A", weight: 0.5 },
+        { fromUUID: "A", toUUID: "B", weight: 0.5 },
+        { fromUUID: "input-0", toUUID: "B", weight: 0.5 },
+        { fromUUID: "B", toUUID: "output-0", weight: 0.5 },
+      ],
+    };
+
+    restoreGraftAliases(fixed);
+
+    // UUIDs must remain unique.
+    const uuids = fixed.neurons.map((n) => n.uuid);
+    assertEquals(new Set(uuids).size, uuids.length);
+    // The colliding neuron keeps its deduplicated identity.
+    assertEquals(fixed.neurons[1].uuid, "B");
+    // Alias tag is consumed regardless.
+    assertEquals(getTag(fixed.neurons[1], "alias"), null);
+
+    // The export must load as a valid forward-only creature (no recurrent edge).
+    const child = Creature.fromJSON(fixed);
+    child.validate({ forwardOnly: true });
+    assert(child);
+  },
+);


### PR DESCRIPTION
# Fix graft-alias UUID collision that corrupts forward-only offspring (Issue #2746)

## Summary

5.0.30 introduced a regression in incompatible (graft) crossover that forced
NEAT-AI-Examples to pin back to 5.0.29
([PR #473 comment](https://github.com/stSoftwareAU/NEAT-AI-Examples/pull/473#issuecomment-4526352714)).
Breeding failed with
`TopologyError: 🚨 [loadFrom] Recurrent synapse … source=breed:fixAliases` and a
downstream `RangeError: Maximum call stack size exceeded`.

**Root cause:** When parents are genetically incompatible, `editParentByIndex`
renames a parent's unmatched hidden neurons onto the other parent's UUIDs and
records the original UUID in an `alias` tag. After breeding, the
`breed:fixAliases` round-trip restored that original UUID. The restore was **not
collision-aware** — it blindly set `neuron.uuid = alias` even when the alias was
already used by another neuron in the offspring. The duplicate UUID made
`loadFrom` map that UUID to a single index and re-point the other neuron's
synapses at it, turning a forward edge into a recurrent one (`from >= to`) on a
forward-only creature, which trips the recurrent-synapse `TopologyError`.

**Fix:** Extracted the restore into `src/breed/RestoreGraftAliases.ts` and made
it collision-aware — an alias is only restored when it does not duplicate a UUID
already present in the offspring; otherwise the neuron keeps its deduplicated
identity (the alias tag is consumed either way). `Offspring.breed` now calls
`restoreGraftAliases(fixed)`.

Closes #2746.

## Evidence

This is a backend/library change with no web interface, so no screenshot
applies. Evidence is the regression reproduction and unit tests.

Running the **pre-fix** restore logic against the minimal collision graph
reproduces the exact error from the bug report:

```
🚨 [loadFrom] Recurrent synapse 2->2 (fromUUID=A, toUUID=A, depth=0)
on forward-only creature (... source=fromJSON). This indicates upstream
corruption (Issue #2514).
```

After the fix the same graph loads as a valid forward-only creature.

```mermaid
flowchart LR
  subgraph before["Naive restore (5.0.30)"]
    B1["idx0 uuid=A"]
    B2["idx1 uuid=B, alias=A"]
    B2 -->|"restore B→A"| BD["two neurons share A → loadFrom\nre-points A→A: recurrent from>=to"]
  end
  subgraph after["Collision-aware restore (fix)"]
    A1["idx0 uuid=A"]
    A2["idx1 uuid=B, alias=A"]
    A2 -->|"alias A already taken → keep B"| AD["UUIDs stay unique → forward-only valid"]
  end
```

## Test Plan

- Added `test/breed/RestoreGraftAliases.ts`:
  - `restores a non-colliding alias` — happy path: alias restored, tag removed,
    synapse endpoints rewritten.
  - `skips alias that collides with an existing UUID` — regression test for the
    recurrent-synapse scenario; asserts UUIDs stay unique and the export loads
    and validates as forward-only.
- Re-ran existing breed/serialisation suites
  (`OffspringForwardOnlyChildAlwaysValidates`,
  `OffspringEnsureUniqueUuidRoundTrip`, `OffspringBreed`, `Breed`,
  `EditParentByIndex`) — all pass.
- `./quality.sh` passes (fmt, lint, type-check, tests).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2746 -->