### PR TITLE
Add 24h minimumReleaseAge quarantine to renovate.json (Issue #3191)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3191.md
+++ b/docs/archive/pr-summaries/pr-summary-3191.md
@@ -1,0 +1,69 @@
+# Renovate 24h quarantine (minimumReleaseAge) — Issue #3191
+
+## Summary
+
+`renovate.json` enabled Renovate via `config:recommended` with **no**
+`minimumReleaseAge` (nor its legacy alias `stabilityDays`), so it was an
+ungated third dependency-update path alongside the two deliberately gated ones:
+
+- `bump-deps.sh` — `deno outdated --update --latest --minimum-dependency-age`
+  (default 24h via `VIBE_BUMP_QUARANTINE_HOURS`).
+- `.github/workflows/deno-outdated.yml` — the same 24h window (Issue #2741).
+
+Renovate could therefore raise a version-bump PR the moment a release is
+published, inside the window the other two paths deliberately close — a
+defence-in-depth supply-chain gap (A03:2025, `supply-chain:quarantine-misconfigured`).
+
+This change makes all three paths agree by adding a **24 hour**
+`minimumReleaseAge` quarantine to `renovate.json`, while:
+
+- **Exempting internal `stSoftwareAU/*` deps** (`minimumReleaseAge: "0"` via a
+  `packageRules` entry) so they still bump immediately — mirroring the
+  `minimumDependencyAge.exclude` globs in `deno.json`.
+- **Letting security advisories bypass the wait** — `vulnerabilityAlerts`
+  keeps `enabled: true` and adds `minimumReleaseAge: "0"`, so OSV/advisory-driven
+  remediation PRs are not held back by the routine quarantine.
+
+Closes #3191.
+
+## Update-path alignment
+
+```mermaid
+flowchart LR
+    subgraph Gated["24h quarantine (aligned)"]
+      A[bump-deps.sh<br/>--minimum-dependency-age]
+      B[deno-outdated.yml<br/>--minimum-dependency-age]
+      C[renovate.json<br/>minimumReleaseAge: 24 hours]
+    end
+    A --> M[main]
+    B --> M
+    C --> M
+    C -. "stSoftwareAU/* → 0h" .-> M
+    C -. "security advisory → 0h" .-> M
+```
+
+## Evidence
+
+CI-config change only — no web interface to screenshot. Verified via the
+"what" tests in `test/ci/RenovateConfig.ts`, which parse the committed
+`renovate.json` and assert on the resulting configuration:
+
+```
+renovate.json enforces a 24h minimumReleaseAge quarantine (Issue #3191) ... ok
+renovate.json exempts internal stSoftwareAU deps from the quarantine (Issue #3191) ... ok
+renovate.json lets security advisories bypass the quarantine (Issue #3191) ... ok
+```
+
+`./quality.sh --lint-only` and `./quality.sh --check-only` both pass.
+
+## Test Plan
+
+- Added to `test/ci/RenovateConfig.ts`:
+  - `renovate.json enforces a 24h minimumReleaseAge quarantine (Issue #3191)` —
+    asserts the top-level `minimumReleaseAge` resolves to 24 hours.
+  - `renovate.json exempts internal stSoftwareAU deps from the quarantine (Issue #3191)` —
+    asserts a `packageRules` entry matches `stSoftwareAU/*` packages with a 0h age.
+  - `renovate.json lets security advisories bypass the quarantine (Issue #3191)` —
+    asserts `vulnerabilityAlerts.minimumReleaseAge` resolves to 0.
+- Added a `durationToHours` helper so the tests assert on the resulting
+  duration (24h / 0h), not on the exact string used to express it.

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "vulnerabilityAlerts": { "enabled": true },
-  "osvVulnerabilityAlerts": true
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "minimumReleaseAge": "0"
+  },
+  "osvVulnerabilityAlerts": true,
+  "minimumReleaseAge": "24 hours",
+  "packageRules": [
+    {
+      "description": "Internal stSoftwareAU/* deps bump immediately (0h quarantine), mirroring deno.json minimumDependencyAge.exclude",
+      "matchPackageNames": [
+        "/^@stsoftware\\//",
+        "/^jsr:@stsoftware\\//",
+        "/^npm:@stsoftware\\//"
+      ],
+      "minimumReleaseAge": "0"
+    }
+  ]
 }

