### PR TITLE
generation_complete emits averageFitness: NaN when verbose is false (Issue #2753)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.38",
+  "version": "5.0.39",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2753.md
+++ b/docs/archive/pr-summaries/pr-summary-2753.md
@@ -1,0 +1,54 @@
+# PR Summary — Issue #2753
+
+## Summary
+
+`generation_complete` training events emitted `averageFitness: NaN` on the
+default code path (`verbose: false`), because `makeElitists()` only computed the
+population mean when `verbose === true`. Downstream consumers (loggers, charts,
+TSV exports) could not distinguish "average not computed" from a genuine
+numerical failure, and `.toFixed()` / JSON serialisation surfaced `NaN` to
+operators.
+
+This applies **Option 1** from the issue: the population average is now always
+computed for `generation_complete`. The `verbose` flag continues to control only
+the per-creature training log emitted by `logVerbose()`, not whether the
+aggregate is available to telemetry — matching how `bestFitness` is always
+populated.
+
+Changes:
+
+- `src/architecture/ElitismUtils.ts`: extracted a `computeAverageScore()` helper
+  that sums `creature.score` over the population. `makeElitists()` now always
+  calls it to populate `averageScore`; `verbose` only gates `logVerbose()`.
+- `src/config/TrainingEvent.ts`: clarified the `averageFitness` doc comment — it
+  is always a finite number, independent of `verbose`.
+
+Closes #2753.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via unit tests
+(see Test Plan). The `./quality.sh` gate passed cleanly: `6865 passed | 0 failed`.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    Pop[Population] --> CAS[computeAverageScore<br/>always runs]
+    CAS --> R[ElitistsResults.averageScore<br/>finite]
+    Pop -. verbose only .-> LV[logVerbose<br/>per-creature log]
+    R --> EV[generation_complete<br/>averageFitness: finite]
+```
+
+## Test Plan
+
+- `test/architecture/ElitismUtils.ts`:
+  - Added `computeAverageScore` tests (mean, single creature, empty-population throw).
+  - Updated the former `averageScore is NaN when not verbose` test (which
+    documented the old buggy behaviour) to
+    `averageScore is computed when not verbose`, asserting a finite mean of `0.7`.
+- `test/config/TrainingEvent.ts`:
+  - Added regression test `averageFitness is finite when verbose is false
+    (Issue #2753)`, evolving with `verbose` omitted and asserting every
+    `generation_complete` event has a finite `averageFitness`.
+- Full `./quality.sh` gate passed (lint, format, type-check, WASM sync, all tests).

--- a/docs/archive/pr-summaries/pr-summary-2753.md
+++ b/docs/archive/pr-summaries/pr-summary-2753.md
@@ -28,7 +28,8 @@ Closes #2753.
 ## Evidence
 
 Backend/CLI change — no web interface to screenshot. Verified via unit tests
-(see Test Plan). The `./quality.sh` gate passed cleanly: `6865 passed | 0 failed`.
+(see Test Plan). The `./quality.sh` gate passed cleanly:
+`6865 passed | 0 failed`.
 
 ### Data flow
 
@@ -43,12 +44,17 @@ flowchart LR
 ## Test Plan
 
 - `test/architecture/ElitismUtils.ts`:
-  - Added `computeAverageScore` tests (mean, single creature, empty-population throw).
+  - Added `computeAverageScore` tests (mean, single creature, empty-population
+    throw).
   - Updated the former `averageScore is NaN when not verbose` test (which
     documented the old buggy behaviour) to
-    `averageScore is computed when not verbose`, asserting a finite mean of `0.7`.
+    `averageScore is computed when not verbose`, asserting a finite mean of
+    `0.7`.
 - `test/config/TrainingEvent.ts`:
-  - Added regression test `averageFitness is finite when verbose is false
-    (Issue #2753)`, evolving with `verbose` omitted and asserting every
-    `generation_complete` event has a finite `averageFitness`.
-- Full `./quality.sh` gate passed (lint, format, type-check, WASM sync, all tests).
+  - Added regression test
+    `averageFitness is finite when verbose is false
+    (Issue #2753)`, evolving
+    with `verbose` omitted and asserting every `generation_complete` event has a
+    finite `averageFitness`.
+- Full `./quality.sh` gate passed (lint, format, type-check, WASM sync, all
+  tests).

--- a/src/architecture/ElitismUtils.ts
+++ b/src/architecture/ElitismUtils.ts
@@ -21,10 +21,10 @@ export function makeElitists(
 
   const result: ElitistsResults = {
     elitists: [],
-    averageScore: NaN,
+    averageScore: computeAverageScore(creatures),
   };
   if (verbose) {
-    result.averageScore = logVerbose(creatures);
+    logVerbose(creatures);
   }
 
   const elitism = Math.min(size, creatures.length);
@@ -40,6 +40,25 @@ export function sortCreaturesByScore(creatures: Creature[]): Creature[] {
   });
 
   return creatures;
+}
+
+/**
+ * Computes the mean of `creature.score` across the population. This is always
+ * available to telemetry (e.g. the `generation_complete` event's
+ * `averageFitness`) regardless of the `verbose` flag, which now only controls
+ * the per-creature training log emitted by {@link logVerbose}.
+ */
+export function computeAverageScore(creatures: Creature[]): number {
+  assert(creatures.length > 0, "Population must have creatures");
+
+  let totalScore = 0;
+  for (const creature of creatures) {
+    const score = creature.score;
+    assert(score !== undefined, "Creature must have a score");
+    totalScore += score;
+  }
+
+  return totalScore / creatures.length;
 }
 
 export function logVerbose(creatures: Creature[]): number {

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -308,7 +308,11 @@ export interface GenerationCompleteEvent {
   readonly generation: number;
   /** The best fitness score in this generation. */
   readonly bestFitness: number;
-  /** The average fitness score across the population. */
+  /**
+   * The average fitness score across the population. Always a finite number;
+   * computed for every generation independent of the `verbose` flag (Issue
+   * #2753).
+   */
   readonly averageFitness: number;
   /** Current population size. */
   readonly populationSize: number;

--- a/test/architecture/ElitismUtils.ts
+++ b/test/architecture/ElitismUtils.ts
@@ -9,6 +9,7 @@ import { assert, assertEquals, assertThrows } from "@std/assert";
 import { addTag, getTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
 import {
+  computeAverageScore,
   logVerbose,
   makeElitists,
   sortCreaturesByScore,
@@ -147,14 +148,22 @@ Deno.test("makeElitists - throws for non-integer size", () => {
   );
 });
 
-Deno.test("makeElitists - averageScore is NaN when not verbose", () => {
-  const creatures = [makeScoredCreature(0.5)];
+// Issue #2753: averageScore is now always computed, even when verbose is false,
+// so the public `generation_complete` event never emits NaN. The previous test
+// documented the old (buggy) NaN-when-not-verbose behaviour and has been
+// updated to assert the finite average is always available.
+Deno.test("makeElitists - averageScore is computed when not verbose", () => {
+  const creatures = [
+    makeScoredCreature(0.8),
+    makeScoredCreature(0.6),
+  ];
   const result = makeElitists(creatures, 1, false);
 
   assert(
-    Number.isNaN(result.averageScore),
-    "averageScore should be NaN when not verbose",
+    Number.isFinite(result.averageScore),
+    "averageScore should be finite when not verbose",
   );
+  assertEquals(result.averageScore, 0.7);
 });
 
 Deno.test("makeElitists - averageScore is computed when verbose", () => {
@@ -166,6 +175,30 @@ Deno.test("makeElitists - averageScore is computed when verbose", () => {
   const result = makeElitists(creatures, 1, true);
 
   assertEquals(result.averageScore, 0.7);
+});
+
+// --- computeAverageScore tests (Issue #2753) ---
+
+Deno.test("computeAverageScore - returns mean of population scores", () => {
+  const creatures = [
+    makeScoredCreature(0.8),
+    makeScoredCreature(0.6),
+    makeScoredCreature(0.4),
+  ];
+
+  assertEquals(computeAverageScore(creatures), 0.6);
+});
+
+Deno.test("computeAverageScore - single creature returns its score", () => {
+  assertEquals(computeAverageScore([makeScoredCreature(0.42)]), 0.42);
+});
+
+Deno.test("computeAverageScore - throws for empty population", () => {
+  assertThrows(
+    () => computeAverageScore([]),
+    Error,
+    "Population must have creatures",
+  );
 });
 
 // --- logVerbose tests ---

--- a/test/config/TrainingEvent.ts
+++ b/test/config/TrainingEvent.ts
@@ -59,6 +59,40 @@ Deno.test("TrainingEvent - generation_complete events are emitted", async () => 
   assert(!isNaN(parsed.getTime()), "Timestamp should be valid ISO-8601");
 });
 
+Deno.test("TrainingEvent - averageFitness is finite when verbose is false (Issue #2753)", async () => {
+  const events: GenerationCompleteEvent[] = [];
+
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([1]) },
+  ];
+
+  const creature = new Creature(2, 1);
+
+  await creature.evolveDataSet(trainingSet, {
+    mutation: Mutation.FFW,
+    iterations: 5,
+    targetError: 0.001,
+    populationSize: 10,
+    threads: 1,
+    // verbose deliberately omitted (defaults to false) — the default code path.
+    onTrainingEvent: (event) => {
+      if (event.kind === "generation_complete") {
+        events.push(event);
+      }
+    },
+  });
+
+  assertGreater(events.length, 0, "Should emit generation_complete events");
+
+  for (const event of events) {
+    assert(
+      Number.isFinite(event.averageFitness),
+      `averageFitness must be finite, got ${event.averageFitness}`,
+    );
+  }
+});
+
 Deno.test("TrainingEvent - generation numbers are sequential", async () => {
   const events: GenerationCompleteEvent[] = [];
 


### PR DESCRIPTION
# PR Summary — Issue #2753

## Summary

`generation_complete` training events emitted `averageFitness: NaN` on the
default code path (`verbose: false`), because `makeElitists()` only computed the
population mean when `verbose === true`. Downstream consumers (loggers, charts,
TSV exports) could not distinguish "average not computed" from a genuine
numerical failure, and `.toFixed()` / JSON serialisation surfaced `NaN` to
operators.

This applies **Option 1** from the issue: the population average is now always
computed for `generation_complete`. The `verbose` flag continues to control only
the per-creature training log emitted by `logVerbose()`, not whether the
aggregate is available to telemetry — matching how `bestFitness` is always
populated.

Changes:

- `src/architecture/ElitismUtils.ts`: extracted a `computeAverageScore()` helper
  that sums `creature.score` over the population. `makeElitists()` now always
  calls it to populate `averageScore`; `verbose` only gates `logVerbose()`.
- `src/config/TrainingEvent.ts`: clarified the `averageFitness` doc comment — it
  is always a finite number, independent of `verbose`.

Closes #2753.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via unit tests
(see Test Plan). The `./quality.sh` gate passed cleanly: `6865 passed | 0 failed`.

### Data flow

```mermaid
flowchart LR
    Pop[Population] --> CAS[computeAverageScore<br/>always runs]
    CAS --> R[ElitistsResults.averageScore<br/>finite]
    Pop -. verbose only .-> LV[logVerbose<br/>per-creature log]
    R --> EV[generation_complete<br/>averageFitness: finite]
```

## Test Plan

- `test/architecture/ElitismUtils.ts`:
  - Added `computeAverageScore` tests (mean, single creature, empty-population throw).
  - Updated the former `averageScore is NaN when not verbose` test (which
    documented the old buggy behaviour) to
    `averageScore is computed when not verbose`, asserting a finite mean of `0.7`.
- `test/config/TrainingEvent.ts`:
  - Added regression test `averageFitness is finite when verbose is false
    (Issue #2753)`, evolving with `verbose` omitted and asserting every
    `generation_complete` event has a finite `averageFitness`.
- Full `./quality.sh` gate passed (lint, format, type-check, WASM sync, all tests).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2753 -->