### PR TITLE
Tests: Replace build.sh source-text grep assertions with behavioural tests (#2886)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -249,6 +249,17 @@ EOF
   return 0
 }
 
+# extract_bundle — unpack the downloaded tarball into the destination tree
+# without honouring archived ownership or permission bits (issue #2744). The
+# --no-same-owner / --no-same-permissions flags ensure a hostile archive
+# cannot set foreign ownership or world-writable/setuid bits on extracted
+# files; permissions fall back to the caller's umask instead.
+extract_bundle() {
+  local archive="$1"
+  local dest="$2"
+  tar --no-same-owner --no-same-permissions -xzf "$archive" -C "$dest"
+}
+
 # write_content_manifest — record sha256(file) for every artefact in the
 # vendored pkg so --verify-only can detect post-install tampering even
 # without a network round-trip. Format is standard `shasum -a 256`
@@ -601,7 +612,7 @@ assert_safe_tar_entries "$tmp_dir/$ASSET_NAME"
 
 mkdir -p "wasm_activation"
 echo "Extracting ${ASSET_NAME} into wasm_activation/..."
-tar --no-same-owner --no-same-permissions -xzf "$tmp_dir/$ASSET_NAME" -C "wasm_activation/"
+extract_bundle "$tmp_dir/$ASSET_NAME" "wasm_activation/"
 
 # Ensure neat_core_rev.txt is consistent with the requested SHA. CI
 # writes this file, but we re-stamp it defensively in case someone

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.22",
+  "version": "5.3.23",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.lock
+++ b/deno.lock
@@ -18,7 +18,8 @@
     "jsr:@std/testing@1.0.19": "1.0.19",
     "jsr:@std/uuid@1.1.1": "1.1.1",
     "jsr:@std/yaml@1.1.1": "1.1.1",
-    "jsr:@stsoftware/tags@1.0.13": "1.0.13"
+    "jsr:@stsoftware/tags@1.0.13": "1.0.13",
+    "npm:cspell@*": "10.0.1"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -82,6 +83,528 @@
       "dependencies": [
         "jsr:@std/cli"
       ]
