### PR TITLE
Test: derive post-fine-tune output bias from shared parent value (#3145)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3145.md
+++ b/docs/archive/pr-summaries/pr-summary-3145.md
@@ -1,0 +1,63 @@
+# Remove magic post-fine-tune bias value in FineTuneUUID test
+
+## Summary
+
+`test/blackbox/FineTuneUUID.ts` asserted the post-fine-tune output-neuron bias
+against a pasted full-precision literal (`-0.49135010426905`) with no
+derivation — the hard-coded-magic-value anti-pattern (check 5). A refactor of
+the fine-tune blend that preserved its observable contract but computed
+intermediate values differently would break the assertion even though behaviour
+was unchanged.
+
+Crucially, that literal is **already the output bias of both parents** in the
+test fixtures (the `previousFittest` and `fittest` creatures share it). Because
+the fine-tune step blends the current fittest *towards* the previous fittest,
+when both parents agree on a value the blend has nothing to move towards and
+must conserve it. The assertion is therefore a **preservation** property, not an
+opaque intermediate.
+
+This PR makes that explicit and removes the magic value:
+
+- Introduced a single source-of-truth constant `SHARED_OUTPUT_BIAS`, documented
+  with the preservation rationale.
+- Both parent fixtures and the line-180 assertion now reference that constant
+  instead of repeating the literal — so the assertion is **derived**, not pasted.
+
+The assertion now verifies the WHAT (a value both parents agree on is preserved
+by fine-tuning) and survives any behaviour-preserving refactor of the blend.
+This follows resolution (a) from the issue.
+
+Closes #3145.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+```mermaid
+flowchart LR
+    P[Both parents share<br/>output bias] --> B[Fine-tune blend:<br/>nothing to move towards]
+    B --> C[Value conserved]
+    C --> A[Assert == SHARED_OUTPUT_BIAS]
+```
+
+Test run after the change:
+
+```
+running 1 test from ./test/blackbox/FineTuneUUID.ts
+tune ... ok (50ms)
+ok | 1 passed | 0 failed
+```
+
+`deno fmt`, `deno lint`, and project-wide `deno check` (`./quality.sh
+--check-only`) all pass.
+
+## Test Plan
+
+- Modified `test/blackbox/FineTuneUUID.ts::tune`:
+  - Replaced the pasted bias literal at the line-180 assertion with the derived
+    `SHARED_OUTPUT_BIAS` constant, documenting the preservation contract.
+  - Both parent output-neuron fixtures now reference the same constant, giving a
+    single source of truth.
+- No business logic changed; no existing test removed or commented out. The test
+  still verifies the same observable behaviour (bias preserved, input weights
+  preserved, `0.32` bias changed, ten creatures produced).

--- a/test/blackbox/FineTuneUUID.ts
+++ b/test/blackbox/FineTuneUUID.ts
@@ -4,6 +4,14 @@ import { fineTuneImprovement } from "@blackbox/FineTune.ts";
 
 ((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
 
+// Both parents share the same output-neuron bias below. Fine-tuning blends the
+// current fittest towards the previous fittest, so when the two parents already
+// agree on a value the blend has nothing to move towards and must conserve it.
+// Deriving the expectation from this single constant (rather than pasting the
+// algorithm's emitted number) keeps the assertion a WHAT-test: it verifies the
+// preservation contract, not an opaque intermediate of today's blend.
+const SHARED_OUTPUT_BIAS = -0.49135010426905;
+
 Deno.test("tune", () => {
   const previousFittest: Creature = Creature.fromJSON({
     neurons: [
@@ -34,7 +42,7 @@ Deno.test("tune", () => {
       {
         type: "output",
         uuid: "output-0",
-        bias: -0.49135010426905,
+        bias: SHARED_OUTPUT_BIAS,
         squash: "BIPOLAR_SIGMOID",
       },
     ],
@@ -112,7 +120,7 @@ Deno.test("tune", () => {
       {
         type: "output",
         uuid: "output-0",
-        bias: -0.49135010426905,
+        bias: SHARED_OUTPUT_BIAS,
         squash: "BIPOLAR_SIGMOID",
       },
     ],
@@ -175,9 +183,12 @@ Deno.test("tune", () => {
       }
 
       if (node.id === -1) {
+        // Preservation: both parents agreed on this output bias, so the
+        // fine-tune blend must conserve it. Derived from the shared fixture
+        // constant rather than the algorithm's emitted value.
         assertAlmostEquals(
           node.bias,
-          -0.49135010426905,
+          SHARED_OUTPUT_BIAS,
           0.0000001,
           n.uuid,
         );


### PR DESCRIPTION
# Remove magic post-fine-tune bias value in FineTuneUUID test

## Summary

`test/blackbox/FineTuneUUID.ts` asserted the post-fine-tune output-neuron bias
against a pasted full-precision literal (`-0.49135010426905`) with no
derivation — the hard-coded-magic-value anti-pattern (check 5). A refactor of
the fine-tune blend that preserved its observable contract but computed
intermediate values differently would break the assertion even though behaviour
was unchanged.

Crucially, that literal is **already the output bias of both parents** in the
test fixtures (the `previousFittest` and `fittest` creatures share it). Because
the fine-tune step blends the current fittest *towards* the previous fittest,
when both parents agree on a value the blend has nothing to move towards and
must conserve it. The assertion is therefore a **preservation** property, not an
opaque intermediate.

This PR makes that explicit and removes the magic value:

- Introduced a single source-of-truth constant `SHARED_OUTPUT_BIAS`, documented
  with the preservation rationale.
- Both parent fixtures and the line-180 assertion now reference that constant
  instead of repeating the literal — so the assertion is **derived**, not pasted.

The assertion now verifies the WHAT (a value both parents agree on is preserved
by fine-tuning) and survives any behaviour-preserving refactor of the blend.
This follows resolution (a) from the issue.

Closes #3145.

## Evidence

Backend/test-only change — no web interface to screenshot.

```mermaid
flowchart LR
    P[Both parents share<br/>output bias] --> B[Fine-tune blend:<br/>nothing to move towards]
    B --> C[Value conserved]
    C --> A[Assert == SHARED_OUTPUT_BIAS]
```

Test run after the change:

```
running 1 test from ./test/blackbox/FineTuneUUID.ts
tune ... ok (50ms)
ok | 1 passed | 0 failed
```

`deno fmt`, `deno lint`, and project-wide `deno check` (`./quality.sh
--check-only`) all pass.

## Test Plan

- Modified `test/blackbox/FineTuneUUID.ts::tune`:
  - Replaced the pasted bias literal at the line-180 assertion with the derived
    `SHARED_OUTPUT_BIAS` constant, documenting the preservation contract.
  - Both parent output-neuron fixtures now reference the same constant, giving a
    single source of truth.
- No business logic changed; no existing test removed or commented out. The test
  still verifies the same observable behaviour (bias preserved, input weights
  preserved, `0.32` bias changed, ten creatures produced).



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqzvc675-02da61`<!-- vibe-worker-issue-3145 -->