### PR TITLE
Compaction: aggressive structural low-impact pruning pass (#3038)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3038.md
+++ b/docs/archive/pr-summaries/pr-summary-3038.md
@@ -1,0 +1,77 @@
+# Compaction: aggressive structural low-impact pruning pass (Issue #3038)
+
+## Summary
+
+Replaces the no-op aggressive placeholder from the two-variant plumbing
+(#3037) with a real **aggressive** compaction pass. On top of the safe folds,
+it speculatively prunes low-impact structure using a **purely structural,
+dataset-free** heuristic and returns the result as a *candidate*. The existing
+score-gated selection keeps the candidate only if it beats the safe variant, so
+the safe variant remains the guaranteed floor and an over-eager prune costs
+nothing. **No training data is threaded into `compactCreature`.**
+
+Closes #3038.
+
+### What changed
+
+- **New `src/compact/AggressivePrune.ts`** — `aggressivePrune(export, threshold)`
+  drops untyped synapses whose `|weight|` is below a small structural threshold
+  (`AGGRESSIVE_PRUNE_WEIGHT_THRESHOLD = 1e-3`), **including** synapses feeding
+  aggregate consumers (`MAXIMUM`/`MINIMUM`/`HYPOT`/`HYPOTv2`) and non-constant
+  neurons — exactly the cases the exact/safe variant must leave untouched.
+  Safety rules mirror the safe pass: frozen synapses, typed synapses
+  (IF roles), and synapses into IF neurons are never pruned, and every output
+  keeps at least one inbound edge.
+- **`src/compact/CompactCreature.ts`** — `compactCreatureVariants` now builds
+  the aggressive candidate on top of the safe variant via `buildAggressiveCompact`:
+  prune low-impact synapses, then run the existing orphan / dead-subgraph
+  cleanup, and return a distinct creature only when the prune changed the
+  structure (otherwise the variants dedupe by UUID exactly as before).
+
+### Why it is safe
+
+- Aggressive = safe folds + extra pruning, so it is never structurally worse
+  than safe.
+- Pruning only removes synapses (never adds), so it cannot introduce backward
+  edges — no `feedbackLoop` handling is required.
+- The heuristic is dataset-free (synapse-weight magnitude only); the candidate
+  is score-gated by population selection.
+
+```mermaid
+flowchart LR
+    O[Original creature] --> S[buildSafeCompact<br/>exact folds]
+    S -->|safe floor| V{compactCreatureVariants}
+    S --> A[buildAggressiveCompact<br/>prune low-impact synapses<br/>+ orphan/dead cleanup]
+    A -->|distinct candidate| V
+    V --> SEL[selectCompactVariant<br/>score-gated]
+    SEL -->|aggressive beats safe| KEEP[aggressive]
+    SEL -->|otherwise| FLOOR[safe floor]
+```
+
+## Evidence
+
+Backend/library change with no web interface — verified via unit tests
+(`deno test`) and the full `./quality.sh` gate. Key behaviours covered:
+
+- `aggressivePrune` drops a low-impact synapse feeding a `MAXIMUM` aggregate.
+- Frozen low-impact synapses and an output's last inbound edge are preserved.
+- Via `compactCreatureVariants`, the aggressive variant has strictly fewer
+  synapses than the safe variant on a fixture where the safe pass keeps a
+  low-impact synapse.
+- The safe variant's UUID is identical with or without the aggressive pass.
+- A harmful prune (lower score) is rejected by `selectCompactVariant`, which
+  falls back to the safe floor.
+
+## Test Plan
+
+Added `test/compact/CompactCreatureAggressivePrune.ts`:
+
+- `aggressivePrune drops a low-impact synapse feeding a MAXIMUM aggregate`
+- `aggressivePrune never touches a frozen low-impact synapse`
+- `aggressivePrune keeps an output's last inbound edge`
+- `compactCreatureVariants: aggressive prunes a synapse the safe variant keeps`
+- `compactCreatureVariants: the safe variant is unchanged by the aggressive pass`
+- `compactCreatureVariants: a harmful aggressive prune is rejected by selection`
+- `compactCreatureVariants: aggressive equals safe when nothing is low-impact`
+
+Existing `test/compact/CompactCreatureVariants.ts` continues to pass unchanged.

--- a/src/compact/AggressivePrune.ts
+++ b/src/compact/AggressivePrune.ts
@@ -1,0 +1,109 @@
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import type { NeuronExport } from "@architecture/NeuronInterfaces.ts";
+import type { SynapseExport } from "@architecture/SynapseInterfaces.ts";
+import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
+
+/**
+ * Default structural threshold below which a synapse weight is judged
+ * "low-impact" (Issue #3038). Purely structural and dataset-free — no error is
+ * ever measured on data here. The exact value is an implementation detail: the
+ * resulting candidate is score-gated by population selection, so the threshold
+ * is free to be tuned later without changing the contract.
+ */
+export const AGGRESSIVE_PRUNE_WEIGHT_THRESHOLD = 1e-3;
+
+/** Result of an aggressive structural prune pass. */
+export interface AggressivePruneResult {
+  /** Whether any synapse was pruned. */
+  changed: boolean;
+  /** Number of synapses removed. */
+  removedSynapses: number;
+}
+
+/**
+ * Aggressive, dataset-free structural prune (Issue #3038).
+ *
+ * Speculatively drops the low-impact synapses the **safe** compaction pass
+ * deliberately leaves untouched: small-magnitude untyped weights, *including*
+ * those feeding aggregate consumers (`MAXIMUM`/`MINIMUM`/`HYPOT`/`HYPOTv2`) and
+ * non-constant neurons — exactly the cases the exact/safe variant must not fold.
+ *
+ * "Low-impact" is judged **structurally only** (`|weight| < threshold`). No
+ * training data is threaded in and no error is measured: the pass is a gamble
+ * whose result is returned as a *candidate*. Population scoring keeps it only if
+ * it beats the safe floor, so an over-eager prune costs nothing.
+ *
+ * Safety rules (mirroring the safe pass so the candidate stays loadable):
+ * - Frozen synapses (Issue #1861) are never pruned.
+ * - Typed synapses (eg IF `condition`/`positive`/`negative` roles) are never
+ *   pruned — dropping one would break the aggregate's activation contract.
+ * - Synapses targeting an `IF` neuron are never pruned, even when untyped.
+ * - Every output neuron keeps at least one inbound synapse for structural
+ *   validity. Hidden neurons stranded by pruning are left to the dedicated
+ *   orphan / dead-subgraph cleanup that runs after this pass.
+ *
+ * The export is modified in place.
+ *
+ * @param creatureExport - The CreatureExport to prune (modified in place).
+ * @param weightThreshold - Magnitude below which a weight is low-impact.
+ * @returns Count of removed synapses and whether anything changed.
+ */
+export function aggressivePrune(
+  creatureExport: CreatureExport,
+  weightThreshold: number = AGGRESSIVE_PRUNE_WEIGHT_THRESHOLD,
+): AggressivePruneResult {
+  normaliseCreatureExport(creatureExport);
+
+  const ifNeuronIds = new Set<number>();
+  const outputNeuronIds = new Set<number>();
+  for (const neuron of creatureExport.neurons as NeuronExport[]) {
+    // CreatureExport.neurons excludes input neurons (they are implicit).
+    if (neuron.squash === "IF") ifNeuronIds.add(neuron.id!);
+    if (neuron.type === "output") outputNeuronIds.add(neuron.id!);
+  }
+
+  // A synapse is structurally pinned (never a prune candidate) when it is
+  // frozen, typed, or targets an IF neuron.
+  const isPinned = (s: SynapseExport): boolean =>
+    s.frozen === true || s.type !== undefined || ifNeuronIds.has(s.toId!);
+
+  // Count the inbound edges each output will retain so its last one is kept.
+  const outputInboundKept = new Map<number, number>();
+  for (const s of creatureExport.synapses) {
+    if (!outputNeuronIds.has(s.toId!)) continue;
+    if (isPinned(s) || Math.abs(s.weight) >= weightThreshold) {
+      outputInboundKept.set(s.toId!, (outputInboundKept.get(s.toId!) ?? 0) + 1);
+    }
+  }
+
+  const pruneSet = new Set<SynapseExport>();
+  for (const s of creatureExport.synapses) {
+    if (isPinned(s)) continue;
+    if (!Number.isFinite(s.weight)) continue;
+    if (Math.abs(s.weight) >= weightThreshold) continue;
+
+    // Keep the last inbound edge of an output for structural validity.
+    if (outputNeuronIds.has(s.toId!)) {
+      const kept = outputInboundKept.get(s.toId!) ?? 0;
+      if (kept === 0) {
+        outputInboundKept.set(s.toId!, 1);
+        continue;
+      }
+    }
+
+    pruneSet.add(s);
+  }
+
+  if (pruneSet.size === 0) return { changed: false, removedSynapses: 0 };
+
+  const before = creatureExport.synapses.length;
+  creatureExport.synapses = creatureExport.synapses.filter(
+    (s) => !pruneSet.has(s),
+  );
+  const removedSynapses = before - creatureExport.synapses.length;
+
+  // Structure changed, so cached memetic references are no longer trustworthy.
+  delete creatureExport.memetic;
+
+  return { changed: removedSynapses > 0, removedSynapses };
+}

--- a/src/compact/CompactCreature.ts
+++ b/src/compact/CompactCreature.ts
@@ -19,6 +19,7 @@ import { mergeParallelIdentityBridges } from "@compact/ParallelIdentityMerge.ts"
 import { mergeParallelBridges } from "@compact/ParallelBridgeMerge.ts";
 import { simplifyLargeWeights } from "@compact/SimplifyLargeWeights.ts";
 import { foldConstants } from "@compact/ConstantFold.ts";
+import { aggressivePrune } from "@compact/AggressivePrune.ts";
 import { collapseConstantIf } from "@compact/IfCollapse.ts";
 import { removeBackwardSynapses } from "@compact/RemoveBackwardSynapses.ts";
 import { mergeTagsByNameValue } from "@utils/TagUtils.ts";
@@ -31,10 +32,12 @@ import type { CompactVariants } from "@compact/CompactVariants.ts";
  *
  * The `safe` variant is the result of all exact, behaviour-preserving folds
  * (the long-standing {@link compactCreature} output). The `aggressive` variant
- * is the safe folds plus extra structural pruning; the aggressive heuristic
- * itself lands in the aggressive-pruning sub-issue of #3029, so for now it is a
- * no-op placeholder equal to the safe variant. Identical variants dedupe via
- * UUID downstream, so the duplicate is never scored.
+ * (Issue #3038) is the safe folds plus a dataset-free structural prune of
+ * low-impact synapses — including those feeding aggregate consumers and
+ * non-constant neurons that the safe pass must leave untouched. It is built on
+ * top of the safe variant, so it is never structurally worse than safe. When
+ * the prune finds nothing the two are identical and dedupe via UUID downstream,
+ * so the duplicate is never scored.
  *
  * @param creature - The creature to compact
  * @param feedbackLoop - Whether to use a feedback loop during compaction
@@ -52,11 +55,65 @@ export function compactCreatureVariants(
   const safe = buildSafeCompact(creature, feedbackLoop, mcmcTemperature);
   if (!safe) return {};
 
-  // No-op placeholder: the aggressive pass currently equals the safe variant.
-  // The real heuristic is the aggressive-pruning sub-issue of #3029. Returning
-  // the same creature keeps the gamble free and lets UUID dedup collapse the
-  // duplicate before selection scores it.
-  return { safe, aggressive: safe };
+  // Issue #3038: build the aggressive candidate on top of the safe floor by
+  // speculatively pruning low-impact structure. When the prune finds nothing,
+  // it returns the safe creature unchanged; identical variants then dedupe via
+  // UUID downstream so the duplicate is never scored.
+  const aggressive = buildAggressiveCompact(safe) ?? safe;
+  return { safe, aggressive };
+}
+
+/**
+ * Build the aggressive compaction candidate (Issue #3038): the safe variant
+ * plus a dataset-free structural prune of low-impact synapses. Returns a new
+ * creature only when the prune actually changed the structure; otherwise
+ * `undefined` so the caller can reuse the safe floor.
+ *
+ * No training data is threaded in — pruning is judged purely on synapse-weight
+ * magnitude. The result is a *candidate*: population scoring keeps it only if it
+ * beats the safe floor, so an over-eager prune costs nothing.
+ *
+ * Pruning only ever removes synapses (never adds), so it cannot introduce new
+ * backward edges — the safe floor's `removeBackwardSynapses` pass already
+ * settled forward-only semantics, hence no `feedbackLoop` handling here.
+ */
+function buildAggressiveCompact(
+  safe: Creature,
+): Creature | undefined {
+  const holdDebug = safe.DEBUG;
+  safe.DEBUG = false;
+  const safeExport = exportJSONUnchecked(safe);
+  safe.DEBUG = holdDebug;
+  normaliseCreatureExport(safeExport);
+
+  const candidate = cloneCreatureExport(safeExport);
+
+  const pruneResult = aggressivePrune(candidate);
+  if (!pruneResult.changed) return undefined;
+
+  // Clean up any structure the prune stranded (now-dangling neurons and
+  // subgraphs that can no longer influence an output).
+  cleanupOrphanedNeurons(candidate);
+  pruneDeadSubgraphs(candidate);
+
+  addTag(candidate, "approach", "compact" as Approach);
+  delete candidate.memetic;
+  removeTag(candidate, "approach-logged");
+
+  // Preserve forwardOnly semantics from the safe floor.
+  if (safe.forwardOnly === true) candidate.forwardOnly = true;
+
+  assertValidSynapseReferences(
+    candidate,
+    "before Creature.fromJSON in buildAggressiveCompact",
+  );
+
+  // Issue #2514: opt out of the load-side recurrent throw — like the safe
+  // path, this repair candidate may carry residual backward synapses that the
+  // load-side cleanup strips.
+  return Creature.fromJSON(candidate, false, "compactCreatureAggressive", {
+    throwOnRecurrent: "never",
+  });
 }
 
 /**

--- a/test/compact/CompactCreatureAggressivePrune.ts
+++ b/test/compact/CompactCreatureAggressivePrune.ts
@@ -1,0 +1,214 @@
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import {
+  AGGRESSIVE_PRUNE_WEIGHT_THRESHOLD,
+  aggressivePrune,
+} from "@compact/AggressivePrune.ts";
+import {
+  compactCreature,
+  compactCreatureVariants,
+} from "@compact/CompactCreature.ts";
+import { selectCompactVariant } from "@compact/CompactVariants.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+// Issue #3038: the aggressive compaction variant speculatively prunes
+// low-impact structure (small-magnitude synapse weights) — including synapses
+// feeding aggregate consumers (MAXIMUM/MINIMUM/HYPOT) that the exact/safe pass
+// must leave untouched. It is judged purely structurally (no training data), is
+// built on top of the safe floor, and is returned as a score-gated candidate.
+
+const TINY = AGGRESSIVE_PRUNE_WEIGHT_THRESHOLD / 1000; // safely low-impact
+
+Deno.test(
+  "aggressivePrune drops a low-impact synapse feeding a MAXIMUM aggregate",
+  () => {
+    const exp: CreatureExport = {
+      input: 2,
+      output: 1,
+      neurons: [
+        { type: "output", uuid: "output-0", bias: 0, squash: "MAXIMUM" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "output-0", weight: 1.5 },
+        { fromUUID: "input-1", toUUID: "output-0", weight: TINY },
+      ],
+    } as unknown as CreatureExport;
+
+    const result = aggressivePrune(exp);
+
+    assert(result.changed, "a low-impact synapse should be pruned");
+    assertEquals(result.removedSynapses, 1);
+    assertEquals(exp.synapses.length, 1, "only the strong synapse remains");
+    assert(
+      Math.abs(exp.synapses[0].weight) >= AGGRESSIVE_PRUNE_WEIGHT_THRESHOLD,
+      "the retained synapse is the high-impact one",
+    );
+  },
+);
+
+Deno.test("aggressivePrune never touches a frozen low-impact synapse", () => {
+  const exp: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 1.5 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: TINY, frozen: true },
+    ],
+  } as unknown as CreatureExport;
+
+  const result = aggressivePrune(exp);
+
+  assertEquals(result.changed, false, "frozen synapse must be preserved");
+  assertEquals(exp.synapses.length, 2);
+});
+
+Deno.test("aggressivePrune keeps an output's last inbound edge", () => {
+  // Both inbound edges are low-impact: one must survive for structural validity.
+  const exp: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: TINY },
+      { fromUUID: "input-1", toUUID: "output-0", weight: TINY },
+    ],
+  } as unknown as CreatureExport;
+
+  const result = aggressivePrune(exp);
+
+  assertEquals(result.removedSynapses, 1, "exactly one low-impact edge pruned");
+  assertEquals(exp.synapses.length, 1, "output keeps a last inbound edge");
+});
+
+/**
+ * A creature whose safe pass folds an exactly-zero synapse (so a safe variant
+ * exists) while retaining a low-impact synapse feeding a MAXIMUM aggregate that
+ * only the aggressive pass can prune.
+ */
+function aggressivelyPrunableCreature(): Creature {
+  const json: CreatureExport = {
+    input: 3,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", bias: 0, squash: "MAXIMUM" },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 2.0 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: 0 }, // safe prunes
+      { fromUUID: "input-2", toUUID: "output-0", weight: TINY }, // aggressive prunes
+    ],
+  } as unknown as CreatureExport;
+  return Creature.fromJSON(json, false);
+}
+
+Deno.test(
+  "compactCreatureVariants: aggressive prunes a synapse the safe variant keeps",
+  async () => {
+    await initWasmForTests();
+
+    const variants = compactCreatureVariants(
+      aggressivelyPrunableCreature(),
+      false,
+    );
+
+    assert(variants.safe !== undefined, "safe candidate should exist");
+    assert(variants.aggressive !== undefined, "aggressive candidate exists");
+
+    const safeSynapses = variants.safe!.exportJSON().synapses.length;
+    const aggressiveSynapses =
+      variants.aggressive!.exportJSON().synapses.length;
+
+    assert(
+      aggressiveSynapses < safeSynapses,
+      `aggressive (${aggressiveSynapses}) should drop the low-impact synapse the safe variant keeps (${safeSynapses})`,
+    );
+
+    // Distinct structure → distinct UUID so selection can score it.
+    assert(
+      CreatureUtil.makeUUID(variants.safe!) !==
+        CreatureUtil.makeUUID(variants.aggressive!),
+      "a real prune yields a distinct aggressive candidate",
+    );
+  },
+);
+
+Deno.test(
+  "compactCreatureVariants: the safe variant is unchanged by the aggressive pass",
+  async () => {
+    await initWasmForTests();
+
+    const safeOnly = compactCreature(aggressivelyPrunableCreature(), false);
+    const variants = compactCreatureVariants(
+      aggressivelyPrunableCreature(),
+      false,
+    );
+
+    assert(safeOnly !== undefined, "safe-only compaction should occur");
+    assertEquals(
+      CreatureUtil.makeUUID(variants.safe!),
+      CreatureUtil.makeUUID(safeOnly!),
+      "the safe floor is identical with or without the aggressive pass",
+    );
+  },
+);
+
+Deno.test(
+  "compactCreatureVariants: a harmful aggressive prune is rejected by selection",
+  async () => {
+    await initWasmForTests();
+
+    const variants = compactCreatureVariants(
+      aggressivelyPrunableCreature(),
+      false,
+    );
+
+    // Construct the prune to hurt the score: the safe floor scores higher.
+    variants.safe!.score = 10;
+    variants.aggressive!.score = 5;
+
+    assertEquals(
+      selectCompactVariant(variants),
+      variants.safe,
+      "score-gated selection falls back to the safe floor",
+    );
+  },
+);
+
+Deno.test(
+  "compactCreatureVariants: aggressive equals safe when nothing is low-impact",
+  async () => {
+    await initWasmForTests();
+
+    // A creature that compacts safely but has no low-impact (tiny) weights.
+    const json: CreatureExport = {
+      input: 2,
+      output: 1,
+      neurons: [
+        { type: "output", uuid: "output-0", bias: 0, squash: "MAXIMUM" },
+      ],
+      synapses: [
+        { fromUUID: "input-0", toUUID: "output-0", weight: 2.0 },
+        { fromUUID: "input-1", toUUID: "output-0", weight: 0 }, // safe prunes
+      ],
+    } as unknown as CreatureExport;
+
+    const variants = compactCreatureVariants(
+      Creature.fromJSON(json, false),
+      false,
+    );
+
+    assert(variants.safe !== undefined, "safe candidate should exist");
+    assertEquals(
+      CreatureUtil.makeUUID(variants.safe!),
+      CreatureUtil.makeUUID(variants.aggressive!),
+      "with no low-impact structure the variants dedupe to one",
+    );
+  },
+);


### PR DESCRIPTION
# Compaction: aggressive structural low-impact pruning pass (Issue #3038)

## Summary

Replaces the no-op aggressive placeholder from the two-variant plumbing
(#3037) with a real **aggressive** compaction pass. On top of the safe folds,
it speculatively prunes low-impact structure using a **purely structural,
dataset-free** heuristic and returns the result as a *candidate*. The existing
score-gated selection keeps the candidate only if it beats the safe variant, so
the safe variant remains the guaranteed floor and an over-eager prune costs
nothing. **No training data is threaded into `compactCreature`.**

Closes #3038.

### What changed

- **New `src/compact/AggressivePrune.ts`** — `aggressivePrune(export, threshold)`
  drops untyped synapses whose `|weight|` is below a small structural threshold
  (`AGGRESSIVE_PRUNE_WEIGHT_THRESHOLD = 1e-3`), **including** synapses feeding
  aggregate consumers (`MAXIMUM`/`MINIMUM`/`HYPOT`/`HYPOTv2`) and non-constant
  neurons — exactly the cases the exact/safe variant must leave untouched.
  Safety rules mirror the safe pass: frozen synapses, typed synapses
  (IF roles), and synapses into IF neurons are never pruned, and every output
  keeps at least one inbound edge.
- **`src/compact/CompactCreature.ts`** — `compactCreatureVariants` now builds
  the aggressive candidate on top of the safe variant via `buildAggressiveCompact`:
  prune low-impact synapses, then run the existing orphan / dead-subgraph
  cleanup, and return a distinct creature only when the prune changed the
  structure (otherwise the variants dedupe by UUID exactly as before).

### Why it is safe

- Aggressive = safe folds + extra pruning, so it is never structurally worse
  than safe.
- Pruning only removes synapses (never adds), so it cannot introduce backward
  edges — no `feedbackLoop` handling is required.
- The heuristic is dataset-free (synapse-weight magnitude only); the candidate
  is score-gated by population selection.

```mermaid
flowchart LR
    O[Original creature] --> S[buildSafeCompact<br/>exact folds]
    S -->|safe floor| V{compactCreatureVariants}
    S --> A[buildAggressiveCompact<br/>prune low-impact synapses<br/>+ orphan/dead cleanup]
    A -->|distinct candidate| V
    V --> SEL[selectCompactVariant<br/>score-gated]
    SEL -->|aggressive beats safe| KEEP[aggressive]
    SEL -->|otherwise| FLOOR[safe floor]
```

## Evidence

Backend/library change with no web interface — verified via unit tests
(`deno test`) and the full `./quality.sh` gate. Key behaviours covered:

- `aggressivePrune` drops a low-impact synapse feeding a `MAXIMUM` aggregate.
- Frozen low-impact synapses and an output's last inbound edge are preserved.
- Via `compactCreatureVariants`, the aggressive variant has strictly fewer
  synapses than the safe variant on a fixture where the safe pass keeps a
  low-impact synapse.
- The safe variant's UUID is identical with or without the aggressive pass.
- A harmful prune (lower score) is rejected by `selectCompactVariant`, which
  falls back to the safe floor.

## Test Plan

Added `test/compact/CompactCreatureAggressivePrune.ts`:

- `aggressivePrune drops a low-impact synapse feeding a MAXIMUM aggregate`
- `aggressivePrune never touches a frozen low-impact synapse`
- `aggressivePrune keeps an output's last inbound edge`
- `compactCreatureVariants: aggressive prunes a synapse the safe variant keeps`
- `compactCreatureVariants: the safe variant is unchanged by the aggressive pass`
- `compactCreatureVariants: a harmful aggressive prune is rejected by selection`
- `compactCreatureVariants: aggressive equals safe when nothing is low-impact`

Existing `test/compact/CompactCreatureVariants.ts` continues to pass unchanged.



## Milestone
This PR is part of the **#3029 Compaction: return a safe constant-fold and an aggressive prune variant** milestone and targets the `milestone/3029-compaction-return-a-safe-constant-fold-and-an` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqhmliiy-b2c10b`<!-- vibe-worker-issue-3038 -->