### PR TITLE
Trim stale hand-maintained src/ tree from AGENTS.md (Issue #3285)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,35 +128,19 @@ but replaces unconditional mutation acceptance with MCMC").
 
 ### 📂 Directory Structure
 
-```
-src/                    # Source code
-  architecture/         # Core neural network architecture (Creature, Neuron, Synapse)
-  blackbox/             # Black-box evaluation utilities
-  breed/                # Crossover and breeding algorithms
-  compact/              # Network compaction and optimisation
-  config/               # Configuration and options (NeatOptions, NeatConfig)
-  costs/                # Cost/fitness functions
-  creature/             # Creature behaviour modules (activation, mutation, serialisation, training)
-  deprecated/           # Deprecated activation functions (HYPOT, HYPOTv2, MEAN)
-  discovery/            # Discovery integration (Rust FFI bridge)
-  errors/               # Error types
-  intelligentDesign/    # Intelligent Design squash optimisation
-  methods/              # Activation functions (squash implementations)
-  multithreading/       # Worker thread utilities
-  mutate/               # Mutation operators
-  NEAT/                 # Core NEAT algorithm (selection, speciation)
-  optimize/             # Optimisation passes
-  propagate/            # Backpropagation (TS orchestration; topological loop and elastic distribution are WASM-only)
-  reconstruct/          # Network reconstruction utilities
-  upgrade/              # Version migration
-  utils/                # Shared utilities
-  wasm/                 # WASM activation bridge
-test/                   # Tests (mirrors src/ structure)
-bench/                  # Benchmarks
-docs/                   # Extended documentation
-wasm_activation/pkg/    # Vendored WASM runtime artifacts from NEAT-AI-core
-scripts/                # Utility scripts
-```
+The per-module layout under `src/` grows as the source tree evolves, so it is
+**not** duplicated here — a hand-maintained tree only rots and misleads. Browse
+`src/` for the current, authoritative module layout, where each subdirectory is
+a subsystem.
+
+Top-level repository directories:
+
+- `src/` — Source code (one subdirectory per subsystem)
+- `test/` — Tests (mirrors `src/` structure)
+- `bench/` — Benchmarks
+- `docs/` — Extended documentation
+- `wasm_activation/pkg/` — Vendored WASM runtime artifacts from NEAT-AI-core
+- `scripts/` — Utility scripts
 
 ### 🗝️ Key Files
 

--- a/docs/archive/pr-summaries/pr-summary-3285.md
+++ b/docs/archive/pr-summaries/pr-summary-3285.md
@@ -1,0 +1,44 @@
+# AGENTS.md Directory Structure — trim the stale hand-maintained `src/` tree
+
+## Summary
+
+The "Directory Structure" section of `AGENTS.md` embedded a hand-maintained
+per-module `src/` tree that had drifted from the real source layout. Eight live
+subsystems existed under `src/` but were **absent** from the tree —
+`cache/`, `neuron/`, `onnx/`, `predictiveCoding/`, `presets/`, `score/`,
+`transfer/`, `workers/` — several of them load-bearing (ONNX export, predictive
+coding, presets, transfer learning). A contributor trusting the map would
+conclude those subsystems did not exist.
+
+Per the audit's preferred fix, the drift-prone per-module `src/` enumeration is
+removed and replaced with a pointer to `src/` as the single source of truth
+that cannot rot. The stable top-level directory list is retained. `Closes #3285`.
+
+```mermaid
+flowchart LR
+    A["AGENTS.md<br/>hand-maintained src/ tree"] -->|source tree grows| B["8 subsystems<br/>omitted → stale map"]
+    A -.trim-to-link.-> C["Pointer to src/<br/>single source of truth"]
+    C -->|cannot drift| D["Contributors read<br/>the real layout"]
+```
+
+## Evidence
+
+Documentation/CLI change — no web interface to screenshot. Verified via a new
+behavioural regression test that reads the real `src/` layout and the AGENTS.md
+section:
+
+- Before the fix: `21/29` subsystems listed, omitting the 8 live subsystems →
+  test fails (reproduces #3285).
+- After the fix: the section names no individual subsystem and points to
+  `src/` → test passes.
+
+Full quality gate (`./quality.sh`) passes cleanly: `7593 passed | 0 failed`.
+
+## Test Plan
+
+- Added `test/docs/AgentsDirectoryStructure.ts`:
+  - `AGENTS.md Directory Structure does not embed a partial src/ module tree` —
+    reads live `src/` subdirectories and asserts the section lists all-or-none,
+    so a subset that silently omits new subsystems cannot creep back in.
+  - `AGENTS.md Directory Structure points to src/ as source of truth` — asserts
+    the section references `src/` as the authoritative layout.

--- a/test/docs/AgentsDirectoryStructure.ts
+++ b/test/docs/AgentsDirectoryStructure.ts
@@ -1,0 +1,73 @@
+/**
+ * Issue #3285 — guard against a stale, hand-maintained `src/` tree in AGENTS.md.
+ *
+ * The "Directory Structure" section of AGENTS.md previously embedded a
+ * per-module `src/` listing that drifted from the real source layout: eight
+ * live subsystems (`cache/`, `neuron/`, `onnx/`, `predictiveCoding/`,
+ * `presets/`, `score/`, `transfer/`, `workers/`) existed on disk but were
+ * absent from the tree, misleading contributors into thinking those subsystems
+ * did not exist.
+ *
+ * The fix replaces that drift-prone enumeration with a pointer to `src/` as the
+ * single source of truth. This behavioural guard reads the real `src/` layout
+ * and the AGENTS.md section, then asserts the section does NOT re-introduce a
+ * partial per-module listing — it must enumerate either every live subsystem or
+ * none of them, so a subset that silently omits new subsystems cannot creep
+ * back in.
+ */
+
+import { assert } from "@std/assert";
+
+/** Extract the body of the "Directory Structure" heading up to the next `###`. */
+function directoryStructureSection(text: string): string {
+  const start = text.indexOf("### 📂 Directory Structure");
+  assert(start !== -1, "AGENTS.md is missing the Directory Structure heading");
+  const rest = text.slice(start + "### 📂 Directory Structure".length);
+  const end = rest.indexOf("\n### ");
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+Deno.test(
+  "AGENTS.md Directory Structure does not embed a partial src/ module tree",
+  async () => {
+    const agents = await Deno.readTextFile(
+      new URL("../../AGENTS.md", import.meta.url),
+    );
+    const section = directoryStructureSection(agents);
+
+    // Live subsystem directories directly under src/.
+    const srcRoot = new URL("../../src/", import.meta.url);
+    const liveSubsystems: string[] = [];
+    for await (const entry of Deno.readDir(srcRoot)) {
+      if (entry.isDirectory) liveSubsystems.push(entry.name);
+    }
+    assert(liveSubsystems.length > 0, "expected src/ to contain subsystems");
+
+    // Which live subsystems are named as `<name>/` inside the section?
+    const listed = liveSubsystems.filter((name) =>
+      section.includes(`${name}/`)
+    );
+
+    // A partial listing is exactly the stale-tree failure mode: some subsystems
+    // documented, others silently omitted. Require all-or-nothing.
+    const omitted = liveSubsystems.filter((name) => !listed.includes(name));
+    assert(
+      listed.length === 0 || omitted.length === 0,
+      `AGENTS.md Directory Structure embeds a partial src/ tree: ` +
+        `${listed.length}/${liveSubsystems.length} subsystems listed, ` +
+        `omitting [${omitted.sort().join(", ")}]. Point to src/ as the ` +
+        `single source of truth instead of maintaining the list by hand.`,
+    );
+  },
+);
+
+Deno.test("AGENTS.md Directory Structure points to src/ as source of truth", async () => {
+  const agents = await Deno.readTextFile(
+    new URL("../../AGENTS.md", import.meta.url),
+  );
+  const section = directoryStructureSection(agents);
+  assert(
+    section.includes("`src/`"),
+    "AGENTS.md Directory Structure should reference `src/` as the source layout",
+  );
+});


### PR DESCRIPTION
# AGENTS.md Directory Structure — trim the stale hand-maintained `src/` tree

## Summary

The "Directory Structure" section of `AGENTS.md` embedded a hand-maintained
per-module `src/` tree that had drifted from the real source layout. Eight live
subsystems existed under `src/` but were **absent** from the tree —
`cache/`, `neuron/`, `onnx/`, `predictiveCoding/`, `presets/`, `score/`,
`transfer/`, `workers/` — several of them load-bearing (ONNX export, predictive
coding, presets, transfer learning). A contributor trusting the map would
conclude those subsystems did not exist.

Per the audit's preferred fix, the drift-prone per-module `src/` enumeration is
removed and replaced with a pointer to `src/` as the single source of truth
that cannot rot. The stable top-level directory list is retained. `Closes #3285`.

```mermaid
flowchart LR
    A["AGENTS.md<br/>hand-maintained src/ tree"] -->|source tree grows| B["8 subsystems<br/>omitted → stale map"]
    A -.trim-to-link.-> C["Pointer to src/<br/>single source of truth"]
    C -->|cannot drift| D["Contributors read<br/>the real layout"]
```

## Evidence

Documentation/CLI change — no web interface to screenshot. Verified via a new
behavioural regression test that reads the real `src/` layout and the AGENTS.md
section:

- Before the fix: `21/29` subsystems listed, omitting the 8 live subsystems →
  test fails (reproduces #3285).
- After the fix: the section names no individual subsystem and points to
  `src/` → test passes.

Full quality gate (`./quality.sh`) passes cleanly: `7593 passed | 0 failed`.

## Test Plan

- Added `test/docs/AgentsDirectoryStructure.ts`:
  - `AGENTS.md Directory Structure does not embed a partial src/ module tree` —
    reads live `src/` subdirectories and asserts the section lists all-or-none,
    so a subset that silently omits new subsystems cannot creep back in.
  - `AGENTS.md Directory Structure points to src/ as source of truth` — asserts
    the section references `src/` as the authoritative layout.



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrepryq4-601d9f`<!-- vibe-worker-issue-3285 -->