### PR TITLE
feat(rust-scorer): pass configured costName via --cost flag (#2745)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.34",
+  "version": "5.0.35",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2745.md
+++ b/docs/archive/pr-summaries/pr-summary-2745.md
@@ -1,0 +1,77 @@
+# Pass configured `costName` to `rust_scorer` via `--cost` flag
+
+## Summary
+
+Plumbed `NeatConfig.costName` through to the external `rust_scorer` binary so
+the native scorer computes the same cost as the TypeScript training loop
+instead of silently defaulting to MSE. Before this change,
+`tryScoreWithRustScorer` invoked the binary positionally with no cost flag,
+which silently disagreed with the TS layer whenever
+`costName !== "MSE"`. Closes #2745.
+
+Changes:
+
+- `RustScorerBridgeInternal.ts` — probe state now records `costSupported`,
+  parsed from the binary's `--help` output (looks for `--cost` token).
+- `RustScorerBridge.ts` — `tryScoreWithRustScorer` accepts an optional
+  `costName: BuiltInCostName`. When supplied and the probe advertises
+  `--cost`, the bridge prepends `["--cost", costName]` to argv. When the
+  probe lacks `--cost` and a non-MSE cost is configured, the bridge logs a
+  one-shot warning and falls back to WASM scoring.
+- `BatchRustScorerBridge.ts` — same `--cost` plumbing for the
+  once-per-generation batch path.
+- `CreatureActivation.ts::evaluateDir` — narrows the configured cost name
+  against `BUILT_IN_COST_NAMES` and only off-loads to Rust when it is a
+  built-in. Custom (user-registered) costs stay on the TS/WASM path.
+- `Fitness.ts` — accepts an optional `costName` constructor argument and
+  forwards the narrowed `BuiltInCostName` to the batch bridge.
+- `Neat.ts` — passes `this.config.costName` to the `Fitness` constructor.
+
+## Evidence
+
+CLI/bridge change, no UI to screenshot. Verified by the new unit tests in
+`test/score/RustScorerBridgeCostFlag.ts` (all 7 pass) and existing
+`test/score/*` (127 pass) plus `test/architecture/Fitness*.ts` (31 pass).
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+    participant TS as NEAT-AI (TS)
+    participant Bridge as RustScorerBridge
+    participant Rust as rust_scorer
+    TS->>Bridge: tryScoreWithRustScorer(creature, dataDir, override, costName)
+    Bridge->>Rust: spawn(binary, ["--help"]) (cached probe)
+    alt probe advertises --cost
+        Bridge->>Rust: spawn(binary, [--cost, NAME, creature.json, dataDir])
+        Rust-->>Bridge: { error, ... }
+        Bridge-->>TS: { error }
+    else probe lacks --cost AND costName !== MSE
+        Bridge-->>TS: undefined (one-shot warn, fall back to WASM)
+    else cost unknown to Rust
+        Rust-->>Bridge: exit != 0 + stderr
+        Bridge-->>TS: undefined (one-shot warn, fall back to WASM)
+    end
+```
+
+## Test Plan
+
+Added `test/score/RustScorerBridgeCostFlag.ts` covering:
+
+- Bridge prepends `--cost <NAME>` when probe advertises the flag.
+- Bridge falls back to WASM with a one-shot warning when the probe lacks
+  `--cost` and the configured cost is non-MSE.
+- Bridge still uses the rust path for MSE when probe lacks `--cost`
+  (preserves prior behaviour since MSE is the binary's historical default).
+- Custom (user-registered) cost names bypass the rust path entirely — the
+  runner is not invoked at all (no probe, no score call).
+- Non-zero exit on unknown cost logs exactly one warning across repeated
+  calls and returns `undefined` so the caller falls back to WASM.
+- Batch bridge prepends `--cost <NAME>` and falls back identically.
+
+Existing tests verified untouched:
+
+- `test/score/RustScorerBridgeHardening.ts` — 5 tests pass.
+- `test/score/RustScorerIntegration.ts` — 4 tests pass.
+- `test/score/BatchRustScorerBridge.ts` — 10 tests pass.
+- `test/architecture/Fitness*.ts` — 31 tests pass.

--- a/docs/archive/pr-summaries/pr-summary-2745.md
+++ b/docs/archive/pr-summaries/pr-summary-2745.md
@@ -3,21 +3,20 @@
 ## Summary
 
 Plumbed `NeatConfig.costName` through to the external `rust_scorer` binary so
-the native scorer computes the same cost as the TypeScript training loop
-instead of silently defaulting to MSE. Before this change,
-`tryScoreWithRustScorer` invoked the binary positionally with no cost flag,
-which silently disagreed with the TS layer whenever
-`costName !== "MSE"`. Closes #2745.
+the native scorer computes the same cost as the TypeScript training loop instead
+of silently defaulting to MSE. Before this change, `tryScoreWithRustScorer`
+invoked the binary positionally with no cost flag, which silently disagreed with
+the TS layer whenever `costName !== "MSE"`. Closes #2745.
 
 Changes:
 
 - `RustScorerBridgeInternal.ts` — probe state now records `costSupported`,
   parsed from the binary's `--help` output (looks for `--cost` token).
 - `RustScorerBridge.ts` — `tryScoreWithRustScorer` accepts an optional
-  `costName: BuiltInCostName`. When supplied and the probe advertises
-  `--cost`, the bridge prepends `["--cost", costName]` to argv. When the
-  probe lacks `--cost` and a non-MSE cost is configured, the bridge logs a
-  one-shot warning and falls back to WASM scoring.
+  `costName: BuiltInCostName`. When supplied and the probe advertises `--cost`,
+  the bridge prepends `["--cost", costName]` to argv. When the probe lacks
+  `--cost` and a non-MSE cost is configured, the bridge logs a one-shot warning
+  and falls back to WASM scoring.
 - `BatchRustScorerBridge.ts` — same `--cost` plumbing for the
   once-per-generation batch path.
 - `CreatureActivation.ts::evaluateDir` — narrows the configured cost name
@@ -61,12 +60,12 @@ Added `test/score/RustScorerBridgeCostFlag.ts` covering:
 - Bridge prepends `--cost <NAME>` when probe advertises the flag.
 - Bridge falls back to WASM with a one-shot warning when the probe lacks
   `--cost` and the configured cost is non-MSE.
-- Bridge still uses the rust path for MSE when probe lacks `--cost`
-  (preserves prior behaviour since MSE is the binary's historical default).
-- Custom (user-registered) cost names bypass the rust path entirely — the
-  runner is not invoked at all (no probe, no score call).
-- Non-zero exit on unknown cost logs exactly one warning across repeated
-  calls and returns `undefined` so the caller falls back to WASM.
+- Bridge still uses the rust path for MSE when probe lacks `--cost` (preserves
+  prior behaviour since MSE is the binary's historical default).
+- Custom (user-registered) cost names bypass the rust path entirely — the runner
+  is not invoked at all (no probe, no score call).
+- Non-zero exit on unknown cost logs exactly one warning across repeated calls
+  and returns `undefined` so the caller falls back to WASM.
 - Batch bridge prepends `--cost <NAME>` and falls back identically.
 
 Existing tests verified untouched:

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -217,6 +217,11 @@ export class Neat {
       this.config.costOfGrowth,
       this.config.feedbackLoop,
       this.config.parallelEvaluation,
+      undefined,
+      // Issue #2745: Forward the configured cost name to the batch rust
+      // scorer so the native scorer computes the same cost as the TS
+      // training loop instead of silently defaulting to MSE.
+      this.config.costName,
     );
 
     this.population = [];

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -13,6 +13,7 @@ import { getEnvRustScorerConfig } from "../score/RustScorerBridge.ts";
 import { BatchScorerError } from "../score/BatchScorerReconciler.ts";
 import { buildBatchScorerDiagnostic } from "../score/BatchScorerDiagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
+import { BUILT_IN_COST_NAMES, type BuiltInCostName } from "@costs";
 
 /**
  * Evaluates fitness scores for a population of creatures.
@@ -91,18 +92,29 @@ export class Fitness {
    */
   private dataDir: string | undefined;
 
+  /**
+   * Issue #2745: Configured cost name (`NeatConfig.costName`) passed through
+   * to the batch rust scorer via `--cost <NAME>` so the native scorer
+   * computes the same cost as the TS layer. Only built-in cost names are
+   * forwarded — custom (user-registered) costs cannot be off-loaded to
+   * the external binary and stay on the TS/WASM path.
+   */
+  private costName: BuiltInCostName | undefined;
+
   constructor(
     workers: WorkerHandler[],
     growth: number,
     feedbackLoop: boolean,
     evalConfig?: RequiredParallelEvaluationConfig,
     dataDir?: string,
+    costName?: string,
   ) {
     this.workers = workers;
     this.feedbackLoop = feedbackLoop;
     this.growth = growth;
     this.evalConfig = evalConfig ?? DEFAULT_PARALLEL_EVALUATION_CONFIG;
     this.dataDir = dataDir;
+    this.costName = toBuiltInCostName(costName);
   }
 
   /**
@@ -219,6 +231,7 @@ export class Fitness {
             forwardOnlyCreatures,
             this.dataDir!,
             rustScorerConfig,
+            this.costName,
           );
           this.lastBatchScorerInvocations = batchRun.invocations;
           if (batchRun.results) {
@@ -412,4 +425,18 @@ export class Fitness {
     this.lastScorerMs = scorerMsAccum;
     this.lastScoredCreatureCount = scoredCount;
   }
+}
+
+/**
+ * Narrow an unconstrained `costName` string to a `BuiltInCostName`, or
+ * return `undefined` if the value is unknown to the built-in registry
+ * (e.g. a user-registered custom cost). Issue #2745.
+ */
+function toBuiltInCostName(
+  costName: string | undefined,
+): BuiltInCostName | undefined {
+  if (costName === undefined) return undefined;
+  return (BUILT_IN_COST_NAMES as readonly string[]).includes(costName)
+    ? (costName as BuiltInCostName)
+    : undefined;
 }

--- a/src/creature/CreatureActivation.ts
+++ b/src/creature/CreatureActivation.ts
@@ -30,6 +30,7 @@ import {
   noteWasmCreatureActivationUse,
 } from "@wasm/WasmCreatureActivationLRU.ts";
 import { tryScoreWithRustScorer } from "../score/RustScorerBridge.ts";
+import { BUILT_IN_COST_NAMES, type BuiltInCostName } from "@costs";
 
 /**
  * Verify WASM is available and the creature is eligible.
@@ -417,12 +418,24 @@ export async function evaluateDir(
   const { ensureWasmActivation } = await import("../wasm/mod.ts");
   await ensureWasmActivation();
 
-  const rustResult = await tryScoreWithRustScorer(
-    creature,
-    dataDir,
-    rustScorer,
-  );
-  if (rustResult) return { error: rustResult.error };
+  // Issue #2745: Off-load to the rust scorer only when the configured cost
+  // is a built-in (the rust binary cannot resolve user-registered custom
+  // costs). Custom costs stay on the TS/WASM path.
+  const configuredCostName = cost.getName();
+  const builtInCost: BuiltInCostName | undefined =
+    (BUILT_IN_COST_NAMES as readonly string[]).includes(configuredCostName)
+      ? (configuredCostName as BuiltInCostName)
+      : undefined;
+
+  if (builtInCost !== undefined) {
+    const rustResult = await tryScoreWithRustScorer(
+      creature,
+      dataDir,
+      rustScorer,
+      builtInCost,
+    );
+    if (rustResult) return { error: rustResult.error };
+  }
 
   requireWasmOrThrow(creature);
 

--- a/src/score/BatchRustScorerBridge.ts
+++ b/src/score/BatchRustScorerBridge.ts
@@ -25,7 +25,9 @@
 import { join, resolve } from "@std/path";
 import type { Creature } from "@creature";
 import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
+import type { BuiltInCostName } from "@costs";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { getLogger } from "@utils/Logger.ts";
 import {
   BatchScorerError,
   type BatchScorerResult,
@@ -72,6 +74,7 @@ export async function tryBatchScoreWithRustScorer(
   creatures: readonly Creature[],
   dataDir: string,
   config: RequiredRustScorerConfig,
+  costName?: BuiltInCostName,
 ): Promise<BatchScorerRunResult> {
   if (!config.enabled || !config.batch) {
     return { results: undefined, invocations: 0 };
@@ -82,6 +85,22 @@ export async function tryBatchScoreWithRustScorer(
 
   const probe = await resolveProbeState(config);
   if (!probe.available) {
+    return { results: undefined, invocations: 0 };
+  }
+
+  // Issue #2745: When a non-MSE cost is configured but the probed binary is
+  // too old to support `--cost`, fall back rather than letting the Rust side
+  // silently compute MSE and disagree with the TS layer.
+  if (
+    costName !== undefined && !probe.costSupported && costName !== "MSE"
+  ) {
+    if (!probe.warned) {
+      getLogger().warn(
+        `[NEAT-AI] Rust scorer at ${config.binaryPath} does not advertise --cost; ` +
+          `falling back to WASM scoring for cost=${costName} (batch mode).`,
+      );
+      probe.warned = true;
+    }
     return { results: undefined, invocations: 0 };
   }
 
@@ -127,9 +146,15 @@ export async function tryBatchScoreWithRustScorer(
     const absoluteCreaturesDir = resolve(Deno.cwd(), creaturesDir);
     const absoluteDataDir = resolve(Deno.cwd(), dataDir);
 
+    // Issue #2745: Prepend `--cost <NAME>` so the Rust scorer computes the
+    // same cost as the TS training loop instead of its built-in default.
+    const args = costName !== undefined && probe.costSupported
+      ? ["--cost", costName, absoluteCreaturesDir, absoluteDataDir]
+      : [absoluteCreaturesDir, absoluteDataDir];
+
     const result = await runCommand(
       config.binaryPath,
-      [absoluteCreaturesDir, absoluteDataDir],
+      args,
       {
         env: buildChildEnv(config.env),
         timeoutMs: config.timeoutMs,

--- a/src/score/RustScorerBridge.ts
+++ b/src/score/RustScorerBridge.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "@std/path";
 import type { Creature } from "@creature";
 import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
+import type { BuiltInCostName } from "@costs";
 import { getLogger } from "@utils/Logger.ts";
 import {
   __getBatchRunner,
@@ -159,12 +160,30 @@ export async function tryScoreWithRustScorer(
   creature: Creature,
   dataDir: string,
   override?: RequiredRustScorerConfig,
+  costName?: BuiltInCostName,
 ): Promise<RustScorerResult | undefined> {
   const config = override ?? getEnvRustScorerConfig();
   if (!config.enabled) return undefined;
 
   const probe = await resolveProbeState(config);
   if (!probe.available) return undefined;
+
+  // Issue #2745: When a non-MSE cost is configured but the probed binary is
+  // too old to advertise `--cost`, fall back to WASM rather than silently
+  // letting the Rust side compute MSE. MSE is the binary's historical
+  // default so it stays compatible without `--cost`.
+  if (
+    costName !== undefined && !probe.costSupported && costName !== "MSE"
+  ) {
+    if (!probe.warned) {
+      getLogger().warn(
+        `[NEAT-AI] Rust scorer at ${config.binaryPath} does not advertise --cost; ` +
+          `falling back to WASM scoring for cost=${costName}.`,
+      );
+      probe.warned = true;
+    }
+    return undefined;
+  }
 
   let creaturePath: string | undefined;
   try {
@@ -173,9 +192,16 @@ export async function tryScoreWithRustScorer(
     // rust_scorer resolves relative paths against its own process cwd, which
     // may not match the Deno/worker cwd. Always hand it absolute paths.
     const absoluteDataDir = resolve(Deno.cwd(), dataDir);
+    // Issue #2745: Prepend `--cost <NAME>` when the configured cost is
+    // a built-in and the binary supports the flag. This stops the Rust
+    // path from silently computing MSE while the TS layer trains against
+    // a different cost.
+    const args = costName !== undefined && probe.costSupported
+      ? ["--cost", costName, creaturePath, absoluteDataDir]
+      : [creaturePath, absoluteDataDir];
     const result = await __getBatchRunner()(
       config.binaryPath,
-      [creaturePath, absoluteDataDir],
+      args,
       {
         env: buildChildEnv(config.env),
         timeoutMs: config.timeoutMs,

--- a/src/score/RustScorerBridgeInternal.ts
+++ b/src/score/RustScorerBridgeInternal.ts
@@ -36,6 +36,14 @@ export interface RustScorerProbeState {
   available: boolean;
   binaryPath: string;
   warned: boolean;
+  /**
+   * Issue #2745: Whether the probed `rust_scorer` binary advertises the
+   * `--cost <NAME>` flag in its `--help` output. Older binaries that
+   * silently compute MSE only set this to `false`; the bridge then falls
+   * back to WASM scoring whenever a non-MSE cost is configured rather than
+   * silently disagreeing with the TS layer.
+   */
+  costSupported: boolean;
 }
 
 async function defaultRunner(
@@ -121,12 +129,18 @@ export async function resolveProbeState(
   if (cached) return cached;
 
   let available = false;
+  let costSupported = false;
   try {
     const probe = await runCommand(config.binaryPath, ["--help"], {
       env: buildChildEnv(config.env),
       timeoutMs: config.timeoutMs,
     });
     available = probe.success || probe.code === 0 || probe.code === 1;
+    // Issue #2745: Detect whether the binary advertises `--cost`. We look
+    // in both stdout and stderr because clap-style help may write to either
+    // depending on whether `--help` exits 0 or 2.
+    const helpText = `${probe.stdout ?? ""}\n${probe.stderr ?? ""}`;
+    costSupported = /(^|\s|,)--cost\b/.test(helpText);
   } catch {
     available = false;
   }
@@ -135,6 +149,7 @@ export async function resolveProbeState(
     available,
     binaryPath: config.binaryPath,
     warned: false,
+    costSupported,
   };
   probeCache.set(key, state);
   return state;

--- a/test/score/RustScorerBridgeCostFlag.ts
+++ b/test/score/RustScorerBridgeCostFlag.ts
@@ -1,0 +1,466 @@
+/**
+ * Tests for Issue #2745 — pass configured `costName` to `rust_scorer`
+ * via `--cost <NAME>` so the native scorer computes the same cost as the
+ * TS training loop.
+ *
+ * Covers:
+ *   - per-creature bridge prepends `--cost <NAME>` when costName is supplied
+ *     and the probed binary advertises the flag
+ *   - per-creature bridge falls back to WASM (returns undefined) when the
+ *     binary does not advertise `--cost` and the configured cost is non-MSE
+ *   - custom (non-built-in) cost names are not off-loaded to the rust path
+ *   - non-zero exit (e.g. rust hard-errors on an unknown cost) logs once and
+ *     returns undefined
+ *   - batch bridge prepends `--cost <NAME>` the same way
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { Costs } from "@costs";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import type { CostInterface } from "@costs/CostInterface.ts";
+import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
+import {
+  __resetRustScorerBridgeForTests,
+  __setRustScorerRunnerForTests,
+} from "../../src/score/RustScorerBridge.ts";
+import { tryBatchScoreWithRustScorer } from "../../src/score/BatchRustScorerBridge.ts";
+import {
+  createConsoleLogger,
+  getLogger,
+  type Logger,
+  setLogger,
+} from "@utils/Logger.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+function buildDataSet(): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < 8; i++) {
+    const a = i / 8;
+    const b = (8 - i) / 8;
+    rows.push({
+      input: new Float32Array([a, b]),
+      output: new Float32Array([a > b ? 1 : -1]),
+    });
+  }
+  return rows;
+}
+
+function captureWarnings(): { warnings: string[]; restore: () => void } {
+  const warnings: string[] = [];
+  const previous = getLogger();
+  const capturing: Logger = {
+    debug: () => {},
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(" "));
+    },
+    error: () => {},
+  };
+  setLogger(capturing);
+  return {
+    warnings,
+    restore: () => setLogger(previous ?? createConsoleLogger("info")),
+  };
+}
+
+function buildConfig(): RequiredRustScorerConfig {
+  return {
+    enabled: true,
+    binaryPath: "rust_scorer",
+    timeoutMs: 0,
+    env: {},
+    batch: false,
+  };
+}
+
+/** Help text that advertises `--cost` (clap-style). */
+const HELP_WITH_COST =
+  "USAGE:\n  rust_scorer [OPTIONS] <CREATURE> <DATA_DIR>\n\nOPTIONS:\n  --cost <NAME>    Cost function (MSE, MAE, ...)\n  -h, --help\n";
+
+/** Help text from an older binary that does not advertise `--cost`. */
+const HELP_WITHOUT_COST =
+  "USAGE:\n  rust_scorer <CREATURE> <DATA_DIR>\n\nOPTIONS:\n  -h, --help\n";
+
+Deno.test("RustScorerBridge: prepends --cost <NAME> when probe advertises the flag", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let scoreArgs: string[] = [];
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: HELP_WITH_COST,
+        stderr: "",
+      });
+    }
+    scoreArgs = args;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: '{"error":0.42}',
+      stderr: "",
+    });
+  });
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const result = await creature.evaluateDir(
+      dataDir,
+      Costs.find("MAE"),
+      false,
+      undefined,
+      undefined,
+      buildConfig(),
+    );
+    assertEquals(result.error, 0.42);
+    assertEquals(scoreArgs[0], "--cost");
+    assertEquals(scoreArgs[1], "MAE");
+    // The remaining args are creature path + data dir.
+    assertEquals(scoreArgs.length, 4);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("RustScorerBridge: falls back to WASM when probe lacks --cost and cost is non-MSE", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let scoreCalls = 0;
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: HELP_WITHOUT_COST,
+        stderr: "",
+      });
+    }
+    scoreCalls++;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: '{"error":0}',
+      stderr: "",
+    });
+  });
+
+  const { warnings, restore } = captureWarnings();
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    // MAE is non-MSE → bridge must skip the rust path entirely.
+    const result = await creature.evaluateDir(
+      dataDir,
+      Costs.find("MAE"),
+      false,
+      undefined,
+      undefined,
+      buildConfig(),
+    );
+    assert(Number.isFinite(result.error));
+    assertEquals(
+      scoreCalls,
+      0,
+      "scorer must not be invoked when --cost is unsupported and cost is non-MSE",
+    );
+    const warned = warnings.find((w) =>
+      w.includes("does not advertise --cost")
+    );
+    assert(
+      warned !== undefined,
+      `expected one-shot warning; got: ${warnings.join("\n")}`,
+    );
+  } finally {
+    restore();
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("RustScorerBridge: still uses rust path for MSE when probe lacks --cost", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let scoreArgs: string[] = [];
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: HELP_WITHOUT_COST,
+        stderr: "",
+      });
+    }
+    scoreArgs = args;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: '{"error":0.07}',
+      stderr: "",
+    });
+  });
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const result = await creature.evaluateDir(
+      dataDir,
+      Costs.find("MSE"),
+      false,
+      undefined,
+      undefined,
+      buildConfig(),
+    );
+    assertEquals(result.error, 0.07);
+    // No `--cost` flag — falls back to positional invocation (MSE is the
+    // binary's historical default so the call is still safe).
+    assertEquals(
+      scoreArgs.length,
+      2,
+      `expected positional args only; got ${JSON.stringify(scoreArgs)}`,
+    );
+    assertEquals(scoreArgs[0].endsWith(".json"), true);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("RustScorerBridge: custom (registered) cost bypasses the rust path entirely", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  // Register a custom cost that mimics MSE so WASM scoring still works.
+  class CustomMSE implements CostInterface {
+    getName(): string {
+      return "ISSUE_2745_CUSTOM_COST";
+    }
+    calculate(target: ArrayLike<number>, output: ArrayLike<number>): number {
+      let s = 0;
+      for (let i = 0; i < target.length; i++) {
+        const d = target[i] - output[i];
+        s += d * d;
+      }
+      return s / target.length;
+    }
+    propagate(target: number, output: number): number {
+      return output - target;
+    }
+  }
+  const custom = new CustomMSE();
+  Costs.registerCustomCost(custom);
+
+  let totalRustCalls = 0;
+  __setRustScorerRunnerForTests(() => {
+    totalRustCalls++;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: HELP_WITH_COST,
+      stderr: "",
+    });
+  });
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const result = await creature.evaluateDir(
+      dataDir,
+      custom,
+      false,
+      undefined,
+      undefined,
+      buildConfig(),
+    );
+    assert(Number.isFinite(result.error));
+    // The rust runner must not be invoked at all — neither probe nor score —
+    // because custom costs cannot be off-loaded to the binary.
+    assertEquals(
+      totalRustCalls,
+      0,
+      "rust runner must not be invoked for custom costs",
+    );
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("RustScorerBridge: non-zero exit on unknown cost logs once and falls back", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let scoreCalls = 0;
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: HELP_WITH_COST,
+        stderr: "",
+      });
+    }
+    scoreCalls++;
+    return Promise.resolve({
+      success: false,
+      code: 2,
+      stdout: "",
+      stderr: "Error: unknown cost function: HINGE",
+    });
+  });
+
+  const { warnings, restore } = captureWarnings();
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    // First call — should log warning and fall back to WASM.
+    const result1 = await creature.evaluateDir(
+      dataDir,
+      Costs.find("HINGE"),
+      false,
+      undefined,
+      undefined,
+      buildConfig(),
+    );
+    assert(Number.isFinite(result1.error));
+    // Second call — should not log again (one-shot behaviour).
+    const result2 = await creature.evaluateDir(
+      dataDir,
+      Costs.find("HINGE"),
+      false,
+      undefined,
+      undefined,
+      buildConfig(),
+    );
+    assert(Number.isFinite(result2.error));
+
+    assert(
+      scoreCalls >= 1,
+      `expected at least one scorer invocation; got ${scoreCalls}`,
+    );
+    const failures = warnings.filter((w) =>
+      w.includes("Rust scorer call failed")
+    );
+    assertEquals(
+      failures.length,
+      1,
+      `expected exactly one failure warning across both calls; got: ${
+        warnings.join("\n")
+      }`,
+    );
+  } finally {
+    restore();
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer: prepends --cost <NAME> when probe advertises the flag", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let scoreArgs: string[] = [];
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: HELP_WITH_COST,
+        stderr: "",
+      });
+    }
+    scoreArgs = args;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: JSON.stringify({
+        "creature-aa": { score: 0.5, error: 0.5, recordCount: 8 },
+      }),
+      stderr: "",
+    });
+  });
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.uuid = "creature-aa";
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const run = await tryBatchScoreWithRustScorer(
+      [creature],
+      dataDir,
+      {
+        enabled: true,
+        binaryPath: "rust_scorer",
+        timeoutMs: 0,
+        env: {},
+        batch: true,
+      },
+      "MAE",
+    );
+    assertEquals(run.invocations, 1);
+    assert(run.results !== undefined);
+    assertEquals(scoreArgs[0], "--cost");
+    assertEquals(scoreArgs[1], "MAE");
+    // Remaining args are creatures dir + data dir.
+    assertEquals(scoreArgs.length, 4);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("BatchRustScorer: falls back when probe lacks --cost and cost is non-MSE", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  let scoreCalls = 0;
+  __setRustScorerRunnerForTests((_command, args) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: HELP_WITHOUT_COST,
+        stderr: "",
+      });
+    }
+    scoreCalls++;
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: "{}",
+      stderr: "",
+    });
+  });
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creature.uuid = "creature-bb";
+  const dataDir = makeDataDir(buildDataSet(), 8);
+  try {
+    const run = await tryBatchScoreWithRustScorer(
+      [creature],
+      dataDir,
+      {
+        enabled: true,
+        binaryPath: "rust_scorer",
+        timeoutMs: 0,
+        env: {},
+        batch: true,
+      },
+      "MAE",
+    );
+    assertEquals(run.results, undefined);
+    assertEquals(run.invocations, 0);
+    assertEquals(scoreCalls, 0);
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});


### PR DESCRIPTION
# Pass configured `costName` to `rust_scorer` via `--cost` flag

## Summary

Plumbed `NeatConfig.costName` through to the external `rust_scorer` binary so
the native scorer computes the same cost as the TypeScript training loop
instead of silently defaulting to MSE. Before this change,
`tryScoreWithRustScorer` invoked the binary positionally with no cost flag,
which silently disagreed with the TS layer whenever
`costName !== "MSE"`. Closes #2745.

Changes:

- `RustScorerBridgeInternal.ts` — probe state now records `costSupported`,
  parsed from the binary's `--help` output (looks for `--cost` token).
- `RustScorerBridge.ts` — `tryScoreWithRustScorer` accepts an optional
  `costName: BuiltInCostName`. When supplied and the probe advertises
  `--cost`, the bridge prepends `["--cost", costName]` to argv. When the
  probe lacks `--cost` and a non-MSE cost is configured, the bridge logs a
  one-shot warning and falls back to WASM scoring.
- `BatchRustScorerBridge.ts` — same `--cost` plumbing for the
  once-per-generation batch path.
- `CreatureActivation.ts::evaluateDir` — narrows the configured cost name
  against `BUILT_IN_COST_NAMES` and only off-loads to Rust when it is a
  built-in. Custom (user-registered) costs stay on the TS/WASM path.
- `Fitness.ts` — accepts an optional `costName` constructor argument and
  forwards the narrowed `BuiltInCostName` to the batch bridge.
- `Neat.ts` — passes `this.config.costName` to the `Fitness` constructor.

## Evidence

CLI/bridge change, no UI to screenshot. Verified by the new unit tests in
`test/score/RustScorerBridgeCostFlag.ts` (all 7 pass) and existing
`test/score/*` (127 pass) plus `test/architecture/Fitness*.ts` (31 pass).

### Sequence

```mermaid
sequenceDiagram
    participant TS as NEAT-AI (TS)
    participant Bridge as RustScorerBridge
    participant Rust as rust_scorer
    TS->>Bridge: tryScoreWithRustScorer(creature, dataDir, override, costName)
    Bridge->>Rust: spawn(binary, ["--help"]) (cached probe)
    alt probe advertises --cost
        Bridge->>Rust: spawn(binary, [--cost, NAME, creature.json, dataDir])
        Rust-->>Bridge: { error, ... }
        Bridge-->>TS: { error }
    else probe lacks --cost AND costName !== MSE
        Bridge-->>TS: undefined (one-shot warn, fall back to WASM)
    else cost unknown to Rust
        Rust-->>Bridge: exit != 0 + stderr
        Bridge-->>TS: undefined (one-shot warn, fall back to WASM)
    end
```

## Test Plan

Added `test/score/RustScorerBridgeCostFlag.ts` covering:

- Bridge prepends `--cost <NAME>` when probe advertises the flag.
- Bridge falls back to WASM with a one-shot warning when the probe lacks
  `--cost` and the configured cost is non-MSE.
- Bridge still uses the rust path for MSE when probe lacks `--cost`
  (preserves prior behaviour since MSE is the binary's historical default).
- Custom (user-registered) cost names bypass the rust path entirely — the
  runner is not invoked at all (no probe, no score call).
- Non-zero exit on unknown cost logs exactly one warning across repeated
  calls and returns `undefined` so the caller falls back to WASM.
- Batch bridge prepends `--cost <NAME>` and falls back identically.

Existing tests verified untouched:

- `test/score/RustScorerBridgeHardening.ts` — 5 tests pass.
- `test/score/RustScorerIntegration.ts` — 4 tests pass.
- `test/score/BatchRustScorerBridge.ts` — 10 tests pass.
- `test/architecture/Fitness*.ts` — 31 tests pass.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2745 -->