### PR TITLE
Milestone: module docs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3119.md
+++ b/docs/archive/pr-summaries/pr-summary-3119.md
@@ -1,0 +1,59 @@
+## Summary
+
+Added a leading `@module` JSDoc block to nine public modules in
+`src/architecture/` that previously went straight from their imports to their
+first `export` with no module-level orientation for a new reader. Each block
+gives a one-to-three-line plain-language summary of what the module provides and
+how it fits the topology/breeding pipeline, following `docs/DOC_STYLE.md` and
+matching well-documented siblings such as `CreatureFactory.ts`.
+
+This is a documentation-only change — no code, types, or behaviour were
+modified. Closes #3119.
+
+Files documented:
+
+- `src/architecture/CreatureState.ts`
+- `src/architecture/CreatureValidate.ts`
+- `src/architecture/DataSet.ts`
+- `src/architecture/ElitismUtils.ts`
+- `src/architecture/NeuronInterfaces.ts`
+- `src/architecture/NoChangePropagate.ts`
+- `src/architecture/Offspring.ts`
+- `src/architecture/SynapseInterfaces.ts`
+- `src/architecture/SyncV5.ts`
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+`deno doc` confirms each new module doc is picked up. For example,
+`deno doc src/architecture/Offspring.ts` now opens with:
+
+```
+@module
+    Builds offspring creatures from two parents for the breeding pipeline —
+    crossover of topology, synapses and hyperparameters. Neurons are aligned
+    between parents by matching stable UUIDs (never array position), so the same
+    genome breeds consistently across machines; child neurons keep their parent
+    UUID and any newly created neurons get a fresh one.
+```
+
+```mermaid
+flowchart LR
+    Imports[imports] --> Doc["/** @module ... */"] --> Export[first export]
+    Doc -.picked up by.-> DenoDoc[deno doc]
+```
+
+Quality gate: `deno fmt`, `deno lint`, and `./quality.sh --check-only`
+(type-check) all pass cleanly on the changed files.
+
+## Test Plan
+
+No unit tests apply — this is a pure documentation change adding JSDoc comments,
+with no new or modified runtime behaviour to assert on (per AGENTS.md, tests
+must verify behaviour, not inspect source text). Verification was done via:
+
+- `deno fmt` / `deno lint` — clean on all 9 files.
+- `./quality.sh --check-only` — type-check passes (exit 0).
+- `deno doc src/architecture/Offspring.ts` — confirms the `@module` block is
+  surfaced in generated documentation.

--- a/docs/archive/pr-summaries/pr-summary-3120.md
+++ b/docs/archive/pr-summaries/pr-summary-3120.md
@@ -1,0 +1,76 @@
+# PR Summary — Issue #3120
+
+## Summary
+
+Added leading `@module` JSDoc blocks to the eight public mutation-operator
+modules in `src/mutate/` that previously opened straight onto their `export`
+with no orienting doc comment. Each block gives a one-line description of what
+the operator does — and, where relevant, its structural inverse — so a reader
+scanning the mutation catalogue can tell at a glance what each operator does
+without reading the body. Documentation only; no behaviour changes. Follows
+[`docs/DOC_STYLE.md`](../../DOC_STYLE.md).
+
+Closes #3120
+
+Files documented:
+
+- `src/mutate/AddBackCon.ts`
+- `src/mutate/AddSelfCon.ts`
+- `src/mutate/RadioactiveInterface.ts`
+- `src/mutate/SubBackCon.ts`
+- `src/mutate/SubConnection.ts`
+- `src/mutate/SubNeuron.ts`
+- `src/mutate/SubSelfCon.ts`
+- `src/mutate/SwapNeurons.ts`
+
+## Evidence
+
+Documentation/CLI-only change — no web interface to screenshot. Verified each
+module's `@module` block renders via the read-only `deno doc`, e.g.:
+
+```text
+$ deno doc src/mutate/SwapNeurons.ts
+@module
+    Mutation operator that swaps the bias and squash (activation) of two distinct
+    hidden neurons, exploring parameter assignments without changing the
+    connection structure.
+```
+
+All eight files render their `@module` summary. Doc text was fact-checked
+against each operator's implementation (e.g. `SwapNeurons` swaps _both_ bias and
+squash, not squash alone).
+
+```mermaid
+flowchart LR
+    subgraph add["Add operators"]
+        ABC[AddBackCon]
+        ASC[AddSelfCon]
+    end
+    subgraph sub["Sub operators"]
+        SBC[SubBackCon]
+        SSC[SubSelfCon]
+        SC[SubConnection]
+        SN[SubNeuron]
+    end
+    SW[SwapNeurons]
+    RI[RadioactiveInterface]
+    ABC <-->|inverse| SBC
+    ASC <-->|inverse| SSC
+    RI -.->|mutate contract| add
+    RI -.->|mutate contract| sub
+```
+
+## Quality checks
+
+- `deno fmt --check src/mutate/` — clean (14 files).
+- `deno lint src/mutate/` — clean (14 files).
+- `deno check src/mutate/*.ts` — clean.
+
+(The full `./quality.sh` runs the complete test suite and exceeds the run
+timeout; the targeted gates above cover this documentation-only change.)
+
+## Test Plan
+
+No code paths changed, so no behavioural tests were added. Verification is the
+read-only `deno doc` render shown above, confirming every listed module now
+exposes a module-level doc comment.

