### PR TITLE
Assert exhaustiveness in mapRustCoordinatedOp instead of silently casting (#3190)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3190.md
+++ b/docs/archive/pr-summaries/pr-summary-3190.md
@@ -1,0 +1,60 @@
+# Assert exhaustiveness in `mapRustCoordinatedOp` instead of silently casting
+
+## Summary
+
+`mapRustCoordinatedOp` in
+`src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts` is the
+translation boundary between the Rust wire union
+(`RustCoordinatedStructuralOperation`, two variants) and the TS
+`CoordinatedStructuralOperation` model (seven variants). Its `default` branch
+previously did `return op as CoordinatedStructuralOperation`, silently blessing
+any unhandled variant through the boundary **unmapped and with no compile
+error**. The day the Rust side emits a third operation (e.g. `setWeight`), that
+value would slip through unmapped — a latent, hard-to-trace data-mapping bug.
+
+This change replaces the silent cast with the project's canonical
+exhaustiveness guard `assertNever` (`src/utils/assertNever.ts`), matching the
+sibling file `ApplyCoordinatedStructuralCandidate.ts`. Now:
+
+- If a new Rust variant is added and this mapper forgets to handle it, `op` is
+  no longer narrowed to `never` and the build fails at the `assertNever` call —
+  turning a latent runtime bug into a compile-time error.
+- At runtime, malformed wire data that escaped the type system throws loudly
+  ("Unhandled variant: …") rather than passing through silently.
+
+`mapRustCoordinatedOp` was made `export`ed (following the existing
+`mapRustCandidate` / `mapRustNeuronCandidate` public-mapper pattern) so its
+behaviour can be exercised directly by tests.
+
+Closes #3190.
+
+## Change flow
+
+```mermaid
+flowchart LR
+    R[RustCoordinatedStructuralOperation] --> M{switch op.type}
+    M -->|removeSynapse| A[mapped op]
+    M -->|addSynapse| A
+    M -->|default: op is never| N["assertNever(op)"]
+    N -->|compile time| C[build fails if new variant unhandled]
+    N -->|runtime| T[throws 'Unhandled variant']
+```
+
+## Evidence
+
+Backend/type-safety change — no web interface to screenshot. Verified via:
+
+- `deno test test/ErrorGuidedStructuralEvolution/MapRustCoordinatedOpExhaustiveness.ts`
+  → `3 passed | 0 failed`.
+- `deno check` on the changed source + test → passes, confirming the `default`
+  branch still type-checks (both variants handled, so `op` narrows to `never`).
+- `deno lint` and `deno fmt` clean on both files.
+
+## Test Plan
+
+Added `test/ErrorGuidedStructuralEvolution/MapRustCoordinatedOpExhaustiveness.ts`:
+
+- **Happy path** — `removeSynapse` maps to the correct TS shape.
+- **Happy path** — `addSynapse` maps and preserves `weight`.
+- **Error path** — an unmapped variant (`setWeight`, cast past the type system)
+  now throws `Error: Unhandled variant …` instead of being silently cast.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts
@@ -24,6 +24,7 @@ import type {
   RustNeuronDiagnostic,
   RustSynapseDiagnostic,
 } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import { assertNever } from "@utils/assertNever.ts";
 
 /**
  * Maps a RustCandidateSynapse to CandidateSynapse.
@@ -275,7 +276,7 @@ export function tryRustHelpfulNeurons(
 /**
  * Maps a single Rust coordinated operation (string UUIDs) to the TS type (number IDs).
  */
-function mapRustCoordinatedOp(
+export function mapRustCoordinatedOp(
   op: RustCoordinatedStructuralOperation,
 ): CoordinatedStructuralOperation {
   switch (op.type) {
@@ -293,7 +294,7 @@ function mapRustCoordinatedOp(
         weight: op.weight,
       };
     default:
-      return op as CoordinatedStructuralOperation;
+      return assertNever(op);
   }
 }
 

--- a/test/ErrorGuidedStructuralEvolution/MapRustCoordinatedOpExhaustiveness.ts
+++ b/test/ErrorGuidedStructuralEvolution/MapRustCoordinatedOpExhaustiveness.ts
@@ -1,0 +1,56 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { mapRustCoordinatedOp } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts";
+import type { RustCoordinatedStructuralOperation } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+
+// Issue #3190: the `default` branch of `mapRustCoordinatedOp` previously cast
+// silently (`op as CoordinatedStructuralOperation`). It now calls the project's
+// exhaustiveness guard `assertNever`, so an unmapped Rust variant that escapes
+// the type system (malformed wire data) fails loudly at runtime instead of
+// being blessed through the boundary unmapped.
+
+Deno.test("mapRustCoordinatedOp maps a removeSynapse operation", () => {
+  const op: RustCoordinatedStructuralOperation = {
+    type: "removeSynapse",
+    fromNeuronUuid: "input-0",
+    toNeuronUuid: "output-0",
+  };
+
+  const mapped = mapRustCoordinatedOp(op);
+  assertEquals(mapped, {
+    type: "removeSynapse",
+    fromNeuronUuid: "input-0",
+    toNeuronUuid: "output-0",
+  });
+});
+
+Deno.test("mapRustCoordinatedOp maps an addSynapse operation with its weight", () => {
+  const op: RustCoordinatedStructuralOperation = {
+    type: "addSynapse",
+    fromNeuronUuid: "input-0",
+    toNeuronUuid: "output-0",
+    weight: 0.75,
+  };
+
+  const mapped = mapRustCoordinatedOp(op);
+  assertEquals(mapped, {
+    type: "addSynapse",
+    fromNeuronUuid: "input-0",
+    toNeuronUuid: "output-0",
+    weight: 0.75,
+  });
+});
+
+Deno.test("mapRustCoordinatedOp throws on an unmapped variant instead of casting silently", () => {
+  // Simulate malformed wire data / a new Rust variant that escaped the type
+  // system. The `default` branch must now assert rather than pass it through.
+  const rogue = { type: "setWeight", fromNeuronUuid: "a", toNeuronUuid: "b" };
+
+  assertThrows(
+    () =>
+      mapRustCoordinatedOp(
+        rogue as unknown as RustCoordinatedStructuralOperation,
+      ),
+    Error,
+    "Unhandled variant",
+  );
+});


### PR DESCRIPTION
# Assert exhaustiveness in `mapRustCoordinatedOp` instead of silently casting

## Summary

`mapRustCoordinatedOp` in
`src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts` is the
translation boundary between the Rust wire union
(`RustCoordinatedStructuralOperation`, two variants) and the TS
`CoordinatedStructuralOperation` model (seven variants). Its `default` branch
previously did `return op as CoordinatedStructuralOperation`, silently blessing
any unhandled variant through the boundary **unmapped and with no compile
error**. The day the Rust side emits a third operation (e.g. `setWeight`), that
value would slip through unmapped — a latent, hard-to-trace data-mapping bug.

This change replaces the silent cast with the project's canonical
exhaustiveness guard `assertNever` (`src/utils/assertNever.ts`), matching the
sibling file `ApplyCoordinatedStructuralCandidate.ts`. Now:

- If a new Rust variant is added and this mapper forgets to handle it, `op` is
  no longer narrowed to `never` and the build fails at the `assertNever` call —
  turning a latent runtime bug into a compile-time error.
- At runtime, malformed wire data that escaped the type system throws loudly
  ("Unhandled variant: …") rather than passing through silently.

`mapRustCoordinatedOp` was made `export`ed (following the existing
`mapRustCandidate` / `mapRustNeuronCandidate` public-mapper pattern) so its
behaviour can be exercised directly by tests.

Closes #3190.

## Change flow

```mermaid
flowchart LR
    R[RustCoordinatedStructuralOperation] --> M{switch op.type}
    M -->|removeSynapse| A[mapped op]
    M -->|addSynapse| A
    M -->|default: op is never| N["assertNever(op)"]
    N -->|compile time| C[build fails if new variant unhandled]
    N -->|runtime| T[throws 'Unhandled variant']
```

## Evidence

Backend/type-safety change — no web interface to screenshot. Verified via:

- `deno test test/ErrorGuidedStructuralEvolution/MapRustCoordinatedOpExhaustiveness.ts`
  → `3 passed | 0 failed`.
- `deno check` on the changed source + test → passes, confirming the `default`
  branch still type-checks (both variants handled, so `op` narrows to `never`).
- `deno lint` and `deno fmt` clean on both files.

## Test Plan

Added `test/ErrorGuidedStructuralEvolution/MapRustCoordinatedOpExhaustiveness.ts`:

- **Happy path** — `removeSynapse` maps to the correct TS shape.
- **Happy path** — `addSynapse` maps and preserves `weight`.
- **Error path** — an unmapped variant (`setWeight`, cast past the type system)
  now throws `Error: Unhandled variant …` instead of being silently cast.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr3jju8y-5531a6`<!-- vibe-worker-issue-3190 -->