### PR TITLE
Timing: Return per-phase timing totals in evolve() results (#3210)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.10",
+  "version": "5.7.11",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3210.md
+++ b/docs/archive/pr-summaries/pr-summary-3210.md
@@ -1,0 +1,72 @@
+# Return per-phase timing totals in evolve() results
+
+## Summary
+
+The `evolve*` functions previously returned only a single total `time` in ms.
+This PR additionally returns `phaseTimingTotals` — a whole-run breakdown of
+where that time went across the major phases (fitness/scoring, breeding,
+mutation, de-duplication, speciation, sort, write-scores, checkpoint writes),
+plus an `otherMs` reconciliation bucket. A production run can now confirm that
+scanning gigabytes of training data (fitness/scoring) dominates, and spot any
+phase worth tuning, **without** wiring up an `onTrainingEvent` listener.
+
+The per-generation `GenerationPhaseTiming` breakdown is already recorded by
+`neat.evolve()` on every generation (Issues #2239/#2274/#2284) and streamed on
+each `generation_complete` event. This change simply **sums** those always-on
+measurements across the whole run — no new instrumentation — so the added
+overhead is effectively zero, matching the expectation in the issue.
+
+The new field is additive: it appears on `evolveDir`, `evolveDataSet`,
+`evolveEnv` and `evolveRL` alongside the existing `error`, `score`, `time` (and
+`generation`). All values are raw milliseconds; percentages are the caller's to
+derive.
+
+Closes #3210.
+
+### Design notes
+
+- **Major phases only** — no breeding sub-phase totals (per the accepted scope).
+- **`otherMs`** captures wall-clock not attributed to a named phase (worker
+  start-up, population seeding, finish-up waits, the final checkpoint write, and
+  any phase overlap) so the buckets reconcile with the run total:
+  `fitnessMs + breedingMs + mutationMs + deduplicationMs + speciationMs +
+  sortMs + writeScoresMs + checkpointWriteMs + otherMs === totalMs`.
+  It is clamped at 0 (matching the existing `nonFitnessMs` convention) so
+  pipelined/overlapping phases never yield a negative bucket.
+- **`generations`** is the number of aggregated generations; **`totalMs`**
+  equals the returned `time`.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot. Verified via new
+unit and integration tests (below) and the full `./quality.sh` gate.
+
+```mermaid
+flowchart LR
+    subgraph Loop["evolve* generation loop"]
+      G[neat.evolve<br/>per-gen GenerationPhaseTiming] --> A[accumulatePhaseTiming]
+    end
+    A --> F[finalisePhaseTimingTotals<br/>+ otherMs reconciliation]
+    F --> R["result: { error, score, time,<br/>generation, phaseTimingTotals }"]
+```
+
+`./quality.sh` result: **7439 passed, 1 failed, 4 ignored**. The single failure
+— `Neuron discovery: collectRustAnalysisCandidates returns analysis bundle` (an
+unhandled Rust `setBias` variant in `DiscoverAnalysis.ts`) — is **pre-existing
+and unrelated** to this change: it fails identically on a clean checkout
+(`git stash` → run → still fails) and touches no phase-timing code.
+
+## Test Plan
+
+- `test/creature/PhaseTimingTotals_test.ts` (new) — unit tests for the
+  accumulator/finaliser:
+  - empty accumulator finalises to zeros;
+  - sums the major phases across generations;
+  - optional per-generation phases default to zero when absent;
+  - named buckets plus `otherMs` reconcile to `totalMs`;
+  - `otherMs` clamps at 0 when overlapping phases exceed wall-clock.
+- `test/creature/EvolvePhaseTimingTotals.ts` (new) — integration test:
+  `evolveDataSet` returns `phaseTimingTotals` whose `generations` matches the
+  number of `generation_complete` events, whose `totalMs` equals the returned
+  `time`, whose `fitnessMs` equals the summed per-generation fitness timings,
+  and whose buckets reconcile with `totalMs`.

--- a/docs/event-driven-evolution.md
+++ b/docs/event-driven-evolution.md
@@ -474,8 +474,10 @@ existing-code path** with one new scorer. Concretely:
 - Signal-based interrupt — `SIGTERM` listener that flips `interrupted = true`
   and lets the current generation finish before exiting cleanly.
 - Time and iteration budgets — `timeoutMinutes`, `iterations`, `targetError`.
-- Result shape — `{ error, score, time, generation }` matches `evolveDir`'s
-  return so existing CLIs and dashboards do not branch on the entry point.
+- Result shape — `{ error, score, time, generation, phaseTimingTotals }` matches
+  `evolveDir`'s return so existing CLIs and dashboards do not branch on the
+  entry point. `phaseTimingTotals` is the whole-run per-phase timing breakdown
+  (Issue #3210); see below.
 
 ### New code paths
 
@@ -525,6 +527,38 @@ sequenceDiagram
     Neat->>Creature: fittest creature
     Creature->>Caller: { error, score, time, generation }
 ```
+
+## ⏱️ Run-level phase timing totals (Issue #3210)
+
+Every `evolve*` function already streams a per-generation
+`GenerationPhaseTiming` on each `generation_complete` event. Alongside the
+single total `time`, the result now also carries `phaseTimingTotals` — the
+whole-run **sum** of those always-on measurements, so a caller can confirm where
+the bulk of the time went (typically fitness/scoring when scanning large
+training data) without wiring up an `onTrainingEvent` listener.
+
+```typescript
+const { time, phaseTimingTotals } = await creature.evolveDataSet(data, opts);
+// e.g. { generations: 200, totalMs: 812_340, fitnessMs: 780_120,
+//        breedingMs: 9_800, mutationMs: 1_400, deduplicationMs: 900,
+//        speciationMs: 700, sortMs: 300, writeScoresMs: 5_100,
+//        checkpointWriteMs: 0, otherMs: 13_920 }
+const scoringShare = phaseTimingTotals.fitnessMs / phaseTimingTotals.totalMs;
+```
+
+- **Major phases only** — `fitnessMs`, `breedingMs`, `mutationMs`,
+  `deduplicationMs`, `speciationMs`, `sortMs`, `writeScoresMs`,
+  `checkpointWriteMs`. No breeding sub-phase totals.
+- **Raw milliseconds** — percentages are the caller's to derive.
+- **`otherMs`** reconciles the named buckets against the run total: worker
+  start-up, population seeding, finish-up waits, the final checkpoint write and
+  any phase overlap. It is clamped at 0, so when pipelined phases overlap
+  wall-clock the named phases can sum to slightly more than `totalMs`.
+- **`generations`** is the number of generations aggregated; **`totalMs`**
+  equals the returned `time`.
+
+The overhead is effectively zero — the per-generation measurements are always
+on; this just sums them.
 
 ## 🧪 Validation hold-out hook (deferred)
 

--- a/mod.ts
+++ b/mod.ts
@@ -80,6 +80,8 @@ export type {
   TruncationReason,
 } from "@creature/EpisodeRunner.ts";
 export type { EvolveRLOptions } from "@creature/CreatureTraining.ts";
+// Issue #3210: whole-run per-phase timing totals returned by the evolve* fns.
+export type { PhaseTimingTotals } from "@creature/PhaseTimingTotals.ts";
 export type { EvolveRLMilestone } from "@creature/EvolveRLStatistics.ts";
 export type {
   EpisodeTrialsEvent,

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1002,7 +1002,13 @@ export class Creature implements CreatureInternal {
     dataSetDir: string,
     options: NeatOptions,
   ): Promise<
-    { error: number; score: number; time: number; generation: number }
+    {
+      error: number;
+      score: number;
+      time: number;
+      generation: number;
+      phaseTimingTotals: training.PhaseTimingTotals;
+    }
   > {
     return training.evolveDir(this, dataSetDir, options);
   }
@@ -1020,7 +1026,13 @@ export class Creature implements CreatureInternal {
       & NeatOptions
       & import("./creature/EpisodicFitnessTypes.ts").EpisodicOptions,
   ): Promise<
-    { error: number; score: number; time: number; generation: number }
+    {
+      error: number;
+      score: number;
+      time: number;
+      generation: number;
+      phaseTimingTotals: training.PhaseTimingTotals;
+    }
   > {
     return training.evolveEnv(this, adapter, options);
   }
@@ -1042,6 +1054,7 @@ export class Creature implements CreatureInternal {
       score: number;
       time: number;
       generation: number;
+      phaseTimingTotals: training.PhaseTimingTotals;
       /**
        * Issue #2629: per-milestone payloads collected when
        * `options.statistics === true`. Omitted when statistics are off.
@@ -1056,7 +1069,14 @@ export class Creature implements CreatureInternal {
   evolveDataSet(
     dataSet: DataRecordInterface[],
     options: NeatOptions,
-  ): Promise<{ error: number; score: number; time: number }> {
+  ): Promise<
+    {
+      error: number;
+      score: number;
+      time: number;
+      phaseTimingTotals: training.PhaseTimingTotals;
+    }
+  > {
     return training.evolveDataSet(this, dataSet, options);
   }
 

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -76,6 +76,15 @@ import type { Fitness } from "@architecture/Fitness.ts";
 import type { EpisodeAdapter } from "@creature/EpisodeAdapter.ts";
 import { buildRLSeedSet } from "@creature/EvolveRLSeedSet.ts";
 import {
+  accumulatePhaseTiming,
+  createPhaseTimingAccumulator,
+  finalisePhaseTimingTotals,
+  type PhaseTimingTotals,
+} from "@creature/PhaseTimingTotals.ts";
+// Re-export so `import * as training` consumers (e.g. Creature.ts) can name the
+// run-level phase-timing totals shape (Issue #3210).
+export type { PhaseTimingTotals } from "@creature/PhaseTimingTotals.ts";
+import {
   type EvolveRLMilestone,
   isMilestoneGeneration,
 } from "@creature/EvolveRLStatistics.ts";
@@ -399,7 +408,13 @@ export async function evolveDir(
   options: NeatOptions,
   deps?: EvolveDirDeps,
 ): Promise<
-  { error: number; score: number; time: number; generation: number }
+  {
+    error: number;
+    score: number;
+    time: number;
+    generation: number;
+    phaseTimingTotals: PhaseTimingTotals;
+  }
 > {
   let interrupted = false;
   const signalListener = () => {
@@ -510,6 +525,8 @@ export async function evolveDir(
   let generation = 0;
   const targetError = config.targetError;
   const iterations = config.iterations;
+  // Issue #3210: sum the always-on per-generation phase timings across the run.
+  const phaseTimingAccumulator = createPhaseTimingAccumulator();
 
   while (true) {
     // deno-lint-ignore no-await-in-loop
@@ -566,6 +583,10 @@ export async function evolveDir(
     // Issue #2239: Include per-phase timing diagnostics from evolve()
     // Issue #2330: Forward compact throughput counters (wall-clock, queue
     // depths, approximate worker wait) on the same event.
+    // Issue #3210: fold this generation's (checkpoint-merged) phase timing
+    // into the whole-run running totals returned alongside `time`.
+    accumulatePhaseTiming(phaseTimingAccumulator, phaseTiming);
+
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
     emitTrainingEvent(config.onTrainingEvent, {
@@ -680,11 +701,13 @@ export async function evolveDir(
   }
 
   Deno.removeSignalListener("SIGTERM", signalListener);
+  const time = Date.now() - start;
   return {
     error: error,
     score: bestScore,
     generation: generation,
-    time: Date.now() - start,
+    time,
+    phaseTimingTotals: finalisePhaseTimingTotals(phaseTimingAccumulator, time),
   };
 }
 
@@ -713,7 +736,13 @@ export async function evolveEnv<S, A>(
   adapter: LegacyEpisodeAdapter<S, A>,
   options: NeatOptions & EpisodicOptions,
 ): Promise<
-  { error: number; score: number; time: number; generation: number }
+  {
+    error: number;
+    score: number;
+    time: number;
+    generation: number;
+    phaseTimingTotals: PhaseTimingTotals;
+  }
 > {
   if (creature.input !== adapter.inputCount) {
     throw new Error(
@@ -819,6 +848,8 @@ export async function evolveEnv<S, A>(
   let generation = 0;
   const targetError = config.targetError;
   const iterations = config.iterations;
+  // Issue #3210: sum the always-on per-generation phase timings across the run.
+  const phaseTimingAccumulator = createPhaseTimingAccumulator();
 
   while (true) {
     generation++;
@@ -864,6 +895,10 @@ export async function evolveEnv<S, A>(
         checkpointWriteMs: Date.now() - checkpointStart,
       };
     }
+
+    // Issue #3210: fold this generation's (checkpoint-merged) phase timing
+    // into the whole-run running totals returned alongside `time`.
+    accumulatePhaseTiming(phaseTimingAccumulator, phaseTiming);
 
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
@@ -966,11 +1001,13 @@ export async function evolveEnv<S, A>(
 
   Deno.removeSignalListener("SIGTERM", signalListener);
   options.signal?.removeEventListener("abort", abortListener);
+  const time = Date.now() - start;
   return {
     error,
     score: bestScore,
     generation,
-    time: Date.now() - start,
+    time,
+    phaseTimingTotals: finalisePhaseTimingTotals(phaseTimingAccumulator, time),
   };
 }
 
@@ -1080,6 +1117,7 @@ export async function evolveRL<S, A>(
     score: number;
     time: number;
     generation: number;
+    phaseTimingTotals: PhaseTimingTotals;
     /**
      * Issue #2629: per-milestone payloads collected when `statistics === true`.
      * Omitted entirely when statistics are disabled so the return shape stays
@@ -1296,6 +1334,8 @@ export async function evolveRL<S, A>(
   let generation = 0;
   const targetError = config.targetError;
   const iterations = config.iterations;
+  // Issue #3210: sum the always-on per-generation phase timings across the run.
+  const phaseTimingAccumulator = createPhaseTimingAccumulator();
 
   while (true) {
     generation++;
@@ -1349,6 +1389,10 @@ export async function evolveRL<S, A>(
         checkpointWriteMs: Date.now() - checkpointStart,
       };
     }
+
+    // Issue #3210: fold this generation's (checkpoint-merged) phase timing
+    // into the whole-run running totals returned alongside `time`.
+    accumulatePhaseTiming(phaseTimingAccumulator, phaseTiming);
 
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
@@ -1520,12 +1564,18 @@ export async function evolveRL<S, A>(
   options.signal?.removeEventListener("abort", abortListener);
   // Issue #2629: include milestones only when statistics were enabled, so
   // callers that did not opt in see the same return shape as #2628.
+  const time = Date.now() - start;
+  const phaseTimingTotals = finalisePhaseTimingTotals(
+    phaseTimingAccumulator,
+    time,
+  );
   if (statisticsEnabled) {
     return {
       error,
       score: bestScore,
       generation,
-      time: Date.now() - start,
+      time,
+      phaseTimingTotals,
       milestones,
     };
   }
@@ -1533,7 +1583,8 @@ export async function evolveRL<S, A>(
     error,
     score: bestScore,
     generation,
-    time: Date.now() - start,
+    time,
+    phaseTimingTotals,
   };
 }
 
@@ -1545,7 +1596,14 @@ export async function evolveDataSet(
   creature: Creature,
   dataSet: DataRecordInterface[],
   options: NeatOptions,
-): Promise<{ error: number; score: number; time: number }> {
+): Promise<
+  {
+    error: number;
+    score: number;
+    time: number;
+    phaseTimingTotals: PhaseTimingTotals;
+  }
+> {
   const config = createNeatConfig(options);
 
   const dataSetDir = makeDataDir(dataSet, config.dataSetPartitionBreak, {

--- a/src/creature/PhaseTimingTotals.ts
+++ b/src/creature/PhaseTimingTotals.ts
@@ -1,0 +1,139 @@
+import type { GenerationPhaseTiming } from "../config/TrainingEvent.ts";
+
+/**
+ * Whole-run, summed per-phase timing totals returned alongside the single
+ * total `time` from the `evolve*` functions (Issue #3210).
+ *
+ * The per-generation {@link GenerationPhaseTiming} breakdown is already
+ * recorded by `neat.evolve()` and streamed on every `generation_complete`
+ * training event. This aggregate simply sums those always-on measurements
+ * across the whole run so a caller can confirm — without wiring up an
+ * `onTrainingEvent` listener — where the bulk of the time went (typically
+ * fitness/scoring when scanning large training data) and spot any phase worth
+ * tuning. All values are raw milliseconds; percentages are the caller's to
+ * derive.
+ *
+ * Scope is deliberately the *major* phases only (no breeding sub-phase
+ * totals). The `otherMs` bucket captures wall-clock not attributed to a named
+ * phase — worker start-up, population seeding, finish-up waits, the final
+ * checkpoint write and any phase overlap — so the buckets reconcile against
+ * the run's total `time`:
+ *
+ *   fitnessMs + breedingMs + mutationMs + deduplicationMs + speciationMs +
+ *   sortMs + writeScoresMs + checkpointWriteMs + otherMs === totalMs
+ */
+export interface PhaseTimingTotals {
+  /** Number of generations whose phase timings were aggregated. */
+  readonly generations: number;
+  /** Total run time in ms — equal to the returned `time`. */
+  readonly totalMs: number;
+  /** Summed fitness/scoring time across all generations in ms. */
+  readonly fitnessMs: number;
+  /** Summed breeding time across all generations in ms. */
+  readonly breedingMs: number;
+  /** Summed mutation time across all generations in ms. */
+  readonly mutationMs: number;
+  /** Summed de-duplication time across all generations in ms. */
+  readonly deduplicationMs: number;
+  /** Summed speciation time across all generations in ms. */
+  readonly speciationMs: number;
+  /** Summed sort time across all generations in ms. */
+  readonly sortMs: number;
+  /** Summed score-file write time across all generations in ms. */
+  readonly writeScoresMs: number;
+  /** Summed checkpoint-write time across all generations in ms. */
+  readonly checkpointWriteMs: number;
+  /**
+   * Wall-clock not attributed to a named phase in ms — worker start-up,
+   * population seeding, finish-up waits, the final checkpoint write and any
+   * phase overlap. Clamped at 0: when pipelined phases overlap, the summed
+   * named phases can exceed wall-clock, in which case this reads 0.
+   */
+  readonly otherMs: number;
+}
+
+/**
+ * Mutable running sum of the major per-generation phases. Reset to zeros by
+ * {@link createPhaseTimingAccumulator} and advanced one generation at a time
+ * by {@link accumulatePhaseTiming}. Finalised into an immutable
+ * {@link PhaseTimingTotals} by {@link finalisePhaseTimingTotals}.
+ */
+export interface PhaseTimingAccumulator {
+  generations: number;
+  fitnessMs: number;
+  breedingMs: number;
+  mutationMs: number;
+  deduplicationMs: number;
+  speciationMs: number;
+  sortMs: number;
+  writeScoresMs: number;
+  checkpointWriteMs: number;
+}
+
+/** Create a zeroed {@link PhaseTimingAccumulator}. */
+export function createPhaseTimingAccumulator(): PhaseTimingAccumulator {
+  return {
+    generations: 0,
+    fitnessMs: 0,
+    breedingMs: 0,
+    mutationMs: 0,
+    deduplicationMs: 0,
+    speciationMs: 0,
+    sortMs: 0,
+    writeScoresMs: 0,
+    checkpointWriteMs: 0,
+  };
+}
+
+/**
+ * Add one generation's {@link GenerationPhaseTiming} into the accumulator.
+ * Optional per-generation phases (mutation, dedup, speciation, sort,
+ * writeScores, checkpoint) contribute 0 when absent.
+ */
+export function accumulatePhaseTiming(
+  acc: PhaseTimingAccumulator,
+  timing: GenerationPhaseTiming,
+): void {
+  acc.generations++;
+  acc.fitnessMs += timing.fitnessMs;
+  acc.breedingMs += timing.breedingMs;
+  acc.mutationMs += timing.mutationMs ?? 0;
+  acc.deduplicationMs += timing.deduplicationMs ?? 0;
+  acc.speciationMs += timing.speciationMs ?? 0;
+  acc.sortMs += timing.sortMs ?? 0;
+  acc.writeScoresMs += timing.writeScoresMs ?? 0;
+  acc.checkpointWriteMs += timing.checkpointWriteMs ?? 0;
+}
+
+/**
+ * Freeze the accumulator into an immutable {@link PhaseTimingTotals}, deriving
+ * the `otherMs` reconciliation bucket from the run's total wall-clock time.
+ *
+ * @param acc The accumulated per-phase sums.
+ * @param runTotalMs The whole-run wall-clock time in ms (the returned `time`).
+ */
+export function finalisePhaseTimingTotals(
+  acc: PhaseTimingAccumulator,
+  runTotalMs: number,
+): PhaseTimingTotals {
+  const accounted = acc.fitnessMs + acc.breedingMs + acc.mutationMs +
+    acc.deduplicationMs + acc.speciationMs + acc.sortMs + acc.writeScoresMs +
+    acc.checkpointWriteMs;
+  // Follow the codebase convention (see nonFitnessMs) of clamping the
+  // wall-clock residual at 0 so overlapping/pipelined phases never yield a
+  // negative "other" bucket.
+  const otherMs = Math.max(0, runTotalMs - accounted);
+  return {
+    generations: acc.generations,
+    totalMs: runTotalMs,
+    fitnessMs: acc.fitnessMs,
+    breedingMs: acc.breedingMs,
+    mutationMs: acc.mutationMs,
+    deduplicationMs: acc.deduplicationMs,
+    speciationMs: acc.speciationMs,
+    sortMs: acc.sortMs,
+    writeScoresMs: acc.writeScoresMs,
+    checkpointWriteMs: acc.checkpointWriteMs,
+    otherMs,
+  };
+}

--- a/test/creature/EvolvePhaseTimingTotals.ts
+++ b/test/creature/EvolvePhaseTimingTotals.ts
@@ -1,0 +1,95 @@
+/**
+ * Integration test: the evolve* functions return whole-run per-phase timing
+ * totals alongside the single total `time` (Issue #3210).
+ *
+ * The aggregate simply sums the always-on per-generation phase timings that
+ * are already streamed on `generation_complete` events, so the returned totals
+ * must reconcile with those events: `generations` matches the event count and
+ * each summed phase equals the sum of that phase across the events.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type {
+  GenerationCompleteEvent,
+  TrainingEvent,
+} from "@config/TrainingEvent.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+Deno.test("evolveDataSet returns run-level phaseTimingTotals", async () => {
+  await initWasmForTests();
+
+  const events: GenerationCompleteEvent[] = [];
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+  ];
+
+  const creature = new Creature(2, 1);
+  const result = await creature.evolveDataSet(trainingSet, {
+    iterations: 5,
+    targetError: 0,
+    populationSize: 10,
+    threads: 1,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        events.push(event);
+      }
+    },
+  });
+
+  const totals = result.phaseTimingTotals;
+  assert(totals !== undefined, "phaseTimingTotals must be present");
+
+  // generations tracks the number of aggregated generations.
+  assert(events.length > 0, "should emit generation_complete events");
+  assertEquals(
+    totals.generations,
+    events.length,
+    "generations must match the number of generation_complete events",
+  );
+
+  // totalMs mirrors the returned run time.
+  assertEquals(totals.totalMs, result.time);
+
+  // Every bucket is a finite non-negative number.
+  for (
+    const [name, value] of Object.entries(totals) as [string, number][]
+  ) {
+    assertEquals(typeof value, "number", `${name} must be a number`);
+    assert(Number.isFinite(value), `${name} must be finite`);
+    assert(value >= 0, `${name} must be non-negative, got ${value}`);
+  }
+
+  // Summed fitness equals the sum of per-generation fitnessMs from the events.
+  const expectedFitness = events.reduce(
+    (sum, e) => sum + e.phaseTiming.fitnessMs,
+    0,
+  );
+  assertEquals(
+    totals.fitnessMs,
+    expectedFitness,
+    "fitnessMs must equal the summed per-generation fitness timings",
+  );
+
+  // The named buckets plus otherMs reconcile exactly with totalMs (unless
+  // overlapping phases pushed otherMs to its 0 clamp).
+  const named = totals.fitnessMs + totals.breedingMs + totals.mutationMs +
+    totals.deduplicationMs + totals.speciationMs + totals.sortMs +
+    totals.writeScoresMs + totals.checkpointWriteMs;
+  if (totals.otherMs > 0) {
+    assertEquals(
+      named + totals.otherMs,
+      totals.totalMs,
+      "named buckets plus otherMs must reconcile with totalMs",
+    );
+  } else {
+    // otherMs clamped at 0: named phases account for at least the wall-clock.
+    assert(
+      named >= totals.totalMs,
+      "when otherMs is 0 the named phases should cover the wall-clock",
+    );
+  }
+});

--- a/test/creature/PhaseTimingTotals_test.ts
+++ b/test/creature/PhaseTimingTotals_test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the whole-run per-phase timing aggregation used by the
+ * `evolve*` functions (Issue #3210).
+ *
+ * The aggregator sums the always-on per-generation {@link GenerationPhaseTiming}
+ * across the run and derives an `otherMs` reconciliation bucket from the run's
+ * total wall-clock time.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import type { GenerationPhaseTiming } from "@config/TrainingEvent.ts";
+import {
+  accumulatePhaseTiming,
+  createPhaseTimingAccumulator,
+  finalisePhaseTimingTotals,
+} from "@creature/PhaseTimingTotals.ts";
+
+/** Build a GenerationPhaseTiming with sensible defaults for the required fields. */
+function timing(
+  overrides: Partial<GenerationPhaseTiming> = {},
+): GenerationPhaseTiming {
+  return {
+    fitnessMs: 0,
+    breedingMs: 0,
+    resultProcessingMs: 0,
+    totalMs: 0,
+    ...overrides,
+  };
+}
+
+Deno.test("PhaseTimingTotals: empty accumulator finalises to zeros", () => {
+  const acc = createPhaseTimingAccumulator();
+  const totals = finalisePhaseTimingTotals(acc, 0);
+  assertEquals(totals.generations, 0);
+  assertEquals(totals.totalMs, 0);
+  assertEquals(totals.fitnessMs, 0);
+  assertEquals(totals.breedingMs, 0);
+  assertEquals(totals.mutationMs, 0);
+  assertEquals(totals.deduplicationMs, 0);
+  assertEquals(totals.speciationMs, 0);
+  assertEquals(totals.sortMs, 0);
+  assertEquals(totals.writeScoresMs, 0);
+  assertEquals(totals.checkpointWriteMs, 0);
+  assertEquals(totals.otherMs, 0);
+});
+
+Deno.test("PhaseTimingTotals: sums the major phases across generations", () => {
+  const acc = createPhaseTimingAccumulator();
+  accumulatePhaseTiming(
+    acc,
+    timing({
+      fitnessMs: 100,
+      breedingMs: 10,
+      mutationMs: 5,
+      deduplicationMs: 4,
+      speciationMs: 3,
+      sortMs: 2,
+      writeScoresMs: 1,
+      checkpointWriteMs: 6,
+    }),
+  );
+  accumulatePhaseTiming(
+    acc,
+    timing({
+      fitnessMs: 200,
+      breedingMs: 20,
+      mutationMs: 5,
+      deduplicationMs: 6,
+      speciationMs: 7,
+      sortMs: 8,
+      writeScoresMs: 9,
+      checkpointWriteMs: 4,
+    }),
+  );
+
+  const totals = finalisePhaseTimingTotals(acc, 500);
+  assertEquals(totals.generations, 2);
+  assertEquals(totals.totalMs, 500);
+  assertEquals(totals.fitnessMs, 300);
+  assertEquals(totals.breedingMs, 30);
+  assertEquals(totals.mutationMs, 10);
+  assertEquals(totals.deduplicationMs, 10);
+  assertEquals(totals.speciationMs, 10);
+  assertEquals(totals.sortMs, 10);
+  assertEquals(totals.writeScoresMs, 10);
+  assertEquals(totals.checkpointWriteMs, 10);
+  // 500 - (300+30+10+10+10+10+10+10) = 110
+  assertEquals(totals.otherMs, 110);
+});
+
+Deno.test("PhaseTimingTotals: optional phases default to zero when absent", () => {
+  const acc = createPhaseTimingAccumulator();
+  // Only the required fields present — mutation/dedup/etc. omitted.
+  accumulatePhaseTiming(acc, timing({ fitnessMs: 50, breedingMs: 5 }));
+  const totals = finalisePhaseTimingTotals(acc, 60);
+  assertEquals(totals.fitnessMs, 50);
+  assertEquals(totals.breedingMs, 5);
+  assertEquals(totals.mutationMs, 0);
+  assertEquals(totals.deduplicationMs, 0);
+  assertEquals(totals.otherMs, 5);
+});
+
+Deno.test("PhaseTimingTotals: named buckets plus otherMs reconcile to totalMs", () => {
+  const acc = createPhaseTimingAccumulator();
+  accumulatePhaseTiming(
+    acc,
+    timing({ fitnessMs: 80, breedingMs: 10, sortMs: 5 }),
+  );
+  const runTotalMs = 120;
+  const t = finalisePhaseTimingTotals(acc, runTotalMs);
+  const sum = t.fitnessMs + t.breedingMs + t.mutationMs + t.deduplicationMs +
+    t.speciationMs + t.sortMs + t.writeScoresMs + t.checkpointWriteMs +
+    t.otherMs;
+  assertEquals(sum, runTotalMs);
+});
+
+Deno.test("PhaseTimingTotals: otherMs clamps at 0 when phases overlap wall-clock", () => {
+  const acc = createPhaseTimingAccumulator();
+  // Summed named phases (300) exceed the run wall-clock (150) due to
+  // pipelined/overlapping phases — otherMs must not go negative.
+  accumulatePhaseTiming(acc, timing({ fitnessMs: 250, breedingMs: 50 }));
+  const totals = finalisePhaseTimingTotals(acc, 150);
+  assertEquals(totals.otherMs, 0);
+  assert(totals.otherMs >= 0, "otherMs must never be negative");
+});


### PR DESCRIPTION
# Return per-phase timing totals in evolve() results

## Summary

The `evolve*` functions previously returned only a single total `time` in ms.
This PR additionally returns `phaseTimingTotals` — a whole-run breakdown of
where that time went across the major phases (fitness/scoring, breeding,
mutation, de-duplication, speciation, sort, write-scores, checkpoint writes),
plus an `otherMs` reconciliation bucket. A production run can now confirm that
scanning gigabytes of training data (fitness/scoring) dominates, and spot any
phase worth tuning, **without** wiring up an `onTrainingEvent` listener.

The per-generation `GenerationPhaseTiming` breakdown is already recorded by
`neat.evolve()` on every generation (Issues #2239/#2274/#2284) and streamed on
each `generation_complete` event. This change simply **sums** those always-on
measurements across the whole run — no new instrumentation — so the added
overhead is effectively zero, matching the expectation in the issue.

The new field is additive: it appears on `evolveDir`, `evolveDataSet`,
`evolveEnv` and `evolveRL` alongside the existing `error`, `score`, `time` (and
`generation`). All values are raw milliseconds; percentages are the caller's to
derive.

Closes #3210.

### Design notes

- **Major phases only** — no breeding sub-phase totals (per the accepted scope).
- **`otherMs`** captures wall-clock not attributed to a named phase (worker
  start-up, population seeding, finish-up waits, the final checkpoint write, and
  any phase overlap) so the buckets reconcile with the run total:
  `fitnessMs + breedingMs + mutationMs + deduplicationMs + speciationMs +
  sortMs + writeScoresMs + checkpointWriteMs + otherMs === totalMs`.
  It is clamped at 0 (matching the existing `nonFitnessMs` convention) so
  pipelined/overlapping phases never yield a negative bucket.
- **`generations`** is the number of aggregated generations; **`totalMs`**
  equals the returned `time`.

## Evidence

Backend/library change only — no web interface to screenshot. Verified via new
unit and integration tests (below) and the full `./quality.sh` gate.

```mermaid
flowchart LR
    subgraph Loop["evolve* generation loop"]
      G[neat.evolve<br/>per-gen GenerationPhaseTiming] --> A[accumulatePhaseTiming]
    end
    A --> F[finalisePhaseTimingTotals<br/>+ otherMs reconciliation]
    F --> R["result: { error, score, time,<br/>generation, phaseTimingTotals }"]
```

`./quality.sh` result: **7439 passed, 1 failed, 4 ignored**. The single failure
— `Neuron discovery: collectRustAnalysisCandidates returns analysis bundle` (an
unhandled Rust `setBias` variant in `DiscoverAnalysis.ts`) — is **pre-existing
and unrelated** to this change: it fails identically on a clean checkout
(`git stash` → run → still fails) and touches no phase-timing code.

## Test Plan

- `test/creature/PhaseTimingTotals_test.ts` (new) — unit tests for the
  accumulator/finaliser:
  - empty accumulator finalises to zeros;
  - sums the major phases across generations;
  - optional per-generation phases default to zero when absent;
  - named buckets plus `otherMs` reconcile to `totalMs`;
  - `otherMs` clamps at 0 when overlapping phases exceed wall-clock.
- `test/creature/EvolvePhaseTimingTotals.ts` (new) — integration test:
  `evolveDataSet` returns `phaseTimingTotals` whose `generations` matches the
  number of `generation_complete` events, whose `totalMs` equals the returned
  `time`, whose `fitnessMs` equals the summed per-generation fitness timings,
  and whose buckets reconcile with `totalMs`.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr4hq6hq-d4a6ea`<!-- vibe-worker-issue-3210 -->