+    }
+  },
+  "npm": {
+    "@cspell/cspell-bundled-dicts@10.0.1": {
+      "integrity": "sha512-WvkSDNX4Uyyj/ZgbPO6L38iFNMfK1EqsH1FteRiI2qLz6QZMXRFrIt12OqiWIplzZDDaVpBH9FCJOPJll0fjCQ==",
+      "dependencies": [
+        "@cspell/dict-ada",
+        "@cspell/dict-al",
+        "@cspell/dict-aws",
+        "@cspell/dict-bash",
+        "@cspell/dict-companies",
+        "@cspell/dict-cpp",
+        "@cspell/dict-cryptocurrencies",
+        "@cspell/dict-csharp",
+        "@cspell/dict-css",
+        "@cspell/dict-dart",
+        "@cspell/dict-data-science",
+        "@cspell/dict-django",
+        "@cspell/dict-docker",
+        "@cspell/dict-dotnet",
+        "@cspell/dict-elixir",
+        "@cspell/dict-en-common-misspellings",
+        "@cspell/dict-en-gb-mit",
+        "@cspell/dict-en_us",
+        "@cspell/dict-filetypes",
+        "@cspell/dict-flutter",
+        "@cspell/dict-fonts",
+        "@cspell/dict-fsharp",
+        "@cspell/dict-fullstack",
+        "@cspell/dict-gaming-terms",
+        "@cspell/dict-git",
+        "@cspell/dict-golang",
+        "@cspell/dict-google",
+        "@cspell/dict-haskell",
+        "@cspell/dict-html",
+        "@cspell/dict-html-symbol-entities",
+        "@cspell/dict-java",
+        "@cspell/dict-julia",
+        "@cspell/dict-k8s",
+        "@cspell/dict-kotlin",
+        "@cspell/dict-latex",
+        "@cspell/dict-lorem-ipsum",
+        "@cspell/dict-lua",
+        "@cspell/dict-makefile",
+        "@cspell/dict-markdown",
+        "@cspell/dict-monkeyc",
+        "@cspell/dict-node",
+        "@cspell/dict-npm",
+        "@cspell/dict-php",
+        "@cspell/dict-powershell",
+        "@cspell/dict-public-licenses",
+        "@cspell/dict-python",
+        "@cspell/dict-r",
+        "@cspell/dict-ruby",
+        "@cspell/dict-rust",
+        "@cspell/dict-scala",
+        "@cspell/dict-shell",
+        "@cspell/dict-software-terms",
+        "@cspell/dict-sql",
+        "@cspell/dict-svelte",
+        "@cspell/dict-swift",
+        "@cspell/dict-terraform",
+        "@cspell/dict-typescript",
+        "@cspell/dict-vue",
+        "@cspell/dict-zig"
+      ]
+    },
+    "@cspell/cspell-json-reporter@10.0.1": {
+      "integrity": "sha512-/nes1RGILec3WCBcoMOd0byNTBtnJuPaVz/+ZzqYkLtY7x58VMcBG5kyP6hPyN8cIwjRADE/SR43gwdXuqk/FA==",
+      "dependencies": [
+        "@cspell/cspell-types"
+      ]
+    },
+    "@cspell/cspell-performance-monitor@10.0.1": {
+      "integrity": "sha512-9tVcHXwRnbazUv4WSG0h3MqV4+LgmLNgSALAQUflPPW0EMxTf7C4Dmv9cgxJyCEQrdnVKCr58nPPaahhz9LJUg=="
+    },
+    "@cspell/cspell-pipe@10.0.1": {
+      "integrity": "sha512-HPeXMD9AZ3V/qPkvQaPcak+C7cJ2z7JTHN8smd6J8L2aThLRky2cHc2OyeaHPSHB7WA47b4z2n5u5nawZhv5VQ=="
+    },
+    "@cspell/cspell-resolver@10.0.1": {
+      "integrity": "sha512-PIzkZHD1fGUQx1XteK2d1iQ0Mzq/maYcoB4jkvAiiR6WqP3MWYNKFdI9z+R5pOq5KgMfW+5Ig1q0oSR6h8irlA==",
+      "dependencies": [
+        "global-directory"
+      ]
+    },
+    "@cspell/cspell-service-bus@10.0.1": {
+      "integrity": "sha512-y6NcIGP2IdXaBL4PVH8vxsr7K27wzz3Ech87UtUtrDSXAiVEOvXgAIknEOUVp59rTlUE8Rn4IRURC6f/hgMyfw=="
+    },
+    "@cspell/cspell-types@10.0.1": {
+      "integrity": "sha512-kLgLShnWADDVreKC63pBrWkcvxgZzFIfO34Jhx/SWfuOIA3cD8AXT+HjyuLfoGJ7mUb58hv2kUziKzEy4INb1w=="
+    },
+    "@cspell/cspell-worker@10.0.1": {
+      "integrity": "sha512-L2bJerfuYOls2wEknm8FmynLtj/G7O4UqX9I/HznRggEW6i2yZIxagDetpVDNowpyavNHJ3SJtUFiyMiZc16Sw==",
+      "dependencies": [
+        "cspell-lib"
+      ]
+    },
+    "@cspell/dict-ada@4.1.1": {
+      "integrity": "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ=="
+    },
+    "@cspell/dict-al@1.1.1": {
+      "integrity": "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ=="
+    },
+    "@cspell/dict-aws@4.0.17": {
+      "integrity": "sha512-ORcblTWcdlGjIbWrgKF+8CNEBQiLVKdUOFoTn0KPNkAYnFcdPP0muT4892h7H4Xafh3j72wqB4/loQ6Nti9E/w=="
+    },
+    "@cspell/dict-bash@4.2.3": {
+      "integrity": "sha512-ljUZoKHbDqw5Sx0qpL2qTUlmkmr+vhZH/sCNrNaBZKTbdgiswErSnIF1jRbGmEitJNxHRHWsuZyVgnTGfVO1Yw==",
+      "dependencies": [
+        "@cspell/dict-shell"
+      ]
+    },
+    "@cspell/dict-companies@3.2.11": {
+      "integrity": "sha512-0cmafbcz2pTHXLd59eLR1gvDvN6aWAOM0+cIL4LLF9GX9yB2iKDNrKsvs4tJRqutoaTdwNFBbV0FYv+6iCtebQ=="
+    },
+    "@cspell/dict-cpp@7.0.2": {
+      "integrity": "sha512-dfbeERiVNeqmo/npivdR6rDiBCqZi3QtjH2Z0HFcXwpdj6i97dX1xaKyK2GUsO/p4u1TOv63Dmj5Vm48haDpuA=="
+    },
+    "@cspell/dict-cryptocurrencies@5.0.5": {
+      "integrity": "sha512-R68hYYF/rtlE6T/dsObStzN5QZw+0aQBinAXuWCVqwdS7YZo0X33vGMfChkHaiCo3Z2+bkegqHlqxZF4TD3rUA=="
+    },
+    "@cspell/dict-csharp@4.0.8": {
+      "integrity": "sha512-qmk45pKFHSxckl5mSlbHxmDitSsGMlk/XzFgt7emeTJWLNSTUK//MbYAkBNRtfzB4uD7pAFiKgpKgtJrTMRnrQ=="
+    },
+    "@cspell/dict-css@4.1.2": {
+      "integrity": "sha512-+ylGoKdwZ2sVOCOnU2Eq5wDZx+RaVX3HoKyNHGGsFvhSw6IidQ6tH/mAPKBDofViHJoWCPNlklE0lTr6MDG3QA=="
+    },
+    "@cspell/dict-dart@2.3.2": {
+      "integrity": "sha512-sUiLW56t9gfZcu8iR/5EUg+KYyRD83Cjl3yjDEA2ApVuJvK1HhX+vn4e4k4YfjpUQMag8XO2AaRhARE09+/rqw=="
+    },
+    "@cspell/dict-data-science@2.0.14": {
+      "integrity": "sha512-jl6Ds4u5u5JT+yY30pWQpAbdCHfy3lCcNkLbpL/AZKoUaLEoXbaYsps9xQtvD7DyaiXxiLZkdH2yHHXtoFtZyg=="
+    },
+    "@cspell/dict-django@4.1.6": {
+      "integrity": "sha512-SdbSFDGy9ulETqNz15oWv2+kpWLlk8DJYd573xhIkeRdcXOjskRuxjSZPKfW7O3NxN/KEf3gm3IevVOiNuFS+w=="
+    },
+    "@cspell/dict-docker@1.1.17": {
+      "integrity": "sha512-OcnVTIpHIYYKhztNTyK8ShAnXTfnqs43hVH6p0py0wlcwRIXe5uj4f12n7zPf2CeBI7JAlPjEsV0Rlf4hbz/xQ=="
+    },
+    "@cspell/dict-dotnet@5.0.13": {
+      "integrity": "sha512-xPp7jMnFpOri7tzmqmm/dXMolXz1t2bhNqxYkOyMqXhvs08oc7BFs+EsbDY0X7hqiISgeFZGNqn0dOCr+ncPYw=="
+    },
+    "@cspell/dict-elixir@4.0.8": {
+      "integrity": "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q=="
+    },
+    "@cspell/dict-en-common-misspellings@2.1.12": {
+      "integrity": "sha512-14Eu6QGqyksqOd4fYPuRb58lK1Va7FQK9XxFsRKnZU8LhL3N+kj7YKDW+7aIaAN/0WGEqslGP6lGbQzNti8Akw=="
+    },
+    "@cspell/dict-en-gb-mit@3.1.24": {
+      "integrity": "sha512-Oowb/Uzkh7OmDRdCcETzMc9imEb4IpLlHJXoYjX8A8DS2X/54gqSjI915JFB8hKtFjBko5OM0BLQ+6cZhFEMmQ=="
+    },
+    "@cspell/dict-en_us@4.4.35": {
+      "integrity": "sha512-xWpxBCc/FzzMMo/A+0qwARVaIIhR0Ql8yhhv4rvsvg+GfQF+LG9yzg2GwTM5N2rjvzmM3nKuR9zxFZq2I6fJSg=="
+    },
+    "@cspell/dict-filetypes@3.0.18": {
+      "integrity": "sha512-yU7RKD/x1IWmDLzWeiItMwgV+6bUcU/af23uS0+uGiFUbsY1qWV/D4rxlAAO6Z7no3J2z8aZOkYIOvUrJq0Rcw=="
+    },
+    "@cspell/dict-flutter@1.1.1": {
+      "integrity": "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A=="
+    },
+    "@cspell/dict-fonts@4.0.6": {
+      "integrity": "sha512-aR/0csY01dNb0A1tw/UmN9rKgHruUxsYsvXu6YlSBJFu60s26SKr/k1o4LavpHTQ+lznlYMqAvuxGkE4Flliqw=="
+    },
+    "@cspell/dict-fsharp@1.1.1": {
+      "integrity": "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA=="
+    },
+    "@cspell/dict-fullstack@3.2.9": {
+      "integrity": "sha512-diZX+usW5aZ4/b2T0QM/H/Wl9aNMbdODa1Jq0ReBr/jazmNeWjd+PyqeVgzd1joEaHY+SAnjrf/i9CwKd2ZtWQ=="
+    },
+    "@cspell/dict-gaming-terms@1.1.2": {
+      "integrity": "sha512-9XnOvaoTBscq0xuD6KTEIkk9hhdfBkkvJAIsvw3JMcnp1214OCGW8+kako5RqQ2vTZR3Tnf3pc57o7VgkM0q1Q=="
+    },
+    "@cspell/dict-git@3.1.0": {
+      "integrity": "sha512-KEt9zGkxqGy2q1nwH4CbyqTSv5nadpn8BAlDnzlRcnL0Xb3LX9xTgSGShKvzb0bw35lHoYyLWN2ZKAqbC4pgGQ=="
+    },
+    "@cspell/dict-golang@6.0.26": {
+      "integrity": "sha512-YKA7Xm5KeOd14v5SQ4ll6afe9VSy3a2DWM7L9uBq4u3lXToRBQ1W5PRa+/Q9udd+DTURyVVnQ+7b9cnOlNxaRg=="
+    },
+    "@cspell/dict-google@1.0.9": {
+      "integrity": "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA=="
+    },
+    "@cspell/dict-haskell@4.0.6": {
+      "integrity": "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ=="
+    },
+    "@cspell/dict-html-symbol-entities@4.0.5": {
+      "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA=="
+    },
+    "@cspell/dict-html@4.0.15": {
+      "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw=="
+    },
+    "@cspell/dict-java@5.0.12": {
+      "integrity": "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A=="
+    },
+    "@cspell/dict-julia@1.1.1": {
+      "integrity": "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA=="
+    },
+    "@cspell/dict-k8s@1.0.12": {
+      "integrity": "sha512-2LcllTWgaTfYC7DmkMPOn9GsBWsA4DZdlun4po8s2ysTP7CPEnZc1ZfK6pZ2eI4TsZemlUQQ+NZxMe9/QutQxg=="
+    },
+    "@cspell/dict-kotlin@1.1.1": {
+      "integrity": "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q=="
+    },
+    "@cspell/dict-latex@5.1.0": {
+      "integrity": "sha512-qxT4guhysyBt0gzoliXYEBYinkAdEtR2M7goRaUH0a7ltCsoqqAeEV8aXYRIdZGcV77gYSobvu3jJL038tlPAw=="
+    },
+    "@cspell/dict-lorem-ipsum@4.0.5": {
+      "integrity": "sha512-9a4TJYRcPWPBKkQAJ/whCu4uCAEgv/O2xAaZEI0n4y1/l18Yyx8pBKoIX5QuVXjjmKEkK7hi5SxyIsH7pFEK9Q=="
+    },
+    "@cspell/dict-lua@4.0.8": {
+      "integrity": "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA=="
+    },
+    "@cspell/dict-makefile@1.0.5": {
+      "integrity": "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ=="
+    },
+    "@cspell/dict-markdown@2.0.17_@cspell+dict-css@4.1.2_@cspell+dict-html@4.0.15_@cspell+dict-html-symbol-entities@4.0.5_@cspell+dict-typescript@3.2.3": {
+      "integrity": "sha512-H8bAxih6U8NOnSPL7R8My+tqjaB4tmnJTjERuz4zYqmf+cH+5xshX3UVgKlwWFcyjsYfv/zEDuRdMctQv1q6HQ==",
+      "dependencies": [
+        "@cspell/dict-css",
+        "@cspell/dict-html",
+        "@cspell/dict-html-symbol-entities",
+        "@cspell/dict-typescript"
+      ]
+    },
+    "@cspell/dict-monkeyc@1.0.12": {
+      "integrity": "sha512-MN7Vs11TdP5mbdNFQP5x2Ac8zOBm97ARg6zM5Sb53YQt/eMvXOMvrep7+/+8NJXs0jkp70bBzjqU4APcqBFNAw=="
+    },
+    "@cspell/dict-node@5.0.9": {
+      "integrity": "sha512-hO+ga+uYZ/WA4OtiMEyKt5rDUlUyu3nXMf8KVEeqq2msYvAPdldKBGH7lGONg6R/rPhv53Rb+0Y1SLdoK1+7wQ=="
+    },
+    "@cspell/dict-npm@5.2.41": {
+      "integrity": "sha512-To3xsfRmMBYVXtWVEdUgV35M9a/JZ54dSuoY6m6D3uHKKL3I326Wmy4xifZ3PU8MQaWhyEH7zbIcUEtKwTQMcA=="
+    },
+    "@cspell/dict-php@4.1.1": {
+      "integrity": "sha512-EXelI+4AftmdIGtA8HL8kr4WlUE11OqCSVlnIgZekmTkEGSZdYnkFdiJ5IANSALtlQ1mghKjz+OFqVs6yowgWA=="
+    },
+    "@cspell/dict-powershell@5.0.15": {
+      "integrity": "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg=="
+    },
+    "@cspell/dict-public-licenses@2.0.16": {
+      "integrity": "sha512-EQRrPvEOmwhwWezV+W7LjXbIBjiy6y/shrET6Qcpnk3XANTzfvWflf9PnJ5kId/oKWvihFy0za0AV1JHd03pSQ=="
+    },
+    "@cspell/dict-python@4.2.27": {
+      "integrity": "sha512-Rj6xQgYS4X6ienjgAZF+njA0GRY4oSPouJWv0vfikCTn6EWlfk0V6Dy1HP3Migj1O+IC2NmespgVq+BZNSp8OA==",
+      "dependencies": [
+        "@cspell/dict-data-science"
+      ]
+    },
+    "@cspell/dict-r@2.1.1": {
+      "integrity": "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw=="
+    },
+    "@cspell/dict-ruby@5.1.1": {
+      "integrity": "sha512-LHrp84oEV6q1ZxPPyj4z+FdKyq1XAKYPtmGptrd+uwHbrF/Ns5+fy6gtSi7pS+uc0zk3JdO9w/tPK+8N1/7WUA=="
+    },
+    "@cspell/dict-rust@4.1.2": {
+      "integrity": "sha512-O1FHrumYcO+HZti3dHfBPUdnDFkI+nbYK3pxYmiM1sr+G0ebOd6qchmswS0Wsc6ZdEVNiPYJY/gZQR6jfW3uOg=="
+    },
+    "@cspell/dict-scala@5.0.9": {
+      "integrity": "sha512-AjVcVAELgllybr1zk93CJ5wSUNu/Zb5kIubymR/GAYkMyBdYFCZ3Zbwn4Zz8GJlFFAbazABGOu0JPVbeY59vGg=="
+    },
+    "@cspell/dict-shell@1.2.0": {
+      "integrity": "sha512-PVctvT22lJ49niMiakO8xieY7ELCAzjSqhejWR7bAMb5AZ9F4WDEs+XdGMnoVHWeXq7K5rcepLPmEJb+37zzIw=="
+    },
+    "@cspell/dict-software-terms@5.2.2": {
+      "integrity": "sha512-0CaYd6TAsKtEoA7tNswm1iptEblTzEe3UG8beG2cpSTHk7afWIVMtJLgXDv0f/Li67Lf3Z1Jf3JeXR7GsJ2TRw=="
+    },
+    "@cspell/dict-sql@2.2.1": {
+      "integrity": "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg=="
+    },
+    "@cspell/dict-svelte@1.0.7": {
+      "integrity": "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ=="
+    },
+    "@cspell/dict-swift@2.0.6": {
+      "integrity": "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA=="
+    },
+    "@cspell/dict-terraform@1.1.3": {
+      "integrity": "sha512-gr6wxCydwSFyyBKhBA2xkENXtVFToheqYYGFvlMZXWjviynXmh+NK/JTvTCk/VHk3+lzbO9EEQKee6VjrAUSbA=="
+    },
+    "@cspell/dict-typescript@3.2.3": {
+      "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg=="
+    },
+    "@cspell/dict-vue@3.0.5": {
+      "integrity": "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA=="
+    },
+    "@cspell/dict-zig@1.0.0": {
+      "integrity": "sha512-XibBIxBlVosU06+M6uHWkFeT0/pW5WajDRYdXG2CgHnq85b0TI/Ks0FuBJykmsgi2CAD3Qtx8UHFEtl/DSFnAQ=="
+    },
+    "@cspell/dynamic-import@10.0.1": {
+      "integrity": "sha512-mP1gdq00aIcH8HxNMqnH11X6BKxLcneDtFgl/ecjIKnaGKwi44m8AndP5Kr4ODaYdl8UUw9O3dJh7KaQXnLHZQ==",
+      "dependencies": [
+        "@cspell/url",
+        "import-meta-resolve"
+      ]
+    },
+    "@cspell/filetypes@10.0.1": {
+      "integrity": "sha512-Z5S35giU5IW49fBBq6BksUbE8PC4IYPfaKuwl5Nl9jkf/OkAKiBmCowKX45NzRUQInwK/GSqqIUifrNeI6LdLw=="
+    },
+    "@cspell/rpc@10.0.1": {
+      "integrity": "sha512-axSRKv3zEAmBm66iD/FV/MPmE4/Yf7c3PZiwTW894Yd3iEhtn3KPKeTrqQ2/tDrhB1Z2qTsap/Hue0MK4o5WXg=="
+    },
+    "@cspell/strong-weak-map@10.0.1": {
+      "integrity": "sha512-lenN1DVyPi8nJLSMSJJ670ddTjyiruLueuSZO1qLcxBqUhgxDt/mALu9N/1m6WdOVcg6m/5cLiZVg2KOo2UzRw=="
+    },
+    "@cspell/url@10.0.1": {
+      "integrity": "sha512-abYYgI29wJhWIfWTYrYuzRYDcHQUQ1N5ylnhxYn1NJnIQMqUWGLbDmt12JABtZ+R6h6UNatQrS7rhP86etvJyQ=="
+    },
+    "ansi-regex@6.2.2": {
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
+    },
+    "array-timsort@1.0.3": {
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="
+    },
+    "chalk-template@1.1.2": {
+      "integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
+      "dependencies": [
+        "chalk"
+      ]
+    },
+    "chalk@5.6.2": {
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
+    },
+    "commander@14.0.3": {
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="
+    },
+    "comment-json@5.0.0": {
+      "integrity": "sha512-uiqLcOiVDJtBP8WGkZHEP+FZIhTzP1dxvn59EfoYUi9gqupjrBWVQkO2atDrbnKPwLeotFYDsuNb26uBMqB+hw==",
+      "dependencies": [
+        "array-timsort",
+        "esprima"
+      ]
+    },
+    "cspell-config-lib@10.0.1": {
+      "integrity": "sha512-hMpo/0j6k7pbiqrLDOLJKD2IGP9XwhjKf2miiM6p84Xeo4nyuFZaxxDCQ68R851HSYFrrdltgpoipMbj1h2Tnw==",
+      "dependencies": [
+        "@cspell/cspell-types",
+        "comment-json",
+        "smol-toml",
+        "yaml"
+      ]
+    },
+    "cspell-dictionary@10.0.1": {
+      "integrity": "sha512-3cZ659vgsZWkzGQJR/sNqGDVt/OnvTSieLKI76V++4t1bHJfochb9ZrrwsuMsb1VPGiyqClUP1/O6WrefF/FVg==",
+      "dependencies": [
+        "@cspell/cspell-performance-monitor",
+        "@cspell/cspell-pipe",
+        "@cspell/cspell-types",
+        "cspell-trie-lib",
+        "fast-equals"
+      ]
+    },
+    "cspell-gitignore@10.0.1": {
+      "integrity": "sha512-wN23U61Mx6qPJN3CesOmBU9vnbJ0jQm/ylK0iaVui3CcnO7Zzl5qLu5mPHUzGQGm8yso6qjyxqo16Ho7LpZGOQ==",
+      "dependencies": [
+        "@cspell/url",
+        "cspell-glob",
+        "cspell-io"
+      ],
+      "bin": true
+    },
+    "cspell-glob@10.0.1": {
+      "integrity": "sha512-7bII9J3aSSpZDwhx7w+zfQXbMxHZQ3be0ilUp5bHrsjz6o07v/NqOHMGcwKdPn1sw2dxDz9sv057xE5pqXnSdw==",
+      "dependencies": [
+        "@cspell/url",
+        "picomatch"
+      ]
+    },
+    "cspell-grammar@10.0.1": {
+      "integrity": "sha512-xC9AFYmaI9wsO//a7S5tdDGKGJVD5UEEsTg+Up2fi7lPfXIryisYmV6tePNL1SEg0idYss4ja8LUZ3Mib09BjQ==",
+      "dependencies": [
+        "@cspell/cspell-pipe",
+        "@cspell/cspell-types"
+      ],
+      "bin": true
+    },
+    "cspell-io@10.0.1": {
+      "integrity": "sha512-8C2ka07faxflnaqEBO3pektS21XViE/SEHT7F5ZD1ou7FyMR5u3xawTBJSczClfsxLt/WYeztBYrpmGAjmjksw==",
+      "dependencies": [
+        "@cspell/cspell-service-bus",
+        "@cspell/url"
+      ]
+    },
+    "cspell-lib@10.0.1": {
+      "integrity": "sha512-RpsIPiLzc4/YMW8BMRKpyJ81x439qjYWcqgdKeXnMkbKM88J9PexzutfFf/4v97v96KzfNitEzMpbI0uj8OeUg==",
+      "dependencies": [
+        "@cspell/cspell-bundled-dicts",
+        "@cspell/cspell-performance-monitor",
+        "@cspell/cspell-pipe",
+        "@cspell/cspell-resolver",
+        "@cspell/cspell-types",
+        "@cspell/dynamic-import",
+        "@cspell/filetypes",
+        "@cspell/rpc",
+        "@cspell/strong-weak-map",
+        "@cspell/url",
+        "cspell-config-lib",
+        "cspell-dictionary",
+        "cspell-glob",
+        "cspell-grammar",
+        "cspell-io",
+        "cspell-trie-lib",
+        "env-paths",
+        "gensequence",
+        "import-fresh",
+        "resolve-from",
+        "vscode-languageserver-textdocument",
+        "vscode-uri",
+        "xdg-basedir"
+      ]
+    },
+    "cspell-trie-lib@10.0.1_@cspell+cspell-types@10.0.1": {
+      "integrity": "sha512-BFvhalSkRQFjKrZ//FKK7fRGrZFpifnxB5AwCkzsIsBZqicsfafcQ1xP21qpb0QqyV/IomjNgviG+tRJs+0rMw==",
+      "dependencies": [
+        "@cspell/cspell-types"
+      ]
+    },
+    "cspell@10.0.1": {
+      "integrity": "sha512-Gg6w/flT3fKfl3la62hfTnhtNnDQ+9mU7kUhVqw/axl/Ms4oENw0oJMkWFIoj4f6nL/SDPz7KcPXd2XbkKFNmQ==",
+      "dependencies": [
+        "@cspell/cspell-json-reporter",
+        "@cspell/cspell-performance-monitor",
+        "@cspell/cspell-pipe",
+        "@cspell/cspell-types",
+        "@cspell/cspell-worker",
+        "@cspell/dynamic-import",
+        "@cspell/url",
+        "ansi-regex",
+        "chalk",
+        "chalk-template",
+        "commander",
+        "cspell-config-lib",
+        "cspell-dictionary",
+        "cspell-gitignore",
+        "cspell-glob",
+        "cspell-io",
+        "cspell-lib",
+        "fast-json-stable-stringify",
+        "flatted",
+        "semver",
+        "tinyglobby"
+      ],
+      "bin": true
+    },
+    "env-paths@4.0.0": {
+      "integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
+      "dependencies": [
+        "is-safe-filename"
+      ]
+    },
+    "esprima@4.0.1": {
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": true
+    },
+    "fast-equals@6.0.0": {
+      "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA=="
+    },
+    "fast-json-stable-stringify@2.1.0": {
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fdir@6.5.0_picomatch@4.0.4": {
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dependencies": [
+        "picomatch"
+      ],
+      "optionalPeers": [
+        "picomatch"
+      ]
+    },
+    "flatted@3.4.2": {
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="
+    },
+    "gensequence@8.0.8": {
+      "integrity": "sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg=="
+    },
+    "global-directory@5.0.0": {
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+      "dependencies": [
+        "ini"
+      ]
+    },
+    "import-fresh@4.0.0": {
+      "integrity": "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw=="
+    },
+    "import-meta-resolve@4.2.0": {
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="
+    },
+    "ini@6.0.0": {
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="
+    },
+    "is-safe-filename@0.1.1": {
+      "integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g=="
+    },
+    "picomatch@4.0.4": {
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
+    },
+    "resolve-from@5.0.0": {
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+    },
+    "semver@7.8.4": {
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "bin": true
+    },
+    "smol-toml@1.6.1": {
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="
+    },
+    "tinyglobby@0.2.17": {
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dependencies": [
+        "fdir",
+        "picomatch"
+      ]
+    },
+    "vscode-languageserver-textdocument@1.0.12": {
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+    },
+    "vscode-uri@3.1.0": {
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
+    },
+    "xdg-basedir@5.1.0": {
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="
+    },
+    "yaml@2.9.0": {
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "bin": true
     }
   },
   "workspace": {

--- a/docs/archive/pr-summaries/pr-summary-2886.md
+++ b/docs/archive/pr-summaries/pr-summary-2886.md
@@ -8,8 +8,8 @@ Closes #2886.
 These HOW-tests read `build.sh` into a string and asserted that literal
 substrings or regexes appeared in the source — so any behaviour-preserving
 refactor (renaming a variable, reordering `tar` flags, switching hashing
-invocations) would break them even though the build still verified tarballs
-and rejected tampering exactly as before.
+invocations) would break them even though the build still verified tarballs and
+rejected tampering exactly as before.
 
 ### Changes
 
