### PR TITLE
Bypass discovery failure cache during drought escalation (#3072)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.6.7",
+  "version": "5.6.8",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3072.md
+++ b/docs/archive/pr-summaries/pr-summary-3072.md
@@ -1,0 +1,79 @@
+# Discovery failure-cache bypass during drought escalation
+
+## Summary
+
+`CandidateFiltering.ts` dropped failure-cache hits _before_ Phase-1 evaluation
+regardless of the Rust-side drought state, so a plateaued creature whose
+candidates were all in the failure cache could go weeks without a single
+candidate reaching evaluation (observed on GRQ-3).
+
+This change lets discovery bypass the failure cache for the highest-value
+candidates while a drought escalation is active:
+
+- When the Rust discovery engine signals a drought — `noveltyEscalationActive`
+  or `creatureDroughtAlarm` (NEAT-AI-Discovery #1423) — and the new
+  `discoveryFailureCacheBypassOnDrought` option is enabled (default `true`), the
+  top-K cached candidates (ranked by `expectedErrorReduction`, K scaling with
+  the worker thread count) are re-admitted for evaluation instead of being
+  dropped.
+- The bypass is logged as
+  `[DiscoveryRunner] failure-cache bypass: N candidates re-evaluated (drought escalation)`.
+- `discoveryFailureCacheBypassOnDrought` is exposed on `NeatOptions` /
+  `NeatArguments` and defaults to `true`.
+
+When no drought is active, behaviour is unchanged: failure-cache hits are still
+dropped before slot allocation.
+
+Closes #3072.
+
+## Changes
+
+- `src/discovery/CandidateFiltering.ts` — drought bypass selecting top-K cached
+  candidates; `failureCacheBypass` diagnostics + log line.
+- `src/discovery/DiscoveryRunner.ts` — map drought metadata from the discovery
+  result and thread `droughtEscalationActive` through both filter call sites.
+- `src/config/NeatArguments.ts` + `src/config/NeatConfig.ts` — new
+  `discoveryFailureCacheBypassOnDrought` option (default `true`).
+- `src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts` — optional
+  `noveltyEscalationActive` / `creatureDroughtAlarm` metadata fields.
+- `docs/config/DISCOVERY.md` — documents the option and the bypass flow.
+
+## Evidence
+
+Backend/library change with no web interface — verified via automated tests and
+the project quality gates (`./quality.sh --check-only` and `--lint-only` both
+pass clean across the project).
+
+```mermaid
+flowchart TD
+    A[Discovery candidates] --> B{Failure-cache hit?}
+    B -->|No| E[Evaluate]
+    B -->|Yes| C{Drought escalation active<br/>and bypass enabled?}
+    C -->|No| D[Drop candidate]
+    C -->|Yes| F{Top-K by expected<br/>error reduction?}
+    F -->|Yes| E
+    F -->|No| D
+```
+
+## Test Plan
+
+Unit — `test/discovery/CandidateFilteringDroughtBypass.ts`:
+
+- drought bypass re-admits cached candidates for evaluation
+- bypass selects the highest-value cached candidate (top-K = 1)
+- top-K scales with thread count
+- no bypass when drought escalation inactive
+- no bypass when the option is disabled even during drought
+- non-cached candidates are unaffected by the bypass
+- `discoveryFailureCacheBypassOnDrought` defaults to `true`
+
+Integration (real Rust FFI failure cache) —
+`test/discovery/DiscoveryRunnerDroughtBypass.ts`:
+
+- creature with a full failure cache + drought counter → ≥1 candidate
+  re-evaluated (acceptance criterion 1); same candidate stays skipped without
+  drought
+- with bypass disabled, the cached candidate stays skipped even during drought
+
+All 563 `test/discovery/*.ts` tests pass, plus the configuration-guide defaults
+suite.

--- a/docs/config/DISCOVERY.md
+++ b/docs/config/DISCOVERY.md
@@ -154,16 +154,51 @@ Bounded concurrency for replay scoring operations.
 
 ## 💾 Caching
 
-| Option                     | Type     | Default                       | Description                                 |
-| -------------------------- | -------- | ----------------------------- | ------------------------------------------- |
-| `discoveryCacheDir`        | `string` | `undefined`                   | Base directory for discovery caching        |
-| `discoveryFailureCacheDir` | `string` | `{discoveryCacheDir}/failure` | Directory for caching failed candidates     |
-| `discoverySuccessCacheDir` | `string` | `{discoveryCacheDir}/success` | Directory for caching successful candidates |
+| Option                                 | Type      | Default                       | Description                                                |
+| -------------------------------------- | --------- | ----------------------------- | ---------------------------------------------------------- |
+| `discoveryCacheDir`                    | `string`  | `undefined`                   | Base directory for discovery caching                       |
+| `discoveryFailureCacheDir`             | `string`  | `{discoveryCacheDir}/failure` | Directory for caching failed candidates                    |
+| `discoverySuccessCacheDir`             | `string`  | `{discoveryCacheDir}/success` | Directory for caching successful candidates                |
+| `discoveryFailureCacheBypassOnDrought` | `boolean` | `true`                        | Re-admit top-K failure-cache hits during a drought (#3072) |
 
 > [!WARNING]
 > Delete the cache directory when the training dataset changes materially.
 > Replaying cached discoveries against a substantially different dataset can
 > introduce stale structural signals that degrade training quality.
+
+### `discoveryFailureCacheBypassOnDrought`
+
+**Default: true** | Type: boolean
+
+Normally `CandidateFiltering` drops failure-cache hits _before_ Phase-1
+evaluation so previously-failed candidates never consume evaluation slots. For a
+plateaued creature this can be self-defeating: once every candidate is in the
+failure cache, **no** candidate reaches evaluation and the creature can never
+escape the drought.
+
+When the Rust discovery engine raises a drought signal —
+`noveltyEscalationActive` or `creatureDroughtAlarm` (NEAT-AI-Discovery #1423) —
+and this option is enabled, the candidate filter re-admits the top-K
+highest-value cached candidates (ranked by `expectedErrorReduction`, K scaling
+with the worker thread count) so at least one candidate is re-evaluated. The
+bypass is logged as:
+
+```text
+[DiscoveryRunner] failure-cache bypass: N candidates re-evaluated (drought escalation)
+```
+
+Set to `false` to keep the strict failure-cache filter even during a drought.
+
+```mermaid
+flowchart TD
+    A[Discovery candidates] --> B{Failure-cache hit?}
+    B -->|No| E[Evaluate]
+    B -->|Yes| C{Drought escalation<br/>active and bypass enabled?}
+    C -->|No| D[Drop candidate]
+    C -->|Yes| F{Top-K by expected<br/>error reduction?}
+    F -->|Yes| E
+    F -->|No| D
+```
 
 ## 🐛 Debug options
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
@@ -78,4 +78,19 @@ export interface DiscoverResult {
    * evidence that no structural improvement exists.
    */
   heapAbortedAtExtensionBoundary?: boolean;
+
+  /**
+   * Issue #3072: Set to `true` by the Rust discovery engine (NEAT-AI-Discovery
+   * #1423) when novelty escalation is active for a plateaued creature. While
+   * active, the TypeScript candidate filter bypasses the failure cache for the
+   * top-K candidates so a plateaued creature is not starved of all candidates.
+   */
+  noveltyEscalationActive?: boolean;
+
+  /**
+   * Issue #3072: Set to `true` by the Rust discovery engine when the creature
+   * drought alarm has fired (no accepted candidates for an extended period).
+   * Treated identically to `noveltyEscalationActive` for failure-cache bypass.
+   */
+  creatureDroughtAlarm?: boolean;
 }

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -474,6 +474,22 @@ export interface NeatArguments {
   discoverySuccessCacheDir?: string;
 
   /**
+   * When true, the discovery failure cache is bypassed for the top-K candidates
+   * while a drought escalation is active (Issue #3072).
+   *
+   * The Rust discovery engine raises a drought signal — `noveltyEscalationActive`
+   * or `creatureDroughtAlarm` — when a creature has plateaued and no candidates
+   * have been accepted for an extended period. Normally `CandidateFiltering`
+   * drops failure-cache hits before Phase-1 evaluation, which can starve a
+   * plateaued creature of all candidates. When this option is enabled and a
+   * drought signal is present, the highest-value cached candidates are
+   * re-admitted for re-evaluation so the creature can escape the drought.
+   *
+   * Defaults to true.
+   */
+  discoveryFailureCacheBypassOnDrought: boolean;
+
+  /**
    * Maximum number of cached successful candidates to re-score during replay.
    *
    * Defaults are applied in createNeatConfig().

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -579,6 +579,8 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
       const base = options.discoveryCacheDir?.trim();
       return base ? `${base}/success` : undefined;
     })(),
+    discoveryFailureCacheBypassOnDrought:
+      options.discoveryFailureCacheBypassOnDrought ?? true,
     discoveryReplayMaxSingles: parseNumber(
       "Discovery replay max singles",
       opts.discoveryReplayMaxSingles,

--- a/src/discovery/CandidateFiltering.ts
+++ b/src/discovery/CandidateFiltering.ts
@@ -42,6 +42,15 @@ export interface FilterCandidatesForEvaluationDeps {
    * Inject a stub in tests for determinism and to avoid filesystem access.
    */
   getSuccessfulRemovalIds?: (dir: string) => Set<string>;
+  /**
+   * Issue #3072: When `true`, the Rust discovery engine has signalled a drought
+   * escalation (novelty escalation active or creature drought alarm fired). When
+   * combined with `config.discoveryFailureCacheBypassOnDrought` and a configured
+   * failure cache directory, the highest-value cached candidates are re-admitted
+   * for evaluation instead of being dropped, so a plateaued creature is not
+   * starved of all candidates.
+   */
+  droughtEscalationActive?: boolean;
 }
 
 export interface FilterCandidatesForEvaluationDiagnostics {
@@ -52,6 +61,13 @@ export interface FilterCandidatesForEvaluationDiagnostics {
     cachedOther: number;
     totalCached: number;
     cachedOtherByType: Map<string, number>;
+  };
+  /**
+   * Issue #3072: Number of failure-cache hits re-admitted for evaluation because
+   * a drought escalation was active. Present (and > 0) only when the bypass fired.
+   */
+  failureCacheBypass?: {
+    count: number;
   };
   categoryDiversity?: Map<string, { selected: number; total: number }>;
   removalSelection?: {
@@ -107,15 +123,50 @@ export function filterCandidatesForEvaluation(
     type === "remove-low-impact" || type === "remove-neuron" ||
     type === "remove-synapse" || type === "cache-informed-removal";
 
+  // Compute failure-cache status once per candidate (single filesystem pass).
+  const cachedStatus = new Map<DiscoveryCandidate, boolean>();
+  if (failureCacheDir) {
+    for (const candidate of candidates) {
+      cachedStatus.set(
+        candidate,
+        isCandidateCached(failureCacheDir, candidate),
+      );
+    }
+  }
+
+  // Issue #3072: During a drought escalation, re-admit the top-K cached
+  // candidates for evaluation rather than dropping them. Without this, a
+  // plateaued creature whose candidates are all in the failure cache would
+  // never have a single candidate reach Phase-1 evaluation.
+  const bypassFailureCache = Boolean(
+    failureCacheDir &&
+      deps.droughtEscalationActive &&
+      config.discoveryFailureCacheBypassOnDrought,
+  );
+  const bypassedCandidates = new Set<DiscoveryCandidate>();
+  if (bypassFailureCache) {
+    const expectedOf = (candidate: DiscoveryCandidate): number => {
+      const value = candidate.change.expectedErrorReduction;
+      return Number.isFinite(value) ? (value ?? 0) : 0;
+    };
+    const bypassTopK = Math.max(1, threadCount);
+    const cachedSorted = candidates
+      .filter((candidate) => cachedStatus.get(candidate) === true)
+      .sort((a, b) => expectedOf(b) - expectedOf(a));
+    for (const candidate of cachedSorted.slice(0, bypassTopK)) {
+      bypassedCandidates.add(candidate);
+    }
+  }
+
   // Filter cached candidates first so they never consume slots.
   const nonRemovalCandidates: DiscoveryCandidate[] = [];
   const removalCandidates: DiscoveryCandidate[] = [];
 
   for (const candidate of candidates) {
     const changeType = candidate.change.type;
-    const cached = failureCacheDir
-      ? isCandidateCached(failureCacheDir, candidate)
-      : false;
+    // A bypassed candidate is treated as not-cached so it re-enters selection.
+    const cached = (cachedStatus.get(candidate) ?? false) &&
+      !bypassedCandidates.has(candidate);
 
     if (isRemovalType(changeType)) {
       cacheStats.totalRemoval++;
@@ -145,6 +196,10 @@ export function filterCandidatesForEvaluation(
       ...cacheStats,
       totalCached,
     };
+  }
+
+  if (bypassedCandidates.size > 0) {
+    diagnostics.failureCacheBypass = { count: bypassedCandidates.size };
   }
 
   // Group non-removal candidates by change type.
@@ -490,6 +545,15 @@ export function logFilteringDiagnostics(
         } due to previous failure: ${parts.join(", ")}`,
       );
     }
+  }
+
+  // Log failure-cache bypass summary (Issue #3072).
+  if (
+    diagnostics?.failureCacheBypass && diagnostics.failureCacheBypass.count > 0
+  ) {
+    getLogger().info(
+      `[DiscoveryRunner] failure-cache bypass: ${diagnostics.failureCacheBypass.count} candidates re-evaluated (drought escalation)`,
+    );
   }
 
   // Log diversity selection summary for non-removal categories.

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -241,7 +241,18 @@ export class DiscoveryRunner {
         removalCandidates: rawDiscover.removalCandidates ?? undefined,
         candidateSquashes: rawDiscover.candidateSquashes ?? undefined,
         reScoringTime: undefined, // Will be set after re-scoring completes
+        noveltyEscalationActive: rawDiscover.noveltyEscalationActive ??
+          undefined,
+        creatureDroughtAlarm: rawDiscover.creatureDroughtAlarm ?? undefined,
       };
+
+      // Issue #3072: A drought escalation (novelty escalation active or the
+      // creature drought alarm) lets the candidate filter bypass the failure
+      // cache for the top-K candidates so a plateaued creature is not starved.
+      const droughtEscalationActive = Boolean(
+        discoverResult.noveltyEscalationActive ||
+          discoverResult.creatureDroughtAlarm,
+      );
 
       const addCount = discoverResult.addHelpfulSynapses?.length ?? 0;
       const neuronCount = discoverResult.addHelpfulNeurons?.length ?? 0;
@@ -305,6 +316,7 @@ export class DiscoveryRunner {
           workerCount,
           config,
           failureCacheDir,
+          droughtEscalationActive,
         );
       if (skipped.length > 0) {
         // Group skipped candidates by type for a cleaner summary
@@ -457,6 +469,7 @@ export class DiscoveryRunner {
               workerCount,
               config,
               failureCacheDir,
+              droughtEscalationActive,
             );
 
           // Note: Cached candidates are already filtered out in #filterCandidatesForEvaluation
@@ -620,6 +633,7 @@ export class DiscoveryRunner {
     threadCount: number,
     config: NeatConfig,
     failureCacheDir?: string,
+    droughtEscalationActive?: boolean,
   ): {
     filtered: DiscoveryCandidate[];
     skipped: Array<{
@@ -641,6 +655,7 @@ export class DiscoveryRunner {
         isCandidateCached: isCandidateCachedSync,
         random: Math.random,
         successCacheDir: config.discoverySuccessCacheDir,
+        droughtEscalationActive,
       },
     );
 

--- a/test/discovery/CandidateFilteringDroughtBypass.ts
+++ b/test/discovery/CandidateFilteringDroughtBypass.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the failure-cache drought bypass in candidate filtering (Issue #3072).
+ *
+ * When the Rust discovery engine signals a drought escalation (novelty
+ * escalation active or the creature drought alarm), the candidate filter must
+ * re-admit the top-K failure-cache hits for evaluation rather than dropping
+ * them. Without this, a plateaued creature whose candidates are all cached as
+ * failures would never have a single candidate reach Phase-1 evaluation.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import type { Creature } from "@creature";
+import type {
+  DiscoveryCandidate,
+  DiscoveryChangeType,
+} from "@discovery/DiscoveryCandidates.ts";
+import { filterCandidatesForEvaluation } from "@discovery/CandidateFiltering.ts";
+
+function makeConfig(overrides: NeatOptions = {}) {
+  return createNeatConfig(overrides);
+}
+
+function makeCandidate(
+  type: DiscoveryChangeType,
+  expected: number,
+  description: string,
+): DiscoveryCandidate {
+  return {
+    creature: {} as unknown as Creature,
+    change: { type, expectedErrorReduction: expected, description },
+  };
+}
+
+const ALL_CACHED = () => true;
+
+Deno.test("filterCandidatesForEvaluation: drought bypass re-admits cached candidates for evaluation", () => {
+  const config = makeConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 1,
+      addSynapses: 0,
+      changeSquash: 0,
+      removeLowImpact: 0,
+    },
+  });
+
+  // Every candidate is a failure-cache hit (drought scenario).
+  const candidates: DiscoveryCandidate[] = [
+    makeCandidate("add-neurons", 0.2, "cached-1"),
+    makeCandidate("add-neurons", 0.5, "cached-2"),
+  ];
+
+  const { filtered, diagnostics } = filterCandidatesForEvaluation(
+    candidates,
+    1,
+    config,
+    {
+      failureCacheDir: "/tmp/failure-cache",
+      isCandidateCached: ALL_CACHED,
+      random: () => 0,
+      droughtEscalationActive: true,
+    },
+  );
+
+  // At least one candidate must reach evaluation despite the full failure cache.
+  assert(filtered.length >= 1, "expected at least one candidate after bypass");
+  assertEquals(diagnostics?.failureCacheBypass?.count, 1);
+});
+
+Deno.test("filterCandidatesForEvaluation: drought bypass selects the highest-value cached candidate", () => {
+  const config = makeConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 1,
+      addSynapses: 0,
+      changeSquash: 0,
+      removeLowImpact: 0,
+    },
+  });
+
+  const candidates: DiscoveryCandidate[] = [
+    makeCandidate("add-neurons", 0.1, "low"),
+    makeCandidate("add-neurons", 0.9, "high"),
+    makeCandidate("add-neurons", 0.4, "mid"),
+  ];
+
+  // threadCount 1 → top-K = 1, so only the highest expected reduction is rescued.
+  const { filtered, diagnostics } = filterCandidatesForEvaluation(
+    candidates,
+    1,
+    config,
+    {
+      failureCacheDir: "/tmp/failure-cache",
+      isCandidateCached: ALL_CACHED,
+      random: () => 0,
+      droughtEscalationActive: true,
+    },
+  );
+
+  assertEquals(diagnostics?.failureCacheBypass?.count, 1);
+  assertEquals(filtered.length, 1);
+  assertEquals(filtered[0].change.description, "high");
+});
+
+Deno.test("filterCandidatesForEvaluation: top-K scales with thread count", () => {
+  const config = makeConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 2,
+      addSynapses: 0,
+      changeSquash: 0,
+      removeLowImpact: 0,
+    },
+  });
+
+  const candidates: DiscoveryCandidate[] = [
+    makeCandidate("add-neurons", 0.1, "c1"),
+    makeCandidate("add-neurons", 0.9, "c2"),
+    makeCandidate("add-neurons", 0.4, "c3"),
+  ];
+
+  // threadCount 2 → top-K = 2 cached candidates re-admitted.
+  const { diagnostics } = filterCandidatesForEvaluation(candidates, 2, config, {
+    failureCacheDir: "/tmp/failure-cache",
+    isCandidateCached: ALL_CACHED,
+    random: () => 0,
+    droughtEscalationActive: true,
+  });
+
+  assertEquals(diagnostics?.failureCacheBypass?.count, 2);
+});
+
+Deno.test("filterCandidatesForEvaluation: no bypass when drought escalation inactive", () => {
+  const config = makeConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 1,
+      addSynapses: 0,
+      changeSquash: 0,
+      removeLowImpact: 0,
+    },
+  });
+
+  const candidates: DiscoveryCandidate[] = [
+    makeCandidate("add-neurons", 0.2, "cached-1"),
+    makeCandidate("add-neurons", 0.5, "cached-2"),
+  ];
+
+  // Drought not active → cached candidates dropped as before.
+  const { filtered, diagnostics } = filterCandidatesForEvaluation(
+    candidates,
+    1,
+    config,
+    {
+      failureCacheDir: "/tmp/failure-cache",
+      isCandidateCached: ALL_CACHED,
+      random: () => 0,
+      droughtEscalationActive: false,
+    },
+  );
+
+  assertEquals(filtered.length, 0);
+  assertEquals(diagnostics?.failureCacheBypass, undefined);
+});
+
+Deno.test("filterCandidatesForEvaluation: no bypass when option disabled even during drought", () => {
+  const config = makeConfig({
+    discoveryFailureCacheBypassOnDrought: false,
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 1,
+      addSynapses: 0,
+      changeSquash: 0,
+      removeLowImpact: 0,
+    },
+  });
+
+  const candidates: DiscoveryCandidate[] = [
+    makeCandidate("add-neurons", 0.2, "cached-1"),
+    makeCandidate("add-neurons", 0.5, "cached-2"),
+  ];
+
+  const { filtered, diagnostics } = filterCandidatesForEvaluation(
+    candidates,
+    1,
+    config,
+    {
+      failureCacheDir: "/tmp/failure-cache",
+      isCandidateCached: ALL_CACHED,
+      random: () => 0,
+      droughtEscalationActive: true,
+    },
+  );
+
+  assertEquals(filtered.length, 0);
+  assertEquals(diagnostics?.failureCacheBypass, undefined);
+});
+
+Deno.test("filterCandidatesForEvaluation: non-cached candidates are unaffected by drought bypass", () => {
+  const config = makeConfig({
+    discoveryMinCandidatesPerCategory: {
+      addNeurons: 1,
+      addSynapses: 0,
+      changeSquash: 0,
+      removeLowImpact: 0,
+    },
+  });
+
+  const candidates: DiscoveryCandidate[] = [
+    makeCandidate("add-neurons", 0.2, "fresh-1"),
+    makeCandidate("add-neurons", 0.5, "fresh-2"),
+  ];
+
+  // Nothing is cached → bypass is a no-op, both fresh candidates flow through.
+  const { filtered, diagnostics } = filterCandidatesForEvaluation(
+    candidates,
+    1,
+    config,
+    {
+      failureCacheDir: "/tmp/failure-cache",
+      isCandidateCached: () => false,
+      random: () => 0,
+      droughtEscalationActive: true,
+    },
+  );
+
+  assertEquals(filtered.length, 2);
+  assertEquals(diagnostics?.failureCacheBypass, undefined);
+});
+
+Deno.test("createNeatConfig: discoveryFailureCacheBypassOnDrought defaults to true", () => {
+  const config = createNeatConfig({});
+  assertEquals(config.discoveryFailureCacheBypassOnDrought, true);
+});

--- a/test/discovery/DiscoveryRunnerDroughtBypass.ts
+++ b/test/discovery/DiscoveryRunnerDroughtBypass.ts
@@ -1,0 +1,237 @@
+/**
+ * Integration test for the failure-cache drought bypass (Issue #3072).
+ *
+ * Mirrors `DiscoveryRunnerFailureCache.ts` "skips cached candidates on
+ * subsequent runs", but with a drought escalation signalled on the second run.
+ * When `noveltyEscalationActive` is set, the previously-cached candidate must be
+ * re-admitted and re-evaluated rather than skipped — proving a plateaued
+ * creature with a full failure cache is no longer starved of all candidates.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import type { DiscoverResult } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
+import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
+import { DEFAULT_COST_OF_GROWTH } from "@config/NeatConfig.ts";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import type { Creature } from "@creature";
+import type { DiscoveryRunnerWorker } from "@discovery/DiscoveryRunner.ts";
+import { DiscoveryRunner } from "@discovery/DiscoveryRunner.ts";
+import { makeBaseCreature } from "../fixtures/SimpleCreatures.ts";
+
+class FakeWorker implements DiscoveryRunnerWorker {
+  #discoverResult: DiscoverResult;
+  #computeError: (creature: Creature) => number;
+
+  constructor(
+    discoverResult: DiscoverResult,
+    computeError: (creature: Creature) => number,
+  ) {
+    this.#discoverResult = discoverResult;
+    this.#computeError = computeError;
+  }
+
+  discover(
+    _creature: Creature,
+    _options: NeatOptions,
+  ): Promise<Awaited<ReturnType<DiscoveryRunnerWorker["discover"]>>> {
+    return Promise.resolve({
+      taskID: 1,
+      duration: 10,
+      discover: this.#discoverResult,
+    });
+  }
+
+  evaluate(
+    creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<Awaited<ReturnType<DiscoveryRunnerWorker["evaluate"]>>> {
+    return Promise.resolve({
+      taskID: 2,
+      duration: 5,
+      evaluate: { error: this.#computeError(creature) },
+    });
+  }
+
+  terminate(): void {
+    // no-op for fake worker
+  }
+}
+
+function makeOptions(overrides: NeatOptions = {}): NeatOptions {
+  return {
+    discoveryRecordTimeOutMinutes: 0.05,
+    discoveryAnalysisTimeoutMinutes: 0.05,
+    threads: 1,
+    costOfGrowth: DEFAULT_COST_OF_GROWTH,
+    costName: "MSE",
+    ...overrides,
+  };
+}
+
+function makeDiscoverResult(
+  overrides: Partial<DiscoverResult> = {},
+): DiscoverResult {
+  return {
+    ID: "DROUGHT_BYPASS_TEST",
+    addHelpfulSynapses: [{
+      fromNeuronUuid: "input-1",
+      toNeuronUuid: "hidden-1",
+      weight: 0.45,
+      targetNeuronImpact: 1.0,
+      expectedCreatureErrorReduction: 0,
+      expectedCreatureScoreGain: 0.2,
+      improvedCount: 5,
+      totalCount: 6,
+    }],
+    addHelpfulNeurons: undefined,
+    removeHarmfulSynapse: undefined,
+    removeHarmfulNeurons: undefined,
+    removalCandidates: undefined,
+    candidateSquashes: undefined,
+    ...overrides,
+  };
+}
+
+Deno.test({
+  name:
+    "DiscoveryRunner re-evaluates cached candidates during drought escalation",
+  // Uses Rust FFI via recordFailure -> getDiscoveryVersion
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const tempDir = await Deno.makeTempDir();
+    const cacheDir = `${tempDir}/failure-cache`;
+
+    try {
+      let evaluationCount = 0;
+      const computeError = (creature: Creature) => {
+        const json = creature.exportJSON();
+        normaliseCreatureExport(json);
+        const hasTestSynapse = json.synapses.some((s) =>
+          s.fromUUID === "input-1" && s.toUUID === "hidden-1" &&
+          Math.abs(s.weight - 0.45) < 1e-6
+        );
+        if (hasTestSynapse) evaluationCount++;
+        return 0.6; // All worse → candidate is cached as a failure.
+      };
+
+      const options = makeOptions({ discoveryFailureCacheDir: cacheDir });
+
+      // First run (no drought): populates the failure cache.
+      const runner1 = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () => new FakeWorker(makeDiscoverResult(), computeError),
+      });
+      await runner1.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options,
+      });
+      assert(evaluationCount >= 1, "First run should evaluate the candidate");
+
+      // Second run WITHOUT drought: the cached candidate is skipped.
+      evaluationCount = 0;
+      const runner2 = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () => new FakeWorker(makeDiscoverResult(), computeError),
+      });
+      await runner2.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options,
+      });
+      assertEquals(
+        evaluationCount,
+        0,
+        "Without drought, cached candidate should be skipped",
+      );
+
+      // Third run WITH drought escalation: the cached candidate is re-admitted.
+      evaluationCount = 0;
+      const runner3 = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            makeDiscoverResult({ noveltyEscalationActive: true }),
+            computeError,
+          ),
+      });
+      await runner3.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options,
+      });
+      assert(
+        evaluationCount >= 1,
+        `Drought escalation should re-evaluate the cached candidate, got ${evaluationCount}`,
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "DiscoveryRunner keeps failure-cache filter during drought when bypass disabled",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const tempDir = await Deno.makeTempDir();
+    const cacheDir = `${tempDir}/failure-cache`;
+
+    try {
+      let evaluationCount = 0;
+      const computeError = (creature: Creature) => {
+        const json = creature.exportJSON();
+        normaliseCreatureExport(json);
+        const hasTestSynapse = json.synapses.some((s) =>
+          s.fromUUID === "input-1" && s.toUUID === "hidden-1" &&
+          Math.abs(s.weight - 0.45) < 1e-6
+        );
+        if (hasTestSynapse) evaluationCount++;
+        return 0.6;
+      };
+
+      const options = makeOptions({
+        discoveryFailureCacheDir: cacheDir,
+        discoveryFailureCacheBypassOnDrought: false,
+      });
+
+      // First run: populate the cache.
+      const runner1 = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () => new FakeWorker(makeDiscoverResult(), computeError),
+      });
+      await runner1.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options,
+      });
+      assert(evaluationCount >= 1, "First run should evaluate the candidate");
+
+      // Second run WITH drought but bypass disabled: still skipped.
+      evaluationCount = 0;
+      const runner2 = new DiscoveryRunner({
+        rustDiscoveryEnabled: () => true,
+        workerFactory: () =>
+          new FakeWorker(
+            makeDiscoverResult({ creatureDroughtAlarm: true }),
+            computeError,
+          ),
+      });
+      await runner2.discoverDir({
+        creature: makeBaseCreature(),
+        dataDir: "/tmp/data",
+        options,
+      });
+      assertEquals(
+        evaluationCount,
+        0,
+        "Bypass disabled → cached candidate stays skipped even during drought",
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});


### PR DESCRIPTION
# Discovery failure-cache bypass during drought escalation

## Summary

`CandidateFiltering.ts` dropped failure-cache hits _before_ Phase-1 evaluation
regardless of the Rust-side drought state, so a plateaued creature whose
candidates were all in the failure cache could go weeks without a single
candidate reaching evaluation (observed on GRQ-3).

This change lets discovery bypass the failure cache for the highest-value
candidates while a drought escalation is active:

- When the Rust discovery engine signals a drought — `noveltyEscalationActive`
  or `creatureDroughtAlarm` (NEAT-AI-Discovery #1423) — and the new
  `discoveryFailureCacheBypassOnDrought` option is enabled (default `true`), the
  top-K cached candidates (ranked by `expectedErrorReduction`, K scaling with
  the worker thread count) are re-admitted for evaluation instead of being
  dropped.
- The bypass is logged as
  `[DiscoveryRunner] failure-cache bypass: N candidates re-evaluated (drought escalation)`.
- `discoveryFailureCacheBypassOnDrought` is exposed on `NeatOptions` /
  `NeatArguments` and defaults to `true`.

When no drought is active, behaviour is unchanged: failure-cache hits are still
dropped before slot allocation.

Closes #3072.

## Changes

- `src/discovery/CandidateFiltering.ts` — drought bypass selecting top-K cached
  candidates; `failureCacheBypass` diagnostics + log line.
- `src/discovery/DiscoveryRunner.ts` — map drought metadata from the discovery
  result and thread `droughtEscalationActive` through both filter call sites.
- `src/config/NeatArguments.ts` + `src/config/NeatConfig.ts` — new
  `discoveryFailureCacheBypassOnDrought` option (default `true`).
- `src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts` — optional
  `noveltyEscalationActive` / `creatureDroughtAlarm` metadata fields.
- `docs/config/DISCOVERY.md` — documents the option and the bypass flow.

## Evidence

Backend/library change with no web interface — verified via automated tests and
the project quality gates (`./quality.sh --check-only` and `--lint-only` both
pass clean across the project).

```mermaid
flowchart TD
    A[Discovery candidates] --> B{Failure-cache hit?}
    B -->|No| E[Evaluate]
    B -->|Yes| C{Drought escalation active<br/>and bypass enabled?}
    C -->|No| D[Drop candidate]
    C -->|Yes| F{Top-K by expected<br/>error reduction?}
    F -->|Yes| E
    F -->|No| D
```

## Test Plan

Unit — `test/discovery/CandidateFilteringDroughtBypass.ts`:

- drought bypass re-admits cached candidates for evaluation
- bypass selects the highest-value cached candidate (top-K = 1)
- top-K scales with thread count
- no bypass when drought escalation inactive
- no bypass when the option is disabled even during drought
- non-cached candidates are unaffected by the bypass
- `discoveryFailureCacheBypassOnDrought` defaults to `true`

Integration (real Rust FFI failure cache) —
`test/discovery/DiscoveryRunnerDroughtBypass.ts`:

- creature with a full failure cache + drought counter → ≥1 candidate
  re-evaluated (acceptance criterion 1); same candidate stays skipped without
  drought
- with bypass disabled, the cached candidate stays skipped even during drought

All 563 `test/discovery/*.ts` tests pass, plus the configuration-guide defaults
suite.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqkle3m8-401772`<!-- vibe-worker-issue-3072 -->