### PR TITLE
Authenticate deno-outdated PR creation with ACTIONS_PUSH PAT (Issue #2780)

### DIFF
--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -47,6 +47,12 @@ jobs:
         # peter-evans/create-pull-request@v8.1.1 (node24 — Issue #2764)
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
+          # Authenticate with the org-level PAT so downstream workflow
+          # triggers (CI checks, labels, reviewer automation) fire on the
+          # raised PR. GITHUB_TOKEN-authored PRs suppress those triggers
+          # until somebody pushes a new commit (Issue #1636, Issue #2780).
+          # Fall back to GITHUB_TOKEN when ACTIONS_PUSH is unset.
+          token: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
           commit-message: "chore: update Deno dependencies"
           title: "chore: update Deno dependencies"
           branch: chore/deno-outdated

--- a/docs/archive/pr-summaries/pr-summary-2780.md
+++ b/docs/archive/pr-summaries/pr-summary-2780.md
@@ -1,0 +1,37 @@
+## Summary
+
+Authenticate the `peter-evans/create-pull-request` step in
+`.github/workflows/deno-outdated.yml` with the org-level `ACTIONS_PUSH` PAT and
+fall back to `GITHUB_TOKEN` only when the secret is unset. Using
+`GITHUB_TOKEN` directly causes GitHub to suppress downstream workflow
+triggers on the created pull request — CI checks, labels, and reviewer
+automation never fire until somebody pushes a new commit. Closes #2780.
+
+This addresses the `pr-creator-token` high-severity finding raised by the
+workflow best-practice auditor (Issue #1636, Issue #2102).
+
+## Evidence
+
+Workflow YAML change only; there is no UI to screenshot. Verified by:
+
+- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deno-outdated.yml'))"` confirms valid YAML.
+- `./quality.sh --lint-only` passes (format, lint, bash script checks).
+
+Diff applied to step at `.github/workflows/deno-outdated.yml:48`:
+
+```yaml
+- uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+  with:
+    token: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
+    commit-message: "chore: update Deno dependencies"
+    ...
+```
+
+## Test Plan
+
+- [x] YAML parses cleanly with `yaml.safe_load`.
+- [x] `./quality.sh --lint-only` passes.
+- [ ] Next scheduled (or manually dispatched) run of
+      `Deno Dependency Updates` raises a PR authored under the
+      `ACTIONS_PUSH` identity, and downstream checks (CI, labels) fire
+      automatically on that PR.


### PR DESCRIPTION
## Summary

Authenticate the `peter-evans/create-pull-request` step in
`.github/workflows/deno-outdated.yml` with the org-level `ACTIONS_PUSH`
PAT and fall back to `GITHUB_TOKEN` only when the secret is unset.
Using `GITHUB_TOKEN` directly causes GitHub to suppress downstream
workflow triggers on the created pull request — CI checks, labels, and
reviewer automation never fire until somebody pushes a new commit.

Closes #2780.

Resolves the `pr-creator-token` high-severity finding raised by the
workflow best-practice auditor (Issue #1636, Issue #2102).

## Evidence

Workflow YAML change only — no UI to screenshot. Verified by:

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deno-outdated.yml'))"` confirms valid YAML.
- `./quality.sh --lint-only` passes (format, lint, bash script checks).

## Test plan

- [x] YAML parses cleanly.
- [x] `./quality.sh --lint-only` passes.
- [ ] Next scheduled (or manually dispatched) run of `Deno Dependency
      Updates` raises a PR authored under `ACTIONS_PUSH` so downstream
      checks fire automatically.