### PR TITLE
Compaction: transitive constant fold + zero-varying-input collapse (#3035)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3035.md
+++ b/docs/archive/pr-summaries/pr-summary-3035.md
@@ -1,0 +1,77 @@
+# Compaction: transitive constant fold + zero-varying-input collapse (safe variant)
+
+## Summary
+
+Extends the safe compaction variant with a **transitive constant fold** that
+iterates to a **fixpoint** and a **zero-varying-input neuron collapse**. Both
+transforms are lossless, so they belong to the safe variant. Closes #3035.
+
+A new module `src/compact/ConstantFold.ts` exports `foldConstants()`, wired into
+`compactCreature()` (`src/compact/CompactCreature.ts`) just before the parallel
+bridge merges.
+
+What it does:
+
+- **Transitive fold (fixpoint).** A `type:"constant"` producer `C` emits the
+  fixed scalar `C.bias`. For every non-aggregate consumer `B`, the contribution
+  `weight · C.bias` is folded into `B.bias` and the synapse removed; when `C`
+  has no consumers left it is deleted. Each fold can turn another neuron's
+  inputs entirely constant, so the pass repeats until nothing changes.
+- **Zero-varying-input collapse.** When a hidden neuron `H` has zero genuinely
+  varying inputs (every input constant, or none at all), its output is the fixed
+  scalar `squash(H.pre)` where `H.pre = Σ(weightᵢ · constantᵢ) + H.bias`. The
+  squash is applied via the existing `Activations.find()` lookup (never
+  hand-rolled). That scalar is folded downstream like a constant and `H` deleted.
+
+Safety rules honoured:
+
+- Only folds into **non-aggregate** consumers (`!isAggregationSquash`); a
+  producer feeding an aggregate consumer (MAXIMUM/MINIMUM/IF/HYPOT/HYPOTv2) is
+  retained for that consumer.
+- A neuron is only treated as constant when it has **zero** varying inputs — any
+  varying input means it is never constant.
+- Only non-aggregate squashes (those exposing a scalar `squash(x)`) collapse.
+- Never folds away an output neuron's last inbound synapse (structural validity).
+- Frozen consumers/synapses (Issue #1861) are never modified.
+- `didCompact` is set and `assertValidSynapseReferences` is asserted after the
+  fold, consistent with the surrounding passes.
+
+```mermaid
+flowchart LR
+    subgraph Before
+      C[const c] -->|w| H[hidden H<br/>LOGISTIC]
+      H -->|w| O[output O]
+      I[input 0] -->|w| O
+    end
+    subgraph After
+      I2[input 0] -->|w| O2[output O<br/>bias absorbs c and H]
+    end
+    Before -->|foldConstants fixpoint| After
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified by unit tests
+exercising real `compactCreature()` activation behaviour over random inputs.
+
+New tests (`test/compact/CompactCreatureConstantTransitiveFold.ts`):
+
+- **Transitive collapse:** `const → hidden(LOGISTIC) → output` with a separate
+  varying input on the output. Asserts both the constant and the constant-fed
+  hidden neuron disappear, outputs are preserved within `1e-6`, and the score is
+  equal-or-higher.
+- **Negative test:** a hidden neuron with one varying input and one constant
+  input is **not** collapsed (it survives compaction); outputs preserved.
+
+```
+deno test test/compact/CompactCreatureConstantTransitiveFold.ts  ->  2 passed
+deno test test/compact/*.ts                                      -> 144 passed
+deno test test/compact/*.ts test/optimize/*.ts                   -> 154 passed
+```
+
+## Test Plan
+
+- Added `test/compact/CompactCreatureConstantTransitiveFold.ts` (transitive
+  collapse + negative no-collapse).
+- Ran the full `compact` and `optimize` suites — no regressions.
+- `./quality.sh` (fmt, lint, type-check, tests) green.

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -18,6 +18,7 @@ import { assertValidSynapseReferences } from "@architecture/AssertValidSynapseRe
 import { mergeParallelIdentityBridges } from "@compact/ParallelIdentityMerge.ts";
 import { mergeParallelBridges } from "@compact/ParallelBridgeMerge.ts";
 import { simplifyLargeWeights } from "@compact/SimplifyLargeWeights.ts";
+import { foldConstants } from "@compact/ConstantFold.ts";
 import { removeBackwardSynapses } from "@compact/RemoveBackwardSynapses.ts";
 import { mergeTagsByNameValue } from "@utils/TagUtils.ts";
 import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
@@ -297,6 +298,20 @@ export function compactCreature(
         break; // restart the loop after each mutation
       }
     }
+  }
+
+  // Issue #3035: Transitive constant fold + zero-varying-input collapse.
+  // Fold `type:"constant"` producers (and hidden neurons that have become
+  // effectively constant) into their non-aggregate consumers' biases, iterating
+  // to a fixpoint so chained constant subgraphs collapse fully. Lossless, so it
+  // belongs to the safe variant.
+  const constantFoldResult = foldConstants(compactCreature);
+  if (constantFoldResult.changed) {
+    assertValidSynapseReferences(
+      compactCreature,
+      "after constant fold",
+    );
+    didCompact = true;
   }
 
   // Issue #1947: Merge parallel IDENTITY bridge neurons that all connect

--- a/src/compact/ConstantFold.ts
+++ b/src/compact/ConstantFold.ts
@@ -1,0 +1,269 @@
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import type { NeuronExport } from "@architecture/NeuronInterfaces.ts";
+import type { SynapseExport } from "@architecture/SynapseInterfaces.ts";
+import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
+import { Activations } from "@methods/activations/Activations.ts";
+import type { ActivationInterface } from "@methods/activations/ActivationInterface.ts";
+import { isAggregationSquash } from "@methods/activations/SquashUtils.ts";
+
+/**
+ * Result of folding constant neurons.
+ */
+export interface ConstantFoldResult {
+  /** Whether any fold/collapse occurred. */
+  changed: boolean;
+  /** Number of neurons removed (constant producers + collapsed hidden). */
+  removedNeurons: number;
+  /** Number of synapses removed. */
+  removedSynapses: number;
+}
+
+/**
+ * Duck-type guard: the activation implements a scalar `squash(x)` method.
+ *
+ * Aggregate activations (IF, MAXIMUM, MINIMUM, HYPOT, HYPOTv2) operate over
+ * multiple inputs and do NOT expose a single-argument squash, so they are
+ * excluded by this guard.
+ */
+function hasScalarSquash(
+  activation: unknown,
+): activation is ActivationInterface {
+  return typeof (activation as ActivationInterface).squash === "function";
+}
+
+/**
+ * Fold `type:"constant"` neurons — and hidden neurons that have become
+ * effectively constant — into their additive (non-aggregate) consumers'
+ * biases, iterating to a fixpoint (Issue #3035).
+ *
+ * Two lossless transforms, both belonging to the **safe** compaction variant:
+ *
+ * 1. **Transitive constant fold (fixpoint).** A constant producer `C` emits the
+ *    fixed scalar `C.bias`. For every non-aggregate consumer `B`, the
+ *    contribution `weight · C.bias` is folded into `B.bias` and the synapse is
+ *    removed. When `C` has no remaining consumers it is deleted. Each fold can
+ *    turn another neuron's inputs entirely constant, so the whole pass repeats
+ *    until nothing changes.
+ *
+ * 2. **Zero-varying-input collapse.** When a hidden neuron `H` has **zero**
+ *    genuinely varying inputs (every input is constant, or it has no inputs at
+ *    all), its output is the fixed scalar `squash(H.pre)` where
+ *    `H.pre = Σ(weightᵢ · constantᵢ) + H.bias`. The squash is applied via the
+ *    existing activation lookup (never hand-rolled). That scalar is then folded
+ *    downstream exactly like a constant producer and `H` is deleted.
+ *
+ * Safety rules:
+ * - Only fold into **non-aggregate** consumers (`!isAggregationSquash`).
+ *   Aggregate squashes treat each inbound value specially, so a constant cannot
+ *   be folded into their bias. A producer feeding an aggregate consumer is
+ *   retained for that consumer.
+ * - A neuron is only treated as effectively constant when it has **zero**
+ *   varying inputs. Any genuinely varying input means the neuron is never
+ *   constant.
+ * - Only non-aggregate squashes (those exposing a scalar `squash(x)`) are
+ *   collapsed; aggregate hidden neurons are left untouched.
+ * - Never fold away an output neuron's last inbound synapse — outputs must keep
+ *   at least one inbound connection for structural validity.
+ * - Frozen consumers/synapses (Issue #1861) are never modified.
+ *
+ * The export is modified in place.
+ *
+ * @param creatureExport - The CreatureExport to fold (modified in place).
+ * @returns Counts of removed neurons/synapses and whether anything changed.
+ */
+export function foldConstants(
+  creatureExport: CreatureExport,
+): ConstantFoldResult {
+  normaliseCreatureExport(creatureExport);
+
+  let removedNeurons = 0;
+  let removedSynapses = 0;
+  let changedAny = false;
+
+  // Outer fixpoint loop: each iteration folds at most one producer, then
+  // rebuilds its working maps so a freshly exposed constant is picked up.
+  for (;;) {
+    const neuronMap = new Map<number, NeuronExport>();
+    for (const n of creatureExport.neurons) {
+      neuronMap.set(n.id!, n);
+    }
+
+    const inward = new Map<number, SynapseExport[]>();
+    const outward = new Map<number, SynapseExport[]>();
+    for (const s of creatureExport.synapses) {
+      const inList = inward.get(s.toId!);
+      if (inList) inList.push(s);
+      else inward.set(s.toId!, [s]);
+
+      const outList = outward.get(s.fromId!);
+      if (outList) outList.push(s);
+      else outward.set(s.fromId!, [s]);
+    }
+
+    const constValue = computeConstantValues(
+      creatureExport.neurons,
+      inward,
+    );
+
+    const folded = foldOneProducer(
+      creatureExport,
+      neuronMap,
+      inward,
+      outward,
+      constValue,
+    );
+
+    if (!folded) break;
+
+    removedNeurons += folded.removedNeurons;
+    removedSynapses += folded.removedSynapses;
+    changedAny = true;
+    delete creatureExport.memetic;
+  }
+
+  return { changed: changedAny, removedNeurons, removedSynapses };
+}
+
+/**
+ * Compute, to a fixpoint, the scalar value of every effectively-constant
+ * neuron. A `constant`-type neuron's value is its bias. A non-aggregate hidden
+ * neuron whose every input is constant (or which has no inputs) is constant
+ * with value `squash(Σ(weightᵢ · constantᵢ) + bias)`.
+ */
+function computeConstantValues(
+  neurons: NeuronExport[],
+  inward: Map<number, SynapseExport[]>,
+): Map<number, number> {
+  const constValue = new Map<number, number>();
+
+  for (const n of neurons) {
+    if (n.type === "constant") {
+      constValue.set(n.id!, n.bias);
+    }
+  }
+
+  for (;;) {
+    let added = false;
+    for (const n of neurons) {
+      if (n.type !== "hidden") continue;
+      if (constValue.has(n.id!)) continue;
+      if (!n.squash || isAggregationSquash(n.squash)) continue;
+
+      const ins = inward.get(n.id!) ?? [];
+
+      let pre = n.bias;
+      let allConst = true;
+      for (const s of ins) {
+        const v = constValue.get(s.fromId!);
+        if (v === undefined) {
+          allConst = false;
+          break;
+        }
+        pre += s.weight * v;
+      }
+      if (!allConst) continue;
+
+      const activation = Activations.find(n.squash);
+      if (!hasScalarSquash(activation)) continue;
+
+      constValue.set(n.id!, activation.squash(pre));
+      added = true;
+    }
+    if (!added) break;
+  }
+
+  return constValue;
+}
+
+/**
+ * Fold a single constant producer into its non-aggregate consumers. Returns the
+ * removal counts when a fold happened, or `undefined` when nothing could be
+ * folded (the fixpoint has been reached).
+ */
+function foldOneProducer(
+  creatureExport: CreatureExport,
+  neuronMap: Map<number, NeuronExport>,
+  inward: Map<number, SynapseExport[]>,
+  outward: Map<number, SynapseExport[]>,
+  constValue: Map<number, number>,
+): { removedNeurons: number; removedSynapses: number } | undefined {
+  for (const producer of creatureExport.neurons) {
+    const value = constValue.get(producer.id!);
+    if (value === undefined) continue;
+    // Never fold/delete an output; disconnected producers are left to the
+    // dedicated orphan cleanup.
+    if (producer.type === "output") continue;
+    if (producer.frozen) continue;
+
+    const outs = outward.get(producer.id!) ?? [];
+    if (outs.length === 0) continue;
+
+    // Group the foldable synapses by consumer so output last-inbound protection
+    // can be applied per consumer.
+    const foldableByConsumer = new Map<number, SynapseExport[]>();
+    for (const s of outs) {
+      if (s.type) continue; // typed synapses (eg IF roles) are never folded
+      if (s.frozen) continue;
+      const consumer = neuronMap.get(s.toId!);
+      if (!consumer) continue;
+      if (consumer.frozen) continue;
+      if (isAggregationSquash(consumer.squash)) continue;
+
+      const list = foldableByConsumer.get(s.toId!);
+      if (list) list.push(s);
+      else foldableByConsumer.set(s.toId!, [s]);
+    }
+
+    if (foldableByConsumer.size === 0) continue;
+
+    const foldSet = new Set<SynapseExport>();
+    for (const [consumerId, synapses] of foldableByConsumer) {
+      const consumer = neuronMap.get(consumerId)!;
+      let toFold = synapses;
+
+      // Structural validity: an output must keep at least one inbound synapse.
+      if (consumer.type === "output") {
+        const totalInbound = (inward.get(consumerId) ?? []).length;
+        if (totalInbound - synapses.length < 1) {
+          // Retain one synapse unfolded so the output keeps an inbound edge.
+          toFold = synapses.slice(1);
+        }
+      }
+
+      for (const s of toFold) {
+        consumer.bias += s.weight * value;
+        foldSet.add(s);
+      }
+    }
+
+    if (foldSet.size === 0) continue;
+
+    let removedSynapses = 0;
+    let removedNeurons = 0;
+
+    const before = creatureExport.synapses.length;
+    creatureExport.synapses = creatureExport.synapses.filter(
+      (s) => !foldSet.has(s),
+    );
+    removedSynapses += before - creatureExport.synapses.length;
+
+    // Delete the producer when it has no remaining outbound synapses, removing
+    // any now-orphaned inbound synapses along with it.
+    const remainingOut = outs.filter((s) => !foldSet.has(s));
+    if (remainingOut.length === 0) {
+      const beforeIncident = creatureExport.synapses.length;
+      creatureExport.synapses = creatureExport.synapses.filter(
+        (s) => s.fromId !== producer.id! && s.toId !== producer.id!,
+      );
+      removedSynapses += beforeIncident - creatureExport.synapses.length;
+      creatureExport.neurons = creatureExport.neurons.filter(
+        (n) => n.id !== producer.id!,
+      );
+      removedNeurons += 1;
+    }
+
+    return { removedNeurons, removedSynapses };
+  }
+
+  return undefined;
+}

--- a/test/compact/CompactCreatureConstantTransitiveFold.ts
+++ b/test/compact/CompactCreatureConstantTransitiveFold.ts
@@ -1,0 +1,151 @@
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import { compactCreature } from "@compact/CompactCreature.ts";
+import { calculate } from "@architecture/Score.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+const GROWTH_COST = 0.0001;
+
+function makeData(inputs: number): number[][] {
+  const data: number[][] = [];
+  for (let i = 500; i--;) {
+    const row: number[] = [];
+    for (let j = 0; j < inputs; j++) {
+      row.push(Math.random() * 2 - 1);
+    }
+    data.push(row);
+  }
+  return data;
+}
+
+function assertOutputsPreserved(
+  before: Creature,
+  after: Creature,
+  data: number[][],
+  output: number,
+) {
+  for (const row of data) {
+    const expected = before.activate(new Float32Array(row), false);
+    const actual = after.activate(new Float32Array(row), false);
+    for (let o = 0; o < output; o++) {
+      assertAlmostEquals(
+        actual[o],
+        expected[o],
+        0.000_001,
+        `output ${o}: actual ${actual[o]}, expected ${expected[o]}`,
+      );
+    }
+  }
+}
+
+Deno.test(
+  "compactCreature collapses a constant -> hidden -> output subgraph to a fixpoint",
+  async () => {
+    await initWasmForTests();
+
+    // input-0 (varying) -----------------------------> output-0
+    // const-c (0.5) --w0.5--> hidden-h (LOGISTIC) --w0.5--> output-0
+    //
+    // Folding const-c into hidden-h leaves hidden-h with zero varying inputs,
+    // which then collapses into output-0. The whole constant-only chain should
+    // disappear while output-0 keeps its genuinely varying input.
+    const json: CreatureExport = {
+      semanticVersion: "4.0.0",
+      forwardOnly: true,
+      input: 1,
+      output: 1,
+      neurons: [
+        { type: "constant", uuid: "const-c", bias: 0.5 },
+        { type: "hidden", uuid: "hidden-h", squash: "LOGISTIC", bias: 0.2 },
+        { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+      ],
+      synapses: [
+        { fromUUID: "const-c", toUUID: "hidden-h", weight: 0.5 },
+        { fromUUID: "hidden-h", toUUID: "output-0", weight: 0.5 },
+        { fromUUID: "input-0", toUUID: "output-0", weight: 0.6 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(json, false);
+    creature.validate();
+
+    const data = makeData(1);
+
+    const compacted = compactCreature(creature, false);
+    assert(compacted !== undefined, "should have compacted");
+    creatureValidate(compacted!, { forwardOnly: true });
+
+    // The whole constant-only subgraph collapsed.
+    assertEquals(
+      compacted!.neurons.some((n) => n.uuid === "const-c"),
+      false,
+      "constant neuron should be folded away",
+    );
+    assertEquals(
+      compacted!.neurons.some((n) => n.uuid === "hidden-h"),
+      false,
+      "constant-fed hidden neuron should collapse",
+    );
+
+    assertOutputsPreserved(creature, compacted!, data, 1);
+
+    // Score must be equal-or-higher (fewer neurons/synapses, identical output).
+    const beforeScore = calculate(creature, 0, GROWTH_COST);
+    const afterScore = calculate(compacted!, 0, GROWTH_COST);
+    assert(
+      afterScore >= beforeScore - 1e-9,
+      `score regressed: before ${beforeScore}, after ${afterScore}`,
+    );
+  },
+);
+
+Deno.test(
+  "compactCreature does NOT collapse a hidden neuron with a varying input",
+  async () => {
+    await initWasmForTests();
+
+    // const-c (0.4) --w0.5--\
+    //                         hidden-h (LOGISTIC) --w0.5--> output-0
+    // input-0 (varying) --w0.7--/
+    //
+    // hidden-h has a genuinely varying input, so it is NEVER constant and must
+    // survive compaction (the constant input may still be folded into its bias).
+    const json: CreatureExport = {
+      semanticVersion: "4.0.0",
+      forwardOnly: true,
+      input: 1,
+      output: 1,
+      neurons: [
+        { type: "constant", uuid: "const-c", bias: 0.4 },
+        { type: "hidden", uuid: "hidden-h", squash: "LOGISTIC", bias: 0.2 },
+        { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+      ],
+      synapses: [
+        { fromUUID: "const-c", toUUID: "hidden-h", weight: 0.5 },
+        { fromUUID: "input-0", toUUID: "hidden-h", weight: 0.7 },
+        { fromUUID: "hidden-h", toUUID: "output-0", weight: 0.5 },
+      ],
+    };
+
+    const creature = Creature.fromJSON(json, false);
+    creature.validate();
+
+    const data = makeData(1);
+
+    const compacted = compactCreature(creature, false);
+
+    // Compaction may fold the constant input into the hidden bias, but the
+    // hidden neuron itself must remain because it has a varying input.
+    const result = compacted ?? creature;
+    creatureValidate(result, { forwardOnly: true });
+    assertEquals(
+      result.neurons.some((n) => n.uuid === "hidden-h"),
+      true,
+      "hidden neuron with a varying input must not be collapsed",
+    );
+
+    assertOutputsPreserved(creature, result, data, 1);
+  },
+);


### PR DESCRIPTION
# Compaction: transitive constant fold + zero-varying-input collapse (safe variant)

## Summary

Extends the safe compaction variant with a **transitive constant fold** that
iterates to a **fixpoint** and a **zero-varying-input neuron collapse**. Both
transforms are lossless, so they belong to the safe variant. Closes #3035.

A new module `src/compact/ConstantFold.ts` exports `foldConstants()`, wired into
`compactCreature()` (`src/compact/CompactCreature.ts`) just before the parallel
bridge merges.

What it does:

- **Transitive fold (fixpoint).** A `type:"constant"` producer `C` emits the
  fixed scalar `C.bias`. For every non-aggregate consumer `B`, the contribution
  `weight · C.bias` is folded into `B.bias` and the synapse removed; when `C`
  has no consumers left it is deleted. Each fold can turn another neuron's
  inputs entirely constant, so the pass repeats until nothing changes.
- **Zero-varying-input collapse.** When a hidden neuron `H` has zero genuinely
  varying inputs (every input constant, or none at all), its output is the fixed
  scalar `squash(H.pre)` where `H.pre = Σ(weightᵢ · constantᵢ) + H.bias`. The
  squash is applied via the existing `Activations.find()` lookup (never
  hand-rolled). That scalar is folded downstream like a constant and `H` deleted.

Safety rules honoured:

- Only folds into **non-aggregate** consumers (`!isAggregationSquash`); a
  producer feeding an aggregate consumer (MAXIMUM/MINIMUM/IF/HYPOT/HYPOTv2) is
  retained for that consumer.
- A neuron is only treated as constant when it has **zero** varying inputs — any
  varying input means it is never constant.
- Only non-aggregate squashes (those exposing a scalar `squash(x)`) collapse.
- Never folds away an output neuron's last inbound synapse (structural validity).
- Frozen consumers/synapses (Issue #1861) are never modified.
- `didCompact` is set and `assertValidSynapseReferences` is asserted after the
  fold, consistent with the surrounding passes.

```mermaid
flowchart LR
    subgraph Before
      C[const c] -->|w| H[hidden H<br/>LOGISTIC]
      H -->|w| O[output O]
      I[input 0] -->|w| O
    end
    subgraph After
      I2[input 0] -->|w| O2[output O<br/>bias absorbs c and H]
    end
    Before -->|foldConstants fixpoint| After
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified by unit tests
exercising real `compactCreature()` activation behaviour over random inputs.

New tests (`test/compact/CompactCreatureConstantTransitiveFold.ts`):

- **Transitive collapse:** `const → hidden(LOGISTIC) → output` with a separate
  varying input on the output. Asserts both the constant and the constant-fed
  hidden neuron disappear, outputs are preserved within `1e-6`, and the score is
  equal-or-higher.
- **Negative test:** a hidden neuron with one varying input and one constant
  input is **not** collapsed (it survives compaction); outputs preserved.

```
deno test test/compact/CompactCreatureConstantTransitiveFold.ts  ->  2 passed
deno test test/compact/*.ts                                      -> 144 passed
deno test test/compact/*.ts test/optimize/*.ts                   -> 154 passed
```

## Test Plan

- Added `test/compact/CompactCreatureConstantTransitiveFold.ts` (transitive
  collapse + negative no-collapse).
- Ran the full `compact` and `optimize` suites — no regressions.
- `./quality.sh` (fmt, lint, type-check, tests) green.



## Milestone
This PR is part of the **#3029 Compaction: return a safe constant-fold and an aggressive prune variant** milestone and targets the `milestone/3029-compaction-return-a-safe-constant-fold-and-an` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqhga07w-5d8f2f`<!-- vibe-worker-issue-3035 -->