### PR TITLE
Instrument Fitness with per-backend scorer-utilisation counts (Issue #3234)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3234.md
+++ b/docs/archive/pr-summaries/pr-summary-3234.md
@@ -1,0 +1,91 @@
+## Summary
+
+Instrument `Fitness` with per-backend scorer-utilisation counts and expose them
+on the `evolve*/train` result. Previously `Fitness.calculate()` tracked a single
+`lastScoredCreatureCount` that spanned **both** the Rust native **batch
+(one-pass)** path and the **per-creature worker** path, so a silent regression —
+the batch path breaks and every creature quietly falls back to the slow worker
+path — looked identical to a healthy run. This change splits that count by
+backend and adds an explicit batch-fallback tally so the split is visible in the
+run result (and therefore in the GRQ-cluster `result.json`). Telemetry only — no
+change to scoring numbers or the batch/worker partition.
+
+**Closes #3234.**
+
+What changed:
+
+- **`src/architecture/Fitness.ts`** — new per-generation counters
+  `lastCreaturesBatchScored`, `lastCreaturesPerCreatureScored`, and
+  `lastBatchFallbackOccurred`. The scored tally is split into `batchScoredCount`
+  / `workerScoredCount`; `lastScoredCreatureCount` stays equal to their sum for
+  existing throughput consumers. The batch `catch` block now sets the fallback
+  flag so a partial/whole fallback is never masked. All new counters are reset
+  in the early-return path alongside the existing resets.
+- **`src/creature/ScorerUtilisationTotals.ts`** (new) —
+  `ScorerUtilisationTotals` type + accumulator
+  (`create`/`accumulate`/`finalise`), mirroring `PhaseTimingTotals`.
+- **`src/creature/CreatureTraining.ts`** — accumulate the per-generation counts
+  across the run and finalise a `scorerUtilisation` field on the result of
+  `evolveDir`, `evolveEnv`, `evolveRL` (and `evolveDataSet`, which delegates to
+  `evolveDir`). Return types updated.
+- **`src/Creature.ts`** — `scorerUtilisation` added to the four wrapper return
+  types.
+- **`src/creature/EpisodicFitness.ts` / `RLEpisodeFitness.ts`** — reset the new
+  counters and report every scored creature under `creaturesPerCreatureScored`
+  (these paths never use the native batch scorer).
+- **`src/NEAT/NeatEvolution.ts`** — per-generation split emitted on the verbose
+  `[Throughput]` log line (`batchScored…/perCreatureScored…/batchFallback…`).
+- **`docs/event-driven-evolution.md`** — new "Run-level scorer-utilisation
+  totals" section with a Mermaid backend-split diagram.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via new and
+existing unit/integration tests (`deno test`) and the repo type gate
+(`./quality.sh --check-only`, `--lint-only`).
+
+```mermaid
+flowchart TD
+    Q[Unique creatures this generation] --> P{forwardOnly?}
+    P -->|yes| B[Batch rust scorer<br/>one process per generation]
+    P -->|no| W[Per-creature worker path]
+    B -->|success| BS[creaturesBatchScored++]
+    B -->|failure| F[batchFallbackGenerations++<br/>revert to worker path]
+    F --> W
+    W --> WS[creaturesPerCreatureScored++]
+```
+
+Selected results:
+
+- `test/architecture/FitnessScorerUtilisation.ts` — 4 passed
+- `test/creature/ScorerUtilisationTotals_test.ts` — 4 passed
+- `test/creature/EvolveScorerUtilisation.ts` — 1 passed
+- `deno test test/architecture/*.ts test/score/*.ts` — 629 passed, 0 failed
+  (regression guard on scoring behaviour)
+- `deno test test/creature/*.ts` — 62 passed, 0 failed (episodic/RL paths)
+- `./quality.sh --check-only` and `--lint-only` — clean
+
+## Test Plan
+
+New tests added:
+
+- **`test/creature/ScorerUtilisationTotals_test.ts`** — accumulator unit tests:
+  empty finalises to zeros; an all-batch run yields
+  `batchScorerInvocations ≈ generations` with zero fallback; a mixed population
+  counts recurrent creatures under `creaturesPerCreatureScored`; a fallback
+  generation increments `batchFallbackGenerations` and counts its creatures
+  per-creature.
+- **`test/architecture/FitnessScorerUtilisation.ts`** — `Fitness.calculate()`
+  split tests against a stubbed rust scorer: (a) all-forwardOnly →
+  `creaturesBatchScored === N`, zero fallback; (b) mixed → recurrent creatures
+  counted per-creature; (c) forced batch failure (stubbed to return no keys) →
+  `lastBatchFallbackOccurred === true`, `creaturesBatchScored === 0`, affected
+  creatures counted per-creature; plus an empty-population reset check.
+- **`test/creature/EvolveScorerUtilisation.ts`** — `evolveDataSet` returns a
+  populated `scorerUtilisation` whose `generations` matches the
+  `generation_complete` event count, with per-creature scoring accumulated
+  across generations and zero batch invocations/fallbacks in the WASM-only
+  environment.
+
+A silent-fallback regression (batch path breaks but scoring still succeeds via
+workers) is caught by tests (b)/(c) and by the runtime `[Throughput]` log line.

--- a/docs/event-driven-evolution.md
+++ b/docs/event-driven-evolution.md
@@ -474,10 +474,12 @@ existing-code path** with one new scorer. Concretely:
 - Signal-based interrupt — `SIGTERM` listener that flips `interrupted = true`
   and lets the current generation finish before exiting cleanly.
 - Time and iteration budgets — `timeoutMinutes`, `iterations`, `targetError`.
-- Result shape — `{ error, score, time, generation, phaseTimingTotals }` matches
-  `evolveDir`'s return so existing CLIs and dashboards do not branch on the
-  entry point. `phaseTimingTotals` is the whole-run per-phase timing breakdown
-  (Issue #3210); see below.
+- Result shape —
+  `{ error, score, time, generation, phaseTimingTotals, scorerUtilisation }`
+  matches `evolveDir`'s return so existing CLIs and dashboards do not branch on
+  the entry point. `phaseTimingTotals` is the whole-run per-phase timing
+  breakdown (Issue #3210) and `scorerUtilisation` is the whole-run per-backend
+  scorer-utilisation breakdown (Issue #3234); see below.
 
 ### New code paths
 
@@ -559,6 +561,53 @@ const scoringShare = phaseTimingTotals.fitnessMs / phaseTimingTotals.totalMs;
 
 The overhead is effectively zero — the per-generation measurements are always
 on; this just sums them.
+
+## 🔀 Run-level scorer-utilisation totals (Issue #3234)
+
+Alongside `phaseTimingTotals`, every `evolve*` result also carries
+`scorerUtilisation` — the whole-run **per-backend** count of how creatures were
+scored. `Fitness.calculate()` can score a generation two ways: the Rust native
+**batch (one-pass)** path (only forwardOnly creatures, one `rust_scorer` process
+per generation) or the **per-creature worker** path (recurrent creatures, and
+anything that falls back). Previously a single combined count spanned both, so a
+silent regression — the batch path breaks and every creature quietly falls back
+to the slow worker path — looked identical to a healthy run. `scorerUtilisation`
+splits the count by backend and tallies fallback generations so that regression
+is visible in `result.json`.
+
+```mermaid
+flowchart TD
+    Q[Unique creatures this generation] --> P{forwardOnly?}
+    P -->|yes| B[Batch rust scorer<br/>one process per generation]
+    P -->|no| W[Per-creature worker path]
+    B -->|success| BS[creaturesBatchScored++]
+    B -->|failure| F[batchFallbackGenerations++<br/>revert to worker path]
+    F --> W
+    W --> WS[creaturesPerCreatureScored++]
+```
+
+```typescript
+const { scorerUtilisation } = await creature.evolveDataSet(data, opts);
+// e.g. { generations: 200, batchScorerInvocations: 200,
+//        creaturesBatchScored: 40_000, creaturesPerCreatureScored: 0,
+//        batchFallbackGenerations: 0 }
+```
+
+- **`batchScorerInvocations`** — total `rust_scorer` processes spawned across
+  the run. Roughly one per generation when batch mode is healthy; `0` means
+  batch mode was disabled, unavailable, or never used.
+- **`creaturesBatchScored`** — creatures resolved via the native batch path. `0`
+  on a batch-enabled host is a red flag: the one-pass path never ran.
+- **`creaturesPerCreatureScored`** — creatures resolved via the worker path
+  (recurrent creatures plus any batch remainder or fallback).
+- **`batchFallbackGenerations`** — generations where a batch attempt failed and
+  its creatures reverted to the worker path. **Non-zero exposes the exact
+  silent-fallback regression this telemetry exists to catch.**
+- **`generations`** is the number of generations aggregated.
+
+The per-generation split is also emitted on the verbose `[Throughput]` log line
+(`batchScored…/perCreatureScored…/batchFallback…`). The overhead is zero — the
+counters are always on; this just sums them.
 
 ## 🧪 Validation hold-out hook (deferred)
 

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1008,6 +1008,7 @@ export class Creature implements CreatureInternal {
       time: number;
       generation: number;
       phaseTimingTotals: training.PhaseTimingTotals;
+      scorerUtilisation: training.ScorerUtilisationTotals;
     }
   > {
     return training.evolveDir(this, dataSetDir, options);
@@ -1032,6 +1033,7 @@ export class Creature implements CreatureInternal {
       time: number;
       generation: number;
       phaseTimingTotals: training.PhaseTimingTotals;
+      scorerUtilisation: training.ScorerUtilisationTotals;
     }
   > {
     return training.evolveEnv(this, adapter, options);
@@ -1055,6 +1057,7 @@ export class Creature implements CreatureInternal {
       time: number;
       generation: number;
       phaseTimingTotals: training.PhaseTimingTotals;
+      scorerUtilisation: training.ScorerUtilisationTotals;
       /**
        * Issue #2629: per-milestone payloads collected when
        * `options.statistics === true`. Omitted when statistics are off.
@@ -1075,6 +1078,7 @@ export class Creature implements CreatureInternal {
       score: number;
       time: number;
       phaseTimingTotals: training.PhaseTimingTotals;
+      scorerUtilisation: training.ScorerUtilisationTotals;
     }
   > {
     return training.evolveDataSet(this, dataSet, options);

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -1047,6 +1047,12 @@ export async function evolve(
         `/depth${throughput.heavyQueueMaxDepth}/wait${throughput.heavyWaitMs}ms` +
         ` scorer=${throughput.scorerMs.toFixed(1)}ms` +
         `/scored${throughput.scoredCreatureCount}` +
+        // Issue #3234: per-backend scorer-utilisation split so a silent batch
+        // fallback is visible on the verbose log line, not just in the result.
+        `/batchScored${neat.fitness.lastCreaturesBatchScored}` +
+        `/perCreatureScored${neat.fitness.lastCreaturesPerCreatureScored}` +
+        `/batchInvocations${neat.fitness.lastBatchScorerInvocations}` +
+        `/batchFallback${neat.fitness.lastBatchFallbackOccurred ? 1 : 0}` +
         `/creaturesPerSec${throughput.creaturesPerSec.toFixed(1)}` +
         // Issue #2523: surface corrupt-parent skip count in the
         // throughput summary so operators can alert on producer

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -86,6 +86,31 @@ export class Fitness {
   lastBatchScorerInvocations = 0;
 
   /**
+   * Creatures scored via the native batch (one-pass) rust-scorer path during
+   * the most recent `calculate()` call (Issue #3234).
+   *
+   * Split out from {@link lastScoredCreatureCount} — which spans both backends
+   * — so a silent regression where the batch path breaks and every creature
+   * quietly falls back to the slow per-creature worker path is visible as a
+   * zero here instead of blending into the combined total.
+   */
+  lastCreaturesBatchScored = 0;
+
+  /**
+   * Creatures scored via the per-creature worker path during the most recent
+   * `calculate()` call (Issue #3234). Includes recurrent creatures that never
+   * enter the batch path and any creatures re-scored after a batch fallback.
+   */
+  lastCreaturesPerCreatureScored = 0;
+
+  /**
+   * True when a batch attempt failed during the most recent `calculate()` call
+   * and its creatures reverted to the per-creature worker path (Issue #3234).
+   * A partial/whole fallback must stay visible, never masked as success.
+   */
+  lastBatchFallbackOccurred = false;
+
+  /**
    * Data directory passed to the external `rust_scorer` binary in batch
    * mode (Issue #2422). `undefined` disables batch scoring regardless of
    * configuration, matching the behaviour of environments where no dataset
@@ -169,6 +194,11 @@ export class Fitness {
       this.lastScorerMs = 0;
       this.lastScoredCreatureCount = 0;
       this.lastBatchScorerInvocations = 0;
+      // Issue #3234: reset per-backend scorer-utilisation counters alongside
+      // the existing telemetry resets.
+      this.lastCreaturesBatchScored = 0;
+      this.lastCreaturesPerCreatureScored = 0;
+      this.lastBatchFallbackOccurred = false;
       return;
     }
 
@@ -182,8 +212,12 @@ export class Fitness {
     // `processNext` will increment these after every `calculateScore()`
     // call. Using bare numeric mutation keeps the hot path allocation-free.
     let scorerMsAccum = 0;
-    let scoredCount = 0;
+    // Issue #3234: split the scored-creature tally by backend so the batch
+    // (one-pass) path and the per-creature worker path can be distinguished.
+    let batchScoredCount = 0;
+    let workerScoredCount = 0;
     this.lastBatchScorerInvocations = 0;
+    this.lastBatchFallbackOccurred = false;
 
     // Issue #2422: When the external rust scorer is enabled in directory
     // mode, invoke it once for the whole generation, map results back to
@@ -248,7 +282,7 @@ export class Fitness {
                 const scoreStart = performance.now();
                 creature.score = calculateScore(creature, error, this.growth);
                 scorerMsAccum += performance.now() - scoreStart;
-                scoredCount++;
+                batchScoredCount++;
               }
               addTag(creature, "score", creature.score.toString());
 
@@ -307,6 +341,9 @@ export class Fitness {
           // creaturesForWorkerPath stays at uniqueQueue so the worker path
           // re-scores everything, including the forwardOnly creatures the
           // batch attempt failed to score.
+          // Issue #3234: mark the fallback so it is counted per-run rather
+          // than silently absorbed by the worker path's success.
+          this.lastBatchFallbackOccurred = true;
         }
       }
       // forwardOnlyCreatures.length === 0 — no temp dir, no spawn. The
@@ -387,7 +424,7 @@ export class Fitness {
         const scoreStart = performance.now();
         creature.score = calculateScore(creature, error, this.growth);
         scorerMsAccum += performance.now() - scoreStart;
-        scoredCount++;
+        workerScoredCount++;
       }
       addTag(creature, "score", creature.score.toString());
 
@@ -421,7 +458,11 @@ export class Fitness {
 
     // Issue #2424: Publish scorer telemetry for throughput metrics assembly.
     this.lastScorerMs = scorerMsAccum;
-    this.lastScoredCreatureCount = scoredCount;
+    // Issue #3234: publish the per-backend split. The combined count is kept
+    // for existing throughput consumers and must equal batch + worker.
+    this.lastCreaturesBatchScored = batchScoredCount;
+    this.lastCreaturesPerCreatureScored = workerScoredCount;
+    this.lastScoredCreatureCount = batchScoredCount + workerScoredCount;
   }
 }
 

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -85,9 +85,33 @@ import {
 // run-level phase-timing totals shape (Issue #3210).
 export type { PhaseTimingTotals } from "@creature/PhaseTimingTotals.ts";
 import {
+  accumulateScorerUtilisation,
+  createScorerUtilisationAccumulator,
+  finaliseScorerUtilisationTotals,
+  type ScorerUtilisationCounts,
+  type ScorerUtilisationTotals,
+} from "@creature/ScorerUtilisationTotals.ts";
+// Re-export so `import * as training` consumers (e.g. Creature.ts) can name the
+// run-level scorer-utilisation totals shape (Issue #3234).
+export type { ScorerUtilisationTotals } from "@creature/ScorerUtilisationTotals.ts";
+import {
   type EvolveRLMilestone,
   isMilestoneGeneration,
 } from "@creature/EvolveRLStatistics.ts";
+
+/**
+ * Snapshot the per-backend scorer-utilisation counts published by `Fitness`
+ * after a generation's `evolve()` cycle (Issue #3234). Read once per
+ * generation into the run-level accumulator.
+ */
+function readScorerUtilisation(fitness: Fitness): ScorerUtilisationCounts {
+  return {
+    batchScorerInvocations: fitness.lastBatchScorerInvocations,
+    creaturesBatchScored: fitness.lastCreaturesBatchScored,
+    creaturesPerCreatureScored: fitness.lastCreaturesPerCreatureScored,
+    batchFallbackOccurred: fitness.lastBatchFallbackOccurred,
+  };
+}
 
 /**
  * Propagate expected values backward through the network for all output neurons.
@@ -414,6 +438,7 @@ export async function evolveDir(
     time: number;
     generation: number;
     phaseTimingTotals: PhaseTimingTotals;
+    scorerUtilisation: ScorerUtilisationTotals;
   }
 > {
   let interrupted = false;
@@ -527,6 +552,8 @@ export async function evolveDir(
   const iterations = config.iterations;
   // Issue #3210: sum the always-on per-generation phase timings across the run.
   const phaseTimingAccumulator = createPhaseTimingAccumulator();
+  // Issue #3234: sum the per-backend scorer-utilisation counts across the run.
+  const scorerUtilisationAccumulator = createScorerUtilisationAccumulator();
 
   while (true) {
     // deno-lint-ignore no-await-in-loop
@@ -586,6 +613,12 @@ export async function evolveDir(
     // Issue #3210: fold this generation's (checkpoint-merged) phase timing
     // into the whole-run running totals returned alongside `time`.
     accumulatePhaseTiming(phaseTimingAccumulator, phaseTiming);
+    // Issue #3234: fold this generation's per-backend scorer-utilisation counts
+    // into the whole-run totals returned alongside `phaseTimingTotals`.
+    accumulateScorerUtilisation(
+      scorerUtilisationAccumulator,
+      readScorerUtilisation(neat.fitness),
+    );
 
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
@@ -708,6 +741,9 @@ export async function evolveDir(
     generation: generation,
     time,
     phaseTimingTotals: finalisePhaseTimingTotals(phaseTimingAccumulator, time),
+    scorerUtilisation: finaliseScorerUtilisationTotals(
+      scorerUtilisationAccumulator,
+    ),
   };
 }
 
@@ -742,6 +778,7 @@ export async function evolveEnv<S, A>(
     time: number;
     generation: number;
     phaseTimingTotals: PhaseTimingTotals;
+    scorerUtilisation: ScorerUtilisationTotals;
   }
 > {
   if (creature.input !== adapter.inputCount) {
@@ -850,6 +887,8 @@ export async function evolveEnv<S, A>(
   const iterations = config.iterations;
   // Issue #3210: sum the always-on per-generation phase timings across the run.
   const phaseTimingAccumulator = createPhaseTimingAccumulator();
+  // Issue #3234: sum the per-backend scorer-utilisation counts across the run.
+  const scorerUtilisationAccumulator = createScorerUtilisationAccumulator();
 
   while (true) {
     generation++;
@@ -899,6 +938,12 @@ export async function evolveEnv<S, A>(
     // Issue #3210: fold this generation's (checkpoint-merged) phase timing
     // into the whole-run running totals returned alongside `time`.
     accumulatePhaseTiming(phaseTimingAccumulator, phaseTiming);
+    // Issue #3234: fold this generation's per-backend scorer-utilisation counts
+    // into the whole-run totals returned alongside `phaseTimingTotals`.
+    accumulateScorerUtilisation(
+      scorerUtilisationAccumulator,
+      readScorerUtilisation(neat.fitness),
+    );
 
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
@@ -1008,6 +1053,9 @@ export async function evolveEnv<S, A>(
     generation,
     time,
     phaseTimingTotals: finalisePhaseTimingTotals(phaseTimingAccumulator, time),
+    scorerUtilisation: finaliseScorerUtilisationTotals(
+      scorerUtilisationAccumulator,
+    ),
   };
 }
 
@@ -1118,6 +1166,7 @@ export async function evolveRL<S, A>(
     time: number;
     generation: number;
     phaseTimingTotals: PhaseTimingTotals;
+    scorerUtilisation: ScorerUtilisationTotals;
     /**
      * Issue #2629: per-milestone payloads collected when `statistics === true`.
      * Omitted entirely when statistics are disabled so the return shape stays
@@ -1336,6 +1385,8 @@ export async function evolveRL<S, A>(
   const iterations = config.iterations;
   // Issue #3210: sum the always-on per-generation phase timings across the run.
   const phaseTimingAccumulator = createPhaseTimingAccumulator();
+  // Issue #3234: sum the per-backend scorer-utilisation counts across the run.
+  const scorerUtilisationAccumulator = createScorerUtilisationAccumulator();
 
   while (true) {
     generation++;
@@ -1393,6 +1444,12 @@ export async function evolveRL<S, A>(
     // Issue #3210: fold this generation's (checkpoint-merged) phase timing
     // into the whole-run running totals returned alongside `time`.
     accumulatePhaseTiming(phaseTimingAccumulator, phaseTiming);
+    // Issue #3234: fold this generation's per-backend scorer-utilisation counts
+    // into the whole-run totals returned alongside `phaseTimingTotals`.
+    accumulateScorerUtilisation(
+      scorerUtilisationAccumulator,
+      readScorerUtilisation(neat.fitness),
+    );
 
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
@@ -1569,6 +1626,10 @@ export async function evolveRL<S, A>(
     phaseTimingAccumulator,
     time,
   );
+  // Issue #3234: finalise the run-level per-backend scorer-utilisation totals.
+  const scorerUtilisation = finaliseScorerUtilisationTotals(
+    scorerUtilisationAccumulator,
+  );
   if (statisticsEnabled) {
     return {
       error,
@@ -1576,6 +1637,7 @@ export async function evolveRL<S, A>(
       generation,
       time,
       phaseTimingTotals,
+      scorerUtilisation,
       milestones,
     };
   }
@@ -1585,6 +1647,7 @@ export async function evolveRL<S, A>(
     generation,
     time,
     phaseTimingTotals,
+    scorerUtilisation,
   };
 }
 
@@ -1602,6 +1665,7 @@ export async function evolveDataSet(
     score: number;
     time: number;
     phaseTimingTotals: PhaseTimingTotals;
+    scorerUtilisation: ScorerUtilisationTotals;
   }
 > {
   const config = createNeatConfig(options);

--- a/src/creature/EpisodicFitness.ts
+++ b/src/creature/EpisodicFitness.ts
@@ -103,6 +103,11 @@ export class EpisodicFitness<S, A> extends Fitness {
     this.lastScorerMs = 0;
     this.lastScoredCreatureCount = 0;
     this.lastBatchScorerInvocations = 0;
+    // Issue #3234: episodic scoring never uses the native batch path, so every
+    // scored creature is per-creature. Reset the split counters each call.
+    this.lastCreaturesBatchScored = 0;
+    this.lastCreaturesPerCreatureScored = 0;
+    this.lastBatchFallbackOccurred = false;
 
     const needsEvaluation = population.filter((c) => c.score === undefined);
 
@@ -254,6 +259,8 @@ export class EpisodicFitness<S, A> extends Fitness {
 
     this.lastScorerMs = scorerMsAccum;
     this.lastScoredCreatureCount = scoredCount;
+    // Issue #3234: every episodic creature is scored on the per-creature path.
+    this.lastCreaturesPerCreatureScored = scoredCount;
     return Promise.resolve();
   }
 

--- a/src/creature/RLEpisodeFitness.ts
+++ b/src/creature/RLEpisodeFitness.ts
@@ -215,6 +215,11 @@ export class RLEpisodeFitness<S, A> extends Fitness {
     this.lastScorerMs = 0;
     this.lastScoredCreatureCount = 0;
     this.lastBatchScorerInvocations = 0;
+    // Issue #3234: RL episode scoring never uses the native batch path — every
+    // scored creature is per-creature. Reset the split counters each call.
+    this.lastCreaturesBatchScored = 0;
+    this.lastCreaturesPerCreatureScored = 0;
+    this.lastBatchFallbackOccurred = false;
 
     if (this.seedSet.length === 0) {
       throw new Error(
@@ -326,6 +331,8 @@ export class RLEpisodeFitness<S, A> extends Fitness {
 
     this.lastScorerMs = scorerMsAccum;
     this.lastScoredCreatureCount = scoredCount;
+    // Issue #3234: every RL creature is scored on the per-creature path.
+    this.lastCreaturesPerCreatureScored = scoredCount;
   }
 
   /**

--- a/src/creature/ScorerUtilisationTotals.ts
+++ b/src/creature/ScorerUtilisationTotals.ts
@@ -1,0 +1,107 @@
+/**
+ * Whole-run, summed per-backend scorer-utilisation counts returned alongside
+ * `phaseTimingTotals` from the `evolve*` functions (Issue #3234).
+ *
+ * `Fitness.calculate()` already tracks how many `rust_scorer` processes it
+ * spawned per generation, but until now the unique-scored creature count was a
+ * single number spanning *both* the native batch (one-pass) path and the
+ * per-creature worker path — so a silent regression where the batch path broke
+ * and every creature quietly fell back to the slow worker path looked
+ * identical to a healthy run. These aggregates split that count by backend and
+ * add an explicit batch-fallback tally so the split is visible in the run
+ * result (and therefore in the GRQ-cluster `result.json`).
+ *
+ * All values are raw counts summed across every generation of the run.
+ */
+
+/**
+ * A single generation's scorer-utilisation snapshot, read from `Fitness`
+ * after each `evolve()` cycle. `batchFallbackOccurred` is a boolean because a
+ * generation either did or did not revert its whole batch to the worker path;
+ * the accumulator turns it into a per-run count of affected generations.
+ */
+export interface ScorerUtilisationCounts {
+  /** `rust_scorer` processes spawned this generation (0 when batch disabled). */
+  readonly batchScorerInvocations: number;
+  /** Creatures scored via the native batch (one-pass) path this generation. */
+  readonly creaturesBatchScored: number;
+  /** Creatures scored via the per-creature worker path this generation. */
+  readonly creaturesPerCreatureScored: number;
+  /**
+   * True when a batch attempt failed this generation and its creatures
+   * reverted to the per-creature worker path. A partial/whole fallback must be
+   * visible, not masked as success.
+   */
+  readonly batchFallbackOccurred: boolean;
+}
+
+/**
+ * Whole-run scorer-utilisation totals surfaced on the `evolve*` result beside
+ * `phaseTimingTotals`.
+ */
+export interface ScorerUtilisationTotals {
+  /** Number of generations whose scorer counts were aggregated. */
+  readonly generations: number;
+  /** Total `rust_scorer` processes spawned across the run. */
+  readonly batchScorerInvocations: number;
+  /** Total creatures scored via the native batch path across the run. */
+  readonly creaturesBatchScored: number;
+  /** Total creatures scored via the per-creature worker path across the run. */
+  readonly creaturesPerCreatureScored: number;
+  /**
+   * Number of generations that hit a batch fallback. Non-zero means the native
+   * batch path failed at least once and scoring silently continued on the slow
+   * worker path — exactly the regression this telemetry exists to expose.
+   */
+  readonly batchFallbackGenerations: number;
+}
+
+/**
+ * Mutable running sum of the per-generation scorer counts. Reset to zeros by
+ * {@link createScorerUtilisationAccumulator}, advanced one generation at a
+ * time by {@link accumulateScorerUtilisation}, and frozen into an immutable
+ * {@link ScorerUtilisationTotals} by {@link finaliseScorerUtilisationTotals}.
+ */
+export interface ScorerUtilisationAccumulator {
+  generations: number;
+  batchScorerInvocations: number;
+  creaturesBatchScored: number;
+  creaturesPerCreatureScored: number;
+  batchFallbackGenerations: number;
+}
+
+/** Create a zeroed {@link ScorerUtilisationAccumulator}. */
+export function createScorerUtilisationAccumulator(): ScorerUtilisationAccumulator {
+  return {
+    generations: 0,
+    batchScorerInvocations: 0,
+    creaturesBatchScored: 0,
+    creaturesPerCreatureScored: 0,
+    batchFallbackGenerations: 0,
+  };
+}
+
+/** Add one generation's {@link ScorerUtilisationCounts} into the accumulator. */
+export function accumulateScorerUtilisation(
+  acc: ScorerUtilisationAccumulator,
+  counts: ScorerUtilisationCounts,
+): void {
+  acc.generations++;
+  acc.batchScorerInvocations += counts.batchScorerInvocations;
+  acc.creaturesBatchScored += counts.creaturesBatchScored;
+  acc.creaturesPerCreatureScored += counts.creaturesPerCreatureScored;
+  if (counts.batchFallbackOccurred) acc.batchFallbackGenerations++;
+}
+
+/** Freeze the accumulator into an immutable {@link ScorerUtilisationTotals}. */
+export function finaliseScorerUtilisationTotals(
+  acc: ScorerUtilisationAccumulator,
+): ScorerUtilisationTotals {
+  return {
+    generations: acc.generations,
+    batchScorerInvocations: acc.batchScorerInvocations,
+    creaturesBatchScored: acc.creaturesBatchScored,
+    creaturesPerCreatureScored: acc.creaturesPerCreatureScored,
+    batchFallbackGenerations: acc.batchFallbackGenerations,
+  };
+}

--- a/test/architecture/FitnessScorerUtilisation.ts
+++ b/test/architecture/FitnessScorerUtilisation.ts
@@ -1,0 +1,261 @@
+/**
+ * Fitness-level per-backend scorer-utilisation split tests (Issue #3234).
+ *
+ * `Fitness.calculate()` splits its unique-scored creature count by backend:
+ * creatures resolved via the native batch (one-pass) rust-scorer path vs the
+ * per-creature worker path, plus a batch-fallback flag. These tests exercise
+ * the three regressions the issue exists to expose:
+ *  (a) an all-forwardOnly population batch-scores everything with zero fallback;
+ *  (b) a mixed population routes recurrent creatures to the per-creature path;
+ *  (c) a forced batch failure flags a fallback and re-scores every creature
+ *      via the per-creature path.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { Fitness } from "@architecture/Fitness.ts";
+import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import {
+  __resetRustScorerBridgeForTests,
+  __setRustScorerRunnerForTests,
+} from "../../src/score/RustScorerBridge.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+class MockWorkerHandler {
+  public evaluateCallCount = 0;
+  addIdleListener(_callback: () => void): void {}
+  isBusy(): boolean {
+    return false;
+  }
+  // deno-lint-ignore require-await
+  async evaluate(
+    _creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<{ evaluate: { error: number } }> {
+    this.evaluateCallCount++;
+    return { evaluate: { error: 0.5 } };
+  }
+}
+
+function buildDataSet(): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < 4; i++) {
+    rows.push({
+      input: new Float32Array([i, 4 - i]),
+      output: new Float32Array([i > 2 ? 1 : -1]),
+    });
+  }
+  return rows;
+}
+
+/** Build `count` distinct creatures, forwardOnly or recurrent as requested. */
+function buildPopulation(count: number, forwardOnly: boolean): Creature[] {
+  const base: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "TANH", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+    forwardOnly,
+  };
+  const creatures: Creature[] = [];
+  for (let i = 0; i < count; i++) {
+    const forked = structuredClone(base);
+    forked.neurons[0].bias = 0.1 * (i + 1) + (forwardOnly ? 0 : 100);
+    creatures.push(Creature.fromJSON(forked));
+  }
+  return creatures;
+}
+
+/** Enable batch rust scoring, run `fn`, and always restore the env. */
+async function withBatchEnabled(
+  runner: Parameters<typeof __setRustScorerRunnerForTests>[0],
+  fn: (fitness: Fitness, worker: MockWorkerHandler) => Promise<void>,
+): Promise<void> {
+  __resetRustScorerBridgeForTests();
+  const prevEnabled = Deno.env.get("NEAT_AI_RUST_SCORER_ENABLED");
+  const prevBatch = Deno.env.get("NEAT_AI_RUST_SCORER_BATCH");
+  Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", "true");
+  Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", "true");
+  __setRustScorerRunnerForTests(runner);
+  const worker = new MockWorkerHandler();
+  const dataDir = makeDataDir(buildDataSet(), 4);
+  try {
+    const fitness = new Fitness(
+      [worker as unknown as WorkerHandler],
+      0.0001,
+      false,
+      undefined,
+      dataDir,
+    );
+    await fn(fitness, worker);
+  } finally {
+    if (prevEnabled === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_ENABLED");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", prevEnabled);
+    }
+    if (prevBatch === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_BATCH");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", prevBatch);
+    }
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+}
+
+/** A runner that scores every supplied UUID successfully in one pass. */
+function successRunner(uuids: string[]) {
+  return (_command: string, args: string[]) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    const payload: Record<
+      string,
+      { score: number; error: number; recordCount: number }
+    > = {};
+    for (let i = 0; i < uuids.length; i++) {
+      payload[uuids[i]] = {
+        score: 0.9 - i * 0.1,
+        error: 0.1 + i * 0.05,
+        recordCount: 4,
+      };
+    }
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: JSON.stringify(payload),
+      stderr: "",
+    });
+  };
+}
+
+Deno.test("scorer utilisation - all-forwardOnly population batch-scored, zero fallback", async () => {
+  const population = buildPopulation(4, true);
+  const uuids = population.map((c) => CreatureUtil.makeUUID(c));
+  await withBatchEnabled(successRunner(uuids), async (fitness, worker) => {
+    await fitness.calculate(population);
+
+    assertEquals(
+      fitness.lastCreaturesBatchScored,
+      4,
+      "all creatures batch-scored",
+    );
+    assertEquals(fitness.lastCreaturesPerCreatureScored, 0);
+    assertEquals(fitness.lastBatchScorerInvocations, 1);
+    assertEquals(fitness.lastBatchFallbackOccurred, false);
+    // The combined count still equals batch + worker for existing consumers.
+    assertEquals(fitness.lastScoredCreatureCount, 4);
+    assertEquals(worker.evaluateCallCount, 0, "batch owns scoring");
+  });
+});
+
+Deno.test("scorer utilisation - mixed population routes recurrent creatures per-creature", async () => {
+  const forwardOnly = buildPopulation(3, true);
+  const recurrent = buildPopulation(2, false);
+  const population = [...forwardOnly, ...recurrent];
+  const forwardUuids = forwardOnly.map((c) => CreatureUtil.makeUUID(c));
+  for (const c of recurrent) CreatureUtil.makeUUID(c);
+
+  await withBatchEnabled(
+    successRunner(forwardUuids),
+    async (fitness, worker) => {
+      await fitness.calculate(population);
+
+      assertEquals(
+        fitness.lastCreaturesBatchScored,
+        3,
+        "forwardOnly batch-scored",
+      );
+      assertEquals(
+        fitness.lastCreaturesPerCreatureScored,
+        2,
+        "recurrent creatures counted per-creature",
+      );
+      assertEquals(fitness.lastBatchScorerInvocations, 1);
+      assertEquals(fitness.lastBatchFallbackOccurred, false);
+      assertEquals(fitness.lastScoredCreatureCount, 5);
+      assertEquals(
+        worker.evaluateCallCount,
+        2,
+        "only the recurrent remainder hits the worker path",
+      );
+    },
+  );
+});
+
+Deno.test("scorer utilisation - forced batch failure flags fallback, counts per-creature", async () => {
+  const population = buildPopulation(3, true);
+  for (const c of population) CreatureUtil.makeUUID(c);
+
+  // Runner returns an empty object so every expected UUID is missing — the
+  // reconciler throws and Fitness falls back to the per-creature worker path.
+  const failingRunner = (_command: string, args: string[]) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: "{}",
+      stderr: "",
+    });
+  };
+
+  await withBatchEnabled(failingRunner, async (fitness, worker) => {
+    await fitness.calculate(population);
+
+    assert(
+      fitness.lastBatchFallbackOccurred,
+      "a batch failure must be visible as a fallback, not masked",
+    );
+    assertEquals(fitness.lastCreaturesBatchScored, 0, "batch scored nothing");
+    assertEquals(
+      fitness.lastCreaturesPerCreatureScored,
+      3,
+      "every creature re-scored via the per-creature path",
+    );
+    assertEquals(fitness.lastBatchScorerInvocations, 0);
+    assertEquals(fitness.lastScoredCreatureCount, 3);
+    assertEquals(worker.evaluateCallCount, 3);
+  });
+});
+
+Deno.test("scorer utilisation - empty population resets the split counters", async () => {
+  const population = buildPopulation(2, true);
+  const uuids = population.map((c) => CreatureUtil.makeUUID(c));
+  await withBatchEnabled(successRunner(uuids), async (fitness) => {
+    await fitness.calculate(population);
+    assert(fitness.lastCreaturesBatchScored > 0, "primed with a real run");
+
+    // A pre-scored population takes the early-return reset path.
+    const alreadyScored = buildPopulation(1, true)[0];
+    alreadyScored.score = 0.5;
+    await fitness.calculate([alreadyScored]);
+
+    assertEquals(fitness.lastCreaturesBatchScored, 0);
+    assertEquals(fitness.lastCreaturesPerCreatureScored, 0);
+    assertEquals(fitness.lastBatchFallbackOccurred, false);
+  });
+});

