### PR TITLE
Milestone: dead code

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.11",
+  "version": "5.7.12",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3211.md
+++ b/docs/archive/pr-summaries/pr-summary-3211.md
@@ -1,20 +1,20 @@
 ## Summary
 
-Removed the redundant `export` keyword from the three Muon quintic
-Newton-Schulz coefficients — `MUON_QUINTIC_A`, `MUON_QUINTIC_B` and
-`MUON_QUINTIC_C` — in `src/propagate/MuonOrthogonalisation.ts`. Graph analysis
-confirmed no other module in the repository (`src/**`, `test/**`, `bench/**`,
-`mod.ts`) imports these symbols; they are used only internally by the quintic
-iteration in their defining file. Narrowing them to module-private constants
-removes dead public surface without changing any behaviour. Closes #3211.
+Removed the redundant `export` keyword from the three Muon quintic Newton-Schulz
+coefficients — `MUON_QUINTIC_A`, `MUON_QUINTIC_B` and `MUON_QUINTIC_C` — in
+`src/propagate/MuonOrthogonalisation.ts`. Graph analysis confirmed no other
+module in the repository (`src/**`, `test/**`, `bench/**`, `mod.ts`) imports
+these symbols; they are used only internally by the quintic iteration in their
+defining file. Narrowing them to module-private constants removes dead public
+surface without changing any behaviour. Closes #3211.
 
 Verification performed before the change:
 
 - `grep -rn "MUON_QUINTIC_[ABC]"` across `src`, `test`, `bench`, `mod.ts`,
   `docs` — the only references are the definitions and the internal uses at
   lines 191, 198 and 204 of the same file.
-- No `export *` barrels exist under `src/` or `mod.ts` that could re-export
-  them implicitly.
+- No `export *` barrels exist under `src/` or `mod.ts` that could re-export them
+  implicitly.
 - `src/propagate/MuonGradientHook.ts` (the only cross-module importer of this
   file) imports `newtonSchulzOrthogonalise` and `RowMajorMatrix` only.
 - No dynamic import or string-keyed access to the constants exists.
@@ -24,8 +24,8 @@ Verification performed before the change:
 Backend/library change only — no web interface to screenshot.
 
 The genuinely-public API of the module (`newtonSchulzOrthogonalise`,
-`orthogonalise2D`, `frobeniusNorm`, `MUON_DEFAULT_STEPS`, `RowMajorMatrix`)
-is unchanged; only the three internal coefficients stop being exported.
+`orthogonalise2D`, `frobeniusNorm`, `MUON_DEFAULT_STEPS`, `RowMajorMatrix`) is
+unchanged; only the three internal coefficients stop being exported.
 
 ```mermaid
 flowchart LR
@@ -39,17 +39,18 @@ flowchart LR
 ```
 
 The existing behaviour tests still exercise the constants through
-`newtonSchulzOrthogonalise` (decorrelation, gramian bounds, idempotence,
-edge cases), so correctness of the quintic iteration remains covered.
+`newtonSchulzOrthogonalise` (decorrelation, gramian bounds, idempotence, edge
+cases), so correctness of the quintic iteration remains covered.
 
 ## Test Plan
 
