### PR TITLE
Correct FAST_CONVERGENCE_PRESET discovery docs to 20% (Issue #3272)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3272.md
+++ b/docs/archive/pr-summaries/pr-summary-3272.md
@@ -1,0 +1,66 @@
+## Summary
+
+`docs/config/PRESETS.md` listed `FAST_CONVERGENCE_PRESET` with **Discovery =
+"Disabled"**, but the source contradicts that: the preset deliberately leaves
+`discoverySampleRate` unset, so config resolution falls through to
+`DEFAULT_DISCOVERY_SAMPLE_RATE` (`0.2` / 20%) and the Rust FFI discovery phase
+runs. The source is authoritative — unlike `QUICK_START_PRESET` and
+`MEMORY_CONSTRAINED_PRESET`, which explicitly set `discoverySampleRate: -1` to
+disable discovery, `FAST_CONVERGENCE_PRESET` does not. Keeping discovery enabled
+is consistent with the preset's stated purpose (reaching the target error in
+_fewer generations_): structural discovery can help find better topologies
+sooner, and the preset already trades extra per-generation compute for fewer
+generations overall.
+
+Chosen fix: option (a) from the issue — correct the docs to show 20% and make
+the deliberate design choice explicit in both the docs and the source docstring,
+so doc and source agree.
+
+Changes:
+
+- `docs/config/PRESETS.md` — table row now shows `20%`; the Fast Convergence
+  description and trade-offs note that `discoverySampleRate` is left at the
+  default and that discovery is **enabled** (not disabled for raw speed).
+- `src/presets/Presets.ts` — added a rationale bullet documenting the deliberate
+  unset of `discoverySampleRate` so future audits see the choice.
+- `test/config/Presets.ts` — new test asserting the resolved
+  `discoverySampleRate` equals `DEFAULT_DISCOVERY_SAMPLE_RATE`, locking
+  docs/source agreement.
+
+Closes #3272
+
+## Evidence
+
+Backend/docs change — no web UI to screenshot. Verified by the config-resolution
+test suite exercising the real `createNeatConfig()` path:
+
+```
+deno test test/config/Presets.ts
+...
+Fast Convergence preset - discovery stays at the default sample rate ... ok
+...
+ok | 26 passed | 0 failed
+```
+
+`./quality.sh --lint-only` and `./quality.sh --check-only` both pass over the
+full tree.
+
+```mermaid
+flowchart LR
+    P["FAST_CONVERGENCE_PRESET<br/>(no discoverySampleRate)"] --> R{createNeatConfig<br/>resolution}
+    R -->|key omitted| D["DEFAULT_DISCOVERY_SAMPLE_RATE = 0.2"]
+    D --> E["Discovery ENABLED at 20%"]
+    E --> Doc["docs table: 20% ✅"]
+```
+
+## Test Plan
+
+- Added
+  `test/config/Presets.ts::"Fast Convergence preset - discovery stays at
+  the default sample rate"`
+  — resolves the preset through `createNeatConfig()` and asserts
+  `discoverySampleRate === DEFAULT_DISCOVERY_SAMPLE_RATE` (0.2), not `-1`, and
+  `> 0`.
+- Ran the full `test/config/Presets.ts` suite: 26 passed, 0 failed.
+- `deno fmt`, `deno lint`, and `deno check` clean on the changed files;
+  `./quality.sh --lint-only` and `--check-only` pass.

