### PR TITLE
perf: Reuse pooled buffers in IF.propagate and IF.record (#3087)

### DIFF
--- a/bench/IfPropagateAllocation.ts
+++ b/bench/IfPropagateAllocation.ts
@@ -1,0 +1,123 @@
+/**
+ * Issue #3087 - Benchmark: IF.propagate per-call typed-array allocation
+ *
+ * IF.propagate previously allocated two typed arrays on every call:
+ *   - `indices` via the slow `Int32Array.from({ length }, cb)` form
+ *   - `errorShares` via `new Float64Array(listLength)`
+ *
+ * Both were discarded at function exit. This benchmark isolates that
+ * allocation pattern and compares it against acquiring pooled buffers from
+ * `BackpropBuffers` and filling `indices` with a plain `for` loop.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-env bench/IfPropagateAllocation.ts
+ */
+
+import { BackpropBuffers } from "@propagate/BackpropBuffers.ts";
+
+// Seeded random for reproducibility (mirrors the in-place shuffle iteration).
+function seededRandom(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
+const random = seededRandom(42);
+
+// Simulate the per-neuron backprop step across a realistic IF-heavy network:
+// many IF neurons, each propagated every sample, every epoch.
+const IF_NEURON_COUNT = 600;
+const MAX_INWARD = 16;
+
+// Variable in-degree per IF neuron.
+const inwardCounts = new Array<number>(IF_NEURON_COUNT);
+for (let i = 0; i < IF_NEURON_COUNT; i++) {
+  inwardCounts[i] = Math.max(1, Math.floor(random() * MAX_INWARD));
+}
+
+// In-place Fisher-Yates over the first `length` entries (matches
+// CreatureUtil.shuffle semantics so both paths do equal shuffle work).
+function shuffleSlice(array: Int32Array, length: number): void {
+  if (length > 1) {
+    for (let i = length; i--;) {
+      const j = Math.round(random() * i);
+      const tmp = array[i];
+      array[i] = array[j];
+      array[j] = tmp;
+    }
+  }
+}
+
+// Consume the buffers so the optimiser cannot eliminate the work.
+let sink = 0;
+function consume(indices: Int32Array, errorShares: Float64Array, len: number) {
+  for (let i = 0; i < len; i++) {
+    sink += indices[i] + errorShares[i];
+  }
+}
+
+// ============================================================================
+// Baseline: fresh typed arrays per call (the pre-#3087 code path)
+// ============================================================================
+Deno.bench({
+  name: `Fresh typed-array allocation per IF.propagate (${IF_NEURON_COUNT}N)`,
+  group: "if-propagate-allocation",
+  baseline: true,
+}, () => {
+  for (let n = 0; n < IF_NEURON_COUNT; n++) {
+    const listLength = inwardCounts[n];
+
+    const indices = Int32Array.from({ length: listLength }, (_, i) => i);
+    shuffleSlice(indices, indices.length);
+
+    const errorShares = new Float64Array(listLength);
+    for (let i = 0; i < listLength; i++) {
+      errorShares[i] = i * 0.5;
+    }
+
+    consume(indices, errorShares, listLength);
+  }
+});
+
+// ============================================================================
+// Optimised: reuse pooled buffers, fill indices with a plain for loop
+// ============================================================================
+const buffers = new BackpropBuffers(MAX_INWARD);
+
+Deno.bench({
+  name: `Pooled buffers per IF.propagate (${IF_NEURON_COUNT}N)`,
+  group: "if-propagate-allocation",
+}, () => {
+  for (let n = 0; n < IF_NEURON_COUNT; n++) {
+    const listLength = inwardCounts[n];
+
+    const buf = buffers.acquire(listLength);
+    const indices = buf.indices;
+    const errorShares = buf.errorShares;
+
+    for (let i = 0; i < listLength; i++) {
+      indices[i] = i;
+    }
+    shuffleSlice(indices, listLength);
+
+    for (let i = 0; i < listLength; i++) {
+      errorShares[i] = i * 0.5;
+    }
+
+    consume(indices, errorShares, listLength);
+    buffers.release(buf);
+  }
+});
+
+console.log("\n" + "=".repeat(70));
+console.log("Issue #3087: IF.propagate per-call typed-array allocation");
+console.log("=".repeat(70));
+console.log(
+  `Simulated ${IF_NEURON_COUNT} IF neurons, max ${MAX_INWARD} inward connections.`,
+);
+console.log(
+  "Baseline allocates `indices` + `errorShares` fresh per call; optimised reuses pooled buffers.",
+);
+console.log(`Lower is better. (sink=${sink})`);

--- a/docs/archive/pr-summaries/pr-summary-3087.md
+++ b/docs/archive/pr-summaries/pr-summary-3087.md
@@ -1,0 +1,85 @@
+# perf: Reuse pooled buffers in IF.propagate instead of per-call typed-array allocation
+
+## Summary
+
+`IF.propagate` is the per-neuron backprop step for every IF neuron, every
+sample, every epoch. It allocated two typed arrays on **every** call — `indices`
+via the slow `Int32Array.from({ length }, cb)` form and `errorShares` via
+`new Float64Array(listLength)` — both discarded at function exit. `IF.record`
+additionally allocated an array per call via `inward.filter(...)`.
+
+This change removes those per-call allocations by reusing the existing
+stack-based buffer pool (`BackpropBuffers`) already used by the regular backprop
+path. **Closes #3087.**
+
+### Changes
+
+- **`BackpropBuffers`** — added `indices: Int32Array` and
+  `errorShares: Float64Array` to the pooled buffer set (allocated and grown
+  alongside the existing eight buffers).
+- **`IF.propagate`** — acquires a pooled buffer set, fills `indices` with a
+  plain `for` loop, uses the pooled `errorShares`, and releases the set after
+  all recursive `fromNeuron.propagate(...)` calls complete. The pool is
+  stack-based, so each recursion level gets its own set.
+- **`CreatureUtil.shuffle`** — gained an optional `length` parameter so the
+  used `0..listLength-1` slice of the pooled `indices` buffer is shuffled
+  without allocating a `subarray` view. Existing callers are unaffected
+  (`length` defaults to `array.length`), and the Fisher-Yates iteration order
+  over the slice is identical, preserving determinism.
+- **`IF.record`** — replaced `inward.filter(...)` with an in-place index scan
+  into a reused, stack-pooled scratch array (`eligibleScratchPool`). The array
+  is consumed synchronously by `buildRecordElasticLinks` and returned to the
+  pool before any recursive `record(...)` call, so a simple stack is safe.
+
+### Correctness
+
+`errorShares` from the pool is not zeroed, but ineligible entries are never
+read: every consuming loop re-applies the same eligibility checks
+(`from === to`, `condition`, sign-vs-`condition`) before using a share. Numeric
+backprop results are therefore unchanged — confirmed by the full IF
+propagation/record suite.
+
+```mermaid
+flowchart LR
+    A[IF.propagate] -->|acquire listLength| P[(BackpropBuffers pool)]
+    P --> I[indices: fill 0..n-1 + shuffle slice]
+    P --> E[errorShares: per-link magnitudes]
+    I --> L[backprop loop]
+    E --> L
+    L -->|recursive propagate uses own pooled set| P
+    L --> R[release back to pool]
+    R --> P
+```
+
+## Evidence
+
+Backend/numerical change — no UI to screenshot. Performance is demonstrated by
+a focused micro-benchmark plus the existing backprop suite.
+
+**`deno bench --allow-read --allow-env bench/IfPropagateAllocation.ts`**
+(Apple M4 Pro, Deno 2.8.3, 600 IF neurons, max in-degree 16):
+
+| benchmark                                            | time/iter (avg) |   iter/s |
+| ---------------------------------------------------- | --------------- | -------- |
+| Fresh typed-array allocation per IF.propagate (600N) |        308.1 µs |    3,245 |
+| Pooled buffers per IF.propagate (600N)               |         49.9 µs |   20,030 |
+
+**Result: pooled path is 6.17× faster** than the fresh per-call allocation
+pattern, removing two (sometimes three) per-call typed-array/array allocations
+from the IF backprop path and cutting GC pressure proportional to
+IF-neurons × samples × epochs.
+
+## Test Plan
+
+- `test/propagate/BackpropBuffers.ts` — added assertions that `acquire` returns
+  `indices`/`errorShares` of sufficient capacity, that they are `Int32Array` /
+  `Float64Array`, and that they grow with capacity.
+- `test/architecture/CreatureUtils.ts` — added tests that
+  `shuffle(array, length)` shuffles only the first `length` elements (leaving
+  the tail untouched and producing a permutation), and that `length === 1`
+  leaves the slice unchanged.
+- Existing IF suites verify numeric backprop results are unchanged:
+  `test/propagate/IF.ts`, `test/propagate/IFWeightedDistribution.ts`,
+  `test/propagate/ifPropagation.ts`, `test/propagate/IfElse.ts`,
+  `test/propagate/record/ElasticRecordIFPrefersPlasticPath.ts`.
+- Full quality gate (`./quality.sh`) passes: 7400 passed, 0 failed.

--- a/src/architecture/CreatureUtils.ts
+++ b/src/architecture/CreatureUtils.ts
@@ -36,11 +36,14 @@ export class CreatureUtil {
    * The shuffle is performed in-place for memory efficiency.
    *
    * @param array - The array to be shuffled
+   * @param length - Optional number of leading elements to shuffle. Defaults to
+   *   the full array length. Lets callers shuffle a pooled buffer's used slice
+   *   without allocating a `subarray` view (Issue #3087).
    */
-  static shuffle(array: Int32Array): void {
-    if (array.length > 1) {
+  static shuffle(array: Int32Array, length: number = array.length): void {
+    if (length > 1) {
       const rng = getRandomNumberGenerator();
-      for (let i = array.length; i--;) {
+      for (let i = length; i--;) {
         const j = Math.round(rng.random() * i);
         [array[i], array[j]] = [array[j], array[i]];
       }

--- a/src/methods/activations/aggregate/IF.ts
+++ b/src/methods/activations/aggregate/IF.ts
@@ -6,7 +6,9 @@ import { findActivationFunction } from "@optimize/FunctionCache.ts";
 import type { InlineActivationInterface } from "@optimize/InlineActivationInterface.ts";
 import type { MakeActivationFunctionInterface } from "@optimize/MakeActivationFunctionInterface.ts";
 import { makeSynapsesValue } from "@optimize/makeSynapsesValue.ts";
+import type { Synapse } from "@architecture/Synapse.ts";
 import { ActivationRange } from "@propagate/ActivationRange.ts";
+import { BackpropBuffers } from "@propagate/BackpropBuffers.ts";
 import {
   type BackPropagationConfig,
   limitValue,
@@ -24,6 +26,15 @@ import type { ApplyLearningsInterface } from "@methods/activations/ApplyLearning
 import type { NeuronActivationInterface } from "@methods/activations/NeuronActivationInterface.ts";
 import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
+
+/**
+ * Issue #3087: Stack-based pool of reusable eligible-connection scratch arrays
+ * for `IF.record`, replacing a per-call `inward.filter(...)` allocation. The
+ * array is filled by an in-place scan, consumed synchronously by
+ * `buildRecordElasticLinks`, and returned to the pool before any recursive
+ * `record(...)` call — so a simple stack is sufficient and reentrancy-safe.
+ */
+const eligibleScratchPool: Synapse[][] = [];
 
 export class IF
   implements
@@ -426,10 +437,26 @@ export class IF
     let improvedValue = currentBias;
 
     const listLength = inward.length;
-    const indices = Int32Array.from({ length: listLength }, (_, i) => i);
+
+    // Issue #3087: Acquire pooled scratch buffers instead of allocating a
+    // fresh `indices` (previously via the slow `Int32Array.from({length}, cb)`
+    // form) and `errorShares` typed array on every call. The pool is the same
+    // stack-based one used by the regular backprop path, so recursive
+    // `fromNeuron.propagate(...)` calls below each get their own buffer set.
+    let backpropBuffers = state.backpropBuffers;
+    if (backpropBuffers === undefined) {
+      backpropBuffers = new BackpropBuffers();
+      state.backpropBuffers = backpropBuffers;
+    }
+    const buf = backpropBuffers.acquire(listLength);
+    const indices = buf.indices;
+    for (let i = 0; i < listLength; i++) {
+      indices[i] = i;
+    }
 
     if (!config.disableRandomSamples) {
-      CreatureUtil.shuffle(indices);
+      // Shuffle only the used `0..listLength-1` slice of the pooled buffer.
+      CreatureUtil.shuffle(indices, listLength);
     }
 
     // Issue #1874: Compute activation-magnitude-weighted error shares
@@ -437,7 +464,10 @@ export class IF
     // magnitudes absorb proportionally more error, consistent with the
     // elastic distribution used by standard neurons.
     const eligibleCount = condition > 0 ? positiveCount : negativeCount;
-    const errorShares = new Float64Array(listLength);
+    // Issue #3087: Reuse the pooled `errorShares` slice. Only eligible
+    // connections are written below; ineligible entries are never read because
+    // the consuming loops re-apply the same eligibility checks before use.
+    const errorShares = buf.errorShares;
     let totalMagnitude = 0;
 
     for (let i = listLength; i--;) {
@@ -530,6 +560,10 @@ export class IF
       improvedValue += improvedAdjustedFromValue;
     }
 
+    // Issue #3087: Return the pooled scratch buffers for reuse. All recursive
+    // `fromNeuron.propagate(...)` calls have completed by this point.
+    backpropBuffers.release(buf);
+
     accumulateBias(
       ns,
       targetValue,
@@ -583,15 +617,23 @@ export class IF
       error = targetValue - currentValue;
     }
 
-    const eligible = inward.filter((c) => {
-      if (c.from === c.to) return false;
-      if (c.type === "condition") return false;
-      if (c.type === "positive" && condition <= 0) return false;
-      if (c.type === "negative" && condition > 0) return false;
-      return true;
-    });
+    // Issue #3087: In-place index scan into a pooled scratch array instead of
+    // allocating a fresh array via `inward.filter(...)` on every call.
+    const eligible = eligibleScratchPool.pop() ?? [];
+    eligible.length = 0;
+    for (let i = 0; i < inward.length; i++) {
+      const c = inward[i];
+      if (c.from === c.to) continue;
+      if (c.type === "condition") continue;
+      if (c.type === "positive" && condition <= 0) continue;
+      if (c.type === "negative" && condition > 0) continue;
+      eligible.push(c);
+    }
 
-    if (eligible.length === 0) return;
+    if (eligible.length === 0) {
+      eligibleScratchPool.push(eligible);
+      return;
+    }
 
     const provisionalErrorPerLink = error / eligible.length;
     const links = buildRecordElasticLinks(
@@ -600,6 +642,10 @@ export class IF
       discoverMap,
       provisionalErrorPerLink,
     );
+    // `links` now holds the synapse references; release the scratch array
+    // before the recursive record(...) calls below reuse the pool.
+    eligible.length = 0;
+    eligibleScratchPool.push(eligible);
     const { links: chosenLinks, shares } = distributeRecordError(error, links, {
       plankConstant: 1e-12,
       allowEqualFallback: true,

--- a/src/propagate/BackpropBuffers.ts
+++ b/src/propagate/BackpropBuffers.ts
@@ -29,6 +29,16 @@ export interface BackpropBufferSet {
   fusedActivations: Float32Array;
   /** Synapse weights for WASM. */
   fusedWeights: Float32Array;
+  /**
+   * Issue #3087: Connection-index scratch for the IF aggregate backprop step
+   * (`IF.propagate`). Filled `0..listLength-1` and optionally shuffled.
+   */
+  indices: Int32Array;
+  /**
+   * Issue #3087: Per-connection error-share scratch for `IF.propagate`,
+   * replacing a `new Float64Array(listLength)` on every call.
+   */
+  errorShares: Float64Array;
   /** Current allocated capacity. */
   capacity: number;
 }
@@ -87,6 +97,8 @@ export class BackpropBuffers {
       fusedHintValues: new Float32Array(capacity),
       fusedActivations: new Float32Array(capacity),
       fusedWeights: new Float32Array(capacity),
+      indices: new Int32Array(capacity),
+      errorShares: new Float64Array(capacity),
       capacity,
     };
   }
@@ -100,6 +112,8 @@ export class BackpropBuffers {
     buf.fusedHintValues = new Float32Array(newCapacity);
     buf.fusedActivations = new Float32Array(newCapacity);
     buf.fusedWeights = new Float32Array(newCapacity);
+    buf.indices = new Int32Array(newCapacity);
+    buf.errorShares = new Float64Array(newCapacity);
     buf.capacity = newCapacity;
     return buf;
   }

--- a/test/architecture/CreatureUtils.ts
+++ b/test/architecture/CreatureUtils.ts
@@ -319,3 +319,30 @@ Deno.test("CreatureUtil.shuffle - preserves all elements (two element array)", (
   assertEquals(sorted[0], 10);
   assertEquals(sorted[1], 20);
 });
+
+// Issue #3087: shuffle accepts an optional `length` so callers can shuffle the
+// used slice of a pooled buffer without allocating a `subarray` view.
+Deno.test("CreatureUtil.shuffle - only shuffles the first `length` elements", () => {
+  // Buffer larger than the used slice; tail entries are sentinels.
+  const arr = new Int32Array([0, 1, 2, 3, 4, -100, -200, -300]);
+  CreatureUtil.shuffle(arr, 5);
+
+  // Tail beyond `length` is untouched.
+  assertEquals(arr[5], -100);
+  assertEquals(arr[6], -200);
+  assertEquals(arr[7], -300);
+
+  // The first 5 entries are a permutation of 0..4.
+  const slice = Array.from(arr.subarray(0, 5)).sort((a, b) => a - b);
+  assertEquals(slice, [0, 1, 2, 3, 4]);
+});
+
+Deno.test("CreatureUtil.shuffle - length of 1 leaves the slice unchanged", () => {
+  const arr = new Int32Array([7, 8, 9]);
+  CreatureUtil.shuffle(arr, 1);
+  // No swaps performed for a single-element slice.
+  assertEquals(arr[0], 7);
+  // Untouched tail.
+  assertEquals(arr[1], 8);
+  assertEquals(arr[2], 9);
+});

--- a/test/propagate/BackpropBuffers.ts
+++ b/test/propagate/BackpropBuffers.ts
@@ -21,8 +21,34 @@ Deno.test("BackpropBuffers - acquire returns buffer with sufficient capacity", (
   assertGreaterOrEqual(buf.fusedHintValues.length, 5);
   assertGreaterOrEqual(buf.fusedActivations.length, 5);
   assertGreaterOrEqual(buf.fusedWeights.length, 5);
+  // Issue #3087: IF.propagate scratch buffers.
+  assertGreaterOrEqual(buf.indices.length, 5);
+  assertGreaterOrEqual(buf.errorShares.length, 5);
 
   pool.release(buf);
+});
+
+Deno.test("BackpropBuffers - IF scratch buffers have correct typed-array kinds", () => {
+  const pool = new BackpropBuffers(8);
+  const buf = pool.acquire(4);
+
+  // Issue #3087: indices is Int32Array, errorShares is Float64Array.
+  assertEquals(buf.indices instanceof Int32Array, true);
+  assertEquals(buf.errorShares instanceof Float64Array, true);
+
+  pool.release(buf);
+});
+
+Deno.test("BackpropBuffers - IF scratch buffers grow with capacity", () => {
+  const pool = new BackpropBuffers(4);
+  const small = pool.acquire(4);
+  pool.release(small);
+
+  const large = pool.acquire(32);
+  assertGreaterOrEqual(large.indices.length, 32);
+  assertGreaterOrEqual(large.errorShares.length, 32);
+
+  pool.release(large);
 });
 
 Deno.test("BackpropBuffers - released buffer is reused by next acquire", () => {


### PR DESCRIPTION
# perf: Reuse pooled buffers in IF.propagate instead of per-call typed-array allocation

## Summary

`IF.propagate` is the per-neuron backprop step for every IF neuron, every
sample, every epoch. It allocated two typed arrays on **every** call — `indices`
via the slow `Int32Array.from({ length }, cb)` form and `errorShares` via
`new Float64Array(listLength)` — both discarded at function exit. `IF.record`
additionally allocated an array per call via `inward.filter(...)`.

This change removes those per-call allocations by reusing the existing
stack-based buffer pool (`BackpropBuffers`) already used by the regular backprop
path. **Closes #3087.**

### Changes

- **`BackpropBuffers`** — added `indices: Int32Array` and
  `errorShares: Float64Array` to the pooled buffer set (allocated and grown
  alongside the existing eight buffers).
- **`IF.propagate`** — acquires a pooled buffer set, fills `indices` with a
  plain `for` loop, uses the pooled `errorShares`, and releases the set after
  all recursive `fromNeuron.propagate(...)` calls complete. The pool is
  stack-based, so each recursion level gets its own set.
- **`CreatureUtil.shuffle`** — gained an optional `length` parameter so the
  used `0..listLength-1` slice of the pooled `indices` buffer is shuffled
  without allocating a `subarray` view. Existing callers are unaffected
  (`length` defaults to `array.length`), and the Fisher-Yates iteration order
  over the slice is identical, preserving determinism.
- **`IF.record`** — replaced `inward.filter(...)` with an in-place index scan
  into a reused, stack-pooled scratch array (`eligibleScratchPool`). The array
  is consumed synchronously by `buildRecordElasticLinks` and returned to the
  pool before any recursive `record(...)` call, so a simple stack is safe.

### Correctness

`errorShares` from the pool is not zeroed, but ineligible entries are never
read: every consuming loop re-applies the same eligibility checks
(`from === to`, `condition`, sign-vs-`condition`) before using a share. Numeric
backprop results are therefore unchanged — confirmed by the full IF
propagation/record suite.

```mermaid
flowchart LR
    A[IF.propagate] -->|acquire listLength| P[(BackpropBuffers pool)]
    P --> I[indices: fill 0..n-1 + shuffle slice]
    P --> E[errorShares: per-link magnitudes]
    I --> L[backprop loop]
    E --> L
    L -->|recursive propagate uses own pooled set| P
    L --> R[release back to pool]
    R --> P
```

## Evidence

Backend/numerical change — no UI to screenshot. Performance is demonstrated by
a focused micro-benchmark plus the existing backprop suite.

**`deno bench --allow-read --allow-env bench/IfPropagateAllocation.ts`**
(Apple M4 Pro, Deno 2.8.3, 600 IF neurons, max in-degree 16):

| benchmark                                            | time/iter (avg) |   iter/s |
| ---------------------------------------------------- | --------------- | -------- |
| Fresh typed-array allocation per IF.propagate (600N) |        308.1 µs |    3,245 |
| Pooled buffers per IF.propagate (600N)               |         49.9 µs |   20,030 |

**Result: pooled path is 6.17× faster** than the fresh per-call allocation
pattern, removing two (sometimes three) per-call typed-array/array allocations
from the IF backprop path and cutting GC pressure proportional to
IF-neurons × samples × epochs.

## Test Plan

- `test/propagate/BackpropBuffers.ts` — added assertions that `acquire` returns
  `indices`/`errorShares` of sufficient capacity, that they are `Int32Array` /
  `Float64Array`, and that they grow with capacity.
- `test/architecture/CreatureUtils.ts` — added tests that
  `shuffle(array, length)` shuffles only the first `length` elements (leaving
  the tail untouched and producing a permutation), and that `length === 1`
  leaves the slice unchanged.
- Existing IF suites verify numeric backprop results are unchanged:
  `test/propagate/IF.ts`, `test/propagate/IFWeightedDistribution.ts`,
  `test/propagate/ifPropagation.ts`, `test/propagate/IfElse.ts`,
  `test/propagate/record/ElasticRecordIFPrefersPlasticPath.ts`.
- Full quality gate (`./quality.sh`) passes: 7400 passed, 0 failed.



## Milestone
This PR is part of the **#3082 Can you see any performance improvements?** milestone and targets the `milestone/3082-can-you-see-any-performance-improvements` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqmaehsl-aa3da7`<!-- vibe-worker-issue-3087 -->