### PR TITLE
Replace magic activation floats in CRISPR DNA-SANE tests (Issue #3144)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3144.md
+++ b/docs/archive/pr-summaries/pr-summary-3144.md
@@ -1,0 +1,77 @@
+# PR Summary — Issue #3144
+
+## Summary
+
+The two CRISPR DNA-SANE rewrite tests in `test/CRISPR/CRISPR.ts`
+(`CRISPR-multi-outputs1` and `CRISPR-multi-outputs2`) ended with six
+full-precision activation floats pasted verbatim from a run, e.g.
+`assertAlmostEquals(out[0], 0.024987129494547844, 1e-5)`. These are the
+hard-coded-magic-value anti-pattern: they assert whatever the activation
+engine *happens to emit* rather than the behaviour the spec requires, so a
+behaviour-preserving backend switch (WASM, future GPU) or a forward-pass
+reorder forces a regenerate-the-constants edit even when the documented
+MIN/MEAN/MAX contract is unchanged — masking real regressions.
+
+This change rewrites the six float assertions to track the spec relationship
+(resolution **(a)** from the issue). DNA-SANE appends three outputs —
+`MINIMUM`, `MEAN`, `MAXIMUM` — each wired to the three previous outputs, which
+CRISPR demotes to hidden. Demotion preserves a neuron's wiring, bias and squash,
+so the demoted outputs compute exactly what the **pre-CRISPR** network's outputs
+compute for the same input. A fresh copy of the original network therefore gives
+a spec-derived oracle (`demoted`), and the new `assertSaneAggregation` helper
+asserts:
+
+- `out[0] == Math.min(...demoted) + biasₘᵢₙ`
+- `out[1] == mean(demoted) + biasₘₑₐₙ`
+- `out[2] == Math.max(...demoted) + biasₘₐₓ`
+
+Because the oracle is derived from the values the network actually computes,
+the assertion tracks the MIN/MEAN/MAX behaviour and tolerates last-digit float
+drift, while still catching a genuine aggregation regression. The strong
+structural assertions already in each test (output count, output squashes,
+synapse counts, tag counts) are untouched.
+
+Closes #3144.
+
+## Evidence
+
+Backend/test-only change — no UI. Verified by running the affected test file:
+
+```
+deno test --allow-all test/CRISPR/CRISPR.ts
+...
+CRISPR-multi-outputs1 ... ok
+CRISPR-multi-outputs2 ... ok
+ok | 7 passed | 0 failed
+```
+
+Confirmed the spec relationship matches the previously-frozen floats within
+the assertion tolerance (max observed delta ≈ 1.7e-8, well under `1e-6`):
+
+| output | frozen float (old) | spec oracle (min/mean/max + bias) |
+| ------ | ------------------ | --------------------------------- |
+| out[0] | 0.024987129494547844 | 0.024987129324674607 |
+| out[1] | 0.3913297653198242 | 0.3913297690451145 |
+| out[2] | 0.5962033867835999 | 0.5962033701896667 |
+
+Repo-wide `deno lint` (1740 files) and `deno check` both pass.
+
+```mermaid
+flowchart LR
+    O[Pre-CRISPR network outputs] -- demotion preserves wiring --> D[Demoted outputs d0,d1,d2]
+    D --> MIN["MINIMUM = min(d)+bias"]
+    D --> MEAN["MEAN = mean(d)+bias"]
+    D --> MAX["MAXIMUM = max(d)+bias"]
+    MIN --> A[assertSaneAggregation]
+    MEAN --> A
+    MAX --> A
+```
+
+## Test Plan
+
+- Rewrote `test/CRISPR/CRISPR.ts::CRISPR-multi-outputs1` and
+  `CRISPR-multi-outputs2` to assert the MIN/MEAN/MAX aggregation contract via
+  the new `assertSaneAggregation` helper instead of six frozen floats.
+- `deno test --allow-all test/CRISPR/CRISPR.ts` — 7 passed, 0 failed.
+- `deno fmt`, `deno lint`, `deno check` clean on the changed file; repo-wide
+  lint and type-check pass.

--- a/test/CRISPR/CRISPR.ts
+++ b/test/CRISPR/CRISPR.ts
@@ -46,6 +46,58 @@ function sampleInput(size: number): Float32Array {
   return Float32Array.from({ length: size }, (_, i) => ((i % 7) - 3) / 10);
 }
 
+/**
+ * Assert the DNA-SANE aggregation contract (Issue #3144).
+ *
+ * The rewrite appends three outputs — MINIMUM, MEAN, MAXIMUM — each wired to
+ * the three previous outputs (now demoted to hidden). Demotion preserves a
+ * neuron's wiring, bias and squash, so the demoted outputs compute exactly what
+ * the *original* network's outputs computed for the same input. That gives us a
+ * spec-derived oracle (`demoted`) for the appended outputs.
+ *
+ * Rather than pinning opaque activation floats pasted from a run — which drift
+ * when the activation backend changes even though the MIN/MEAN/MAX behaviour is
+ * unchanged — assert the relationship directly: out[0] is the minimum of the
+ * demoted outputs, out[1] their mean, out[2] their maximum, each offset by the
+ * appended output's own bias.
+ */
+function assertSaneAggregation(
+  creature: Creature,
+  out: Float32Array,
+  demoted: Float32Array,
+): void {
+  const outputs = creature.neurons.filter((neuron) => neuron.type === "output");
+  assertEquals(
+    outputs.map((neuron) => neuron.squash ?? ""),
+    ["MINIMUM", "MEAN", "MAXIMUM"],
+    "appended outputs use the MIN/MEAN/MAX squashes in order",
+  );
+
+  const demotedValues = Array.from(demoted);
+  assertEquals(demotedValues.length, 3, "three demoted outputs aggregated");
+  const mean = demotedValues.reduce((sum, value) => sum + value, 0) /
+    demotedValues.length;
+
+  assertAlmostEquals(
+    out[0],
+    Math.min(...demotedValues) + outputs[0].bias,
+    1e-6,
+    "MINIMUM output equals the smallest demoted output (plus its bias)",
+  );
+  assertAlmostEquals(
+    out[1],
+    mean + outputs[1].bias,
+    1e-6,
+    "MEAN output equals the mean of the demoted outputs (plus its bias)",
+  );
+  assertAlmostEquals(
+    out[2],
+    Math.max(...demotedValues) + outputs[2].bias,
+    1e-6,
+    "MAXIMUM output equals the largest demoted output (plus its bias)",
+  );
+}
+
 function loadNetwork(): Creature {
   return Creature.fromJSON(
     JSON.parse(Deno.readTextFileSync("test/data/CRISPR/network.json")),
@@ -282,12 +334,15 @@ Deno.test("CRISPR-multi-outputs1", () => {
   assertEquals(taggedNeuronCount(networkSANE, "Sane Output"), 3);
   assertEquals(taggedSynapseCount(networkSANE, "Sane Output"), 9);
 
-  // The transformed network computes deterministic outputs for a fixed input.
-  const out = networkSANE.activate(new Float32Array([0.1, 0.2, 0.3]));
+  // The transformed network honours the MIN/MEAN/MAX aggregation contract over
+  // the demoted outputs for a fixed input (Issue #3144). A fresh copy of the
+  // pre-CRISPR network yields the demoted-output values (demotion preserves
+  // their wiring), giving a spec-derived oracle rather than frozen floats.
+  const fixedInput = new Float32Array([0.1, 0.2, 0.3]);
+  const demoted = Creature.fromJSON(json).activate(fixedInput);
+  const out = networkSANE.activate(fixedInput);
   assertEquals(out.length, 3);
-  assertAlmostEquals(out[0], 0.024987129494547844, 1e-5);
-  assertAlmostEquals(out[1], 0.3913297653198242, 1e-5);
-  assertAlmostEquals(out[2], 0.5962033867835999, 1e-5);
+  assertSaneAggregation(networkSANE, out, demoted);
 });
 
 Deno.test("CRISPR-multi-outputs2", () => {
@@ -353,11 +408,13 @@ Deno.test("CRISPR-multi-outputs2", () => {
   assertEquals(taggedNeuronCount(networkSANE, "Sane Output"), 3);
   assertEquals(taggedSynapseCount(networkSANE, "Sane Output"), 9);
 
-  const out = networkSANE.activate(new Float32Array([0.1, 0.2, 0.3]));
+  // Same MIN/MEAN/MAX aggregation contract over the demoted outputs (Issue
+  // #3144); the pre-CRISPR network supplies the demoted-output oracle.
+  const fixedInput = new Float32Array([0.1, 0.2, 0.3]);
+  const demoted = Creature.fromJSON(json).activate(fixedInput);
+  const out = networkSANE.activate(fixedInput);
   assertEquals(out.length, 3);
-  assertAlmostEquals(out[0], 0.05990000069141388, 1e-5);
-  assertAlmostEquals(out[1], 0.22394384443759918, 1e-5);
-  assertAlmostEquals(out[2], 0.530064046382904, 1e-5);
+  assertSaneAggregation(networkSANE, out, demoted);
 });
 
 Deno.test("CRISPR-uuid", () => {


### PR DESCRIPTION
# PR Summary — Issue #3144

## Summary

The two CRISPR DNA-SANE rewrite tests in `test/CRISPR/CRISPR.ts`
(`CRISPR-multi-outputs1` and `CRISPR-multi-outputs2`) ended with six
full-precision activation floats pasted verbatim from a run, e.g.
`assertAlmostEquals(out[0], 0.024987129494547844, 1e-5)`. These are the
hard-coded-magic-value anti-pattern: they assert whatever the activation
engine *happens to emit* rather than the behaviour the spec requires, so a
behaviour-preserving backend switch (WASM, future GPU) or a forward-pass
reorder forces a regenerate-the-constants edit even when the documented
MIN/MEAN/MAX contract is unchanged — masking real regressions.

This change rewrites the six float assertions to track the spec relationship
(resolution **(a)** from the issue). DNA-SANE appends three outputs —
`MINIMUM`, `MEAN`, `MAXIMUM` — each wired to the three previous outputs, which
CRISPR demotes to hidden. Demotion preserves a neuron's wiring, bias and squash,
so the demoted outputs compute exactly what the **pre-CRISPR** network's outputs
compute for the same input. A fresh copy of the original network therefore gives
a spec-derived oracle (`demoted`), and the new `assertSaneAggregation` helper
asserts:

- `out[0] == Math.min(...demoted) + biasₘᵢₙ`
- `out[1] == mean(demoted) + biasₘₑₐₙ`
- `out[2] == Math.max(...demoted) + biasₘₐₓ`

Because the oracle is derived from the values the network actually computes,
the assertion tracks the MIN/MEAN/MAX behaviour and tolerates last-digit float
drift, while still catching a genuine aggregation regression. The strong
structural assertions already in each test (output count, output squashes,
synapse counts, tag counts) are untouched.

Closes #3144.

## Evidence

Backend/test-only change — no UI. Verified by running the affected test file:

```
deno test --allow-all test/CRISPR/CRISPR.ts
...
CRISPR-multi-outputs1 ... ok
CRISPR-multi-outputs2 ... ok
ok | 7 passed | 0 failed
```

Confirmed the spec relationship matches the previously-frozen floats within
the assertion tolerance (max observed delta ≈ 1.7e-8, well under `1e-6`):

| output | frozen float (old) | spec oracle (min/mean/max + bias) |
| ------ | ------------------ | --------------------------------- |
| out[0] | 0.024987129494547844 | 0.024987129324674607 |
| out[1] | 0.3913297653198242 | 0.3913297690451145 |
| out[2] | 0.5962033867835999 | 0.5962033701896667 |

Repo-wide `deno lint` (1740 files) and `deno check` both pass.

```mermaid
flowchart LR
    O[Pre-CRISPR network outputs] -- demotion preserves wiring --> D[Demoted outputs d0,d1,d2]
    D --> MIN["MINIMUM = min(d)+bias"]
    D --> MEAN["MEAN = mean(d)+bias"]
    D --> MAX["MAXIMUM = max(d)+bias"]
    MIN --> A[assertSaneAggregation]
    MEAN --> A
    MAX --> A
```

## Test Plan

- Rewrote `test/CRISPR/CRISPR.ts::CRISPR-multi-outputs1` and
  `CRISPR-multi-outputs2` to assert the MIN/MEAN/MAX aggregation contract via
  the new `assertSaneAggregation` helper instead of six frozen floats.
- `deno test --allow-all test/CRISPR/CRISPR.ts` — 7 passed, 0 failed.
- `deno fmt`, `deno lint`, `deno check` clean on the changed file; repo-wide
  lint and type-check pass.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqzteljh-e94294`<!-- vibe-worker-issue-3144 -->