### PR TITLE
Fix docs importing from non-existent subpath exports (#3281)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,8 +397,7 @@ project deliberately does **not** depend on `@std/log`.
    call `setLogger()` directly:
 
    ```typescript
-   import { Neat } from "@stsoftware/neat-ai";
-   import { setLogger } from "@stsoftware/neat-ai/utils/Logger";
+   import { Neat, setLogger } from "@stsoftware/neat-ai";
 
    // Option A — inject via NeatOptions
    const neat = new Neat(input, output, fitness, {
@@ -413,6 +412,11 @@ project deliberately does **not** depend on `@std/log`.
    // Option B — set globally
    setLogger(myCustomLogger);
    ```
+
+   > **One entry point.** `deno.json` declares `"exports": "./mod.ts"`, so the
+   > package exposes exactly one public specifier: `@stsoftware/neat-ai`. There
+   > are no subpaths (`/utils/Logger`, `/wasm`, …); every public symbol is
+   > re-exported from the root barrel. Import from `@stsoftware/neat-ai` only.
 
 4. **Missing logging features** (e.g. structured key/value pairs, async sinks)
    should be raised as a separate issue against `src/utils/Logger.ts`. Do not

--- a/docs/archive/pr-summaries/pr-summary-3281.md
+++ b/docs/archive/pr-summaries/pr-summary-3281.md
@@ -1,0 +1,62 @@
+# Fix docs importing from non-existent subpath exports
+
+## Summary
+
+`deno.json` declares `"exports": "./mod.ts"` — a bare string — so the package
+exposes exactly one public specifier, the root `@stsoftware/neat-ai`; there are
+no `/utils/Logger` or `/wasm` subpaths. Three docs imported from those
+non-existent subpaths, so every copy-paste threw a module-resolution error for
+an external consumer. Each symbol is already re-exported from the root barrel
+(`mod.ts`), so the fix is to import from `@stsoftware/neat-ai`. Closes #3281.
+
+Changes:
+
+- **`AGENTS.md:401`** — `setLogger` now imported from `@stsoftware/neat-ai`
+  (merged into the existing `Neat` import), replacing
+  `@stsoftware/neat-ai/utils/Logger`.
+- **`docs/troubleshooting/MEMORY.md:79`** and
+  **`docs/troubleshooting/WASM.md:198`** — `setMaxCachedWasmCreatureActivations`
+  now imported from `@stsoftware/neat-ai`, replacing `neat-ai/wasm`.
+- Added a short "one entry point" note to each of the three files so future
+  examples do not invent subpaths.
+
+The `@utils/` alias in `deno.json` is an internal source alias, not a published
+export, and is unaffected. Source-path references such as `src/utils/Logger.ts`
+in prose are not imports and were left unchanged.
+
+## Evidence
+
+Documentation/CLI change — no web interface to screenshot. Verified via the new
+fact-check test, which imports the symbols from the public entry point and
+invokes them exactly as the corrected docs show, then asserts the docs no longer
+reference the broken subpaths:
+
+```
+running 3 tests from ./test/docs/RootImportSpecifiers.ts
+mod.ts re-exports setLogger (AGENTS.md logging example) ... ok
+mod.ts re-exports setMaxCachedWasmCreatureActivations (troubleshooting example) ... ok
+docs import these symbols from the root specifier, not a subpath ... ok
+
+ok | 3 passed | 0 failed
+```
+
+```mermaid
+flowchart LR
+    A["Doc snippet"] -->|"before: /utils/Logger, neat-ai/wasm"| B["Module-resolution error"]
+    A -->|"after: @stsoftware/neat-ai"| C["mod.ts root barrel"]
+    C --> D["setLogger, setMaxCachedWasmCreatureActivations"]
+```
+
+## Test Plan
+
+- Added `test/docs/RootImportSpecifiers.ts`:
+  - `setLogger` imported from `mod.ts` and exercised (custom logger receives the
+    call).
+  - `setMaxCachedWasmCreatureActivations` imported from `mod.ts` and its effect
+    asserted via `getMaxCachedWasmCreatureActivations`.
+  - Regression guard scanning `AGENTS.md`, `docs/troubleshooting/MEMORY.md`, and
+    `docs/troubleshooting/WASM.md` for the forbidden subpath specifiers
+    (`@stsoftware/neat-ai/utils/Logger`, `neat-ai/wasm`) — fails against the
+    unfixed docs, passes after the fix.
+- Ran `deno fmt`, `deno lint`, `deno check` on the new test (clean) and the
+  existing `test/docs` suite (all pass).

--- a/docs/troubleshooting/MEMORY.md
+++ b/docs/troubleshooting/MEMORY.md
@@ -76,9 +76,12 @@ The WASM activation cache stores compiled creature networks. Reduce the limit
 for memory-constrained environments:
 
 ```typescript
-import { setMaxCachedWasmCreatureActivations } from "neat-ai/wasm";
+import { setMaxCachedWasmCreatureActivations } from "@stsoftware/neat-ai";
 setMaxCachedWasmCreatureActivations(256); // Default: 512
 ```
+
+> The package exposes a single entry point, `@stsoftware/neat-ai`; every public
+> symbol is re-exported from it. There are no subpath specifiers.
 
 **Step 4 — Check population size:**
 

--- a/docs/troubleshooting/WASM.md
+++ b/docs/troubleshooting/WASM.md
@@ -195,9 +195,11 @@ supported workaround.
 - The LRU (Least Recently Used) cache automatically evicts old entries (default:
   512 cached instances). Reduce the limit if memory is tight:
   ```typescript
-  import { setMaxCachedWasmCreatureActivations } from "neat-ai/wasm";
+  import { setMaxCachedWasmCreatureActivations } from "@stsoftware/neat-ai";
   setMaxCachedWasmCreatureActivations(256);
   ```
+  The package exposes a single entry point, `@stsoftware/neat-ai`; every public
+  symbol is re-exported from it, so there are no subpath specifiers.
 - Reduce parallel creature count or population size.
 
 ## 🧪 Producer-gate WASM compile rejects (Issue #2672)

--- a/test/docs/RootImportSpecifiers.ts
+++ b/test/docs/RootImportSpecifiers.ts
@@ -1,0 +1,81 @@
+/**
+ * Issue #3281 — fact-check guard for the package's single public entry point.
+ *
+ * `deno.json` declares `"exports": "./mod.ts"` — a bare string, so the only
+ * published specifier is the root `@stsoftware/neat-ai`. There is no
+ * `/utils/Logger` or `/wasm` subpath. Docs that imported from those subpaths
+ * threw a module-resolution error on the first copy-paste.
+ *
+ * These are "what" tests: the symbols the docs use are imported from the public
+ * entry point (`mod.ts`) and invoked exactly as the corrected examples show,
+ * proving the root specifier resolves. A companion guard scans the affected doc
+ * files so the broken subpath specifiers cannot creep back in.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  getLogger,
+  getMaxCachedWasmCreatureActivations,
+  setLogger,
+  setMaxCachedWasmCreatureActivations,
+} from "../../mod.ts";
+
+Deno.test("mod.ts re-exports setLogger (AGENTS.md logging example)", () => {
+  const original = getLogger();
+  try {
+    const calls: string[] = [];
+    setLogger({
+      debug: () => calls.push("debug"),
+      info: () => calls.push("info"),
+      warn: () => calls.push("warn"),
+      error: () => calls.push("error"),
+    });
+    getLogger().info("hello");
+    assertEquals(calls, ["info"]);
+  } finally {
+    setLogger(original);
+  }
+});
+
+Deno.test(
+  "mod.ts re-exports setMaxCachedWasmCreatureActivations (troubleshooting example)",
+  () => {
+    const original = getMaxCachedWasmCreatureActivations();
+    try {
+      setMaxCachedWasmCreatureActivations(256);
+      assertEquals(getMaxCachedWasmCreatureActivations(), 256);
+    } finally {
+      setMaxCachedWasmCreatureActivations(original);
+    }
+  },
+);
+
+Deno.test("docs import these symbols from the root specifier, not a subpath", async () => {
+  // Files that previously imported from non-existent subpaths (#3281).
+  const files = [
+    "AGENTS.md",
+    "docs/troubleshooting/MEMORY.md",
+    "docs/troubleshooting/WASM.md",
+  ];
+
+  // Specifiers the package does not export — every copy-paste of these fails.
+  const forbiddenSpecifiers = [
+    "@stsoftware/neat-ai/utils/Logger",
+    "neat-ai/wasm",
+  ];
+
+  const texts = await Promise.all(
+    files.map((file) =>
+      Deno.readTextFile(new URL(`../../${file}`, import.meta.url))
+    ),
+  );
+
+  files.forEach((file, i) => {
+    for (const specifier of forbiddenSpecifiers) {
+      assert(
+        !texts[i].includes(`from "${specifier}"`),
+        `${file} still imports from the non-existent subpath "${specifier}"`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
# Fix docs importing from non-existent subpath exports

## Summary

`deno.json` declares `"exports": "./mod.ts"` — a bare string — so the package
exposes exactly one public specifier, the root `@stsoftware/neat-ai`; there are
no `/utils/Logger` or `/wasm` subpaths. Three docs imported from those
non-existent subpaths, so every copy-paste threw a module-resolution error for
an external consumer. Each symbol is already re-exported from the root barrel
(`mod.ts`), so the fix is to import from `@stsoftware/neat-ai`. Closes #3281.

Changes:

- **`AGENTS.md:401`** — `setLogger` now imported from `@stsoftware/neat-ai`
  (merged into the existing `Neat` import), replacing
  `@stsoftware/neat-ai/utils/Logger`.
- **`docs/troubleshooting/MEMORY.md:79`** and
  **`docs/troubleshooting/WASM.md:198`** — `setMaxCachedWasmCreatureActivations`
  now imported from `@stsoftware/neat-ai`, replacing `neat-ai/wasm`.
- Added a short "one entry point" note to each of the three files so future
  examples do not invent subpaths.

The `@utils/` alias in `deno.json` is an internal source alias, not a published
export, and is unaffected. Source-path references such as `src/utils/Logger.ts`
in prose are not imports and were left unchanged.

## Evidence

Documentation/CLI change — no web interface to screenshot. Verified via the new
fact-check test, which imports the symbols from the public entry point and
invokes them exactly as the corrected docs show, then asserts the docs no longer
reference the broken subpaths:

```
running 3 tests from ./test/docs/RootImportSpecifiers.ts
mod.ts re-exports setLogger (AGENTS.md logging example) ... ok
mod.ts re-exports setMaxCachedWasmCreatureActivations (troubleshooting example) ... ok
docs import these symbols from the root specifier, not a subpath ... ok

ok | 3 passed | 0 failed
```

```mermaid
flowchart LR
    A["Doc snippet"] -->|"before: /utils/Logger, neat-ai/wasm"| B["Module-resolution error"]
    A -->|"after: @stsoftware/neat-ai"| C["mod.ts root barrel"]
    C --> D["setLogger, setMaxCachedWasmCreatureActivations"]
```

## Test Plan

- Added `test/docs/RootImportSpecifiers.ts`:
  - `setLogger` imported from `mod.ts` and exercised (custom logger receives the
    call).
  - `setMaxCachedWasmCreatureActivations` imported from `mod.ts` and its effect
    asserted via `getMaxCachedWasmCreatureActivations`.
  - Regression guard scanning `AGENTS.md`, `docs/troubleshooting/MEMORY.md`, and
    `docs/troubleshooting/WASM.md` for the forbidden subpath specifiers
    (`@stsoftware/neat-ai/utils/Logger`, `neat-ai/wasm`) — fails against the
    unfixed docs, passes after the fix.
- Ran `deno fmt`, `deno lint`, `deno check` on the new test (clean) and the
  existing `test/docs` suite (all pass).



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mremzi2y-1af4e2`<!-- vibe-worker-issue-3281 -->