### PR TITLE
Multi-fidelity fitness: deterministic ranking-pass corpus subsample (Issue #3257)

### DIFF
--- a/bench/FitnessSampleRate.ts
+++ b/bench/FitnessSampleRate.ts
@@ -1,0 +1,175 @@
+/**
+ * Benchmark for the fitness ranking-pass subsample (Issue #3257).
+ *
+ * Measures the two things the issue's merge gate cares about, on a
+ * representative synthetic binary corpus (no production data required):
+ *
+ *  1. **Wall-clock** — how `evaluateDir` scoring time scales with
+ *     `fitnessSampleRate` (1.0 → 0.5 → 0.25 → 0.1). The forward-only fused
+ *     WASM path is exercised, matching the production scorer shape.
+ *  2. **Quality** — the Spearman (rank) correlation between each subsample's
+ *     per-creature scores and the full-corpus scores across a frozen
+ *     population. This is the "does rank order survive the subsample?" signal;
+ *     the issue suggests ≥ 0.95 before recommending a preset.
+ *
+ * Usage:
+ *   deno run --allow-read --allow-write --allow-env --allow-ffi \
+ *     bench/FitnessSampleRate.ts
+ *
+ * This is a `deno run` app (not a `Deno.bench` harness) so it is excluded from
+ * `deno bench` in `deno.json`.
+ *
+ * Reference run (27.5 MiB synthetic corpus, population 24; Issue #3257):
+ *
+ *   rate    wall-clock    speedup   spearman-vs-full
+ *   ------  -----------  --------  ----------------
+ *    1.00      3738ms     1.02×            1.0000
+ *    0.50      2104ms     1.80×            1.0000
+ *    0.25      1067ms     3.56×            0.9991
+ *    0.10       468ms     8.11×            1.0000
+ *
+ * Wall-clock falls ~proportionally to the rate; rank order (Spearman) stays
+ * ≥ 0.999 — well above the suggested 0.95 preset gate — on this uniform
+ * synthetic workload. Real production corpora may correlate less, so the
+ * default stays 1.0 (full corpus) and enabling a sub-1 preset should be
+ * confirmed against the production corpus first.
+ */
+
+import { Creature } from "@creature";
+import { Costs } from "@costs";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import { ensureWasmActivation } from "@wasm/EnsureWasmActivation.ts";
+import { calculate as calculateScore } from "@architecture/Score.ts";
+
+const INPUT = 32;
+const OUTPUT = 4;
+const RECORDS = 200_000; // ~ (32+4)*4*200k ≈ 27 MiB corpus
+const POPULATION = 24;
+const RATES = [1, 0.5, 0.25, 0.1];
+
+/** Deterministic LCG so the corpus and population are reproducible. */
+function lcg(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (Math.imul(s, 1_664_525) + 1_013_904_223) >>> 0;
+    return s / 0xffff_ffff;
+  };
+}
+
+function buildCorpus(): DataRecordInterface[] {
+  const rng = lcg(3257);
+  const rows: DataRecordInterface[] = new Array(RECORDS);
+  for (let i = 0; i < RECORDS; i++) {
+    const input = new Float32Array(INPUT);
+    for (let k = 0; k < INPUT; k++) input[k] = rng() * 2 - 1;
+    const output = new Float32Array(OUTPUT);
+    for (let k = 0; k < OUTPUT; k++) output[k] = rng();
+    rows[i] = { input, output };
+  }
+  return rows;
+}
+
+function buildPopulation(): Creature[] {
+  const pop: Creature[] = [];
+  for (let i = 0; i < POPULATION; i++) {
+    const c = new Creature(INPUT, OUTPUT, {
+      layers: [{ count: 16 }, { count: 8 }],
+    });
+    // Diversify weights so the population has a genuine score spread.
+    const rng = lcg(1000 + i);
+    for (const syn of c.synapses) syn.weight = rng() * 2 - 1;
+    pop.push(c);
+  }
+  return pop;
+}
+
+/** Spearman rank correlation of two equal-length numeric arrays. */
+function spearman(a: number[], b: number[]): number {
+  const rank = (xs: number[]): number[] => {
+    const order = xs.map((v, i) => [v, i] as const).sort((p, q) => p[0] - q[0]);
+    const r = new Array<number>(xs.length);
+    for (let i = 0; i < order.length; i++) r[order[i][1]] = i;
+    return r;
+  };
+  const ra = rank(a);
+  const rb = rank(b);
+  const n = a.length;
+  const mean = (n - 1) / 2;
+  let num = 0;
+  let da = 0;
+  let db = 0;
+  for (let i = 0; i < n; i++) {
+    const x = ra[i] - mean;
+    const y = rb[i] - mean;
+    num += x * y;
+    da += x * x;
+    db += y * y;
+  }
+  return da === 0 || db === 0 ? 1 : num / Math.sqrt(da * db);
+}
+
+async function scorePopulation(
+  pop: Creature[],
+  dir: string,
+  rate: number,
+): Promise<{ scores: number[]; ms: number }> {
+  const cost = Costs.find("MSE");
+  const scores: number[] = [];
+  const start = performance.now();
+  for (const c of pop) {
+    // deno-lint-ignore no-await-in-loop -- sequential scoring is the measured workload.
+    const { error } = await c.evaluateDir(
+      dir,
+      cost,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      rate,
+    );
+    // Same fitness transform the evolution loop applies, so the ranking we
+    // correlate is the one selection would actually see.
+    scores.push(calculateScore(c, error, 0.000_000_1));
+  }
+  return { scores, ms: performance.now() - start };
+}
+
+async function main() {
+  await ensureWasmActivation();
+  console.log(
+    `Corpus: ${RECORDS.toLocaleString()} records × ${INPUT}in/${OUTPUT}out ` +
+      `(${((RECORDS * (INPUT + OUTPUT) * 4) / 1024 / 1024).toFixed(1)} MiB); ` +
+      `population ${POPULATION}`,
+  );
+
+  const dir = makeDataDir(buildCorpus(), RECORDS);
+  try {
+    const pop = buildPopulation();
+    // Warm the WASM compilation cache so the first rate is not penalised.
+    await scorePopulation(pop, dir, 1);
+
+    const baseline = await scorePopulation(pop, dir, 1);
+    console.log("\nrate    wall-clock    speedup   spearman-vs-full");
+    console.log("------  -----------  --------  ----------------");
+    for (const rate of RATES) {
+      // deno-lint-ignore no-await-in-loop -- rates are measured one at a time.
+      const run = await scorePopulation(pop, dir, rate);
+      const speedup = baseline.ms / run.ms;
+      const rho = spearman(run.scores, baseline.scores);
+      console.log(
+        `${rate.toFixed(2).padStart(5)}  ${
+          `${run.ms.toFixed(0)}ms`.padStart(10)
+        }  ${`${speedup.toFixed(2)}×`.padStart(8)}  ${
+          rho.toFixed(4).padStart(16)
+        }`,
+      );
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/deno.json
+++ b/deno.json
@@ -82,6 +82,7 @@
       "bench/DenseNumberMapBenchmark.ts",
       "bench/DiscoveryAnalysisCacheRelease.ts",
       "bench/FastConvergencePreset.ts",
+      "bench/FitnessSampleRate.ts",
       "bench/GenerationalInertiaSchedule.ts",
       "bench/IncrementalScoreUpdate.ts",
       "bench/MainThreadScoreWork.ts",

--- a/docs/PERFORMANCE_TUNING.md
+++ b/docs/PERFORMANCE_TUNING.md
@@ -62,6 +62,7 @@ this guide assume you can observe the same metrics live.
 - [Thread Pool Configuration](#thread-pool-configuration)
 - [Memory Management](#memory-management)
 - [Population Size and Selection Pressure](#population-size-and-selection-pressure)
+- [Fitness Corpus Subsampling](#fitness-corpus-subsampling)
 - [When to Enable WASM Activation](#when-to-enable-wasm-activation)
 - [Discovery and GPU Acceleration](#discovery-and-gpu-acceleration)
 - [Memetic Evolution (Backpropagation + Evolution)](#memetic-evolution-backpropagation--evolution)
@@ -514,6 +515,66 @@ rates for large creatures.
 - **Set to 0** to completely disable topology expansion for large creatures.
 - **Raise towards 1.0** only if your problem genuinely requires very large,
   structurally diverse networks.
+
+---
+
+## 🎯 Fitness Corpus Subsampling
+
+`fitnessSampleRate` (Issue #3257) trades a small amount of ranking precision for
+a large cut in per-generation scoring work. In production evolution ≈95 % of
+`evolveDir` wall-clock is fitness evaluation against a multi-GiB binary corpus,
+so scoring each creature on a **deterministic, stratified subsample** of records
+is the single largest algorithmic lever available.
+
+- **Range:** `0.0001 … 1`. **Default `1`** (score the full corpus — today's
+  behaviour, unchanged unless you opt in).
+- **What it does:** on the streaming `evaluateDir` reader, a record at global
+  index `i` is kept iff `floor((i + 1) × rate) > floor(i × rate)`. This keeps
+  exactly `floor(N × rate)` records, spread evenly (a stride), in a single pass
+  — **no second corpus is written to disk**. The selection is RNG-free, so the
+  same creature on the same corpus always sees the same records and rank
+  comparisons stay honest.
+- **Why it wins:** halving the scored records roughly halves the 95 % phase —
+  far larger than another few-percent kernel tweak — **provided** rank order on
+  the subsample tracks the full-corpus rank for your workload.
+
+```typescript
+// Score each creature on a deterministic 25 % of the corpus per generation.
+await creature.evolveDir(".training", {
+  fitnessSampleRate: 0.25,
+});
+```
+
+### Before you enable a sub-1 rate
+
+Run `bench/FitnessSampleRate.ts` against a representative corpus and confirm the
+**Spearman (rank) correlation** of subsample vs full scores stays high (≥ 0.95
+is a sensible bar) across a frozen population. On a uniform synthetic 27 MiB
+corpus the reference run shows wall-clock falling ~proportionally to the rate
+with Spearman ≥ 0.999:
+
+| rate | wall-clock | speedup | Spearman vs full |
+| ---: | ---------: | ------: | ---------------: |
+| 1.00 |     3738ms |   1.02× |           1.0000 |
+| 0.50 |     2104ms |   1.80× |           1.0000 |
+| 0.25 |     1067ms |   3.56× |           0.9991 |
+| 0.10 |      468ms |   8.11× |           1.0000 |
+
+Real production corpora may correlate less than a uniform synthetic one, so keep
+the default at `1.0` until the correlation is confirmed on your data. When the
+external `rust_scorer` batch path is enabled, a sub-1 rate currently stays on
+the TS/WASM path (the native binary cannot yet skip records) — record-level
+subsampling inside the streaming reader is tracked as a scorer follow-up.
+
+```mermaid
+flowchart LR
+    A[Population] --> B{fitnessSampleRate}
+    B -- "= 1 (default)" --> C[Score full corpus]
+    B -- "< 1" --> D[Stratified stride:<br/>keep floor N×rate records]
+    D --> E[Score subsample<br/>one pass, records skipped]
+    C --> F[Rank + select]
+    E --> F
+```
 
 ---
 

--- a/docs/archive/pr-summaries/pr-summary-3257.md
+++ b/docs/archive/pr-summaries/pr-summary-3257.md
@@ -1,0 +1,92 @@
+## Summary
+
+Adds an optional **multi-fidelity fitness** knob, `fitnessSampleRate`, that
+scores each creature on a **deterministic, stratified subsample** of the binary
+fitness corpus during the per-generation ranking pass. Production evolution
+spends ≈95 % of `evolveDir` wall-clock in fitness evaluation, so scoring fewer
+records per generation is the single largest algorithmic lever available. The
+subsample is applied inside the streaming `evaluateDir` reader — records are
+skipped in **one pass, with no second corpus written to disk** — and the
+**default stays `1.0`** (score the full corpus), so production quality is
+unchanged unless a run opts in. **Closes #3257.**
+
+Scope note (honest deferral): the issue targets the forward-only **Rust batch**
+scorer path for the full production off-load. The native `rust_scorer` binary
+cannot yet skip records inside its streaming reader, so a sub-`1` rate currently
+stays on the TS/WASM path (which this PR fully implements and benchmarks). The
+record-level skip in the scorer — plus the elite full-corpus **confirmation
+pass** and the production 21 GiB corpus + Spearman ≥ 0.95 gate — is tracked as a
+follow-up (see below), because it needs a scorer release and the production
+corpus that this bench host does not have.
+
+### What changed
+
+- `src/creature/FitnessSubsample.ts` — pure, RNG-free stride selector: keep
+  record `i` iff `floor((i+1)·rate) > floor(i·rate)` (keeps exactly
+  `floor(N·rate)` records, evenly spread, fully deterministic across generations
+  and machines). Plus `resolveFitnessSampleRate` clamp and
+  `expectedSampledCount`.
+- `evaluateDir` (`CreatureActivation.ts`) — applies the subsample on **both**
+  the fused-WASM path (compacts each batch to the sampled records before the
+  single fused call) and the per-record path. Full rate (`1`) takes the original
+  code path with zero added work. A sub-`1` rate skips the native off-load so
+  the requested subsample is honoured.
+- Config — `fitnessSampleRate` added to `NeatArguments`, `NeatOptions`
+  (numeric-coercible), and `createNeatConfig` (validated `0.0001..1`, default
+  `1`), mirroring `trainingSampleRate`. Threaded through the worker init payload
+  (`WorkerHandler` → `WorkerProcessor` → `evaluateDir`) so `evolveDir` honours
+  it on the worker path.
+- `bench/FitnessSampleRate.ts` — wall-clock + Spearman correlation harness.
+- `docs/PERFORMANCE_TUNING.md` — new **Fitness Corpus Subsampling** section.
+
+```mermaid
+flowchart LR
+    A[Population] --> B{fitnessSampleRate}
+    B -- "= 1 (default)" --> C[Score full corpus]
+    B -- "< 1" --> D[Stratified stride:<br/>keep floor N×rate records]
+    D --> E[Score subsample<br/>one pass, records skipped]
+    C --> F[Rank + select]
+    E --> F
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified by benchmark and
+unit tests.
+
+**Benchmark** (`bench/FitnessSampleRate.ts`, 27.5 MiB synthetic corpus,
+population 24, forward-only fused WASM path):
+
+| rate | wall-clock | speedup | Spearman vs full |
+| ---: | ---------: | ------: | ---------------: |
+| 1.00 |     3738ms |   1.02× |           1.0000 |
+| 0.50 |     2104ms |   1.80× |           1.0000 |
+| 0.25 |     1067ms |   3.56× |           0.9991 |
+| 0.10 |      468ms |   8.11× |           1.0000 |
+
+Wall-clock falls ~proportionally to the rate (well past the ≥ 5 % gate); rank
+order (Spearman) stays ≥ 0.999, above the suggested 0.95 preset bar, on this
+uniform synthetic workload. Real production corpora may correlate less, which is
+exactly why the **default is `1.0`** and enabling a sub-`1` preset should be
+confirmed against the production corpus first (the follow-up covers that on the
+GRQ corpus).
+
+## Test Plan
+
+- `test/creature/FitnessSubsample.ts` — stride maths: rate clamp, exact
+  `floor(N·rate)` count, even stratification, determinism, phase rotation.
+- `test/creature/FitnessSubsampleEvaluateDir.ts` — integration "what" tests:
+  scoring the full corpus at `0.5` yields the **same** error as scoring a corpus
+  containing only the sampled records (proving the reader kept exactly the
+  stride and did less work), on both the fused and per-record paths; default `1`
+  reproduces the full-corpus error exactly.
+- `test/config/NeatConfigParseOptions.ts` — `fitnessSampleRate` default,
+  number/string coercion, and out-of-range / non-numeric validation errors.
+
+## Follow-up
+
+The production Rust-batch off-load (record-level skip in the `rust_scorer`
+streaming reader) and the elite full-corpus confirmation pass are tracked in
+**stSoftwareAU/NEAT-AI-scorer#310**, cross-linked from this issue — they require
+a scorer release and the production 21 GiB corpus for the merge-gate correlation
+study, which this bench host cannot run.

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1124,6 +1124,9 @@ export class Creature implements CreatureInternal {
     cachedFiles?: string[],
     rustScorer?:
       import("./config/RustScorerConfig.ts").RequiredRustScorerConfig,
+    // Issue #3257: Optional ranking-pass subsample rate in (0, 1]. Default 1
+    // scores the full corpus (unchanged behaviour).
+    fitnessSampleRate?: number,
   ): Promise<{ error: number }> {
     return activation.evaluateDir(
       this,
@@ -1133,6 +1136,7 @@ export class Creature implements CreatureInternal {
       outputRanges,
       cachedFiles,
       rustScorer,
+      fitnessSampleRate,
     );
   }
 

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -238,6 +238,16 @@ export interface NeatArguments {
   /** The percentage of observations that will be used for training. Range 0..1 */
   trainingSampleRate: number;
 
+  /**
+   * Issue #3257: Fraction of the binary fitness corpus scored per creature
+   * during the per-generation ranking pass. A deterministic, stratified
+   * subsample (records skipped in one streaming pass — no second corpus on
+   * disk) so scoring does proportionally less work while preserving rank
+   * order. Range 0.0001..1; default 1 (score the full corpus — today's
+   * behaviour, so production quality is unchanged unless opted in).
+   */
+  fitnessSampleRate: number;
+
   /** The target error to reach, once the network falls below this error, the process is stopped. Default: 0.05, Range 0..1 */
   targetError: number;
 

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -313,6 +313,14 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
       1,
       { min: 0.0001, max: 1 },
     ),
+    // Issue #3257: Ranking-pass fitness corpus subsample. Default 1 = full
+    // corpus (unchanged behaviour); mirrors the trainingSampleRate bounds.
+    fitnessSampleRate: parseNumber(
+      "Fitness Sample Rate",
+      opts.fitnessSampleRate,
+      1,
+      { min: 0.0001, max: 1 },
+    ),
 
     debug: options.debug === true || getGlobalDebug(),
 

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -46,6 +46,7 @@ type NumericOptionKeys =
   | "creativeThinkingConnectionCount"
   | "dataSetPartitionBreak"
   | "trainingSampleRate"
+  | "fitnessSampleRate"
   | "focusRate"
   | "targetError"
   | "costOfGrowth"

--- a/src/creature/CreatureActivation.ts
+++ b/src/creature/CreatureActivation.ts
@@ -31,6 +31,10 @@ import {
 } from "@wasm/WasmCreatureActivationLRU.ts";
 import { tryScoreWithRustScorer } from "../score/RustScorerBridge.ts";
 import { BUILT_IN_COST_NAMES, type BuiltInCostName } from "@costs";
+import {
+  resolveFitnessSampleRate,
+  shouldScoreRecord,
+} from "./FitnessSubsample.ts";
 
 /**
  * Verify WASM is available and the creature is eligible.
@@ -401,6 +405,14 @@ function applyWasmTraceData(
  * Issue #1229: WASM is required by default with no fallback.
  * Issue #2260: Accepts optional pre-cached file list to avoid repeated
  * directory scans in long-lived workers.
+ * Issue #3257: Accepts an optional `fitnessSampleRate` in `(0, 1]`. When below
+ * `1`, the streaming reader scores each creature on a deterministic,
+ * stratified subsample of records (one pass, records skipped — no second
+ * corpus on disk) so the ranking pass does proportionally less work. The
+ * default `1` preserves today's full-corpus behaviour exactly. Because the
+ * external `rust_scorer` cannot yet skip records, a sub-`1` rate stays on the
+ * TS/WASM path rather than off-loading a full-corpus score that would
+ * contradict the requested subsample.
  */
 export async function evaluateDir(
   creature: Creature,
@@ -410,9 +422,15 @@ export async function evaluateDir(
   outputRanges?: ReadonlyArray<RequiredOutputRange>,
   cachedFiles?: string[],
   rustScorer?: RequiredRustScorerConfig,
+  fitnessSampleRate?: number,
 ): Promise<{ error: number }> {
   const files = cachedFiles ?? dataFiles(dataDir).files;
   assert(files.length > 0, "No data files found");
+
+  // Issue #3257: Resolve the ranking-pass subsample rate. `1` (default) means
+  // score every record; a sub-`1` rate keeps a deterministic stratified stride.
+  const sampleRate = resolveFitnessSampleRate(fitnessSampleRate);
+  const subsampling = sampleRate < 1;
 
   // Issue #1247: Auto-initialise WASM before scoring if not yet available.
   const { ensureWasmActivation } = await import("../wasm/mod.ts");
@@ -427,7 +445,10 @@ export async function evaluateDir(
       ? (configuredCostName as BuiltInCostName)
       : undefined;
 
-  if (builtInCost !== undefined) {
+  // Issue #3257: Skip the native off-load when a subsample is requested — the
+  // external binary would score the full corpus and disagree with the
+  // subsampled ranking. Full-rate scoring off-loads exactly as before.
+  if (builtInCost !== undefined && !subsampling) {
     const rustResult = await tryScoreWithRustScorer(
       creature,
       dataDir,
@@ -503,6 +524,18 @@ export async function evaluateDir(
       costName as typeof supportedFusedCosts[number],
     );
 
+  // Issue #3257: When subsampling, the fused path compacts each batch down to
+  // only the sampled records before the single fused WASM call, so the WASM
+  // work drops proportionally to the rate while staying one call per batch.
+  // Allocated once and reused; left null on the default full-rate path so
+  // nothing changes for production.
+  const compactArray = subsampling && useFusedWasm
+    ? new Float32Array(BATCH_SIZE * valuesCount)
+    : null;
+  // 0-based record position across every shard and batch — drives the
+  // deterministic stratified stride in `shouldScoreRecord`.
+  let globalRecordIndex = 0;
+
   for (let fileIndx = files.length; fileIndx--;) {
     const filePath = files[fileIndx];
     // deno-lint-ignore no-sync-fn-in-async-fn -- Intentional: synchronous I/O for batch processing performance.
@@ -521,8 +554,31 @@ export async function evaluateDir(
         );
 
         if (useFusedWasm) {
-          const floatsRead = recordsRead * valuesCount;
-          const slice = batchArray.subarray(0, floatsRead);
+          // Issue #3257: On the subsample path, compact the batch to only the
+          // sampled records and score that slice; otherwise score the whole
+          // batch exactly as before (zero overhead at full rate).
+          let slice: Float32Array;
+          let recordsScored: number;
+          if (subsampling) {
+            let compactRecords = 0;
+            for (let r = 0; r < recordsRead; r++) {
+              if (shouldScoreRecord(globalRecordIndex + r, sampleRate)) {
+                const src = r * valuesCount;
+                compactArray!.set(
+                  batchArray.subarray(src, src + valuesCount),
+                  compactRecords * valuesCount,
+                );
+                compactRecords++;
+              }
+            }
+            globalRecordIndex += recordsRead;
+            recordsScored = compactRecords;
+            if (compactRecords === 0) continue;
+            slice = compactArray!.subarray(0, compactRecords * valuesCount);
+          } else {
+            slice = batchArray.subarray(0, recordsRead * valuesCount);
+            recordsScored = recordsRead;
+          }
           const wasm = creature.cachedWasmActivation!;
 
           // Issue #2214: Wrap fused WASM batch calls in try-catch so that
@@ -560,11 +616,19 @@ export async function evaluateDir(
             );
             return { error: Number.MAX_SAFE_INTEGER };
           }
-          count += recordsRead;
+          count += recordsScored;
           continue;
         }
 
         for (let recordIndex = 0; recordIndex < recordsRead; recordIndex++) {
+          // Issue #3257: Skip records outside the deterministic stratified
+          // subsample. `globalRecordIndex` advances for every record so the
+          // stride is stable across batches and shards.
+          const keepRecord = !subsampling ||
+            shouldScoreRecord(globalRecordIndex, sampleRate);
+          globalRecordIndex++;
+          if (!keepRecord) continue;
+
           const offset = recordIndex * valuesCount;
           const inputEnd = offset + creature.input;
           const observations = batchArray.subarray(offset, inputEnd);

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -485,6 +485,8 @@ export async function evolveDir(
       config.customCost,
       config.wasmCache,
       outputRanges,
+      // Issue #3257: ranking-pass fitness corpus subsample rate.
+      config.fitnessSampleRate,
     );
     try {
       // deno-lint-ignore no-await-in-loop
@@ -507,6 +509,8 @@ export async function evolveDir(
           config.customCost,
           config.wasmCache,
           outputRanges,
+          // Issue #3257: ranking-pass fitness corpus subsample rate.
+          config.fitnessSampleRate,
         );
         // deno-lint-ignore no-await-in-loop
         await w.waitUntilReady();

--- a/src/creature/FitnessSubsample.ts
+++ b/src/creature/FitnessSubsample.ts
@@ -1,0 +1,83 @@
+/**
+ * Deterministic, stratified record subsampling for fitness evaluation
+ * (Issue #3257).
+ *
+ * Production evolution spends ≈95 % of `evolveDir` wall-clock scoring every
+ * creature against a multi-GiB binary corpus. The largest remaining lever is
+ * algorithmic: score each creature on a deterministic **subsample** of records
+ * during the ranking pass, then confirm the elite on the full corpus. This
+ * module owns the pure record-selection maths so both the streaming
+ * `evaluateDir` reader and the tests share one implementation.
+ *
+ * The selection is intentionally **RNG-free**: a record at global index `i` is
+ * kept iff `floor((i + 1) * rate) > floor(i * rate)`. This keeps exactly
+ * `floor(N * rate)` records out of any prefix of `N`, spread as evenly as
+ * possible (a stratified stride), and is fully deterministic across
+ * generations and machines — a creature scored on the same corpus with the
+ * same rate always sees the same records, so rank comparisons stay honest.
+ *
+ * An optional integer `phase` rotates the stride so different generations can
+ * sample different strata without a random seed; `phase = 0` is the canonical
+ * deterministic ordering.
+ *
+ * @module FitnessSubsample
+ */
+
+/** Minimum permitted fitness sample rate — mirrors `trainingSampleRate`. */
+export const MIN_FITNESS_SAMPLE_RATE = 0.0001;
+
+/** Default fitness sample rate: score the full corpus (today's behaviour). */
+export const DEFAULT_FITNESS_SAMPLE_RATE = 1;
+
+/**
+ * Clamp a caller-supplied fitness sample rate into the valid `[MIN, 1]` range.
+ *
+ * `undefined`, non-finite, or out-of-range values collapse to the nearest
+ * bound (with `undefined`/non-finite defaulting to `1` — the full corpus),
+ * mirroring `resolveTrainingSampleRate` in `TrainingSetup.ts` so the two
+ * sampling knobs behave identically.
+ */
+export function resolveFitnessSampleRate(rate?: number): number {
+  if (rate === undefined || !Number.isFinite(rate)) {
+    return DEFAULT_FITNESS_SAMPLE_RATE;
+  }
+  return Math.min(1, Math.max(MIN_FITNESS_SAMPLE_RATE, rate));
+}
+
+/**
+ * Whether the record at `globalIndex` (0-based, counted across every shard and
+ * batch of the corpus) is part of the deterministic stratified subsample.
+ *
+ * At `rate >= 1` every record is kept, so callers should short-circuit the
+ * whole subsample machinery when the rate is `1` to avoid per-record overhead
+ * on the default path.
+ *
+ * @param globalIndex - 0-based record position across the whole corpus.
+ * @param rate - Resolved sample rate in `(0, 1]`.
+ * @param phase - Optional non-negative integer stride rotation (default 0).
+ */
+export function shouldScoreRecord(
+  globalIndex: number,
+  rate: number,
+  phase: number = 0,
+): boolean {
+  if (rate >= 1) return true;
+  if (globalIndex < 0) return false;
+  // Rotate by `phase` records so different generations sample different
+  // strata while keeping the even stride and full determinism.
+  const shifted = globalIndex + phase;
+  return Math.floor((shifted + 1) * rate) > Math.floor(shifted * rate);
+}
+
+/**
+ * Number of records the stratified stride keeps out of the first `total`
+ * records at `rate` — exactly `floor(total * rate)` for `phase = 0`.
+ *
+ * Exposed for callers and tests that need to reason about the sampled count
+ * (e.g. asserting a wall-clock saving is proportional to the rate).
+ */
+export function expectedSampledCount(total: number, rate: number): number {
+  if (total <= 0) return 0;
+  if (rate >= 1) return total;
+  return Math.floor(total * resolveFitnessSampleRate(rate));
+}

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -97,6 +97,13 @@ export interface RequestData {
      * evaluation error for outputs that fall outside the specified ranges.
      */
     outputRanges?: ReadonlyArray<RequiredOutputRange>;
+    /**
+     * Issue #3257: Ranking-pass fitness corpus subsample rate in (0, 1].
+     * When below 1, the worker's `evaluateDir` scores each creature on a
+     * deterministic stratified subsample of records. Omitted/1 scores the
+     * full corpus (unchanged behaviour).
+     */
+    fitnessSampleRate?: number;
   };
   /** Creature evaluation request */
   evaluate?: {
@@ -328,6 +335,8 @@ export class WorkerHandler
     customCost?: { filePath: string },
     wasmCache?: WasmCacheConfig,
     outputRanges?: ReadonlyArray<RequiredOutputRange>,
+    // Issue #3257: Ranking-pass fitness corpus subsample rate in (0, 1].
+    fitnessSampleRate?: number,
   ) {
     let rejectInitError: ((err: Error) => void) | null = null;
     const initErrorPromise: Promise<never> = new Promise((_, reject) => {
@@ -417,6 +426,12 @@ export class WorkerHandler
           wasmCache,
           outputRanges: outputRanges && outputRanges.length > 0
             ? outputRanges
+            : undefined,
+          // Issue #3257: forward the ranking-pass subsample rate; omit at the
+          // default 1 so the wire payload is unchanged for full-corpus runs.
+          fitnessSampleRate: fitnessSampleRate !== undefined &&
+              fitnessSampleRate < 1
+            ? fitnessSampleRate
             : undefined,
         },
       };

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -94,6 +94,9 @@ export class WorkerProcessor {
   /** Issue #1620: Per-output range constraints for fitness penalty. */
   private outputRanges?: ReadonlyArray<RequiredOutputRange>;
 
+  /** Issue #3257: Ranking-pass fitness corpus subsample rate in (0, 1]. */
+  private fitnessSampleRate?: number;
+
   private wasmInitAttempted = false;
 
   /** Issue #2260: Cache dataset file list across evaluate calls. */
@@ -186,6 +189,9 @@ export class WorkerProcessor {
         this.outputRanges = data.initialize.outputRanges;
       }
 
+      // Issue #3257: Store the ranking-pass subsample rate (if opted in).
+      this.fitnessSampleRate = data.initialize.fitnessSampleRate;
+
       return {
         taskID: data.taskID,
         duration: Date.now() - start,
@@ -241,6 +247,9 @@ export class WorkerProcessor {
           data.evaluate.feedbackLoop,
           this.outputRanges,
           cachedFiles,
+          undefined,
+          // Issue #3257: apply the ranking-pass subsample when opted in.
+          this.fitnessSampleRate,
         );
 
         return {

--- a/test/config/NeatConfigParseOptions.ts
+++ b/test/config/NeatConfigParseOptions.ts
@@ -161,3 +161,38 @@ Deno.test("NeatConfigParseOptions - discoveryRecordTimeOutMinutes accepts overri
     1,
   );
 });
+
+// Issue #3257: fitnessSampleRate — ranking-pass corpus subsample.
+Deno.test("NeatConfigParseOptions - fitnessSampleRate defaults to 1", () => {
+  assertEquals(createNeatConfig({}).fitnessSampleRate, 1);
+});
+
+Deno.test("NeatConfigParseOptions - fitnessSampleRate accepts number", () => {
+  assertEquals(
+    createNeatConfig({ fitnessSampleRate: 0.25 }).fitnessSampleRate,
+    0.25,
+  );
+});
+
+Deno.test("NeatConfigParseOptions - fitnessSampleRate accepts string", () => {
+  assertEquals(
+    createNeatConfig({ fitnessSampleRate: "0.1" }).fitnessSampleRate,
+    0.1,
+  );
+});
+
+Deno.test("NeatConfigParseOptions - fitnessSampleRate out of range throws clear error", () => {
+  const error = assertThrows(
+    () => createNeatConfig({ fitnessSampleRate: 2 }),
+    Error,
+  );
+  assertStringIncludes(error.message, "Fitness Sample Rate must be between");
+});
+
+Deno.test("NeatConfigParseOptions - fitnessSampleRate invalid string throws clear error", () => {
+  const error = assertThrows(
+    () => createNeatConfig({ fitnessSampleRate: "abc" }),
+    Error,
+  );
+  assertStringIncludes(error.message, "Fitness Sample Rate must be a number");
+});

--- a/test/creature/FitnessSubsample.ts
+++ b/test/creature/FitnessSubsample.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the deterministic, stratified fitness record subsample
+ * (Issue #3257).
+ *
+ * These verify the pure selection maths that both the streaming `evaluateDir`
+ * reader and the ranking-pass benchmark rely on: the rate clamp mirrors
+ * `trainingSampleRate`, the stride keeps exactly `floor(N * rate)` records,
+ * the selection is fully deterministic (no RNG), and the optional phase
+ * rotates the strata without changing the kept count.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  DEFAULT_FITNESS_SAMPLE_RATE,
+  expectedSampledCount,
+  MIN_FITNESS_SAMPLE_RATE,
+  resolveFitnessSampleRate,
+  shouldScoreRecord,
+} from "../../src/creature/FitnessSubsample.ts";
+
+function countKept(total: number, rate: number, phase = 0): number {
+  let kept = 0;
+  for (let i = 0; i < total; i++) {
+    if (shouldScoreRecord(i, rate, phase)) kept++;
+  }
+  return kept;
+}
+
+Deno.test("resolveFitnessSampleRate - defaults to full corpus", () => {
+  assertEquals(
+    resolveFitnessSampleRate(undefined),
+    DEFAULT_FITNESS_SAMPLE_RATE,
+  );
+  assertEquals(resolveFitnessSampleRate(undefined), 1);
+});
+
+Deno.test("resolveFitnessSampleRate - non-finite collapses to 1", () => {
+  assertEquals(resolveFitnessSampleRate(Number.NaN), 1);
+  assertEquals(resolveFitnessSampleRate(Number.POSITIVE_INFINITY), 1);
+});
+
+Deno.test("resolveFitnessSampleRate - clamps to [MIN, 1]", () => {
+  assertEquals(resolveFitnessSampleRate(2), 1);
+  assertEquals(resolveFitnessSampleRate(0), MIN_FITNESS_SAMPLE_RATE);
+  assertEquals(resolveFitnessSampleRate(-0.5), MIN_FITNESS_SAMPLE_RATE);
+  assertEquals(resolveFitnessSampleRate(0.5), 0.5);
+});
+
+Deno.test("shouldScoreRecord - rate 1 keeps every record", () => {
+  for (let i = 0; i < 1000; i++) {
+    assert(shouldScoreRecord(i, 1), `record ${i} must be kept at rate 1`);
+  }
+});
+
+Deno.test("shouldScoreRecord - negative index is never kept", () => {
+  assert(!shouldScoreRecord(-1, 0.5));
+});
+
+Deno.test("shouldScoreRecord - keeps exactly floor(N*rate) records", () => {
+  for (const total of [10, 100, 997, 2048]) {
+    for (const rate of [0.5, 0.25, 0.1, 0.05]) {
+      assertEquals(
+        countKept(total, rate),
+        Math.floor(total * rate),
+        `total=${total} rate=${rate}`,
+      );
+    }
+  }
+});
+
+Deno.test("shouldScoreRecord - stride is evenly spread (stratified)", () => {
+  // At rate 0.5 the kept records must alternate — never two adjacent gaps of
+  // the same parity clustering at one end.
+  const kept: number[] = [];
+  for (let i = 0; i < 10; i++) {
+    if (shouldScoreRecord(i, 0.5)) kept.push(i);
+  }
+  assertEquals(kept, [1, 3, 5, 7, 9]);
+});
+
+Deno.test("shouldScoreRecord - is deterministic across calls", () => {
+  const runA: boolean[] = [];
+  const runB: boolean[] = [];
+  for (let i = 0; i < 500; i++) runA.push(shouldScoreRecord(i, 0.17));
+  for (let i = 0; i < 500; i++) runB.push(shouldScoreRecord(i, 0.17));
+  assertEquals(runA, runB);
+});
+
+Deno.test("shouldScoreRecord - phase rotates strata, keeps count stable", () => {
+  const total = 100;
+  const rate = 0.3;
+  const base = countKept(total, rate, 0);
+  // A non-zero phase selects a different set but the same-sized set (within
+  // one record, due to the prefix boundary) so ranking cost stays ~constant.
+  for (const phase of [1, 7, 33]) {
+    const shifted = countKept(total, rate, phase);
+    assert(
+      Math.abs(shifted - base) <= 1,
+      `phase ${phase} kept ${shifted}, base ${base}`,
+    );
+  }
+  // The selected set genuinely differs for at least one phase.
+  const setA = new Set<number>();
+  const setB = new Set<number>();
+  for (let i = 0; i < total; i++) {
+    if (shouldScoreRecord(i, rate, 0)) setA.add(i);
+    if (shouldScoreRecord(i, rate, 1)) setB.add(i);
+  }
+  let differs = false;
+  for (const v of setA) {
+    if (!setB.has(v)) {
+      differs = true;
+      break;
+    }
+  }
+  assert(differs, "phase 1 must differ from phase 0");
+});
+
+Deno.test("expectedSampledCount - matches the stride", () => {
+  assertEquals(expectedSampledCount(0, 0.5), 0);
+  assertEquals(expectedSampledCount(100, 1), 100);
+  assertEquals(expectedSampledCount(100, 0.25), 25);
+  assertEquals(expectedSampledCount(997, 0.1), 99);
+  // Out-of-range rate is clamped before counting.
+  assertEquals(expectedSampledCount(100, 2), 100);
+});

--- a/test/creature/FitnessSubsampleEvaluateDir.ts
+++ b/test/creature/FitnessSubsampleEvaluateDir.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration tests for the `fitnessSampleRate` ranking-pass subsample applied
+ * inside the streaming `evaluateDir` binary reader (Issue #3257).
+ *
+ * These are implementation-independent "what" tests: rather than inspecting
+ * internal counters, they build a synthetic binary corpus and assert that
+ * scoring the full corpus at a sub-`1` rate produces the *same* average error
+ * as scoring a corpus that contains only the sampled records — proving the
+ * reader kept exactly the deterministic stratified stride and did less work.
+ * The default rate `1` must reproduce the full-corpus error bit-for-bit.
+ */
+
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import { Costs } from "@costs";
+import { shouldScoreRecord } from "@creature/FitnessSubsample.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/**
+ * Build a corpus where odd-indexed records carry a systematically different
+ * target from even-indexed ones, so a 0.5 stride (which keeps odd indices)
+ * yields a genuinely different mean error from the full corpus.
+ */
+function buildDataSet(n: number): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < n; i++) {
+    const a = (i % 7) / 7;
+    const b = ((i * 3) % 11) / 11;
+    // Even records target one extreme, odd records the other.
+    const t = i % 2 === 0 ? 0.9 : -0.9;
+    rows.push({
+      input: new Float32Array([a, b]),
+      output: new Float32Array([t]),
+    });
+  }
+  return rows;
+}
+
+/** Records that the deterministic stride keeps at `rate` (single-file order). */
+function sampledSubset(
+  rows: DataRecordInterface[],
+  rate: number,
+): DataRecordInterface[] {
+  return rows.filter((_, i) => shouldScoreRecord(i, rate));
+}
+
+Deno.test("evaluateDir - default rate 1 matches undefined (full corpus)", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const rows = buildDataSet(40);
+  const dir = makeDataDir(rows, 40); // single .bin file → deterministic order
+  try {
+    const full = await creature.evaluateDir(dir, Costs.find("MSE"), false);
+    const explicitOne = await creature.evaluateDir(
+      dir,
+      Costs.find("MSE"),
+      false,
+      undefined,
+      undefined,
+      undefined,
+      1,
+    );
+    assertEquals(explicitOne.error, full.error);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("evaluateDir - fused path subsample scores exactly the sampled records", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const rows = buildDataSet(40);
+  const fullDir = makeDataDir(rows, 40);
+  const reducedDir = makeDataDir(sampledSubset(rows, 0.5), 40);
+  try {
+    const full = await creature.evaluateDir(fullDir, Costs.find("MSE"), false);
+    const reduced = await creature.evaluateDir(
+      reducedDir,
+      Costs.find("MSE"),
+      false,
+    );
+    const subsampled = await creature.evaluateDir(
+      fullDir,
+      Costs.find("MSE"),
+      false,
+      undefined,
+      undefined,
+      undefined,
+      0.5,
+    );
+
+    // Subsampling the full corpus == scoring only the sampled records.
+    assertAlmostEquals(subsampled.error, reduced.error, 1e-6);
+    // And the crafted corpus makes the subsample genuinely differ from full,
+    // proving records were actually skipped (not silently full-scored).
+    assertEquals(
+      Math.abs(subsampled.error - full.error) > 1e-3,
+      true,
+      `subsample ${subsampled.error} should differ from full ${full.error}`,
+    );
+  } finally {
+    await Deno.remove(fullDir, { recursive: true });
+    await Deno.remove(reducedDir, { recursive: true });
+  }
+});
+
+Deno.test("evaluateDir - per-record path subsample scores exactly the sampled records", async () => {
+  await initWasmForTests();
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const rows = buildDataSet(40);
+  const fullDir = makeDataDir(rows, 40);
+  const reducedDir = makeDataDir(sampledSubset(rows, 0.5), 40);
+  // Issue #1620: a non-empty output range disables the fused path, forcing the
+  // per-record loop so its subsample skip is exercised too. The bounds are
+  // wide enough to add no penalty, isolating the subsample behaviour.
+  const ranges = [{ min: -2, max: 2, penaltyWeight: 1 }];
+  try {
+    const reduced = await creature.evaluateDir(
+      reducedDir,
+      Costs.find("MSE"),
+      false,
+      ranges,
+    );
+    const subsampled = await creature.evaluateDir(
+      fullDir,
+      Costs.find("MSE"),
+      false,
+      ranges,
+      undefined,
+      undefined,
+      0.5,
+    );
+    assertAlmostEquals(subsampled.error, reduced.error, 1e-6);
+  } finally {
+    await Deno.remove(fullDir, { recursive: true });
+    await Deno.remove(reducedDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds an optional **multi-fidelity fitness** knob, `fitnessSampleRate`, that
scores each creature on a **deterministic, stratified subsample** of the binary
fitness corpus during the per-generation ranking pass. Production evolution
spends ≈95 % of `evolveDir` wall-clock in fitness evaluation, so scoring fewer
records per generation is the single largest algorithmic lever available. The
subsample is applied inside the streaming `evaluateDir` reader — records are
skipped in **one pass, with no second corpus written to disk** — and the
**default stays `1.0`** (score the full corpus), so production quality is
unchanged unless a run opts in. **Closes #3257.**

Scope note (honest deferral): the issue targets the forward-only **Rust batch**
scorer path for the full production off-load. The native `rust_scorer` binary
cannot yet skip records inside its streaming reader, so a sub-`1` rate currently
stays on the TS/WASM path (which this PR fully implements and benchmarks). The
record-level skip in the scorer — plus the elite full-corpus **confirmation
pass** and the production 21 GiB corpus + Spearman ≥ 0.95 gate — is tracked as a
follow-up (see below), because it needs a scorer release and the production
corpus that this bench host does not have.

### What changed

- `src/creature/FitnessSubsample.ts` — pure, RNG-free stride selector: keep
  record `i` iff `floor((i+1)·rate) > floor(i·rate)` (keeps exactly
  `floor(N·rate)` records, evenly spread, fully deterministic across generations
  and machines). Plus `resolveFitnessSampleRate` clamp and
  `expectedSampledCount`.
- `evaluateDir` (`CreatureActivation.ts`) — applies the subsample on **both**
  the fused-WASM path (compacts each batch to the sampled records before the
  single fused call) and the per-record path. Full rate (`1`) takes the original
  code path with zero added work. A sub-`1` rate skips the native off-load so
  the requested subsample is honoured.
- Config — `fitnessSampleRate` added to `NeatArguments`, `NeatOptions`
  (numeric-coercible), and `createNeatConfig` (validated `0.0001..1`, default
  `1`), mirroring `trainingSampleRate`. Threaded through the worker init payload
  (`WorkerHandler` → `WorkerProcessor` → `evaluateDir`) so `evolveDir` honours
  it on the worker path.
- `bench/FitnessSampleRate.ts` — wall-clock + Spearman correlation harness.
- `docs/PERFORMANCE_TUNING.md` — new **Fitness Corpus Subsampling** section.

```mermaid
flowchart LR
    A[Population] --> B{fitnessSampleRate}
    B -- "= 1 (default)" --> C[Score full corpus]
    B -- "< 1" --> D[Stratified stride:<br/>keep floor N×rate records]
    D --> E[Score subsample<br/>one pass, records skipped]
    C --> F[Rank + select]
    E --> F
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified by benchmark and
unit tests.

**Benchmark** (`bench/FitnessSampleRate.ts`, 27.5 MiB synthetic corpus,
population 24, forward-only fused WASM path):

| rate | wall-clock | speedup | Spearman vs full |
| ---: | ---------: | ------: | ---------------: |
| 1.00 |     3738ms |   1.02× |           1.0000 |
| 0.50 |     2104ms |   1.80× |           1.0000 |
| 0.25 |     1067ms |   3.56× |           0.9991 |
| 0.10 |      468ms |   8.11× |           1.0000 |

Wall-clock falls ~proportionally to the rate (well past the ≥ 5 % gate); rank
order (Spearman) stays ≥ 0.999, above the suggested 0.95 preset bar, on this
uniform synthetic workload. Real production corpora may correlate less, which is
exactly why the **default is `1.0`** and enabling a sub-`1` preset should be
confirmed against the production corpus first (the follow-up covers that on the
GRQ corpus).

## Test Plan

- `test/creature/FitnessSubsample.ts` — stride maths: rate clamp, exact
  `floor(N·rate)` count, even stratification, determinism, phase rotation.
- `test/creature/FitnessSubsampleEvaluateDir.ts` — integration "what" tests:
  scoring the full corpus at `0.5` yields the **same** error as scoring a corpus
  containing only the sampled records (proving the reader kept exactly the
  stride and did less work), on both the fused and per-record paths; default `1`
  reproduces the full-corpus error exactly.
- `test/config/NeatConfigParseOptions.ts` — `fitnessSampleRate` default,
  number/string coercion, and out-of-range / non-numeric validation errors.

## Follow-up

The production Rust-batch off-load (record-level skip in the `rust_scorer`
streaming reader) and the elite full-corpus confirmation pass are tracked in
**stSoftwareAU/NEAT-AI-scorer#310**, cross-linked from this issue — they require
a scorer release and the production 21 GiB corpus for the merge-gate correlation
study, which this bench host cannot run.



## Milestone
This PR is part of the **#3256 Improve evolution wall-clock on production GRQ creatures & training data (benchmark-gated)** milestone and targets the `milestone/3256-improve-evolution-wall-clock-on-production-gr` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrdbuaqk-0b05d6`<!-- vibe-worker-issue-3257 -->