### PR TITLE
Wire bench/ suites into a runnable deno bench task + CI (Issue #3175)

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,0 +1,63 @@
+name: Benchmarks
+
+# Runs a fast benchmark smoke pass so the `bench/` Deno.bench suites are
+# actually executed on every change to the benchmarks or their runner config
+# (Issue #3175). This is deliberately a small, fast subset — the full
+# benchmark suite (`deno task bench`) is a long-running, manual/nightly
+# command. Fanning the full suite across a CI matrix and the OOM hardening
+# are tracked as separate sub-issues of #3169.
+
+on:
+  pull_request:
+    branches:
+      - Develop
+    paths:
+      - "bench/**"
+      - "deno.json"
+      - ".github/workflows/bench.yaml"
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref so rapid pushes don't pile up.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege GITHUB_TOKEN scopes: the job only reads the repo and
+# uploads an artifact.
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Benchmark smoke
+    runs-on: ubuntu-latest
+    # The smoke subset is fast; keep a generous cap purely as a wedge guard.
+    timeout-minutes: 20
+    env:
+      NEAT_RUST_DISCOVERY_OPTIONAL: "true"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Deno
+        # denoland/setup-deno@v2.0.4
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+
+      - name: Sync WASM package from NEAT-AI-core
+        run: ./build.sh --verify-only
+
+      - name: Run benchmark smoke pass
+        run: |
+          set -Eeuo pipefail
+          export NO_COLOR=true
+          deno task bench:smoke | tee bench-smoke-output.txt
+
+      - name: Upload benchmark output
+        if: ${{ always() }}
+        # actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: bench-smoke-output
+          path: bench-smoke-output.txt
+          retention-days: 7
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Issue #3175:** Benchmarks in `bench/` are now runnable via a single
+  documented command. `deno.json` gains a `bench` task (`deno task bench`, full
+  suite) and a `bench:smoke` task (fast subset), plus a `bench` config whose
+  `include`/`exclude` widen `deno bench` discovery to the PascalCase
+  `Deno.bench` files while skipping the standalone profiling harnesses. A new
+  `.github/workflows/bench.yaml` runs the smoke pass in CI so benchmarks are
+  actually executed. Verification confirmed the "Performance"-named files under
+  `test/` (`FatherPerformance.ts`, `OffspringBreedPerformance.ts`,
+  `DiscoveryPerformanceSummary.ts`, `PerformanceGuide.ts`, and the `test/bench/`
+  harness tests) are genuine, fast correctness tests — their timing counterparts
+  already live in `bench/` — so they remain in the unit suite with no coverage
+  regression.
 - **Issue #3053:** New `trainingTaskTimeoutMinutes` option caps the wall-clock
   budget of any **single** training task independent of the overall
   `timeoutMinutes` run budget (default `5`; `0` disables). Previously a task

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,6 +319,36 @@ Avoid **"how" tests** that check implementation details:
 > unpredictably under different system loads. Keep timing logic strictly within
 > `bench/`.
 
+### 🏃 Running benchmarks
+
+Benchmarks live in `bench/` and are **not** part of the unit-test / coverage
+suite, so they never count against the ≤120s-per-test budget. Run them
+explicitly:
+
+```bash
+# Full Deno.bench suite (long-running — manual / nightly use).
+deno task bench
+
+# Fast smoke subset — the same command the Benchmarks CI job runs.
+deno task bench:smoke
+
+# A single benchmark file.
+deno bench --allow-read --allow-write --allow-env --allow-ffi bench/Activate.ts
+```
+
+`deno task bench` uses the `bench.include` / `bench.exclude` config in
+`deno.json`. `deno bench` only auto-discovers `*.bench.ts` files, so `include`
+widens discovery to the whole `bench/` tree; `exclude` lists the standalone
+profiling harnesses that are launched with `deno run` (they do heavy work at
+module top level) so `deno task bench` does not execute them. New profiling
+scripts of that kind should either be named without a `Deno.bench` suite or
+guard their entry point with `import.meta.main`.
+
+The `.github/workflows/bench.yaml` workflow runs `deno task bench:smoke` on pull
+requests that touch `bench/` or `deno.json`, so the benchmarks are actually
+executed in CI. It is intentionally a small, fast pass; fanning the full suite
+across a CI matrix and OOM hardening are tracked as separate sub-issues.
+
 ## ➕ Adding Configuration
 
 When adding a new configuration option, follow the established pattern:

--- a/deno.json
+++ b/deno.json
@@ -60,9 +60,40 @@
     "@creature": "./src/Creature.ts",
     "@globalAccessors": "./src/globalAccessors.ts"
   },
