### PR TITLE
Enforce the T+15 hard cap in the evolve loops and bound awaitInFlightTasks (#2896)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-2896.md
+++ b/docs/archive/pr-summaries/pr-summary-2896.md
@@ -1,0 +1,75 @@
+# Enforce the T+15 hard cap in the evolve loops and bound `awaitInFlightTasks`
+
+## Summary
+
+The three evolve variants in `src/creature/CreatureTraining.ts` (`evolveDir`,
+`evolveEnv`, `evolveRL`) now break out of the finish-up cycle **unconditionally**
+once the absolute T+15 hard deadline (Issue #2895) passes — abandoning any
+in-flight discovery/training bookkeeping while still restoring the best creature
+and writing the creature store. `Neat.awaitInFlightTasks` is also bounded so its
+30 s default wait can never push past the cap.
+
+Previously (see `GRQ-19-sloth.log`) the finish-up cycle could clear stuck
+discoveries, then keep running full generations, fine-tuning and waits until the
+external 3-hour watchdog killed the process — losing all work. The per-phase
+wall-clock guards added in #2432/#2871 only fire *between* finish-up checks; this
+issue adds the outer guarantee they cannot provide on their own. The hard cap
+turns a watchdog-kill into a clean return of the best creature found so far.
+
+Closes #2896.
+
+## What changed
+
+- **`src/NEAT/Neat.ts`**
+  - New `abandonInFlightPastHardDeadline(hardDeadlineMS)` method: when the cap is
+    set and already in the past, it logs
+    `[Neat] Hard deadline (timeoutMinutes + grace) exceeded — abandoning N in-flight task(s)`,
+    clears `discoveryInProgress`/`trainingInProgress`, and returns `true` to
+    signal the loop must break. Returns `false` (no-op) before the cap or when
+    the cap is `0` (no timeout configured).
+  - `awaitInFlightTasks(timeoutMs, hardDeadlineTS = this.hardDeadlineTS)` now caps
+    the effective wait at `max(0, hardDeadlineTS - Date.now())`, so the 30 s
+    default cannot overshoot the cap. `hardDeadlineTS = 0` disables the cap
+    (preserving prior behaviour for runs with no timeout).
+- **`src/creature/CreatureTraining.ts`** — in each of the three `completed`
+  blocks, `neat.abandonInFlightPastHardDeadline(hardDeadlineMS)` is checked
+  before `finishUp()`; a `true` result breaks immediately. The local
+  `hardDeadlineMS` (previously plumbed-but-unused under a `no-unused-vars`
+  ignore) is now consumed, and the lint-ignore is removed. The post-loop
+  sequence (worker termination, best-creature restore, `writeCreatures`) is
+  unchanged — the `break` lands there exactly as the normal path does.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via unit tests and
+the full quality gate (`./quality.sh`: **7105 passed, 0 failed, 4 ignored**).
+
+### Hard-cap finish-up flow
+
+```mermaid
+flowchart TD
+    C{completed?} -->|no| Evolve[next evolve generation]
+    C -->|yes| I{interrupted?}
+    I -->|yes| Break
+    I -->|no| HC{"Date.now() > hardDeadlineMS?"}
+    HC -->|yes| Abandon["clear discovery/training maps<br/>log warning"] --> Break
+    HC -->|no| F{"finishUp() done?"}
+    F -->|yes| Break
+    F -->|no| Await["awaitInFlightTasks()<br/>capped at hardDeadlineTS"] --> C
+    Break[break loop] --> Post["terminate workers →<br/>restore best creature →<br/>writeCreatures"]
+```
+
+## Test Plan
+
+- **`test/NEAT/NeatHardDeadlineEnforcement.ts`** (new) — `abandonInFlightPastHardDeadline`:
+  - past deadline → returns `true` and both in-progress maps are emptied (no
+    elapsed-time measurement; behavioural per #2888);
+  - future deadline → returns `false`, bookkeeping untouched;
+  - zero deadline → returns `false` (cap disabled), bookkeeping untouched.
+- **`test/NEAT/NeatAwaitInFlightTasks.ts`** (extended):
+  - a never-settling task with a past `hardDeadlineTS` returns immediately
+    (cap clamps the wait to 0) without abandoning the maps itself;
+  - `hardDeadlineTS = 0` disables the cap so a soon-settling task still
+    completes within the normal timeout.
+- **`test/NEAT/NeatFinishUp.ts`** — existing finish-up tests still pass unchanged.
+- Full `./quality.sh` passes.

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -570,6 +570,34 @@ export class Neat {
   }
 
   /**
+   * Issue #2896: enforce the absolute T+15 hard cap during the finish-up cycle.
+   *
+   * When `hardDeadlineMS` is set (non-zero) and already in the past, abandon all
+   * in-flight discovery/training bookkeeping — so the abandoned promises cannot
+   * be re-awaited — and signal the caller to break out of the evolve loop, even
+   * when {@link finishUp} would still ask for more wait generations. The
+   * caller's post-loop sequence (worker termination, best-creature restore and
+   * `writeCreatures`) still runs because the break lands there.
+   *
+   * @param hardDeadlineMS Absolute hard-deadline epoch ms (0/unset = no cap).
+   * @returns `true` when the cap was exceeded and the loop must break.
+   */
+  abandonInFlightPastHardDeadline(hardDeadlineMS: number): boolean {
+    if (!hardDeadlineMS || Date.now() <= hardDeadlineMS) {
+      return false;
+    }
+
+    const abandoned = this.discoveryInProgress.size +
+      this.trainingInProgress.size;
+    getLogger().warn(
+      `[Neat] Hard deadline (timeoutMinutes + grace) exceeded — abandoning ${abandoned} in-flight task(s)`,
+    );
+    this.discoveryInProgress.clear();
+    this.trainingInProgress.clear();
+    return true;
+  }
+
+  /**
    * Issue #2240: Lightweight wait for in-flight discovery and training tasks.
    *
    * Instead of running full evolve() cycles while waiting for async tasks
@@ -578,8 +606,15 @@ export class Neat {
    * resources on unnecessary fitness evaluation, breeding, and mutation.
    *
    * @param timeoutMs - Maximum time to wait before returning (default 30s)
+   * @param hardDeadlineTS - Absolute hard-deadline epoch ms (Issue #2896).
+   *   Defaults to this instance's {@link hardDeadlineTS}. The effective wait is
+   *   capped at `hardDeadlineTS - Date.now()` (minimum 0) so the 30s default
+   *   cannot push the finish-up wait past the T+15 cap. 0 disables the cap.
    */
-  async awaitInFlightTasks(timeoutMs = 30_000): Promise<void> {
+  async awaitInFlightTasks(
+    timeoutMs = 30_000,
+    hardDeadlineTS = this.hardDeadlineTS,
+  ): Promise<void> {
     const inFlightPromises: Promise<void>[] = [
       ...this.discoveryInProgress.values(),
       ...this.trainingInProgress.values(),
@@ -589,17 +624,23 @@ export class Neat {
       return;
     }
 
+    // Issue #2896: never wait past the absolute hard deadline. Cap the effective
+    // timeout at the time remaining before the cap (minimum 0).
+    const effectiveTimeoutMs = hardDeadlineTS > 0
+      ? Math.min(timeoutMs, Math.max(0, hardDeadlineTS - Date.now()))
+      : timeoutMs;
+
     const discoveryCount = this.discoveryInProgress.size;
     const trainingCount = this.trainingInProgress.size;
     getLogger().info(
       `[Neat] Awaiting ${inFlightPromises.length} in-flight task(s) ` +
         `(${discoveryCount} discovery, ${trainingCount} training) ` +
-        `with ${timeoutMs}ms timeout`,
+        `with ${effectiveTimeoutMs}ms timeout`,
     );
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<void>((resolve) => {
-      timeoutId = setTimeout(resolve, timeoutMs);
+      timeoutId = setTimeout(resolve, effectiveTimeoutMs);
     });
 
     try {

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -392,9 +392,8 @@ export async function evolveDir(
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
   // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
-  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
-  // so the value is computed but not yet consumed.
-  // deno-lint-ignore no-unused-vars
+  // no timeout is configured. Issue #2896 enforces it in the finish-up cycle
+  // below via neat.abandonInFlightPastHardDeadline(hardDeadlineMS).
   const hardDeadlineMS =
     computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
@@ -595,6 +594,16 @@ export async function evolveDir(
 
     if (completed) {
       if (interrupted) break;
+
+      // Issue #2896: enforce the absolute T+15 hard cap. Once it passes, abandon
+      // any in-flight discovery/training bookkeeping and break unconditionally —
+      // even when finishUp() would still ask for more wait generations. The
+      // post-loop sequence (worker termination, best-creature restore,
+      // writeCreatures) still runs because the break lands there.
+      if (neat.abandonInFlightPastHardDeadline(hardDeadlineMS)) {
+        break;
+      }
+
       if (neat.finishUp(iterations, endTimeMS, start, generation)) {
         break;
       }
@@ -715,9 +724,8 @@ export async function evolveEnv<S, A>(
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
   // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
-  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
-  // so the value is computed but not yet consumed.
-  // deno-lint-ignore no-unused-vars
+  // no timeout is configured. Issue #2896 enforces it in the finish-up cycle
+  // below via neat.abandonInFlightPastHardDeadline(hardDeadlineMS).
   const hardDeadlineMS =
     computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
@@ -876,6 +884,16 @@ export async function evolveEnv<S, A>(
 
     if (completed) {
       if (interrupted) break;
+
+      // Issue #2896: enforce the absolute T+15 hard cap. Once it passes, abandon
+      // any in-flight discovery/training bookkeeping and break unconditionally —
+      // even when finishUp() would still ask for more wait generations. The
+      // post-loop sequence (best-creature restore, writeCreatures) still runs
+      // because the break lands there.
+      if (neat.abandonInFlightPastHardDeadline(hardDeadlineMS)) {
+        break;
+      }
+
       if (neat.finishUp(iterations, endTimeMS, start, generation)) {
         break;
       }
@@ -1071,9 +1089,8 @@ export async function evolveRL<S, A>(
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
   // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
-  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
-  // so the value is computed but not yet consumed.
-  // deno-lint-ignore no-unused-vars
+  // no timeout is configured. Issue #2896 enforces it in the finish-up cycle
+  // below via neat.abandonInFlightPastHardDeadline(hardDeadlineMS).
   const hardDeadlineMS =
     computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
@@ -1382,6 +1399,16 @@ export async function evolveRL<S, A>(
 
     if (completed) {
       if (interrupted) break;
+
+      // Issue #2896: enforce the absolute T+15 hard cap. Once it passes, abandon
+      // any in-flight discovery/training bookkeeping and break unconditionally —
+      // even when finishUp() would still ask for more wait generations. The
+      // post-loop sequence (best-creature restore, writeCreatures) still runs
+      // because the break lands there.
+      if (neat.abandonInFlightPastHardDeadline(hardDeadlineMS)) {
+        break;
+      }
+
       if (neat.finishUp(iterations, endTimeMS, start, generation)) {
         break;
       }

--- a/test/NEAT/NeatAwaitInFlightTasks.ts
+++ b/test/NEAT/NeatAwaitInFlightTasks.ts
@@ -205,6 +205,71 @@ Deno.test("awaitInFlightTasks: handles both discovery and training simultaneousl
   }
 });
 
+// ============================================================================
+// Issue #2896: awaitInFlightTasks must never wait past the absolute hard cap.
+// A hardDeadlineTS already in the past caps the effective timeout at 0, so the
+// wait returns immediately even for a never-settling task — without abandoning
+// the bookkeeping itself (the loop's hard-cap break owns that).
+// ============================================================================
+
+Deno.test("awaitInFlightTasks: past hard deadline caps the wait and returns immediately", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    // A task that never settles — only the hard-cap timeout can release us.
+    neat.discoveryInProgress.set("never-settles", new Promise(() => {}));
+
+    // hardDeadlineTS already in the past → effective timeout clamps to 0. If the
+    // cap were not applied the 30s default would hang and the runner's per-test
+    // timeout would fail (Issue #2888: behavioural, no elapsed-time assertion).
+    await neat.awaitInFlightTasks(30_000, Date.now() - 1000);
+
+    // awaitInFlightTasks only waits; it does not clear the maps.
+    assertEquals(
+      neat.discoveryInProgress.size,
+      1,
+      "awaitInFlightTasks must not abandon tasks itself",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("awaitInFlightTasks: zero hardDeadlineTS disables the cap", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    let resolved = false;
+    let timerId: ReturnType<typeof setTimeout>;
+    const taskPromise = new Promise<void>((resolve) => {
+      timerId = setTimeout(() => {
+        resolved = true;
+        resolve();
+      }, 50);
+    });
+    neat.trainingInProgress.set("settles-soon", taskPromise);
+
+    try {
+      // hardDeadlineTS = 0 disables the cap, so the normal 5s timeout applies
+      // and the task completes well within it.
+      await neat.awaitInFlightTasks(5000, 0);
+      assert(resolved, "Task should complete when the cap is disabled");
+    } finally {
+      clearTimeout(timerId!);
+    }
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
 Deno.test("finishUp: logs waiting message with task counts", async () => {
   const dataDir = createTestDataDir(2, 1);
   const workers = createTestWorkers(dataDir);

--- a/test/NEAT/NeatHardDeadlineEnforcement.ts
+++ b/test/NEAT/NeatHardDeadlineEnforcement.ts
@@ -1,0 +1,132 @@
+import { assert, assertEquals } from "@std/assert";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import { Neat } from "@neat/Neat.ts";
+import { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import {
+  type DataRecordInterface,
+  makeDataDir,
+} from "@architecture/DataSet.ts";
+
+/**
+ * Unit tests for Neat.abandonInFlightPastHardDeadline() — Issue #2896.
+ *
+ * The finish-up cycle must break out of the evolve loop unconditionally once
+ * the absolute T+15 hard cap passes, abandoning any in-flight discovery/training
+ * bookkeeping so the abandoned promises cannot be re-awaited. Assertions are
+ * behavioural (state + return value), not elapsed-time measurements (#2888).
+ */
+
+function createTestDataDir(input: number, output: number): string {
+  const records: DataRecordInterface[] = [];
+  for (let i = 0; i < 10; i++) {
+    records.push({
+      input: new Float32Array(
+        Array.from({ length: input }, () => Math.random()),
+      ),
+      output: new Float32Array(
+        Array.from({ length: output }, () => Math.random()),
+      ),
+    });
+  }
+  return makeDataDir(records, 2000);
+}
+
+function createTestWorkers(dataDir: string): WorkerHandler[] {
+  return [new WorkerHandler(dataDir, "MSE", true)];
+}
+
+async function terminateWorkers(workers: WorkerHandler[]): Promise<void> {
+  await Promise.all(workers.map((w) => w.waitUntilReady().catch(() => {})));
+  for (const w of workers) {
+    w.terminate();
+  }
+}
+
+Deno.test("abandonInFlightPastHardDeadline: breaks and abandons in-flight tasks once the cap has passed", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    // Never-settling discovery/training tasks that would otherwise wedge the run.
+    neat.discoveryInProgress.set("stuck-disc", new Promise(() => {}));
+    neat.trainingInProgress.set("stuck-train", new Promise(() => {}));
+
+    // Hard deadline already in the past.
+    const broke = neat.abandonInFlightPastHardDeadline(Date.now() - 1000);
+
+    assert(broke, "Should signal a break once the hard deadline has passed");
+    assertEquals(
+      neat.discoveryInProgress.size,
+      0,
+      "discoveryInProgress must be empty after the forced break",
+    );
+    assertEquals(
+      neat.trainingInProgress.size,
+      0,
+      "trainingInProgress must be empty after the forced break",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("abandonInFlightPastHardDeadline: does not break or abandon before the cap", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    neat.discoveryInProgress.set("disc", Promise.resolve());
+    neat.trainingInProgress.set("train", Promise.resolve());
+
+    // Hard deadline well in the future.
+    const broke = neat.abandonInFlightPastHardDeadline(Date.now() + 60_000);
+
+    assertEquals(broke, false, "Should not break before the hard deadline");
+    assertEquals(
+      neat.discoveryInProgress.size,
+      1,
+      "Discovery bookkeeping must be untouched before the cap",
+    );
+    assertEquals(
+      neat.trainingInProgress.size,
+      1,
+      "Training bookkeeping must be untouched before the cap",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("abandonInFlightPastHardDeadline: zero deadline disables the cap entirely", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    neat.trainingInProgress.set("train", Promise.resolve());
+
+    // 0 means "no timeout configured" → no cap, regardless of wall clock.
+    const broke = neat.abandonInFlightPastHardDeadline(0);
+
+    assertEquals(
+      broke,
+      false,
+      "A zero hard deadline must never break the loop",
+    );
+    assertEquals(
+      neat.trainingInProgress.size,
+      1,
+      "Training bookkeeping must be untouched when the cap is disabled",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});


### PR DESCRIPTION
# Enforce the T+15 hard cap in the evolve loops and bound `awaitInFlightTasks`

## Summary

The three evolve variants in `src/creature/CreatureTraining.ts` (`evolveDir`,
`evolveEnv`, `evolveRL`) now break out of the finish-up cycle **unconditionally**
once the absolute T+15 hard deadline (Issue #2895) passes — abandoning any
in-flight discovery/training bookkeeping while still restoring the best creature
and writing the creature store. `Neat.awaitInFlightTasks` is also bounded so its
30 s default wait can never push past the cap.

Previously (see `GRQ-19-sloth.log`) the finish-up cycle could clear stuck
discoveries, then keep running full generations, fine-tuning and waits until the
external 3-hour watchdog killed the process — losing all work. The per-phase
wall-clock guards added in #2432/#2871 only fire *between* finish-up checks; this
issue adds the outer guarantee they cannot provide on their own. The hard cap
turns a watchdog-kill into a clean return of the best creature found so far.

Closes #2896.

## What changed

- **`src/NEAT/Neat.ts`**
  - New `abandonInFlightPastHardDeadline(hardDeadlineMS)` method: when the cap is
    set and already in the past, it logs
    `[Neat] Hard deadline (timeoutMinutes + grace) exceeded — abandoning N in-flight task(s)`,
    clears `discoveryInProgress`/`trainingInProgress`, and returns `true` to
    signal the loop must break. Returns `false` (no-op) before the cap or when
    the cap is `0` (no timeout configured).
  - `awaitInFlightTasks(timeoutMs, hardDeadlineTS = this.hardDeadlineTS)` now caps
    the effective wait at `max(0, hardDeadlineTS - Date.now())`, so the 30 s
    default cannot overshoot the cap. `hardDeadlineTS = 0` disables the cap
    (preserving prior behaviour for runs with no timeout).
- **`src/creature/CreatureTraining.ts`** — in each of the three `completed`
  blocks, `neat.abandonInFlightPastHardDeadline(hardDeadlineMS)` is checked
  before `finishUp()`; a `true` result breaks immediately. The local
  `hardDeadlineMS` (previously plumbed-but-unused under a `no-unused-vars`
  ignore) is now consumed, and the lint-ignore is removed. The post-loop
  sequence (worker termination, best-creature restore, `writeCreatures`) is
  unchanged — the `break` lands there exactly as the normal path does.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via unit tests and
the full quality gate (`./quality.sh`: **7105 passed, 0 failed, 4 ignored**).

### Hard-cap finish-up flow

```mermaid
flowchart TD
    C{completed?} -->|no| Evolve[next evolve generation]
    C -->|yes| I{interrupted?}
    I -->|yes| Break
    I -->|no| HC{"Date.now() > hardDeadlineMS?"}
    HC -->|yes| Abandon["clear discovery/training maps<br/>log warning"] --> Break
    HC -->|no| F{"finishUp() done?"}
    F -->|yes| Break
    F -->|no| Await["awaitInFlightTasks()<br/>capped at hardDeadlineTS"] --> C
    Break[break loop] --> Post["terminate workers →<br/>restore best creature →<br/>writeCreatures"]
```

## Test Plan

- **`test/NEAT/NeatHardDeadlineEnforcement.ts`** (new) — `abandonInFlightPastHardDeadline`:
  - past deadline → returns `true` and both in-progress maps are emptied (no
    elapsed-time measurement; behavioural per #2888);
  - future deadline → returns `false`, bookkeeping untouched;
  - zero deadline → returns `false` (cap disabled), bookkeeping untouched.
- **`test/NEAT/NeatAwaitInFlightTasks.ts`** (extended):
  - a never-settling task with a past `hardDeadlineTS` returns immediately
    (cap clamps the wait to 0) without abandoning the maps itself;
  - `hardDeadlineTS = 0` disables the cap so a soon-settling task still
    completes within the normal timeout.
- **`test/NEAT/NeatFinishUp.ts`** — existing finish-up tests still pass unchanged.
- Full `./quality.sh` passes.



## Milestone
This PR is part of the **fix-timeout** milestone and targets the `milestone/fix-timeout` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq9l1hln-d62d60`<!-- vibe-worker-issue-2896 -->