### PR TITLE
Fix wrong defaults and mislabelled semantics in docs/api/CONFIGURATION.md (Issue #3277)

### DIFF
--- a/docs/api/CONFIGURATION.md
+++ b/docs/api/CONFIGURATION.md
@@ -56,20 +56,20 @@ import type { NeatOptions, NeatOptionsInput } from "@stsoftware/neat-ai";
 
 ### 🎯 Core fields
 
-| Field            | Type                  | Default                         | Description                                                |
-| ---------------- | --------------------- | ------------------------------- | ---------------------------------------------------------- |
-| `costName`       | `CostName`            | `"MSE"`                         | Cost function name                                         |
-| `populationSize` | `number`              | `50`                            | Target population size (min: 2)                            |
-| `iterations`     | `number`              | `MAX_SAFE_INTEGER`              | Maximum evolution generations                              |
-| `targetError`    | `number`              | `0.05`                          | Stop when error falls below this (0–1)                     |
-| `mutationRate`   | `number`              | `0.3`                           | Probability of mutation (>0.001)                           |
-| `mutationAmount` | `number`              | `1`                             | Number of changes per gene during mutation (min: 1)        |
-| `elitism`        | `number`              | `1`                             | Top-performing creatures retained each generation (min: 1) |
-| `selection`      | `SelectionInterface`  | Random                          | Selection strategy (randomly chosen each run)              |
-| `mutation`       | `MutationInterface[]` | `Mutation.FFW`                  | Allowed mutation types                                     |
-| `threads`        | `number`              | `navigator.hardwareConcurrency` | Worker threads for parallel evaluation                     |
-| `verbose`        | `boolean`             | `false`                         | Enable debug logging                                       |
-| `log`            | `number`              | `0`                             | Log status every N generations (0 = off, 1 if verbose)     |
+| Field            | Type                  | Default                             | Description                                                                               |
+| ---------------- | --------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------- |
+| `costName`       | `CostName`            | `"MSE"`                             | Cost function name                                                                        |
+| `populationSize` | `number`              | `50`                                | Target population size (min: 2)                                                           |
+| `iterations`     | `number`              | `MAX_SAFE_INTEGER`                  | Maximum evolution generations                                                             |
+| `targetError`    | `number`              | `0.05`                              | Stop when error falls below this (0–1)                                                    |
+| `mutationRate`   | `number`              | `0.3`                               | Probability of mutation (>0.001)                                                          |
+| `mutationAmount` | `number`              | `1`                                 | Number of changes per gene during mutation (min: 1)                                       |
+| `elitism`        | `number`              | `1`                                 | Top-performing creatures retained each generation (min: 1)                                |
+| `selection`      | `SelectionInterface`  | Random                              | Selection strategy (randomly chosen each run)                                             |
+| `mutation`       | `MutationInterface[]` | `Mutation.FFW`                      | Allowed mutation types                                                                    |
+| `threads`        | `number`              | `navigator.hardwareConcurrency + 2` | Worker threads for parallel evaluation (see [Workers](../config/WORKERS.md))              |
+| `verbose`        | `boolean`             | `false`                             | Verbose logging; when `true`, `log` defaults to `1` (see [Logging](../config/LOGGING.md)) |
+| `log`            | `number`              | `0`                                 | Log status every N generations (0 = off, 1 if verbose)                                    |
 
 ### 🎓 Training fields
 
@@ -84,12 +84,12 @@ import type { NeatOptions, NeatOptionsInput } from "@stsoftware/neat-ai";
 
 ### 🔒 Network constraints
 
-| Field                  | Type      | Default       | Description                           |
-| ---------------------- | --------- | ------------- | ------------------------------------- |
-| `feedbackLoop`         | `boolean` | `false`       | Enable recurrent connections          |
-| `maxConns`             | `number`  | `Infinity`    | Maximum synapses allowed              |
-| `maximumNumberOfNodes` | `number`  | `Infinity`    | Maximum hidden neurons allowed        |
-| `costOfGrowth`         | `number`  | `0.000_000_1` | Complexity penalty per synapse/neuron |
+| Field                  | Type      | Default            | Description                                                                  |
+| ---------------------- | --------- | ------------------ | ---------------------------------------------------------------------------- |
+| `feedbackLoop`         | `boolean` | `false`            | Enable recurrent connections                                                 |
+| `maxConns`             | `number`  | `MAX_SAFE_INTEGER` | Maximum synapses allowed (see [Core evolution](../config/CORE_EVOLUTION.md)) |
+| `maximumNumberOfNodes` | `number`  | `MAX_SAFE_INTEGER` | Maximum neurons allowed (see [Core evolution](../config/CORE_EVOLUTION.md))  |
+| `costOfGrowth`         | `number`  | `0.000_000_1`      | Complexity penalty per synapse/neuron                                        |
 
 ### 🔬 Discovery fields
 
@@ -211,8 +211,8 @@ defaults are applied.
 
 | Field                 | Type     | Default | Description                                            |
 | --------------------- | -------- | ------- | ------------------------------------------------------ |
-| `medium`              | `number` | `100`   | Synapse count threshold for "medium" creatures         |
-| `large`               | `number` | `300`   | Synapse count threshold for "large" creatures          |
+| `medium`              | `number` | `100`   | Neuron count threshold for "medium" creatures          |
+| `large`               | `number` | `300`   | Neuron count threshold for "large" creatures           |
 | `largeTopologyWeight` | `number` | `0.1`   | Topology mutation weight reduction for large creatures |
 
 ### `mcmc` — MCMCConfig

--- a/docs/archive/pr-summaries/pr-summary-3277.md
+++ b/docs/archive/pr-summaries/pr-summary-3277.md
@@ -1,0 +1,51 @@
+# Fix wrong defaults and mislabelled semantics in `docs/api/CONFIGURATION.md`
+
+## Summary
+
+The config-key reference table in `docs/api/CONFIGURATION.md` had drifted from
+the source of truth in `src/config/NeatConfig.ts`, listing wrong defaults and
+mislabelling what several knobs control. Reconciled each row against the code
+(and, where a sibling `docs/config/*` doc already documents the value, linked to
+it so the two copies stop drifting). Closes #3277.
+
+Corrections:
+
+| Field                              | Was                              | Now                                                        | Source of truth                                        |
+| ---------------------------------- | -------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ |
+| `threads` default                  | `navigator.hardwareConcurrency`  | `navigator.hardwareConcurrency + 2` (+ link to Workers)    | `NeatConfig.ts:239-240`, `DEFAULT_HEAVY_TASK_WORKER_COUNT` = 2 |
+| `maxConns` default                 | `Infinity`                       | `MAX_SAFE_INTEGER` (+ link to Core evolution)              | `NeatConfig.ts` `parseNumber(... MAX_SAFE_INTEGER)`    |
+| `maximumNumberOfNodes` default     | `Infinity` / "Maximum **hidden** neurons" | `MAX_SAFE_INTEGER` / "Maximum neurons" (+ link) | `NeatConfig.ts` (caps all neurons)                     |
+| `adaptiveMutationThresholds.medium`/`.large` | "**Synapse** count threshold" | "Neuron count threshold"                    | `AdaptiveMutationThresholds.ts:13,20`                  |
+| `verbose` description              | "Enable debug logging"           | "Verbose logging; when `true`, `log` defaults to `1`" (+ link to Logging) | `NeatConfig.ts:420,424` (`verbose` ≠ `debug`) |
+
+`verbose` and `debug` are distinct flags: `debug` toggles debug mode, while
+`verbose` controls log cadence (it makes `log` default to `1`).
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot. Verified by a new
+"what" test that parses the doc table and asserts each documented default/label
+matches the real source constant, so the drift cannot silently return.
+
+```
+deno test --allow-read test/docs/ApiConfigurationDefaults.ts
+ok | 6 passed | 0 failed
+```
+
+Full quality gate: `7578 passed | 0 failed`.
+
+## Test Plan
+
+Added `test/docs/ApiConfigurationDefaults.ts` (fails against the unfixed doc,
+passes after the fix):
+
+- `threads` default documents `+ DEFAULT_HEAVY_TASK_WORKER_COUNT`.
+- `maxConns` default is `MAX_SAFE_INTEGER`, not `Infinity`.
+- `maximumNumberOfNodes` default is `MAX_SAFE_INTEGER` and is not labelled
+  "hidden".
+- `adaptiveMutationThresholds.medium`/`.large` are neuron (not synapse) counts.
+- `verbose` description is not conflated with `debug`.
+- Documented numeric defaults still match `createNeatConfig({})`.
+
+Existing `test/docs/ApiReferenceSplit.ts` continues to pass, confirming the new
+relative links resolve on disk.

--- a/test/docs/ApiConfigurationDefaults.ts
+++ b/test/docs/ApiConfigurationDefaults.ts
@@ -1,0 +1,94 @@
+/**
+ * Issue #3277 — verifies the config-key reference table in
+ * docs/api/CONFIGURATION.md matches the source of truth in
+ * src/config/NeatConfig.ts (and AdaptiveMutationThresholds.ts).
+ *
+ * These are "what" tests: they read the actual doc (data) and the actual
+ * source constants, then assert the documented defaults and semantics agree
+ * with the code. They fail if the doc drifts from the source again.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, resolve } from "@std/path";
+import { DEFAULT_HEAVY_TASK_WORKER_COUNT } from "@config/NeatConfig.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+
+const REPO_ROOT = resolve(fromFileUrl(import.meta.url), "..", "..", "..");
+const CONFIG_DOC = `${REPO_ROOT}/docs/api/CONFIGURATION.md`;
+
+/** Return the trimmed cells of the first markdown table row whose first cell
+ * contains the given field name in backticks. */
+async function tableRow(field: string): Promise<string[]> {
+  const content = await Deno.readTextFile(CONFIG_DOC);
+  const needle = `\`${field}\``;
+  for (const line of content.split("\n")) {
+    if (!line.trimStart().startsWith("|")) continue;
+    const cells = line.split("|").slice(1, -1).map((c) => c.trim());
+    if (cells.length > 0 && cells[0].includes(needle)) return cells;
+  }
+  throw new Error(`No table row found for field \`${field}\` in ${CONFIG_DOC}`);
+}
+
+Deno.test("CONFIGURATION.md - threads default reflects hardwareConcurrency + heavyTaskWorkerCount", async () => {
+  const [, , def] = await tableRow("threads");
+  // The source computes hardwareConcurrency + DEFAULT_HEAVY_TASK_WORKER_COUNT,
+  // not a bare hardwareConcurrency. The row must show the "+ N" addend.
+  assert(
+    def.includes(`+ ${DEFAULT_HEAVY_TASK_WORKER_COUNT}`),
+    `threads default must document "+ ${DEFAULT_HEAVY_TASK_WORKER_COUNT}", got: ${def}`,
+  );
+});
+
+Deno.test("CONFIGURATION.md - maxConns default is MAX_SAFE_INTEGER not Infinity", async () => {
+  const [, , def] = await tableRow("maxConns");
+  assert(def.includes("MAX_SAFE_INTEGER"), `maxConns default wrong: ${def}`);
+  assert(!def.includes("Infinity"), `maxConns must not say Infinity: ${def}`);
+});
+
+Deno.test("CONFIGURATION.md - maximumNumberOfNodes default and semantics", async () => {
+  const row = await tableRow("maximumNumberOfNodes");
+  const def = row[2];
+  const desc = row[3];
+  assert(
+    def.includes("MAX_SAFE_INTEGER"),
+    `maximumNumberOfNodes default wrong: ${def}`,
+  );
+  assert(!def.includes("Infinity"), `must not say Infinity: ${def}`);
+  // Caps all neurons, not only hidden neurons.
+  assert(
+    !/hidden/i.test(desc),
+    `maximumNumberOfNodes must not be labelled "hidden": ${desc}`,
+  );
+});
+
+Deno.test("CONFIGURATION.md - adaptiveMutationThresholds medium/large are neuron counts", async () => {
+  const fields = ["medium", "large"];
+  const rows = await Promise.all(fields.map((f) => tableRow(f)));
+  fields.forEach((field, i) => {
+    const desc = rows[i][3];
+    assert(
+      /neuron/i.test(desc),
+      `${field} must be a neuron count threshold: ${desc}`,
+    );
+    assert(
+      !/synapse/i.test(desc),
+      `${field} must not be labelled a synapse count: ${desc}`,
+    );
+  });
+});
+
+Deno.test("CONFIGURATION.md - verbose is not conflated with debug", async () => {
+  const desc = (await tableRow("verbose"))[3];
+  assert(
+    !/debug/i.test(desc),
+    `verbose description must not mention debug (that is a separate flag): ${desc}`,
+  );
+});
+
+Deno.test("CONFIGURATION.md - documented defaults still match code", () => {
+  // Guards the numeric source-of-truth the doc now cites.
+  const config = createNeatConfig({});
+  assert(config.maxConns === Number.MAX_SAFE_INTEGER);
+  assert(config.maximumNumberOfNodes === Number.MAX_SAFE_INTEGER);
+  assert(DEFAULT_HEAVY_TASK_WORKER_COUNT === 2);
+});


### PR DESCRIPTION
# Fix wrong defaults and mislabelled semantics in `docs/api/CONFIGURATION.md`

## Summary

The config-key reference table in `docs/api/CONFIGURATION.md` had drifted from
the source of truth in `src/config/NeatConfig.ts`, listing wrong defaults and
mislabelling what several knobs control. Reconciled each row against the code
(and, where a sibling `docs/config/*` doc already documents the value, linked to
it so the two copies stop drifting). Closes #3277.

Corrections:

| Field                                        | Was                                       | Now                                                                       | Source of truth                                                |
| -------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------- |
| `threads` default                            | `navigator.hardwareConcurrency`           | `navigator.hardwareConcurrency + 2` (+ link to Workers)                   | `NeatConfig.ts:239-240`, `DEFAULT_HEAVY_TASK_WORKER_COUNT` = 2 |
| `maxConns` default                           | `Infinity`                                | `MAX_SAFE_INTEGER` (+ link to Core evolution)                             | `NeatConfig.ts` `parseNumber(... MAX_SAFE_INTEGER)`            |
| `maximumNumberOfNodes` default               | `Infinity` / "Maximum **hidden** neurons" | `MAX_SAFE_INTEGER` / "Maximum neurons" (+ link)                           | `NeatConfig.ts` (caps all neurons)                             |
| `adaptiveMutationThresholds.medium`/`.large` | "**Synapse** count threshold"             | "Neuron count threshold"                                                  | `AdaptiveMutationThresholds.ts:13,20`                          |
| `verbose` description                        | "Enable debug logging"                    | "Verbose logging; when `true`, `log` defaults to `1`" (+ link to Logging) | `NeatConfig.ts:420,424` (`verbose` ≠ `debug`)                  |

`verbose` and `debug` are distinct flags: `debug` toggles debug mode, while
`verbose` controls log cadence (it makes `log` default to `1`).

## Evidence

Documentation-only change — no web interface to screenshot. Verified by a new
"what" test that parses the doc table and asserts each documented default/label
matches the real source constant, so the drift cannot silently return.

```
deno test --allow-read test/docs/ApiConfigurationDefaults.ts
ok | 6 passed | 0 failed
```

Full quality gate: `7578 passed | 0 failed`.

## Test Plan

Added `test/docs/ApiConfigurationDefaults.ts` (fails against the unfixed doc,
passes after the fix):

- `threads` default documents `+ DEFAULT_HEAVY_TASK_WORKER_COUNT`.
- `maxConns` default is `MAX_SAFE_INTEGER`, not `Infinity`.
- `maximumNumberOfNodes` default is `MAX_SAFE_INTEGER` and is not labelled
  "hidden".
- `adaptiveMutationThresholds.medium`/`.large` are neuron (not synapse) counts.
- `verbose` description is not conflated with `debug`.
- Documented numeric defaults still match `createNeatConfig({})`.

Existing `test/docs/ApiReferenceSplit.ts` continues to pass, confirming the new
relative links resolve on disk.



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mreknml9-8c8aae`<!-- vibe-worker-issue-3277 -->