### PR TITLE
Replace magic UUID literal with WHAT-assertions (Issue #3143)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3143.md
+++ b/docs/archive/pr-summaries/pr-summary-3143.md
@@ -1,0 +1,63 @@
+# PR Summary — Issue #3143
+
+## Summary
+
+`test/creature/CreatureUUID.ts` pinned the output of
+`CreatureUtil.makeUUID(clean)` to the hard-coded literal
+`6c65e71e-a5c6-5e46-8abb-06f991c79c63`, with a comment admitting the value was
+implementation-derived and had to be hand-edited *"when export identity /
+makeUUID canonicalisation changes"*. That is a magic-value "how" test: it
+asserts the answer the current code happens to produce rather than the answer
+the spec requires, so any legitimate change to the UUID derivation forces a
+manual rewrite of the constant instead of surfacing a real regression.
+
+This change applies resolution (a) from the issue — rewrite the assertion to
+the durable **WHAT** properties:
+
+1. `makeUUID` returns a well-formed **RFC-4122 v5** UUID (version nibble `5`,
+   RFC-4122 variant nibble `8`/`9`/`a`/`b`).
+2. That UUID is **stable across reconstruction** of the same canonical
+   structure — `makeUUID(fromJSON(export))` round-trips. `exportJSON()` omits
+   the top-level `uuid`, so the round-trip genuinely re-derives the value from
+   the wire structure rather than echoing a carried field.
+
+These are properties any refactor of the canonicalisation must preserve, so the
+test now catches real regressions without obstructing future changes. The
+relational determinism/order-independence checks already present in the file
+(`assertEquals(uuid2, uuid1)`, `assertEquals(uuid3, uuid1)`, `assertNotEquals`
+and the `ignoreOrderUUID` test) are untouched.
+
+Closes #3143.
+
+## Evidence
+
+Backend/test-only change — no UI to screenshot. Verified via the test runner.
+
+Targeted run (`deno test test/creature/CreatureUUID.ts`):
+
+```
+running 5 tests from ./test/creature/CreatureUUID.ts
+knownName ... ok
+ignoreTags ... ok
+keepUUID ... ok
+generateUUID ... ok
+ignoreOrderUUID ... ok
+ok | 5 passed | 0 failed
+```
+
+Full quality gate (`./quality.sh`): `ok | 7365 passed (2 steps) | 0 failed | 4 ignored`.
+
+```mermaid
+flowchart LR
+    A[magic literal pin<br/>uuid2 === '6c65...c63'] -->|Issue #3143| B[WHAT assertions]
+    B --> C[RFC-4122 v5 format]
+    B --> D[stable across<br/>export/import round-trip]
+```
+
+## Test Plan
+
+- Modified `test/creature/CreatureUUID.ts::ignoreTags`: replaced the
+  hard-coded UUID `assert` with an RFC-4122 v5 format assertion plus an
+  export/import round-trip stability `assertEquals`.
+- No existing tests removed or commented out; the surrounding relational
+  assertions remain in place.

--- a/test/creature/CreatureUUID.ts
+++ b/test/creature/CreatureUUID.ts
@@ -136,13 +136,31 @@ Deno.test("ignoreTags", () => {
   assertEquals(uuid3, uuid1, "Alive creature should match was: " + uuid3);
 
   /**
-   * Manually update when export identity / makeUUID canonicalisation changes.
-   * Issue #2308: Updated after switching makeUUID to direct string construction
-   * (avoiding the expensive exportJSON() path).
+   * Issue #3143: Assert the durable WHAT properties instead of pinning the
+   * opaque literal `makeUUID` happened to produce. The previous magic-value
+   * assertion had to be hand-edited whenever the canonicalisation changed
+   * (see Issue #2308), so it obstructed refactoring rather than catching real
+   * regressions. The spec-level guarantees are: `makeUUID` returns a
+   * well-formed RFC-4122 v5 UUID, and that UUID is stable across an
+   * export/import reconstruction of the same canonical structure.
    */
+  const rfc4122v5 =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
   assert(
-    uuid2 === "6c65e71e-a5c6-5e46-8abb-06f991c79c63",
-    "Wrong UUID was: " + uuid2,
+    rfc4122v5.test(uuid2),
+    "makeUUID should return a well-formed RFC-4122 v5 UUID, was: " + uuid2,
+  );
+
+  // Stable across reconstruction: exportJSON() omits the top-level uuid, so
+  // makeUUID re-derives the value from the wire structure. A refactor of the
+  // canonicalisation must keep this round-trip identity intact.
+  const roundTripUUID = CreatureUtil.makeUUID(
+    Creature.fromJSON(alive.exportJSON()),
+  );
+  assertEquals(
+    roundTripUUID,
+    uuid2,
+    `UUID should be stable across reconstruction: ${roundTripUUID} vs ${uuid2}`,
   );
 });
 


### PR DESCRIPTION
# PR Summary — Issue #3143

## Summary

`test/creature/CreatureUUID.ts` pinned the output of
`CreatureUtil.makeUUID(clean)` to the hard-coded literal
`6c65e71e-a5c6-5e46-8abb-06f991c79c63`, with a comment admitting the value was
implementation-derived and had to be hand-edited *"when export identity /
makeUUID canonicalisation changes"*. That is a magic-value "how" test: it
asserts the answer the current code happens to produce rather than the answer
the spec requires, so any legitimate change to the UUID derivation forces a
manual rewrite of the constant instead of surfacing a real regression.

This change applies resolution (a) from the issue — rewrite the assertion to
the durable **WHAT** properties:

1. `makeUUID` returns a well-formed **RFC-4122 v5** UUID (version nibble `5`,
   RFC-4122 variant nibble `8`/`9`/`a`/`b`).
2. That UUID is **stable across reconstruction** of the same canonical
   structure — `makeUUID(fromJSON(export))` round-trips. `exportJSON()` omits
   the top-level `uuid`, so the round-trip genuinely re-derives the value from
   the wire structure rather than echoing a carried field.

These are properties any refactor of the canonicalisation must preserve, so the
test now catches real regressions without obstructing future changes. The
relational determinism/order-independence checks already present in the file
(`assertEquals(uuid2, uuid1)`, `assertEquals(uuid3, uuid1)`, `assertNotEquals`
and the `ignoreOrderUUID` test) are untouched.

Closes #3143.

## Evidence

Backend/test-only change — no UI to screenshot. Verified via the test runner.

Targeted run (`deno test test/creature/CreatureUUID.ts`):

```
running 5 tests from ./test/creature/CreatureUUID.ts
knownName ... ok
ignoreTags ... ok
keepUUID ... ok
generateUUID ... ok
ignoreOrderUUID ... ok
ok | 5 passed | 0 failed
```

Full quality gate (`./quality.sh`): `ok | 7365 passed (2 steps) | 0 failed | 4 ignored`.

```mermaid
flowchart LR
    A[magic literal pin<br/>uuid2 === '6c65...c63'] -->|Issue #3143| B[WHAT assertions]
    B --> C[RFC-4122 v5 format]
    B --> D[stable across<br/>export/import round-trip]
```

## Test Plan

- Modified `test/creature/CreatureUUID.ts::ignoreTags`: replaced the
  hard-coded UUID `assert` with an RFC-4122 v5 format assertion plus an
  export/import round-trip stability `assertEquals`.
- No existing tests removed or commented out; the surrounding relational
  assertions remain in place.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqzteljh-e94294`<!-- vibe-worker-issue-3143 -->