### PR TITLE
Add @module docs to src/architecture public modules (Issue #3119)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3119.md
+++ b/docs/archive/pr-summaries/pr-summary-3119.md
@@ -1,0 +1,59 @@
+## Summary
+
+Added a leading `@module` JSDoc block to nine public modules in
+`src/architecture/` that previously went straight from their imports to their
+first `export` with no module-level orientation for a new reader. Each block
+gives a one-to-three-line plain-language summary of what the module provides and
+how it fits the topology/breeding pipeline, following `docs/DOC_STYLE.md` and
+matching well-documented siblings such as `CreatureFactory.ts`.
+
+This is a documentation-only change — no code, types, or behaviour were
+modified. Closes #3119.
+
+Files documented:
+
+- `src/architecture/CreatureState.ts`
+- `src/architecture/CreatureValidate.ts`
+- `src/architecture/DataSet.ts`
+- `src/architecture/ElitismUtils.ts`
+- `src/architecture/NeuronInterfaces.ts`
+- `src/architecture/NoChangePropagate.ts`
+- `src/architecture/Offspring.ts`
+- `src/architecture/SynapseInterfaces.ts`
+- `src/architecture/SyncV5.ts`
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+`deno doc` confirms each new module doc is picked up. For example,
+`deno doc src/architecture/Offspring.ts` now opens with:
+
+```
+@module
+    Builds offspring creatures from two parents for the breeding pipeline —
+    crossover of topology, synapses and hyperparameters. Neurons are aligned
+    between parents by matching stable UUIDs (never array position), so the same
+    genome breeds consistently across machines; child neurons keep their parent
+    UUID and any newly created neurons get a fresh one.
+```
+
+```mermaid
+flowchart LR
+    Imports[imports] --> Doc["/** @module ... */"] --> Export[first export]
+    Doc -.picked up by.-> DenoDoc[deno doc]
+```
+
+Quality gate: `deno fmt`, `deno lint`, and `./quality.sh --check-only`
+(type-check) all pass cleanly on the changed files.
+
+## Test Plan
+
+No unit tests apply — this is a pure documentation change adding JSDoc comments,
+with no new or modified runtime behaviour to assert on (per AGENTS.md, tests
+must verify behaviour, not inspect source text). Verification was done via:
+
+- `deno fmt` / `deno lint` — clean on all 9 files.
+- `./quality.sh --check-only` — type-check passes (exit 0).
+- `deno doc src/architecture/Offspring.ts` — confirms the `@module` block is
+  surfaced in generated documentation.

--- a/src/architecture/CreatureState.ts
+++ b/src/architecture/CreatureState.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Per-activation runtime state for a creature's neurons and synapses — the
+ * scratch buffers backpropagation reads and writes. {@link NeuronState} holds
+ * one neuron's running activation, bias and error totals; {@link CreatureState}
+ * owns the dense collections of those buffers for a whole topology. This state
+ * is ephemeral working memory, not part of the persisted UUID-only wire format.
+ */
 import { assert } from "@std/assert";
 import type { Creature } from "@creature";
 import type { Synapse } from "@architecture/Synapse.ts";

--- a/src/architecture/CreatureValidate.ts
+++ b/src/architecture/CreatureValidate.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Structural and topological validation for a creature. {@link creatureValidate}
+ * checks the invariants a healthy topology must hold — no self or backward
+ * connections, no duplicate synapses, every hidden neuron wired in and out,
+ * finite biases — and raises a {@link TopologyError} or {@link ValidationError}
+ * when a mutation, breeding or discovery step produces an invalid creature.
+ */
 import { assert } from "@std/assert";
 import type { Creature } from "@creature";
 import { TopologyError } from "@errors/TopologyError.ts";

--- a/src/architecture/DataSet.ts
+++ b/src/architecture/DataSet.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Training-dataset serialisation. {@link makeDataDir} writes an array of
+ * input/output {@link DataRecordInterface} records to partitioned binary files
+ * in a temporary directory, the on-disk format the trainer streams during
+ * evolution so a large dataset need not be held in memory at once.
+ */
 import { ValidationError } from "@errors/ValidationError.ts";
 
 export interface DataRecordInterface {

--- a/src/architecture/ElitismUtils.ts
+++ b/src/architecture/ElitismUtils.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Elitism helpers for the evolutionary loop. {@link makeElitists} selects the
+ * fittest creatures of a population to carry forward unchanged into the next
+ * generation, guarding the best-known solutions from being lost to mutation or
+ * breeding, and reports the population's average score alongside the elites.
+ */
 import { assert } from "@std/assert";
 import { blue, bold, green, red, white, yellow } from "@std/fmt/colors";
 import { addTag, getTag } from "@stsoftware/tags/mod";

--- a/src/architecture/NeuronInterfaces.ts
+++ b/src/architecture/NeuronInterfaces.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Type definitions for neurons. Distinguishes the export shape
+ * ({@link NeuronExport}, the UUID-only wire format that crosses process and
+ * machine boundaries) from the internal shape carrying the runtime integer id.
+ * These interfaces fix the contract every neuron serialisation and breeding
+ * path shares; they contain no logic.
+ */
 import type { TagsInterface } from "@stsoftware/tags/mod";
 import type { NeuronStateInterface } from "@architecture/CreatureState.ts";
 

--- a/src/architecture/NoChangePropagate.ts
+++ b/src/architecture/NoChangePropagate.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Backpropagation shortcut for unchanged neurons. {@link noChangePropagate}
+ * walks a neuron's inward connections and propagates updates only where an
+ * upstream activation actually changed, skipping neurons flagged `noChange` so
+ * the gradient pass avoids redundant work on a stable subgraph.
+ */
 import type { NeuronActivationInterface } from "@methods/activations/NeuronActivationInterface.ts";
 import type { BackPropagationConfig } from "@propagate/BackPropagation.ts";
 import type { Neuron } from "@architecture/Neuron.ts";

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Builds offspring creatures from two parents for the breeding pipeline —
+ * crossover of topology, synapses and hyperparameters. Neurons are aligned
+ * between parents by matching stable UUIDs (never array position), so the same
+ * genome breeds consistently across machines; child neurons keep their parent
+ * UUID and any newly created neurons get a fresh one.
+ */
 import { assert } from "@std/assert";
 import { addTags } from "@stsoftware/tags/mod";
 import { memeticUpdate } from "@blackbox/MemeticUpdate.ts";

--- a/src/architecture/SynapseInterfaces.ts
+++ b/src/architecture/SynapseInterfaces.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Type definitions for synapses (connections). Distinguishes the internal,
+ * index-based shape ({@link SynapseInternal}, used during in-memory creature
+ * operations) from the export shape that crosses process boundaries. These
+ * interfaces fix the shared contract for synapse serialisation and traversal;
+ * they contain no logic.
+ */
 import type { TagInterface } from "@stsoftware/tags/mod";
 import type { SynapseState } from "@propagate/SynapseState.ts";
 

--- a/src/architecture/SyncV5.ts
+++ b/src/architecture/SyncV5.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Deterministic RFC 4122 version-5 UUID generation. {@link generate} hashes a
+ * namespace UUID together with a byte payload (SHA-1) to derive a stable,
+ * reproducible UUID — the same namespace and data always yield the same UUID,
+ * which lets neuron identities be derived deterministically rather than randomly.
+ */
 import { concat } from "@std/bytes";
 import { crypto as stdCrypto } from "@std/crypto";
 


### PR DESCRIPTION
## Summary

Added a leading `@module` JSDoc block to nine public modules in
`src/architecture/` that previously went straight from their imports to their
first `export` with no module-level orientation for a new reader. Each block
gives a one-to-three-line plain-language summary of what the module provides and
how it fits the topology/breeding pipeline, following `docs/DOC_STYLE.md` and
matching well-documented siblings such as `CreatureFactory.ts`.

This is a documentation-only change — no code, types, or behaviour were
modified. Closes #3119.

Files documented:

- `src/architecture/CreatureState.ts`
- `src/architecture/CreatureValidate.ts`
- `src/architecture/DataSet.ts`
- `src/architecture/ElitismUtils.ts`
- `src/architecture/NeuronInterfaces.ts`
- `src/architecture/NoChangePropagate.ts`
- `src/architecture/Offspring.ts`
- `src/architecture/SynapseInterfaces.ts`
- `src/architecture/SyncV5.ts`

## Evidence

Backend/library change only — no web interface to screenshot.

`deno doc` confirms each new module doc is picked up. For example,
`deno doc src/architecture/Offspring.ts` now opens with:

```
@module
    Builds offspring creatures from two parents for the breeding pipeline —
    crossover of topology, synapses and hyperparameters. Neurons are aligned
    between parents by matching stable UUIDs (never array position), so the same
    genome breeds consistently across machines; child neurons keep their parent
    UUID and any newly created neurons get a fresh one.
```

```mermaid
flowchart LR
    Imports[imports] --> Doc["/** @module ... */"] --> Export[first export]
    Doc -.picked up by.-> DenoDoc[deno doc]
```

Quality gate: `deno fmt`, `deno lint`, and `./quality.sh --check-only`
(type-check) all pass cleanly on the changed files.

## Test Plan

No unit tests apply — this is a pure documentation change adding JSDoc comments,
with no new or modified runtime behaviour to assert on (per AGENTS.md, tests
must verify behaviour, not inspect source text). Verification was done via:

- `deno fmt` / `deno lint` — clean on all 9 files.
- `./quality.sh --check-only` — type-check passes (exit 0).
- `deno doc src/architecture/Offspring.ts` — confirms the `@module` block is
  surfaced in generated documentation.



## Milestone
This PR is part of the **module docs** milestone and targets the `milestone/module-docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqswp8zx-0c3aad`<!-- vibe-worker-issue-3119 -->