### PR TITLE
Publish: only publish on Develop and skip already-published versions (#2904)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Defence in depth (Issue #2904): the push trigger already restricts to
+    # Develop, but make the branch requirement explicit so the job never runs
+    # on any other ref.
+    if: github.ref == 'refs/heads/Develop'
     permissions:
       contents: read
       id-token: write # OIDC for JSR (provenance + tokenless publish)
@@ -36,9 +40,35 @@ jobs:
       - name: Verify WASM package matches deno.json neatCore.rev
         run: ./build.sh --verify-only
 
+      # Issue #2904: skip publishing when deno.json's version is already on JSR.
+      # Every push to Develop runs this workflow, but the package version only
+      # changes on a release commit. Re-running `jsr publish` for an existing
+      # version hangs the CLI until the 15-minute job timeout cancels it, so
+      # gate the publish step on the version being new. A 200 from the JSR
+      # version meta endpoint means the version is published; 404 means it is
+      # not.
+      - name: Determine whether the version needs publishing
+        id: needs_publish
+        run: |
+          name=$(jq -r .name deno.json)
+          version=$(jq -r .version deno.json)
+          status=$(curl -s -o /dev/null -w '%{http_code}' \
+            "https://jsr.io/${name}/${version}_meta.json")
+          if [ "$status" = "200" ]; then
+            echo "${name}@${version} is already published on JSR; skipping publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          elif [ "$status" = "404" ]; then
+            echo "${name}@${version} is not on JSR; will publish."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unexpected HTTP ${status} from JSR meta endpoint; attempting publish." >&2
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # Tokenless publish: package must be linked to this repo on JSR.
       # For runs triggered by bots (e.g. stservice): scope admin must disable
       # "Only allow publishing when triggered by a scope member" in scope settings.
       # See https://jsr.io/docs/scopes#github-actions-publishing-security
       - name: Publish to JSR
+        if: steps.needs_publish.outputs.publish == 'true'
         run: npx jsr publish

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.23",
+  "version": "5.3.24",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2904.md
+++ b/docs/archive/pr-summaries/pr-summary-2904.md
@@ -4,17 +4,16 @@ The Publish workflow was hanging on routine pushes to Develop. Every push to
 Develop triggers `.github/workflows/publish.yml`, but the package `version` in
 `deno.json` only changes on a release commit. When the version is unchanged,
 `npx jsr publish` re-attempts an already-published version and hangs the CLI
-until the 15-minute job timeout cancels it — exactly the
-**"Publish / publish (push) — Cancelled after 15m"** seen in the issue
-screenshot.
+until the 15-minute job timeout cancels it — exactly the **"Publish / publish
+(push) — Cancelled after 15m"** seen in the issue screenshot.
 
 Two guards now prevent this:
 
 1. **Explicit Develop branch guard** — the publish job carries
    `if: github.ref == 'refs/heads/Develop'`. The push trigger already restricts
    to Develop, but the explicit guard makes the requirement unambiguous so the
-   job never runs on any other ref (the issue's literal ask: *should not be
-   attempting to publish unless on the Develop branch*).
+   job never runs on any other ref (the issue's literal ask: _should not be
+   attempting to publish unless on the Develop branch_).
 2. **Version-already-published gate** — a new step queries the JSR version meta
    endpoint (`https://jsr.io/<name>/<version>_meta.json`): HTTP 200 means the
    version is already published (skip), 404 means it is new (publish). The

--- a/docs/archive/pr-summaries/pr-summary-2904.md
+++ b/docs/archive/pr-summaries/pr-summary-2904.md
@@ -1,0 +1,65 @@
+## Summary
+
+The Publish workflow was hanging on routine pushes to Develop. Every push to
+Develop triggers `.github/workflows/publish.yml`, but the package `version` in
+`deno.json` only changes on a release commit. When the version is unchanged,
+`npx jsr publish` re-attempts an already-published version and hangs the CLI
+until the 15-minute job timeout cancels it — exactly the
+**"Publish / publish (push) — Cancelled after 15m"** seen in the issue
+screenshot.
+
+Two guards now prevent this:
+
+1. **Explicit Develop branch guard** — the publish job carries
+   `if: github.ref == 'refs/heads/Develop'`. The push trigger already restricts
+   to Develop, but the explicit guard makes the requirement unambiguous so the
+   job never runs on any other ref (the issue's literal ask: *should not be
+   attempting to publish unless on the Develop branch*).
+2. **Version-already-published gate** — a new step queries the JSR version meta
+   endpoint (`https://jsr.io/<name>/<version>_meta.json`): HTTP 200 means the
+   version is already published (skip), 404 means it is new (publish). The
+   `jsr publish` step is gated on this check, so a routine Develop push that
+   does not bump the version never reaches `jsr publish` and can no longer hang.
+
+Closes #2904.
+
+## Evidence
+
+This is a CI/workflow change with no web interface to screenshot. Verification
+is via the new structured tests plus `actionlint`.
+
+Confirmed against the live JSR endpoint that the published version returns 200
+and an unpublished version returns 404:
+
+```
+published 5.3.23  -> HTTP 200
+bogus 99.99.99    -> HTTP 404
+```
+
+Publish gating flow:
+
+```mermaid
+flowchart TD
+    Push[Push event] --> Branch{github.ref ==\nrefs/heads/Develop?}
+    Branch -- no --> Skip[Job does not run]
+    Branch -- yes --> Verify[build.sh --verify-only]
+    Verify --> Check[Query JSR\nversion meta.json]
+    Check -->|HTTP 200 already published| NoPublish[Skip publish — no hang]
+    Check -->|HTTP 404 new version| Publish[npx jsr publish]
+```
+
+## Test Plan
+
+- Added `test/scripts/PublishBranchGuard.ts` (parses the committed workflow YAML
+  and asserts on configuration — "what" tests):
+  - `publish.yml only triggers on push to Develop` — the only trigger key is
+    `push` and its branches are exactly `[Develop]`.
+  - `publish job carries an explicit Develop branch guard` — the job `if:`
+    references `github.ref` and requires `refs/heads/Develop`.
+  - `publish step is gated on a prior version-published check` — the
+    `jsr publish` step has an `if:` that depends on a prior step output, and
+    that step queries JSR for the `deno.json` version.
+- Existing `test/scripts/PublishWorkflow.ts` (build.sh `--verify-only`, no
+  auto-advance of `neatCore.rev`) still passes.
+- Full `test/ci/` + `test/scripts/` suites pass (179 tests); `actionlint`,
+  `deno fmt`, `deno lint`, and `deno check` all clean.

--- a/test/scripts/PublishBranchGuard.ts
+++ b/test/scripts/PublishBranchGuard.ts
@@ -1,0 +1,150 @@
+import { assert, assertEquals } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Issue #2904 — the Publish workflow must not attempt to publish unless on the
+ * Develop branch, and must not re-attempt publishing a version that is already
+ * on JSR.
+ *
+ * Symptom: every push to Develop triggers the workflow, but the package
+ * `version` only changes on a release commit. Running `jsr publish` for a
+ * version that already exists on JSR hangs the CLI until the 15-minute job
+ * timeout cancels it ("Publish / publish (push) — Cancelled after 15m").
+ *
+ * Two guards prevent this:
+ *  1. The push trigger restricts to Develop AND the job carries an explicit
+ *     `if: github.ref == 'refs/heads/Develop'` guard (defence in depth — the
+ *     job never runs on any other ref).
+ *  2. The publish step is gated on a prior step that checks whether the version
+ *     is already published, so a routine Develop push that does not bump the
+ *     version never reaches `jsr publish`.
+ *
+ * These are "what" tests: they parse the committed workflow YAML and assert on
+ * the resulting configuration.
+ */
+
+interface Step {
+  name?: string;
+  id?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+}
+
+interface Job {
+  if?: string;
+  steps?: Step[];
+}
+
+interface PushTrigger {
+  branches?: string[];
+}
+
+interface Triggers {
+  push?: PushTrigger;
+  // Any other trigger key (pull_request, workflow_dispatch, …) would let the
+  // workflow run off Develop, so we assert the set of trigger keys explicitly.
+  [key: string]: unknown;
+}
+
+interface Workflow {
+  on?: Triggers;
+  jobs?: Record<string, Job>;
+}
+
+const PUBLISH_WORKFLOW = ".github/workflows/publish.yml";
+
+async function readPublishWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(PUBLISH_WORKFLOW);
+  return parse(text) as Workflow;
+}
+
+function publishJob(wf: Workflow): Job {
+  const jobs = wf.jobs ?? {};
+  const job = jobs["publish"];
+  assert(job !== undefined, "publish.yml must define a `publish` job");
+  return job;
+}
+
+Deno.test("publish.yml only triggers on push to Develop", async () => {
+  const wf = await readPublishWorkflow();
+  // `parse` may key the `on:` block as the boolean `true` because YAML treats a
+  // bare `on` as a truthy keyword; tolerate both spellings.
+  const triggers = (wf.on ?? (wf as Record<string, unknown>)["true"]) as
+    | Triggers
+    | undefined;
+  assert(triggers !== undefined, "publish.yml must declare an `on:` block");
+
+  const triggerKeys = Object.keys(triggers);
+  assertEquals(
+    triggerKeys,
+    ["push"],
+    "publish.yml must only trigger on push (no pull_request/workflow_dispatch " +
+      "that could run off the Develop branch)",
+  );
+
+  assertEquals(
+    triggers.push?.branches,
+    ["Develop"],
+    "publish.yml push trigger must be restricted to the Develop branch",
+  );
+});
+
+Deno.test("publish job carries an explicit Develop branch guard", async () => {
+  const wf = await readPublishWorkflow();
+  const job = publishJob(wf);
+  const guard = job.if ?? "";
+  assert(
+    guard.includes("github.ref"),
+    "publish job `if:` must reference github.ref so the job only runs on a " +
+      `specific branch; got: ${JSON.stringify(job.if)}`,
+  );
+  assert(
+    guard.includes("refs/heads/Develop"),
+    "publish job `if:` must require refs/heads/Develop so publish never runs " +
+      `on any other branch (Issue #2904); got: ${JSON.stringify(job.if)}`,
+  );
+});
+
+Deno.test("publish step is gated on a prior version-published check", async () => {
+  const wf = await readPublishWorkflow();
+  const job = publishJob(wf);
+  const steps = job.steps ?? [];
+
+  const publishStep = steps.find((s) => (s.run ?? "").includes("jsr publish"));
+  assert(
+    publishStep !== undefined,
+    "publish job must contain a step that runs `jsr publish`",
+  );
+
+  const condition = publishStep.if ?? "";
+  assert(
+    condition.length > 0,
+    "the `jsr publish` step must carry an `if:` guard so a routine Develop " +
+      "push that does not bump the version never re-attempts publishing an " +
+      "already-published version (Issue #2904)",
+  );
+
+  // The guard must reference the output of an earlier step (steps.<id>.outputs)
+  // rather than a constant, so it reflects the live published-version check.
+  assert(
+    condition.includes("steps.") && condition.includes("outputs."),
+    "the `jsr publish` step `if:` must depend on a prior step output " +
+      `(steps.<id>.outputs.<name>); got: ${JSON.stringify(publishStep.if)}`,
+  );
+
+  // The referenced step must exist and actually query JSR for the version.
+  const checkStep = steps.find((s) =>
+    (s.run ?? "").includes("jsr.io") && (s.run ?? "").includes("deno.json")
+  );
+  assert(
+    checkStep !== undefined && typeof checkStep.id === "string",
+    "publish job must contain an identified step that checks JSR for the " +
+      "deno.json version before publishing",
+  );
+  assert(
+    condition.includes(checkStep!.id!),
+    "the `jsr publish` step `if:` must reference the version-check step id " +
+      `(${checkStep!.id}); got: ${JSON.stringify(publishStep.if)}`,
+  );
+});


