### PR TITLE
Add advisory-driven Renovate security-update channel (Issue #3007)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,15 @@ opening a PR (see the secure-coding principles section of
 - **Secret scanning** — `gitleaks` patterns live in `.gitleaks.toml` at the
   repository root.
 - **Dependency bumps** — the weekly `deno outdated` job in
-  `.github/workflows/deno-outdated.yml` raises automated bump PRs.
+  `.github/workflows/deno-outdated.yml` raises automated _freshness_ bump PRs
+  (whatever is newest, honouring the 24h quarantine).
+- **Advisory-driven security updates** — `renovate.json` enables Renovate's
+  OSV-backed vulnerability-alert channel (`vulnerabilityAlerts` +
+  `osvVulnerabilityAlerts`). Where the OSV scan above _detects_ a disclosed CVE,
+  this channel _remediates_ it: Renovate raises a dedicated bump PR for any
+  dependency carrying a known OSV advisory, shrinking the window between
+  disclosure and a reviewable fix rather than waiting for the next weekly
+  freshness run.
 
 For everything else, see the sibling docs: [`README.md`](./README.md),
 [`AGENTS.md`](./AGENTS.md), [`CONTRIBUTING.md`](./CONTRIBUTING.md),

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.10",
+  "version": "5.5.11",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3007.md
+++ b/docs/archive/pr-summaries/pr-summary-3007.md
@@ -1,0 +1,79 @@
+# SCR-AUTO-UPDATE: enable the advisory-driven security-update channel
+
+## Summary
+
+The repository already had _freshness-driven_ dependency automation
+(`.github/workflows/deno-outdated.yml` weekly bump, `bump-deps.sh` quarantine
+refresh) and advisory _detection_ (`.github/workflows/osv-scan.yml`), but no
+advisory-_driven_ update channel. When a CVE was disclosed against a pinned
+`jsr:`/`npm:` dependency, nothing raised a targeted remediation PR — the team
+waited for the next weekly freshness run (plus the 24h quarantine) or responded
+manually to the OSV scan failure.
+
+This change adds a minimal `renovate.json` that enables Renovate's OSV-backed
+vulnerability-alert channel. Renovate supports the Deno manager (`jsr:`, `npm:`,
+`https://deno.land/*`), so the control is genuinely available here (unlike
+Dependabot, which does not parse `deno.json`/`deno.lock`). The existing
+freshness job is left untouched — this closes the _remediation-automation_ half
+of the same loop that `osv-scan.yml` _detects_.
+
+`SECURITY.md` is updated to document the new channel alongside the existing
+automation.
+
+Closes #3007.
+
+## Evidence
+
+This is a config/CI change with no web interface to screenshot. Verification is
+via the new "what" tests that parse the committed `renovate.json` and assert on
+the resulting configuration (schema reference, `config:recommended` preset,
+`vulnerabilityAlerts.enabled`, `osvVulnerabilityAlerts`).
+
+```mermaid
+flowchart LR
+    CVE[CVE disclosed against<br/>pinned dependency] --> Detect
+    subgraph Detection
+      Detect[osv-scan.yml<br/>weekly OSV scan] -->|fails CI| Signal[Actionable signal]
+    end
+    subgraph Remediation
+      CVE --> Renovate[renovate.json<br/>osvVulnerabilityAlerts]
+      Renovate -->|raises targeted bump PR| PR[Fix PR waiting<br/>for review]
+    end
+    Freshness[deno-outdated.yml<br/>weekly freshness bump] -.routine, not advisory.-> PR
+```
+
+Before: detection only (red CI), remediation manual. After: a dedicated
+remediation PR is raised automatically for any dependency carrying a known OSV
+advisory.
+
+Test run:
+
+```text
+running 5 tests from ./test/ci/RenovateConfig.ts
+renovate.json exists and parses as JSON (Issue #3007) ... ok
+renovate.json references the Renovate schema (Issue #3007) ... ok
+renovate.json extends a recommended preset (Issue #3007) ... ok
+renovate.json enables the vulnerability-alert channel (Issue #3007) ... ok
+renovate.json enables OSV-backed vulnerability alerts (Issue #3007) ... ok
+ok | 5 passed | 0 failed
+```
+
+## Test Plan
+
+- Added `test/ci/RenovateConfig.ts` — five "what" tests parsing the committed
+  `renovate.json`:
+  - exists and parses as JSON
+  - references the Renovate schema (`$schema`)
+  - extends `config:recommended`
+  - `vulnerabilityAlerts.enabled === true`
+  - `osvVulnerabilityAlerts === true`
+- Confirmed the tests fail against the unfixed tree (no `renovate.json`) and
+  pass after adding the file (TDD).
+- `./quality.sh --lint-only` passes (fmt, lint, bash syntax).
+- `markdownlint-cli2` clean on `SECURITY.md`.
+
+## Deno regression avoided
+
+- Chose Renovate's native Deno manager (config-only `renovate.json`) over GitHub
+  Dependabot, which does not parse `deno.json`/`deno.lock`. No Node tooling,
+  `package.json`, or lockfile was introduced.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "vulnerabilityAlerts": { "enabled": true },
+  "osvVulnerabilityAlerts": true
+}