@@ -23,15 +23,18 @@ and rejected tampering exactly as before.
     `content-manifest.sha256 is not git-ignored`, which asks git itself via
     `git check-ignore -q` (rc 1 = not ignored) rather than grepping the
     `.gitignore` text.
-  - Replaced `build.sh extracts without honouring archived owner/permission
-    bits` with `build.sh extract_bundle does not honour archived permission
-    bits`, which drives the real `extract_bundle` helper against a 0777
-    archive member under a restrictive umask and asserts the extracted file is
-    masked (not group/other-accessible). A regression to `tar -p` extracts
-    0777 and fails the test.
+  - Replaced
+    `build.sh extracts without honouring archived owner/permission
+    bits`
+    with `build.sh extract_bundle does not honour archived permission
+    bits`,
+    which drives the real `extract_bundle` helper against a 0777 archive member
+    under a restrictive umask and asserts the extracted file is masked (not
+    group/other-accessible). A regression to `tar -p` extracts 0777 and fails
+    the test.
 - **`test/scripts/BuildScript.ts`**
-  - Deleted `build.sh exposes a --rev option for explicit historical pins` —
-    the `--rev` contract is already proven behaviourally by the `--help`,
+  - Deleted `build.sh exposes a --rev option for explicit historical pins` — the
+    `--rev` contract is already proven behaviourally by the `--help`,
     `--rev rejects non-hex`, and `--rev requires a value` tests; the
     release-tag/asset-name greps tested only download-path wording.
 - **`build.sh`**
