### PR TITLE
Extend coverage CI job timeout to 60 minutes (Issue #3168)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,7 +22,9 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Coverage is the heaviest run (full suite + coverage collection) and has
+    # occasionally exceeded 30 minutes, failing PRs (Issue #3168). Allow an hour.
+    timeout-minutes: 60
     env:
       NEAT_RUST_DISCOVERY_OPTIONAL: "true"
       # Enable per-process discovery directory isolation so parallel test

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.5",
+  "version": "5.7.6",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3168.md
+++ b/docs/archive/pr-summaries/pr-summary-3168.md
@@ -1,0 +1,47 @@
+## Summary
+
+Extended the CI **Test Coverage** job timeout from 30 minutes to 60 minutes.
+The coverage run is the heaviest workflow (full test suite plus coverage
+collection) and has occasionally exceeded 30 minutes, causing PRs to fail on a
+timeout rather than a genuine test failure. Raising the cap to an hour gives the
+run enough head-room while still staying well under the 6-hour GitHub default
+that the existing resource-hygiene gate guards against. Closes #3168.
+
+Change: `.github/workflows/coverage.yaml` — `timeout-minutes: 30` → `60`.
+
+```mermaid
+flowchart LR
+    PR[Pull request to Develop] --> Cov[coverage job]
+    Cov --> T{Run under<br/>timeout-minutes?}
+    T -- "was 30 min" --> Fail[❌ killed at 30 min<br/>PR fails on timeout]
+    T -- "now 60 min" --> Pass[✅ completes within budget]
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the
+workflow-configuration unit tests, which parse the committed YAML and assert on
+the resulting configuration (a "what" test, not a source grep).
+
+Test run (`deno test -A --config ./deno.json test/ci/WorkflowJobTimeoutMinutes.ts`):
+
+```
+at least one workflow file is present to validate ... ok
+every workflow job declares an explicit timeout-minutes ... ok
+coverage workflow allows at least an hour for its job ... ok
+ok | 3 passed | 0 failed
+```
+
+The full `test/ci` suite (88 tests, including actionlint, action pinning and the
+existing timeout-hygiene gate) passes with the change.
+
+## Test Plan
+
+- Added `test/ci/WorkflowJobTimeoutMinutes.ts::coverage workflow allows at least
+  an hour for its job` — a regression test that parses `coverage.yaml` and
+  asserts the coverage job's `timeout-minutes` is at least 60. It failed against
+  the unchanged workflow (`timeout-minutes (30) must be at least 60 minutes`) and
+  passes after the change.
+- Existing generic timeout gate (`every workflow job declares an explicit
+  timeout-minutes`) still passes — 60 remains below the 360-minute GitHub
+  default.

--- a/docs/archive/pr-summaries/pr-summary-3168.md
+++ b/docs/archive/pr-summaries/pr-summary-3168.md
@@ -1,11 +1,11 @@
 ## Summary
 
-Extended the CI **Test Coverage** job timeout from 30 minutes to 60 minutes.
-The coverage run is the heaviest workflow (full test suite plus coverage
-collection) and has occasionally exceeded 30 minutes, causing PRs to fail on a
-timeout rather than a genuine test failure. Raising the cap to an hour gives the
-run enough head-room while still staying well under the 6-hour GitHub default
-that the existing resource-hygiene gate guards against. Closes #3168.
+Extended the CI **Test Coverage** job timeout from 30 minutes to 60 minutes. The
+coverage run is the heaviest workflow (full test suite plus coverage collection)
+and has occasionally exceeded 30 minutes, causing PRs to fail on a timeout
+rather than a genuine test failure. Raising the cap to an hour gives the run
+enough head-room while still staying well under the 6-hour GitHub default that
+the existing resource-hygiene gate guards against. Closes #3168.
 
 Change: `.github/workflows/coverage.yaml` — `timeout-minutes: 30` → `60`.
 
@@ -23,7 +23,8 @@ Backend/CI-only change — no web interface to screenshot. Verified via the
 workflow-configuration unit tests, which parse the committed YAML and assert on
 the resulting configuration (a "what" test, not a source grep).
 
-Test run (`deno test -A --config ./deno.json test/ci/WorkflowJobTimeoutMinutes.ts`):
+Test run
+(`deno test -A --config ./deno.json test/ci/WorkflowJobTimeoutMinutes.ts`):
 
 ```
 at least one workflow file is present to validate ... ok
@@ -37,11 +38,14 @@ existing timeout-hygiene gate) passes with the change.
 
 ## Test Plan
 
