### PR TITLE
Docs audit: Discovery subsystem guides (#2964)

### DIFF
--- a/docs/DISCOVERY_ARCHITECTURE.md
+++ b/docs/DISCOVERY_ARCHITECTURE.md
@@ -20,9 +20,19 @@ guidance, see [DISCOVERY_GUIDE.md](DISCOVERY_GUIDE.md) and
 [DISCOVERY_DIR.md](DISCOVERY_DIR.md).
 
 > [!NOTE]
-> This document is contributor-focused. For user-facing configuration and
-> distributed setup guidance, refer to [DISCOVERY_GUIDE.md](DISCOVERY_GUIDE.md).
-> For the integration API, refer to [DISCOVERY_DIR.md](DISCOVERY_DIR.md).
+> **Discovery** is a [NEAT-AI](../AGENTS.md#-terminology) themed term for
+> error-guided structural evolution
+> ([glossary](GLOSSARY.md#-themed--house-terms)). Unlike standard NEAT's blind
+> `add-node` / `add-connection` mutations, the pipeline below records per-neuron
+> errors and proposes _targeted_ edits — see
+> [DISCOVERY_GUIDE.md §Discovery vs standard NEAT](DISCOVERY_GUIDE.md#-discovery-vs-standard-neat)
+> for that contrast and the
+> [canonical NEAT-vs-NEAT-AI rule](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
+
+This document is **contributor-focused**: for user-facing configuration and
+distributed setup refer to [DISCOVERY_GUIDE.md](DISCOVERY_GUIDE.md); for the
+integration API and on-disk layout refer to
+[DISCOVERY_DIR.md](DISCOVERY_DIR.md).
 
 ## 🔗 TS host ↔ Rust extension data flow
 
@@ -191,7 +201,7 @@ available as `additionalImprovements`.
 
 ## 🗺️ Module Dependency Map
 
-### `src/discovery/` — Pipeline Orchestration (37 files)
+### `src/discovery/` — Pipeline Orchestration
 
 ```mermaid
 graph TD
@@ -275,7 +285,7 @@ graph TD
     DR --> PDQ & BS & NEI & DSM & DT & DCL
 ```
 
-### 🦀 `src/architecture/ErrorGuidedStructuralEvolution/` — Rust FFI & Structure Operations (38 files)
+### 🦀 `src/architecture/ErrorGuidedStructuralEvolution/` — Rust FFI & Structure Operations
 
 ```mermaid
 graph TD
@@ -476,45 +486,15 @@ two-step validation approach:
 
 The success cache stores candidates that improved the creature's score. Each
 entry preserves enough information to **replay** the candidate on a future
-creature.
+creature. Entries are sub-keyed by change type, one `{hash}.json` document per
+candidate.
 
-**Directory structure:**
-
-```mermaid
-graph TD
-    classDef root fill:#9b59b6,stroke:#8e44ad,color:#fff
-    classDef dir fill:#3498db,stroke:#2980b9,color:#fff
-    classDef file fill:#2ecc71,stroke:#27ae60,color:#fff
-
-    ROOT["{successCacheDir}/"]:::root
-    AN["add-neurons/"]:::dir
-    AS["add-synapses/"]:::dir
-    CQ["change-squash/"]:::dir
-    RN["remove-neuron/"]:::dir
-    RLI["remove-low-impact/"]:::dir
-    RS["remove-synapse/"]:::dir
-    CIR["cache-informed-removal/"]:::dir
-    CS["coordinated-structural/"]:::dir
-
-    ANF["{hash}.json"]:::file
-    ASF["{hash}.json"]:::file
-    CQF["{hash}.json"]:::file
-    RNF["{hash}.json"]:::file
-    RLIF["{hash}.json"]:::file
-    RSF["{hash}.json"]:::file
-    CIRF["{hash}.json"]:::file
-    CSF["{hash}.json"]:::file
-
-    ROOT --> AN & AS & CQ & RN & RLI & RS & CIR & CS
-    AN --> ANF
-    AS --> ASF
-    CQ --> CQF
-    RN --> RNF
-    RLI --> RLIF
-    RS --> RSF
-    CIR --> CIRF
-    CS --> CSF
-```
+> [!NOTE]
+> The **on-disk directory tree** (success and failure caches, candidate
+> snapshots, focus-analysis traces, lock files) is documented once in
+> [DISCOVERY_DIR.md §On-disk discovery cache layout](DISCOVERY_DIR.md#-on-disk-discovery-cache-layout)
+> — this section covers the cache's _role and contents_ rather than repeating
+> the layout.
 
 **Entry metadata** (enhanced in #1733):
 

--- a/docs/DISCOVERY_DIR.md
+++ b/docs/DISCOVERY_DIR.md
@@ -10,11 +10,15 @@
 > [GPU_ACCELERATION.md](GPU_ACCELERATION.md) (Graphics Processing Unit (GPU)
 > backend selection), and the topic index in [`docs/README.md`](README.md).
 
-The `Creature.discoveryDir()` helper schedules targeted discovery work over a
-sampled dataset and returns the best performing candidate creature together with
-a human-friendly summary. This guide explains how to prepare data, invoke
-discovery, and fold improvements back into your controller workflow without
-referencing private infrastructure.
+The `Creature.discoveryDir()` helper schedules targeted
+[**Discovery**](GLOSSARY.md#-themed--house-terms) work — NEAT-AI's error-guided
+structural evolution — over a sampled dataset and returns the best performing
+candidate creature together with a human-friendly summary. This guide explains
+how to prepare data, invoke discovery, and fold improvements back into your
+controller workflow without referencing private infrastructure. For the concept
+and the standard-NEAT contrast see
+[DISCOVERY_GUIDE.md](DISCOVERY_GUIDE.md#-discovery-vs-standard-neat); for
+pipeline internals see [DISCOVERY_ARCHITECTURE.md](DISCOVERY_ARCHITECTURE.md).
 
 ## 🔧 Prerequisites
 
@@ -25,19 +29,14 @@ referencing private infrastructure.
   `cargo build --release` and either:
   - copy the resulting `libneat_ai_discovery` artefact into `~/.cargo/lib`, or
   - set `NEAT_AI_DISCOVERY_LIB_PATH=/absolute/path/to/libneat_ai_discovery.*`.
-- Discovery-aware builds of `NEAT-AI`. Use `isRustDiscoveryEnabled()` to assert
-  that the Rust module is available before scheduling work:
-
-```18:38:src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts
-export function isRustDiscoveryEnabled(): boolean {
-  try {
-    return isRustLibraryAvailable();
-  } catch {
-    // FFI not allowed or library not available
-    return false;
-  }
-}
-```
+- Discovery-aware builds of `NEAT-AI`. `discoveryDir()` internally calls
+  `isRustDiscoveryEnabled()` and skips the discovery phase when the Rust module
+  cannot be loaded, so a missing library degrades gracefully rather than
+  throwing. The guard returns `true` only when the native library loads; GPU
+  availability is probed for telemetry but does **not** gate discovery (the Rust
+  library handles CPU fallback internally), and the result is cached after the
+  first call for low overhead. The implementation lives in
+  [`RustDiscoveryLibrary.ts`](../src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryLibrary.ts).
 
 > [!NOTE]
 > If `isRustDiscoveryEnabled()` returns `false`, the Rust library is not
@@ -80,10 +79,11 @@ forward-only.
 
 ## 🗄️ On-disk discovery cache layout
 
-Discovery persists state under a `.discovery/` directory rooted at the workspace
-(or at the path passed via `discoveryWorkDir`). The host writes per-run
-candidate snapshots, focus-selection diagnostics, and the success / failure
-caches consumed by replay. A typical tree looks like:
+Discovery persists state under a `.discovery/` directory rooted at the current
+working directory (or at the path passed via `discoveryBaseDirectory`, which
+defaults to `.discovery`). The host writes per-run candidate snapshots,
+focus-selection diagnostics, and the success / failure caches consumed by
+replay. A typical tree looks like:
 
 ```text
 .discovery/

--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -16,14 +16,60 @@
 
 ## 📖 Overview
 
-Discovery is designed for **continuous, incremental improvements** to neural
-networks through automated structure analysis. Each discovery iteration finds
-small improvements (typically 1-3%), which accumulate over time through repeated
-iterations.
+**Discovery** is a [NEAT-AI](../AGENTS.md#-terminology) themed term for
+**error-guided structural evolution** — see the
+[glossary entry](GLOSSARY.md#-themed--house-terms). It is designed for
+**continuous, incremental improvements** to neural networks through automated
+structure analysis. Each discovery iteration finds small improvements (typically
+1-3%), which accumulate over time through repeated iterations.
 
 > [!IMPORTANT]
 > Discovery is NOT about finding large 10%+ improvements in a single run. It's
 > about finding many small 1-2% improvements that compound over time.
+
+## 🆚 Discovery vs standard NEAT
+
+Discovery is a NEAT-AI-specific mechanism with **no direct standard-NEAT
+equivalent**. The contrast is the clearest way to understand it (the canonical
+rule for when to write "NEAT-AI" versus "standard NEAT" lives in
+[AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)):
+
+- **Standard NEAT** grows topology with **blind structural mutations** —
+  `add-node` and `add-connection` are applied at random and only later judged by
+  fitness. The search has no model of _where_ a network is failing.
+- **NEAT-AI Discovery** is **error-guided**. It records each neuron's
+  activations and errors, asks the Rust
+  [Foreign Function Interface (FFI)](GLOSSARY.md#-acronyms) extension where the
+  creature is making mistakes, and proposes **targeted** candidate edits ranked
+  by expected error reduction. Each candidate is then re-scored and gated by the
+  [cost-of-growth](#-selection-strategy-cost-benefit-analysis) rule before it is
+  accepted.
+
+In other words, standard NEAT mutates and hopes; Discovery measures, then edits.
+
+```mermaid
+flowchart LR
+    classDef record fill:#3498db,stroke:#2980b9,color:#fff
+    classDef analyse fill:#e07b53,stroke:#c0392b,color:#fff
+    classDef propose fill:#9b59b6,stroke:#8e44ad,color:#fff
+    classDef gate fill:#f39c12,stroke:#e67e22,color:#fff
+    classDef accept fill:#2ecc71,stroke:#27ae60,color:#fff
+
+    R["1. Record<br/>per-neuron errors<br/>+ activations"]:::record
+    A["2. Analyse (Rust FFI)<br/>where is the<br/>creature failing?"]:::analyse
+    P["3. Propose<br/>targeted candidate<br/>edits, ranked"]:::propose
+    G["4. Gate<br/>re-score +<br/>cost-of-growth"]:::gate
+    K["5. Accept best<br/>net improvement"]:::accept
+
+    R --> A --> P --> G --> K
+    K -. "next iteration" .-> R
+```
+
+This loop is the user-facing view; the
+[architecture guide](DISCOVERY_ARCHITECTURE.md) documents the two-phase
+pipeline, caches, and FFI handshake behind it, and the
+[on-disk layout reference](DISCOVERY_DIR.md) covers the cache directories and
+the `Creature.discoveryDir()` API.
 
 ## ⚙️ How Discovery Works
 

--- a/docs/archive/pr-summaries/pr-summary-2964.md
+++ b/docs/archive/pr-summaries/pr-summary-2964.md
@@ -1,0 +1,89 @@
+# PR Summary — Docs audit: Discovery subsystem guides (#2964)
+
+## Summary
+
+Phase 2 documentation audit (part of #2956) of the three Discovery guides —
+`DISCOVERY_ARCHITECTURE.md`, `DISCOVERY_GUIDE.md`, and `DISCOVERY_DIR.md`. The
+guides were fact-checked against the current Rust Discovery module and its
+TypeScript surface, de-duplicated into a clear division of labour, and given an
+explicit explanation of the **Discovery** themed term and how it differs from
+standard NEAT. **Closes #2964.**
+
+### What changed
+
+- **Explain "Discovery" + NEAT-AI vs standard NEAT.** `DISCOVERY_GUIDE.md` now
+  glosses Discovery as a NEAT-AI themed term (linked to the glossary) and adds a
+  **🆚 Discovery vs standard NEAT** section: standard NEAT grows topology with
+  blind `add-node` / `add-connection` mutations, whereas NEAT-AI Discovery is
+  error-guided — it records per-neuron errors, asks the Rust FFI extension where
+  the creature is failing, and proposes targeted edits gated by cost-of-growth.
+  Defers to the canonical NEAT-vs-NEAT-AI rule in `AGENTS.md`.
+
+- **Fact-check fixes (drift removed).**
+  - `DISCOVERY_DIR.md` referenced a non-existent `discoveryWorkDir` option →
+    corrected to the real `discoveryBaseDirectory` (default `.discovery`,
+    verified in `src/config/NeatConfig.ts` / `NeatArguments.ts`).
+  - The embedded `isRustDiscoveryEnabled()` snippet pointed at the wrong file
+    (`RustDiscovery.ts`, a barrel) with an outdated body. Replaced with an
+    accurate description (caches result, probes GPU for telemetry only) pointing
+    at the real implementation in `RustDiscoveryLibrary.ts`.
+  - Dropped drift-prone hard-coded file counts ("37 files", "38 files") from
+    `DISCOVERY_ARCHITECTURE.md`.
+
+- **De-duplication.** The on-disk cache directory tree appeared in both
+  `DISCOVERY_ARCHITECTURE.md` and `DISCOVERY_DIR.md`. It now lives **only** in
+  `DISCOVERY_DIR.md` (the on-disk-layout doc); the architecture doc links to it
+  and keeps just the cache's role/contents. Division of labour: architecture =
+  internals, guide = how-to-use, dir = on-disk layout + API.
+
+- **Cross-links.** All three docs now link to each other and to the glossary
+  themed-terms entry; the new error-guided flow diagram supplements the existing
+  architecture/flow diagrams.
+
+### Error-guided discovery flow (added to DISCOVERY_GUIDE.md)
+
+```mermaid
+flowchart LR
+    R["1. Record<br/>per-neuron errors<br/>+ activations"]
+    A["2. Analyse (Rust FFI)<br/>where is the<br/>creature failing?"]
+    P["3. Propose<br/>targeted candidate<br/>edits, ranked"]
+    G["4. Gate<br/>re-score +<br/>cost-of-growth"]
+    K["5. Accept best<br/>net improvement"]
+
+    R --> A --> P --> G --> K
+    K -. "next iteration" .-> R
+```
+
+## Evidence
+
+Documentation-only change (no runtime code). Verified via:
+
+- `test/docs/DiscoveryGuides.ts` — new "what" tests (read the real files,
+  assert on outcomes): all 7 pass.
+- `deno test --allow-read "test/docs/*.ts"` — 83 passed, 0 failed.
+- `deno fmt`, `deno lint`, `deno check` — clean on all changed files.
+- `markdownlint-cli2` — 0 errors across the docs.
+- No stray Liquid (`{% %}` / `{{ }}`) outside code fences.
+
+## Test Plan
+
+Added `test/docs/DiscoveryGuides.ts` covering:
+
+- All three docs exist, are substantive, and carry a Mermaid diagram.
+- Each doc cross-links to its two siblings and to `GLOSSARY.md`.
+- `DISCOVERY_GUIDE.md` makes the standard-NEAT contrast explicit and links the
+  canonical NEAT-vs-NEAT-AI rule.
+- On-disk layout lives in `DISCOVERY_DIR.md`; the architecture doc defers to it.
+- `DISCOVERY_DIR.md` names `discoveryBaseDirectory` and no longer references the
+  stale `discoveryWorkDir`.
+- All relative links in the three docs resolve on disk.
+- `docs/README.md` still indexes all three docs.
+
+## Acceptance criteria
+
+- [x] Architecture/layout/usage verified against current code.
+- [x] Clear, non-overlapping division of the three docs with cross-links;
+      duplication removed.
+- [x] "Discovery" explained; NEAT-AI-vs-standard-NEAT distinction explicit.
+- [x] At least one Mermaid architecture/flow diagram; obsolete content removed.
+- [x] Cross-links resolve; linked from `docs/README.md`.

--- a/test/docs/DiscoveryGuides.ts
+++ b/test/docs/DiscoveryGuides.ts
@@ -1,0 +1,169 @@
+/**
+ * Issue #2964 — Phase 2 documentation audit of the Discovery subsystem guides.
+ *
+ * Verifies the three Discovery guides are accurate, non-overlapping, and
+ * cross-linked:
+ *
+ *   1. All three docs exist, are substantive, and carry a Mermaid diagram.
+ *   2. Each doc cross-links to the other two and to the canonical glossary.
+ *   3. "Discovery" (the themed term) is glossed and the NEAT-AI-vs-standard-
+ *      NEAT distinction is explicit, deferring to the canonical rule in
+ *      AGENTS.md.
+ *   4. On-disk layout lives in DISCOVERY_DIR.md (the division of labour): the
+ *      architecture doc defers to it rather than repeating the directory tree.
+ *   5. DISCOVERY_DIR.md names the real config option (`discoveryBaseDirectory`)
+ *      and no longer references the non-existent `discoveryWorkDir`.
+ *   6. All relative links in the three docs resolve on disk.
+ *   7. docs/README.md still indexes all three docs.
+ *
+ * These are "what" tests: they read the actual files and assert on outcomes
+ * (links resolve, sections exist), not on implementation details such as
+ * exact wording or line counts.
+ */
+
+import { assert } from "@std/assert";
+import { dirname, fromFileUrl, resolve } from "@std/path";
+
+const REPO_ROOT = resolve(fromFileUrl(import.meta.url), "..", "..", "..");
+const DOCS_DIR = `${REPO_ROOT}/docs`;
+const DOCS_README = `${DOCS_DIR}/README.md`;
+
+const ARCH = "DISCOVERY_ARCHITECTURE.md";
+const GUIDE = "DISCOVERY_GUIDE.md";
+const DIR = "DISCOVERY_DIR.md";
+const DISCOVERY_DOCS: ReadonlyArray<string> = [ARCH, GUIDE, DIR];
+
+async function readDoc(name: string): Promise<string> {
+  return await Deno.readTextFile(`${DOCS_DIR}/${name}`);
+}
+
+Deno.test("Discovery docs exist, are substantive, and carry a Mermaid diagram", async () => {
+  const docs = await Promise.all(
+    DISCOVERY_DOCS.map(async (name) => ({
+      name,
+      content: await readDoc(name),
+    })),
+  );
+  for (const { name, content } of docs) {
+    assert(
+      content.length > 1000,
+      `${name} must be substantive (>1000 chars), got ${content.length}`,
+    );
+    assert(
+      /^#\s/m.test(content),
+      `${name} must contain at least one Markdown heading`,
+    );
+    assert(
+      content.includes("```mermaid"),
+      `${name} must contain at least one fenced \`\`\`mermaid block`,
+    );
+  }
+});
+
+Deno.test("Each Discovery doc cross-links to its siblings and the glossary", async () => {
+  const docs = await Promise.all(
+    DISCOVERY_DOCS.map(async (name) => ({
+      name,
+      content: await readDoc(name),
+    })),
+  );
+  for (const { name, content } of docs) {
+    for (const sibling of DISCOVERY_DOCS) {
+      if (sibling === name) continue;
+      assert(
+        content.includes(sibling),
+        `${name} must cross-link to ${sibling}`,
+      );
+    }
+    assert(
+      content.includes("GLOSSARY.md"),
+      `${name} must link to the canonical glossary (GLOSSARY.md)`,
+    );
+  }
+});
+
+Deno.test("DISCOVERY_GUIDE makes the NEAT-AI-vs-standard-NEAT distinction explicit", async () => {
+  const content = await readDoc(GUIDE);
+  assert(
+    content.includes("standard NEAT"),
+    "DISCOVERY_GUIDE.md must contrast Discovery with standard NEAT",
+  );
+  assert(
+    content.includes("-neat-vs-neat-ai--which-term-to-use"),
+    "DISCOVERY_GUIDE.md must link to the canonical NEAT-vs-NEAT-AI rule in AGENTS.md",
+  );
+});
+
+Deno.test("On-disk cache layout lives in DISCOVERY_DIR, not duplicated in the architecture doc", async () => {
+  const arch = await readDoc(ARCH);
+  // The architecture doc must defer the on-disk tree to DISCOVERY_DIR rather
+  // than repeating the changeType directory listing.
+  assert(
+    arch.includes(DIR),
+    "DISCOVERY_ARCHITECTURE.md must link to DISCOVERY_DIR.md for the on-disk layout",
+  );
+  const dir = await readDoc(DIR);
+  assert(
+    dir.includes(".discovery/"),
+    "DISCOVERY_DIR.md must document the on-disk .discovery/ layout",
+  );
+});
+
+Deno.test("DISCOVERY_DIR names the real config option and drops the stale one", async () => {
+  const content = await readDoc(DIR);
+  assert(
+    content.includes("discoveryBaseDirectory"),
+    "DISCOVERY_DIR.md must reference the real option discoveryBaseDirectory",
+  );
+  assert(
+    !content.includes("discoveryWorkDir"),
+    "DISCOVERY_DIR.md must not reference the non-existent discoveryWorkDir option",
+  );
+});
+
+Deno.test("Discovery docs relative links resolve", async () => {
+  await Promise.all(
+    DISCOVERY_DOCS.map(async (name) => {
+      const path = `${DOCS_DIR}/${name}`;
+      const content = await Deno.readTextFile(path);
+      await assertLinksResolve(content, dirname(path));
+    }),
+  );
+});
+
+Deno.test("docs/README.md still indexes all three Discovery docs", async () => {
+  const content = await Deno.readTextFile(DOCS_README);
+  for (const name of DISCOVERY_DOCS) {
+    assert(
+      content.includes(name),
+      `docs/README.md must continue to index ${name}`,
+    );
+  }
+});
+
+async function assertLinksResolve(content: string, baseDir: string) {
+  const linkRe = /\[[^\]]+\]\(([^)]+)\)/g;
+  const targets: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = linkRe.exec(content)) !== null) {
+    const target = match[1];
+    if (target.startsWith("http://") || target.startsWith("https://")) continue;
+    if (target.startsWith("#")) continue;
+    const [pathPart] = target.split("#");
+    if (!pathPart) continue;
+    targets.push(pathPart);
+  }
+  const failures = await Promise.all(
+    targets.map(async (pathPart) => {
+      const resolved = resolve(baseDir, pathPart);
+      try {
+        await Deno.stat(resolved);
+        return null;
+      } catch {
+        return `broken link: ${pathPart} (resolved to ${resolved})`;
+      }
+    }),
+  );
+  const broken = failures.filter((r): r is string => r !== null);
+  assert(broken.length === 0, `broken links:\n${broken.join("\n")}`);
+}


### PR DESCRIPTION
# PR Summary — Docs audit: Discovery subsystem guides (#2964)

## Summary

Phase 2 documentation audit (part of #2956) of the three Discovery guides —
`DISCOVERY_ARCHITECTURE.md`, `DISCOVERY_GUIDE.md`, and `DISCOVERY_DIR.md`. The
guides were fact-checked against the current Rust Discovery module and its
TypeScript surface, de-duplicated into a clear division of labour, and given an
explicit explanation of the **Discovery** themed term and how it differs from
standard NEAT. **Closes #2964.**

### What changed

- **Explain "Discovery" + NEAT-AI vs standard NEAT.** `DISCOVERY_GUIDE.md` now
  glosses Discovery as a NEAT-AI themed term (linked to the glossary) and adds a
  **🆚 Discovery vs standard NEAT** section: standard NEAT grows topology with
  blind `add-node` / `add-connection` mutations, whereas NEAT-AI Discovery is
  error-guided — it records per-neuron errors, asks the Rust FFI extension where
  the creature is failing, and proposes targeted edits gated by cost-of-growth.
  Defers to the canonical NEAT-vs-NEAT-AI rule in `AGENTS.md`.

- **Fact-check fixes (drift removed).**
  - `DISCOVERY_DIR.md` referenced a non-existent `discoveryWorkDir` option →
    corrected to the real `discoveryBaseDirectory` (default `.discovery`,
    verified in `src/config/NeatConfig.ts` / `NeatArguments.ts`).
  - The embedded `isRustDiscoveryEnabled()` snippet pointed at the wrong file
    (`RustDiscovery.ts`, a barrel) with an outdated body. Replaced with an
    accurate description (caches result, probes GPU for telemetry only) pointing
    at the real implementation in `RustDiscoveryLibrary.ts`.
  - Dropped drift-prone hard-coded file counts ("37 files", "38 files") from
    `DISCOVERY_ARCHITECTURE.md`.

- **De-duplication.** The on-disk cache directory tree appeared in both
  `DISCOVERY_ARCHITECTURE.md` and `DISCOVERY_DIR.md`. It now lives **only** in
  `DISCOVERY_DIR.md` (the on-disk-layout doc); the architecture doc links to it
  and keeps just the cache's role/contents. Division of labour: architecture =
  internals, guide = how-to-use, dir = on-disk layout + API.

- **Cross-links.** All three docs now link to each other and to the glossary
  themed-terms entry; the new error-guided flow diagram supplements the existing
  architecture/flow diagrams.

### Error-guided discovery flow (added to DISCOVERY_GUIDE.md)

```mermaid
flowchart LR
    R["1. Record<br/>per-neuron errors<br/>+ activations"]
    A["2. Analyse (Rust FFI)<br/>where is the<br/>creature failing?"]
    P["3. Propose<br/>targeted candidate<br/>edits, ranked"]
    G["4. Gate<br/>re-score +<br/>cost-of-growth"]
    K["5. Accept best<br/>net improvement"]

    R --> A --> P --> G --> K
    K -. "next iteration" .-> R
```

## Evidence

Documentation-only change (no runtime code). Verified via:

- `test/docs/DiscoveryGuides.ts` — new "what" tests (read the real files,
  assert on outcomes): all 7 pass.
- `deno test --allow-read "test/docs/*.ts"` — 83 passed, 0 failed.
- `deno fmt`, `deno lint`, `deno check` — clean on all changed files.
- `markdownlint-cli2` — 0 errors across the docs.
- No stray Liquid (`{% %}` / `{{ }}`) outside code fences.

## Test Plan

Added `test/docs/DiscoveryGuides.ts` covering:

- All three docs exist, are substantive, and carry a Mermaid diagram.
- Each doc cross-links to its two siblings and to `GLOSSARY.md`.
- `DISCOVERY_GUIDE.md` makes the standard-NEAT contrast explicit and links the
  canonical NEAT-vs-NEAT-AI rule.
- On-disk layout lives in `DISCOVERY_DIR.md`; the architecture doc defers to it.
- `DISCOVERY_DIR.md` names `discoveryBaseDirectory` and no longer references the
  stale `discoveryWorkDir`.
- All relative links in the three docs resolve on disk.
- `docs/README.md` still indexes all three docs.

## Acceptance criteria

- [x] Architecture/layout/usage verified against current code.
- [x] Clear, non-overlapping division of the three docs with cross-links;
      duplication removed.
- [x] "Discovery" explained; NEAT-AI-vs-standard-NEAT distinction explicit.
- [x] At least one Mermaid architecture/flow diagram; obsolete content removed.
- [x] Cross-links resolve; linked from `docs/README.md`.



## Milestone
This PR is part of the **clean up docs** milestone and targets the `milestone/clean-up-docs` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqfzplzs-b13248`<!-- vibe-worker-issue-2964 -->