### PR TITLE
Bound Discovery worker count to the host memory envelope (GRQ#3295)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.18",
+  "version": "5.7.19",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/src/config/DiscoveryWorkerEnvelope.ts
+++ b/src/config/DiscoveryWorkerEnvelope.ts
@@ -1,0 +1,161 @@
+/**
+ * Discovery worker-memory envelope → `workerThreadCap` wiring
+ * (stSoftwareAU/GRQ#3295, part of GRQ#3267 — Discovery OOM-killed on a 16 GB host).
+ *
+ * ## Why this exists
+ *
+ * The default thread count is `hardwareConcurrency + DEFAULT_HEAVY_TASK_WORKER_COUNT`
+ * (e.g. `10 + 2 = 12` on GRQ-22). Every spawned Deno worker isolate inherits the
+ * **process-level** `--max-old-space-size` (see {@link ./../workers/WorkerHeapBudget.ts}),
+ * so on a 16 GB host all 12 isolates carry the same 4096 MB budget — an aggregate
+ * ~48 GB potential worker heap with no accounting that
+ * `threads × per_worker ≤ host RAM`. The #1569 memory cap
+ * ({@link ./WorkerThreadCapConfig.ts}) that would bound this is opt-in and disabled
+ * by default (`maxMemoryMB = 0`), and Discovery never set it — so no cap was applied
+ * and the process was OOM-killed.
+ *
+ * ## The fix
+ *
+ * The external Discovery runner (`worker/Discovery/run.sh`, in the GRQ repo)
+ * carves a host-derived worker-memory envelope and exports it via env. This module
+ * reads that envelope and turns it into `workerThreadCap` overrides **automatically**
+ * — no per-caller opt-in — so `createNeatConfig` caps the effective thread count to
+ * `floor(envelope / per_worker_budget)`, guaranteeing `threads × per_worker ≤ envelope`.
+ *
+ * The contract is intentionally split across the process boundary, mirroring
+ * {@link ./../workers/WorkerHeapBudget.ts}:
+ *   - `DISCOVERY_WORKER_ENVELOPE_MB` — aggregate worker-isolate memory envelope (MB).
+ *     Maps to `workerThreadCap.maxMemoryMB`. Presence of a positive value here is
+ *     what activates the cap.
+ *   - `DISCOVERY_HEAP_SIZE_MB` — the **actual** per-worker V8 old-space budget: the
+ *     process `--max-old-space-size` every worker isolate inherits. Maps to
+ *     `workerThreadCap.estimatedMemoryPerWorkerMB` so the cap reflects the real
+ *     per-isolate footprint (4096 on GRQ-22), not the static 2048 MB guess.
+ *   - `DISCOVERY_PER_WORKER_HEAP_CAP_MB` — fallback per-worker cap, used only when
+ *     `DISCOVERY_HEAP_SIZE_MB` is unset.
+ *
+ * When `DISCOVERY_WORKER_ENVELOPE_MB` is unset (every non-Discovery caller),
+ * {@link resolveDiscoveryWorkerThreadCap} returns `undefined` and behaviour is
+ * unchanged: the cap stays disabled.
+ *
+ * @module
+ */
+
+import {
+  DISCOVERY_HEAP_SIZE_ENV,
+  type EnvReader,
+} from "@workers/WorkerHeapBudget.ts";
+
+export type { EnvReader };
+
+/**
+ * Environment variable the Discovery runner sets to the aggregate worker-isolate
+ * memory envelope (MB). A positive value here activates the automatic cap.
+ */
+export const DISCOVERY_WORKER_ENVELOPE_ENV = "DISCOVERY_WORKER_ENVELOPE_MB";
+
+/**
+ * Environment variable the Discovery runner sets to the derived per-worker V8
+ * heap cap (MB). Used as the per-worker estimate only when
+ * {@link DISCOVERY_HEAP_SIZE_ENV} is unset.
+ */
+export const DISCOVERY_PER_WORKER_HEAP_CAP_ENV =
+  "DISCOVERY_PER_WORKER_HEAP_CAP_MB";
+
+/**
+ * `workerThreadCap` overrides derived from the Discovery memory envelope.
+ *
+ * `estimatedMemoryPerWorkerMB` is optional: when neither the actual per-worker V8
+ * budget nor the exported per-worker cap is available, it is left unset so the
+ * parser applies its static default.
+ */
+export interface DiscoveryWorkerThreadCapOverrides {
+  /** Aggregate worker-memory envelope (MB) → `workerThreadCap.maxMemoryMB`. */
+  maxMemoryMB: number;
+  /** Actual per-worker V8 budget (MB) → `workerThreadCap.estimatedMemoryPerWorkerMB`. */
+  estimatedMemoryPerWorkerMB?: number;
+}
+
+/**
+ * Read a positive-integer megabyte value from the environment.
+ *
+ * Returns `undefined` when the variable is unset, empty, non-numeric,
+ * non-integer, or not strictly positive — so a malformed or zero value can never
+ * activate or distort the cap. Wrapped in `try/catch` so a missing `--allow-env`
+ * permission is treated as unconfigured rather than throwing.
+ */
+function readPositiveIntMb(env: EnvReader, key: string): number | undefined {
+  let raw: string | undefined;
+  try {
+    raw = env.get(key) ?? undefined;
+  } catch {
+    // No --allow-env (or reader threw): treat as unconfigured.
+    return undefined;
+  }
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    return undefined;
+  }
+  return n;
+}
+
+/**
+ * Resolve automatic `workerThreadCap` overrides from the Discovery memory
+ * envelope exported by `worker/Discovery/run.sh`.
+ *
+ * Returns `undefined` unless {@link DISCOVERY_WORKER_ENVELOPE_ENV} holds a
+ * positive integer — so non-Discovery callers (env unset) keep the cap disabled
+ * and their behaviour unchanged. When active, `maxMemoryMB` is the envelope and
+ * `estimatedMemoryPerWorkerMB` is the actual per-worker V8 budget
+ * ({@link DISCOVERY_HEAP_SIZE_ENV}, the process `--max-old-space-size` every
+ * isolate inherits), falling back to the exported per-worker cap
+ * ({@link DISCOVERY_PER_WORKER_HEAP_CAP_ENV}).
+ *
+ * @param env - Environment reader (defaults to `Deno.env`).
+ */
+export function resolveDiscoveryWorkerThreadCap(
+  env: EnvReader = Deno.env,
+): DiscoveryWorkerThreadCapOverrides | undefined {
+  const envelope = readPositiveIntMb(env, DISCOVERY_WORKER_ENVELOPE_ENV);
+  if (envelope === undefined) return undefined;
+
+  // The real per-isolate footprint is the process V8 budget every worker
+  // inherits (DISCOVERY_HEAP_SIZE_MB); the derived per-worker cap is only a
+  // fallback when the process budget is not exported.
+  const perWorker = readPositiveIntMb(env, DISCOVERY_HEAP_SIZE_ENV) ??
+    readPositiveIntMb(env, DISCOVERY_PER_WORKER_HEAP_CAP_ENV);
+
+  return perWorker === undefined
+    ? { maxMemoryMB: envelope }
+    : { maxMemoryMB: envelope, estimatedMemoryPerWorkerMB: perWorker };
+}
+
+/**
+ * Merge Discovery-envelope-derived `workerThreadCap` defaults under any explicit
+ * user overrides. Explicit user values always win; the envelope only fills fields
+ * the user did not supply. Returns the user overrides unchanged when no envelope
+ * is active (so the parser's static defaults apply).
+ *
+ * @param userOverrides - Raw `workerThreadCap` overrides from user options.
+ * @param envelope - Envelope-derived overrides, or `undefined` when inactive.
+ */
+export function mergeDiscoveryWorkerThreadCapDefaults(
+  userOverrides: Record<string, unknown> | undefined,
+  envelope: DiscoveryWorkerThreadCapOverrides | undefined,
+): Record<string, unknown> | undefined {
+  if (envelope === undefined) return userOverrides;
+
+  const merged: Record<string, unknown> = { maxMemoryMB: envelope.maxMemoryMB };
+  if (envelope.estimatedMemoryPerWorkerMB !== undefined) {
+    merged.estimatedMemoryPerWorkerMB = envelope.estimatedMemoryPerWorkerMB;
+  }
+  if (userOverrides) {
+    for (const [key, value] of Object.entries(userOverrides)) {
+      if (value !== undefined) merged[key] = value;
+    }
+  }
+  return merged;
+}

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -74,6 +74,12 @@ import {
 // Extracted cross-field validation
 import { validateNeatConfig } from "@config/NeatConfigValidation.ts";
 
+// Issue GRQ#3295: automatic Discovery worker-memory envelope → workerThreadCap.
+import {
+  mergeDiscoveryWorkerThreadCapDefaults,
+  resolveDiscoveryWorkerThreadCap,
+} from "@config/DiscoveryWorkerEnvelope.ts";
+
 // Issue #2492: DNA-sharing knob preset
 import {
   type DnaSharingMode,
@@ -227,9 +233,16 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
     min: 1,
   });
 
