### PR TITLE
Discovery: map taskDescriptor to PascalCase FFI wire shape (#3012)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/api/COSTS_AND_ACTIVATIONS.md
+++ b/docs/api/COSTS_AND_ACTIVATIONS.md
@@ -126,6 +126,38 @@ interface TaskDescriptor {
 `OTHER_COST_NAME` is `"OTHER"`; `OTHER_TASK_DESCRIPTOR` is the fully-`unknown`
 descriptor returned for any unrecognised cost.
 
+#### FFI wire shape (Issue #3012)
+
+The `TaskDescriptor` above uses snake_case **internal** names. NEAT-AI-Discovery
+(the Rust consumer) deserialises a different, PascalCase shape, so every
+descriptor crossing the FFI boundary is mapped through
+`taskDescriptorToRustWire(descriptor, numOutputs)` first. Forwarding the
+internal shape unchanged makes Rust fail with `unknown variant 'unbounded'`.
+
+```typescript
+interface RustWireTaskDescriptor {
+  readonly targetTopology: RustWireTopology; // "Independent" | "Simplex" | …
+  readonly targetRange: RustWireRange; // "Unbounded" | "Positive" | …
+  readonly outputSquashFamily: RustWireSquashFamily; // "BoundedUnipolar" | …
+  readonly numOutputs: number; // from the creature export
+}
+```
+
+| Internal field       | Wire field           | Example mapping                        |
+| -------------------- | -------------------- | -------------------------------------- |
+| `topology`           | `targetTopology`     | `independent` → `Independent`          |
+| `range`              | `targetRange`        | `signed_unit` → `SignedUnit`           |
+| `outputSquashFamily` | `outputSquashFamily` | `bounded_unipolar` → `BoundedUnipolar` |
+| _(none)_             | `numOutputs`         | output neuron count                    |
+| `costName`           | _(dropped)_          | never sent on the wire                 |
+
+```mermaid
+flowchart LR
+  A["costNameToTaskDescriptor<br/>(snake_case internal)"] --> B["taskDescriptorToRustWire<br/>(PascalCase wire)"]
+  B --> C["recordDiscovery /<br/>analyzeParallel FFI"]
+  C --> D["NEAT-AI-Discovery (Rust)"]
+```
+
 ---
 
 ## ⚡ Activation Functions

--- a/docs/archive/pr-summaries/pr-summary-3012.md
+++ b/docs/archive/pr-summaries/pr-summary-3012.md
@@ -1,0 +1,70 @@
+# taskDescriptor FFI wire format: snake_case → PascalCase (Issue #3012)
+
+## Summary
+
+`#2785` attached the internal snake_case `TaskDescriptor` (`#2786`) directly to
+the `recordDiscovery` / `analyzeParallel` FFI payloads. NEAT-AI-Discovery (Rust,
+`#1314`) deserialises a **PascalCase** `TaskDescriptor`, so it failed with
+`unknown variant 'unbounded'` and Rust synapse/neuron analysis degraded to
+repeated "Rust synapse/neuron analysis unavailable".
+
+This change adds a dedicated wire mapper,
+`taskDescriptorToRustWire(descriptor, numOutputs)`, and applies it at both FFI
+boundaries before `JSON.stringify`. The internal `#2786` types are unchanged.
+
+Mappings (TS internal → Rust wire):
+
+- `topology` → `targetTopology` (`independent` → `Independent`, …)
+- `range` → `targetRange` (`signed_unit` → `SignedUnit`, …)
+- `outputSquashFamily` → `outputSquashFamily` (`bounded_unipolar` →
+  `BoundedUnipolar`, …)
+- adds `numOutputs` from the creature export
+- drops the internal-only `costName` (never sent on the wire)
+
+Closes #3012.
+
+## Evidence
+
+Backend/FFI change — no web UI to screenshot. Verified by the tests below (TDD:
+the new wire-shape assertions fail against the unfixed producer that forwarded
+the snake_case descriptor, and pass after the mapper lands).
+
+```mermaid
+flowchart LR
+  A["costNameToTaskDescriptor<br/>(snake_case internal)"] --> B["taskDescriptorToRustWire<br/>(PascalCase wire)"]
+  B --> C["recordDiscovery /<br/>analyzeParallel FFI"]
+  C --> D["NEAT-AI-Discovery (Rust)"]
+```
+
+Golden fixtures mirror the canonical payloads from Discovery
+`tests/ffi/issue_1314_task_descriptor_plumbing.rs` (MSE, CROSS_ENTROPY, HINGE,
+OTHER).
+
+## Test Plan
+
+New `test/ErrorGuidedStructuralEvolution/TaskDescriptorRustWire.ts`:
+
+- `taskDescriptorToRustWire emits only the Discovery contract fields` — every
+  built-in + `OTHER` carries only `targetTopology` / `targetRange` /
+  `outputSquashFamily` / `numOutputs`, all PascalCase; no `topology` / `range` /
+  `costName`.
+- `… MSE never serialises the snake_case 'unbounded'` — exact regression guard.
+- `… matches Discovery #1314 golden fixtures` — byte-for-byte contract lock.
+- `… maps the neutral OTHER descriptor` and `… clamps invalid numOutputs`.
+
+Updated `test/ErrorGuidedStructuralEvolution/DiscoveryTaskDescriptor.ts` —
+`recordDiscovery` / `analyzeParallel` / `ensureRustCombinedAnalysis` stubs now
+assert on `JSON.parse(JSON.stringify(input)).taskDescriptor` (the serialised
+wire shape) instead of the internal object reference, and verify the wire
+payload omits `costName` / `topology` / `range`.
+
+Files changed:
+
+- `src/costs/TaskDescriptorRustWire.ts` (new mapper + wire types)
+- `src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryTypes.ts`
+  (`taskDescriptor` fields now typed `RustWireTaskDescriptor`)
+- `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts`
+  (`recordDiscovery` maps to the wire shape)
+- `src/architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts`
+  (`analyzeParallel` maps to the wire shape)
+- `docs/api/COSTS_AND_ACTIVATIONS.md` (documents the FFI wire shape)

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
@@ -25,6 +25,7 @@ import {
   finalizeRustFlushDiagnostics as finalizeRustFlushDiagnosticsImpl,
   observeRustTrainingRecord as observeRustTrainingRecordImpl,
 } from "@architecture/ErrorGuidedStructuralEvolution/RustFlushDiagnostics.ts";
+import { taskDescriptorToRustWire } from "@costs/TaskDescriptorRustWire.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { appendAll } from "@utils/ArrayAppend.ts";
 import { isReleased } from "@utils/ReleasableRef.ts";
@@ -315,7 +316,12 @@ export class DiscoverStructureRecording extends DiscoverStructureBase {
       "binary_file_path": this.rustBinaryFilePath || undefined,
       "record_indices": recordIndicesLocal,
       "timeout_seconds": timeoutSeconds,
-      taskDescriptor: this.taskDescriptor,
+      // Map the internal snake_case descriptor to the PascalCase FFI wire
+      // shape NEAT-AI-Discovery deserialises (Issue #3012).
+      taskDescriptor: taskDescriptorToRustWire(
+        this.taskDescriptor,
+        this.creature.output,
+      ),
     };
 
     const result = this.deps.recordDiscovery(rustInput);

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts
@@ -18,6 +18,7 @@ import type {
 import { creatureToRustFormat } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import type { DiscoverStructureDeps } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { TaskDescriptor } from "@costs/CostTaskDescriptor.ts";
+import { taskDescriptorToRustWire } from "@costs/TaskDescriptorRustWire.ts";
 import {
   buildRuntimeIdToWireMap,
   resolveRuntimeIdToWireUuid,
@@ -175,7 +176,17 @@ export function ensureRustCombinedAnalysis(
       : undefined,
     analysisDeadlineMs: effectiveDeadlineMs,
     focusNeuronErrorShares,
-    ...(taskDescriptor ? { taskDescriptor } : {}),
+    // Map the internal snake_case descriptor to the PascalCase FFI wire shape
+    // NEAT-AI-Discovery deserialises (Issue #3012). Stays absent when no
+    // descriptor is configured (backward compatible).
+    ...(taskDescriptor
+      ? {
+        taskDescriptor: taskDescriptorToRustWire(
+          taskDescriptor,
+          creature.output,
+        ),
+      }
+      : {}),
   };
 
   const parallelResult = deps.analyzeParallel(parallelInput);

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryTypes.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryTypes.ts
@@ -5,7 +5,7 @@
  * Rust library via Deno's Foreign Function Interface.
  */
 
-import type { TaskDescriptor } from "@costs/CostTaskDescriptor.ts";
+import type { RustWireTaskDescriptor } from "@costs/TaskDescriptorRustWire.ts";
 
 /**
  * Result of recording discovery data via Rust module.
@@ -241,14 +241,16 @@ export interface RustParallelAnalysisInput {
    */
   focusNeuronErrorShares?: Record<string, number>;
   /**
-   * Structural descriptor of the configured cost (Issue #2785). Built-in costs
-   * carry their canonical name; custom JS costs collapse to the neutral `OTHER`
-   * descriptor so the real custom name never leaves the process.
+   * Structural descriptor of the configured cost on the FFI wire (Issues #2785,
+   * #3012). PascalCase shape NEAT-AI-Discovery deserialises — built-in costs
+   * carry their canonical structure; custom JS costs collapse to the neutral
+   * `Unknown` / `Unbounded` / `Any` descriptor so the real custom name never
+   * leaves the process.
    *
    * Optional on the wire: an older Discovery build that ignores this field
    * still works (backward compatible).
    */
-  taskDescriptor?: TaskDescriptor;
+  taskDescriptor?: RustWireTaskDescriptor;
 }
 
 /**
@@ -495,14 +497,16 @@ export interface RustRecordInput {
   "record_indices"?: number[];
   "timeout_seconds"?: number;
   /**
-   * Structural descriptor of the configured cost (Issue #2785). Built-in costs
-   * carry their canonical name; custom JS costs collapse to the neutral `OTHER`
-   * descriptor so the real custom name never leaves the process.
+   * Structural descriptor of the configured cost on the FFI wire (Issues #2785,
+   * #3012). PascalCase shape NEAT-AI-Discovery deserialises — built-in costs
+   * carry their canonical structure; custom JS costs collapse to the neutral
+   * `Unknown` / `Unbounded` / `Any` descriptor so the real custom name never
+   * leaves the process.
    *
    * Optional on the wire: an older Discovery build that ignores this field
    * still works (backward compatible).
    */
-  taskDescriptor?: TaskDescriptor;
+  taskDescriptor?: RustWireTaskDescriptor;
 }
 
 /**

--- a/src/costs/TaskDescriptorRustWire.ts
+++ b/src/costs/TaskDescriptorRustWire.ts
@@ -1,0 +1,117 @@
+/**
+ * Wire/FFI mapper that converts the internal snake_case {@link TaskDescriptor}
+ * (Issue #2786) into the PascalCase shape NEAT-AI-Discovery expects on the
+ * `recordDiscovery` / `analyzeParallel` FFI boundary (Issue #3012).
+ *
+ * NEAT-AI-Discovery deserialises a Rust `TaskDescriptor` with camelCase field
+ * names (`targetTopology`, `targetRange`, `outputSquashFamily`, `numOutputs`)
+ * and PascalCase enum variants (`Unbounded`, `BoundedUnipolar`, …). Forwarding
+ * the internal descriptor unchanged makes Rust fail with
+ * `unknown variant 'unbounded'`, so every payload crossing the FFI boundary
+ * must be mapped through {@link taskDescriptorToRustWire} first.
+ *
+ * The internal {@link TaskDescriptor} types (Issue #2786) stay unchanged; this
+ * module is the single source of truth for the wire shape.
+ */
+
+import type {
+  CostRange,
+  CostTopology,
+  OutputSquashFamily,
+  TaskDescriptor,
+} from "@costs/CostTaskDescriptor.ts";
+
+/** PascalCase target topology accepted by NEAT-AI-Discovery. */
+export type RustWireTopology =
+  | "Independent"
+  | "Simplex"
+  | "Margin"
+  | "OneHot"
+  | "Unknown";
+
+/** PascalCase target range accepted by NEAT-AI-Discovery. */
+export type RustWireRange =
+  | "Unbounded"
+  | "Positive"
+  | "Unit"
+  | "SignedUnit";
+
+/** PascalCase output squash family accepted by NEAT-AI-Discovery. */
+export type RustWireSquashFamily =
+  | "Unbounded"
+  | "Positive"
+  | "BoundedUnipolar"
+  | "BoundedBipolar"
+  | "Any";
+
+/**
+ * The exact `taskDescriptor` shape sent across the FFI boundary. Field names
+ * and enum casing match the Rust `TaskDescriptor` struct in
+ * NEAT-AI-Discovery (`src/analysis/task_descriptor.rs`).
+ *
+ * Note: the internal `costName` is deliberately **not** present on the wire —
+ * Rust has no such field and a custom cost's real name must never leak.
+ */
+export interface RustWireTaskDescriptor {
+  readonly targetTopology: RustWireTopology;
+  readonly targetRange: RustWireRange;
+  readonly outputSquashFamily: RustWireSquashFamily;
+  readonly numOutputs: number;
+}
+
+const TOPOLOGY_TO_WIRE: Readonly<Record<CostTopology, RustWireTopology>> =
+  Object.freeze({
+    independent: "Independent",
+    simplex: "Simplex",
+    margin: "Margin",
+    one_hot: "OneHot",
+    unknown: "Unknown",
+  });
+
+const RANGE_TO_WIRE: Readonly<Record<CostRange, RustWireRange>> = Object.freeze(
+  {
+    unbounded: "Unbounded",
+    positive: "Positive",
+    unit: "Unit",
+    signed_unit: "SignedUnit",
+  },
+);
+
+const SQUASH_FAMILY_TO_WIRE: Readonly<
+  Record<OutputSquashFamily, RustWireSquashFamily>
+> = Object.freeze({
+  unbounded: "Unbounded",
+  positive: "Positive",
+  bounded_unipolar: "BoundedUnipolar",
+  bounded_bipolar: "BoundedBipolar",
+  any: "Any",
+});
+
+/**
+ * Maps an internal {@link TaskDescriptor} to the PascalCase wire shape Discovery
+ * deserialises, attaching `numOutputs` from the creature export.
+ *
+ * Unrecognised enum values (which the type system already forbids) defensively
+ * collapse to the neutral `Unknown` / `Unbounded` / `Any` variants rather than
+ * forwarding a value Rust would reject.
+ *
+ * @param descriptor - The internal structural descriptor (Issue #2786).
+ * @param numOutputs - Number of output neurons from the creature export.
+ * @returns The wire descriptor with PascalCase field names and enum variants.
+ */
+export function taskDescriptorToRustWire(
+  descriptor: TaskDescriptor,
+  numOutputs: number,
+): RustWireTaskDescriptor {
+  const safeNumOutputs = Number.isFinite(numOutputs) && numOutputs > 0
+    ? Math.floor(numOutputs)
+    : 0;
+
+  return {
+    targetTopology: TOPOLOGY_TO_WIRE[descriptor.topology] ?? "Unknown",
+    targetRange: RANGE_TO_WIRE[descriptor.range] ?? "Unbounded",
+    outputSquashFamily: SQUASH_FAMILY_TO_WIRE[descriptor.outputSquashFamily] ??
+      "Any",
+    numOutputs: safeNumOutputs,
+  };
+}

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryTaskDescriptor.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryTaskDescriptor.ts
@@ -20,9 +20,8 @@ import type {
 import {
   costNameToTaskDescriptor,
   OTHER_COST_NAME,
-  OTHER_TASK_DESCRIPTOR,
-  type TaskDescriptor,
 } from "@costs/CostTaskDescriptor.ts";
+import type { RustWireTaskDescriptor } from "@costs/TaskDescriptorRustWire.ts";
 import { initWasmForTests } from "../_initWasm.ts";
 
 function makeCreature(): Creature {
@@ -107,16 +106,24 @@ Deno.test("recordDiscovery carries the configured cost task descriptor (Issue #2
       1,
       "recordDiscovery should be invoked once",
     );
+    // Assert the serialised FFI wire shape (Issue #3012), not the internal
+    // object reference — Discovery deserialises PascalCase field names/variants.
+    const wire: RustWireTaskDescriptor =
+      JSON.parse(JSON.stringify(recordedInputs[0])).taskDescriptor;
     assertEquals(
-      recordedInputs[0].taskDescriptor,
-      crossEntropyDescriptor,
-      "recordDiscovery should send the configured descriptor",
+      wire,
+      {
+        targetTopology: "Simplex",
+        targetRange: "Unit",
+        outputSquashFamily: "BoundedUnipolar",
+        numOutputs: 1,
+      },
+      "recordDiscovery should send the PascalCase wire descriptor for CROSS_ENTROPY",
     );
-    assertEquals(
-      recordedInputs[0].taskDescriptor?.costName,
-      "CROSS_ENTROPY",
-      "built-in cost sends its canonical name",
-    );
+    // Internal-only fields must never appear on the wire.
+    assert(!("costName" in wire), "wire must not include internal costName");
+    assert(!("topology" in wire), "wire must not include internal topology");
+    assert(!("range" in wire), "wire must not include internal range");
   } finally {
     await structure.cleanUp();
   }
@@ -163,11 +170,16 @@ Deno.test("recordDiscovery defaults to the neutral OTHER descriptor when no cost
     );
     assertEquals(structure.flushRustChunk(), true);
 
-    assertEquals(
-      recordedInputs[0].taskDescriptor,
-      OTHER_TASK_DESCRIPTOR,
-      "missing cost defaults to the neutral OTHER descriptor",
-    );
+    // Missing cost defaults to the neutral OTHER descriptor, mapped to its
+    // PascalCase wire form (Issue #3012).
+    const wire: RustWireTaskDescriptor =
+      JSON.parse(JSON.stringify(recordedInputs[0])).taskDescriptor;
+    assertEquals(wire, {
+      targetTopology: "Unknown",
+      targetRange: "Unbounded",
+      outputSquashFamily: "Any",
+      numOutputs: 1,
+    });
   } finally {
     await structure.cleanUp();
   }
@@ -232,12 +244,21 @@ Deno.test("analyzeParallel carries the configured cost task descriptor (Issue #2
       1,
       "analyzeParallel should be invoked once",
     );
-    assertEquals(
-      analyzeInputs[0].taskDescriptor,
-      mseDescriptor,
-      "analyzeParallel should send the configured descriptor",
+    // Assert the serialised FFI wire shape (Issue #3012). MSE's internal range
+    // and squash are both snake_case "unbounded"; the wire must be "Unbounded".
+    const wire: RustWireTaskDescriptor =
+      JSON.parse(JSON.stringify(analyzeInputs[0])).taskDescriptor;
+    assertEquals(wire, {
+      targetTopology: "Independent",
+      targetRange: "Unbounded",
+      outputSquashFamily: "Unbounded",
+      numOutputs: 1,
+    });
+    // Exact regression guard: the snake_case variant must never reach the wire.
+    assert(
+      !JSON.stringify(analyzeInputs[0]).includes('"unbounded"'),
+      'MSE wire must not contain snake_case "unbounded"',
     );
-    assertEquals(analyzeInputs[0].taskDescriptor?.costName, "MSE");
   } finally {
     await structure.cleanUp();
   }
@@ -280,8 +301,17 @@ Deno.test("ensureRustCombinedAnalysis never leaks a custom cost name, sending OT
   );
 
   assert(capturedInput, "analyzeParallel should have been called");
-  const sent: TaskDescriptor | undefined = capturedInput.taskDescriptor;
-  assertEquals(sent?.costName, OTHER_COST_NAME);
+  // The custom cost collapses to the neutral OTHER descriptor on the wire — a
+  // PascalCase shape carrying no name (Issue #3012).
+  const sent: RustWireTaskDescriptor | undefined =
+    JSON.parse(JSON.stringify(capturedInput)).taskDescriptor;
+  assertEquals(sent, {
+    targetTopology: "Unknown",
+    targetRange: "Unbounded",
+    outputSquashFamily: "Any",
+    numOutputs: 1,
+  });
+  assert(sent && !("costName" in sent), "wire must not include costName");
   // The raw custom name must not appear anywhere in the serialised payload.
   assert(
     !JSON.stringify(capturedInput).includes("my-secret-custom-cost"),

--- a/test/ErrorGuidedStructuralEvolution/TaskDescriptorRustWire.ts
+++ b/test/ErrorGuidedStructuralEvolution/TaskDescriptorRustWire.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression + contract tests for the cost {@link TaskDescriptor} FFI wire
+ * mapper (Issue #3012).
+ *
+ * The #2785 regression happened because the internal snake_case descriptor was
+ * forwarded to NEAT-AI-Discovery unchanged, so Rust failed with
+ * `unknown variant 'unbounded'`. These tests lock the *serialised* wire shape
+ * — PascalCase field names and enum variants — for every built-in cost plus the
+ * neutral `OTHER` descriptor, and mirror the canonical golden payloads from
+ * Discovery `tests/ffi/issue_1314_task_descriptor_plumbing.rs`.
+ */
+import { assert, assertEquals } from "@std/assert";
+import {
+  costNameToTaskDescriptor,
+  OTHER_TASK_DESCRIPTOR,
+} from "@costs/CostTaskDescriptor.ts";
+import {
+  type RustWireTaskDescriptor,
+  taskDescriptorToRustWire,
+} from "@costs/TaskDescriptorRustWire.ts";
+
+/** Every built-in cost name carried by a canonical descriptor. */
+const BUILT_IN_COST_NAMES = [
+  "MSE",
+  "MAE",
+  "MAPE",
+  "MSLE",
+  "BINARY_CROSS_ENTROPY",
+  "CROSS_ENTROPY",
+  "HINGE",
+] as const;
+
+/** Allowed PascalCase enum values on the wire (no snake_case permitted). */
+const ALLOWED_TOPOLOGIES = new Set([
+  "Independent",
+  "Simplex",
+  "Margin",
+  "OneHot",
+  "Unknown",
+]);
+const ALLOWED_RANGES = new Set([
+  "Unbounded",
+  "Positive",
+  "Unit",
+  "SignedUnit",
+]);
+const ALLOWED_SQUASH = new Set([
+  "Unbounded",
+  "Positive",
+  "BoundedUnipolar",
+  "BoundedBipolar",
+  "Any",
+]);
+
+Deno.test("taskDescriptorToRustWire emits only the Discovery contract fields (Issue #3012)", () => {
+  for (const costName of [...BUILT_IN_COST_NAMES, "OTHER"]) {
+    const wire = taskDescriptorToRustWire(
+      costNameToTaskDescriptor(costName),
+      1,
+    );
+
+    // Exactly the four contract fields — no internal-only fields leak.
+    assertEquals(
+      Object.keys(wire).sort(),
+      ["numOutputs", "outputSquashFamily", "targetRange", "targetTopology"],
+      `${costName} wire must carry only the Discovery contract fields`,
+    );
+
+    const serialised = JSON.parse(JSON.stringify(wire));
+    assertEquals(
+      "topology" in serialised,
+      false,
+      `${costName} wire must not include internal 'topology'`,
+    );
+    assertEquals(
+      "range" in serialised,
+      false,
+      `${costName} wire must not include internal 'range'`,
+    );
+    assertEquals(
+      "costName" in serialised,
+      false,
+      `${costName} wire must not include internal 'costName'`,
+    );
+
+    // Enum values are PascalCase variants Discovery can deserialise.
+    assert(
+      ALLOWED_TOPOLOGIES.has(wire.targetTopology),
+      `${costName} targetTopology '${wire.targetTopology}' must be PascalCase`,
+    );
+    assert(
+      ALLOWED_RANGES.has(wire.targetRange),
+      `${costName} targetRange '${wire.targetRange}' must be PascalCase`,
+    );
+    assert(
+      ALLOWED_SQUASH.has(wire.outputSquashFamily),
+      `${costName} outputSquashFamily '${wire.outputSquashFamily}' must be PascalCase`,
+    );
+  }
+});
+
+Deno.test("taskDescriptorToRustWire MSE never serialises the snake_case 'unbounded' (Issue #3012 regression)", () => {
+  // This is the exact regression: MSE's internal range + squash are both
+  // 'unbounded' (snake_case); the wire must use 'Unbounded' (PascalCase).
+  const wire = taskDescriptorToRustWire(costNameToTaskDescriptor("MSE"), 1);
+  const json = JSON.stringify({ taskDescriptor: wire });
+
+  assert(
+    !json.includes('"unbounded"'),
+    `MSE wire must not contain snake_case "unbounded": ${json}`,
+  );
+  assert(
+    json.includes('"Unbounded"'),
+    `MSE wire must use PascalCase "Unbounded": ${json}`,
+  );
+});
+
+Deno.test("taskDescriptorToRustWire matches Discovery #1314 golden fixtures (Issue #3012)", () => {
+  // Golden payloads mirrored from NEAT-AI-Discovery
+  // tests/ffi/issue_1314_task_descriptor_plumbing.rs. Field names and enum
+  // casing must match byte-for-byte (modulo numOutputs).
+  const golden: Record<string, RustWireTaskDescriptor> = {
+    MSE: {
+      targetTopology: "Independent",
+      targetRange: "Unbounded",
+      outputSquashFamily: "Unbounded",
+      numOutputs: 1,
+    },
+    CROSS_ENTROPY: {
+      targetTopology: "Simplex",
+      targetRange: "Unit",
+      outputSquashFamily: "BoundedUnipolar",
+      numOutputs: 3,
+    },
+    HINGE: {
+      targetTopology: "Margin",
+      targetRange: "SignedUnit",
+      outputSquashFamily: "BoundedBipolar",
+      numOutputs: 1,
+    },
+    OTHER: {
+      targetTopology: "Unknown",
+      targetRange: "Unbounded",
+      outputSquashFamily: "Any",
+      numOutputs: 2,
+    },
+  };
+
+  for (const [costName, expected] of Object.entries(golden)) {
+    const wire = taskDescriptorToRustWire(
+      costNameToTaskDescriptor(costName),
+      expected.numOutputs,
+    );
+    assertEquals(
+      JSON.parse(JSON.stringify(wire)),
+      expected,
+      `${costName} wire must match the Discovery #1314 golden fixture`,
+    );
+  }
+});
+
+Deno.test("taskDescriptorToRustWire maps the neutral OTHER descriptor (Issue #3012)", () => {
+  const wire = taskDescriptorToRustWire(OTHER_TASK_DESCRIPTOR, 4);
+  assertEquals(wire, {
+    targetTopology: "Unknown",
+    targetRange: "Unbounded",
+    outputSquashFamily: "Any",
+    numOutputs: 4,
+  });
+});
+
+Deno.test("taskDescriptorToRustWire clamps invalid numOutputs to zero (Issue #3012)", () => {
+  for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    const wire = taskDescriptorToRustWire(
+      costNameToTaskDescriptor("MSE"),
+      bad,
+    );
+    assertEquals(
+      wire.numOutputs,
+      0,
+      `numOutputs ${bad} must clamp to 0`,
+    );
+  }
+  // Fractional counts floor to an integer.
+  assertEquals(
+    taskDescriptorToRustWire(costNameToTaskDescriptor("MSE"), 2.9).numOutputs,
+    2,
+  );
+});


### PR DESCRIPTION
# taskDescriptor FFI wire format: snake_case → PascalCase (Issue #3012)

## Summary

`#2785` attached the internal snake_case `TaskDescriptor` (`#2786`) directly to
the `recordDiscovery` / `analyzeParallel` FFI payloads. NEAT-AI-Discovery (Rust,
`#1314`) deserialises a **PascalCase** `TaskDescriptor`, so it failed with
`unknown variant 'unbounded'` and Rust synapse/neuron analysis degraded to
repeated "Rust synapse/neuron analysis unavailable".

This change adds a dedicated wire mapper,
`taskDescriptorToRustWire(descriptor, numOutputs)`, and applies it at both FFI
boundaries before `JSON.stringify`. The internal `#2786` types are unchanged.

Mappings (TS internal → Rust wire):

- `topology` → `targetTopology` (`independent` → `Independent`, …)
- `range` → `targetRange` (`signed_unit` → `SignedUnit`, …)
- `outputSquashFamily` → `outputSquashFamily` (`bounded_unipolar` →
  `BoundedUnipolar`, …)
- adds `numOutputs` from the creature export
- drops the internal-only `costName` (never sent on the wire)

Closes #3012.

## Evidence

Backend/FFI change — no web UI to screenshot. Verified by the tests below (TDD:
the new wire-shape assertions fail against the unfixed producer that forwarded
the snake_case descriptor, and pass after the mapper lands).

```mermaid
flowchart LR
  A["costNameToTaskDescriptor<br/>(snake_case internal)"] --> B["taskDescriptorToRustWire<br/>(PascalCase wire)"]
  B --> C["recordDiscovery /<br/>analyzeParallel FFI"]
  C --> D["NEAT-AI-Discovery (Rust)"]
```

Golden fixtures mirror the canonical payloads from Discovery
`tests/ffi/issue_1314_task_descriptor_plumbing.rs` (MSE, CROSS_ENTROPY, HINGE,
OTHER).

## Test Plan

New `test/ErrorGuidedStructuralEvolution/TaskDescriptorRustWire.ts`:

- `taskDescriptorToRustWire emits only the Discovery contract fields` — every
  built-in + `OTHER` carries only `targetTopology` / `targetRange` /
  `outputSquashFamily` / `numOutputs`, all PascalCase; no `topology` / `range` /
  `costName`.
- `… MSE never serialises the snake_case 'unbounded'` — exact regression guard.
- `… matches Discovery #1314 golden fixtures` — byte-for-byte contract lock.
- `… maps the neutral OTHER descriptor` and `… clamps invalid numOutputs`.

Updated `test/ErrorGuidedStructuralEvolution/DiscoveryTaskDescriptor.ts` —
`recordDiscovery` / `analyzeParallel` / `ensureRustCombinedAnalysis` stubs now
assert on `JSON.parse(JSON.stringify(input)).taskDescriptor` (the serialised
wire shape) instead of the internal object reference, and verify the wire
payload omits `costName` / `topology` / `range`.

Files changed:

- `src/costs/TaskDescriptorRustWire.ts` (new mapper + wire types)
- `src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryTypes.ts`
  (`taskDescriptor` fields now typed `RustWireTaskDescriptor`)
- `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts`
  (`recordDiscovery` maps to the wire shape)
- `src/architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts`
  (`analyzeParallel` maps to the wire shape)
- `docs/api/COSTS_AND_ACTIVATIONS.md` (documents the FFI wire shape)



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqgh2ndg-7f02a7`<!-- vibe-worker-issue-3012 -->