### PR TITLE
Seed warm-up: stamp tags only at the export/save boundary; strip once warm (#2909)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.26",
+  "version": "5.3.27",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2909.md
+++ b/docs/archive/pr-summaries/pr-summary-2909.md
@@ -1,0 +1,74 @@
+# Stamp warm-up tags only at the export/save boundary; strip both once warm
+
+## Summary
+
+Warm-up tags (`warmupGenerations` / `currentGeneration`) are now written from
+Neat-level state **only when a creature is exported for persistence**, and both
+tags are **removed once the accumulated counter passes `warmupGenerations`**, so
+warm-up logic is zero cost after warm-up completes and no stale seed value
+lands on disk.
+
+Previously only the per-generation fittest was re-stamped, so whichever creature
+actually landed on disk usually carried the stale seed value and the next run
+resumed from it.
+
+New helper `applySeedWarmupTagsAtSave(target, warmupGenerations, currentGeneration)`
+in `src/architecture/CreatureFactory.ts`:
+
+- **Warming** (`warmupGenerations > 0 && currentGeneration <= warmupGenerations`):
+  stamps both tags via `writeSeedWarmupProgressTags`, preserving its #2831
+  monotonic-max guard (a higher generation is never lowered).
+- **Warm** (`currentGeneration > warmupGenerations`) or **not configured**:
+  `removeTag` both tags if present.
+
+It operates on any taggable target (a live `Creature` or an exported JSON
+object), so callers can stamp the export rather than mutating live population
+members. `writeSeedWarmupProgressTags` and `readCurrentGenerationFromCreature`
+were widened from `Creature` to `TagsInterface` (a backwards-compatible
+widening) to support this.
+
+Applied at both library save boundaries:
+
+- **`src/NEAT/NeatEvolution.ts`** — the fittest return path now uses the helper,
+  so it strips once warm instead of only stamping while warming. The fittest is
+  already a clone, so tagging it directly is safe.
+- **`src/creature/CreatureTraining.ts`** — `writeCreatures()` stamps the
+  exported JSON of every population member as it is written, so the saved file
+  is correct regardless of which creature is saved.
+
+Closes #2909.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot. Verified via unit
+tests (`test/architecture/SeedWarmupPersistence.ts`): all 16 pass.
+
+```mermaid
+flowchart TD
+    X[Creature about to be saved] --> W{warmupGenerations > 0 and counter <= warmupGenerations?}
+    W -- warming --> S[Stamp both tags from Neat-level counter]
+    W -- warm / not configured --> R[Remove both tags if present]
+    S --> E[exportJSON written to disk]
+    R --> E
+```
+
+## Test Plan
+
+Added to `test/architecture/SeedWarmupPersistence.ts`:
+
+- `applySeedWarmupTagsAtSave: while warming stamps both tags from counter` —
+  carries the accumulated counter, never a stale seed value.
+- `applySeedWarmupTagsAtSave: keeps #2831 monotonic-max guard` — a lower
+  Neat-level counter never lowers an existing higher generation.
+- `applySeedWarmupTagsAtSave: once warm strips both tags`.
+- `applySeedWarmupTagsAtSave: not configured strips stale tags`.
+- `applySeedWarmupTagsAtSave: not configured adds no tags`.
+- `applySeedWarmupTagsAtSave: stamps the exported JSON object` — verifies the
+  helper works on an export object (the `writeCreatures()` path).
+- `applySeedWarmupTagsAtSave: strips stale tags from exported JSON once warm`.
+
+Note: `./quality.sh` reported one failure in
+`test/score/RustScorerBridgeHardening.ts` ("logs trimmed stderr on non-zero
+exit"). This test is unrelated to this change (Rust scorer stderr logging) and
+**passes in isolation** — it is flaky under parallel load. All warm-up tag tests
+pass.

--- a/docs/archive/pr-summaries/pr-summary-2909.md
+++ b/docs/archive/pr-summaries/pr-summary-2909.md
@@ -5,18 +5,20 @@
 Warm-up tags (`warmupGenerations` / `currentGeneration`) are now written from
 Neat-level state **only when a creature is exported for persistence**, and both
 tags are **removed once the accumulated counter passes `warmupGenerations`**, so
-warm-up logic is zero cost after warm-up completes and no stale seed value
-lands on disk.
+warm-up logic is zero cost after warm-up completes and no stale seed value lands
+on disk.
 
 Previously only the per-generation fittest was re-stamped, so whichever creature
 actually landed on disk usually carried the stale seed value and the next run
 resumed from it.
 
-New helper `applySeedWarmupTagsAtSave(target, warmupGenerations, currentGeneration)`
-in `src/architecture/CreatureFactory.ts`:
+New helper
+`applySeedWarmupTagsAtSave(target, warmupGenerations, currentGeneration)` in
+`src/architecture/CreatureFactory.ts`:
 
-- **Warming** (`warmupGenerations > 0 && currentGeneration <= warmupGenerations`):
-  stamps both tags via `writeSeedWarmupProgressTags`, preserving its #2831
+- **Warming**
+  (`warmupGenerations > 0 && currentGeneration <= warmupGenerations`): stamps
+  both tags via `writeSeedWarmupProgressTags`, preserving its #2831
   monotonic-max guard (a higher generation is never lowered).
 - **Warm** (`currentGeneration > warmupGenerations`) or **not configured**:
   `removeTag` both tags if present.

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -47,8 +47,8 @@ import {
 import { processCompletedResults } from "@neat/ProcessCompletedResults.ts";
 import { selectTrainingCandidates } from "@neat/TrainingCandidates.ts";
 import {
+  applySeedWarmupTagsAtSave,
   isSeedWarmupStructuralLockActive,
-  writeSeedWarmupProgressTags,
 } from "@architecture/CreatureFactory.ts";
 
 /**
@@ -983,13 +983,15 @@ export async function evolve(
     );
   }
 
-  if (neat.warmupGenerations > 0) {
-    writeSeedWarmupProgressTags(
-      fittest,
-      neat.warmupGenerations,
-      neat.currentGeneration,
-    );
-  }
+  // Issue #2909: stamp warm-up tags only at this save boundary while warming,
+  // and strip both once warm (or when warm-up was never configured) so the
+  // returned fittest never carries stale warm-up state. The fittest is already
+  // a clone, so tagging it directly is safe.
+  applySeedWarmupTagsAtSave(
+    fittest,
+    neat.warmupGenerations,
+    neat.currentGeneration,
+  );
 
   return {
     fittest: fittest,

--- a/src/architecture/CreatureFactory.ts
+++ b/src/architecture/CreatureFactory.ts
@@ -44,7 +44,12 @@
 import { Creature } from "@creature";
 import type { DataRecordInterface } from "@architecture/DataSet.ts";
 import { pickOutputSquashForCost } from "@costs/CostOutputSquash.ts";
-import { addTag, getTag } from "@stsoftware/tags/mod";
+import {
+  addTag,
+  getTag,
+  removeTag,
+  type TagsInterface,
+} from "@stsoftware/tags/mod";
 
 /** Inclusive numeric range, e.g. `{ min: -1, max: 1 }`. */
 export interface NumericRange {
@@ -163,7 +168,9 @@ export function readWarmupGenerationsFromCreature(creature: Creature): number {
  * Parse the saved evolution generation from a creature tag.
  * Returns 0 when the tag is absent or invalid.
  */
-export function readCurrentGenerationFromCreature(creature: Creature): number {
+export function readCurrentGenerationFromCreature(
+  creature: TagsInterface,
+): number {
   const tag = getTag(creature, CURRENT_GENERATION_TAG);
   if (!tag) return 0;
   const n = Number.parseInt(tag, 10);
@@ -216,7 +223,7 @@ export function isSeedWarmupStructuralLockActive(
  * tagging from clobbering generations accumulated across machines/breeding.
  */
 export function writeSeedWarmupProgressTags(
-  creature: Creature,
+  creature: TagsInterface,
   warmupGenerations: number,
   currentGeneration: number,
 ): void {
@@ -238,6 +245,41 @@ export function writeSeedWarmupProgressTags(
       String(next),
     );
   }
+}
+
+/**
+ * Issue #2909: Apply seed warm-up progress tags at an export/save boundary.
+ *
+ * Warm-up tags must only be written when a creature is persisted, and stripped
+ * once warm-up has completed, so warm-up logic costs nothing after warm-up.
+ *
+ * - While warming (`warmupGenerations > 0` and the accumulated counter has not
+ *   yet passed it, `currentGeneration <= warmupGenerations`), stamp both tags
+ *   from the Neat-level values via {@link writeSeedWarmupProgressTags}, keeping
+ *   its #2831 monotonic-max guard so a higher generation is never lowered.
+ * - When warm (`currentGeneration > warmupGenerations`) or warm-up was never
+ *   configured, strip both tags if present so the saved JSON carries no stale
+ *   warm-up state.
+ *
+ * Operates on any taggable target — a live `Creature` or an exported JSON
+ * object — so callers can stamp the export rather than mutating live
+ * population members.
+ */
+export function applySeedWarmupTagsAtSave(
+  target: TagsInterface,
+  warmupGenerations: number,
+  currentGeneration: number,
+): void {
+  const warming = Number.isFinite(warmupGenerations) &&
+    warmupGenerations > 0 &&
+    Number.isFinite(currentGeneration) &&
+    currentGeneration <= warmupGenerations;
+  if (warming) {
+    writeSeedWarmupProgressTags(target, warmupGenerations, currentGeneration);
+    return;
+  }
+  removeTag(target, WARMUP_GENERATIONS_TAG);
+  removeTag(target, CURRENT_GENERATION_TAG);
 }
 
 function applyWarmupGenerationsTag(

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -45,6 +45,7 @@ import {
 import { buildOutgoingSynapsesMap } from "@propagate/sparse/CalculatePathsToOutput.ts";
 import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
 import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+import { applySeedWarmupTagsAtSave } from "@architecture/CreatureFactory.ts";
 import { BufferPool } from "@utils/BufferPool.ts";
 import {
   type DiscoveryDirResult,
@@ -343,6 +344,15 @@ async function writeCreatures(neat: Neat, dir: string): Promise<void> {
     }
     const json = c.exportJSON();
     assertValidWriteableSemanticVersion(json.semanticVersion);
+    // Issue #2909: stamp warm-up tags only at this export boundary. Stamp the
+    // exported JSON (not the live population member) so the saved file is
+    // correct regardless of which creature is saved: while warming it carries
+    // the Neat-level counter, and once warm both tags are stripped.
+    applySeedWarmupTagsAtSave(
+      json,
+      neat.warmupGenerations,
+      neat.currentGeneration,
+    );
     const txt = JSON.stringify(json);
     const filePath = dir + "/" + counter + ".json";
     writes.push(Deno.writeTextFile(filePath, txt));

--- a/test/architecture/SeedWarmupPersistence.ts
+++ b/test/architecture/SeedWarmupPersistence.ts
@@ -2,11 +2,12 @@
  * Seed warm-up tag persistence (export / load round-trip).
  */
 import { assertEquals } from "@std/assert";
-import { addTag } from "@stsoftware/tags/mod";
+import { addTag, getTag } from "@stsoftware/tags/mod";
 import { Creature } from "@creature";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import { Offspring } from "@architecture/Offspring.ts";
 import {
+  applySeedWarmupTagsAtSave,
   creatureForProblem,
   CURRENT_GENERATION_TAG,
   readCurrentGenerationFromCreature,
@@ -206,4 +207,115 @@ Deno.test("Offspring.breed: warm-up tags survive grafted breeding", () => {
   assertEquals(child !== undefined, true);
   assertEquals(readWarmupGenerationsFromCreature(child!), 40);
   assertEquals(readCurrentGenerationFromCreature(child!), 7);
+});
+
+// ─── Issue #2909: save-boundary stamping / stripping ────────────────────────
+
+Deno.test("applySeedWarmupTagsAtSave: while warming stamps both tags from counter", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    warmupGenerations: 20,
+  });
+  // Stale seed value lingering on the creature.
+  addTag(creature, CURRENT_GENERATION_TAG, "1");
+
+  applySeedWarmupTagsAtSave(creature, 20, 8);
+
+  assertEquals(readWarmupGenerationsFromCreature(creature), 20);
+  // Never a stale seed value — carries the accumulated counter.
+  assertEquals(readCurrentGenerationFromCreature(creature), 8);
+});
+
+Deno.test("applySeedWarmupTagsAtSave: keeps #2831 monotonic-max guard", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    warmupGenerations: 30,
+  });
+  addTag(creature, CURRENT_GENERATION_TAG, "15");
+
+  // A lower Neat-level counter must never lower an existing higher generation.
+  applySeedWarmupTagsAtSave(creature, 30, 9);
+
+  assertEquals(readCurrentGenerationFromCreature(creature), 15);
+});
+
+Deno.test("applySeedWarmupTagsAtSave: once warm strips both tags", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    warmupGenerations: 10,
+  });
+  // Stale warm-up tags present from earlier warming.
+  addTag(creature, WARMUP_GENERATIONS_TAG, "10");
+  addTag(creature, CURRENT_GENERATION_TAG, "10");
+
+  // counter (11) > warmupGenerations (10) => warm.
+  applySeedWarmupTagsAtSave(creature, 10, 11);
+
+  assertEquals(getTag(creature, WARMUP_GENERATIONS_TAG), null);
+  assertEquals(getTag(creature, CURRENT_GENERATION_TAG), null);
+});
+
+Deno.test("applySeedWarmupTagsAtSave: not configured strips stale tags", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+  addTag(creature, WARMUP_GENERATIONS_TAG, "5");
+  addTag(creature, CURRENT_GENERATION_TAG, "3");
+
+  // warmupGenerations 0 => warm-up never configured.
+  applySeedWarmupTagsAtSave(creature, 0, 0);
+
+  assertEquals(getTag(creature, WARMUP_GENERATIONS_TAG), null);
+  assertEquals(getTag(creature, CURRENT_GENERATION_TAG), null);
+});
+
+Deno.test("applySeedWarmupTagsAtSave: not configured adds no tags", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+
+  applySeedWarmupTagsAtSave(creature, 0, 0);
+
+  assertEquals(getTag(creature, WARMUP_GENERATIONS_TAG), null);
+  assertEquals(getTag(creature, CURRENT_GENERATION_TAG), null);
+});
+
+Deno.test("applySeedWarmupTagsAtSave: stamps the exported JSON object", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    warmupGenerations: 25,
+  });
+  const json: CreatureExport = creature.exportJSON();
+
+  applySeedWarmupTagsAtSave(json, 25, 13);
+
+  const warmupTag = json.tags?.find((t) => t.name === WARMUP_GENERATIONS_TAG);
+  const generationTag = json.tags?.find((t) =>
+    t.name === CURRENT_GENERATION_TAG
+  );
+  assertEquals(warmupTag?.value, "25");
+  assertEquals(generationTag?.value, "13");
+});
+
+Deno.test("applySeedWarmupTagsAtSave: strips stale tags from exported JSON once warm", () => {
+  const creature = creatureForProblem({
+    inputs: 4,
+    outputs: 1,
+    warmupGenerations: 12,
+  });
+  // Stale seed value on the live creature that would otherwise land on disk.
+  addTag(creature, CURRENT_GENERATION_TAG, "1");
+  const json: CreatureExport = creature.exportJSON();
+
+  // counter (13) > warmupGenerations (12) => warm.
+  applySeedWarmupTagsAtSave(json, 12, 13);
+
+  assertEquals(
+    json.tags?.find((t) => t.name === WARMUP_GENERATIONS_TAG),
+    undefined,
+  );
+  assertEquals(
+    json.tags?.find((t) => t.name === CURRENT_GENERATION_TAG),
+    undefined,
+  );
 });


