### PR TITLE
Discovery: release record-phase JS retainers before analysis heap check (#3026)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3026.md
+++ b/docs/archive/pr-summaries/pr-summary-3026.md
@@ -1,0 +1,96 @@
+# Release record-phase JS retainers before the analysis heap check
+
+## Summary
+
+Sub-issue of #3022 — addresses **suspected root cause #3**: JS-side retainers
+from the recording phase leave the worker heap near CRITICAL before analysis
+even starts. Closes #3026.
+
+By the time control reaches the analysis-extension boundary (`DataRecorder.ts`),
+the recording phase has already persisted everything the analysis phase reads —
+the merged `discovery_data.parquet` and the `selected_indices.json` written
+during recording — yet its in-memory copies are still alive on the small default
+worker V8 heap:
+
+- `selectedIndices` — the per-file sampled-index map (the dominant retainer; it
+  grows with every sampled record across every file),
+- `rustAccumulatedData` / `rustAccumulatedNeuronData` — sample accumulators,
+- `rustBinaryFilePaths` / `rustAccumulatedEstimatedBytes` — recording
+  bookkeeping.
+
+On their own these push the heap fraction the `AnalysisHeapGuard` samples
+artificially toward the 85% CRITICAL threshold — not because analysis needs the
+memory, but because record-phase retainers were never released.
+
+### Change
+
+- New `DiscoverStructure.releaseRecordingRetainers()`
+  (`DiscoverStructureRecording.ts`) drops those in-memory copies and returns a
+  small report (`releasedIndexEntries`, `releasedAccumulatedSamples`) for
+  observability and tests. State the analysis phase still consumes is
+  deliberately preserved: `recordedNeuronTotalAbsError` (focus ranking),
+  `parquetFilePath`, `combinedRustAnalysis`, and `creature` — so there is no
+  use-after-free.
+- `DataRecorder` calls it on the `recordingSuccess` path, immediately **before**
+  `checkAnalysisHeapAbort` samples the heap.
+- Optional best-effort `globalThis.gc?.()` (reusing `attemptProactiveGc`) when
+  `memory.proactiveGc` is enabled; correctness never depends on GC running.
+
+This mirrors the per-chunk cache release of #2642
+(`releaseCombinedRustAnalysisCache`) applied to the record→analysis handoff. It
+reduces the demand side rather than raising the worker heap limit (the other
+#3022 sub-issues), and is the lowest-risk, most local of the three.
+
+## Evidence
+
+Backend/memory change — no UI to screenshot. Verified by tests (below) and the
+full quality gate (`./quality.sh`: **7305 passed, 0 failed, 4 ignored**).
+
+```mermaid
+flowchart TD
+    classDef ok fill:#1e8449,stroke:#196f3d,color:#fff
+    classDef warn fill:#d68910,stroke:#b7770d,color:#fff
+    R[Recording phase done<br/>parquet + indices on disk] --> RR[releaseRecordingRetainers<br/>drop in-memory copies #3026]:::ok
+    RR --> B{Heap CRITICAL at<br/>extension boundary?}
+    B -- no --> L[Analysis loop]:::ok
+    B -- yes --> S[Skip analysis,<br/>return partial]:::warn
+```
+
+Preserved across the release (no use-after-free): `recordedNeuronTotalAbsError`,
+`parquetFilePath`, `combinedRustAnalysis`, `creature`.
+
+## Test Plan
+
+New `test/ErrorGuidedStructuralEvolution/ReleaseRecordingRetainers.ts`:
+
+1. **`releaseRecordingRetainers empties record-phase state but preserves
+   analysis state`**
+   — records a representative batch against a named binary file, flushes, then
+   asserts the release empties `selectedIndices`, `rustAccumulatedData`,
+   `rustAccumulatedNeuronData`, `rustBinaryFilePaths` and zeroes
+   `rustAccumulatedEstimatedBytes`, while `recordedNeuronTotalAbsError` and
+   `parquetFilePath` survive unchanged. Also asserts a second release is a safe
+   no-op.
+2. **`releaseRecordingRetainers lowers the boundary heap sample below
+   CRITICAL`**
+   — models the boundary sample as `floor + retained-bytes` (the length-only
+   modelling style of `DiscoveryWorkerHeapLimit`), injected through the
+   `_setHeapGuardProviderForTests` seam. Before the release the sample is
+   CRITICAL and `checkAnalysisHeapAbort` aborts; after the release `heapUsed` is
+   measurably lower, the sample is below `criticalThreshold`, and the guard no
+   longer aborts.
+
+Regression-checked green: `AnalysisCacheRelease`, `DiscoveryWorkerHeapLimit`,
+`AnalysisHeapGuard`, `AnalysisLoopHeapGuard`, `DiscoverStructureCleanUp` (33
+passed), plus the full suite.
+
+## Acceptance criteria
+
+- [x] Record-phase retainers explicitly released before the extension-boundary
+      heap sample in `DataRecorder`.
+- [x] New test shows post-cleanup worker `heapUsed` is meaningfully lower /
+      below CRITICAL for a representative (mocked) recording workload.
+- [x] No change to recorded output — only in-memory copies of already-persisted
+      data are dropped; no behavioural change when monitoring is disabled.
+- [x] No use-after-free in the analysis loop — analysis-needed state preserved;
+      existing analysis/cleanup tests stay green.

--- a/docs/troubleshooting/MEMORY.md
+++ b/docs/troubleshooting/MEMORY.md
@@ -221,6 +221,27 @@ raising the V8 heap (Step 5) or lowering `criticalThreshold` (Step 2) changes
 when they fire. A graceful abort means analysis produced no (or partial)
 structural candidates for that cycle — evolution continues; it does not crash.
 
+#### Releasing record-phase retainers before the boundary (Issue #3026)
+
+Before the extension-boundary guard samples the heap, `DataRecorder` now calls
+`DiscoverStructure.releaseRecordingRetainers()`. By the time recording finishes
+it has already persisted everything analysis reads — the merged
+`discovery_data.parquet` and the `selected_indices.json` written during
+recording — yet the in-memory sample accumulators (`rustAccumulatedData`,
+`rustAccumulatedNeuronData`) and the per-file sampled-index map
+(`selectedIndices`) are still alive on the small default worker heap. On their
+own they push the sampled heap fraction artificially toward CRITICAL.
+
+Dropping those in-memory copies at the record→analysis handoff lowers the
+sampled `heapUsed` so the guard reads the heap analysis actually needs, not the
+record-phase leftovers — the per-chunk cache release of #2642 applied to the
+boundary. State analysis still consumes is preserved
+(`recordedNeuronTotalAbsError` for focus ranking, `parquetFilePath`,
+`combinedRustAnalysis`, `creature`), so there is no use-after-free and no change
+to recorded output. When `memory.proactiveGc` is enabled a best-effort
+`globalThis.gc?.()` runs after the references are dropped, but correctness never
+depends on GC running.
+
 #### Off-heap (RSS / native budget) awareness (Issue #3025)
 
 The discovery worker runs on a small default V8 heap (~269 MB), so after a
@@ -247,7 +268,8 @@ preserves the legacy V8-only behaviour.
 flowchart TD
     classDef ok fill:#1e8449,stroke:#196f3d,color:#fff
     classDef warn fill:#d68910,stroke:#b7770d,color:#fff
-    R[Recording phase done] --> B{Heap CRITICAL at\nextension boundary?}
+    R[Recording phase done] --> RR[Release record-phase\nretainers #3026]:::ok
+    RR --> B{Heap CRITICAL at\nextension boundary?}
     B -- no --> L[Analysis loop]:::ok
     B -- yes --> N{nativeBudgetBytes &gt; 0\nand RSS within budget?}
     N -- yes --> L

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
@@ -349,6 +349,18 @@ export class DataRecorder {
         };
       }
 
+      // Issue #3026: Release record-phase JS retainers before sampling the
+      // heap at the analysis-extension boundary. The recording phase has
+      // already persisted its output (merged parquet + selected_indices.json),
+      // so the in-memory sample accumulators and per-file index map are dead
+      // weight on the small default worker V8 heap. Dropping them here lowers
+      // the heap sample the guard reads — the #2642 chunk-cache release applied
+      // to the record→analysis handoff — without touching analysis-needed
+      // state or recorded output.
+      discoverStructure.releaseRecordingRetainers({
+        attemptGc: this.config.memory.proactiveGc,
+      });
+
       // Issue #2594: Heap-aware extension guard.
       // Before we extend the timeout to give analysis room to run, sample
       // the heap. If MemoryMonitor reports CRITICAL pressure here, the

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
@@ -26,6 +26,7 @@ import {
   observeRustTrainingRecord as observeRustTrainingRecordImpl,
 } from "@architecture/ErrorGuidedStructuralEvolution/RustFlushDiagnostics.ts";
 import { taskDescriptorToRustWire } from "@costs/TaskDescriptorRustWire.ts";
+import { attemptProactiveGc } from "@neat/MemoryMonitor.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { appendAll } from "@utils/ArrayAppend.ts";
 import { isReleased } from "@utils/ReleasableRef.ts";
@@ -515,6 +516,64 @@ export class DiscoverStructureRecording extends DiscoverStructureBase {
       }
     }
     return true;
+  }
+
+  /**
+   * Release record-phase JS retainers the analysis phase no longer needs,
+   * ahead of the analysis-extension heap check (Issue #3026).
+   *
+   * Once {@link flushRustRecording} has produced the on-disk parquet output,
+   * the in-memory sample accumulators and the per-file sampled-index map are
+   * dead weight on the small default worker V8 heap. The recording phase has
+   * already persisted everything the analysis phase reads — the merged parquet
+   * file (`parquetFilePath`) and the `selected_indices.json` written to
+   * `indicesFilePath` during recording — so dropping the in-memory copies
+   * changes no recorded output.
+   *
+   * This mirrors the per-chunk cache release of #2642
+   * ({@link releaseCombinedRustAnalysisCache}) applied to the
+   * record→analysis handoff. State the analysis phase still consumes is
+   * deliberately preserved: `recordedNeuronTotalAbsError` (focus ranking),
+   * `parquetFilePath`, `combinedRustAnalysis`, and `creature`.
+   *
+   * @param options.attemptGc request a proactive `globalThis.gc?.()` after
+   *   dropping the references. Only effective under
+   *   `--v8-flags=--expose-gc`; correctness never depends on GC running.
+   * @returns counts of what was released, for observability and tests.
+   */
+  public releaseRecordingRetainers(
+    options?: Readonly<{ attemptGc?: boolean }>,
+  ): { releasedIndexEntries: number; releasedAccumulatedSamples: number } {
+    let releasedIndexEntries = 0;
+    for (const key of Object.keys(this.selectedIndices)) {
+      releasedIndexEntries += this.selectedIndices[key]?.length ?? 0;
+    }
+    const releasedAccumulatedSamples = this.rustAccumulatedData.length;
+
+    // In-memory copies only — the analysis phase reads the merged parquet and
+    // `selected_indices.json` from disk, never these fields.
+    this.selectedIndices = {};
+    this.rustAccumulatedData = [];
+    this.rustAccumulatedNeuronData = [];
+    this.rustAccumulatedEstimatedBytes = 0;
+    this.rustBinaryFilePaths = new Set();
+
+    if (options?.attemptGc) {
+      // Best-effort; a no-op unless the runtime was started with --expose-gc.
+      attemptProactiveGc();
+    }
+
+    if (
+      this.loggingEnabled &&
+      (releasedIndexEntries > 0 || releasedAccumulatedSamples > 0)
+    ) {
+      this.log(
+        "info",
+        `Released record-phase retainers before analysis heap check: ${releasedIndexEntries} index entries, ${releasedAccumulatedSamples} accumulated samples.`,
+      );
+    }
+
+    return { releasedIndexEntries, releasedAccumulatedSamples };
   }
 
   // ── Flush diagnostics ──────────────────────────────────────────────

