### PR TITLE
Replace memory-estimate magic-value test with per-target cap invariant (Issue #2999)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2999.md
+++ b/docs/archive/pr-summaries/pr-summary-2999.md
@@ -1,18 +1,18 @@
 ## Summary
 
-Rewrote the benchmark-shaped unit test `test/propagate/SyntheticSynapsesProductionScale.ts:307-350`
-("synthetic synapses: memory estimate at production scale") into a proper
-**"what" test** that asserts the invariant the per-target cap actually
-guarantees. Closes #2999.
+Rewrote the benchmark-shaped unit test
+`test/propagate/SyntheticSynapsesProductionScale.ts:307-350` ("synthetic
+synapses: memory estimate at production scale") into a proper **"what" test**
+that asserts the invariant the per-target cap actually guarantees. Closes #2999.
 
 The old test fabricated a memory figure from a magic constant
 (`const estimatedBytesPerSynapse = 88`), multiplied it by `result.addedCount`,
-`console.log`-ged a throughput-style report, then asserted against two
-spec-less round numbers (`assertLess(estimatedAdditionalMB, 50)` and
+`console.log`-ged a throughput-style report, then asserted against two spec-less
+round numbers (`assertLess(estimatedAdditionalMB, 50)` and
 `assertLess(expansionRatio, 5)`). None of these numbers were measured or
 specified — they tracked what the current estimate heuristic happened to
-produce, so any change to the heuristic or the cap forced the magic values to
-be re-tuned even when no observable behaviour regressed. The `console.log` was
+produce, so any change to the heuristic or the cap forced the magic values to be
+re-tuned even when no observable behaviour regressed. The `console.log` was
 benchmark output that added no correctness signal.
 
 ### What changed
@@ -20,8 +20,8 @@ benchmark output that added no correctness signal.
 The rewritten test (renamed to "synthetic synapses: no target exceeds the
 per-target cap at production scale") asserts the genuine invariant:
 
-- Group the returned `syntheticKeys` by their target neuron index (`toIdx`).
-  A target neuron is the `to` endpoint for exactly one adjacent layer pair, so
+- Group the returned `syntheticKeys` by their target neuron index (`toIdx`). A
+  target neuron is the `to` endpoint for exactly one adjacent layer pair, so
   this count is the complete per-target synthetic count.
 - Assert every per-target count is `<= DEFAULT_MAX_SYNTHETIC_PER_TARGET`. This
   is the behaviour the cap exists to enforce and bounds total memory growth far
@@ -73,5 +73,5 @@ Full `./quality.sh` passes: `ok | 7252 passed (2 steps) | 0 failed | 4 ignored`.
   layout or the sampling heuristic, failing only if the cap is genuinely
   violated.
 - Verified the existing six tests in the file are unchanged and still pass.
-- Ran the full quality gate (`./quality.sh`) — lint, format, type-check, and
-  the entire test suite pass cleanly.
+- Ran the full quality gate (`./quality.sh`) — lint, format, type-check, and the
+  entire test suite pass cleanly.

--- a/docs/archive/pr-summaries/pr-summary-2999.md
+++ b/docs/archive/pr-summaries/pr-summary-2999.md
@@ -1,0 +1,77 @@
+## Summary
+
+Rewrote the benchmark-shaped unit test `test/propagate/SyntheticSynapsesProductionScale.ts:307-350`
+("synthetic synapses: memory estimate at production scale") into a proper
+**"what" test** that asserts the invariant the per-target cap actually
+guarantees. Closes #2999.
+
+The old test fabricated a memory figure from a magic constant
+(`const estimatedBytesPerSynapse = 88`), multiplied it by `result.addedCount`,
+`console.log`-ged a throughput-style report, then asserted against two
+spec-less round numbers (`assertLess(estimatedAdditionalMB, 50)` and
+`assertLess(expansionRatio, 5)`). None of these numbers were measured or
+specified — they tracked what the current estimate heuristic happened to
+produce, so any change to the heuristic or the cap forced the magic values to
+be re-tuned even when no observable behaviour regressed. The `console.log` was
+benchmark output that added no correctness signal.
+
+### What changed
+
+The rewritten test (renamed to "synthetic synapses: no target exceeds the
+per-target cap at production scale") asserts the genuine invariant:
+
+- Group the returned `syntheticKeys` by their target neuron index (`toIdx`).
+  A target neuron is the `to` endpoint for exactly one adjacent layer pair, so
+  this count is the complete per-target synthetic count.
+- Assert every per-target count is `<= DEFAULT_MAX_SYNTHETIC_PER_TARGET`. This
+  is the behaviour the cap exists to enforce and bounds total memory growth far
+  more meaningfully than a hand-guessed bytes-per-synapse estimate.
+- Guard against a vacuous pass: assert the cap actually engages at production
+  scale (`skippedCount > 0`) and that some targets receive synthetic synapses.
+- Confirm the creature remains structurally valid after generation.
+
+All fabricated `estimatedBytesPerSynapse` / `50 MB` / `5x` arithmetic and the
+benchmark-style `console.log` were dropped. No timing or performance metric is
+measured in the test, consistent with the project's unit-test-vs-benchmark
+policy.
+
+```mermaid
+flowchart LR
+    A[generateSyntheticSynapses] --> B[syntheticKeys: fromIdx-toIdx]
+    B --> C[group by toIdx]
+    C --> D{count <= DEFAULT_MAX_SYNTHETIC_PER_TARGET?}
+    D -- yes --> E[invariant holds]
+    D -- no --> F[fail: cap violated]
+```
+
+## Evidence
+
+Backend/CLI test change — no web interface to screenshot.
+
+Targeted run of the modified file (7 tests, all pass):
+
+```
+running 7 tests from ./test/propagate/SyntheticSynapsesProductionScale.ts
+synthetic synapses: per-target cap limits count at production scale ... ok
+synthetic synapses: uncapped vs capped count comparison ... ok
+synthetic synapses: creature outputs restored after generate and remove all ... ok
+synthetic synapses: full training lifecycle at production scale ... ok
+synthetic synapses: generation is deterministic at production scale ... ok
+synthetic synapses: custom maxPerTarget limits connections ... ok
+synthetic synapses: no target exceeds the per-target cap at production scale ... ok
+ok | 7 passed | 0 failed (3s)
+```
+
+Full `./quality.sh` passes: `ok | 7252 passed (2 steps) | 0 failed | 4 ignored`.
+
+## Test Plan
+
+- Modified `test/propagate/SyntheticSynapsesProductionScale.ts` — replaced the
+  memory-estimate test (Test 7) with a per-target cap invariant assertion that
+  no target neuron exceeds `DEFAULT_MAX_SYNTHETIC_PER_TARGET`.
+- The new test is a "what" test: it survives any internal change to memory
+  layout or the sampling heuristic, failing only if the cap is genuinely
+  violated.
+- Verified the existing six tests in the file are unchanged and still pass.
+- Ran the full quality gate (`./quality.sh`) — lint, format, type-check, and
+  the entire test suite pass cleanly.

--- a/test/propagate/SyntheticSynapsesProductionScale.ts
+++ b/test/propagate/SyntheticSynapsesProductionScale.ts
@@ -10,7 +10,13 @@
  * These are correctness tests only — timing is measured in bench/.
  */
 
-import { assert, assertEquals, assertGreater, assertLess } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertGreater,
+  assertLess,
+  assertLessOrEqual,
+} from "@std/assert";
 import { Creature } from "@creature";
 import {
   DEFAULT_MAX_SYNTHETIC_PER_TARGET,
@@ -301,50 +307,52 @@ Deno.test("synthetic synapses: custom maxPerTarget limits connections", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Test 7: Memory estimate — document additional memory usage
+// Test 7: Per-target cap invariant — no target exceeds the cap at scale
 // ---------------------------------------------------------------------------
 
-Deno.test("synthetic synapses: memory estimate at production scale", () => {
+Deno.test("synthetic synapses: no target exceeds the per-target cap at production scale", () => {
   const rng = createSeededRng(42);
   const json = generateProductionCreature(10, 3, rng);
   const creature = Creature.fromJSON(json);
 
-  const originalSynapseCount = creature.synapses.length;
   const result = generateSyntheticSynapses(creature);
 
-  // Estimate memory: each synapse object has from (8), to (8), weight (8),
-  // plus object overhead (~64 bytes). Plus the tracking key string (~20 bytes).
-  const estimatedBytesPerSynapse = 88;
-  const estimatedAdditionalMB = (result.addedCount * estimatedBytesPerSynapse) /
-    (1024 * 1024);
+  // The feature guarantees each target neuron receives at most
+  // DEFAULT_MAX_SYNTHETIC_PER_TARGET synthetic synapses (per adjacent layer
+  // pair). A target neuron is the "to" endpoint for exactly one layer pair,
+  // so counting synthetic keys grouped by their target index directly bounds
+  // per-target growth — this is the behaviour the cap exists to enforce, and
+  // it bounds total memory growth far more meaningfully than a hand-guessed
+  // bytes-per-synapse estimate ever could.
+  const perTargetCount = new Map<string, number>();
+  for (const key of result.syntheticKeys) {
+    // Keys are "fromIdx-toIdx" with non-negative integer indices, so the
+    // first "-" separates the two endpoints.
+    const toIdx = key.slice(key.indexOf("-") + 1);
+    perTargetCount.set(toIdx, (perTargetCount.get(toIdx) ?? 0) + 1);
+  }
 
-  console.log(
-    `Synthetic synapse memory estimate:`,
-    `\n  Original synapses: ${originalSynapseCount}`,
-    `\n  Synthetic added: ${result.addedCount}`,
-    `\n  Skipped (capped): ${result.skippedCount}`,
-    `\n  Total synapses: ${creature.synapses.length}`,
-    `\n  Expansion ratio: ${
-      (creature.synapses.length / originalSynapseCount).toFixed(1)
-    }x`,
-    `\n  Estimated additional memory: ${estimatedAdditionalMB.toFixed(1)} MB`,
-    `\n  Max per target: ${DEFAULT_MAX_SYNTHETIC_PER_TARGET}`,
+  for (const [toIdx, count] of perTargetCount) {
+    assertLessOrEqual(
+      count,
+      DEFAULT_MAX_SYNTHETIC_PER_TARGET,
+      `Target ${toIdx} received ${count} synthetic synapses, exceeding cap ${DEFAULT_MAX_SYNTHETIC_PER_TARGET}`,
+    );
+  }
+
+  // Guard against a vacuous pass: at production scale the cap must actually
+  // engage, so the invariant above is genuinely exercised.
+  assertGreater(
+    perTargetCount.size,
+    0,
+    "Some target neurons should receive synthetic synapses",
+  );
+  assertGreater(
+    result.skippedCount,
+    0,
+    "The per-target cap should have engaged at production scale",
   );
 
-  // Memory should be reasonable (under 50 MB for synapse objects)
-  assertLess(
-    estimatedAdditionalMB,
-    50,
-    `Additional memory should be under 50 MB, estimated ${
-      estimatedAdditionalMB.toFixed(1)
-    } MB`,
-  );
-
-  // Expansion ratio should be reasonable (under 5x)
-  const expansionRatio = creature.synapses.length / originalSynapseCount;
-  assertLess(
-    expansionRatio,
-    5,
-    `Expansion ratio should be under 5x, got ${expansionRatio.toFixed(1)}x`,
-  );
+  // Creature should remain structurally valid after generation.
+  creature.validate();
 });


### PR DESCRIPTION
## Summary

Rewrote the benchmark-shaped unit test `test/propagate/SyntheticSynapsesProductionScale.ts:307-350`
("synthetic synapses: memory estimate at production scale") into a proper
**"what" test** that asserts the invariant the per-target cap actually
guarantees. Closes #2999.

The old test fabricated a memory figure from a magic constant
(`const estimatedBytesPerSynapse = 88`), multiplied it by `result.addedCount`,
`console.log`-ged a throughput-style report, then asserted against two
spec-less round numbers (`assertLess(estimatedAdditionalMB, 50)` and
`assertLess(expansionRatio, 5)`). None of these numbers were measured or
specified — they tracked what the current estimate heuristic happened to
produce, so any change to the heuristic or the cap forced the magic values to
be re-tuned even when no observable behaviour regressed. The `console.log` was
benchmark output that added no correctness signal.

### What changed

The rewritten test (renamed to "synthetic synapses: no target exceeds the
per-target cap at production scale") asserts the genuine invariant:

- Group the returned `syntheticKeys` by their target neuron index (`toIdx`).
  A target neuron is the `to` endpoint for exactly one adjacent layer pair, so
  this count is the complete per-target synthetic count.
- Assert every per-target count is `<= DEFAULT_MAX_SYNTHETIC_PER_TARGET`. This
  is the behaviour the cap exists to enforce and bounds total memory growth far
  more meaningfully than a hand-guessed bytes-per-synapse estimate.
- Guard against a vacuous pass: assert the cap actually engages at production
  scale (`skippedCount > 0`) and that some targets receive synthetic synapses.
- Confirm the creature remains structurally valid after generation.

All fabricated `estimatedBytesPerSynapse` / `50 MB` / `5x` arithmetic and the
benchmark-style `console.log` were dropped. No timing or performance metric is
measured in the test, consistent with the project's unit-test-vs-benchmark
policy.

```mermaid
flowchart LR
    A[generateSyntheticSynapses] --> B[syntheticKeys: fromIdx-toIdx]
    B --> C[group by toIdx]
    C --> D{count <= DEFAULT_MAX_SYNTHETIC_PER_TARGET?}
    D -- yes --> E[invariant holds]
    D -- no --> F[fail: cap violated]
```

## Evidence

Backend/CLI test change — no web interface to screenshot.

Targeted run of the modified file (7 tests, all pass):

```
running 7 tests from ./test/propagate/SyntheticSynapsesProductionScale.ts
synthetic synapses: per-target cap limits count at production scale ... ok
synthetic synapses: uncapped vs capped count comparison ... ok
synthetic synapses: creature outputs restored after generate and remove all ... ok
synthetic synapses: full training lifecycle at production scale ... ok
synthetic synapses: generation is deterministic at production scale ... ok
synthetic synapses: custom maxPerTarget limits connections ... ok
synthetic synapses: no target exceeds the per-target cap at production scale ... ok
ok | 7 passed | 0 failed (3s)
```

Full `./quality.sh` passes: `ok | 7252 passed (2 steps) | 0 failed | 4 ignored`.

## Test Plan

- Modified `test/propagate/SyntheticSynapsesProductionScale.ts` — replaced the
  memory-estimate test (Test 7) with a per-target cap invariant assertion that
  no target neuron exceeds `DEFAULT_MAX_SYNTHETIC_PER_TARGET`.
- The new test is a "what" test: it survives any internal change to memory
  layout or the sampling heuristic, failing only if the cap is genuinely
  violated.
- Verified the existing six tests in the file are unchanged and still pass.
- Ran the full quality gate (`./quality.sh`) — lint, format, type-check, and
  the entire test suite pass cleanly.
