### PR TITLE
Security: enable advisory-driven security-update channel via renovate.json (#3007)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.11",
+  "version": "5.5.12",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3007.md
+++ b/docs/archive/pr-summaries/pr-summary-3007.md
@@ -1,79 +1,78 @@
-# SCR-AUTO-UPDATE: enable the advisory-driven security-update channel
+# SCR-AUTO-UPDATE — enable advisory-driven security-update channel
 
 ## Summary
 
-The repository already had _freshness-driven_ dependency automation
-(`.github/workflows/deno-outdated.yml` weekly bump, `bump-deps.sh` quarantine
-refresh) and advisory _detection_ (`.github/workflows/osv-scan.yml`), but no
-advisory-_driven_ update channel. When a CVE was disclosed against a pinned
-`jsr:`/`npm:` dependency, nothing raised a targeted remediation PR — the team
-waited for the next weekly freshness run (plus the 24h quarantine) or responded
-manually to the OSV scan failure.
+The repository had dependency-update automation, but only the _freshness-driven_
+half: `.github/workflows/deno-outdated.yml` raises a weekly PR for whatever is
+newest, and `.github/workflows/osv-scan.yml` _detects_ advisories (failing CI)
+but raises no remediation PR. When a CVE is disclosed against a pinned
+dependency, nothing automatically opened a targeted bump — the team waited for
+the next weekly freshness run or responded manually to the OSV scan failure.
 
-This change adds a minimal `renovate.json` that enables Renovate's OSV-backed
-vulnerability-alert channel. Renovate supports the Deno manager (`jsr:`, `npm:`,
-`https://deno.land/*`), so the control is genuinely available here (unlike
-Dependabot, which does not parse `deno.json`/`deno.lock`). The existing
-freshness job is left untouched — this closes the _remediation-automation_ half
-of the same loop that `osv-scan.yml` _detects_.
+This change adds a minimal `renovate.json` that enables Renovate's
+_advisory-driven_ security-update channel alongside the existing freshness job.
+Renovate supports the Deno manager (`jsr:`, `npm:`, `https://deno.land/*`), and
+with `osvVulnerabilityAlerts` enabled it raises a dedicated PR for any
+dependency carrying a known OSV advisory — turning "an advisory exists" into "a
+fix PR is waiting for review" and shrinking the exposure window between
+disclosure and remediation. `deno-outdated.yml` is left intact for routine
+freshness bumps.
 
-`SECURITY.md` is updated to document the new channel alongside the existing
-automation.
+`renovate.json`:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "vulnerabilityAlerts": { "enabled": true },
+  "osvVulnerabilityAlerts": true
+}
+```
+
+`SECURITY.md` is updated to document the new channel under the in-repo
+automation list.
 
 Closes #3007.
 
 ## Evidence
 
-This is a config/CI change with no web interface to screenshot. Verification is
-via the new "what" tests that parse the committed `renovate.json` and assert on
-the resulting configuration (schema reference, `config:recommended` preset,
-`vulnerabilityAlerts.enabled`, `osvVulnerabilityAlerts`).
+This is a CI/config change with no web interface to screenshot. Verification is
+via the new behavioural tests, which parse the committed `renovate.json` and
+assert on the resolved configuration.
+
+```
+deno test test/ci/RenovateSecurityUpdates.ts --allow-read
+ok | 5 passed | 0 failed
+```
+
+Full quality gate: `./quality.sh` → `7265 passed | 0 failed | 4 ignored`.
+
+The two complementary automation channels after this change:
 
 ```mermaid
 flowchart LR
-    CVE[CVE disclosed against<br/>pinned dependency] --> Detect
-    subgraph Detection
-      Detect[osv-scan.yml<br/>weekly OSV scan] -->|fails CI| Signal[Actionable signal]
+    subgraph Freshness
+        A[deno-outdated.yml<br/>weekly] --> B[bump PR for newest version]
     end
-    subgraph Remediation
-      CVE --> Renovate[renovate.json<br/>osvVulnerabilityAlerts]
-      Renovate -->|raises targeted bump PR| PR[Fix PR waiting<br/>for review]
+    subgraph Advisory
+        C[OSV advisory disclosed] --> D[osv-scan.yml<br/>detects, fails CI]
+        C --> E[renovate.json<br/>osvVulnerabilityAlerts]
+        E --> F[targeted remediation PR]
     end
