### PR TITLE
🟢 dead-code: unused export `asRecord` in TypeGuards.ts (Issue #3061)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.6.3",
+  "version": "5.6.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3061.md
+++ b/docs/archive/pr-summaries/pr-summary-3061.md
@@ -25,13 +25,16 @@ After removal, the surviving `isRecord` export is still imported and exercised:
 
 Verification commands:
 
-- `deno check src/utils/TypeGuards.ts src/creature/CreatureSerialization.ts` — passes.
+- `deno check src/utils/TypeGuards.ts src/creature/CreatureSerialization.ts` —
+  passes.
 - `deno test test/creature/SerialisationTypeSafety.ts` — 7 passed, 0 failed.
 - `./quality.sh` — 7356 passed, 0 failed, 4 ignored.
 
 ## Test Plan
 
 No new tests required — this is a dead-code deletion with no behaviour change.
-The existing `test/creature/SerialisationTypeSafety.ts::isRecord - validates
-plain objects` guards the surviving `isRecord` export, and the full quality gate
+The existing
+`test/creature/SerialisationTypeSafety.ts::isRecord - validates
+plain objects`
+guards the surviving `isRecord` export, and the full quality gate
 (`./quality.sh`) confirms nothing else depended on `asRecord`.

--- a/docs/archive/pr-summaries/pr-summary-3061.md
+++ b/docs/archive/pr-summaries/pr-summary-3061.md
@@ -1,0 +1,37 @@
+## Summary
+
+Removed the unused `asRecord` type-guard helper from `src/utils/TypeGuards.ts`.
+Static dead-code analysis flagged it as an unused export, and a full-repo search
+(`rg "\basRecord\b"`) confirmed the symbol appeared exactly once — its own
+declaration — with no importer, no quoted-string/dynamic reference, and no
+re-export from `mod.ts`. The sibling export `isRecord` remains and is still used
+by `src/creature/CreatureSerialization.ts`. Closes #3061.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+Confirmation that `asRecord` had no dynamic or reflective use before removal:
+
+```
+$ rg -n "asRecord" .
+./src/utils/TypeGuards.ts:25:export function asRecord(   # declaration only — now removed
+```
+
+After removal, the surviving `isRecord` export is still imported and exercised:
+
+- `src/creature/CreatureSerialization.ts` imports and calls `isRecord`.
+- `test/creature/SerialisationTypeSafety.ts` covers `isRecord` behaviour.
+
+Verification commands:
+
+- `deno check src/utils/TypeGuards.ts src/creature/CreatureSerialization.ts` — passes.
+- `deno test test/creature/SerialisationTypeSafety.ts` — 7 passed, 0 failed.
+- `./quality.sh` — 7356 passed, 0 failed, 4 ignored.
+
+## Test Plan
+
+No new tests required — this is a dead-code deletion with no behaviour change.
+The existing `test/creature/SerialisationTypeSafety.ts::isRecord - validates
+plain objects` guards the surviving `isRecord` export, and the full quality gate
+(`./quality.sh`) confirms nothing else depended on `asRecord`.

--- a/src/utils/TypeGuards.ts
+++ b/src/utils/TypeGuards.ts
@@ -16,14 +16,3 @@ export function isRecord(
   return value !== null && value !== undefined &&
     typeof value === "object" && !Array.isArray(value);
 }
-
-/**
- * Narrows a value to `Record<string, unknown>` when it is a plain object,
- * or returns `undefined` otherwise.  Useful at serialisation boundaries
- * where JSON-parsed data may not match the expected shape.
- */
-export function asRecord(
-  value: unknown,
-): Record<string, unknown> | undefined {
-  return isRecord(value) ? value : undefined;
-}


### PR DESCRIPTION
## Summary

Removed the unused `asRecord` type-guard helper from `src/utils/TypeGuards.ts`.
Static dead-code analysis flagged it as an unused export, and a full-repo search
(`rg "\basRecord\b"`) confirmed the symbol appeared exactly once — its own
declaration — with no importer, no quoted-string/dynamic reference, and no
re-export from `mod.ts`. The sibling export `isRecord` remains and is still used
by `src/creature/CreatureSerialization.ts`. Closes #3061.

## Evidence

Backend/library change only — no web interface to screenshot.

Confirmation that `asRecord` had no dynamic or reflective use before removal:

```
$ rg -n "asRecord" .
./src/utils/TypeGuards.ts:25:export function asRecord(   # declaration only — now removed
```

After removal, the surviving `isRecord` export is still imported and exercised:

- `src/creature/CreatureSerialization.ts` imports and calls `isRecord`.
- `test/creature/SerialisationTypeSafety.ts` covers `isRecord` behaviour.

Verification commands:

- `deno check src/utils/TypeGuards.ts src/creature/CreatureSerialization.ts` —
  passes.
- `deno test test/creature/SerialisationTypeSafety.ts` — 7 passed, 0 failed.
- `./quality.sh` — 7356 passed, 0 failed, 4 ignored.

## Test Plan

No new tests required — this is a dead-code deletion with no behaviour change.
The existing
`test/creature/SerialisationTypeSafety.ts::isRecord - validates
plain objects`
guards the surviving `isRecord` export, and the full quality gate
(`./quality.sh`) confirms nothing else depended on `asRecord`.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqk6z5zk-5ad6a0`<!-- vibe-worker-issue-3061 -->