### PR TITLE
Test: replace HOW-assertion on worker call distribution (#2837)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.8",
+  "version": "5.3.9",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2837.md
+++ b/docs/archive/pr-summaries/pr-summary-2837.md
@@ -1,19 +1,18 @@
 ## Summary
 
-Removed a HOW-test anti-pattern from `test/breed/ParallelBreeding.ts`. The
-test `ParallelBreeding - worker path distributes work across all workers`
-asserted that **every** mock worker was called at least once — coupling the
-test to the scheduler's internal distribution strategy. A behaviour-preserving
-change (e.g. a work-stealing scheduler that drains tasks through one fast
-worker, or a change in pool sizing) would produce identical offspring yet leave
-a worker at zero calls and break the test.
+Removed a HOW-test anti-pattern from `test/breed/ParallelBreeding.ts`. The test
+`ParallelBreeding - worker path distributes work across all workers` asserted
+that **every** mock worker was called at least once — coupling the test to the
+scheduler's internal distribution strategy. A behaviour-preserving change (e.g.
+a work-stealing scheduler that drains tasks through one fast worker, or a change
+in pool sizing) would produce identical offspring yet leave a worker at zero
+calls and break the test.
 
 The test now asserts the **observable contract** of `breedBatch()`: the batch
 yields valid offspring with the correct input/output shape. A **tolerant**
 load-spreading check is retained — that the pool processed the batch and work
-was spread across more than one worker — without demanding a specific
-per-worker count. This survives any distribution strategy that genuinely uses
-the pool.
+was spread across more than one worker — without demanding a specific per-worker
+count. This survives any distribution strategy that genuinely uses the pool.
 
 Closes #2837.
 
@@ -42,5 +41,5 @@ flowchart LR
   - outcome assertions: `offspring.length > 0`, each child `validate()`s with
     `input === 5` and `output === 2`;
   - a tolerant distribution assertion: total calls `> 0` and `workersUsed > 1`.
-- No existing tests were removed or commented out; the sibling worker-path
-  tests remain unchanged.
+- No existing tests were removed or commented out; the sibling worker-path tests
+  remain unchanged.

--- a/docs/archive/pr-summaries/pr-summary-2837.md
+++ b/docs/archive/pr-summaries/pr-summary-2837.md
@@ -1,0 +1,46 @@
+## Summary
+
+Removed a HOW-test anti-pattern from `test/breed/ParallelBreeding.ts`. The
+test `ParallelBreeding - worker path distributes work across all workers`
+asserted that **every** mock worker was called at least once — coupling the
+test to the scheduler's internal distribution strategy. A behaviour-preserving
+change (e.g. a work-stealing scheduler that drains tasks through one fast
+worker, or a change in pool sizing) would produce identical offspring yet leave
+a worker at zero calls and break the test.
+
+The test now asserts the **observable contract** of `breedBatch()`: the batch
+yields valid offspring with the correct input/output shape. A **tolerant**
+load-spreading check is retained — that the pool processed the batch and work
+was spread across more than one worker — without demanding a specific
+per-worker count. This survives any distribution strategy that genuinely uses
+the pool.
+
+Closes #2837.
+
+## Evidence
+
+This is a test-only change (no production code touched), so there is no UI or
+performance evidence. Verification is via the test suite.
+
+```mermaid
+flowchart LR
+    A[breedBatch via worker pool] --> B[valid offspring produced]
+    A --> C[work spread across pool]
+    B -.->|assert outcome| D[input=5, output=2, validate]
+    C -.->|tolerant assert| E[workers used > 1, not every worker]
+```
+
+- Targeted run: `deno test --allow-all test/breed/ParallelBreeding.ts` →
+  `10 passed | 0 failed`.
+- Full quality gate: `./quality.sh` → `7037 passed | 0 failed | 4 ignored`.
+
+## Test Plan
+
+- Renamed `ParallelBreeding - worker path distributes work across all workers`
+  to `ParallelBreeding - worker path spreads a batch across the pool`.
+- Replaced the per-worker `callCounts[i] > 0` loop (HOW-assertion) with:
+  - outcome assertions: `offspring.length > 0`, each child `validate()`s with
+    `input === 5` and `output === 2`;
+  - a tolerant distribution assertion: total calls `> 0` and `workersUsed > 1`.
+- No existing tests were removed or commented out; the sibling worker-path
+  tests remain unchanged.

--- a/test/breed/ParallelBreeding.ts
+++ b/test/breed/ParallelBreeding.ts
@@ -419,14 +419,22 @@ Deno.test("ParallelBreeding - worker path handles large batch without stack over
   }
 });
 
