### PR TITLE
Add @module docs to src/methods/activations interfaces (Issue #3123)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3123.md
+++ b/docs/archive/pr-summaries/pr-summary-3123.md
@@ -1,0 +1,63 @@
+# DOC-MODULE-DOC: `@module` docs for `src/methods/activations` interfaces
+
+## Summary
+
+The public interface and registry modules in `src/methods/activations/` opened
+straight onto imports then an exported symbol, with no leading module-level doc
+comment explaining what contract each one defines. Because these are the
+extension points a consumer implements to add an activation, the missing
+`@module` block cost integrators discoverability.
+
+Added a short leading `@module` JSDoc block to each of the five affected files,
+following [`docs/DOC_STYLE.md`](../../DOC_STYLE.md) and matching the existing
+style in `TypeGuards.ts`:
+
+- `src/methods/activations/ActivationInterface.ts` — scalar `squash(x)` contract.
+- `src/methods/activations/Activations.ts` — central activation registry.
+- `src/methods/activations/NeuronActivationInterface.ts` — whole-`Neuron`
+  activation/propagation/record contract.
+- `src/methods/activations/NeuronFixableInterface.ts` — optional post-mutation
+  `fix()` contract.
+- `src/methods/activations/UnSquashInterface.ts` — optional inverse-of-`squash`
+  contract.
+
+Documentation only — no code or behaviour change. Australian English throughout.
+
+Closes #3123.
+
+## Evidence
+
+This is a documentation-only change with no web interface to screenshot.
+Verification was done with the read-only `deno doc` command, which now surfaces
+the `@module` summary for every file. Example:
+
+```
+$ deno doc src/methods/activations/ActivationInterface.ts
+@module
+    Contract every standard activation function implements: the `squash(x)`
+    forward pass mapping a neuron's pre-activation value to its output. ...
+```
+
+All five files render their `@module` block; previously `deno doc` showed only
+the exported symbol with no module summary.
+
+```mermaid
+flowchart LR
+    Abstract["AbstractActivationInterface<br/>(naming, error, range)"] --> AI["ActivationInterface<br/>squash(x)"]
+    Abstract --> NAI["NeuronActivationInterface<br/>activate / propagate / record"]
+    Abstract --> UnS["UnSquashInterface<br/>unSquash()"]
+    Abstract --> Fix["NeuronFixableInterface<br/>fix()"]
+    AI --> Reg["Activations<br/>(registry)"]
+    NAI --> Reg
+```
+
+## Test Plan
+
+No tests added or modified. Per `AGENTS.md`, asserting on documentation content
+would be a "how" test (grepping source for patterns), which the project
+prohibits. Verification instead relied on:
+
+- `deno doc <file>` for each of the five files — confirms the `@module` summary
+  renders.
+- `./quality.sh --lint-only` — formatting, lint, and bash checks pass.
+- `./quality.sh --check-only` — `deno check` type-checks the full tree cleanly.

--- a/src/methods/activations/ActivationInterface.ts
+++ b/src/methods/activations/ActivationInterface.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Contract every standard activation function implements: the `squash(x)`
+ * forward pass mapping a neuron's pre-activation value to its output. Extends
+ * `AbstractActivationInterface` (naming, error, and range behaviour) and is the
+ * base an integrator implements to add a new activation to the registry.
+ */
+
 import type { AbstractActivationInterface } from "@methods/activations/AbstractActivationInterface.ts";
 
 interface SquashAndDeriveResult {

--- a/src/methods/activations/Activations.ts
+++ b/src/methods/activations/Activations.ts
@@ -1,3 +1,13 @@
+/**
+ * @module
+ *
+ * Central registry of every activation function: registers each implementation
+ * under its canonical name plus aliases, builds the mutation-weighted random
+ * pool, and resolves a name to its `AbstractActivationInterface` (throwing
+ * `ActivationError` for unknown names). The single lookup point used across
+ * mutation, breeding, and serialisation.
+ */
+
 import { assert } from "@std/assert";
 import { ActivationError } from "@errors/ActivationError.ts";
 import { HYPOT } from "@deprecated/HYPOT.ts";

--- a/src/methods/activations/NeuronActivationInterface.ts
+++ b/src/methods/activations/NeuronActivationInterface.ts
@@ -1,3 +1,13 @@
+/**
+ * @module
+ *
+ * Contract for activations that operate over a whole `Neuron` rather than a
+ * single scalar: forward activation with tracing, error back-propagation, and
+ * Discovery recording. Aggregate-style activations implement this instead of
+ * the scalar `ActivationInterface` because they need the neuron's incoming
+ * connections and state.
+ */
+
 import type { DiscoverRecord } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { Neuron } from "@architecture/Neuron.ts";
 import type { BackPropagationConfig } from "@propagate/BackPropagation.ts";

--- a/src/methods/activations/NeuronFixableInterface.ts
+++ b/src/methods/activations/NeuronFixableInterface.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Optional contract for activations that can repair a `Neuron` into a valid
+ * state via `fix()` — e.g. clamping bias or pruning incompatible connections
+ * after a mutation. Implemented only by activations that need post-mutation
+ * fix-up; most activations do not.
+ */
+
 import type { AbstractActivationInterface } from "@methods/activations/AbstractActivationInterface.ts";
 import type { Neuron } from "@architecture/Neuron.ts";
 

--- a/src/methods/activations/UnSquashInterface.ts
+++ b/src/methods/activations/UnSquashInterface.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Optional contract for the inverse of `squash`: `unSquash(activation, hint?)`
+ * recovers a pre-activation value from an output, used by optimisation passes
+ * that reason backwards through a neuron. Only activations with a tractable
+ * inverse implement this; callers feature-detect it via the `TypeGuards`.
+ */
+
 import type { AbstractActivationInterface } from "@methods/activations/AbstractActivationInterface.ts";
 
 export interface UnSquashInterface extends AbstractActivationInterface {


### PR DESCRIPTION
# DOC-MODULE-DOC: `@module` docs for `src/methods/activations` interfaces

## Summary

The public interface and registry modules in `src/methods/activations/` opened
straight onto imports then an exported symbol, with no leading module-level doc
comment explaining what contract each one defines. Because these are the
extension points a consumer implements to add an activation, the missing
`@module` block cost integrators discoverability.

Added a short leading `@module` JSDoc block to each of the five affected files,
following [`docs/DOC_STYLE.md`](../../DOC_STYLE.md) and matching the existing
style in `TypeGuards.ts`:

- `src/methods/activations/ActivationInterface.ts` — scalar `squash(x)` contract.
- `src/methods/activations/Activations.ts` — central activation registry.
- `src/methods/activations/NeuronActivationInterface.ts` — whole-`Neuron`
  activation/propagation/record contract.
- `src/methods/activations/NeuronFixableInterface.ts` — optional post-mutation
  `fix()` contract.
- `src/methods/activations/UnSquashInterface.ts` — optional inverse-of-`squash`
  contract.

Documentation only — no code or behaviour change. Australian English throughout.

Closes #3123.

## Evidence

This is a documentation-only change with no web interface to screenshot.
Verification was done with the read-only `deno doc` command, which now surfaces
the `@module` summary for every file. Example:

```
$ deno doc src/methods/activations/ActivationInterface.ts
@module
    Contract every standard activation function implements: the `squash(x)`
    forward pass mapping a neuron's pre-activation value to its output. ...
```

All five files render their `@module` block; previously `deno doc` showed only
the exported symbol with no module summary.

```mermaid
flowchart LR
    Abstract["AbstractActivationInterface<br/>(naming, error, range)"] --> AI["ActivationInterface<br/>squash(x)"]
    Abstract --> NAI["NeuronActivationInterface<br/>activate / propagate / record"]
    Abstract --> UnS["UnSquashInterface<br/>unSquash()"]
    Abstract --> Fix["NeuronFixableInterface<br/>fix()"]
    AI --> Reg["Activations<br/>(registry)"]
    NAI --> Reg
```

## Test Plan

No tests added or modified. Per `AGENTS.md`, asserting on documentation content
would be a "how" test (grepping source for patterns), which the project
prohibits. Verification instead relied on:

- `deno doc <file>` for each of the five files — confirms the `@module` summary
  renders.
- `./quality.sh --lint-only` — formatting, lint, and bash checks pass.
- `./quality.sh --check-only` — `deno check` type-checks the full tree cleanly.



## Milestone
This PR is part of the **module docs** milestone and targets the `milestone/module-docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqsyzfot-ea7ea4`<!-- vibe-worker-issue-3123 -->