### PR TITLE
Fix evolve() spread-push stack overflow with stack-safe append (Issue #2897)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-2897.md
+++ b/docs/archive/pr-summaries/pr-summary-2897.md
@@ -1,0 +1,56 @@
+## Summary
+
+Fixed the `evolve()` spread-push stack overflow at `src/NEAT/NeatEvolution.ts:688`.
+Spreading an unbounded `offspringBatch` into `newPopulation.push(...offspringBatch)`
+exceeds V8's argument/stack limit (~65k–130k elements) once the configured
+population size is large enough, throwing
+`RangeError: Maximum call stack size exceeded`. This crashed the "Run Suggest
+Improvements" example after bumping `@stsoftware/neat-ai` 5.3.15 → 5.3.19
+(stSoftwareAU/NEAT-AI-Examples#578).
+
+The fix introduces a stack-safe in-place append helper
+(`src/utils/ArrayAppend.ts` → `appendAll<T>(target, items)`) that appends via a
+plain indexed loop — no spread, no `push.apply` (same stack limit), no `concat`
+(would allocate a new array, but `newPopulation` is `const` and aliased/mutated
+later at lines 704 and 735). Population contents and ordering are unchanged:
+creative-thinking clones first, then offspring, exactly as before.
+
+Closes #2897.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. Verified via tests and
+the full quality gate.
+
+```mermaid
+flowchart LR
+    A[offspringBatch = await breedingPromise] --> B{append}
+    B -- "push(...offspringBatch)" --> C[RangeError at large size]
+    B -- "appendAll(newPopulation, offspringBatch)" --> D[Stack-safe indexed loop]
+    D --> E[Order + contents identical]
+```
+
+- `appendAll` uses an indexed loop, so each element is appended without placing
+  a per-element argument on the call stack — scales to any batch size.
+- Regression test `test/utils/ArrayAppend.ts` includes a **canary** assertion
+  (`assertThrows(() => target.push(...bigArray), RangeError)` at 200,000
+  primitive elements) proving the test size genuinely exceeds the engine's
+  spread limit, plus a **fix** assertion that `appendAll` appends the same batch
+  without throwing while preserving order, length, and the pre-existing front
+  element.
+- `./quality.sh < /dev/null` passes: `7062 passed | 0 failed | 4 ignored`,
+  exit 0. `test/NEAT/PhasePipelining.ts`, `test/NEAT/Evolve.ts`, and
+  `test/NEAT/NeatEvolve.ts` all pass.
+
+## Test Plan
+
+- Added `test/utils/ArrayAppend.ts`:
+  - happy path — appends in order after existing contents
+  - empty `items` — no-op
+  - empty `target` — receives all items in order
+  - large batch (≥200k) — canary `RangeError` for spread-push + `appendAll`
+    succeeds preserving order/length/front element (regression for #2897)
+- Ran `test/NEAT/PhasePipelining.ts` (the breeding/offspring pipeline) — passes.
+- Ran the full `./quality.sh` gate — passes cleanly.
+
+No changes to `semanticVersion` handling, neuron UUIDs, or any wire format.

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -26,6 +26,7 @@ import { Mutator } from "@neat/Mutator.ts";
 import { CRISPR } from "@reconstruct/CRISPR.ts";
 import { CrisprError } from "@errors/CrisprError.ts";
 import { simplify } from "@optimize/Simplify.ts";
+import { appendAll } from "@utils/ArrayAppend.ts";
 import { validateOrDiagnose } from "@utils/Diagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
@@ -685,7 +686,10 @@ export async function evolve(
   // Issue #2314: Await breeding results now that all overlapped main-thread
   // work is complete.
   const offspringBatch = await breedingPromise;
-  newPopulation.push(...offspringBatch);
+  // Issue #2897: Stack-safe in-place append. Spreading an unbounded
+  // offspringBatch into push() arguments throws RangeError once the batch
+  // exceeds V8's argument/stack limit; appendAll uses an indexed loop instead.
+  appendAll(newPopulation, offspringBatch);
   const breedingMs = Date.now() - breedingStartMs;
   // Issue #2323: Compute pure worker breeding duration. If the .then()
   // callback has not fired yet (breedingWorkerEndMs is still 0), the worker

--- a/src/utils/ArrayAppend.ts
+++ b/src/utils/ArrayAppend.ts
@@ -1,0 +1,26 @@
+/**
+ * Stack-safe in-place array append (Issue #2897).
+ *
+ * Appends every element of `items` onto the end of `target`, mutating `target`
+ * and preserving both the existing `target` contents and the order of `items`.
+ *
+ * ## Why not `target.push(...items)`?
+ * Spreading an array into function arguments places one argument per element on
+ * the call stack. For an unbounded array this exceeds the V8 argument/stack
+ * limit (~65k–130k elements depending on stack depth) and throws
+ * `RangeError: Maximum call stack size exceeded`. The same limit applies to
+ * `Array.prototype.push.apply(target, items)`, so that is no safer.
+ *
+ * `concat` avoids the stack limit but allocates a *new* array; the crash site
+ * (`NeatEvolution.ts`) holds `newPopulation` as a `const` that is aliased and
+ * mutated later, so the append must be in place. A plain indexed loop appends
+ * in place with no per-element argument on the stack, so it scales to any size.
+ *
+ * @param target The array to append onto, mutated in place.
+ * @param items  The elements to append, in order. An empty list is a no-op.
+ */
+export function appendAll<T>(target: T[], items: readonly T[]): void {
+  for (let i = 0; i < items.length; i++) {
+    target.push(items[i]);
+  }
+}

--- a/test/utils/ArrayAppend.ts
+++ b/test/utils/ArrayAppend.ts
@@ -1,0 +1,43 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { appendAll } from "@utils/ArrayAppend.ts";
+
+Deno.test("appendAll - happy path appends in order after existing contents", () => {
+  const target = [1, 2, 3];
+  appendAll(target, [4, 5, 6]);
+  assertEquals(target, [1, 2, 3, 4, 5, 6]);
+});
+
+Deno.test("appendAll - empty items is a no-op", () => {
+  const target = ["a", "b"];
+  appendAll(target, []);
+  assertEquals(target, ["a", "b"]);
+});
+
+Deno.test("appendAll - empty target receives all items in order", () => {
+  const target: number[] = [];
+  appendAll(target, [10, 20, 30]);
+  assertEquals(target, [10, 20, 30]);
+});
+
+Deno.test("appendAll - large batch exceeds the spread limit (regression #2897)", () => {
+  // Size chosen to exceed V8's spread-into-arguments limit. The canary below
+  // proves the size is genuinely over the limit; if a future V8 raises it, the
+  // canary fails loudly so the size can be revisited rather than passing for
+  // the wrong reason.
+  const SIZE = 200_000;
+  const bigArray = new Array(SIZE);
+  for (let i = 0; i < SIZE; i++) bigArray[i] = i;
+
+  // Canary: the original spread-push crashes at this scale.
+  const canary: number[] = [];
+  assertThrows(() => canary.push(...bigArray), RangeError);
+
+  // Fix: appendAll appends the same batch without throwing, preserving the
+  // pre-existing front element, length, and order.
+  const target = [-1];
+  appendAll(target, bigArray);
+  assertEquals(target.length, SIZE + 1);
+  assertEquals(target[0], -1);
+  assertEquals(target[1], 0);
+  assertEquals(target[SIZE], SIZE - 1);
+});


### PR DESCRIPTION
## Summary

Fixed the `evolve()` spread-push stack overflow at `src/NEAT/NeatEvolution.ts:688`.
Spreading an unbounded `offspringBatch` into `newPopulation.push(...offspringBatch)`
exceeds V8's argument/stack limit (~65k–130k elements) once the configured
population size is large enough, throwing
`RangeError: Maximum call stack size exceeded`. This crashed the "Run Suggest
Improvements" example after bumping `@stsoftware/neat-ai` 5.3.15 → 5.3.19
(stSoftwareAU/NEAT-AI-Examples#578).

The fix introduces a stack-safe in-place append helper
(`src/utils/ArrayAppend.ts` → `appendAll<T>(target, items)`) that appends via a
plain indexed loop — no spread, no `push.apply` (same stack limit), no `concat`
(would allocate a new array, but `newPopulation` is `const` and aliased/mutated
later at lines 704 and 735). Population contents and ordering are unchanged:
creative-thinking clones first, then offspring, exactly as before.

Closes #2897.

## Evidence

Backend/library change — no web interface to screenshot. Verified via tests and
the full quality gate.

```mermaid
flowchart LR
    A[offspringBatch = await breedingPromise] --> B{append}
    B -- "push(...offspringBatch)" --> C[RangeError at large size]
    B -- "appendAll(newPopulation, offspringBatch)" --> D[Stack-safe indexed loop]
    D --> E[Order + contents identical]
```

- `appendAll` uses an indexed loop, so each element is appended without placing
  a per-element argument on the call stack — scales to any batch size.
- Regression test `test/utils/ArrayAppend.ts` includes a **canary** assertion
  (`assertThrows(() => target.push(...bigArray), RangeError)` at 200,000
  primitive elements) proving the test size genuinely exceeds the engine's
  spread limit, plus a **fix** assertion that `appendAll` appends the same batch
  without throwing while preserving order, length, and the pre-existing front
  element.
- `./quality.sh < /dev/null` passes: `7062 passed | 0 failed | 4 ignored`,
  exit 0. `test/NEAT/PhasePipelining.ts`, `test/NEAT/Evolve.ts`, and
  `test/NEAT/NeatEvolve.ts` all pass.

## Test Plan

- Added `test/utils/ArrayAppend.ts`:
  - happy path — appends in order after existing contents
  - empty `items` — no-op
  - empty `target` — receives all items in order
  - large batch (≥200k) — canary `RangeError` for spread-push + `appendAll`
    succeeds preserving order/length/front element (regression for #2897)
- Ran `test/NEAT/PhasePipelining.ts` (the breeding/offspring pipeline) — passes.
- Ran the full `./quality.sh` gate — passes cleanly.

No changes to `semanticVersion` handling, neuron UUIDs, or any wire format.
