### PR TITLE
Remove wall-clock timing assertions from discovery/NEAT unit tests (Issue #2888)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.20",
+  "version": "5.3.21",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2888.md
+++ b/docs/archive/pr-summaries/pr-summary-2888.md
@@ -2,14 +2,14 @@
 
 ## Summary
 
-Removed flake-prone wall-clock timing assertions from two unit test files.
-These assertions compared a `Date.now()` delta against a fixed millisecond
-budget — a "HOW"-flavoured check that depends on the machine the test runs on
-(loaded CI runner, shared laptop, ARM-vs-x86) rather than on observable
-behaviour. Per the project testing policy in `AGENTS.md` ("Unit tests must never
-measure timing or performance"), liveness/hang intent is now left to the test
-runner's own per-test timeout, while the genuine behavioural assertions that
-were already present are retained. Closes #2888.
+Removed flake-prone wall-clock timing assertions from two unit test files. These
+assertions compared a `Date.now()` delta against a fixed millisecond budget — a
+"HOW"-flavoured check that depends on the machine the test runs on (loaded CI
+runner, shared laptop, ARM-vs-x86) rather than on observable behaviour. Per the
+project testing policy in `AGENTS.md` ("Unit tests must never measure timing or
+performance"), liveness/hang intent is now left to the test runner's own
+per-test timeout, while the genuine behavioural assertions that were already
+present are retained. Closes #2888.
 
 Changes:
 

--- a/docs/archive/pr-summaries/pr-summary-2888.md
+++ b/docs/archive/pr-summaries/pr-summary-2888.md
@@ -1,0 +1,62 @@
+# Remove wall-clock timing assertions from discovery/NEAT unit tests
+
+## Summary
+
+Removed flake-prone wall-clock timing assertions from two unit test files.
+These assertions compared a `Date.now()` delta against a fixed millisecond
+budget — a "HOW"-flavoured check that depends on the machine the test runs on
+(loaded CI runner, shared laptop, ARM-vs-x86) rather than on observable
+behaviour. Per the project testing policy in `AGENTS.md` ("Unit tests must never
+measure timing or performance"), liveness/hang intent is now left to the test
+runner's own per-test timeout, while the genuine behavioural assertions that
+were already present are retained. Closes #2888.
+
+Changes:
+
+- `test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts` — dropped four
+  `Date.now()`-delta budget assertions (`elapsed < 5000`, `< 2000`, `< 10000`,
+  `< 30000`) and their unused `startTime`/`elapsed` locals. The surviving
+  assertions (`assertExists`, neuron-count bounds, finite-error checks, "may be
+  undefined or array" type checks) already capture the real behaviour; a genuine
+  infinite loop is caught by the runner's per-test timeout.
+- `test/NEAT/NeatAwaitInFlightTasks.ts` — dropped the redundant
+  `elapsedMs < 5000` assertion after `awaitInFlightTasks(200)`. The sibling
+  `assertEquals(neat.discoveryInProgress.size, 1, ...)` already proves the
+  timeout fired and left the long-running task in flight, making the wall-clock
+  check redundant.
+
+No production code changed — these are test-only edits.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verified by running
+the affected suites locally (Rust discovery library available, GPU enabled via
+Metal):
+
+```
+deno test -A test/NEAT/NeatAwaitInFlightTasks.ts
+ok | 6 passed | 0 failed (358ms)
+
+deno test -A test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
+ok | 6 passed | 0 failed (550ms)
+```
+
+`./quality.sh --lint-only` and `deno check` on both files pass cleanly.
+
+```mermaid
+flowchart LR
+    A["Date.now() delta<br/>vs ms budget"] -->|flakes on loaded/ARM CI| B[remove]
+    B --> C{behaviour still covered?}
+    C -->|"yes — sibling assertions<br/>(size, exists, bounds)"| D[keep behavioural asserts]
+    C -->|"hang detection"| E[runner per-test timeout]
+```
+
+## Test Plan
+
+- Modified `test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts`: removed
+  timing budget assertions from the "weighted selection", "all-zero error",
+  "analyze phases respect timeout", and "batching" tests; behavioural assertions
+  retained. All 6 tests pass.
+- Modified `test/NEAT/NeatAwaitInFlightTasks.ts`: removed the redundant
+  `elapsedMs < 5000` assertion from "respects timeout with long-running tasks";
+  the still-in-flight assertion proves the timeout behaviour. All 6 tests pass.

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
@@ -207,24 +207,21 @@ Deno.test({
       throw new Error("Rust recording flush failed");
     }
 
-    // selectNeuronsWeightedByError should complete even if selection is difficult
-    const startTime = Date.now();
+    // selectNeuronsWeightedByError should complete even if selection is
+    // difficult. Termination is the behaviour under test; a genuine infinite
+    // loop is caught by the test runner's own per-test timeout, not by a
+    // wall-clock budget (Issue #2888).
     const selectedNeurons = await discoverStructure
       .selectNeuronsWeightedByError(
         10,
         DEFAULT_COST_OF_GROWTH,
       );
-    const elapsed = Date.now() - startTime;
 
     assertExists(selectedNeurons, "Should return selected neurons");
     assert(selectedNeurons.length > 0, "Should select at least some neurons");
     assert(
       selectedNeurons.length <= 10,
       "Should not select more than requested",
-    );
-    assert(
-      elapsed < 5000,
-      `Selection took ${elapsed}ms, should complete in < 5s (would hang forever if infinite loop)`,
     );
 
     await discoverStructure.cleanUp();
@@ -352,20 +349,16 @@ Deno.test({
     // With zero error, should return empty or fall back gracefully
     assertExists(viableNeurons, "Should handle zero-error case");
 
-    // Selection should not hang with zero total error
-    const startTime = Date.now();
+    // Selection should not hang with zero total error. Termination is the
+    // behaviour under test; a genuine hang is caught by the runner's per-test
+    // timeout rather than a wall-clock budget (Issue #2888).
     const selectedNeurons = await discoverStructure
       .selectNeuronsWeightedByError(
         5,
         DEFAULT_COST_OF_GROWTH,
       );
-    const elapsed = Date.now() - startTime;
 
     assertExists(selectedNeurons, "Should handle zero-error selection");
-    assert(
-      elapsed < 2000,
-      `Selection with zero error took ${elapsed}ms, should complete quickly`,
-    );
 
     await discoverStructure.cleanUp();
   },
@@ -406,9 +399,9 @@ Deno.test({
     // Wait for timeout to pass (0.1s timeout + small buffer)
     await new Promise((resolve) => setTimeout(resolve, 150));
 
-    // These should all return quickly due to timeout checks
-    const startTime = Date.now();
-
+    // These should all return after the configured timeout has elapsed. A
+    // genuine hang is caught by the runner's per-test timeout, not by a
+    // wall-clock budget (Issue #2888).
     const analysisResult = await discoverStructure.analyze(
       5,
       DEFAULT_COST_OF_GROWTH,
@@ -422,15 +415,7 @@ Deno.test({
       DEFAULT_COST_OF_GROWTH,
     );
 
-    const elapsed = Date.now() - startTime;
-
-    // All should return undefined or complete quickly due to timeout
-    assert(
-      elapsed < 10000,
-      `Analysis phases took ${elapsed}ms after timeout, should exit quickly`,
-    );
-
-    // Results may be undefined due to timeout, which is correct behavior
+    // Results may be undefined due to timeout, which is correct behaviour
     assert(
       analysisResult === undefined || Array.isArray(analysisResult),
       "Analysis should return undefined or array",
@@ -489,16 +474,12 @@ Deno.test({
       throw new Error("Rust recording flush failed");
     }
 
-    // listViableNeurons uses batching internally - if this completes, batching works
-    const startTime = Date.now();
+    // listViableNeurons uses batching internally - if this completes, batching
+    // works. A genuine hang is caught by the runner's per-test timeout, not by
+    // a wall-clock budget (Issue #2888).
     const viableNeurons = await discoverStructure.listViableNeurons();
-    const elapsed = Date.now() - startTime;
 
     assertExists(viableNeurons, "Should complete with batching");
-    assert(
-      elapsed < 30000,
-      `Should complete in reasonable time (${elapsed}ms), not hang`,
-    );
 
     await discoverStructure.cleanUp();
   },

--- a/test/NEAT/NeatAwaitInFlightTasks.ts
+++ b/test/NEAT/NeatAwaitInFlightTasks.ts
@@ -137,15 +137,11 @@ Deno.test("awaitInFlightTasks: respects timeout with long-running tasks", async 
     neat.discoveryInProgress.set("slow-uuid", taskPromise);
 
     try {
-      const startMs = Date.now();
+      // Returns after the short timeout without waiting for the 60s task. The
+      // assertion below — that the discovery task is still in flight — proves
+      // the timeout fired rather than the task completing (Issue #2888); a
+      // genuine hang is caught by the runner's per-test timeout.
       await neat.awaitInFlightTasks(200); // Short timeout
-      const elapsedMs = Date.now() - startMs;
-
-      // Should have returned after roughly the timeout, not waited for the full task
-      assert(
-        elapsedMs < 5000,
-        `Should have timed out quickly, but took ${elapsedMs}ms`,
-      );
 
       // Task is still in progress (not cleared by timeout)
       assertEquals(


### PR DESCRIPTION
# Remove wall-clock timing assertions from discovery/NEAT unit tests

## Summary

Removed flake-prone wall-clock timing assertions from two unit test files.
These assertions compared a `Date.now()` delta against a fixed millisecond
budget — a "HOW"-flavoured check that depends on the machine the test runs on
(loaded CI runner, shared laptop, ARM-vs-x86) rather than on observable
behaviour. Per the project testing policy in `AGENTS.md` ("Unit tests must never
measure timing or performance"), liveness/hang intent is now left to the test
runner's own per-test timeout, while the genuine behavioural assertions that
were already present are retained. Closes #2888.

Changes:

- `test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts` — dropped four
  `Date.now()`-delta budget assertions (`elapsed < 5000`, `< 2000`, `< 10000`,
  `< 30000`) and their unused `startTime`/`elapsed` locals. The surviving
  assertions (`assertExists`, neuron-count bounds, finite-error checks, "may be
  undefined or array" type checks) already capture the real behaviour; a genuine
  infinite loop is caught by the runner's per-test timeout.
- `test/NEAT/NeatAwaitInFlightTasks.ts` — dropped the redundant
  `elapsedMs < 5000` assertion after `awaitInFlightTasks(200)`. The sibling
  `assertEquals(neat.discoveryInProgress.size, 1, ...)` already proves the
  timeout fired and left the long-running task in flight, making the wall-clock
  check redundant.

No production code changed — these are test-only edits.

## Evidence

Backend/test-only change — no web interface to screenshot. Verified by running
the affected suites locally (Rust discovery library available, GPU enabled via
Metal):

```
deno test -A test/NEAT/NeatAwaitInFlightTasks.ts
ok | 6 passed | 0 failed (358ms)

deno test -A test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts
ok | 6 passed | 0 failed (550ms)
```

`./quality.sh --lint-only` and `deno check` on both files pass cleanly.

```mermaid
flowchart LR
    A["Date.now() delta<br/>vs ms budget"] -->|flakes on loaded/ARM CI| B[remove]
    B --> C{behaviour still covered?}
    C -->|"yes — sibling assertions<br/>(size, exists, bounds)"| D[keep behavioural asserts]
    C -->|"hang detection"| E[runner per-test timeout]
```

## Test Plan

- Modified `test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts`: removed
  timing budget assertions from the "weighted selection", "all-zero error",
  "analyze phases respect timeout", and "batching" tests; behavioural assertions
  retained. All 6 tests pass.
- Modified `test/NEAT/NeatAwaitInFlightTasks.ts`: removed the redundant
  `elapsedMs < 5000` assertion from "respects timeout with long-running tasks";
  the still-in-flight assertion proves the timeout behaviour. All 6 tests pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq7mvxa1-015736`<!-- vibe-worker-issue-2888 -->