### PR TITLE
CI: Extend coverage job timeout to an hour (#3168)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,7 +22,10 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Coverage runs the full suite under instrumentation and can exceed
+    # 30 minutes on a slow runner, failing PRs spuriously. Allow a full hour
+    # (Issue #3168) while staying well under the 6-hour GitHub default.
+    timeout-minutes: 60
     env:
       NEAT_RUST_DISCOVERY_OPTIONAL: "true"
       # Enable per-process discovery directory isolation so parallel test

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.5",
+  "version": "5.7.6",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3168.md
+++ b/docs/archive/pr-summaries/pr-summary-3168.md
@@ -1,19 +1,18 @@
 ## Summary
 
-The `Test Coverage` CI workflow (`.github/workflows/coverage.yaml`) ran the
-full test suite under coverage instrumentation with a 30-minute job cap.
-Heavy runs occasionally exceeded 30 minutes on slower runners, so GitHub
-killed the job and the PR failed spuriously. This PR raises the
-`timeout-minutes` for the `coverage` job from 30 to 60 (a full hour), while
-staying well under the 6-hour GitHub default that the existing hygiene test
-guards against. Closes #3168.
+The `Test Coverage` CI workflow (`.github/workflows/coverage.yaml`) ran the full
+test suite under coverage instrumentation with a 30-minute job cap. Heavy runs
+occasionally exceeded 30 minutes on slower runners, so GitHub killed the job and
+the PR failed spuriously. This PR raises the `timeout-minutes` for the
+`coverage` job from 30 to 60 (a full hour), while staying well under the 6-hour
+GitHub default that the existing hygiene test guards against. Closes #3168.
 
 ## Evidence
 
 Backend/CI-only change — no web interface to screenshot.
 
-- Workflow diff: `timeout-minutes: 30` → `timeout-minutes: 60` in the
-  `coverage` job.
+- Workflow diff: `timeout-minutes: 30` → `timeout-minutes: 60` in the `coverage`
+  job.
 - `actionlint .github/workflows/coverage.yaml` passes clean.
 - New test result:
 
@@ -28,10 +27,13 @@ ok | 3 passed | 0 failed
 
 ## Test Plan
 
-- Added `test/ci/WorkflowJobTimeoutMinutes.ts::coverage workflow job allows
-  at least an hour (Issue #3168)` — parses the committed `coverage.yaml` and
-  asserts the `coverage` job's `timeout-minutes` is at least 60. Fails
-  against the previous value of 30, passes after the change.
-- Existing generic test (`every workflow job declares an explicit
-  timeout-minutes`) still passes: 60 remains a positive integer below the
-  360-minute default.
+- Added
+  `test/ci/WorkflowJobTimeoutMinutes.ts::coverage workflow job allows
+  at least an hour (Issue #3168)`
+  — parses the committed `coverage.yaml` and asserts the `coverage` job's
+  `timeout-minutes` is at least 60. Fails against the previous value of 30,
+  passes after the change.
+- Existing generic test
+  (`every workflow job declares an explicit
+  timeout-minutes`) still passes: 60
+  remains a positive integer below the 360-minute default.

--- a/docs/archive/pr-summaries/pr-summary-3168.md
+++ b/docs/archive/pr-summaries/pr-summary-3168.md
@@ -1,0 +1,37 @@
+## Summary
+
+The `Test Coverage` CI workflow (`.github/workflows/coverage.yaml`) ran the
+full test suite under coverage instrumentation with a 30-minute job cap.
+Heavy runs occasionally exceeded 30 minutes on slower runners, so GitHub
+killed the job and the PR failed spuriously. This PR raises the
+`timeout-minutes` for the `coverage` job from 30 to 60 (a full hour), while
+staying well under the 6-hour GitHub default that the existing hygiene test
+guards against. Closes #3168.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+- Workflow diff: `timeout-minutes: 30` → `timeout-minutes: 60` in the
+  `coverage` job.
+- `actionlint .github/workflows/coverage.yaml` passes clean.
+- New test result:
+
+```
+running 3 tests from ./test/ci/WorkflowJobTimeoutMinutes.ts
+at least one workflow file is present to validate ... ok
+every workflow job declares an explicit timeout-minutes ... ok
+coverage workflow job allows at least an hour (Issue #3168) ... ok
+
+ok | 3 passed | 0 failed
+```
+
+## Test Plan
+
+- Added `test/ci/WorkflowJobTimeoutMinutes.ts::coverage workflow job allows
+  at least an hour (Issue #3168)` — parses the committed `coverage.yaml` and
+  asserts the `coverage` job's `timeout-minutes` is at least 60. Fails
+  against the previous value of 30, passes after the change.
+- Existing generic test (`every workflow job declares an explicit
+  timeout-minutes`) still passes: 60 remains a positive integer below the
+  360-minute default.

--- a/test/ci/WorkflowJobTimeoutMinutes.ts
+++ b/test/ci/WorkflowJobTimeoutMinutes.ts
@@ -85,3 +85,22 @@ Deno.test("every workflow job declares an explicit timeout-minutes", async () =>
     }
   }
 });
