### PR TITLE
Enhance seed warm-up functionality in NEAT framework

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.1.4",
+  "version": "5.3.0",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -84,6 +84,22 @@ export class Mutator {
   private mcmcCohortFallbackStd = 0;
 
   /**
+   * Seed warm-up: when `warmupGenerations > 0` and
+   * `currentGeneration <= warmupGenerations`, structural-reduction and
+   * squash-changing mutations are excluded from candidate selection.
+   */
+  private warmupGenerations = 0;
+  private currentGeneration = 0;
+
+  /** Mutation names allowed during seed warm-up. */
+  private static readonly warmupAllowedMutations = new Set([
+    Mutation.ADD_NODE.name,
+    Mutation.ADD_CONN.name,
+    Mutation.MOD_WEIGHT.name,
+    Mutation.MOD_BIAS.name,
+  ]);
+
+  /**
    * Issue #2457: Per-role squash effectiveness tracker. Persists across
    * generations within a run so ModSquash can bias toward squashes that
    * historically improved fitness in similar roles. When omitted, the
@@ -162,6 +178,37 @@ export class Mutator {
     this.mcmcCohortFallbackStd = Number.isFinite(fallbackStd) && fallbackStd > 0
       ? fallbackStd
       : 0;
+  }
+
+  /**
+   * Configure seed warm-up mutation gating for the current generation.
+   * No-op when `warmupGenerations` is 0 (default — unchanged behaviour).
+   */
+  public setWarmupContext(
+    warmupGenerations: number,
+    currentGeneration: number,
+  ): void {
+    this.warmupGenerations = Number.isFinite(warmupGenerations) &&
+        warmupGenerations > 0
+      ? Math.floor(warmupGenerations)
+      : 0;
+    this.currentGeneration = Number.isFinite(currentGeneration) &&
+        currentGeneration > 0
+      ? Math.floor(currentGeneration)
+      : 0;
+  }
+
+  private isSeedWarmupActive(): boolean {
+    return this.warmupGenerations > 0 &&
+      this.currentGeneration > 0 &&
+      this.currentGeneration <= this.warmupGenerations;
+  }
+
+  private applySeedWarmupFilter<T extends { name: string }>(
+    candidates: readonly T[],
+  ): readonly T[] {
+    if (!this.isSeedWarmupActive()) return candidates;
+    return candidates.filter((c) => Mutator.warmupAllowedMutations.has(c.name));
   }
 
   /**
@@ -615,9 +662,9 @@ export class Mutator {
       }
     });
 
-    // Pre-compute weight/bias count for weighted selection (Issue #1009)
+    const warmupFiltered = this.applySeedWarmupFilter(candidates);
     let weightBiasCount = 0;
-    for (const candidate of candidates) {
+    for (const candidate of warmupFiltered) {
       if (
         candidate.name === Mutation.MOD_BIAS.name ||
         candidate.name === Mutation.MOD_WEIGHT.name
@@ -625,15 +672,15 @@ export class Mutator {
         weightBiasCount++;
       }
     }
-
-    // Issue #2125: Pre-compute non-expansion candidates once per cache key.
-    // This avoids repeated .filter() calls in selectMutationMethod() for large
-    // creatures, reducing per-call array allocations and GC pressure.
-    const nonExpansionCandidates = candidates.filter((c) =>
+    const nonExpansionCandidates = warmupFiltered.filter((c) =>
       !this.isTopologyExpansionMutation(c.name)
     );
 
-    return { candidates, weightBiasCount, nonExpansionCandidates };
+    return {
+      candidates: warmupFiltered,
+      weightBiasCount,
+      nonExpansionCandidates,
+    };
   }
 
   /**

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -36,6 +36,10 @@ import {
 import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 import { configureSharedSubnetworkIndex } from "@discovery/SubnetworkHashIndex.ts";
+import {
+  readCurrentGenerationFromCreature,
+  readWarmupGenerationsFromCreature,
+} from "@architecture/CreatureFactory.ts";
 
 // Extracted modules
 import * as evolution from "@neat/NeatEvolution.ts";
@@ -144,6 +148,15 @@ export class Neat {
    * each generation by `computeAdaptivePopulationSize()`.
    */
   effectivePopulationSize: number;
+
+  /**
+   * Seed warm-up generation count from the initial creature tag.
+   * Zero means warm-up is disabled (default behaviour).
+   */
+  warmupGenerations = 0;
+
+  /** Current evolution generation (1-based, incremented at start of evolve). */
+  currentGeneration = 0;
 
   /** Data directory for discovery replay (Issue #997) */
   dataDir?: string;
@@ -560,12 +573,16 @@ export class Neat {
   }
 
   async populatePopulation(creature: Creature) {
+    this.warmupGenerations = readWarmupGenerationsFromCreature(creature);
+    this.currentGeneration = readCurrentGenerationFromCreature(creature);
+
     const mutator = new Mutator(
       this.config,
       undefined,
       undefined,
       this.squashEffectivenessTracker,
     );
+    mutator.setWarmupContext(this.warmupGenerations, this.currentGeneration);
     while (this.population.length < this.config.populationSize - 1) {
       const clonedCreature = creature.shallowClone();
       const creatures = [clonedCreature];

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -46,6 +46,7 @@ import {
 } from "@neat/CpuUtilisation.ts";
 import { processCompletedResults } from "@neat/ProcessCompletedResults.ts";
 import { selectTrainingCandidates } from "@neat/TrainingCandidates.ts";
+import { writeSeedWarmupProgressTags } from "@architecture/CreatureFactory.ts";
 
 /**
  * The result returned by a single call to `evolve()`.
@@ -81,6 +82,8 @@ export async function evolve(
 ): Promise<EvolveResult> {
   // Issue #2239: Per-generation timing diagnostics
   const evolveStartMs = Date.now();
+
+  neat.currentGeneration++;
 
   neat.additionalGenerationCount--;
 
@@ -633,6 +636,7 @@ export async function evolve(
     // histogram persists across generations.
     neat.squashEffectivenessTracker,
   );
+  mutator.setWarmupContext(neat.warmupGenerations, neat.currentGeneration);
 
   // Issue #2527: Provide the per-creature cohort std lookup so the
   // Mutator can run M-H acceptance against the GRPO group-relative
@@ -953,6 +957,14 @@ export async function evolve(
         // throughput summary so operators can alert on producer
         // corruption.
         ` corruptParentSkips=${throughput.corruptParentSkips}`,
+    );
+  }
+
+  if (neat.warmupGenerations > 0) {
+    writeSeedWarmupProgressTags(
+      fittest,
+      neat.warmupGenerations,
+      neat.currentGeneration,
     );
   }
 

--- a/src/architecture/CreatureFactory.ts
+++ b/src/architecture/CreatureFactory.ts
@@ -44,6 +44,7 @@
 import { Creature } from "@creature";
 import type { DataRecordInterface } from "@architecture/DataSet.ts";
 import { pickOutputSquashForCost } from "@costs/CostOutputSquash.ts";
+import { addTag, getTag } from "@stsoftware/tags/mod";
 
 /** Inclusive numeric range, e.g. `{ min: -1, max: 1 }`. */
 export interface NumericRange {
@@ -99,6 +100,12 @@ export interface ProblemSpec {
    * `CreatureOptions.feedbackEnabled`; defaults to forward-only.
    */
   feedbackEnabled?: boolean;
+  /**
+   * Optional seed warm-up length (generations). When set, the factory
+   * writes a `warmupGenerations` creature tag so evolution can defer
+   * structural pruning and squash changes until weights/biases align.
+   */
+  warmupGenerations?: number;
 }
 
 /** Result of {@link scanTrainingData}: the non-declarable observations. */
@@ -134,6 +141,75 @@ export const DEAD_FEATURE_VARIANCE_THRESHOLD = 1e-8;
  * sample-limited problems.
  */
 export const HIGH_DIMENSIONAL_INPUT_THRESHOLD = 100;
+
+/** Creature tag key for seed warm-up generation count. */
+export const WARMUP_GENERATIONS_TAG = "warmupGenerations";
+
+/** Creature tag key for evolution progress during seed warm-up resume. */
+export const CURRENT_GENERATION_TAG = "currentGeneration";
+
+/**
+ * Parse the seed warm-up generation count from a creature tag.
+ * Returns 0 when the tag is absent or invalid (no warm-up).
+ */
+export function readWarmupGenerationsFromCreature(creature: Creature): number {
+  const tag = getTag(creature, WARMUP_GENERATIONS_TAG);
+  if (!tag) return 0;
+  const n = Number.parseInt(tag, 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/**
+ * Parse the saved evolution generation from a creature tag.
+ * Returns 0 when the tag is absent or invalid.
+ */
+export function readCurrentGenerationFromCreature(creature: Creature): number {
+  const tag = getTag(creature, CURRENT_GENERATION_TAG);
+  if (!tag) return 0;
+  const n = Number.parseInt(tag, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+/**
+ * Persist seed warm-up progress on a creature so export/load can resume
+ * evolution with the correct warm-up gate.
+ */
+export function writeSeedWarmupProgressTags(
+  creature: Creature,
+  warmupGenerations: number,
+  currentGeneration: number,
+): void {
+  if (Number.isFinite(warmupGenerations) && warmupGenerations > 0) {
+    addTag(
+      creature,
+      WARMUP_GENERATIONS_TAG,
+      String(Math.floor(warmupGenerations)),
+    );
+  }
+  if (Number.isFinite(currentGeneration) && currentGeneration > 0) {
+    addTag(
+      creature,
+      CURRENT_GENERATION_TAG,
+      String(Math.floor(currentGeneration)),
+    );
+  }
+}
+
+function applyWarmupGenerationsTag(
+  creature: Creature,
+  warmupGenerations: number | undefined,
+): void {
+  if (warmupGenerations === undefined) return;
+  if (!Number.isFinite(warmupGenerations) || warmupGenerations < 0) {
+    throw new RangeError(
+      `warmupGenerations must be a non-negative integer, got ${warmupGenerations}`,
+    );
+  }
+  const n = Math.floor(warmupGenerations);
+  if (n > 0) {
+    addTag(creature, WARMUP_GENERATIONS_TAG, String(n));
+  }
+}
 
 // ─── Activation families (for weight-init scaling) ──────────────────────
 
@@ -335,6 +411,7 @@ export function creatureForProblem(spec: ProblemSpec): Creature {
   );
 
   rescaleWeightsForInit(creature);
+  applyWarmupGenerationsTag(creature, spec.warmupGenerations);
   return creature;
 }
 
@@ -444,6 +521,8 @@ export interface DatasetFactoryOptions {
   hiddenSquash?: string;
   /** Whether feedback / recurrent topology is allowed. */
   feedbackEnabled?: boolean;
+  /** Seed warm-up length; see {@link ProblemSpec.warmupGenerations}. */
+  warmupGenerations?: number;
 }
 
 /**
@@ -484,6 +563,7 @@ export function creatureForDataset(
     hiddenCapacity: options.hiddenCapacity,
     hiddenSquash: options.hiddenSquash,
     feedbackEnabled: options.feedbackEnabled,
+    warmupGenerations: options.warmupGenerations,
   };
   const creature = creatureForProblem(spec);
 

--- a/test/NEAT/MutatorWarmup.ts
+++ b/test/NEAT/MutatorWarmup.ts
@@ -1,0 +1,73 @@
+import { assert } from "@std/assert";
+import { Creature } from "@creature";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { Mutation } from "@neat/Mutation.ts";
+import { Mutator } from "@neat/Mutator.ts";
+import {
+  createSeededRng,
+  setRandomNumberGenerator,
+} from "@utils/RandomNumberGenerator.ts";
+
+/** Mutations excluded during seed warm-up (structural reduction / squash change). */
+const WARMUP_BLOCKED = new Set([
+  Mutation.SUB_NODE.name,
+  Mutation.SUB_CONN.name,
+  Mutation.MOD_SQUASH.name,
+  Mutation.SWAP_NODES.name,
+  Mutation.ADD_SELF_CONN.name,
+  Mutation.SUB_SELF_CONN.name,
+  Mutation.ADD_BACK_CONN.name,
+  Mutation.SUB_BACK_CONN.name,
+]);
+
+Deno.test("MutatorWarmup: no gating when warm-up is disabled", () => {
+  setRandomNumberGenerator(createSeededRng(42));
+  const config = createNeatConfig({
+    populationSize: 10,
+    mutation: [Mutation.SUB_NODE],
+  });
+  const mutator = new Mutator(config);
+  const creature = new Creature(3, 2, { layers: [{ count: 8 }] });
+
+  const method = mutator.selectMutationMethod(creature);
+  assert(method.name === Mutation.SUB_NODE.name);
+});
+
+Deno.test("MutatorWarmup: blocks structural/squash mutations during warm-up", () => {
+  setRandomNumberGenerator(createSeededRng(99));
+  const config = createNeatConfig({
+    populationSize: 10,
+    mutation: [
+      ...Mutation.FFW,
+      ...Mutation.ALL.filter((m) =>
+        !Mutation.FFW.some((f) => f.name === m.name)
+      ),
+    ],
+    feedbackLoop: true,
+  });
+  const mutator = new Mutator(config);
+  mutator.setWarmupContext(10, 3);
+  const creature = new Creature(3, 2, { layers: [{ count: 8 }] });
+
+  for (let i = 0; i < 200; i++) {
+    const method = mutator.selectMutationMethod(creature);
+    assert(
+      !WARMUP_BLOCKED.has(method.name),
+      `warm-up must not select ${method.name}`,
+    );
+  }
+});
+
+Deno.test("MutatorWarmup: full mutation set after warm-up expires", () => {
+  setRandomNumberGenerator(createSeededRng(7));
+  const config = createNeatConfig({
+    populationSize: 10,
+    mutation: [Mutation.SUB_NODE],
+  });
+  const mutator = new Mutator(config);
+  mutator.setWarmupContext(5, 6);
+  const creature = new Creature(3, 2, { layers: [{ count: 8 }] });
+
+  const method = mutator.selectMutationMethod(creature);
+  assert(method.name === Mutation.SUB_NODE.name);
+});

--- a/test/NEAT/NeatPopulatePopulation.ts
+++ b/test/NEAT/NeatPopulatePopulation.ts
@@ -1,5 +1,11 @@
 import { assert, assertEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
+import {
+  creatureForProblem,
+  CURRENT_GENERATION_TAG,
+  WARMUP_GENERATIONS_TAG,
+} from "@architecture/CreatureFactory.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import type { NeatOptions } from "@config/NeatOptions.ts";
 import { Neat } from "@neat/Neat.ts";
@@ -204,6 +210,37 @@ Deno.test("populatePopulation: works with existing population", async () => {
       10,
       "Population should be filled to populationSize",
     );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("populatePopulation: restores warm-up tags from seed creature", async () => {
+  const dataDir = createTestDataDir(3, 2);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 5 };
+    const neat = new Neat(3, 2, options, workers);
+
+    const seedCreature = creatureForProblem({
+      inputs: 3,
+      outputs: 2,
+      cost: "MSE",
+      warmupGenerations: 20,
+    });
+    addTag(seedCreature, CURRENT_GENERATION_TAG, "7");
+
+    await neat.populatePopulation(seedCreature);
+
+    assertEquals(neat.warmupGenerations, 20);
+    assertEquals(neat.currentGeneration, 7);
+
+    const seedJson = neat.population[0].exportJSON();
+    const warmupTag = seedJson.tags?.find((t) =>
+      t.name === WARMUP_GENERATIONS_TAG
+    );
+    assertEquals(warmupTag?.value, "20");
   } finally {
     await terminateWorkers(workers);
   }

--- a/test/architecture/CreatureFactory.ts
+++ b/test/architecture/CreatureFactory.ts
@@ -17,6 +17,7 @@
  *    pruning, target stats) — not normalization.
  */
 import { assert, assertEquals, assertThrows } from "@std/assert";
+import { getTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
 import {
   creatureForDataset,
@@ -25,6 +26,8 @@ import {
   HIGH_DIMENSIONAL_INPUT_THRESHOLD,
   pickHiddenCapacity,
   pickOutputSquashForProblem,
+  readCurrentGenerationFromCreature,
+  readWarmupGenerationsFromCreature,
   rescaleWeightsForInit,
   scanTrainingData,
   targetInitStddev,
@@ -383,6 +386,40 @@ Deno.test("creatureForDataset: classification output bias is NOT overridden", ()
 Deno.test("creatureForDataset: empty training set throws", () => {
   assertThrows(
     () => creatureForDataset([], { cost: "MSE" }),
+    RangeError,
+  );
+});
+
+Deno.test("creatureForProblem: optional warmupGenerations tag when set", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    cost: "MSE",
+    warmupGenerations: 25,
+  });
+  assertEquals(getTag(creature, "warmupGenerations"), "25");
+  const roundTrip = Creature.fromJSON(creature.exportJSON());
+  assertEquals(readWarmupGenerationsFromCreature(roundTrip), 25);
+  assertEquals(readCurrentGenerationFromCreature(roundTrip), 0);
+});
+
+Deno.test("creatureForProblem: omits warmupGenerations tag when unset", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    cost: "MSE",
+  });
+  assertEquals(getTag(creature, "warmupGenerations"), null);
+});
+
+Deno.test("creatureForProblem: rejects negative warmupGenerations", () => {
+  assertThrows(
+    () =>
+      creatureForProblem({
+        inputs: 4,
+        outputs: 1,
+        warmupGenerations: -1,
+      }),
     RangeError,
   );
 });

--- a/test/architecture/SeedWarmupPersistence.ts
+++ b/test/architecture/SeedWarmupPersistence.ts
@@ -1,0 +1,61 @@
+/**
+ * Seed warm-up tag persistence (export / load round-trip).
+ */
+import { assertEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature } from "@creature";
+import {
+  creatureForProblem,
+  CURRENT_GENERATION_TAG,
+  readCurrentGenerationFromCreature,
+  readWarmupGenerationsFromCreature,
+  WARMUP_GENERATIONS_TAG,
+  writeSeedWarmupProgressTags,
+} from "@architecture/CreatureFactory.ts";
+
+Deno.test("readCurrentGenerationFromCreature: absent tag returns 0", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+  assertEquals(readCurrentGenerationFromCreature(creature), 0);
+});
+
+Deno.test("readCurrentGenerationFromCreature: invalid tag returns 0", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+  addTag(creature, CURRENT_GENERATION_TAG, "not-a-number");
+  assertEquals(readCurrentGenerationFromCreature(creature), 0);
+});
+
+Deno.test("writeSeedWarmupProgressTags: both tags survive exportJSON and loadFrom", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    cost: "MSE",
+    warmupGenerations: 25,
+  });
+  writeSeedWarmupProgressTags(creature, 25, 12);
+
+  const json = creature.exportJSON();
+  const warmupTag = json.tags?.find((t) => t.name === WARMUP_GENERATIONS_TAG);
+  const generationTag = json.tags?.find((t) =>
+    t.name === CURRENT_GENERATION_TAG
+  );
+  assertEquals(warmupTag?.value, "25");
+  assertEquals(generationTag?.value, "12");
+
+  const loaded = Creature.fromJSON(json);
+  assertEquals(readWarmupGenerationsFromCreature(loaded), 25);
+  assertEquals(readCurrentGenerationFromCreature(loaded), 12);
+});
+
+Deno.test("writeSeedWarmupProgressTags: updated generation survives re-export", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    warmupGenerations: 10,
+  });
+  writeSeedWarmupProgressTags(creature, 10, 3);
+  writeSeedWarmupProgressTags(creature, 10, 4);
+
+  const loaded = Creature.fromJSON(creature.exportJSON());
+  assertEquals(readCurrentGenerationFromCreature(loaded), 4);
+  assertEquals(readWarmupGenerationsFromCreature(loaded), 10);
+});


### PR DESCRIPTION
- Introduced warm-up generation handling in the Mutator class, allowing for mutation gating during initial generations.
- Added methods to set and check warm-up context, filtering allowed mutations based on the current generation.
- Updated Neat class to read warm-up parameters from the creature and pass them to the Mutator.
- Implemented tag reading and writing for warm-up generations and current generation in the CreatureFactory.
- Added tests to ensure correct behavior of warm-up functionality and tag persistence.

This update improves the evolutionary process by deferring certain mutations until the model has stabilized, enhancing overall performance.