### PR TITLE
docs(api): reconcile stale method signatures/return shapes with src/ (Issue #3278)

### DIFF
--- a/docs/api/CREATURE.md
+++ b/docs/api/CREATURE.md
@@ -66,22 +66,22 @@ new Creature(input: number, output: number, options?: {
 
 ### 🔧 Key Methods
 
-| Method               | Signature                                                                                   | Description                                                                                        |
-| -------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `activate`           | `(input: Float32Array, feedbackLoop?: boolean): Float32Array`                               | Forward pass through the network using WASM. Returns output values.                                |
-| `activateAndTrace`   | `(input: Float32Array, feedbackLoop: boolean, sparseConfig: SparseConfig): Float32Array`    | Activation with tracing enabled for analysis.                                                      |
-| `propagate`          | `(expected: Float32Array, config: BackPropagationConfig, sparseConfig: SparseConfig): void` | Backpropagation — propagates errors backwards through the network.                                 |
-| `propagateUpdate`    | `(config: BackPropagationConfig, sparseConfig: SparseConfig): void`                         | Updates weights/biases based on propagated errors.                                                 |
-| `record`             | `(expected: Float32Array): Map<string, DiscoverRecord>`                                     | Records expected outputs for discovery analysis.                                                   |
-| `exportJSON`         | `(): CreatureExport`                                                                        | Canonical serialisation: wire UUIDs plus resolved runtime ids (`id` / `fromId` / `toId`).          |
-| `exportSnapshotJSON` | `(): CreatureExport`                                                                        | Wire-only snapshot: same topology as `exportJSON` but omits numeric ids (sharing / schema checks). |
-| `traceJSON`          | `(): CreatureTrace`                                                                         | Exports with detailed trace information from last activation.                                      |
-| `loadFrom`           | `(json: CreatureInternal \| CreatureExport, validate: boolean): void`                       | Loads creature structure from a JSON object.                                                       |
-| `connect`            | `(from: number, to: number, weight: number, type?: SynapseType): Synapse`                   | Creates a synapse between two neurons.                                                             |
-| `getSynapse`         | `(from: number, to: number): Synapse \| null`                                               | Gets the synapse between two neurons, or `null`.                                                   |
-| `shallowClone`       | `(): Creature`                                                                              | Fast clone without JSON serialisation overhead.                                                    |
-| `dispose`            | `(): void`                                                                                  | Releases all resources and memory.                                                                 |
-| `clearCache`         | `(from?: number, to?: number): void`                                                        | Clears internal synapse connection caches.                                                         |
+| Method               | Signature                                                                                   | Description                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `activate`           | `(input: Float32Array, feedbackLoop?: boolean): Float32Array`                               | Forward pass through the network using WASM. Returns output values.                                   |
+| `activateAndTrace`   | `(input: Float32Array, feedbackLoop: boolean, sparseConfig: SparseConfig): Float32Array`    | Activation with tracing enabled for analysis.                                                         |
+| `propagate`          | `(expected: Float32Array, config: BackPropagationConfig, sparseConfig: SparseConfig): void` | Backpropagation — propagates errors backwards through the network.                                    |
+| `propagateUpdate`    | `(config: BackPropagationConfig, sparseConfig: SparseConfig): void`                         | Updates weights/biases based on propagated errors.                                                    |
+| `record`             | `(expected: Float32Array): Map<number, DiscoverRecord>`                                     | Records expected outputs for discovery analysis. The map key is the runtime neuron `id` (a `number`). |
+| `exportJSON`         | `(): CreatureExport`                                                                        | Canonical serialisation: wire UUIDs plus resolved runtime ids (`id` / `fromId` / `toId`).             |
+| `exportSnapshotJSON` | `(): CreatureExport`                                                                        | Wire-only snapshot: same topology as `exportJSON` but omits numeric ids (sharing / schema checks).    |
+| `traceJSON`          | `(): CreatureTrace`                                                                         | Exports with detailed trace information from last activation.                                         |
+| `loadFrom`           | `(json: CreatureInternal \| CreatureExport, validate: boolean): void`                       | Loads creature structure from a JSON object.                                                          |
+| `connect`            | `(from: number, to: number, weight: number, type?: SynapseType): Synapse`                   | Creates a synapse between two neurons.                                                                |
+| `getSynapse`         | `(from: number, to: number): Synapse \| null`                                               | Gets the synapse between two neurons, or `null`.                                                      |
+| `shallowClone`       | `(): Creature`                                                                              | Fast clone without JSON serialisation overhead.                                                       |
+| `dispose`            | `(): void`                                                                                  | Releases all resources and memory.                                                                    |
+| `clearCache`         | `(from?: number, to?: number): void`                                                        | Clears internal synapse connection caches.                                                            |
 
 ### ⚡ Static Methods
 

--- a/docs/api/EVOLUTION.md
+++ b/docs/api/EVOLUTION.md
@@ -39,6 +39,8 @@ async evolveDir(
   score: number;
   time: number;
   generation: number;
+  phaseTimingTotals: PhaseTimingTotals;
+  scorerUtilisation: ScorerUtilisationTotals;
 }>
 ```
 
@@ -53,6 +55,10 @@ async evolveDir(
 - `score` — Final best score (negative error minus complexity penalty)
 - `time` — Elapsed milliseconds
 - `generation` — Number of generations completed
+- `phaseTimingTotals` — Whole-run summed per-phase timing totals
+  (`PhaseTimingTotals`, Issue #3210); see [Run telemetry](#run-telemetry)
+- `scorerUtilisation` — Whole-run scorer-utilisation totals split by backend
+  (`ScorerUtilisationTotals`, Issue #3234); see [Run telemetry](#run-telemetry)
 
 ### 📁 Dataset Format
 
@@ -114,9 +120,15 @@ async evolveRL<S, A>(
   score: number;
   time: number;
   generation: number;
+  phaseTimingTotals: PhaseTimingTotals;
+  scorerUtilisation: ScorerUtilisationTotals;
   milestones?: EvolveRLMilestone[];
 }>
 ```
+
+`phaseTimingTotals` and `scorerUtilisation` carry the same whole-run telemetry
+as `evolveDir()` — see [Run telemetry](#run-telemetry). `milestones` is present
+only when `options.statistics === true`.
 
 `EvolveRLOptions` extends `NeatOptions` with:
 
@@ -129,6 +141,44 @@ async evolveRL<S, A>(
 | `onEpisodeTrials`     | `(event) => void`    | —          | Per-creature per-generation reward breakdown for variance charts            |
 | `signal`              | `AbortSignal`        | —          | External interrupt signal                                                   |
 | `adapterDescription`  | `AdapterDescription` | —          | Importable adapter URL + JSON config for the worker pool when `threads > 1` |
+
+### Run telemetry
+
+Both `evolveDir()` and `evolveRL()` return two whole-run telemetry objects
+alongside the scalar result. `PhaseTimingTotals` is a public export documented
+as "returned by the `evolve*` fns"; the signatures below are mirrored from
+`src/creature/PhaseTimingTotals.ts` and
+`src/creature/ScorerUtilisationTotals.ts`.
+
+```typescript
+// phaseTimingTotals — summed per-phase wall-clock across the whole run,
+// in raw milliseconds (Issue #3210). The named buckets plus otherMs
+// reconcile to totalMs (== the returned `time`).
+interface PhaseTimingTotals {
+  readonly generations: number;
+  readonly totalMs: number;
+  readonly fitnessMs: number;
+  readonly breedingMs: number;
+  readonly mutationMs: number;
+  readonly deduplicationMs: number;
+  readonly speciationMs: number;
+  readonly sortMs: number;
+  readonly writeScoresMs: number;
+  readonly checkpointWriteMs: number;
+  readonly otherMs: number; // unattributed wall-clock; clamped at 0
+}
+
+// scorerUtilisation — per-backend scorer counts summed across the run
+// (Issue #3234). batchFallbackGenerations > 0 means the native batch
+// path failed at least once and scoring fell back to the slow worker path.
+interface ScorerUtilisationTotals {
+  readonly generations: number;
+  readonly batchScorerInvocations: number;
+  readonly creaturesBatchScored: number;
+  readonly creaturesPerCreatureScored: number;
+  readonly batchFallbackGenerations: number;
+}
+```
 
 ### EpisodeAdapter
 
@@ -277,7 +327,7 @@ class PlateauDetector {
 
   recordFitness(fitness: number): void;
   isOnPlateau(): boolean;
-  isRapidlyImproving(): boolean;
+  isImproving(): boolean;
   getMutationMultiplier(): number;
   getGenerationsOnPlateau(): number;
 }

--- a/docs/api/INTEROP.md
+++ b/docs/api/INTEROP.md
@@ -77,15 +77,47 @@ Deno.writeTextFileSync("checkpoint.json", JSON.stringify(checkpoint));
 
 **Returns:** `CheckpointInterface` — serialisable checkpoint object.
 
-### `importCheckpoint(checkpoint, inputCount, outputCount)`
+### `importCheckpoint(checkpoint, options?)`
 
 Imports a checkpoint to create a creature for a new task, handling UUID mapping
-when input/output dimensions differ from the source task.
+when input/output dimensions differ from the source task. The new task's
+input/output counts are passed through `options.targetInputCount` /
+`options.targetOutputCount` — not as positional arguments.
+
+```typescript
+type CheckpointImportOptions = {
+  inputIdMapping?: Map<number, number>; // source→target input UUID mapping
+  outputIdMapping?: Map<number, number>; // source→target output UUID mapping
+  targetInputCount?: number; // inputs in the target task
+  targetOutputCount?: number; // outputs in the target task
+  freezeHidden?: boolean; // freeze hidden weights (default false)
+};
+
+function importCheckpoint(
+  checkpoint: CheckpointInterface,
+  options?: CheckpointImportOptions,
+): Creature;
+```
 
 ```typescript
 const checkpoint = JSON.parse(Deno.readTextFileSync("checkpoint.json"));
-const creature = importCheckpoint(checkpoint, 8, 3); // new task: 8 inputs, 3 outputs
+// new task: 8 inputs, 3 outputs
+const creature = importCheckpoint(checkpoint, {
+  targetInputCount: 8,
+  targetOutputCount: 3,
+});
 ```
+
+| Parameter                   | Type                  | Description                                               |
+| --------------------------- | --------------------- | --------------------------------------------------------- |
+| `checkpoint`                | `CheckpointInterface` | The checkpoint to import                                  |
+| `options.targetInputCount`  | `number`              | Inputs in the target task (defaults to the source)        |
+| `options.targetOutputCount` | `number`              | Outputs in the target task (defaults to the source)       |
+| `options.inputIdMapping`    | `Map<number, number>` | Source→target input UUID mapping (positional if omitted)  |
+| `options.outputIdMapping`   | `Map<number, number>` | Source→target output UUID mapping (positional if omitted) |
+| `options.freezeHidden`      | `boolean`             | Freeze hidden neuron weights (default `false`)            |
+
+**Returns:** `Creature` — a creature adapted to the target task.
 
 ### `createSeededPopulation(options)`
 

--- a/docs/archive/pr-summaries/pr-summary-3278.md
+++ b/docs/archive/pr-summaries/pr-summary-3278.md
@@ -1,0 +1,83 @@
+# PR Summary — Issue #3278
+
+## Summary
+
+Several `docs/api/*` reference pages documented method signatures, return shapes
+and enum members that had drifted from `src/`, so copy-paste examples would not
+type-check and an agent would infer the wrong API surface. This PR reconciles
+each cited page against the current source. **Closes #3278.**
+
+Fixes applied:
+
+- **`docs/api/INTEROP.md` — `importCheckpoint` signature.** Changed the heading
+  and example from the positional
+  `importCheckpoint(checkpoint, inputCount, outputCount)` /
+  `importCheckpoint(checkpoint, 8, 3)` to the real
+  `importCheckpoint(checkpoint: CheckpointInterface, options?: CheckpointImportOptions): Creature`
+  (`src/transfer/Checkpoint.ts:143-146`). The target counts come from
+  `options.targetInputCount` / `options.targetOutputCount`
+  (`src/transfer/Checkpoint.ts:149-150`). Added a typed options block, a
+  corrected example, a parameter table and a `Returns` line.
+- **`docs/api/CREATURE.md` — `record()` return type.** Changed the documented
+  key from `Map<string, DiscoverRecord>` to `Map<number, DiscoverRecord>`
+  (`src/Creature.ts:993`, `src/creature/CreatureTraining.ts:138-141`). The key
+  is the runtime neuron `id` — `discoverMap.set(neuron.id, …)` in
+  `src/neuron/NeuronRecord.ts:46`.
+- **`docs/api/EVOLUTION.md` — `PlateauDetector` method name.** Replaced the
+  non-existent `isRapidlyImproving(): boolean` with the real
+  `isImproving(): boolean` (`src/NEAT/PlateauDetector.ts:179`;
+  `grep -rn isRapidlyImproving src/` is empty).
+- **`docs/api/EVOLUTION.md` — `evolveDir()` / `evolveRL()` return shapes.**
+  Added the two telemetry fields both functions return —
+  `phaseTimingTotals: PhaseTimingTotals` (Issue #3210) and
+  `scorerUtilisation: ScorerUtilisationTotals` (Issue #3234) —
+  (`src/Creature.ts:1004-1012`, `1060-1067`). Added a **Run telemetry** section
+  documenting both interface shapes, mirrored from
+  `src/creature/PhaseTimingTotals.ts` and
+  `src/creature/ScorerUtilisationTotals.ts`, with a note that the signatures are
+  mirrored from `src/`.
+
+### Already correct — no change needed
+
+- **`ValidationErrorName` union (`docs/api/ERRORS.md`).** The issue asked to add
+  `NEURON_ORDER` and `DUPLICATE_SYNAPSE`, but the base branch already lists all
+  9 members (added by #3273 / PR #3295). Verified against
+  `src/errors/ValidationError.ts:10-19`. No edit was made.
+
+```mermaid
+flowchart LR
+    Src[src/ source of truth] --> Audit{docs/api/* match?}
+    Audit -- "importCheckpoint" --> F1[INTEROP.md: options?, Creature]
+    Audit -- "record()" --> F2[CREATURE.md: Map&lt;number,…&gt;]
+    Audit -- "PlateauDetector" --> F3[EVOLUTION.md: isImproving]
+    Audit -- "evolve* returns" --> F4[EVOLUTION.md: phaseTimingTotals + scorerUtilisation]
+    Audit -- "ValidationErrorName" --> OK[ERRORS.md: already 9 members #3273]
+```
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot. Each fix was
+verified by reading the cited `src/` locations:
+
+| Doc claim (after fix)                                                 | Source of truth                                                                      |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `importCheckpoint(checkpoint, options?): Creature`                    | `src/transfer/Checkpoint.ts:143-146`                                                 |
+| counts from `options.targetInputCount/targetOutputCount`              | `src/transfer/Checkpoint.ts:149-150`                                                 |
+| `record(): Map<number, DiscoverRecord>`                               | `src/Creature.ts:993`; key `neuron.id` at `src/neuron/NeuronRecord.ts:46`            |
+| `PlateauDetector.isImproving()`                                       | `src/NEAT/PlateauDetector.ts:179`                                                    |
+| `evolveDir/evolveRL` return `phaseTimingTotals` + `scorerUtilisation` | `src/Creature.ts:1004-1012, 1060-1067`                                               |
+| `PhaseTimingTotals` / `ScorerUtilisationTotals` shapes                | `src/creature/PhaseTimingTotals.ts:25`, `src/creature/ScorerUtilisationTotals.ts:42` |
+
+Validation:
+
+- `deno fmt --check` on the three changed files — clean.
+- `markdownlint-cli2` on the three changed files — no errors (the sole repo-wide
+  error is a pre-existing `MD028` in `ERRORS.md:82`, untouched here).
+
+## Test Plan
+
+No automated tests were added. Per `AGENTS.md`, tests that grep or inspect
+documentation/source text are explicitly forbidden ("how" tests), and this
+change has no runtime behaviour — it only corrects prose/signatures in Markdown
+reference pages. Verification is the manual source-cross-check table above plus
+the `deno fmt` and `markdownlint` gates.


### PR DESCRIPTION
# PR Summary — Issue #3278

## Summary

Several `docs/api/*` reference pages documented method signatures, return shapes
and enum members that had drifted from `src/`, so copy-paste examples would not
type-check and an agent would infer the wrong API surface. This PR reconciles
each cited page against the current source. **Closes #3278.**

Fixes applied:

- **`docs/api/INTEROP.md` — `importCheckpoint` signature.** Changed the heading
  and example from the positional
  `importCheckpoint(checkpoint, inputCount, outputCount)` /
  `importCheckpoint(checkpoint, 8, 3)` to the real
  `importCheckpoint(checkpoint: CheckpointInterface, options?: CheckpointImportOptions): Creature`
  (`src/transfer/Checkpoint.ts:143-146`). The target counts come from
  `options.targetInputCount` / `options.targetOutputCount`
  (`src/transfer/Checkpoint.ts:149-150`). Added a typed options block, a
  corrected example, a parameter table and a `Returns` line.
- **`docs/api/CREATURE.md` — `record()` return type.** Changed the documented
  key from `Map<string, DiscoverRecord>` to `Map<number, DiscoverRecord>`
  (`src/Creature.ts:993`, `src/creature/CreatureTraining.ts:138-141`). The key
  is the runtime neuron `id` — `discoverMap.set(neuron.id, …)` in
  `src/neuron/NeuronRecord.ts:46`.
- **`docs/api/EVOLUTION.md` — `PlateauDetector` method name.** Replaced the
  non-existent `isRapidlyImproving(): boolean` with the real
  `isImproving(): boolean` (`src/NEAT/PlateauDetector.ts:179`;
  `grep -rn isRapidlyImproving src/` is empty).
- **`docs/api/EVOLUTION.md` — `evolveDir()` / `evolveRL()` return shapes.**
  Added the two telemetry fields both functions return —
  `phaseTimingTotals: PhaseTimingTotals` (Issue #3210) and
  `scorerUtilisation: ScorerUtilisationTotals` (Issue #3234) —
  (`src/Creature.ts:1004-1012`, `1060-1067`). Added a **Run telemetry** section
  documenting both interface shapes, mirrored from
  `src/creature/PhaseTimingTotals.ts` and
  `src/creature/ScorerUtilisationTotals.ts`, with a note that the signatures are
  mirrored from `src/`.

### Already correct — no change needed

- **`ValidationErrorName` union (`docs/api/ERRORS.md`).** The issue asked to add
  `NEURON_ORDER` and `DUPLICATE_SYNAPSE`, but the base branch already lists all
  9 members (added by #3273 / PR #3295). Verified against
  `src/errors/ValidationError.ts:10-19`. No edit was made.

```mermaid
flowchart LR
    Src[src/ source of truth] --> Audit{docs/api/* match?}
    Audit -- "importCheckpoint" --> F1[INTEROP.md: options?, Creature]
    Audit -- "record()" --> F2[CREATURE.md: Map&lt;number,…&gt;]
    Audit -- "PlateauDetector" --> F3[EVOLUTION.md: isImproving]
    Audit -- "evolve* returns" --> F4[EVOLUTION.md: phaseTimingTotals + scorerUtilisation]
    Audit -- "ValidationErrorName" --> OK[ERRORS.md: already 9 members #3273]
```

## Evidence

Documentation-only change — no web interface to screenshot. Each fix was
verified by reading the cited `src/` locations:

| Doc claim (after fix)                                                 | Source of truth                                                                      |
| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| `importCheckpoint(checkpoint, options?): Creature`                    | `src/transfer/Checkpoint.ts:143-146`                                                 |
| counts from `options.targetInputCount/targetOutputCount`              | `src/transfer/Checkpoint.ts:149-150`                                                 |
| `record(): Map<number, DiscoverRecord>`                               | `src/Creature.ts:993`; key `neuron.id` at `src/neuron/NeuronRecord.ts:46`            |
| `PlateauDetector.isImproving()`                                       | `src/NEAT/PlateauDetector.ts:179`                                                    |
| `evolveDir/evolveRL` return `phaseTimingTotals` + `scorerUtilisation` | `src/Creature.ts:1004-1012, 1060-1067`                                               |
| `PhaseTimingTotals` / `ScorerUtilisationTotals` shapes                | `src/creature/PhaseTimingTotals.ts:25`, `src/creature/ScorerUtilisationTotals.ts:42` |

Validation:

- `deno fmt --check` on the three changed files — clean.
- `markdownlint-cli2` on the three changed files — no errors (the sole repo-wide
  error is a pre-existing `MD028` in `ERRORS.md:82`, untouched here).

## Test Plan

No automated tests were added. Per `AGENTS.md`, tests that grep or inspect
documentation/source text are explicitly forbidden ("how" tests), and this
change has no runtime behaviour — it only corrects prose/signatures in Markdown
reference pages. Verification is the manual source-cross-check table above plus
the `deno fmt` and `markdownlint` gates.



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrekp4gx-73a440`<!-- vibe-worker-issue-3278 -->