### PR TITLE
Un-pin activation cache cap once caches are ruled out as retainer (GRQ #3082)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.6",
+  "version": "5.7.7",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/src/NEAT/MemoryMonitor.ts
+++ b/src/NEAT/MemoryMonitor.ts
@@ -112,6 +112,8 @@ export function determinePressureLevel(
  * oldest entries to bring the cache within the new cap.
  */
 export function applyWarningResponse(logger: Logger): void {
+  // Remember the cap so it can be restored once pressure clears (#3082).
+  captureActivationCapBaseline();
   const currentCap = getMaxCachedWasmCreatureActivations();
   const reducedCap = Math.max(1, Math.floor(currentCap / 2));
   setMaxCachedWasmCreatureActivations(reducedCap);
@@ -154,6 +156,22 @@ let _lastSnapshotAtMs = 0;
 /** Whether the "entered backoff" message has already been logged for the current cooldown. */
 let _backoffNotified = false;
 
+/**
+ * The activation-cache cap captured the first time pressure forced a reduction,
+ * so it can be RESTORED once the caches are shown not to be the retainer or
+ * heap pressure clears (Issue #3082). `null` means no pressure-driven reduction
+ * is currently in effect.
+ *
+ * Without this, a single heap spike pins the activation cap at 1 for the rest
+ * of the run and evolve throughput collapses — a major contributor to the
+ * GRQ-16 forex `easy` run overrunning its ~1h target. The adaptive backoff
+ * (#2381) already concludes "caches appear not to be the retainer" when the
+ * critical-response burst limit is exceeded; at that point continuing to pin
+ * the cap at 1 achieves no memory relief and only starves throughput, so we
+ * restore it.
+ */
+let _preReductionActivationCap: number | null = null;
+
 /** Reset pressure-response log counters (for tests; module state is shared across a worker). */
 export function resetMemoryPressureLogCountersForTests(): void {
   _criticalResponseLogCount = 0;
@@ -162,6 +180,42 @@ export function resetMemoryPressureLogCountersForTests(): void {
   _criticalBackoffUntilMs = 0;
   _lastSnapshotAtMs = 0;
   _backoffNotified = false;
+  _preReductionActivationCap = null;
+}
+
+/**
+ * Remember the activation-cache cap before the first pressure-driven reduction
+ * of a pressure episode so restoreActivationCapIfRecovered() can put it back.
+ * Only captures a genuine baseline (> 1) and only once per episode. Issue #3082.
+ */
+function captureActivationCapBaseline(): void {
+  if (_preReductionActivationCap !== null) return;
+  const currentCap = getMaxCachedWasmCreatureActivations();
+  if (currentCap > 1) {
+    _preReductionActivationCap = currentCap;
+  }
+}
+
+/**
+ * Restore the activation-cache cap to its pre-pressure baseline (Issue #3082).
+ *
+ * Called when the caches have been shown not to be the retainer (adaptive
+ * backoff engaged) or heap pressure has returned to normal — in both cases
+ * keeping the cap pinned at 1 buys no memory relief and only collapses evolve
+ * throughput. Returns true when a restoration happened.
+ */
+export function restoreActivationCapIfRecovered(logger: Logger): boolean {
+  if (_preReductionActivationCap === null) return false;
+  const baseline = _preReductionActivationCap;
+  _preReductionActivationCap = null;
+  if (getMaxCachedWasmCreatureActivations() >= baseline) return false;
+  setMaxCachedWasmCreatureActivations(baseline);
+  logger.warn(
+    `[MemoryMonitor] Restored activation cache cap to ${baseline} — the caches ` +
+      `were not the retainer / heap pressure cleared, so the cap was un-pinned ` +
+      `to avoid throttling throughput for the rest of the run`,
+  );
+  return true;
 }
 
 /**
@@ -169,6 +223,8 @@ export function resetMemoryPressureLogCountersForTests(): void {
  * caches and attempt garbage collection.
  */
 export function applyCriticalResponse(logger: Logger): void {
+  // Remember the cap so it can be restored once pressure clears (#3082).
+  captureActivationCapBaseline();
   // Shrink activation cache to minimum
   const currentCap = getMaxCachedWasmCreatureActivations();
   setMaxCachedWasmCreatureActivations(1);
@@ -379,11 +435,21 @@ export function checkMemoryAndEvict(
               `critical responses for ` +
               `${config.criticalBackoffCooldownMs}ms to avoid thrashing`,
           );
+          // We have now concluded the caches are not the retainer. Un-pin the
+          // activation cap that applyCriticalResponse just slammed to 1 —
+          // keeping it pinned buys no memory relief and only collapses evolve
+          // throughput for the rest of the run (Issue #3082).
+          restoreActivationCapIfRecovered(logger);
         }
       }
     } else if (pressureLevel === "warning") {
       applyWarningResponse(logger);
       evicted = true;
+    } else {
+      // pressureLevel === "normal": heap has recovered — restore any cap that a
+      // previous pressure response pinned low so throughput is not throttled
+      // for the rest of the run (Issue #3082).
+      restoreActivationCapIfRecovered(logger);
     }
   }
 

--- a/test/NEAT/MemoryMonitor.ts
+++ b/test/NEAT/MemoryMonitor.ts
@@ -12,6 +12,7 @@ import {
   type MemorySnapshot,
   type MemoryUsageProvider,
   resetMemoryPressureLogCountersForTests,
+  restoreActivationCapIfRecovered,
 } from "@neat/MemoryMonitor.ts";
 import {
   DEFAULT_MEMORY_CONFIG,
@@ -685,6 +686,116 @@ Deno.test(
         clock.now,
       );
       assertEquals(result.snapshot !== null, true);
+    } finally {
+      setMaxCachedWasmCreatureActivations(originalCap);
+      resetMemoryPressureLogCountersForTests();
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Activation-cap restoration — stops the cap being pinned at 1 for the whole
+// run once heap recovers or the caches are shown not to be the retainer.
+// Issue #3082.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "restoreActivationCapIfRecovered restores the cap after a critical response and normal recovery (#3082)",
+  () => {
+    const originalCap = getMaxCachedWasmCreatureActivations();
+    const config: RequiredMemoryConfig = {
+      ...DEFAULT_MEMORY_CONFIG,
+      enabled: true,
+    };
+    try {
+      resetMemoryPressureLogCountersForTests();
+      setMaxCachedWasmCreatureActivations(200);
+      const logger = createTestLogger();
+      const clock = fakeClock();
+
+      // Critical pressure pins the cap at 1.
+      checkMemoryAndEvict(
+        config,
+        logger,
+        fakeMemoryProvider(900, 1000),
+        clock.now,
+      );
+      assertStrictEquals(getMaxCachedWasmCreatureActivations(), 1);
+
+      // Heap recovers to normal — the cap is restored to its baseline (200),
+      // not left pinned at 1 for the rest of the run.
+      clock.advance(1000);
+      const result = checkMemoryAndEvict(
+        config,
+        logger,
+        fakeMemoryProvider(100, 1000),
+        clock.now,
+      );
+      assertStrictEquals(result.pressureLevel, "normal");
+      assertStrictEquals(getMaxCachedWasmCreatureActivations(), 200);
+    } finally {
+      setMaxCachedWasmCreatureActivations(originalCap);
+      resetMemoryPressureLogCountersForTests();
+    }
+  },
+);
+
+Deno.test(
+  "critical-response burst backoff un-pins the activation cap (#3082)",
+  () => {
+    const originalCap = getMaxCachedWasmCreatureActivations();
+    const config: RequiredMemoryConfig = {
+      ...DEFAULT_MEMORY_CONFIG,
+      enabled: true,
+    };
+    try {
+      resetMemoryPressureLogCountersForTests();
+      setMaxCachedWasmCreatureActivations(200);
+      const logger = createTestLogger();
+      const clock = fakeClock();
+
+      // Fire enough sustained-critical checks to exceed the burst limit within
+      // the window. Once the monitor concludes the caches are not the retainer
+      // it must un-pin the cap rather than leave it collapsed at 1.
+      const checks = config.criticalBackoffBurst + 1;
+      for (let i = 0; i < checks; i++) {
+        checkMemoryAndEvict(
+          config,
+          logger,
+          fakeMemoryProvider(900, 1000),
+          clock.now,
+        );
+        clock.advance(100);
+      }
+
+      assertStrictEquals(
+        getMaxCachedWasmCreatureActivations(),
+        200,
+        "cap should be restored to baseline once caches are ruled out as the retainer",
+      );
+      const restoreLogged = logger.messages.some((m) =>
+        m.includes("Restored activation cache cap to 200")
+      );
+      assertStrictEquals(restoreLogged, true);
+    } finally {
+      setMaxCachedWasmCreatureActivations(originalCap);
+      resetMemoryPressureLogCountersForTests();
+    }
+  },
+);
+
+Deno.test(
+  "restoreActivationCapIfRecovered is a no-op when no reduction was in effect (#3082)",
+  () => {
+    const originalCap = getMaxCachedWasmCreatureActivations();
+    try {
+      resetMemoryPressureLogCountersForTests();
+      setMaxCachedWasmCreatureActivations(50);
+      const logger = createTestLogger();
+      // No prior pressure response captured a baseline → nothing to restore.
+      const restored = restoreActivationCapIfRecovered(logger);
+      assertStrictEquals(restored, false);
+      assertStrictEquals(getMaxCachedWasmCreatureActivations(), 50);
     } finally {
       setMaxCachedWasmCreatureActivations(originalCap);
       resetMemoryPressureLogCountersForTests();


### PR DESCRIPTION
## Summary

MemoryMonitor's critical-level response slams the WASM activation cache cap to
**1** and never restores it. A single heap spike therefore pins the cap at 1 for
the rest of the run and evolve throughput collapses — a major contributor to the
GRQ-16 forex `easy` run overrunning its ~1h target
(stSoftwareAU/GRQ#3082, root cause #2).

The adaptive backoff (#2381) already concludes *"caches appear not to be the
retainer"* when the critical-response burst limit is exceeded, yet the cap
stayed collapsed at 1 regardless — achieving thrash and no memory relief.

## Change

- Capture the pre-reduction cap on the first pressure response of an episode.
- Restore it (`restoreActivationCapIfRecovered`) when either:
  - the **burst-limit backoff engages** (caches shown not to be the retainer —
    keeping the cap at 1 buys no relief and only starves throughput), or
  - heap pressure **returns to normal**.

Restoration only runs in those two safe cases, so the cap stays low while heap
is genuinely elevated and is never re-inflated against a real retainer.

## Tests

Three new cases in `test/NEAT/MemoryMonitor.ts`:
- critical response → normal recovery restores the baseline cap;
- sustained-critical burst backoff un-pins the cap (the thrash fix);
- `restoreActivationCapIfRecovered` is a no-op when nothing was reduced.

`deno fmt`/`lint`/`check` clean; `deno test test/NEAT/MemoryMonitor.ts` → 33 passed.

## Release / consumer note

Do **not** auto-merge or publish. The GRQ consumer bump waits for a human
release per the release-gating rules; tracked in the cross-linked GRQ follow-up.

Relates to stSoftwareAU/GRQ#3082. Sibling upstream defect: stSoftwareAU/NEAT-AI#3166.