### PR TITLE
Assert forwardOnly population uses the Rust batch path (fallback counted, not silent)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3237.md
+++ b/docs/archive/pr-summaries/pr-summary-3237.md
@@ -1,0 +1,66 @@
+# Assert forwardOnly population uses the Rust batch path (and fallback is counted)
+
+## Summary
+
+Adds two **permanent automated assertions** that a `forwardOnly` population is
+scored via the Rust **batch** path — one `rust_scorer` invocation per generation
+— and that a batch failure is surfaced as a measurable **fallback**, never
+silently swallowed. Both tests drive `Fitness.calculate()` across several
+generations and accumulate each generation's per-backend counts into the
+run-level `ScorerUtilisationTotals` (the same telemetry surfaced on the
+`evolve*` result and in the GRQ-cluster `result.json`), then assert on the
+aggregate. Closes #3237.
+
+The per-backend instrumentation this issue depends on
+(`Fitness.lastBatchScorerInvocations` / `lastCreaturesBatchScored` /
+`lastCreaturesPerCreatureScored` / `lastBatchFallbackOccurred` and the
+`ScorerUtilisationTotals` accumulator) already landed via the sibling
+instrumentation sub-issue, so this change is **test-only** — it locks that
+signal behind a regression gate that fails the PR before merge if the batch path
+silently stops being used or a fallback stops being recorded.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified by test execution
+and by a negative-control check (temporarily routing `forwardOnly` creatures
+onto the worker path made `FitnessBatchPathUsed.ts` fail as intended, confirming
+it is a genuine regression detector, then the source was restored).
+
+```mermaid
+flowchart TD
+    Pop[forwardOnly population] --> Calc[Fitness.calculate per generation]
+    Calc --> Part{forwardOnly?}
+    Part -- yes --> Batch[tryBatchScoreWithRustScorer<br/>1 rust_scorer invocation/gen]
+    Part -- no --> Worker[per-creature worker path]
+    Batch -- success --> CB[creaturesBatchScored++]
+    Batch -- failure --> FB[batchFallbackOccurred = true<br/>revert whole batch to worker path]
+    FB --> Worker
+    Worker --> CP[creaturesPerCreatureScored++]
+    CB --> Acc[ScorerUtilisationTotals accumulator]
+    CP --> Acc
+    FB --> Acc
+    Acc --> Assert[Tests assert:<br/>batchScorerInvocations ≈ generations<br/>creaturesBatchScored == forwardOnly creatures<br/>batchFallbackGenerations counted, not silent]
+```
+
+## Test Plan
+
+- **`test/architecture/FitnessBatchPathUsed.ts`** — all-`forwardOnly` population
+  over 4 generations with the batch scorer enabled (mock success runner).
+  Asserts `batchScorerInvocations` == generations, `creaturesBatchScored` ==
+  forwardOnly creatures × generations, `creaturesPerCreatureScored` == 0, the
+  worker path was never called, and `batchFallbackGenerations` == 0 — i.e. the
+  batch path was used, not the per-creature worker path.
+- **`test/architecture/FitnessBatchFallbackCounted.ts`** — all-`forwardOnly`
+  population over 3 generations with a runner that forces a `BatchScorerError`
+  (missing keys). Asserts `batchFallbackGenerations` > 0 (== generations), the
+  affected creatures are counted as per-creature-scored, nothing is
+  batch-scored, and every creature still ends each generation with a valid,
+  finite score — the fallback is graceful and counted, never masked as success.
+- `deno fmt`, `deno lint`, and `deno check` pass on both new files.
+- Full `./quality.sh --skip-discovery --skip-wasm` run: **7458 passed**
+  (includes both new tests). One unrelated, pre-existing failure —
+  `test/ErrorGuidedStructuralEvolution/NeuronDiscoveryIntegration.ts`
+  (`Unhandled variant: setBias` from the Rust discovery FFI mapper) — reproduces
+  on the clean milestone tree **without** these new files, so it is an
+  environmental discovery-library/TS version mismatch (discovery build was
+  skipped), not a regression from this change.

