### PR TITLE
Add CODEOWNERS coverage for CI/CD surface (Issue #3187)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS — required reviewers for privileged surfaces (Issue #3187)
+#
+# GitHub requires a listed code owner's approval on any pull request that
+# touches a path matched below, once the "Require review from Code Owners"
+# branch-protection rule is enabled on the default branch. This closes the
+# poisoned-pipeline / secret-exfiltration path where a workflow edit runs
+# with privileged secrets (the write-scoped ACTIONS_PUSH PAT and the JSR
+# OIDC `id-token`) the moment CI fires — before a human necessarily
+# notices the workflow diff.
+#
+# Owner teams MUST have write (push) access to this repository, otherwise
+# GitHub silently ignores the rule. `@stSoftwareAU/developers` is the
+# maintaining team with push access to NEAT-AI.
+
+# CI/CD surface — all GitHub Actions workflows and composite actions.
+/.github/workflows/  @stSoftwareAU/developers
+/.github/actions/    @stSoftwareAU/developers
+
+# The CODEOWNERS file itself, so ownership rules cannot be quietly changed.
+/.github/CODEOWNERS  @stSoftwareAU/developers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,16 @@ opening a PR (see the secure-coding principles section of
   dependency carrying a known OSV advisory, shrinking the window between
   disclosure and a reviewable fix rather than waiting for the next weekly
   freshness run.
+- **Code-owner review of the CI/CD surface** — `.github/CODEOWNERS` requires a
+  review from the maintaining team (`@stSoftwareAU/developers`) on any PR that
+  edits `.github/workflows/` or `.github/actions/`. Several workflows run with
+  privileged credentials — `publish.yml` / `pages.yml` request
+  `id-token: write`, and `quality.yml` / `update-package-version.yml` expose the
+  write-scoped `ACTIONS_PUSH` PAT — so requiring a named owner's approval closes
+  the poisoned-pipeline path where a workflow edit exfiltrates those secrets the
+  moment CI fires. Enforcement additionally depends on the default branch
+  enabling the **Require review from Code Owners** branch-protection rule (a
+  repository setting that lives outside the tree).
 
 For everything else, see the sibling docs: [`README.md`](./README.md),
 [`AGENTS.md`](./AGENTS.md), [`CONTRIBUTING.md`](./CONTRIBUTING.md),

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.9",
+  "version": "5.7.10",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/README.md
+++ b/docs/README.md
@@ -164,6 +164,9 @@ Project-level policies, audits, and release plumbing.
   contributors (terminology, invariants, testing rules).
 - **[../CONTRIBUTING.md](../CONTRIBUTING.md)** — first-time contributor guide.
 - **[../SECURITY.md](../SECURITY.md)** — security disclosure policy.
+- **[REPO_GOVERNANCE.md](REPO_GOVERNANCE.md)** — CI/CD code ownership
+  (`.github/CODEOWNERS`) and required branch-protection settings that guard the
+  privileged workflows (Issue #3187).
 - **[../CHANGELOG.md](../CHANGELOG.md)** — release notes.
 - **[EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md)** — 🧭 cluster overview
   for the NEAT-AI-core dependency. Day-to-day workflow for bumping the pinned

--- a/docs/REPO_GOVERNANCE.md
+++ b/docs/REPO_GOVERNANCE.md
@@ -1,0 +1,94 @@
+# Repository governance — CI/CD code ownership and branch protection
+
+This page documents the repository-level controls that protect the CI/CD surface
+of NEAT-AI. It accompanies the [`.github/CODEOWNERS`](../.github/CODEOWNERS)
+file added for Issue #3187.
+
+## Why the CI/CD surface needs code owners
+
+The repository ships several **privileged** GitHub Actions workflows — jobs that
+run with secrets beyond the default `GITHUB_TOKEN`:
+
+| Workflow                                       | Privileged capability                                                      |
+| ---------------------------------------------- | -------------------------------------------------------------------------- |
+| `.github/workflows/publish.yml`                | `id-token: write` — OIDC tokenless publish of `@stsoftware/neat-ai` to JSR |
+| `.github/workflows/pages.yml`                  | `id-token: write` + `pages: write` — GitHub Pages deploy                   |
+| `.github/workflows/update-package-version.yml` | `secrets.ACTIONS_PUSH` — write-scoped push PAT                             |
+| `.github/workflows/quality.yml`                | `secrets.ACTIONS_PUSH`, `secrets.GITLEAKS_LICENSE`                         |
+| `.github/workflows/semgrep.yml`                | `secrets.SEMGREP_APP_TOKEN`                                                |
+| `.github/workflows/coverage.yaml`              | `secrets.CODECOV_TOKEN`                                                    |
+
+Without a code-owner rule covering `.github/workflows/`, a single careless or
+compromised account could open a pull request that quietly edits one of these
+workflows. The edited workflow then runs with those secrets **the moment CI
+fires** — before a human necessarily notices the diff. That is the canonical
+poisoned-pipeline / secret-exfiltration path. Requiring a named code owner's
+review on every CI/CD change closes it.
+
+```mermaid
+flowchart TD
+    A[Contributor opens PR<br/>editing .github/workflows/*] --> B{CODEOWNERS rule<br/>covers path?}
+    B -- No --> C[CI runs edited workflow<br/>with ACTIONS_PUSH / JSR OIDC / tokens]
+    C --> D[Secrets exfiltrated<br/>poisoned pipeline]
+    B -- Yes --> E{Code owner<br/>review approved?}
+    E -- No --> F[Merge blocked<br/>attack path closed]
+    E -- Yes --> G[Trusted change merges]
+```
+
+## Code owners
+
+[`.github/CODEOWNERS`](../.github/CODEOWNERS) assigns the CI/CD surface to
+`@stSoftwareAU/developers`. Code owners **must have write access** to the
+repository, otherwise GitHub silently ignores the rule and enforces no review.
+The `developers` team holds write (push) access and is the trusted human
+reviewer for this repo. (The `vibe-coders` team also has write access but is the
+automated worker account, so it is not used as a human code owner.)
+
+> The `maintainers` team that some templates suggest does **not** exist in the
+> `stSoftwareAU` org — pointing a rule at a non-existent team leaves it
+> unenforced. `test/ci/CodeownersWorkflowsCoverage.ts` guards against that
+> regression.
+
+## Required branch-protection settings
+
+CODEOWNERS only _requests_ review; it is enforced **only** once branch
+protection requires it. These are repository settings (not files in the tree),
+so they must be configured once by a repository administrator on the default
+branch (`Develop`):
+
+- **Require a pull request before merging** — block direct pushes to the default
+  branch.
+- **Require review from Code Owners** — enforce the CODEOWNERS approval before
+  merge. This is the setting that makes the rule above effective.
+- **Block force-pushes** to the default branch.
+- **Require linear history** — recommended if the team uses a rebase/squash
+  workflow.
+- **Require signed commits** — recommended; recent commits on the default branch
+  carry no signature markers.
+
+### Configuring via the GitHub CLI
+
+An administrator can apply the core controls with:
+
+```bash
+gh api -X PUT repos/stSoftwareAU/NEAT-AI/branches/Develop/protection \
+  --input - <<'JSON'
+{
+  "required_pull_request_reviews": {
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 1
+  },
+  "required_status_checks": null,
+  "enforce_admins": true,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "required_linear_history": true
+}
+JSON
+```
+
+> Branch protection cannot be asserted by the unit-test suite — it is a
+> server-side setting invisible to a static checkout. The tests in
+> `test/ci/CodeownersWorkflowsCoverage.ts` verify the part that _is_ visible:
+> that a CODEOWNERS file exists and covers the CI/CD surface with a valid, real
+> owner.

--- a/docs/archive/pr-summaries/pr-summary-3187.md
+++ b/docs/archive/pr-summaries/pr-summary-3187.md
@@ -1,0 +1,78 @@
+# PR Summary — Issue #3187
+
+## Summary
+
+Add a `CODEOWNERS` file that requires a trusted reviewer on every change to the
+privileged CI/CD surface, closing a `severity:high` repo-level governance gap.
+No `CODEOWNERS` file previously existed in any of the three locations GitHub
+recognises, yet several workflows run with credentials well beyond
+`GITHUB_TOKEN` — `publish.yml` / `pages.yml` request `id-token: write` (JSR
+OIDC / Pages), and `quality.yml` / `update-package-version.yml` expose the
+write-scoped `ACTIONS_PUSH` PAT. Without an owner rule, a single careless or
+compromised account could open a PR that quietly edits a workflow which then
+exfiltrates those secrets the moment CI fires. Requiring a named code owner's
+review closes that poisoned-pipeline path. Closes #3187.
+
+### Owner team choice
+
+The issue suggested `@stSoftwareAU/maintainers`, but that team **does not exist**
+in the org (available teams: `ai-users`, `developers`, `service`, `support`,
+`system-admin`, `vibe-coders`). A CODEOWNERS rule naming a non-existent team is
+silently ignored by GitHub and enforces nothing. Only `developers` and
+`vibe-coders` have push access to NEAT-AI, and `vibe-coders` is the automation
+account — so the human maintaining team **`@stSoftwareAU/developers`** is used.
+
+### Branch-protection recommendations (repo settings, outside the tree)
+
+CODEOWNERS enforcement additionally requires the default branch to enable
+**Require review from Code Owners**. These are repository settings that cannot
+be committed to the tree and are documented here as recommendations:
+
+- Enable **required review** so CODEOWNERS approval is enforced before merge.
+- Block **direct push and force-push** to the default branch.
+- Enable **linear history** if the team uses a rebase/squash workflow.
+- Consider **required signed commits**.
+
+## Evidence
+
+Backend/governance change — no web UI to screenshot. Verified via TDD: the new
+test suite fails without the CODEOWNERS file and passes with it.
+
+Red proof (file temporarily removed):
+
+```
+CODEOWNERS file exists in a recognised location (Issue #3187) => FAILED
+CODEOWNERS covers the workflows directory (Issue #3187) => FAILED
+CODEOWNERS covers the composite actions directory (Issue #3187) => FAILED
+every CODEOWNERS owner is a valid @user or @org/team (Issue #3187) => FAILED
+FAILED | 0 passed | 4 failed
+```
+
+Green (file present):
+
+```
+ok | 4 passed | 0 failed
+```
+
+```mermaid
+flowchart LR
+    A[PR edits .github/workflows/*] --> B{CODEOWNERS matches path}
+    B -->|"@stSoftwareAU/developers"| C[Require code-owner review]
+    C -->|approved| D[Merge allowed]
+    C -->|not approved| E[Merge blocked]
+```
+
+## Test Plan
+
+- Added `test/ci/CodeownersWorkflowsCoverage.ts`:
+  - `CODEOWNERS file exists in a recognised location` — asserts the file is
+    present in `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`.
+  - `CODEOWNERS covers the workflows directory` — `.github/workflows/*`
+    resolves to at least one owner (last-match-wins semantics).
+  - `CODEOWNERS covers the composite actions directory` — `.github/actions/*`
+    resolves to at least one owner.
+  - `every CODEOWNERS owner is a valid @user or @org/team` — every owner token
+    matches `@user` / `@org/team`, so the rule actually enforces.
+- Confirmed the suite fails against the unfixed tree (no CODEOWNERS) and passes
+  once `.github/CODEOWNERS` is added.
+- `deno fmt --check`, `deno lint`, and `deno check` pass on the new test.

--- a/docs/archive/pr-summaries/pr-summary-3187.md
+++ b/docs/archive/pr-summaries/pr-summary-3187.md
@@ -6,8 +6,8 @@ Add a `CODEOWNERS` file that requires a trusted reviewer on every change to the
 privileged CI/CD surface, closing a `severity:high` repo-level governance gap.
 No `CODEOWNERS` file previously existed in any of the three locations GitHub
 recognises, yet several workflows run with credentials well beyond
-`GITHUB_TOKEN` — `publish.yml` / `pages.yml` request `id-token: write` (JSR
-OIDC / Pages), and `quality.yml` / `update-package-version.yml` expose the
+`GITHUB_TOKEN` — `publish.yml` / `pages.yml` request `id-token: write` (JSR OIDC
+/ Pages), and `quality.yml` / `update-package-version.yml` expose the
 write-scoped `ACTIONS_PUSH` PAT. Without an owner rule, a single careless or
 compromised account could open a PR that quietly edits a workflow which then
 exfiltrates those secrets the moment CI fires. Requiring a named code owner's
@@ -15,23 +15,30 @@ review closes that poisoned-pipeline path. Closes #3187.
 
 ### Owner team choice
 
-The issue suggested `@stSoftwareAU/maintainers`, but that team **does not exist**
-in the org (available teams: `ai-users`, `developers`, `service`, `support`,
-`system-admin`, `vibe-coders`). A CODEOWNERS rule naming a non-existent team is
-silently ignored by GitHub and enforces nothing. Only `developers` and
-`vibe-coders` have push access to NEAT-AI, and `vibe-coders` is the automation
-account — so the human maintaining team **`@stSoftwareAU/developers`** is used.
+The issue suggested `@stSoftwareAU/maintainers`, but that team **does not
+exist** in the org (available teams: `ai-users`, `developers`, `service`,
+`support`, `system-admin`, `vibe-coders`). A CODEOWNERS rule naming a
+non-existent team is silently ignored by GitHub and enforces nothing. Only
+`developers` and `vibe-coders` have push access to NEAT-AI, and `vibe-coders` is
+the automation account — so the human maintaining team
+**`@stSoftwareAU/developers`** is used.
 
 ### Branch-protection recommendations (repo settings, outside the tree)
 
 CODEOWNERS enforcement additionally requires the default branch to enable
 **Require review from Code Owners**. These are repository settings that cannot
-be committed to the tree and are documented here as recommendations:
+be committed to the tree, so they are documented as an admin runbook in the new
+[`docs/REPO_GOVERNANCE.md`](../../REPO_GOVERNANCE.md) (with a ready-to-run
+`gh api` snippet):
 
 - Enable **required review** so CODEOWNERS approval is enforced before merge.
 - Block **direct push and force-push** to the default branch.
 - Enable **linear history** if the team uses a rebase/squash workflow.
 - Consider **required signed commits**.
+
+The change also adds a bullet to [`SECURITY.md`](../../../SECURITY.md)
+documenting the code-owner control alongside the other supply-chain defences,
+and links the new governance doc from the docs index.
 
 ## Evidence
 
@@ -51,7 +58,7 @@ FAILED | 0 passed | 4 failed
 Green (file present):
 
 ```
-ok | 4 passed | 0 failed
+ok | 5 passed | 0 failed
 ```
 
 ```mermaid
@@ -67,12 +74,15 @@ flowchart LR
 - Added `test/ci/CodeownersWorkflowsCoverage.ts`:
   - `CODEOWNERS file exists in a recognised location` — asserts the file is
     present in `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`.
-  - `CODEOWNERS covers the workflows directory` — `.github/workflows/*`
-    resolves to at least one owner (last-match-wins semantics).
+  - `CODEOWNERS covers the workflows directory` — `.github/workflows/*` resolves
+    to at least one owner (last-match-wins semantics).
   - `CODEOWNERS covers the composite actions directory` — `.github/actions/*`
     resolves to at least one owner.
   - `every CODEOWNERS owner is a valid @user or @org/team` — every owner token
     matches `@user` / `@org/team`, so the rule actually enforces.
+  - `CODEOWNERS does not reference the non-existent 'maintainers' team` —
+    regression guard for the ineffective-owner failure mode (a rule pointing at
+    a team without write access is silently ignored by GitHub).
 - Confirmed the suite fails against the unfixed tree (no CODEOWNERS) and passes
   once `.github/CODEOWNERS` is added.
 - `deno fmt --check`, `deno lint`, and `deno check` pass on the new test.

--- a/test/ci/CodeownersWorkflowsCoverage.ts
+++ b/test/ci/CodeownersWorkflowsCoverage.ts
@@ -1,0 +1,155 @@
+/**
+ * Issue #3187 — the repository must ship a `CODEOWNERS` file that requires a
+ * trusted reviewer on every change to the privileged CI/CD surface under
+ * `.github/workflows/` (and `.github/actions/`).
+ *
+ * Several workflows run with credentials far beyond `GITHUB_TOKEN`:
+ * `publish.yml` and `pages.yml` request `id-token: write` (JSR OIDC / Pages),
+ * while `quality.yml` and `update-package-version.yml` expose the
+ * write-scoped `secrets.ACTIONS_PUSH` PAT. Without a CODEOWNERS rule covering
+ * these paths, a single careless or compromised account could open a PR that
+ * quietly edits a workflow which then exfiltrates those secrets the moment CI
+ * fires. Requiring a named code owner's review closes that path.
+ *
+ * This test pins down the governance guarantee so it cannot be silently
+ * removed:
+ *
+ *   1. A CODEOWNERS file exists in one of the three locations GitHub
+ *      recognises (`CODEOWNERS`, `.github/CODEOWNERS`, `docs/CODEOWNERS`).
+ *   2. The workflows directory resolves to at least one owner.
+ *   3. Every owner token is a valid `@user` / `@org/team` reference (so the
+ *      rule actually enforces instead of being ignored by GitHub).
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+
+/** Locations GitHub scans for a CODEOWNERS file, in precedence order. */
+const CODEOWNERS_LOCATIONS = [
+  "CODEOWNERS",
+  ".github/CODEOWNERS",
+  "docs/CODEOWNERS",
+];
+
+interface CodeownersRule {
+  pattern: string;
+  owners: string[];
+}
+
+/** Read the first CODEOWNERS file found, or null when none exists. */
+export async function readCodeowners(): Promise<
+  { path: string; source: string } | null
+> {
+  const reads = CODEOWNERS_LOCATIONS.map(async (rel) => {
+    try {
+      const source = await Deno.readTextFile(join(REPO_ROOT, rel));
+      return { path: rel, source };
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound) return null;
+      throw err;
+    }
+  });
+  // Precedence order: first existing location wins.
+  const results = await Promise.all(reads);
+  return results.find((r) => r !== null) ?? null;
+}
+
+/** Parse CODEOWNERS text into ordered { pattern, owners } rules. */
+export function parseCodeowners(source: string): CodeownersRule[] {
+  const rules: CodeownersRule[] = [];
+  for (const rawLine of source.split("\n")) {
+    const line = rawLine.replace(/#.*$/, "").trim();
+    if (line === "") continue;
+    const [pattern, ...owners] = line.split(/\s+/);
+    if (!pattern) continue;
+    rules.push({ pattern, owners });
+  }
+  return rules;
+}
+
+/** Convert a CODEOWNERS/gitignore-style pattern to an anchored RegExp. */
+function patternToRegExp(pattern: string): RegExp {
+  const anchoredToRoot = pattern.startsWith("/");
+  const core = pattern.replace(/^\/+/, "").replace(/\/+$/, "");
+
+  const escaped = core
+    .split("/")
+    .map((segment) =>
+      segment
+        .split("*")
+        .map((part) => part.replace(/[.+^${}()|[\]\\]/g, "\\$&"))
+        .join("[^/]*")
+    )
+    .join("/");
+
+  const prefix = anchoredToRoot ? "^/?" : "^(?:.*/)?";
+  // Match the file/dir itself and, for a directory pattern, everything beneath.
+  return new RegExp(prefix + escaped + "(?:/.*)?$");
+}
+
+/** Owners for a path using CODEOWNERS last-match-wins semantics. */
+export function ownersFor(rules: CodeownersRule[], path: string): string[] {
+  let owners: string[] = [];
+  for (const rule of rules) {
+    if (patternToRegExp(rule.pattern).test(path)) owners = rule.owners;
+  }
+  return owners;
+}
+
+const OWNER_TOKEN = /^@[A-Za-z0-9-]+(?:\/[A-Za-z0-9._-]+)?$/;
+
+Deno.test("CODEOWNERS file exists in a recognised location (Issue #3187)", async () => {
+  const file = await readCodeowners();
+  assert(
+    file !== null,
+    `A CODEOWNERS file must exist in one of: ${
+      CODEOWNERS_LOCATIONS.join(", ")
+    }`,
+  );
+});
+
+Deno.test("CODEOWNERS covers the workflows directory (Issue #3187)", async () => {
+  const file = await readCodeowners();
+  assert(file !== null, "CODEOWNERS file is required");
+  const rules = parseCodeowners(file.source);
+
+  const owners = ownersFor(rules, ".github/workflows/publish.yml");
+  assert(
+    owners.length > 0,
+    "`.github/workflows/` must resolve to at least one code owner",
+  );
+});
+
+Deno.test("CODEOWNERS covers the composite actions directory (Issue #3187)", async () => {
+  const file = await readCodeowners();
+  assert(file !== null, "CODEOWNERS file is required");
+  const rules = parseCodeowners(file.source);
+
+  const owners = ownersFor(rules, ".github/actions/setup/action.yml");
+  assert(
+    owners.length > 0,
+    "`.github/actions/` must resolve to at least one code owner",
+  );
+});
+
+Deno.test("every CODEOWNERS owner is a valid @user or @org/team (Issue #3187)", async () => {
+  const file = await readCodeowners();
+  assert(file !== null, "CODEOWNERS file is required");
+  const rules = parseCodeowners(file.source);
+
+  assert(rules.length > 0, "CODEOWNERS must declare at least one rule");
+  for (const rule of rules) {
+    assert(
+      rule.owners.length > 0,
+      `Rule "${rule.pattern}" must name at least one owner`,
+    );
+    for (const owner of rule.owners) {
+      assert(
+        OWNER_TOKEN.test(owner),
+        `Owner "${owner}" for "${rule.pattern}" must be a @user or @org/team reference`,
+      );
+    }
+  }
+});

--- a/test/ci/CodeownersWorkflowsCoverage.ts
+++ b/test/ci/CodeownersWorkflowsCoverage.ts
@@ -153,3 +153,27 @@ Deno.test("every CODEOWNERS owner is a valid @user or @org/team (Issue #3187)", 
     }
   }
 });
