### PR TITLE
Refactor: migrate Discovery cache and diagnostics timestamps to Temporal (#2814)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-2814.md
+++ b/docs/archive/pr-summaries/pr-summary-2814.md
@@ -1,0 +1,61 @@
+## Summary
+
+Migrated wall-clock timestamp call sites in the Discovery cache, diagnostics,
+cleanup state, validation reports, and focus-selection analysis from
+`new Date().toISOString()` to `Temporal.Now.instant().toString()`, matching
+the date/time policy adopted in #2813. Closes #2814.
+
+Per-phase elapsed-time measurements (e.g. `Date.now() - start` profiling) were
+deliberately left untouched — those are monotonic-style measurements where
+`Date.now()` remains the correct tool.
+
+### Files migrated
+
+| File | Lines | Change |
+|------|-------|--------|
+| `src/discovery/SuccessCache.ts` | 140 | `metadata.timestamp ?? Temporal.Now.instant().toString()` |
+| `src/discovery/FailureCache.ts` | 151 | `timestamp: Temporal.Now.instant().toString()` |
+| `src/discovery/DiscoveryEvaluationSummary.ts` | 60 | archive-filename timestamp now derived from `Temporal.Now.instant()` |
+| `src/discovery/DiscoveryDiagnostics.ts` | 136 | `timestamp: Temporal.Now.instant().toString()` |
+| `src/discovery/DiscoveryCleanup.ts` | 35 | lock-file `startedAt` now uses `Temporal.Now.instant().toString()` |
+| `src/architecture/ErrorGuidedStructuralEvolution/DiscoveryValidation.ts` | 107, 148, 190, 230 | held `Date` instance replaced with a single `Temporal.Now.instant().toString()` ISO string; printed `Timestamp:` field now reads from that string |
+| `src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts` | 136 | `timestamp: Temporal.Now.instant().toString()` |
+
+The on-disk wire format remains a plain ISO-8601 string. `Temporal.Instant`
+serialises with nanosecond precision (e.g. `2026-05-30T03:21:09.123456789Z`)
+which is still ISO-8601-conformant and round-trips through both
+`Temporal.Instant.from()` and `new Date()`.
+
+The Australian-format `YYYYMMDD-HHMMSS` issue-directory prefix in
+`DiscoveryValidation.ts` still slices to 15 characters; this works
+identically with the nanosecond-precision Temporal string because the
+extra digits land after the slice cutoff.
+
+### Deno regression avoided
+
+This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the
+AGENTS.md date/time policy, no `@js-temporal/polyfill` and no `@std/datetime`
+dependency was added — the migration uses Deno 2.7+'s native `Temporal`.
+
+## Evidence
+
+Backend-only change; no UI to screenshot. Verified via:
+
+- New regression test
+  `test/discovery/CacheTemporalTimestamps.ts` asserts that the persisted
+  `timestamp` field written by both `SuccessCache` and `FailureCache` is a
+  string parseable by `Temporal.Instant.from()` and that the parsed instant
+  falls inside the recording window.
+- Full `./quality.sh` run: 6990 passed | 0 failed | 4 ignored (2m31s).
+
+## Test Plan
+
+- New: `test/discovery/CacheTemporalTimestamps.ts`
+  - `SuccessCache persists timestamp as Temporal.Instant-parseable ISO string`
+  - `FailureCache persists timestamp as Temporal.Instant-parseable ISO string`
+- Existing tests still pass — most notably
+  `test/discovery/SuccessCache.ts`, `test/discovery/FailureCacheOperations.ts`,
+  `test/discovery/DiscoveryCleanup.ts`,
+  `test/discovery/DiscoveryDiagnostics.ts`, and
+  `test/ErrorGuidedStructuralEvolution/ValidateAndFixIfNeeded.ts`
+  (which exercises the issue-directory timestamp filename code path).

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryValidation.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryValidation.ts
@@ -104,8 +104,8 @@ function recordValidationIssue(
 ): void {
   try {
     // Create timestamp in Australian format (yyyymmdd-HHmmss)
-    const now = new Date();
-    const timestamp = now.toISOString()
+    const nowIso = Temporal.Now.instant().toString();
+    const timestamp = nowIso
       .replace(/[-:]/g, "")
       .replace("T", "-")
       .slice(0, 15);
@@ -145,7 +145,7 @@ function recordValidationIssue(
       `Validation Error Report`,
       `=======================`,
       ``,
-      `Timestamp: ${now.toISOString()}`,
+      `Timestamp: ${nowIso}`,
       `Discovery ID: ${discoveryID}`,
       `Operation Type: ${operationType}`,
       ``,
@@ -187,8 +187,8 @@ export function recordDiscoveryIssue(
 ): void {
   try {
     // Create timestamp in Australian format (yyyymmdd-HHmmss)
-    const now = new Date();
-    const timestamp = now.toISOString()
+    const nowIso = Temporal.Now.instant().toString();
+    const timestamp = nowIso
       .replace(/[-:]/g, "")
       .replace("T", "-")
       .slice(0, 15);
@@ -227,7 +227,7 @@ export function recordDiscoveryIssue(
       `Discovery Issue Report`,
       `======================`,
       ``,
-      `Timestamp: ${now.toISOString()}`,
+      `Timestamp: ${nowIso}`,
       `Discovery ID: ${discoveryID}`,
       `Operation Type: ${operationType}`,
       `Issue Type: ${issueType}`,

--- a/src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts
@@ -133,7 +133,7 @@ export function writeFocusSelectionAnalysis(
 
     const analysis: FocusSelectionAnalysis = {
       discoveryID,
-      timestamp: new Date().toISOString(),
+      timestamp: Temporal.Now.instant().toString(),
       costOfGrowth,
       selectionMethod,
       totalCandidates: candidates.length,

--- a/src/discovery/DiscoveryCleanup.ts
+++ b/src/discovery/DiscoveryCleanup.ts
@@ -32,7 +32,7 @@ export function createDiscoveryLockFile(dir: string): void {
   const lockPath = `${dir}/${LOCK_FILE_NAME}`;
   const data: DiscoveryLockData = {
     pid: Deno.pid,
-    startedAt: new Date().toISOString(),
+    startedAt: Temporal.Now.instant().toString(),
   };
   Deno.writeTextFileSync(lockPath, JSON.stringify(data));
 }

--- a/src/discovery/DiscoveryDiagnostics.ts
+++ b/src/discovery/DiscoveryDiagnostics.ts
@@ -133,7 +133,7 @@ export function persistDiagnostics(
 
   const payload: Record<string, unknown> = {
     discoveryID,
-    timestamp: new Date().toISOString(),
+    timestamp: Temporal.Now.instant().toString(),
     changeTypes: Object.fromEntries(diagnostics),
   };
 

--- a/src/discovery/DiscoveryEvaluationSummary.ts
+++ b/src/discovery/DiscoveryEvaluationSummary.ts
@@ -57,7 +57,7 @@ function sanitizeSegment(value: string): string {
 }
 
 function makeArchiveTimestamp(): string {
-  return new Date().toISOString().replace(/[:.]/g, "-");
+  return Temporal.Now.instant().toString().replace(/[:.]/g, "-");
 }
 
 function safeRealPath(path: string): string {

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -148,7 +148,7 @@ function buildCacheEntryPayload(
     changeType: candidate.change.type,
     description: candidate.change.description,
     ...metadata,
-    timestamp: new Date().toISOString(),
+    timestamp: Temporal.Now.instant().toString(),
     ...(discoveryVersion ? { discoveryVersion } : {}),
   };
 

--- a/src/discovery/SuccessCache.ts
+++ b/src/discovery/SuccessCache.ts
@@ -137,7 +137,7 @@ export function recordSuccessSync(
     changeType: candidate.change.type,
     description: candidate.change.description,
     ...metadata,
-    timestamp: metadata.timestamp ?? new Date().toISOString(),
+    timestamp: metadata.timestamp ?? Temporal.Now.instant().toString(),
     ...(discoveryVersion ? { discoveryVersion } : {}),
     rustRequest: baseCreature
       ? buildRustRequest(baseCreature, candidate)

--- a/test/discovery/CacheTemporalTimestamps.ts
+++ b/test/discovery/CacheTemporalTimestamps.ts
@@ -1,0 +1,169 @@
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path/join";
+import type { DiscoverResult } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import type { CandidateSynapse } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { buildDiscoveryCandidates } from "@discovery/DiscoveryCandidates.ts";
+import { buildCacheKey, recordFailureSync } from "@discovery/FailureCache.ts";
+import { recordSuccessSync } from "@discovery/SuccessCache.ts";
+import { closeRustLibrary } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import { makeForwardOnlyCreature as makeBaseCreature } from "../fixtures/SimpleCreatures.ts";
+
+/**
+ * Issue #2814 — persisted cache `timestamp` fields must be ISO-8601 strings
+ * parseable by `Temporal.Instant.from()`. This guards against regressions
+ * back to `new Date().toISOString()` (which has only millisecond precision)
+ * and confirms the wire format remains a plain string.
+ */
+
+function makeAddSynapseCandidate(): CandidateSynapse {
+  return {
+    fromNeuronUuid: "input-0",
+    toNeuronUuid: "output-0",
+    weight: 0.5,
+    targetNeuronImpact: 1,
+    expectedCreatureErrorReduction: 0.01,
+    expectedCreatureScoreGain: 0.01,
+    improvedCount: 10,
+    totalCount: 10,
+    comment: "temporal-timestamp-test",
+  };
+}
+
+Deno.test(
+  "SuccessCache persists timestamp as Temporal.Instant-parseable ISO string",
+  async () => {
+    const baseCreature = makeBaseCreature();
+    const discovery: DiscoverResult = {
+      ID: "discovery-success-temporal-test",
+      addHelpfulSynapses: [makeAddSynapseCandidate()],
+      addHelpfulNeurons: undefined,
+      coordinatedStructuralCandidates: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+    const candidates = buildDiscoveryCandidates(baseCreature, discovery, {
+      skipCombinedCandidates: true,
+    });
+    const addSynapse = candidates.find((c) => c.change.type === "add-synapses");
+    if (!addSynapse) throw new Error("Expected add-synapses candidate");
+
+    const cacheDir = await Deno.makeTempDir({
+      prefix: "neat-ai-success-temporal-",
+    });
+    try {
+      const before = Temporal.Now.instant();
+      recordSuccessSync(
+        cacheDir,
+        addSynapse,
+        {
+          originalScore: 1,
+          candidateScore: 1.1,
+          scoreDelta: 0.1,
+          originalError: 1,
+          error: 0.9,
+        },
+        baseCreature,
+      );
+      const after = Temporal.Now.instant();
+
+      const filePath = join(
+        cacheDir,
+        addSynapse.change.type,
+        `${buildCacheKey(addSynapse)}.json`,
+      );
+      const parsed = JSON.parse(await Deno.readTextFile(filePath)) as {
+        timestamp?: unknown;
+      };
+      assertEquals(typeof parsed.timestamp, "string");
+
+      // Must be parseable as a Temporal.Instant.
+      const instant = Temporal.Instant.from(parsed.timestamp as string);
+      assert(instant instanceof Temporal.Instant);
+
+      // Persisted instant must fall within the recording window (inclusive).
+      assert(
+        Temporal.Instant.compare(instant, before) >= 0,
+        `timestamp ${parsed.timestamp} should be >= ${before.toString()}`,
+      );
+      assert(
+        Temporal.Instant.compare(instant, after) <= 0,
+        `timestamp ${parsed.timestamp} should be <= ${after.toString()}`,
+      );
+    } finally {
+      closeRustLibrary();
+      try {
+        await Deno.remove(cacheDir, { recursive: true });
+      } catch {
+        // Ignore cleanup failure in tests.
+      }
+    }
+  },
+);
+
+Deno.test(
+  "FailureCache persists timestamp as Temporal.Instant-parseable ISO string",
+  async () => {
+    const baseCreature = makeBaseCreature();
+    const discovery: DiscoverResult = {
+      ID: "discovery-failure-temporal-test",
+      addHelpfulSynapses: [makeAddSynapseCandidate()],
+      addHelpfulNeurons: undefined,
+      coordinatedStructuralCandidates: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+    const candidates = buildDiscoveryCandidates(baseCreature, discovery, {
+      skipCombinedCandidates: true,
+    });
+    const addSynapse = candidates.find((c) => c.change.type === "add-synapses");
+    if (!addSynapse) throw new Error("Expected add-synapses candidate");
+
+    const cacheDir = await Deno.makeTempDir({
+      prefix: "neat-ai-failure-temporal-",
+    });
+    try {
+      const before = Temporal.Now.instant();
+      recordFailureSync(cacheDir, addSynapse, {
+        originalScore: 1,
+        candidateScore: 0.9,
+        scoreDelta: -0.1,
+        originalError: 1,
+        error: 1.1,
+      });
+      const after = Temporal.Now.instant();
+
+      const filePath = join(
+        cacheDir,
+        addSynapse.change.type,
+        `${buildCacheKey(addSynapse)}.json`,
+      );
+      const parsed = JSON.parse(await Deno.readTextFile(filePath)) as {
+        timestamp?: unknown;
+      };
+      assertEquals(typeof parsed.timestamp, "string");
+
+      const instant = Temporal.Instant.from(parsed.timestamp as string);
+      assert(instant instanceof Temporal.Instant);
+
+      assert(
+        Temporal.Instant.compare(instant, before) >= 0,
+        `timestamp ${parsed.timestamp} should be >= ${before.toString()}`,
+      );
+      assert(
+        Temporal.Instant.compare(instant, after) <= 0,
+        `timestamp ${parsed.timestamp} should be <= ${after.toString()}`,
+      );
+    } finally {
+      closeRustLibrary();
+      try {
+        await Deno.remove(cacheDir, { recursive: true });
+      } catch {
+        // Ignore cleanup failure in tests.
+      }
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Migrated wall-clock timestamp call sites in the Discovery cache, diagnostics,
cleanup state, validation reports, and focus-selection analysis from
`new Date().toISOString()` to `Temporal.Now.instant().toString()`, matching
the date/time policy adopted in #2813. Closes #2814.

Per-phase elapsed-time measurements (e.g. `Date.now() - start` profiling) were
deliberately left untouched — those are monotonic-style measurements where
`Date.now()` remains the correct tool.

### Files migrated

| File | Lines | Change |
| ------ | ------- | -------- |
| `src/discovery/SuccessCache.ts` | 140 | `metadata.timestamp ?? Temporal.Now.instant().toString()` |
| `src/discovery/FailureCache.ts` | 151 | `timestamp: Temporal.Now.instant().toString()` |
| `src/discovery/DiscoveryEvaluationSummary.ts` | 60 | archive-filename timestamp now derived from `Temporal.Now.instant()` |
| `src/discovery/DiscoveryDiagnostics.ts` | 136 | `timestamp: Temporal.Now.instant().toString()` |
| `src/discovery/DiscoveryCleanup.ts` | 35 | lock-file `startedAt` now uses `Temporal.Now.instant().toString()` |
| `src/architecture/ErrorGuidedStructuralEvolution/DiscoveryValidation.ts` | 107, 148, 190, 230 | held `Date` instance replaced with a single `Temporal.Now.instant().toString()` ISO string; printed `Timestamp:` field now reads from that string |
| `src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts` | 136 | `timestamp: Temporal.Now.instant().toString()` |

The on-disk wire format remains a plain ISO-8601 string. `Temporal.Instant`
serialises with nanosecond precision (e.g. `2026-05-30T03:21:09.123456789Z`)
which is still ISO-8601-conformant and round-trips through both
`Temporal.Instant.from()` and `new Date()`.

The Australian-format `YYYYMMDD-HHMMSS` issue-directory prefix in
`DiscoveryValidation.ts` still slices to 15 characters; this works
identically with the nanosecond-precision Temporal string because the
extra digits land after the slice cutoff.

### Deno regression avoided

This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the
AGENTS.md date/time policy, no `@js-temporal/polyfill` and no `@std/datetime`
dependency was added — the migration uses Deno 2.7+'s native `Temporal`.

## Evidence

Backend-only change; no UI to screenshot. Verified via:

- New regression test
  `test/discovery/CacheTemporalTimestamps.ts` asserts that the persisted
  `timestamp` field written by both `SuccessCache` and `FailureCache` is a
  string parseable by `Temporal.Instant.from()` and that the parsed instant
  falls inside the recording window.
- Full `./quality.sh` run: 6990 passed | 0 failed | 4 ignored (2m31s).

## Test Plan

- New: `test/discovery/CacheTemporalTimestamps.ts`
  - `SuccessCache persists timestamp as Temporal.Instant-parseable ISO string`
  - `FailureCache persists timestamp as Temporal.Instant-parseable ISO string`
- Existing tests still pass — most notably
  `test/discovery/SuccessCache.ts`, `test/discovery/FailureCacheOperations.ts`,
  `test/discovery/DiscoveryCleanup.ts`,
  `test/discovery/DiscoveryDiagnostics.ts`, and
  `test/ErrorGuidedStructuralEvolution/ValidateAndFixIfNeeded.ts`
  (which exercises the issue-directory timestamp filename code path).



## Milestone
This PR is part of the **Temporal** milestone and targets the `milestone/temporal` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mprky2m9-0d16ae`<!-- vibe-worker-issue-2814 -->