### PR TITLE
Compaction: return safe + aggressive variants as candidates (#3037)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3037.md
+++ b/docs/archive/pr-summaries/pr-summary-3037.md
@@ -1,0 +1,80 @@
+## Summary
+
+Plumbing so compaction can surface **two** candidates — a **safe** compact (all
+exact, behaviour-preserving folds; score guaranteed ≥ original) and an
+**aggressive** compact (safe folds plus future extra structural pruning) — and
+feed both into the existing score-based selection so the best wins. The
+aggressive gamble can never cost anything because the safe variant is the floor.
+
+In this issue the aggressive pass is a **no-op placeholder equal to the safe
+variant** (the real heuristic lands in the aggressive-pruning sub-issue of
+#3029). Identical variants dedupe via the existing UUID dedup, so the duplicate
+is never scored. Closes #3037.
+
+### Changes
+
+- **New `compactCreatureVariants(creature, feedbackLoop, mcmcTemperature)`**
+  (`src/compact/CompactCreature.ts`) returning `{ safe?, aggressive? }`. The
+  existing compaction body moved into an internal `buildSafeCompact()` that
+  produces the safe variant; `aggressive` is the no-op placeholder (same
+  creature) for now.
+- **Back-compat preserved**: `compactCreature()` and `Creature.compact()` are
+  thin wrappers that return the safe variant. New `Creature.compactVariants()`
+  exposes both.
+- **New `src/compact/CompactVariants.ts`**: the `CompactVariants` type plus
+  `selectCompactVariant()` — picks the best single candidate for call sites that
+  consume one creature. The safe variant is the floor (wins ties, is the
+  fallback); an aggressive variant only displaces it when it is a *distinct*
+  creature (different UUID) with a strictly higher finite score. Identical
+  variants return the safe one without scoring the duplicate.
+- **All four call sites updated to offer both candidates to selection**:
+  - `src/blackbox/FineTune.ts` (acceptCandidate path) — offers both variants;
+    `acceptCandidate`'s UUID set dedupes the identical placeholder.
+  - `src/architecture/training/TrainingTeardown.ts`
+  - `src/architecture/training/TrainingPredictiveCoding.ts`
+  - `src/propagate/RemoveSyntheticSynapses.ts`
+
+  The latter three route through `selectCompactVariant()`, which returns the
+  safe variant today — preserving current behaviour while the aggressive pass is
+  identical/absent.
+
+### Flow
+
+```mermaid
+flowchart LR
+    C[Creature.compactVariants] --> S[buildSafeCompact]
+    S --> SV[safe variant]
+    S --> AV[aggressive variant<br/>no-op placeholder = safe]
+    SV --> SEL{score-based selection}
+    AV --> SEL
+    SEL -->|identical → UUID dedup| BEST[best candidate]
+    SEL -->|distinct + higher score| BEST
+```
+
+## Evidence
+
+Backend/compaction change only — no web interface to screenshot. Verified via
+unit tests (`deno test`) and the full quality gate.
+
+- New tests pass: `deno test test/compact/CompactCreatureVariants.ts` → 8/8.
+- All compaction tests green: `deno test test/compact/*.ts` → 157/157.
+- Call-site suites green: blackbox (82), `RemoveSyntheticSynapses` +
+  `TrainingTeardown` + `PredictiveCodingTrainer` (20).
+- Full `./quality.sh` ran fmt/lint/type-check + suite: **7288 passed**. The only
+  failure was `test/mutate/ModBiasRegularisation.ts` — a pre-existing stochastic
+  mutation test unrelated to compaction; it passes deterministically on re-run.
+
+## Test Plan
+
+Added `test/compact/CompactCreatureVariants.ts`:
+
+- `compactCreatureVariants` returns both a safe and an aggressive candidate.
+- `compactCreature` returns the safe variant (back-compat: same UUID as
+  `variants.safe`).
+- No-op aggressive pass dedupes to a single scored candidate via UUID (mirrors
+  the call-site selection collapsing identical variants to one).
+- `compactCreatureVariants` returns empty `{}` when nothing compacts.
+- `selectCompactVariant` unit coverage: falls back to the present variant;
+  keeps safe when variants are identical (distinct instances, same UUID);
+  prefers a distinct strictly-higher-scoring aggressive; keeps safe on lower
+  score or ties.

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -32,7 +32,11 @@ import { Synapse } from "@architecture/Synapse.ts";
 import type { SynapseInternal } from "@architecture/SynapseInterfaces.ts";
 import type { MemeticInterface } from "@blackbox/MemeticInterface.ts";
 import type { EvolvableHyperparameters } from "@config/HyperparameterConfig.ts";
-import { compactCreature } from "@compact/CompactCreature.ts";
+import {
+  compactCreature,
+  compactCreatureVariants,
+} from "@compact/CompactCreature.ts";
+import type { CompactVariants } from "@compact/CompactVariants.ts";
 import type { NeatOptions } from "@config/NeatOptions.ts";
 import type { CostInterface } from "@costs/CostInterface.ts";
 import { Activations } from "@methods/activations/Activations.ts";
@@ -642,6 +646,20 @@ export class Creature implements CreatureInternal {
     mcmcTemperature?: number,
   ): Creature | undefined {
     return compactCreature(this, feedbackLoop, mcmcTemperature);
+  }
+
+  /**
+   * Issue #3037: Produce both compaction candidates — a `safe` variant (all
+   * exact folds, score guaranteed ≥ this creature) and an `aggressive` variant
+   * (safe folds plus extra structural pruning). Feed both into score-based
+   * selection so the best wins; the safe variant is the floor the aggressive
+   * gamble can never cost anything against.
+   */
+  compactVariants(
+    feedbackLoop: boolean,
+    mcmcTemperature?: number,
+  ): CompactVariants {
+    return compactCreatureVariants(this, feedbackLoop, mcmcTemperature);
   }
 
   validate(options?: {

--- a/src/architecture/training/TrainingPredictiveCoding.ts
+++ b/src/architecture/training/TrainingPredictiveCoding.ts
@@ -9,6 +9,7 @@
 import type { CostInterface } from "@costs/CostInterface.ts";
 import { Creature } from "@creature";
 import { compactUnused } from "@compact/CompactUnused.ts";
+import { selectCompactVariant } from "@compact/CompactVariants.ts";
 import type { TrainOptions } from "@config/TrainOptions.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { trainWithPredictiveCoding } from "@predictiveCoding/PredictiveCodingTrainer.ts";
@@ -57,7 +58,11 @@ export function trainDirPredictiveCoding(
   const feedbackLoop = options.feedbackLoop ?? false;
   let compact = compactUnused(creature.traceJSON(), 1e-7);
   if (!compact) {
-    compact = Creature.fromJSON(creature.exportJSON()).compact(feedbackLoop);
+    // Issue #3037: select the best of the safe + aggressive compaction
+    // candidates (the safe variant is the floor; identical variants dedupe).
+    compact = selectCompactVariant(
+      Creature.fromJSON(creature.exportJSON()).compactVariants(feedbackLoop),
+    );
   }
 
   // Issue #1913: Add trace tags indicating Predictive Coding was used.

--- a/src/architecture/training/TrainingTeardown.ts
+++ b/src/architecture/training/TrainingTeardown.ts
@@ -9,6 +9,7 @@
 
 import { Creature } from "@creature";
 import { compactUnused } from "@compact/CompactUnused.ts";
+import { selectCompactVariant } from "@compact/CompactVariants.ts";
 import { removeSyntheticSynapses } from "@propagate/RemoveSyntheticSynapses.ts";
 import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
 import type {
@@ -185,7 +186,11 @@ export function finaliseTraining(
 
   let compact = compactUnused(bestTraceJSON, iterationConfig.plankConstant);
   if (!compact) {
-    compact = Creature.fromJSON(bestTraceJSON).compact(feedbackLoop);
+    // Issue #3037: select the best of the safe + aggressive compaction
+    // candidates (the safe variant is the floor; identical variants dedupe).
+    compact = selectCompactVariant(
+      Creature.fromJSON(bestTraceJSON).compactVariants(feedbackLoop),
+    );
   }
 
   return {

--- a/src/blackbox/FineTune.ts
+++ b/src/blackbox/FineTune.ts
@@ -579,9 +579,13 @@ export function fineTuneImprovement(
     }
   };
 
-  const compactNetwork = fittest.compact(feedbackLoop);
+  // Issue #3037: offer both compaction candidates (safe + aggressive) to
+  // selection. acceptCandidate dedupes by UUID, so the no-op aggressive
+  // placeholder collapses into the safe candidate rather than being scored.
+  const compactCandidates = fittest.compactVariants(feedbackLoop);
   const forwardOnly = feedbackLoop !== true;
-  acceptCandidate(compactNetwork);
+  acceptCandidate(compactCandidates.safe);
+  acceptCandidate(compactCandidates.aggressive);
   const resultSame = tuneRandomize(
     fittest,
     previousFittest,

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -24,9 +24,47 @@ import { removeBackwardSynapses } from "@compact/RemoveBackwardSynapses.ts";
 import { mergeTagsByNameValue } from "@utils/TagUtils.ts";
 import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
 import { exportJSONUnchecked } from "@creature/CreatureSerialization.ts";
+import type { CompactVariants } from "@compact/CompactVariants.ts";
+
+/**
+ * Produce both compaction candidates for a creature (Issue #3037).
+ *
+ * The `safe` variant is the result of all exact, behaviour-preserving folds
+ * (the long-standing {@link compactCreature} output). The `aggressive` variant
+ * is the safe folds plus extra structural pruning; the aggressive heuristic
+ * itself lands in the aggressive-pruning sub-issue of #3029, so for now it is a
+ * no-op placeholder equal to the safe variant. Identical variants dedupe via
+ * UUID downstream, so the duplicate is never scored.
+ *
+ * @param creature - The creature to compact
+ * @param feedbackLoop - Whether to use a feedback loop during compaction
+ * @param mcmcTemperature - Issue #2200: Optional MCMC temperature for probabilistic
+ *   weight rescaling acceptance. When provided, worsening rescalings may be accepted
+ *   with probability exp(-delta / temperature) instead of greedy rejection.
+ * @returns The safe and aggressive candidates; either is absent when no
+ *   compaction occurred.
+ */
+export function compactCreatureVariants(
+  creature: Creature,
+  feedbackLoop: boolean,
+  mcmcTemperature?: number,
+): CompactVariants {
+  const safe = buildSafeCompact(creature, feedbackLoop, mcmcTemperature);
+  if (!safe) return {};
+
+  // No-op placeholder: the aggressive pass currently equals the safe variant.
+  // The real heuristic is the aggressive-pruning sub-issue of #3029. Returning
+  // the same creature keeps the gamble free and lets UUID dedup collapse the
+  // duplicate before selection scores it.
+  return { safe, aggressive: safe };
+}
 
 /**
  * Compacts a creature by removing redundant neurons and connections.
+ *
+ * Thin wrapper over {@link compactCreatureVariants} that returns the safe
+ * variant for back-compat — the floor that score-based selection can never do
+ * worse than.
  *
  * @param creature - The creature to compact
  * @param feedbackLoop - Whether to use a feedback loop during compaction
@@ -36,6 +74,18 @@ import { exportJSONUnchecked } from "@creature/CreatureSerialization.ts";
  * @returns A new compacted creature or undefined if no compaction occurred
  */
 export function compactCreature(
+  creature: Creature,
+  feedbackLoop: boolean,
+  mcmcTemperature?: number,
+): Creature | undefined {
+  return compactCreatureVariants(creature, feedbackLoop, mcmcTemperature).safe;
+}
+
+/**
+ * Build the safe compaction candidate — all exact, behaviour-preserving folds.
+ * The returned creature's score is guaranteed ≥ the original's.
+ */
+function buildSafeCompact(
   creature: Creature,
   feedbackLoop: boolean,
   mcmcTemperature?: number,

--- a/src/compact/CompactVariants.ts
+++ b/src/compact/CompactVariants.ts
@@ -1,0 +1,54 @@
+import type { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+
+/**
+ * The two candidates produced by compaction (Issue #3037).
+ *
+ * - `safe`: all exact, behaviour-preserving folds. Its score is guaranteed to
+ *   be ≥ the original creature's, so it is the floor that selection can never
+ *   do worse than.
+ * - `aggressive`: the safe folds plus extra structural pruning — a gamble that
+ *   can never cost anything because `safe` is always available as the floor.
+ *
+ * Either field is absent when compaction produced no usable creature for that
+ * variant. When the aggressive pass is a no-op (as in the #3037 plumbing) the
+ * two are identical and dedupe via UUID rather than being scored twice.
+ */
+export type CompactVariants = {
+  safe?: Creature;
+  aggressive?: Creature;
+};
+
+/**
+ * Pick the best single candidate from a {@link CompactVariants} pair for the
+ * call sites that consume one compacted creature.
+ *
+ * The `safe` variant is the guaranteed floor, so it wins ties and is the
+ * fallback whenever the aggressive variant is absent. The `aggressive` variant
+ * only displaces it when it is a *distinct* creature (different UUID) with a
+ * strictly higher finite score. When the two are identical — the no-op
+ * placeholder of #3037 — the duplicate is never scored and `safe` is returned.
+ */
+export function selectCompactVariant(
+  variants: CompactVariants,
+): Creature | undefined {
+  const { safe, aggressive } = variants;
+  if (!aggressive) return safe;
+  if (!safe) return aggressive;
+
+  // Identical variants dedupe: keep the safe floor, never score the duplicate.
+  if (CreatureUtil.makeUUID(safe) === CreatureUtil.makeUUID(aggressive)) {
+    return safe;
+  }
+
+  const safeScore = safe.score;
+  const aggressiveScore = aggressive.score;
+  if (
+    Number.isFinite(aggressiveScore) && Number.isFinite(safeScore) &&
+    (aggressiveScore as number) > (safeScore as number)
+  ) {
+    return aggressive;
+  }
+
+  return safe;
+}

--- a/src/propagate/RemoveSyntheticSynapses.ts
+++ b/src/propagate/RemoveSyntheticSynapses.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Creature } from "@creature";
+import { selectCompactVariant } from "@compact/CompactVariants.ts";
 
 /** Default threshold: same as the backpropagation plankConstant. */
 const DEFAULT_THRESHOLD = 0.000_000_1;
@@ -67,7 +68,9 @@ export function removeSyntheticSynapses(
   if (zeroed > 0) {
     // Delegate to the standard compact function for zero-weight synapse
     // removal, orphan cleanup, and dead subgraph pruning (DRY).
-    const compacted = creature.compact(false);
+    // Issue #3037: select the best of the safe + aggressive compaction
+    // candidates (the safe variant is the floor; identical variants dedupe).
+    const compacted = selectCompactVariant(creature.compactVariants(false));
     if (compacted) {
       creature.loadFrom(
         compacted.exportJSON(),

--- a/test/compact/CompactCreatureVariants.ts
+++ b/test/compact/CompactCreatureVariants.ts
@@ -1,0 +1,209 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import {
+  compactCreature,
+  compactCreatureVariants,
+} from "@compact/CompactCreature.ts";
+import { selectCompactVariant } from "@compact/CompactVariants.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+// Issue #3037: compaction surfaces two candidates — a `safe` variant (all exact
+// folds, score guaranteed ≥ original) and an `aggressive` variant (safe folds
+// plus extra structural pruning). In this plumbing issue the aggressive pass is
+// a no-op placeholder equal to the safe variant, so the two must dedupe via the
+// existing UUID dedup rather than being scored twice.
+
+const FIXTURE = "test/data/constant-fold-full-removal.json";
+
+function loadFixture(path: string): CreatureExport {
+  return JSON.parse(Deno.readTextFileSync(path)) as CreatureExport;
+}
+
+/** Build a tiny IDENTITY input→output creature with a given output bias. */
+function tinyCreature(bias: number, score?: number): Creature {
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", bias, squash: "IDENTITY" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1 },
+    ],
+  } as unknown as CreatureExport;
+  const creature = Creature.fromJSON(json, false);
+  if (score !== undefined) creature.score = score;
+  return creature;
+}
+
+Deno.test(
+  "compactCreatureVariants returns both a safe and an aggressive candidate",
+  async () => {
+    await initWasmForTests();
+
+    const creature = Creature.fromJSON(loadFixture(FIXTURE), false);
+    const variants = compactCreatureVariants(creature, false);
+
+    assert(variants.safe !== undefined, "safe candidate should exist");
+    assert(
+      variants.aggressive !== undefined,
+      "aggressive candidate should exist",
+    );
+  },
+);
+
+Deno.test(
+  "compactCreature returns the safe variant for back-compat",
+  async () => {
+    await initWasmForTests();
+
+    const safeOnly = compactCreature(
+      Creature.fromJSON(loadFixture(FIXTURE), false),
+      false,
+    );
+    const variants = compactCreatureVariants(
+      Creature.fromJSON(loadFixture(FIXTURE), false),
+      false,
+    );
+
+    assert(safeOnly !== undefined, "compactCreature should still compact");
+    assertEquals(
+      CreatureUtil.makeUUID(safeOnly!),
+      CreatureUtil.makeUUID(variants.safe!),
+      "compactCreature must return the safe variant",
+    );
+  },
+);
+
+Deno.test(
+  "no-op aggressive pass dedupes to a single scored candidate via UUID",
+  async () => {
+    await initWasmForTests();
+
+    const variants = compactCreatureVariants(
+      Creature.fromJSON(loadFixture(FIXTURE), false),
+      false,
+    );
+
+    // Identical variants share a UUID.
+    assertEquals(
+      CreatureUtil.makeUUID(variants.safe!),
+      CreatureUtil.makeUUID(variants.aggressive!),
+      "no-op aggressive variant must equal the safe variant",
+    );
+
+    // Mirror the call-site selection: offering both candidates to a
+    // UUID-deduping set must collect exactly one unique candidate.
+    const UUIDs = new Set<string>();
+    for (const candidate of [variants.safe, variants.aggressive]) {
+      if (candidate) UUIDs.add(CreatureUtil.makeUUID(candidate));
+    }
+    assertEquals(UUIDs.size, 1, "identical variants must dedupe to one");
+
+    // selectCompactVariant keeps the safe floor and never scores the duplicate.
+    assertEquals(
+      selectCompactVariant(variants),
+      variants.safe,
+      "selection must keep the safe variant",
+    );
+  },
+);
+
+Deno.test(
+  "compactCreatureVariants returns empty when nothing compacts",
+  async () => {
+    await initWasmForTests();
+
+    // A bare input→output creature has nothing to fold.
+    const variants = compactCreatureVariants(tinyCreature(0.1), false);
+
+    assertEquals(variants.safe, undefined, "no safe candidate when no-op");
+    assertEquals(
+      variants.aggressive,
+      undefined,
+      "no aggressive candidate when no-op",
+    );
+  },
+);
+
+Deno.test("selectCompactVariant falls back to the present variant", () => {
+  const safe = tinyCreature(0.1);
+  const aggressive = tinyCreature(0.2);
+
+  assertEquals(
+    selectCompactVariant({ safe }),
+    safe,
+    "returns safe when aggressive is absent",
+  );
+  assertEquals(
+    selectCompactVariant({ aggressive }),
+    aggressive,
+    "returns aggressive when safe is absent",
+  );
+  assertEquals(
+    selectCompactVariant({}),
+    undefined,
+    "returns undefined when empty",
+  );
+});
+
+Deno.test(
+  "selectCompactVariant keeps safe when variants are identical (distinct instances)",
+  () => {
+    // Two distinct Creature instances with identical structure share a UUID.
+    const safe = tinyCreature(0.1, 5);
+    const aggressive = tinyCreature(0.1, 999); // score ignored — identical UUID
+
+    assertEquals(
+      CreatureUtil.makeUUID(safe),
+      CreatureUtil.makeUUID(aggressive),
+      "fixture sanity: clones must share a UUID",
+    );
+    assertEquals(
+      selectCompactVariant({ safe, aggressive }),
+      safe,
+      "duplicate must never be scored — keep the safe floor",
+    );
+  },
+);
+
+Deno.test(
+  "selectCompactVariant prefers a distinct, strictly higher-scoring aggressive",
+  () => {
+    const safe = tinyCreature(0.1, 5);
+    const aggressive = tinyCreature(0.2, 6); // distinct UUID, higher score
+
+    assert(
+      CreatureUtil.makeUUID(safe) !== CreatureUtil.makeUUID(aggressive),
+      "fixture sanity: variants must differ",
+    );
+    assertEquals(
+      selectCompactVariant({ safe, aggressive }),
+      aggressive,
+      "higher-scoring distinct aggressive wins",
+    );
+  },
+);
+
+Deno.test(
+  "selectCompactVariant keeps safe when aggressive does not improve the score",
+  () => {
+    const safe = tinyCreature(0.1, 6);
+    const lower = tinyCreature(0.2, 5); // distinct, lower score
+    assertEquals(
+      selectCompactVariant({ safe, aggressive: lower }),
+      safe,
+      "lower-scoring aggressive must not displace the safe floor",
+    );
+
+    const tieSafe = tinyCreature(0.1, 5);
+    const tieAggr = tinyCreature(0.2, 5); // distinct, equal score
+    assertEquals(
+      selectCompactVariant({ safe: tieSafe, aggressive: tieAggr }),
+      tieSafe,
+      "ties keep the safe floor",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Plumbing so compaction can surface **two** candidates — a **safe** compact (all
exact, behaviour-preserving folds; score guaranteed ≥ original) and an
**aggressive** compact (safe folds plus future extra structural pruning) — and
feed both into the existing score-based selection so the best wins. The
aggressive gamble can never cost anything because the safe variant is the floor.

In this issue the aggressive pass is a **no-op placeholder equal to the safe
variant** (the real heuristic lands in the aggressive-pruning sub-issue of
#3029). Identical variants dedupe via the existing UUID dedup, so the duplicate
is never scored. Closes #3037.

### Changes

- **New `compactCreatureVariants(creature, feedbackLoop, mcmcTemperature)`**
  (`src/compact/CompactCreature.ts`) returning `{ safe?, aggressive? }`. The
  existing compaction body moved into an internal `buildSafeCompact()` that
  produces the safe variant; `aggressive` is the no-op placeholder (same
  creature) for now.
- **Back-compat preserved**: `compactCreature()` and `Creature.compact()` are
  thin wrappers that return the safe variant. New `Creature.compactVariants()`
  exposes both.
- **New `src/compact/CompactVariants.ts`**: the `CompactVariants` type plus
  `selectCompactVariant()` — picks the best single candidate for call sites that
  consume one creature. The safe variant is the floor (wins ties, is the
  fallback); an aggressive variant only displaces it when it is a *distinct*
  creature (different UUID) with a strictly higher finite score. Identical
  variants return the safe one without scoring the duplicate.
- **All four call sites updated to offer both candidates to selection**:
  - `src/blackbox/FineTune.ts` (acceptCandidate path) — offers both variants;
    `acceptCandidate`'s UUID set dedupes the identical placeholder.
  - `src/architecture/training/TrainingTeardown.ts`
  - `src/architecture/training/TrainingPredictiveCoding.ts`
  - `src/propagate/RemoveSyntheticSynapses.ts`

  The latter three route through `selectCompactVariant()`, which returns the
  safe variant today — preserving current behaviour while the aggressive pass is
  identical/absent.

### Flow

```mermaid
flowchart LR
    C[Creature.compactVariants] --> S[buildSafeCompact]
    S --> SV[safe variant]
    S --> AV[aggressive variant<br/>no-op placeholder = safe]
    SV --> SEL{score-based selection}
    AV --> SEL
    SEL -->|identical → UUID dedup| BEST[best candidate]
    SEL -->|distinct + higher score| BEST
```

## Evidence

Backend/compaction change only — no web interface to screenshot. Verified via
unit tests (`deno test`) and the full quality gate.

- New tests pass: `deno test test/compact/CompactCreatureVariants.ts` → 8/8.
- All compaction tests green: `deno test test/compact/*.ts` → 157/157.
- Call-site suites green: blackbox (82), `RemoveSyntheticSynapses` +
  `TrainingTeardown` + `PredictiveCodingTrainer` (20).
- Full `./quality.sh` ran fmt/lint/type-check + suite: **7288 passed**. The only
  failure was `test/mutate/ModBiasRegularisation.ts` — a pre-existing stochastic
  mutation test unrelated to compaction; it passes deterministically on re-run.

## Test Plan

Added `test/compact/CompactCreatureVariants.ts`:

- `compactCreatureVariants` returns both a safe and an aggressive candidate.
- `compactCreature` returns the safe variant (back-compat: same UUID as
  `variants.safe`).
- No-op aggressive pass dedupes to a single scored candidate via UUID (mirrors
  the call-site selection collapsing identical variants to one).
- `compactCreatureVariants` returns empty `{}` when nothing compacts.
- `selectCompactVariant` unit coverage: falls back to the present variant;
  keeps safe when variants are identical (distinct instances, same UUID);
  prefers a distinct strictly-higher-scoring aggressive; keeps safe on lower
  score or ties.



## Milestone
This PR is part of the **#3029 Compaction: return a safe constant-fold and an aggressive prune variant** milestone and targets the `milestone/3029-compaction-return-a-safe-constant-fold-and-an` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqhjj2y8-2c53d5`<!-- vibe-worker-issue-3037 -->