### PR TITLE
Add assertNever exhaustiveness guard to CoordinatedStructuralOperation switches (#2880)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.18",
+  "version": "5.3.19",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2880.md
+++ b/docs/archive/pr-summaries/pr-summary-2880.md
@@ -18,8 +18,8 @@ The `switch` over the `op.type` discriminant of the
 This PR adds a shared `assertNever(x: never)` helper and a `default` branch to
 both switches. If an eighth operation variant is ever added to
 `CoordinatedStructuralOperation`, both call sites now **fail to compile** until
-the new variant is handled — turning a latent data-loss bug into a
-compile-time error.
+the new variant is handled — turning a latent data-loss bug into a compile-time
+error.
 
 Closes #2880.
 
@@ -29,8 +29,8 @@ Closes #2880.
   parameter type `never` makes the compiler reject any unhandled union variant
   at the call site; at runtime (malformed wire data that escaped the type
   system) it throws with the offending value embedded so the failure is loud.
-- **`ApplyCoordinatedStructuralCandidate.ts`** — added `default: assertNever(op)`
-  to the operation-apply switch.
+- **`ApplyCoordinatedStructuralCandidate.ts`** — added
+  `default: assertNever(op)` to the operation-apply switch.
 - **`DiscoveryWireFormat.ts`** — added `default: return assertNever(op)` to
   `toWireCoordinatedOperation`.
 

--- a/docs/archive/pr-summaries/pr-summary-2880.md
+++ b/docs/archive/pr-summaries/pr-summary-2880.md
@@ -1,0 +1,74 @@
+# Add `assertNever` exhaustiveness guard to CoordinatedStructuralOperation switches
+
+## Summary
+
+The `switch` over the `op.type` discriminant of the
+`CoordinatedStructuralOperation` discriminated union was used in two places
+**without an exhaustiveness guard**:
+
+- `src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts`
+  — the loop body's arms end in `continue`, so a missing case would **silently
+  skip** a structural edit at runtime, corrupting a coordinated ablation that
+  Discovery emitted (the operations "must be applied in-order" as "a single
+  ablation").
+- `src/discovery/DiscoveryWireFormat.ts` (`toWireCoordinatedOperation`) — its
+  arms `return`, so a missing case surfaced only as an unhelpful "not all code
+  paths return a value" error rather than a precise exhaustiveness failure.
+
+This PR adds a shared `assertNever(x: never)` helper and a `default` branch to
+both switches. If an eighth operation variant is ever added to
+`CoordinatedStructuralOperation`, both call sites now **fail to compile** until
+the new variant is handled — turning a latent data-loss bug into a
+compile-time error.
+
+Closes #2880.
+
+## Changes
+
+- **New** `src/utils/assertNever.ts` — generic exhaustiveness guard. The
+  parameter type `never` makes the compiler reject any unhandled union variant
+  at the call site; at runtime (malformed wire data that escaped the type
+  system) it throws with the offending value embedded so the failure is loud.
+- **`ApplyCoordinatedStructuralCandidate.ts`** — added `default: assertNever(op)`
+  to the operation-apply switch.
+- **`DiscoveryWireFormat.ts`** — added `default: return assertNever(op)` to
+  `toWireCoordinatedOperation`.
+
+### Exhaustiveness flow
+
+```mermaid
+flowchart LR
+    A[New CoordinatedStructuralOperation variant added] --> B{Case handled<br/>at both switches?}
+    B -- "yes" --> C[Compiles]
+    B -- "no" --> D["op is not 'never'<br/>at default branch"]
+    D --> E[Compile error at the<br/>unhandled call site]
+```
+
+## Evidence
+
+Backend/type-system change — no UI to screenshot. Verified by:
+
+- `deno check src/utils/assertNever.ts ApplyCoordinatedStructuralCandidate.ts DiscoveryWireFormat.ts`
+  — passes, confirming the `default` branches narrow `op` to `never` (i.e. all
+  seven variants are currently handled at both sites).
+- `deno check mod.ts` — full project type-check passes.
+- `deno lint` / `deno fmt` — clean.
+- Test run: `20 passed | 0 failed` across the new guard tests and the existing
+  coordinated-structural suites.
+
+## Test Plan
+
+Added `test/utils/AssertNever.ts`:
+
+- **Runtime throw path** — `assertNever` cast through `never` throws an `Error`
+  whose message contains `"Unhandled variant"` and the offending value.
+- **Exhaustive switch** — an exhaustive `switch` returns the handled value and
+  never reaches the guard.
+- **String value** — a string-only rogue value is serialised safely into the
+  error message.
+
+Existing coordinated-structural suites (`CoordinatedStructuralCandidate`,
+`CoordinatedStructuralCandidateMoreOps`,
+`CoordinatedStructuralCandidatePreserveSynapseMetadata`) continue to pass,
+confirming the added `default` arms do not change behaviour for the seven
+existing variants.

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -17,6 +17,7 @@ import {
   buildWireToRuntimeIdMap,
   resolveCoordinatedEdgeEndpoints,
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
+import { assertNever } from "@utils/assertNever.ts";
 import { clampAndTrack } from "@utils/OverflowGuardStats.ts";
 import {
   passesProducerCompileGate,
@@ -328,6 +329,12 @@ export function applyCoordinatedStructuralCandidate(
         // No-op if synapse doesn't exist (idempotent).
         continue;
       }
+
+      default:
+        // Exhaustiveness guard: if a new CoordinatedStructuralOperation variant
+        // is added without a case above, this fails to compile rather than
+        // silently dropping the operation from the coordinated ablation.
+        assertNever(op);
     }
   }
 

--- a/src/discovery/DiscoveryWireFormat.ts
+++ b/src/discovery/DiscoveryWireFormat.ts
@@ -14,6 +14,7 @@ import {
   buildRuntimeIdToWireMap,
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
 import type { Creature } from "@creature";
+import { assertNever } from "@utils/assertNever.ts";
 import type {
   DiscoveredNeuronDetails,
   DiscoveryCandidate,
@@ -293,6 +294,10 @@ function toWireCoordinatedOperation(
         ),
         bias: op.bias,
       };
+    default:
+      // Exhaustiveness guard: a new CoordinatedStructuralOperation variant must
+      // be handled here or the compile fails at this site.
+      return assertNever(op);
   }
 }
 

--- a/src/utils/assertNever.ts
+++ b/src/utils/assertNever.ts
@@ -1,0 +1,16 @@
+/**
+ * Exhaustiveness guard for discriminated-union `switch` statements.
+ *
+ * Place `return assertNever(x)` (or `assertNever(x)`) in the `default` branch
+ * of a `switch` over a union discriminant. The compiler narrows the value to
+ * `never` only when every variant is handled; if a new variant is added and a
+ * call site forgets to handle it, the value is no longer `never` and the
+ * compile fails at that site — turning a latent runtime data-loss bug into a
+ * compile-time error.
+ *
+ * At runtime (e.g. malformed wire data that escaped the type system) it throws
+ * with the offending value so the failure is loud rather than silent.
+ */
+export function assertNever(x: never): never {
+  throw new Error(`Unhandled variant: ${JSON.stringify(x)}`);
+}

--- a/test/utils/AssertNever.ts
+++ b/test/utils/AssertNever.ts
@@ -1,0 +1,41 @@
+import { assert, assertStringIncludes, assertThrows } from "@std/assert";
+import { assertNever } from "@utils/assertNever.ts";
+
+Deno.test("assertNever - throws with the offending value embedded", () => {
+  // Cast through `never`: this is the runtime escape-hatch path that fires when
+  // malformed data slips past the compiler's exhaustiveness check.
+  const rogue = { type: "eighthVariant", payload: 42 } as unknown as never;
+  const err = assertThrows(
+    () => assertNever(rogue),
+    Error,
+  );
+  assertStringIncludes(err.message, "Unhandled variant");
+  assertStringIncludes(err.message, "eighthVariant");
+  assertStringIncludes(err.message, "42");
+});
+
+Deno.test("assertNever - exhaustive switch never reaches the guard", () => {
+  type Op = { type: "a" } | { type: "b" };
+
+  function handle(op: Op): string {
+    switch (op.type) {
+      case "a":
+        return "handled-a";
+      case "b":
+        return "handled-b";
+      default:
+        return assertNever(op);
+    }
+  }
+
+  assert(handle({ type: "a" }) === "handled-a");
+  assert(handle({ type: "b" }) === "handled-b");
+});
+
+Deno.test("assertNever - serialises a string-only value safely", () => {
+  const err = assertThrows(
+    () => assertNever("ninthVariant" as unknown as never),
+    Error,
+  );
+  assertStringIncludes(err.message, "ninthVariant");
+});


### PR DESCRIPTION
# Add `assertNever` exhaustiveness guard to CoordinatedStructuralOperation switches

## Summary

The `switch` over the `op.type` discriminant of the
`CoordinatedStructuralOperation` discriminated union was used in two places
**without an exhaustiveness guard**:

- `src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts`
  — the loop body's arms end in `continue`, so a missing case would **silently
  skip** a structural edit at runtime, corrupting a coordinated ablation that
  Discovery emitted (the operations "must be applied in-order" as "a single
  ablation").
- `src/discovery/DiscoveryWireFormat.ts` (`toWireCoordinatedOperation`) — its
  arms `return`, so a missing case surfaced only as an unhelpful "not all code
  paths return a value" error rather than a precise exhaustiveness failure.

This PR adds a shared `assertNever(x: never)` helper and a `default` branch to
both switches. If an eighth operation variant is ever added to
`CoordinatedStructuralOperation`, both call sites now **fail to compile** until
the new variant is handled — turning a latent data-loss bug into a
compile-time error.

Closes #2880.

## Changes

- **New** `src/utils/assertNever.ts` — generic exhaustiveness guard. The
  parameter type `never` makes the compiler reject any unhandled union variant
  at the call site; at runtime (malformed wire data that escaped the type
  system) it throws with the offending value embedded so the failure is loud.
- **`ApplyCoordinatedStructuralCandidate.ts`** — added `default: assertNever(op)`
  to the operation-apply switch.
- **`DiscoveryWireFormat.ts`** — added `default: return assertNever(op)` to
  `toWireCoordinatedOperation`.

### Exhaustiveness flow

```mermaid
flowchart LR
    A[New CoordinatedStructuralOperation variant added] --> B{Case handled<br/>at both switches?}
    B -- "yes" --> C[Compiles]
    B -- "no" --> D["op is not 'never'<br/>at default branch"]
    D --> E[Compile error at the<br/>unhandled call site]
```

## Evidence

Backend/type-system change — no UI to screenshot. Verified by:

- `deno check src/utils/assertNever.ts ApplyCoordinatedStructuralCandidate.ts DiscoveryWireFormat.ts`
  — passes, confirming the `default` branches narrow `op` to `never` (i.e. all
  seven variants are currently handled at both sites).
- `deno check mod.ts` — full project type-check passes.
- `deno lint` / `deno fmt` — clean.
- Test run: `20 passed | 0 failed` across the new guard tests and the existing
  coordinated-structural suites.

## Test Plan

Added `test/utils/AssertNever.ts`:

- **Runtime throw path** — `assertNever` cast through `never` throws an `Error`
  whose message contains `"Unhandled variant"` and the offending value.
- **Exhaustive switch** — an exhaustive `switch` returns the handled value and
  never reaches the guard.
- **String value** — a string-only rogue value is serialised safely into the
  error message.

Existing coordinated-structural suites (`CoordinatedStructuralCandidate`,
`CoordinatedStructuralCandidateMoreOps`,
`CoordinatedStructuralCandidatePreserveSynapseMetadata`) continue to pass,
confirming the added `default` arms do not change behaviour for the seven
existing variants.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq6mbjje-8aa895`<!-- vibe-worker-issue-2880 -->