### PR TITLE
Migrate GitHub Pages off Node 20 legacy build (#2877)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,80 @@
+name: Deploy GitHub Pages
+
+# Builds the `docs/` site and deploys it through the modern, GitHub-Actions
+# based Pages pipeline (Issue #2877). This replaces GitHub's managed legacy
+# `pages-build-deployment` runner, which still executes
+# `actions/checkout@v4` and `actions/upload-artifact@v4` on the deprecated
+# Node 20 runtime. Every action below runs on Node 24 (or a pinned Docker
+# image), so no Node 20 deprecation warnings remain.
+#
+# IMPORTANT (one-time, human/admin step): after this workflow merges to
+# `Develop`, set Settings → Pages → "Source" to "GitHub Actions" (Pages
+# `build_type: workflow`). Until that switch is flipped the legacy branch
+# build keeps running; flipping it hands deployment to this workflow.
+
+on:
+  push:
+    branches: [Develop]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+# Serialise Pages deployments. Unlike the lint/test workflows we do NOT cancel
+# an in-flight run: a half-finished deployment must complete to leave the live
+# site in a consistent state (Issue #2842).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+# Least-privilege GITHUB_TOKEN scopes (Issue #2706). The build job only reads
+# the repo; the deploy job needs pages:write to publish and id-token:write for
+# the OIDC verification actions/deploy-pages performs.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build docs site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Configure Pages
+        # actions/configure-pages@v6.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
+
+      - name: Build with Jekyll
+        # actions/jekyll-build-pages@v1.0.13 (pinned Docker image, no Node runtime)
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload Pages artifact
+        # actions/upload-pages-artifact@v5.0.0 (composite; wraps upload-artifact@v7, Node 24)
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        # actions/deploy-pages@v5.0.0 — Node 24 runtime
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.17",
+  "version": "5.3.18",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2877.md
+++ b/docs/archive/pr-summaries/pr-summary-2877.md
@@ -5,35 +5,35 @@
 The `github-actions-audit` finding `BP-RUNNER-actions-upload-artifact-node20`
 fired again because the runner reported Node 20 deprecation warnings for
 `actions/checkout@v4` and `actions/upload-artifact@v4` — but the evidence run
-was **`pages-build-deployment`**, GitHub's *managed* legacy Pages builder, not
+was **`pages-build-deployment`**, GitHub's _managed_ legacy Pages builder, not
 any workflow in this repository. Every repo-owned workflow was already migrated
 (checkout `@v6`, upload-artifact `@v7`, all SHA-pinned), so the only remaining
 Node 20 source was the legacy "deploy from a branch" Pages build, which we
 cannot edit because GitHub generates and runs it itself.
 
 GitHub Pages was configured as `build_type: legacy` (source: `Develop` branch,
-`/docs`). The fix is to stop using that managed builder by owning the
-deployment ourselves: a new `.github/workflows/pages.yml` builds the `docs/`
-site and publishes it through the modern, SHA-pinned Pages actions, all of
-which run on **Node 24** (or a pinned Docker image) rather than Node 20:
+`/docs`). The fix is to stop using that managed builder by owning the deployment
+ourselves: a new `.github/workflows/pages.yml` builds the `docs/` site and
+publishes it through the modern, SHA-pinned Pages actions, all of which run on
+**Node 24** (or a pinned Docker image) rather than Node 20:
 
-| Action | Pin | Runtime |
-| --- | --- | --- |
-| `actions/checkout` | `de0fac2…` (v6.0.2) | node24 |
-| `actions/configure-pages` | `45bfe01…` (v6.0.0) | node24 |
-| `actions/jekyll-build-pages` | `44a6e6b…` (v1.0.13) | pinned Docker image |
-| `actions/upload-pages-artifact` | `fc324d3…` (v5.0.0) | composite → upload-artifact@v7 (node24) |
-| `actions/deploy-pages` | `cd2ce8f…` (v5.0.0) | node24 |
+| Action                          | Pin                  | Runtime                                 |
+| ------------------------------- | -------------------- | --------------------------------------- |
+| `actions/checkout`              | `de0fac2…` (v6.0.2)  | node24                                  |
+| `actions/configure-pages`       | `45bfe01…` (v6.0.0)  | node24                                  |
+| `actions/jekyll-build-pages`    | `44a6e6b…` (v1.0.13) | pinned Docker image                     |
+| `actions/upload-pages-artifact` | `fc324d3…` (v5.0.0)  | composite → upload-artifact@v7 (node24) |
+| `actions/deploy-pages`          | `cd2ce8f…` (v5.0.0)  | node24                                  |
 
 Closes #2877.
 
 > **One-time human/admin step (after merge):** flip **Settings → Pages →
