### PR TITLE
ci: bump actions/checkout to v6.0.2 (node24)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,8 +23,8 @@ jobs:
     name: Lint GitHub Actions workflows
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       # Wraps rhysd/actionlint and pins the underlying binary by release.

--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Deno
         # denoland/setup-deno@v2.0.4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: "Dependency Review"
         # actions/dependency-review-action@v4.9.0
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -13,8 +13,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Read version from deno.json
         id: version

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -13,8 +13,8 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v4
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       # actions/setup-node@v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       id-token: write # OIDC for JSR (provenance + tokenless publish)
     steps:
-      # actions/checkout@v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Deno
         # denoland/setup-deno@v2.0.4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -31,8 +31,8 @@ jobs:
       # re-introduced only at push time via a per-command auth header so
       # it never lives on disk.
       - name: Checkout Code
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           token: ${{ secrets.ACTIONS_PUSH }} # Use the GitHub Actions token for write access
           persist-credentials: false

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -17,8 +17,8 @@ jobs:
       # Bump alongside dependabot/renovate updates; quarantine policy: 24h.
       image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
     steps:
-      # actions/checkout@v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - run: semgrep ci --config p/default --config p/security-audit --config p/owasp-top-ten
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,8 +13,8 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       # Runs koalaman/shellcheck (https://github.com/koalaman/shellcheck) via the
       # ludeeus/action-shellcheck wrapper to lint shell scripts in the repository.
       # ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -13,8 +13,8 @@ jobs:
   spellcheck: # run the action
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       # streetsidesoftware/cspell-action@v8.4.0
       - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2
         with:

--- a/.github/workflows/update-package-version.yml
+++ b/.github/workflows/update-package-version.yml
@@ -24,8 +24,8 @@ jobs:
       # re-introduce the PAT only at push time via a per-command
       # auth header.
       - name: Checkout Code
-        # actions/checkout@v4.3.1
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           token: ${{ secrets.ACTIONS_PUSH }}
           persist-credentials: false

--- a/docs/archive/pr-summaries/pr-summary-2763.md
+++ b/docs/archive/pr-summaries/pr-summary-2763.md
@@ -1,0 +1,35 @@
+## Summary
+Bumped pinned `actions/checkout` SHA from `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1, Node 20) to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2, Node 24) across all GitHub Actions workflows to eliminate the Node 20 runner-deprecation warnings reported in #2763. Closes #2763.
+
+## Evidence
+
+This is a workflow/config change with no UI surface and no runtime behaviour change — there is nothing to screenshot. Verification:
+
+- `./quality.sh --lint-only < /dev/null` passes cleanly (formatting, linting, bash checks).
+- `grep -rn 'actions/checkout@' .github/workflows` confirms every pin now resolves to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` with a matching `# actions/checkout@v6.0.2` comment.
+- Upstream `action.yml` at `v6.0.2` declares `using: node24`, so the deprecation warning will no longer be emitted.
+
+```mermaid
+flowchart LR
+  A["v4.3.1<br/>SHA 34e114…<br/>node20 (deprecated)"] --> B["v6.0.2<br/>SHA de0fac…<br/>node24 (current)"]
+```
+
+Files updated (11):
+
+- `.github/workflows/actionlint.yml`
+- `.github/workflows/deno-outdated.yml`
+- `.github/workflows/dependency-review.yml`
+- `.github/workflows/github-release.yml`
+- `.github/workflows/markdown-lint.yml`
+- `.github/workflows/publish.yml`
+- `.github/workflows/quality.yml`
+- `.github/workflows/semgrep.yml`
+- `.github/workflows/shellcheck.yml`
+- `.github/workflows/spellcheck.yaml`
+- `.github/workflows/update-package-version.yml`
+
+`coverage.yaml` was already on `v6.0.2` and is unchanged.
+
+## Test Plan
+- [x] `./quality.sh --lint-only < /dev/null` passes
+- [ ] On merge, confirm workflow run logs no longer show `Node.js 20 actions are deprecated` for `actions/checkout`


### PR DESCRIPTION
## Summary

Bumped pinned `actions/checkout` SHA from `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1, Node 20) to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2, Node 24) across all GitHub Actions workflows to eliminate the Node 20 runner-deprecation warnings reported in #2763. Closes #2763.

## Evidence

This is a workflow/config change with no UI surface and no runtime behaviour change — there is nothing to screenshot. Verification:

- `./quality.sh --lint-only < /dev/null` passes cleanly (formatting, linting, bash checks).
- `grep -rn 'actions/checkout@' .github/workflows` confirms every pin now resolves to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` with a matching `# actions/checkout@v6.0.2` comment.
- Upstream `action.yml` at `v6.0.2` declares `using: node24`, so the deprecation warning will no longer be emitted.

```mermaid
flowchart LR
  A["v4.3.1<br/>SHA 34e114…<br/>node20 (deprecated)"] --> B["v6.0.2<br/>SHA de0fac…<br/>node24 (current)"]
```

Files updated (11):

- `.github/workflows/actionlint.yml`
- `.github/workflows/deno-outdated.yml`
- `.github/workflows/dependency-review.yml`
- `.github/workflows/github-release.yml`
- `.github/workflows/markdown-lint.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/quality.yml`
- `.github/workflows/semgrep.yml`
- `.github/workflows/shellcheck.yml`
- `.github/workflows/spellcheck.yaml`
- `.github/workflows/update-package-version.yml`

`coverage.yaml` was already on `v6.0.2` and is unchanged.

## Test Plan

- [x] `./quality.sh --lint-only < /dev/null` passes
- [ ] On merge, confirm workflow run logs no longer show `Node.js 20 actions are deprecated` for `actions/checkout`



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2763 -->