### PR TITLE
Replace hard-coded MSE magic value with derived spec assertion (Issue #2838)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.9",
+  "version": "5.3.10",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2838.md
+++ b/docs/archive/pr-summaries/pr-summary-2838.md
@@ -1,0 +1,61 @@
+## Summary
+
+Removed the undocumented hard-coded MSE magic value `0.396_802` from
+`test/score/Penalty.ts:36` and replaced it with a documented, input-derived
+WHAT-test. Closes #2838.
+
+The previous assertion captured the exact score the scorer happened to produce
+for the `large.json` fixture to six decimal places with a `1e-6` tolerance, with
+no derivation or spec reference. That is a HOW-test anti-pattern: any change to
+the penalty/MSE formula — including a legitimate improvement — forced a
+developer to paste in whatever the new run printed, so the assertion could not
+distinguish an intended change from a regression.
+
+The fixture is large (180 hidden neurons, 13,135 synapses), so hand-computing
+the MSE is not practical. Instead the test now asserts the scoring **spec**
+(`score = 1 - error - complexityPenalty - versionPenalty`, per
+`src/architecture/Score.ts`):
+
+- **Strict ceiling** — `score < 1 - error`, because every penalty term is
+  non-negative. This catches the error not being subtracted, a flipped penalty
+  sign, or a penalty going negative.
+- **Structure-derived expectation** — the expected score is derived from the
+  fixture's own structure (`hidden * growthCost + synapses * growthCost / 10`)
+  rather than copied from output, asserted with a `1e-4` tolerance that bounds
+  the small weight/bias and version-penalty terms.
+
+```mermaid
+flowchart LR
+    A["Inputs<br/>error=0.603, growthCost=1e-7"] --> B["scoreCeiling = 1 - error"]
+    C["Fixture structure<br/>hidden + synapses"] --> D["structuralPenalty"]
+    B --> E["expectedScore = ceiling - structuralPenalty"]
+    D --> E
+    E --> F["assertAlmostEquals(score, expectedScore, 1e-4)"]
+    B --> G["assert(score < ceiling)"]
+```
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+`test/score/Penalty.ts` passes after the change:
+
+```
+Score: Calculation with given parameters ... ok
+Score: Weight change should affect score ... ok
+valuePenalty: Edge Cases ... ok
+valuePenalty: Various Values ... ok
+ok | 4 passed | 0 failed
+```
+
+`./quality.sh --lint-only` and `./quality.sh --check-only` both pass cleanly.
+
+## Test Plan
+
+- Modified `test/score/Penalty.ts` → `Score: Calculation with given parameters`:
+  replaced the magic-constant assertion with a strict ceiling assertion plus a
+  structure-derived expected-score assertion. Verified the test still passes
+  (score `0.3968016…` sits below the `0.397` ceiling and within `1e-4` of the
+  structure-derived expectation).
+- Existing relational checks (`upgradedScore >= score`, weight-change raises the
+  score) are unchanged and still pass.

--- a/test/score/Penalty.ts
+++ b/test/score/Penalty.ts
@@ -33,8 +33,37 @@ Deno.test("Score: Calculation with given parameters", () => {
     );
   }
 
-  const expectedScore = 0.396_802;
-  assertAlmostEquals(score, expectedScore, 0.000_001, `Score was: ${score}`);
+  // The fitness score is defined in src/architecture/Score.ts as:
+  //   score = 1 - error - complexityPenalty - versionPenalty
+  // Every penalty term is non-negative, so `1 - error` is a ceiling the score
+  // can never reach. Asserting against this derived relationship — rather than
+  // a copied six-decimal magic constant — keeps the test tracking the scoring
+  // *spec*: subtracting the error, keeping penalties positive, and bounding the
+  // complexity penalty by network size. A legitimate tweak to the penalty
+  // formula no longer forces a developer to paste in whatever the new run
+  // prints, but a regression (error not subtracted, a flipped penalty sign, or
+  // an unbounded penalty) still breaks the test.
+  const error = 0.603;
+  const scoreCeiling = 1 - error; // 0.397 — strict, unreachable upper bound
+  assert(
+    score < scoreCeiling,
+    `Score ${score} must sit below the error ceiling ${scoreCeiling}: ` +
+      `the complexity and version penalties are strictly positive`,
+  );
+
+  // The complexity penalty is dominated by the deterministic, size-driven terms
+  // of the formula (hidden-neuron growth + synapse growth), both scaled by
+  // growthCost. We can therefore derive the expected score from the fixture's
+  // own structure instead of capturing it from output. The remaining
+  // weight/bias and version-penalty terms are small, so a 1e-4 tolerance bounds
+  // them without reconstructing the entire formula.
+  const growthCost = 0.000_000_1;
+  const hiddenNeurons = creature.neurons.length - creature.input -
+    creature.output;
+  const structuralPenalty = hiddenNeurons * growthCost +
+    creature.synapses.length * growthCost / 10;
+  const expectedScore = scoreCeiling - structuralPenalty;
+  assertAlmostEquals(score, expectedScore, 0.000_1, `Score was: ${score}`);
 });
 
 Deno.test("Score: Weight change should affect score", () => {


### PR DESCRIPTION
## Summary

Removed the undocumented hard-coded MSE magic value `0.396_802` from
`test/score/Penalty.ts:36` and replaced it with a documented, input-derived
WHAT-test. Closes #2838.

The previous assertion captured the exact score the scorer happened to produce
for the `large.json` fixture to six decimal places with a `1e-6` tolerance, with
no derivation or spec reference. That is a HOW-test anti-pattern: any change to
the penalty/MSE formula — including a legitimate improvement — forced a
developer to paste in whatever the new run printed, so the assertion could not
distinguish an intended change from a regression.

The fixture is large (180 hidden neurons, 13,135 synapses), so hand-computing
the MSE is not practical. Instead the test now asserts the scoring **spec**
(`score = 1 - error - complexityPenalty - versionPenalty`, per
`src/architecture/Score.ts`):

- **Strict ceiling** — `score < 1 - error`, because every penalty term is
  non-negative. This catches the error not being subtracted, a flipped penalty
  sign, or a penalty going negative.
- **Structure-derived expectation** — the expected score is derived from the
  fixture's own structure (`hidden * growthCost + synapses * growthCost / 10`)
  rather than copied from output, asserted with a `1e-4` tolerance that bounds
  the small weight/bias and version-penalty terms.

```mermaid
flowchart LR
    A["Inputs<br/>error=0.603, growthCost=1e-7"] --> B["scoreCeiling = 1 - error"]
    C["Fixture structure<br/>hidden + synapses"] --> D["structuralPenalty"]
    B --> E["expectedScore = ceiling - structuralPenalty"]
    D --> E
    E --> F["assertAlmostEquals(score, expectedScore, 1e-4)"]
    B --> G["assert(score < ceiling)"]
```

## Evidence

Backend/test-only change — no web interface to screenshot.

`test/score/Penalty.ts` passes after the change:

```
Score: Calculation with given parameters ... ok
Score: Weight change should affect score ... ok
valuePenalty: Edge Cases ... ok
valuePenalty: Various Values ... ok
ok | 4 passed | 0 failed
```

`./quality.sh --lint-only` and `./quality.sh --check-only` both pass cleanly.

## Test Plan

- Modified `test/score/Penalty.ts` → `Score: Calculation with given parameters`:
  replaced the magic-constant assertion with a strict ceiling assertion plus a
  structure-derived expected-score assertion. Verified the test still passes
  (score `0.3968016…` sits below the `0.397` ceiling and within `1e-4` of the
  structure-derived expectation).
- Existing relational checks (`upgradedScore >= score`, weight-change raises the
  score) are unchanged and still pass.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpwa05kr-a017dc`<!-- vibe-worker-issue-2838 -->