+
+// A code owner must have write access or GitHub silently ignores the rule and
+// enforces no review. The `maintainers` team suggested by some templates does
+// not exist in the stSoftwareAU org, so pointing a rule at it would leave the
+// CI/CD surface unprotected. Guard against that regression explicitly.
+const NONEXISTENT_TEAM = /^@[A-Za-z0-9-]+\/maintainers$/i;
+
+Deno.test("CODEOWNERS does not reference the non-existent 'maintainers' team (Issue #3187)", async () => {
+  const file = await readCodeowners();
+  assert(file !== null, "CODEOWNERS file is required");
+  const rules = parseCodeowners(file.source);
+
+  for (const rule of rules) {
+    for (const owner of rule.owners) {
+      assert(
+        !NONEXISTENT_TEAM.test(owner),
+        `Owner "${owner}" for "${rule.pattern}" references a 'maintainers' team ` +
+          "that does not exist in the stSoftwareAU org. A code owner must have " +
+          "write access, otherwise GitHub ignores the rule and no review is " +
+          "enforced. Use @stSoftwareAU/developers instead.",
+      );
+    }
+  }
+});


### PR DESCRIPTION
# PR Summary — Issue #3187

## Summary

Add a `CODEOWNERS` file that requires a trusted reviewer on every change to the
privileged CI/CD surface, closing a `severity:high` repo-level governance gap.
No `CODEOWNERS` file previously existed in any of the three locations GitHub
recognises, yet several workflows run with credentials well beyond
`GITHUB_TOKEN` — `publish.yml` / `pages.yml` request `id-token: write` (JSR OIDC
/ Pages), and `quality.yml` / `update-package-version.yml` expose the
write-scoped `ACTIONS_PUSH` PAT. Without an owner rule, a single careless or
compromised account could open a PR that quietly edits a workflow which then
exfiltrates those secrets the moment CI fires. Requiring a named code owner's
review closes that poisoned-pipeline path. Closes #3187.

