### PR TITLE
perf: production-cost-faithful pace-lever bake-off harness (Issue #3259)

### DIFF
--- a/bench/ProductionPaceLeverBakeOff.ts
+++ b/bench/ProductionPaceLeverBakeOff.ts
@@ -1,0 +1,518 @@
+/**
+ * Issue #3259 — Production-calibrated bake-off of generation-efficiency levers.
+ *
+ * Parent: #3256 (production evolution wall-clock on the GRQ corpus).
+ *
+ * ## Why a new harness
+ *
+ * The prior pace work (#2928–#2934, `bench/EvolutionPaceLeverComparison.ts`,
+ * Fast Convergence preset) ranks levers by **raw wall-clock** on tiny fixtures
+ * where a fitness evaluation is nearly free. In production the opposite holds:
+ * fitness scoring is ≈95 % of wall-clock and each full-corpus evaluation costs
+ * *minutes* of CPU on a 21 GiB corpus. Under that regime the raw-wall-clock
+ * ranking is dominated by breeding/overhead and does **not** transfer.
+ *
+ * ## The corpus-independent metric
+ *
+ * When fitness dominates and every full-corpus evaluation costs the same `C`
+ * seconds, total wall-clock ≈ `N_scored × C`, where `N_scored` is the number
+ * of full-corpus fitness evaluations performed. Ranking levers by wall-clock is
+ * therefore equivalent to ranking them by **`N_scored`** — a quantity that is
+ * independent of `C` and hence of corpus size. So we can rank the levers
+ * faithfully on a laptop by *counting scored evaluations*, then multiply by the
+ * production per-evaluation cost (measured on GRQ via #3256 `phaseTimingTotals`)
+ * to obtain a modelled production wall-clock. That is the transfer bridge this
+ * issue asks for.
+ *
+ * The harness mirrors production's score-carry contract exactly
+ * (`Fitness.calculate` scores only `score === undefined` creatures — Issue
+ * #1016): elites carry their score forward and cost **zero** re-scores, while
+ * memetically-trained creatures must be re-scored because training changes
+ * their output. Each lever therefore moves `N_scored` in a way this harness
+ * measures directly:
+ *
+ *   - `populationSize`  — new (unscored) creatures bred per generation.
+ *   - `elitismFraction` — elites carried without re-scoring (redundant scores
+ *     avoided); the question "how many full-corpus scores are redundant?".
+ *   - `trainPerGen`     — memetic backprop adds one re-score per trained
+ *     creature per generation.
+ *
+ * ## What this harness is and is NOT
+ *
+ * This is a **methodology** harness. Its convergence dynamics run on a small
+ * seeded synthetic supervised problem, so its `N_scored` figures are a sanity
+ * check of the *method*, **not** production evidence. Per this issue's adoption
+ * gate, a preset may be flipped only when the primary metric improves by ≥5 %
+ * on the **production creature + 21 GiB binary corpus** with repeatable seeds.
+ * To produce the adoption-gate numbers on GRQ, a human replaces the synthetic
+ * `buildNetwork`/`buildDataset`/scoring with the production creature and corpus
+ * scorer, and sets `costPerEvalSeconds` to the value measured from #3256
+ * `phaseTimingTotals`. This file flips **no** default.
+ *
+ * No production/runtime code is changed — this is pure measurement + docs.
+ *
+ * Run with (synthetic sanity check):
+ *   deno run --allow-read --allow-env --allow-ffi \
+ *     bench/ProductionPaceLeverBakeOff.ts
+ *
+ * The standalone run reads the modelled per-evaluation cost from the
+ * `BAKE_OFF_COST_PER_EVAL_SECONDS` environment variable when set (else the
+ * 90-second placeholder), so the real GRQ per-eval cost can be modelled without
+ * editing the source.
+ */
+
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { createBackPropagationConfig } from "@propagate/BackPropagation.ts";
+import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
+import {
+  createSeededRng,
+  type RandomNumberGenerator,
+} from "@utils/RandomNumberGenerator.ts";
+
+// ---------------------------------------------------------------------------
+// Options + results
+// ---------------------------------------------------------------------------
+
+/** Tunable problem, population policy, and production cost model. */
+export interface BakeOffOptions {
+  readonly inputs: number;
+  readonly outputs: number;
+  readonly hidden: number;
+  readonly datasetSize: number;
+  /** Population size (the `populationSize` lever). */
+  readonly populationSize: number;
+  /**
+   * Fraction of the population carried forward as elites without re-scoring
+   * (the elitism lever). Clamped to `[0, 0.9]`; always keeps at least one.
+   */
+  readonly elitismFraction: number;
+  /** Fittest members trained with real backprop each generation (memetic). */
+  readonly trainPerGen: number;
+  /** Inner backprop iterations per trained creature per generation. */
+  readonly innerTrainIters: number;
+  /** Generation cap. */
+  readonly generations: number;
+  /** Best-error threshold that counts as "reached target". */
+  readonly targetError: number;
+  /** Deterministic seed. */
+  readonly seed: number;
+  /**
+   * Modelled cost of one full-corpus fitness evaluation, in seconds. On GRQ
+   * this is derived from #3256 `phaseTimingTotals` (fitness ms ÷ scored count).
+   * Only scales `modelledWallClockSeconds`; it never affects `scoredEvaluations`
+   * or the lever ranking.
+   */
+  readonly costPerEvalSeconds: number;
+}
+
+/** Measured outcome for one lever configuration. */
+export interface BakeOffResult {
+  readonly name: string;
+  readonly populationSize: number;
+  readonly elitismFraction: number;
+  readonly trainPerGen: number;
+  /**
+   * Total number of full-corpus fitness evaluations performed — the
+   * corpus-independent primary metric (production wall-clock ∝ this).
+   */
+  readonly scoredEvaluations: number;
+  /** Generations until `targetError` reached, or `null` if never reached. */
+  readonly generationsToTarget: number | null;
+  /** Best (lowest) error reached during the run. */
+  readonly bestError: number;
+  /** Modelled production wall-clock: `scoredEvaluations × costPerEvalSeconds`. */
+  readonly modelledWallClockSeconds: number;
+}
+
+/**
+ * Production-shaped defaults. Kept modest so a standalone run finishes quickly;
+ * the *ranking* — not the absolute count — is the transferable signal.
+ * `costPerEvalSeconds` defaults to a 90-second placeholder (a minutes-scale
+ * full-corpus score); pass the real GRQ figure to model true wall-clock.
+ */
+export const DEFAULT_BAKE_OFF_OPTIONS: BakeOffOptions = {
+  inputs: 6,
+  outputs: 3,
+  hidden: 8,
+  datasetSize: 48,
+  populationSize: 24,
+  elitismFraction: 0.1,
+  trainPerGen: 6,
+  innerTrainIters: 4,
+  generations: 60,
+  targetError: 0.05,
+  seed: 3259,
+  costPerEvalSeconds: 90,
+};
+
+// ---------------------------------------------------------------------------
+// Fixed supervised problem (same construction as EvolutionPaceLeverComparison)
+// ---------------------------------------------------------------------------
+
+interface Sample {
+  readonly input: Float32Array;
+  readonly target: Float32Array;
+}
+
+const BASE_LEARNING_RATE = 0.1;
+const BASE_PERTURB_SCALE = 0.1;
+
+function buildNetwork(
+  rng: RandomNumberGenerator,
+  opts: BakeOffOptions,
+): CreatureExport {
+  const neurons: CreatureExport["neurons"] = [];
+  const synapses: CreatureExport["synapses"] = [];
+
+  const inputUUIDs = Array.from(
+    { length: opts.inputs },
+    (_, i) => `input-${i}`,
+  );
+  const hiddenUUIDs: string[] = [];
+  for (let h = 0; h < opts.hidden; h++) {
+    const uuid = `h-${h}`;
+    hiddenUUIDs.push(uuid);
+    neurons.push({
+      type: "hidden",
+      uuid,
+      squash: "TANH",
+      bias: (rng.random() * 2 - 1) * 0.1,
+    });
+  }
+  const outputUUIDs: string[] = [];
+  for (let o = 0; o < opts.outputs; o++) {
+    const uuid = `output-${o}`;
+    outputUUIDs.push(uuid);
+    neurons.push({
+      type: "output",
+      uuid,
+      squash: "LOGISTIC",
+      bias: (rng.random() * 2 - 1) * 0.1,
+    });
+  }
+
+  for (const from of inputUUIDs) {
+    for (const to of hiddenUUIDs) {
+      synapses.push({
+        fromUUID: from,
+        toUUID: to,
+        weight: (rng.random() * 2 - 1) * 0.3,
+      });
+    }
+  }
+  for (const from of hiddenUUIDs) {
+    for (const to of outputUUIDs) {
+      synapses.push({
+        fromUUID: from,
+        toUUID: to,
+        weight: (rng.random() * 2 - 1) * 0.3,
+      });
+    }
+  }
+
+  return {
+    input: opts.inputs,
+    output: opts.outputs,
+    neurons,
+    synapses,
+  };
+}
+
+function buildDataset(
+  rng: RandomNumberGenerator,
+  opts: BakeOffOptions,
+): Sample[] {
+  const targetW: number[][] = Array.from(
+    { length: opts.outputs },
+    () => Array.from({ length: opts.inputs }, () => rng.random() * 2 - 1),
+  );
+  const logistic = (x: number) => 1 / (1 + Math.exp(-x));
+
+  const samples: Sample[] = [];
+  for (let s = 0; s < opts.datasetSize; s++) {
+    const input = new Float32Array(opts.inputs);
+    for (let i = 0; i < opts.inputs; i++) input[i] = rng.random() * 2 - 1;
+    const target = new Float32Array(opts.outputs);
+    for (let o = 0; o < opts.outputs; o++) {
+      let sum = 0;
+      for (let i = 0; i < opts.inputs; i++) sum += targetW[o][i] * input[i];
+      target[o] = logistic(sum);
+    }
+    samples.push({ input, target });
+  }
+  return samples;
+}
+
+function meanError(
+  creature: Creature,
+  data: readonly Sample[],
+  outputs: number,
+): number {
+  let total = 0;
+  for (const { input, target } of data) {
+    const out = creature.activate(input);
+    for (let o = 0; o < outputs; o++) total += Math.abs(out[o] - target[o]);
+  }
+  return total / (data.length * outputs);
+}
+
+function trainCreature(
+  creature: Creature,
+  data: readonly Sample[],
+  learningRate: number,
+  innerIters: number,
+): void {
+  const json = creature.exportJSON();
+  const config = createBackPropagationConfig({
+    generations: 1,
+    learningRate,
+    plankConstant: 1e-7,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: 1,
+  });
+  const sparse = new SparseConfig(json, config);
+  for (let iter = 0; iter < innerIters; iter++) {
+    for (const { input, target } of data) {
+      creature.activateAndTrace(input, false, sparse);
+      creature.propagate(target, config, sparse);
+    }
+  }
+  creature.applyLearnings(config, sparse);
+}
+
+function perturb(
+  source: Creature,
+  rng: RandomNumberGenerator,
+  scale: number,
+): Creature {
+  const json = source.exportJSON();
+  for (const s of json.synapses) s.weight += (rng.random() * 2 - 1) * scale;
+  for (const n of json.neurons) {
+    if (typeof n.bias === "number") n.bias += (rng.random() * 2 - 1) * scale;
+  }
+  return Creature.fromJSON(json);
+}
+
+// ---------------------------------------------------------------------------
+// One member of the evolving population
+// ---------------------------------------------------------------------------
+
+interface Member {
+  creature: Creature;
+  error: number;
+}
+
+/** Number of elites carried (score reused) for the given options. */
+export function eliteCount(opts: BakeOffOptions): number {
+  const fraction = Math.min(0.9, Math.max(0, opts.elitismFraction));
+  return Math.max(1, Math.floor(opts.populationSize * fraction));
+}
+
+// ---------------------------------------------------------------------------
+// Core bake-off loop, parameterised by the population-policy levers
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs one seeded evolution under `opts`, faithfully counting full-corpus
+ * fitness evaluations under production's score-carry contract (elites are never
+ * re-scored; trained creatures always are). Pure and deterministic: identical
+ * options → identical `scoredEvaluations`, `generationsToTarget`, `bestError`.
+ */
+export function runBakeOffConfig(opts: BakeOffOptions): BakeOffResult {
+  const setupRng = createSeededRng(opts.seed);
+  const dataset = buildDataset(setupRng, opts);
+  // A distinct stream for evolution so dataset size does not shift breeding.
+  const rng = createSeededRng(opts.seed ^ 0x5bd1e995);
+
+  let scoredEvaluations = 0;
+  const score = (creature: Creature): number => {
+    scoredEvaluations++;
+    return meanError(creature, dataset, opts.outputs);
+  };
+
+  // Initial population — every member is unscored, so every member is scored.
+  let members: Member[] = [];
+  for (let p = 0; p < opts.populationSize; p++) {
+    const creature = Creature.fromJSON(buildNetwork(setupRng, opts));
+    members.push({ creature, error: score(creature) });
+  }
+
+  const keep = Math.min(members.length, eliteCount(opts));
+  let best = Number.POSITIVE_INFINITY;
+  let generationsToTarget: number | null = null;
+
+  for (let gen = 0; gen < opts.generations; gen++) {
+    members.sort((a, b) => a.error - b.error);
+    best = Math.min(best, members[0].error);
+
+    if (best <= opts.targetError) {
+      generationsToTarget = gen;
+      break;
+    }
+
+    // Memetic training: train the fittest `trainPerGen`, then re-score them
+    // (training changes their output, so the carried score is invalidated).
+    const trainCount = Math.min(opts.trainPerGen, members.length);
+    for (let i = 0; i < trainCount; i++) {
+      const m = members[i];
+      trainCreature(
+        m.creature,
+        dataset,
+        BASE_LEARNING_RATE,
+        opts.innerTrainIters,
+      );
+      m.error = score(m.creature);
+    }
+    members.sort((a, b) => a.error - b.error);
+
+    // Elitism: carry the top `keep` members WITH their scores (no re-score).
+    const next: Member[] = members.slice(0, keep).map((m) => ({ ...m }));
+
+    // Breed the remainder from the top quartile; each child is unscored.
+    const topQuarter = Math.max(1, Math.floor(members.length / 4));
+    while (next.length < opts.populationSize) {
+      const parent = members[rng.randomInt(0, topQuarter - 1)];
+      const childCreature = perturb(parent.creature, rng, BASE_PERTURB_SCALE);
+      next.push({ creature: childCreature, error: score(childCreature) });
+    }
+
+    members = next;
+  }
+
+  // Final sweep so a last-generation improvement is not missed (no re-score:
+  // every surviving member already carries a score).
+  for (const m of members) best = Math.min(best, m.error);
+  if (generationsToTarget === null && best <= opts.targetError) {
+    generationsToTarget = opts.generations;
+  }
+
+  return {
+    name:
+      `pop=${opts.populationSize} elite=${opts.elitismFraction} train=${opts.trainPerGen}`,
+    populationSize: opts.populationSize,
+    elitismFraction: opts.elitismFraction,
+    trainPerGen: opts.trainPerGen,
+    scoredEvaluations,
+    generationsToTarget,
+    bestError: best,
+    modelledWallClockSeconds: scoredEvaluations * opts.costPerEvalSeconds,
+  };
+}
+
+/**
+ * One-factor-at-a-time sweep: runs `base` once per override, changing a single
+ * lever each time. Returns one result per override (in order).
+ */
+export function runLeverSweep(
+  base: BakeOffOptions,
+  overrides: readonly Partial<BakeOffOptions>[],
+): BakeOffResult[] {
+  return overrides.map((o) => runBakeOffConfig({ ...base, ...o }));
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+/** Renders results as a GitHub-flavoured Markdown table. */
+export function formatBakeOffTable(results: readonly BakeOffResult[]): string {
+  const header =
+    "| config | scored evals | gens-to-target | best error | modelled wall-clock (s) |";
+  const divider =
+    "| ------ | ------------ | -------------- | ---------- | ----------------------- |";
+  const rows = results.map((r) => {
+    const gens = r.generationsToTarget === null
+      ? "—"
+      : r.generationsToTarget.toString();
+    return `| ${r.name} | ${r.scoredEvaluations} | ${gens} | ${
+      r.bestError.toFixed(6)
+    } | ${r.modelledWallClockSeconds.toFixed(1)} |`;
+  });
+  return [header, divider, ...rows].join("\n");
+}
+
+/**
+ * Picks the result with the lowest modelled wall-clock among those that
+ * reached the target. Returns `null` when none reached it.
+ */
+export function recommendByWallClock(
+  results: readonly BakeOffResult[],
+): BakeOffResult | null {
+  const reached = results.filter((r) => r.generationsToTarget !== null);
+  if (reached.length === 0) return null;
+  return reached.reduce((best, r) =>
+    r.modelledWallClockSeconds < best.modelledWallClockSeconds ? r : best
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Standalone benchmark entrypoint
+// ---------------------------------------------------------------------------
+
+/** Reads the modelled per-eval cost from the environment, else the default. */
+function resolveCostPerEvalSeconds(fallback: number): number {
+  const raw = Deno.env.get("BAKE_OFF_COST_PER_EVAL_SECONDS");
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(
+      `BAKE_OFF_COST_PER_EVAL_SECONDS must be a positive number, got: ${raw}`,
+    );
+  }
+  return parsed;
+}
+
+if (import.meta.main) {
+  const base: BakeOffOptions = {
+    ...DEFAULT_BAKE_OFF_OPTIONS,
+    costPerEvalSeconds: resolveCostPerEvalSeconds(
+      DEFAULT_BAKE_OFF_OPTIONS.costPerEvalSeconds,
+    ),
+  };
+  console.log("Issue #3259 — Production pace-lever bake-off\n");
+  console.log(
+    `Primary metric: full-corpus scored evaluations (production wall-clock ∝ this).\n` +
+      `Modelled cost per evaluation: ${base.costPerEvalSeconds}s ` +
+      `(set BAKE_OFF_COST_PER_EVAL_SECONDS to the GRQ figure).\n`,
+  );
+
+  const sweeps: Record<string, Partial<BakeOffOptions>[]> = {
+    populationSize: [
+      { populationSize: 12 },
+      { populationSize: 24 },
+      { populationSize: 48 },
+    ],
+    elitismFraction: [
+      { elitismFraction: 0.0 },
+      { elitismFraction: 0.1 },
+      { elitismFraction: 0.25 },
+      { elitismFraction: 0.5 },
+    ],
+    trainPerGen: [
+      { trainPerGen: 0 },
+      { trainPerGen: 2 },
+      { trainPerGen: 6 },
+    ],
+  };
+
+  for (const [lever, overrides] of Object.entries(sweeps)) {
+    console.log(`\n### ${lever} sweep\n`);
+    const results = runLeverSweep(base, overrides);
+    console.log(formatBakeOffTable(results));
+    const rec = recommendByWallClock(results);
+    if (rec) {
+      console.log(
+        `\nLowest modelled wall-clock that reached target: ${rec.name} ` +
+          `(${rec.scoredEvaluations} scored evals).`,
+      );
+    }
+  }
+
+  console.log(
+    "\nNOTE: synthetic sanity check only — NOT production evidence. " +
+      "Flip a default only after ≥5% improvement on the GRQ corpus/creature.",
+  );
+}

--- a/docs/PERFORMANCE_RESEARCH.md
+++ b/docs/PERFORMANCE_RESEARCH.md
@@ -1006,6 +1006,89 @@ _inform_ default changes (e.g. #2928) but do not, by themselves, change any
 default. Re-run the harness on a representative problem before flipping a
 production default.
 
+## 🏭 Production Pace-Lever Bake-Off — Generation-Efficiency Levers (Issue #3259)
+
+Parent: **#3256** (production evolution wall-clock on the GRQ corpus).
+
+The OFF-by-default lever study above (#2931) — and the earlier pace work
+(#2928–#2934, `bench/EvolutionPaceLeverComparison.ts`, Fast Convergence preset)
+— ranks levers by **raw wall-clock on tiny fixtures**, where a fitness
+evaluation is nearly free. Production is the opposite regime: fitness scoring is
+**≈95 % of wall-clock** and each full-corpus evaluation costs _minutes_ of CPU
+on a 21 GiB corpus. There, `generations × population × corpus-bytes` dominates,
+so the raw-wall-clock ranking of levers measured on small fixtures does **not**
+transfer.
+
+### The corpus-independent primary metric
+
+When fitness dominates and every full-corpus evaluation costs the same `C`
+seconds, total wall-clock ≈ `N_scored × C`, where `N_scored` is the number of
+full-corpus fitness evaluations performed. Ranking levers by wall-clock is
+therefore equivalent to ranking them by **`N_scored`** — a quantity independent
+of `C`, and hence of corpus size. So the levers can be ranked faithfully on a
+laptop by _counting scored evaluations_, then multiplied by the production
+per-evaluation cost (measured on GRQ via #3256 `phaseTimingTotals`: fitness-ms ÷
+scored-count) to model production wall-clock.
+
+`bench/ProductionPaceLeverBakeOff.ts` implements exactly this. It mirrors the
+production score-carry contract (`Fitness.calculate` scores only
+`score === undefined` creatures — Issue #1016): elites carry their score forward
+and cost **zero** re-scores, while memetically-trained creatures are always
+re-scored because training changes their output. Each lever moves `N_scored`:
+
+| Lever             | Effect on `N_scored` per generation   | Bake-off question                                       |
+| ----------------- | ------------------------------------- | ------------------------------------------------------- |
+| `populationSize`  | New (unscored) creatures bred per gen | Smaller pop + more gens for fewer scored evals overall? |
+| `elitismFraction` | Elites carried without re-scoring     | How many full-corpus scores are redundant?              |
+| `trainPerGen`     | +1 re-score per trained creature      | Does memetic backprop pay for its extra scores?         |
+
+```mermaid
+flowchart LR
+  L[populationSize / elitism / trainPerGen] --> N["N_scored<br/>(full-corpus evaluations)"]
+  C["per-eval cost C (s)<br/>from GRQ #3256"] --> W
+  N --> W["modelled wall-clock<br/>= N_scored × C"]
+  W --> R{"≥5% better than<br/>production baseline?"}
+  R -- yes --> A[adopt preset]
+  R -- no --> D[document negative / neutral]
+```
+
+### Synthetic sanity check — NOT production evidence
+
+Running the harness on its small seeded synthetic problem
+(`deno run --allow-read --allow-env --allow-ffi bench/ProductionPaceLeverBakeOff.ts`,
+`C = 90 s` placeholder) validates that the method captures the expected
+directional dynamics:
+
+| Sweep             | Result                                                                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `populationSize`  | 12 / 24 / 48 → **267 / 388 / 748** scored evals to target; the smaller pop reaches the same score for far fewer full-corpus scores.       |
+| `elitismFraction` | 0 / 0.1 / 0.25 / 0.5 → **459 / 388 / 384 / 312** scored evals; carrying more elites removes redundant re-scores with no loss of reach.    |
+| `trainPerGen`     | 0 / 2 / 6 → **706 / 432 / 388** scored evals; memetic backprop more than pays for its extra re-scores by converging in fewer generations. |
+
+> [!WARNING]
+> These are a **methodology sanity check on a synthetic fixture**, not
+> production evidence. Exactly the transfer caveat the parent issue raises
+> applies — do **not** treat these lifts (or the tiny-XOR DNA-sharing lifts in
+> `docs/dna-sharing-bake-off-results.md`) as a reason to flip a GRQ default.
+
+### Adoption gate
+
+Per #3259, a production preset may be adopted — or a default flipped — **only**
+when the primary metric (`N_scored`, equivalently modelled wall-clock) improves
+by **≥5 %** on the **production creature + 21 GiB binary corpus** with
+repeatable seeds. Producing those numbers requires GRQ Apple-Silicon hardware
+and the production corpus/creature, which are **not** reachable from CI or an
+autonomous worker. To generate the adoption-gate evidence, a human runs the
+harness on GRQ: swap the synthetic `buildNetwork`/`buildDataset`/scoring for the
+production creature and corpus scorer, set the per-evaluation cost via
+`BAKE_OFF_COST_PER_EVAL_SECONDS` (from #3256 `phaseTimingTotals`), and record
+the host class, neat-ai/scorer/core versions, and corpus path alongside each
+row. Until that run exists, **no default is flipped** — this section ships the
+transfer-correct measurement method, not a preset.
+
+Follow-up for the human-run production bake-off is tracked on the parent
+milestone **#3256**.
+
 ## 📚 See Also
 
 - [PERFORMANCE_TUNING.md](./PERFORMANCE_TUNING.md) — Operational tuning guide

--- a/docs/archive/pr-summaries/pr-summary-3259.md
+++ b/docs/archive/pr-summaries/pr-summary-3259.md
@@ -1,0 +1,80 @@
+# [perf] Production pace-lever bake-off harness (Issue #3259)
+
+## Summary
+
+Parent milestone: **#3256** (production evolution wall-clock on the GRQ corpus).
+
+The prior pace work (#2928–#2934, `bench/EvolutionPaceLeverComparison.ts`, Fast
+Convergence preset) ranks generation-efficiency levers by **raw wall-clock on
+tiny fixtures**, where a fitness evaluation is nearly free. Production is the
+opposite regime: fitness is ≈95 % of wall-clock and each full-corpus evaluation
+costs _minutes_ on a 21 GiB corpus, so that ranking does **not** transfer.
+
+This PR ships the **transfer-correct measurement method** the issue asks for —
+"implement code only where a knob is missing". The missing knob is a bake-off
+whose primary metric survives the production cost regime:
+
+> When fitness dominates and every full-corpus evaluation costs the same `C`
+> seconds, wall-clock ≈ `N_scored × C`. Ranking levers by wall-clock is
+> therefore equivalent to ranking them by **`N_scored`** (the count of
+> full-corpus fitness evaluations) — a quantity **independent of `C`, hence of
+> corpus size**. So the levers can be ranked faithfully on a laptop by counting
+> scored evaluations, then multiplied by the GRQ per-eval cost (from #3256
+> `phaseTimingTotals`) to model production wall-clock.
+
+`bench/ProductionPaceLeverBakeOff.ts` sweeps `populationSize`,
+`elitismFraction`, and `trainPerGen`, mirroring production's score-carry
+contract exactly (`Fitness.calculate` scores only `score === undefined`
+creatures — Issue #1016): elites carry their score and cost **zero** re-scores,
+memetically-trained creatures are always re-scored.
+`docs/PERFORMANCE_RESEARCH.md` records the methodology, the synthetic
+sanity-check numbers, and the adoption gate.
+
+**No default is flipped and no production preset is adopted.** The ≥5 % adoption
+gate must be met on the **production creature + 21 GiB corpus** on GRQ hardware,
+which is not reachable from CI or an autonomous worker. The follow-up production
+run is tracked on the parent milestone **#3256**.
+
+Closes #3259.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Evidence is the harness's
+own deterministic output and the passing tests.
+
+Standalone synthetic sanity check (`C = 90 s` placeholder), directional dynamics
+as expected — **methodology validation, NOT production evidence**:
+
+| Sweep                                  | scored evals → target                                                                     |
+| -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `populationSize` 12 / 24 / 48          | **267 / 388 / 748** — smaller pop reaches the same score for far fewer full-corpus scores |
+| `elitismFraction` 0 / 0.1 / 0.25 / 0.5 | **459 / 388 / 384 / 312** — carrying more elites removes redundant re-scores              |
+| `trainPerGen` 0 / 2 / 6                | **706 / 432 / 388** — memetic backprop pays for its re-scores via faster convergence      |
+
+```mermaid
+flowchart LR
+  L[populationSize / elitism / trainPerGen] --> N["N_scored<br/>(full-corpus evaluations)"]
+  C["per-eval cost C (s)<br/>from GRQ #3256"] --> W
+  N --> W["modelled wall-clock<br/>= N_scored × C"]
+  W --> R{"≥5% better than<br/>production baseline?"}
+  R -- yes --> A[adopt preset]
+  R -- no --> D[document negative / neutral]
+```
+
+## Test Plan
+
+Added `test/bench/ProductionPaceLeverBakeOff.ts` (11 WHAT-tests, all passing):
+
+- `runBakeOffConfig` is deterministic across repeated runs.
+- Metrics are finite/non-negative and
+  `modelledWallClockSeconds =
+  scoredEvaluations × costPerEvalSeconds`.
+- `eliteCount` grows with elitism and keeps ≥1; negatives clamp to the floor.
+- **Elitism never increases scored evaluations** (score-carry contract).
+- **`trainPerGen` adds full-corpus re-scores** (train=4 > train=0 strictly).
+- Cost model is linear in `costPerEvalSeconds`.
+- `runLeverSweep`, `recommendByWallClock`, and `formatBakeOffTable` behave.
+
+`test/ci/BenchTaskConfig.ts` and `test/utils/NoUnusedStdDependency.ts` still
+pass; `deno fmt`/`lint`/`check` and `markdownlint-cli2` are clean on the new
+files.

--- a/test/bench/ProductionPaceLeverBakeOff.ts
+++ b/test/bench/ProductionPaceLeverBakeOff.ts
@@ -1,0 +1,194 @@
+/**
+ * Issue #3259 — Tests for the production pace-lever bake-off harness.
+ *
+ * These exercise the real harness functions in
+ * `bench/ProductionPaceLeverBakeOff.ts` with a small, fast option set so the
+ * quality gate stays within its time budget. They assert the properties the
+ * issue's methodology depends on:
+ *
+ *   1. Determinism — identical options → identical scored-evaluation count,
+ *      generations-to-target, and best error.
+ *   2. The score-carry contract is honoured — higher elitism carries more
+ *      elites without re-scoring, so it never *increases* scored evaluations
+ *      at a fixed population/train policy.
+ *   3. Memetic training adds re-scores — a higher `trainPerGen` performs more
+ *      full-corpus evaluations per generation.
+ *   4. The cost model is linear — `modelledWallClockSeconds` scales with
+ *      `costPerEvalSeconds` and equals `scoredEvaluations × cost`.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  type BakeOffOptions,
+  type BakeOffResult,
+  DEFAULT_BAKE_OFF_OPTIONS,
+  eliteCount,
+  formatBakeOffTable,
+  recommendByWallClock,
+  runBakeOffConfig,
+  runLeverSweep,
+} from "../../bench/ProductionPaceLeverBakeOff.ts";
+
+/** Small, fast options so the suite stays within the time budget. */
+const FAST_OPTIONS: BakeOffOptions = {
+  inputs: 4,
+  outputs: 2,
+  hidden: 4,
+  datasetSize: 12,
+  populationSize: 8,
+  elitismFraction: 0.25,
+  trainPerGen: 2,
+  innerTrainIters: 2,
+  generations: 6,
+  targetError: 0.18,
+  seed: 3259,
+  costPerEvalSeconds: 90,
+};
+
+function fingerprint(r: BakeOffResult): string {
+  return `${r.scoredEvaluations}:${r.generationsToTarget}:${
+    r.bestError.toFixed(8)
+  }`;
+}
+
+Deno.test("runBakeOffConfig - is deterministic across repeated runs", () => {
+  const first = runBakeOffConfig(FAST_OPTIONS);
+  const second = runBakeOffConfig(FAST_OPTIONS);
+  assertEquals(fingerprint(first), fingerprint(second));
+});
+
+Deno.test("runBakeOffConfig - reports finite, non-negative metrics", () => {
+  const r = runBakeOffConfig(FAST_OPTIONS);
+  assertEquals(Number.isFinite(r.bestError), true);
+  assertEquals(r.bestError >= 0, true);
+  assertEquals(r.scoredEvaluations >= FAST_OPTIONS.populationSize, true);
+  assertEquals(
+    r.modelledWallClockSeconds,
+    r.scoredEvaluations * FAST_OPTIONS.costPerEvalSeconds,
+  );
+  if (r.generationsToTarget !== null) {
+    assertEquals(
+      r.generationsToTarget >= 0 &&
+        r.generationsToTarget <= FAST_OPTIONS.generations,
+      true,
+    );
+  }
+});
+
+Deno.test("eliteCount - grows with elitism fraction and keeps at least one", () => {
+  assertEquals(eliteCount({ ...FAST_OPTIONS, elitismFraction: 0 }), 1);
+  const low = eliteCount({ ...FAST_OPTIONS, elitismFraction: 0.25 });
+  const high = eliteCount({ ...FAST_OPTIONS, elitismFraction: 0.5 });
+  assertEquals(high >= low, true);
+  // Negative fractions clamp to the one-elite floor.
+  assertEquals(eliteCount({ ...FAST_OPTIONS, elitismFraction: -1 }), 1);
+});
+
+Deno.test("elitism - more elites never increase scored evaluations", () => {
+  // Elites carry their score (no re-score), so raising the elitism fraction at
+  // a fixed population/train policy can only reduce or hold the scored count.
+  const low = runBakeOffConfig({ ...FAST_OPTIONS, elitismFraction: 0.0 });
+  const high = runBakeOffConfig({ ...FAST_OPTIONS, elitismFraction: 0.5 });
+  // Only compare when neither short-circuits early on reaching target.
+  if (low.generationsToTarget === null && high.generationsToTarget === null) {
+    assertEquals(high.scoredEvaluations <= low.scoredEvaluations, true);
+  } else {
+    assertExists(low.scoredEvaluations);
+  }
+});
+
+Deno.test("trainPerGen - memetic training adds full-corpus re-scores", () => {
+  // With no early stop, each trained creature is re-scored every generation, so
+  // trainPerGen=4 must perform strictly more scored evaluations than train=0.
+  const opts = { ...FAST_OPTIONS, targetError: 0, generations: 4 };
+  const none = runBakeOffConfig({ ...opts, trainPerGen: 0 });
+  const some = runBakeOffConfig({ ...opts, trainPerGen: 4 });
+  assertEquals(none.generationsToTarget, null);
+  assertEquals(some.generationsToTarget, null);
+  assertEquals(some.scoredEvaluations > none.scoredEvaluations, true);
+});
+
+Deno.test("cost model - modelled wall-clock scales linearly with cost", () => {
+  const cheap = runBakeOffConfig({ ...FAST_OPTIONS, costPerEvalSeconds: 1 });
+  const dear = runBakeOffConfig({ ...FAST_OPTIONS, costPerEvalSeconds: 100 });
+  // Same lever policy → same scored-eval count → wall-clock differs only by cost.
+  assertEquals(cheap.scoredEvaluations, dear.scoredEvaluations);
+  assertEquals(
+    dear.modelledWallClockSeconds,
+    cheap.modelledWallClockSeconds * 100,
+  );
+});
+
+Deno.test("runLeverSweep - returns one result per override", () => {
+  const results = runLeverSweep(FAST_OPTIONS, [
+    { populationSize: 6 },
+    { populationSize: 8 },
+    { populationSize: 12 },
+  ]);
+  assertEquals(results.length, 3);
+  assertEquals(results[0].populationSize, 6);
+  assertEquals(results[2].populationSize, 12);
+});
+
+Deno.test("recommendByWallClock - picks lowest modelled wall-clock that reached target", () => {
+  const reached = (evals: number): BakeOffResult => ({
+    name: `x${evals}`,
+    populationSize: 8,
+    elitismFraction: 0.1,
+    trainPerGen: 2,
+    scoredEvaluations: evals,
+    generationsToTarget: 3,
+    bestError: 0.1,
+    modelledWallClockSeconds: evals * 90,
+  });
+  const never: BakeOffResult = {
+    name: "never",
+    populationSize: 8,
+    elitismFraction: 0.1,
+    trainPerGen: 2,
+    scoredEvaluations: 5,
+    generationsToTarget: null,
+    bestError: 0.9,
+    modelledWallClockSeconds: 450,
+  };
+  const rec = recommendByWallClock([reached(40), never, reached(20)]);
+  assertExists(rec);
+  assertEquals(rec.scoredEvaluations, 20);
+  // All-unreached returns null.
+  assertEquals(recommendByWallClock([never]), null);
+});
+
+Deno.test("formatBakeOffTable - renders a header, divider, and one row per result", () => {
+  const results = runLeverSweep(FAST_OPTIONS, [
+    { populationSize: 6 },
+    { populationSize: 8 },
+  ]);
+  const table = formatBakeOffTable(results);
+  const lines = table.split("\n");
+  assertEquals(lines.length, results.length + 2);
+  assertEquals(lines[0].includes("scored evals"), true);
+  assertEquals(lines[0].includes("modelled wall-clock"), true);
+});
+
+Deno.test("formatBakeOffTable - shows an em dash when target not reached", () => {
+  const unreached: BakeOffResult = {
+    name: "never",
+    populationSize: 8,
+    elitismFraction: 0.1,
+    trainPerGen: 2,
+    scoredEvaluations: 5,
+    generationsToTarget: null,
+    bestError: 0.9,
+    modelledWallClockSeconds: 450,
+  };
+  const table = formatBakeOffTable([unreached]);
+  assertEquals(table.includes("| — |"), true);
+});
+
+Deno.test("DEFAULT_BAKE_OFF_OPTIONS - harder target than the fast test set", () => {
+  assertEquals(
+    DEFAULT_BAKE_OFF_OPTIONS.targetError < FAST_OPTIONS.targetError,
+    true,
+  );
+  assertEquals(DEFAULT_BAKE_OFF_OPTIONS.costPerEvalSeconds > 0, true);
+});


### PR DESCRIPTION
# [perf] Production pace-lever bake-off harness (Issue #3259)

## Summary

Parent milestone: **#3256** (production evolution wall-clock on the GRQ corpus).

The prior pace work (#2928–#2934, `bench/EvolutionPaceLeverComparison.ts`, Fast
Convergence preset) ranks generation-efficiency levers by **raw wall-clock on
tiny fixtures**, where a fitness evaluation is nearly free. Production is the
opposite regime: fitness is ≈95 % of wall-clock and each full-corpus evaluation
costs _minutes_ on a 21 GiB corpus, so that ranking does **not** transfer.

This PR ships the **transfer-correct measurement method** the issue asks for —
"implement code only where a knob is missing". The missing knob is a bake-off
whose primary metric survives the production cost regime:

> When fitness dominates and every full-corpus evaluation costs the same `C`
> seconds, wall-clock ≈ `N_scored × C`. Ranking levers by wall-clock is
> therefore equivalent to ranking them by **`N_scored`** (the count of
> full-corpus fitness evaluations) — a quantity **independent of `C`, hence of
> corpus size**. So the levers can be ranked faithfully on a laptop by counting
> scored evaluations, then multiplied by the GRQ per-eval cost (from #3256
> `phaseTimingTotals`) to model production wall-clock.

`bench/ProductionPaceLeverBakeOff.ts` sweeps `populationSize`,
`elitismFraction`, and `trainPerGen`, mirroring production's score-carry
contract exactly (`Fitness.calculate` scores only `score === undefined`
creatures — Issue #1016): elites carry their score and cost **zero** re-scores,
memetically-trained creatures are always re-scored.
`docs/PERFORMANCE_RESEARCH.md` records the methodology, the synthetic
sanity-check numbers, and the adoption gate.

**No default is flipped and no production preset is adopted.** The ≥5 % adoption
gate must be met on the **production creature + 21 GiB corpus** on GRQ hardware,
which is not reachable from CI or an autonomous worker. The follow-up production
run is tracked on the parent milestone **#3256**.

Closes #3259.

## Evidence

Backend/CLI change — no web interface to screenshot. Evidence is the harness's
own deterministic output and the passing tests.

Standalone synthetic sanity check (`C = 90 s` placeholder), directional dynamics
as expected — **methodology validation, NOT production evidence**:

| Sweep                                  | scored evals → target                                                                     |
| -------------------------------------- | ----------------------------------------------------------------------------------------- |
| `populationSize` 12 / 24 / 48          | **267 / 388 / 748** — smaller pop reaches the same score for far fewer full-corpus scores |
| `elitismFraction` 0 / 0.1 / 0.25 / 0.5 | **459 / 388 / 384 / 312** — carrying more elites removes redundant re-scores              |
| `trainPerGen` 0 / 2 / 6                | **706 / 432 / 388** — memetic backprop pays for its re-scores via faster convergence      |

```mermaid
flowchart LR
  L[populationSize / elitism / trainPerGen] --> N["N_scored<br/>(full-corpus evaluations)"]
  C["per-eval cost C (s)<br/>from GRQ #3256"] --> W
  N --> W["modelled wall-clock<br/>= N_scored × C"]
  W --> R{"≥5% better than<br/>production baseline?"}
  R -- yes --> A[adopt preset]
  R -- no --> D[document negative / neutral]
```

## Test Plan

Added `test/bench/ProductionPaceLeverBakeOff.ts` (11 WHAT-tests, all passing):

- `runBakeOffConfig` is deterministic across repeated runs.
- Metrics are finite/non-negative and
  `modelledWallClockSeconds =
  scoredEvaluations × costPerEvalSeconds`.
- `eliteCount` grows with elitism and keeps ≥1; negatives clamp to the floor.
- **Elitism never increases scored evaluations** (score-carry contract).
- **`trainPerGen` adds full-corpus re-scores** (train=4 > train=0 strictly).
- Cost model is linear in `costPerEvalSeconds`.
- `runLeverSweep`, `recommendByWallClock`, and `formatBakeOffTable` behave.

`test/ci/BenchTaskConfig.ts` and `test/utils/NoUnusedStdDependency.ts` still
pass; `deno fmt`/`lint`/`check` and `markdownlint-cli2` are clean on the new
files.



## Milestone
This PR is part of the **#3256 Improve evolution wall-clock on production GRQ creatures & training data (benchmark-gated)** milestone and targets the `milestone/3256-improve-evolution-wall-clock-on-production-gr` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrdcugof-cd7a98`<!-- vibe-worker-issue-3259 -->