### PR TITLE
Plateau Escape: Inject random immigrants on a detected plateau (#2933)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,26 @@ ONNX export — are extensions beyond the standard NEAT algorithm. See
     default** — opt-in via `novelty: { enabled: true }` and set a `behaviour`
     tag on each creature. See [Novelty Search](./docs/NOVELTY_SEARCH.md).
 
+24. **Random Immigrants (Fresh Genomes on a Plateau)**: When the population
+    stalls, boosting the mutation rate only perturbs the _existing_ genomes — it
+    adds no new genetic material. Driven by the existing plateau signal,
+    random-immigrant injection replaces the weakest _non-elite_ creatures with
+    freshly seeded genomes once the population has been on a plateau for
+    `triggerWindow` generations, then waits `cooldown` generations before
+    injecting again. Elites are always preserved. **OFF by default** — opt-in
+    via `randomImmigrants: { enabled: true }`. Tune `injectionFraction` (the
+    fraction of non-elites replaced), `triggerWindow`, and `cooldown`.
+
+    ```mermaid
+    flowchart LR
+        A[Generation] --> B{On plateau for<br/>triggerWindow gens?}
+        B -- no --> E[Breed + mutate as usual]
+        B -- yes --> C{Cooldown<br/>elapsed?}
+        C -- no --> E
+        C -- yes --> D[Replace weakest non-elites<br/>with fresh genomes<br/>elites preserved]
+        D --> E
+    ```
+
 ## 🚀 Quick Start
 
 ```typescript

--- a/bench/RandomImmigrantsStagnationEscape.ts
+++ b/bench/RandomImmigrantsStagnationEscape.ts
@@ -1,0 +1,126 @@
+/**
+ * Issue #2933 - Random-immigrants stagnation-trap escape benchmark.
+ *
+ * Compares generations-to-solve on a deliberate stagnation trap with
+ * random-immigrant injection OFF (pure mutation) vs ON. The landscape is a
+ * wide flat plateau (fitness 0.6 for x < 0.8) whose only gradient is hidden
+ * beyond x = 0.8. With a small mutation step the population does an unbiased
+ * random walk on the plateau and effectively never crosses the gap; fresh
+ * immigrants sampled uniformly across the domain land beyond the edge, after
+ * which ordinary gradient ascent finishes the climb.
+ *
+ * Drives the real PlateauDetector + RandomImmigrants controller. Population
+ * is modelled as scalar genomes so the benchmark is fast and deterministic.
+ *
+ * Run with:
+ *   deno run --allow-read --allow-env bench/RandomImmigrantsStagnationEscape.ts
+ */
+
+import { PlateauDetector } from "@neat/PlateauDetector.ts";
+import { RandomImmigrants } from "@neat/RandomImmigrants.ts";
+import { DEFAULT_RANDOM_IMMIGRANTS_CONFIG } from "@config/RandomImmigrantsConfig.ts";
+
+const POPULATION = 30;
+const ELITES = 2;
+const MAX_GENERATIONS = 80;
+const SIGMA = 0.01;
+const TARGET = 0.95;
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function gaussian(rng: () => number): number {
+  const u = Math.max(rng(), 1e-12);
+  const v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+function trapFitness(x: number): number {
+  if (x < 0.8) return 0.6;
+  return 0.6 + (x - 0.8) * 2;
+}
+
+function clamp01(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+
+function runTrap(useImmigrants: boolean, seed: number): {
+  solved: boolean;
+  generations: number;
+  bestFitness: number;
+} {
+  const rng = mulberry32(seed);
+
+  const detector = new PlateauDetector({
+    windowSize: 5,
+    minImprovementRate: 0.001,
+    rapidImprovementRate: 0.01,
+    responseMutationMultiplier: 1.0,
+    responseImprovementMultiplier: 1.0,
+    enabled: true,
+  });
+
+  const immigrants = new RandomImmigrants({
+    ...DEFAULT_RANDOM_IMMIGRANTS_CONFIG,
+    enabled: useImmigrants,
+    injectionFraction: 0.3,
+    triggerWindow: 3,
+    cooldown: 5,
+  });
+
+  let pop: number[] = [];
+  for (let i = 0; i < POPULATION; i++) pop.push(rng() * 0.4);
+
+  let bestFitness = 0;
+  for (let gen = 0; gen < MAX_GENERATIONS; gen++) {
+    const scored = pop
+      .map((x) => ({ x, f: trapFitness(x) }))
+      .sort((a, b) => b.f - a.f);
+    bestFitness = Math.max(bestFitness, scored[0].f);
+    if (bestFitness >= TARGET) {
+      return { solved: true, generations: gen, bestFitness };
+    }
+
+    detector.recordFitness(scored[0].f);
+
+    const elites = scored.slice(0, ELITES).map((s) => s.x);
+    const next = [...elites];
+    while (next.length < POPULATION) {
+      const parent = elites[Math.floor(rng() * elites.length)];
+      next.push(clamp01(parent + gaussian(rng) * SIGMA));
+    }
+
+    if (immigrants.shouldInject(detector.getGenerationsOnPlateau(), gen)) {
+      const count = immigrants.immigrantCount(next.length, ELITES);
+      for (let i = 0; i < count; i++) {
+        next[next.length - 1 - i] = rng();
+      }
+      immigrants.recordInjection(gen);
+    }
+
+    pop = next;
+  }
+
+  return { solved: false, generations: MAX_GENERATIONS, bestFitness };
+}
+
+const seeds = [1, 2, 3, 4, 5];
+console.log("seed | immigrants OFF        | immigrants ON");
+console.log("-----+-----------------------+----------------------");
+for (const seed of seeds) {
+  const off = runTrap(false, seed);
+  const on = runTrap(true, seed);
+  const fmt = (r: { solved: boolean; generations: number }) =>
+    r.solved ? `solved @ gen ${r.generations}` : `stuck (>= ${r.generations})`;
+  console.log(
+    `  ${seed}  | ${fmt(off).padEnd(21)} | ${fmt(on)}`,
+  );
+}

--- a/docs/archive/pr-summaries/pr-summary-2933.md
+++ b/docs/archive/pr-summaries/pr-summary-2933.md
@@ -1,0 +1,92 @@
+# Inject random immigrants (fresh genomes) on a detected plateau
+
+## Summary
+
+When the population stalls, the only existing stagnation response was to scale
+the mutation rate — which perturbs _existing_ genomes but adds no new genetic
+material. This PR adds an optional, **OFF-by-default** random-immigrants
+controller driven by the **existing** `PlateauDetector` signal: once the
+population has been on a plateau for a configurable number of generations, the
+weakest _non-elite_ creatures are replaced with freshly seeded genomes, with a
+cooldown between injections to avoid thrashing. Elites are always preserved.
+
+Closes #2933.
+
+### What changed
+
+- **`src/config/RandomImmigrantsConfig.ts`** (new) — `RandomImmigrantsConfig`,
+  `RequiredRandomImmigrantsConfig`, and `DEFAULT_RANDOM_IMMIGRANTS_CONFIG`
+  (`enabled: false`, `injectionFraction: 0.1`, `triggerWindow: 5`,
+  `cooldown: 10`).
+- **`src/NEAT/RandomImmigrants.ts`** (new) — the `RandomImmigrants` controller
+  (decision logic: `shouldInject`, `immigrantCount`, `recordInjection`, `reset`)
+  and the `injectRandomImmigrants` helper (mechanical replacement that preserves
+  elites and replaces the weakest non-elites, ranking unscored offspring as
+  weakest so freshly bred genomes go first).
+- **`src/NEAT/NeatEvolution.ts`** — injection wired in right after the new
+  population is assembled and before de-duplication, reusing
+  `plateauDetector.getGenerationsOnPlateau()`. Fresh immigrants are minimal
+  `Creature(input, output)` genomes matching the fittest's I/O and feedback
+  setting. A no-op unless `randomImmigrants.enabled`.
+- **`src/NEAT/Neat.ts`** — owns a `RandomImmigrants` instance so the cooldown
+  state survives across generations.
+- Config plumbed through `NeatArguments`, `NeatOptions` (both override blocks
+  and both `Omit` lists), `NeatConfig`, `PopulationParsers`
+  (`parseRandomImmigrants`), the `NeatConfigParsers` barrel, and a cross-field
+  check in `NeatConfigValidation` (enabled ⇒ `injectionFraction > 0`).
+- **`README.md`** — new feature entry with a Mermaid flow diagram.
+
+### Flow
+
+```mermaid
+flowchart LR
+    A[Generation] --> B{On plateau for<br/>triggerWindow gens?}
+    B -- no --> E[Breed + mutate as usual]
+    B -- yes --> C{Cooldown<br/>elapsed?}
+    C -- no --> E
+    C -- yes --> D[Replace weakest non-elites<br/>with fresh genomes<br/>elites preserved]
+    D --> E
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via tests and a
+deterministic stagnation-trap benchmark.
+
+**Stagnation-trap escape** (`bench/RandomImmigrantsStagnationEscape.ts`): a wide
+flat-plateau landscape whose only gradient is hidden beyond `x = 0.8`. Pure
+mutation does an unbiased random walk and never crosses the gap; fresh
+immigrants sampled across the domain land beyond the edge, after which ordinary
+gradient ascent finishes the climb.
+
+```
+seed | immigrants OFF        | immigrants ON
+-----+-----------------------+----------------------
+  1  | stuck (>= 80)         | solved @ gen 8
+  2  | stuck (>= 80)         | solved @ gen 8
+  3  | stuck (>= 80)         | solved @ gen 17
+  4  | stuck (>= 80)         | solved @ gen 8
+  5  | stuck (>= 80)         | solved @ gen 11
+```
+
+Immigrants escape the trap on every seed within ≤17 generations; pure mutation
+stays stuck for the full 80-generation budget.
+
+## Test Plan
+
+- `test/config/RandomImmigrantsConfig.ts` — defaults applied & OFF by default;
+  custom and partial overrides; range validation for `injectionFraction`,
+  `triggerWindow`, `cooldown`; enabled-with-zero-fraction rejected.
+- `test/NEAT/RandomImmigrants.ts` — controller gating (disabled, trigger window,
+  cooldown, reset), `immigrantCount` arithmetic, and `injectRandomImmigrants`
+  behaviour (elites preserved, weakest/unscored replaced first, count clamped,
+  zero-count no-op).
+- `test/NEAT/RandomImmigrantsStagnationEscape.ts` — drives the **real**
+  `PlateauDetector` + `RandomImmigrants` on the stagnation trap and asserts
+  enabled escapes faster than (and never slower than) pure mutation across 5
+  seeds; plus an end-to-end `evolveDataSet` run with injection enabled that
+  completes with a well-formed result.
+
+Quality gate: `deno fmt`, `deno lint`, and project-wide `deno check` pass; the
+full `test/NEAT/` suite (799 tests) and `test/config/` suite (373 tests) pass.
+The feature is OFF by default, so existing behaviour and tests are unchanged.

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -28,6 +28,7 @@ import { Mutator } from "@neat/Mutator.ts";
 import { MCMCState } from "@neat/MCMCState.ts";
 import { NoveltySearch } from "@neat/NoveltySearch.ts";
 import { PlateauDetector } from "@neat/PlateauDetector.ts";
+import { RandomImmigrants } from "@neat/RandomImmigrants.ts";
 import { SpeciesPlateauDetector } from "@neat/SpeciesPlateauDetector.ts";
 import { TrainingRegressionTracker } from "@neat/TrainingRegressionTracker.ts";
 import { SquashEffectivenessTracker } from "@neat/SquashEffectivenessTracker.ts";
@@ -100,6 +101,13 @@ export class Neat {
   crisprIndex = 0;
   /** Plateau detector for fitness stagnation detection (Issue #1039) */
   readonly plateauDetector: PlateauDetector;
+
+  /**
+   * Random-immigrants controller (Issue #2933). Decides when to inject
+   * fresh genomes on a detected plateau. OFF by default; only injects when
+   * `config.randomImmigrants.enabled`.
+   */
+  readonly randomImmigrants: RandomImmigrants;
 
   /**
    * Per-species plateau detector for stagnant-species retirement
@@ -290,6 +298,10 @@ export class Neat {
     this.CRISPRs = Neat.deepCloneAndShuffle(this.config.CRISPRs);
 
     this.plateauDetector = new PlateauDetector(this.config.plateauDetection);
+
+    // Issue #2933: Random-immigrants controller. A no-op when
+    // `randomImmigrants.enabled` is false.
+    this.randomImmigrants = new RandomImmigrants(this.config.randomImmigrants);
 
     // Issue #2454: Per-species stagnation detector. The detector is a
     // no-op when `speciesStagnation.enabled` is false.

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -7,7 +7,9 @@
 
 import { assert } from "@std/assert";
 import { addTag, getTag } from "@stsoftware/tags/mod";
-import type { Creature } from "@creature";
+import { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { injectRandomImmigrants } from "@neat/RandomImmigrants.ts";
 import { DeDuplicator } from "@architecture/DeDuplicator.ts";
 import {
   makeElitists,
@@ -743,6 +745,49 @@ export async function evolve(
     ...newPopulation,
     ...dnaPopulation,
   ]; // Keep pseudo sorted.
+
+  // Issue #2933: On a sustained plateau, inject fresh genomes (random
+  // immigrants) in place of the weakest non-elite creatures. Elites (the
+  // leading `elitists.length` entries) are always preserved. This adds new
+  // genetic material — complementing the mutation-rate boost above — to help
+  // the population escape a stagnation trap. OFF by default: a no-op unless
+  // `randomImmigrants.enabled`.
+  if (
+    neat.randomImmigrants.shouldInject(
+      neat.plateauDetector.getGenerationsOnPlateau(),
+      neat.currentGeneration,
+    )
+  ) {
+    const immigrantCount = neat.randomImmigrants.immigrantCount(
+      neat.population.length,
+      elitists.length,
+    );
+    const feedbackEnabled = fittest.forwardOnly === false;
+    const makeImmigrant = (): Creature => {
+      const immigrant = new Creature(fittest.input, fittest.output, {
+        feedbackEnabled,
+      });
+      CreatureUtil.makeUUID(immigrant);
+      return immigrant;
+    };
+    const injection = injectRandomImmigrants(
+      neat.population,
+      elitists.length,
+      immigrantCount,
+      makeImmigrant,
+    );
+    if (injection.injected > 0) {
+      neat.randomImmigrants.recordInjection(neat.currentGeneration);
+      if (neat.config.verbose) {
+        getLogger().info(
+          `[RandomImmigrants] Injected ${injection.injected} fresh genome(s) ` +
+            `on plateau ` +
+            `(${neat.plateauDetector.getGenerationsOnPlateau()} generations), ` +
+            `preserving ${elitists.length} elite(s)`,
+        );
+      }
+    }
+  }
 
   // Issue #1099: Single-pass de-duplication on the combined population
   // Issue #2274: Time de-duplication phase

--- a/src/NEAT/RandomImmigrants.ts
+++ b/src/NEAT/RandomImmigrants.ts
@@ -1,0 +1,206 @@
+/**
+ * RandomImmigrants.ts - Inject fresh genomes on a detected plateau
+ * (Issue #2933).
+ *
+ * When evolution stalls, the fastest way to resume progress is often to
+ * inject **fresh** genetic material rather than perturb the existing
+ * genomes. This module provides a small, isolated controller that — driven
+ * by the existing {@link PlateauDetector} signal — replaces the weakest
+ * non-elite creatures with freshly seeded genomes while always preserving
+ * the elites.
+ *
+ * The controller is split into two concerns so each is independently
+ * testable:
+ *
+ * - {@link RandomImmigrants} owns the *decision* logic: when on a plateau
+ *   long enough, and outside the cooldown window, it signals an injection
+ *   and reports how many immigrants to create.
+ * - {@link injectRandomImmigrants} performs the *mechanical* replacement on
+ *   a population array, preserving elites and replacing the weakest
+ *   non-elite creatures with genomes produced by a caller-supplied factory.
+ *
+ * OFF by default — see {@link RandomImmigrantsConfig}.
+ */
+
+import type { Creature } from "@creature";
+import type { RequiredRandomImmigrantsConfig } from "@config/RandomImmigrantsConfig.ts";
+
+/**
+ * Outcome of an immigrant-injection pass.
+ */
+export interface ImmigrantInjectionResult {
+  /** Number of non-elite creatures replaced with fresh genomes. */
+  injected: number;
+  /** UUIDs of the creatures that were replaced (for logging / telemetry). */
+  replacedUuids: string[];
+}
+
+/**
+ * Decides when to inject random immigrants and how many to create, based on
+ * the existing plateau signal plus a trigger window and cooldown.
+ *
+ * The detector is stateful only in that it remembers the generation of the
+ * last injection so it can enforce the cooldown. All decisions are pure
+ * functions of the supplied arguments and that single recorded value.
+ *
+ * @example
+ * ```ts
+ * const controller = new RandomImmigrants(config);
+ * if (controller.shouldInject(generationsOnPlateau, currentGeneration)) {
+ *   const count = controller.immigrantCount(populationSize, eliteCount);
+ *   injectRandomImmigrants(population, eliteCount, count, makeImmigrant);
+ *   controller.recordInjection(currentGeneration);
+ * }
+ * ```
+ */
+export class RandomImmigrants {
+  private readonly config: RequiredRandomImmigrantsConfig;
+  private lastInjectionGeneration: number | null = null;
+
+  /**
+   * Creates a new controller with the given configuration.
+   *
+   * @param config - Random-immigrants configuration (all fields required)
+   */
+  constructor(config: RequiredRandomImmigrantsConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Decides whether immigrants should be injected this generation.
+   *
+   * Returns `true` only when:
+   * - injection is `enabled`, and
+   * - the population has been on a plateau for at least `triggerWindow`
+   *   generations, and
+   * - the configured `cooldown` has elapsed since the last injection.
+   *
+   * @param generationsOnPlateau - Consecutive generations on a plateau
+   *   (from {@link PlateauDetector.getGenerationsOnPlateau}).
+   * @param currentGeneration - The current generation number.
+   * @returns `true` if immigrants should be injected this generation.
+   */
+  shouldInject(
+    generationsOnPlateau: number,
+    currentGeneration: number,
+  ): boolean {
+    if (!this.config.enabled) {
+      return false;
+    }
+    if (generationsOnPlateau < this.config.triggerWindow) {
+      return false;
+    }
+    if (this.lastInjectionGeneration !== null) {
+      const sinceLast = currentGeneration - this.lastInjectionGeneration;
+      if (sinceLast < this.config.cooldown) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Computes how many immigrants to inject for a given population.
+   *
+   * The count is `floor(injectionFraction * nonEliteCount)`, where
+   * `nonEliteCount = max(0, populationSize - eliteCount)`. When the
+   * fraction rounds down to zero but at least one non-elite slot exists and
+   * injection is enabled, a single immigrant is injected so an enabled
+   * controller always makes progress on a plateau.
+   *
+   * @param populationSize - Total population size.
+   * @param eliteCount - Number of elites that must be preserved.
+   * @returns The number of immigrants to inject (>= 0).
+   */
+  immigrantCount(populationSize: number, eliteCount: number): number {
+    if (!this.config.enabled) {
+      return 0;
+    }
+    const nonElite = Math.max(0, populationSize - eliteCount);
+    if (nonElite === 0) {
+      return 0;
+    }
+    const count = Math.floor(nonElite * this.config.injectionFraction);
+    return Math.max(1, count);
+  }
+
+  /**
+   * Records that an injection happened at the given generation, starting the
+   * cooldown window.
+   *
+   * @param currentGeneration - The generation in which immigrants were
+   *   injected.
+   */
+  recordInjection(currentGeneration: number): void {
+    this.lastInjectionGeneration = currentGeneration;
+  }
+
+  /**
+   * Resets the controller's cooldown state. Call when starting a new
+   * evolution run.
+   */
+  reset(): void {
+    this.lastInjectionGeneration = null;
+  }
+}
+
+/**
+ * Replaces the weakest non-elite creatures in a population with fresh
+ * genomes, preserving the elites.
+ *
+ * The first `eliteCount` entries of `population` are treated as elites and
+ * are never touched. The remaining creatures are ranked by score (ascending
+ * — worst first); creatures without a numeric score are treated as the
+ * weakest so freshly bred, not-yet-evaluated offspring are replaced before
+ * any scored survivor. The weakest `count` of them are disposed and
+ * replaced in place by genomes from `makeImmigrant`.
+ *
+ * The population array is mutated in place and its length is preserved.
+ *
+ * @param population - The population array (elites first). Mutated in place.
+ * @param eliteCount - Number of leading elites to preserve.
+ * @param count - Number of immigrants to inject.
+ * @param makeImmigrant - Factory producing a fresh genome per call.
+ * @returns The number injected and the UUIDs of the replaced creatures.
+ */
+export function injectRandomImmigrants(
+  population: Creature[],
+  eliteCount: number,
+  count: number,
+  makeImmigrant: () => Creature,
+): ImmigrantInjectionResult {
+  const safeElite = Math.max(0, Math.min(eliteCount, population.length));
+  const rest = population.slice(safeElite);
+  const replaceCount = Math.max(0, Math.min(count, rest.length));
+  if (replaceCount === 0) {
+    return { injected: 0, replacedUuids: [] };
+  }
+
+  // Rank non-elites worst-first. Unscored creatures (freshly bred offspring)
+  // sort as the weakest so they are replaced ahead of any scored survivor.
+  rest.sort((a, b) => scoreOf(a) - scoreOf(b));
+
+  const replacedUuids: string[] = [];
+  for (let i = 0; i < replaceCount; i++) {
+    const victim = rest[i];
+    if (victim.uuid) {
+      replacedUuids.push(victim.uuid);
+    }
+    victim.dispose();
+    rest[i] = makeImmigrant();
+  }
+
+  // Rebuild the population in place: preserved elites followed by the
+  // (re-populated) non-elite slice.
+  population.length = safeElite;
+  for (let i = 0; i < rest.length; i++) {
+    population.push(rest[i]);
+  }
+
+  return { injected: replaceCount, replacedUuids };
+}
+
+/** Score used for worst-first ranking; missing scores rank as weakest. */
+function scoreOf(creature: Creature): number {
+  return typeof creature.score === "number" ? creature.score : -Infinity;
+}

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -15,6 +15,7 @@ import type { RequiredEnsembleDiversityConfig } from "@config/EnsembleDiversityC
 import type { RequiredFineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
 import type { RequiredFitnessSharingConfig } from "@config/FitnessSharingConfig.ts";
 import type { RequiredNoveltyConfig } from "@config/NoveltyConfig.ts";
+import type { RequiredRandomImmigrantsConfig } from "@config/RandomImmigrantsConfig.ts";
 import type { RequiredSpeciesStagnationConfig } from "@config/SpeciesStagnationConfig.ts";
 import type { RequiredStabilityAdaptationConfig } from "@config/StabilityAdaptationConfig.ts";
 import type { RequiredQuantumStepConfig } from "@config/QuantumStepConfig.ts";
@@ -953,6 +954,20 @@ export interface NeatArguments {
    * - behaviourTag: Tag holding the behaviour descriptor (default: "behaviour")
    */
   novelty: RequiredNoveltyConfig;
+
+  /**
+   * Random-immigrant injection configuration (Issue #2933).
+   * OFF by default. When `enabled`, on a detected plateau the weakest
+   * non-elite creatures are replaced with freshly seeded genomes, adding
+   * new genetic material to escape a stagnation trap. Elites are always
+   * preserved.
+   * Configuration options:
+   * - enabled: Whether immigrant injection is active (default: false)
+   * - injectionFraction: Fraction of non-elites replaced per injection (default: 0.1)
+   * - triggerWindow: Generations on plateau before injecting (default: 5)
+   * - cooldown: Generations to wait between injections (default: 10)
+   */
+  randomImmigrants: RequiredRandomImmigrantsConfig;
 
   /**
    * Species stagnation detection and breeding-budget reclamation

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -60,6 +60,7 @@ import {
   parsePlateauDetection,
   parsePredictiveCoding,
   parseQuantumStep,
+  parseRandomImmigrants,
   parseSelectionPressure,
   parseSpecialist,
   parseSpeciesStagnation,
@@ -721,6 +722,10 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
     // Issue #2932: Parse novelty (behavioural-diversity) configuration
     novelty: parseNovelty(
       opts.novelty as Record<string, unknown> | undefined,
+    ),
+    // Issue #2933: Parse random-immigrants configuration
+    randomImmigrants: parseRandomImmigrants(
+      opts.randomImmigrants as Record<string, unknown> | undefined,
     ),
     // Issue #2454: Parse species stagnation configuration
     speciesStagnation: parseSpeciesStagnation(

--- a/src/config/NeatConfigParsers.ts
+++ b/src/config/NeatConfigParsers.ts
@@ -34,6 +34,7 @@ export {
   parseFineTunePopulation,
   parseFitnessSharing,
   parseNovelty,
+  parseRandomImmigrants,
   parseSpeciesStagnation,
 } from "@config/parsers/PopulationParsers.ts";
 export {

--- a/src/config/NeatConfigValidation.ts
+++ b/src/config/NeatConfigValidation.ts
@@ -216,6 +216,20 @@ export function validateNeatConfig(config: NeatArguments): void {
     );
   }
 
+  // Issue #2933: When random-immigrant injection is enabled, the injection
+  // fraction must be strictly positive — a zero fraction would never inject.
+  if (
+    config.randomImmigrants.enabled &&
+    config.randomImmigrants.injectionFraction <= 0
+  ) {
+    throw new ConfigurationError(
+      `randomImmigrants.injectionFraction must be greater than 0 when ` +
+        `enabled. injectionFraction: ` +
+        `${config.randomImmigrants.injectionFraction}`,
+      "CROSS_FIELD_VALIDATION",
+    );
+  }
+
   // Discovery focus neuron UUID validation
   if (!Array.isArray(config.discoveryFocusNeuronUUIDs)) {
     throw new ConfigurationError(

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -9,6 +9,7 @@ import type { EnsembleDiversityConfig } from "@config/EnsembleDiversityConfig.ts
 import type { FineTunePopulationConfig } from "@config/FineTunePopulationConfig.ts";
 import type { FitnessSharingConfig } from "@config/FitnessSharingConfig.ts";
 import type { NoveltyConfig } from "@config/NoveltyConfig.ts";
+import type { RandomImmigrantsConfig } from "@config/RandomImmigrantsConfig.ts";
 import type { SpeciesStagnationConfig } from "@config/SpeciesStagnationConfig.ts";
 import type { NeatArguments } from "@config/NeatArguments.ts";
 import type { PlateauDetectionConfig } from "@neat/PlateauDetector.ts";
@@ -127,6 +128,7 @@ export type NeatOptions =
     | "squashEffectiveness"
     | "fitnessSharing"
     | "novelty"
+    | "randomImmigrants"
     | "speciesStagnation"
     | "compatibilityGating"
     | "selectionPressure"
@@ -199,6 +201,8 @@ export type NeatOptions =
     fitnessSharing?: FitnessSharingConfig;
     /** Partial overrides for novelty selection configuration (Issue #2932, defaults applied if not specified) */
     novelty?: NoveltyConfig;
+    /** Partial overrides for random-immigrants configuration (Issue #2933, defaults applied if not specified) */
+    randomImmigrants?: RandomImmigrantsConfig;
     /** Partial overrides for species stagnation configuration (Issue #2454, defaults applied if not specified) */
     speciesStagnation?: SpeciesStagnationConfig;
     /** Partial overrides for compatibility gating configuration (Issue #2455, defaults applied if not specified) */
@@ -303,6 +307,7 @@ export type NeatOptionsInput =
     | "squashEffectiveness"
     | "fitnessSharing"
     | "novelty"
+    | "randomImmigrants"
     | "speciesStagnation"
     | "compatibilityGating"
     | "selectionPressure"
@@ -364,6 +369,8 @@ export type NeatOptionsInput =
     fitnessSharing?: CoerceNumeric<FitnessSharingConfig>;
     /** Novelty selection configuration (Issue #2932). Numeric fields coerced from CLI. */
     novelty?: CoerceNumeric<NoveltyConfig>;
+    /** Random-immigrants configuration (Issue #2933). Numeric fields coerced from CLI. */
+    randomImmigrants?: CoerceNumeric<RandomImmigrantsConfig>;
     /** Species stagnation configuration (Issue #2454). Numeric fields coerced from CLI. */
     speciesStagnation?: CoerceNumeric<SpeciesStagnationConfig>;
     /** Compatibility gating configuration (Issue #2455). Numeric fields coerced from CLI. */

--- a/src/config/RandomImmigrantsConfig.ts
+++ b/src/config/RandomImmigrantsConfig.ts
@@ -1,0 +1,79 @@
+/**
+ * RandomImmigrantsConfig.ts - Configuration for random-immigrant injection
+ * on a detected fitness plateau (Issue #2933).
+ *
+ * When a population stalls, perturbing the *existing* genomes (the job of
+ * the adaptive mutation multiplier in {@link PlateauDetector}) adds no new
+ * genetic material. Random immigrants are a classic, low-risk escape
+ * mechanism: replace the weakest non-elite creatures with freshly seeded
+ * genomes while always preserving the elites. This complements — rather
+ * than replaces — mutation boosting.
+ *
+ * The controller is driven by the **existing** plateau signal: it injects
+ * only when the population has been on a plateau for `triggerWindow`
+ * generations, replaces a configurable `injectionFraction` of the
+ * non-elite population, and waits `cooldown` generations between
+ * injections to avoid thrashing.
+ *
+ * OFF by default — when `enabled` is `false`, no immigrants are injected
+ * and evolution behaves exactly as before this issue.
+ */
+
+/**
+ * Partial overrides for random-immigrant injection. All fields optional;
+ * defaults from {@link DEFAULT_RANDOM_IMMIGRANTS_CONFIG} are applied for any
+ * omitted field.
+ */
+export interface RandomImmigrantsConfig {
+  /**
+   * Whether random-immigrant injection is active. When `false` (the
+   * default), no immigrants are injected and the population is unchanged.
+   * Default: `false`.
+   */
+  enabled?: boolean;
+
+  /**
+   * Fraction of the **non-elite** population to replace with fresh genomes
+   * on each injection, in the range `(0, 1]`. For example `0.1` replaces
+   * the weakest 10% of the non-elite creatures. Elites are never replaced.
+   * Default: `0.1`.
+   */
+  injectionFraction?: number;
+
+  /**
+   * Number of consecutive generations the population must be on a plateau
+   * before the first injection fires. A larger window waits for a more
+   * firmly established plateau before disrupting the population. Must be a
+   * positive integer. Default: `5`.
+   */
+  triggerWindow?: number;
+
+  /**
+   * Minimum number of generations to wait after an injection before another
+   * injection may fire, even while the plateau persists. Prevents repeated
+   * injections from thrashing the population. Must be a non-negative
+   * integer. Default: `10`.
+   */
+  cooldown?: number;
+}
+
+/**
+ * Required version of {@link RandomImmigrantsConfig} with every field
+ * populated. Produced by `createNeatConfig()` after defaults are applied.
+ */
+export type RequiredRandomImmigrantsConfig = Required<RandomImmigrantsConfig>;
+
+/**
+ * Default values for random-immigrant injection.
+ *
+ * Issue #2933: OFF by default (`enabled: false`) so existing behaviour and
+ * tests are unchanged. Set `enabled: true` to escape a stagnation trap by
+ * injecting fresh genetic material on a detected plateau.
+ */
+export const DEFAULT_RANDOM_IMMIGRANTS_CONFIG: RequiredRandomImmigrantsConfig =
+  {
+    enabled: false,
+    injectionFraction: 0.1,
+    triggerWindow: 5,
+    cooldown: 10,
+  };

--- a/src/config/parsers/PopulationParsers.ts
+++ b/src/config/parsers/PopulationParsers.ts
@@ -32,6 +32,10 @@ import {
   type RequiredNoveltyConfig,
 } from "@config/NoveltyConfig.ts";
 import {
+  DEFAULT_RANDOM_IMMIGRANTS_CONFIG,
+  type RequiredRandomImmigrantsConfig,
+} from "@config/RandomImmigrantsConfig.ts";
+import {
   DEFAULT_SPECIES_STAGNATION_CONFIG,
   type RequiredSpeciesStagnationConfig,
 } from "@config/SpeciesStagnationConfig.ts";
@@ -174,6 +178,36 @@ export function parseNovelty(
       ? overrides.behaviourTag
       : d.behaviourTag,
   } as RequiredNoveltyConfig;
+}
+
+/** Parse random-immigrants configuration (Issue #2933). */
+export function parseRandomImmigrants(
+  overrides: Record<string, unknown> | undefined,
+): RequiredRandomImmigrantsConfig {
+  const d = DEFAULT_RANDOM_IMMIGRANTS_CONFIG;
+  return {
+    enabled: typeof overrides?.enabled === "boolean"
+      ? overrides.enabled
+      : d.enabled,
+    injectionFraction: parseNumber(
+      "Random immigrants injectionFraction",
+      overrides?.injectionFraction,
+      d.injectionFraction,
+      { min: 0, max: 1 },
+    ),
+    triggerWindow: parseNumber(
+      "Random immigrants triggerWindow",
+      overrides?.triggerWindow,
+      d.triggerWindow,
+      { integer: true, min: 1 },
+    ),
+    cooldown: parseNumber(
+      "Random immigrants cooldown",
+      overrides?.cooldown,
+      d.cooldown,
+      { integer: true, min: 0 },
+    ),
+  } as RequiredRandomImmigrantsConfig;
 }
 
 /** Parse compatibility gating configuration (Issue #2455). */

--- a/test/NEAT/RandomImmigrants.ts
+++ b/test/NEAT/RandomImmigrants.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for random-immigrant injection on a detected plateau (Issue #2933).
+ *
+ * Verifies:
+ *  - The {@link RandomImmigrants} controller only signals an injection when
+ *    enabled, on a plateau for at least `triggerWindow` generations, and
+ *    outside the cooldown window.
+ *  - {@link injectRandomImmigrants} preserves the leading elites, replaces
+ *    the weakest non-elite creatures (unscored offspring first), and keeps
+ *    the population length unchanged.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import {
+  injectRandomImmigrants,
+  RandomImmigrants,
+} from "@neat/RandomImmigrants.ts";
+import { DEFAULT_RANDOM_IMMIGRANTS_CONFIG } from "@config/RandomImmigrantsConfig.ts";
+
+function controller(
+  overrides: Partial<typeof DEFAULT_RANDOM_IMMIGRANTS_CONFIG> = {},
+): RandomImmigrants {
+  return new RandomImmigrants({
+    ...DEFAULT_RANDOM_IMMIGRANTS_CONFIG,
+    ...overrides,
+  });
+}
+
+/** Build a tiny creature tagged with a score and uuid for ranking tests. */
+function scored(score: number | undefined, uuid: string): Creature {
+  const c = new Creature(2, 1);
+  c.score = score;
+  c.uuid = uuid;
+  return c;
+}
+
+Deno.test("RandomImmigrants - disabled never injects", () => {
+  const c = controller({ enabled: false, triggerWindow: 1 });
+  assertEquals(c.shouldInject(100, 100), false);
+  assertEquals(c.immigrantCount(50, 1), 0);
+});
+
+Deno.test("RandomImmigrants - waits for triggerWindow generations on plateau", () => {
+  const c = controller({ enabled: true, triggerWindow: 5, cooldown: 0 });
+  assertEquals(c.shouldInject(4, 10), false);
+  assertEquals(c.shouldInject(5, 10), true);
+  assertEquals(c.shouldInject(6, 11), true);
+});
+
+Deno.test("RandomImmigrants - cooldown blocks repeat injections", () => {
+  const c = controller({ enabled: true, triggerWindow: 3, cooldown: 10 });
+  assertEquals(c.shouldInject(3, 20), true);
+  c.recordInjection(20);
+  // Still on plateau, but within the cooldown window.
+  assertEquals(c.shouldInject(4, 25), false);
+  assertEquals(c.shouldInject(5, 29), false);
+  // Cooldown elapsed (30 - 20 === 10).
+  assertEquals(c.shouldInject(6, 30), true);
+});
+
+Deno.test("RandomImmigrants - reset clears the cooldown", () => {
+  const c = controller({ enabled: true, triggerWindow: 1, cooldown: 10 });
+  c.recordInjection(5);
+  assertEquals(c.shouldInject(1, 6), false);
+  c.reset();
+  assertEquals(c.shouldInject(1, 6), true);
+});
+
+Deno.test("RandomImmigrants - immigrantCount is floor(fraction * nonElite), min 1", () => {
+  const c = controller({ enabled: true, injectionFraction: 0.1 });
+  // 0.1 * (100 - 1) = 9.9 → floor 9
+  assertEquals(c.immigrantCount(100, 1), 9);
+  // Rounds down to 0 but enabled → at least one immigrant.
+  assertEquals(c.immigrantCount(10, 5), 1);
+  // No non-elite slots → none.
+  assertEquals(c.immigrantCount(3, 3), 0);
+  assertEquals(c.immigrantCount(2, 5), 0);
+});
+
+Deno.test("injectRandomImmigrants - preserves elites and replaces weakest non-elites", () => {
+  // Elites first (highest scores), then non-elites worst → best.
+  const elite0 = scored(100, "elite-0");
+  const elite1 = scored(90, "elite-1");
+  const mid = scored(50, "mid");
+  const worst = scored(10, "worst");
+  const best = scored(70, "best-non-elite");
+  const population = [elite0, elite1, mid, worst, best];
+
+  let made = 0;
+  const result = injectRandomImmigrants(
+    population,
+    2, // eliteCount
+    1, // replace the single weakest non-elite
+    () => {
+      made++;
+      return scored(undefined, `immigrant-${made}`);
+    },
+  );
+
+  assertEquals(result.injected, 1);
+  assertEquals(result.replacedUuids, ["worst"]);
+  assertEquals(population.length, 5);
+  // Elites untouched and still at the front.
+  assertEquals(population[0], elite0);
+  assertEquals(population[1], elite1);
+  // The weakest non-elite is gone; the others survive.
+  const uuids = population.map((c) => c.uuid);
+  assert(!uuids.includes("worst"), "weakest non-elite should be replaced");
+  assert(uuids.includes("mid"), "mid survivor should remain");
+  assert(uuids.includes("best-non-elite"), "best survivor should remain");
+  assert(uuids.includes("immigrant-1"), "fresh immigrant should be present");
+});
+
+Deno.test("injectRandomImmigrants - unscored offspring are replaced before scored survivors", () => {
+  const elite = scored(100, "elite");
+  const scoredSurvivor = scored(80, "scored");
+  const offspringA = scored(undefined, "offspring-a");
+  const offspringB = scored(undefined, "offspring-b");
+  const population = [elite, scoredSurvivor, offspringA, offspringB];
+
+  const result = injectRandomImmigrants(
+    population,
+    1,
+    2,
+    () => scored(undefined, "immigrant"),
+  );
+
+  assertEquals(result.injected, 2);
+  // Both unscored offspring replaced; the scored survivor kept.
+  assertEquals(result.replacedUuids.sort(), ["offspring-a", "offspring-b"]);
+  const uuids = population.map((c) => c.uuid);
+  assert(uuids.includes("elite"));
+  assert(uuids.includes("scored"));
+  assert(!uuids.includes("offspring-a"));
+  assert(!uuids.includes("offspring-b"));
+});
+
+Deno.test("injectRandomImmigrants - count clamped to non-elite count", () => {
+  const population = [scored(10, "a"), scored(5, "b"), scored(1, "c")];
+  const result = injectRandomImmigrants(
+    population,
+    1,
+    99, // more than available non-elites
+    () => scored(undefined, "immigrant"),
+  );
+  // Only 2 non-elites available.
+  assertEquals(result.injected, 2);
+  assertEquals(population.length, 3);
+  assertEquals(population[0].uuid, "a"); // elite preserved
+});
+
+Deno.test("injectRandomImmigrants - zero count is a no-op", () => {
+  const population = [scored(10, "a"), scored(5, "b")];
+  const result = injectRandomImmigrants(
+    population,
+    1,
+    0,
+    () => scored(undefined, "immigrant"),
+  );
+  assertEquals(result.injected, 0);
+  assertEquals(result.replacedUuids, []);
+  assertEquals(population.map((c) => c.uuid), ["a", "b"]);
+});

--- a/test/NEAT/RandomImmigrantsStagnationEscape.ts
+++ b/test/NEAT/RandomImmigrantsStagnationEscape.ts
@@ -1,0 +1,200 @@
+/**
+ * Stagnation-trap escape test for random immigrants (Issue #2933).
+ *
+ * Demonstrates the acceptance criterion: a population escapes a deliberate
+ * stagnation trap faster when random-immigrant injection is enabled.
+ *
+ * The landscape is a wide flat plateau (fitness 0.6 for x < 0.8) with the
+ * only gradient hidden beyond x = 0.8. Pure mutation does an unbiased random
+ * walk on the plateau and, with a small step size, effectively never crosses
+ * the gap. Fresh immigrants sampled uniformly across the domain land beyond
+ * the plateau edge, after which ordinary gradient ascent finishes the climb.
+ *
+ * This drives the *real* {@link PlateauDetector} and {@link RandomImmigrants}
+ * controller; the population is modelled as scalar genomes so the test is
+ * fast and fully deterministic (seeded RNG).
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { Mutation } from "@neat/Mutation.ts";
+import { PlateauDetector } from "@neat/PlateauDetector.ts";
+import { RandomImmigrants } from "@neat/RandomImmigrants.ts";
+import { DEFAULT_RANDOM_IMMIGRANTS_CONFIG } from "@config/RandomImmigrantsConfig.ts";
+
+const POPULATION = 30;
+const ELITES = 2;
+const MAX_GENERATIONS = 80;
+const SIGMA = 0.01; // small steps → cannot cross the plateau by drift
+const TARGET = 0.95;
+
+/** Deterministic PRNG so the test is reproducible across runs. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function gaussian(rng: () => number): number {
+  const u = Math.max(rng(), 1e-12);
+  const v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+/** Flat plateau below 0.8; the only gradient is hidden beyond the edge. */
+function trapFitness(x: number): number {
+  if (x < 0.8) return 0.6;
+  return 0.6 + (x - 0.8) * 2; // 0.6 at x=0.8 → 1.0 at x=1.0
+}
+
+function clamp01(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+
+interface RunResult {
+  solved: boolean;
+  generations: number;
+}
+
+function runTrap(useImmigrants: boolean, seed: number): RunResult {
+  const rng = mulberry32(seed);
+
+  const detector = new PlateauDetector({
+    windowSize: 5,
+    minImprovementRate: 0.001,
+    rapidImprovementRate: 0.01,
+    responseMutationMultiplier: 1.0,
+    responseImprovementMultiplier: 1.0,
+    enabled: true,
+  });
+
+  const immigrants = new RandomImmigrants({
+    ...DEFAULT_RANDOM_IMMIGRANTS_CONFIG,
+    enabled: useImmigrants,
+    injectionFraction: 0.3,
+    triggerWindow: 3,
+    cooldown: 5,
+  });
+
+  // Population starts trapped near the bottom of the plateau.
+  let pop: number[] = [];
+  for (let i = 0; i < POPULATION; i++) pop.push(rng() * 0.4);
+
+  for (let gen = 0; gen < MAX_GENERATIONS; gen++) {
+    // Evaluate and check for the global optimum.
+    const scored = pop
+      .map((x) => ({ x, f: trapFitness(x) }))
+      .sort((a, b) => b.f - a.f);
+    const best = scored[0].f;
+    if (best >= TARGET) {
+      return { solved: true, generations: gen };
+    }
+
+    detector.recordFitness(best);
+
+    // Build the next generation: carry the elites, breed the remainder by
+    // mutating a random elite (small Gaussian step — pure hill-climbing).
+    const elites = scored.slice(0, ELITES).map((s) => s.x);
+    const next = [...elites];
+    while (next.length < POPULATION) {
+      const parent = elites[Math.floor(rng() * elites.length)];
+      next.push(clamp01(parent + gaussian(rng) * SIGMA));
+    }
+
+    // Inject random immigrants in place of the weakest non-elite offspring.
+    if (
+      immigrants.shouldInject(detector.getGenerationsOnPlateau(), gen)
+    ) {
+      const count = immigrants.immigrantCount(next.length, ELITES);
+      // Offspring (indices >= ELITES) are unevaluated; replace the trailing
+      // `count` of them with fresh uniform-random genomes.
+      for (let i = 0; i < count; i++) {
+        next[next.length - 1 - i] = rng();
+      }
+      immigrants.recordInjection(gen);
+    }
+
+    pop = next;
+  }
+
+  return { solved: false, generations: MAX_GENERATIONS };
+}
+
+Deno.test("RandomImmigrants - escapes a stagnation trap faster than pure mutation", () => {
+  const seeds = [1, 2, 3, 4, 5];
+  let withSolved = 0;
+  let withoutSolved = 0;
+
+  for (const seed of seeds) {
+    const withImm = runTrap(true, seed);
+    const withoutImm = runTrap(false, seed);
+
+    if (withImm.solved) withSolved++;
+    if (withoutImm.solved) withoutSolved++;
+
+    // For every seed, enabling immigrants must escape at least as fast as
+    // (and in practice much faster than) pure mutation.
+    assert(
+      withImm.generations <= withoutImm.generations,
+      `seed ${seed}: immigrants (${withImm.generations}g) should not be ` +
+        `slower than pure mutation (${withoutImm.generations}g)`,
+    );
+  }
+
+  // Immigrants escape the trap on every seed; pure mutation stays stuck.
+  assert(
+    withSolved === seeds.length,
+    `immigrants should solve all ${seeds.length} seeds, solved ${withSolved}`,
+  );
+  assert(
+    withoutSolved < withSolved,
+    `pure mutation should escape fewer traps than immigrants ` +
+      `(without: ${withoutSolved}, with: ${withSolved})`,
+  );
+});
+
+Deno.test("RandomImmigrants - evolveDataSet runs end-to-end with injection enabled", async () => {
+  // Drives the real evolve() wiring with random immigrants enabled and an
+  // aggressive trigger so an injection fires within the run. The XOR set with
+  // a very low target error encourages stagnation, exercising the on-plateau
+  // injection path on actual Creature genomes.
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+  ];
+
+  const creature = new Creature(2, 1);
+  const result = await creature.evolveDataSet(trainingSet, {
+    mutation: Mutation.FFW,
+    iterations: 30,
+    targetError: 0.0001,
+    populationSize: 20,
+    elitism: 2,
+    threads: 1,
+    plateauDetection: {
+      enabled: true,
+      windowSize: 3,
+      minImprovementRate: 0.001,
+      responseMutationMultiplier: 2.0,
+    },
+    randomImmigrants: {
+      enabled: true,
+      injectionFraction: 0.2,
+      triggerWindow: 2,
+      cooldown: 3,
+    },
+  });
+
+  // The run completes and returns a well-formed result — the injection path
+  // produced valid genomes that survived breeding, dedup and scoring.
+  assertEquals(typeof result.error, "number");
+  assertEquals(typeof result.score, "number");
+  assert(Number.isFinite(result.error), "error should be finite");
+});

--- a/test/config/RandomImmigrantsConfig.ts
+++ b/test/config/RandomImmigrantsConfig.ts
@@ -1,0 +1,86 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { DEFAULT_RANDOM_IMMIGRANTS_CONFIG } from "@config/RandomImmigrantsConfig.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+
+Deno.test("RandomImmigrantsConfig - defaults are applied and OFF by default", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.randomImmigrants.enabled, false);
+  assertEquals(
+    config.randomImmigrants.enabled,
+    DEFAULT_RANDOM_IMMIGRANTS_CONFIG.enabled,
+  );
+  assertEquals(
+    config.randomImmigrants.injectionFraction,
+    DEFAULT_RANDOM_IMMIGRANTS_CONFIG.injectionFraction,
+  );
+  assertEquals(
+    config.randomImmigrants.triggerWindow,
+    DEFAULT_RANDOM_IMMIGRANTS_CONFIG.triggerWindow,
+  );
+  assertEquals(
+    config.randomImmigrants.cooldown,
+    DEFAULT_RANDOM_IMMIGRANTS_CONFIG.cooldown,
+  );
+});
+
+Deno.test("RandomImmigrantsConfig - custom values override defaults", () => {
+  const config = createNeatConfig({
+    randomImmigrants: {
+      enabled: true,
+      injectionFraction: 0.25,
+      triggerWindow: 3,
+      cooldown: 7,
+    },
+  });
+  assertEquals(config.randomImmigrants.enabled, true);
+  assertEquals(config.randomImmigrants.injectionFraction, 0.25);
+  assertEquals(config.randomImmigrants.triggerWindow, 3);
+  assertEquals(config.randomImmigrants.cooldown, 7);
+});
+
+Deno.test("RandomImmigrantsConfig - partial overrides keep other defaults", () => {
+  const config = createNeatConfig({ randomImmigrants: { enabled: true } });
+  assertEquals(config.randomImmigrants.enabled, true);
+  assertEquals(
+    config.randomImmigrants.injectionFraction,
+    DEFAULT_RANDOM_IMMIGRANTS_CONFIG.injectionFraction,
+  );
+  assertEquals(
+    config.randomImmigrants.triggerWindow,
+    DEFAULT_RANDOM_IMMIGRANTS_CONFIG.triggerWindow,
+  );
+});
+
+Deno.test("RandomImmigrantsConfig - injectionFraction out of range is rejected", () => {
+  assertThrows(() =>
+    createNeatConfig({ randomImmigrants: { injectionFraction: 1.5 } })
+  );
+  assertThrows(() =>
+    createNeatConfig({ randomImmigrants: { injectionFraction: -0.1 } })
+  );
+});
+
+Deno.test("RandomImmigrantsConfig - triggerWindow must be a positive integer", () => {
+  assertThrows(() =>
+    createNeatConfig({ randomImmigrants: { triggerWindow: 0 } })
+  );
+  assertThrows(() =>
+    createNeatConfig({ randomImmigrants: { triggerWindow: 2.5 } })
+  );
+});
+
+Deno.test("RandomImmigrantsConfig - cooldown must be a non-negative integer", () => {
+  // Zero cooldown is permitted (inject every generation while on plateau).
+  const config = createNeatConfig({ randomImmigrants: { cooldown: 0 } });
+  assertEquals(config.randomImmigrants.cooldown, 0);
+  assertThrows(() => createNeatConfig({ randomImmigrants: { cooldown: -1 } }));
+  assertThrows(() => createNeatConfig({ randomImmigrants: { cooldown: 1.5 } }));
+});
+
+Deno.test("RandomImmigrantsConfig - enabled with zero injectionFraction is rejected", () => {
+  assertThrows(() =>
+    createNeatConfig({
+      randomImmigrants: { enabled: true, injectionFraction: 0 },
+    })
+  );
+});


### PR DESCRIPTION
# Inject random immigrants (fresh genomes) on a detected plateau

## Summary

When the population stalls, the only existing stagnation response was to scale
the mutation rate — which perturbs _existing_ genomes but adds no new genetic
material. This PR adds an optional, **OFF-by-default** random-immigrants
controller driven by the **existing** `PlateauDetector` signal: once the
population has been on a plateau for a configurable number of generations, the
weakest _non-elite_ creatures are replaced with freshly seeded genomes, with a
cooldown between injections to avoid thrashing. Elites are always preserved.

Closes #2933.

### What changed

- **`src/config/RandomImmigrantsConfig.ts`** (new) — `RandomImmigrantsConfig`,
  `RequiredRandomImmigrantsConfig`, and `DEFAULT_RANDOM_IMMIGRANTS_CONFIG`
  (`enabled: false`, `injectionFraction: 0.1`, `triggerWindow: 5`,
  `cooldown: 10`).
- **`src/NEAT/RandomImmigrants.ts`** (new) — the `RandomImmigrants` controller
  (decision logic: `shouldInject`, `immigrantCount`, `recordInjection`, `reset`)
  and the `injectRandomImmigrants` helper (mechanical replacement that preserves
  elites and replaces the weakest non-elites, ranking unscored offspring as
  weakest so freshly bred genomes go first).
- **`src/NEAT/NeatEvolution.ts`** — injection wired in right after the new
  population is assembled and before de-duplication, reusing
  `plateauDetector.getGenerationsOnPlateau()`. Fresh immigrants are minimal
  `Creature(input, output)` genomes matching the fittest's I/O and feedback
  setting. A no-op unless `randomImmigrants.enabled`.
- **`src/NEAT/Neat.ts`** — owns a `RandomImmigrants` instance so the cooldown
  state survives across generations.
- Config plumbed through `NeatArguments`, `NeatOptions` (both override blocks
  and both `Omit` lists), `NeatConfig`, `PopulationParsers`
  (`parseRandomImmigrants`), the `NeatConfigParsers` barrel, and a cross-field
  check in `NeatConfigValidation` (enabled ⇒ `injectionFraction > 0`).
- **`README.md`** — new feature entry with a Mermaid flow diagram.

### Flow

```mermaid
flowchart LR
    A[Generation] --> B{On plateau for<br/>triggerWindow gens?}
    B -- no --> E[Breed + mutate as usual]
    B -- yes --> C{Cooldown<br/>elapsed?}
    C -- no --> E
    C -- yes --> D[Replace weakest non-elites<br/>with fresh genomes<br/>elites preserved]
    D --> E
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via tests and a
deterministic stagnation-trap benchmark.

**Stagnation-trap escape** (`bench/RandomImmigrantsStagnationEscape.ts`): a wide
flat-plateau landscape whose only gradient is hidden beyond `x = 0.8`. Pure
mutation does an unbiased random walk and never crosses the gap; fresh
immigrants sampled across the domain land beyond the edge, after which ordinary
gradient ascent finishes the climb.

```
seed | immigrants OFF        | immigrants ON
-----+-----------------------+----------------------
  1  | stuck (>= 80)         | solved @ gen 8
  2  | stuck (>= 80)         | solved @ gen 8
  3  | stuck (>= 80)         | solved @ gen 17
  4  | stuck (>= 80)         | solved @ gen 8
  5  | stuck (>= 80)         | solved @ gen 11
```

Immigrants escape the trap on every seed within ≤17 generations; pure mutation
stays stuck for the full 80-generation budget.

## Test Plan

- `test/config/RandomImmigrantsConfig.ts` — defaults applied & OFF by default;
  custom and partial overrides; range validation for `injectionFraction`,
  `triggerWindow`, `cooldown`; enabled-with-zero-fraction rejected.
- `test/NEAT/RandomImmigrants.ts` — controller gating (disabled, trigger window,
  cooldown, reset), `immigrantCount` arithmetic, and `injectRandomImmigrants`
  behaviour (elites preserved, weakest/unscored replaced first, count clamped,
  zero-count no-op).
- `test/NEAT/RandomImmigrantsStagnationEscape.ts` — drives the **real**
  `PlateauDetector` + `RandomImmigrants` on the stagnation trap and asserts
  enabled escapes faster than (and never slower than) pure mutation across 5
  seeds; plus an end-to-end `evolveDataSet` run with injection enabled that
  completes with a well-formed result.

Quality gate: `deno fmt`, `deno lint`, and project-wide `deno check` pass; the
full `test/NEAT/` suite (799 tests) and `test/config/` suite (373 tests) pass.
The feature is OFF by default, so existing behaviour and tests are unchanged.



## Milestone
This PR is part of the **Improve evolution** milestone and targets the `milestone/improve-evolution` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqad8vp8-6c7b9f`<!-- vibe-worker-issue-2933 -->