### PR TITLE
Add timeout-minutes to every workflow job (Issue #2841)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -22,6 +22,7 @@ jobs:
   actionlint:
     name: Lint GitHub Actions workflows
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       NEAT_RUST_DISCOVERY_OPTIONAL: "true"
       # Enable per-process discovery directory isolation so parallel test

--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -23,6 +23,7 @@ jobs:
   outdated:
     name: Run deno outdated and raise PR
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: "Checkout repository"
         # actions/checkout@v6.0.2

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write # OIDC for JSR (provenance + tokenless publish)

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       NEAT_RUST_DISCOVERY_OPTIONAL: "true"
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,6 +11,7 @@ jobs:
   semgrep:
     name: Semgrep SAST scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       # semgrep/semgrep:latest as of 2026-05-22 (multi-arch index digest).
       # Pinned to close the supply-chain hole on SEMGREP_APP_TOKEN — see #2743.

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   spellcheck: # run the action
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/update-package-version.yml
+++ b/.github/workflows/update-package-version.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   update-version:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2841.md
+++ b/docs/archive/pr-summaries/pr-summary-2841.md
@@ -1,0 +1,73 @@
+## Summary
+
+Every job in `.github/workflows/*.y*ml` inherited the GitHub default of 360
+minutes (6 hours) because none declared `timeout-minutes:`. A wedged step — a
+hung `deno test` in `coverage.yaml`, a stalled network fetch, or a `git push`
+blocked on a prompt in `quality.yml` — could therefore hold a runner for up to
+six hours, burning minutes quota and blocking the queue before GitHub kills it.
+
+This PR adds an explicit per-job `timeout-minutes:` to all 12 workflow jobs,
+sized to each job's normal runtime plus headroom, capping the blast radius of a
+wedged step and surfacing genuine slowdowns as fast failures.
+
+Closes #2841.
+
+| Workflow file                | Job                 | `timeout-minutes` |
+| ---------------------------- | ------------------- | ----------------- |
+| `actionlint.yml`             | `actionlint`        | 10                |
+| `markdown-lint.yml`          | `markdownlint`      | 10                |
+| `shellcheck.yml`             | `shellcheck`        | 10                |
+| `spellcheck.yaml`            | `spellcheck`        | 10                |
+| `dependency-review.yml`      | `dependency-review` | 10                |
+| `semgrep.yml`                | `semgrep`           | 15                |
+| `github-release.yml`         | `release`           | 15                |
+| `publish.yml`                | `publish`           | 15                |
+| `deno-outdated.yml`          | `outdated`          | 15                |
+| `update-package-version.yml` | `update-version`    | 15                |
+| `coverage.yaml`              | `coverage`          | 30                |
+| `quality.yml`                | `quality`           | 30                |
+
+Short lint/scan jobs get a tight 10-minute bound; the SAST scan and the
+release/maintenance jobs get 15; the heavier test/build jobs get 30.
+
+## Evidence
+
+This is a CI configuration change with no web interface to screenshot. It is
+verified by a new governance test, `test/ci/WorkflowJobTimeoutMinutes.ts`, which
+parses every workflow YAML and asserts each job declares a positive-integer
+`timeout-minutes` below the 360-minute default. The test fails against the
+unfixed tree and passes after the change.
+
+```
+running 2 tests from ./test/ci/WorkflowJobTimeoutMinutes.ts
+at least one workflow file is present to validate ... ok
+every workflow job declares an explicit timeout-minutes ... ok
+
+ok | 2 passed | 0 failed
+```
+
+The full `test/ci` workflow-governance suite (67 tests) remains green after the
+change.
+
+```mermaid
+flowchart LR
+    Step[Wedged step] --> Q{timeout-minutes?}
+    Q -- "absent (before)" --> D[Runs to 360-min<br/>GitHub default]
+    Q -- "explicit (after)" --> T[Fails fast at<br/>per-job bound]
+    D --> Quota[Holds runner ~6h<br/>blocks queue]
+    T --> Fast[Frees runner<br/>surfaces slowdown]
+```
+
+## Test Plan
+
+- Added `test/ci/WorkflowJobTimeoutMinutes.ts`:
+  - `at least one workflow file is present to validate` — guards against the
+    suite silently passing on an empty directory.
+  - `every workflow job declares an explicit timeout-minutes` — parses each
+    `.github/workflows/*.y*ml`, iterates its jobs, and asserts each declares a
+    positive-integer `timeout-minutes` tighter than the 360-minute default.
+- Confirmed the new test fails before the YAML change and passes after.
+- Ran the existing `test/ci/*.ts` workflow-governance suites plus the
+  `test/scripts` workflow tests — all 67 pass.
+- `deno fmt --check`, `deno lint`, and `deno check` clean on the new test and
+  the changed workflow files.

--- a/test/ci/WorkflowJobTimeoutMinutes.ts
+++ b/test/ci/WorkflowJobTimeoutMinutes.ts
@@ -1,0 +1,87 @@
+import { assert } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verifies that every job in every `.github/workflows/*.y*ml` file declares an
+ * explicit `timeout-minutes:` (Issue #2841 — workflow resource-hygiene
+ * hardening).
+ *
+ * A job without `timeout-minutes:` inherits the GitHub default of 360 minutes
+ * (6 hours). A wedged step — a hung `deno test`, a stalled network fetch, or a
+ * `git push` blocked on a prompt — would therefore hold a runner for up to six
+ * hours, burning minutes quota and blocking the queue before GitHub kills it.
+ * An explicit per-job timeout caps the blast radius and surfaces genuine
+ * slowdowns as fast failures.
+ *
+ * This is a "what" test: it parses the committed workflow YAML and asserts on
+ * the resulting configuration, not on how the value happens to be written.
+ */
+
+interface Job {
+  "timeout-minutes"?: number;
+  "runs-on"?: string;
+}
+
+interface Workflow {
+  name?: string;
+  jobs?: Record<string, Job>;
+}
+
+const WORKFLOW_DIR = ".github/workflows";
+
+// The 6-hour GitHub default we are guarding against. Any explicit bound must be
+// well below this; a job needing longer almost certainly has a wedged step.
+const GITHUB_DEFAULT_TIMEOUT_MINUTES = 360;
+
+async function listWorkflowFiles(): Promise<string[]> {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(WORKFLOW_DIR)) {
+    if (!entry.isFile) continue;
+    if (/\.ya?ml$/.test(entry.name)) {
+      files.push(`${WORKFLOW_DIR}/${entry.name}`);
+    }
+  }
+  return files.sort();
+}
+
+async function readWorkflow(path: string): Promise<Workflow> {
+  const text = await Deno.readTextFile(path);
+  return parse(text) as Workflow;
+}
+
+Deno.test("at least one workflow file is present to validate", async () => {
+  const files = await listWorkflowFiles();
+  assert(files.length > 0, `no workflow files found under ${WORKFLOW_DIR}`);
+});
+
+Deno.test("every workflow job declares an explicit timeout-minutes", async () => {
+  const files = await listWorkflowFiles();
+  const workflows = await Promise.all(
+    files.map(async (file) => ({ file, wf: await readWorkflow(file) })),
+  );
+  for (const { file, wf } of workflows) {
+    const jobs = wf.jobs ?? {};
+    const jobIds = Object.keys(jobs);
+    assert(jobIds.length > 0, `${file} declares no jobs`);
+
+    for (const jobId of jobIds) {
+      const job = jobs[jobId];
+      const timeout = job["timeout-minutes"];
+      assert(
+        typeof timeout === "number",
+        `${file} job "${jobId}" is missing timeout-minutes (inherits the ` +
+          `${GITHUB_DEFAULT_TIMEOUT_MINUTES}-minute GitHub default)`,
+      );
+      assert(
+        Number.isInteger(timeout) && timeout > 0,
+        `${file} job "${jobId}" timeout-minutes must be a positive integer, ` +
+          `got ${timeout}`,
+      );
+      assert(
+        timeout < GITHUB_DEFAULT_TIMEOUT_MINUTES,
+        `${file} job "${jobId}" timeout-minutes (${timeout}) must be tighter ` +
+          `than the ${GITHUB_DEFAULT_TIMEOUT_MINUTES}-minute GitHub default`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Every job in `.github/workflows/*.y*ml` inherited the GitHub default of 360
minutes (6 hours) because none declared `timeout-minutes:`. A wedged step — a
hung `deno test` in `coverage.yaml`, a stalled network fetch, or a `git push`
blocked on a prompt in `quality.yml` — could therefore hold a runner for up to
six hours, burning minutes quota and blocking the queue before GitHub kills it.

This PR adds an explicit per-job `timeout-minutes:` to all 12 workflow jobs,
sized to each job's normal runtime plus headroom, capping the blast radius of a
wedged step and surfacing genuine slowdowns as fast failures.

Closes #2841.

| Workflow file                | Job                 | `timeout-minutes` |
| ---------------------------- | ------------------- | ----------------- |
| `actionlint.yml`             | `actionlint`        | 10                |
| `markdown-lint.yml`          | `markdownlint`      | 10                |
| `shellcheck.yml`             | `shellcheck`        | 10                |
| `spellcheck.yaml`            | `spellcheck`        | 10                |
| `dependency-review.yml`      | `dependency-review` | 10                |
| `semgrep.yml`                | `semgrep`           | 15                |
| `github-release.yml`         | `release`           | 15                |
| `publish.yml`                | `publish`           | 15                |
| `deno-outdated.yml`          | `outdated`          | 15                |
| `update-package-version.yml` | `update-version`    | 15                |
| `coverage.yaml`              | `coverage`          | 30                |
| `quality.yml`                | `quality`           | 30                |

Short lint/scan jobs get a tight 10-minute bound; the SAST scan and the
release/maintenance jobs get 15; the heavier test/build jobs get 30.

## Evidence

This is a CI configuration change with no web interface to screenshot. It is
verified by a new governance test, `test/ci/WorkflowJobTimeoutMinutes.ts`, which
parses every workflow YAML and asserts each job declares a positive-integer
`timeout-minutes` below the 360-minute default. The test fails against the
unfixed tree and passes after the change.

```
running 2 tests from ./test/ci/WorkflowJobTimeoutMinutes.ts
at least one workflow file is present to validate ... ok
every workflow job declares an explicit timeout-minutes ... ok

ok | 2 passed | 0 failed
```

The full `test/ci` workflow-governance suite (67 tests) remains green after the
change.

```mermaid
flowchart LR
    Step[Wedged step] --> Q{timeout-minutes?}
    Q -- "absent (before)" --> D[Runs to 360-min<br/>GitHub default]
    Q -- "explicit (after)" --> T[Fails fast at<br/>per-job bound]
    D --> Quota[Holds runner ~6h<br/>blocks queue]
    T --> Fast[Frees runner<br/>surfaces slowdown]
```

## Test Plan

- Added `test/ci/WorkflowJobTimeoutMinutes.ts`:
  - `at least one workflow file is present to validate` — guards against the
    suite silently passing on an empty directory.
  - `every workflow job declares an explicit timeout-minutes` — parses each
    `.github/workflows/*.y*ml`, iterates its jobs, and asserts each declares a
    positive-integer `timeout-minutes` tighter than the 360-minute default.
- Confirmed the new test fails before the YAML change and passes after.
- Ran the existing `test/ci/*.ts` workflow-governance suites plus the
  `test/scripts` workflow tests — all 67 pass.
- `deno fmt --check`, `deno lint`, and `deno check` clean on the new test and
  the changed workflow files.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpvp1cc6-66ca66`<!-- vibe-worker-issue-2841 -->