### PR TITLE
Deduplicate NEAT-AI vs NEAT admonition across 11 docs (Issue #3289)

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -7,16 +7,10 @@ sub-documents under [`docs/comparison/`](./docs/comparison/) so you can go as
 deep as you like without wading through one giant page.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** NEAT-AI started from
-> **[NEAT (NeuroEvolution of Augmenting Topologies)](./AGENTS.md#-terminology)**
-> as published by
-> [Stanley & Miikkulainen (2002)](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf),
-> but extends it well beyond the 2002 paper with gradient training, memetic
-> evolution, error-guided Discovery, MCMC mutation acceptance, synthetic
-> synapses, and more. Throughout these docs, **NEAT** means the standard 2002
-> algorithm and **NEAT-AI** means this project. The
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
 > [NEAT vs NEAT-AI rule in AGENTS.md](./AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
-> is the one canonical statement of the convention.
+> for the one canonical statement of the convention.
 
 New to NEAT-AI? Read on — this hub assumes no prior expertise.
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -13,13 +13,10 @@ things:
    understanding.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** NEAT-AI began as the original NeuroEvolution of Augmenting
-> Topologies algorithm
-> ([Stanley & Miikkulainen 2002](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf))
-> but has grown well past it. This glossary does **not** restate the rule for
-> when to say "NEAT-AI" versus "standard NEAT" — the
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
 > [NEAT vs NEAT-AI rule in AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
-> is the one canonical entry. Read it once; every other doc defers to it.
+> for the one canonical statement of the convention.
 
 New here? Start with [`../README.md`](../README.md), then skim this glossary,
 then dip into a [topic guide](README.md). The companion

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,16 +4,10 @@ Welcome to the NEAT-AI documentation. This page is the topic-by-topic table of
 contents — every long-form guide in the repository has a home here.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** NEAT-AI started from the original NeuroEvolution of
-> Augmenting Topologies algorithm
-> ([Stanley & Miikkulainen 2002](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf))
-> but extends it with memetic evolution, error-guided Discovery, MCMC mutation
-> acceptance, synthetic synapses, predictive coding, Muon-style orthogonalised
-> gradients, and other modern algorithms. When this documentation describes what
-> **this repository** does, it says **NEAT-AI**. When it discusses the 2002
-> algorithm itself, it says **NEAT** (or "standard NEAT", "pure NEAT"). The
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
 > [NEAT vs NEAT-AI rule in AGENTS.md](../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
-> is the canonical entry.
+> for the one canonical statement of the convention.
 
 If you have not used NEAT-AI before, follow the **Where to start** reading path
 below; it walks from a zero-knowledge introduction through to the topic guides

--- a/docs/archive/pr-summaries/pr-summary-3289.md
+++ b/docs/archive/pr-summaries/pr-summary-3289.md
@@ -1,0 +1,79 @@
+# De-duplicate the "NEAT-AI ≠ NEAT" terminology admonition (Issue #3289)
+
+## Summary
+
+The full "NEAT-AI ≠ NEAT" `> [!IMPORTANT]` admonition was restated in **11 live
+(non-archive) docs**, each maintaining its own copy of a rule the project
+declares canonical in `AGENTS.md` § "🆚 NEAT vs NEAT-AI — which term to use".
+Eleven copies of the same normative paragraph drift apart over time — one gets
+clarified, the others do not — and bloat every comparison doc with boilerplate.
+
+Following the model already used by the root `README.md`, each of the 11
+callouts is now a single concise one-line summary that **links** to the one
+canonical rule instead of restating it. `AGENTS.md` remains the single source of
+truth; every other doc defers to it.
+
+Files updated (all 11 named in the issue):
+
+- `docs/README.md`, `docs/GLOSSARY.md`, `COMPARISON.md`
+- `docs/comparison/`: `ARCHITECTURES.md`, `ECOSYSTEM.md`,
+  `TRAINING_PARADIGMS.md`, `PROS_AND_CONS.md`, `IMPLEMENTED.md`,
+  `UNIQUE_APPROACHES.md`, `FUTURE_WORK.md`, `REFERENCES.md`
+
+Each callout keeps the correct relative path to the canonical anchor
+(`../AGENTS.md`, `./AGENTS.md`, or `../../AGENTS.md` depending on the doc's
+location).
+
+Closes #3289.
+
+```mermaid
+flowchart TD
+    Canon["AGENTS.md § 🆚 NEAT vs NEAT-AI<br/>(single canonical rule)"]
+    subgraph Before["Before — 11 restated copies"]
+        B1["docs/README.md"]:::dup
+        B2["docs/GLOSSARY.md"]:::dup
+        B3["COMPARISON.md"]:::dup
+        B4["docs/comparison/*.md ×8"]:::dup
+    end
+    subgraph After["After — concise deferrals"]
+        A1["docs/README.md"] -->|link| Canon
+        A2["docs/GLOSSARY.md"] -->|link| Canon
+        A3["COMPARISON.md"] -->|link| Canon
+        A4["docs/comparison/*.md ×8"] -->|link| Canon
+    end
+    classDef dup fill:#E8575A,stroke:#B8444A,color:#fff;
+```
+
+## Evidence
+
+Docs-only change — no web interface to screenshot. Verified by the new
+behavioural test plus the existing doc test suite (link resolution, Jekyll
+Liquid safety, glossary/style) and the full `./quality.sh` gate (fmt, lint,
+type-check, 7597 tests) passing cleanly (exit 0).
+
+New test `test/docs/NeatTerminologyDefersToCanonical.ts` reproduced the defect
+before the fix — it failed on `docs/README.md` (and the other docs that
+re-embedded the 2002 paper citation) and passes after each callout was reduced
+to a concise deferral.
+
+A strict prose/line-count assertion on the summary wording was deliberately
+avoided: issue #3142 removed exactly that class of "callout wording" grep from
+`test/docs/ComparisonSplit.ts` because it broke on any reword. The new test
+instead guards the durable structural invariant — every governed doc's
+terminology callout links to the canonical anchor and does **not** re-cite the
+founding paper — so it catches the duplication returning without breaking on a
+future reword of the one-line summary.
+
+## Test Plan
+
+- Added `test/docs/NeatTerminologyDefersToCanonical.ts`:
+  - `AGENTS.md is the single canonical home of the NEAT vs NEAT-AI rule` —
+    asserts the canonical heading exists so the anchor the other docs link to
+    resolves.
+  - `governed docs defer to the canonical NEAT vs NEAT-AI rule` — for each of
+    the 11 docs, asserts the terminology callout exists, links to the canonical
+    anchor, and does not re-cite the Stanley & Miikkulainen (2002) paper.
+- Confirmed the second test failed against the pre-fix docs and passes after.
+- Ran `test/docs/ComparisonSplit.ts`, `DocsIndex.ts`, `GlossaryAndStyle.ts`,
+  `DiscoveryGuides.ts`, `JekyllLiquidSafety.ts` — all pass.
+- Ran the full `./quality.sh` gate — exit 0, 7597 passed / 0 failed.

--- a/docs/comparison/ARCHITECTURES.md
+++ b/docs/comparison/ARCHITECTURES.md
@@ -6,12 +6,10 @@ network families it is most often compared against: feedforward networks, CNNs,
 RNNs/LSTMs, and Transformers.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** The evolving-topology core below is inherited from
-> standard [NEAT](../../AGENTS.md#-terminology); the UUID-keyed neurons,
-> error-guided mutation, MCMC acceptance, gradient training, and synthetic
-> synapses are NEAT-AI extensions. The
-> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) is
-> the canonical convention.
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
+> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> for the one canonical statement of the convention.
 
 ## 🧠 Traditional Feedforward Neural Networks
 

--- a/docs/comparison/ECOSYSTEM.md
+++ b/docs/comparison/ECOSYSTEM.md
@@ -5,10 +5,10 @@ Part of the [Comparison hub](../../COMPARISON.md). This page contrasts
 toolchain (TensorFlow, PyTorch, Keras, scikit-learn).
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** The genetic substrate below is inherited from standard
-> [NEAT](../../AGENTS.md#-terminology); everything else is a NEAT-AI extension.
-> See the
-> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
+> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> for the one canonical statement of the convention.
 
 ## 📚 Standard ML Libraries (TensorFlow, PyTorch, etc.)
 

--- a/docs/comparison/FUTURE_WORK.md
+++ b/docs/comparison/FUTURE_WORK.md
@@ -6,10 +6,10 @@ approaches. These represent opportunities for future development and can serve
 as a task list.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** The gaps below are measured against the modern industry
-> state of the art, not against the 2002
-> [NEAT](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use) algorithm. Several
-> items that were once gaps are now implemented NEAT-AI extensions, marked ✅.
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
+> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> for the one canonical statement of the convention.
 
 The gaps are grouped into high, medium, and low priority below.
 

--- a/docs/comparison/IMPLEMENTED.md
+++ b/docs/comparison/IMPLEMENTED.md
@@ -7,13 +7,10 @@ a reader never confuses what the original algorithm did with what this
 repository adds.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** Everything in the _Standard NEAT machinery_ list below
-> comes from
-> [Stanley & Miikkulainen (2002)](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf).
-> Everything in the _NEAT-AI extensions_ lists is added by this repository and
-> has no counterpart in the 2002 paper. The
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
 > [NEAT vs NEAT-AI rule in AGENTS.md](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
-> is the canonical statement of the convention.
+> for the one canonical statement of the convention.
 
 ## 🔬 Standard NEAT machinery (Stanley & Miikkulainen, 2002)
 

--- a/docs/comparison/PROS_AND_CONS.md
+++ b/docs/comparison/PROS_AND_CONS.md
@@ -5,11 +5,10 @@ for **[NEAT-AI](../../AGENTS.md#-terminology)** against traditional neural
 networks.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** The pros below that derive from the genetic substrate
-> (population-based search, speciation) are inherited from standard
-> [NEAT](../../AGENTS.md#-terminology); the gradient training, regularisation,
-> MCMC, transfer learning, and tooling pros are NEAT-AI extensions. See the
-> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
+> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> for the one canonical statement of the convention.
 
 ## 🧬 NEAT-AI — Pros
 

--- a/docs/comparison/REFERENCES.md
+++ b/docs/comparison/REFERENCES.md
@@ -4,10 +4,10 @@ Part of the [Comparison hub](../../COMPARISON.md). Consolidated supporting
 references for every external claim made across the comparison sub-documents.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** The first reference below is the **standard NEAT** paper;
-> everything NEAT-AI adds on top is cited against the modern literature in the
-> sections that follow. See the
-> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
+> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> for the one canonical statement of the convention.
 
 ## 🧬 NEAT algorithm (standard NEAT)
 

--- a/docs/comparison/TRAINING_PARADIGMS.md
+++ b/docs/comparison/TRAINING_PARADIGMS.md
@@ -6,11 +6,10 @@ paradigm of traditional neural networks, and explains where NEAT-AI sits in the
 reinforcement-learning landscape.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** The genetic operators below are inherited from standard
-> [NEAT](../../AGENTS.md#-terminology); the gradient step, memetic learning,
-> MCMC acceptance, synthetic synapses, and advanced breeding are NEAT-AI
-> extensions. See the
-> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
+> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> for the one canonical statement of the convention.
 
 ## 🧠 Traditional Neural Networks
 

--- a/docs/comparison/UNIQUE_APPROACHES.md
+++ b/docs/comparison/UNIQUE_APPROACHES.md
@@ -6,9 +6,10 @@ standard [NEAT](../../AGENTS.md#-terminology) and, in most cases, uncommon in
 other open-source neuroevolution libraries.
 
 > [!IMPORTANT]
-> **NEAT-AI ≠ NEAT.** Every approach below is a NEAT-AI extension. Where it
-> contrasts with the 2002 algorithm, that contrast is stated explicitly, per the
-> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use).
+> **NEAT-AI ≠ NEAT.** **NEAT** means the original 2002 algorithm; **NEAT-AI**
+> means this project — they are no longer the same thing. See the
+> [NEAT vs NEAT-AI rule](../../AGENTS.md#-neat-vs-neat-ai--which-term-to-use)
+> for the one canonical statement of the convention.
 
 ## 1. 🧬 Memetic Evolution (Hybrid Evolution + Backpropagation)
 

--- a/test/docs/NeatTerminologyDefersToCanonical.ts
+++ b/test/docs/NeatTerminologyDefersToCanonical.ts
@@ -1,0 +1,100 @@
+/**
+ * Issue #3289 — the "NEAT-AI ≠ NEAT" terminology admonition was restated in
+ * full across 11 live docs, giving the same normative rule 11 copies that drift
+ * apart over time. `AGENTS.md` § "🆚 NEAT vs NEAT-AI — which term to use" is the
+ * one canonical statement; every other doc must *defer* to it with a concise
+ * link rather than re-state the rule (or re-cite the founding 2002 paper).
+ *
+ * These are behavioural "what" tests, in the spirit of ComparisonSplit.ts and
+ * DiscoveryGuides.ts:
+ *
+ *   1. AGENTS.md actually defines the canonical rule heading (so the anchor the
+ *      other docs link to resolves to a real section).
+ *   2. Each governed doc's terminology callout links to that canonical anchor.
+ *   3. Each governed doc's terminology callout is a concise deferral — it must
+ *      not re-embed the Stanley & Miikkulainen (2002) paper citation, which is
+ *      the boilerplate the canonical rule already owns. This guards against the
+ *      restated-paragraph duplication returning.
+ *
+ * The assertions target the structure of the terminology callout (its link and
+ * the absence of a re-cited paper URL), not the exact wording of its summary
+ * sentence, so a reword of the one-line summary does not break the test.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, resolve } from "@std/path";
+
+const REPO_ROOT = resolve(fromFileUrl(import.meta.url), "..", "..", "..");
+
+// Anchor GitHub generates for the canonical AGENTS.md heading.
+const CANON_ANCHOR = "-neat-vs-neat-ai--which-term-to-use";
+const CANON_HEADING = "### 🆚 NEAT vs NEAT-AI — which term to use";
+// The founding-paper citation the canonical rule owns; a deferring callout must
+// not re-embed it.
+const PAPER_URL_MARKER = "stanley.ec02.pdf";
+
+// Live (non-archive) docs that must defer to the one canonical rule.
+const GOVERNED_DOCS: ReadonlyArray<string> = [
+  "docs/README.md",
+  "docs/GLOSSARY.md",
+  "COMPARISON.md",
+  "docs/comparison/ARCHITECTURES.md",
+  "docs/comparison/ECOSYSTEM.md",
+  "docs/comparison/TRAINING_PARADIGMS.md",
+  "docs/comparison/PROS_AND_CONS.md",
+  "docs/comparison/IMPLEMENTED.md",
+  "docs/comparison/UNIQUE_APPROACHES.md",
+  "docs/comparison/FUTURE_WORK.md",
+  "docs/comparison/REFERENCES.md",
+];
+
+/** Return the `> [!IMPORTANT]` blockquote that carries the NEAT-AI ≠ NEAT rule. */
+function extractTerminologyCallout(content: string): string {
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === "> [!IMPORTANT]") {
+      const block: string[] = [];
+      let j = i + 1;
+      while (j < lines.length && lines[j].startsWith(">")) {
+        block.push(lines[j]);
+        j++;
+      }
+      const text = block.join("\n");
+      if (text.includes("NEAT-AI ≠ NEAT")) return text;
+    }
+  }
+  return "";
+}
+
+Deno.test("AGENTS.md is the single canonical home of the NEAT vs NEAT-AI rule", async () => {
+  const agents = await Deno.readTextFile(`${REPO_ROOT}/AGENTS.md`);
+  assert(
+    agents.includes(CANON_HEADING),
+    "AGENTS.md must define the canonical '🆚 NEAT vs NEAT-AI — which term to use' heading",
+  );
+});
+
+Deno.test("governed docs defer to the canonical NEAT vs NEAT-AI rule", async () => {
+  const docs = await Promise.all(
+    GOVERNED_DOCS.map(async (rel) => ({
+      rel,
+      content: await Deno.readTextFile(`${REPO_ROOT}/${rel}`),
+    })),
+  );
+  for (const { rel, content } of docs) {
+    const callout = extractTerminologyCallout(content);
+    assert(
+      callout !== "",
+      `${rel} must contain a NEAT-AI ≠ NEAT terminology callout`,
+    );
+    assert(
+      callout.includes(CANON_ANCHOR),
+      `${rel} callout must link to the canonical rule (${CANON_ANCHOR})`,
+    );
+    assert(
+      !callout.includes(PAPER_URL_MARKER),
+      `${rel} callout must defer to AGENTS.md, not re-cite the 2002 paper — ` +
+        `this is the restated-paragraph duplication issue #3289 removes`,
+    );
+  }
+});


### PR DESCRIPTION
# De-duplicate the "NEAT-AI ≠ NEAT" terminology admonition (Issue #3289)

## Summary

The full "NEAT-AI ≠ NEAT" `> [!IMPORTANT]` admonition was restated in **11 live
(non-archive) docs**, each maintaining its own copy of a rule the project
declares canonical in `AGENTS.md` § "🆚 NEAT vs NEAT-AI — which term to use".
Eleven copies of the same normative paragraph drift apart over time — one gets
clarified, the others do not — and bloat every comparison doc with boilerplate.

Following the model already used by the root `README.md`, each of the 11
callouts is now a single concise one-line summary that **links** to the one
canonical rule instead of restating it. `AGENTS.md` remains the single source of
truth; every other doc defers to it.

Files updated (all 11 named in the issue):

- `docs/README.md`, `docs/GLOSSARY.md`, `COMPARISON.md`
- `docs/comparison/`: `ARCHITECTURES.md`, `ECOSYSTEM.md`,
  `TRAINING_PARADIGMS.md`, `PROS_AND_CONS.md`, `IMPLEMENTED.md`,
  `UNIQUE_APPROACHES.md`, `FUTURE_WORK.md`, `REFERENCES.md`

Each callout keeps the correct relative path to the canonical anchor
(`../AGENTS.md`, `./AGENTS.md`, or `../../AGENTS.md` depending on the doc's
location).

Closes #3289.

```mermaid
flowchart TD
    Canon["AGENTS.md § 🆚 NEAT vs NEAT-AI<br/>(single canonical rule)"]
    subgraph Before["Before — 11 restated copies"]
        B1["docs/README.md"]:::dup
        B2["docs/GLOSSARY.md"]:::dup
        B3["COMPARISON.md"]:::dup
        B4["docs/comparison/*.md ×8"]:::dup
    end
    subgraph After["After — concise deferrals"]
        A1["docs/README.md"] -->|link| Canon
        A2["docs/GLOSSARY.md"] -->|link| Canon
        A3["COMPARISON.md"] -->|link| Canon
        A4["docs/comparison/*.md ×8"] -->|link| Canon
    end
    classDef dup fill:#E8575A,stroke:#B8444A,color:#fff;
```

## Evidence

Docs-only change — no web interface to screenshot. Verified by the new
behavioural test plus the existing doc test suite (link resolution, Jekyll
Liquid safety, glossary/style) and the full `./quality.sh` gate (fmt, lint,
type-check, 7597 tests) passing cleanly (exit 0).

New test `test/docs/NeatTerminologyDefersToCanonical.ts` reproduced the defect
before the fix — it failed on `docs/README.md` (and the other docs that
re-embedded the 2002 paper citation) and passes after each callout was reduced
to a concise deferral.

A strict prose/line-count assertion on the summary wording was deliberately
avoided: issue #3142 removed exactly that class of "callout wording" grep from
`test/docs/ComparisonSplit.ts` because it broke on any reword. The new test
instead guards the durable structural invariant — every governed doc's
terminology callout links to the canonical anchor and does **not** re-cite the
founding paper — so it catches the duplication returning without breaking on a
future reword of the one-line summary.

## Test Plan

- Added `test/docs/NeatTerminologyDefersToCanonical.ts`:
  - `AGENTS.md is the single canonical home of the NEAT vs NEAT-AI rule` —
    asserts the canonical heading exists so the anchor the other docs link to
    resolves.
  - `governed docs defer to the canonical NEAT vs NEAT-AI rule` — for each of
    the 11 docs, asserts the terminology callout exists, links to the canonical
    anchor, and does not re-cite the Stanley & Miikkulainen (2002) paper.
- Confirmed the second test failed against the pre-fix docs and passes after.
- Ran `test/docs/ComparisonSplit.ts`, `DocsIndex.ts`, `GlossaryAndStyle.ts`,
  `DiscoveryGuides.ts`, `JekyllLiquidSafety.ts` — all pass.
- Ran the full `./quality.sh` gate — exit 0, 7597 passed / 0 failed.



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mreshnfm-0ac8a3`<!-- vibe-worker-issue-3289 -->