--- a/test/creature/EvolveScorerUtilisation.ts
+++ b/test/creature/EvolveScorerUtilisation.ts
@@ -1,0 +1,86 @@
+/**
+ * Integration test: the evolve* functions return whole-run per-backend
+ * scorer-utilisation totals alongside `phaseTimingTotals` (Issue #3234).
+ *
+ * With the native batch rust scorer disabled (the default in this test
+ * environment) every creature is scored on the per-creature worker path, so
+ * the run-level totals must show all scoring under `creaturesPerCreatureScored`
+ * with zero batch invocations and zero fallback generations. The counts must
+ * also accumulate across generations — `generations` matches the number of
+ * `generation_complete` events.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type {
+  GenerationCompleteEvent,
+  TrainingEvent,
+} from "@config/TrainingEvent.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+Deno.test("evolveDataSet returns run-level scorerUtilisation", async () => {
+  await initWasmForTests();
+
+  const events: GenerationCompleteEvent[] = [];
+  const trainingSet = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+  ];
+
+  const creature = new Creature(2, 1);
+  const result = await creature.evolveDataSet(trainingSet, {
+    iterations: 5,
+    targetError: 0,
+    populationSize: 10,
+    threads: 1,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        events.push(event);
+      }
+    },
+  });
+
+  const util = result.scorerUtilisation;
+  assert(util !== undefined, "scorerUtilisation must be present");
+
+  // generations tracks the number of aggregated generations.
+  assert(events.length > 0, "should emit generation_complete events");
+  assertEquals(
+    util.generations,
+    events.length,
+    "generations must match the number of generation_complete events",
+  );
+
+  // Every count is a finite non-negative integer.
+  for (const [name, value] of Object.entries(util) as [string, number][]) {
+    assertEquals(typeof value, "number", `${name} must be a number`);
+    assert(Number.isFinite(value), `${name} must be finite`);
+    assert(value >= 0, `${name} must be non-negative, got ${value}`);
+    assertEquals(value, Math.trunc(value), `${name} must be an integer`);
+  }
+
+  // Batch scoring is disabled in this environment: everything is per-creature,
+  // no batch process was spawned, and no generation hit a fallback.
+  assertEquals(
+    util.batchScorerInvocations,
+    0,
+    "no batch scorer process without the native binary enabled",
+  );
+  assertEquals(
+    util.creaturesBatchScored,
+    0,
+    "no creatures batch-scored without batch mode",
+  );
+  assertEquals(
+    util.batchFallbackGenerations,
+    0,
+    "a healthy per-creature run has zero batch fallbacks",
+  );
+  // Real scoring happened across the run on the per-creature path.
+  assert(
+    util.creaturesPerCreatureScored > 0,
+    "creatures must be scored on the per-creature path",
+  );
+});

--- a/test/creature/ScorerUtilisationTotals_test.ts
+++ b/test/creature/ScorerUtilisationTotals_test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the whole-run per-backend scorer-utilisation aggregation used
+ * by the `evolve*` functions (Issue #3234).
+ *
+ * The aggregator sums the per-generation batch/worker split captured by
+ * `Fitness.calculate()` and counts the generations that hit a batch fallback,
+ * so a silent regression (batch path breaks but scoring still succeeds via
+ * workers) surfaces as a non-zero `batchFallbackGenerations` in a run that
+ * expects zero.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  accumulateScorerUtilisation,
+  createScorerUtilisationAccumulator,
+  finaliseScorerUtilisationTotals,
+  type ScorerUtilisationCounts,
+} from "@creature/ScorerUtilisationTotals.ts";
+
+/** Build a ScorerUtilisationCounts with zeroed defaults. */
+function counts(
+  overrides: Partial<ScorerUtilisationCounts> = {},
+): ScorerUtilisationCounts {
+  return {
+    batchScorerInvocations: 0,
+    creaturesBatchScored: 0,
+    creaturesPerCreatureScored: 0,
+    batchFallbackOccurred: false,
+    ...overrides,
+  };
+}
+
+Deno.test("ScorerUtilisationTotals: empty accumulator finalises to zeros", () => {
+  const acc = createScorerUtilisationAccumulator();
+  const totals = finaliseScorerUtilisationTotals(acc);
+  assertEquals(totals.generations, 0);
+  assertEquals(totals.batchScorerInvocations, 0);
+  assertEquals(totals.creaturesBatchScored, 0);
+  assertEquals(totals.creaturesPerCreatureScored, 0);
+  assertEquals(totals.batchFallbackGenerations, 0);
+});
+
+Deno.test("ScorerUtilisationTotals: all-batch run — invocations match generations, zero fallback", () => {
+  const acc = createScorerUtilisationAccumulator();
+  const generations = 5;
+  for (let g = 0; g < generations; g++) {
+    accumulateScorerUtilisation(
+      acc,
+      counts({ batchScorerInvocations: 1, creaturesBatchScored: 8 }),
+    );
+  }
+  const totals = finaliseScorerUtilisationTotals(acc);
+  assertEquals(totals.generations, generations);
+  // One scorer process per generation → invocations equal generation count.
+  assertEquals(totals.batchScorerInvocations, generations);
+  assertEquals(totals.creaturesBatchScored, 8 * generations);
+  assertEquals(totals.creaturesPerCreatureScored, 0);
+  assertEquals(totals.batchFallbackGenerations, 0);
+});
+
+Deno.test("ScorerUtilisationTotals: mixed population — recurrent creatures counted per-creature", () => {
+  const acc = createScorerUtilisationAccumulator();
+  // Each generation batches 6 forwardOnly creatures and worker-scores 4
+  // recurrent creatures.
+  accumulateScorerUtilisation(
+    acc,
+    counts({
+      batchScorerInvocations: 1,
+      creaturesBatchScored: 6,
+      creaturesPerCreatureScored: 4,
+    }),
+  );
+  accumulateScorerUtilisation(
+    acc,
+    counts({
+      batchScorerInvocations: 1,
+      creaturesBatchScored: 6,
+      creaturesPerCreatureScored: 4,
+    }),
+  );
+  const totals = finaliseScorerUtilisationTotals(acc);
+  assertEquals(totals.generations, 2);
+  assertEquals(totals.batchScorerInvocations, 2);
+  assertEquals(totals.creaturesBatchScored, 12);
+  assertEquals(totals.creaturesPerCreatureScored, 8);
+  assertEquals(totals.batchFallbackGenerations, 0);
+});
+
+Deno.test("ScorerUtilisationTotals: batch fallback counted, affected creatures per-creature", () => {
+  const acc = createScorerUtilisationAccumulator();
+  // Healthy generation: batch scored everything.
+  accumulateScorerUtilisation(
+    acc,
+    counts({ batchScorerInvocations: 1, creaturesBatchScored: 10 }),
+  );
+  // Fallback generation: batch attempt failed, all creatures re-scored by
+  // workers, no batch process recorded.
+  accumulateScorerUtilisation(
+    acc,
+    counts({
+      batchScorerInvocations: 0,
+      creaturesBatchScored: 0,
+      creaturesPerCreatureScored: 10,
+      batchFallbackOccurred: true,
+    }),
+  );
+  const totals = finaliseScorerUtilisationTotals(acc);
+  assertEquals(totals.generations, 2);
+  assertEquals(totals.batchScorerInvocations, 1);
+  assertEquals(totals.creaturesBatchScored, 10);
+  assertEquals(totals.creaturesPerCreatureScored, 10);
+  assert(
+    totals.batchFallbackGenerations > 0,
+    "a batch fallback must be visible, not masked",
+  );
+  assertEquals(totals.batchFallbackGenerations, 1);
+});


