### PR TITLE
Pin semgrep/semgrep container image to sha256 digest (#2743)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,7 +12,10 @@ jobs:
     name: Semgrep SAST scan
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      # semgrep/semgrep:latest as of 2026-05-22 (multi-arch index digest).
+      # Pinned to close the supply-chain hole on SEMGREP_APP_TOKEN — see #2743.
+      # Bump alongside dependabot/renovate updates; quarantine policy: 24h.
+      image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
     steps:
       # actions/checkout@v4.3.1
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.37",
+  "version": "5.0.38",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2743.md
+++ b/docs/archive/pr-summaries/pr-summary-2743.md
@@ -1,0 +1,65 @@
+## Summary
+
+Pin the `semgrep/semgrep` container image in `.github/workflows/semgrep.yml` to an immutable `sha256:` digest, closing the supply-chain hole on `SEMGREP_APP_TOKEN`. A bare `image: semgrep/semgrep` resolved to whatever the registry's `:latest` pointer happened to reference at runner-pull time; a takeover or compromised push of that tag would have executed attacker code with the secret in scope. Adds a regression test that scans every workflow file and asserts each `container.image:` reference is pinned to `@sha256:<64-hex>`. Closes #2743.
+
+## Evidence
+
+Workflow diff:
+
+```yaml
+container:
+  # semgrep/semgrep:latest as of 2026-05-22 (multi-arch index digest).
+  # Pinned to close the supply-chain hole on SEMGREP_APP_TOKEN — see #2743.
+  # Bump alongside dependabot/renovate updates; quarantine policy: 24h.
+  image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
+```
+
+The pinned digest is the multi-architecture OCI index for `semgrep/semgrep:latest` as published 2026-05-22, satisfying the 24h quarantine window (Issue #1613) on today's date (2026-05-24). The image is external (not under `stSoftwareAU/*`), so the quarantine applies.
+
+Supply-chain attack surface, before and after:
+
+```mermaid
+flowchart LR
+    subgraph Before["Before #2743"]
+        A1[PR opens] --> A2[Runner pulls 'semgrep/semgrep']
+        A2 --> A3{Registry resolves :latest}
+        A3 -- compromised --> A4[Attacker container starts\nwith SEMGREP_APP_TOKEN]
+        A4 --> A5[Token exfiltrated]
+    end
+    subgraph After["After #2743"]
+        B1[PR opens] --> B2[Runner pulls\nsemgrep/semgrep@sha256:7cad…]
+        B2 --> B3{Digest matches?}
+        B3 -- yes --> B4[Known-good container]
+        B3 -- no --> B5[Pull fails, job aborts]
+    end
+```
+
+Tests:
+
+```
+running 6 tests from ./test/ci/WorkflowContainerImagePinning.ts
+extractContainerImages parses the long `container:\n  image:` form ... ok
+extractContainerImages parses the `container: name` shorthand ... ok
+extractContainerImages parses `services.x.image:` references ... ok
+extractContainerImages ignores `container:` mapping headers without inline image ... ok
+every workflow `container.image:` is pinned to a sha256 digest (Issue #2743) ... ok
+semgrep.yml container image is pinned (Issue #2743 regression) ... ok
+
+ok | 6 passed | 0 failed
+```
+
+`./quality.sh --lint-only` passes (fmt, lint, shellcheck).
+
+## Test Plan
+
+- Added `test/ci/WorkflowContainerImagePinning.ts` with six tests:
+  - Four unit tests covering the `extractContainerImages` parser (long form, shorthand, `services.*.image:`, and ignoring bare `container:` mapping headers).
+  - One workflow-scan test asserting every `container.image:` in `.github/workflows/*.y*ml` ends in `@sha256:<64-hex>`. This is the long-term guard — any future workflow that introduces an unpinned image will fail CI.
+  - One narrowly-scoped regression test asserting `semgrep.yml` pins `semgrep/semgrep` specifically.
+- Existing `test/ci/SemgrepRulePacks.ts` continues to pass — the rule-pack flags are unchanged.
+- Existing `test/ci/WorkflowActionPinning.ts` continues to pass — the `actions/checkout@<SHA>` pin is unchanged.
+
+## Notes for Reviewers
+
+- The digest is the multi-arch OCI image index, not a per-architecture manifest, so it resolves correctly on the `ubuntu-latest` (amd64) runner without locking out future arm64 runners.
+- The `extractContainerImages` parser is intentionally lightweight (line-by-line regex, strips trailing comments) rather than a full YAML parser. The risk of a false negative is mitigated by the four parser unit tests; the shape of GitHub Actions workflows is narrow enough that a regex is appropriate here and consistent with the sibling `extractUses` / `extractSemgrepConfigs` helpers.

--- a/docs/archive/pr-summaries/pr-summary-2743.md
+++ b/docs/archive/pr-summaries/pr-summary-2743.md
@@ -1,6 +1,13 @@
 ## Summary
 
-Pin the `semgrep/semgrep` container image in `.github/workflows/semgrep.yml` to an immutable `sha256:` digest, closing the supply-chain hole on `SEMGREP_APP_TOKEN`. A bare `image: semgrep/semgrep` resolved to whatever the registry's `:latest` pointer happened to reference at runner-pull time; a takeover or compromised push of that tag would have executed attacker code with the secret in scope. Adds a regression test that scans every workflow file and asserts each `container.image:` reference is pinned to `@sha256:<64-hex>`. Closes #2743.
+Pin the `semgrep/semgrep` container image in `.github/workflows/semgrep.yml` to
+an immutable `sha256:` digest, closing the supply-chain hole on
+`SEMGREP_APP_TOKEN`. A bare `image: semgrep/semgrep` resolved to whatever the
+registry's `:latest` pointer happened to reference at runner-pull time; a
+takeover or compromised push of that tag would have executed attacker code with
+the secret in scope. Adds a regression test that scans every workflow file and
+asserts each `container.image:` reference is pinned to `@sha256:<64-hex>`.
+Closes #2743.
 
 ## Evidence
 
@@ -14,7 +21,10 @@ container:
   image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 ```
 
-The pinned digest is the multi-architecture OCI index for `semgrep/semgrep:latest` as published 2026-05-22, satisfying the 24h quarantine window (Issue #1613) on today's date (2026-05-24). The image is external (not under `stSoftwareAU/*`), so the quarantine applies.
+The pinned digest is the multi-architecture OCI index for
+`semgrep/semgrep:latest` as published 2026-05-22, satisfying the 24h quarantine
+window (Issue #1613) on today's date (2026-05-24). The image is external (not
+under `stSoftwareAU/*`), so the quarantine applies.
 
 Supply-chain attack surface, before and after:
 
@@ -53,13 +63,26 @@ ok | 6 passed | 0 failed
 ## Test Plan
 
 - Added `test/ci/WorkflowContainerImagePinning.ts` with six tests:
-  - Four unit tests covering the `extractContainerImages` parser (long form, shorthand, `services.*.image:`, and ignoring bare `container:` mapping headers).
-  - One workflow-scan test asserting every `container.image:` in `.github/workflows/*.y*ml` ends in `@sha256:<64-hex>`. This is the long-term guard — any future workflow that introduces an unpinned image will fail CI.
-  - One narrowly-scoped regression test asserting `semgrep.yml` pins `semgrep/semgrep` specifically.
-- Existing `test/ci/SemgrepRulePacks.ts` continues to pass — the rule-pack flags are unchanged.
-- Existing `test/ci/WorkflowActionPinning.ts` continues to pass — the `actions/checkout@<SHA>` pin is unchanged.
+  - Four unit tests covering the `extractContainerImages` parser (long form,
+    shorthand, `services.*.image:`, and ignoring bare `container:` mapping
+    headers).
+  - One workflow-scan test asserting every `container.image:` in
+    `.github/workflows/*.y*ml` ends in `@sha256:<64-hex>`. This is the long-term
+    guard — any future workflow that introduces an unpinned image will fail CI.
+  - One narrowly-scoped regression test asserting `semgrep.yml` pins
+    `semgrep/semgrep` specifically.
+- Existing `test/ci/SemgrepRulePacks.ts` continues to pass — the rule-pack flags
+  are unchanged.
+- Existing `test/ci/WorkflowActionPinning.ts` continues to pass — the
+  `actions/checkout@<SHA>` pin is unchanged.
 
 ## Notes for Reviewers
 
-- The digest is the multi-arch OCI image index, not a per-architecture manifest, so it resolves correctly on the `ubuntu-latest` (amd64) runner without locking out future arm64 runners.
-- The `extractContainerImages` parser is intentionally lightweight (line-by-line regex, strips trailing comments) rather than a full YAML parser. The risk of a false negative is mitigated by the four parser unit tests; the shape of GitHub Actions workflows is narrow enough that a regex is appropriate here and consistent with the sibling `extractUses` / `extractSemgrepConfigs` helpers.
+- The digest is the multi-arch OCI image index, not a per-architecture manifest,
+  so it resolves correctly on the `ubuntu-latest` (amd64) runner without locking
+  out future arm64 runners.
+- The `extractContainerImages` parser is intentionally lightweight (line-by-line
+  regex, strips trailing comments) rather than a full YAML parser. The risk of a
+  false negative is mitigated by the four parser unit tests; the shape of GitHub
+  Actions workflows is narrow enough that a regex is appropriate here and
+  consistent with the sibling `extractUses` / `extractSemgrepConfigs` helpers.

--- a/test/ci/WorkflowContainerImagePinning.ts
+++ b/test/ci/WorkflowContainerImagePinning.ts
@@ -1,0 +1,166 @@
+/**
+ * Issue #2743 — every `container.image:` reference in
+ * `.github/workflows/*.y*ml` must pin to an immutable `@sha256:<digest>`
+ * rather than a moving tag such as `:latest`, `:v1`, or a bare image name.
+ *
+ * Container images are at least as supply-chain-sensitive as actions:
+ * `.github/workflows/semgrep.yml` runs the SAST job inside `image:
+ * semgrep/semgrep` while injecting `SEMGREP_APP_TOKEN`. A compromised
+ * push to the upstream tag would execute attacker code with that secret in
+ * scope. SHA-pinning the image closes the same gap that 40-char SHAs close
+ * for `uses:` references.
+ *
+ * This test scans every workflow file and asserts that any `container:`
+ * block (either `container: image: foo` shorthand or the long
+ * `container:\n  image: foo` form) is pinned to a `sha256:` digest.
+ */
+
+import { assert, assertMatch } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const WORKFLOWS_DIR = join(REPO_ROOT, ".github/workflows");
+
+interface ImageRef {
+  workflow: string;
+  image: string;
+  line: number;
+}
+
+/**
+ * Extract every container `image:` reference from a workflow source.
+ *
+ * Matches both the `container: image: foo` shorthand and the long
+ * `container:\n  image: foo` form. Also picks up `services.*.image:`
+ * which is the same supply-chain surface.
+ */
+export function extractContainerImages(source: string): ImageRef[] {
+  const out: ImageRef[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Strip trailing comments before matching.
+    const code = line.replace(/#.*$/, "");
+
+    // Long form: `image: name` (under `container:` or `services.x:`).
+    const longMatch = code.match(/^\s*image:\s*['"]?([^'"\s]+)['"]?\s*$/);
+    if (longMatch) {
+      out.push({ workflow: "", image: longMatch[1], line: i + 1 });
+      continue;
+    }
+
+    // Shorthand: `container: name` (no nested image: key).
+    const shortMatch = code.match(
+      /^\s*container:\s*['"]?([^'"\s{][^'"\s]*)['"]?\s*$/,
+    );
+    if (shortMatch) {
+      out.push({ workflow: "", image: shortMatch[1], line: i + 1 });
+    }
+  }
+  return out;
+}
+
+async function listWorkflowFiles(): Promise<string[]> {
+  const names: string[] = [];
+  for await (const entry of Deno.readDir(WORKFLOWS_DIR)) {
+    if (!entry.isFile) continue;
+    if (!/\.ya?ml$/.test(entry.name)) continue;
+    names.push(entry.name);
+  }
+  names.sort();
+  return names;
+}
+
+async function readAllWorkflows(): Promise<
+  { name: string; source: string }[]
+> {
+  const files = await listWorkflowFiles();
+  const reads = files.map(async (name) => ({
+    name,
+    source: await Deno.readTextFile(join(WORKFLOWS_DIR, name)),
+  }));
+  return await Promise.all(reads);
+}
+
+Deno.test("extractContainerImages parses the long `container:\\n  image:` form", () => {
+  const src = [
+    "jobs:",
+    "  semgrep:",
+    "    container:",
+    "      image: semgrep/semgrep@sha256:abc",
+  ].join("\n");
+  const refs = extractContainerImages(src);
+  assert(refs.length === 1, `expected 1 image ref, got ${refs.length}`);
+  assert(refs[0].image === "semgrep/semgrep@sha256:abc");
+  assert(refs[0].line === 4);
+});
+
+Deno.test("extractContainerImages parses the `container: name` shorthand", () => {
+  const src = "    container: alpine:3.20\n";
+  const refs = extractContainerImages(src);
+  assert(refs.length === 1);
+  assert(refs[0].image === "alpine:3.20");
+});
+
+Deno.test("extractContainerImages parses `services.x.image:` references", () => {
+  const src = [
+    "    services:",
+    "      postgres:",
+    "        image: postgres@sha256:deadbeef",
+  ].join("\n");
+  const refs = extractContainerImages(src);
+  assert(refs.length === 1);
+  assert(refs[0].image === "postgres@sha256:deadbeef");
+});
+
+Deno.test("extractContainerImages ignores `container:` mapping headers without inline image", () => {
+  const src = [
+    "    container:",
+    "      image: foo@sha256:abc",
+    "      env:",
+    "        FOO: bar",
+  ].join("\n");
+  const refs = extractContainerImages(src);
+  // Only the image: line should be captured, not the `container:` mapping
+  // header (which is followed by a child key, not a value).
+  assert(refs.length === 1, `expected 1 ref, got ${refs.length}`);
+  assert(refs[0].image === "foo@sha256:abc");
+});
+
+Deno.test(
+  "every workflow `container.image:` is pinned to a sha256 digest (Issue #2743)",
+  async () => {
+    const workflows = await readAllWorkflows();
+    assert(workflows.length > 0, "expected at least one workflow file");
+    for (const { name, source } of workflows) {
+      const refs = extractContainerImages(source);
+      for (const r of refs) {
+        assertMatch(
+          r.image,
+          /@sha256:[0-9a-f]{64}$/,
+          `${name}: container image '${r.image}' on line ${r.line} must be pinned to '@sha256:<64-hex>' to prevent supply-chain attacks on the runner secrets`,
+        );
+      }
+    }
+  },
+);
+
+Deno.test(
+  "semgrep.yml container image is pinned (Issue #2743 regression)",
+  async () => {
+    const path = join(WORKFLOWS_DIR, "semgrep.yml");
+    const source = await Deno.readTextFile(path);
+    const refs = extractContainerImages(source);
+    assert(
+      refs.length >= 1,
+      "expected at least one container image ref in semgrep.yml",
+    );
+    const semgrep = refs.find((r) => r.image.startsWith("semgrep/semgrep"));
+    assert(semgrep, "expected a semgrep/semgrep container image ref");
+    assertMatch(
+      semgrep.image,
+      /^semgrep\/semgrep@sha256:[0-9a-f]{64}$/,
+      `semgrep.yml image must pin semgrep/semgrep to a sha256 digest, got '${semgrep.image}'`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Pin the `semgrep/semgrep` container image in `.github/workflows/semgrep.yml` to an immutable `sha256:` digest, closing the supply-chain hole on `SEMGREP_APP_TOKEN`. A bare `image: semgrep/semgrep` resolved to whatever the registry's `:latest` pointer happened to reference at runner-pull time; a takeover or compromised push of that tag would have executed attacker code with the secret in scope. Adds a regression test that scans every workflow file and asserts each `container.image:` reference is pinned to `@sha256:<64-hex>`. Closes #2743.

## Evidence

Workflow diff:

```yaml
container:
  # semgrep/semgrep:latest as of 2026-05-22 (multi-arch index digest).
  # Pinned to close the supply-chain hole on SEMGREP_APP_TOKEN — see #2743.
  # Bump alongside dependabot/renovate updates; quarantine policy: 24h.
  image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
```

The pinned digest is the multi-architecture OCI index for `semgrep/semgrep:latest` as published 2026-05-22, satisfying the 24h quarantine window (Issue #1613) on today's date (2026-05-24). The image is external (not under `stSoftwareAU/*`), so the quarantine applies.

Supply-chain attack surface, before and after:

```mermaid
flowchart LR
    subgraph Before["Before #2743"]
        A1[PR opens] --> A2[Runner pulls 'semgrep/semgrep']
        A2 --> A3{Registry resolves :latest}
        A3 -- compromised --> A4[Attacker container starts\nwith SEMGREP_APP_TOKEN]
        A4 --> A5[Token exfiltrated]
    end
    subgraph After["After #2743"]
        B1[PR opens] --> B2[Runner pulls\nsemgrep/semgrep@sha256:7cad…]
        B2 --> B3{Digest matches?}
        B3 -- yes --> B4[Known-good container]
        B3 -- no --> B5[Pull fails, job aborts]
    end
```

Tests:

```
running 6 tests from ./test/ci/WorkflowContainerImagePinning.ts
extractContainerImages parses the long `container:\n  image:` form ... ok
extractContainerImages parses the `container: name` shorthand ... ok
extractContainerImages parses `services.x.image:` references ... ok
extractContainerImages ignores `container:` mapping headers without inline image ... ok
every workflow `container.image:` is pinned to a sha256 digest (Issue #2743) ... ok
semgrep.yml container image is pinned (Issue #2743 regression) ... ok

ok | 6 passed | 0 failed
```

`./quality.sh --lint-only` passes (fmt, lint, shellcheck).

## Test Plan

- Added `test/ci/WorkflowContainerImagePinning.ts` with six tests:
  - Four unit tests covering the `extractContainerImages` parser (long form, shorthand, `services.*.image:`, and ignoring bare `container:` mapping headers).
  - One workflow-scan test asserting every `container.image:` in `.github/workflows/*.y*ml` ends in `@sha256:<64-hex>`. This is the long-term guard — any future workflow that introduces an unpinned image will fail CI.
  - One narrowly-scoped regression test asserting `semgrep.yml` pins `semgrep/semgrep` specifically.
- Existing `test/ci/SemgrepRulePacks.ts` continues to pass — the rule-pack flags are unchanged.
- Existing `test/ci/WorkflowActionPinning.ts` continues to pass — the `actions/checkout@<SHA>` pin is unchanged.

## Notes for Reviewers

- The digest is the multi-arch OCI image index, not a per-architecture manifest, so it resolves correctly on the `ubuntu-latest` (amd64) runner without locking out future arm64 runners.
- The `extractContainerImages` parser is intentionally lightweight (line-by-line regex, strips trailing comments) rather than a full YAML parser. The risk of a false negative is mitigated by the four parser unit tests; the shape of GitHub Actions workflows is narrow enough that a regex is appropriate here and consistent with the sibling `extractUses` / `extractSemgrepConfigs` helpers.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2743 -->