-Deno.test("ParallelBreeding - worker path distributes work across all workers", async () => {
+Deno.test("ParallelBreeding - worker path spreads a batch across the pool", async () => {
+  // Issue #2837: Previously this test asserted every worker was called at
+  // least once — a HOW-test that couples to the scheduler's distribution
+  // strategy. A behaviour-preserving change (e.g. work-stealing that drains
+  // tasks through one fast worker) would leave a worker at zero calls yet
+  // produce identical offspring. We now assert the observable contract: the
+  // batch yields valid offspring, and — tolerantly — that work is spread
+  // across the pool rather than funnelled through a single worker.
   const { genus } = createTestPopulation(30, 5, 2);
   const config = createNeatConfig({
     populationSize: 30,
     geneticCompatibilityThreshold: 0.3,
   });
 
-  // Track how many times each mock worker is called
+  // Track how many times each mock worker is called, without asserting on
+  // the exact per-worker distribution.
   const callCounts = [0, 0, 0];
   const mockWorkers = callCounts.map((_, index) => {
     return {
@@ -464,13 +472,29 @@ Deno.test("ParallelBreeding - worker path distributes work across all workers", 
   });
 
   const parallelBreeding = new ParallelBreeding(genus, config, mockWorkers);
-  await parallelBreeding.breedBatch(20);
+  const offspring = await parallelBreeding.breedBatch(30);
 
-  // Each worker should have been called at least once
-  for (let i = 0; i < callCounts.length; i++) {
-    assert(
-      callCounts[i] > 0,
-      `Worker ${i} should have been called at least once, got ${callCounts[i]}`,
-    );
+  // Observable outcome: breeding the batch via the worker pool produces
+  // valid offspring with the expected shape.
+  assert(offspring.length > 0, "Worker breeding should produce offspring");
+  for (const child of offspring) {
+    child.validate();
+    assertEquals(child.input, 5, "Offspring should have correct input count");
+    assertEquals(child.output, 2, "Offspring should have correct output count");
   }
+
+  // Tolerant load-spreading check: the pool processed the batch and no single
+  // worker handled the entire workload. This survives any distribution
+  // strategy that genuinely uses more than one worker, without demanding a
+  // specific per-worker count.
+  const totalCalls = callCounts.reduce((sum, count) => sum + count, 0);
+  assert(totalCalls > 0, "The worker pool should have processed the batch");
+  const workersUsed = callCounts.filter((count) => count > 0).length;
+  assert(
+    workersUsed > 1,
+    `Work should be spread across the pool, not funnelled through one worker; ` +
+      `workers used: ${workersUsed} of ${callCounts.length} (calls: ${
+        callCounts.join(", ")
+      })`,
+  );
 });


### PR DESCRIPTION
## Summary

Removed a HOW-test anti-pattern from `test/breed/ParallelBreeding.ts`. The test
`ParallelBreeding - worker path distributes work across all workers` asserted
that **every** mock worker was called at least once — coupling the test to the
scheduler's internal distribution strategy. A behaviour-preserving change (e.g.
a work-stealing scheduler that drains tasks through one fast worker, or a change
in pool sizing) would produce identical offspring yet leave a worker at zero
calls and break the test.

The test now asserts the **observable contract** of `breedBatch()`: the batch
yields valid offspring with the correct input/output shape. A **tolerant**
load-spreading check is retained — that the pool processed the batch and work
was spread across more than one worker — without demanding a specific per-worker
count. This survives any distribution strategy that genuinely uses the pool.

Closes #2837.

## Evidence

This is a test-only change (no production code touched), so there is no UI or
performance evidence. Verification is via the test suite.

```mermaid
flowchart LR
    A[breedBatch via worker pool] --> B[valid offspring produced]
    A --> C[work spread across pool]
    B -.->|assert outcome| D[input=5, output=2, validate]
    C -.->|tolerant assert| E[workers used > 1, not every worker]
```

- Targeted run: `deno test --allow-all test/breed/ParallelBreeding.ts` →
  `10 passed | 0 failed`.
- Full quality gate: `./quality.sh` → `7037 passed | 0 failed | 4 ignored`.

## Test Plan

- Renamed `ParallelBreeding - worker path distributes work across all workers`
  to `ParallelBreeding - worker path spreads a batch across the pool`.
- Replaced the per-worker `callCounts[i] > 0` loop (HOW-assertion) with:
  - outcome assertions: `offspring.length > 0`, each child `validate()`s with
    `input === 5` and `output === 2`;
  - a tolerant distribution assertion: total calls `> 0` and `workersUsed > 1`.
- No existing tests were removed or commented out; the sibling worker-path tests
  remain unchanged.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpwajllm-d98ea3`<!-- vibe-worker-issue-2837 -->