### PR TITLE
Test: replace HOW-assertions on private DiscoverStructure methods (#2849)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.12",
+  "version": "5.3.13",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2849.md
+++ b/docs/archive/pr-summaries/pr-summary-2849.md
@@ -1,0 +1,62 @@
+# Replace HOW-assertions on private DiscoverStructure methods with public-surface calls (Issue #2849)
+
+## Summary
+
+Two test files asserted on **private** `DiscoverStructure` methods reached
+through `as unknown as` casts — anti-pattern #1 (testing implementation
+internals the public API does not expose). A behaviour-preserving refactor
+(renaming/inlining the helpers, or the in-progress TypeScript→Rust migration)
+would leave the observable discovery output unchanged yet break these tests,
+because the private methods they reached for would vanish.
+
+In all three cases the private method is just a thin delegator to a
+**documented, module-level exported function**. The fix points the tests at
+that stable public surface instead of casting through `unknown`:
+
+- `mapRustNeuronCandidate` / `mapRustCandidate` →
+  `DiscoverAnalysis.ts` exports `mapRustNeuronCandidate` / `mapRustCandidate`.
+- `findCandidateSquash` →
+  `DiscoverSquashAnalysis.ts` exports `findCandidateSquash`.
+
+No production code changed — the asserted behaviour (a Rust candidate's optional
+`comment` survives mapping; which squash candidate is selected and how its
+error/impact scale) is identical. The squash test mirrors the facade's
+estimator/index-map caching via a small `makeImpactFn` closure backed by the
+public `calculateNeuronImpact`, so `findCandidateSquash` sees the same inputs as
+the production call site.
+
+Closes #2849.
+
+```mermaid
+flowchart LR
+    subgraph Before
+      T1[Test] -->|as unknown as cast| P1[private method]
+      P1 --> F1[exported fn]
+    end
+    subgraph After
+      T2[Test] -->|direct import| F2[exported fn]
+    end
+```
+
+## Evidence
+
+Backend/test-only change — no UI to screenshot. Verified by running the two
+affected files and the full quality gate:
+
+- Targeted: `deno test test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts test/discovery/DiscoverStructureSquash.ts` → `4 passed | 0 failed`.
+- Full `./quality.sh` (fmt + lint + type-check + all tests) → `7037 passed | 0 failed | 4 ignored`.
+
+The squash test retains its original assertions (`currentError ≈ 1`,
+`expectedCreatureScoreGain < 1e-4`), confirming the observable behaviour is
+unchanged after dropping the cast.
+
+## Test Plan
+
+- Rewrote `test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts`
+  to call the exported `mapRustNeuronCandidate` / `mapRustCandidate` directly,
+  removing the `DiscoverStructurePrivateApi` shape, the `as unknown as` cast, and
+  the now-unnecessary `DiscoverStructure` instantiation and temp-dir plumbing.
+- Rewrote `test/discovery/DiscoverStructureSquash.ts` to call the exported
+  `findCandidateSquash` directly, supplying a `calculateNeuronImpact`-backed
+  closure in place of the private instance method and the `internal` cast.
+- No tests removed or disabled; both files retain their original assertions.

--- a/docs/archive/pr-summaries/pr-summary-2849.md
+++ b/docs/archive/pr-summaries/pr-summary-2849.md
@@ -10,13 +10,13 @@ would leave the observable discovery output unchanged yet break these tests,
 because the private methods they reached for would vanish.
 
 In all three cases the private method is just a thin delegator to a
-**documented, module-level exported function**. The fix points the tests at
-that stable public surface instead of casting through `unknown`:
+**documented, module-level exported function**. The fix points the tests at that
+stable public surface instead of casting through `unknown`:
 
