### PR TITLE
Breeding: Remove mid-run warm-up tag maintenance (#2911)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2911.md
+++ b/docs/archive/pr-summaries/pr-summary-2911.md
@@ -1,0 +1,70 @@
+## Summary
+
+Stop maintaining the `warmupGenerations` / `currentGeneration` tags on
+creatures **during a run**. The Neat-level warm-up counter is the single
+source of truth mid-run; the two tags exist only at the load
+(`Neat.populatePopulation`) and save (Issue #2909) boundaries. Three sites
+were the de facto count-keeping mechanism and the reason saved creatures
+carried stale values — offspring inherited `max(parents)` without
+incrementing, so a stale seed value propagated forever. Removing them
+makes the counter authoritative. Closes #2911.
+
+Removed:
+
+- `propagateSeedWarmupTags` in `src/architecture/Offspring.ts` and both
+  call sites — offspring no longer inherit warm-up tags.
+- `propagateSeedWarmupTagsFromTeachers` in
+  `src/breed/OnPolicyDistillationBreed.ts` and its call site — the
+  distilled student no longer inherits teacher warm-up tags.
+- The warm-up tag copy in `WorkerHandler.train()` — the training
+  round-trip no longer carries warm-up tags.
+
+Warm-up protection is unaffected: it is enforced at the Neat level via
+`mutator.setWarmupContext(...)` in `NeatEvolution.ts`, not via per-creature
+tags. The full suite (including `test/NEAT/MutatorWarmup.ts`) passes.
+
+## Evidence
+
+Backend-only change — no web interface to screenshot. Verified via the
+test suite and the acceptance-criteria grep.
+
+`./quality.sh < /dev/null` passes: **7069 passed, 0 failed** (exit 0).
+
+Acceptance-criteria grep — no code path outside the load/save boundary
+(`src/architecture/CreatureFactory.ts`) reads or writes the two tags:
+
+```
+$ grep -rn "WARMUP_GENERATIONS_TAG\|CURRENT_GENERATION_TAG" src/ \
+    | grep -v "src/architecture/CreatureFactory.ts"
+(no matches)
+```
+
+```mermaid
+flowchart LR
+    subgraph Before["Before — tags maintained mid-run"]
+      P1[Parents/Teachers] -->|copy max tags| O1[Offspring]
+      C1[Creature] -->|copy tags| T1[Train round-trip]
+    end
+    subgraph After["After — counter is source of truth"]
+      P2[Parents/Teachers] -->|no tags copied| O2[Offspring]
+      C2[Creature] -->|no tags copied| T2[Train round-trip]
+      N[Neat-level counter] -.->|stamps at save| Save[(Saved creature)]
+    end
+```
+
+## Test Plan
+
+- `test/architecture/SeedWarmupPersistence.ts` — replaced the three
+  "warm-up tags survive breeding" assertions with
+  `Offspring.breed: offspring does NOT carry warm-up tags from parents`
+  and `grafted breeding does NOT carry warm-up tags`; save-boundary and
+  read/write round-trip tests retained unchanged.
+- `test/breed/OnPolicyDistillationBreed.ts` — rewrote
+  `warm-up tags survive onto offspring` to assert the distilled student
+  carries **no** warm-up tags.
+- `test/multithreading/WorkerHandler.ts` — rewrote
+  `WorkerHandler.train: keeps warm-up tags…` to assert the train payload
+  does **not** carry the two warm-up tags, while existing training-context
+  tags (`untrained-error`) remain.
+- `test/NEAT/MutatorWarmup.ts` — unchanged, still passes (structural
+  mutations remain blocked during warm-up).

--- a/docs/archive/pr-summaries/pr-summary-2911.md
+++ b/docs/archive/pr-summaries/pr-summary-2911.md
@@ -1,23 +1,22 @@
 ## Summary
 
-Stop maintaining the `warmupGenerations` / `currentGeneration` tags on
-creatures **during a run**. The Neat-level warm-up counter is the single
-source of truth mid-run; the two tags exist only at the load
-(`Neat.populatePopulation`) and save (Issue #2909) boundaries. Three sites
-were the de facto count-keeping mechanism and the reason saved creatures
-carried stale values — offspring inherited `max(parents)` without
-incrementing, so a stale seed value propagated forever. Removing them
-makes the counter authoritative. Closes #2911.
+Stop maintaining the `warmupGenerations` / `currentGeneration` tags on creatures
+**during a run**. The Neat-level warm-up counter is the single source of truth
+mid-run; the two tags exist only at the load (`Neat.populatePopulation`) and
+save (Issue #2909) boundaries. Three sites were the de facto count-keeping
+mechanism and the reason saved creatures carried stale values — offspring
+inherited `max(parents)` without incrementing, so a stale seed value propagated
+forever. Removing them makes the counter authoritative. Closes #2911.
 
 Removed:
 
-- `propagateSeedWarmupTags` in `src/architecture/Offspring.ts` and both
-  call sites — offspring no longer inherit warm-up tags.
+- `propagateSeedWarmupTags` in `src/architecture/Offspring.ts` and both call
+  sites — offspring no longer inherit warm-up tags.
 - `propagateSeedWarmupTagsFromTeachers` in
-  `src/breed/OnPolicyDistillationBreed.ts` and its call site — the
-  distilled student no longer inherits teacher warm-up tags.
-- The warm-up tag copy in `WorkerHandler.train()` — the training
-  round-trip no longer carries warm-up tags.
+  `src/breed/OnPolicyDistillationBreed.ts` and its call site — the distilled
+  student no longer inherits teacher warm-up tags.
+- The warm-up tag copy in `WorkerHandler.train()` — the training round-trip no
+  longer carries warm-up tags.
 
 Warm-up protection is unaffected: it is enforced at the Neat level via
 `mutator.setWarmupContext(...)` in `NeatEvolution.ts`, not via per-creature
@@ -25,8 +24,8 @@ tags. The full suite (including `test/NEAT/MutatorWarmup.ts`) passes.
 
 ## Evidence
 
-Backend-only change — no web interface to screenshot. Verified via the
-test suite and the acceptance-criteria grep.
+Backend-only change — no web interface to screenshot. Verified via the test
+suite and the acceptance-criteria grep.
 
 `./quality.sh < /dev/null` passes: **7069 passed, 0 failed** (exit 0).
 
@@ -54,17 +53,17 @@ flowchart LR
 
 ## Test Plan
 
-- `test/architecture/SeedWarmupPersistence.ts` — replaced the three
-  "warm-up tags survive breeding" assertions with
-  `Offspring.breed: offspring does NOT carry warm-up tags from parents`
-  and `grafted breeding does NOT carry warm-up tags`; save-boundary and
-  read/write round-trip tests retained unchanged.
+- `test/architecture/SeedWarmupPersistence.ts` — replaced the three "warm-up
+  tags survive breeding" assertions with
+  `Offspring.breed: offspring does NOT carry warm-up tags from parents` and
+  `grafted breeding does NOT carry warm-up tags`; save-boundary and read/write
+  round-trip tests retained unchanged.
 - `test/breed/OnPolicyDistillationBreed.ts` — rewrote
-  `warm-up tags survive onto offspring` to assert the distilled student
-  carries **no** warm-up tags.
+  `warm-up tags survive onto offspring` to assert the distilled student carries
+  **no** warm-up tags.
 - `test/multithreading/WorkerHandler.ts` — rewrote
-  `WorkerHandler.train: keeps warm-up tags…` to assert the train payload
-  does **not** carry the two warm-up tags, while existing training-context
-  tags (`untrained-error`) remain.
-- `test/NEAT/MutatorWarmup.ts` — unchanged, still passes (structural
-  mutations remain blocked during warm-up).
+  `WorkerHandler.train: keeps warm-up tags…` to assert the train payload does
+  **not** carry the two warm-up tags, while existing training-context tags
+  (`untrained-error`) remain.
+- `test/NEAT/MutatorWarmup.ts` — unchanged, still passes (structural mutations
+  remain blocked during warm-up).

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -30,11 +30,6 @@ import type {
 import { creatureValidate } from "@architecture/CreatureValidate.ts";
 import { assertForwardOnlyTopologyAfterBulkRemap } from "@architecture/ForwardOnlySynapseGuard.ts";
 import {
-  readCurrentGenerationFromCreature,
-  readWarmupGenerationsFromCreature,
-  writeSeedWarmupProgressTags,
-} from "@architecture/CreatureFactory.ts";
-import {
   runProducerCompileProbe,
   setProducerStep,
 } from "@wasm/ProducerCompileGuard.ts";
@@ -125,24 +120,6 @@ export function computeNeuronDependencyIndex(
   return indx;
 }
 
-function propagateSeedWarmupTags(
-  child: Creature,
-  mother: Creature,
-  father: Creature,
-): void {
-  const warmupGenerations = Math.max(
-    readWarmupGenerationsFromCreature(mother),
-    readWarmupGenerationsFromCreature(father),
-  );
-  if (warmupGenerations <= 0) return;
-
-  const currentGeneration = Math.max(
-    readCurrentGenerationFromCreature(mother),
-    readCurrentGenerationFromCreature(father),
-  );
-  writeSeedWarmupProgressTags(child, warmupGenerations, currentGeneration);
-}
-
 export class Offspring {
   /**
    * Create an offspring from two parent networks.
@@ -214,7 +191,6 @@ export class Offspring {
         if (!child) child = subgraphTransplant(mother, father);
       }
       if (child) {
-        propagateSeedWarmupTags(child, mother, father);
         // Memetic update (same as standard crossover path)
         if (mother.memetic) {
           child.memetic = memeticUpdate(mother, child);
@@ -805,7 +781,6 @@ export class Offspring {
       acc.offspringCount++;
     }
 
-    propagateSeedWarmupTags(offspring, mother, father);
     return offspring;
   }
 

--- a/src/breed/OnPolicyDistillationBreed.ts
+++ b/src/breed/OnPolicyDistillationBreed.ts
@@ -40,11 +40,6 @@ import { buildOutgoingSynapsesMap } from "@propagate/sparse/CalculatePathsToOutp
 import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
-import {
-  readCurrentGenerationFromCreature,
-  readWarmupGenerationsFromCreature,
-  writeSeedWarmupProgressTags,
-} from "@architecture/CreatureFactory.ts";
 
 /**
  * Result of an OPD breed call, returned from {@link onPolicyDistillationBreed}.
@@ -202,31 +197,6 @@ function evaluateBatchError(
   return inputs.length === 0 ? 0 : total / inputs.length;
 }
 
-function propagateSeedWarmupTagsFromTeachers(
-  offspring: Creature,
-  teachers: readonly Creature[],
-): void {
-  let warmupGenerations = 0;
-  let currentGeneration = 0;
-  for (const teacher of teachers) {
-    warmupGenerations = Math.max(
-      warmupGenerations,
-      readWarmupGenerationsFromCreature(teacher),
-    );
-    currentGeneration = Math.max(
-      currentGeneration,
-      readCurrentGenerationFromCreature(teacher),
-    );
-  }
-  if (warmupGenerations > 0) {
-    writeSeedWarmupProgressTags(
-      offspring,
-      warmupGenerations,
-      currentGeneration,
-    );
-  }
-}
-
 /**
  * On-Policy Distillation breeding operator.
  *
@@ -357,7 +327,6 @@ export function onPolicyDistillationBreed(
   // 4. Establish the offspring's identity and confirm UUID stability.
   delete student.uuid;
   CreatureUtil.makeUUID(student);
-  propagateSeedWarmupTagsFromTeachers(student, effectiveTeachers);
 
   return {
     offspring: student,

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -21,10 +21,6 @@ import type { NeatConfig } from "@config/NeatConfig.ts";
 import type { RequiredOutputRange } from "@config/OutputRangeConfig.ts";
 import type { TrainOptions } from "@config/TrainOptions.ts";
 import type { WasmCacheConfig } from "@config/WasmCacheConfig.ts";
-import {
-  CURRENT_GENERATION_TAG,
-  WARMUP_GENERATIONS_TAG,
-} from "@architecture/CreatureFactory.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { clearForGc } from "@utils/ReleasableRef.ts";
 import {
@@ -474,16 +470,8 @@ export class WorkerHandler
 
   train(creature: Creature, options: TrainOptions) {
     const json = creature.exportJSON();
-    const warmupGenerations = getTag(creature, WARMUP_GENERATIONS_TAG);
-    const currentGeneration = getTag(creature, CURRENT_GENERATION_TAG);
 
     delete json.tags;
-    if (warmupGenerations) {
-      addTag(json, WARMUP_GENERATIONS_TAG, warmupGenerations);
-    }
-    if (currentGeneration) {
-      addTag(json, CURRENT_GENERATION_TAG, currentGeneration);
-    }
 
     addTag(
       json,

--- a/test/architecture/SeedWarmupPersistence.ts
+++ b/test/architecture/SeedWarmupPersistence.ts
@@ -92,7 +92,12 @@ Deno.test("writeSeedWarmupProgressTags: still raises generation when higher (Iss
   assertEquals(readCurrentGenerationFromCreature(creature), 14);
 });
 
-Deno.test("Offspring.breed: carries the HIGHER of two differing parent generations (Issue #2831)", () => {
+// ─── Issue #2911: offspring no longer inherit warm-up tags mid-run ───────────
+// The Neat-level counter is the single source of truth during a run; tags
+// exist only at the load / save boundary. Breeding must therefore NOT copy
+// the two warm-up tags onto offspring.
+
+Deno.test("Offspring.breed: offspring does NOT carry warm-up tags from parents (Issue #2911)", () => {
   const mum = Creature.fromJSON({
     input: 2,
     output: 1,
@@ -122,7 +127,7 @@ Deno.test("Offspring.breed: carries the HIGHER of two differing parent generatio
       { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
     ],
   } as CreatureExport);
-  // Differing generations: the offspring must inherit the larger (30).
+  // Parents differ, both carry warm-up tags — neither must propagate.
   writeSeedWarmupProgressTags(mum, 25, 30);
   writeSeedWarmupProgressTags(dad, 25, 5);
 
@@ -133,55 +138,11 @@ Deno.test("Offspring.breed: carries the HIGHER of two differing parent generatio
   }
 
   assertEquals(child !== undefined, true);
-  assertEquals(readCurrentGenerationFromCreature(child!), 30);
-  assertEquals(readWarmupGenerationsFromCreature(child!), 25);
+  assertEquals(getTag(child!, WARMUP_GENERATIONS_TAG), null);
+  assertEquals(getTag(child!, CURRENT_GENERATION_TAG), null);
 });
 
-Deno.test("Offspring.breed: warm-up tags survive standard breeding", () => {
-  const mum = Creature.fromJSON({
-    input: 2,
-    output: 1,
-    forwardOnly: true,
-    neurons: [
-      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0 },
-      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
-    ],
-    synapses: [
-      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
-      { fromUUID: "input-1", toUUID: "hidden-0", weight: -0.2 },
-      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
-    ],
-  } as CreatureExport);
-  const dad = Creature.fromJSON({
-    input: 2,
-    output: 1,
-    forwardOnly: true,
-    neurons: [
-      { type: "hidden", uuid: "hidden-0", squash: "IDENTITY", bias: 0.1 },
-      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
-    ],
-    synapses: [
-      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.1 },
-      { fromUUID: "input-1", toUUID: "hidden-0", weight: 0.3 },
-      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.7 },
-      { fromUUID: "input-0", toUUID: "output-0", weight: 0.2 },
-    ],
-  } as CreatureExport);
-  writeSeedWarmupProgressTags(mum, 25, 12);
-  writeSeedWarmupProgressTags(dad, 25, 12);
-
-  let child: Creature | undefined;
-  for (let attempt = 0; attempt < 50; attempt++) {
-    child = Offspring.breed(mum, dad, { forwardOnly: true });
-    if (child) break;
-  }
-
-  assertEquals(child !== undefined, true);
-  assertEquals(readWarmupGenerationsFromCreature(child!), 25);
-  assertEquals(readCurrentGenerationFromCreature(child!), 12);
-});
-
-Deno.test("Offspring.breed: warm-up tags survive grafted breeding", () => {
+Deno.test("Offspring.breed: grafted breeding does NOT carry warm-up tags (Issue #2911)", () => {
   const mum = creatureForProblem({
     inputs: 3,
     outputs: 1,
@@ -205,8 +166,8 @@ Deno.test("Offspring.breed: warm-up tags survive grafted breeding", () => {
   }
 
   assertEquals(child !== undefined, true);
-  assertEquals(readWarmupGenerationsFromCreature(child!), 40);
-  assertEquals(readCurrentGenerationFromCreature(child!), 7);
+  assertEquals(getTag(child!, WARMUP_GENERATIONS_TAG), null);
+  assertEquals(getTag(child!, CURRENT_GENERATION_TAG), null);
 });
 
 // ─── Issue #2909: save-boundary stamping / stripping ────────────────────────

--- a/test/breed/OnPolicyDistillationBreed.ts
+++ b/test/breed/OnPolicyDistillationBreed.ts
@@ -21,14 +21,14 @@ import {
   type RequiredOpdConfig,
 } from "@config/OpdConfig.ts";
 import { onPolicyDistillationBreed } from "@breed/OnPolicyDistillationBreed.ts";
-import { addTag } from "@stsoftware/tags/mod";
+import { addTag, getTag } from "@stsoftware/tags/mod";
 import { Breed } from "@breed/Breed.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { Genus } from "@neat/Genus.ts";
 import { createNeatConfig } from "@config/NeatConfig.ts";
 import {
-  readCurrentGenerationFromCreature,
-  readWarmupGenerationsFromCreature,
+  CURRENT_GENERATION_TAG,
+  WARMUP_GENERATIONS_TAG,
   writeSeedWarmupProgressTags,
 } from "@architecture/CreatureFactory.ts";
 
@@ -320,8 +320,10 @@ Deno.test(
 );
 
 Deno.test(
-  "OnPolicyDistillationBreed - warm-up tags survive onto offspring",
+  "OnPolicyDistillationBreed - offspring does NOT carry warm-up tags from teachers (Issue #2911)",
   () => {
+    // The Neat-level counter is the single source of truth mid-run; the
+    // distilled student must not inherit the teachers' warm-up tags.
     const teacherA = buildSimpleCreature(2, ["warm-a-h0", "warm-a-h1"]);
     const teacherB = buildSimpleCreature(2, ["warm-b-h0", "warm-b-h1"]);
     writeSeedWarmupProgressTags(teacherA, 1440, 77);
@@ -337,7 +339,7 @@ Deno.test(
     );
 
     assert(result, "OPD must produce an offspring");
-    assertEquals(readWarmupGenerationsFromCreature(result.offspring), 1440);
-    assertEquals(readCurrentGenerationFromCreature(result.offspring), 77);
+    assertEquals(getTag(result.offspring, WARMUP_GENERATIONS_TAG), null);
+    assertEquals(getTag(result.offspring, CURRENT_GENERATION_TAG), null);
   },
 );

--- a/test/multithreading/WorkerHandler.ts
+++ b/test/multithreading/WorkerHandler.ts
@@ -80,7 +80,7 @@ Deno.test("WorkerHandler: terminate cleans up without error", async () => {
   assertEquals(handler.isBusy(), false);
 });
 
-Deno.test("WorkerHandler.train: keeps warm-up tags in train payload", async () => {
+Deno.test("WorkerHandler.train: does NOT carry warm-up tags in train payload (Issue #2911)", async () => {
   const handler = new WorkerHandler(
     await Deno.makeTempDir(),
     "MSE",
@@ -130,17 +130,15 @@ Deno.test("WorkerHandler.train: keeps warm-up tags in train payload", async () =
   }
 
   const tags = captured?.train?.creature?.tags;
+  // The Neat-level counter is the single source of truth mid-run — the
+  // training round-trip must not carry the two warm-up tags.
   assertEquals(
-    typeof tags?.find((t) => t.name === WARMUP_GENERATIONS_TAG)?.value,
-    "string",
+    tags?.find((t) => t.name === WARMUP_GENERATIONS_TAG),
+    undefined,
   );
   assertEquals(
-    tags?.find((t) => t.name === WARMUP_GENERATIONS_TAG)?.value,
-    "1440",
-  );
-  assertEquals(
-    tags?.find((t) => t.name === CURRENT_GENERATION_TAG)?.value,
-    "12",
+    tags?.find((t) => t.name === CURRENT_GENERATION_TAG),
+    undefined,
   );
   // Existing training context tags should still be present.
   assertEquals(tags?.find((t) => t.name === "untrained-error")?.value, "0.5");


### PR DESCRIPTION
## Summary

Stop maintaining the `warmupGenerations` / `currentGeneration` tags on creatures
**during a run**. The Neat-level warm-up counter is the single source of truth
mid-run; the two tags exist only at the load (`Neat.populatePopulation`) and
save (Issue #2909) boundaries. Three sites were the de facto count-keeping
mechanism and the reason saved creatures carried stale values — offspring
inherited `max(parents)` without incrementing, so a stale seed value propagated
forever. Removing them makes the counter authoritative. Closes #2911.

Removed:

- `propagateSeedWarmupTags` in `src/architecture/Offspring.ts` and both call
  sites — offspring no longer inherit warm-up tags.
- `propagateSeedWarmupTagsFromTeachers` in
  `src/breed/OnPolicyDistillationBreed.ts` and its call site — the distilled
  student no longer inherits teacher warm-up tags.
- The warm-up tag copy in `WorkerHandler.train()` — the training round-trip no
  longer carries warm-up tags.

Warm-up protection is unaffected: it is enforced at the Neat level via
`mutator.setWarmupContext(...)` in `NeatEvolution.ts`, not via per-creature
tags. The full suite (including `test/NEAT/MutatorWarmup.ts`) passes.

## Evidence

Backend-only change — no web interface to screenshot. Verified via the test
suite and the acceptance-criteria grep.

`./quality.sh < /dev/null` passes: **7069 passed, 0 failed** (exit 0).

Acceptance-criteria grep — no code path outside the load/save boundary
(`src/architecture/CreatureFactory.ts`) reads or writes the two tags:

```
$ grep -rn "WARMUP_GENERATIONS_TAG\|CURRENT_GENERATION_TAG" src/ \
    | grep -v "src/architecture/CreatureFactory.ts"
(no matches)
```

```mermaid
flowchart LR
    subgraph Before["Before — tags maintained mid-run"]
      P1[Parents/Teachers] -->|copy max tags| O1[Offspring]
      C1[Creature] -->|copy tags| T1[Train round-trip]
    end
    subgraph After["After — counter is source of truth"]
      P2[Parents/Teachers] -->|no tags copied| O2[Offspring]
      C2[Creature] -->|no tags copied| T2[Train round-trip]
      N[Neat-level counter] -.->|stamps at save| Save[(Saved creature)]
    end
```

## Test Plan

- `test/architecture/SeedWarmupPersistence.ts` — replaced the three "warm-up
  tags survive breeding" assertions with
  `Offspring.breed: offspring does NOT carry warm-up tags from parents` and
  `grafted breeding does NOT carry warm-up tags`; save-boundary and read/write
  round-trip tests retained unchanged.
- `test/breed/OnPolicyDistillationBreed.ts` — rewrote
  `warm-up tags survive onto offspring` to assert the distilled student carries
  **no** warm-up tags.
- `test/multithreading/WorkerHandler.ts` — rewrote
  `WorkerHandler.train: keeps warm-up tags…` to assert the train payload does
  **not** carry the two warm-up tags, while existing training-context tags
  (`untrained-error`) remain.
- `test/NEAT/MutatorWarmup.ts` — unchanged, still passes (structural mutations
  remain blocked during warm-up).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq9r0xrr-9279ac`<!-- vibe-worker-issue-2911 -->