--- a/test/ci/RenovateConfig.ts
+++ b/test/ci/RenovateConfig.ts
@@ -24,6 +24,13 @@ const RENOVATE_CONFIG = join(REPO_ROOT, "renovate.json");
 
 interface VulnerabilityAlerts {
   enabled?: boolean;
+  minimumReleaseAge?: string;
+}
+
+interface PackageRule {
+  description?: string;
+  matchPackageNames?: string[];
+  minimumReleaseAge?: string;
 }
 
 interface RenovateConfig {
@@ -31,6 +38,29 @@ interface RenovateConfig {
   extends?: string[];
   vulnerabilityAlerts?: VulnerabilityAlerts;
   osvVulnerabilityAlerts?: boolean;
+  minimumReleaseAge?: string;
+  packageRules?: PackageRule[];
+}
+
+/** Parse a Renovate duration string (e.g. "24 hours", "0") to hours. */
+function durationToHours(value: string): number {
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed) / 3600; // bare seconds
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*(hour|day|week|minute)s?$/i);
+  if (!match) return NaN;
+  const amount = Number(match[1]);
+  switch (match[2].toLowerCase()) {
+    case "minute":
+      return amount / 60;
+    case "hour":
+      return amount;
+    case "day":
+      return amount * 24;
+    case "week":
+      return amount * 24 * 7;
+    default:
+      return NaN;
+  }
 }
 
 async function readConfig(): Promise<RenovateConfig> {
@@ -94,5 +124,58 @@ Deno.test("renovate.json enables OSV-backed vulnerability alerts (Issue #3007)",
     "osvVulnerabilityAlerts must be true so OSV advisories (the same database " +
       "osv-scan.yml detects against) raise dedicated remediation PRs — closing " +
       "the remediation-automation half of the detection loop",
+  );
+});
+
+Deno.test("renovate.json enforces a 24h minimumReleaseAge quarantine (Issue #3191)", async () => {
+  const config = await readConfig();
+  assert(
+    typeof config.minimumReleaseAge === "string",
+    "renovate.json must set a top-level minimumReleaseAge so routine version " +
+      "bumps are quarantined, matching the 24h window enforced by bump-deps.sh " +
+      "and .github/workflows/deno-outdated.yml",
+  );
+  assertEquals(
+    durationToHours(config.minimumReleaseAge!),
+    24,
+    "the top-level minimumReleaseAge must be 24 hours to agree with the other " +
+      "two gated dependency-update paths (VIBE_BUMP_QUARANTINE_HOURS default)",
+  );
+});
+
+Deno.test("renovate.json exempts internal stSoftwareAU deps from the quarantine (Issue #3191)", async () => {
+  const config = await readConfig();
+  assert(
+    Array.isArray(config.packageRules) && config.packageRules.length > 0,
+    "renovate.json must declare packageRules to exempt internal " +
+      "stSoftwareAU/* dependencies, which are bumped immediately",
+  );
+  const internalRule = config.packageRules!.find((rule) =>
+    rule.minimumReleaseAge !== undefined &&
+    durationToHours(rule.minimumReleaseAge) === 0 &&
+    Array.isArray(rule.matchPackageNames) &&
+    rule.matchPackageNames.some((pattern) => /stsoftware/i.test(pattern))
+  );
+  assert(
+    internalRule !== undefined,
+    "renovate.json must contain a packageRule matching internal " +
+      "stSoftwareAU/* packages with minimumReleaseAge 0 so internal deps " +
+      "update immediately, mirroring deno.json minimumDependencyAge.exclude",
+  );
+});
+
+Deno.test("renovate.json lets security advisories bypass the quarantine (Issue #3191)", async () => {
+  const config = await readConfig();
+  assert(
+    config.vulnerabilityAlerts !== undefined &&
+      typeof config.vulnerabilityAlerts.minimumReleaseAge === "string",
+    "vulnerabilityAlerts.minimumReleaseAge must be set so advisory-driven " +
+      "security patches are not held back by the routine quarantine",
+  );
+  assertEquals(
+    durationToHours(config.vulnerabilityAlerts!.minimumReleaseAge!),
+    0,
+    "security remediation PRs should not wait out the 24h quarantine — set " +
+      "vulnerabilityAlerts.minimumReleaseAge to 0",
   );
 });


