### PR TITLE
Stop synthesising Deno remove-neuron gain; consume Discovery estimate (NEAT-AI-Discovery#1520)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.15",
+  "version": "5.7.16",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-1520.md
+++ b/docs/archive/pr-summaries/pr-summary-1520.md
@@ -1,0 +1,89 @@
+# Stop the Deno placeholder remove-neuron gain in `DiscoverSquashAnalysis.ts`
+
+## Summary
+
+The over-threshold ("harmful") remove-neuron gain in
+`src/architecture/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts` was
+**fabricated** on the Deno side by the Issue #2483 sink:
+
+```
+expectedCreatureScoreGain = min(0.5, max(0.1, 0.1 + (excessMagnitude / 10) * 0.4))
+```
+
+where `excessMagnitude = log10(err) − log10(1e10)`. That formula ignored network
+topology — it turned a large squash error into a large *positive* gain
+regardless of how many layers separated the neuron from the output(s). For the
+recorded `neuron-1802938338` failure it claimed `+0.17882921` while the measured
+effect was `−0.000194` (~920× too large and opposite in sign).
+
+Estimation authority has moved to the propagation-aware **NEAT-AI-Discovery
+(Rust)** estimator `estimate_remove_neuron_gain`
+(stSoftwareAU/NEAT-AI-Discovery#1518, cross-repo per
+stSoftwareAU/NEAT-AI-Discovery#2942). This change makes the Deno side **stop
+synthesising the gain** and instead **consume an injected Discovery estimate**:
+
+- Both remove-neuron sinks (`findCandidateSquash` and
+  `analyzeSelectedNeuronsForHarmfulRemoval`) now take an optional
+  `RemoveNeuronGainEstimator` and surface its value verbatim.
+- When no estimate is injected, the emitted gain is a **non-fabricated neutral
+  `0`** — never the old placeholder. The `DiscoverSquashAnalysis` benchmark
+  surfaces a zero gain as the cross-repo sequencing signal (per #1516) that the
+  Discovery estimate is not yet wired.
+- The Issue #2483 WASM-hygiene behaviour is **preserved**: over-threshold
+  neurons are still promoted for removal (removal is gated on error magnitude,
+  not gain). Only the *gain value* stopped being synthesised.
+
+The estimator seam is threaded through the callers
+`DiscoverStructureAnalysis.analyzeSelectedNeuronsSquashes` and
+`analyzeSelectedNeuronsForHarmfulRemoval`, so a Discovery estimate can be
+injected without further signature churn.
+
+> The stale line reference `:261` in the issue is the squash-**change**
+> `conservativeScale` (`sampleCount / 40000`), not a remove-neuron gain — it
+> feeds `CandidateSquash`, not `CandidateHarmfulNeuron`, so it is deliberately
+> left untouched. The two genuine remove-neuron placeholder sinks (`:196`,
+> `:479` in the issue) are the ones removed.
+
+Closes stSoftwareAU/NEAT-AI-Discovery#1520
+
+## Data flow
+
+```mermaid
+flowchart LR
+    A[Over-threshold neuron<br/>err &gt; 1e10] --> B{DiscoverSquashAnalysis}
+    B -->|#2483 hygiene: still removal-eligible| C[CandidateHarmfulNeuron]
+    B -->|gain value| D{RemoveNeuronGainEstimator<br/>injected?}
+    D -->|yes| E[Discovery estimate<br/>propagation-aware, ≤ 0]
+    D -->|no| F[Neutral 0<br/>bench sequencing signal]
+    E --> C
+    F --> C
+```
+
+## Evidence
+
+Backend/CLI change — no web interface. Verified via `deno test` on the
+`DiscoverSquashAnalysis` suite (14 passed, incl. 4 new), project-wide
+`deno lint` (1789 files) and `deno check` (`quality.sh --check-only`), all green.
+
+Regression proof: the new assertions require the gain to equal the injected
+estimate (or `0`), which the old placeholder path (returning `0.5` for these
+inputs) would fail.
+
+## Test Plan
+
+Added to `test/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts`:
+
+- `DiscoverSquashAnalysis - remove-neuron gain is not synthesised locally (findCandidateSquash)` —
+  injects a Discovery estimate, asserts the harmful-sink gain equals it and does
+  **not** match the placeholder formula.
+- `DiscoverSquashAnalysis - remove-neuron gain defaults to non-fabricated zero (findCandidateSquash)` —
+  no estimator → gain `0`, still `!= placeholder`, neuron still promoted for
+  removal.
+- `DiscoverSquashAnalysis - remove-neuron gain is consumed from Discovery (analyzeSelectedNeuronsForHarmfulRemoval)` —
+  injected estimate consumed verbatim.
+- `DiscoverSquashAnalysis - harmful removal emits non-fabricated zero without an estimate` —
+  default-path guard.
+
+Existing `calculateSquashError*` and
+`analyzeSelectedNeuronsForHarmfulRemoval loads records via wire uuid path` cases
+continue to pass, guarding the preserved #2483 identification behaviour.

--- a/docs/archive/pr-summaries/pr-summary-1520.md
+++ b/docs/archive/pr-summaries/pr-summary-1520.md
@@ -11,7 +11,7 @@ expectedCreatureScoreGain = min(0.5, max(0.1, 0.1 + (excessMagnitude / 10) * 0.4
 ```
 
 where `excessMagnitude = log10(err) − log10(1e10)`. That formula ignored network
-topology — it turned a large squash error into a large *positive* gain
+topology — it turned a large squash error into a large _positive_ gain
 regardless of how many layers separated the neuron from the output(s). For the
 recorded `neuron-1802938338` failure it claimed `+0.17882921` while the measured
 effect was `−0.000194` (~920× too large and opposite in sign).
@@ -31,7 +31,7 @@ synthesising the gain** and instead **consume an injected Discovery estimate**:
   Discovery estimate is not yet wired.
 - The Issue #2483 WASM-hygiene behaviour is **preserved**: over-threshold
   neurons are still promoted for removal (removal is gated on error magnitude,
-  not gain). Only the *gain value* stopped being synthesised.
+  not gain). Only the _gain value_ stopped being synthesised.
 
 The estimator seam is threaded through the callers
 `DiscoverStructureAnalysis.analyzeSelectedNeuronsSquashes` and
@@ -63,7 +63,8 @@ flowchart LR
 
 Backend/CLI change — no web interface. Verified via `deno test` on the
 `DiscoverSquashAnalysis` suite (14 passed, incl. 4 new), project-wide
-`deno lint` (1789 files) and `deno check` (`quality.sh --check-only`), all green.
+`deno lint` (1789 files) and `deno check` (`quality.sh --check-only`), all
+green.
 
 Regression proof: the new assertions require the gain to equal the injected
 estimate (or `0`), which the old placeholder path (returning `0.5` for these
@@ -73,16 +74,16 @@ inputs) would fail.
 
 Added to `test/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts`:
 
-- `DiscoverSquashAnalysis - remove-neuron gain is not synthesised locally (findCandidateSquash)` —
-  injects a Discovery estimate, asserts the harmful-sink gain equals it and does
-  **not** match the placeholder formula.
-- `DiscoverSquashAnalysis - remove-neuron gain defaults to non-fabricated zero (findCandidateSquash)` —
-  no estimator → gain `0`, still `!= placeholder`, neuron still promoted for
+- `DiscoverSquashAnalysis - remove-neuron gain is not synthesised locally (findCandidateSquash)`
+  — injects a Discovery estimate, asserts the harmful-sink gain equals it and
+  does **not** match the placeholder formula.
+- `DiscoverSquashAnalysis - remove-neuron gain defaults to non-fabricated zero (findCandidateSquash)`
+  — no estimator → gain `0`, still `!= placeholder`, neuron still promoted for
   removal.
-- `DiscoverSquashAnalysis - remove-neuron gain is consumed from Discovery (analyzeSelectedNeuronsForHarmfulRemoval)` —
-  injected estimate consumed verbatim.
-- `DiscoverSquashAnalysis - harmful removal emits non-fabricated zero without an estimate` —
-  default-path guard.
+- `DiscoverSquashAnalysis - remove-neuron gain is consumed from Discovery (analyzeSelectedNeuronsForHarmfulRemoval)`
+  — injected estimate consumed verbatim.
+- `DiscoverSquashAnalysis - harmful removal emits non-fabricated zero without an estimate`
+  — default-path guard.
 
 Existing `calculateSquashError*` and
 `analyzeSelectedNeuronsForHarmfulRemoval loads records via wire uuid path` cases

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts
@@ -20,6 +20,42 @@ import type {
 import { buildRuntimeIdToWireMap } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
 
 /**
+ * Injected propagation-aware remove-neuron gain estimator (Issue #1520).
+ *
+ * Estimation authority for the remove-neuron gain has moved to the
+ * NEAT-AI-Discovery (Rust) `estimate_remove_neuron_gain` estimator
+ * (NEAT-AI-Discovery #1518, cross-repo per NEAT-AI-Discovery #2942). The Deno
+ * squash analyser no longer synthesises the gain locally — it consumes this
+ * injected estimate instead. Implementations return the honest,
+ * propagation-aware gain for removing `neuronUuid` (typically `<= 0`), or
+ * `undefined` when no estimate is available.
+ */
+export type RemoveNeuronGainEstimator = (
+  neuronUuid: string,
+) => number | undefined;
+
+/**
+ * Resolve the remove-neuron gain for an over-threshold ("harmful") neuron.
+ *
+ * Issue #1520: the previous `0.1 + (log10(err) − 10)/10 × 0.4` placeholder
+ * (clamped to `[0.1, 0.5]`) is gone. When a Discovery estimate is injected we
+ * surface it verbatim; otherwise we emit a non-fabricated neutral `0`. A zero
+ * gain keeps the neuron removal-eligible (removal is gated on error magnitude,
+ * not gain) while the `DiscoverSquashAnalysis` benchmark surfaces the zero as
+ * the cross-repo sequencing signal that the Discovery estimate is not yet wired
+ * (NEAT-AI-Discovery #1516).
+ */
+function resolveRemoveNeuronGain(
+  neuronUuid: string,
+  estimateRemoveNeuronGain?: RemoveNeuronGainEstimator,
+): number {
+  const estimate = estimateRemoveNeuronGain?.(neuronUuid);
+  return typeof estimate === "number" && Number.isFinite(estimate)
+    ? estimate
+    : 0;
+}
+
+/**
  * Calculates MSE between ideal and actual activations.
  *
  * Issue #3092: The previous implementation routed every sample through a
@@ -110,6 +146,13 @@ export function findCandidateSquash(
    * "this neuron should be removed".
    */
   harmfulSink?: CandidateHarmfulNeuron[],
+  /**
+   * Issue #1520: injected Discovery estimator supplying the honest,
+   * propagation-aware remove-neuron gain for an over-threshold neuron. When
+   * omitted, the emitted gain is a non-fabricated neutral `0` rather than the
+   * old synthetic placeholder formula.
+   */
+  estimateRemoveNeuronGain?: RemoveNeuronGainEstimator,
 ): CandidateSquash | undefined {
   const idToWire = buildRuntimeIdToWireMap(creature);
   const rawValues: number[] = [];
@@ -188,12 +231,13 @@ export function findCandidateSquash(
       const averageActivation = activationCount > 0
         ? activationSum / activationCount
         : 0;
-      const errorLog = Math.log10(baselineError);
-      const thresholdLog = Math.log10(MAX_REASONABLE_SQUASH_ERROR);
-      const excessMagnitude = errorLog - thresholdLog;
-      const expectedCreatureScoreGain = Math.min(
-        0.5,
-        Math.max(0.1, 0.1 + (excessMagnitude / 10) * 0.4),
+      // Issue #1520: delegate the remove-neuron gain to the injected Discovery
+      // estimator instead of synthesising it from the error magnitude. The
+      // over-threshold neuron is still promoted for removal (#2483 WASM
+      // hygiene) — only the fabricated gain value is gone.
+      const expectedCreatureScoreGain = resolveRemoveNeuronGain(
+        neuronUuid,
+        estimateRemoveNeuronGain,
       );
       harmfulSink.push({
         neuronUuid,
@@ -400,6 +444,12 @@ export async function analyzeSelectedNeuronsForHarmfulRemoval(
     message: string,
     details?: unknown,
   ) => void,
+  /**
+   * Issue #1520: injected Discovery estimator supplying the honest,
+   * propagation-aware remove-neuron gain. When omitted, the emitted gain is a
+   * non-fabricated neutral `0` rather than the old synthetic placeholder.
+   */
+  estimateRemoveNeuronGain?: RemoveNeuronGainEstimator,
 ): Promise<CandidateHarmfulNeuron[] | undefined> {
   if (focusList.length === 0) return undefined;
   const idToWire = buildRuntimeIdToWireMap(creature);
@@ -471,12 +521,12 @@ export async function analyzeSelectedNeuronsForHarmfulRemoval(
       if (baselineActivationError > MAX_REASONABLE_SQUASH_ERROR) {
         const neuronUuid = idToWire.get(neuronId);
         assert(neuronUuid, `Missing wire uuid for neuron ${neuronId}`);
-        const errorLog = Math.log10(baselineActivationError);
-        const thresholdLog = Math.log10(MAX_REASONABLE_SQUASH_ERROR);
-        const excessMagnitude = errorLog - thresholdLog;
-        const expectedCreatureScoreGain = Math.min(
-          0.5,
-          Math.max(0.1, 0.1 + (excessMagnitude / 10) * 0.4),
+        // Issue #1520: consume the injected Discovery estimate rather than
+        // fabricating the gain from the error magnitude. The over-threshold
+        // neuron is still returned for removal (#2483 WASM hygiene).
+        const expectedCreatureScoreGain = resolveRemoveNeuronGain(
+          neuronUuid,
+          estimateRemoveNeuronGain,
         );
 
         return {

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureAnalysis.ts
@@ -37,6 +37,7 @@ import {
 import {
   analyzeSelectedNeuronsForHarmfulRemoval as analyzeHarmfulNeuronsImpl,
   findCandidateSquash as findCandidateSquashImpl,
+  type RemoveNeuronGainEstimator,
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts";
 import { assert } from "@std/assert";
 import type { NeuronErrorInfo } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts";
@@ -550,6 +551,13 @@ export class DiscoverStructureAnalysis extends DiscoverStructureRecording {
      * instead of merely logging "this neuron should be removed".
      */
     harmfulSink?: CandidateHarmfulNeuron[],
+    /**
+     * Issue #1520: injected Discovery estimator forwarded to
+     * {@link findCandidateSquashImpl} so the over-threshold remove-neuron gain
+     * comes from the propagation-aware Discovery estimate rather than the old
+     * synthetic placeholder.
+     */
+    estimateRemoveNeuronGain?: RemoveNeuronGainEstimator,
   ): Promise<CandidateSquash[] | undefined> {
     if (focusList.length === 0) return undefined;
 
@@ -610,6 +618,7 @@ export class DiscoverStructureAnalysis extends DiscoverStructureRecording {
         this.loggingEnabled,
         (level, message, details) => this.log(level, message, details),
         harmfulSink,
+        estimateRemoveNeuronGain,
       );
     });
 
@@ -622,6 +631,12 @@ export class DiscoverStructureAnalysis extends DiscoverStructureRecording {
 
   public async analyzeSelectedNeuronsForHarmfulRemoval(
     focusList: number[],
+    /**
+     * Issue #1520: injected Discovery estimator forwarded to the squash
+     * analyser so the remove-neuron gain is consumed from the propagation-aware
+     * Discovery estimate rather than fabricated locally.
+     */
+    estimateRemoveNeuronGain?: RemoveNeuronGainEstimator,
   ): Promise<CandidateHarmfulNeuron[] | undefined> {
     if (focusList.length === 0) return undefined;
 
@@ -654,6 +669,7 @@ export class DiscoverStructureAnalysis extends DiscoverStructureRecording {
       this.tempDir,
       this.loggingEnabled,
       (level, message, details) => this.log(level, message, details),
+      estimateRemoveNeuronGain,
     );
   }
 

--- a/test/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts
@@ -1,14 +1,48 @@
-import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
+import {
+  assertAlmostEquals,
+  assertEquals,
+  assertNotEquals,
+  assertThrows,
+} from "@std/assert";
 import { Creature } from "@creature";
 import { buildWireToRuntimeIdMap } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
 import {
   analyzeSelectedNeuronsForHarmfulRemoval,
   calculateSquashError,
   calculateSquashErrorFromRaw,
+  findCandidateSquash,
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts";
+import type { CandidateHarmfulNeuron } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts";
 import { Activations } from "@methods/activations/Activations.ts";
 import type { ActivationInterface } from "@methods/activations/ActivationInterface.ts";
 import { TopologyError } from "@errors/TopologyError.ts";
+
+/**
+ * Reproduces the retired Issue #2483 placeholder remove-neuron gain
+ * (`0.1 + (log10(err) − 10)/10 × 0.4`, clamped to `[0.1, 0.5]`). A gain that
+ * still matches this for any error magnitude means the synthetic sink has been
+ * reintroduced (Issue #1520 regression guard).
+ */
+function placeholderGain(errorMagnitude: number): number {
+  const excessMagnitude = Math.log10(errorMagnitude) - Math.log10(1e10);
+  return Math.min(0.5, Math.max(0.1, 0.1 + (excessMagnitude / 10) * 0.4));
+}
+
+/** Over-threshold hidden neuron (IDENTITY squash) that trips the removal sink. */
+function overThresholdCreature(): Creature {
+  return Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-target", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-target", weight: 0.5 },
+      { fromUUID: "hidden-target", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+}
 
 Deno.test("calculateSquashError - returns zero for identical arrays", () => {
   const ideal = [1.0, 2.0, 3.0];
@@ -162,5 +196,130 @@ Deno.test(
 
     assertEquals(loadedPath, "/tmp/discovery/hidden-target");
     assertEquals(result?.[0]?.neuronUuid, "hidden-target");
+  },
+);
+
+Deno.test(
+  "DiscoverSquashAnalysis - remove-neuron gain is not synthesised locally (findCandidateSquash)",
+  () => {
+    // Issue #1520: over-threshold neurons still route to the harmful sink,
+    // but the gain must come from the injected Discovery estimate, never the
+    // retired placeholder formula.
+    const creature = overThresholdCreature();
+    const hiddenId = buildWireToRuntimeIdMap(creature).get("hidden-target")!;
+
+    const records = [{ value: 1, activation: 1, errors: [1e11] }];
+    const harmfulSink: CandidateHarmfulNeuron[] = [];
+
+    // Honest propagation-aware estimate from the 247b83ab failure example.
+    const discoveryEstimate = -0.000194;
+    let requestedUuid: string | undefined;
+
+    const candidate = findCandidateSquash(
+      creature,
+      hiddenId,
+      records,
+      () => 1,
+      false,
+      () => {},
+      harmfulSink,
+      (neuronUuid: string) => {
+        requestedUuid = neuronUuid;
+        return discoveryEstimate;
+      },
+    );
+
+    // No squash change is returned for an over-threshold neuron.
+    assertEquals(candidate, undefined);
+    // The neuron is still promoted for removal (#2483 WASM hygiene preserved).
+    assertEquals(harmfulSink.length, 1);
+    assertEquals(harmfulSink[0].neuronUuid, "hidden-target");
+    assertEquals(requestedUuid, "hidden-target");
+
+    // The surfaced gain is the injected Discovery estimate...
+    assertEquals(harmfulSink[0].expectedCreatureScoreGain, discoveryEstimate);
+    // ...and does NOT match the retired placeholder formula.
+    const synthetic = placeholderGain(harmfulSink[0].errorMagnitude);
+    assertNotEquals(harmfulSink[0].expectedCreatureScoreGain, synthetic);
+  },
+);
+
+Deno.test(
+  "DiscoverSquashAnalysis - remove-neuron gain defaults to non-fabricated zero (findCandidateSquash)",
+  () => {
+    // Without an injected estimate the Deno side emits a neutral 0, never the
+    // synthetic placeholder (Issue #1520). Removal identification is retained.
+    const creature = overThresholdCreature();
+    const hiddenId = buildWireToRuntimeIdMap(creature).get("hidden-target")!;
+
+    const records = [{ value: 1, activation: 1, errors: [1e11] }];
+    const harmfulSink: CandidateHarmfulNeuron[] = [];
+
+    findCandidateSquash(
+      creature,
+      hiddenId,
+      records,
+      () => 1,
+      false,
+      () => {},
+      harmfulSink,
+    );
+
+    assertEquals(harmfulSink.length, 1);
+    assertEquals(harmfulSink[0].expectedCreatureScoreGain, 0);
+    const synthetic = placeholderGain(harmfulSink[0].errorMagnitude);
+    assertNotEquals(harmfulSink[0].expectedCreatureScoreGain, synthetic);
+  },
+);
+
+Deno.test(
+  "DiscoverSquashAnalysis - remove-neuron gain is consumed from Discovery (analyzeSelectedNeuronsForHarmfulRemoval)",
+  async () => {
+    const creature = overThresholdCreature();
+    const hiddenId = buildWireToRuntimeIdMap(creature).get("hidden-target")!;
+
+    const discoveryEstimate = -0.000194;
+    let requestedUuid: string | undefined;
+
+    const result = await analyzeSelectedNeuronsForHarmfulRemoval(
+      creature,
+      [hiddenId],
+      () => Promise.resolve([{ value: 1, activation: 1, errors: [1e11] }]),
+      "/tmp/discovery",
+      false,
+      () => {},
+      (neuronUuid: string) => {
+        requestedUuid = neuronUuid;
+        return discoveryEstimate;
+      },
+    );
+
+    assertEquals(requestedUuid, "hidden-target");
+    assertEquals(result?.[0]?.neuronUuid, "hidden-target");
+    assertEquals(result?.[0]?.expectedCreatureScoreGain, discoveryEstimate);
+    const synthetic = placeholderGain(result![0].errorMagnitude);
+    assertNotEquals(result?.[0]?.expectedCreatureScoreGain, synthetic);
+  },
+);
+
+Deno.test(
+  "DiscoverSquashAnalysis - harmful removal emits non-fabricated zero without an estimate",
+  async () => {
+    const creature = overThresholdCreature();
+    const hiddenId = buildWireToRuntimeIdMap(creature).get("hidden-target")!;
+
+    const result = await analyzeSelectedNeuronsForHarmfulRemoval(
+      creature,
+      [hiddenId],
+      () => Promise.resolve([{ value: 1, activation: 1, errors: [1e11] }]),
+      "/tmp/discovery",
+      false,
+      () => {},
+    );
+
+    assertEquals(result?.[0]?.neuronUuid, "hidden-target");
+    assertEquals(result?.[0]?.expectedCreatureScoreGain, 0);
+    const synthetic = placeholderGain(result![0].errorMagnitude);
+    assertNotEquals(result?.[0]?.expectedCreatureScoreGain, synthetic);
   },
 );


### PR DESCRIPTION
# Stop the Deno placeholder remove-neuron gain in `DiscoverSquashAnalysis.ts`

## Summary

The over-threshold ("harmful") remove-neuron gain in
`src/architecture/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts` was
**fabricated** on the Deno side by the Issue #2483 sink:

```
expectedCreatureScoreGain = min(0.5, max(0.1, 0.1 + (excessMagnitude / 10) * 0.4))
```

where `excessMagnitude = log10(err) − log10(1e10)`. That formula ignored network
topology — it turned a large squash error into a large *positive* gain
regardless of how many layers separated the neuron from the output(s). For the
recorded `neuron-1802938338` failure it claimed `+0.17882921` while the measured
effect was `−0.000194` (~920× too large and opposite in sign).

Estimation authority has moved to the propagation-aware **NEAT-AI-Discovery
(Rust)** estimator `estimate_remove_neuron_gain`
(stSoftwareAU/NEAT-AI-Discovery#1518, cross-repo per
stSoftwareAU/NEAT-AI-Discovery#2942). This change makes the Deno side **stop
synthesising the gain** and instead **consume an injected Discovery estimate**:

- Both remove-neuron sinks (`findCandidateSquash` and
  `analyzeSelectedNeuronsForHarmfulRemoval`) now take an optional
  `RemoveNeuronGainEstimator` and surface its value verbatim.
- When no estimate is injected, the emitted gain is a **non-fabricated neutral
  `0`** — never the old placeholder. The `DiscoverSquashAnalysis` benchmark
  surfaces a zero gain as the cross-repo sequencing signal (per #1516) that the
  Discovery estimate is not yet wired.
- The Issue #2483 WASM-hygiene behaviour is **preserved**: over-threshold
  neurons are still promoted for removal (removal is gated on error magnitude,
  not gain). Only the *gain value* stopped being synthesised.

The estimator seam is threaded through the callers
`DiscoverStructureAnalysis.analyzeSelectedNeuronsSquashes` and
`analyzeSelectedNeuronsForHarmfulRemoval`, so a Discovery estimate can be
injected without further signature churn.

> The stale line reference `:261` in the issue is the squash-**change**
> `conservativeScale` (`sampleCount / 40000`), not a remove-neuron gain — it
> feeds `CandidateSquash`, not `CandidateHarmfulNeuron`, so it is deliberately
> left untouched. The two genuine remove-neuron placeholder sinks (`:196`,
> `:479` in the issue) are the ones removed.

Closes stSoftwareAU/NEAT-AI-Discovery#1520

## Data flow

```mermaid
flowchart LR
    A[Over-threshold neuron<br/>err &gt; 1e10] --> B{DiscoverSquashAnalysis}
    B -->|#2483 hygiene: still removal-eligible| C[CandidateHarmfulNeuron]
    B -->|gain value| D{RemoveNeuronGainEstimator<br/>injected?}
    D -->|yes| E[Discovery estimate<br/>propagation-aware, ≤ 0]
    D -->|no| F[Neutral 0<br/>bench sequencing signal]
    E --> C
    F --> C
```

## Evidence

Backend/CLI change — no web interface. Verified via `deno test` on the
`DiscoverSquashAnalysis` suite (14 passed, incl. 4 new), project-wide
`deno lint` (1789 files) and `deno check` (`quality.sh --check-only`), all green.

Regression proof: the new assertions require the gain to equal the injected
estimate (or `0`), which the old placeholder path (returning `0.5` for these
inputs) would fail.

## Test Plan

Added to `test/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts`:

- `DiscoverSquashAnalysis - remove-neuron gain is not synthesised locally (findCandidateSquash)` —
  injects a Discovery estimate, asserts the harmful-sink gain equals it and does
  **not** match the placeholder formula.
- `DiscoverSquashAnalysis - remove-neuron gain defaults to non-fabricated zero (findCandidateSquash)` —
  no estimator → gain `0`, still `!= placeholder`, neuron still promoted for
  removal.
- `DiscoverSquashAnalysis - remove-neuron gain is consumed from Discovery (analyzeSelectedNeuronsForHarmfulRemoval)` —
  injected estimate consumed verbatim.
- `DiscoverSquashAnalysis - harmful removal emits non-fabricated zero without an estimate` —
  default-path guard.

Existing `calculateSquashError*` and
`analyzeSelectedNeuronsForHarmfulRemoval loads records via wire uuid path` cases
continue to pass, guarding the preserved #2483 identification behaviour.
