### PR TITLE
Replace fixture-dump assertions in Trace.ts with behavioural checks (#2839)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.10",
+  "version": "5.3.11",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2839.md
+++ b/docs/archive/pr-summaries/pr-summary-2839.md
@@ -16,16 +16,17 @@ Following suggestion (a) in the issue, `checkMemetic` now separates the two
 concerns:
 
 - **Kept (genuine WHAT-assertions)** — the documented UUID→integer key
-  migration: bias key `552c68d3-…` → `675812961`, weight key `input-115` → `115`,
-  and `weights[115][1].toId === 855726674`. These verify observable migration
-  behaviour and survive a fixture regeneration.
+  migration: bias key `552c68d3-…` → `675812961`, weight key `input-115` →
+  `115`, and `weights[115][1].toId === 855726674`. These verify observable
+  migration behaviour and survive a fixture regeneration.
 - **Replaced (fixture-dump magnitudes)** — exact counts/score/generation and the
   bias/weight magnitudes are now structural/finite checks: the memetic block
   exists with the expected shape, `generation` is an integer, `score` and the
-  migrated bias/weight values are finite, and neuron/synapse counts are positive.
+  migrated bias/weight values are finite, and neuron/synapse counts are
+  positive.
 - **Node-count test** — `nodeState.count === 1386` is now `Number.isInteger` and
-  `> 0`, asserting the trace state restores a positive accumulation count without
-  echoing the fixture magnitude.
+  `> 0`, asserting the trace state restores a positive accumulation count
+  without echoing the fixture magnitude.
 
 No production code changed — `Creature.fromJSON` migration behaviour is
 unchanged. This is a test-quality refactor.

--- a/docs/archive/pr-summaries/pr-summary-2839.md
+++ b/docs/archive/pr-summaries/pr-summary-2839.md
@@ -1,0 +1,71 @@
+## Summary
+
+Removed the hard-coded fixture-dump (HOW-test) assertions from
+`test/propagate/Trace.ts` and kept only the assertions that protect real
+behaviour. Closes #2839.
+
+The test previously pasted raw magnitudes straight out of
+`test/data/traced.json` — `neurons.length === 1001`, `synapses.length === 2449`,
+`memetic.generation === 6`, `memetic.score === 0.47133930519315353`, the exact
+bias/weight magnitudes (`0.0001412`, `0.1234`), and `nodeState.count === 1386`.
+These carry no spec or rationale: they assert "the fixture currently contains
+these numbers", so regenerating `traced.json` (or any change that alters stored
+magnitudes while preserving behaviour) broke the test for a non-regression.
+
+Following suggestion (a) in the issue, `checkMemetic` now separates the two
+concerns:
+
+- **Kept (genuine WHAT-assertions)** — the documented UUID→integer key
+  migration: bias key `552c68d3-…` → `675812961`, weight key `input-115` → `115`,
+  and `weights[115][1].toId === 855726674`. These verify observable migration
+  behaviour and survive a fixture regeneration.
+- **Replaced (fixture-dump magnitudes)** — exact counts/score/generation and the
+  bias/weight magnitudes are now structural/finite checks: the memetic block
+  exists with the expected shape, `generation` is an integer, `score` and the
+  migrated bias/weight values are finite, and neuron/synapse counts are positive.
+- **Node-count test** — `nodeState.count === 1386` is now `Number.isInteger` and
+  `> 0`, asserting the trace state restores a positive accumulation count without
+  echoing the fixture magnitude.
+
+No production code changed — `Creature.fromJSON` migration behaviour is
+unchanged. This is a test-quality refactor.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+Targeted test run after the refactor (all 5 tests pass):
+
+```
+running 5 tests from ./test/propagate/Trace.ts
+Trace - loads creature with memetic data from JSON ... ok
+Trace - loads creature trace state with a positive node count ... ok
+Trace - traceJSON round-trip preserves memetic data ... ok
+Trace - exportJSON round-trip preserves memetic data ... ok
+Trace - applyLearnings modifies creature and remains valid ... ok
+
+ok | 5 passed | 0 failed
+```
+
+`./quality.sh --lint-only` and `./quality.sh --check-only` both pass cleanly.
+
+```mermaid
+flowchart LR
+    F[(traced.json fixture)] -->|fromJSON| C[Creature]
+    C --> K{checkMemetic}
+    K -->|KEEP| M[UUID→integer key migration<br/>675812961 · weights·115· · toId 855726674]
+    K -->|REPLACE| S[Structural / finite checks<br/>shape · Number.isFinite · counts > 0]
+    K -.->|REMOVED| D[Raw magnitude dumps<br/>1001 · 2449 · gen 6 · 0.4713… · count 1386]
+```
+
+## Test Plan
+
+- Modified `test/propagate/Trace.ts`:
+  - `checkMemetic` — retains the three documented migration assertions; replaces
+    fixture magnitudes with shape + `Number.isFinite` + positive-count checks.
+  - Renamed `Trace - loads creature trace state with correct node count` →
+    `… with a positive node count`; asserts `Number.isInteger` and `> 0` instead
+    of the exact `1386`.
+  - Dropped the now-unused `assertAlmostEquals` import.
+- Verified all 5 tests in the file pass after the change.
+- No existing tests were commented out or removed.

