### PR TITLE
🟢 dead-code: remove unused export MIN_COST_OF_GROWTH (Issue #3064)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.6.5",
+  "version": "5.6.6",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3064.md
+++ b/docs/archive/pr-summaries/pr-summary-3064.md
@@ -1,0 +1,36 @@
+# 🟢 dead-code: remove unused export `MIN_COST_OF_GROWTH`
+
+## Summary
+
+Static dead-code analysis flagged `MIN_COST_OF_GROWTH` in
+`src/config/NeatConfig.ts` as an unused export. A full-repo search
+(`rg "MIN_COST_OF_GROWTH"` plus a broader `costOfGrowth` / `COST_OF_GROWTH`
+sweep) confirmed the constant appeared only at its own declaration — no
+importer, no `mod.ts` re-export, and no string-keyed/dynamic config lookup
+referencing it. It is a genuinely dead config constant, so it has been
+removed along with its doc comment. Closes #3064.
+
+## Evidence
+
+This is a backend/library change with no web interface to screenshot.
+Verification was via the project quality gate:
+
+- `./quality.sh` passed cleanly: **7356 passed | 0 failed | 4 ignored**.
+- `deno lint` (unused-symbol detection) and `deno check` (type-check) both
+  pass with the constant removed, confirming nothing in the tree consumed it.
+
+```mermaid
+flowchart LR
+    A["rg MIN_COST_OF_GROWTH"] --> B{"any importer<br/>or dynamic use?"}
+    B -- "no — declaration only" --> C["Delete constant"]
+    C --> D["./quality.sh<br/>7356 passed, 0 failed"]
+```
+
+## Test Plan
+
+No new test was added: an "absence of export" assertion would be a
+structural ("how") test, which the project's testing policy disallows. The
+existing quality gate is the correct verifier here — `deno lint` and
+`deno check` fail on a dangling reference, and the full test suite
+(7356 tests) confirms no behavioural regression. This mirrors the prior
+dead-code removals (#3060, #3061, #3062).

--- a/docs/archive/pr-summaries/pr-summary-3064.md
+++ b/docs/archive/pr-summaries/pr-summary-3064.md
@@ -7,8 +7,8 @@ Static dead-code analysis flagged `MIN_COST_OF_GROWTH` in
 (`rg "MIN_COST_OF_GROWTH"` plus a broader `costOfGrowth` / `COST_OF_GROWTH`
 sweep) confirmed the constant appeared only at its own declaration — no
 importer, no `mod.ts` re-export, and no string-keyed/dynamic config lookup
-referencing it. It is a genuinely dead config constant, so it has been
-removed along with its doc comment. Closes #3064.
+referencing it. It is a genuinely dead config constant, so it has been removed
+along with its doc comment. Closes #3064.
 
 ## Evidence
 
@@ -16,8 +16,8 @@ This is a backend/library change with no web interface to screenshot.
 Verification was via the project quality gate:
 
 - `./quality.sh` passed cleanly: **7356 passed | 0 failed | 4 ignored**.
-- `deno lint` (unused-symbol detection) and `deno check` (type-check) both
-  pass with the constant removed, confirming nothing in the tree consumed it.
+- `deno lint` (unused-symbol detection) and `deno check` (type-check) both pass
+  with the constant removed, confirming nothing in the tree consumed it.
 
 ```mermaid
 flowchart LR
@@ -28,9 +28,8 @@ flowchart LR
 
 ## Test Plan
 
-No new test was added: an "absence of export" assertion would be a
-structural ("how") test, which the project's testing policy disallows. The
-existing quality gate is the correct verifier here — `deno lint` and
-`deno check` fail on a dangling reference, and the full test suite
-(7356 tests) confirms no behavioural regression. This mirrors the prior
-dead-code removals (#3060, #3061, #3062).
+No new test was added: an "absence of export" assertion would be a structural
+("how") test, which the project's testing policy disallows. The existing quality
+gate is the correct verifier here — `deno lint` and `deno check` fail on a
+dangling reference, and the full test suite (7356 tests) confirms no behavioural
+regression. This mirrors the prior dead-code removals (#3060, #3061, #3062).

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -111,11 +111,6 @@ export const DEFAULT_DISCOVERY_RECORD_TIMEOUT_MINUTES = 5;
 export const DEFAULT_TRAINING_TASK_TIMEOUT_MINUTES = 5;
 
 /**
- * Minimum allowed cost of growth value.
- */
-export const MIN_COST_OF_GROWTH = 0.000_000_000_1;
-
-/**
  * Minimum allowed discovery analysis timeout in minutes.
  */
 export const MIN_ANALYSIS_TIMEOUT_MINUTES = 0.05; // 3 seconds


### PR DESCRIPTION
# 🟢 dead-code: remove unused export `MIN_COST_OF_GROWTH`

## Summary

Static dead-code analysis flagged `MIN_COST_OF_GROWTH` in
`src/config/NeatConfig.ts` as an unused export. A full-repo search
(`rg "MIN_COST_OF_GROWTH"` plus a broader `costOfGrowth` / `COST_OF_GROWTH`
sweep) confirmed the constant appeared only at its own declaration — no
importer, no `mod.ts` re-export, and no string-keyed/dynamic config lookup
referencing it. It is a genuinely dead config constant, so it has been removed
along with its doc comment. Closes #3064.

## Evidence

This is a backend/library change with no web interface to screenshot.
Verification was via the project quality gate:

- `./quality.sh` passed cleanly: **7356 passed | 0 failed | 4 ignored**.
- `deno lint` (unused-symbol detection) and `deno check` (type-check) both pass
  with the constant removed, confirming nothing in the tree consumed it.

```mermaid
flowchart LR
    A["rg MIN_COST_OF_GROWTH"] --> B{"any importer<br/>or dynamic use?"}
    B -- "no — declaration only" --> C["Delete constant"]
    C --> D["./quality.sh<br/>7356 passed, 0 failed"]
```

## Test Plan

No new test was added: an "absence of export" assertion would be a structural
("how") test, which the project's testing policy disallows. The existing quality
gate is the correct verifier here — `deno lint` and `deno check` fail on a
dangling reference, and the full test suite (7356 tests) confirms no behavioural
regression. This mirrors the prior dead-code removals (#3060, #3061, #3062).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqkepykj-a258d5`<!-- vibe-worker-issue-3064 -->