### PR TITLE
Migrate Checkpoint/Diagnostics/WasmActivation timestamps to Temporal (#2815)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-2815.md
+++ b/docs/archive/pr-summaries/pr-summary-2815.md
@@ -1,0 +1,71 @@
+## Summary
+
+Migrated the remaining wall-clock `new Date()` / `Date.now()` call sites in
+`src/transfer/Checkpoint.ts`, `src/utils/Diagnostics.ts`, and
+`src/wasm/WasmActivation.ts` to native `Temporal`, matching the date/time
+policy in #2813 and the sibling migration in #2814. Closes #2815.
+
+### Files migrated
+
+| File | Line | Before | After |
+|------|------|--------|-------|
+| `src/transfer/Checkpoint.ts` | 71 | `createdAt: new Date().toISOString()` | `createdAt: Temporal.Now.instant().toString()` |
+| `src/utils/Diagnostics.ts` | 58 | `new Date().toISOString().replace(/[:.]/g, "-")` | `Temporal.Now.instant().toString().replace(/[:.]/g, "-")` |
+| `src/wasm/WasmActivation.ts` | 190–193, 72, 79 | `timestamp: Date.now()` (number) | `timestamp: Temporal.Now.instant().toString()` (string) |
+
+`lastCreateFailure.timestamp` was a `number` (epoch ms). An audit of every
+caller (`getLastWasmCreateFailure` consumers in `ProducerCompileGuard.ts`,
+`WasmCompilationCache.ts`, and the `WasmCompileFailureRecovery` test) showed
+no caller reads the field as a numeric delta — they only check the record's
+presence or render `failure.message`. The field is therefore now an
+ISO-8601 string, consistent with how every other persisted/reported
+timestamp in the codebase represents wall-clock instants. The type
+annotation was updated at both the declaration and the public getter so
+TypeScript catches any future numeric consumer at compile time.
+
+`CheckpointMetadata.createdAt` was already typed as `string` and is part
+of the persisted checkpoint wire format — switching its producer to
+`Temporal.Now.instant().toString()` preserves the on-disk contract
+(ISO-8601 string) while bringing it under the Temporal policy. The string
+gains nanosecond precision, which remains ISO-8601-conformant and
+round-trips through both `Temporal.Instant.from()` and `new Date()`.
+
+Per-phase elapsed-time measurements (`MemoryMonitor`, `ThroughputMetrics`,
+`NeatEvolution` profiling) were explicitly out of scope per the policy
+in #2813.
+
+### Deno regression avoided
+
+This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the
+AGENTS.md date/time policy, no `@js-temporal/polyfill` and no
+`@std/datetime` dependency was added — the migration uses Deno 2.7+'s
+native `Temporal`.
+
+## Evidence
+
+Backend-only change; no UI to screenshot. Verified via:
+
+- New regression test in `test/transfer/Checkpoint.ts`:
+  `Issue #2815: checkpoint createdAt is a Temporal.Instant-parseable
+  ISO-8601 string` — round-trips `metadata.createdAt` through
+  `Temporal.Instant.from()` (which throws on malformed input) and asserts
+  the resulting instant falls inside the recording window.
+- Existing tests covering the migrated paths still pass:
+  `test/transfer/Checkpoint.ts` (full file),
+  `test/utils/Diagnostics.ts` (writes / filename pattern),
+  `test/wasm/WasmCompileFailureRecovery.ts` (failure-cache behaviour for
+  `WasmCreatureActivation.create`).
+- Full `./quality.sh` run: **6991 passed | 0 failed | 4 ignored (2m47s)**.
+
+## Test Plan
+
+- New regression test
+  `test/transfer/Checkpoint.ts::Issue #2815: checkpoint createdAt is a
+  Temporal.Instant-parseable ISO-8601 string`.
+- Existing tests must continue to pass:
+  - `test/transfer/Checkpoint.ts` — every export/import scenario.
+  - `test/utils/Diagnostics.ts` — verifies the `.diagnostics/`
+    filename pattern using the new Temporal timestamp.
+  - `test/wasm/WasmCompileFailureRecovery.ts` — covers
+    `getLastWasmCreateFailure()` with the new string `timestamp` type.
+- `./quality.sh` (lint, format, type-check, full test suite) passes.

--- a/src/transfer/Checkpoint.ts
+++ b/src/transfer/Checkpoint.ts
@@ -68,7 +68,8 @@ export function exportCheckpoint(
   const metadata: CheckpointMetadata = {
     sourceTask: options?.sourceTask,
     description: options?.description,
-    createdAt: new Date().toISOString(),
+    // Issue #2815: wall-clock instant — use Temporal for ISO timestamps.
+    createdAt: Temporal.Now.instant().toString(),
     score: creature.score,
     generations: options?.generations,
     sourceInputCount: creature.input,

--- a/src/utils/Diagnostics.ts
+++ b/src/utils/Diagnostics.ts
@@ -55,7 +55,8 @@ export function writeDiagnostics(options: DiagnosticsOptions): void {
   }
 
   const filePrefix = prefix ? `${prefix}-` : "";
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  // Issue #2815: wall-clock instant — use Temporal for ISO timestamps.
+  const timestamp = Temporal.Now.instant().toString().replace(/[:.]/g, "-");
 
   // Write error text
   const errorText = error instanceof Error

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -68,15 +68,20 @@ export interface WasmTraceResult {
  * the WASM constructor surfaces once per offending creature uuid rather than
  * once per retry. Reading this value clears nothing — callers compare
  * timestamps to confirm freshness.
+ *
+ * Issue #2815: `timestamp` is an ISO-8601 string sourced from
+ * `Temporal.Now.instant().toString()` (wall-clock instant). Downstream
+ * consumers compare records by identity / message rather than by numeric
+ * delta, so the string form is the appropriate Temporal representation.
  */
-let lastCreateFailure: { message: string; timestamp: number } | null = null;
+let lastCreateFailure: { message: string; timestamp: string } | null = null;
 
 /**
  * Read the most recent `WasmCreatureActivation.create` failure (if any).
  * Issue #2483.
  */
 export function getLastWasmCreateFailure():
-  | { message: string; timestamp: number }
+  | { message: string; timestamp: string }
   | null {
   return lastCreateFailure;
 }
@@ -189,7 +194,8 @@ export class WasmCreatureActivation {
       // surface it once per creature instead of logging here on every retry.
       lastCreateFailure = {
         message: error instanceof Error ? error.message : String(error),
-        timestamp: Date.now(),
+        // Issue #2815: wall-clock instant — use Temporal for ISO timestamps.
+        timestamp: Temporal.Now.instant().toString(),
       };
       return null;
     }

--- a/test/transfer/Checkpoint.ts
+++ b/test/transfer/Checkpoint.ts
@@ -526,6 +526,38 @@ Deno.test("checkpoint metadata - timestamps are valid ISO strings", async () => 
   assert(!isNaN(date.getTime()), "createdAt should be a valid ISO date");
 });
 
+// Issue #2815: createdAt must be a wall-clock ISO-8601 instant
+// parseable by Temporal.Instant.from, not just a Date-parseable string.
+Deno.test(
+  "Issue #2815: checkpoint createdAt is a Temporal.Instant-parseable ISO-8601 string",
+  async () => {
+    await initWasmForTests();
+    const before = Temporal.Now.instant();
+    const creature = new Creature(2, 1);
+    const checkpoint = exportCheckpoint(creature);
+    const after = Temporal.Now.instant();
+
+    assertEquals(
+      typeof checkpoint.metadata.createdAt,
+      "string",
+      "createdAt should be a string",
+    );
+
+    // Round-trip through Temporal.Instant.from — this throws on a malformed
+    // value, which is exactly what we want the regression test to catch.
+    const instant = Temporal.Instant.from(checkpoint.metadata.createdAt);
+
+    assert(
+      Temporal.Instant.compare(instant, before) >= 0,
+      `createdAt ${checkpoint.metadata.createdAt} should be >= ${before.toString()}`,
+    );
+    assert(
+      Temporal.Instant.compare(instant, after) <= 0,
+      `createdAt ${checkpoint.metadata.createdAt} should be <= ${after.toString()}`,
+    );
+  },
+);
+
 Deno.test("importCheckpoint - no options returns identical creature", async () => {
   await initWasmForTests();
   const creature = new Creature(2, 1, {


### PR DESCRIPTION
## Summary

Migrated the remaining wall-clock `new Date()` / `Date.now()` call sites in
`src/transfer/Checkpoint.ts`, `src/utils/Diagnostics.ts`, and
`src/wasm/WasmActivation.ts` to native `Temporal`, matching the date/time
policy in #2813 and the sibling migration in #2814. Closes #2815.

### Files migrated

| File | Line | Before | After |
|------|------|--------|-------|
| `src/transfer/Checkpoint.ts` | 71 | `createdAt: new Date().toISOString()` | `createdAt: Temporal.Now.instant().toString()` |
| `src/utils/Diagnostics.ts` | 58 | `new Date().toISOString().replace(/[:.]/g, "-")` | `Temporal.Now.instant().toString().replace(/[:.]/g, "-")` |
| `src/wasm/WasmActivation.ts` | 190–193, 72, 79 | `timestamp: Date.now()` (number) | `timestamp: Temporal.Now.instant().toString()` (string) |

`lastCreateFailure.timestamp` was a `number` (epoch ms). An audit of every
caller (`getLastWasmCreateFailure` consumers in `ProducerCompileGuard.ts`,
`WasmCompilationCache.ts`, and the `WasmCompileFailureRecovery` test) showed
no caller reads the field as a numeric delta — they only check the record's
presence or render `failure.message`. The field is therefore now an
ISO-8601 string, consistent with how every other persisted/reported
timestamp in the codebase represents wall-clock instants. The type
annotation was updated at both the declaration and the public getter so
TypeScript catches any future numeric consumer at compile time.

`CheckpointMetadata.createdAt` was already typed as `string` and is part
of the persisted checkpoint wire format — switching its producer to
`Temporal.Now.instant().toString()` preserves the on-disk contract
(ISO-8601 string) while bringing it under the Temporal policy. The string
gains nanosecond precision, which remains ISO-8601-conformant and
round-trips through both `Temporal.Instant.from()` and `new Date()`.

Per-phase elapsed-time measurements (`MemoryMonitor`, `ThroughputMetrics`,
`NeatEvolution` profiling) were explicitly out of scope per the policy
in #2813.

### Deno regression avoided

This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the
AGENTS.md date/time policy, no `@js-temporal/polyfill` and no
`@std/datetime` dependency was added — the migration uses Deno 2.7+'s
native `Temporal`.

## Evidence

Backend-only change; no UI to screenshot. Verified via:

- New regression test in `test/transfer/Checkpoint.ts`:
  `Issue #2815: checkpoint createdAt is a Temporal.Instant-parseable
  ISO-8601 string` — round-trips `metadata.createdAt` through
  `Temporal.Instant.from()` (which throws on malformed input) and asserts
  the resulting instant falls inside the recording window.
- Existing tests covering the migrated paths still pass:
  `test/transfer/Checkpoint.ts` (full file),
  `test/utils/Diagnostics.ts` (writes / filename pattern),
  `test/wasm/WasmCompileFailureRecovery.ts` (failure-cache behaviour for
  `WasmCreatureActivation.create`).
- Full `./quality.sh` run: **6991 passed | 0 failed | 4 ignored (2m47s)**.

## Test Plan

- New regression test
  `test/transfer/Checkpoint.ts::Issue #2815: checkpoint createdAt is a
  Temporal.Instant-parseable ISO-8601 string`.
- Existing tests must continue to pass:
  - `test/transfer/Checkpoint.ts` — every export/import scenario.
  - `test/utils/Diagnostics.ts` — verifies the `.diagnostics/`
    filename pattern using the new Temporal timestamp.
  - `test/wasm/WasmCompileFailureRecovery.ts` — covers
    `getLastWasmCreateFailure()` with the new string `timestamp` type.
- `./quality.sh` (lint, format, type-check, full test suite) passes.