### PR DESCRIPTION
## Summary

Instrument `Fitness` with per-backend scorer-utilisation counts and expose them
on the `evolve*/train` result. Previously `Fitness.calculate()` tracked a single
`lastScoredCreatureCount` that spanned **both** the Rust native **batch
(one-pass)** path and the **per-creature worker** path, so a silent regression —
the batch path breaks and every creature quietly falls back to the slow worker
path — looked identical to a healthy run. This change splits that count by
backend and adds an explicit batch-fallback tally so the split is visible in the
run result (and therefore in the GRQ-cluster `result.json`). Telemetry only — no
change to scoring numbers or the batch/worker partition.

**Closes #3234.**

What changed:

- **`src/architecture/Fitness.ts`** — new per-generation counters
  `lastCreaturesBatchScored`, `lastCreaturesPerCreatureScored`, and
  `lastBatchFallbackOccurred`. The scored tally is split into `batchScoredCount`
  / `workerScoredCount`; `lastScoredCreatureCount` stays equal to their sum for
  existing throughput consumers. The batch `catch` block now sets the fallback
  flag so a partial/whole fallback is never masked. All new counters are reset
  in the early-return path alongside the existing resets.
- **`src/creature/ScorerUtilisationTotals.ts`** (new) —
  `ScorerUtilisationTotals` type + accumulator
  (`create`/`accumulate`/`finalise`), mirroring `PhaseTimingTotals`.
