### PR TITLE
Compaction: exact IF-collapse when all condition inputs are constant (#3036)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3036.md
+++ b/docs/archive/pr-summaries/pr-summary-3036.md
@@ -1,0 +1,76 @@
+# Compaction: exact IF-collapse when all condition inputs are constant (safe variant)
+
+## Summary
+
+An `IF` neuron picks its branch by `condition = Σ(condition-type inbound
+values)`, taking the positive branch when `condition > 0` else the negative
+branch (`src/methods/activations/aggregate/IF.ts`). When **every**
+condition-type input is constant, the selector is fixed at compaction time, so
+the IF can be collapsed losslessly to its always-taken branch. This is exact, so
+it belongs to the **safe** compaction variant.
+
+New pass `collapseConstantIf` (`src/compact/IfCollapse.ts`):
+
+1. Detects `squash === "IF"` neurons whose condition synapses (`type:"condition"`)
+   all originate from constant neurons. Branch roles are read from the synapse
+   `type` field exactly as `IF.ts` reads it — never from ordering. Constant
+   detection reuses `computeConstantValues` (now exported from `ConstantFold.ts`),
+   so both `type:"constant"` producers and effectively-constant hidden neurons
+   count.
+2. Computes the fixed `condition`; the taken branch is `positive` if
+   `condition > 0`, else `negative`.
+3. Keeps only the taken branch's inbound synapses, stripping their `type` so they
+   become ordinary additive edges; drops the condition + untaken-branch synapses.
+4. Rewrites the squash to `IDENTITY`, so the output becomes
+   `Σ(taken-branch values) + bias` — identical to the IF's always-taken result.
+
+The pass runs in `compactCreature` **before** the constant fold, so any constants
+it strands are absorbed by the subsequent constant-fold round and orphan cleanup.
+Frozen IF neurons / frozen inbound synapses are never modified; condition-less
+(malformed) IFs are left for the IF-repair pass. Out of scope: speculative IF
+pruning when condition inputs are *not* all constant (aggressive variant of #3029).
+
+Closes #3036.
+
+```mermaid
+flowchart LR
+    subgraph Before["IF (condition all-constant)"]
+        C[const → condition] --> IF{IF}
+        P[positive branch] --> IF
+        N[negative branch] --> IF
+        IF --> O[output]
+    end
+    subgraph After["collapsed (condition > 0)"]
+        P2[positive branch] --> ID[IDENTITY = Σ + bias]
+        ID --> O2[output]
+    end
+    Before -->|collapseConstantIf| After
+```
+
+## Evidence
+
+Backend/compaction change with no web interface — verified via unit tests and the
+full quality gate (`./quality.sh`: **7281 passed, 0 failed**).
+
+Regression linkage: with the new `collapseConstantIf` call removed from
+`CompactCreature.ts`, the two collapse tests fail (IF squash stays `IF`); with it
+wired in, all three pass. The negative test passes in both states, confirming
+varying-condition IFs are untouched.
+
+## Test Plan
+
+Added `test/compact/CompactCreatureIfCollapse.ts` with fixtures under
+`test/data/`:
+
+- `if-collapse-positive.json` — `condition = 0.5 > 0` → collapses to the positive
+  branch; asserts squash is no longer `IF`, only the varying positive synapse
+  survives (additive, no `type`), condition/untaken constants are removed, lower
+  neuron/synapse counts, outputs identical within `1e-6`, score ≥ original.
+- `if-collapse-negative.json` — `condition = -0.5 ≤ 0` → collapses to the negative
+  branch; same assertions for the other branch direction.
+- `if-collapse-varying-condition.json` — **negative test:** the condition input
+  varies, so the IF is left unchanged (squash stays `IF`, condition synapse
+  retained), outputs identical.
+
+All assert `creatureValidate({ forwardOnly: true })` (covering
+`assertValidSynapseReferences`).

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -19,6 +19,7 @@ import { mergeParallelIdentityBridges } from "@compact/ParallelIdentityMerge.ts"
 import { mergeParallelBridges } from "@compact/ParallelBridgeMerge.ts";
 import { simplifyLargeWeights } from "@compact/SimplifyLargeWeights.ts";
 import { foldConstants } from "@compact/ConstantFold.ts";
+import { collapseConstantIf } from "@compact/IfCollapse.ts";
 import { removeBackwardSynapses } from "@compact/RemoveBackwardSynapses.ts";
 import { mergeTagsByNameValue } from "@utils/TagUtils.ts";
 import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
@@ -298,6 +299,20 @@ export function compactCreature(
         break; // restart the loop after each mutation
       }
     }
+  }
+
+  // Issue #3036: Exact IF-collapse when every condition input is constant.
+  // The selector is fixed at compaction time, so the IF is rewritten to its
+  // always-taken branch as a plain additive (IDENTITY) neuron, dropping the
+  // dead condition + untaken-branch synapses. Lossless → safe variant. Runs
+  // before the constant fold so any constants it strands are absorbed below.
+  const ifCollapseResult = collapseConstantIf(compactCreature);
+  if (ifCollapseResult.changed) {
+    assertValidSynapseReferences(
+      compactCreature,
+      "after constant IF collapse",
+    );
+    didCompact = true;
   }
 
   // Issue #3035: Transitive constant fold + zero-varying-input collapse.