+  "tasks": {
+    "bench": "deno bench --allow-read --allow-write --allow-env --allow-ffi",
+    "bench:smoke": "deno bench --allow-read --allow-write --allow-env --allow-ffi bench/FatherCompatibility.ts bench/Activate.ts"
+  },
   "test": {
     "include": [
       "test/**/*.ts"
+    ]
+  },
+  "bench": {
+    "include": [
+      "bench/**/*.ts"
+    ],
+    "exclude": [
+      "bench/ActivateAndTraceApp.ts",
+      "bench/ActivateApp.ts",
+      "bench/AdaptiveLearningRateConvergence.ts",
+      "bench/CosineAnnealingWarmRestart.ts",
+      "bench/CreatureStateNodeMap.ts",
+      "bench/DenseNumberMapBenchmark.ts",
+      "bench/DiscoveryAnalysisCacheRelease.ts",
+      "bench/FastConvergencePreset.ts",
+      "bench/GenerationalInertiaSchedule.ts",
+      "bench/IncrementalScoreUpdate.ts",
+      "bench/MainThreadScoreWork.ts",
+      "bench/MaxWeightBiasRecalculation.ts",
+      "bench/NoveltyDeceptiveEscape.ts",
+      "bench/OnPolicyDistillationBreed.ts",
+      "bench/RandomImmigrantsStagnationEscape.ts",
+      "bench/RevisitDiagnostic.ts",
+      "bench/ScoreCalculationCache.ts",
+      "bench/ScorePooledBuffers.ts",
+      "bench/SelectiveCacheInvalidation.ts",
+      "bench/WasmScoreScan.ts"
     ]
   },
   "fmt": {

--- a/docs/archive/pr-summaries/pr-summary-3175.md
+++ b/docs/archive/pr-summaries/pr-summary-3175.md
@@ -1,0 +1,99 @@
+# Convert benchmark-style tests to Deno.bench and run them separately
+
+## Summary
+
+Closes #3175 (part of #3169).
+
+**Verification finding first.** The issue asked to move "benchmarks disguised as
+unit tests" out of `test/**` into `bench/`, listing seven candidate files — but
+each had to be verified before moving. Verification showed **none of them is a
+benchmark disguised as a test**:
+
+| Candidate (`test/`)                                                     | Verdict | Evidence                                                                                                                                                                   |
+| ----------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `breed/FatherPerformance.ts`                                            | Keep    | Pure correctness asserts (result equivalence, valid creatures); no timing API. Runs ~0.5s. Bench counterpart already in `bench/FatherCompatibility.ts`.                    |
+| `breed/OffspringBreedPerformance.ts`                                    | Keep    | Correctness asserts (offspring validity, parents unmodified, activation equivalence); no timing API. Runs ~1.5s. Bench counterpart already in `bench/BreedPerformance.ts`. |
+| `discovery/DiscoveryPerformanceSummary.ts`                              | Keep    | Tests the `formatDiscoveryPerformanceSummary` formatter output; no timing.                                                                                                 |
+| `ErrorGuidedStructuralEvolution/DiscoverDirectoryPerformanceSummary.ts` | Keep    | Formatter correctness; no timing.                                                                                                                                          |
+| `docs/PerformanceGuide.ts`                                              | Keep    | Verifies documented behaviour (cache-stats shape, WASM correctness, shallowClone equivalence); no timing.                                                                  |
+| `bench/EvolutionPaceLeverComparison.ts`                                 | Keep    | Fast unit test of the harness that already lives in `bench/EvolutionPaceLeverComparison.ts`; deterministic/table asserts, no timing.                                       |
+| `bench/ProductionScaleEvolveDirProfile.ts`                              | Keep    | Fast structural assert; production-scale profiling already in `bench/ProductionScaleEvolveDirProfile.ts`.                                                                  |
+
+The correctness/timing split the issue asks for **had already been done** by
+prior work — each file's header even points at its `bench/` counterpart. Moving
+these files would delete real test coverage and cause a coverage regression, so
+they correctly stay in the unit suite.
+
+**The genuine gap** was acceptance criterion 2: the `bench/` suites were _not
+runnable via any documented command or CI job_. `deno bench` only auto-discovers
+`*.bench.ts` files, so the ~115 PascalCase `Deno.bench` files (e.g.
+`bench/Activate.ts`) were never executed by any task or workflow. This PR closes
+that gap:
+
+- **`deno.json`** — added a `tasks` block (`bench`, `bench:smoke`) and a `bench`
+  config. `bench.include` widens `deno bench` discovery to the whole `bench/`
+  tree; `bench.exclude` lists the 20 standalone profiling harnesses (launched
+  with `deno run`, doing heavy work at module top level) so `deno task bench`
+  does not execute them.
+- **`.github/workflows/bench.yaml`** — a non-gating Benchmarks workflow that
+  runs `deno task bench:smoke` on PRs touching `bench/` or `deno.json`,
+  uploading the output as an artifact. Kept to a small fast subset deliberately
+  — the full-suite CI matrix and OOM hardening are out of scope (separate
+  sub-issues of #3169).
+- **`CONTRIBUTING.md` / `CHANGELOG.md`** — documented the commands and the
+  config.
+
+Acceptance criteria: (1) no benchmark-style tests were found to remove — the
+listed files are genuine tests kept in place; (2) `bench/` suites are now
+runnable via `deno task bench` / `deno task bench:smoke` and the CI job; (3)
+behavioural assertions preserved (files unchanged); (4) no coverage regression
+(nothing removed).
+
+## Evidence
+
+This is a backend/tooling change with no web interface to screenshot. Evidence
+is the benchmark smoke pass actually running the `bench/` suites:
+
+```text
+$ deno task bench:smoke
+file:///.../bench/FatherCompatibility.ts
+| benchmark                                           | time/iter (avg) |  iter/s |
+| --------------------------------------------------- | --------------- | ------- |
+| Original (with exportJSON)                          |          3.4 ms |   294.5 |
+| Optimised (direct Creature access)                  |          1.6 ms |   626.6 |
+| Export overhead only (mother + father)              |         80.9 µs |  12,360 |
+| Original compatibility only                         |          2.7 ms |   364.6 |
+| Optimised compatibility only                        |          1.1 ms |   917.3 |
+| createCompatibleFather (pre-exported, key gen only) |          2.5 ms |   394.7 |
+
+file:///.../bench/Activate.ts
+| benchmark | time/iter (avg) |  iter/s |
+| --------- | --------------- | ------- |
+| Activate  |          8.9 ms |   112.3 |
+```
+
+### How the benchmark runner is wired
+
+```mermaid
+flowchart LR
+    Dev[deno task bench] --> Cfg[deno.json bench config]
+    Cfg -->|include bench/**/*.ts| Suite[Deno.bench suites]
+    Cfg -->|exclude 20 harnesses| Skip[Standalone deno run profilers]
+    CI[bench.yaml on PR] --> Smoke[deno task bench:smoke]
+    Smoke --> Fast[FatherCompatibility + Activate]
+    Fast --> Art[Upload bench-smoke-output.txt]
+```
+
+## Test Plan
+
+- Added `test/ci/BenchTaskConfig.ts` (5 tests, all passing): asserts the `bench`
+  and `bench:smoke` tasks exist and invoke `deno bench`; `bench.include` covers
+  the tree; every `bench.exclude` path exists on disk (guards against stale
+  excludes silently re-including a heavy profiler); the `bench:smoke` files
+  exist; and `bench.yaml` runs `deno task bench:smoke`.
+- Ran `deno task bench:smoke` — both benchmark files execute and report timings
+  (output above).
+- `deno fmt --check`, `deno lint`, `deno check`, and `actionlint` pass on all
+  changed files. `markdownlint-cli2` reports 0 errors.
+- Confirmed the seven listed candidates still pass and run fast (≤~1.5s each),
+  well within the ≤120s-per-test budget.

--- a/test/ci/BenchTaskConfig.ts
+++ b/test/ci/BenchTaskConfig.ts
@@ -1,0 +1,125 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verifies the benchmark runner wiring added for Issue #3175.
+ *
+ * The `bench/` directory holds Deno.bench suites, but until #3175 nothing ran
+ * them: `deno bench` only auto-discovers `*.bench.ts` files, so the many
+ * PascalCase `Deno.bench` files were never executed by any task or CI job.
+ *
+ * This test locks in the two guarantees that keep the new `deno task bench`
+ * entry point honest:
+ *
+ *   1. The `bench` config discovers the whole `bench/` tree, while every
+ *      standalone profiling harness (run via `deno run`, not `deno bench`) is
+ *      listed in `exclude` so `deno task bench` never executes its heavy
+ *      top-level code. A stale exclude entry (a file that no longer exists)
+ *      would silently drift, so we assert each excluded path is real.
+ *   2. The benchmark smoke workflow runs `deno task bench:smoke`, so the
+ *      benchmarks are actually exercised in CI.
+ */
+
+interface DenoConfig {
+  tasks?: Record<string, string>;
+  bench?: {
+    include?: string[];
+    exclude?: string[];
+  };
+}
+
+async function loadDenoConfig(): Promise<DenoConfig> {
+  return JSON.parse(await Deno.readTextFile("deno.json")) as DenoConfig;
+}
+
+Deno.test("deno.json exposes documented benchmark tasks", async () => {
+  const config = await loadDenoConfig();
+  const tasks = config.tasks ?? {};
+
+  assert(
+    typeof tasks.bench === "string",
+    "expected a `bench` task in deno.json",
+  );
+  assertStringIncludes(
+    tasks.bench,
+    "deno bench",
+    "the `bench` task should invoke `deno bench`",
+  );
+
+  assert(
+    typeof tasks["bench:smoke"] === "string",
+    "expected a `bench:smoke` task in deno.json",
+  );
+  assertStringIncludes(
+    tasks["bench:smoke"],
+    "deno bench",
+    "the `bench:smoke` task should invoke `deno bench`",
+  );
+});
+
+Deno.test("bench config discovers the whole bench/ tree", async () => {
+  const config = await loadDenoConfig();
+  const include = config.bench?.include ?? [];
+  assert(
+    include.includes("bench/**/*.ts"),
+    `bench.include should cover the bench/ tree, got: ${include.join(", ")}`,
+  );
+});
+
+Deno.test("every excluded profiling harness still exists on disk", async () => {
+  const config = await loadDenoConfig();
+  const exclude = config.bench?.exclude ?? [];
+  assert(
+    exclude.length > 0,
+    "expected some standalone harnesses to be excluded",
+  );
+
+  const stats = await Promise.all(
+    exclude.map((path) => Deno.stat(path).catch(() => null)),
+  );
+  exclude.forEach((path, i) => {
+    assert(
+      stats[i]?.isFile === true,
+      `excluded bench path does not exist (stale exclude?): ${path}`,
+    );
+  });
+});
+
+Deno.test("bench:smoke task references real benchmark files", async () => {
+  const config = await loadDenoConfig();
+  const smoke = config.tasks?.["bench:smoke"] ?? "";
+
+  // Pull the bench/*.ts arguments off the command line and confirm each exists.
+  const files = smoke.split(/\s+/).filter((token) => token.endsWith(".ts"));
+  assert(files.length > 0, "bench:smoke should name at least one bench file");
+
+  const stats = await Promise.all(
+    files.map((path) => Deno.stat(path).catch(() => null)),
+  );
+  files.forEach((path, i) => {
+    assert(
+      stats[i]?.isFile === true,
+      `bench:smoke references a missing file: ${path}`,
+    );
+  });
+});
+
+Deno.test("benchmark workflow runs the smoke task", async () => {
+  const workflow = parse(
+    await Deno.readTextFile(".github/workflows/bench.yaml"),
+  ) as {
+    jobs?: Record<string, { steps?: Array<{ run?: string }> }>;
+  };
+
+  const steps = Object.values(workflow.jobs ?? {}).flatMap((job) =>
+    job.steps ?? []
+  );
+  const runsSmoke = steps.some((step) =>
+    step.run?.includes("deno task bench:smoke")
+  );
+  assertEquals(
+    runsSmoke,
+    true,
+    "bench.yaml should execute `deno task bench:smoke`",
+  );
+});


### PR DESCRIPTION
# Convert benchmark-style tests to Deno.bench and run them separately

## Summary

Closes #3175 (part of #3169).

**Verification finding first.** The issue asked to move "benchmarks disguised as
unit tests" out of `test/**` into `bench/`, listing seven candidate files — but
each had to be verified before moving. Verification showed **none of them is a
benchmark disguised as a test**:

| Candidate (`test/`)                                                     | Verdict | Evidence                                                                                                                                                                   |
| ----------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `breed/FatherPerformance.ts`                                            | Keep    | Pure correctness asserts (result equivalence, valid creatures); no timing API. Runs ~0.5s. Bench counterpart already in `bench/FatherCompatibility.ts`.                    |
| `breed/OffspringBreedPerformance.ts`                                    | Keep    | Correctness asserts (offspring validity, parents unmodified, activation equivalence); no timing API. Runs ~1.5s. Bench counterpart already in `bench/BreedPerformance.ts`. |
| `discovery/DiscoveryPerformanceSummary.ts`                              | Keep    | Tests the `formatDiscoveryPerformanceSummary` formatter output; no timing.                                                                                                 |
| `ErrorGuidedStructuralEvolution/DiscoverDirectoryPerformanceSummary.ts` | Keep    | Formatter correctness; no timing.                                                                                                                                          |
| `docs/PerformanceGuide.ts`                                              | Keep    | Verifies documented behaviour (cache-stats shape, WASM correctness, shallowClone equivalence); no timing.                                                                  |
| `bench/EvolutionPaceLeverComparison.ts`                                 | Keep    | Fast unit test of the harness that already lives in `bench/EvolutionPaceLeverComparison.ts`; deterministic/table asserts, no timing.                                       |
| `bench/ProductionScaleEvolveDirProfile.ts`                              | Keep    | Fast structural assert; production-scale profiling already in `bench/ProductionScaleEvolveDirProfile.ts`.                                                                  |

The correctness/timing split the issue asks for **had already been done** by
prior work — each file's header even points at its `bench/` counterpart. Moving
these files would delete real test coverage and cause a coverage regression, so
they correctly stay in the unit suite.

**The genuine gap** was acceptance criterion 2: the `bench/` suites were _not
runnable via any documented command or CI job_. `deno bench` only auto-discovers
`*.bench.ts` files, so the ~115 PascalCase `Deno.bench` files (e.g.
`bench/Activate.ts`) were never executed by any task or workflow. This PR closes
that gap:

- **`deno.json`** — added a `tasks` block (`bench`, `bench:smoke`) and a `bench`
  config. `bench.include` widens `deno bench` discovery to the whole `bench/`
  tree; `bench.exclude` lists the 20 standalone profiling harnesses (launched
  with `deno run`, doing heavy work at module top level) so `deno task bench`
  does not execute them.
- **`.github/workflows/bench.yaml`** — a non-gating Benchmarks workflow that
  runs `deno task bench:smoke` on PRs touching `bench/` or `deno.json`,
  uploading the output as an artifact. Kept to a small fast subset deliberately
  — the full-suite CI matrix and OOM hardening are out of scope (separate
  sub-issues of #3169).
- **`CONTRIBUTING.md` / `CHANGELOG.md`** — documented the commands and the
  config.

Acceptance criteria: (1) no benchmark-style tests were found to remove — the
listed files are genuine tests kept in place; (2) `bench/` suites are now
runnable via `deno task bench` / `deno task bench:smoke` and the CI job; (3)
behavioural assertions preserved (files unchanged); (4) no coverage regression
(nothing removed).

## Evidence

This is a backend/tooling change with no web interface to screenshot. Evidence
is the benchmark smoke pass actually running the `bench/` suites:

```text
$ deno task bench:smoke
file:///.../bench/FatherCompatibility.ts
| benchmark                                           | time/iter (avg) |  iter/s |
| --------------------------------------------------- | --------------- | ------- |
| Original (with exportJSON)                          |          3.4 ms |   294.5 |
| Optimised (direct Creature access)                  |          1.6 ms |   626.6 |
| Export overhead only (mother + father)              |         80.9 µs |  12,360 |
| Original compatibility only                         |          2.7 ms |   364.6 |
| Optimised compatibility only                        |          1.1 ms |   917.3 |
| createCompatibleFather (pre-exported, key gen only) |          2.5 ms |   394.7 |

file:///.../bench/Activate.ts
| benchmark | time/iter (avg) |  iter/s |
| --------- | --------------- | ------- |
| Activate  |          8.9 ms |   112.3 |
```

### How the benchmark runner is wired

```mermaid
flowchart LR
    Dev[deno task bench] --> Cfg[deno.json bench config]
    Cfg -->|include bench/**/*.ts| Suite[Deno.bench suites]
    Cfg -->|exclude 20 harnesses| Skip[Standalone deno run profilers]
    CI[bench.yaml on PR] --> Smoke[deno task bench:smoke]
    Smoke --> Fast[FatherCompatibility + Activate]
    Fast --> Art[Upload bench-smoke-output.txt]
```

## Test Plan

- Added `test/ci/BenchTaskConfig.ts` (5 tests, all passing): asserts the `bench`
  and `bench:smoke` tasks exist and invoke `deno bench`; `bench.include` covers
  the tree; every `bench.exclude` path exists on disk (guards against stale
  excludes silently re-including a heavy profiler); the `bench:smoke` files
  exist; and `bench.yaml` runs `deno task bench:smoke`.
- Ran `deno task bench:smoke` — both benchmark files execute and report timings
  (output above).
- `deno fmt --check`, `deno lint`, `deno check`, and `actionlint` pass on all
  changed files. `markdownlint-cli2` reports 0 errors.
- Confirmed the seven listed candidates still pass and run fast (≤~1.5s each),
  well within the ≤120s-per-test budget.



## Milestone
This PR is part of the **#3169 Speed up CI test suite: dedupe, parallelise, split out benchmark tests** milestone and targets the `milestone/3169-speed-up-ci-test-suite-dedupe-parallelise-spl` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr1r1xyv-6d18da`<!-- vibe-worker-issue-3175 -->