--- a/docs/archive/pr-summaries/pr-summary-3121.md
+++ b/docs/archive/pr-summaries/pr-summary-3121.md
@@ -1,0 +1,61 @@
+# Add `@module` docs to `src/blackbox` memetic modules (#3121)
+
+## Summary
+
+Six public modules in the `src/blackbox/` (memetic / fine-tune, aliased
+`@blackbox/`) namespace exported a public symbol but had no leading module-level
+doc comment, so a reader could not orient themselves to the fine-tune lifecycle
+without tracing call sites. This PR adds a short leading `@module` JSDoc block
+to each of the listed files, following
+[`docs/DOC_STYLE.md`](../../DOC_STYLE.md). Documentation only — no code changes.
+
+Files documented:
+
+- `src/blackbox/Discover.ts` — reconstructs a child's memetic record from a
+  matching scored parent.
+- `src/blackbox/FineTune.ts` — quantum-step fine-tuning of the fittest creature.
+- `src/blackbox/FineTunePopulation.ts` — builds the per-generation fine-tune
+  population.
+- `src/blackbox/MemeticInterface.ts` — type definitions for the memetic record.
+- `src/blackbox/MemeticUpdate.ts` — propagates a parent's memetic record onto a
+  child during breeding.
+- `src/blackbox/Retry.ts` — re-runs fine-tuning when a creature's live score has
+  drifted from its recorded memetic score.
+
+Closes #3121.
+
+## Evidence
+
+This is a documentation-only change with no web interface to screenshot. Each
+module doc was verified to be recognised as module-level documentation with the
+read-only `deno doc` command, e.g.:
+
+```text
+$ deno doc src/blackbox/Discover.ts
+Memetic-state discovery for the fine-tune (memetic evolution) path.
+
+`discover` compares a scored parent with an as-yet-unscored child of
+identical topology and, when their structure matches, reconstructs the
+child's memetic record ...
+```
+
+All six files print their `@module` description, confirming the doc blocks are
+attached at module level. `deno fmt --check`, `deno lint`, and `deno check` all
+pass on the changed files.
+
+```mermaid
+flowchart LR
+    MI["MemeticInterface.ts<br/>(memetic record types)"] --> D["Discover.ts"]
+    MI --> FT["FineTune.ts"]
+    MI --> MU["MemeticUpdate.ts"]
+    FT --> FTP["FineTunePopulation.ts"]
+    FT --> R["Retry.ts"]
+    FTP --> R
+```
+
+## Test Plan
+
+No automated tests were added: a test that greps source files for `@module`
+would be a forbidden "how" test (per `AGENTS.md`), and the change adds no
+behaviour to assert on. Validation is via `deno doc` (above) plus the standard
+quality gate (`deno fmt`, `deno lint`, `deno check`), all of which pass.

--- a/docs/archive/pr-summaries/pr-summary-3122.md
+++ b/docs/archive/pr-summaries/pr-summary-3122.md
@@ -1,0 +1,45 @@
+# DOC-MODULE-DOC: `src/optimize` module docs
+
+## Summary
+
+Added a short leading `@module` JSDoc block to the five public modules in the
+`src/optimize/` (`@optimize/`) namespace that exported a symbol but opened
+straight onto imports/code with no module-level doc comment. Each block follows
+[`docs/DOC_STYLE.md`](../../DOC_STYLE.md) — a one-line plain-language gloss of
+what the optimisation pass / interface does, in Australian English — so a reader
+of this published surface (`publish.include: ["src/**"]`) can orient without
+reading the implementation. Documentation only; no code changes. Closes #3122.
+
+Files documented:
+
+- `src/optimize/FunctionCache.ts`
+- `src/optimize/InlineActivationInterface.ts`
+- `src/optimize/MakeActivationFunctionInterface.ts`
+- `src/optimize/Simplify.ts`
+- `src/optimize/SimplifyBiasInterface.ts`
+
+## Evidence
+
+Backend/library change with no web interface to screenshot. Verified the module
+docs render via the read-only `deno doc` tool, e.g.:
+
+```
+$ deno doc src/optimize/Simplify.ts
+Behaviour-preserving simplification passes for an exported creature.
+
+`simplify()` folds constants, prunes redundant synapses ...
+@module
+```
+
+All five files now emit their leading description through `deno doc`.
+
+## Test Plan
+
+No unit tests added. Per [`AGENTS.md`](../../../AGENTS.md) testing policy,
+asserting on documentation content (grepping source for `@module`) is a "how"
+test and is explicitly discouraged; the change carries no runtime behaviour to
+assert on. Verification instead relies on:
+
+- `deno doc src/optimize/<file>.ts` — confirms each module doc renders.
+- `./quality.sh` — passed cleanly (lint, format, type-check, full test suite:
+  7397 passed, 0 failed), confirming the added comments do not break the build.

