### PR TITLE
Discovery: Clamp recording and analysis-timeout extensions to the T+15 hard deadline (#2898)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-2898.md
+++ b/docs/archive/pr-summaries/pr-summary-2898.md
@@ -1,0 +1,75 @@
+## Summary
+
+Clamp every per-discovery deadline to the caller's absolute hard deadline
+(T+15) so no discovery phase can run past it regardless of worker-queue delay.
+Closes #2898.
+
+The #2432 allocation clamps the *relative* record+analysis budget at schedule
+time, but the worker re-anchors those budgets at `Date.now()` when it starts
+processing a request. Queue delays therefore silently shift the absolute
+completion time past the caller's deadline, and analysis-timeout extensions
+compound the drift (GRQ-18-sloth.log showed repeated extension cycles).
+
+This change passes the absolute deadline across the worker boundary and clamps
+every per-discovery deadline against it:
+
+- **`src/config/NeatArguments.ts`** — new optional internal field
+  `discoveryHardDeadlineTS?: number` (epoch ms). A plain number, so it crosses
+  `Worker.postMessage` in the per-call frozen config. Absent when no
+  `timeoutMinutes` is configured → behaviour unchanged.
+- **`src/NEAT/NeatScheduling.ts`** (`scheduleDiscovery`) — sets
+  `discoveryHardDeadlineTS` from `neat.hardDeadlineTS` in the per-call config
+  override (only when a hard deadline is configured). The #2432 relative
+  allocation stays as the phase-split mechanism.
+- **`src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts`**
+  - Constructor: `timeoutTS = min(now + recordBudget, discoveryHardDeadlineTS)`
+    — fixes the drift where a queued request anchors its relative budget at
+    start time, not schedule time.
+  - Record→analysis boundary (`extendTimeoutForAnalysisPhase`):
+    `analysisDeadlineAt = min(now + analysisBudget, discoveryHardDeadlineTS)`.
+  - `refreshAnalysisTimeout`: re-supplies the cap so top-ups never overshoot it.
+- **`src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts`**
+  (`extendTimeoutForAnalysis`) — accepts and remembers the hard cap and never
+  sets `timeoutTS` past it. Once past the cap the computed remaining budget is
+  ≤ 0, so the analysis loop's existing per-chunk checks exit — delivering
+  "extensions clamped to the T+15 cap, at most one further extension once past
+  T". Added a public `getTimeoutTS()` accessor.
+
+The recording-loop checks (`DataRecorderRecording.ts` via `ctx.timeoutTS`) and
+analysis per-chunk checks (`DataRecorderAnalysis.ts` via `getTimeoutTS()`)
+inherit the clamp once the sources are clamped — no change needed there, proven
+by regression tests.
+
+## Evidence
+
+Backend/worker change — no UI to screenshot. Verified by unit tests and the
+full quality gate (`./quality.sh`): **7101 passed, 0 failed, 4 ignored**.
+
+```mermaid
+flowchart LR
+    A[scheduleDiscovery<br/>absolute discoveryHardDeadlineTS] --> B[Worker queue<br/>delay no longer shifts cap]
+    B --> C[DataRecorder recording<br/>timeoutTS clamped]
+    C --> D[Analysis extension<br/>analysisDeadlineAt clamped]
+    D --> E[refreshAnalysisTimeout<br/>never past cap]
+```
+
+## Test Plan
+
+New regression suite
+`test/ErrorGuidedStructuralEvolution/DiscoveryHardDeadlineClamp.ts` (injected
+timestamps, no real waiting — #2888 policy):
+
+- DataRecorder constructor clamps recording `timeoutTS` to a near-future cap.
+- DataRecorder constructor clamps `timeoutTS` to an already-past cap (request
+  whose hard deadline elapsed in the queue).
+- DataRecorder leaves `timeoutTS` unclamped when no hard deadline is configured.
+- `extendTimeoutForAnalysisPhase` clamps `analysisDeadlineAt`, `timeoutTS`, and
+  the DiscoverStructure deadline to the cap.
+- `refreshAnalysisTimeout` never moves the deadline past the cap.
+- `DiscoverStructure.extendTimeoutForAnalysis` clamps to a supplied cap.
+- `extendTimeoutForAnalysis` remembers the cap for later top-ups.
+- `extendTimeoutForAnalysis` is unchanged when no cap is supplied.
+
+Existing discovery/analysis suites
+(`DiscoverAnalysisPerChunkTimeout`, `NeuronDiscoveryIntegration`, `HardDeadline`,
+`NeatConstruction`) continue to pass, confirming no behaviour change.

--- a/src/NEAT/NeatScheduling.ts
+++ b/src/NEAT/NeatScheduling.ts
@@ -152,6 +152,14 @@ export function scheduleDiscovery(
     // Issue #2432: clamp the analysis ceiling to the slack remaining after
     // recording so record + analysis ≤ caller's wall-clock budget.
     discoveryAnalysisTimeoutMinutes: allocation.analysisMinutes,
+    // Issue #2898: pass the absolute hard deadline across the worker boundary so
+    // the worker clamps every per-discovery deadline to T+15 regardless of how
+    // long the request waited in the queue. The #2432 relative allocation above
+    // stays as the phase-split mechanism. Only set when a hard deadline is
+    // configured (0 means no `timeoutMinutes`), leaving behaviour unchanged.
+    ...(neat.hardDeadlineTS > 0
+      ? { discoveryHardDeadlineTS: neat.hardDeadlineTS }
+      : {}),
   });
 
   const taskStartTime = Date.now();

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
@@ -95,7 +95,7 @@ export async function recordDirectory(
   return await recorder.recordDirectory(dataDir);
 }
 
-class DataRecorder {
+export class DataRecorder {
   private readonly BYTES_PER_RECORD: number;
   private readonly BATCH_SIZE: number;
   private readonly sampleRate: number;
@@ -105,6 +105,13 @@ class DataRecorder {
   private readonly timeoutSeconds: number;
   private readonly analysisTimeoutSeconds: number;
   private analysisDeadlineAt?: number;
+  /**
+   * Issue #2898: absolute hard-deadline timestamp (epoch ms) carried across the
+   * worker boundary in the per-call config. Clamps every per-discovery deadline
+   * to the caller's T+15 cap. `undefined` when no `timeoutMinutes` is
+   * configured, in which case clamping is a no-op (behaviour unchanged).
+   */
+  private readonly discoveryHardDeadlineTS?: number;
   private readonly discoveryMaxNeurons: number;
   private readonly drainEveryNBatches: number;
   private readonly rustFlushRecords: number;
@@ -136,7 +143,15 @@ class DataRecorder {
       config.discoveryRecordTimeOutMinutes,
     );
     this.timeoutSeconds = discoveryRecordTimeOutMinutes * 60;
+    // Issue #2898: clamp the recording deadline to the absolute hard cap. A
+    // request queued behind a busy worker would otherwise anchor its relative
+    // budget at start time, not schedule time, drifting the completion past
+    // T+15. `min(now + recordBudget, hardDeadline)` ties it back to the cap.
+    this.discoveryHardDeadlineTS = config.discoveryHardDeadlineTS;
     this.timeoutTS = Date.now() + this.timeoutSeconds * 1000;
+    if (this.discoveryHardDeadlineTS !== undefined) {
+      this.timeoutTS = Math.min(this.timeoutTS, this.discoveryHardDeadlineTS);
+    }
 
     const analysisTimeoutMinutes = Math.min(
       60,
@@ -366,13 +381,10 @@ class DataRecorder {
         };
       }
 
-      // Extend timeout for analysis phase
-      const analysisTimeoutSeconds = this.analysisTimeoutSeconds;
-      const analysisTimeoutMinutes = analysisTimeoutSeconds / 60;
-      const analysisDeadlineAt = Date.now() + analysisTimeoutSeconds * 1000;
-      this.analysisDeadlineAt = analysisDeadlineAt;
-      discoverStructure.extendTimeoutForAnalysis(analysisTimeoutSeconds);
-      this.timeoutTS = analysisDeadlineAt;
+      // Extend timeout for analysis phase (clamped to the hard deadline)
+      const analysisTimeoutMinutes = this.extendTimeoutForAnalysisPhase(
+        discoverStructure,
+      );
 
       if (shouldLogDiscovery(config)) {
         getLogger().info(
@@ -532,7 +544,36 @@ class DataRecorder {
     perfStats.totalTime = Date.now() - startTime;
   }
 
-  private refreshAnalysisTimeout(
+  /**
+   * Move from recording into analysis, extending the deadline by the configured
+   * analysis budget but never past the absolute hard deadline (Issue #2898).
+   *
+   * `analysisDeadlineAt = min(now + analysisBudget, discoveryHardDeadlineTS)`.
+   * The same clamped value is pushed into the DiscoverStructure (which also
+   * remembers the cap for later `refreshAnalysisTimeout` top-ups) and mirrored
+   * onto `this.timeoutTS`, which the analysis loop reads via `getTimeoutTS()`.
+   *
+   * @returns the analysis budget in minutes, for logging.
+   */
+  extendTimeoutForAnalysisPhase(discoverStructure: DiscoverStructure): number {
+    const analysisTimeoutSeconds = this.analysisTimeoutSeconds;
+    let analysisDeadlineAt = Date.now() + analysisTimeoutSeconds * 1000;
+    if (this.discoveryHardDeadlineTS !== undefined) {
+      analysisDeadlineAt = Math.min(
+        analysisDeadlineAt,
+        this.discoveryHardDeadlineTS,
+      );
+    }
+    this.analysisDeadlineAt = analysisDeadlineAt;
+    discoverStructure.extendTimeoutForAnalysis(
+      analysisTimeoutSeconds,
+      this.discoveryHardDeadlineTS,
+    );
+    this.timeoutTS = analysisDeadlineAt;
+    return analysisTimeoutSeconds / 60;
+  }
+
+  refreshAnalysisTimeout(
     discoverStructure: DiscoverStructure,
   ): void {
     if (this.analysisDeadlineAt === undefined) {
@@ -543,7 +584,22 @@ class DataRecorder {
       return;
     }
     const remainingSeconds = Math.max(1, Math.floor(remainingMs / 1000));
-    discoverStructure.extendTimeoutForAnalysis(remainingSeconds);
+    // Issue #2898: re-supply the hard cap so the top-up can never overshoot it,
+    // even though `analysisDeadlineAt` is already clamped.
+    discoverStructure.extendTimeoutForAnalysis(
+      remainingSeconds,
+      this.discoveryHardDeadlineTS,
+    );
     this.timeoutTS = this.analysisDeadlineAt;
+  }
+
+  /** Current recording/analysis deadline (epoch ms). Issue #2898 — test seam. */
+  get currentTimeoutTS(): number {
+    return this.timeoutTS;
+  }
+
+  /** Clamped analysis deadline (epoch ms), once analysis has begun. Issue #2898. */
+  get currentAnalysisDeadlineAt(): number | undefined {
+    return this.analysisDeadlineAt;
   }
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
@@ -128,6 +128,12 @@ export class DiscoverStructureBase {
     undefined;
   protected lastNeuronScanStats?: NeuronScanStats;
   protected analysisDeadlineMs?: number;
+  /**
+   * Issue #2898: absolute hard-deadline timestamp (epoch ms). Once supplied,
+   * `extendTimeoutForAnalysis` will never move `timeoutTS` past this cap, so
+   * analysis-timeout extensions can never run past the caller's T+15 deadline.
+   */
+  protected analysisHardDeadlineTS?: number;
   protected cachedRemovalCandidates?:
     import("./DiscoverResult.ts").RemovalCandidate[];
   protected combinedRustAnalysis?: CombinedAnalysisCache;
@@ -292,13 +298,42 @@ export class DiscoverStructureBase {
     return false;
   }
 
-  public extendTimeoutForAnalysis(analysisTimeSeconds: number): void {
+  /**
+   * Expose the current absolute timeout timestamp (epoch ms) so callers and
+   * tests can assert the active deadline. Issue #2898.
+   */
+  public getTimeoutTS(): number {
+    return this.timeoutTS;
+  }
+
+  /**
+   * Extend the deadline to give the analysis phase room to run.
+   *
+   * Issue #2898: an optional absolute hard-deadline cap (epoch ms) clamps the
+   * extended deadline so it can never move past the caller's T+15 wall-clock
+   * cap, no matter how long the discovery request waited in the worker queue.
+   * The cap is remembered, so later `refreshAnalysisTimeout` top-ups stay
+   * clamped even if a cap is not re-supplied. Once the cap is reached the
+   * remaining budget the analysis loop computes is ≤ 0, so its per-chunk checks
+   * exit promptly. When no cap is supplied behaviour is unchanged.
+   */
+  public extendTimeoutForAnalysis(
+    analysisTimeSeconds: number,
+    hardDeadlineTS?: number,
+  ): void {
     assert(
       analysisTimeSeconds > 0,
       `Analysis time must be greater than 0, was: ${analysisTimeSeconds}`,
     );
-    this.timeoutTS = Date.now() + analysisTimeSeconds * 1000;
-    this.analysisDeadlineMs = this.timeoutTS;
+    if (hardDeadlineTS !== undefined) {
+      this.analysisHardDeadlineTS = hardDeadlineTS;
+    }
+    let target = Date.now() + analysisTimeSeconds * 1000;
+    if (this.analysisHardDeadlineTS !== undefined) {
+      target = Math.min(target, this.analysisHardDeadlineTS);
+    }
+    this.timeoutTS = target;
+    this.analysisDeadlineMs = target;
     this.analysisTimeoutGuardEnabled = false;
   }
 

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -313,6 +313,17 @@ export interface NeatArguments {
    */
   discoveryAnalysisTimeoutMinutes: number;
 
+  /**
+   * Absolute hard-deadline timestamp (epoch ms) for a single discovery
+   * request (Issue #2898). Plumbed across the worker boundary in the per-call
+   * frozen config built by `scheduleDiscovery` so every per-discovery deadline
+   * — recording `timeoutTS`, the analysis extension, and `refreshAnalysisTimeout`
+   * top-ups — can be clamped to the caller's absolute T+15 cap regardless of
+   * worker-queue delay. Absent (undefined) when no `timeoutMinutes` is
+   * configured, in which case clamping is a no-op and behaviour is unchanged.
+   */
+  discoveryHardDeadlineTS?: number;
+
   /** The number of observations per promise */
   discoveryBatchSize: number;
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryHardDeadlineClamp.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryHardDeadlineClamp.ts
@@ -1,0 +1,185 @@
+/**
+ * Issue #2898: clamp discovery recording and analysis-timeout extensions to the
+ * absolute hard deadline (T+15).
+ *
+ * The worker re-anchors its relative record/analysis budgets at `Date.now()`
+ * when it dequeues a request, so a queue delay silently shifts the absolute
+ * completion time past the caller's deadline. These tests prove every
+ * per-discovery deadline — the recording `timeoutTS`, the analysis extension,
+ * and `refreshAnalysisTimeout` top-ups — is clamped to the absolute
+ * `discoveryHardDeadlineTS` cap. Timestamps are injected (a near-future or
+ * already-past cap); the assertions compare against the cap, so no real waiting
+ * is required (#2888 policy).
+ */
+import { assert } from "@std/assert";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { DataRecorder } from "@architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import type { NeatConfig } from "@config/NeatConfig.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+function makeTestCreature(): Creature {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { uuid: "hidden-a", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-a", weight: -0.5 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+/** Build a config with an injected absolute hard deadline (epoch ms). */
+function configWithHardDeadline(
+  hardDeadlineTS: number | undefined,
+  overrides: Record<string, unknown> = {},
+): NeatConfig {
+  const base = createNeatConfig({
+    discoveryRecordTimeOutMinutes: 5,
+    discoveryAnalysisTimeoutMinutes: 10,
+    ...overrides,
+  });
+  return { ...base, discoveryHardDeadlineTS: hardDeadlineTS } as NeatConfig;
+}
+
+Deno.test("DataRecorder constructor clamps recording timeoutTS to a near-future hard deadline", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  // Cap 5 seconds out — far inside the 5-minute record budget.
+  const cap = Date.now() + 5_000;
+  const recorder = new DataRecorder(creature, configWithHardDeadline(cap), {});
+  assert(
+    recorder.currentTimeoutTS <= cap,
+    `timeoutTS ${recorder.currentTimeoutTS} must not exceed cap ${cap}`,
+  );
+});
+
+Deno.test("DataRecorder constructor clamps recording timeoutTS to an already-past hard deadline", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  const cap = Date.now() - 1_000; // hard deadline already elapsed in the queue
+  const recorder = new DataRecorder(creature, configWithHardDeadline(cap), {});
+  assert(
+    recorder.currentTimeoutTS <= cap,
+    `timeoutTS ${recorder.currentTimeoutTS} must not exceed past cap ${cap}`,
+  );
+});
+
+Deno.test("DataRecorder leaves timeoutTS unclamped when no hard deadline is configured", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  const before = Date.now();
+  const recorder = new DataRecorder(
+    creature,
+    configWithHardDeadline(undefined),
+    {},
+  );
+  // Record budget is 5 minutes; without a cap the deadline sits ~5 min out.
+  const budgetMs = 5 * 60 * 1000;
+  assert(
+    recorder.currentTimeoutTS >= before + budgetMs - 2_000,
+    `Expected unclamped timeoutTS ~${
+      before + budgetMs
+    }, got ${recorder.currentTimeoutTS}`,
+  );
+});
+
+Deno.test("DataRecorder.extendTimeoutForAnalysisPhase clamps analysis deadline to the hard cap", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  const cap = Date.now() + 3_000; // cap well inside the 10-minute analysis budget
+  const config = configWithHardDeadline(cap);
+  const recorder = new DataRecorder(creature, config, {});
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+
+  recorder.extendTimeoutForAnalysisPhase(ds);
+
+  assert(
+    recorder.currentAnalysisDeadlineAt !== undefined &&
+      recorder.currentAnalysisDeadlineAt <= cap,
+    `analysisDeadlineAt ${recorder.currentAnalysisDeadlineAt} must not exceed cap ${cap}`,
+  );
+  assert(
+    recorder.currentTimeoutTS <= cap,
+    `timeoutTS ${recorder.currentTimeoutTS} must not exceed cap ${cap}`,
+  );
+  assert(
+    ds.getTimeoutTS() <= cap,
+    `DiscoverStructure timeoutTS ${ds.getTimeoutTS()} must not exceed cap ${cap}`,
+  );
+});
+
+Deno.test("DataRecorder.refreshAnalysisTimeout never moves the deadline past the hard cap", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  const cap = Date.now() + 4_000;
+  const config = configWithHardDeadline(cap);
+  const recorder = new DataRecorder(creature, config, {});
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+
+  recorder.extendTimeoutForAnalysisPhase(ds);
+  // A top-up must stay clamped — the refreshed deadline can only shrink toward
+  // or hold at the cap, never overshoot it.
+  recorder.refreshAnalysisTimeout(ds);
+
+  assert(
+    recorder.currentTimeoutTS <= cap,
+    `post-refresh timeoutTS ${recorder.currentTimeoutTS} must not exceed cap ${cap}`,
+  );
+  assert(
+    ds.getTimeoutTS() <= cap,
+    `post-refresh DiscoverStructure timeoutTS ${ds.getTimeoutTS()} must not exceed cap ${cap}`,
+  );
+});
+
+Deno.test("DiscoverStructure.extendTimeoutForAnalysis clamps to the supplied hard cap", () => {
+  const creature = makeTestCreature();
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+  const cap = Date.now() + 2_000;
+  // Ask for a 10-minute extension but cap 2s out — must land on the cap.
+  ds.extendTimeoutForAnalysis(600, cap);
+  assert(
+    ds.getTimeoutTS() <= cap,
+    `timeoutTS ${ds.getTimeoutTS()} must not exceed cap ${cap}`,
+  );
+});
+
+Deno.test("DiscoverStructure.extendTimeoutForAnalysis remembers the cap for later top-ups", () => {
+  const creature = makeTestCreature();
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+  const cap = Date.now() + 2_000;
+  ds.extendTimeoutForAnalysis(600, cap);
+  // A later top-up with no cap supplied must still honour the remembered cap.
+  ds.extendTimeoutForAnalysis(600);
+  assert(
+    ds.getTimeoutTS() <= cap,
+    `timeoutTS ${ds.getTimeoutTS()} must not exceed remembered cap ${cap}`,
+  );
+});
+
+Deno.test("DiscoverStructure.extendTimeoutForAnalysis is unchanged when no cap is supplied", () => {
+  const creature = makeTestCreature();
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+  const before = Date.now();
+  ds.extendTimeoutForAnalysis(600); // 10 minutes, no cap
+  const tenMinutes = 600 * 1000;
+  assert(
+    ds.getTimeoutTS() >= before + tenMinutes - 2_000,
+    `Expected unclamped timeoutTS ~${
+      before + tenMinutes
+    }, got ${ds.getTimeoutTS()}`,
+  );
+});


### PR DESCRIPTION
## Summary

Clamp every per-discovery deadline to the caller's absolute hard deadline
(T+15) so no discovery phase can run past it regardless of worker-queue delay.
Closes #2898.

The #2432 allocation clamps the *relative* record+analysis budget at schedule
time, but the worker re-anchors those budgets at `Date.now()` when it starts
processing a request. Queue delays therefore silently shift the absolute
completion time past the caller's deadline, and analysis-timeout extensions
compound the drift (GRQ-18-sloth.log showed repeated extension cycles).

This change passes the absolute deadline across the worker boundary and clamps
every per-discovery deadline against it:

- **`src/config/NeatArguments.ts`** — new optional internal field
  `discoveryHardDeadlineTS?: number` (epoch ms). A plain number, so it crosses
  `Worker.postMessage` in the per-call frozen config. Absent when no
  `timeoutMinutes` is configured → behaviour unchanged.
- **`src/NEAT/NeatScheduling.ts`** (`scheduleDiscovery`) — sets
  `discoveryHardDeadlineTS` from `neat.hardDeadlineTS` in the per-call config
  override (only when a hard deadline is configured). The #2432 relative
  allocation stays as the phase-split mechanism.
- **`src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts`**
  - Constructor: `timeoutTS = min(now + recordBudget, discoveryHardDeadlineTS)`
    — fixes the drift where a queued request anchors its relative budget at
    start time, not schedule time.
  - Record→analysis boundary (`extendTimeoutForAnalysisPhase`):
    `analysisDeadlineAt = min(now + analysisBudget, discoveryHardDeadlineTS)`.
  - `refreshAnalysisTimeout`: re-supplies the cap so top-ups never overshoot it.
- **`src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts`**
  (`extendTimeoutForAnalysis`) — accepts and remembers the hard cap and never
  sets `timeoutTS` past it. Once past the cap the computed remaining budget is
  ≤ 0, so the analysis loop's existing per-chunk checks exit — delivering
  "extensions clamped to the T+15 cap, at most one further extension once past
  T". Added a public `getTimeoutTS()` accessor.

The recording-loop checks (`DataRecorderRecording.ts` via `ctx.timeoutTS`) and
analysis per-chunk checks (`DataRecorderAnalysis.ts` via `getTimeoutTS()`)
inherit the clamp once the sources are clamped — no change needed there, proven
by regression tests.

## Evidence

Backend/worker change — no UI to screenshot. Verified by unit tests and the
full quality gate (`./quality.sh`): **7101 passed, 0 failed, 4 ignored**.

```mermaid
flowchart LR
    A[scheduleDiscovery<br/>absolute discoveryHardDeadlineTS] --> B[Worker queue<br/>delay no longer shifts cap]
    B --> C[DataRecorder recording<br/>timeoutTS clamped]
    C --> D[Analysis extension<br/>analysisDeadlineAt clamped]
    D --> E[refreshAnalysisTimeout<br/>never past cap]
```

## Test Plan

New regression suite
`test/ErrorGuidedStructuralEvolution/DiscoveryHardDeadlineClamp.ts` (injected
timestamps, no real waiting — #2888 policy):

- DataRecorder constructor clamps recording `timeoutTS` to a near-future cap.
- DataRecorder constructor clamps `timeoutTS` to an already-past cap (request
  whose hard deadline elapsed in the queue).
- DataRecorder leaves `timeoutTS` unclamped when no hard deadline is configured.
- `extendTimeoutForAnalysisPhase` clamps `analysisDeadlineAt`, `timeoutTS`, and
  the DiscoverStructure deadline to the cap.
- `refreshAnalysisTimeout` never moves the deadline past the cap.
- `DiscoverStructure.extendTimeoutForAnalysis` clamps to a supplied cap.
- `extendTimeoutForAnalysis` remembers the cap for later top-ups.
- `extendTimeoutForAnalysis` is unchanged when no cap is supplied.

Existing discovery/analysis suites
(`DiscoverAnalysisPerChunkTimeout`, `NeuronDiscoveryIntegration`, `HardDeadline`,
`NeatConstruction`) continue to pass, confirming no behaviour change.
