### PR TITLE
Docs: audit core-concept & themed guides (Phase 2) (#2963)

### DIFF
--- a/docs/ACTIVATION_FUNCTIONS.md
+++ b/docs/ACTIVATION_FUNCTIONS.md
@@ -38,8 +38,13 @@ introduce non-linearity, enabling the network to learn complex patterns.
 
 In NEAT-AI, each neuron can have its own activation function. This is more
 flexible than traditional neural networks, where all neurons in a layer
-typically share the same function. NEAT-AI's topology evolution can discover
-which activation works best for each neuron's role in the network.
+typically share the same function — and it also differs from **standard NEAT**,
+which evolves activation functions only by random mutation. NEAT-AI's topology
+evolution (plus [Intelligent Design](./INTELLIGENT_DESIGN.md)) can discover
+which activation works best for each neuron's role in the network. For the
+convention on flagging NEAT-AI-vs-standard differences, see the
+[NEAT-vs-NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use); the
+[squash](GLOSSARY.md#-themed--house-terms) term is defined in the glossary.
 
 ### 📖 Key Terms
 

--- a/docs/BACKPROP_ELASTICITY.md
+++ b/docs/BACKPROP_ELASTICITY.md
@@ -11,6 +11,17 @@
 > (Rectified Linear Unit), **TANH** (hyperbolic tangent), **MCMC** (Markov-chain
 > Monte Carlo).
 
+<!-- -->
+
+> [!NOTE]
+> **NEAT-AI vs standard backpropagation.** Textbook backpropagation applies the
+> chain rule uniformly to every weight. NEAT-AI's elastic variant is a
+> NEAT-AI-specific departure: it solves for a target pre-squash value and
+> distributes the required change by a minimum-change, saturation-aware
+> heuristic. For the project-wide convention on flagging such differences, see
+> the [NEAT-vs-NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use);
+> [squash](GLOSSARY.md#-themed--house-terms) is defined in the glossary.
+
 ## 🔗 Sibling docs in the **Compute / WASM** cluster
 
 - [ACTIVATION_FUNCTIONS.md](./ACTIVATION_FUNCTIONS.md) — squash catalogue and

--- a/docs/CRISPR_GUIDE.md
+++ b/docs/CRISPR_GUIDE.md
@@ -12,10 +12,21 @@
 > surface is summarised in [`docs/api/CREATURE.md`](api/CREATURE.md#-crispr).
 
 This guide complements that API summary with the conventions and gotchas that
-catch out new authors. For the project-wide vocabulary that places CRISPR
-alongside Grafting, Discovery, and Intelligent Design, see
-[`AGENTS.md`](../AGENTS.md#-terminology); the documentation index is in
+catch out new authors. For the project-wide vocabulary that places
+[CRISPR](GLOSSARY.md#-themed--house-terms) alongside
+[Grafting](GLOSSARY.md#-themed--house-terms),
+[Discovery](GLOSSARY.md#-themed--house-terms), and
+[Intelligent Design](GLOSSARY.md#-themed--house-terms), see the
+[glossary](GLOSSARY.md); the documentation index is in
 [`docs/README.md`](README.md).
+
+> [!NOTE]
+> **NEAT-AI vs standard NEAT.** Standard NEAT has no notion of hand-crafted gene
+> edits — topology only ever changes through random add-node / add-connection
+> mutation and crossover. CRISPR is a NEAT-AI-specific tool for **deliberate**,
+> author-driven structural edits that preserve neuron UUIDs (the project's
+> identity invariant). See the
+> [NEAT-vs-NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
 
 ## 🧪 What a CRISPR injection looks like
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -119,6 +119,11 @@ NEAT-AI) plus a few codebase-specific terms.
 - **Horizontal gene transfer** — subgraph transplantation that copies connected
   subgraphs between genetically incompatible Creatures, inspired by biological
   [horizontal gene transfer](https://en.wikipedia.org/wiki/Horizontal_gene_transfer).
+- **Novelty search** — optional selection that rewards _behavioural_ diversity
+  (what a Creature does on a probe set) rather than raw fitness, to escape
+  deceptive landscapes. Standard technique from
+  [Lehman & Stanley 2011](https://doi.org/10.1162/EVCO_a_00025); **OFF by
+  default** in NEAT-AI. See [NOVELTY_SEARCH.md](NOVELTY_SEARCH.md).
 
 > [!TIP]
 > Spotted a fun label in the codebase that is not defined here? Add it to this

--- a/docs/INTELLIGENT_DESIGN.md
+++ b/docs/INTELLIGENT_DESIGN.md
@@ -1,14 +1,26 @@
 # 🧠 Intelligent Design
 
-> **Intelligent Design** in NEAT-AI is the systematic per-neuron search over
-> squash (activation) functions. For each hidden neuron, it tries the candidate
-> squash, scores the modified creature, and keeps the substitution if it
-> improves fitness. Successful substitutions are persisted as **tacit
-> knowledge** so future runs can replay them without re-discovering them. The
-> implementation lives in
-> [`src/intelligentDesign/`](../src/intelligentDesign/mod.ts); the project-wide
-> vocabulary is in [`AGENTS.md`](../AGENTS.md#-terminology) and the doc index is
-> [`docs/README.md`](README.md).
+> **[Intelligent Design](GLOSSARY.md#-themed--house-terms)** in NEAT-AI is the
+> systematic per-neuron search over [squash](GLOSSARY.md#-themed--house-terms)
+> (activation) functions. For each hidden neuron, it tries the candidate squash,
+> scores the modified creature, and keeps the substitution if it improves
+> fitness. Successful substitutions are persisted as **tacit knowledge** so
+> future runs can replay them without re-discovering them. The implementation
+> lives in [`src/intelligentDesign/`](../src/intelligentDesign/mod.ts); the
+> themed vocabulary is defined in the [glossary](GLOSSARY.md) and the doc index
+> is [`docs/README.md`](README.md).
+
+<!-- -->
+
+> [!NOTE]
+> **NEAT-AI vs standard NEAT.** Standard NEAT mutates activation functions
+> _randomly_ as part of topology mutation. Intelligent Design is a NEAT-AI
+> extension: an exhaustive, per-neuron hyper-parameter search whose results are
+> cached and shared. The name is a wink at the
+> [intelligent-design debate](https://en.wikipedia.org/wiki/Intelligent_design),
+> not a claim about the technique. See the
+> [NEAT-vs-NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) for
+> the project-wide convention.
 
 <!-- -->
 

--- a/docs/NOVELTY_SEARCH.md
+++ b/docs/NOVELTY_SEARCH.md
@@ -1,6 +1,23 @@
-# Novelty (Behavioural-Diversity) Selection
+# 🧭 Novelty (Behavioural-Diversity) Selection
 
-> Issue #2932 — escape deceptive landscapes by rewarding behavioural novelty.
+> **Novelty search** ([glossary](GLOSSARY.md#-themed--house-terms)) is optional
+> selection that rewards what a [Creature](GLOSSARY.md#-themed--house-terms)
+> _does_ — its behaviour on a probe set — rather than its raw fitness, to escape
+> deceptive landscapes. The mechanism is **OFF by default** (Issue #2932); when
+> disabled, ranking and selection are exactly as before. Implementation:
+> [`src/config/NoveltyConfig.ts`](../src/config/NoveltyConfig.ts).
+>
+> Acronyms used here: **kNN** (k-Nearest Neighbours), **FIFO**
+> (First-In-First-Out), **i.i.d.** (independent and identically distributed).
+
+## 🔗 Foundation docs
+
+- [GLOSSARY.md](GLOSSARY.md) — canonical terms (Creature, novelty search,
+  Islands).
+- [DOC_STYLE.md](DOC_STYLE.md) — the house style this guide follows.
+- [docs/README.md](README.md) — full topic index.
+
+## 🌍 The problem: deceptive landscapes
 
 On **deceptive** problems, pure-fitness selection drives the population into a
 local optimum where fitness stops improving and the effective pace of evolution
@@ -9,13 +26,23 @@ collapses. **Novelty search**
 behavioural diversity rather than — or blended with — raw fitness, and is a
 well-established accelerant for escaping deception.
 
-NEAT-AI's existing diversity mechanisms (speciation, fitness sharing,
-compatibility gating) maintain **structural** diversity only. Novelty selection
-adds **behavioural** diversity: it compares what creatures _do_, not how they
-are wired.
+## 🆚 NEAT-AI vs the textbook
 
-The mechanism is **OFF by default**. When disabled, ranking and selection are
-exactly as before.
+Novelty search is a **standard** evolutionary-computation technique, not a
+NEAT-AI invention — the algorithm below is the
+[Lehman & Stanley](https://doi.org/10.1162/EVCO_a_00025) formulation (behaviour
+descriptor → kNN distance to population + archive → blend with fitness). What is
+**NEAT-AI-specific** is how it slots into the existing machinery:
+
+- NEAT-AI's prior diversity mechanisms
+  ([Islands](GLOSSARY.md#-themed--house-terms), speciation, fitness sharing,
+  compatibility gating) maintain **structural** diversity only — they compare
+  how Creatures are _wired_. Novelty selection adds **behavioural** diversity:
+  it compares what Creatures _do_.
+- It is **OFF by default**, layered on the standard NEAT-AI fitness ranking as
+  an opt-in blend rather than replacing it. For the project-wide convention on
+  when a behaviour is "NEAT-AI" versus "standard NEAT", see the
+  [NEAT-vs-NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
 
 ## How it works
 
@@ -105,3 +132,14 @@ The acceptance test
 [`test/NEAT/NoveltySearchDeceptive.ts`](../test/NEAT/NoveltySearchDeceptive.ts)
 asserts novelty escapes the trap in strictly fewer generations than
 fitness-only.
+
+## 🔗 Related
+
+- [`src/config/NoveltyConfig.ts`](../src/config/NoveltyConfig.ts) —
+  configuration shape and defaults (matched by the table above).
+- [GLOSSARY.md](GLOSSARY.md#-themed--house-terms) — the canonical novelty-search
+  and Islands definitions.
+- [Lehman & Stanley, 2011](https://doi.org/10.1162/EVCO_a_00025) — the original
+  novelty-search paper.
+- [`README.md`](../README.md) and [`docs/README.md`](README.md) — entry point
+  and topic index.

--- a/docs/REINFORCEMENT_LEARNING.md
+++ b/docs/REINFORCEMENT_LEARNING.md
@@ -359,4 +359,8 @@ in [`event-driven-evolution.md`](event-driven-evolution.md).
   [`event-driven-evolution.md`](event-driven-evolution.md).
 
 For the project-wide vocabulary (Creature, Discovery, CRISPR, Grafting, MCMC),
-see [`AGENTS.md`](../AGENTS.md#-terminology).
+see the [glossary](GLOSSARY.md#-themed--house-terms). For where NEAT-AI sits
+relative to standard NEAT and industry RL, see the comparison table above and
+the [NEAT-vs-NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
+**RL** throughout this guide is
+[Reinforcement Learning](https://en.wikipedia.org/wiki/Reinforcement_learning).

--- a/docs/archive/pr-summaries/pr-summary-2963.md
+++ b/docs/archive/pr-summaries/pr-summary-2963.md
@@ -1,0 +1,70 @@
+# PR Summary — Docs audit Phase 2: core-concept & themed guides (#2963)
+
+## Summary
+
+Phase 2 of the documentation audit milestone (#2956): audit the eight
+deep/themed guides — the docs richest in themed vocabulary (Intelligent Design,
+CRISPR, DNA, Evolution) and NEAT-AI-specific algorithm choices — against the
+house style in [`DOC_STYLE.md`](../../DOC_STYLE.md). Each guide now links its
+themed terms to the canonical [`GLOSSARY.md`](../../GLOSSARY.md), expands
+acronyms on first use, and makes NEAT-AI-vs-standard-NEAT differences explicit
+by deferring to the one canonical
+[NEAT-vs-NEAT-AI rule](../../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
+
+Every algorithm claim was fact-checked against the implementation. The one
+genuine accuracy gap found — the `evolveRL` RFC describing a contract that
+diverged from the shipped `EpisodeAdapter` — is now flagged with a pointer to
+the accurate, runnable contract.
+
+**Closes #2963.**
+
+### What changed per guide
+
+| Guide                             | Change                                                                                                                                                                                                                                                           |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NOVELTY_SEARCH.md`               | Foundation-doc links; acronym table (kNN, FIFO, i.i.d.); explicit "standard technique vs NEAT-AI integration" section; Related footer. Defaults verified against `src/config/NoveltyConfig.ts`.                                                                  |
+| `event-driven-evolution.md`       | `> [!IMPORTANT]` note flagging it as a **design RFC**, pointing to the shipped `EpisodeAdapter` contract (`observationLength` getter, `decodeAction`, `reset → {observation, state}`, `step(state, action)`) — fact-checked vs `src/creature/EpisodeAdapter.ts`. |
+| `INTELLIGENT_DESIGN.md`           | Glossary links for Intelligent Design / squash; NEAT-AI-vs-standard NOTE. Tier lists verified against `src/intelligentDesign/AlternativeSquashes.ts`.                                                                                                            |
+| `CRISPR_GUIDE.md`                 | Glossary links (CRISPR, Grafting, Discovery, Intelligent Design); NEAT-AI-vs-standard NOTE.                                                                                                                                                                      |
+| `BACKPROP_ELASTICITY.md`          | NEAT-AI-vs-standard-backprop NOTE; glossary link for squash.                                                                                                                                                                                                     |
+| `ACTIVATION_FUNCTIONS.md`         | Made the standard-NEAT difference explicit; glossary link for squash; defer to the NEAT-vs rule.                                                                                                                                                                 |
+| `REINFORCEMENT_LEARNING.md`       | Glossary link; RL expansion; pointer to the NEAT-vs rule (comparison table already covered NEAT-AI-vs-industry).                                                                                                                                                 |
+| `dna-sharing-bake-off-results.md` | Expand MSE on first use; glossary links (Islands, DNA, horizontal gene transfer); NEAT-AI-vs-standard NOTE. `recommendedDnaSharingStrategy` verified against `src/transfer/mod.ts`.                                                                              |
+| `GLOSSARY.md`                     | New **Novelty search** themed-term entry so the guide can link to it.                                                                                                                                                                                            |
+
+### Fact-checks performed (doc claim ↔ code)
+
+```mermaid
+flowchart LR
+    A[Guide claim] --> B{Matches code?}
+    B -->|Intelligent Design tiers| C[AlternativeSquashes.ts ✓]
+    B -->|Novelty defaults| D[NoveltyConfig.ts ✓]
+    B -->|DNA-sharing winner| E[transfer/mod.ts ✓]
+    B -->|evolveRL adapter shape| F[EpisodeAdapter.ts — RFC diverged → noted]
+```
+
+## Evidence
+
+Documentation-only change; no web UI to screenshot. Verified via the repo's docs
+test suite and markdown tooling:
+
+- `deno test test/docs/DocsIndex.ts test/docs/JekyllLiquidSafety.ts test/docs/GlossaryAndStyle.ts`
+  → **28 passed / 0 failed** (internal links resolve; no unescaped Liquid;
+  glossary + style invariants hold).
+- `markdownlint-cli2` over all nine touched files → **0 errors**.
+- `./quality.sh --skip-tests --skip-discovery --skip-wasm` → **EXIT 0**
+  (`deno fmt`, `deno lint`, bash check, `deno check` all pass).
+
+## Test Plan
+
+- Ran `test/docs/DocsIndex.ts`, `test/docs/JekyllLiquidSafety.ts`,
+  `test/docs/GlossaryAndStyle.ts` (the docs-invariant suite that guards
+  internal-link resolution, Jekyll/Liquid safety, and glossary/style rules).
+- Ran `test/scripts/MarkdownLintWorkflow.ts` (8 passed).
+- Confirmed every new file reference and heading anchor resolves
+  (`GLOSSARY.md#-themed--house-terms`,
+  `AGENTS.md#-neat-vs-neat-ai--which-term-to-use`, the `evolveRL` anchors,
+  `src/config/NoveltyConfig.ts`, `src/creature/EpisodeAdapter.ts`).
+
+No source code changed, so no new unit tests were required; the docs-invariant
+tests above are the regression guard for these files.

--- a/docs/dna-sharing-bake-off-results.md
+++ b/docs/dna-sharing-bake-off-results.md
@@ -16,9 +16,19 @@ the harness from #2491
 ([`bench/DnaSharingBakeOff.ts`](../bench/DnaSharingBakeOff.ts)).
 
 The bake-off is part of the parent investigation in #2490 — "what is the
-cheapest way to share useful behaviour between a small Europa island and a
-larger production cluster without violating the AGENTS.md UUID stability
+cheapest way to share useful behaviour between a small Europa
+[island](GLOSSARY.md#-themed--house-terms) and a larger production cluster
+without violating the AGENTS.md UUID (Universally Unique Identifier) stability
 invariant?".
+
+> [!NOTE]
+> **NEAT-AI vs standard NEAT.** Inter-island DNA-sharing strategies are a
+> NEAT-AI extension — standard NEAT's island model only migrates whole
+> Creatures, it has no notion of transplanting partial
+> [DNA](GLOSSARY.md#-themed--house-terms) (subgraphs, pruning templates, or
+> distilled students) between islands. See the
+> [NEAT-vs-NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) and
+> [horizontal gene transfer](GLOSSARY.md#-themed--house-terms) in the glossary.
 
 ## 📊 Lift at a glance
 
@@ -38,9 +48,11 @@ this fixture.
 ## Method
 
 - **Harness**: `bench/DnaSharingBakeOff.ts` (Issue #2491). Single-process
-  harness that scores each strategy as `-MSE` against a probe dataset (higher is
-  better), reusing the public `Creature.activate` so the same WASM path as
-  production is exercised.
+  harness that scores each strategy as negative
+  [Mean Squared Error (MSE)](https://en.wikipedia.org/wiki/Mean_squared_error)
+  against a probe dataset (higher is better), reusing the public
+  `Creature.activate` so the same WASM (WebAssembly) path as production is
+  exercised.
 - **Recipient (production)**: `test/breed/samples/mother-1.json` — the default
   fallback when no `PRODUCTION_URL` env var is supplied.
 - **Donor (Europa)**: `test/breed/samples/father-1.json` — the default fallback

--- a/docs/event-driven-evolution.md
+++ b/docs/event-driven-evolution.md
@@ -7,6 +7,22 @@
 > #2612 (worker contract). Replaces the `evolveEnv` design from the earlier RFC
 > #2610.
 
+<!-- -->
+
+> [!IMPORTANT]
+> **This is the design RFC, not the shipped API reference.** The implemented
+> [`EpisodeAdapter`](../src/creature/EpisodeAdapter.ts) refined the contract
+> below as it landed (Issue #2626): the observation-size member is
+> `observationLength` (a getter, not `observationShape`); the adapter adds an
+> abstract `decodeAction(creatureOutput, state)` rather than baking action
+> decoding into the network output; `reset(rngSeed)` returns
+> `{ observation, state }`; and `step(state, action)` threads the simulator
+> state explicitly. For the **accurate, runnable** contract and a worked
+> `CountingAdapter`, see
+> [`REINFORCEMENT_LEARNING.md`](REINFORCEMENT_LEARNING.md#-driving-evolution-with-evolverl)
+> and [`API_REFERENCE.md`](API_REFERENCE.md#-creatureevolverl). The names in the
+> code blocks below are the original proposal, kept for design provenance.
+
 NEAT-AI today gives **supervised batch evolution** the full library treatment
 through `Creature.evolveDir()` / `Creature.evolveDataSet()`: worker pool,
 plateau detection, checkpointing, lifecycle events, signal-based interrupt. It


### PR DESCRIPTION
# PR Summary — Docs audit Phase 2: core-concept & themed guides (#2963)

## Summary

Phase 2 of the documentation audit milestone (#2956): audit the eight
deep/themed guides — the docs richest in themed vocabulary (Intelligent Design,
CRISPR, DNA, Evolution) and NEAT-AI-specific algorithm choices — against the
house style in [`DOC_STYLE.md`](../../DOC_STYLE.md). Each guide now links its
themed terms to the canonical [`GLOSSARY.md`](../../GLOSSARY.md), expands
acronyms on first use, and makes NEAT-AI-vs-standard-NEAT differences explicit
by deferring to the one canonical
[NEAT-vs-NEAT-AI rule](../../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).

Every algorithm claim was fact-checked against the implementation. The one
genuine accuracy gap found — the `evolveRL` RFC describing a contract that
diverged from the shipped `EpisodeAdapter` — is now flagged with a pointer to
the accurate, runnable contract.

**Closes #2963.**

### What changed per guide

| Guide                             | Change                                                                                                                                                                                                                                                           |
| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `NOVELTY_SEARCH.md`               | Foundation-doc links; acronym table (kNN, FIFO, i.i.d.); explicit "standard technique vs NEAT-AI integration" section; Related footer. Defaults verified against `src/config/NoveltyConfig.ts`.                                                                  |
| `event-driven-evolution.md`       | `> [!IMPORTANT]` note flagging it as a **design RFC**, pointing to the shipped `EpisodeAdapter` contract (`observationLength` getter, `decodeAction`, `reset → {observation, state}`, `step(state, action)`) — fact-checked vs `src/creature/EpisodeAdapter.ts`. |
| `INTELLIGENT_DESIGN.md`           | Glossary links for Intelligent Design / squash; NEAT-AI-vs-standard NOTE. Tier lists verified against `src/intelligentDesign/AlternativeSquashes.ts`.                                                                                                            |
| `CRISPR_GUIDE.md`                 | Glossary links (CRISPR, Grafting, Discovery, Intelligent Design); NEAT-AI-vs-standard NOTE.                                                                                                                                                                      |
| `BACKPROP_ELASTICITY.md`          | NEAT-AI-vs-standard-backprop NOTE; glossary link for squash.                                                                                                                                                                                                     |
| `ACTIVATION_FUNCTIONS.md`         | Made the standard-NEAT difference explicit; glossary link for squash; defer to the NEAT-vs rule.                                                                                                                                                                 |
| `REINFORCEMENT_LEARNING.md`       | Glossary link; RL expansion; pointer to the NEAT-vs rule (comparison table already covered NEAT-AI-vs-industry).                                                                                                                                                 |
| `dna-sharing-bake-off-results.md` | Expand MSE on first use; glossary links (Islands, DNA, horizontal gene transfer); NEAT-AI-vs-standard NOTE. `recommendedDnaSharingStrategy` verified against `src/transfer/mod.ts`.                                                                              |
| `GLOSSARY.md`                     | New **Novelty search** themed-term entry so the guide can link to it.                                                                                                                                                                                            |

### Fact-checks performed (doc claim ↔ code)

```mermaid
flowchart LR
    A[Guide claim] --> B{Matches code?}
    B -->|Intelligent Design tiers| C[AlternativeSquashes.ts ✓]
    B -->|Novelty defaults| D[NoveltyConfig.ts ✓]
    B -->|DNA-sharing winner| E[transfer/mod.ts ✓]
    B -->|evolveRL adapter shape| F[EpisodeAdapter.ts — RFC diverged → noted]
```

## Evidence

Documentation-only change; no web UI to screenshot. Verified via the repo's docs
test suite and markdown tooling:

- `deno test test/docs/DocsIndex.ts test/docs/JekyllLiquidSafety.ts test/docs/GlossaryAndStyle.ts`
  → **28 passed / 0 failed** (internal links resolve; no unescaped Liquid;
  glossary + style invariants hold).
- `markdownlint-cli2` over all nine touched files → **0 errors**.
- `./quality.sh --skip-tests --skip-discovery --skip-wasm` → **EXIT 0**
  (`deno fmt`, `deno lint`, bash check, `deno check` all pass).

## Test Plan

- Ran `test/docs/DocsIndex.ts`, `test/docs/JekyllLiquidSafety.ts`,
  `test/docs/GlossaryAndStyle.ts` (the docs-invariant suite that guards
  internal-link resolution, Jekyll/Liquid safety, and glossary/style rules).
- Ran `test/scripts/MarkdownLintWorkflow.ts` (8 passed).
- Confirmed every new file reference and heading anchor resolves
  (`GLOSSARY.md#-themed--house-terms`,
  `AGENTS.md#-neat-vs-neat-ai--which-term-to-use`, the `evolveRL` anchors,
  `src/config/NoveltyConfig.ts`, `src/creature/EpisodeAdapter.ts`).

No source code changed, so no new unit tests were required; the docs-invariant
tests above are the regression guard for these files.



## Milestone
This PR is part of the **clean up docs** milestone and targets the `milestone/clean-up-docs` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqfza4nr-a18c30`<!-- vibe-worker-issue-2963 -->