### PR TITLE
Docs: Temporal vs Date/performance.now() migration policy (#2813)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,6 +449,66 @@ deno info --json mod.ts | grep -o '"specifier": "[^"]*"' | grep '@std/log' \
   || echo 'no @std/log dependency'
 ```
 
+### 🕒 Date/time handling — Temporal vs Date
+
+NEAT-AI uses the native [`Temporal`](https://tc39.es/proposal-temporal/docs/)
+API for **wall-clock and calendar-style timestamps**, and keeps `Date.now()` /
+`performance.now()` for **elapsed-time measurements**. `Temporal` is stable in
+**Deno 2.7+** — no `--unstable-temporal` flag and no polyfill are required.
+
+**Use `Temporal` for wall-clock / calendar timestamps.** Anything that records
+_when something happened_ on the real-world clock:
+
+- Timestamps written to logs.
+- Timestamps emitted in event payloads (e.g. training events).
+- Timestamps persisted to JSON on disk.
+- Dates/times printed in a user-facing report.
+
+```typescript
+// ✅ Wall-clock timestamp — ISO 8601 string for a log, event, or JSON field
+const occurredAt = Temporal.Now.instant().toString();
+// e.g. "2026-05-30T03:21:09.123456789Z"
+```
+
+**Keep `Date.now()` / `performance.now()` for elapsed-time measurements.**
+Anything that measures _how long something took_ or drives a relative deadline:
+
+- Per-phase timings (start/stop durations).
+- Throttling cool-downs.
+- Sliding-window TTLs (time-to-live).
+- Deadline computations driven by `Date.now()` deltas.
+
+`Temporal` is **not** the right tool for monotonic elapsed timing — do not
+migrate these to `Temporal`.
+
+```typescript
+// ✅ Elapsed-time measurement — keep Date.now() / performance.now()
+const start = performance.now();
+runPhase();
+const elapsedMs = performance.now() - start;
+```
+
+**Canonical "do NOT migrate" examples** (these measure elapsed time, not
+wall-clock instants):
+
+- `src/NEAT/MemoryMonitor.ts` — sampling cadence and elapsed-window logic.
+- `src/NEAT/ThroughputMetrics.ts` — throughput is `count / elapsed`.
+- Per-phase timing in `src/NEAT/NeatEvolution.ts` — phase start/stop deltas.
+
+**Forbidden dependencies.** Do **not** add either of the following, and do not
+introduce any new `package.json`-only dependency to satisfy date/time needs
+(consistent with the project's Deno-regression guardrail):
+
+- `@js-temporal/polyfill` — native `Temporal` is already stable in Deno 2.7+, so
+  the polyfill is redundant.
+- `@std/datetime` (`jsr:@std/datetime`) — `Temporal` covers wall-clock
+  formatting and arithmetic without an extra dependency.
+
+> [!NOTE]
+> Quick test of which tool to reach for: if the value answers _"at what point on
+> the calendar?"_ use `Temporal`; if it answers _"how long?"_ use `Date.now()` /
+> `performance.now()`.
+
 ### 🧪 Testing
 
 #### Unit Tests vs Benchmarks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -502,6 +502,17 @@ already consumer-pluggable. See the
 rationale, the audit command, and an example of injecting a custom `Logger` via
 `NeatOptions.logger` / `setLogger()`.
 
+### 🕒 Date/time handling
+
+Use the native `Temporal` API (stable in Deno 2.7+) for **wall-clock /
+calendar-style timestamps** — anything logged, emitted in an event payload,
+persisted to JSON, or shown in a user-facing report. Keep `Date.now()` /
+`performance.now()` for **elapsed-time measurements** (phase timings,
+cool-downs, sliding-window TTLs). Do **not** add `@js-temporal/polyfill` or
+`@std/datetime`. See the
+[Date/time handling section in AGENTS.md](./AGENTS.md#-datetime-handling--temporal-vs-date)
+for the full policy and canonical examples.
+
 ## 📁 Project Structure
 
 ```

--- a/docs/archive/pr-summaries/pr-summary-2813.md
+++ b/docs/archive/pr-summaries/pr-summary-2813.md
@@ -1,0 +1,70 @@
+# PR Summary — Document Temporal vs Date/performance.now() migration policy
+
+## Summary
+
+Adds a single source of truth for date/time handling so the upcoming `Temporal`
+migration sub-issues (part of #2804) can reference one canonical policy and
+contributors don't reintroduce `Date`-based wall-clock timestamps or extra
+date/time dependencies.
+
+- New **"🕒 Date/time handling — Temporal vs Date"** sub-section under _Coding
+  Conventions_ in `AGENTS.md`.
+- A short pointer to it from the conventions area of `CONTRIBUTING.md`,
+  mirroring the existing Logging-policy pointer.
+
+The policy codifies:
+
+- **Use `Temporal`** (e.g. `Temporal.Now.instant().toString()`) for wall-clock /
+  calendar-style timestamps — anything logged, emitted as an event payload,
+  persisted to JSON on disk, or printed in a user-facing report.
+- **Keep `Date.now()` / `performance.now()`** for elapsed-time measurements —
+  per-phase timings, throttling cool-downs, sliding-window TTLs, and deadline
+  computations driven by `Date.now()` deltas. `Temporal` is not the right tool
+  for monotonic elapsed timing.
+- Native `Temporal` is stable in **Deno 2.7+** (no `--unstable-temporal` flag,
+  no polyfill).
+- **Forbidden dependencies:** `@js-temporal/polyfill` (redundant — native
+  `Temporal` is stable) and `@std/datetime`, plus any new `package.json`-only
+  dependency (consistent with the project's Deno-regression guardrail).
+- Canonical **"do NOT migrate"** examples: `src/NEAT/MemoryMonitor.ts`,
+  `src/NEAT/ThroughputMetrics.ts`, and per-phase timing in
+  `src/NEAT/NeatEvolution.ts`.
+
+This is greenfield guidance: a survey confirmed no current `@std/datetime`
+imports and no existing `Temporal.*` usage in the repo.
+
+Closes #2813.
+
+## Acceptance criteria
+
+- [x] `AGENTS.md` contains a new "Date/time handling — Temporal vs Date" section
+      (Australian English spelling).
+- [x] The section explicitly lists what counts as wall-clock vs elapsed-time and
+      gives one canonical code snippet for each.
+- [x] The section states that `@std/datetime` and `@js-temporal/polyfill` must
+      not be added.
+- [x] `quality.sh` formatting + lint pass (see Evidence).
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot.
+
+- `deno fmt AGENTS.md CONTRIBUTING.md` → clean.
+- `./quality.sh --lint-only` → passed: formatting (2449 files), linting (1640
+  files), and bash-script checks all green.
+
+```mermaid
+flowchart TD
+    Q{What does the value represent?}
+    Q -->|"at what point on the calendar?"| W[Temporal.Now.instant&#40;&#41;.toString&#40;&#41;]
+    Q -->|"how long did it take?"| E[Date.now&#40;&#41; / performance.now&#40;&#41;]
+    W --> WU["logs, event payloads,<br/>persisted JSON, user reports"]
+    E --> EU["phase timings, cool-downs,<br/>sliding-window TTLs, deadlines"]
+    EU --> KEEP["MemoryMonitor, ThroughputMetrics,<br/>NeatEvolution phase timing — do NOT migrate"]
+```
+
+## Test Plan
+
+No code paths changed, so no unit tests were added or modified — the change is
+limited to `AGENTS.md` and `CONTRIBUTING.md` policy documentation. Verification
+was via the quality gate's formatting and lint steps (above).


### PR DESCRIPTION
# PR Summary — Document Temporal vs Date/performance.now() migration policy

## Summary

Adds a single source of truth for date/time handling so the upcoming `Temporal`
migration sub-issues (part of #2804) can reference one canonical policy and
contributors don't reintroduce `Date`-based wall-clock timestamps or extra
date/time dependencies.

- New **"🕒 Date/time handling — Temporal vs Date"** sub-section under _Coding
  Conventions_ in `AGENTS.md`.
- A short pointer to it from the conventions area of `CONTRIBUTING.md`,
  mirroring the existing Logging-policy pointer.

The policy codifies:

- **Use `Temporal`** (e.g. `Temporal.Now.instant().toString()`) for wall-clock /
  calendar-style timestamps — anything logged, emitted as an event payload,
  persisted to JSON on disk, or printed in a user-facing report.
- **Keep `Date.now()` / `performance.now()`** for elapsed-time measurements —
  per-phase timings, throttling cool-downs, sliding-window TTLs, and deadline
  computations driven by `Date.now()` deltas. `Temporal` is not the right tool
  for monotonic elapsed timing.
- Native `Temporal` is stable in **Deno 2.7+** (no `--unstable-temporal` flag,
  no polyfill).
- **Forbidden dependencies:** `@js-temporal/polyfill` (redundant — native
  `Temporal` is stable) and `@std/datetime`, plus any new `package.json`-only
  dependency (consistent with the project's Deno-regression guardrail).
- Canonical **"do NOT migrate"** examples: `src/NEAT/MemoryMonitor.ts`,
  `src/NEAT/ThroughputMetrics.ts`, and per-phase timing in
  `src/NEAT/NeatEvolution.ts`.

This is greenfield guidance: a survey confirmed no current `@std/datetime`
imports and no existing `Temporal.*` usage in the repo.

Closes #2813.

## Acceptance criteria

- [x] `AGENTS.md` contains a new "Date/time handling — Temporal vs Date" section
      (Australian English spelling).
- [x] The section explicitly lists what counts as wall-clock vs elapsed-time and
      gives one canonical code snippet for each.
- [x] The section states that `@std/datetime` and `@js-temporal/polyfill` must
      not be added.
- [x] `quality.sh` formatting + lint pass (see Evidence).

## Evidence

Documentation-only change — no web interface to screenshot.

- `deno fmt AGENTS.md CONTRIBUTING.md` → clean.
- `./quality.sh --lint-only` → passed: formatting (2449 files), linting (1640
  files), and bash-script checks all green.

```mermaid
flowchart TD
    Q{What does the value represent?}
    Q -->|"at what point on the calendar?"| W[Temporal.Now.instant&#40;&#41;.toString&#40;&#41;]
    Q -->|"how long did it take?"| E[Date.now&#40;&#41; / performance.now&#40;&#41;]
    W --> WU["logs, event payloads,<br/>persisted JSON, user reports"]
    E --> EU["phase timings, cool-downs,<br/>sliding-window TTLs, deadlines"]
    EU --> KEEP["MemoryMonitor, ThroughputMetrics,<br/>NeatEvolution phase timing — do NOT migrate"]
```

## Test Plan

No code paths changed, so no unit tests were added or modified — the change is
limited to `AGENTS.md` and `CONTRIBUTING.md` policy documentation. Verification
was via the quality gate's formatting and lint steps (above).



## Milestone
This PR is part of the **Temporal** milestone and targets the `milestone/temporal` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mprj5xdb-adb590`<!-- vibe-worker-issue-2813 -->