### PR DESCRIPTION
# Stamp warm-up tags only at the export/save boundary; strip both once warm

## Summary

Warm-up tags (`warmupGenerations` / `currentGeneration`) are now written from
Neat-level state **only when a creature is exported for persistence**, and both
tags are **removed once the accumulated counter passes `warmupGenerations`**, so
warm-up logic is zero cost after warm-up completes and no stale seed value lands
on disk.

Previously only the per-generation fittest was re-stamped, so whichever creature
actually landed on disk usually carried the stale seed value and the next run
resumed from it.

New helper
`applySeedWarmupTagsAtSave(target, warmupGenerations, currentGeneration)` in
`src/architecture/CreatureFactory.ts`:

- **Warming**
  (`warmupGenerations > 0 && currentGeneration <= warmupGenerations`): stamps
  both tags via `writeSeedWarmupProgressTags`, preserving its #2831
  monotonic-max guard (a higher generation is never lowered).
- **Warm** (`currentGeneration > warmupGenerations`) or **not configured**:
  `removeTag` both tags if present.

It operates on any taggable target (a live `Creature` or an exported JSON
object), so callers can stamp the export rather than mutating live population
members. `writeSeedWarmupProgressTags` and `readCurrentGenerationFromCreature`
were widened from `Creature` to `TagsInterface` (a backwards-compatible
widening) to support this.

