### PR TITLE
Discovery #3025: AnalysisHeapGuard off-heap (RSS) awareness

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3025.md
+++ b/docs/archive/pr-summaries/pr-summary-3025.md
@@ -1,0 +1,104 @@
+# Discovery #3022: AnalysisHeapGuard off-heap (RSS) awareness
+
+## Summary
+
+The discovery worker runs on a small default V8 heap (~269 MB). After the
+recording phase the V8 heap fraction sits near the 85% critical threshold even
+though the bulk of memory is native/Rust **RSS** with plenty of headroom (GRQ-23
+observed `heap=231MB/269MB rss=13289MB`). `AnalysisHeapGuard` decided **solely**
+on the V8 heap fraction, so a healthy run was mis-classified as CRITICAL and
+analysis was aborted.
+
+This change makes the guard off-heap aware while preserving genuine-OOM aborts:
+
+- New `memory.nativeBudgetBytes` config (RSS budget in bytes). Default `0`
+  disables off-heap awareness and preserves the legacy V8-only behaviour.
+- `HeapGuardSample` widened with `rss` / `external`; `sampleHeapPressure`
+  captures both (the default provider already exposes them via
+  `Deno.memoryUsage()`).
+- New pure, unit-testable `shouldAbortOnHeapPressure(sample, memoryConfig)`
+  encodes the rule: a worker-V8-only CRITICAL does **not** abort while RSS is
+  within `nativeBudgetBytes`; RSS over budget (or unreported) still aborts so a
+  real OOM is never masked.
+- Both discovery call sites now flow through it: `checkAnalysisHeapAbort`
+  (`DataRecorder.ts` extension boundary) and `isHeapCritical`
+  (`DataRecorderAnalysis.ts` in-loop guard). No V8-only abort decision remains
+  on the discovery path.
+
+Closes #3025.
+
+## Acceptance criteria
+
+- [x] Guard no longer aborts on worker-V8-only CRITICAL when configured native
+      budget has headroom (covered by tests).
+- [x] RSS-over-budget still aborts (no masking of real OOM).
+- [x] Default/legacy behaviour preserved when no native budget is configured
+      (`nativeBudgetBytes === 0`); `memory.enabled === false` still never trips.
+- [x] Both call sites updated; no remaining V8-only abort decision on the
+      discovery path.
+
+## Decision flow
+
+```mermaid
+flowchart TD
+    classDef ok fill:#1e8449,stroke:#196f3d,color:#fff
+    classDef warn fill:#d68910,stroke:#b7770d,color:#fff
+    S[CRITICAL heap sample] --> E{monitoring enabled?}
+    E -- no --> K[continue]:::ok
+    E -- yes --> B{nativeBudgetBytes &gt; 0?}
+    B -- no --> A[abort - legacy V8-only]:::warn
+    B -- yes --> R{RSS reported and within budget?}
+    R -- yes --> K
+    R -- no --> A
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified by unit tests
+calling the real guard and config functions.
+
+- `test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts`
+  - `shouldAbortOnHeapPressure: V8-only CRITICAL within native budget does NOT abort`
+  - `shouldAbortOnHeapPressure: RSS over native budget still aborts (genuine OOM)`
+  - `shouldAbortOnHeapPressure: no native budget configured keeps legacy V8-only abort`
+  - `shouldAbortOnHeapPressure: budget configured but RSS unreported falls back to abort`
+  - `checkAnalysisHeapAbort: GRQ-23 V8-only CRITICAL within budget returns abort:false`
+  - `checkAnalysisHeapAbort: RSS over budget still aborts and logs`
+  - `isHeapCritical: V8-only CRITICAL within budget returns false`
+  - `sampleHeapPressure: captures rss and external from the provider`
+- `test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts`
+  - `in-loop heap guard: V8-only CRITICAL within native budget keeps the loop running`
+  - `in-loop heap guard: RSS over native budget still aborts`
+- `test/config/parsers/RuntimeParsers.ts`
+  - `parseMemoryConfig - nativeBudgetBytes defaults to 0`
+  - `parseMemoryConfig - applies nativeBudgetBytes override`
+  - `parseMemoryConfig - rejects negative nativeBudgetBytes`
+
+Command output (affected suites):
+
+```
+test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts        ok | 22 passed
+test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts    ok |  5 passed
+test/ErrorGuidedStructuralEvolution/DiscoveryWorkerHeapLimit.ts ok |  3 passed (1 ignored)
+test/config/parsers/RuntimeParsers.ts                           ok | 14 passed
+```
+
+`deno lint` (1727 files) and `./quality.sh --check-only` (type-check) both pass.
+
+## Test Plan
+
+- Added off-heap-awareness unit cases to `AnalysisHeapGuard.ts` (pure function,
+  `checkAnalysisHeapAbort`, `isHeapCritical`, `sampleHeapPressure`).
+- Extended the in-loop guard test `AnalysisLoopHeapGuard.ts` with the
+  within-budget (no abort) and over-budget (abort) paths.
+- Added config parser cases for `nativeBudgetBytes` default, override, and
+  negative rejection.
+- Existing guard tests (legacy V8-only behaviour, `memory.enabled === false`)
+  and the `DiscoveryWorkerHeapLimit` regression cases remain green unchanged.
+
+## Notes
+
+- The complementary worker heap-limit propagation (the
+  `DiscoveryWorkerHeapLimit` red→green switch) is a separate #3022 sub-issue;
+  either approach alone stops the false abort. This PR takes the off-heap route
+  and leaves that switch for its sibling PR.

--- a/docs/troubleshooting/MEMORY.md
+++ b/docs/troubleshooting/MEMORY.md
@@ -221,16 +221,42 @@ raising the V8 heap (Step 5) or lowering `criticalThreshold` (Step 2) changes
 when they fire. A graceful abort means analysis produced no (or partial)
 structural candidates for that cycle — evolution continues; it does not crash.
 
+#### Off-heap (RSS / native budget) awareness (Issue #3025)
+
+The discovery worker runs on a small default V8 heap (~269 MB), so after a
+recording phase the V8 heap fraction sits near the critical threshold even
+though the bulk of memory is native/Rust RSS with plenty of headroom (GRQ-23
+observed `heap=231MB/269MB rss=13289MB`). Deciding solely on the V8 fraction
+mis-classified that healthy run as fatal.
+
+Set `memory.nativeBudgetBytes` to the worker's total resident-set (RSS) budget
+to make the guards off-heap aware:
+
+| `nativeBudgetBytes` | Worker-V8-only CRITICAL  | RSS over budget |
+| ------------------- | ------------------------ | --------------- |
+| `0` (default)       | aborts (legacy)          | aborts          |
+| `> 0`               | continues (RSS headroom) | aborts (OOM)    |
+
+The decision lives in the pure, unit-tested `shouldAbortOnHeapPressure`: a
+CRITICAL sample driven only by the V8 fraction no longer aborts while RSS stays
+within `nativeBudgetBytes`, but RSS exceeding the budget — or RSS being
+unreported — still aborts, so a genuine OOM is never masked. The default of `0`
+preserves the legacy V8-only behaviour.
+
 ```mermaid
 flowchart TD
     classDef ok fill:#1e8449,stroke:#196f3d,color:#fff
     classDef warn fill:#d68910,stroke:#b7770d,color:#fff
     R[Recording phase done] --> B{Heap CRITICAL at\nextension boundary?}
