### PR TITLE
Test: replace activation benchmark with finite-output assertion (#2848)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.11",
+  "version": "5.3.12",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2848.md
+++ b/docs/archive/pr-summaries/pr-summary-2848.md
@@ -1,0 +1,48 @@
+## Summary
+
+Replaced a benchmark masquerading as a unit test in
+`test/methods/activations/SquashLookupTable.ts`. The old case
+`"Squash lookup table - performance comparable to original"` warmed up a
+creature, ran a 1000-iteration `creature.activate()` timing loop wrapped in
+`performance.now()`, printed per-iteration time via `console.log`, and finished
+with the tautological assertion `timePerIteration > 0` — which any running loop
+satisfies. The case verified no correctness, slowed the unit suite, and emitted
+log noise (test-audit anti-pattern #4).
+
+It is now rewritten as a proper WHAT-test
+(`"Squash lookup table - large creature produces finite output for varied
+inputs"`) that asserts the observable behaviour the surrounding tests care
+about: the `traced.json` creature — which exercises many lookup-table squash
+functions — produces a finite output of the expected width for a deterministic
+spread of varied inputs. The timing loop, warm-up, `console.log`, and
+non-deterministic `Math.random` inputs are all removed; throughput measurement
+belongs in a dedicated benchmark, not the unit runner.
+
+Closes #2848.
+
+## Evidence
+
+Backend/test-only change — no UI to screenshot. Verified via the test runner.
+
+Before: 1000-iteration timing loop + warm-up, single tautological assertion,
+`console.log` noise.
+After: deterministic finite-output assertions; file runs in ~15ms.
+
+```
+running 5 tests from ./test/methods/activations/SquashLookupTable.ts
+Squash lookup table - WASM activation runs ... ok
+Squash lookup table - activation produces correct output ... ok
+Squash lookup table - consistent with traced.json creature ... ok
+Squash lookup table - handles all non-inline squash functions ... ok
+Squash lookup table - large creature produces finite output for varied inputs ... ok
+ok | 5 passed | 0 failed
+```
+
+## Test Plan
+
+- Rewrote `test/methods/activations/SquashLookupTable.ts::"Squash lookup table -
+  large creature produces finite output for varied inputs"` to assert output
+  width and finiteness across 16 deterministic input vectors, replacing the
+  former timing-loop case.
+- Ran the file: 5 passed / 0 failed.
+- Ran the full `./quality.sh` gate (fmt, lint, type-check, tests).

--- a/docs/archive/pr-summaries/pr-summary-2848.md
+++ b/docs/archive/pr-summaries/pr-summary-2848.md
@@ -11,12 +11,13 @@ log noise (test-audit anti-pattern #4).
 
 It is now rewritten as a proper WHAT-test
 (`"Squash lookup table - large creature produces finite output for varied
-inputs"`) that asserts the observable behaviour the surrounding tests care
-about: the `traced.json` creature — which exercises many lookup-table squash
-functions — produces a finite output of the expected width for a deterministic
-spread of varied inputs. The timing loop, warm-up, `console.log`, and
-non-deterministic `Math.random` inputs are all removed; throughput measurement
-belongs in a dedicated benchmark, not the unit runner.
+inputs"`)
+that asserts the observable behaviour the surrounding tests care about: the
+`traced.json` creature — which exercises many lookup-table squash functions —
+produces a finite output of the expected width for a deterministic spread of
+varied inputs. The timing loop, warm-up, `console.log`, and non-deterministic
+`Math.random` inputs are all removed; throughput measurement belongs in a
+dedicated benchmark, not the unit runner.
 
 Closes #2848.
 
@@ -25,8 +26,8 @@ Closes #2848.
 Backend/test-only change — no UI to screenshot. Verified via the test runner.
 
 Before: 1000-iteration timing loop + warm-up, single tautological assertion,
-`console.log` noise.
-After: deterministic finite-output assertions; file runs in ~15ms.
+`console.log` noise. After: deterministic finite-output assertions; file runs in
+~15ms.
 
 ```
 running 5 tests from ./test/methods/activations/SquashLookupTable.ts
@@ -40,9 +41,10 @@ ok | 5 passed | 0 failed
 
 ## Test Plan
 
-- Rewrote `test/methods/activations/SquashLookupTable.ts::"Squash lookup table -
-  large creature produces finite output for varied inputs"` to assert output
-  width and finiteness across 16 deterministic input vectors, replacing the
-  former timing-loop case.
+- Rewrote
+  `test/methods/activations/SquashLookupTable.ts::"Squash lookup table -
+  large creature produces finite output for varied inputs"`
+  to assert output width and finiteness across 16 deterministic input vectors,
+  replacing the former timing-loop case.
 - Ran the file: 5 passed / 0 failed.
 - Ran the full `./quality.sh` gate (fmt, lint, type-check, tests).

--- a/test/methods/activations/SquashLookupTable.ts
+++ b/test/methods/activations/SquashLookupTable.ts
@@ -257,49 +257,41 @@ Deno.test("Squash lookup table - handles all non-inline squash functions", () =>
   }
 });
 
-Deno.test("Squash lookup table - performance comparable to original", () => {
-  // Create a creature similar to the acceptance criteria:
-  // "2000 observations, 700 hidden neurons and 18000 synapses"
-  // For the test, we'll use a scaled-down version
-
+Deno.test("Squash lookup table - large creature produces finite output for varied inputs", () => {
+  // The traced.json creature exercises many lookup-table squash functions.
+  // Assert the observable behaviour: every input yields a finite output of
+  // the expected width. Throughput is measured separately in a benchmark,
+  // not asserted here.
   const creature = Creature.fromJSON(
     JSON.parse(Deno.readTextFileSync("test/data/traced.json")),
   );
   creature.fix();
 
-  // Generate inputs for testing
+  // Deterministic spread of inputs across the [-2, 2] range, so the test is
+  // reproducible (no Math.random) while still covering varied activations.
   const inputs: Float32Array[] = [];
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 16; i++) {
     const input = new Float32Array(creature.input);
     for (let j = 0; j < creature.input; j++) {
-      input[j] = Math.random() * 4 - 2;
+      // Map (i, j) onto [-2, 2] deterministically.
+      input[j] = ((((i + 1) * (j + 1)) % 41) / 10) - 2;
     }
     inputs.push(input);
   }
 
-  // Warm up
-  creature.clearState();
   for (const input of inputs) {
-    creature.activate(input, false);
+    creature.clearState();
+    const output = creature.activate(input, false);
+
+    assertEquals(
+      output.length,
+      creature.output,
+      "activation output width should match creature.output",
+    );
+    assertEquals(
+      output.every(Number.isFinite),
+      true,
+      "activation output must be finite for every input",
+    );
   }
-
-  // Measure performance
-  const iterations = 1000;
-  creature.clearState();
-
-  const start = performance.now();
-  for (let i = 0; i < iterations; i++) {
-    const input = inputs[i % inputs.length];
-    creature.activate(input, false);
-  }
-  const end = performance.now();
-
-  const timePerIteration = (end - start) / iterations;
-  console.log(
-    `Activation time per iteration: ${timePerIteration.toFixed(3)}ms`,
-  );
-
-  // The test passes if activation completes successfully
-  // The actual performance comparison is done in the benchmark
-  assertEquals(timePerIteration > 0, true, "Should complete in positive time");
 });


### PR DESCRIPTION
## Summary

Replaced a benchmark masquerading as a unit test in
`test/methods/activations/SquashLookupTable.ts`. The old case
`"Squash lookup table - performance comparable to original"` warmed up a
creature, ran a 1000-iteration `creature.activate()` timing loop wrapped in
`performance.now()`, printed per-iteration time via `console.log`, and finished
with the tautological assertion `timePerIteration > 0` — which any running loop
satisfies. The case verified no correctness, slowed the unit suite, and emitted
log noise (test-audit anti-pattern #4).

It is now rewritten as a proper WHAT-test
(`"Squash lookup table - large creature produces finite output for varied
inputs"`) that asserts the observable behaviour the surrounding tests care
about: the `traced.json` creature — which exercises many lookup-table squash
functions — produces a finite output of the expected width for a deterministic
spread of varied inputs. The timing loop, warm-up, `console.log`, and
non-deterministic `Math.random` inputs are all removed; throughput measurement
belongs in a dedicated benchmark, not the unit runner.

Closes #2848.

## Evidence

Backend/test-only change — no UI to screenshot. Verified via the test runner.

Before: 1000-iteration timing loop + warm-up, single tautological assertion,
`console.log` noise.
After: deterministic finite-output assertions; file runs in ~15ms.

```
running 5 tests from ./test/methods/activations/SquashLookupTable.ts
Squash lookup table - WASM activation runs ... ok
Squash lookup table - activation produces correct output ... ok
Squash lookup table - consistent with traced.json creature ... ok
Squash lookup table - handles all non-inline squash functions ... ok
Squash lookup table - large creature produces finite output for varied inputs ... ok
ok | 5 passed | 0 failed
```

## Test Plan

- Rewrote `test/methods/activations/SquashLookupTable.ts::"Squash lookup table -
  large creature produces finite output for varied inputs"` to assert output
  width and finiteness across 16 deterministic input vectors, replacing the
  former timing-loop case.
- Ran the file: 5 passed / 0 failed.
- Ran the full `./quality.sh` gate (fmt, lint, type-check, tests).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpwfr229-f2fa86`<!-- vibe-worker-issue-2848 -->