-> "Source"** to **"GitHub Actions"** (Pages `build_type: workflow`). This
-> change is admin-gated and must happen *after* the workflow lands on
-> `Develop` — flipping it earlier would break the live site, since the
-> deploying workflow would not yet exist on the default branch. Until it is
-> flipped the legacy Node 20 builder keeps running; flipping it hands
-> deployment to the new workflow and retires the deprecated runner for good.
+> "Source"** to **"GitHub Actions"** (Pages `build_type: workflow`). This change
+> is admin-gated and must happen _after_ the workflow lands on `Develop` —
+> flipping it earlier would break the live site, since the deploying workflow
+> would not yet exist on the default branch. Until it is flipped the legacy Node
+> 20 builder keeps running; flipping it hands deployment to the new workflow and
+> retires the deprecated runner for good.
 
 ## Evidence
 
@@ -85,6 +85,6 @@ actionlint                                           # clean
 
 ## Deno regression avoided
 
-Kept the change Deno-native: the validation is a Deno test under `test/ci/`
-run by `deno test`; no Node tooling, `package.json`, or `node_modules` was
+Kept the change Deno-native: the validation is a Deno test under `test/ci/` run
+by `deno test`; no Node tooling, `package.json`, or `node_modules` was
 introduced.

--- a/docs/archive/pr-summaries/pr-summary-2877.md
+++ b/docs/archive/pr-summaries/pr-summary-2877.md
@@ -1,0 +1,90 @@
+# Migrate GitHub Pages off the Node 20 legacy build (Issue #2877)
+
+## Summary
+
+The `github-actions-audit` finding `BP-RUNNER-actions-upload-artifact-node20`
+fired again because the runner reported Node 20 deprecation warnings for
+`actions/checkout@v4` and `actions/upload-artifact@v4` — but the evidence run
+was **`pages-build-deployment`**, GitHub's *managed* legacy Pages builder, not
+any workflow in this repository. Every repo-owned workflow was already migrated
+(checkout `@v6`, upload-artifact `@v7`, all SHA-pinned), so the only remaining
+Node 20 source was the legacy "deploy from a branch" Pages build, which we
+cannot edit because GitHub generates and runs it itself.
+
+GitHub Pages was configured as `build_type: legacy` (source: `Develop` branch,
+`/docs`). The fix is to stop using that managed builder by owning the
+deployment ourselves: a new `.github/workflows/pages.yml` builds the `docs/`
+site and publishes it through the modern, SHA-pinned Pages actions, all of
+which run on **Node 24** (or a pinned Docker image) rather than Node 20:
+
+| Action | Pin | Runtime |
+| --- | --- | --- |
+| `actions/checkout` | `de0fac2…` (v6.0.2) | node24 |
+| `actions/configure-pages` | `45bfe01…` (v6.0.0) | node24 |
+| `actions/jekyll-build-pages` | `44a6e6b…` (v1.0.13) | pinned Docker image |
+| `actions/upload-pages-artifact` | `fc324d3…` (v5.0.0) | composite → upload-artifact@v7 (node24) |
+| `actions/deploy-pages` | `cd2ce8f…` (v5.0.0) | node24 |
+
+Closes #2877.
+
+> **One-time human/admin step (after merge):** flip **Settings → Pages →
+> "Source"** to **"GitHub Actions"** (Pages `build_type: workflow`). This
+> change is admin-gated and must happen *after* the workflow lands on
+> `Develop` — flipping it earlier would break the live site, since the
+> deploying workflow would not yet exist on the default branch. Until it is
+> flipped the legacy Node 20 builder keeps running; flipping it hands
+> deployment to the new workflow and retires the deprecated runner for good.
+
+## Evidence
+
+This is a CI/configuration change with no web UI to screenshot. Validation is
+via `actionlint` (clean across all workflows) and the Deno CI test suite under
+`test/ci/` (70 tests pass, including the 5 new ones).
+
+```mermaid
+flowchart TD
+    subgraph Before["Before — legacy build_type"]
+      A[push to Develop /docs] --> B["GitHub-managed<br/>pages-build-deployment"]
+      B --> C["actions/checkout@v4 + actions/upload-artifact@v4<br/>⚠️ Node 20 deprecated"]
+      C --> D[Live site]
+    end
+    subgraph After["After — GitHub Actions deployment"]
+      E[push to Develop /docs] --> F["pages.yml: build job<br/>checkout@v6 → configure-pages@v6<br/>jekyll-build-pages → upload-pages-artifact@v5"]
+      F --> G["pages.yml: deploy job<br/>deploy-pages@v5 (Node 24)"]
+      G --> H[Live site]
+    end
+```
+
+## Test Plan
+
+New test file `test/ci/PagesDeploymentWorkflow.ts` (TDD — written first, failed
+against the absent workflow, passes after adding `pages.yml`):
+
+- **exists and parses** — `pages.yml` is present and valid YAML with at least
+  one job.
+- **publishes via `actions/deploy-pages`** — confirms migration to the
+  GitHub-Actions deployment model (`configure-pages`, `upload-pages-artifact`,
+  `deploy-pages`), so the legacy `pages-build-deployment` runner is retired.
+- **builds `./docs`** — `jekyll-build-pages` builds from the same `./docs`
+  source the legacy build served, preserving the rendered site.
+- **deploy permissions** — the deploy job grants `pages: write` and
+  `id-token: write`, which `deploy-pages` requires.
+- **no Node 20 actions** — no `uses:` directive pins `actions/checkout` or
+  `actions/upload-artifact` to its deprecated `@v4` (Node 20) major.
+
+The new workflow is also covered by the repo's existing generic CI tests
+(`WorkflowActionPinning`, `WorkflowJobTimeoutMinutes`,
+`WorkflowPersistCredentialsFalse`, container-image pinning) — all green.
+
+Run:
+
+```bash
+deno test --allow-read --allow-env "test/ci/*.ts"   # 70 passed
+actionlint                                           # clean
+```
+
+## Deno regression avoided
+
+Kept the change Deno-native: the validation is a Deno test under `test/ci/`
+run by `deno test`; no Node tooling, `package.json`, or `node_modules` was
+introduced.

