### PR TITLE
Carry over the higher generation count when breeding and loading creatures (#2831)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Issue #2831:** Carry over the higher generation count when breeding and
+  loading creatures. The `currentGeneration` tag is now **monotonic** —
+  `writeSeedWarmupProgressTags` never lowers an existing value. Previously the
+  end-of-round tagging overwrote the fittest creature's generation with the
+  local `Neat.currentGeneration` counter, so a cross-bred offspring that
+  inherited a higher generation (`Math.max` of its parents) from another machine
+  was reset to the lower local count. With ~1-minute generations and ~15-minute
+  rounds, repeatedly losing the count meant a population evolving across
+  machines never converged. Breeding already takes `Math.max` of both parents;
+  the carryover now also survives the save/load and end-of-round write paths.
+
 ## [5.2.0] - 2026-05-30
 
 ### Changed

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2831.md
+++ b/docs/archive/pr-summaries/pr-summary-2831.md
@@ -1,0 +1,79 @@
+# Carry over the higher generation count when breeding and loading creatures
+
+## Summary
+
+When evolving across machines (evolve ~15 min, change the sample size, then
+cross-breed with other machines), the evolution generation count was being
+silently reset, so a population that had accumulated many generations never
+converged. With ~1-minute generations and ~15-minute rounds, repeatedly losing
+the count means the population never gets there.
+
+Root cause (found via TDD): breeding already carried the **higher** of the two
+parents' generations (`Math.max`, `Offspring.ts:139`), but the **end-of-round
+tagging** clobbered it. After each round `NeatEvolution` calls
+`writeSeedWarmupProgressTags(fittest, neat.warmupGenerations, neat.currentGeneration)`,
+which **overwrote** the fittest creature's `currentGeneration` tag with the
+local `Neat.currentGeneration` counter. A cross-bred offspring that inherited a
+higher generation (e.g. 30) from a creature loaded from another machine was
+reset to the lower local count (e.g. 6).
+
+The fix makes the `currentGeneration` tag **monotonic** at the single shared
+write point: `writeSeedWarmupProgressTags` now reads the creature's existing
+generation and writes `Math.max(existing, currentGeneration)` — it never lowers
+the value. This carries the higher generation through breeding, the save/load
+round-trip, and the end-of-round write, defensively across every path that
+writes the tag.
+
+Closes #2831.
+
+## Evidence
+
+This is a backend/library change with no web interface to screenshot. It is
+verified by unit tests that call the real functions and assert on the resulting
+tags.
+
+```mermaid
+flowchart LR
+    A[Machine A<br/>gen 30 creature] -->|cross-breed| C[Offspring<br/>Math.max parents = 30]
+    B[Machine B<br/>local counter = 6] --> R{End-of-round write}
+    C --> R
+    R -->|"before: overwrite -> 6 (lost)"| X[gen 6 ❌]
+    R -->|"after: max(30, 6) -> 30 (kept)"| Y[gen 30 ✅]
+```
+
+The new failing-then-passing test demonstrates the clobber and the fix:
+
+```
+writeSeedWarmupProgressTags: never lowers an existing higher generation
+  before fix -> Actual 6 / Expected 30  (FAILED)
+  after  fix -> ok
+```
+
+## Test Plan
+
+Added to `test/architecture/SeedWarmupPersistence.ts`:
+
+- `writeSeedWarmupProgressTags: never lowers an existing higher generation` —
+  writes gen 30 then a later gen 6; asserts the tag stays 30 (the regression
+  test; fails against the unfixed code).
+- `writeSeedWarmupProgressTags: still raises generation when higher` — writes
+  gen 6 then gen 14; asserts the tag advances to 14 (monotonic increase still
+  works).
+- `Offspring.breed: carries the HIGHER of two differing parent generations` —
+  parents with generations 30 and 5; asserts the offspring inherits 30.
+
+Existing tests continue to pass unchanged (no test removed or commented out),
+including `populatePopulation: restores warm-up tags from seed creature` and the
+`OnPolicyDistillationBreed` warm-up carryover.
+
+Commands run:
+
+- `deno test test/architecture/SeedWarmupPersistence.ts` — 9 passed
+- `deno test test/architecture/CreatureFactory.ts test/architecture/SeedWarmupStructuralLock.ts test/breed/OnPolicyDistillationBreed.ts`
+  — 54 passed
+- `deno test test/NEAT/NeatPopulatePopulation.ts test/multithreading/WorkerHandler.ts`
+  — 12 passed
+- `deno test test/NEAT/DiscoveryReplayWarmup.ts test/NEAT/NeatFinishUp.ts` — 12
+  passed
+- `./quality.sh --lint-only` — format, lint, bash checks pass
+- `deno check` on changed/related files — passes

--- a/src/architecture/CreatureFactory.ts
+++ b/src/architecture/CreatureFactory.ts
@@ -221,6 +221,13 @@ export function isSeedWarmupStructuralLockActiveForCreature(
 /**
  * Persist seed warm-up progress on a creature so export/load can resume
  * evolution with the correct warm-up gate.
+ *
+ * Issue #2831: the generation tag is **monotonic** — it is never lowered.
+ * A creature that already carries a higher generation (e.g. a cross-bred
+ * offspring inheriting `Math.max` of its parents, or a creature loaded from
+ * a machine that ran further) keeps that higher value even when the local
+ * `currentGeneration` counter is behind. This stops the end-of-round
+ * tagging from clobbering generations accumulated across machines/breeding.
  */
 export function writeSeedWarmupProgressTags(
   creature: Creature,
@@ -235,10 +242,14 @@ export function writeSeedWarmupProgressTags(
     );
   }
   if (Number.isFinite(currentGeneration) && currentGeneration > 0) {
+    // Carry over the higher generation: never overwrite an existing tag
+    // with a smaller value.
+    const existing = readCurrentGenerationFromCreature(creature);
+    const next = Math.max(existing, Math.floor(currentGeneration));
     addTag(
       creature,
       CURRENT_GENERATION_TAG,
-      String(Math.floor(currentGeneration)),
+      String(next),
     );
   }
 }

--- a/test/architecture/SeedWarmupPersistence.ts
+++ b/test/architecture/SeedWarmupPersistence.ts
@@ -62,6 +62,80 @@ Deno.test("writeSeedWarmupProgressTags: updated generation survives re-export", 
   assertEquals(readWarmupGenerationsFromCreature(loaded), 10);
 });
 
