### PR TITLE
Surface warm-up resume/accumulation state in logs and training events (#2947)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2947.md
+++ b/docs/archive/pr-summaries/pr-summary-2947.md
@@ -21,10 +21,10 @@ Three signals were added:
    warm-up: resumed currentGeneration=900 / warmupGenerations=1440 (lock active, source=population)
    ```
 
-   The `source` (`primary-seed` | `population` | `none`) is what makes the
-   #2945 bug self-evident: a tagless factory seed resuming from a population
-   member (`source=population`) is otherwise indistinguishable from a fresh
-   start (`source=none`).
+   The `source` (`primary-seed` | `population` | `none`) is what makes the #2945
+   bug self-evident: a tagless factory seed resuming from a population member
+   (`source=population`) is otherwise indistinguishable from a fresh start
+   (`source=none`).
 
 2. **Per-generation event fields** — `generation_complete` events now carry the
    accumulated `currentGeneration` and a derived `warmupLockActive` boolean
@@ -40,17 +40,17 @@ Three signals were added:
    ```
 
 When warm-up is not configured (`warmupGenerations <= 0`) nothing is logged and
-the event fields are absent — zero overhead once warm, consistent with the
-#2903 design goal. A lineage that resumes already-warm suppresses the lock-lift
-line (seeded in `populatePopulation`), so it fires only on a genuine
-warm-up → warm transition during the run.
+the event fields are absent — zero overhead once warm, consistent with the #2903
+design goal. A lineage that resumes already-warm suppresses the lock-lift line
+(seeded in `populatePopulation`), so it fires only on a genuine warm-up → warm
+transition during the run.
 
 ## Evidence
 
 Backend/CLI change — no web interface to screenshot. Verified via the new unit
 tests (7 passing) and the full quality gate (`./quality.sh`: 7212 passed, 0
-failed). Sample captured output from the existing `NeatPopulatePopulation`
-suite confirms the resume line in situ:
+failed). Sample captured output from the existing `NeatPopulatePopulation` suite
+confirms the resume line in situ:
 
 ```
 warm-up: resumed currentGeneration=37 / warmupGenerations=1440 (lock active, source=population)
@@ -90,7 +90,8 @@ New tests in `test/NEAT/WarmupObservability.ts`:
   warm-up window and asserts the lift line fires exactly once and not again on
   subsequent generations.
 - `generation_complete carries accumulated counter and lock state while
-  warming` — end-to-end via `evolveDataSet`; asserts the events expose
+  warming`
+  — end-to-end via `evolveDataSet`; asserts the events expose
   `currentGeneration` and `warmupLockActive === true`.
 - `generation_complete omits warm-up fields when warm-up is not configured` —
   asserts both fields are `undefined`.

