### PR TITLE
docs(contributing): pin core by immutable SHA, not branch (Issue #3275)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,39 +135,56 @@ optional — tests and the core library work without it.
 
 Shared native Rust computation lives in the external
 [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) repository and is
-consumed by tracking `neatCore.ref` (default `Develop`) in `deno.json` and
-syncing `wasm_activation/pkg` via `./build.sh`.
+consumed as a vendored WASM bundle **pinned by an immutable 40-char SHA** in
+`deno.json` (`neatCore.rev`), attested by `neatCore.assetSha256`, and synced
+into `wasm_activation/pkg` via `./build.sh`. The `neatCore.ref` field is only a
+human-readable label recording which branch the pinned SHA came from — it is
+**not** branch-tracking. `deno.json` is the single source of truth; `neatCore`
+is pinned by SHA, never by branch.
 
-For the full pinning policy (semver rules, approval tiers, CI auth), see
-[docs/CORE_DEPENDENCY_POLICY.md](./docs/CORE_DEPENDENCY_POLICY.md).
+For the full pinning policy (semver rules, approval tiers, CI auth) see
+[docs/CORE_DEPENDENCY_POLICY.md](./docs/CORE_DEPENDENCY_POLICY.md); for the
+day-to-day bump workflow see
+[docs/EXTERNAL_NEAT_AI_CORE.md](./docs/EXTERNAL_NEAT_AI_CORE.md).
 
-### Using Latest Core in PRs
+### Bumping the pinned core revision
 
-By default, NEAT-AI follows latest `Develop` from NEAT-AI-core:
+`deno.json` pins the core by immutable SHA. A valid `neatCore` block carries
+`repo`, `ref`, a 40-char `rev`, and a 64-char `assetSha256`:
 
-1. Ensure `deno.json` has:
+```json
+"neatCore": {
+  "repo": "stSoftwareAU/NEAT-AI-core",
+  "ref": "Develop",
+  "rev": "fb793eba1fbfb2bf444ada43cc97b059292d1abc",
+  "assetSha256": "81f7b7a886b8bedbea85c0dda216058e02181f64035034904038e76a36102fe3"
+}
+```
 
-   ```json
-   "neatCore": { "repo": "stSoftwareAU/NEAT-AI-core", "ref": "Develop" }
-   ```
+An example that omits `rev`/`assetSha256` would fail `./quality.sh`, which runs
+`./build.sh --verify-only` and errors when `neatCore.rev` is unset.
 
-2. Refresh the WASM package:
+To bump the pin (see
+[docs/EXTERNAL_NEAT_AI_CORE.md](./docs/EXTERNAL_NEAT_AI_CORE.md) for the
+authoritative workflow):
 
-   ```bash
-   ./build.sh
-   ```
-
-3. (Historical note for older branches) some workflows mention
+1. Run `./build.sh` — it resolves the target NEAT-AI-core commit, downloads the
+   matching `wasm-bundle-<SHA>` artefact, refreshes `wasm_activation/pkg`, and
+   updates `deno.json` `neatCore.rev` + `assetSha256`. Pass a specific commit
+   with `./build.sh --rev <40-char-sha>`.
+2. (Historical note for older branches) some workflows mention
    `cargo update -p neat-core`; in this repository layout, use `./build.sh`
    instead because Rust/Cargo is no longer built in-tree.
-4. Run the full `./quality.sh` gate.
-5. Run the parity gate to verify no behavioural drift:
+3. Run the full `./quality.sh` gate.
+4. Run the parity gate to verify no behavioural drift:
 
    ```bash
    ./scripts/parity-gate.sh
    ```
 
-6. Commit the artifact refresh in your PR (approval controls rollout timing).
+5. Commit the updated `deno.json` and `wasm_activation/pkg` **together** in your
+   PR — the pin and the artefact must move as one commit (approval controls
+   rollout timing).
 
 See [docs/PARITY_GATE.md](./docs/PARITY_GATE.md) for the full parity checklist
 that must pass before removing in-tree Rust or after any core bump.

--- a/docs/archive/pr-summaries/pr-summary-3275.md
+++ b/docs/archive/pr-summaries/pr-summary-3275.md
@@ -1,0 +1,66 @@
+# Fix CONTRIBUTING.md core-pinning contradiction (immutable SHA, not branch)
+
+## Summary
+
+`CONTRIBUTING.md` described the NEAT-AI-core dependency as **branch-tracking**
+("consumed by tracking `neatCore.ref` (default `Develop`)" and "By default,
+NEAT-AI follows latest `Develop`", with a `rev`-less example config). That
+contradicted the rest of the repo, which pins core by an **immutable 40-char
+SHA**: `README.md`, `AGENTS.md`, `deno.json` (`neatCore.rev` + `assetSha256`),
+and `build.sh --verify-only` (called by `quality.sh`). A first-time contributor
+following the old wording would write a branch-tracking `neatCore` block and hit
+a `quality.sh` failure they could not explain.
+
+This rewrites the core-pinning section of `CONTRIBUTING.md` to match the
+immutable-SHA policy:
+
+- Describe pinning via `neatCore.rev` (40-char SHA) + `assetSha256` in
+  `deno.json`, and clarify that `neatCore.ref` is only a human-readable branch
+  label — not branch-tracking.
+- Drop the "follows latest `Develop`" wording.
+- Replace the `rev`-less example with a full `neatCore` block including `rev`
+  and `assetSha256`, and note that a `rev`-less example would fail `quality.sh`
+  (which runs `build.sh --verify-only`).
+- Link `docs/EXTERNAL_NEAT_AI_CORE.md` as the authoritative bump workflow
+  (alongside the existing `docs/CORE_DEPENDENCY_POLICY.md` link) rather than
+  restating it.
+
+Closes #3275.
+
+## Evidence
+
+Documentation + test change only; no web interface to screenshot. Verified via
+`deno test`, `deno fmt --check`, `deno lint`, `markdownlint-cli2`, and
+`./build.sh --verify-only` (exit 0).
+
+The contradiction the fix removes:
+
+```mermaid
+flowchart LR
+    subgraph Before["Before — contradiction"]
+        C1["CONTRIBUTING.md<br/>follows latest Develop<br/>(rev-less example)"] -. "contradicts" .- P1["README / AGENTS / deno.json<br/>build.sh --verify-only<br/>immutable SHA"]
+    end
+    subgraph After["After — aligned"]
+        C2["CONTRIBUTING.md<br/>pinned by rev + assetSha256"] --- P2["README / AGENTS / deno.json<br/>build.sh --verify-only<br/>immutable SHA"]
+    end
+    Before --> After
+```
+
+## Test Plan
+
+Added `test/scripts/ContributingCorePin.ts` (parses the `json` `neatCore` fenced
+block in `CONTRIBUTING.md` and asserts against real values — no source
+grepping):
+
+- `CONTRIBUTING.md documents a json neatCore example` — the block exists.
+- `CONTRIBUTING.md neatCore example is SHA-pinned, not branch-tracking` —
+  example carries a 40-char hex `rev` and a 64-char hex `assetSha256`.
+  Reproduces #3275: fails against the old `rev`-less example, passes after the
+  fix.
+- `CONTRIBUTING.md neatCore example agrees with deno.json on repo` — documented
+  `repo` matches `deno.json`.
+- `CONTRIBUTING.md does not claim core follows latest Develop` — the
+  branch-tracking claim is gone.
+
+All four pass; existing `test/scripts/CoreDependencyPolicy.ts` continues to
+pass.

--- a/test/scripts/ContributingCorePin.ts
+++ b/test/scripts/ContributingCorePin.ts
@@ -1,0 +1,95 @@
+import { assert, assertEquals } from "@std/assert";
+
+/**
+ * Tests that CONTRIBUTING.md describes the NEAT-AI-core dependency as
+ * immutable-SHA pinned — matching deno.json, README.md, AGENTS.md and the
+ * `build.sh --verify-only` gate — rather than branch-tracking.
+ *
+ * Issue #3275 — CONTRIBUTING.md previously said core "follows latest Develop"
+ * and showed a `rev`-less example config that would fail `quality.sh`
+ * (which runs `build.sh --verify-only`, requiring `neatCore.rev`).
+ */
+
+const DENO_JSON = "deno.json";
+const CONTRIBUTING = "CONTRIBUTING.md";
+
+/**
+ * Extract the `neatCore` pin advertised by a documented `json` fenced block
+ * and parse it into an object. The fenced block is an object body
+ * (a `"neatCore": { ... }` fragment), so we wrap it in braces before parsing.
+ */
+function extractDocNeatCore(
+  doc: string,
+): {
+  repo?: unknown;
+  ref?: unknown;
+  rev?: unknown;
+  assetSha256?: unknown;
+} | null {
+  const fences = doc.matchAll(/```json\s*([\s\S]*?)```/g);
+  for (const match of fences) {
+    const body = match[1];
+    if (!body.includes('"neatCore"')) continue;
+    try {
+      const parsed = JSON.parse(`{${body}}`);
+      return parsed.neatCore ?? null;
+    } catch {
+      // Not a parseable fragment — keep scanning for the right block.
+    }
+  }
+  return null;
+}
+
+Deno.test("CONTRIBUTING.md documents a json neatCore example", async () => {
+  const doc = await Deno.readTextFile(CONTRIBUTING);
+  const docNeatCore = extractDocNeatCore(doc);
+  assert(
+    docNeatCore,
+    `${CONTRIBUTING} must document a json neatCore block`,
+  );
+});
+
+Deno.test("CONTRIBUTING.md neatCore example is SHA-pinned, not branch-tracking", async () => {
+  const doc = await Deno.readTextFile(CONTRIBUTING);
+  const docNeatCore = extractDocNeatCore(doc);
+  assert(docNeatCore, `${CONTRIBUTING} must document a json neatCore block`);
+
+  assert(
+    typeof docNeatCore.rev === "string" &&
+      /^[0-9a-f]{40}$/.test(docNeatCore.rev),
+    "CONTRIBUTING.md neatCore example must include a 40-char hex neatCore.rev " +
+      "so it matches the immutable-SHA policy and passes build.sh --verify-only",
+  );
+  assert(
+    typeof docNeatCore.assetSha256 === "string" &&
+      /^[0-9a-f]{64}$/.test(docNeatCore.assetSha256),
+    "CONTRIBUTING.md neatCore example must include a 64-char hex " +
+      "neatCore.assetSha256 attesting the vendored WASM bundle",
+  );
+});
+
+Deno.test("CONTRIBUTING.md neatCore example agrees with deno.json on repo", async () => {
+  const json = JSON.parse(await Deno.readTextFile(DENO_JSON));
+  const denoNeatCore = json.neatCore;
+  assert(denoNeatCore, "deno.json must define neatCore");
+
+  const doc = await Deno.readTextFile(CONTRIBUTING);
+  const docNeatCore = extractDocNeatCore(doc);
+  assert(docNeatCore, `${CONTRIBUTING} must document a json neatCore block`);
+
+  assertEquals(
+    docNeatCore.repo,
+    denoNeatCore.repo,
+    "CONTRIBUTING.md and deno.json must agree on neatCore.repo",
+  );
+});
+
+Deno.test("CONTRIBUTING.md does not claim core follows latest Develop", async () => {
+  const doc = await Deno.readTextFile(CONTRIBUTING);
+  // The branch-tracking claim contradicts the immutable-SHA pinning policy.
+  assert(
+    !/follows latest\s+`?Develop`?/i.test(doc),
+    "CONTRIBUTING.md must not describe core as following latest Develop — " +
+      "core is pinned by immutable SHA in deno.json (Issue #3275)",
+  );
+});


### PR DESCRIPTION
# Fix CONTRIBUTING.md core-pinning contradiction (immutable SHA, not branch)

## Summary

`CONTRIBUTING.md` described the NEAT-AI-core dependency as **branch-tracking**
("consumed by tracking `neatCore.ref` (default `Develop`)" and "By default,
NEAT-AI follows latest `Develop`", with a `rev`-less example config). That
contradicted the rest of the repo, which pins core by an **immutable 40-char
SHA**: `README.md`, `AGENTS.md`, `deno.json` (`neatCore.rev` + `assetSha256`),
and `build.sh --verify-only` (called by `quality.sh`). A first-time contributor
following the old wording would write a branch-tracking `neatCore` block and hit
a `quality.sh` failure they could not explain.

This rewrites the core-pinning section of `CONTRIBUTING.md` to match the
immutable-SHA policy:

- Describe pinning via `neatCore.rev` (40-char SHA) + `assetSha256` in
  `deno.json`, and clarify that `neatCore.ref` is only a human-readable branch
  label — not branch-tracking.
- Drop the "follows latest `Develop`" wording.
- Replace the `rev`-less example with a full `neatCore` block including `rev`
  and `assetSha256`, and note that a `rev`-less example would fail `quality.sh`
  (which runs `build.sh --verify-only`).
- Link `docs/EXTERNAL_NEAT_AI_CORE.md` as the authoritative bump workflow
  (alongside the existing `docs/CORE_DEPENDENCY_POLICY.md` link) rather than
  restating it.

Closes #3275.

## Evidence

Documentation + test change only; no web interface to screenshot. Verified via
`deno test`, `deno fmt --check`, `deno lint`, `markdownlint-cli2`, and
`./build.sh --verify-only` (exit 0).

The contradiction the fix removes:

```mermaid
flowchart LR
    subgraph Before["Before — contradiction"]
        C1["CONTRIBUTING.md<br/>follows latest Develop<br/>(rev-less example)"] -. "contradicts" .- P1["README / AGENTS / deno.json<br/>build.sh --verify-only<br/>immutable SHA"]
    end
    subgraph After["After — aligned"]
        C2["CONTRIBUTING.md<br/>pinned by rev + assetSha256"] --- P2["README / AGENTS / deno.json<br/>build.sh --verify-only<br/>immutable SHA"]
    end
    Before --> After
```

## Test Plan

Added `test/scripts/ContributingCorePin.ts` (parses the `json` `neatCore` fenced
block in `CONTRIBUTING.md` and asserts against real values — no source
grepping):

- `CONTRIBUTING.md documents a json neatCore example` — the block exists.
- `CONTRIBUTING.md neatCore example is SHA-pinned, not branch-tracking` —
  example carries a 40-char hex `rev` and a 64-char hex `assetSha256`.
  Reproduces #3275: fails against the old `rev`-less example, passes after the
  fix.
- `CONTRIBUTING.md neatCore example agrees with deno.json on repo` — documented
  `repo` matches `deno.json`.
- `CONTRIBUTING.md does not claim core follows latest Develop` — the
  branch-tracking claim is gone.

All four pass; existing `test/scripts/CoreDependencyPolicy.ts` continues to
pass.



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrei69j2-791557`<!-- vibe-worker-issue-3275 -->