### PR TITLE
Add set -Eeuo pipefail to workflow version blocks (Issue #3003)

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Read version from deno.json
         id: version
         run: |
+          set -Eeuo pipefail
           VERSION=$(jq -r .version deno.json)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Determine whether the version needs publishing
         id: needs_publish
         run: |
+          set -Eeuo pipefail
           name=$(jq -r .name deno.json)
           version=$(jq -r .version deno.json)
           status=$(curl -s -o /dev/null -w '%{http_code}' \

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.8",
+  "version": "5.5.9",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3003.md
+++ b/docs/archive/pr-summaries/pr-summary-3003.md
@@ -2,28 +2,28 @@
 
 ## Summary
 
-The *Determine whether the version needs publishing* step in
+The _Determine whether the version needs publishing_ step in
 `.github/workflows/publish.yml` (and the small version-read block in
 `.github/workflows/github-release.yml`) ran multi-line bash without the
 `set -Eeuo pipefail` preamble that every other substantial run block in the
 repository's workflows already uses. Without strict mode, a `jq` or `curl`
 failure would not abort the step — an unset or empty `name`/`version` could
 silently produce a malformed JSR meta URL, the HTTP status check would fall
-through to the permissive `else` branch, and the publish workflow would
-proceed to `npx jsr publish` on the basis of an unverified result.
+through to the permissive `else` branch, and the publish workflow would proceed
+to `npx jsr publish` on the basis of an unverified result.
 
-This change adds `set -Eeuo pipefail` as the first line of both blocks so a
-tool failure becomes a clean, early abort instead of a silent degradation —
-important in a publish workflow where acting on a wrong answer has
-release-level consequences.
+This change adds `set -Eeuo pipefail` as the first line of both blocks so a tool
+failure becomes a clean, early abort instead of a silent degradation — important
+in a publish workflow where acting on a wrong answer has release-level
+consequences.
 
 Closes #3003.
 
 ## Evidence
 
-CLI/workflow-only change — no web interface to screenshot. Verified by a new
-CI test plus the existing workflow-validation suite (`actionlint`, action
-pinning, concurrency, timeouts) all passing.
+CLI/workflow-only change — no web interface to screenshot. Verified by a new CI
+test plus the existing workflow-validation suite (`actionlint`, action pinning,
+concurrency, timeouts) all passing.
 
 ```mermaid
 flowchart TD
@@ -36,15 +36,15 @@ flowchart TD
 ```
 
 `./quality.sh --lint-only` (format + lint + bash syntax) and
-`./quality.sh --check-only` (type-check) both pass cleanly. The full
-`test/ci/` suite passes (72 tests).
+`./quality.sh --check-only` (type-check) both pass cleanly. The full `test/ci/`
+suite passes (72 tests).
 
 ## Test Plan
 
 - Added `test/ci/WorkflowVersionCheckStrictMode.ts`, which parses each
-  workflow's YAML and asserts the version-handling run block
-  (`publish.yml` step `needs_publish`, `github-release.yml` step `version`)
-  opens with `set -Eeuo pipefail`. The test fails against the pre-fix
-  workflows (first command line was `name=$(jq ...)` / `VERSION=$(jq ...)`)
-  and passes after the change.
+  workflow's YAML and asserts the version-handling run block (`publish.yml` step
+  `needs_publish`, `github-release.yml` step `version`) opens with
+  `set -Eeuo pipefail`. The test fails against the pre-fix workflows (first
+  command line was `name=$(jq ...)` / `VERSION=$(jq ...)`) and passes after the
+  change.
 - Ran the full `test/ci/` suite — 72 passed, 0 failed.

--- a/docs/archive/pr-summaries/pr-summary-3003.md
+++ b/docs/archive/pr-summaries/pr-summary-3003.md
@@ -1,0 +1,50 @@
+# Add strict-mode preamble to workflow version blocks
+
+## Summary
+
+The *Determine whether the version needs publishing* step in
+`.github/workflows/publish.yml` (and the small version-read block in
+`.github/workflows/github-release.yml`) ran multi-line bash without the
+`set -Eeuo pipefail` preamble that every other substantial run block in the
+repository's workflows already uses. Without strict mode, a `jq` or `curl`
+failure would not abort the step — an unset or empty `name`/`version` could
+silently produce a malformed JSR meta URL, the HTTP status check would fall
+through to the permissive `else` branch, and the publish workflow would
+proceed to `npx jsr publish` on the basis of an unverified result.
+
+This change adds `set -Eeuo pipefail` as the first line of both blocks so a
+tool failure becomes a clean, early abort instead of a silent degradation —
+important in a publish workflow where acting on a wrong answer has
+release-level consequences.
+
+Closes #3003.
+
+## Evidence
+
+CLI/workflow-only change — no web interface to screenshot. Verified by a new
+CI test plus the existing workflow-validation suite (`actionlint`, action
+pinning, concurrency, timeouts) all passing.
+
+```mermaid
+flowchart TD
+    A[jq -r .name / .version] -->|set -Eeuo pipefail| B{jq or curl failed?}
+    B -- yes --> C[Step aborts early<br/>publish does NOT run]
+    B -- no --> D{HTTP status}
+    D -- 200 --> E[publish=false]
+    D -- 404 --> F[publish=true]
+    D -- other --> G[publish=true]
+```
+
+`./quality.sh --lint-only` (format + lint + bash syntax) and
+`./quality.sh --check-only` (type-check) both pass cleanly. The full
+`test/ci/` suite passes (72 tests).
+
+## Test Plan
+
+- Added `test/ci/WorkflowVersionCheckStrictMode.ts`, which parses each
+  workflow's YAML and asserts the version-handling run block
+  (`publish.yml` step `needs_publish`, `github-release.yml` step `version`)
+  opens with `set -Eeuo pipefail`. The test fails against the pre-fix
+  workflows (first command line was `name=$(jq ...)` / `VERSION=$(jq ...)`)
+  and passes after the change.
+- Ran the full `test/ci/` suite — 72 passed, 0 failed.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -138,6 +138,7 @@
     "dlopen",
     "dylib",
     "egse",
+    "Eeuo",
     "elem",
     "Emde",
     "endraw",

--- a/test/ci/WorkflowVersionCheckStrictMode.ts
+++ b/test/ci/WorkflowVersionCheckStrictMode.ts
@@ -1,0 +1,101 @@
+/**
+ * Issue #3003 — the version-handling bash blocks in the publish and
+ * release workflows must open with the strict-mode preamble
+ * `set -Eeuo pipefail`, matching the convention used by every other
+ * substantial run block in the repository's workflows.
+ *
+ * Without strict mode, a failure of `jq` or `curl` inside the block does
+ * not abort the step: an unset or empty `name`/`version` silently
+ * produces a malformed JSR meta URL, the HTTP status check falls through
+ * to the permissive `else` branch, and the workflow proceeds to publish
+ * on the basis of an unverified result. `-e` aborts on error, `-u`
+ * catches unset variables and `-o pipefail` surfaces pipeline failures,
+ * turning these silent degradations into a clean, early failure — which
+ * matters in a publish workflow where acting on a wrong answer has
+ * release-level consequences.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+
+interface Step {
+  name?: string;
+  id?: string;
+  run?: string;
+}
+
+interface Job {
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(relPath: string): Promise<Workflow> {
+  const text = await Deno.readTextFile(join(REPO_ROOT, relPath));
+  return parse(text) as Workflow;
+}
+
+function collectSteps(wf: Workflow): Step[] {
+  const steps: Step[] = [];
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      steps.push(step);
+    }
+  }
+  return steps;
+}
+
+/** First non-blank, non-comment line of a run block. */
+function firstCommandLine(run: string): string {
+  for (const line of run.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    return trimmed;
+  }
+  return "";
+}
+
+// Each entry pins the workflow plus the step that performs version work
+// (matched by step id where available, else by name) — the exact blocks
+// the issue requires to enable strict mode.
+const TARGETS = [
+  {
+    workflow: ".github/workflows/publish.yml",
+    match: (s: Step) => s.id === "needs_publish",
+    label: "Determine whether the version needs publishing",
+  },
+  {
+    workflow: ".github/workflows/github-release.yml",
+    match: (s: Step) => s.id === "version",
+    label: "Read version from deno.json",
+  },
+];
+
+for (const target of TARGETS) {
+  Deno.test(
+    `${target.workflow} "${target.label}" run block opens with set -Eeuo pipefail (Issue #3003)`,
+    async () => {
+      const wf = await readWorkflow(target.workflow);
+      const step = collectSteps(wf).find(target.match);
+      assert(
+        step !== undefined,
+        `${target.workflow} expected a step matching "${target.label}"`,
+      );
+      assert(
+        typeof step.run === "string",
+        `${target.workflow} step "${target.label}" expected a run: block`,
+      );
+      assert(
+        firstCommandLine(step.run) === "set -Eeuo pipefail",
+        `${target.workflow} step "${target.label}" must open its run: block ` +
+          "with `set -Eeuo pipefail` so a jq/curl failure aborts the step " +
+          "instead of silently publishing on an unverified result.",
+      );
+    },
+  );
+}


### PR DESCRIPTION
# Add strict-mode preamble to workflow version blocks

## Summary

The _Determine whether the version needs publishing_ step in
`.github/workflows/publish.yml` (and the small version-read block in
`.github/workflows/github-release.yml`) ran multi-line bash without the
`set -Eeuo pipefail` preamble that every other substantial run block in the
repository's workflows already uses. Without strict mode, a `jq` or `curl`
failure would not abort the step — an unset or empty `name`/`version` could
silently produce a malformed JSR meta URL, the HTTP status check would fall
through to the permissive `else` branch, and the publish workflow would proceed
to `npx jsr publish` on the basis of an unverified result.

This change adds `set -Eeuo pipefail` as the first line of both blocks so a tool
failure becomes a clean, early abort instead of a silent degradation — important
in a publish workflow where acting on a wrong answer has release-level
consequences.

Closes #3003.

## Evidence

CLI/workflow-only change — no web interface to screenshot. Verified by a new CI
test plus the existing workflow-validation suite (`actionlint`, action pinning,
concurrency, timeouts) all passing.

```mermaid
flowchart TD
    A[jq -r .name / .version] -->|set -Eeuo pipefail| B{jq or curl failed?}
    B -- yes --> C[Step aborts early<br/>publish does NOT run]
    B -- no --> D{HTTP status}
    D -- 200 --> E[publish=false]
    D -- 404 --> F[publish=true]
    D -- other --> G[publish=true]
```

`./quality.sh --lint-only` (format + lint + bash syntax) and
`./quality.sh --check-only` (type-check) both pass cleanly. The full `test/ci/`
suite passes (72 tests).

## Test Plan

- Added `test/ci/WorkflowVersionCheckStrictMode.ts`, which parses each
  workflow's YAML and asserts the version-handling run block (`publish.yml` step
  `needs_publish`, `github-release.yml` step `version`) opens with
  `set -Eeuo pipefail`. The test fails against the pre-fix workflows (first
  command line was `name=$(jq ...)` / `VERSION=$(jq ...)`) and passes after the
  change.
- Ran the full `test/ci/` suite — 72 passed, 0 failed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqgr62lg-fc0db7`<!-- vibe-worker-issue-3003 -->