--- a/docs/archive/pr-summaries/pr-summary-3123.md
+++ b/docs/archive/pr-summaries/pr-summary-3123.md
@@ -12,7 +12,8 @@ Added a short leading `@module` JSDoc block to each of the five affected files,
 following [`docs/DOC_STYLE.md`](../../DOC_STYLE.md) and matching the existing
 style in `TypeGuards.ts`:
 
-- `src/methods/activations/ActivationInterface.ts` — scalar `squash(x)` contract.
+- `src/methods/activations/ActivationInterface.ts` — scalar `squash(x)`
+  contract.
 - `src/methods/activations/Activations.ts` — central activation registry.
 - `src/methods/activations/NeuronActivationInterface.ts` — whole-`Neuron`
   activation/propagation/record contract.

--- a/docs/archive/pr-summaries/pr-summary-3123.md
+++ b/docs/archive/pr-summaries/pr-summary-3123.md
@@ -1,0 +1,63 @@
+# DOC-MODULE-DOC: `@module` docs for `src/methods/activations` interfaces
+
+## Summary
+
+The public interface and registry modules in `src/methods/activations/` opened
+straight onto imports then an exported symbol, with no leading module-level doc
+comment explaining what contract each one defines. Because these are the
+extension points a consumer implements to add an activation, the missing
+`@module` block cost integrators discoverability.
+
+Added a short leading `@module` JSDoc block to each of the five affected files,
+following [`docs/DOC_STYLE.md`](../../DOC_STYLE.md) and matching the existing
+style in `TypeGuards.ts`:
+
+- `src/methods/activations/ActivationInterface.ts` — scalar `squash(x)` contract.
+- `src/methods/activations/Activations.ts` — central activation registry.
+- `src/methods/activations/NeuronActivationInterface.ts` — whole-`Neuron`
+  activation/propagation/record contract.
+- `src/methods/activations/NeuronFixableInterface.ts` — optional post-mutation
+  `fix()` contract.
+- `src/methods/activations/UnSquashInterface.ts` — optional inverse-of-`squash`
+  contract.
+
+Documentation only — no code or behaviour change. Australian English throughout.
+
+Closes #3123.
+
+## Evidence
+
+This is a documentation-only change with no web interface to screenshot.
+Verification was done with the read-only `deno doc` command, which now surfaces
+the `@module` summary for every file. Example:
+
+```
+$ deno doc src/methods/activations/ActivationInterface.ts
+@module
+    Contract every standard activation function implements: the `squash(x)`
+    forward pass mapping a neuron's pre-activation value to its output. ...
+```
+
+All five files render their `@module` block; previously `deno doc` showed only
+the exported symbol with no module summary.
+
+```mermaid
+flowchart LR
+    Abstract["AbstractActivationInterface<br/>(naming, error, range)"] --> AI["ActivationInterface<br/>squash(x)"]
+    Abstract --> NAI["NeuronActivationInterface<br/>activate / propagate / record"]
+    Abstract --> UnS["UnSquashInterface<br/>unSquash()"]
+    Abstract --> Fix["NeuronFixableInterface<br/>fix()"]
+    AI --> Reg["Activations<br/>(registry)"]
+    NAI --> Reg
+```
+
+## Test Plan
+
+No tests added or modified. Per `AGENTS.md`, asserting on documentation content
+would be a "how" test (grepping source for patterns), which the project
+prohibits. Verification instead relied on:
+
+- `deno doc <file>` for each of the five files — confirms the `@module` summary
+  renders.
+- `./quality.sh --lint-only` — formatting, lint, and bash checks pass.
+- `./quality.sh --check-only` — `deno check` type-checks the full tree cleanly.

--- a/src/architecture/CreatureState.ts
+++ b/src/architecture/CreatureState.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Per-activation runtime state for a creature's neurons and synapses — the
+ * scratch buffers backpropagation reads and writes. {@link NeuronState} holds
+ * one neuron's running activation, bias and error totals; {@link CreatureState}
+ * owns the dense collections of those buffers for a whole topology. This state
+ * is ephemeral working memory, not part of the persisted UUID-only wire format.
+ */
 import { assert } from "@std/assert";
 import type { Creature } from "@creature";
 import type { Synapse } from "@architecture/Synapse.ts";

