### PR TITLE
Remove unused export filterCachedCandidates (Issue #3062)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3062.md
+++ b/docs/archive/pr-summaries/pr-summary-3062.md
@@ -1,0 +1,37 @@
+## Summary
+
+Removed the unused export `filterCachedCandidates` from
+`src/discovery/FailureCache.ts`. Static dead-code analysis flagged it as an
+unused export, and a whole-repo search (`grep -rn "filterCachedCandidates"
+--include="*.ts"`) confirmed the function had **no in-repo importer**, was not
+re-exported from `mod.ts`, and was not referenced by any test or dynamic/
+reflective lookup — only the declaration itself existed. Deleting it removes
+dead code with no behavioural impact.
+
+The helper it relied on, `isCandidateCachedSync`, remains in place — it is a
+public export still used by tests and other call sites, so it is unaffected.
+
+Closes #3062.
+
+## Evidence
+
+This is a backend/library change with no web interface to screenshot. Verified
+instead via:
+
+- **Whole-repo reference search** — `grep -rn "filterCachedCandidates"
+  --include="*.ts" .` returns no matches after removal (previously only the
+  declaration line).
+- **Type-check** — `deno check src/discovery/FailureCache.ts` passes.
+- **Full quality gate** — `./quality.sh` passes cleanly: **7356 passed, 0
+  failed, 4 ignored**.
+
+## Test Plan
+
+No new tests are required — this is a pure dead-code removal of an export with
+zero callers. The existing `FailureCache` test suite
+(`test/discovery/FailureCacheOperations.ts`,
+`test/discovery/FailureCacheErrorReduction.ts`,
+`test/discovery/FailureCacheKeys.ts`, and related specs) continues to pass,
+confirming the remaining cache functions (`isCandidateCached`,
+`isCandidateCachedSync`, `recordFailure`, `recordFailureSync`, `buildCacheKey`)
+are intact and behave as before.

--- a/docs/archive/pr-summaries/pr-summary-3062.md
+++ b/docs/archive/pr-summaries/pr-summary-3062.md
@@ -2,11 +2,12 @@
 
 Removed the unused export `filterCachedCandidates` from
 `src/discovery/FailureCache.ts`. Static dead-code analysis flagged it as an
-unused export, and a whole-repo search (`grep -rn "filterCachedCandidates"
---include="*.ts"`) confirmed the function had **no in-repo importer**, was not
-re-exported from `mod.ts`, and was not referenced by any test or dynamic/
-reflective lookup — only the declaration itself existed. Deleting it removes
-dead code with no behavioural impact.
+unused export, and a whole-repo search
+(`grep -rn "filterCachedCandidates"
+--include="*.ts"`) confirmed the function
+had **no in-repo importer**, was not re-exported from `mod.ts`, and was not
+referenced by any test or dynamic/ reflective lookup — only the declaration
+itself existed. Deleting it removes dead code with no behavioural impact.
 
 The helper it relied on, `isCandidateCachedSync`, remains in place — it is a
 public export still used by tests and other call sites, so it is unaffected.
@@ -18,9 +19,10 @@ Closes #3062.
 This is a backend/library change with no web interface to screenshot. Verified
 instead via:
 
-- **Whole-repo reference search** — `grep -rn "filterCachedCandidates"
-  --include="*.ts" .` returns no matches after removal (previously only the
-  declaration line).
+- **Whole-repo reference search** —
+  `grep -rn "filterCachedCandidates"
+  --include="*.ts" .` returns no matches
+  after removal (previously only the declaration line).
 - **Type-check** — `deno check src/discovery/FailureCache.ts` passes.
 - **Full quality gate** — `./quality.sh` passes cleanly: **7356 passed, 0
   failed, 4 ignored**.

--- a/src/discovery/FailureCache.ts
+++ b/src/discovery/FailureCache.ts
@@ -300,32 +300,3 @@ export function recordFailureSync(
     );
   }
 }
-
-/**
- * Filters candidates, removing those that are already cached as failures.
- *
- * @param cacheDir - The cache directory path (if undefined, no filtering is done)
- * @param candidates - The candidates to filter
- * @returns Object with filtered candidates and count of skipped candidates
- */
-export function filterCachedCandidates(
-  cacheDir: string | undefined,
-  candidates: DiscoveryCandidate[],
-): { filtered: DiscoveryCandidate[]; cachedCount: number } {
-  if (!cacheDir) {
-    return { filtered: candidates, cachedCount: 0 };
-  }
-
-  const filtered: DiscoveryCandidate[] = [];
-  let cachedCount = 0;
-
-  for (const candidate of candidates) {
-    if (isCandidateCachedSync(cacheDir, candidate)) {
-      cachedCount++;
-    } else {
-      filtered.push(candidate);
-    }
-  }
-
-  return { filtered, cachedCount };
-}


### PR DESCRIPTION
## Summary

Removed the unused export `filterCachedCandidates` from
`src/discovery/FailureCache.ts`. Static dead-code analysis flagged it as an
unused export, and a whole-repo search (`grep -rn "filterCachedCandidates"
--include="*.ts"`) confirmed the function had **no in-repo importer**, was not
re-exported from `mod.ts`, and was not referenced by any test or dynamic/
reflective lookup — only the declaration itself existed. Deleting it removes
dead code with no behavioural impact.

The helper it relied on, `isCandidateCachedSync`, remains in place — it is a
public export still used by tests and other call sites, so it is unaffected.

Closes #3062.

## Evidence

This is a backend/library change with no web interface to screenshot. Verified
instead via:

- **Whole-repo reference search** — `grep -rn "filterCachedCandidates"
  --include="*.ts" .` returns no matches after removal (previously only the
  declaration line).
- **Type-check** — `deno check src/discovery/FailureCache.ts` passes.
- **Full quality gate** — `./quality.sh` passes cleanly: **7356 passed, 0
  failed, 4 ignored**.

## Test Plan

No new tests are required — this is a pure dead-code removal of an export with
zero callers. The existing `FailureCache` test suite
(`test/discovery/FailureCacheOperations.ts`,
`test/discovery/FailureCacheErrorReduction.ts`,
`test/discovery/FailureCacheKeys.ts`, and related specs) continues to pass,
confirming the remaining cache functions (`isCandidateCached`,
`isCandidateCachedSync`, `recordFailure`, `recordFailureSync`, `buildCacheKey`)
are intact and behave as before.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqk98lrz-4b093c`<!-- vibe-worker-issue-3062 -->