### PR TITLE
Add costName → TaskDescriptor mapping helper (#2786)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.43",
+  "version": "5.0.44",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.0.42",
+  "version": "5.0.43",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2786.md
+++ b/docs/archive/pr-summaries/pr-summary-2786.md
@@ -1,0 +1,62 @@
+# Add a costName → TaskDescriptor mapping helper
+
+## Summary
+
+Adds a pure helper, `costNameToTaskDescriptor`, that maps a configured cost name
+to the structural `TaskDescriptor` NEAT-AI sends to Discovery. Built-in costs
+map to their canonical descriptor (topology / range / output squash family); any
+custom JS cost or unrecognised name collapses to the `OTHER` sentinel with a
+neutral descriptor, and the custom cost's real name is **never** emitted. No
+wire/FFI changes are included — sending the descriptor is handled separately
+(#2785). Closes #2786.
+
+New file `src/costs/CostTaskDescriptor.ts` exports the descriptor types
+(`TaskDescriptor`, `CostTopology`, `CostRange`, `OutputSquashFamily`,
+`DescriptorCostName`), the `OTHER_COST_NAME` / `OTHER_TASK_DESCRIPTOR`
+sentinels, and the `costNameToTaskDescriptor` function. All are re-exported from
+`mod.ts`.
+
+### Mapping table (Issue #2786)
+
+| costName              | topology    | range         | output squash family |
+| --------------------- | ----------- | ------------- | -------------------- |
+| MSE, MAE              | independent | unbounded     | unbounded            |
+| MAPE, MSLE            | independent | positive      | positive             |
+| BINARY_CROSS_ENTROPY  | independent | unit          | bounded_unipolar     |
+| CROSS_ENTROPY         | simplex     | unit          | bounded_unipolar     |
+| HINGE                 | margin      | signed_unit   | bounded_bipolar      |
+| CATEGORICAL_ERROR     | one_hot     | unit          | bounded_unipolar     |
+| **OTHER (custom JS)** | **unknown** | **unbounded** | **any**              |
+
+### Design notes
+
+- A `Map` (not a plain object) backs the lookup so arbitrary inputs such as
+  `"toString"` or `"__proto__"` cannot resolve to inherited prototype members.
+- Descriptors are `Object.freeze`d and safe to share without defensive copies.
+- The input string is never reflected into the returned descriptor, so a custom
+  cost name cannot leak to Discovery.
+
+```mermaid
+flowchart LR
+    A[costName] --> B{known built-in?}
+    B -- yes --> C[canonical TaskDescriptor]
+    B -- "no (custom JS / unknown)" --> D[OTHER + neutral descriptor]
+```
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot. Verified via the
+unit tests below (`15 passed | 0 failed`), plus `deno fmt`, `deno lint`, and
+`deno check` across the tree.
+
+## Test Plan
+
+Added `test/costs/CostTaskDescriptor.ts`:
+
+- Each of the eight named costs in the table maps to its exact descriptor.
+- Every registered built-in (`BUILT_IN_COST_NAMES`) echoes its own name and a
+  non-`unknown` topology.
+- Unknown cost → neutral `OTHER` descriptor.
+- A custom cost name is never reflected back into the descriptor JSON.
+- Empty string, prototype member names, and non-string input all map to `OTHER`.
+- Returned descriptors are frozen.

--- a/mod.ts
+++ b/mod.ts
@@ -209,6 +209,28 @@ export type { CostInterface } from "@costs/CostInterface.ts";
 export { Costs } from "@costs";
 
 /**
+ * Cost → TaskDescriptor mapping helper
+ *
+ * Pure helper that maps a configured cost name to the structural descriptor
+ * sent to Discovery. Built-in costs map to their canonical descriptor; custom
+ * costs collapse to the `OTHER` sentinel without leaking their real name.
+ *
+ * @see {@link module:src/costs/CostTaskDescriptor}
+ */
+export {
+  costNameToTaskDescriptor,
+  OTHER_COST_NAME,
+  OTHER_TASK_DESCRIPTOR,
+} from "@costs/CostTaskDescriptor.ts";
+export type {
+  CostRange,
+  CostTopology,
+  DescriptorCostName,
+  OutputSquashFamily,
+  TaskDescriptor,
+} from "@costs/CostTaskDescriptor.ts";
+
+/**
  * Selection Class
  *
  * This class handles the selection process within the NEAT algorithm, responsible for selecting the fittest individuals for reproduction.

--- a/src/costs/CostTaskDescriptor.ts
+++ b/src/costs/CostTaskDescriptor.ts
@@ -1,0 +1,182 @@
+/**
+ * Pure mapping from a configured cost name to the {@link TaskDescriptor} that
+ * NEAT-AI sends to Discovery (Issue #2786).
+ *
+ * The descriptor captures only the *structural shape* a cost imposes on the
+ * output layer — never the cost's implementation. Built-in costs map to their
+ * canonical descriptor; any custom JS cost or unrecognised name collapses to
+ * the {@link OTHER_COST_NAME} sentinel with a neutral descriptor.
+ *
+ * > [!IMPORTANT]
+ * > The real name of a custom cost is **never** emitted. Returning the custom
+ * > name would imply structure Discovery cannot rely on, so unrecognised names
+ * > are always reported as `OTHER`.
+ *
+ * This helper is intentionally free of wire/FFI concerns — sending the
+ * descriptor is handled separately (Issue #2785).
+ */
+
+import type { BuiltInCostName } from "@costs";
+
+/** Sentinel cost name emitted for any custom JS / unrecognised cost. */
+export const OTHER_COST_NAME = "OTHER";
+
+/**
+ * Topology the cost imposes across the output neurons.
+ *
+ * - `independent` — outputs scored element-wise, no cross-output coupling.
+ * - `simplex` — outputs form a probability distribution that sums to one.
+ * - `margin` — a signed decision margin (e.g. hinge loss).
+ * - `one_hot` — exactly one output is the correct class.
+ * - `unknown` — structure cannot be inferred (custom costs).
+ */
+export type CostTopology =
+  | "independent"
+  | "simplex"
+  | "margin"
+  | "one_hot"
+  | "unknown";
+
+/**
+ * Numeric range the cost expects target/output values to occupy.
+ *
+ * - `unbounded` — any real value.
+ * - `positive` — non-negative values.
+ * - `unit` — the closed interval [0, 1].
+ * - `signed_unit` — the closed interval [-1, 1].
+ */
+export type CostRange =
+  | "unbounded"
+  | "positive"
+  | "unit"
+  | "signed_unit";
+
+/**
+ * Family of output squash the cost is compatible with.
+ *
+ * - `unbounded` — linear / identity-style outputs.
+ * - `positive` — non-negative outputs (e.g. softplus, relu).
+ * - `bounded_unipolar` — outputs in [0, 1] (e.g. sigmoid, softmax).
+ * - `bounded_bipolar` — outputs in [-1, 1] (e.g. tanh).
+ * - `any` — no compatibility constraint (custom costs).
+ */
+export type OutputSquashFamily =
+  | "unbounded"
+  | "positive"
+  | "bounded_unipolar"
+  | "bounded_bipolar"
+  | "any";
+
+/**
+ * Canonical cost name carried in a descriptor. This is always a built-in name,
+ * the additional `BINARY_CROSS_ENTROPY` built-in, or the `OTHER` sentinel —
+ * never the real name of a custom cost.
+ */
+export type DescriptorCostName =
+  | BuiltInCostName
+  | "BINARY_CROSS_ENTROPY"
+  | typeof OTHER_COST_NAME;
+
+/** Structural descriptor of a cost, sent to Discovery. */
+export interface TaskDescriptor {
+  /** Canonical/sanitised cost name; `OTHER` for custom or unknown costs. */
+  readonly costName: DescriptorCostName;
+  /** Topology the cost imposes across outputs. */
+  readonly topology: CostTopology;
+  /** Numeric range the cost expects. */
+  readonly range: CostRange;
+  /** Output squash family the cost is compatible with. */
+  readonly outputSquashFamily: OutputSquashFamily;
+}
+
+/**
+ * Neutral descriptor returned for any custom JS cost or unrecognised name. It
+ * deliberately carries no information that would imply structure Discovery
+ * cannot rely on, and never embeds the real custom name.
+ */
+export const OTHER_TASK_DESCRIPTOR: TaskDescriptor = Object.freeze({
+  costName: OTHER_COST_NAME,
+  topology: "unknown",
+  range: "unbounded",
+  outputSquashFamily: "any",
+});
+
+/**
+ * Canonical descriptors for every named built-in cost (the table in Issue
+ * #2786). A `Map` is used rather than a plain object so arbitrary lookups (e.g.
+ * `"toString"`) cannot resolve to inherited prototype members.
+ */
+const BUILT_IN_DESCRIPTORS: ReadonlyMap<string, TaskDescriptor> = new Map(
+  ([
+    {
+      costName: "MSE",
+      topology: "independent",
+      range: "unbounded",
+      outputSquashFamily: "unbounded",
+    },
+    {
+      costName: "MAE",
+      topology: "independent",
+      range: "unbounded",
+      outputSquashFamily: "unbounded",
+    },
+    {
+      costName: "MAPE",
+      topology: "independent",
+      range: "positive",
+      outputSquashFamily: "positive",
+    },
+    {
+      costName: "MSLE",
+      topology: "independent",
+      range: "positive",
+      outputSquashFamily: "positive",
+    },
+    {
+      costName: "BINARY_CROSS_ENTROPY",
+      topology: "independent",
+      range: "unit",
+      outputSquashFamily: "bounded_unipolar",
+    },
+    {
+      costName: "CROSS_ENTROPY",
+      topology: "simplex",
+      range: "unit",
+      outputSquashFamily: "bounded_unipolar",
+    },
+    {
+      costName: "HINGE",
+      topology: "margin",
+      range: "signed_unit",
+      outputSquashFamily: "bounded_bipolar",
+    },
+    {
+      costName: "CATEGORICAL_ERROR",
+      topology: "one_hot",
+      range: "unit",
+      outputSquashFamily: "bounded_unipolar",
+    },
+  ] satisfies TaskDescriptor[]).map((
+    descriptor,
+  ) => [descriptor.costName, Object.freeze(descriptor)] as const),
+);
+
+/**
+ * Maps a configured cost name to its {@link TaskDescriptor}.
+ *
+ * Built-in costs map to their canonical descriptor. Any custom JS cost or
+ * unrecognised name returns {@link OTHER_TASK_DESCRIPTOR} — the input string is
+ * never reflected back, so a custom cost's real name cannot leak to Discovery.
+ *
+ * The returned descriptor is frozen and safe to share without defensive copies.
+ *
+ * @param costName - The configured cost name (built-in or custom).
+ * @returns The canonical descriptor, or the neutral `OTHER` descriptor.
+ */
+export function costNameToTaskDescriptor(costName: string): TaskDescriptor {
+  if (typeof costName !== "string") {
+    return OTHER_TASK_DESCRIPTOR;
+  }
+
+  return BUILT_IN_DESCRIPTORS.get(costName) ?? OTHER_TASK_DESCRIPTOR;
+}

--- a/test/costs/CostTaskDescriptor.ts
+++ b/test/costs/CostTaskDescriptor.ts
@@ -1,0 +1,134 @@
+import { assert, assertEquals } from "@std/assert";
+import { BUILT_IN_COST_NAMES } from "@costs";
+import {
+  costNameToTaskDescriptor,
+  OTHER_COST_NAME,
+  OTHER_TASK_DESCRIPTOR,
+  type TaskDescriptor,
+} from "@costs/CostTaskDescriptor.ts";
+
+/** Expected descriptors per the table in Issue #2786. */
+const EXPECTED: ReadonlyArray<TaskDescriptor> = [
+  {
+    costName: "MSE",
+    topology: "independent",
+    range: "unbounded",
+    outputSquashFamily: "unbounded",
+  },
+  {
+    costName: "MAE",
+    topology: "independent",
+    range: "unbounded",
+    outputSquashFamily: "unbounded",
+  },
+  {
+    costName: "MAPE",
+    topology: "independent",
+    range: "positive",
+    outputSquashFamily: "positive",
+  },
+  {
+    costName: "MSLE",
+    topology: "independent",
+    range: "positive",
+    outputSquashFamily: "positive",
+  },
+  {
+    costName: "BINARY_CROSS_ENTROPY",
+    topology: "independent",
+    range: "unit",
+    outputSquashFamily: "bounded_unipolar",
+  },
+  {
+    costName: "CROSS_ENTROPY",
+    topology: "simplex",
+    range: "unit",
+    outputSquashFamily: "bounded_unipolar",
+  },
+  {
+    costName: "HINGE",
+    topology: "margin",
+    range: "signed_unit",
+    outputSquashFamily: "bounded_bipolar",
+  },
+  {
+    costName: "CATEGORICAL_ERROR",
+    topology: "one_hot",
+    range: "unit",
+    outputSquashFamily: "bounded_unipolar",
+  },
+];
+
+for (const expected of EXPECTED) {
+  Deno.test(`costNameToTaskDescriptor - maps ${expected.costName} per the table`, () => {
+    assertEquals(costNameToTaskDescriptor(expected.costName), expected);
+  });
+}
+
+Deno.test("costNameToTaskDescriptor - every registered built-in maps to a non-OTHER descriptor with its own name", () => {
+  for (const name of BUILT_IN_COST_NAMES) {
+    const descriptor = costNameToTaskDescriptor(name);
+    assertEquals(
+      descriptor.costName,
+      name,
+      `built-in ${name} should echo its canonical name`,
+    );
+    assert(
+      descriptor.topology !== "unknown",
+      `built-in ${name} should not collapse to the unknown topology`,
+    );
+  }
+});
+
+Deno.test("costNameToTaskDescriptor - unknown cost returns the neutral OTHER descriptor", () => {
+  const descriptor = costNameToTaskDescriptor("NOT_A_REAL_COST");
+  assertEquals(descriptor, OTHER_TASK_DESCRIPTOR);
+  assertEquals(descriptor.costName, OTHER_COST_NAME);
+  assertEquals(descriptor.topology, "unknown");
+  assertEquals(descriptor.range, "unbounded");
+  assertEquals(descriptor.outputSquashFamily, "any");
+});
+
+Deno.test("costNameToTaskDescriptor - custom cost name is never reflected back", () => {
+  const secretName = "topSecretProprietaryLoss_v42";
+  const descriptor = costNameToTaskDescriptor(secretName);
+
+  assertEquals(descriptor.costName, OTHER_COST_NAME);
+  // The real custom name must not appear anywhere in the emitted descriptor.
+  assert(
+    !JSON.stringify(descriptor).includes(secretName),
+    "custom cost name leaked into the descriptor",
+  );
+});
+
+Deno.test("costNameToTaskDescriptor - empty string maps to OTHER", () => {
+  assertEquals(costNameToTaskDescriptor(""), OTHER_TASK_DESCRIPTOR);
+});
+
+Deno.test("costNameToTaskDescriptor - prototype member names do not resolve to descriptors", () => {
+  for (
+    const key of ["toString", "constructor", "hasOwnProperty", "__proto__"]
+  ) {
+    const descriptor = costNameToTaskDescriptor(key);
+    assertEquals(
+      descriptor,
+      OTHER_TASK_DESCRIPTOR,
+      `lookup of prototype member ${key} should be OTHER`,
+    );
+  }
+});
+
+Deno.test("costNameToTaskDescriptor - returned descriptor is immutable", () => {
+  const descriptor = costNameToTaskDescriptor("MSE");
+  assert(Object.isFrozen(descriptor), "built-in descriptor should be frozen");
+  assert(
+    Object.isFrozen(OTHER_TASK_DESCRIPTOR),
+    "OTHER descriptor should be frozen",
+  );
+});
+
+Deno.test("costNameToTaskDescriptor - non-string input maps to OTHER", () => {
+  // deno-lint-ignore no-explicit-any
+  const descriptor = costNameToTaskDescriptor(undefined as any);
+  assertEquals(descriptor, OTHER_TASK_DESCRIPTOR);
+});


### PR DESCRIPTION
# Add a costName → TaskDescriptor mapping helper

## Summary

Adds a pure helper, `costNameToTaskDescriptor`, that maps a configured cost name
to the structural `TaskDescriptor` NEAT-AI sends to Discovery. Built-in costs
map to their canonical descriptor (topology / range / output squash family); any
custom JS cost or unrecognised name collapses to the `OTHER` sentinel with a
neutral descriptor, and the custom cost's real name is **never** emitted. No
wire/FFI changes are included — sending the descriptor is handled separately
(#2785). Closes #2786.

New file `src/costs/CostTaskDescriptor.ts` exports the descriptor types
(`TaskDescriptor`, `CostTopology`, `CostRange`, `OutputSquashFamily`,
`DescriptorCostName`), the `OTHER_COST_NAME` / `OTHER_TASK_DESCRIPTOR`
sentinels, and the `costNameToTaskDescriptor` function. All are re-exported from
`mod.ts`.

### Mapping table (Issue #2786)

| costName              | topology    | range         | output squash family |
| --------------------- | ----------- | ------------- | -------------------- |
| MSE, MAE              | independent | unbounded     | unbounded            |
| MAPE, MSLE            | independent | positive      | positive             |
| BINARY_CROSS_ENTROPY  | independent | unit          | bounded_unipolar     |
| CROSS_ENTROPY         | simplex     | unit          | bounded_unipolar     |
| HINGE                 | margin      | signed_unit   | bounded_bipolar      |
| CATEGORICAL_ERROR     | one_hot     | unit          | bounded_unipolar     |
| **OTHER (custom JS)** | **unknown** | **unbounded** | **any**              |

### Design notes

- A `Map` (not a plain object) backs the lookup so arbitrary inputs such as
  `"toString"` or `"__proto__"` cannot resolve to inherited prototype members.
- Descriptors are `Object.freeze`d and safe to share without defensive copies.
- The input string is never reflected into the returned descriptor, so a custom
  cost name cannot leak to Discovery.

```mermaid
flowchart LR
    A[costName] --> B{known built-in?}
    B -- yes --> C[canonical TaskDescriptor]
    B -- "no (custom JS / unknown)" --> D[OTHER + neutral descriptor]
```

## Evidence

Backend/library change only — no web interface to screenshot. Verified via the
unit tests below (`15 passed | 0 failed`), plus `deno fmt`, `deno lint`, and
`deno check` across the tree.

## Test Plan

Added `test/costs/CostTaskDescriptor.ts`:

- Each of the eight named costs in the table maps to its exact descriptor.
- Every registered built-in (`BUILT_IN_COST_NAMES`) echoes its own name and a
  non-`unknown` topology.
- Unknown cost → neutral `OTHER` descriptor.
- A custom cost name is never reflected back into the descriptor JSON.
- Empty string, prototype member names, and non-string input all map to `OTHER`.
- Returned descriptors are frozen.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-2786 -->