### PR TITLE
perf: Eliminate double deep-clone of memetic in the creature export path (#3088)

### DIFF
--- a/bench/export/ExportJsonMemetic.ts
+++ b/bench/export/ExportJsonMemetic.ts
@@ -1,0 +1,141 @@
+/**
+ * Issue #3088 — benchmark the creature export path on a creature carrying a
+ * non-trivial memetic blob (weights / biases / ancestry).
+ *
+ * The existing export benches (ExportJson.ts) and worker benches
+ * (bench/WorkerJsonSerialisation.ts) do not populate `creature.memetic`, so
+ * they never exercised the memetic deep-clone that dominated this path.
+ *
+ * Before #3088 the export deep-cloned `creature.memetic` twice (once in
+ * CreatureExportBuilder.build(), then again inside
+ * convertMemeticExportToWireJson) and threw the first clone away. After #3088
+ * the wire converter is the single owner that clones exactly once.
+ *
+ * Run: deno bench --allow-all bench/export/ExportJsonMemetic.ts
+ */
+import { Creature } from "@creature";
+import type { CreatureExport } from "../../mod.ts";
+import {
+  exportJSONWithRuntimeIds,
+} from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+import type {
+  MemeticAncestorSnapshot,
+  MemeticBiasInterface,
+  MemeticInterface,
+  MemeticWeightsInterface,
+} from "@blackbox/MemeticInterface.ts";
+
+const INPUT = 8;
+const HIDDEN = 200;
+const OUTPUT = 4;
+const ANCESTRY_DEPTH = 3;
+
+/** Build a dense-ish feed-forward creature with HIDDEN hidden neurons. */
+function buildCreature(): Creature {
+  const neurons: CreatureExport["neurons"] = [];
+  for (let i = 0; i < HIDDEN; i++) {
+    neurons.push({
+      type: "hidden",
+      uuid: `hidden-${i}`,
+      squash: "LOGISTIC",
+      bias: (i % 7) * 0.1 - 0.3,
+    });
+  }
+  for (let o = 0; o < OUTPUT; o++) {
+    neurons.push({
+      type: "output",
+      uuid: `output-${o}`,
+      squash: "IDENTITY",
+      bias: o * 0.05,
+    });
+  }
+
+  const synapses: CreatureExport["synapses"] = [];
+  // input → hidden
+  for (let h = 0; h < HIDDEN; h++) {
+    const i = h % INPUT;
+    synapses.push({
+      fromUUID: `input-${i}`,
+      toUUID: `hidden-${h}`,
+      weight: 0.01 * h - 0.5,
+    });
+  }
+  // hidden → hidden (forward only: lower index → higher index)
+  for (let h = 1; h < HIDDEN; h++) {
+    synapses.push({
+      fromUUID: `hidden-${h - 1}`,
+      toUUID: `hidden-${h}`,
+      weight: 0.02 * h - 0.4,
+    });
+  }
+  // last hidden → outputs
+  for (let o = 0; o < OUTPUT; o++) {
+    synapses.push({
+      fromUUID: `hidden-${HIDDEN - 1}`,
+      toUUID: `output-${o}`,
+      weight: 0.3 + o * 0.05,
+    });
+  }
+
+  const json: CreatureExport = {
+    neurons,
+    synapses,
+    input: INPUT,
+    output: OUTPUT,
+  };
+  const creature = Creature.fromJSON(json);
+  creature.score = -0.1;
+  creature.memetic = buildMemetic(creature);
+  return creature;
+}
+
+/** Populate a memetic snapshot (weights/biases) keyed by runtime integer ids. */
+function buildSnapshot(creature: Creature): {
+  weights: MemeticWeightsInterface;
+  biases: MemeticBiasInterface;
+} {
+  const idOf = (uuid: string) =>
+    creature.neurons.find((n) => n.uuid === uuid)!.id;
+  const biases: MemeticBiasInterface = {};
+  const weights: MemeticWeightsInterface = {};
+  for (let h = 0; h < HIDDEN; h++) {
+    const id = idOf(`hidden-${h}`);
+    biases[id] = 0.1 * h - 0.5;
+    if (h > 0) {
+      const fromId = idOf(`hidden-${h - 1}`);
+      weights[fromId] = [{ toId: id, weight: 0.02 * h - 0.4 }];
+    }
+  }
+  return { weights, biases };
+}
+
+function buildMemetic(creature: Creature): MemeticInterface {
+  const base = buildSnapshot(creature);
+  const ancestry: MemeticAncestorSnapshot[] = [];
+  for (let g = 0; g < ANCESTRY_DEPTH; g++) {
+    const snap = buildSnapshot(creature);
+    ancestry.push({
+      generation: g,
+      score: -0.2 - g * 0.01,
+      weights: snap.weights,
+      biases: snap.biases,
+    });
+  }
+  return {
+    generation: ANCESTRY_DEPTH,
+    score: -0.2,
+    weights: base.weights,
+    biases: base.biases,
+    ancestry,
+  };
+}
+
+const creature = buildCreature();
+
+Deno.bench("exportJSON (wire, with memetic)", () => {
+  creature.exportJSON();
+});
+
+Deno.bench("exportJSONWithRuntimeIds (with memetic)", () => {
+  exportJSONWithRuntimeIds(creature);
+});

--- a/docs/archive/pr-summaries/pr-summary-3088.md
+++ b/docs/archive/pr-summaries/pr-summary-3088.md
@@ -1,0 +1,86 @@
+# perf: Eliminate double deep-clone of memetic in the creature export path
+
+## Summary
+
+Every external creature export deep-cloned `creature.memetic` **twice** and
+threw the first clone away: once in `CreatureExportBuilder.build()` and again
+inside `convertMemeticExportToWireJson()` (the wire converter). This ran
+per-genome, per-generation on the worker→main dispatch and breeding paths, on
+exactly the fittest / fine-tuned creatures that carry the largest memetic blobs.
+
+The fix makes the wire converter the **single owner** that clones memetic
+exactly once. `CreatureExportBuilder.build()` gains a `cloneMemetic` flag
+(default `true`, so every existing caller is byte-for-byte unchanged). The two
+wire-export call sites pass `cloneMemetic = false` because
+`convertMemeticExportToWireJson()` already deep-clones its input — so the build
+clone was pure waste:
+
+- `exportJSON()` / `exportSnapshotJSON()` (wire path) → `build(false, false)`.
+- `exportJSONWithRuntimeIds()` (worker→main / breeding path) →
+  `build(true, false)`.
+
+The wire converter never mutates its input, so attaching `creature.memetic` by
+reference here never aliases the live creature into the export. The only
+in-place consumer (`normaliseCreatureExport` via the `includeIds` branch) still
+receives a private deep copy from `build()`, so no semantics change.
+
+Net: **one** deep clone instead of two on every export, no semantic change.
+
+Closes #3088.
+
+## Data flow
+
+```mermaid
+flowchart LR
+    subgraph Before["Before — 2 clones"]
+        B1[build] -->|clone #1 wasted| BW[convertMemeticExportToWireJson]
+        BW -->|clone #2| BOUT[wire memetic]
+    end
+    subgraph After["After — 1 clone"]
+        A1[build cloneMemetic=false] -->|by reference| AW[convertMemeticExportToWireJson]
+        AW -->|clone #1| AOUT[wire memetic]
+    end
+```
+
+## Evidence
+
+Backend/library change — no UI to screenshot. Performance is demonstrated by a
+new benchmark that exports a creature carrying a non-trivial memetic (weights /
+biases / ancestry); none of the pre-existing export/worker benches populated
+`creature.memetic`, so the clone cost was never measured.
+
+`bench/export/ExportJsonMemetic.ts` (200 hidden neurons, depth-3 ancestry),
+`deno bench`, Apple M4 / Deno 2.8.3:
+
+| benchmark                                 | before (avg) | after (avg) | change      |
+| ----------------------------------------- | ------------ | ----------- | ----------- |
+| `exportJSON` (wire, with memetic)         | 747.5 µs     | 446.9 µs    | **−40.2 %** |
+| `exportJSONWithRuntimeIds` (with memetic) | 741.4 µs     | 440.5 µs    | **−40.6 %** |
+
+Baseline ("before") was captured by stashing only the three `src/` changes and
+re-running the same benchmark; the wins scale with memetic size.
+
+## Test Plan
+
+- Added `test/creature/MemeticExportSingleClone.ts` ("what" tests, not timing):
+  - `exportJSON`: wire memetic is correct (weights as
+    `{ fromUUID, toUUID, weight }` array, biases keyed by wire UUID strings) and
+    is **not aliased** to the live `creature.memetic` — mutating the export
+    leaves the creature untouched.
+  - `exportJSONWithRuntimeIds`: exported memetic is independent of the live
+    creature.
+  - `exportJSON` → `fromJSON` round-trip preserves memetic generation, score,
+    biases, and weights.
+- Full `./quality.sh` gate passes: **7403 passed, 0 failed, 4 ignored**.
+
+## Files changed
+
+- `src/utils/CreatureExportBuilder.ts` —
+  `build(includeIds, cloneMemetic = true)`.
+- `src/creature/CreatureSerialization.ts` — wire path skips the redundant clone.
+- `src/architecture/PopulateRuntimeIdsFromCreature.ts` — runtime-id wire export
+  skips the redundant clone.
+- `bench/export/ExportJsonMemetic.ts` — new memetic-populated export benchmark.
+- `test/creature/MemeticExportSingleClone.ts` — new regression tests.
+
+Part of #3082 (performance-improvement sweep).

--- a/src/architecture/PopulateRuntimeIdsFromCreature.ts
+++ b/src/architecture/PopulateRuntimeIdsFromCreature.ts
@@ -97,7 +97,10 @@ export function exportJSONWithRuntimeIdsUnchecked(
 }
 
 function buildExportWithRuntimeIds(creature: Creature): CreatureExport {
-  const json = new CreatureExportBuilder(creature).build(true);
+  // Issue #3088: convertMemeticExportToWireJson deep-clones memetic, so build()
+  // attaches it by reference (cloneMemetic=false) to avoid a redundant clone on
+  // this per-genome worker→main / breeding hot path.
+  const json = new CreatureExportBuilder(creature).build(true, false);
   if (json.memetic) {
     json.memetic = convertMemeticExportToWireJson(creature, json.memetic);
   }

--- a/src/creature/CreatureSerialization.ts
+++ b/src/creature/CreatureSerialization.ts
@@ -105,7 +105,11 @@ function buildCreatureExportJSON(
   includeIds: boolean,
 ): CreatureExport {
   const builder = new CreatureExportBuilder(creature);
-  const json = builder.build(includeIds) as CreatureExport;
+  // Issue #3088: the wire path (convertMemeticExportToWireJson) deep-clones
+  // memetic itself, so only ask build() to clone for the includeIds path,
+  // which mutates memetic in place via normaliseCreatureExport. This avoids a
+  // redundant second clone on every wire export.
+  const json = builder.build(includeIds, includeIds) as CreatureExport;
   if (includeIds && json.memetic) {
     normaliseCreatureExport(json);
   } else if (json.memetic) {

--- a/src/utils/CreatureExportBuilder.ts
+++ b/src/utils/CreatureExportBuilder.ts
@@ -19,8 +19,15 @@ export class CreatureExportBuilder {
    * @param includeIds When true, includes runtime integer `id` on neurons
    *   and `fromId`/`toId` on synapses. External consumers should use the
    *   default (false) which produces UUID-only output (Issue #2054).
+   * @param cloneMemetic When true (default), `memetic` is deep-cloned so the
+   *   caller can safely mutate it in place. Callers that hand the export to
+   *   {@link convertMemeticExportToWireJson} (the wire path) should pass
+   *   `false`: that converter deep-clones memetic itself, so cloning here too
+   *   is pure waste (Issue #3088). The export then carries `creature.memetic`
+   *   by reference — the wire converter never mutates its input, so the live
+   *   creature is never aliased into.
    */
-  build(includeIds = false): CreatureExport {
+  build(includeIds = false, cloneMemetic = true): CreatureExport {
     const creature = this.creature;
     const neurons = creature.neurons;
     const synapses = creature.synapses;
@@ -78,8 +85,13 @@ export class CreatureExportBuilder {
 
     const memetic = creature.memetic;
     if (memetic) {
-      // Deep clone memetic data using JSON.parse/stringify for robust cloning
-      json.memetic = JSON.parse(JSON.stringify(memetic));
+      // Issue #3088: only deep-clone when the caller mutates memetic in place
+      // (the includeIds → normaliseCreatureExport path). Wire-export callers
+      // pass cloneMemetic=false because convertMemeticExportToWireJson clones
+      // memetic itself; cloning here as well was a redundant per-export clone.
+      json.memetic = cloneMemetic
+        ? JSON.parse(JSON.stringify(memetic))
+        : memetic;
     }
 
     // Issue #1863: Export per-creature evolvable hyperparameters

--- a/test/creature/MemeticExportSingleClone.ts
+++ b/test/creature/MemeticExportSingleClone.ts
@@ -1,0 +1,146 @@
+/**
+ * Issue #3088 — the creature export path must clone `creature.memetic` exactly
+ * once and must never alias the live creature's memetic into the export.
+ *
+ * These are "what" tests: they assert on the exported wire JSON and on the
+ * isolation of the live creature's memetic, not on how many clones happen
+ * internally (that is measured by bench/export/ExportJsonMemetic.ts). They
+ * pass before and after the optimisation and guard against a future change
+ * that aliases memetic by reference without a downstream clone.
+ */
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../mod.ts";
+import type { MemeticInterface } from "@blackbox/MemeticInterface.ts";
+import { Creature } from "@creature";
+import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
+
+function makeCreatureWithMemetic(): Creature {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", id: 5003, uuid: "hidden-3", squash: "Cosine", bias: 3 },
+      {
+        type: "hidden",
+        id: 5004,
+        uuid: "hidden-4",
+        squash: "CLIPPED",
+        bias: 2,
+      },
+      { type: "output", squash: "IDENTITY", uuid: "output-0", bias: 1 },
+      { type: "output", squash: "IDENTITY", uuid: "output-1", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-3", weight: -0.3 },
+      { fromUUID: "input-1", toUUID: "hidden-3", weight: 0.3 },
+      { fromUUID: "hidden-3", toUUID: "hidden-4", weight: -0.5 },
+      { fromUUID: "hidden-4", toUUID: "output-0", weight: 0.6 },
+      { fromUUID: "hidden-4", toUUID: "output-1", weight: 0.7 },
+      { fromUUID: "input-2", toUUID: "output-1", weight: 0.8 },
+    ],
+    input: 3,
+    output: 2,
+  };
+  const creature = Creature.fromJSON(json);
+  creature.score = -0.1;
+
+  // Build a non-trivial runtime memetic keyed by the live integer ids so the
+  // wire conversion has real weights/biases/ancestry to rewrite.
+  const idOf = (uuid: string): number =>
+    creature.neurons.find((n) => n.uuid === uuid)!.id;
+  const h3 = idOf("hidden-3");
+  const h4 = idOf("hidden-4");
+
+  creature.memetic = {
+    generation: 2,
+    score: -0.2,
+    biases: { [h3]: 3.1, [h4]: 2.1 },
+    weights: { [h3]: [{ toId: h4, weight: -0.55 }] },
+    ancestry: [
+      {
+        generation: 1,
+        score: -0.3,
+        biases: { [h3]: 3.0 },
+        weights: { [h3]: [{ toId: h4, weight: -0.5 }] },
+      },
+    ],
+  };
+  return creature;
+}
+
+Deno.test("exportJSON: wire memetic is independent of live creature.memetic", () => {
+  const creature = makeCreatureWithMemetic();
+  const snapshot = JSON.stringify(creature.memetic);
+
+  const exported = creature.exportJSON();
+  assert(exported.memetic, "export should carry memetic");
+
+  // Wire format: weights become an array of { fromUUID, toUUID, weight } rows,
+  // biases are keyed by wire UUID strings (no numeric neuron keys).
+  const wire = exported.memetic as unknown as {
+    weights: Array<{ fromUUID: string; toUUID: string; weight: number }>;
+    biases: Record<string, number>;
+  };
+  assert(Array.isArray(wire.weights), "wire weights should be an array");
+  assertEquals(wire.weights[0].fromUUID, "hidden-3");
+  assertEquals(wire.weights[0].toUUID, "hidden-4");
+  assertEquals(wire.biases["hidden-3"], 3.1);
+
+  // No aliasing: the export must not be the same object as the live memetic,
+  // and mutating the export must not touch the live creature.
+  assert(
+    exported.memetic !== (creature.memetic as unknown),
+    "export memetic must not be the same object as creature.memetic",
+  );
+  (exported.memetic as unknown as { biases: Record<string, number> }).biases =
+    {};
+  (exported.memetic as unknown as { weights: unknown[] }).weights = [];
+  assertEquals(
+    JSON.stringify(creature.memetic),
+    snapshot,
+    "mutating the export must not alter the live creature.memetic",
+  );
+});
+
+Deno.test("exportJSONWithRuntimeIds: memetic is independent of live creature.memetic", () => {
+  const creature = makeCreatureWithMemetic();
+  const snapshot = JSON.stringify(creature.memetic);
+
+  const exported = exportJSONWithRuntimeIds(creature);
+  assert(exported.memetic, "runtime-id export should carry memetic");
+  assert(
+    exported.memetic !== (creature.memetic as unknown),
+    "export memetic must not alias creature.memetic",
+  );
+
+  (exported.memetic as unknown as { biases: Record<string, number> }).biases =
+    {};
+  assertEquals(
+    JSON.stringify(creature.memetic),
+    snapshot,
+    "mutating the runtime-id export must not alter the live creature.memetic",
+  );
+});
+
+Deno.test("exportJSON → fromJSON round-trip preserves memetic values", () => {
+  const creature = makeCreatureWithMemetic();
+  const h3 = creature.neurons.find((n) => n.uuid === "hidden-3")!.id;
+  const h4 = creature.neurons.find((n) => n.uuid === "hidden-4")!.id;
+
+  const restored = Creature.fromJSON(creature.exportJSON());
+  const m = restored.memetic as MemeticInterface;
+  assert(m, "restored creature should have memetic");
+
+  const rh3 = restored.neurons.find((n) => n.uuid === "hidden-3")!.id;
+  const rh4 = restored.neurons.find((n) => n.uuid === "hidden-4")!.id;
+
+  assertEquals(m.generation, 2);
+  assertEquals(m.score, -0.2);
+  assertEquals(m.biases[rh3], 3.1);
+  assertEquals(m.biases[rh4], 2.1);
+  assertEquals(m.weights[rh3][0].toId, rh4);
+  assertEquals(m.weights[rh3][0].weight, -0.55);
+
+  // Identity of original ids is irrelevant beyond resolving via UUID; this just
+  // asserts the original creature still owns its own ids (not mutated by export).
+  assertEquals(creature.neurons.find((n) => n.uuid === "hidden-3")!.id, h3);
+  assertEquals(creature.neurons.find((n) => n.uuid === "hidden-4")!.id, h4);
+});


### PR DESCRIPTION
# perf: Eliminate double deep-clone of memetic in the creature export path

## Summary

Every external creature export deep-cloned `creature.memetic` **twice** and
threw the first clone away: once in `CreatureExportBuilder.build()` and again
inside `convertMemeticExportToWireJson()` (the wire converter). This ran
per-genome, per-generation on the worker→main dispatch and breeding paths, on
exactly the fittest / fine-tuned creatures that carry the largest memetic blobs.

The fix makes the wire converter the **single owner** that clones memetic
exactly once. `CreatureExportBuilder.build()` gains a `cloneMemetic` flag
(default `true`, so every existing caller is byte-for-byte unchanged). The two
wire-export call sites pass `cloneMemetic = false` because
`convertMemeticExportToWireJson()` already deep-clones its input — so the build
clone was pure waste:

- `exportJSON()` / `exportSnapshotJSON()` (wire path) → `build(false, false)`.
- `exportJSONWithRuntimeIds()` (worker→main / breeding path) →
  `build(true, false)`.

The wire converter never mutates its input, so attaching `creature.memetic` by
reference here never aliases the live creature into the export. The only
in-place consumer (`normaliseCreatureExport` via the `includeIds` branch) still
receives a private deep copy from `build()`, so no semantics change.

Net: **one** deep clone instead of two on every export, no semantic change.

Closes #3088.

## Data flow

```mermaid
flowchart LR
    subgraph Before["Before — 2 clones"]
        B1[build] -->|clone #1 wasted| BW[convertMemeticExportToWireJson]
        BW -->|clone #2| BOUT[wire memetic]
    end
    subgraph After["After — 1 clone"]
        A1[build cloneMemetic=false] -->|by reference| AW[convertMemeticExportToWireJson]
        AW -->|clone #1| AOUT[wire memetic]
    end
```

## Evidence

Backend/library change — no UI to screenshot. Performance is demonstrated by a
new benchmark that exports a creature carrying a non-trivial memetic (weights /
biases / ancestry); none of the pre-existing export/worker benches populated
`creature.memetic`, so the clone cost was never measured.

`bench/export/ExportJsonMemetic.ts` (200 hidden neurons, depth-3 ancestry),
`deno bench`, Apple M4 / Deno 2.8.3:

| benchmark                                 | before (avg) | after (avg) | change      |
| ----------------------------------------- | ------------ | ----------- | ----------- |
| `exportJSON` (wire, with memetic)         | 747.5 µs     | 446.9 µs    | **−40.2 %** |
| `exportJSONWithRuntimeIds` (with memetic) | 741.4 µs     | 440.5 µs    | **−40.6 %** |

Baseline ("before") was captured by stashing only the three `src/` changes and
re-running the same benchmark; the wins scale with memetic size.

## Test Plan

- Added `test/creature/MemeticExportSingleClone.ts` ("what" tests, not timing):
  - `exportJSON`: wire memetic is correct (weights as
    `{ fromUUID, toUUID, weight }` array, biases keyed by wire UUID strings) and
    is **not aliased** to the live `creature.memetic` — mutating the export
    leaves the creature untouched.
  - `exportJSONWithRuntimeIds`: exported memetic is independent of the live
    creature.
  - `exportJSON` → `fromJSON` round-trip preserves memetic generation, score,
    biases, and weights.
- Full `./quality.sh` gate passes: **7403 passed, 0 failed, 4 ignored**.

## Files changed

- `src/utils/CreatureExportBuilder.ts` —
  `build(includeIds, cloneMemetic = true)`.
- `src/creature/CreatureSerialization.ts` — wire path skips the redundant clone.
- `src/architecture/PopulateRuntimeIdsFromCreature.ts` — runtime-id wire export
  skips the redundant clone.
- `bench/export/ExportJsonMemetic.ts` — new memetic-populated export benchmark.
- `test/creature/MemeticExportSingleClone.ts` — new regression tests.

Part of #3082 (performance-improvement sweep).



## Milestone
This PR is part of the **#3082 Can you see any performance improvements?** milestone and targets the `milestone/3082-can-you-see-any-performance-improvements` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqmuagax-21b0ad`<!-- vibe-worker-issue-3088 -->