### PR TITLE
Cost-aware evolveDir targetError early-stop and champion selection (#2787)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Issue #2787 (depends on Issue #2786):** Cost-aware `evolveDir`
+  `targetError` early-stop and champion comparison. A new pure mapping helper
+  `costNameToTaskDescriptor()` (`src/costs/CostDescriptor.ts`) gives every
+  built-in cost a canonical descriptor (topology, range, output squash family),
+  and custom JS costs collapse to the sentinel `OTHER` + neutral descriptor —
+  the user's custom name is never echoed back. `evolveDir` /
+  `evolveDataSet` / `evolveRL` now route their `error <= targetError`
+  early-stop and `fittestScore > bestScore` champion comparison through
+  `shouldEarlyStop()` / `isBetterChampion()`
+  (`src/costs/CostAwareEarlyStop.ts`) so a `targetError` of `1.5` is
+  interpreted in the cost's natural range — clamped/rejected for unit-range
+  costs like `CATEGORICAL_ERROR`, applied directly for unbounded `MSE`/`MAE`,
+  and (regression guard) passed through verbatim for `OTHER`. This is the
+  caller-side counterpart to the Discovery cost-aware thresholds
+  (`stSoftwareAU/neat-ai-discovery#1320`).
 - **Issue #2736:** New `"CATEGORICAL_ERROR"` built-in cost function for
   multi-class one-hot targets. It reports the argmax misclassification rate
   (`error = 1 - accuracy`) so `evolveDir` `error`/`score`, champion selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,20 +33,19 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **Issue #2787 (depends on Issue #2786):** Cost-aware `evolveDir`
-  `targetError` early-stop and champion comparison. A new pure mapping helper
+- **Issue #2787 (depends on Issue #2786):** Cost-aware `evolveDir` `targetError`
+  early-stop and champion comparison. A new pure mapping helper
   `costNameToTaskDescriptor()` (`src/costs/CostDescriptor.ts`) gives every
   built-in cost a canonical descriptor (topology, range, output squash family),
   and custom JS costs collapse to the sentinel `OTHER` + neutral descriptor —
-  the user's custom name is never echoed back. `evolveDir` /
-  `evolveDataSet` / `evolveRL` now route their `error <= targetError`
-  early-stop and `fittestScore > bestScore` champion comparison through
-  `shouldEarlyStop()` / `isBetterChampion()`
-  (`src/costs/CostAwareEarlyStop.ts`) so a `targetError` of `1.5` is
-  interpreted in the cost's natural range — clamped/rejected for unit-range
-  costs like `CATEGORICAL_ERROR`, applied directly for unbounded `MSE`/`MAE`,
-  and (regression guard) passed through verbatim for `OTHER`. This is the
-  caller-side counterpart to the Discovery cost-aware thresholds
+  the user's custom name is never echoed back. `evolveDir` / `evolveDataSet` /
+  `evolveRL` now route their `error <= targetError` early-stop and
+  `fittestScore > bestScore` champion comparison through `shouldEarlyStop()` /
+  `isBetterChampion()` (`src/costs/CostAwareEarlyStop.ts`) so a `targetError` of
+  `1.5` is interpreted in the cost's natural range — clamped/rejected for
+  unit-range costs like `CATEGORICAL_ERROR`, applied directly for unbounded
+  `MSE`/`MAE`, and (regression guard) passed through verbatim for `OTHER`. This
+  is the caller-side counterpart to the Discovery cost-aware thresholds
   (`stSoftwareAU/neat-ai-discovery#1320`).
 - **Issue #2736:** New `"CATEGORICAL_ERROR"` built-in cost function for
   multi-class one-hot targets. It reports the argmax misclassification rate

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.42",
+  "version": "5.0.43",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2787.md
+++ b/docs/archive/pr-summaries/pr-summary-2787.md
@@ -1,40 +1,40 @@
 ## Summary
 
 Make NEAT-AI's `evolveDir` (`evolveDataSet` / `evolveRL`) interpret
-`targetError` early-stop and champion comparison in a **cost-consistent
-way**. Before this change a `0.1` `CATEGORICAL_ERROR` (≈90 % accuracy) and
-a `0.1` `MSE` (an unbounded regression metric) were both compared with the
-same `error <= targetError` formula on a fixed scale — mis-calibrated
-stopping and selection. After this change the threshold is interpreted in
-the cost's natural range using a new pure descriptor helper.
+`targetError` early-stop and champion comparison in a **cost-consistent way**.
+Before this change a `0.1` `CATEGORICAL_ERROR` (≈90 % accuracy) and a `0.1`
+`MSE` (an unbounded regression metric) were both compared with the same
+`error <= targetError` formula on a fixed scale — mis-calibrated stopping and
+selection. After this change the threshold is interpreted in the cost's natural
+range using a new pure descriptor helper.
 
 Two small additions, one wiring change:
 
-1. **`src/costs/CostDescriptor.ts`** — pure helper that maps each built-in
-   cost to a canonical `TaskDescriptor` (topology / range / output squash
-   family) per the table in Issue #2786. Custom JS costs collapse to the
-   sentinel `OTHER` + neutral descriptor; the caller-supplied name is never
-   echoed back (leakage guard).
+1. **`src/costs/CostDescriptor.ts`** — pure helper that maps each built-in cost
+   to a canonical `TaskDescriptor` (topology / range / output squash family) per
+   the table in Issue #2786. Custom JS costs collapse to the sentinel `OTHER` +
+   neutral descriptor; the caller-supplied name is never echoed back (leakage
+   guard).
 2. **`src/costs/CostAwareEarlyStop.ts`** — `shouldEarlyStop()`,
    `calibrateTargetError()`, `isBetterChampion()`. Unit-range costs reject
-   out-of-range thresholds (defer to `iterations` / `timeoutMinutes` rather
-   than halting on a fat-fingered target). Positive-range costs reject
-   negative thresholds. Unbounded costs accept any positive threshold.
-   `OTHER` falls back to the legacy `error <= targetError` comparator — the
-   regression guard required by the issue.
+   out-of-range thresholds (defer to `iterations` / `timeoutMinutes` rather than
+   halting on a fat-fingered target). Positive-range costs reject negative
+   thresholds. Unbounded costs accept any positive threshold. `OTHER` falls back
+   to the legacy `error <= targetError` comparator — the regression guard
+   required by the issue.
 3. **`src/creature/CreatureTraining.ts`** — the three call sites for
    `evolveDir`, `evolveDataSet` and `evolveRL` now route through
-   `shouldEarlyStop()` and `isBetterChampion()` (same module, single seam
-   for future cost-specific tie-breaks such as a continuous companion
-   metric for `CATEGORICAL_ERROR`).
+   `shouldEarlyStop()` and `isBetterChampion()` (same module, single seam for
+   future cost-specific tie-breaks such as a continuous companion metric for
+   `CATEGORICAL_ERROR`).
 
 Closes #2787.
 
 ## Evidence
 
 This is a backend/library change with no UI. Verified via the new unit and
-integration tests below; all 29 new tests plus the pre-existing 63 tests
-in `test/costs/` pass.
+integration tests below; all 29 new tests plus the pre-existing 63 tests in
+`test/costs/` pass.
 
 ```mermaid
 flowchart LR
@@ -48,17 +48,17 @@ flowchart LR
 
 ### Tests pinning the cost-aware behaviour
 
-- `test/costs/CostDescriptor.ts` — every built-in maps to the row from the
-  Issue #2786 table; custom names collapse to `OTHER`; the original name is
-  not leaked back.
-- `test/costs/CostAwareEarlyStop.ts` — unit-range, signed-unit, positive
-  and unbounded costs each handle in-range, out-of-range, and negative
-  thresholds correctly; `OTHER` preserves legacy behaviour.
+- `test/costs/CostDescriptor.ts` — every built-in maps to the row from the Issue
+  #2786 table; custom names collapse to `OTHER`; the original name is not leaked
+  back.
+- `test/costs/CostAwareEarlyStop.ts` — unit-range, signed-unit, positive and
+  unbounded costs each handle in-range, out-of-range, and negative thresholds
+  correctly; `OTHER` preserves legacy behaviour.
 - `test/costs/CostAwareEarlyStopIntegration.ts` — with the SAME user
-  `targetError = 1.5`, `CATEGORICAL_ERROR` does NOT early-stop on
-  `error = 0.5` (out-of-range threshold defers), while `MSE` DOES early-stop
-  on `error = 0.5` (legitimate unbounded threshold) — the differential
-  behaviour required by the acceptance criteria.
+  `targetError = 1.5`, `CATEGORICAL_ERROR` does NOT early-stop on `error = 0.5`
+  (out-of-range threshold defers), while `MSE` DOES early-stop on `error = 0.5`
+  (legitimate unbounded threshold) — the differential behaviour required by the
+  acceptance criteria.
 
 Verification command:
 

--- a/docs/archive/pr-summaries/pr-summary-2787.md
+++ b/docs/archive/pr-summaries/pr-summary-2787.md
@@ -1,0 +1,81 @@
+## Summary
+
+Make NEAT-AI's `evolveDir` (`evolveDataSet` / `evolveRL`) interpret
+`targetError` early-stop and champion comparison in a **cost-consistent
+way**. Before this change a `0.1` `CATEGORICAL_ERROR` (≈90 % accuracy) and
+a `0.1` `MSE` (an unbounded regression metric) were both compared with the
+same `error <= targetError` formula on a fixed scale — mis-calibrated
+stopping and selection. After this change the threshold is interpreted in
+the cost's natural range using a new pure descriptor helper.
+
+Two small additions, one wiring change:
+
+1. **`src/costs/CostDescriptor.ts`** — pure helper that maps each built-in
+   cost to a canonical `TaskDescriptor` (topology / range / output squash
+   family) per the table in Issue #2786. Custom JS costs collapse to the
+   sentinel `OTHER` + neutral descriptor; the caller-supplied name is never
+   echoed back (leakage guard).
+2. **`src/costs/CostAwareEarlyStop.ts`** — `shouldEarlyStop()`,
+   `calibrateTargetError()`, `isBetterChampion()`. Unit-range costs reject
+   out-of-range thresholds (defer to `iterations` / `timeoutMinutes` rather
+   than halting on a fat-fingered target). Positive-range costs reject
+   negative thresholds. Unbounded costs accept any positive threshold.
+   `OTHER` falls back to the legacy `error <= targetError` comparator — the
+   regression guard required by the issue.
+3. **`src/creature/CreatureTraining.ts`** — the three call sites for
+   `evolveDir`, `evolveDataSet` and `evolveRL` now route through
+   `shouldEarlyStop()` and `isBetterChampion()` (same module, single seam
+   for future cost-specific tie-breaks such as a continuous companion
+   metric for `CATEGORICAL_ERROR`).
+
+Closes #2787.
+
+## Evidence
+
+This is a backend/library change with no UI. Verified via the new unit and
+integration tests below; all 29 new tests plus the pre-existing 63 tests
+in `test/costs/` pass.
+
+```mermaid
+flowchart LR
+    User["User: targetError = 1.5"] --> Wiring["CreatureTraining.evolveDir"]
+    Wiring --> Helper["shouldEarlyStop(error, target, costName)"]
+    Helper --> Descriptor["costNameToTaskDescriptor(costName)"]
+    Descriptor -->|unit range:<br/>CATEGORICAL_ERROR| Defer["out-of-range threshold<br/>=> defer to iterations<br/>(does NOT stop)"]
+    Descriptor -->|unbounded:<br/>MSE / MAE| Apply["error <= 1.5<br/>(stops on small enough error)"]
+    Descriptor -->|sentinel OTHER<br/>custom JS cost| Legacy["legacy error <= targetError<br/>(regression guard)"]
+```
+
+### Tests pinning the cost-aware behaviour
+
+- `test/costs/CostDescriptor.ts` — every built-in maps to the row from the
+  Issue #2786 table; custom names collapse to `OTHER`; the original name is
+  not leaked back.
+- `test/costs/CostAwareEarlyStop.ts` — unit-range, signed-unit, positive
+  and unbounded costs each handle in-range, out-of-range, and negative
+  thresholds correctly; `OTHER` preserves legacy behaviour.
+- `test/costs/CostAwareEarlyStopIntegration.ts` — with the SAME user
+  `targetError = 1.5`, `CATEGORICAL_ERROR` does NOT early-stop on
+  `error = 0.5` (out-of-range threshold defers), while `MSE` DOES early-stop
+  on `error = 0.5` (legitimate unbounded threshold) — the differential
+  behaviour required by the acceptance criteria.
+
+Verification command:
+
+```bash
+deno test --allow-all --no-check 'test/costs/*.ts' < /dev/null
+# ok | 92 passed | 0 failed
+```
+
+## Test Plan
+
+- [x] `test/costs/CostDescriptor.ts` — new (13 cases).
+- [x] `test/costs/CostAwareEarlyStop.ts` — new (13 cases).
+- [x] `test/costs/CostAwareEarlyStopIntegration.ts` — new (3 cases).
+- [x] All 92 cost tests pass (`deno test 'test/costs/*.ts'`).
+- [x] `evolve_NOT_gate` smoke run still terminates on `targetError` — no
+      regression on the legacy `error <= targetError` path for in-range
+      thresholds.
+- [x] `deno check` clean on the touched files plus
+      `src/creature/CreatureTraining.ts`.
+- [x] `./quality.sh --lint-only` clean (`deno fmt`, lint, bash check).

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -243,6 +243,7 @@
     "Miikkulainen",
     "Millidge",
     "Millis",
+    "misclass",
     "Mish",
     "Misra",
     "mkdirp",

--- a/src/costs/CostAwareEarlyStop.ts
+++ b/src/costs/CostAwareEarlyStop.ts
@@ -1,0 +1,105 @@
+/**
+ * Cost-aware `targetError` early-stop and champion-selection helpers used by
+ * `evolveDir` (Issue #2787).
+ *
+ * Before this module: `error <= targetError` was applied on a fixed scale
+ * regardless of cost. A `0.1` `CATEGORICAL_ERROR` (≈90% accuracy) and a
+ * `0.1` `MSE` (an unbounded regression metric) were stopped at the same
+ * threshold — mis-calibrated.
+ *
+ * After this module: the threshold is interpreted in the cost's natural
+ * range using the descriptor from {@link costNameToTaskDescriptor}.
+ * Unit-range costs (CATEGORICAL_ERROR, CROSS_ENTROPY, BINARY_CROSS_ENTROPY)
+ * clamp the threshold into `[0, 1]`. Positive-range costs (MAPE, MSLE)
+ * floor it at `0`. Unbounded costs (MSE, MAE) accept any threshold.
+ *
+ * **Regression guard:** custom JS costs (`OTHER`) bypass calibration and
+ * fall back to the legacy `error <= targetError` / `score > bestScore`
+ * comparators verbatim.
+ */
+
+import { costNameToTaskDescriptor } from "@costs/CostDescriptor.ts";
+
+/**
+ * Returns a `targetError` value clamped into the cost's natural range. For
+ * unknown/custom costs the input is returned unchanged (legacy behaviour).
+ */
+export function calibrateTargetError(
+  targetError: number,
+  costName: string | undefined,
+): number {
+  const descriptor = costNameToTaskDescriptor(costName);
+  if (descriptor.costName === "OTHER") {
+    // Regression guard: do not touch thresholds for custom costs.
+    return targetError;
+  }
+  switch (descriptor.range) {
+    case "unit":
+      // Error is in `[0, 1]`. Clamp the threshold so a too-large user input
+      // does not trivially stop the run, and a negative input does not
+      // disable early-stop.
+      return Math.max(0, Math.min(1, targetError));
+    case "signed_unit":
+      // HINGE (margin) is bounded below by 0; treat negative as 0. Allow
+      // any positive threshold — hinge can exceed 1 in practice when the
+      // margin is violated by a wide margin.
+      return Math.max(0, targetError);
+    case "positive":
+      return Math.max(0, targetError);
+    case "unbounded":
+      return targetError;
+  }
+}
+
+/**
+ * Returns `true` iff `error` meets the cost-aware early-stop threshold for
+ * `costName`. For OTHER (custom JS cost), behaves as the legacy comparator
+ * `error <= targetError`.
+ *
+ * For built-in costs, an out-of-range threshold (e.g. `targetError = 1.5`
+ * for the unit-range `CATEGORICAL_ERROR`) is treated as "no early-stop on
+ * this criterion" — the run defers to `iterations` / `timeoutMinutes`. A
+ * fat-fingered threshold should not silently halt the run on the very
+ * first generation.
+ */
+export function shouldEarlyStop(
+  error: number,
+  targetError: number,
+  costName: string | undefined,
+): boolean {
+  const descriptor = costNameToTaskDescriptor(costName);
+  if (descriptor.costName === "OTHER") {
+    return error <= targetError; // Regression guard for custom JS costs.
+  }
+  switch (descriptor.range) {
+    case "unit":
+      if (targetError < 0 || targetError > 1) return false;
+      break;
+    case "signed_unit":
+    case "positive":
+      if (targetError < 0) return false;
+      break;
+    case "unbounded":
+      break;
+  }
+  return error <= targetError;
+}
+
+/**
+ * Returns `true` iff `candidateScore` should replace `bestScore` as the
+ * champion under `costName`. Currently a strict `>` comparison for every
+ * cost (matches the legacy behaviour today) and NaN-safe: a NaN candidate
+ * never wins, and any finite candidate beats a NaN incumbent. Routing
+ * champion comparison through this helper gives future cost-specific
+ * tie-breaks (e.g. continuous companion CE for CATEGORICAL_ERROR) a single
+ * seam to extend without further touching `evolveDir`.
+ */
+export function isBetterChampion(
+  candidateScore: number,
+  bestScore: number,
+  _costName: string | undefined,
+): boolean {
+  if (Number.isNaN(candidateScore)) return false;
+  if (Number.isNaN(bestScore)) return true;
+  return candidateScore > bestScore;
+}

--- a/src/costs/CostDescriptor.ts
+++ b/src/costs/CostDescriptor.ts
@@ -1,0 +1,136 @@
+/**
+ * costName → TaskDescriptor mapping helper (Issue #2786).
+ *
+ * Pure helper: given a cost name, return the canonical descriptor used by
+ * Discovery and by the caller-side cost-aware early-stop / champion
+ * selection logic (Issue #2787). No wire/FFI changes happen here — the
+ * descriptor is a value object.
+ *
+ * Built-ins map per the table in Issue #2786. Custom JS costs and any
+ * unrecognised name map to the sentinel `OTHER` plus a neutral descriptor.
+ * The original custom name is NEVER returned to the caller — that would
+ * leak structure to Discovery and defeat the purpose of the sentinel.
+ *
+ * | costName               | topology     | range        | output squash family |
+ * |------------------------|--------------|--------------|----------------------|
+ * | MSE, MAE               | independent  | unbounded    | unbounded            |
+ * | MAPE, MSLE             | independent  | positive     | positive             |
+ * | BINARY_CROSS_ENTROPY   | independent  | unit         | bounded_unipolar     |
+ * | CROSS_ENTROPY          | simplex      | unit         | bounded_unipolar     |
+ * | HINGE                  | margin       | signed_unit  | bounded_bipolar      |
+ * | CATEGORICAL_ERROR      | one_hot      | unit         | bounded_unipolar     |
+ * | OTHER (custom JS)      | unknown      | unbounded    | any                  |
+ */
+
+/** Topology of the target distribution implied by the cost. */
+export type CostTopology =
+  | "independent"
+  | "simplex"
+  | "margin"
+  | "one_hot"
+  | "unknown";
+
+/** Numerical range the cost is defined over. */
+export type CostRange = "unbounded" | "positive" | "unit" | "signed_unit";
+
+/** Output activation family that pairs naturally with the cost. */
+export type CostSquashFamily =
+  | "unbounded"
+  | "positive"
+  | "bounded_unipolar"
+  | "bounded_bipolar"
+  | "any";
+
+/**
+ * Canonical descriptor for a cost. The `costName` field is either one of
+ * the built-in names or the literal sentinel `"OTHER"`. The original
+ * caller-supplied name for a custom cost is never copied into this struct.
+ */
+export interface TaskDescriptor {
+  readonly costName: string;
+  readonly topology: CostTopology;
+  readonly range: CostRange;
+  readonly outputSquashFamily: CostSquashFamily;
+}
+
+const NEUTRAL_OTHER: TaskDescriptor = Object.freeze({
+  costName: "OTHER",
+  topology: "unknown",
+  range: "unbounded",
+  outputSquashFamily: "any",
+});
+
+const TABLE: Readonly<Record<string, TaskDescriptor>> = Object.freeze({
+  MSE: {
+    costName: "MSE",
+    topology: "independent",
+    range: "unbounded",
+    outputSquashFamily: "unbounded",
+  },
+  MAE: {
+    costName: "MAE",
+    topology: "independent",
+    range: "unbounded",
+    outputSquashFamily: "unbounded",
+  },
+  MAPE: {
+    costName: "MAPE",
+    topology: "independent",
+    range: "positive",
+    outputSquashFamily: "positive",
+  },
+  MSLE: {
+    costName: "MSLE",
+    topology: "independent",
+    range: "positive",
+    outputSquashFamily: "positive",
+  },
+  BINARY_CROSS_ENTROPY: {
+    costName: "BINARY_CROSS_ENTROPY",
+    topology: "independent",
+    range: "unit",
+    outputSquashFamily: "bounded_unipolar",
+  },
+  CROSS_ENTROPY: {
+    costName: "CROSS_ENTROPY",
+    topology: "simplex",
+    range: "unit",
+    outputSquashFamily: "bounded_unipolar",
+  },
+  HINGE: {
+    costName: "HINGE",
+    topology: "margin",
+    range: "signed_unit",
+    outputSquashFamily: "bounded_bipolar",
+  },
+  CATEGORICAL_ERROR: {
+    costName: "CATEGORICAL_ERROR",
+    topology: "one_hot",
+    range: "unit",
+    outputSquashFamily: "bounded_unipolar",
+  },
+});
+
+/**
+ * Maps a (possibly undefined or custom) cost name to its canonical
+ * `TaskDescriptor`. Unknown/custom names are collapsed to a neutral
+ * `OTHER` descriptor — the original name is never copied through.
+ */
+export function costNameToTaskDescriptor(
+  name: string | undefined,
+): TaskDescriptor {
+  if (!name) return NEUTRAL_OTHER;
+  const descriptor = TABLE[name];
+  return descriptor ?? NEUTRAL_OTHER;
+}
+
+/**
+ * True iff `name` is a built-in cost the project knows how to calibrate
+ * cost-aware behaviour for. Custom JS costs return false so callers can
+ * route them through the legacy (cost-agnostic) path as a regression guard
+ * (Issue #2787 acceptance criteria).
+ */
+export function isCostAware(name: string | undefined): boolean {
+  if (!name) return false;
+  return Object.hasOwn(TABLE, name);
+}

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -25,6 +25,10 @@ import { dataFiles } from "@architecture/Training.ts";
 import { createNeatConfig } from "@config/NeatConfig.ts";
 import type { NeatOptions } from "@config/NeatOptions.ts";
 import { Costs } from "@costs";
+import {
+  isBetterChampion,
+  shouldEarlyStop,
+} from "@costs/CostAwareEarlyStop.ts";
 import { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import { Neat } from "@neat/Neat.ts";
 import {
@@ -461,7 +465,12 @@ export async function evolveDir(
     const fittest = result.fittest;
     const fittestScore = fittest.score!;
     assert(fittestScore >= bestScore, "Score is less than best score");
-    if (fittestScore > bestScore) {
+    // Issue #2787: route champion comparison through the cost-aware helper.
+    // Today this remains a strict `score > bestScore` for every cost
+    // (NaN-safe) so existing runs do not regress; the seam is in place for
+    // future cost-specific tie-breaks (e.g. continuous companion CE for
+    // CATEGORICAL_ERROR).
+    if (isBetterChampion(fittestScore, bestScore, config.costName)) {
       const errorTmp = getTag(fittest, "error");
       assert(errorTmp, "No error tag found");
 
@@ -532,7 +541,12 @@ export async function evolveDir(
       });
     }
 
-    const completed = interrupted || timedOut || error <= targetError ||
+    // Issue #2787: cost-aware early-stop. For built-in costs the threshold
+    // is clamped into the cost's natural range (e.g. CATEGORICAL_ERROR
+    // ∈ [0, 1] vs unbounded MSE); custom JS costs fall back to the legacy
+    // `error <= targetError` comparator as a regression guard.
+    const earlyStop = shouldEarlyStop(error, targetError, config.costName);
+    const completed = interrupted || timedOut || earlyStop ||
       generation >= iterations;
 
     if (
@@ -734,7 +748,12 @@ export async function evolveEnv<S, A>(
     const fittest = result.fittest;
     const fittestScore = fittest.score!;
     assert(fittestScore >= bestScore, "Score is less than best score");
-    if (fittestScore > bestScore) {
+    // Issue #2787: route champion comparison through the cost-aware helper.
+    // Today this remains a strict `score > bestScore` for every cost
+    // (NaN-safe) so existing runs do not regress; the seam is in place for
+    // future cost-specific tie-breaks (e.g. continuous companion CE for
+    // CATEGORICAL_ERROR).
+    if (isBetterChampion(fittestScore, bestScore, config.costName)) {
       const errorTmp = getTag(fittest, "error");
       assert(errorTmp, "No error tag found");
 
@@ -791,7 +810,12 @@ export async function evolveEnv<S, A>(
       });
     }
 
-    const completed = interrupted || timedOut || error <= targetError ||
+    // Issue #2787: cost-aware early-stop. For built-in costs the threshold
+    // is clamped into the cost's natural range (e.g. CATEGORICAL_ERROR
+    // ∈ [0, 1] vs unbounded MSE); custom JS costs fall back to the legacy
+    // `error <= targetError` comparator as a regression guard.
+    const earlyStop = shouldEarlyStop(error, targetError, config.costName);
+    const completed = interrupted || timedOut || earlyStop ||
       generation >= iterations;
 
     if (
@@ -1182,7 +1206,12 @@ export async function evolveRL<S, A>(
     const fittest = result.fittest;
     const fittestScore = fittest.score!;
     assert(fittestScore >= bestScore, "Score is less than best score");
-    if (fittestScore > bestScore) {
+    // Issue #2787: route champion comparison through the cost-aware helper.
+    // Today this remains a strict `score > bestScore` for every cost
+    // (NaN-safe) so existing runs do not regress; the seam is in place for
+    // future cost-specific tie-breaks (e.g. continuous companion CE for
+    // CATEGORICAL_ERROR).
+    if (isBetterChampion(fittestScore, bestScore, config.costName)) {
       const errorTmp = getTag(fittest, "error");
       assert(errorTmp, "No error tag found");
 
@@ -1274,7 +1303,12 @@ export async function evolveRL<S, A>(
       });
     }
 
-    const completed = interrupted || timedOut || error <= targetError ||
+    // Issue #2787: cost-aware early-stop. For built-in costs the threshold
+    // is clamped into the cost's natural range (e.g. CATEGORICAL_ERROR
+    // ∈ [0, 1] vs unbounded MSE); custom JS costs fall back to the legacy
+    // `error <= targetError` comparator as a regression guard.
+    const earlyStop = shouldEarlyStop(error, targetError, config.costName);
+    const completed = interrupted || timedOut || earlyStop ||
       generation >= iterations;
 
     if (

--- a/test/costs/CostAwareEarlyStop.ts
+++ b/test/costs/CostAwareEarlyStop.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the cost-aware `targetError` early-stop / champion comparison
+ * helpers used by `evolveDir`. Issue #2787.
+ *
+ * The point of these helpers is that a `0.1` `CATEGORICAL_ERROR` (an
+ * accuracy-style metric in `[0, 1]`) and a `0.1` `MSE` (an unbounded
+ * regression metric) are no longer treated on the same fixed scale. The
+ * helpers consult the cost descriptor (Issue #2786) and apply the threshold
+ * in the cost's natural range.
+ *
+ * For custom JS costs (`OTHER`), the helpers fall back to the legacy
+ * `error <= targetError` / `score > bestScore` behaviour as a regression
+ * guard.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  calibrateTargetError,
+  isBetterChampion,
+  shouldEarlyStop,
+} from "@costs/CostAwareEarlyStop.ts";
+
+Deno.test("shouldEarlyStop - CATEGORICAL_ERROR stops on its unit scale", () => {
+  // 90% accuracy = 0.1 misclassification rate.
+  assertEquals(shouldEarlyStop(0.10, 0.10, "CATEGORICAL_ERROR"), true);
+  assertEquals(shouldEarlyStop(0.11, 0.10, "CATEGORICAL_ERROR"), false);
+});
+
+Deno.test("shouldEarlyStop - unit-range targetError above 1.0 defers to other stop criteria", () => {
+  // CATEGORICAL_ERROR is bounded in [0, 1]. A targetError of 2.0 is
+  // nonsensical on the unit scale and the cost-aware helper refuses to
+  // stop on it — the run defers to `iterations` / `timeoutMinutes` rather
+  // than halting on a fat-fingered threshold.
+  assertEquals(shouldEarlyStop(0.5, 2.0, "CATEGORICAL_ERROR"), false);
+  assertEquals(shouldEarlyStop(1.0, 2.0, "CATEGORICAL_ERROR"), false);
+  // Within-range thresholds still work normally.
+  assertEquals(shouldEarlyStop(0.5, 0.5, "CATEGORICAL_ERROR"), true);
+  assertEquals(shouldEarlyStop(0.5, 0.4, "CATEGORICAL_ERROR"), false);
+});
+
+Deno.test("shouldEarlyStop - MSE is unbounded; threshold passes through", () => {
+  // MSE can exceed 1.0. A targetError of 2.0 means "stop when MSE <= 2.0".
+  assertEquals(shouldEarlyStop(2.5, 2.0, "MSE"), false);
+  assertEquals(shouldEarlyStop(2.0, 2.0, "MSE"), true);
+  assertEquals(shouldEarlyStop(0.001, 2.0, "MSE"), true);
+});
+
+Deno.test("shouldEarlyStop - calibrated thresholds: CATEGORICAL_ERROR vs MSE at targetError=1.5", () => {
+  // Same user-supplied `targetError = 1.5`, different cost-aware behaviour.
+  // For CATEGORICAL_ERROR (unit), 1.5 is clamped to 1.0, so error=0.5
+  // does NOT trigger early stop.
+  assertEquals(shouldEarlyStop(0.5, 1.5, "CATEGORICAL_ERROR"), false);
+  // For MSE (unbounded), 1.5 is a legitimate threshold and error=0.5
+  // DOES trigger early stop.
+  assertEquals(shouldEarlyStop(0.5, 1.5, "MSE"), true);
+});
+
+Deno.test("shouldEarlyStop - HINGE (signed_unit margin) accepts any positive threshold", () => {
+  assertEquals(shouldEarlyStop(0.0, 0.1, "HINGE"), true);
+  assertEquals(shouldEarlyStop(0.2, 0.1, "HINGE"), false);
+});
+
+Deno.test("shouldEarlyStop - positive-range costs reject negative thresholds", () => {
+  // MAPE / MSLE error >= 0; a negative threshold means "never stop", not
+  // "always stop".
+  assertEquals(shouldEarlyStop(0.0, -1, "MAPE"), false);
+  assertEquals(shouldEarlyStop(0.0, 0, "MAPE"), true);
+});
+
+Deno.test("shouldEarlyStop - OTHER (custom JS cost) preserves legacy behaviour", () => {
+  // Regression guard from Issue #2787 acceptance criteria.
+  assertEquals(shouldEarlyStop(0.05, 0.1, "MY_CUSTOM_COST"), true);
+  assertEquals(shouldEarlyStop(0.15, 0.1, "MY_CUSTOM_COST"), false);
+  // No clamping: a targetError of 2.0 on an unknown cost just acts as the
+  // raw comparator.
+  assertEquals(shouldEarlyStop(1.5, 2.0, "MY_CUSTOM_COST"), true);
+  // undefined cost name behaves like a custom cost (legacy behaviour).
+  assertEquals(shouldEarlyStop(0.05, 0.1, undefined), true);
+});
+
+Deno.test("calibrateTargetError - clamps unit-range thresholds", () => {
+  assertEquals(calibrateTargetError(0.5, "CATEGORICAL_ERROR"), 0.5);
+  assertEquals(calibrateTargetError(2.0, "CATEGORICAL_ERROR"), 1.0);
+  assertEquals(calibrateTargetError(-0.5, "CATEGORICAL_ERROR"), 0.0);
+});
+
+Deno.test("calibrateTargetError - leaves unbounded thresholds unchanged", () => {
+  assertEquals(calibrateTargetError(2.0, "MSE"), 2.0);
+  assertEquals(calibrateTargetError(0.001, "MSE"), 0.001);
+});
+
+Deno.test("calibrateTargetError - positive-range floors negative thresholds at 0", () => {
+  assertEquals(calibrateTargetError(-1, "MAPE"), 0);
+  assertEquals(calibrateTargetError(0.5, "MAPE"), 0.5);
+});
+
+Deno.test("calibrateTargetError - OTHER passes through unchanged", () => {
+  assertEquals(calibrateTargetError(2.0, "MY_CUSTOM"), 2.0);
+  assertEquals(calibrateTargetError(-1, "MY_CUSTOM"), -1);
+});
+
+Deno.test("isBetterChampion - higher score wins for all costs", () => {
+  // Champion comparison is "score > bestScore" today. The cost-aware
+  // wrapper preserves this for every cost (including OTHER) so existing
+  // runs do not regress, but routes the comparison through the helper so
+  // future cost-specific tie-breaks (e.g. companion CE for CATEGORICAL_ERROR)
+  // have a single seam to extend.
+  assertEquals(isBetterChampion(0.9, 0.8, "MSE"), true);
+  assertEquals(isBetterChampion(0.8, 0.9, "MSE"), false);
+  assertEquals(isBetterChampion(0.9, 0.9, "MSE"), false);
+  assertEquals(isBetterChampion(0.9, 0.8, "CATEGORICAL_ERROR"), true);
+  assertEquals(isBetterChampion(0.9, 0.8, "MY_CUSTOM"), true);
+  assertEquals(isBetterChampion(0.9, 0.8, undefined), true);
+});
+
+Deno.test("isBetterChampion - NaN never wins", () => {
+  assertEquals(isBetterChampion(Number.NaN, 0.5, "MSE"), false);
+  assertEquals(isBetterChampion(0.5, Number.NaN, "MSE"), true);
+});

--- a/test/costs/CostAwareEarlyStopIntegration.ts
+++ b/test/costs/CostAwareEarlyStopIntegration.ts
@@ -1,0 +1,76 @@
+/**
+ * Integration test for the cost-aware `targetError` early-stop wiring in
+ * `evolveDir` / `evolveDataSet` (Issue #2787).
+ *
+ * The "what" being tested: with the **same** user-supplied `targetError`,
+ * a `CATEGORICAL_ERROR` run and an `MSE` run stop on appropriately-scaled
+ * thresholds rather than on the same fixed scale. We verify this by
+ * running the cost-aware helpers exactly as `CreatureTraining.ts` does and
+ * asserting the early-stop decisions diverge per cost.
+ *
+ * This is an integration test of the wiring (the helpers are imported from
+ * the same module the production code uses) rather than a slow end-to-end
+ * `evolveDataSet` run — the unit tests in `CostAwareEarlyStop.ts` already
+ * pin the per-cost arithmetic.
+ */
+
+import { assertEquals } from "@std/assert";
+import { shouldEarlyStop } from "@costs/CostAwareEarlyStop.ts";
+
+Deno.test("evolveDir wiring - same targetError diverges between CATEGORICAL_ERROR and MSE", () => {
+  // Imagine an evolveDir caller that supplied `targetError = 1.5`. For the
+  // unit-range CATEGORICAL_ERROR cost (error always in [0, 1]) this is
+  // clamped to 1.0; an intermediate error of 0.5 does NOT trigger
+  // early-stop because the calibrated threshold reflects the cost's
+  // natural range. For the unbounded MSE cost the same input is a
+  // legitimate threshold and the same 0.5 error DOES trigger early-stop.
+  //
+  // This is exactly what `CreatureTraining.ts` now does on every
+  // generation completion check.
+  const observedError = 0.5;
+  const userTargetError = 1.5;
+
+  const categoricalStop = shouldEarlyStop(
+    observedError,
+    userTargetError,
+    "CATEGORICAL_ERROR",
+  );
+  const mseStop = shouldEarlyStop(observedError, userTargetError, "MSE");
+
+  assertEquals(
+    categoricalStop,
+    false,
+    "CATEGORICAL_ERROR must not stop on 0.5 ≤ clamped 1.0 boundary at error=0.5",
+  );
+  assertEquals(mseStop, true, "MSE must stop on raw 0.5 ≤ 1.5");
+});
+
+Deno.test("evolveDir wiring - both costs stop at their natural high-quality thresholds", () => {
+  // Sanity check: at the realistic high-quality threshold each cost
+  // typically targets, both stop.
+  assertEquals(
+    shouldEarlyStop(0.05, 0.10, "CATEGORICAL_ERROR"),
+    true,
+    "CATEGORICAL_ERROR at 5% misclass stops on 10% threshold",
+  );
+  assertEquals(
+    shouldEarlyStop(0.001, 0.01, "MSE"),
+    true,
+    "MSE at 0.001 stops on 0.01 threshold",
+  );
+});
+
+Deno.test("evolveDir wiring - OTHER (custom cost) preserves legacy behaviour", () => {
+  // Regression guard. With a custom JS cost the helper must behave as the
+  // pre-#2787 `error <= targetError` comparator on every input, including
+  // values that would have been clamped for a built-in unit-range cost.
+  assertEquals(shouldEarlyStop(0.5, 1.5, "MY_CUSTOM_REGRESSION_COST"), true);
+  assertEquals(shouldEarlyStop(0.05, 0.10, "MY_CUSTOM_REGRESSION_COST"), true);
+  assertEquals(shouldEarlyStop(0.15, 0.10, "MY_CUSTOM_REGRESSION_COST"), false);
+  // Behaviour is independent of the unrecognised name — leakage guard
+  // from the #2786 mapping helper.
+  assertEquals(
+    shouldEarlyStop(0.5, 1.5, "DIFFERENT_CUSTOM"),
+    shouldEarlyStop(0.5, 1.5, "MY_CUSTOM_REGRESSION_COST"),
+  );
+});

--- a/test/costs/CostDescriptor.ts
+++ b/test/costs/CostDescriptor.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the costName -> TaskDescriptor mapping helper
+ * introduced for Issue #2787 (which depends on Issue #2786).
+ *
+ * The helper is intentionally pure: given a cost name string it returns the
+ * canonical descriptor (topology, range, output squash family). Custom or
+ * unrecognised names map to the sentinel `OTHER` + a neutral descriptor and
+ * never echo the caller-supplied name back to the descriptor.
+ */
+
+import { assertEquals, assertNotStrictEquals } from "@std/assert";
+import {
+  costNameToTaskDescriptor,
+  isCostAware,
+  type TaskDescriptor,
+} from "@costs/CostDescriptor.ts";
+import { BUILT_IN_COST_NAMES } from "@costs";
+
+Deno.test("costNameToTaskDescriptor - MSE maps to independent / unbounded / unbounded", () => {
+  const descriptor = costNameToTaskDescriptor("MSE");
+  assertEquals(
+    descriptor,
+    {
+      costName: "MSE",
+      topology: "independent",
+      range: "unbounded",
+      outputSquashFamily: "unbounded",
+    } satisfies TaskDescriptor,
+  );
+});
+
+Deno.test("costNameToTaskDescriptor - MAE maps to independent / unbounded / unbounded", () => {
+  const descriptor = costNameToTaskDescriptor("MAE");
+  assertEquals(descriptor.topology, "independent");
+  assertEquals(descriptor.range, "unbounded");
+  assertEquals(descriptor.outputSquashFamily, "unbounded");
+});
+
+Deno.test("costNameToTaskDescriptor - MAPE maps to independent / positive / positive", () => {
+  const descriptor = costNameToTaskDescriptor("MAPE");
+  assertEquals(descriptor.topology, "independent");
+  assertEquals(descriptor.range, "positive");
+  assertEquals(descriptor.outputSquashFamily, "positive");
+});
+
+Deno.test("costNameToTaskDescriptor - MSLE maps to independent / positive / positive", () => {
+  const descriptor = costNameToTaskDescriptor("MSLE");
+  assertEquals(descriptor.topology, "independent");
+  assertEquals(descriptor.range, "positive");
+  assertEquals(descriptor.outputSquashFamily, "positive");
+});
+
+Deno.test("costNameToTaskDescriptor - CROSS_ENTROPY maps to simplex / unit / bounded_unipolar", () => {
+  const descriptor = costNameToTaskDescriptor("CROSS_ENTROPY");
+  assertEquals(descriptor.topology, "simplex");
+  assertEquals(descriptor.range, "unit");
+  assertEquals(descriptor.outputSquashFamily, "bounded_unipolar");
+});
+
+Deno.test("costNameToTaskDescriptor - BINARY_CROSS_ENTROPY maps to independent / unit / bounded_unipolar", () => {
+  // BINARY_CROSS_ENTROPY is not implemented as a Cost class in this repo, but
+  // the mapping helper is the canonical place for its descriptor (Issue
+  // #2786). When the cost is added later, the descriptor must already be in
+  // sync.
+  const descriptor = costNameToTaskDescriptor("BINARY_CROSS_ENTROPY");
+  assertEquals(descriptor.topology, "independent");
+  assertEquals(descriptor.range, "unit");
+  assertEquals(descriptor.outputSquashFamily, "bounded_unipolar");
+});
+
+Deno.test("costNameToTaskDescriptor - HINGE maps to margin / signed_unit / bounded_bipolar", () => {
+  const descriptor = costNameToTaskDescriptor("HINGE");
+  assertEquals(descriptor.topology, "margin");
+  assertEquals(descriptor.range, "signed_unit");
+  assertEquals(descriptor.outputSquashFamily, "bounded_bipolar");
+});
+
+Deno.test("costNameToTaskDescriptor - CATEGORICAL_ERROR maps to one_hot / unit / bounded_unipolar", () => {
+  const descriptor = costNameToTaskDescriptor("CATEGORICAL_ERROR");
+  assertEquals(descriptor.topology, "one_hot");
+  assertEquals(descriptor.range, "unit");
+  assertEquals(descriptor.outputSquashFamily, "bounded_unipolar");
+});
+
+Deno.test("costNameToTaskDescriptor - unknown/custom cost maps to OTHER + neutral descriptor", () => {
+  const descriptor = costNameToTaskDescriptor("MY_USER_DEFINED_COST");
+  assertEquals(descriptor.costName, "OTHER");
+  assertEquals(descriptor.topology, "unknown");
+  assertEquals(descriptor.range, "unbounded");
+  assertEquals(descriptor.outputSquashFamily, "any");
+});
+
+Deno.test("costNameToTaskDescriptor - the original custom name is never echoed back", () => {
+  const descriptor = costNameToTaskDescriptor(
+    "LEAKY_NAME_THAT_REVEALS_STRUCTURE",
+  );
+  assertNotStrictEquals(
+    descriptor.costName,
+    "LEAKY_NAME_THAT_REVEALS_STRUCTURE",
+  );
+  assertEquals(descriptor.costName, "OTHER");
+});
+
+Deno.test("costNameToTaskDescriptor - empty/unset name maps to OTHER", () => {
+  assertEquals(costNameToTaskDescriptor("").costName, "OTHER");
+  assertEquals(costNameToTaskDescriptor(undefined).costName, "OTHER");
+});
+
+Deno.test("costNameToTaskDescriptor - every built-in maps to a non-OTHER descriptor", () => {
+  for (const name of BUILT_IN_COST_NAMES) {
+    const descriptor = costNameToTaskDescriptor(name);
+    assertEquals(
+      descriptor.costName,
+      name,
+      `Built-in ${name} should map to its own descriptor, not OTHER`,
+    );
+  }
+});
+
+Deno.test("isCostAware - built-ins are cost-aware; OTHER is not", () => {
+  assertEquals(isCostAware("MSE"), true);
+  assertEquals(isCostAware("CATEGORICAL_ERROR"), true);
+  assertEquals(isCostAware("CROSS_ENTROPY"), true);
+  assertEquals(isCostAware("HINGE"), true);
+  // Custom JS cost — must fall back to current ("OTHER") behaviour.
+  assertEquals(isCostAware("MY_USER_DEFINED_COST"), false);
+  assertEquals(isCostAware(undefined), false);
+});


### PR DESCRIPTION
## Summary

Make NEAT-AI's `evolveDir` (`evolveDataSet` / `evolveRL`) interpret
`targetError` early-stop and champion comparison in a **cost-consistent
way**. Before this change a `0.1` `CATEGORICAL_ERROR` (≈90 % accuracy) and
a `0.1` `MSE` (an unbounded regression metric) were both compared with the
same `error <= targetError` formula on a fixed scale — mis-calibrated
stopping and selection. After this change the threshold is interpreted in
the cost's natural range using a new pure descriptor helper.

Two small additions, one wiring change:

1. **`src/costs/CostDescriptor.ts`** — pure helper that maps each built-in
   cost to a canonical `TaskDescriptor` (topology / range / output squash
   family) per the table in Issue #2786. Custom JS costs collapse to the
   sentinel `OTHER` + neutral descriptor; the caller-supplied name is never
   echoed back (leakage guard).
2. **`src/costs/CostAwareEarlyStop.ts`** — `shouldEarlyStop()`,
   `calibrateTargetError()`, `isBetterChampion()`. Unit-range costs reject
   out-of-range thresholds (defer to `iterations` / `timeoutMinutes` rather
   than halting on a fat-fingered target). Positive-range costs reject
   negative thresholds. Unbounded costs accept any positive threshold.
   `OTHER` falls back to the legacy `error <= targetError` comparator — the
   regression guard required by the issue.
3. **`src/creature/CreatureTraining.ts`** — the three call sites for
   `evolveDir`, `evolveDataSet` and `evolveRL` now route through
   `shouldEarlyStop()` and `isBetterChampion()` (same module, single seam
   for future cost-specific tie-breaks such as a continuous companion
   metric for `CATEGORICAL_ERROR`).

Closes #2787.

## Evidence

This is a backend/library change with no UI. Verified via the new unit and
integration tests below; all 29 new tests plus the pre-existing 63 tests
in `test/costs/` pass.

```mermaid
flowchart LR
    User["User: targetError = 1.5"] --> Wiring["CreatureTraining.evolveDir"]
    Wiring --> Helper["shouldEarlyStop(error, target, costName)"]
    Helper --> Descriptor["costNameToTaskDescriptor(costName)"]
    Descriptor -->|unit range:<br/>CATEGORICAL_ERROR| Defer["out-of-range threshold<br/>=> defer to iterations<br/>(does NOT stop)"]
    Descriptor -->|unbounded:<br/>MSE / MAE| Apply["error <= 1.5<br/>(stops on small enough error)"]
    Descriptor -->|sentinel OTHER<br/>custom JS cost| Legacy["legacy error <= targetError<br/>(regression guard)"]
```

### Tests pinning the cost-aware behaviour

- `test/costs/CostDescriptor.ts` — every built-in maps to the row from the
  Issue #2786 table; custom names collapse to `OTHER`; the original name is
  not leaked back.
- `test/costs/CostAwareEarlyStop.ts` — unit-range, signed-unit, positive
  and unbounded costs each handle in-range, out-of-range, and negative
  thresholds correctly; `OTHER` preserves legacy behaviour.
- `test/costs/CostAwareEarlyStopIntegration.ts` — with the SAME user
  `targetError = 1.5`, `CATEGORICAL_ERROR` does NOT early-stop on
  `error = 0.5` (out-of-range threshold defers), while `MSE` DOES early-stop
  on `error = 0.5` (legitimate unbounded threshold) — the differential
  behaviour required by the acceptance criteria.

Verification command:

```bash
deno test --allow-all --no-check 'test/costs/*.ts' < /dev/null
# ok | 92 passed | 0 failed
```

## Test Plan

- [x] `test/costs/CostDescriptor.ts` — new (13 cases).
- [x] `test/costs/CostAwareEarlyStop.ts` — new (13 cases).
- [x] `test/costs/CostAwareEarlyStopIntegration.ts` — new (3 cases).
- [x] All 92 cost tests pass (`deno test 'test/costs/*.ts'`).
- [x] `evolve_NOT_gate` smoke run still terminates on `targetError` — no
      regression on the legacy `error <= targetError` path for in-range
      thresholds.
- [x] `deno check` clean on the touched files plus
      `src/creature/CreatureTraining.ts`.
- [x] `./quality.sh --lint-only` clean (`deno fmt`, lint, bash check).



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-2787 -->