--- a/docs/archive/pr-summaries/pr-summary-2947.md
+++ b/docs/archive/pr-summaries/pr-summary-2947.md
@@ -1,0 +1,100 @@
+# Surface warm-up resume/accumulation state in logs and training events
+
+## Summary
+
+Part of #2944 — makes the seed warm-up resume/accumulation state **observable**
+so a frozen or resetting lineage counter is obvious at a glance, independent of
+the seeding fix (#2945). Previously the only evidence of "resumed at generation
+900" vs "restarted at 0" was a tag buried in a multi-megabyte creature JSON.
+
+This change is **observability only** — it does not alter counting, seeding, or
+stamping behaviour.
+
+Closes #2947.
+
+Three signals were added:
+
+1. **Run-start resume log** (`Neat.populatePopulation`) — after the lineage
+   counter is seeded, emits one info line:
+
+   ```
+   warm-up: resumed currentGeneration=900 / warmupGenerations=1440 (lock active, source=population)
+   ```
+
+   The `source` (`primary-seed` | `population` | `none`) is what makes the
+   #2945 bug self-evident: a tagless factory seed resuming from a population
+   member (`source=population`) is otherwise indistinguishable from a fresh
+   start (`source=none`).
+
+2. **Per-generation event fields** — `generation_complete` events now carry the
+   accumulated `currentGeneration` and a derived `warmupLockActive` boolean
+   (built by the new `buildWarmupEventFields` helper), so dashboards can chart
+   the counter climbing across runs and alert if it is flat or resetting.
+
+3. **Lock-lift transition log** (`evolve`) — logs a single greppable line when
+   the structural lock lifts (`currentGeneration` first exceeds
+   `warmupGenerations`):
+
+   ```
+   warm-up: structural lock lifted at currentGeneration=1441 (warmupGenerations=1440)
+   ```
+
+When warm-up is not configured (`warmupGenerations <= 0`) nothing is logged and
+the event fields are absent — zero overhead once warm, consistent with the
+#2903 design goal. A lineage that resumes already-warm suppresses the lock-lift
+line (seeded in `populatePopulation`), so it fires only on a genuine
+warm-up → warm transition during the run.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via the new unit
+tests (7 passing) and the full quality gate (`./quality.sh`: 7212 passed, 0
+failed). Sample captured output from the existing `NeatPopulatePopulation`
+suite confirms the resume line in situ:
+
+```
+warm-up: resumed currentGeneration=37 / warmupGenerations=1440 (lock active, source=population)
+warm-up: resumed currentGeneration=7 / warmupGenerations=20 (lock active, source=primary-seed)
+```
+
+### Observability flow
+
+```mermaid
+flowchart TD
+    A[populatePopulation seeds<br/>currentGeneration via Math.max] --> B{warmupGenerations > 0?}
+    B -- no --> Z[silent: no log, no event fields]
+    B -- yes --> C[log: warm-up resumed<br/>counter / window, lock, source]
+    C --> D[set warmupLockLiftLogged = !lockActive]
+    D --> E[evolve: currentGeneration++]
+    E --> F{first time<br/>currentGeneration > warmupGenerations<br/>and not yet logged?}
+    F -- yes --> G[log: structural lock lifted once]
+    F -- no --> H[generation_complete event]
+    G --> H
+    H --> I[event carries currentGeneration<br/>+ warmupLockActive]
+```
+
+## Test Plan
+
+New tests in `test/NEAT/WarmupObservability.ts`:
+
+- `resume log reports primary-seed source while locked` — seed carries both
+  tags; asserts the single resume line with `source=primary-seed`, the
+  accumulated counter, and `lock active`.
+- `resume log reports population source when the seed is tagless` — tagless
+  factory seed plus a tagged prior champion in the population; asserts
+  `source=population` and the population-sourced counter.
+- `no warm-up configured logs nothing` — asserts zero resume/lift lines.
+- `buildWarmupEventFields surfaces accumulated counter and lock state` — unit
+  test of the helper across not-configured / warming / past-window cases.
+- `lock-lift transition logs exactly once per run` — drives `evolve()` past the
+  warm-up window and asserts the lift line fires exactly once and not again on
+  subsequent generations.
+- `generation_complete carries accumulated counter and lock state while
+  warming` — end-to-end via `evolveDataSet`; asserts the events expose
+  `currentGeneration` and `warmupLockActive === true`.
+- `generation_complete omits warm-up fields when warm-up is not configured` —
+  asserts both fields are `undefined`.
+
+All existing warm-up / training-event tests continue to pass
+(`SeedWarmupAccumulation`, `PhaseTimingFields`, `TrainingEvent`,
+`SeedWarmupStructuralLock`, `NeatPopulatePopulation`).

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -40,6 +40,7 @@ import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 import { configureSharedSubnetworkIndex } from "@discovery/SubnetworkHashIndex.ts";
 import {
+  isSeedWarmupStructuralLockActive,
   readCurrentGenerationFromCreature,
   readWarmupGenerationsFromCreature,
 } from "@architecture/CreatureFactory.ts";
@@ -194,6 +195,15 @@ export class Neat {
    * The on-disk tag name remains `currentGeneration`.
    */
   currentGeneration = 0;
+
+  /**
+   * Issue #2947: tracks whether the warm-up → warm structural-lock-lift
+   * transition has already been logged this run, so the transition line is
+   * emitted at most once. Seeded `true` in `populatePopulation` when the
+   * lineage resumes already warm (lock lifted on resume), so only a genuine
+   * mid-run lift produces the log line.
+   */
+  warmupLockLiftLogged = false;
 
   /** Data directory for discovery replay (Issue #997) */
   dataDir?: string;
@@ -755,11 +765,43 @@ export class Neat {
       (m, c) => Math.max(m, readCurrentGenerationFromCreature(c)),
       0,
     );
+    const seedGeneration = readCurrentGenerationFromCreature(creature);
     this.currentGeneration = Math.max(
       this.currentGeneration,
-      readCurrentGenerationFromCreature(creature),
+      seedGeneration,
       populationMax,
     );
+
+    // Issue #2947: surface the resumed warm-up state exactly once at run start
+    // so a frozen/resetting counter is obvious at a glance. The `source` makes
+    // the #2945 bug self-evident: a tagless factory seed (source=population)
+    // looks identical to a fresh start (source=none) without it. No logging
+    // when warm-up is not configured — zero overhead once warm (#2903).
+    if (this.warmupGenerations > 0) {
+      const lockActive = isSeedWarmupStructuralLockActive(
+        this.warmupGenerations,
+        this.currentGeneration,
+      );
+      let source: "primary-seed" | "population" | "none";
+      if (this.currentGeneration <= 0) {
+        source = "none";
+      } else if (seedGeneration >= this.currentGeneration) {
+        source = "primary-seed";
+      } else if (populationMax >= this.currentGeneration) {
+        source = "population";
+      } else {
+        source = "none";
+      }
+      getLogger().info(
+        `warm-up: resumed currentGeneration=${this.currentGeneration} / ` +
+          `warmupGenerations=${this.warmupGenerations} ` +
+          `(lock ${lockActive ? "active" : "lifted"}, source=${source})`,
+      );
+      // Resuming already warm (lock lifted on resume) means no mid-run
+      // transition will occur — suppress the lock-lift line so it only fires
+      // on a genuine warm-up → warm transition during this run.
+      this.warmupLockLiftLogged = !lockActive;
+    }
 
     const mutator = new Mutator(
       this.config,

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -91,6 +91,21 @@ export async function evolve(
 
   neat.currentGeneration++;
 
+  // Issue #2947: log the warm-up → warm transition exactly once per run, when
+  // the structural lock lifts (currentGeneration first exceeds
+  // warmupGenerations). Greppable marker for the warm-up window ending.
+  if (
+    neat.warmupGenerations > 0 &&
+    !neat.warmupLockLiftLogged &&
+    neat.currentGeneration > neat.warmupGenerations
+  ) {
+    neat.warmupLockLiftLogged = true;
+    getLogger().info(
+      `warm-up: structural lock lifted at currentGeneration=` +
+        `${neat.currentGeneration} (warmupGenerations=${neat.warmupGenerations})`,
+    );
+  }
+
   neat.additionalGenerationCount--;
 
   // Issue #2263: Proactive pre-fitness memory monitoring.

--- a/src/architecture/CreatureFactory.ts
+++ b/src/architecture/CreatureFactory.ts
@@ -212,6 +212,31 @@ export function isSeedWarmupStructuralLockActive(
 }
 
 /**
+ * Issue #2947: Build the warm-up observability fields for a
+ * `generation_complete` training event.
+ *
+ * Returns the lineage-accumulated counter and a derived `warmupLockActive`
+ * boolean **only** when warm-up is configured (`warmupGenerations > 0`).
+ * Returns `undefined` otherwise so the fields are absent on the event,
+ * keeping zero overhead once warm-up is not in play (the #2903 design goal).
+ */
+export function buildWarmupEventFields(
+  warmupGenerations: number,
+  currentGeneration: number,
+): { currentGeneration: number; warmupLockActive: boolean } | undefined {
+  if (!Number.isFinite(warmupGenerations) || warmupGenerations <= 0) {
+    return undefined;
+  }
+  return {
+    currentGeneration,
+    warmupLockActive: isSeedWarmupStructuralLockActive(
+      warmupGenerations,
+      currentGeneration,
+    ),
+  };
+}
+
+/**
  * Persist seed warm-up progress on a creature so export/load can resume
  * evolution with the correct warm-up gate.
  *

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -329,6 +329,25 @@ export interface GenerationCompleteEvent {
    * depth/wait counters that explain *why* a generation is fast or slow.
    */
   readonly throughput?: GenerationThroughputMetrics;
+  /**
+   * Issue #2947: Lineage-accumulated warm-up generation counter — the single
+   * source of truth for how many generations this lineage has evolved across
+   * **all** runs (see `Neat.currentGeneration`). Lets dashboards chart the
+   * counter climbing across runs and alert if it is flat or resetting.
+   *
+   * Present only when seed warm-up is configured (`warmupGenerations > 0`);
+   * absent once warm-up is not in play, keeping zero overhead consistent with
+   * the #2903 design goal.
+   */
+  readonly currentGeneration?: number;
+  /**
+   * Issue #2947: Whether the seed warm-up structural lock is currently active
+   * (derived from `warmupGenerations` and `currentGeneration`). `true` while
+   * warming, `false` once the warm-up window has elapsed.
+   *
+   * Present only when seed warm-up is configured (`warmupGenerations > 0`).
+   */
+  readonly warmupLockActive?: boolean;
 }
 
 /**

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -46,7 +46,10 @@ import {
 import { buildOutgoingSynapsesMap } from "@propagate/sparse/CalculatePathsToOutput.ts";
 import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
 import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
-import { applySeedWarmupTagsAtSave } from "@architecture/CreatureFactory.ts";
+import {
+  applySeedWarmupTagsAtSave,
+  buildWarmupEventFields,
+} from "@architecture/CreatureFactory.ts";
 import { BufferPool } from "@utils/BufferPool.ts";
 import {
   type DiscoveryDirResult,
@@ -575,6 +578,9 @@ export async function evolveDir(
       elapsedMs: generationElapsedMs,
       phaseTiming,
       throughput: result.throughput,
+      // Issue #2947: surface the lineage-accumulated warm-up counter and the
+      // derived lock state (present only while warm-up is configured).
+      ...buildWarmupEventFields(neat.warmupGenerations, neat.currentGeneration),
     });
 
     // Issue #1615: Emit plateau_detected event when on plateau
@@ -871,6 +877,9 @@ export async function evolveEnv<S, A>(
       elapsedMs: generationElapsedMs,
       phaseTiming,
       throughput: result.throughput,
+      // Issue #2947: surface the lineage-accumulated warm-up counter and the
+      // derived lock state (present only while warm-up is configured).
+      ...buildWarmupEventFields(neat.warmupGenerations, neat.currentGeneration),
     });
 
     if (result.plateau.onPlateau) {
@@ -1353,6 +1362,9 @@ export async function evolveRL<S, A>(
       elapsedMs: generationElapsedMs,
       phaseTiming,
       throughput: result.throughput,
+      // Issue #2947: surface the lineage-accumulated warm-up counter and the
+      // derived lock state (present only while warm-up is configured).
+      ...buildWarmupEventFields(neat.warmupGenerations, neat.currentGeneration),
     });
 
     if (result.plateau.onPlateau) {

--- a/test/NEAT/WarmupObservability.ts
+++ b/test/NEAT/WarmupObservability.ts
@@ -1,0 +1,307 @@
+/**
+ * Issue #2947: Warm-up resume/accumulation observability.
+ *
+ * Verifies the operator-visible signals added so a frozen/resetting warm-up
+ * counter is obvious at a glance (independent of the seeding fix #2945):
+ *
+ * 1. A single run-start resume log from `populatePopulation` carrying the
+ *    accumulated `currentGeneration`, the configured `warmupGenerations`, the
+ *    lock state, and the resume `source` (primary-seed vs population vs none).
+ * 2. The `generation_complete` training event exposes the accumulated counter
+ *    and a derived `warmupLockActive` boolean (via `buildWarmupEventFields`).
+ * 3. The warm-up → warm transition (structural lock lifting) is logged exactly
+ *    once per run when it occurs.
+ * 4. No warm-up logging at all when warm-up is not configured.
+ *
+ * Tests capture an injected logger and assert on its emitted lines — a "what"
+ * test on the observable output, not on implementation details.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import {
+  buildWarmupEventFields,
+  creatureForProblem,
+  writeSeedWarmupProgressTags,
+} from "@architecture/CreatureFactory.ts";
+import type { Logger } from "@utils/Logger.ts";
+import { Neat } from "@neat/Neat.ts";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import type {
+  GenerationCompleteEvent,
+  TrainingEvent,
+} from "@config/TrainingEvent.ts";
+import { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import {
+  type DataRecordInterface,
+  makeDataDir,
+} from "@architecture/DataSet.ts";
+
+const INPUTS = 3;
+const OUTPUTS = 1;
+
+/**
+ * A logger that records every emitted info line, for assertions. Injected via
+ * `NeatOptions.logger` (the documented integration path) because constructing
+ * a Neat resets the global logger to `config.logger`.
+ */
+function captureLogger(): { logger: Logger; infos: string[] } {
+  const infos: string[] = [];
+  const logger: Logger = {
+    debug() {},
+    info(...args: unknown[]) {
+      infos.push(args.map((a) => String(a)).join(" "));
+    },
+    warn() {},
+    error() {},
+  };
+  return { logger, infos };
+}
+
+/** Lines emitted by the run-start resume log. */
+function resumeLines(infos: string[]): string[] {
+  return infos.filter((l) => l.includes("warm-up: resumed"));
+}
+
+/** Lines emitted by the lock-lift transition log. */
+function liftLines(infos: string[]): string[] {
+  return infos.filter((l) => l.includes("structural lock lifted"));
+}
+
+Deno.test("WarmupObservability: resume log reports primary-seed source while locked", async () => {
+  const { logger, infos } = captureLogger();
+  // Primary seed carries both the warm-up length and accumulated progress.
+  const seed = creatureForProblem({
+    inputs: INPUTS,
+    outputs: OUTPUTS,
+    cost: "MSE",
+    warmupGenerations: 10,
+  });
+  writeSeedWarmupProgressTags(seed, 10, 4);
+
+  const neat = new Neat(INPUTS, OUTPUTS, { populationSize: 4, logger }, []);
+  await neat.populatePopulation(seed);
+
+  const lines = resumeLines(infos);
+  assertEquals(lines.length, 1, "resume log must be emitted exactly once");
+  assert(
+    lines[0].includes("currentGeneration=4"),
+    `expected accumulated counter in: ${lines[0]}`,
+  );
+  assert(
+    lines[0].includes("warmupGenerations=10"),
+    `expected warm-up length in: ${lines[0]}`,
+  );
+  assert(
+    lines[0].includes("lock active"),
+    `expected active lock in: ${lines[0]}`,
+  );
+  assert(
+    lines[0].includes("source=primary-seed"),
+    `expected primary-seed source in: ${lines[0]}`,
+  );
+  // Lock-lift line must NOT fire — the lineage resumes still warming.
+  assertEquals(liftLines(infos).length, 0);
+});
+
+Deno.test("WarmupObservability: resume log reports population source when the seed is tagless", async () => {
+  const { logger, infos } = captureLogger();
+  // Tagless factory seed: warm-up length but no accumulated progress.
+  const seed = creatureForProblem({
+    inputs: INPUTS,
+    outputs: OUTPUTS,
+    cost: "MSE",
+    warmupGenerations: 10,
+  });
+
+  // A prior champion in the starting population carries the lineage counter.
+  const champion = creatureForProblem({
+    inputs: INPUTS,
+    outputs: OUTPUTS,
+    cost: "MSE",
+    warmupGenerations: 10,
+  });
+  writeSeedWarmupProgressTags(champion, 10, 6);
+
+  const neat = new Neat(
+    INPUTS,
+    OUTPUTS,
+    { populationSize: 4, creatures: [champion.exportJSON()], logger },
+    [],
+  );
+  await neat.populatePopulation(seed);
+
+  const lines = resumeLines(infos);
+  assertEquals(lines.length, 1, "resume log must be emitted exactly once");
+  assert(
+    lines[0].includes("currentGeneration=6"),
+    `expected population-sourced counter in: ${lines[0]}`,
+  );
+  assert(
+    lines[0].includes("source=population"),
+    `expected population source in: ${lines[0]}`,
+  );
+  assert(lines[0].includes("lock active"), `expected active lock: ${lines[0]}`);
+});
+
+Deno.test("WarmupObservability: no warm-up configured logs nothing", async () => {
+  const { logger, infos } = captureLogger();
+  // No warmupGenerations tag — warm-up is not configured.
+  const seed = creatureForProblem({
+    inputs: INPUTS,
+    outputs: OUTPUTS,
+    cost: "MSE",
+  });
+
+  const neat = new Neat(INPUTS, OUTPUTS, { populationSize: 4, logger }, []);
+  await neat.populatePopulation(seed);
+
+  assertEquals(
+    resumeLines(infos).length,
+    0,
+    "no resume log when warm-up is not configured",
+  );
+  assertEquals(liftLines(infos).length, 0);
+});
+
+Deno.test("WarmupObservability: buildWarmupEventFields surfaces accumulated counter and lock state", () => {
+  // Not configured → undefined (fields absent on the event; zero overhead).
+  assertEquals(buildWarmupEventFields(0, 5), undefined);
+  assertEquals(buildWarmupEventFields(-1, 5), undefined);
+
+  // Configured and still warming → lock active.
+  assertEquals(buildWarmupEventFields(10, 5), {
+    currentGeneration: 5,
+    warmupLockActive: true,
+  });
+
+  // Configured and past the window → lock lifted.
+  assertEquals(buildWarmupEventFields(10, 15), {
+    currentGeneration: 15,
+    warmupLockActive: false,
+  });
+});
+
+Deno.test("WarmupObservability: lock-lift transition logs exactly once per run", async () => {
+  const records: DataRecordInterface[] = [];
+  for (let i = 0; i < 12; i++) {
+    records.push({
+      input: new Float32Array(Array.from({ length: INPUTS }, () => 0.5)),
+      output: new Float32Array(Array.from({ length: OUTPUTS }, () => 0.5)),
+    });
+  }
+  const dataDir = makeDataDir(records, 2000);
+  const workers = [new WorkerHandler(dataDir, "MSE", true)];
+
+  try {
+    const { logger, infos } = captureLogger();
+    // Warm-up of 1 with the lineage already at the window edge: the very
+    // next generation lifts the structural lock.
+    const seed = creatureForProblem({
+      inputs: INPUTS,
+      outputs: OUTPUTS,
+      cost: "MSE",
+      warmupGenerations: 1,
+    });
+    writeSeedWarmupProgressTags(seed, 1, 1);
+
+    const options: NeatOptions = { populationSize: 6, logger };
+    const neat = new Neat(INPUTS, OUTPUTS, options, workers);
+    await neat.populatePopulation(seed);
+
+    // Resume log fired with the lock still active.
+    const resume = resumeLines(infos);
+    assertEquals(resume.length, 1);
+    assert(resume[0].includes("lock active"), `expected active: ${resume[0]}`);
+
+    // First generation crosses the window → lock lifts → logged once.
+    await neat.evolve();
+    assert(neat.currentGeneration > 1, "generation must advance past warm-up");
+    const afterFirst = liftLines(infos);
+    assertEquals(afterFirst.length, 1, "lock-lift must be logged once");
+    assert(
+      afterFirst[0].includes("warmupGenerations=1"),
+      `expected warm-up length in lift line: ${afterFirst[0]}`,
+    );
+
+    // Subsequent generations must not re-log the transition.
+    await neat.evolve();
+    assertEquals(
+      liftLines(infos).length,
+      1,
+      "lock-lift must not be logged again",
+    );
+  } finally {
+    await Promise.all(workers.map((w) => w.waitUntilReady().catch(() => {})));
+    for (const w of workers) {
+      w.terminate();
+    }
+  }
+});
+
+const TRAINING_SET = [
+  { input: new Float32Array([0, 0, 0]), output: new Float32Array([0]) },
+  { input: new Float32Array([1, 1, 1]), output: new Float32Array([1]) },
+];
+
+Deno.test("WarmupObservability: generation_complete carries accumulated counter and lock state while warming", async () => {
+  const events: GenerationCompleteEvent[] = [];
+
+  // Seed tagged with a long warm-up so the lock stays active across the run.
+  const seed = new Creature(INPUTS, OUTPUTS, { layers: [{ count: 4 }] });
+  writeSeedWarmupProgressTags(seed, 100, 5);
+
+  await seed.evolveDataSet(TRAINING_SET, {
+    iterations: 3,
+    targetError: 0,
+    populationSize: 10,
+    threads: 1,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        events.push(event);
+      }
+    },
+  });
+
+  assert(events.length > 0, "should emit generation_complete events");
+  for (const event of events) {
+    assertEquals(
+      typeof event.currentGeneration,
+      "number",
+      "accumulated counter must be present while warming",
+    );
+    assert(
+      (event.currentGeneration ?? 0) >= 5,
+      `counter must include the resumed value, got ${event.currentGeneration}`,
+    );
+    assertEquals(
+      event.warmupLockActive,
+      true,
+      "lock must be active throughout this short warm-up run",
+    );
+  }
+});
+
+Deno.test("WarmupObservability: generation_complete omits warm-up fields when warm-up is not configured", async () => {
+  const events: GenerationCompleteEvent[] = [];
+
+  // No warm-up tags — fields must be absent (zero overhead once warm).
+  const seed = new Creature(INPUTS, OUTPUTS, { layers: [{ count: 4 }] });
+
+  await seed.evolveDataSet(TRAINING_SET, {
+    iterations: 3,
+    targetError: 0,
+    populationSize: 10,
+    threads: 1,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        events.push(event);
+      }
+    },
+  });
+
+  assert(events.length > 0, "should emit generation_complete events");
+  for (const event of events) {
+    assertEquals(event.currentGeneration, undefined);
+    assertEquals(event.warmupLockActive, undefined);
+  }
+});