### PR DESCRIPTION
## Summary

The Publish workflow was hanging on routine pushes to Develop. Every push to
Develop triggers `.github/workflows/publish.yml`, but the package `version` in
`deno.json` only changes on a release commit. When the version is unchanged,
`npx jsr publish` re-attempts an already-published version and hangs the CLI
until the 15-minute job timeout cancels it — exactly the **"Publish / publish
(push) — Cancelled after 15m"** seen in the issue screenshot.

Two guards now prevent this:

1. **Explicit Develop branch guard** — the publish job carries
   `if: github.ref == 'refs/heads/Develop'`. The push trigger already restricts
   to Develop, but the explicit guard makes the requirement unambiguous so the
   job never runs on any other ref (the issue's literal ask: _should not be
   attempting to publish unless on the Develop branch_).
2. **Version-already-published gate** — a new step queries the JSR version meta
   endpoint (`https://jsr.io/<name>/<version>_meta.json`): HTTP 200 means the
   version is already published (skip), 404 means it is new (publish). The
   `jsr publish` step is gated on this check, so a routine Develop push that
   does not bump the version never reaches `jsr publish` and can no longer hang.

Closes #2904.

## Evidence

This is a CI/workflow change with no web interface to screenshot. Verification
is via the new structured tests plus `actionlint`.

