### PR TITLE
Remove unused export DEFAULT_MIN_COHORT_SIZE (Issue #3148)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3148.md
+++ b/docs/archive/pr-summaries/pr-summary-3148.md
@@ -1,0 +1,38 @@
+# Remove unused export `DEFAULT_MIN_COHORT_SIZE`
+
+## Summary
+
+Removed the dead exported constant `DEFAULT_MIN_COHORT_SIZE = 4` from
+`src/NEAT/GroupRelativeAdvantage.ts`. A whole-repository word-boundary search
+confirmed the symbol had exactly one occurrence — its own declaration. It was
+never imported, never re-exported from `mod.ts`, and the `AdvantageOptions`
+interface has no `minCohortSize?` field for it to back, so the default had
+nothing to default. Its siblings `DEFAULT_ADVANTAGE_EPS` and
+`DEFAULT_ADVANTAGE_CLIP` remain (they are consumed by `eps?` / `clip?`).
+
+Closes #3148.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+Verification performed:
+
+- `git grep -n "DEFAULT_MIN_COHORT_SIZE"` before the change returned a single
+  hit (the declaration); after removal it returns none.
+- `./quality.sh` passes cleanly (`EXIT=0`, `7366 passed | 0 failed`), confirming
+  the type-checker found no dangling reference to the removed symbol.
+
+```mermaid
+flowchart LR
+    A["export const DEFAULT_MIN_COHORT_SIZE = 4"] -->|"0 importers, no minCohortSize option"| B["dead code"]
+    B --> C["removed"]
+```
+
+## Test Plan
+
+- Added `test/NEAT/GroupRelativeAdvantage.ts` regression test
+  "GRPO advantage: DEFAULT_MIN_COHORT_SIZE is not part of the module surface
+  (Issue #3148)" — imports the module namespace and asserts the key is absent.
+- Existing `test/NEAT/GroupRelativeAdvantage.ts` suite (15 tests) continues to
+  pass, confirming the surviving exports and behaviour are unchanged.

--- a/src/NEAT/GroupRelativeAdvantage.ts
+++ b/src/NEAT/GroupRelativeAdvantage.ts
@@ -28,7 +28,6 @@
 /** Defaults for the group-relative advantage transform. */
 export const DEFAULT_ADVANTAGE_EPS = 1e-8;
 export const DEFAULT_ADVANTAGE_CLIP = 10;
-export const DEFAULT_MIN_COHORT_SIZE = 4;
 
 /** Options for {@link computeGroupRelativeAdvantages}. */
 export interface AdvantageOptions {

--- a/test/NEAT/GroupRelativeAdvantage.ts
+++ b/test/NEAT/GroupRelativeAdvantage.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_ADVANTAGE_EPS,
   normaliseDeltaWithCohortStd,
 } from "@neat/GroupRelativeAdvantage.ts";
+import * as advantageModule from "@neat/GroupRelativeAdvantage.ts";
 
 Deno.test("GRPO advantage: signs match expected ordering for a known cohort", () => {
   // Cohort mean = 3, so 1 and 2 are below average, 4 and 5 above.
@@ -86,6 +87,17 @@ Deno.test("GRPO advantage: default clip is ±10", () => {
   assertEquals(DEFAULT_ADVANTAGE_CLIP, 10);
   assert(DEFAULT_ADVANTAGE_EPS > 0 && DEFAULT_ADVANTAGE_EPS < 1e-3);
 });
+
+Deno.test(
+  "GRPO advantage: DEFAULT_MIN_COHORT_SIZE is not part of the module surface (Issue #3148)",
+  () => {
+    // The unused export was removed; nothing wires a min-cohort default in.
+    assert(
+      !("DEFAULT_MIN_COHORT_SIZE" in advantageModule),
+      "DEFAULT_MIN_COHORT_SIZE must not be exported — it had no consumer",
+    );
+  },
+);
 
 Deno.test("computeAdvantageStats: skips non-finite entries", () => {
   const stats = computeAdvantageStats([1, NaN, 3, Infinity, 5]);


### PR DESCRIPTION
# Remove unused export `DEFAULT_MIN_COHORT_SIZE`

## Summary

Removed the dead exported constant `DEFAULT_MIN_COHORT_SIZE = 4` from
`src/NEAT/GroupRelativeAdvantage.ts`. A whole-repository word-boundary search
confirmed the symbol had exactly one occurrence — its own declaration. It was
never imported, never re-exported from `mod.ts`, and the `AdvantageOptions`
interface has no `minCohortSize?` field for it to back, so the default had
nothing to default. Its siblings `DEFAULT_ADVANTAGE_EPS` and
`DEFAULT_ADVANTAGE_CLIP` remain (they are consumed by `eps?` / `clip?`).

Closes #3148.

## Evidence

Backend/library change only — no web interface to screenshot.

Verification performed:

- `git grep -n "DEFAULT_MIN_COHORT_SIZE"` before the change returned a single
  hit (the declaration); after removal it returns none.
- `./quality.sh` passes cleanly (`EXIT=0`, `7366 passed | 0 failed`), confirming
  the type-checker found no dangling reference to the removed symbol.

```mermaid
flowchart LR
    A["export const DEFAULT_MIN_COHORT_SIZE = 4"] -->|"0 importers, no minCohortSize option"| B["dead code"]
    B --> C["removed"]
```

## Test Plan

- Added `test/NEAT/GroupRelativeAdvantage.ts` regression test
  "GRPO advantage: DEFAULT_MIN_COHORT_SIZE is not part of the module surface
  (Issue #3148)" — imports the module namespace and asserts the key is absent.
- Existing `test/NEAT/GroupRelativeAdvantage.ts` suite (15 tests) continues to
  pass, confirming the surviving exports and behaviour are unchanged.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqzyx4jz-67a7af`<!-- vibe-worker-issue-3148 -->