### PR TITLE
Add end-to-end T+15 guard test and timeout-semantics docs (Issue #2902)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -772,6 +772,9 @@ governance / contributor documents:
 - **docs/DISCOVERY_DIR.md** - Technical API reference for `discoveryDir()`
 - **docs/GPU_ACCELERATION.md** - GPU acceleration details
 - **docs/CONFIGURATION_GUIDE.md** - Complete configuration options reference
+- **docs/TIMEOUTS.md** - `timeoutMinutes` semantics and the absolute T+15 hard
+  cap: deadline propagation from `evolveDir` to the worker clamps, what each
+  phase does at the cap, and the unchanged external-watchdog backstop
 - **docs/PERFORMANCE_TUNING.md** - Performance tuning guide for large-scale
   training
 - **docs/PERFORMANCE_RESEARCH.md** - Performance research with WASM migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,21 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Issue #2902 (acceptance gate for #2892; builds on #2895, #2896, #2898,
+  #2899, #2901):** `evolveDir(timeoutMinutes = T)` now carries a guaranteed
+  upper bound on how long it can run. Once the absolute hard cap —
+  `T +
+  min(15, T)` minutes ("T+15") — passes, the run abandons any in-flight
+  discovery, training, and replay work, keeps the best creature found so far,
+  writes `creatureStore`, and returns. In practice a run configured with
+  `--timeout=45` completes within the hour, leaving the caller time for its
+  normal save / model check-in instead of being killed mid-write by an external
+  watchdog. The external watchdog (e.g. GRQ's 3-hour `max-task-hours`) remains
+  the unchanged backstop. The semantics — what each phase does at the cap and
+  how the deadline propagates from `evolveDir` down to the worker clamps — are
+  documented in the new [`docs/TIMEOUTS.md`](./docs/TIMEOUTS.md), and an
+  end-to-end behavioural guard (`test/creature/EvolveDirHardDeadline.ts`) proves
+  the bound holds in training and stubbed-discovery modes alike.
 - **Issue #2787 (depends on Issue #2786):** Cost-aware `evolveDir` `targetError`
   early-stop and champion comparison. A new pure mapping helper
   `costNameToTaskDescriptor()` (`src/costs/CostDescriptor.ts`) gives every

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,11 @@ Drop-in API and configuration material.
   configuration surface. The detail docs under [`config/`](config/) cover
   presets, core evolution, training, discovery, mutation adaptation,
   regularisation, population sizing, workers, logging, and recipes.
+- **[TIMEOUTS.md](TIMEOUTS.md)** — `timeoutMinutes` semantics and the absolute
+  **T+15** hard cap: the two deadlines, what each phase does at the cap (abandon
+  in-flight work, keep partial results, return the best creature), how the
+  deadline propagates from `evolveDir` to the worker clamps, and the unchanged
+  external-watchdog backstop.
 - **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — FAQ-style index of common
   problems. The detail docs under [`troubleshooting/`](troubleshooting/) cover
   WASM, discovery / FFI, memory, performance, training divergence, CI /

--- a/docs/TIMEOUTS.md
+++ b/docs/TIMEOUTS.md
@@ -1,0 +1,140 @@
+# ⏱️ Timeout Semantics — the T+15 Hard Cap
+
+How long can an evolution run actually take? This document is the single source
+of truth for the **`timeoutMinutes`** option and the **absolute hard cap** that
+bounds `evolveDir` (and its siblings `evolveDataSet`, `evolveEnv`, `evolveRL`).
+
+> [!IMPORTANT]
+> **The guarantee in one line:** a run configured with `timeoutMinutes = T`
+> returns within **`T + min(15, T)` minutes** of wall-clock — "T+15" for any
+> `T ≥ 15` — abandoning in-flight work while keeping the best creature found so
+> far. A run started with `--timeout=45` therefore finishes inside the hour,
+> leaving the caller time for its normal save / model check-in.
+
+## 🧩 The two deadlines
+
+Evolution tracks **two** wall-clock deadlines, both anchored at the run's start
+timestamp:
+
+| Deadline                        | Value                             | Role                                                                                                                                                                                                  |
+| ------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Soft timeout** (`endTimeMS`)  | `start + max(1, T) × 60 000 ms`   | Stops starting _new_ generations once it passes. The loop then enters the finish-up phase and waits — briefly — for in-flight discovery / training to settle so their partial results are not wasted. |
+| **Hard cap** (`hardDeadlineTS`) | `start + (T + grace) × 60 000 ms` | The point of no return. Once it passes, every phase abandons in-flight work and the run returns. Nothing is allowed to push past it.                                                                  |
+
+The grace period is clamped:
+
+```text
+grace = min(HARD_DEADLINE_GRACE_MINUTES, max(1, T))   // HARD_DEADLINE_GRACE_MINUTES = 15
+```
+
+So the grace never exceeds 15 minutes for long runs, and stays proportionate for
+short ones (a 2-minute run gets at most 2 minutes of grace, not 15). When
+`timeoutMinutes` is `0`/unset there is **no** soft timeout and **no** hard cap —
+the run is bounded only by `iterations`, `targetError`, `SIGTERM`, and the
+external watchdog. The canonical computation lives in
+[`src/NEAT/HardDeadline.ts`](../src/NEAT/HardDeadline.ts)
+(`computeHardDeadlineTS`).
+
+## 🛑 What each phase does at the hard cap
+
+The cap is enforced cooperatively — each phase checks the absolute
+`hardDeadlineTS` at its own next safe boundary and stops there. None of them
+waits past it.
+
+- **Evolve loop** — `Neat.abandonInFlightPastHardDeadline(hardDeadlineTS)` is
+  the first check in the finish-up branch. Once the cap has passed it clears
+  `discoveryInProgress` / `trainingInProgress` (so the abandoned promises can
+  never be re-awaited) and breaks the loop **unconditionally**, even when
+  `finishUp()` would otherwise still ask for more wait generations.
+- **Finish-up wait** — `Neat.awaitInFlightTasks()` caps its own timeout at the
+  time remaining before `hardDeadlineTS`. A never-resolving in-flight promise
+  can therefore never wedge the wait past the cap.
+- **Discovery** — the absolute `discoveryHardDeadlineTS` crosses the worker
+  boundary (Issue #2898), so the worker clamps every per-discovery
+  record/analysis deadline to the cap regardless of how long the request waited
+  in the queue. The relative phase-split allocation (record vs analysis) still
+  applies _inside_ that ceiling.
+- **Training** — scheduled training tasks carry the same absolute hard deadline
+  (Issue #2899) and are clamped to it.
+- **Discovery replay** — `DiscoveryReplayQueue.scheduleReplay()` refuses to
+  start a replay once the cap has passed, and
+  `waitForCompletion(hardDeadlineTS)` drops any queued replay and signals the
+  in-flight one to abort cooperatively at its next candidate boundary (Issue
+  #2901).
+
+In every case the **partial results already gathered are kept** and the **best
+creature found so far is loaded onto the caller's creature**, `creatureStore` is
+written, and the run returns its normal `{ error, score, generation, time }`
+summary. The cap costs you only the _unfinished_ work, never the finished work.
+
+## 🔀 How the deadline propagates
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller
+    participant evolveDir
+    participant Neat
+    participant Worker as Discovery/Training worker
+    participant Replay as DiscoveryReplayQueue
+
+    Caller->>evolveDir: evolveDir(timeoutMinutes = T)
+    Note over evolveDir: start = now()<br/>endTimeMS = start + T·60s<br/>hardDeadlineTS = start + (T + min(15,T))·60s
+    evolveDir->>Neat: new Neat(... hardDeadlineTS ...)
+
+    loop each generation
+        Neat->>Worker: scheduleDiscovery / scheduleTraining<br/>(carry hardDeadlineTS)
+        Worker-->>Worker: clamp per-task deadline to min(local, hardDeadlineTS)
+        Neat->>Replay: scheduleReplay(... hardDeadlineTS ...)
+    end
+
+    Note over evolveDir,Neat: soft timeout passes → finish-up phase
+    evolveDir->>Neat: abandonInFlightPastHardDeadline(hardDeadlineTS)
+    alt now > hardDeadlineTS
+        Neat-->>Neat: clear discoveryInProgress + trainingInProgress
+        Neat-->>evolveDir: true → break the loop
+    else still before the cap
+        evolveDir->>Neat: awaitInFlightTasks() (capped at hardDeadlineTS)
+    end
+
+    evolveDir->>Replay: waitForCompletion(hardDeadlineTS)
+    Replay-->>Replay: drop queued replay, abort in-flight at next boundary
+    evolveDir->>Caller: load best creature, write creatureStore, return
+```
+
+The data flow, in one line:
+
+```text
+evolveDir → Neat.hardDeadlineTS → scheduleDiscovery / scheduleTraining / replay queue → worker clamps
+```
+
+## 🛰️ The external watchdog is unchanged
+
+The T+15 hard cap is an **in-process** guarantee. The external watchdog — for
+example GRQ's 3-hour `max-task-hours` — remains the independent backstop and is
+**unchanged** by any of this. The cap exists so that, in the normal case, a run
+finishes and checks its model in _well before_ the watchdog ever has to fire;
+the watchdog only catches pathological situations (a wedged process, a deadlock
+outside the cooperative checkpoints) that an in-process deadline cannot reach.
+
+## ✅ Verifying the guarantee
+
+The end-to-end guard
+[`test/creature/EvolveDirHardDeadline.ts`](../test/creature/EvolveDirHardDeadline.ts)
+drives `evolveDir` with a tiny `timeoutMinutes` and stubbed never-resolving
+discovery / training work, with the cap placed in the past via an injected start
+timestamp (so the assertions are behavioural, never elapsed-time measurements —
+the policy from Issue #2888). It asserts the run **returns**, the best creature
+is loaded onto the caller's creature, `creatureStore` is written and loadable,
+and the in-flight maps are empty. The replay-queue hard-cap bound has dedicated
+coverage in
+[`test/NEAT/DiscoveryReplayQueueDeadline.ts`](../test/NEAT/DiscoveryReplayQueueDeadline.ts).
+
+## 🔗 Related
+
+- [`src/NEAT/HardDeadline.ts`](../src/NEAT/HardDeadline.ts) — the pure
+  `computeHardDeadlineTS` helper and `HARD_DEADLINE_GRACE_MINUTES` constant.
+- [CONFIGURATION_GUIDE.md](CONFIGURATION_GUIDE.md) — the full configuration
+  surface, including `timeoutMinutes`.
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — what to do when a run does not stop
+  when you expect it to.

--- a/docs/archive/pr-summaries/pr-summary-2902.md
+++ b/docs/archive/pr-summaries/pr-summary-2902.md
@@ -1,0 +1,89 @@
+# End-to-end T+15 guard test and timeout-semantics documentation
+
+## Summary
+
+This is the acceptance gate for the parent timeout milestone (#2892): it proves,
+end-to-end, that `evolveDir(timeoutMinutes = T)` returns with consistent state
+once the absolute **T+15** hard cap passes — even with slow / never-resolving
+in-flight discovery and training — and documents the timeout semantics. The
+enforcement itself was delivered by the dependency sub-issues (#2895, #2896,
+#2898, #2899, #2901); this change adds the integration-level guard and the docs.
+**Closes #2902.**
+
+What changed:
+
+- **Integration guard** `test/creature/EvolveDirHardDeadline.ts` — drives a real
+  `evolveDir` run with a tiny `timeoutMinutes` and stubbed never-resolving
+  in-flight work, with the cap placed in the past via an injected start
+  timestamp, and asserts behaviour (not durations): the run returns, the best
+  creature is loaded onto the caller's creature, `creatureStore` is written and
+  loadable, and the in-flight maps are empty. Covers a training-mode run and a
+  discovery-mode run (discovery stubbed — no Rust FFI in CI).
+- **Test-only seam** on `evolveDir` (`EvolveDirDeps`) — an optional 4th `deps?`
+  parameter (`startTimeMS`, `onNeatReady`), consistent with the existing `deps?`
+  seams on `discoveryDir` / `discoveryReplayDir`. Lets the guard drive the cap
+  deterministically without real sleeps (policy #2888). Production callers omit
+  `deps`; the defaults reproduce the prior behaviour exactly.
+- **`docs/TIMEOUTS.md`** (new) — `timeoutMinutes` semantics, the
+  `T + min(15, T)` hard cap, what each phase does at the cap (abandon in-flight,
+  keep partial results, return best creature), a Mermaid sequence diagram of
+  deadline propagation
+  (`evolveDir → Neat → scheduleDiscovery / scheduleTraining / replay
+  queue → worker clamps`),
+  and the unchanged external-watchdog backstop. Linked from `docs/README.md` and
+  the AGENTS.md doc index.
+- **`CHANGELOG.md`** — Unreleased entry describing the guarantee (a
+  `--timeout=45` run completes within the hour, in time for the caller's normal
+  save / check-in) and noting the external watchdog (GRQ's 3-hour
+  `max-task-hours`) remains the unchanged backstop.
+
+## Evidence
+
+Backend / CLI change — no web interface to screenshot. Verified via the new
+integration test, the existing NEAT suite (771 passed), and the full
+config-driven `deno test` run (exit 0, no failures), plus
+`./quality.sh --lint-only` and `./quality.sh --check-only` (both pass).
+
+### Regression linkage (acceptance criterion)
+
+The guard fails against the pre-#2896 behaviour and passes with the hard-cap
+enforcement in place. The hard-cap branch
+(`Neat.abandonInFlightPastHardDeadline`) breaks on the **first** completed
+cycle, so the run returns at exactly `generation === 1`. With the branch
+neutered, the finish-up cycle can only clear the stuck task and then spin
+through further evolve() generations before stopping, so the run reaches
+`generation` 2+ and the `result.generation === 1` assertion fails. This was
+verified empirically by temporarily neutering `abandonInFlightPastHardDeadline`
+(both tests then failed on that assertion) and restoring it (both pass). The
+assertion is behavioural — a return value, never an elapsed-time measurement
+(#2888).
+
+### Deadline propagation
+
+```mermaid
+flowchart LR
+    E["evolveDir<br/>(timeoutMinutes = T)"] --> N["Neat.hardDeadlineTS<br/>= start + (T + min(15,T))·60s"]
+    N --> D[scheduleDiscovery]
+    N --> Tr[scheduleTraining]
+    N --> R[discoveryReplayQueue]
+    D --> W[worker clamps per-task deadline]
+    Tr --> W
+    R --> W
+    N --> A{"past hard cap?"}
+    A -->|yes| B["abandon in-flight,<br/>keep partial results,<br/>load best, write store, return"]
+```
+
+## Test Plan
+
+- **Added** `test/creature/EvolveDirHardDeadline.ts`:
+  - `training-mode run returns once the hard cap passes` — never-resolving
+    training stub; asserts return at `generation === 1`, finite score/error,
+    loaded best creature activates + round-trips, in-flight maps empty, no
+    replay wedged, `creatureStore` written and every persisted creature
+    loadable.
+  - `discovery-mode run (stubbed) returns once the hard cap passes` — same, with
+    a never-resolving discovery stub (no Rust FFI).
+- **Verified** the guard depends on #2896 by temporarily neutering the hard-cap
+  branch (both tests fail on `result.generation === 1`) and restoring it.
+- `./quality.sh --lint-only` and `--check-only` pass; full `deno test` passes;
+  `test/NEAT/*` (771 tests) pass.

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -363,6 +363,30 @@ async function writeCreatures(neat: Neat, dir: string): Promise<void> {
 }
 
 /**
+ * Test-only injection seam for {@link evolveDir} (Issue #2902).
+ *
+ * Lets the end-to-end T+15 hard-deadline guard drive the absolute cap
+ * deterministically without real sleeps (behavioural-test policy #2888).
+ * Production callers omit `deps` entirely; the defaults reproduce the
+ * pre-existing behaviour exactly.
+ *
+ * - `startTimeMS` overrides the run-start timestamp that anchors both the soft
+ *   `endTimeMS` and the absolute T+15 hard cap. Passing a timestamp far enough
+ *   in the past places both deadlines behind the wall clock, so the very first
+ *   finish-up cycle takes the hard-cap branch.
+ * - `onNeatReady` is invoked with the live {@link Neat} instance once the
+ *   population is seeded and before the evolve loop starts, so a test can stub
+ *   never-resolving in-flight discovery / training promises (no Rust FFI in CI)
+ *   and later inspect the in-flight maps once the run returns.
+ */
+export interface EvolveDirDeps {
+  /** Override the run-start timestamp (ms since epoch). */
+  startTimeMS?: number;
+  /** Invoked with the constructed {@link Neat} instance before the evolve loop. */
+  onNeatReady?: (neat: Neat) => void;
+}
+
+/**
  * Evolve the creature on a dataset directory using NEAT.
  * Supports multi-threaded workers, checkpointing, and timeout.
  */
@@ -370,6 +394,7 @@ export async function evolveDir(
   creature: Creature,
   dataSetDir: string,
   options: NeatOptions,
+  deps?: EvolveDirDeps,
 ): Promise<
   { error: number; score: number; time: number; generation: number }
 > {
@@ -381,7 +406,10 @@ export async function evolveDir(
 
   Deno.addSignalListener("SIGTERM", signalListener);
 
-  const start = Date.now();
+  // Issue #2902: `deps?.startTimeMS` is a test-only override that anchors both
+  // the soft `endTimeMS` and the absolute T+15 hard cap to an injected (past)
+  // timestamp, so the hard-cap branch can be driven without real sleeps.
+  const start = deps?.startTimeMS ?? Date.now();
   const config = createNeatConfig(options);
 
   // Issue #1566: Apply WASM cache caps from config before training starts.
@@ -462,6 +490,11 @@ export async function evolveDir(
 
   neat.setDataDir(dataSetDir);
   await neat.populatePopulation(creature);
+
+  // Issue #2902: hand the constructed Neat instance to the test seam (if any)
+  // so integration guards can stub never-resolving in-flight work before the
+  // evolve loop. No-op for production callers.
+  deps?.onNeatReady?.(neat);
 
   let error = Infinity;
   let bestScore = -Infinity;

--- a/test/creature/EvolveDirHardDeadline.ts
+++ b/test/creature/EvolveDirHardDeadline.ts
@@ -1,0 +1,224 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { evolveDir } from "@creature/CreatureTraining.ts";
+import type { EvolveDirDeps } from "@creature/CreatureTraining.ts";
+import type { Neat } from "@neat/Neat.ts";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import {
+  type DataRecordInterface,
+  makeDataDir,
+} from "@architecture/DataSet.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/**
+ * End-to-end T+15 hard-deadline guard — Issue #2902, part of #2892.
+ *
+ * Proves that `evolveDir(timeoutMinutes = T)` returns with consistent state
+ * once the absolute hard cap (T + min(15, T) minutes) passes, even when
+ * discovery / training work is stubbed to never resolve. The cap is driven by
+ * an injected past `startTimeMS` rather than real sleeps, so every assertion is
+ * behavioural (state + return value), never an elapsed-time measurement — the
+ * policy from #2888. The whole suite stays well inside the 120 s test budget.
+ *
+ * Linkage to #2896: the run terminates because the finish-up cycle takes the
+ * `abandonInFlightPastHardDeadline` branch, which breaks on the *first*
+ * completed cycle (so the run returns at `generation === 1`). Against the
+ * pre-#2896 behaviour the finish-up cycle could only clear the stuck task and
+ * then spin through further evolve() generations / waits before stopping, so a
+ * run that returns at exactly generation 1 with a never-resolving in-flight
+ * task could not have happened. Verified by temporarily neutering the branch:
+ * the `result.generation === 1` assertion then fails (the run reaches
+ * generation 2+), confirming the test genuinely depends on the hard cap.
+ */
+
+/** Minimal 2-in / 1-out dataset; the model never needs to converge here. */
+function tinyDataSet(): DataRecordInterface[] {
+  return [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+  ];
+}
+
+/**
+ * Build the shared options + a past-start deps seam so the soft timeout and the
+ * T+15 hard cap are already behind the wall clock when the first finish-up
+ * cycle runs. `captureNeat` lets the caller stub in-flight work and inspect the
+ * in-flight maps after the run.
+ */
+function hardDeadlineDeps(captureNeat: (neat: Neat) => void): EvolveDirDeps {
+  return {
+    // One hour in the past: with timeoutMinutes = 1 the soft endTime (start +
+    // 1 min) and the hard cap (start + 1 min + 1 min grace) both sit ~58 min
+    // before now, so abandonInFlightPastHardDeadline fires on generation 1.
+    startTimeMS: Date.now() - 60 * 60 * 1000,
+    onNeatReady: captureNeat,
+  };
+}
+
+function baseOptions(creatureStore: string): NeatOptions {
+  return {
+    populationSize: 10,
+    iterations: 1,
+    timeoutMinutes: 1,
+    threads: 1,
+    creatureStore,
+  };
+}
+
+/** Load every persisted creature from a `creatureStore` directory. */
+async function loadStoredCreatures(dir: string): Promise<Creature[]> {
+  const creatures: Creature[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    if (!entry.isFile || !entry.name.endsWith(".json")) continue;
+    const json = JSON.parse(await Deno.readTextFile(`${dir}/${entry.name}`));
+    creatures.push(Creature.fromJSON(json));
+  }
+  return creatures;
+}
+
+Deno.test({
+  name:
+    "evolveDir T+15 guard: training-mode run returns once the hard cap passes",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await initWasmForTests();
+
+    const dataSetDir = makeDataDir(tinyDataSet(), 2000);
+    const creatureStore = await Deno.makeTempDir({ prefix: "neat-t15-train-" });
+    const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+
+    let captured: Neat | undefined;
+    const deps = hardDeadlineDeps((neat) => {
+      captured = neat;
+      // Stubbed never-resolving training work — only the hard cap can release
+      // the finish-up cycle (no Rust FFI involved).
+      neat.trainingInProgress.set("stuck-train", new Promise<void>(() => {}));
+    });
+
+    const result = await evolveDir(
+      creature,
+      dataSetDir,
+      baseOptions(creatureStore),
+      deps,
+    );
+
+    // The function returned (no hang) with a finite best result loaded onto the
+    // caller's creature.
+    assert(Number.isFinite(result.score), "best score must be finite");
+    assert(Number.isFinite(result.error), "best error must be finite");
+    // #2896 linkage: the hard-cap branch breaks on the *first* completed cycle,
+    // before finishUp() can ask for more wait generations. Against the
+    // pre-#2896 behaviour the finish-up cycle would clear the stub and spin
+    // through extra evolve() generations (generation > 1) before stopping, so a
+    // run that returns at exactly generation 1 with a never-resolving in-flight
+    // task can only have taken the abandonInFlightPastHardDeadline branch.
+    assertEquals(
+      result.generation,
+      1,
+      "the hard-cap branch must break on the first completed cycle",
+    );
+    // The best creature found was loaded onto the caller's creature: it is a
+    // valid, activatable network that round-trips through JSON.
+    const activation = creature.activate(new Float32Array([1, 0]))[0];
+    assert(
+      Number.isFinite(activation),
+      "loaded best creature must activate to a finite value",
+    );
+    assertEquals(
+      Creature.fromJSON(creature.exportJSON()).input,
+      2,
+      "loaded best creature must round-trip through JSON",
+    );
+
+    // In-flight bookkeeping was abandoned by the hard-cap branch.
+    assert(captured, "onNeatReady must have handed back the Neat instance");
+    assertEquals(
+      captured.trainingInProgress.size,
+      0,
+      "trainingInProgress must be empty after the hard-cap break",
+    );
+    assertEquals(
+      captured.discoveryInProgress.size,
+      0,
+      "discoveryInProgress must be empty after the hard-cap break",
+    );
+    assertEquals(
+      captured.discoveryReplayQueue.isReplayInProgress(),
+      false,
+      "no replay may be left wedged after the run returns",
+    );
+
+    // creatureStore was written and the persisted creatures are loadable.
+    const stored = await loadStoredCreatures(creatureStore);
+    assert(stored.length > 0, "creatureStore must contain at least one file");
+    for (const loaded of stored) {
+      assertEquals(loaded.input, 2, "stored creature input must round-trip");
+      assertEquals(loaded.output, 1, "stored creature output must round-trip");
+    }
+
+    await Deno.remove(dataSetDir, { recursive: true });
+    await Deno.remove(creatureStore, { recursive: true });
+  },
+});
+
+Deno.test({
+  name:
+    "evolveDir T+15 guard: discovery-mode run (stubbed) returns once the hard cap passes",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await initWasmForTests();
+
+    const dataSetDir = makeDataDir(tinyDataSet(), 2000);
+    const creatureStore = await Deno.makeTempDir({ prefix: "neat-t15-disc-" });
+    const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+
+    let captured: Neat | undefined;
+    const deps = hardDeadlineDeps((neat) => {
+      captured = neat;
+      // Discovery stubbed so CI needs no Rust FFI: a never-resolving promise
+      // standing in for an in-flight discovery task.
+      neat.discoveryInProgress.set("stuck-disc", new Promise<void>(() => {}));
+    });
+
+    const result = await evolveDir(
+      creature,
+      dataSetDir,
+      baseOptions(creatureStore),
+      deps,
+    );
+
+    assert(Number.isFinite(result.score), "best score must be finite");
+    assert(Number.isFinite(result.error), "best error must be finite");
+    // #2896 linkage: see the training-mode test — breaking at exactly
+    // generation 1 with a never-resolving stub proves the hard-cap branch fired.
+    assertEquals(
+      result.generation,
+      1,
+      "the hard-cap branch must break on the first completed cycle",
+    );
+
+    assert(captured, "onNeatReady must have handed back the Neat instance");
+    assertEquals(
+      captured.discoveryInProgress.size,
+      0,
+      "discoveryInProgress must be empty after the hard-cap break",
+    );
+    assertEquals(
+      captured.trainingInProgress.size,
+      0,
+      "trainingInProgress must be empty after the hard-cap break",
+    );
+
+    const stored = await loadStoredCreatures(creatureStore);
+    assert(stored.length > 0, "creatureStore must contain at least one file");
+    assertEquals(stored[0].input, 2, "stored creature input must round-trip");
+    assertEquals(stored[0].output, 1, "stored creature output must round-trip");
+
+    await Deno.remove(dataSetDir, { recursive: true });
+    await Deno.remove(creatureStore, { recursive: true });
+  },
+});


### PR DESCRIPTION
# End-to-end T+15 guard test and timeout-semantics documentation

## Summary

This is the acceptance gate for the parent timeout milestone (#2892): it proves,
end-to-end, that `evolveDir(timeoutMinutes = T)` returns with consistent state
once the absolute **T+15** hard cap passes — even with slow / never-resolving
in-flight discovery and training — and documents the timeout semantics. The
enforcement itself was delivered by the dependency sub-issues (#2895, #2896,
#2898, #2899, #2901); this change adds the integration-level guard and the docs.
**Closes #2902.**

What changed:

- **Integration guard** `test/creature/EvolveDirHardDeadline.ts` — drives a real
  `evolveDir` run with a tiny `timeoutMinutes` and stubbed never-resolving
  in-flight work, with the cap placed in the past via an injected start
  timestamp, and asserts behaviour (not durations): the run returns, the best
  creature is loaded onto the caller's creature, `creatureStore` is written and
  loadable, and the in-flight maps are empty. Covers a training-mode run and a
  discovery-mode run (discovery stubbed — no Rust FFI in CI).
- **Test-only seam** on `evolveDir` (`EvolveDirDeps`) — an optional 4th `deps?`
  parameter (`startTimeMS`, `onNeatReady`), consistent with the existing `deps?`
  seams on `discoveryDir` / `discoveryReplayDir`. Lets the guard drive the cap
  deterministically without real sleeps (policy #2888). Production callers omit
  `deps`; the defaults reproduce the prior behaviour exactly.
- **`docs/TIMEOUTS.md`** (new) — `timeoutMinutes` semantics, the
  `T + min(15, T)` hard cap, what each phase does at the cap (abandon in-flight,
  keep partial results, return best creature), a Mermaid sequence diagram of
  deadline propagation
  (`evolveDir → Neat → scheduleDiscovery / scheduleTraining / replay
  queue → worker clamps`),
  and the unchanged external-watchdog backstop. Linked from `docs/README.md` and
  the AGENTS.md doc index.
- **`CHANGELOG.md`** — Unreleased entry describing the guarantee (a
  `--timeout=45` run completes within the hour, in time for the caller's normal
  save / check-in) and noting the external watchdog (GRQ's 3-hour
  `max-task-hours`) remains the unchanged backstop.

## Evidence

Backend / CLI change — no web interface to screenshot. Verified via the new
integration test, the existing NEAT suite (771 passed), and the full
config-driven `deno test` run (exit 0, no failures), plus
`./quality.sh --lint-only` and `./quality.sh --check-only` (both pass).

### Regression linkage (acceptance criterion)

The guard fails against the pre-#2896 behaviour and passes with the hard-cap
enforcement in place. The hard-cap branch
(`Neat.abandonInFlightPastHardDeadline`) breaks on the **first** completed
cycle, so the run returns at exactly `generation === 1`. With the branch
neutered, the finish-up cycle can only clear the stuck task and then spin
through further evolve() generations before stopping, so the run reaches
`generation` 2+ and the `result.generation === 1` assertion fails. This was
verified empirically by temporarily neutering `abandonInFlightPastHardDeadline`
(both tests then failed on that assertion) and restoring it (both pass). The
assertion is behavioural — a return value, never an elapsed-time measurement
(#2888).

### Deadline propagation

```mermaid
flowchart LR
    E["evolveDir<br/>(timeoutMinutes = T)"] --> N["Neat.hardDeadlineTS<br/>= start + (T + min(15,T))·60s"]
    N --> D[scheduleDiscovery]
    N --> Tr[scheduleTraining]
    N --> R[discoveryReplayQueue]
    D --> W[worker clamps per-task deadline]
    Tr --> W
    R --> W
    N --> A{"past hard cap?"}
    A -->|yes| B["abandon in-flight,<br/>keep partial results,<br/>load best, write store, return"]
```

## Test Plan

- **Added** `test/creature/EvolveDirHardDeadline.ts`:
  - `training-mode run returns once the hard cap passes` — never-resolving
    training stub; asserts return at `generation === 1`, finite score/error,
    loaded best creature activates + round-trips, in-flight maps empty, no
    replay wedged, `creatureStore` written and every persisted creature
    loadable.
  - `discovery-mode run (stubbed) returns once the hard cap passes` — same, with
    a never-resolving discovery stub (no Rust FFI).
- **Verified** the guard depends on #2896 by temporarily neutering the hard-cap
  branch (both tests fail on `result.generation === 1`) and restoring it.
- `./quality.sh --lint-only` and `--check-only` pass; full `deno test` passes;
  `test/NEAT/*` (771 tests) pass.



## Milestone
This PR is part of the **fix-timeout** milestone and targets the `milestone/fix-timeout` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq9o1mgl-61300c`<!-- vibe-worker-issue-2902 -->