### PR TITLE
Remove flaky wall-clock timing assertions in DiscoveryTimeout tests (#2998)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.7",
+  "version": "5.5.8",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-2998.md
+++ b/docs/archive/pr-summaries/pr-summary-2998.md
@@ -1,0 +1,75 @@
+# Remove flaky wall-clock timing assertions from DiscoveryTimeout tests
+
+## Summary
+
+`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` gated four test cases
+on a host-machine wall-clock budget (`elapsed < 15_000`, measured via
+`Date.now()`). A wall-clock comparison inside a unit test asserts on the _speed
+of the host machine_, not the _behaviour of the code_ — it is flaky by
+construction: on a loaded CI runner, a shared laptop, or a slow/ARM box the same
+correct code can exceed 15 s and fail, while genuinely broken code that runs
+fast still passes.
+
+The behaviour these cases actually care about — that a configured timeout aborts
+the run and produces a _partial_ recording — is already asserted observably in
+the same blocks (`recorded > 0`, `recorded < recordCount`, `parquetCount > 0`,
+`assertExists(result)`). The timing assertion added no correctness signal, so it
+was removed (issue option (a), the preferred fix).
+
+Removed assertions and their now-unused `start`/`elapsed`/`Date.now()` plumbing
+from all four tests:
+
+- `Batch size 128 saves more batches than 512 on timeout` (the
+  `elapsed128 < 15_000 && elapsed512 < 15_000` guard at the former line 322,
+  plus its "regression guard for timeout tests are slow on GPU machines" comment
+  the issue cited as the file acknowledging the hazard).
+- `DiscoverDirectory returns partial results on timeout` (former line 400).
+- `Timeout during file reading returns partial data` (former line 475).
+- `Discovery completes successfully with reasonable timeout` (former line 550).
+
+The issue named the latter three explicitly; the fourth (former line 322) is the
+identical anti-pattern in the same file — the issue quotes its own comment at
+line 319 — so it was removed too for a consistent, complete fix.
+
+Closes #2998.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verified by running
+the modified test file; all four behavioural tests still pass without the timing
+gate:
+
+```
+Batch size 128 saves more batches than 512 on timeout ... ok (254ms)
+DiscoverDirectory returns partial results on timeout ... ok (126ms)
+Timeout during file reading returns partial data ... ok (1s)
+Discovery completes successfully with reasonable timeout ... ok (25ms)
+ok | 4 passed | 0 failed (1s)
+```
+
+The observed runtimes (25 ms–1 s) confirm the 15 s assertion never gated real
+behaviour on a fast machine, while still being able to fail spuriously on a slow
+one — exactly the flakiness removed.
+
+```mermaid
+flowchart LR
+    A[recordDirectory hits<br/>configured timeout] --> B[returns partial result]
+    B --> C{assert WHAT}
+    C --> D[recorded &gt; 0]
+    C --> E[recorded &lt; recordCount]
+    C --> F[parquetCount &gt; 0]
+    B -.removed HOW.-> G[elapsed &lt; 15_000ms]
+    style G stroke-dasharray: 5 5,color:#999
+```
+
+## Test Plan
+
+- No new tests added: the issue is removal of a counter-productive,
+  non-behavioural assertion. The existing partial-recording assertions in each
+  test continue to prove the timeout fired.
+- Ran `deno test test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` — 4
+  passed, 0 failed.
+- Ran `deno fmt --check`, `deno lint`, `deno check` on the file — all clean (the
+  removed `start`/`elapsed` locals would otherwise trip the no-unused-vars
+  lint).
+- Ran `./quality.sh` — full project gate.

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts
@@ -243,13 +243,11 @@ Deno.test({
           log: 0,
         });
 
-        const start128 = Date.now();
         const result128 = await recordDirectory(
           creature128,
           tmpDir128,
           config128,
         );
-        const elapsed128 = Date.now() - start128;
 
         const config512 = createNeatConfig({
           discoveryBatchSize: 512,
@@ -262,13 +260,11 @@ Deno.test({
           log: 0,
         });
 
-        const start512 = Date.now();
         const result512 = await recordDirectory(
           creature512,
           tmpDir512,
           config512,
         );
-        const elapsed512 = Date.now() - start512;
 
         // Both should return results (not throw) - this tests timeout handling and FFI integration.
         assertExists(result128, "Batch 128 should return result");
@@ -314,13 +310,6 @@ Deno.test({
         assert(
           recorded512 < recordCount,
           `Expected partial recording for batch=512. Recorded=${recorded512}, total=${recordCount}`,
-        );
-
-        // This is a regression guard for "timeout tests are slow on GPU machines".
-        // We want this test bounded even when GPUs are available.
-        assert(
-          elapsed128 < 15_000 && elapsed512 < 15_000,
-          `Expected both runs to finish quickly. elapsed128=${elapsed128}ms elapsed512=${elapsed512}ms`,
         );
       } finally {
         // Restore original DENO_TEST value
@@ -370,9 +359,7 @@ Deno.test({
       const originalDenoTest = Deno.env.get("DENO_TEST");
       Deno.env.set("DENO_TEST", "true");
       try {
-        const start = Date.now();
         const result = await recordDirectory(creature, tmpDir, config);
-        const elapsed = Date.now() - start;
 
         // Should return result (not throw)
         assertExists(result, "Should return result even with timeout");
@@ -394,11 +381,6 @@ Deno.test({
         assert(
           recorded < recordCount,
           `Expected partial recording. Recorded=${recorded}, total=${recordCount}`,
-        );
-
-        assert(
-          elapsed < 15_000,
-          `Expected timeout test to be fast. elapsed=${elapsed}ms`,
         );
       } finally {
         // Restore original DENO_TEST value
@@ -449,9 +431,7 @@ Deno.test({
       const originalDenoTest = Deno.env.get("DENO_TEST");
       Deno.env.set("DENO_TEST", "true");
       try {
-        const start = Date.now();
         const result = await recordDirectory(creature, tmpDir, config);
-        const elapsed = Date.now() - start;
 
         // Should complete without throwing
         assertExists(result, "Should return result despite timeout");
@@ -469,11 +449,6 @@ Deno.test({
         assert(
           recorded > 0,
           "Expected to record at least one sample before timing out",
-        );
-
-        assert(
-          elapsed < 15_000,
-          `Expected timeout test to be fast. elapsed=${elapsed}ms`,
         );
       } finally {
         // Restore original DENO_TEST value
@@ -525,9 +500,7 @@ Deno.test({
       const originalDenoTest = Deno.env.get("DENO_TEST");
       Deno.env.set("DENO_TEST", "true");
       try {
-        const start = Date.now();
         const result = await recordDirectory(creature, tmpDir, config);
-        const elapsed = Date.now() - start;
 
         // Should complete successfully
         assertExists(result, "Should return result");
@@ -544,11 +517,6 @@ Deno.test({
         assert(
           recorded === recordCount,
           `Expected all records to be recorded. Recorded=${recorded}, total=${recordCount}`,
-        );
-
-        assert(
-          elapsed < 15_000,
-          `Expected discovery (record-only) test to be fast. elapsed=${elapsed}ms`,
         );
       } finally {
         // Restore original DENO_TEST value


### PR DESCRIPTION
# Remove flaky wall-clock timing assertions from DiscoveryTimeout tests

## Summary

`test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` gated four test cases
on a host-machine wall-clock budget (`elapsed < 15_000`, measured via
`Date.now()`). A wall-clock comparison inside a unit test asserts on the _speed
of the host machine_, not the _behaviour of the code_ — it is flaky by
construction: on a loaded CI runner, a shared laptop, or a slow/ARM box the same
correct code can exceed 15 s and fail, while genuinely broken code that runs
fast still passes.

The behaviour these cases actually care about — that a configured timeout aborts
the run and produces a _partial_ recording — is already asserted observably in
the same blocks (`recorded > 0`, `recorded < recordCount`, `parquetCount > 0`,
`assertExists(result)`). The timing assertion added no correctness signal, so it
was removed (issue option (a), the preferred fix).

Removed assertions and their now-unused `start`/`elapsed`/`Date.now()` plumbing
from all four tests:

- `Batch size 128 saves more batches than 512 on timeout` (the
  `elapsed128 < 15_000 && elapsed512 < 15_000` guard at the former line 322,
  plus its "regression guard for timeout tests are slow on GPU machines" comment
  the issue cited as the file acknowledging the hazard).
- `DiscoverDirectory returns partial results on timeout` (former line 400).
- `Timeout during file reading returns partial data` (former line 475).
- `Discovery completes successfully with reasonable timeout` (former line 550).

The issue named the latter three explicitly; the fourth (former line 322) is the
identical anti-pattern in the same file — the issue quotes its own comment at
line 319 — so it was removed too for a consistent, complete fix.

Closes #2998.

## Evidence

Backend/test-only change — no web interface to screenshot. Verified by running
the modified test file; all four behavioural tests still pass without the timing
gate:

```
Batch size 128 saves more batches than 512 on timeout ... ok (254ms)
DiscoverDirectory returns partial results on timeout ... ok (126ms)
Timeout during file reading returns partial data ... ok (1s)
Discovery completes successfully with reasonable timeout ... ok (25ms)
ok | 4 passed | 0 failed (1s)
```

The observed runtimes (25 ms–1 s) confirm the 15 s assertion never gated real
behaviour on a fast machine, while still being able to fail spuriously on a slow
one — exactly the flakiness removed.

```mermaid
flowchart LR
    A[recordDirectory hits<br/>configured timeout] --> B[returns partial result]
    B --> C{assert WHAT}
    C --> D[recorded &gt; 0]
    C --> E[recorded &lt; recordCount]
    C --> F[parquetCount &gt; 0]
    B -.removed HOW.-> G[elapsed &lt; 15_000ms]
    style G stroke-dasharray: 5 5,color:#999
```

## Test Plan

- No new tests added: the issue is removal of a counter-productive,
  non-behavioural assertion. The existing partial-recording assertions in each
  test continue to prove the timeout fired.
- Ran `deno test test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` — 4
  passed, 0 failed.
- Ran `deno fmt --check`, `deno lint`, `deno check` on the file — all clean (the
  removed `start`/`elapsed` locals would otherwise trip the no-unused-vars
  lint).
- Ran `./quality.sh` — full project gate.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqgjn1na-89713b`<!-- vibe-worker-issue-2998 -->