### PR TITLE
Milestone: fix-timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -772,6 +772,9 @@ governance / contributor documents:
 - **docs/DISCOVERY_DIR.md** - Technical API reference for `discoveryDir()`
 - **docs/GPU_ACCELERATION.md** - GPU acceleration details
 - **docs/CONFIGURATION_GUIDE.md** - Complete configuration options reference
+- **docs/TIMEOUTS.md** - `timeoutMinutes` semantics and the absolute T+15 hard
+  cap: deadline propagation from `evolveDir` to the worker clamps, what each
+  phase does at the cap, and the unchanged external-watchdog backstop
 - **docs/PERFORMANCE_TUNING.md** - Performance tuning guide for large-scale
   training
 - **docs/PERFORMANCE_RESEARCH.md** - Performance research with WASM migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,21 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Issue #2902 (acceptance gate for #2892; builds on #2895, #2896, #2898,
+  #2899, #2901):** `evolveDir(timeoutMinutes = T)` now carries a guaranteed
+  upper bound on how long it can run. Once the absolute hard cap —
+  `T +
+  min(15, T)` minutes ("T+15") — passes, the run abandons any in-flight
+  discovery, training, and replay work, keeps the best creature found so far,
+  writes `creatureStore`, and returns. In practice a run configured with
+  `--timeout=45` completes within the hour, leaving the caller time for its
+  normal save / model check-in instead of being killed mid-write by an external
+  watchdog. The external watchdog (e.g. GRQ's 3-hour `max-task-hours`) remains
+  the unchanged backstop. The semantics — what each phase does at the cap and
+  how the deadline propagates from `evolveDir` down to the worker clamps — are
+  documented in the new [`docs/TIMEOUTS.md`](./docs/TIMEOUTS.md), and an
+  end-to-end behavioural guard (`test/creature/EvolveDirHardDeadline.ts`) proves
+  the bound holds in training and stubbed-discovery modes alike.
 - **Issue #2787 (depends on Issue #2786):** Cost-aware `evolveDir` `targetError`
   early-stop and champion comparison. A new pure mapping helper
   `costNameToTaskDescriptor()` (`src/costs/CostDescriptor.ts`) gives every

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.28",
+  "version": "5.4.0",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.3.27",
+  "version": "5.3.28",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.lock
+++ b/deno.lock
@@ -19,7 +19,8 @@
     "jsr:@std/uuid@1.1.1": "1.1.1",
     "jsr:@std/yaml@1.1.1": "1.1.1",
     "jsr:@stsoftware/tags@1.0.13": "1.0.13",
-    "npm:cspell@*": "10.0.1"
+    "npm:cspell@*": "10.0.1",
+    "npm:cspell@latest": "10.0.1"
   },
   "jsr": {
     "@std/assert@1.0.19": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,11 @@ Drop-in API and configuration material.
   configuration surface. The detail docs under [`config/`](config/) cover
   presets, core evolution, training, discovery, mutation adaptation,
   regularisation, population sizing, workers, logging, and recipes.
+- **[TIMEOUTS.md](TIMEOUTS.md)** — `timeoutMinutes` semantics and the absolute
+  **T+15** hard cap: the two deadlines, what each phase does at the cap (abandon
+  in-flight work, keep partial results, return the best creature), how the
+  deadline propagates from `evolveDir` to the worker clamps, and the unchanged
+  external-watchdog backstop.
 - **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — FAQ-style index of common
   problems. The detail docs under [`troubleshooting/`](troubleshooting/) cover
   WASM, discovery / FFI, memory, performance, training divergence, CI /

--- a/docs/TIMEOUTS.md
+++ b/docs/TIMEOUTS.md
@@ -1,0 +1,140 @@
+# ⏱️ Timeout Semantics — the T+15 Hard Cap
+
+How long can an evolution run actually take? This document is the single source
+of truth for the **`timeoutMinutes`** option and the **absolute hard cap** that
+bounds `evolveDir` (and its siblings `evolveDataSet`, `evolveEnv`, `evolveRL`).
+
+> [!IMPORTANT]
+> **The guarantee in one line:** a run configured with `timeoutMinutes = T`
+> returns within **`T + min(15, T)` minutes** of wall-clock — "T+15" for any
+> `T ≥ 15` — abandoning in-flight work while keeping the best creature found so
+> far. A run started with `--timeout=45` therefore finishes inside the hour,
+> leaving the caller time for its normal save / model check-in.
+
+## 🧩 The two deadlines
+
+Evolution tracks **two** wall-clock deadlines, both anchored at the run's start
+timestamp:
+
+| Deadline                        | Value                             | Role                                                                                                                                                                                                  |
+| ------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Soft timeout** (`endTimeMS`)  | `start + max(1, T) × 60 000 ms`   | Stops starting _new_ generations once it passes. The loop then enters the finish-up phase and waits — briefly — for in-flight discovery / training to settle so their partial results are not wasted. |
+| **Hard cap** (`hardDeadlineTS`) | `start + (T + grace) × 60 000 ms` | The point of no return. Once it passes, every phase abandons in-flight work and the run returns. Nothing is allowed to push past it.                                                                  |
+
+The grace period is clamped:
+
+```text
+grace = min(HARD_DEADLINE_GRACE_MINUTES, max(1, T))   // HARD_DEADLINE_GRACE_MINUTES = 15
+```
+
+So the grace never exceeds 15 minutes for long runs, and stays proportionate for
+short ones (a 2-minute run gets at most 2 minutes of grace, not 15). When
+`timeoutMinutes` is `0`/unset there is **no** soft timeout and **no** hard cap —
+the run is bounded only by `iterations`, `targetError`, `SIGTERM`, and the
+external watchdog. The canonical computation lives in
+[`src/NEAT/HardDeadline.ts`](../src/NEAT/HardDeadline.ts)
+(`computeHardDeadlineTS`).
+
+## 🛑 What each phase does at the hard cap
+
+The cap is enforced cooperatively — each phase checks the absolute
+`hardDeadlineTS` at its own next safe boundary and stops there. None of them
+waits past it.
+
+- **Evolve loop** — `Neat.abandonInFlightPastHardDeadline(hardDeadlineTS)` is
+  the first check in the finish-up branch. Once the cap has passed it clears
+  `discoveryInProgress` / `trainingInProgress` (so the abandoned promises can
+  never be re-awaited) and breaks the loop **unconditionally**, even when
+  `finishUp()` would otherwise still ask for more wait generations.
+- **Finish-up wait** — `Neat.awaitInFlightTasks()` caps its own timeout at the
+  time remaining before `hardDeadlineTS`. A never-resolving in-flight promise
+  can therefore never wedge the wait past the cap.
+- **Discovery** — the absolute `discoveryHardDeadlineTS` crosses the worker
+  boundary (Issue #2898), so the worker clamps every per-discovery
+  record/analysis deadline to the cap regardless of how long the request waited
+  in the queue. The relative phase-split allocation (record vs analysis) still
+  applies _inside_ that ceiling.
+- **Training** — scheduled training tasks carry the same absolute hard deadline
+  (Issue #2899) and are clamped to it.
+- **Discovery replay** — `DiscoveryReplayQueue.scheduleReplay()` refuses to
+  start a replay once the cap has passed, and
+  `waitForCompletion(hardDeadlineTS)` drops any queued replay and signals the
+  in-flight one to abort cooperatively at its next candidate boundary (Issue
+  #2901).
+
+In every case the **partial results already gathered are kept** and the **best
+creature found so far is loaded onto the caller's creature**, `creatureStore` is
+written, and the run returns its normal `{ error, score, generation, time }`
+summary. The cap costs you only the _unfinished_ work, never the finished work.
+
+## 🔀 How the deadline propagates
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller
+    participant evolveDir
+    participant Neat
+    participant Worker as Discovery/Training worker
+    participant Replay as DiscoveryReplayQueue
+
+    Caller->>evolveDir: evolveDir(timeoutMinutes = T)
+    Note over evolveDir: start = now()<br/>endTimeMS = start + T·60s<br/>hardDeadlineTS = start + (T + min(15,T))·60s
+    evolveDir->>Neat: new Neat(... hardDeadlineTS ...)
+
+    loop each generation
+        Neat->>Worker: scheduleDiscovery / scheduleTraining<br/>(carry hardDeadlineTS)
+        Worker-->>Worker: clamp per-task deadline to min(local, hardDeadlineTS)
+        Neat->>Replay: scheduleReplay(... hardDeadlineTS ...)
+    end
+
+    Note over evolveDir,Neat: soft timeout passes → finish-up phase
+    evolveDir->>Neat: abandonInFlightPastHardDeadline(hardDeadlineTS)
+    alt now > hardDeadlineTS
+        Neat-->>Neat: clear discoveryInProgress + trainingInProgress
+        Neat-->>evolveDir: true → break the loop
+    else still before the cap
+        evolveDir->>Neat: awaitInFlightTasks() (capped at hardDeadlineTS)
+    end
+
+    evolveDir->>Replay: waitForCompletion(hardDeadlineTS)
+    Replay-->>Replay: drop queued replay, abort in-flight at next boundary
+    evolveDir->>Caller: load best creature, write creatureStore, return
+```
+
+The data flow, in one line:
+
+```text
+evolveDir → Neat.hardDeadlineTS → scheduleDiscovery / scheduleTraining / replay queue → worker clamps
+```
+
+## 🛰️ The external watchdog is unchanged
+
+The T+15 hard cap is an **in-process** guarantee. The external watchdog — for
+example GRQ's 3-hour `max-task-hours` — remains the independent backstop and is
+**unchanged** by any of this. The cap exists so that, in the normal case, a run
+finishes and checks its model in _well before_ the watchdog ever has to fire;
+the watchdog only catches pathological situations (a wedged process, a deadlock
+outside the cooperative checkpoints) that an in-process deadline cannot reach.
+
+## ✅ Verifying the guarantee
+
+The end-to-end guard
+[`test/creature/EvolveDirHardDeadline.ts`](../test/creature/EvolveDirHardDeadline.ts)
+drives `evolveDir` with a tiny `timeoutMinutes` and stubbed never-resolving
+discovery / training work, with the cap placed in the past via an injected start
+timestamp (so the assertions are behavioural, never elapsed-time measurements —
+the policy from Issue #2888). It asserts the run **returns**, the best creature
+is loaded onto the caller's creature, `creatureStore` is written and loadable,
+and the in-flight maps are empty. The replay-queue hard-cap bound has dedicated
+coverage in
+[`test/NEAT/DiscoveryReplayQueueDeadline.ts`](../test/NEAT/DiscoveryReplayQueueDeadline.ts).
+
+## 🔗 Related
+
+- [`src/NEAT/HardDeadline.ts`](../src/NEAT/HardDeadline.ts) — the pure
+  `computeHardDeadlineTS` helper and `HARD_DEADLINE_GRACE_MINUTES` constant.
+- [CONFIGURATION_GUIDE.md](CONFIGURATION_GUIDE.md) — the full configuration
+  surface, including `timeoutMinutes`.
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — what to do when a run does not stop
+  when you expect it to.

--- a/docs/archive/pr-summaries/pr-summary-2895.md
+++ b/docs/archive/pr-summaries/pr-summary-2895.md
@@ -1,0 +1,58 @@
+# Add hard-deadline (T+15) helper and plumb `hardDeadlineTS`
+
+## Summary
+
+Introduces a single source of truth for the evolution hard cap — the absolute
+wall-clock timestamp past which `evolveDir` must abandon all in-flight work —
+and plumbs it through `Neat` and the three evolve variants so later sub-issues
+can enforce it in each phase. Pure plumbing: no behavioural change to existing
+runs. Closes #2895. Part of #2892.
+
+- **New module `src/NEAT/HardDeadline.ts`** exporting:
+  - `HARD_DEADLINE_GRACE_MINUTES = 15` — the maximum permitted overrun past
+    `timeoutMinutes`.
+  - `computeHardDeadlineTS(startMS, timeoutMinutes)` — returns
+    `startMS + timeoutMinutes * 60_000 + graceMS`, where
+    `graceMS = min(15, max(1, timeoutMinutes)) * 60_000`. Returns `undefined`
+    when `timeoutMinutes` is 0/unset (no timeout → no cap). The helper is pure
+    (absolute timestamps in, absolute timestamps out), so tests need no real
+    clock (policy from #2888).
+- **`src/NEAT/Neat.ts`** — new `hardDeadlineTS` field set alongside `endTimeTS`
+  from the same options via the helper (0 when no timeout). Both now anchor to
+  one captured `startTS`.
+- **`src/creature/CreatureTraining.ts`** — each of the three evolve variants
+  computes `hardDeadlineMS` next to its existing `endTimeMS`. The value is
+  computed but not yet consumed (enforcement lands in follow-up sub-issues),
+  marked with a documented `deno-lint-ignore no-unused-vars`.
+
+## Data flow
+
+```mermaid
+flowchart LR
+    O[NeatOptions.timeoutMinutes] --> H[computeHardDeadlineTS]
+    S[startMS / startTS] --> H
+    H -->|undefined → 0| N[Neat.hardDeadlineTS]
+    H -->|undefined → 0| C[CreatureTraining hardDeadlineMS x3]
+    N -.future sub-issues.-> E[per-phase enforcement]
+    C -.future sub-issues.-> E
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via unit tests and
+the full quality gate.
+
+- `./quality.sh` passes cleanly: `ok | 7093 passed (2 steps) | 0 failed`.
+- The helper is pure; all assertions are on returned/derived timestamps, never
+  on elapsed wall-clock time (policy from #2888).
+
+## Test Plan
+
+- **`test/NEAT/HardDeadline.ts`** (new) — covers:
+  - grace constant is 15 minutes;
+  - no timeout configured → `undefined` (both 0 and `undefined` inputs);
+  - T=2 → grace 2 m; T=45 → grace capped at 15 m (T+15); T=120 → grace clamped
+    to 15 m; T=1 → grace 1 m.
+- **`test/NEAT/NeatConstruction.ts`** (extended) — asserts
+  `hardDeadlineTS - endTimeTS === 5 minutes` for `timeoutMinutes=5`, and
+  `hardDeadlineTS === 0` when no timeout is set (consistent with `endTimeTS`).

--- a/docs/archive/pr-summaries/pr-summary-2896.md
+++ b/docs/archive/pr-summaries/pr-summary-2896.md
@@ -1,0 +1,75 @@
+# Enforce the T+15 hard cap in the evolve loops and bound `awaitInFlightTasks`
+
+## Summary
+
+The three evolve variants in `src/creature/CreatureTraining.ts` (`evolveDir`,
+`evolveEnv`, `evolveRL`) now break out of the finish-up cycle **unconditionally**
+once the absolute T+15 hard deadline (Issue #2895) passes — abandoning any
+in-flight discovery/training bookkeeping while still restoring the best creature
+and writing the creature store. `Neat.awaitInFlightTasks` is also bounded so its
+30 s default wait can never push past the cap.
+
+Previously (see `GRQ-19-sloth.log`) the finish-up cycle could clear stuck
+discoveries, then keep running full generations, fine-tuning and waits until the
+external 3-hour watchdog killed the process — losing all work. The per-phase
+wall-clock guards added in #2432/#2871 only fire *between* finish-up checks; this
+issue adds the outer guarantee they cannot provide on their own. The hard cap
+turns a watchdog-kill into a clean return of the best creature found so far.
+
+Closes #2896.
+
+## What changed
+
+- **`src/NEAT/Neat.ts`**
+  - New `abandonInFlightPastHardDeadline(hardDeadlineMS)` method: when the cap is
+    set and already in the past, it logs
+    `[Neat] Hard deadline (timeoutMinutes + grace) exceeded — abandoning N in-flight task(s)`,
+    clears `discoveryInProgress`/`trainingInProgress`, and returns `true` to
+    signal the loop must break. Returns `false` (no-op) before the cap or when
+    the cap is `0` (no timeout configured).
+  - `awaitInFlightTasks(timeoutMs, hardDeadlineTS = this.hardDeadlineTS)` now caps
+    the effective wait at `max(0, hardDeadlineTS - Date.now())`, so the 30 s
+    default cannot overshoot the cap. `hardDeadlineTS = 0` disables the cap
+    (preserving prior behaviour for runs with no timeout).
+- **`src/creature/CreatureTraining.ts`** — in each of the three `completed`
+  blocks, `neat.abandonInFlightPastHardDeadline(hardDeadlineMS)` is checked
+  before `finishUp()`; a `true` result breaks immediately. The local
+  `hardDeadlineMS` (previously plumbed-but-unused under a `no-unused-vars`
+  ignore) is now consumed, and the lint-ignore is removed. The post-loop
+  sequence (worker termination, best-creature restore, `writeCreatures`) is
+  unchanged — the `break` lands there exactly as the normal path does.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via unit tests and
+the full quality gate (`./quality.sh`: **7105 passed, 0 failed, 4 ignored**).
+
+### Hard-cap finish-up flow
+
+```mermaid
+flowchart TD
+    C{completed?} -->|no| Evolve[next evolve generation]
+    C -->|yes| I{interrupted?}
+    I -->|yes| Break
+    I -->|no| HC{"Date.now() > hardDeadlineMS?"}
+    HC -->|yes| Abandon["clear discovery/training maps<br/>log warning"] --> Break
+    HC -->|no| F{"finishUp() done?"}
+    F -->|yes| Break
+    F -->|no| Await["awaitInFlightTasks()<br/>capped at hardDeadlineTS"] --> C
+    Break[break loop] --> Post["terminate workers →<br/>restore best creature →<br/>writeCreatures"]
+```
+
+## Test Plan
+
+- **`test/NEAT/NeatHardDeadlineEnforcement.ts`** (new) — `abandonInFlightPastHardDeadline`:
+  - past deadline → returns `true` and both in-progress maps are emptied (no
+    elapsed-time measurement; behavioural per #2888);
+  - future deadline → returns `false`, bookkeeping untouched;
+  - zero deadline → returns `false` (cap disabled), bookkeeping untouched.
+- **`test/NEAT/NeatAwaitInFlightTasks.ts`** (extended):
+  - a never-settling task with a past `hardDeadlineTS` returns immediately
+    (cap clamps the wait to 0) without abandoning the maps itself;
+  - `hardDeadlineTS = 0` disables the cap so a soon-settling task still
+    completes within the normal timeout.
+- **`test/NEAT/NeatFinishUp.ts`** — existing finish-up tests still pass unchanged.
+- Full `./quality.sh` passes.

--- a/docs/archive/pr-summaries/pr-summary-2896.md
+++ b/docs/archive/pr-summaries/pr-summary-2896.md
@@ -3,33 +3,33 @@
 ## Summary
 
 The three evolve variants in `src/creature/CreatureTraining.ts` (`evolveDir`,
-`evolveEnv`, `evolveRL`) now break out of the finish-up cycle **unconditionally**
-once the absolute T+15 hard deadline (Issue #2895) passes — abandoning any
-in-flight discovery/training bookkeeping while still restoring the best creature
-and writing the creature store. `Neat.awaitInFlightTasks` is also bounded so its
-30 s default wait can never push past the cap.
+`evolveEnv`, `evolveRL`) now break out of the finish-up cycle
+**unconditionally** once the absolute T+15 hard deadline (Issue #2895) passes —
+abandoning any in-flight discovery/training bookkeeping while still restoring
+the best creature and writing the creature store. `Neat.awaitInFlightTasks` is
+also bounded so its 30 s default wait can never push past the cap.
 
 Previously (see `GRQ-19-sloth.log`) the finish-up cycle could clear stuck
 discoveries, then keep running full generations, fine-tuning and waits until the
 external 3-hour watchdog killed the process — losing all work. The per-phase
-wall-clock guards added in #2432/#2871 only fire *between* finish-up checks; this
-issue adds the outer guarantee they cannot provide on their own. The hard cap
-turns a watchdog-kill into a clean return of the best creature found so far.
+wall-clock guards added in #2432/#2871 only fire _between_ finish-up checks;
+this issue adds the outer guarantee they cannot provide on their own. The hard
+cap turns a watchdog-kill into a clean return of the best creature found so far.
 
 Closes #2896.
 
 ## What changed
 
 - **`src/NEAT/Neat.ts`**
-  - New `abandonInFlightPastHardDeadline(hardDeadlineMS)` method: when the cap is
-    set and already in the past, it logs
+  - New `abandonInFlightPastHardDeadline(hardDeadlineMS)` method: when the cap
+    is set and already in the past, it logs
     `[Neat] Hard deadline (timeoutMinutes + grace) exceeded — abandoning N in-flight task(s)`,
     clears `discoveryInProgress`/`trainingInProgress`, and returns `true` to
     signal the loop must break. Returns `false` (no-op) before the cap or when
     the cap is `0` (no timeout configured).
-  - `awaitInFlightTasks(timeoutMs, hardDeadlineTS = this.hardDeadlineTS)` now caps
-    the effective wait at `max(0, hardDeadlineTS - Date.now())`, so the 30 s
-    default cannot overshoot the cap. `hardDeadlineTS = 0` disables the cap
+  - `awaitInFlightTasks(timeoutMs, hardDeadlineTS = this.hardDeadlineTS)` now
+    caps the effective wait at `max(0, hardDeadlineTS - Date.now())`, so the 30
+    s default cannot overshoot the cap. `hardDeadlineTS = 0` disables the cap
     (preserving prior behaviour for runs with no timeout).
 - **`src/creature/CreatureTraining.ts`** — in each of the three `completed`
   blocks, `neat.abandonInFlightPastHardDeadline(hardDeadlineMS)` is checked
@@ -61,15 +61,17 @@ flowchart TD
 
 ## Test Plan
 
-- **`test/NEAT/NeatHardDeadlineEnforcement.ts`** (new) — `abandonInFlightPastHardDeadline`:
+- **`test/NEAT/NeatHardDeadlineEnforcement.ts`** (new) —
+  `abandonInFlightPastHardDeadline`:
   - past deadline → returns `true` and both in-progress maps are emptied (no
     elapsed-time measurement; behavioural per #2888);
   - future deadline → returns `false`, bookkeeping untouched;
   - zero deadline → returns `false` (cap disabled), bookkeeping untouched.
 - **`test/NEAT/NeatAwaitInFlightTasks.ts`** (extended):
-  - a never-settling task with a past `hardDeadlineTS` returns immediately
-    (cap clamps the wait to 0) without abandoning the maps itself;
+  - a never-settling task with a past `hardDeadlineTS` returns immediately (cap
+    clamps the wait to 0) without abandoning the maps itself;
   - `hardDeadlineTS = 0` disables the cap so a soon-settling task still
     completes within the normal timeout.
-- **`test/NEAT/NeatFinishUp.ts`** — existing finish-up tests still pass unchanged.
+- **`test/NEAT/NeatFinishUp.ts`** — existing finish-up tests still pass
+  unchanged.
 - Full `./quality.sh` passes.

--- a/docs/archive/pr-summaries/pr-summary-2897.md
+++ b/docs/archive/pr-summaries/pr-summary-2897.md
@@ -1,12 +1,12 @@
 ## Summary
 
-Fixed the `evolve()` spread-push stack overflow at `src/NEAT/NeatEvolution.ts:688`.
-Spreading an unbounded `offspringBatch` into `newPopulation.push(...offspringBatch)`
-exceeds V8's argument/stack limit (~65k–130k elements) once the configured
-population size is large enough, throwing
-`RangeError: Maximum call stack size exceeded`. This crashed the "Run Suggest
-Improvements" example after bumping `@stsoftware/neat-ai` 5.3.15 → 5.3.19
-(stSoftwareAU/NEAT-AI-Examples#578).
+Fixed the `evolve()` spread-push stack overflow at
+`src/NEAT/NeatEvolution.ts:688`. Spreading an unbounded `offspringBatch` into
+`newPopulation.push(...offspringBatch)` exceeds V8's argument/stack limit
+(~65k–130k elements) once the configured population size is large enough,
+throwing `RangeError: Maximum call stack size exceeded`. This crashed the "Run
+Suggest Improvements" example after bumping `@stsoftware/neat-ai` 5.3.15 →
+5.3.19 (stSoftwareAU/NEAT-AI-Examples#578).
 
 The fix introduces a stack-safe in-place append helper
 (`src/utils/ArrayAppend.ts` → `appendAll<T>(target, items)`) that appends via a

--- a/docs/archive/pr-summaries/pr-summary-2897.md
+++ b/docs/archive/pr-summaries/pr-summary-2897.md
@@ -1,0 +1,56 @@
+## Summary
+
+Fixed the `evolve()` spread-push stack overflow at `src/NEAT/NeatEvolution.ts:688`.
+Spreading an unbounded `offspringBatch` into `newPopulation.push(...offspringBatch)`
+exceeds V8's argument/stack limit (~65k–130k elements) once the configured
+population size is large enough, throwing
+`RangeError: Maximum call stack size exceeded`. This crashed the "Run Suggest
+Improvements" example after bumping `@stsoftware/neat-ai` 5.3.15 → 5.3.19
+(stSoftwareAU/NEAT-AI-Examples#578).
+
+The fix introduces a stack-safe in-place append helper
+(`src/utils/ArrayAppend.ts` → `appendAll<T>(target, items)`) that appends via a
+plain indexed loop — no spread, no `push.apply` (same stack limit), no `concat`
+(would allocate a new array, but `newPopulation` is `const` and aliased/mutated
+later at lines 704 and 735). Population contents and ordering are unchanged:
+creative-thinking clones first, then offspring, exactly as before.
+
+Closes #2897.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. Verified via tests and
+the full quality gate.
+
+```mermaid
+flowchart LR
+    A[offspringBatch = await breedingPromise] --> B{append}
+    B -- "push(...offspringBatch)" --> C[RangeError at large size]
+    B -- "appendAll(newPopulation, offspringBatch)" --> D[Stack-safe indexed loop]
+    D --> E[Order + contents identical]
+```
+
+- `appendAll` uses an indexed loop, so each element is appended without placing
+  a per-element argument on the call stack — scales to any batch size.
+- Regression test `test/utils/ArrayAppend.ts` includes a **canary** assertion
+  (`assertThrows(() => target.push(...bigArray), RangeError)` at 200,000
+  primitive elements) proving the test size genuinely exceeds the engine's
+  spread limit, plus a **fix** assertion that `appendAll` appends the same batch
+  without throwing while preserving order, length, and the pre-existing front
+  element.
+- `./quality.sh < /dev/null` passes: `7062 passed | 0 failed | 4 ignored`,
+  exit 0. `test/NEAT/PhasePipelining.ts`, `test/NEAT/Evolve.ts`, and
+  `test/NEAT/NeatEvolve.ts` all pass.
+
+## Test Plan
+
+- Added `test/utils/ArrayAppend.ts`:
+  - happy path — appends in order after existing contents
+  - empty `items` — no-op
+  - empty `target` — receives all items in order
+  - large batch (≥200k) — canary `RangeError` for spread-push + `appendAll`
+    succeeds preserving order/length/front element (regression for #2897)
+- Ran `test/NEAT/PhasePipelining.ts` (the breeding/offspring pipeline) — passes.
+- Ran the full `./quality.sh` gate — passes cleanly.
+
+No changes to `semanticVersion` handling, neuron UUIDs, or any wire format.

--- a/docs/archive/pr-summaries/pr-summary-2898.md
+++ b/docs/archive/pr-summaries/pr-summary-2898.md
@@ -1,0 +1,75 @@
+## Summary
+
+Clamp every per-discovery deadline to the caller's absolute hard deadline
+(T+15) so no discovery phase can run past it regardless of worker-queue delay.
+Closes #2898.
+
+The #2432 allocation clamps the *relative* record+analysis budget at schedule
+time, but the worker re-anchors those budgets at `Date.now()` when it starts
+processing a request. Queue delays therefore silently shift the absolute
+completion time past the caller's deadline, and analysis-timeout extensions
+compound the drift (GRQ-18-sloth.log showed repeated extension cycles).
+
+This change passes the absolute deadline across the worker boundary and clamps
+every per-discovery deadline against it:
+
+- **`src/config/NeatArguments.ts`** — new optional internal field
+  `discoveryHardDeadlineTS?: number` (epoch ms). A plain number, so it crosses
+  `Worker.postMessage` in the per-call frozen config. Absent when no
+  `timeoutMinutes` is configured → behaviour unchanged.
+- **`src/NEAT/NeatScheduling.ts`** (`scheduleDiscovery`) — sets
+  `discoveryHardDeadlineTS` from `neat.hardDeadlineTS` in the per-call config
+  override (only when a hard deadline is configured). The #2432 relative
+  allocation stays as the phase-split mechanism.
+- **`src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts`**
+  - Constructor: `timeoutTS = min(now + recordBudget, discoveryHardDeadlineTS)`
+    — fixes the drift where a queued request anchors its relative budget at
+    start time, not schedule time.
+  - Record→analysis boundary (`extendTimeoutForAnalysisPhase`):
+    `analysisDeadlineAt = min(now + analysisBudget, discoveryHardDeadlineTS)`.
+  - `refreshAnalysisTimeout`: re-supplies the cap so top-ups never overshoot it.
+- **`src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts`**
+  (`extendTimeoutForAnalysis`) — accepts and remembers the hard cap and never
+  sets `timeoutTS` past it. Once past the cap the computed remaining budget is
+  ≤ 0, so the analysis loop's existing per-chunk checks exit — delivering
+  "extensions clamped to the T+15 cap, at most one further extension once past
+  T". Added a public `getTimeoutTS()` accessor.
+
+The recording-loop checks (`DataRecorderRecording.ts` via `ctx.timeoutTS`) and
+analysis per-chunk checks (`DataRecorderAnalysis.ts` via `getTimeoutTS()`)
+inherit the clamp once the sources are clamped — no change needed there, proven
+by regression tests.
+
+## Evidence
+
+Backend/worker change — no UI to screenshot. Verified by unit tests and the
+full quality gate (`./quality.sh`): **7101 passed, 0 failed, 4 ignored**.
+
+```mermaid
+flowchart LR
+    A[scheduleDiscovery<br/>absolute discoveryHardDeadlineTS] --> B[Worker queue<br/>delay no longer shifts cap]
+    B --> C[DataRecorder recording<br/>timeoutTS clamped]
+    C --> D[Analysis extension<br/>analysisDeadlineAt clamped]
+    D --> E[refreshAnalysisTimeout<br/>never past cap]
+```
+
+## Test Plan
+
+New regression suite
+`test/ErrorGuidedStructuralEvolution/DiscoveryHardDeadlineClamp.ts` (injected
+timestamps, no real waiting — #2888 policy):
+
+- DataRecorder constructor clamps recording `timeoutTS` to a near-future cap.
+- DataRecorder constructor clamps `timeoutTS` to an already-past cap (request
+  whose hard deadline elapsed in the queue).
+- DataRecorder leaves `timeoutTS` unclamped when no hard deadline is configured.
+- `extendTimeoutForAnalysisPhase` clamps `analysisDeadlineAt`, `timeoutTS`, and
+  the DiscoverStructure deadline to the cap.
+- `refreshAnalysisTimeout` never moves the deadline past the cap.
+- `DiscoverStructure.extendTimeoutForAnalysis` clamps to a supplied cap.
+- `extendTimeoutForAnalysis` remembers the cap for later top-ups.
+- `extendTimeoutForAnalysis` is unchanged when no cap is supplied.
+
+Existing discovery/analysis suites
+(`DiscoverAnalysisPerChunkTimeout`, `NeuronDiscoveryIntegration`, `HardDeadline`,
+`NeatConstruction`) continue to pass, confirming no behaviour change.

--- a/docs/archive/pr-summaries/pr-summary-2898.md
+++ b/docs/archive/pr-summaries/pr-summary-2898.md
@@ -1,10 +1,10 @@
 ## Summary
 
-Clamp every per-discovery deadline to the caller's absolute hard deadline
-(T+15) so no discovery phase can run past it regardless of worker-queue delay.
-Closes #2898.
+Clamp every per-discovery deadline to the caller's absolute hard deadline (T+15)
+so no discovery phase can run past it regardless of worker-queue delay. Closes
+#2898.
 
-The #2432 allocation clamps the *relative* record+analysis budget at schedule
+The #2432 allocation clamps the _relative_ record+analysis budget at schedule
 time, but the worker re-anchors those budgets at `Date.now()` when it starts
 processing a request. Queue delays therefore silently shift the absolute
 completion time past the caller's deadline, and analysis-timeout extensions
@@ -30,8 +30,8 @@ every per-discovery deadline against it:
   - `refreshAnalysisTimeout`: re-supplies the cap so top-ups never overshoot it.
 - **`src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts`**
   (`extendTimeoutForAnalysis`) — accepts and remembers the hard cap and never
-  sets `timeoutTS` past it. Once past the cap the computed remaining budget is
-  ≤ 0, so the analysis loop's existing per-chunk checks exit — delivering
+  sets `timeoutTS` past it. Once past the cap the computed remaining budget is ≤
+  0, so the analysis loop's existing per-chunk checks exit — delivering
   "extensions clamped to the T+15 cap, at most one further extension once past
   T". Added a public `getTimeoutTS()` accessor.
 
@@ -42,8 +42,8 @@ by regression tests.
 
 ## Evidence
 
-Backend/worker change — no UI to screenshot. Verified by unit tests and the
-full quality gate (`./quality.sh`): **7101 passed, 0 failed, 4 ignored**.
+Backend/worker change — no UI to screenshot. Verified by unit tests and the full
+quality gate (`./quality.sh`): **7101 passed, 0 failed, 4 ignored**.
 
 ```mermaid
 flowchart LR
@@ -70,6 +70,6 @@ timestamps, no real waiting — #2888 policy):
 - `extendTimeoutForAnalysis` remembers the cap for later top-ups.
 - `extendTimeoutForAnalysis` is unchanged when no cap is supplied.
 
-Existing discovery/analysis suites
-(`DiscoverAnalysisPerChunkTimeout`, `NeuronDiscoveryIntegration`, `HardDeadline`,
-`NeatConstruction`) continue to pass, confirming no behaviour change.
+Existing discovery/analysis suites (`DiscoverAnalysisPerChunkTimeout`,
+`NeuronDiscoveryIntegration`, `HardDeadline`, `NeatConstruction`) continue to
+pass, confirming no behaviour change.

--- a/docs/archive/pr-summaries/pr-summary-2899.md
+++ b/docs/archive/pr-summaries/pr-summary-2899.md
@@ -1,0 +1,70 @@
+## Summary
+
+Clamp scheduled fine-tuning tasks to the absolute hard deadline so worker-side
+training stops at the run's wall-clock deadline even when the task sat in the
+worker queue after being scheduled with a relative `trainingTimeOutMinutes`
+budget. Closes #2899.
+
+Previously `timeoutTS` was computed from `Date.now()` plus the relative budget
+when the worker dequeued the task. A task that waited in the queue therefore got
+its full relative budget anchored at dequeue time, drifting past the run's
+intended end (`GRQ-19-sloth.log` showed `Fine tuning increased fitness…` lines
+continuing right up to the watchdog kill). This change carries the absolute
+`hardDeadlineTS` (epoch ms) with each scheduled task and clamps the relative
+budget against it.
+
+### Changes
+
+- **`src/config/TrainOptions.ts`** — add optional `hardDeadlineTS?: number`
+  (plain number — survives `Worker.postMessage`).
+- **`src/NEAT/NeatScheduling.ts`** — `scheduleTraining` sets `hardDeadlineTS`
+  from `neat.hardDeadlineTS` (left absent when `0`, so behaviour is unchanged).
+- **`src/architecture/training/TrainingSetup.ts`** — plumb `hardDeadlineTS`
+  through `TrainingSetupState` and `prepareTraining`.
+- **`src/architecture/training/TrainingOutcome.ts`** — extract a pure,
+  `now`-injectable
+  `computeTimeoutTS(now, trainingTimeOutMinutes,
+  hardDeadlineTS)` helper that
+  clamps to `min(now + minutes, hardDeadlineTS)`; `createEpochState` calls it
+  with `Date.now()`.
+
+When `hardDeadlineTS` is absent (direct `creature.train()` callers), the
+computation is identical to before. A hard deadline already in the past is
+returned verbatim, so the existing per-iteration timeout check
+(`TrainingEpoch.ts`) trips on the next check and returns the best-so-far result.
+
+### Flow
+
+```mermaid
+flowchart LR
+    Neat["neat.hardDeadlineTS<br/>(absolute T+15)"] -->|scheduleTraining| TO[TrainOptions.hardDeadlineTS]
+    TO -->|postMessage| W[worker]
+    W -->|prepareTraining| SS[TrainingSetupState.hardDeadlineTS]
+    SS -->|createEpochState| C["computeTimeoutTS()"]
+    Rel["now + trainingTimeOutMinutes"] --> C
+    C -->|"min(relative, hard)"| TS[EpochState.timeoutTS]
+    TS --> Check["per-iteration timeout check"]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via unit tests
+(injected timestamps, no elapsed-time assertions per #2888) and the full
+`./quality.sh` suite (7100 tests pass; a transient unrelated breed flake
+`SyntheticLocationE2E` passed on re-run and is unaffected by these changes).
+
+## Test Plan
+
+- `test/architecture/training/TrainingOutcome.ts` (new) — `computeTimeoutTS`:
+  - clamps to an earlier hard deadline (15 min budget, 5 min deadline →
+    deadline)
+  - absent / `undefined` / `0` hard deadline reproduces the pre-#2899 relative
+    computation exactly
+  - keeps the relative budget when it is the earlier limit
+  - no relative budget falls back to the hard deadline
+  - no budget and no deadline → `0` (no timeout)
+  - hard deadline already in the past is returned verbatim (per-iteration check
+    then exits promptly)
+- `test/architecture/training/TrainingSetup.ts` — added a case asserting
+  `prepareTraining` carries `hardDeadlineTS` through, and that it stays
+  `undefined` when absent.

--- a/docs/archive/pr-summaries/pr-summary-2900.md
+++ b/docs/archive/pr-summaries/pr-summary-2900.md
@@ -1,0 +1,132 @@
+# Audit spread-into-arguments call sites and fix unbounded ones
+
+## Summary
+
+Swept `src/` for every spread-into-call-arguments site, verified the runtime
+bound of each by reading the upstream code, and replaced the genuinely
+**unbounded** ones with the stack-safe `appendAll` helper from #2897 (plus a new
+`insertAll` helper for the one unbounded `splice` insertion). This closes the
+`RangeError: Maximum call stack size exceeded` regression class fixed at
+`NeatEvolution.ts:688` so no other code path can reproduce it. Bounded sites
+(fixed constants, CPU/thread count, small config caps) are left untouched and
+documented below. Every change is behaviour-preserving — the order and contents
+of each affected array are identical to before.
+
+Closes #2900.
+
+### New helper
+
+`insertAll(target, index, items)` was added to `src/utils/ArrayAppend.ts`
+alongside the existing `appendAll`. It performs a stack-safe in-place insertion
+(detach tail → indexed-append items → indexed-append tail) that is
+behaviour-identical to `target.splice(index, 0, ...items)` but never spreads
+`items` into call arguments.
+
+### Corrections to the issue's initial classification
+
+The issue's first-pass verdicts were explicitly a "head start — verify, do not
+trust blindly". Verification surfaced four corrections:
+
+- **`FineTunePopulation.ts:218,255` were mislabelled bounded** ("loop bound
+  12"). The `for (… attempts < 12 …)` loop bounds the _iteration count_, not the
+  _spread size_. Each iteration spreads `extendedTunedPopulation`, sized up to
+  `fineTunePopSize` = `max(ceil(populationSize/5), …)`, which scales with the
+  configured population size → **unbounded. Fixed.**
+- **`FineTunePopulation.ts:162` is actually bounded ≤2**, not unbounded.
+  `retry()` returns `fineTuneImprovement(…, 2, …)`, which caps its output at
+  `popSize=2`; the "scales with `genus.population`" reasoning conflated the
+  _input_ population with the bounded _output_. Converted anyway for consistency
+  (it appends into the same population-scaled array as the genuinely-unbounded
+  sites) and because the acceptance criteria name it.
+- **`DiscoverStructureRecording.ts:114` / `DiscoverDataLoading.ts:118` were
+  mislabelled bounded** ("slice(0,64) cap"). The 64-sample cap only applies to
+  the timeout _grace_ path. The normal path spreads a batch sized by
+  `discoveryBatchSize` (config, default 128, **no upper cap**) / the dataset
+  record count → **unbounded. Fixed.**
+- **The single-line sweep regex missed multi-line `push(\n  ...builder())`
+  spreads** in `DiscoveryCandidates.ts` (lines 234, 245, 270, 310, 332, 341). A
+  multi-line re-sweep found six more candidate-list spreads that scale with
+  discovery results → **fixed.**
+
+## Full classification of every spread-into-arguments site in `src/`
+
+### Fixed — confirmed unbounded → stack-safe
+
+| Site                                                               | Spread value              | Verified bound                                      | Fix         |
+| ------------------------------------------------------------------ | ------------------------- | --------------------------------------------------- | ----------- |
+| `blackbox/FineTunePopulation.ts:153`                               | `restoredTunedPopulation` | ≤2 alone, but appended into population-scaled array | `appendAll` |
+| `blackbox/FineTunePopulation.ts:162`                               | `retryPopulation`         | ≤2 alone (see correction); same array               | `appendAll` |
+| `blackbox/FineTunePopulation.ts:218`                               | `extendedTunedPopulation` | ≤ `fineTunePopSize` ∝ `populationSize/5`            | `appendAll` |
+| `blackbox/FineTunePopulation.ts:255`                               | `extendedTunedPopulation` | ≤ `fineTunePopSize` ∝ `populationSize/5`            | `appendAll` |
+| `discovery/DiscoveryWireFormat.ts:335`                             | `current` (array node)    | creature wire payload synapse/neuron array          | `appendAll` |
+| `discovery/DiscoveryCandidates.ts:234,245,270,291,306,310,332,341` | candidate-builder results | scale with neuron/synapse/discovery counts          | `appendAll` |
+| `discovery/CandidateApplicationOps.ts:64,199,334,435`              | `newSynapses` / `toAdd`   | candidate synapse (connection) count                | `appendAll` |
+| `discovery/CandidateApplicationOps.ts:165`                         | `remaining` neurons       | candidate hidden-neuron count                       | `insertAll` |
+| `architecture/…/DiscoverStructureRecording.ts:114`                 | `effectiveRecordIndices`  | ≤ `discoveryBatchSize` (config, no max)             | `appendAll` |
+| `architecture/…/DiscoverDataLoading.ts:118`                        | `fileRecords`             | dataset record count per binary file                | `appendAll` |
+
+### Left as-is — confirmed bounded
+
+| Site                                          | Spread value                    | Verified bound                                                                                                |
+| --------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `discovery/BrittlenessScorer.ts:169`          | `Math.max(...allOutputChanges)` | ≤ `maxSamples`(50) × `perturbationsPerInput`(default 5)                                                       |
+| `discovery/BatchDiscoveryValidator.ts:95,117` | structural/weight-only results  | input candidate list pre-capped upstream by `filterCandidatesForEvaluation` (`maxCandidates ≈ 2×threadCount`) |
+| `discovery/CandidateFiltering.ts:240`         | `sampled`                       | ≤ `maxCandidates` = `max(2×threadCount, categoryCount)`                                                       |
+| `discovery/DiscoveryReplayRunner.ts:141`      | `pool`                          | worker count = thread / replay concurrency (≈ CPU cores)                                                      |
+| `transfer/KnowledgeDistillation.ts:163`       | `studentExports` (splice)       | ≤ `MAX_STUDENT_NEURONS` (64)                                                                                  |
+| `transfer/CompactModuleGraft.ts:364`          | `inserted` (splice)             | ≤ module max size (32)                                                                                        |
+| `breed/SubgraphTransplant.ts:283`             | `transplantedNeurons` (splice)  | ≤ `MAX_SUBGRAPH_SIZE` (5)                                                                                     |
+
+Array-literal spreads (`[...a, ...b]`, e.g. `NeatEvolution.ts:731–737`) are
+iterative in V8 and out of scope — untouched.
+
+## Evidence
+
+This is a backend/library change with no web interface to screenshot. Coverage
+is via the test suite (`./quality.sh < /dev/null` passes the full gate). The
+regression class is proven by crash-canary tests: each large-batch test first
+asserts the _original_ spread throws `RangeError` at the chosen size, then
+asserts the stack-safe path succeeds with identical contents and order.
+
+```mermaid
+flowchart TD
+    S[Sweep src/ for spread-into-arguments<br/>single-line + multi-line] --> C{Spread arg bounded<br/>at run time?}
+    C -- "unbounded (population /<br/>synapses / records / candidates)" --> F[appendAll / insertAll]
+    C -- "bounded (constant,<br/>CPU count, small config cap)" --> L[Leave as-is, record bound]
+    F --> T[Crash-canary regression test]
+```
+
+### A note on the `FineTunePopulation` large-scale test
+
+Driving a genuine 65k+ spread through `FindTunePopulation.make()` is impractical
+for a unit test — it would need hundreds of thousands of scored,
+species-assigned creatures plus the heavy per-creature fine-tuning compute, far
+exceeding the 120s unit-test budget. The regression is instead covered by
+testing the exact operation the fixed lines now perform (appending a large
+`Creature[]` batch into the population array via `appendAll`, with a crash
+canary), plus a genuine wide-array behavioural test on the
+`assertNoLegacyDiscoveryIdFields` traversal (a fixed unbounded call site).
+
+## Test Plan
+
+- `test/utils/ArrayAppend.ts` — added `insertAll` happy-path, in-place-mutation,
+  empty, clamp, and large-batch (#2900) regression tests with a `splice` crash
+  canary. Existing `appendAll` tests retained.
+- `test/discovery/DiscoveryWireFormatStackSafe.ts` (new) — exercises the fixed
+  `assertNoLegacyDiscoveryIdFields` traversal: clean payload,
+  leaked-legacy-field detection, a 200k-wide array traversed without
+  `RangeError` (with a `push(...)` canary), legacy detection inside a wide
+  array, and nested array/object ordering.
+- `test/blackbox/FineTunePopulationStackSafe.ts` (new) — appends a 200k
+  `Creature[]` batch into a population array via `appendAll` without
+  `RangeError` (with a canary), and verifies small-batch order/contents.
+
+Run:
+
+```bash
+deno test --allow-all \
+  test/utils/ArrayAppend.ts \
+  test/discovery/DiscoveryWireFormatStackSafe.ts \
+  test/blackbox/FineTunePopulationStackSafe.ts < /dev/null
+# 16 passed | 0 failed
+```

--- a/docs/archive/pr-summaries/pr-summary-2901.md
+++ b/docs/archive/pr-summaries/pr-summary-2901.md
@@ -14,8 +14,8 @@ Closes #2901.
 ### What changed
 
 - **`src/NEAT/DiscoveryReplayQueue.ts`**
-  - New `DiscoveryReplayControl` (`{ deadlineTS?, signal? }`) plumbed through the
-    `replayDir` dependency.
+  - New `DiscoveryReplayControl` (`{ deadlineTS?, signal? }`) plumbed through
+    the `replayDir` dependency.
   - `waitForCompletion(hardDeadlineTS?)` — once the current time is past the cap
     it drops `#queuedCreature`, aborts the in-flight replay via an
     `AbortController`, and returns without awaiting. A `0`/`undefined` cap means
@@ -44,8 +44,8 @@ exactly as before.
 
 Backend/CLI change — no UI to screenshot. Verified via new behavioural unit
 tests (injected timestamps and a pre-aborted signal — no elapsed-time
-measurement, per the #2888 policy) and the full quality gate
-(`./quality.sh`: `7112 passed | 0 failed`).
+measurement, per the #2888 policy) and the full quality gate (`./quality.sh`:
+`7112 passed | 0 failed`).
 
 ```mermaid
 sequenceDiagram

--- a/docs/archive/pr-summaries/pr-summary-2901.md
+++ b/docs/archive/pr-summaries/pr-summary-2901.md
@@ -1,0 +1,85 @@
+# Bound discovery replay queue waits and replays to the hard deadline
+
+## Summary
+
+Made `DiscoveryReplayQueue` deadline-aware so a configured `--timeout` run can
+no longer be held past its hard cap by background replay. `waitForCompletion()`
+now stops waiting at the absolute cap, queued replays past the cap are dropped,
+and in-flight replays receive an **absolute** deadline (immune to
+worker-queue/start delays) plus a cooperative abort signal. Uncapped runs keep
+the unbounded wait, preserving the Issue #1509 guarantee.
+
+Closes #2901.
+
+### What changed
+
+- **`src/NEAT/DiscoveryReplayQueue.ts`**
+  - New `DiscoveryReplayControl` (`{ deadlineTS?, signal? }`) plumbed through the
+    `replayDir` dependency.
+  - `waitForCompletion(hardDeadlineTS?)` — once the current time is past the cap
+    it drops `#queuedCreature`, aborts the in-flight replay via an
+    `AbortController`, and returns without awaiting. A `0`/`undefined` cap means
+    unbounded (the #1509 path).
+  - `scheduleReplay(..., hardDeadlineTS?)` — skips scheduling when already past
+    the cap; otherwise carries the cap into the queued entry.
+  - `#startReplay` — passes an absolute deadline of
+    `min(now + effectiveTimeout, hardDeadlineTS)` and the abort signal to the
+    runner.
+- **`src/discovery/DiscoveryReplayRunner.ts` / `DiscoveryReplayRunnerTypes.ts`**
+  - `replayDir` accepts an absolute `deadlineTS` and an abort `signal`. The
+    relative `timeoutMinutes` is still converted at start, but when an absolute
+    `deadlineTS` is supplied the runner clamps to the earlier of the two, so a
+    late start cannot extend the cap. `isTimedOut()` now also returns `true`
+    when the signal is aborted — the existing per-candidate-boundary checks then
+    stop the replay with no further candidate evaluation (no further
+    data-directory reads).
+- **`src/creature/CreatureTraining.ts`** — the three evolve variants
+  (`evolveDir`, `evolveEnv`, `evolveRL`) pass `hardDeadlineMS || undefined` to
+  `waitForCompletion`, so only a configured timeout introduces the bounded wait.
+
+Existing `scheduleReplay`/`waitForCompletion` callers without a cap behave
+exactly as before.
+
+## Evidence
+
+Backend/CLI change — no UI to screenshot. Verified via new behavioural unit
+tests (injected timestamps and a pre-aborted signal — no elapsed-time
+measurement, per the #2888 policy) and the full quality gate
+(`./quality.sh`: `7112 passed | 0 failed`).
+
+```mermaid
+sequenceDiagram
+    participant E as evolve* (CreatureTraining)
+    participant Q as DiscoveryReplayQueue
+    participant R as DiscoveryReplayRunner
+    E->>Q: waitForCompletion(hardDeadlineMS || undefined)
+    alt now >= hard cap
+        Q->>Q: drop #queuedCreature
+        Q-->>R: abort signal
+        Q-->>E: return (no further await)
+        R->>R: next candidate boundary -> stop (no more reads)
+    else within cap / uncapped
+        Q->>R: await in-flight + queued replays
+        Q-->>E: return when drained (#1509)
+    end
+```
+
+## Test Plan
+
+- `test/NEAT/DiscoveryReplayQueueDeadline.ts` (new):
+  - past-cap `waitForCompletion` drops the queued replay and aborts the
+    in-flight one;
+  - `scheduleReplay` skips scheduling once past the cap;
+  - `#startReplay` passes the absolute hard cap to the runner;
+  - zero cap waits unbounded (preserves #1509).
+- `test/discovery/DiscoveryReplayRunnerDeadline.ts` (new):
+  - absolute deadline earlier than `now + timeoutMinutes` wins and stops
+    evaluation;
+  - a pre-aborted signal stops the runner at the candidate boundary with no
+    evaluation;
+  - a far-future deadline completes normally.
+- Existing `test/NEAT/DiscoveryReplayQueue.ts`,
+  `test/NEAT/DiscoveryReplayQueueCompletion.ts`,
+  `test/NEAT/DiscoveryReplayIntegration.ts`,
+  `test/NEAT/DiscoveryReplayWarmup.ts`, and
+  `test/discovery/DiscoveryReplayRunner.ts` all pass unchanged.

--- a/docs/archive/pr-summaries/pr-summary-2902.md
+++ b/docs/archive/pr-summaries/pr-summary-2902.md
@@ -1,0 +1,89 @@
+# End-to-end T+15 guard test and timeout-semantics documentation
+
+## Summary
+
+This is the acceptance gate for the parent timeout milestone (#2892): it proves,
+end-to-end, that `evolveDir(timeoutMinutes = T)` returns with consistent state
+once the absolute **T+15** hard cap passes — even with slow / never-resolving
+in-flight discovery and training — and documents the timeout semantics. The
+enforcement itself was delivered by the dependency sub-issues (#2895, #2896,
+#2898, #2899, #2901); this change adds the integration-level guard and the docs.
+**Closes #2902.**
+
+What changed:
+
+- **Integration guard** `test/creature/EvolveDirHardDeadline.ts` — drives a real
+  `evolveDir` run with a tiny `timeoutMinutes` and stubbed never-resolving
+  in-flight work, with the cap placed in the past via an injected start
+  timestamp, and asserts behaviour (not durations): the run returns, the best
+  creature is loaded onto the caller's creature, `creatureStore` is written and
+  loadable, and the in-flight maps are empty. Covers a training-mode run and a
+  discovery-mode run (discovery stubbed — no Rust FFI in CI).
+- **Test-only seam** on `evolveDir` (`EvolveDirDeps`) — an optional 4th `deps?`
+  parameter (`startTimeMS`, `onNeatReady`), consistent with the existing `deps?`
+  seams on `discoveryDir` / `discoveryReplayDir`. Lets the guard drive the cap
+  deterministically without real sleeps (policy #2888). Production callers omit
+  `deps`; the defaults reproduce the prior behaviour exactly.
+- **`docs/TIMEOUTS.md`** (new) — `timeoutMinutes` semantics, the
+  `T + min(15, T)` hard cap, what each phase does at the cap (abandon in-flight,
+  keep partial results, return best creature), a Mermaid sequence diagram of
+  deadline propagation
+  (`evolveDir → Neat → scheduleDiscovery / scheduleTraining / replay
+  queue → worker clamps`),
+  and the unchanged external-watchdog backstop. Linked from `docs/README.md` and
+  the AGENTS.md doc index.
+- **`CHANGELOG.md`** — Unreleased entry describing the guarantee (a
+  `--timeout=45` run completes within the hour, in time for the caller's normal
+  save / check-in) and noting the external watchdog (GRQ's 3-hour
+  `max-task-hours`) remains the unchanged backstop.
+
+## Evidence
+
+Backend / CLI change — no web interface to screenshot. Verified via the new
+integration test, the existing NEAT suite (771 passed), and the full
+config-driven `deno test` run (exit 0, no failures), plus
+`./quality.sh --lint-only` and `./quality.sh --check-only` (both pass).
+
+### Regression linkage (acceptance criterion)
+
+The guard fails against the pre-#2896 behaviour and passes with the hard-cap
+enforcement in place. The hard-cap branch
+(`Neat.abandonInFlightPastHardDeadline`) breaks on the **first** completed
+cycle, so the run returns at exactly `generation === 1`. With the branch
+neutered, the finish-up cycle can only clear the stuck task and then spin
+through further evolve() generations before stopping, so the run reaches
+`generation` 2+ and the `result.generation === 1` assertion fails. This was
+verified empirically by temporarily neutering `abandonInFlightPastHardDeadline`
+(both tests then failed on that assertion) and restoring it (both pass). The
+assertion is behavioural — a return value, never an elapsed-time measurement
+(#2888).
+
+### Deadline propagation
+
+```mermaid
+flowchart LR
+    E["evolveDir<br/>(timeoutMinutes = T)"] --> N["Neat.hardDeadlineTS<br/>= start + (T + min(15,T))·60s"]
+    N --> D[scheduleDiscovery]
+    N --> Tr[scheduleTraining]
+    N --> R[discoveryReplayQueue]
+    D --> W[worker clamps per-task deadline]
+    Tr --> W
+    R --> W
+    N --> A{"past hard cap?"}
+    A -->|yes| B["abandon in-flight,<br/>keep partial results,<br/>load best, write store, return"]
+```
+
+## Test Plan
+
+- **Added** `test/creature/EvolveDirHardDeadline.ts`:
+  - `training-mode run returns once the hard cap passes` — never-resolving
+    training stub; asserts return at `generation === 1`, finite score/error,
+    loaded best creature activates + round-trips, in-flight maps empty, no
+    replay wedged, `creatureStore` written and every persisted creature
+    loadable.
+  - `discovery-mode run (stubbed) returns once the hard cap passes` — same, with
+    a never-resolving discovery stub (no Rust FFI).
+- **Verified** the guard depends on #2896 by temporarily neutering the hard-cap
+  branch (both tests fail on `result.generation === 1`) and restoring it.
+- `./quality.sh --lint-only` and `--check-only` pass; full `deno test` passes;
+  `test/NEAT/*` (771 tests) pass.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -16,6 +16,7 @@
     "Alammar",
     "Attn",
     "arities",
+    "deadln",
     "deepseek",
     "Distill",
     "distill",

--- a/src/NEAT/DiscoveryReplayQueue.ts
+++ b/src/NEAT/DiscoveryReplayQueue.ts
@@ -28,6 +28,22 @@ export interface DiscoveryReplayWarmupContext {
 }
 
 /**
+ * Cooperative control for an in-flight replay (Issue #2901).
+ *
+ * Carries the absolute deadline and abort signal so a replay can be bounded to
+ * the evolution hard cap rather than a start-anchored relative budget.
+ */
+export interface DiscoveryReplayControl {
+  /**
+   * Absolute wall-clock deadline (ms since epoch). Replay stops at its next
+   * candidate-boundary check once this passes.
+   */
+  deadlineTS?: number;
+  /** Cooperative abort signal — when aborted, replay stops at the next boundary. */
+  signal?: AbortSignal;
+}
+
+/**
  * Dependencies for the DiscoveryReplayQueue.
  * These can be injected for testing purposes.
  */
@@ -40,12 +56,14 @@ export interface DiscoveryReplayQueueDeps {
    * @param dataDir The data directory containing training data
    * @param options NEAT options
    * @param timeoutMinutes Optional timeout in minutes (0 or undefined = no timeout)
+   * @param control Optional absolute deadline / abort signal (Issue #2901)
    */
   replayDir?: (
     creature: Creature,
     dataDir: string,
     options: NeatOptions,
     timeoutMinutes?: number,
+    control?: DiscoveryReplayControl,
   ) => Promise<DiscoveryReplayDirResult>;
 }
 
@@ -68,9 +86,13 @@ export class DiscoveryReplayQueue {
     dataDir: string;
     options: NeatOptions;
     timeoutMinutes?: number;
+    hardDeadlineTS?: number;
   } | null = null;
   #completedResults: DiscoveryReplayDirResult[] = [];
   #currentPromise: Promise<void> | null = null;
+  // Issue #2901: abort controller for the in-flight replay, so the queue can
+  // cooperatively signal it to stop when the evolution hard cap is reached.
+  #currentAbort: AbortController | null = null;
 
   constructor(deps: DiscoveryReplayQueueDeps = {}) {
     this.#deps = {
@@ -91,6 +113,7 @@ export class DiscoveryReplayQueue {
     dataDir: string,
     options: NeatOptions,
     timeoutMinutes?: number,
+    control?: DiscoveryReplayControl,
   ): Promise<DiscoveryReplayDirResult> {
     const runner = new DiscoveryReplayRunner();
     return await runner.replayDir({
@@ -98,6 +121,8 @@ export class DiscoveryReplayQueue {
       dataDir,
       options,
       timeoutMinutes,
+      deadlineTS: control?.deadlineTS,
+      signal: control?.signal,
     });
   }
 
@@ -116,6 +141,10 @@ export class DiscoveryReplayQueue {
    *        If provided, replay timeout is capped to this value.
    * @param warmupContext Optional Neat-level seed warm-up context. When
    *        supplied and the lock is active, replay is skipped (Issue #2910).
+   * @param hardDeadlineTS Optional absolute wall-clock hard cap (ms since
+   *        epoch, Issue #2901). When supplied and already passed, scheduling is
+   *        skipped. Otherwise it bounds the in-flight replay's absolute
+   *        deadline to `min(now + effectiveTimeout, hardDeadlineTS)`.
    */
   scheduleReplay(
     creature: Creature,
@@ -123,6 +152,7 @@ export class DiscoveryReplayQueue {
     options: NeatOptions,
     remainingTimeMinutes?: number,
     warmupContext?: DiscoveryReplayWarmupContext,
+    hardDeadlineTS?: number,
   ): void {
     // Issue #2828/#2910: never replay cached structural discoveries while the
     // seed warm-up structural lock is active — replay can prune or rewire
@@ -137,6 +167,12 @@ export class DiscoveryReplayQueue {
         warmupContext.currentGeneration,
       )
     ) {
+      return;
+    }
+
+    // Issue #2901: skip scheduling entirely once past the absolute hard cap.
+    // A replay started now could only run past the deadline.
+    if (hardDeadlineTS !== undefined && Date.now() >= hardDeadlineTS) {
       return;
     }
 
@@ -183,6 +219,7 @@ export class DiscoveryReplayQueue {
         dataDir,
         options,
         timeoutMinutes: effectiveTimeout,
+        hardDeadlineTS,
       };
       return;
     }
@@ -193,6 +230,7 @@ export class DiscoveryReplayQueue {
       dataDir,
       options,
       effectiveTimeout,
+      hardDeadlineTS,
     );
   }
 
@@ -203,20 +241,39 @@ export class DiscoveryReplayQueue {
    * @param dataDir The data directory containing training data
    * @param options NEAT options
    * @param timeoutMinutes Optional timeout in minutes
+   * @param hardDeadlineTS Optional absolute hard cap (ms since epoch). The
+   *        replay's absolute deadline is `min(now + effectiveTimeout,
+   *        hardDeadlineTS)` (Issue #2901).
    */
   #startReplay(
     creature: Creature,
     dataDir: string,
     options: NeatOptions,
     timeoutMinutes?: number,
+    hardDeadlineTS?: number,
   ): void {
     this.#replayInProgress = true;
+
+    // Issue #2901: derive an absolute deadline so worker-queue/start delays
+    // cannot shift the cap, and wire a cooperative abort signal so
+    // waitForCompletion() can abandon this replay at the hard cap.
+    const abortController = new AbortController();
+    this.#currentAbort = abortController;
+
+    const timeoutDeadlineTS = timeoutMinutes !== undefined && timeoutMinutes > 0
+      ? Date.now() + timeoutMinutes * 60 * 1000
+      : undefined;
+    const deadlineTS =
+      timeoutDeadlineTS !== undefined && hardDeadlineTS !== undefined
+        ? Math.min(timeoutDeadlineTS, hardDeadlineTS)
+        : timeoutDeadlineTS ?? hardDeadlineTS;
 
     this.#currentPromise = this.#deps.replayDir!(
       creature,
       dataDir,
       options,
       timeoutMinutes,
+      { deadlineTS, signal: abortController.signal },
     )
       .then((result) => {
         this.#completedResults.push(result);
@@ -227,6 +284,7 @@ export class DiscoveryReplayQueue {
       .finally(() => {
         this.#replayInProgress = false;
         this.#currentPromise = null;
+        this.#currentAbort = null;
 
         // Process the next queued creature if any
         if (this.#queuedCreature) {
@@ -237,6 +295,7 @@ export class DiscoveryReplayQueue {
             queued.dataDir,
             queued.options,
             queued.timeoutMinutes,
+            queued.hardDeadlineTS,
           );
         }
       });
@@ -267,10 +326,26 @@ export class DiscoveryReplayQueue {
   /**
    * Wait for any in-progress replay to complete.
    * Useful for testing and graceful shutdown.
+   *
+   * @param hardDeadlineTS Optional absolute wall-clock hard cap (ms since
+   *        epoch, Issue #2901). Once the current time is past this cap, the
+   *        wait is abandoned: any queued replay is dropped and the in-flight
+   *        replay is signalled to abort cooperatively. The method then returns
+   *        without awaiting further work. When omitted (or `<= 0`) the wait is
+   *        unbounded, preserving the Issue #1509 guarantee for uncapped runs.
    */
-  async waitForCompletion(): Promise<void> {
+  async waitForCompletion(hardDeadlineTS?: number): Promise<void> {
+    const capped = hardDeadlineTS !== undefined && hardDeadlineTS > 0;
     // Collect all promises to wait for rather than awaiting in loop
     while (this.#currentPromise || this.#queuedCreature) {
+      // Issue #2901: stop waiting at the hard cap. Drop the queued replay so it
+      // never starts, signal the in-flight replay to abort, and return without
+      // awaiting — the abandoned replay stops at its next candidate boundary.
+      if (capped && Date.now() >= hardDeadlineTS!) {
+        this.#queuedCreature = null;
+        this.#currentAbort?.abort();
+        return;
+      }
       const promiseToWait = this.#currentPromise;
       if (promiseToWait) {
         // deno-lint-ignore no-await-in-loop

--- a/src/NEAT/HardDeadline.ts
+++ b/src/NEAT/HardDeadline.ts
@@ -1,0 +1,46 @@
+/**
+ * Hard-deadline (T+15) helper — Issue #2895, part of #2892.
+ *
+ * A single source of truth for the evolution hard cap: the absolute wall-clock
+ * timestamp past which `evolveDir` must abandon all in-flight work. Discovery,
+ * training and replay phases each anchor their own relative budgets at task
+ * start with no shared absolute cap, so GRQ runs configured with a short
+ * `--timeout` can still be killed by the external watchdog. This module
+ * computes a shared cap that later sub-issues enforce in each phase.
+ *
+ * The helper is pure — absolute timestamps in, absolute timestamps out — so
+ * tests need no real clock (policy from #2888).
+ */
+
+/** The maximum permitted overrun, in minutes, past the configured `timeoutMinutes`. */
+export const HARD_DEADLINE_GRACE_MINUTES = 15;
+
+/**
+ * Compute the absolute hard-deadline timestamp.
+ *
+ * Returns `startMS + timeoutMinutes * 60_000 + graceMS`, where the grace period
+ * is clamped to `min(HARD_DEADLINE_GRACE_MINUTES, max(1, timeoutMinutes))`
+ * minutes. Clamping grace to `min(15, T)` keeps short runs proportionate (a
+ * 2-minute run gets at most 2 minutes of grace) while never exceeding the
+ * 15-minute cap for long runs.
+ *
+ * @param startMS         Absolute start timestamp in milliseconds.
+ * @param timeoutMinutes  Configured soft timeout in minutes.
+ * @returns The absolute hard-deadline timestamp in milliseconds, or `undefined`
+ *          when `timeoutMinutes` is 0/unset (no timeout configured → no cap).
+ */
+export function computeHardDeadlineTS(
+  startMS: number,
+  timeoutMinutes: number,
+): number | undefined {
+  if (!timeoutMinutes) {
+    return undefined;
+  }
+
+  const graceMinutes = Math.min(
+    HARD_DEADLINE_GRACE_MINUTES,
+    Math.max(1, timeoutMinutes),
+  );
+
+  return startMS + timeoutMinutes * 60_000 + graceMinutes * 60_000;
+}

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -570,6 +570,34 @@ export class Neat {
   }
 
   /**
+   * Issue #2896: enforce the absolute T+15 hard cap during the finish-up cycle.
+   *
+   * When `hardDeadlineMS` is set (non-zero) and already in the past, abandon all
+   * in-flight discovery/training bookkeeping — so the abandoned promises cannot
+   * be re-awaited — and signal the caller to break out of the evolve loop, even
+   * when {@link finishUp} would still ask for more wait generations. The
+   * caller's post-loop sequence (worker termination, best-creature restore and
+   * `writeCreatures`) still runs because the break lands there.
+   *
+   * @param hardDeadlineMS Absolute hard-deadline epoch ms (0/unset = no cap).
+   * @returns `true` when the cap was exceeded and the loop must break.
+   */
+  abandonInFlightPastHardDeadline(hardDeadlineMS: number): boolean {
+    if (!hardDeadlineMS || Date.now() <= hardDeadlineMS) {
+      return false;
+    }
+
+    const abandoned = this.discoveryInProgress.size +
+      this.trainingInProgress.size;
+    getLogger().warn(
+      `[Neat] Hard deadline (timeoutMinutes + grace) exceeded — abandoning ${abandoned} in-flight task(s)`,
+    );
+    this.discoveryInProgress.clear();
+    this.trainingInProgress.clear();
+    return true;
+  }
+
+  /**
    * Issue #2240: Lightweight wait for in-flight discovery and training tasks.
    *
    * Instead of running full evolve() cycles while waiting for async tasks
@@ -578,8 +606,15 @@ export class Neat {
    * resources on unnecessary fitness evaluation, breeding, and mutation.
    *
    * @param timeoutMs - Maximum time to wait before returning (default 30s)
+   * @param hardDeadlineTS - Absolute hard-deadline epoch ms (Issue #2896).
+   *   Defaults to this instance's {@link hardDeadlineTS}. The effective wait is
+   *   capped at `hardDeadlineTS - Date.now()` (minimum 0) so the 30s default
+   *   cannot push the finish-up wait past the T+15 cap. 0 disables the cap.
    */
-  async awaitInFlightTasks(timeoutMs = 30_000): Promise<void> {
+  async awaitInFlightTasks(
+    timeoutMs = 30_000,
+    hardDeadlineTS = this.hardDeadlineTS,
+  ): Promise<void> {
     const inFlightPromises: Promise<void>[] = [
       ...this.discoveryInProgress.values(),
       ...this.trainingInProgress.values(),
@@ -589,17 +624,23 @@ export class Neat {
       return;
     }
 
+    // Issue #2896: never wait past the absolute hard deadline. Cap the effective
+    // timeout at the time remaining before the cap (minimum 0).
+    const effectiveTimeoutMs = hardDeadlineTS > 0
+      ? Math.min(timeoutMs, Math.max(0, hardDeadlineTS - Date.now()))
+      : timeoutMs;
+
     const discoveryCount = this.discoveryInProgress.size;
     const trainingCount = this.trainingInProgress.size;
     getLogger().info(
       `[Neat] Awaiting ${inFlightPromises.length} in-flight task(s) ` +
         `(${discoveryCount} discovery, ${trainingCount} training) ` +
-        `with ${timeoutMs}ms timeout`,
+        `with ${effectiveTimeoutMs}ms timeout`,
     );
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<void>((resolve) => {
-      timeoutId = setTimeout(resolve, timeoutMs);
+      timeoutId = setTimeout(resolve, effectiveTimeoutMs);
     });
 
     try {

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -23,6 +23,7 @@ import type {
 import { WorkerPool } from "@multithreading/WorkerPool.ts";
 import type { CrisprInterface } from "@reconstruct/CRISPR.ts";
 import { Genus } from "@neat/Genus.ts";
+import { computeHardDeadlineTS } from "@neat/HardDeadline.ts";
 import { Mutator } from "@neat/Mutator.ts";
 import { MCMCState } from "@neat/MCMCState.ts";
 import { PlateauDetector } from "@neat/PlateauDetector.ts";
@@ -80,6 +81,12 @@ export class Neat {
 
   /** Timestamp when evolution should end (if timeout is set) */
   readonly endTimeTS: number;
+  /**
+   * Absolute hard-deadline timestamp — the wall-clock cap past which all
+   * in-flight work must be abandoned (Issue #2895). 0 when no timeout is set.
+   * Enforcement lands in follow-up sub-issues; this is shared plumbing.
+   */
+  readonly hardDeadlineTS: number;
   /** Current population of creatures */
   population: Creature[];
   /** Available CRISPR modifications for targeted evolution (read-only after init) */
@@ -262,9 +269,16 @@ export class Neat {
       this.population.push(n);
     });
 
+    const startTS = Date.now();
     this.endTimeTS = options.timeoutMinutes
-      ? Date.now() + Math.max(1, options.timeoutMinutes) * 60_000
+      ? startTS + Math.max(1, options.timeoutMinutes) * 60_000
       : 0;
+    // Issue #2895: shared absolute hard cap (endTimeTS + clamped grace). 0 when
+    // no timeout is configured, mirroring endTimeTS.
+    this.hardDeadlineTS = computeHardDeadlineTS(
+      startTS,
+      options.timeoutMinutes ?? 0,
+    ) ?? 0;
     this.CRISPRs = Neat.deepCloneAndShuffle(this.config.CRISPRs);
 
     this.plateauDetector = new PlateauDetector(this.config.plateauDetection);

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -26,6 +26,7 @@ import { Mutator } from "@neat/Mutator.ts";
 import { CRISPR } from "@reconstruct/CRISPR.ts";
 import { CrisprError } from "@errors/CrisprError.ts";
 import { simplify } from "@optimize/Simplify.ts";
+import { appendAll } from "@utils/ArrayAppend.ts";
 import { validateOrDiagnose } from "@utils/Diagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
@@ -685,7 +686,10 @@ export async function evolve(
   // Issue #2314: Await breeding results now that all overlapped main-thread
   // work is complete.
   const offspringBatch = await breedingPromise;
-  newPopulation.push(...offspringBatch);
+  // Issue #2897: Stack-safe in-place append. Spreading an unbounded
+  // offspringBatch into push() arguments throws RangeError once the batch
+  // exceeds V8's argument/stack limit; appendAll uses an indexed loop instead.
+  appendAll(newPopulation, offspringBatch);
   const breedingMs = Date.now() - breedingStartMs;
   // Issue #2323: Compute pure worker breeding duration. If the .then()
   // callback has not fired yet (breedingWorkerEndMs is still 0), the worker

--- a/src/NEAT/NeatScheduling.ts
+++ b/src/NEAT/NeatScheduling.ts
@@ -152,6 +152,14 @@ export function scheduleDiscovery(
     // Issue #2432: clamp the analysis ceiling to the slack remaining after
     // recording so record + analysis ≤ caller's wall-clock budget.
     discoveryAnalysisTimeoutMinutes: allocation.analysisMinutes,
+    // Issue #2898: pass the absolute hard deadline across the worker boundary so
+    // the worker clamps every per-discovery deadline to T+15 regardless of how
+    // long the request waited in the queue. The #2432 relative allocation above
+    // stays as the phase-split mechanism. Only set when a hard deadline is
+    // configured (0 means no `timeoutMinutes`), leaving behaviour unchanged.
+    ...(neat.hardDeadlineTS > 0
+      ? { discoveryHardDeadlineTS: neat.hardDeadlineTS }
+      : {}),
   });
 
   const taskStartTime = Date.now();

--- a/src/NEAT/NeatScheduling.ts
+++ b/src/NEAT/NeatScheduling.ts
@@ -310,6 +310,10 @@ export function scheduleTraining(
     trainingSampleRate: neat.config.trainingSampleRate,
     disableRandomSamples: neat.config.disableRandomSamples,
     trainingTimeOutMinutes: trainingTimeOutMinutes,
+    // Issue #2899: carry the absolute hard deadline so worker-side training
+    // stops at T+15 even when the task sat in the worker queue. 0 means no
+    // deadline configured; leave it absent so behaviour is unchanged.
+    hardDeadlineTS: neat.hardDeadlineTS > 0 ? neat.hardDeadlineTS : undefined,
     batchSize: neat.config.trainingBatchSize,
     maximumBiasAdjustmentScale: neat.config.maximumBiasAdjustmentScale,
     maximumWeightAdjustmentScale: neat.config.maximumWeightAdjustmentScale,

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
@@ -95,7 +95,7 @@ export async function recordDirectory(
   return await recorder.recordDirectory(dataDir);
 }
 
-class DataRecorder {
+export class DataRecorder {
   private readonly BYTES_PER_RECORD: number;
   private readonly BATCH_SIZE: number;
   private readonly sampleRate: number;
@@ -105,6 +105,13 @@ class DataRecorder {
   private readonly timeoutSeconds: number;
   private readonly analysisTimeoutSeconds: number;
   private analysisDeadlineAt?: number;
+  /**
+   * Issue #2898: absolute hard-deadline timestamp (epoch ms) carried across the
+   * worker boundary in the per-call config. Clamps every per-discovery deadline
+   * to the caller's T+15 cap. `undefined` when no `timeoutMinutes` is
+   * configured, in which case clamping is a no-op (behaviour unchanged).
+   */
+  private readonly discoveryHardDeadlineTS?: number;
   private readonly discoveryMaxNeurons: number;
   private readonly drainEveryNBatches: number;
   private readonly rustFlushRecords: number;
@@ -136,7 +143,15 @@ class DataRecorder {
       config.discoveryRecordTimeOutMinutes,
     );
     this.timeoutSeconds = discoveryRecordTimeOutMinutes * 60;
+    // Issue #2898: clamp the recording deadline to the absolute hard cap. A
+    // request queued behind a busy worker would otherwise anchor its relative
+    // budget at start time, not schedule time, drifting the completion past
+    // T+15. `min(now + recordBudget, hardDeadline)` ties it back to the cap.
+    this.discoveryHardDeadlineTS = config.discoveryHardDeadlineTS;
     this.timeoutTS = Date.now() + this.timeoutSeconds * 1000;
+    if (this.discoveryHardDeadlineTS !== undefined) {
+      this.timeoutTS = Math.min(this.timeoutTS, this.discoveryHardDeadlineTS);
+    }
 
     const analysisTimeoutMinutes = Math.min(
       60,
@@ -366,13 +381,10 @@ class DataRecorder {
         };
       }
 
-      // Extend timeout for analysis phase
-      const analysisTimeoutSeconds = this.analysisTimeoutSeconds;
-      const analysisTimeoutMinutes = analysisTimeoutSeconds / 60;
-      const analysisDeadlineAt = Date.now() + analysisTimeoutSeconds * 1000;
-      this.analysisDeadlineAt = analysisDeadlineAt;
-      discoverStructure.extendTimeoutForAnalysis(analysisTimeoutSeconds);
-      this.timeoutTS = analysisDeadlineAt;
+      // Extend timeout for analysis phase (clamped to the hard deadline)
+      const analysisTimeoutMinutes = this.extendTimeoutForAnalysisPhase(
+        discoverStructure,
+      );
 
       if (shouldLogDiscovery(config)) {
         getLogger().info(
@@ -532,7 +544,36 @@ class DataRecorder {
     perfStats.totalTime = Date.now() - startTime;
   }
 
-  private refreshAnalysisTimeout(
+  /**
+   * Move from recording into analysis, extending the deadline by the configured
+   * analysis budget but never past the absolute hard deadline (Issue #2898).
+   *
+   * `analysisDeadlineAt = min(now + analysisBudget, discoveryHardDeadlineTS)`.
+   * The same clamped value is pushed into the DiscoverStructure (which also
+   * remembers the cap for later `refreshAnalysisTimeout` top-ups) and mirrored
+   * onto `this.timeoutTS`, which the analysis loop reads via `getTimeoutTS()`.
+   *
+   * @returns the analysis budget in minutes, for logging.
+   */
+  extendTimeoutForAnalysisPhase(discoverStructure: DiscoverStructure): number {
+    const analysisTimeoutSeconds = this.analysisTimeoutSeconds;
+    let analysisDeadlineAt = Date.now() + analysisTimeoutSeconds * 1000;
+    if (this.discoveryHardDeadlineTS !== undefined) {
+      analysisDeadlineAt = Math.min(
+        analysisDeadlineAt,
+        this.discoveryHardDeadlineTS,
+      );
+    }
+    this.analysisDeadlineAt = analysisDeadlineAt;
+    discoverStructure.extendTimeoutForAnalysis(
+      analysisTimeoutSeconds,
+      this.discoveryHardDeadlineTS,
+    );
+    this.timeoutTS = analysisDeadlineAt;
+    return analysisTimeoutSeconds / 60;
+  }
+
+  refreshAnalysisTimeout(
     discoverStructure: DiscoverStructure,
   ): void {
     if (this.analysisDeadlineAt === undefined) {
@@ -543,7 +584,22 @@ class DataRecorder {
       return;
     }
     const remainingSeconds = Math.max(1, Math.floor(remainingMs / 1000));
-    discoverStructure.extendTimeoutForAnalysis(remainingSeconds);
+    // Issue #2898: re-supply the hard cap so the top-up can never overshoot it,
+    // even though `analysisDeadlineAt` is already clamped.
+    discoverStructure.extendTimeoutForAnalysis(
+      remainingSeconds,
+      this.discoveryHardDeadlineTS,
+    );
     this.timeoutTS = this.analysisDeadlineAt;
+  }
+
+  /** Current recording/analysis deadline (epoch ms). Issue #2898 — test seam. */
+  get currentTimeoutTS(): number {
+    return this.timeoutTS;
+  }
+
+  /** Clamped analysis deadline (epoch ms), once analysis has begun. Issue #2898. */
+  get currentAnalysisDeadlineAt(): number | undefined {
+    return this.analysisDeadlineAt;
   }
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDataLoading.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDataLoading.ts
@@ -7,6 +7,7 @@
  * binary files, with retry logic for file descriptor limits.
  */
 import { getLogger } from "@utils/Logger.ts";
+import { appendAll } from "@utils/ArrayAppend.ts";
 import { DiscoveryError } from "@errors/DiscoveryError.ts";
 import { TopologyError } from "@errors/TopologyError.ts";
 import type {
@@ -115,7 +116,9 @@ export async function loadInputNeuronFromBinary(
 
   // Flatten the results into a single array
   for (const fileRecords of allFileRecords) {
-    records.push(...fileRecords);
+    // Issue #2900: stack-safe append; fileRecords scales with the dataset
+    // record count for a binary file, so spreading risks RangeError.
+    appendAll(records, fileRecords);
   }
 
   return records;

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
@@ -128,6 +128,12 @@ export class DiscoverStructureBase {
     undefined;
   protected lastNeuronScanStats?: NeuronScanStats;
   protected analysisDeadlineMs?: number;
+  /**
+   * Issue #2898: absolute hard-deadline timestamp (epoch ms). Once supplied,
+   * `extendTimeoutForAnalysis` will never move `timeoutTS` past this cap, so
+   * analysis-timeout extensions can never run past the caller's T+15 deadline.
+   */
+  protected analysisHardDeadlineTS?: number;
   protected cachedRemovalCandidates?:
     import("./DiscoverResult.ts").RemovalCandidate[];
   protected combinedRustAnalysis?: CombinedAnalysisCache;
@@ -292,13 +298,42 @@ export class DiscoverStructureBase {
     return false;
   }
 
-  public extendTimeoutForAnalysis(analysisTimeSeconds: number): void {
+  /**
+   * Expose the current absolute timeout timestamp (epoch ms) so callers and
+   * tests can assert the active deadline. Issue #2898.
+   */
+  public getTimeoutTS(): number {
+    return this.timeoutTS;
+  }
+
+  /**
+   * Extend the deadline to give the analysis phase room to run.
+   *
+   * Issue #2898: an optional absolute hard-deadline cap (epoch ms) clamps the
+   * extended deadline so it can never move past the caller's T+15 wall-clock
+   * cap, no matter how long the discovery request waited in the worker queue.
+   * The cap is remembered, so later `refreshAnalysisTimeout` top-ups stay
+   * clamped even if a cap is not re-supplied. Once the cap is reached the
+   * remaining budget the analysis loop computes is ≤ 0, so its per-chunk checks
+   * exit promptly. When no cap is supplied behaviour is unchanged.
+   */
+  public extendTimeoutForAnalysis(
+    analysisTimeSeconds: number,
+    hardDeadlineTS?: number,
+  ): void {
     assert(
       analysisTimeSeconds > 0,
       `Analysis time must be greater than 0, was: ${analysisTimeSeconds}`,
     );
-    this.timeoutTS = Date.now() + analysisTimeSeconds * 1000;
-    this.analysisDeadlineMs = this.timeoutTS;
+    if (hardDeadlineTS !== undefined) {
+      this.analysisHardDeadlineTS = hardDeadlineTS;
+    }
+    let target = Date.now() + analysisTimeSeconds * 1000;
+    if (this.analysisHardDeadlineTS !== undefined) {
+      target = Math.min(target, this.analysisHardDeadlineTS);
+    }
+    this.timeoutTS = target;
+    this.analysisDeadlineMs = target;
     this.analysisTimeoutGuardEnabled = false;
   }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
@@ -26,6 +26,7 @@ import {
   observeRustTrainingRecord as observeRustTrainingRecordImpl,
 } from "@architecture/ErrorGuidedStructuralEvolution/RustFlushDiagnostics.ts";
 import { getLogger } from "@utils/Logger.ts";
+import { appendAll } from "@utils/ArrayAppend.ts";
 import { isReleased } from "@utils/ReleasableRef.ts";
 import { DiscoverStructureBase } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts";
 import {
@@ -111,7 +112,9 @@ export class DiscoverStructureRecording extends DiscoverStructureBase {
       if (!this.selectedIndices[binaryFilePath]) {
         this.selectedIndices[binaryFilePath] = [];
       }
-      this.selectedIndices[binaryFilePath].push(...effectiveRecordIndices);
+      // Issue #2900: stack-safe append; a batch holds up to discoveryBatchSize
+      // indices (config, no hard upper cap), so spreading risks RangeError.
+      appendAll(this.selectedIndices[binaryFilePath], effectiveRecordIndices);
 
       Deno.writeTextFileSync(
         this.indicesFilePath,

--- a/src/architecture/training/TrainingOutcome.ts
+++ b/src/architecture/training/TrainingOutcome.ts
@@ -36,6 +36,39 @@ export interface EpochState {
   timeoutTS: number;
 }
 
+/**
+ * Computes the absolute timeout timestamp (epoch ms) for a training run.
+ *
+ * Issue #2899: the relative budget ({@link trainingTimeOutMinutes}) is
+ * anchored at worker start, which drifts when the task waited in the worker
+ * queue. When an absolute {@link hardDeadlineTS} is supplied it clamps the
+ * relative budget so the run stops at the hard deadline regardless of queue
+ * delay. A `trainingTimeOutMinutes` of `0` means "no relative budget"; an
+ * absent/zero `hardDeadlineTS` leaves the relative computation unchanged.
+ *
+ * Pure and `now`-injectable so it can be unit-tested without elapsed-time
+ * assertions (#2888 policy).
+ *
+ * @param now - current epoch ms (injected for deterministic testing)
+ * @param trainingTimeOutMinutes - relative budget in minutes (0 = none)
+ * @param hardDeadlineTS - absolute hard deadline epoch ms (0/undefined = none)
+ * @returns the timeout timestamp in epoch ms, or 0 for no timeout
+ */
+export function computeTimeoutTS(
+  now: number,
+  trainingTimeOutMinutes: number,
+  hardDeadlineTS?: number,
+): number {
+  const relativeTS = trainingTimeOutMinutes > 0
+    ? now + trainingTimeOutMinutes * 60 * 1000
+    : 0;
+  const hardTS = hardDeadlineTS ?? 0;
+  if (hardTS > 0) {
+    return relativeTS > 0 ? Math.min(relativeTS, hardTS) : hardTS;
+  }
+  return relativeTS;
+}
+
 /** Construct the initial epoch state from setup output. */
 export function createEpochState(setup: TrainingSetupState): EpochState {
   return {
@@ -49,9 +82,11 @@ export function createEpochState(setup: TrainingSetupState): EpochState {
     scratch: { buffer: null },
     indxMap: new Map(),
     timedOut: false,
-    timeoutTS: setup.trainingTimeOutMinutes > 0
-      ? Date.now() + setup.trainingTimeOutMinutes * 60 * 1000
-      : 0,
+    timeoutTS: computeTimeoutTS(
+      Date.now(),
+      setup.trainingTimeOutMinutes,
+      setup.hardDeadlineTS,
+    ),
   };
 }
 

--- a/src/architecture/training/TrainingSetup.ts
+++ b/src/architecture/training/TrainingSetup.ts
@@ -125,6 +125,11 @@ export interface TrainingSetupState {
   iterations: number;
   trainingSampleRate: number;
   trainingTimeOutMinutes: number;
+  /**
+   * Absolute hard deadline (epoch ms) to clamp the relative timeout against.
+   * Issue #2899: undefined/0 leaves the relative budget unchanged.
+   */
+  hardDeadlineTS: number | undefined;
   ID: string;
   BYTES_PER_RECORD: number;
   recordBuffer: Uint8Array;
@@ -159,6 +164,8 @@ export function prepareTraining(
   const iterations = resolveIterations(options);
   const trainingSampleRate = resolveTrainingSampleRate(options);
   const trainingTimeOutMinutes = options.trainingTimeOutMinutes ?? 0;
+  // Issue #2899: carry the absolute hard deadline through to epoch state.
+  const hardDeadlineTS = options.hardDeadlineTS;
 
   const valuesCount = creature.input + creature.output;
   const BYTES_PER_RECORD = valuesCount * 4; // Each float is 4 bytes
@@ -222,6 +229,7 @@ export function prepareTraining(
     iterations,
     trainingSampleRate,
     trainingTimeOutMinutes,
+    hardDeadlineTS,
     ID: shortId,
     BYTES_PER_RECORD,
     recordBuffer,

--- a/src/blackbox/FineTunePopulation.ts
+++ b/src/blackbox/FineTunePopulation.ts
@@ -10,6 +10,7 @@ import { restoreSource } from "@blackbox/RestoreSource.ts";
 import type { AdaptiveFineTuneTracker } from "@blackbox/AdaptiveFineTuneTracker.ts";
 
 import { retry } from "@blackbox/Retry.ts";
+import { appendAll } from "@utils/ArrayAppend.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 
@@ -150,7 +151,9 @@ export class FindTunePopulation {
             this.neat.config.quantumStep,
           );
 
-          fineTunedPopulation.push(...restoredTunedPopulation);
+          // Issue #2900: stack-safe append; fineTunedPopulation scales with
+          // populationSize via fineTunePopSize, so spreading risks RangeError.
+          appendAll(fineTunedPopulation, restoredTunedPopulation);
         }
       } else {
         const retryPopulation = retry(
@@ -159,7 +162,7 @@ export class FindTunePopulation {
           undefined,
           this.neat.config.quantumStep,
         );
-        fineTunedPopulation.push(...retryPopulation);
+        appendAll(fineTunedPopulation, retryPopulation);
       }
 
       for (let attempts = 0; attempts < 12; attempts++) {
@@ -215,7 +218,7 @@ export class FindTunePopulation {
                 this.neat.config.quantumStep,
               );
 
-              fineTunedPopulation.push(...extendedTunedPopulation);
+              appendAll(fineTunedPopulation, extendedTunedPopulation);
             }
           }
         } else {
@@ -252,7 +255,7 @@ export class FindTunePopulation {
             this.neat.config.quantumStep,
           );
 
-          fineTunedPopulation.push(...extendedTunedPopulation);
+          appendAll(fineTunedPopulation, extendedTunedPopulation);
 
           /* Remove the chosen creature from the array */
           tmpFineTunePopulation.splice(location, 1);

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -313,6 +313,17 @@ export interface NeatArguments {
    */
   discoveryAnalysisTimeoutMinutes: number;
 
+  /**
+   * Absolute hard-deadline timestamp (epoch ms) for a single discovery
+   * request (Issue #2898). Plumbed across the worker boundary in the per-call
+   * frozen config built by `scheduleDiscovery` so every per-discovery deadline
+   * — recording `timeoutTS`, the analysis extension, and `refreshAnalysisTimeout`
+   * top-ups — can be clamped to the caller's absolute T+15 cap regardless of
+   * worker-queue delay. Absent (undefined) when no `timeoutMinutes` is
+   * configured, in which case clamping is a no-op and behaviour is unchanged.
+   */
+  discoveryHardDeadlineTS?: number;
+
   /** The number of observations per promise */
   discoveryBatchSize: number;
 

--- a/src/config/TrainOptions.ts
+++ b/src/config/TrainOptions.ts
@@ -29,6 +29,22 @@ export interface TrainArguments extends BackPropagationArguments {
   trainingTimeOutMinutes: number;
 
   /**
+   * Absolute hard deadline (epoch milliseconds) at which training must stop.
+   *
+   * Issue #2899: A scheduled fine-tuning task may sit in the worker queue
+   * after being scheduled with a relative {@link trainingTimeOutMinutes}
+   * budget. The relative budget is otherwise anchored when the worker
+   * dequeues the task, so a queued task can run past the run's wall-clock
+   * deadline. Carrying the absolute deadline lets the worker clamp the
+   * relative budget to `min(now + trainingTimeOutMinutes, hardDeadlineTS)`.
+   *
+   * A plain number so it survives `Worker.postMessage`. When absent,
+   * behaviour is unchanged (direct `creature.train()` callers are
+   * unaffected).
+   */
+  hardDeadlineTS?: number;
+
+  /**
    * Enable feedback loop where the previous result feeds back into the next interaction.
    * Useful for time-series forecasting and recurrent neural networks.
    * More information: https://www.mathworks.com/help/deeplearning/ug/design-time-series-narx-feedback-neural-networks.html

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -363,6 +363,30 @@ async function writeCreatures(neat: Neat, dir: string): Promise<void> {
 }
 
 /**
+ * Test-only injection seam for {@link evolveDir} (Issue #2902).
+ *
+ * Lets the end-to-end T+15 hard-deadline guard drive the absolute cap
+ * deterministically without real sleeps (behavioural-test policy #2888).
+ * Production callers omit `deps` entirely; the defaults reproduce the
+ * pre-existing behaviour exactly.
+ *
+ * - `startTimeMS` overrides the run-start timestamp that anchors both the soft
+ *   `endTimeMS` and the absolute T+15 hard cap. Passing a timestamp far enough
+ *   in the past places both deadlines behind the wall clock, so the very first
+ *   finish-up cycle takes the hard-cap branch.
+ * - `onNeatReady` is invoked with the live {@link Neat} instance once the
+ *   population is seeded and before the evolve loop starts, so a test can stub
+ *   never-resolving in-flight discovery / training promises (no Rust FFI in CI)
+ *   and later inspect the in-flight maps once the run returns.
+ */
+export interface EvolveDirDeps {
+  /** Override the run-start timestamp (ms since epoch). */
+  startTimeMS?: number;
+  /** Invoked with the constructed {@link Neat} instance before the evolve loop. */
+  onNeatReady?: (neat: Neat) => void;
+}
+
+/**
  * Evolve the creature on a dataset directory using NEAT.
  * Supports multi-threaded workers, checkpointing, and timeout.
  */
@@ -370,6 +394,7 @@ export async function evolveDir(
   creature: Creature,
   dataSetDir: string,
   options: NeatOptions,
+  deps?: EvolveDirDeps,
 ): Promise<
   { error: number; score: number; time: number; generation: number }
 > {
@@ -381,7 +406,10 @@ export async function evolveDir(
 
   Deno.addSignalListener("SIGTERM", signalListener);
 
-  const start = Date.now();
+  // Issue #2902: `deps?.startTimeMS` is a test-only override that anchors both
+  // the soft `endTimeMS` and the absolute T+15 hard cap to an injected (past)
+  // timestamp, so the hard-cap branch can be driven without real sleeps.
+  const start = deps?.startTimeMS ?? Date.now();
   const config = createNeatConfig(options);
 
   // Issue #1566: Apply WASM cache caps from config before training starts.
@@ -462,6 +490,11 @@ export async function evolveDir(
 
   neat.setDataDir(dataSetDir);
   await neat.populatePopulation(creature);
+
+  // Issue #2902: hand the constructed Neat instance to the test seam (if any)
+  // so integration guards can stub never-resolving in-flight work before the
+  // evolve loop. No-op for production callers.
+  deps?.onNeatReady?.(neat);
 
   let error = Infinity;
   let bestScore = -Infinity;

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -392,9 +392,8 @@ export async function evolveDir(
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
   // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
-  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
-  // so the value is computed but not yet consumed.
-  // deno-lint-ignore no-unused-vars
+  // no timeout is configured. Issue #2896 enforces it in the finish-up cycle
+  // below via neat.abandonInFlightPastHardDeadline(hardDeadlineMS).
   const hardDeadlineMS =
     computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
@@ -595,6 +594,16 @@ export async function evolveDir(
 
     if (completed) {
       if (interrupted) break;
+
+      // Issue #2896: enforce the absolute T+15 hard cap. Once it passes, abandon
+      // any in-flight discovery/training bookkeeping and break unconditionally —
+      // even when finishUp() would still ask for more wait generations. The
+      // post-loop sequence (worker termination, best-creature restore,
+      // writeCreatures) still runs because the break lands there.
+      if (neat.abandonInFlightPastHardDeadline(hardDeadlineMS)) {
+        break;
+      }
+
       if (neat.finishUp(iterations, endTimeMS, start, generation)) {
         break;
       }
@@ -715,9 +724,8 @@ export async function evolveEnv<S, A>(
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
   // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
-  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
-  // so the value is computed but not yet consumed.
-  // deno-lint-ignore no-unused-vars
+  // no timeout is configured. Issue #2896 enforces it in the finish-up cycle
+  // below via neat.abandonInFlightPastHardDeadline(hardDeadlineMS).
   const hardDeadlineMS =
     computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
@@ -876,6 +884,16 @@ export async function evolveEnv<S, A>(
 
     if (completed) {
       if (interrupted) break;
+
+      // Issue #2896: enforce the absolute T+15 hard cap. Once it passes, abandon
+      // any in-flight discovery/training bookkeeping and break unconditionally —
+      // even when finishUp() would still ask for more wait generations. The
+      // post-loop sequence (best-creature restore, writeCreatures) still runs
+      // because the break lands there.
+      if (neat.abandonInFlightPastHardDeadline(hardDeadlineMS)) {
+        break;
+      }
+
       if (neat.finishUp(iterations, endTimeMS, start, generation)) {
         break;
       }
@@ -1071,9 +1089,8 @@ export async function evolveRL<S, A>(
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
   // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
-  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
-  // so the value is computed but not yet consumed.
-  // deno-lint-ignore no-unused-vars
+  // no timeout is configured. Issue #2896 enforces it in the finish-up cycle
+  // below via neat.abandonInFlightPastHardDeadline(hardDeadlineMS).
   const hardDeadlineMS =
     computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
@@ -1382,6 +1399,16 @@ export async function evolveRL<S, A>(
 
     if (completed) {
       if (interrupted) break;
+
+      // Issue #2896: enforce the absolute T+15 hard cap. Once it passes, abandon
+      // any in-flight discovery/training bookkeeping and break unconditionally —
+      // even when finishUp() would still ask for more wait generations. The
+      // post-loop sequence (best-creature restore, writeCreatures) still runs
+      // because the break lands there.
+      if (neat.abandonInFlightPastHardDeadline(hardDeadlineMS)) {
+        break;
+      }
+
       if (neat.finishUp(iterations, endTimeMS, start, generation)) {
         break;
       }

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -32,6 +32,7 @@ import {
 } from "@costs/CostAwareEarlyStop.ts";
 import { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import { Neat } from "@neat/Neat.ts";
+import { computeHardDeadlineTS } from "@neat/HardDeadline.ts";
 import {
   type BackPropagationConfig,
   createBackPropagationConfig,
@@ -390,6 +391,12 @@ export async function evolveDir(
   const endTimeMS = config.timeoutMinutes
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
+  // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
+  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
+  // so the value is computed but not yet consumed.
+  // deno-lint-ignore no-unused-vars
+  const hardDeadlineMS =
+    computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
   const workers: WorkerHandler[] = [];
   const threads = config.threads;
@@ -707,6 +714,12 @@ export async function evolveEnv<S, A>(
   const endTimeMS = config.timeoutMinutes
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
+  // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
+  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
+  // so the value is computed but not yet consumed.
+  // deno-lint-ignore no-unused-vars
+  const hardDeadlineMS =
+    computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
   const trialsPerScore = options.trialsPerScore !== undefined
     ? Math.max(1, Math.floor(options.trialsPerScore))
@@ -1057,6 +1070,12 @@ export async function evolveRL<S, A>(
   const endTimeMS = config.timeoutMinutes
     ? start + Math.max(1, config.timeoutMinutes) * 60000
     : 0;
+  // Issue #2895: shared absolute hard cap (endTimeMS + clamped grace). 0 when
+  // no timeout is configured. Plumbing only — enforcement lands in follow-ups,
+  // so the value is computed but not yet consumed.
+  // deno-lint-ignore no-unused-vars
+  const hardDeadlineMS =
+    computeHardDeadlineTS(start, config.timeoutMinutes ?? 0) ?? 0;
 
   // Lazy import avoids a circular module graph (Neat.ts → Creature.ts →
   // CreatureTraining.ts → RLEpisodeFitness.ts → Fitness.ts vs Neat.ts → Fitness.ts).

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -626,7 +626,11 @@ export async function evolveDir(
   // Issue #1509: Await background replay queue completion before returning.
   // Without this, callers that delete the data directory after evolveDir()
   // returns may cause NotFound errors in still-running replay workers.
-  await neat.discoveryReplayQueue.waitForCompletion();
+  // Issue #2901: bound the wait to the absolute hard cap when a timeout is
+  // configured (hardDeadlineMS > 0); uncapped runs keep the unbounded wait.
+  await neat.discoveryReplayQueue.waitForCompletion(
+    hardDeadlineMS || undefined,
+  );
 
   if (bestCreature) {
     creature.loadFrom(bestCreature, config.debug, "training:restoreBest");
@@ -905,8 +909,10 @@ export async function evolveEnv<S, A>(
   // No worker pool to terminate — episode rollouts ran inline. Replay queue
   // never had a chance to schedule anything (no dataDir was provided), but
   // await it for symmetry with evolveDir() in case a future change wires one
-  // through.
-  await neat.discoveryReplayQueue.waitForCompletion();
+  // through. Issue #2901: bound the wait to the absolute hard cap when set.
+  await neat.discoveryReplayQueue.waitForCompletion(
+    hardDeadlineMS || undefined,
+  );
 
   if (bestCreature) {
     creature.loadFrom(bestCreature, config.debug, "evolveEnv:restoreBest");
@@ -1452,7 +1458,10 @@ export async function evolveRL<S, A>(
   // pool was constructed (single-threaded or missing adapterDescription)
   // this is a no-op.
   workerPool?.terminate();
-  await neat.discoveryReplayQueue.waitForCompletion();
+  // Issue #2901: bound the wait to the absolute hard cap when a timeout is set.
+  await neat.discoveryReplayQueue.waitForCompletion(
+    hardDeadlineMS || undefined,
+  );
 
   if (bestCreature) {
     creature.loadFrom(bestCreature, config.debug, "evolveRL:restoreBest");

--- a/src/discovery/CandidateApplicationOps.ts
+++ b/src/discovery/CandidateApplicationOps.ts
@@ -9,6 +9,7 @@
  */
 
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { appendAll, insertAll } from "@utils/ArrayAppend.ts";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import { assertNoRecurrentSynapseOnForwardOnly } from "@architecture/ForwardOnlyAssertion.ts";
 import {
@@ -61,7 +62,9 @@ export function applyAddSynapses(
   );
   if (newSynapses.length === 0) return undefined;
 
-  creatureJSON.synapses.push(...newSynapses);
+  // Issue #2900: stack-safe append; newSynapses scales with candidate
+  // connection count, so spreading risks RangeError on large networks.
+  appendAll(creatureJSON.synapses, newSynapses);
   // Issue #2514: candidate creatures may carry intentionally illegal
   // hints (forward-only filter happens here, but also above on a
   // best-effort basis). Opt out of the load-side throw so the
@@ -162,7 +165,9 @@ export function applyAddNeurons(
     const insertAt = firstOutputIndex >= 0
       ? firstOutputIndex
       : mergedNeurons.length;
-    mergedNeurons.splice(insertAt, 0, ...remaining);
+    // Issue #2900: stack-safe insertion; `remaining` scales with candidate
+    // neuron count, so spreading into splice risks RangeError on large networks.
+    insertAll(mergedNeurons, insertAt, remaining);
     for (const neuron of remaining) inserted.add(neuron.id!);
   }
 
@@ -196,7 +201,9 @@ export function applyAddNeurons(
           return from !== undefined && to !== undefined && from < to;
         })()),
   );
-  creatureJSON.synapses.push(...newSynapses);
+  // Issue #2900: stack-safe append; newSynapses scales with candidate
+  // connection count, so spreading risks RangeError on large networks.
+  appendAll(creatureJSON.synapses, newSynapses);
 
   // Issue #2514: candidate creatures may still hold filtered-but-not-yet-pruned
   // recurrent hints. Opt out of the load-side throw — the combiner is the
@@ -331,7 +338,9 @@ export function applyRemoveSynapse(
     );
   }
 
-  creatureJSON.synapses.push(...toAdd);
+  // Issue #2900: stack-safe append; toAdd scales with candidate connection
+  // count, so spreading risks RangeError on large networks.
+  appendAll(creatureJSON.synapses, toAdd);
 
   // Issue #2514: candidate creatures may still hold filtered-but-not-yet-pruned
   // recurrent hints. Opt out of the load-side throw.
@@ -432,7 +441,9 @@ export function applyRemoveNeuron(
 
   if (toRemove.size === 0 && toAdd.length === 0) return creature;
 
-  creatureJSON.synapses.push(...toAdd);
+  // Issue #2900: stack-safe append; toAdd scales with candidate connection
+  // count, so spreading risks RangeError on large networks.
+  appendAll(creatureJSON.synapses, toAdd);
 
   // Issue #2514: candidate creatures may still hold filtered-but-not-yet-pruned
   // recurrent hints. Opt out of the load-side throw.

--- a/src/discovery/DiscoveryCandidates.ts
+++ b/src/discovery/DiscoveryCandidates.ts
@@ -43,6 +43,7 @@ import type {
   CoordinatedStructuralCandidate,
 } from "@architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
 import type { Creature } from "@creature";
+import { appendAll } from "@utils/ArrayAppend.ts";
 
 // Re-export from focused modules for backwards compatibility
 export { shortID } from "@discovery/CandidateDescriptions.ts";
@@ -231,8 +232,12 @@ export function buildDiscoveryCandidates(
   }
 
   // --- Single neurons ---
-  candidates.push(
-    ...buildSingleNeuronCandidates(
+  // Issue #2900: stack-safe appends throughout — each builder returns a list
+  // that scales with the discovery's neuron/synapse count, so spreading into
+  // push/splice arguments risks RangeError on large networks.
+  appendAll(
+    candidates,
+    buildSingleNeuronCandidates(
       discovery.ID,
       baseCreature,
       helpfulNeuronCandidates,
@@ -242,8 +247,9 @@ export function buildDiscoveryCandidates(
   );
 
   // --- Coordinated structural ---
-  candidates.push(
-    ...buildCoordinatedStructuralCandidates(
+  appendAll(
+    candidates,
+    buildCoordinatedStructuralCandidates(
       discovery,
       baseCreature,
       getExpectedCoordinated,
@@ -267,8 +273,9 @@ export function buildDiscoveryCandidates(
   }
 
   // --- Single synapses ---
-  candidates.push(
-    ...buildSingleSynapseCandidates(
+  appendAll(
+    candidates,
+    buildSingleSynapseCandidates(
       discovery.ID,
       baseCreature,
       addHelpfulSynapses,
@@ -288,7 +295,7 @@ export function buildDiscoveryCandidates(
     getExpectedRemoval,
     discoveryFailureCacheDir,
   );
-  candidates.push(...synapseRemovalResult.candidates);
+  appendAll(candidates, synapseRemovalResult.candidates);
 
   // --- Combined squash changes ---
   let changedSquashCreature: Creature | undefined;
@@ -303,12 +310,13 @@ export function buildDiscoveryCandidates(
       discoveryFailureCacheDir,
     );
     changedSquashCreature = squashResult.creature;
-    candidates.push(...squashResult.candidates);
+    appendAll(candidates, squashResult.candidates);
   }
 
   // --- Single squash changes ---
-  candidates.push(
-    ...buildSingleSquashCandidates(
+  appendAll(
+    candidates,
+    buildSingleSquashCandidates(
       discovery.ID,
       baseCreature,
       candidateSquashes,
@@ -329,8 +337,9 @@ export function buildDiscoveryCandidates(
   }
 
   // --- Low-impact removal candidates ---
-  candidates.push(
-    ...buildLowImpactRemovalCandidates(
+  appendAll(
+    candidates,
+    buildLowImpactRemovalCandidates(
       discovery,
       baseCreature,
       discoveryFailureCacheDir,
@@ -338,8 +347,9 @@ export function buildDiscoveryCandidates(
   );
 
   // --- Cache-informed multi-neuron removal candidates ---
-  candidates.push(
-    ...buildCacheInformedRemovalCandidates(
+  appendAll(
+    candidates,
+    buildCacheInformedRemovalCandidates(
       baseCreature,
       options?.discoverySuccessCacheDir,
       undefined, // Use default seed

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -90,7 +90,8 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
   async replayDir(
     input: DiscoveryReplayDirInput,
   ): Promise<DiscoveryReplayDirResult> {
-    const { creature, dataDir, options, timeoutMinutes } = input;
+    const { creature, dataDir, options, timeoutMinutes, deadlineTS, signal } =
+      input;
     const config = createNeatConfig(options);
     const verifyScores = config.discoveryReplayVerifyScores;
     const replayConcurrency = verifyScores
@@ -102,16 +103,26 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       diagnosticsEnabled ? {} : undefined;
     let resultToReturn: DiscoveryReplayDirResult | undefined;
 
-    // Issue #1113: Calculate timeout deadline if timeout is provided
-    const deadlineTS = timeoutMinutes !== undefined && timeoutMinutes > 0
-      ? Date.now() + timeoutMinutes * 60 * 1000
-      : undefined;
+    // Issue #1113/#2901: resolve the absolute deadline. A relative
+    // `timeoutMinutes` is converted at runner start; a caller-supplied
+    // `deadlineTS` is absolute and immune to worker-queue/start delays. When
+    // both are present we clamp to the earlier of the two so a late start can
+    // never extend the cap past the intended absolute deadline.
+    const convertedDeadlineTS =
+      timeoutMinutes !== undefined && timeoutMinutes > 0
+        ? Date.now() + timeoutMinutes * 60 * 1000
+        : undefined;
+    const effectiveDeadlineTS =
+      deadlineTS !== undefined && convertedDeadlineTS !== undefined
+        ? Math.min(deadlineTS, convertedDeadlineTS)
+        : deadlineTS ?? convertedDeadlineTS;
     let timedOut = false;
 
-    // Helper to check if we've exceeded the timeout
+    // Helper to check if we've exceeded the timeout or been asked to abort.
     const isTimedOut = (): boolean => {
-      if (!deadlineTS) return false;
-      return Date.now() >= deadlineTS;
+      if (signal?.aborted) return true;
+      if (effectiveDeadlineTS === undefined) return false;
+      return Date.now() >= effectiveDeadlineTS;
     };
 
     const successCacheDir = config.discoverySuccessCacheDir;

--- a/src/discovery/DiscoveryReplayRunnerTypes.ts
+++ b/src/discovery/DiscoveryReplayRunnerTypes.ts
@@ -22,6 +22,24 @@ export interface DiscoveryReplayDirInput {
    * This prevents replay from hanging the evolution process when time runs out.
    */
   timeoutMinutes?: number;
+  /**
+   * Optional absolute wall-clock deadline (ms since epoch) — Issue #2901.
+   *
+   * When supplied, replay stops at its next candidate-boundary check once the
+   * deadline passes. Unlike {@link timeoutMinutes} (converted to a deadline at
+   * runner start), an absolute deadline cannot be shifted by worker-queue or
+   * start delays. When both are provided the runner clamps to the earlier of
+   * the two.
+   */
+  deadlineTS?: number;
+  /**
+   * Optional cooperative abort signal — Issue #2901.
+   *
+   * When aborted, replay stops at its next candidate-boundary check and
+   * performs no further data-directory reads. Used by the queue to abandon an
+   * in-flight replay once the evolution hard cap is reached.
+   */
+  signal?: AbortSignal;
 }
 
 export interface DiscoveryReplayEvaluationSummary {

--- a/src/discovery/DiscoveryWireFormat.ts
+++ b/src/discovery/DiscoveryWireFormat.ts
@@ -1,4 +1,5 @@
 import { TopologyError } from "@errors/TopologyError.ts";
+import { appendAll } from "@utils/ArrayAppend.ts";
 import type {
   CandidateHarmfulNeuron,
   CandidateNeuron,
@@ -332,7 +333,9 @@ export function assertNoLegacyDiscoveryIdFields(value: unknown): void {
     const current = stack.pop();
     if (!current || typeof current !== "object") continue;
     if (Array.isArray(current)) {
-      stack.push(...current);
+      // Issue #2900: stack-safe append; `current` can be a wide creature array
+      // (synapses/neurons), so spreading risks RangeError on large payloads.
+      appendAll(stack, current);
       continue;
     }
     for (const [key, nested] of Object.entries(current)) {

--- a/src/utils/ArrayAppend.ts
+++ b/src/utils/ArrayAppend.ts
@@ -1,0 +1,26 @@
+/**
+ * Stack-safe in-place array append (Issue #2897).
+ *
+ * Appends every element of `items` onto the end of `target`, mutating `target`
+ * and preserving both the existing `target` contents and the order of `items`.
+ *
+ * ## Why not `target.push(...items)`?
+ * Spreading an array into function arguments places one argument per element on
+ * the call stack. For an unbounded array this exceeds the V8 argument/stack
+ * limit (~65k–130k elements depending on stack depth) and throws
+ * `RangeError: Maximum call stack size exceeded`. The same limit applies to
+ * `Array.prototype.push.apply(target, items)`, so that is no safer.
+ *
+ * `concat` avoids the stack limit but allocates a *new* array; the crash site
+ * (`NeatEvolution.ts`) holds `newPopulation` as a `const` that is aliased and
+ * mutated later, so the append must be in place. A plain indexed loop appends
+ * in place with no per-element argument on the stack, so it scales to any size.
+ *
+ * @param target The array to append onto, mutated in place.
+ * @param items  The elements to append, in order. An empty list is a no-op.
+ */
+export function appendAll<T>(target: T[], items: readonly T[]): void {
+  for (let i = 0; i < items.length; i++) {
+    target.push(items[i]);
+  }
+}

--- a/src/utils/ArrayAppend.ts
+++ b/src/utils/ArrayAppend.ts
@@ -24,3 +24,41 @@ export function appendAll<T>(target: T[], items: readonly T[]): void {
     target.push(items[i]);
   }
 }
+
+/**
+ * Stack-safe in-place array insertion (Issue #2900).
+ *
+ * Inserts every element of `items` into `target` at position `index`, mutating
+ * `target` in place. Behaviour is identical to
+ * `target.splice(index, 0, ...items)` — same resulting order and contents — but
+ * without spreading `items` into call arguments.
+ *
+ * ## Why not `target.splice(index, 0, ...items)`?
+ * `splice` takes the inserted elements as individual arguments, so spreading an
+ * unbounded `items` array places one argument per element on the call stack and
+ * throws `RangeError: Maximum call stack size exceeded` past V8's limit — the
+ * same failure mode as `push(...items)`. This helper detaches the tail, appends
+ * `items` with an indexed loop, then re-appends the tail, so it scales to any
+ * size while keeping the same `target` array object (callers that alias
+ * `target` keep their reference).
+ *
+ * @param target The array to insert into, mutated in place.
+ * @param index  The position at which to insert; clamped to `[0, target.length]`.
+ * @param items  The elements to insert, in order. An empty list is a no-op.
+ */
+export function insertAll<T>(
+  target: T[],
+  index: number,
+  items: readonly T[],
+): void {
+  if (items.length === 0) return;
+  const at = Math.max(0, Math.min(index, target.length));
+  const tail = target.slice(at);
+  target.length = at;
+  for (let i = 0; i < items.length; i++) {
+    target.push(items[i]);
+  }
+  for (let i = 0; i < tail.length; i++) {
+    target.push(tail[i]);
+  }
+}

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryHardDeadlineClamp.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryHardDeadlineClamp.ts
@@ -1,0 +1,185 @@
+/**
+ * Issue #2898: clamp discovery recording and analysis-timeout extensions to the
+ * absolute hard deadline (T+15).
+ *
+ * The worker re-anchors its relative record/analysis budgets at `Date.now()`
+ * when it dequeues a request, so a queue delay silently shifts the absolute
+ * completion time past the caller's deadline. These tests prove every
+ * per-discovery deadline — the recording `timeoutTS`, the analysis extension,
+ * and `refreshAnalysisTimeout` top-ups — is clamped to the absolute
+ * `discoveryHardDeadlineTS` cap. Timestamps are injected (a near-future or
+ * already-past cap); the assertions compare against the cap, so no real waiting
+ * is required (#2888 policy).
+ */
+import { assert } from "@std/assert";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import { DataRecorder } from "@architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import type { NeatConfig } from "@config/NeatConfig.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+function makeTestCreature(): Creature {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { uuid: "hidden-a", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-a", weight: -0.5 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+/** Build a config with an injected absolute hard deadline (epoch ms). */
+function configWithHardDeadline(
+  hardDeadlineTS: number | undefined,
+  overrides: Record<string, unknown> = {},
+): NeatConfig {
+  const base = createNeatConfig({
+    discoveryRecordTimeOutMinutes: 5,
+    discoveryAnalysisTimeoutMinutes: 10,
+    ...overrides,
+  });
+  return { ...base, discoveryHardDeadlineTS: hardDeadlineTS } as NeatConfig;
+}
+
+Deno.test("DataRecorder constructor clamps recording timeoutTS to a near-future hard deadline", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  // Cap 5 seconds out — far inside the 5-minute record budget.
+  const cap = Date.now() + 5_000;
+  const recorder = new DataRecorder(creature, configWithHardDeadline(cap), {});
+  assert(
+    recorder.currentTimeoutTS <= cap,
+    `timeoutTS ${recorder.currentTimeoutTS} must not exceed cap ${cap}`,
+  );
+});
+
+Deno.test("DataRecorder constructor clamps recording timeoutTS to an already-past hard deadline", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  const cap = Date.now() - 1_000; // hard deadline already elapsed in the queue
+  const recorder = new DataRecorder(creature, configWithHardDeadline(cap), {});
+  assert(
+    recorder.currentTimeoutTS <= cap,
+    `timeoutTS ${recorder.currentTimeoutTS} must not exceed past cap ${cap}`,
+  );
+});
+
+Deno.test("DataRecorder leaves timeoutTS unclamped when no hard deadline is configured", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  const before = Date.now();
+  const recorder = new DataRecorder(
+    creature,
+    configWithHardDeadline(undefined),
+    {},
+  );
+  // Record budget is 5 minutes; without a cap the deadline sits ~5 min out.
+  const budgetMs = 5 * 60 * 1000;
+  assert(
+    recorder.currentTimeoutTS >= before + budgetMs - 2_000,
+    `Expected unclamped timeoutTS ~${
+      before + budgetMs
+    }, got ${recorder.currentTimeoutTS}`,
+  );
+});
+
+Deno.test("DataRecorder.extendTimeoutForAnalysisPhase clamps analysis deadline to the hard cap", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  const cap = Date.now() + 3_000; // cap well inside the 10-minute analysis budget
+  const config = configWithHardDeadline(cap);
+  const recorder = new DataRecorder(creature, config, {});
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+
+  recorder.extendTimeoutForAnalysisPhase(ds);
+
+  assert(
+    recorder.currentAnalysisDeadlineAt !== undefined &&
+      recorder.currentAnalysisDeadlineAt <= cap,
+    `analysisDeadlineAt ${recorder.currentAnalysisDeadlineAt} must not exceed cap ${cap}`,
+  );
+  assert(
+    recorder.currentTimeoutTS <= cap,
+    `timeoutTS ${recorder.currentTimeoutTS} must not exceed cap ${cap}`,
+  );
+  assert(
+    ds.getTimeoutTS() <= cap,
+    `DiscoverStructure timeoutTS ${ds.getTimeoutTS()} must not exceed cap ${cap}`,
+  );
+});
+
+Deno.test("DataRecorder.refreshAnalysisTimeout never moves the deadline past the hard cap", async () => {
+  await initWasmForTests();
+  const creature = makeTestCreature();
+  const cap = Date.now() + 4_000;
+  const config = configWithHardDeadline(cap);
+  const recorder = new DataRecorder(creature, config, {});
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+
+  recorder.extendTimeoutForAnalysisPhase(ds);
+  // A top-up must stay clamped — the refreshed deadline can only shrink toward
+  // or hold at the cap, never overshoot it.
+  recorder.refreshAnalysisTimeout(ds);
+
+  assert(
+    recorder.currentTimeoutTS <= cap,
+    `post-refresh timeoutTS ${recorder.currentTimeoutTS} must not exceed cap ${cap}`,
+  );
+  assert(
+    ds.getTimeoutTS() <= cap,
+    `post-refresh DiscoverStructure timeoutTS ${ds.getTimeoutTS()} must not exceed cap ${cap}`,
+  );
+});
+
+Deno.test("DiscoverStructure.extendTimeoutForAnalysis clamps to the supplied hard cap", () => {
+  const creature = makeTestCreature();
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+  const cap = Date.now() + 2_000;
+  // Ask for a 10-minute extension but cap 2s out — must land on the cap.
+  ds.extendTimeoutForAnalysis(600, cap);
+  assert(
+    ds.getTimeoutTS() <= cap,
+    `timeoutTS ${ds.getTimeoutTS()} must not exceed cap ${cap}`,
+  );
+});
+
+Deno.test("DiscoverStructure.extendTimeoutForAnalysis remembers the cap for later top-ups", () => {
+  const creature = makeTestCreature();
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+  const cap = Date.now() + 2_000;
+  ds.extendTimeoutForAnalysis(600, cap);
+  // A later top-up with no cap supplied must still honour the remembered cap.
+  ds.extendTimeoutForAnalysis(600);
+  assert(
+    ds.getTimeoutTS() <= cap,
+    `timeoutTS ${ds.getTimeoutTS()} must not exceed remembered cap ${cap}`,
+  );
+});
+
+Deno.test("DiscoverStructure.extendTimeoutForAnalysis is unchanged when no cap is supplied", () => {
+  const creature = makeTestCreature();
+  const ds = new DiscoverStructure(creature, 300, 100, {});
+  const before = Date.now();
+  ds.extendTimeoutForAnalysis(600); // 10 minutes, no cap
+  const tenMinutes = 600 * 1000;
+  assert(
+    ds.getTimeoutTS() >= before + tenMinutes - 2_000,
+    `Expected unclamped timeoutTS ~${
+      before + tenMinutes
+    }, got ${ds.getTimeoutTS()}`,
+  );
+});

--- a/test/NEAT/DiscoveryReplayQueueDeadline.ts
+++ b/test/NEAT/DiscoveryReplayQueueDeadline.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for Issue #2901: DiscoveryReplayQueue deadline awareness.
+ *
+ * The queue must bound both waiting and replaying to an absolute hard cap:
+ * - `waitForCompletion(pastDeadline)` drops the queued replay and signals the
+ *   in-flight replay to abort, returning without awaiting further work.
+ * - `scheduleReplay` skips scheduling once already past the cap.
+ * - `#startReplay` passes an absolute deadline to the runner.
+ * - Uncapped behaviour (no/zero deadline) is unchanged, preserving #1509.
+ *
+ * Behavioural "what" tests with injected timestamps — no elapsed-time
+ * measurement (policy from #2888). Past = epoch ms `1`; future =
+ * `Number.MAX_SAFE_INTEGER`.
+ */
+import { assertEquals } from "@std/assert";
+import type { Creature } from "@creature";
+import {
+  type DiscoveryReplayControl,
+  DiscoveryReplayQueue,
+  type DiscoveryReplayQueueDeps,
+} from "@neat/DiscoveryReplayQueue.ts";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import type { DiscoveryReplayDirResult } from "@discovery/DiscoveryReplayRunner.ts";
+import { makeForwardOnlyCreature as makeBaseCreature } from "../fixtures/SimpleCreatures.ts";
+
+const EMPTY_RESULT: DiscoveryReplayDirResult = {
+  original: { error: 0, score: 0 },
+  evaluatedSingles: 0,
+  evaluatedCombos: 0,
+  pruned: 0,
+  skippedAlreadyApplied: 0,
+  skippedNotApplicable: 0,
+};
+
+Deno.test("DiscoveryReplayQueue - waitForCompletion past the hard cap drops the queued replay and aborts the in-flight one", async () => {
+  const creature1 = makeBaseCreature();
+  creature1.uuid = "fittest-1";
+  const creature2 = makeBaseCreature();
+  creature2.uuid = "fittest-2";
+
+  const startedUuids: string[] = [];
+  let inFlightSignal: AbortSignal | undefined;
+
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: (
+      creature: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+      _timeoutMinutes?: number,
+      control?: DiscoveryReplayControl,
+    ): Promise<DiscoveryReplayDirResult> => {
+      startedUuids.push(creature.uuid ?? "unknown");
+      inFlightSignal = control?.signal;
+      // Resolve only when aborted — models a long replay that stops
+      // cooperatively at its next candidate boundary.
+      return new Promise((resolve) => {
+        const finish = () => resolve({ ...EMPTY_RESULT, timedOut: true });
+        if (control?.signal?.aborted) finish();
+        else control?.signal?.addEventListener("abort", finish);
+      });
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+  const opts = { discoveryCacheDir: "/tmp/cache", costOfGrowth: 0 };
+
+  queue.scheduleReplay(creature1, "/tmp/data", opts); // starts immediately
+  queue.scheduleReplay(creature2, "/tmp/data", opts); // queued behind it
+
+  // Past the hard cap: epoch ms 1 is always in the past.
+  await queue.waitForCompletion(1);
+
+  assertEquals(
+    startedUuids,
+    ["fittest-1"],
+    "Queued replay must not start once past the hard cap",
+  );
+  assertEquals(
+    inFlightSignal?.aborted,
+    true,
+    "In-flight replay must be signalled to abort at the hard cap",
+  );
+
+  // Drain: the in-flight promise resolves on abort, so an uncapped wait settles.
+  await queue.waitForCompletion(Number.MAX_SAFE_INTEGER);
+  assertEquals(
+    queue.isReplayInProgress(),
+    false,
+    "No replay should be in progress after the abandoned replay settles",
+  );
+});
+
+Deno.test("DiscoveryReplayQueue - scheduleReplay skips scheduling once past the hard cap", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "fittest-1";
+
+  const startedUuids: string[] = [];
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: (c: Creature): Promise<DiscoveryReplayDirResult> => {
+      startedUuids.push(c.uuid ?? "unknown");
+      return Promise.resolve(EMPTY_RESULT);
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+
+  // hardDeadlineTS = 1 (epoch ms) is always in the past.
+  queue.scheduleReplay(
+    creature,
+    "/tmp/data",
+    { discoveryCacheDir: "/tmp/cache", costOfGrowth: 0 },
+    undefined,
+    undefined,
+    1,
+  );
+
+  await queue.waitForCompletion();
+
+  assertEquals(startedUuids, [], "No replay should start past the hard cap");
+  assertEquals(queue.isReplayInProgress(), false);
+});
+
+Deno.test("DiscoveryReplayQueue - startReplay passes the absolute hard cap to the runner", async () => {
+  const creature = makeBaseCreature();
+  creature.uuid = "fittest-1";
+
+  let capturedDeadline: number | undefined = -1;
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: (
+      _c: Creature,
+      _dataDir: string,
+      _options: NeatOptions,
+      _timeoutMinutes?: number,
+      control?: DiscoveryReplayControl,
+    ): Promise<DiscoveryReplayDirResult> => {
+      capturedDeadline = control?.deadlineTS;
+      return Promise.resolve(EMPTY_RESULT);
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+
+  // No relative timeout configured (discoveryReplayTimeoutMinutes: 0), so the
+  // absolute deadline passed to the runner is exactly the hard cap.
+  const hardCap = Number.MAX_SAFE_INTEGER;
+  queue.scheduleReplay(
+    creature,
+    "/tmp/data",
+    {
+      discoveryCacheDir: "/tmp/cache",
+      costOfGrowth: 0,
+      discoveryReplayTimeoutMinutes: 0,
+    },
+    undefined,
+    undefined,
+    hardCap,
+  );
+
+  await queue.waitForCompletion();
+
+  assertEquals(
+    capturedDeadline,
+    hardCap,
+    "Runner should receive the absolute hard cap as its deadline",
+  );
+});
+
+Deno.test("DiscoveryReplayQueue - waitForCompletion with a zero cap waits unbounded (preserves #1509)", async () => {
+  const creature1 = makeBaseCreature();
+  creature1.uuid = "fittest-1";
+  const creature2 = makeBaseCreature();
+  creature2.uuid = "fittest-2";
+
+  const completed: string[] = [];
+  const mockDeps: DiscoveryReplayQueueDeps = {
+    replayDir: async (c: Creature): Promise<DiscoveryReplayDirResult> => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      completed.push(c.uuid ?? "unknown");
+      return EMPTY_RESULT;
+    },
+  };
+
+  const queue = new DiscoveryReplayQueue(mockDeps);
+  const opts = { discoveryCacheDir: "/tmp/cache", costOfGrowth: 0 };
+
+  queue.scheduleReplay(creature1, "/tmp/data", opts);
+  queue.scheduleReplay(creature2, "/tmp/data", opts);
+
+  // A zero cap means "no cap" — both replays must complete (Issue #1509).
+  await queue.waitForCompletion(0);
+
+  assertEquals(
+    completed.length,
+    2,
+    "Zero cap must wait for both in-flight and queued replays",
+  );
+  assertEquals(queue.isReplayInProgress(), false);
+});

--- a/test/NEAT/HardDeadline.ts
+++ b/test/NEAT/HardDeadline.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "@std/assert";
+import {
+  computeHardDeadlineTS,
+  HARD_DEADLINE_GRACE_MINUTES,
+} from "@neat/HardDeadline.ts";
+
+// All assertions use absolute timestamps passed in (no real clock), per the
+// policy in #2888: tests assert on returned timestamps, not elapsed wall-clock.
+const START = 1_000_000_000_000; // fixed, arbitrary absolute millisecond epoch
+
+Deno.test("HardDeadline - grace cap constant is 15 minutes", () => {
+  assertEquals(HARD_DEADLINE_GRACE_MINUTES, 15);
+});
+
+Deno.test("HardDeadline - no timeout configured returns undefined", () => {
+  assertEquals(computeHardDeadlineTS(START, 0), undefined);
+});
+
+Deno.test("HardDeadline - unset (undefined) timeout returns undefined", () => {
+  assertEquals(
+    computeHardDeadlineTS(START, undefined as unknown as number),
+    undefined,
+  );
+});
+
+Deno.test("HardDeadline - T=2 gives grace of 2 minutes", () => {
+  // grace = min(15, max(1, 2)) = 2 minutes
+  const expected = START + 2 * 60_000 + 2 * 60_000;
+  assertEquals(computeHardDeadlineTS(START, 2), expected);
+});
+
+Deno.test("HardDeadline - T=45 caps grace at 15 minutes (T+15)", () => {
+  // grace = min(15, max(1, 45)) = 15 minutes
+  const expected = START + 45 * 60_000 + 15 * 60_000;
+  assertEquals(computeHardDeadlineTS(START, 45), expected);
+});
+
+Deno.test("HardDeadline - T=120 clamps grace to 15 minutes", () => {
+  // grace = min(15, max(1, 120)) = 15 minutes
+  const expected = START + 120 * 60_000 + 15 * 60_000;
+  assertEquals(computeHardDeadlineTS(START, 120), expected);
+});
+
+Deno.test("HardDeadline - T=1 gives grace of 1 minute", () => {
+  // grace = min(15, max(1, 1)) = 1 minute
+  const expected = START + 1 * 60_000 + 1 * 60_000;
+  assertEquals(computeHardDeadlineTS(START, 1), expected);
+});

--- a/test/NEAT/NeatAwaitInFlightTasks.ts
+++ b/test/NEAT/NeatAwaitInFlightTasks.ts
@@ -205,6 +205,71 @@ Deno.test("awaitInFlightTasks: handles both discovery and training simultaneousl
   }
 });
 
+// ============================================================================
+// Issue #2896: awaitInFlightTasks must never wait past the absolute hard cap.
+// A hardDeadlineTS already in the past caps the effective timeout at 0, so the
+// wait returns immediately even for a never-settling task — without abandoning
+// the bookkeeping itself (the loop's hard-cap break owns that).
+// ============================================================================
+
+Deno.test("awaitInFlightTasks: past hard deadline caps the wait and returns immediately", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    // A task that never settles — only the hard-cap timeout can release us.
+    neat.discoveryInProgress.set("never-settles", new Promise(() => {}));
+
+    // hardDeadlineTS already in the past → effective timeout clamps to 0. If the
+    // cap were not applied the 30s default would hang and the runner's per-test
+    // timeout would fail (Issue #2888: behavioural, no elapsed-time assertion).
+    await neat.awaitInFlightTasks(30_000, Date.now() - 1000);
+
+    // awaitInFlightTasks only waits; it does not clear the maps.
+    assertEquals(
+      neat.discoveryInProgress.size,
+      1,
+      "awaitInFlightTasks must not abandon tasks itself",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("awaitInFlightTasks: zero hardDeadlineTS disables the cap", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    let resolved = false;
+    let timerId: ReturnType<typeof setTimeout>;
+    const taskPromise = new Promise<void>((resolve) => {
+      timerId = setTimeout(() => {
+        resolved = true;
+        resolve();
+      }, 50);
+    });
+    neat.trainingInProgress.set("settles-soon", taskPromise);
+
+    try {
+      // hardDeadlineTS = 0 disables the cap, so the normal 5s timeout applies
+      // and the task completes well within it.
+      await neat.awaitInFlightTasks(5000, 0);
+      assert(resolved, "Task should complete when the cap is disabled");
+    } finally {
+      clearTimeout(timerId!);
+    }
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
 Deno.test("finishUp: logs waiting message with task counts", async () => {
   const dataDir = createTestDataDir(2, 1);
   const workers = createTestWorkers(dataDir);

--- a/test/NEAT/NeatConstruction.ts
+++ b/test/NEAT/NeatConstruction.ts
@@ -286,6 +286,14 @@ Deno.test("NeatConstruction: timeout is set when timeoutMinutes provided", async
       neat.endTimeTS > Date.now(),
       "endTimeTS should be in the future",
     );
+    // Issue #2895: hardDeadlineTS must be endTimeTS plus the clamped grace.
+    // For timeoutMinutes=5, grace = min(15, max(1, 5)) = 5 minutes. Asserting
+    // the offset from endTimeTS keeps the check independent of the clock.
+    assertEquals(
+      neat.hardDeadlineTS - neat.endTimeTS,
+      5 * 60_000,
+      "hardDeadlineTS should be endTimeTS + 5 minutes of grace",
+    );
   } finally {
     await terminateWorkers(workers);
   }
@@ -306,6 +314,12 @@ Deno.test("NeatConstruction: timeout is zero when not provided", async () => {
       neat.endTimeTS,
       0,
       "endTimeTS should be 0 when no timeout",
+    );
+    // Issue #2895: hardDeadlineTS mirrors endTimeTS — both 0 when no timeout.
+    assertEquals(
+      neat.hardDeadlineTS,
+      0,
+      "hardDeadlineTS should be 0 when no timeout",
     );
   } finally {
     await terminateWorkers(workers);

--- a/test/NEAT/NeatHardDeadlineEnforcement.ts
+++ b/test/NEAT/NeatHardDeadlineEnforcement.ts
@@ -1,0 +1,132 @@
+import { assert, assertEquals } from "@std/assert";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import { Neat } from "@neat/Neat.ts";
+import { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import {
+  type DataRecordInterface,
+  makeDataDir,
+} from "@architecture/DataSet.ts";
+
+/**
+ * Unit tests for Neat.abandonInFlightPastHardDeadline() — Issue #2896.
+ *
+ * The finish-up cycle must break out of the evolve loop unconditionally once
+ * the absolute T+15 hard cap passes, abandoning any in-flight discovery/training
+ * bookkeeping so the abandoned promises cannot be re-awaited. Assertions are
+ * behavioural (state + return value), not elapsed-time measurements (#2888).
+ */
+
+function createTestDataDir(input: number, output: number): string {
+  const records: DataRecordInterface[] = [];
+  for (let i = 0; i < 10; i++) {
+    records.push({
+      input: new Float32Array(
+        Array.from({ length: input }, () => Math.random()),
+      ),
+      output: new Float32Array(
+        Array.from({ length: output }, () => Math.random()),
+      ),
+    });
+  }
+  return makeDataDir(records, 2000);
+}
+
+function createTestWorkers(dataDir: string): WorkerHandler[] {
+  return [new WorkerHandler(dataDir, "MSE", true)];
+}
+
+async function terminateWorkers(workers: WorkerHandler[]): Promise<void> {
+  await Promise.all(workers.map((w) => w.waitUntilReady().catch(() => {})));
+  for (const w of workers) {
+    w.terminate();
+  }
+}
+
+Deno.test("abandonInFlightPastHardDeadline: breaks and abandons in-flight tasks once the cap has passed", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    // Never-settling discovery/training tasks that would otherwise wedge the run.
+    neat.discoveryInProgress.set("stuck-disc", new Promise(() => {}));
+    neat.trainingInProgress.set("stuck-train", new Promise(() => {}));
+
+    // Hard deadline already in the past.
+    const broke = neat.abandonInFlightPastHardDeadline(Date.now() - 1000);
+
+    assert(broke, "Should signal a break once the hard deadline has passed");
+    assertEquals(
+      neat.discoveryInProgress.size,
+      0,
+      "discoveryInProgress must be empty after the forced break",
+    );
+    assertEquals(
+      neat.trainingInProgress.size,
+      0,
+      "trainingInProgress must be empty after the forced break",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("abandonInFlightPastHardDeadline: does not break or abandon before the cap", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    neat.discoveryInProgress.set("disc", Promise.resolve());
+    neat.trainingInProgress.set("train", Promise.resolve());
+
+    // Hard deadline well in the future.
+    const broke = neat.abandonInFlightPastHardDeadline(Date.now() + 60_000);
+
+    assertEquals(broke, false, "Should not break before the hard deadline");
+    assertEquals(
+      neat.discoveryInProgress.size,
+      1,
+      "Discovery bookkeeping must be untouched before the cap",
+    );
+    assertEquals(
+      neat.trainingInProgress.size,
+      1,
+      "Training bookkeeping must be untouched before the cap",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("abandonInFlightPastHardDeadline: zero deadline disables the cap entirely", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    neat.trainingInProgress.set("train", Promise.resolve());
+
+    // 0 means "no timeout configured" → no cap, regardless of wall clock.
+    const broke = neat.abandonInFlightPastHardDeadline(0);
+
+    assertEquals(
+      broke,
+      false,
+      "A zero hard deadline must never break the loop",
+    );
+    assertEquals(
+      neat.trainingInProgress.size,
+      1,
+      "Training bookkeeping must be untouched when the cap is disabled",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});

--- a/test/architecture/training/TrainingOutcome.ts
+++ b/test/architecture/training/TrainingOutcome.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for training-outcome timeout computation (Issue #2899).
+ *
+ * `computeTimeoutTS` is pure and `now`-injectable, so these tests assert on
+ * computed timestamps with injected clock values — no elapsed-time
+ * measurement (#2888 policy).
+ */
+
+import { assertEquals } from "@std/assert";
+import { computeTimeoutTS } from "@architecture/training/TrainingOutcome.ts";
+
+// A fixed, injected "now" — never Date.now().
+const NOW = 1_000_000_000_000;
+const MINUTE_MS = 60 * 1000;
+
+Deno.test("computeTimeoutTS - clamps to an earlier hard deadline", () => {
+  // Relative budget would expire at NOW + 15 min, but the hard deadline is
+  // only 5 minutes away → the hard deadline wins.
+  const hardDeadlineTS = NOW + 5 * MINUTE_MS;
+  const timeoutTS = computeTimeoutTS(NOW, 15, hardDeadlineTS);
+  assertEquals(timeoutTS, hardDeadlineTS);
+});
+
+Deno.test("computeTimeoutTS - absent hard deadline reproduces relative budget", () => {
+  // Exactly the pre-#2899 computation: now + minutes * 60 * 1000.
+  assertEquals(computeTimeoutTS(NOW, 15), NOW + 15 * MINUTE_MS);
+  assertEquals(computeTimeoutTS(NOW, 15, undefined), NOW + 15 * MINUTE_MS);
+  // A zero hard deadline is treated as "no deadline".
+  assertEquals(computeTimeoutTS(NOW, 15, 0), NOW + 15 * MINUTE_MS);
+});
+
+Deno.test("computeTimeoutTS - keeps relative budget when it is the earlier limit", () => {
+  // Hard deadline is far in the future → the relative budget still governs.
+  const hardDeadlineTS = NOW + 60 * MINUTE_MS;
+  assertEquals(computeTimeoutTS(NOW, 10, hardDeadlineTS), NOW + 10 * MINUTE_MS);
+});
+
+Deno.test("computeTimeoutTS - no relative budget falls back to the hard deadline", () => {
+  // trainingTimeOutMinutes === 0 (no relative budget) but a hard deadline is
+  // present → the hard deadline caps the run.
+  const hardDeadlineTS = NOW + 5 * MINUTE_MS;
+  assertEquals(computeTimeoutTS(NOW, 0, hardDeadlineTS), hardDeadlineTS);
+});
+
+Deno.test("computeTimeoutTS - no budget and no deadline means no timeout", () => {
+  assertEquals(computeTimeoutTS(NOW, 0), 0);
+  assertEquals(computeTimeoutTS(NOW, 0, 0), 0);
+});
+
+Deno.test("computeTimeoutTS - hard deadline already in the past returns that past instant", () => {
+  // A deadline earlier than `now` is returned verbatim; the per-iteration
+  // timeout check then trips immediately and the best-so-far result returns.
+  const pastDeadline = NOW - 5 * MINUTE_MS;
+  assertEquals(computeTimeoutTS(NOW, 15, pastDeadline), pastDeadline);
+});

--- a/test/architecture/training/TrainingSetup.ts
+++ b/test/architecture/training/TrainingSetup.ts
@@ -108,4 +108,23 @@ Deno.test("TrainingSetup - prepareTraining allocates buffers and applies options
   // bestCreatureJSON should match creature I/O counts.
   assertEquals(setup.bestCreatureJSON.input, 3);
   assertEquals(setup.bestCreatureJSON.output, 2);
+  // Issue #2899: absent hardDeadlineTS leaves the field undefined.
+  assertEquals(setup.hardDeadlineTS, undefined);
+});
+
+Deno.test("TrainingSetup - prepareTraining carries hardDeadlineTS through (Issue #2899)", () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const hardDeadlineTS = 1_000_000_000_000;
+  const setup = prepareTraining(
+    creature,
+    {
+      iterations: 1,
+      trainingTimeOutMinutes: 15,
+      hardDeadlineTS,
+    },
+    "deadln01",
+  );
+
+  assertEquals(setup.trainingTimeOutMinutes, 15);
+  assertEquals(setup.hardDeadlineTS, hardDeadlineTS);
 });

--- a/test/blackbox/FineTunePopulationStackSafe.ts
+++ b/test/blackbox/FineTunePopulationStackSafe.ts
@@ -1,0 +1,62 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import { appendAll } from "@utils/ArrayAppend.ts";
+
+// Issue #2900: FindTunePopulation.make() appends fine-tuned batches into
+// `fineTunedPopulation` (FineTunePopulation.ts:153/162/218/255). The batch size
+// scales with `fineTunePopSize`, which is derived from the configured
+// population size (>= ceil(populationSize / 5)), so spreading the batch into
+// `push(...batch)` could throw `RangeError: Maximum call stack size exceeded`
+// at large population sizes.
+//
+// Driving make() at that scale is impractical for a unit test — it would need
+// hundreds of thousands of scored, species-assigned creatures and the heavy
+// per-creature fine-tuning compute, far exceeding the 120s unit-test budget.
+// These tests instead exercise the exact operation the fixed lines now perform:
+// appending a large Creature[] batch into a population array via the stack-safe
+// helper, with a canary proving the old spread crashes at the same size.
+
+function makeMinimalCreature(): Creature {
+  // Smallest valid creature: two inputs wired to one output.
+  return Creature.fromJSON({
+    neurons: [
+      { bias: 0, type: "input", squash: "LOGISTIC", index: 0 },
+      { bias: 0, type: "input", squash: "LOGISTIC", index: 1 },
+      { bias: 0, type: "output", squash: "BIPOLAR_SIGMOID", index: 2 },
+    ],
+    synapses: [{ weight: 0.5, from: 1, to: 2 }],
+    input: 2,
+    output: 1,
+  });
+}
+
+Deno.test("FineTunePopulation append - large fine-tuned batch appends without RangeError (regression #2900)", () => {
+  const SIZE = 200_000;
+  const batch: Creature[] = new Array(SIZE);
+  const shared = makeMinimalCreature();
+  for (let i = 0; i < SIZE; i++) batch[i] = shared;
+
+  // Canary: this is the spread that FineTunePopulation.ts used to run.
+  const canary: Creature[] = [];
+  assertThrows(() => canary.push(...batch), RangeError);
+
+  // Fix: the population already holds a seed creature; appending the batch
+  // preserves the seed at the front and the batch order behind it.
+  const fineTunedPopulation: Creature[] = [shared];
+  appendAll(fineTunedPopulation, batch);
+
+  assertEquals(fineTunedPopulation.length, SIZE + 1);
+  assertEquals(fineTunedPopulation[0], shared);
+  assertEquals(fineTunedPopulation[SIZE], shared);
+});
+
+Deno.test("FineTunePopulation append - order and contents preserved for a small batch", () => {
+  const a = makeMinimalCreature();
+  const b = makeMinimalCreature();
+  const c = makeMinimalCreature();
+
+  const fineTunedPopulation: Creature[] = [a];
+  appendAll(fineTunedPopulation, [b, c]);
+
+  assertEquals(fineTunedPopulation, [a, b, c]);
+});

--- a/test/creature/EvolveDirHardDeadline.ts
+++ b/test/creature/EvolveDirHardDeadline.ts
@@ -1,0 +1,224 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { evolveDir } from "@creature/CreatureTraining.ts";
+import type { EvolveDirDeps } from "@creature/CreatureTraining.ts";
+import type { Neat } from "@neat/Neat.ts";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import {
+  type DataRecordInterface,
+  makeDataDir,
+} from "@architecture/DataSet.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/**
+ * End-to-end T+15 hard-deadline guard — Issue #2902, part of #2892.
+ *
+ * Proves that `evolveDir(timeoutMinutes = T)` returns with consistent state
+ * once the absolute hard cap (T + min(15, T) minutes) passes, even when
+ * discovery / training work is stubbed to never resolve. The cap is driven by
+ * an injected past `startTimeMS` rather than real sleeps, so every assertion is
+ * behavioural (state + return value), never an elapsed-time measurement — the
+ * policy from #2888. The whole suite stays well inside the 120 s test budget.
+ *
+ * Linkage to #2896: the run terminates because the finish-up cycle takes the
+ * `abandonInFlightPastHardDeadline` branch, which breaks on the *first*
+ * completed cycle (so the run returns at `generation === 1`). Against the
+ * pre-#2896 behaviour the finish-up cycle could only clear the stuck task and
+ * then spin through further evolve() generations / waits before stopping, so a
+ * run that returns at exactly generation 1 with a never-resolving in-flight
+ * task could not have happened. Verified by temporarily neutering the branch:
+ * the `result.generation === 1` assertion then fails (the run reaches
+ * generation 2+), confirming the test genuinely depends on the hard cap.
+ */
+
+/** Minimal 2-in / 1-out dataset; the model never needs to converge here. */
+function tinyDataSet(): DataRecordInterface[] {
+  return [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+  ];
+}
+
+/**
+ * Build the shared options + a past-start deps seam so the soft timeout and the
+ * T+15 hard cap are already behind the wall clock when the first finish-up
+ * cycle runs. `captureNeat` lets the caller stub in-flight work and inspect the
+ * in-flight maps after the run.
+ */
+function hardDeadlineDeps(captureNeat: (neat: Neat) => void): EvolveDirDeps {
+  return {
+    // One hour in the past: with timeoutMinutes = 1 the soft endTime (start +
+    // 1 min) and the hard cap (start + 1 min + 1 min grace) both sit ~58 min
+    // before now, so abandonInFlightPastHardDeadline fires on generation 1.
+    startTimeMS: Date.now() - 60 * 60 * 1000,
+    onNeatReady: captureNeat,
+  };
+}
+
+function baseOptions(creatureStore: string): NeatOptions {
+  return {
+    populationSize: 10,
+    iterations: 1,
+    timeoutMinutes: 1,
+    threads: 1,
+    creatureStore,
+  };
+}
+
+/** Load every persisted creature from a `creatureStore` directory. */
+async function loadStoredCreatures(dir: string): Promise<Creature[]> {
+  const creatures: Creature[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    if (!entry.isFile || !entry.name.endsWith(".json")) continue;
+    const json = JSON.parse(await Deno.readTextFile(`${dir}/${entry.name}`));
+    creatures.push(Creature.fromJSON(json));
+  }
+  return creatures;
+}
+
+Deno.test({
+  name:
+    "evolveDir T+15 guard: training-mode run returns once the hard cap passes",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await initWasmForTests();
+
+    const dataSetDir = makeDataDir(tinyDataSet(), 2000);
+    const creatureStore = await Deno.makeTempDir({ prefix: "neat-t15-train-" });
+    const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+
+    let captured: Neat | undefined;
+    const deps = hardDeadlineDeps((neat) => {
+      captured = neat;
+      // Stubbed never-resolving training work — only the hard cap can release
+      // the finish-up cycle (no Rust FFI involved).
+      neat.trainingInProgress.set("stuck-train", new Promise<void>(() => {}));
+    });
+
+    const result = await evolveDir(
+      creature,
+      dataSetDir,
+      baseOptions(creatureStore),
+      deps,
+    );
+
+    // The function returned (no hang) with a finite best result loaded onto the
+    // caller's creature.
+    assert(Number.isFinite(result.score), "best score must be finite");
+    assert(Number.isFinite(result.error), "best error must be finite");
+    // #2896 linkage: the hard-cap branch breaks on the *first* completed cycle,
+    // before finishUp() can ask for more wait generations. Against the
+    // pre-#2896 behaviour the finish-up cycle would clear the stub and spin
+    // through extra evolve() generations (generation > 1) before stopping, so a
+    // run that returns at exactly generation 1 with a never-resolving in-flight
+    // task can only have taken the abandonInFlightPastHardDeadline branch.
+    assertEquals(
+      result.generation,
+      1,
+      "the hard-cap branch must break on the first completed cycle",
+    );
+    // The best creature found was loaded onto the caller's creature: it is a
+    // valid, activatable network that round-trips through JSON.
+    const activation = creature.activate(new Float32Array([1, 0]))[0];
+    assert(
+      Number.isFinite(activation),
+      "loaded best creature must activate to a finite value",
+    );
+    assertEquals(
+      Creature.fromJSON(creature.exportJSON()).input,
+      2,
+      "loaded best creature must round-trip through JSON",
+    );
+
+    // In-flight bookkeeping was abandoned by the hard-cap branch.
+    assert(captured, "onNeatReady must have handed back the Neat instance");
+    assertEquals(
+      captured.trainingInProgress.size,
+      0,
+      "trainingInProgress must be empty after the hard-cap break",
+    );
+    assertEquals(
+      captured.discoveryInProgress.size,
+      0,
+      "discoveryInProgress must be empty after the hard-cap break",
+    );
+    assertEquals(
+      captured.discoveryReplayQueue.isReplayInProgress(),
+      false,
+      "no replay may be left wedged after the run returns",
+    );
+
+    // creatureStore was written and the persisted creatures are loadable.
+    const stored = await loadStoredCreatures(creatureStore);
+    assert(stored.length > 0, "creatureStore must contain at least one file");
+    for (const loaded of stored) {
+      assertEquals(loaded.input, 2, "stored creature input must round-trip");
+      assertEquals(loaded.output, 1, "stored creature output must round-trip");
+    }
+
+    await Deno.remove(dataSetDir, { recursive: true });
+    await Deno.remove(creatureStore, { recursive: true });
+  },
+});
+
+Deno.test({
+  name:
+    "evolveDir T+15 guard: discovery-mode run (stubbed) returns once the hard cap passes",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await initWasmForTests();
+
+    const dataSetDir = makeDataDir(tinyDataSet(), 2000);
+    const creatureStore = await Deno.makeTempDir({ prefix: "neat-t15-disc-" });
+    const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+
+    let captured: Neat | undefined;
+    const deps = hardDeadlineDeps((neat) => {
+      captured = neat;
+      // Discovery stubbed so CI needs no Rust FFI: a never-resolving promise
+      // standing in for an in-flight discovery task.
+      neat.discoveryInProgress.set("stuck-disc", new Promise<void>(() => {}));
+    });
+
+    const result = await evolveDir(
+      creature,
+      dataSetDir,
+      baseOptions(creatureStore),
+      deps,
+    );
+
+    assert(Number.isFinite(result.score), "best score must be finite");
+    assert(Number.isFinite(result.error), "best error must be finite");
+    // #2896 linkage: see the training-mode test — breaking at exactly
+    // generation 1 with a never-resolving stub proves the hard-cap branch fired.
+    assertEquals(
+      result.generation,
+      1,
+      "the hard-cap branch must break on the first completed cycle",
+    );
+
+    assert(captured, "onNeatReady must have handed back the Neat instance");
+    assertEquals(
+      captured.discoveryInProgress.size,
+      0,
+      "discoveryInProgress must be empty after the hard-cap break",
+    );
+    assertEquals(
+      captured.trainingInProgress.size,
+      0,
+      "trainingInProgress must be empty after the hard-cap break",
+    );
+
+    const stored = await loadStoredCreatures(creatureStore);
+    assert(stored.length > 0, "creatureStore must contain at least one file");
+    assertEquals(stored[0].input, 2, "stored creature input must round-trip");
+    assertEquals(stored[0].output, 1, "stored creature output must round-trip");
+
+    await Deno.remove(dataSetDir, { recursive: true });
+    await Deno.remove(creatureStore, { recursive: true });
+  },
+});

--- a/test/discovery/DiscoveryReplayRunnerDeadline.ts
+++ b/test/discovery/DiscoveryReplayRunnerDeadline.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for Issue #2901: DiscoveryReplayRunner absolute-deadline and
+ * cooperative-abort handling.
+ *
+ * The runner must honour an absolute `deadlineTS` (immune to worker-queue /
+ * start delays) and a cooperative abort `signal`. When either fires, the
+ * runner stops at its next candidate-boundary check and performs no further
+ * data-directory reads (no candidate evaluation).
+ *
+ * These are behavioural "what" tests using injected timestamps and a
+ * pre-aborted signal — no elapsed-time measurement (policy from #2888).
+ */
+import { assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { DiscoveryReplayRunner } from "@discovery/DiscoveryReplayRunner.ts";
+import { DISCOVERY_WIRE_SCHEMA_VERSION } from "@discovery/DiscoveryWireFormat.ts";
+import type { SuccessCacheEntry } from "@discovery/SuccessCache.ts";
+import { makeForwardOnlyCreature as makeBaseCreature } from "../fixtures/SimpleCreatures.ts";
+
+function makeEntry(overrides: Partial<SuccessCacheEntry>): SuccessCacheEntry {
+  return {
+    wireSchemaVersion: overrides.wireSchemaVersion ??
+      DISCOVERY_WIRE_SCHEMA_VERSION,
+    key: overrides.key ?? "k",
+    changeType: overrides.changeType ?? "add-synapses",
+    description: overrides.description,
+    originalScore: overrides.originalScore ?? 0.5,
+    candidateScore: overrides.candidateScore ?? 0.6,
+    scoreDelta: overrides.scoreDelta ?? 0.1,
+    error: overrides.error ?? 0.4,
+    originalError: overrides.originalError ?? 0.5,
+    timestamp: overrides.timestamp ?? new Date().toISOString(),
+    rustRequest: overrides.rustRequest,
+    actualCreatureChange: overrides.actualCreatureChange,
+    discoveryVersion: overrides.discoveryVersion,
+  };
+}
+
+const OPTIONS = {
+  discoverySuccessCacheDir: "/tmp/does-not-matter",
+  costOfGrowth: 0,
+  discoveryReplayMaxSingles: 10,
+  threads: 1,
+};
+
+Deno.test("DiscoveryReplayRunner honours an absolute deadline earlier than now + timeoutMinutes", async () => {
+  const base = makeBaseCreature();
+  base.uuid = "base";
+
+  let evaluateCalls = 0;
+  let listCalls = 0;
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: (_dir) => {
+      listCalls++;
+      return [makeEntry({ key: "k1" })];
+    },
+    archiveEntry: () => {},
+    applyEntry: (current, entry) => {
+      const clone = Creature.fromJSON(current.exportJSON());
+      clone.uuid = `${current.uuid ?? "base"}-${entry.key}`;
+      return clone;
+    },
+    evaluateError: () => {
+      evaluateCalls++;
+      return Promise.resolve({ error: 0, score: 0.5 });
+    },
+  });
+
+  // timeoutMinutes is generous (10m) but the absolute deadline is in the past
+  // (1ms after epoch). The earlier deadline must win, so the runner times out
+  // before evaluating any candidate.
+  const result = await runner.replayDir({
+    creature: base,
+    dataDir: "/tmp/does-not-matter",
+    options: OPTIONS,
+    timeoutMinutes: 10,
+    deadlineTS: 1,
+  });
+
+  assertEquals(
+    result.timedOut,
+    true,
+    "Absolute deadline should win over timeoutMinutes",
+  );
+  assertEquals(
+    result.evaluatedSingles,
+    0,
+    "No singles evaluated after timeout",
+  );
+  assertEquals(
+    evaluateCalls,
+    0,
+    "No candidate evaluation after the deadline boundary",
+  );
+  assertEquals(
+    listCalls,
+    1,
+    "Cache listed once before the first boundary check",
+  );
+});
+
+Deno.test("DiscoveryReplayRunner stops at the candidate boundary when the abort signal is already aborted", async () => {
+  const base = makeBaseCreature();
+  base.uuid = "base";
+
+  let evaluateCalls = 0;
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: (_dir) => [makeEntry({ key: "k1" })],
+    archiveEntry: () => {},
+    applyEntry: (current, entry) => {
+      const clone = Creature.fromJSON(current.exportJSON());
+      clone.uuid = `${current.uuid ?? "base"}-${entry.key}`;
+      return clone;
+    },
+    evaluateError: () => {
+      evaluateCalls++;
+      return Promise.resolve({ error: 0, score: 0.5 });
+    },
+  });
+
+  const controller = new AbortController();
+  controller.abort();
+
+  const result = await runner.replayDir({
+    creature: base,
+    dataDir: "/tmp/does-not-matter",
+    options: OPTIONS,
+    signal: controller.signal,
+  });
+
+  assertEquals(result.timedOut, true, "Aborted signal should stop the replay");
+  assertEquals(result.evaluatedSingles, 0, "No singles evaluated once aborted");
+  assertEquals(
+    evaluateCalls,
+    0,
+    "Aborted replay performs no candidate evaluation",
+  );
+});
+
+Deno.test("DiscoveryReplayRunner completes normally when the absolute deadline is far in the future", async () => {
+  const base = makeBaseCreature();
+  base.uuid = "base";
+
+  const runner = new DiscoveryReplayRunner({
+    listEntries: (_dir) => [makeEntry({ key: "k1" })],
+    archiveEntry: () => {},
+    applyEntry: (current, entry) => {
+      const clone = Creature.fromJSON(current.exportJSON());
+      clone.uuid = `${current.uuid ?? "base"}-${entry.key}`;
+      return clone;
+    },
+    evaluateError: (c) => {
+      const id = c.uuid ?? "";
+      if (id.endsWith("-k1")) {
+        return Promise.resolve({ error: 0.4, score: 0.6 });
+      }
+      return Promise.resolve({ error: 0.5, score: 0.5 });
+    },
+  });
+
+  const result = await runner.replayDir({
+    creature: base,
+    dataDir: "/tmp/does-not-matter",
+    options: OPTIONS,
+    deadlineTS: Number.MAX_SAFE_INTEGER,
+  });
+
+  assertEquals(
+    result.timedOut,
+    undefined,
+    "Far-future deadline should not time out",
+  );
+  assertEquals(result.evaluatedSingles, 1);
+});

--- a/test/discovery/DiscoveryWireFormatStackSafe.ts
+++ b/test/discovery/DiscoveryWireFormatStackSafe.ts
@@ -1,0 +1,64 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { assertNoLegacyDiscoveryIdFields } from "@discovery/DiscoveryWireFormat.ts";
+import { TopologyError } from "@errors/TopologyError.ts";
+
+// Issue #2900: assertNoLegacyDiscoveryIdFields walks a wire payload with an
+// explicit stack and previously did `stack.push(...current)` for arrays. A
+// creature wire payload can carry a very wide synapse/neuron array, so the
+// spread could throw RangeError. These tests confirm the traversal stays
+// behaviour-identical while scaling to arrays past the spread limit.
+
+Deno.test("assertNoLegacyDiscoveryIdFields - accepts a clean payload", () => {
+  assertNoLegacyDiscoveryIdFields({
+    synapses: [{ from: 0, to: 1, weight: 0.5 }],
+    neurons: [{ index: 0 }, { index: 1 }],
+  });
+});
+
+Deno.test("assertNoLegacyDiscoveryIdFields - throws on a leaked legacy id field", () => {
+  assertThrows(
+    () =>
+      assertNoLegacyDiscoveryIdFields({
+        operations: [{ fromNeuronId: 7 }],
+      }),
+    TopologyError,
+  );
+});
+
+Deno.test("assertNoLegacyDiscoveryIdFields - traverses a wide array without RangeError (regression #2900)", () => {
+  const SIZE = 200_000;
+  const wide = new Array(SIZE);
+  for (let i = 0; i < SIZE; i++) wide[i] = { ok: i };
+
+  // Canary: spreading an array this wide into push arguments crashes; this is
+  // the exact shape the traversal used to run on each array node.
+  const canary: unknown[] = [];
+  assertThrows(() => canary.push(...wide), RangeError);
+
+  // The traversal now uses a stack-safe append, so a wide-but-clean payload
+  // validates without throwing.
+  assertNoLegacyDiscoveryIdFields({ synapses: wide });
+});
+
+Deno.test("assertNoLegacyDiscoveryIdFields - still detects a legacy field inside a wide array (regression #2900)", () => {
+  const SIZE = 200_000;
+  const wide = new Array(SIZE);
+  for (let i = 0; i < SIZE; i++) wide[i] = { ok: i };
+  // Hide a legacy field deep in the wide array.
+  wide[SIZE - 1] = { removedNeuronIds: [3] };
+
+  assertThrows(
+    () => assertNoLegacyDiscoveryIdFields({ synapses: wide }),
+    TopologyError,
+  );
+});
+
+Deno.test("assertNoLegacyDiscoveryIdFields - order of traversal preserves contents (behaviour unchanged)", () => {
+  // A nested structure that mixes arrays and objects; no legacy fields means
+  // a clean pass, proving appendAll visits the same nodes as the old spread.
+  assertNoLegacyDiscoveryIdFields({
+    a: [1, 2, [3, 4, { b: [5, 6] }]],
+    c: { d: [{ e: 7 }] },
+  });
+  assertEquals(true, true);
+});

--- a/test/utils/ArrayAppend.ts
+++ b/test/utils/ArrayAppend.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertThrows } from "@std/assert";
-import { appendAll } from "@utils/ArrayAppend.ts";
+import { appendAll, insertAll } from "@utils/ArrayAppend.ts";
 
 Deno.test("appendAll - happy path appends in order after existing contents", () => {
   const target = [1, 2, 3];
@@ -40,4 +40,55 @@ Deno.test("appendAll - large batch exceeds the spread limit (regression #2897)",
   assertEquals(target[0], -1);
   assertEquals(target[1], 0);
   assertEquals(target[SIZE], SIZE - 1);
+});
+
+Deno.test("insertAll - inserts in order at the given index", () => {
+  const target = [1, 2, 5, 6];
+  insertAll(target, 2, [3, 4]);
+  assertEquals(target, [1, 2, 3, 4, 5, 6]);
+});
+
+Deno.test("insertAll - mutates the same array object in place", () => {
+  const target = [1, 4];
+  const alias = target;
+  insertAll(target, 1, [2, 3]);
+  // The alias still references the mutated array (no reassignment).
+  assertEquals(alias, [1, 2, 3, 4]);
+  assertEquals(alias, target);
+});
+
+Deno.test("insertAll - empty items is a no-op", () => {
+  const target = ["a", "b"];
+  insertAll(target, 1, []);
+  assertEquals(target, ["a", "b"]);
+});
+
+Deno.test("insertAll - index 0 prepends, index >= length appends", () => {
+  const front = [3, 4];
+  insertAll(front, 0, [1, 2]);
+  assertEquals(front, [1, 2, 3, 4]);
+
+  const back = [1, 2];
+  insertAll(back, 99, [3, 4]); // clamped to length
+  assertEquals(back, [1, 2, 3, 4]);
+});
+
+Deno.test("insertAll - large batch exceeds the splice spread limit (regression #2900)", () => {
+  const SIZE = 200_000;
+  const bigArray = new Array(SIZE);
+  for (let i = 0; i < SIZE; i++) bigArray[i] = i;
+
+  // Canary: the original splice-spread crashes at this scale.
+  const canary = [-1, -2];
+  assertThrows(() => canary.splice(1, 0, ...bigArray), RangeError);
+
+  // Fix: insertAll inserts the same batch without throwing, preserving the
+  // surrounding elements and the inserted order.
+  const target = [-1, -2];
+  insertAll(target, 1, bigArray);
+  assertEquals(target.length, SIZE + 2);
+  assertEquals(target[0], -1);
+  assertEquals(target[1], 0);
+  assertEquals(target[SIZE], SIZE - 1);
+  assertEquals(target[SIZE + 1], -2);
 });

--- a/test/utils/ArrayAppend.ts
+++ b/test/utils/ArrayAppend.ts
@@ -1,0 +1,43 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { appendAll } from "@utils/ArrayAppend.ts";
+
+Deno.test("appendAll - happy path appends in order after existing contents", () => {
+  const target = [1, 2, 3];
+  appendAll(target, [4, 5, 6]);
+  assertEquals(target, [1, 2, 3, 4, 5, 6]);
+});
+
+Deno.test("appendAll - empty items is a no-op", () => {
+  const target = ["a", "b"];
+  appendAll(target, []);
+  assertEquals(target, ["a", "b"]);
+});
+
+Deno.test("appendAll - empty target receives all items in order", () => {
+  const target: number[] = [];
+  appendAll(target, [10, 20, 30]);
+  assertEquals(target, [10, 20, 30]);
+});
+
+Deno.test("appendAll - large batch exceeds the spread limit (regression #2897)", () => {
+  // Size chosen to exceed V8's spread-into-arguments limit. The canary below
+  // proves the size is genuinely over the limit; if a future V8 raises it, the
+  // canary fails loudly so the size can be revisited rather than passing for
+  // the wrong reason.
+  const SIZE = 200_000;
+  const bigArray = new Array(SIZE);
+  for (let i = 0; i < SIZE; i++) bigArray[i] = i;
+
+  // Canary: the original spread-push crashes at this scale.
+  const canary: number[] = [];
+  assertThrows(() => canary.push(...bigArray), RangeError);
+
+  // Fix: appendAll appends the same batch without throwing, preserving the
+  // pre-existing front element, length, and order.
+  const target = [-1];
+  appendAll(target, bigArray);
+  assertEquals(target.length, SIZE + 1);
+  assertEquals(target[0], -1);
+  assertEquals(target[1], 0);
+  assertEquals(target[SIZE], SIZE - 1);
+});


### PR DESCRIPTION
## Milestone: fix-timeout

This PR merges the completed milestone branch into Develop.
Closes #2922

### Issues addressed
- #2902: End-to-end T+15 guard test and timeout-semantics documentation
- #2901: Bound discovery replay queue waits and replays to the hard deadline
- #2900: Audit spread-into-arguments call sites in src/ and apply stack-safe fixes to unbounded ones
- #2899: Clamp scheduled training tasks to the absolute hard deadline
- #2898: Clamp discovery recording and analysis-timeout extensions to the absolute hard deadline
- #2897: Fix evolve() spread-push stack overflow at NeatEvolution.ts:688 with stack-safe append helper and regression test
- #2896: Enforce the T+15 hard cap in the evolve loops and bound awaitInFlightTasks
- #2895: Add hard-deadline (T+15) helper and plumb hardDeadlineTS through Neat and the evolve variants

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.