### PR TITLE
Bound finish-up wait for optional training tasks (Issue #2871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Issue #2871:** Evolution now always finalizes even when an optional training
+  task never settles. Training is a best-effort phase, but the finish-up loop in
+  `Neat.finishUp()` only bounded the wait for _discovery_ tasks — the _training_
+  branch waited indefinitely, so an orphaned (never-resolving) training promise
+  pinned `trainingInProgress` and the run spun until an external wall-clock cap
+  killed it, discarding the whole compute window with no champion checkin. The
+  training branch now uses the identical bounded-wait logic as discovery (the
+  smaller of an iteration-derived and a wall-clock-derived generation cap; Issue
+  #2432): once the budget is exhausted the stuck training task is abandoned and
+  the run finalizes and checks in the best-so-far creature. The shared cap
+  computation was extracted into `computeMaxWaitGenerations()`.
 - **Issue #2831:** Carry over the higher generation count when breeding and
   loading creatures. The `currentGeneration` tag is now **monotonic** —
   `writeSeedWarmupProgressTags` never lowers an existing value. Previously the

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.16",
+  "version": "5.3.17",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2871.md
+++ b/docs/archive/pr-summaries/pr-summary-2871.md
@@ -1,0 +1,99 @@
+# Evolution never finalizes: bound the finish-up wait for optional training tasks
+
+## Summary
+
+A training task whose worker promise never settled (e.g. a timed-out
+per-creature CPU score whose worker task is orphaned) was **never reaped from
+`Neat.trainingInProgress`**, so the finish-up loop spun forever and the
+evolution run never finalized — discarding the whole compute window with no
+champion checkin.
+
+The root cause is in `Neat.finishUp()`: the **discovery** branch already bounds
+its wait and clears stuck tasks (Issues #2432), but the **training** branch
+simply logged `Waiting for N training task(s)` and returned `false` every
+generation, with no deadline. A single optional training task that failed to
+settle therefore wedged the entire run.
+
+Training and discovery are optional/best-effort phases — they may be waited on
+for a _bounded_ time but must **never** gate finalisation + checkin. This change
+makes the training branch use the **identical** bounded-wait logic as discovery:
+the smaller of an iteration-derived cap and a wall-clock-derived cap. Once the
+budget is exhausted (or the caller's `--timeout` wall-clock deadline passes),
+the stuck training task is abandoned and the run finalizes and checks in the
+best-so-far creature.
+
+The duplicated cap computation (previously inline in the discovery branch) was
+extracted into a shared private helper `computeMaxWaitGenerations()` used by
+both branches, so the two paths stay in lock-step (DRY).
+
+Closes #2871.
+
+## Behaviour change
+
+```mermaid
+flowchart TD
+    A[finishUp called] --> B{discoveryInProgress > 0?}
+    B -- yes --> C[bounded wait; clear stuck on deadline]
+    B -- no --> D{trainingInProgress > 0?}
+    D -- "yes (before)" --> E["return false forever ❌<br/>run never finalizes"]
+    D -- "yes (after)" --> F["bounded wait; abandon stuck<br/>on deadline ✅"]
+    F --> G[finalize + checkin best creature]
+    D -- no --> G
+```
+
+Before: the training branch had no deadline, so a never-settling training
+promise pinned `trainingInProgress.size` and `finishUp()` returned `false`
+indefinitely. After: training is bounded exactly like discovery — the run always
+proceeds to checkin.
+
+## Evidence
+
+Backend/library change only — no UI to screenshot. Verified via unit tests that
+drive `Neat.finishUp()` with an injected never-settling training promise and
+assert the map is emptied and the loop reaches a terminal `true`.
+
+New/updated tests in `test/NEAT/NeatFinishUp.ts`:
+
+- `finishUp: training timeout clears stuck trainings` — a never-settling
+  training promise is abandoned after the generation-count budget.
+- `finishUp: clears stuck trainings promptly when wall-clock deadline has
+  passed`
+  — an expired `--timeout` clears the stuck task within a few calls even with a
+  generous iteration cap.
+- `finishUp: eventually finalizes despite a never-settling training task` — the
+  finish-up loop reaches a terminal `true` (finalize + checkin) rather than
+  spinning forever.
+
+All existing `finishUp` tests (including the discovery-timeout and cleanup-delay
+cases) continue to pass, confirming the extracted `computeMaxWaitGenerations()`
+preserves discovery behaviour.
+
+```
+ok | 35 passed | 0 failed
+```
+
+(test/NEAT/NeatFinishUp.ts, NeatAwaitInFlightTasks.ts,
+MaxConcurrentDiscoveries.ts, NeatSchedulingLogReplaySummary.ts)
+
+## Test Plan
+
+- `deno test --allow-all test/NEAT/NeatFinishUp.ts` — new and existing finish-up
+  cases.
+- `deno test --allow-all test/NEAT/NeatAwaitInFlightTasks.ts
+  test/NEAT/MaxConcurrentDiscoveries.ts
+  test/NEAT/NeatSchedulingLogReplaySummary.ts`
+  — adjacent scheduling/await tests.
+- `./quality.sh --skip-tests` — lint, format, type-check, WASM/discovery sync
+  (exit 0).
+
+## Notes
+
+- The fix is deliberately at the `Neat.finishUp()` level (suggested fixes #1 and
+  #3 in the issue): it guarantees the run finalizes regardless of _why_ a worker
+  training promise leaked, matching the design intent that optional tasks must
+  never gate checkin. The worker-side path already returns with `timedOut: true`
+  on the normal timeout; this defensive bound covers the case where the promise
+  is nonetheless orphaned.
+- Consistent with the existing discovery path, abandoned tasks are cleared from
+  the in-progress map (no per-task worker abort handle is tracked at this
+  layer).

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -173,6 +173,11 @@ export class Neat {
   additionalGenerationCount = 0;
   private discoveryWaitGenerations = 0;
   private maxDiscoveryWaitGenerations = 0;
+  // Issue #2871: bound the finish-up wait for optional training tasks the same
+  // way discovery is bounded, so an orphaned (never-settling) training promise
+  // can never wedge the run from finalizing and checking in the best creature.
+  private trainingWaitGenerations = 0;
+  private maxTrainingWaitGenerations = 0;
   trainingInProgress = new Map<string, Promise<void>>();
   discoveryInProgress = new Map<string, Promise<void>>();
   discoveryComplete: ResponseData[] = [];
@@ -307,6 +312,80 @@ export class Neat {
     return cloned;
   }
 
+  /**
+   * Compute the bounded number of finish-up generations to wait for an
+   * optional in-flight phase (discovery or training) before abandoning it.
+   *
+   * Issue #2871: extracted from the discovery branch of {@link finishUp} so
+   * training is bounded by the identical limiting-factor logic — the smaller
+   * of an iteration-derived cap and a wall-clock-derived cap (Issue #2432).
+   */
+  private computeMaxWaitGenerations(
+    iterations?: number,
+    endTimeMS?: number,
+    startTimeMS?: number,
+    currentGeneration?: number,
+  ): number {
+    const DEFAULT_MAX_WAIT_MS = 5 * 60 * 1000;
+    let maxWaitByIterations = 20;
+    let maxWaitByTime = 20;
+
+    if (iterations) {
+      maxWaitByIterations = Math.max(1, Math.floor(iterations * 0.5));
+    }
+
+    if (startTimeMS && currentGeneration && currentGeneration > 0) {
+      const elapsedMS = Date.now() - startTimeMS;
+      const avgTimePerGeneration = elapsedMS / currentGeneration;
+
+      if (avgTimePerGeneration > 0) {
+        const maxGenerationsIn5Minutes = Math.max(
+          1,
+          Math.floor(DEFAULT_MAX_WAIT_MS / avgTimePerGeneration),
+        );
+
+        if (endTimeMS) {
+          const remainingTimeMS = endTimeMS - Date.now();
+          if (remainingTimeMS > 0) {
+            const estimatedGenerations = Math.max(
+              1,
+              Math.floor(remainingTimeMS / avgTimePerGeneration),
+            );
+            maxWaitByTime = Math.floor(estimatedGenerations * 0.5);
+          } else {
+            // Issue #2432: wall-clock deadline already exceeded — keep the
+            // grace window tight (1 generation) so a stuck task does not
+            // silently extend the caller's --timeout into an unbounded
+            // generation-count wait.
+            maxWaitByTime = 1;
+          }
+        } else {
+          maxWaitByTime = maxGenerationsIn5Minutes;
+        }
+
+        getLogger().info(
+          `Avg time per generation: ${
+            Math.round(avgTimePerGeneration)
+          }ms, max wait: ${maxGenerationsIn5Minutes} generations in 5 minutes`,
+        );
+      }
+    } else if (endTimeMS) {
+      const remainingTimeMS = endTimeMS - Date.now();
+      if (remainingTimeMS > 0) {
+        const estimatedGenerations = Math.max(
+          1,
+          Math.floor(remainingTimeMS / 30000),
+        );
+        maxWaitByTime = Math.floor(estimatedGenerations * 0.5);
+      } else {
+        // Issue #2432: same wall-clock guard as above.
+        maxWaitByTime = 1;
+      }
+    }
+
+    return Math.max(1, Math.min(maxWaitByIterations, maxWaitByTime));
+  }
+
   finishUp(
     iterations?: number,
     endTimeMS?: number,
@@ -328,66 +407,11 @@ export class Neat {
 
     if (this.discoveryInProgress.size > 0) {
       if (this.maxDiscoveryWaitGenerations === 0) {
-        const DEFAULT_MAX_WAIT_MS = 5 * 60 * 1000;
-        let maxWaitByIterations = 20;
-        let maxWaitByTime = 20;
-
-        if (iterations) {
-          maxWaitByIterations = Math.max(1, Math.floor(iterations * 0.5));
-        }
-
-        if (startTimeMS && currentGeneration && currentGeneration > 0) {
-          const elapsedMS = Date.now() - startTimeMS;
-          const avgTimePerGeneration = elapsedMS / currentGeneration;
-
-          if (avgTimePerGeneration > 0) {
-            const maxGenerationsIn5Minutes = Math.max(
-              1,
-              Math.floor(DEFAULT_MAX_WAIT_MS / avgTimePerGeneration),
-            );
-
-            if (endTimeMS) {
-              const remainingTimeMS = endTimeMS - Date.now();
-              if (remainingTimeMS > 0) {
-                const estimatedGenerations = Math.max(
-                  1,
-                  Math.floor(remainingTimeMS / avgTimePerGeneration),
-                );
-                maxWaitByTime = Math.floor(estimatedGenerations * 0.5);
-              } else {
-                // Issue #2432: wall-clock deadline already exceeded — keep the
-                // grace window tight (1 generation) so a stuck discovery does
-                // not silently extend the caller's --timeout into an
-                // unbounded generation-count wait.
-                maxWaitByTime = 1;
-              }
-            } else {
-              maxWaitByTime = maxGenerationsIn5Minutes;
-            }
-
-            getLogger().info(
-              `Avg time per generation: ${
-                Math.round(avgTimePerGeneration)
-              }ms, max wait: ${maxGenerationsIn5Minutes} generations in 5 minutes`,
-            );
-          }
-        } else if (endTimeMS) {
-          const remainingTimeMS = endTimeMS - Date.now();
-          if (remainingTimeMS > 0) {
-            const estimatedGenerations = Math.max(
-              1,
-              Math.floor(remainingTimeMS / 30000),
-            );
-            maxWaitByTime = Math.floor(estimatedGenerations * 0.5);
-          } else {
-            // Issue #2432: same wall-clock guard as above.
-            maxWaitByTime = 1;
-          }
-        }
-
-        this.maxDiscoveryWaitGenerations = Math.max(
-          1,
-          Math.min(maxWaitByIterations, maxWaitByTime),
+        this.maxDiscoveryWaitGenerations = this.computeMaxWaitGenerations(
+          iterations,
+          endTimeMS,
+          startTimeMS,
+          currentGeneration,
         );
         getLogger().info(
           `Discovery timeout set to ${this.maxDiscoveryWaitGenerations} generations (based on limiting factor)`,
@@ -439,12 +463,62 @@ export class Neat {
     }
 
     if (this.trainingInProgress.size > 0) {
+      // Issue #2871: training is an optional/best-effort phase. Bound the wait
+      // exactly like discovery so an orphaned training promise that never
+      // settles (e.g. a timed-out per-creature CPU score whose worker task is
+      // never reaped) cannot keep the run from finalizing and checking in the
+      // best-so-far creature.
+      if (this.maxTrainingWaitGenerations === 0) {
+        this.maxTrainingWaitGenerations = this.computeMaxWaitGenerations(
+          iterations,
+          endTimeMS,
+          startTimeMS,
+          currentGeneration,
+        );
+        getLogger().info(
+          `Training timeout set to ${this.maxTrainingWaitGenerations} generations (based on limiting factor)`,
+        );
+      }
+
+      this.trainingWaitGenerations++;
+
+      // The wall-clock deadline takes precedence over the generation-count
+      // wait: once the caller's --timeout has expired we must not let a stuck
+      // training task keep the loop alive.
+      const wallClockExpired = endTimeMS !== undefined && endTimeMS > 0 &&
+        Date.now() >= endTimeMS;
+
+      if (
+        wallClockExpired ||
+        this.trainingWaitGenerations >= this.maxTrainingWaitGenerations
+      ) {
+        const stuckUUIDs = Array.from(this.trainingInProgress.keys()).map(
+          (uuid) => uuid.substring(Math.max(0, uuid.length - 8)),
+        );
+        const reason = wallClockExpired
+          ? "wall-clock deadline expired"
+          : `${this.trainingWaitGenerations} generations`;
+        getLogger().warn(
+          `[Neat] Training timeout reached after ${reason}. Abandoning stuck training task(s): ${
+            stuckUUIDs.join(", ")
+          }`,
+        );
+
+        this.trainingInProgress.clear();
+        this.trainingWaitGenerations = 0;
+        this.maxTrainingWaitGenerations = 0;
+
+        return false;
+      }
+
       const trainingUUIDs = Array.from(this.trainingInProgress.keys()).map(
         (uuid) => uuid.substring(Math.max(0, uuid.length - 8)),
       );
       getLogger().info(
         `[Neat] Waiting for ${this.trainingInProgress.size} training task(s) ` +
-          `to complete - In progress: ${trainingUUIDs.join(", ")}`,
+          `to complete (${this.trainingWaitGenerations}/${this.maxTrainingWaitGenerations}) - In progress: ${
+            trainingUUIDs.join(", ")
+          }`,
       );
       return false;
     }

--- a/test/NEAT/NeatFinishUp.ts
+++ b/test/NEAT/NeatFinishUp.ts
@@ -170,6 +170,115 @@ Deno.test("finishUp: discovery timeout clears stuck discoveries", async () => {
   }
 });
 
+// ============================================================================
+// Issue #2871: Training is an optional/best-effort phase and must NEVER be
+// able to wedge the run. A training task whose worker promise never settles
+// (e.g. a timed-out per-creature CPU score) must be abandoned after a bounded
+// wait so the run can finalize and check in the best-so-far creature.
+// ============================================================================
+
+Deno.test("finishUp: training timeout clears stuck trainings", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    // A training promise that never settles (mimics an orphaned timed-out
+    // worker task that never resolves nor rejects).
+    neat.trainingInProgress.set("stuck-train-uuid", new Promise(() => {}));
+
+    // Call finishUp repeatedly with iterations=4 to bound the wait at 2.
+    let cleared = false;
+    for (let i = 0; i < 10; i++) {
+      const result = neat.finishUp(4);
+      if (neat.trainingInProgress.size === 0 || result === true) {
+        cleared = true;
+        break;
+      }
+    }
+
+    assert(cleared, "Training should be cleared after timeout generations");
+    assertEquals(
+      neat.trainingInProgress.size,
+      0,
+      "Training map should be empty after timeout",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("finishUp: clears stuck trainings promptly when wall-clock deadline has passed", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    // Simulate a stuck (never-settling) training task.
+    neat.trainingInProgress.set("expired-train-uuid", new Promise(() => {}));
+
+    // Wall-clock deadline already in the past (caller's --timeout exceeded).
+    const start = Date.now() - 10 * 60_000; // ran for 10 minutes
+    const endTimeMS = Date.now() - 60_000; // 1 minute past deadline
+    const iterations = 1000; // generous cap — must NOT keep the run alive
+    const currentGeneration = 5;
+
+    let cleared = false;
+    for (let i = 0; i < 5; i++) {
+      neat.finishUp(iterations, endTimeMS, start, currentGeneration);
+      if (neat.trainingInProgress.size === 0) {
+        cleared = true;
+        break;
+      }
+    }
+    assert(
+      cleared,
+      "Stuck training should be cleared within a few generations after the wall-clock deadline expires",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("finishUp: eventually finalizes despite a never-settling training task", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    // Orphaned training promise that will never settle.
+    neat.trainingInProgress.set("never-settles", new Promise(() => {}));
+
+    // Drive the finish-up loop with a bounded iteration cap. It must reach a
+    // terminal `true` (finalize + checkin) rather than spinning forever.
+    let finalized = false;
+    for (let i = 0; i < 50; i++) {
+      if (neat.finishUp(4)) {
+        finalized = true;
+        break;
+      }
+    }
+
+    assert(
+      finalized,
+      "Run must finalize even when a training task never settles",
+    );
+    assertEquals(
+      neat.trainingInProgress.size,
+      0,
+      "Stuck training must be abandoned before finalizing",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
 Deno.test("finishUp: returns false when additionalGenerationCount > 0", async () => {
   const dataDir = createTestDataDir(2, 1);
   const workers = createTestWorkers(dataDir);


### PR DESCRIPTION
# Evolution never finalizes: bound the finish-up wait for optional training tasks

## Summary

A training task whose worker promise never settled (e.g. a timed-out
per-creature CPU score whose worker task is orphaned) was **never reaped from
`Neat.trainingInProgress`**, so the finish-up loop spun forever and the
evolution run never finalized — discarding the whole compute window with no
champion checkin.

The root cause is in `Neat.finishUp()`: the **discovery** branch already bounds
its wait and clears stuck tasks (Issues #2432), but the **training** branch
simply logged `Waiting for N training task(s)` and returned `false` every
generation, with no deadline. A single optional training task that failed to
settle therefore wedged the entire run.

Training and discovery are optional/best-effort phases — they may be waited on
for a _bounded_ time but must **never** gate finalisation + checkin. This change
makes the training branch use the **identical** bounded-wait logic as discovery:
the smaller of an iteration-derived cap and a wall-clock-derived cap. Once the
budget is exhausted (or the caller's `--timeout` wall-clock deadline passes),
the stuck training task is abandoned and the run finalizes and checks in the
best-so-far creature.

The duplicated cap computation (previously inline in the discovery branch) was
extracted into a shared private helper `computeMaxWaitGenerations()` used by
both branches, so the two paths stay in lock-step (DRY).

Closes #2871.

## Behaviour change

```mermaid
flowchart TD
    A[finishUp called] --> B{discoveryInProgress > 0?}
    B -- yes --> C[bounded wait; clear stuck on deadline]
    B -- no --> D{trainingInProgress > 0?}
    D -- "yes (before)" --> E["return false forever ❌<br/>run never finalizes"]
    D -- "yes (after)" --> F["bounded wait; abandon stuck<br/>on deadline ✅"]
    F --> G[finalize + checkin best creature]
    D -- no --> G
```

Before: the training branch had no deadline, so a never-settling training
promise pinned `trainingInProgress.size` and `finishUp()` returned `false`
indefinitely. After: training is bounded exactly like discovery — the run always
proceeds to checkin.

## Evidence

Backend/library change only — no UI to screenshot. Verified via unit tests that
drive `Neat.finishUp()` with an injected never-settling training promise and
assert the map is emptied and the loop reaches a terminal `true`.

New/updated tests in `test/NEAT/NeatFinishUp.ts`:

- `finishUp: training timeout clears stuck trainings` — a never-settling
  training promise is abandoned after the generation-count budget.
- `finishUp: clears stuck trainings promptly when wall-clock deadline has
  passed`
  — an expired `--timeout` clears the stuck task within a few calls even with a
  generous iteration cap.
- `finishUp: eventually finalizes despite a never-settling training task` — the
  finish-up loop reaches a terminal `true` (finalize + checkin) rather than
  spinning forever.

All existing `finishUp` tests (including the discovery-timeout and cleanup-delay
cases) continue to pass, confirming the extracted `computeMaxWaitGenerations()`
preserves discovery behaviour.

```
ok | 35 passed | 0 failed
```

(test/NEAT/NeatFinishUp.ts, NeatAwaitInFlightTasks.ts,
MaxConcurrentDiscoveries.ts, NeatSchedulingLogReplaySummary.ts)

## Test Plan

- `deno test --allow-all test/NEAT/NeatFinishUp.ts` — new and existing finish-up
  cases.
- `deno test --allow-all test/NEAT/NeatAwaitInFlightTasks.ts
  test/NEAT/MaxConcurrentDiscoveries.ts
  test/NEAT/NeatSchedulingLogReplaySummary.ts`
  — adjacent scheduling/await tests.
- `./quality.sh --skip-tests` — lint, format, type-check, WASM/discovery sync
  (exit 0).

## Notes

- The fix is deliberately at the `Neat.finishUp()` level (suggested fixes #1 and
  #3 in the issue): it guarantees the run finalizes regardless of _why_ a worker
  training promise leaked, matching the design intent that optional tasks must
  never gate checkin. The worker-side path already returns with `timedOut: true`
  on the normal timeout; this defensive bound covers the case where the promise
  is nonetheless orphaned.
- Consistent with the existing discovery path, abandoned tasks are cleared from
  the in-progress map (no per-task worker abort handle is tracked at this
  layer).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq4qyj7b-b42773`<!-- vibe-worker-issue-2871 -->