### PR TITLE
Fix mislabelled discovery defaults in DISCOVERY_GUIDE.md (Issue #3279)

### DIFF
--- a/docs/DISCOVERY_GUIDE.md
+++ b/docs/DISCOVERY_GUIDE.md
@@ -233,25 +233,33 @@ carry no warm-up state on disk and incur **zero warm-up cost** thereafter (Issue
 
 ## 🛠️ Configuration
 
-### ⚡ Production-Tuned Defaults
+### ⚡ Production-Tuned Overrides (illustrative)
 
-These defaults are tuned for continuous incremental discovery:
+These are **illustrative overrides** for continuous incremental discovery — not
+the library defaults. Each line shows a value you might set to depart from the
+shipped default; every comment names the real default alongside it. For the
+authoritative default of every option, see the
+[Discovery parameters table](./config/DISCOVERY.md) and, for `costOfGrowth`, the
+[Core evolution table](./config/CORE_EVOLUTION.md) — treat those tables as the
+single source of truth so this example cannot drift.
 
 ```typescript
 const options: NeatOptions = {
-  // Recording phase (1 minute = ~50k records at 700 records/sec)
+  // Shorten the recording phase (default: 5 minutes ≈ ~200k records at 700 records/sec)
   discoveryRecordTimeOutMinutes: 1,
 
-  // Analysis phase (10 minutes for thorough analysis)
+  // Analysis phase — 10 minutes, matching the default (shown for context)
   discoveryAnalysisTimeoutMinutes: 10,
 
-  // Cost of growth penalty (each synapse/neuron must earn back this cost)
-  costOfGrowth: 0.001, // Default: candidates must reduce error > 0.001 per synapse
+  // Raise the growth penalty well above the default of 0.0000001 — a much
+  // stricter gate, so only candidates that reduce error by more than 0.001 per
+  // synapse are accepted (fewer, higher-value structural additions)
+  costOfGrowth: 0.001,
 
-  // Analyse 6 neurons per iteration (balances speed vs thoroughness)
+  // Analyse 6 neurons per iteration — matches the default (balances speed vs thoroughness)
   discoveryMaxNeurons: 6,
 
-  // Sample 5% of data (faster while maintaining statistical validity)
+  // Sample 5% of data — below the default of 0.2 (20%) for faster iteration
   discoverySampleRate: 0.05,
 };
 ```

--- a/docs/archive/pr-summaries/pr-summary-3279.md
+++ b/docs/archive/pr-summaries/pr-summary-3279.md
@@ -1,0 +1,75 @@
+# Fix mislabelled discovery "defaults" in `docs/DISCOVERY_GUIDE.md`
+
+## Summary
+
+The "Production-Tuned Defaults" block in `docs/DISCOVERY_GUIDE.md` reproduced
+pre-#1386 discovery values and carried an inline `// Default:` comment that was
+~10,000× off the real default, contradicting both source and a sibling
+troubleshooting doc. This PR corrects that block. **Closes #3279.**
+
+Verified discrepancies fixed:
+
+- **`costOfGrowth`** — the guide set `costOfGrowth: 0.001` with the comment
+  `// Default: candidates must reduce error > 0.001 per synapse`. The real
+  default is `DEFAULT_COST_OF_GROWTH = 0.000_000_1`
+  (`src/config/NeatConfig.ts`). The comment now names the real default
+  (`0.0000001`) and describes the `0.001` line as a deliberate, much-stricter
+  **override**.
+- **`discoverySampleRate`** — the guide quoted `0.05` as a default; the real
+  default is `DEFAULT_DISCOVERY_SAMPLE_RATE = 0.2`. The comment now states the
+  `0.2` default and frames `0.05` as an override for faster iteration.
+- **Record-timeout comment** — updated to name the real 5-minute default rather
+  than the stale 1-minute snapshot.
+- The block heading is reframed from **"Production-Tuned Defaults"** to
+  **"Production-Tuned Overrides (illustrative)"**, and now links to the
+  authoritative [`docs/config/DISCOVERY.md`](../../config/DISCOVERY.md) and
+  [`docs/config/CORE_EVOLUTION.md`](../../config/CORE_EVOLUTION.md) tables so
+  the example cannot silently drift from source again.
+
+This resolves the doc-vs-doc contradiction: `docs/troubleshooting/DISCOVERY.md`
+already states `0.0000001`, so a tuner reading the two docs no longer gets
+conflicting growth-penalty guidance.
+
+## Evidence
+
+Documentation-only change — no web UI to screenshot. Correctness is guarded by a
+new "what" test that reads the published guide and asserts it against the real
+source constants.
+
+```mermaid
+flowchart LR
+    Src[src/config/NeatConfig.ts<br/>DEFAULT_COST_OF_GROWTH = 0.0000001<br/>DEFAULT_DISCOVERY_SAMPLE_RATE = 0.2] --> Test
+    Guide[docs/DISCOVERY_GUIDE.md<br/>overrides block] --> Test
+    Test[test/docs/DiscoveryGuideDefaults.ts] -->|asserts guide matches source| OK[No drift / no mislabel]
+```
+
+Before → after (the offending line):
+
+```diff
+- costOfGrowth: 0.001, // Default: candidates must reduce error > 0.001 per synapse
++ // Raise the growth penalty well above the default of 0.0000001 — a much
++ // stricter gate ... costOfGrowth: 0.001
+```
+
+## Test Plan
+
+Added `test/docs/DiscoveryGuideDefaults.ts` (Issue #3279), mirroring the
+existing `test/docs/ErrorsDocMatchesValidationError.ts` pattern:
+
+- `Discovery defaults in source are the authoritative values` — asserts
+  `DEFAULT_COST_OF_GROWTH === 0.0000001` and
+  `DEFAULT_DISCOVERY_SAMPLE_RATE ===
+  0.2`.
+- `DISCOVERY_GUIDE.md never restates the wrong costOfGrowth default` —
+  reproduces the bug: fails against the old `// Default: ... 0.001` comment.
+- `DISCOVERY_GUIDE.md quotes the correct costOfGrowth default` — requires
+  `0.0000001` to appear.
+- `DISCOVERY_GUIDE.md reframes the block as overrides, not defaults` — requires
+  the misleading heading to be gone.
+- `DISCOVERY_GUIDE.md links to the authoritative defaults tables` — requires
+  links to `config/DISCOVERY.md` and `config/CORE_EVOLUTION.md`.
+
+All five pass after the fix; four failed against the unfixed doc. Existing
+`test/config/ConfigurationGuideDefaults.ts`,
+`test/config/MCMCConfigDocumentation.ts`, and `test/docs/*` suites continue to
+pass.

--- a/test/docs/DiscoveryGuideDefaults.ts
+++ b/test/docs/DiscoveryGuideDefaults.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue #3279 — docs/DISCOVERY_GUIDE.md must not mislabel discovery override
+ * examples as "defaults", and any default it quotes must match source.
+ *
+ * The bug: the "Production-Tuned Defaults" block reproduced pre-#1386 values and
+ * carried an inline `// Default: candidates must reduce error > 0.001 per
+ * synapse` comment that is ~10,000× off the real `DEFAULT_COST_OF_GROWTH`
+ * (0.0000001). It also quoted `discoverySampleRate: 0.05` as a default when the
+ * real default is 0.2, directly contradicting docs/troubleshooting/DISCOVERY.md
+ * and docs/config/DISCOVERY.md.
+ *
+ * These are "what" tests: they assert the real source constants, then assert the
+ * published guide never restates a wrong default and points at the authoritative
+ * tables so the block cannot silently drift again.
+ *
+ * @module
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, resolve } from "@std/path";
+import {
+  DEFAULT_COST_OF_GROWTH,
+  DEFAULT_DISCOVERY_SAMPLE_RATE,
+} from "@config/NeatConfig.ts";
+
+const REPO_ROOT = resolve(fromFileUrl(import.meta.url), "..", "..", "..");
+const GUIDE = `${REPO_ROOT}/docs/DISCOVERY_GUIDE.md`;
+
+Deno.test("Discovery defaults in source are the authoritative values", () => {
+  assertEquals(DEFAULT_COST_OF_GROWTH, 0.000_000_1);
+  assertEquals(DEFAULT_DISCOVERY_SAMPLE_RATE, 0.2);
+});
+
+Deno.test("DISCOVERY_GUIDE.md never restates the wrong costOfGrowth default", async () => {
+  const content = await Deno.readTextFile(GUIDE);
+  // The exact 10,000×-off claim the guide used to teach.
+  assert(
+    !content.includes("Default: candidates must reduce error > 0.001"),
+    "DISCOVERY_GUIDE.md must not state 0.001 as the costOfGrowth default",
+  );
+  // No `// Default:` inline comment may sit on the same line as costOfGrowth:
+  // 0.001 — that is the mislabel this issue fixes.
+  for (const line of content.split("\n")) {
+    if (line.includes("costOfGrowth") && /\/\/\s*Default/i.test(line)) {
+      assert(
+        !line.includes("0.001"),
+        `costOfGrowth line still mislabels 0.001 as a default: ${line.trim()}`,
+      );
+    }
+  }
+});
+
+Deno.test("DISCOVERY_GUIDE.md quotes the correct costOfGrowth default", async () => {
+  const content = await Deno.readTextFile(GUIDE);
+  assert(
+    content.includes("0.0000001"),
+    "DISCOVERY_GUIDE.md must quote the real costOfGrowth default 0.0000001 " +
+      "(matches DEFAULT_COST_OF_GROWTH and docs/troubleshooting/DISCOVERY.md)",
+  );
+});
+
+Deno.test("DISCOVERY_GUIDE.md reframes the block as overrides, not defaults", async () => {
+  const content = await Deno.readTextFile(GUIDE);
+  assert(
+    !content.includes("### ⚡ Production-Tuned Defaults"),
+    "The block must no longer be titled 'Production-Tuned Defaults' — it lists " +
+      "illustrative overrides, not library defaults",
+  );
+});
+
+Deno.test("DISCOVERY_GUIDE.md links to the authoritative defaults tables", async () => {
+  const content = await Deno.readTextFile(GUIDE);
+  assert(
+    content.includes("config/DISCOVERY.md"),
+    "DISCOVERY_GUIDE.md must link to docs/config/DISCOVERY.md for authoritative " +
+      "discovery defaults",
+  );
+  assert(
+    content.includes("config/CORE_EVOLUTION.md"),
+    "DISCOVERY_GUIDE.md must link to docs/config/CORE_EVOLUTION.md for the " +
+      "authoritative costOfGrowth default",
+  );
+});


### PR DESCRIPTION
# Fix mislabelled discovery "defaults" in `docs/DISCOVERY_GUIDE.md`

## Summary

The "Production-Tuned Defaults" block in `docs/DISCOVERY_GUIDE.md` reproduced
pre-#1386 discovery values and carried an inline `// Default:` comment that was
~10,000× off the real default, contradicting both source and a sibling
troubleshooting doc. This PR corrects that block. **Closes #3279.**

Verified discrepancies fixed:

- **`costOfGrowth`** — the guide set `costOfGrowth: 0.001` with the comment
  `// Default: candidates must reduce error > 0.001 per synapse`. The real
  default is `DEFAULT_COST_OF_GROWTH = 0.000_000_1`
  (`src/config/NeatConfig.ts`). The comment now names the real default
  (`0.0000001`) and describes the `0.001` line as a deliberate, much-stricter
  **override**.
- **`discoverySampleRate`** — the guide quoted `0.05` as a default; the real
  default is `DEFAULT_DISCOVERY_SAMPLE_RATE = 0.2`. The comment now states the
  `0.2` default and frames `0.05` as an override for faster iteration.
- **Record-timeout comment** — updated to name the real 5-minute default rather
  than the stale 1-minute snapshot.
- The block heading is reframed from **"Production-Tuned Defaults"** to
  **"Production-Tuned Overrides (illustrative)"**, and now links to the
  authoritative [`docs/config/DISCOVERY.md`](../../config/DISCOVERY.md) and
  [`docs/config/CORE_EVOLUTION.md`](../../config/CORE_EVOLUTION.md) tables so
  the example cannot silently drift from source again.

This resolves the doc-vs-doc contradiction: `docs/troubleshooting/DISCOVERY.md`
already states `0.0000001`, so a tuner reading the two docs no longer gets
conflicting growth-penalty guidance.

## Evidence

Documentation-only change — no web UI to screenshot. Correctness is guarded by a
new "what" test that reads the published guide and asserts it against the real
source constants.

```mermaid
flowchart LR
    Src[src/config/NeatConfig.ts<br/>DEFAULT_COST_OF_GROWTH = 0.0000001<br/>DEFAULT_DISCOVERY_SAMPLE_RATE = 0.2] --> Test
    Guide[docs/DISCOVERY_GUIDE.md<br/>overrides block] --> Test
    Test[test/docs/DiscoveryGuideDefaults.ts] -->|asserts guide matches source| OK[No drift / no mislabel]
```

Before → after (the offending line):

```diff
- costOfGrowth: 0.001, // Default: candidates must reduce error > 0.001 per synapse
+ // Raise the growth penalty well above the default of 0.0000001 — a much
+ // stricter gate ... costOfGrowth: 0.001
```

## Test Plan

Added `test/docs/DiscoveryGuideDefaults.ts` (Issue #3279), mirroring the
existing `test/docs/ErrorsDocMatchesValidationError.ts` pattern:

- `Discovery defaults in source are the authoritative values` — asserts
  `DEFAULT_COST_OF_GROWTH === 0.0000001` and
  `DEFAULT_DISCOVERY_SAMPLE_RATE ===
  0.2`.
- `DISCOVERY_GUIDE.md never restates the wrong costOfGrowth default` —
  reproduces the bug: fails against the old `// Default: ... 0.001` comment.
- `DISCOVERY_GUIDE.md quotes the correct costOfGrowth default` — requires
  `0.0000001` to appear.
- `DISCOVERY_GUIDE.md reframes the block as overrides, not defaults` — requires
  the misleading heading to be gone.
- `DISCOVERY_GUIDE.md links to the authoritative defaults tables` — requires
  links to `config/DISCOVERY.md` and `config/CORE_EVOLUTION.md`.

All five pass after the fix; four failed against the unfixed doc. Existing
`test/config/ConfigurationGuideDefaults.ts`,
`test/config/MCMCConfigDocumentation.ts`, and `test/docs/*` suites continue to
pass.



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mremzi2y-1af4e2`<!-- vibe-worker-issue-3279 -->