### PR TITLE
Docs: audit Rust/WASM, core-parity & dependency-policy docs (#2968)

### DIFF
--- a/docs/CI_EXTERNAL_NEAT_AI_CORE.md
+++ b/docs/CI_EXTERNAL_NEAT_AI_CORE.md
@@ -2,8 +2,8 @@
 
 > **Brief:** Continuous Integration (CI) here never builds Rust or resolves
 > NEAT-AI-core HEAD. It only **verifies** that the vendored
-> `wasm_activation/pkg/**` matches the SHA pinned in `deno.json`. For the
-> cluster overview start at
+> [WebAssembly (WASM)](GLOSSARY.md#-acronyms) bundle `wasm_activation/pkg/**`
+> matches the SHA pinned in `deno.json`. For the cluster overview start at
 > [docs/EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md).
 
 ## What the workflows do today

--- a/docs/CORE_DEPENDENCY_POLICY.md
+++ b/docs/CORE_DEPENDENCY_POLICY.md
@@ -1,9 +1,9 @@
 # NEAT-AI-core Release and Pinning Policy
 
-Issue #2342 — ADR for how NEAT-AI consumes native computation from
-[NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) after removing all
-in-repo Rust source. Issue #2433 / #2434 extended this to an artifact-based
-auto-sync flow that mirrors the GRQ ← NEAT-AI pattern.
+Issue #2342 — Architecture Decision Record (ADR) for how NEAT-AI consumes native
+computation from [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core)
+after removing all in-repo Rust source. Issue #2433 / #2434 extended this to an
+artifact-based auto-sync flow that mirrors the GRQ ← NEAT-AI pattern.
 
 ## Decision Summary
 
@@ -38,9 +38,10 @@ flowchart LR
 
 Pinning by upstream commit SHA stops a release _tag_ from being renamed or
 replaced, but it does not prevent the _asset_ attached to a release from being
-swapped (compromised CI runner, leaked release-write token, MITM on the
-unauthenticated `releases/download/...` URL). `build.sh` therefore enforces two
-independent content-hash guards on every download:
+swapped (compromised Continuous Integration (CI) runner, leaked release-write
+token, Man-in-the-Middle (MITM) attack on the unauthenticated
+`releases/download/...` URL). `build.sh` therefore enforces two independent
+content-hash guards on every download:
 
 1. **`deno.json` pin** — set `neatCore.assetSha256` to the expected SHA-256 of
    `wasm_activation-pkg.tar.gz`. When set, `build.sh` recomputes the hash
@@ -86,7 +87,8 @@ bits are never honoured.
 - Release control happens at PR approval and merge timing.
 - No Rust toolchain required in NEAT-AI CI or local contributor setup.
 - External API stays unchanged (`wasm_activation/pkg/**` is still published to
-  JSR exactly as before), so GRQ and other downstream consumers do not change
+  the [JavaScript Registry (JSR)](https://jsr.io/) exactly as before), so GRQ (a
+  downstream NEAT-AI-core consumer) and other downstream consumers do not change
   their imports.
 - The full `(repo, ref, rev)` triple is still recorded in `deno.json`, so any
   past build is reproducible by passing `--rev <SHA>` to `build.sh`.

--- a/docs/EXTERNAL_NEAT_AI_CORE.md
+++ b/docs/EXTERNAL_NEAT_AI_CORE.md
@@ -19,13 +19,13 @@ flowchart LR
 
 This cluster has five docs. Use this overview to pick the one you need.
 
-| Doc                                                          | When to read                                                                                                 |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| **This page**                                                | Day-to-day workflow for bumping the pinned revision.                                                         |
-| [`CORE_DEPENDENCY_POLICY.md`](CORE_DEPENDENCY_POLICY.md)     | The pinning policy ADR — why we pin by SHA, semver bands, approval tiers, and the `build.sh` mode reference. |
-| [`PARITY_GATE.md`](PARITY_GATE.md)                           | Release checklist — what the parity gate runs and how to interpret its output.                               |
-| [`CI_EXTERNAL_NEAT_AI_CORE.md`](CI_EXTERNAL_NEAT_AI_CORE.md) | What the GitHub Actions workflows do for this dependency, and the sync-policy guard.                         |
-| [`PARITY_AUDITS.md`](PARITY_AUDITS.md)                       | Archived audits (#2367, #2368, #2369) for in-tree code that has since been removed.                          |
+| Doc                                                          | When to read                                                                                                                                |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **This page**                                                | Day-to-day workflow for bumping the pinned revision.                                                                                        |
+| [`CORE_DEPENDENCY_POLICY.md`](CORE_DEPENDENCY_POLICY.md)     | The pinning policy Architecture Decision Record (ADR) — why we pin by SHA, semver bands, approval tiers, and the `build.sh` mode reference. |
+| [`PARITY_GATE.md`](PARITY_GATE.md)                           | Release checklist — what the parity gate runs and how to interpret its output.                                                              |
+| [`CI_EXTERNAL_NEAT_AI_CORE.md`](CI_EXTERNAL_NEAT_AI_CORE.md) | What the GitHub Actions workflows do for this dependency, and the sync-policy guard.                                                        |
+| [`PARITY_AUDITS.md`](PARITY_AUDITS.md)                       | Archived audits (#2367, #2368, #2369) for in-tree code that has since been removed.                                                         |
 
 ## TL;DR
 
@@ -84,8 +84,12 @@ deno eval 'const c = JSON.parse(Deno.readTextFileSync("../NEAT-AI-scorer/deno.js
 ```
 
 If the revisions differ, update the scorer pin and rerun its tests in the same
-coordinated bump. The scorer alignment policy is verified by
-[`test/scripts/ScorerAlignmentPolicy.ts`](../test/scripts/ScorerAlignmentPolicy.ts).
+coordinated bump. Alignment is a manual coordinated step: the former
+`test/scripts/ScorerAlignmentPolicy.ts` check was removed in Issue #2887 because
+it asserted on documentation text rather than runtime behaviour. The scorer
+lives in a separate repository, so this workspace cannot verify its pin
+automatically — compare the two `neatCore.rev` values with the commands above
+when bumping.
 
 ## Sync invariant
 

--- a/docs/PARITY_AUDITS.md
+++ b/docs/PARITY_AUDITS.md
@@ -63,9 +63,9 @@ into NEAT-AI-core, consumed via `wasm_activation/pkg/**`.
 
 Current scoring parity is verified by
 [`test/score/WasmJsScoreParity.ts`](../test/score/WasmJsScoreParity.ts): the
-test scores a deterministic synthetic creature end-to-end through the WASM
-activation module and asserts the score is finite, non-negative and bounded
-by 1.
+test scores a deterministic synthetic creature end-to-end through the
+[WebAssembly (WASM)](GLOSSARY.md#-acronyms) activation module and asserts the
+score is finite, non-negative and bounded by 1.
 
 The original audit narrative lives in the merged PR for Issue #2368 (browse via
 `git log` or GitHub's PR history); the per-PR summary file was pruned in Issue

--- a/docs/PARITY_GATE.md
+++ b/docs/PARITY_GATE.md
@@ -3,6 +3,22 @@
 Issue #2345 — parity checklist that validates NEAT-AI stays aligned with the
 pinned [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) revision.
 
+The numerically heavy core lives in Rust and is consumed here as a vendored
+[WebAssembly (WASM)](GLOSSARY.md#-acronyms) bundle; the
+[TypeScript](https://www.typescriptlang.org/) (TS) runtime calls across that
+boundary. This gate confirms the two sides still agree — see
+[TS_RUST_MIGRATION.md](TS_RUST_MIGRATION.md) for what lives where and why.
+
+```mermaid
+flowchart LR
+    Pin["deno.json<br/>neatCore.rev (SHA)"] --> S1["Step 1<br/>Core dependency policy<br/>CoreDependencyPolicy.ts"]
+    S1 --> S2["Step 2<br/>./build.sh<br/>sync wasm_activation/pkg"]
+    S2 --> S3["Step 3<br/>TS ↔ WASM parity tests<br/>WasmJsScoreParity + MSE"]
+    S3 --> Pass{"all pass?"}
+    Pass -- "yes" --> Sign["Sign-off / release"]
+    Pass -- "no" --> Block["Block repin<br/>(see Failure response)"]
+```
+
 ## When to run the gate
 
 - After bumping `deno.json` `neatCore.rev`.
@@ -42,9 +58,12 @@ deno test --no-check --allow-read \
 Verifies the invariants from
 [docs/CORE_DEPENDENCY_POLICY.md](CORE_DEPENDENCY_POLICY.md):
 
-- `deno.json` pins `neatCore.repo` and `neatCore.rev`.
-- `neatCore.rev` is a full 40-character hex SHA.
-- The policy document exists and references the required topics.
+- `deno.json` pins `neatCore.repo` and `neatCore.ref`; `neatCore.rev` is a full
+  40-character hex SHA when set.
+- The policy document exists.
+- The `neatCore` block documented in `CORE_DEPENDENCY_POLICY.md` agrees with
+  `deno.json` on `repo` and `ref` (the keyword-grep assertions were dropped in
+  Issue #2887 in favour of this behavioural check).
 
 ### Step 2 — Sync WASM artifacts from pinned rev
 

--- a/docs/VERSION_VISIBILITY.md
+++ b/docs/VERSION_VISIBILITY.md
@@ -8,9 +8,10 @@ version it actually loaded, once per process, at startup.
 Two pieces of context made this necessary:
 
 - The GRQ-logs / Develop trap-sample storm in May 2026 was eventually traced
-  back to GRQ workers pinned to `5.0.13`. That JSR release predates the
-  position-blind topology-hash collision fix from PR #2678, which only landed in
-  `5.0.14`+.
+  back to GRQ (a downstream NEAT-AI consumer) workers pinned to `5.0.13`. That
+  [JavaScript Registry (JSR)](https://jsr.io/) release predates the
+  position-blind topology-hash collision fix from Pull Request (PR) #2678, which
+  only landed in `5.0.14`+.
 - The only way to discover the running version at the time was to read it out of
   a captured stack trace
   (`https://jsr.io/@stsoftware/neat-ai/5.0.13/src/architecture/Offspring.ts:688`).
@@ -80,3 +81,16 @@ load path, and JSR consumers derive the version from `import.meta.url` after
 publish. Downstream consumers (GRQ and sibling repos) need to refresh their
 `@stsoftware/neat-ai` pin to the new JSR version so they pick up the fix; verify
 the line in their logs after the restart.
+
+## Related documents
+
+- [docs/README.md](README.md) — full documentation index.
+- [docs/CORE_DEPENDENCY_POLICY.md](CORE_DEPENDENCY_POLICY.md) — how the pinned
+  NEAT-AI-core revision (and the `@stsoftware/neat-ai` version) is bumped.
+- [docs/EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md) — cluster overview
+  for the NEAT-AI-core dependency.
+
+---
+
+**Up to:** [`README.md`](../README.md) (entry point) ·
+[`docs/README.md`](README.md) (topic index).

--- a/docs/archive/pr-summaries/pr-summary-2968.md
+++ b/docs/archive/pr-summaries/pr-summary-2968.md
@@ -1,0 +1,79 @@
+# PR Summary — Docs audit: Rust/WASM, core-parity & dependency-policy docs
+
+## Summary
+
+Phase 2 of the documentation audit (#2956) for the Rust/WASM, core-parity and
+dependency-policy cluster. Each in-scope doc was fact-checked against the
+current Continuous Integration (CI) workflows, the parity gate script,
+`build.sh`, `bump-deps.sh` and the dependency policy. Stale claims were
+corrected, obsolete references deleted, acronyms expanded on first use, and a
+Mermaid flow added for the parity gate. **Closes #2968.**
+
+The cluster was already consolidated in a prior pass (#2570/#2962): the three
+~13-line `*_PARITY_AUDIT.md` files are redirect stubs pointing at the single
+`PARITY_AUDITS.md`. They are **retained** because
+`test/scripts/ParityAuditsConsolidation.ts` requires them to remain as redirects
+so historical PR-summary links still resolve — the parity story is told once in
+`PARITY_AUDITS.md`.
+
+### Key fact-check fixes
+
+| Doc                                               | Change                                                       | Why                                                                                                                                                                                               |
+| ------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PARITY_GATE.md`                                  | Rewrote Step 1 invariants                                    | The "references the required topics" keyword-grep assertion was removed in #2887; `CoreDependencyPolicy.ts` now checks the policy doc's `neatCore` block agrees with `deno.json` on `repo`/`ref`. |
+| `PARITY_GATE.md`                                  | Added a Mermaid gate flow; expanded WASM/TS                  | Acceptance criterion: a Mermaid flow for the parity gate; acronyms on first use.                                                                                                                  |
+| `EXTERNAL_NEAT_AI_CORE.md`                        | Removed reference to `test/scripts/ScorerAlignmentPolicy.ts` | That test was deleted in #2887/#2890; scorer alignment is now a manual coordinated bump.                                                                                                          |
+| `CORE_DEPENDENCY_POLICY.md`                       | Expanded ADR / CI / MITM / JSR                               | House style — define acronyms on first use.                                                                                                                                                       |
+| `CI_EXTERNAL_NEAT_AI_CORE.md`, `PARITY_AUDITS.md` | Expanded WASM on first use                                   | House style.                                                                                                                                                                                      |
+| `VERSION_VISIBILITY.md`                           | Expanded JSR / GRQ / PR; added cluster cross-link footer     | House style + consistent cross-linking with sibling cluster docs.                                                                                                                                 |
+
+### Verified accurate (no change needed)
+
+- `PARITY_GATE.md` command blocks match `scripts/parity-gate.sh` (Step 1
+  command, Step 2 `./build.sh`, Step 3 test list, all flags).
+- `build.sh` mode table in `CORE_DEPENDENCY_POLICY.md` matches the script's
+  actual flags (`--verify-only`, `--rev`, `--clean`, `--allow-unverified`).
+- `CI_EXTERNAL_NEAT_AI_CORE.md` matches `quality.yml`/`publish.yml`
+  (`./build.sh --verify-only`).
+- `deno.json` pins `neatCore.repo`/`ref`/`rev`/`assetSha256` as documented.
+- `TS_RUST_MIGRATION.md` already expands every acronym and explains the
+  Rust/WASM-vs-TS split — left as-is.
+
+## Evidence
+
+Documentation-only change; no UI or runtime behaviour. Verified via the
+doc-coupled test suite, `deno fmt`, and `cspell`.
+
+```
+ok | 39 passed | 0 failed
+```
+
+Tests run: `ParityAuditsConsolidation.ts`, `ParityGate.ts`,
+`CoreDependencyPolicy.ts`, `BuildScript.ts`, `ContributorCoreDocs.ts`,
+`DocsIndex.ts` (all green). `deno fmt --check` and `cspell` clean on all six
+edited files.
+
+### Parity-gate flow added to `PARITY_GATE.md`
+
+```mermaid
+flowchart LR
+    Pin["deno.json<br/>neatCore.rev (SHA)"] --> S1["Step 1<br/>Core dependency policy"]
+    S1 --> S2["Step 2<br/>./build.sh sync"]
+    S2 --> S3["Step 3<br/>TS ↔ WASM parity tests"]
+    S3 --> Pass{"all pass?"}
+    Pass -- "yes" --> Sign["Sign-off / release"]
+    Pass -- "no" --> Block["Block repin"]
+```
+
+## Test Plan
+
+No new tests were added — this is a documentation audit and the existing
+doc-coupled tests already pin the contract each doc must satisfy:
+
+- `test/scripts/ParityAuditsConsolidation.ts` — consolidation + redirect stubs.
+- `test/scripts/ParityGate.ts` — gate doc exists; script CLI surface.
+- `test/scripts/CoreDependencyPolicy.ts` — policy doc agrees with `deno.json`.
+- `test/scripts/BuildScript.ts` — policy doc describes the artifact flow.
+- `test/docs/DocsIndex.ts` — `docs/README.md` indexes and links every doc.
+
+All pass after the edits.


### PR DESCRIPTION
# PR Summary — Docs audit: Rust/WASM, core-parity & dependency-policy docs

## Summary

Phase 2 of the documentation audit (#2956) for the Rust/WASM, core-parity and
dependency-policy cluster. Each in-scope doc was fact-checked against the
current Continuous Integration (CI) workflows, the parity gate script,
`build.sh`, `bump-deps.sh` and the dependency policy. Stale claims were
corrected, obsolete references deleted, acronyms expanded on first use, and a
Mermaid flow added for the parity gate. **Closes #2968.**

The cluster was already consolidated in a prior pass (#2570/#2962): the three
~13-line `*_PARITY_AUDIT.md` files are redirect stubs pointing at the single
`PARITY_AUDITS.md`. They are **retained** because
`test/scripts/ParityAuditsConsolidation.ts` requires them to remain as redirects
so historical PR-summary links still resolve — the parity story is told once in
`PARITY_AUDITS.md`.

### Key fact-check fixes

| Doc                                               | Change                                                       | Why                                                                                                                                                                                               |
| ------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `PARITY_GATE.md`                                  | Rewrote Step 1 invariants                                    | The "references the required topics" keyword-grep assertion was removed in #2887; `CoreDependencyPolicy.ts` now checks the policy doc's `neatCore` block agrees with `deno.json` on `repo`/`ref`. |
| `PARITY_GATE.md`                                  | Added a Mermaid gate flow; expanded WASM/TS                  | Acceptance criterion: a Mermaid flow for the parity gate; acronyms on first use.                                                                                                                  |
| `EXTERNAL_NEAT_AI_CORE.md`                        | Removed reference to `test/scripts/ScorerAlignmentPolicy.ts` | That test was deleted in #2887/#2890; scorer alignment is now a manual coordinated bump.                                                                                                          |
| `CORE_DEPENDENCY_POLICY.md`                       | Expanded ADR / CI / MITM / JSR                               | House style — define acronyms on first use.                                                                                                                                                       |
| `CI_EXTERNAL_NEAT_AI_CORE.md`, `PARITY_AUDITS.md` | Expanded WASM on first use                                   | House style.                                                                                                                                                                                      |
| `VERSION_VISIBILITY.md`                           | Expanded JSR / GRQ / PR; added cluster cross-link footer     | House style + consistent cross-linking with sibling cluster docs.                                                                                                                                 |

### Verified accurate (no change needed)

- `PARITY_GATE.md` command blocks match `scripts/parity-gate.sh` (Step 1
  command, Step 2 `./build.sh`, Step 3 test list, all flags).
- `build.sh` mode table in `CORE_DEPENDENCY_POLICY.md` matches the script's
  actual flags (`--verify-only`, `--rev`, `--clean`, `--allow-unverified`).
- `CI_EXTERNAL_NEAT_AI_CORE.md` matches `quality.yml`/`publish.yml`
  (`./build.sh --verify-only`).
- `deno.json` pins `neatCore.repo`/`ref`/`rev`/`assetSha256` as documented.
- `TS_RUST_MIGRATION.md` already expands every acronym and explains the
  Rust/WASM-vs-TS split — left as-is.

## Evidence

Documentation-only change; no UI or runtime behaviour. Verified via the
doc-coupled test suite, `deno fmt`, and `cspell`.

```
ok | 39 passed | 0 failed
```

Tests run: `ParityAuditsConsolidation.ts`, `ParityGate.ts`,
`CoreDependencyPolicy.ts`, `BuildScript.ts`, `ContributorCoreDocs.ts`,
`DocsIndex.ts` (all green). `deno fmt --check` and `cspell` clean on all six
edited files.

### Parity-gate flow added to `PARITY_GATE.md`

```mermaid
flowchart LR
    Pin["deno.json<br/>neatCore.rev (SHA)"] --> S1["Step 1<br/>Core dependency policy"]
    S1 --> S2["Step 2<br/>./build.sh sync"]
    S2 --> S3["Step 3<br/>TS ↔ WASM parity tests"]
    S3 --> Pass{"all pass?"}
    Pass -- "yes" --> Sign["Sign-off / release"]
    Pass -- "no" --> Block["Block repin"]
```

## Test Plan

No new tests were added — this is a documentation audit and the existing
doc-coupled tests already pin the contract each doc must satisfy:

- `test/scripts/ParityAuditsConsolidation.ts` — consolidation + redirect stubs.
- `test/scripts/ParityGate.ts` — gate doc exists; script CLI surface.
- `test/scripts/CoreDependencyPolicy.ts` — policy doc agrees with `deno.json`.
- `test/scripts/BuildScript.ts` — policy doc describes the artifact flow.
- `test/docs/DocsIndex.ts` — `docs/README.md` indexes and links every doc.

All pass after the edits.



## Milestone
This PR is part of the **clean up docs** milestone and targets the `milestone/clean-up-docs` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqg399ze-e3f52e`<!-- vibe-worker-issue-2968 -->