Confirmed against the live JSR endpoint that the published version returns 200
and an unpublished version returns 404:

```
published 5.3.23  -> HTTP 200
bogus 99.99.99    -> HTTP 404
```

Publish gating flow:

```mermaid
flowchart TD
    Push[Push event] --> Branch{github.ref ==\nrefs/heads/Develop?}
    Branch -- no --> Skip[Job does not run]
    Branch -- yes --> Verify[build.sh --verify-only]
    Verify --> Check[Query JSR\nversion meta.json]
    Check -->|HTTP 200 already published| NoPublish[Skip publish — no hang]
    Check -->|HTTP 404 new version| Publish[npx jsr publish]
```

## Test Plan

- Added `test/scripts/PublishBranchGuard.ts` (parses the committed workflow YAML
  and asserts on configuration — "what" tests):
  - `publish.yml only triggers on push to Develop` — the only trigger key is
    `push` and its branches are exactly `[Develop]`.
  - `publish job carries an explicit Develop branch guard` — the job `if:`
    references `github.ref` and requires `refs/heads/Develop`.
  - `publish step is gated on a prior version-published check` — the
    `jsr publish` step has an `if:` that depends on a prior step output, and
    that step queries JSR for the `deno.json` version.
- Existing `test/scripts/PublishWorkflow.ts` (build.sh `--verify-only`, no
  auto-advance of `neatCore.rev`) still passes.
- Full `test/ci/` + `test/scripts/` suites pass (179 tests); `actionlint`,
  `deno fmt`, `deno lint`, and `deno check` all clean.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq90x8ir-4a660a`<!-- vibe-worker-issue-2904 -->