-    B -- yes --> S1[Skip analysis,\nreturn partial]:::warn
     B -- no --> L[Analysis loop]:::ok
+    B -- yes --> N{nativeBudgetBytes &gt; 0\nand RSS within budget?}
+    N -- yes --> L
+    N -- no --> S1[Skip analysis,\nreturn partial]:::warn
     L --> C{Heap CRITICAL before\niteration / chunk?}
-    C -- yes --> S2[Stop, return\naccumulated candidates]:::warn
     C -- no --> P[Process chunk]:::ok
+    C -- yes --> M{RSS within budget?}
+    M -- yes --> P
+    M -- no --> S2[Stop, return\naccumulated candidates]:::warn
     P --> C
 ```
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts
@@ -32,6 +32,13 @@ export interface HeapGuardSample {
   pressureLevel: PressureLevel;
   heapUsed: number;
   heapTotal: number;
+  /**
+   * Resident-set size in bytes (off-heap / native / Rust + V8). Issue #3025.
+   * `0` when the provider does not report RSS.
+   */
+  rss: number;
+  /** External (non-heap) bytes attributed to V8. `0` when unreported. */
+  external: number;
 }
 
 /**
@@ -81,23 +88,63 @@ export function sampleHeapPressure(
     pressureLevel,
     heapUsed: sample.heapUsed,
     heapTotal: sample.heapTotal,
+    rss: sample.rss ?? 0,
+    external: sample.external ?? 0,
   };
 }
 
 /**
- * Returns true when the most recent heap sample is at or above the
- * `MemoryMonitor` CRITICAL threshold and the extension should be skipped.
+ * Pure, unit-testable abort decision (Issue #3025).
  *
- * Honours `memoryConfig.enabled` — when monitoring is disabled the guard
- * never trips, preserving the legacy unconditional-extension behaviour.
+ * The discovery worker runs on a small default V8 heap, so after recording the
+ * V8 heap fraction sits near the critical threshold while the bulk of memory is
+ * off-heap (native/Rust) RSS that still has plenty of headroom. Deciding solely
+ * on the V8 fraction mis-classifies such a healthy run as fatal.
+ *
+ * The rule, in order:
+ * 1. Monitoring disabled → never abort (legacy behaviour).
+ * 2. Not CRITICAL → never abort.
+ * 3. No native budget configured (`nativeBudgetBytes <= 0`) → legacy V8-only
+ *    decision: a CRITICAL V8 fraction aborts.
+ * 4. RSS unreported (`rss <= 0`) → cannot trust off-heap headroom, so fall back
+ *    to the legacy decision and abort. Missing telemetry never silently
+ *    disables the safeguard.
+ * 5. RSS exceeds the budget → abort (genuine OOM is never masked).
+ * 6. Otherwise the CRITICAL is driven only by the V8 fraction while RSS is
+ *    within budget → do NOT abort.
+ */
+export function shouldAbortOnHeapPressure(
+  sample: HeapGuardSample,
+  memoryConfig: RequiredMemoryConfig,
+): boolean {
+  if (!memoryConfig.enabled) return false;
+  if (sample.pressureLevel !== "critical") return false;
+
+  const budget = memoryConfig.nativeBudgetBytes;
+  if (budget <= 0) return true; // off-heap awareness not configured
+  if (sample.rss <= 0) return true; // RSS unknown — keep the legacy safeguard
+  if (sample.rss > budget) return true; // genuine OOM — RSS over budget
+
+  // Worker-V8-only CRITICAL with off-heap headroom — safe to continue.
+  return false;
+}
+
+/**
+ * Returns true when the most recent heap sample warrants skipping the
+ * extension / aborting the analysis loop.
+ *
+ * Delegates to {@link shouldAbortOnHeapPressure}, so a worker-V8-only CRITICAL
+ * sample no longer trips when an off-heap (RSS) budget is configured and RSS
+ * has headroom (Issue #3025). Honours `memoryConfig.enabled` — when monitoring
+ * is disabled the guard never trips, preserving legacy behaviour.
  */
 export function isHeapCritical(
   memoryConfig: RequiredMemoryConfig,
   provider?: MemoryUsageProvider,
 ): boolean {
   if (!memoryConfig.enabled) return false;
-  return sampleHeapPressure(memoryConfig, provider).pressureLevel ===
-    "critical";
+  const sample = sampleHeapPressure(memoryConfig, provider);
+  return shouldAbortOnHeapPressure(sample, memoryConfig);
 }
 
 /**
@@ -116,7 +163,7 @@ export function checkAnalysisHeapAbort(
   provider?: MemoryUsageProvider,
 ): { abort: boolean; sample: HeapGuardSample } {
   const sample = sampleHeapPressure(memoryConfig, provider);
-  if (memoryConfig.enabled && sample.pressureLevel === "critical") {
+  if (shouldAbortOnHeapPressure(sample, memoryConfig)) {
     logger.warn(
       `[Neat] Discovery ${discoveryID} analysis aborted: heap CRITICAL at extension boundary`,
     );

--- a/src/config/MemoryConfig.ts
+++ b/src/config/MemoryConfig.ts
@@ -108,6 +108,26 @@ export interface MemoryConfig {
    * Defaults to false (so production behaviour is unchanged unless opted in).
    */
   proactiveGc?: boolean;
+
+  /**
+   * Off-heap (native/Rust) resident-set budget in bytes. Issue #3025.
+   *
+   * The discovery worker runs on a small default V8 heap (~269 MB), so after
+   * the recording phase the V8 heap fraction sits near the critical threshold
+   * even though the bulk of memory is native/Rust RSS with plenty of headroom.
+   * The `AnalysisHeapGuard` would then mis-classify a healthy run as CRITICAL
+   * and abort analysis (see GRQ-23).
+   *
+   * When this is `> 0`, a worker-V8-only CRITICAL sample no longer forces an
+   * abort as long as resident-set size (RSS) stays within the budget. RSS
+   * exceeding the budget still aborts (genuine OOM is never masked). When the
+   * provider does not report RSS the guard falls back to the legacy V8-only
+   * decision so missing telemetry can never silently disable the safeguard.
+   *
+   * Defaults to 0, which disables off-heap awareness and preserves the legacy
+   * V8-only abort behaviour.
+   */
+  nativeBudgetBytes?: number;
 }
 
 /**
@@ -128,4 +148,5 @@ export const DEFAULT_MEMORY_CONFIG: RequiredMemoryConfig = {
   criticalBackoffWindowMs: 10_000,
   criticalBackoffCooldownMs: 60_000,
   proactiveGc: false,
+  nativeBudgetBytes: 0,
 };

--- a/src/config/parsers/RuntimeParsers.ts
+++ b/src/config/parsers/RuntimeParsers.ts
@@ -123,6 +123,12 @@ export function parseMemoryConfig(
     proactiveGc: overrides?.proactiveGc !== undefined
       ? Boolean(overrides.proactiveGc)
       : d.proactiveGc,
+    nativeBudgetBytes: parseNumber(
+      "Memory nativeBudgetBytes",
+      overrides?.nativeBudgetBytes,
+      d.nativeBudgetBytes,
+      { integer: true, min: 0 },
+    ),
   } as RequiredMemoryConfig;
 }
 

--- a/test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts
@@ -5,8 +5,10 @@ import { assert, assertEquals } from "@std/assert";
 import {
   _setHeapGuardProviderForTests,
   checkAnalysisHeapAbort,
+  type HeapGuardSample,
   isHeapCritical,
   sampleHeapPressure,
+  shouldAbortOnHeapPressure,
 } from "@architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts";
 import { DEFAULT_MEMORY_CONFIG } from "@config/MemoryConfig.ts";
 import type { Logger } from "@utils/Logger.ts";
@@ -139,6 +141,153 @@ Deno.test("checkAnalysisHeapAbort: no abort when monitoring disabled even if cri
   );
   assertEquals(result.abort, false);
   assertEquals(lines.length, 0);
+});
+
+// --- Issue #3025: off-heap (RSS/native budget) awareness ------------------
+
+const MB = 1024 * 1024;
+
+/** Configured RSS budget with headroom above the GRQ-23 sample's RSS. */
+const NATIVE_BUDGET = Math.round(16384 * MB);
+
+/** GRQ-23: V8 heap ≈86% (CRITICAL) but native RSS well within budget. */
+const GRQ23_SAMPLE = {
+  heapUsed: Math.round(231 * MB),
+  heapTotal: Math.round(269 * MB),
+  rss: Math.round(13289 * MB),
+  external: Math.round(47 * MB),
+};
+
+function criticalSample(rss: number): HeapGuardSample {
+  return {
+    usageFraction: 0.86,
+    pressureLevel: "critical",
+    heapUsed: Math.round(231 * MB),
+    heapTotal: Math.round(269 * MB),
+    rss,
+    external: Math.round(47 * MB),
+  };
+}
+
+Deno.test("sampleHeapPressure: captures rss and external from the provider (#3025)", () => {
+  const sample = sampleHeapPressure(
+    DEFAULT_MEMORY_CONFIG,
+    fixedProvider({
+      heapUsed: 95,
+      heapTotal: 100,
+      rss: 12345,
+      external: 678,
+    }),
+  );
+  assertEquals(sample.rss, 12345);
+  assertEquals(sample.external, 678);
+});
+
+Deno.test("sampleHeapPressure: rss/external default to 0 when unreported (#3025)", () => {
+  const sample = sampleHeapPressure(
+    DEFAULT_MEMORY_CONFIG,
+    fixedProvider({ heapUsed: 95, heapTotal: 100 }),
+  );
+  assertEquals(sample.rss, 0);
+  assertEquals(sample.external, 0);
+});
+
+Deno.test("shouldAbortOnHeapPressure: V8-only CRITICAL within native budget does NOT abort (#3025)", () => {
+  const config = { ...DEFAULT_MEMORY_CONFIG, nativeBudgetBytes: NATIVE_BUDGET };
+  assertEquals(
+    shouldAbortOnHeapPressure(criticalSample(GRQ23_SAMPLE.rss), config),
+    false,
+  );
+});
+
+Deno.test("shouldAbortOnHeapPressure: RSS over native budget still aborts (genuine OOM) (#3025)", () => {
+  const config = { ...DEFAULT_MEMORY_CONFIG, nativeBudgetBytes: NATIVE_BUDGET };
+  assertEquals(
+    shouldAbortOnHeapPressure(criticalSample(NATIVE_BUDGET + MB), config),
+    true,
+  );
+});
+
+Deno.test("shouldAbortOnHeapPressure: no native budget configured keeps legacy V8-only abort (#3025)", () => {
+  // DEFAULT_MEMORY_CONFIG has nativeBudgetBytes = 0.
+  assertEquals(
+    shouldAbortOnHeapPressure(
+      criticalSample(GRQ23_SAMPLE.rss),
+      DEFAULT_MEMORY_CONFIG,
+    ),
+    true,
+  );
+});
+
+Deno.test("shouldAbortOnHeapPressure: budget configured but RSS unreported falls back to abort (#3025)", () => {
+  const config = { ...DEFAULT_MEMORY_CONFIG, nativeBudgetBytes: NATIVE_BUDGET };
+  assertEquals(shouldAbortOnHeapPressure(criticalSample(0), config), true);
+});
+
+Deno.test("shouldAbortOnHeapPressure: non-critical never aborts even with budget (#3025)", () => {
+  const config = { ...DEFAULT_MEMORY_CONFIG, nativeBudgetBytes: NATIVE_BUDGET };
+  const normal: HeapGuardSample = {
+    usageFraction: 0.1,
+    pressureLevel: "normal",
+    heapUsed: 10,
+    heapTotal: 100,
+    rss: NATIVE_BUDGET + MB, // even over budget — not critical, so no abort
+    external: 0,
+  };
+  assertEquals(shouldAbortOnHeapPressure(normal, config), false);
+});
+
+Deno.test("shouldAbortOnHeapPressure: monitoring disabled never aborts (#3025)", () => {
+  const config = {
+    ...DEFAULT_MEMORY_CONFIG,
+    enabled: false,
+    nativeBudgetBytes: NATIVE_BUDGET,
+  };
+  assertEquals(shouldAbortOnHeapPressure(criticalSample(0), config), false);
+});
+
+Deno.test("checkAnalysisHeapAbort: GRQ-23 V8-only CRITICAL within budget returns abort:false (#3025)", () => {
+  const config = { ...DEFAULT_MEMORY_CONFIG, nativeBudgetBytes: NATIVE_BUDGET };
+  const { logger, lines } = makeRecordingLogger();
+  const result = checkAnalysisHeapAbort(
+    "grq23-disc",
+    config,
+    logger,
+    fixedProvider(GRQ23_SAMPLE),
+  );
+  assertEquals(result.abort, false);
+  assertEquals(result.sample.pressureLevel, "critical");
+  assertEquals(result.sample.rss, GRQ23_SAMPLE.rss);
+  assertEquals(
+    lines.length,
+    0,
+    "no abort log when off-heap budget has headroom",
+  );
+});
+
+Deno.test("checkAnalysisHeapAbort: RSS over budget still aborts and logs (#3025)", () => {
+  const config = { ...DEFAULT_MEMORY_CONFIG, nativeBudgetBytes: NATIVE_BUDGET };
+  const { logger, lines } = makeRecordingLogger();
+  const result = checkAnalysisHeapAbort(
+    "grq23-oom",
+    config,
+    logger,
+    fixedProvider({ ...GRQ23_SAMPLE, rss: NATIVE_BUDGET + MB }),
+  );
+  assertEquals(result.abort, true);
+  assertEquals(lines.filter((l) => l.level === "warn").length, 1);
+});
+
+Deno.test("isHeapCritical: V8-only CRITICAL within budget returns false (#3025)", () => {
+  const config = { ...DEFAULT_MEMORY_CONFIG, nativeBudgetBytes: NATIVE_BUDGET };
+  assertEquals(isHeapCritical(config, fixedProvider(GRQ23_SAMPLE)), false);
+  assertEquals(
+    isHeapCritical(
+      config,
+      fixedProvider({ ...GRQ23_SAMPLE, rss: NATIVE_BUDGET + MB }),
+    ),
+    true,
+  );
 });
 
 Deno.test("_setHeapGuardProviderForTests: module-level override is honoured", () => {

--- a/test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts
@@ -73,6 +73,8 @@ interface RunOptions {
   readonly heapSample: MemoryUsageSample;
   /** Whether heap monitoring is enabled in the config. */
   readonly memoryEnabled?: boolean;
+  /** Off-heap (RSS) budget in bytes — Issue #3025. 0/undefined disables it. */
+  readonly nativeBudgetBytes?: number;
 }
 
 async function runWith(
@@ -119,7 +121,10 @@ async function runWith(
     discoveryMaxNeurons: 6,
     discoveryAnalysisChunkSize: 1,
     discoveryAnalysisPerChunkMaxMs: 60_000,
-    memory: { enabled: options.memoryEnabled ?? true },
+    memory: {
+      enabled: options.memoryEnabled ?? true,
+      nativeBudgetBytes: options.nativeBudgetBytes ?? 0,
+    },
   });
 
   const perfStats = new DiscoveryPerformanceStats();
@@ -199,6 +204,59 @@ Deno.test(
     assert(
       chunkCalls > 0,
       "chunks should run normally when heap is not under pressure",
+    );
+  },
+);
+
+Deno.test(
+  "in-loop heap guard: V8-only CRITICAL within native budget keeps the loop running (#3025)",
+  async () => {
+    const MB = 1024 * 1024;
+    const { perfStats, chunkCalls } = await runWith({
+      // V8 heap ≈86% (CRITICAL) but RSS well within the configured budget.
+      heapSample: {
+        heapUsed: Math.round(231 * MB),
+        heapTotal: Math.round(269 * MB),
+        rss: Math.round(13289 * MB),
+        external: Math.round(47 * MB),
+      },
+      nativeBudgetBytes: Math.round(16384 * MB),
+    });
+
+    assertFalse(
+      perfStats.analysisHeapAborted,
+      "off-heap headroom must keep the loop running despite V8 CRITICAL",
+    );
+    assert(
+      chunkCalls > 0,
+      "chunks should run when only the V8 fraction is critical but RSS is within budget",
+    );
+  },
+);
+
+Deno.test(
+  "in-loop heap guard: RSS over native budget still aborts (#3025)",
+  async () => {
+    const MB = 1024 * 1024;
+    const budget = Math.round(16384 * MB);
+    const { perfStats, chunkCalls } = await runWith({
+      heapSample: {
+        heapUsed: Math.round(231 * MB),
+        heapTotal: Math.round(269 * MB),
+        rss: budget + MB, // RSS itself over budget — genuine OOM
+        external: Math.round(47 * MB),
+      },
+      nativeBudgetBytes: budget,
+    });
+
+    assert(
+      perfStats.analysisHeapAborted,
+      "RSS over budget must still abort the loop (no masking of real OOM)",
+    );
+    assertEquals(
+      chunkCalls,
+      0,
+      "no chunk should run once RSS exceeds the native budget",
     );
   },
 );

--- a/test/config/parsers/RuntimeParsers.ts
+++ b/test/config/parsers/RuntimeParsers.ts
@@ -84,6 +84,24 @@ Deno.test("parseMemoryConfig - rejects warningThreshold above 1", () => {
   );
 });
 
+Deno.test("parseMemoryConfig - nativeBudgetBytes defaults to 0 (#3025)", () => {
+  const cfg = parseMemoryConfig(undefined);
+  assertEquals(cfg.nativeBudgetBytes, DEFAULT_MEMORY_CONFIG.nativeBudgetBytes);
+  assertEquals(cfg.nativeBudgetBytes, 0);
+});
+
+Deno.test("parseMemoryConfig - applies nativeBudgetBytes override (#3025)", () => {
+  const cfg = parseMemoryConfig({ nativeBudgetBytes: 8_589_934_592 });
+  assertEquals(cfg.nativeBudgetBytes, 8_589_934_592);
+});
+
+Deno.test("parseMemoryConfig - rejects negative nativeBudgetBytes (#3025)", () => {
+  assertThrows(
+    () => parseMemoryConfig({ nativeBudgetBytes: -1 }),
+    ConfigurationError,
+  );
+});
+
 Deno.test("parseParallelEvaluation - returns defaults when no overrides", () => {
   const cfg = parseParallelEvaluation(undefined);
   assertEquals(


### PR DESCRIPTION
# Discovery #3022: AnalysisHeapGuard off-heap (RSS) awareness

## Summary

The discovery worker runs on a small default V8 heap (~269 MB). After the
recording phase the V8 heap fraction sits near the 85% critical threshold even
though the bulk of memory is native/Rust **RSS** with plenty of headroom (GRQ-23
observed `heap=231MB/269MB rss=13289MB`). `AnalysisHeapGuard` decided **solely**
on the V8 heap fraction, so a healthy run was mis-classified as CRITICAL and
analysis was aborted.

This change makes the guard off-heap aware while preserving genuine-OOM aborts:

- New `memory.nativeBudgetBytes` config (RSS budget in bytes). Default `0`
  disables off-heap awareness and preserves the legacy V8-only behaviour.
- `HeapGuardSample` widened with `rss` / `external`; `sampleHeapPressure`
  captures both (the default provider already exposes them via
  `Deno.memoryUsage()`).
- New pure, unit-testable `shouldAbortOnHeapPressure(sample, memoryConfig)`
  encodes the rule: a worker-V8-only CRITICAL does **not** abort while RSS is
  within `nativeBudgetBytes`; RSS over budget (or unreported) still aborts so a
  real OOM is never masked.
- Both discovery call sites now flow through it: `checkAnalysisHeapAbort`
  (`DataRecorder.ts` extension boundary) and `isHeapCritical`
  (`DataRecorderAnalysis.ts` in-loop guard). No V8-only abort decision remains
  on the discovery path.

Closes #3025.

## Acceptance criteria

- [x] Guard no longer aborts on worker-V8-only CRITICAL when configured native
      budget has headroom (covered by tests).
- [x] RSS-over-budget still aborts (no masking of real OOM).
- [x] Default/legacy behaviour preserved when no native budget is configured
      (`nativeBudgetBytes === 0`); `memory.enabled === false` still never trips.
- [x] Both call sites updated; no remaining V8-only abort decision on the
      discovery path.

## Decision flow

```mermaid
flowchart TD
    classDef ok fill:#1e8449,stroke:#196f3d,color:#fff
    classDef warn fill:#d68910,stroke:#b7770d,color:#fff
    S[CRITICAL heap sample] --> E{monitoring enabled?}
    E -- no --> K[continue]:::ok
    E -- yes --> B{nativeBudgetBytes &gt; 0?}
    B -- no --> A[abort - legacy V8-only]:::warn
    B -- yes --> R{RSS reported and within budget?}
    R -- yes --> K
    R -- no --> A
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified by unit tests
calling the real guard and config functions.

