### PR TITLE
fix: enforce dep-bump quarantine in deno-outdated workflow (#2741)

### DIFF
--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -35,7 +35,13 @@ jobs:
           deno-version: v2.x
 
       - name: Update Deno dependencies
-        run: deno outdated --update --latest
+        # Honour the dep-bump quarantine (Issue #2741): only pick up external
+        # versions published more than VIBE_BUMP_QUARANTINE_HOURS hours ago, so
+        # a freshly published malicious release cannot land in the auto-raised
+        # PR. --minimum-dependency-age takes minutes, matching bump-deps.sh.
+        env:
+          VIBE_BUMP_QUARANTINE_HOURS: "24"
+        run: deno outdated --update --latest --minimum-dependency-age="$((VIBE_BUMP_QUARANTINE_HOURS * 60))"
 
       - name: Create Pull Request
         # peter-evans/create-pull-request@v7.0.11
@@ -46,6 +52,8 @@ jobs:
           branch: chore/deno-outdated
           delete-branch: true
           body: |
-            Automated Deno dependency update via `deno outdated --update --latest`.
+            Automated Deno dependency update via
+            `deno outdated --update --latest --minimum-dependency-age` with a
+            24h quarantine (Issue #2741).
 
             Raised by `.github/workflows/deno-outdated.yml` (Issue #2362).

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.35",
+  "version": "5.0.36",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2741.md
+++ b/docs/archive/pr-summaries/pr-summary-2741.md
@@ -16,9 +16,9 @@ env:
 run: deno outdated --update --latest --minimum-dependency-age="$((VIBE_BUMP_QUARANTINE_HOURS * 60))"
 ```
 
-`--minimum-dependency-age` takes minutes, matching `bump-deps.sh`, so a
-version published less than 24h ago can no longer land in the Monday-morning
-auto-raised PR.
+`--minimum-dependency-age` takes minutes, matching `bump-deps.sh`, so a version
+published less than 24h ago can no longer land in the Monday-morning auto-raised
+PR.
 
 Closes #2741.
 
@@ -47,16 +47,16 @@ ok | 3 passed | 0 failed
 ```
 
 `./quality.sh` passes apart from one pre-existing flaky test
-(`evolveRL_heapStability_test.ts`, Issue #2693) that is unrelated to this
-change and passes when run in isolation.
+(`evolveRL_heapStability_test.ts`, Issue #2693) that is unrelated to this change
+and passes when run in isolation.
 
 ## Test Plan
 
 - Added `test/ci/DenoOutdatedWorkflowQuarantine.ts`:
   - Asserts the workflow runs `deno outdated` with `--minimum-dependency-age`.
   - Asserts no executable `run:` step invokes a bare
-    `deno outdated --update --latest` without the quarantine flag (comment
-    lines are stripped before matching).
+    `deno outdated --update --latest` without the quarantine flag (comment lines
+    are stripped before matching).
   - Asserts the quarantine is sourced from `VIBE_BUMP_QUARANTINE_HOURS`.
 - The pre-existing `test/ci/QualityWorkflowDepBumpQuarantine.ts` still passes —
   the `deno outdated --update --latest` substring guard remains satisfied.

--- a/docs/archive/pr-summaries/pr-summary-2741.md
+++ b/docs/archive/pr-summaries/pr-summary-2741.md
@@ -1,0 +1,62 @@
+## Summary
+
+The weekly `.github/workflows/deno-outdated.yml` workflow is the only automated
+dep-bump path on the repo (the inline `quality.yml` step was removed by Issue
+#2697). It ran a bare `deno outdated --update --latest` with **no**
+`--minimum-dependency-age` flag, so freshly published external Deno/JSR/npm
+versions could be picked up the moment they hit a registry — bypassing the
+documented dep-bump quarantine (`VIBE_BUMP_QUARANTINE_HOURS`, default 24h)
+enforced by `bump-deps.sh` and `docs/CORE_DEPENDENCY_POLICY.md`.
+
+This change passes the quarantine through to the workflow:
+
+```yaml
+env:
+  VIBE_BUMP_QUARANTINE_HOURS: "24"
+run: deno outdated --update --latest --minimum-dependency-age="$((VIBE_BUMP_QUARANTINE_HOURS * 60))"
+```
+
+`--minimum-dependency-age` takes minutes, matching `bump-deps.sh`, so a
+version published less than 24h ago can no longer land in the Monday-morning
+auto-raised PR.
+
+Closes #2741.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+Quarantine flow after the fix:
+
+```mermaid
+flowchart LR
+    A[Monday 06:00 UTC cron] --> B[deno outdated --update --latest]
+    B --> C{published > 24h ago?}
+    C -- yes --> D[bump candidate]
+    C -- no --> E[skipped: too fresh]
+    D --> F[peter-evans/create-pull-request]
+```
+
+New test `test/ci/DenoOutdatedWorkflowQuarantine.ts` passes:
+
+```
+deno-outdated.yml passes --minimum-dependency-age to deno outdated (Issue #2741) ... ok
+deno-outdated.yml never runs a bare `deno outdated --update --latest` (Issue #2741) ... ok
+deno-outdated.yml drives the quarantine from VIBE_BUMP_QUARANTINE_HOURS (Issue #2741) ... ok
+ok | 3 passed | 0 failed
+```
+
+`./quality.sh` passes apart from one pre-existing flaky test
+(`evolveRL_heapStability_test.ts`, Issue #2693) that is unrelated to this
+change and passes when run in isolation.
+
+## Test Plan
+
+- Added `test/ci/DenoOutdatedWorkflowQuarantine.ts`:
+  - Asserts the workflow runs `deno outdated` with `--minimum-dependency-age`.
+  - Asserts no executable `run:` step invokes a bare
+    `deno outdated --update --latest` without the quarantine flag (comment
+    lines are stripped before matching).
+  - Asserts the quarantine is sourced from `VIBE_BUMP_QUARANTINE_HOURS`.
+- The pre-existing `test/ci/QualityWorkflowDepBumpQuarantine.ts` still passes —
+  the `deno outdated --update --latest` substring guard remains satisfied.

--- a/test/ci/DenoOutdatedWorkflowQuarantine.ts
+++ b/test/ci/DenoOutdatedWorkflowQuarantine.ts
@@ -1,0 +1,80 @@
+/**
+ * Issue #2741 — the weekly `.github/workflows/deno-outdated.yml` workflow is
+ * the only automated dep-bump path on the repo (the inline quality.yml step
+ * was removed by Issue #2697). It must respect the documented dep-bump
+ * quarantine: external Deno/JSR/npm versions younger than
+ * VIBE_BUMP_QUARANTINE_HOURS (default 24h) must not be picked up, so a
+ * freshly published malicious release cannot land in the auto-raised PR.
+ *
+ * `deno outdated` enforces this via `--minimum-dependency-age=<minutes>`
+ * (see bump-deps.sh and docs/CORE_DEPENDENCY_POLICY.md). These tests fail if
+ * the workflow runs a bare `deno outdated --update --latest` with no
+ * quarantine flag.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const DENO_OUTDATED_WORKFLOW = join(
+  REPO_ROOT,
+  ".github/workflows/deno-outdated.yml",
+);
+
+Deno.test(
+  "deno-outdated.yml passes --minimum-dependency-age to deno outdated (Issue #2741)",
+  async () => {
+    const body = await Deno.readTextFile(DENO_OUTDATED_WORKFLOW);
+    assert(
+      /deno\s+outdated[^\n]*--minimum-dependency-age/.test(body),
+      "deno-outdated.yml must run `deno outdated` with --minimum-dependency-age " +
+        "so the dep-bump quarantine (VIBE_BUMP_QUARANTINE_HOURS) is enforced — " +
+        "otherwise a freshly published malicious release can land in the " +
+        "auto-raised PR.",
+    );
+  },
+);
+
+Deno.test(
+  "deno-outdated.yml never runs a bare `deno outdated --update --latest` (Issue #2741)",
+  async () => {
+    const fullBody = await Deno.readTextFile(DENO_OUTDATED_WORKFLOW);
+    // Strip YAML comment lines: the header comment legitimately describes the
+    // bare command in prose. Only executable `run:` steps matter here.
+    const body = fullBody
+      .split("\n")
+      .filter((line) => !/^\s*#/.test(line))
+      .join("\n");
+    // Every `deno outdated --update --latest` invocation in the run: steps
+    // must also carry --minimum-dependency-age. A match without the flag is a
+    // quarantine bypass.
+    const invocations = body.match(
+      /deno\s+outdated\s+--update\s+--latest[^\n]*/g,
+    ) ?? [];
+    assert(
+      invocations.length > 0,
+      "deno-outdated.yml must still run `deno outdated --update --latest` — " +
+        "it is the reviewable single source of truth for dep bumps.",
+    );
+    for (const inv of invocations) {
+      assert(
+        /--minimum-dependency-age/.test(inv),
+        "deno-outdated.yml runs `deno outdated --update --latest` without " +
+          `--minimum-dependency-age (quarantine bypass): ${inv.trim()}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "deno-outdated.yml drives the quarantine from VIBE_BUMP_QUARANTINE_HOURS (Issue #2741)",
+  async () => {
+    const body = await Deno.readTextFile(DENO_OUTDATED_WORKFLOW);
+    assert(
+      /VIBE_BUMP_QUARANTINE_HOURS/.test(body),
+      "deno-outdated.yml must source its quarantine window from " +
+        "VIBE_BUMP_QUARANTINE_HOURS, matching bump-deps.sh and " +
+        "docs/CORE_DEPENDENCY_POLICY.md.",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

The weekly `.github/workflows/deno-outdated.yml` workflow is the only automated
dep-bump path on the repo (the inline `quality.yml` step was removed by Issue
#2697). It ran a bare `deno outdated --update --latest` with **no**
`--minimum-dependency-age` flag, so freshly published external Deno/JSR/npm
versions could be picked up the moment they hit a registry — bypassing the
documented dep-bump quarantine (`VIBE_BUMP_QUARANTINE_HOURS`, default 24h)
enforced by `bump-deps.sh` and `docs/CORE_DEPENDENCY_POLICY.md`.

This change passes the quarantine through to the workflow:

```yaml
env:
  VIBE_BUMP_QUARANTINE_HOURS: "24"
run: deno outdated --update --latest --minimum-dependency-age="$((VIBE_BUMP_QUARANTINE_HOURS * 60))"
```

`--minimum-dependency-age` takes minutes, matching `bump-deps.sh`, so a
version published less than 24h ago can no longer land in the Monday-morning
auto-raised PR.

Closes #2741.

## Evidence

Backend/CI-only change — no web interface to screenshot.

Quarantine flow after the fix:

```mermaid
flowchart LR
    A[Monday 06:00 UTC cron] --> B[deno outdated --update --latest]
    B --> C{published > 24h ago?}
    C -- yes --> D[bump candidate]
    C -- no --> E[skipped: too fresh]
    D --> F[peter-evans/create-pull-request]
```

New test `test/ci/DenoOutdatedWorkflowQuarantine.ts` passes:

```
deno-outdated.yml passes --minimum-dependency-age to deno outdated (Issue #2741) ... ok
deno-outdated.yml never runs a bare `deno outdated --update --latest` (Issue #2741) ... ok
deno-outdated.yml drives the quarantine from VIBE_BUMP_QUARANTINE_HOURS (Issue #2741) ... ok
ok | 3 passed | 0 failed
```

`./quality.sh` passes apart from one pre-existing flaky test
(`evolveRL_heapStability_test.ts`, Issue #2693) that is unrelated to this
change and passes when run in isolation.

## Test Plan

- Added `test/ci/DenoOutdatedWorkflowQuarantine.ts`:
  - Asserts the workflow runs `deno outdated` with `--minimum-dependency-age`.
  - Asserts no executable `run:` step invokes a bare
    `deno outdated --update --latest` without the quarantine flag (comment
    lines are stripped before matching).
  - Asserts the quarantine is sourced from `VIBE_BUMP_QUARANTINE_HOURS`.
- The pre-existing `test/ci/QualityWorkflowDepBumpQuarantine.ts` still passes —
  the `deno outdated --update --latest` substring guard remains satisfied.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2741 -->