--- a/test/architecture/FitnessBatchFallbackCounted.ts
+++ b/test/architecture/FitnessBatchFallbackCounted.ts
@@ -1,0 +1,204 @@
+/**
+ * Permanent assertion: a batch-scorer failure is **counted** as a fallback, not
+ * silently swallowed (Issue #3237, parent #3233).
+ *
+ * When `tryBatchScoreWithRustScorer` fails for a `forwardOnly` population,
+ * `Fitness.calculate()` reverts the whole generation to the per-creature worker
+ * path so the generation still completes — but it must record that it did so.
+ * This test forces a batch failure (the runner returns an empty result map, so
+ * every expected UUID is missing and the reconciler throws
+ * `BatchScorerError`) across several generations and accumulates the per-backend
+ * counts into the run-level {@link ScorerUtilisationTotals}.
+ *
+ * It fails if a fallback stops being recorded: `batchFallbackGenerations` would
+ * read zero even though the batch path never scored anything and every creature
+ * quietly re-scored on the slow worker path — exactly the "never fail silently"
+ * regression this telemetry exists to expose.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { Fitness } from "@architecture/Fitness.ts";
+import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import {
+  accumulateScorerUtilisation,
+  createScorerUtilisationAccumulator,
+  finaliseScorerUtilisationTotals,
+} from "@creature/ScorerUtilisationTotals.ts";
+import {
+  __resetRustScorerBridgeForTests,
+  __setRustScorerRunnerForTests,
+} from "../../src/score/RustScorerBridge.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/** Records how many times the per-creature worker path was exercised. */
+class MockWorkerHandler {
+  public evaluateCallCount = 0;
+  addIdleListener(_callback: () => void): void {}
+  isBusy(): boolean {
+    return false;
+  }
+  // deno-lint-ignore require-await
+  async evaluate(
+    _creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<{ evaluate: { error: number } }> {
+    this.evaluateCallCount++;
+    return { evaluate: { error: 0.5 } };
+  }
+}
+
+function buildDataSet(): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < 4; i++) {
+    rows.push({
+      input: new Float32Array([i, 4 - i]),
+      output: new Float32Array([i > 2 ? 1 : -1]),
+    });
+  }
+  return rows;
+}
+
+/** Build `count` distinct forwardOnly creatures. */
+function buildForwardOnlyPopulation(count: number): Creature[] {
+  const base: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "TANH", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+  };
+  const creatures: Creature[] = [];
+  for (let i = 0; i < count; i++) {
+    const forked = structuredClone(base);
+    forked.neurons[0].bias = 0.1 * (i + 1);
+    creatures.push(Creature.fromJSON(forked));
+  }
+  return creatures;
+}
+
+/**
+ * A runner that responds to the `--help` probe but returns an empty result map
+ * for the batch call, so every expected UUID is missing and the reconciler
+ * throws `BatchScorerError` — forcing the per-creature fallback.
+ */
+function failingRunner(_command: string, args: string[]) {
+  if (args.length === 1 && args[0] === "--help") {
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: "usage",
+      stderr: "",
+    });
+  }
+  return Promise.resolve({
+    success: true,
+    code: 0,
+    stdout: "{}",
+    stderr: "",
+  });
+}
+
+Deno.test("batch failure is counted as a fallback and re-scored per-creature every generation", async () => {
+  const GENERATIONS = 3;
+  const POPULATION_SIZE = 4;
+
+  __resetRustScorerBridgeForTests();
+  const prevEnabled = Deno.env.get("NEAT_AI_RUST_SCORER_ENABLED");
+  const prevBatch = Deno.env.get("NEAT_AI_RUST_SCORER_BATCH");
+  Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", "true");
+  Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", "true");
+
+  const population = buildForwardOnlyPopulation(POPULATION_SIZE);
+  for (const c of population) CreatureUtil.makeUUID(c);
+  __setRustScorerRunnerForTests(failingRunner);
+
+  const worker = new MockWorkerHandler();
+  const dataDir = makeDataDir(buildDataSet(), 4);
+  try {
+    const fitness = new Fitness(
+      [worker as unknown as WorkerHandler],
+      0.0001,
+      false,
+      undefined,
+      dataDir,
+    );
+
+    const acc = createScorerUtilisationAccumulator();
+    for (let gen = 0; gen < GENERATIONS; gen++) {
+      // Reset scores so every generation re-evaluates the whole population.
+      for (const creature of population) creature.score = undefined;
+
+      // Sequential by design: each generation reads Fitness state before the
+      // next, so the calls cannot be batched into a single Promise.all.
+      // deno-lint-ignore no-await-in-loop
+      await fitness.calculate(population);
+
+      accumulateScorerUtilisation(acc, {
+        batchScorerInvocations: fitness.lastBatchScorerInvocations,
+        creaturesBatchScored: fitness.lastCreaturesBatchScored,
+        creaturesPerCreatureScored: fitness.lastCreaturesPerCreatureScored,
+        batchFallbackOccurred: fitness.lastBatchFallbackOccurred,
+      });
+
+      // The generation still completes with valid, finite scores despite the
+      // batch failure — the fallback is graceful, not lost.
+      for (const creature of population) {
+        assert(
+          typeof creature.score === "number" && Number.isFinite(creature.score),
+          "creature scored with a finite value via the fallback path",
+        );
+      }
+    }
+
+    const totals = finaliseScorerUtilisationTotals(acc);
+
+    assertEquals(totals.generations, GENERATIONS);
+    // Every generation's batch attempt failed and was counted — not swallowed.
+    assert(
+      totals.batchFallbackGenerations > 0,
+      "a batch failure must be recorded as a fallback, never masked as success",
+    );
+    assertEquals(
+      totals.batchFallbackGenerations,
+      GENERATIONS,
+      "every generation's batch failure is counted",
+    );
+    // Nothing was batch-scored; the affected creatures counted as per-creature.
+    assertEquals(totals.creaturesBatchScored, 0, "batch scored nothing");
+    assertEquals(
+      totals.creaturesPerCreatureScored,
+      POPULATION_SIZE * GENERATIONS,
+      "fallback creatures counted as per-creature-scored",
+    );
+    assertEquals(
+      worker.evaluateCallCount,
+      POPULATION_SIZE * GENERATIONS,
+      "every creature re-scored on the per-creature worker path",
+    );
+  } finally {
+    if (prevEnabled === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_ENABLED");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", prevEnabled);
+    }
+    if (prevBatch === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_BATCH");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", prevBatch);
+    }
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});

