### PR TITLE
Make stall tuning constants module-private (Issue #3212)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3212.md
+++ b/docs/archive/pr-summaries/pr-summary-3212.md
@@ -1,0 +1,58 @@
+## Summary
+
+Removed the redundant `export` keyword from the two stall-detection tuning
+constants — `DEFAULT_PER_CHUNK_GRACE_MS` and `STALL_WARMUP_MIN_COMPLETED_CHUNKS`
+— in `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts`.
+Graph analysis confirmed no other module in the repository (`src/**`, `test/**`,
+`bench/**`, `mod.ts`, `docs/**`) imports these symbols; they are consumed only
+internally by the per-chunk timeout and stall-warmup logic in their defining
+file. Narrowing them to module-private constants removes dead public surface
+without changing any behaviour. Closes #3212.
+
+Verification performed before the change:
+
+- `grep -rn "DEFAULT_PER_CHUNK_GRACE_MS\|STALL_WARMUP_MIN_COMPLETED_CHUNKS"`
+  across `src`, `test`, `bench`, `mod.ts`, `docs` — the only references are the
+  definitions and the internal uses (`:458,485,616,741,760,770`) plus a
+  `{@link}` doc reference at `:121`, all within the same file.
+- The three test files that import from `DataRecorderAnalysis.ts`
+  (`DiscoverAnalysisStallWarmup.ts`, `DiscoverAnalysisChunking.ts`,
+  `DiscoverAnalysisPerChunkTimeout.ts`) import only `runAnalysisLoop`,
+  `chunkFocusList`, `formatStallMemoryDiagnostics` and `ParallelAnalysisFn` —
+  never the two constants.
+- No `export *` barrels exist under `src/` or `mod.ts`, and the module is not
+  re-exported from `mod.ts`.
+- No dynamic import or string-keyed access to the constants exists.
+- The `{@link DEFAULT_PER_CHUNK_GRACE_MS}` doc reference resolves fine for a
+  module-private symbol.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot. Verified via the
+new runtime test that inspects the module namespace object.
+
+```mermaid
+flowchart LR
+    A["export const<br/>DEFAULT_PER_CHUNK_GRACE_MS<br/>STALL_WARMUP_MIN_COMPLETED_CHUNKS"] -->|remove export| B["module-private const<br/>(same internal uses)"]
+    B --> C["public surface unchanged:<br/>runAnalysisLoop, chunkFocusList,<br/>formatStallMemoryDiagnostics"]
+```
+
+## Test Plan
+
+- Added `test/ErrorGuidedStructuralEvolution/DataRecorderAnalysisExports.ts`:
+  - `stall tuning constants are not over-exported` — dynamically imports the
+    module and asserts `DEFAULT_PER_CHUNK_GRACE_MS` and
+    `STALL_WARMUP_MIN_COMPLETED_CHUNKS` are `undefined` on the module namespace.
+    Fails against the unfixed code (constants exported → `1000` / `2`) and
+    passes after removing `export`.
+  - `genuine public surface stays exported` — asserts `runAnalysisLoop`,
+    `chunkFocusList` and `formatStallMemoryDiagnostics` remain callable
+    functions.
+- Existing `DataRecorderAnalysis.ts` consumers (stall-warmup, chunking and
+  per-chunk-timeout suites) continue to pass unchanged.
+
+> Note: the pre-existing failure in
+> `test/ErrorGuidedStructuralEvolution/NeuronDiscoveryIntegration.ts`
+> ("Unhandled variant: setWeight") is unrelated to this change — it fails on the
+> base branch without these edits and stems from a Rust coordinated-op variant
+> not handled in `DiscoverAnalysis.ts`.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
@@ -45,7 +45,7 @@ export type ParallelAnalysisFn = (
  * mid-flight timeout fires (Issue #2420). A small amount of slack avoids
  * racing the budget in normal operation.
  */
-export const DEFAULT_PER_CHUNK_GRACE_MS = 1_000;
+const DEFAULT_PER_CHUNK_GRACE_MS = 1_000;
 
 /**
  * Minimum number of completed chunks before the per-chunk stall guard may
@@ -55,7 +55,7 @@ export const DEFAULT_PER_CHUNK_GRACE_MS = 1_000;
  * amortised against a fast second chunk avoids tearing down the retry loop
  * after evaluating only one chunk's worth of neurons.
  */
-export const STALL_WARMUP_MIN_COMPLETED_CHUNKS = 2;
+const STALL_WARMUP_MIN_COMPLETED_CHUNKS = 2;
 
 /**
  * Returns a one-line diagnostic of the current Deno heap / RSS state.

--- a/test/ErrorGuidedStructuralEvolution/DataRecorderAnalysisExports.ts
+++ b/test/ErrorGuidedStructuralEvolution/DataRecorderAnalysisExports.ts
@@ -1,0 +1,26 @@
+/**
+ * Guards the public export surface of `DataRecorderAnalysis.ts` (Issue #3212).
+ *
+ * The stall-detection tuning constants `DEFAULT_PER_CHUNK_GRACE_MS` and
+ * `STALL_WARMUP_MIN_COMPLETED_CHUNKS` are consumed only inside their defining
+ * module, so they must stay module-private rather than being over-exported.
+ * These tests inspect the module namespace object at runtime — a behavioural
+ * check that fails if the `export` keyword is ever re-added — while confirming
+ * the genuinely public helpers remain reachable.
+ */
+import { assertEquals } from "@std/assert";
+
+const mod = await import(
+  "@architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts"
+) as Record<string, unknown>;
+
+Deno.test("DataRecorderAnalysis - stall tuning constants are not over-exported", () => {
+  assertEquals(mod.DEFAULT_PER_CHUNK_GRACE_MS, undefined);
+  assertEquals(mod.STALL_WARMUP_MIN_COMPLETED_CHUNKS, undefined);
+});
+
+Deno.test("DataRecorderAnalysis - genuine public surface stays exported", () => {
+  assertEquals(typeof mod.runAnalysisLoop, "function");
+  assertEquals(typeof mod.chunkFocusList, "function");
+  assertEquals(typeof mod.formatStallMemoryDiagnostics, "function");
+});


### PR DESCRIPTION
## Summary

Removed the redundant `export` keyword from the two stall-detection tuning
constants — `DEFAULT_PER_CHUNK_GRACE_MS` and `STALL_WARMUP_MIN_COMPLETED_CHUNKS`
— in `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts`.
Graph analysis confirmed no other module in the repository (`src/**`, `test/**`,
`bench/**`, `mod.ts`, `docs/**`) imports these symbols; they are consumed only
internally by the per-chunk timeout and stall-warmup logic in their defining
file. Narrowing them to module-private constants removes dead public surface
without changing any behaviour. Closes #3212.

Verification performed before the change:

- `grep -rn "DEFAULT_PER_CHUNK_GRACE_MS\|STALL_WARMUP_MIN_COMPLETED_CHUNKS"`
  across `src`, `test`, `bench`, `mod.ts`, `docs` — the only references are the
  definitions and the internal uses (`:458,485,616,741,760,770`) plus a
  `{@link}` doc reference at `:121`, all within the same file.
- The three test files that import from `DataRecorderAnalysis.ts`
  (`DiscoverAnalysisStallWarmup.ts`, `DiscoverAnalysisChunking.ts`,
  `DiscoverAnalysisPerChunkTimeout.ts`) import only `runAnalysisLoop`,
  `chunkFocusList`, `formatStallMemoryDiagnostics` and `ParallelAnalysisFn` —
  never the two constants.
- No `export *` barrels exist under `src/` or `mod.ts`, and the module is not
  re-exported from `mod.ts`.
- No dynamic import or string-keyed access to the constants exists.
- The `{@link DEFAULT_PER_CHUNK_GRACE_MS}` doc reference resolves fine for a
  module-private symbol.

## Evidence

Backend/library change only — no web interface to screenshot. Verified via the
new runtime test that inspects the module namespace object.

```mermaid
flowchart LR
    A["export const<br/>DEFAULT_PER_CHUNK_GRACE_MS<br/>STALL_WARMUP_MIN_COMPLETED_CHUNKS"] -->|remove export| B["module-private const<br/>(same internal uses)"]
    B --> C["public surface unchanged:<br/>runAnalysisLoop, chunkFocusList,<br/>formatStallMemoryDiagnostics"]
```

## Test Plan

- Added `test/ErrorGuidedStructuralEvolution/DataRecorderAnalysisExports.ts`:
  - `stall tuning constants are not over-exported` — dynamically imports the
    module and asserts `DEFAULT_PER_CHUNK_GRACE_MS` and
    `STALL_WARMUP_MIN_COMPLETED_CHUNKS` are `undefined` on the module namespace.
    Fails against the unfixed code (constants exported → `1000` / `2`) and
    passes after removing `export`.
  - `genuine public surface stays exported` — asserts `runAnalysisLoop`,
    `chunkFocusList` and `formatStallMemoryDiagnostics` remain callable
    functions.
- Existing `DataRecorderAnalysis.ts` consumers (stall-warmup, chunking and
  per-chunk-timeout suites) continue to pass unchanged.

> Note: the pre-existing failure in
> `test/ErrorGuidedStructuralEvolution/NeuronDiscoveryIntegration.ts`
> ("Unhandled variant: setWeight") is unrelated to this change — it fails on the
> base branch without these edits and stems from a Rust coordinated-op variant
> not handled in `DiscoverAnalysis.ts`.



## Milestone
This PR is part of the **dead code** milestone and targets the `milestone/dead-code` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr4jk5ww-f95c49`<!-- vibe-worker-issue-3212 -->