### PR TITLE
Remove unused export getDistanceCacheMaxSize (Issue #3063)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3063.md
+++ b/docs/archive/pr-summaries/pr-summary-3063.md
@@ -1,0 +1,34 @@
+## Summary
+
+Removed the unused export `getDistanceCacheMaxSize` from
+`src/breed/DistanceCache.ts`. Static dead-code analysis (and a confirming
+repo-wide `grep`) found the accessor had no in-repo importer, no test caller,
+and was not re-exported from `mod.ts` — it was dead code.
+
+The current maximum cache size remains observable through the surviving public
+surface: `setDistanceCacheMaxSize()` sets it and `getDistanceCacheStats().maxSize`
+reads it back, so no behaviour is lost. Closes #3063.
+
+## Evidence
+
+Backend/library change with no web interface — no screenshot applicable.
+
+Verification performed:
+
+- `grep -rn "getDistanceCacheMaxSize" --include="*.ts"` returned only the
+  declaration before removal (no callers), confirming the function was dead.
+- `deno test test/breed/DistanceCache.ts` passes (11 tests) after removal.
+- Pre-existing flaky test `test/NEAT/RandomImmigrantsStagnationEscape.ts`
+  (`createCompatibleFatherFromCreatures` in `src/breed/Father.ts`) intermittently
+  fails in the full parallel `quality.sh` run. It passes in isolation **both
+  with and without** this change, so it is unrelated to this dead-code removal.
+
+## Test Plan
+
+- Added `test/breed/DistanceCache.ts::"DistanceCache - max size is observable
+  via stats"` — sets the max size via `setDistanceCacheMaxSize` and asserts it
+  is reflected in `getDistanceCacheStats().maxSize`, including the clamp-to-1
+  behaviour for values below 1. This locks in the replacement read path for the
+  removed accessor.
+- Existing `DistanceCache` and `CacheDiagnostics` tests continue to pass
+  unchanged.

--- a/docs/archive/pr-summaries/pr-summary-3063.md
+++ b/docs/archive/pr-summaries/pr-summary-3063.md
@@ -6,8 +6,9 @@ repo-wide `grep`) found the accessor had no in-repo importer, no test caller,
 and was not re-exported from `mod.ts` — it was dead code.
 
 The current maximum cache size remains observable through the surviving public
-surface: `setDistanceCacheMaxSize()` sets it and `getDistanceCacheStats().maxSize`
-reads it back, so no behaviour is lost. Closes #3063.
+surface: `setDistanceCacheMaxSize()` sets it and
+`getDistanceCacheStats().maxSize` reads it back, so no behaviour is lost. Closes
+#3063.
 
 ## Evidence
 
@@ -19,16 +20,19 @@ Verification performed:
   declaration before removal (no callers), confirming the function was dead.
 - `deno test test/breed/DistanceCache.ts` passes (11 tests) after removal.
 - Pre-existing flaky test `test/NEAT/RandomImmigrantsStagnationEscape.ts`
-  (`createCompatibleFatherFromCreatures` in `src/breed/Father.ts`) intermittently
-  fails in the full parallel `quality.sh` run. It passes in isolation **both
-  with and without** this change, so it is unrelated to this dead-code removal.
+  (`createCompatibleFatherFromCreatures` in `src/breed/Father.ts`)
+  intermittently fails in the full parallel `quality.sh` run. It passes in
+  isolation **both with and without** this change, so it is unrelated to this
+  dead-code removal.
 
 ## Test Plan
 
-- Added `test/breed/DistanceCache.ts::"DistanceCache - max size is observable
-  via stats"` — sets the max size via `setDistanceCacheMaxSize` and asserts it
-  is reflected in `getDistanceCacheStats().maxSize`, including the clamp-to-1
-  behaviour for values below 1. This locks in the replacement read path for the
-  removed accessor.
+- Added
+  `test/breed/DistanceCache.ts::"DistanceCache - max size is observable
+  via stats"`
+  — sets the max size via `setDistanceCacheMaxSize` and asserts it is reflected
+  in `getDistanceCacheStats().maxSize`, including the clamp-to-1 behaviour for
+  values below 1. This locks in the replacement read path for the removed
+  accessor.
 - Existing `DistanceCache` and `CacheDiagnostics` tests continue to pass
   unchanged.

--- a/src/breed/DistanceCache.ts
+++ b/src/breed/DistanceCache.ts
@@ -93,13 +93,6 @@ export function setDistanceCacheMaxSize(max: number): void {
 }
 
 /**
- * Get the current maximum cache size.
- */
-export function getDistanceCacheMaxSize(): number {
-  return maxSize;
-}
-
-/**
  * Return the current number of cached entries.
  */
 export function getDistanceCacheSize(): number {

--- a/test/breed/DistanceCache.ts
+++ b/test/breed/DistanceCache.ts
@@ -119,6 +119,20 @@ Deno.test("DistanceCache - LRU eviction when exceeding max size", () => {
   clearDistanceCache();
 });
 
+Deno.test("DistanceCache - max size is observable via stats", () => {
+  clearDistanceCache();
+  setDistanceCacheMaxSize(42);
+  assertEquals(getDistanceCacheStats().maxSize, 42);
+
+  // Values below 1 are clamped to 1.
+  setDistanceCacheMaxSize(0);
+  assertEquals(getDistanceCacheStats().maxSize, 1);
+
+  // Reset to default for other tests.
+  setDistanceCacheMaxSize(10_000);
+  clearDistanceCache();
+});
+
 Deno.test("DistanceCache - stats track hits and misses", () => {
   clearDistanceCache();
   setCachedDistance("s1", "s2", 0.9);


### PR DESCRIPTION
## Summary

Removed the unused export `getDistanceCacheMaxSize` from
`src/breed/DistanceCache.ts`. Static dead-code analysis (and a confirming
repo-wide `grep`) found the accessor had no in-repo importer, no test caller,
and was not re-exported from `mod.ts` — it was dead code.

The current maximum cache size remains observable through the surviving public
surface: `setDistanceCacheMaxSize()` sets it and `getDistanceCacheStats().maxSize`
reads it back, so no behaviour is lost. Closes #3063.

## Evidence

Backend/library change with no web interface — no screenshot applicable.

Verification performed:

- `grep -rn "getDistanceCacheMaxSize" --include="*.ts"` returned only the
  declaration before removal (no callers), confirming the function was dead.
- `deno test test/breed/DistanceCache.ts` passes (11 tests) after removal.
- Pre-existing flaky test `test/NEAT/RandomImmigrantsStagnationEscape.ts`
  (`createCompatibleFatherFromCreatures` in `src/breed/Father.ts`) intermittently
  fails in the full parallel `quality.sh` run. It passes in isolation **both
  with and without** this change, so it is unrelated to this dead-code removal.

## Test Plan

- Added `test/breed/DistanceCache.ts::"DistanceCache - max size is observable
  via stats"` — sets the max size via `setDistanceCacheMaxSize` and asserts it
  is reflected in `getDistanceCacheStats().maxSize`, including the clamp-to-1
  behaviour for values below 1. This locks in the replacement read path for the
  removed accessor.
- Existing `DistanceCache` and `CacheDiagnostics` tests continue to pass
  unchanged.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqkce2j8-abb955`<!-- vibe-worker-issue-3063 -->