### PR TITLE
Clamp scheduled training tasks to the absolute hard deadline (#2899)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-2899.md
+++ b/docs/archive/pr-summaries/pr-summary-2899.md
@@ -1,0 +1,70 @@
+## Summary
+
+Clamp scheduled fine-tuning tasks to the absolute hard deadline so worker-side
+training stops at the run's wall-clock deadline even when the task sat in the
+worker queue after being scheduled with a relative `trainingTimeOutMinutes`
+budget. Closes #2899.
+
+Previously `timeoutTS` was computed from `Date.now()` plus the relative budget
+when the worker dequeued the task. A task that waited in the queue therefore got
+its full relative budget anchored at dequeue time, drifting past the run's
+intended end (`GRQ-19-sloth.log` showed `Fine tuning increased fitness…` lines
+continuing right up to the watchdog kill). This change carries the absolute
+`hardDeadlineTS` (epoch ms) with each scheduled task and clamps the relative
+budget against it.
+
+### Changes
+
+- **`src/config/TrainOptions.ts`** — add optional `hardDeadlineTS?: number`
+  (plain number — survives `Worker.postMessage`).
+- **`src/NEAT/NeatScheduling.ts`** — `scheduleTraining` sets `hardDeadlineTS`
+  from `neat.hardDeadlineTS` (left absent when `0`, so behaviour is unchanged).
+- **`src/architecture/training/TrainingSetup.ts`** — plumb `hardDeadlineTS`
+  through `TrainingSetupState` and `prepareTraining`.
+- **`src/architecture/training/TrainingOutcome.ts`** — extract a pure,
+  `now`-injectable
+  `computeTimeoutTS(now, trainingTimeOutMinutes,
+  hardDeadlineTS)` helper that
+  clamps to `min(now + minutes, hardDeadlineTS)`; `createEpochState` calls it
+  with `Date.now()`.
+
+When `hardDeadlineTS` is absent (direct `creature.train()` callers), the
+computation is identical to before. A hard deadline already in the past is
+returned verbatim, so the existing per-iteration timeout check
+(`TrainingEpoch.ts`) trips on the next check and returns the best-so-far result.
+
+### Flow
+
+```mermaid
+flowchart LR
+    Neat["neat.hardDeadlineTS<br/>(absolute T+15)"] -->|scheduleTraining| TO[TrainOptions.hardDeadlineTS]
+    TO -->|postMessage| W[worker]
+    W -->|prepareTraining| SS[TrainingSetupState.hardDeadlineTS]
+    SS -->|createEpochState| C["computeTimeoutTS()"]
+    Rel["now + trainingTimeOutMinutes"] --> C
+    C -->|"min(relative, hard)"| TS[EpochState.timeoutTS]
+    TS --> Check["per-iteration timeout check"]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via unit tests
+(injected timestamps, no elapsed-time assertions per #2888) and the full
+`./quality.sh` suite (7100 tests pass; a transient unrelated breed flake
+`SyntheticLocationE2E` passed on re-run and is unaffected by these changes).
+
+## Test Plan
+
+- `test/architecture/training/TrainingOutcome.ts` (new) — `computeTimeoutTS`:
+  - clamps to an earlier hard deadline (15 min budget, 5 min deadline →
+    deadline)
+  - absent / `undefined` / `0` hard deadline reproduces the pre-#2899 relative
+    computation exactly
+  - keeps the relative budget when it is the earlier limit
+  - no relative budget falls back to the hard deadline
+  - no budget and no deadline → `0` (no timeout)
+  - hard deadline already in the past is returned verbatim (per-iteration check
+    then exits promptly)
+- `test/architecture/training/TrainingSetup.ts` — added a case asserting
+  `prepareTraining` carries `hardDeadlineTS` through, and that it stays
+  `undefined` when absent.

--- a/src/NEAT/NeatScheduling.ts
+++ b/src/NEAT/NeatScheduling.ts
@@ -310,6 +310,10 @@ export function scheduleTraining(
     trainingSampleRate: neat.config.trainingSampleRate,
     disableRandomSamples: neat.config.disableRandomSamples,
     trainingTimeOutMinutes: trainingTimeOutMinutes,
+    // Issue #2899: carry the absolute hard deadline so worker-side training
+    // stops at T+15 even when the task sat in the worker queue. 0 means no
+    // deadline configured; leave it absent so behaviour is unchanged.
+    hardDeadlineTS: neat.hardDeadlineTS > 0 ? neat.hardDeadlineTS : undefined,
     batchSize: neat.config.trainingBatchSize,
     maximumBiasAdjustmentScale: neat.config.maximumBiasAdjustmentScale,
     maximumWeightAdjustmentScale: neat.config.maximumWeightAdjustmentScale,

--- a/src/architecture/training/TrainingOutcome.ts
+++ b/src/architecture/training/TrainingOutcome.ts
@@ -36,6 +36,39 @@ export interface EpochState {
   timeoutTS: number;
 }
 
+/**
+ * Computes the absolute timeout timestamp (epoch ms) for a training run.
+ *
+ * Issue #2899: the relative budget ({@link trainingTimeOutMinutes}) is
+ * anchored at worker start, which drifts when the task waited in the worker
+ * queue. When an absolute {@link hardDeadlineTS} is supplied it clamps the
+ * relative budget so the run stops at the hard deadline regardless of queue
+ * delay. A `trainingTimeOutMinutes` of `0` means "no relative budget"; an
+ * absent/zero `hardDeadlineTS` leaves the relative computation unchanged.
+ *
+ * Pure and `now`-injectable so it can be unit-tested without elapsed-time
+ * assertions (#2888 policy).
+ *
+ * @param now - current epoch ms (injected for deterministic testing)
+ * @param trainingTimeOutMinutes - relative budget in minutes (0 = none)
+ * @param hardDeadlineTS - absolute hard deadline epoch ms (0/undefined = none)
+ * @returns the timeout timestamp in epoch ms, or 0 for no timeout
+ */
+export function computeTimeoutTS(
+  now: number,
+  trainingTimeOutMinutes: number,
+  hardDeadlineTS?: number,
+): number {
+  const relativeTS = trainingTimeOutMinutes > 0
+    ? now + trainingTimeOutMinutes * 60 * 1000
+    : 0;
+  const hardTS = hardDeadlineTS ?? 0;
+  if (hardTS > 0) {
+    return relativeTS > 0 ? Math.min(relativeTS, hardTS) : hardTS;
+  }
+  return relativeTS;
+}
+
 /** Construct the initial epoch state from setup output. */
 export function createEpochState(setup: TrainingSetupState): EpochState {
   return {
@@ -49,9 +82,11 @@ export function createEpochState(setup: TrainingSetupState): EpochState {
     scratch: { buffer: null },
     indxMap: new Map(),
     timedOut: false,
-    timeoutTS: setup.trainingTimeOutMinutes > 0
-      ? Date.now() + setup.trainingTimeOutMinutes * 60 * 1000
-      : 0,
+    timeoutTS: computeTimeoutTS(
+      Date.now(),
+      setup.trainingTimeOutMinutes,
+      setup.hardDeadlineTS,
+    ),
   };
 }
 

--- a/src/architecture/training/TrainingSetup.ts
+++ b/src/architecture/training/TrainingSetup.ts
@@ -125,6 +125,11 @@ export interface TrainingSetupState {
   iterations: number;
   trainingSampleRate: number;
   trainingTimeOutMinutes: number;
+  /**
+   * Absolute hard deadline (epoch ms) to clamp the relative timeout against.
+   * Issue #2899: undefined/0 leaves the relative budget unchanged.
+   */
+  hardDeadlineTS: number | undefined;
   ID: string;
   BYTES_PER_RECORD: number;
   recordBuffer: Uint8Array;
@@ -159,6 +164,8 @@ export function prepareTraining(
   const iterations = resolveIterations(options);
   const trainingSampleRate = resolveTrainingSampleRate(options);
   const trainingTimeOutMinutes = options.trainingTimeOutMinutes ?? 0;
+  // Issue #2899: carry the absolute hard deadline through to epoch state.
+  const hardDeadlineTS = options.hardDeadlineTS;
 
   const valuesCount = creature.input + creature.output;
   const BYTES_PER_RECORD = valuesCount * 4; // Each float is 4 bytes
@@ -222,6 +229,7 @@ export function prepareTraining(
     iterations,
     trainingSampleRate,
     trainingTimeOutMinutes,
+    hardDeadlineTS,
     ID: shortId,
     BYTES_PER_RECORD,
     recordBuffer,

--- a/src/config/TrainOptions.ts
+++ b/src/config/TrainOptions.ts
@@ -29,6 +29,22 @@ export interface TrainArguments extends BackPropagationArguments {
   trainingTimeOutMinutes: number;
 
   /**
+   * Absolute hard deadline (epoch milliseconds) at which training must stop.
+   *
+   * Issue #2899: A scheduled fine-tuning task may sit in the worker queue
+   * after being scheduled with a relative {@link trainingTimeOutMinutes}
+   * budget. The relative budget is otherwise anchored when the worker
+   * dequeues the task, so a queued task can run past the run's wall-clock
+   * deadline. Carrying the absolute deadline lets the worker clamp the
+   * relative budget to `min(now + trainingTimeOutMinutes, hardDeadlineTS)`.
+   *
+   * A plain number so it survives `Worker.postMessage`. When absent,
+   * behaviour is unchanged (direct `creature.train()` callers are
+   * unaffected).
+   */
+  hardDeadlineTS?: number;
+
+  /**
    * Enable feedback loop where the previous result feeds back into the next interaction.
    * Useful for time-series forecasting and recurrent neural networks.
    * More information: https://www.mathworks.com/help/deeplearning/ug/design-time-series-narx-feedback-neural-networks.html

--- a/test/architecture/training/TrainingOutcome.ts
+++ b/test/architecture/training/TrainingOutcome.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for training-outcome timeout computation (Issue #2899).
+ *
+ * `computeTimeoutTS` is pure and `now`-injectable, so these tests assert on
+ * computed timestamps with injected clock values — no elapsed-time
+ * measurement (#2888 policy).
+ */
+
+import { assertEquals } from "@std/assert";
+import { computeTimeoutTS } from "@architecture/training/TrainingOutcome.ts";
+
+// A fixed, injected "now" — never Date.now().
+const NOW = 1_000_000_000_000;
+const MINUTE_MS = 60 * 1000;
+
+Deno.test("computeTimeoutTS - clamps to an earlier hard deadline", () => {
+  // Relative budget would expire at NOW + 15 min, but the hard deadline is
+  // only 5 minutes away → the hard deadline wins.
+  const hardDeadlineTS = NOW + 5 * MINUTE_MS;
+  const timeoutTS = computeTimeoutTS(NOW, 15, hardDeadlineTS);
+  assertEquals(timeoutTS, hardDeadlineTS);
+});
+
+Deno.test("computeTimeoutTS - absent hard deadline reproduces relative budget", () => {
+  // Exactly the pre-#2899 computation: now + minutes * 60 * 1000.
+  assertEquals(computeTimeoutTS(NOW, 15), NOW + 15 * MINUTE_MS);
+  assertEquals(computeTimeoutTS(NOW, 15, undefined), NOW + 15 * MINUTE_MS);
+  // A zero hard deadline is treated as "no deadline".
+  assertEquals(computeTimeoutTS(NOW, 15, 0), NOW + 15 * MINUTE_MS);
+});
+
+Deno.test("computeTimeoutTS - keeps relative budget when it is the earlier limit", () => {
+  // Hard deadline is far in the future → the relative budget still governs.
+  const hardDeadlineTS = NOW + 60 * MINUTE_MS;
+  assertEquals(computeTimeoutTS(NOW, 10, hardDeadlineTS), NOW + 10 * MINUTE_MS);
+});
+
+Deno.test("computeTimeoutTS - no relative budget falls back to the hard deadline", () => {
+  // trainingTimeOutMinutes === 0 (no relative budget) but a hard deadline is
+  // present → the hard deadline caps the run.
+  const hardDeadlineTS = NOW + 5 * MINUTE_MS;
+  assertEquals(computeTimeoutTS(NOW, 0, hardDeadlineTS), hardDeadlineTS);
+});
+
+Deno.test("computeTimeoutTS - no budget and no deadline means no timeout", () => {
+  assertEquals(computeTimeoutTS(NOW, 0), 0);
+  assertEquals(computeTimeoutTS(NOW, 0, 0), 0);
+});
+
+Deno.test("computeTimeoutTS - hard deadline already in the past returns that past instant", () => {
+  // A deadline earlier than `now` is returned verbatim; the per-iteration
+  // timeout check then trips immediately and the best-so-far result returns.
+  const pastDeadline = NOW - 5 * MINUTE_MS;
+  assertEquals(computeTimeoutTS(NOW, 15, pastDeadline), pastDeadline);
+});

--- a/test/architecture/training/TrainingSetup.ts
+++ b/test/architecture/training/TrainingSetup.ts
@@ -108,4 +108,23 @@ Deno.test("TrainingSetup - prepareTraining allocates buffers and applies options
   // bestCreatureJSON should match creature I/O counts.
   assertEquals(setup.bestCreatureJSON.input, 3);
   assertEquals(setup.bestCreatureJSON.output, 2);
+  // Issue #2899: absent hardDeadlineTS leaves the field undefined.
+  assertEquals(setup.hardDeadlineTS, undefined);
+});
+
+Deno.test("TrainingSetup - prepareTraining carries hardDeadlineTS through (Issue #2899)", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const hardDeadlineTS = 1_000_000_000_000;
+  const setup = prepareTraining(
+    creature,
+    {
+      iterations: 1,
+      trainingTimeOutMinutes: 15,
+      hardDeadlineTS,
+    },
+    "deadln01",
+  );
+
+  assertEquals(setup.trainingTimeOutMinutes, 15);
+  assertEquals(setup.hardDeadlineTS, hardDeadlineTS);
 });


### PR DESCRIPTION
## Summary

Clamp scheduled fine-tuning tasks to the absolute hard deadline so worker-side
training stops at the run's wall-clock deadline even when the task sat in the
worker queue after being scheduled with a relative `trainingTimeOutMinutes`
budget. Closes #2899.

Previously `timeoutTS` was computed from `Date.now()` plus the relative budget
when the worker dequeued the task. A task that waited in the queue therefore got
its full relative budget anchored at dequeue time, drifting past the run's
intended end (`GRQ-19-sloth.log` showed `Fine tuning increased fitness…` lines
continuing right up to the watchdog kill). This change carries the absolute
`hardDeadlineTS` (epoch ms) with each scheduled task and clamps the relative
budget against it.

### Changes

- **`src/config/TrainOptions.ts`** — add optional `hardDeadlineTS?: number`
  (plain number — survives `Worker.postMessage`).
- **`src/NEAT/NeatScheduling.ts`** — `scheduleTraining` sets `hardDeadlineTS`
  from `neat.hardDeadlineTS` (left absent when `0`, so behaviour is unchanged).
- **`src/architecture/training/TrainingSetup.ts`** — plumb `hardDeadlineTS`
  through `TrainingSetupState` and `prepareTraining`.
- **`src/architecture/training/TrainingOutcome.ts`** — extract a pure,
  `now`-injectable
  `computeTimeoutTS(now, trainingTimeOutMinutes,
  hardDeadlineTS)` helper that
  clamps to `min(now + minutes, hardDeadlineTS)`; `createEpochState` calls it
  with `Date.now()`.

When `hardDeadlineTS` is absent (direct `creature.train()` callers), the
computation is identical to before. A hard deadline already in the past is
returned verbatim, so the existing per-iteration timeout check
(`TrainingEpoch.ts`) trips on the next check and returns the best-so-far result.

### Flow

```mermaid
flowchart LR
    Neat["neat.hardDeadlineTS<br/>(absolute T+15)"] -->|scheduleTraining| TO[TrainOptions.hardDeadlineTS]
    TO -->|postMessage| W[worker]
    W -->|prepareTraining| SS[TrainingSetupState.hardDeadlineTS]
    SS -->|createEpochState| C["computeTimeoutTS()"]
    Rel["now + trainingTimeOutMinutes"] --> C
    C -->|"min(relative, hard)"| TS[EpochState.timeoutTS]
    TS --> Check["per-iteration timeout check"]
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via unit tests
(injected timestamps, no elapsed-time assertions per #2888) and the full
`./quality.sh` suite (7100 tests pass; a transient unrelated breed flake
`SyntheticLocationE2E` passed on re-run and is unaffected by these changes).

## Test Plan

- `test/architecture/training/TrainingOutcome.ts` (new) — `computeTimeoutTS`:
  - clamps to an earlier hard deadline (15 min budget, 5 min deadline →
    deadline)
  - absent / `undefined` / `0` hard deadline reproduces the pre-#2899 relative
    computation exactly
  - keeps the relative budget when it is the earlier limit
  - no relative budget falls back to the hard deadline
  - no budget and no deadline → `0` (no timeout)
  - hard deadline already in the past is returned verbatim (per-iteration check
    then exits promptly)
- `test/architecture/training/TrainingSetup.ts` — added a case asserting
  `prepareTraining` carries `hardDeadlineTS` through, and that it stays
  `undefined` when absent.



## Milestone
This PR is part of the **fix-timeout** milestone and targets the `milestone/fix-timeout` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq9l1hln-d62d60`<!-- vibe-worker-issue-2899 -->