### PR TITLE
Docs audit Phase 0: canonical glossary + documentation style guide (#2957)

### DIFF
--- a/docs/DOC_STYLE.md
+++ b/docs/DOC_STYLE.md
@@ -1,0 +1,81 @@
+# ✍️ NEAT-AI Documentation Style Guide
+
+This short guide codifies the **house style** for NEAT-AI (NeuroEvolution of
+Augmenting Topologies — Artificial Intelligence) documentation. It is the single
+rulebook the documentation audit (Issue #2956) applies to every doc, so each
+per-doc pass enforces the same conventions instead of reinventing them.
+
+Pair it with the [canonical glossary (`GLOSSARY.md`)](GLOSSARY.md): the glossary
+defines the terms; this guide says how to use them.
+
+## 🎯 The rules
+
+Apply every rule below to any doc you write or audit.
+
+1. **Define every acronym on first use, with a link.** The first time a doc uses
+   an acronym, expand it and link to a deeper reference — e.g. "WebAssembly
+   (WASM)" or "Markov Chain Monte Carlo (MCMC)". The
+   [glossary](GLOSSARY.md#-acronyms) is the canonical expansion table; link
+   there or to the primary source.
+2. **Explain each themed term on use; link to the glossary.** House terms
+   (Creature, Discovery, Intelligent Design, Islands, CRISPR, Grafting …) are
+   fun, but a newcomer must never be confused. Give a one-line plain-language
+   gloss and link to the
+   [themed-terms section](GLOSSARY.md#-themed--house-terms).
+3. **Call out NEAT-AI-vs-standard-NEAT and industry differences explicitly.**
+   Wherever NEAT-AI behaves differently from the original 2002 algorithm or from
+   common industry practice, say so in so many words. The
+   [NEAT vs NEAT-AI rule in AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+   is the **one canonical statement** of when to write "NEAT-AI" versus
+   "standard NEAT" — link to it; never restate or contradict it.
+4. **Fact-check claims against both the implementation and external
+   references.** A claim must match what the code actually does _and_ line up
+   with the external/industry reference it cites. **Delete obsolete content
+   outright** — do not archive it inline; stale docs mislead more than missing
+   ones.
+5. **Keep documents small.** Favour several focused, linked sub-documents over
+   one monolith. If a doc grows past a comfortable single-screen-of-scrolling
+   topic, split it and link the parts (see how
+   [`CONFIGURATION_GUIDE.md`](CONFIGURATION_GUIDE.md) fans out into
+   [`config/`](config/)).
+6. **Prefer colour and Mermaid diagrams; always add supporting references.** A
+   picture tells a thousand words — [Mermaid](https://mermaid.js.org/) renders
+   natively on GitHub. Add a diagram wherever it aids understanding, and back
+   every non-obvious claim with a reference or link.
+7. **Use Australian English.** Spell it `colour`, `behaviour`, `organisation`,
+   `favour`, `centre`, `optimise` — in prose, code comments, and diagrams.
+8. **Keep internal/AI-facing docs brief and consistent.** Documents like
+   [AGENTS.md](../AGENTS.md) refer back to the main docs rather than repeating
+   them. One source of truth per fact.
+
+## 🔁 How the foundation docs relate
+
+```mermaid
+flowchart LR
+    Style["DOC_STYLE.md<br/>(how to write)"] --> Doc["Any topic doc"]
+    Glossary["GLOSSARY.md<br/>(terms + acronyms)"] --> Doc
+    Agents["AGENTS.md<br/>(NEAT vs NEAT-AI rule,<br/>invariants)"] --> Glossary
+    Agents --> Style
+    Doc --> Index["docs/README.md<br/>(topic index)"]
+```
+
+## ✅ Per-doc audit checklist
+
+When auditing a doc, confirm each of these before considering it done:
+
+- [ ] Every acronym is expanded on first use and linked.
+- [ ] Every themed term is glossed and links to [`GLOSSARY.md`](GLOSSARY.md).
+- [ ] NEAT-AI-vs-standard-NEAT / industry differences are called out, deferring
+      to the [canonical rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
+- [ ] Every claim is fact-checked against the code and an external reference.
+- [ ] Obsolete content is deleted, not archived inline.
+- [ ] The doc is small and focused; oversized docs are split and linked.
+- [ ] At least one Mermaid diagram where it helps, plus supporting links.
+- [ ] Australian English throughout.
+
+## 🔗 Related reading
+
+- [Glossary (`GLOSSARY.md`)](GLOSSARY.md) — canonical acronyms and themed terms.
+- [AGENTS.md](../AGENTS.md) — contributor conventions and the canonical
+  NEAT-vs-NEAT-AI rule.
+- [docs/README.md](README.md) — the topic-by-topic documentation index.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,135 @@
+# 📖 NEAT-AI Glossary
+
+This is the **canonical glossary** for NEAT-AI (NeuroEvolution of Augmenting
+Topologies — Artificial Intelligence). It is the single source of truth for two
+things:
+
+1. **Acronyms** — every shorthand the project uses, expanded with a
+   deeper-reading link so nobody has to guess what a TLA (Three-Letter Acronym)
+   means.
+2. **Themed / house terms** — the playful vocabulary (Creature, Discovery,
+   CRISPR, Grafting, Islands …) mapped plainly onto the mainstream
+   machine-learning idea behind each one, so the fun never gets in the way of
+   understanding.
+
+> [!IMPORTANT]
+> **NEAT-AI ≠ NEAT.** NEAT-AI began as the original NeuroEvolution of Augmenting
+> Topologies algorithm
+> ([Stanley & Miikkulainen 2002](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf))
+> but has grown well past it. This glossary does **not** restate the rule for
+> when to say "NEAT-AI" versus "standard NEAT" — the
+> [NEAT vs NEAT-AI rule in AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> is the one canonical entry. Read it once; every other doc defers to it.
+
+New here? Start with [`../README.md`](../README.md), then skim this glossary,
+then dip into a [topic guide](README.md). The companion
+[documentation style guide (`DOC_STYLE.md`)](DOC_STYLE.md) explains how these
+conventions are applied across the docs.
+
+## 🗺️ How the vocabulary fits together
+
+```mermaid
+flowchart TD
+    Pop["Population<br/>(many Creatures)"] --> Island["Islands<br/>(isolated sub-populations)"]
+    Island --> Creature["Creature<br/>(one genome / network)"]
+    Creature --> Evo["Evolution loop"]
+    Evo --> Mutate["Mutation<br/>(MCMC acceptance)"]
+    Evo --> Breed["Breeding<br/>(Grafting / crossover)"]
+    Evo --> Disc["Discovery<br/>(error-guided structure)"]
+    Evo --> ID["Intelligent Design<br/>(per-neuron squash search)"]
+    Disc --> Crispr["CRISPR injection<br/>(targeted gene edit)"]
+```
+
+## 🔤 Acronyms
+
+Each acronym is expanded on first use and linked to a deeper reference. When you
+introduce one of these in a doc, expand it the first time and link here or to
+the source.
+
+| Acronym     | Expansion                                                                        | Go deeper                                                                                                                                  |
+| ----------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **NEAT**    | NeuroEvolution of Augmenting Topologies                                          | [Stanley & Miikkulainen 2002](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf)                                                   |
+| **NEAT-AI** | NeuroEvolution of Augmenting Topologies — Artificial Intelligence (this project) | [AGENTS.md terminology](../AGENTS.md#-terminology)                                                                                         |
+| **MCMC**    | Markov Chain Monte Carlo                                                         | [Metropolis–Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)                                                 |
+| **WASM**    | WebAssembly                                                                      | [WebAssembly](https://webassembly.org/)                                                                                                    |
+| **FFI**     | Foreign Function Interface                                                       | [Deno FFI](https://docs.deno.com/runtime/fundamentals/ffi/)                                                                                |
+| **GPU**     | Graphics Processing Unit                                                         | [Graphics processing unit](https://en.wikipedia.org/wiki/Graphics_processing_unit)                                                         |
+| **CPU**     | Central Processing Unit                                                          | [Central processing unit](https://en.wikipedia.org/wiki/Central_processing_unit)                                                           |
+| **RL**      | Reinforcement Learning                                                           | [Reinforcement learning](https://en.wikipedia.org/wiki/Reinforcement_learning); see [REINFORCEMENT_LEARNING.md](REINFORCEMENT_LEARNING.md) |
+| **CRISPR**  | Clustered Regularly Interspaced Short Palindromic Repeats                        | [CRISPR-Cas9 overview](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/)                                 |
+| **ONNX**    | Open Neural Network Exchange                                                     | [onnx.ai](https://onnx.ai/)                                                                                                                |
+| **CNN**     | Convolutional Neural Network                                                     | [Convolutional neural network](https://en.wikipedia.org/wiki/Convolutional_neural_network)                                                 |
+| **RNN**     | Recurrent Neural Network                                                         | [Recurrent neural network](https://en.wikipedia.org/wiki/Recurrent_neural_network)                                                         |
+| **LLM**     | Large Language Model                                                             | [Large language model](https://en.wikipedia.org/wiki/Large_language_model)                                                                 |
+| **JSR**     | JavaScript Registry                                                              | [jsr.io](https://jsr.io/)                                                                                                                  |
+| **UUID**    | Universally Unique Identifier                                                    | [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier); see the neuron UUID invariant in [AGENTS.md](../AGENTS.md)            |
+| **MSE**     | Mean Squared Error                                                               | [Mean squared error](https://en.wikipedia.org/wiki/Mean_squared_error)                                                                     |
+| **DX12**    | DirectX 12 (Windows GPU API)                                                     | [DirectX 12](https://en.wikipedia.org/wiki/DirectX#DirectX_12)                                                                             |
+| **CI**      | Continuous Integration                                                           | [Continuous integration](https://en.wikipedia.org/wiki/Continuous_integration)                                                             |
+
+## 🧬 Themed / house terms
+
+We keep the tone playful, but every nickname maps to a mainstream idea. These
+plain-language definitions live here; the
+[AGENTS.md terminology section](../AGENTS.md#-terminology) is the matching
+contributor-facing reference and stays in lock-step with this table.
+
+- **Creature** — an individual neural network (genome) inside a population. The
+  fundamental unit that NEAT-AI evolves, named in the original
+  [NEAT paper](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf).
+- **Evolution** — the outer optimisation loop: score every Creature, select the
+  fittest, breed and mutate the next generation, repeat. This is classic
+  [evolutionary computation](https://en.wikipedia.org/wiki/Evolutionary_computation),
+  augmented in NEAT-AI with local gradient descent (memetic evolution).
+- **Islands** — isolated sub-populations that evolve in parallel and
+  occasionally exchange Creatures. Borrowed from the
+  [island model](https://en.wikipedia.org/wiki/Island_model) of evolutionary
+  algorithms; it preserves diversity and dodges premature convergence.
+- **Discovery** — error-guided structural evolution. Instead of mutating
+  topology blindly, NEAT-AI uses the Rust FFI (Foreign Function Interface)
+  extension to analyse where a Creature is making errors and propose targeted
+  structural improvements. See [DISCOVERY_GUIDE.md](DISCOVERY_GUIDE.md).
+- **Intelligent Design** — systematically testing different squash (activation)
+  functions for each hidden neuron rather than leaving the choice to chance. See
+  [INTELLIGENT_DESIGN.md](INTELLIGENT_DESIGN.md). (The name is a wink at the
+  [intelligent-design debate](https://en.wikipedia.org/wiki/Intelligent_design);
+  the technique is ordinary hyper-parameter search per neuron.)
+- **CRISPR injection** — a targeted "gene edit" that adds hand-crafted synapses
+  or neurons to a Creature, inspired by the real-world
+  [CRISPR-Cas9](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/)
+  gene-editing technique. See [CRISPR_GUIDE.md](CRISPR_GUIDE.md).
+- **Grafting** — crossover (breeding) between genomes with incompatible shapes,
+  related to the
+  [island-model speciation](https://en.wikipedia.org/wiki/Island_model)
+  strategies used in evolutionary algorithms.
+- **Squash** — our term for the activation function applied to a neuron. See
+  [ACTIVATION_FUNCTIONS.md](ACTIVATION_FUNCTIONS.md).
+- **Memetic evolution** — evolutionary search combined with local gradient
+  descent, the well-studied
+  [memetic algorithm](https://en.wikipedia.org/wiki/Memetic_algorithm).
+- **MCMC acceptance** — applying the
+  [Metropolis–Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)
+  criterion to mutation acceptance: worsening mutations are accepted with a
+  temperature-dependent probability, helping early escape from local optima.
+- **Synthetic synapses** — temporary zero-weight connections added between
+  adjacent topological layers before backpropagation to widen the gradient
+  search space, then pruned. Similar in spirit to
+  [layer densification](https://en.wikipedia.org/wiki/Dense_layer).
+- **Horizontal gene transfer** — subgraph transplantation that copies connected
+  subgraphs between genetically incompatible Creatures, inspired by biological
+  [horizontal gene transfer](https://en.wikipedia.org/wiki/Horizontal_gene_transfer).
+
+> [!TIP]
+> Spotted a fun label in the codebase that is not defined here? Add it to this
+> table **and** to [AGENTS.md](../AGENTS.md#-terminology), with a link to the
+> mainstream term it stands for. The two lists must never drift apart.
+
+## 🔗 Related reading
+
+- [Documentation style guide (`DOC_STYLE.md`)](DOC_STYLE.md) — the rules that
+  govern how these terms are used across the docs.
+- [AGENTS.md](../AGENTS.md) — contributor conventions, the NEAT-vs-NEAT-AI rule,
+  and the project invariants.
+- [docs/README.md](README.md) — the topic-by-topic documentation index.
+- [../COMPARISON.md](../COMPARISON.md) — how NEAT-AI differs from standard NEAT,
+  classical neural networks, and modern LLMs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,11 +38,22 @@ A new reader should follow the docs in this order:
 5. **A topic guide** — each guide assumes the basics from steps 1–3 and focuses
    on a single subsystem.
 
+Two **foundation documents** underpin every other doc — keep them open while
+reading or writing:
+
+- **[GLOSSARY.md](GLOSSARY.md)** — the canonical glossary. Every acronym
+  expanded with a deeper-reading link; every themed term (Creature, Discovery,
+  CRISPR, Grafting, Islands …) explained in plain language.
+- **[DOC_STYLE.md](DOC_STYLE.md)** — the short documentation style guide: the
+  rules (define acronyms, link themed terms, call out NEAT-vs-NEAT-AI
+  differences, fact-check, keep docs small, prefer diagrams) every doc follows.
+
 ## 🗺️ Reading map
 
 ```mermaid
 flowchart LR
     R[../README.md<br/>zero-knowledge entry] --> I[docs/README.md<br/>topic index]
+    I --> Found[Foundation<br/>Glossary + Style guide]
     I --> Compute[Compute / WASM]
     I --> Discovery[Discovery / FFI]
     I --> Perf[Performance]

--- a/docs/archive/pr-summaries/pr-summary-2957.md
+++ b/docs/archive/pr-summaries/pr-summary-2957.md
@@ -1,0 +1,71 @@
+# PR Summary — Issue #2957
+
+## Summary
+
+Establishes the **Phase 0 foundation** for the documentation audit (#2956): one
+canonical glossary and one short documentation style guide, both linked from
+`docs/README.md`, so every later per-doc audit applies the same rules instead of
+reinventing them. Closes #2957.
+
+- **`docs/GLOSSARY.md`** — the canonical glossary. Expands every project acronym
+  (NEAT, MCMC, WASM, FFI, GPU, RL, CRISPR, ONNX, …) with a deeper-reading link,
+  and explains every themed/house term (Creature, Evolution, Islands, Discovery,
+  Intelligent Design, CRISPR, Grafting, …) in plain language mapped to its
+  mainstream machine-learning idea. It defers the `NEAT-AI ≠ NEAT` rule to the
+  canonical entry in `AGENTS.md` rather than restating it — no contradictory
+  copies.
+- **`docs/DOC_STYLE.md`** — the short style guide codifying the audit rules:
+  define acronyms on first use with a link, explain themed terms and link the
+  glossary, call out NEAT-AI-vs-standard-NEAT / industry differences, fact-check
+  against both implementation and references, keep docs small, prefer colour +
+  Mermaid diagrams, Australian English, and keep internal docs brief.
+- **`docs/README.md`** — links both foundation documents from the "Where to
+  start" path and the reading-map diagram.
+
+Both new documents are themselves examples of the house style (acronyms defined,
+links present, a Mermaid diagram each).
+
+## Evidence
+
+This is a documentation + test change with no web interface to screenshot.
+Verification is via the new `test/docs/GlossaryAndStyle.ts` suite and the
+existing docs tests, all passing (`deno test test/docs/*.ts` → 66 passed), plus
+clean `deno fmt --check`, `markdownlint-cli2`, and `cspell` runs.
+
+How the foundation documents relate:
+
+```mermaid
+flowchart LR
+    Style["DOC_STYLE.md<br/>(how to write)"] --> Doc["Any topic doc"]
+    Glossary["GLOSSARY.md<br/>(terms + acronyms)"] --> Doc
+    Agents["AGENTS.md<br/>(NEAT vs NEAT-AI rule,<br/>invariants)"] --> Glossary
+    Agents --> Style
+    Doc --> Index["docs/README.md<br/>(topic index)"]
+```
+
+## Test Plan
+
+Added `test/docs/GlossaryAndStyle.ts` — "what" tests that read the real files
+and assert on outcomes:
+
+- `docs/GLOSSARY.md` exists, is substantive, expands every required acronym,
+  explains every themed term, links the canonical NEAT-vs-NEAT-AI rule in
+  `AGENTS.md`, contains a Mermaid diagram, and has resolvable internal links.
+- `docs/DOC_STYLE.md` exists, is substantive, captures the core house-style
+  rules, links the glossary and the canonical NEAT rule, and has resolvable
+  internal links.
+- `docs/README.md` links both foundation documents.
+
+All new and existing docs tests pass (66 passed, 0 failed).
+
+## Acceptance criteria
+
+- [x] A single canonical glossary exists, linked from `docs/README.md`, covering
+      the acronyms and themed terms (each acronym expanded + linked; each themed
+      term explained).
+- [x] A short documentation style guide exists capturing the bullet rules.
+- [x] No duplicated/contradictory copies of the NEAT-vs-NEAT-AI rule remain;
+      non-canonical docs (glossary, style guide, README, COMPARISON,
+      CONTRIBUTING) link to the canonical `AGENTS.md` entry.
+- [x] Glossary and style guide are themselves examples of the house style
+      (acronyms defined, links present, at least one Mermaid diagram each).

--- a/test/docs/GlossaryAndStyle.ts
+++ b/test/docs/GlossaryAndStyle.ts
@@ -1,0 +1,201 @@
+/**
+ * Issue #2957 — Phase 0 foundation of the documentation audit (#2956).
+ *
+ * Verifies the two foundation documents the rest of the audit references:
+ *
+ *   1. `docs/GLOSSARY.md` — the canonical glossary. Every acronym is
+ *      expanded with a deeper-reading link; every themed/house term is
+ *      explained; the `NEAT-AI ≠ NEAT` rule points back to the canonical
+ *      entry in `AGENTS.md` rather than restating it.
+ *   2. `docs/DOC_STYLE.md` — the short documentation style guide that
+ *      codifies the rules every per-doc audit must apply.
+ *   3. `docs/README.md` links to both foundation documents.
+ *
+ * These are "what" tests: they read the real files and assert on
+ * outcomes (terms present, links resolve, a Mermaid diagram exists), not
+ * on implementation details such as line counts or heading styles.
+ */
+
+import { assert, assertStringIncludes } from "@std/assert";
+import { dirname, fromFileUrl, join, resolve } from "@std/path";
+
+const REPO_ROOT = resolve(fromFileUrl(import.meta.url), "..", "..", "..");
+const DOCS_INDEX = join(REPO_ROOT, "docs", "README.md");
+const GLOSSARY = join(REPO_ROOT, "docs", "GLOSSARY.md");
+const DOC_STYLE = join(REPO_ROOT, "docs", "DOC_STYLE.md");
+
+// Acronyms that must be expanded in the glossary. Matched as substrings;
+// the expansion may appear as "WebAssembly (WASM)" or the linked phrase.
+const ACRONYM_EXPANSIONS: ReadonlyArray<
+  { acronym: string; expansion: string }
+> = [
+  { acronym: "NEAT", expansion: "NeuroEvolution of Augmenting Topologies" },
+  { acronym: "MCMC", expansion: "Markov Chain Monte Carlo" },
+  { acronym: "WASM", expansion: "WebAssembly" },
+  { acronym: "GPU", expansion: "Graphics Processing Unit" },
+  { acronym: "RL", expansion: "Reinforcement Learning" },
+  { acronym: "FFI", expansion: "Foreign Function Interface" },
+  {
+    acronym: "CRISPR",
+    expansion: "Clustered Regularly Interspaced Short Palindromic Repeats",
+  },
+];
+
+// Themed / house terms that must be explained in the glossary.
+const THEMED_TERMS: ReadonlyArray<string> = [
+  "Creature",
+  "Intelligent Design",
+  "Evolution",
+  "Islands",
+  "Discovery",
+  "CRISPR",
+  "Grafting",
+];
+
+/** Collect resolvable relative-link targets and assert each exists. */
+async function assertLinksResolve(file: string): Promise<void> {
+  const content = await Deno.readTextFile(file);
+  const linkRe = /\[[^\]]+\]\(([^)]+)\)/g;
+  const baseDir = dirname(file);
+  const targets: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = linkRe.exec(content)) !== null) {
+    const target = match[1];
+    if (target.startsWith("http://") || target.startsWith("https://")) continue;
+    if (target.startsWith("#")) continue;
+    const [pathPart] = target.split("#");
+    if (!pathPart) continue;
+    targets.push(pathPart);
+  }
+  const results = await Promise.all(
+    targets.map(async (pathPart) => {
+      const resolved = resolve(baseDir, pathPart);
+      try {
+        await Deno.stat(resolved);
+        return null;
+      } catch {
+        return `broken link: ${pathPart} (resolved to ${resolved})`;
+      }
+    }),
+  );
+  const failures = results.filter((r): r is string => r !== null);
+  assert(
+    failures.length === 0,
+    `${file} has broken internal links:\n${failures.join("\n")}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// docs/GLOSSARY.md — canonical glossary
+// ---------------------------------------------------------------------------
+
+Deno.test("docs/GLOSSARY.md exists and is substantive", async () => {
+  const content = await Deno.readTextFile(GLOSSARY);
+  assert(content.length > 800, "docs/GLOSSARY.md must be substantive");
+});
+
+Deno.test("docs/GLOSSARY.md expands every required acronym", async () => {
+  const raw = await Deno.readTextFile(GLOSSARY);
+  const normalised = raw.replace(/^\s*>\s?/gm, "").replace(/\s+/g, " ");
+  for (const { acronym, expansion } of ACRONYM_EXPANSIONS) {
+    assert(
+      normalised.includes(expansion),
+      `docs/GLOSSARY.md must expand "${acronym}" to "${expansion}"`,
+    );
+  }
+});
+
+Deno.test("docs/GLOSSARY.md explains every themed term", async () => {
+  const content = await Deno.readTextFile(GLOSSARY);
+  for (const term of THEMED_TERMS) {
+    assertStringIncludes(
+      content,
+      term,
+      `docs/GLOSSARY.md must explain the themed term "${term}"`,
+    );
+  }
+});
+
+Deno.test("docs/GLOSSARY.md defers the NEAT-vs-NEAT-AI rule to AGENTS.md", async () => {
+  const content = await Deno.readTextFile(GLOSSARY);
+  assertStringIncludes(
+    content,
+    "../AGENTS.md#-neat-vs-neat-ai--which-term-to-use",
+    "docs/GLOSSARY.md must link to the canonical NEAT-vs-NEAT-AI rule in AGENTS.md",
+  );
+});
+
+Deno.test("docs/GLOSSARY.md includes at least one Mermaid diagram", async () => {
+  const content = await Deno.readTextFile(GLOSSARY);
+  assertStringIncludes(
+    content,
+    "```mermaid",
+    "docs/GLOSSARY.md must contain at least one fenced ```mermaid block",
+  );
+});
+
+Deno.test("docs/GLOSSARY.md internal links resolve", async () => {
+  await assertLinksResolve(GLOSSARY);
+});
+
+// ---------------------------------------------------------------------------
+// docs/DOC_STYLE.md — documentation style guide
+// ---------------------------------------------------------------------------
+
+Deno.test("docs/DOC_STYLE.md exists and is substantive", async () => {
+  const content = await Deno.readTextFile(DOC_STYLE);
+  assert(content.length > 800, "docs/DOC_STYLE.md must be substantive");
+});
+
+Deno.test("docs/DOC_STYLE.md captures the core house-style rules", async () => {
+  const raw = await Deno.readTextFile(DOC_STYLE);
+  const lower = raw.toLowerCase();
+  const rules = [
+    "acronym", // define every acronym on first use
+    "glossary", // link themed terms to the glossary
+    "fact-check", // fact-check against implementation + references
+    "mermaid", // prefer colour + Mermaid diagrams
+  ];
+  for (const rule of rules) {
+    assert(
+      lower.includes(rule),
+      `docs/DOC_STYLE.md must mention the "${rule}" rule`,
+    );
+  }
+});
+
+Deno.test("docs/DOC_STYLE.md links to the glossary and the NEAT rule", async () => {
+  const content = await Deno.readTextFile(DOC_STYLE);
+  assertStringIncludes(
+    content,
+    "GLOSSARY.md",
+    "docs/DOC_STYLE.md must link to the glossary",
+  );
+  assertStringIncludes(
+    content,
+    "../AGENTS.md#-neat-vs-neat-ai--which-term-to-use",
+    "docs/DOC_STYLE.md must link to the canonical NEAT-vs-NEAT-AI rule",
+  );
+});
+
+Deno.test("docs/DOC_STYLE.md internal links resolve", async () => {
+  await assertLinksResolve(DOC_STYLE);
+});
+
+// ---------------------------------------------------------------------------
+// docs/README.md — links to the foundation documents
+// ---------------------------------------------------------------------------
+
+Deno.test("docs/README.md links to the glossary and style guide", async () => {
+  const content = await Deno.readTextFile(DOCS_INDEX);
+  assertStringIncludes(
+    content,
+    "GLOSSARY.md",
+    "docs/README.md must link to the canonical glossary",
+  );
+  assertStringIncludes(
+    content,
+    "DOC_STYLE.md",
+    "docs/README.md must link to the documentation style guide",
+  );
+});


### PR DESCRIPTION
# PR Summary — Issue #2957

## Summary

Establishes the **Phase 0 foundation** for the documentation audit (#2956): one
canonical glossary and one short documentation style guide, both linked from
`docs/README.md`, so every later per-doc audit applies the same rules instead of
reinventing them. Closes #2957.

- **`docs/GLOSSARY.md`** — the canonical glossary. Expands every project acronym
  (NEAT, MCMC, WASM, FFI, GPU, RL, CRISPR, ONNX, …) with a deeper-reading link,
  and explains every themed/house term (Creature, Evolution, Islands, Discovery,
  Intelligent Design, CRISPR, Grafting, …) in plain language mapped to its
  mainstream machine-learning idea. It defers the `NEAT-AI ≠ NEAT` rule to the
  canonical entry in `AGENTS.md` rather than restating it — no contradictory
  copies.
- **`docs/DOC_STYLE.md`** — the short style guide codifying the audit rules:
  define acronyms on first use with a link, explain themed terms and link the
  glossary, call out NEAT-AI-vs-standard-NEAT / industry differences, fact-check
  against both implementation and references, keep docs small, prefer colour +
  Mermaid diagrams, Australian English, and keep internal docs brief.
- **`docs/README.md`** — links both foundation documents from the "Where to
  start" path and the reading-map diagram.

Both new documents are themselves examples of the house style (acronyms defined,
links present, a Mermaid diagram each).

## Evidence

This is a documentation + test change with no web interface to screenshot.
Verification is via the new `test/docs/GlossaryAndStyle.ts` suite and the
existing docs tests, all passing (`deno test test/docs/*.ts` → 66 passed), plus
clean `deno fmt --check`, `markdownlint-cli2`, and `cspell` runs.

How the foundation documents relate:

```mermaid
flowchart LR
    Style["DOC_STYLE.md<br/>(how to write)"] --> Doc["Any topic doc"]
    Glossary["GLOSSARY.md<br/>(terms + acronyms)"] --> Doc
    Agents["AGENTS.md<br/>(NEAT vs NEAT-AI rule,<br/>invariants)"] --> Glossary
    Agents --> Style
    Doc --> Index["docs/README.md<br/>(topic index)"]
```

## Test Plan

Added `test/docs/GlossaryAndStyle.ts` — "what" tests that read the real files
and assert on outcomes:

- `docs/GLOSSARY.md` exists, is substantive, expands every required acronym,
  explains every themed term, links the canonical NEAT-vs-NEAT-AI rule in
  `AGENTS.md`, contains a Mermaid diagram, and has resolvable internal links.
- `docs/DOC_STYLE.md` exists, is substantive, captures the core house-style
  rules, links the glossary and the canonical NEAT rule, and has resolvable
  internal links.
- `docs/README.md` links both foundation documents.

All new and existing docs tests pass (66 passed, 0 failed).

## Acceptance criteria

- [x] A single canonical glossary exists, linked from `docs/README.md`, covering
      the acronyms and themed terms (each acronym expanded + linked; each themed
      term explained).
- [x] A short documentation style guide exists capturing the bullet rules.
- [x] No duplicated/contradictory copies of the NEAT-vs-NEAT-AI rule remain;
      non-canonical docs (glossary, style guide, README, COMPARISON,
      CONTRIBUTING) link to the canonical `AGENTS.md` entry.
- [x] Glossary and style guide are themselves examples of the house style
      (acronyms defined, links present, at least one Mermaid diagram each).



## Milestone
This PR is part of the **clean up docs** milestone and targets the `milestone/clean-up-docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqfrmv90-a6073b`<!-- vibe-worker-issue-2957 -->