--- a/test/architecture/FitnessBatchPathUsed.ts
+++ b/test/architecture/FitnessBatchPathUsed.ts
@@ -1,0 +1,212 @@
+/**
+ * Permanent assertion: a `forwardOnly` population is scored via the Rust
+ * **batch** path — one `rust_scorer` invocation per generation — not the slow
+ * per-creature worker path (Issue #3237, parent #3233).
+ *
+ * `Fitness.calculate()` partitions each generation: `forwardOnly` creatures go
+ * through `tryBatchScoreWithRustScorer` (one process per generation) while
+ * recurrent creatures take the per-creature worker path. This test drives an
+ * all-`forwardOnly` population through several generations, accumulating each
+ * generation's per-backend counts into the run-level
+ * {@link ScorerUtilisationTotals} — the exact telemetry surfaced on the
+ * `evolve*` result and in the GRQ-cluster `result.json`.
+ *
+ * It fails if the batch path silently stops being used (regression to
+ * per-creature scoring): `batchScorerInvocations` would drop below the
+ * generation count and `creaturesBatchScored` would fall to zero while
+ * `creaturesPerCreatureScored` absorbed the load.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { Fitness } from "@architecture/Fitness.ts";
+import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import {
+  accumulateScorerUtilisation,
+  createScorerUtilisationAccumulator,
+  finaliseScorerUtilisationTotals,
+} from "@creature/ScorerUtilisationTotals.ts";
+import {
+  __resetRustScorerBridgeForTests,
+  __setRustScorerRunnerForTests,
+} from "../../src/score/RustScorerBridge.ts";
+
+((globalThis as unknown) as { DEBUG: boolean }).DEBUG = true;
+
+/** Records how many times the per-creature worker path was exercised. */
+class MockWorkerHandler {
+  public evaluateCallCount = 0;
+  addIdleListener(_callback: () => void): void {}
+  isBusy(): boolean {
+    return false;
+  }
+  // deno-lint-ignore require-await
+  async evaluate(
+    _creature: Creature,
+    _feedbackLoop: boolean,
+  ): Promise<{ evaluate: { error: number } }> {
+    this.evaluateCallCount++;
+    return { evaluate: { error: 0.5 } };
+  }
+}
+
+function buildDataSet(): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < 4; i++) {
+    rows.push({
+      input: new Float32Array([i, 4 - i]),
+      output: new Float32Array([i > 2 ? 1 : -1]),
+    });
+  }
+  return rows;
+}
+
+/** Build `count` distinct forwardOnly creatures. */
+function buildForwardOnlyPopulation(count: number): Creature[] {
+  const base: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "TANH", bias: 0.5 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.8 },
+    ],
+    input: 2,
+    output: 1,
+    forwardOnly: true,
+  };
+  const creatures: Creature[] = [];
+  for (let i = 0; i < count; i++) {
+    const forked = structuredClone(base);
+    forked.neurons[0].bias = 0.1 * (i + 1);
+    creatures.push(Creature.fromJSON(forked));
+  }
+  return creatures;
+}
+
+/** A runner that scores every supplied UUID successfully in one pass. */
+function successRunner(uuids: string[]) {
+  return (_command: string, args: string[]) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    const payload: Record<
+      string,
+      { score: number; error: number; recordCount: number }
+    > = {};
+    for (let i = 0; i < uuids.length; i++) {
+      payload[uuids[i]] = {
+        score: 0.9 - i * 0.1,
+        error: 0.1 + i * 0.05,
+        recordCount: 4,
+      };
+    }
+    return Promise.resolve({
+      success: true,
+      code: 0,
+      stdout: JSON.stringify(payload),
+      stderr: "",
+    });
+  };
+}
+
+Deno.test("forwardOnly population is batch-scored every generation, never per-creature", async () => {
+  const GENERATIONS = 4;
+  const POPULATION_SIZE = 5;
+
+  __resetRustScorerBridgeForTests();
+  const prevEnabled = Deno.env.get("NEAT_AI_RUST_SCORER_ENABLED");
+  const prevBatch = Deno.env.get("NEAT_AI_RUST_SCORER_BATCH");
+  Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", "true");
+  Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", "true");
+
+  const population = buildForwardOnlyPopulation(POPULATION_SIZE);
+  const uuids = population.map((c) => CreatureUtil.makeUUID(c));
+  __setRustScorerRunnerForTests(successRunner(uuids));
+
+  const worker = new MockWorkerHandler();
+  const dataDir = makeDataDir(buildDataSet(), 4);
+  try {
+    const fitness = new Fitness(
+      [worker as unknown as WorkerHandler],
+      0.0001,
+      false,
+      undefined,
+      dataDir,
+    );
+
+    const acc = createScorerUtilisationAccumulator();
+    for (let gen = 0; gen < GENERATIONS; gen++) {
+      // Reset scores so every generation re-evaluates the whole population.
+      for (const creature of population) creature.score = undefined;
+
+      // Sequential by design: each generation reads Fitness state before the
+      // next, so the calls cannot be batched into a single Promise.all.
+      // deno-lint-ignore no-await-in-loop
+      await fitness.calculate(population);
+
+      accumulateScorerUtilisation(acc, {
+        batchScorerInvocations: fitness.lastBatchScorerInvocations,
+        creaturesBatchScored: fitness.lastCreaturesBatchScored,
+        creaturesPerCreatureScored: fitness.lastCreaturesPerCreatureScored,
+        batchFallbackOccurred: fitness.lastBatchFallbackOccurred,
+      });
+
+      // Every creature still ends the generation with a valid, finite score.
+      for (const creature of population) {
+        assert(
+          typeof creature.score === "number" && Number.isFinite(creature.score),
+          "creature scored with a finite value",
+        );
+      }
+    }
+
+    const totals = finaliseScorerUtilisationTotals(acc);
+
+    assertEquals(totals.generations, GENERATIONS);
+    // One rust_scorer process per generation — the batch path was used.
+    assertEquals(
+      totals.batchScorerInvocations,
+      GENERATIONS,
+      "batchScorerInvocations must equal the generation count",
+    );
+    // Every forwardOnly creature, every generation, went through the batch path.
+    assertEquals(
+      totals.creaturesBatchScored,
+      POPULATION_SIZE * GENERATIONS,
+      "creaturesBatchScored must equal the forwardOnly creatures scored",
+    );
+    // The per-creature worker path was never used for a forwardOnly population.
+    assertEquals(totals.creaturesPerCreatureScored, 0);
+    assertEquals(
+      worker.evaluateCallCount,
+      0,
+      "no forwardOnly creature reached the per-creature worker path",
+    );
+    // No fallback: the batch path succeeded every generation.
+    assertEquals(totals.batchFallbackGenerations, 0);
+  } finally {
+    if (prevEnabled === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_ENABLED");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_ENABLED", prevEnabled);
+    }
+    if (prevBatch === undefined) {
+      Deno.env.delete("NEAT_AI_RUST_SCORER_BATCH");
+    } else {
+      Deno.env.set("NEAT_AI_RUST_SCORER_BATCH", prevBatch);
+    }
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});