-- Added `test/propagate/MuonOrthogonalisation.ts::"Muon - quintic coefficients
-  are not part of the public export surface"` — a regression guard that
-  dynamically imports the module and asserts the three coefficients are **not**
-  in its export keys, while the intended public API remains exported. Confirmed
-  this test fails when the `export` keyword is present and passes once the
-  constants are module-private.
+- Added
+  `test/propagate/MuonOrthogonalisation.ts::"Muon - quintic coefficients
+  are not part of the public export surface"`
+  — a regression guard that dynamically imports the module and asserts the three
+  coefficients are **not** in its export keys, while the intended public API
+  remains exported. Confirmed this test fails when the `export` keyword is
+  present and passes once the constants are module-private.
 - All 20 tests in `test/propagate/MuonOrthogonalisation.ts` pass.
 - Full `./quality.sh` run: 7440 passed. The single unrelated failure
   (`NeuronDiscoveryIntegration.ts::collectRustAnalysisCandidates` — a

--- a/docs/archive/pr-summaries/pr-summary-3211.md
+++ b/docs/archive/pr-summaries/pr-summary-3211.md
@@ -1,0 +1,58 @@
+## Summary
+
+Removed the redundant `export` keyword from the three Muon quintic
+Newton-Schulz coefficients — `MUON_QUINTIC_A`, `MUON_QUINTIC_B` and
+`MUON_QUINTIC_C` — in `src/propagate/MuonOrthogonalisation.ts`. Graph analysis
+confirmed no other module in the repository (`src/**`, `test/**`, `bench/**`,
+`mod.ts`) imports these symbols; they are used only internally by the quintic
+iteration in their defining file. Narrowing them to module-private constants
+removes dead public surface without changing any behaviour. Closes #3211.
+
+Verification performed before the change:
+
+- `grep -rn "MUON_QUINTIC_[ABC]"` across `src`, `test`, `bench`, `mod.ts`,
+  `docs` — the only references are the definitions and the internal uses at
+  lines 191, 198 and 204 of the same file.
+- No `export *` barrels exist under `src/` or `mod.ts` that could re-export
+  them implicitly.
+- `src/propagate/MuonGradientHook.ts` (the only cross-module importer of this
+  file) imports `newtonSchulzOrthogonalise` and `RowMajorMatrix` only.
+- No dynamic import or string-keyed access to the constants exists.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+The genuinely-public API of the module (`newtonSchulzOrthogonalise`,
+`orthogonalise2D`, `frobeniusNorm`, `MUON_DEFAULT_STEPS`, `RowMajorMatrix`)
+is unchanged; only the three internal coefficients stop being exported.
+
+```mermaid
+flowchart LR
+    subgraph before[Before]
+        A1[export MUON_QUINTIC_A/B/C] -.->|no importers| X((none))
+        A1 --> I1[quintic iteration<br/>same file]
+    end
+    subgraph after[After]
+        A2[const MUON_QUINTIC_A/B/C<br/>module-private] --> I2[quintic iteration<br/>same file]
+    end
+```
+
+The existing behaviour tests still exercise the constants through
+`newtonSchulzOrthogonalise` (decorrelation, gramian bounds, idempotence,
+edge cases), so correctness of the quintic iteration remains covered.
+
+## Test Plan
+
+- Added `test/propagate/MuonOrthogonalisation.ts::"Muon - quintic coefficients
+  are not part of the public export surface"` — a regression guard that
+  dynamically imports the module and asserts the three coefficients are **not**
+  in its export keys, while the intended public API remains exported. Confirmed
+  this test fails when the `export` keyword is present and passes once the
+  constants are module-private.
+- All 20 tests in `test/propagate/MuonOrthogonalisation.ts` pass.
+- Full `./quality.sh` run: 7440 passed. The single unrelated failure
+  (`NeuronDiscoveryIntegration.ts::collectRustAnalysisCandidates` — a
+  Rust-coordinated `setWeight` variant mapping) is pre-existing on the
+  `milestone/dead-code` base branch and independent of this change (verified by
+  re-running it with these changes stashed).

--- a/docs/archive/pr-summaries/pr-summary-3212.md
+++ b/docs/archive/pr-summaries/pr-summary-3212.md
@@ -1,0 +1,58 @@
+## Summary
+
+Removed the redundant `export` keyword from the two stall-detection tuning
+constants — `DEFAULT_PER_CHUNK_GRACE_MS` and `STALL_WARMUP_MIN_COMPLETED_CHUNKS`
+— in `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts`.
+Graph analysis confirmed no other module in the repository (`src/**`, `test/**`,
+`bench/**`, `mod.ts`, `docs/**`) imports these symbols; they are consumed only
+internally by the per-chunk timeout and stall-warmup logic in their defining
+file. Narrowing them to module-private constants removes dead public surface
+without changing any behaviour. Closes #3212.
+
+Verification performed before the change:
+
+- `grep -rn "DEFAULT_PER_CHUNK_GRACE_MS\|STALL_WARMUP_MIN_COMPLETED_CHUNKS"`
+  across `src`, `test`, `bench`, `mod.ts`, `docs` — the only references are the
+  definitions and the internal uses (`:458,485,616,741,760,770`) plus a
+  `{@link}` doc reference at `:121`, all within the same file.
+- The three test files that import from `DataRecorderAnalysis.ts`
+  (`DiscoverAnalysisStallWarmup.ts`, `DiscoverAnalysisChunking.ts`,
+  `DiscoverAnalysisPerChunkTimeout.ts`) import only `runAnalysisLoop`,
+  `chunkFocusList`, `formatStallMemoryDiagnostics` and `ParallelAnalysisFn` —
+  never the two constants.
+- No `export *` barrels exist under `src/` or `mod.ts`, and the module is not
+  re-exported from `mod.ts`.
+- No dynamic import or string-keyed access to the constants exists.
+- The `{@link DEFAULT_PER_CHUNK_GRACE_MS}` doc reference resolves fine for a
+  module-private symbol.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot. Verified via the
+new runtime test that inspects the module namespace object.
+
+```mermaid
+flowchart LR
+    A["export const<br/>DEFAULT_PER_CHUNK_GRACE_MS<br/>STALL_WARMUP_MIN_COMPLETED_CHUNKS"] -->|remove export| B["module-private const<br/>(same internal uses)"]
+    B --> C["public surface unchanged:<br/>runAnalysisLoop, chunkFocusList,<br/>formatStallMemoryDiagnostics"]
+```
+
+## Test Plan
+
+- Added `test/ErrorGuidedStructuralEvolution/DataRecorderAnalysisExports.ts`:
+  - `stall tuning constants are not over-exported` — dynamically imports the
+    module and asserts `DEFAULT_PER_CHUNK_GRACE_MS` and
+    `STALL_WARMUP_MIN_COMPLETED_CHUNKS` are `undefined` on the module namespace.
+    Fails against the unfixed code (constants exported → `1000` / `2`) and
+    passes after removing `export`.
+  - `genuine public surface stays exported` — asserts `runAnalysisLoop`,
+    `chunkFocusList` and `formatStallMemoryDiagnostics` remain callable
+    functions.
+- Existing `DataRecorderAnalysis.ts` consumers (stall-warmup, chunking and
+  per-chunk-timeout suites) continue to pass unchanged.
+
+> Note: the pre-existing failure in
+> `test/ErrorGuidedStructuralEvolution/NeuronDiscoveryIntegration.ts`
+> ("Unhandled variant: setWeight") is unrelated to this change — it fails on the
+> base branch without these edits and stems from a Rust coordinated-op variant
+> not handled in `DiscoverAnalysis.ts`.

--- a/docs/archive/pr-summaries/pr-summary-3213.md
+++ b/docs/archive/pr-summaries/pr-summary-3213.md
@@ -1,0 +1,52 @@
+# Remove unused export `DISCOVERY_SAMPLE_RATE_DISABLED`
+
+## Summary
+
+The sentinel constant `DISCOVERY_SAMPLE_RATE_DISABLED` in
+`src/config/ParseOptions.ts` was exported but never imported by any other
+module. A static module-graph scan across `src/**`, `test/**`, `bench/**` and
+`mod.ts` found the constant is used only internally, at
+`parseDiscoverySampleRate` (line 172). `ParseOptions.ts` is not re-exported from
+`mod.ts` and the repository contains no `export *` barrels, so dropping the
+`export` keyword cannot break any external consumer.
+
+This change removes the `export` keyword, keeping the constant module-private,
+and adds behaviour tests that pin the public `-1` "disabled" sentinel semantics
+so the un-exported constant cannot silently change meaning.
+
+Closes #3213.
+
+## Evidence
+
+Backend/CLI change only — no web interface to screenshot.
+
+Verified no importers exist outside the defining file:
+
+```
+$ grep -rn "DISCOVERY_SAMPLE_RATE_DISABLED" src test bench mod.ts
+src/config/ParseOptions.ts:126:const DISCOVERY_SAMPLE_RATE_DISABLED = -1;
+src/config/ParseOptions.ts:172:  if (num === DISCOVERY_SAMPLE_RATE_DISABLED) {
+```
+
+The public function `parseDiscoverySampleRate` continues to honour the `-1`
+disabled sentinel, confirmed by the new tests:
+
+```
+parseDiscoverySampleRate - -1 sentinel (numeric) returns -1 (disabled) ... ok
+parseDiscoverySampleRate - '-1' sentinel (string) returns -1 (disabled) ... ok
+ok | 9 passed | 0 failed
+```
+
+Note: an unrelated pre-existing failure in
+`test/ErrorGuidedStructuralEvolution/NeuronDiscoveryIntegration.ts`
+(`Unhandled variant: setWeight` from the Rust/WASM coordinated-ops path) exists
+on the base branch and is independent of this change — confirmed by reproducing
+it with this change stashed.
+
+## Test Plan
+
+- Added `parseDiscoverySampleRate - -1 sentinel (numeric) returns -1 (disabled)`
+  and `parseDiscoverySampleRate - '-1' sentinel (string) returns -1 (disabled)`
+  to `test/config/ParseOptionsNegativeZero.ts`, exercising the internal
+  `DISCOVERY_SAMPLE_RATE_DISABLED` sentinel through the public API.
+- Existing negative-zero normalisation tests continue to pass unchanged.

--- a/docs/archive/pr-summaries/pr-summary-3214.md
+++ b/docs/archive/pr-summaries/pr-summary-3214.md
@@ -1,0 +1,55 @@
+## Summary
+
+Removed the redundant `export` keyword from the retry-cap constant
+`MOD_WEIGHT_MAX_RETRIES` in `src/mutate/ModWeight.ts`. Static module-graph
+analysis confirmed no other module in the repository (`src/**`, `test/**`,
+`bench/**`, `mod.ts`) imports the symbol; it is used only internally by the
+bounded no-op retry loop in `performMutation` (Issue #2383). Narrowing it to a
+module-private constant removes dead public surface without changing any
+behaviour. Closes #3214.
+
+Verification performed before the change:
+
+- `grep -rn "MOD_WEIGHT_MAX_RETRIES"` across `src`, `test`, `bench`, `mod.ts`,
+  `docs`, `scripts` — the only references are the definition at line 24 and the
+  internal use at line 110 of the same file.
+- `ModWeight.ts` is not re-exported from `mod.ts`, and no `export *` barrels
+  exist under `src/mutate/` that could re-export it implicitly.
+- No dynamic/reflective use found — the constant is referenced only by name in
+  its defining file.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+The internal retry loop that consumes `MOD_WEIGHT_MAX_RETRIES` is already
+covered by the behavioural tests in `test/mutate/ModWeightNoOpRetry.ts`, which
+exercise the bounded-retry behaviour without importing the constant. These tests
+continue to pass after the change, confirming behaviour is preserved while the
+symbol becomes module-private.
+
+Test evidence:
+
+- `deno check src/mutate/ModWeight.ts` — clean.
+- `deno lint src/mutate/ModWeight.ts` — clean.
+- `deno test -A test/mutate/ModWeight*.ts` — `27 passed | 0 failed`.
+
+Note: the full `quality.sh` run shows one pre-existing, unrelated failure in
+`test/ErrorGuidedStructuralEvolution/NeuronDiscoveryIntegration.ts` (an
+unhandled `setWeight` variant in `DiscoverAnalysis.ts`). It was confirmed to
+fail identically on the unmodified base branch (via `git stash`) and is not
+connected to this single-keyword change.
+
+## Test Plan
+
+- Existing `test/mutate/ModWeightNoOpRetry.ts` — verifies the bounded retry loop
+  governed by `MOD_WEIGHT_MAX_RETRIES` (retries past a no-op synapse, returns
+  false cleanly when no change is possible, never reports a change without one).
+  No import of the constant, so it remains a "what" test.
+- Existing `test/mutate/ModWeightBehavioural.ts`, `ModWeightRegularisation.ts`,
+  `ModWeightFocus.ts`, `ModWeightFocusFiltering.ts` — full ModWeight suite
+  passes (27 tests).
+
+No new tests were added: the change removes public surface only, and adding a
+test that greps the source for the `export` keyword would be a forbidden "how"
+test per `AGENTS.md`.

--- a/docs/archive/pr-summaries/pr-summary-3215.md
+++ b/docs/archive/pr-summaries/pr-summary-3215.md
@@ -1,0 +1,54 @@
+# Make `DEFAULT_SUBNETWORK_INDEX_SIZE` module-private (Issue #3215)
+
+## Summary
+
+The default-capacity constant `DEFAULT_SUBNETWORK_INDEX_SIZE` was `export`ed
+from `src/discovery/SubnetworkHashIndex.ts` but no other module in the
+repository imports it. A token scan across `src/**`, `test/**`, `bench/**` and
+`mod.ts` finds zero importers outside the defining file — the constant is used
+only internally, as the constructor default (line 53) and the shared-index
+initialiser (line 318). This change drops the `export` keyword to keep the
+symbol module-private, removing dead public surface area. Behaviour is
+unchanged. Closes #3215.
+
+## Evidence
+
+Backend-only change with no web interface, so no screenshot applies.
+
+Verified there are no importers before removing the export:
+
+```
+$ grep -rn "DEFAULT_SUBNETWORK_INDEX_SIZE" src test bench mod.ts
+src/discovery/SubnetworkHashIndex.ts:30:const DEFAULT_SUBNETWORK_INDEX_SIZE = 50_000;
+src/discovery/SubnetworkHashIndex.ts:53:  constructor(maxEntries: number = DEFAULT_SUBNETWORK_INDEX_SIZE) {
+src/discovery/SubnetworkHashIndex.ts:318:  DEFAULT_SUBNETWORK_INDEX_SIZE,
+```
+
+Both remaining references are internal to the defining file. The module is not
+re-exported from `mod.ts` and the repo contains no `export *` barrels, so
+dropping `export` cannot break any external consumer.
+
+```mermaid
+flowchart LR
+    C["const DEFAULT_SUBNETWORK_INDEX_SIZE"] --> A["constructor default (:53)"]
+    C --> B["sharedIndex initialiser (:318)"]
+    X["external importers"] -. none .-> C
+```
+
+## Test Plan
+
+- No test imported the constant, so no test needed updating.
+- The existing behavioural guard
+  `test/discovery/SubnetworkHashIndex.ts` →
+  `"SubnetworkHashIndex - default size 50,000 and isEnabled() reflects size"`
+  constructs `new SubnetworkHashIndex()` with no arguments and asserts the
+  index is enabled. It exercises the default-constructor behaviour that the
+  constant backs, without depending on the exported symbol, and continues to
+  pass after the change.
+- `deno test test/discovery/SubnetworkHashIndex.ts` — 19 passed / 0 failed.
+- `deno check src/discovery/SubnetworkHashIndex.ts` — clean.
+- Full `./quality.sh` passes lint, format and type-check. One unrelated test
+  (`NeuronDiscoveryIntegration.ts` → `collectRustAnalysisCandidates returns
+  analysis bundle`) fails on both this branch and the untouched base branch —
+  a pre-existing Rust-dylib `setWeight` variant mismatch with no connection to
+  this one-line export change.

--- a/docs/archive/pr-summaries/pr-summary-3215.md
+++ b/docs/archive/pr-summaries/pr-summary-3215.md
@@ -38,17 +38,17 @@ flowchart LR
 ## Test Plan
 
 - No test imported the constant, so no test needed updating.
-- The existing behavioural guard
-  `test/discovery/SubnetworkHashIndex.ts` →
+- The existing behavioural guard `test/discovery/SubnetworkHashIndex.ts` →
   `"SubnetworkHashIndex - default size 50,000 and isEnabled() reflects size"`
-  constructs `new SubnetworkHashIndex()` with no arguments and asserts the
-  index is enabled. It exercises the default-constructor behaviour that the
-  constant backs, without depending on the exported symbol, and continues to
-  pass after the change.
+  constructs `new SubnetworkHashIndex()` with no arguments and asserts the index
+  is enabled. It exercises the default-constructor behaviour that the constant
+  backs, without depending on the exported symbol, and continues to pass after
+  the change.
 - `deno test test/discovery/SubnetworkHashIndex.ts` — 19 passed / 0 failed.
 - `deno check src/discovery/SubnetworkHashIndex.ts` — clean.
 - Full `./quality.sh` passes lint, format and type-check. One unrelated test
-  (`NeuronDiscoveryIntegration.ts` → `collectRustAnalysisCandidates returns
-  analysis bundle`) fails on both this branch and the untouched base branch —
-  a pre-existing Rust-dylib `setWeight` variant mismatch with no connection to
-  this one-line export change.
+  (`NeuronDiscoveryIntegration.ts` →
+  `collectRustAnalysisCandidates returns
+  analysis bundle`) fails on both this
+  branch and the untouched base branch — a pre-existing Rust-dylib `setWeight`
+  variant mismatch with no connection to this one-line export change.

--- a/docs/archive/pr-summaries/pr-summary-3216.md
+++ b/docs/archive/pr-summaries/pr-summary-3216.md
@@ -1,0 +1,47 @@
+# Remove unused export `DEFAULT_OFFENDER_DETAIL_CAP` (Issue #3216)
+
+## Summary
+
+The diagnostics cap constant `DEFAULT_OFFENDER_DETAIL_CAP` in
+`src/score/BatchScorerDiagnostics.ts` was exported but had no importer anywhere
+in `src/`, `test/`, `bench/`, or `mod.ts`. Its only use is internal — the
+fallback for `options.detailCap` inside `buildBatchScorerDiagnostic`. Dropped the
+`export` keyword so the constant is module-private, removing the dead export
+while keeping behaviour identical.
+
+`BatchScorerDiagnostics.ts` is not re-exported from `mod.ts` and the repository
+has no `export *` barrels, so narrowing the visibility cannot break any external
+consumer. A token scan confirmed the only two references are the definition
+(line 30) and the internal fallback use (line 170), both in the defining file.
+
+Closes #3216.
+
+## Evidence
+
+Backend-only change — no web interface to screenshot. Verified via the existing
+behavioural test that exercises the default cap through the public API
+(`buildBatchScorerDiagnostic`), plus lint/format/type-check:
+
+- `deno test test/score/BatchScorerDiagnostics.ts` → **11 passed, 0 failed**,
+  including `... caps detail at 10 with +N more suffix`, which asserts the
+  default cap of 10 is applied when `detailCap` is omitted (i.e. the value the
+  constant supplies) — a "what" test that survives the visibility change.
+- `./quality.sh --check-only` → exit 0 (type-check across the tree).
+- `./quality.sh --lint-only` → exit 0 (1753 files linted, `deno fmt` clean,
+  bash scripts clean).
+
+Reference (unused-export before removal):
+
+```mermaid
+flowchart LR
+    Def["export const DEFAULT_OFFENDER_DETAIL_CAP = 10<br/>line 30"] --> Use["fallback at line 170<br/>options.detailCap ?? DEFAULT_OFFENDER_DETAIL_CAP"]
+    Ext["external importers"] -. none .- Def
+```
+
+## Test Plan
+
+No new test required — the existing
+`test/score/BatchScorerDiagnostics.ts::"... caps detail at 10 with +N more suffix"`
+already guards the default-cap-of-10 behaviour through the public API without
+importing the constant, so it remains the safety net for this change. All 11
+tests in that file pass after the edit.

--- a/docs/archive/pr-summaries/pr-summary-3216.md
+++ b/docs/archive/pr-summaries/pr-summary-3216.md
@@ -5,8 +5,8 @@
 The diagnostics cap constant `DEFAULT_OFFENDER_DETAIL_CAP` in
 `src/score/BatchScorerDiagnostics.ts` was exported but had no importer anywhere
 in `src/`, `test/`, `bench/`, or `mod.ts`. Its only use is internal — the
-fallback for `options.detailCap` inside `buildBatchScorerDiagnostic`. Dropped the
-`export` keyword so the constant is module-private, removing the dead export
+fallback for `options.detailCap` inside `buildBatchScorerDiagnostic`. Dropped
+the `export` keyword so the constant is module-private, removing the dead export
 while keeping behaviour identical.
 
 `BatchScorerDiagnostics.ts` is not re-exported from `mod.ts` and the repository
@@ -27,8 +27,8 @@ behavioural test that exercises the default cap through the public API
   default cap of 10 is applied when `detailCap` is omitted (i.e. the value the
   constant supplies) — a "what" test that survives the visibility change.
 - `./quality.sh --check-only` → exit 0 (type-check across the tree).
-- `./quality.sh --lint-only` → exit 0 (1753 files linted, `deno fmt` clean,
-  bash scripts clean).
+- `./quality.sh --lint-only` → exit 0 (1753 files linted, `deno fmt` clean, bash
+  scripts clean).
 
 Reference (unused-export before removal):
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
@@ -45,7 +45,7 @@ export type ParallelAnalysisFn = (
  * mid-flight timeout fires (Issue #2420). A small amount of slack avoids
  * racing the budget in normal operation.
  */
-export const DEFAULT_PER_CHUNK_GRACE_MS = 1_000;
+const DEFAULT_PER_CHUNK_GRACE_MS = 1_000;
 
 /**
  * Minimum number of completed chunks before the per-chunk stall guard may
@@ -55,7 +55,7 @@ export const DEFAULT_PER_CHUNK_GRACE_MS = 1_000;
  * amortised against a fast second chunk avoids tearing down the retry loop
  * after evaluating only one chunk's worth of neurons.
  */
-export const STALL_WARMUP_MIN_COMPLETED_CHUNKS = 2;
+const STALL_WARMUP_MIN_COMPLETED_CHUNKS = 2;
 
 /**
  * Returns a one-line diagnostic of the current Deno heap / RSS state.

--- a/src/config/ParseOptions.ts
+++ b/src/config/ParseOptions.ts
@@ -123,7 +123,7 @@ export function parseNumber(
 }
 
 /** Sentinel for "discovery sampling disabled". Only -1 is allowed; other negatives (e.g. -0.12) are rejected. */
-export const DISCOVERY_SAMPLE_RATE_DISABLED = -1;
+const DISCOVERY_SAMPLE_RATE_DISABLED = -1;
 
 /**
  * Parses discovery sample rate: -1 (disabled) or a number in [0, 1].

--- a/src/discovery/SubnetworkHashIndex.ts
+++ b/src/discovery/SubnetworkHashIndex.ts
@@ -26,8 +26,8 @@ import { exportJSON } from "@creature/CreatureSerialization.ts";
 import type { DiscoveryCandidate } from "@discovery/DiscoveryCandidates.ts";
 import { extractExponent } from "@discovery/FailureCacheKey.ts";
 
-/** Default maximum entries kept in the in-memory index. */
-export const DEFAULT_SUBNETWORK_INDEX_SIZE = 50_000;
+/** Default maximum entries kept in the in-memory index (module-private). */
+const DEFAULT_SUBNETWORK_INDEX_SIZE = 50_000;
 
 interface InternalEntry<T> {
   value: T;

--- a/src/mutate/ModWeight.ts
+++ b/src/mutate/ModWeight.ts
@@ -21,7 +21,7 @@ import { clampAndTrack } from "@utils/OverflowGuardStats.ts";
  * slot and emitting noisy telemetry, we retry a bounded number of times with
  * fresh random draws before returning false.
  */
-export const MOD_WEIGHT_MAX_RETRIES = 8;
+const MOD_WEIGHT_MAX_RETRIES = 8;
 
 /**
  * Mutation operator that modifies synapse weights.

--- a/src/propagate/MuonOrthogonalisation.ts
+++ b/src/propagate/MuonOrthogonalisation.ts
@@ -28,10 +28,13 @@
  * module is never invoked.
  */
 
-/** Standard Muon quintic Newton-Schulz coefficients. */
-export const MUON_QUINTIC_A = 3.4445;
-export const MUON_QUINTIC_B = -4.7750;
-export const MUON_QUINTIC_C = 2.0315;
+/**
+ * Standard Muon quintic Newton-Schulz coefficients. Module-private: used only
+ * by the quintic iteration below, with no in-repo importers (Issue #3211).
+ */
+const MUON_QUINTIC_A = 3.4445;
+const MUON_QUINTIC_B = -4.7750;
+const MUON_QUINTIC_C = 2.0315;
 
 /** Default number of Newton-Schulz iterations (the V4 standard is 5). */
 export const MUON_DEFAULT_STEPS = 5;

--- a/src/score/BatchScorerDiagnostics.ts
+++ b/src/score/BatchScorerDiagnostics.ts
@@ -27,7 +27,7 @@ import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import type { BatchScorerError } from "./BatchScorerReconciler.ts";
 
 /** Default cap for the per-creature detail list emitted in the log line. */
-export const DEFAULT_OFFENDER_DETAIL_CAP = 10;
+const DEFAULT_OFFENDER_DETAIL_CAP = 10;
 
 /**
  * `forwardOnly` composition counters for a population. Any creature whose

--- a/test/ErrorGuidedStructuralEvolution/DataRecorderAnalysisExports.ts
+++ b/test/ErrorGuidedStructuralEvolution/DataRecorderAnalysisExports.ts
@@ -1,0 +1,26 @@
+/**
+ * Guards the public export surface of `DataRecorderAnalysis.ts` (Issue #3212).
+ *
+ * The stall-detection tuning constants `DEFAULT_PER_CHUNK_GRACE_MS` and
+ * `STALL_WARMUP_MIN_COMPLETED_CHUNKS` are consumed only inside their defining
+ * module, so they must stay module-private rather than being over-exported.
+ * These tests inspect the module namespace object at runtime — a behavioural
+ * check that fails if the `export` keyword is ever re-added — while confirming
+ * the genuinely public helpers remain reachable.
+ */
+import { assertEquals } from "@std/assert";
+
+const mod = await import(
+  "@architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts"
+) as Record<string, unknown>;
+
+Deno.test("DataRecorderAnalysis - stall tuning constants are not over-exported", () => {
+  assertEquals(mod.DEFAULT_PER_CHUNK_GRACE_MS, undefined);
+  assertEquals(mod.STALL_WARMUP_MIN_COMPLETED_CHUNKS, undefined);
+});
+
+Deno.test("DataRecorderAnalysis - genuine public surface stays exported", () => {
+  assertEquals(typeof mod.runAnalysisLoop, "function");
+  assertEquals(typeof mod.chunkFocusList, "function");
+  assertEquals(typeof mod.formatStallMemoryDiagnostics, "function");
+});

--- a/test/config/ParseOptionsNegativeZero.ts
+++ b/test/config/ParseOptionsNegativeZero.ts
@@ -53,3 +53,15 @@ Deno.test("parseDiscoverySampleRate - normalises '-0' string to 0", () => {
   assertEquals(Object.is(result, -0), false, "Result should not be -0");
   assertEquals(result, 0, "Result should be positive 0");
 });
+
+// --- parseDiscoverySampleRate disabled sentinel (Issue #3213) ---
+// The -1 "disabled" sentinel is a module-private constant; these tests pin the
+// public behaviour so keeping it un-exported cannot silently change semantics.
+
+Deno.test("parseDiscoverySampleRate - -1 sentinel (numeric) returns -1 (disabled)", () => {
+  assertEquals(parseDiscoverySampleRate(-1, 0.5), -1);
+});
+
+Deno.test("parseDiscoverySampleRate - '-1' sentinel (string) returns -1 (disabled)", () => {
+  assertEquals(parseDiscoverySampleRate("-1", 0.5), -1);
+});

--- a/test/propagate/MuonOrthogonalisation.ts
+++ b/test/propagate/MuonOrthogonalisation.ts
@@ -301,6 +301,34 @@ Deno.test("Muon - default steps constant is 5 (V4 standard)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Export contract (Issue #3211): the quintic Newton-Schulz coefficients are
+// module-private implementation details, not part of the public surface. The
+// intended public API stays exported.
+// ---------------------------------------------------------------------------
+
+Deno.test("Muon - quintic coefficients are not part of the public export surface", async () => {
+  const mod = await import("@propagate/MuonOrthogonalisation.ts");
+  const keys = Object.keys(mod);
+  for (const name of ["MUON_QUINTIC_A", "MUON_QUINTIC_B", "MUON_QUINTIC_C"]) {
+    assert(
+      !keys.includes(name),
+      `${name} must be module-private (over-exported dead code, Issue #3211)`,
+    );
+  }
+  // The genuinely-public API must remain exported.
+  for (
+    const name of [
+      "newtonSchulzOrthogonalise",
+      "orthogonalise2D",
+      "frobeniusNorm",
+      "MUON_DEFAULT_STEPS",
+    ]
+  ) {
+    assert(keys.includes(name), `${name} must remain part of the public API`);
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Config + hook integration.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Milestone: dead code

This PR merges the completed milestone branch into Develop.
Closes #3225

### Issues addressed
- #3216: 🟢 dead-code: unused export `DEFAULT_OFFENDER_DETAIL_CAP` in BatchScorerDiagnostics.ts
- #3215: 🟢 dead-code: unused export `DEFAULT_SUBNETWORK_INDEX_SIZE` in SubnetworkHashIndex.ts
- #3214: 🟢 dead-code: unused export `MOD_WEIGHT_MAX_RETRIES` in ModWeight.ts
- #3213: 🟢 dead-code: unused export `DISCOVERY_SAMPLE_RATE_DISABLED` in ParseOptions.ts
- #3212: 🟢 dead-code: over-exported constants `DEFAULT_PER_CHUNK_GRACE_MS` & `STALL_WARMUP_MIN_COMPLETED_CHUNKS` in DataRecorderAnalysis.ts
- #3211: 🟢 dead-code: over-exported constants `MUON_QUINTIC_A`/`B`/`C` in MuonOrthogonalisation.ts

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.