--- a/test/ci/RenovateConfig.ts
+++ b/test/ci/RenovateConfig.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #3007 — SCR-AUTO-UPDATE: the repository had freshness-driven dependency
+ * automation (`.github/workflows/deno-outdated.yml` weekly bump,
+ * `bump-deps.sh` quarantine refresh) and advisory *detection*
+ * (`.github/workflows/osv-scan.yml`), but no advisory-*driven* update channel.
+ * When a CVE is disclosed against a pinned dependency nothing raised a targeted
+ * remediation PR — the team waited for the next weekly freshness run or
+ * responded manually to the OSV scan failure.
+ *
+ * `renovate.json` closes that remediation-automation gap: Renovate supports the
+ * Deno manager (`jsr:`, `npm:`, `https://deno.land/*`) and, with
+ * `osvVulnerabilityAlerts`/`vulnerabilityAlerts`, raises a dedicated PR for any
+ * dependency carrying a known OSV advisory — the channel that was missing.
+ *
+ * These are "what" tests: they parse the committed Renovate config and assert
+ * on the resulting configuration, not on how each value happens to be written.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const RENOVATE_CONFIG = join(REPO_ROOT, "renovate.json");
+
+interface VulnerabilityAlerts {
+  enabled?: boolean;
+}
+
+interface RenovateConfig {
+  $schema?: string;
+  extends?: string[];
+  vulnerabilityAlerts?: VulnerabilityAlerts;
+  osvVulnerabilityAlerts?: boolean;
+}
+
+async function readConfig(): Promise<RenovateConfig> {
+  const text = await Deno.readTextFile(RENOVATE_CONFIG);
+  return JSON.parse(text) as RenovateConfig;
+}
+
+Deno.test("renovate.json exists and parses as JSON (Issue #3007)", async () => {
+  const config = await readConfig();
+  assert(
+    typeof config === "object" && config !== null,
+    "renovate.json did not parse to an object",
+  );
+});
+
+Deno.test("renovate.json references the Renovate schema (Issue #3007)", async () => {
+  const config = await readConfig();
+  assert(
+    typeof config.$schema === "string" &&
+      /renovate-schema\.json$/.test(config.$schema),
+    "renovate.json should set $schema to the Renovate schema so editors and " +
+      "Renovate validate the config",
+  );
+});
+
+Deno.test("renovate.json extends a recommended preset (Issue #3007)", async () => {
+  const config = await readConfig();
+  assert(
+    Array.isArray(config.extends) && config.extends.length > 0,
+    "renovate.json must extend at least one shared preset so it inherits " +
+      "sensible defaults",
+  );
+  assert(
+    config.extends!.some((preset) => /config:recommended/.test(preset)),
+    'renovate.json should extend "config:recommended" for the baseline ' +
+      "Renovate behaviour",
+  );
+});
+
+Deno.test("renovate.json enables the vulnerability-alert channel (Issue #3007)", async () => {
+  const config = await readConfig();
+  assert(
+    config.vulnerabilityAlerts !== undefined &&
+      typeof config.vulnerabilityAlerts === "object",
+    "renovate.json must declare a vulnerabilityAlerts block to turn on the " +
+      "advisory-driven update channel",
+  );
+  assertEquals(
+    config.vulnerabilityAlerts!.enabled,
+    true,
+    "vulnerabilityAlerts.enabled must be true so Renovate raises remediation " +
+      "PRs for dependencies with security advisories",
+  );
+});
+
+Deno.test("renovate.json enables OSV-backed vulnerability alerts (Issue #3007)", async () => {
+  const config = await readConfig();
+  assertEquals(
+    config.osvVulnerabilityAlerts,
+    true,
+    "osvVulnerabilityAlerts must be true so OSV advisories (the same database " +
+      "osv-scan.yml detects against) raise dedicated remediation PRs — closing " +
+      "the remediation-automation half of the detection loop",
+  );
+});


