### PR TITLE
perf: Cache SynapseState reference to avoid nested-Map double lookup (#3089)

### DIFF
--- a/bench/SynapseStateConnectionLookup.ts
+++ b/bench/SynapseStateConnectionLookup.ts
@@ -1,0 +1,120 @@
+/**
+ * Benchmark: Cache SynapseState reference to avoid nested-Map double lookup
+ * (Issue #3089).
+ *
+ * The per-step backprop path resolves a synapse's SynapseState through a
+ * two-level Map (two hash lookups). connectionFor() memoises the reference on
+ * the Synapse instance, returning it after a single generation comparison.
+ *
+ * This bench isolates the per-step state lookup that no existing bench covered
+ * (NumericConnectionKeys measures the topology connectionSet, not this state
+ * lookup). It compares:
+ *   - connection(from, to)  — the original nested-Map double lookup
+ *   - connectionFor(synapse) — the cached reference path (steady state)
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write --allow-env bench/SynapseStateConnectionLookup.ts
+ */
+import { Creature } from "@creature";
+import type { Synapse } from "@architecture/Synapse.ts";
+
+function buildCreature(targetNeurons: number): Creature {
+  const input = Math.max(5, Math.floor(targetNeurons * 0.1));
+  const output = Math.max(2, Math.floor(targetNeurons * 0.05));
+  const hidden = targetNeurons - input - output;
+
+  if (hidden <= 0) {
+    return new Creature(input, output);
+  }
+
+  const layerCount = Math.min(3, Math.ceil(hidden / 20));
+  const perLayer = Math.floor(hidden / layerCount);
+  const layers = [];
+  for (let i = 0; i < layerCount; i++) {
+    layers.push({
+      count: i === layerCount - 1
+        ? hidden - perLayer * (layerCount - 1)
+        : perLayer,
+    });
+  }
+  return new Creature(input, output, { layers });
+}
+
+const creature200 = buildCreature(200);
+const creature500 = buildCreature(500);
+
+console.log("=== Creature Sizes ===");
+console.log(
+  `~200: ${creature200.neurons.length} neurons, ${creature200.synapses.length} synapses`,
+);
+console.log(
+  `~500: ${creature500.neurons.length} neurons, ${creature500.synapses.length} synapses`,
+);
+
+// Each backprop step touches each synapse's state multiple times (adjustedWeight
+// alone resolves it 2-3x). Replay that multiplicity per synapse.
+const TOUCHES_PER_SYNAPSE = 3;
+
+function runConnection(creature: Creature): number {
+  const state = creature.state;
+  const synapses = creature.synapses;
+  let acc = 0;
+  for (let i = 0; i < synapses.length; i++) {
+    const c = synapses[i];
+    for (let t = 0; t < TOUCHES_PER_SYNAPSE; t++) {
+      acc += state.connection(c.from, c.to).count;
+    }
+  }
+  return acc;
+}
+
+function runConnectionFor(creature: Creature, synapses: Synapse[]): number {
+  const state = creature.state;
+  let acc = 0;
+  for (let i = 0; i < synapses.length; i++) {
+    const c = synapses[i];
+    for (let t = 0; t < TOUCHES_PER_SYNAPSE; t++) {
+      acc += state.connectionFor(c).count;
+    }
+  }
+  return acc;
+}
+
+// Prime the connectionFor cache once so we measure the steady-state hit path,
+// which is what the inner training loop sees across samples and epochs.
+runConnectionFor(creature200, creature200.synapses);
+runConnectionFor(creature500, creature500.synapses);
+
+Deno.bench({
+  name: "connection() nested-Map double lookup (~200 neurons)",
+  group: "stateLookup-200",
+  baseline: true,
+  fn: () => {
+    runConnection(creature200);
+  },
+});
+
+Deno.bench({
+  name: "connectionFor() cached reference (~200 neurons)",
+  group: "stateLookup-200",
+  fn: () => {
+    runConnectionFor(creature200, creature200.synapses);
+  },
+});
+
+Deno.bench({
+  name: "connection() nested-Map double lookup (~500 neurons)",
+  group: "stateLookup-500",
+  baseline: true,
+  fn: () => {
+    runConnection(creature500);
+  },
+});
+
+Deno.bench({
+  name: "connectionFor() cached reference (~500 neurons)",
+  group: "stateLookup-500",
+  fn: () => {
+    runConnectionFor(creature500, creature500.synapses);
+  },
+});

--- a/docs/archive/pr-summaries/pr-summary-3087.md
+++ b/docs/archive/pr-summaries/pr-summary-3087.md
@@ -21,11 +21,11 @@ path. **Closes #3087.**
   plain `for` loop, uses the pooled `errorShares`, and releases the set after
   all recursive `fromNeuron.propagate(...)` calls complete. The pool is
   stack-based, so each recursion level gets its own set.
-- **`CreatureUtil.shuffle`** — gained an optional `length` parameter so the
-  used `0..listLength-1` slice of the pooled `indices` buffer is shuffled
-  without allocating a `subarray` view. Existing callers are unaffected
-  (`length` defaults to `array.length`), and the Fisher-Yates iteration order
-  over the slice is identical, preserving determinism.
+- **`CreatureUtil.shuffle`** — gained an optional `length` parameter so the used
+  `0..listLength-1` slice of the pooled `indices` buffer is shuffled without
+  allocating a `subarray` view. Existing callers are unaffected (`length`
+  defaults to `array.length`), and the Fisher-Yates iteration order over the
+  slice is identical, preserving determinism.
 - **`IF.record`** — replaced `inward.filter(...)` with an in-place index scan
   into a reused, stack-pooled scratch array (`eligibleScratchPool`). The array
   is consumed synchronously by `buildRecordElasticLinks` and returned to the
@@ -53,21 +53,21 @@ flowchart LR
 
 ## Evidence
 
-Backend/numerical change — no UI to screenshot. Performance is demonstrated by
-a focused micro-benchmark plus the existing backprop suite.
+Backend/numerical change — no UI to screenshot. Performance is demonstrated by a
+focused micro-benchmark plus the existing backprop suite.
 
-**`deno bench --allow-read --allow-env bench/IfPropagateAllocation.ts`**
-(Apple M4 Pro, Deno 2.8.3, 600 IF neurons, max in-degree 16):
+**`deno bench --allow-read --allow-env bench/IfPropagateAllocation.ts`** (Apple
+M4 Pro, Deno 2.8.3, 600 IF neurons, max in-degree 16):
 
-| benchmark                                            | time/iter (avg) |   iter/s |
-| ---------------------------------------------------- | --------------- | -------- |
-| Fresh typed-array allocation per IF.propagate (600N) |        308.1 µs |    3,245 |
-| Pooled buffers per IF.propagate (600N)               |         49.9 µs |   20,030 |
+| benchmark                                            | time/iter (avg) | iter/s |
+| ---------------------------------------------------- | --------------- | ------ |
+| Fresh typed-array allocation per IF.propagate (600N) | 308.1 µs        | 3,245  |
+| Pooled buffers per IF.propagate (600N)               | 49.9 µs         | 20,030 |
 
 **Result: pooled path is 6.17× faster** than the fresh per-call allocation
 pattern, removing two (sometimes three) per-call typed-array/array allocations
-from the IF backprop path and cutting GC pressure proportional to
-IF-neurons × samples × epochs.
+from the IF backprop path and cutting GC pressure proportional to IF-neurons ×
+samples × epochs.
 
 ## Test Plan
 

--- a/docs/archive/pr-summaries/pr-summary-3089.md
+++ b/docs/archive/pr-summaries/pr-summary-3089.md
@@ -1,0 +1,94 @@
+# perf: Cache SynapseState reference to avoid nested-Map double lookup
+
+## Summary
+
+`CreatureState.connection(from, to)` resolved a synapse's `SynapseState` through
+a two-level `Map` — two hash lookups — and was called multiple times per synapse
+per backprop step (e.g. `adjustedWeight` alone resolves it 2–3×). This made it
+one of the highest-multiplicity operations on the pure-JS training path.
+
+This change memoises the resolved `SynapseState` reference **on the `Synapse`
+instance** and adds a `CreatureState.connectionFor(synapse)` accessor that
+returns the cached reference after the first resolution, skipping both hash
+lookups. A generation counter on `CreatureState` is bumped on every reset of the
+connection map (`clear()`), so a stale cache is detected in `O(1)` — no walking
+of the nested map is required.
+
+`connectionFor()` is behaviourally identical to
+`connection(synapse.from, synapse.to)`; only the cost of resolution differs, so
+backprop numeric results are unchanged.
+
+Closes #3089.
+
+### Changes
+
+- `src/architecture/Synapse.ts` — added runtime-only `stateCache?` and
+  `stateGeneration?` fields (never serialised).
+- `src/architecture/CreatureState.ts` — added `stateGeneration` counter,
+  `connectionFor(synapse)`, and a generation bump in `clear()`.
+- Hot call sites that already hold the `Synapse` now use `connectionFor`:
+  `Weight.ts` (`adjustedWeight`), `NeuronPropagation.ts`, `MuonGradientHook.ts`,
+  `WasmTopologicalBackprop.ts`, `CreatureActivation.ts`, and the aggregate
+  methods `aggregate/{MINIMUM,MAXIMUM,IF}.ts`.
+
+### How invalidation works
+
+```mermaid
+flowchart LR
+    A["connectionFor(synapse)"] --> B{"synapse.stateGeneration ==\nstate.stateGeneration\n&& cache set?"}
+    B -- yes --> C["return cached\nSynapseState (O(1))"]
+    B -- no --> D["connection(from, to)\nnested-Map resolve"]
+    D --> E["cache ref + stamp\ngeneration on synapse"]
+    E --> C
+    F["CreatureState.clear()\n(topology reset)"] --> G["connectionMap.clear()\nstateGeneration++"]
+    G -. "next call mismatches\n→ re-resolve" .-> B
+```
+
+## Evidence
+
+Backend/training-path change — no UI to screenshot. Evidence is the new
+micro-benchmark and the test suite.
+
+New micro-bench `bench/SynapseStateConnectionLookup.ts` isolates the per-step
+state lookup that no existing bench covered (`NumericConnectionKeys` measures
+the topology `connectionSet`, not this state lookup). It replays the realistic
+per-synapse multiplicity (3 touches/synapse) over the full synapse set.
+
+Run:
+`deno bench --allow-read --allow-write --allow-env bench/SynapseStateConnectionLookup.ts`
+
+| Scenario                      | `connection()` (double lookup) | `connectionFor()` (cached) | Speed-up         |
+| ----------------------------- | ------------------------------ | -------------------------- | ---------------- |
+| ~200 neurons, 8,084 synapses  | 435.3 µs                       | 222.8 µs                   | **1.95× faster** |
+| ~500 neurons, 50,669 synapses | 3.0 ms                         | 1.4 ms                     | **2.09× faster** |
+
+(Apple M4 Pro, Deno 2.8.3.) The cached path roughly halves the cost of the
+isolated state lookup — a constant-factor cut on the innermost training loop
+that scales with synapse count, samples, and epochs.
+
+## Test Plan
+
+New `test/architecture/CreatureStateConnectionFor.ts` (8 tests):
+
+- `connectionFor` resolves the **same** `SynapseState` as `connection()`.
+- Returns the cached reference on repeated calls (memoised on the synapse).
+- Mutations via the cached state are visible through `connection()` (same
+  object).
+- Independent state per synapse pair.
+- `clear()` invalidates the cache via the generation tag — a fresh
+  `SynapseState` is returned.
+- Re-resolves after `clear()` even when the synapse still holds the old
+  reference.
+- Distinct fresh state across multiple clears.
+- Topology mutation → `clearState()` → re-activation yields fresh state (the
+  invariant called out in the issue).
+
+Existing `test/architecture/CreatureState.ts` and `CreatureStateFlatArray.ts`
+continue to pass unchanged, confirming `connection()` behaviour is untouched.
+
+**Documented test update:** `test/propagate/WeightConvergence.ts` mocks
+`CreatureState`. Because `adjustedWeight` now resolves state via
+`connectionFor(synapse)` instead of `connection(from, to)`, the two
+batch-boundary mocks gained a `connectionFor` method returning the same
+`SynapseState`. The behavioural assertions are unchanged — only the mocked
+collaborator method was added to match the new accessor.

--- a/src/architecture/CreatureState.ts
+++ b/src/architecture/CreatureState.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import type { Creature } from "@creature";
+import type { Synapse } from "@architecture/Synapse.ts";
 import type { BackpropBuffers } from "@propagate/BackpropBuffers.ts";
 import { SynapseState } from "@propagate/SynapseState.ts";
 import { DenseNumberMap } from "@architecture/DenseNumberMap.ts";
@@ -127,6 +128,14 @@ export class CreatureState {
   private nodeArray: NeuronState[];
   private connectionMap;
   private creature;
+  /**
+   * Issue #3089: Generation counter for the synapse-state cache. Bumped on
+   * every reset of {@link connectionMap} (see {@link clear}). A cached
+   * `SynapseState` on a {@link Synapse} is only valid while its
+   * `stateGeneration` matches this counter, so a stale cache is detected in
+   * `O(1)` without walking the nested map.
+   */
+  private stateGeneration = 0;
   public activations: Float32Array = new Float32Array(0);
   /**
    * Cache for adjusted activation values per neuron index.
@@ -173,6 +182,33 @@ export class CreatureState {
       fromMap.set(to, tmpState);
       return tmpState;
     }
+  }
+
+  /**
+   * Issue #3089: Resolve the {@link SynapseState} for a synapse, memoising the
+   * reference on the synapse itself to avoid the nested-`Map` double lookup on
+   * subsequent calls within the same generation.
+   *
+   * The first call for a synapse (or after a {@link clear}) resolves through
+   * {@link connection} and caches the result. Later calls return the cached
+   * reference directly after a single generation comparison — eliminating both
+   * hash lookups on the innermost backprop loop.
+   *
+   * Behaviourally identical to `connection(synapse.from, synapse.to)`; only the
+   * cost of resolution differs.
+   */
+  connectionFor(synapse: Synapse): SynapseState {
+    if (
+      synapse.stateGeneration === this.stateGeneration &&
+      synapse.stateCache !== undefined
+    ) {
+      return synapse.stateCache;
+    }
+
+    const state = this.connection(synapse.from, synapse.to);
+    synapse.stateCache = state;
+    synapse.stateGeneration = this.stateGeneration;
+    return state;
   }
 
   node(indx: number): NeuronState {
@@ -231,5 +267,9 @@ export class CreatureState {
       this.nodeArray[i] = new NeuronState();
     }
     this.connectionMap.clear();
+    // Issue #3089: Invalidate every cached SynapseState reference in O(1) by
+    // bumping the generation counter. Synapses holding a stale cache will
+    // re-resolve through connection() on their next connectionFor() call.
+    this.stateGeneration++;
   }
 }

--- a/src/architecture/Synapse.ts
+++ b/src/architecture/Synapse.ts
@@ -5,6 +5,7 @@ import type {
   SynapseExport,
   SynapseInternal,
 } from "@architecture/SynapseInterfaces.ts";
+import type { SynapseState } from "@propagate/SynapseState.ts";
 
 /**
  * Represents a synapse (connection) between two neurons in a neural network.
@@ -43,6 +44,21 @@ export class Synapse implements SynapseInternal {
 
   /** Tags for storing metadata about the synapse */
   public tags?: TagInterface[];
+
+  /**
+   * Issue #3089: Memoised SynapseState reference for this synapse, paired with
+   * {@link stateGeneration}. The hot backprop path resolves a synapse's state
+   * through a nested `Map` (two hash lookups) many times per step; caching the
+   * reference here lets {@link CreatureState.connectionFor} skip both lookups
+   * after the first resolution. The cache is validated against
+   * `CreatureState`'s generation counter, which is bumped whenever the
+   * connection map is reset — so a stale cache is detected in `O(1)`.
+   *
+   * These fields are runtime-only and are never serialised.
+   */
+  public stateCache?: SynapseState;
+  /** Generation tag matching {@link CreatureState}'s counter (Issue #3089). */
+  public stateGeneration?: number;
 
   /**
    * Generates a random weight value with controlled precision.

--- a/src/creature/CreatureActivation.ts
+++ b/src/creature/CreatureActivation.ts
@@ -344,19 +344,19 @@ function applyWasmTraceData(
     if (squash === "MINIMUM" || squash === "MAXIMUM") {
       const winningLocalIdx = Math.round(entry.traceInfo);
       for (const c of inwardList) {
-        const cs = creature.state.connection(c.from, c.to);
+        const cs = creature.state.connectionFor(c);
         if (cs.used === undefined) cs.used = false;
       }
       if (winningLocalIdx >= 0 && winningLocalIdx < inwardList.length) {
         const winningConnection = inwardList[winningLocalIdx];
-        creature.state.connection(winningConnection.from, winningConnection.to)
+        creature.state.connectionFor(winningConnection)
           .used = true;
       }
     } else if (squash === "IF") {
       const positiveBranch = entry.traceInfo > 0.5;
       if (positiveBranch) {
         for (const c of inwardList) {
-          const cs = creature.state.connection(c.from, c.to);
+          const cs = creature.state.connectionFor(c);
           switch (c.type) {
             case "condition":
             case "negative":
@@ -369,7 +369,7 @@ function applyWasmTraceData(
       } else {
         for (const c of inwardList) {
           if (c.type === "negative") {
-            creature.state.connection(c.from, c.to).used = true;
+            creature.state.connectionFor(c).used = true;
           }
         }
       }
@@ -388,7 +388,7 @@ function applyWasmTraceData(
 
     const inwardList = creature.inwardConnections(i);
     for (const c of inwardList) {
-      const cs = creature.state.connection(c.from, c.to);
+      const cs = creature.state.connectionFor(c);
       cs.used = true;
     }
   }

--- a/src/methods/activations/aggregate/IF.ts
+++ b/src/methods/activations/aggregate/IF.ts
@@ -287,8 +287,9 @@ export class IF
 
     if (condition > 0) {
       for (let i = inward.length; i--;) {
-        const { from, to, type } = inward[i];
-        const cs = state.connection(from, to);
+        const c = inward[i];
+        const { type } = c;
+        const cs = state.connectionFor(c); // Issue #3089: cached state lookup
         switch (type) {
           case "condition":
           case "negative":
@@ -300,10 +301,10 @@ export class IF
       }
     } else {
       for (let i = inward.length; i--;) {
-        const { from, to, type } = inward[i];
+        const c = inward[i];
 
-        if (type === "negative") {
-          state.connection(from, to).used = true;
+        if (c.type === "negative") {
+          state.connectionFor(c).used = true; // Issue #3089: cached state lookup
         }
       }
     }
@@ -352,7 +353,7 @@ export class IF
     const state = neuron.creature.state;
     for (let i = inward.length; i--;) {
       const c = inward[i];
-      const cs = state.connection(c.from, c.to);
+      const cs = state.connectionFor(c); // Issue #3089: cached state lookup
       switch (c.type) {
         case "condition":
           break;
@@ -516,7 +517,7 @@ export class IF
       const fromNeuron = neuron.creature.neurons[c.from];
       const fromActivation = fromNeuron.adjustedActivation(config);
 
-      const cs = state.connection(c.from, c.to);
+      const cs = state.connectionFor(c); // Issue #3089: cached state lookup
 
       const fromWeight = adjustedWeight(state, c, config);
       const fromValue = fromWeight * fromActivation;

--- a/src/methods/activations/aggregate/MAXIMUM.ts
+++ b/src/methods/activations/aggregate/MAXIMUM.ts
@@ -131,8 +131,8 @@ export class MAXIMUM
 
     for (let i = 0, len = fromList.length; i < len; i++) {
       const c = fromList[i];
-      const { from, to, weight } = c;
-      const cs = state.connection(from, to);
+      const { from, weight } = c;
+      const cs = state.connectionFor(c); // Issue #3089: cached state lookup
       if (cs.used === undefined) cs.used = false;
 
       const value = activations[from] * weight;
@@ -198,7 +198,7 @@ export class MAXIMUM
       assert(c.to === neuron.index, "mismatched index");
       if (c.from === c.to) continue;
 
-      const cs = state.connection(c.from, c.to);
+      const cs = state.connectionFor(c); // Issue #3089: cached state lookup
       if (!cs.used) {
         neuron.creature.disconnect(c.from, c.to);
         changed = true;
@@ -263,7 +263,7 @@ export class MAXIMUM
 
       const { from, to, weight } = mainConnection!;
 
-      const mainCS = state.connection(from, to);
+      const mainCS = state.connectionFor(mainConnection!); // Issue #3089: cached state lookup
       accumulateWeight(
         weight,
         mainCS,
@@ -342,7 +342,7 @@ export class MAXIMUM
             const proximity = 1 - (distance / threshold);
             const leakError = error * LEAK_FRACTION * proximity;
             if (Math.abs(leakError) > config.plankConstant) {
-              const cs = state.connection(info.c.from, info.c.to);
+              const cs = state.connectionFor(info.c); // Issue #3089: cached state lookup
               const targetValue = info.fromValue + leakError;
               accumulateWeight(
                 info.c.weight,

--- a/src/methods/activations/aggregate/MINIMUM.ts
+++ b/src/methods/activations/aggregate/MINIMUM.ts
@@ -133,8 +133,8 @@ export class MINIMUM
 
     for (let i = 0, len = fromList.length; i < len; i++) {
       const c = fromList[i];
-      const { from, to, weight } = c;
-      const cs = state.connection(from, to);
+      const { from, weight } = c;
+      const cs = state.connectionFor(c); // Issue #3089: cached state lookup
       if (cs.used === undefined) cs.used = false;
 
       const value = activations[from] * weight;
@@ -200,7 +200,7 @@ export class MINIMUM
       assert(c.to === neuron.index, "mismatched index");
       if (c.from === c.to) continue;
 
-      const cs = state.connection(c.from, c.to);
+      const cs = state.connectionFor(c); // Issue #3089: cached state lookup
       if (!cs.used) {
         neuron.creature.disconnect(c.from, c.to);
         changed = true;
@@ -265,7 +265,7 @@ export class MINIMUM
 
       const { from, to, weight } = mainConnection!;
 
-      const mainCS = state.connection(from, to);
+      const mainCS = state.connectionFor(mainConnection!); // Issue #3089: cached state lookup
       accumulateWeight(
         weight,
         mainCS,
@@ -345,7 +345,7 @@ export class MINIMUM
             const proximity = 1 - (distance / threshold);
             const leakError = error * LEAK_FRACTION * proximity;
             if (Math.abs(leakError) > config.plankConstant) {
-              const cs = state.connection(info.c.from, info.c.to);
+              const cs = state.connectionFor(info.c); // Issue #3089: cached state lookup
               const targetValue = info.fromValue + leakError;
               accumulateWeight(
                 info.c.weight,

--- a/src/neuron/NeuronPropagation.ts
+++ b/src/neuron/NeuronPropagation.ts
@@ -54,7 +54,7 @@ export function propagateUpdate(
   let minSynapseCount = Infinity;
   for (let i = 0; i < toList.length; i++) {
     const c = toList[i];
-    const cs = state.connection(c.from, c.to);
+    const cs = state.connectionFor(c); // Issue #3089: cached state lookup
     currentWeights.push(c.weight);
     candidateWeights.push(calculateWeight(cs, c, config));
     if (coordinationEnabled) {
@@ -352,7 +352,7 @@ export function propagate(
           updateNeeded &&
           Math.abs(improvedFromActivation) > config.plankConstant
         ) {
-          const cs = state.connection(from, to);
+          const cs = state.connectionFor(c); // Issue #3089: cached state lookup
           accumulateWeight(
             c.weight,
             cs,

--- a/src/propagate/MuonGradientHook.ts
+++ b/src/propagate/MuonGradientHook.ts
@@ -96,7 +96,7 @@ export function applyMuonGradientOrthogonalisation(
         let normSq = 0;
         for (let c = 0; c < cols; c++) {
           const synapse = inward[c];
-          const cs = state.connection(synapse.from, synapse.to);
+          const cs = state.connectionFor(synapse); // Issue #3089: cached state lookup
           if (cs.batchAverageWeight === undefined) continue;
           const delta = cs.batchAverageWeight - synapse.weight;
           if (!Number.isFinite(delta)) continue;
@@ -137,7 +137,7 @@ export function applyMuonGradientOrthogonalisation(
         for (let c = 0; c < cols; c++) {
           if (written[r * cols + c] === 0) continue;
           const synapse = inward[c];
-          const cs = state.connection(synapse.from, synapse.to);
+          const cs = state.connectionFor(synapse); // Issue #3089: cached state lookup
           const newDelta = data[r * cols + c];
           if (!Number.isFinite(newDelta)) continue;
           cs.batchAverageWeight = synapse.weight + newDelta;

--- a/src/propagate/WasmTopologicalBackprop.ts
+++ b/src/propagate/WasmTopologicalBackprop.ts
@@ -376,7 +376,7 @@ export function wasmTopologicalBackprop(
     const countDelta = result[sbase];
     if (countDelta > 0) {
       const syn = allSynapses[i];
-      const cs = state.connection(syn.from, syn.to);
+      const cs = state.connectionFor(syn); // Issue #3089: cached state lookup
       cs.count += countDelta;
       cs.totalPositiveActivation += result[sbase + 1];
       cs.totalNegativeActivation += result[sbase + 2];

--- a/src/propagate/Weight.ts
+++ b/src/propagate/Weight.ts
@@ -78,7 +78,7 @@ export function adjustedWeight(
   if (config.disableWeightAdjustment || c.frozen) {
     return c.weight;
   }
-  const cs = creatureState.connection(c.from, c.to);
+  const cs = creatureState.connectionFor(c); // Issue #3089: cached state lookup
   if (cs.count && cs.count % config.batchSize === 0) {
     cs.batchAverageWeight = calculateWeight(cs, c, config);
   }

--- a/test/architecture/CreatureStateConnectionFor.ts
+++ b/test/architecture/CreatureStateConnectionFor.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for CreatureState.connectionFor (Issue #3089).
+ *
+ * connectionFor memoises the SynapseState reference on the Synapse instance,
+ * skipping the nested-Map double lookup after the first resolution. The cache
+ * is validated against a generation counter that is bumped on every reset of
+ * the connection map (CreatureState.clear), so a stale cache is detected in
+ * O(1).
+ */
+
+import { assert, assertEquals, assertStrictEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { CreatureState } from "@architecture/CreatureState.ts";
+import { Synapse } from "@architecture/Synapse.ts";
+import { SynapseState } from "@propagate/SynapseState.ts";
+
+Deno.test("connectionFor - resolves the same SynapseState as connection()", () => {
+  const creature = new Creature(2, 1);
+  const state = new CreatureState(creature);
+  const synapse = new Synapse(0, 1, 0.5);
+
+  const viaMap = state.connection(0, 1);
+  const viaCache = state.connectionFor(synapse);
+
+  assert(viaCache instanceof SynapseState);
+  assertStrictEquals(viaCache, viaMap);
+});
+
+Deno.test("connectionFor - returns the cached reference on repeated calls", () => {
+  const creature = new Creature(2, 1);
+  const state = new CreatureState(creature);
+  const synapse = new Synapse(0, 1, 0.5);
+
+  const first = state.connectionFor(synapse);
+  const second = state.connectionFor(synapse);
+
+  assertStrictEquals(first, second);
+  // The reference is memoised on the synapse itself.
+  assertStrictEquals(synapse.stateCache, first);
+});
+
+Deno.test("connectionFor - mutations via the cached state are visible through connection()", () => {
+  const creature = new Creature(2, 1);
+  const state = new CreatureState(creature);
+  const synapse = new Synapse(0, 1, 0.5);
+
+  const cached = state.connectionFor(synapse);
+  cached.count = 7;
+
+  // Same underlying object, so connection() sees the mutation.
+  assertEquals(state.connection(0, 1).count, 7);
+  assertEquals(state.connectionFor(synapse).count, 7);
+});
+
+Deno.test("connectionFor - independent state per synapse pair", () => {
+  const creature = new Creature(2, 1);
+  const state = new CreatureState(creature);
+  const a = new Synapse(0, 1, 0.5);
+  const b = new Synapse(0, 2, 0.5);
+
+  const csA = state.connectionFor(a);
+  const csB = state.connectionFor(b);
+
+  assert(csA !== csB);
+  csA.count = 3;
+  assertEquals(csB.count, 0);
+});
+
+Deno.test("connectionFor - clear() invalidates the cache via the generation tag", () => {
+  const creature = new Creature(2, 1);
+  const state = new CreatureState(creature);
+  const synapse = new Synapse(0, 1, 0.5);
+
+  const before = state.connectionFor(synapse);
+  before.count = 5;
+
+  state.clear();
+
+  // After a reset, a fresh SynapseState must be returned — not the stale one.
+  const after = state.connectionFor(synapse);
+  assert(after !== before, "expected a fresh SynapseState after clear()");
+  assertEquals(after.count, 0);
+});
+
+Deno.test("connectionFor - re-resolves after clear() even if the synapse still holds an old reference", () => {
+  const creature = new Creature(2, 1);
+  const state = new CreatureState(creature);
+  const synapse = new Synapse(0, 1, 0.5);
+
+  // Prime the cache, then reset.
+  state.connectionFor(synapse);
+  const staleRef = synapse.stateCache;
+  assert(staleRef !== undefined);
+
+  state.clear();
+
+  // The synapse still carries the stale reference, but the generation tag no
+  // longer matches, so connectionFor must resolve a new one.
+  const resolved = state.connectionFor(synapse);
+  assert(resolved !== staleRef);
+  assertStrictEquals(synapse.stateCache, resolved);
+});
+
+Deno.test("connectionFor - tracks the connection map across multiple clears", () => {
+  const creature = new Creature(2, 1);
+  const state = new CreatureState(creature);
+  const synapse = new Synapse(0, 1, 0.5);
+
+  const refs = new Set<SynapseState>();
+  for (let i = 0; i < 4; i++) {
+    const cs = state.connectionFor(synapse);
+    refs.add(cs);
+    // Repeated calls in the same generation return the cached reference.
+    assertStrictEquals(state.connectionFor(synapse), cs);
+    state.clear();
+  }
+
+  // Each clear() produced a distinct fresh SynapseState.
+  assertEquals(refs.size, 4);
+});
+
+Deno.test("connectionFor - topology mutation then re-activation yields fresh state (Issue #3089)", () => {
+  // Train-shaped flow: build, run state through clear (as clearState does on
+  // topology change), and confirm the synapse cache is invalidated so the
+  // re-resolved state is fresh rather than the stale pre-mutation reference.
+  const creature = new Creature(2, 1, {
+    layers: [{ count: 2, squash: "IDENTITY" }],
+  });
+
+  const synapse = creature.synapses[0];
+  const state = creature.state;
+
+  const pre = state.connectionFor(synapse);
+  pre.count = 11;
+  assertEquals(state.connectionFor(synapse).count, 11);
+
+  // clearState() resets the connection map on topology change.
+  creature.clearState();
+
+  const post = state.connectionFor(synapse);
+  assert(post !== pre, "expected fresh SynapseState after clearState()");
+  assertEquals(post.count, 0);
+});

--- a/test/propagate/WeightConvergence.ts
+++ b/test/propagate/WeightConvergence.ts
@@ -118,8 +118,11 @@ Deno.test("adjustedWeight - returns original weight before batch boundary", () =
 
   // Create a mock CreatureState that returns our SynapseState
   const cs = new SynapseState();
+  // Issue #3089: adjustedWeight now resolves state via connectionFor(synapse)
+  // (cached reference) rather than connection(from, to); the mock provides both.
   const mockState = {
     connection: (_from: number, _to: number) => cs,
+    connectionFor: (_synapse: Synapse) => cs,
   } as unknown as CreatureState;
 
   // Accumulate fewer samples than batchSize
@@ -149,8 +152,11 @@ Deno.test("adjustedWeight - recalculates at batch boundary", () => {
   const synapse = fakeSynapse(0.5);
 
   const cs = new SynapseState();
+  // Issue #3089: adjustedWeight now resolves state via connectionFor(synapse)
+  // (cached reference) rather than connection(from, to); the mock provides both.
   const mockState = {
     connection: (_from: number, _to: number) => cs,
+    connectionFor: (_synapse: Synapse) => cs,
   } as unknown as CreatureState;
 
   // Accumulate exactly batchSize samples pointing toward weight=3
@@ -176,8 +182,11 @@ Deno.test("adjustedWeight - disableWeightAdjustment returns original", () => {
   const synapse = fakeSynapse(0.5);
 
   const cs = new SynapseState();
+  // Issue #3089: adjustedWeight now resolves state via connectionFor(synapse)
+  // (cached reference) rather than connection(from, to); the mock provides both.
   const mockState = {
     connection: (_from: number, _to: number) => cs,
+    connectionFor: (_synapse: Synapse) => cs,
   } as unknown as CreatureState;
 
   accumulateWeight(synapse.weight, cs, 10.0, 1.0, config);


### PR DESCRIPTION
# perf: Cache SynapseState reference to avoid nested-Map double lookup

## Summary

`CreatureState.connection(from, to)` resolved a synapse's `SynapseState` through
a two-level `Map` — two hash lookups — and was called multiple times per synapse
per backprop step (e.g. `adjustedWeight` alone resolves it 2–3×). This made it
one of the highest-multiplicity operations on the pure-JS training path.

This change memoises the resolved `SynapseState` reference **on the `Synapse`
instance** and adds a `CreatureState.connectionFor(synapse)` accessor that
returns the cached reference after the first resolution, skipping both hash
lookups. A generation counter on `CreatureState` is bumped on every reset of the
connection map (`clear()`), so a stale cache is detected in `O(1)` — no walking
of the nested map is required.

`connectionFor()` is behaviourally identical to
`connection(synapse.from, synapse.to)`; only the cost of resolution differs, so
backprop numeric results are unchanged.

Closes #3089.

### Changes

- `src/architecture/Synapse.ts` — added runtime-only `stateCache?` and
  `stateGeneration?` fields (never serialised).
- `src/architecture/CreatureState.ts` — added `stateGeneration` counter,
  `connectionFor(synapse)`, and a generation bump in `clear()`.
- Hot call sites that already hold the `Synapse` now use `connectionFor`:
  `Weight.ts` (`adjustedWeight`), `NeuronPropagation.ts`, `MuonGradientHook.ts`,
  `WasmTopologicalBackprop.ts`, `CreatureActivation.ts`, and the aggregate
  methods `aggregate/{MINIMUM,MAXIMUM,IF}.ts`.

### How invalidation works

```mermaid
flowchart LR
    A["connectionFor(synapse)"] --> B{"synapse.stateGeneration ==\nstate.stateGeneration\n&& cache set?"}
    B -- yes --> C["return cached\nSynapseState (O(1))"]
    B -- no --> D["connection(from, to)\nnested-Map resolve"]
    D --> E["cache ref + stamp\ngeneration on synapse"]
    E --> C
    F["CreatureState.clear()\n(topology reset)"] --> G["connectionMap.clear()\nstateGeneration++"]
    G -. "next call mismatches\n→ re-resolve" .-> B
```

## Evidence

Backend/training-path change — no UI to screenshot. Evidence is the new
micro-benchmark and the test suite.

New micro-bench `bench/SynapseStateConnectionLookup.ts` isolates the per-step
state lookup that no existing bench covered (`NumericConnectionKeys` measures
the topology `connectionSet`, not this state lookup). It replays the realistic
per-synapse multiplicity (3 touches/synapse) over the full synapse set.

Run:
`deno bench --allow-read --allow-write --allow-env bench/SynapseStateConnectionLookup.ts`

| Scenario                      | `connection()` (double lookup) | `connectionFor()` (cached) | Speed-up         |
| ----------------------------- | ------------------------------ | -------------------------- | ---------------- |
| ~200 neurons, 8,084 synapses  | 435.3 µs                       | 222.8 µs                   | **1.95× faster** |
| ~500 neurons, 50,669 synapses | 3.0 ms                         | 1.4 ms                     | **2.09× faster** |

(Apple M4 Pro, Deno 2.8.3.) The cached path roughly halves the cost of the
isolated state lookup — a constant-factor cut on the innermost training loop
that scales with synapse count, samples, and epochs.

## Test Plan

New `test/architecture/CreatureStateConnectionFor.ts` (8 tests):

- `connectionFor` resolves the **same** `SynapseState` as `connection()`.
- Returns the cached reference on repeated calls (memoised on the synapse).
- Mutations via the cached state are visible through `connection()` (same
  object).
- Independent state per synapse pair.
- `clear()` invalidates the cache via the generation tag — a fresh
  `SynapseState` is returned.
- Re-resolves after `clear()` even when the synapse still holds the old
  reference.
- Distinct fresh state across multiple clears.
- Topology mutation → `clearState()` → re-activation yields fresh state (the
  invariant called out in the issue).

Existing `test/architecture/CreatureState.ts` and `CreatureStateFlatArray.ts`
continue to pass unchanged, confirming `connection()` behaviour is untouched.

**Documented test update:** `test/propagate/WeightConvergence.ts` mocks
`CreatureState`. Because `adjustedWeight` now resolves state via
`connectionFor(synapse)` instead of `connection(from, to)`, the two
batch-boundary mocks gained a `connectionFor` method returning the same
`SynapseState`. The behavioural assertions are unchanged — only the mocked
collaborator method was added to match the new accessor.



## Milestone
This PR is part of the **#3082 Can you see any performance improvements?** milestone and targets the `milestone/3082-can-you-see-any-performance-improvements` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqmaehsl-aa3da7`<!-- vibe-worker-issue-3089 -->