--- a/docs/config/PRESETS.md
+++ b/docs/config/PRESETS.md
@@ -22,7 +22,7 @@ const config = createNeatConfig({
 | `LARGE_NETWORK_PRESET`      | 200        | 30%       | 2 hrs   | Complex problems with many inputs/outputs    |
 | `MEMORY_CONSTRAINED_PRESET` | 20         | Disabled  | 30 min  | Limited-memory environments, CI/CD runners   |
 | `DISCOVERY_FOCUSED_PRESET`  | 100        | 50%       | 3 hrs   | Finding novel architectures, research        |
-| `FAST_CONVERGENCE_PRESET`   | 50         | Disabled  | 30 min  | Reaching a target error in fewer generations |
+| `FAST_CONVERGENCE_PRESET`   | 50         | 20%       | 30 min  | Reaching a target error in fewer generations |
 
 ### ⚡ Quick Start
 
@@ -122,13 +122,18 @@ species stagnation tightened (`haltWindow: 12`, `extinctionWindow: 20`).
 `trainPerGen` is deliberately left unset so the supervised auto-scaling applies
 (`round(populationSize × 0.2)` — 10 for this population); pinning a small
 literal would starve gradient descent and slow convergence.
+`discoverySampleRate` is also left unset, so discovery stays at the default 20%
+(`DEFAULT_DISCOVERY_SAMPLE_RATE`); structural discovery is **enabled** for this
+preset and can help reach the target in fewer generations — it is not disabled
+for raw speed the way `QUICK_START_PRESET` and `MEMORY_CONSTRAINED_PRESET` are.
 
 > [!NOTE]
 > **Trade-offs.** Higher per-generation cost (adaptive sizing can grow the
-> population; the auto-scaled `trainPerGen` runs more backprop passes) and a
-> little more premature-convergence risk from the higher elitism and aggressive
-> plateau response. Plateau detection's 2× boost and per-species stagnation
-> reclamation are the diversity counter-weights.
+> population; the auto-scaled `trainPerGen` runs more backprop passes; discovery
+> stays at the default 20%, so the Rust FFI structural-analysis phase runs) and
+> a little more premature-convergence risk from the higher elitism and
+> aggressive plateau response. Plateau detection's 2× boost and per-species
+> stagnation reclamation are the diversity counter-weights.
 >
 > **When NOT to use it.** On trivially easy tasks (e.g. 2-input XOR) the
 > defaults already converge in a handful of generations and the extra

--- a/src/presets/Presets.ts
+++ b/src/presets/Presets.ts
@@ -204,6 +204,13 @@ export const DISCOVERY_FOCUSED_PRESET: NeatOptions = {
  *   Issue #2791). Pinning a small literal here would *starve* gradient
  *   descent below the default and slow convergence — the lever is the
  *   auto-scaling, not a hard-coded number.
+ * - **`discoverySampleRate` is deliberately left unset** so it resolves to
+ *   the default 20% (`DEFAULT_DISCOVERY_SAMPLE_RATE`). Discovery is *enabled*
+ *   for this preset — unlike `QUICK_START_PRESET` and
+ *   `MEMORY_CONSTRAINED_PRESET`, which set `discoverySampleRate: -1` to
+ *   disable it. Structural discovery can help reach the target in fewer
+ *   generations, which is exactly what this preset optimises for (Issue
+ *   #3272).
  * - `elitism: 2` — Retain the top two performers so hard-won solutions
  *   are never lost to mutation.
  * - `timeoutMinutes: 30` — Sensible wall-clock guard.

--- a/test/config/Presets.ts
+++ b/test/config/Presets.ts
@@ -6,7 +6,10 @@
  * user overrides via spread syntax.
  */
 import { assert, assertEquals, assertNotEquals } from "@std/assert";
-import { createNeatConfig } from "@config/NeatConfig.ts";
+import {
+  createNeatConfig,
+  DEFAULT_DISCOVERY_SAMPLE_RATE,
+} from "@config/NeatConfig.ts";
 import {
   DISCOVERY_FOCUSED_PRESET,
   FAST_CONVERGENCE_PRESET,
@@ -146,6 +149,20 @@ Deno.test("Fast Convergence preset - produces valid configuration", () => {
   );
   assertEquals(config.targetError, FAST_CONVERGENCE_PRESET.targetError);
   assertEquals(config.iterations, FAST_CONVERGENCE_PRESET.iterations);
+});
+
+Deno.test("Fast Convergence preset - discovery stays at the default sample rate", () => {
+  // The preset deliberately does NOT set discoverySampleRate, so config
+  // resolution falls through to DEFAULT_DISCOVERY_SAMPLE_RATE (0.2 / 20%).
+  // Discovery is therefore ENABLED for this preset (Issue #3272) — the docs
+  // table must reflect 20%, not "Disabled".
+  const config = createNeatConfig({ ...FAST_CONVERGENCE_PRESET });
+  assertEquals(config.discoverySampleRate, DEFAULT_DISCOVERY_SAMPLE_RATE);
+  assertNotEquals(config.discoverySampleRate, -1);
+  assert(
+    config.discoverySampleRate > 0,
+    "discovery must be active (rate > 0) for the Fast Convergence preset",
+  );
 });
 
 Deno.test("Fast Convergence preset - plateau detection is enabled", () => {


### PR DESCRIPTION
## Summary

`docs/config/PRESETS.md` listed `FAST_CONVERGENCE_PRESET` with **Discovery =
"Disabled"**, but the source contradicts that: the preset deliberately leaves
`discoverySampleRate` unset, so config resolution falls through to
`DEFAULT_DISCOVERY_SAMPLE_RATE` (`0.2` / 20%) and the Rust FFI discovery phase
runs. The source is authoritative — unlike `QUICK_START_PRESET` and
`MEMORY_CONSTRAINED_PRESET`, which explicitly set `discoverySampleRate: -1` to
disable discovery, `FAST_CONVERGENCE_PRESET` does not. Keeping discovery enabled
is consistent with the preset's stated purpose (reaching the target error in
_fewer generations_): structural discovery can help find better topologies
sooner, and the preset already trades extra per-generation compute for fewer
generations overall.

Chosen fix: option (a) from the issue — correct the docs to show 20% and make
the deliberate design choice explicit in both the docs and the source docstring,
so doc and source agree.

Changes:

- `docs/config/PRESETS.md` — table row now shows `20%`; the Fast Convergence
  description and trade-offs note that `discoverySampleRate` is left at the
  default and that discovery is **enabled** (not disabled for raw speed).
- `src/presets/Presets.ts` — added a rationale bullet documenting the deliberate
  unset of `discoverySampleRate` so future audits see the choice.
- `test/config/Presets.ts` — new test asserting the resolved
  `discoverySampleRate` equals `DEFAULT_DISCOVERY_SAMPLE_RATE`, locking
  docs/source agreement.

Closes #3272

## Evidence

Backend/docs change — no web UI to screenshot. Verified by the config-resolution
test suite exercising the real `createNeatConfig()` path:

```
deno test test/config/Presets.ts
...
Fast Convergence preset - discovery stays at the default sample rate ... ok
...
ok | 26 passed | 0 failed
```

`./quality.sh --lint-only` and `./quality.sh --check-only` both pass over the
full tree.

```mermaid
flowchart LR
    P["FAST_CONVERGENCE_PRESET<br/>(no discoverySampleRate)"] --> R{createNeatConfig<br/>resolution}
    R -->|key omitted| D["DEFAULT_DISCOVERY_SAMPLE_RATE = 0.2"]
    D --> E["Discovery ENABLED at 20%"]
    E --> Doc["docs table: 20% ✅"]
```

## Test Plan

- Added
  `test/config/Presets.ts::"Fast Convergence preset - discovery stays at
  the default sample rate"`
  — resolves the preset through `createNeatConfig()` and asserts
  `discoverySampleRate === DEFAULT_DISCOVERY_SAMPLE_RATE` (0.2), not `-1`, and
  `> 0`.
- Ran the full `test/config/Presets.ts` suite: 26 passed, 0 failed.
- `deno fmt`, `deno lint`, and `deno check` clean on the changed files;
  `./quality.sh --lint-only` and `--check-only` pass.



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrei6mnm-8618f5`<!-- vibe-worker-issue-3272 -->