### PR TITLE
Add hard-deadline (T+15) helper and plumb hardDeadlineTS (Issue #2895)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-2895.md
+++ b/docs/archive/pr-summaries/pr-summary-2895.md
@@ -1,0 +1,58 @@
+# Add hard-deadline (T+15) helper and plumb `hardDeadlineTS`
+
+## Summary
+
+Introduces a single source of truth for the evolution hard cap — the absolute
+wall-clock timestamp past which `evolveDir` must abandon all in-flight work —
+and plumbs it through `Neat` and the three evolve variants so later sub-issues
+can enforce it in each phase. Pure plumbing: no behavioural change to existing
+runs. Closes #2895. Part of #2892.
+
+- **New module `src/NEAT/HardDeadline.ts`** exporting:
+  - `HARD_DEADLINE_GRACE_MINUTES = 15` — the maximum permitted overrun past
+    `timeoutMinutes`.
+  - `computeHardDeadlineTS(startMS, timeoutMinutes)` — returns
+    `startMS + timeoutMinutes * 60_000 + graceMS`, where
+    `graceMS = min(15, max(1, timeoutMinutes)) * 60_000`. Returns `undefined`
+    when `timeoutMinutes` is 0/unset (no timeout → no cap). The helper is pure
+    (absolute timestamps in, absolute timestamps out), so tests need no real
+    clock (policy from #2888).
+- **`src/NEAT/Neat.ts`** — new `hardDeadlineTS` field set alongside `endTimeTS`
+  from the same options via the helper (0 when no timeout). Both now anchor to
+  one captured `startTS`.
+- **`src/creature/CreatureTraining.ts`** — each of the three evolve variants
+  computes `hardDeadlineMS` next to its existing `endTimeMS`. The value is
+  computed but not yet consumed (enforcement lands in follow-up sub-issues),
+  marked with a documented `deno-lint-ignore no-unused-vars`.
+
+## Data flow
+
+```mermaid
+flowchart LR
+    O[NeatOptions.timeoutMinutes] --> H[computeHardDeadlineTS]
+    S[startMS / startTS] --> H
+    H -->|undefined → 0| N[Neat.hardDeadlineTS]
+    H -->|undefined → 0| C[CreatureTraining hardDeadlineMS x3]
+    N -.future sub-issues.-> E[per-phase enforcement]
+    C -.future sub-issues.-> E
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via unit tests and
+the full quality gate.
+
+- `./quality.sh` passes cleanly: `ok | 7093 passed (2 steps) | 0 failed`.
+- The helper is pure; all assertions are on returned/derived timestamps, never
+  on elapsed wall-clock time (policy from #2888).
+
+## Test Plan
+
+- **`test/NEAT/HardDeadline.ts`** (new) — covers:
+  - grace constant is 15 minutes;
+  - no timeout configured → `undefined` (both 0 and `undefined` inputs);
+  - T=2 → grace 2 m; T=45 → grace capped at 15 m (T+15); T=120 → grace clamped
+    to 15 m; T=1 → grace 1 m.
+- **`test/NEAT/NeatConstruction.ts`** (extended) — asserts
+  `hardDeadlineTS - endTimeTS === 5 minutes` for `timeoutMinutes=5`, and
+  `hardDeadlineTS === 0` when no timeout is set (consistent with `endTimeTS`).

--- a/src/NEAT/HardDeadline.ts
+++ b/src/NEAT/HardDeadline.ts
@@ -1,0 +1,46 @@
+/**
+ * Hard-deadline (T+15) helper — Issue #2895, part of #2892.
+ *
+ * A single source of truth for the evolution hard cap: the absolute wall-clock
+ * timestamp past which `evolveDir` must abandon all in-flight work. Discovery,
+ * training and replay phases each anchor their own relative budgets at task
+ * start with no shared absolute cap, so GRQ runs configured with a short
+ * `--timeout` can still be killed by the external watchdog. This module
+ * computes a shared cap that later sub-issues enforce in each phase.
+ *
+ * The helper is pure — absolute timestamps in, absolute timestamps out — so
+ * tests need no real clock (policy from #2888).
+ */
+
+/** The maximum permitted overrun, in minutes, past the configured `timeoutMinutes`. */
+export const HARD_DEADLINE_GRACE_MINUTES = 15;
+
+/**
+ * Compute the absolute hard-deadline timestamp.
+ *
+ * Returns `startMS + timeoutMinutes * 60_000 + graceMS`, where the grace period
+ * is clamped to `min(HARD_DEADLINE_GRACE_MINUTES, max(1, timeoutMinutes))`
+ * minutes. Clamping grace to `min(15, T)` keeps short runs proportionate (a
+ * 2-minute run gets at most 2 minutes of grace) while never exceeding the
+ * 15-minute cap for long runs.
+ *
+ * @param startMS         Absolute start timestamp in milliseconds.
+ * @param timeoutMinutes  Configured soft timeout in minutes.
+ * @returns The absolute hard-deadline timestamp in milliseconds, or `undefined`
+ *          when `timeoutMinutes` is 0/unset (no timeout configured → no cap).
+ */
+export function computeHardDeadlineTS(
+  startMS: number,
+  timeoutMinutes: number,
+): number | undefined {
+  if (!timeoutMinutes) {
+    return undefined;
+  }
+
+  const graceMinutes = Math.min(
+    HARD_DEADLINE_GRACE_MINUTES,
+    Math.max(1, timeoutMinutes),
+  );
+
+  return startMS + timeoutMinutes * 60_000 + graceMinutes * 60_000;
+}

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -23,6 +23,7 @@ import type {
 import { WorkerPool } from "@multithreading/WorkerPool.ts";
 import type { CrisprInterface } from "@reconstruct/CRISPR.ts";
 import { Genus } from "@neat/Genus.ts";
+import { computeHardDeadlineTS } from "@neat/HardDeadline.ts";
 import { Mutator } from "@neat/Mutator.ts";
 import { MCMCState } from "@neat/MCMCState.ts";
 import { PlateauDetector } from "@neat/PlateauDetector.ts";
@@ -80,6 +81,12 @@ export class Neat {
 
   /** Timestamp when evolution should end (if timeout is set) */
   readonly endTimeTS: number;
+  /**
+   * Absolute hard-deadline timestamp — the wall-clock cap past which all
+   * in-flight work must be abandoned (Issue #2895). 0 when no timeout is set.
+   * Enforcement lands in follow-up sub-issues; this is shared plumbing.
+   */
+  readonly hardDeadlineTS: number;
   /** Current population of creatures */
   population: Creature[];
   /** Available CRISPR modifications for targeted evolution (read-only after init) */
@@ -262,9 +269,16 @@ export class Neat {
       this.population.push(n);
     });
 
+    const startTS = Date.now();
     this.endTimeTS = options.timeoutMinutes
-      ? Date.now() + Math.max(1, options.timeoutMinutes) * 60_000
+      ? startTS + Math.max(1, options.timeoutMinutes) * 60_000
       : 0;
+    // Issue #2895: shared absolute hard cap (endTimeTS + clamped grace). 0 when
+    // no timeout is configured, mirroring endTimeTS.
+    this.hardDeadlineTS = computeHardDeadlineTS(
+      startTS,
+      options.timeoutMinutes ?? 0,
+    ) ?? 0;
     this.CRISPRs = Neat.deepCloneAndShuffle(this.config.CRISPRs);
 
     this.plateauDetector = new PlateauDetector(this.config.plateauDetection);

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -32,6 +32,7 @@ import {
 } from "@costs/CostAwareEarlyStop.ts";
 import { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import { Neat } from "@neat/Neat.ts";
+import { computeHardDeadlineTS } from "@neat/HardDeadline.ts";
 import {
   type BackPropagationConfig,
   createBackPropagationConfig,
@@ -390,6 +391,12 @@ export async function evolveDir(
   const endTimeMS = config.timeoutMinutes
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
+  // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
+  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
+  // so the value is computed but not yet consumed.
+  // deno-lint-ignore no-unused-vars
+  const hardDeadlineMS =
+    computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
   const workers: WorkerHandler[] = [];
   const threads = config.threads;
@@ -707,6 +714,12 @@ export async function evolveEnv<S, A>(
   const endTimeMS = config.timeoutMinutes
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
+  // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
+  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
+  // so the value is computed but not yet consumed.
+  // deno-lint-ignore no-unused-vars
+  const hardDeadlineMS =
+    computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
   const trialsPerScore = options.trialsPerScore !== undefined
     ? Math.max(1, Math.floor(options.trialsPerScore))
@@ -1057,6 +1070,12 @@ export async function evolveRL<S, A>(
   const endTimeMS = config.timeoutMinutes
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
+  // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
+  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
+  // so the value is computed but not yet consumed.
+  // deno-lint-ignore no-unused-vars
+  const hardDeadlineMS =
+    computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
   // Lazy import avoids a circular module graph (Neat.ts → Creature.ts →
   // CreatureTraining.ts → RLEpisodeFitness.ts → Fitness.ts vs Neat.ts → Fitness.ts).

--- a/test/NEAT/HardDeadline.ts
+++ b/test/NEAT/HardDeadline.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "@std/assert";
+import {
+  computeHardDeadlineTS,
+  HARD_DEADLINE_GRACE_MINUTES,
+} from "@neat/HardDeadline.ts";
+
+// All assertions use absolute timestamps passed in (no real clock), per the
+// policy in #2888: tests assert on returned timestamps, not elapsed wall-clock.
+const START = 1_000_000_000_000; // fixed, arbitrary absolute millisecond epoch
+
+Deno.test("HardDeadline - grace cap constant is 15 minutes", () => {
+  assertEquals(HARD_DEADLINE_GRACE_MINUTES, 15);
+});
+
+Deno.test("HardDeadline - no timeout configured returns undefined", () => {
+  assertEquals(computeHardDeadlineTS(START, 0), undefined);
+});
+
+Deno.test("HardDeadline - unset (undefined) timeout returns undefined", () => {
+  assertEquals(
+    computeHardDeadlineTS(START, undefined as unknown as number),
+    undefined,
+  );
+});
+
+Deno.test("HardDeadline - T=2 gives grace of 2 minutes", () => {
+  // grace = min(15, max(1, 2)) = 2 minutes
+  const expected = START + 2 * 60_000 + 2 * 60_000;
+  assertEquals(computeHardDeadlineTS(START, 2), expected);
+});
+
+Deno.test("HardDeadline - T=45 caps grace at 15 minutes (T+15)", () => {
+  // grace = min(15, max(1, 45)) = 15 minutes
+  const expected = START + 45 * 60_000 + 15 * 60_000;
+  assertEquals(computeHardDeadlineTS(START, 45), expected);
+});
+
+Deno.test("HardDeadline - T=120 clamps grace to 15 minutes", () => {
+  // grace = min(15, max(1, 120)) = 15 minutes
+  const expected = START + 120 * 60_000 + 15 * 60_000;
+  assertEquals(computeHardDeadlineTS(START, 120), expected);
+});
+
+Deno.test("HardDeadline - T=1 gives grace of 1 minute", () => {
+  // grace = min(15, max(1, 1)) = 1 minute
+  const expected = START + 1 * 60_000 + 1 * 60_000;
+  assertEquals(computeHardDeadlineTS(START, 1), expected);
+});

--- a/test/NEAT/NeatConstruction.ts
+++ b/test/NEAT/NeatConstruction.ts
@@ -286,6 +286,14 @@ Deno.test("NeatConstruction: timeout is set when timeoutMinutes provided", async
       neat.endTimeTS > Date.now(),
       "endTimeTS should be in the future",
     );
+    // Issue #2895: hardDeadlineTS must be endTimeTS plus the clamped grace.
+    // For timeoutMinutes=5, grace = min(15, max(1, 5)) = 5 minutes. Asserting
+    // the offset from endTimeTS keeps the check independent of the clock.
+    assertEquals(
+      neat.hardDeadlineTS - neat.endTimeTS,
+      5 * 60_000,
+      "hardDeadlineTS should be endTimeTS + 5 minutes of grace",
+    );
   } finally {
     await terminateWorkers(workers);
   }
@@ -306,6 +314,12 @@ Deno.test("NeatConstruction: timeout is zero when not provided", async () => {
       neat.endTimeTS,
       0,
       "endTimeTS should be 0 when no timeout",
+    );
+    // Issue #2895: hardDeadlineTS mirrors endTimeTS — both 0 when no timeout.
+    assertEquals(
+      neat.hardDeadlineTS,
+      0,
+      "hardDeadlineTS should be 0 when no timeout",
     );
   } finally {
     await terminateWorkers(workers);


### PR DESCRIPTION
# Add hard-deadline (T+15) helper and plumb `hardDeadlineTS`

## Summary

Introduces a single source of truth for the evolution hard cap — the absolute
wall-clock timestamp past which `evolveDir` must abandon all in-flight work —
and plumbs it through `Neat` and the three evolve variants so later sub-issues
can enforce it in each phase. Pure plumbing: no behavioural change to existing
runs. Closes #2895. Part of #2892.

- **New module `src/NEAT/HardDeadline.ts`** exporting:
  - `HARD_DEADLINE_GRACE_MINUTES = 15` — the maximum permitted overrun past
    `timeoutMinutes`.
  - `computeHardDeadlineTS(startMS, timeoutMinutes)` — returns
    `startMS + timeoutMinutes * 60_000 + graceMS`, where
    `graceMS = min(15, max(1, timeoutMinutes)) * 60_000`. Returns `undefined`
    when `timeoutMinutes` is 0/unset (no timeout → no cap). The helper is pure
    (absolute timestamps in, absolute timestamps out), so tests need no real
    clock (policy from #2888).
- **`src/NEAT/Neat.ts`** — new `hardDeadlineTS` field set alongside `endTimeTS`
  from the same options via the helper (0 when no timeout). Both now anchor to
  one captured `startTS`.
- **`src/creature/CreatureTraining.ts`** — each of the three evolve variants
  computes `hardDeadlineMS` next to its existing `endTimeMS`. The value is
  computed but not yet consumed (enforcement lands in follow-up sub-issues),
  marked with a documented `deno-lint-ignore no-unused-vars`.

## Data flow

```mermaid
flowchart LR
    O[NeatOptions.timeoutMinutes] --> H[computeHardDeadlineTS]
    S[startMS / startTS] --> H
    H -->|undefined → 0| N[Neat.hardDeadlineTS]
    H -->|undefined → 0| C[CreatureTraining hardDeadlineMS x3]
    N -.future sub-issues.-> E[per-phase enforcement]
    C -.future sub-issues.-> E
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via unit tests and
the full quality gate.

- `./quality.sh` passes cleanly: `ok | 7093 passed (2 steps) | 0 failed`.
- The helper is pure; all assertions are on returned/derived timestamps, never
  on elapsed wall-clock time (policy from #2888).

## Test Plan

- **`test/NEAT/HardDeadline.ts`** (new) — covers:
  - grace constant is 15 minutes;
  - no timeout configured → `undefined` (both 0 and `undefined` inputs);
  - T=2 → grace 2 m; T=45 → grace capped at 15 m (T+15); T=120 → grace clamped
    to 15 m; T=1 → grace 1 m.
- **`test/NEAT/NeatConstruction.ts`** (extended) — asserts
  `hardDeadlineTS - endTimeTS === 5 minutes` for `timeoutMinutes=5`, and
  `hardDeadlineTS === 0` when no timeout is set (consistent with `endTimeTS`).



## Milestone
This PR is part of the **fix-timeout** milestone and targets the `milestone/fix-timeout` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq9l1hln-d62d60`<!-- vibe-worker-issue-2895 -->