--- a/src/compact/ConstantFold.ts
+++ b/src/compact/ConstantFold.ts
@@ -130,7 +130,7 @@ export function foldConstants(
  * neuron whose every input is constant (or which has no inputs) is constant
  * with value `squash(Σ(weightᵢ · constantᵢ) + bias)`.
  */
-function computeConstantValues(
+export function computeConstantValues(
   neurons: NeuronExport[],
   inward: Map<number, SynapseExport[]>,
 ): Map<number, number> {

--- a/src/compact/IfCollapse.ts
+++ b/src/compact/IfCollapse.ts
@@ -1,0 +1,142 @@
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import type { SynapseExport } from "@architecture/SynapseInterfaces.ts";
+import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
+import { computeConstantValues } from "@compact/ConstantFold.ts";
+
+/**
+ * Result of collapsing constant-conditioned IF neurons.
+ */
+export interface IfCollapseResult {
+  /** Whether any IF neuron was collapsed. */
+  changed: boolean;
+  /** Number of IF neurons collapsed to a plain additive form. */
+  collapsedIfs: number;
+  /** Number of synapses removed (dead condition + untaken-branch edges). */
+  removedSynapses: number;
+}
+
+/**
+ * Exact IF-collapse for the **safe** compaction variant (Issue #3036).
+ *
+ * An IF neuron selects its branch by `condition = Σ(condition-type inbound
+ * values)`, taking the positive branch when `condition > 0` else the negative
+ * branch (see `src/methods/activations/aggregate/IF.ts`). The branch role of
+ * each inbound synapse is read from its `type` field exactly as `IF.ts` reads
+ * it — never from synapse ordering:
+ *
+ * - `type === "condition"` → contributes to the selector.
+ * - `type === "negative"`  → negative branch.
+ * - anything else (`"positive"` or no `type`) → positive branch (the IF
+ *   activation's `default` case).
+ *
+ * When **every** condition-type input is constant, the selector is fixed at
+ * compaction time, so the IF can be collapsed losslessly to its always-taken
+ * branch:
+ *
+ * 1. Compute the fixed `condition = Σ(weightᵢ · constantᵢ)` over the
+ *    condition synapses.
+ * 2. The taken branch is `positive` if `condition > 0`, else `negative`.
+ * 3. Keep only the taken branch's inbound synapses, stripping their `type`
+ *    so they become ordinary additive edges; drop the condition synapses and
+ *    the untaken branch's synapses.
+ * 4. Rewrite the neuron's squash to `IDENTITY`. Its output then becomes
+ *    `Σ(taken-branch values) + bias` — identical to the IF's always-taken
+ *    result `(taken) + bias`.
+ *
+ * The resulting additive neuron (and any constants the collapse strands) is
+ * left for a subsequent constant-fold round and orphan cleanup to absorb, so
+ * this pass composes with the base fold without duplicating its work.
+ *
+ * Constants are detected with the same {@link computeConstantValues} routine as
+ * the base fold, so a condition input that is a `type:"constant"` producer or a
+ * hidden neuron that has become effectively constant both count.
+ *
+ * Safety rules:
+ * - Only collapse when **all** condition synapses originate from
+ *   (effectively) constant neurons; any varying condition input leaves the IF
+ *   untouched.
+ * - An IF with no condition synapses is malformed; it is left for the dedicated
+ *   IF-repair pass rather than collapsed here.
+ * - Frozen IF neurons, or IFs with any frozen inbound synapse, are never
+ *   modified (Issue #1861).
+ *
+ * The export is modified in place.
+ *
+ * @param creatureExport - The CreatureExport to collapse (modified in place).
+ * @returns Counts of collapsed IFs / removed synapses and whether anything changed.
+ */
+export function collapseConstantIf(
+  creatureExport: CreatureExport,
+): IfCollapseResult {
+  normaliseCreatureExport(creatureExport);
+
+  const inward = new Map<number, SynapseExport[]>();
+  for (const s of creatureExport.synapses) {
+    const list = inward.get(s.toId!);
+    if (list) list.push(s);
+    else inward.set(s.toId!, [s]);
+  }
+
+  const constValue = computeConstantValues(creatureExport.neurons, inward);
+
+  const toDrop = new Set<SynapseExport>();
+  let collapsedIfs = 0;
+
+  for (const neuron of creatureExport.neurons) {
+    if (neuron.squash !== "IF") continue;
+    if (neuron.frozen) continue;
+
+    const ins = inward.get(neuron.id!) ?? [];
+    if (ins.some((s) => s.frozen)) continue;
+
+    const conditionSynapses = ins.filter((s) => s.type === "condition");
+    // A condition-less IF is malformed; leave it to the IF-repair pass.
+    if (conditionSynapses.length === 0) continue;
+
+    let allConst = true;
+    let condition = 0;
+    for (const s of conditionSynapses) {
+      const v = constValue.get(s.fromId!);
+      if (v === undefined) {
+        allConst = false;
+        break;
+      }
+      condition += s.weight * v;
+    }
+    if (!allConst) continue;
+
+    // Branch roles mirror IF.ts: "negative" is explicit; everything that is
+    // neither "condition" nor "negative" is the positive (default) branch.
+    const keepNegative = condition <= 0;
+    for (const s of ins) {
+      const isNegative = s.type === "negative";
+      const taken = keepNegative
+        ? isNegative
+        : !isNegative && s.type !== "condition";
+      if (taken) {
+        // Surviving branch edges become plain additive synapses.
+        delete s.type;
+      } else {
+        toDrop.add(s);
+      }
+    }
+
+    // Σ(taken-branch values) + bias via an ordinary additive neuron.
+    neuron.squash = "IDENTITY";
+    collapsedIfs++;
+  }
+
+  if (collapsedIfs === 0) {
+    return { changed: false, collapsedIfs: 0, removedSynapses: 0 };
+  }
+
+  const before = creatureExport.synapses.length;
+  creatureExport.synapses = creatureExport.synapses.filter(
+    (s) => !toDrop.has(s),
+  );
+  const removedSynapses = before - creatureExport.synapses.length;
+
+  delete creatureExport.memetic;
+
+  return { changed: true, collapsedIfs, removedSynapses };
+}

--- a/test/compact/CompactCreatureIfCollapse.ts
+++ b/test/compact/CompactCreatureIfCollapse.ts
@@ -1,0 +1,227 @@
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { creatureValidate } from "@architecture/CreatureValidate.ts";
+import { compactCreature } from "@compact/CompactCreature.ts";
+import { calculate } from "@architecture/Score.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+// Issue #3036: exact IF-collapse for the safe compaction variant. When every
+// condition-type input of an IF neuron is constant, the selector is fixed at
+// compaction time, so the IF collapses losslessly to its always-taken branch as
+// a plain additive (IDENTITY) neuron. Behaviour must be preserved to ~1e-6 and
+// the score must not regress.
+
+const GROWTH_COST = 0.0001;
+
+function makeData(inputs: number): number[][] {
+  const data: number[][] = [];
+  for (let i = 500; i--;) {
+    const row: number[] = [];
+    for (let j = 0; j < inputs; j++) {
+      row.push(Math.random() * 2 - 1);
+    }
+    data.push(row);
+  }
+  return data;
+}
+
+function assertOutputsPreserved(
+  before: Creature,
+  after: Creature,
+  data: number[][],
+  output: number,
+) {
+  for (const row of data) {
+    const expected = before.activate(new Float32Array(row), false);
+    const actual = after.activate(new Float32Array(row), false);
+    for (let o = 0; o < output; o++) {
+      assertAlmostEquals(
+        actual[o],
+        expected[o],
+        0.000_001,
+        `output ${o}: actual ${actual[o]}, expected ${expected[o]}`,
+      );
+    }
+  }
+}
+
+function loadFixture(path: string): CreatureExport {
+  return JSON.parse(Deno.readTextFileSync(path)) as CreatureExport;
+}
+
+Deno.test(
+  "compactCreature collapses a constant-conditioned IF to its positive branch (condition > 0)",
+  async () => {
+    await initWasmForTests();
+
+    // const-cond (1.0) --condition w0.5--> if-neuron (IF) --> output-0
+    // input-0  ---------positive  w0.6--/
+    // const-neg (0.3) --negative  w0.4--/
+    //
+    // condition = 1.0 * 0.5 = 0.5 > 0 → positive branch is always taken. The IF
+    // collapses to IDENTITY carrying only the (varying) positive synapse; the
+    // condition + negative synapses are dropped and both constants strand.
+    const json = loadFixture("test/data/if-collapse-positive.json");
+
+    const creature = Creature.fromJSON(json, false);
+    creature.validate();
+
+    const data = makeData(creature.input);
+
+    const compacted = compactCreature(creature, false);
+    assert(compacted !== undefined, "should have compacted");
+    creatureValidate(compacted!, { forwardOnly: true });
+
+    const neurons = compacted!.neurons;
+    const exported = compacted!.exportJSON();
+
+    // The IF neuron survives as a plain additive (non-IF) neuron.
+    const collapsed = neurons.find((n) => n.uuid === "if-neuron");
+    assert(collapsed, "the collapsed neuron must be retained");
+    assert(
+      collapsed!.squash !== "IF",
+      `IF squash must be rewritten, got ${collapsed!.squash}`,
+    );
+
+    // Only the positive-branch synapse survives into the collapsed neuron, with
+    // no role type left on it.
+    const inbound = exported.synapses.filter((s) => s.toUUID === "if-neuron");
+    assertEquals(inbound.length, 1, "only the taken branch synapse survives");
+    assertEquals(inbound[0].fromUUID, "input-0");
+    assertEquals(inbound[0].type, undefined, "surviving synapse is additive");
+
+    // Constants that fed the condition / untaken branch are gone.
+    assertEquals(
+      neurons.some((n) => n.uuid === "const-cond"),
+      false,
+      "condition constant should be stranded and cleaned up",
+    );
+    assertEquals(
+      neurons.some((n) => n.uuid === "const-neg"),
+      false,
+      "untaken-branch constant should be stranded and cleaned up",
+    );
+
+    // Lower neuron / synapse counts.
+    assert(
+      compacted!.neurons.length < creature.neurons.length,
+      "neuron count should drop",
+    );
+    assert(
+      compacted!.synapses.length < creature.synapses.length,
+      "synapse count should drop",
+    );
+
+    assertOutputsPreserved(creature, compacted!, data, creature.output);
+
+    const beforeScore = calculate(creature, 0, GROWTH_COST);
+    const afterScore = calculate(compacted!, 0, GROWTH_COST);
+    assert(
+      afterScore >= beforeScore - 1e-9,
+      `score regressed: before ${beforeScore}, after ${afterScore}`,
+    );
+  },
+);
+
+Deno.test(
+  "compactCreature collapses a constant-conditioned IF to its negative branch (condition <= 0)",
+  async () => {
+    await initWasmForTests();
+
+    // const-cond (1.0) --condition w-0.5--> if-neuron (IF) --> output-0
+    // input-1  ---------negative  w0.7--/
+    // const-pos (0.2) --positive  w0.9--/
+    //
+    // condition = 1.0 * -0.5 = -0.5 <= 0 → negative branch is always taken.
+    const json = loadFixture("test/data/if-collapse-negative.json");
+
+    const creature = Creature.fromJSON(json, false);
+    creature.validate();
+
+    const data = makeData(creature.input);
+
+    const compacted = compactCreature(creature, false);
+    assert(compacted !== undefined, "should have compacted");
+    creatureValidate(compacted!, { forwardOnly: true });
+
+    const neurons = compacted!.neurons;
+    const exported = compacted!.exportJSON();
+
+    const collapsed = neurons.find((n) => n.uuid === "if-neuron");
+    assert(collapsed, "the collapsed neuron must be retained");
+    assert(
+      collapsed!.squash !== "IF",
+      `IF squash must be rewritten, got ${collapsed!.squash}`,
+    );
+
+    // Only the negative-branch (varying) synapse survives, stripped of its role.
+    const inbound = exported.synapses.filter((s) => s.toUUID === "if-neuron");
+    assertEquals(inbound.length, 1, "only the taken branch synapse survives");
+    assertEquals(inbound[0].fromUUID, "input-1");
+    assertEquals(inbound[0].type, undefined, "surviving synapse is additive");
+
+    assertEquals(
+      neurons.some((n) => n.uuid === "const-cond"),
+      false,
+      "condition constant should be stranded and cleaned up",
+    );
+    assertEquals(
+      neurons.some((n) => n.uuid === "const-pos"),
+      false,
+      "untaken-branch constant should be stranded and cleaned up",
+    );
+
+    assertOutputsPreserved(creature, compacted!, data, creature.output);
+
+    const beforeScore = calculate(creature, 0, GROWTH_COST);
+    const afterScore = calculate(compacted!, 0, GROWTH_COST);
+    assert(
+      afterScore >= beforeScore - 1e-9,
+      `score regressed: before ${beforeScore}, after ${afterScore}`,
+    );
+  },
+);
+
+Deno.test(
+  "compactCreature leaves an IF with a varying condition input unchanged",
+  async () => {
+    await initWasmForTests();
+
+    // input-0 --condition w0.5--> if-neuron (IF) --> output-0
+    // const-pos (0.4) -positive w0.6--/
+    // input-1 ---------negative  w0.3--/
+    //
+    // The condition input varies, so the selector is not fixed and the IF must
+    // be left intact (this case belongs to the aggressive variant, not here).
+    const json = loadFixture("test/data/if-collapse-varying-condition.json");
+
+    const creature = Creature.fromJSON(json, false);
+    creature.validate();
+
+    const data = makeData(creature.input);
+
+    const compacted = compactCreature(creature, false);
+    // The IF survives regardless of whether any unrelated compaction happened.
+    const after = compacted ?? creature;
+    creatureValidate(after, { forwardOnly: true });
+
+    const ifNeuron = after.neurons.find((n) => n.uuid === "if-neuron");
+    assert(ifNeuron, "IF neuron must be retained");
+    assertEquals(
+      ifNeuron!.squash,
+      "IF",
+      "IF with a varying condition must stay an IF",
+    );
+
+    // The condition synapse must still be present and typed.
+    const exported = after.exportJSON();
+    const condition = exported.synapses.find(
+      (s) => s.toUUID === "if-neuron" && s.type === "condition",
+    );
+    assert(condition, "the condition synapse must be retained");
+    assertEquals(condition!.fromUUID, "input-0");
+
+    assertOutputsPreserved(creature, after, data, creature.output);
+  },
+);

--- a/test/data/if-collapse-negative.json
+++ b/test/data/if-collapse-negative.json
@@ -1,0 +1,33 @@
+{
+  "semanticVersion": "4.0.0",
+  "forwardOnly": true,
+  "input": 2,
+  "output": 1,
+  "neurons": [
+    { "type": "constant", "uuid": "const-cond", "bias": 1.0 },
+    { "type": "constant", "uuid": "const-pos", "bias": 0.2 },
+    { "type": "hidden", "uuid": "if-neuron", "bias": 0.1, "squash": "IF" },
+    { "type": "output", "uuid": "output-0", "bias": 0, "squash": "IDENTITY" }
+  ],
+  "synapses": [
+    {
+      "fromUUID": "input-1",
+      "toUUID": "if-neuron",
+      "weight": 0.7,
+      "type": "negative"
+    },
+    {
+      "fromUUID": "const-cond",
+      "toUUID": "if-neuron",
+      "weight": -0.5,
+      "type": "condition"
+    },
+    {
+      "fromUUID": "const-pos",
+      "toUUID": "if-neuron",
+      "weight": 0.9,
+      "type": "positive"
+    },
+    { "fromUUID": "if-neuron", "toUUID": "output-0", "weight": 0.8 }
+  ]
+}

--- a/test/data/if-collapse-positive.json
+++ b/test/data/if-collapse-positive.json
@@ -1,0 +1,33 @@
+{
+  "semanticVersion": "4.0.0",
+  "forwardOnly": true,
+  "input": 2,
+  "output": 1,
+  "neurons": [
+    { "type": "constant", "uuid": "const-cond", "bias": 1.0 },
+    { "type": "constant", "uuid": "const-neg", "bias": 0.3 },
+    { "type": "hidden", "uuid": "if-neuron", "bias": 0.2, "squash": "IF" },
+    { "type": "output", "uuid": "output-0", "bias": 0, "squash": "IDENTITY" }
+  ],
+  "synapses": [
+    {
+      "fromUUID": "input-0",
+      "toUUID": "if-neuron",
+      "weight": 0.6,
+      "type": "positive"
+    },
+    {
+      "fromUUID": "const-cond",
+      "toUUID": "if-neuron",
+      "weight": 0.5,
+      "type": "condition"
+    },
+    {
+      "fromUUID": "const-neg",
+      "toUUID": "if-neuron",
+      "weight": 0.4,
+      "type": "negative"
+    },
+    { "fromUUID": "if-neuron", "toUUID": "output-0", "weight": 0.8 }
+  ]
+}

--- a/test/data/if-collapse-varying-condition.json
+++ b/test/data/if-collapse-varying-condition.json
@@ -1,0 +1,32 @@
+{
+  "semanticVersion": "4.0.0",
+  "forwardOnly": true,
+  "input": 2,
+  "output": 1,
+  "neurons": [
+    { "type": "constant", "uuid": "const-pos", "bias": 0.4 },
+    { "type": "hidden", "uuid": "if-neuron", "bias": 0, "squash": "IF" },
+    { "type": "output", "uuid": "output-0", "bias": 0, "squash": "IDENTITY" }
+  ],
+  "synapses": [
+    {
+      "fromUUID": "input-0",
+      "toUUID": "if-neuron",
+      "weight": 0.5,
+      "type": "condition"
+    },
+    {
+      "fromUUID": "const-pos",
+      "toUUID": "if-neuron",
+      "weight": 0.6,
+      "type": "positive"
+    },
+    {
+      "fromUUID": "input-1",
+      "toUUID": "if-neuron",
+      "weight": 0.3,
+      "type": "negative"
+    },
+    { "fromUUID": "if-neuron", "toUUID": "output-0", "weight": 0.7 }
+  ]
+}


### PR DESCRIPTION
# Compaction: exact IF-collapse when all condition inputs are constant (safe variant)

## Summary

An `IF` neuron picks its branch by `condition = Σ(condition-type inbound
values)`, taking the positive branch when `condition > 0` else the negative
branch (`src/methods/activations/aggregate/IF.ts`). When **every**
condition-type input is constant, the selector is fixed at compaction time, so
the IF can be collapsed losslessly to its always-taken branch. This is exact, so
it belongs to the **safe** compaction variant.

New pass `collapseConstantIf` (`src/compact/IfCollapse.ts`):

1. Detects `squash === "IF"` neurons whose condition synapses (`type:"condition"`)
   all originate from constant neurons. Branch roles are read from the synapse
   `type` field exactly as `IF.ts` reads it — never from ordering. Constant
   detection reuses `computeConstantValues` (now exported from `ConstantFold.ts`),
   so both `type:"constant"` producers and effectively-constant hidden neurons
   count.
2. Computes the fixed `condition`; the taken branch is `positive` if
   `condition > 0`, else `negative`.
3. Keeps only the taken branch's inbound synapses, stripping their `type` so they
   become ordinary additive edges; drops the condition + untaken-branch synapses.
4. Rewrites the squash to `IDENTITY`, so the output becomes
   `Σ(taken-branch values) + bias` — identical to the IF's always-taken result.

The pass runs in `compactCreature` **before** the constant fold, so any constants
it strands are absorbed by the subsequent constant-fold round and orphan cleanup.
Frozen IF neurons / frozen inbound synapses are never modified; condition-less
(malformed) IFs are left for the IF-repair pass. Out of scope: speculative IF
pruning when condition inputs are *not* all constant (aggressive variant of #3029).

Closes #3036.

```mermaid
flowchart LR
    subgraph Before["IF (condition all-constant)"]
        C[const → condition] --> IF{IF}
        P[positive branch] --> IF
        N[negative branch] --> IF
        IF --> O[output]
    end
    subgraph After["collapsed (condition > 0)"]
        P2[positive branch] --> ID[IDENTITY = Σ + bias]
        ID --> O2[output]
    end
    Before -->|collapseConstantIf| After
```

## Evidence

Backend/compaction change with no web interface — verified via unit tests and the
full quality gate (`./quality.sh`: **7281 passed, 0 failed**).

Regression linkage: with the new `collapseConstantIf` call removed from
`CompactCreature.ts`, the two collapse tests fail (IF squash stays `IF`); with it
wired in, all three pass. The negative test passes in both states, confirming
varying-condition IFs are untouched.

## Test Plan

Added `test/compact/CompactCreatureIfCollapse.ts` with fixtures under
`test/data/`:

- `if-collapse-positive.json` — `condition = 0.5 > 0` → collapses to the positive
  branch; asserts squash is no longer `IF`, only the varying positive synapse
  survives (additive, no `type`), condition/untaken constants are removed, lower
  neuron/synapse counts, outputs identical within `1e-6`, score ≥ original.
- `if-collapse-negative.json` — `condition = -0.5 ≤ 0` → collapses to the negative
  branch; same assertions for the other branch direction.
- `if-collapse-varying-condition.json` — **negative test:** the condition input
  varies, so the IF is left unchanged (squash stays `IF`, condition synapse
  retained), outputs identical.

All assert `creatureValidate({ forwardOnly: true })` (covering
`assertValidSynapseReferences`).



## Milestone
This PR is part of the **#3029 Compaction: return a safe constant-fold and an aggressive prune variant** milestone and targets the `milestone/3029-compaction-return-a-safe-constant-fold-and-an` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqhjj2y8-2c53d5`<!-- vibe-worker-issue-3036 -->