### PR TITLE
CI: add set -Eeuo pipefail to markdown-lint detect-deno block (#3006)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Detect Deno worker module
         id: detect-deno
         run: |
+          set -Eeuo pipefail
           if [ -f worker/deno/mod.ts ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.9",
+  "version": "5.5.10",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3006.md
+++ b/docs/archive/pr-summaries/pr-summary-3006.md
@@ -1,0 +1,58 @@
+## Summary
+
+Added the `set -Eeuo pipefail` strict-mode preamble to the one remaining
+multi-line `run:` block flagged by the `github-actions-audit` finding that still
+lacked it — the `Detect Deno worker module` step in
+`.github/workflows/markdown-lint.yml`. Without strict mode a failing command
+inside the block does not abort the step, so a stale or empty step output could
+silently flow into the conditional Deno steps that gate on it.
+
+The two other blocks cited by the issue — `.github/workflows/publish.yml`
+(`Determine whether the version needs
+publishing`) and
+`.github/workflows/github-release.yml` (`Read version
+from deno.json`) — already
+open with `set -Eeuo pipefail`, having been brought into line by Issue #3003 (PR
+#3014), so no change was needed there. The `coverage.yaml`, `quality.yml` and
+`update-package-version.yml` workflows are cited by the issue itself as the
+house-style standard and are out of scope.
+
+Closes #3006.
+
+## Evidence
+
+This is a CI workflow YAML hygiene change with no web interface to screenshot.
+Verification is by the added behaviour-style test that parses the workflow YAML
+and asserts the run block opens with the preamble.
+
+Before — `markdown-lint.yml` `detect-deno` step:
+
+```yaml
+id: detect-deno
+run: |
+  if [ -f worker/deno/mod.ts ]; then
+```
+
+After:
+
+```yaml
+id: detect-deno
+run: |
+  set -Eeuo pipefail
+  if [ -f worker/deno/mod.ts ]; then
+```
+
+```mermaid
+flowchart LR
+    A[jq/test/grep fails] -->|no set| B[empty/stale step output] --> C[conditional steps run on bad input]
+    A -->|set -Eeuo pipefail| D[step aborts loudly]
+```
+
+## Test Plan
+
+- Added `test/ci/MarkdownLintStrictMode.ts`, modelled on the existing
+  `test/ci/WorkflowVersionCheckStrictMode.ts`. It parses
+  `.github/workflows/markdown-lint.yml`, locates the `detect-deno` step, and
+  asserts its `run:` block's first command line is `set -Eeuo pipefail`. The
+  test failed against the unfixed workflow and passes after the fix.
+- `./quality.sh` run clean (fmt, lint, type-check, full test suite).

--- a/test/ci/MarkdownLintStrictMode.ts
+++ b/test/ci/MarkdownLintStrictMode.ts
@@ -1,0 +1,87 @@
+/**
+ * Issue #3006 — the multi-line bash blocks in the markdown-lint workflow
+ * must open with the strict-mode preamble `set -Eeuo pipefail`, matching
+ * the convention used by every other substantial run block in the
+ * repository's workflows (publish.yml and github-release.yml were brought
+ * into line by Issue #3003).
+ *
+ * The "Detect Deno worker module" step writes a step output that later
+ * steps gate on. Without strict mode a failure inside the block does not
+ * abort the step: an unset or empty value silently flows into the
+ * conditional steps. `-e` aborts on error, `-u` catches unset variables
+ * and `-o pipefail` surfaces pipeline failures, turning these silent
+ * degradations into a clean, early failure.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+
+interface Step {
+  name?: string;
+  id?: string;
+  run?: string;
+}
+
+interface Job {
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(relPath: string): Promise<Workflow> {
+  const text = await Deno.readTextFile(join(REPO_ROOT, relPath));
+  return parse(text) as Workflow;
+}
+
+function collectSteps(wf: Workflow): Step[] {
+  const steps: Step[] = [];
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      steps.push(step);
+    }
+  }
+  return steps;
+}
+
+/** First non-blank, non-comment line of a run block. */
+function firstCommandLine(run: string): string {
+  for (const line of run.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    return trimmed;
+  }
+  return "";
+}
+
+const TARGET = {
+  workflow: ".github/workflows/markdown-lint.yml",
+  match: (s: Step) => s.id === "detect-deno",
+  label: "Detect Deno worker module",
+};
+
+Deno.test(
+  `${TARGET.workflow} "${TARGET.label}" run block opens with set -Eeuo pipefail (Issue #3006)`,
+  async () => {
+    const wf = await readWorkflow(TARGET.workflow);
+    const step = collectSteps(wf).find(TARGET.match);
+    assert(
+      step !== undefined,
+      `${TARGET.workflow} expected a step matching "${TARGET.label}"`,
+    );
+    assert(
+      typeof step.run === "string",
+      `${TARGET.workflow} step "${TARGET.label}" expected a run: block`,
+    );
+    assert(
+      firstCommandLine(step.run) === "set -Eeuo pipefail",
+      `${TARGET.workflow} step "${TARGET.label}" must open its run: block ` +
+        "with `set -Eeuo pipefail` so a failing command aborts the step " +
+        "instead of silently writing a stale step output.",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Added the `set -Eeuo pipefail` strict-mode preamble to the one remaining
multi-line `run:` block flagged by the `github-actions-audit` finding that still
lacked it — the `Detect Deno worker module` step in
`.github/workflows/markdown-lint.yml`. Without strict mode a failing command
inside the block does not abort the step, so a stale or empty step output could
silently flow into the conditional Deno steps that gate on it.

The two other blocks cited by the issue — `.github/workflows/publish.yml`
(`Determine whether the version needs
publishing`) and
`.github/workflows/github-release.yml` (`Read version
from deno.json`) — already
open with `set -Eeuo pipefail`, having been brought into line by Issue #3003 (PR
#3014), so no change was needed there. The `coverage.yaml`, `quality.yml` and
`update-package-version.yml` workflows are cited by the issue itself as the
house-style standard and are out of scope.

Closes #3006.

## Evidence

This is a CI workflow YAML hygiene change with no web interface to screenshot.
Verification is by the added behaviour-style test that parses the workflow YAML
and asserts the run block opens with the preamble.

Before — `markdown-lint.yml` `detect-deno` step:

```yaml
id: detect-deno
run: |
  if [ -f worker/deno/mod.ts ]; then
```

After:

```yaml
id: detect-deno
run: |
  set -Eeuo pipefail
  if [ -f worker/deno/mod.ts ]; then
```

```mermaid
flowchart LR
    A[jq/test/grep fails] -->|no set| B[empty/stale step output] --> C[conditional steps run on bad input]
    A -->|set -Eeuo pipefail| D[step aborts loudly]
```

## Test Plan

- Added `test/ci/MarkdownLintStrictMode.ts`, modelled on the existing
  `test/ci/WorkflowVersionCheckStrictMode.ts`. It parses
  `.github/workflows/markdown-lint.yml`, locates the `detect-deno` step, and
  asserts its `run:` block's first command line is `set -Eeuo pipefail`. The
  test failed against the unfixed workflow and passes after the fix.
- `./quality.sh` run clean (fmt, lint, type-check, full test suite).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqgr62lg-fc0db7`<!-- vibe-worker-issue-3006 -->