### PR TITLE
Declare SPDX Apache-2.0 license in deno.json (Issue #3189)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
   "version": "5.7.8",
+  "license": "Apache-2.0",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3189.md
+++ b/docs/archive/pr-summaries/pr-summary-3189.md
@@ -1,0 +1,42 @@
+# Declare the `license` field in deno.json (SPDX Apache-2.0)
+
+## Summary
+
+`@stsoftware/neat-ai` is published to JSR, so `deno.json` is consumer-facing
+metadata. The manifest declared `name`, `exports`, and `version` but had **no
+`license` key**, even though the repo ships an Apache-2.0 `LICENSE` file.
+Without a machine-readable licence, JSR's package page, SBOM generators, and
+dependency-licence scanners cannot cross-check the manifest against the
+`LICENSE` file and must fall back to heuristics.
+
+This PR adds the exact SPDX short code matching the committed `LICENSE`:
+
+```json
+"license": "Apache-2.0"
+```
+
+Closes #3189.
+
+## Evidence
+
+Backend/metadata change — no web interface to screenshot. Verified via the new
+CI tests and the quality gate:
+
+- `deno test test/ci/LicenseMetadata.ts` — 2 passed, 0 failed.
+- `./quality.sh --check-only` — `deno fmt`, `deno lint`, and `deno check` all
+  pass cleanly with the change applied.
+
+The SPDX identifier `Apache-2.0` is the canonical short code from
+<https://spdx.org/licenses/> and agrees with the `LICENSE` file
+(`Apache License, Version 2.0`).
+
+## Test Plan
+
+Added `test/ci/LicenseMetadata.ts` following TDD (failed before the manifest
+change, passes after):
+
+- `deno.json declares an SPDX license field` — asserts `license` equals
+  `Apache-2.0`.
+- `declared license agrees with the committed LICENSE file` — asserts the
+  `LICENSE` file is Apache-2.0 and the manifest short code matches it, so the
+  two can never silently drift.

--- a/test/ci/LicenseMetadata.ts
+++ b/test/ci/LicenseMetadata.ts
@@ -1,0 +1,44 @@
+import { assert, assertEquals } from "@std/assert";
+
+/**
+ * Verifies the SPDX licence metadata added for Issue #3189.
+ *
+ * `@stsoftware/neat-ai` is published to JSR, so `deno.json` is consumer-facing
+ * metadata. Without a machine-readable `license` field, JSR's package page,
+ * SBOM generators, and dependency-licence scanners cannot cross-check the
+ * licence against the committed `LICENSE` file and must fall back to
+ * heuristics. These tests lock in that the manifest declares the exact SPDX
+ * short code matching the Apache-2.0 `LICENSE` file.
+ */
+
+interface DenoConfig {
+  license?: string;
+}
+
+async function loadDenoConfig(): Promise<DenoConfig> {
+  return JSON.parse(await Deno.readTextFile("deno.json")) as DenoConfig;
+}
+
+Deno.test("deno.json declares an SPDX license field", async () => {
+  const config = await loadDenoConfig();
+  assertEquals(
+    config.license,
+    "Apache-2.0",
+    "deno.json should declare the SPDX short code `Apache-2.0`",
+  );
+});
+
+Deno.test("declared license agrees with the committed LICENSE file", async () => {
+  const config = await loadDenoConfig();
+  const license = await Deno.readTextFile("LICENSE");
+
+  assert(
+    license.includes("Apache License") && license.includes("Version 2.0"),
+    "LICENSE file should be Apache License, Version 2.0",
+  );
+  assertEquals(
+    config.license,
+    "Apache-2.0",
+    "manifest license must match the Apache-2.0 LICENSE file",
+  );
+});


### PR DESCRIPTION
# Declare the `license` field in deno.json (SPDX Apache-2.0)

## Summary

`@stsoftware/neat-ai` is published to JSR, so `deno.json` is consumer-facing
metadata. The manifest declared `name`, `exports`, and `version` but had **no
`license` key**, even though the repo ships an Apache-2.0 `LICENSE` file.
Without a machine-readable licence, JSR's package page, SBOM generators, and
dependency-licence scanners cannot cross-check the manifest against the
`LICENSE` file and must fall back to heuristics.

This PR adds the exact SPDX short code matching the committed `LICENSE`:

```json
"license": "Apache-2.0"
```

Closes #3189.

## Evidence

Backend/metadata change — no web interface to screenshot. Verified via the new
CI tests and the quality gate:

- `deno test test/ci/LicenseMetadata.ts` — 2 passed, 0 failed.
- `./quality.sh --check-only` — `deno fmt`, `deno lint`, and `deno check` all
  pass cleanly with the change applied.

The SPDX identifier `Apache-2.0` is the canonical short code from
<https://spdx.org/licenses/> and agrees with the `LICENSE` file
(`Apache License, Version 2.0`).

## Test Plan

Added `test/ci/LicenseMetadata.ts` following TDD (failed before the manifest
change, passes after):

- `deno.json declares an SPDX license field` — asserts `license` equals
  `Apache-2.0`.
- `declared license agrees with the committed LICENSE file` — asserts the
  `LICENSE` file is Apache-2.0 and the manifest short code matches it, so the
  two can never silently drift.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr3f3cpn-0e38df`<!-- vibe-worker-issue-3189 -->