- `test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts`
  - `shouldAbortOnHeapPressure: V8-only CRITICAL within native budget does NOT abort`
  - `shouldAbortOnHeapPressure: RSS over native budget still aborts (genuine OOM)`
  - `shouldAbortOnHeapPressure: no native budget configured keeps legacy V8-only abort`
  - `shouldAbortOnHeapPressure: budget configured but RSS unreported falls back to abort`
  - `checkAnalysisHeapAbort: GRQ-23 V8-only CRITICAL within budget returns abort:false`
  - `checkAnalysisHeapAbort: RSS over budget still aborts and logs`
  - `isHeapCritical: V8-only CRITICAL within budget returns false`
  - `sampleHeapPressure: captures rss and external from the provider`
- `test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts`
  - `in-loop heap guard: V8-only CRITICAL within native budget keeps the loop running`
  - `in-loop heap guard: RSS over native budget still aborts`
- `test/config/parsers/RuntimeParsers.ts`
  - `parseMemoryConfig - nativeBudgetBytes defaults to 0`
  - `parseMemoryConfig - applies nativeBudgetBytes override`
  - `parseMemoryConfig - rejects negative nativeBudgetBytes`

Command output (affected suites):

```
test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts        ok | 22 passed
test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts    ok |  5 passed
test/ErrorGuidedStructuralEvolution/DiscoveryWorkerHeapLimit.ts ok |  3 passed (1 ignored)
test/config/parsers/RuntimeParsers.ts                           ok | 14 passed
```