### PR DESCRIPTION
# Assert forwardOnly population uses the Rust batch path (and fallback is counted)

## Summary

Adds two **permanent automated assertions** that a `forwardOnly` population is
scored via the Rust **batch** path — one `rust_scorer` invocation per generation
— and that a batch failure is surfaced as a measurable **fallback**, never
silently swallowed. Both tests drive `Fitness.calculate()` across several
generations and accumulate each generation's per-backend counts into the
run-level `ScorerUtilisationTotals` (the same telemetry surfaced on the
`evolve*` result and in the GRQ-cluster `result.json`), then assert on the
aggregate. Closes #3237.

The per-backend instrumentation this issue depends on
(`Fitness.lastBatchScorerInvocations` / `lastCreaturesBatchScored` /
`lastCreaturesPerCreatureScored` / `lastBatchFallbackOccurred` and the
`ScorerUtilisationTotals` accumulator) already landed via the sibling
instrumentation sub-issue, so this change is **test-only** — it locks that
signal behind a regression gate that fails the PR before merge if the batch path
silently stops being used or a fallback stops being recorded.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified by test execution
and by a negative-control check (temporarily routing `forwardOnly` creatures
onto the worker path made `FitnessBatchPathUsed.ts` fail as intended, confirming
it is a genuine regression detector, then the source was restored).

