### PR TITLE
perf: copy-on-write clone in memeticUpdate (Issue #3091)

### DIFF
--- a/bench/MemeticUpdateCopyOnWrite.ts
+++ b/bench/MemeticUpdateCopyOnWrite.ts
@@ -1,0 +1,189 @@
+/**
+ * Benchmark for Issue #3091: avoid the full JSON deep-clone in memeticUpdate.
+ *
+ * memeticUpdate runs per-offspring during breeding (Offspring.ts) and
+ * per-mutation on the revert path (Mutator.ts) — i.e. O(children × generations).
+ * The old implementation deep-cloned the parent's entire memetic graph via
+ * `JSON.parse(JSON.stringify(...))` and then appended only the handful of
+ * changed bias/weight entries. For a populated memetic the round-trip dominates
+ * the additive merge it precedes.
+ *
+ * This bench compares the old JSON-clone-then-append (baseline) against the new
+ * copy-on-write structural clone (current `memeticUpdate`) over a creature with
+ * a populated memetic and a small diff.
+ *
+ * Run with:
+ *   deno bench --allow-all bench/MemeticUpdateCopyOnWrite.ts
+ */
+import { Creature, type CreatureExport } from "../mod.ts";
+import { memeticUpdate } from "@blackbox/MemeticUpdate.ts";
+import type { MemeticInterface } from "@blackbox/MemeticInterface.ts";
+
+// Build a parent/child pair with a densely-populated memetic and a small diff.
+function buildPair(hidden: number): { parent: Creature; child: Creature } {
+  const neurons: CreatureExport["neurons"] = [];
+  const synapses: CreatureExport["synapses"] = [];
+  for (let h = 0; h < hidden; h++) {
+    neurons.push({
+      type: "hidden",
+      id: 10_000 + h,
+      uuid: `hidden-${h}`,
+      squash: "LOGISTIC",
+      bias: 0.1 + h * 0.001,
+    });
+    // Each hidden neuron is fed by both inputs and feeds the output.
+    synapses.push(
+      { fromUUID: "input-0", toUUID: `hidden-${h}`, weight: 0.2 + h * 0.0001 },
+      { fromUUID: "input-1", toUUID: `hidden-${h}`, weight: 0.3 + h * 0.0001 },
+      { fromUUID: `hidden-${h}`, toUUID: "output-0", weight: 0.4 + h * 0.0001 },
+    );
+  }
+  neurons.push({
+    type: "output",
+    uuid: "output-0",
+    squash: "IDENTITY",
+    bias: 0.05,
+  });
+
+  const exportJSON: CreatureExport = { input: 2, output: 1, neurons, synapses };
+
+  const parent = Creature.fromJSON(exportJSON);
+
+  // Populate a large memetic graph: biases for every neuron + per-fromId
+  // weight arrays (several entries each) for every source neuron, plus a few
+  // generations of ancestry snapshots. This mirrors a memetic that has
+  // accumulated many tracked changes — exactly what the old JSON round-trip
+  // had to serialise/parse in full.
+  const buildBiases = (): MemeticInterface["biases"] => {
+    const b: MemeticInterface["biases"] = {};
+    for (let h = 0; h < hidden; h++) b[10_000 + h] = 0.1 + h * 0.001;
+    return b;
+  };
+  const buildWeights = (): MemeticInterface["weights"] => {
+    const w: MemeticInterface["weights"] = {};
+    for (let h = 0; h < hidden; h++) {
+      const arr = [];
+      for (let k = 0; k < 8; k++) {
+        arr.push({ toId: 20_000 + k, weight: 0.4 + h * 0.0001 + k * 0.01 });
+      }
+      w[10_000 + h] = arr;
+    }
+    return w;
+  };
+  const ancestry: NonNullable<MemeticInterface["ancestry"]> = [];
+  for (let g = 0; g < 3; g++) {
+    ancestry.push({
+      generation: 4 - g,
+      score: 0.5 - g * 0.01,
+      biases: buildBiases(),
+      weights: buildWeights(),
+    });
+  }
+  parent.memetic = {
+    generation: 5,
+    score: 0.6,
+    biases: buildBiases(),
+    weights: buildWeights(),
+    ancestry,
+  };
+
+  // Child carries a single changed bias so the merge appends exactly one entry.
+  const childJSON: CreatureExport = JSON.parse(JSON.stringify(exportJSON));
+  childJSON.neurons[0].bias = 0.999;
+  const child = Creature.fromJSON(childJSON);
+
+  return { parent, child };
+}
+
+/** Old implementation: full JSON deep-clone then additive merge. */
+function memeticUpdateJsonClone(
+  parent: Creature,
+  child: Creature,
+): MemeticInterface | undefined {
+  if (!parent.memetic) return undefined;
+  if (parent.neurons.length !== child.neurons.length) return undefined;
+
+  const memetic: MemeticInterface = JSON.parse(JSON.stringify(parent.memetic));
+
+  const squashMap = new Map<number, string>();
+  const biasMap = new Map<number, number>();
+  for (let i = parent.input; i < parent.neurons.length; i++) {
+    const neuron = parent.neurons[i];
+    squashMap.set(neuron.id, neuron.squash ?? "NONE");
+    biasMap.set(neuron.id, neuron.bias);
+  }
+  for (let i = child.input; i < child.neurons.length; i++) {
+    const neuron = child.neurons[i];
+    const squash = squashMap.get(neuron.id);
+    if (!squash) return undefined;
+    if ((neuron.squash ?? "NONE") !== squash) return undefined;
+    if (neuron.bias !== biasMap.get(neuron.id)) {
+      if (memetic.biases === undefined) memetic.biases = {};
+      if (memetic.biases[neuron.id] === undefined) {
+        memetic.biases[neuron.id] = neuron.bias;
+      }
+    }
+  }
+
+  const weightsMap = new Map<number, Map<number, number>>();
+  const foundSet = new Set<string>();
+  for (const synapse of parent.synapses) {
+    const fromId = parent.neurons[synapse.from]?.id;
+    const toId = parent.neurons[synapse.to]?.id;
+    if (fromId === undefined || toId === undefined) return undefined;
+    let w = weightsMap.get(fromId);
+    if (w === undefined) {
+      w = new Map();
+      weightsMap.set(fromId, w);
+    }
+    w.set(toId, synapse.weight);
+    foundSet.add(`${fromId}-${toId}`);
+  }
+  for (const synapse of child.synapses) {
+    const fromId = child.neurons[synapse.from]?.id;
+    const toId = child.neurons[synapse.to]?.id;
+    if (fromId === undefined || toId === undefined) return undefined;
+    foundSet.delete(`${fromId}-${toId}`);
+    const fromWeights = weightsMap.get(fromId);
+    if (fromWeights === undefined) return undefined;
+    const weight = fromWeights.get(toId);
+    if (weight === undefined) return undefined;
+    if (
+      synapse.weight !== weight && Math.abs(synapse.weight - weight) > 0.000_001
+    ) {
+      if (memetic.weights === undefined) memetic.weights = {};
+      let fw = memetic.weights[fromId];
+      if (fw === undefined) {
+        fw = [];
+        memetic.weights[fromId] = fw;
+      }
+      if (fw.find((x) => x.toId === toId) === undefined) {
+        memetic.weights[fromId].push({ toId, weight });
+      }
+    }
+  }
+  if (foundSet.size > 0) return undefined;
+  return memetic;
+}
+
+for (const hidden of [50, 200, 800]) {
+  const { parent, child } = buildPair(hidden);
+  const group = `memeticUpdate (${hidden} hidden neurons)`;
+
+  Deno.bench({
+    name: "JSON deep-clone (baseline)",
+    group,
+    baseline: true,
+    fn: () => {
+      memeticUpdateJsonClone(parent, child);
+    },
+  });
+
+  Deno.bench({
+    name: "copy-on-write (Issue #3091)",
+    group,
+    fn: () => {
+      memeticUpdate(parent, child);
+    },
+  });
+}

--- a/docs/archive/pr-summaries/pr-summary-3091.md
+++ b/docs/archive/pr-summaries/pr-summary-3091.md
@@ -1,0 +1,80 @@
+# perf: Avoid full JSON deep-clone in memeticUpdate (additive merge)
+
+## Summary
+
+`memeticUpdate` deep-cloned the parent's **entire** memetic graph via
+`JSON.parse(JSON.stringify(parent.memetic))` and then appended only the handful
+of changed bias/weight entries. The function runs per-offspring during breeding
+(`Offspring.ts`) and per-mutation on the revert path (`Mutator.ts`) — i.e.
+`O(children × generations)` — so for a populated memetic the full serialise/parse
+round-trip dominated the additive merge it preceded.
+
+This replaces the JSON round-trip with a **copy-on-write structural clone**:
+
+- Shallow-copy the top-level object, carrying `generation`, `score` and the
+  never-modified `ancestry` subtree **by reference** (not re-serialised).
+- Shallow-copy `biases` with `{ ...parent.memetic.biases }` (values are
+  primitives, so a shallow copy fully isolates it).
+- Build `weights` as a new object that reuses each parent per-`fromId` array
+  **by reference** until that key is first mutated; on first write the single
+  array (and its entries) is copied. The result never aliases
+  `parent.memetic`'s arrays for any key it mutates.
+
+The merge output is value-identical to the old JSON-clone path for every
+parent/child diff; only the cloning strategy changed.
+
+Closes #3091. Part of the #3082 performance-improvement sweep.
+
+## Evidence
+
+This is a backend/library change with no web interface — no screenshot
+applies. Verified via the new equivalence/isolation tests and a benchmark.
+
+### Benchmark (`bench/MemeticUpdateCopyOnWrite.ts`)
+
+Parent with a densely-populated memetic (biases for every neuron, multi-entry
+weight arrays per source neuron, and 3 generations of ancestry snapshots) and a
+child carrying a single changed bias. Baseline is the old JSON-clone-then-append;
+candidate is the new copy-on-write `memeticUpdate`.
+
+| Memetic size      | JSON deep-clone (baseline) | Copy-on-write (#3091) | Speed-up |
+| ----------------- | -------------------------- | --------------------- | -------- |
+| 50 hidden neurons | 263.2 µs                   | 40.3 µs               | 6.54x    |
+| 200 hidden neurons| 1.1 ms                     | 162.2 µs              | 6.55x    |
+| 800 hidden neurons| 4.3 ms                     | 737.4 µs              | 5.79x    |
+
+The absolute saving grows with memetic size because the removed cost is the
+full serialise/parse of the whole graph, while the copies are proportional to
+the (small) number of changed entries.
+
+```mermaid
+flowchart LR
+    A[parent.memetic] -->|old: JSON.parse JSON.stringify\nfull deep-clone| B[clone whole graph]
+    A -->|new: shallow + COW| C[shallow-copy top-level\nbiases shallow-copy\nweights reused by ref]
+    C -->|on first write to a fromId| D[copy that one array]
+    B --> E[append diffs]
+    C --> E
+    D --> E
+    E --> F[returned memetic]
+```
+
+## Test Plan
+
+New `test/blackbox/MemeticUpdateCopyOnWrite.ts`:
+
+- **Equivalence** — `memeticUpdate COW - equals JSON reference across a range of
+  diffs`: the returned memetic deep-equals an independent JSON-clone-then-append
+  reference for no-diff, bias-diff, weight-diff (existing key and key `5001`),
+  and combined-diff cases.
+- **Isolation** — `memeticUpdate COW - mutating result never mutates parent`:
+  the mutated `fromId` array is a distinct object from the parent's; mutating
+  the result's biases/weights/generation/score leaves `parent.memetic`
+  unchanged.
+- **COW reuse** — `memeticUpdate COW - unmutated weight arrays equal parent
+  values`: untouched weight keys and the `ancestry` subtree carry the parent's
+  values (shared by reference, as intended).
+
+Existing `test/blackbox/MemeticUpdateDuplicateLoop.ts` (bias/weight detection,
+undefined guards, existing-data preservation) continues to pass unchanged.
+
+Full `./quality.sh` passes: `7416 passed | 0 failed`.

--- a/src/blackbox/MemeticUpdate.ts
+++ b/src/blackbox/MemeticUpdate.ts
@@ -15,7 +15,31 @@ export function memeticUpdate(
     return undefined;
   }
 
-  const memetic: MemeticInterface = JSON.parse(JSON.stringify(parent.memetic));
+  // Issue #3091: avoid a full JSON deep-clone of the entire memetic graph.
+  // memeticUpdate runs per-offspring during breeding (O(children ×
+  // generations)) yet only appends the handful of changed bias/weight entries.
+  // Instead of serialising/parsing the whole graph we shallow-copy the
+  // top-level object — carrying `generation`, `score` and the never-touched
+  // `ancestry` subtree by reference — and clone only the small containers we
+  // append to. `biases` is shallow-copied (values are primitives). `weights`
+  // uses copy-on-write: each per-`fromId` array is reused from the parent by
+  // reference until the first time we mutate that key, at which point we copy
+  // just that single array. The result never aliases `parent.memetic`'s arrays
+  // for any key it mutates.
+  const parentMemetic = parent.memetic;
+  const memetic: MemeticInterface = {
+    ...parentMemetic,
+    biases: parentMemetic.biases
+      ? { ...parentMemetic.biases }
+      : parentMemetic.biases,
+    weights: parentMemetic.weights
+      ? { ...parentMemetic.weights }
+      : parentMemetic.weights,
+  };
+
+  // Tracks `fromId` weight arrays already copied for this call so the
+  // copy-on-write clone happens at most once per key.
+  const copiedWeightKeys = new Set<number>();
 
   const squashMap = new Map<number, string>();
   const biasMap = new Map<number, number>();
@@ -93,10 +117,17 @@ export function memeticUpdate(
       if (fromWeights === undefined) {
         fromWeights = [];
         memetic.weights[fromId] = fromWeights;
+        copiedWeightKeys.add(fromId);
+      } else if (!copiedWeightKeys.has(fromId)) {
+        // Copy-on-write: this array is still the parent's. Clone it (and its
+        // entries) before mutating so we never alias `parent.memetic`.
+        fromWeights = fromWeights.map((e) => ({ ...e }));
+        memetic.weights[fromId] = fromWeights;
+        copiedWeightKeys.add(fromId);
       }
       const toWeight = fromWeights.find((w) => w.toId === toId);
       if (toWeight === undefined) {
-        memetic.weights[fromId].push({
+        fromWeights.push({
           toId,
           weight: weight,
         });

--- a/test/blackbox/MemeticUpdateCopyOnWrite.ts
+++ b/test/blackbox/MemeticUpdateCopyOnWrite.ts
@@ -1,0 +1,224 @@
+/**
+ * Issue #3091: memeticUpdate must avoid the full JSON deep-clone and instead
+ * use a copy-on-write structural clone. These tests pin two guarantees:
+ *
+ *  1. Equivalence — the returned memetic deep-equals the result of the old
+ *     JSON-clone-then-append reference across a range of parent/child diffs.
+ *  2. Isolation — mutating the returned memetic (top-level containers and the
+ *     per-`fromId` weight arrays it appends to) never mutates `parent.memetic`.
+ */
+import { assert, assertEquals, assertNotStrictEquals } from "@std/assert";
+import { Creature, type CreatureExport } from "../../mod.ts";
+import { memeticUpdate } from "@blackbox/MemeticUpdate.ts";
+import type { MemeticInterface } from "@blackbox/MemeticInterface.ts";
+
+function baseCreature(): CreatureExport {
+  return {
+    input: 2,
+    output: 1,
+    neurons: [
+      {
+        type: "hidden",
+        id: 5001,
+        uuid: "hidden-1",
+        squash: "LOGISTIC",
+        bias: 0.5,
+      },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "hidden-1", weight: 0.25 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.8 },
+    ],
+  };
+}
+
+/**
+ * Reference implementation: the original full JSON deep-clone followed by the
+ * same additive merge. Used only to assert equivalence in tests.
+ */
+function memeticUpdateJsonReference(
+  parent: Creature,
+  child: Creature,
+): MemeticInterface | undefined {
+  if (!parent.memetic) return undefined;
+  if (parent.neurons.length !== child.neurons.length) return undefined;
+
+  const memetic: MemeticInterface = JSON.parse(JSON.stringify(parent.memetic));
+
+  const squashMap = new Map<number, string>();
+  const biasMap = new Map<number, number>();
+  for (let i = parent.input; i < parent.neurons.length; i++) {
+    const neuron = parent.neurons[i];
+    squashMap.set(neuron.id, neuron.squash ?? "NONE");
+    biasMap.set(neuron.id, neuron.bias);
+  }
+  for (let i = child.input; i < child.neurons.length; i++) {
+    const neuron = child.neurons[i];
+    const squash = squashMap.get(neuron.id);
+    if (!squash) return undefined;
+    if ((neuron.squash ?? "NONE") !== squash) return undefined;
+    if (neuron.bias !== biasMap.get(neuron.id)) {
+      if (memetic.biases === undefined) memetic.biases = {};
+      if (memetic.biases[neuron.id] === undefined) {
+        memetic.biases[neuron.id] = neuron.bias;
+      }
+    }
+  }
+
+  const weightsMap = new Map<number, Map<number, number>>();
+  const foundSet = new Set<string>();
+  for (const synapse of parent.synapses) {
+    const fromId = parent.neurons[synapse.from]?.id;
+    const toId = parent.neurons[synapse.to]?.id;
+    if (fromId === undefined || toId === undefined) return undefined;
+    let weights = weightsMap.get(fromId);
+    if (weights === undefined) {
+      weights = new Map();
+      weightsMap.set(fromId, weights);
+    }
+    weights.set(toId, synapse.weight);
+    foundSet.add(`${fromId}-${toId}`);
+  }
+  for (const synapse of child.synapses) {
+    const fromId = child.neurons[synapse.from]?.id;
+    const toId = child.neurons[synapse.to]?.id;
+    if (fromId === undefined || toId === undefined) return undefined;
+    foundSet.delete(`${fromId}-${toId}`);
+    const fromWeights = weightsMap.get(fromId);
+    if (fromWeights === undefined) return undefined;
+    const weight = fromWeights.get(toId);
+    if (weight === undefined) return undefined;
+    if (
+      synapse.weight !== weight && Math.abs(synapse.weight - weight) > 0.000_001
+    ) {
+      if (memetic.weights === undefined) memetic.weights = {};
+      let fw = memetic.weights[fromId];
+      if (fw === undefined) {
+        fw = [];
+        memetic.weights[fromId] = fw;
+      }
+      if (fw.find((w) => w.toId === toId) === undefined) {
+        memetic.weights[fromId].push({ toId, weight });
+      }
+    }
+  }
+  if (foundSet.size > 0) return undefined;
+  return memetic;
+}
+
+function populatedMemetic(): MemeticInterface {
+  return {
+    generation: 7,
+    score: 0.42,
+    biases: { [5001]: 0.31, [9999]: 0.9 },
+    weights: {
+      [0]: [{ toId: 5001, weight: 0.41 }],
+      [1]: [{ toId: 5001, weight: 0.22 }],
+      [5001]: [{ toId: 7777, weight: 0.6 }],
+    },
+    ancestry: [
+      {
+        generation: 6,
+        score: 0.4,
+        biases: { [5001]: 0.3 },
+        weights: { [0]: [{ toId: 5001, weight: 0.4 }] },
+      },
+    ],
+  };
+}
+
+Deno.test("memeticUpdate COW - equals JSON reference across a range of diffs", () => {
+  const diffs: Array<(c: CreatureExport) => void> = [
+    () => {}, // no diff
+    (c) => (c.neurons[0].bias = 0.7), // bias diff
+    (c) => (c.synapses[0].weight = 0.95), // weight diff on existing key
+    (c) => (c.synapses[2].weight = 0.95), // weight diff on key 5001
+    (c) => {
+      c.neurons[0].bias = 0.66;
+      c.synapses[0].weight = 0.11;
+      c.synapses[1].weight = 0.99;
+    }, // combined diffs
+  ];
+
+  for (const [i, applyDiff] of diffs.entries()) {
+    const parent = Creature.fromJSON(baseCreature());
+    parent.memetic = populatedMemetic();
+    const refParent = Creature.fromJSON(baseCreature());
+    refParent.memetic = populatedMemetic();
+
+    const childJSON = baseCreature();
+    applyDiff(childJSON);
+    const child = Creature.fromJSON(childJSON);
+    const refChild = Creature.fromJSON(childJSON);
+
+    const actual = memeticUpdate(parent, child);
+    const expected = memeticUpdateJsonReference(refParent, refChild);
+
+    assertEquals(actual, expected, `diff #${i} should match JSON reference`);
+  }
+});
+
+Deno.test("memeticUpdate COW - mutating result never mutates parent", () => {
+  const parent = Creature.fromJSON(baseCreature());
+  parent.memetic = populatedMemetic();
+  const parentSnapshot = JSON.parse(JSON.stringify(parent.memetic));
+
+  const childJSON = baseCreature();
+  childJSON.neurons[0].bias = 0.7; // bias diff
+  childJSON.synapses[0].weight = 0.95; // weight diff on key 0
+  const child = Creature.fromJSON(childJSON);
+
+  const result = memeticUpdate(parent, child);
+  assert(result, "Should return a MemeticInterface");
+
+  // The mutated weight array must be a distinct object from the parent's.
+  assertNotStrictEquals(
+    result.weights[0],
+    parent.memetic!.weights[0],
+    "mutated fromId array must be copied, not aliased",
+  );
+
+  // Aggressively mutate the containers the function builds/appends to. The
+  // never-modified `ancestry` subtree is intentionally shared by reference
+  // (Issue #3091), so it is exercised separately below — not here.
+  result.biases[5001] = -999;
+  result.biases[12345] = -1;
+  result.weights[0].push({ toId: 4242, weight: -7 });
+  result.weights[0][0].weight = -7;
+  result.weights[42] = [{ toId: 1, weight: 1 }];
+  result.generation = -1;
+  result.score = -1;
+
+  // Parent's biases/weights/generation/score must be unchanged.
+  assertEquals(
+    parent.memetic!.biases,
+    parentSnapshot.biases,
+    "parent biases must be unchanged",
+  );
+  assertEquals(
+    parent.memetic!.weights,
+    parentSnapshot.weights,
+    "parent weights must be unchanged after mutating the result",
+  );
+  assertEquals(parent.memetic!.generation, parentSnapshot.generation);
+  assertEquals(parent.memetic!.score, parentSnapshot.score);
+});
+
+Deno.test("memeticUpdate COW - unmutated weight arrays equal parent values", () => {
+  const parent = Creature.fromJSON(baseCreature());
+  parent.memetic = populatedMemetic();
+
+  const childJSON = baseCreature();
+  childJSON.synapses[0].weight = 0.95; // only key 0 mutated
+  const child = Creature.fromJSON(childJSON);
+
+  const result = memeticUpdate(parent, child);
+  assert(result, "Should return a MemeticInterface");
+
+  // Untouched keys carry the same values as the parent (COW reuse is fine).
+  assertEquals(result.weights[1], parent.memetic!.weights[1]);
+  assertEquals(result.weights[5001], parent.memetic!.weights[5001]);
+  assertEquals(result.ancestry, parent.memetic!.ancestry);
+});


### PR DESCRIPTION
# perf: Avoid full JSON deep-clone in memeticUpdate (additive merge)

## Summary

`memeticUpdate` deep-cloned the parent's **entire** memetic graph via
`JSON.parse(JSON.stringify(parent.memetic))` and then appended only the handful
of changed bias/weight entries. The function runs per-offspring during breeding
(`Offspring.ts`) and per-mutation on the revert path (`Mutator.ts`) — i.e.
`O(children × generations)` — so for a populated memetic the full serialise/parse
round-trip dominated the additive merge it preceded.

This replaces the JSON round-trip with a **copy-on-write structural clone**:

- Shallow-copy the top-level object, carrying `generation`, `score` and the
  never-modified `ancestry` subtree **by reference** (not re-serialised).
- Shallow-copy `biases` with `{ ...parent.memetic.biases }` (values are
  primitives, so a shallow copy fully isolates it).
- Build `weights` as a new object that reuses each parent per-`fromId` array
  **by reference** until that key is first mutated; on first write the single
  array (and its entries) is copied. The result never aliases
  `parent.memetic`'s arrays for any key it mutates.

The merge output is value-identical to the old JSON-clone path for every
parent/child diff; only the cloning strategy changed.

Closes #3091. Part of the #3082 performance-improvement sweep.

## Evidence

This is a backend/library change with no web interface — no screenshot
applies. Verified via the new equivalence/isolation tests and a benchmark.

### Benchmark (`bench/MemeticUpdateCopyOnWrite.ts`)

Parent with a densely-populated memetic (biases for every neuron, multi-entry
weight arrays per source neuron, and 3 generations of ancestry snapshots) and a
child carrying a single changed bias. Baseline is the old JSON-clone-then-append;
candidate is the new copy-on-write `memeticUpdate`.

| Memetic size      | JSON deep-clone (baseline) | Copy-on-write (#3091) | Speed-up |
| ----------------- | -------------------------- | --------------------- | -------- |
| 50 hidden neurons | 263.2 µs                   | 40.3 µs               | 6.54x    |
| 200 hidden neurons| 1.1 ms                     | 162.2 µs              | 6.55x    |
| 800 hidden neurons| 4.3 ms                     | 737.4 µs              | 5.79x    |

The absolute saving grows with memetic size because the removed cost is the
full serialise/parse of the whole graph, while the copies are proportional to
the (small) number of changed entries.

```mermaid
flowchart LR
    A[parent.memetic] -->|old: JSON.parse JSON.stringify\nfull deep-clone| B[clone whole graph]
    A -->|new: shallow + COW| C[shallow-copy top-level\nbiases shallow-copy\nweights reused by ref]
    C -->|on first write to a fromId| D[copy that one array]
    B --> E[append diffs]
    C --> E
    D --> E
    E --> F[returned memetic]
```

## Test Plan

New `test/blackbox/MemeticUpdateCopyOnWrite.ts`:

- **Equivalence** — `memeticUpdate COW - equals JSON reference across a range of
  diffs`: the returned memetic deep-equals an independent JSON-clone-then-append
  reference for no-diff, bias-diff, weight-diff (existing key and key `5001`),
  and combined-diff cases.
- **Isolation** — `memeticUpdate COW - mutating result never mutates parent`:
  the mutated `fromId` array is a distinct object from the parent's; mutating
  the result's biases/weights/generation/score leaves `parent.memetic`
  unchanged.
- **COW reuse** — `memeticUpdate COW - unmutated weight arrays equal parent
  values`: untouched weight keys and the `ancestry` subtree carry the parent's
  values (shared by reference, as intended).

Existing `test/blackbox/MemeticUpdateDuplicateLoop.ts` (bias/weight detection,
undefined guards, existing-data preservation) continues to pass unchanged.

Full `./quality.sh` passes: `7416 passed | 0 failed`.



## Milestone
This PR is part of the **#3082 Can you see any performance improvements?** milestone and targets the `milestone/3082-can-you-see-any-performance-improvements` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqmwizsg-fa6113`<!-- vibe-worker-issue-3091 -->