### PR TITLE
Migrate CreatureTraining event timestamps to native Temporal (Issue #2817)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-2817.md
+++ b/docs/archive/pr-summaries/pr-summary-2817.md
@@ -1,0 +1,59 @@
+## Summary
+
+Migrated all eight wall-clock `timestamp` emissions in
+`src/creature/CreatureTraining.ts` from `new Date().toISOString()` to
+`Temporal.Now.instant().toString()`, matching the date/time policy in AGENTS.md
+and continuing the milestone work started in #2814–#2816. Closes #2817.
+
+Per-phase elapsed-time measurements (`Date.now()` deltas, `performance.now()`
+spans) inside `CreatureTraining.ts` were deliberately left untouched — those are
+monotonic-style measurements where `Date.now()` is the correct tool, per the
+AGENTS.md "do NOT migrate" guidance.
+
+### Sites migrated
+
+| Lines            | Event kind                                                      |
+| ---------------- | --------------------------------------------------------------- |
+| 521, 535         | `generation_complete`, `plateau_detected`                       |
+| 798, 811         | `generation_complete`, `plateau_detected`                       |
+| 1263, 1276, 1315 | `generation_complete`, `plateau_detected`, `evolverl_milestone` |
+| 1390             | `evolverl_milestone` (synthetic final)                          |
+
+The on-disk / event-bus wire format remains a plain ISO-8601 string.
+`Temporal.Instant.toString()` emits nanosecond precision (e.g.
+`2026-05-30T03:21:09.123456789Z`) which is still ISO-8601-conformant and
+round-trips through both `Temporal.Instant.from()` and `new Date()` — existing
+test assertions that parse with `new Date(timestamp)` continue to pass.
+
+`TrainingEvent.timestamp` remains typed as `string`; no interface change was
+required.
+
+### Deno regression avoided
+
+This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the AGENTS.md
+date/time policy, no `@js-temporal/polyfill` and no `@std/datetime` dependency
+was added — the migration uses Deno 2.7+'s native `Temporal`.
+
+## Evidence
+
+Backend-only change; no UI to screenshot. Verified via:
+
+- New regression test in `test/config/TrainingEvent.ts`:
+  `TrainingEvent - timestamps are parseable by Temporal.Instant.from (Issue #2817)`
+  asserts that every emitted event timestamp parses through
+  `Temporal.Instant.from()` and yields an epoch after the 2020-01-01 cutoff.
+- Existing `TrainingEvent` and `CreatureTrainEvolve` test suites still pass
+  (`new Date(timestamp)` parsers handle the nanosecond ISO string
+  transparently).
+- `deno fmt`, `deno lint`, and `deno check` clean on the touched files.
+
+## Test Plan
+
+- Modified: `test/config/TrainingEvent.ts`
+  - Added:
+    `TrainingEvent - timestamps are parseable by Temporal.Instant.from (Issue #2817)`
+- Re-ran:
+  - `test/config/TrainingEvent.ts` — 9 passed
+  - `test/creature/CreatureTrainEvolve.ts` — passes
+  - `test/creature/CreatureTrainingTypedErrors.ts` — passes
+  - Combined run: 30 passed | 0 failed

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -518,7 +518,7 @@ export async function evolveDir(
       (generation === 1 ? start : iterationStartMS);
     emitTrainingEvent(config.onTrainingEvent, {
       kind: "generation_complete",
-      timestamp: new Date().toISOString(),
+      timestamp: Temporal.Now.instant().toString(),
       generation,
       bestFitness: fittestScore,
       averageFitness: result.averageScore,
@@ -532,7 +532,7 @@ export async function evolveDir(
     if (result.plateau.onPlateau) {
       emitTrainingEvent(config.onTrainingEvent, {
         kind: "plateau_detected",
-        timestamp: new Date().toISOString(),
+        timestamp: Temporal.Now.instant().toString(),
         generation,
         stagnationCount: result.plateau.generationsOnPlateau,
         plateauThreshold: config.plateauDetection.windowSize,
@@ -795,7 +795,7 @@ export async function evolveEnv<S, A>(
       (generation === 1 ? start : iterationStartMS);
     emitTrainingEvent(config.onTrainingEvent, {
       kind: "generation_complete",
-      timestamp: new Date().toISOString(),
+      timestamp: Temporal.Now.instant().toString(),
       generation,
       bestFitness: fittestScore,
       averageFitness: result.averageScore,
@@ -808,7 +808,7 @@ export async function evolveEnv<S, A>(
     if (result.plateau.onPlateau) {
       emitTrainingEvent(config.onTrainingEvent, {
         kind: "plateau_detected",
-        timestamp: new Date().toISOString(),
+        timestamp: Temporal.Now.instant().toString(),
         generation,
         stagnationCount: result.plateau.generationsOnPlateau,
         plateauThreshold: config.plateauDetection.windowSize,
@@ -1260,7 +1260,7 @@ export async function evolveRL<S, A>(
       (generation === 1 ? start : iterationStartMS);
     emitTrainingEvent(config.onTrainingEvent, {
       kind: "generation_complete",
-      timestamp: new Date().toISOString(),
+      timestamp: Temporal.Now.instant().toString(),
       generation,
       bestFitness: fittestScore,
       averageFitness: result.averageScore,
@@ -1273,7 +1273,7 @@ export async function evolveRL<S, A>(
     if (result.plateau.onPlateau) {
       emitTrainingEvent(config.onTrainingEvent, {
         kind: "plateau_detected",
-        timestamp: new Date().toISOString(),
+        timestamp: Temporal.Now.instant().toString(),
         generation,
         stagnationCount: result.plateau.generationsOnPlateau,
         plateauThreshold: config.plateauDetection.windowSize,
@@ -1312,7 +1312,7 @@ export async function evolveRL<S, A>(
       milestones.push(milestone);
       emitTrainingEvent(config.onTrainingEvent, {
         kind: "evolverl_milestone",
-        timestamp: new Date().toISOString(),
+        timestamp: Temporal.Now.instant().toString(),
         ...milestone,
       });
     }
@@ -1387,7 +1387,7 @@ export async function evolveRL<S, A>(
     milestones.push(milestone);
     emitTrainingEvent(config.onTrainingEvent, {
       kind: "evolverl_milestone",
-      timestamp: new Date().toISOString(),
+      timestamp: Temporal.Now.instant().toString(),
       ...milestone,
     });
   }

--- a/test/config/TrainingEvent.ts
+++ b/test/config/TrainingEvent.ts
@@ -307,3 +307,44 @@ Deno.test("TrainingEvent - species_adjusted events are emitted", async () => {
       typeof first.compatibilityThreshold === "number",
   );
 });
+
+Deno.test("TrainingEvent - timestamps are parseable by Temporal.Instant.from (Issue #2817)", async () => {
+  const events: TrainingEvent[] = [];
+
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([1]) },
+  ];
+
+  const creature = new Creature(2, 1);
+
+  await creature.evolveDataSet(trainingSet, {
+    mutation: Mutation.FFW,
+    iterations: 3,
+    targetError: 0.001,
+    populationSize: 10,
+    threads: 1,
+    onTrainingEvent: (event) => {
+      events.push(event);
+    },
+  });
+
+  assertGreater(events.length, 0, "Should emit at least one training event");
+
+  // Issue #2817: wall-clock timestamps emitted by CreatureTraining must be
+  // produced by Temporal.Now.instant().toString() — i.e. native Temporal —
+  // which means every timestamp must parse through Temporal.Instant.from
+  // without throwing and produce an epoch after the 2020-01-01 cutoff (a
+  // sanity check that we are emitting a real wall-clock instant, not a
+  // zero/epoch placeholder).
+  // Cutoff: 2020-01-01T00:00:00Z in epoch nanoseconds.
+  const cutoffNs = Temporal.Instant.from("2020-01-01T00:00:00Z")
+    .epochNanoseconds;
+  for (const event of events) {
+    const instant = Temporal.Instant.from(event.timestamp);
+    assert(
+      instant.epochNanoseconds > cutoffNs,
+      `Event timestamp ${event.timestamp} should be after 2020-01-01`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Migrated all eight wall-clock `timestamp` emissions in
`src/creature/CreatureTraining.ts` from `new Date().toISOString()` to
`Temporal.Now.instant().toString()`, matching the date/time policy in AGENTS.md
and continuing the milestone work started in #2814–#2816. Closes #2817.

Per-phase elapsed-time measurements (`Date.now()` deltas, `performance.now()`
spans) inside `CreatureTraining.ts` were deliberately left untouched — those are
monotonic-style measurements where `Date.now()` is the correct tool, per the
AGENTS.md "do NOT migrate" guidance.

### Sites migrated

| Lines            | Event kind                                                      |
| ---------------- | --------------------------------------------------------------- |
| 521, 535         | `generation_complete`, `plateau_detected`                       |
| 798, 811         | `generation_complete`, `plateau_detected`                       |
| 1263, 1276, 1315 | `generation_complete`, `plateau_detected`, `evolverl_milestone` |
| 1390             | `evolverl_milestone` (synthetic final)                          |

The on-disk / event-bus wire format remains a plain ISO-8601 string.
`Temporal.Instant.toString()` emits nanosecond precision (e.g.
`2026-05-30T03:21:09.123456789Z`) which is still ISO-8601-conformant and
round-trips through both `Temporal.Instant.from()` and `new Date()` — existing
test assertions that parse with `new Date(timestamp)` continue to pass.

`TrainingEvent.timestamp` remains typed as `string`; no interface change was
required.

### Deno regression avoided

This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the AGENTS.md
date/time policy, no `@js-temporal/polyfill` and no `@std/datetime` dependency
was added — the migration uses Deno 2.7+'s native `Temporal`.

## Evidence

Backend-only change; no UI to screenshot. Verified via:

- New regression test in `test/config/TrainingEvent.ts`:
  `TrainingEvent - timestamps are parseable by Temporal.Instant.from (Issue #2817)`
  asserts that every emitted event timestamp parses through
  `Temporal.Instant.from()` and yields an epoch after the 2020-01-01 cutoff.
- Existing `TrainingEvent` and `CreatureTrainEvolve` test suites still pass
  (`new Date(timestamp)` parsers handle the nanosecond ISO string
  transparently).
- `deno fmt`, `deno lint`, and `deno check` clean on the touched files.

## Test Plan

- Modified: `test/config/TrainingEvent.ts`
  - Added:
    `TrainingEvent - timestamps are parseable by Temporal.Instant.from (Issue #2817)`
- Re-ran:
  - `test/config/TrainingEvent.ts` — 9 passed
  - `test/creature/CreatureTrainEvolve.ts` — passes
  - `test/creature/CreatureTrainingTypedErrors.ts` — passes
  - Combined run: 30 passed | 0 failed



## Milestone
This PR is part of the **Temporal** milestone and targets the `milestone/temporal` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mprky2m9-0d16ae`<!-- vibe-worker-issue-2817 -->