@@ -42,11 +45,11 @@ and rejected tampering exactly as before.
 
 ### Note
 
-The permission/owner *stripping* property is only fully observable as root,
-but the new `extract_bundle` test still catches the meaningful regression
-(swapping `--no-same-permissions` for `-p`, which preserves 0777 even for
-non-root) and proves extraction lands files correctly. The path-traversal and
-absolute-path extraction safety remains covered behaviourally by the existing
+The permission/owner _stripping_ property is only fully observable as root, but
+the new `extract_bundle` test still catches the meaningful regression (swapping
+`--no-same-permissions` for `-p`, which preserves 0777 even for non-root) and
+proves extraction lands files correctly. The path-traversal and absolute-path
+extraction safety remains covered behaviourally by the existing
 `assert_safe_tar_entries` tests.
 
 ## Evidence
@@ -74,7 +77,12 @@ flowchart LR
 
 ## Test Plan
 
-- `test/scripts/BuildScriptContentHash.ts::content-manifest.sha256 is not git-ignored` — `git check-ignore` exits 1 for the manifest path.
-- `test/scripts/BuildScriptContentHash.ts::build.sh extract_bundle does not honour archived permission bits` — sources `extract_bundle`, extracts a 0777 member under `umask 077`, asserts the extracted mode is masked and content matches.
-- Existing behavioural tests retained as coverage for the deleted greps (`verify_tarball_sha256` mismatch, `--verify-only` tampered/missing manifest, `assetSha256` pin format, `--rev` validation, `--help`).
+- `test/scripts/BuildScriptContentHash.ts::content-manifest.sha256 is not git-ignored`
+  — `git check-ignore` exits 1 for the manifest path.
+- `test/scripts/BuildScriptContentHash.ts::build.sh extract_bundle does not honour archived permission bits`
+  — sources `extract_bundle`, extracts a 0777 member under `umask 077`, asserts
+  the extracted mode is masked and content matches.
+- Existing behavioural tests retained as coverage for the deleted greps
+  (`verify_tarball_sha256` mismatch, `--verify-only` tampered/missing manifest,
+  `assetSha256` pin format, `--rev` validation, `--help`).
 - Full `./quality.sh` run passes (7058 tests).