+Deno.test("writeSeedWarmupProgressTags: never lowers an existing higher generation (Issue #2831)", () => {
+  // Simulates the end-of-round tagging clobber: a fittest creature that
+  // carried generation 30 (e.g. from a cross-bred ancestor on another
+  // machine) must not be reset to a lower local counter (6).
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    warmupGenerations: 25,
+  });
+  writeSeedWarmupProgressTags(creature, 25, 30);
+  // A later write with a lower generation must keep the higher value.
+  writeSeedWarmupProgressTags(creature, 25, 6);
+
+  assertEquals(readCurrentGenerationFromCreature(creature), 30);
+  assertEquals(readWarmupGenerationsFromCreature(creature), 25);
+});
+
+Deno.test("writeSeedWarmupProgressTags: still raises generation when higher (Issue #2831)", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    warmupGenerations: 25,
+  });
+  writeSeedWarmupProgressTags(creature, 25, 6);
+  writeSeedWarmupProgressTags(creature, 25, 14);
+
+  assertEquals(readCurrentGenerationFromCreature(creature), 14);
+});
+
+Deno.test("Offspring.breed: carries the HIGHER of two differing parent generations (Issue #2831)", () => {
+  const mum = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+    ],
+  } as CreatureExport);
+  const dad = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0.1 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.1 },
+      { fromUUID: "input-1", toUUID: "hidden-0", weight: 0.3 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.7 },
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
+    ],
+  } as CreatureExport);
+  // Differing generations: the offspring must inherit the larger (30).
+  writeSeedWarmupProgressTags(mum, 25, 30);
+  writeSeedWarmupProgressTags(dad, 25, 5);
+
+  let child: Creature | undefined;
+  for (let attempt = 0; attempt < 50; attempt++) {
+    child = Offspring.breed(mum, dad, { forwardOnly: true });
+    if (child) break;
+  }
+
+  assertEquals(child !== undefined, true);
+  assertEquals(readCurrentGenerationFromCreature(child!), 30);
+  assertEquals(readWarmupGenerationsFromCreature(child!), 25);
+});
+
 Deno.test("Offspring.breed: warm-up tags survive standard breeding", () => {
   const mum = Creature.fromJSON({
     input: 2,


### PR DESCRIPTION
# Carry over the higher generation count when breeding and loading creatures

## Summary

When evolving across machines (evolve ~15 min, change the sample size, then
cross-breed with other machines), the evolution generation count was being
silently reset, so a population that had accumulated many generations never
converged. With ~1-minute generations and ~15-minute rounds, repeatedly losing
the count means the population never gets there.

Root cause (found via TDD): breeding already carried the **higher** of the two
parents' generations (`Math.max`, `Offspring.ts:139`), but the **end-of-round
tagging** clobbered it. After each round `NeatEvolution` calls
`writeSeedWarmupProgressTags(fittest, neat.warmupGenerations, neat.currentGeneration)`,
which **overwrote** the fittest creature's `currentGeneration` tag with the
local `Neat.currentGeneration` counter. A cross-bred offspring that inherited a
higher generation (e.g. 30) from a creature loaded from another machine was
reset to the lower local count (e.g. 6).

The fix makes the `currentGeneration` tag **monotonic** at the single shared
write point: `writeSeedWarmupProgressTags` now reads the creature's existing
generation and writes `Math.max(existing, currentGeneration)` — it never lowers
the value. This carries the higher generation through breeding, the save/load
round-trip, and the end-of-round write, defensively across every path that
writes the tag.

Closes #2831.

## Evidence

This is a backend/library change with no web interface to screenshot. It is
verified by unit tests that call the real functions and assert on the resulting
tags.

```mermaid
flowchart LR
    A[Machine A<br/>gen 30 creature] -->|cross-breed| C[Offspring<br/>Math.max parents = 30]
    B[Machine B<br/>local counter = 6] --> R{End-of-round write}
    C --> R
    R -->|"before: overwrite -> 6 (lost)"| X[gen 6 ❌]
    R -->|"after: max(30, 6) -> 30 (kept)"| Y[gen 30 ✅]
```

The new failing-then-passing test demonstrates the clobber and the fix:

```
writeSeedWarmupProgressTags: never lowers an existing higher generation
  before fix -> Actual 6 / Expected 30  (FAILED)
  after  fix -> ok
```

## Test Plan

Added to `test/architecture/SeedWarmupPersistence.ts`:

- `writeSeedWarmupProgressTags: never lowers an existing higher generation` —
  writes gen 30 then a later gen 6; asserts the tag stays 30 (the regression
  test; fails against the unfixed code).
- `writeSeedWarmupProgressTags: still raises generation when higher` — writes
  gen 6 then gen 14; asserts the tag advances to 14 (monotonic increase still
  works).
- `Offspring.breed: carries the HIGHER of two differing parent generations` —
  parents with generations 30 and 5; asserts the offspring inherits 30.

Existing tests continue to pass unchanged (no test removed or commented out),
including `populatePopulation: restores warm-up tags from seed creature` and the
`OnPolicyDistillationBreed` warm-up carryover.

Commands run:

- `deno test test/architecture/SeedWarmupPersistence.ts` — 9 passed
- `deno test test/architecture/CreatureFactory.ts test/architecture/SeedWarmupStructuralLock.ts test/breed/OnPolicyDistillationBreed.ts`
  — 54 passed
- `deno test test/NEAT/NeatPopulatePopulation.ts test/multithreading/WorkerHandler.ts`
  — 12 passed
- `deno test test/NEAT/DiscoveryReplayWarmup.ts test/NEAT/NeatFinishUp.ts` — 12
  passed
- `./quality.sh --lint-only` — format, lint, bash checks pass
- `deno check` on changed/related files — passes



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpv0gox7-8c1bcf`<!-- vibe-worker-issue-2831 -->