### PR TITLE
Novelty: optional behavioural-diversity selection to escape deceptive landscapes (#2932)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Issue #2932:** Optional novelty (behavioural-diversity) selection to escape
+  deceptive landscapes. A new self-contained module
+  (`src/NEAT/NoveltySearch.ts`) adds a per-creature behaviour descriptor
+  (problem-supplied via a `behaviour` tag), a bounded novelty archive, a
+  k-nearest-neighbour novelty score, and a configurable blend
+  `score' = (1 - weight)·fitness + weight·novelty` used in parent-selection
+  ranking. **OFF by default** (`novelty: { enabled: false }`), so existing
+  behaviour and tests are unchanged. A deterministic deceptive-task benchmark
+  (`bench/NoveltyDeceptiveEscape.ts`) and acceptance test show novelty escaping
+  a local optimum in far fewer generations than fitness-only search. See
+  [`docs/NOVELTY_SEARCH.md`](./docs/NOVELTY_SEARCH.md).
+
 ### Fixed
 
 - **Issue #2871:** Evolution now always finalizes even when an optional training

--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ ONNX export — are extensions beyond the standard NEAT algorithm. See
     [dense layers](https://en.wikipedia.org/wiki/Dense_layer). Opt-in via
     `syntheticSynapses: true` in the training configuration.
 
+23. **Novelty (Behavioural-Diversity) Selection**: On deceptive problems,
+    pure-fitness selection drives the population into local optima where the
+    pace of evolution collapses.
+    [Novelty search (Lehman & Stanley, 2011)](https://doi.org/10.1162/EVCO_a_00025)
+    rewards behavioural diversity instead. Each creature is given a numeric
+    behaviour descriptor (problem-supplied via a tag — for example the output
+    vector on a probe set); its novelty score is the mean distance to its `k`
+    nearest neighbours across the population and a bounded archive; and ranking
+    uses the blend `score' = (1 - weight)·fitness + weight·novelty`. **OFF by
+    default** — opt-in via `novelty: { enabled: true }` and set a `behaviour`
+    tag on each creature. See [Novelty Search](./docs/NOVELTY_SEARCH.md).
+
 ## 🚀 Quick Start
 
 ```typescript

--- a/bench/NoveltyDeceptiveEscape.ts
+++ b/bench/NoveltyDeceptiveEscape.ts
@@ -1,0 +1,110 @@
+/**
+ * Issue #2932 - Novelty (behavioural-diversity) deceptive-escape benchmark.
+ *
+ * Compares generations-to-solve on a 1-D deceptive landscape with novelty
+ * selection OFF (pure fitness) vs ON (fitness/novelty blend). The population
+ * starts inside a deceptive basin near x=0 (fitness cap 0.8); the global
+ * optimum (1.0) sits at x=1 across a fitness valley at x=0.5. Pure fitness
+ * is trapped; novelty migrates the population across the valley.
+ *
+ * Run with:
+ *   deno run --allow-read --allow-env bench/NoveltyDeceptiveEscape.ts
+ */
+
+import { DEFAULT_NOVELTY_CONFIG } from "@config/NoveltyConfig.ts";
+import { blendScores, NoveltySearch } from "@neat/NoveltySearch.ts";
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function gaussian(rng: () => number): number {
+  const u = Math.max(rng(), 1e-12);
+  const v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+function deceptiveFitness(x: number): number {
+  if (x < 0.5) return 0.8 * (1 - x / 0.5);
+  return (x - 0.5) / 0.5;
+}
+
+const POPULATION = 40;
+const MAX_GENERATIONS = 150;
+const SIGMA = 0.1;
+const TARGET = 0.95;
+
+function runDeceptive(useNovelty: boolean, seed: number): {
+  solved: boolean;
+  generations: number;
+  bestFitness: number;
+} {
+  const rng = mulberry32(seed);
+  let population: number[] = [];
+  for (let i = 0; i < POPULATION; i++) population.push(rng() * 0.4);
+
+  const search = new NoveltySearch({
+    ...DEFAULT_NOVELTY_CONFIG,
+    enabled: true,
+    weight: 0.6,
+    neighbours: 10,
+  });
+
+  let bestFitness = 0;
+  for (let gen = 0; gen < MAX_GENERATIONS; gen++) {
+    const fitness = population.map(deceptiveFitness);
+    bestFitness = Math.max(bestFitness, ...fitness);
+    if (bestFitness >= TARGET) {
+      return { solved: true, generations: gen, bestFitness };
+    }
+
+    let selectionScore: number[];
+    if (useNovelty) {
+      const behaviours = population.map((x) => [x]);
+      const novelty = search.computeNovelty(behaviours);
+      search.updateArchive(behaviours, novelty);
+      selectionScore = blendScores(fitness, novelty, search.config.weight);
+    } else {
+      selectionScore = fitness;
+    }
+
+    const order = population
+      .map((_, i) => i)
+      .sort((a, b) => selectionScore[b] - selectionScore[a]);
+    const next: number[] = [population[order[0]]];
+    while (next.length < POPULATION) {
+      const a = order[Math.floor(rng() * order.length)];
+      const b = order[Math.floor(rng() * order.length)];
+      const parent = selectionScore[a] >= selectionScore[b] ? a : b;
+      let child = population[parent] + gaussian(rng) * SIGMA;
+      child = Math.min(1, Math.max(0, child));
+      next.push(child);
+    }
+    population = next;
+  }
+  return { solved: false, generations: MAX_GENERATIONS, bestFitness };
+}
+
+console.log("Deceptive-escape benchmark (Issue #2932)");
+console.log("seed | fitness-only            | with-novelty");
+const seeds = [12345, 222, 9001, 4242, 77777];
+for (const seed of seeds) {
+  const f = runDeceptive(false, seed);
+  const n = runDeceptive(true, seed);
+  const fTxt = f.solved
+    ? `solved @ gen ${f.generations}`
+    : `trapped (best ${f.bestFitness.toFixed(3)})`;
+  const nTxt = n.solved
+    ? `solved @ gen ${n.generations}`
+    : `trapped (best ${n.bestFitness.toFixed(3)})`;
+  console.log(
+    `${String(seed).padEnd(5)}| ${fTxt.padEnd(24)}| ${nTxt}`,
+  );
+}

--- a/docs/NOVELTY_SEARCH.md
+++ b/docs/NOVELTY_SEARCH.md
@@ -1,0 +1,107 @@
+# Novelty (Behavioural-Diversity) Selection
+
+> Issue #2932 — escape deceptive landscapes by rewarding behavioural novelty.
+
+On **deceptive** problems, pure-fitness selection drives the population into a
+local optimum where fitness stops improving and the effective pace of evolution
+collapses. **Novelty search**
+([Lehman & Stanley, 2011](https://doi.org/10.1162/EVCO_a_00025)) rewards
+behavioural diversity rather than — or blended with — raw fitness, and is a
+well-established accelerant for escaping deception.
+
+NEAT-AI's existing diversity mechanisms (speciation, fitness sharing,
+compatibility gating) maintain **structural** diversity only. Novelty selection
+adds **behavioural** diversity: it compares what creatures _do_, not how they
+are wired.
+
+The mechanism is **OFF by default**. When disabled, ranking and selection are
+exactly as before.
+
+## How it works
+
+1. **Behaviour descriptor** — a numeric vector describing a creature's
+   behaviour, supplied by the problem's fitness function as a comma-separated
+   `behaviour` tag (for example, the creature's output vector on a fixed probe
+   set). Creatures without a parseable descriptor contribute no novelty.
+2. **Novelty score** — the mean Euclidean distance from a creature's descriptor
+   to its `k` nearest neighbours, drawn from both the current population and a
+   bounded **archive** of past behaviours. A creature that behaves unlike
+   everything seen so far scores high.
+3. **Bounded archive** — novel behaviours are retained (first-in, first-out once
+   `archiveLimit` is reached) so the population is pushed away from regions
+   already explored, not just away from the current generation.
+4. **Blend** — ranking uses `score' = (1 - weight)·fitness + weight·novelty`,
+   with fitness and novelty min-max normalised first so their scales do not
+   dominate each other.
+
+```mermaid
+flowchart LR
+    A[Population] --> B[Behaviour descriptor<br/>behaviour tag]
+    B --> C[kNN novelty score<br/>population + archive]
+    D[(Novelty archive<br/>bounded FIFO)] --> C
+    C --> E["Blend<br/>(1-w)·fitness + w·novelty"]
+    F[Raw fitness] --> E
+    E --> G[FitnessRanking<br/>parent selection]
+    C --> D
+```
+
+## Configuration
+
+```ts
+const neat = new Neat(input, output, fitness, {
+  novelty: {
+    enabled: true, // OFF by default
+    weight: 0.5, // blend weight w in [0,1] (0 = pure fitness)
+    neighbours: 15, // k nearest neighbours for the novelty score
+    archiveLimit: 500, // maximum behaviours retained in the archive
+    addThreshold: 0, // minimum novelty to admit a behaviour to the archive
+    behaviourTag: "behaviour", // tag holding the descriptor
+  },
+});
+```
+
+| Option         | Default       | Meaning                                                     |
+| -------------- | ------------- | ----------------------------------------------------------- |
+| `enabled`      | `false`       | Master switch. OFF leaves ranking unchanged.                |
+| `weight`       | `0.5`         | Blend weight `w`; `0` is pure fitness, `1` is pure novelty. |
+| `neighbours`   | `15`          | `k` for the k-nearest-neighbour novelty score.              |
+| `archiveLimit` | `500`         | Archive cap; oldest behaviours are evicted first.           |
+| `addThreshold` | `0`           | Minimum novelty before a behaviour is archived.             |
+| `behaviourTag` | `"behaviour"` | Creature tag holding the descriptor.                        |
+
+## Supplying behaviour descriptors
+
+The fitness function tags each creature with its behaviour descriptor — a
+comma-separated list of finite numbers:
+
+```ts
+import { addTag } from "@stsoftware/tags/mod";
+
+// e.g. the creature's outputs on a fixed probe set
+addTag(creature, "behaviour", probeOutputs.join(","));
+```
+
+When fewer than two creatures expose a parseable descriptor there is nothing
+meaningful to compare, so ranking is left untouched — novelty is safe to enable
+even before descriptors are wired up.
+
+## Evidence
+
+A deterministic deceptive-landscape benchmark
+([`bench/NoveltyDeceptiveEscape.ts`](../bench/NoveltyDeceptiveEscape.ts)) starts
+the population inside a deceptive basin (fitness cap `0.8`) with the global
+optimum (`1.0`) on the far side of a fitness valley. Pure-fitness selection is
+trapped; novelty selection escapes in a handful of generations:
+
+| seed  | fitness-only         | with novelty    |
+| ----- | -------------------- | --------------- |
+| 12345 | trapped (best 0.800) | solved @ gen 8  |
+| 222   | trapped (best 0.800) | solved @ gen 9  |
+| 9001  | trapped (best 0.800) | solved @ gen 8  |
+| 4242  | trapped (best 0.800) | solved @ gen 11 |
+| 77777 | trapped (best 0.800) | solved @ gen 5  |
+
+The acceptance test
+[`test/NEAT/NoveltySearchDeceptive.ts`](../test/NEAT/NoveltySearchDeceptive.ts)
+asserts novelty escapes the trap in strictly fewer generations than
+fitness-only.

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,6 +135,10 @@ Subsystems that only some users need.
   the migration path for the five episodic examples in NEAT-AI-Examples.
 - **[dna-sharing-bake-off-results.md](dna-sharing-bake-off-results.md)** —
   bake-off comparison of inter-island DNA-sharing primitives (Issue #2496).
+- **[NOVELTY_SEARCH.md](NOVELTY_SEARCH.md)** — optional novelty
+  (behavioural-diversity) selection to escape deceptive landscapes: behaviour
+  descriptors, the bounded archive, the kNN novelty score, and the
+  fitness/novelty blend (Issue #2932).
 
 ## 🏛️ Governance and core dependency
 

--- a/docs/archive/pr-summaries/pr-summary-2932.md
+++ b/docs/archive/pr-summaries/pr-summary-2932.md
@@ -1,0 +1,90 @@
+## Summary
+
+Adds an optional **novelty (behavioural-diversity) selection** mechanism to
+escape deceptive landscapes, where pure-fitness selection stalls in local optima
+and the pace of evolution collapses. The new mechanism is a self-contained
+module behind an **OFF-by-default** feature flag, so existing behaviour and
+tests are unchanged. Closes #2932.
+
+When enabled, ranking blends raw fitness with a behavioural-novelty score:
+
+- a per-creature **behaviour descriptor** (problem-supplied via a `behaviour`
+  tag — e.g. the output vector on a probe set),
+- a bounded, FIFO **novelty archive**,
+- a **k-nearest-neighbour novelty score** (mean distance to the `k` nearest
+  behaviours across the population + archive),
+- a configurable blend `score' = (1 - weight)·fitness + weight·novelty` (both
+  terms min-max normalised), fed into `FitnessRanking` via the existing
+  score-override hook used by fitness sharing.
+
+### What changed
+
+- **New** `src/config/NoveltyConfig.ts` — `NoveltyConfig` /
+  `RequiredNoveltyConfig` / `DEFAULT_NOVELTY_CONFIG` (`enabled: false`).
+- **New** `src/NEAT/NoveltySearch.ts` — pure-numeric core (`behaviourDistance`,
+  `meanNearestNeighbourDistance`, `normalise`, `blendScores`), the
+  `NoveltyArchive` and `NoveltySearch` classes, and the `extractBehaviour` /
+  `buildNoveltyBlendedScores` bridge to live breeding.
+- **Config wiring** — `parseNovelty` (PopulationParsers + barrel), and the
+  `novelty` field threaded through `NeatArguments`, `NeatOptions` (both option
+  shapes + both `Omit` lists), and `NeatConfig`.
+- **Breeding** — `Breed` accepts an optional persistent `NoveltySearch`; when
+  `novelty.enabled` it blends novelty into the mother-selection ranking. The
+  engine is owned by `Neat` (`neat.noveltySearch`) so the archive accumulates
+  across generations, and is passed in at both `Breed` construction sites
+  (`Neat.ts`, `NeatEvolution.ts`).
+- **Docs** — `docs/NOVELTY_SEARCH.md` (with a Mermaid flow diagram), a README
+  Feature Highlight, docs index entry, and a CHANGELOG entry.
+
+### Safety / no-op guarantees
+
+- `enabled: false` (default) → the novelty branch is skipped entirely; ranking
+  is byte-for-byte as before.
+- `enabled: true` but fewer than two creatures expose a parseable descriptor →
+  `buildNoveltyBlendedScores` returns `undefined` and ranking is left untouched.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via the test suite
+and a deterministic deceptive-landscape benchmark.
+
+```mermaid
+flowchart LR
+    A[Population] --> B[Behaviour descriptor]
+    B --> C[kNN novelty score]
+    D[(Novelty archive)] --> C
+    C --> E["Blend (1-w)·fitness + w·novelty"]
+    F[Raw fitness] --> E
+    E --> G[FitnessRanking]
+    C --> D
+```
+
+`bench/NoveltyDeceptiveEscape.ts` — population starts inside a deceptive basin
+(fitness cap `0.8`); the global optimum (`1.0`) sits across a fitness valley.
+Pure fitness is trapped; novelty escapes in a handful of generations:
+
+| seed  | fitness-only         | with novelty    |
+| ----- | -------------------- | --------------- |
+| 12345 | trapped (best 0.800) | solved @ gen 8  |
+| 222   | trapped (best 0.800) | solved @ gen 9  |
+| 9001  | trapped (best 0.800) | solved @ gen 8  |
+| 4242  | trapped (best 0.800) | solved @ gen 11 |
+| 77777 | trapped (best 0.800) | solved @ gen 5  |
+
+## Test Plan
+
+- `test/config/NoveltyConfig.ts` — defaults applied, OFF by default, overrides,
+  partial overrides, range validation (weight, neighbours), empty-tag fallback.
+- `test/NEAT/NoveltySearch.ts` — distance, kNN mean, archive FIFO eviction +
+  defensive copies + floor, normalise, blend (weight 0/1/0.5 + clamping),
+  `computeNovelty`, `updateArchive` threshold, `extractBehaviour`,
+  `buildNoveltyBlendedScores` (no-op + blend + archive).
+- `test/NEAT/NoveltySearchDeceptive.ts` — **acceptance**: novelty escapes the
+  deceptive trap in strictly fewer generations than fitness-only (deterministic,
+  seeded).
+- `test/breed/BreedNovelty.ts` — Breed wiring: disabled engine untouched,
+  enabled engine archives behaviours, enabled-but-no-tags safe no-op.
+
+Quality gates run: `deno fmt`, `deno lint`, `deno check` (full project),
+bash-script check — all clean. Affected suites (config, breed, NEAT novelty)
+pass.

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -26,6 +26,7 @@ import { Genus } from "@neat/Genus.ts";
 import { computeHardDeadlineTS } from "@neat/HardDeadline.ts";
 import { Mutator } from "@neat/Mutator.ts";
 import { MCMCState } from "@neat/MCMCState.ts";
+import { NoveltySearch } from "@neat/NoveltySearch.ts";
 import { PlateauDetector } from "@neat/PlateauDetector.ts";
 import { SpeciesPlateauDetector } from "@neat/SpeciesPlateauDetector.ts";
 import { TrainingRegressionTracker } from "@neat/TrainingRegressionTracker.ts";
@@ -110,6 +111,13 @@ export class Neat {
 
   /** Issue #2200: MCMC temperature state for Metropolis-Hastings acceptance */
   readonly mcmcState: MCMCState;
+
+  /**
+   * Persistent novelty (behavioural-diversity) search engine (Issue #2932).
+   * Holds the cross-generation novelty archive. OFF by default; only
+   * consulted when `config.novelty.enabled`.
+   */
+  readonly noveltySearch: NoveltySearch;
 
   /**
    * Issue #2457: Per-role squash effectiveness tracker.
@@ -291,6 +299,10 @@ export class Neat {
 
     // Issue #2200: Initialise MCMC temperature state
     this.mcmcState = new MCMCState(this.config.mcmc);
+
+    // Issue #2932: Initialise the persistent novelty search engine. The
+    // archive lives here so it accumulates across generations.
+    this.noveltySearch = new NoveltySearch(this.config.novelty);
 
     // Issue #2457: Initialise the per-role squash effectiveness tracker.
     this.squashEffectivenessTracker = new SquashEffectivenessTracker(
@@ -755,7 +767,7 @@ export class Neat {
       genus.addCreature(creature);
     }
 
-    const breed = new Breed(genus, this.config);
+    const breed = new Breed(genus, this.config, this.noveltySearch);
     const deDuplicator = new DeDuplicator(breed, mutator);
     await deDuplicator.perform(this.population);
   }

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -607,7 +607,7 @@ export async function evolve(
     return result;
   });
 
-  const breed = new Breed(genus, neat.config);
+  const breed = new Breed(genus, neat.config, neat.noveltySearch);
 
   // Issue #2323: Start timing main-thread overlap work (runs concurrently
   // with worker breeding).

--- a/src/NEAT/NoveltySearch.ts
+++ b/src/NEAT/NoveltySearch.ts
@@ -1,0 +1,309 @@
+/**
+ * NoveltySearch.ts - Novelty (behavioural-diversity) selection (Issue
+ * #2932).
+ *
+ * Implements the behaviour descriptor, bounded archive, k-nearest-neighbour
+ * novelty score and fitness/novelty blend described by Lehman & Stanley
+ * (2011, "Abandoning Objectives: Evolution Through the Search for Novelty
+ * Alone"). The mechanism is OFF by default and self-contained behind the
+ * {@link RequiredNoveltyConfig} feature flag — see
+ * {@link ../config/NoveltyConfig.ts}.
+ *
+ * The core is pure-numeric and side-effect free so it is cheap to unit test
+ * and to drive from a standalone deceptive-task benchmark. The
+ * {@link extractBehaviour} / {@link buildNoveltyBlendedScores} helpers bridge
+ * to live breeding by reading a per-creature behaviour tag and producing a
+ * UUID → blended-score map suitable for `FitnessRanking`'s score override.
+ */
+
+import { getTag } from "@stsoftware/tags/mod";
+import type { Creature } from "@creature";
+import type { RequiredNoveltyConfig } from "@config/NoveltyConfig.ts";
+
+/** A behaviour descriptor: a vector of finite numbers. */
+export type BehaviourDescriptor = readonly number[];
+
+/**
+ * Euclidean distance between two behaviour descriptors. When the
+ * descriptors differ in length the shared leading prefix is compared, so a
+ * partial descriptor still yields a meaningful distance.
+ *
+ * @param a - First behaviour descriptor.
+ * @param b - Second behaviour descriptor.
+ * @returns The Euclidean distance over the shared prefix (0 for empty).
+ */
+export function behaviourDistance(
+  a: BehaviourDescriptor,
+  b: BehaviourDescriptor,
+): number {
+  const n = Math.min(a.length, b.length);
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    const d = a[i] - b[i];
+    sum += d * d;
+  }
+  return Math.sqrt(sum);
+}
+
+/**
+ * Mean distance from a target descriptor to its `k` nearest neighbours
+ * within `others`. This is the novelty score: a behaviour far from all
+ * others scores high.
+ *
+ * @param target - The descriptor whose novelty is measured.
+ * @param others - Candidate neighbour descriptors (population + archive).
+ * @param k - Number of nearest neighbours to average over (clamped to the
+ *   number available).
+ * @returns The mean distance to the `k` nearest neighbours, or `0` when
+ *   there are no other descriptors.
+ */
+export function meanNearestNeighbourDistance(
+  target: BehaviourDescriptor,
+  others: readonly BehaviourDescriptor[],
+  k: number,
+): number {
+  if (others.length === 0) return 0;
+  const distances = others
+    .map((o) => behaviourDistance(target, o))
+    .sort((x, y) => x - y);
+  const kk = Math.min(Math.max(1, Math.floor(k)), distances.length);
+  let sum = 0;
+  for (let i = 0; i < kk; i++) sum += distances[i];
+  return sum / kk;
+}
+
+/**
+ * A bounded, first-in-first-out archive of behaviour descriptors. Stored
+ * copies are defensive so external mutation cannot corrupt the archive.
+ */
+export class NoveltyArchive {
+  readonly #entries: number[][] = [];
+  readonly #limit: number;
+
+  /**
+   * @param limit - Maximum retained descriptors (minimum 1). When exceeded
+   *   the oldest descriptor is evicted.
+   */
+  constructor(limit: number) {
+    this.#limit = Math.max(1, Math.floor(limit));
+  }
+
+  /** Number of descriptors currently retained. */
+  get size(): number {
+    return this.#entries.length;
+  }
+
+  /** Read-only view of the retained descriptors (oldest first). */
+  get entries(): readonly BehaviourDescriptor[] {
+    return this.#entries;
+  }
+
+  /**
+   * Append a copy of `descriptor`, evicting the oldest entry when the
+   * archive is over its limit. Empty descriptors are ignored.
+   *
+   * @param descriptor - The behaviour descriptor to archive.
+   */
+  add(descriptor: BehaviourDescriptor): void {
+    if (descriptor.length === 0) return;
+    this.#entries.push(descriptor.slice());
+    while (this.#entries.length > this.#limit) {
+      this.#entries.shift();
+    }
+  }
+
+  /** Remove all archived descriptors. */
+  clear(): void {
+    this.#entries.length = 0;
+  }
+}
+
+/**
+ * Novelty search engine: holds the persistent archive and computes novelty
+ * scores for a generation's behaviour descriptors. One instance lives for
+ * the lifetime of a run so the archive accumulates across generations.
+ */
+export class NoveltySearch {
+  readonly config: RequiredNoveltyConfig;
+  readonly archive: NoveltyArchive;
+
+  /**
+   * @param config - Resolved novelty configuration.
+   */
+  constructor(config: RequiredNoveltyConfig) {
+    this.config = config;
+    this.archive = new NoveltyArchive(config.archiveLimit);
+  }
+
+  /**
+   * Compute the novelty score for each descriptor in `behaviours`. Novelty
+   * is the mean distance to the `k` nearest neighbours drawn from the rest
+   * of the current population **and** the archive.
+   *
+   * @param behaviours - This generation's behaviour descriptors, in order.
+   * @returns Novelty scores aligned to `behaviours` by index.
+   */
+  computeNovelty(behaviours: readonly BehaviourDescriptor[]): number[] {
+    const archiveEntries = this.archive.entries;
+    return behaviours.map((target, i) => {
+      const others: BehaviourDescriptor[] = [];
+      for (let j = 0; j < behaviours.length; j++) {
+        if (j !== i) others.push(behaviours[j]);
+      }
+      for (const entry of archiveEntries) others.push(entry);
+      return meanNearestNeighbourDistance(
+        target,
+        others,
+        this.config.neighbours,
+      );
+    });
+  }
+
+  /**
+   * Admit behaviours whose novelty meets `addThreshold` into the archive.
+   *
+   * @param behaviours - This generation's descriptors.
+   * @param novelty - Their novelty scores (from {@link computeNovelty}).
+   */
+  updateArchive(
+    behaviours: readonly BehaviourDescriptor[],
+    novelty: readonly number[],
+  ): void {
+    for (let i = 0; i < behaviours.length; i++) {
+      if (novelty[i] >= this.config.addThreshold) {
+        this.archive.add(behaviours[i]);
+      }
+    }
+  }
+}
+
+/**
+ * Min-max normalise `values` into `[0, 1]`. When every value is equal the
+ * result is a neutral `0.5` for each, so a flat dimension neither helps nor
+ * hurts the blend.
+ *
+ * @param values - The values to normalise.
+ * @returns Normalised values aligned to `values` by index.
+ */
+export function normalise(values: readonly number[]): number[] {
+  if (values.length === 0) return [];
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const range = max - min;
+  if (range === 0) return values.map(() => 0.5);
+  return values.map((v) => (v - min) / range);
+}
+
+/**
+ * Blend fitness and novelty into a single ranking score per index using
+ * `score' = (1 - weight)·fitnessNorm + weight·noveltyNorm`. Both inputs are
+ * min-max normalised first so their differing scales do not dominate.
+ *
+ * @param fitness - Raw fitness per index.
+ * @param novelty - Novelty score per index (same length as `fitness`).
+ * @param weight - Blend weight in `[0, 1]`.
+ * @returns Blended scores in `[0, 1]`, aligned by index.
+ */
+export function blendScores(
+  fitness: readonly number[],
+  novelty: readonly number[],
+  weight: number,
+): number[] {
+  const w = Math.min(1, Math.max(0, weight));
+  const fitnessNorm = normalise(fitness);
+  const noveltyNorm = normalise(novelty);
+  return fitness.map((_, i) => (1 - w) * fitnessNorm[i] + w * noveltyNorm[i]);
+}
+
+/**
+ * Parse a creature's behaviour descriptor from its tag. The tag value is a
+ * comma-separated list of finite numbers (for example an output vector on a
+ * probe set).
+ *
+ * @param creature - The creature to read.
+ * @param tag - The tag name holding the descriptor.
+ * @returns The parsed descriptor, or `undefined` when the tag is absent,
+ *   empty, or contains a non-finite value.
+ */
+export function extractBehaviour(
+  creature: Creature,
+  tag: string,
+): number[] | undefined {
+  const txt = getTag(creature, tag);
+  if (!txt) return undefined;
+  const parts = txt.split(",").map((s) => Number.parseFloat(s.trim()));
+  if (parts.length === 0) return undefined;
+  for (const p of parts) {
+    if (!Number.isFinite(p)) return undefined;
+  }
+  return parts;
+}
+
+/**
+ * Build a UUID → blended-score map for live breeding. Reads each creature's
+ * behaviour descriptor, computes novelty against the population and the
+ * persistent archive, blends it with the supplied base fitness, and updates
+ * the archive.
+ *
+ * Safe by construction: when fewer than two creatures expose a parseable
+ * behaviour descriptor there is nothing meaningful to compare, so the
+ * function returns `undefined` and the caller leaves ranking untouched.
+ *
+ * @param population - The current population.
+ * @param baseScore - Returns the base fitness for a creature (raw score or
+ *   an upstream override such as fitness sharing).
+ * @param search - The persistent novelty engine (archive lives here).
+ * @returns A UUID → blended-score map, or `undefined` when novelty cannot be
+ *   applied (no/too-few behaviour descriptors).
+ */
+export function buildNoveltyBlendedScores(
+  population: readonly Creature[],
+  baseScore: (creature: Creature) => number,
+  search: NoveltySearch,
+): Map<string, number> | undefined {
+  const tag = search.config.behaviourTag;
+  const behaviours: BehaviourDescriptor[] = [];
+  let described = 0;
+  for (const creature of population) {
+    const b = extractBehaviour(creature, tag);
+    if (b) {
+      behaviours.push(b);
+      described++;
+    } else {
+      // Absent descriptor → least-novel placeholder so the creature is not
+      // rewarded for missing behaviour data.
+      behaviours.push([]);
+    }
+  }
+  if (described < 2) return undefined;
+
+  const novelty = search.computeNovelty(behaviours);
+  const fitness = population.map((c) => {
+    const s = baseScore(c);
+    return Number.isFinite(s) ? s : 0;
+  });
+  const blended = blendScores(fitness, novelty, search.config.weight);
+
+  const map = new Map<string, number>();
+  for (let i = 0; i < population.length; i++) {
+    const uuid = population[i].uuid;
+    if (uuid) map.set(uuid, blended[i]);
+  }
+
+  // Archive only the genuinely described behaviours.
+  const describedBehaviours: BehaviourDescriptor[] = [];
+  const describedNovelty: number[] = [];
+  for (let i = 0; i < behaviours.length; i++) {
+    if (behaviours[i].length > 0) {
+      describedBehaviours.push(behaviours[i]);
+      describedNovelty.push(novelty[i]);
+    }
+  }
+  search.updateArchive(describedBehaviours, describedNovelty);
+
+  return map;
+}

--- a/src/breed/Breed.ts
+++ b/src/breed/Breed.ts
@@ -15,6 +15,10 @@ import {
   findFather,
   selectParent,
 } from "@breed/ParentSelection.ts";
+import {
+  buildNoveltyBlendedScores,
+  type NoveltySearch,
+} from "@neat/NoveltySearch.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 
@@ -65,15 +69,26 @@ export class Breed {
   lastCorruptParentSkips = 0;
 
   /**
+   * Persistent novelty search engine (Issue #2932). Provided by the owning
+   * `Neat` so its archive accumulates across generations. `undefined` when
+   * novelty selection is not wired in (e.g. direct/test construction).
+   */
+  private readonly noveltySearch?: NoveltySearch;
+
+  /**
    * Creates a new Breed instance.
    *
    * @param genus - The genus containing the population
    * @param config - NEAT configuration options (used directly, no re-parsing)
+   * @param noveltySearch - Optional persistent novelty engine (Issue #2932).
+   *   When supplied and `config.novelty.enabled`, mother-selection ranking
+   *   blends fitness with behavioural novelty.
    */
-  constructor(genus: Genus, config: NeatConfig) {
+  constructor(genus: Genus, config: NeatConfig, noveltySearch?: NoveltySearch) {
     this.genus = genus;
     this.options = { ...config };
     this.cachedConfig = config;
+    this.noveltySearch = noveltySearch;
   }
 
   /**
@@ -130,6 +145,30 @@ export class Breed {
     } else if (config.fitnessSharing.enabled) {
       scoreOverride = buildAdjustedFitnessMap(this.genus);
     }
+
+    // Issue #2932: When novelty selection is enabled, blend the base score
+    // (raw fitness, or whatever override was chosen above) with a
+    // behavioural-novelty score so the population can escape deceptive
+    // local optima. No-op when no pre-computed ranking is reused and the
+    // population lacks behaviour descriptors.
+    if (
+      config.novelty.enabled && this.noveltySearch && !populationRanking
+    ) {
+      const base = scoreOverride;
+      const blended = buildNoveltyBlendedScores(
+        this.genus.population,
+        (creature) => {
+          const override = base?.get(creature.uuid!);
+          if (override !== undefined && Number.isFinite(override)) {
+            return override;
+          }
+          return Number.isFinite(creature.score) ? creature.score! : 0;
+        },
+        this.noveltySearch,
+      );
+      if (blended) scoreOverride = blended;
+    }
+
     const ranking = populationRanking ??
       new FitnessRanking(this.genus.population, scoreOverride);
 

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -14,6 +14,7 @@ import type { DiscoveryMinCandidatesPerCategory } from "@config/DiscoveryMinCand
 import type { RequiredEnsembleDiversityConfig } from "@config/EnsembleDiversityConfig.ts";
 import type { RequiredFineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
 import type { RequiredFitnessSharingConfig } from "@config/FitnessSharingConfig.ts";
+import type { RequiredNoveltyConfig } from "@config/NoveltyConfig.ts";
 import type { RequiredSpeciesStagnationConfig } from "@config/SpeciesStagnationConfig.ts";
 import type { RequiredStabilityAdaptationConfig } from "@config/StabilityAdaptationConfig.ts";
 import type { RequiredQuantumStepConfig } from "@config/QuantumStepConfig.ts";
@@ -937,6 +938,21 @@ export interface NeatArguments {
    * - minSpeciesSlots: Floor for per-species breeding slots (default: 1)
    */
   fitnessSharing: RequiredFitnessSharingConfig;
+
+  /**
+   * Novelty (behavioural-diversity) selection configuration (Issue #2932).
+   * OFF by default. When `enabled`, ranking blends fitness with a
+   * k-nearest-neighbour novelty score over per-creature behaviour
+   * descriptors to escape deceptive local optima.
+   * Configuration options:
+   * - enabled: Whether novelty selection is active (default: false)
+   * - weight: Blend weight in score' = (1-w)*fitness + w*novelty (default: 0.5)
+   * - neighbours: k nearest neighbours for the novelty score (default: 15)
+   * - archiveLimit: Maximum behaviours retained in the archive (default: 500)
+   * - addThreshold: Minimum novelty to admit to the archive (default: 0)
+   * - behaviourTag: Tag holding the behaviour descriptor (default: "behaviour")
+   */
+  novelty: RequiredNoveltyConfig;
 
   /**
    * Species stagnation detection and breeding-budget reclamation

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -54,6 +54,7 @@ import {
   parseHyperparameterEvolution,
   parseMcmc,
   parseMemoryConfig,
+  parseNovelty,
   parseOpd,
   parseParallelEvaluation,
   parsePlateauDetection,
@@ -716,6 +717,10 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
     // Issue #2453: Parse fitness sharing configuration
     fitnessSharing: parseFitnessSharing(
       opts.fitnessSharing as Record<string, unknown> | undefined,
+    ),
+    // Issue #2932: Parse novelty (behavioural-diversity) configuration
+    novelty: parseNovelty(
+      opts.novelty as Record<string, unknown> | undefined,
     ),
     // Issue #2454: Parse species stagnation configuration
     speciesStagnation: parseSpeciesStagnation(

--- a/src/config/NeatConfigParsers.ts
+++ b/src/config/NeatConfigParsers.ts
@@ -33,6 +33,7 @@ export {
   parseEnsembleDiversity,
   parseFineTunePopulation,
   parseFitnessSharing,
+  parseNovelty,
   parseSpeciesStagnation,
 } from "@config/parsers/PopulationParsers.ts";
 export {

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -8,6 +8,7 @@ import type { DiscoveryMinCandidatesPerCategory } from "@config/DiscoveryMinCand
 import type { EnsembleDiversityConfig } from "@config/EnsembleDiversityConfig.ts";
 import type { FineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
 import type { FitnessSharingConfig } from "@config/FitnessSharingConfig.ts";
+import type { NoveltyConfig } from "@config/NoveltyConfig.ts";
 import type { SpeciesStagnationConfig } from "@config/SpeciesStagnationConfig.ts";
 import type { NeatArguments } from "@config/NeatArguments.ts";
 import type { PlateauDetectionConfig } from "@neat/PlateauDetector.ts";
@@ -125,6 +126,7 @@ export type NeatOptions =
     | "parallelEvaluation"
     | "squashEffectiveness"
     | "fitnessSharing"
+    | "novelty"
     | "speciesStagnation"
     | "compatibilityGating"
     | "selectionPressure"
@@ -195,6 +197,8 @@ export type NeatOptions =
     squashEffectiveness?: SquashEffectivenessConfig;
     /** Partial overrides for fitness sharing configuration (Issue #2453, defaults applied if not specified) */
     fitnessSharing?: FitnessSharingConfig;
+    /** Partial overrides for novelty selection configuration (Issue #2932, defaults applied if not specified) */
+    novelty?: NoveltyConfig;
     /** Partial overrides for species stagnation configuration (Issue #2454, defaults applied if not specified) */
     speciesStagnation?: SpeciesStagnationConfig;
     /** Partial overrides for compatibility gating configuration (Issue #2455, defaults applied if not specified) */
@@ -298,6 +302,7 @@ export type NeatOptionsInput =
     | "parallelEvaluation"
     | "squashEffectiveness"
     | "fitnessSharing"
+    | "novelty"
     | "speciesStagnation"
     | "compatibilityGating"
     | "selectionPressure"
@@ -357,6 +362,8 @@ export type NeatOptionsInput =
     squashEffectiveness?: CoerceNumeric<SquashEffectivenessConfig>;
     /** Fitness sharing configuration (Issue #2453). Numeric fields coerced from CLI. */
     fitnessSharing?: CoerceNumeric<FitnessSharingConfig>;
+    /** Novelty selection configuration (Issue #2932). Numeric fields coerced from CLI. */
+    novelty?: CoerceNumeric<NoveltyConfig>;
     /** Species stagnation configuration (Issue #2454). Numeric fields coerced from CLI. */
     speciesStagnation?: CoerceNumeric<SpeciesStagnationConfig>;
     /** Compatibility gating configuration (Issue #2455). Numeric fields coerced from CLI. */

--- a/src/config/NoveltyConfig.ts
+++ b/src/config/NoveltyConfig.ts
@@ -1,0 +1,92 @@
+/**
+ * NoveltyConfig.ts - Configuration for novelty (behavioural-diversity)
+ * selection (Issue #2932).
+ *
+ * On **deceptive** problems pure fitness selection drives the population
+ * into local optima where fitness stops improving and the effective pace
+ * of evolution collapses. Novelty search (Lehman & Stanley, 2011) rewards
+ * behavioural diversity instead of — or blended with — raw fitness, and is
+ * a well-established accelerant for escaping deception.
+ *
+ * When `enabled`, each creature is given a **behaviour descriptor** (a
+ * numeric vector, problem-supplied via a tag), a **novelty score** equal to
+ * the mean distance to its *k* nearest neighbours across the current
+ * population and a bounded **archive** of past behaviours, and ranking uses
+ * the blend `score' = (1 - weight)·fitness + weight·novelty`.
+ *
+ * OFF by default — when `enabled` is `false`, ranking and selection behave
+ * exactly as before this issue.
+ */
+
+/**
+ * Partial overrides for novelty selection. All fields optional; defaults
+ * from {@link DEFAULT_NOVELTY_CONFIG} are applied for any omitted field.
+ */
+export interface NoveltyConfig {
+  /**
+   * Whether novelty selection is active. When `false` (the default), no
+   * behaviour descriptors are read, the archive stays empty, and ranking
+   * uses raw fitness exactly as before. Default: `false`.
+   */
+  enabled?: boolean;
+
+  /**
+   * Blend weight `w` in `score' = (1 - w)·fitness + w·novelty`, in the
+   * range `[0, 1]`. `0` is pure fitness, `1` is pure novelty. Default:
+   * `0.5`.
+   */
+  weight?: number;
+
+  /**
+   * Number of nearest neighbours `k` used to compute the novelty score
+   * (mean distance to the `k` closest behaviours across the population and
+   * archive). Default: `15`.
+   */
+  neighbours?: number;
+
+  /**
+   * Maximum number of behaviour descriptors retained in the novelty
+   * archive. When the cap is exceeded the oldest entries are evicted
+   * (first-in, first-out). Default: `500`.
+   */
+  archiveLimit?: number;
+
+  /**
+   * Minimum novelty score a behaviour must reach before it is admitted to
+   * the archive. `0` admits every evaluated behaviour (bounded by
+   * `archiveLimit`); a higher value keeps only behaviours that are
+   * genuinely novel relative to what has been seen. Default: `0`.
+   */
+  addThreshold?: number;
+
+  /**
+   * Name of the creature tag holding the behaviour descriptor — a
+   * comma-separated list of finite numbers (for example the output vector
+   * on a probe set), set by the problem's fitness function. Creatures
+   * without a parseable descriptor contribute no novelty. Default:
+   * `"behaviour"`.
+   */
+  behaviourTag?: string;
+}
+
+/**
+ * Required version of {@link NoveltyConfig} with every field populated.
+ * Produced by `createNeatConfig()` after defaults are applied.
+ */
+export type RequiredNoveltyConfig = Required<NoveltyConfig>;
+
+/**
+ * Default values for novelty selection.
+ *
+ * Issue #2932: OFF by default (`enabled: false`) so existing behaviour and
+ * tests are unchanged. Set `enabled: true` and supply a behaviour
+ * descriptor tag to escape deceptive landscapes.
+ */
+export const DEFAULT_NOVELTY_CONFIG: RequiredNoveltyConfig = {
+  enabled: false,
+  weight: 0.5,
+  neighbours: 15,
+  archiveLimit: 500,
+  addThreshold: 0,
+  behaviourTag: "behaviour",
+};

--- a/src/config/parsers/PopulationParsers.ts
+++ b/src/config/parsers/PopulationParsers.ts
@@ -28,6 +28,10 @@ import {
   type RequiredFitnessSharingConfig,
 } from "@config/FitnessSharingConfig.ts";
 import {
+  DEFAULT_NOVELTY_CONFIG,
+  type RequiredNoveltyConfig,
+} from "@config/NoveltyConfig.ts";
+import {
   DEFAULT_SPECIES_STAGNATION_CONFIG,
   type RequiredSpeciesStagnationConfig,
 } from "@config/SpeciesStagnationConfig.ts";
@@ -130,6 +134,46 @@ export function parseFitnessSharing(
       { integer: true, min: 0 },
     ),
   } as RequiredFitnessSharingConfig;
+}
+
+/** Parse novelty (behavioural-diversity) configuration (Issue #2932). */
+export function parseNovelty(
+  overrides: Record<string, unknown> | undefined,
+): RequiredNoveltyConfig {
+  const d = DEFAULT_NOVELTY_CONFIG;
+  return {
+    enabled: typeof overrides?.enabled === "boolean"
+      ? overrides.enabled
+      : d.enabled,
+    weight: parseNumber(
+      "Novelty weight",
+      overrides?.weight,
+      d.weight,
+      { min: 0, max: 1 },
+    ),
+    neighbours: parseNumber(
+      "Novelty neighbours",
+      overrides?.neighbours,
+      d.neighbours,
+      { integer: true, min: 1 },
+    ),
+    archiveLimit: parseNumber(
+      "Novelty archiveLimit",
+      overrides?.archiveLimit,
+      d.archiveLimit,
+      { integer: true, min: 1 },
+    ),
+    addThreshold: parseNumber(
+      "Novelty addThreshold",
+      overrides?.addThreshold,
+      d.addThreshold,
+      { min: 0 },
+    ),
+    behaviourTag: typeof overrides?.behaviourTag === "string" &&
+        overrides.behaviourTag.length > 0
+      ? overrides.behaviourTag
+      : d.behaviourTag,
+  } as RequiredNoveltyConfig;
 }
 
 /** Parse compatibility gating configuration (Issue #2455). */

--- a/test/NEAT/NoveltySearch.ts
+++ b/test/NEAT/NoveltySearch.ts
@@ -1,0 +1,195 @@
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature, CreatureUtil } from "../../mod.ts";
+import type { CreatureInternal } from "@architecture/CreatureInterfaces.ts";
+import { DEFAULT_NOVELTY_CONFIG } from "@config/NoveltyConfig.ts";
+import {
+  behaviourDistance,
+  blendScores,
+  buildNoveltyBlendedScores,
+  extractBehaviour,
+  meanNearestNeighbourDistance,
+  normalise,
+  NoveltyArchive,
+  NoveltySearch,
+} from "@neat/NoveltySearch.ts";
+
+/** Build a minimal valid creature with a unique UUID and optional tags. */
+function makeCreature(
+  idx: number,
+  score: number,
+  behaviour?: string,
+): Creature {
+  const internal: CreatureInternal = {
+    input: 1,
+    output: 1,
+    neurons: [{
+      index: 1,
+      type: "output",
+      squash: "IDENTITY",
+      bias: idx * 0.001,
+    }],
+    synapses: [{ from: 0, to: 1, weight: 1 + idx * 0.001 }],
+  };
+  const creature = Creature.fromJSON(internal);
+  CreatureUtil.makeUUID(creature);
+  creature.score = score;
+  if (behaviour !== undefined) addTag(creature, "behaviour", behaviour);
+  return creature;
+}
+
+Deno.test("behaviourDistance - Euclidean over shared prefix", () => {
+  assertEquals(behaviourDistance([0, 0], [3, 4]), 5);
+  assertEquals(behaviourDistance([1, 1], [1, 1]), 0);
+  // Differing lengths compare the shared prefix only.
+  assertEquals(behaviourDistance([0, 0, 99], [3, 4]), 5);
+  assertEquals(behaviourDistance([], [1, 2]), 0);
+});
+
+Deno.test("meanNearestNeighbourDistance - averages the k closest", () => {
+  const target = [0];
+  const others = [[1], [2], [10]];
+  // k=2 → mean of distances 1 and 2 = 1.5
+  assertAlmostEquals(meanNearestNeighbourDistance(target, others, 2), 1.5);
+  // k larger than available is clamped → mean of 1,2,10 = 13/3
+  assertAlmostEquals(
+    meanNearestNeighbourDistance(target, others, 99),
+    13 / 3,
+  );
+  // No neighbours → 0
+  assertEquals(meanNearestNeighbourDistance(target, [], 3), 0);
+});
+
+Deno.test("NoveltyArchive - bounded FIFO eviction", () => {
+  const archive = new NoveltyArchive(3);
+  archive.add([1]);
+  archive.add([2]);
+  archive.add([3]);
+  assertEquals(archive.size, 3);
+  archive.add([4]); // evicts [1]
+  assertEquals(archive.size, 3);
+  assertEquals(archive.entries[0], [2]);
+  assertEquals(archive.entries[2], [4]);
+});
+
+Deno.test("NoveltyArchive - stores defensive copies and ignores empty", () => {
+  const archive = new NoveltyArchive(5);
+  const original = [1, 2];
+  archive.add(original);
+  original[0] = 99;
+  assertEquals(archive.entries[0], [1, 2]); // unaffected by mutation
+  archive.add([]); // ignored
+  assertEquals(archive.size, 1);
+  archive.clear();
+  assertEquals(archive.size, 0);
+});
+
+Deno.test("NoveltyArchive - limit floors at 1", () => {
+  const archive = new NoveltyArchive(0);
+  archive.add([1]);
+  archive.add([2]);
+  assertEquals(archive.size, 1);
+  assertEquals(archive.entries[0], [2]);
+});
+
+Deno.test("normalise - min-max into [0,1] with neutral flat", () => {
+  assertEquals(normalise([0, 5, 10]), [0, 0.5, 1]);
+  assertEquals(normalise([7, 7, 7]), [0.5, 0.5, 0.5]);
+  assertEquals(normalise([]), []);
+});
+
+Deno.test("blendScores - weight 0 is pure fitness order, weight 1 is novelty", () => {
+  const fitness = [10, 0]; // creature 0 fitter
+  const novelty = [0, 10]; // creature 1 more novel
+  const pureFitness = blendScores(fitness, novelty, 0);
+  assert(pureFitness[0] > pureFitness[1]);
+  const pureNovelty = blendScores(fitness, novelty, 1);
+  assert(pureNovelty[1] > pureNovelty[0]);
+  // Balanced blend ties.
+  const balanced = blendScores(fitness, novelty, 0.5);
+  assertAlmostEquals(balanced[0], balanced[1]);
+});
+
+Deno.test("blendScores - weight is clamped to [0,1]", () => {
+  const fitness = [10, 0];
+  const novelty = [0, 10];
+  assertEquals(
+    blendScores(fitness, novelty, 5),
+    blendScores(fitness, novelty, 1),
+  );
+  assertEquals(
+    blendScores(fitness, novelty, -5),
+    blendScores(fitness, novelty, 0),
+  );
+});
+
+Deno.test("NoveltySearch.computeNovelty - isolated behaviour scores highest", () => {
+  const search = new NoveltySearch({
+    ...DEFAULT_NOVELTY_CONFIG,
+    enabled: true,
+    neighbours: 2,
+  });
+  const behaviours = [[0], [0.1], [0.2], [10]];
+  const novelty = search.computeNovelty(behaviours);
+  // The outlier at 10 is far from everything → most novel.
+  const maxIdx = novelty.indexOf(Math.max(...novelty));
+  assertEquals(maxIdx, 3);
+});
+
+Deno.test("NoveltySearch.updateArchive - admits above threshold only", () => {
+  const search = new NoveltySearch({
+    ...DEFAULT_NOVELTY_CONFIG,
+    enabled: true,
+    addThreshold: 1,
+  });
+  search.updateArchive([[0], [1], [2]], [0.5, 2, 1.5]);
+  assertEquals(search.archive.size, 2); // only novelty 2 and 1.5 admitted
+});
+
+Deno.test("extractBehaviour - parses comma-separated numeric tag", () => {
+  const c = makeCreature(0, 1, "0.5, 1.0, -2");
+  assertEquals(extractBehaviour(c, "behaviour"), [0.5, 1.0, -2]);
+});
+
+Deno.test("extractBehaviour - returns undefined for missing or invalid tags", () => {
+  const noTag = makeCreature(1, 1);
+  assertEquals(extractBehaviour(noTag, "behaviour"), undefined);
+  const invalid = makeCreature(2, 1, "0.5, oops");
+  assertEquals(extractBehaviour(invalid, "behaviour"), undefined);
+});
+
+Deno.test("buildNoveltyBlendedScores - returns undefined when too few descriptors", () => {
+  const search = new NoveltySearch({
+    ...DEFAULT_NOVELTY_CONFIG,
+    enabled: true,
+  });
+  const pop = [makeCreature(0, 1, "0"), makeCreature(1, 2)]; // only one described
+  const result = buildNoveltyBlendedScores(pop, (c) => c.score!, search);
+  assertEquals(result, undefined);
+});
+
+Deno.test("buildNoveltyBlendedScores - blends, maps every creature, and archives", () => {
+  const search = new NoveltySearch({
+    ...DEFAULT_NOVELTY_CONFIG,
+    enabled: true,
+    weight: 1, // pure novelty so the outlier wins regardless of fitness
+    neighbours: 2,
+  });
+  const pop = [
+    makeCreature(0, 5, "0"),
+    makeCreature(1, 5, "0.1"),
+    makeCreature(2, 5, "0.2"),
+    makeCreature(3, 1, "10"), // low fitness but behaviourally isolated
+  ];
+  const result = buildNoveltyBlendedScores(pop, (c) => c.score!, search);
+  assert(result !== undefined);
+  // Every creature present in the map.
+  assertEquals(result!.size, 4);
+  // Under pure-novelty blend the isolated creature ranks highest.
+  const outlier = result!.get(pop[3].uuid!)!;
+  for (let i = 0; i < 3; i++) {
+    assert(outlier > result!.get(pop[i].uuid!)!);
+  }
+  // Described behaviours were archived.
+  assertEquals(search.archive.size, 4);
+});

--- a/test/NEAT/NoveltySearchDeceptive.ts
+++ b/test/NEAT/NoveltySearchDeceptive.ts
@@ -1,0 +1,142 @@
+import { assert } from "@std/assert";
+import { DEFAULT_NOVELTY_CONFIG } from "@config/NoveltyConfig.ts";
+import { blendScores, NoveltySearch } from "@neat/NoveltySearch.ts";
+
+/**
+ * Deceptive-landscape acceptance test (Issue #2932).
+ *
+ * A 1-D deceptive fitness landscape: the population starts inside a
+ * deceptive basin near `x = 0` whose fitness caps at `0.8`, while the global
+ * optimum (`1.0`) sits at `x = 1`, on the far side of a fitness valley at
+ * `x = 0.5`. Pure-fitness selection climbs into the trap and cannot cross
+ * the valley; novelty selection rewards behavioural spread and migrates the
+ * population rightward, escaping the trap in far fewer generations.
+ *
+ * The simulation is fully deterministic (seeded PRNG, no wall-clock timing),
+ * so the comparison is reproducible.
+ */
+
+/** Deterministic mulberry32 PRNG. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Standard-normal sample via Box-Muller from a uniform PRNG. */
+function gaussian(rng: () => number): number {
+  const u = Math.max(rng(), 1e-12);
+  const v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+/** Deceptive fitness: trap basin caps at 0.8 near x=0; optimum 1.0 at x=1. */
+function deceptiveFitness(x: number): number {
+  if (x < 0.5) return 0.8 * (1 - x / 0.5);
+  return (x - 0.5) / 0.5;
+}
+
+const POPULATION = 40;
+const MAX_GENERATIONS = 150;
+const SIGMA = 0.1;
+const TARGET = 0.95;
+const SEED = 12345;
+
+interface RunResult {
+  solved: boolean;
+  generations: number;
+  bestFitness: number;
+}
+
+/**
+ * Run the deceptive GA. With `useNovelty`, ranking blends fitness with a
+ * kNN novelty score over the behaviour descriptor `[x]`; otherwise ranking
+ * is pure fitness. Both modes share the same seed so the only difference is
+ * the selection criterion.
+ */
+function runDeceptive(useNovelty: boolean): RunResult {
+  const rng = mulberry32(SEED);
+  // All genomes start inside the deceptive basin [0, 0.4].
+  let population: number[] = [];
+  for (let i = 0; i < POPULATION; i++) population.push(rng() * 0.4);
+
+  const search = new NoveltySearch({
+    ...DEFAULT_NOVELTY_CONFIG,
+    enabled: true,
+    weight: 0.6,
+    neighbours: 10,
+    archiveLimit: 500,
+  });
+
+  let bestFitness = 0;
+  for (let gen = 0; gen < MAX_GENERATIONS; gen++) {
+    const fitness = population.map(deceptiveFitness);
+    bestFitness = Math.max(bestFitness, ...fitness);
+    if (bestFitness >= TARGET) {
+      return { solved: true, generations: gen, bestFitness };
+    }
+
+    // Selection score: blended novelty or raw fitness.
+    let selectionScore: number[];
+    if (useNovelty) {
+      const behaviours = population.map((x) => [x]);
+      const novelty = search.computeNovelty(behaviours);
+      search.updateArchive(behaviours, novelty);
+      selectionScore = blendScores(fitness, novelty, search.config.weight);
+    } else {
+      selectionScore = fitness;
+    }
+
+    // Rank by selection score (descending).
+    const order = population
+      .map((_, i) => i)
+      .sort((a, b) => selectionScore[b] - selectionScore[a]);
+
+    // Elitism: carry the top individual unchanged.
+    const next: number[] = [population[order[0]]];
+
+    // Breed the rest via tournament selection + Gaussian mutation.
+    while (next.length < POPULATION) {
+      const a = order[Math.floor(rng() * order.length)];
+      const b = order[Math.floor(rng() * order.length)];
+      const parent = selectionScore[a] >= selectionScore[b] ? a : b;
+      let child = population[parent] + gaussian(rng) * SIGMA;
+      child = Math.min(1, Math.max(0, child));
+      next.push(child);
+    }
+    population = next;
+  }
+
+  return { solved: false, generations: MAX_GENERATIONS, bestFitness };
+}
+
+Deno.test("NoveltySearch - escapes a deceptive landscape in fewer generations", () => {
+  const fitnessOnly = runDeceptive(false);
+  const withNovelty = runDeceptive(true);
+
+  // Pure-fitness selection is trapped in the deceptive basin (cap 0.8) and
+  // never reaches the global optimum within the generation budget.
+  assert(
+    !fitnessOnly.solved,
+    `fitness-only unexpectedly solved at gen ${fitnessOnly.generations} ` +
+      `(best=${fitnessOnly.bestFitness})`,
+  );
+
+  // Novelty selection escapes the trap and reaches the global optimum.
+  assert(
+    withNovelty.solved,
+    `novelty failed to solve (best=${withNovelty.bestFitness})`,
+  );
+
+  // Acceptance criterion: fewer generations to escape with novelty enabled.
+  assert(
+    withNovelty.generations < fitnessOnly.generations,
+    `expected novelty (${withNovelty.generations}) < ` +
+      `fitness-only (${fitnessOnly.generations})`,
+  );
+});

--- a/test/breed/BreedNovelty.ts
+++ b/test/breed/BreedNovelty.ts
@@ -1,0 +1,105 @@
+/**
+ * Breed × novelty-selection wiring tests (Issue #2932).
+ *
+ * Verifies that the novelty engine, when supplied to a `Breed` and enabled
+ * via config, influences mother-selection ranking — and that it is an inert
+ * no-op when disabled or when no behaviour descriptors are present, so
+ * existing behaviour is unchanged.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature, type CreatureExport, CreatureUtil } from "../../mod.ts";
+import { Breed } from "@breed/Breed.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { Genus } from "@neat/Genus.ts";
+import { NoveltySearch } from "@neat/NoveltySearch.ts";
+
+function makeCreature(
+  idx: number,
+  score: number,
+  behaviour?: string,
+): Creature {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "output",
+        uuid: "output-0",
+        squash: "IDENTITY",
+        bias: idx * 0.01,
+      },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 + idx * 0.01 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 0.3 + idx * 0.01 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  CreatureUtil.makeUUID(creature);
+  creature.score = score;
+  addTag(creature, "score", score.toString());
+  if (behaviour !== undefined) addTag(creature, "behaviour", behaviour);
+  return creature;
+}
+
+function createGenus(creatures: Creature[]): Genus {
+  const genus = new Genus();
+  for (const creature of creatures) genus.addCreature(creature);
+  return genus;
+}
+
+Deno.test("Breed novelty - disabled engine leaves the archive untouched", () => {
+  const creatures = [
+    makeCreature(0, 0.9, "0"),
+    makeCreature(1, 0.5, "1"),
+    makeCreature(2, 0.1, "10"),
+  ];
+  const genus = createGenus(creatures);
+  const search = new NoveltySearch(
+    createNeatConfig({ novelty: { enabled: false } }).novelty,
+  );
+  const breed = new Breed(
+    genus,
+    createNeatConfig({ novelty: { enabled: false } }),
+    search,
+  );
+  for (let i = 0; i < 20; i++) breed.breed();
+  // Novelty disabled → engine never consulted → archive stays empty.
+  assertEquals(search.archive.size, 0);
+});
+
+Deno.test("Breed novelty - enabled engine archives behaviours during breeding", () => {
+  const config = createNeatConfig({
+    novelty: { enabled: true, weight: 0.5, neighbours: 2 },
+  });
+  const creatures = [
+    makeCreature(0, 0.9, "0"),
+    makeCreature(1, 0.5, "1"),
+    makeCreature(2, 0.1, "10"),
+  ];
+  const genus = createGenus(creatures);
+  const search = new NoveltySearch(config.novelty);
+  const breed = new Breed(genus, config, search);
+
+  // The novelty branch runs while building the mother-selection ranking, so
+  // a single breed() call consults the engine and archives the described
+  // behaviours regardless of whether crossover yields offspring.
+  breed.breed();
+  assert(search.archive.size > 0, "Archive should accumulate behaviours");
+});
+
+Deno.test("Breed novelty - enabled but no behaviour tags is a safe no-op", () => {
+  const config = createNeatConfig({ novelty: { enabled: true } });
+  const creatures = [
+    makeCreature(0, 0.9),
+    makeCreature(1, 0.5),
+    makeCreature(2, 0.1),
+  ];
+  const genus = createGenus(creatures);
+  const search = new NoveltySearch(config.novelty);
+  const breed = new Breed(genus, config, search);
+  for (let i = 0; i < 10; i++) breed.breed();
+  // No descriptors → nothing meaningful to compare → archive stays empty.
+  assertEquals(search.archive.size, 0);
+});

--- a/test/config/NoveltyConfig.ts
+++ b/test/config/NoveltyConfig.ts
@@ -1,0 +1,70 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { DEFAULT_NOVELTY_CONFIG } from "@config/NoveltyConfig.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+
+Deno.test("NoveltyConfig - defaults are applied and OFF by default", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.novelty.enabled, false);
+  assertEquals(config.novelty.enabled, DEFAULT_NOVELTY_CONFIG.enabled);
+  assertEquals(config.novelty.weight, DEFAULT_NOVELTY_CONFIG.weight);
+  assertEquals(config.novelty.neighbours, DEFAULT_NOVELTY_CONFIG.neighbours);
+  assertEquals(
+    config.novelty.archiveLimit,
+    DEFAULT_NOVELTY_CONFIG.archiveLimit,
+  );
+  assertEquals(
+    config.novelty.addThreshold,
+    DEFAULT_NOVELTY_CONFIG.addThreshold,
+  );
+  assertEquals(
+    config.novelty.behaviourTag,
+    DEFAULT_NOVELTY_CONFIG.behaviourTag,
+  );
+});
+
+Deno.test("NoveltyConfig - custom values override defaults", () => {
+  const config = createNeatConfig({
+    novelty: {
+      enabled: true,
+      weight: 0.25,
+      neighbours: 7,
+      archiveLimit: 100,
+      addThreshold: 0.5,
+      behaviourTag: "phenotype",
+    },
+  });
+  assertEquals(config.novelty.enabled, true);
+  assertEquals(config.novelty.weight, 0.25);
+  assertEquals(config.novelty.neighbours, 7);
+  assertEquals(config.novelty.archiveLimit, 100);
+  assertEquals(config.novelty.addThreshold, 0.5);
+  assertEquals(config.novelty.behaviourTag, "phenotype");
+});
+
+Deno.test("NoveltyConfig - partial overrides keep other defaults", () => {
+  const config = createNeatConfig({ novelty: { enabled: true } });
+  assertEquals(config.novelty.enabled, true);
+  assertEquals(config.novelty.weight, DEFAULT_NOVELTY_CONFIG.weight);
+  assertEquals(
+    config.novelty.behaviourTag,
+    DEFAULT_NOVELTY_CONFIG.behaviourTag,
+  );
+});
+
+Deno.test("NoveltyConfig - weight out of range is rejected", () => {
+  assertThrows(() => createNeatConfig({ novelty: { weight: 1.5 } }));
+  assertThrows(() => createNeatConfig({ novelty: { weight: -0.1 } }));
+});
+
+Deno.test("NoveltyConfig - neighbours must be a positive integer", () => {
+  assertThrows(() => createNeatConfig({ novelty: { neighbours: 0 } }));
+  assertThrows(() => createNeatConfig({ novelty: { neighbours: 1.5 } }));
+});
+
+Deno.test("NoveltyConfig - empty behaviourTag falls back to the default", () => {
+  const config = createNeatConfig({ novelty: { behaviourTag: "" } });
+  assertEquals(
+    config.novelty.behaviourTag,
+    DEFAULT_NOVELTY_CONFIG.behaviourTag,
+  );
+});


### PR DESCRIPTION
## Summary

Adds an optional **novelty (behavioural-diversity) selection** mechanism to
escape deceptive landscapes, where pure-fitness selection stalls in local optima
and the pace of evolution collapses. The new mechanism is a self-contained
module behind an **OFF-by-default** feature flag, so existing behaviour and
tests are unchanged. Closes #2932.

When enabled, ranking blends raw fitness with a behavioural-novelty score:

- a per-creature **behaviour descriptor** (problem-supplied via a `behaviour`
  tag — e.g. the output vector on a probe set),
- a bounded, FIFO **novelty archive**,
- a **k-nearest-neighbour novelty score** (mean distance to the `k` nearest
  behaviours across the population + archive),
- a configurable blend `score' = (1 - weight)·fitness + weight·novelty` (both
  terms min-max normalised), fed into `FitnessRanking` via the existing
  score-override hook used by fitness sharing.

### What changed

- **New** `src/config/NoveltyConfig.ts` — `NoveltyConfig` /
  `RequiredNoveltyConfig` / `DEFAULT_NOVELTY_CONFIG` (`enabled: false`).
- **New** `src/NEAT/NoveltySearch.ts` — pure-numeric core (`behaviourDistance`,
  `meanNearestNeighbourDistance`, `normalise`, `blendScores`), the
  `NoveltyArchive` and `NoveltySearch` classes, and the `extractBehaviour` /
  `buildNoveltyBlendedScores` bridge to live breeding.
- **Config wiring** — `parseNovelty` (PopulationParsers + barrel), and the
  `novelty` field threaded through `NeatArguments`, `NeatOptions` (both option
  shapes + both `Omit` lists), and `NeatConfig`.
- **Breeding** — `Breed` accepts an optional persistent `NoveltySearch`; when
  `novelty.enabled` it blends novelty into the mother-selection ranking. The
  engine is owned by `Neat` (`neat.noveltySearch`) so the archive accumulates
  across generations, and is passed in at both `Breed` construction sites
  (`Neat.ts`, `NeatEvolution.ts`).
- **Docs** — `docs/NOVELTY_SEARCH.md` (with a Mermaid flow diagram), a README
  Feature Highlight, docs index entry, and a CHANGELOG entry.

### Safety / no-op guarantees

- `enabled: false` (default) → the novelty branch is skipped entirely; ranking
  is byte-for-byte as before.
- `enabled: true` but fewer than two creatures expose a parseable descriptor →
  `buildNoveltyBlendedScores` returns `undefined` and ranking is left untouched.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via the test suite
and a deterministic deceptive-landscape benchmark.

```mermaid
flowchart LR
    A[Population] --> B[Behaviour descriptor]
    B --> C[kNN novelty score]
    D[(Novelty archive)] --> C
    C --> E["Blend (1-w)·fitness + w·novelty"]
    F[Raw fitness] --> E
    E --> G[FitnessRanking]
    C --> D
```

`bench/NoveltyDeceptiveEscape.ts` — population starts inside a deceptive basin
(fitness cap `0.8`); the global optimum (`1.0`) sits across a fitness valley.
Pure fitness is trapped; novelty escapes in a handful of generations:

| seed  | fitness-only         | with novelty    |
| ----- | -------------------- | --------------- |
| 12345 | trapped (best 0.800) | solved @ gen 8  |
| 222   | trapped (best 0.800) | solved @ gen 9  |
| 9001  | trapped (best 0.800) | solved @ gen 8  |
| 4242  | trapped (best 0.800) | solved @ gen 11 |
| 77777 | trapped (best 0.800) | solved @ gen 5  |

## Test Plan

- `test/config/NoveltyConfig.ts` — defaults applied, OFF by default, overrides,
  partial overrides, range validation (weight, neighbours), empty-tag fallback.
- `test/NEAT/NoveltySearch.ts` — distance, kNN mean, archive FIFO eviction +
  defensive copies + floor, normalise, blend (weight 0/1/0.5 + clamping),
  `computeNovelty`, `updateArchive` threshold, `extractBehaviour`,
  `buildNoveltyBlendedScores` (no-op + blend + archive).
- `test/NEAT/NoveltySearchDeceptive.ts` — **acceptance**: novelty escapes the
  deceptive trap in strictly fewer generations than fitness-only (deterministic,
  seeded).
- `test/breed/BreedNovelty.ts` — Breed wiring: disabled engine untouched,
  enabled engine archives behaviours, enabled-but-no-tags safe no-op.

Quality gates run: `deno fmt`, `deno lint`, `deno check` (full project),
bash-script check — all clean. Affected suites (config, breed, NEAT novelty)
pass.



## Milestone
This PR is part of the **Improve evolution** milestone and targets the `milestone/improve-evolution` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqa8ia4z-7b4b57`<!-- vibe-worker-issue-2932 -->