### PR TITLE
Update version to 5.3.3 and enhance seed warmup functionality in NEAT…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -30,6 +30,11 @@ import type {
 import { creatureValidate } from "@architecture/CreatureValidate.ts";
 import { assertForwardOnlyTopologyAfterBulkRemap } from "@architecture/ForwardOnlySynapseGuard.ts";
 import {
+  readCurrentGenerationFromCreature,
+  readWarmupGenerationsFromCreature,
+  writeSeedWarmupProgressTags,
+} from "@architecture/CreatureFactory.ts";
+import {
   runProducerCompileProbe,
   setProducerStep,
 } from "@wasm/ProducerCompileGuard.ts";
@@ -120,6 +125,24 @@ export function computeNeuronDependencyIndex(
   return indx;
 }
 
+function propagateSeedWarmupTags(
+  child: Creature,
+  mother: Creature,
+  father: Creature,
+): void {
+  const warmupGenerations = Math.max(
+    readWarmupGenerationsFromCreature(mother),
+    readWarmupGenerationsFromCreature(father),
+  );
+  if (warmupGenerations <= 0) return;
+
+  const currentGeneration = Math.max(
+    readCurrentGenerationFromCreature(mother),
+    readCurrentGenerationFromCreature(father),
+  );
+  writeSeedWarmupProgressTags(child, warmupGenerations, currentGeneration);
+}
+
 export class Offspring {
   /**
    * Create an offspring from two parent networks.
@@ -191,6 +214,7 @@ export class Offspring {
         if (!child) child = subgraphTransplant(mother, father);
       }
       if (child) {
+        propagateSeedWarmupTags(child, mother, father);
         // Memetic update (same as standard crossover path)
         if (mother.memetic) {
           child.memetic = memeticUpdate(mother, child);
@@ -781,6 +805,7 @@ export class Offspring {
       acc.offspringCount++;
     }
 
+    propagateSeedWarmupTags(offspring, mother, father);
     return offspring;
   }
 

--- a/src/breed/OnPolicyDistillationBreed.ts
+++ b/src/breed/OnPolicyDistillationBreed.ts
@@ -40,6 +40,11 @@ import { buildOutgoingSynapsesMap } from "@propagate/sparse/CalculatePathsToOutp
 import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
+import {
+  readCurrentGenerationFromCreature,
+  readWarmupGenerationsFromCreature,
+  writeSeedWarmupProgressTags,
+} from "@architecture/CreatureFactory.ts";
 
 /**
  * Result of an OPD breed call, returned from {@link onPolicyDistillationBreed}.
@@ -197,6 +202,31 @@ function evaluateBatchError(
   return inputs.length === 0 ? 0 : total / inputs.length;
 }
 
+function propagateSeedWarmupTagsFromTeachers(
+  offspring: Creature,
+  teachers: readonly Creature[],
+): void {
+  let warmupGenerations = 0;
+  let currentGeneration = 0;
+  for (const teacher of teachers) {
+    warmupGenerations = Math.max(
+      warmupGenerations,
+      readWarmupGenerationsFromCreature(teacher),
+    );
+    currentGeneration = Math.max(
+      currentGeneration,
+      readCurrentGenerationFromCreature(teacher),
+    );
+  }
+  if (warmupGenerations > 0) {
+    writeSeedWarmupProgressTags(
+      offspring,
+      warmupGenerations,
+      currentGeneration,
+    );
+  }
+}
+
 /**
  * On-Policy Distillation breeding operator.
  *
@@ -327,6 +357,7 @@ export function onPolicyDistillationBreed(
   // 4. Establish the offspring's identity and confirm UUID stability.
   delete student.uuid;
   CreatureUtil.makeUUID(student);
+  propagateSeedWarmupTagsFromTeachers(student, effectiveTeachers);
 
   return {
     offspring: student,

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -21,6 +21,10 @@ import type { NeatConfig } from "@config/NeatConfig.ts";
 import type { RequiredOutputRange } from "@config/OutputRangeConfig.ts";
 import type { TrainOptions } from "@config/TrainOptions.ts";
 import type { WasmCacheConfig } from "@config/WasmCacheConfig.ts";
+import {
+  CURRENT_GENERATION_TAG,
+  WARMUP_GENERATIONS_TAG,
+} from "@architecture/CreatureFactory.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { clearForGc } from "@utils/ReleasableRef.ts";
 import {
@@ -470,8 +474,16 @@ export class WorkerHandler
 
   train(creature: Creature, options: TrainOptions) {
     const json = creature.exportJSON();
+    const warmupGenerations = getTag(creature, WARMUP_GENERATIONS_TAG);
+    const currentGeneration = getTag(creature, CURRENT_GENERATION_TAG);
 
     delete json.tags;
+    if (warmupGenerations) {
+      addTag(json, WARMUP_GENERATIONS_TAG, warmupGenerations);
+    }
+    if (currentGeneration) {
+      addTag(json, CURRENT_GENERATION_TAG, currentGeneration);
+    }
 
     addTag(
       json,

--- a/test/architecture/SeedWarmupPersistence.ts
+++ b/test/architecture/SeedWarmupPersistence.ts
@@ -4,6 +4,8 @@
 import { assertEquals } from "@std/assert";
 import { addTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Offspring } from "@architecture/Offspring.ts";
 import {
   creatureForProblem,
   CURRENT_GENERATION_TAG,
@@ -58,4 +60,76 @@ Deno.test("writeSeedWarmupProgressTags: updated generation survives re-export", 
   const loaded = Creature.fromJSON(creature.exportJSON());
   assertEquals(readCurrentGenerationFromCreature(loaded), 4);
   assertEquals(readWarmupGenerationsFromCreature(loaded), 10);
+});
+
+Deno.test("Offspring.breed: warm-up tags survive standard breeding", () => {
+  const mum = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  } as CreatureExport);
+  const dad = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: 0.3 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.7 },
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
+    ],
+  } as CreatureExport);
+  writeSeedWarmupProgressTags(mum, 25, 12);
+  writeSeedWarmupProgressTags(dad, 25, 12);
+
+  let child: Creature | undefined;
+  for (let attempt = 0; attempt < 50; attempt++) {
+    child = Offspring.breed(mum, dad, { forwardOnly: true });
+    if (child) break;
+  }
+
+  assertEquals(child !== undefined, true);
+  assertEquals(readWarmupGenerationsFromCreature(child!), 25);
+  assertEquals(readCurrentGenerationFromCreature(child!), 12);
+});
+
+Deno.test("Offspring.breed: warm-up tags survive grafted breeding", () => {
+  const mum = creatureForProblem({
+    inputs: 3,
+    outputs: 1,
+    warmupGenerations: 40,
+  });
+  const dad = creatureForProblem({
+    inputs: 3,
+    outputs: 1,
+    warmupGenerations: 40,
+  });
+  writeSeedWarmupProgressTags(mum, 40, 7);
+  writeSeedWarmupProgressTags(dad, 40, 7);
+
+  let child: Creature | undefined;
+  for (let attempt = 0; attempt < 50; attempt++) {
+    child = Offspring.breed(mum, dad, {
+      forwardOnly: true,
+      geneticCompatibilityThreshold: 1.1,
+    });
+    if (child) break;
+  }
+
+  assertEquals(child !== undefined, true);
+  assertEquals(readWarmupGenerationsFromCreature(child!), 40);
+  assertEquals(readCurrentGenerationFromCreature(child!), 7);
 });

--- a/test/breed/OnPolicyDistillationBreed.ts
+++ b/test/breed/OnPolicyDistillationBreed.ts
@@ -26,6 +26,11 @@ import { Breed } from "@breed/Breed.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { Genus } from "@neat/Genus.ts";
 import { createNeatConfig } from "@config/NeatConfig.ts";
+import {
+  readCurrentGenerationFromCreature,
+  readWarmupGenerationsFromCreature,
+  writeSeedWarmupProgressTags,
+} from "@architecture/CreatureFactory.ts";
 
 // DEBUG mode is intentionally NOT enabled here: it injects diagnostic
 // numeric `id` fields into `exportJSON()` output that destabilise the
@@ -311,5 +316,28 @@ Deno.test(
         );
       }
     }
+  },
+);
+
+Deno.test(
+  "OnPolicyDistillationBreed - warm-up tags survive onto offspring",
+  () => {
+    const teacherA = buildSimpleCreature(2, ["warm-a-h0", "warm-a-h1"]);
+    const teacherB = buildSimpleCreature(2, ["warm-b-h0", "warm-b-h1"]);
+    writeSeedWarmupProgressTags(teacherA, 1440, 77);
+    writeSeedWarmupProgressTags(teacherB, 1440, 77);
+
+    const result = onPolicyDistillationBreed(
+      [teacherA, teacherB],
+      defaultOpd({
+        teacherCount: 2,
+        distillationSteps: 4,
+        calibrationBatchSize: 4,
+      }),
+    );
+
+    assert(result, "OPD must produce an offspring");
+    assertEquals(readWarmupGenerationsFromCreature(result.offspring), 1440);
+    assertEquals(readCurrentGenerationFromCreature(result.offspring), 77);
   },
 );

--- a/test/multithreading/WorkerHandler.ts
+++ b/test/multithreading/WorkerHandler.ts
@@ -5,7 +5,14 @@
  * and lifecycle management using direct (MockWorker) mode.
  */
 import { assertEquals, assertExists } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature } from "@creature";
 import { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import type { TrainOptions } from "@config/TrainOptions.ts";
+import {
+  CURRENT_GENERATION_TAG,
+  WARMUP_GENERATIONS_TAG,
+} from "@architecture/CreatureFactory.ts";
 
 Deno.test("WorkerHandler: constructs in direct mode and initialises", async () => {
   const handler = new WorkerHandler(
@@ -71,4 +78,70 @@ Deno.test("WorkerHandler: terminate cleans up without error", async () => {
 
   // Should not throw after termination
   assertEquals(handler.isBusy(), false);
+});
+
+Deno.test("WorkerHandler.train: keeps warm-up tags in train payload", async () => {
+  const handler = new WorkerHandler(
+    await Deno.makeTempDir(),
+    "MSE",
+    true,
+  );
+  await handler.waitUntilReady();
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  addTag(creature, WARMUP_GENERATIONS_TAG, "1440");
+  addTag(creature, CURRENT_GENERATION_TAG, "12");
+  addTag(creature, "error", "0.5");
+  creature.score = 1.23;
+
+  let captured:
+    | {
+      train?: { creature?: { tags?: Array<{ name: string; value: string }> } };
+    }
+    | undefined;
+
+  const originalMakePromiseDeferred = (handler as unknown as {
+    makePromiseDeferred: (
+      data: unknown,
+      clearAfterPost?: () => void,
+    ) => Promise<unknown>;
+  }).makePromiseDeferred;
+
+  (handler as unknown as {
+    makePromiseDeferred: (
+      data: unknown,
+      clearAfterPost?: () => void,
+    ) => Promise<unknown>;
+  }).makePromiseDeferred = (data: unknown) => {
+    captured = data as typeof captured;
+    return Promise.resolve({ train: { ID: "mock", creature: {} } });
+  };
+
+  try {
+    await handler.train(creature, {} as TrainOptions);
+  } finally {
+    (handler as unknown as {
+      makePromiseDeferred: (
+        data: unknown,
+        clearAfterPost?: () => void,
+      ) => Promise<unknown>;
+    }).makePromiseDeferred = originalMakePromiseDeferred;
+    handler.terminate();
+  }
+
+  const tags = captured?.train?.creature?.tags;
+  assertEquals(
+    typeof tags?.find((t) => t.name === WARMUP_GENERATIONS_TAG)?.value,
+    "string",
+  );
+  assertEquals(
+    tags?.find((t) => t.name === WARMUP_GENERATIONS_TAG)?.value,
+    "1440",
+  );
+  assertEquals(
+    tags?.find((t) => t.name === CURRENT_GENERATION_TAG)?.value,
+    "12",
+  );
+  // Existing training context tags should still be present.
+  assertEquals(tags?.find((t) => t.name === "untrained-error")?.value, "0.5");
 });


### PR DESCRIPTION
… framework

- Bump version in deno.json from 5.3.2 to 5.3.3.
- Introduce functions to propagate warmup generation tags from parents to offspring in the Offspring class.
- Implement warmup tag handling in OnPolicyDistillationBreed to ensure offspring retain warmup information from teachers.
- Update WorkerHandler to maintain warmup tags during training.
- Add tests to verify that warmup tags persist through breeding and training processes.

This update improves the evolutionary process by ensuring that warmup information is consistently passed through generations, enhancing overall performance.