### PR TITLE
perf: Drop per-batch re-serialisation of discovery selected-indices map (#3086)

### DIFF
--- a/bench/DiscoveryIndicesPersistence.ts
+++ b/bench/DiscoveryIndicesPersistence.ts
@@ -1,0 +1,78 @@
+/**
+ * Benchmark for discovery selected-indices persistence cost.
+ *
+ * Issue #3086: During discovery recording, `record()` previously re-serialised
+ * and rewrote the entire (monotonically growing) selected-indices map to disk on
+ * every batch via a blocking `writeTextFileSync`. Persistence is already provided
+ * by the per-chunk flush write (`writeRustParquetChunk`) and the end-of-phase
+ * flush, so the per-batch write was redundant O(batches × total_indices) blocking
+ * I/O on the dominant recording phase.
+ *
+ * This benchmark contrasts the two persistence strategies on a representative
+ * recording workload:
+ *   1. per-batch  — serialise + write the whole growing map every batch (before)
+ *   2. per-flush  — serialise + write only on each chunk flush + once at the end
+ *                   (after)
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write bench/DiscoveryIndicesPersistence.ts
+ */
+
+import { appendAll } from "@utils/ArrayAppend.ts";
+
+// Representative recording shape: 256 batches of 128 indices each across a
+// single binary file, with a chunk flush every 16 batches (matching the order
+// of magnitude of discoveryRustFlushRecords / discoveryBatchSize defaults).
+const BATCH_COUNT = 256;
+const BATCH_SIZE = 128;
+const FLUSH_EVERY = 16;
+
+const tempDir = Deno.makeTempDirSync({ prefix: "bench-indices-" });
+const indicesFilePath = `${tempDir}/selected_indices.json`;
+const binaryFilePath = `${tempDir}/training_data.bin`;
+
+function makeBatch(start: number): number[] {
+  const out = new Array<number>(BATCH_SIZE);
+  for (let i = 0; i < BATCH_SIZE; i++) out[i] = start + i;
+  return out;
+}
+
+const batches: number[][] = [];
+for (let b = 0; b < BATCH_COUNT; b++) batches.push(makeBatch(b * BATCH_SIZE));
+
+/** Old behaviour: write the whole growing map after every batch. */
+function perBatchPersistence(): void {
+  const selectedIndices: Record<string, number[]> = {};
+  selectedIndices[binaryFilePath] = [];
+  for (let b = 0; b < BATCH_COUNT; b++) {
+    appendAll(selectedIndices[binaryFilePath], batches[b]);
+    Deno.writeTextFileSync(indicesFilePath, JSON.stringify(selectedIndices));
+  }
+}
+
+/** New behaviour: write only on each chunk flush plus a single final write. */
+function perFlushPersistence(): void {
+  const selectedIndices: Record<string, number[]> = {};
+  selectedIndices[binaryFilePath] = [];
+  for (let b = 0; b < BATCH_COUNT; b++) {
+    appendAll(selectedIndices[binaryFilePath], batches[b]);
+    if ((b + 1) % FLUSH_EVERY === 0) {
+      Deno.writeTextFileSync(indicesFilePath, JSON.stringify(selectedIndices));
+    }
+  }
+  // Single end-of-phase flush.
+  Deno.writeTextFileSync(indicesFilePath, JSON.stringify(selectedIndices));
+}
+
+Deno.bench({
+  name: "selected-indices persistence — per-batch write (before, Issue #3086)",
+  group: "discovery-indices-persistence",
+  baseline: true,
+  fn: perBatchPersistence,
+});
+
+Deno.bench({
+  name: "selected-indices persistence — per-flush write (after, Issue #3086)",
+  group: "discovery-indices-persistence",
+  fn: perFlushPersistence,
+});

--- a/docs/archive/pr-summaries/pr-summary-3083.md
+++ b/docs/archive/pr-summaries/pr-summary-3083.md
@@ -23,9 +23,10 @@ order that was never disturbed.
    (`src/architecture/SynapseOrderGuard.ts`) — gated on `creature.DEBUG`, so it
    adds **zero** cost to the production hot path while catching any future code
    path that violates the ordering invariant during tests.
-3. Replaced the `slice(0,index)` / `slice(index)` / `[...left, neuron, ...right]`
-   triple-allocation neuron rebuild with a single in-place
-   `neurons.splice(neuron.index, 0, neuron)` plus the existing tail-index bump.
+3. Replaced the `slice(0,index)` / `slice(index)` /
+   `[...left, neuron, ...right]` triple-allocation neuron rebuild with a single
+   in-place `neurons.splice(neuron.index, 0, neuron)` plus the existing
+   tail-index bump.
 
 ### Behaviour change
 
@@ -55,10 +56,10 @@ micro-benchmark and the existing + new unit tests.
 many ADD_NODE mutations (`deno run -A bench/mutate/AddNeuronInsertResort.ts`).
 Averages of three runs each, `creature.DEBUG` off (production path):
 
-| Scenario | Synapses (end) | Mutations | Before (avg/mutation) | After (avg/mutation) | Improvement |
-|---|---|---|---|---|---|
-| 20in/5out/100hidden | 1100 | 200 | ~426 µs | ~410 µs | ~3.7% |
-| 40in/10out/200hidden | 2600 | 300 | ~1.045 ms | ~1.000 ms | ~4.3% |
+| Scenario             | Synapses (end) | Mutations | Before (avg/mutation) | After (avg/mutation) | Improvement |
+| -------------------- | -------------- | --------- | --------------------- | -------------------- | ----------- |
+| 20in/5out/100hidden  | 1100           | 200       | ~426 µs               | ~410 µs              | ~3.7%       |
+| 40in/10out/200hidden | 2600           | 300       | ~1.045 ms             | ~1.000 ms            | ~4.3%       |
 
 The saving is consistent across runs (outside measurement noise) and grows with
 synapse count `E`, matching the `O(E log E) → O(E)` reduction. Ordering and

--- a/docs/archive/pr-summaries/pr-summary-3084.md
+++ b/docs/archive/pr-summaries/pr-summary-3084.md
@@ -18,17 +18,18 @@ JavaScript `Map` already preserves insertion order, so a true O(1) LRU needs no
   `cache.keys().next().value` — the least-recently-used entry.
 
 This removes the per-entry `lastAccess` field and the global `accessCounter`,
-and shrinks each cache value from an object to a bare `number`. Hit/miss/eviction
-statistics (`getDistanceCacheStats`) are unchanged, and eviction still strictly
-bounds the cache at `maxSize`.
+and shrinks each cache value from an object to a bare `number`.
+Hit/miss/eviction statistics (`getDistanceCacheStats`) are unchanged, and
+eviction still strictly bounds the cache at `maxSize`.
 
 Closes #3084.
 
 ## Evidence
 
 Backend/CLI change — no web interface to screenshot. Verified by tests and a
-dedicated benchmark (`bench/DistanceCacheEviction.ts`) that drives the write path
-well past `maxSize` so nearly every insert evicts, isolating the eviction cost.
+dedicated benchmark (`bench/DistanceCacheEviction.ts`) that drives the write
+path well past `maxSize` so nearly every insert evicts, isolating the eviction
+cost.
 
 ### Benchmark: eviction-heavy writes (40 000 inserts into a 2 000-entry cache)
 
@@ -60,10 +61,10 @@ All tests in `test/breed/DistanceCache.ts` pass (14 total). Added three new
 
 - `DistanceCache - a hit refreshes recency so the unaccessed entry is evicted` —
   a hit on the oldest entry makes it most-recently-used, so the next insert
-  evicts the now-oldest *unaccessed* entry.
-- `DistanceCache - eviction strictly bounds the cache at maxSize` — inserting 100
-  distinct entries into a 5-entry cache keeps size at 5, records 95 evictions,
-  and retains exactly the last 5 inserts.
+  evicts the now-oldest _unaccessed_ entry.
+- `DistanceCache - eviction strictly bounds the cache at maxSize` — inserting
+  100 distinct entries into a 5-entry cache keeps size at 5, records 95
+  evictions, and retains exactly the last 5 inserts.
 - `DistanceCache - shrinking maxSize evicts oldest entries immediately` —
   lowering `maxSize` drops the oldest entries down to the new bound, retaining
   the most-recently inserted.

--- a/docs/archive/pr-summaries/pr-summary-3085.md
+++ b/docs/archive/pr-summaries/pr-summary-3085.md
@@ -31,10 +31,10 @@ Added an `extract-strategy` group contrasting the old copy-return against the
 new view-return on an identical production-scale `result` buffer (1000
 iterations/run, Apple M4 Pro, Deno 2.8.3):
 
-| benchmark                          | time/iter (avg) |  iter/s | result            |
-| ---------------------------------- | --------------- | ------- | ----------------- |
-| Extract: copy-return [old]         |          1.1 ms |   912.4 | baseline          |
-| Extract: view-return [Issue #3085] |        503.9 µs |   1,985 | **2.17× faster**  |
+| benchmark                          | time/iter (avg) | iter/s | result           |
+| ---------------------------------- | --------------- | ------ | ---------------- |
+| Extract: copy-return [old]         | 1.1 ms          | 912.4  | baseline         |
+| Extract: view-return [Issue #3085] | 503.9 µs        | 1,985  | **2.17× faster** |
 
 Removing the 2 allocations + 2 bulk copies per call roughly halves the
 extraction cost and cuts GC pressure on the hot path.
@@ -54,13 +54,13 @@ flowchart LR
 ## Test Plan
 
 - Added `test/wasm/ActivateAndTraceViewReturn.ts`:
-  - `numeric outputs are correct` — verifies `outputs`/`activations`/`hintValues`
-    against a hand-computed known network (numeric parity unchanged).
+  - `numeric outputs are correct` — verifies
+    `outputs`/`activations`/`hintValues` against a hand-computed known network
+    (numeric parity unchanged).
   - `earlier result survives a later call (per-call buffer)` — retains the first
     call's views, runs a second activation with different input, and asserts the
     first result is unchanged. This guards against a regression to aliasing live
     WASM memory.
-- Existing trace/backprop suites continue to pass
-  (`WasmBackpropagation.ts`, `ActivateAndTraceBatch4Way.ts`,
-  `test/propagate/*`).
+- Existing trace/backprop suites continue to pass (`WasmBackpropagation.ts`,
+  `ActivateAndTraceBatch4Way.ts`, `test/propagate/*`).
 - Full `./quality.sh` gate: **7392 passed, 0 failed**.

--- a/docs/archive/pr-summaries/pr-summary-3086.md
+++ b/docs/archive/pr-summaries/pr-summary-3086.md
@@ -3,20 +3,22 @@
 ## Summary
 
 During discovery recording, `DiscoverStructureRecording.record()` synchronously
-re-serialised and rewrote the **entire** selected-indices map to disk on **every**
-batch via a blocking `Deno.writeTextFileSync`. The map grows monotonically across
-the whole recording phase, making this an `O(batches × total_indices)`
-blocking-I/O cost on the dominant phase for large datasets.
+re-serialised and rewrote the **entire** selected-indices map to disk on
+**every** batch via a blocking `Deno.writeTextFileSync`. The map grows
+monotonically across the whole recording phase, making this an
+`O(batches × total_indices)` blocking-I/O cost on the dominant phase for large
+datasets.
 
 The write was redundant: `writeRustParquetChunk` already persists the same
 `selected_indices.json` atomically alongside **every** parquet chunk flush, and
 `flushRustRecording` covers the end of the recording phase. The analysis phase
-only reads `selected_indices.json` *after* recording completes
+only reads `selected_indices.json` _after_ recording completes
 (`DiscoverDataLoading.ts`), never an intermediate version.
 
 This change removes the per-batch write from `record()`. Persistence is now
-provided solely by the per-chunk flush write plus the single end-of-phase flush —
-which also keeps the indices map and the parquet chunks written together in sync.
+provided solely by the per-chunk flush write plus the single end-of-phase flush
+— which also keeps the indices map and the parquet chunks written together in
+sync.
 
 Closes #3086.
 
@@ -36,8 +38,8 @@ flowchart LR
     end
 ```
 
-- `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts` —
-  removed the per-batch `Deno.writeTextFileSync`; in-memory `appendAll` of the
+- `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts`
+  — removed the per-batch `Deno.writeTextFileSync`; in-memory `appendAll` of the
   selected indices is retained, persistence deferred to chunk flush.
 
 ## Evidence
@@ -49,10 +51,10 @@ Backend-only change — no UI to screenshot.
 Models the two persistence strategies on a representative recording workload
 (256 batches × 128 indices, chunk flush every 16 batches):
 
-| Strategy | time/iter (avg) | iter/s |
-| --- | --- | --- |
-| per-batch write (**before**) | 161.9 ms | 6.2 |
-| per-flush write (**after**) | 4.1 ms | 241.9 |
+| Strategy                     | time/iter (avg) | iter/s |
+| ---------------------------- | --------------- | ------ |
+| per-batch write (**before**) | 161.9 ms        | 6.2    |
+| per-flush write (**after**)  | 4.1 ms          | 241.9  |
 
 **~39× faster** for the modelled workload (the blob rewritten each batch keeps
 growing, so the saving compounds with longer recording phases). Run with:
@@ -66,14 +68,14 @@ deno bench --allow-read --allow-write bench/DiscoveryIndicesPersistence.ts
 - Added `test/discovery/DiscoverStructureRecordIndices.ts` →
   `"DiscoverStructure: record() defers indices persistence to chunk flush (Issue #3086)"`:
   - asserts `initialize()` seeds an empty map on disk;
-  - drives two `record()` batches **without** an intervening flush and asserts the
-    on-disk `selected_indices.json` is still the seeded empty map (regression
-    guard — fails if the per-batch write is reintroduced);
+  - drives two `record()` batches **without** an intervening flush and asserts
+    the on-disk `selected_indices.json` is still the seeded empty map
+    (regression guard — fails if the per-batch write is reintroduced);
   - asserts a chunk flush then persists the complete, correct map with absolute
     index offsets preserved.
   - Verified the guard **fails** against the old per-batch-write behaviour and
     **passes** with the fix (TDD).
-- Existing discovery recording/flush tests
-  (`DiscoverStructureRecordIndices.ts`, `DiscoveryRustFlush.ts`) continue to pass —
-  the final indices file is still complete and the analysis phase still loads it.
+- Existing discovery recording/flush tests (`DiscoverStructureRecordIndices.ts`,
+  `DiscoveryRustFlush.ts`) continue to pass — the final indices file is still
+  complete and the analysis phase still loads it.
 - Full quality gate: `./quality.sh` — 7396 passed, 0 failed.

--- a/docs/archive/pr-summaries/pr-summary-3086.md
+++ b/docs/archive/pr-summaries/pr-summary-3086.md
@@ -1,0 +1,79 @@
+# perf: Drop per-batch synchronous re-serialisation of the discovery selected-indices map
+
+## Summary
+
+During discovery recording, `DiscoverStructureRecording.record()` synchronously
+re-serialised and rewrote the **entire** selected-indices map to disk on **every**
+batch via a blocking `Deno.writeTextFileSync`. The map grows monotonically across
+the whole recording phase, making this an `O(batches × total_indices)`
+blocking-I/O cost on the dominant phase for large datasets.
+
+The write was redundant: `writeRustParquetChunk` already persists the same
+`selected_indices.json` atomically alongside **every** parquet chunk flush, and
+`flushRustRecording` covers the end of the recording phase. The analysis phase
+only reads `selected_indices.json` *after* recording completes
+(`DiscoverDataLoading.ts`), never an intermediate version.
+
+This change removes the per-batch write from `record()`. Persistence is now
+provided solely by the per-chunk flush write plus the single end-of-phase flush —
+which also keeps the indices map and the parquet chunks written together in sync.
+
+Closes #3086.
+
+## Change
+
+```mermaid
+flowchart LR
+    subgraph Before
+      R1[record batch] -->|writeTextFileSync<br/>whole growing map| D1[(selected_indices.json)]
+      R1 --> A1[accumulate samples]
+      A1 --> F1[chunk flush] -->|writeTextFileSync| D1
+    end
+    subgraph After
+      R2[record batch] --> A2[accumulate samples<br/>append indices in memory]
+      A2 --> F2[chunk flush] -->|writeTextFileSync<br/>once per chunk| D2[(selected_indices.json)]
+      F2 --> E2[end-of-phase flush] --> D2
+    end
+```
+
+- `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts` —
+  removed the per-batch `Deno.writeTextFileSync`; in-memory `appendAll` of the
+  selected indices is retained, persistence deferred to chunk flush.
+
+## Evidence
+
+Backend-only change — no UI to screenshot.
+
+### Benchmark (`bench/DiscoveryIndicesPersistence.ts`)
+
+Models the two persistence strategies on a representative recording workload
+(256 batches × 128 indices, chunk flush every 16 batches):
+
+| Strategy | time/iter (avg) | iter/s |
+| --- | --- | --- |
+| per-batch write (**before**) | 161.9 ms | 6.2 |
+| per-flush write (**after**) | 4.1 ms | 241.9 |
+
+**~39× faster** for the modelled workload (the blob rewritten each batch keeps
+growing, so the saving compounds with longer recording phases). Run with:
+
+```bash
+deno bench --allow-read --allow-write bench/DiscoveryIndicesPersistence.ts
+```
+
+## Test Plan
+
+- Added `test/discovery/DiscoverStructureRecordIndices.ts` →
+  `"DiscoverStructure: record() defers indices persistence to chunk flush (Issue #3086)"`:
+  - asserts `initialize()` seeds an empty map on disk;
+  - drives two `record()` batches **without** an intervening flush and asserts the
+    on-disk `selected_indices.json` is still the seeded empty map (regression
+    guard — fails if the per-batch write is reintroduced);
+  - asserts a chunk flush then persists the complete, correct map with absolute
+    index offsets preserved.
+  - Verified the guard **fails** against the old per-batch-write behaviour and
+    **passes** with the fix (TDD).
+- Existing discovery recording/flush tests
+  (`DiscoverStructureRecordIndices.ts`, `DiscoveryRustFlush.ts`) continue to pass —
+  the final indices file is still complete and the analysis phase still loads it.
+- Full quality gate: `./quality.sh` — 7396 passed, 0 failed.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
@@ -118,10 +118,13 @@ export class DiscoverStructureRecording extends DiscoverStructureBase {
       // indices (config, no hard upper cap), so spreading risks RangeError.
       appendAll(this.selectedIndices[binaryFilePath], effectiveRecordIndices);
 
-      Deno.writeTextFileSync(
-        this.indicesFilePath,
-        JSON.stringify(this.selectedIndices),
-      );
+      // Issue #3086: do NOT re-serialise and rewrite the whole (monotonically
+      // growing) selected-indices map here. Persisting it on every batch was
+      // redundant O(batches × total_indices) blocking I/O. The map is written
+      // to `indicesFilePath` atomically alongside each parquet chunk in
+      // `writeRustParquetChunk`, and `flushRustRecording` covers end-of-phase.
+      // The analysis phase only reads `selected_indices.json` after recording
+      // completes (DiscoverDataLoading.ts), never an intermediate version.
 
       if (!this.rustBinaryFilePath) {
         this.rustBinaryFilePath = binaryFilePath;

--- a/test/discovery/DiscoverStructureRecordIndices.ts
+++ b/test/discovery/DiscoverStructureRecordIndices.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path/join";
 import { Creature } from "@creature";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
@@ -117,6 +118,104 @@ Deno.test("DiscoverStructure preserves record indices for single binary chunk", 
     await structure.cleanUp();
   }
 });
+
+/**
+ * Issue #3086: `record()` must NOT re-serialise and rewrite the whole
+ * selected-indices map per batch. Persistence is deferred to each chunk flush
+ * (`writeRustParquetChunk`) and the end-of-phase flush. These tests assert on
+ * the observable on-disk side effect (`selected_indices.json`) so they verify
+ * the behavioural contract, not the implementation.
+ */
+Deno.test(
+  "DiscoverStructure: record() defers indices persistence to chunk flush (Issue #3086)",
+  async () => {
+    await initWasmForTests();
+    const creature = makeCreature();
+    const baseDir = await Deno.makeTempDir({ prefix: "record-indices-3086-" });
+    const binaryFilePath = "/tmp/fake-3086.bin";
+
+    const structure = new DiscoverStructure(
+      creature,
+      60,
+      100,
+      {
+        isRustDiscoveryEnabled: () => true,
+        isRustLibraryAvailable: () => true,
+        recordDiscovery: () => ({ success: true, file: "chunk.parquet" }),
+        mergeDiscoveryParquet: () => ({
+          success: true,
+          outputFile: "merged.parquet",
+        }),
+        analyzeParallel: () => ({
+          success: true,
+          helpfulNeurons: [],
+          helpfulSynapses: [],
+          harmfulSynapses: [],
+        }),
+        readDiscoveryRecords: () => ({ success: true, records: [] }),
+      },
+      { baseDirectory: baseDir, disableCleanup: true },
+    );
+
+    const neuronPromises = new Map<number, Promise<void>>();
+    const indicesFilePath = join(
+      structure.getTempDir(),
+      "selected_indices.json",
+    );
+
+    try {
+      structure.initialize(neuronPromises);
+
+      // initialize() seeds the file with an empty map.
+      assertEquals(
+        JSON.parse(await Deno.readTextFile(indicesFilePath)),
+        {},
+        "initialize() should seed an empty indices map",
+      );
+
+      // Two record() batches WITHOUT an intervening flush.
+      const first = makeBatch(0, 4);
+      const second = makeBatch(100, 4);
+      assert(
+        structure.record(
+          first.trainingRecords,
+          neuronPromises,
+          binaryFilePath,
+          first.rawIndices,
+        ),
+        "first batch should record",
+      );
+      assert(
+        structure.record(
+          second.trainingRecords,
+          neuronPromises,
+          binaryFilePath,
+          second.rawIndices,
+        ),
+        "second batch should record",
+      );
+
+      // Regression guard: record() must not have rewritten the indices file
+      // per batch — on disk it is still the seeded empty map until a flush.
+      assertEquals(
+        JSON.parse(await Deno.readTextFile(indicesFilePath)),
+        {},
+        "record() must not persist the indices map per batch (Issue #3086)",
+      );
+
+      // A chunk flush persists the complete, correct map.
+      assertEquals(structure.flushRustChunk(), true, "flush should succeed");
+      assertEquals(
+        JSON.parse(await Deno.readTextFile(indicesFilePath)),
+        { [binaryFilePath]: [...first.rawIndices, ...second.rawIndices] },
+        "chunk flush should persist all accumulated indices",
+      );
+    } finally {
+      await structure.cleanUp();
+      await Deno.remove(baseDir, { recursive: true }).catch(() => {});
+    }
+  },
+);
 
 function makeBatch(
   startIndex: number,


### PR DESCRIPTION
# perf: Drop per-batch synchronous re-serialisation of the discovery selected-indices map

## Summary

During discovery recording, `DiscoverStructureRecording.record()` synchronously
re-serialised and rewrote the **entire** selected-indices map to disk on
**every** batch via a blocking `Deno.writeTextFileSync`. The map grows
monotonically across the whole recording phase, making this an
`O(batches × total_indices)` blocking-I/O cost on the dominant phase for large
datasets.

The write was redundant: `writeRustParquetChunk` already persists the same
`selected_indices.json` atomically alongside **every** parquet chunk flush, and
`flushRustRecording` covers the end of the recording phase. The analysis phase
only reads `selected_indices.json` _after_ recording completes
(`DiscoverDataLoading.ts`), never an intermediate version.

This change removes the per-batch write from `record()`. Persistence is now
provided solely by the per-chunk flush write plus the single end-of-phase flush
— which also keeps the indices map and the parquet chunks written together in
sync.

Closes #3086.

## Change

```mermaid
flowchart LR
    subgraph Before
      R1[record batch] -->|writeTextFileSync<br/>whole growing map| D1[(selected_indices.json)]
      R1 --> A1[accumulate samples]
      A1 --> F1[chunk flush] -->|writeTextFileSync| D1
    end
    subgraph After
      R2[record batch] --> A2[accumulate samples<br/>append indices in memory]
      A2 --> F2[chunk flush] -->|writeTextFileSync<br/>once per chunk| D2[(selected_indices.json)]
      F2 --> E2[end-of-phase flush] --> D2
    end
```

- `src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts`
  — removed the per-batch `Deno.writeTextFileSync`; in-memory `appendAll` of the
  selected indices is retained, persistence deferred to chunk flush.

## Evidence

Backend-only change — no UI to screenshot.

### Benchmark (`bench/DiscoveryIndicesPersistence.ts`)

Models the two persistence strategies on a representative recording workload
(256 batches × 128 indices, chunk flush every 16 batches):

| Strategy                     | time/iter (avg) | iter/s |
| ---------------------------- | --------------- | ------ |
| per-batch write (**before**) | 161.9 ms        | 6.2    |
| per-flush write (**after**)  | 4.1 ms          | 241.9  |

**~39× faster** for the modelled workload (the blob rewritten each batch keeps
growing, so the saving compounds with longer recording phases). Run with:

```bash
deno bench --allow-read --allow-write bench/DiscoveryIndicesPersistence.ts
```

## Test Plan

- Added `test/discovery/DiscoverStructureRecordIndices.ts` →
  `"DiscoverStructure: record() defers indices persistence to chunk flush (Issue #3086)"`:
  - asserts `initialize()` seeds an empty map on disk;
  - drives two `record()` batches **without** an intervening flush and asserts
    the on-disk `selected_indices.json` is still the seeded empty map
    (regression guard — fails if the per-batch write is reintroduced);
  - asserts a chunk flush then persists the complete, correct map with absolute
    index offsets preserved.
  - Verified the guard **fails** against the old per-batch-write behaviour and
    **passes** with the fix (TDD).
- Existing discovery recording/flush tests (`DiscoverStructureRecordIndices.ts`,
  `DiscoveryRustFlush.ts`) continue to pass — the final indices file is still
  complete and the analysis phase still loads it.
- Full quality gate: `./quality.sh` — 7396 passed, 0 failed.



## Milestone
This PR is part of the **#3082 Can you see any performance improvements?** milestone and targets the `milestone/3082-can-you-see-any-performance-improvements` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqmaehsl-aa3da7`<!-- vibe-worker-issue-3086 -->