### PR TITLE
Creature Factory: smarter initial creature seed (Issue #2794)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-2794.md
+++ b/docs/archive/pr-summaries/pr-summary-2794.md
@@ -1,0 +1,111 @@
+## Summary
+
+Adds a Creature Factory that seeds a smarter _initial_ creature from
+observations, outputs, and cost — replacing the bare
+`new Creature(nInput, nOutput)` with random output activations as the default
+starting point for evolution. The factory only changes the seed; mutation,
+Discovery, breeding, and training proceed exactly as today.
+
+The factory lives in its own module (`src/architecture/CreatureFactory.ts`) so
+`Creature.ts` (already 1.2k lines) does not grow beyond a pair of one-line
+static forwarders. `evolveDir` and every other existing signature are untouched.
+
+Closes #2794.
+
+## What the factory decides
+
+| Decision             | Source                                      | Rule                                                                                                                                               |
+| -------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Output activation    | `cost` + `outputs` + declared `outputRange` | Cost-aware default (SOFTMAX / LOGISTIC / TANH), then bounded-range bias (TANH for `[-1,1]`, LOGISTIC for `[0,1]`), else IDENTITY                   |
+| Hidden width         | `(inputs, outputs)`                         | Heaton (`⅔·n_in + n_out`, capped `<2·n_in`) for small problems; geometric mean `√(n_in·n_out)` for high-dim (≥100 inputs) to avoid 2000-wide seeds |
+| Hidden squash        | Caller hint or default                      | Defaults to `RELU`, pairs with He init                                                                                                             |
+| Weight init          | Activation family at destination            | He (`√(2/fan_in)`) for ReLU family; Xavier (`√(2/(fan_in+fan_out))`) for tanh/sigmoid family; LeCun otherwise                                      |
+| Output bias          | `forDataset` scan only                      | Mean of target column, but only when output is IDENTITY (regression); classification activations leave bias alone                                  |
+| Dead-feature pruning | `forDataset` scan only                      | Synapses out of constant inputs zeroed at construction                                                                                             |
+
+The dataset-scan tier (`creatureForDataset`) deliberately does **not** normalise
+inputs: once `inputRange` is declared, normalisation has no remaining motive.
+Only the truly non-declarable signals are inferred (dead features, target mean).
+
+## Public API (additive)
+
+```ts
+// Metadata-only (no scan)
+const seed = Creature.forProblem({
+  inputs,
+  outputs,
+  cost,
+  inputRange,
+  outputRange,
+});
+
+// Optional data scan
+const seed2 = Creature.forDataset(trainingData, { cost });
+
+await seed.evolveDir(dir); // unchanged
+```
+
+Module-level functions are also exported for callers who prefer not to go
+through the static facade: `creatureForProblem`, `creatureForDataset`,
+`scanTrainingData`, `pickOutputSquashForProblem`, `pickHiddenCapacity`,
+`targetInitStddev`, and `rescaleWeightsForInit`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Spec[ProblemSpec or DataRecords] --> Factory[CreatureFactory]
+    Factory --> Squash[pickOutputSquashForProblem]
+    Factory --> Capacity[pickHiddenCapacity]
+    Squash --> Builder
+    Capacity --> Builder
+    Builder[new Creature with layers + outputSquash] --> Rescale[rescaleWeightsForInit]
+    Rescale --> Seed[Creature]
+    Seed --> Evolve[evolveDir - unchanged]
+```
+
+## Evidence
+
+Backend-only change with no UI surface. The factory is exercised by a new
+unit-test suite — see Test Plan below. All 33 new tests pass; the existing
+creature, costs, and architecture test suites continue to pass. The worked
+example from the issue (3000 inputs, 1 output, MSE, `outputRange: [-1, 1]`) now
+seeds a 55-wide RELU hidden layer with He scaling and a TANH output, exactly the
+"small + bounded" prescription.
+
+The acceptance "headline test" (MNIST factory seed converging to ≥95%) is a
+multi-hour wall-clock evolution run that does not belong in the unit-test suite
+(Issue #574, Issue #603 — tests must finish within 120 seconds). The structural
+prerequisites for that headline are verified directly: the MNIST shape (784×10,
+CROSS_ENTROPY) produces an 89-wide RELU hidden layer with He-scaled weights and
+SOFTMAX outputs.
+
+## Test Plan
+
+New file: `test/architecture/CreatureFactory.ts` — 33 tests.
+
+- Output squash selection (8 tests): SOFTMAX for multi-class CROSS_ENTROPY /
+  CATEGORICAL_ERROR, LOGISTIC for BINARY_CROSS_ENTROPY, TANH for HINGE and for
+  bounded `[-1,1]` regression, LOGISTIC for `[0,1]` regression, IDENTITY for
+  unbounded regression, IDENTITY when no cost is declared.
+- Hidden-capacity heuristic (5 tests): geometric mean for high-dim (3000×1 →
+  55), Heaton for small problems (10×2 → 9), `2·n_in` cap (1×5 → 2), explicit
+  `hiddenCapacity` override, threshold edge case (100×1 → 10).
+- Weight-init scaling (4 tests): He stddev, Xavier stddev, LeCun fallback,
+  RELU-hidden He bound respected post-construction.
+- Construction integrity (5 tests): MNIST-shape SOFTMAX classifier,
+  worked-example 3000-input regressor, default `RELU` hidden, `hiddenSquash`
+  override, invalid dim rejection.
+- Dataset scan (4 tests): dead-feature detection, target-mean computation,
+  empty-set rejection, inconsistent-shape rejection.
+- `creatureForDataset` (4 tests): regression bias warm-start equals target mean,
+  dead-input synapses zeroed, classification bias preserved (not overridden),
+  empty set rejected.
+- Static forwarders (2 tests): `Creature.forProblem` and `Creature.forDataset`
+  delegate correctly.
+- Standalone rescaler (1 test): idempotent and finite for a manually constructed
+  creature.
+
+Regression run: `test/creature/` + `test/architecture/` + `test/costs/` all pass
+except for the pre-existing `evolveRL_heapStability_test.ts` flake
+(timing-sensitive heap measurement, passes on re-run, unrelated to this change).

--- a/mod.ts
+++ b/mod.ts
@@ -29,6 +29,35 @@ export { Creature, CURRENT_CREATURE_SEMANTIC_VERSION } from "@creature";
 export { exportSnapshotJSON } from "@creature/CreatureSerialization.ts";
 
 /**
+ * Creature Factory (Issue #2794)
+ *
+ * Builds a smarter *initial* creature from problem metadata (input /
+ * output dimensions, cost name, declared value ranges) or — optionally —
+ * from a training-set scan that adds dead-feature pruning and output
+ * bias warm-start. Same evolution thereafter; the factory just hands
+ * `evolveDir` a better starting point.
+ *
+ * @see {@link module:src/architecture/CreatureFactory}
+ */
+export {
+  creatureForDataset,
+  creatureForProblem,
+  DEAD_FEATURE_VARIANCE_THRESHOLD,
+  HIGH_DIMENSIONAL_INPUT_THRESHOLD,
+  pickHiddenCapacity,
+  pickOutputSquashForProblem,
+  rescaleWeightsForInit,
+  scanTrainingData,
+  targetInitStddev,
+} from "@architecture/CreatureFactory.ts";
+export type {
+  DatasetFactoryOptions,
+  DatasetScan,
+  NumericRange,
+  ProblemSpec,
+} from "@architecture/CreatureFactory.ts";
+
+/**
  * Episode-rollout API.
  *
  * - {@link EpisodeAdapter} (abstract class, Issue #2626) is the class-shaped

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -48,6 +48,7 @@ import { rejectRecurrentSynapseIfForwardOnlyCreature } from "@architecture/Forwa
 import { TypedTopology } from "@architecture/TypedTopology.ts";
 
 // Extracted modules
+import * as creatureFactory from "@architecture/CreatureFactory.ts";
 import * as activation from "@creature/CreatureActivation.ts";
 import * as topology from "@creature/CreatureTopology.ts";
 import type { TopologyCaches } from "@creature/CreatureTopology.ts";
@@ -1205,6 +1206,31 @@ export class Creature implements CreatureInternal {
     creature.fix({ forwardOnly: creature.forwardOnly });
     creatureValidate(creature, { forwardOnly: creature.forwardOnly });
     return creature;
+  }
+
+  /**
+   * Build a smarter initial creature from problem metadata
+   * (Issue #2794). Thin forwarder to {@link creatureForProblem} in
+   * `@architecture/CreatureFactory.ts`; see that module for the
+   * heuristics applied.
+   *
+   * Cycle-safety: {@link creatureFactory} only references the Creature
+   * class from inside function bodies, so the static import below resolves
+   * fine under ES-module live bindings.
+   */
+  static forProblem(spec: creatureFactory.ProblemSpec): Creature {
+    return creatureFactory.creatureForProblem(spec);
+  }
+
+  /**
+   * Build a smarter initial creature from a training set
+   * (Issue #2794). Thin forwarder to {@link creatureForDataset}.
+   */
+  static forDataset(
+    records: readonly DataRecordInterface[],
+    options?: creatureFactory.DatasetFactoryOptions,
+  ): Creature {
+    return creatureFactory.creatureForDataset(records, options);
   }
 
   shallowClone(): Creature {

--- a/src/architecture/CreatureFactory.ts
+++ b/src/architecture/CreatureFactory.ts
@@ -1,0 +1,517 @@
+/**
+ * Creature Factory (Issue #2794).
+ *
+ * Builds a smarter *initial* creature than `new Creature(nIn, nOut)` by
+ * choosing the output activation, hidden-layer capacity, hidden squash, and
+ * weight-scaling from problem metadata. The factory only seeds the starting
+ * point — evolution (mutation, Discovery, breeding, training) proceeds
+ * exactly as today. The principle: seed only from facts true of *any*
+ * problem, never a dataset-specific architecture copied from a benchmark.
+ *
+ * The factory lives in its own module so {@link Creature} does not grow.
+ * `Creature.ts` and `evolveDir` signatures are unchanged; the factory simply
+ * hands `evolveDir` a better starting `Creature`.
+ *
+ * Sources for the heuristics used here:
+ *
+ * - Output activation + loss coupling: ML Mastery
+ *   <https://machinelearningmastery.com/choose-an-activation-function-for-deep-learning/>
+ *   and the canonical CostDescriptor table.
+ * - Weight initialisation: He vs Xavier
+ *   <https://www.aryanupadhyay.com/post/why-weight-initialization-is-important-in-deep-learning-xavier-vs-he-explained>.
+ * - Hidden-layer capacity: Heaton, "The Number of Hidden Layers"
+ *   <https://www.heatonresearch.com/2017/06/01/hidden-layers.html>.
+ *
+ * Two factory entry points:
+ *
+ * - {@link creatureForProblem} — metadata-only, no data scan. Uses
+ *   `(inputs, outputs, cost)` plus declarable `inputRange` / `outputRange`
+ *   to pick output activation, hidden capacity, and weight scaling.
+ * - {@link creatureForDataset} — optional scan over a training set. Adds
+ *   only the non-declarable smarts: dead/constant feature pruning and
+ *   target-mean output bias initialisation. Normalisation is *not* a
+ *   reason to scan once ranges are declared.
+ *
+ * The public API on {@link Creature} surfaces these as static methods:
+ *
+ * ```ts
+ * const seed  = Creature.forProblem({ inputs, outputs, cost, inputRange, outputRange });
+ * const seed2 = Creature.forDataset(trainingData, { cost });
+ * await seed.evolveDir(dir); // unchanged
+ * ```
+ */
+
+import { Creature } from "@creature";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import { pickOutputSquashForCost } from "@costs/CostOutputSquash.ts";
+
+/** Inclusive numeric range, e.g. `{ min: -1, max: 1 }`. */
+export interface NumericRange {
+  min: number;
+  max: number;
+}
+
+/**
+ * Problem metadata for {@link creatureForProblem}.
+ *
+ * Only `inputs` and `outputs` are required. Every other field is an
+ * optional hint that lets the factory make a smarter seed without needing
+ * to scan the data.
+ */
+export interface ProblemSpec {
+  /** Number of observation features (input neurons). */
+  inputs: number;
+  /** Number of output neurons. */
+  outputs: number;
+  /**
+   * Cost / task name (e.g. `"MSE"`, `"CROSS_ENTROPY"`, `"CATEGORICAL_ERROR"`,
+   * `"BINARY_CROSS_ENTROPY"`, `"HINGE"`). When omitted, the factory falls
+   * back to the regression defaults (linear output, no bias).
+   */
+  cost?: string;
+  /**
+   * Declared input value range. When provided the factory does *not* try
+   * to normalise inputs — declared-as-already-normalised inputs are
+   * trusted. The scan-tier (dead-feature pruning) ignores this range; it
+   * only inspects per-feature variance.
+   */
+  inputRange?: NumericRange;
+  /**
+   * Declared output value range. When the cost has no built-in output
+   * pairing (regression costs like MSE) and the range is bounded
+   * symmetrically (≈ `[-1, 1]`), the factory picks TANH; otherwise it
+   * picks the linear IDENTITY activation.
+   */
+  outputRange?: NumericRange;
+  /**
+   * Optional override for hidden-layer width. When omitted the factory
+   * derives capacity from `(inputs, outputs)` using Heaton's rule for
+   * small problems and the geometric mean for high-dimensional ones.
+   */
+  hiddenCapacity?: number;
+  /**
+   * Optional override for hidden-neuron squash. When omitted the factory
+   * defaults to `"RELU"`, which composes well with He initialisation.
+   */
+  hiddenSquash?: string;
+  /**
+   * Whether feedback / recurrent topology is allowed. Mirrors
+   * `CreatureOptions.feedbackEnabled`; defaults to forward-only.
+   */
+  feedbackEnabled?: boolean;
+}
+
+/** Result of {@link scanTrainingData}: the non-declarable observations. */
+export interface DatasetScan {
+  /** Number of records scanned. */
+  sampleCount: number;
+  /** Per-input feature mean over the scanned records. */
+  inputMean: Float32Array;
+  /** Per-input feature variance over the scanned records (population). */
+  inputVariance: Float32Array;
+  /**
+   * Indices of inputs whose variance is below {@link DEAD_FEATURE_VARIANCE_THRESHOLD}.
+   * Empty when no dead features were detected.
+   */
+  deadInputIndices: number[];
+  /** Per-output target mean over the scanned records. */
+  outputMean: Float32Array;
+  /** Per-output target variance over the scanned records. */
+  outputVariance: Float32Array;
+}
+
+/**
+ * Variance below this is treated as a "constant / near-constant" input
+ * feature in {@link scanTrainingData}. Far smaller than the per-feature
+ * variance of any meaningful normalised input.
+ */
+export const DEAD_FEATURE_VARIANCE_THRESHOLD = 1e-8;
+
+/**
+ * High-dimensional crossover: above this input count the factory prefers
+ * the geometric-mean capacity rule (sqrt(n_in·n_out)) over Heaton's rule
+ * (2/3·n_in + n_out) to avoid seeding 2000-wide hidden layers for
+ * sample-limited problems.
+ */
+export const HIGH_DIMENSIONAL_INPUT_THRESHOLD = 100;
+
+// ─── Activation families (for weight-init scaling) ──────────────────────
+
+/** Activations paired with He initialisation: stddev = sqrt(2 / fan_in). */
+const HE_FAMILY: ReadonlySet<string> = new Set([
+  "RELU",
+  "ReLU",
+  "LeakyReLU",
+  "RELU6",
+  "ReLU6",
+  "ELU",
+  "SELU",
+  "GELU",
+  "Mish",
+  "MISH",
+  "Swish",
+  "SWISH",
+  "Softplus",
+  "SOFTPLUS",
+]);
+
+/** Activations paired with Xavier/Glorot: stddev = sqrt(2 / (fan_in+fan_out)). */
+const XAVIER_FAMILY: ReadonlySet<string> = new Set([
+  "LOGISTIC",
+  "TANH",
+  "BIPOLAR_SIGMOID",
+  "SOFTSIGN",
+  "SOFTMAX",
+  "ArcTan",
+  "ARCTAN",
+  "HARD_TANH",
+  "LogSigmoid",
+  "BIPOLAR",
+  "IDENTITY",
+]);
+
+/**
+ * Standard deviation of a uniform draw on `[-0.5, 0.5]` (the existing
+ * {@link Synapse.randomWeight} range with `scale = 1`). Used to rescale
+ * the constructor's random weights to the target init stddev.
+ */
+const RANDOM_WEIGHT_STDDEV = Math.sqrt(1 / 12);
+
+/**
+ * Pick the output squash for a problem spec.
+ *
+ * The cost descriptor takes precedence (e.g. CROSS_ENTROPY → SOFTMAX).
+ * Regression costs (which return `undefined` from
+ * {@link pickOutputSquashForCost}) then look at `outputRange`:
+ *
+ * - Bounded symmetric ≈ `[-1, 1]` → `TANH`.
+ * - Bounded ≥ 0 → `LOGISTIC` if `[0, 1]`, otherwise still TANH.
+ * - Unbounded / unknown → `IDENTITY` (linear), the standard regression
+ *   choice.
+ */
+export function pickOutputSquashForProblem(spec: ProblemSpec): string {
+  const costPick = pickOutputSquashForCost(spec.cost, spec.outputs);
+  if (costPick) return costPick;
+
+  const range = spec.outputRange;
+  if (range && Number.isFinite(range.min) && Number.isFinite(range.max)) {
+    const min = range.min;
+    const max = range.max;
+    if (Math.abs(min + max) < 1e-6 && max > 0) {
+      // Symmetric around zero → bipolar bounded output.
+      return "TANH";
+    }
+    if (min >= 0 && max <= 1) {
+      // Unit-interval target → Bernoulli-style sigmoid.
+      return "LOGISTIC";
+    }
+    if (Number.isFinite(min) && Number.isFinite(max)) {
+      // Bounded but not on a canonical interval — default to TANH which
+      // at least cannot blow up.
+      return "TANH";
+    }
+  }
+
+  // No cost opinion, no range → linear regression output.
+  return "IDENTITY";
+}
+
+/**
+ * Pick a starting hidden-layer width from `(inputs, outputs)`.
+ *
+ * Heaton's "between input and output" rule is used for small problems
+ * (`inputs < HIGH_DIMENSIONAL_INPUT_THRESHOLD`); the geometric mean
+ * `sqrt(inputs·outputs)` is used for high-dimensional problems where
+ * `2/3·inputs + outputs` is far too wide. Always returns at least 1.
+ */
+export function pickHiddenCapacity(spec: ProblemSpec): number {
+  if (spec.hiddenCapacity !== undefined) {
+    return Math.max(1, Math.floor(spec.hiddenCapacity));
+  }
+  const nIn = Math.max(1, Math.floor(spec.inputs));
+  const nOut = Math.max(1, Math.floor(spec.outputs));
+
+  if (nIn >= HIGH_DIMENSIONAL_INPUT_THRESHOLD) {
+    // High-dim / sample-limited regime — geometric mean. The worked
+    // example in #2794: n_in=3000, n_out=1 → 55.
+    return Math.max(1, Math.round(Math.sqrt(nIn * nOut)));
+  }
+
+  // Heaton's rule, capped at 2·n_in.
+  const heaton = Math.ceil((2 / 3) * nIn + nOut);
+  const cap = Math.max(1, Math.floor(2 * nIn));
+  return Math.max(1, Math.min(heaton, cap));
+}
+
+/**
+ * Return the target standard deviation for a synapse weight whose
+ * destination neuron uses `squash`, given the layer's `fan_in` /
+ * `fan_out`.
+ */
+export function targetInitStddev(
+  squash: string | undefined,
+  fanIn: number,
+  fanOut: number,
+): number {
+  const fIn = Math.max(1, fanIn);
+  const fOut = Math.max(1, fanOut);
+  if (squash && HE_FAMILY.has(squash)) {
+    return Math.sqrt(2 / fIn);
+  }
+  if (squash && XAVIER_FAMILY.has(squash)) {
+    return Math.sqrt(2 / (fIn + fOut));
+  }
+  // Conservative default: LeCun-style 1/sqrt(fan_in).
+  return Math.sqrt(1 / fIn);
+}
+
+/**
+ * Rescale every non-input synapse weight so its expected stddev matches
+ * the target init for the destination neuron's squash. Operates in place;
+ * preserves the sign and zero-cluster of {@link Synapse.randomWeight}.
+ */
+export function rescaleWeightsForInit(creature: Creature): void {
+  // Count fan_in per destination and fan_out per source.
+  const fanIn = new Int32Array(creature.neurons.length);
+  const fanOut = new Int32Array(creature.neurons.length);
+  for (const s of creature.synapses) {
+    fanIn[s.to]++;
+    fanOut[s.from]++;
+  }
+
+  for (const s of creature.synapses) {
+    const dest = creature.neurons[s.to];
+    const target = targetInitStddev(dest.squash, fanIn[s.to], fanOut[s.from]);
+    // Scale the existing random weight from its native uniform stddev to
+    // the target stddev. Preserves the constructor's deterministic
+    // sampling order — useful for reproducibility under a seeded RNG.
+    const scale = target / RANDOM_WEIGHT_STDDEV;
+    s.weight = s.weight * scale;
+  }
+}
+
+/**
+ * Metadata-only factory entry point. See {@link ProblemSpec} for the
+ * supported hints.
+ *
+ * @example
+ * ```ts
+ * const seed = creatureForProblem({
+ *   inputs: 3000,
+ *   outputs: 1,
+ *   cost: "MSE",
+ *   outputRange: { min: -1, max: 1 },
+ * });
+ * // → small hidden layer (~55), TANH output, He-scaled weights.
+ * ```
+ */
+export function creatureForProblem(spec: ProblemSpec): Creature {
+  if (!Number.isFinite(spec.inputs) || spec.inputs < 1) {
+    throw new RangeError(
+      `creatureForProblem: inputs must be ≥ 1, got ${spec.inputs}`,
+    );
+  }
+  if (!Number.isFinite(spec.outputs) || spec.outputs < 1) {
+    throw new RangeError(
+      `creatureForProblem: outputs must be ≥ 1, got ${spec.outputs}`,
+    );
+  }
+
+  const outputSquash = pickOutputSquashForProblem(spec);
+  const hiddenCount = pickHiddenCapacity(spec);
+  const hiddenSquash = spec.hiddenSquash ?? "RELU";
+
+  const creature = new Creature(
+    Math.floor(spec.inputs),
+    Math.floor(spec.outputs),
+    {
+      costName: spec.cost,
+      outputLayer: { squash: outputSquash },
+      layers: hiddenCount > 0
+        ? [{ count: hiddenCount, squash: hiddenSquash }]
+        : undefined,
+      feedbackEnabled: spec.feedbackEnabled,
+    },
+  );
+
+  rescaleWeightsForInit(creature);
+  return creature;
+}
+
+/**
+ * Scan a training set for the non-declarable signals the metadata-only
+ * factory cannot infer:
+ *
+ * - Per-input feature mean / variance (and dead/constant features).
+ * - Per-output target mean / variance (for bias warm-start).
+ *
+ * Deliberately *not* in scope: normalisation. Once `inputRange` is
+ * declared (see {@link ProblemSpec.inputRange}) the normalisation motive
+ * to scan disappears, so the factory does not attempt it.
+ *
+ * Time / space complexity: O(N · (inputs + outputs)). For very large
+ * datasets the caller can pass a sampled subset.
+ */
+export function scanTrainingData(
+  records: readonly DataRecordInterface[],
+): DatasetScan {
+  if (records.length === 0) {
+    throw new RangeError(
+      "scanTrainingData: training set must contain at least one record",
+    );
+  }
+  const inputLen = records[0].input.length;
+  const outputLen = records[0].output.length;
+  if (inputLen === 0) {
+    throw new RangeError("scanTrainingData: input length must be ≥ 1");
+  }
+
+  // Welford's algorithm for stable per-dim mean/variance.
+  const inputMean = new Float64Array(inputLen);
+  const inputM2 = new Float64Array(inputLen);
+  const outputMean = new Float64Array(outputLen);
+  const outputM2 = new Float64Array(outputLen);
+
+  let n = 0;
+  for (const rec of records) {
+    if (rec.input.length !== inputLen) {
+      throw new RangeError(
+        `scanTrainingData: inconsistent input length at record ${n}: ` +
+          `expected ${inputLen}, got ${rec.input.length}`,
+      );
+    }
+    if (rec.output.length !== outputLen) {
+      throw new RangeError(
+        `scanTrainingData: inconsistent output length at record ${n}: ` +
+          `expected ${outputLen}, got ${rec.output.length}`,
+      );
+    }
+    n++;
+    for (let i = 0; i < inputLen; i++) {
+      const x = rec.input[i];
+      const delta = x - inputMean[i];
+      inputMean[i] += delta / n;
+      const delta2 = x - inputMean[i];
+      inputM2[i] += delta * delta2;
+    }
+    for (let j = 0; j < outputLen; j++) {
+      const y = rec.output[j];
+      const delta = y - outputMean[j];
+      outputMean[j] += delta / n;
+      const delta2 = y - outputMean[j];
+      outputM2[j] += delta * delta2;
+    }
+  }
+
+  const inputVariance = new Float32Array(inputLen);
+  const dead: number[] = [];
+  for (let i = 0; i < inputLen; i++) {
+    const v = n > 0 ? inputM2[i] / n : 0;
+    inputVariance[i] = v;
+    if (v <= DEAD_FEATURE_VARIANCE_THRESHOLD) dead.push(i);
+  }
+  const outputVariance = new Float32Array(outputLen);
+  for (let j = 0; j < outputLen; j++) {
+    outputVariance[j] = n > 0 ? outputM2[j] / n : 0;
+  }
+
+  const inputMeanF32 = new Float32Array(inputLen);
+  for (let i = 0; i < inputLen; i++) inputMeanF32[i] = inputMean[i];
+  const outputMeanF32 = new Float32Array(outputLen);
+  for (let j = 0; j < outputLen; j++) outputMeanF32[j] = outputMean[j];
+
+  return {
+    sampleCount: n,
+    inputMean: inputMeanF32,
+    inputVariance,
+    deadInputIndices: dead,
+    outputMean: outputMeanF32,
+    outputVariance,
+  };
+}
+
+/** Options for {@link creatureForDataset}. */
+export interface DatasetFactoryOptions {
+  /** Cost / task name (see {@link ProblemSpec.cost}). */
+  cost?: string;
+  /** Declared input value range; identical semantics to {@link ProblemSpec.inputRange}. */
+  inputRange?: NumericRange;
+  /** Declared output value range; identical semantics to {@link ProblemSpec.outputRange}. */
+  outputRange?: NumericRange;
+  /** Hidden-layer width override. */
+  hiddenCapacity?: number;
+  /** Hidden-neuron squash override. */
+  hiddenSquash?: string;
+  /** Whether feedback / recurrent topology is allowed. */
+  feedbackEnabled?: boolean;
+}
+
+/**
+ * Dataset-aware factory. Scans `records` for non-declarable signals
+ * (dead features, target stats) and seeds the creature accordingly:
+ *
+ * - **Dead-feature pruning** — synapses originating from constant inputs
+ *   are zeroed so the initial forward pass does not propagate their
+ *   noise. The input neuron itself is left in place because input arity
+ *   is fixed for the lifetime of a creature.
+ * - **Output bias warm-start** — for regression-style costs (no
+ *   classification output activation), each output neuron's bias is set
+ *   to the mean of its target column. The model can therefore predict
+ *   the mean without any training, dramatically lowering the starting
+ *   loss.
+ *
+ * @returns a fresh {@link Creature} ready for `evolveDir`.
+ */
+export function creatureForDataset(
+  records: readonly DataRecordInterface[],
+  options: DatasetFactoryOptions = {},
+): Creature {
+  if (records.length === 0) {
+    throw new RangeError(
+      "creatureForDataset: training set must contain at least one record",
+    );
+  }
+  const scan = scanTrainingData(records);
+  const inputs = records[0].input.length;
+  const outputs = records[0].output.length;
+
+  const spec: ProblemSpec = {
+    inputs,
+    outputs,
+    cost: options.cost,
+    inputRange: options.inputRange,
+    outputRange: options.outputRange,
+    hiddenCapacity: options.hiddenCapacity,
+    hiddenSquash: options.hiddenSquash,
+    feedbackEnabled: options.feedbackEnabled,
+  };
+  const creature = creatureForProblem(spec);
+
+  // Output bias warm-start — only meaningful when the output activation
+  // is the linear IDENTITY (regression). Classification activations
+  // (SOFTMAX / LOGISTIC / TANH) sit on a non-linear curve so the mean
+  // target is not a sensible bias.
+  const outputSquash = pickOutputSquashForProblem(spec);
+  if (outputSquash === "IDENTITY") {
+    const outputNeurons = creature.neurons.filter((n) => n.type === "output");
+    for (
+      let j = 0;
+      j < outputNeurons.length && j < scan.outputMean.length;
+      j++
+    ) {
+      const mean = scan.outputMean[j];
+      if (Number.isFinite(mean)) outputNeurons[j].bias = mean;
+    }
+  }
+
+  // Dead-feature pruning: zero out synapses originating from inputs
+  // whose variance was at floor.
+  if (scan.deadInputIndices.length > 0) {
+    const dead = new Set(scan.deadInputIndices);
+    for (const synapse of creature.synapses) {
+      if (dead.has(synapse.from)) synapse.weight = 0;
+    }
+  }
+
+  return creature;
+}

--- a/test/architecture/CreatureFactory.ts
+++ b/test/architecture/CreatureFactory.ts
@@ -1,0 +1,431 @@
+/**
+ * Tests for the Creature Factory (Issue #2794).
+ *
+ * Covers the metadata-only entry point (`creatureForProblem`) and the
+ * optional dataset-scan entry point (`creatureForDataset`), plus the
+ * static-method forwarders on `Creature`.
+ *
+ * Acceptance criteria from the issue:
+ *  - Factory lives in its own module — exercised by importing from
+ *    `@architecture/CreatureFactory.ts` directly.
+ *  - Output activation + loss derived from the cost.
+ *  - Weight/bias init scaled by fan-in / activation.
+ *  - Capacity heuristic from `(n_in, n_out)`, biased small for high-dim.
+ *  - Declarable input/output ranges select bounded output (TANH) and
+ *    skip normalization with no scan.
+ *  - Optional `forDataset` scan adds non-declarable smarts (dead-feature
+ *    pruning, target stats) — not normalization.
+ */
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import {
+  creatureForDataset,
+  creatureForProblem,
+  DEAD_FEATURE_VARIANCE_THRESHOLD,
+  HIGH_DIMENSIONAL_INPUT_THRESHOLD,
+  pickHiddenCapacity,
+  pickOutputSquashForProblem,
+  rescaleWeightsForInit,
+  scanTrainingData,
+  targetInitStddev,
+} from "@architecture/CreatureFactory.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+
+// ─── Output squash selection ────────────────────────────────────────────
+
+Deno.test("pickOutputSquashForProblem: CROSS_ENTROPY + multi-class → SOFTMAX", () => {
+  assertEquals(
+    pickOutputSquashForProblem({
+      inputs: 10,
+      outputs: 10,
+      cost: "CROSS_ENTROPY",
+    }),
+    "SOFTMAX",
+  );
+});
+
+Deno.test("pickOutputSquashForProblem: CATEGORICAL_ERROR + multi-class → SOFTMAX", () => {
+  assertEquals(
+    pickOutputSquashForProblem({
+      inputs: 784,
+      outputs: 10,
+      cost: "CATEGORICAL_ERROR",
+    }),
+    "SOFTMAX",
+  );
+});
+
+Deno.test("pickOutputSquashForProblem: BINARY_CROSS_ENTROPY → LOGISTIC", () => {
+  assertEquals(
+    pickOutputSquashForProblem({
+      inputs: 5,
+      outputs: 1,
+      cost: "BINARY_CROSS_ENTROPY",
+    }),
+    "LOGISTIC",
+  );
+});
+
+Deno.test("pickOutputSquashForProblem: HINGE → TANH", () => {
+  assertEquals(
+    pickOutputSquashForProblem({ inputs: 5, outputs: 3, cost: "HINGE" }),
+    "TANH",
+  );
+});
+
+Deno.test("pickOutputSquashForProblem: MSE with no range → IDENTITY (linear)", () => {
+  assertEquals(
+    pickOutputSquashForProblem({ inputs: 10, outputs: 1, cost: "MSE" }),
+    "IDENTITY",
+  );
+});
+
+Deno.test("pickOutputSquashForProblem: MSE with outputRange [-1, 1] → TANH", () => {
+  assertEquals(
+    pickOutputSquashForProblem({
+      inputs: 3000,
+      outputs: 1,
+      cost: "MSE",
+      outputRange: { min: -1, max: 1 },
+    }),
+    "TANH",
+  );
+});
+
+Deno.test("pickOutputSquashForProblem: MSE with outputRange [0, 1] → LOGISTIC", () => {
+  assertEquals(
+    pickOutputSquashForProblem({
+      inputs: 10,
+      outputs: 1,
+      cost: "MSE",
+      outputRange: { min: 0, max: 1 },
+    }),
+    "LOGISTIC",
+  );
+});
+
+Deno.test("pickOutputSquashForProblem: no cost, no range → IDENTITY", () => {
+  assertEquals(
+    pickOutputSquashForProblem({ inputs: 5, outputs: 2 }),
+    "IDENTITY",
+  );
+});
+
+// ─── Hidden-capacity heuristic ──────────────────────────────────────────
+
+Deno.test("pickHiddenCapacity: high-dim uses geometric mean (3000×1 → ~55)", () => {
+  const hidden = pickHiddenCapacity({ inputs: 3000, outputs: 1 });
+  // sqrt(3000) ≈ 54.77 → rounds to 55.
+  assertEquals(hidden, 55);
+});
+
+Deno.test("pickHiddenCapacity: small problems use Heaton (10×2 → 9)", () => {
+  // ⌈2/3 · 10 + 2⌉ = ⌈8.667⌉ = 9. Cap = 20, not active.
+  const hidden = pickHiddenCapacity({ inputs: 10, outputs: 2 });
+  assertEquals(hidden, 9);
+});
+
+Deno.test("pickHiddenCapacity: Heaton cap at 2·n_in (1×5 → cap=2)", () => {
+  // ⌈2/3 + 5⌉ = 6, cap = 2, result = 2.
+  const hidden = pickHiddenCapacity({ inputs: 1, outputs: 5 });
+  assertEquals(hidden, 2);
+});
+
+Deno.test("pickHiddenCapacity: explicit hiddenCapacity override wins", () => {
+  assertEquals(
+    pickHiddenCapacity({ inputs: 3000, outputs: 1, hiddenCapacity: 8 }),
+    8,
+  );
+});
+
+Deno.test("pickHiddenCapacity: high-dim threshold edge case", () => {
+  // Right at threshold: 100×1 → geometric path → round(sqrt(100)) = 10.
+  assert(
+    pickHiddenCapacity({
+      inputs: HIGH_DIMENSIONAL_INPUT_THRESHOLD,
+      outputs: 1,
+    }) === 10,
+  );
+});
+
+// ─── Weight-init scaling ────────────────────────────────────────────────
+
+Deno.test("targetInitStddev: He family scales by sqrt(2/fan_in)", () => {
+  const stddev = targetInitStddev("RELU", 100, 10);
+  assertEquals(stddev, Math.sqrt(2 / 100));
+});
+
+Deno.test("targetInitStddev: Xavier family scales by sqrt(2/(fan_in+fan_out))", () => {
+  const stddev = targetInitStddev("TANH", 100, 100);
+  assertEquals(stddev, Math.sqrt(2 / 200));
+});
+
+Deno.test("targetInitStddev: unknown squash falls back to LeCun (sqrt(1/fan_in))", () => {
+  const stddev = targetInitStddev("MYSTERY", 100, 10);
+  assertEquals(stddev, Math.sqrt(1 / 100));
+});
+
+Deno.test("rescaleWeightsForInit: hidden-layer weights bounded by He scaling", () => {
+  const creature = creatureForProblem({
+    inputs: 100,
+    outputs: 1,
+    cost: "MSE",
+    hiddenSquash: "RELU",
+  });
+  // fan_in into the hidden layer = 100, He stddev = sqrt(2/100) ≈ 0.1414.
+  // A weight rescaled from uniform [-0.5, 0.5] (stddev ≈ 0.289) to the
+  // target scales by 0.1414/0.289 ≈ 0.49 — so |weight| ≤ 0.5 · 0.49 ≈ 0.245.
+  // The bound applies only to He-family destinations (the hidden layer);
+  // the output's Xavier scale legitimately produces larger weights when
+  // fan_in into the output is small.
+  const heLimit = Math.sqrt(2 / 100) * 0.5 / Math.sqrt(1 / 12);
+  let heChecked = 0;
+  for (const synapse of creature.synapses) {
+    const dest = creature.neurons[synapse.to];
+    if (dest.squash !== "RELU") continue;
+    heChecked++;
+    assert(
+      Math.abs(synapse.weight) <= heLimit + 1e-6,
+      `weight ${synapse.weight} exceeded He upper bound ${heLimit}`,
+    );
+  }
+  assert(
+    heChecked > 0,
+    "expected at least one synapse into the RELU hidden layer",
+  );
+});
+
+// ─── Construction integrity ─────────────────────────────────────────────
+
+Deno.test("creatureForProblem(MNIST-shape) produces a valid SOFTMAX classifier", () => {
+  const creature = creatureForProblem({
+    inputs: 784,
+    outputs: 10,
+    cost: "CROSS_ENTROPY",
+    inputRange: { min: 0, max: 1 },
+  });
+  creatureValidate(creature);
+  assertEquals(creature.input, 784);
+  assertEquals(creature.output, 10);
+  for (const neuron of creature.neurons) {
+    if (neuron.type === "output") assertEquals(neuron.squash, "SOFTMAX");
+  }
+  // The factory should not seed a 2·784-wide hidden layer for this input
+  // arity; 784 is past the high-dim threshold so geometric mean applies.
+  // sqrt(784·10) ≈ 88.5 → 89.
+  const hiddenCount =
+    creature.neurons.filter((n) => n.type === "hidden").length;
+  assertEquals(hiddenCount, 89);
+});
+
+Deno.test("creatureForProblem(worked-example) uses small hidden + TANH output", () => {
+  // From the issue: 3000 inputs, 1 output, MSE, all values in [-1, 1].
+  const creature = creatureForProblem({
+    inputs: 3000,
+    outputs: 1,
+    cost: "MSE",
+    inputRange: { min: -1, max: 1 },
+    outputRange: { min: -1, max: 1 },
+  });
+  creatureValidate(creature);
+  const output = creature.neurons.find((n) => n.type === "output")!;
+  assertEquals(output.squash, "TANH");
+  const hiddenCount =
+    creature.neurons.filter((n) => n.type === "hidden").length;
+  // sqrt(3000) ≈ 55 — much smaller than 2/3·3000 = 2000.
+  assertEquals(hiddenCount, 55);
+});
+
+Deno.test("creatureForProblem leaves hidden neurons as RELU by default", () => {
+  const creature = creatureForProblem({ inputs: 8, outputs: 2, cost: "MSE" });
+  for (const neuron of creature.neurons) {
+    if (neuron.type === "hidden") assertEquals(neuron.squash, "RELU");
+  }
+});
+
+Deno.test("creatureForProblem honours hiddenSquash override", () => {
+  const creature = creatureForProblem({
+    inputs: 8,
+    outputs: 2,
+    cost: "MSE",
+    hiddenSquash: "TANH",
+  });
+  for (const neuron of creature.neurons) {
+    if (neuron.type === "hidden") assertEquals(neuron.squash, "TANH");
+  }
+});
+
+Deno.test("creatureForProblem rejects non-positive dims", () => {
+  assertThrows(
+    () => creatureForProblem({ inputs: 0, outputs: 1 }),
+    RangeError,
+  );
+  assertThrows(
+    () => creatureForProblem({ inputs: 5, outputs: 0 }),
+    RangeError,
+  );
+});
+
+// ─── Dataset scan ───────────────────────────────────────────────────────
+
+Deno.test("scanTrainingData: detects constant (dead) features", () => {
+  const records: DataRecordInterface[] = [
+    { input: new Float32Array([0, 1, 2]), output: new Float32Array([0.1]) },
+    { input: new Float32Array([0, 3, 4]), output: new Float32Array([0.2]) },
+    { input: new Float32Array([0, 5, 6]), output: new Float32Array([0.3]) },
+  ];
+  const scan = scanTrainingData(records);
+  assertEquals(scan.sampleCount, 3);
+  assertEquals(scan.deadInputIndices, [0]);
+  assert(scan.inputVariance[0] <= DEAD_FEATURE_VARIANCE_THRESHOLD);
+  assert(scan.inputVariance[1] > DEAD_FEATURE_VARIANCE_THRESHOLD);
+});
+
+Deno.test("scanTrainingData: target mean used for output-bias warm-start", () => {
+  const records: DataRecordInterface[] = [
+    { input: new Float32Array([1, 2]), output: new Float32Array([5]) },
+    { input: new Float32Array([3, 4]), output: new Float32Array([7]) },
+    { input: new Float32Array([5, 6]), output: new Float32Array([9]) },
+  ];
+  const scan = scanTrainingData(records);
+  // mean = (5 + 7 + 9) / 3 = 7.
+  assertEquals(scan.outputMean[0], 7);
+});
+
+Deno.test("scanTrainingData: rejects empty training set", () => {
+  assertThrows(
+    () => scanTrainingData([]),
+    RangeError,
+  );
+});
+
+Deno.test("scanTrainingData: rejects inconsistent record shapes", () => {
+  assertThrows(
+    () =>
+      scanTrainingData([
+        { input: new Float32Array([1, 2]), output: new Float32Array([0]) },
+        { input: new Float32Array([1, 2, 3]), output: new Float32Array([0]) },
+      ]),
+    RangeError,
+  );
+});
+
+Deno.test("creatureForDataset: regression output bias matches target mean", () => {
+  const records: DataRecordInterface[] = [
+    { input: new Float32Array([1, 2]), output: new Float32Array([5]) },
+    { input: new Float32Array([3, 4]), output: new Float32Array([7]) },
+    { input: new Float32Array([5, 6]), output: new Float32Array([9]) },
+  ];
+  const creature = creatureForDataset(records, { cost: "MSE" });
+  const output = creature.neurons.find((n) => n.type === "output")!;
+  assertEquals(output.squash, "IDENTITY");
+  // Target mean = 7; output bias should be initialised to that.
+  assertEquals(output.bias, 7);
+});
+
+Deno.test("creatureForDataset: zeroes synapses out of dead inputs", () => {
+  const records: DataRecordInterface[] = [
+    { input: new Float32Array([0, 1, 2]), output: new Float32Array([0.1]) },
+    { input: new Float32Array([0, 3, 4]), output: new Float32Array([0.2]) },
+    { input: new Float32Array([0, 5, 6]), output: new Float32Array([0.3]) },
+  ];
+  const creature = creatureForDataset(records, { cost: "MSE" });
+  // Input neuron 0 is constant — every synapse from index 0 must be zeroed.
+  let zeroed = 0;
+  let nonZeroFromOtherInputs = 0;
+  for (const synapse of creature.synapses) {
+    if (synapse.from === 0) {
+      assertEquals(synapse.weight, 0);
+      zeroed++;
+    } else if (synapse.from === 1 || synapse.from === 2) {
+      if (synapse.weight !== 0) nonZeroFromOtherInputs++;
+    }
+  }
+  assert(zeroed > 0, "expected at least one synapse from dead input 0");
+  assert(
+    nonZeroFromOtherInputs > 0,
+    "live inputs must keep some non-zero synapses",
+  );
+});
+
+Deno.test("creatureForDataset: classification output bias is NOT overridden", () => {
+  // Bias warm-start is meaningful only for IDENTITY outputs (regression);
+  // a SOFTMAX output should NOT be force-set to the one-hot mean.
+  const records: DataRecordInterface[] = [
+    {
+      input: new Float32Array([0.1, 0.2]),
+      output: new Float32Array([1, 0, 0]),
+    },
+    {
+      input: new Float32Array([0.3, 0.4]),
+      output: new Float32Array([0, 1, 0]),
+    },
+    {
+      input: new Float32Array([0.5, 0.6]),
+      output: new Float32Array([0, 0, 1]),
+    },
+  ];
+  const creature = creatureForDataset(records, { cost: "CATEGORICAL_ERROR" });
+  for (const neuron of creature.neurons) {
+    if (neuron.type === "output") {
+      assertEquals(neuron.squash, "SOFTMAX");
+      // The IDENTITY-only bias path must NOT have run, so bias is still
+      // the constructor's small random draw, certainly not 1/3.
+      assert(
+        Math.abs(neuron.bias) < 0.2,
+        `softmax output bias should be near the constructor default, was ${neuron.bias}`,
+      );
+    }
+  }
+});
+
+Deno.test("creatureForDataset: empty training set throws", () => {
+  assertThrows(
+    () => creatureForDataset([], { cost: "MSE" }),
+    RangeError,
+  );
+});
+
+// ─── Static-method forwarders on Creature ───────────────────────────────
+
+Deno.test("Creature.forProblem static method delegates to factory", () => {
+  const creature = Creature.forProblem({
+    inputs: 4,
+    outputs: 10,
+    cost: "CROSS_ENTROPY",
+  });
+  assert(creature instanceof Creature);
+  for (const neuron of creature.neurons) {
+    if (neuron.type === "output") assertEquals(neuron.squash, "SOFTMAX");
+  }
+});
+
+Deno.test("Creature.forDataset static method delegates to factory", () => {
+  const records: DataRecordInterface[] = [
+    { input: new Float32Array([1, 2]), output: new Float32Array([10]) },
+    { input: new Float32Array([3, 4]), output: new Float32Array([20]) },
+  ];
+  const creature = Creature.forDataset(records, { cost: "MSE" });
+  assert(creature instanceof Creature);
+  const output = creature.neurons.find((n) => n.type === "output")!;
+  assertEquals(output.squash, "IDENTITY");
+  assertEquals(output.bias, 15);
+});
+
+// ─── Manual rescaleWeightsForInit (independent of construction) ─────────
+
+Deno.test("rescaleWeightsForInit is idempotent in scale ratio for fixed topology", () => {
+  // Build with default constructor (no factory), then run the rescaler
+  // manually. After rescaling, weights should match the He stddev for
+  // RELU hidden, regardless of the initial random draw magnitudes.
+  const creature = new Creature(50, 1, {
+    layers: [{ count: 8, squash: "RELU" }],
+  });
+  rescaleWeightsForInit(creature);
+  for (const synapse of creature.synapses) {
+    assert(Number.isFinite(synapse.weight));
+    // Weight must remain bounded — never NaN, never huge.
+    assert(Math.abs(synapse.weight) < 10);
+  }
+});


### PR DESCRIPTION
## Summary

Adds a Creature Factory that seeds a smarter _initial_ creature from
observations, outputs, and cost — replacing the bare
`new Creature(nInput, nOutput)` with random output activations as the default
starting point for evolution. The factory only changes the seed; mutation,
Discovery, breeding, and training proceed exactly as today.

The factory lives in its own module (`src/architecture/CreatureFactory.ts`) so
`Creature.ts` (already 1.2k lines) does not grow beyond a pair of one-line
static forwarders. `evolveDir` and every other existing signature are untouched.

Closes #2794.

## What the factory decides

| Decision             | Source                                      | Rule                                                                                                                                               |
| -------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
| Output activation    | `cost` + `outputs` + declared `outputRange` | Cost-aware default (SOFTMAX / LOGISTIC / TANH), then bounded-range bias (TANH for `[-1,1]`, LOGISTIC for `[0,1]`), else IDENTITY                   |
| Hidden width         | `(inputs, outputs)`                         | Heaton (`⅔·n_in + n_out`, capped `<2·n_in`) for small problems; geometric mean `√(n_in·n_out)` for high-dim (≥100 inputs) to avoid 2000-wide seeds |
| Hidden squash        | Caller hint or default                      | Defaults to `RELU`, pairs with He init                                                                                                             |
| Weight init          | Activation family at destination            | He (`√(2/fan_in)`) for ReLU family; Xavier (`√(2/(fan_in+fan_out))`) for tanh/sigmoid family; LeCun otherwise                                      |
| Output bias          | `forDataset` scan only                      | Mean of target column, but only when output is IDENTITY (regression); classification activations leave bias alone                                  |
| Dead-feature pruning | `forDataset` scan only                      | Synapses out of constant inputs zeroed at construction                                                                                             |

The dataset-scan tier (`creatureForDataset`) deliberately does **not** normalise
inputs: once `inputRange` is declared, normalisation has no remaining motive.
Only the truly non-declarable signals are inferred (dead features, target mean).

## Public API (additive)

```ts
// Metadata-only (no scan)
const seed = Creature.forProblem({
  inputs,
  outputs,
  cost,
  inputRange,
  outputRange,
});

// Optional data scan
const seed2 = Creature.forDataset(trainingData, { cost });

await seed.evolveDir(dir); // unchanged
```

Module-level functions are also exported for callers who prefer not to go
through the static facade: `creatureForProblem`, `creatureForDataset`,
`scanTrainingData`, `pickOutputSquashForProblem`, `pickHiddenCapacity`,
`targetInitStddev`, and `rescaleWeightsForInit`.

## Architecture

```mermaid
flowchart LR
    Spec[ProblemSpec or DataRecords] --> Factory[CreatureFactory]
    Factory --> Squash[pickOutputSquashForProblem]
    Factory --> Capacity[pickHiddenCapacity]
    Squash --> Builder
    Capacity --> Builder
    Builder[new Creature with layers + outputSquash] --> Rescale[rescaleWeightsForInit]
    Rescale --> Seed[Creature]
    Seed --> Evolve[evolveDir - unchanged]
```

## Evidence

Backend-only change with no UI surface. The factory is exercised by a new
unit-test suite — see Test Plan below. All 33 new tests pass; the existing
creature, costs, and architecture test suites continue to pass. The worked
example from the issue (3000 inputs, 1 output, MSE, `outputRange: [-1, 1]`) now
seeds a 55-wide RELU hidden layer with He scaling and a TANH output, exactly the
"small + bounded" prescription.

The acceptance "headline test" (MNIST factory seed converging to ≥95%) is a
multi-hour wall-clock evolution run that does not belong in the unit-test suite
(Issue #574, Issue #603 — tests must finish within 120 seconds). The structural
prerequisites for that headline are verified directly: the MNIST shape (784×10,
CROSS_ENTROPY) produces an 89-wide RELU hidden layer with He-scaled weights and
SOFTMAX outputs.

## Test Plan

New file: `test/architecture/CreatureFactory.ts` — 33 tests.

- Output squash selection (8 tests): SOFTMAX for multi-class CROSS_ENTROPY /
  CATEGORICAL_ERROR, LOGISTIC for BINARY_CROSS_ENTROPY, TANH for HINGE and for
  bounded `[-1,1]` regression, LOGISTIC for `[0,1]` regression, IDENTITY for
  unbounded regression, IDENTITY when no cost is declared.
- Hidden-capacity heuristic (5 tests): geometric mean for high-dim (3000×1 →
  55), Heaton for small problems (10×2 → 9), `2·n_in` cap (1×5 → 2), explicit
  `hiddenCapacity` override, threshold edge case (100×1 → 10).
- Weight-init scaling (4 tests): He stddev, Xavier stddev, LeCun fallback,
  RELU-hidden He bound respected post-construction.
- Construction integrity (5 tests): MNIST-shape SOFTMAX classifier,
  worked-example 3000-input regressor, default `RELU` hidden, `hiddenSquash`
  override, invalid dim rejection.
- Dataset scan (4 tests): dead-feature detection, target-mean computation,
  empty-set rejection, inconsistent-shape rejection.
- `creatureForDataset` (4 tests): regression bias warm-start equals target mean,
  dead-input synapses zeroed, classification bias preserved (not overridden),
  empty set rejected.
- Static forwarders (2 tests): `Creature.forProblem` and `Creature.forDataset`
  delegate correctly.
- Standalone rescaler (1 test): idempotent and finite for a manually constructed
  creature.

Regression run: `test/creature/` + `test/architecture/` + `test/costs/` all pass
except for the pre-existing `evolveRL_heapStability_test.ts` flake
(timing-sensitive heap measurement, passes on re-run, unrelated to this change).



## Milestone
This PR is part of the **Factory** milestone and targets the `milestone/factory` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpqjofa5-7c3dae`<!-- vibe-worker-issue-2794 -->