### PR TITLE
Docs audit: README.md entry point — runnable Quick Start + glossary link (#2959)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ New here? Skim this section first; every topic guide is one link away.
   how to bump the pinned NEAT-AI-core revision.
 - **[AGENTS.md](./AGENTS.md)** — terminology and coding conventions for human
   and AI contributors.
+- **[Glossary](./docs/GLOSSARY.md)** — the canonical reference for every acronym
+  and house term used here (Creature, Discovery, Grafting, CRISPR, Intelligent
+  Design, MCMC, FFI, WASM, …). When a themed word below is unfamiliar, this is
+  the place to look it up.
 - **[COMPARISON.md](./COMPARISON.md)** — how NEAT-AI compares to other AI
   approaches (and to standard NEAT).
 - **Topic guides** — quick jumps to the most-used docs:
@@ -261,8 +265,36 @@ ONNX export — are extensions beyond the standard NEAT algorithm. See
 
 ## 🚀 Quick Start
 
+Install nothing — NEAT-AI is published to the
+[JavaScript Registry (JSR)](https://jsr.io/@stsoftware/neat-ai) and the
+WebAssembly (WASM) backend initialises itself on first use. Create a
+**Creature** (a NEAT-AI genome — one neural network), run a forward pass, then
+round-trip it through JSON:
+
 ```typescript
-// Single discovery iteration
+import { Creature } from "@stsoftware/neat-ai";
+
+// A Creature with 2 inputs, 1 output, and one hidden layer of 3 neurons.
+const creature = new Creature(2, 1, { layers: [{ count: 3 }] });
+
+// activate() runs a single forward pass through the WASM backend.
+const output = creature.activate(new Float32Array([0.5, 0.3]));
+console.log(output); // Float32Array(1) [ … ]
+
+// Serialise and restore — UUID-stable, safe to share between machines.
+const json = creature.exportJSON();
+const restored = Creature.fromJSON(json);
+```
+
+Run it with `deno run -A example.ts` (the `-A` permission lets Deno fetch the
+WASM bytes from JSR on first run).
+
+Once you have training data, `evolveDataSet()` evolves a population toward it.
+The optional error-guided **Discovery** step then proposes structural
+improvements — one iteration looks like:
+
+```typescript
+// Requires the optional NEAT-AI-Discovery Rust extension (see note below).
 const result = await creature.discoveryDir(dataDir, {
   discoveryRecordTimeOutMinutes: 1,
   discoveryAnalysisTimeoutMinutes: 10,
@@ -270,9 +302,14 @@ const result = await creature.discoveryDir(dataDir, {
 
 if (result.improvement) {
   console.log(`Found ${result.improvement.changeType} improvement!`);
-  // Use improved creature for next iteration
+  // Use the improved creature for the next iteration.
 }
 ```
+
+`discoveryDir()` needs the optional
+[NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) Rust
+extension. Without it the discovery phase is skipped — `activate()`, training,
+and evolution still run end-to-end in WASM.
 
 > [!TIP]
 > For distributed, multi-machine workflows that accumulate small improvements
@@ -282,7 +319,7 @@ if (result.improvement) {
 ## 💻 Usage
 
 This project is designed to be used in a DenoJS environment. Please refer to the
-[DenoJS documentation](https://deno.land/manual) for setup and usage
+[Deno runtime manual](https://docs.deno.com/runtime/manual/) for setup and usage
 instructions.
 
 ## 📚 Documentation

--- a/docs/archive/pr-summaries/pr-summary-2959.md
+++ b/docs/archive/pr-summaries/pr-summary-2959.md
@@ -1,0 +1,72 @@
+# Docs audit: README.md (top-level entry point)
+
+## Summary
+
+Phase 1 of the documentation audit (#2956): fact-checked and refreshed the
+top-level `README.md` so the project's front door is accurate, runnable, and
+links out to the glossary. Closes #2959.
+
+Changes:
+
+- **Quick Start now runs as written.** The old snippet was a bare
+  `creature.discoveryDir(...)` fragment with no import, no `creature`, and no
+  `dataDir` — it could not run, and `discoveryDir()` silently needs the optional
+  Rust extension. Replaced it with a complete, copy-paste-runnable example
+  (`import { Creature }` from the JSR package → `new Creature(2, 1, …)` →
+  `activate()` → `exportJSON()`/`fromJSON()` round-trip) that runs purely in
+  WASM. The discovery snippet is kept as a follow-on step and now explicitly
+  flagged as requiring the optional
+  [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery)
+  extension. The example was verified against the current `mod.ts` (output
+  `Float32Array(1)`, clone restored).
+- **Links onward to the glossary.** Added a **Glossary**
+  ([`docs/GLOSSARY.md`](../../GLOSSARY.md)) entry to the Docs map so unfamiliar
+  house terms (Creature, Discovery, Grafting, CRISPR, Intelligent Design, MCMC,
+  FFI, WASM) resolve to their canonical definitions — satisfying the #2956
+  house-style "link to the glossary" rule.
+- **Fixed a stale link.** `https://deno.land/manual` (302-redirects) → the
+  canonical `https://docs.deno.com/runtime/manual/`.
+
+Verified during the audit (no change needed): every linked doc resolves
+(`docs/README.md`, all topic guides, `SECURITY.md`, `CHANGELOG.md`, etc.); the
+`discoveryDir()` signature and `result.improvement.changeType` shape match
+`src/Creature.ts` / `src/discovery/DiscoveryRunnerTypes.ts`; the NEAT vs NEAT-AI
+distinction, acronym-on-first-use, and the existing Mermaid diagrams (high-level
+architecture, dependency graph, random-immigrants flow) already meet the
+acceptance criteria.
+
+## Acceptance criteria
+
+- [x] Every feature/claim verified against current code; stale link removed.
+- [x] The quick-start / working example runs as written (verified against
+      `mod.ts`).
+- [x] Acronyms defined on first use; themed terms now link to the glossary;
+      NEAT-vs-NEAT-AI distinction explicit (`> [!IMPORTANT]` callout).
+- [x] Mermaid diagrams present (architecture, dependency graph, random
+      immigrants).
+- [x] All internal links resolve; README links onward to `docs/README.md` and
+      the glossary.
+
+## Evidence
+
+Documentation-only change — no web UI to screenshot. The Quick Start example was
+executed against the local build:
+
+```text
+[neat-ai] running version 5.5.3 (local)
+output: Float32Array(1) [ 0.060647428035736084 ]
+clone neurons: 6
+```
+
+Quality gates run for this docs change:
+
+- `deno fmt --check README.md` → clean.
+- `markdownlint-cli2 README.md` → 0 errors.
+
+## Test Plan
+
+No code changed, so no unit tests were added. Validation was:
+
+- Ran the new Quick Start example end-to-end against `mod.ts` (output above).
+- Confirmed all README internal doc links resolve on disk.
+- `deno fmt --check` and `markdownlint-cli2` both pass on the edited README.


### PR DESCRIPTION
# Docs audit: README.md (top-level entry point)

## Summary

Phase 1 of the documentation audit (#2956): fact-checked and refreshed the
top-level `README.md` so the project's front door is accurate, runnable, and
links out to the glossary. Closes #2959.

Changes:

- **Quick Start now runs as written.** The old snippet was a bare
  `creature.discoveryDir(...)` fragment with no import, no `creature`, and no
  `dataDir` — it could not run, and `discoveryDir()` silently needs the optional
  Rust extension. Replaced it with a complete, copy-paste-runnable example
  (`import { Creature }` from the JSR package → `new Creature(2, 1, …)` →
  `activate()` → `exportJSON()`/`fromJSON()` round-trip) that runs purely in
  WASM. The discovery snippet is kept as a follow-on step and now explicitly
  flagged as requiring the optional
  [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery)
  extension. The example was verified against the current `mod.ts` (output
  `Float32Array(1)`, clone restored).
- **Links onward to the glossary.** Added a **Glossary**
  ([`docs/GLOSSARY.md`](../../GLOSSARY.md)) entry to the Docs map so unfamiliar
  house terms (Creature, Discovery, Grafting, CRISPR, Intelligent Design, MCMC,
  FFI, WASM) resolve to their canonical definitions — satisfying the #2956
  house-style "link to the glossary" rule.
- **Fixed a stale link.** `https://deno.land/manual` (302-redirects) → the
  canonical `https://docs.deno.com/runtime/manual/`.

Verified during the audit (no change needed): every linked doc resolves
(`docs/README.md`, all topic guides, `SECURITY.md`, `CHANGELOG.md`, etc.); the
`discoveryDir()` signature and `result.improvement.changeType` shape match
`src/Creature.ts` / `src/discovery/DiscoveryRunnerTypes.ts`; the NEAT vs NEAT-AI
distinction, acronym-on-first-use, and the existing Mermaid diagrams (high-level
architecture, dependency graph, random-immigrants flow) already meet the
acceptance criteria.

## Acceptance criteria

- [x] Every feature/claim verified against current code; stale link removed.
- [x] The quick-start / working example runs as written (verified against
      `mod.ts`).
- [x] Acronyms defined on first use; themed terms now link to the glossary;
      NEAT-vs-NEAT-AI distinction explicit (`> [!IMPORTANT]` callout).
- [x] Mermaid diagrams present (architecture, dependency graph, random
      immigrants).
- [x] All internal links resolve; README links onward to `docs/README.md` and
      the glossary.

## Evidence

Documentation-only change — no web UI to screenshot. The Quick Start example was
executed against the local build:

```text
[neat-ai] running version 5.5.3 (local)
output: Float32Array(1) [ 0.060647428035736084 ]
clone neurons: 6
```

Quality gates run for this docs change:

- `deno fmt --check README.md` → clean.
- `markdownlint-cli2 README.md` → 0 errors.

## Test Plan

No code changed, so no unit tests were added. Validation was:

- Ran the new Quick Start example end-to-end against `mod.ts` (output above).
- Confirmed all README internal doc links resolve on disk.
- `deno fmt --check` and `markdownlint-cli2` both pass on the edited README.



## Milestone
This PR is part of the **clean up docs** milestone and targets the `milestone/clean-up-docs` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqftj3rw-80191d`<!-- vibe-worker-issue-2959 -->