--- a/docs/archive/pr-summaries/pr-summary-2886.md
+++ b/docs/archive/pr-summaries/pr-summary-2886.md
@@ -1,0 +1,80 @@
+## Summary
+
+Removed the source-text grep-as-assertion tests on `build.sh` and
+`wasm_activation/pkg/.gitignore`, replacing them with behavioural WHAT-tests
+that exercise observable outcomes instead of the script's internal wording.
+Closes #2886.
+
+These HOW-tests read `build.sh` into a string and asserted that literal
+substrings or regexes appeared in the source — so any behaviour-preserving
+refactor (renaming a variable, reordering `tar` flags, switching hashing
+invocations) would break them even though the build still verified tarballs
+and rejected tampering exactly as before.
+
+### Changes
+
+- **`test/scripts/BuildScriptContentHash.ts`**
+  - Deleted `build.sh declares a content manifest file constant` — redundant
+    with the manifest-committed and `--verify-only` missing/tampered tests.
+  - Deleted `build.sh has tarball SHA-256 verification logic` — redundant with
+    the `verify_tarball_sha256` mismatch test, the `assetSha256` pin-format
+    test, and the `guard_unverified_extract` anchor test.
+  - Replaced `pkg/.gitignore allows content-manifest.sha256` with
+    `content-manifest.sha256 is not git-ignored`, which asks git itself via
+    `git check-ignore -q` (rc 1 = not ignored) rather than grepping the
+    `.gitignore` text.
+  - Replaced `build.sh extracts without honouring archived owner/permission
+    bits` with `build.sh extract_bundle does not honour archived permission
+    bits`, which drives the real `extract_bundle` helper against a 0777
+    archive member under a restrictive umask and asserts the extracted file is
+    masked (not group/other-accessible). A regression to `tar -p` extracts
+    0777 and fails the test.
+- **`test/scripts/BuildScript.ts`**
+  - Deleted `build.sh exposes a --rev option for explicit historical pins` —
+    the `--rev` contract is already proven behaviourally by the `--help`,
+    `--rev rejects non-hex`, and `--rev requires a value` tests; the
+    release-tag/asset-name greps tested only download-path wording.
+- **`build.sh`**
+  - Extracted the inline `tar --no-same-owner --no-same-permissions -xzf`
+    invocation into an `extract_bundle()` helper so the tar-safety behaviour is
+    testable in isolation (sourced like the existing `verify_tarball_sha256`,
+    `guard_unverified_extract`, and `assert_safe_tar_entries` helpers).
+
+### Note
+
+The permission/owner *stripping* property is only fully observable as root,
+but the new `extract_bundle` test still catches the meaningful regression
+(swapping `--no-same-permissions` for `-p`, which preserves 0777 even for
+non-root) and proves extraction lands files correctly. The path-traversal and
+absolute-path extraction safety remains covered behaviourally by the existing
+`assert_safe_tar_entries` tests.
+
+## Evidence
+
+Backend/shell change — no UI to screenshot. Verified by running the affected
+test files and the full quality gate.
+
+```
+running 11 tests from ./test/scripts/BuildScriptContentHash.ts
+...
+build.sh extract_bundle does not honour archived permission bits ... ok
+content-manifest.sha256 is not git-ignored ... ok
+running 8 tests from ./test/scripts/BuildScript.ts
+...
+ok | 19 passed | 0 failed
+```
+
+Full gate: `./quality.sh` → `ok | 7058 passed (2 steps) | 0 failed | 4 ignored`.
+
+```mermaid
+flowchart LR
+    A[grep build.sh source text] -->|brittle HOW-test| B[breaks on refactor]
+    C[run extract_bundle / git check-ignore] -->|robust WHAT-test| D[asserts observable outcome]
+```
+
+## Test Plan
+
+- `test/scripts/BuildScriptContentHash.ts::content-manifest.sha256 is not git-ignored` — `git check-ignore` exits 1 for the manifest path.
+- `test/scripts/BuildScriptContentHash.ts::build.sh extract_bundle does not honour archived permission bits` — sources `extract_bundle`, extracts a 0777 member under `umask 077`, asserts the extracted mode is masked and content matches.
+- Existing behavioural tests retained as coverage for the deleted greps (`verify_tarball_sha256` mismatch, `--verify-only` tampered/missing manifest, `assetSha256` pin format, `--rev` validation, `--help`).
+- Full `./quality.sh` run passes (7058 tests).

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -358,6 +358,7 @@
     "serialiser",
     "serialisable",
     "serialiser",