-- `mapRustNeuronCandidate` / `mapRustCandidate` →
-  `DiscoverAnalysis.ts` exports `mapRustNeuronCandidate` / `mapRustCandidate`.
-- `findCandidateSquash` →
-  `DiscoverSquashAnalysis.ts` exports `findCandidateSquash`.
+- `mapRustNeuronCandidate` / `mapRustCandidate` → `DiscoverAnalysis.ts` exports
+  `mapRustNeuronCandidate` / `mapRustCandidate`.
+- `findCandidateSquash` → `DiscoverSquashAnalysis.ts` exports
+  `findCandidateSquash`.
 
 No production code changed — the asserted behaviour (a Rust candidate's optional
 `comment` survives mapping; which squash candidate is selected and how its
@@ -43,8 +43,11 @@ flowchart LR
 Backend/test-only change — no UI to screenshot. Verified by running the two
 affected files and the full quality gate:
 
-- Targeted: `deno test test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts test/discovery/DiscoverStructureSquash.ts` → `4 passed | 0 failed`.
-- Full `./quality.sh` (fmt + lint + type-check + all tests) → `7037 passed | 0 failed | 4 ignored`.
+- Targeted:
+  `deno test test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts test/discovery/DiscoverStructureSquash.ts`
+  → `4 passed | 0 failed`.
+- Full `./quality.sh` (fmt + lint + type-check + all tests) →
+  `7037 passed | 0 failed | 4 ignored`.
 
 The squash test retains its original assertions (`currentError ≈ 1`,
 `expectedCreatureScoreGain < 1e-4`), confirming the observable behaviour is
@@ -52,10 +55,12 @@ unchanged after dropping the cast.
 
 ## Test Plan
 
-- Rewrote `test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts`
+- Rewrote
+  `test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts`
   to call the exported `mapRustNeuronCandidate` / `mapRustCandidate` directly,
-  removing the `DiscoverStructurePrivateApi` shape, the `as unknown as` cast, and
-  the now-unnecessary `DiscoverStructure` instantiation and temp-dir plumbing.
+  removing the `DiscoverStructurePrivateApi` shape, the `as unknown as` cast,
+  and the now-unnecessary `DiscoverStructure` instantiation and temp-dir
+  plumbing.
 - Rewrote `test/discovery/DiscoverStructureSquash.ts` to call the exported
   `findCandidateSquash` directly, supplying a `calculateNeuronImpact`-backed
   closure in place of the private instance method and the `internal` cast.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -98,6 +98,7 @@
     "dedup",
     "dedupe",
     "deduplicator",
+    "delegator",
     "delisting",
     "deltaed",
     "denom",

--- a/test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts
+++ b/test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts
@@ -1,159 +1,105 @@
 import { assertEquals } from "@std/assert";
-import { Creature } from "@creature";
-import { CreatureUtil } from "@architecture/CreatureUtils.ts";
-import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import {
+  mapRustCandidate,
+  mapRustNeuronCandidate,
+} from "@architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts";
 import type {
   RustCandidateNeuron,
   RustCandidateSynapse,
 } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
-import type {
-  CandidateNeuron,
-  CandidateSynapse,
-} from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts";
 
-type DiscoverStructurePrivateApi = {
-  mapRustNeuronCandidate: (
-    candidate: RustCandidateNeuron,
-  ) => CandidateNeuron;
-  mapRustCandidate: (candidate: RustCandidateSynapse) => CandidateSynapse;
-};
-
-function makeCreatureWithUuid(): Creature {
-  const creature = Creature.fromJSON({
-    input: 1,
-    output: 1,
-    neurons: [
-      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
-    ],
-    synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 1 }],
-  });
-  creature.validate();
-  CreatureUtil.makeUUID(creature);
-  return creature;
-}
+// Issue #2849: These tests previously reached the private
+// `DiscoverStructure.mapRustNeuronCandidate` / `mapRustCandidate` methods
+// through an `as unknown as` cast, coupling them to the class's internal
+// factoring. The mapping logic is exposed as documented public functions in
+// DiscoverAnalysis.ts, so we exercise that stable surface directly. The
+// observable WHAT — a Rust candidate's optional `comment` survives the mapping
+// into the TypeScript candidate shape — is unchanged.
 
 Deno.test(
-  "Rust discovery candidate parsing succeeds with optional comment field",
+  "Rust discovery candidate mapping preserves the optional comment field",
   () => {
-    const baseDirectory = Deno.makeTempDirSync({ prefix: "neat-ai-comment-" });
-    try {
-      const discoverStructure = new DiscoverStructure(
-        makeCreatureWithUuid(),
-        1,
-        1,
-        {},
-        { baseDirectory, skipRecordPhase: true },
-      );
+    const parsedNeuron = JSON.parse(JSON.stringify({
+      sourceNeuronUuid: "input-0",
+      targetNeuronUuid: "output-0",
+      incomingWeight: 0.42,
+      outgoingWeight: -0.13,
+      squash: "TANH",
+      bias: 0.01,
+      targetNeuronImpact: 1.0,
+      expectedCreatureErrorReduction: 0.0,
+      expectedCreatureScoreGain: 0.123,
+      improvedCount: 4,
+      totalCount: 5,
+      comment: "diagnostic: add-neuron suggested due to error spike cluster",
+    })) as RustCandidateNeuron;
 
-      const neuronJson = JSON.stringify({
-        sourceNeuronUuid: "input-0",
-        targetNeuronUuid: "output-0",
-        incomingWeight: 0.42,
-        outgoingWeight: -0.13,
-        squash: "TANH",
-        bias: 0.01,
-        targetNeuronImpact: 1.0,
-        expectedCreatureErrorReduction: 0.0,
-        expectedCreatureScoreGain: 0.123,
-        improvedCount: 4,
-        totalCount: 5,
-        comment: "diagnostic: add-neuron suggested due to error spike cluster",
-      });
+    const mappedNeuron = mapRustNeuronCandidate(parsedNeuron);
+    assertEquals(
+      mappedNeuron.comment,
+      "diagnostic: add-neuron suggested due to error spike cluster",
+    );
+    assertEquals(mappedNeuron.fromNeuronUuid, "input-0");
+    assertEquals(mappedNeuron.toNeuronUuid, "output-0");
 
-      const parsedNeuron = JSON.parse(neuronJson) as RustCandidateNeuron;
-      const mappedNeuron =
-        (discoverStructure as unknown as DiscoverStructurePrivateApi)
-          .mapRustNeuronCandidate(parsedNeuron);
-      assertEquals(
-        mappedNeuron.comment,
-        "diagnostic: add-neuron suggested due to error spike cluster",
-      );
-      assertEquals(mappedNeuron.fromNeuronUuid, "input-0");
-      assertEquals(mappedNeuron.toNeuronUuid, "output-0");
+    const parsedSynapse = JSON.parse(JSON.stringify({
+      fromNeuronUuid: "input-0",
+      toNeuronUuid: "output-0",
+      weight: 0.99,
+      targetNeuronImpact: 1.0,
+      expectedCreatureErrorReduction: 0.0,
+      expectedCreatureScoreGain: 0.5,
+      improvedCount: 8,
+      totalCount: 10,
+      comment: "diagnostic: add-synapse chosen as strongest source",
+    })) as RustCandidateSynapse;
 
-      const synapseJson = JSON.stringify({
-        fromNeuronUuid: "input-0",
-        toNeuronUuid: "output-0",
-        weight: 0.99,
-        targetNeuronImpact: 1.0,
-        expectedCreatureErrorReduction: 0.0,
-        expectedCreatureScoreGain: 0.5,
-        improvedCount: 8,
-        totalCount: 10,
-        comment: "diagnostic: add-synapse chosen as strongest source",
-      });
-
-      const parsedSynapse = JSON.parse(synapseJson) as RustCandidateSynapse;
-      const mappedSynapse =
-        (discoverStructure as unknown as DiscoverStructurePrivateApi)
-          .mapRustCandidate(parsedSynapse);
-      assertEquals(
-        mappedSynapse.comment,
-        "diagnostic: add-synapse chosen as strongest source",
-      );
-      assertEquals(mappedSynapse.fromNeuronUuid, "input-0");
-      assertEquals(mappedSynapse.toNeuronUuid, "output-0");
-    } finally {
-      Deno.removeSync(baseDirectory, { recursive: true });
-    }
+    const mappedSynapse = mapRustCandidate(parsedSynapse);
+    assertEquals(
+      mappedSynapse.comment,
+      "diagnostic: add-synapse chosen as strongest source",
+    );
+    assertEquals(mappedSynapse.fromNeuronUuid, "input-0");
+    assertEquals(mappedSynapse.toNeuronUuid, "output-0");
   },
 );
 
 Deno.test(
-  "Rust discovery candidate parsing succeeds when comment is absent",
+  "Rust discovery candidate mapping leaves comment undefined when absent",
   () => {
-    const baseDirectory = Deno.makeTempDirSync({ prefix: "neat-ai-comment-" });
-    try {
-      const discoverStructure = new DiscoverStructure(
-        makeCreatureWithUuid(),
-        1,
-        1,
-        {},
-        { baseDirectory, skipRecordPhase: true },
-      );
+    const parsedNeuron = JSON.parse(JSON.stringify({
+      sourceNeuronUuid: "input-0",
+      targetNeuronUuid: "output-0",
+      incomingWeight: 0.42,
+      outgoingWeight: -0.13,
+      squash: "TANH",
+      bias: 0.01,
+      targetNeuronImpact: 1.0,
+      expectedCreatureErrorReduction: 0.0,
+      expectedCreatureScoreGain: 0.123,
+      improvedCount: 4,
+      totalCount: 5,
+    })) as RustCandidateNeuron;
 
-      const neuronJson = JSON.stringify({
-        sourceNeuronUuid: "input-0",
-        targetNeuronUuid: "output-0",
-        incomingWeight: 0.42,
-        outgoingWeight: -0.13,
-        squash: "TANH",
-        bias: 0.01,
-        targetNeuronImpact: 1.0,
-        expectedCreatureErrorReduction: 0.0,
-        expectedCreatureScoreGain: 0.123,
-        improvedCount: 4,
-        totalCount: 5,
-      });
+    const mappedNeuron = mapRustNeuronCandidate(parsedNeuron);
+    assertEquals(mappedNeuron.comment, undefined);
+    assertEquals(mappedNeuron.fromNeuronUuid, "input-0");
+    assertEquals(mappedNeuron.toNeuronUuid, "output-0");
 
-      const parsedNeuron = JSON.parse(neuronJson) as RustCandidateNeuron;
-      const mappedNeuron =
-        (discoverStructure as unknown as DiscoverStructurePrivateApi)
-          .mapRustNeuronCandidate(parsedNeuron);
-      assertEquals(mappedNeuron.comment, undefined);
-      assertEquals(mappedNeuron.fromNeuronUuid, "input-0");
-      assertEquals(mappedNeuron.toNeuronUuid, "output-0");
+    const parsedSynapse = JSON.parse(JSON.stringify({
+      fromNeuronUuid: "input-0",
+      toNeuronUuid: "output-0",
+      weight: 0.99,
+      targetNeuronImpact: 1.0,
+      expectedCreatureErrorReduction: 0.0,
+      expectedCreatureScoreGain: 0.5,
+      improvedCount: 8,
+      totalCount: 10,
+    })) as RustCandidateSynapse;
 
-      const synapseJson = JSON.stringify({
-        fromNeuronUuid: "input-0",
-        toNeuronUuid: "output-0",
-        weight: 0.99,
-        targetNeuronImpact: 1.0,
-        expectedCreatureErrorReduction: 0.0,
-        expectedCreatureScoreGain: 0.5,
-        improvedCount: 8,
-        totalCount: 10,
-      });
-
-      const parsedSynapse = JSON.parse(synapseJson) as RustCandidateSynapse;
-      const mappedSynapse =
-        (discoverStructure as unknown as DiscoverStructurePrivateApi)
-          .mapRustCandidate(parsedSynapse);
-      assertEquals(mappedSynapse.comment, undefined);
-      assertEquals(mappedSynapse.fromNeuronUuid, "input-0");
-      assertEquals(mappedSynapse.toNeuronUuid, "output-0");
-    } finally {
-      Deno.removeSync(baseDirectory, { recursive: true });
-    }
+    const mappedSynapse = mapRustCandidate(parsedSynapse);
+    assertEquals(mappedSynapse.comment, undefined);
+    assertEquals(mappedSynapse.fromNeuronUuid, "input-0");
+    assertEquals(mappedSynapse.toNeuronUuid, "output-0");
   },
 );

