### PR TITLE
Discovery: focus-selection roulette diversity floor (#3074)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.6.9",
+  "version": "5.6.10",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3074.md
+++ b/docs/archive/pr-summaries/pr-summary-3074.md
@@ -1,0 +1,88 @@
+# Discovery focus-selection diversity floor (#3074)
+
+## Summary
+
+On a plateaued network the squared `error × impact` weighting in the discovery
+focus-selection roulette let a single neuron capture almost all of the wheel
+(~98% on the GRQ-3 fixture, 1673 neurons). Six neurons were nominally selected
+but the search effectively repeated the same target.
+
+This change adds a **diversity floor** to the TypeScript roulette path:
+
+1. **Water-fill cap.** Each neuron's roulette weight is iteratively clipped down
+   to at most a `1/N` share of the total (`N` = candidate count). At the fixed
+   point the heaviest neuron holds no more than `1/N` of the wheel, so it can no
+   longer dominate, while sub-mean weights keep their relative ordering. This
+   replaces a naive single-pass clip, which did not bound concentration when the
+   tail mass was smaller than the mean.
+2. **Concentration metric.** `weightConcentrationRatio` (heaviest neuron's share
+   of the floored weight, in `[0, 1]`) is recorded in `focus-selection.json` and
+   on the focus-selection summary, and surfaced in the discovery analysis logs
+   with a ⚠️ marker when it stays ≥ 0.5.
+3. **Drought round-robin.** When `epochsSinceLastAccepted` exceeds the drought
+   threshold (default 20), selection abandons roulette and rotates
+   deterministically through the top `3×count` ranked neurons, with the start
+   offset advanced by the drought length so successive plateaued epochs explore
+   distinct targets. This is exposed via an optional `diversity` argument on
+   `selectNeuronsWeightedByError`.
+
+The cap is always on and solves the production concentration problem; the
+round-robin is an optional, drought-gated path.
+
+Companion work: NEAT-AI-Discovery #1445 (Rust ranking diversity), GRQ #2764.
+
+Closes #3074.
+
+## Evidence
+
+This is a backend/library change with no web interface, so evidence is the unit
+test suite (`test/discovery/FocusSelectionDiversityFloor.ts`). The acceptance
+criteria are verified directly:
+
+- **GRQ-3 fixture** (1673 neurons, one holding ~98% pre-floor): the recorded
+  `weightConcentrationRatio` drops to ≈ `1/1673` — well below the `< 0.5`
+  target.
+- **Synthetic dominant neuron** (50 candidates): pre-floor share `> 0.9`,
+  post-floor `weightConcentrationRatio < 0.5`.
+
+```mermaid
+flowchart TD
+    A[error x impact weights] --> B[square + output-cap scale]
+    B --> C{drought?<br/>epochsSinceLastAccepted &gt; threshold}
+    C -- "yes" --> D[round-robin top 3xN<br/>rotate by drought length]
+    C -- "no" --> E[water-fill cap each weight to 1/N share]
+    E --> F[weightConcentrationRatio &le; 1/N]
+    F --> G[weighted roulette selection]
+    D --> H[focus-selection.json<br/>+ weightConcentrationRatio]
+    G --> H
+```
+
+## Test Plan
+
+New tests in `test/discovery/FocusSelectionDiversityFloor.ts` (pure "what"
+tests, no Rust/WASM required — they call the real `selectNeuronsWeightedByError`
+and assert on its output and the analysis JSON it writes):
+
+- `Diversity floor keeps weight concentration below 0.5 on a synthetic dominant
+  neuron`
+  — post-floor ratio `< 0.5`, pre-floor share `> 0.9`.
+- `Diversity floor bounds concentration on a GRQ-3 sized pool (1673 neurons)` —
+  acceptance fixture, ratio `< 0.5`.
+- `Diversity floor is a no-op for an already uniform distribution` — ratio
+  `1/N`.
+- `Drought triggers deterministic round-robin across distinct top-ranked
+  neurons`
+  — mode `round-robin`, 6 distinct neurons selected.
+- `Round-robin offset rotates with the drought length` — different drought
+  lengths yield different focus lists.
+- `No drought (epochs below threshold) keeps the weighted roulette path`.
+
+All existing focus-selection tests continue to pass, and the full `./quality.sh`
+gate (fmt, lint, type-check, tests) was run.
+
+### Note on field naming
+
+The new JSON field is camelCase `weightConcentrationRatio` to match the existing
+`focus-selection.json` schema (`totalWeightedSum`, `selectionMethod`, …); the
+issue's `weight_concentration_ratio` is the snake_case Rust-side spelling of the
+same metric.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
@@ -374,6 +374,21 @@ export async function runAnalysisLoop(
       );
     }
 
