### PR TITLE
Test: assert observable behaviour for assertContract() idempotency (#2802)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2802.md
+++ b/docs/archive/pr-summaries/pr-summary-2802.md
@@ -1,14 +1,13 @@
 ## Summary
 
 Removed a HOW-assertion (anti-pattern #1) from
-`test/creature/EpisodeAdapter_test.ts`. The test
-"EpisodeAdapter: assertContract() is idempotent on repeat calls" previously
-subclassed `DefaultGuardAdapter` purely to count internal `reset()`
-invocations and asserted `resetCalls === 1`. That pinned an implementation
-detail (the one-shot caching of the contract probe) rather than any
-observable behaviour, so a valid refactor of `assertContract()` — lazy
-reset, reset-on-every-call, or validation without reset — would break the
-test even though the behaviour was unchanged.
+`test/creature/EpisodeAdapter_test.ts`. The test "EpisodeAdapter:
+assertContract() is idempotent on repeat calls" previously subclassed
+`DefaultGuardAdapter` purely to count internal `reset()` invocations and
+asserted `resetCalls === 1`. That pinned an implementation detail (the one-shot
+caching of the contract probe) rather than any observable behaviour, so a valid
+refactor of `assertContract()` — lazy reset, reset-on-every-call, or validation
+without reset — would break the test even though the behaviour was unchanged.
 
 The test now asserts the observable contract directly (issue option (a)):
 calling `assertContract()` repeatedly on a well-formed adapter is safe and
@@ -21,8 +20,8 @@ Closes #2802.
 
 Backend/test-only change — no UI to screenshot.
 
-Targeted run of the affected file (all 10 tests pass, including the
-rewritten idempotency test):
+Targeted run of the affected file (all 10 tests pass, including the rewritten
+idempotency test):
 
 ```
 running 10 tests from ./test/creature/EpisodeAdapter_test.ts
@@ -34,15 +33,15 @@ ok | 10 passed | 0 failed (6ms)
 ### Pre-existing unrelated failure
 
 `./quality.sh` reports one failure in
-`test/creature/evolveRL_heapStability_test.ts` ("heap stays bounded across
-many generations", Issue #2693). This is a GC/heap-measurement test wholly
-unrelated to this change — it fails identically on the clean `Develop` tree
-with my change stashed, confirming it is pre-existing and not caused by this
-PR.
+`test/creature/evolveRL_heapStability_test.ts` ("heap stays bounded across many
+generations", Issue #2693). This is a GC/heap-measurement test wholly unrelated
+to this change — it fails identically on the clean `Develop` tree with my change
+stashed, confirming it is pre-existing and not caused by this PR.
 
 ## Test Plan
 
-- Modified `test/creature/EpisodeAdapter_test.ts::EpisodeAdapter: assertContract() is idempotent on repeat calls`
-  to assert observable behaviour (no throw, stable `undefined` return on
-  repeat calls) instead of counting internal `reset()` calls.
+- Modified
+  `test/creature/EpisodeAdapter_test.ts::EpisodeAdapter: assertContract() is idempotent on repeat calls`
+  to assert observable behaviour (no throw, stable `undefined` return on repeat
+  calls) instead of counting internal `reset()` calls.
 - Ran `deno test test/creature/EpisodeAdapter_test.ts` — 10 passed, 0 failed.

--- a/docs/archive/pr-summaries/pr-summary-2802.md
+++ b/docs/archive/pr-summaries/pr-summary-2802.md
@@ -1,0 +1,48 @@
+## Summary
+
+Removed a HOW-assertion (anti-pattern #1) from
+`test/creature/EpisodeAdapter_test.ts`. The test
+"EpisodeAdapter: assertContract() is idempotent on repeat calls" previously
+subclassed `DefaultGuardAdapter` purely to count internal `reset()`
+invocations and asserted `resetCalls === 1`. That pinned an implementation
+detail (the one-shot caching of the contract probe) rather than any
+observable behaviour, so a valid refactor of `assertContract()` — lazy
+reset, reset-on-every-call, or validation without reset — would break the
+test even though the behaviour was unchanged.
+
+The test now asserts the observable contract directly (issue option (a)):
+calling `assertContract()` repeatedly on a well-formed adapter is safe and
+returns a stable result (`undefined`) without throwing. No reference to the
+internal `reset()` method remains.
+
+Closes #2802.
+
+## Evidence
+
+Backend/test-only change — no UI to screenshot.
+
+Targeted run of the affected file (all 10 tests pass, including the
+rewritten idempotency test):
+
+```
+running 10 tests from ./test/creature/EpisodeAdapter_test.ts
+...
+EpisodeAdapter: assertContract() is idempotent on repeat calls ... ok (0ms)
+ok | 10 passed | 0 failed (6ms)
+```
+
+### Pre-existing unrelated failure
+
+`./quality.sh` reports one failure in
+`test/creature/evolveRL_heapStability_test.ts` ("heap stays bounded across
+many generations", Issue #2693). This is a GC/heap-measurement test wholly
+unrelated to this change — it fails identically on the clean `Develop` tree
+with my change stashed, confirming it is pre-existing and not caused by this
+PR.
+
+## Test Plan
+
+- Modified `test/creature/EpisodeAdapter_test.ts::EpisodeAdapter: assertContract() is idempotent on repeat calls`
+  to assert observable behaviour (no throw, stable `undefined` return on
+  repeat calls) instead of counting internal `reset()` calls.
+- Ran `deno test test/creature/EpisodeAdapter_test.ts` — 10 passed, 0 failed.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -386,6 +386,7 @@
     "stringifying",
     "stsoftware",
     "subarray",
+    "subclassed",
     "subdirs",
     "submessages",
     "subvectors",

--- a/test/creature/EpisodeAdapter_test.ts
+++ b/test/creature/EpisodeAdapter_test.ts
@@ -344,20 +344,12 @@ Deno.test("EpisodeAdapter: argmax decodeAction picks the largest index", () => {
 // ---------------------------------------------------------------------------
 
 Deno.test("EpisodeAdapter: assertContract() is idempotent on repeat calls", () => {
-  let resetCalls = 0;
-
-  class CountingResetAdapter extends DefaultGuardAdapter {
-    override reset(
-      _rngSeed: number,
-    ): { observation: Float32Array; state: null } {
-      resetCalls++;
-      return { observation: new Float32Array([0]), state: null };
-    }
-  }
-
-  const adapter = new CountingResetAdapter();
-  adapter.assertContract();
-  adapter.assertContract();
-  adapter.assertContract();
-  assertEquals(resetCalls, 1);
+  // Observable behaviour: repeatedly validating a well-formed adapter is
+  // safe and yields a stable result (no throw, returns void each time). We
+  // deliberately avoid asserting how many times reset() runs internally —
+  // that is an implementation detail the contract does not promise.
+  const adapter = new DefaultGuardAdapter();
+  assertEquals(adapter.assertContract(), undefined);
+  assertEquals(adapter.assertContract(), undefined);
+  assertEquals(adapter.assertContract(), undefined);
 });


### PR DESCRIPTION
## Summary

Removed a HOW-assertion (anti-pattern #1) from
`test/creature/EpisodeAdapter_test.ts`. The test
"EpisodeAdapter: assertContract() is idempotent on repeat calls" previously
subclassed `DefaultGuardAdapter` purely to count internal `reset()`
invocations and asserted `resetCalls === 1`. That pinned an implementation
detail (the one-shot caching of the contract probe) rather than any
observable behaviour, so a valid refactor of `assertContract()` — lazy
reset, reset-on-every-call, or validation without reset — would break the
test even though the behaviour was unchanged.

The test now asserts the observable contract directly (issue option (a)):
calling `assertContract()` repeatedly on a well-formed adapter is safe and
returns a stable result (`undefined`) without throwing. No reference to the
internal `reset()` method remains.

Closes #2802.

## Evidence

Backend/test-only change — no UI to screenshot.

Targeted run of the affected file (all 10 tests pass, including the
rewritten idempotency test):

```
running 10 tests from ./test/creature/EpisodeAdapter_test.ts
...
EpisodeAdapter: assertContract() is idempotent on repeat calls ... ok (0ms)
ok | 10 passed | 0 failed (6ms)
```

### Pre-existing unrelated failure

`./quality.sh` reports one failure in
`test/creature/evolveRL_heapStability_test.ts` ("heap stays bounded across
many generations", Issue #2693). This is a GC/heap-measurement test wholly
unrelated to this change — it fails identically on the clean `Develop` tree
with my change stashed, confirming it is pre-existing and not caused by this
PR.

## Test Plan

- Modified `test/creature/EpisodeAdapter_test.ts::EpisodeAdapter: assertContract() is idempotent on repeat calls`
  to assert observable behaviour (no throw, stable `undefined` return on
  repeat calls) instead of counting internal `reset()` calls.
- Ran `deno test test/creature/EpisodeAdapter_test.ts` — 10 passed, 0 failed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpqsqedv-89690d`<!-- vibe-worker-issue-2802 -->