### PR TITLE
docs: drop CATEGORICAL_ERROR from user docs and CHANGELOG (#2806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
   is the caller-side counterpart to the Discovery cost-aware thresholds
   (`stSoftwareAU/neat-ai-discovery#1320`).
 
+### Removed
+
+- **Issue #2806 (part of Issue #2798):** Removed the `CATEGORICAL_ERROR` cost.
+  Use `CROSS_ENTROPY` for multi-class training so the scorer, champion selection
+  and `targetError` early-stop all reflect the classification task. Argmax /
+  top-1 accuracy remains available as a reporting metric only — it is no longer
+  selectable as a `costName`. As `CATEGORICAL_ERROR` was only ever in the
+  unreleased changelog, no released behaviour changes.
+
 ### Security
 
 - **Issue #2704:** `CreatureSerialization.fromJSON` (the default JSON-load path)

--- a/docs/ACTIVATION_FUNCTIONS.md
+++ b/docs/ACTIVATION_FUNCTIONS.md
@@ -138,9 +138,9 @@ chosen randomly for hidden neurons; the caller opts in via the `costName` option
 (see [Cost coupling](#-cost-coupling-issue-2793)) or by passing
 `outputLayer.squash` explicitly.
 
-| Name                                                   | Output Range | Pair with                         | Summary                                                                                                                                                                                                                                                                                                                           |
-| :----------------------------------------------------- | :----------- | :-------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [SOFTMAX](../src/methods/activations/types/SOFTMAX.ts) | (0, 1)       | CROSS_ENTROPY / CATEGORICAL_ERROR | Multi-class probability head. Per-neuron `squash(x)` is a logistic surrogate that the WASM forward pass treats as LOGISTIC; the project-canonical vector normalisation lives in `softmaxNormalise()` for true probability outputs. `calculateError()` returns the cross-entropy-form gradient with no sigmoid-derivative scaling. |
+| Name                                                   | Output Range | Pair with     | Summary                                                                                                                                                                                                                                                                                                                           |
+| :----------------------------------------------------- | :----------- | :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [SOFTMAX](../src/methods/activations/types/SOFTMAX.ts) | (0, 1)       | CROSS_ENTROPY | Multi-class probability head. Per-neuron `squash(x)` is a logistic surrogate that the WASM forward pass treats as LOGISTIC; the project-canonical vector normalisation lives in `softmaxNormalise()` for true probability outputs. `calculateError()` returns the cross-entropy-form gradient with no sigmoid-derivative scaling. |
 
 #### 🧷 Cost coupling (Issue #2793)
 
@@ -149,7 +149,7 @@ activation defaults to the natural pairing:
 
 ```typescript
 // Multi-class classifier — outputs auto-wired to SOFTMAX
-const classifier = new Creature(784, 10, { costName: "CATEGORICAL_ERROR" });
+const classifier = new Creature(784, 10, { costName: "CROSS_ENTROPY" });
 
 // Binary probability head — outputs auto-wired to LOGISTIC
 const detector = new Creature(64, 1, { costName: "BINARY_CROSS_ENTROPY" });

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -429,15 +429,14 @@ import type { CostInterface } from "@stsoftware/neat-ai";
 
 ### 📋 Built-in Cost Functions
 
-| Name                  | Class                          | Best For                     | Formula                                        |
-| --------------------- | ------------------------------ | ---------------------------- | ---------------------------------------------- |
-| `"MSE"`               | Mean Squared Error             | General regression (default) | `(1/n) * Sum((y - y')^2)`                      |
-| `"MAE"`               | Mean Absolute Error            | Regression with outliers     | `(1/n) * Sum(\|y - y'\|)`                      |
-| `"MAPE"`              | Mean Absolute Percentage Error | Forecasting, relative error  | `(1/n) * Sum(\|(y' - y) / y\|)`                |
-| `"MSLE"`              | Mean Squared Logarithmic Error | Wide value ranges            | `(1/n) * Sum((log(y) - log(y'))^2)`            |
-| `"CROSS_ENTROPY"`     | Cross Entropy                  | Classification               | `-Sum(y * log(y') + (1-y) * log(1-y'))`        |
-| `"HINGE"`             | Hinge Loss                     | SVM / binary classification  | `max(0, 1 - y * y')`                           |
-| `"CATEGORICAL_ERROR"` | Categorical (argmax) error     | Multi-class one-hot targets  | `(1/n) * Sum(argmax(y) != argmax(y') ? 1 : 0)` |
+| Name              | Class                          | Best For                     | Formula                                 |
+| ----------------- | ------------------------------ | ---------------------------- | --------------------------------------- |
+| `"MSE"`           | Mean Squared Error             | General regression (default) | `(1/n) * Sum((y - y')^2)`               |
+| `"MAE"`           | Mean Absolute Error            | Regression with outliers     | `(1/n) * Sum(\|y - y'\|)`               |
+| `"MAPE"`          | Mean Absolute Percentage Error | Forecasting, relative error  | `(1/n) * Sum(\|(y' - y) / y\|)`         |
+| `"MSLE"`          | Mean Squared Logarithmic Error | Wide value ranges            | `(1/n) * Sum((log(y) - log(y'))^2)`     |
+| `"CROSS_ENTROPY"` | Cross Entropy                  | Classification               | `-Sum(y * log(y') + (1-y) * log(1-y'))` |
+| `"HINGE"`         | Hinge Loss                     | SVM / binary classification  | `max(0, 1 - y * y')`                    |
 
 > [!IMPORTANT]
 > **Regression costs can decouple from classification accuracy on one-hot
@@ -450,13 +449,9 @@ import type { CostInterface } from "@stsoftware/neat-ai";
 > `score = 1 - error - penalties`, the reported score then overstates task
 > quality.
 >
-> Use `"CATEGORICAL_ERROR"` when argmax accuracy is the real objective. It
-> reports the **misclassification rate** (`error = 1 - accuracy`), so the
-> scorer, champion selection and `targetError` early-stop all reflect the
-> classification task. It is **non-differentiable** and intended for
-> scoring/early-stop — NEAT-AI derives backpropagation gradients independently
-> of `costName`, so training still proceeds normally. It needs at least two
-> outputs; with a single output the argmax is always index `0`.
+> Use `"CROSS_ENTROPY"` for multi-class training so the scorer, champion
+> selection and `targetError` early-stop all reflect the classification task.
+> Argmax / top-1 accuracy remains available as a reporting metric only.
 
 ### 📐 CostInterface
 

--- a/docs/api/COSTS_AND_ACTIVATIONS.md
+++ b/docs/api/COSTS_AND_ACTIVATIONS.md
@@ -25,25 +25,23 @@ import type { CostInterface } from "@stsoftware/neat-ai";
 
 ### 📋 Built-in cost functions
 
-| Name                  | Class                          | Best For                     | Formula                                 |
-| --------------------- | ------------------------------ | ---------------------------- | --------------------------------------- |
-| `"MSE"`               | Mean Squared Error             | General regression (default) | `(1/n) * Sum((y - y')^2)`               |
-| `"MAE"`               | Mean Absolute Error            | Regression with outliers     | `(1/n) * Sum(\|y - y'\|)`               |
-| `"MAPE"`              | Mean Absolute Percentage Error | Forecasting, relative error  | `(1/n) * Sum(\|(y' - y) / y\|)`         |
-| `"MSLE"`              | Mean Squared Logarithmic Error | Wide value ranges            | `(1/n) * Sum((log(y) - log(y'))^2)`     |
-| `"CROSS_ENTROPY"`     | Cross Entropy                  | Classification               | `-Sum(y * log(y') + (1-y) * log(1-y'))` |
-| `"HINGE"`             | Hinge Loss                     | SVM / binary classification  | `max(0, 1 - y * y')`                    |
-| `"CATEGORICAL_ERROR"` | Categorical (argmax) Error     | Multi-class classification   | `(1/n) * Sum(argmax(y) != argmax(y'))`  |
+| Name              | Class                          | Best For                     | Formula                                 |
+| ----------------- | ------------------------------ | ---------------------------- | --------------------------------------- |
+| `"MSE"`           | Mean Squared Error             | General regression (default) | `(1/n) * Sum((y - y')^2)`               |
+| `"MAE"`           | Mean Absolute Error            | Regression with outliers     | `(1/n) * Sum(\|y - y'\|)`               |
+| `"MAPE"`          | Mean Absolute Percentage Error | Forecasting, relative error  | `(1/n) * Sum(\|(y' - y) / y\|)`         |
+| `"MSLE"`          | Mean Squared Logarithmic Error | Wide value ranges            | `(1/n) * Sum((log(y) - log(y'))^2)`     |
+| `"CROSS_ENTROPY"` | Cross Entropy                  | Classification               | `-Sum(y * log(y') + (1-y) * log(1-y'))` |
+| `"HINGE"`         | Hinge Loss                     | SVM / binary classification  | `max(0, 1 - y * y')`                    |
 
-These seven names make up `BUILT_IN_COST_NAMES`.
+These six names make up `BUILT_IN_COST_NAMES`.
 
 ### 🦀 Native scorer off-load (`--cost`)
 
 When the optional `rust_scorer` binary is enabled
 (`NEAT_AI_RUST_SCORER_ENABLED`), NEAT-AI passes the configured `costName` to the
-binary via `--cost <NAME>`. **All seven `BUILT_IN_COST_NAMES` values — including
-`CATEGORICAL_ERROR` — are eligible for native off-load** once the scorer release
-containing
+binary via `--cost <NAME>`. **All six `BUILT_IN_COST_NAMES` values are eligible
+for native off-load** once the scorer release containing
 [NEAT-AI-scorer#134](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/134)
 is deployed.
 

--- a/docs/archive/pr-summaries/pr-summary-2806.md
+++ b/docs/archive/pr-summaries/pr-summary-2806.md
@@ -1,0 +1,52 @@
+# PR Summary — Issue #2806
+
+## Summary
+
+Removed all user-facing documentation references to the `CATEGORICAL_ERROR` cost
+so the docs match the post-removal code (dependency #2805), and recorded the
+removal in the changelog. Closes #2806.
+
+Changes:
+
+- `docs/API_REFERENCE.md` — dropped the `"CATEGORICAL_ERROR"` cost-table row and
+  rewrote the recommendation note to point multi-class users at `CROSS_ENTROPY`,
+  noting argmax/top-1 accuracy is a reporting metric only.
+- `docs/api/COSTS_AND_ACTIVATIONS.md` — dropped the `"CATEGORICAL_ERROR"` row,
+  corrected the built-in count from seven to six, and removed it from the native
+  off-load list (now matching `src/config/RustScorerConfig.ts`).
+- `docs/config/TRAINING.md` — dropped `CATEGORICAL_ERROR` from the recognised
+  supervised-cost list.
+- `docs/ACTIVATION_FUNCTIONS.md` — dropped `CATEGORICAL_ERROR` from the SOFTMAX
+  "Pair with" cell and the cost-coupling example (now `CROSS_ENTROPY`), required
+  to satisfy the "no `docs/` reference" acceptance criterion.
+- `CHANGELOG.md` — added a `### Removed` entry under `## [Unreleased]` recording
+  the removal and the `CROSS_ENTROPY` guidance. The Unreleased #2791
+  supervised-cost list already excluded `CATEGORICAL_ERROR` (updated when #2805
+  merged), so no further edit was needed there.
+
+No `docs/archive/**` historical records were edited, and no already-released
+changelog entries were rewritten.
+
+## Evidence
+
+Docs-only change — no web interface to screenshot. Verification performed:
+
+- `grep` confirms no file under `docs/` excluding `docs/archive/**` references
+  `CATEGORICAL_ERROR`.
+- `deno fmt --check` passes on all changed files.
+- `markdownlint-cli2` reports 0 errors across the repository.
+- Cross-checked the surviving cost set against the source of truth
+  (`BUILT_IN_COST_NAMES` doc comment in `src/config/RustScorerConfig.ts`):
+  `MSE`, `MAE`, `MAPE`, `MSLE`, `CROSS_ENTROPY`, `HINGE` — six names.
+
+## Test Plan
+
+This is a documentation-only change with no code paths, so no unit tests were
+added. Validation:
+
+- [x] `deno fmt --check` clean on changed files
+- [x] `markdownlint-cli2` — 0 errors
+- [x] No `CATEGORICAL_ERROR` references remain under `docs/` (excluding
+      `docs/archive/**`)
+- [x] `CHANGELOG.md` has the `### Removed` Unreleased entry with `CROSS_ENTROPY`
+      guidance

--- a/docs/config/TRAINING.md
+++ b/docs/config/TRAINING.md
@@ -54,7 +54,7 @@ weight mutation alone.
 **How the default is chosen**
 
 - **Recognised built-in supervised costs** (`MSE`, `MAE`, `MAPE`, `MSLE`,
-  `CROSS_ENTROPY`, `CATEGORICAL_ERROR`, `HINGE`) scale with the population:
+  `CROSS_ENTROPY`, `HINGE`) scale with the population:
   `max(1, round(populationSize × 0.2))`.
 - **Custom or unrecognised costs** keep the conservative default of `1`, so
   evolution-only tasks are unchanged.


### PR DESCRIPTION
# PR Summary — Issue #2806

## Summary

Removed all user-facing documentation references to the `CATEGORICAL_ERROR` cost
so the docs match the post-removal code (dependency #2805), and recorded the
removal in the changelog. Closes #2806.

Changes:

- `docs/API_REFERENCE.md` — dropped the `"CATEGORICAL_ERROR"` cost-table row and
  rewrote the recommendation note to point multi-class users at `CROSS_ENTROPY`,
  noting argmax/top-1 accuracy is a reporting metric only.
- `docs/api/COSTS_AND_ACTIVATIONS.md` — dropped the `"CATEGORICAL_ERROR"` row,
  corrected the built-in count from seven to six, and removed it from the native
  off-load list (now matching `src/config/RustScorerConfig.ts`).
- `docs/config/TRAINING.md` — dropped `CATEGORICAL_ERROR` from the recognised
  supervised-cost list.
- `docs/ACTIVATION_FUNCTIONS.md` — dropped `CATEGORICAL_ERROR` from the SOFTMAX
  "Pair with" cell and the cost-coupling example (now `CROSS_ENTROPY`), required
  to satisfy the "no `docs/` reference" acceptance criterion.
- `CHANGELOG.md` — added a `### Removed` entry under `## [Unreleased]` recording
  the removal and the `CROSS_ENTROPY` guidance. The Unreleased #2791
  supervised-cost list already excluded `CATEGORICAL_ERROR` (updated when #2805
  merged), so no further edit was needed there.

No `docs/archive/**` historical records were edited, and no already-released
changelog entries were rewritten.

## Evidence

Docs-only change — no web interface to screenshot. Verification performed:

- `grep` confirms no file under `docs/` excluding `docs/archive/**` references
  `CATEGORICAL_ERROR`.
- `deno fmt --check` passes on all changed files.
- `markdownlint-cli2` reports 0 errors across the repository.
- Cross-checked the surviving cost set against the source of truth
  (`BUILT_IN_COST_NAMES` doc comment in `src/config/RustScorerConfig.ts`):
  `MSE`, `MAE`, `MAPE`, `MSLE`, `CROSS_ENTROPY`, `HINGE` — six names.

## Test Plan

This is a documentation-only change with no code paths, so no unit tests were
added. Validation:

- [x] `deno fmt --check` clean on changed files
- [x] `markdownlint-cli2` — 0 errors
- [x] No `CATEGORICAL_ERROR` references remain under `docs/` (excluding
      `docs/archive/**`)
- [x] `CHANGELOG.md` has the `### Removed` Unreleased entry with `CROSS_ENTROPY`
      guidance



## Milestone
This PR is part of the **CATEGORICAL_ERROR** milestone and targets the `milestone/categorical-error` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpqustu5-c32c74`<!-- vibe-worker-issue-2806 -->