--- a/test/discovery/DiscoverStructureSquash.ts
+++ b/test/discovery/DiscoverStructureSquash.ts
@@ -1,11 +1,12 @@
 import { assert, assertAlmostEquals } from "@std/assert";
 import { Creature } from "@creature";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
-import {
-  type CandidateSquash,
-  type DiscoverRecord,
-  DiscoverStructure,
+import type {
+  CandidateSquash,
+  DiscoverRecord,
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { findCandidateSquash } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts";
+import { calculateNeuronImpact } from "@architecture/ErrorGuidedStructuralEvolution/NeuronImpact.ts";
 import type { ActivationInterface } from "@methods/activations/ActivationInterface.ts";
 import { Activations } from "@methods/activations/Activations.ts";
 import { STEP } from "@methods/activations/types/STEP.ts";
@@ -14,6 +15,13 @@ import { ActivationRange } from "@propagate/ActivationRange.ts";
 // Integer IDs computed from deterministic UUID hash.
 const ID_HIDDEN_STEP = 891010353; // "hidden-step"
 const ID_HIDDEN_CHAIN = 1836654946; // "hidden-chain"
+
+// Issue #2849: These tests previously reached the private
+// `DiscoverStructure.findCandidateSquash` method through an `as unknown as`
+// cast, coupling them to the class's internal factoring. The squash-selection
+// logic is exposed as a documented public function in DiscoverSquashAnalysis.ts,
+// so we drive it directly. The observable WHAT — which squash candidate gets
+// suggested and its error/impact scaling — is unchanged.
 
 class LookupActivation implements ActivationInterface {
   public readonly range: ActivationRange;
@@ -38,6 +46,35 @@ class LookupActivation implements ActivationInterface {
   }
 }
 
+/**
+ * Builds an impact function with the same estimator/index-map caching the
+ * DiscoverStructure facade uses, so `findCandidateSquash` sees identical
+ * behaviour to the production call site.
+ */
+function makeImpactFn(
+  creature: Creature,
+): (neuronId: number, derivativeMap?: Map<number, number>) => number {
+  let estimator:
+    | ReturnType<typeof calculateNeuronImpact>["estimator"]
+    | undefined;
+  let indexMap: Map<number, number> | undefined;
+  return (neuronId, derivativeMap) => {
+    const result = calculateNeuronImpact(
+      creature,
+      neuronId,
+      estimator,
+      indexMap,
+      derivativeMap,
+    );
+    estimator = result.estimator;
+    indexMap = result.indexMap;
+    return result.impact;
+  };
+}
+
+// Discovery logging is irrelevant to these assertions.
+const noopLog = () => {};
+
 function makeStepLockedCreature(): Creature {
   const creature = Creature.fromJSON({
     input: 1,
@@ -58,7 +95,6 @@ function makeStepLockedCreature(): Creature {
 
 Deno.test("squash estimates are computed in activation domain", () => {
   const creature = makeStepLockedCreature();
-  const discover = new DiscoverStructure(creature, 30);
 
   const activations = Activations as unknown as {
     list: () => ActivationInterface[];
@@ -79,25 +115,19 @@ Deno.test("squash estimates are computed in activation domain", () => {
     { activation: 0, value: -6, errors: [12] },
   ];
 
-  const internal = discover as unknown as {
-    findCandidateSquash: (
-      neuronId: number,
-      recs: DiscoverRecord[],
-    ) => CandidateSquash | undefined;
-    tempDir: string;
-  };
-
   try {
-    const candidate = internal.findCandidateSquash(ID_HIDDEN_STEP, records);
+    const candidate: CandidateSquash | undefined = findCandidateSquash(
+      creature,
+      ID_HIDDEN_STEP,
+      records,
+      makeImpactFn(creature),
+      false,
+      noopLog,
+    );
     assert(candidate, "Expected a squash candidate to be suggested.");
     assertAlmostEquals(candidate.currentError, 1, 1e-6);
   } finally {
     activations.list = originalList;
-    try {
-      Deno.removeSync(internal.tempDir, { recursive: true });
-    } catch {
-      // Ignore if already cleaned.
-    }
   }
 });
 
@@ -122,7 +152,6 @@ function makeDilutedImpactCreature(): Creature {
 
 Deno.test("squash estimates scale by neuron impact to avoid inflated expectations", () => {
   const creature = makeDilutedImpactCreature();
-  const discover = new DiscoverStructure(creature, 30);
 
   const activations = Activations as unknown as {
     list: () => ActivationInterface[];
@@ -146,16 +175,15 @@ Deno.test("squash estimates scale by neuron impact to avoid inflated expectation
     { activation: 0.1, value: 0.1, errors: [largeError] },
   ];
 
-  const internal = discover as unknown as {
-    findCandidateSquash: (
-      neuronId: number,
-      recs: DiscoverRecord[],
-    ) => CandidateSquash | undefined;
-    tempDir: string;
-  };
-
   try {
-    const candidate = internal.findCandidateSquash(ID_HIDDEN_CHAIN, records);
+    const candidate: CandidateSquash | undefined = findCandidateSquash(
+      creature,
+      ID_HIDDEN_CHAIN,
+      records,
+      makeImpactFn(creature),
+      false,
+      noopLog,
+    );
     assert(
       candidate,
       "Expected diluted chain neuron to return a squash candidate.",
@@ -166,10 +194,5 @@ Deno.test("squash estimates scale by neuron impact to avoid inflated expectation
     );
   } finally {
     activations.list = originalList;
-    try {
-      Deno.removeSync(internal.tempDir, { recursive: true });
-    } catch {
-      // Ignore cleanup errors to keep the test resilient on CI.
-    }
   }
 });


### PR DESCRIPTION
# Replace HOW-assertions on private DiscoverStructure methods with public-surface calls (Issue #2849)

## Summary

Two test files asserted on **private** `DiscoverStructure` methods reached
through `as unknown as` casts — anti-pattern #1 (testing implementation
internals the public API does not expose). A behaviour-preserving refactor
(renaming/inlining the helpers, or the in-progress TypeScript→Rust migration)
would leave the observable discovery output unchanged yet break these tests,
because the private methods they reached for would vanish.

In all three cases the private method is just a thin delegator to a
**documented, module-level exported function**. The fix points the tests at that
stable public surface instead of casting through `unknown`:

- `mapRustNeuronCandidate` / `mapRustCandidate` → `DiscoverAnalysis.ts` exports
  `mapRustNeuronCandidate` / `mapRustCandidate`.
- `findCandidateSquash` → `DiscoverSquashAnalysis.ts` exports
  `findCandidateSquash`.

No production code changed — the asserted behaviour (a Rust candidate's optional
`comment` survives mapping; which squash candidate is selected and how its
error/impact scale) is identical. The squash test mirrors the facade's
estimator/index-map caching via a small `makeImpactFn` closure backed by the
public `calculateNeuronImpact`, so `findCandidateSquash` sees the same inputs as
the production call site.

Closes #2849.

```mermaid
flowchart LR
    subgraph Before
      T1[Test] -->|as unknown as cast| P1[private method]
      P1 --> F1[exported fn]
    end
    subgraph After
      T2[Test] -->|direct import| F2[exported fn]
    end
```

## Evidence

Backend/test-only change — no UI to screenshot. Verified by running the two
affected files and the full quality gate:

- Targeted:
  `deno test test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts test/discovery/DiscoverStructureSquash.ts`
  → `4 passed | 0 failed`.
- Full `./quality.sh` (fmt + lint + type-check + all tests) →
  `7037 passed | 0 failed | 4 ignored`.

The squash test retains its original assertions (`currentError ≈ 1`,
`expectedCreatureScoreGain < 1e-4`), confirming the observable behaviour is
unchanged after dropping the cast.

## Test Plan

- Rewrote
  `test/ErrorGuidedStructuralEvolution/RustDiscoveryCandidateCommentCompatibility.ts`
  to call the exported `mapRustNeuronCandidate` / `mapRustCandidate` directly,
  removing the `DiscoverStructurePrivateApi` shape, the `as unknown as` cast,
  and the now-unnecessary `DiscoverStructure` instantiation and temp-dir
  plumbing.
- Rewrote `test/discovery/DiscoverStructureSquash.ts` to call the exported
  `findCandidateSquash` directly, supplying a `calculateNeuronImpact`-backed
  closure in place of the private instance method and the `internal` cast.
- No tests removed or disabled; both files retain their original assertions.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpwmskeu-941274`<!-- vibe-worker-issue-2849 -->