--- a/test/ci/PagesDeploymentWorkflow.ts
+++ b/test/ci/PagesDeploymentWorkflow.ts
@@ -1,0 +1,172 @@
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+/**
+ * Issue #2877 — migrate GitHub Pages off the legacy "deploy from a branch"
+ * build so the project stops triggering GitHub's managed
+ * `pages-build-deployment` workflow, which still runs `actions/checkout@v4`
+ * and `actions/upload-artifact@v4` on the deprecated Node 20 runtime.
+ *
+ * The fix is a repo-owned Pages deployment workflow that builds the `docs/`
+ * site and publishes it through the modern, SHA-pinned Pages actions
+ * (`actions/configure-pages`, `actions/jekyll-build-pages`,
+ * `actions/upload-pages-artifact`, `actions/deploy-pages`) — all of which run
+ * on Node 24 / Docker rather than Node 20.
+ *
+ * This is a "what" test: it parses the committed workflow YAML and asserts on
+ * the resulting configuration, not on how the value happens to be written.
+ */
+
+interface Step {
+  name?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+}
+
+interface Job {
+  "runs-on"?: string;
+  permissions?: Record<string, string>;
+  steps?: Step[];
+  needs?: string | string[];
+  environment?: unknown;
+}
+
+interface Workflow {
+  name?: string;
+  on?: unknown;
+  permissions?: Record<string, string>;
+  jobs?: Record<string, Job>;
+}
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const PAGES_WORKFLOW = join(REPO_ROOT, ".github/workflows/pages.yml");
+
+async function readPagesWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(PAGES_WORKFLOW);
+  return parse(text) as Workflow;
+}
+
+function allSteps(wf: Workflow): Step[] {
+  const steps: Step[] = [];
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const step of job.steps ?? []) steps.push(step);
+  }
+  return steps;
+}
+
+/** Strip the `@<ref>` suffix from a `uses:` reference. */
+function actionName(uses: string): string {
+  return uses.split("@")[0];
+}
+
+Deno.test("Pages deployment workflow exists and parses (Issue #2877)", async () => {
+  const wf = await readPagesWorkflow();
+  assert(typeof wf === "object" && wf !== null, "pages.yml did not parse");
+  assert(
+    wf.jobs && Object.keys(wf.jobs).length > 0,
+    "pages.yml declares no jobs",
+  );
+});
+
+Deno.test(
+  "Pages workflow publishes via actions/deploy-pages, not the legacy branch build (Issue #2877)",
+  async () => {
+    const wf = await readPagesWorkflow();
+    const actions = allSteps(wf)
+      .map((s) => s.uses)
+      .filter((u): u is string => typeof u === "string")
+      .map(actionName);
+
+    assert(
+      actions.includes("actions/deploy-pages"),
+      "pages.yml must deploy through actions/deploy-pages (the modern, " +
+        "GitHub-Actions-based Pages deployment) so the legacy " +
+        "pages-build-deployment runner is no longer used",
+    );
+    assert(
+      actions.includes("actions/upload-pages-artifact"),
+      "pages.yml must upload the built site with actions/upload-pages-artifact",
+    );
+    assert(
+      actions.includes("actions/configure-pages"),
+      "pages.yml must call actions/configure-pages before deploying",
+    );
+  },
+);
+
+Deno.test(
+  "Pages workflow builds the docs/ directory it currently serves (Issue #2877)",
+  async () => {
+    const wf = await readPagesWorkflow();
+    const build = allSteps(wf).find(
+      (s) =>
+        typeof s.uses === "string" &&
+        actionName(s.uses) === "actions/jekyll-build-pages",
+    );
+    assert(
+      build !== undefined,
+      "pages.yml must build the site with actions/jekyll-build-pages so the " +
+        "rendered output matches the previous legacy `/docs` branch build",
+    );
+    assertEquals(
+      build.with?.source,
+      "./docs",
+      "jekyll-build-pages must build from ./docs (the existing Pages source)",
+    );
+  },
+);
+
+Deno.test(
+  "Pages deploy job grants the pages:write and id-token:write scopes deploy-pages needs (Issue #2877)",
+  async () => {
+    const wf = await readPagesWorkflow();
+    // Permissions may be set at the top level or on the deploying job; collect
+    // the effective scopes that apply to the deploy-pages step.
+    const topLevel = wf.permissions ?? {};
+    const deployJob = Object.values(wf.jobs ?? {}).find((job) =>
+      (job.steps ?? []).some(
+        (s) =>
+          typeof s.uses === "string" &&
+          actionName(s.uses) === "actions/deploy-pages",
+      )
+    );
+    assert(deployJob !== undefined, "no job runs actions/deploy-pages");
+    const effective = { ...topLevel, ...(deployJob.permissions ?? {}) };
+
+    assertEquals(
+      effective.pages,
+      "write",
+      "the deploy job needs `pages: write` for actions/deploy-pages",
+    );
+    assertEquals(
+      effective["id-token"],
+      "write",
+      "the deploy job needs `id-token: write` for actions/deploy-pages " +
+        "OIDC verification",
+    );
+  },
+);
+
+Deno.test(
+  "Pages workflow uses only supported runtimes — no @v4 Node 20 actions (Issue #2877)",
+  async () => {
+    const wf = await readPagesWorkflow();
+    // The deprecation the issue tracks is actions/checkout@v4 and
+    // actions/upload-artifact@v4 running on Node 20. No actual `uses:`
+    // directive may pin either action to its Node 20 `@v4` major (header
+    // comments that merely mention the deprecation are not `uses:` directives
+    // and so are correctly ignored).
+    for (const uses of allSteps(wf).map((s) => s.uses)) {
+      if (typeof uses !== "string") continue;
+      assert(
+        !/^actions\/upload-artifact@v4(\.|$)/.test(uses),
+        `pages.yml must not use the deprecated ${uses}`,
+      );
+      assert(
+        !/^actions\/checkout@v4(\.|$)/.test(uses),
+        `pages.yml must not use the deprecated ${uses}`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
# Migrate GitHub Pages off the Node 20 legacy build (Issue #2877)

## Summary

The `github-actions-audit` finding `BP-RUNNER-actions-upload-artifact-node20`
fired again because the runner reported Node 20 deprecation warnings for
`actions/checkout@v4` and `actions/upload-artifact@v4` — but the evidence run
was **`pages-build-deployment`**, GitHub's *managed* legacy Pages builder, not
any workflow in this repository. Every repo-owned workflow was already migrated
(checkout `@v6`, upload-artifact `@v7`, all SHA-pinned), so the only remaining
Node 20 source was the legacy "deploy from a branch" Pages build, which we
cannot edit because GitHub generates and runs it itself.

GitHub Pages was configured as `build_type: legacy` (source: `Develop` branch,
`/docs`). The fix is to stop using that managed builder by owning the
deployment ourselves: a new `.github/workflows/pages.yml` builds the `docs/`
site and publishes it through the modern, SHA-pinned Pages actions, all of
which run on **Node 24** (or a pinned Docker image) rather than Node 20:

| Action | Pin | Runtime |
| --- | --- | --- |
| `actions/checkout` | `de0fac2…` (v6.0.2) | node24 |
| `actions/configure-pages` | `45bfe01…` (v6.0.0) | node24 |
| `actions/jekyll-build-pages` | `44a6e6b…` (v1.0.13) | pinned Docker image |
| `actions/upload-pages-artifact` | `fc324d3…` (v5.0.0) | composite → upload-artifact@v7 (node24) |
| `actions/deploy-pages` | `cd2ce8f…` (v5.0.0) | node24 |

Closes #2877.

> **One-time human/admin step (after merge):** flip **Settings → Pages →
> "Source"** to **"GitHub Actions"** (Pages `build_type: workflow`). This
> change is admin-gated and must happen *after* the workflow lands on
> `Develop` — flipping it earlier would break the live site, since the
> deploying workflow would not yet exist on the default branch. Until it is
> flipped the legacy Node 20 builder keeps running; flipping it hands
> deployment to the new workflow and retires the deprecated runner for good.

## Evidence

This is a CI/configuration change with no web UI to screenshot. Validation is
via `actionlint` (clean across all workflows) and the Deno CI test suite under
`test/ci/` (70 tests pass, including the 5 new ones).

```mermaid
flowchart TD
    subgraph Before["Before — legacy build_type"]
      A[push to Develop /docs] --> B["GitHub-managed<br/>pages-build-deployment"]
      B --> C["actions/checkout@v4 + actions/upload-artifact@v4<br/>⚠️ Node 20 deprecated"]
      C --> D[Live site]
    end
    subgraph After["After — GitHub Actions deployment"]
      E[push to Develop /docs] --> F["pages.yml: build job<br/>checkout@v6 → configure-pages@v6<br/>jekyll-build-pages → upload-pages-artifact@v5"]
      F --> G["pages.yml: deploy job<br/>deploy-pages@v5 (Node 24)"]
      G --> H[Live site]
    end
```

## Test Plan

New test file `test/ci/PagesDeploymentWorkflow.ts` (TDD — written first, failed
against the absent workflow, passes after adding `pages.yml`):

- **exists and parses** — `pages.yml` is present and valid YAML with at least
  one job.
- **publishes via `actions/deploy-pages`** — confirms migration to the
  GitHub-Actions deployment model (`configure-pages`, `upload-pages-artifact`,
  `deploy-pages`), so the legacy `pages-build-deployment` runner is retired.
- **builds `./docs`** — `jekyll-build-pages` builds from the same `./docs`
  source the legacy build served, preserving the rendered site.
- **deploy permissions** — the deploy job grants `pages: write` and
  `id-token: write`, which `deploy-pages` requires.
- **no Node 20 actions** — no `uses:` directive pins `actions/checkout` or
  `actions/upload-artifact` to its deprecated `@v4` (Node 20) major.

The new workflow is also covered by the repo's existing generic CI tests
(`WorkflowActionPinning`, `WorkflowJobTimeoutMinutes`,
`WorkflowPersistCredentialsFalse`, container-image pinning) — all green.

Run:

```bash
deno test --allow-read --allow-env "test/ci/*.ts"   # 70 passed
actionlint                                           # clean
```

## Deno regression avoided

Kept the change Deno-native: the validation is a Deno test under `test/ci/`
run by `deno test`; no Node tooling, `package.json`, or `node_modules` was
introduced.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq6jvclv-18af2c`<!-- vibe-worker-issue-2877 -->