`deno lint` (1727 files) and `./quality.sh --check-only` (type-check) both pass.

## Test Plan

- Added off-heap-awareness unit cases to `AnalysisHeapGuard.ts` (pure function,
  `checkAnalysisHeapAbort`, `isHeapCritical`, `sampleHeapPressure`).
- Extended the in-loop guard test `AnalysisLoopHeapGuard.ts` with the
  within-budget (no abort) and over-budget (abort) paths.
- Added config parser cases for `nativeBudgetBytes` default, override, and
  negative rejection.
- Existing guard tests (legacy V8-only behaviour, `memory.enabled === false`)
  and the `DiscoveryWorkerHeapLimit` regression cases remain green unchanged.

## Notes

- The complementary worker heap-limit propagation (the
  `DiscoveryWorkerHeapLimit` red→green switch) is a separate #3022 sub-issue;
  either approach alone stops the false abort. This PR takes the off-heap route
  and leaves that switch for its sibling PR.



## Milestone
This PR is part of the **#3022 Discovery worker uses default ~270MB V8 heap; AnalysisHeapGuard aborts analysis after recording (GRQ-23 logs)** milestone and targets the `milestone/3022-discovery-worker-uses-default-270mb-v8-heap-a` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqhdm7ta-70228b`<!-- vibe-worker-issue-3025 -->