### PR TITLE
Seed warmup: gate Discovery and DiscoveryReplay behind structural lock (#2828)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -105,6 +105,34 @@ while (true) {
 }
 ```
 
+## 🧊 Seed Warm-Up Structural Lock
+
+Creatures seeded by the Creature Factory can carry a `warmupGenerations` tag
+(Issue #2825). While a seed is **within its warm-up window**
+(`currentGeneration <= warmupGenerations`), every structural-reduction path is
+locked so the factory topology can align its weights and biases **before** any
+pruning or rewiring happens. The lock suppresses:
+
+- structural-reduction / squash-changing **mutations**,
+- inline **Discovery** scheduling,
+- cached-discovery **replay**.
+
+The single source of truth is
+`isSeedWarmupStructuralLockActive(warmupGenerations, currentGeneration)` in
+`CreatureFactory.ts` (Issue #2828). It is **conservative**: if a seed declares
+`warmupGenerations > 0` but its `currentGeneration` is not yet known, the lock
+stays active so nothing prunes before the warm-up window can be proven elapsed.
+
+```mermaid
+flowchart TD
+    A[New fittest creature] --> B{warmupGenerations &gt; 0<br/>and currentGeneration &le; warmupGenerations?}
+    B -- Yes (lock active) --> C[Skip Discovery + replay<br/>weight/bias training continues]
+    B -- No (lock released) --> D[Schedule Discovery + replay as normal]
+```
+
+Once `currentGeneration > warmupGenerations`, the lock releases and Discovery
+and replay resume automatically.
+
 ## 🛠️ Configuration
 
 ### ⚡ Production-Tuned Defaults

--- a/docs/archive/pr-summaries/pr-summary-2828.md
+++ b/docs/archive/pr-summaries/pr-summary-2828.md
@@ -1,0 +1,71 @@
+# Seed warm-up: gate Discovery and DiscoveryReplay behind the structural lock
+
+## Summary
+
+Creatures seeded with `warmupGenerations` (Creature Factory #2825) are meant to
+defer **all structural reduction and squash changes** until the warm-up window
+has elapsed (`currentGeneration > warmupGenerations`), so the factory topology
+can align weights/biases first. The warm-up gate was only enforced in
+`Mutator.applySeedWarmupFilter()` — **inline Discovery and cached-discovery
+replay bypassed it entirely**, so factory seeds were pruned/rewired (e.g. 51 →
+17 neurons) long before generation 1440.
+
+This change centralises the lock and applies it to every structural path.
+**Closes #2828.**
+
+- **New single source of truth** in `CreatureFactory.ts`:
+  `isSeedWarmupStructuralLockActive(warmupGenerations, currentGeneration)` and
+  the creature-tag convenience wrapper
+  `isSeedWarmupStructuralLockActiveForCreature(creature)`. The helper is
+  **conservative**: a seed declaring `warmupGenerations > 0` whose
+  `currentGeneration` is not yet known stays **locked**, so nothing prunes
+  before warm-up can be proven elapsed.
+- **`NeatEvolution`** (primary fix): skips both `scheduleDiscovery` and
+  `discoveryReplayQueue.scheduleReplay` while the lock is active, using the
+  reliable `neat.warmupGenerations` / `neat.currentGeneration` state.
+- **`NeatScheduling.scheduleDiscovery`**: defensive early-return guard.
+- **`DiscoveryReplayQueue.scheduleReplay`**: defensive guard read from the
+  creature's own warm-up tags (the queue does not hold the owning `Neat`).
+
+Mutation gating (`Mutator`) is unchanged — it already enforced the warm-up
+filter; this PR closes the Discovery/replay bypass without altering existing
+mutation behaviour.
+
+## Evidence
+
+This is a backend/algorithm change with no web interface to screenshot. It is
+verified by unit and integration tests that call the real functions.
+
+```mermaid
+flowchart TD
+    A[New fittest creature] --> B{Warm-up structural lock active?}
+    B -- Yes --> C[Skip Discovery + replay<br/>weight/bias training continues]
+    B -- No --> D[Schedule Discovery + replay as normal]
+```
+
+Quality gate: `./quality.sh` — **7016 passed** (full suite), formatting, lint,
+type-check, and markdownlint all clean.
+
+## Test Plan
+
+New tests (all call real functions and assert on results):
+
+- `test/architecture/SeedWarmupStructuralLock.ts`
+  - `isSeedWarmupStructuralLockActive`: inactive with no warm-up; active across
+    the window including the `currentGeneration == warmupGenerations` boundary;
+    released once elapsed; conservative when generation unknown/`<= 0`; ignores
+    non-finite inputs.
+  - `isSeedWarmupStructuralLockActiveForCreature`: reads warm-up tags off a
+    creature for the no-tag, mid-window, elapsed, and missing-generation cases.
+- `test/NEAT/DiscoveryReplayWarmup.ts` (exercises the real
+  `DiscoveryReplayQueue` with an injected `replayDir` spy):
+  - skips replay during the warm-up window;
+  - skips replay when the `currentGeneration` tag is missing (conservative);
+  - replays once warm-up has elapsed;
+  - replays when no warm-up is configured.
+
+Existing suites confirmed green (no regressions): `test/NEAT/MutatorWarmup.ts`,
+`test/NEAT/DiscoveryReplayQueue.ts`, `test/NEAT/DiscoveryReplayIntegration.ts`,
+`test/NEAT/DiscoveryReplayQueueCompletion.ts`,
+`test/architecture/SeedWarmupPersistence.ts`,
+`test/NEAT/NeatPopulatePopulation.ts`.

--- a/src/NEAT/DiscoveryReplayQueue.ts
+++ b/src/NEAT/DiscoveryReplayQueue.ts
@@ -5,6 +5,7 @@ import {
   DiscoveryReplayRunner,
 } from "@discovery/DiscoveryReplayRunner.ts";
 import { createNeatConfig } from "@config/NeatConfig.ts";
+import { isSeedWarmupStructuralLockActiveForCreature } from "@architecture/CreatureFactory.ts";
 import { getLogger } from "@utils/Logger.ts";
 
 // Re-export for use by Neat.ts (Issue #1150)
@@ -104,6 +105,15 @@ export class DiscoveryReplayQueue {
     options: NeatOptions,
     remainingTimeMinutes?: number,
   ): void {
+    // Issue #2828: never replay cached structural discoveries while the
+    // creature's seed warm-up structural lock is active — replay can prune
+    // or rewire topology, which must wait until warm-up has elapsed. The
+    // lock state is read from the creature's own warm-up tags because this
+    // queue does not hold the owning Neat instance.
+    if (isSeedWarmupStructuralLockActiveForCreature(creature)) {
+      return;
+    }
+
     const config = createNeatConfig(options);
 
     // Skip if no cache directory is configured

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -46,7 +46,10 @@ import {
 } from "@neat/CpuUtilisation.ts";
 import { processCompletedResults } from "@neat/ProcessCompletedResults.ts";
 import { selectTrainingCandidates } from "@neat/TrainingCandidates.ts";
-import { writeSeedWarmupProgressTags } from "@architecture/CreatureFactory.ts";
+import {
+  isSeedWarmupStructuralLockActive,
+  writeSeedWarmupProgressTags,
+} from "@architecture/CreatureFactory.ts";
 
 /**
  * The result returned by a single call to `evolve()`.
@@ -325,7 +328,23 @@ export async function evolve(
       elitists.push(simplified);
     }
 
-    if (trainingTimeOutMinutes !== -1) {
+    // Issue #2828: while the seed warm-up structural lock is active, skip
+    // both inline Discovery and cached-discovery replay — they prune/rewire
+    // topology, which must wait until the warm-up window has elapsed so the
+    // factory seed can align weights/biases first.
+    const warmupLockActive = isSeedWarmupStructuralLockActive(
+      neat.warmupGenerations,
+      neat.currentGeneration,
+    );
+
+    if (warmupLockActive && neat.config.verbose) {
+      getLogger().info(
+        `Skipping discovery and replay: seed warm-up structural lock ` +
+          `active (generation ${neat.currentGeneration}/${neat.warmupGenerations})`,
+      );
+    }
+
+    if (!warmupLockActive && trainingTimeOutMinutes !== -1) {
       // Estimate if we have enough time for discovery
       const estimatedDiscoveryMinutes = neat.lastDiscoveryDurationMS > 0
         ? Math.ceil(neat.lastDiscoveryDurationMS / 60000) + 1
@@ -343,7 +362,7 @@ export async function evolve(
     }
 
     // Issue #997: Schedule background replay of cached discoveries
-    if (neat.dataDir && neat.config.discoveryCacheDir) {
+    if (!warmupLockActive && neat.dataDir && neat.config.discoveryCacheDir) {
       neat.discoveryReplayQueue.scheduleReplay(
         fittest,
         neat.dataDir,

--- a/src/NEAT/NeatScheduling.ts
+++ b/src/NEAT/NeatScheduling.ts
@@ -11,6 +11,7 @@ import { ensureDirSync } from "@std/fs";
 import { addTag, getTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { isSeedWarmupStructuralLockActive } from "@architecture/CreatureFactory.ts";
 import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import {
   exportJSONWithRuntimeIds,
@@ -40,6 +41,24 @@ export function scheduleDiscovery(
   creature: Creature,
   timeOutMinutes: number,
 ): void {
+  // Issue #2828: never schedule structural Discovery while the seed
+  // warm-up structural lock is active — Discovery prunes/rewires topology
+  // and must wait until the warm-up window has elapsed.
+  if (
+    isSeedWarmupStructuralLockActive(
+      neat.warmupGenerations,
+      neat.currentGeneration,
+    )
+  ) {
+    if (neat.config.verbose) {
+      getLogger().info(
+        `Skipping discovery: seed warm-up structural lock active ` +
+          `(generation ${neat.currentGeneration}/${neat.warmupGenerations})`,
+      );
+    }
+    return;
+  }
+
   if (neat.config.discoverySampleRate <= 0) {
     return;
   }

--- a/src/architecture/CreatureFactory.ts
+++ b/src/architecture/CreatureFactory.ts
@@ -171,6 +171,54 @@ export function readCurrentGenerationFromCreature(creature: Creature): number {
 }
 
 /**
+ * Issue #2828: Centralised seed warm-up structural lock.
+ *
+ * While the lock is active, no path may apply structural reduction or
+ * squash changes to a warm-up seed — neither mutations, inline Discovery,
+ * Discovery replay, nor pruning-template DNA sharing. This lets a factory
+ * topology (e.g. 50 hidden → 1 output) align weights/biases before any
+ * structural pruning is permitted.
+ *
+ * The lock is active when warm-up is configured (`warmupGenerations > 0`)
+ * and the current generation has not yet passed it
+ * (`currentGeneration <= warmupGenerations`).
+ *
+ * Conservative default: when warm-up is configured but the current
+ * generation is unknown (`<= 0`, e.g. a freshly seeded creature whose
+ * `currentGeneration` tag has not been written yet), the lock stays
+ * **active**. We never prune a warm-up seed before we can prove the
+ * warm-up window has elapsed.
+ */
+export function isSeedWarmupStructuralLockActive(
+  warmupGenerations: number,
+  currentGeneration: number,
+): boolean {
+  if (!Number.isFinite(warmupGenerations) || warmupGenerations <= 0) {
+    // No warm-up configured — structural changes are always allowed.
+    return false;
+  }
+  if (!Number.isFinite(currentGeneration) || currentGeneration <= 0) {
+    // Warm-up configured but generation unknown — stay locked.
+    return true;
+  }
+  return currentGeneration <= warmupGenerations;
+}
+
+/**
+ * Read the seed warm-up structural lock state directly from a creature's
+ * tags. Used by paths (e.g. {@link DiscoveryReplayQueue}) that only have
+ * the creature, not the owning `Neat` instance.
+ */
+export function isSeedWarmupStructuralLockActiveForCreature(
+  creature: Creature,
+): boolean {
+  return isSeedWarmupStructuralLockActive(
+    readWarmupGenerationsFromCreature(creature),
+    readCurrentGenerationFromCreature(creature),
+  );
+}
+
+/**
  * Persist seed warm-up progress on a creature so export/load can resume
  * evolution with the correct warm-up gate.
  */

--- a/test/NEAT/DiscoveryReplayWarmup.ts
+++ b/test/NEAT/DiscoveryReplayWarmup.ts
@@ -1,0 +1,107 @@
+/**
+ * Issue #2828: DiscoveryReplayQueue must honour the seed warm-up
+ * structural lock. While a creature is within its warm-up window, replay
+ * of cached structural discoveries must not run (replay can prune/rewire
+ * topology). Once warm-up has elapsed, replay resumes as normal.
+ */
+import { assertEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import type { Creature } from "@creature";
+import {
+  DiscoveryReplayQueue,
+  type DiscoveryReplayQueueDeps,
+} from "@neat/DiscoveryReplayQueue.ts";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import {
+  CURRENT_GENERATION_TAG,
+  WARMUP_GENERATIONS_TAG,
+} from "@architecture/CreatureFactory.ts";
+import { makeForwardOnlyCreature as makeBaseCreature } from "../fixtures/SimpleCreatures.ts";
+
+function trackingDeps(): {
+  deps: DiscoveryReplayQueueDeps;
+  calls: () => number;
+} {
+  let started = 0;
+  const deps: DiscoveryReplayQueueDeps = {
+    replayDir: (
+      _creature: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+    ) => {
+      started++;
+      return Promise.resolve({
+        original: { error: 0.5, score: 0.5 },
+        evaluatedSingles: 0,
+        evaluatedCombos: 0,
+        pruned: 0,
+        skippedAlreadyApplied: 0,
+        skippedNotApplicable: 0,
+      });
+    },
+  };
+  return { deps, calls: () => started };
+}
+
+const OPTIONS: NeatOptions = {
+  discoveryCacheDir: "/tmp/cache",
+  costOfGrowth: 0,
+};
+
+Deno.test("DiscoveryReplayWarmup: skips replay during warm-up window", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "warmup-locked";
+  addTag(creature, WARMUP_GENERATIONS_TAG, "1440");
+  addTag(creature, CURRENT_GENERATION_TAG, "100");
+
+  const { deps, calls } = trackingDeps();
+  const queue = new DiscoveryReplayQueue(deps);
+
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  await queue.waitForCompletion();
+
+  assertEquals(calls(), 0, "Replay must not run while warm-up lock is active");
+});
+
+Deno.test("DiscoveryReplayWarmup: skips replay when generation tag missing", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "warmup-no-gen";
+  addTag(creature, WARMUP_GENERATIONS_TAG, "1440");
+  // No currentGeneration tag — conservative lock must still block replay.
+
+  const { deps, calls } = trackingDeps();
+  const queue = new DiscoveryReplayQueue(deps);
+
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  await queue.waitForCompletion();
+
+  assertEquals(calls(), 0, "Conservative lock must block replay");
+});
+
+Deno.test("DiscoveryReplayWarmup: replays once warm-up has elapsed", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "warmup-elapsed";
+  addTag(creature, WARMUP_GENERATIONS_TAG, "10");
+  addTag(creature, CURRENT_GENERATION_TAG, "11");
+
+  const { deps, calls } = trackingDeps();
+  const queue = new DiscoveryReplayQueue(deps);
+
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  await queue.waitForCompletion();
+
+  assertEquals(calls(), 1, "Replay must run after warm-up elapses");
+});
+
+Deno.test("DiscoveryReplayWarmup: replays when no warm-up configured", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "no-warmup";
+
+  const { deps, calls } = trackingDeps();
+  const queue = new DiscoveryReplayQueue(deps);
+
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  await queue.waitForCompletion();
+
+  assertEquals(calls(), 1, "Replay must run when no warm-up is configured");
+});

--- a/test/architecture/SeedWarmupStructuralLock.ts
+++ b/test/architecture/SeedWarmupStructuralLock.ts
@@ -1,0 +1,71 @@
+/**
+ * Issue #2828: Seed warm-up structural lock gating.
+ *
+ * The lock blocks every structural-reduction path (mutations, inline
+ * Discovery, Discovery replay, pruning-template DNA sharing) until the
+ * warm-up window has elapsed.
+ */
+import { assertEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature } from "@creature";
+import {
+  CURRENT_GENERATION_TAG,
+  isSeedWarmupStructuralLockActive,
+  isSeedWarmupStructuralLockActiveForCreature,
+  WARMUP_GENERATIONS_TAG,
+} from "@architecture/CreatureFactory.ts";
+
+Deno.test("structural lock: inactive when no warm-up configured", () => {
+  assertEquals(isSeedWarmupStructuralLockActive(0, 0), false);
+  assertEquals(isSeedWarmupStructuralLockActive(0, 5), false);
+});
+
+Deno.test("structural lock: active during the warm-up window", () => {
+  assertEquals(isSeedWarmupStructuralLockActive(1440, 1), true);
+  assertEquals(isSeedWarmupStructuralLockActive(1440, 720), true);
+  // Boundary: the final warm-up generation is still locked.
+  assertEquals(isSeedWarmupStructuralLockActive(1440, 1440), true);
+});
+
+Deno.test("structural lock: released once warm-up has elapsed", () => {
+  assertEquals(isSeedWarmupStructuralLockActive(1440, 1441), false);
+  assertEquals(isSeedWarmupStructuralLockActive(5, 6), false);
+});
+
+Deno.test("structural lock: conservative when generation unknown", () => {
+  // Warm-up configured but the current generation has not been written
+  // yet (fresh factory seed): stay locked so nothing prunes early.
+  assertEquals(isSeedWarmupStructuralLockActive(1440, 0), true);
+  assertEquals(isSeedWarmupStructuralLockActive(1440, -1), true);
+});
+
+Deno.test("structural lock: ignores non-finite inputs", () => {
+  assertEquals(isSeedWarmupStructuralLockActive(NaN, 5), false);
+  assertEquals(isSeedWarmupStructuralLockActive(10, NaN), true);
+});
+
+Deno.test("structural lock (creature): no warm-up tag → inactive", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+  assertEquals(isSeedWarmupStructuralLockActiveForCreature(creature), false);
+});
+
+Deno.test("structural lock (creature): warm-up tag, mid-window → active", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+  addTag(creature, WARMUP_GENERATIONS_TAG, "1440");
+  addTag(creature, CURRENT_GENERATION_TAG, "100");
+  assertEquals(isSeedWarmupStructuralLockActiveForCreature(creature), true);
+});
+
+Deno.test("structural lock (creature): warm-up tag, window elapsed → inactive", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+  addTag(creature, WARMUP_GENERATIONS_TAG, "10");
+  addTag(creature, CURRENT_GENERATION_TAG, "11");
+  assertEquals(isSeedWarmupStructuralLockActiveForCreature(creature), false);
+});
+
+Deno.test("structural lock (creature): warm-up tag, no generation tag → active", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+  addTag(creature, WARMUP_GENERATIONS_TAG, "1440");
+  // No currentGeneration tag — conservative lock keeps structural pruning off.
+  assertEquals(isSeedWarmupStructuralLockActiveForCreature(creature), true);
+});


### PR DESCRIPTION
# Seed warm-up: gate Discovery and DiscoveryReplay behind the structural lock

## Summary

Creatures seeded with `warmupGenerations` (Creature Factory #2825) are meant to
defer **all structural reduction and squash changes** until the warm-up window
has elapsed (`currentGeneration > warmupGenerations`), so the factory topology
can align weights/biases first. The warm-up gate was only enforced in
`Mutator.applySeedWarmupFilter()` — **inline Discovery and cached-discovery
replay bypassed it entirely**, so factory seeds were pruned/rewired (e.g. 51 →
17 neurons) long before generation 1440.

This change centralises the lock and applies it to every structural path.
**Closes #2828.**

- **New single source of truth** in `CreatureFactory.ts`:
  `isSeedWarmupStructuralLockActive(warmupGenerations, currentGeneration)` and
  the creature-tag convenience wrapper
  `isSeedWarmupStructuralLockActiveForCreature(creature)`. The helper is
  **conservative**: a seed declaring `warmupGenerations > 0` whose
  `currentGeneration` is not yet known stays **locked**, so nothing prunes
  before warm-up can be proven elapsed.
- **`NeatEvolution`** (primary fix): skips both `scheduleDiscovery` and
  `discoveryReplayQueue.scheduleReplay` while the lock is active, using the
  reliable `neat.warmupGenerations` / `neat.currentGeneration` state.
- **`NeatScheduling.scheduleDiscovery`**: defensive early-return guard.
- **`DiscoveryReplayQueue.scheduleReplay`**: defensive guard read from the
  creature's own warm-up tags (the queue does not hold the owning `Neat`).

Mutation gating (`Mutator`) is unchanged — it already enforced the warm-up
filter; this PR closes the Discovery/replay bypass without altering existing
mutation behaviour.

## Evidence

This is a backend/algorithm change with no web interface to screenshot. It is
verified by unit and integration tests that call the real functions.

```mermaid
flowchart TD
    A[New fittest creature] --> B{Warm-up structural lock active?}
    B -- Yes --> C[Skip Discovery + replay<br/>weight/bias training continues]
    B -- No --> D[Schedule Discovery + replay as normal]