- **`src/creature/CreatureTraining.ts`** — accumulate the per-generation counts
  across the run and finalise a `scorerUtilisation` field on the result of
  `evolveDir`, `evolveEnv`, `evolveRL` (and `evolveDataSet`, which delegates to
  `evolveDir`). Return types updated.
- **`src/Creature.ts`** — `scorerUtilisation` added to the four wrapper return
  types.
- **`src/creature/EpisodicFitness.ts` / `RLEpisodeFitness.ts`** — reset the new
  counters and report every scored creature under `creaturesPerCreatureScored`
  (these paths never use the native batch scorer).
- **`src/NEAT/NeatEvolution.ts`** — per-generation split emitted on the verbose
  `[Throughput]` log line (`batchScored…/perCreatureScored…/batchFallback…`).
- **`docs/event-driven-evolution.md`** — new "Run-level scorer-utilisation
  totals" section with a Mermaid backend-split diagram.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via new and
existing unit/integration tests (`deno test`) and the repo type gate
(`./quality.sh --check-only`, `--lint-only`).

```mermaid
flowchart TD
    Q[Unique creatures this generation] --> P{forwardOnly?}
    P -->|yes| B[Batch rust scorer<br/>one process per generation]
    P -->|no| W[Per-creature worker path]
    B -->|success| BS[creaturesBatchScored++]
    B -->|failure| F[batchFallbackGenerations++<br/>revert to worker path]
    F --> W
    W --> WS[creaturesPerCreatureScored++]
```