-  // Issue #1569: Parse worker thread cap config and apply memory-based capping
+  // Issue #1569: Parse worker thread cap config and apply memory-based capping.
+  // Issue GRQ#3295: when the Discovery runner exports a host-derived worker-memory
+  // envelope (DISCOVERY_WORKER_ENVELOPE_MB) and per-worker V8 budget, wire them in
+  // automatically so the cap fires without any per-caller opt-in. Explicit user
+  // overrides still win; non-Discovery callers (env unset) keep the cap disabled.
   const workerThreadCap = parseWorkerThreadCap(
-    opts.workerThreadCap as Record<string, unknown> | undefined,
+    mergeDiscoveryWorkerThreadCapDefaults(
+      opts.workerThreadCap as Record<string, unknown> | undefined,
+      resolveDiscoveryWorkerThreadCap(),
+    ),
   );
 
   if (workerThreadCap.maxMemoryMB > 0) {

--- a/test/config/DiscoveryWorkerEnvelope.ts
+++ b/test/config/DiscoveryWorkerEnvelope.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the Discovery worker-memory envelope → workerThreadCap resolver
+ * (stSoftwareAU/GRQ#3295).
+ *
+ * These exercise the pure env → overrides mapping with an injected reader, so
+ * they are hermetic and never touch the real process environment.
+ */
+import { assertEquals } from "@std/assert";
+import {
+  DISCOVERY_PER_WORKER_HEAP_CAP_ENV,
+  DISCOVERY_WORKER_ENVELOPE_ENV,
+  mergeDiscoveryWorkerThreadCapDefaults,
+  resolveDiscoveryWorkerThreadCap,
+} from "@config/DiscoveryWorkerEnvelope.ts";
+import { DISCOVERY_HEAP_SIZE_ENV } from "@workers/WorkerHeapBudget.ts";
+
+/** Build an env getter from a plain record for hermetic tests. */
+function envFrom(
+  map: Record<string, string>,
+): { get(key: string): string | undefined } {
+  return { get: (k) => (k in map ? map[k] : undefined) };
+}
+
+Deno.test("resolveDiscoveryWorkerThreadCap: undefined when envelope env unset", () => {
+  assertEquals(resolveDiscoveryWorkerThreadCap(envFrom({})), undefined);
+  // Per-worker present but no envelope → still inactive.
+  assertEquals(
+    resolveDiscoveryWorkerThreadCap(
+      envFrom({ [DISCOVERY_HEAP_SIZE_ENV]: "4096" }),
+    ),
+    undefined,
+  );
+});
+
+Deno.test("resolveDiscoveryWorkerThreadCap: maps envelope + actual heap budget (GRQ-22)", () => {
+  const overrides = resolveDiscoveryWorkerThreadCap(
+    envFrom({
+      [DISCOVERY_WORKER_ENVELOPE_ENV]: "7840",
+      [DISCOVERY_HEAP_SIZE_ENV]: "4096",
+    }),
+  );
+  assertEquals(overrides, {
+    maxMemoryMB: 7840,
+    estimatedMemoryPerWorkerMB: 4096,
+  });
+});
+
+Deno.test("resolveDiscoveryWorkerThreadCap: actual heap budget wins over derived per-worker cap", () => {
+  const overrides = resolveDiscoveryWorkerThreadCap(
+    envFrom({
+      [DISCOVERY_WORKER_ENVELOPE_ENV]: "6000",
+      [DISCOVERY_HEAP_SIZE_ENV]: "4096",
+      [DISCOVERY_PER_WORKER_HEAP_CAP_ENV]: "256",
+    }),
+  );
+  // The real per-isolate footprint is the process heap (4096), not the derived
+  // cap (256) — using the smaller value would under-count and OOM.
+  assertEquals(overrides?.estimatedMemoryPerWorkerMB, 4096);
+});
+
+Deno.test("resolveDiscoveryWorkerThreadCap: falls back to exported per-worker cap when heap unset", () => {
+  const overrides = resolveDiscoveryWorkerThreadCap(
+    envFrom({
+      [DISCOVERY_WORKER_ENVELOPE_ENV]: "6000",
+      [DISCOVERY_PER_WORKER_HEAP_CAP_ENV]: "2048",
+    }),
+  );
+  assertEquals(overrides, {
+    maxMemoryMB: 6000,
+    estimatedMemoryPerWorkerMB: 2048,
+  });
+});
+
+Deno.test("resolveDiscoveryWorkerThreadCap: no per-worker source leaves estimate unset", () => {
+  const overrides = resolveDiscoveryWorkerThreadCap(
+    envFrom({ [DISCOVERY_WORKER_ENVELOPE_ENV]: "6000" }),
+  );
+  assertEquals(overrides, { maxMemoryMB: 6000 });
+});
+
+Deno.test("resolveDiscoveryWorkerThreadCap: rejects zero / non-integer / non-numeric envelope", () => {
+  for (const bad of ["0", "-1", "1.5", "abc", "", "  "]) {
+    assertEquals(
+      resolveDiscoveryWorkerThreadCap(
+        envFrom({ [DISCOVERY_WORKER_ENVELOPE_ENV]: bad }),
+      ),
+      undefined,
+      `envelope '${bad}' must not activate the cap`,
+    );
+  }
+});
+
+Deno.test("resolveDiscoveryWorkerThreadCap: unconfigured when env reader throws (no --allow-env)", () => {
+  const throwing = {
+    get() {
+      throw new Error("NotCapable: env access denied");
+    },
+  };
+  assertEquals(resolveDiscoveryWorkerThreadCap(throwing), undefined);
+});
+
+Deno.test("mergeDiscoveryWorkerThreadCapDefaults: returns user overrides unchanged when no envelope", () => {
+  const user = { maxMemoryMB: 1234 };
+  assertEquals(
+    mergeDiscoveryWorkerThreadCapDefaults(user, undefined),
+    user,
+  );
+  assertEquals(
+    mergeDiscoveryWorkerThreadCapDefaults(undefined, undefined),
+    undefined,
+  );
+});
+
+Deno.test("mergeDiscoveryWorkerThreadCapDefaults: envelope fills gaps, user wins on conflict", () => {
+  const merged = mergeDiscoveryWorkerThreadCapDefaults(
+    { maxMemoryMB: 999 },
+    { maxMemoryMB: 7840, estimatedMemoryPerWorkerMB: 4096 },
+  );
+  // Explicit user maxMemoryMB wins; envelope supplies the per-worker estimate.
+  assertEquals(merged, { maxMemoryMB: 999, estimatedMemoryPerWorkerMB: 4096 });
+});

--- a/test/config/WorkerThreadCapConfig.ts
+++ b/test/config/WorkerThreadCapConfig.ts
@@ -1,9 +1,65 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
   createNeatConfig,
   DEFAULT_HEAVY_TASK_WORKER_COUNT,
 } from "@config/NeatConfig.ts";
 import { DEFAULT_WORKER_THREAD_CAP_CONFIG } from "@config/WorkerThreadCapConfig.ts";
+import {
+  DISCOVERY_PER_WORKER_HEAP_CAP_ENV,
+  DISCOVERY_WORKER_ENVELOPE_ENV,
+} from "@config/DiscoveryWorkerEnvelope.ts";
+import { DISCOVERY_HEAP_SIZE_ENV } from "@workers/WorkerHeapBudget.ts";
+import { getLogger, type Logger, setLogger } from "@utils/Logger.ts";
+
+/** Env vars the Discovery envelope wiring reads (GRQ#3295). */
+const ENVELOPE_ENV_KEYS = [
+  DISCOVERY_WORKER_ENVELOPE_ENV,
+  DISCOVERY_HEAP_SIZE_ENV,
+  DISCOVERY_PER_WORKER_HEAP_CAP_ENV,
+];
+
+/**
+ * Run `fn` with the given envelope env vars set, restoring the prior process
+ * environment afterwards. Tests within a file run sequentially and each file
+ * runs in its own process under `deno test --parallel`, so the set/restore
+ * window cannot race another test.
+ */
+function withEnvelopeEnv(
+  overrides: Record<string, string>,
+  fn: () => void,
+): void {
+  const prior = new Map<string, string | undefined>();
+  for (const key of ENVELOPE_ENV_KEYS) {
+    prior.set(key, Deno.env.get(key));
+    Deno.env.delete(key);
+  }
+  try {
+    for (const [key, value] of Object.entries(overrides)) {
+      Deno.env.set(key, value);
+    }
+    fn();
+  } finally {
+    for (const [key, value] of prior) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  }
+}
+
+/** Logger that records emitted lines by level for assertions. */
+function makeRecordingLogger(): {
+  logger: Logger;
+  lines: { level: string; message: string }[];
+} {
+  const lines: { level: string; message: string }[] = [];
+  const logger: Logger = {
+    debug: (...a) => lines.push({ level: "debug", message: a.join(" ") }),
+    info: (...a) => lines.push({ level: "info", message: a.join(" ") }),
+    warn: (...a) => lines.push({ level: "warn", message: a.join(" ") }),
+    error: (...a) => lines.push({ level: "error", message: a.join(" ") }),
+  };
+  return { logger, lines };
+}
 
 Deno.test("WorkerThreadCapConfig - default values are sensible", () => {
   assertEquals(DEFAULT_WORKER_THREAD_CAP_CONFIG.maxMemoryMB, 0);
@@ -149,6 +205,92 @@ Deno.test("WorkerThreadCapConfig - backwards compatible when not set", () => {
   const expected = Math.max(1, navigator.hardwareConcurrency ?? 1) +
     DEFAULT_HEAVY_TASK_WORKER_COUNT;
   assertEquals(config.threads, expected);
+});
+
+Deno.test("worker thread cap — GRQ-22 envelope", () => {
+  // GRQ-22 signature: available 7840 MB, 10 cores → 12 default threads, each
+  // worker isolate carries the process --max-old-space-size=4096. Without the
+  // cap this over-commits 12 × 4096 ≈ 48 GB on a 16 GB host and OOM-kills.
+  const { logger, lines } = makeRecordingLogger();
+  // The cap-fired warning is emitted through the global getLogger() before
+  // createNeatConfig installs its own logger, so install the recorder globally
+  // to capture it (restored afterwards).
+  const priorLogger = getLogger();
+  setLogger(logger);
+  withEnvelopeEnv(
+    {
+      [DISCOVERY_WORKER_ENVELOPE_ENV]: "7840",
+      [DISCOVERY_HEAP_SIZE_ENV]: "4096",
+    },
+    () => {
+      const config = createNeatConfig({ logger });
+
+      // Cap wired automatically from env — no opt-in needed.
+      assertEquals(config.workerThreadCap.maxMemoryMB, 7840);
+      assertEquals(config.workerThreadCap.estimatedMemoryPerWorkerMB, 4096);
+
+      // Core invariant: aggregate worker heap fits the envelope (and available).
+      const aggregate = config.threads *
+        config.workerThreadCap.estimatedMemoryPerWorkerMB;
+      assert(
+        aggregate <= config.workerThreadCap.maxMemoryMB,
+        `aggregate ${aggregate} must be <= envelope ${config.workerThreadCap.maxMemoryMB}`,
+      );
+      assert(
+        aggregate <= 7840,
+        `aggregate ${aggregate} must be <= available 7840`,
+      );
+
+      // floor(7840 / 4096) = 1, far below the ≥3 default (min 1 core + 2).
+      assertEquals(config.threads, 1);
+
+      // The cap-fired warning records the host-derived numbers.
+      const warn = lines.find((l) =>
+        l.level === "warn" && l.message.includes("capped")
+      );
+      assert(warn, "expected a worker-thread-cap warning");
+      assert(
+        warn!.message.includes("maxMemoryMB: 7840"),
+        `warn should record host maxMemoryMB: ${warn!.message}`,
+      );
+      assert(
+        warn!.message.includes("estimatedMemoryPerWorkerMB: 4096"),
+        `warn should record host estimatedMemoryPerWorkerMB: ${warn!.message}`,
+      );
+    },
+  );
+  setLogger(priorLogger);
+});
+
+Deno.test("worker thread cap — disabled when Discovery envelope env unset", () => {
+  // Non-Discovery callers: env absent → behaviour unchanged, cap stays disabled.
+  withEnvelopeEnv({}, () => {
+    const config = createNeatConfig({});
+    assertEquals(config.workerThreadCap.maxMemoryMB, 0);
+    assertEquals(config.workerThreadCap.estimatedMemoryPerWorkerMB, 2048);
+    const expected = Math.max(1, navigator.hardwareConcurrency ?? 1) +
+      DEFAULT_HEAVY_TASK_WORKER_COUNT;
+    assertEquals(config.threads, expected);
+  });
+});
+
+Deno.test("worker thread cap — explicit user override wins over envelope env", () => {
+  // A caller that sets maxMemoryMB explicitly keeps control; the envelope only
+  // supplies the per-worker estimate it did not provide.
+  withEnvelopeEnv(
+    {
+      [DISCOVERY_WORKER_ENVELOPE_ENV]: "7840",
+      [DISCOVERY_HEAP_SIZE_ENV]: "4096",
+    },
+    () => {
+      const config = createNeatConfig({
+        workerThreadCap: { maxMemoryMB: 16384 },
+      });
+      assertEquals(config.workerThreadCap.maxMemoryMB, 16384);
+      // Per-worker estimate still comes from the host envelope (4096).
+      assertEquals(config.workerThreadCap.estimatedMemoryPerWorkerMB, 4096);
+    },
+  );
 });
 
 Deno.test("WorkerThreadCapConfig - config rejects property assignment after creation", () => {


### PR DESCRIPTION
## Summary

Root-cause fix for **stSoftwareAU/GRQ#3295** (part of GRQ#3267 — *Discovery OOM-killed on a 16 GB host*). The whole change is NEAT-AI-only.

On GRQ-22 (16 GB, 10 cores) Discovery spawned **12 workers each reporting `configured V8 old-space budget 4096 MB`** — a ~48 GB potential aggregate worker heap — and the process was OOM-killed. Root causes:

- `defaultThreads = coreCount + DEFAULT_HEAVY_TASK_WORKER_COUNT` → `10 + 2 = 12`.
- Every Deno worker isolate inherits the **process-level** `--max-old-space-size` (only lever that resizes an isolate; see `WorkerHeapBudget.ts`), so all 12 carried 4096 MB with no `threads × per_worker ≤ host RAM` accounting.
- The #1569 memory cap (`workerThreadCap`) is opt-in and disabled by default (`maxMemoryMB = 0`); Discovery never set it → no cap applied.

## Change

New `src/config/DiscoveryWorkerEnvelope.ts` consumes the host-derived envelope the external Discovery runner (`worker/Discovery/run.sh`, GRQ#3294) exports via env and wires it into `workerThreadCap` **automatically — not opt-in**:

| Env var | → | `workerThreadCap` field |
| --- | --- | --- |
| `DISCOVERY_WORKER_ENVELOPE_MB` (positive value activates the cap) | → | `maxMemoryMB` |
| `DISCOVERY_HEAP_SIZE_MB` (actual per-isolate V8 budget, i.e. the inherited process flag) | → | `estimatedMemoryPerWorkerMB` |
| `DISCOVERY_PER_WORKER_HEAP_CAP_MB` | → | fallback per-worker estimate |

`createNeatConfig` then caps effective threads to `floor(envelope / per_worker)`, guaranteeing `threads × per_worker ≤ envelope`, and the existing cap-fired `warn` records the host-derived numbers. The per-worker estimate uses the **actual** inherited isolate budget (4096 on GRQ-22), not the static 2048 MB guess, so the cap reflects reality.

**Safety:** when `DISCOVERY_WORKER_ENVELOPE_MB` is unset (every non-Discovery caller), the resolver returns `undefined` and behaviour is unchanged — the cap stays disabled. Explicit user overrides still win. Env reads are wrapped in `try/catch`, so a missing `--allow-env` is treated as unconfigured rather than throwing.

```mermaid
flowchart LR
  RS["worker/Discovery/run.sh<br/>(GRQ, #3294)"] -->|"DISCOVERY_WORKER_ENVELOPE_MB<br/>DISCOVERY_HEAP_SIZE_MB"| ENV[(env)]
  ENV --> R["resolveDiscoveryWorkerThreadCap()"]
  R --> M["merge under user overrides"]
  M --> C["createNeatConfig<br/>threads = min(default, floor(envelope / per_worker))"]
  C --> W["cap-fired warn:<br/>host-derived maxMemoryMB / estimatedMemoryPerWorkerMB"]
```

## Test Plan

- `test/config/DiscoveryWorkerEnvelope.ts` — hermetic env→overrides mapping: envelope+heap (GRQ-22), actual-heap-wins-over-derived-cap, fallback, rejects zero/non-integer/non-numeric, unconfigured when reader throws, merge semantics.
- `test/config/WorkerThreadCapConfig.ts` — new `worker thread cap — GRQ-22 envelope` (asserts `threads × estimatedMemoryPerWorkerMB ≤ maxMemoryMB ≤ available`, effective threads = 1, warn records host numbers), `disabled when env unset`, `explicit user override wins`. All pre-existing cases still pass.

`deno fmt`, `deno lint`, and `deno check` clean on all touched files.