### PR TITLE
ci: add actionlint workflow as github-actions lint gate (#2762)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,41 @@
+name: Actionlint
+
+# Lint every GitHub Actions workflow file on push and pull request so
+# regressions in `.github/workflows/*.y*ml` fail the build before they
+# merge (Issue #2762). actionlint catches mistyped expressions, missing
+# permission blocks, unsupported runners, shell-script issues inside
+# `run:` blocks, and many other workflow-only foot-guns that no other
+# linter in this repo covers.
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [Develop, main, master]
+
+# Least-privilege GITHUB_TOKEN scopes (Issue #2706). actionlint only
+# reads files; no write access is required.
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      # Wraps rhysd/actionlint and pins the underlying binary by release.
+      # The SHA below is pinned to v2.1.2 per Issue #2696 so a re-tagged
+      # release cannot silently change the action body. Bump alongside
+      # dependabot updates; quarantine policy is 24h (Issue #2742).
+      - name: Run actionlint
+        # raven-actions/actionlint@v2.1.2
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8
+        with:
+          # Fail the job on any actionlint finding. Default is to fail
+          # only on errors; we treat warnings as errors too so reviewers
+          # see them before merge.
+          fail-on-error: true

--- a/docs/archive/pr-summaries/pr-summary-2762.md
+++ b/docs/archive/pr-summaries/pr-summary-2762.md
@@ -1,0 +1,56 @@
+# Add CI lint gate for `github-actions` bucket
+
+## Summary
+
+Adds `.github/workflows/actionlint.yml`, a CI lint gate that runs the standard
+GitHub Actions linter (`actionlint`) on every push and pull request so workflow
+regressions fail the build before they merge. Without this gate, mistakes in any
+other workflow file (mistyped expressions, missing `permissions:` blocks,
+unsupported runner labels, shell-script issues inside `run:` blocks) would only
+surface the next time that workflow runs — often long after the offending PR
+merged.
+
+Closes #2762.
+
+## Deno regression avoided
+
+The new lint gate was wired up entirely with GitHub Actions and the existing
+Deno-based CI helpers — no `package.json`, `npx`, or other Node-only tooling was
+introduced.
+
+## Evidence
+
+This is a CI-only change (no UI, no runtime hot path), so evidence is the new
+tests under `test/ci/ActionlintWorkflow.ts` which pin down the expected shape of
+the workflow:
+
+- The workflow file exists at `.github/workflows/actionlint.yml`.
+- It triggers on both `pull_request` and `push`.
+- It declares a least-privilege `contents: read` permission block.
+- At least one step invokes `actionlint` (via `raven-actions/actionlint`).
+- It checks out the repository before linting.
+
+All 43 tests under `test/ci/` continue to pass, including the existing
+`WorkflowActionPinning` and `WorkflowContainerImagePinning` invariants that the
+new workflow respects.
+
+```mermaid
+flowchart LR
+    A[push / PR] --> B[actionlint.yml]
+    B --> C[checkout repo<br/>persist-credentials: false]
+    C --> D[raven-actions/actionlint@v2.1.2<br/>pinned to 40-char SHA]
+    D --> E{findings?}
+    E -- yes --> F[fail build]
+    E -- no --> G[pass]
+```
+
+## Test Plan
+
+- Added `test/ci/ActionlintWorkflow.ts` with five assertions covering file
+  existence, triggers, permissions, the actionlint invocation, and the checkout
+  step.
+- Verified the new workflow is pinned to a 40-char commit SHA with a
+  resolved-tag comment, so the existing `WorkflowActionPinning` test (Issue
+  #2696) keeps passing.
+- Ran `deno fmt`, `deno lint`, and `deno check` on the new files.
+- Ran the full `test/ci/` suite: 43 passed, 0 failed.

--- a/test/ci/ActionlintWorkflow.ts
+++ b/test/ci/ActionlintWorkflow.ts
@@ -1,0 +1,139 @@
+/**
+ * Issue #2762 — `.github/workflows/actionlint.yml` is the CI lint gate
+ * for the `github-actions` bucket. It runs the standard GitHub Actions
+ * linter (`actionlint`) on every push and pull request so that workflow
+ * regressions fail the build before they land.
+ *
+ * Without this gate, a regression in any other workflow file (e.g. a
+ * mistyped expression, a missing `permissions:` block, an unpinned
+ * third-party action) would only be discovered the next time that
+ * workflow runs — long after the offending PR has merged.
+ *
+ * This test pins down the expected shape of the workflow so the gate
+ * cannot be silently removed or downgraded:
+ *
+ *   1. The file exists at `.github/workflows/actionlint.yml`.
+ *   2. It triggers on both `pull_request` and `push`.
+ *   3. At least one job runs the `actionlint` binary (either via an
+ *      action wrapper or by invoking the binary directly).
+ *   4. It declares a read-only `contents: read` permission block so the
+ *      job runs under least-privilege (consistent with the other lint
+ *      workflows in this repo — see Issue #2706).
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const WORKFLOW_PATH = join(REPO_ROOT, ".github/workflows/actionlint.yml");
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+}
+
+interface Job {
+  "runs-on"?: string;
+  steps?: Step[];
+}
+
+interface Workflow {
+  name?: string;
+  on?: unknown;
+  permissions?: Record<string, string>;
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  return parse(text) as Workflow;
+}
+
+Deno.test("actionlint workflow file exists (Issue #2762)", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} must be a regular file`);
+});
+
+Deno.test(
+  "actionlint workflow triggers on both pull_request and push (Issue #2762)",
+  async () => {
+    const wf = await readWorkflow();
+    assert(wf.on, "actionlint workflow must declare an `on:` trigger");
+    const triggers = wf.on as Record<string, unknown>;
+    assert(
+      "pull_request" in triggers,
+      "actionlint workflow must trigger on pull_request",
+    );
+    assert(
+      "push" in triggers,
+      "actionlint workflow must trigger on push",
+    );
+  },
+);
+
+Deno.test(
+  "actionlint workflow declares read-only contents permission (Issue #2762)",
+  async () => {
+    const wf = await readWorkflow();
+    assert(
+      wf.permissions,
+      "actionlint workflow must declare a top-level `permissions:` block",
+    );
+    assertEquals(
+      wf.permissions.contents,
+      "read",
+      "actionlint workflow must run under least-privilege contents: read",
+    );
+  },
+);
+
+Deno.test(
+  "actionlint workflow invokes the actionlint linter (Issue #2762)",
+  async () => {
+    const wf = await readWorkflow();
+    const jobs = wf.jobs ?? {};
+    assert(
+      Object.keys(jobs).length > 0,
+      "actionlint workflow must declare at least one job",
+    );
+    let invokesActionlint = false;
+    for (const job of Object.values(jobs)) {
+      for (const step of job.steps ?? []) {
+        const usesActionlint = (step.uses ?? "").toLowerCase().includes(
+          "actionlint",
+        );
+        const runsActionlint = /\bactionlint\b/.test(step.run ?? "");
+        if (usesActionlint || runsActionlint) {
+          invokesActionlint = true;
+        }
+      }
+    }
+    assert(
+      invokesActionlint,
+      "actionlint workflow must include a step that runs actionlint " +
+        "(either via an action wrapper or by invoking the binary directly)",
+    );
+  },
+);
+
+Deno.test(
+  "actionlint workflow checks out the repository before linting (Issue #2762)",
+  async () => {
+    const wf = await readWorkflow();
+    let checksOut = false;
+    for (const job of Object.values(wf.jobs ?? {})) {
+      for (const step of job.steps ?? []) {
+        if ((step.uses ?? "").startsWith("actions/checkout@")) {
+          checksOut = true;
+        }
+      }
+    }
+    assert(
+      checksOut,
+      "actionlint workflow must check out the repository so the linter " +
+        "can read the workflow files under .github/workflows/",
+    );
+  },
+);


### PR DESCRIPTION
# Add CI lint gate for `github-actions` bucket

## Summary

Adds `.github/workflows/actionlint.yml`, a CI lint gate that runs the standard
GitHub Actions linter (`actionlint`) on every push and pull request so workflow
regressions fail the build before they merge. Without this gate, mistakes in any
other workflow file (mistyped expressions, missing `permissions:` blocks,
unsupported runner labels, shell-script issues inside `run:` blocks) would only
surface the next time that workflow runs — often long after the offending PR
merged.

Closes #2762.

## Deno regression avoided

The new lint gate was wired up entirely with GitHub Actions and the existing
Deno-based CI helpers — no `package.json`, `npx`, or other Node-only tooling was
introduced.

## Evidence

This is a CI-only change (no UI, no runtime hot path), so evidence is the new
tests under `test/ci/ActionlintWorkflow.ts` which pin down the expected shape of
the workflow:

- The workflow file exists at `.github/workflows/actionlint.yml`.
- It triggers on both `pull_request` and `push`.
- It declares a least-privilege `contents: read` permission block.
- At least one step invokes `actionlint` (via `raven-actions/actionlint`).
- It checks out the repository before linting.

All 43 tests under `test/ci/` continue to pass, including the existing
`WorkflowActionPinning` and `WorkflowContainerImagePinning` invariants that the
new workflow respects.

```mermaid
flowchart LR
    A[push / PR] --> B[actionlint.yml]
    B --> C[checkout repo<br/>persist-credentials: false]
    C --> D[raven-actions/actionlint@v2.1.2<br/>pinned to 40-char SHA]
    D --> E{findings?}
    E -- yes --> F[fail build]
    E -- no --> G[pass]
```

## Test Plan

- Added `test/ci/ActionlintWorkflow.ts` with five assertions covering file
  existence, triggers, permissions, the actionlint invocation, and the checkout
  step.
- Verified the new workflow is pinned to a 40-char commit SHA with a
  resolved-tag comment, so the existing `WorkflowActionPinning` test (Issue
  #2696) keeps passing.
- Ran `deno fmt`, `deno lint`, and `deno check` on the new files.
- Ran the full `test/ci/` suite: 43 passed, 0 failed.



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2762 -->