Selected results:

- `test/architecture/FitnessScorerUtilisation.ts` — 4 passed
- `test/creature/ScorerUtilisationTotals_test.ts` — 4 passed
- `test/creature/EvolveScorerUtilisation.ts` — 1 passed
- `deno test test/architecture/*.ts test/score/*.ts` — 629 passed, 0 failed
  (regression guard on scoring behaviour)
- `deno test test/creature/*.ts` — 62 passed, 0 failed (episodic/RL paths)
- `./quality.sh --check-only` and `--lint-only` — clean

## Test Plan

New tests added:

- **`test/creature/ScorerUtilisationTotals_test.ts`** — accumulator unit tests:
  empty finalises to zeros; an all-batch run yields
  `batchScorerInvocations ≈ generations` with zero fallback; a mixed population
  counts recurrent creatures under `creaturesPerCreatureScored`; a fallback
  generation increments `batchFallbackGenerations` and counts its creatures
  per-creature.
- **`test/architecture/FitnessScorerUtilisation.ts`** — `Fitness.calculate()`
  split tests against a stubbed rust scorer: (a) all-forwardOnly →
  `creaturesBatchScored === N`, zero fallback; (b) mixed → recurrent creatures
  counted per-creature; (c) forced batch failure (stubbed to return no keys) →
  `lastBatchFallbackOccurred === true`, `creaturesBatchScored === 0`, affected
  creatures counted per-creature; plus an empty-population reset check.
- **`test/creature/EvolveScorerUtilisation.ts`** — `evolveDataSet` returns a
  populated `scorerUtilisation` whose `generations` matches the
  `generation_complete` event count, with per-creature scoring accumulated
  across generations and zero batch invocations/fallbacks in the WASM-only
  environment.

A silent-fallback regression (batch path breaks but scoring still succeeds via
workers) is caught by tests (b)/(c) and by the runtime `[Throughput]` log line.



## Milestone
This PR is part of the **#3233 Flag Rust scorer utilisation in results; verify one-pass batch scoring** milestone and targets the `milestone/3233-flag-rust-scorer-utilisation-in-results-verif` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr9dzph7-9e587c`<!-- vibe-worker-issue-3234 -->