### PR TITLE
docs(optimize): add @module docs to src/optimize passes (Issue #3122)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3122.md
+++ b/docs/archive/pr-summaries/pr-summary-3122.md
@@ -1,0 +1,45 @@
+# DOC-MODULE-DOC: `src/optimize` module docs
+
+## Summary
+
+Added a short leading `@module` JSDoc block to the five public modules in the
+`src/optimize/` (`@optimize/`) namespace that exported a symbol but opened
+straight onto imports/code with no module-level doc comment. Each block follows
+[`docs/DOC_STYLE.md`](../../DOC_STYLE.md) — a one-line plain-language gloss of
+what the optimisation pass / interface does, in Australian English — so a reader
+of this published surface (`publish.include: ["src/**"]`) can orient without
+reading the implementation. Documentation only; no code changes. Closes #3122.
+
+Files documented:
+
+- `src/optimize/FunctionCache.ts`
+- `src/optimize/InlineActivationInterface.ts`
+- `src/optimize/MakeActivationFunctionInterface.ts`
+- `src/optimize/Simplify.ts`
+- `src/optimize/SimplifyBiasInterface.ts`
+
+## Evidence
+
+Backend/library change with no web interface to screenshot. Verified the module
+docs render via the read-only `deno doc` tool, e.g.:
+
+```
+$ deno doc src/optimize/Simplify.ts
+Behaviour-preserving simplification passes for an exported creature.
+
+`simplify()` folds constants, prunes redundant synapses ...
+@module
+```
+
+All five files now emit their leading description through `deno doc`.
+
+## Test Plan
+
+No unit tests added. Per [`AGENTS.md`](../../../AGENTS.md) testing policy,
+asserting on documentation content (grepping source for `@module`) is a "how"
+test and is explicitly discouraged; the change carries no runtime behaviour to
+assert on. Verification instead relies on:
+
+- `deno doc src/optimize/<file>.ts` — confirms each module doc renders.
+- `./quality.sh` — passed cleanly (lint, format, type-check, full test suite:
+  7397 passed, 0 failed), confirming the added comments do not break the build.

--- a/src/optimize/FunctionCache.ts
+++ b/src/optimize/FunctionCache.ts
@@ -1,3 +1,14 @@
+/**
+ * Single-entry cache for compiled neuron activation functions.
+ *
+ * `findActivationFunction` keys a generated activation-function body by a
+ * deterministic UUIDv5 (over the body plus an optional suffix) and returns the
+ * previously compiled function on a hit, evicting the stale entry on a miss so
+ * the caller can recompile. Avoids recompiling identical inlined activations.
+ *
+ * @module
+ */
+
 import type { ActivationFunction } from "@optimize/MakeActivationFunctionInterface.ts";
 
 import { generate as generateV5Sync } from "@architecture/SyncV5.ts";

--- a/src/optimize/InlineActivationInterface.ts
+++ b/src/optimize/InlineActivationInterface.ts
@@ -1,3 +1,13 @@
+/**
+ * Contract for activation functions that can emit inline source code.
+ *
+ * Implementers return a JavaScript expression that computes a neuron's
+ * activation in place, letting the optimiser splice the activation directly
+ * into a generated function body rather than calling through an interface.
+ *
+ * @module
+ */
+
 import type { Neuron } from "@architecture/Neuron.ts";
 
 export interface InlineActivationInterface {

--- a/src/optimize/MakeActivationFunctionInterface.ts
+++ b/src/optimize/MakeActivationFunctionInterface.ts
@@ -1,3 +1,14 @@
+/**
+ * Contract for building compiled activation functions for a neuron.
+ *
+ * Defines the `ActivationFunction` shape returned at runtime and the
+ * `makeActivationFunction` factory that, given a neuron and a {@link FunctionCache},
+ * produces (or reuses) the compiled closure that computes that neuron's
+ * activation and value.
+ *
+ * @module
+ */
+
 import type { Neuron } from "@architecture/Neuron.ts";
 import type { FunctionCache } from "@optimize/FunctionCache.ts";
 import type { NeuronActivationInterface } from "@methods/activations/NeuronActivationInterface.ts";

--- a/src/optimize/Simplify.ts
+++ b/src/optimize/Simplify.ts
@@ -1,3 +1,15 @@
+/**
+ * Behaviour-preserving simplification passes for an exported creature.
+ *
+ * `simplify()` folds constants, prunes redundant synapses (e.g. collapsing
+ * COMPLEMENT-of-COMPLEMENT to IDENTITY), removes neurons that no longer affect
+ * the output and normalises computational neuron order — all without changing
+ * what the creature computes. Helpers `removeKnownSign` and `removeNeuron`
+ * support those passes.
+ *
+ * @module
+ */
+
 import { addTag, removeTag } from "@stsoftware/tags/mod";
 import { type CreatureExport, CreatureUtil } from "../../mod.ts";
 import { normaliseComputationalNeuronOrderInExport } from "@architecture/NormaliseComputationalNeuronOrder.ts";

--- a/src/optimize/SimplifyBiasInterface.ts
+++ b/src/optimize/SimplifyBiasInterface.ts
@@ -1,3 +1,13 @@
+/**
+ * Contract for activation functions that can simplify a neuron's bias.
+ *
+ * Implementers map a raw bias to an equivalent simplified value during a
+ * simplification pass, letting `Simplify` fold the bias into the activation
+ * without changing the neuron's output.
+ *
+ * @module
+ */
+
 export interface SimplifyBiasInterface {
   simplifyBias(bias: number): number;
 }


### PR DESCRIPTION
# DOC-MODULE-DOC: `src/optimize` module docs

## Summary

Added a short leading `@module` JSDoc block to the five public modules in the
`src/optimize/` (`@optimize/`) namespace that exported a symbol but opened
straight onto imports/code with no module-level doc comment. Each block follows
[`docs/DOC_STYLE.md`](../../DOC_STYLE.md) — a one-line plain-language gloss of
what the optimisation pass / interface does, in Australian English — so a reader
of this published surface (`publish.include: ["src/**"]`) can orient without
reading the implementation. Documentation only; no code changes. Closes #3122.

Files documented:

- `src/optimize/FunctionCache.ts`
- `src/optimize/InlineActivationInterface.ts`
- `src/optimize/MakeActivationFunctionInterface.ts`
- `src/optimize/Simplify.ts`
- `src/optimize/SimplifyBiasInterface.ts`

## Evidence

Backend/library change with no web interface to screenshot. Verified the module
docs render via the read-only `deno doc` tool, e.g.:

```
$ deno doc src/optimize/Simplify.ts
Behaviour-preserving simplification passes for an exported creature.

`simplify()` folds constants, prunes redundant synapses ...
@module
```

All five files now emit their leading description through `deno doc`.

## Test Plan

No unit tests added. Per [`AGENTS.md`](../../../AGENTS.md) testing policy,
asserting on documentation content (grepping source for `@module`) is a "how"
test and is explicitly discouraged; the change carries no runtime behaviour to
assert on. Verification instead relies on:

- `deno doc src/optimize/<file>.ts` — confirms each module doc renders.
- `./quality.sh` — passed cleanly (lint, format, type-check, full test suite:
  7397 passed, 0 failed), confirming the added comments do not break the build.



## Milestone
This PR is part of the **module docs** milestone and targets the `milestone/module-docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqsyzfot-ea7ea4`<!-- vibe-worker-issue-3122 -->