### PR TITLE
Add concurrency cancel-in-progress to pile-up-prone workflows (Issue #2842)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,6 +13,12 @@ on:
   push:
     branches: [Develop, main, master]
 
+# Cancel superseded runs on the same ref so rapid successive pushes don't
+# pile up redundant lint runs (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege GITHUB_TOKEN scopes (Issue #2706). actionlint only
 # reads files; no write access is required.
 permissions:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -5,6 +5,12 @@ on:
     branches:
       - Develop
 
+# Cancel superseded runs on the same ref so rapid successive pushes don't
+# pile up redundant (heavy) coverage runs (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege GITHUB_TOKEN scopes (Issue #2706). The workflow uploads
 # artifacts, posts check-run annotations via EnricoMi/publish-unit-test-result-action,
 # and uploads coverage/results to Codecov.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,12 @@ on:
   pull_request:
     branches: ["Develop"]
 
+# Cancel superseded runs on the same ref so rapid successive pushes don't
+# pile up redundant dependency-review runs (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #
 # permissions:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - Develop
 
+# Serialise release runs but NEVER cancel one mid-flight: cancel-in-progress is
+# false so an in-progress release is never interrupted (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [Develop, main, master]
 
+# Cancel superseded runs on the same ref so rapid successive pushes don't
+# pile up redundant lint runs (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - Develop
 
+# Serialise JSR publish runs but NEVER cancel one mid-flight: cancel-in-progress
+# is false so an in-progress publish is never interrupted (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,6 +6,12 @@ on:
       - Develop
   workflow_dispatch: # Allow manual trigger if needed
 
+# Cancel superseded runs on the same ref so rapid successive pushes don't
+# pile up redundant (heavy) quality runs (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege GITHUB_TOKEN scopes (Issue #2706). The push back to the PR
 # branch uses secrets.ACTIONS_PUSH (a PAT), not the default GITHUB_TOKEN, so the
 # default token only needs read access.

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: ["Develop"]
 
+# Cancel superseded runs on the same ref so rapid successive pushes don't
+# pile up redundant SAST scans (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,6 +6,12 @@ on:
       - Develop
   workflow_dispatch:
 
+# Cancel superseded runs on the same ref so rapid successive pushes don't
+# pile up redundant lint runs (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -4,6 +4,12 @@ on:
     branches:
       - Develop
 
+# Cancel superseded runs on the same ref so rapid successive pushes don't
+# pile up redundant spell-check runs (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege GITHUB_TOKEN scopes (Issue #2706). The cspell action only
 # reads files; no write access is required.
 permissions:

--- a/.github/workflows/update-package-version.yml
+++ b/.github/workflows/update-package-version.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - Develop
 
+# Cancel superseded runs on the same ref so rapid successive pushes don't
+# pile up redundant version-bump runs (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-version:
     runs-on: ubuntu-latest

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2842.md
+++ b/docs/archive/pr-summaries/pr-summary-2842.md
@@ -1,0 +1,83 @@
+# Add `concurrency:` cancel-in-progress to pile-up-prone workflows
+
+## Summary
+
+No workflow in `.github/workflows/` declared a `concurrency:` group, so
+superseded runs were never cancelled. When a contributor pushed several
+commits to a PR branch in quick succession, every push started a fresh run of
+each `pull_request` workflow while the earlier runs kept executing — wasting
+minutes quota (especially on the heavy `coverage` and `quality` jobs) and
+delaying the run that reflects the latest commit.
+
+This change adds a top-level `concurrency:` block keyed on the workflow and ref
+to every pile-up-prone PR-triggered workflow, with `cancel-in-progress: true`
+so a stale run is cancelled as soon as a newer one starts. The release/publish
+workflows also gain a concurrency group to serialise runs, but keep
+`cancel-in-progress: false` so an in-flight release or JSR publish is never
+interrupted mid-run.
+
+Closes #2842.
+
+### Workflows changed
+
+| Workflow | Trigger | `cancel-in-progress` |
+| --- | --- | --- |
+| `actionlint.yml` | `pull_request` + `push` | `true` |
+| `coverage.yaml` | `pull_request` | `true` |
+| `dependency-review.yml` | `pull_request` | `true` |
+| `markdown-lint.yml` | `pull_request` + `push` | `true` |
+| `quality.yml` | `pull_request` | `true` |
+| `semgrep.yml` | `pull_request` | `true` |
+| `shellcheck.yml` | `pull_request` | `true` |
+| `spellcheck.yaml` | `pull_request` | `true` |
+| `update-package-version.yml` | `pull_request` | `true` |
+| `github-release.yml` | `push: Develop` | `false` (never interrupt a release) |
+| `publish.yml` | `push: Develop` | `false` (never interrupt a JSR publish) |
+
+Each group is {% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %}
+so concurrent runs of the **same** workflow on the **same** ref collapse,
+without colliding across different workflows or branches/PRs.
+
+`deno-outdated.yml` is intentionally left unchanged — it triggers only on a
+weekly `schedule` and `workflow_dispatch`, so it is not pile-up-prone from
+rapid pushes.
+
+## Evidence
+
+This is a CI-configuration change with no web interface to screenshot. It is
+verified by a new behavioural test that parses the committed workflow YAML and
+asserts on the resulting configuration.
+
+```mermaid
+flowchart TD
+    P1[Push commit A] --> R1[Run A starts]
+    P2[Push commit B] --> G{Same concurrency group?}
+    R1 --> G
+    G -->|PR workflow: cancel-in-progress true| C[Cancel stale Run A] --> R2[Run B reflects latest commit]
+    G -->|Release workflow: cancel-in-progress false| Q[Run A finishes, Run B queues] --> R3[Release never interrupted]
+```
+
+Test run:
+
+```
+deno test --allow-read test/ci/WorkflowConcurrencyGroup.ts
+ok | 11 passed | 0 failed
+```
+
+Full `test/ci/` suite (no regressions): `56 passed | 0 failed`.
+
+## Test Plan
+
+- Added `test/ci/WorkflowConcurrencyGroup.ts`:
+  - For each of the 9 pile-up-prone workflows, asserts a top-level
+    `concurrency:` block exists, its `group` includes both `github.workflow`
+    and the ref (`github.ref`/`github.head_ref`), and `cancel-in-progress` is
+    `true`.
+  - For `github-release.yml` and `publish.yml`, asserts that if a concurrency
+    block is present, `cancel-in-progress` is `false` so an in-flight release
+    is never cancelled.
+- Confirmed the test fails against the unfixed workflows (9 failures) and
+  passes after adding the concurrency blocks.
+- Re-ran the existing `test/ci/` and `test/scripts/` workflow tests
+  (timeouts, container-image pinning, persist-credentials, least-privilege
+  permissions) — all pass, confirming no regressions.

--- a/docs/archive/pr-summaries/pr-summary-2842.md
+++ b/docs/archive/pr-summaries/pr-summary-2842.md
@@ -3,15 +3,15 @@
 ## Summary
 
 No workflow in `.github/workflows/` declared a `concurrency:` group, so
-superseded runs were never cancelled. When a contributor pushed several
-commits to a PR branch in quick succession, every push started a fresh run of
-each `pull_request` workflow while the earlier runs kept executing — wasting
-minutes quota (especially on the heavy `coverage` and `quality` jobs) and
-delaying the run that reflects the latest commit.
+superseded runs were never cancelled. When a contributor pushed several commits
+to a PR branch in quick succession, every push started a fresh run of each
+`pull_request` workflow while the earlier runs kept executing — wasting minutes
+quota (especially on the heavy `coverage` and `quality` jobs) and delaying the
+run that reflects the latest commit.
 
 This change adds a top-level `concurrency:` block keyed on the workflow and ref
-to every pile-up-prone PR-triggered workflow, with `cancel-in-progress: true`
-so a stale run is cancelled as soon as a newer one starts. The release/publish
+to every pile-up-prone PR-triggered workflow, with `cancel-in-progress: true` so
+a stale run is cancelled as soon as a newer one starts. The release/publish
 workflows also gain a concurrency group to serialise runs, but keep
 `cancel-in-progress: false` so an in-flight release or JSR publish is never
 interrupted mid-run.
@@ -20,27 +20,27 @@ Closes #2842.
 
 ### Workflows changed
 
-| Workflow | Trigger | `cancel-in-progress` |
-| --- | --- | --- |
-| `actionlint.yml` | `pull_request` + `push` | `true` |
-| `coverage.yaml` | `pull_request` | `true` |
-| `dependency-review.yml` | `pull_request` | `true` |
-| `markdown-lint.yml` | `pull_request` + `push` | `true` |
-| `quality.yml` | `pull_request` | `true` |
-| `semgrep.yml` | `pull_request` | `true` |
-| `shellcheck.yml` | `pull_request` | `true` |
-| `spellcheck.yaml` | `pull_request` | `true` |
-| `update-package-version.yml` | `pull_request` | `true` |
-| `github-release.yml` | `push: Develop` | `false` (never interrupt a release) |
-| `publish.yml` | `push: Develop` | `false` (never interrupt a JSR publish) |
+| Workflow                     | Trigger                 | `cancel-in-progress`                    |
+| ---------------------------- | ----------------------- | --------------------------------------- |
+| `actionlint.yml`             | `pull_request` + `push` | `true`                                  |
+| `coverage.yaml`              | `pull_request`          | `true`                                  |
+| `dependency-review.yml`      | `pull_request`          | `true`                                  |
+| `markdown-lint.yml`          | `pull_request` + `push` | `true`                                  |
+| `quality.yml`                | `pull_request`          | `true`                                  |
+| `semgrep.yml`                | `pull_request`          | `true`                                  |
+| `shellcheck.yml`             | `pull_request`          | `true`                                  |
+| `spellcheck.yaml`            | `pull_request`          | `true`                                  |
+| `update-package-version.yml` | `pull_request`          | `true`                                  |
+| `github-release.yml`         | `push: Develop`         | `false` (never interrupt a release)     |
+| `publish.yml`                | `push: Develop`         | `false` (never interrupt a JSR publish) |
 
-Each group is {% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %}
-so concurrent runs of the **same** workflow on the **same** ref collapse,
-without colliding across different workflows or branches/PRs.
+Each group is {% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %} so
+concurrent runs of the **same** workflow on the **same** ref collapse, without
+colliding across different workflows or branches/PRs.
 
 `deno-outdated.yml` is intentionally left unchanged — it triggers only on a
-weekly `schedule` and `workflow_dispatch`, so it is not pile-up-prone from
-rapid pushes.
+weekly `schedule` and `workflow_dispatch`, so it is not pile-up-prone from rapid
+pushes.
 
 ## Evidence
 
@@ -70,14 +70,14 @@ Full `test/ci/` suite (no regressions): `56 passed | 0 failed`.
 
 - Added `test/ci/WorkflowConcurrencyGroup.ts`:
   - For each of the 9 pile-up-prone workflows, asserts a top-level
-    `concurrency:` block exists, its `group` includes both `github.workflow`
-    and the ref (`github.ref`/`github.head_ref`), and `cancel-in-progress` is
+    `concurrency:` block exists, its `group` includes both `github.workflow` and
+    the ref (`github.ref`/`github.head_ref`), and `cancel-in-progress` is
     `true`.
   - For `github-release.yml` and `publish.yml`, asserts that if a concurrency
-    block is present, `cancel-in-progress` is `false` so an in-flight release
-    is never cancelled.
-- Confirmed the test fails against the unfixed workflows (9 failures) and
-  passes after adding the concurrency blocks.
-- Re-ran the existing `test/ci/` and `test/scripts/` workflow tests
-  (timeouts, container-image pinning, persist-credentials, least-privilege
-  permissions) — all pass, confirming no regressions.
+    block is present, `cancel-in-progress` is `false` so an in-flight release is
+    never cancelled.
+- Confirmed the test fails against the unfixed workflows (9 failures) and passes
+  after adding the concurrency blocks.
+- Re-ran the existing `test/ci/` and `test/scripts/` workflow tests (timeouts,
+  container-image pinning, persist-credentials, least-privilege permissions) —
+  all pass, confirming no regressions.

--- a/test/ci/WorkflowConcurrencyGroup.ts
+++ b/test/ci/WorkflowConcurrencyGroup.ts
@@ -1,0 +1,128 @@
+import { assert, assertEquals } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verifies that pile-up-prone `.github/workflows/*.y*ml` files declare a
+ * top-level `concurrency:` group so superseded runs are cancelled (Issue
+ * #2842 — workflow resource-hygiene hardening).
+ *
+ * When a contributor pushes several commits to a PR branch in quick
+ * succession, every push starts a fresh run of each `pull_request` workflow
+ * while the earlier runs keep executing. On the heavier jobs (`coverage`,
+ * `quality`) those superseded runs each hold a runner for the full
+ * test/build cycle, wasting minutes quota and delaying the run that reflects
+ * the latest commit. A `concurrency:` group keyed on the workflow and ref,
+ * with `cancel-in-progress: true`, cancels the stale run as soon as a newer
+ * one starts.
+ *
+ * The release/publish workflows trigger on `push: Develop`; they may declare
+ * concurrency to serialise releases, but MUST keep `cancel-in-progress:
+ * false` so an in-flight release or JSR publish is never interrupted
+ * mid-run.
+ *
+ * This is a "what" test: it parses the committed workflow YAML and asserts on
+ * the resulting configuration, not on how the value happens to be written.
+ */
+
+interface Concurrency {
+  group?: string;
+  "cancel-in-progress"?: boolean | string;
+}
+
+interface Workflow {
+  name?: string;
+  concurrency?: Concurrency | string;
+}
+
+const WORKFLOW_DIR = ".github/workflows";
+
+// PR-triggered workflows where rapid successive pushes queue redundant runs.
+// Each MUST cancel superseded runs (cancel-in-progress: true).
+const PILE_UP_PRONE = [
+  "actionlint.yml",
+  "coverage.yaml",
+  "dependency-review.yml",
+  "markdown-lint.yml",
+  "quality.yml",
+  "semgrep.yml",
+  "shellcheck.yml",
+  "spellcheck.yaml",
+  "update-package-version.yml",
+];
+
+// Release/publish workflows trigger on push: Develop. They may serialise via a
+// concurrency group, but an in-flight run must never be cancelled mid-release.
+const RELEASE_WORKFLOWS = [
+  "github-release.yml",
+  "publish.yml",
+];
+
+async function readWorkflow(name: string): Promise<Workflow> {
+  const text = await Deno.readTextFile(`${WORKFLOW_DIR}/${name}`);
+  return parse(text) as Workflow;
+}
+
+function asConcurrency(wf: Workflow): Concurrency {
+  const c = wf.concurrency;
+  assert(
+    c !== undefined && typeof c === "object",
+    "expected a top-level concurrency: block (object with group and " +
+      "cancel-in-progress)",
+  );
+  return c as Concurrency;
+}
+
+for (const name of PILE_UP_PRONE) {
+  Deno.test(
+    `${name} declares a concurrency group that cancels superseded runs (Issue #2842)`,
+    async () => {
+      const wf = await readWorkflow(name);
+      const concurrency = asConcurrency(wf);
+
+      const group = concurrency.group;
+      assert(
+        typeof group === "string" && group.length > 0,
+        `${name} concurrency.group must be a non-empty string`,
+      );
+      // Keyed on the workflow + ref so concurrent runs of the SAME workflow on
+      // the SAME ref collapse, without colliding across different workflows or
+      // refs.
+      assert(
+        group.includes("github.workflow"),
+        `${name} concurrency.group must include github.workflow so groups do ` +
+          `not collide across workflows; got: ${group}`,
+      );
+      assert(
+        group.includes("github.ref") || group.includes("github.head_ref"),
+        `${name} concurrency.group must include the ref (github.ref or ` +
+          `github.head_ref) so distinct branches/PRs do not collide; got: ${group}`,
+      );
+
+      assertEquals(
+        concurrency["cancel-in-progress"],
+        true,
+        `${name} must set cancel-in-progress: true so a stale run is cancelled ` +
+          `as soon as a newer one starts`,
+      );
+    },
+  );
+}
+
+for (const name of RELEASE_WORKFLOWS) {
+  Deno.test(
+    `${name} never cancels an in-flight release/publish (Issue #2842)`,
+    async () => {
+      const wf = await readWorkflow(name);
+      // Concurrency is optional here, but if present it must not interrupt an
+      // in-flight release.
+      if (wf.concurrency === undefined) return;
+      const concurrency = asConcurrency(wf);
+      assertEquals(
+        concurrency["cancel-in-progress"],
+        false,
+        `${name} must keep cancel-in-progress: false so an in-flight release ` +
+          `or JSR publish is never interrupted mid-run`,
+      );
+    },
+  );
+}


### PR DESCRIPTION
# Add `concurrency:` cancel-in-progress to pile-up-prone workflows

## Summary

No workflow in `.github/workflows/` declared a `concurrency:` group, so
superseded runs were never cancelled. When a contributor pushed several
commits to a PR branch in quick succession, every push started a fresh run of
each `pull_request` workflow while the earlier runs kept executing — wasting
minutes quota (especially on the heavy `coverage` and `quality` jobs) and
delaying the run that reflects the latest commit.

This change adds a top-level `concurrency:` block keyed on the workflow and ref
to every pile-up-prone PR-triggered workflow, with `cancel-in-progress: true`
so a stale run is cancelled as soon as a newer one starts. The release/publish
workflows also gain a concurrency group to serialise runs, but keep
`cancel-in-progress: false` so an in-flight release or JSR publish is never
interrupted mid-run.

Closes #2842.

### Workflows changed

| Workflow | Trigger | `cancel-in-progress` |
| --- | --- | --- |
| `actionlint.yml` | `pull_request` + `push` | `true` |
| `coverage.yaml` | `pull_request` | `true` |
| `dependency-review.yml` | `pull_request` | `true` |
| `markdown-lint.yml` | `pull_request` + `push` | `true` |
| `quality.yml` | `pull_request` | `true` |
| `semgrep.yml` | `pull_request` | `true` |
| `shellcheck.yml` | `pull_request` | `true` |
| `spellcheck.yaml` | `pull_request` | `true` |
| `update-package-version.yml` | `pull_request` | `true` |
| `github-release.yml` | `push: Develop` | `false` (never interrupt a release) |
| `publish.yml` | `push: Develop` | `false` (never interrupt a JSR publish) |

Each group is {% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %}
so concurrent runs of the **same** workflow on the **same** ref collapse,
without colliding across different workflows or branches/PRs.

`deno-outdated.yml` is intentionally left unchanged — it triggers only on a
weekly `schedule` and `workflow_dispatch`, so it is not pile-up-prone from
rapid pushes.

## Evidence

This is a CI-configuration change with no web interface to screenshot. It is
verified by a new behavioural test that parses the committed workflow YAML and
asserts on the resulting configuration.

```mermaid
flowchart TD
    P1[Push commit A] --> R1[Run A starts]
    P2[Push commit B] --> G{Same concurrency group?}
    R1 --> G
    G -->|PR workflow: cancel-in-progress true| C[Cancel stale Run A] --> R2[Run B reflects latest commit]
    G -->|Release workflow: cancel-in-progress false| Q[Run A finishes, Run B queues] --> R3[Release never interrupted]
```

Test run:

```
deno test --allow-read test/ci/WorkflowConcurrencyGroup.ts
ok | 11 passed | 0 failed
```

Full `test/ci/` suite (no regressions): `56 passed | 0 failed`.

## Test Plan

- Added `test/ci/WorkflowConcurrencyGroup.ts`:
  - For each of the 9 pile-up-prone workflows, asserts a top-level
    `concurrency:` block exists, its `group` includes both `github.workflow`
    and the ref (`github.ref`/`github.head_ref`), and `cancel-in-progress` is
    `true`.
  - For `github-release.yml` and `publish.yml`, asserts that if a concurrency
    block is present, `cancel-in-progress` is `false` so an in-flight release
    is never cancelled.
- Confirmed the test fails against the unfixed workflows (9 failures) and
  passes after adding the concurrency blocks.
- Re-ran the existing `test/ci/` and `test/scripts/` workflow tests
  (timeouts, container-image pinning, persist-credentials, least-privilege
  permissions) — all pass, confirming no regressions.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpvs4y0p-f0782a`<!-- vibe-worker-issue-2842 -->