### PR TITLE
Discovery: degrade-and-continue at heap-CRITICAL extension boundary (GRQ #3296)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.18",
+  "version": "5.7.19",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.7.19",
+  "version": "5.7.20",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-degrade-and-continue-3296.md
+++ b/docs/archive/pr-summaries/pr-summary-degrade-and-continue-3296.md
@@ -1,0 +1,84 @@
+## Summary
+
+Discovery now **degrades and continues** at the analysis-extension boundary
+under CRITICAL heap pressure instead of aborting the iteration to zero
+candidates. This is the NEAT-AI root-cause fix for **GRQ #3296** (part of
+GRQ milestone #3267 — "Discovery OOM-killed on 16 GB host — adapt to host
+memory").
+
+Previously, when the off-heap-aware guard reported CRITICAL pressure at the
+extension boundary (genuine native-budget exhaustion), `DataRecorder` skipped
+the analysis phase and returned an empty `DiscoverResult` carrying
+`heapAbortedAtExtensionBoundary: true` — a 0-candidate skip that the parent
+issue classes as a failure ("a loud degraded skip … is still a failure").
+
+Now the boundary reduces the analysis footprint (fewer focus neurons, smaller
+Rust FFI chunks) and pushes through to a genuine completion — candidates, or an
+honest no-improvement result. The degrade decision is logged with the reduced
+knob values so the smaller footprint is observable.
+
+### What changed
+
+- **New `AnalysisDegradeDecision.ts`** — a pure, deterministic helper
+  (`computeDegradedAnalysisKnobs`) that computes the minimal analysis footprint
+  from the current knobs: focus breadth reduced to a quarter (floored at one
+  neuron), analysis chunk size bounded to a small chunk. Returns a grep-friendly
+  reason string naming each reduced knob and its `from->to` value.
+- **`AnalysisExtensionBoundary.ts`** — added `resolveDegradedAnalysisBoundary`,
+  which samples the heap through the same off-heap-aware guard and, when it
+  would previously have aborted, returns `degraded: true` with the degraded
+  knobs and logs the degrade decision, instead of building an empty result. The
+  legacy `resolveHeapAbortBoundary` is retained (still unit-tested) but is no
+  longer the production path.
+- **`DataRecorder.ts`** — the extension boundary now calls
+  `resolveDegradedAnalysisBoundary` and runs `runAnalysisLoop` with the degraded
+  knobs plus a `degradedFirstPass` signal rather than returning early.
+- **`DataRecorderAnalysis.ts`** — the in-loop heap guard honours
+  `degradedFirstPass`: the first (retryAttempt 0) minimal-footprint pass runs to
+  completion — including its first chunk — instead of aborting immediately, so a
+  starved host reaches a genuine completion. Subsequent iterations honour the
+  guard normally, so a run that stays CRITICAL still bails with whatever
+  candidates it found.
+
+```mermaid
+flowchart TD
+    A[Recording done] --> B{Heap CRITICAL at\nextension boundary?}
+    B -- no --> C[Run analysis\nnormal footprint]
+    B -- yes (was: abort → 0 candidates) --> D[Degrade footprint\nlog reduced knobs]
+    D --> E[Run one minimal-footprint\npass to completion]
+    E --> F{Still CRITICAL\nnext iteration?}
+    F -- yes --> G[Stop with candidates\nfound so far]
+    F -- no --> C
+    C --> H[Genuine completion:\ncandidates or honest no-improvement]
+    E --> H
+```
+
+## Evidence
+
+Backend/library change — no UI. Verified via `deno test`:
+
+- `test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` — 6 cases
+  pinning the reduction rules, floors, unbounded-chunk handling, non-finite
+  fallback, and the starved-at-start minimal footprint.
+- `test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts` — added 3
+  `resolveDegradedAnalysisBoundary` cases (happy path unchanged; CRITICAL
+  degrades and logs; genuine budget exhaustion degrades instead of forcing an
+  OOM-prone abort).
+- `test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts` — added
+  `degrades footprint and continues at extension boundary instead of aborting`,
+  which forces persistent CRITICAL heap with `degradedFirstPass` and asserts the
+  loop analyses neurons and submits a chunk (no 0-candidate abort), driven
+  through the real `runAnalysisLoop`.
+
+All existing extension-boundary, heap-guard, worker-payload, and outcome tests
+continue to pass (`resolveHeapAbortBoundary` and the
+`heapAbortedAtExtensionBoundary` wire contract are unchanged).
+
+## Test Plan
+
+- `deno test test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` — 6 passed
+- `deno test test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts` — 10 passed
+- `deno test test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts` — 6 passed
+- `deno test test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts` — 25 passed
+- `deno test test/multithreading/WorkerProcessor.ts test/NEAT/DiscoveryOutcome.ts test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` — 17 passed
+- `deno check` + `deno fmt` + `deno lint` clean on all changed files

--- a/docs/archive/pr-summaries/pr-summary-degrade-and-continue-3296.md
+++ b/docs/archive/pr-summaries/pr-summary-degrade-and-continue-3296.md
@@ -2,9 +2,8 @@
 
 Discovery now **degrades and continues** at the analysis-extension boundary
 under CRITICAL heap pressure instead of aborting the iteration to zero
-candidates. This is the NEAT-AI root-cause fix for **GRQ #3296** (part of
-GRQ milestone #3267 — "Discovery OOM-killed on 16 GB host — adapt to host
-memory").
+candidates. This is the NEAT-AI root-cause fix for **GRQ #3296** (part of GRQ
+milestone #3267 — "Discovery OOM-killed on 16 GB host — adapt to host memory").
 
 Previously, when the off-heap-aware guard reported CRITICAL pressure at the
 extension boundary (genuine native-budget exhaustion), `DataRecorder` skipped
@@ -76,9 +75,14 @@ continue to pass (`resolveHeapAbortBoundary` and the
 
 ## Test Plan
 
-- `deno test test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` — 6 passed
-- `deno test test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts` — 10 passed
-- `deno test test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts` — 6 passed
-- `deno test test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts` — 25 passed
-- `deno test test/multithreading/WorkerProcessor.ts test/NEAT/DiscoveryOutcome.ts test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` — 17 passed
+- `deno test test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` — 6
+  passed
+- `deno test test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts` —
+  10 passed
+- `deno test test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts` — 6
+  passed
+- `deno test test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts`
+  — 25 passed
+- `deno test test/multithreading/WorkerProcessor.ts test/NEAT/DiscoveryOutcome.ts test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts`
+  — 17 passed
 - `deno check` + `deno fmt` + `deno lint` clean on all changed files

--- a/src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
@@ -1,0 +1,134 @@
+/**
+ * Degrade-and-continue decision for the discovery analysis-extension boundary
+ * (Issue #3296, part of GRQ #3267).
+ *
+ * When the heap is CRITICAL at the analysis-extension boundary the historical
+ * response was to abort the iteration and return an empty {@link DiscoverResult}
+ * with `heapAbortedAtExtensionBoundary: true` — a 0-candidate skip. The accepted
+ * requirement is instead to **degrade the footprint and push through** so the
+ * iteration reaches a genuine completion (candidates, or an honest
+ * no-improvement result) rather than a 0-candidate abort.
+ *
+ * This module is a small, pure, side-effect-free helper that computes the
+ * degraded analysis knobs from the current ones. It is deliberately independent
+ * of the runtime so it can be unit-tested deterministically, and so the same
+ * "minimal footprint" values are used both at the extension boundary and when a
+ * host is memory-starved at the very start of a discovery run.
+ *
+ * @module
+ */
+
+/** The analysis-phase knobs that the degrade decision may reduce. */
+export interface AnalysisKnobs {
+  /** Focus breadth — neurons submitted to one analysis pass. */
+  discoveryMaxNeurons: number;
+  /**
+   * Max neurons per Rust combined-analysis FFI call. `<= 0` means "whole focus
+   * list in one call" (unbounded); reducing it bounds the peak FFI allocation.
+   */
+  analysisChunkSize: number;
+}
+
+/** A single knob that the degrade decision reduced. */
+export interface KnobReduction {
+  knob: string;
+  /** Original value (`0` for an unbounded chunk size). */
+  from: number;
+  to: number;
+}
+
+/** Outcome of {@link computeDegradedAnalysisKnobs}. */
+export interface DegradedAnalysisDecision {
+  /** The degraded knobs to run analysis with. */
+  knobs: AnalysisKnobs;
+  /** The knobs that were actually reduced (empty when already minimal). */
+  reductions: KnobReduction[];
+  /**
+   * Grep-friendly, human-readable summary of which knobs were reduced and to
+   * what — logged so the reduced footprint is observable.
+   */
+  reason: string;
+}
+
+/**
+ * Focus breadth is never degraded below this — at least one neuron must be
+ * analysed so the pass reaches a genuine completion instead of skipping.
+ */
+export const MIN_DEGRADED_MAX_NEURONS = 1;
+
+/**
+ * Fraction of the current focus breadth kept when degrading. A quarter keeps a
+ * meaningful (but much smaller) working set so candidates can still be found.
+ */
+export const DEGRADED_MAX_NEURONS_FACTOR = 0.25;
+
+/**
+ * Chunk size the degraded analysis bounds each Rust FFI call to. Small enough to
+ * keep the peak combined-analysis allocation modest on a starved host, large
+ * enough to make progress in a bounded number of calls.
+ */
+export const DEGRADED_ANALYSIS_CHUNK_SIZE = 4;
+
+/** Coerce a value to a positive integer, or fall back when non-finite / <= 0. */
+function positiveIntOr(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+/**
+ * Compute the minimal-footprint analysis knobs to continue with under memory
+ * pressure. Pure and deterministic: given the current knobs it returns the
+ * degraded knobs, the list of reductions applied, and a log-ready reason.
+ *
+ * Rules:
+ *  - Focus breadth (`discoveryMaxNeurons`) is reduced to a quarter, floored at
+ *    {@link MIN_DEGRADED_MAX_NEURONS} so at least one neuron is always analysed.
+ *  - Chunk size (`analysisChunkSize`) is bounded to
+ *    {@link DEGRADED_ANALYSIS_CHUNK_SIZE}. An unbounded (`<= 0`) or larger chunk
+ *    is reduced; an already-small chunk is left untouched.
+ *  - A knob already at or below its degraded target is not listed as reduced.
+ */
+export function computeDegradedAnalysisKnobs(
+  current: AnalysisKnobs,
+): DegradedAnalysisDecision {
+  const reductions: KnobReduction[] = [];
+
+  // Focus breadth → quarter, floored so at least one neuron runs.
+  const fromNeurons = positiveIntOr(
+    current.discoveryMaxNeurons,
+    MIN_DEGRADED_MAX_NEURONS,
+  );
+  const toNeurons = Math.max(
+    MIN_DEGRADED_MAX_NEURONS,
+    Math.min(fromNeurons, Math.ceil(fromNeurons * DEGRADED_MAX_NEURONS_FACTOR)),
+  );
+  if (toNeurons < fromNeurons) {
+    reductions.push({ knob: "maxNeurons", from: fromNeurons, to: toNeurons });
+  }
+
+  // Chunk size → bounded small chunk. `0`/negative means unbounded (whole list).
+  const fromChunkRaw = Number.isFinite(current.analysisChunkSize)
+    ? Math.floor(current.analysisChunkSize)
+    : 0;
+  const fromChunk = fromChunkRaw > 0 ? fromChunkRaw : 0;
+  let toChunk: number;
+  if (fromChunk === 0 || fromChunk > DEGRADED_ANALYSIS_CHUNK_SIZE) {
+    toChunk = DEGRADED_ANALYSIS_CHUNK_SIZE;
+    reductions.push({ knob: "chunkSize", from: fromChunk, to: toChunk });
+  } else {
+    toChunk = fromChunk;
+  }
+
+  const reason = reductions.length > 0
+    ? `minimal footprint: ${
+      reductions
+        .map((r) => `${r.knob} ${r.from === 0 ? "unbounded" : r.from}->${r.to}`)
+        .join(", ")
+    }`
+    : "already at minimal footprint";
+
+  return {
+    knobs: { discoveryMaxNeurons: toNeurons, analysisChunkSize: toChunk },
+    reductions,
+    reason,
+  };
+}

--- a/src/architecture/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts
@@ -25,7 +25,16 @@ import type { RequiredMemoryConfig } from "@config/MemoryConfig.ts";
 import type { MemoryUsageProvider } from "@neat/MemoryMonitor.ts";
 import type { Logger } from "@utils/Logger.ts";
 import type { DiscoverResult } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
-import { checkAnalysisHeapAbort } from "@architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts";
+import {
+  checkAnalysisHeapAbort,
+  type HeapGuardSample,
+  sampleHeapPressure,
+  shouldAbortOnHeapPressure,
+} from "@architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts";
+import {
+  type AnalysisKnobs,
+  computeDegradedAnalysisKnobs,
+} from "@architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts";
 
 /** Options for {@link buildEmptyDiscoverResult}. */
 export interface EmptyDiscoverResultOptions {
@@ -96,4 +105,69 @@ export function resolveHeapAbortBoundary(
   return buildEmptyDiscoverResult(ID, {
     heapAbortedAtExtensionBoundary: true,
   });
+}
+
+/** Outcome of {@link resolveDegradedAnalysisBoundary}. */
+export interface AnalysisBoundaryDecision {
+  /**
+   * `true` when the heap was CRITICAL at the boundary and analysis will run at a
+   * degraded, minimal footprint instead of aborting to zero candidates.
+   */
+  degraded: boolean;
+  /** The knobs analysis should run with (degraded when `degraded === true`). */
+  knobs: AnalysisKnobs;
+  /** The heap sample taken at the boundary. */
+  sample: HeapGuardSample;
+  /** Log-ready summary of the reduced knobs — set only when `degraded`. */
+  reason?: string;
+}
+
+/**
+ * Degrade-and-continue analysis-extension boundary decision (Issue #3296).
+ *
+ * Replaces the historical abort-to-zero-candidates behaviour: when the heap is
+ * CRITICAL at the extension boundary, instead of returning an empty result the
+ * boundary **degrades the analysis footprint** (fewer focus neurons, smaller
+ * Rust FFI chunks — see {@link computeDegradedAnalysisKnobs}) and reports that
+ * analysis should continue at that minimal footprint. The degrade decision is
+ * logged with the reduced knob values so the smaller footprint is observable.
+ *
+ * When the heap is not CRITICAL the current knobs are returned unchanged and
+ * `degraded` is `false` — the happy path is untouched.
+ *
+ * The same helper serves the "starved at start" case: passing the starting
+ * knobs when the host is already memory-starved yields the minimal footprint to
+ * begin analysis with, rather than deferring or skipping.
+ *
+ * @param ID - Discovery ID for the log line.
+ * @param memoryConfig - Resolved memory config (thresholds + native budget).
+ * @param logger - Logger for the grep-friendly degrade-decision line.
+ * @param currentKnobs - The knobs analysis would otherwise run with.
+ * @param provider - Optional injected heap sample source (tests).
+ */
+export function resolveDegradedAnalysisBoundary(
+  ID: string,
+  memoryConfig: RequiredMemoryConfig,
+  logger: Logger,
+  currentKnobs: AnalysisKnobs,
+  provider?: MemoryUsageProvider,
+): AnalysisBoundaryDecision {
+  const sample = sampleHeapPressure(memoryConfig, provider);
+  if (!shouldAbortOnHeapPressure(sample, memoryConfig)) {
+    return { degraded: false, knobs: currentKnobs, sample };
+  }
+
+  const decision = computeDegradedAnalysisKnobs(currentKnobs);
+  const heapPct = (sample.usageFraction * 100).toFixed(0);
+  logger.warn(
+    `[Neat] Discovery ${ID} analysis DEGRADED at extension boundary ` +
+      `(heap CRITICAL ${heapPct}%): continuing at ${decision.reason} ` +
+      `(#3296)`,
+  );
+  return {
+    degraded: true,
+    knobs: decision.knobs,
+    sample,
+    reason: decision.reason,
+  };
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
@@ -30,7 +30,7 @@ import { runRecordingPhase } from "@architecture/ErrorGuidedStructuralEvolution/
 import { runAnalysisLoop } from "@architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts";
 import {
   buildEmptyDiscoverResult,
-  resolveHeapAbortBoundary,
+  resolveDegradedAnalysisBoundary,
 } from "@architecture/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts";
 import {
   computeRecordCoverage,
@@ -383,28 +383,28 @@ export class DataRecorder {
         attemptGc: this.config.memory.proactiveGc,
       });
 
-      // Issue #2594: Heap-aware extension guard.
-      // Before we extend the timeout to give analysis room to run, sample
-      // the heap. If MemoryMonitor reports CRITICAL pressure here, the
-      // analysis phase is very likely to OOM the worker — the
-      // critical-level cache eviction has already fired in earlier ticks
-      // and was not enough. Skip the extension entirely and reuse the
-      // partial-result path so the caller gets the same empty
-      // DiscoverResult shape as the recordingSuccess === false branch.
-      // Issue #2737/#3025: Surface a genuine heap-driven abort as a structured
-      // field on the DiscoverResult so the upstream training event pipeline can
-      // emit a `"heap_critical_skip"` outcome instead of indistinguishably
-      // reporting `"no_change"`. The guard is off-heap (RSS) aware, so a
-      // worker-default-heap CRITICAL with native-budget headroom returns `null`
-      // here (analysis continues, signal stays unset) — no false positive.
-      const heapAbortResult = resolveHeapAbortBoundary(
+      // Issue #2594/#3025/#3296: Heap-aware extension boundary — degrade, don't
+      // abort. Before extending the timeout for analysis, sample the heap. If
+      // the off-heap-aware guard reports CRITICAL pressure here (genuine
+      // budget exhaustion), the historical response was to skip analysis and
+      // return an empty, 0-candidate result. Issue #3296 replaces that abort
+      // with degrade-and-continue: reduce the analysis footprint (fewer focus
+      // neurons, smaller Rust FFI chunks) and push through to a genuine
+      // completion instead. The degrade decision is logged with the reduced
+      // knob values so the smaller footprint is observable. A worker-default
+      // heap CRITICAL with native-budget headroom is not degraded — the happy
+      // path is untouched (`degraded === false`).
+      const boundary = resolveDegradedAnalysisBoundary(
         this.ID,
         this.config.memory,
         getLogger(),
+        {
+          discoveryMaxNeurons: this.discoveryMaxNeurons,
+          analysisChunkSize: this.config.discoveryAnalysisChunkSize,
+        },
       );
-      if (heapAbortResult) {
-        return heapAbortResult;
-      }
+      const analysisMaxNeurons = boundary.knobs.discoveryMaxNeurons;
+      const analysisChunkSize = boundary.knobs.analysisChunkSize;
 
       // Extend timeout for analysis phase (clamped to the hard deadline)
       const analysisTimeoutMinutes = this.extendTimeoutForAnalysisPhase(
@@ -424,12 +424,17 @@ export class DataRecorder {
         {
           ID: this.ID,
           config: this.config,
-          discoveryMaxNeurons: this.discoveryMaxNeurons,
+          discoveryMaxNeurons: analysisMaxNeurons,
           costOfGrowth: this.config.costOfGrowth,
-          analysisChunkSize: this.config.discoveryAnalysisChunkSize,
+          analysisChunkSize: analysisChunkSize,
           perChunkMaxMs: this.config.discoveryAnalysisPerChunkMaxMs,
           getTimeoutTS: () => this.timeoutTS,
           refreshAnalysisTimeout: (ds) => this.refreshAnalysisTimeout(ds),
+          // #3296: when the boundary degraded under memory pressure, run at
+          // least one minimal-footprint pass before the in-loop heap guard may
+          // abort — so a starved host reaches a genuine completion instead of a
+          // zero-candidate abort at the very first iteration.
+          degradedFirstPass: boundary.degraded,
         },
         discoverStructure,
         perfStats,

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderAnalysis.ts
@@ -146,6 +146,15 @@ export interface AnalysisLoopContext {
    * should not set this.
    */
   readonly heapCriticalProbe?: () => boolean;
+  /**
+   * Degrade-and-continue signal (Issue #3296). When `true`, the extension
+   * boundary degraded the analysis footprint under CRITICAL heap pressure
+   * instead of aborting. In that case the in-loop heap guard must let the first
+   * (retryAttempt 0) minimal-footprint pass run to completion rather than
+   * aborting immediately — otherwise the degraded run would still abort to zero
+   * candidates. Subsequent iterations honour the guard normally.
+   */
+  readonly degradedFirstPass?: boolean;
 }
 
 /**
@@ -325,13 +334,26 @@ export async function runAnalysisLoop(
     // iteration and abort gracefully with whatever candidates we have rather
     // than pressing on into OOM.
     if (heapCritical()) {
-      heapAbortedFlag = true;
-      getLogger().warn(
-        `[Neat] Discovery ${
-          blue(ID)
-        } analysis aborted: heap CRITICAL during analysis loop after ${attemptedNeurons.size} neuron(s) [${formatStallMemoryDiagnostics()}]`,
-      );
-      break;
+      // #3296: degrade-and-continue. When the boundary degraded into a
+      // minimal-footprint pass, run the first (retryAttempt 0) pass to a
+      // genuine completion instead of aborting to zero candidates. Only the
+      // first pass is spared; later iterations honour the guard so a run that
+      // stays CRITICAL still bails out with whatever candidates it found.
+      if (ctx.degradedFirstPass && retryAttempt === 0) {
+        getLogger().warn(
+          `[Neat] Discovery ${
+            blue(ID)
+          } heap CRITICAL at degraded analysis start — running one minimal-footprint pass to completion [${formatStallMemoryDiagnostics()}] (#3296)`,
+        );
+      } else {
+        heapAbortedFlag = true;
+        getLogger().warn(
+          `[Neat] Discovery ${
+            blue(ID)
+          } analysis aborted: heap CRITICAL during analysis loop after ${attemptedNeurons.size} neuron(s) [${formatStallMemoryDiagnostics()}]`,
+        );
+        break;
+      }
     }
     // Allow callers (especially tests) to explicitly skip the analysis phase by
     // setting discoveryMaxNeurons to 0. This keeps record/flush coverage (FFI)
@@ -436,7 +458,13 @@ export async function runAnalysisLoop(
       // so heap can cross CRITICAL part-way through a multi-chunk iteration.
       // Stop submitting further chunks and return the partial result instead
       // of OOMing the worker.
-      if (heapCritical()) {
+      // #3296: on the degraded first pass, let the first (minimal-footprint)
+      // chunk run so the iteration reaches a genuine completion instead of
+      // aborting to zero candidates. Degraded focus breadth is small, so this
+      // is typically the only chunk; any later chunk still honours the guard.
+      const spareForDegradedPass = ctx.degradedFirstPass === true &&
+        retryAttempt === 0 && chunkIdx === 1;
+      if (heapCritical() && !spareForDegradedPass) {
         iterationHeapAborted = true;
         getLogger().warn(
           `[Neat] Discovery ${

--- a/test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the degrade-and-continue knob decision (Issue #3296).
+ *
+ * `computeDegradedAnalysisKnobs` is the single source of truth for the minimal
+ * analysis footprint used both at the CRITICAL-heap extension boundary and when
+ * a host is memory-starved at the start of a discovery run. These tests pin the
+ * reduction rules, the floors, and the observable reason string.
+ */
+import { assert, assertEquals } from "@std/assert";
+import {
+  computeDegradedAnalysisKnobs,
+  DEGRADED_ANALYSIS_CHUNK_SIZE,
+  MIN_DEGRADED_MAX_NEURONS,
+} from "@architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts";
+
+Deno.test("computeDegradedAnalysisKnobs: reduces focus breadth to a quarter and bounds chunk size", () => {
+  const decision = computeDegradedAnalysisKnobs({
+    discoveryMaxNeurons: 16,
+    analysisChunkSize: 32,
+  });
+  assertEquals(decision.knobs.discoveryMaxNeurons, 4); // ceil(16 * 0.25)
+  assertEquals(decision.knobs.analysisChunkSize, DEGRADED_ANALYSIS_CHUNK_SIZE);
+  // Both knobs reduced — the reason names each with from->to.
+  assertEquals(decision.reductions.length, 2);
+  assert(decision.reason.includes("maxNeurons 16->4"));
+  assert(decision.reason.includes("chunkSize 32->4"));
+});
+
+Deno.test("computeDegradedAnalysisKnobs: an unbounded chunk size is bounded to the degraded chunk", () => {
+  const decision = computeDegradedAnalysisKnobs({
+    discoveryMaxNeurons: 12,
+    analysisChunkSize: 0, // whole focus list in one FFI call
+  });
+  assertEquals(decision.knobs.analysisChunkSize, DEGRADED_ANALYSIS_CHUNK_SIZE);
+  assert(decision.reason.includes("chunkSize unbounded->4"));
+});
+
+Deno.test("computeDegradedAnalysisKnobs: focus breadth never drops below one neuron", () => {
+  const decision = computeDegradedAnalysisKnobs({
+    discoveryMaxNeurons: 1,
+    analysisChunkSize: 1,
+  });
+  assertEquals(decision.knobs.discoveryMaxNeurons, MIN_DEGRADED_MAX_NEURONS);
+  // Already minimal — nothing to reduce.
+  assertEquals(decision.reductions.length, 0);
+  assertEquals(decision.reason, "already at minimal footprint");
+});
+
+Deno.test("computeDegradedAnalysisKnobs: an already-small chunk size is left untouched", () => {
+  const decision = computeDegradedAnalysisKnobs({
+    discoveryMaxNeurons: 8,
+    analysisChunkSize: 2,
+  });
+  assertEquals(decision.knobs.analysisChunkSize, 2);
+  // Only the focus breadth was reduced.
+  assertEquals(decision.reductions.length, 1);
+  assertEquals(decision.reductions[0].knob, "maxNeurons");
+});
+
+Deno.test("computeDegradedAnalysisKnobs: starved-at-start large host yields a minimal footprint", () => {
+  // A starved host starting analysis with a wide breadth degrades to the
+  // minimal footprint immediately rather than deferring.
+  const decision = computeDegradedAnalysisKnobs({
+    discoveryMaxNeurons: 40,
+    analysisChunkSize: 64,
+  });
+  assert(decision.knobs.discoveryMaxNeurons < 40);
+  assert(decision.knobs.discoveryMaxNeurons >= MIN_DEGRADED_MAX_NEURONS);
+  assertEquals(decision.knobs.analysisChunkSize, DEGRADED_ANALYSIS_CHUNK_SIZE);
+});
+
+Deno.test("computeDegradedAnalysisKnobs: non-finite inputs fall back to the minimal footprint", () => {
+  const decision = computeDegradedAnalysisKnobs({
+    discoveryMaxNeurons: Number.NaN,
+    analysisChunkSize: Number.NaN,
+  });
+  assertEquals(decision.knobs.discoveryMaxNeurons, MIN_DEGRADED_MAX_NEURONS);
+  assertEquals(decision.knobs.analysisChunkSize, DEGRADED_ANALYSIS_CHUNK_SIZE);
+});

--- a/test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts
@@ -10,6 +10,7 @@
 import { assert, assertEquals } from "@std/assert";
 import {
   buildEmptyDiscoverResult,
+  resolveDegradedAnalysisBoundary,
   resolveHeapAbortBoundary,
 } from "@architecture/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts";
 import { DEFAULT_MEMORY_CONFIG } from "@config/MemoryConfig.ts";
@@ -109,4 +110,77 @@ Deno.test("resolveHeapAbortBoundary: monitoring disabled never aborts", () => {
     provider({ heapUsed: 260 * MB, heapTotal: 269 * MB }), // would be critical
   );
   assertEquals(decision, null);
+});
+
+function capturingLogger(): { logger: Logger; warnings: string[] } {
+  const warnings: string[] = [];
+  return {
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: (...args: unknown[]) => warnings.push(args.join(" ")),
+      error: () => {},
+    },
+    warnings,
+  };
+}
+
+Deno.test("resolveDegradedAnalysisBoundary: not critical returns the current knobs unchanged (happy path)", () => {
+  const { logger, warnings } = capturingLogger();
+  const decision = resolveDegradedAnalysisBoundary(
+    "disc-8",
+    DEFAULT_MEMORY_CONFIG,
+    logger,
+    { discoveryMaxNeurons: 16, analysisChunkSize: 32 },
+    provider({ heapUsed: 50 * MB, heapTotal: 269 * MB }), // ≈0.19, normal
+  );
+  assertEquals(decision.degraded, false);
+  assertEquals(decision.knobs.discoveryMaxNeurons, 16);
+  assertEquals(decision.knobs.analysisChunkSize, 32);
+  assertEquals(decision.reason, undefined);
+  assertEquals(warnings.length, 0);
+});
+
+Deno.test("resolveDegradedAnalysisBoundary: CRITICAL heap degrades and continues instead of aborting", () => {
+  const { logger, warnings } = capturingLogger();
+  const decision = resolveDegradedAnalysisBoundary(
+    "disc-9",
+    DEFAULT_MEMORY_CONFIG, // legacy CRITICAL (no native budget) → would-abort
+    logger,
+    { discoveryMaxNeurons: 16, analysisChunkSize: 32 },
+    provider({ heapUsed: 231 * MB, heapTotal: 269 * MB }), // ≈0.86, critical
+  );
+  assertEquals(decision.degraded, true);
+  // Footprint reduced — analysis continues at the minimal footprint.
+  assert(decision.knobs.discoveryMaxNeurons < 16);
+  assert(decision.knobs.analysisChunkSize < 32);
+  // The degrade decision is logged with the reduced knob values.
+  assertEquals(warnings.length, 1);
+  assert(warnings[0].includes("DEGRADED at extension boundary"));
+  assert(warnings[0].includes("maxNeurons 16->"));
+  assert(warnings[0].includes("chunkSize 32->"));
+});
+
+Deno.test("resolveDegradedAnalysisBoundary: genuine budget exhaustion degrades (no OOM-forcing abort)", () => {
+  // RSS over the native budget — the previous behaviour aborted to zero
+  // candidates. #3296 degrades to the minimal footprint and continues.
+  const config: RequiredMemoryConfig = {
+    ...DEFAULT_MEMORY_CONFIG,
+    nativeBudgetBytes: 8 * 1024 * MB,
+  };
+  const { logger } = capturingLogger();
+  const decision = resolveDegradedAnalysisBoundary(
+    "disc-10",
+    config,
+    logger,
+    { discoveryMaxNeurons: 12, analysisChunkSize: 0 },
+    provider({
+      heapUsed: 231 * MB,
+      heapTotal: 269 * MB,
+      rss: 9 * 1024 * MB, // over the 8 GB budget — genuine exhaustion
+      external: 47 * MB,
+    }),
+  );
+  assertEquals(decision.degraded, true);
+  assert(decision.knobs.discoveryMaxNeurons < 12);
 });

--- a/test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts
@@ -75,6 +75,12 @@ interface RunOptions {
   readonly memoryEnabled?: boolean;
   /** Off-heap (RSS) budget in bytes — Issue #3025. 0/undefined disables it. */
   readonly nativeBudgetBytes?: number;
+  /**
+   * Degrade-and-continue signal (Issue #3296): when true, the boundary degraded
+   * under memory pressure, so the loop must run one minimal-footprint pass to a
+   * genuine completion instead of aborting to zero candidates.
+   */
+  readonly degradedFirstPass?: boolean;
 }
 
 async function runWith(
@@ -144,6 +150,7 @@ async function runWith(
         perChunkMaxMs: 60_000,
         getTimeoutTS: () => deadlineMs,
         refreshAnalysisTimeout: () => {},
+        degradedFirstPass: options.degradedFirstPass,
       },
       structure,
       perfStats,
@@ -186,6 +193,29 @@ Deno.test(
       perfStats.neuronsAnalyzed,
       0,
       "no neurons analysed when aborting before the first chunk",
+    );
+  },
+);
+
+Deno.test(
+  "degrades footprint and continues at extension boundary instead of aborting",
+  async () => {
+    // Same persistently-CRITICAL heap as the abort-to-zero case above, but the
+    // boundary degraded (degradedFirstPass = true). The loop must run one
+    // minimal-footprint pass to a genuine completion instead of aborting with
+    // zero neurons analysed (Issue #3296).
+    const { perfStats, chunkCalls } = await runWith({
+      heapSample: { heapUsed: 95, heapTotal: 100 }, // CRITICAL
+      degradedFirstPass: true,
+    });
+
+    assert(
+      chunkCalls > 0,
+      "degraded first pass must submit at least one analysis chunk (no 0-candidate abort)",
+    );
+    assert(
+      perfStats.neuronsAnalyzed > 0,
+      "degraded first pass must analyse neurons rather than skip to zero",
     );
   },
 );


### PR DESCRIPTION
## Summary

Discovery now **degrades and continues** at the analysis-extension boundary
under CRITICAL heap pressure instead of aborting the iteration to zero
candidates. This is the NEAT-AI root-cause fix for **GRQ #3296** (part of
GRQ milestone #3267 — "Discovery OOM-killed on 16 GB host — adapt to host
memory").

Previously, when the off-heap-aware guard reported CRITICAL pressure at the
extension boundary (genuine native-budget exhaustion), `DataRecorder` skipped
the analysis phase and returned an empty `DiscoverResult` carrying
`heapAbortedAtExtensionBoundary: true` — a 0-candidate skip that the parent
issue classes as a failure ("a loud degraded skip … is still a failure").

Now the boundary reduces the analysis footprint (fewer focus neurons, smaller
Rust FFI chunks) and pushes through to a genuine completion — candidates, or an
honest no-improvement result. The degrade decision is logged with the reduced
knob values so the smaller footprint is observable.

### What changed

- **New `AnalysisDegradeDecision.ts`** — a pure, deterministic helper
  (`computeDegradedAnalysisKnobs`) that computes the minimal analysis footprint
  from the current knobs: focus breadth reduced to a quarter (floored at one
  neuron), analysis chunk size bounded to a small chunk. Returns a grep-friendly
  reason string naming each reduced knob and its `from->to` value.
- **`AnalysisExtensionBoundary.ts`** — added `resolveDegradedAnalysisBoundary`,
  which samples the heap through the same off-heap-aware guard and, when it
  would previously have aborted, returns `degraded: true` with the degraded
  knobs and logs the degrade decision, instead of building an empty result. The
  legacy `resolveHeapAbortBoundary` is retained (still unit-tested) but is no
  longer the production path.
- **`DataRecorder.ts`** — the extension boundary now calls
  `resolveDegradedAnalysisBoundary` and runs `runAnalysisLoop` with the degraded
  knobs plus a `degradedFirstPass` signal rather than returning early.
- **`DataRecorderAnalysis.ts`** — the in-loop heap guard honours
  `degradedFirstPass`: the first (retryAttempt 0) minimal-footprint pass runs to
  completion — including its first chunk — instead of aborting immediately, so a
  starved host reaches a genuine completion. Subsequent iterations honour the
  guard normally, so a run that stays CRITICAL still bails with whatever
  candidates it found.

```mermaid
flowchart TD
    A[Recording done] --> B{Heap CRITICAL at\nextension boundary?}
    B -- no --> C[Run analysis\nnormal footprint]
    B -- yes (was: abort → 0 candidates) --> D[Degrade footprint\nlog reduced knobs]
    D --> E[Run one minimal-footprint\npass to completion]
    E --> F{Still CRITICAL\nnext iteration?}
    F -- yes --> G[Stop with candidates\nfound so far]
    F -- no --> C
    C --> H[Genuine completion:\ncandidates or honest no-improvement]
    E --> H
```

## Evidence

Backend/library change — no UI. Verified via `deno test`:

- `test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` — 6 cases
  pinning the reduction rules, floors, unbounded-chunk handling, non-finite
  fallback, and the starved-at-start minimal footprint.
- `test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts` — added 3
  `resolveDegradedAnalysisBoundary` cases (happy path unchanged; CRITICAL
  degrades and logs; genuine budget exhaustion degrades instead of forcing an
  OOM-prone abort).
- `test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts` — added
  `degrades footprint and continues at extension boundary instead of aborting`,
  which forces persistent CRITICAL heap with `degradedFirstPass` and asserts the
  loop analyses neurons and submits a chunk (no 0-candidate abort), driven
  through the real `runAnalysisLoop`.

All existing extension-boundary, heap-guard, worker-payload, and outcome tests
continue to pass (`resolveHeapAbortBoundary` and the
`heapAbortedAtExtensionBoundary` wire contract are unchanged).

## Test Plan

- `deno test test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` — 6 passed
- `deno test test/ErrorGuidedStructuralEvolution/AnalysisExtensionBoundary.ts` — 10 passed
- `deno test test/ErrorGuidedStructuralEvolution/AnalysisLoopHeapGuard.ts` — 6 passed
- `deno test test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts` — 25 passed
- `deno test test/multithreading/WorkerProcessor.ts test/NEAT/DiscoveryOutcome.ts test/ErrorGuidedStructuralEvolution/DiscoveryTimeout.ts` — 17 passed
- `deno check` + `deno fmt` + `deno lint` clean on all changed files

---
Cross-repo root-cause fix for **stSoftwareAU/GRQ#3296** (milestone GRQ#3267). The consuming GRQ repo is bumped to a released version through the normal dependency-bump flow once this is released — no pre-release / git-ref bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)