### PR TITLE
Add CODEOWNERS coverage for CI/CD surface (Issue #3187)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS — required reviewers for privileged surfaces (Issue #3187)
+#
+# GitHub requires a listed code owner's approval on any pull request that
+# touches a path matched below, once the "Require review from Code Owners"
+# branch-protection rule is enabled on the default branch. This closes the
+# poisoned-pipeline / secret-exfiltration path where a workflow edit runs
+# with privileged secrets (the write-scoped ACTIONS_PUSH PAT and the JSR
+# OIDC `id-token`) the moment CI fires — before a human necessarily
+# notices the workflow diff.
+#
+# Owner teams MUST have write (push) access to this repository, otherwise
+# GitHub silently ignores the rule. `@stSoftwareAU/developers` is the
+# maintaining team with push access to NEAT-AI.
+
+# CI/CD surface — all GitHub Actions workflows and composite actions.
+/.github/workflows/  @stSoftwareAU/developers
+/.github/actions/    @stSoftwareAU/developers
+
+# The CODEOWNERS file itself, so ownership rules cannot be quietly changed.
+/.github/CODEOWNERS  @stSoftwareAU/developers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,16 @@ opening a PR (see the secure-coding principles section of
   dependency carrying a known OSV advisory, shrinking the window between
   disclosure and a reviewable fix rather than waiting for the next weekly
   freshness run.
+- **Code-owner review of the CI/CD surface** — `.github/CODEOWNERS` requires a
+  review from the maintaining team (`@stSoftwareAU/developers`) on any PR that
+  edits `.github/workflows/` or `.github/actions/`. Several workflows run with
+  privileged credentials — `publish.yml` / `pages.yml` request
+  `id-token: write`, and `quality.yml` / `update-package-version.yml` expose the
+  write-scoped `ACTIONS_PUSH` PAT — so requiring a named owner's approval closes
+  the poisoned-pipeline path where a workflow edit exfiltrates those secrets the
+  moment CI fires. Enforcement additionally depends on the default branch
+  enabling the **Require review from Code Owners** branch-protection rule (a
+  repository setting that lives outside the tree).
 
 For everything else, see the sibling docs: [`README.md`](./README.md),
 [`AGENTS.md`](./AGENTS.md), [`CONTRIBUTING.md`](./CONTRIBUTING.md),

--- a/docs/archive/pr-summaries/pr-summary-3187.md
+++ b/docs/archive/pr-summaries/pr-summary-3187.md
@@ -1,0 +1,78 @@
+# PR Summary — Issue #3187
+
+## Summary
+
+Add a `CODEOWNERS` file that requires a trusted reviewer on every change to the
+privileged CI/CD surface, closing a `severity:high` repo-level governance gap.
+No `CODEOWNERS` file previously existed in any of the three locations GitHub
+recognises, yet several workflows run with credentials well beyond
+`GITHUB_TOKEN` — `publish.yml` / `pages.yml` request `id-token: write` (JSR
+OIDC / Pages), and `quality.yml` / `update-package-version.yml` expose the
+write-scoped `ACTIONS_PUSH` PAT. Without an owner rule, a single careless or
+compromised account could open a PR that quietly edits a workflow which then
+exfiltrates those secrets the moment CI fires. Requiring a named code owner's
+review closes that poisoned-pipeline path. Closes #3187.
+
+### Owner team choice
+
+The issue suggested `@stSoftwareAU/maintainers`, but that team **does not exist**
+in the org (available teams: `ai-users`, `developers`, `service`, `support`,
+`system-admin`, `vibe-coders`). A CODEOWNERS rule naming a non-existent team is
+silently ignored by GitHub and enforces nothing. Only `developers` and
+`vibe-coders` have push access to NEAT-AI, and `vibe-coders` is the automation
+account — so the human maintaining team **`@stSoftwareAU/developers`** is used.
+
+### Branch-protection recommendations (repo settings, outside the tree)
+
+CODEOWNERS enforcement additionally requires the default branch to enable
+**Require review from Code Owners**. These are repository settings that cannot
+be committed to the tree and are documented here as recommendations:
+
+- Enable **required review** so CODEOWNERS approval is enforced before merge.
+- Block **direct push and force-push** to the default branch.
+- Enable **linear history** if the team uses a rebase/squash workflow.
+- Consider **required signed commits**.
+
+## Evidence
+
+Backend/governance change — no web UI to screenshot. Verified via TDD: the new
+test suite fails without the CODEOWNERS file and passes with it.
+
+Red proof (file temporarily removed):
+
+```
+CODEOWNERS file exists in a recognised location (Issue #3187) => FAILED
+CODEOWNERS covers the workflows directory (Issue #3187) => FAILED
+CODEOWNERS covers the composite actions directory (Issue #3187) => FAILED
+every CODEOWNERS owner is a valid @user or @org/team (Issue #3187) => FAILED
+FAILED | 0 passed | 4 failed
+```
+
+Green (file present):
+
+```
+ok | 4 passed | 0 failed
+```
+
+```mermaid
+flowchart LR
+    A[PR edits .github/workflows/*] --> B{CODEOWNERS matches path}
+    B -->|"@stSoftwareAU/developers"| C[Require code-owner review]
+    C -->|approved| D[Merge allowed]
+    C -->|not approved| E[Merge blocked]
+```
+
+## Test Plan
+
+- Added `test/ci/CodeownersWorkflowsCoverage.ts`:
+  - `CODEOWNERS file exists in a recognised location` — asserts the file is
+    present in `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`.
+  - `CODEOWNERS covers the workflows directory` — `.github/workflows/*`
+    resolves to at least one owner (last-match-wins semantics).
+  - `CODEOWNERS covers the composite actions directory` — `.github/actions/*`
+    resolves to at least one owner.
+  - `every CODEOWNERS owner is a valid @user or @org/team` — every owner token
+    matches `@user` / `@org/team`, so the rule actually enforces.
+- Confirmed the suite fails against the unfixed tree (no CODEOWNERS) and passes
+  once `.github/CODEOWNERS` is added.
+- `deno fmt --check`, `deno lint`, and `deno check` pass on the new test.

--- a/test/ci/CodeownersWorkflowsCoverage.ts
+++ b/test/ci/CodeownersWorkflowsCoverage.ts
@@ -1,0 +1,155 @@
+/**
+ * Issue #3187 — the repository must ship a `CODEOWNERS` file that requires a
+ * trusted reviewer on every change to the privileged CI/CD surface under
+ * `.github/workflows/` (and `.github/actions/`).
+ *
+ * Several workflows run with credentials far beyond `GITHUB_TOKEN`:
+ * `publish.yml` and `pages.yml` request `id-token: write` (JSR OIDC / Pages),
+ * while `quality.yml` and `update-package-version.yml` expose the
+ * write-scoped `secrets.ACTIONS_PUSH` PAT. Without a CODEOWNERS rule covering
+ * these paths, a single careless or compromised account could open a PR that
+ * quietly edits a workflow which then exfiltrates those secrets the moment CI
+ * fires. Requiring a named code owner's review closes that path.
+ *
+ * This test pins down the governance guarantee so it cannot be silently
+ * removed:
+ *
+ *   1. A CODEOWNERS file exists in one of the three locations GitHub
+ *      recognises (`CODEOWNERS`, `.github/CODEOWNERS`, `docs/CODEOWNERS`).
+ *   2. The workflows directory resolves to at least one owner.
+ *   3. Every owner token is a valid `@user` / `@org/team` reference (so the
+ *      rule actually enforces instead of being ignored by GitHub).
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+
+/** Locations GitHub scans for a CODEOWNERS file, in precedence order. */
+const CODEOWNERS_LOCATIONS = [
+  "CODEOWNERS",
+  ".github/CODEOWNERS",
+  "docs/CODEOWNERS",
+];
+
+interface CodeownersRule {
+  pattern: string;
+  owners: string[];
+}
+
+/** Read the first CODEOWNERS file found, or null when none exists. */
+export async function readCodeowners(): Promise<
+  { path: string; source: string } | null
+> {
+  const reads = CODEOWNERS_LOCATIONS.map(async (rel) => {
+    try {
+      const source = await Deno.readTextFile(join(REPO_ROOT, rel));
+      return { path: rel, source };
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound) return null;
+      throw err;
+    }
+  });
+  // Precedence order: first existing location wins.
+  const results = await Promise.all(reads);
+  return results.find((r) => r !== null) ?? null;
+}
+
+/** Parse CODEOWNERS text into ordered { pattern, owners } rules. */
+export function parseCodeowners(source: string): CodeownersRule[] {
+  const rules: CodeownersRule[] = [];
+  for (const rawLine of source.split("\n")) {
+    const line = rawLine.replace(/#.*$/, "").trim();
+    if (line === "") continue;
+    const [pattern, ...owners] = line.split(/\s+/);
+    if (!pattern) continue;
+    rules.push({ pattern, owners });
+  }
+  return rules;
+}
+
+/** Convert a CODEOWNERS/gitignore-style pattern to an anchored RegExp. */
+function patternToRegExp(pattern: string): RegExp {
+  const anchoredToRoot = pattern.startsWith("/");
+  const core = pattern.replace(/^\/+/, "").replace(/\/+$/, "");
+
+  const escaped = core
+    .split("/")
+    .map((segment) =>
+      segment
+        .split("*")
+        .map((part) => part.replace(/[.+^${}()|[\]\\]/g, "\\$&"))
+        .join("[^/]*")
+    )
+    .join("/");
+
+  const prefix = anchoredToRoot ? "^/?" : "^(?:.*/)?";
+  // Match the file/dir itself and, for a directory pattern, everything beneath.
+  return new RegExp(prefix + escaped + "(?:/.*)?$");
+}
+
+/** Owners for a path using CODEOWNERS last-match-wins semantics. */
+export function ownersFor(rules: CodeownersRule[], path: string): string[] {
+  let owners: string[] = [];
+  for (const rule of rules) {
+    if (patternToRegExp(rule.pattern).test(path)) owners = rule.owners;
+  }
+  return owners;
+}
+
+const OWNER_TOKEN = /^@[A-Za-z0-9-]+(?:\/[A-Za-z0-9._-]+)?$/;
+
+Deno.test("CODEOWNERS file exists in a recognised location (Issue #3187)", async () => {
+  const file = await readCodeowners();
+  assert(
+    file !== null,
+    `A CODEOWNERS file must exist in one of: ${
+      CODEOWNERS_LOCATIONS.join(", ")
+    }`,
+  );
+});
+
+Deno.test("CODEOWNERS covers the workflows directory (Issue #3187)", async () => {
+  const file = await readCodeowners();
+  assert(file !== null, "CODEOWNERS file is required");
+  const rules = parseCodeowners(file.source);
+
+  const owners = ownersFor(rules, ".github/workflows/publish.yml");
+  assert(
+    owners.length > 0,
+    "`.github/workflows/` must resolve to at least one code owner",
+  );
+});
+
+Deno.test("CODEOWNERS covers the composite actions directory (Issue #3187)", async () => {
+  const file = await readCodeowners();
+  assert(file !== null, "CODEOWNERS file is required");
+  const rules = parseCodeowners(file.source);
+
+  const owners = ownersFor(rules, ".github/actions/setup/action.yml");
+  assert(
+    owners.length > 0,
+    "`.github/actions/` must resolve to at least one code owner",
+  );
+});
+
+Deno.test("every CODEOWNERS owner is a valid @user or @org/team (Issue #3187)", async () => {
+  const file = await readCodeowners();
+  assert(file !== null, "CODEOWNERS file is required");
+  const rules = parseCodeowners(file.source);
+
+  assert(rules.length > 0, "CODEOWNERS must declare at least one rule");
+  for (const rule of rules) {
+    assert(
+      rule.owners.length > 0,
+      `Rule "${rule.pattern}" must name at least one owner`,
+    );
+    for (const owner of rule.owners) {
+      assert(
+        OWNER_TOKEN.test(owner),
+        `Owner "${owner}" for "${rule.pattern}" must be a @user or @org/team reference`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
# PR Summary — Issue #3187

## Summary

Add a `CODEOWNERS` file that requires a trusted reviewer on every change to the
privileged CI/CD surface, closing a `severity:high` repo-level governance gap.
No `CODEOWNERS` file previously existed in any of the three locations GitHub
recognises, yet several workflows run with credentials well beyond
`GITHUB_TOKEN` — `publish.yml` / `pages.yml` request `id-token: write` (JSR
OIDC / Pages), and `quality.yml` / `update-package-version.yml` expose the
write-scoped `ACTIONS_PUSH` PAT. Without an owner rule, a single careless or
compromised account could open a PR that quietly edits a workflow which then
exfiltrates those secrets the moment CI fires. Requiring a named code owner's
review closes that poisoned-pipeline path. Closes #3187.

### Owner team choice

The issue suggested `@stSoftwareAU/maintainers`, but that team **does not exist**
in the org (available teams: `ai-users`, `developers`, `service`, `support`,
`system-admin`, `vibe-coders`). A CODEOWNERS rule naming a non-existent team is
silently ignored by GitHub and enforces nothing. Only `developers` and
`vibe-coders` have push access to NEAT-AI, and `vibe-coders` is the automation
account — so the human maintaining team **`@stSoftwareAU/developers`** is used.

### Branch-protection recommendations (repo settings, outside the tree)

CODEOWNERS enforcement additionally requires the default branch to enable
**Require review from Code Owners**. These are repository settings that cannot
be committed to the tree and are documented here as recommendations:

- Enable **required review** so CODEOWNERS approval is enforced before merge.
- Block **direct push and force-push** to the default branch.
- Enable **linear history** if the team uses a rebase/squash workflow.
- Consider **required signed commits**.

## Evidence

Backend/governance change — no web UI to screenshot. Verified via TDD: the new
test suite fails without the CODEOWNERS file and passes with it.

Red proof (file temporarily removed):

```
CODEOWNERS file exists in a recognised location (Issue #3187) => FAILED
CODEOWNERS covers the workflows directory (Issue #3187) => FAILED
CODEOWNERS covers the composite actions directory (Issue #3187) => FAILED
every CODEOWNERS owner is a valid @user or @org/team (Issue #3187) => FAILED
FAILED | 0 passed | 4 failed
```

Green (file present):

```
ok | 4 passed | 0 failed
```

```mermaid
flowchart LR
    A[PR edits .github/workflows/*] --> B{CODEOWNERS matches path}
    B -->|"@stSoftwareAU/developers"| C[Require code-owner review]
    C -->|approved| D[Merge allowed]
    C -->|not approved| E[Merge blocked]
```

## Test Plan

- Added `test/ci/CodeownersWorkflowsCoverage.ts`:
  - `CODEOWNERS file exists in a recognised location` — asserts the file is
    present in `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`.
  - `CODEOWNERS covers the workflows directory` — `.github/workflows/*`
    resolves to at least one owner (last-match-wins semantics).
  - `CODEOWNERS covers the composite actions directory` — `.github/actions/*`
    resolves to at least one owner.
  - `every CODEOWNERS owner is a valid @user or @org/team` — every owner token
    matches `@user` / `@org/team`, so the rule actually enforces.
- Confirmed the suite fails against the unfixed tree (no CODEOWNERS) and passes
  once `.github/CODEOWNERS` is added.
- `deno fmt --check`, `deno lint`, and `deno check` pass on the new test.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr3d3eap-49a529`<!-- vibe-worker-issue-3187 -->