### PR DESCRIPTION
# Renovate 24h quarantine (minimumReleaseAge) — Issue #3191

## Summary

`renovate.json` enabled Renovate via `config:recommended` with **no**
`minimumReleaseAge` (nor its legacy alias `stabilityDays`), so it was an
ungated third dependency-update path alongside the two deliberately gated ones:

- `bump-deps.sh` — `deno outdated --update --latest --minimum-dependency-age`
  (default 24h via `VIBE_BUMP_QUARANTINE_HOURS`).
- `.github/workflows/deno-outdated.yml` — the same 24h window (Issue #2741).

Renovate could therefore raise a version-bump PR the moment a release is
published, inside the window the other two paths deliberately close — a
defence-in-depth supply-chain gap (A03:2025, `supply-chain:quarantine-misconfigured`).

This change makes all three paths agree by adding a **24 hour**
`minimumReleaseAge` quarantine to `renovate.json`, while:

- **Exempting internal `stSoftwareAU/*` deps** (`minimumReleaseAge: "0"` via a
  `packageRules` entry) so they still bump immediately — mirroring the
  `minimumDependencyAge.exclude` globs in `deno.json`.
- **Letting security advisories bypass the wait** — `vulnerabilityAlerts`
  keeps `enabled: true` and adds `minimumReleaseAge: "0"`, so OSV/advisory-driven
  remediation PRs are not held back by the routine quarantine.

Closes #3191.

## Update-path alignment

```mermaid
flowchart LR
    subgraph Gated["24h quarantine (aligned)"]
      A[bump-deps.sh<br/>--minimum-dependency-age]
      B[deno-outdated.yml<br/>--minimum-dependency-age]
      C[renovate.json<br/>minimumReleaseAge: 24 hours]
    end
    A --> M[main]
    B --> M
    C --> M
    C -. "stSoftwareAU/* → 0h" .-> M
    C -. "security advisory → 0h" .-> M
```

## Evidence

CI-config change only — no web interface to screenshot. Verified via the
"what" tests in `test/ci/RenovateConfig.ts`, which parse the committed
`renovate.json` and assert on the resulting configuration:

```
renovate.json enforces a 24h minimumReleaseAge quarantine (Issue #3191) ... ok
renovate.json exempts internal stSoftwareAU deps from the quarantine (Issue #3191) ... ok
renovate.json lets security advisories bypass the quarantine (Issue #3191) ... ok
```

`./quality.sh --lint-only` and `./quality.sh --check-only` both pass.

## Test Plan

- Added to `test/ci/RenovateConfig.ts`:
  - `renovate.json enforces a 24h minimumReleaseAge quarantine (Issue #3191)` —
    asserts the top-level `minimumReleaseAge` resolves to 24 hours.
  - `renovate.json exempts internal stSoftwareAU deps from the quarantine (Issue #3191)` —
    asserts a `packageRules` entry matches `stSoftwareAU/*` packages with a 0h age.
  - `renovate.json lets security advisories bypass the quarantine (Issue #3191)` —
    asserts `vulnerabilityAlerts.minimumReleaseAge` resolves to 0.
- Added a `durationToHours` helper so the tests assert on the resulting
  duration (24h / 0h), not on the exact string used to express it.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr3jju8y-5531a6`<!-- vibe-worker-issue-3191 -->