### PR TITLE
fix(wasm): surface real WASM load failure cause in topology ops (Issue #3230)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.13",
+  "version": "5.7.14",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3230.md
+++ b/docs/archive/pr-summaries/pr-summary-3230.md
@@ -1,0 +1,86 @@
+# Fail loud with the real WASM load cause in topology ops
+
+## Summary
+
+A NEAT-AI training run aborted inside `simplify()` because
+`WasmTopologyOps.validateTopology` "could not load the NEAT-AI-core WASM
+bundle". The guard `requireWasm` threw a generic message telling the caller to
+`Run ./build.sh` — useless to a project consuming `@stsoftware/neat-ai` from JSR
+(which cannot rebuild the vendored bundle) — and, critically, it **hid the real
+reason** the bundle failed to load. Auto-init (`WasmAutoInit.ts` /
+`initWasmActivation`) deliberately swallows the load failure and returns
+`false`, so the underlying cause (e.g. a Deno `PermissionDenied` net/read error,
+or a corrupt artefact) never reached the operator.
+
+This fix makes the failure **loud with its true cause** (Issue #3234) instead of
+masking it:
+
+- `WasmModuleLoader` now records the last load failure in `lastLoadError` during
+  both async (`initWasmActivation`) and sync (`initWasmActivationSync`) init,
+  clears it on success, and exposes it via a new `getWasmLoadError()` getter
+  (also re-exported from `src/wasm/mod.ts`).
+- `WasmTopologyOps.requireWasm` now surfaces that underlying cause in its error
+  message, attaches the original error via `Error.cause` for diagnostics, and
+  gives actionable guidance for **both** JSR consumers (ensure the runtime can
+  load the vendored bundle — Deno needs read/net access to fetch
+  `wasm_activation_bg.wasm`) **and** local developers (`./build.sh`).
+
+Consistent with the project's core-dependency policy, **no TypeScript fallback**
+is introduced — topology validation stays WASM-only. Only the failure
+diagnostics improve; a missing bundle is an environment/config fault that must
+fail loud, not silently degrade.
+
+The published 5.7.x artefact does ship a loadable bundle: `deno.json`'s
+`publish.include` carries `wasm_activation/pkg/**` and those files are committed
+(see `wasm_activation/pkg/.gitignore`), so the fix targets the diagnostics gap,
+which is the actionable root cause per the issue's investigation areas.
+
+Closes #3230.
+
+## Evidence
+
+This is a backend/library change with no web interface to screenshot. Evidence
+is the new unit tests (below) plus the failure-path flow:
+
+```mermaid
+flowchart TD
+    A["auto-init loads WASM bundle"] -->|success| B["lastLoadError = null"]
+    A -->|"fails (PermissionDenied, corrupt artefact, ...)"| C["lastLoadError = real error"]
+    D["simplify() → validate → validateTopology"] --> E["requireWasm(fn, name)"]
+    E -->|"fn present"| F["run WASM op"]
+    E -->|"fn null"| G["throw Error: names op + real cause\n+ JSR & local guidance; Error.cause = lastLoadError"]
+    C -.recorded cause.-> G
+```
+
+Before: `… requires the NEAT-AI-core WASM bundle, but it could not be loaded. Run
+./build.sh …` (no cause).
+
+After: `… requires the NEAT-AI-core WASM bundle, but it could not be loaded.
+Underlying load error: PermissionDenied: Requires net access to "jsr.io". If you
+are consuming @stsoftware/neat-ai from JSR, ensure the runtime can load the
+vendored bundle … If you are developing NEAT-AI locally, run ./build.sh …` with
+the original error attached via `Error.cause`.
+
+## Test Plan
+
+- Added `test/wasm/WasmTopologyOpsRequireWasm.ts`:
+  - `requireWasm` returns the function when the bundle is loaded.
+  - `requireWasm` surfaces the injected underlying load error in the message and
+    attaches it via `Error.cause`, and includes JSR-consumer guidance
+    (reproduces the reported abort's missing-cause defect).
+  - `requireWasm` explains a never-initialised bundle when no cause was recorded
+    (and attaches no `cause`).
+- Added `test/wasm/WasmLoadErrorIntrospection.ts`:
+  - `getWasmLoadError()` is `null` after a successful load (no spurious cause).
+
+All four new tests pass. `deno fmt --check`, `deno lint`, and `deno check` pass
+on the touched files.
+
+### Pre-existing unrelated failure
+
+`./quality.sh` reports one **pre-existing** failure unrelated to this change —
+`test/ErrorGuidedStructuralEvolution/NeuronDiscoveryIntegration.ts`
+("collectRustAnalysisCandidates returns analysis bundle") fails with
+`Unhandled variant: {"type":"setBias",…}` from the locally-built Rust Discovery
+library. It fails identically on the clean tree (verified by stashing this
+change) and touches none of the WASM-loader files modified here.

--- a/docs/archive/pr-summaries/pr-summary-3230.md
+++ b/docs/archive/pr-summaries/pr-summary-3230.md
@@ -52,14 +52,17 @@ flowchart TD
     C -.recorded cause.-> G
 ```
 
-Before: `… requires the NEAT-AI-core WASM bundle, but it could not be loaded. Run
-./build.sh …` (no cause).
+Before:
+`… requires the NEAT-AI-core WASM bundle, but it could not be loaded. Run
+./build.sh …`
+(no cause).
 
-After: `… requires the NEAT-AI-core WASM bundle, but it could not be loaded.
+After:
+`… requires the NEAT-AI-core WASM bundle, but it could not be loaded.
 Underlying load error: PermissionDenied: Requires net access to "jsr.io". If you
 are consuming @stsoftware/neat-ai from JSR, ensure the runtime can load the
-vendored bundle … If you are developing NEAT-AI locally, run ./build.sh …` with
-the original error attached via `Error.cause`.
+vendored bundle … If you are developing NEAT-AI locally, run ./build.sh …`
+with the original error attached via `Error.cause`.
 
 ## Test Plan
 

--- a/src/wasm/WasmModuleLoader.ts
+++ b/src/wasm/WasmModuleLoader.ts
@@ -24,6 +24,27 @@ let wasmModule: WasmModule | null = null;
 let compiledNetworkClass: WasmCompiledNetworkConstructor | null = null;
 let initPromise: Promise<boolean> | null = null;
 
+/**
+ * Issue #3230: The real, underlying reason the WASM bundle failed to load.
+ *
+ * Auto-init (`WasmAutoInit.ts`) and `initWasmActivation` deliberately swallow
+ * the load failure and return `false` so a missing bundle does not crash at
+ * import time. Without capturing *why* it failed, downstream consumers of
+ * WASM-only operations (e.g. `WasmTopologyOps.validateTopology`) can only
+ * report a generic "could not be loaded" message — useless to a JSR consumer
+ * who cannot "run ./build.sh". We record the last load error here so those
+ * consumers can fail loud with the actual cause (Issue #3234).
+ */
+let lastLoadError: Error | null = null;
+
+/** Normalise an unknown thrown value into an `Error`. */
+function toError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+  return new Error(String(value));
+}
+
 // Standalone function pointers
 let squashFn: ((squashType: number, value: number) => number) | null = null;
 let derivativeFn: ((squashType: number, value: number) => number) | null = null;
@@ -476,8 +497,10 @@ export async function initWasmActivation(): Promise<boolean> {
       const module = await import(modulePath);
       await module.default();
       assignFunctionPointers(module);
+      lastLoadError = null;
       return true;
     } catch (error) {
+      lastLoadError = toError(error);
       const code = (error as { code?: string })?.code;
       const msg = (error as Error)?.message ?? String(error);
       const isNotFound = code === "ERR_MODULE_NOT_FOUND" ||
@@ -530,8 +553,10 @@ export function initWasmActivationSync(
       jsBindings.initSync(wasmBinary);
     }
     assignFunctionPointers(jsBindings);
+    lastLoadError = null;
     return true;
   } catch (error) {
+    lastLoadError = toError(error);
     getLogger().error(
       "Failed to initialise WASM activation module sync:",
       error,
@@ -545,6 +570,17 @@ export function initWasmActivationSync(
  */
 export function isWasmActivationAvailable(): boolean {
   return wasmModule !== null && compiledNetworkClass !== null;
+}
+
+/**
+ * Issue #3230: The underlying error from the most recent failed attempt to load
+ * the WASM bundle, or `null` if the bundle loaded successfully or was never
+ * initialised. Used by WASM-only operations to surface *why* the bundle could
+ * not be loaded (e.g. a `PermissionDenied` net/read error for a JSR consumer),
+ * instead of a generic "could not be loaded" message.
+ */
+export function getWasmLoadError(): Error | null {
+  return lastLoadError;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/wasm/WasmTopologyOps.ts
+++ b/src/wasm/WasmTopologyOps.ts
@@ -19,6 +19,7 @@ import {
   getScanAvailableConnectionsFn,
   getValidateStructuralIntegrityFn,
   getValidateTopologyFn,
+  getWasmLoadError,
 } from "@wasm/WasmModuleLoader.ts";
 
 // ---------------------------------------------------------------------------
@@ -103,14 +104,45 @@ export interface TopologyValidationResult {
   synapseIndex: number;
 }
 
-/** Throws a clear error when the WASM topology bundle is unavailable. */
-function requireWasm<T>(fn: T | null | undefined, name: string): T {
+/**
+ * Throws a clear error when the WASM topology bundle is unavailable.
+ *
+ * Issue #3230: the previous message only told the caller to "run ./build.sh",
+ * which is useless to a project consuming `@stsoftware/neat-ai` from JSR — that
+ * consumer cannot rebuild the vendored bundle. Worse, the *real* reason the
+ * bundle failed to load (e.g. a Deno `PermissionDenied` net/read error, or a
+ * corrupt artefact) was swallowed during auto-init, so the abort surfaced a
+ * generic message with no actionable cause.
+ *
+ * We now surface the underlying load error captured by the loader
+ * ({@link getWasmLoadError}) so the failure is loud with its true cause
+ * (Issue #3234), and we give guidance for both JSR consumers and local
+ * developers. `loadError` defaults to the loader's recorded error but is
+ * injectable for testing.
+ */
+export function requireWasm<T>(
+  fn: T | null | undefined,
+  name: string,
+  loadError: Error | null = getWasmLoadError(),
+): T {
   if (!fn) {
-    throw new Error(
+    const cause = loadError
+      ? `Underlying load error: ${loadError.name}: ${loadError.message}.`
+      : `No underlying load error was recorded, so the WASM module was ` +
+        `never initialised (auto-init may have been skipped or the process ` +
+        `exited before it completed).`;
+    const error = new Error(
       `WasmTopologyOps.${name} requires the NEAT-AI-core WASM bundle, ` +
-        `but it could not be loaded. Run ./build.sh to refresh ` +
-        `wasm_activation/pkg from the pinned core revision.`,
+        `but it could not be loaded. ${cause} ` +
+        `If you are consuming @stsoftware/neat-ai from JSR, ensure the ` +
+        `runtime can load the vendored bundle at wasm_activation/pkg ` +
+        `(Deno needs read/net access to the package location to fetch ` +
+        `wasm_activation_bg.wasm). If you are developing NEAT-AI locally, ` +
+        `run ./build.sh to refresh wasm_activation/pkg from the pinned ` +
+        `core revision.`,
+      loadError ? { cause: loadError } : undefined,
     );
+    throw error;
   }
   return fn;
 }

--- a/src/wasm/mod.ts
+++ b/src/wasm/mod.ts
@@ -25,6 +25,7 @@ export {
 
 // Issue #1405 - Module loading, init, and availability from WasmModuleLoader
 export {
+  getWasmLoadError,
   initWasmActivation,
   initWasmActivationSync,
   isWasmActivationAvailable,

--- a/test/wasm/WasmLoadErrorIntrospection.ts
+++ b/test/wasm/WasmLoadErrorIntrospection.ts
@@ -1,0 +1,18 @@
+/**
+ * Issue #3230 — `getWasmLoadError()` introspection.
+ *
+ * When the bundle loads successfully there must be no recorded load error, so
+ * downstream WASM-only operations do not report a spurious cause. The capture
+ * of a genuine load failure is covered by the `requireWasm` message tests
+ * (`WasmTopologyOpsRequireWasm.ts`), which inject the error directly rather
+ * than depend on the ambient (already-initialised) WASM state.
+ */
+
+import { assertEquals } from "@std/assert";
+import { getWasmLoadError, initWasmActivation } from "@wasm/mod.ts";
+
+Deno.test("getWasmLoadError is null after a successful load", async () => {
+  const ok = await initWasmActivation();
+  assertEquals(ok, true, "WASM must initialise for this test");
+  assertEquals(getWasmLoadError(), null);
+});

--- a/test/wasm/WasmTopologyOpsRequireWasm.ts
+++ b/test/wasm/WasmTopologyOpsRequireWasm.ts
@@ -1,0 +1,66 @@
+/**
+ * Issue #3230 — `requireWasm` must fail loud with the *real* reason the
+ * NEAT-AI-core WASM bundle could not be loaded.
+ *
+ * A NEAT-AI training run aborted inside `simplify()` because
+ * `WasmTopologyOps.validateTopology` could not load the bundle. The old error
+ * only said "Run ./build.sh", which is useless to a project consuming
+ * `@stsoftware/neat-ai` from JSR (it cannot rebuild the vendored bundle) and
+ * hid the actual cause (e.g. a Deno `PermissionDenied` net/read error).
+ *
+ * These tests exercise the exported `requireWasm` guard directly with an
+ * injected load error, so they do not depend on the ambient WASM state.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { requireWasm } from "@wasm/WasmTopologyOps.ts";
+
+Deno.test("requireWasm returns the function when the bundle is loaded", () => {
+  const fn = (a: number) => a + 1;
+  const resolved = requireWasm(fn, "validateTopology", null);
+  assertEquals(resolved, fn);
+  assertEquals(resolved(41), 42);
+});
+
+Deno.test("requireWasm surfaces the underlying load error as the cause", () => {
+  const loadError = new Error(
+    'PermissionDenied: Requires net access to "jsr.io"',
+  );
+  loadError.name = "PermissionDenied";
+
+  let thrown: unknown;
+  try {
+    requireWasm(null, "validateTopology", loadError);
+  } catch (err) {
+    thrown = err;
+  }
+
+  assert(thrown instanceof Error, "requireWasm should throw an Error");
+  const message = (thrown as Error).message;
+  // Names the failing operation and the WASM bundle requirement.
+  assertStringIncludes(message, "WasmTopologyOps.validateTopology");
+  assertStringIncludes(message, "NEAT-AI-core WASM bundle");
+  // Surfaces the real cause instead of a generic message.
+  assertStringIncludes(message, "PermissionDenied");
+  assertStringIncludes(message, "net access");
+  // Guidance for JSR consumers (who cannot run ./build.sh).
+  assertStringIncludes(message, "JSR");
+  // The original error is attached via Error.cause for diagnostics.
+  assertEquals((thrown as Error).cause, loadError);
+});
+
+Deno.test("requireWasm explains a never-initialised bundle when no cause recorded", () => {
+  let thrown: unknown;
+  try {
+    requireWasm(undefined, "scanAvailableConnections", null);
+  } catch (err) {
+    thrown = err;
+  }
+
+  assert(thrown instanceof Error, "requireWasm should throw an Error");
+  const message = (thrown as Error).message;
+  assertStringIncludes(message, "WasmTopologyOps.scanAvailableConnections");
+  assertStringIncludes(message, "never initialised");
+  // No cause is attached when there is no recorded load error.
+  assertEquals((thrown as Error).cause, undefined);
+});


### PR DESCRIPTION
# Fail loud with the real WASM load cause in topology ops

## Summary

A NEAT-AI training run aborted inside `simplify()` because
`WasmTopologyOps.validateTopology` "could not load the NEAT-AI-core WASM
bundle". The guard `requireWasm` threw a generic message telling the caller to
`Run ./build.sh` — useless to a project consuming `@stsoftware/neat-ai` from JSR
(which cannot rebuild the vendored bundle) — and, critically, it **hid the real
reason** the bundle failed to load. Auto-init (`WasmAutoInit.ts` /
`initWasmActivation`) deliberately swallows the load failure and returns
`false`, so the underlying cause (e.g. a Deno `PermissionDenied` net/read error,
or a corrupt artefact) never reached the operator.

This fix makes the failure **loud with its true cause** (Issue #3234) instead of
masking it:

- `WasmModuleLoader` now records the last load failure in `lastLoadError` during
  both async (`initWasmActivation`) and sync (`initWasmActivationSync`) init,
  clears it on success, and exposes it via a new `getWasmLoadError()` getter
  (also re-exported from `src/wasm/mod.ts`).
- `WasmTopologyOps.requireWasm` now surfaces that underlying cause in its error
  message, attaches the original error via `Error.cause` for diagnostics, and
  gives actionable guidance for **both** JSR consumers (ensure the runtime can
  load the vendored bundle — Deno needs read/net access to fetch
  `wasm_activation_bg.wasm`) **and** local developers (`./build.sh`).

Consistent with the project's core-dependency policy, **no TypeScript fallback**
is introduced — topology validation stays WASM-only. Only the failure
diagnostics improve; a missing bundle is an environment/config fault that must
fail loud, not silently degrade.

The published 5.7.x artefact does ship a loadable bundle: `deno.json`'s
`publish.include` carries `wasm_activation/pkg/**` and those files are committed
(see `wasm_activation/pkg/.gitignore`), so the fix targets the diagnostics gap,
which is the actionable root cause per the issue's investigation areas.

Closes #3230.

## Evidence

This is a backend/library change with no web interface to screenshot. Evidence
is the new unit tests (below) plus the failure-path flow:

```mermaid
flowchart TD
    A["auto-init loads WASM bundle"] -->|success| B["lastLoadError = null"]
    A -->|"fails (PermissionDenied, corrupt artefact, ...)"| C["lastLoadError = real error"]
    D["simplify() → validate → validateTopology"] --> E["requireWasm(fn, name)"]
    E -->|"fn present"| F["run WASM op"]
    E -->|"fn null"| G["throw Error: names op + real cause\n+ JSR & local guidance; Error.cause = lastLoadError"]
    C -.recorded cause.-> G
```

Before: `… requires the NEAT-AI-core WASM bundle, but it could not be loaded. Run
./build.sh …` (no cause).

After: `… requires the NEAT-AI-core WASM bundle, but it could not be loaded.
Underlying load error: PermissionDenied: Requires net access to "jsr.io". If you
are consuming @stsoftware/neat-ai from JSR, ensure the runtime can load the
vendored bundle … If you are developing NEAT-AI locally, run ./build.sh …` with
the original error attached via `Error.cause`.

## Test Plan

- Added `test/wasm/WasmTopologyOpsRequireWasm.ts`:
  - `requireWasm` returns the function when the bundle is loaded.
  - `requireWasm` surfaces the injected underlying load error in the message and
    attaches it via `Error.cause`, and includes JSR-consumer guidance
    (reproduces the reported abort's missing-cause defect).
  - `requireWasm` explains a never-initialised bundle when no cause was recorded
    (and attaches no `cause`).
- Added `test/wasm/WasmLoadErrorIntrospection.ts`:
  - `getWasmLoadError()` is `null` after a successful load (no spurious cause).

All four new tests pass. `deno fmt --check`, `deno lint`, and `deno check` pass
on the touched files.

### Pre-existing unrelated failure

`./quality.sh` reports one **pre-existing** failure unrelated to this change —
`test/ErrorGuidedStructuralEvolution/NeuronDiscoveryIntegration.ts`
("collectRustAnalysisCandidates returns analysis bundle") fails with
`Unhandled variant: {"type":"setBias",…}` from the locally-built Rust Discovery
library. It fails identically on the clean tree (verified by stashing this
change) and touches none of the WASM-loader files modified here.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr8gmkpw-0af538`<!-- vibe-worker-issue-3230 -->