### PR TITLE
Config: expose selection-pressure parameters (Issue #2929)

### DIFF
--- a/docs/PERFORMANCE_TUNING.md
+++ b/docs/PERFORMANCE_TUNING.md
@@ -437,6 +437,42 @@ performers. Higher pressure means faster convergence but risks losing diversity.
 - **Adaptive mutation** adjusts these automatically based on creature size — see
   [Adaptive Mutation Thresholds](#adaptive-mutation-thresholds) below.
 
+#### Tunable selection-pressure knobs (`selectionPressure`)
+
+Issue #2929 exposes the previously hardcoded selection-pressure parameters
+through `selectionPressure`. Every default reproduces the prior behaviour, so
+existing runs are unchanged unless a knob is overridden. These knobs apply to
+the active `selection` strategy (`POWER` or `TOURNAMENT`).
+
+| Parameter                                          | Default | Description                                                                        |
+| -------------------------------------------------- | ------- | ---------------------------------------------------------------------------------- |
+| `selectionPressure.power`                          | `4`     | POWER selection exponent. Higher → stronger bias towards the top-ranked creatures. |
+| `selectionPressure.tournamentSize`                 | `5`     | Fixed tournament size used when `adaptiveTournament` is `false`.                   |
+| `selectionPressure.tournamentProbability`          | `0.5`   | Probability of picking the best tournament participant. Higher → more pressure.    |
+| `selectionPressure.adaptiveTournament`             | `true`  | Scale tournament size with population size instead of using `tournamentSize`.      |
+| `selectionPressure.adaptiveTournamentMinSize`      | `3`     | Floor for the adaptive tournament size.                                            |
+| `selectionPressure.adaptiveTournamentSqrtExponent` | `0.5`   | Population scaling exponent: `floor(pop ^ exponent)`. `0.5` = square-root scaling. |
+| `selectionPressure.adaptiveTournamentCapFraction`  | `0.1`   | Cap as a fraction of population: `floor(pop * fraction)`.                          |
+
+**Recommendations**:
+
+- **For faster convergence (more exploitation)**: raise `power` (e.g. 6–12),
+  raise `tournamentProbability` towards `1.0`, or raise
+  `adaptiveTournamentSqrtExponent`/`adaptiveTournamentCapFraction` so larger
+  tournaments form. This selects the best creatures more often.
+- **For longer exploration**: lower `power` (e.g. 1–3), lower
+  `tournamentProbability`, or shrink the adaptive bounds. This keeps weaker
+  creatures in the breeding pool for longer.
+- All values are validated at config time; out-of-range input (e.g.
+  `power <= 0`, `tournamentProbability > 1`) is rejected with a clear error.
+
+```ts
+const neat = new Neat(input, output, fitness, {
+  selection: Selection.POWER,
+  selectionPressure: { power: 8 }, // stronger exploitation
+});
+```
+
 ### 🔄 Adaptive Mutation Thresholds
 
 Large creatures (many neurons) are more fragile — random topology changes are

--- a/docs/archive/pr-summaries/pr-summary-2929.md
+++ b/docs/archive/pr-summaries/pr-summary-2929.md
@@ -1,0 +1,99 @@
+# Expose selection-pressure parameters as configuration (Issue #2929)
+
+## Summary
+
+Selection pressure is one of the most direct levers on convergence speed, yet
+several of its knobs were hardcoded:
+
+- `src/methods/Selection.ts` — `POWER.power = 4`, `TOURNAMENT.size = 5`,
+  `TOURNAMENT.probability = 0.5`.
+- `src/breed/AdaptiveTournamentSize.ts` — the fully hardcoded formula
+  `max(3, min(floor(sqrt(pop)), floor(pop * 0.1)))`.
+
+This change exposes all of them through the standard `NeatOptions`/`NeatConfig`
+surface via a new `selectionPressure` config object, with validation and
+defaults that reproduce the current behaviour exactly. Users can now tune the
+exploration/exploitation trade-off for their problem.
+
+**Closes #2929.**
+
+### New `selectionPressure` knobs
+
+| Knob                             | Default | Meaning                                                    |
+| -------------------------------- | ------- | ---------------------------------------------------------- |
+| `power`                          | `4`     | POWER selection exponent                                   |
+| `tournamentSize`                 | `5`     | Fixed tournament size when adaptive sizing is off          |
+| `tournamentProbability`          | `0.5`   | Probability of picking the best tournament participant     |
+| `adaptiveTournament`             | `true`  | Scale tournament size with population size                 |
+| `adaptiveTournamentMinSize`      | `3`     | Floor for the adaptive tournament size                     |
+| `adaptiveTournamentSqrtExponent` | `0.5`   | Population scaling exponent `floor(pop ^ exponent)` (sqrt) |
+| `adaptiveTournamentCapFraction`  | `0.1`   | Cap as a fraction of population `floor(pop * fraction)`    |
+
+Out-of-range values (e.g. `power <= 0`, `tournamentProbability > 1`,
+`adaptiveTournamentCapFraction > 1`) are rejected by `parseNumber` with a clear
+`ConfigurationError` at config-creation time.
+
+### Bit-for-bit default behaviour
+
+- Defaults are sourced from the existing `Selection` singletons
+  (`Selection.POWER.power`, `Selection.TOURNAMENT.size/probability`).
+- `calculateAdaptiveTournamentSize` keeps `Math.sqrt` for the default exponent
+  (`0.5`) so results are identical to the prior implementation; the configurable
+  `Math.pow` path is only used for non-default exponents.
+
+```mermaid
+flowchart LR
+    O[NeatOptions.selectionPressure] --> P[parseSelectionPressure]
+    P --> C[NeatConfig.selectionPressure]
+    C --> SP[selectParent]
+    SP -->|POWER| Pw[selectPower&#40;power&#41;]
+    SP -->|TOURNAMENT| AT{adaptiveTournament?}
+    AT -->|yes| Adp[calculateAdaptiveTournamentSize&#40;pop, bounds&#41;]
+    AT -->|no| Fix[tournamentSize]
+    Adp --> T[selectTournament&#40;size, probability&#41;]
+    Fix --> T
+```
+
+## Evidence
+
+Backend/library change — no UI to screenshot. Verified by the full quality gate
+(`./quality.sh`): **7136 passed | 0 failed | 4 ignored**, including all
+pre-existing selection/tournament tests, which pass unchanged (proving defaults
+reproduce current behaviour).
+
+The new behavioural tests confirm the acceptance criterion that stronger
+pressure increases the chance of selecting the top-ranked creature:
+
+- `test/breed/SelectionPressure.ts::SelectionPressure - higher POWER exponent
+  selects the top creature more often`
+- `test/breed/SelectionPressure.ts::SelectionPressure - larger tournament size
+  selects the top creature more often`
+
+## Test Plan
+
+Added:
+
+- `test/config/SelectionPressureConfig.ts` — defaults reproduce prior values,
+  custom/partial overrides, CLI string coercion, and out-of-range rejection for
+  every knob.
+- `test/breed/SelectionPressure.ts` — custom adaptive bounds change the computed
+  size while defaults match the prior formula; POWER exponent and tournament
+  size measurably raise the probability of selecting the top creature; default
+  config still drives adaptive tournament selection.
+
+No existing tests were modified or removed.
+
+## Files changed
+
+- `src/config/SelectionPressureConfig.ts` (new) — config interface, `Required`
+  type, and defaults.
+- `src/config/parsers/SelectionParsers.ts` (new) — `parseSelectionPressure`.
+- `src/config/NeatConfigParsers.ts` — re-export the new parser.
+- `src/config/NeatConfig.ts` — wire `selectionPressure` into `createNeatConfig`.
+- `src/config/NeatArguments.ts`, `src/config/NeatOptions.ts` — add the field to
+  the config and options surfaces.
+- `src/breed/AdaptiveTournamentSize.ts` — accept optional tunable bounds.
+- `src/breed/ParentSelection.ts` — read knobs from config instead of the
+  hardcoded `Selection` singletons.
+- `mod.ts` — export the new config types and default constant.
+- `docs/PERFORMANCE_TUNING.md` — document the new knobs.

--- a/mod.ts
+++ b/mod.ts
@@ -190,6 +190,22 @@ export type {
 export { DEFAULT_ADAPTIVE_POPULATION_CONFIG } from "@config/AdaptivePopulationConfig.ts";
 
 /**
+ * Selection-pressure configuration (Issue #2929)
+ *
+ * Exposes the previously hardcoded selection-pressure knobs — the POWER
+ * selection exponent, the tournament size and probability, and the
+ * adaptive-tournament bounds — through the standard config surface. Every
+ * default reproduces the prior behaviour exactly.
+ *
+ * @see {@link module:src/config/SelectionPressureConfig}
+ */
+export type {
+  RequiredSelectionPressureConfig,
+  SelectionPressureConfig,
+} from "@config/SelectionPressureConfig.ts";
+export { DEFAULT_SELECTION_PRESSURE_CONFIG } from "@config/SelectionPressureConfig.ts";
+
+/**
  * Parallel Batch Creature Evaluation
  *
  * Issue #1862: Controls topology-aware grouping and concurrency

--- a/src/breed/AdaptiveTournamentSize.ts
+++ b/src/breed/AdaptiveTournamentSize.ts
@@ -19,14 +19,40 @@
  */
 
 /**
+ * Tunable bounds for {@link calculateAdaptiveTournamentSize} (Issue #2929).
+ *
+ * The defaults reproduce the prior hardcoded formula
+ * `max(3, min(floor(sqrt(pop)), floor(pop * 0.1)))` exactly.
+ */
+export interface AdaptiveTournamentBounds {
+  /** Minimum tournament size (default: 3). */
+  minSize?: number;
+  /**
+   * Population scaling exponent: `floor(population ^ exponent)`. The default
+   * `0.5` reproduces square-root scaling.
+   */
+  sqrtExponent?: number;
+  /** Cap as a fraction of population: `floor(population * fraction)` (default: 0.1). */
+  capFraction?: number;
+}
+
+const DEFAULT_MIN_SIZE = 3;
+const DEFAULT_SQRT_EXPONENT = 0.5;
+const DEFAULT_CAP_FRACTION = 0.1;
+
+/**
  * Calculates the adaptive tournament size based on population size.
  *
  * The formula uses:
- * - Minimum size of 3 (ensures meaningful selection pressure)
- * - Square root scaling for moderate selection pressure
- * - 10% cap to prevent excessive pressure in large populations
+ * - A minimum size (default 3) ensuring meaningful selection pressure
+ * - Exponent scaling for moderate selection pressure (default 0.5 → sqrt)
+ * - A population-fraction cap (default 10%) preventing excessive pressure
+ *
+ * All three bounds are tunable via the optional {@link AdaptiveTournamentBounds}
+ * argument (Issue #2929); omitting it reproduces the prior behaviour exactly.
  *
  * @param populationSize - The current population size
+ * @param bounds - Optional tunable bounds (defaults reproduce prior behaviour)
  * @returns The recommended tournament size
  *
  * @example
@@ -43,20 +69,30 @@
  */
 export function calculateAdaptiveTournamentSize(
   populationSize: number,
+  bounds?: AdaptiveTournamentBounds,
 ): number {
   // Handle edge cases for very small populations
   if (populationSize <= 2) {
     return populationSize;
   }
 
-  // Calculate size using sqrt scaling capped at 10%
-  // Formula: max(3, min(floor(sqrt(population)), floor(population * 0.1)))
-  const sqrtSize = Math.floor(Math.sqrt(populationSize));
-  const percentSize = Math.floor(populationSize * 0.1);
+  const minSize = bounds?.minSize ?? DEFAULT_MIN_SIZE;
+  const sqrtExponent = bounds?.sqrtExponent ?? DEFAULT_SQRT_EXPONENT;
+  const capFraction = bounds?.capFraction ?? DEFAULT_CAP_FRACTION;
 
-  // Take the minimum of sqrt and percentage to balance pressure
+  // Calculate size using exponent scaling capped at a population fraction.
+  // Formula: max(minSize, min(floor(pop ^ exponent), floor(pop * fraction)))
+  // Use Math.sqrt for the default exponent so results are bit-for-bit
+  // identical to the prior implementation (Math.pow may differ by 1 ULP).
+  const scaledRaw = sqrtExponent === DEFAULT_SQRT_EXPONENT
+    ? Math.sqrt(populationSize)
+    : Math.pow(populationSize, sqrtExponent);
+  const sqrtSize = Math.floor(scaledRaw);
+  const percentSize = Math.floor(populationSize * capFraction);
+
+  // Take the minimum of exponent-scaled and fraction-capped sizes
   const scaledSize = Math.min(sqrtSize, percentSize);
 
-  // Ensure minimum tournament size of 3 for meaningful selection
-  return Math.max(3, scaledSize);
+  // Ensure the configured minimum tournament size for meaningful selection
+  return Math.max(minSize, scaledSize);
 }

--- a/src/breed/ParentSelection.ts
+++ b/src/breed/ParentSelection.ts
@@ -222,25 +222,30 @@ export function selectParent(
   ranking: FitnessRanking,
   config: NeatConfig,
 ): Creature {
+  // Issue #2929: selection-pressure knobs now come from config instead of
+  // the hardcoded Selection singletons. Defaults reproduce prior behaviour.
+  const sp = config.selectionPressure;
   switch (config.selection) {
     case Selection.POWER: {
-      return ranking.selectPower(Selection.POWER.power);
+      return ranking.selectPower(sp.power);
     }
     case Selection.FITNESS_PROPORTIONATE: {
       return ranking.selectFitnessProportionate();
     }
     case Selection.TOURNAMENT: {
       // Issue #1019: Use adaptive tournament size that scales with population
-      // instead of fixed size of 5. This improves selection pressure for
-      // large populations and reduces variance for small populations.
-      const adaptiveSize = calculateAdaptiveTournamentSize(
-        ranking.sortedPopulation.length,
-      );
+      // instead of a fixed size. This improves selection pressure for large
+      // populations and reduces variance for small populations. Issue #2929:
+      // the bounds (and the adaptive toggle / fixed size) are configurable.
+      const size = sp.adaptiveTournament
+        ? calculateAdaptiveTournamentSize(ranking.sortedPopulation.length, {
+          minSize: sp.adaptiveTournamentMinSize,
+          sqrtExponent: sp.adaptiveTournamentSqrtExponent,
+          capFraction: sp.adaptiveTournamentCapFraction,
+        })
+        : sp.tournamentSize;
 
-      return ranking.selectTournament(
-        adaptiveSize,
-        Selection.TOURNAMENT.probability,
-      );
+      return ranking.selectTournament(size, sp.tournamentProbability);
     }
     default: {
       throw new ValidationError(

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -9,6 +9,7 @@ import type { MutationInterface } from "@neat/MutationInterface.ts";
 import type { RequiredPlateauDetectionConfig } from "@neat/PlateauDetector.ts";
 import type { RequiredAdaptiveMutationThresholds } from "@config/AdaptiveMutationThresholds.ts";
 import type { RequiredCompatibilityGatingConfig } from "@config/CompatibilityGatingConfig.ts";
+import type { RequiredSelectionPressureConfig } from "@config/SelectionPressureConfig.ts";
 import type { DiscoveryMinCandidatesPerCategory } from "@config/DiscoveryMinCandidatesPerCategory.ts";
 import type { RequiredEnsembleDiversityConfig } from "@config/EnsembleDiversityConfig.ts";
 import type { RequiredFineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
@@ -973,6 +974,28 @@ export interface NeatArguments {
    *   fallback (default: 3)
    */
   compatibilityGating: RequiredCompatibilityGatingConfig;
+
+  /**
+   * Selection-pressure configuration (Issue #2929).
+   *
+   * Exposes the previously hardcoded selection-pressure knobs so the
+   * exploration/exploitation trade-off can be tuned per problem:
+   * - power: POWER selection exponent (default: 4; higher biases harder
+   *   towards top-ranked creatures)
+   * - tournamentSize: fixed tournament size when adaptive sizing is off
+   *   (default: 5)
+   * - tournamentProbability: probability of picking the best participant
+   *   (default: 0.5)
+   * - adaptiveTournament: scale tournament size with population (default: true)
+   * - adaptiveTournamentMinSize: floor for adaptive size (default: 3)
+   * - adaptiveTournamentSqrtExponent: population scaling exponent
+   *   (default: 0.5, i.e. square-root scaling)
+   * - adaptiveTournamentCapFraction: cap as a fraction of population
+   *   (default: 0.1)
+   *
+   * Every default reproduces the prior hardcoded behaviour exactly.
+   */
+  selectionPressure: RequiredSelectionPressureConfig;
 
   /**
    * Tolerate corrupt parents during breeding (Issue #2523).

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -59,6 +59,7 @@ import {
   parsePlateauDetection,
   parsePredictiveCoding,
   parseQuantumStep,
+  parseSelectionPressure,
   parseSpecialist,
   parseSpeciesStagnation,
   parseSquashEffectiveness,
@@ -729,6 +730,12 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
         opts.compatibilityGating as Record<string, unknown> | undefined,
         dnaPreset.compatibilityGating,
       ),
+    ),
+
+    // Issue #2929: Parse selection-pressure configuration (POWER exponent,
+    // tournament size/probability, adaptive-tournament bounds).
+    selectionPressure: parseSelectionPressure(
+      opts.selectionPressure as Record<string, unknown> | undefined,
     ),
 
     // Issue #2492: Knob-tuning preset for inter-island DNA sharing.

--- a/src/config/NeatConfigParsers.ts
+++ b/src/config/NeatConfigParsers.ts
@@ -41,6 +41,7 @@ export {
   parsePredictiveCoding,
   parseQuantumStep,
 } from "@config/parsers/TrainingParsers.ts";
+export { parseSelectionPressure } from "@config/parsers/SelectionParsers.ts";
 export {
   parseBiasRegularisation,
   parseWeightRegularisation,

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -3,6 +3,7 @@ import type { RandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 import type { TrainingEventCallback } from "@config/TrainingEvent.ts";
 import type { AdaptiveMutationThresholds } from "@config/AdaptiveMutationThresholds.ts";
 import type { CompatibilityGatingConfig } from "@config/CompatibilityGatingConfig.ts";
+import type { SelectionPressureConfig } from "@config/SelectionPressureConfig.ts";
 import type { DiscoveryMinCandidatesPerCategory } from "@config/DiscoveryMinCandidatesPerCategory.ts";
 import type { EnsembleDiversityConfig } from "@config/EnsembleDiversityConfig.ts";
 import type { FineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
@@ -126,6 +127,7 @@ export type NeatOptions =
     | "fitnessSharing"
     | "speciesStagnation"
     | "compatibilityGating"
+    | "selectionPressure"
     | "outputRanges"
     | "logger"
     | "rng"
@@ -197,6 +199,8 @@ export type NeatOptions =
     speciesStagnation?: SpeciesStagnationConfig;
     /** Partial overrides for compatibility gating configuration (Issue #2455, defaults applied if not specified) */
     compatibilityGating?: CompatibilityGatingConfig;
+    /** Partial overrides for selection-pressure configuration (Issue #2929, defaults applied if not specified) */
+    selectionPressure?: SelectionPressureConfig;
     /**
      * Optional per-output range constraints (Issue #1620).
      *
@@ -296,6 +300,7 @@ export type NeatOptionsInput =
     | "fitnessSharing"
     | "speciesStagnation"
     | "compatibilityGating"
+    | "selectionPressure"
     | "outputRanges"
     | "logger"
     | "logLevel"
@@ -356,6 +361,8 @@ export type NeatOptionsInput =
     speciesStagnation?: CoerceNumeric<SpeciesStagnationConfig>;
     /** Compatibility gating configuration (Issue #2455). Numeric fields coerced from CLI. */
     compatibilityGating?: CoerceNumeric<CompatibilityGatingConfig>;
+    /** Selection-pressure configuration (Issue #2929). Numeric fields coerced from CLI. */
+    selectionPressure?: CoerceNumeric<SelectionPressureConfig>;
     /** Per-output range constraints (Issue #1620). Numeric fields coerced from CLI. */
     outputRanges?: readonly CoerceNumeric<OutputRange>[];
     /** Custom logger instance (not coerced — functions cannot come from CLI). */

--- a/src/config/SelectionPressureConfig.ts
+++ b/src/config/SelectionPressureConfig.ts
@@ -1,0 +1,102 @@
+/**
+ * SelectionPressureConfig.ts - Configuration for selection-pressure knobs
+ * (Issue #2929).
+ *
+ * Selection pressure is one of the most direct levers on convergence speed:
+ * stronger pressure exploits good genomes faster (quicker convergence, more
+ * risk of premature convergence); weaker pressure explores longer. These
+ * parameters were previously hardcoded in `src/methods/Selection.ts` and
+ * `src/breed/AdaptiveTournamentSize.ts`; this config exposes them through the
+ * standard `NeatOptions`/`NeatConfig` surface.
+ *
+ * Every default reproduces the prior hardcoded behaviour exactly, so existing
+ * runs are unchanged unless a knob is overridden.
+ */
+
+import { Selection } from "@methods/Selection.ts";
+
+/**
+ * Configuration for selection pressure (POWER exponent, tournament size and
+ * probability, and adaptive-tournament bounds).
+ */
+export interface SelectionPressureConfig {
+  /**
+   * Exponent applied in POWER selection: a uniform random number is raised to
+   * this power before indexing the fitness-sorted population, so higher values
+   * bias selection more strongly towards the top-ranked creatures. Must be
+   * greater than 0. Default: `4` (the prior `Selection.POWER.power`).
+   */
+  power?: number;
+
+  /**
+   * Fixed tournament size used when adaptive tournament sizing is disabled
+   * (`adaptiveTournament: false`). When adaptive sizing is enabled this value
+   * is ignored. Default: `5` (the prior `Selection.TOURNAMENT.size`).
+   */
+  tournamentSize?: number;
+
+  /**
+   * Probability of selecting the best participant in a tournament (otherwise
+   * the next best is considered, and so on). Higher values increase selection
+   * pressure. Default: `0.5` (the prior `Selection.TOURNAMENT.probability`).
+   */
+  tournamentProbability?: number;
+
+  /**
+   * Whether tournament size scales adaptively with population size. When
+   * `true` (default) the size is derived from `calculateAdaptiveTournamentSize`
+   * using the bounds below; when `false` the fixed `tournamentSize` is used.
+   * Default: `true` (the prior behaviour from Issue #1019).
+   */
+  adaptiveTournament?: boolean;
+
+  /**
+   * Minimum adaptive tournament size, ensuring meaningful selection pressure
+   * even for small populations. Must be a positive integer. Default: `3`.
+   */
+  adaptiveTournamentMinSize?: number;
+
+  /**
+   * Exponent governing how adaptive tournament size scales with population:
+   * `floor(population ^ exponent)`. The prior behaviour used square-root
+   * scaling, so the default `0.5` reproduces it exactly. Higher values raise
+   * selection pressure for large populations. Must be greater than 0.
+   * Default: `0.5`.
+   */
+  adaptiveTournamentSqrtExponent?: number;
+
+  /**
+   * Cap on adaptive tournament size as a fraction of the population, applied
+   * as `floor(population * fraction)` and taken as the minimum against the
+   * exponent-scaled size. Prevents excessive pressure in large populations.
+   * Must be greater than 0 and at most 1. Default: `0.1` (10%).
+   */
+  adaptiveTournamentCapFraction?: number;
+}
+
+/**
+ * Required version of {@link SelectionPressureConfig} with every field
+ * populated. Produced by `parseSelectionPressure` after defaults are applied.
+ */
+export type RequiredSelectionPressureConfig = Required<
+  SelectionPressureConfig
+>;
+
+/**
+ * Default selection-pressure values. Each default is sourced from the prior
+ * hardcoded literal so behaviour is unchanged unless overridden:
+ * - `power`, `tournamentSize`, `tournamentProbability` come from the
+ *   `Selection` strategy singletons.
+ * - `adaptiveTournament*` reproduce the `calculateAdaptiveTournamentSize`
+ *   formula `max(3, min(floor(sqrt(pop)), floor(pop * 0.1)))`.
+ */
+export const DEFAULT_SELECTION_PRESSURE_CONFIG:
+  RequiredSelectionPressureConfig = {
+    power: Selection.POWER.power,
+    tournamentSize: Selection.TOURNAMENT.size,
+    tournamentProbability: Selection.TOURNAMENT.probability,
+    adaptiveTournament: true,
+    adaptiveTournamentMinSize: 3,
+    adaptiveTournamentSqrtExponent: 0.5,
+    adaptiveTournamentCapFraction: 0.1,
+  };

--- a/src/config/parsers/SelectionParsers.ts
+++ b/src/config/parsers/SelectionParsers.ts
@@ -1,0 +1,61 @@
+/**
+ * SelectionParsers.ts - Sub-config parser for selection pressure (Issue #2929).
+ *
+ * Parses and validates the selection-pressure knobs (POWER exponent,
+ * tournament size and probability, and adaptive-tournament bounds). Defaults
+ * reproduce the prior hardcoded behaviour exactly.
+ */
+
+import {
+  DEFAULT_SELECTION_PRESSURE_CONFIG,
+  type RequiredSelectionPressureConfig,
+} from "@config/SelectionPressureConfig.ts";
+import { parseNumber } from "@config/ParseOptions.ts";
+
+/** Parse selection-pressure configuration (Issue #2929). */
+export function parseSelectionPressure(
+  overrides: Record<string, unknown> | undefined,
+): RequiredSelectionPressureConfig {
+  const d = DEFAULT_SELECTION_PRESSURE_CONFIG;
+  return {
+    power: parseNumber(
+      "Selection pressure power",
+      overrides?.power,
+      d.power,
+      { minExclusive: 0 },
+    ),
+    tournamentSize: parseNumber(
+      "Selection pressure tournamentSize",
+      overrides?.tournamentSize,
+      d.tournamentSize,
+      { integer: true, min: 1 },
+    ),
+    tournamentProbability: parseNumber(
+      "Selection pressure tournamentProbability",
+      overrides?.tournamentProbability,
+      d.tournamentProbability,
+      { min: 0, max: 1 },
+    ),
+    adaptiveTournament: typeof overrides?.adaptiveTournament === "boolean"
+      ? overrides.adaptiveTournament
+      : d.adaptiveTournament,
+    adaptiveTournamentMinSize: parseNumber(
+      "Selection pressure adaptiveTournamentMinSize",
+      overrides?.adaptiveTournamentMinSize,
+      d.adaptiveTournamentMinSize,
+      { integer: true, min: 1 },
+    ),
+    adaptiveTournamentSqrtExponent: parseNumber(
+      "Selection pressure adaptiveTournamentSqrtExponent",
+      overrides?.adaptiveTournamentSqrtExponent,
+      d.adaptiveTournamentSqrtExponent,
+      { minExclusive: 0 },
+    ),
+    adaptiveTournamentCapFraction: parseNumber(
+      "Selection pressure adaptiveTournamentCapFraction",
+      overrides?.adaptiveTournamentCapFraction,
+      d.adaptiveTournamentCapFraction,
+      { minExclusive: 0, max: 1 },
+    ),
+  } as RequiredSelectionPressureConfig;
+}

--- a/test/breed/SelectionPressure.ts
+++ b/test/breed/SelectionPressure.ts
@@ -1,0 +1,174 @@
+/**
+ * Behavioural tests for configurable selection pressure (Issue #2929).
+ *
+ * Verifies that:
+ * - `calculateAdaptiveTournamentSize` honours custom bounds while its
+ *   defaults reproduce the prior formula.
+ * - Increasing the POWER exponent measurably increases the probability that
+ *   the top-ranked creature is selected.
+ * - Increasing the (fixed) tournament size measurably increases the
+ *   probability that the top-ranked creature is selected.
+ *
+ * These are statistical "what" tests: they run enough iterations through the
+ * real selection code that the directional effect is robust without relying on
+ * a seeded global RNG (tests run in parallel and share the global RNG).
+ */
+import { assert, assertEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature, CreatureUtil, Selection } from "../../mod.ts";
+import type { CreatureInternal } from "@architecture/CreatureInterfaces.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { FitnessRanking } from "@breed/FitnessRanking.ts";
+import { selectParent } from "@breed/ParentSelection.ts";
+import { calculateAdaptiveTournamentSize } from "@breed/AdaptiveTournamentSize.ts";
+
+/** Build a population with strictly descending scores (best first). */
+function createPopulationOfSize(size: number): Creature[] {
+  const creatures: Creature[] = [];
+  for (let i = 0; i < size; i++) {
+    const ni: CreatureInternal = {
+      input: 1,
+      output: 1,
+      score: size - i, // descending scores → creature 0 is best
+      neurons: [{
+        index: 1,
+        type: "output",
+        squash: "IDENTITY",
+        bias: i * 0.001, // distinct biases → unique UUIDs
+      }],
+      synapses: [{ from: 0, to: 1, weight: 1 + i * 0.001 }],
+    };
+    const creature = Creature.fromJSON(ni);
+    CreatureUtil.makeUUID(creature);
+    creature.score = ni.score;
+    addTag(creature, "score", ni.score!.toString());
+    creatures.push(creature);
+  }
+  return creatures;
+}
+
+/** Count how often `selectParent` returns the top-ranked creature. */
+function countTopSelections(
+  ranking: FitnessRanking,
+  config: ReturnType<typeof createNeatConfig>,
+  iterations: number,
+): number {
+  const topUuid = ranking.sortedPopulation[0].uuid;
+  let count = 0;
+  for (let i = 0; i < iterations; i++) {
+    if (selectParent(ranking, config).uuid === topUuid) count++;
+  }
+  return count;
+}
+
+// ── Adaptive bounds ─────────────────────────────────────────────────
+
+Deno.test("SelectionPressure - adaptive bounds default to prior formula", () => {
+  // Omitting bounds reproduces max(3, min(floor(sqrt(pop)), floor(pop*0.1))).
+  for (const pop of [10, 50, 100, 400, 1000]) {
+    const sqrtSize = Math.floor(Math.sqrt(pop));
+    const pctSize = Math.floor(pop * 0.1);
+    const expected = Math.max(3, Math.min(sqrtSize, pctSize));
+    assertEquals(calculateAdaptiveTournamentSize(pop), expected);
+  }
+});
+
+Deno.test("SelectionPressure - custom adaptive bounds change the size", () => {
+  // Population 100: default sqrt scaling → 10. A higher exponent and cap
+  // fraction raise the size; a higher minimum raises the floor.
+  assertEquals(calculateAdaptiveTournamentSize(100), 10);
+
+  // capFraction 0.5 lifts the 10% cap so the sqrt term (10) wins.
+  assertEquals(
+    calculateAdaptiveTournamentSize(100, { capFraction: 0.5 }),
+    10,
+  );
+
+  // exponent 1.0 → floor(100^1)=100, capped at floor(100*0.5)=50.
+  assertEquals(
+    calculateAdaptiveTournamentSize(100, {
+      sqrtExponent: 1,
+      capFraction: 0.5,
+    }),
+    50,
+  );
+
+  // A high minimum dominates for a small population.
+  assertEquals(
+    calculateAdaptiveTournamentSize(10, { minSize: 8 }),
+    8,
+  );
+});
+
+// ── POWER exponent ──────────────────────────────────────────────────
+
+Deno.test("SelectionPressure - higher POWER exponent selects the top creature more often", () => {
+  const creatures = createPopulationOfSize(50);
+  const ranking = new FitnessRanking(creatures);
+  const iterations = 4000;
+
+  const lowConfig = createNeatConfig({
+    selection: Selection.POWER,
+    selectionPressure: { power: 1 },
+  });
+  const highConfig = createNeatConfig({
+    selection: Selection.POWER,
+    selectionPressure: { power: 12 },
+  });
+
+  const lowTop = countTopSelections(ranking, lowConfig, iterations);
+  const highTop = countTopSelections(ranking, highConfig, iterations);
+
+  assert(
+    highTop > lowTop,
+    `Higher POWER exponent should pick the top creature more often: ` +
+      `power=12 picked top ${highTop} times vs power=1 ${lowTop} times`,
+  );
+});
+
+// ── Tournament size ─────────────────────────────────────────────────
+
+Deno.test("SelectionPressure - larger tournament size selects the top creature more often", () => {
+  const creatures = createPopulationOfSize(50);
+  const ranking = new FitnessRanking(creatures);
+  const iterations = 4000;
+
+  const smallConfig = createNeatConfig({
+    selection: Selection.TOURNAMENT,
+    selectionPressure: {
+      adaptiveTournament: false,
+      tournamentSize: 2,
+      tournamentProbability: 1, // deterministic: best participant always wins
+    },
+  });
+  const largeConfig = createNeatConfig({
+    selection: Selection.TOURNAMENT,
+    selectionPressure: {
+      adaptiveTournament: false,
+      tournamentSize: 25,
+      tournamentProbability: 1,
+    },
+  });
+
+  const smallTop = countTopSelections(ranking, smallConfig, iterations);
+  const largeTop = countTopSelections(ranking, largeConfig, iterations);
+
+  assert(
+    largeTop > smallTop,
+    `Larger tournament should pick the top creature more often: ` +
+      `size=25 picked top ${largeTop} times vs size=2 ${smallTop} times`,
+  );
+});
+
+Deno.test("SelectionPressure - default config reproduces adaptive tournament selection", () => {
+  // With defaults, TOURNAMENT selection still uses the adaptive size path and
+  // returns valid members of the population.
+  const creatures = createPopulationOfSize(100);
+  const ranking = new FitnessRanking(creatures);
+  const config = createNeatConfig({ selection: Selection.TOURNAMENT });
+
+  for (let i = 0; i < 50; i++) {
+    const selected = selectParent(ranking, config);
+    assert(creatures.some((c) => c.uuid === selected.uuid));
+  }
+});

--- a/test/config/SelectionPressureConfig.ts
+++ b/test/config/SelectionPressureConfig.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for selection-pressure configuration (Issue #2929).
+ *
+ * Verifies that the POWER exponent, tournament size/probability, and
+ * adaptive-tournament bounds are exposed through `createNeatConfig`, default
+ * to the prior hardcoded values, and reject out-of-range input with a clear
+ * error.
+ */
+import { assertEquals, assertThrows } from "@std/assert";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { DEFAULT_SELECTION_PRESSURE_CONFIG } from "@config/SelectionPressureConfig.ts";
+import { ConfigurationError } from "@errors/ConfigurationError.ts";
+import { Selection } from "@methods/Selection.ts";
+
+Deno.test("SelectionPressureConfig - defaults reproduce prior hardcoded values", () => {
+  const config = createNeatConfig({});
+  const sp = config.selectionPressure;
+
+  // Sourced from the Selection strategy singletons.
+  assertEquals(sp.power, Selection.POWER.power);
+  assertEquals(sp.power, 4);
+  assertEquals(sp.tournamentSize, Selection.TOURNAMENT.size);
+  assertEquals(sp.tournamentSize, 5);
+  assertEquals(sp.tournamentProbability, Selection.TOURNAMENT.probability);
+  assertEquals(sp.tournamentProbability, 0.5);
+
+  // Adaptive-tournament bounds reproduce the prior formula.
+  assertEquals(sp.adaptiveTournament, true);
+  assertEquals(sp.adaptiveTournamentMinSize, 3);
+  assertEquals(sp.adaptiveTournamentSqrtExponent, 0.5);
+  assertEquals(sp.adaptiveTournamentCapFraction, 0.1);
+
+  // Mirror the exported default constant.
+  assertEquals(sp, DEFAULT_SELECTION_PRESSURE_CONFIG);
+});
+
+Deno.test("SelectionPressureConfig - custom values override defaults", () => {
+  const config = createNeatConfig({
+    selectionPressure: {
+      power: 8,
+      tournamentSize: 12,
+      tournamentProbability: 0.9,
+      adaptiveTournament: false,
+      adaptiveTournamentMinSize: 4,
+      adaptiveTournamentSqrtExponent: 0.75,
+      adaptiveTournamentCapFraction: 0.2,
+    },
+  });
+  const sp = config.selectionPressure;
+  assertEquals(sp.power, 8);
+  assertEquals(sp.tournamentSize, 12);
+  assertEquals(sp.tournamentProbability, 0.9);
+  assertEquals(sp.adaptiveTournament, false);
+  assertEquals(sp.adaptiveTournamentMinSize, 4);
+  assertEquals(sp.adaptiveTournamentSqrtExponent, 0.75);
+  assertEquals(sp.adaptiveTournamentCapFraction, 0.2);
+});
+
+Deno.test("SelectionPressureConfig - partial overrides merge with defaults", () => {
+  const config = createNeatConfig({
+    selectionPressure: { power: 6 },
+  });
+  const sp = config.selectionPressure;
+  assertEquals(sp.power, 6);
+  // Unspecified knobs keep their defaults.
+  assertEquals(
+    sp.tournamentSize,
+    DEFAULT_SELECTION_PRESSURE_CONFIG.tournamentSize,
+  );
+  assertEquals(
+    sp.adaptiveTournamentCapFraction,
+    DEFAULT_SELECTION_PRESSURE_CONFIG.adaptiveTournamentCapFraction,
+  );
+});
+
+Deno.test("SelectionPressureConfig - numeric fields coerced from string (CLI)", () => {
+  const config = createNeatConfig({
+    selectionPressure: {
+      power: "7",
+      tournamentSize: "9",
+      adaptiveTournamentCapFraction: "0.15",
+    },
+  });
+  const sp = config.selectionPressure;
+  assertEquals(sp.power, 7);
+  assertEquals(sp.tournamentSize, 9);
+  assertEquals(sp.adaptiveTournamentCapFraction, 0.15);
+});
+
+Deno.test("SelectionPressureConfig - rejects non-positive power", () => {
+  assertThrows(
+    () => createNeatConfig({ selectionPressure: { power: 0 } }),
+    ConfigurationError,
+    "Selection pressure power",
+  );
+  assertThrows(
+    () => createNeatConfig({ selectionPressure: { power: -2 } }),
+    ConfigurationError,
+    "Selection pressure power",
+  );
+});
+
+Deno.test("SelectionPressureConfig - rejects out-of-range tournament probability", () => {
+  assertThrows(
+    () =>
+      createNeatConfig({ selectionPressure: { tournamentProbability: 1.5 } }),
+    ConfigurationError,
+    "Selection pressure tournamentProbability",
+  );
+  assertThrows(
+    () =>
+      createNeatConfig({ selectionPressure: { tournamentProbability: -0.1 } }),
+    ConfigurationError,
+    "Selection pressure tournamentProbability",
+  );
+});
+
+Deno.test("SelectionPressureConfig - rejects non-integer / non-positive tournament size", () => {
+  assertThrows(
+    () => createNeatConfig({ selectionPressure: { tournamentSize: 2.5 } }),
+    ConfigurationError,
+    "Selection pressure tournamentSize",
+  );
+  assertThrows(
+    () => createNeatConfig({ selectionPressure: { tournamentSize: 0 } }),
+    ConfigurationError,
+    "Selection pressure tournamentSize",
+  );
+});
+
+Deno.test("SelectionPressureConfig - rejects out-of-range adaptive bounds", () => {
+  assertThrows(
+    () =>
+      createNeatConfig({
+        selectionPressure: { adaptiveTournamentSqrtExponent: 0 },
+      }),
+    ConfigurationError,
+    "Selection pressure adaptiveTournamentSqrtExponent",
+  );
+  assertThrows(
+    () =>
+      createNeatConfig({
+        selectionPressure: { adaptiveTournamentCapFraction: 1.5 },
+      }),
+    ConfigurationError,
+    "Selection pressure adaptiveTournamentCapFraction",
+  );
+  assertThrows(
+    () =>
+      createNeatConfig({
+        selectionPressure: { adaptiveTournamentMinSize: 0 },
+      }),
+    ConfigurationError,
+    "Selection pressure adaptiveTournamentMinSize",
+  );
+});


### PR DESCRIPTION
# Expose selection-pressure parameters as configuration (Issue #2929)

## Summary

Selection pressure is one of the most direct levers on convergence speed, yet
several of its knobs were hardcoded:

- `src/methods/Selection.ts` — `POWER.power = 4`, `TOURNAMENT.size = 5`,
  `TOURNAMENT.probability = 0.5`.
- `src/breed/AdaptiveTournamentSize.ts` — the fully hardcoded formula
  `max(3, min(floor(sqrt(pop)), floor(pop * 0.1)))`.

This change exposes all of them through the standard `NeatOptions`/`NeatConfig`
surface via a new `selectionPressure` config object, with validation and
defaults that reproduce the current behaviour exactly. Users can now tune the
exploration/exploitation trade-off for their problem.

**Closes #2929.**

### New `selectionPressure` knobs

| Knob                             | Default | Meaning                                                    |
| -------------------------------- | ------- | ---------------------------------------------------------- |
| `power`                          | `4`     | POWER selection exponent                                   |
| `tournamentSize`                 | `5`     | Fixed tournament size when adaptive sizing is off          |
| `tournamentProbability`          | `0.5`   | Probability of picking the best tournament participant     |
| `adaptiveTournament`             | `true`  | Scale tournament size with population size                 |
| `adaptiveTournamentMinSize`      | `3`     | Floor for the adaptive tournament size                     |
| `adaptiveTournamentSqrtExponent` | `0.5`   | Population scaling exponent `floor(pop ^ exponent)` (sqrt) |
| `adaptiveTournamentCapFraction`  | `0.1`   | Cap as a fraction of population `floor(pop * fraction)`    |

Out-of-range values (e.g. `power <= 0`, `tournamentProbability > 1`,
`adaptiveTournamentCapFraction > 1`) are rejected by `parseNumber` with a clear
`ConfigurationError` at config-creation time.

### Bit-for-bit default behaviour

- Defaults are sourced from the existing `Selection` singletons
  (`Selection.POWER.power`, `Selection.TOURNAMENT.size/probability`).
- `calculateAdaptiveTournamentSize` keeps `Math.sqrt` for the default exponent
  (`0.5`) so results are identical to the prior implementation; the configurable
  `Math.pow` path is only used for non-default exponents.

```mermaid
flowchart LR
    O[NeatOptions.selectionPressure] --> P[parseSelectionPressure]
    P --> C[NeatConfig.selectionPressure]
    C --> SP[selectParent]
    SP -->|POWER| Pw[selectPower&#40;power&#41;]
    SP -->|TOURNAMENT| AT{adaptiveTournament?}
    AT -->|yes| Adp[calculateAdaptiveTournamentSize&#40;pop, bounds&#41;]
    AT -->|no| Fix[tournamentSize]
    Adp --> T[selectTournament&#40;size, probability&#41;]
    Fix --> T
```

## Evidence

Backend/library change — no UI to screenshot. Verified by the full quality gate
(`./quality.sh`): **7136 passed | 0 failed | 4 ignored**, including all
pre-existing selection/tournament tests, which pass unchanged (proving defaults
reproduce current behaviour).

The new behavioural tests confirm the acceptance criterion that stronger
pressure increases the chance of selecting the top-ranked creature:

- `test/breed/SelectionPressure.ts::SelectionPressure - higher POWER exponent
  selects the top creature more often`
- `test/breed/SelectionPressure.ts::SelectionPressure - larger tournament size
  selects the top creature more often`

## Test Plan

Added:

- `test/config/SelectionPressureConfig.ts` — defaults reproduce prior values,
  custom/partial overrides, CLI string coercion, and out-of-range rejection for
  every knob.
- `test/breed/SelectionPressure.ts` — custom adaptive bounds change the computed
  size while defaults match the prior formula; POWER exponent and tournament
  size measurably raise the probability of selecting the top creature; default
  config still drives adaptive tournament selection.

No existing tests were modified or removed.

## Files changed

- `src/config/SelectionPressureConfig.ts` (new) — config interface, `Required`
  type, and defaults.
- `src/config/parsers/SelectionParsers.ts` (new) — `parseSelectionPressure`.
- `src/config/NeatConfigParsers.ts` — re-export the new parser.
- `src/config/NeatConfig.ts` — wire `selectionPressure` into `createNeatConfig`.
- `src/config/NeatArguments.ts`, `src/config/NeatOptions.ts` — add the field to
  the config and options surfaces.
- `src/breed/AdaptiveTournamentSize.ts` — accept optional tunable bounds.
- `src/breed/ParentSelection.ts` — read knobs from config instead of the
  hardcoded `Selection` singletons.
- `mod.ts` — export the new config types and default constant.
- `docs/PERFORMANCE_TUNING.md` — document the new knobs.
