### PR TITLE
Define Muon, predictive coding and OPD in the glossary (#3287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ NeuroEvolution of Augmenting Topologies algorithm published by
 in DenoJS using TypeScript. NEAT-AI keeps the speciation and structure-mutation
 ideas from standard NEAT but layers on much more recent research: memetic
 evolution, error-guided <strong>Discovery</strong>, Markov Chain Monte Carlo
-(MCMC) mutation acceptance, synthetic synapses, predictive coding, Muon-style
-orthogonalised gradients, and other algorithms (some published only weeks
-before this paragraph was written).
+(MCMC) mutation acceptance, synthetic synapses,
+<a href="docs/PREDICTIVE_CODING.md">predictive coding</a>,
+<a href="docs/comparison/UNIQUE_APPROACHES.md">Muon-style orthogonalised
+gradients</a>, and other algorithms (some published only weeks
+before this paragraph was written). Every house term and acronym here is defined
+in the <a href="docs/GLOSSARY.md">glossary</a>.
 </p>
 
 > [!IMPORTANT]

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -46,26 +46,27 @@ Each acronym is expanded on first use and linked to a deeper reference. When you
 introduce one of these in a doc, expand it the first time and link here or to
 the source.
 
-| Acronym     | Expansion                                                                        | Go deeper                                                                                                                                  |
-| ----------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **NEAT**    | NeuroEvolution of Augmenting Topologies                                          | [Stanley & Miikkulainen 2002](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf)                                                   |
-| **NEAT-AI** | NeuroEvolution of Augmenting Topologies — Artificial Intelligence (this project) | [AGENTS.md terminology](../AGENTS.md#-terminology)                                                                                         |
-| **MCMC**    | Markov Chain Monte Carlo                                                         | [Metropolis–Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)                                                 |
-| **WASM**    | WebAssembly                                                                      | [WebAssembly](https://webassembly.org/)                                                                                                    |
-| **FFI**     | Foreign Function Interface                                                       | [Deno FFI](https://docs.deno.com/runtime/fundamentals/ffi/)                                                                                |
-| **GPU**     | Graphics Processing Unit                                                         | [Graphics processing unit](https://en.wikipedia.org/wiki/Graphics_processing_unit)                                                         |
-| **CPU**     | Central Processing Unit                                                          | [Central processing unit](https://en.wikipedia.org/wiki/Central_processing_unit)                                                           |
-| **RL**      | Reinforcement Learning                                                           | [Reinforcement learning](https://en.wikipedia.org/wiki/Reinforcement_learning); see [REINFORCEMENT_LEARNING.md](REINFORCEMENT_LEARNING.md) |
-| **CRISPR**  | Clustered Regularly Interspaced Short Palindromic Repeats                        | [CRISPR-Cas9 overview](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/)                                 |
-| **ONNX**    | Open Neural Network Exchange                                                     | [onnx.ai](https://onnx.ai/)                                                                                                                |
-| **CNN**     | Convolutional Neural Network                                                     | [Convolutional neural network](https://en.wikipedia.org/wiki/Convolutional_neural_network)                                                 |
-| **RNN**     | Recurrent Neural Network                                                         | [Recurrent neural network](https://en.wikipedia.org/wiki/Recurrent_neural_network)                                                         |
-| **LLM**     | Large Language Model                                                             | [Large language model](https://en.wikipedia.org/wiki/Large_language_model)                                                                 |
-| **JSR**     | JavaScript Registry                                                              | [jsr.io](https://jsr.io/)                                                                                                                  |
-| **UUID**    | Universally Unique Identifier                                                    | [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier); see the neuron UUID invariant in [AGENTS.md](../AGENTS.md)            |
-| **MSE**     | Mean Squared Error                                                               | [Mean squared error](https://en.wikipedia.org/wiki/Mean_squared_error)                                                                     |
-| **DX12**    | DirectX 12 (Windows GPU API)                                                     | [DirectX 12](https://en.wikipedia.org/wiki/DirectX#DirectX_12)                                                                             |
-| **CI**      | Continuous Integration                                                           | [Continuous integration](https://en.wikipedia.org/wiki/Continuous_integration)                                                             |
+| Acronym     | Expansion                                                                        | Go deeper                                                                                                                                                                |
+| ----------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **NEAT**    | NeuroEvolution of Augmenting Topologies                                          | [Stanley & Miikkulainen 2002](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf)                                                                                 |
+| **NEAT-AI** | NeuroEvolution of Augmenting Topologies — Artificial Intelligence (this project) | [AGENTS.md terminology](../AGENTS.md#-terminology)                                                                                                                       |
+| **MCMC**    | Markov Chain Monte Carlo                                                         | [Metropolis–Hastings](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm)                                                                               |
+| **WASM**    | WebAssembly                                                                      | [WebAssembly](https://webassembly.org/)                                                                                                                                  |
+| **FFI**     | Foreign Function Interface                                                       | [Deno FFI](https://docs.deno.com/runtime/fundamentals/ffi/)                                                                                                              |
+| **GPU**     | Graphics Processing Unit                                                         | [Graphics processing unit](https://en.wikipedia.org/wiki/Graphics_processing_unit)                                                                                       |
+| **CPU**     | Central Processing Unit                                                          | [Central processing unit](https://en.wikipedia.org/wiki/Central_processing_unit)                                                                                         |
+| **RL**      | Reinforcement Learning                                                           | [Reinforcement learning](https://en.wikipedia.org/wiki/Reinforcement_learning); see [REINFORCEMENT_LEARNING.md](REINFORCEMENT_LEARNING.md)                               |
+| **CRISPR**  | Clustered Regularly Interspaced Short Palindromic Repeats                        | [CRISPR-Cas9 overview](https://www.nature.com/scitable/topicpage/crispr-cas9-a-precise-tool-for-33169884/)                                                               |
+| **ONNX**    | Open Neural Network Exchange                                                     | [onnx.ai](https://onnx.ai/)                                                                                                                                              |
+| **CNN**     | Convolutional Neural Network                                                     | [Convolutional neural network](https://en.wikipedia.org/wiki/Convolutional_neural_network)                                                                               |
+| **RNN**     | Recurrent Neural Network                                                         | [Recurrent neural network](https://en.wikipedia.org/wiki/Recurrent_neural_network)                                                                                       |
+| **LLM**     | Large Language Model                                                             | [Large language model](https://en.wikipedia.org/wiki/Large_language_model)                                                                                               |
+| **JSR**     | JavaScript Registry                                                              | [jsr.io](https://jsr.io/)                                                                                                                                                |
+| **UUID**    | Universally Unique Identifier                                                    | [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier); see the neuron UUID invariant in [AGENTS.md](../AGENTS.md)                                          |
+| **MSE**     | Mean Squared Error                                                               | [Mean squared error](https://en.wikipedia.org/wiki/Mean_squared_error)                                                                                                   |
+| **DX12**    | DirectX 12 (Windows GPU API)                                                     | [DirectX 12](https://en.wikipedia.org/wiki/DirectX#DirectX_12)                                                                                                           |
+| **CI**      | Continuous Integration                                                           | [Continuous integration](https://en.wikipedia.org/wiki/Continuous_integration)                                                                                           |
+| **OPD**     | On-Policy Distillation                                                           | [Knowledge distillation](https://en.wikipedia.org/wiki/Knowledge_distillation); the elites-into-generalist breed operator in the [Specialist Pipeline](api/EVOLUTION.md) |
 
 ## 🧬 Themed / house terms
 
@@ -124,6 +125,18 @@ NEAT-AI) plus a few codebase-specific terms.
   deceptive landscapes. Standard technique from
   [Lehman & Stanley 2011](https://doi.org/10.1162/EVCO_a_00025); **OFF by
   default** in NEAT-AI. See [NOVELTY_SEARCH.md](NOVELTY_SEARCH.md).
+- **Predictive coding** — an alternative to plain backpropagation in which each
+  layer iteratively minimises local prediction errors passed between layers,
+  inspired by the neuroscience theory of
+  [predictive coding](https://en.wikipedia.org/wiki/Predictive_coding). See
+  [PREDICTIVE_CODING.md](PREDICTIVE_CODING.md).
+- **Muon-style orthogonalised gradients** — an optional gradient step that runs
+  a Newton–Schulz polynomial iteration to
+  [orthogonalise](https://en.wikipedia.org/wiki/Orthogonalization) each
+  per-neuron incoming-weight gradient matrix before applying it, decorrelating
+  update directions. Inspired by the Muon optimiser; opt-in via
+  `gradientOrthogonalisation: "muon"`. See
+  [UNIQUE_APPROACHES.md](comparison/UNIQUE_APPROACHES.md).
 
 > [!TIP]
 > Spotted a fun label in the codebase that is not defined here? Add it to this

--- a/docs/api/EVOLUTION.md
+++ b/docs/api/EVOLUTION.md
@@ -379,7 +379,8 @@ orchestrator. The default `Creature.evolveDir()` loop manages them internally.
 Issue #2530: two-stage post-training pipeline that mirrors specialist /
 generalist distillation. Stage 1 seeds dedicated specialist species per declared
 sub-task; Stage 2 periodically distils the elites into a generalist via the OPD
-breed operator. Disabled by default.
+(On-Policy Distillation) breed operator. Disabled by default. See the
+[glossary entry for OPD](../GLOSSARY.md).
 
 ```typescript
 import {

--- a/docs/archive/pr-summaries/pr-summary-3287.md
+++ b/docs/archive/pr-summaries/pr-summary-3287.md
@@ -1,0 +1,58 @@
+## Summary
+
+The README bills `docs/GLOSSARY.md` as "the canonical reference for **every**
+acronym and house term used here", yet three terms it front-loads were defined
+nowhere the reader is pointed to: **predictive coding**, **Muon-style
+orthogonalised gradients**, and **OPD** (On-Policy Distillation). This closed the
+gap between the promise and the glossary. Closes #3287.
+
+Changes:
+
+- **`docs/GLOSSARY.md`**
+  - Added an **OPD — On-Policy Distillation** row to the acronyms table, linking
+    Knowledge distillation and the Specialist Pipeline in `api/EVOLUTION.md`.
+  - Added themed-term entries for **Predictive coding** (links Wikipedia and
+    `PREDICTIVE_CODING.md`) and **Muon-style orthogonalised gradients** (links
+    orthogonalisation, notes the opt-in `gradientOrthogonalisation: "muon"`, and
+    points to `comparison/UNIQUE_APPROACHES.md`).
+- **`docs/api/EVOLUTION.md`** — expanded OPD on first use to
+  "OPD (On-Policy Distillation)" and linked the glossary entry.
+- **`README.md`** — glossed the two terms where they first appear (line 12):
+  linked `predictive coding` → `docs/PREDICTIVE_CODING.md` and
+  `Muon-style orthogonalised gradients` → `docs/comparison/UNIQUE_APPROACHES.md`,
+  and reaffirmed the glossary as the lookup for every house term/acronym.
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot. Verified via the
+existing behavioural link-resolution and doc tests:
+
+- `deno test test/docs/GlossaryAndStyle.ts` — glossary internal links resolve
+  (covers the three new link targets).
+- `deno test test/docs/DiscoveryGuides.ts test/docs/ConfigDocsExports.ts
+  test/docs/ErrorsDocMatchesValidationError.ts test/docs/DocsIndex.ts` — 16
+  passed / 0 failed.
+- `./quality.sh --lint-only` — formatting, linting, and bash checks pass
+  (exit 0). `markdownlint-cli2` reports no errors in the three edited files.
+
+Per Issue #3142 the glossary's prose-grep assertions (required-acronym /
+themed-term substring checks) were deliberately removed as editorial, so no new
+prose-grep test was added; the observable behaviour here is that the new
+first-use links resolve, which the existing link-resolution test verifies.
+
+```mermaid
+flowchart LR
+    R["README.md<br/>first use"] -->|"gloss + link"| G["docs/GLOSSARY.md"]
+    E["docs/api/EVOLUTION.md<br/>OPD expanded"] --> G
+    G --> P["PREDICTIVE_CODING.md"]
+    G --> U["comparison/UNIQUE_APPROACHES.md"]
+    G --> K["Wikipedia refs"]
+```
+
+## Test Plan
+
+- Ran `test/docs/GlossaryAndStyle.ts` (link resolution) — passes with the three
+  new glossary links.
+- Ran the wider `test/docs/*` suite — 16 passed / 0 failed.
+- Ran `./quality.sh --lint-only` — exit 0.
+- Ran `markdownlint-cli2` on the edited files — no errors.


### PR DESCRIPTION
## Summary

The README bills `docs/GLOSSARY.md` as "the canonical reference for **every**
acronym and house term used here", yet three terms it front-loads were defined
nowhere the reader is pointed to: **predictive coding**, **Muon-style
orthogonalised gradients**, and **OPD** (On-Policy Distillation). This closed the
gap between the promise and the glossary. Closes #3287.

Changes:

- **`docs/GLOSSARY.md`**
  - Added an **OPD — On-Policy Distillation** row to the acronyms table, linking
    Knowledge distillation and the Specialist Pipeline in `api/EVOLUTION.md`.
  - Added themed-term entries for **Predictive coding** (links Wikipedia and
    `PREDICTIVE_CODING.md`) and **Muon-style orthogonalised gradients** (links
    orthogonalisation, notes the opt-in `gradientOrthogonalisation: "muon"`, and
    points to `comparison/UNIQUE_APPROACHES.md`).
- **`docs/api/EVOLUTION.md`** — expanded OPD on first use to
  "OPD (On-Policy Distillation)" and linked the glossary entry.
- **`README.md`** — glossed the two terms where they first appear (line 12):
  linked `predictive coding` → `docs/PREDICTIVE_CODING.md` and
  `Muon-style orthogonalised gradients` → `docs/comparison/UNIQUE_APPROACHES.md`,
  and reaffirmed the glossary as the lookup for every house term/acronym.

## Evidence

Documentation-only change — no web interface to screenshot. Verified via the
existing behavioural link-resolution and doc tests:

- `deno test test/docs/GlossaryAndStyle.ts` — glossary internal links resolve
  (covers the three new link targets).
- `deno test test/docs/DiscoveryGuides.ts test/docs/ConfigDocsExports.ts
  test/docs/ErrorsDocMatchesValidationError.ts test/docs/DocsIndex.ts` — 16
  passed / 0 failed.
- `./quality.sh --lint-only` — formatting, linting, and bash checks pass
  (exit 0). `markdownlint-cli2` reports no errors in the three edited files.

Per Issue #3142 the glossary's prose-grep assertions (required-acronym /
themed-term substring checks) were deliberately removed as editorial, so no new
prose-grep test was added; the observable behaviour here is that the new
first-use links resolve, which the existing link-resolution test verifies.

```mermaid
flowchart LR
    R["README.md<br/>first use"] -->|"gloss + link"| G["docs/GLOSSARY.md"]
    E["docs/api/EVOLUTION.md<br/>OPD expanded"] --> G
    G --> P["PREDICTIVE_CODING.md"]
    G --> U["comparison/UNIQUE_APPROACHES.md"]
    G --> K["Wikipedia refs"]
```

## Test Plan

- Ran `test/docs/GlossaryAndStyle.ts` (link resolution) — passes with the three
  new glossary links.
- Ran the wider `test/docs/*` suite — 16 passed / 0 failed.
- Ran `./quality.sh --lint-only` — exit 0.
- Ran `markdownlint-cli2` on the edited files — no errors.



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mreshnfm-0ac8a3`<!-- vibe-worker-issue-3287 -->