### PR TITLE
De-export internal helper selectCombinationEmoji (Issue #3150)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3150.md
+++ b/docs/archive/pr-summaries/pr-summary-3150.md
@@ -1,0 +1,47 @@
+# PR Summary — Issue #3150
+
+## Summary
+
+`selectCombinationEmoji` in `src/discovery/CandidateDescriptions.ts` was
+declared `export` but had no importer anywhere in the repository — a
+whole-repo word-boundary search finds references only inside its own module,
+where `buildCombinationDescription` calls it once. It is not re-exported from
+`mod.ts` or any barrel, and no test imports it.
+
+This change drops the unused `export` keyword, keeping the function as a
+module-private helper. Behaviour is unchanged — the symbol is still live
+internally. Closes #3150.
+
+**Deno regression avoided:** verified and added coverage with native Deno
+tooling (`deno test`, `deno lint`, `deno check`) — no Node tooling introduced.
+
+## Evidence
+
+Backend-only change with no web interface to screenshot. Verified via tests
+and the project quality gate.
+
+- New test exercises the emoji-selection logic through the public
+  `buildCombinationDescription` API (the only consumer of the now-private
+  helper), so coverage survives the de-export and any future refactor.
+- `deno lint` and `deno check` are clean on both changed files.
+- The two failures observed during the full `quality.sh` run
+  (`VersionStartupLog.ts` and `DiscoveryTimeout.ts`) are pre-existing flakes
+  unrelated to this change — both pass cleanly when run in isolation (`9
+  passed | 0 failed`). They are timing/heap-pressure sensitive under the full
+  parallel suite and do not touch `discovery/CandidateDescriptions`.
+
+```mermaid
+flowchart LR
+    A[buildCombinationDescription<br/>exported public API] -->|calls internally| B[selectCombinationEmoji<br/>now module-private]
+    X[other src / test / mod.ts] -.->|no importers| B
+```
+
+## Test Plan
+
+Added `test/discovery/CandidateDescriptions.ts` (10 tests, all passing):
+
+- `shortID` happy path + short-id edge case.
+- `buildCombinationDescription` covering each emoji branch: 🏆 (3+ types),
+  🦋 (removal+addition), ⚡ (squash+removal), ✂️ (pure neuron removal),
+  🌱 (neurons+synapses), 🧬 (single add-neurons), single remove-synapse.
+- `describeSingleCoordinatedStructuralOperation` for `addNeuron`.

--- a/src/discovery/CandidateDescriptions.ts
+++ b/src/discovery/CandidateDescriptions.ts
@@ -80,8 +80,11 @@ export function describeSingleCoordinatedStructuralOperation(
 /**
  * Select an appropriate emoji for the combination based on change types.
  * Each combination category has a unique emoji to distinguish at a glance.
+ *
+ * Module-private helper: only consumed internally by
+ * `buildCombinationDescription` (Issue #3150 — dropped the unused `export`).
  */
-export function selectCombinationEmoji(types: string[]): string {
+function selectCombinationEmoji(types: string[]): string {
   const typeSet = new Set(types);
   const hasRemoval = typeSet.has("remove-low-impact") ||
     typeSet.has("remove-neuron") ||

--- a/test/discovery/CandidateDescriptions.ts
+++ b/test/discovery/CandidateDescriptions.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for CandidateDescriptions.
+ *
+ * Issue #3150: `selectCombinationEmoji` is a module-private helper (no longer
+ * exported). Its emoji-selection behaviour is verified here through the public
+ * `buildCombinationDescription` API, which prefixes every description with the
+ * emoji chosen for the supplied change types. Covers each combination category.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  buildCombinationDescription,
+  describeSingleCoordinatedStructuralOperation,
+  shortID,
+} from "@discovery/CandidateDescriptions.ts";
+
+Deno.test("shortID - truncates long UUID to last 8 chars", () => {
+  assertEquals(shortID("abcdef12-3456-7890-abcd-ef1234567890"), "34567890");
+});
+
+Deno.test("shortID - returns short ids unchanged", () => {
+  assertEquals(shortID("short"), "short");
+});
+
+Deno.test("buildCombinationDescription - 3+ types uses 🏆 emoji", () => {
+  const out = buildCombinationDescription(
+    ["add-neurons", "remove-neuron", "change-squash"],
+    3,
+    false,
+  );
+  assert(out.startsWith("🏆"), `expected 🏆 prefix, got: ${out}`);
+});
+
+Deno.test("buildCombinationDescription - removal + addition uses 🦋 emoji", () => {
+  const out = buildCombinationDescription(
+    ["remove-neuron", "add-neurons"],
+    2,
+    false,
+  );
+  assert(out.startsWith("🦋"), `expected 🦋 prefix, got: ${out}`);
+});
+
+Deno.test("buildCombinationDescription - squash + removal uses ⚡ emoji", () => {
+  const out = buildCombinationDescription(
+    ["change-squash", "remove-neuron"],
+    2,
+    false,
+  );
+  assert(out.startsWith("⚡"), `expected ⚡ prefix, got: ${out}`);
+});
+
+Deno.test("buildCombinationDescription - pure neuron removal uses ✂️ emoji", () => {
+  // Multi-type pure-removal combination (not a single remove-synapse type).
+  const out = buildCombinationDescription(
+    ["remove-neuron", "remove-low-impact"],
+    4,
+    true,
+  );
+  assert(out.startsWith("✂️"), `expected ✂️ prefix, got: ${out}`);
+  assertEquals(out, "✂️ Pruned 4 low-impact neurons");
+});
+
+Deno.test("buildCombinationDescription - neurons + synapses uses 🌱 emoji", () => {
+  const out = buildCombinationDescription(
+    ["add-neurons", "add-synapses"],
+    2,
+    false,
+  );
+  assert(out.startsWith("🌱"), `expected 🌱 prefix, got: ${out}`);
+});
+
+Deno.test("buildCombinationDescription - single add-neurons describes count", () => {
+  // Pure addition without paired synapses selects the 🧬 structural emoji.
+  assertEquals(
+    buildCombinationDescription(["add-neurons"], 3, false),
+    "🧬 Added 3 neurons",
+  );
+});
+
+Deno.test("buildCombinationDescription - single remove-synapse describes count", () => {
+  assertEquals(
+    buildCombinationDescription(["remove-synapse"], 5, true),
+    "✂️ Removed 5 synapses",
+  );
+});
+
+Deno.test("describeSingleCoordinatedStructuralOperation - addNeuron", () => {
+  const out = describeSingleCoordinatedStructuralOperation({
+    type: "addNeuron",
+    neuronUuid: "abcdef12-3456-7890-abcd-ef1234567890",
+    squash: "TANH",
+  } as never);
+  assertEquals(out, "💡 Added neuron 34567890 (TANH)");
+});


### PR DESCRIPTION
# PR Summary — Issue #3150

## Summary

`selectCombinationEmoji` in `src/discovery/CandidateDescriptions.ts` was
declared `export` but had no importer anywhere in the repository — a
whole-repo word-boundary search finds references only inside its own module,
where `buildCombinationDescription` calls it once. It is not re-exported from
`mod.ts` or any barrel, and no test imports it.

This change drops the unused `export` keyword, keeping the function as a
module-private helper. Behaviour is unchanged — the symbol is still live
internally. Closes #3150.

**Deno regression avoided:** verified and added coverage with native Deno
tooling (`deno test`, `deno lint`, `deno check`) — no Node tooling introduced.

## Evidence

Backend-only change with no web interface to screenshot. Verified via tests
and the project quality gate.

- New test exercises the emoji-selection logic through the public
  `buildCombinationDescription` API (the only consumer of the now-private
  helper), so coverage survives the de-export and any future refactor.
- `deno lint` and `deno check` are clean on both changed files.
- The two failures observed during the full `quality.sh` run
  (`VersionStartupLog.ts` and `DiscoveryTimeout.ts`) are pre-existing flakes
  unrelated to this change — both pass cleanly when run in isolation (`9
  passed | 0 failed`). They are timing/heap-pressure sensitive under the full
  parallel suite and do not touch `discovery/CandidateDescriptions`.

```mermaid
flowchart LR
    A[buildCombinationDescription<br/>exported public API] -->|calls internally| B[selectCombinationEmoji<br/>now module-private]
    X[other src / test / mod.ts] -.->|no importers| B
```

## Test Plan

Added `test/discovery/CandidateDescriptions.ts` (10 tests, all passing):

- `shortID` happy path + short-id edge case.
- `buildCombinationDescription` covering each emoji branch: 🏆 (3+ types),
  🦋 (removal+addition), ⚡ (squash+removal), ✂️ (pure neuron removal),
  🌱 (neurons+synapses), 🧬 (single add-neurons), single remove-synapse.
- `describeSingleCoordinatedStructuralOperation` for `addNeuron`.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr01nuy5-7e3692`<!-- vibe-worker-issue-3150 -->