### PR TITLE
Docs audit: operational guides — Configuration, Troubleshooting, Timeouts (#2969)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -21,6 +21,35 @@ flowchart LR
     Idx --> ONNX[troubleshooting/ONNX.md]
 ```
 
+## 🧭 First-response decision tree
+
+Not sure which topic you need? Start here and follow the first branch that
+matches your symptom.
+
+```mermaid
+flowchart TD
+    Start{What went wrong?} --> Crash[Process crashed / killed]
+    Start --> Err[Error message thrown]
+    Start --> Slow[Run is too slow]
+    Start --> Bad[Run finishes but results are poor]
+
+    Crash --> OOM{Exit 143 / SIGTERM?}
+    OOM -->|yes| Mem[troubleshooting/MEMORY.md]
+    OOM -->|no| WASMc[troubleshooting/WASM.md]
+
+    Err --> Val{ValidationError?}
+    Val -->|yes| Cfg[troubleshooting/CONFIGURATION.md]
+    Val -->|no| Ffi{FFI / discovery / GPU?}
+    Ffi -->|yes| Disc[troubleshooting/DISCOVERY.md]
+    Ffi -->|no| Onnx{ONNX export?}
+    Onnx -->|yes| ONNXd[troubleshooting/ONNX.md]
+    Onnx -->|no| WASMe[troubleshooting/WASM.md]
+
+    Slow --> Perf[troubleshooting/PERFORMANCE.md]
+
+    Bad --> Train[troubleshooting/TRAINING.md]
+```
+
 ## ⚙️ WASM (WebAssembly) — init, load, and runtime panics
 
 WASM activation is mandatory; there is no JavaScript fallback. See
@@ -47,10 +76,10 @@ WASM activation is mandatory; there is no JavaScript fallback. See
 - **WASM panic during fitness evaluation** — handled gracefully since Issues
   #2207 / #2212; root cause is usually numerical overflow. →
   [WASM panic recovery](troubleshooting/WASM.md#-wasm-panic-recovery).
-- **`[Offspring] dropping offspring that fails WASM compile`** or
-  **`[Mutator] reverting mutation that fails WASM compile`** — the producer gate
-  trapped on a bred or mutated topology and wrote a replay-ready dump under
-  `.diagnostics/` (Issue #2672). →
+- **`[Offspring/breed] dropping offspring from step=… that fails WASM compile`**
+  or **`[Mutator] reverting mutation from step=… that fails WASM compile`** —
+  the producer gate trapped on a bred or mutated topology and wrote a
+  replay-ready dump under `.diagnostics/` (Issue #2672). →
   [Producer-gate WASM compile rejects](troubleshooting/WASM.md#-producer-gate-wasm-compile-rejects-issue-2672).
 
 ## 🦀 Discovery / Rust FFI — build, load, and GPU backend selection
@@ -65,10 +94,10 @@ diagnostics.
 - **Segfault / "Killed: 9" loading the library** — `arm64` vs `x86_64` (or
   `glibc` vs `musl`) mismatch; rebuild on the target machine. →
   [Architecture mismatch errors](troubleshooting/DISCOVERY.md#-architecture-mismatch-errors-arm64-vs-x86).
-- **`Discovery disabled: Rust library loaded but GPU probe failed`** — no
-  compatible `wgpu` adapter (Metal / Vulkan / DirectX 12); discovery falls back
-  to CPU or is disabled. →
-  [No GPU detected](troubleshooting/DISCOVERY.md#-no-gpu-detected).
+- **`ℹ️  No GPU detected — discovery will use CPU fallback`** — no compatible
+  `wgpu` adapter (Metal / Vulkan / DirectX 12). This is **non-fatal**: the GPU
+  probe is informational only and does not gate discovery, which continues on
+  CPU. → [No GPU detected](troubleshooting/DISCOVERY.md#-no-gpu-detected).
 - **Library cannot be found at the default locations** — set
   `NEAT_AI_DISCOVERY_LIB_PATH` to an absolute path. →
   [Setting NEAT_AI_DISCOVERY_LIB_PATH](troubleshooting/DISCOVERY.md#-setting-neat_ai_discovery_lib_path).
@@ -155,12 +184,19 @@ See [`troubleshooting/ONNX.md`](troubleshooting/ONNX.md) for full details.
 
 ## 🌐 Environment variables reference
 
-| Variable                          | Default  | Purpose                                     |
-| --------------------------------- | -------- | ------------------------------------------- |
-| `NEAT_AI_DISCOVERY_LIB_PATH`      | _(none)_ | Override discovery library location         |
-| `NEAT_AI_WORKER_INIT_TIMEOUT_MS`  | `60000`  | Worker initialisation timeout (ms)          |
-| `NEAT_AI_DISCOVERY_VERBOSE`       | _(none)_ | Enable verbose discovery logging in workers |
-| `NEAT_AI_DISCOVERY_DETERMINISTIC` | _(none)_ | Force deterministic discovery (testing)     |
+| Variable                          | Default        | Purpose                                                                |
+| --------------------------------- | -------------- | ---------------------------------------------------------------------- |
+| `NEAT_AI_DISCOVERY_LIB_PATH`      | _(none)_       | Override discovery library location                                    |
+| `NEAT_AI_WORKER_INIT_TIMEOUT_MS`  | `60000`        | Worker initialisation timeout (ms); ignored below `1000`               |
+| `NEAT_AI_DISCOVERY_VERBOSE`       | _(none)_       | Enable verbose discovery logging in workers (`1`)                      |
+| `NEAT_AI_DISCOVERY_DETERMINISTIC` | _(none)_       | Force deterministic discovery for testing (`1` / `true`)               |
+| `NEAT_AI_RUST_SCORER_ENABLED`     | `false`        | Route fitness scoring through the external Rust scorer process         |
+| `NEAT_AI_RUST_SCORER_BINARY_PATH` | `rust_scorer`  | Path to the Rust scorer binary                                         |
+| `NEAT_AI_RUST_SCORER_BATCH`       | `true`         | Directory/batch scoring mode; set `false` for per-creature invocations |
+| `NEAT_AI_RUST_SCORER_TIMEOUT_MS`  | `0` (no limit) | Per-invocation timeout for the Rust scorer (ms)                        |
+| `NEAT_AI_RUST_SCORER_TMP_DIR`     | _(data dir)_   | Working directory for Rust scorer batch I/O                            |
+| `NEAT_AI_RUST_SCORER_ENV`         | _(none)_       | JSON object of extra env vars passed to the Rust scorer child process  |
+| `NEAT_AI_TRACE_PREDICTION`        | _(none)_       | Log detailed discovery failure-cache prediction traces (`1`)           |
 
 ## 🆘 Getting help
 

--- a/docs/archive/pr-summaries/pr-summary-2969.md
+++ b/docs/archive/pr-summaries/pr-summary-2969.md
@@ -1,0 +1,80 @@
+# Docs audit: operational guides (Configuration, Troubleshooting, Timeouts)
+
+## Summary
+
+Phase 2 of the documentation audit (#2956). Fact-checked the three operational
+guides — `docs/CONFIGURATION_GUIDE.md`, `docs/TROUBLESHOOTING.md`,
+`docs/TIMEOUTS.md` — against the current code and corrected obsolete content.
+Closes #2969.
+
+Findings and changes:
+
+- **`CONFIGURATION_GUIDE.md`** — verified accurate, no changes needed. It is a
+  topic index over `docs/config/`; all linked detail docs exist, the four
+  presets (`QUICK_START_PRESET`, `LARGE_NETWORK_PRESET`,
+  `MEMORY_CONSTRAINED_PRESET`, `DISCOVERY_FOCUSED_PRESET`) match `src/config/`,
+  and `createNeatConfig()` / `NeatOptionsInput` are accurate.
+- **`TIMEOUTS.md`** — verified accurate, no changes needed.
+  `HARD_DEADLINE_GRACE_MINUTES = 15`, `computeHardDeadlineTS`, the
+  `T + min(15, T)` guarantee, and the `evolveDir` / `evolveDataSet` /
+  `evolveEnv` / `evolveRL` sibling set all match `src/NEAT/HardDeadline.ts` and
+  `src/creature/CreatureTraining.ts`.
+- **`TROUBLESHOOTING.md`** — corrected obsolete content and expanded coverage:
+  - **Obsolete GPU message removed.** The code no longer emits
+    `Discovery disabled: Rust library loaded but GPU probe failed`, and the GPU
+    probe no longer gates discovery — it is informational only and discovery
+    always falls back to CPU (`RustDiscoveryLibrary.ts`). Updated both the index
+    entry and `troubleshooting/DISCOVERY.md` to the current message
+    `ℹ️  No GPU detected — discovery will use CPU fallback`.
+  - **Producer-gate log labels corrected** to match the actual log lines
+    (`[Offspring/breed] dropping offspring from step=…`,
+    `[Mutator] reverting
+    mutation from step=…`).
+  - **Environment-variable reference expanded** with the current Rust scorer
+    knobs (`NEAT_AI_RUST_SCORER_ENABLED`, `_BINARY_PATH`, `_BATCH`,
+    `_TIMEOUT_MS`, `_TMP_DIR`, `_ENV`) and `NEAT_AI_TRACE_PREDICTION`, with
+    defaults verified against `src/score/RustScorerBridge.ts` and friends.
+  - **Added a first-response decision tree** (Mermaid) routing readers from
+    symptom to the right topic doc, per the issue's request.
+
+## Evidence
+
+Docs-only change — no web interface to screenshot. Verified by:
+
+- `deno fmt` — clean.
+- `cspell` (docs/cspell.json) — 0 issues.
+- `markdownlint-cli2` — 0 errors across all 103 markdown files.
+- Each quoted error string, env var default, and constant was grepped against
+  `src/` to confirm it exists verbatim (or removed where it no longer does).
+
+New first-response decision tree added to `TROUBLESHOOTING.md`:
+
+```mermaid
+flowchart TD
+    Start{What went wrong?} --> Crash[Process crashed / killed]
+    Start --> Err[Error message thrown]
+    Start --> Slow[Run is too slow]
+    Start --> Bad[Run finishes but results are poor]
+
+    Crash --> OOM{Exit 143 / SIGTERM?}
+    OOM -->|yes| Mem[troubleshooting/MEMORY.md]
+    OOM -->|no| WASMc[troubleshooting/WASM.md]
+
+    Err --> Val{ValidationError?}
+    Val -->|yes| Cfg[troubleshooting/CONFIGURATION.md]
+    Val -->|no| Ffi{FFI / discovery / GPU?}
+    Ffi -->|yes| Disc[troubleshooting/DISCOVERY.md]
+    Ffi -->|no| Onnx{ONNX export?}
+    Onnx -->|yes| ONNXd[troubleshooting/ONNX.md]
+    Onnx -->|no| WASMe[troubleshooting/WASM.md]
+
+    Slow --> Perf[troubleshooting/PERFORMANCE.md]
+
+    Bad --> Train[troubleshooting/TRAINING.md]
+```
+
+## Test Plan
+
+No code changed, so no unit tests were added. Documentation accuracy was
+validated by grepping `src/` for every quoted string/default and by the
+`deno fmt`, `cspell`, and `markdownlint-cli2` gates above.

--- a/docs/troubleshooting/DISCOVERY.md
+++ b/docs/troubleshooting/DISCOVERY.md
@@ -114,14 +114,17 @@ deno run --allow-ffi --allow-read --allow-env your_script.ts
 
 ## 🖥️ No GPU detected
 
-**Symptom:** `Discovery disabled: Rust library loaded but GPU probe failed`
+**Symptom:** `ℹ️  No GPU detected — discovery will use CPU fallback`
 
-This is a **non-fatal** condition. The library loaded but no usable GPU was
-found. Discovery simply will not run. On macOS, ensure Metal is available.
+This is a **non-fatal**, informational condition. The library loaded but no
+usable GPU was found. The GPU probe is for logging/telemetry only — it does
+**not** gate discovery, which continues to run on the CPU path handled inside
+the Rust library. GPU accelerates analysis but is not required. On macOS, ensure
+Metal is available if you want the acceleration.
 
 The Rust extension uses `wgpu` to negotiate Metal (macOS), Vulkan (Linux), or
-DirectX 12 (Windows). When no compatible adapter is available it falls back to
-CPU; if even the CPU path is unavailable, discovery is disabled. See
+DirectX 12 (Windows). When no compatible adapter is available the library falls
+back to CPU computation automatically. See
 [`../GPU_ACCELERATION.md`](../GPU_ACCELERATION.md) for backend selection
 details.
 


### PR DESCRIPTION
# Docs audit: operational guides (Configuration, Troubleshooting, Timeouts)

## Summary

Phase 2 of the documentation audit (#2956). Fact-checked the three operational
guides — `docs/CONFIGURATION_GUIDE.md`, `docs/TROUBLESHOOTING.md`,
`docs/TIMEOUTS.md` — against the current code and corrected obsolete content.
Closes #2969.

Findings and changes:

- **`CONFIGURATION_GUIDE.md`** — verified accurate, no changes needed. It is a
  topic index over `docs/config/`; all linked detail docs exist, the four
  presets (`QUICK_START_PRESET`, `LARGE_NETWORK_PRESET`,
  `MEMORY_CONSTRAINED_PRESET`, `DISCOVERY_FOCUSED_PRESET`) match `src/config/`,
  and `createNeatConfig()` / `NeatOptionsInput` are accurate.
- **`TIMEOUTS.md`** — verified accurate, no changes needed.
  `HARD_DEADLINE_GRACE_MINUTES = 15`, `computeHardDeadlineTS`, the
  `T + min(15, T)` guarantee, and the `evolveDir` / `evolveDataSet` /
  `evolveEnv` / `evolveRL` sibling set all match `src/NEAT/HardDeadline.ts` and
  `src/creature/CreatureTraining.ts`.
- **`TROUBLESHOOTING.md`** — corrected obsolete content and expanded coverage:
  - **Obsolete GPU message removed.** The code no longer emits
    `Discovery disabled: Rust library loaded but GPU probe failed`, and the GPU
    probe no longer gates discovery — it is informational only and discovery
    always falls back to CPU (`RustDiscoveryLibrary.ts`). Updated both the index
    entry and `troubleshooting/DISCOVERY.md` to the current message
    `ℹ️  No GPU detected — discovery will use CPU fallback`.
  - **Producer-gate log labels corrected** to match the actual log lines
    (`[Offspring/breed] dropping offspring from step=…`,
    `[Mutator] reverting
    mutation from step=…`).
  - **Environment-variable reference expanded** with the current Rust scorer
    knobs (`NEAT_AI_RUST_SCORER_ENABLED`, `_BINARY_PATH`, `_BATCH`,
    `_TIMEOUT_MS`, `_TMP_DIR`, `_ENV`) and `NEAT_AI_TRACE_PREDICTION`, with
    defaults verified against `src/score/RustScorerBridge.ts` and friends.
  - **Added a first-response decision tree** (Mermaid) routing readers from
    symptom to the right topic doc, per the issue's request.

## Evidence

Docs-only change — no web interface to screenshot. Verified by:

- `deno fmt` — clean.
- `cspell` (docs/cspell.json) — 0 issues.
- `markdownlint-cli2` — 0 errors across all 103 markdown files.
- Each quoted error string, env var default, and constant was grepped against
  `src/` to confirm it exists verbatim (or removed where it no longer does).

New first-response decision tree added to `TROUBLESHOOTING.md`:

```mermaid
flowchart TD
    Start{What went wrong?} --> Crash[Process crashed / killed]
    Start --> Err[Error message thrown]
    Start --> Slow[Run is too slow]
    Start --> Bad[Run finishes but results are poor]

    Crash --> OOM{Exit 143 / SIGTERM?}
    OOM -->|yes| Mem[troubleshooting/MEMORY.md]
    OOM -->|no| WASMc[troubleshooting/WASM.md]

    Err --> Val{ValidationError?}
    Val -->|yes| Cfg[troubleshooting/CONFIGURATION.md]
    Val -->|no| Ffi{FFI / discovery / GPU?}
    Ffi -->|yes| Disc[troubleshooting/DISCOVERY.md]
    Ffi -->|no| Onnx{ONNX export?}
    Onnx -->|yes| ONNXd[troubleshooting/ONNX.md]
    Onnx -->|no| WASMe[troubleshooting/WASM.md]

    Slow --> Perf[troubleshooting/PERFORMANCE.md]

    Bad --> Train[troubleshooting/TRAINING.md]
```

## Test Plan

No code changed, so no unit tests were added. Documentation accuracy was
validated by grepping `src/` for every quoted string/default and by the
`deno fmt`, `cspell`, and `markdownlint-cli2` gates above.



## Milestone
This PR is part of the **clean up docs** milestone and targets the `milestone/clean-up-docs` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqg3zarg-19cf73`<!-- vibe-worker-issue-2969 -->