--- a/test/ErrorGuidedStructuralEvolution/ReleaseRecordingRetainers.ts
+++ b/test/ErrorGuidedStructuralEvolution/ReleaseRecordingRetainers.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for releasing record-phase JS retainers ahead of the
+ * analysis-extension heap check (Issue #3026).
+ *
+ * Suspected root cause #3 of #3022: by the time control reaches the
+ * record→analysis boundary in `DataRecorder`, the recording phase has left
+ * its per-file sampled-index map and sample accumulators alive on the small
+ * default worker V8 heap. The heap guard then samples a heap that is
+ * artificially near the 85% CRITICAL threshold — not because analysis needs
+ * the memory, but because record-phase retainers were never released.
+ *
+ * `DiscoverStructure.releaseRecordingRetainers()` drops those in-memory
+ * copies (the parquet output and `selected_indices.json` on disk remain the
+ * source of truth the analysis phase reads). These tests assert:
+ *
+ * 1. The release empties the record-phase retainers while preserving the
+ *    state the analysis phase still consumes (`recordedNeuronTotalAbsError`,
+ *    `parquetFilePath`) — no use-after-free.
+ * 2. Modelling the boundary heap sample as `floor + retained-bytes`, the
+ *    release measurably lowers `heapUsed` so the sample drops from CRITICAL
+ *    to below the threshold, independent of the guard's abort decision.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { DiscoverStructureDeps } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import {
+  _setHeapGuardProviderForTests,
+  checkAnalysisHeapAbort,
+  sampleHeapPressure,
+} from "@architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts";
+import { DEFAULT_MEMORY_CONFIG } from "@config/MemoryConfig.ts";
+import type { Logger } from "@utils/Logger.ts";
+import type { MemoryUsageSample } from "@neat/MemoryMonitor.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+const MB = 1024 * 1024;
+/** Bytes modelled per retained sampled-index (a packed JS number). */
+const BYTES_PER_INDEX = 8;
+
+function makeTestCreature(): Creature {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { uuid: "hidden-a", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "hidden-b", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-b", weight: -0.5 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "hidden-b", toUUID: "output-0", weight: -0.25 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+function makeTrainingData(count: number): DataRecordInterface[] {
+  const samples: DataRecordInterface[] = [];
+  for (let i = 0; i < count; i++) {
+    samples.push({
+      input: Float32Array.from([i / count, (i + 1) / count]),
+      output: Float32Array.from([i / count]),
+    });
+  }
+  return samples;
+}
+
+/**
+ * Build a recorded `DiscoverStructure` wired to deterministic in-memory stubs,
+ * mirroring the record→analysis state at the extension boundary.
+ */
+async function buildRecordedStructure(): Promise<
+  { structure: DiscoverStructure; tempParquetPath: string }
+> {
+  await initWasmForTests();
+
+  const creature = makeTestCreature();
+  const tempParquetPath = await Deno.makeTempFile({
+    prefix: "release-recording-retainers-",
+    suffix: ".parquet",
+  });
+
+  const deps: Partial<DiscoverStructureDeps> = {
+    isRustDiscoveryEnabled: () => true,
+    isRustLibraryAvailable: () => true,
+    recordDiscovery: () => ({ success: true, file: tempParquetPath }),
+    mergeDiscoveryParquet: () => ({
+      success: true,
+      outputFile: tempParquetPath,
+    }),
+    analyzeParallel: () => ({ success: true }),
+    readDiscoveryRecords: () => ({ success: true, records: [] }),
+  };
+
+  const structure = new DiscoverStructure(creature, 600, 100, deps);
+  const neuronPromises = new Map<number, Promise<void>>();
+  structure.initialize(neuronPromises);
+
+  // Record a sampled batch against a named binary file so the per-file index
+  // map is populated, exactly as a real recording phase leaves it.
+  const sampleCount = 20;
+  const recordIndices = Array.from({ length: sampleCount }, (_, i) => i);
+  structure.record(
+    makeTrainingData(sampleCount),
+    neuronPromises,
+    "/data/training-data.bin",
+    recordIndices,
+  );
+  structure.flushRustRecording();
+
+  return { structure, tempParquetPath };
+}
+
+/** Test-side model: bytes retained by the in-memory record-phase state. */
+function modelRetainedBytes(structure: DiscoverStructure): number {
+  const selectedIndices = structure["selectedIndices"] as Record<
+    string,
+    number[]
+  >;
+  let entries = 0;
+  for (const key of Object.keys(selectedIndices)) {
+    entries += selectedIndices[key]?.length ?? 0;
+  }
+  return entries * BYTES_PER_INDEX;
+}
+
+Deno.test("releaseRecordingRetainers empties record-phase state but preserves analysis state", async () => {
+  const { structure, tempParquetPath } = await buildRecordedStructure();
+
+  try {
+    // Before release: the per-file index map and the analysis-needed error
+    // totals are both populated.
+    const selectedBefore = structure["selectedIndices"] as Record<
+      string,
+      number[]
+    >;
+    assert(
+      Object.keys(selectedBefore).length > 0,
+      "selectedIndices should be populated after recording",
+    );
+    const errorTotals = structure["recordedNeuronTotalAbsError"] as Map<
+      number,
+      number
+    >;
+    assert(
+      errorTotals.size > 0,
+      "recordedNeuronTotalAbsError should be populated after recording",
+    );
+    const parquetBefore = structure["parquetFilePath"];
+    assert(parquetBefore, "parquetFilePath should be set after flush");
+
+    const report = structure.releaseRecordingRetainers();
+
+    // Released record-phase retainers.
+    assert(
+      report.releasedIndexEntries > 0,
+      "should report released index entries",
+    );
+    assertEquals(
+      Object.keys(structure["selectedIndices"] as Record<string, number[]>)
+        .length,
+      0,
+      "selectedIndices must be empty after release",
+    );
+    assertEquals(
+      (structure["rustAccumulatedData"] as unknown[]).length,
+      0,
+      "rustAccumulatedData must be empty after release",
+    );
+    assertEquals(
+      (structure["rustAccumulatedNeuronData"] as unknown[]).length,
+      0,
+      "rustAccumulatedNeuronData must be empty after release",
+    );
+    assertEquals(
+      (structure["rustBinaryFilePaths"] as Set<string>).size,
+      0,
+      "rustBinaryFilePaths must be empty after release",
+    );
+    assertEquals(structure["rustAccumulatedEstimatedBytes"], 0);
+
+    // Preserved analysis state — no use-after-free in the analysis loop.
+    assertEquals(
+      (structure["recordedNeuronTotalAbsError"] as Map<number, number>).size,
+      errorTotals.size,
+      "recordedNeuronTotalAbsError must survive the release",
+    );
+    assertEquals(
+      structure["parquetFilePath"],
+      parquetBefore,
+      "parquetFilePath must survive the release",
+    );
+
+    // Idempotent: a second release is a safe no-op.
+    const second = structure.releaseRecordingRetainers();
+    assertEquals(second.releasedIndexEntries, 0);
+  } finally {
+    await structure.cleanUp();
+    try {
+      await Deno.remove(tempParquetPath);
+    } catch {
+      // Ignore cleanup failures
+    }
+  }
+});
+
+Deno.test("releaseRecordingRetainers lowers the boundary heap sample below CRITICAL", async () => {
+  const { structure, tempParquetPath } = await buildRecordedStructure();
+
+  try {
+    // Model a representative-scale recording workload: a heavy discovery run
+    // leaves millions of sampled indices alive on the small default worker
+    // heap. (Length-only model, mirroring DiscoveryWorkerHeapLimit's injected
+    // byte counts — no large real allocation.)
+    const REPRESENTATIVE_ENTRIES = 4_000_000; // 4M * 8B = 32 MB modelled
+    (structure["selectedIndices"] as Record<string, number[]>)[
+      "/data/training-data.bin"
+    ] = new Array(REPRESENTATIVE_ENTRIES);
+
+    // Worker heap (default ~269 MB) with a floor that, combined with the
+    // retained index bytes, sits above the 85% CRITICAL threshold but drops
+    // below it once the retainers are released.
+    const WORKER_HEAP_TOTAL = Math.round(269 * MB);
+    const HEAP_FLOOR = Math.round(210 * MB);
+    _setHeapGuardProviderForTests((): MemoryUsageSample => ({
+      heapUsed: HEAP_FLOOR + modelRetainedBytes(structure),
+      heapTotal: WORKER_HEAP_TOTAL,
+    }));
+
+    // Before release: the record-phase retainers push the sample to CRITICAL.
+    const before = sampleHeapPressure(DEFAULT_MEMORY_CONFIG);
+    assert(
+      before.usageFraction >= DEFAULT_MEMORY_CONFIG.criticalThreshold,
+      `expected CRITICAL before release, got fraction ${before.usageFraction}`,
+    );
+    assertEquals(before.pressureLevel, "critical");
+
+    const { logger } = makeLogger();
+    const abortBefore = checkAnalysisHeapAbort(
+      "release-3026",
+      DEFAULT_MEMORY_CONFIG,
+      logger,
+    );
+    assertEquals(abortBefore.abort, true);
+
+    // Release the record-phase retainers.
+    const report = structure.releaseRecordingRetainers();
+    assertEquals(report.releasedIndexEntries, REPRESENTATIVE_ENTRIES);
+
+    // After release: heapUsed measurably lower and below the threshold.
+    const after = sampleHeapPressure(DEFAULT_MEMORY_CONFIG);
+    assert(
+      after.heapUsed < before.heapUsed,
+      `cleanup must lower heapUsed (before ${before.heapUsed}, after ${after.heapUsed})`,
+    );
+    assert(
+      after.usageFraction < DEFAULT_MEMORY_CONFIG.criticalThreshold,
+      `expected below CRITICAL after release, got fraction ${after.usageFraction}`,
+    );
+    assert(
+      after.pressureLevel !== "critical",
+      `expected non-CRITICAL pressure after release, got ${after.pressureLevel}`,
+    );
+
+    const abortAfter = checkAnalysisHeapAbort(
+      "release-3026",
+      DEFAULT_MEMORY_CONFIG,
+      logger,
+    );
+    assertEquals(abortAfter.abort, false);
+  } finally {
+    _setHeapGuardProviderForTests(undefined);
+    await structure.cleanUp();
+    try {
+      await Deno.remove(tempParquetPath);
+    } catch {
+      // Ignore cleanup failures
+    }
+  }
+});
+
+function makeLogger(): { logger: Logger; lines: string[] } {
+  const lines: string[] = [];
+  const logger: Logger = {
+    debug: (...args) => lines.push(args.join(" ")),
+    info: (...args) => lines.push(args.join(" ")),
+    warn: (...args) => lines.push(args.join(" ")),
+    error: (...args) => lines.push(args.join(" ")),
+  };
+  return { logger, lines };
+}


### PR DESCRIPTION
# Release record-phase JS retainers before the analysis heap check

## Summary

Sub-issue of #3022 — addresses **suspected root cause #3**: JS-side retainers
from the recording phase leave the worker heap near CRITICAL before analysis
even starts. Closes #3026.

By the time control reaches the analysis-extension boundary (`DataRecorder.ts`),
the recording phase has already persisted everything the analysis phase reads —
the merged `discovery_data.parquet` and the `selected_indices.json` written
during recording — yet its in-memory copies are still alive on the small default
worker V8 heap:

- `selectedIndices` — the per-file sampled-index map (the dominant retainer; it
  grows with every sampled record across every file),
- `rustAccumulatedData` / `rustAccumulatedNeuronData` — sample accumulators,
- `rustBinaryFilePaths` / `rustAccumulatedEstimatedBytes` — recording
  bookkeeping.

On their own these push the heap fraction the `AnalysisHeapGuard` samples
artificially toward the 85% CRITICAL threshold — not because analysis needs the
memory, but because record-phase retainers were never released.

### Change

- New `DiscoverStructure.releaseRecordingRetainers()`
  (`DiscoverStructureRecording.ts`) drops those in-memory copies and returns a
  small report (`releasedIndexEntries`, `releasedAccumulatedSamples`) for
  observability and tests. State the analysis phase still consumes is
  deliberately preserved: `recordedNeuronTotalAbsError` (focus ranking),
  `parquetFilePath`, `combinedRustAnalysis`, and `creature` — so there is no
  use-after-free.
- `DataRecorder` calls it on the `recordingSuccess` path, immediately **before**
  `checkAnalysisHeapAbort` samples the heap.
- Optional best-effort `globalThis.gc?.()` (reusing `attemptProactiveGc`) when
  `memory.proactiveGc` is enabled; correctness never depends on GC running.

This mirrors the per-chunk cache release of #2642
(`releaseCombinedRustAnalysisCache`) applied to the record→analysis handoff. It
reduces the demand side rather than raising the worker heap limit (the other
#3022 sub-issues), and is the lowest-risk, most local of the three.

## Evidence

Backend/memory change — no UI to screenshot. Verified by tests (below) and the
full quality gate (`./quality.sh`: **7305 passed, 0 failed, 4 ignored**).

```mermaid
flowchart TD
    classDef ok fill:#1e8449,stroke:#196f3d,color:#fff
    classDef warn fill:#d68910,stroke:#b7770d,color:#fff
    R[Recording phase done<br/>parquet + indices on disk] --> RR[releaseRecordingRetainers<br/>drop in-memory copies #3026]:::ok
    RR --> B{Heap CRITICAL at<br/>extension boundary?}
    B -- no --> L[Analysis loop]:::ok
    B -- yes --> S[Skip analysis,<br/>return partial]:::warn
```

Preserved across the release (no use-after-free): `recordedNeuronTotalAbsError`,
`parquetFilePath`, `combinedRustAnalysis`, `creature`.

## Test Plan

New `test/ErrorGuidedStructuralEvolution/ReleaseRecordingRetainers.ts`:

1. **`releaseRecordingRetainers empties record-phase state but preserves
   analysis state`**
   — records a representative batch against a named binary file, flushes, then
   asserts the release empties `selectedIndices`, `rustAccumulatedData`,
   `rustAccumulatedNeuronData`, `rustBinaryFilePaths` and zeroes
   `rustAccumulatedEstimatedBytes`, while `recordedNeuronTotalAbsError` and
   `parquetFilePath` survive unchanged. Also asserts a second release is a safe
   no-op.
2. **`releaseRecordingRetainers lowers the boundary heap sample below
   CRITICAL`**
   — models the boundary sample as `floor + retained-bytes` (the length-only
   modelling style of `DiscoveryWorkerHeapLimit`), injected through the
   `_setHeapGuardProviderForTests` seam. Before the release the sample is
   CRITICAL and `checkAnalysisHeapAbort` aborts; after the release `heapUsed` is
   measurably lower, the sample is below `criticalThreshold`, and the guard no
   longer aborts.

Regression-checked green: `AnalysisCacheRelease`, `DiscoveryWorkerHeapLimit`,
`AnalysisHeapGuard`, `AnalysisLoopHeapGuard`, `DiscoverStructureCleanUp` (33
passed), plus the full suite.

## Acceptance criteria

- [x] Record-phase retainers explicitly released before the extension-boundary
      heap sample in `DataRecorder`.
- [x] New test shows post-cleanup worker `heapUsed` is meaningfully lower /
      below CRITICAL for a representative (mocked) recording workload.
- [x] No change to recorded output — only in-memory copies of already-persisted
      data are dropped; no behavioural change when monitoring is disabled.
- [x] No use-after-free in the analysis loop — analysis-needed state preserved;
      existing analysis/cleanup tests stay green.



## Milestone
This PR is part of the **#3022 Discovery worker uses default ~270MB V8 heap; AnalysisHeapGuard aborts analysis after recording (GRQ-23 logs)** milestone and targets the `milestone/3022-discovery-worker-uses-default-270mb-v8-heap-a` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqhga07w-5d8f2f`<!-- vibe-worker-issue-3026 -->