```mermaid
flowchart TD
    Pop[forwardOnly population] --> Calc[Fitness.calculate per generation]
    Calc --> Part{forwardOnly?}
    Part -- yes --> Batch[tryBatchScoreWithRustScorer<br/>1 rust_scorer invocation/gen]
    Part -- no --> Worker[per-creature worker path]
    Batch -- success --> CB[creaturesBatchScored++]
    Batch -- failure --> FB[batchFallbackOccurred = true<br/>revert whole batch to worker path]
    FB --> Worker
    Worker --> CP[creaturesPerCreatureScored++]
    CB --> Acc[ScorerUtilisationTotals accumulator]
    CP --> Acc
    FB --> Acc
    Acc --> Assert[Tests assert:<br/>batchScorerInvocations ≈ generations<br/>creaturesBatchScored == forwardOnly creatures<br/>batchFallbackGenerations counted, not silent]
```

## Test Plan

- **`test/architecture/FitnessBatchPathUsed.ts`** — all-`forwardOnly` population
  over 4 generations with the batch scorer enabled (mock success runner).
  Asserts `batchScorerInvocations` == generations, `creaturesBatchScored` ==
  forwardOnly creatures × generations, `creaturesPerCreatureScored` == 0, the
  worker path was never called, and `batchFallbackGenerations` == 0 — i.e. the
  batch path was used, not the per-creature worker path.
- **`test/architecture/FitnessBatchFallbackCounted.ts`** — all-`forwardOnly`
  population over 3 generations with a runner that forces a `BatchScorerError`
  (missing keys). Asserts `batchFallbackGenerations` > 0 (== generations), the
  affected creatures are counted as per-creature-scored, nothing is
  batch-scored, and every creature still ends each generation with a valid,
  finite score — the fallback is graceful and counted, never masked as success.
- `deno fmt`, `deno lint`, and `deno check` pass on both new files.
- Full `./quality.sh --skip-discovery --skip-wasm` run: **7458 passed**
  (includes both new tests). One unrelated, pre-existing failure —
  `test/ErrorGuidedStructuralEvolution/NeuronDiscoveryIntegration.ts`
  (`Unhandled variant: setBias` from the Rust discovery FFI mapper) — reproduces
  on the clean milestone tree **without** these new files, so it is an
  environmental discovery-library/TS version mismatch (discovery build was
  skipped), not a regression from this change.



## Milestone
This PR is part of the **#3233 Flag Rust scorer utilisation in results; verify one-pass batch scoring** milestone and targets the `milestone/3233-flag-rust-scorer-utilisation-in-results-verif` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr9ffkn9-24030a`<!-- vibe-worker-issue-3237 -->