--- a/src/architecture/CreatureValidate.ts
+++ b/src/architecture/CreatureValidate.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Structural and topological validation for a creature. {@link creatureValidate}
+ * checks the invariants a healthy topology must hold — no self or backward
+ * connections, no duplicate synapses, every hidden neuron wired in and out,
+ * finite biases — and raises a {@link TopologyError} or {@link ValidationError}
+ * when a mutation, breeding or discovery step produces an invalid creature.
+ */
 import { assert } from "@std/assert";
 import type { Creature } from "@creature";
 import { TopologyError } from "@errors/TopologyError.ts";

--- a/src/architecture/DataSet.ts
+++ b/src/architecture/DataSet.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Training-dataset serialisation. {@link makeDataDir} writes an array of
+ * input/output {@link DataRecordInterface} records to partitioned binary files
+ * in a temporary directory, the on-disk format the trainer streams during
+ * evolution so a large dataset need not be held in memory at once.
+ */
 import { ValidationError } from "@errors/ValidationError.ts";
 
 export interface DataRecordInterface {

--- a/src/architecture/ElitismUtils.ts
+++ b/src/architecture/ElitismUtils.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Elitism helpers for the evolutionary loop. {@link makeElitists} selects the
+ * fittest creatures of a population to carry forward unchanged into the next
+ * generation, guarding the best-known solutions from being lost to mutation or
+ * breeding, and reports the population's average score alongside the elites.
+ */
 import { assert } from "@std/assert";
 import { blue, bold, green, red, white, yellow } from "@std/fmt/colors";
 import { addTag, getTag } from "@stsoftware/tags/mod";

--- a/src/architecture/NeuronInterfaces.ts
+++ b/src/architecture/NeuronInterfaces.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Type definitions for neurons. Distinguishes the export shape
+ * ({@link NeuronExport}, the UUID-only wire format that crosses process and
+ * machine boundaries) from the internal shape carrying the runtime integer id.
+ * These interfaces fix the contract every neuron serialisation and breeding
+ * path shares; they contain no logic.
+ */
 import type { TagsInterface } from "@stsoftware/tags/mod";
 import type { NeuronStateInterface } from "@architecture/CreatureState.ts";
 

--- a/src/architecture/NoChangePropagate.ts
+++ b/src/architecture/NoChangePropagate.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Backpropagation shortcut for unchanged neurons. {@link noChangePropagate}
+ * walks a neuron's inward connections and propagates updates only where an
+ * upstream activation actually changed, skipping neurons flagged `noChange` so
+ * the gradient pass avoids redundant work on a stable subgraph.
+ */
 import type { NeuronActivationInterface } from "@methods/activations/NeuronActivationInterface.ts";
 import type { BackPropagationConfig } from "@propagate/BackPropagation.ts";
 import type { Neuron } from "@architecture/Neuron.ts";

--- a/src/architecture/Offspring.ts
+++ b/src/architecture/Offspring.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Builds offspring creatures from two parents for the breeding pipeline —
+ * crossover of topology, synapses and hyperparameters. Neurons are aligned
+ * between parents by matching stable UUIDs (never array position), so the same
+ * genome breeds consistently across machines; child neurons keep their parent
+ * UUID and any newly created neurons get a fresh one.
+ */
 import { assert } from "@std/assert";
 import { addTags } from "@stsoftware/tags/mod";
 import { memeticUpdate } from "@blackbox/MemeticUpdate.ts";

--- a/src/architecture/SynapseInterfaces.ts
+++ b/src/architecture/SynapseInterfaces.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Type definitions for synapses (connections). Distinguishes the internal,
+ * index-based shape ({@link SynapseInternal}, used during in-memory creature
+ * operations) from the export shape that crosses process boundaries. These
+ * interfaces fix the shared contract for synapse serialisation and traversal;
+ * they contain no logic.
+ */
 import type { TagInterface } from "@stsoftware/tags/mod";
 import type { SynapseState } from "@propagate/SynapseState.ts";
 

--- a/src/architecture/SyncV5.ts
+++ b/src/architecture/SyncV5.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Deterministic RFC 4122 version-5 UUID generation. {@link generate} hashes a
+ * namespace UUID together with a byte payload (SHA-1) to derive a stable,
+ * reproducible UUID — the same namespace and data always yield the same UUID,
+ * which lets neuron identities be derived deterministically rather than randomly.
+ */
 import { concat } from "@std/bytes";
 import { crypto as stdCrypto } from "@std/crypto";
 

--- a/src/blackbox/Discover.ts
+++ b/src/blackbox/Discover.ts
@@ -1,3 +1,14 @@
+/**
+ * Memetic-state discovery for the fine-tune (memetic evolution) path.
+ *
+ * `discover` compares a scored parent with an as-yet-unscored child of
+ * identical topology and, when their structure matches, reconstructs the
+ * child's memetic record — the per-neuron bias and per-synapse weight deltas
+ * inherited from the parent — so locally fine-tuned state is carried across
+ * during breeding instead of being lost.
+ *
+ * @module
+ */
 import { assert } from "@std/assert";
 import type { Creature } from "../../mod.ts";
 import type { MemeticInterface } from "@blackbox/MemeticInterface.ts";

--- a/src/blackbox/FineTune.ts
+++ b/src/blackbox/FineTune.ts
@@ -1,3 +1,15 @@
+/**
+ * Quantum-step fine-tuning (memetic evolution) of the fittest creature.
+ *
+ * This module performs the local fine-tune step: it compares the current
+ * fittest creature against a previous fittest, nudges biases and weights by an
+ * adaptive quantum step (`quantumAdjust` / `calculateEffectiveStep`), and emits
+ * a population of fine-tuned candidates (`fineTuneImprovement`) for selection.
+ * Adjustments are biased by trajectory momentum and recorded in each
+ * candidate's memetic record.
+ *
+ * @module
+ */
 import { assert } from "@std/assert";
 import { addTag, removeTag } from "@stsoftware/tags/mod";
 import type { CreatureExport } from "../../mod.ts";

--- a/src/blackbox/FineTunePopulation.ts
+++ b/src/blackbox/FineTunePopulation.ts
@@ -1,3 +1,14 @@
+/**
+ * Builds the per-generation fine-tune (memetic evolution) population.
+ *
+ * `FindTunePopulation.make` orchestrates the fine-tune step across a whole
+ * generation: it pairs the fittest creature with suitable lower-scoring
+ * partners (the previous fittest, a restored source, and same-species
+ * neighbours), drives each pairing through `fineTuneImprovement`, dedupes by
+ * UUID, and adds the resulting candidates to the genus for selection.
+ *
+ * @module
+ */
 import { assert } from "@std/assert";
 import { type Creature, CreatureUtil } from "../../mod.ts";
 import { ValidationError } from "@errors/ValidationError.ts";

--- a/src/blackbox/MemeticInterface.ts
+++ b/src/blackbox/MemeticInterface.ts
@@ -1,3 +1,15 @@
+/**
+ * Type definitions for the memetic (local fine-tuning) record carried on a
+ * creature.
+ *
+ * A `MemeticInterface` captures the per-neuron bias and per-synapse weight
+ * deltas produced by fine-tuning, the generation and score they were recorded
+ * at, and an optional bounded `ancestry` of earlier snapshots used for
+ * trajectory analysis. These shapes are shared across the `@blackbox/`
+ * fine-tune modules.
+ *
+ * @module
+ */
 export interface MemeticWeightInterface {
   toId: number;
   weight: number;

--- a/src/blackbox/MemeticUpdate.ts
+++ b/src/blackbox/MemeticUpdate.ts
@@ -1,3 +1,16 @@
+/**
+ * Propagates a parent's memetic (local fine-tuning) record onto a child during
+ * breeding.
+ *
+ * `memeticUpdate` returns a new memetic record for a child whose topology
+ * matches its parent, copying the parent's bias and weight deltas and appending
+ * any changes the child introduced. It uses a copy-on-write strategy (Issue
+ * #3091) to avoid a full deep clone on the per-offspring hot path, and returns
+ * `undefined` when the structures diverge so the caller falls back to
+ * `discover`.
+ *
+ * @module
+ */
 import type { Creature } from "../../mod.ts";
 import type { MemeticInterface } from "@blackbox/MemeticInterface.ts";
 

--- a/src/blackbox/Retry.ts
+++ b/src/blackbox/Retry.ts
@@ -1,3 +1,14 @@
+/**
+ * Re-runs fine-tuning (memetic evolution) on creatures whose live score has
+ * drifted from their recorded memetic score.
+ *
+ * `retry` scans a population for creatures whose current score differs from the
+ * score stored in their memetic record, picks one (weighted towards the largest
+ * improvement), and fine-tunes it against its restored source — either pushing
+ * forward (`retry`) or backtracking when the source scored higher.
+ *
+ * @module
+ */
 import { assert } from "@std/assert";
 import { addTag } from "@stsoftware/tags/mod";
 import type { Creature } from "../../mod.ts";

--- a/src/breed/Father.ts
+++ b/src/breed/Father.ts
@@ -656,10 +656,14 @@ export function createCompatibleFatherFromCreatures(
     fatherIndexToId[i] = fatherNeurons[i].id;
   }
 
-  // Issue #2050: Build ID-to-UUID map for mother neurons
+  // Issue #2050: Build ID-to-UUID map for mother neurons.
+  // Input neurons use id = inputIndex (see NeuronId.ts), so map id `i`
+  // directly rather than indexing motherNeurons positionally — a bred or
+  // immigrant genome may carry fewer/reordered neuron entries than its
+  // declared input count, which made `motherNeurons[i]` undefined.
   const motherIdToUuid = new Map<number, string>();
   for (let i = 0; i < mother.input; i++) {
-    motherIdToUuid.set(motherNeurons[i].id, `input-${i}`);
+    motherIdToUuid.set(i, `input-${i}`);
   }
   for (const neuron of motherNeurons) {
     if (neuron.type !== "input") {
@@ -671,7 +675,7 @@ export function createCompatibleFatherFromCreatures(
   // Issue #2050: Build a combined ID → UUID map for synapse uuid resolution
   const combinedIdToUuid = new Map<number, string>();
   for (let i = 0; i < father.input; i++) {
-    combinedIdToUuid.set(fatherNeurons[i].id, `input-${i}`);
+    combinedIdToUuid.set(i, `input-${i}`);
   }
 
   const newNeurons: NeuronExport[] = [];

--- a/src/methods/activations/ActivationInterface.ts
+++ b/src/methods/activations/ActivationInterface.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Contract every standard activation function implements: the `squash(x)`
+ * forward pass mapping a neuron's pre-activation value to its output. Extends
+ * `AbstractActivationInterface` (naming, error, and range behaviour) and is the
+ * base an integrator implements to add a new activation to the registry.
+ */
+
 import type { AbstractActivationInterface } from "@methods/activations/AbstractActivationInterface.ts";
 
 interface SquashAndDeriveResult {

--- a/src/methods/activations/Activations.ts
+++ b/src/methods/activations/Activations.ts
@@ -1,3 +1,13 @@
+/**
+ * @module
+ *
+ * Central registry of every activation function: registers each implementation
+ * under its canonical name plus aliases, builds the mutation-weighted random
+ * pool, and resolves a name to its `AbstractActivationInterface` (throwing
+ * `ActivationError` for unknown names). The single lookup point used across
+ * mutation, breeding, and serialisation.
+ */
+
 import { assert } from "@std/assert";
 import { ActivationError } from "@errors/ActivationError.ts";
 import { HYPOT } from "@deprecated/HYPOT.ts";

--- a/src/methods/activations/NeuronActivationInterface.ts
+++ b/src/methods/activations/NeuronActivationInterface.ts
@@ -1,3 +1,13 @@
+/**
+ * @module
+ *
+ * Contract for activations that operate over a whole `Neuron` rather than a
+ * single scalar: forward activation with tracing, error back-propagation, and
+ * Discovery recording. Aggregate-style activations implement this instead of
+ * the scalar `ActivationInterface` because they need the neuron's incoming
+ * connections and state.
+ */
+
 import type { DiscoverRecord } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { Neuron } from "@architecture/Neuron.ts";
 import type { BackPropagationConfig } from "@propagate/BackPropagation.ts";

--- a/src/methods/activations/NeuronFixableInterface.ts
+++ b/src/methods/activations/NeuronFixableInterface.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Optional contract for activations that can repair a `Neuron` into a valid
+ * state via `fix()` — e.g. clamping bias or pruning incompatible connections
+ * after a mutation. Implemented only by activations that need post-mutation
+ * fix-up; most activations do not.
+ */
+
 import type { AbstractActivationInterface } from "@methods/activations/AbstractActivationInterface.ts";
 import type { Neuron } from "@architecture/Neuron.ts";
 

--- a/src/methods/activations/UnSquashInterface.ts
+++ b/src/methods/activations/UnSquashInterface.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Optional contract for the inverse of `squash`: `unSquash(activation, hint?)`
+ * recovers a pre-activation value from an output, used by optimisation passes
+ * that reason backwards through a neuron. Only activations with a tractable
+ * inverse implement this; callers feature-detect it via the `TypeGuards`.
+ */
+
 import type { AbstractActivationInterface } from "@methods/activations/AbstractActivationInterface.ts";
 
 export interface UnSquashInterface extends AbstractActivationInterface {

--- a/src/mutate/AddBackCon.ts
+++ b/src/mutate/AddBackCon.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Mutation operator that adds a back (recurrent) connection — a synapse
+ * feeding from a later neuron to an earlier one — giving the topology memory
+ * of past activations. Standard NEAT adds only feed-forward links; NEAT-AI
+ * permits these recurrent edges unless the creature is `forwardOnly`.
+ */
 import { Synapse } from "@architecture/Synapse.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "@mutate/AbstractMutationOperator.ts";

--- a/src/mutate/AddSelfCon.ts
+++ b/src/mutate/AddSelfCon.ts
@@ -1,3 +1,10 @@
+/**
+ * @module
+ *
+ * Mutation operator that adds a self-connection — a synapse from a neuron back
+ * to itself — so a single neuron can retain state across activations. Skipped
+ * when the creature is `forwardOnly`, since self-loops are recurrent.
+ */
 import { Synapse } from "@architecture/Synapse.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 import { AbstractMutationOperator } from "@mutate/AbstractMutationOperator.ts";

--- a/src/mutate/RadioactiveInterface.ts
+++ b/src/mutate/RadioactiveInterface.ts
@@ -1,3 +1,12 @@
+/**
+ * @module
+ *
+ * Shared contract for "radioactive" mutation operators: a single `mutate`
+ * entry point that applies one structural change to a creature, optionally
+ * steered by a {@link MutationBias} from predictive-coding error guidance.
+ * Implemented by the abstract mutation operator so every operator in the
+ * `@mutate/` catalogue exposes the same interface.
+ */
 import type { MutationBias } from "@predictiveCoding/PredictionErrorGuidedMutation.ts";
 
 export interface RadioactiveInterface {

--- a/src/mutate/SubBackCon.ts
+++ b/src/mutate/SubBackCon.ts
@@ -1,3 +1,10 @@
+/**
+ * @module
+ *
+ * Mutation operator that removes a back (recurrent) connection, pruning the
+ * recurrent edges that {@link AddBackCon} introduces. Tidies the affected
+ * neuron order afterwards so the creature stays computationally valid.
+ */
 import { moveConstantNeuronIntoPrefix } from "@architecture/NormaliseComputationalNeuronOrder.ts";
 import { removeHiddenNeuron } from "@compact/CompactUtils.ts";
 import type { ActivationInterface } from "@methods/activations/ActivationInterface.ts";

--- a/src/mutate/SubConnection.ts
+++ b/src/mutate/SubConnection.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Mutation operator that removes a feed-forward connection from the network,
+ * operating directly on the creature's arrays with no export/import cycle.
+ * Any neuron left without connections is cleaned up so the topology stays
+ * valid.
+ */
 import { moveConstantNeuronIntoPrefix } from "@architecture/NormaliseComputationalNeuronOrder.ts";
 import { removeHiddenNeuron } from "@compact/CompactUtils.ts";
 import type { ActivationInterface } from "@methods/activations/ActivationInterface.ts";

--- a/src/mutate/SubNeuron.ts
+++ b/src/mutate/SubNeuron.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Mutation operator that removes a hidden neuron from the network, operating
+ * directly on the creature's arrays with no export/import cycle. Repairs any
+ * invalid IF neurons left behind and renormalises neuron order so the
+ * creature stays computationally valid.
+ */
 import { moveConstantNeuronIntoPrefix } from "@architecture/NormaliseComputationalNeuronOrder.ts";
 import { repairInvalidIfNeuronsInCreature } from "@architecture/RepairInvalidIfNeurons.ts";
 import { removeHiddenNeuron } from "@compact/CompactUtils.ts";

--- a/src/mutate/SubSelfCon.ts
+++ b/src/mutate/SubSelfCon.ts
@@ -1,3 +1,10 @@
+/**
+ * @module
+ *
+ * Mutation operator that removes a self-connection, pruning the self-loops
+ * that {@link AddSelfCon} introduces. Only neurons whose self-connection can
+ * be safely removed are considered, keeping the topology valid.
+ */
 import { moveConstantNeuronIntoPrefix } from "@architecture/NormaliseComputationalNeuronOrder.ts";
 import { removeHiddenNeuron } from "@compact/CompactUtils.ts";
 import type { ActivationInterface } from "@methods/activations/ActivationInterface.ts";

--- a/src/mutate/SwapNeurons.ts
+++ b/src/mutate/SwapNeurons.ts
@@ -1,3 +1,11 @@
+/**
+ * @module
+ *
+ * Mutation operator that swaps the squash (activation) and bias of two hidden
+ * neurons, exploring the parameter space without changing the connection
+ * structure. Unlike a sub/add pair it preserves the existing topology — only
+ * the two neurons' activation behaviour is exchanged.
+ */
 import { assert } from "@std/assert";
 import { AbstractMutationOperator } from "@mutate/AbstractMutationOperator.ts";
 

--- a/src/optimize/FunctionCache.ts
+++ b/src/optimize/FunctionCache.ts
@@ -1,3 +1,14 @@
+/**
+ * Single-entry cache for compiled neuron activation functions.
+ *
+ * `findActivationFunction` keys a generated activation-function body by a
+ * deterministic UUIDv5 (over the body plus an optional suffix) and returns the
+ * previously compiled function on a hit, evicting the stale entry on a miss so
+ * the caller can recompile. Avoids recompiling identical inlined activations.
+ *
+ * @module
+ */
+
 import type { ActivationFunction } from "@optimize/MakeActivationFunctionInterface.ts";
 
 import { generate as generateV5Sync } from "@architecture/SyncV5.ts";

--- a/src/optimize/InlineActivationInterface.ts
+++ b/src/optimize/InlineActivationInterface.ts
@@ -1,3 +1,13 @@
+/**
+ * Contract for activation functions that can emit inline source code.
+ *
+ * Implementers return a JavaScript expression that computes a neuron's
+ * activation in place, letting the optimiser splice the activation directly
+ * into a generated function body rather than calling through an interface.
+ *
+ * @module
+ */
+
 import type { Neuron } from "@architecture/Neuron.ts";
 
 export interface InlineActivationInterface {

--- a/src/optimize/MakeActivationFunctionInterface.ts
+++ b/src/optimize/MakeActivationFunctionInterface.ts
@@ -1,3 +1,14 @@
+/**
+ * Contract for building compiled activation functions for a neuron.
+ *
+ * Defines the `ActivationFunction` shape returned at runtime and the
+ * `makeActivationFunction` factory that, given a neuron and a {@link FunctionCache},
+ * produces (or reuses) the compiled closure that computes that neuron's
+ * activation and value.
+ *
+ * @module
+ */
+
 import type { Neuron } from "@architecture/Neuron.ts";
 import type { FunctionCache } from "@optimize/FunctionCache.ts";
 import type { NeuronActivationInterface } from "@methods/activations/NeuronActivationInterface.ts";

--- a/src/optimize/Simplify.ts
+++ b/src/optimize/Simplify.ts
@@ -1,3 +1,15 @@
+/**
+ * Behaviour-preserving simplification passes for an exported creature.
+ *
+ * `simplify()` folds constants, prunes redundant synapses (e.g. collapsing
+ * COMPLEMENT-of-COMPLEMENT to IDENTITY), removes neurons that no longer affect
+ * the output and normalises computational neuron order — all without changing
+ * what the creature computes. Helpers `removeKnownSign` and `removeNeuron`
+ * support those passes.
+ *
+ * @module
+ */
+
 import { addTag, removeTag } from "@stsoftware/tags/mod";
 import { type CreatureExport, CreatureUtil } from "../../mod.ts";
 import { normaliseComputationalNeuronOrderInExport } from "@architecture/NormaliseComputationalNeuronOrder.ts";

--- a/src/optimize/SimplifyBiasInterface.ts
+++ b/src/optimize/SimplifyBiasInterface.ts
@@ -1,3 +1,13 @@
+/**
+ * Contract for activation functions that can simplify a neuron's bias.
+ *
+ * Implementers map a raw bias to an equivalent simplified value during a
+ * simplification pass, letting `Simplify` fold the bias into the activation
+ * without changing the neuron's output.
+ *
+ * @module
+ */
+
 export interface SimplifyBiasInterface {
   simplifyBias(bias: number): number;
 }

--- a/test/breed/FatherDegenerateInputs.ts
+++ b/test/breed/FatherDegenerateInputs.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression test for PR #3131: `createCompatibleFatherFromCreatures` must not
+ * crash when a parent genome carries fewer (or reordered) neuron entries than
+ * its declared `input` count.
+ *
+ * The end-to-end random-immigrants evolution path
+ * (test/NEAT/RandomImmigrantsStagnationEscape.ts) bred a degenerate genome
+ * whose `neurons` array held fewer entries than `mother.input`. The old code
+ * indexed `motherNeurons[i]` positionally for `i < mother.input`, so the
+ * missing entry was `undefined` and `.id` threw
+ * `TypeError: Cannot read properties of undefined (reading 'id')`
+ * (src/breed/Father.ts:662).
+ *
+ * Input neurons always use `id = inputIndex` (see NeuronId.ts), so the map is
+ * built from `i` directly — robust to a short or reordered neuron array.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { createCompatibleFatherFromCreatures } from "@breed/Father.ts";
+import { Creature } from "../../mod.ts";
+
+Deno.test(
+  "createCompatibleFatherFromCreatures: tolerates a genome with fewer neurons than its input count (PR #3131)",
+  () => {
+    const mother = new Creature(2, 1);
+    const father = new Creature(2, 1);
+
+    // Simulate the degenerate bred genome observed in production: trim the
+    // neuron array so `mother.neurons.length < mother.input`. The old
+    // positional access `motherNeurons[i].id` would read past the end of the
+    // array and throw on the `undefined` slot.
+    mother.neurons = mother.neurons.filter((n) => n.type !== "input");
+    assert(
+      mother.neurons.length < mother.input,
+      "test setup: neurons array should now be shorter than input count",
+    );
+
+    // Must not throw; input ids map to `input-i` regardless of array shape.
+    const adjusted = createCompatibleFatherFromCreatures(mother, father);
+    assertEquals(adjusted.input, father.input);
+    assertEquals(adjusted.output, father.output);
+  },
+);


### PR DESCRIPTION
## Milestone: module docs

This PR merges the completed milestone branch into Develop.
Closes #3130

### Issues addressed
- #3123: 🟢 DOC-MODULE-DOC: src/methods/activations interfaces missing @module docs
- #3122: 🟢 DOC-MODULE-DOC: src/optimize passes missing @module docs
- #3121: 🟢 DOC-MODULE-DOC: src/blackbox memetic modules missing @module docs
- #3120: 🟢 DOC-MODULE-DOC: src/mutate operators missing @module docs
- #3119: 🟢 DOC-MODULE-DOC: src/architecture public modules missing @module docs

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.