### PR DESCRIPTION
# Surface warm-up resume/accumulation state in logs and training events

## Summary

Part of #2944 — makes the seed warm-up resume/accumulation state **observable**
so a frozen or resetting lineage counter is obvious at a glance, independent of
the seeding fix (#2945). Previously the only evidence of "resumed at generation
900" vs "restarted at 0" was a tag buried in a multi-megabyte creature JSON.

This change is **observability only** — it does not alter counting, seeding, or
stamping behaviour.

Closes #2947.

Three signals were added:

1. **Run-start resume log** (`Neat.populatePopulation`) — after the lineage
   counter is seeded, emits one info line:

   ```
   warm-up: resumed currentGeneration=900 / warmupGenerations=1440 (lock active, source=population)
   ```

   The `source` (`primary-seed` | `population` | `none`) is what makes the
   #2945 bug self-evident: a tagless factory seed resuming from a population
   member (`source=population`) is otherwise indistinguishable from a fresh
   start (`source=none`).

2. **Per-generation event fields** — `generation_complete` events now carry the
   accumulated `currentGeneration` and a derived `warmupLockActive` boolean
   (built by the new `buildWarmupEventFields` helper), so dashboards can chart
   the counter climbing across runs and alert if it is flat or resetting.

3. **Lock-lift transition log** (`evolve`) — logs a single greppable line when
   the structural lock lifts (`currentGeneration` first exceeds
   `warmupGenerations`):

   ```
   warm-up: structural lock lifted at currentGeneration=1441 (warmupGenerations=1440)
   ```

When warm-up is not configured (`warmupGenerations <= 0`) nothing is logged and
the event fields are absent — zero overhead once warm, consistent with the
#2903 design goal. A lineage that resumes already-warm suppresses the lock-lift
line (seeded in `populatePopulation`), so it fires only on a genuine
warm-up → warm transition during the run.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via the new unit
tests (7 passing) and the full quality gate (`./quality.sh`: 7212 passed, 0
failed). Sample captured output from the existing `NeatPopulatePopulation`
suite confirms the resume line in situ:

```
warm-up: resumed currentGeneration=37 / warmupGenerations=1440 (lock active, source=population)
warm-up: resumed currentGeneration=7 / warmupGenerations=20 (lock active, source=primary-seed)
```

### Observability flow

```mermaid
flowchart TD
    A[populatePopulation seeds<br/>currentGeneration via Math.max] --> B{warmupGenerations > 0?}
    B -- no --> Z[silent: no log, no event fields]
    B -- yes --> C[log: warm-up resumed<br/>counter / window, lock, source]
    C --> D[set warmupLockLiftLogged = !lockActive]
    D --> E[evolve: currentGeneration++]
    E --> F{first time<br/>currentGeneration > warmupGenerations<br/>and not yet logged?}
    F -- yes --> G[log: structural lock lifted once]
    F -- no --> H[generation_complete event]
    G --> H
    H --> I[event carries currentGeneration<br/>+ warmupLockActive]
```

## Test Plan

New tests in `test/NEAT/WarmupObservability.ts`:

- `resume log reports primary-seed source while locked` — seed carries both
  tags; asserts the single resume line with `source=primary-seed`, the
  accumulated counter, and `lock active`.
- `resume log reports population source when the seed is tagless` — tagless
  factory seed plus a tagged prior champion in the population; asserts
  `source=population` and the population-sourced counter.
- `no warm-up configured logs nothing` — asserts zero resume/lift lines.
- `buildWarmupEventFields surfaces accumulated counter and lock state` — unit
  test of the helper across not-configured / warming / past-window cases.
- `lock-lift transition logs exactly once per run` — drives `evolve()` past the
  warm-up window and asserts the lift line fires exactly once and not again on
  subsequent generations.
- `generation_complete carries accumulated counter and lock state while
  warming` — end-to-end via `evolveDataSet`; asserts the events expose
  `currentGeneration` and `warmupLockActive === true`.
- `generation_complete omits warm-up fields when warm-up is not configured` —
  asserts both fields are `undefined`.

All existing warm-up / training-event tests continue to pass
(`SeedWarmupAccumulation`, `PhaseTimingFields`, `TrainingEvent`,
`SeedWarmupStructuralLock`, `NeatPopulatePopulation`).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqc4un61-734b76`<!-- vibe-worker-issue-2947 -->