Applied at both library save boundaries:

- **`src/NEAT/NeatEvolution.ts`** — the fittest return path now uses the helper,
  so it strips once warm instead of only stamping while warming. The fittest is
  already a clone, so tagging it directly is safe.
- **`src/creature/CreatureTraining.ts`** — `writeCreatures()` stamps the
  exported JSON of every population member as it is written, so the saved file
  is correct regardless of which creature is saved.

Closes #2909.

## Evidence

Backend/library change only — no web interface to screenshot. Verified via unit
tests (`test/architecture/SeedWarmupPersistence.ts`): all 16 pass.

```mermaid
flowchart TD
    X[Creature about to be saved] --> W{warmupGenerations > 0 and counter <= warmupGenerations?}
    W -- warming --> S[Stamp both tags from Neat-level counter]
    W -- warm / not configured --> R[Remove both tags if present]
    S --> E[exportJSON written to disk]
    R --> E
```

## Test Plan

Added to `test/architecture/SeedWarmupPersistence.ts`:

- `applySeedWarmupTagsAtSave: while warming stamps both tags from counter` —
  carries the accumulated counter, never a stale seed value.
- `applySeedWarmupTagsAtSave: keeps #2831 monotonic-max guard` — a lower
  Neat-level counter never lowers an existing higher generation.
- `applySeedWarmupTagsAtSave: once warm strips both tags`.
- `applySeedWarmupTagsAtSave: not configured strips stale tags`.
- `applySeedWarmupTagsAtSave: not configured adds no tags`.
- `applySeedWarmupTagsAtSave: stamps the exported JSON object` — verifies the
  helper works on an export object (the `writeCreatures()` path).
- `applySeedWarmupTagsAtSave: strips stale tags from exported JSON once warm`.

Note: `./quality.sh` reported one failure in
`test/score/RustScorerBridgeHardening.ts` ("logs trimmed stderr on non-zero
exit"). This test is unrelated to this change (Rust scorer stderr logging) and
**passes in isolation** — it is flaky under parallel load. All warm-up tag tests
pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq96qlxt-bcd6bb`<!-- vibe-worker-issue-2909 -->