### PR TITLE
Bump version to 5.2.0 and document Temporal migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,14 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-05-30
+
 ### Changed
+
+- Adopted the native `Temporal` API for wall-clock timestamps in training
+  events, discovery cache entries, checkpoint metadata, diagnostics, and
+  validation reports. Elapsed-time measurements continue to use `Date.now()` /
+  `performance.now()`. (Issues #2814, #2815, #2816, #2817; policy in #2813.)
 
 - **Issue #2791:** `trainPerGen` now auto-scales with the population for
   supervised costs so per-genome gradient training is no longer starved.

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2814.md
+++ b/docs/archive/pr-summaries/pr-summary-2814.md
@@ -2,8 +2,8 @@
 
 Migrated wall-clock timestamp call sites in the Discovery cache, diagnostics,
 cleanup state, validation reports, and focus-selection analysis from
-`new Date().toISOString()` to `Temporal.Now.instant().toString()`, matching
-the date/time policy adopted in #2813. Closes #2814.
+`new Date().toISOString()` to `Temporal.Now.instant().toString()`, matching the
+date/time policy adopted in #2813. Closes #2814.
 
 Per-phase elapsed-time measurements (e.g. `Date.now() - start` profiling) were
 deliberately left untouched — those are monotonic-style measurements where
@@ -11,15 +11,15 @@ deliberately left untouched — those are monotonic-style measurements where
 
 ### Files migrated
 
-| File | Lines | Change |
-|------|-------|--------|
-| `src/discovery/SuccessCache.ts` | 140 | `metadata.timestamp ?? Temporal.Now.instant().toString()` |
-| `src/discovery/FailureCache.ts` | 151 | `timestamp: Temporal.Now.instant().toString()` |
-| `src/discovery/DiscoveryEvaluationSummary.ts` | 60 | archive-filename timestamp now derived from `Temporal.Now.instant()` |
-| `src/discovery/DiscoveryDiagnostics.ts` | 136 | `timestamp: Temporal.Now.instant().toString()` |
-| `src/discovery/DiscoveryCleanup.ts` | 35 | lock-file `startedAt` now uses `Temporal.Now.instant().toString()` |
-| `src/architecture/ErrorGuidedStructuralEvolution/DiscoveryValidation.ts` | 107, 148, 190, 230 | held `Date` instance replaced with a single `Temporal.Now.instant().toString()` ISO string; printed `Timestamp:` field now reads from that string |
-| `src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts` | 136 | `timestamp: Temporal.Now.instant().toString()` |
+| File                                                                         | Lines              | Change                                                                                                                                            |
+| ---------------------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/discovery/SuccessCache.ts`                                              | 140                | `metadata.timestamp ?? Temporal.Now.instant().toString()`                                                                                         |
+| `src/discovery/FailureCache.ts`                                              | 151                | `timestamp: Temporal.Now.instant().toString()`                                                                                                    |
+| `src/discovery/DiscoveryEvaluationSummary.ts`                                | 60                 | archive-filename timestamp now derived from `Temporal.Now.instant()`                                                                              |
+| `src/discovery/DiscoveryDiagnostics.ts`                                      | 136                | `timestamp: Temporal.Now.instant().toString()`                                                                                                    |
+| `src/discovery/DiscoveryCleanup.ts`                                          | 35                 | lock-file `startedAt` now uses `Temporal.Now.instant().toString()`                                                                                |
+| `src/architecture/ErrorGuidedStructuralEvolution/DiscoveryValidation.ts`     | 107, 148, 190, 230 | held `Date` instance replaced with a single `Temporal.Now.instant().toString()` ISO string; printed `Timestamp:` field now reads from that string |
+| `src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts` | 136                | `timestamp: Temporal.Now.instant().toString()`                                                                                                    |
 
 The on-disk wire format remains a plain ISO-8601 string. `Temporal.Instant`
 serialises with nanosecond precision (e.g. `2026-05-30T03:21:09.123456789Z`)
@@ -27,25 +27,24 @@ which is still ISO-8601-conformant and round-trips through both
 `Temporal.Instant.from()` and `new Date()`.
 
 The Australian-format `YYYYMMDD-HHMMSS` issue-directory prefix in
-`DiscoveryValidation.ts` still slices to 15 characters; this works
-identically with the nanosecond-precision Temporal string because the
-extra digits land after the slice cutoff.
+`DiscoveryValidation.ts` still slices to 15 characters; this works identically
+with the nanosecond-precision Temporal string because the extra digits land
+after the slice cutoff.
 
 ### Deno regression avoided
 
-This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the
-AGENTS.md date/time policy, no `@js-temporal/polyfill` and no `@std/datetime`
-dependency was added — the migration uses Deno 2.7+'s native `Temporal`.
+This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the AGENTS.md
+date/time policy, no `@js-temporal/polyfill` and no `@std/datetime` dependency
+was added — the migration uses Deno 2.7+'s native `Temporal`.
 
 ## Evidence
 
 Backend-only change; no UI to screenshot. Verified via:
 
-- New regression test
-  `test/discovery/CacheTemporalTimestamps.ts` asserts that the persisted
-  `timestamp` field written by both `SuccessCache` and `FailureCache` is a
-  string parseable by `Temporal.Instant.from()` and that the parsed instant
-  falls inside the recording window.
+- New regression test `test/discovery/CacheTemporalTimestamps.ts` asserts that
+  the persisted `timestamp` field written by both `SuccessCache` and
+  `FailureCache` is a string parseable by `Temporal.Instant.from()` and that the
+  parsed instant falls inside the recording window.
 - Full `./quality.sh` run: 6990 passed | 0 failed | 4 ignored (2m31s).
 
 ## Test Plan
@@ -53,9 +52,9 @@ Backend-only change; no UI to screenshot. Verified via:
 - New: `test/discovery/CacheTemporalTimestamps.ts`
   - `SuccessCache persists timestamp as Temporal.Instant-parseable ISO string`
   - `FailureCache persists timestamp as Temporal.Instant-parseable ISO string`
-- Existing tests still pass — most notably
-  `test/discovery/SuccessCache.ts`, `test/discovery/FailureCacheOperations.ts`,
+- Existing tests still pass — most notably `test/discovery/SuccessCache.ts`,
+  `test/discovery/FailureCacheOperations.ts`,
   `test/discovery/DiscoveryCleanup.ts`,
   `test/discovery/DiscoveryDiagnostics.ts`, and
-  `test/ErrorGuidedStructuralEvolution/ValidateAndFixIfNeeded.ts`
-  (which exercises the issue-directory timestamp filename code path).
+  `test/ErrorGuidedStructuralEvolution/ValidateAndFixIfNeeded.ts` (which
+  exercises the issue-directory timestamp filename code path).

--- a/docs/archive/pr-summaries/pr-summary-2815.md
+++ b/docs/archive/pr-summaries/pr-summary-2815.md
@@ -2,44 +2,42 @@
 
 Migrated the remaining wall-clock `new Date()` / `Date.now()` call sites in
 `src/transfer/Checkpoint.ts`, `src/utils/Diagnostics.ts`, and
-`src/wasm/WasmActivation.ts` to native `Temporal`, matching the date/time
-policy in #2813 and the sibling migration in #2814. Closes #2815.
+`src/wasm/WasmActivation.ts` to native `Temporal`, matching the date/time policy
+in #2813 and the sibling migration in #2814. Closes #2815.
 
 ### Files migrated
 
-| File | Line | Before | After |
-|------|------|--------|-------|
-| `src/transfer/Checkpoint.ts` | 71 | `createdAt: new Date().toISOString()` | `createdAt: Temporal.Now.instant().toString()` |
-| `src/utils/Diagnostics.ts` | 58 | `new Date().toISOString().replace(/[:.]/g, "-")` | `Temporal.Now.instant().toString().replace(/[:.]/g, "-")` |
-| `src/wasm/WasmActivation.ts` | 190–193, 72, 79 | `timestamp: Date.now()` (number) | `timestamp: Temporal.Now.instant().toString()` (string) |
+| File                         | Line            | Before                                           | After                                                     |
+| ---------------------------- | --------------- | ------------------------------------------------ | --------------------------------------------------------- |
+| `src/transfer/Checkpoint.ts` | 71              | `createdAt: new Date().toISOString()`            | `createdAt: Temporal.Now.instant().toString()`            |
+| `src/utils/Diagnostics.ts`   | 58              | `new Date().toISOString().replace(/[:.]/g, "-")` | `Temporal.Now.instant().toString().replace(/[:.]/g, "-")` |
+| `src/wasm/WasmActivation.ts` | 190–193, 72, 79 | `timestamp: Date.now()` (number)                 | `timestamp: Temporal.Now.instant().toString()` (string)   |
 
 `lastCreateFailure.timestamp` was a `number` (epoch ms). An audit of every
 caller (`getLastWasmCreateFailure` consumers in `ProducerCompileGuard.ts`,
-`WasmCompilationCache.ts`, and the `WasmCompileFailureRecovery` test) showed
-no caller reads the field as a numeric delta — they only check the record's
-presence or render `failure.message`. The field is therefore now an
-ISO-8601 string, consistent with how every other persisted/reported
-timestamp in the codebase represents wall-clock instants. The type
-annotation was updated at both the declaration and the public getter so
-TypeScript catches any future numeric consumer at compile time.
+`WasmCompilationCache.ts`, and the `WasmCompileFailureRecovery` test) showed no
+caller reads the field as a numeric delta — they only check the record's
+presence or render `failure.message`. The field is therefore now an ISO-8601
+string, consistent with how every other persisted/reported timestamp in the
+codebase represents wall-clock instants. The type annotation was updated at both
+the declaration and the public getter so TypeScript catches any future numeric
+consumer at compile time.
 
-`CheckpointMetadata.createdAt` was already typed as `string` and is part
-of the persisted checkpoint wire format — switching its producer to
-`Temporal.Now.instant().toString()` preserves the on-disk contract
-(ISO-8601 string) while bringing it under the Temporal policy. The string
-gains nanosecond precision, which remains ISO-8601-conformant and
-round-trips through both `Temporal.Instant.from()` and `new Date()`.
+`CheckpointMetadata.createdAt` was already typed as `string` and is part of the
+persisted checkpoint wire format — switching its producer to
+`Temporal.Now.instant().toString()` preserves the on-disk contract (ISO-8601
+string) while bringing it under the Temporal policy. The string gains nanosecond
+precision, which remains ISO-8601-conformant and round-trips through both
+`Temporal.Instant.from()` and `new Date()`.
 
 Per-phase elapsed-time measurements (`MemoryMonitor`, `ThroughputMetrics`,
-`NeatEvolution` profiling) were explicitly out of scope per the policy
-in #2813.
+`NeatEvolution` profiling) were explicitly out of scope per the policy in #2813.
 
 ### Deno regression avoided
 
-This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the
-AGENTS.md date/time policy, no `@js-temporal/polyfill` and no
-`@std/datetime` dependency was added — the migration uses Deno 2.7+'s
-native `Temporal`.
+This repo is a Deno repo (`deno.json`, `deno.lock` present). Per the AGENTS.md
+date/time policy, no `@js-temporal/polyfill` and no `@std/datetime` dependency
+was added — the migration uses Deno 2.7+'s native `Temporal`.
 
 ## Evidence
 
@@ -47,14 +45,14 @@ Backend-only change; no UI to screenshot. Verified via:
 
 - New regression test in `test/transfer/Checkpoint.ts`:
   `Issue #2815: checkpoint createdAt is a Temporal.Instant-parseable
-  ISO-8601 string` — round-trips `metadata.createdAt` through
-  `Temporal.Instant.from()` (which throws on malformed input) and asserts
-  the resulting instant falls inside the recording window.
+  ISO-8601 string`
+  — round-trips `metadata.createdAt` through `Temporal.Instant.from()` (which
+  throws on malformed input) and asserts the resulting instant falls inside the
+  recording window.
 - Existing tests covering the migrated paths still pass:
-  `test/transfer/Checkpoint.ts` (full file),
-  `test/utils/Diagnostics.ts` (writes / filename pattern),
-  `test/wasm/WasmCompileFailureRecovery.ts` (failure-cache behaviour for
-  `WasmCreatureActivation.create`).
+  `test/transfer/Checkpoint.ts` (full file), `test/utils/Diagnostics.ts` (writes
+  / filename pattern), `test/wasm/WasmCompileFailureRecovery.ts` (failure-cache
+  behaviour for `WasmCreatureActivation.create`).
 - Full `./quality.sh` run: **6991 passed | 0 failed | 4 ignored (2m47s)**.
 
 ## Test Plan
@@ -64,8 +62,8 @@ Backend-only change; no UI to screenshot. Verified via:
   Temporal.Instant-parseable ISO-8601 string`.
 - Existing tests must continue to pass:
   - `test/transfer/Checkpoint.ts` — every export/import scenario.
-  - `test/utils/Diagnostics.ts` — verifies the `.diagnostics/`
-    filename pattern using the new Temporal timestamp.
+  - `test/utils/Diagnostics.ts` — verifies the `.diagnostics/` filename pattern
+    using the new Temporal timestamp.
   - `test/wasm/WasmCompileFailureRecovery.ts` — covers
     `getLastWasmCreateFailure()` with the new string `timestamp` type.
 - `./quality.sh` (lint, format, type-check, full test suite) passes.

--- a/docs/archive/pr-summaries/pr-summary-2816.md
+++ b/docs/archive/pr-summaries/pr-summary-2816.md
@@ -2,49 +2,51 @@
 
 Migrated the five `TrainingEvent.timestamp` call sites in the NEAT evolution
 loop from `new Date().toISOString()` to `Temporal.Now.instant().toString()`,
-matching the wall-clock policy in AGENTS.md and the migration already applied
-to `CreatureTraining.ts`. The `TrainingEvent` interface is unchanged — the
-field stays typed as `string` (ISO-8601) and remains parseable by both
-`new Date(...)` and `Temporal.Instant.from(...)`. Per-phase elapsed-time
-measurements (`Date.now()` deltas, `performance.now()`) are intentionally not
-touched. Closes #2816.
+matching the wall-clock policy in AGENTS.md and the migration already applied to
+`CreatureTraining.ts`. The `TrainingEvent` interface is unchanged — the field
+stays typed as `string` (ISO-8601) and remains parseable by both `new Date(...)`
+and `Temporal.Instant.from(...)`. Per-phase elapsed-time measurements
+(`Date.now()` deltas, `performance.now()`) are intentionally not touched. Closes
+#2816.
 
 ## Evidence
 
 Backend-only change — no UI to screenshot. Verified by:
 
-- `deno test test/config/TrainingEvent.ts` — 10 passed, including the new
-  Issue #2816 regression test and the existing Issue #2817 Temporal-parse
-  assertion.
+- `deno test test/config/TrainingEvent.ts` — 10 passed, including the new Issue
+  #2816 regression test and the existing Issue #2817 Temporal-parse assertion.
 - `deno test test/config/TrainingEvent.ts test/config/ThroughputMetrics.ts
-  test/config/PhaseTimingFields.ts` — 25 passed.
+  test/config/PhaseTimingFields.ts`
+  — 25 passed.
 - `./quality.sh --skip-discovery --skip-wasm --lint-only` — clean.
 - `./quality.sh --skip-discovery --skip-wasm --check-only` — clean.
 
 Migrated sites:
 
-| File | Line | Event kind |
-|------|------|------------|
-| `src/NEAT/NeatEvolution.ts` | 100 | `memory_pressure` (pre-fitness) |
-| `src/NEAT/NeatEvolution.ts` | 240 | `species_adjusted` |
-| `src/NEAT/NeatEvolution.ts` | 494 | `population_resized` |
-| `src/NEAT/NeatEvolution.ts` | 791 | `memory_pressure` (post-fitness) |
-| `src/NEAT/ProcessCompletedResults.ts` | 143 | `discovery_complete` |
+| File                                  | Line | Event kind                       |
+| ------------------------------------- | ---- | -------------------------------- |
+| `src/NEAT/NeatEvolution.ts`           | 100  | `memory_pressure` (pre-fitness)  |
+| `src/NEAT/NeatEvolution.ts`           | 240  | `species_adjusted`               |
+| `src/NEAT/NeatEvolution.ts`           | 494  | `population_resized`             |
+| `src/NEAT/NeatEvolution.ts`           | 791  | `memory_pressure` (post-fitness) |
+| `src/NEAT/ProcessCompletedResults.ts` | 143  | `discovery_complete`             |
 
 ## Test Plan
 
-- Added `TrainingEvent - NeatEvolution events use Temporal.Instant timestamps
-  (Issue #2816)` in `test/config/TrainingEvent.ts`. The test runs
-  `evolveDataSet`, filters for `species_adjusted` events (the canonical
-  NeatEvolution.ts emission site), and asserts each `timestamp` parses cleanly
-  via `Temporal.Instant.from(...)` and lies after the 2020-01-01 cutoff —
-  catching any regression to `new Date().toISOString()` or a zero/epoch
-  placeholder.
-- Existing `TrainingEvent - timestamps are parseable by Temporal.Instant.from
-  (Issue #2817)` test continues to pass, covering all event kinds.
+- Added
+  `TrainingEvent - NeatEvolution events use Temporal.Instant timestamps
+  (Issue #2816)`
+  in `test/config/TrainingEvent.ts`. The test runs `evolveDataSet`, filters for
+  `species_adjusted` events (the canonical NeatEvolution.ts emission site), and
+  asserts each `timestamp` parses cleanly via `Temporal.Instant.from(...)` and
+  lies after the 2020-01-01 cutoff — catching any regression to
+  `new Date().toISOString()` or a zero/epoch placeholder.
+- Existing
+  `TrainingEvent - timestamps are parseable by Temporal.Instant.from
+  (Issue #2817)`
+  test continues to pass, covering all event kinds.
 
 ### Deno regression avoided
 
-No Node tooling, `package.json`, or `@js-temporal/polyfill` was introduced —
-the migration uses Deno 2.7+ native `Temporal`, consistent with AGENTS.md
-guidance.
+No Node tooling, `package.json`, or `@js-temporal/polyfill` was introduced — the
+migration uses Deno 2.7+ native `Temporal`, consistent with AGENTS.md guidance.

--- a/docs/archive/pr-summaries/pr-summary-2818.md
+++ b/docs/archive/pr-summaries/pr-summary-2818.md
@@ -1,0 +1,50 @@
+## Summary
+
+Bumped the package version from `5.1.3` to `5.2.0` in `deno.json` and added a
+`## [5.2.0] - 2026-05-30` heading to `CHANGELOG.md` summarising the Temporal
+migration completed across Issues #2813–#2817. The previously unreleased
+entries are now grouped under the `5.2.0` heading, leaving `[Unreleased]`
+empty for the next cycle. Closes #2818.
+
+The version bump from `5.1.x` to `5.2.0` is a minor bump: it adds new
+user-visible capability (native `Temporal` wall-clock timestamps) without
+breaking changes — elapsed-time call sites continue to use `Date.now()` /
+`performance.now()`.
+
+## Evidence
+
+This is a metadata-only change (no UI, no public API surface area added),
+verified by:
+
+- `./quality.sh --skip-discovery --skip-wasm` passed cleanly:
+  `ok | 6993 passed (2 steps) | 0 failed | 4 ignored (2m21s)`.
+- Acceptance grep confirms no forbidden imports remain in source:
+  `Grep "std/datetime|@js-temporal" src/` returns no matches.
+- `deno.json` `version` field is `5.2.0`.
+- `CHANGELOG.md` now carries a `## [5.2.0] - 2026-05-30` section whose
+  `### Changed` lead entry documents the Temporal adoption with references to
+  Issues #2813, #2814, #2815, #2816, and #2817.
+
+### Release lineage
+
+```mermaid
+gitGraph
+   commit id: "5.0.0"
+   commit id: "5.1.x (internal)"
+   branch milestone/temporal
+   commit id: "#2813 policy"
+   commit id: "#2814 discovery"
+   commit id: "#2815 checkpoint"
+   commit id: "#2816 training events"
+   commit id: "#2817 creature training"
+   commit id: "5.2.0 (this PR)" tag: "v5.2.0"
+```
+
+## Test Plan
+
+- [x] `deno.json` `"version"` is `5.2.0`.
+- [x] `CHANGELOG.md` has a `## [5.2.0]` section dated `2026-05-30` that lists
+      the Temporal adoption referencing Issues #2813–#2817.
+- [x] `grep -r "std/datetime\|@js-temporal" src/` returns no matches.
+- [x] `./quality.sh --skip-discovery --skip-wasm` passes (full test suite
+      including lint, format, type-check, bash check, and all 6993 tests).


### PR DESCRIPTION
## Summary

Bumped the package version from `5.1.3` to `5.2.0` in `deno.json` and added a
`## [5.2.0] - 2026-05-30` heading to `CHANGELOG.md` summarising the Temporal
migration completed across Issues #2813–#2817. The previously unreleased
entries are now grouped under the `5.2.0` heading, leaving `[Unreleased]`
empty for the next cycle. Closes #2818.

The version bump from `5.1.x` to `5.2.0` is a minor bump: it adds new
user-visible capability (native `Temporal` wall-clock timestamps) without
breaking changes — elapsed-time call sites continue to use `Date.now()` /
`performance.now()`.

## Evidence

This is a metadata-only change (no UI, no public API surface area added),
verified by:

- `./quality.sh --skip-discovery --skip-wasm` passed cleanly:
  `ok | 6993 passed (2 steps) | 0 failed | 4 ignored (2m21s)`.
- Acceptance grep confirms no forbidden imports remain in source:
  `Grep "std/datetime|@js-temporal" src/` returns no matches.
- `deno.json` `version` field is `5.2.0`.
- `CHANGELOG.md` now carries a `## [5.2.0] - 2026-05-30` section whose
  `### Changed` lead entry documents the Temporal adoption with references to
  Issues #2813, #2814, #2815, #2816, and #2817.

### Release lineage

```mermaid
gitGraph
   commit id: "5.0.0"
   commit id: "5.1.x (internal)"
   branch milestone/temporal
   commit id: "#2813 policy"
   commit id: "#2814 discovery"
   commit id: "#2815 checkpoint"
   commit id: "#2816 training events"
   commit id: "#2817 creature training"
   commit id: "5.2.0 (this PR)" tag: "v5.2.0"
```

## Test Plan

- [x] `deno.json` `"version"` is `5.2.0`.
- [x] `CHANGELOG.md` has a `## [5.2.0]` section dated `2026-05-30` that lists
      the Temporal adoption referencing Issues #2813–#2817.
- [x] `grep -r "std/datetime\|@js-temporal" src/` returns no matches.
- [x] `./quality.sh --skip-discovery --skip-wasm` passes (full test suite
      including lint, format, type-check, bash check, and all 6993 tests).



## Milestone
This PR is part of the **Temporal** milestone and targets the `milestone/temporal` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mprldj68-445806`<!-- vibe-worker-issue-2818 -->