### PR TITLE
De-export module-private msOrZero helper (Issue #3149)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3149.md
+++ b/docs/archive/pr-summaries/pr-summary-3149.md
@@ -1,0 +1,42 @@
+## Summary
+
+Removed the unused `export` from the `msOrZero` helper in
+`src/architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts`. A
+whole-repository word-boundary search confirmed `msOrZero` is referenced only
+inside its own module (its definition plus one internal call from
+`formatDiscoveryPerformanceSummary`) — no other `src/` module, test, or bench
+imports it, and it is not re-exported from any barrel. The `export` keyword
+therefore exposed a symbol nothing outside the file consumed.
+
+The safe change is to drop only the `export` keyword, keeping the function as a
+module-private helper. The function body is unchanged, so behaviour is
+identical. Closes #3149.
+
+```mermaid
+flowchart LR
+    A["formatDiscoveryPerformanceSummary()"] -->|calls| B["msOrZero()<br/>(module-private)"]
+    X["other modules / tests / bench"] -. no importer .-> B
+```
+
+## Evidence
+
+Backend/library change with no web interface to screenshot. Verified via the
+quality gate and the targeted test file:
+
+- `deno test test/discovery/DiscoveryPerformanceSummary.ts` → `2 passed`.
+- `./quality.sh` → `7367 passed | 0 failed | 4 ignored` (lint, format,
+  type-check, WASM sync, full test suite).
+- Confirmed no remaining importer: `grep -rn '\bmsOrZero\b' src test bench mod.ts`
+  matches only the definition and the single internal call, both inside
+  `DiscoveryPerformance.ts`.
+
+## Test Plan
+
+- Added `test/discovery/DiscoveryPerformanceSummary.ts` →
+  "Discovery performance summary clamps non-finite total times to zero
+  (Issue #3149)": feeds non-finite `recordPhaseTime` / `analysisPhaseTime` /
+  `totalTime` through the public `formatDiscoveryPerformanceSummary` and asserts
+  no `Infinity`/`NaN` leaks into the rendered output and each total renders as
+  the zero-duration form. This locks in the clamping behaviour `msOrZero`
+  provides now that the helper is module-private.
+- Existing "omits unrecorded (zero) phase timings" test continues to pass.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts
@@ -18,8 +18,11 @@ export const shouldLogDiscovery = (config: NeatConfig): boolean =>
 
 /**
  * Clamps non-finite values to zero for safe formatting.
+ *
+ * Module-private helper (Issue #3149): only consumed internally by
+ * `formatDiscoveryPerformanceSummary`; nothing outside this file imports it.
  */
-export function msOrZero(ms: number): number {
+function msOrZero(ms: number): number {
   return Number.isFinite(ms) ? ms : 0;
 }
 

--- a/test/discovery/DiscoveryPerformanceSummary.ts
+++ b/test/discovery/DiscoveryPerformanceSummary.ts
@@ -76,3 +76,61 @@ Deno.test("Discovery performance summary omits unrecorded (zero) phase timings",
     `Expected 'Cleanup' to be omitted when unrecorded, got:\n${text}`,
   );
 });
+
+Deno.test("Discovery performance summary clamps non-finite total times to zero (Issue #3149)", () => {
+  // The module-private `msOrZero` helper guards the "Total ... phase" / "Total
+  // time" lines against non-finite inputs (NaN / Infinity). Exercise it through
+  // the public formatter so the clamping survives even though the helper is no
+  // longer exported.
+  const text = formatDiscoveryPerformanceSummary(
+    "feedface",
+    {
+      // Record phase — non-finite total
+      recordsProcessed: 1,
+      filesProcessed: 1,
+      initializationTime: 0,
+      fileProcessingTime: 0,
+      promiseWaitTime: 0,
+      recordPhaseTime: Number.POSITIVE_INFINITY,
+
+      // Analysis phase — NaN total
+      neuronsAnalyzed: 1,
+      retryAttempts: 0,
+      focusSelectionTime: 0,
+      rustCombinedAnalysisTime: 0,
+      neuronAnalysisTime: 0,
+      synapseAnalysisTime: 0,
+      harmfulSynapseAnalysisTime: 0,
+      harmfulNeuronAnalysisTime: 0,
+      squashAnalysisTime: 0,
+      analysisPhaseTime: Number.NaN,
+
+      // Candidate counts
+      helpfulSynapseCount: 0,
+      helpfulNeuronCount: 0,
+      coordinatedStructuralCount: 0,
+      harmfulSynapseCount: 0,
+      harmfulNeuronCount: 0,
+      squashCount: 0,
+      removalCount: 0,
+
+      // Overall — non-finite total
+      cleanupTime: 0,
+      totalTime: Number.NEGATIVE_INFINITY,
+    },
+    { colour: false },
+  );
+
+  // Non-finite values must never leak into the rendered summary.
+  assert(
+    !text.includes("Infinity") && !text.includes("NaN"),
+    `Expected non-finite times to be clamped, got:\n${text}`,
+  );
+
+  // Each clamped total renders as the zero-duration form rather than a blank or
+  // a garbage token.
+  const zeroDuration = "0d 0h 0m 0s 0ms 0µs 0ns";
+  assertStringIncludes(text, `Total record phase: ${zeroDuration}`);
+  assertStringIncludes(text, `Total analysis phase: ${zeroDuration}`);
+  assertStringIncludes(text, `Total time: ${zeroDuration}`);
+});


### PR DESCRIPTION
## Summary

Removed the unused `export` from the `msOrZero` helper in
`src/architecture/ErrorGuidedStructuralEvolution/DiscoveryPerformance.ts`. A
whole-repository word-boundary search confirmed `msOrZero` is referenced only
inside its own module (its definition plus one internal call from
`formatDiscoveryPerformanceSummary`) — no other `src/` module, test, or bench
imports it, and it is not re-exported from any barrel. The `export` keyword
therefore exposed a symbol nothing outside the file consumed.

The safe change is to drop only the `export` keyword, keeping the function as a
module-private helper. The function body is unchanged, so behaviour is
identical. Closes #3149.

```mermaid
flowchart LR
    A["formatDiscoveryPerformanceSummary()"] -->|calls| B["msOrZero()<br/>(module-private)"]
    X["other modules / tests / bench"] -. no importer .-> B
```

## Evidence

Backend/library change with no web interface to screenshot. Verified via the
quality gate and the targeted test file:

- `deno test test/discovery/DiscoveryPerformanceSummary.ts` → `2 passed`.
- `./quality.sh` → `7367 passed | 0 failed | 4 ignored` (lint, format,
  type-check, WASM sync, full test suite).
- Confirmed no remaining importer: `grep -rn '\bmsOrZero\b' src test bench mod.ts`
  matches only the definition and the single internal call, both inside
  `DiscoveryPerformance.ts`.

## Test Plan

- Added `test/discovery/DiscoveryPerformanceSummary.ts` →
  "Discovery performance summary clamps non-finite total times to zero
  (Issue #3149)": feeds non-finite `recordPhaseTime` / `analysisPhaseTime` /
  `totalTime` through the public `formatDiscoveryPerformanceSummary` and asserts
  no `Infinity`/`NaN` leaks into the rendered output and each total renders as
  the zero-duration form. This locks in the clamping behaviour `msOrZero`
  provides now that the helper is module-private.
- Existing "omits unrecorded (zero) phase timings" test continues to pass.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqzyx4jz-67a7af`<!-- vibe-worker-issue-3149 -->