+    "setuid",
     "setweight",
     "shareprices",
     "Shao",

--- a/test/scripts/BuildScript.ts
+++ b/test/scripts/BuildScript.ts
@@ -187,25 +187,13 @@ Deno.test({
   },
 });
 
-Deno.test({
-  name: "build.sh exposes a --rev option for explicit historical pins",
-  permissions: { read: true },
-  fn: async () => {
-    const buildScript = await Deno.readTextFile("build.sh");
-    assert(
-      buildScript.includes("--rev"),
-      "build.sh should accept --rev <SHA> for explicit pinning",
-    );
-    assert(
-      /wasm-bundle-/.test(buildScript),
-      "build.sh should reference per-commit Release tag pattern wasm-bundle-<SHA>",
-    );
-    assert(
-      buildScript.includes("wasm_activation-pkg.tar.gz"),
-      "build.sh should reference the wasm_activation-pkg.tar.gz asset",
-    );
-  },
-});
+// The "build.sh exposes a --rev option" source-text grep was removed
+// (issue #2886): the --rev contract is already proven behaviourally by the
+// "--help lists new flags", "--rev rejects non-hex / wrong-length values"
+// and "--rev requires a value" tests above, which run build.sh and assert on
+// its exit codes and stderr. The release-tag/asset-name greps tested only
+// the internal wording of the network download path and added no behavioural
+// signal.
 
 Deno.test({
   name: "CORE_DEPENDENCY_POLICY documents the new artifact-based flow",

--- a/test/scripts/BuildScriptContentHash.ts
+++ b/test/scripts/BuildScriptContentHash.ts
@@ -40,40 +40,13 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
-Deno.test({
-  name: "build.sh declares a content manifest file constant",
-  permissions: { read: true },
-  fn: async () => {
-    const script = await Deno.readTextFile("build.sh");
-    assert(
-      script.includes("content-manifest.sha256"),
-      "build.sh must reference wasm_activation/pkg/content-manifest.sha256",
-    );
-  },
-});
-
-Deno.test({
-  name: "build.sh has tarball SHA-256 verification logic",
-  permissions: { read: true },
-  fn: async () => {
-    const script = await Deno.readTextFile("build.sh");
-    // Should reference shasum -a 256 (the hashing tool) and assetSha256
-    // (the optional deno.json pin) so a reviewer sees how upstream tarballs
-    // are content-verified before extract.
-    assert(
-      /shasum\s+-a\s+256/.test(script),
-      "build.sh must use 'shasum -a 256' to hash the downloaded tarball",
-    );
-    assert(
-      script.includes("assetSha256"),
-      "build.sh must read neatCore.assetSha256 from deno.json",
-    );
-    assert(
-      script.includes(".sha256"),
-      "build.sh must look for a sidecar .sha256 release asset",
-    );
-  },
-});
+// The content-manifest constant and the SHA-256 / assetSha256 / sidecar
+// verification logic were previously asserted by grepping build.sh source
+// text (issue #2886). Those HOW-tests are removed: the behaviour is proven
+// by the WHAT-tests below — `verify_tarball_sha256` failing on a hash
+// mismatch, `--verify-only` failing on a tampered or missing manifest, and
+// `deno.json` pinning a 64-char assetSha256 — none of which depend on the
+// script's internal wording.
 
 Deno.test({
   name: "build.sh fails the tarball check on SHA-256 mismatch (helper unit)",
@@ -146,13 +119,27 @@ Deno.test({
 });
 
 Deno.test({
-  name: "wasm_activation/pkg/.gitignore allows content-manifest.sha256",
-  permissions: { read: true },
+  name: "content-manifest.sha256 is not git-ignored",
+  permissions: { run: true, read: true },
   fn: async () => {
-    const gi = await Deno.readTextFile("wasm_activation/pkg/.gitignore");
-    assert(
-      gi.includes("!content-manifest.sha256"),
-      "pkg/.gitignore must un-ignore content-manifest.sha256",
+    // Behavioural check (issue #2886): ask git itself whether the manifest is
+    // ignored rather than grepping pkg/.gitignore source text. `git
+    // check-ignore` exits 0 when a path IS ignored and 1 when it is not, so
+    // the un-ignore rule working means rc=1. Removing the `!content-manifest
+    // .sha256` exception would let the blanket `*` rule ignore it again,
+    // flipping this to rc=0 and failing the test.
+    const cmd = new Deno.Command("git", {
+      args: ["check-ignore", "-q", MANIFEST_PATH],
+      stdout: "null",
+      stderr: "piped",
+      cwd: Deno.cwd(),
+    });
+    const out = await cmd.output();
+    assertEquals(
+      out.code,
+      1,
+      `${MANIFEST_PATH} must NOT be git-ignored (rc 1 = not ignored); ` +
+        `got rc=${out.code}, stderr=${new TextDecoder().decode(out.stderr)}`,
     );
   },
 });
@@ -450,14 +437,51 @@ Deno.test({
 });
 
 Deno.test({
-  name: "build.sh extracts without honouring archived owner/permission bits",
-  permissions: { read: true },
+  name: "build.sh extract_bundle does not honour archived permission bits",
+  permissions: { run: true, read: true, write: true },
   fn: async () => {
-    const script = await Deno.readTextFile("build.sh");
-    assert(
-      /tar\s+--no-same-owner\s+--no-same-permissions\s+-xzf/.test(script),
-      "tar extract must pass --no-same-owner --no-same-permissions",
-    );
+    // Behavioural replacement (issue #2886) for the old source-text grep:
+    // drive build.sh's real extract_bundle helper against an archive whose
+    // member is mode 0777 under a restrictive umask. With
+    // --no-same-permissions the archived bits are dropped and the umask
+    // applies, so the extracted file must not be group/other-accessible. A
+    // regression to `tar -p` (preserve permissions) would extract 0777 and
+    // fail this assertion.
+    const tmpDir = await Deno.makeTempDir({ prefix: "neat-extract-" });
+    try {
+      await Deno.mkdir(`${tmpDir}/src/pkg`, { recursive: true });
+      const member = `${tmpDir}/src/pkg/wasm_activation.js`;
+      await Deno.writeTextFile(member, "export const x = 1;\n");
+      await Deno.chmod(member, 0o777);
+      const mkTar = new Deno.Command("tar", {
+        args: ["-czf", `${tmpDir}/bundle.tar.gz`, "-C", `${tmpDir}/src`, "pkg"],
+      });
+      assertEquals((await mkTar.output()).code, 0);
+
+      const dest = `${tmpDir}/out`;
+      await Deno.mkdir(dest, { recursive: true });
+      const run = await runSourcedFn(
+        "extract_bundle",
+        `umask 077\nextract_bundle '${tmpDir}/bundle.tar.gz' '${dest}'`,
+      );
+      assertEquals(run.code, 0, `extract_bundle must succeed; ${run.stderr}`);
+
+      const extracted = `${dest}/pkg/wasm_activation.js`;
+      assertEquals(
+        await Deno.readTextFile(extracted),
+        "export const x = 1;\n",
+        "extracted file content must match the archived file",
+      );
+      const mode = ((await Deno.stat(extracted)).mode ?? 0) & 0o777;
+      assertEquals(
+        mode & 0o077,
+        0,
+        `extracted mode must be masked by umask, not the archived 0777; ` +
+          `got ${mode.toString(8)}`,
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
   },
 });
 


### PR DESCRIPTION
## Summary

Removed the source-text grep-as-assertion tests on `build.sh` and
`wasm_activation/pkg/.gitignore`, replacing them with behavioural WHAT-tests
that exercise observable outcomes instead of the script's internal wording.
Closes #2886.

These HOW-tests read `build.sh` into a string and asserted that literal
substrings or regexes appeared in the source — so any behaviour-preserving
refactor (renaming a variable, reordering `tar` flags, switching hashing
invocations) would break them even though the build still verified tarballs
and rejected tampering exactly as before.

### Changes

- **`test/scripts/BuildScriptContentHash.ts`**
  - Deleted `build.sh declares a content manifest file constant` — redundant
    with the manifest-committed and `--verify-only` missing/tampered tests.
  - Deleted `build.sh has tarball SHA-256 verification logic` — redundant with
    the `verify_tarball_sha256` mismatch test, the `assetSha256` pin-format
    test, and the `guard_unverified_extract` anchor test.
  - Replaced `pkg/.gitignore allows content-manifest.sha256` with
    `content-manifest.sha256 is not git-ignored`, which asks git itself via
    `git check-ignore -q` (rc 1 = not ignored) rather than grepping the
    `.gitignore` text.
  - Replaced `build.sh extracts without honouring archived owner/permission
    bits` with `build.sh extract_bundle does not honour archived permission
    bits`, which drives the real `extract_bundle` helper against a 0777
    archive member under a restrictive umask and asserts the extracted file is
    masked (not group/other-accessible). A regression to `tar -p` extracts
    0777 and fails the test.
- **`test/scripts/BuildScript.ts`**
  - Deleted `build.sh exposes a --rev option for explicit historical pins` —
    the `--rev` contract is already proven behaviourally by the `--help`,
    `--rev rejects non-hex`, and `--rev requires a value` tests; the
    release-tag/asset-name greps tested only download-path wording.
- **`build.sh`**
  - Extracted the inline `tar --no-same-owner --no-same-permissions -xzf`
    invocation into an `extract_bundle()` helper so the tar-safety behaviour is
    testable in isolation (sourced like the existing `verify_tarball_sha256`,
    `guard_unverified_extract`, and `assert_safe_tar_entries` helpers).

### Note

The permission/owner *stripping* property is only fully observable as root,
but the new `extract_bundle` test still catches the meaningful regression
(swapping `--no-same-permissions` for `-p`, which preserves 0777 even for
non-root) and proves extraction lands files correctly. The path-traversal and
absolute-path extraction safety remains covered behaviourally by the existing
`assert_safe_tar_entries` tests.

## Evidence

Backend/shell change — no UI to screenshot. Verified by running the affected
test files and the full quality gate.

```
running 11 tests from ./test/scripts/BuildScriptContentHash.ts
...
build.sh extract_bundle does not honour archived permission bits ... ok
content-manifest.sha256 is not git-ignored ... ok
running 8 tests from ./test/scripts/BuildScript.ts
...
ok | 19 passed | 0 failed
```

Full gate: `./quality.sh` → `ok | 7058 passed (2 steps) | 0 failed | 4 ignored`.

```mermaid
flowchart LR
    A[grep build.sh source text] -->|brittle HOW-test| B[breaks on refactor]
    C[run extract_bundle / git check-ignore] -->|robust WHAT-test| D[asserts observable outcome]
```

## Test Plan

- `test/scripts/BuildScriptContentHash.ts::content-manifest.sha256 is not git-ignored` — `git check-ignore` exits 1 for the manifest path.
- `test/scripts/BuildScriptContentHash.ts::build.sh extract_bundle does not honour archived permission bits` — sources `extract_bundle`, extracts a 0777 member under `umask 077`, asserts the extracted mode is masked and content matches.
- Existing behavioural tests retained as coverage for the deleted greps (`verify_tarball_sha256` mismatch, `--verify-only` tampered/missing manifest, `assetSha256` pin format, `--rev` validation, `--help`).
- Full `./quality.sh` run passes (7058 tests).