### PR DESCRIPTION
# SCR-AUTO-UPDATE: enable the advisory-driven security-update channel

## Summary

The repository already had _freshness-driven_ dependency automation
(`.github/workflows/deno-outdated.yml` weekly bump, `bump-deps.sh` quarantine
refresh) and advisory _detection_ (`.github/workflows/osv-scan.yml`), but no
advisory-_driven_ update channel. When a CVE was disclosed against a pinned
`jsr:`/`npm:` dependency, nothing raised a targeted remediation PR — the team
waited for the next weekly freshness run (plus the 24h quarantine) or responded
manually to the OSV scan failure.

This change adds a minimal `renovate.json` that enables Renovate's OSV-backed
vulnerability-alert channel. Renovate supports the Deno manager (`jsr:`, `npm:`,
`https://deno.land/*`), so the control is genuinely available here (unlike
Dependabot, which does not parse `deno.json`/`deno.lock`). The existing
freshness job is left untouched — this closes the _remediation-automation_ half
of the same loop that `osv-scan.yml` _detects_.

`SECURITY.md` is updated to document the new channel alongside the existing
automation.

Closes #3007.

## Evidence

This is a config/CI change with no web interface to screenshot. Verification is
via the new "what" tests that parse the committed `renovate.json` and assert on
the resulting configuration (schema reference, `config:recommended` preset,
`vulnerabilityAlerts.enabled`, `osvVulnerabilityAlerts`).

```mermaid
flowchart LR
    CVE[CVE disclosed against<br/>pinned dependency] --> Detect
    subgraph Detection
      Detect[osv-scan.yml<br/>weekly OSV scan] -->|fails CI| Signal[Actionable signal]
    end
    subgraph Remediation
      CVE --> Renovate[renovate.json<br/>osvVulnerabilityAlerts]
      Renovate -->|raises targeted bump PR| PR[Fix PR waiting<br/>for review]
    end
    Freshness[deno-outdated.yml<br/>weekly freshness bump] -.routine, not advisory.-> PR
```

Before: detection only (red CI), remediation manual. After: a dedicated
remediation PR is raised automatically for any dependency carrying a known OSV
advisory.

Test run:

```text
running 5 tests from ./test/ci/RenovateConfig.ts
renovate.json exists and parses as JSON (Issue #3007) ... ok
renovate.json references the Renovate schema (Issue #3007) ... ok
renovate.json extends a recommended preset (Issue #3007) ... ok
renovate.json enables the vulnerability-alert channel (Issue #3007) ... ok
renovate.json enables OSV-backed vulnerability alerts (Issue #3007) ... ok
ok | 5 passed | 0 failed
```

## Test Plan

- Added `test/ci/RenovateConfig.ts` — five "what" tests parsing the committed
  `renovate.json`:
  - exists and parses as JSON
  - references the Renovate schema (`$schema`)
  - extends `config:recommended`
  - `vulnerabilityAlerts.enabled === true`
  - `osvVulnerabilityAlerts === true`
- Confirmed the tests fail against the unfixed tree (no `renovate.json`) and
  pass after adding the file (TDD).
- `./quality.sh --lint-only` passes (fmt, lint, bash syntax).
- `markdownlint-cli2` clean on `SECURITY.md`.

## Deno regression avoided

- Chose Renovate's native Deno manager (config-only `renovate.json`) over GitHub
  Dependabot, which does not parse `deno.json`/`deno.lock`. No Node tooling,
  `package.json`, or lockfile was introduced.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqgrv4gu-2d5e63`<!-- vibe-worker-issue-3007 -->