-- Added `test/ci/WorkflowJobTimeoutMinutes.ts::coverage workflow allows at least
-  an hour for its job` — a regression test that parses `coverage.yaml` and
-  asserts the coverage job's `timeout-minutes` is at least 60. It failed against
-  the unchanged workflow (`timeout-minutes (30) must be at least 60 minutes`) and
-  passes after the change.
-- Existing generic timeout gate (`every workflow job declares an explicit
-  timeout-minutes`) still passes — 60 remains below the 360-minute GitHub
-  default.
+- Added
+  `test/ci/WorkflowJobTimeoutMinutes.ts::coverage workflow allows at least
+  an hour for its job`
+  — a regression test that parses `coverage.yaml` and asserts the coverage job's
+  `timeout-minutes` is at least 60. It failed against the unchanged workflow
+  (`timeout-minutes (30) must be at least 60 minutes`) and passes after the
+  change.
+- Existing generic timeout gate
+  (`every workflow job declares an explicit
+  timeout-minutes`) still passes —
+  60 remains below the 360-minute GitHub default.

--- a/test/ci/WorkflowJobTimeoutMinutes.ts
+++ b/test/ci/WorkflowJobTimeoutMinutes.ts
@@ -85,3 +85,27 @@ Deno.test("every workflow job declares an explicit timeout-minutes", async () =>
     }
   }
 });
+
+// The coverage run collects test coverage across the whole suite and is the
+// heaviest workflow. It has occasionally exceeded the previous 30-minute cap
+// and failed PRs (Issue #3168). Its bound is deliberately more generous than
+// the other jobs, so assert the floor explicitly to guard against a regression
+// back to a too-tight value.
+const COVERAGE_WORKFLOW = `${WORKFLOW_DIR}/coverage.yaml`;
+const COVERAGE_MIN_TIMEOUT_MINUTES = 60;
+
+Deno.test("coverage workflow allows at least an hour for its job", async () => {
+  const wf = await readWorkflow(COVERAGE_WORKFLOW);
+  const jobs = wf.jobs ?? {};
+  const jobIds = Object.keys(jobs);
+  assert(jobIds.length > 0, `${COVERAGE_WORKFLOW} declares no jobs`);
+
+  for (const jobId of jobIds) {
+    const timeout = jobs[jobId]["timeout-minutes"];
+    assert(
+      typeof timeout === "number" && timeout >= COVERAGE_MIN_TIMEOUT_MINUTES,
+      `${COVERAGE_WORKFLOW} job "${jobId}" timeout-minutes (${timeout}) must be ` +
+        `at least ${COVERAGE_MIN_TIMEOUT_MINUTES} minutes (Issue #3168)`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Extended the CI **Test Coverage** job timeout from 30 minutes to 60 minutes.
The coverage run is the heaviest workflow (full test suite plus coverage
collection) and has occasionally exceeded 30 minutes, causing PRs to fail on a
timeout rather than a genuine test failure. Raising the cap to an hour gives the
run enough head-room while still staying well under the 6-hour GitHub default
that the existing resource-hygiene gate guards against. Closes #3168.

Change: `.github/workflows/coverage.yaml` — `timeout-minutes: 30` → `60`.

```mermaid
flowchart LR
    PR[Pull request to Develop] --> Cov[coverage job]
    Cov --> T{Run under<br/>timeout-minutes?}
    T -- "was 30 min" --> Fail[❌ killed at 30 min<br/>PR fails on timeout]
    T -- "now 60 min" --> Pass[✅ completes within budget]
```

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the
workflow-configuration unit tests, which parse the committed YAML and assert on
the resulting configuration (a "what" test, not a source grep).

Test run (`deno test -A --config ./deno.json test/ci/WorkflowJobTimeoutMinutes.ts`):

```
at least one workflow file is present to validate ... ok
every workflow job declares an explicit timeout-minutes ... ok
coverage workflow allows at least an hour for its job ... ok
ok | 3 passed | 0 failed
```

The full `test/ci` suite (88 tests, including actionlint, action pinning and the
existing timeout-hygiene gate) passes with the change.

## Test Plan

- Added `test/ci/WorkflowJobTimeoutMinutes.ts::coverage workflow allows at least
  an hour for its job` — a regression test that parses `coverage.yaml` and
  asserts the coverage job's `timeout-minutes` is at least 60. It failed against
  the unchanged workflow (`timeout-minutes (30) must be at least 60 minutes`) and
  passes after the change.
- Existing generic timeout gate (`every workflow job declares an explicit
  timeout-minutes`) still passes — 60 remains below the 360-minute GitHub
  default.