```

Quality gate: `./quality.sh` — **7016 passed** (full suite), formatting, lint,
type-check, and markdownlint all clean.

## Test Plan

New tests (all call real functions and assert on results):

- `test/architecture/SeedWarmupStructuralLock.ts`
  - `isSeedWarmupStructuralLockActive`: inactive with no warm-up; active across
    the window including the `currentGeneration == warmupGenerations` boundary;
    released once elapsed; conservative when generation unknown/`<= 0`; ignores
    non-finite inputs.
  - `isSeedWarmupStructuralLockActiveForCreature`: reads warm-up tags off a
    creature for the no-tag, mid-window, elapsed, and missing-generation cases.
- `test/NEAT/DiscoveryReplayWarmup.ts` (exercises the real
  `DiscoveryReplayQueue` with an injected `replayDir` spy):
  - skips replay during the warm-up window;
  - skips replay when the `currentGeneration` tag is missing (conservative);
  - replays once warm-up has elapsed;
  - replays when no warm-up is configured.

Existing suites confirmed green (no regressions): `test/NEAT/MutatorWarmup.ts`,
`test/NEAT/DiscoveryReplayQueue.ts`, `test/NEAT/DiscoveryReplayIntegration.ts`,
`test/NEAT/DiscoveryReplayQueueCompletion.ts`,
`test/architecture/SeedWarmupPersistence.ts`,
`test/NEAT/NeatPopulatePopulation.ts`.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mprxoeup-cf4fb4`<!-- vibe-worker-issue-2828 -->