### Owner team choice

The issue suggested `@stSoftwareAU/maintainers`, but that team **does not
exist** in the org (available teams: `ai-users`, `developers`, `service`,
`support`, `system-admin`, `vibe-coders`). A CODEOWNERS rule naming a
non-existent team is silently ignored by GitHub and enforces nothing. Only
`developers` and `vibe-coders` have push access to NEAT-AI, and `vibe-coders` is
the automation account — so the human maintaining team
**`@stSoftwareAU/developers`** is used.

### Branch-protection recommendations (repo settings, outside the tree)

CODEOWNERS enforcement additionally requires the default branch to enable
**Require review from Code Owners**. These are repository settings that cannot
be committed to the tree, so they are documented as an admin runbook in the new
[`docs/REPO_GOVERNANCE.md`](../../REPO_GOVERNANCE.md) (with a ready-to-run
`gh api` snippet):

- Enable **required review** so CODEOWNERS approval is enforced before merge.
- Block **direct push and force-push** to the default branch.
- Enable **linear history** if the team uses a rebase/squash workflow.
- Consider **required signed commits**.

The change also adds a bullet to [`SECURITY.md`](../../../SECURITY.md)
documenting the code-owner control alongside the other supply-chain defences,
and links the new governance doc from the docs index.

## Evidence

