### PR TITLE
Fix drifted performance & troubleshooting docs (Issue #3282)

### DIFF
--- a/docs/PERFORMANCE_TUNING.md
+++ b/docs/PERFORMANCE_TUNING.md
@@ -187,9 +187,19 @@ const config = createNeatConfig({
 The distance cache stores genetic compatibility scores between pairs of
 creatures. These scores determine which creatures belong to the same species.
 
-| Parameter               | Default | Description                   |
-| ----------------------- | ------- | ----------------------------- |
-| `distanceCache.maxSize` | `10000` | Maximum cached distance pairs |
+> [!IMPORTANT]
+> The distance-cache size is **not** a `NeatOptions` / `NeatConfig` field —
+> there is no `distanceCache.maxSize` config key. It is a process-wide LRU that
+> defaults to **10,000** entries and is tuned imperatively at runtime via
+> `setDistanceCacheMaxSize()` (the distance-cache counterpart to
+> `setMaxCachedWasmCreatureActivations()`):
+>
+> ```typescript
+> import { setDistanceCacheMaxSize } from "@stsoftware/neat-ai";
+>
+> // Size the cache to cover a population of N creatures without eviction.
+> setDistanceCacheMaxSize(50_000); // Default: 10_000
+> ```
 
 **How it works**: Computing the genetic distance between two creatures requires
 comparing their full genome structure. The LRU cache stores results keyed by
@@ -213,15 +223,17 @@ xychart-beta
 ```
 
 A cache hit is ~7.9× cheaper than a full genome comparison, which is why sizing
-`distanceCache.maxSize` to cover your population matters at scale.
+the distance cache (via `setDistanceCacheMaxSize()`) to cover your population
+matters at scale.
 
 **Recommendations**:
 
 - For a population of size `N`, each generation computes up to `N*(N-1)/2`
   pairwise distances. The default of 10,000 covers populations up to ~140
   creatures without eviction.
-- **For large populations** (500+), increase to `N * N / 2` or higher. Cache
-  hits at 66 ns are dramatically faster than recomputation at 521 ns.
+- **For large populations** (500+), call `setDistanceCacheMaxSize(N * N / 2)` or
+  higher. Cache hits at 66 ns are dramatically faster than recomputation at 521
+  ns.
 - **With high population turnover** (many new creatures each generation), the
   cache hit rate drops. Expect ~64% hit rate with 20% turnover versus ~100% for
   stable populations.
@@ -230,8 +242,8 @@ A cache hit is ~7.9× cheaper than a full genome comparison, which is why sizing
 > The distance cache uses UUID pairs as keys. Creatures that are eliminated and
 > replaced each generation will never yield a cache hit for their pairings,
 > which is why high turnover reduces hit rates significantly. If your problem
-> involves aggressive culling, consider raising `distanceCache.maxSize` beyond
-> the default.
+> involves aggressive culling, consider raising the distance-cache size with
+> `setDistanceCacheMaxSize()` beyond the default.
 
 ---
 
@@ -242,13 +254,17 @@ and mutation across CPU cores.
 
 ### Thread Count (`threads`)
 
-| Parameter | Default                                     | Description              |
-| --------- | ------------------------------------------- | ------------------------ |
-| `threads` | `navigator.hardwareConcurrency` (all cores) | Number of worker threads |
+| Parameter | Default                             | Description              |
+| --------- | ----------------------------------- | ------------------------ |
+| `threads` | `navigator.hardwareConcurrency + 2` | Number of worker threads |
+
+The default adds two heavy-task workers on top of the core count
+(`hardwareConcurrency + 2`) so the pool keeps making progress while some workers
+are busy on longer breeding/discovery tasks.
 
 **Recommendations**:
 
-- **Use the default** (all available cores) for dedicated training machines.
+- **Use the default** (all cores plus two) for dedicated training machines.
 - **Reserve 1–2 cores** (`cores - 2`) on shared machines or when running
   alongside other processes.
 - **More threads are not always better**: each worker consumes memory for its
@@ -805,8 +821,8 @@ with memory management.
 
 **Step-by-step approach**:
 
-1. **Start with all cores**: `threads: navigator.hardwareConcurrency` (the
-   default).
+1. **Start with the default**: leave `threads` unset to get
+   `navigator.hardwareConcurrency + 2` (all cores plus two heavy-task workers).
 2. **Enable memory capping**: Set `workerThreadCap.maxMemoryMB` to 80% of
    available RAM.
 3. **Monitor memory**: Use `getCacheStats()` and system memory tools to check

--- a/docs/archive/pr-summaries/pr-summary-3282.md
+++ b/docs/archive/pr-summaries/pr-summary-3282.md
@@ -1,0 +1,45 @@
+# Fix drifted performance & troubleshooting docs (Issue #3282)
+
+## Summary
+
+`docs/PERFORMANCE_TUNING.md` and the `docs/troubleshooting/*` performance docs
+had drifted from source — documenting a config key that does not exist, a
+WASM-cache default a real run never sees, and a build path/command that is gone.
+This PR realigns each claim with the source of truth. Closes #3282.
+
+| Claim | Was | Now | Source of truth |
+| ----- | --- | --- | --------------- |
+| Distance-cache size | `distanceCache.maxSize` config option (default `10000`) | Not a `NeatOptions`/`NeatConfig` field; runtime `setDistanceCacheMaxSize()` call, default `10_000` | `src/breed/DistanceCache.ts:15,94`; zero `distanceCache` hits in `src/config/` |
+| WASM activation-cache default | "Default: 512" (MEMORY.md, WASM.md) | Effective default `populationSize * 2`; `512` labelled as the low-level module fallback | `src/config/parsers/RuntimeParsers.ts:56-59`; `src/wasm/WasmCreatureActivationLRU.ts:51` |
+| `threads` default | `navigator.hardwareConcurrency` | `navigator.hardwareConcurrency + 2` | `src/config/NeatConfig.ts:239-240`, `DEFAULT_HEAVY_TASK_WORKER_COUNT = 2` |
+| WASM build command | `cd wasm_activation && ./build.sh` (from source) | Repo-root `./build.sh`, described as syncing the vendored NEAT-AI-core bundle | `build.sh` header; no `wasm_activation/build.sh` exists |
+
+### Enabling change — public export
+
+The docs now describe tuning the distance cache via `setDistanceCacheMaxSize()`.
+That setter previously lived only in `src/breed/DistanceCache.ts` and was **not**
+re-exported from the single public entry point (`mod.ts`), so the documented call
+would not have been reachable by consumers. It is now re-exported from `mod.ts`,
+exactly mirroring the already-public `setMaxCachedWasmCreatureActivations()` WASM
+cache setter, so the documentation is truthful.
+
+## Evidence
+
+Documentation + a one-line public-export change — no web UI to screenshot. The
+export is verified by a unit test that imports the setter from the public
+`mod.ts` barrel and asserts it bounds the cache; the full `./quality.sh` gate
+passes (7591 tests, 0 failed).
+
+```mermaid
+flowchart LR
+    A["setDistanceCacheMaxSize()<br/>src/breed/DistanceCache.ts"] -->|re-export| B["mod.ts<br/>@stsoftware/neat-ai"]
+    B -->|documented as runtime knob| C["docs/PERFORMANCE_TUNING.md"]
+```
+
+## Test Plan
+
+- Added `test/breed/DistanceCache.ts::DistanceCache - setDistanceCacheMaxSize is
+  re-exported from mod.ts and bounds the cache` — imports the setter from the
+  public `mod.ts` entry point, sets a small bound, inserts more entries than the
+  bound, and asserts LRU eviction keeps the cache within `maxSize`.
+- `./quality.sh` passes cleanly (lint, format, type-check, WASM sync, all tests).

--- a/docs/troubleshooting/MEMORY.md
+++ b/docs/troubleshooting/MEMORY.md
@@ -77,8 +77,13 @@ for memory-constrained environments:
 
 ```typescript
 import { setMaxCachedWasmCreatureActivations } from "@stsoftware/neat-ai";
-setMaxCachedWasmCreatureActivations(256); // Default: 512
+setMaxCachedWasmCreatureActivations(256); // Effective default: populationSize * 2
 ```
+
+> A configured `Neat` run derives the WASM activation-cache limit from your
+> population — the **effective default is `populationSize * 2`**. The bare `512`
+> is only the low-level module fallback used when the LRU is driven directly
+> without a `Neat` config; a normal run never sees it.
 
 > The package exposes a single entry point, `@stsoftware/neat-ai`; every public
 > symbol is re-exported from it. There are no subpath specifiers.

--- a/docs/troubleshooting/PERFORMANCE.md
+++ b/docs/troubleshooting/PERFORMANCE.md
@@ -31,7 +31,8 @@ flowchart TD
 **Step 1 — Check worker threads:**
 
 Verify how many threads are being used. By default, NEAT-AI uses
-`navigator.hardwareConcurrency` (all available CPU cores).
+`navigator.hardwareConcurrency + 2` (all available CPU cores plus two heavy-task
+workers).
 
 ```typescript
 // Check effective thread count

--- a/docs/troubleshooting/WASM.md
+++ b/docs/troubleshooting/WASM.md
@@ -37,9 +37,12 @@ worker pre-fetch, runtime panics, and recovery behaviour. See the index in
   - `wasm_activation.js`
   - `wasm_activation_bg.wasm`
 - Ensure Deno has `--allow-read` (for local files) and `--allow-net` (for JSR).
-- If building from source, run:
+- If the vendored bundle is missing or stale, re-sync it by running the
+  repo-root `./build.sh`. This does **not** build WASM from source — it syncs
+  the pre-built, vendored WASM bundle (`wasm_activation/pkg`) from the pinned
+  NEAT-AI-core release into your checkout:
   ```bash
-  cd wasm_activation && ./build.sh
+  ./build.sh
   ```
 
 ## ⚠️ WASM module not initialised
@@ -192,8 +195,11 @@ supported workaround.
 
 **Solutions:**
 
-- The LRU (Least Recently Used) cache automatically evicts old entries (default:
-  512 cached instances). Reduce the limit if memory is tight:
+- The LRU (Least Recently Used) cache automatically evicts old entries. A
+  configured `Neat` run sizes it from your population, so the **effective
+  default is `populationSize * 2`** cached instances; the bare `512` is only the
+  low-level module fallback used when the LRU is driven directly without a
+  `Neat` config. Reduce the limit if memory is tight:
   ```typescript
   import { setMaxCachedWasmCreatureActivations } from "@stsoftware/neat-ai";
   setMaxCachedWasmCreatureActivations(256);

--- a/mod.ts
+++ b/mod.ts
@@ -546,6 +546,18 @@ export type { CacheStats } from "@cache/CacheStats.ts";
 export { getCacheStats } from "@cache/getCacheStats.ts";
 
 /**
+ * Distance Cache Tuning (Issue #1293)
+ *
+ * The distance cache stores pairwise genetic-compatibility scores keyed by
+ * creature UUID pairs. Its size is not a `NeatOptions` / `NeatConfig` field;
+ * it defaults to 10,000 entries and is tuned imperatively via
+ * {@link setDistanceCacheMaxSize} — the distance-cache counterpart to
+ * {@link setMaxCachedWasmCreatureActivations}. See
+ * `docs/PERFORMANCE_TUNING.md` for sizing guidance.
+ */
+export { setDistanceCacheMaxSize } from "@breed/DistanceCache.ts";
+
+/**
  * WASM preload for workers (Issue #1285, Issue #2545)
  *
  * Call {@link fetchWasmForWorkers} in the main thread before spawning workers

--- a/test/breed/DistanceCache.ts
+++ b/test/breed/DistanceCache.ts
@@ -4,7 +4,7 @@
  * Issue #1293: Verifies that pairwise genetic compatibility distances
  * are correctly cached and retrieved, and that LRU eviction works.
  */
-import { assertEquals, assertNotEquals } from "@std/assert";
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
 import { Creature } from "@creature";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
@@ -17,6 +17,10 @@ import {
   setCachedDistance,
   setDistanceCacheMaxSize,
 } from "@breed/DistanceCache.ts";
+// Issue #3282: the distance-cache size is not a NeatOptions/NeatConfig field;
+// it is tuned at runtime via this setter, which must be reachable from the
+// single public entry point (`mod.ts`) exactly like the WASM cache setter.
+import { setDistanceCacheMaxSize as publicSetDistanceCacheMaxSize } from "../../mod.ts";
 
 function makeCreature(prefix: string, hiddenCount: number): Creature {
   const neurons: CreatureExport["neurons"] = [];
@@ -355,4 +359,26 @@ Deno.test("DistanceCache - shared neurons produce correct cached compatibility",
   assertEquals(cachedResult, 0.5);
 
   clearDistanceCache();
+});
+
+Deno.test("DistanceCache - setDistanceCacheMaxSize is re-exported from mod.ts and bounds the cache", () => {
+  clearDistanceCache();
+
+  // The public entry point exposes the runtime knob documented in
+  // docs/PERFORMANCE_TUNING.md (Issue #3282).
+  assertEquals(typeof publicSetDistanceCacheMaxSize, "function");
+
+  publicSetDistanceCacheMaxSize(3);
+  assertEquals(getDistanceCacheStats().maxSize, 3);
+
+  // Insert more entries than the configured bound; LRU eviction keeps the
+  // cache within maxSize.
+  for (let i = 0; i < 6; i++) {
+    setCachedDistance(`u-${i}`, `v-${i}`, i);
+  }
+  assert(getDistanceCacheSize() <= 3);
+
+  // Restore the default so other tests see the documented 10,000 bound.
+  clearDistanceCache();
+  setDistanceCacheMaxSize(10_000);
 });


### PR DESCRIPTION
# Fix drifted performance & troubleshooting docs (Issue #3282)

## Summary

`docs/PERFORMANCE_TUNING.md` and the `docs/troubleshooting/*` performance docs
had drifted from source — documenting a config key that does not exist, a
WASM-cache default a real run never sees, and a build path/command that is gone.
This PR realigns each claim with the source of truth. Closes #3282.

| Claim | Was | Now | Source of truth |
| ----- | --- | --- | --------------- |
| Distance-cache size | `distanceCache.maxSize` config option (default `10000`) | Not a `NeatOptions`/`NeatConfig` field; runtime `setDistanceCacheMaxSize()` call, default `10_000` | `src/breed/DistanceCache.ts:15,94`; zero `distanceCache` hits in `src/config/` |
| WASM activation-cache default | "Default: 512" (MEMORY.md, WASM.md) | Effective default `populationSize * 2`; `512` labelled as the low-level module fallback | `src/config/parsers/RuntimeParsers.ts:56-59`; `src/wasm/WasmCreatureActivationLRU.ts:51` |
| `threads` default | `navigator.hardwareConcurrency` | `navigator.hardwareConcurrency + 2` | `src/config/NeatConfig.ts:239-240`, `DEFAULT_HEAVY_TASK_WORKER_COUNT = 2` |
| WASM build command | `cd wasm_activation && ./build.sh` (from source) | Repo-root `./build.sh`, described as syncing the vendored NEAT-AI-core bundle | `build.sh` header; no `wasm_activation/build.sh` exists |

### Enabling change — public export

The docs now describe tuning the distance cache via `setDistanceCacheMaxSize()`.
That setter previously lived only in `src/breed/DistanceCache.ts` and was **not**
re-exported from the single public entry point (`mod.ts`), so the documented call
would not have been reachable by consumers. It is now re-exported from `mod.ts`,
exactly mirroring the already-public `setMaxCachedWasmCreatureActivations()` WASM
cache setter, so the documentation is truthful.

## Evidence

Documentation + a one-line public-export change — no web UI to screenshot. The
export is verified by a unit test that imports the setter from the public
`mod.ts` barrel and asserts it bounds the cache; the full `./quality.sh` gate
passes (7591 tests, 0 failed).

```mermaid
flowchart LR
    A["setDistanceCacheMaxSize()<br/>src/breed/DistanceCache.ts"] -->|re-export| B["mod.ts<br/>@stsoftware/neat-ai"]
    B -->|documented as runtime knob| C["docs/PERFORMANCE_TUNING.md"]
```

## Test Plan

- Added `test/breed/DistanceCache.ts::DistanceCache - setDistanceCacheMaxSize is
  re-exported from mod.ts and bounds the cache` — imports the setter from the
  public `mod.ts` entry point, sets a small bound, inserts more entries than the
  bound, and asserts LRU eviction keeps the cache within `maxSize`.
- `./quality.sh` passes cleanly (lint, format, type-check, WASM sync, all tests).



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrepryq4-601d9f`<!-- vibe-worker-issue-3282 -->