### PR TITLE
Update production creature size/shape statistics (Issue #3018)

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -84,7 +84,7 @@ and cited in the linked sub-documents.**
 | Cross-incompatible-parent breeding | ❌ Refuses             | ✅ Extension (grafting, subgraph) | n/a                     |
 | Transfer learning                  | ❌                     | ✅ Checkpoints + ONNX             | ✅ Pre-trained models   |
 | Non-differentiable objectives      | ✅                     | ✅                                | ❌ Needs gradients      |
-| Scales to billions of parameters   | ❌                     | 🟡 ~500 hidden neurons in prod    | ✅                      |
+| Scales to billions of parameters   | ❌                     | 🟡 ~1,700 hidden neurons in prod  | ✅                      |
 
 Legend: ✅ supported · 🟡 partial · ❌ not supported. See
 [Pros and cons](./docs/comparison/PROS_AND_CONS.md) and

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.5.12",
+  "version": "5.5.13",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/PERFORMANCE_TUNING.md
+++ b/docs/PERFORMANCE_TUNING.md
@@ -698,7 +698,7 @@ training, near-zero connections are pruned and only useful ones are retained.
 - **Very small networks**: Networks with fewer than 10 neurons have limited
   layer structure; synthetic synapses add little value.
 - **Memory-constrained environments**: Synthetic synapses temporarily increase
-  the network size. At production scale (~1,000 neurons), expect a ~3.3x
+  the network size. At production scale (~1,700 neurons), expect a ~3.3x
   expansion in synapse count during training.
 
 ### Performance Implications

--- a/docs/archive/pr-summaries/pr-summary-3018.md
+++ b/docs/archive/pr-summaries/pr-summary-3018.md
@@ -1,0 +1,71 @@
+## Summary
+
+Updated the documented size/shape statistics of the production creature, which
+were badly understated. Two docs claimed production "maxes out" at **~500 hidden
+neurons** (and ~16,000 synapses), but the live creature is far larger. Closes
+#3018.
+
+The numbers come from the live production genome
+[`stSoftwareAU/GRQ-cluster/network.json`](https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json)
+(creature "Bob Bailey", version 115, snapshot **2026-06-16**):
+
+| Metric                  | Old docs claim | Actual (live genome) |
+| ----------------------- | -------------: | -------------------: |
+| Hidden neurons          |           ~500 |       1,669 (~1,700) |
+| Synapses                |         16,000 |     21,689 (~22,000) |
+| Inputs                  |     (unstated) |                2,461 |
+| Listed neurons (total)¹ |              — |                1,673 |
+
+¹ 1,669 hidden + 3 constant + 1 output. Genome is forward-only, semantic
+version 4.0.0.
+
+### Files changed
+
+- **`COMPARISON.md`** — "Scales to billions of parameters" row updated from
+  `~500 hidden neurons in prod` to `~1,700 hidden neurons in prod`.
+- **`docs/comparison/PROS_AND_CONS.md`** — the "Limited scalability" con updated
+  from "max out around 500 hidden neurons and 16,000 synapses" to "~1,700 hidden
+  neurons and ~22,000 synapses across 2,461 inputs, and keeps growing", with a
+  link to the source genome and the snapshot date so the figure is traceable.
+
+The figures are kept as `~` approximations (the creature grows over time) and
+carry a dated snapshot reference so future drift is obvious.
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot. The statistics were
+verified against the live production genome:
+
+```text
+$ gh api repos/stSoftwareAU/GRQ-cluster/contents/network.json \
+    -H "Accept: application/vnd.github.raw" > grq-network.json
+# parsed:
+input:    2461
+output:   1
+neurons:  1673  (constant 3, hidden 1669, output 1)
+synapses: 21689
+forwardOnly: true   semanticVersion: 4.0.0
+# snapshot commit date: 2026-06-16T10:23:26Z
+```
+
+```mermaid
+flowchart LR
+    A["Live genome<br/>GRQ-cluster/network.json"] -->|parse| B["2,461 inputs<br/>1,669 hidden neurons<br/>21,689 synapses"]
+    B --> C["COMPARISON.md<br/>~1,700 hidden neurons"]
+    B --> D["PROS_AND_CONS.md<br/>~1,700 neurons / ~22,000 synapses"]
+```
+
+`./quality.sh --lint-only` passes cleanly (formatting, lint, bash check). The
+relevant remaining gates (type-check, tests) are unaffected — no source code was
+touched.
+
+## Test Plan
+
+No unit tests were added. This is a pure documentation correction with no code
+change, and per `AGENTS.md` tests that grep documentation for literal strings
+are "how" tests and are explicitly discouraged. Validation performed:
+
+- `deno fmt` on both changed Markdown files — clean.
+- `./quality.sh --lint-only < /dev/null` — passes (formatting, lint, bash
+  syntax).
+- Figures cross-checked against the live `GRQ-cluster/network.json` genome.

--- a/docs/archive/pr-summaries/pr-summary-3018.md
+++ b/docs/archive/pr-summaries/pr-summary-3018.md
@@ -16,8 +16,8 @@ The numbers come from the live production genome
 | Inputs                  |     (unstated) |                2,461 |
 | Listed neurons (total)¹ |              — |                1,673 |
 
-¹ 1,669 hidden + 3 constant + 1 output. Genome is forward-only, semantic
-version 4.0.0.
+¹ 1,669 hidden + 3 constant + 1 output. Genome is forward-only, semantic version
+4.0.0.
 
 ### Files changed
 

--- a/docs/archive/pr-summaries/pr-summary-3018.md
+++ b/docs/archive/pr-summaries/pr-summary-3018.md
@@ -1,71 +1,53 @@
 ## Summary
 
-Updated the documented size/shape statistics of the production creature, which
-were badly understated. Two docs claimed production "maxes out" at **~500 hidden
-neurons** (and ~16,000 synapses), but the live creature is far larger. Closes
-#3018.
+The docs understated the size of the live production creature. Several spots
+claimed "~500 hidden neurons", but the production genome
+([GRQ-cluster/network.json](https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json))
+is far larger. This PR refreshes those statistics to match the actual deployed
+creature. Closes #3018.
 
-The numbers come from the live production genome
-[`stSoftwareAU/GRQ-cluster/network.json`](https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json)
-(creature "Bob Bailey", version 115, snapshot **2026-06-16**):
+Measured directly from the production `network.json` (semantic version 4.0.0,
+forward-only):
 
-| Metric                  | Old docs claim | Actual (live genome) |
-| ----------------------- | -------------: | -------------------: |
-| Hidden neurons          |           ~500 |       1,669 (~1,700) |
-| Synapses                |         16,000 |     21,689 (~22,000) |
-| Inputs                  |     (unstated) |                2,461 |
-| Listed neurons (total)¹ |              — |                1,673 |
+| Metric         | Old docs claim | Actual production value |
+| -------------- | -------------- | ----------------------- |
+| Hidden neurons | ~500           | 1,669 (~1,700)          |
+| Synapses       | ~16,000        | 21,689 (~22,000)        |
+| Inputs         | not stated     | 2,461                   |
+| Outputs        | —              | 1                       |
+| Total neurons  | —              | 1,673                   |
 
-¹ 1,669 hidden + 3 constant + 1 output. Genome is forward-only, semantic version
-4.0.0.
+Files updated:
 
-### Files changed
+- `COMPARISON.md` — scalability row now reads "~1,700 hidden neurons in prod".
+- `docs/comparison/PROS_AND_CONS.md` — the "limited scalability" con now states
+  the real figures (~1,700 hidden neurons, 2,461 inputs, ~22,000 synapses) with
+  a link to the source genome, rather than "max out around 500 hidden neurons
+  and 16,000 synapses".
+- `docs/PERFORMANCE_TUNING.md` — production-scale synthetic-synapse note updated
+  from "~1,000 neurons" to "~1,700 neurons".
 
-- **`COMPARISON.md`** — "Scales to billions of parameters" row updated from
-  `~500 hidden neurons in prod` to `~1,700 hidden neurons in prod`.
-- **`docs/comparison/PROS_AND_CONS.md`** — the "Limited scalability" con updated
-  from "max out around 500 hidden neurons and 16,000 synapses" to "~1,700 hidden
-  neurons and ~22,000 synapses across 2,461 inputs, and keeps growing", with a
-  link to the source genome and the snapshot date so the figure is traceable.
-
-The figures are kept as `~` approximations (the creature grows over time) and
-carry a dated snapshot reference so future drift is obvious.
+Numbers are rounded for readability; historical benchmark/results snapshots
+under `bench/results/` and `docs/*-results.md` record specific past runs and
+were left unchanged.
 
 ## Evidence
 
-Documentation-only change — no web interface to screenshot. The statistics were
-verified against the live production genome:
+This is a documentation-only change (no TypeScript modified), so there is no UI
+to screenshot and no runtime behaviour to benchmark. Verification:
 
-```text
-$ gh api repos/stSoftwareAU/GRQ-cluster/contents/network.json \
-    -H "Accept: application/vnd.github.raw" > grq-network.json
-# parsed:
-input:    2461
-output:   1
-neurons:  1673  (constant 3, hidden 1669, output 1)
-synapses: 21689
-forwardOnly: true   semanticVersion: 4.0.0
-# snapshot commit date: 2026-06-16T10:23:26Z
-```
-
-```mermaid
-flowchart LR
-    A["Live genome<br/>GRQ-cluster/network.json"] -->|parse| B["2,461 inputs<br/>1,669 hidden neurons<br/>21,689 synapses"]
-    B --> C["COMPARISON.md<br/>~1,700 hidden neurons"]
-    B --> D["PROS_AND_CONS.md<br/>~1,700 neurons / ~22,000 synapses"]
-```
-
-`./quality.sh --lint-only` passes cleanly (formatting, lint, bash check). The
-relevant remaining gates (type-check, tests) are unaffected — no source code was
-touched.
+- Production statistics derived by parsing the live `network.json` fetched from
+  `stSoftwareAU/GRQ-cluster`:
+  `input: 2461, output: 1, neurons: 1673 (1669 hidden, 3 constant, 1 output), synapses: 21689`.
+- `./quality.sh --lint-only` passes cleanly (formatting, linting, bash check).
+- `markdownlint-cli2` reports 0 errors.
 
 ## Test Plan
 
-No unit tests were added. This is a pure documentation correction with no code
-change, and per `AGENTS.md` tests that grep documentation for literal strings
-are "how" tests and are explicitly discouraged. Validation performed:
+No unit tests apply — only prose statistics in Markdown changed, and the project
+guidelines forbid tests that grep source/doc text for patterns. Validation was
+done via the documentation quality gate:
 
-- `deno fmt` on both changed Markdown files — clean.
-- `./quality.sh --lint-only < /dev/null` — passes (formatting, lint, bash
-  syntax).
-- Figures cross-checked against the live `GRQ-cluster/network.json` genome.
+- `./quality.sh --lint-only` — passed.
+- `deno fmt` on the changed files — no formatting changes needed after edit.
+- `markdownlint-cli2` — 0 errors.

--- a/docs/comparison/PROS_AND_CONS.md
+++ b/docs/comparison/PROS_AND_CONS.md
@@ -59,10 +59,12 @@ networks.
 1. **Computational cost**: population-based training requires more resources.
 2. **Slower convergence**: evolutionary search is slower than pure gradient
    descent.
-3. **Limited scalability**: struggles with very large networks. In production we
-   max out around 500 hidden neurons and 16,000 synapses; the `discoveryDir`
-   feature helps push past this by finding structural improvements
-   incrementally.
+3. **Limited scalability**: struggles with very large networks, though "limited"
+   is relative — the live production creature
+   ([`GRQ-cluster/network.json`](https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json),
+   snapshot 2026-06-16) carries ~1,700 hidden neurons and ~22,000 synapses
+   across 2,461 inputs, and keeps growing. The `discoveryDir` feature helps push
+   past this by finding structural improvements incrementally.
 4. **Sequential processing**: less efficient for pure parallel computation than
    fixed architectures, though topology-aware parallel batch evaluation helps.
 5. **Limited unsupervised learning**: NEAT-AI (like standard NEAT) is typically


### PR DESCRIPTION
## Summary

The docs understated the size of the live production creature. Several spots
claimed "~500 hidden neurons", but the production genome
([GRQ-cluster/network.json](https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json))
is far larger. This PR refreshes those statistics to match the actual deployed
creature. Closes #3018.

Measured directly from the production `network.json` (semantic version 4.0.0,
forward-only):

| Metric         | Old docs claim | Actual production value |
| -------------- | -------------- | ----------------------- |
| Hidden neurons | ~500           | 1,669 (~1,700)          |
| Synapses       | ~16,000        | 21,689 (~22,000)        |
| Inputs         | not stated     | 2,461                   |
| Outputs        | —              | 1                       |
| Total neurons  | —              | 1,673                   |

Files updated:

- `COMPARISON.md` — scalability row now reads "~1,700 hidden neurons in prod".
- `docs/comparison/PROS_AND_CONS.md` — the "limited scalability" con now states
  the real figures (~1,700 hidden neurons, 2,461 inputs, ~22,000 synapses) with
  a link to the source genome, rather than "max out around 500 hidden neurons
  and 16,000 synapses".
- `docs/PERFORMANCE_TUNING.md` — production-scale synthetic-synapse note updated
  from "~1,000 neurons" to "~1,700 neurons".

Numbers are rounded for readability; historical benchmark/results snapshots
under `bench/results/` and `docs/*-results.md` record specific past runs and
were left unchanged.

## Evidence

This is a documentation-only change (no TypeScript modified), so there is no UI
to screenshot and no runtime behaviour to benchmark. Verification:

- Production statistics derived by parsing the live `network.json` fetched from
  `stSoftwareAU/GRQ-cluster`:
  `input: 2461, output: 1, neurons: 1673 (1669 hidden, 3 constant, 1 output), synapses: 21689`.
- `./quality.sh --lint-only` passes cleanly (formatting, linting, bash check).
- `markdownlint-cli2` reports 0 errors.

## Test Plan

No unit tests apply — only prose statistics in Markdown changed, and the project
guidelines forbid tests that grep source/doc text for patterns. Validation was
done via the documentation quality gate:

- `./quality.sh --lint-only` — passed.
- `deno fmt` on the changed files — no formatting changes needed after edit.
- `markdownlint-cli2` — 0 errors.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqgytveo-17e14a`<!-- vibe-worker-issue-3018 -->