### PR TITLE
Compaction: fold type:"constant" neurons into additive consumers (safe variant) (#3034)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3034.md
+++ b/docs/archive/pr-summaries/pr-summary-3034.md
@@ -1,0 +1,73 @@
+# Compaction: fold `type:"constant"` neurons into additive consumers (safe variant)
+
+## Summary
+
+Adds the production-derived regression fixtures and tests that lock in the
+**safe constant fold** behaviour for `compactCreature`. Closes #3034.
+
+The behaviour-preserving fold itself already lives in
+`src/compact/ConstantFold.ts` (`foldConstants`, wired into
+`src/compact/CompactCreature.ts`): a `type:"constant"` neuron emits the fixed
+scalar `bias`, so for every **non-aggregate** consumer `B` the contribution
+`weight · constant.bias` is folded into `B.bias` and the synapse is dropped;
+once the constant has no remaining outbound synapses it is removed, while a
+constant feeding an aggregate consumer (`MAXIMUM`/`MINIMUM`/`IF`/`HYPOT`/
+`HYPOTv2`) is retained. This issue lands the **TDD fixtures** the acceptance
+criteria require — two trimmed subgraphs drawn from the production creature
+cited in #3029 — proving the safe fold on real network shapes.
+
+```mermaid
+flowchart LR
+    subgraph Before
+      C1[constant<br/>bias 0.5] -- w0.5 --> H1[HARD_TANH<br/>bias 0.2]
+      I0[input-0] -- w0.7 --> H1
+      H1 --> O1[output-0]
+    end
+    subgraph After
+      I0b[input-0] -- w0.7 --> H2[HARD_TANH<br/>bias 0.45]
+      H2 --> O2[output-0]
+    end
+    Before -->|fold weight·bias into consumer bias, drop synapse, delete constant| After
+```
+
+## Evidence
+
+Backend/compaction change — no UI to screenshot. Verified by unit tests that
+call the real `compactCreature` pipeline and assert on folded biases, dropped
+synapses, retained constants, output equivalence (~1e-6) and non-regressing
+score.
+
+New trimmed fixtures vendored into `test/data/`:
+
+- `constant-fold-full-removal.json` — constant `legacy-neuron-1762683495`
+  feeds only a `HARD_TANH` hidden neuron (`533d8616-…`).
+- `constant-fold-partial-if.json` — constant `neuron-132866057` feeds an `IF`
+  (aggregate) consumer plus a non-`IF` consumer.
+
+Test run:
+
+```
+running 2 tests from ./test/compact/CompactCreatureConstantFold.ts
+... full removal ... ok
+... partial fold ... ok
+ok | 2 passed | 0 failed
+```
+
+Full `./quality.sh` is green apart from a pre-existing stochastic flake
+(`test/mutate/ModBiasRegularisation.ts` — a random 221-vs-279 L2 outcome,
+unrelated to this change); it passes on re-run.
+
+## Test Plan
+
+Added `test/compact/CompactCreatureConstantFold.ts`:
+
+1. **Full removal (HARD_TANH-only):** the constant folds into the HARD_TANH
+   bias (`0.2 + 0.5·0.5 = 0.45`), its synapse is dropped, the constant is
+   deleted, the HARD_TANH neuron survives (it keeps a varying input), outputs
+   match within 1e-6 and score does not regress.
+2. **Partial fold (IF + non-IF):** the non-IF synapse folds away
+   (`0.1 + 0.4·0.5 = 0.3`), the IF synapse is kept, the constant is retained,
+   outputs match within 1e-6 and score does not regress.
+
+Existing `test/compact/CompactCreatureDisconnectedConstant.ts` behaviour is
+left intact.

--- a/test/compact/CompactCreatureConstantFold.ts
+++ b/test/compact/CompactCreatureConstantFold.ts
@@ -1,0 +1,188 @@
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import { compactCreature } from "@compact/CompactCreature.ts";
+import { calculate } from "@architecture/Score.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+// Issue #3034: safe constant fold — fold `type:"constant"` neurons into their
+// additive (non-aggregate) consumers' biases and drop the folded synapses.
+//
+// Both fixtures are trimmed subgraphs vendored from the production creature
+// cited in #3029 (kept tiny so the assertions stay legible). Behaviour must be
+// preserved to ~1e-6 and the score must not regress.
+
+const GROWTH_COST = 0.0001;
+
+function makeData(inputs: number): number[][] {
+  const data: number[][] = [];
+  for (let i = 500; i--;) {
+    const row: number[] = [];
+    for (let j = 0; j < inputs; j++) {
+      row.push(Math.random() * 2 - 1);
+    }
+    data.push(row);
+  }
+  return data;
+}
+
+function assertOutputsPreserved(
+  before: Creature,
+  after: Creature,
+  data: number[][],
+  output: number,
+) {
+  for (const row of data) {
+    const expected = before.activate(new Float32Array(row), false);
+    const actual = after.activate(new Float32Array(row), false);
+    for (let o = 0; o < output; o++) {
+      assertAlmostEquals(
+        actual[o],
+        expected[o],
+        0.000_001,
+        `output ${o}: actual ${actual[o]}, expected ${expected[o]}`,
+      );
+    }
+  }
+}
+
+function loadFixture(path: string): CreatureExport {
+  return JSON.parse(Deno.readTextFileSync(path)) as CreatureExport;
+}
+
+Deno.test(
+  "compactCreature folds a constant into its sole HARD_TANH consumer and removes it (full removal)",
+  async () => {
+    await initWasmForTests();
+
+    // legacy-neuron-1762683495 (constant 0.5) --w0.5--\
+    //                                                   533d8616… (HARD_TANH) --> output-0
+    // input-0 (varying) -----------------------w0.7---/
+    //
+    // HARD_TANH is not an aggregation squash, so the constant's fixed
+    // contribution (0.5 * 0.5) folds into the HARD_TANH bias and the synapse is
+    // dropped. The constant then has no outbound synapses and is removed
+    // entirely. The HARD_TANH neuron survives because it still has a varying
+    // input.
+    const json = loadFixture("test/data/constant-fold-full-removal.json");
+
+    const creature = Creature.fromJSON(json, false);
+    creature.validate();
+
+    const data = makeData(creature.input);
+
+    const compacted = compactCreature(creature, false);
+    assert(compacted !== undefined, "should have compacted");
+    creatureValidate(compacted!, { forwardOnly: true });
+
+    const neurons = compacted!.neurons;
+
+    // Constant folded away entirely.
+    assertEquals(
+      neurons.some((n) => n.uuid === "legacy-neuron-1762683495"),
+      false,
+      "constant neuron should be removed once it has no outbound synapses",
+    );
+
+    // HARD_TANH consumer retained with an updated bias.
+    const consumer = neurons.find(
+      (n) => n.uuid === "533d8616-037c-4278-b95c-3a2a1ce15ee6",
+    );
+    assert(
+      consumer,
+      "HARD_TANH consumer must be retained (has a varying input)",
+    );
+    // Folded bias: 0.2 + (0.5 * 0.5) = 0.45
+    assertAlmostEquals(consumer!.bias, 0.45, 1e-9);
+
+    // The folded synapse is gone.
+    const exported = compacted!.exportJSON();
+    assertEquals(
+      exported.synapses.some(
+        (s) => s.fromUUID === "legacy-neuron-1762683495",
+      ),
+      false,
+      "the folded constant synapse should be dropped",
+    );
+
+    assertOutputsPreserved(creature, compacted!, data, creature.output);
+
+    const beforeScore = calculate(creature, 0, GROWTH_COST);
+    const afterScore = calculate(compacted!, 0, GROWTH_COST);
+    assert(
+      afterScore >= beforeScore - 1e-9,
+      `score regressed: before ${beforeScore}, after ${afterScore}`,
+    );
+  },
+);
+
+Deno.test(
+  "compactCreature partially folds a constant: drops non-IF synapses, keeps the IF synapse (partial fold)",
+  async () => {
+    await initWasmForTests();
+
+    // neuron-132866057 (constant 0.5) --w0.4--> nonif-consumer (HARD_TANH) --> output-0
+    //                  \---- "positive" w0.3 --> if-consumer (IF) ----------> output-0
+    //
+    // The constant feeds both an aggregate IF consumer and a non-aggregate
+    // HARD_TANH consumer. Only the non-IF synapse may be folded; the IF synapse
+    // is left untouched, so the constant is retained for the IF consumer.
+    const json = loadFixture("test/data/constant-fold-partial-if.json");
+
+    const creature = Creature.fromJSON(json, false);
+    creature.validate();
+
+    const data = makeData(creature.input);
+
+    const compacted = compactCreature(creature, false);
+    assert(compacted !== undefined, "should have compacted");
+    creatureValidate(compacted!, { forwardOnly: true });
+
+    const neurons = compacted!.neurons;
+    const exported = compacted!.exportJSON();
+
+    // Constant retained because the IF consumer still references it.
+    assertEquals(
+      neurons.some((n) => n.uuid === "neuron-132866057"),
+      true,
+      "constant must be retained while an aggregate consumer references it",
+    );
+
+    // The IF synapse is kept.
+    assertEquals(
+      exported.synapses.some(
+        (s) => s.fromUUID === "neuron-132866057" && s.toUUID === "if-consumer",
+      ),
+      true,
+      "the synapse into the IF (aggregate) consumer must be kept",
+    );
+
+    // The non-IF synapse is folded away.
+    assertEquals(
+      exported.synapses.some(
+        (s) =>
+          s.fromUUID === "neuron-132866057" && s.toUUID === "nonif-consumer",
+      ),
+      false,
+      "the synapse into the non-aggregate consumer must be folded away",
+    );
+
+    // Non-IF consumer bias updated: 0.1 + (0.4 * 0.5) = 0.3
+    const nonIf = neurons.find((n) => n.uuid === "nonif-consumer");
+    assert(
+      nonIf,
+      "non-aggregate consumer must be retained (has a varying input)",
+    );
+    assertAlmostEquals(nonIf!.bias, 0.3, 1e-9);
+
+    assertOutputsPreserved(creature, compacted!, data, creature.output);
+
+    const beforeScore = calculate(creature, 0, GROWTH_COST);
+    const afterScore = calculate(compacted!, 0, GROWTH_COST);
+    assert(
+      afterScore >= beforeScore - 1e-9,
+      `score regressed: before ${beforeScore}, after ${afterScore}`,
+    );
+  },
+);

--- a/test/data/constant-fold-full-removal.json
+++ b/test/data/constant-fold-full-removal.json
@@ -1,0 +1,33 @@
+{
+  "semanticVersion": "4.0.0",
+  "forwardOnly": true,
+  "input": 1,
+  "output": 1,
+  "neurons": [
+    { "type": "constant", "uuid": "legacy-neuron-1762683495", "bias": 0.5 },
+    {
+      "type": "hidden",
+      "uuid": "533d8616-037c-4278-b95c-3a2a1ce15ee6",
+      "bias": 0.2,
+      "squash": "HARD_TANH"
+    },
+    { "type": "output", "uuid": "output-0", "bias": 0.1, "squash": "IDENTITY" }
+  ],
+  "synapses": [
+    {
+      "fromUUID": "input-0",
+      "toUUID": "533d8616-037c-4278-b95c-3a2a1ce15ee6",
+      "weight": 0.7
+    },
+    {
+      "fromUUID": "legacy-neuron-1762683495",
+      "toUUID": "533d8616-037c-4278-b95c-3a2a1ce15ee6",
+      "weight": 0.5
+    },
+    {
+      "fromUUID": "533d8616-037c-4278-b95c-3a2a1ce15ee6",
+      "toUUID": "output-0",
+      "weight": 0.5
+    }
+  ]
+}

--- a/test/data/constant-fold-partial-if.json
+++ b/test/data/constant-fold-partial-if.json
@@ -1,0 +1,45 @@
+{
+  "semanticVersion": "4.0.0",
+  "forwardOnly": true,
+  "input": 2,
+  "output": 1,
+  "neurons": [
+    { "type": "constant", "uuid": "neuron-132866057", "bias": 0.5 },
+    {
+      "type": "hidden",
+      "uuid": "nonif-consumer",
+      "bias": 0.1,
+      "squash": "HARD_TANH"
+    },
+    { "type": "hidden", "uuid": "if-consumer", "bias": 0, "squash": "IF" },
+    { "type": "output", "uuid": "output-0", "bias": 0, "squash": "IDENTITY" }
+  ],
+  "synapses": [
+    { "fromUUID": "input-0", "toUUID": "nonif-consumer", "weight": 0.6 },
+    {
+      "fromUUID": "neuron-132866057",
+      "toUUID": "nonif-consumer",
+      "weight": 0.4
+    },
+    {
+      "fromUUID": "input-0",
+      "toUUID": "if-consumer",
+      "weight": -0.3,
+      "type": "condition"
+    },
+    {
+      "fromUUID": "neuron-132866057",
+      "toUUID": "if-consumer",
+      "weight": 0.3,
+      "type": "positive"
+    },
+    {
+      "fromUUID": "input-1",
+      "toUUID": "if-consumer",
+      "weight": 0.3,
+      "type": "negative"
+    },
+    { "fromUUID": "nonif-consumer", "toUUID": "output-0", "weight": 0.8 },
+    { "fromUUID": "if-consumer", "toUUID": "output-0", "weight": 0.7 }
+  ]
+}


### PR DESCRIPTION
# Compaction: fold `type:"constant"` neurons into additive consumers (safe variant)

## Summary

Adds the production-derived regression fixtures and tests that lock in the
**safe constant fold** behaviour for `compactCreature`. Closes #3034.

The behaviour-preserving fold itself already lives in
`src/compact/ConstantFold.ts` (`foldConstants`, wired into
`src/compact/CompactCreature.ts`): a `type:"constant"` neuron emits the fixed
scalar `bias`, so for every **non-aggregate** consumer `B` the contribution
`weight · constant.bias` is folded into `B.bias` and the synapse is dropped;
once the constant has no remaining outbound synapses it is removed, while a
constant feeding an aggregate consumer (`MAXIMUM`/`MINIMUM`/`IF`/`HYPOT`/
`HYPOTv2`) is retained. This issue lands the **TDD fixtures** the acceptance
criteria require — two trimmed subgraphs drawn from the production creature
cited in #3029 — proving the safe fold on real network shapes.

```mermaid
flowchart LR
    subgraph Before
      C1[constant<br/>bias 0.5] -- w0.5 --> H1[HARD_TANH<br/>bias 0.2]
      I0[input-0] -- w0.7 --> H1
      H1 --> O1[output-0]
    end
    subgraph After
      I0b[input-0] -- w0.7 --> H2[HARD_TANH<br/>bias 0.45]
      H2 --> O2[output-0]
    end
    Before -->|fold weight·bias into consumer bias, drop synapse, delete constant| After
```

## Evidence

Backend/compaction change — no UI to screenshot. Verified by unit tests that
call the real `compactCreature` pipeline and assert on folded biases, dropped
synapses, retained constants, output equivalence (~1e-6) and non-regressing
score.

New trimmed fixtures vendored into `test/data/`:

- `constant-fold-full-removal.json` — constant `legacy-neuron-1762683495`
  feeds only a `HARD_TANH` hidden neuron (`533d8616-…`).
- `constant-fold-partial-if.json` — constant `neuron-132866057` feeds an `IF`
  (aggregate) consumer plus a non-`IF` consumer.

Test run:

```
running 2 tests from ./test/compact/CompactCreatureConstantFold.ts
... full removal ... ok
... partial fold ... ok
ok | 2 passed | 0 failed
```

Full `./quality.sh` is green apart from a pre-existing stochastic flake
(`test/mutate/ModBiasRegularisation.ts` — a random 221-vs-279 L2 outcome,
unrelated to this change); it passes on re-run.

## Test Plan

Added `test/compact/CompactCreatureConstantFold.ts`:

1. **Full removal (HARD_TANH-only):** the constant folds into the HARD_TANH
   bias (`0.2 + 0.5·0.5 = 0.45`), its synapse is dropped, the constant is
   deleted, the HARD_TANH neuron survives (it keeps a varying input), outputs
   match within 1e-6 and score does not regress.
2. **Partial fold (IF + non-IF):** the non-IF synapse folds away
   (`0.1 + 0.4·0.5 = 0.3`), the IF synapse is kept, the constant is retained,
   outputs match within 1e-6 and score does not regress.

Existing `test/compact/CompactCreatureDisconnectedConstant.ts` behaviour is
left intact.



## Milestone
This PR is part of the **#3029 Compaction: return a safe constant-fold and an aggressive prune variant** milestone and targets the `milestone/3029-compaction-return-a-safe-constant-fold-and-an` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqhjj2y8-2c53d5`<!-- vibe-worker-issue-3034 -->