### PR TITLE
currentGeneration: gate on loaded creature's warm-up tag (#3138)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -193,9 +193,15 @@ therefore persists through the export / reload boundary:
   exported creature is stamped with the Neat-level counter, kept **monotonic**
   (never lowered below an already-higher saved value, Issue #2831).
 - **Reload / resume** (`populatePopulation`): the lineage counter resumes from
-  the **highest saved `currentGeneration` tag** via `Math.max`, so the next run
-  picks up where the previous one left off instead of restarting at the seed
-  value (Issue #2908).
+  the **highest saved `currentGeneration` tag** across both the loaded seed and
+  the whole starting population (prior champions from other machines), via
+  `Math.max` — the cross-machine "always increase, take the maximum" point
+  (Issues #2908, #2945, #3138). The next run picks up at the population maximum
+  instead of restarting at a tagless seed.
+- **Gate on the loaded creature** (Issue #3138): all `currentGeneration` logic
+  is skipped when the **loaded** champion has graduated (no `warmupGenerations`
+  tag). A still-warming immigrant in `config.creatures` can never seed
+  `currentGeneration` once the loaded creature is past warm-up.
 - **Mid-run**: offspring no longer carry the warm-up tags — the Neat-level
   counter is the single source of truth during a run (Issue #2911).
 

--- a/docs/archive/pr-summaries/pr-summary-3138.md
+++ b/docs/archive/pr-summaries/pr-summary-3138.md
@@ -1,0 +1,69 @@
+# currentGeneration must always increase across machines (Issue #3138)
+
+## Summary
+
+`currentGeneration` is the lineage counter that gates the seed warm-up
+structural lock (#2828). Across a teams run it was not climbing reliably, so
+warm-up never completed across machines. The converged design — accumulate
+(start + generations run), reconcile across machines by taking the **maximum**
+at the population seed, gate on the **loaded** creature, and strip both tags
+once warm — was largely already in place from #2908 / #2945 / #2909 / #2911.
+
+The one remaining gap: `Neat.populatePopulation` seeded the counter
+**unconditionally**. When the loaded champion had graduated (no
+`warmupGenerations` tag), a still-warming immigrant in `config.creatures` could
+still seed `currentGeneration` from its tag — violating the "**gate on the
+loaded creature only**" rule.
+
+The fix gates the population-max scan and counter seeding on the **loaded**
+creature's `warmupGenerations` tag: once the loaded champion has graduated,
+warm-up is off for the whole call and no immigrant can seed the counter. The
+save boundary (`applySeedWarmupTagsAtSave`) already strips both tags in that
+case, so the output emerges warm-up-free.
+
+The cross-machine "take the maximum" and "start + N" accumulation paths were
+verified by new regression tests and already passed — confirming those parts
+were correct; only the graduated-gate test was red before this change.
+
+Closes #3138.
+
+## Evidence
+
+Backend/engine change — no UI to screenshot. Verified by unit tests
+(`deno test`) and the full `./quality.sh` gate (**7401 passed, 0 failed**).
+
+The three concrete issue cases, exercised as "what" tests against
+`populatePopulation`:
+
+| Case | Setup | Expected | Result |
+| --- | --- | --- | --- |
+| Accumulate | loaded tag 10, run 50 generations | `currentGeneration == 60` | pass (already worked) |
+| Cross-machine max | machine A tag 10, machine B tag 20 | seed `currentGeneration == 20` | pass (already worked) |
+| Graduated gate | graduated seed + immigrant tag 500 | `currentGeneration == 0` | **red before fix → green after** |
+
+```mermaid
+flowchart TD
+    A[populatePopulation: read loaded creature] --> B{warmupGenerations tag present?}
+    B -- "no (graduated)" --> C[Skip population-max scan<br/>currentGeneration untouched]
+    B -- "yes (warming)" --> D[Scan whole population for max currentGeneration]
+    D --> E["currentGeneration = max(in-memory, seed, populationMax)"]
+    C --> F[Save boundary strips both tags]
+    E --> G[evolve: currentGeneration++ per generation]
+    G --> H[Save boundary stamps currentGeneration = start + N]
+```
+
+## Test Plan
+
+Added to `test/NEAT/NeatPopulatePopulation.ts`:
+
+- `populatePopulation: start 10 + 50 generations accumulates to 60 (Issue #3138)`
+  — start generation seeded from the tag, then 50 increments → 60.
+- `populatePopulation: machine A (10) and machine B (20) take the maximum 20 (Issue #3138)`
+  — two prior champions in `config.creatures`; the seed takes `max(10, 20)`.
+- `populatePopulation: graduated seed ignores a warming immigrant's generation (Issue #3138)`
+  — graduated loaded seed; a warming immigrant (tag 500) must **not** seed the
+  counter (stays 0). This test was failing before the gate and passes after.
+
+Existing warm-up tests (`SeedWarmupPersistence.ts`, the rest of
+`NeatPopulatePopulation.ts`) remain green, confirming no regression to the
+#2908 / #2945 / #2909 / #2911 behaviour.

--- a/docs/archive/pr-summaries/pr-summary-3138.md
+++ b/docs/archive/pr-summaries/pr-summary-3138.md
@@ -35,11 +35,11 @@ Backend/engine change — no UI to screenshot. Verified by unit tests
 The three concrete issue cases, exercised as "what" tests against
 `populatePopulation`:
 
-| Case | Setup | Expected | Result |
-| --- | --- | --- | --- |
-| Accumulate | loaded tag 10, run 50 generations | `currentGeneration == 60` | pass (already worked) |
-| Cross-machine max | machine A tag 10, machine B tag 20 | seed `currentGeneration == 20` | pass (already worked) |
-| Graduated gate | graduated seed + immigrant tag 500 | `currentGeneration == 0` | **red before fix → green after** |
+| Case              | Setup                              | Expected                       | Result                           |
+| ----------------- | ---------------------------------- | ------------------------------ | -------------------------------- |
+| Accumulate        | loaded tag 10, run 50 generations  | `currentGeneration == 60`      | pass (already worked)            |
+| Cross-machine max | machine A tag 10, machine B tag 20 | seed `currentGeneration == 20` | pass (already worked)            |
+| Graduated gate    | graduated seed + immigrant tag 500 | `currentGeneration == 0`       | **red before fix → green after** |
 
 ```mermaid
 flowchart TD
@@ -65,5 +65,5 @@ Added to `test/NEAT/NeatPopulatePopulation.ts`:
   counter (stays 0). This test was failing before the gate and passes after.
 
 Existing warm-up tests (`SeedWarmupPersistence.ts`, the rest of
-`NeatPopulatePopulation.ts`) remain green, confirming no regression to the
-#2908 / #2945 / #2909 / #2911 behaviour.
+`NeatPopulatePopulation.ts`) remain green, confirming no regression to the #2908
+/ #2945 / #2909 / #2911 behaviour.

--- a/docs/visualize/bar_chart.html
+++ b/docs/visualize/bar_chart.html
@@ -10,25 +10,25 @@
     />
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <style>
-      .unused-input {
-        background-color: lightyellow;
-      }
+    .unused-input {
+      background-color: lightyellow;
+    }
 
-      #chartContainer {
-        height: 100vh;
-        overflow-y: scroll;
-      }
+    #chartContainer {
+      height: 100vh;
+      overflow-y: scroll;
+    }
 
-      #barChartContainer {
-        width: 100%;
-        height: auto;
-        overflow-y: scroll;
-      }
+    #barChartContainer {
+      width: 100%;
+      height: auto;
+      overflow-y: scroll;
+    }
 
-      canvas {
-        display: block;
-        height: 100%;
-      }
+    canvas {
+      display: block;
+      height: 100%;
+    }
     </style>
   </head>
 

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -813,33 +813,42 @@ export class Neat {
 
   async populatePopulation(creature: Creature) {
     this.warmupGenerations = readWarmupGenerationsFromCreature(creature);
-    // Issue #2908: seed the lineage-accumulated generation counter
-    // monotonically — fold the saved tag in via Math.max so no load path can
-    // ever lower it (consistent with the monotonic tag write in #2831).
-    // Issue #2945: also fold in the maximum currentGeneration across the whole
-    // starting population (the prior champions loaded via config.creatures),
-    // not just the primary seed. In production the primary seed is a tagless
-    // factory template, so the accumulated lineage value lives only on those
-    // population members — resuming from the seed alone restarts the counter
-    // at 0 every run and the warm-up gate never lifts. Monotonic-max keeps
-    // tagless clones contributing 0, so they can never lower the counter.
-    const populationMax = this.population.reduce(
-      (m, c) => Math.max(m, readCurrentGenerationFromCreature(c)),
-      0,
-    );
-    const seedGeneration = readCurrentGenerationFromCreature(creature);
-    this.currentGeneration = Math.max(
-      this.currentGeneration,
-      seedGeneration,
-      populationMax,
-    );
 
-    // Issue #2947: surface the resumed warm-up state exactly once at run start
-    // so a frozen/resetting counter is obvious at a glance. The `source` makes
-    // the #2945 bug self-evident: a tagless factory seed (source=population)
-    // looks identical to a fresh start (source=none) without it. No logging
-    // when warm-up is not configured — zero overhead once warm (#2903).
+    // Issue #3138: gate every currentGeneration computation on the LOADED
+    // creature's warm-up tag. When the loaded champion has graduated (no
+    // `warmupGenerations` tag), warm-up is off for the whole call, so we skip
+    // the population-max scan and the counter seeding entirely. This is the
+    // "gate on the loaded creature only" rule: a still-warming immigrant in
+    // `config.creatures` must never seed `currentGeneration` once the loaded
+    // champion has graduated. The save boundary then strips both tags so the
+    // output emerges warm-up-free.
     if (this.warmupGenerations > 0) {
+      // Issue #2908: seed the lineage-accumulated generation counter
+      // monotonically — fold the saved tag in via Math.max so no load path can
+      // ever lower it (consistent with the monotonic tag write in #2831).
+      // Issue #2945: also fold in the maximum currentGeneration across the whole
+      // starting population (the prior champions loaded via config.creatures),
+      // not just the primary seed. In production the primary seed is a tagless
+      // factory template, so the accumulated lineage value lives only on those
+      // population members — resuming from the seed alone restarts the counter
+      // at 0 every run and the warm-up gate never lifts. Taking the maximum is
+      // the cross-machine "always increase" point (Issue #3138): tagless clones
+      // contribute 0 so they can never lower the counter.
+      const populationMax = this.population.reduce(
+        (m, c) => Math.max(m, readCurrentGenerationFromCreature(c)),
+        0,
+      );
+      const seedGeneration = readCurrentGenerationFromCreature(creature);
+      this.currentGeneration = Math.max(
+        this.currentGeneration,
+        seedGeneration,
+        populationMax,
+      );
+
+      // Issue #2947: surface the resumed warm-up state exactly once at run start
+      // so a frozen/resetting counter is obvious at a glance. The `source` makes
+      // the #2945 bug self-evident: a tagless factory seed (source=population)
+      // looks identical to a fresh start (source=none) without it.
       const lockActive = isSeedWarmupStructuralLockActive(
         this.warmupGenerations,
         this.currentGeneration,

--- a/test/NEAT/NeatPopulatePopulation.ts
+++ b/test/NEAT/NeatPopulatePopulation.ts
@@ -450,3 +450,124 @@ Deno.test("populatePopulation: restores warm-up tags from seed creature", async 
     await terminateWorkers(workers);
   }
 });
+
+// ─── Issue #3138: currentGeneration must always increase across machines ─────
+// The three concrete cases from the issue: accumulate (start + generations
+// run), take the cross-machine maximum at the population-max seed, and skip all
+// currentGeneration logic when the loaded creature has graduated (no warm-up
+// tag) so a still-warming immigrant can never seed the counter.
+
+Deno.test("populatePopulation: start 10 + 50 generations accumulates to 60 (Issue #3138)", async () => {
+  const dataDir = createTestDataDir(3, 2);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    const options: NeatOptions = { populationSize: 5 };
+    const neat = new Neat(3, 2, options, workers);
+
+    // Loaded champion is warming and has reached generation 10.
+    const seedCreature = creatureForProblem({
+      inputs: 3,
+      outputs: 2,
+      cost: "MSE",
+      warmupGenerations: 1440,
+    });
+    addTag(seedCreature, CURRENT_GENERATION_TAG, "10");
+
+    await neat.populatePopulation(seedCreature);
+    assertEquals(neat.currentGeneration, 10, "Start generation from the tag");
+
+    // Run 50 generations exactly as evolve() does (single increment writer).
+    for (let g = 0; g < 50; g++) {
+      neat.currentGeneration++;
+    }
+
+    assertEquals(
+      neat.currentGeneration,
+      60,
+      "currentGeneration must accumulate start + generations run (10 + 50)",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("populatePopulation: machine A (10) and machine B (20) take the maximum 20 (Issue #3138)", async () => {
+  const dataDir = createTestDataDir(3, 2);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    // Two prior champions from different machines, at generations 10 and 20.
+    const machineA = new Creature(3, 2, { layers: [{ count: 3 }] });
+    addTag(machineA, CURRENT_GENERATION_TAG, "10");
+    const machineB = new Creature(3, 2, { layers: [{ count: 3 }] });
+    addTag(machineB, CURRENT_GENERATION_TAG, "20");
+
+    const options: NeatOptions = {
+      populationSize: 5,
+      creatures: [machineA.exportJSON(), machineB.exportJSON()],
+    };
+    const neat = new Neat(3, 2, options, workers);
+
+    // Tagless factory-style warming primary seed.
+    const seedCreature = creatureForProblem({
+      inputs: 3,
+      outputs: 2,
+      cost: "MSE",
+      warmupGenerations: 1440,
+    });
+
+    await neat.populatePopulation(seedCreature);
+
+    assertEquals(
+      neat.currentGeneration,
+      20,
+      "Cross-machine seed must take the maximum (max(10, 20) = 20)",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("populatePopulation: graduated seed ignores a warming immigrant's generation (Issue #3138)", async () => {
+  // Gate on the loaded creature only: when the loaded champion has graduated
+  // (no warmupGenerations tag), warm-up is off for the whole call. A still
+  // warming immigrant in config.creatures must NOT seed currentGeneration.
+  const dataDir = createTestDataDir(3, 2);
+  const workers = createTestWorkers(dataDir);
+
+  try {
+    // A still-warming immigrant carrying both warm-up tags.
+    const immigrant = creatureForProblem({
+      inputs: 3,
+      outputs: 2,
+      cost: "MSE",
+      warmupGenerations: 1440,
+    });
+    addTag(immigrant, CURRENT_GENERATION_TAG, "500");
+
+    const options: NeatOptions = {
+      populationSize: 5,
+      creatures: [immigrant.exportJSON()],
+    };
+    const neat = new Neat(3, 2, options, workers);
+
+    // Graduated loaded champion: no warmupGenerations tag at all.
+    const seedCreature = new Creature(3, 2, { layers: [{ count: 3 }] });
+
+    await neat.populatePopulation(seedCreature);
+
+    assertEquals(
+      neat.warmupGenerations,
+      0,
+      "Loaded creature has graduated — warm-up stays off",
+    );
+    assertEquals(
+      neat.currentGeneration,
+      0,
+      "A warming immigrant must not seed currentGeneration once graduated",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});


### PR DESCRIPTION
# currentGeneration must always increase across machines (Issue #3138)

## Summary

`currentGeneration` is the lineage counter that gates the seed warm-up
structural lock (#2828). Across a teams run it was not climbing reliably, so
warm-up never completed across machines. The converged design — accumulate
(start + generations run), reconcile across machines by taking the **maximum**
at the population seed, gate on the **loaded** creature, and strip both tags
once warm — was largely already in place from #2908 / #2945 / #2909 / #2911.

The one remaining gap: `Neat.populatePopulation` seeded the counter
**unconditionally**. When the loaded champion had graduated (no
`warmupGenerations` tag), a still-warming immigrant in `config.creatures` could
still seed `currentGeneration` from its tag — violating the "**gate on the
loaded creature only**" rule.

The fix gates the population-max scan and counter seeding on the **loaded**
creature's `warmupGenerations` tag: once the loaded champion has graduated,
warm-up is off for the whole call and no immigrant can seed the counter. The
save boundary (`applySeedWarmupTagsAtSave`) already strips both tags in that
case, so the output emerges warm-up-free.

The cross-machine "take the maximum" and "start + N" accumulation paths were
verified by new regression tests and already passed — confirming those parts
were correct; only the graduated-gate test was red before this change.

Closes #3138.

## Evidence

Backend/engine change — no UI to screenshot. Verified by unit tests
(`deno test`) and the full `./quality.sh` gate (**7401 passed, 0 failed**).

The three concrete issue cases, exercised as "what" tests against
`populatePopulation`:

| Case | Setup | Expected | Result |
| --- | --- | --- | --- |
| Accumulate | loaded tag 10, run 50 generations | `currentGeneration == 60` | pass (already worked) |
| Cross-machine max | machine A tag 10, machine B tag 20 | seed `currentGeneration == 20` | pass (already worked) |
| Graduated gate | graduated seed + immigrant tag 500 | `currentGeneration == 0` | **red before fix → green after** |

```mermaid
flowchart TD
    A[populatePopulation: read loaded creature] --> B{warmupGenerations tag present?}
    B -- "no (graduated)" --> C[Skip population-max scan<br/>currentGeneration untouched]
    B -- "yes (warming)" --> D[Scan whole population for max currentGeneration]
    D --> E["currentGeneration = max(in-memory, seed, populationMax)"]
    C --> F[Save boundary strips both tags]
    E --> G[evolve: currentGeneration++ per generation]
    G --> H[Save boundary stamps currentGeneration = start + N]
```

## Test Plan

Added to `test/NEAT/NeatPopulatePopulation.ts`:

- `populatePopulation: start 10 + 50 generations accumulates to 60 (Issue #3138)`
  — start generation seeded from the tag, then 50 increments → 60.
- `populatePopulation: machine A (10) and machine B (20) take the maximum 20 (Issue #3138)`
  — two prior champions in `config.creatures`; the seed takes `max(10, 20)`.
- `populatePopulation: graduated seed ignores a warming immigrant's generation (Issue #3138)`
  — graduated loaded seed; a warming immigrant (tag 500) must **not** seed the
  counter (stays 0). This test was failing before the gate and passes after.

Existing warm-up tests (`SeedWarmupPersistence.ts`, the rest of
`NeatPopulatePopulation.ts`) remain green, confirming no regression to the
#2908 / #2945 / #2909 / #2911 behaviour.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqwf3729-843497`<!-- vibe-worker-issue-3138 -->