### PR TITLE
NEAT: Resume warm-up currentGeneration from whole seed population (#2945)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2945.md
+++ b/docs/archive/pr-summaries/pr-summary-2945.md
@@ -1,0 +1,61 @@
+## Summary
+
+Resume the warm-up `currentGeneration` counter from the **maximum across the
+entire starting population AND the primary seed**, not just the primary seed
+creature. Closes #2945.
+
+**Root cause:** `Neat.populatePopulation` seeded the lineage-accumulated
+generation counter from only the single primary seed creature. In production
+(the GRQ isolated-team harness) that primary seed is a freshly-built **factory
+template** that carries `warmupGenerations` but never `currentGeneration`, so
+`readCurrentGenerationFromCreature` returned `0` and a fresh `Neat` stayed at
+`0`. The tag-carrying champions from prior runs *were* loaded — but only as
+population members via `config.creatures` — and `populatePopulation` never
+inspected them when seeding the counter. Net effect: every run restarted the
+counter at `0`, stamped exports with that small per-run value, and the
+structural-lock gate (`currentGeneration <= warmupGenerations`) never lifted —
+files frozen at `currentGeneration: 1` against `warmupGenerations: 1440`.
+
+**Fix:** fold the maximum `currentGeneration` across `this.population` (the
+prior champions, already loaded in the constructor) into the existing
+monotonic `Math.max` seed alongside the primary seed. Because it is
+monotonic-max, tagless clones contribute `0` and can never lower the counter,
+so the genuinely-fresh case still starts at `0`. The lineage self-heals from
+the current stuck `1`.
+
+```mermaid
+flowchart LR
+    A[Tagless factory seed<br/>currentGeneration = 0] --> M{Math.max}
+    B[config.creatures<br/>prior champions<br/>currentGeneration = K] --> M
+    C[in-memory counter] --> M
+    M --> R[Resume at K<br/>not 0]
+    R --> G[Run G generations] --> S[Stamp export K + G]
+```
+
+## Evidence
+
+Backend-only change — no web interface to screenshot. Verified via TDD unit
+tests. Each new test fails against the unfixed code and passes after the fix
+(confirmed by stashing `src/NEAT/Neat.ts` and re-running: the two resume tests
+`FAILED`, the tagless-fresh test stayed `ok`).
+
+`./quality.sh` passes cleanly (exit 0): fmt, lint, type-check, and all 7205
+tests.
+
+## Test Plan
+
+Added to `test/NEAT/NeatPopulatePopulation.ts`:
+
+- `populatePopulation: resumes counter from tagged config.creatures when primary seed is tagless`
+  — tagless primary seed + `config.creatures` carrying `currentGeneration: 37`
+  resumes the counter at `37` (not `0`).
+- `populatePopulation: stamps exports with resumed counter plus generations run`
+  — after resuming at `K=37` and running `G=4` generations, the counter reads
+  `K + G = 41` (monotonic accumulation preserved).
+- `populatePopulation: a fully tagless population still starts at zero`
+  — no `currentGeneration` anywhere still starts the counter at `0` (no change
+  for the genuinely-fresh case).
+
+Existing monotonic-max tests (`never lowers an already-higher in-memory
+counter`, `missing tag leaves a higher in-memory counter untouched`) continue
+to pass, confirming the never-lower semantics from #2831/#2908 are preserved.

--- a/docs/archive/pr-summaries/pr-summary-2945.md
+++ b/docs/archive/pr-summaries/pr-summary-2945.md
@@ -9,7 +9,7 @@ generation counter from only the single primary seed creature. In production
 (the GRQ isolated-team harness) that primary seed is a freshly-built **factory
 template** that carries `warmupGenerations` but never `currentGeneration`, so
 `readCurrentGenerationFromCreature` returned `0` and a fresh `Neat` stayed at
-`0`. The tag-carrying champions from prior runs *were* loaded — but only as
+`0`. The tag-carrying champions from prior runs _were_ loaded — but only as
 population members via `config.creatures` — and `populatePopulation` never
 inspected them when seeding the counter. Net effect: every run restarted the
 counter at `0`, stamped exports with that small per-run value, and the
@@ -17,11 +17,10 @@ structural-lock gate (`currentGeneration <= warmupGenerations`) never lifted —
 files frozen at `currentGeneration: 1` against `warmupGenerations: 1440`.
 
 **Fix:** fold the maximum `currentGeneration` across `this.population` (the
-prior champions, already loaded in the constructor) into the existing
-monotonic `Math.max` seed alongside the primary seed. Because it is
-monotonic-max, tagless clones contribute `0` and can never lower the counter,
-so the genuinely-fresh case still starts at `0`. The lineage self-heals from
-the current stuck `1`.
+prior champions, already loaded in the constructor) into the existing monotonic
+`Math.max` seed alongside the primary seed. Because it is monotonic-max, tagless
+clones contribute `0` and can never lower the counter, so the genuinely-fresh
+case still starts at `0`. The lineage self-heals from the current stuck `1`.
 
 ```mermaid
 flowchart LR
@@ -52,10 +51,12 @@ Added to `test/NEAT/NeatPopulatePopulation.ts`:
 - `populatePopulation: stamps exports with resumed counter plus generations run`
   — after resuming at `K=37` and running `G=4` generations, the counter reads
   `K + G = 41` (monotonic accumulation preserved).
-- `populatePopulation: a fully tagless population still starts at zero`
-  — no `currentGeneration` anywhere still starts the counter at `0` (no change
-  for the genuinely-fresh case).
+- `populatePopulation: a fully tagless population still starts at zero` — no
+  `currentGeneration` anywhere still starts the counter at `0` (no change for
+  the genuinely-fresh case).
 
-Existing monotonic-max tests (`never lowers an already-higher in-memory
-counter`, `missing tag leaves a higher in-memory counter untouched`) continue
-to pass, confirming the never-lower semantics from #2831/#2908 are preserved.
+Existing monotonic-max tests
+(`never lowers an already-higher in-memory
+counter`,
+`missing tag leaves a higher in-memory counter untouched`) continue to pass,
+confirming the never-lower semantics from #2831/#2908 are preserved.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -391,6 +391,7 @@
     "stringified",
     "stringifying",
     "stsoftware",
+    "tagless",
     "subarray",
     "subclassed",
     "subdirs",

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -744,9 +744,21 @@ export class Neat {
     // Issue #2908: seed the lineage-accumulated generation counter
     // monotonically — fold the saved tag in via Math.max so no load path can
     // ever lower it (consistent with the monotonic tag write in #2831).
+    // Issue #2945: also fold in the maximum currentGeneration across the whole
+    // starting population (the prior champions loaded via config.creatures),
+    // not just the primary seed. In production the primary seed is a tagless
+    // factory template, so the accumulated lineage value lives only on those
+    // population members — resuming from the seed alone restarts the counter
+    // at 0 every run and the warm-up gate never lifts. Monotonic-max keeps
+    // tagless clones contributing 0, so they can never lower the counter.
+    const populationMax = this.population.reduce(
+      (m, c) => Math.max(m, readCurrentGenerationFromCreature(c)),
+      0,
+    );
     this.currentGeneration = Math.max(
       this.currentGeneration,
       readCurrentGenerationFromCreature(creature),
+      populationMax,
     );
 
     const mutator = new Mutator(

--- a/test/NEAT/NeatPopulatePopulation.ts
+++ b/test/NEAT/NeatPopulatePopulation.ts
@@ -309,6 +309,117 @@ Deno.test("populatePopulation: missing tag leaves a higher in-memory counter unt
   }
 });
 
+Deno.test("populatePopulation: resumes counter from tagged config.creatures when primary seed is tagless", async () => {
+  // Issue #2945: in production the primary seed is a freshly-built factory
+  // template that carries warmupGenerations but no currentGeneration. The
+  // accumulated lineage value lives on the prior champions loaded via
+  // config.creatures. The counter must resume from the population maximum,
+  // not from the tagless primary seed (which would restart at 0 every run).
+  const dataDir = createTestDataDir(3, 2);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    // Prior champion carrying the accumulated lineage tag.
+    const champion = new Creature(3, 2, { layers: [{ count: 3 }] });
+    addTag(champion, CURRENT_GENERATION_TAG, "37");
+
+    const options: NeatOptions = {
+      populationSize: 5,
+      creatures: [champion.exportJSON()],
+    };
+    const neat = new Neat(3, 2, options, workers);
+
+    // Tagless factory-style primary seed: warm-up length only, no progress.
+    const seedCreature = creatureForProblem({
+      inputs: 3,
+      outputs: 2,
+      cost: "MSE",
+      warmupGenerations: 1440,
+    });
+
+    await neat.populatePopulation(seedCreature);
+
+    assertEquals(
+      neat.currentGeneration,
+      37,
+      "Counter must resume from the population maximum, not the tagless seed",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("populatePopulation: stamps exports with resumed counter plus generations run", async () => {
+  // Issue #2945: after resuming at K from the population and running G
+  // generations, the in-memory counter (and therefore the export stamp) must
+  // read K + G — proving the lineage accumulates rather than resetting.
+  const dataDir = createTestDataDir(3, 2);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const champion = new Creature(3, 2, { layers: [{ count: 3 }] });
+    addTag(champion, CURRENT_GENERATION_TAG, "37");
+
+    const options: NeatOptions = {
+      populationSize: 5,
+      creatures: [champion.exportJSON()],
+    };
+    const neat = new Neat(3, 2, options, workers);
+
+    const seedCreature = creatureForProblem({
+      inputs: 3,
+      outputs: 2,
+      cost: "MSE",
+      warmupGenerations: 1440,
+    });
+
+    await neat.populatePopulation(seedCreature);
+    assertEquals(neat.currentGeneration, 37, "Resume at population maximum");
+
+    // Run G generations (exactly what evolve() does each generation).
+    const G = 4;
+    for (let g = 0; g < G; g++) {
+      neat.currentGeneration++;
+    }
+
+    assertEquals(
+      neat.currentGeneration,
+      41,
+      "Counter must read K + G (37 + 4) after running the generations",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("populatePopulation: a fully tagless population still starts at zero", async () => {
+  // Issue #2945: the genuinely-fresh case must be unchanged — no
+  // currentGeneration anywhere means the counter starts at 0.
+  const dataDir = createTestDataDir(3, 2);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const member = new Creature(3, 2, { layers: [{ count: 3 }] });
+    const options: NeatOptions = {
+      populationSize: 5,
+      creatures: [member.exportJSON()],
+    };
+    const neat = new Neat(3, 2, options, workers);
+
+    const seedCreature = new Creature(3, 2, { layers: [{ count: 3 }] });
+
+    await neat.populatePopulation(seedCreature);
+
+    assertEquals(
+      neat.currentGeneration,
+      0,
+      "A fully tagless population must start the counter at 0",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
 Deno.test("populatePopulation: restores warm-up tags from seed creature", async () => {
   const dataDir = createTestDataDir(3, 2);
   const workers = createTestWorkers(dataDir);


### PR DESCRIPTION
## Summary

Resume the warm-up `currentGeneration` counter from the **maximum across the
entire starting population AND the primary seed**, not just the primary seed
creature. Closes #2945.

**Root cause:** `Neat.populatePopulation` seeded the lineage-accumulated
generation counter from only the single primary seed creature. In production
(the GRQ isolated-team harness) that primary seed is a freshly-built **factory
template** that carries `warmupGenerations` but never `currentGeneration`, so
`readCurrentGenerationFromCreature` returned `0` and a fresh `Neat` stayed at
`0`. The tag-carrying champions from prior runs *were* loaded — but only as
population members via `config.creatures` — and `populatePopulation` never
inspected them when seeding the counter. Net effect: every run restarted the
counter at `0`, stamped exports with that small per-run value, and the
structural-lock gate (`currentGeneration <= warmupGenerations`) never lifted —
files frozen at `currentGeneration: 1` against `warmupGenerations: 1440`.

**Fix:** fold the maximum `currentGeneration` across `this.population` (the
prior champions, already loaded in the constructor) into the existing
monotonic `Math.max` seed alongside the primary seed. Because it is
monotonic-max, tagless clones contribute `0` and can never lower the counter,
so the genuinely-fresh case still starts at `0`. The lineage self-heals from
the current stuck `1`.

```mermaid
flowchart LR
    A[Tagless factory seed<br/>currentGeneration = 0] --> M{Math.max}
    B[config.creatures<br/>prior champions<br/>currentGeneration = K] --> M
    C[in-memory counter] --> M
    M --> R[Resume at K<br/>not 0]
    R --> G[Run G generations] --> S[Stamp export K + G]