--- a/test/propagate/Trace.ts
+++ b/test/propagate/Trace.ts
@@ -1,34 +1,42 @@
 import { createBackPropagationConfig } from "@propagate/BackPropagation.ts";
 import { Creature } from "@creature";
 import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
-import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 
 ((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
 
+// Verifies the observable behaviour of loading a creature with memetic data:
+// the creature is structurally valid, the memetic block has the expected
+// shape with finite values, and the UUID→integer key migration produced the
+// expected integer keys. Exact fixture magnitudes (generation/score/bias/weight
+// values, neuron/synapse counts) are intentionally NOT asserted — those are
+// fixture-dump values that change when `traced.json` is regenerated without any
+// behavioural regression (Issue #2839).
 function checkMemetic(creature: Creature) {
   creature.validate();
-  assertEquals(creature.neurons.length, 1001);
-  assertEquals(creature.synapses.length, 2449);
+
+  // Structural: the fixture loaded with neurons and synapses present.
+  assert(creature.neurons.length > 0);
+  assert(creature.synapses.length > 0);
+
+  // The memetic block exists with the expected shape and finite values.
   assert(creature.memetic);
-  assert(creature.memetic.generation === 6);
-  assert(creature.memetic.score === 0.47133930519315353);
+  assert(Number.isInteger(creature.memetic.generation));
+  assert(Number.isFinite(creature.memetic.score));
   assert(creature.memetic.biases);
-  // After UUID→integer migration, bias key "552c68d3-6ea2-4e0c-a6bb-d7d1b0ad2661" → 675812961
-  assertAlmostEquals(
-    creature.memetic.biases[675812961],
-    0.0001412,
-  );
   assert(creature.memetic.weights);
-  // After UUID→integer migration, weight key "input-115" (input neuron index 115) → 115
+
+  // WHAT: UUID→integer bias-key migration produced the expected integer key.
+  // bias key "552c68d3-6ea2-4e0c-a6bb-d7d1b0ad2661" → 675812961
+  assert(creature.memetic.biases[675812961] !== undefined);
+  assert(Number.isFinite(creature.memetic.biases[675812961]));
+
+  // WHAT: UUID→integer weight-key migration.
+  // weight key "input-115" (input neuron index 115) → 115
   assert(creature.memetic.weights[115]);
   // "115b0169-65c3-4c87-9904-316bae966a6f" → 855726674
-  assert(
-    creature.memetic.weights[115][1].toId === 855726674,
-  );
-  assertAlmostEquals(
-    creature.memetic.weights[115][1].weight,
-    0.1234,
-  );
+  assert(creature.memetic.weights[115][1].toId === 855726674);
+  assert(Number.isFinite(creature.memetic.weights[115][1].weight));
 }
 
 Deno.test("Trace - loads creature with memetic data from JSON", () => {
@@ -38,12 +46,16 @@ Deno.test("Trace - loads creature with memetic data from JSON", () => {
   checkMemetic(creature);
 });
 
-Deno.test("Trace - loads creature trace state with correct node count", () => {
+Deno.test("Trace - loads creature trace state with a positive node count", () => {
   const creature = Creature.fromJSON(
     JSON.parse(Deno.readTextFileSync("test/data/traced.json")),
   );
   const nodeState = creature.state.node(999);
-  assertEquals(nodeState.count, 1386);
+  // WHAT: the persisted trace state restores a node accumulation count.
+  // The exact magnitude is a fixture-dump value (Issue #2839) — assert it is a
+  // positive integer rather than echoing the current fixture number.
+  assert(Number.isInteger(nodeState.count));
+  assert(nodeState.count > 0);
 });
 
 Deno.test("Trace - traceJSON round-trip preserves memetic data", () => {


### PR DESCRIPTION
## Summary

Removed the hard-coded fixture-dump (HOW-test) assertions from
`test/propagate/Trace.ts` and kept only the assertions that protect real
behaviour. Closes #2839.

The test previously pasted raw magnitudes straight out of
`test/data/traced.json` — `neurons.length === 1001`, `synapses.length === 2449`,
`memetic.generation === 6`, `memetic.score === 0.47133930519315353`, the exact
bias/weight magnitudes (`0.0001412`, `0.1234`), and `nodeState.count === 1386`.
These carry no spec or rationale: they assert "the fixture currently contains
these numbers", so regenerating `traced.json` (or any change that alters stored
magnitudes while preserving behaviour) broke the test for a non-regression.

Following suggestion (a) in the issue, `checkMemetic` now separates the two
concerns:

- **Kept (genuine WHAT-assertions)** — the documented UUID→integer key
  migration: bias key `552c68d3-…` → `675812961`, weight key `input-115` → `115`,
  and `weights[115][1].toId === 855726674`. These verify observable migration
  behaviour and survive a fixture regeneration.
- **Replaced (fixture-dump magnitudes)** — exact counts/score/generation and the
  bias/weight magnitudes are now structural/finite checks: the memetic block
  exists with the expected shape, `generation` is an integer, `score` and the
  migrated bias/weight values are finite, and neuron/synapse counts are positive.
- **Node-count test** — `nodeState.count === 1386` is now `Number.isInteger` and
  `> 0`, asserting the trace state restores a positive accumulation count without
  echoing the fixture magnitude.

No production code changed — `Creature.fromJSON` migration behaviour is
unchanged. This is a test-quality refactor.

## Evidence

Backend/test-only change — no web interface to screenshot.

Targeted test run after the refactor (all 5 tests pass):

```
running 5 tests from ./test/propagate/Trace.ts
Trace - loads creature with memetic data from JSON ... ok
Trace - loads creature trace state with a positive node count ... ok
Trace - traceJSON round-trip preserves memetic data ... ok
Trace - exportJSON round-trip preserves memetic data ... ok
Trace - applyLearnings modifies creature and remains valid ... ok

ok | 5 passed | 0 failed
```

`./quality.sh --lint-only` and `./quality.sh --check-only` both pass cleanly.

```mermaid
flowchart LR
    F[(traced.json fixture)] -->|fromJSON| C[Creature]
    C --> K{checkMemetic}
    K -->|KEEP| M[UUID→integer key migration<br/>675812961 · weights·115· · toId 855726674]
    K -->|REPLACE| S[Structural / finite checks<br/>shape · Number.isFinite · counts > 0]
    K -.->|REMOVED| D[Raw magnitude dumps<br/>1001 · 2449 · gen 6 · 0.4713… · count 1386]
```

## Test Plan

- Modified `test/propagate/Trace.ts`:
  - `checkMemetic` — retains the three documented migration assertions; replaces
    fixture magnitudes with shape + `Number.isFinite` + positive-count checks.
  - Renamed `Trace - loads creature trace state with correct node count` →
    `… with a positive node count`; asserts `Number.isInteger` and `> 0` instead
    of the exact `1386`.
  - Dropped the now-unused `assertAlmostEquals` import.
- Verified all 5 tests in the file pass after the change.
- No existing tests were commented out or removed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpwfsxat-2cb0cd`<!-- vibe-worker-issue-2839 -->