### PR TITLE
Test: assert on stable UUIDs not hashed neuron IDs in compact tests (#2834)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.6",
+  "version": "5.3.7",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2834.md
+++ b/docs/archive/pr-summaries/pr-summary-2834.md
@@ -1,0 +1,46 @@
+## Summary
+
+Removed hard-coded UUID-hash neuron IDs from the `test/compact/` tests so the
+assertions describe the *observable* behaviour (which neuron/synapse survives,
+identified by its stable UUID) rather than coupling to the internal
+UUID→integer hashing routine. The magic integers (`217046707`, `4227520`,
+`550257383`, and the two converted-constant ids `1640249334` / `890998550`) are
+implementation details — a behaviour-preserving change to the hashing algorithm
+would have broken these tests even though pruning/orphan-removal still works.
+This was a HOW-test refactoring blocker (anti-pattern: hard-coded magic values).
+
+Closes #2834.
+
+## Changes
+
+- `test/compact/CleanupOrphanedNeurons.ts`
+  - Orphan-removal: identify the removed neuron/synapse by `uuid === "orphan-hidden-1"` / `toUUID === "orphan-hidden-1"` instead of the hashed id `217046707`.
+  - Hidden→constant conversion (both LOGISTIC and TANH cases): locate the converted neuron as the sole `type === "constant"` neuron rather than by the hashed ids `1640249334` / `890998550`. (Conversion drops the source UUID, so the observable property is the neuron's type.)
+- `test/compact/ZeroWeightSynapsePruningTyped.ts`
+  - Count IF inbound synapses by `toUUID === "if-0"` instead of `toId === 4227520`.
+- `test/compact/ZeroWeightSynapsePruning.ts`
+  - Assert the orphaned hidden neuron is gone by `uuid === "hidden-unused"` instead of `id === 550257383`.
+
+No production code changed — these are test-only assertion refactors that preserve the behaviour being verified.
+
+## Evidence
+
+Backend/test-only change — no UI to screenshot. Verified by running the three
+affected test files and the full quality gate.
+
+```
+deno test test/compact/CleanupOrphanedNeurons.ts \
+          test/compact/ZeroWeightSynapsePruningTyped.ts \
+          test/compact/ZeroWeightSynapsePruning.ts
+ok | 11 passed | 0 failed
+
+./quality.sh
+ok | 7024 passed (2 steps) | 0 failed | 4 ignored
+```
+
+## Test Plan
+
+- `test/compact/CleanupOrphanedNeurons.ts` — 9 tests pass with UUID/type-based assertions.
+- `test/compact/ZeroWeightSynapsePruningTyped.ts` — IF-target preservation verified via `toUUID`.
+- `test/compact/ZeroWeightSynapsePruning.ts` — behaviour-preserving compaction verified via `uuid`.
+- Full `./quality.sh` (fmt, lint, type-check, all tests) passes cleanly.

--- a/docs/archive/pr-summaries/pr-summary-2834.md
+++ b/docs/archive/pr-summaries/pr-summary-2834.md
@@ -1,27 +1,35 @@
 ## Summary
 
 Removed hard-coded UUID-hash neuron IDs from the `test/compact/` tests so the
-assertions describe the *observable* behaviour (which neuron/synapse survives,
-identified by its stable UUID) rather than coupling to the internal
-UUID→integer hashing routine. The magic integers (`217046707`, `4227520`,
-`550257383`, and the two converted-constant ids `1640249334` / `890998550`) are
-implementation details — a behaviour-preserving change to the hashing algorithm
-would have broken these tests even though pruning/orphan-removal still works.
-This was a HOW-test refactoring blocker (anti-pattern: hard-coded magic values).
+assertions describe the _observable_ behaviour (which neuron/synapse survives,
+identified by its stable UUID) rather than coupling to the internal UUID→integer
+hashing routine. The magic integers (`217046707`, `4227520`, `550257383`, and
+the two converted-constant ids `1640249334` / `890998550`) are implementation
+details — a behaviour-preserving change to the hashing algorithm would have
+broken these tests even though pruning/orphan-removal still works. This was a
+HOW-test refactoring blocker (anti-pattern: hard-coded magic values).
 
 Closes #2834.
 
 ## Changes
 
 - `test/compact/CleanupOrphanedNeurons.ts`
-  - Orphan-removal: identify the removed neuron/synapse by `uuid === "orphan-hidden-1"` / `toUUID === "orphan-hidden-1"` instead of the hashed id `217046707`.
-  - Hidden→constant conversion (both LOGISTIC and TANH cases): locate the converted neuron as the sole `type === "constant"` neuron rather than by the hashed ids `1640249334` / `890998550`. (Conversion drops the source UUID, so the observable property is the neuron's type.)
+  - Orphan-removal: identify the removed neuron/synapse by
+    `uuid === "orphan-hidden-1"` / `toUUID === "orphan-hidden-1"` instead of the
+    hashed id `217046707`.
+  - Hidden→constant conversion (both LOGISTIC and TANH cases): locate the
+    converted neuron as the sole `type === "constant"` neuron rather than by the
+    hashed ids `1640249334` / `890998550`. (Conversion drops the source UUID, so
+    the observable property is the neuron's type.)
 - `test/compact/ZeroWeightSynapsePruningTyped.ts`
-  - Count IF inbound synapses by `toUUID === "if-0"` instead of `toId === 4227520`.
+  - Count IF inbound synapses by `toUUID === "if-0"` instead of
+    `toId === 4227520`.
 - `test/compact/ZeroWeightSynapsePruning.ts`
-  - Assert the orphaned hidden neuron is gone by `uuid === "hidden-unused"` instead of `id === 550257383`.
+  - Assert the orphaned hidden neuron is gone by `uuid === "hidden-unused"`
+    instead of `id === 550257383`.
 
-No production code changed — these are test-only assertion refactors that preserve the behaviour being verified.
+No production code changed — these are test-only assertion refactors that
+preserve the behaviour being verified.
 
 ## Evidence
 
@@ -40,7 +48,10 @@ ok | 7024 passed (2 steps) | 0 failed | 4 ignored
 
 ## Test Plan
 
-- `test/compact/CleanupOrphanedNeurons.ts` — 9 tests pass with UUID/type-based assertions.
-- `test/compact/ZeroWeightSynapsePruningTyped.ts` — IF-target preservation verified via `toUUID`.
-- `test/compact/ZeroWeightSynapsePruning.ts` — behaviour-preserving compaction verified via `uuid`.
+- `test/compact/CleanupOrphanedNeurons.ts` — 9 tests pass with UUID/type-based
+  assertions.
+- `test/compact/ZeroWeightSynapsePruningTyped.ts` — IF-target preservation
+  verified via `toUUID`.
+- `test/compact/ZeroWeightSynapsePruning.ts` — behaviour-preserving compaction
+  verified via `uuid`.
 - Full `./quality.sh` (fmt, lint, type-check, all tests) passes cleanly.

--- a/test/compact/CleanupOrphanedNeurons.ts
+++ b/test/compact/CleanupOrphanedNeurons.ts
@@ -72,19 +72,20 @@ Deno.test("cleanupOrphanedNeurons - should remove hidden neuron with no outward 
   const creature = Creature.fromJSON(creatureExport);
   creatureValidate(creature);
 
-  // The orphaned neuron should have been removed
+  // The orphaned neuron should have been removed. Identify it by its stable
+  // UUID rather than the derived integer hash, so a behaviour-preserving change
+  // to the hashing routine does not break this assertion.
   assertEquals(creatureExport.neurons.length, 2);
-  // orphan-hidden-1 → id 217046707
   assertEquals(
-    creatureExport.neurons.find((n) => n.id === 217046707),
+    creatureExport.neurons.find((n) => n.uuid === "orphan-hidden-1"),
     undefined,
     "Orphaned neuron should be removed",
   );
 
-  // The synapse to the orphaned neuron should also be removed
+  // The synapse to the orphaned neuron should also be removed.
   assertEquals(creatureExport.synapses.length, 2);
   assertEquals(
-    creatureExport.synapses.find((s) => s.toId === 217046707),
+    creatureExport.synapses.find((s) => s.toUUID === "orphan-hidden-1"),
     undefined,
     "Synapse to orphaned neuron should be removed",
   );
@@ -423,10 +424,11 @@ Deno.test("cleanupOrphanedNeurons - should apply squash function when converting
   // Run cleanup - should convert hidden to constant with squashed bias
   cleanupOrphanedNeurons(creatureExport);
 
-  // The hidden neuron should have been converted to a constant
-  // hidden-no-inward → id 1640249334
+  // The hidden neuron should have been converted to a constant. Identify it
+  // observably as the sole constant neuron rather than by a derived hash id
+  // (conversion drops the source UUID).
   const convertedNeuron = creatureExport.neurons.find(
-    (n) => n.id === 1640249334,
+    (n) => n.type === "constant",
   );
   assertEquals(
     convertedNeuron?.type,
@@ -493,10 +495,11 @@ Deno.test("cleanupOrphanedNeurons - should apply TANH squash function when conve
   assertEquals(result.converted, 1, "Should have converted 1 neuron");
   assertEquals(result.removed, 0, "Should have removed 0 neurons");
 
-  // Verify the constant neuron has the TANH-squashed bias
-  // hidden-tanh → id 890998550
+  // Verify the constant neuron has the TANH-squashed bias. Identify it
+  // observably as the sole constant neuron rather than by a derived hash id
+  // (conversion drops the source UUID).
   const convertedNeuron = creatureExport.neurons.find(
-    (n) => n.id === 890998550,
+    (n) => n.type === "constant",
   );
   assertEquals(convertedNeuron?.type, "constant");
   assertAlmostEquals(

--- a/test/compact/ZeroWeightSynapsePruning.ts
+++ b/test/compact/ZeroWeightSynapsePruning.ts
@@ -69,8 +69,10 @@ Deno.test("Compact: prunes zero-weight synapses then removes newly-orphaned neur
   // - the inbound synapse to the newly removed neuron (input-0 -> hidden-unused)
   assertEquals(compacted.synapses.length, beforeSynapseCount - 2);
   assertEquals(compacted.synapses.some((s) => s.weight === 0), false);
+  // The newly-orphaned hidden neuron should be gone. Identify it by its stable
+  // UUID rather than the derived integer hash.
   assertEquals(
-    compacted.neurons.some((n) => n.id === 550257383),
+    compacted.neurons.some((n) => n.uuid === "hidden-unused"),
     false,
   );
 

--- a/test/compact/ZeroWeightSynapsePruningTyped.ts
+++ b/test/compact/ZeroWeightSynapsePruningTyped.ts
@@ -46,9 +46,10 @@ Deno.test("pruneZeroWeightSynapses: keeps typed synapses, protects IF targets, a
   // - 1 inbound to output-1 (kept for structural safety) => 1 remains
   // - 3 typed required by IF + 1 untyped zero to IF => 4 remain
   assertEquals(exportJSON.synapses.length, 6);
-  // if-0 hidden neuron gets deterministic integer id 4227520
+  // The IF neuron must retain all four inbound synapses. Identify them by the
+  // stable UUID rather than the derived integer hash.
   assertEquals(
-    exportJSON.synapses.filter((s) => s.toId === 4227520).length,
+    exportJSON.synapses.filter((s) => s.toUUID === "if-0").length,
     4,
   );
   assertEquals(


### PR DESCRIPTION
## Summary

Removed hard-coded UUID-hash neuron IDs from the `test/compact/` tests so the
assertions describe the _observable_ behaviour (which neuron/synapse survives,
identified by its stable UUID) rather than coupling to the internal UUID→integer
hashing routine. The magic integers (`217046707`, `4227520`, `550257383`, and
the two converted-constant ids `1640249334` / `890998550`) are implementation
details — a behaviour-preserving change to the hashing algorithm would have
broken these tests even though pruning/orphan-removal still works. This was a
HOW-test refactoring blocker (anti-pattern: hard-coded magic values).

Closes #2834.

## Changes

- `test/compact/CleanupOrphanedNeurons.ts`
  - Orphan-removal: identify the removed neuron/synapse by
    `uuid === "orphan-hidden-1"` / `toUUID === "orphan-hidden-1"` instead of the
    hashed id `217046707`.
  - Hidden→constant conversion (both LOGISTIC and TANH cases): locate the
    converted neuron as the sole `type === "constant"` neuron rather than by the
    hashed ids `1640249334` / `890998550`. (Conversion drops the source UUID, so
    the observable property is the neuron's type.)
- `test/compact/ZeroWeightSynapsePruningTyped.ts`
  - Count IF inbound synapses by `toUUID === "if-0"` instead of
    `toId === 4227520`.
- `test/compact/ZeroWeightSynapsePruning.ts`
  - Assert the orphaned hidden neuron is gone by `uuid === "hidden-unused"`
    instead of `id === 550257383`.

No production code changed — these are test-only assertion refactors that
preserve the behaviour being verified.

## Evidence

Backend/test-only change — no UI to screenshot. Verified by running the three
affected test files and the full quality gate.

```
deno test test/compact/CleanupOrphanedNeurons.ts \
          test/compact/ZeroWeightSynapsePruningTyped.ts \
          test/compact/ZeroWeightSynapsePruning.ts
ok | 11 passed | 0 failed

./quality.sh
ok | 7024 passed (2 steps) | 0 failed | 4 ignored
```

## Test Plan

- `test/compact/CleanupOrphanedNeurons.ts` — 9 tests pass with UUID/type-based
  assertions.
- `test/compact/ZeroWeightSynapsePruningTyped.ts` — IF-target preservation
  verified via `toUUID`.
- `test/compact/ZeroWeightSynapsePruning.ts` — behaviour-preserving compaction
  verified via `uuid`.
- Full `./quality.sh` (fmt, lint, type-check, all tests) passes cleanly.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpvqdke1-440daf`<!-- vibe-worker-issue-2834 -->