### PR TITLE
Commit deno.lock for transitive-dependency integrity pinning (Issue #2865)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.15",
+  "version": "5.3.16",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -99,7 +99,6 @@
       ]
     }
   },
-  "lock": false,
   "exclude": [
     ".analysis",
     ".coverage",

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,120 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1.0.19": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/bytes@1.0.6": "1.0.6",
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
+    "jsr:@std/cli@1.0.17": "1.0.17",
+    "jsr:@std/crypto@1.1.0": "1.1.0",
+    "jsr:@std/crypto@^1.1.0": "1.1.0",
+    "jsr:@std/csv@1.0.6": "1.0.6",
+    "jsr:@std/data-structures@^1.1.0": "1.1.0",
+    "jsr:@std/fmt@1.0.10": "1.0.10",
+    "jsr:@std/fs@1.0.24": "1.0.24",
+    "jsr:@std/fs@^1.0.24": "1.0.24",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@1.1.5": "1.1.5",
+    "jsr:@std/path@^1.1.5": "1.1.5",
+    "jsr:@std/streams@1.1.1": "1.1.1",
+    "jsr:@std/streams@^1.0.9": "1.1.1",
+    "jsr:@std/testing@1.0.19": "1.0.19",
+    "jsr:@std/uuid@1.1.1": "1.1.1",
+    "jsr:@std/yaml@1.1.1": "1.1.1",
+    "jsr:@stsoftware/tags@1.0.13": "1.0.13"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
+    "@std/cli@1.0.17": {
+      "integrity": "e15b9abe629e17be90cc6216327f03a29eae613365f1353837fa749aad29ce7b"
+    },
+    "@std/crypto@1.1.0": {
+      "integrity": "b8d6d0a6377a32b213af2661ed7bf1062d94feac0c57def5526a8e74a95c3ec8"
+    },
+    "@std/csv@1.0.6": {
+      "integrity": "52ef0e62799a0028d278fa04762f17f9bd263fad9a8e7f98c14fbd371d62d9fd",
+      "dependencies": [
+        "jsr:@std/streams@^1.0.9"
+      ]
+    },
+    "@std/data-structures@1.1.0": {
+      "integrity": "c35ae4ad5d8e41a38573c2fe3e19b18ea2505f63cfea201edcb8720aca1f7f58"
+    },
+    "@std/fmt@1.0.10": {
+      "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.5"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    },
+    "@std/streams@1.1.1": {
+      "integrity": "92556d350e537e9dce527a6d08f6f15be3ff65e656079dea69d15252187c7613",
+      "dependencies": [
+        "jsr:@std/bytes@^1.0.6"
+      ]
+    },
+    "@std/testing@1.0.19": {
+      "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs@^1.0.24",
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.5"
+      ]
+    },
+    "@std/uuid@1.1.1": {
+      "integrity": "7b49060282d90f72fec64952f8c7a2914cbe6fdba3eca665f8cedc90830154a7",
+      "dependencies": [
+        "jsr:@std/bytes@^1.0.6",
+        "jsr:@std/crypto@^1.1.0"
+      ]
+    },
+    "@std/yaml@1.1.1": {
+      "integrity": "a57665ecf3d17b926380593a56625d8a10cc7281802f1e993b5ebc94a48e71f8"
+    },
+    "@stsoftware/tags@1.0.13": {
+      "integrity": "c5ee40f804d08ed7308c373bab07c0bd96cf1a470db6d977e056a6c206a2a5a2",
+      "dependencies": [
+        "jsr:@std/cli"
+      ]
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@1.0.19",
+      "jsr:@std/bytes@1.0.6",
+      "jsr:@std/crypto@1.1.0",
+      "jsr:@std/csv@1.0.6",
+      "jsr:@std/fmt@1.0.10",
+      "jsr:@std/fs@1.0.24",
+      "jsr:@std/path@1.1.5",
+      "jsr:@std/streams@1.1.1",
+      "jsr:@std/testing@1.0.19",
+      "jsr:@std/uuid@1.1.1",
+      "jsr:@std/yaml@1.1.1",
+      "jsr:@stsoftware/tags@1.0.13"
+    ]
+  }
+}

