### PR TITLE
🟡 Source-text grep used as assertion against build.sh/quality.sh in test/scripts/ (Issue #2997)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2997.md
+++ b/docs/archive/pr-summaries/pr-summary-2997.md
@@ -16,12 +16,13 @@ established by `test/scripts/BuildScriptContentHash.ts` under issue #2886.
   **non-hidden** `build-fingerprint` file containing the expected SHA-256 of
   `<repo>@<rev>` — and that no hidden `.build-fingerprint` companion is created.
 - `test/scripts/QualityScript.ts` — the grep over `quality.sh`
-  (`includes("VIBE_BUMP_QUARANTINE_HOURS")`, `includes("--minimum-dependency-age")`
-  plus a regex over the body) is replaced by a test that places a fake `deno` on
-  PATH (via a temp `HOME/.deno/bin`, the directory `quality.sh` prepends),
-  runs the deps step through `--lint-only`, and asserts on the **command line
-  actually emitted** to `deno outdated` — including the hours → minutes
-  conversion (`VIBE_BUMP_QUARANTINE_HOURS=3` → `--minimum-dependency-age=180`).
+  (`includes("VIBE_BUMP_QUARANTINE_HOURS")`,
+  `includes("--minimum-dependency-age")` plus a regex over the body) is replaced
+  by a test that places a fake `deno` on PATH (via a temp `HOME/.deno/bin`, the
+  directory `quality.sh` prepends), runs the deps step through `--lint-only`,
+  and asserts on the **command line actually emitted** to `deno outdated` —
+  including the hours → minutes conversion (`VIBE_BUMP_QUARANTINE_HOURS=3` →
+  `--minimum-dependency-age=180`).
 
 The genuinely behavioural cases already in these files (the `--dry-run`
 flag-parsing tests, the non-integer `VIBE_BUMP_QUARANTINE_HOURS` rejection test,
@@ -61,12 +62,17 @@ running the affected test files and the quality gate:
 
 ## Test Plan
 
-- Rewrote `test/scripts/BuildFingerprint.ts::build.sh refresh_fingerprint writes
-  a non-hidden build-fingerprint` — sources and runs the real
-  `refresh_fingerprint`; a regression to a hidden `.build-fingerprint` (or a
-  wrong fingerprint value/location) fails the assertions.
+- Rewrote
+  `test/scripts/BuildFingerprint.ts::build.sh refresh_fingerprint writes
+  a non-hidden build-fingerprint`
+  — sources and runs the real `refresh_fingerprint`; a regression to a hidden
+  `.build-fingerprint` (or a wrong fingerprint value/location) fails the
+  assertions.
 - Rewrote `test/scripts/QualityScript.ts::quality.sh dep update invokes
-  \`deno outdated\` with --minimum-dependency-age` — shims `deno`, runs the deps
-  step, and asserts the emitted argv carries `--update --latest
-  --minimum-dependency-age=180`; dropping the flag or mis-converting hours fails.
+  \`deno
+  outdated\` with
+  --minimum-dependency-age`— shims`deno`, runs the deps
+  step, and asserts the emitted argv carries`--update
+  --latest --minimum-dependency-age=180`; dropping the flag or mis-converting
+  hours fails.
 - All other existing test cases in both files are retained unchanged.

--- a/docs/archive/pr-summaries/pr-summary-2997.md
+++ b/docs/archive/pr-summaries/pr-summary-2997.md
@@ -1,0 +1,72 @@
+# Replace source-text grep assertions against build.sh / quality.sh with WHAT-tests
+
+## Summary
+
+Two tests asserted behaviour by grepping the **source text** of shell scripts
+rather than running them — HOW-tests that pass merely because a string appears
+somewhere in the file (even in a comment) and break on any rename or reflow that
+leaves behaviour unchanged. They are now WHAT-tests that drive the real script
+logic and assert on the observable outcome, matching the pattern already
+established by `test/scripts/BuildScriptContentHash.ts` under issue #2886.
+
+- `test/scripts/BuildFingerprint.ts` — the two greps over `build.sh`
+  (`includes("build-fingerprint")` / `!includes("pkg/.build-fingerprint")`) are
+  replaced by a test that sources `build.sh`'s real `refresh_fingerprint`
+  helper, runs it against a temp `DEST_DIR`, and observes that it writes a
+  **non-hidden** `build-fingerprint` file containing the expected SHA-256 of
+  `<repo>@<rev>` — and that no hidden `.build-fingerprint` companion is created.
+- `test/scripts/QualityScript.ts` — the grep over `quality.sh`
+  (`includes("VIBE_BUMP_QUARANTINE_HOURS")`, `includes("--minimum-dependency-age")`
+  plus a regex over the body) is replaced by a test that places a fake `deno` on
+  PATH (via a temp `HOME/.deno/bin`, the directory `quality.sh` prepends),
+  runs the deps step through `--lint-only`, and asserts on the **command line
+  actually emitted** to `deno outdated` — including the hours → minutes
+  conversion (`VIBE_BUMP_QUARANTINE_HOURS=3` → `--minimum-dependency-age=180`).
+
+The genuinely behavioural cases already in these files (the `--dry-run`
+flag-parsing tests, the non-integer `VIBE_BUMP_QUARANTINE_HOURS` rejection test,
+the committed `build-fingerprint` file/format checks, and the `git`-driven
+`.gitignore` checks) are kept unchanged.
+
+Out of scope: `test/scripts/BuildScript.ts:202-214` greps a Markdown document
+(`docs/CORE_DEPENDENCY_POLICY.md`), not a script — documentation content has no
+behavioural form, and it falls outside this issue's title ("against
+build.sh/quality.sh"), so it is left as-is.
+
+Closes #2997.
+
+## Why this matters
+
+```mermaid
+flowchart LR
+    subgraph Before["HOW-test (before)"]
+        A[read build.sh / quality.sh text] --> B{string present<br/>anywhere?}
+        B -->|yes| C[pass — even if in a comment<br/>or never wired to a command]
+    end
+    subgraph After["WHAT-test (after)"]
+        D[run real helper / script] --> E{observed outcome:<br/>file written / argv emitted?}
+        E -->|matches| F[pass — survives any refactor<br/>that keeps behaviour]
+    end
+```
+
+## Evidence
+
+Backend/CLI test-only change — no web interface to screenshot. Verified by
+running the affected test files and the quality gate:
+
+- `deno test test/scripts/BuildFingerprint.ts test/scripts/QualityScript.ts` —
+  18 passed, 0 failed.
+- `./quality.sh --check-only` — type-check passes tree-wide (1696 files).
+- `./quality.sh --lint-only` — fmt, lint, and bash-script checks pass.
+
+## Test Plan
+
+- Rewrote `test/scripts/BuildFingerprint.ts::build.sh refresh_fingerprint writes
+  a non-hidden build-fingerprint` — sources and runs the real
+  `refresh_fingerprint`; a regression to a hidden `.build-fingerprint` (or a
+  wrong fingerprint value/location) fails the assertions.
+- Rewrote `test/scripts/QualityScript.ts::quality.sh dep update invokes
+  \`deno outdated\` with --minimum-dependency-age` — shims `deno`, runs the deps
+  step, and asserts the emitted argv carries `--update --latest
+  --minimum-dependency-age=180`; dropping the flag or mis-converting hours fails.
+- All other existing test cases in both files are retained unchanged.

--- a/test/scripts/BuildFingerprint.ts
+++ b/test/scripts/BuildFingerprint.ts
@@ -7,30 +7,114 @@ import { assert, assertEquals } from "@std/assert";
  * The canonical build fingerprint is `pkg/build-fingerprint` (non-hidden).
  */
 
+/** Lowercase hex SHA-256 of a string, used to predict the fingerprint. */
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    return (await Deno.stat(path)).isFile;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Source a single named function out of build.sh into a sub-shell, set the
+ * globals it depends on, and run it. Mirrors the helper in
+ * BuildScriptContentHash.ts so we exercise the real bash logic rather than
+ * grepping the script's source text (issue #2997). A temp file (not process
+ * substitution) is used because `source <(...)` does not reliably define
+ * functions across all bash builds (e.g. macOS bash 3.2).
+ */
+async function runSourcedFn(
+  fnName: string,
+  preamble: string,
+  invocation: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const fnTmp = await Deno.makeTempFile({ prefix: "neat-fn-", suffix: ".sh" });
+  try {
+    const extract = new Deno.Command("awk", {
+      args: [`/^${fnName}\\(\\)/,/^}$/`, "./build.sh"],
+      stdout: "piped",
+      cwd: Deno.cwd(),
+    });
+    const ex = await extract.output();
+    await Deno.writeFile(fnTmp, ex.stdout);
+
+    const script = `set -e\nsource '${fnTmp}'\n${preamble}\n${invocation}\n`;
+    const cmd = new Deno.Command("bash", {
+      args: ["-c", script],
+      stdout: "piped",
+      stderr: "piped",
+      cwd: Deno.cwd(),
+    });
+    const out = await cmd.output();
+    return {
+      stdout: new TextDecoder().decode(out.stdout),
+      stderr: new TextDecoder().decode(out.stderr),
+      code: out.code,
+    };
+  } finally {
+    await Deno.remove(fnTmp);
+  }
+}
+
+// Behavioural replacement (issue #2997) for the old source-text greps that
+// asserted build.sh "includes('build-fingerprint')" and
+// "!includes('pkg/.build-fingerprint')". Those HOW-tests passed merely because
+// a string appeared somewhere in the file. The WHAT-test below runs build.sh's
+// real refresh_fingerprint helper and observes the file it actually writes: a
+// non-hidden `build-fingerprint` holding the expected SHA-256, with no hidden
+// `.build-fingerprint` companion.
 Deno.test({
-  name: "build.sh writes fingerprint to non-hidden file (build-fingerprint)",
-  permissions: { read: true },
+  name: "build.sh refresh_fingerprint writes a non-hidden build-fingerprint",
+  permissions: { run: true, read: true, write: true },
   fn: async () => {
-    const buildScript = await Deno.readTextFile("build.sh");
+    if (!(await fileExists("build.sh"))) return;
 
-    // The build script should write to build-fingerprint (non-hidden)
-    assert(
-      buildScript.includes("build-fingerprint"),
-      "build.sh should write fingerprint to pkg/build-fingerprint (non-hidden)",
-    );
-  },
-});
+    const destDir = await Deno.makeTempDir({ prefix: "neat-fingerprint-" });
+    try {
+      const repo = "stSoftwareAU/NEAT-AI-core";
+      const rev = "0123456789abcdef0123456789abcdef01234567";
 
-Deno.test({
-  name: "build.sh does not write hidden pkg/.build-fingerprint",
-  permissions: { read: true },
-  fn: async () => {
-    const buildScript = await Deno.readTextFile("build.sh");
+      const result = await runSourcedFn(
+        "refresh_fingerprint",
+        `export NEAT_CORE_REPO='${repo}'\nDEST_DIR='${destDir}'`,
+        `refresh_fingerprint '${rev}'`,
+      );
+      // shasum may be unavailable on minimal CI; the helper is a no-op then.
+      if (result.code !== 0) return;
 
-    assert(
-      !buildScript.includes("pkg/.build-fingerprint"),
-      "build.sh must not write a hidden fingerprint file",
-    );
+      const fingerprintPath = `${destDir}/build-fingerprint`;
+      const hiddenPath = `${destDir}/.build-fingerprint`;
+
+      assert(
+        await fileExists(fingerprintPath),
+        `refresh_fingerprint must write ${fingerprintPath} (non-hidden); ` +
+          `stderr=${result.stderr}`,
+      );
+      assert(
+        !(await fileExists(hiddenPath)),
+        "refresh_fingerprint must not write a hidden .build-fingerprint",
+      );
+
+      const written = (await Deno.readTextFile(fingerprintPath)).trim();
+      assertEquals(
+        written,
+        await sha256Hex(`${repo}@${rev}`),
+        "fingerprint must be the SHA-256 of '<repo>@<rev>'",
+      );
+    } finally {
+      await Deno.remove(destDir, { recursive: true });
+    }
   },
 });
 

--- a/test/scripts/QualityScript.ts
+++ b/test/scripts/QualityScript.ts
@@ -260,30 +260,77 @@ Deno.test(
  * `--minimum-dependency-age`, any developer running `./quality.sh` with the
  * deps step enabled silently bypasses the VIBE_BUMP_QUARANTINE_HOURS gate
  * and may pull in a too-recent (potentially malicious) registry version.
+ *
+ * Issue #2997 — this was previously a source-text grep over quality.sh (a
+ * HOW-test that passed if the string appeared anywhere, even in a comment).
+ * It is now a WHAT-test: a fake `deno` is placed on PATH that records its
+ * argv, quality.sh runs its deps step (via --lint-only, which keeps RUN_DEPS
+ * on), and we assert on the command line actually emitted to `deno outdated`,
+ * including the hours → minutes conversion.
  */
 Deno.test({
   name:
-    "quality.sh dep update passes --minimum-dependency-age (Issue #2742 quarantine)",
-  permissions: { read: true },
+    "quality.sh dep update invokes `deno outdated` with --minimum-dependency-age (Issue #2742 quarantine)",
+  permissions: { run: true, read: true, write: true, env: true },
   fn: async () => {
-    const body = await Deno.readTextFile("./quality.sh");
-    assert(
-      body.includes("VIBE_BUMP_QUARANTINE_HOURS"),
-      "quality.sh must honour VIBE_BUMP_QUARANTINE_HOURS for the dep update",
-    );
-    assert(
-      body.includes("--minimum-dependency-age"),
-      "quality.sh must pass --minimum-dependency-age to `deno outdated --update --latest`",
-    );
+    // quality.sh prepends "$HOME/.deno/bin" to PATH, so the shim must live
+    // there. Point HOME at a temp dir whose .deno/bin holds the fake `deno`.
+    const home = await Deno.makeTempDir({ prefix: "neat-quality-home-" });
+    try {
+      const binDir = `${home}/.deno/bin`;
+      await Deno.mkdir(binDir, { recursive: true });
+      const callLog = `${home}/deno-calls.log`;
+      const shim = `${binDir}/deno`;
+      // Records each invocation's argv (one line) and always succeeds, so
+      // fmt/lint/the deps update all "pass" without touching the real toolchain.
+      await Deno.writeTextFile(
+        shim,
+        `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${callLog}"\nexit 0\n`,
+      );
+      await Deno.chmod(shim, 0o755);
 
-    // The flag must apply specifically to the `deno outdated --update --latest`
-    // invocation, not appear unused elsewhere.
-    const outdatedBlock =
-      /deno outdated --update --latest[\s\S]{0,200}?--minimum-dependency-age=\$\{?QUALITY_QUARANTINE_MINUTES\}?/;
-    assert(
-      outdatedBlock.test(body),
-      "quality.sh must call `deno outdated --update --latest` with `--minimum-dependency-age=${QUALITY_QUARANTINE_MINUTES}`",
-    );
+      const command = new Deno.Command("bash", {
+        args: ["./quality.sh", "--lint-only"],
+        stdout: "piped",
+        stderr: "piped",
+        cwd: Deno.cwd(),
+        env: {
+          PATH: Deno.env.get("PATH") ?? "",
+          HOME: home,
+          VIBE_BUMP_QUARANTINE_HOURS: "3",
+        },
+      });
+      const output = await command.output();
+      assertEquals(
+        output.code,
+        0,
+        `quality.sh --lint-only must succeed with the shim; stderr=${
+          new TextDecoder().decode(output.stderr)
+        }`,
+      );
+
+      const calls = (await Deno.readTextFile(callLog))
+        .split("\n")
+        .filter((l) => l.trim().length > 0);
+      const outdated = calls.find((l) => l.startsWith("outdated"));
+      assert(
+        outdated !== undefined,
+        `expected a 'deno outdated' invocation; got calls: ${
+          JSON.stringify(calls)
+        }`,
+      );
+      assert(
+        outdated.includes("--update") && outdated.includes("--latest"),
+        `deno outdated must update to latest; got: ${outdated}`,
+      );
+      // 3 hours → 180 minutes proves the conversion, not just the literal flag.
+      assert(
+        outdated.includes("--minimum-dependency-age=180"),
+        `deno outdated must carry the quarantine window in minutes; got: ${outdated}`,
+      );
+    } finally {
+      await Deno.remove(home, { recursive: true });
+    }
   },
 });
 


### PR DESCRIPTION
# Replace source-text grep assertions against build.sh / quality.sh with WHAT-tests

## Summary

Two tests asserted behaviour by grepping the **source text** of shell scripts
rather than running them — HOW-tests that pass merely because a string appears
somewhere in the file (even in a comment) and break on any rename or reflow that
leaves behaviour unchanged. They are now WHAT-tests that drive the real script
logic and assert on the observable outcome, matching the pattern already
established by `test/scripts/BuildScriptContentHash.ts` under issue #2886.

- `test/scripts/BuildFingerprint.ts` — the two greps over `build.sh`
  (`includes("build-fingerprint")` / `!includes("pkg/.build-fingerprint")`) are
  replaced by a test that sources `build.sh`'s real `refresh_fingerprint`
  helper, runs it against a temp `DEST_DIR`, and observes that it writes a
  **non-hidden** `build-fingerprint` file containing the expected SHA-256 of
  `<repo>@<rev>` — and that no hidden `.build-fingerprint` companion is created.
- `test/scripts/QualityScript.ts` — the grep over `quality.sh`
  (`includes("VIBE_BUMP_QUARANTINE_HOURS")`, `includes("--minimum-dependency-age")`
  plus a regex over the body) is replaced by a test that places a fake `deno` on
  PATH (via a temp `HOME/.deno/bin`, the directory `quality.sh` prepends),
  runs the deps step through `--lint-only`, and asserts on the **command line
  actually emitted** to `deno outdated` — including the hours → minutes
  conversion (`VIBE_BUMP_QUARANTINE_HOURS=3` → `--minimum-dependency-age=180`).

The genuinely behavioural cases already in these files (the `--dry-run`
flag-parsing tests, the non-integer `VIBE_BUMP_QUARANTINE_HOURS` rejection test,
the committed `build-fingerprint` file/format checks, and the `git`-driven
`.gitignore` checks) are kept unchanged.

Out of scope: `test/scripts/BuildScript.ts:202-214` greps a Markdown document
(`docs/CORE_DEPENDENCY_POLICY.md`), not a script — documentation content has no
behavioural form, and it falls outside this issue's title ("against
build.sh/quality.sh"), so it is left as-is.

Closes #2997.

## Why this matters

```mermaid
flowchart LR
    subgraph Before["HOW-test (before)"]
        A[read build.sh / quality.sh text] --> B{string present<br/>anywhere?}
        B -->|yes| C[pass — even if in a comment<br/>or never wired to a command]
    end
    subgraph After["WHAT-test (after)"]
        D[run real helper / script] --> E{observed outcome:<br/>file written / argv emitted?}
        E -->|matches| F[pass — survives any refactor<br/>that keeps behaviour]
    end
```

## Evidence

Backend/CLI test-only change — no web interface to screenshot. Verified by
running the affected test files and the quality gate:

- `deno test test/scripts/BuildFingerprint.ts test/scripts/QualityScript.ts` —
  18 passed, 0 failed.
- `./quality.sh --check-only` — type-check passes tree-wide (1696 files).
- `./quality.sh --lint-only` — fmt, lint, and bash-script checks pass.

## Test Plan

- Rewrote `test/scripts/BuildFingerprint.ts::build.sh refresh_fingerprint writes
  a non-hidden build-fingerprint` — sources and runs the real
  `refresh_fingerprint`; a regression to a hidden `.build-fingerprint` (or a
  wrong fingerprint value/location) fails the assertions.
- Rewrote `test/scripts/QualityScript.ts::quality.sh dep update invokes
  \`deno outdated\` with --minimum-dependency-age` — shims `deno`, runs the deps
  step, and asserts the emitted argv carries
  `--update --latest --minimum-dependency-age=180`; dropping the flag or
  mis-converting hours fails.
- All other existing test cases in both files are retained unchanged.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqgcsrfr-199f65`<!-- vibe-worker-issue-2997 -->