+
+// The coverage job runs the full test suite under coverage instrumentation and
+// occasionally exceeds 30 minutes, causing spurious PR failures (Issue #3168).
+// Its timeout is extended to a full hour to absorb that variance while still
+// staying well under the 6-hour GitHub default.
+const COVERAGE_JOB_MIN_TIMEOUT_MINUTES = 60;
+
+Deno.test("coverage workflow job allows at least an hour (Issue #3168)", async () => {
+  const wf = await readWorkflow(`${WORKFLOW_DIR}/coverage.yaml`);
+  const job = (wf.jobs ?? {})["coverage"];
+  assert(job !== undefined, "coverage.yaml is missing the 'coverage' job");
+  const timeout = job["timeout-minutes"];
+  assert(
+    typeof timeout === "number" && timeout >= COVERAGE_JOB_MIN_TIMEOUT_MINUTES,
+    `coverage job timeout-minutes (${timeout}) must be at least ` +
+      `${COVERAGE_JOB_MIN_TIMEOUT_MINUTES} minutes so heavy coverage runs ` +
+      `don't fail spuriously`,
+  );
+});


### PR DESCRIPTION
## Summary

The `Test Coverage` CI workflow (`.github/workflows/coverage.yaml`) ran the full
test suite under coverage instrumentation with a 30-minute job cap. Heavy runs
occasionally exceeded 30 minutes on slower runners, so GitHub killed the job and
the PR failed spuriously. This PR raises the `timeout-minutes` for the
`coverage` job from 30 to 60 (a full hour), while staying well under the 6-hour
GitHub default that the existing hygiene test guards against. Closes #3168.

## Evidence

Backend/CI-only change — no web interface to screenshot.

- Workflow diff: `timeout-minutes: 30` → `timeout-minutes: 60` in the `coverage`
  job.
- `actionlint .github/workflows/coverage.yaml` passes clean.
- New test result:

```
running 3 tests from ./test/ci/WorkflowJobTimeoutMinutes.ts
at least one workflow file is present to validate ... ok
every workflow job declares an explicit timeout-minutes ... ok
coverage workflow job allows at least an hour (Issue #3168) ... ok

ok | 3 passed | 0 failed
```

## Test Plan

- Added
  `test/ci/WorkflowJobTimeoutMinutes.ts::coverage workflow job allows
  at least an hour (Issue #3168)`
  — parses the committed `coverage.yaml` and asserts the `coverage` job's
  `timeout-minutes` is at least 60. Fails against the previous value of 30,
  passes after the change.
- Existing generic test
  (`every workflow job declares an explicit
  timeout-minutes`) still passes: 60
  remains a positive integer below the 360-minute default.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr1jec9o-67e0d0`<!-- vibe-worker-issue-3168 -->