### PR TITLE
DiscoveryReplay: read warm-up gate from Neat-level state (#2910)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.24",
+  "version": "5.3.25",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2910.md
+++ b/docs/archive/pr-summaries/pr-summary-2910.md
@@ -12,8 +12,9 @@ seeded topology during the warm-up window.
 This change switches the gate to **Neat-level warm-up context** supplied by the
 caller. `scheduleReplay` now accepts an optional `warmupContext`
 (`{ warmupGenerations, currentGeneration }`) and gates with the existing numbers
-variant `isSeedWarmupStructuralLockActive(warmupGenerations, currentGeneration)`.
-The call site in `NeatEvolution.ts` passes `neat.warmupGenerations` /
+variant
+`isSeedWarmupStructuralLockActive(warmupGenerations, currentGeneration)`. The
+call site in `NeatEvolution.ts` passes `neat.warmupGenerations` /
 `neat.currentGeneration`. The now-unused per-creature helper
 `isSeedWarmupStructuralLockActiveForCreature` has been removed.
 

--- a/docs/archive/pr-summaries/pr-summary-2910.md
+++ b/docs/archive/pr-summaries/pr-summary-2910.md
@@ -1,0 +1,55 @@
+# Read the discovery replay warm-up gate from Neat-level state
+
+## Summary
+
+`DiscoveryReplayQueue.scheduleReplay` previously read the seed warm-up
+structural lock from the creature's own warm-up tags via
+`isSeedWarmupStructuralLockActiveForCreature(creature)`. Once mid-run creatures
+stop carrying warm-up tags (#2911), an untagged creature would read
+`warmupGenerations = 0` → lock **inactive** → a cached replay could prune the
+seeded topology during the warm-up window.
+
+This change switches the gate to **Neat-level warm-up context** supplied by the
+caller. `scheduleReplay` now accepts an optional `warmupContext`
+(`{ warmupGenerations, currentGeneration }`) and gates with the existing numbers
+variant `isSeedWarmupStructuralLockActive(warmupGenerations, currentGeneration)`.
+The call site in `NeatEvolution.ts` passes `neat.warmupGenerations` /
+`neat.currentGeneration`. The now-unused per-creature helper
+`isSeedWarmupStructuralLockActiveForCreature` has been removed.
+
+Lock semantics are unchanged: locked while `count <= warmupGenerations`;
+conservatively locked when warm-up is configured but the count is unknown
+(`<= 0`); unlocked when `count > warmupGenerations` or when warm-up is not
+configured.
+
+Closes #2910.
+
+## Evidence
+
+Backend/CLI change — no UI to screenshot. Verified by the unit tests below and
+the full quality gate (`./quality.sh < /dev/null`): **7060 passed, 0 failed**.
+
+```mermaid
+flowchart LR
+    A[NeatEvolution] -->|warmupGenerations, currentGeneration| B[scheduleReplay]
+    B --> C{isSeedWarmupStructuralLockActive}
+    C -->|locked| D[skip replay]
+    C -->|unlocked| E[start replay]
+```
+
+## Test Plan
+
+- Rewrote `test/NEAT/DiscoveryReplayWarmup.ts` to drive the gate via Neat-level
+  context (no per-creature tags):
+  - skips replay during the active warm-up window;
+  - **untagged creature during warm-up stays locked** (the #2910 regression);
+  - conservative lock when the current generation is unknown;
+  - replays once the count exceeds `warmupGenerations`;
+  - replays when no warm-up is configured / no context is supplied;
+  - per-creature tags are ignored in favour of the Neat-level context.
+- Updated `test/architecture/SeedWarmupStructuralLock.ts`: removed the four
+  `(creature)` cases that exercised the deleted
+  `isSeedWarmupStructuralLockActiveForCreature` helper. The numbers-variant
+  cases (active/inactive/boundary/conservative/non-finite) remain and cover the
+  shared gate logic. This test deletion is a direct consequence of removing the
+  helper the issue authorised removing.

--- a/src/NEAT/DiscoveryReplayQueue.ts
+++ b/src/NEAT/DiscoveryReplayQueue.ts
@@ -5,11 +5,27 @@ import {
   DiscoveryReplayRunner,
 } from "@discovery/DiscoveryReplayRunner.ts";
 import { createNeatConfig } from "@config/NeatConfig.ts";
-import { isSeedWarmupStructuralLockActiveForCreature } from "@architecture/CreatureFactory.ts";
+import { isSeedWarmupStructuralLockActive } from "@architecture/CreatureFactory.ts";
 import { getLogger } from "@utils/Logger.ts";
 
 // Re-export for use by Neat.ts (Issue #1150)
 export type { DiscoveryReplayDirResult };
+
+/**
+ * Neat-level seed warm-up context supplied by the caller (Issue #2910).
+ *
+ * The {@link DiscoveryReplayQueue} holds no `Neat` reference, so the owning
+ * evolution loop passes the warm-up counters explicitly. Reading the lock
+ * state from this context — rather than from per-creature tags — keeps the
+ * gate correct once mid-run creatures stop carrying warm-up tags (#2911):
+ * an untagged creature inside an active warm-up window stays locked.
+ */
+export interface DiscoveryReplayWarmupContext {
+  /** Configured warm-up generation count (0 = warm-up disabled). */
+  warmupGenerations: number;
+  /** Current evolution generation (<= 0 = unknown). */
+  currentGeneration: number;
+}
 
 /**
  * Dependencies for the DiscoveryReplayQueue.
@@ -98,19 +114,29 @@ export class DiscoveryReplayQueue {
    * @param remainingTimeMinutes Optional remaining evolution time in minutes.
    *        If provided and below the minimum threshold, replay is skipped.
    *        If provided, replay timeout is capped to this value.
+   * @param warmupContext Optional Neat-level seed warm-up context. When
+   *        supplied and the lock is active, replay is skipped (Issue #2910).
    */
   scheduleReplay(
     creature: Creature,
     dataDir: string,
     options: NeatOptions,
     remainingTimeMinutes?: number,
+    warmupContext?: DiscoveryReplayWarmupContext,
   ): void {
-    // Issue #2828: never replay cached structural discoveries while the
-    // creature's seed warm-up structural lock is active — replay can prune
-    // or rewire topology, which must wait until warm-up has elapsed. The
-    // lock state is read from the creature's own warm-up tags because this
-    // queue does not hold the owning Neat instance.
-    if (isSeedWarmupStructuralLockActiveForCreature(creature)) {
+    // Issue #2828/#2910: never replay cached structural discoveries while the
+    // seed warm-up structural lock is active — replay can prune or rewire
+    // topology, which must wait until warm-up has elapsed. The lock state is
+    // read from Neat-level warm-up context supplied by the caller (this queue
+    // holds no Neat reference). Reading per-creature tags would silently open
+    // the lock once mid-run creatures stop carrying warm-up tags (#2911).
+    if (
+      warmupContext &&
+      isSeedWarmupStructuralLockActive(
+        warmupContext.warmupGenerations,
+        warmupContext.currentGeneration,
+      )
+    ) {
       return;
     }
 

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -368,6 +368,10 @@ export async function evolve(
         neat.dataDir,
         neat.config,
         trainingTimeOutMinutes > 0 ? trainingTimeOutMinutes : undefined,
+        {
+          warmupGenerations: neat.warmupGenerations,
+          currentGeneration: neat.currentGeneration,
+        },
       );
     }
   }

--- a/src/architecture/CreatureFactory.ts
+++ b/src/architecture/CreatureFactory.ts
@@ -205,20 +205,6 @@ export function isSeedWarmupStructuralLockActive(
 }
 
 /**
- * Read the seed warm-up structural lock state directly from a creature's
- * tags. Used by paths (e.g. {@link DiscoveryReplayQueue}) that only have
- * the creature, not the owning `Neat` instance.
- */
-export function isSeedWarmupStructuralLockActiveForCreature(
-  creature: Creature,
-): boolean {
-  return isSeedWarmupStructuralLockActive(
-    readWarmupGenerationsFromCreature(creature),
-    readCurrentGenerationFromCreature(creature),
-  );
-}
-
-/**
  * Persist seed warm-up progress on a creature so export/load can resume
  * evolution with the correct warm-up gate.
  *

--- a/test/NEAT/DiscoveryReplayWarmup.ts
+++ b/test/NEAT/DiscoveryReplayWarmup.ts
@@ -1,8 +1,13 @@
 /**
- * Issue #2828: DiscoveryReplayQueue must honour the seed warm-up
- * structural lock. While a creature is within its warm-up window, replay
- * of cached structural discoveries must not run (replay can prune/rewire
- * topology). Once warm-up has elapsed, replay resumes as normal.
+ * Issue #2828 / #2910: DiscoveryReplayQueue must honour the seed warm-up
+ * structural lock. While the warm-up window is active, replay of cached
+ * structural discoveries must not run (replay can prune/rewire topology).
+ * Once warm-up has elapsed, replay resumes as normal.
+ *
+ * Issue #2910: the lock state is read from Neat-level warm-up context passed
+ * by the caller, NOT from per-creature warm-up tags. This keeps the gate
+ * correct once mid-run creatures stop carrying warm-up tags (#2911) — an
+ * untagged creature inside an active warm-up window must still be locked.
  */
 import { assertEquals } from "@std/assert";
 import { addTag } from "@stsoftware/tags/mod";
@@ -48,46 +53,73 @@ const OPTIONS: NeatOptions = {
   costOfGrowth: 0,
 };
 
-Deno.test("DiscoveryReplayWarmup: skips replay during warm-up window", async () => {
+Deno.test("DiscoveryReplayWarmup: skips replay during warm-up window (Neat context)", async () => {
   const creature = makeBaseCreature();
   creature.uuid = "warmup-locked";
-  addTag(creature, WARMUP_GENERATIONS_TAG, "1440");
-  addTag(creature, CURRENT_GENERATION_TAG, "100");
 
   const { deps, calls } = trackingDeps();
   const queue = new DiscoveryReplayQueue(deps);
 
-  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS, undefined, {
+    warmupGenerations: 1440,
+    currentGeneration: 100,
+  });
   await queue.waitForCompletion();
 
   assertEquals(calls(), 0, "Replay must not run while warm-up lock is active");
 });
 
-Deno.test("DiscoveryReplayWarmup: skips replay when generation tag missing", async () => {
+Deno.test("DiscoveryReplayWarmup: untagged creature during warm-up stays locked", async () => {
+  // Regression for #2910: the creature carries NO warm-up tags (as mid-run
+  // creatures will once #2911 lands). The lock must still be active because
+  // the Neat-level context says warm-up has not elapsed.
   const creature = makeBaseCreature();
-  creature.uuid = "warmup-no-gen";
-  addTag(creature, WARMUP_GENERATIONS_TAG, "1440");
-  // No currentGeneration tag — conservative lock must still block replay.
+  creature.uuid = "warmup-untagged";
 
   const { deps, calls } = trackingDeps();
   const queue = new DiscoveryReplayQueue(deps);
 
-  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS, undefined, {
+    warmupGenerations: 1440,
+    currentGeneration: 5,
+  });
+  await queue.waitForCompletion();
+
+  assertEquals(
+    calls(),
+    0,
+    "Untagged creature must stay locked during active warm-up window",
+  );
+});
+
+Deno.test("DiscoveryReplayWarmup: conservative lock when generation unknown", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "warmup-no-gen";
+
+  const { deps, calls } = trackingDeps();
+  const queue = new DiscoveryReplayQueue(deps);
+
+  // Warm-up configured but current generation unknown (<= 0) → stay locked.
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS, undefined, {
+    warmupGenerations: 1440,
+    currentGeneration: 0,
+  });
   await queue.waitForCompletion();
 
   assertEquals(calls(), 0, "Conservative lock must block replay");
 });
 
-Deno.test("DiscoveryReplayWarmup: replays once warm-up has elapsed", async () => {
+Deno.test("DiscoveryReplayWarmup: replays once warm-up has elapsed (Neat context)", async () => {
   const creature = makeBaseCreature();
   creature.uuid = "warmup-elapsed";
-  addTag(creature, WARMUP_GENERATIONS_TAG, "10");
-  addTag(creature, CURRENT_GENERATION_TAG, "11");
 
   const { deps, calls } = trackingDeps();
   const queue = new DiscoveryReplayQueue(deps);
 
-  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS, undefined, {
+    warmupGenerations: 10,
+    currentGeneration: 11,
+  });
   await queue.waitForCompletion();
 
   assertEquals(calls(), 1, "Replay must run after warm-up elapses");
@@ -100,8 +132,52 @@ Deno.test("DiscoveryReplayWarmup: replays when no warm-up configured", async () 
   const { deps, calls } = trackingDeps();
   const queue = new DiscoveryReplayQueue(deps);
 
-  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS, undefined, {
+    warmupGenerations: 0,
+    currentGeneration: 50,
+  });
   await queue.waitForCompletion();
 
   assertEquals(calls(), 1, "Replay must run when no warm-up is configured");
+});
+
+Deno.test("DiscoveryReplayWarmup: replays when no warm-up context supplied", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "no-context";
+
+  const { deps, calls } = trackingDeps();
+  const queue = new DiscoveryReplayQueue(deps);
+
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  await queue.waitForCompletion();
+
+  assertEquals(
+    calls(),
+    1,
+    "Replay must run when no warm-up context is supplied",
+  );
+});
+
+Deno.test("DiscoveryReplayWarmup: per-creature tags are ignored in favour of Neat context", async () => {
+  // The creature is tagged as if warm-up has elapsed, but the Neat-level
+  // context says the lock is active. The context must win.
+  const creature = makeBaseCreature();
+  creature.uuid = "tags-ignored";
+  addTag(creature, WARMUP_GENERATIONS_TAG, "10");
+  addTag(creature, CURRENT_GENERATION_TAG, "999");
+
+  const { deps, calls } = trackingDeps();
+  const queue = new DiscoveryReplayQueue(deps);
+
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS, undefined, {
+    warmupGenerations: 1440,
+    currentGeneration: 100,
+  });
+  await queue.waitForCompletion();
+
+  assertEquals(
+    calls(),
+    0,
+    "Neat-level context must override per-creature warm-up tags",
+  );
 });

--- a/test/architecture/SeedWarmupStructuralLock.ts
+++ b/test/architecture/SeedWarmupStructuralLock.ts
@@ -6,14 +6,7 @@
  * warm-up window has elapsed.
  */
 import { assertEquals } from "@std/assert";
-import { addTag } from "@stsoftware/tags/mod";
-import { Creature } from "@creature";
-import {
-  CURRENT_GENERATION_TAG,
-  isSeedWarmupStructuralLockActive,
-  isSeedWarmupStructuralLockActiveForCreature,
-  WARMUP_GENERATIONS_TAG,
-} from "@architecture/CreatureFactory.ts";
+import { isSeedWarmupStructuralLockActive } from "@architecture/CreatureFactory.ts";
 
 Deno.test("structural lock: inactive when no warm-up configured", () => {
   assertEquals(isSeedWarmupStructuralLockActive(0, 0), false);
@@ -44,28 +37,8 @@ Deno.test("structural lock: ignores non-finite inputs", () => {
   assertEquals(isSeedWarmupStructuralLockActive(10, NaN), true);
 });
 
-Deno.test("structural lock (creature): no warm-up tag → inactive", () => {
-  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
-  assertEquals(isSeedWarmupStructuralLockActiveForCreature(creature), false);
-});
-
-Deno.test("structural lock (creature): warm-up tag, mid-window → active", () => {
-  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
-  addTag(creature, WARMUP_GENERATIONS_TAG, "1440");
-  addTag(creature, CURRENT_GENERATION_TAG, "100");
-  assertEquals(isSeedWarmupStructuralLockActiveForCreature(creature), true);
-});
-
-Deno.test("structural lock (creature): warm-up tag, window elapsed → inactive", () => {
-  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
-  addTag(creature, WARMUP_GENERATIONS_TAG, "10");
-  addTag(creature, CURRENT_GENERATION_TAG, "11");
-  assertEquals(isSeedWarmupStructuralLockActiveForCreature(creature), false);
-});
-
-Deno.test("structural lock (creature): warm-up tag, no generation tag → active", () => {
-  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
-  addTag(creature, WARMUP_GENERATIONS_TAG, "1440");
-  // No currentGeneration tag — conservative lock keeps structural pruning off.
-  assertEquals(isSeedWarmupStructuralLockActiveForCreature(creature), true);
-});
+// Issue #2910: the per-creature variant
+// `isSeedWarmupStructuralLockActiveForCreature` has been removed — its only
+// production caller (DiscoveryReplayQueue) now reads the lock from Neat-level
+// warm-up context. The remaining tests above cover the numbers variant that
+// every gate uses.


### PR DESCRIPTION
# Read the discovery replay warm-up gate from Neat-level state

## Summary

`DiscoveryReplayQueue.scheduleReplay` previously read the seed warm-up
structural lock from the creature's own warm-up tags via
`isSeedWarmupStructuralLockActiveForCreature(creature)`. Once mid-run creatures
stop carrying warm-up tags (#2911), an untagged creature would read
`warmupGenerations = 0` → lock **inactive** → a cached replay could prune the
seeded topology during the warm-up window.

This change switches the gate to **Neat-level warm-up context** supplied by the
caller. `scheduleReplay` now accepts an optional `warmupContext`
(`{ warmupGenerations, currentGeneration }`) and gates with the existing numbers
variant `isSeedWarmupStructuralLockActive(warmupGenerations, currentGeneration)`.
The call site in `NeatEvolution.ts` passes `neat.warmupGenerations` /
`neat.currentGeneration`. The now-unused per-creature helper
`isSeedWarmupStructuralLockActiveForCreature` has been removed.

Lock semantics are unchanged: locked while `count <= warmupGenerations`;
conservatively locked when warm-up is configured but the count is unknown
(`<= 0`); unlocked when `count > warmupGenerations` or when warm-up is not
configured.

Closes #2910.

## Evidence

Backend/CLI change — no UI to screenshot. Verified by the unit tests below and
the full quality gate (`./quality.sh < /dev/null`): **7060 passed, 0 failed**.

```mermaid
flowchart LR
    A[NeatEvolution] -->|warmupGenerations, currentGeneration| B[scheduleReplay]
    B --> C{isSeedWarmupStructuralLockActive}
    C -->|locked| D[skip replay]
    C -->|unlocked| E[start replay]
```

## Test Plan

- Rewrote `test/NEAT/DiscoveryReplayWarmup.ts` to drive the gate via Neat-level
  context (no per-creature tags):
  - skips replay during the active warm-up window;
  - **untagged creature during warm-up stays locked** (the #2910 regression);
  - conservative lock when the current generation is unknown;
  - replays once the count exceeds `warmupGenerations`;
  - replays when no warm-up is configured / no context is supplied;
  - per-creature tags are ignored in favour of the Neat-level context.
- Updated `test/architecture/SeedWarmupStructuralLock.ts`: removed the four
  `(creature)` cases that exercised the deleted
  `isSeedWarmupStructuralLockActiveForCreature` helper. The numbers-variant
  cases (active/inactive/boundary/conservative/non-finite) remain and cover the
  shared gate logic. This test deletion is a direct consequence of removing the
  helper the issue authorised removing.
