### PR TITLE
Fix docs/config imports: correct package scope + export createNeatConfig (#3271)

### DIFF
--- a/docs/DOC_STYLE.md
+++ b/docs/DOC_STYLE.md
@@ -33,6 +33,14 @@ Apply every rule below to any doc you write or audit.
    with the external/industry reference it cites. **Delete obsolete content
    outright** — do not archive it inline; stale docs mislead more than missing
    ones.
+   - **Import examples must resolve.** Every
+     `import … from "@stsoftware/neat-ai"` in an example must use the published
+     scope `@stsoftware/neat-ai` (never a stale scope such as
+     `@anthropic/neat-ai`) and may import **only** symbols actually re-exported
+     from [`mod.ts`](../mod.ts) — the package's sole `exports` entry. Never
+     import from a `src/…` path in reader-facing docs. If an example needs a
+     symbol that is not yet exported, add the re-export to `mod.ts` (and a
+     public-export test) rather than deep-importing (Issue #3271).
 5. **Keep documents small.** Favour several focused, linked sub-documents over
    one monolith. If a doc grows past a comfortable single-screen-of-scrolling
    topic, split it and link the parts (see how

--- a/docs/archive/pr-summaries/pr-summary-3271.md
+++ b/docs/archive/pr-summaries/pr-summary-3271.md
@@ -1,0 +1,66 @@
+# PR Summary — Fix `docs/config/` imports (Issue #3271)
+
+## Summary
+
+Every code example under `docs/config/` imported from the non-existent package
+scope `@anthropic/neat-ai`, so copy-pasting any config example failed to
+resolve. The published package is `@stsoftware/neat-ai` (`deno.json:2`). A
+second, related defect: the examples import `createNeatConfig`, which was
+**not** re-exported from `mod.ts` (the package's sole `exports` entry) — it
+lived only in `src/config/NeatConfig.ts`. So even with the scope fixed, the
+examples still failed to import.
+
+This PR fixes both defects so every `docs/config/` example works as written:
+
+- **Scope corrected** — replaced `@anthropic/neat-ai` with `@stsoftware/neat-ai`
+  in all nine affected `docs/config/*.md` files (CORE_EVOLUTION, DISCOVERY,
+  LOGGING, MUTATION_ADAPTATION, POPULATION, PRESETS, RECIPES, TRAINING,
+  WORKERS).
+- **Export gap closed** — re-exported `createNeatConfig` and the `NeatConfig`
+  type from `mod.ts`, so
+  `import { createNeatConfig } from "@stsoftware/neat-ai"` now resolves. This
+  also makes the `mod.ts` JSDoc preset example (lines 617-621) valid. The
+  presets themselves (`QUICK_START_PRESET`, …) were already exported.
+- **Style guard added** — `docs/DOC_STYLE.md` now records that example imports
+  must use the published `@stsoftware/neat-ai` scope and may import only symbols
+  actually re-exported from `mod.ts`.
+
+The historical record in `docs/archive/pr-summaries/pr-summary-2966.md`
+(documenting the earlier `@anthropic` → `@stsoftware` rename) is intentionally
+left unchanged.
+
+Closes #3271.
+
+## Evidence
+
+Backend/docs change — no web interface to screenshot. Verified via a new
+public-export test that imports `createNeatConfig` from the package root and
+exercises it exactly as the docs show, plus the existing quality gates.
+
+```mermaid
+flowchart LR
+    Doc["docs/config/*.md example<br/>import { createNeatConfig }<br/>from &quot;@stsoftware/neat-ai&quot;"]
+    Mod["mod.ts<br/>(package root, sole exports entry)"]
+    Src["src/config/NeatConfig.ts<br/>createNeatConfig()"]
+    Doc -->|resolves to| Mod
+    Mod -->|re-exports| Src
+```
+
+Before this PR the example resolved to `@anthropic/neat-ai` (no such package),
+and `createNeatConfig` was reachable only via a deep `src/…` path.
+
+## Test Plan
+
+- Added `test/docs/ConfigDocsExports.ts`:
+  - `mod.ts re-exports createNeatConfig (docs/config CORE_EVOLUTION example)` —
+    imports `createNeatConfig`/`NeatConfig` from `../../mod.ts` and asserts the
+    returned config; this failed to type-check before the re-export was added
+    (regression test for the export gap).
+  - `createNeatConfig accepts a spread preset with an override (docs/config
+    PRESETS example)`
+    — reproduces the `{ ...QUICK_START_PRESET, populationSize:
+    25 }` pattern
+    from the docs.
+- `deno test test/docs/ test/PublicExports_RL_test.ts` — passes.
+- `./quality.sh --check-only` — passes (whole-project type-check).
+- `./quality.sh --lint-only` — passes (fmt + lint + bash check).

--- a/docs/config/CORE_EVOLUTION.md
+++ b/docs/config/CORE_EVOLUTION.md
@@ -6,7 +6,7 @@ when to stop, and how growth is penalised. These options live on the top-level
 `NeatOptions` object and are validated by `createNeatConfig()`.
 
 ```ts
-import { createNeatConfig } from "@anthropic/neat-ai";
+import { createNeatConfig } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   populationSize: 50,

--- a/docs/config/DISCOVERY.md
+++ b/docs/config/DISCOVERY.md
@@ -8,7 +8,7 @@ remove low-impact elements) based on error patterns recorded during evaluation.
 Set `discoverySampleRate` to `-1` to disable discovery entirely.
 
 ```ts
-import { createNeatConfig } from "@anthropic/neat-ai";
+import { createNeatConfig } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   discoverySampleRate: 0.2,

--- a/docs/config/LOGGING.md
+++ b/docs/config/LOGGING.md
@@ -5,7 +5,7 @@ Artificial Intelligence) routes its log output, how often it logs, and how to
 make a run deterministic for reproducibility experiments.
 
 ```ts
-import { createNeatConfig } from "@anthropic/neat-ai";
+import { createNeatConfig } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   log: 1,

--- a/docs/config/MUTATION_ADAPTATION.md
+++ b/docs/config/MUTATION_ADAPTATION.md
@@ -7,7 +7,7 @@ exploration alive when the population stagnates, and tighten exploitation when
 fitness improves.
 
 ```ts
-import { createNeatConfig } from "@anthropic/neat-ai";
+import { createNeatConfig } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   adaptiveMutationThresholds: {

--- a/docs/config/POPULATION.md
+++ b/docs/config/POPULATION.md
@@ -6,7 +6,7 @@ creatures dedicated to fine-tuning, based on diversity and recent fitness
 improvements.
 
 ```ts
-import { createNeatConfig } from "@anthropic/neat-ai";
+import { createNeatConfig } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   populationSize: 100,

--- a/docs/config/PRESETS.md
+++ b/docs/config/PRESETS.md
@@ -6,7 +6,7 @@ is a `NeatOptions` object that can be spread into your configuration — user
 overrides take precedence when spread after the preset.
 
 ```ts
-import { createNeatConfig, QUICK_START_PRESET } from "@anthropic/neat-ai";
+import { createNeatConfig, QUICK_START_PRESET } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   ...QUICK_START_PRESET,
@@ -30,7 +30,7 @@ Small population, fast iterations, good for learning and prototyping. Discovery
 is disabled for speed.
 
 ```ts
-import { createNeatConfig, QUICK_START_PRESET } from "@anthropic/neat-ai";
+import { createNeatConfig, QUICK_START_PRESET } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   ...QUICK_START_PRESET,
@@ -48,7 +48,7 @@ ensemble diversity enabled. Suitable for complex problems requiring larger
 architectures.
 
 ```ts
-import { createNeatConfig, LARGE_NETWORK_PRESET } from "@anthropic/neat-ai";
+import { createNeatConfig, LARGE_NETWORK_PRESET } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   ...LARGE_NETWORK_PRESET,
@@ -69,7 +69,7 @@ smaller populations, and disables discovery.
 import {
   createNeatConfig,
   MEMORY_CONSTRAINED_PRESET,
-} from "@anthropic/neat-ai";
+} from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   ...MEMORY_CONSTRAINED_PRESET,
@@ -85,7 +85,10 @@ Aggressive structural evolution with higher sample rates, more neurons analysed
 per iteration, and longer timeouts. Suitable for finding novel architectures.
 
 ```ts
-import { createNeatConfig, DISCOVERY_FOCUSED_PRESET } from "@anthropic/neat-ai";
+import {
+  createNeatConfig,
+  DISCOVERY_FOCUSED_PRESET,
+} from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   ...DISCOVERY_FOCUSED_PRESET,
@@ -104,7 +107,7 @@ default**, so reaching `targetError` takes fewer generations. A one-line opt-in
 to "evolve faster".
 
 ```ts
-import { createNeatConfig, FAST_CONVERGENCE_PRESET } from "@anthropic/neat-ai";
+import { createNeatConfig, FAST_CONVERGENCE_PRESET } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   ...FAST_CONVERGENCE_PRESET,
@@ -144,7 +147,7 @@ import {
   createNeatConfig,
   DISCOVERY_FOCUSED_PRESET,
   MEMORY_CONSTRAINED_PRESET,
-} from "@anthropic/neat-ai";
+} from "@stsoftware/neat-ai";
 
 // Start with memory constraints, then override with discovery settings
 // but keep limited threads.

--- a/docs/config/RECIPES.md
+++ b/docs/config/RECIPES.md
@@ -8,7 +8,7 @@ starting point — adjust the values to your dataset and compute budget.
 Small population, quick iterations to validate an approach:
 
 ```ts
-import { createNeatConfig } from "@anthropic/neat-ai";
+import { createNeatConfig } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   populationSize: 10,

--- a/docs/config/TRAINING.md
+++ b/docs/config/TRAINING.md
@@ -7,7 +7,7 @@ and validated. These options sit on the top-level `NeatOptions` object or on
 dedicated nested configs (`dataFuzzing`, `crossValidation`).
 
 ```ts
-import { createNeatConfig } from "@anthropic/neat-ai";
+import { createNeatConfig } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   // Omit trainPerGen to auto-scale with the population for supervised costs

--- a/docs/config/WORKERS.md
+++ b/docs/config/WORKERS.md
@@ -7,7 +7,7 @@ roles, and control how creatures are distributed across workers during
 evaluation.
 
 ```ts
-import { createNeatConfig } from "@anthropic/neat-ai";
+import { createNeatConfig } from "@stsoftware/neat-ai";
 
 const config = createNeatConfig({
   threads: 8,

--- a/mod.ts
+++ b/mod.ts
@@ -121,6 +121,18 @@ export { CreatureUtil } from "@architecture/CreatureUtils.ts";
 export type { NeatOptions, NeatOptionsInput } from "@config/NeatOptions.ts";
 
 /**
+ * NEAT Configuration Factory
+ *
+ * Issue #3271: `createNeatConfig()` validates user `NeatOptions` and returns a
+ * frozen `NeatConfig`. It is the symbol every `docs/config/` example imports,
+ * so it must be reachable from the package root — not only from `src/`.
+ *
+ * @see {@link module:src/config/NeatConfig}
+ */
+export { createNeatConfig } from "@config/NeatConfig.ts";
+export type { NeatConfig } from "@config/NeatConfig.ts";
+
+/**
  * Output Range Constraints
  *
  * Issue #1620: Per-output range constraints for evolution. When specified,

--- a/test/docs/ConfigDocsExports.ts
+++ b/test/docs/ConfigDocsExports.ts
@@ -1,0 +1,43 @@
+/**
+ * Issue #3271 — fact-check guard for docs/config/.
+ *
+ * Every example under `docs/config/` imports `createNeatConfig` (and, in
+ * PRESETS.md, the built-in presets) from the package root `@stsoftware/neat-ai`,
+ * which resolves to `mod.ts`. Those examples only compile if the public entry
+ * point actually re-exports `createNeatConfig` and the `NeatConfig` type.
+ *
+ * These are "what" tests: `createNeatConfig` is imported from the public entry
+ * point and invoked exactly as the docs show, then the returned configuration
+ * is asserted — not a source-text grep.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  createNeatConfig,
+  type NeatConfig,
+  QUICK_START_PRESET,
+} from "../../mod.ts";
+
+Deno.test("mod.ts re-exports createNeatConfig (docs/config CORE_EVOLUTION example)", () => {
+  const config: NeatConfig = createNeatConfig({
+    populationSize: 50,
+    iterations: 1_000,
+    targetError: 0.05,
+    mutationRate: 0.3,
+    elitism: 1,
+    costOfGrowth: 0.000_000_1,
+  });
+  assertEquals(config.populationSize, 50);
+  assertEquals(config.iterations, 1_000);
+  // The factory returns a frozen, validated configuration.
+  assert(Object.isFrozen(config));
+});
+
+Deno.test("createNeatConfig accepts a spread preset with an override (docs/config PRESETS example)", () => {
+  const config: NeatConfig = createNeatConfig({
+    ...QUICK_START_PRESET,
+    populationSize: 25, // override preset value
+  });
+  assertEquals(config.populationSize, 25);
+  assert(Object.isFrozen(config));
+});


### PR DESCRIPTION
# PR Summary — Fix `docs/config/` imports (Issue #3271)

## Summary

Every code example under `docs/config/` imported from the non-existent package
scope `@anthropic/neat-ai`, so copy-pasting any config example failed to
resolve. The published package is `@stsoftware/neat-ai` (`deno.json:2`). A
second, related defect: the examples import `createNeatConfig`, which was
**not** re-exported from `mod.ts` (the package's sole `exports` entry) — it
lived only in `src/config/NeatConfig.ts`. So even with the scope fixed, the
examples still failed to import.

This PR fixes both defects so every `docs/config/` example works as written:

- **Scope corrected** — replaced `@anthropic/neat-ai` with `@stsoftware/neat-ai`
  in all nine affected `docs/config/*.md` files (CORE_EVOLUTION, DISCOVERY,
  LOGGING, MUTATION_ADAPTATION, POPULATION, PRESETS, RECIPES, TRAINING,
  WORKERS).
- **Export gap closed** — re-exported `createNeatConfig` and the `NeatConfig`
  type from `mod.ts`, so
  `import { createNeatConfig } from "@stsoftware/neat-ai"` now resolves. This
  also makes the `mod.ts` JSDoc preset example (lines 617-621) valid. The
  presets themselves (`QUICK_START_PRESET`, …) were already exported.
- **Style guard added** — `docs/DOC_STYLE.md` now records that example imports
  must use the published `@stsoftware/neat-ai` scope and may import only symbols
  actually re-exported from `mod.ts`.

The historical record in `docs/archive/pr-summaries/pr-summary-2966.md`
(documenting the earlier `@anthropic` → `@stsoftware` rename) is intentionally
left unchanged.

Closes #3271.

## Evidence

Backend/docs change — no web interface to screenshot. Verified via a new
public-export test that imports `createNeatConfig` from the package root and
exercises it exactly as the docs show, plus the existing quality gates.

```mermaid
flowchart LR
    Doc["docs/config/*.md example<br/>import { createNeatConfig }<br/>from &quot;@stsoftware/neat-ai&quot;"]
    Mod["mod.ts<br/>(package root, sole exports entry)"]
    Src["src/config/NeatConfig.ts<br/>createNeatConfig()"]
    Doc -->|resolves to| Mod
    Mod -->|re-exports| Src
```

Before this PR the example resolved to `@anthropic/neat-ai` (no such package),
and `createNeatConfig` was reachable only via a deep `src/…` path.

## Test Plan

- Added `test/docs/ConfigDocsExports.ts`:
  - `mod.ts re-exports createNeatConfig (docs/config CORE_EVOLUTION example)` —
    imports `createNeatConfig`/`NeatConfig` from `../../mod.ts` and asserts the
    returned config; this failed to type-check before the re-export was added
    (regression test for the export gap).
  - `createNeatConfig accepts a spread preset with an override (docs/config
    PRESETS example)`
    — reproduces the `{ ...QUICK_START_PRESET, populationSize:
    25 }` pattern
    from the docs.
- `deno test test/docs/ test/PublicExports_RL_test.ts` — passes.
- `./quality.sh --check-only` — passes (whole-project type-check).
- `./quality.sh --lint-only` — passes (fmt + lint + bash check).



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrei69j2-791557`<!-- vibe-worker-issue-3271 -->