--- a/docs/archive/pr-summaries/pr-summary-2865.md
+++ b/docs/archive/pr-summaries/pr-summary-2865.md
@@ -1,0 +1,73 @@
+# SCR-LOCKFILE: commit deno.lock for transitive-dependency integrity pinning
+
+## Summary
+
+`deno.json` previously set `"lock": false` with **no committed `deno.lock`**, so
+the **transitive** dependency graph was unpinned and no integrity hashes were
+recorded. Exact-pinning the *direct* `jsr:` imports does not pin what those
+packages themselves resolve to — a newly published (potentially malicious)
+patch/minor within an allowed transitive range could be pulled into a build even
+though nothing in `deno.json` changed.
+
+This change closes that supply-chain readiness gap:
+
+- Removed the `"lock": false` line from `deno.json`, re-enabling Deno's
+  lockfile (default behaviour).
+- Generated and committed `deno.lock` (Deno lockfile v5) recording the exact
+  resolved version **and** an integrity hash for every dependency in the tree.
+  Deno now verifies the resolved graph on every `cache`/`install`/`run`, so any
+  tamper or unexpected transitive substitution fails the integrity check. This
+  makes the existing 24h bump quarantine meaningful by pinning what actually
+  ships between bumps.
+
+The lockfile is repo-local only — it is **not** in `publish.include`, so nothing
+changes for downstream JSR consumers; it restores integrity verification for
+this repo's own CI and contributors. It also gives the scheduled OSV scanner
+(#2864) a real committed lockfile rather than relying solely on an ephemeral one.
+
+Closes #2865.
+
+### Test change documented (business-logic supersession)
+
+`test/ci/OsvScanWorkflow.ts` contained an assertion (from #2864) that
+`deno.json` must **keep** `"lock": false`. Issue #2865 deliberately reverses
+that policy, so this single test was updated — not removed — to assert the new,
+correct posture (`config.lock !== false`). All other OSV-scan assertions
+(ephemeral lockfile generation, never-commits, scanner wiring) are unchanged and
+still pass.
+
+```mermaid
+flowchart LR
+    A["deno.json<br/>imports: exact-pin DIRECT deps"] --> B{committed<br/>deno.lock?}
+    B -- "before: lock:false, none" --> C["transitive graph UNPINNED<br/>no integrity hashes"]
+    B -- "after: lock enabled + committed" --> D["full graph pinned<br/>integrity verified every<br/>cache / install / run"]
+```
+
+## Evidence
+
+Backend/config change — no web interface to screenshot. Verified via tests and
+the full quality gate.
+
+- `deno.lock` generated with `deno cache mod.ts test/**/*.ts` (Deno 2.8.1),
+  recording integrity hashes for all resolved `jsr:` dependencies including
+  transitive `@std/internal`.
+- New test `test/scripts/LockfilePinning.ts` (4 cases) — all pass.
+- Updated `test/ci/OsvScanWorkflow.ts` — all 9 cases pass.
+- Full `./quality.sh`: **7050 passed | 0 failed | 4 ignored**.
+
+## Test Plan
+
+Added `test/scripts/LockfilePinning.ts` ("what" tests parsing the committed
+manifest/lockfile):
+
+- `deno.json does not disable the lockfile` — asserts `lock !== false`.
+- `a committed deno.lock exists at the repo root`.
+- `deno.lock records integrity hashes for dependencies` — asserts at least one
+  integrity hash is recorded across the jsr/npm/remote sections.
+- `deno.lock pins the exact-pinned direct dependencies` — asserts every direct
+  `jsr:` import in `deno.json` is present in the lockfile.
+
+Modified `test/ci/OsvScanWorkflow.ts`:
+
+- Renamed/rewrote the `"lock": false` assertion to assert the lockfile is **not**
+  disabled, reflecting the #2865 policy change (documented above).

--- a/docs/archive/pr-summaries/pr-summary-2865.md
+++ b/docs/archive/pr-summaries/pr-summary-2865.md
@@ -4,15 +4,15 @@
 
 `deno.json` previously set `"lock": false` with **no committed `deno.lock`**, so
 the **transitive** dependency graph was unpinned and no integrity hashes were
-recorded. Exact-pinning the *direct* `jsr:` imports does not pin what those
+recorded. Exact-pinning the _direct_ `jsr:` imports does not pin what those
 packages themselves resolve to — a newly published (potentially malicious)
 patch/minor within an allowed transitive range could be pulled into a build even
 though nothing in `deno.json` changed.
 
 This change closes that supply-chain readiness gap:
 
-- Removed the `"lock": false` line from `deno.json`, re-enabling Deno's
-  lockfile (default behaviour).
+- Removed the `"lock": false` line from `deno.json`, re-enabling Deno's lockfile
+  (default behaviour).
 - Generated and committed `deno.lock` (Deno lockfile v5) recording the exact
   resolved version **and** an integrity hash for every dependency in the tree.
   Deno now verifies the resolved graph on every `cache`/`install`/`run`, so any
@@ -23,7 +23,8 @@ This change closes that supply-chain readiness gap:
 The lockfile is repo-local only — it is **not** in `publish.include`, so nothing
 changes for downstream JSR consumers; it restores integrity verification for
 this repo's own CI and contributors. It also gives the scheduled OSV scanner
-(#2864) a real committed lockfile rather than relying solely on an ephemeral one.
+(#2864) a real committed lockfile rather than relying solely on an ephemeral
+one.
 
 Closes #2865.
 
@@ -69,5 +70,5 @@ manifest/lockfile):
 
 Modified `test/ci/OsvScanWorkflow.ts`:
 
-- Renamed/rewrote the `"lock": false` assertion to assert the lockfile is **not**
-  disabled, reflecting the #2865 policy change (documented above).
+- Renamed/rewrote the `"lock": false` assertion to assert the lockfile is
+  **not** disabled, reflecting the #2865 policy change (documented above).

--- a/test/ci/OsvScanWorkflow.ts
+++ b/test/ci/OsvScanWorkflow.ts
@@ -212,13 +212,17 @@ Deno.test("osv-scan.yml invokes the OSV scanner action against the lockfile (Iss
   );
 });
 
-Deno.test('deno.json keeps "lock": false so the scan does not change dev policy (Issue #2864)', async () => {
+// Issue #2865 supersedes #2864's "lock": false assumption: the repo now
+// commits a real deno.lock for transitive-dependency integrity pinning, so
+// deno.json must NOT disable the lockfile. The OSV scanner still points at a
+// deno.lock — now the committed one rather than an ephemeral throwaway.
+Deno.test('deno.json does not disable the lockfile (Issue #2865 supersedes #2864 "lock": false)', async () => {
   const text = await Deno.readTextFile(DENO_JSON);
   const config = JSON.parse(text) as { lock?: unknown };
-  assertEquals(
-    config.lock,
-    false,
-    'deno.json must keep "lock": false — the OSV scan generates its own ' +
-      "ephemeral lockfile in CI and must not flip the repo's lock policy",
+  assert(
+    config.lock !== false,
+    'deno.json must not set "lock": false — Issue #2865 commits a real ' +
+      "deno.lock so transitive-dependency integrity is verified on every " +
+      "cache/install/run, including the OSV scan",
   );
 });

--- a/test/scripts/LockfilePinning.ts
+++ b/test/scripts/LockfilePinning.ts
@@ -1,0 +1,93 @@
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+/**
+ * Issue #2865 — SCR-LOCKFILE: supply-chain integrity pinning.
+ *
+ * This repo exact-pins its *direct* dependencies in deno.json's `imports`
+ * map, but without a committed deno.lock the *transitive* dependency graph
+ * is unpinned and no integrity hashes are recorded. A new — potentially
+ * malicious — patch/minor version within an allowed transitive range could
+ * be pulled into a build even though nothing in deno.json changed.
+ *
+ * A committed deno.lock closes that gap: it records the exact resolved
+ * version *and* an integrity hash for every dependency in the tree, so Deno
+ * verifies the resolved graph on every cache/install/run.
+ *
+ * These are "what" tests: they parse the committed deno.json / deno.lock and
+ * assert on the resulting integrity-pinning posture, not on how each value
+ * happens to be written.
+ */
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const DENO_JSON = join(REPO_ROOT, "deno.json");
+const DENO_LOCK = join(REPO_ROOT, "deno.lock");
+
+Deno.test("deno.json does not disable the lockfile (Issue #2865)", async () => {
+  const json = JSON.parse(await Deno.readTextFile(DENO_JSON));
+  assert(
+    json.lock !== false,
+    'deno.json must not set "lock": false — disabling the lockfile turns off ' +
+      "transitive-dependency integrity verification across local dev and CI",
+  );
+});
+
+Deno.test("a committed deno.lock exists at the repo root (Issue #2865)", async () => {
+  const info = await Deno.stat(DENO_LOCK);
+  assert(info.isFile, "deno.lock must exist at the repository root");
+});
+
+Deno.test("deno.lock records integrity hashes for dependencies (Issue #2865)", async () => {
+  const lock = JSON.parse(await Deno.readTextFile(DENO_LOCK));
+  assert(
+    typeof lock.version === "string" && lock.version.length > 0,
+    "deno.lock must declare a lockfile format version",
+  );
+
+  // Collect every integrity hash recorded across the JSR/npm/remote sections.
+  const integrities: string[] = [];
+  for (const section of [lock.jsr, lock.npm, lock.remote]) {
+    if (!section || typeof section !== "object") continue;
+    for (const entry of Object.values(section as Record<string, unknown>)) {
+      if (typeof entry === "string") {
+        // `remote` maps specifier -> integrity hash directly.
+        integrities.push(entry);
+      } else if (entry && typeof entry === "object") {
+        const hash = (entry as { integrity?: unknown }).integrity;
+        if (typeof hash === "string") integrities.push(hash);
+      }
+    }
+  }
+
+  assert(
+    integrities.length > 0,
+    "deno.lock must record at least one dependency integrity hash so the " +
+      "resolved dependency graph is verified on every cache/install/run",
+  );
+});
+
+Deno.test("deno.lock pins the exact-pinned direct dependencies (Issue #2865)", async () => {
+  const json = JSON.parse(await Deno.readTextFile(DENO_JSON));
+  const lock = JSON.parse(await Deno.readTextFile(DENO_LOCK));
+
+  // The lockfile must reference every direct jsr: import declared in deno.json.
+  const jsrImports = Object.values(json.imports as Record<string, string>)
+    .filter((spec) => spec.startsWith("jsr:"));
+
+  const jsrSection = (lock.jsr ?? {}) as Record<string, unknown>;
+  const specifiers = (lock.specifiers ?? {}) as Record<string, unknown>;
+  const lockText = JSON.stringify(lock);
+
+  for (const spec of jsrImports) {
+    // e.g. "jsr:@std/crypto@1.1.0" -> bare "@std/crypto@1.1.0".
+    const bare = spec.slice("jsr:".length).split("/").slice(0, 2).join("/");
+    const pkgName = bare.split("@").slice(0, -1).join("@") || bare;
+    const present = pkgName in jsrSection ||
+      pkgName in specifiers ||
+      lockText.includes(pkgName);
+    assert(
+      present,
+      `deno.lock must pin direct dependency "${pkgName}" declared in deno.json`,
+    );
+  }
+});


### PR DESCRIPTION
# SCR-LOCKFILE: commit deno.lock for transitive-dependency integrity pinning

## Summary

`deno.json` previously set `"lock": false` with **no committed `deno.lock`**, so
the **transitive** dependency graph was unpinned and no integrity hashes were
recorded. Exact-pinning the *direct* `jsr:` imports does not pin what those
packages themselves resolve to — a newly published (potentially malicious)
patch/minor within an allowed transitive range could be pulled into a build even
though nothing in `deno.json` changed.

This change closes that supply-chain readiness gap:

- Removed the `"lock": false` line from `deno.json`, re-enabling Deno's
  lockfile (default behaviour).
- Generated and committed `deno.lock` (Deno lockfile v5) recording the exact
  resolved version **and** an integrity hash for every dependency in the tree.
  Deno now verifies the resolved graph on every `cache`/`install`/`run`, so any
  tamper or unexpected transitive substitution fails the integrity check. This
  makes the existing 24h bump quarantine meaningful by pinning what actually
  ships between bumps.

The lockfile is repo-local only — it is **not** in `publish.include`, so nothing
changes for downstream JSR consumers; it restores integrity verification for
this repo's own CI and contributors. It also gives the scheduled OSV scanner
(#2864) a real committed lockfile rather than relying solely on an ephemeral one.

Closes #2865.

### Test change documented (business-logic supersession)

`test/ci/OsvScanWorkflow.ts` contained an assertion (from #2864) that
`deno.json` must **keep** `"lock": false`. Issue #2865 deliberately reverses
that policy, so this single test was updated — not removed — to assert the new,
correct posture (`config.lock !== false`). All other OSV-scan assertions
(ephemeral lockfile generation, never-commits, scanner wiring) are unchanged and
still pass.

```mermaid
flowchart LR
    A["deno.json<br/>imports: exact-pin DIRECT deps"] --> B{committed<br/>deno.lock?}
    B -- "before: lock:false, none" --> C["transitive graph UNPINNED<br/>no integrity hashes"]
    B -- "after: lock enabled + committed" --> D["full graph pinned<br/>integrity verified every<br/>cache / install / run"]
```

## Evidence

Backend/config change — no web interface to screenshot. Verified via tests and
the full quality gate.

- `deno.lock` generated with `deno cache mod.ts test/**/*.ts` (Deno 2.8.1),
  recording integrity hashes for all resolved `jsr:` dependencies including
  transitive `@std/internal`.
- New test `test/scripts/LockfilePinning.ts` (4 cases) — all pass.
- Updated `test/ci/OsvScanWorkflow.ts` — all 9 cases pass.
- Full `./quality.sh`: **7050 passed | 0 failed | 4 ignored**.

## Test Plan

Added `test/scripts/LockfilePinning.ts` ("what" tests parsing the committed
manifest/lockfile):

- `deno.json does not disable the lockfile` — asserts `lock !== false`.
- `a committed deno.lock exists at the repo root`.
- `deno.lock records integrity hashes for dependencies` — asserts at least one
  integrity hash is recorded across the jsr/npm/remote sections.
- `deno.lock pins the exact-pinned direct dependencies` — asserts every direct
  `jsr:` import in `deno.json` is present in the lockfile.

Modified `test/ci/OsvScanWorkflow.ts`:

- Renamed/rewrote the `"lock": false` assertion to assert the lockfile is **not**
  disabled, reflecting the #2865 policy change (documented above).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq29xtg7-95e209`<!-- vibe-worker-issue-2865 -->