```

## Evidence

Backend-only change — no web interface to screenshot. Verified via TDD unit
tests. Each new test fails against the unfixed code and passes after the fix
(confirmed by stashing `src/NEAT/Neat.ts` and re-running: the two resume tests
`FAILED`, the tagless-fresh test stayed `ok`).

`./quality.sh` passes cleanly (exit 0): fmt, lint, type-check, and all 7205
tests.

## Test Plan

Added to `test/NEAT/NeatPopulatePopulation.ts`:

- `populatePopulation: resumes counter from tagged config.creatures when primary seed is tagless`
  — tagless primary seed + `config.creatures` carrying `currentGeneration: 37`
  resumes the counter at `37` (not `0`).
- `populatePopulation: stamps exports with resumed counter plus generations run`
  — after resuming at `K=37` and running `G=4` generations, the counter reads
  `K + G = 41` (monotonic accumulation preserved).
- `populatePopulation: a fully tagless population still starts at zero`
  — no `currentGeneration` anywhere still starts the counter at `0` (no change
  for the genuinely-fresh case).

Existing monotonic-max tests (`never lowers an already-higher in-memory
counter`, `missing tag leaves a higher in-memory counter untouched`) continue
to pass, confirming the never-lower semantics from #2831/#2908 are preserved.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqbyvcvw-b96df1`<!-- vibe-worker-issue-2945 -->