+    // Issue #3074: surface the diversity-floor weight concentration so a
+    // plateaued network (one neuron dominating the roulette) is visible in the
+    // normal discovery logs, not only in focus-selection.json.
+    if (shouldLogDiscovery(config)) {
+      const ratio = discoverStructure.getLastFocusSelection()
+        ?.weightConcentrationRatio;
+      if (ratio !== undefined) {
+        getLogger().info(
+          `Discovery ${blue(ID)} focus weight concentration ratio ${
+            ratio.toFixed(4)
+          }${ratio >= 0.5 ? " ⚠️ high (plateau risk)" : ""}`,
+        );
+      }
+    }
+
     // Mark these neurons as attempted
     newFocusList.forEach((uuid) => attemptedNeurons.add(uuid));
     perfStats.neuronsAnalyzed += newFocusList.length;

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureAnalysis.ts
@@ -46,6 +46,7 @@ import {
   selectNeuronsWeightedByError as selectNeuronsWeightedByErrorImpl,
   updateFocusSelectionSummary,
 } from "@architecture/ErrorGuidedStructuralEvolution/FocusSelection.ts";
+import type { FocusDiversityOptions } from "@architecture/ErrorGuidedStructuralEvolution/FocusSelection.ts";
 import {
   formatMillis,
   logAnalysisSkipped,
@@ -104,6 +105,7 @@ export class DiscoverStructureAnalysis extends DiscoverStructureRecording {
     costOfGrowth: number,
     retryNumber?: number,
     mode: "add" | "remove" = "add",
+    diversity: FocusDiversityOptions = {},
   ): Promise<number[]> {
     assert(count > 0, "Count must be greater than 0");
     this.lastFocusSelection = undefined;
@@ -168,6 +170,7 @@ export class DiscoverStructureAnalysis extends DiscoverStructureRecording {
       (level, message, details) => this.log(level, message, details),
       retryNumber,
       mode,
+      diversity,
     );
     const maxErrorTime = Date.now() - maxErrorStart;
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
@@ -245,6 +245,15 @@ export class DiscoverStructureBase {
     return this.tempDir;
   }
 
+  /**
+   * Returns the most recent focus selection summary, or `undefined` if no
+   * selection has run yet. Exposes the diversity-floor concentration metric
+   * (Issue #3074) to callers such as the analysis loop logging.
+   */
+  public getLastFocusSelection(): FocusSelectionSummary | undefined {
+    return this.lastFocusSelection;
+  }
+
   public shouldSkipRecording(): boolean {
     if (!this.skipRecordPhase) {
       return false;

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts
@@ -161,7 +161,12 @@ export interface CandidateAnalysisBundle {
   neuronMetadata?: { candidatesFound: number; candidatesReturned: number };
 }
 
-export type FocusSelectionMode = "weighted" | "forced" | "all" | "random";
+export type FocusSelectionMode =
+  | "weighted"
+  | "forced"
+  | "all"
+  | "random"
+  | "round-robin";
 
 export interface FocusSelectionSummaryEntry {
   id: number;
@@ -174,6 +179,14 @@ export interface FocusSelectionSummary {
   reason: string;
   neurons: FocusSelectionSummaryEntry[];
   totalWeight?: number;
+  /**
+   * Share of the (diversity-floored) roulette weight held by the single
+   * heaviest neuron, in `[0, 1]` (Issue #3074). A value near 1 means one
+   * neuron dominates the wheel and the nominally-distinct focus neurons
+   * collapse onto one target; the diversity floor keeps this well below 1 on
+   * plateaued networks.
+   */
+  weightConcentrationRatio?: number;
 }
 
 export interface NeuronScanStats {
@@ -221,6 +234,12 @@ export interface FocusSelectionAnalysis {
   totalCandidates: number;
   selectedCount: number;
   totalWeightedSum: number;
+  /**
+   * Share of the (diversity-floored) roulette weight held by the single
+   * heaviest neuron, in `[0, 1]` (Issue #3074). Acceptance target on
+   * plateaued fixtures: `weightConcentrationRatio < 0.5` after the floor.
+   */
+  weightConcentrationRatio?: number;
   candidates: FocusNeuronCandidate[];
   lowImpactNeurons: LowImpactNeuron[];
   retryNumber?: number;

--- a/src/architecture/ErrorGuidedStructuralEvolution/FocusSelection.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/FocusSelection.ts
@@ -8,8 +8,10 @@
 export { listViableNeurons } from "@architecture/ErrorGuidedStructuralEvolution/FocusSelectionRanking.ts";
 
 export {
+  DEFAULT_FOCUS_DROUGHT_THRESHOLD,
   focusSelectionKey,
   selectNeuronsWeightedByError,
   updateFocusSelectionSummary,
   writeFocusSelectionAnalysis,
 } from "@architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts";
+export type { FocusDiversityOptions } from "@architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts";

--- a/src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts
@@ -18,6 +18,84 @@ import type {
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts";
 
 /**
+ * Default number of epochs without an accepted candidate before focus
+ * selection abandons error-weighted roulette in favour of deterministic
+ * round-robin across the top-ranked neurons (Issue #3074). On a plateaued
+ * network the squared roulette weighting otherwise keeps re-selecting the same
+ * dominant neuron; round-robin guarantees the focus list rotates through
+ * distinct targets while the drought persists.
+ */
+export const DEFAULT_FOCUS_DROUGHT_THRESHOLD = 20;
+
+/**
+ * Optional diversity controls for {@link selectNeuronsWeightedByError}
+ * (Issue #3074).
+ */
+export interface FocusDiversityOptions {
+  /**
+   * Number of discovery epochs since a candidate was last accepted. When this
+   * exceeds {@link FocusDiversityOptions.droughtThreshold} the selection
+   * switches to round-robin across the top-ranked neurons. Defaults to 0 (no
+   * drought).
+   */
+  epochsSinceLastAccepted?: number;
+  /**
+   * Drought threshold in epochs. Defaults to
+   * {@link DEFAULT_FOCUS_DROUGHT_THRESHOLD}.
+   */
+  droughtThreshold?: number;
+}
+
+/**
+ * Computes the share of total weight held by the single heaviest entry
+ * (Issue #3074). Returns 0 for an empty or non-positive distribution.
+ */
+function weightConcentration(weights: readonly number[]): number {
+  let max = 0;
+  let total = 0;
+  for (const w of weights) {
+    if (!Number.isFinite(w) || w <= 0) continue;
+    total += w;
+    if (w > max) max = w;
+  }
+  return total > 0 ? max / total : 0;
+}
+
+/**
+ * Applies the diversity floor to a roulette weight distribution (Issue #3074).
+ *
+ * Iteratively clips any weight above the running mean (`total / N`) down to
+ * that mean until no weight exceeds it ("water filling"). At the fixed point
+ * the heaviest neuron holds at most a `1/N` share of the total, so no single
+ * neuron can dominate the wheel, while sub-mean weights are left untouched so
+ * the relative ordering of the tail survives. Returns a new array; the input
+ * is not mutated.
+ */
+function applyDiversityFloor(weights: readonly number[]): number[] {
+  const n = weights.length;
+  let current = weights.map((w) => (Number.isFinite(w) && w > 0 ? w : 0));
+  if (n === 0) return current;
+  // Weights only ever decrease and the total is monotonically non-increasing,
+  // so this converges quickly; the iteration cap is a safety backstop.
+  for (let iter = 0; iter < 100; iter++) {
+    let total = 0;
+    for (const w of current) total += w;
+    if (total <= 0) break;
+    const cap = total / n;
+    let changed = false;
+    current = current.map((w) => {
+      if (w > cap) {
+        changed = true;
+        return cap;
+      }
+      return w;
+    });
+    if (!changed) break;
+  }
+  return current;
+}
+
+/**
  * Generates a cache key for focus selection.
  */
 export function focusSelectionKey(focusList: readonly number[]): string {
@@ -89,6 +167,7 @@ export function writeFocusSelectionAnalysis(
     details?: unknown,
   ) => void,
   retryNumber?: number,
+  weightConcentrationRatio?: number,
 ): void {
   try {
     const selectedSet = new Set(selectedIds);
@@ -139,6 +218,7 @@ export function writeFocusSelectionAnalysis(
       totalCandidates: candidates.length,
       selectedCount: selectedIds.size,
       totalWeightedSum,
+      weightConcentrationRatio,
       candidates,
       lowImpactNeurons,
       retryNumber,
@@ -192,6 +272,7 @@ export async function selectNeuronsWeightedByError(
   ) => void,
   retryNumber?: number,
   mode: "add" | "remove" = "add",
+  diversity: FocusDiversityOptions = {},
 ): Promise<{
   selected: number[];
   focusSelection: FocusSelectionSummary;
@@ -279,14 +360,40 @@ export async function selectNeuronsWeightedByError(
       }`,
     );
   }
-  const weightedValues = rawWeights.map((entry) => ({
+  const scaledValues = rawWeights.map((entry) => ({
     id: entry.id,
     weight: entry.raw * scale,
+  }));
+
+  // Issue #3074: Diversity floor. The squared weighting above lets a single
+  // neuron capture almost all of the roulette weight on a plateaued network
+  // (one neuron held ~98% on GRQ-3), so the nominally-distinct focus neurons
+  // collapse onto one target. Water-fill each neuron's weight down to at most
+  // a 1/N share of the total (N = candidate count) so no single neuron can
+  // dominate the wheel, while preserving the relative ordering of the tail.
+  const flooredWeights = applyDiversityFloor(
+    scaledValues.map((entry) => entry.weight),
+  );
+  const weightedValues = scaledValues.map((entry, i) => ({
+    id: entry.id,
+    weight: flooredWeights[i],
   }));
   const totalWeightedSum = weightedValues.reduce(
     (sum, entry) => sum + entry.weight,
     0,
   );
+  const weightConcentrationRatio = weightConcentration(flooredWeights);
+  const preFloorConcentration = weightConcentration(
+    scaledValues.map((entry) => entry.weight),
+  );
+  if (loggingEnabled && preFloorConcentration > weightConcentrationRatio) {
+    logFn(
+      "debug",
+      `Diversity floor reduced weight concentration from ${
+        preFloorConcentration.toFixed(4)
+      } to ${weightConcentrationRatio.toFixed(4)} (N=${scaledValues.length})`,
+    );
+  }
   const weightMapAll = new Map(
     weightedValues.map((entry) => [entry.id, entry.weight]),
   );
@@ -303,6 +410,7 @@ export async function selectNeuronsWeightedByError(
       totalWeightedSum,
       "all viable neurons selected",
     );
+    focusSelection.weightConcentrationRatio = weightConcentrationRatio;
     const selectedSet = new Set(ids);
     writeFocusSelectionAnalysis(
       tempDir,
@@ -315,6 +423,7 @@ export async function selectNeuronsWeightedByError(
       costOfGrowth,
       logFn,
       retryNumber,
+      weightConcentrationRatio,
     );
     return { selected: ids, focusSelection };
   }
@@ -396,6 +505,58 @@ export async function selectNeuronsWeightedByError(
     return { selected: fallback, focusSelection };
   }
 
+  // Issue #3074: Drought round-robin. When discovery has gone many epochs
+  // without accepting a candidate the network is plateaued, and even the
+  // diversity-floored roulette tends to keep re-sampling the same heavy
+  // neurons. Switch to a deterministic round-robin across the top 3×count
+  // ranked neurons, rotating the start offset by the drought length so
+  // successive plateaued epochs cycle through distinct targets.
+  const droughtThreshold = diversity.droughtThreshold ??
+    DEFAULT_FOCUS_DROUGHT_THRESHOLD;
+  const epochsSinceLastAccepted = diversity.epochsSinceLastAccepted ?? 0;
+  if (epochsSinceLastAccepted > droughtThreshold) {
+    const ranked = [...neuronErrors].sort((a, b) =>
+      (b.totalError * b.impact) - (a.totalError * a.impact)
+    );
+    const poolSize = Math.min(ranked.length, count * 3);
+    const offset = poolSize > 0 ? epochsSinceLastAccepted % poolSize : 0;
+    const roundRobin: number[] = [];
+    for (let i = 0; i < count && i < poolSize; i++) {
+      roundRobin.push(ranked[(offset + i) % poolSize].id);
+    }
+    if (loggingEnabled) {
+      logFn(
+        "info",
+        `Drought round-robin focus selection: epochsSinceLastAccepted=${epochsSinceLastAccepted} > threshold ${droughtThreshold}; rotating ${roundRobin.length} of top ${poolSize} ranked neurons (offset ${offset}).`,
+      );
+    }
+    const focusSelection = updateFocusSelectionSummary(
+      loggingEnabled,
+      discoveryID,
+      "round-robin",
+      roundRobin,
+      logFn,
+      weightMapAll,
+      totalWeightedSum,
+      `drought round-robin (epochsSinceLastAccepted=${epochsSinceLastAccepted} > ${droughtThreshold})`,
+    );
+    focusSelection.weightConcentrationRatio = weightConcentrationRatio;
+    writeFocusSelectionAnalysis(
+      tempDir,
+      discoveryID,
+      loggingEnabled,
+      neuronErrors,
+      new Set(roundRobin),
+      totalWeightedSum,
+      "round-robin-drought",
+      costOfGrowth,
+      logFn,
+      retryNumber,
+      weightConcentrationRatio,
+    );
+    return { selected: roundRobin, focusSelection };
+  }
+
   // Use while loop with max iterations to prevent infinite loops
   const maxIterations = Math.min(count, neuronErrors.length) * 100;
   let iterations = 0;
@@ -458,6 +619,7 @@ export async function selectNeuronsWeightedByError(
     totalWeightedSum,
     "error x impact weighting",
   );
+  focusSelection.weightConcentrationRatio = weightConcentrationRatio;
   writeFocusSelectionAnalysis(
     tempDir,
     discoveryID,
@@ -469,6 +631,7 @@ export async function selectNeuronsWeightedByError(
     costOfGrowth,
     logFn,
     retryNumber,
+    weightConcentrationRatio,
   );
 
   return { selected: selection, focusSelection };

--- a/src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts
@@ -515,8 +515,12 @@ export async function selectNeuronsWeightedByError(
     DEFAULT_FOCUS_DROUGHT_THRESHOLD;
   const epochsSinceLastAccepted = diversity.epochsSinceLastAccepted ?? 0;
   if (epochsSinceLastAccepted > droughtThreshold) {
+    // Rank to mirror the weighting logic: "add" favours the highest
+    // error × impact, "remove" favours the lowest impact.
     const ranked = [...neuronErrors].sort((a, b) =>
-      (b.totalError * b.impact) - (a.totalError * a.impact)
+      mode === "add"
+        ? (b.totalError * b.impact) - (a.totalError * a.impact)
+        : a.impact - b.impact
     );
     const poolSize = Math.min(ranked.length, count * 3);
     const offset = poolSize > 0 ? epochsSinceLastAccepted % poolSize : 0;

--- a/test/discovery/FocusSelectionDiversityFloor.ts
+++ b/test/discovery/FocusSelectionDiversityFloor.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the discovery focus-selection diversity floor (Issue #3074).
+ *
+ * On a plateaued network the squared error × impact weighting lets a single
+ * neuron capture almost all of the roulette weight, so the nominally-distinct
+ * focus neurons collapse onto one target. The diversity floor caps each
+ * neuron's weight at 1/N of the total (the mean), bounding the
+ * `weightConcentrationRatio` recorded in focus-selection.json. During a drought
+ * the selection switches to deterministic round-robin across the top-ranked
+ * neurons.
+ *
+ * These are pure "what" tests: they call the real selection function with
+ * synthetic neuron error data and assert on its outputs and the analysis JSON
+ * it writes. No Rust / WASM is required.
+ */
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import {
+  selectNeuronsWeightedByError,
+} from "@architecture/ErrorGuidedStructuralEvolution/FocusSelectionWeighting.ts";
+import type {
+  FocusNeuronCandidate,
+  NeuronErrorInfo,
+} from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts";
+
+const noopLog = (
+  _level: "debug" | "info" | "warn" | "error",
+  _message: string,
+  _details?: unknown,
+): void => {};
+
+interface WrittenAnalysis {
+  weightConcentrationRatio?: number;
+  selectionMethod: string;
+  candidates: FocusNeuronCandidate[];
+}
+
+async function runSelection(
+  neuronErrors: NeuronErrorInfo[],
+  count: number,
+  costOfGrowth: number,
+  diversity: { epochsSinceLastAccepted?: number; droughtThreshold?: number } =
+    {},
+): Promise<{
+  selected: number[];
+  mode: string;
+  concentration?: number;
+  analysis: WrittenAnalysis;
+}> {
+  const tempDir = await Deno.makeTempDir({ prefix: "focus-diversity-" });
+  try {
+    const result = await selectNeuronsWeightedByError(
+      count,
+      costOfGrowth,
+      neuronErrors,
+      () => Promise.resolve(0), // no output-error cap
+      false,
+      "test-discovery",
+      tempDir,
+      noopLog,
+      undefined,
+      "add",
+      diversity,
+    );
+    const analysis = JSON.parse(
+      await Deno.readTextFile(`${tempDir}/focus-selection.json`),
+    ) as WrittenAnalysis;
+    return {
+      selected: result.selected,
+      mode: result.focusSelection.mode,
+      concentration: result.focusSelection.weightConcentrationRatio,
+      analysis,
+    };
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+}
+
+/**
+ * Builds a candidate pool with one dominant neuron (id 0) plus `tail` modest
+ * neurons. The dominant neuron's error × impact is far larger, so without a
+ * floor it would hold almost all of the squared roulette weight.
+ */
+function dominantPool(
+  tail: number,
+  dominantErrorImpact = 1.0,
+): NeuronErrorInfo[] {
+  const neurons: NeuronErrorInfo[] = [
+    { id: 0, totalError: dominantErrorImpact, impact: 1 },
+  ];
+  for (let i = 1; i <= tail; i++) {
+    // error × impact just above costOfGrowth so they remain viable but tiny.
+    neurons.push({ id: i, totalError: 0.002, impact: 1 });
+  }
+  return neurons;
+}
+
+Deno.test("Diversity floor keeps weight concentration below 0.5 on a synthetic dominant neuron", async () => {
+  const neuronErrors = dominantPool(49); // 50 candidates, one dominant
+  const { concentration, analysis } = await runSelection(
+    neuronErrors,
+    6,
+    0.001,
+  );
+
+  assert(concentration !== undefined, "concentration ratio should be recorded");
+  assert(
+    concentration! < 0.5,
+    `post-floor concentration ${concentration} should be < 0.5`,
+  );
+  assertEquals(
+    analysis.weightConcentrationRatio,
+    concentration,
+    "analysis JSON should record the same concentration ratio",
+  );
+
+  // The raw (pre-floor) squared weights show the dominance the floor corrects:
+  // the dominant neuron's weightedScore vastly exceeds the rest.
+  const dominant = analysis.candidates.find((c) => c.neuronId === 0)!;
+  const preFloorTotal = analysis.candidates.reduce(
+    (s, c) => s + c.weightedScore,
+    0,
+  );
+  const preFloorShare = dominant.weightedScore / preFloorTotal;
+  assert(
+    preFloorShare > 0.9,
+    `pre-floor share ${preFloorShare} should dominate (> 0.9), proving the floor matters`,
+  );
+});
+
+Deno.test("Diversity floor bounds concentration on a GRQ-3 sized pool (1673 neurons)", async () => {
+  // GRQ-3 fixture shape: 1673 candidate neurons, one holding ~98% of the
+  // squared roulette weight before the floor is applied.
+  const neuronErrors = dominantPool(1672);
+  const { concentration } = await runSelection(neuronErrors, 6, 0.001);
+
+  assert(concentration !== undefined);
+  assert(
+    concentration! < 0.5,
+    `GRQ-3 fixture post-floor concentration ${concentration} should be < 0.5`,
+  );
+});
+
+Deno.test("Diversity floor is a no-op for an already uniform distribution", async () => {
+  const neuronErrors: NeuronErrorInfo[] = Array.from(
+    { length: 20 },
+    (_, i) => ({ id: i, totalError: 0.5, impact: 1 }),
+  );
+  const { concentration } = await runSelection(neuronErrors, 6, 0.001);
+
+  assert(concentration !== undefined);
+  // Uniform weights → each holds 1/20 of the total.
+  assertAlmostEquals(concentration!, 1 / 20, 1e-9);
+});
+
+Deno.test("Drought triggers deterministic round-robin across distinct top-ranked neurons", async () => {
+  const neuronErrors = dominantPool(49);
+  const { selected, mode, analysis } = await runSelection(
+    neuronErrors,
+    6,
+    0.001,
+    { epochsSinceLastAccepted: 100, droughtThreshold: 20 },
+  );
+
+  assertEquals(mode, "round-robin");
+  assertEquals(analysis.selectionMethod, "round-robin-drought");
+  assertEquals(selected.length, 6, "should select the requested count");
+  assertEquals(
+    new Set(selected).size,
+    6,
+    "round-robin selection must be distinct neurons",
+  );
+});
+
+Deno.test("Round-robin offset rotates with the drought length", async () => {
+  // 30 candidates → pool size = 3 × count = 18 (smaller than the pool).
+  const neuronErrors = dominantPool(29);
+
+  // Different drought lengths produce different start offsets, so the rotated
+  // focus lists differ — successive plateaued epochs explore distinct targets.
+  const first = await runSelection(neuronErrors, 6, 0.001, {
+    epochsSinceLastAccepted: 21,
+    droughtThreshold: 20,
+  });
+  const second = await runSelection(neuronErrors, 6, 0.001, {
+    epochsSinceLastAccepted: 25,
+    droughtThreshold: 20,
+  });
+
+  assertEquals(first.mode, "round-robin");
+  assertEquals(second.mode, "round-robin");
+  assert(
+    JSON.stringify(first.selected) !== JSON.stringify(second.selected),
+    "different drought lengths should rotate to different focus lists",
+  );
+});
+
+Deno.test("No drought (epochs below threshold) keeps the weighted roulette path", async () => {
+  const neuronErrors = dominantPool(49);
+  const { mode } = await runSelection(neuronErrors, 6, 0.001, {
+    epochsSinceLastAccepted: 5,
+    droughtThreshold: 20,
+  });
+  assertEquals(mode, "weighted");
+});


### PR DESCRIPTION
# Discovery focus-selection diversity floor (#3074)

## Summary

On a plateaued network the squared `error × impact` weighting in the discovery
focus-selection roulette let a single neuron capture almost all of the wheel
(~98% on the GRQ-3 fixture, 1673 neurons). Six neurons were nominally selected
but the search effectively repeated the same target.

This change adds a **diversity floor** to the TypeScript roulette path:

1. **Water-fill cap.** Each neuron's roulette weight is iteratively clipped down
   to at most a `1/N` share of the total (`N` = candidate count). At the fixed
   point the heaviest neuron holds no more than `1/N` of the wheel, so it can no
   longer dominate, while sub-mean weights keep their relative ordering. This
   replaces a naive single-pass clip, which did not bound concentration when the
   tail mass was smaller than the mean.
2. **Concentration metric.** `weightConcentrationRatio` (heaviest neuron's share
   of the floored weight, in `[0, 1]`) is recorded in `focus-selection.json` and
   on the focus-selection summary, and surfaced in the discovery analysis logs
   with a ⚠️ marker when it stays ≥ 0.5.
3. **Drought round-robin.** When `epochsSinceLastAccepted` exceeds the drought
   threshold (default 20), selection abandons roulette and rotates
   deterministically through the top `3×count` ranked neurons, with the start
   offset advanced by the drought length so successive plateaued epochs explore
   distinct targets. This is exposed via an optional `diversity` argument on
   `selectNeuronsWeightedByError`.

The cap is always on and solves the production concentration problem; the
round-robin is an optional, drought-gated path.

Companion work: NEAT-AI-Discovery #1445 (Rust ranking diversity), GRQ #2764.

Closes #3074.

## Evidence

This is a backend/library change with no web interface, so evidence is the unit
test suite (`test/discovery/FocusSelectionDiversityFloor.ts`). The acceptance
criteria are verified directly:

- **GRQ-3 fixture** (1673 neurons, one holding ~98% pre-floor): the recorded
  `weightConcentrationRatio` drops to ≈ `1/1673` — well below the `< 0.5`
  target.
- **Synthetic dominant neuron** (50 candidates): pre-floor share `> 0.9`,
  post-floor `weightConcentrationRatio < 0.5`.

```mermaid
flowchart TD
    A[error x impact weights] --> B[square + output-cap scale]
    B --> C{drought?<br/>epochsSinceLastAccepted &gt; threshold}
    C -- "yes" --> D[round-robin top 3xN<br/>rotate by drought length]
    C -- "no" --> E[water-fill cap each weight to 1/N share]
    E --> F[weightConcentrationRatio &le; 1/N]
    F --> G[weighted roulette selection]
    D --> H[focus-selection.json<br/>+ weightConcentrationRatio]
    G --> H
```

## Test Plan

New tests in `test/discovery/FocusSelectionDiversityFloor.ts` (pure "what"
tests, no Rust/WASM required — they call the real `selectNeuronsWeightedByError`
and assert on its output and the analysis JSON it writes):

- `Diversity floor keeps weight concentration below 0.5 on a synthetic dominant
  neuron`
  — post-floor ratio `< 0.5`, pre-floor share `> 0.9`.
- `Diversity floor bounds concentration on a GRQ-3 sized pool (1673 neurons)` —
  acceptance fixture, ratio `< 0.5`.
- `Diversity floor is a no-op for an already uniform distribution` — ratio
  `1/N`.
- `Drought triggers deterministic round-robin across distinct top-ranked
  neurons`
  — mode `round-robin`, 6 distinct neurons selected.
- `Round-robin offset rotates with the drought length` — different drought
  lengths yield different focus lists.
- `No drought (epochs below threshold) keeps the weighted roulette path`.

All existing focus-selection tests continue to pass, and the full `./quality.sh`
gate (fmt, lint, type-check, tests) was run.

### Note on field naming

The new JSON field is camelCase `weightConcentrationRatio` to match the existing
`focus-selection.json` schema (`totalWeightedSum`, `selectionMethod`, …); the
issue's `weight_concentration_ratio` is the snake_case Rust-side spelling of the
same metric.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqkwg1ue-fb1162`<!-- vibe-worker-issue-3074 -->