### PR TITLE
Docs: audit Predictive Coding guides — fact-check vs implementation (#2965)

### DIFF
--- a/docs/PREDICTIVE_CODING.md
+++ b/docs/PREDICTIVE_CODING.md
@@ -49,11 +49,32 @@ See the [docs index](./README.md) for the full topic map.
 8. [References](#8--references)
 9. [Further Reading](#-further-reading)
 
-This document describes the architecture for integrating **Predictive Coding**
-(PC) as an optional training mode in NEAT-AI. It serves as the blueprint for all
-subsequent implementation work.
+This document describes the architecture **and current implementation** of
+**Predictive Coding** (PC) as an optional training mode in NEAT-AI. It began as
+the design blueprint for the feature (issue
+[#1549](https://github.com/stSoftwareAU/NEAT-AI/issues/1549)); the TypeScript
+implementation now ships, so the sections below note where the shipped code
+matches the original design and where it diverges.
 
 Part of [#1549](https://github.com/stSoftwareAU/NEAT-AI/issues/1549).
+
+> [!IMPORTANT]
+> **Implementation status (verified June 2026).** PC ships as a
+> **TypeScript-only** training mode under
+> [`src/predictiveCoding/`](../src/predictiveCoding/), wired through
+> `predictiveCoding` in
+> [`src/config/PredictiveCodingConfig.ts`](../src/config/PredictiveCodingConfig.ts).
+> It is **opt-in** (`enabled: false` by default), includes adaptive scaling
+> (Issue #1915) and trace tags (Issue #1913), and **fully replaces** standard
+> elastic backprop for a creature when enabled. The **Rust/WASM inference
+> engine** described in [Section 2.7](#27--typescript-vs-rustwasm-decision) and
+> [Phase 3](#-phase-3--rustwasm-pc-inference) is **planned but not yet
+> implemented** (issue
+> [#1560](https://github.com/stSoftwareAU/NEAT-AI/issues/1560)). The `replace`
+> vs `complement` integration mode in the original design
+> ([Phase 5](#-phase-5--complement-mode-and-advanced-features)) is also **not
+> yet implemented** — there is no `integrationMode` config field. See
+> [NEAT-AI vs canonical PC](#-neat-ai-vs-canonical-predictive-coding).
 
 ## 🔁 The predictive-coding loop at a glance
 
@@ -194,6 +215,29 @@ The key difference is that elastic backprop performs a **single pass** through
 the network, while PC performs **iterative settling** before weight updates.
 PC's iterative inference can potentially find better target activations for
 hidden neurons, particularly in deep or recurrent topologies.
+
+### 🆚 NEAT-AI vs canonical predictive coding
+
+NEAT-AI's PC implementation follows the canonical Rao & Ballard (1999) /
+Whittington & Bogacz (2017) formulation for the core energy function, settling
+dynamics, and Hebbian weight rule, but **diverges** from the textbook algorithm
+in several deliberate ways. Call these out when comparing against the
+literature:
+
+| Aspect             | Canonical PC                                         | NEAT-AI                                                                                                                      |
+| ------------------ | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Network shape      | Strict hierarchical layers                           | Arbitrary directed graphs; "depth" is the topological distance from inputs (computed at prepare)                             |
+| Prediction weights | Separate feedback weights \(W_{fb}\) (Rao & Ballard) | **Shared (tied) weights** — feedback uses the transpose of the feedforward weight ([2.3](#23--weight-symmetry-decision))     |
+| Hyper-parameters   | Fixed learning/inference rates                       | **Adaptive scaling** by topology (Issue #1915) — not part of any textbook formulation ([Section 6](#6--configuration-guide)) |
+| Gradient stability | Raw activity gradients                               | Inference gradients **L2-normalised** (capped at 1.0) to prevent divergence in deep topologies                               |
+| Role in training   | Standalone learner                                   | One **opt-in** mode inside the memetic NEAT-AI pipeline; replaces elastic backprop when enabled                              |
+| Compute backend    | n/a                                                  | **TypeScript only** today; Rust/WASM hot loop ([2.7](#27--typescript-vs-rustwasm-decision)) is planned (#1560), not shipped  |
+
+These divergences are pragmatic adaptations so PC fits NEAT-AI's
+variable-topology creatures and per-neuron/per-synapse architecture. The
+mathematical validation suite (see
+[PREDICTIVE_CODING_BENCHMARKS.md §4](./PREDICTIVE_CODING_BENCHMARKS.md#4--mathematical-validation-summary))
+confirms the core PC properties still hold under these adaptations.
 
 ---
 
@@ -353,10 +397,15 @@ flowchart LR
     S --> N
 ```
 
-This replaces or complements the elastic backpropagation step
-(`Neuron.propagate()`) when PC mode is active. The existing
-`Neuron.propagateUpdate()` mechanism for applying accumulated weight/bias
-changes can be reused — the only difference is **how** the deltas are computed.
+When PC mode is active it **replaces** the elastic backpropagation step
+(`Neuron.propagate()`) — the shipped trainer
+([`src/architecture/training/TrainingPredictiveCoding.ts`](../src/architecture/training/TrainingPredictiveCoding.ts))
+routes training through the PC learner instead of standard backprop. The
+existing `Neuron.propagateUpdate()` mechanism for applying accumulated
+weight/bias changes is reused — the only difference is **how** the deltas are
+computed. (A `complement` mode that runs both was part of the original design
+but is not yet implemented; see
+[Phase 5](#-phase-5--complement-mode-and-advanced-features).)
 
 ### 2.6 🔌 Integration with Existing Forward Activation
 
@@ -404,14 +453,22 @@ activations become the "true" activations used for fitness evaluation.
 | PC-enhanced structural discovery   | Rust (NEAT-AI-Discovery) | Prediction errors provide richer signals for the existing GPU-accelerated analysis  |
 | Integration tests and validation   | TypeScript (Deno)        | Follows existing test patterns                                                      |
 
-The Rust/WASM components extend the existing `wasm_activation` crate
-(`wasm_activation/src/`). New Rust modules:
+> [!NOTE]
+> **Not yet implemented (status June 2026).** The Rust/WASM components below are
+> the planned design (issue
+> [#1560](https://github.com/stSoftwareAU/NEAT-AI/issues/1560)). The shipped PC
+> inference and learning loops run in **TypeScript** under
+> [`src/predictiveCoding/`](../src/predictiveCoding/). The file names below do
+> **not** exist yet — treat this subsection as the forward plan.
+
+The Rust/WASM components would extend the existing `wasm_activation` crate
+(`wasm_activation/src/`). Planned Rust modules:
 
 - `wasm_activation/src/pc_inference.rs` — Settling loop with convergence
   detection
 - `wasm_activation/src/pc_learning.rs` — Batch Hebbian weight updates
 
-The TypeScript side calls these through the existing WASM bridge pattern
+The TypeScript side would call these through the existing WASM bridge pattern
 (`src/wasm/`), adding new wrapper functions in a `PredictiveCodingWasm.ts`
 module.
 
@@ -461,38 +518,32 @@ updates are computed during training.
 Following the established config pattern (see `src/config/` for examples like
 `BiasRegularisationConfig.ts`):
 
-**File: `src/config/PredictiveCodingConfig.ts`**
+**File:
+[`src/config/PredictiveCodingConfig.ts`](../src/config/PredictiveCodingConfig.ts)**
+(shipped — the block below mirrors the actual source):
 
 ```typescript
 /**
- * Configuration for Predictive Coding training mode.
+ * Configuration for Predictive Coding (PC) training mode.
  *
  * When enabled, training uses iterative inference (settling) followed by
- * local Hebbian weight updates instead of (or alongside) elastic
- * backpropagation.
+ * local Hebbian weight updates instead of elastic backpropagation.
  */
 export interface PredictiveCodingConfig {
-  /** Whether PC training is enabled. Default: false */
+  /** Whether PC training mode is active (default: false). */
   enabled?: boolean;
 
-  /** Maximum iterations for inference settling. Default: 20 */
-  maxInferenceIterations?: number;
+  /** Number of settling iterations for inference (default: 50). */
+  inferenceSteps?: number;
 
-  /** Convergence threshold for early stopping during settling.
-   *  Settling stops when |E_prev - E_current| < threshold. Default: 1e-4 */
-  convergenceThreshold?: number;
-
-  /** Learning rate for activity updates during inference. Default: 0.1 */
+  /** Learning rate for inference updates (default: 0.05). */
   inferenceRate?: number;
 
-  /** Learning rate for weight updates after settling. Default: 0.01 */
+  /** Learning rate for weight updates (default: 0.001). */
   learningRate?: number;
 
-  /** Strategy for combining PC with existing backprop.
-   *  - "replace": PC replaces elastic backprop entirely
-   *  - "complement": PC runs first, then elastic backprop refines
-   *  Default: "replace" */
-  integrationMode?: "replace" | "complement";
+  /** Convergence threshold for inference energy (default: 1e-6). */
+  energyThreshold?: number;
 }
 
 export type RequiredPredictiveCodingConfig = Required<PredictiveCodingConfig>;
@@ -500,15 +551,22 @@ export type RequiredPredictiveCodingConfig = Required<PredictiveCodingConfig>;
 export const DEFAULT_PREDICTIVE_CODING_CONFIG: RequiredPredictiveCodingConfig =
   {
     enabled: false,
-    maxInferenceIterations: 20,
-    convergenceThreshold: 1e-4,
-    inferenceRate: 0.1,
-    learningRate: 0.01,
-    integrationMode: "replace",
+    inferenceSteps: 50,
+    inferenceRate: 0.05,
+    learningRate: 0.001,
+    energyThreshold: 1e-6,
   };
 ```
 
-**Integration points** (following the config pattern from `MEMORY.md`):
+> [!NOTE]
+> The original design sketched extra fields (`maxInferenceIterations`,
+> `convergenceThreshold`, `integrationMode`). The shipped config consolidated
+> these into `inferenceSteps` and `energyThreshold`, and **omits**
+> `integrationMode` (there is currently only the `replace` behaviour). The
+> [Configuration Guide](#6--configuration-guide) below documents the live fields
+> and their effective values under adaptive scaling.
+
+**Integration points** (following the config pattern in `src/config/`):
 
 1. Add `predictiveCoding: RequiredPredictiveCodingConfig` to
    `src/config/NeatArguments.ts`
@@ -558,7 +616,15 @@ fields.
 
 ## 4. 🗓️ Implementation Roadmap
 
-### 🧱 Phase 1: Configuration and State Infrastructure
+> [!NOTE]
+> **Status (June 2026).** Phases 1–2 (config, state, TypeScript inference) are
+> **shipped**, together with adaptive scaling (Issue #1915) and trace tags
+> (Issue #1913). Phase 4's prediction-error-guided mutation exists
+> ([`src/predictiveCoding/PredictionErrorGuidedMutation.ts`](../src/predictiveCoding/PredictionErrorGuidedMutation.ts)).
+> **Phase 3 (Rust/WASM) and Phase 5 (complement mode) are not yet implemented.**
+> Status markers below: ✅ shipped · 🟡 partial · 🔜 planned.
+
+### 🧱 Phase 1 ✅: Configuration and State Infrastructure
 
 **Goal**: Add PC configuration and extend creature state without changing any
 runtime behaviour.
@@ -579,28 +645,35 @@ runtime behaviour.
 - `src/config/NeatConfig.ts` (modified)
 - `src/architecture/CreatureState.ts` (modified)
 
-### 🔬 Phase 2: TypeScript PC Inference Prototype
+### 🔬 Phase 2 ✅: TypeScript PC Inference
 
-**Goal**: Implement PC inference (settling) in TypeScript as a working
-prototype.
+**Goal**: Implement PC inference (settling) in TypeScript.
 
-- Implement the settling algorithm in a new `src/propagate/PredictiveCoding.ts`
-  module
-- Integrate with `CreatureTraining.ts` — call settling before weight updates
-  when `pc.enabled === true`
-- Implement Hebbian weight update rule
-- Write tests verifying convergence on simple networks (XOR, AND, OR)
-- Benchmark inference loop to establish baseline for WASM optimisation
+- Settling algorithm and Hebbian weight update implemented under
+  `src/predictiveCoding/`
+- Integrated with training via
+  `src/architecture/training/TrainingPredictiveCoding.ts` — routes training
+  through the PC learner when `predictiveCoding.enabled === true`
+- Tests verify convergence on simple networks (XOR, regression)
+- Benchmarks establish the baseline for the planned WASM optimisation
 - **Depends on**: Phase 1
 - **Result**: PC training works end-to-end in TypeScript; performance baseline
   established
 
-**Key files**:
+**Key files (as shipped)**:
 
-- `src/propagate/PredictiveCoding.ts` (new)
-- `src/creature/CreatureTraining.ts` (modified)
+- [`src/predictiveCoding/PredictiveCodingInference.ts`](../src/predictiveCoding/PredictiveCodingInference.ts)
+  — settling loop
+- [`src/predictiveCoding/PredictiveCodingLearning.ts`](../src/predictiveCoding/PredictiveCodingLearning.ts)
+  — Hebbian weight updates
+- [`src/predictiveCoding/PredictiveCodingTrainer.ts`](../src/predictiveCoding/PredictiveCodingTrainer.ts)
+  — training orchestration
+- [`src/predictiveCoding/PredictionErrorComputation.ts`](../src/predictiveCoding/PredictionErrorComputation.ts)
+  — energy and error computation
+- [`src/architecture/training/TrainingPredictiveCoding.ts`](../src/architecture/training/TrainingPredictiveCoding.ts)
+  — pipeline integration
 
-### ⚡ Phase 3: Rust/WASM PC Inference
+### ⚡ Phase 3 🔜: Rust/WASM PC Inference
 
 **Goal**: Port the PC inference hot loop to Rust/WASM for production
 performance.
@@ -620,7 +693,7 @@ performance.
 - `wasm_activation/src/lib.rs` (modified — re-export new modules)
 - `src/wasm/PredictiveCodingWasm.ts` (new)
 
-### 🔍 Phase 4: Discovery Integration
+### 🔍 Phase 4 🟡: Discovery Integration
 
 **Goal**: Feed PC prediction errors into the structural evolution pipeline.
 
@@ -638,7 +711,7 @@ performance.
 - `src/architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts` (modified)
 - NEAT-AI-Discovery repo (separate PRs)
 
-### 🚀 Phase 5: Complement Mode and Advanced Features
+### 🚀 Phase 5 🔜: Complement Mode and Advanced Features
 
 **Goal**: Enable PC and elastic backprop to work together, and add adaptive
 settling.
@@ -691,9 +764,9 @@ The PC inference loop is the critical performance bottleneck:
 > [!TIP]
 > Early convergence detection is an important optimisation. When prediction
 > errors are already small (e.g., after weight updates stabilise), the settling
-> loop can terminate well before `maxInferenceIterations` — reducing per-sample
-> cost significantly. Tuning `convergenceThreshold` is worthwhile when
-> optimising for throughput.
+> loop can terminate well before `inferenceSteps` — reducing per-sample cost
+> significantly. Tuning `energyThreshold` is worthwhile when optimising for
+> throughput.
 
 ### 🔧 Adaptive Scaling for Complex Creatures (Issue #1915)
 

--- a/docs/PREDICTIVE_CODING_BENCHMARKS.md
+++ b/docs/PREDICTIVE_CODING_BENCHMARKS.md
@@ -127,6 +127,23 @@ signal degradation is significant.
 > correctness outweigh the settling cost — especially once the Rust/WASM
 > inference engine (#1560) is in place.
 
+#### 🔁 Re-verification — June 2026 (Issue #2965)
+
+Re-run on Apple M4 Pro, **Deno 2.8.3**, to confirm the numbers reproduce. The
+February 2026 rows above are retained for historical comparison. Figures are
+within noise of the original run; on XOR, PC was marginally faster on this run.
+
+| Problem    | Method            | time/iter (avg) | iter/s |
+| ---------- | ----------------- | --------------- | ------ |
+| XOR        | Standard backprop | 4.0 ms          | 249.5  |
+| XOR        | Predictive Coding | 3.7 ms          | 266.8  |
+| Regression | Standard backprop | 5.8 ms          | 171.4  |
+| Regression | Predictive Coding | 8.6 ms          | 115.9  |
+
+**Finding**: Reproducible. PC ≈ backprop on XOR (~1.07× either way, within run
+variance) and ~1.48× slower on regression — consistent with the original finding
+that PC's settling overhead is modest on small networks.
+
 ## 2. ⚡ Inference and Learning Speed
 
 _Source bench script:_
@@ -178,6 +195,23 @@ of synapses (quadratic in dense layers).
 **Finding**: Weight updates are very fast — a single pass applying pre-computed
 deltas with constraint enforcement. Even for large networks (93 neurons, 2,090
 synapses), updates complete in under 60 us.
+
+### 🔁 Re-verification — June 2026 (Issue #2965)
+
+Re-run on Apple M4 Pro, **Deno 2.8.3**. Numbers reproduce within
+hardware/runtime noise; the February 2026 rows above are retained for
+comparison.
+
+| Stage          | Small (7) | Medium (37) | Large (93) |
+| -------------- | --------- | ----------- | ---------- |
+| Inference (50) | 36.7 us   | 2.4 ms      | 38.1 ms    |
+| Gradient comp. | 1.2 us    | 54.0 us     | 745.8 us   |
+| Hebbian update | 326.5 ns  | 8.5 us      | 54.3 us    |
+
+**Finding**: Reproducible. Inference still dominates and scales super-linearly;
+gradient computation and Hebbian updates remain cheap (large-network Hebbian
+update still under 60 us). This continues to motivate the planned Rust/WASM
+inference engine (#1560) for production-scale networks.
 
 ## 3. 🏗️ Structural Evolution
 

--- a/docs/archive/pr-summaries/pr-summary-2964.md
+++ b/docs/archive/pr-summaries/pr-summary-2964.md
@@ -58,12 +58,12 @@ flowchart LR
 
 Documentation-only change (no runtime code). Verified via:
 
-- `test/docs/DiscoveryGuides.ts` — new "what" tests (read the real files,
-  assert on outcomes): all 7 pass.
+- `test/docs/DiscoveryGuides.ts` — new "what" tests (read the real files, assert
+  on outcomes): all 7 pass.
 - `deno test --allow-read "test/docs/*.ts"` — 83 passed, 0 failed.
 - `deno fmt`, `deno lint`, `deno check` — clean on all changed files.
 - `markdownlint-cli2` — 0 errors across the docs.
-- No stray Liquid (`{% %}` / `{{ }}`) outside code fences.
+- No stray Liquid ({% raw %}`{% %}` / `{{ }}`{% endraw %}) outside code fences.
 
 ## Test Plan
 

--- a/docs/archive/pr-summaries/pr-summary-2965.md
+++ b/docs/archive/pr-summaries/pr-summary-2965.md
@@ -1,0 +1,120 @@
+# PR Summary — Docs audit: Predictive Coding guides (#2965)
+
+## Summary
+
+Phase 2 documentation audit (part of #2956) of the two Predictive Coding (PC)
+guides — `docs/PREDICTIVE_CODING.md` and `docs/PREDICTIVE_CODING_BENCHMARKS.md`.
+The concept/architecture guide was fact-checked against the shipped TypeScript
+implementation and the cited literature, the divergences from canonical PC were
+made explicit, and the benchmark numbers were re-verified for reproducibility.
+**Closes #2965.**
+
+### What changed
+
+- **Config block corrected (biggest drift).** Section 3.2 documented a config
+  interface that never shipped — `maxInferenceIterations`,
+  `convergenceThreshold`, and `integrationMode`. The actual
+  [`src/config/PredictiveCodingConfig.ts`](../../../src/config/PredictiveCodingConfig.ts)
+  exposes `enabled`, `inferenceSteps` (50), `inferenceRate` (0.05),
+  `learningRate` (0.001), `energyThreshold` (1e-6). The block now mirrors the
+  real source, with a note explaining the consolidation. A stale `[!TIP]` that
+  named the old fields was fixed too.
+
+- **Implementation status made explicit.** A top-of-doc `[!IMPORTANT]` callout
+  records (verified June 2026) that PC ships **TypeScript-only** under
+  `src/predictiveCoding/`, is opt-in, includes adaptive scaling (#1915) and
+  trace tags (#1913), and **fully replaces** elastic backprop when enabled. The
+  **Rust/WASM inference engine** (Section 2.7 / Phase 3, issue #1560) and the
+  `complement` integration mode (Phase 5) are flagged as **planned, not yet
+  implemented** — the file names in those sections do not exist on disk.
+
+- **NEAT-AI vs canonical PC.** New `🆚 NEAT-AI vs canonical predictive coding`
+  section in §1 with a table of deliberate divergences: arbitrary directed
+  graphs vs strict layers, shared/tied (transpose) weights, topology-based
+  adaptive scaling, L2-normalised inference gradients, opt-in pipeline role, and
+  TypeScript-only backend.
+
+- **File paths fixed.** Phase 2's `src/propagate/PredictiveCoding.ts` /
+  `CreatureTraining.ts` corrected to the real modules
+  (`src/predictiveCoding/PredictiveCoding{Inference,Learning,Trainer}.ts`,
+  `PredictionErrorComputation.ts`,
+  `src/architecture/training/TrainingPredictiveCoding.ts`). Roadmap phases now
+  carry ✅ shipped / 🟡 partial / 🔜 planned markers.
+
+- **Benchmarks re-verified.** Both `convergence.ts` and `speed.ts` were re-run
+  (Apple M4 Pro, **Deno 2.8.3**, June 2026). Numbers reproduce within run/
+  hardware noise; results appended as dated re-verification tables, keeping the
+  February 2026 rows per the doc's own "append, don't overwrite" methodology.
+
+- **Pre-existing gate failure fixed.** `pr-summary-2964.md` had an unescaped
+  Liquid sequence that was failing `test/docs/JekyllLiquidSafety.ts`; wrapped it
+  in `{% raw %}…{% endraw %}` so the shared docs gate passes.
+
+### NEAT-AI vs canonical PC (divergence summary)
+
+```mermaid
+flowchart LR
+    C["Canonical PC<br/>(Rao & Ballard 1999;<br/>Whittington & Bogacz 2017)"]
+    N["NEAT-AI PC"]
+    C -->|"strict layers"| N1["arbitrary directed graphs<br/>(depth = topo distance)"]
+    C -->|"separate Wfb"| N2["shared/tied weights<br/>(transpose of Wff)"]
+    C -->|"fixed rates"| N3["adaptive scaling by topology<br/>(#1915)"]
+    C -->|"raw gradients"| N4["L2-normalised inference<br/>gradients (capped 1.0)"]
+    C -->|"n/a backend"| N5["TypeScript only;<br/>Rust/WASM planned (#1560)"]
+    N1 --> N
+    N2 --> N
+    N3 --> N
+    N4 --> N
+    N5 --> N
+```
+
+### On splitting the large guide
+
+The issue invited a split "if warranted". The guide is already one half of a
+two-doc cluster (concept/architecture in `PREDICTIVE_CODING.md`, results in
+`PREDICTIVE_CODING_BENCHMARKS.md`), has a single coherent TOC, and is the
+canonical PC design-plus-status reference. A further physical split would
+fragment the cross-references for little readability gain, so it was **not**
+performed; the doc was instead reorganised in place with status markers and an
+explicit implemented-vs-planned framing. Diagrams/charts are present
+(predictive-coding loop, inference/learning flowcharts, dependency graph,
+benchmark-pipeline flow).
+
+## Evidence
+
+Documentation-only change (no runtime code). Verified via:
+
+- `deno test test/docs/DocsIndex.ts test/docs/GlossaryAndStyle.ts
+  test/docs/JekyllLiquidSafety.ts`
+  — 28 passed, 0 failed (after the Liquid fix).
+- `deno fmt` — clean on all changed files.
+- `markdownlint-cli2` — 0 errors across the docs.
+- Custom anchor check — all 21 intra-doc `#…` links resolve; all new relative
+  `src/…` links point at files that exist on disk.
+- Benchmark reproducibility (Apple M4 Pro, Deno 2.8.3): convergence — XOR
+  backprop 4.0 ms / PC 3.7 ms, regression backprop 5.8 ms / PC 8.6 ms; speed —
+  large-network (93 neurons) inference 38.1 ms, Hebbian update 54.3 µs.
+
+## Test Plan
+
+No new code paths, so no new unit tests. Validation relied on the existing docs
+test-suite plus reproducibility runs:
+
+- `test/docs/JekyllLiquidSafety.ts` — passes after escaping the stray Liquid in
+  `pr-summary-2964.md` (previously failing on the base branch).
+- `test/docs/DocsIndex.ts`, `test/docs/GlossaryAndStyle.ts` — confirm the PC
+  guides remain indexed and style-compliant.
+- Ground-truth fact-check cross-checked every documented config field, trace
+  tag, file path, and "planned vs shipped" claim against `src/predictiveCoding/`
+  and `src/config/PredictiveCodingConfig.ts`.
+
+## Acceptance criteria
+
+- [x] PC description verified vs implementation + cited literature; stale config
+      block and file paths corrected.
+- [x] Benchmark numbers re-verified reproducible (Deno 2.8.3) and appended with
+      dates; historical rows retained per methodology.
+- [x] NEAT-AI-vs-standard divergences explicit; "PC" and acronyms defined on
+      first use (acronym list retained).
+- [x] Diagrams/charts present; split judged not warranted (rationale above).
+- [x] Cross-links resolve; both guides linked from `docs/README.md`.


### PR DESCRIPTION
# PR Summary — Docs audit: Predictive Coding guides (#2965)

## Summary

Phase 2 documentation audit (part of #2956) of the two Predictive Coding (PC)
guides — `docs/PREDICTIVE_CODING.md` and `docs/PREDICTIVE_CODING_BENCHMARKS.md`.
The concept/architecture guide was fact-checked against the shipped TypeScript
implementation and the cited literature, the divergences from canonical PC were
made explicit, and the benchmark numbers were re-verified for reproducibility.
**Closes #2965.**

### What changed

- **Config block corrected (biggest drift).** Section 3.2 documented a config
  interface that never shipped — `maxInferenceIterations`,
  `convergenceThreshold`, and `integrationMode`. The actual
  [`src/config/PredictiveCodingConfig.ts`](../../../src/config/PredictiveCodingConfig.ts)
  exposes `enabled`, `inferenceSteps` (50), `inferenceRate` (0.05),
  `learningRate` (0.001), `energyThreshold` (1e-6). The block now mirrors the
  real source, with a note explaining the consolidation. A stale `[!TIP]` that
  named the old fields was fixed too.

- **Implementation status made explicit.** A top-of-doc `[!IMPORTANT]` callout
  records (verified June 2026) that PC ships **TypeScript-only** under
  `src/predictiveCoding/`, is opt-in, includes adaptive scaling (#1915) and
  trace tags (#1913), and **fully replaces** elastic backprop when enabled. The
  **Rust/WASM inference engine** (Section 2.7 / Phase 3, issue #1560) and the
  `complement` integration mode (Phase 5) are flagged as **planned, not yet
  implemented** — the file names in those sections do not exist on disk.

- **NEAT-AI vs canonical PC.** New `🆚 NEAT-AI vs canonical predictive coding`
  section in §1 with a table of deliberate divergences: arbitrary directed
  graphs vs strict layers, shared/tied (transpose) weights, topology-based
  adaptive scaling, L2-normalised inference gradients, opt-in pipeline role, and
  TypeScript-only backend.

- **File paths fixed.** Phase 2's `src/propagate/PredictiveCoding.ts` /
  `CreatureTraining.ts` corrected to the real modules
  (`src/predictiveCoding/PredictiveCoding{Inference,Learning,Trainer}.ts`,
  `PredictionErrorComputation.ts`,
  `src/architecture/training/TrainingPredictiveCoding.ts`). Roadmap phases now
  carry ✅ shipped / 🟡 partial / 🔜 planned markers.

- **Benchmarks re-verified.** Both `convergence.ts` and `speed.ts` were re-run
  (Apple M4 Pro, **Deno 2.8.3**, June 2026). Numbers reproduce within run/
  hardware noise; results appended as dated re-verification tables, keeping the
  February 2026 rows per the doc's own "append, don't overwrite" methodology.

- **Pre-existing gate failure fixed.** `pr-summary-2964.md` had an unescaped
  Liquid sequence that was failing `test/docs/JekyllLiquidSafety.ts`; wrapped it
  in `{% raw %}…{% endraw %}` so the shared docs gate passes.

### NEAT-AI vs canonical PC (divergence summary)

```mermaid
flowchart LR
    C["Canonical PC<br/>(Rao & Ballard 1999;<br/>Whittington & Bogacz 2017)"]
    N["NEAT-AI PC"]
    C -->|"strict layers"| N1["arbitrary directed graphs<br/>(depth = topo distance)"]
    C -->|"separate Wfb"| N2["shared/tied weights<br/>(transpose of Wff)"]
    C -->|"fixed rates"| N3["adaptive scaling by topology<br/>(#1915)"]
    C -->|"raw gradients"| N4["L2-normalised inference<br/>gradients (capped 1.0)"]
    C -->|"n/a backend"| N5["TypeScript only;<br/>Rust/WASM planned (#1560)"]
    N1 --> N
    N2 --> N
    N3 --> N
    N4 --> N
    N5 --> N
```

### On splitting the large guide

The issue invited a split "if warranted". The guide is already one half of a
two-doc cluster (concept/architecture in `PREDICTIVE_CODING.md`, results in
`PREDICTIVE_CODING_BENCHMARKS.md`), has a single coherent TOC, and is the
canonical PC design-plus-status reference. A further physical split would
fragment the cross-references for little readability gain, so it was **not**
performed; the doc was instead reorganised in place with status markers and an
explicit implemented-vs-planned framing. Diagrams/charts are present
(predictive-coding loop, inference/learning flowcharts, dependency graph,
benchmark-pipeline flow).

## Evidence

Documentation-only change (no runtime code). Verified via:

- `deno test test/docs/DocsIndex.ts test/docs/GlossaryAndStyle.ts
  test/docs/JekyllLiquidSafety.ts`
  — 28 passed, 0 failed (after the Liquid fix).
- `deno fmt` — clean on all changed files.
- `markdownlint-cli2` — 0 errors across the docs.
- Custom anchor check — all 21 intra-doc `#…` links resolve; all new relative
  `src/…` links point at files that exist on disk.
- Benchmark reproducibility (Apple M4 Pro, Deno 2.8.3): convergence — XOR
  backprop 4.0 ms / PC 3.7 ms, regression backprop 5.8 ms / PC 8.6 ms; speed —
  large-network (93 neurons) inference 38.1 ms, Hebbian update 54.3 µs.

## Test Plan

No new code paths, so no new unit tests. Validation relied on the existing docs
test-suite plus reproducibility runs:

- `test/docs/JekyllLiquidSafety.ts` — passes after escaping the stray Liquid in
  `pr-summary-2964.md` (previously failing on the base branch).
- `test/docs/DocsIndex.ts`, `test/docs/GlossaryAndStyle.ts` — confirm the PC
  guides remain indexed and style-compliant.
- Ground-truth fact-check cross-checked every documented config field, trace
  tag, file path, and "planned vs shipped" claim against `src/predictiveCoding/`
  and `src/config/PredictiveCodingConfig.ts`.

## Acceptance criteria

- [x] PC description verified vs implementation + cited literature; stale config
      block and file paths corrected.
- [x] Benchmark numbers re-verified reproducible (Deno 2.8.3) and appended with
      dates; historical rows retained per methodology.
- [x] NEAT-AI-vs-standard divergences explicit; "PC" and acronyms defined on
      first use (acronym list retained).
- [x] Diagrams/charts present; split judged not warranted (rationale above).
- [x] Cross-links resolve; both guides linked from `docs/README.md`.



## Milestone
This PR is part of the **clean up docs** milestone and targets the `milestone/clean-up-docs` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqfza4nr-a18c30`<!-- vibe-worker-issue-2965 -->