### PR TITLE
perf: Return zero-copy views from WASM activateAndTrace (#3085)

### DIFF
--- a/bench/ActivateAndTraceBulkCopy.ts
+++ b/bench/ActivateAndTraceBulkCopy.ts
@@ -314,6 +314,92 @@ Deno.bench(
   },
 );
 
+// ============================================================================
+// Issue #3085: view-return vs copy-return contrast
+//
+// `activateAndTrace` now returns `activations`/`hintValues` as zero-copy
+// `subarray` views into the per-call `result` buffer instead of freshly
+// allocated copies. These two benchmarks isolate the extraction cost on an
+// identical `result` buffer so the allocation + bulk-copy saving is visible
+// independent of the WASM activation itself.
+// ============================================================================
+type TraceExtract = {
+  outputs: Float32Array;
+  activations: Float32Array;
+  hintValues: Float32Array;
+};
+
+// Old behaviour: three standalone copies.
+function extractCopy(
+  result: Float32Array,
+  numOutputs: number,
+  numNonInputs: number,
+): TraceExtract {
+  const outputs = new Float32Array(numOutputs);
+  outputs.set(result.subarray(0, numOutputs));
+  const activations = new Float32Array(numNonInputs);
+  activations.set(result.subarray(numOutputs, numOutputs + numNonInputs));
+  const hintValues = new Float32Array(numNonInputs);
+  hintValues.set(
+    result.subarray(numOutputs + numNonInputs, numOutputs + 2 * numNonInputs),
+  );
+  return { outputs, activations, hintValues };
+}
+
+// New behaviour (Issue #3085): outputs copied, activations/hintValues as views.
+function extractView(
+  result: Float32Array,
+  numOutputs: number,
+  numNonInputs: number,
+): TraceExtract {
+  const outputs = new Float32Array(numOutputs);
+  outputs.set(result.subarray(0, numOutputs));
+  const activations = result.subarray(numOutputs, numOutputs + numNonInputs);
+  const hintValues = result.subarray(
+    numOutputs + numNonInputs,
+    numOutputs + 2 * numNonInputs,
+  );
+  return { outputs, activations, hintValues };
+}
+
+// A representative production-scale result buffer (outputs + 2*nonInputs + a
+// terminator), read element-wise after extraction to mirror the consumer.
+const extractNumOutputs = productionCreature.output;
+const extractNonInputs = productionNumNonInputs;
+const extractResult = new Float32Array(
+  extractNumOutputs + 2 * extractNonInputs + 1,
+);
+for (let i = 0; i < extractResult.length; i++) extractResult[i] = i * 0.001;
+extractResult[extractResult.length - 1] = -1; // trace terminator
+
+function consume(t: TraceExtract): number {
+  let sum = t.outputs[0];
+  for (let i = 0; i < t.activations.length; i++) {
+    sum += t.activations[i] + t.hintValues[i];
+  }
+  return sum;
+}
+
+Deno.bench(
+  "Extract: copy-return [old]",
+  { group: "extract-strategy", baseline: true },
+  () => {
+    for (let i = 0; i < ITERATIONS; i++) {
+      consume(extractCopy(extractResult, extractNumOutputs, extractNonInputs));
+    }
+  },
+);
+
+Deno.bench(
+  "Extract: view-return [Issue #3085]",
+  { group: "extract-strategy" },
+  () => {
+    for (let i = 0; i < ITERATIONS; i++) {
+      consume(extractView(extractResult, extractNumOutputs, extractNonInputs));
+    }
+  },
+);
+
 console.log(`\n`);
 console.log(
   `Note: The bulk copy optimisation (Issue #1172) is already applied.`,

--- a/docs/archive/pr-summaries/pr-summary-3085.md
+++ b/docs/archive/pr-summaries/pr-summary-3085.md
@@ -1,0 +1,66 @@
+# perf: Return zero-copy views from WASM `activateAndTrace`
+
+## Summary
+
+`WasmCreatureActivation.activateAndTrace` allocated **two** throwaway
+`Float32Array`s per call (`activations`, `hintValues`) and bulk-copied WASM
+result slices into them, only for the consumer in `CreatureActivation.ts` to
+read those arrays straight back out element-wise into `creature.state`. On the
+dominant per-sample backprop training path this is pure wasted work.
+
+This change returns `activations` and `hintValues` as zero-copy `subarray`
+**views** into the single per-call `result` buffer — no allocation, no copy.
+`outputs` stays a standalone copy because it is returned to external callers who
+may retain it (keeping it small avoids pinning the whole `result` buffer alive).
+
+**Correctness — the one sensitive step (verified):** the WASM binding
+`activate_and_trace` (`wasm_activation/pkg/wasm_activation.js:83`) `.slice()`s
+the WASM linear-memory slice before returning, so `result` is a fresh per-call
+copy, **not** a live view that a later call would overwrite. Taking `subarray`
+views into it is therefore safe.
+
+Closes #3085.
+
+## Evidence
+
+Backend/WASM change — no UI to screenshot.
+
+### Benchmark (before/after) — `bench/ActivateAndTraceBulkCopy.ts`
+
+Added an `extract-strategy` group contrasting the old copy-return against the
+new view-return on an identical production-scale `result` buffer (1000
+iterations/run, Apple M4 Pro, Deno 2.8.3):
+
+| benchmark                          | time/iter (avg) |  iter/s | result            |
+| ---------------------------------- | --------------- | ------- | ----------------- |
+| Extract: copy-return [old]         |          1.1 ms |   912.4 | baseline          |
+| Extract: view-return [Issue #3085] |        503.9 µs |   1,985 | **2.17× faster**  |
+
+Removing the 2 allocations + 2 bulk copies per call roughly halves the
+extraction cost and cuts GC pressure on the hot path.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    WASM["activate_and_trace<br/>(.slice → fresh copy)"] --> R[result buffer]
+    R -->|copy| O[outputs]
+    R -->|subarray view| A[activations]
+    R -->|subarray view| H[hintValues]
+    A -->|read element-wise| S[creature.state]
+    H -->|read element-wise| S
+```
+
+## Test Plan
+
+- Added `test/wasm/ActivateAndTraceViewReturn.ts`:
+  - `numeric outputs are correct` — verifies `outputs`/`activations`/`hintValues`
+    against a hand-computed known network (numeric parity unchanged).
+  - `earlier result survives a later call (per-call buffer)` — retains the first
+    call's views, runs a second activation with different input, and asserts the
+    first result is unchanged. This guards against a regression to aliasing live
+    WASM memory.
+- Existing trace/backprop suites continue to pass
+  (`WasmBackpropagation.ts`, `ActivateAndTraceBatch4Way.ts`,
+  `test/propagate/*`).
+- Full `./quality.sh` gate: **7392 passed, 0 failed**.

--- a/src/wasm/WasmActivation.ts
+++ b/src/wasm/WasmActivation.ts
@@ -387,20 +387,27 @@ export class WasmCreatureActivation {
       this.invalidateAfterWasmPanic(error);
     }
 
+    // Issue #3085: `result` is a fresh per-call copy of WASM linear memory
+    // (the binding `.slice()`s the WASM slice before returning), so it is safe
+    // to hand back zero-copy `subarray` views into it. `activations` and
+    // `hintValues` are read straight back out element-wise by the consumer and
+    // never retained, so views avoid two heap allocations + two bulk copies per
+    // traced activation on the backprop hot path.
+    //
+    // `outputs` stays a standalone copy: it is returned to external callers who
+    // may retain it, and keeping it small avoids pinning the whole `result`
+    // buffer (including trace data) alive for the lifetime of that reference.
     const outputs = new Float32Array(this.numOutputs);
     outputs.set(result.subarray(0, this.numOutputs));
 
-    const activations = new Float32Array(numNonInputs);
-    activations.set(
-      result.subarray(this.numOutputs, this.numOutputs + numNonInputs),
+    const activations = result.subarray(
+      this.numOutputs,
+      this.numOutputs + numNonInputs,
     );
 
-    const hintValues = new Float32Array(numNonInputs);
-    hintValues.set(
-      result.subarray(
-        this.numOutputs + numNonInputs,
-        this.numOutputs + 2 * numNonInputs,
-      ),
+    const hintValues = result.subarray(
+      this.numOutputs + numNonInputs,
+      this.numOutputs + 2 * numNonInputs,
     );
 
     const traceEntries: WasmTraceEntry[] = [];

--- a/test/wasm/ActivateAndTraceViewReturn.ts
+++ b/test/wasm/ActivateAndTraceViewReturn.ts
@@ -1,0 +1,123 @@
+/**
+ * WASM activateAndTrace() Zero-Copy View Return Tests
+ *
+ * Issue #3085 - perf: Return zero-copy views from WASM activateAndTrace instead
+ *               of throwaway Float32Arrays.
+ *
+ * `activateAndTrace` returns `activations` and `hintValues` as zero-copy
+ * `subarray` views into the per-call `result` buffer rather than freshly
+ * allocated copies. These tests pin the observable behaviour that must hold for
+ * that optimisation to be correct:
+ *
+ *   1. Numeric outputs are unchanged for a known network.
+ *   2. The returned views stay valid and independent across consecutive calls
+ *      (the `result` buffer is a fresh per-call copy, not a live WASM
+ *      linear-memory view that a later call would overwrite).
+ */
+
+import { assert, assertAlmostEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureInternal } from "@architecture/CreatureInterfaces.ts";
+import {
+  compileCreatureToWasm,
+  initWasmActivation,
+  isWasmActivationAvailable,
+  WasmCreatureActivation,
+} from "@wasm/mod.ts";
+
+const TOLERANCE = 1e-5;
+
+// A tiny deterministic network: 2 inputs, 1 hidden ReLU, 1 output IDENTITY.
+//   hidden (index 2, bias 0.5, ReLU):     in0*1.0 + in1*-0.5 + 0.5
+//   output (index 3, bias -0.2, IDENTITY): hidden*2.0 - 0.2
+function makeNetwork(): Creature {
+  const json: CreatureInternal = {
+    neurons: [
+      { type: "hidden", index: 2, bias: 0.5, squash: "ReLU" },
+      { type: "output", index: 3, bias: -0.2, squash: "IDENTITY" },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 1.0 },
+      { from: 1, to: 2, weight: -0.5 },
+      { from: 2, to: 3, weight: 2.0 },
+    ],
+    input: 2,
+    output: 1,
+  };
+  const creature = Creature.fromJSON(json);
+  creature.fix();
+  creature.clearState();
+  return creature;
+}
+
+Deno.test({
+  name: "activateAndTrace view-return: Module initialisation",
+  async fn() {
+    const result = await initWasmActivation();
+    assert(result, "WASM module should initialise successfully");
+    assert(isWasmActivationAvailable(), "WASM should be available after init");
+  },
+});
+
+Deno.test({
+  name: "activateAndTrace view-return: numeric outputs are correct",
+  fn() {
+    const compiled = compileCreatureToWasm(makeNetwork());
+    const wasm = WasmCreatureActivation.create(compiled);
+    assert(wasm, "Should create WASM activation");
+
+    const trace = wasm.activateAndTrace(new Float32Array([1.0, 2.0]));
+
+    // hidden pre = 1*1.0 + 2*-0.5 + 0.5 = 0.5 -> ReLU -> 0.5
+    // output pre = 0.5*2.0 - 0.2 = 0.8 -> IDENTITY -> 0.8
+    assertAlmostEquals(trace.outputs[0], 0.8, TOLERANCE, "output");
+
+    // Non-input neurons in index order: hidden (2), output (3).
+    assertAlmostEquals(trace.activations[0], 0.5, TOLERANCE, "hidden act");
+    assertAlmostEquals(trace.activations[1], 0.8, TOLERANCE, "output act");
+
+    // For these standard squashes hintValue == pre-squash weighted sum + bias.
+    assertAlmostEquals(trace.hintValues[0], 0.5, TOLERANCE, "hidden hint");
+    assertAlmostEquals(trace.hintValues[1], 0.8, TOLERANCE, "output hint");
+  },
+});
+
+Deno.test({
+  name:
+    "activateAndTrace view-return: earlier result survives a later call (per-call buffer)",
+  fn() {
+    const compiled = compileCreatureToWasm(makeNetwork());
+    const wasm = WasmCreatureActivation.create(compiled);
+    assert(wasm, "Should create WASM activation");
+
+    // First call — retain its views.
+    const first = wasm.activateAndTrace(new Float32Array([1.0, 2.0]));
+    const firstActivations = Float32Array.from(first.activations);
+    const firstHintValues = Float32Array.from(first.hintValues);
+
+    // Second call with different input must not corrupt the first result's
+    // views. If `result` aliased live WASM memory, this would overwrite them.
+    const second = wasm.activateAndTrace(new Float32Array([0.5, -1.0]));
+
+    // hidden pre = 0.5*1.0 + -1.0*-0.5 + 0.5 = 1.5 -> ReLU -> 1.5
+    // output pre = 1.5*2.0 - 0.2 = 2.8
+    assertAlmostEquals(second.activations[0], 1.5, TOLERANCE, "2nd hidden act");
+    assertAlmostEquals(second.activations[1], 2.8, TOLERANCE, "2nd output act");
+
+    // First result still holds its original values.
+    for (let i = 0; i < first.activations.length; i++) {
+      assertAlmostEquals(
+        first.activations[i],
+        firstActivations[i],
+        TOLERANCE,
+        `first activations[${i}] unchanged`,
+      );
+      assertAlmostEquals(
+        first.hintValues[i],
+        firstHintValues[i],
+        TOLERANCE,
+        `first hintValues[${i}] unchanged`,
+      );
+    }
+  },
+});


### PR DESCRIPTION
# perf: Return zero-copy views from WASM `activateAndTrace`

## Summary

`WasmCreatureActivation.activateAndTrace` allocated **two** throwaway
`Float32Array`s per call (`activations`, `hintValues`) and bulk-copied WASM
result slices into them, only for the consumer in `CreatureActivation.ts` to
read those arrays straight back out element-wise into `creature.state`. On the
dominant per-sample backprop training path this is pure wasted work.

This change returns `activations` and `hintValues` as zero-copy `subarray`
**views** into the single per-call `result` buffer — no allocation, no copy.
`outputs` stays a standalone copy because it is returned to external callers who
may retain it (keeping it small avoids pinning the whole `result` buffer alive).

**Correctness — the one sensitive step (verified):** the WASM binding
`activate_and_trace` (`wasm_activation/pkg/wasm_activation.js:83`) `.slice()`s
the WASM linear-memory slice before returning, so `result` is a fresh per-call
copy, **not** a live view that a later call would overwrite. Taking `subarray`
views into it is therefore safe.

Closes #3085.

## Evidence

Backend/WASM change — no UI to screenshot.

### Benchmark (before/after) — `bench/ActivateAndTraceBulkCopy.ts`

Added an `extract-strategy` group contrasting the old copy-return against the
new view-return on an identical production-scale `result` buffer (1000
iterations/run, Apple M4 Pro, Deno 2.8.3):

| benchmark                          | time/iter (avg) |  iter/s | result            |
| ---------------------------------- | --------------- | ------- | ----------------- |
| Extract: copy-return [old]         |          1.1 ms |   912.4 | baseline          |
| Extract: view-return [Issue #3085] |        503.9 µs |   1,985 | **2.17× faster**  |

Removing the 2 allocations + 2 bulk copies per call roughly halves the
extraction cost and cuts GC pressure on the hot path.

### Data flow

```mermaid
flowchart LR
    WASM["activate_and_trace<br/>(.slice → fresh copy)"] --> R[result buffer]
    R -->|copy| O[outputs]
    R -->|subarray view| A[activations]
    R -->|subarray view| H[hintValues]
    A -->|read element-wise| S[creature.state]
    H -->|read element-wise| S
```

## Test Plan

- Added `test/wasm/ActivateAndTraceViewReturn.ts`:
  - `numeric outputs are correct` — verifies `outputs`/`activations`/`hintValues`
    against a hand-computed known network (numeric parity unchanged).
  - `earlier result survives a later call (per-call buffer)` — retains the first
    call's views, runs a second activation with different input, and asserts the
    first result is unchanged. This guards against a regression to aliasing live
    WASM memory.
- Existing trace/backprop suites continue to pass
  (`WasmBackpropagation.ts`, `ActivateAndTraceBatch4Way.ts`,
  `test/propagate/*`).
- Full `./quality.sh` gate: **7392 passed, 0 failed**.



## Milestone
This PR is part of the **#3082 Can you see any performance improvements?** milestone and targets the `milestone/3082-can-you-see-any-performance-improvements` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqm7s2vo-ac4403`<!-- vibe-worker-issue-3085 -->