### PR TITLE
Add scheduled OSV vulnerability scan workflow (Issue #2864)

### DIFF
--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,68 @@
+# Scheduled OSV vulnerability scan (Issue #2864 — SCR-VULN-SCAN)
+#
+# `dependency-review.yml` only inspects dependencies that change within a PR
+# diff, and `deno-outdated.yml` is a weekly *freshness* bump (newest version,
+# not "because of an advisory"). Neither alerts us when a CVE is disclosed
+# against an exact-pinned dependency we already ship (deno.json pins every
+# jsr:@std/* and jsr:@stsoftware/* import to an exact version).
+#
+# This workflow closes that detection gap: on a weekly schedule (and on
+# demand) it generates an *ephemeral* lockfile and scans the resolved
+# dependency tree against the OSV advisory database. osv-scanner exits
+# non-zero when it finds a known advisory, so the job fails and the signal is
+# actionable. deno.json's "lock": false policy is left intact — the lockfile
+# is produced only for the scan and never committed.
+name: OSV vulnerability scan
+
+on:
+  schedule:
+    # 07:00 UTC every Wednesday — mid-week, offset from the Monday
+    # deno-outdated bump so a CVE disclosed after Monday is caught within days
+    # rather than waiting for the next freshness run.
+    - cron: "0 7 * * 3"
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref so repeated manual dispatches don't
+# pile up redundant scans (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege GITHUB_TOKEN scopes (Issue #2706). The scan only reads the
+# repository and fails the job on findings; it never writes.
+permissions:
+  contents: read
+
+jobs:
+  osv-scan:
+    name: Scan resolved deps against the OSV database
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Setup Deno
+        # denoland/setup-deno@v2.0.4
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with:
+          deno-version: v2.x
+
+      - name: Generate ephemeral lockfile
+        # deno.json sets "lock": false, so pass --lock explicitly to write a
+        # transient deno.lock capturing the resolved tree. This file is NOT
+        # committed — it exists only for the scan step below.
+        run: deno cache --lock=deno.lock --no-check mod.ts
+
+      - name: Run OSV scanner
+        # google/osv-scanner-action@v2.3.8
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2
+        with:
+          # Scan the ephemeral lockfile so newly-disclosed advisories against
+          # the pinned @std/* and @stsoftware/* versions are surfaced between
+          # weekly bumps. osv-scanner exits non-zero on any known advisory.
+          scan-args: |-
+            --lockfile=./deno.lock

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,14 @@ opening a PR (see the secure-coding principles section of
 
 - **Dependency review** — every PR is scanned by
   [`actions/dependency-review-action`](https://github.com/actions/dependency-review-action)
-  via `.github/workflows/dependency-review.yml`.
+  via `.github/workflows/dependency-review.yml`. This is PR-diff scoped: it only
+  flags dependencies that change within a pull request.
+- **Scheduled vulnerability scan** — a weekly OSV scan
+  (`.github/workflows/osv-scan.yml`) re-checks the _whole_ resolved dependency
+  tree against the [OSV](https://osv.dev/) advisory database, catching CVEs
+  disclosed against an already-merged, exact-pinned dependency between bumps. It
+  generates an ephemeral lockfile for the scan and leaves `deno.json`'s
+  `"lock": false` policy intact.
 - **Static analysis (SAST)** — Semgrep runs on each PR via
   `.github/workflows/semgrep.yml`.
 - **Secret scanning** — `gitleaks` patterns live in `.gitleaks.toml` at the

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.14",
+  "version": "5.3.15",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2864.md
+++ b/docs/archive/pr-summaries/pr-summary-2864.md
@@ -1,0 +1,74 @@
+# SCR-VULN-SCAN: scheduled OSV vulnerability scan for pinned Deno deps
+
+## Summary
+
+Added a scheduled, full-tree dependency vulnerability scanner to close the
+**SCR-VULN-SCAN** detection gap. `Closes #2864.`
+
+NEAT-AI pins every external dependency to an exact version in `deno.json` and
+only bumps on the weekly `deno-outdated` schedule. Before this change, nothing
+in CI re-scanned those already-merged, exact-pinned deps against an advisory
+database: `dependency-review.yml` is PR-diff scoped (it only flags deps that
+change in a PR), and `deno-outdated.yml` is a _freshness_ bump, not a
+vulnerability scan. So a CVE disclosed against a version we already ship went
+unmonitored until the next Monday bump.
+
+`.github/workflows/osv-scan.yml` closes that gap:
+
+- Runs on a **weekly `schedule`** (07:00 UTC Wednesday — offset from the Monday
+  `deno-outdated` bump) plus **`workflow_dispatch`** for on-demand runs.
+- Generates an **ephemeral `deno.lock`** in CI (`deno cache --lock=deno.lock`)
+  because `deno.json` sets `"lock": false`. The lockfile is never committed, so
+  the repo's lock policy for normal development is left untouched.
+- Scans the resolved tree with the **SHA-pinned**
+  `google/osv-scanner-action@9a49870…` (v2.3.8), consistent with the repo's
+  existing action-pinning policy. osv-scanner exits non-zero on any known
+  advisory, so the job fails and the signal is actionable.
+- Declares **least-privilege** `permissions: contents: read`, an explicit
+  `timeout-minutes`, and a `concurrency` group — matching the repo's workflow
+  hygiene tests.
+
+### Detection-gap before/after
+
+```mermaid
+flowchart LR
+    subgraph Before
+        PR1[PR opened] --> DR1[dependency-review<br/>PR-diff only]
+        CVE1[CVE disclosed<br/>against pinned dep] -.->|no CI alert| GAP[Unmonitored<br/>until next bump]
+    end
+    subgraph After
+        CVE2[CVE disclosed<br/>against pinned dep] --> CRON[Weekly osv-scan<br/>+ on-demand]
+        CRON --> SCAN[Scan full resolved<br/>tree vs OSV DB]
+        SCAN -->|advisory found| FAIL[Job fails — actionable signal]
+    end
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via tests and
+the repo's quality gate:
+
+- New tests pass: `deno test --allow-read test/ci/OsvScanWorkflow.ts` → **9
+  passed**.
+- All existing CI workflow tests still pass (the new workflow satisfies the
+  cross-workflow action-pinning, container-pinning, timeout, and
+  concurrency-group invariants): `test/ci/*.ts` → **65 passed**.
+- `actionlint .github/workflows/osv-scan.yml` → OK.
+- `./quality.sh --lint-only`, `markdownlint-cli2`, and `cspell` → clean.
+
+## Test Plan
+
+Added `test/ci/OsvScanWorkflow.ts` — parse-and-assert ("what") tests over the
+committed YAML and `deno.json`:
+
+- `osv-scan.yml exists and parses as YAML`
+- `runs on a weekly schedule` (5-field cron with a pinned day-of-week)
+- `supports manual dispatch` (`workflow_dispatch`)
+- `grants least-privilege permissions` (`contents: read`)
+- `job declares an explicit timeout` (positive, below the 360-minute default)
+- `generates an ephemeral lockfile for the scan` (`deno cache --lock` →
+  `deno.lock`)
+- `never commits the ephemeral lockfile` (no `git add deno.lock` / `git commit`)
+- `invokes the OSV scanner action against the lockfile` (`google/osv-scanner`,
+  `scan-args` → `deno.lock`)
+- `deno.json keeps "lock": false` so the scan does not change dev policy

--- a/test/ci/OsvScanWorkflow.ts
+++ b/test/ci/OsvScanWorkflow.ts
@@ -1,0 +1,224 @@
+/**
+ * Issue #2864 — SCR-VULN-SCAN: the repo had no *scheduled, full-tree*
+ * dependency vulnerability scanner. `dependency-review.yml` only inspects
+ * deps that change within a PR diff and `deno-outdated.yml` is a weekly
+ * freshness bump, not an advisory scan. Neither alerts us when a CVE is
+ * disclosed against an exact-pinned dependency we already ship.
+ *
+ * `.github/workflows/osv-scan.yml` closes that detection gap: on a weekly
+ * schedule (and on demand) it generates an *ephemeral* lockfile and scans the
+ * resolved tree against the OSV advisory database, failing on known
+ * advisories so the signal is actionable.
+ *
+ * These are "what" tests: they parse the committed workflow YAML (and
+ * deno.json) and assert on the resulting configuration, not on how each value
+ * happens to be written.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const OSV_WORKFLOW = join(REPO_ROOT, ".github/workflows/osv-scan.yml");
+const DENO_JSON = join(REPO_ROOT, "deno.json");
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+}
+
+interface Job {
+  "runs-on"?: string;
+  "timeout-minutes"?: number;
+  permissions?: Record<string, string>;
+  steps?: Step[];
+}
+
+interface Concurrency {
+  group?: string;
+  "cancel-in-progress"?: boolean | string;
+}
+
+interface Workflow {
+  name?: string;
+  // `on:` is parsed by @std/yaml as the boolean key `true`, so accept both.
+  on?: unknown;
+  true?: unknown;
+  permissions?: Record<string, string>;
+  concurrency?: Concurrency | string;
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(OSV_WORKFLOW);
+  return parse(text) as Workflow;
+}
+
+async function readWorkflowText(): Promise<string> {
+  return await Deno.readTextFile(OSV_WORKFLOW);
+}
+
+function triggers(wf: Workflow): Record<string, unknown> {
+  // YAML maps the unquoted `on:` key to the boolean true.
+  const on = (wf.on ?? wf.true) as Record<string, unknown> | undefined;
+  assert(
+    on !== undefined && typeof on === "object",
+    "workflow has no on: block",
+  );
+  return on;
+}
+
+function allSteps(wf: Workflow): Step[] {
+  const steps: Step[] = [];
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const step of job.steps ?? []) steps.push(step);
+  }
+  return steps;
+}
+
+Deno.test("osv-scan.yml exists and parses as YAML (Issue #2864)", async () => {
+  const wf = await readWorkflow();
+  assert(typeof wf === "object" && wf !== null, "osv-scan.yml did not parse");
+  const jobIds = Object.keys(wf.jobs ?? {});
+  assert(jobIds.length > 0, "osv-scan.yml declares no jobs");
+});
+
+Deno.test("osv-scan.yml runs on a weekly schedule (Issue #2864)", async () => {
+  const wf = await readWorkflow();
+  const on = triggers(wf);
+  const schedule = on["schedule"] as Array<{ cron?: string }> | undefined;
+  assert(
+    Array.isArray(schedule) && schedule.length > 0,
+    "osv-scan.yml must declare a schedule: trigger so the resolved dependency " +
+      "tree is re-scanned between weekly bumps, not only on PR diffs",
+  );
+  for (const entry of schedule) {
+    assert(
+      typeof entry.cron === "string" && entry.cron.trim().length > 0,
+      "each schedule entry must carry a non-empty cron expression",
+    );
+    const fields = entry.cron!.trim().split(/\s+/);
+    assertEquals(
+      fields.length,
+      5,
+      `cron '${entry.cron}' must have 5 fields (min hour dom mon dow)`,
+    );
+    // Day-of-week field pins the run to a specific weekday (weekly cadence),
+    // not "every day" (*).
+    assert(
+      fields[4] !== "*",
+      `cron '${entry.cron}' must pin a day-of-week for a weekly cadence, ` +
+        `got dow='${fields[4]}'`,
+    );
+  }
+});
+
+Deno.test("osv-scan.yml supports manual dispatch (Issue #2864)", async () => {
+  const wf = await readWorkflow();
+  const on = triggers(wf);
+  assert(
+    "workflow_dispatch" in on,
+    "osv-scan.yml should expose workflow_dispatch so the scan can be run on " +
+      "demand after a fresh advisory is published",
+  );
+});
+
+Deno.test("osv-scan.yml grants least-privilege permissions (Issue #2864)", async () => {
+  const wf = await readWorkflow();
+  const jobPerms = Object.values(wf.jobs ?? {})
+    .map((j) => j.permissions)
+    .find((p) => p !== undefined);
+  const perms = wf.permissions ?? jobPerms;
+  assert(
+    perms !== undefined && typeof perms === "object",
+    "osv-scan.yml must declare an explicit permissions block (least privilege)",
+  );
+  assertEquals(
+    perms["contents"],
+    "read",
+    "osv-scan.yml should only need contents: read — it scans, it does not push",
+  );
+});
+
+Deno.test("osv-scan.yml job declares an explicit timeout (Issue #2864)", async () => {
+  const wf = await readWorkflow();
+  for (const [jobId, job] of Object.entries(wf.jobs ?? {})) {
+    const timeout = job["timeout-minutes"];
+    assert(
+      typeof timeout === "number" && Number.isInteger(timeout) && timeout > 0 &&
+        timeout < 360,
+      `osv-scan.yml job "${jobId}" must set a positive timeout-minutes well ` +
+        `below the 360-minute GitHub default, got ${timeout}`,
+    );
+  }
+});
+
+Deno.test("osv-scan.yml generates an ephemeral lockfile for the scan (Issue #2864)", async () => {
+  const wf = await readWorkflow();
+  const runSteps = allSteps(wf)
+    .map((s) => s.run)
+    .filter((r): r is string => typeof r === "string");
+  const body = runSteps.join("\n");
+  // deno.json sets "lock": false, so the scan step must produce a transient
+  // deno.lock by passing --lock explicitly.
+  assert(
+    /deno\s+cache[^\n]*--lock/.test(body) ||
+      /deno\s+install[^\n]*--lock/.test(body),
+    "osv-scan.yml must generate a lockfile via `deno cache --lock=...` (or " +
+      '`deno install --lock=...`) because deno.json sets "lock": false',
+  );
+  assert(
+    /deno\.lock/.test(body),
+    "the generated lockfile must be named deno.lock so the scanner can find it",
+  );
+});
+
+Deno.test("osv-scan.yml never commits the ephemeral lockfile (Issue #2864)", async () => {
+  const text = await readWorkflowText();
+  // Strip comment lines: prose may legitimately mention not committing.
+  const code = text
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+  assert(
+    !/git\s+add[^\n]*deno\.lock/.test(code),
+    "osv-scan.yml must not `git add deno.lock` — the lockfile is transient and " +
+      'deno.json\'s "lock": false policy must stay intact',
+  );
+  assert(
+    !/git\s+commit/.test(code),
+    "osv-scan.yml must not commit anything — it is a read-only scanner",
+  );
+});
+
+Deno.test("osv-scan.yml invokes the OSV scanner action against the lockfile (Issue #2864)", async () => {
+  const wf = await readWorkflow();
+  const steps = allSteps(wf);
+  const osvStep = steps.find(
+    (s) => typeof s.uses === "string" && /google\/osv-scanner/.test(s.uses),
+  );
+  assert(
+    osvStep !== undefined,
+    "osv-scan.yml must run a google/osv-scanner action to scan the resolved " +
+      "tree against the OSV advisory database",
+  );
+  const scanArgs = String(osvStep!.with?.["scan-args"] ?? "");
+  assert(
+    /deno\.lock/.test(scanArgs),
+    "the osv-scanner step must point scan-args at the generated deno.lock",
+  );
+});
+
+Deno.test('deno.json keeps "lock": false so the scan does not change dev policy (Issue #2864)', async () => {
+  const text = await Deno.readTextFile(DENO_JSON);
+  const config = JSON.parse(text) as { lock?: unknown };
+  assertEquals(
+    config.lock,
+    false,
+    'deno.json must keep "lock": false — the OSV scan generates its own ' +
+      "ephemeral lockfile in CI and must not flip the repo's lock policy",
+  );
+});


### PR DESCRIPTION
# SCR-VULN-SCAN: scheduled OSV vulnerability scan for pinned Deno deps

## Summary

Added a scheduled, full-tree dependency vulnerability scanner to close the
**SCR-VULN-SCAN** detection gap. `Closes #2864.`

NEAT-AI pins every external dependency to an exact version in `deno.json` and
only bumps on the weekly `deno-outdated` schedule. Before this change, nothing
in CI re-scanned those already-merged, exact-pinned deps against an advisory
database: `dependency-review.yml` is PR-diff scoped (it only flags deps that
change in a PR), and `deno-outdated.yml` is a _freshness_ bump, not a
vulnerability scan. So a CVE disclosed against a version we already ship went
unmonitored until the next Monday bump.

`.github/workflows/osv-scan.yml` closes that gap:

- Runs on a **weekly `schedule`** (07:00 UTC Wednesday — offset from the Monday
  `deno-outdated` bump) plus **`workflow_dispatch`** for on-demand runs.
- Generates an **ephemeral `deno.lock`** in CI (`deno cache --lock=deno.lock`)
  because `deno.json` sets `"lock": false`. The lockfile is never committed, so
  the repo's lock policy for normal development is left untouched.
- Scans the resolved tree with the **SHA-pinned**
  `google/osv-scanner-action@9a49870…` (v2.3.8), consistent with the repo's
  existing action-pinning policy. osv-scanner exits non-zero on any known
  advisory, so the job fails and the signal is actionable.
- Declares **least-privilege** `permissions: contents: read`, an explicit
  `timeout-minutes`, and a `concurrency` group — matching the repo's workflow
  hygiene tests.

### Detection-gap before/after

```mermaid
flowchart LR
    subgraph Before
        PR1[PR opened] --> DR1[dependency-review<br/>PR-diff only]
        CVE1[CVE disclosed<br/>against pinned dep] -.->|no CI alert| GAP[Unmonitored<br/>until next bump]
    end
    subgraph After
        CVE2[CVE disclosed<br/>against pinned dep] --> CRON[Weekly osv-scan<br/>+ on-demand]
        CRON --> SCAN[Scan full resolved<br/>tree vs OSV DB]
        SCAN -->|advisory found| FAIL[Job fails — actionable signal]
    end
```

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via tests and
the repo's quality gate:

- New tests pass: `deno test --allow-read test/ci/OsvScanWorkflow.ts` → **9
  passed**.
- All existing CI workflow tests still pass (the new workflow satisfies the
  cross-workflow action-pinning, container-pinning, timeout, and
  concurrency-group invariants): `test/ci/*.ts` → **65 passed**.
- `actionlint .github/workflows/osv-scan.yml` → OK.
- `./quality.sh --lint-only`, `markdownlint-cli2`, and `cspell` → clean.

## Test Plan

Added `test/ci/OsvScanWorkflow.ts` — parse-and-assert ("what") tests over the
committed YAML and `deno.json`:

- `osv-scan.yml exists and parses as YAML`
- `runs on a weekly schedule` (5-field cron with a pinned day-of-week)
- `supports manual dispatch` (`workflow_dispatch`)
- `grants least-privilege permissions` (`contents: read`)
- `job declares an explicit timeout` (positive, below the 360-minute default)
- `generates an ephemeral lockfile for the scan` (`deno cache --lock` →
  `deno.lock`)
- `never commits the ephemeral lockfile` (no `git add deno.lock` / `git commit`)
- `invokes the OSV scanner action against the lockfile` (`google/osv-scanner`,
  `scan-args` → `deno.lock`)
- `deno.json keeps "lock": false` so the scan does not change dev policy



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq26eagb-d9adc7`<!-- vibe-worker-issue-2864 -->