### PR TITLE
Discovery #3027: integration guard for heap-abort signal across wire path

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3027.md
+++ b/docs/archive/pr-summaries/pr-summary-3027.md
@@ -1,0 +1,80 @@
+# Discovery #3027: integration guard for the heap-abort signal
+
+## Summary
+
+The discovery worker runs on a small default ~269 MB V8 heap, so after the
+recording phase the V8 fraction sits near CRITICAL even when the host has ample
+off-heap (native/Rust RSS) headroom. The off-heap-aware guard (#3025) already
+prevents that false positive from aborting analysis. This issue **closes the
+loop on the observable signal**: it proves end-to-end that
+`heapAbortedAtExtensionBoundary` (and therefore the `"heap_critical_skip"`
+training outcome) is emitted **only** for a genuine budget-exhaustion abort, and
+adds the **integration guard** so the regression cannot silently return.
+
+What changed:
+
+- **Extracted `AnalysisExtensionBoundary.ts`** — a single source of truth for
+  the empty `DiscoverResult` shape and the heap-abort boundary decision that
+  `DataRecorder.recordFiles()` previously built inline in three duplicated
+  branches. `resolveHeapAbortBoundary()` is the production function the
+  integration test drives, so the test exercises real code rather than
+  re-implementing the rule.
+- **Refactored `DataRecorder`** to use `buildEmptyDiscoverResult()` (Rust
+  unavailable / recording failed) and `resolveHeapAbortBoundary()` (heap-abort
+  branch). Behaviour is unchanged; duplication is removed.
+- **Added the integration guard** — `DiscoveryHeapAbortBoundaryIntegration.ts`
+  composes the _real_ production functions across the whole wire path and
+  asserts the explicit #3022 rule.
+
+No guard-rule change lives here (that is #3025) and no existing tests were
+removed or disabled.
+
+Closes #3027.
+
+## Evidence
+
+This is a backend/library change with no web interface — evidence is the new
+tests plus the existing suite passing (`7315 passed | 0 failed`).
+
+### Signal wire path covered end-to-end
+
+```mermaid
+flowchart LR
+    A["resolveHeapAbortBoundary<br/>(DataRecorder boundary)"] -->|DiscoverResult| B["buildDiscoverResponsePayload<br/>(WorkerProcessor wire)"]
+    B -->|payload| C["chooseDiscoveryCompleteOutcome<br/>(DiscoveryOutcome)"]
+    C --> D{"outcome"}
+    D -->|"budget headroom"| E["no_change<br/>(signal unset)"]
+    D -->|"genuine exhaustion / legacy"| F["heap_critical_skip<br/>(signal=true)"]
+```
+
+The integration test asserts the explicit rule as an assertion (not a comment):
+_either_ the serialized worker heap sample is below CRITICAL at the boundary,
+_or_ the guard does not abort while configured native-budget headroom exists —
+in both legs the wire signal is unset and the outcome is not
+`"heap_critical_skip"`.
+
+### Manual acceptance checklist (external GRQ runner)
+
+- [ ] GRQ-scale discovery (520 binary files, 5% sample on a 24 GB host) no
+      longer logs `heap CRITICAL at extension boundary` immediately after a
+      normal recording phase. (Operational; runs in the external runner, not
+      in-repo CI.)
+
+## Test Plan
+
+- **`test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts`**
+  (new):
+  - worker-default-heap with native-budget headroom → no abort, wire signal
+    `undefined`, outcome `"no_change"` (the #3022 false-positive case).
+  - genuine budget exhaustion (RSS > budget) → field set, signal survives the
+    worker serialization boundary, outcome `"heap_critical_skip"`.
+  - legacy V8-only config (no native budget) → still aborts on CRITICAL across
+    the wire (negative-path / no-regression).
+- **`test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts`** (new):
+  unit coverage for `buildEmptyDiscoverResult` (flag absent / set / false) and
+  `resolveHeapAbortBoundary` (not-critical → null, legacy CRITICAL → aborted,
+  budget headroom → null, monitoring disabled → null).
+- Existing `AnalysisHeapGuard.ts`, `DiscoveryWorkerHeapLimit.ts`,
+  `DiscoveryOutcome.ts`, and `WorkerProcessor.ts` tests still pass against the
+  refactored `DataRecorder`.
+- Full `./quality.sh` passes (fmt, lint, type-check, 7315 tests).

--- a/src/architecture/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts
@@ -1,0 +1,99 @@
+/**
+ * Analysis-extension boundary result builder (Issue #3027).
+ *
+ * `DataRecorder.recordFiles()` returns an empty {@link DiscoverResult} in
+ * three places — Rust unavailable, recording phase failed, and the heap-aware
+ * extension guard abort. The shapes were duplicated inline; this module gives
+ * a single source of truth so the empty-result contract (every candidate field
+ * `undefined`) cannot drift between branches.
+ *
+ * Crucially it also exposes the heap-abort decision as one production function
+ * ({@link resolveHeapAbortBoundary}) so the record→boundary→wire→outcome path
+ * can be integration-tested end-to-end against real production code, rather
+ * than re-implementing the rule in a test (Issue #3022 acceptance criteria).
+ *
+ * The decision delegates to {@link checkAnalysisHeapAbort}, which since Issue
+ * #3025 is off-heap (RSS) aware: a worker-V8-only CRITICAL sample no longer
+ * aborts while the configured native budget still has headroom. So the
+ * `heapAbortedAtExtensionBoundary` signal is only set for a genuine
+ * budget-exhaustion abort — exactly the false-positive this issue guards.
+ *
+ * @module
+ */
+
+import type { RequiredMemoryConfig } from "@config/MemoryConfig.ts";
+import type { MemoryUsageProvider } from "@neat/MemoryMonitor.ts";
+import type { Logger } from "@utils/Logger.ts";
+import type { DiscoverResult } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import { checkAnalysisHeapAbort } from "@architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts";
+
+/** Options for {@link buildEmptyDiscoverResult}. */
+export interface EmptyDiscoverResultOptions {
+  /**
+   * When `true`, marks the empty result as a heap-driven analysis-extension
+   * abort so the upstream pipeline can emit `"heap_critical_skip"` rather than
+   * `"no_change"` (Issue #2737). Omitted/`false` for the Rust-unavailable and
+   * recording-failed branches.
+   */
+  heapAbortedAtExtensionBoundary?: boolean;
+}
+
+/**
+ * Build the canonical empty {@link DiscoverResult}: every candidate field is
+ * `undefined` because the analysis loop never produced candidates. Single
+ * source of truth shared by every early-return branch in `DataRecorder`.
+ *
+ * @param ID - The discovery ID to echo back on the result.
+ * @param options - Optional structured signals (e.g. the heap-abort flag).
+ */
+export function buildEmptyDiscoverResult(
+  ID: string,
+  options: EmptyDiscoverResultOptions = {},
+): DiscoverResult {
+  const result: DiscoverResult = {
+    ID,
+    addHelpfulSynapses: undefined,
+    addHelpfulNeurons: undefined,
+    coordinatedStructuralCandidates: undefined,
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
+    candidateSquashes: undefined,
+  };
+  // Only attach the signal when explicitly requested so happy-path and
+  // non-heap early returns leave the field `undefined` on the wire.
+  if (options.heapAbortedAtExtensionBoundary) {
+    result.heapAbortedAtExtensionBoundary = true;
+  }
+  return result;
+}
+
+/**
+ * Make the analysis-extension boundary decision (Issue #2594/#2737/#3025).
+ *
+ * Samples the heap via {@link checkAnalysisHeapAbort} (the off-heap-aware
+ * guard) and, when it aborts, returns the empty {@link DiscoverResult} carrying
+ * `heapAbortedAtExtensionBoundary: true`. Returns `null` when analysis may
+ * proceed — i.e. the guard did not abort, including the worker-default-heap
+ * case where the V8 fraction is CRITICAL but the native budget still has
+ * headroom. In that case the signal is left unset so downstream telemetry does
+ * not mislabel a healthy iteration as `"heap_critical_skip"`.
+ *
+ * @param ID - The discovery ID (used for the result and the guard log line).
+ * @param memoryConfig - Resolved memory config (thresholds + native budget).
+ * @param logger - Logger for the guard's grep-friendly abort line.
+ * @param provider - Optional injected heap sample source (tests).
+ * @returns The abort result, or `null` to continue into analysis.
+ */
+export function resolveHeapAbortBoundary(
+  ID: string,
+  memoryConfig: RequiredMemoryConfig,
+  logger: Logger,
+  provider?: MemoryUsageProvider,
+): DiscoverResult | null {
+  const heapAbort = checkAnalysisHeapAbort(ID, memoryConfig, logger, provider);
+  if (!heapAbort.abort) return null;
+  return buildEmptyDiscoverResult(ID, {
+    heapAbortedAtExtensionBoundary: true,
+  });
+}

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
@@ -28,7 +28,10 @@ import {
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts";
 import { runRecordingPhase } from "@architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts";
 import { runAnalysisLoop } from "@architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts";
-import { checkAnalysisHeapAbort } from "@architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts";
+import {
+  buildEmptyDiscoverResult,
+  resolveHeapAbortBoundary,
+} from "@architecture/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 
@@ -236,16 +239,7 @@ export class DataRecorder {
         );
       }
       // Return empty result - discovery is skipped
-      return {
-        ID: this.ID,
-        addHelpfulSynapses: undefined,
-        addHelpfulNeurons: undefined,
-        coordinatedStructuralCandidates: undefined,
-        removeHarmfulSynapse: undefined,
-        removeHarmfulNeurons: undefined,
-        removalCandidates: undefined,
-        candidateSquashes: undefined,
-      };
+      return buildEmptyDiscoverResult(this.ID);
     }
 
     const binaryFiles = await this.getBinaryFiles(dataDir);
@@ -337,16 +331,7 @@ export class DataRecorder {
       fileProcessTime = perfStats.fileProcessingTime;
 
       if (!recordingSuccess) {
-        return {
-          ID: this.ID,
-          addHelpfulSynapses: undefined,
-          addHelpfulNeurons: undefined,
-          coordinatedStructuralCandidates: undefined,
-          removeHarmfulSynapse: undefined,
-          removeHarmfulNeurons: undefined,
-          removalCandidates: undefined,
-          candidateSquashes: undefined,
-        };
+        return buildEmptyDiscoverResult(this.ID);
       }
 
       // Issue #3026: Release record-phase JS retainers before sampling the
@@ -369,28 +354,19 @@ export class DataRecorder {
       // and was not enough. Skip the extension entirely and reuse the
       // partial-result path so the caller gets the same empty
       // DiscoverResult shape as the recordingSuccess === false branch.
-      const heapAbort = checkAnalysisHeapAbort(
+      // Issue #2737/#3025: Surface a genuine heap-driven abort as a structured
+      // field on the DiscoverResult so the upstream training event pipeline can
+      // emit a `"heap_critical_skip"` outcome instead of indistinguishably
+      // reporting `"no_change"`. The guard is off-heap (RSS) aware, so a
+      // worker-default-heap CRITICAL with native-budget headroom returns `null`
+      // here (analysis continues, signal stays unset) — no false positive.
+      const heapAbortResult = resolveHeapAbortBoundary(
         this.ID,
         this.config.memory,
         getLogger(),
       );
-      if (heapAbort.abort) {
-        // Issue #2737: Surface the heap-driven abort as a structured field on
-        // the DiscoverResult so the upstream training event pipeline can emit
-        // a `"heap_critical_skip"` outcome instead of indistinguishably
-        // reporting `"no_change"`. The candidate arrays are still `undefined`
-        // because the analysis loop never ran.
-        return {
-          ID: this.ID,
-          addHelpfulSynapses: undefined,
-          addHelpfulNeurons: undefined,
-          coordinatedStructuralCandidates: undefined,
-          removeHarmfulSynapse: undefined,
-          removeHarmfulNeurons: undefined,
-          removalCandidates: undefined,
-          candidateSquashes: undefined,
-          heapAbortedAtExtensionBoundary: true,
-        };
+      if (heapAbortResult) {
+        return heapAbortResult;
       }
 
       // Extend timeout for analysis phase (clamped to the hard deadline)

--- a/test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the analysis-extension boundary helpers (Issue #3027).
+ *
+ * `buildEmptyDiscoverResult` is the single source of truth for the empty
+ * `DiscoverResult` shape returned by every early-return branch in
+ * `DataRecorder`; `resolveHeapAbortBoundary` makes the off-heap-aware abort
+ * decision. These tests pin the contract directly; the wire-level end-to-end
+ * behaviour is covered by `DiscoveryHeapAbortBoundaryIntegration.ts`.
+ */
+import { assert, assertEquals } from "@std/assert";
+import {
+  buildEmptyDiscoverResult,
+  resolveHeapAbortBoundary,
+} from "@architecture/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts";
+import { DEFAULT_MEMORY_CONFIG } from "@config/MemoryConfig.ts";
+import type { RequiredMemoryConfig } from "@config/MemoryConfig.ts";
+import type { Logger } from "@utils/Logger.ts";
+import type { MemoryUsageSample } from "@neat/MemoryMonitor.ts";
+
+const MB = 1024 * 1024;
+
+function noopLogger(): Logger {
+  return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+}
+
+function provider(sample: MemoryUsageSample): () => MemoryUsageSample {
+  return () => sample;
+}
+
+Deno.test("buildEmptyDiscoverResult: every candidate field is undefined, no heap flag", () => {
+  const result = buildEmptyDiscoverResult("disc-1");
+  assertEquals(result.ID, "disc-1");
+  assertEquals(result.addHelpfulSynapses, undefined);
+  assertEquals(result.addHelpfulNeurons, undefined);
+  assertEquals(result.coordinatedStructuralCandidates, undefined);
+  assertEquals(result.removeHarmfulSynapse, undefined);
+  assertEquals(result.removeHarmfulNeurons, undefined);
+  assertEquals(result.removalCandidates, undefined);
+  assertEquals(result.candidateSquashes, undefined);
+  // The flag must be absent (not `false`) so happy-path wire shapes match.
+  assertEquals(result.heapAbortedAtExtensionBoundary, undefined);
+  assert(!("heapAbortedAtExtensionBoundary" in result));
+});
+
+Deno.test("buildEmptyDiscoverResult: heap-abort option sets the structured flag", () => {
+  const result = buildEmptyDiscoverResult("disc-2", {
+    heapAbortedAtExtensionBoundary: true,
+  });
+  assertEquals(result.heapAbortedAtExtensionBoundary, true);
+});
+
+Deno.test("buildEmptyDiscoverResult: heap-abort option false leaves the flag unset", () => {
+  const result = buildEmptyDiscoverResult("disc-3", {
+    heapAbortedAtExtensionBoundary: false,
+  });
+  assertEquals(result.heapAbortedAtExtensionBoundary, undefined);
+});
+
+Deno.test("resolveHeapAbortBoundary: returns null when heap is not critical", () => {
+  const decision = resolveHeapAbortBoundary(
+    "disc-4",
+    DEFAULT_MEMORY_CONFIG,
+    noopLogger(),
+    provider({ heapUsed: 50 * MB, heapTotal: 269 * MB }), // ≈0.19, normal
+  );
+  assertEquals(decision, null);
+});
+
+Deno.test("resolveHeapAbortBoundary: returns aborted result on legacy CRITICAL (no native budget)", () => {
+  const decision = resolveHeapAbortBoundary(
+    "disc-5",
+    DEFAULT_MEMORY_CONFIG, // nativeBudgetBytes = 0
+    noopLogger(),
+    provider({ heapUsed: 231 * MB, heapTotal: 269 * MB }), // ≈0.86, critical
+  );
+  assert(decision !== null);
+  assertEquals(decision?.heapAbortedAtExtensionBoundary, true);
+  assertEquals(decision?.ID, "disc-5");
+});
+
+Deno.test("resolveHeapAbortBoundary: native-budget headroom suppresses the abort despite CRITICAL V8 fraction", () => {
+  const config: RequiredMemoryConfig = {
+    ...DEFAULT_MEMORY_CONFIG,
+    nativeBudgetBytes: 20 * 1024 * MB,
+  };
+  const decision = resolveHeapAbortBoundary(
+    "disc-6",
+    config,
+    noopLogger(),
+    provider({
+      heapUsed: 231 * MB,
+      heapTotal: 269 * MB, // ≈0.86, critical V8 fraction
+      rss: 8 * 1024 * MB, // within the 20 GB native budget
+      external: 47 * MB,
+    }),
+  );
+  assertEquals(decision, null);
+});
+
+Deno.test("resolveHeapAbortBoundary: monitoring disabled never aborts", () => {
+  const config: RequiredMemoryConfig = {
+    ...DEFAULT_MEMORY_CONFIG,
+    enabled: false,
+  };
+  const decision = resolveHeapAbortBoundary(
+    "disc-7",
+    config,
+    noopLogger(),
+    provider({ heapUsed: 260 * MB, heapTotal: 269 * MB }), // would be critical
+  );
+  assertEquals(decision, null);
+});

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts
@@ -1,0 +1,239 @@
+/**
+ * Integration guard for the heap-abort signal across the discovery wire path
+ * (Issue #3027, the integration-guard item of #3022).
+ *
+ * ## What this pins down
+ *
+ * The `heapAbortedAtExtensionBoundary` signal originates at the
+ * analysis-extension boundary in `DataRecorder` and travels:
+ *
+ * ```
+ * resolveHeapAbortBoundary  (DataRecorder boundary, AnalysisExtensionBoundary.ts)
+ *   -> buildDiscoverResponsePayload  (worker serialization, WorkerProcessor.ts)
+ *     -> chooseDiscoveryCompleteOutcome  (outcome map, DiscoveryOutcome.ts)
+ * ```
+ *
+ * The existing unit tests cover each hop in isolation. This test composes the
+ * *real* production functions for every hop so a regression at any seam — the
+ * guard, the wire payload, or the outcome map — is caught end-to-end, not just
+ * in-process. It is the structural defence that the #3022 false positive
+ * (`heap_critical_skip` emitted for a worker-default-heap-but-budget-has-
+ * headroom iteration) cannot silently return.
+ *
+ * The only thing mocked is the recording phase: the heap sample is injected via
+ * the same `_setHeapGuardProviderForTests` seam `DataRecorder` reads through, so
+ * no real `Deno.memoryUsage()` or analysis loop runs.
+ *
+ * ## The explicit rule (encoded as assertions, not comments)
+ *
+ * Either the serialized worker heap sample is below CRITICAL at the boundary,
+ * **or** the guard does not abort while configured native-budget headroom
+ * exists. In both legs the wire payload's `heapAbortedAtExtensionBoundary` is
+ * unset and the outcome is not `"heap_critical_skip"`. The negative leg proves
+ * a genuine budget-exhaustion abort still sets the field and yields
+ * `"heap_critical_skip"`.
+ */
+import { assert, assertEquals } from "@std/assert";
+import {
+  _setHeapGuardProviderForTests,
+  type HeapGuardSample,
+  sampleHeapPressure,
+} from "@architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts";
+import { resolveHeapAbortBoundary } from "@architecture/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts";
+import { buildDiscoverResponsePayload } from "@multithreading/workers/WorkerProcessor.ts";
+import { chooseDiscoveryCompleteOutcome } from "@neat/DiscoveryOutcome.ts";
+import { DEFAULT_MEMORY_CONFIG } from "@config/MemoryConfig.ts";
+import type { RequiredMemoryConfig } from "@config/MemoryConfig.ts";
+import type { Logger } from "@utils/Logger.ts";
+import type { MemoryUsageSample } from "@neat/MemoryMonitor.ts";
+import type { DiscoverResult } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+
+const MB = 1024 * 1024;
+
+/**
+ * Worker-shaped post-recording heap sample on the small default ~269 MB worker
+ * V8 heap: ≈231 MB used (≈86%, above the 0.85 critical threshold). The native
+ * RSS sits well within a generous budget — the GRQ-23 false-positive shape.
+ */
+const WORKER_DEFAULT_HEAP_TOTAL = Math.round(269 * MB);
+const POST_RECORDING_HEAP_USED = Math.round(231 * MB);
+
+/** Native (RSS) budget with ample headroom for the worker-default case. */
+const NATIVE_BUDGET = Math.round(20 * 1024 * MB); // ~20 GB host
+const HEALTHY_RSS = Math.round(8 * 1024 * MB); // ~8 GB, within budget
+
+function makeRecordingLogger(): { logger: Logger; warnings: string[] } {
+  const warnings: string[] = [];
+  const logger: Logger = {
+    debug: () => {},
+    info: () => {},
+    warn: (...args) => warnings.push(args.join(" ")),
+    error: () => {},
+  };
+  return { logger, warnings };
+}
+
+function fixedProvider(sample: MemoryUsageSample): () => MemoryUsageSample {
+  return () => sample;
+}
+
+/** Config that makes the guard off-heap (RSS) aware, as on the GRQ host. */
+function budgetAwareConfig(): RequiredMemoryConfig {
+  return { ...DEFAULT_MEMORY_CONFIG, nativeBudgetBytes: NATIVE_BUDGET };
+}
+
+/**
+ * Drive the full record→boundary→wire→outcome pipeline with an injected heap
+ * sample, returning the wire payload's signal and the resolved outcome. Uses
+ * the module seam exactly the way `DataRecorder` reads the heap, so no provider
+ * is threaded through `resolveHeapAbortBoundary` (production read path).
+ */
+function runBoundaryPipeline(
+  sample: MemoryUsageSample,
+  memoryConfig: RequiredMemoryConfig,
+): {
+  abortResult: DiscoverResult | null;
+  wireSignal: boolean | undefined;
+  outcome: string;
+} {
+  try {
+    _setHeapGuardProviderForTests(fixedProvider(sample));
+    const { logger } = makeRecordingLogger();
+
+    // Hop 1: DataRecorder boundary decision (real production function).
+    const abortResult = resolveHeapAbortBoundary(
+      "grq-int",
+      memoryConfig,
+      logger,
+    );
+
+    // A `null` decision means analysis continues; DataRecorder then returns a
+    // happy-path result carrying no heap-abort flag. Model that wire shape.
+    const wireSource: DiscoverResult = abortResult ?? {
+      ID: "grq-int",
+      addHelpfulSynapses: undefined,
+      addHelpfulNeurons: undefined,
+      coordinatedStructuralCandidates: undefined,
+      removeHarmfulSynapse: undefined,
+      removeHarmfulNeurons: undefined,
+      removalCandidates: undefined,
+      candidateSquashes: undefined,
+    };
+
+    // Hop 2: cross the worker serialization boundary (real production function).
+    const payload = buildDiscoverResponsePayload(wireSource);
+
+    // Hop 3: map the serialized signal to a discovery_complete outcome.
+    const outcome = chooseDiscoveryCompleteOutcome({
+      heapAbortedAtExtensionBoundary: payload.heapAbortedAtExtensionBoundary,
+    });
+
+    return {
+      abortResult,
+      wireSignal: payload.heapAbortedAtExtensionBoundary,
+      outcome,
+    };
+  } finally {
+    _setHeapGuardProviderForTests(undefined);
+  }
+}
+
+Deno.test(
+  "DiscoveryHeapAbortBoundaryIntegration: worker-default-heap with native-budget headroom does NOT emit heap_critical_skip across the wire",
+  () => {
+    const config = budgetAwareConfig();
+    const sample: MemoryUsageSample = {
+      heapUsed: POST_RECORDING_HEAP_USED,
+      heapTotal: WORKER_DEFAULT_HEAP_TOTAL,
+      rss: HEALTHY_RSS,
+      external: Math.round(47 * MB),
+    };
+
+    // The explicit #3022 rule, encoded as an assertion: EITHER the serialized
+    // worker heap sample is below CRITICAL at the boundary, OR the guard does
+    // not abort while configured budget headroom exists.
+    const guardSample: HeapGuardSample = sampleHeapPressure(config);
+    const belowCritical = guardSample.usageFraction < config.criticalThreshold;
+    const budgetHeadroom = config.nativeBudgetBytes > 0 &&
+      guardSample.rss <= config.nativeBudgetBytes;
+    assert(
+      belowCritical || budgetHeadroom,
+      "boundary rule violated: heap is CRITICAL AND no native-budget headroom",
+    );
+
+    const { abortResult, wireSignal, outcome } = runBoundaryPipeline(
+      sample,
+      config,
+    );
+
+    // Here the V8 fraction IS critical (proving the off-heap headroom leg is
+    // what keeps the run alive, not a sub-critical sample).
+    assert(
+      guardSample.usageFraction >= config.criticalThreshold,
+      "expected the worker-default V8 fraction to be CRITICAL for this case",
+    );
+    assertEquals(guardSample.pressureLevel, "critical");
+
+    // No abort, no signal on the wire, and not a heap_critical_skip outcome.
+    assertEquals(abortResult, null);
+    assertEquals(wireSignal, undefined);
+    assertEquals(outcome, "no_change");
+    assert(
+      outcome !== "heap_critical_skip",
+      "false positive: healthy budget-headroom iteration mislabelled",
+    );
+  },
+);
+
+Deno.test(
+  "DiscoveryHeapAbortBoundaryIntegration: genuine budget exhaustion still sets the field and yields heap_critical_skip across the wire",
+  () => {
+    const config = budgetAwareConfig();
+    // Same CRITICAL V8 fraction, but RSS now exceeds the native budget — a
+    // genuine OOM that must never be masked.
+    const sample: MemoryUsageSample = {
+      heapUsed: POST_RECORDING_HEAP_USED,
+      heapTotal: WORKER_DEFAULT_HEAP_TOTAL,
+      rss: NATIVE_BUDGET + Math.round(512 * MB),
+      external: Math.round(47 * MB),
+    };
+
+    const { abortResult, wireSignal, outcome } = runBoundaryPipeline(
+      sample,
+      config,
+    );
+
+    assert(abortResult !== null, "expected a genuine budget-exhaustion abort");
+    assertEquals(abortResult?.heapAbortedAtExtensionBoundary, true);
+    // Candidate fields stay undefined — analysis never ran.
+    assertEquals(abortResult?.addHelpfulSynapses, undefined);
+    assertEquals(abortResult?.candidateSquashes, undefined);
+
+    // Signal survives the worker serialization boundary and drives the outcome.
+    assertEquals(wireSignal, true);
+    assertEquals(outcome, "heap_critical_skip");
+  },
+);
+
+Deno.test(
+  "DiscoveryHeapAbortBoundaryIntegration: legacy V8-only config (no native budget) still aborts on CRITICAL across the wire",
+  () => {
+    // nativeBudgetBytes = 0 → off-heap awareness disabled → legacy behaviour:
+    // a CRITICAL worker-default V8 fraction aborts and yields heap_critical_skip.
+    const sample: MemoryUsageSample = {
+      heapUsed: POST_RECORDING_HEAP_USED,
+      heapTotal: WORKER_DEFAULT_HEAP_TOTAL,
+      rss: HEALTHY_RSS,
+      external: Math.round(47 * MB),
+    };
+
+    const { abortResult, wireSignal, outcome } = runBoundaryPipeline(
+      sample,
+      DEFAULT_MEMORY_CONFIG, // nativeBudgetBytes = 0
+    );
+
+    assert(abortResult !== null, "legacy config must still abort on CRITICAL");
+    assertEquals(wireSignal, true);
+    assertEquals(outcome, "heap_critical_skip");
+  },
+);


### PR DESCRIPTION
# Discovery #3027: integration guard for the heap-abort signal

## Summary

The discovery worker runs on a small default ~269 MB V8 heap, so after the
recording phase the V8 fraction sits near CRITICAL even when the host has ample
off-heap (native/Rust RSS) headroom. The off-heap-aware guard (#3025) already
prevents that false positive from aborting analysis. This issue **closes the
loop on the observable signal**: it proves end-to-end that
`heapAbortedAtExtensionBoundary` (and therefore the `"heap_critical_skip"`
training outcome) is emitted **only** for a genuine budget-exhaustion abort, and
adds the **integration guard** so the regression cannot silently return.

What changed:

- **Extracted `AnalysisExtensionBoundary.ts`** — a single source of truth for
  the empty `DiscoverResult` shape and the heap-abort boundary decision that
  `DataRecorder.recordFiles()` previously built inline in three duplicated
  branches. `resolveHeapAbortBoundary()` is the production function the
  integration test drives, so the test exercises real code rather than
  re-implementing the rule.
- **Refactored `DataRecorder`** to use `buildEmptyDiscoverResult()` (Rust
  unavailable / recording failed) and `resolveHeapAbortBoundary()` (heap-abort
  branch). Behaviour is unchanged; duplication is removed.
- **Added the integration guard** — `DiscoveryHeapAbortBoundaryIntegration.ts`
  composes the _real_ production functions across the whole wire path and
  asserts the explicit #3022 rule.

No guard-rule change lives here (that is #3025) and no existing tests were
removed or disabled.

Closes #3027.

## Evidence

This is a backend/library change with no web interface — evidence is the new
tests plus the existing suite passing (`7315 passed | 0 failed`).

### Signal wire path covered end-to-end

```mermaid
flowchart LR
    A["resolveHeapAbortBoundary<br/>(DataRecorder boundary)"] -->|DiscoverResult| B["buildDiscoverResponsePayload<br/>(WorkerProcessor wire)"]
    B -->|payload| C["chooseDiscoveryCompleteOutcome<br/>(DiscoveryOutcome)"]
    C --> D{"outcome"}
    D -->|"budget headroom"| E["no_change<br/>(signal unset)"]
    D -->|"genuine exhaustion / legacy"| F["heap_critical_skip<br/>(signal=true)"]
```

The integration test asserts the explicit rule as an assertion (not a comment):
_either_ the serialized worker heap sample is below CRITICAL at the boundary,
_or_ the guard does not abort while configured native-budget headroom exists —
in both legs the wire signal is unset and the outcome is not
`"heap_critical_skip"`.

### Manual acceptance checklist (external GRQ runner)

- [ ] GRQ-scale discovery (520 binary files, 5% sample on a 24 GB host) no
      longer logs `heap CRITICAL at extension boundary` immediately after a
      normal recording phase. (Operational; runs in the external runner, not
      in-repo CI.)

## Test Plan

- **`test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts`**
  (new):
  - worker-default-heap with native-budget headroom → no abort, wire signal
    `undefined`, outcome `"no_change"` (the #3022 false-positive case).
  - genuine budget exhaustion (RSS > budget) → field set, signal survives the
    worker serialization boundary, outcome `"heap_critical_skip"`.
  - legacy V8-only config (no native budget) → still aborts on CRITICAL across
    the wire (negative-path / no-regression).
- **`test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts`** (new):
  unit coverage for `buildEmptyDiscoverResult` (flag absent / set / false) and
  `resolveHeapAbortBoundary` (not-critical → null, legacy CRITICAL → aborted,
  budget headroom → null, monitoring disabled → null).
- Existing `AnalysisHeapGuard.ts`, `DiscoveryWorkerHeapLimit.ts`,
  `DiscoveryOutcome.ts`, and `WorkerProcessor.ts` tests still pass against the
  refactored `DataRecorder`.
- Full `./quality.sh` passes (fmt, lint, type-check, 7315 tests).



## Milestone
This PR is part of the **#3022 Discovery worker uses default ~270MB V8 heap; AnalysisHeapGuard aborts analysis after recording (GRQ-23 logs)** milestone and targets the `milestone/3022-discovery-worker-uses-default-270mb-v8-heap-a` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqhjj2y8-2c53d5`<!-- vibe-worker-issue-3027 -->