-    Freshness[deno-outdated.yml<br/>weekly freshness bump] -.routine, not advisory.-> PR
-```
-
-Before: detection only (red CI), remediation manual. After: a dedicated
-remediation PR is raised automatically for any dependency carrying a known OSV
-advisory.
-
-Test run:
-
-```text
-running 5 tests from ./test/ci/RenovateConfig.ts
-renovate.json exists and parses as JSON (Issue #3007) ... ok
-renovate.json references the Renovate schema (Issue #3007) ... ok
-renovate.json extends a recommended preset (Issue #3007) ... ok
-renovate.json enables the vulnerability-alert channel (Issue #3007) ... ok
-renovate.json enables OSV-backed vulnerability alerts (Issue #3007) ... ok
-ok | 5 passed | 0 failed
 ```
 
 ## Test Plan
 
-- Added `test/ci/RenovateConfig.ts` — five "what" tests parsing the committed
-  `renovate.json`:
-  - exists and parses as JSON
-  - references the Renovate schema (`$schema`)
-  - extends `config:recommended`
-  - `vulnerabilityAlerts.enabled === true`
-  - `osvVulnerabilityAlerts === true`
-- Confirmed the tests fail against the unfixed tree (no `renovate.json`) and
-  pass after adding the file (TDD).
-- `./quality.sh --lint-only` passes (fmt, lint, bash syntax).
-- `markdownlint-cli2` clean on `SECURITY.md`.
+Added `test/ci/RenovateSecurityUpdates.ts` (5 tests), mirroring the existing
+`test/ci/OsvScanWorkflow.ts` "what" style:
 
-## Deno regression avoided
+- `renovate.json exists and parses as JSON`
+- `renovate.json references the Renovate schema`
+- `renovate.json extends a base preset`
+- `renovate.json enables vulnerability alerts`
+  (`vulnerabilityAlerts.enabled === true`)
+- `renovate.json enables OSV-backed vulnerability alerts`
+  (`osvVulnerabilityAlerts === true`)
 
-- Chose Renovate's native Deno manager (config-only `renovate.json`) over GitHub
-  Dependabot, which does not parse `deno.json`/`deno.lock`. No Node tooling,
-  `package.json`, or lockfile was introduced.
+Each test failed before `renovate.json` was added (TDD red) and passes after
+(green).

--- a/test/ci/RenovateSecurityUpdates.ts
+++ b/test/ci/RenovateSecurityUpdates.ts
@@ -1,0 +1,91 @@
+/**
+ * Issue #3007 — SCR-AUTO-UPDATE: the security-update channel was off. The repo
+ * had *freshness-driven* dependency automation (`deno-outdated.yml` raises a
+ * weekly PR for whatever is newest) and *advisory detection*
+ * (`osv-scan.yml` fails CI when a CVE is disclosed against the resolved tree),
+ * but nothing turned "an advisory exists" into "a fix PR is waiting for
+ * review". The mean-time-to-patch was therefore bounded by the weekly
+ * freshness cadence rather than by how fast a maintainer can review a focused
+ * security bump.
+ *
+ * `renovate.json` closes that remediation-automation gap. Renovate supports
+ * the Deno manager (jsr:, npm:, https://deno.land/*) and, with
+ * `osvVulnerabilityAlerts` enabled, raises a dedicated PR for any dependency
+ * carrying a known OSV advisory — the advisory-driven channel that was
+ * missing. The freshness job (`deno-outdated.yml`) is left intact for routine
+ * bumps.
+ *
+ * These are "what" tests: they parse the committed renovate.json and assert on
+ * the resulting configuration, not on how each value happens to be written.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const RENOVATE_JSON = join(REPO_ROOT, "renovate.json");
+
+interface RenovateConfig {
+  $schema?: string;
+  extends?: string[];
+  vulnerabilityAlerts?: { enabled?: boolean };
+  osvVulnerabilityAlerts?: boolean;
+}
+
+async function readRenovate(): Promise<RenovateConfig> {
+  const text = await Deno.readTextFile(RENOVATE_JSON);
+  return JSON.parse(text) as RenovateConfig;
+}
+
+Deno.test("renovate.json exists and parses as JSON (Issue #3007)", async () => {
+  const config = await readRenovate();
+  assert(
+    typeof config === "object" && config !== null,
+    "renovate.json did not parse as a JSON object",
+  );
+});
+
+Deno.test("renovate.json references the Renovate schema (Issue #3007)", async () => {
+  const config = await readRenovate();
+  assert(
+    typeof config.$schema === "string" &&
+      /renovate-schema\.json/.test(config.$schema),
+    "renovate.json should set $schema to the Renovate schema so editors " +
+      "validate the config",
+  );
+});
+
+Deno.test("renovate.json extends a base preset (Issue #3007)", async () => {
+  const config = await readRenovate();
+  assert(
+    Array.isArray(config.extends) && config.extends.length > 0,
+    "renovate.json should extend a base preset (e.g. config:recommended) so " +
+      "it inherits sensible defaults rather than re-deriving them",
+  );
+});
+
+Deno.test("renovate.json enables vulnerability alerts (Issue #3007)", async () => {
+  const config = await readRenovate();
+  assert(
+    config.vulnerabilityAlerts !== undefined &&
+      typeof config.vulnerabilityAlerts === "object",
+    "renovate.json must declare a vulnerabilityAlerts block",
+  );
+  assertEquals(
+    config.vulnerabilityAlerts!.enabled,
+    true,
+    "renovate.json must enable vulnerabilityAlerts so security updates are " +
+      "raised as PRs — this is the advisory-driven channel that was missing",
+  );
+});
+
+Deno.test("renovate.json enables OSV-backed vulnerability alerts (Issue #3007)", async () => {
+  const config = await readRenovate();
+  assertEquals(
+    config.osvVulnerabilityAlerts,
+    true,
+    "renovate.json must set osvVulnerabilityAlerts: true so any dependency " +
+      "with a known OSV advisory gets a dedicated remediation PR, closing the " +
+      "gap left by the detection-only osv-scan.yml",
+  );
+});


### PR DESCRIPTION
# SCR-AUTO-UPDATE — enable advisory-driven security-update channel

## Summary

The repository had dependency-update automation, but only the
*freshness-driven* half: `.github/workflows/deno-outdated.yml` raises a weekly
PR for whatever is newest, and `.github/workflows/osv-scan.yml` *detects*
advisories (failing CI) but raises no remediation PR. When a CVE is disclosed
against a pinned dependency, nothing automatically opened a targeted bump — the
team waited for the next weekly freshness run or responded manually to the OSV
scan failure.

This change adds a minimal `renovate.json` that enables Renovate's
*advisory-driven* security-update channel alongside the existing freshness job.
Renovate supports the Deno manager (`jsr:`, `npm:`, `https://deno.land/*`), and
with `osvVulnerabilityAlerts` enabled it raises a dedicated PR for any
dependency carrying a known OSV advisory — turning "an advisory exists" into "a
fix PR is waiting for review" and shrinking the exposure window between
disclosure and remediation. `deno-outdated.yml` is left intact for routine
freshness bumps.

`renovate.json`:

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["config:recommended"],
  "vulnerabilityAlerts": { "enabled": true },
  "osvVulnerabilityAlerts": true
}
```

`SECURITY.md` is updated to document the new channel under the in-repo
automation list.

Closes #3007.

## Evidence

This is a CI/config change with no web interface to screenshot. Verification is
via the new behavioural tests, which parse the committed `renovate.json` and
assert on the resolved configuration.

```
deno test test/ci/RenovateSecurityUpdates.ts --allow-read
ok | 5 passed | 0 failed
```

Full quality gate: `./quality.sh` → `7265 passed | 0 failed | 4 ignored`.

The two complementary automation channels after this change:

```mermaid
flowchart LR
    subgraph Freshness
        A[deno-outdated.yml<br/>weekly] --> B[bump PR for newest version]
    end
    subgraph Advisory
        C[OSV advisory disclosed] --> D[osv-scan.yml<br/>detects, fails CI]
        C --> E[renovate.json<br/>osvVulnerabilityAlerts]
        E --> F[targeted remediation PR]
    end
```

## Test Plan

Added `test/ci/RenovateSecurityUpdates.ts` (5 tests), mirroring the existing
`test/ci/OsvScanWorkflow.ts` "what" style:

- `renovate.json exists and parses as JSON`
- `renovate.json references the Renovate schema`
- `renovate.json extends a base preset`
- `renovate.json enables vulnerability alerts` (`vulnerabilityAlerts.enabled === true`)
- `renovate.json enables OSV-backed vulnerability alerts` (`osvVulnerabilityAlerts === true`)

Each test failed before `renovate.json` was added (TDD red) and passes after
(green).
