### PR TITLE
Bump softprops/action-gh-release to v3.0.0 (node24) (#2766)

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -23,8 +23,8 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        # softprops/action-gh-release@v2.6.2
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
+        # softprops/action-gh-release@v3.0.0 (node24 runtime)
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: Release v${{ steps.version.outputs.version }}

--- a/docs/archive/pr-summaries/pr-summary-2763.md
+++ b/docs/archive/pr-summaries/pr-summary-2763.md
@@ -1,13 +1,23 @@
 ## Summary
-Bumped pinned `actions/checkout` SHA from `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1, Node 20) to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2, Node 24) across all GitHub Actions workflows to eliminate the Node 20 runner-deprecation warnings reported in #2763. Closes #2763.
+
+Bumped pinned `actions/checkout` SHA from
+`34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1, Node 20) to
+`de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2, Node 24) across all GitHub
+Actions workflows to eliminate the Node 20 runner-deprecation warnings reported
+in #2763. Closes #2763.
 
 ## Evidence
 
-This is a workflow/config change with no UI surface and no runtime behaviour change — there is nothing to screenshot. Verification:
+This is a workflow/config change with no UI surface and no runtime behaviour
+change — there is nothing to screenshot. Verification:
 
-- `./quality.sh --lint-only < /dev/null` passes cleanly (formatting, linting, bash checks).
-- `grep -rn 'actions/checkout@' .github/workflows` confirms every pin now resolves to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` with a matching `# actions/checkout@v6.0.2` comment.
-- Upstream `action.yml` at `v6.0.2` declares `using: node24`, so the deprecation warning will no longer be emitted.
+- `./quality.sh --lint-only < /dev/null` passes cleanly (formatting, linting,
+  bash checks).
+- `grep -rn 'actions/checkout@' .github/workflows` confirms every pin now
+  resolves to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` with a matching
+  `# actions/checkout@v6.0.2` comment.
+- Upstream `action.yml` at `v6.0.2` declares `using: node24`, so the deprecation
+  warning will no longer be emitted.
 
 ```mermaid
 flowchart LR
@@ -31,5 +41,7 @@ Files updated (11):
 `coverage.yaml` was already on `v6.0.2` and is unchanged.
 
 ## Test Plan
+
 - [x] `./quality.sh --lint-only < /dev/null` passes
-- [ ] On merge, confirm workflow run logs no longer show `Node.js 20 actions are deprecated` for `actions/checkout`
+- [ ] On merge, confirm workflow run logs no longer show
+      `Node.js 20 actions are deprecated` for `actions/checkout`

--- a/docs/archive/pr-summaries/pr-summary-2766.md
+++ b/docs/archive/pr-summaries/pr-summary-2766.md
@@ -1,0 +1,27 @@
+## Summary
+
+Bumped pinned `softprops/action-gh-release` SHA from
+`3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` (v2.6.2, Node 20) to
+`b4309332981a82ec1c5618f44dd2e27cc8bfbfda` (v3.0.0, Node 24) in
+`.github/workflows/github-release.yml` to eliminate the Node 20
+runner-deprecation warning reported in #2766. Closes #2766.
+
+## Evidence
+
+This is a workflow/config change with no UI surface and no runtime behaviour
+change — there is nothing to screenshot. Verification:
+
+- `./quality.sh --lint-only < /dev/null` passes cleanly (formatting, linting,
+  bash checks).
+- `grep -n 'softprops/action-gh-release' .github/workflows/github-release.yml`
+  confirms the pin now resolves to
+  `b4309332981a82ec1c5618f44dd2e27cc8bfbfda` with a matching
+  `# softprops/action-gh-release@v3.0.0 (node24 runtime)` comment.
+- Upstream `action.yml` at `v3.0.0` declares `using: node24`, so the
+  deprecation warning will no longer be emitted.
+
+## Test Plan
+
+- [x] `./quality.sh --lint-only < /dev/null`
+- [ ] Confirm next push to `Develop` does not emit the Node 20 deprecation
+      warning for `softprops/action-gh-release` in the `release` job.


### PR DESCRIPTION
## Summary

Bumped pinned `softprops/action-gh-release` SHA from
`3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` (v2.6.2, Node 20) to
`b4309332981a82ec1c5618f44dd2e27cc8bfbfda` (v3.0.0, Node 24) in
`.github/workflows/github-release.yml` to eliminate the Node 20
runner-deprecation warning reported in #2766. Closes #2766.

## Evidence

This is a workflow/config change with no UI surface and no runtime behaviour
change — there is nothing to screenshot. Verification:

- `./quality.sh --lint-only < /dev/null` passes cleanly (formatting, linting,
  bash checks).
- `grep -n 'softprops/action-gh-release' .github/workflows/github-release.yml`
  confirms the pin now resolves to
  `b4309332981a82ec1c5618f44dd2e27cc8bfbfda` with a matching
  `# softprops/action-gh-release@v3.0.0 (node24 runtime)` comment.
- Upstream `action.yml` at `v3.0.0` declares `using: node24`, so the
  deprecation warning will no longer be emitted.

## Test Plan

- [x] `./quality.sh --lint-only < /dev/null`
- [ ] Confirm next push to `Develop` does not emit the Node 20 deprecation
      warning for `softprops/action-gh-release` in the `release` job.



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-2766 -->