Backend/governance change — no web UI to screenshot. Verified via TDD: the new
test suite fails without the CODEOWNERS file and passes with it.

Red proof (file temporarily removed):

```
CODEOWNERS file exists in a recognised location (Issue #3187) => FAILED
CODEOWNERS covers the workflows directory (Issue #3187) => FAILED
CODEOWNERS covers the composite actions directory (Issue #3187) => FAILED
every CODEOWNERS owner is a valid @user or @org/team (Issue #3187) => FAILED
FAILED | 0 passed | 4 failed
```

Green (file present):

```
ok | 5 passed | 0 failed
```

```mermaid
flowchart LR
    A[PR edits .github/workflows/*] --> B{CODEOWNERS matches path}
    B -->|"@stSoftwareAU/developers"| C[Require code-owner review]
    C -->|approved| D[Merge allowed]
    C -->|not approved| E[Merge blocked]
```

## Test Plan

- Added `test/ci/CodeownersWorkflowsCoverage.ts`:
  - `CODEOWNERS file exists in a recognised location` — asserts the file is
    present in `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`.
  - `CODEOWNERS covers the workflows directory` — `.github/workflows/*` resolves
    to at least one owner (last-match-wins semantics).
  - `CODEOWNERS covers the composite actions directory` — `.github/actions/*`
    resolves to at least one owner.
  - `every CODEOWNERS owner is a valid @user or @org/team` — every owner token
    matches `@user` / `@org/team`, so the rule actually enforces.
  - `CODEOWNERS does not reference the non-existent 'maintainers' team` —
    regression guard for the ineffective-owner failure mode (a rule pointing at
    a team without write access is silently ignored by GitHub).
- Confirmed the suite fails against the unfixed tree (no CODEOWNERS) and passes
  once `.github/CODEOWNERS` is added.
- `deno fmt --check`, `deno lint`, and `deno check` pass on the new test.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr3hahc9-6f9c7a`<!-- vibe-worker-issue-3187 -->