### PR TITLE
Docs: add @module docs to src/blackbox memetic modules (#3121)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3121.md
+++ b/docs/archive/pr-summaries/pr-summary-3121.md
@@ -1,0 +1,61 @@
+# Add `@module` docs to `src/blackbox` memetic modules (#3121)
+
+## Summary
+
+Six public modules in the `src/blackbox/` (memetic / fine-tune, aliased
+`@blackbox/`) namespace exported a public symbol but had no leading module-level
+doc comment, so a reader could not orient themselves to the fine-tune lifecycle
+without tracing call sites. This PR adds a short leading `@module` JSDoc block
+to each of the listed files, following
+[`docs/DOC_STYLE.md`](../../DOC_STYLE.md). Documentation only — no code changes.
+
+Files documented:
+
+- `src/blackbox/Discover.ts` — reconstructs a child's memetic record from a
+  matching scored parent.
+- `src/blackbox/FineTune.ts` — quantum-step fine-tuning of the fittest creature.
+- `src/blackbox/FineTunePopulation.ts` — builds the per-generation fine-tune
+  population.
+- `src/blackbox/MemeticInterface.ts` — type definitions for the memetic record.
+- `src/blackbox/MemeticUpdate.ts` — propagates a parent's memetic record onto a
+  child during breeding.
+- `src/blackbox/Retry.ts` — re-runs fine-tuning when a creature's live score has
+  drifted from its recorded memetic score.
+
+Closes #3121.
+
+## Evidence
+
+This is a documentation-only change with no web interface to screenshot. Each
+module doc was verified to be recognised as module-level documentation with the
+read-only `deno doc` command, e.g.:
+
+```text
+$ deno doc src/blackbox/Discover.ts
+Memetic-state discovery for the fine-tune (memetic evolution) path.
+
+`discover` compares a scored parent with an as-yet-unscored child of
+identical topology and, when their structure matches, reconstructs the
+child's memetic record ...
+```
+
+All six files print their `@module` description, confirming the doc blocks are
+attached at module level. `deno fmt --check`, `deno lint`, and `deno check` all
+pass on the changed files.
+
+```mermaid
+flowchart LR
+    MI["MemeticInterface.ts<br/>(memetic record types)"] --> D["Discover.ts"]
+    MI --> FT["FineTune.ts"]
+    MI --> MU["MemeticUpdate.ts"]
+    FT --> FTP["FineTunePopulation.ts"]
+    FT --> R["Retry.ts"]
+    FTP --> R
+```
+
+## Test Plan
+
+No automated tests were added: a test that greps source files for `@module`
+would be a forbidden "how" test (per `AGENTS.md`), and the change adds no
+behaviour to assert on. Validation is via `deno doc` (above) plus the standard
+quality gate (`deno fmt`, `deno lint`, `deno check`), all of which pass.

--- a/src/blackbox/Discover.ts
+++ b/src/blackbox/Discover.ts
@@ -1,3 +1,14 @@
+/**
+ * Memetic-state discovery for the fine-tune (memetic evolution) path.
+ *
+ * `discover` compares a scored parent with an as-yet-unscored child of
+ * identical topology and, when their structure matches, reconstructs the
+ * child's memetic record — the per-neuron bias and per-synapse weight deltas
+ * inherited from the parent — so locally fine-tuned state is carried across
+ * during breeding instead of being lost.
+ *
+ * @module
+ */
 import { assert } from "@std/assert";
 import type { Creature } from "../../mod.ts";
 import type { MemeticInterface } from "@blackbox/MemeticInterface.ts";

--- a/src/blackbox/FineTune.ts
+++ b/src/blackbox/FineTune.ts
@@ -1,3 +1,15 @@
+/**
+ * Quantum-step fine-tuning (memetic evolution) of the fittest creature.
+ *
+ * This module performs the local fine-tune step: it compares the current
+ * fittest creature against a previous fittest, nudges biases and weights by an
+ * adaptive quantum step (`quantumAdjust` / `calculateEffectiveStep`), and emits
+ * a population of fine-tuned candidates (`fineTuneImprovement`) for selection.
+ * Adjustments are biased by trajectory momentum and recorded in each
+ * candidate's memetic record.
+ *
+ * @module
+ */
 import { assert } from "@std/assert";
 import { addTag, removeTag } from "@stsoftware/tags/mod";
 import type { CreatureExport } from "../../mod.ts";

--- a/src/blackbox/FineTunePopulation.ts
+++ b/src/blackbox/FineTunePopulation.ts
@@ -1,3 +1,14 @@
+/**
+ * Builds the per-generation fine-tune (memetic evolution) population.
+ *
+ * `FindTunePopulation.make` orchestrates the fine-tune step across a whole
+ * generation: it pairs the fittest creature with suitable lower-scoring
+ * partners (the previous fittest, a restored source, and same-species
+ * neighbours), drives each pairing through `fineTuneImprovement`, dedupes by
+ * UUID, and adds the resulting candidates to the genus for selection.
+ *
+ * @module
+ */
 import { assert } from "@std/assert";
 import { type Creature, CreatureUtil } from "../../mod.ts";
 import { ValidationError } from "@errors/ValidationError.ts";

--- a/src/blackbox/MemeticInterface.ts
+++ b/src/blackbox/MemeticInterface.ts
@@ -1,3 +1,15 @@
+/**
+ * Type definitions for the memetic (local fine-tuning) record carried on a
+ * creature.
+ *
+ * A `MemeticInterface` captures the per-neuron bias and per-synapse weight
+ * deltas produced by fine-tuning, the generation and score they were recorded
+ * at, and an optional bounded `ancestry` of earlier snapshots used for
+ * trajectory analysis. These shapes are shared across the `@blackbox/`
+ * fine-tune modules.
+ *
+ * @module
+ */
 export interface MemeticWeightInterface {
   toId: number;
   weight: number;

--- a/src/blackbox/MemeticUpdate.ts
+++ b/src/blackbox/MemeticUpdate.ts
@@ -1,3 +1,16 @@
+/**
+ * Propagates a parent's memetic (local fine-tuning) record onto a child during
+ * breeding.
+ *
+ * `memeticUpdate` returns a new memetic record for a child whose topology
+ * matches its parent, copying the parent's bias and weight deltas and appending
+ * any changes the child introduced. It uses a copy-on-write strategy (Issue
+ * #3091) to avoid a full deep clone on the per-offspring hot path, and returns
+ * `undefined` when the structures diverge so the caller falls back to
+ * `discover`.
+ *
+ * @module
+ */
 import type { Creature } from "../../mod.ts";
 import type { MemeticInterface } from "@blackbox/MemeticInterface.ts";
 

--- a/src/blackbox/Retry.ts
+++ b/src/blackbox/Retry.ts
@@ -1,3 +1,14 @@
+/**
+ * Re-runs fine-tuning (memetic evolution) on creatures whose live score has
+ * drifted from their recorded memetic score.
+ *
+ * `retry` scans a population for creatures whose current score differs from the
+ * score stored in their memetic record, picks one (weighted towards the largest
+ * improvement), and fine-tunes it against its restored source — either pushing
+ * forward (`retry`) or backtracking when the source scored higher.
+ *
+ * @module
+ */
 import { assert } from "@std/assert";
 import { addTag } from "@stsoftware/tags/mod";
 import type { Creature } from "../../mod.ts";


### PR DESCRIPTION
# Add `@module` docs to `src/blackbox` memetic modules (#3121)

## Summary

Six public modules in the `src/blackbox/` (memetic / fine-tune, aliased
`@blackbox/`) namespace exported a public symbol but had no leading module-level
doc comment, so a reader could not orient themselves to the fine-tune lifecycle
without tracing call sites. This PR adds a short leading `@module` JSDoc block
to each of the listed files, following
[`docs/DOC_STYLE.md`](../../DOC_STYLE.md). Documentation only — no code changes.

Files documented:

- `src/blackbox/Discover.ts` — reconstructs a child's memetic record from a
  matching scored parent.
- `src/blackbox/FineTune.ts` — quantum-step fine-tuning of the fittest creature.
- `src/blackbox/FineTunePopulation.ts` — builds the per-generation fine-tune
  population.
- `src/blackbox/MemeticInterface.ts` — type definitions for the memetic record.
- `src/blackbox/MemeticUpdate.ts` — propagates a parent's memetic record onto a
  child during breeding.
- `src/blackbox/Retry.ts` — re-runs fine-tuning when a creature's live score has
  drifted from its recorded memetic score.

Closes #3121.

## Evidence

This is a documentation-only change with no web interface to screenshot. Each
module doc was verified to be recognised as module-level documentation with the
read-only `deno doc` command, e.g.:

```text
$ deno doc src/blackbox/Discover.ts
Memetic-state discovery for the fine-tune (memetic evolution) path.

`discover` compares a scored parent with an as-yet-unscored child of
identical topology and, when their structure matches, reconstructs the
child's memetic record ...
```

All six files print their `@module` description, confirming the doc blocks are
attached at module level. `deno fmt --check`, `deno lint`, and `deno check` all
pass on the changed files.

```mermaid
flowchart LR
    MI["MemeticInterface.ts<br/>(memetic record types)"] --> D["Discover.ts"]
    MI --> FT["FineTune.ts"]
    MI --> MU["MemeticUpdate.ts"]
    FT --> FTP["FineTunePopulation.ts"]
    FT --> R["Retry.ts"]
    FTP --> R
```

## Test Plan

No automated tests were added: a test that greps source files for `@module`
would be a forbidden "how" test (per `AGENTS.md`), and the change adds no
behaviour to assert on. Validation is via `deno doc` (above) plus the standard
quality gate (`deno fmt`, `deno lint`, `deno check`), all of which pass.



## Milestone
This PR is part of the **module docs** milestone and targets the `milestone/module-docs` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqsvtoy2-501493`<!-- vibe-worker-issue-3121 -->