### PR TITLE
Collapse README to a single docs-index pointer (Issue #3288)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,17 @@ For project terminology, coding conventions, and development guidelines, see
 
 ## 📖 Docs map
 
-New here? Skim this section first; every topic guide is one link away.
+New here? **[docs/README.md](./docs/README.md)** is the single, canonical
+documentation index — a topic-by-topic table of contents with a "where to start"
+reading path and a one-line summary for every long-form guide (Compute / WASM,
+Discovery / FFI, Performance, Reference, Specialised topics, Governance). This
+README deliberately does **not** re-catalogue those guides; it links off to the
+one index so the two never drift apart.
 
-- **[docs/README.md](./docs/README.md)** — full topic index with a "where to
-  start" reading path and one-line summaries for every long-form guide.
+Top entry points:
+
+- **[docs/README.md](./docs/README.md)** — full documentation index; start here
+  for any topic guide.
 - **[CONTRIBUTING.md](./CONTRIBUTING.md)** — development setup, workflow, and
   how to bump the pinned NEAT-AI-core revision.
 - **[AGENTS.md](./AGENTS.md)** — terminology and coding conventions for human
@@ -42,28 +49,6 @@ New here? Skim this section first; every topic guide is one link away.
   the place to look it up.
 - **[COMPARISON.md](./COMPARISON.md)** — how NEAT-AI compares to other AI
   approaches (and to standard NEAT).
-- **Topic guides** — quick jumps to the most-used docs:
-  - Compute / WebAssembly (WASM):
-    [Activation Functions](./docs/ACTIVATION_FUNCTIONS.md),
-    [Backprop Elasticity](./docs/BACKPROP_ELASTICITY.md),
-    [GPU Acceleration](./docs/GPU_ACCELERATION.md)
-  - Discovery / Foreign Function Interface (FFI):
-    [Discovery Guide](./docs/DISCOVERY_GUIDE.md),
-    [DiscoveryDir API](./docs/DISCOVERY_DIR.md),
-    [Discovery Architecture](./docs/DISCOVERY_ARCHITECTURE.md)
-  - Performance: [Performance Tuning](./docs/PERFORMANCE_TUNING.md),
-    [Performance Research](./docs/PERFORMANCE_RESEARCH.md)
-  - Reference: [API Reference](./docs/API_REFERENCE.md),
-    [Configuration Guide](./docs/CONFIGURATION_GUIDE.md),
-    [Troubleshooting](./docs/TROUBLESHOOTING.md)
-  - Specialised: [CRISPR Guide](./docs/CRISPR_GUIDE.md),
-    [Intelligent Design](./docs/INTELLIGENT_DESIGN.md),
-    [Predictive Coding](./docs/PREDICTIVE_CODING.md)
-  - Topic guides:
-    [Reinforcement learning / agent rollouts](./docs/REINFORCEMENT_LEARNING.md)
-  - Governance: [Core Dependency Policy](./docs/CORE_DEPENDENCY_POLICY.md),
-    [Parity Gate](./docs/PARITY_GATE.md), [Security](./SECURITY.md),
-    [Changelog](./CHANGELOG.md)
 
 ## 🏗️ High-level architecture
 
@@ -324,79 +309,6 @@ and evolution still run end-to-end in WASM.
 This project is designed to be used in a DenoJS environment. Please refer to the
 [Deno runtime manual](https://docs.deno.com/runtime/manual/) for setup and usage
 instructions.
-
-## 📚 Documentation
-
-For detailed documentation, see the [docs/](./docs/) directory:
-
-### 🚀 Getting Started
-
-- **[CONTRIBUTING.md](./CONTRIBUTING.md)**: First-time contributor guide with
-  development setup and workflow
-- **[Configuration Guide](./docs/CONFIGURATION_GUIDE.md)**: Complete reference
-  of all configuration options and presets
-
-### 🧠 Core Concepts
-
-- **[COMPARISON.md](./COMPARISON.md)**: How NEAT-AI compares to standard NEAT,
-  traditional neural networks, CNNs, RNNs, and modern LLMs
-- **[Discovery Guide](./docs/DISCOVERY_GUIDE.md)**: Complete guide to
-  distributed, multi-machine discovery workflows, including failure/success
-  caches, replay, candidate category limits, focus overrides, and the
-  cost-of-growth gate
-- **[Intelligent Design](./docs/INTELLIGENT_DESIGN.md)**: Systematic squash
-  function optimisation for hidden neurons
-
-### 🔧 API & Reference
-
-- **[API Reference](./docs/API_REFERENCE.md)**: Short topic index linking to
-  per-surface detail docs under [`docs/api/`](./docs/api/)
-- **[DiscoveryDir API](./docs/DISCOVERY_DIR.md)**: Technical API reference for
-  `Creature.discoveryDir()` and data preparation
-- **[Activation Functions Guide](./docs/ACTIVATION_FUNCTIONS.md)**: Complete
-  guide to all 30+ activation functions with selection guidance
-
-### 🔬 Advanced Topics
-
-- **[Predictive Coding](./docs/PREDICTIVE_CODING.md)**: Neuroscience-inspired
-  predictive coding training mode
-- **[Predictive Coding Benchmarks](./docs/PREDICTIVE_CODING_BENCHMARKS.md)**:
-  Benchmark results for predictive coding
-- **[Elastic Backpropagation](./docs/BACKPROP_ELASTICITY.md)**: Why we prefer
-  minimum-change weight updates and avoid pushing saturated squashes further
-  into saturation
-- **[GPU Acceleration](./docs/GPU_ACCELERATION.md)**: GPU acceleration for
-  discovery on macOS using Metal
-- **[WASM Resident Topology](./docs/WASM_RESIDENT_TOPOLOGY.md)**: Feasibility
-  analysis for WASM-resident creature topology
-
-### ⚡ Operations
-
-- **[Performance Tuning](./docs/PERFORMANCE_TUNING.md)**: Tuning WASM caches,
-  thread pools, memory management, and scaling for large-scale training
-- **[Performance Research](./docs/PERFORMANCE_RESEARCH.md)**: WASM migration
-  research and benchmark learnings
-- **[Troubleshooting](./docs/TROUBLESHOOTING.md)**: Common issues and solutions
-  for WASM, discovery, memory, CI, and configuration
-
-### 🦀 Core Dependency
-
-- **[Core Dependency Policy](./docs/CORE_DEPENDENCY_POLICY.md)**: How NEAT-AI
-  pins and consumes [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core)
-  via `deno.json` + `build.sh` (semver, rev pinning, approval tiers)
-- **[External NEAT-AI-core](./docs/EXTERNAL_NEAT_AI_CORE.md)**: Day-to-day
-  workflow for bumping the pinned revision and refreshing `wasm_activation/pkg`
-- **[Parity Gate](./docs/PARITY_GATE.md)**: Pre-removal verification checklist
-  for repin + artefact parity validation
-- **[CI for External Core](./docs/CI_EXTERNAL_NEAT_AI_CORE.md)**: CI plumbing
-  for `build.sh`-driven artifact sync
-
-### 🤝 For Contributors
-
-- **[AGENTS.md](./AGENTS.md)**: Coding conventions, terminology, and development
-  guidelines
-- **[Discovery Architecture](./docs/DISCOVERY_ARCHITECTURE.md)**: Internal
-  discovery pipeline architecture
 
 ## 🌐 Related Repositories
 

--- a/docs/archive/pr-summaries/pr-summary-3288.md
+++ b/docs/archive/pr-summaries/pr-summary-3288.md
@@ -1,0 +1,75 @@
+# PR Summary — Issue #3288
+
+## Summary
+
+`README.md` maintained **two** overlapping documentation indexes in the same
+file — `## 📖 Docs map` and `## 📚 Documentation` — while a third, canonical
+index already lived in `docs/README.md`. The two README blocks duplicated the
+same guides and had **already drifted apart** (each linked docs the other
+omitted). Three parallel indexes of the same guides cannot stay in sync, so a
+reader got a different, incomplete picture depending on which block they
+scrolled to, and every new doc had to be remembered in three places.
+
+This PR makes `docs/README.md` the single source of truth for the topic-by-topic
+index and reduces the README to a pointer:
+
+- **Trimmed `## 📖 Docs map`** to a short pointer that defers to
+  `docs/README.md`, plus a handful of top entry-point links (`CONTRIBUTING.md`,
+  `AGENTS.md`, `Glossary`, `COMPARISON.md`). The inline "Topic guides"
+  sub-catalogue that duplicated `docs/README.md` was removed.
+- **Deleted the second `## 📚 Documentation` catalogue** entirely. Every guide
+  it listed is already indexed in `docs/README.md`.
+- No other README content changed; contextual links inside feature prose (e.g.
+  the Discovery and Predictive Coding references) are untouched.
+
+Closes #3288.
+
+## Evidence
+
+This is a documentation + test change with no web interface to screenshot.
+Verification is via the new behavioural tests and the existing docs suite.
+
+Before → after structure:
+
+```mermaid
+flowchart TB
+    subgraph Before["Before — three parallel, drifting indexes"]
+        R1["README.md<br/>## 📖 Docs map"] -.->|overlap| D1["docs/README.md<br/>canonical index"]
+        R2["README.md<br/>## 📚 Documentation"] -.->|overlap| D1
+        R1 -.->|drift| R2
+    end
+    subgraph After["After — one index, README links off"]
+        RA["README.md<br/>## 📖 Docs map (pointer)"] -->|links off to| DA["docs/README.md<br/>single canonical index"]
+    end
+```
+
+Test run:
+
+```
+running 4 tests from ./test/docs/ReadmeSingleDocsIndex.ts
+README relative links all resolve on disk ... ok
+README defers to the canonical docs/README.md index ... ok
+README no longer carries a second '## 📚 Documentation' catalogue ... ok
+README Docs map is a pointer, not a duplicate catalogue ... ok
+ok | 4 passed | 0 failed
+```
+
+The full `test/docs/` suite (102 tests) passes, confirming no other doc test
+relied on the removed README catalogue. `deno fmt --check` and `deno lint` pass
+on the changed files.
+
+## Test Plan
+
+Added `test/docs/ReadmeSingleDocsIndex.ts` — behavioural ("what") tests that
+read the committed Markdown and assert on observable facts:
+
+- **README relative links all resolve on disk** — guards against broken links
+  introduced by the edit.
+- **README defers to the canonical docs/README.md index** — the single
+  `Docs
+  map` section links to `docs/README.md`.
+- **README no longer carries a second `## 📚 Documentation` catalogue** — the
+  regression guard; this test failed against the pre-fix README and passes now.
+- **README Docs map is a pointer, not a duplicate catalogue** — the README links
+  to fewer `docs/` guides than the canonical index, i.e. it does not
+  re-catalogue the guides `docs/README.md` owns.

--- a/test/docs/ReadmeSingleDocsIndex.ts
+++ b/test/docs/ReadmeSingleDocsIndex.ts
@@ -1,0 +1,137 @@
+/**
+ * Issue #3288 — the README must maintain a single "Docs map" pointer that
+ * defers to the canonical documentation index in `docs/README.md`, rather
+ * than re-implementing the catalogue inline.
+ *
+ * Before this issue the README carried TWO overlapping documentation
+ * indexes ("## 📖 Docs map" and "## 📚 Documentation") that duplicated
+ * `docs/README.md` and had already drifted out of sync. Three parallel
+ * indexes of the same guides cannot stay consistent.
+ *
+ * These are behavioural ("what") tests: they read the actual link targets
+ * and section structure of the committed Markdown and assert on observable
+ * facts (links resolve; the canonical index is referenced; the second
+ * catalogue is gone; the README is a pointer, not a duplicate catalogue).
+ */
+
+import { assert } from "@std/assert";
+import { dirname, fromFileUrl, resolve } from "@std/path";
+
+const REPO_ROOT = resolve(fromFileUrl(import.meta.url), "..", "..", "..");
+const README = `${REPO_ROOT}/README.md`;
+const DOCS_README = `${REPO_ROOT}/docs/README.md`;
+
+/** Extract the resolvable relative-link targets from Markdown content. */
+function relativeLinkTargets(content: string): string[] {
+  const linkRe = /\[[^\]]+\]\(([^)]+)\)/g;
+  const targets: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = linkRe.exec(content)) !== null) {
+    const target = match[1];
+    if (target.startsWith("http://") || target.startsWith("https://")) continue;
+    if (target.startsWith("#")) continue;
+    const [pathPart] = target.split("#");
+    if (!pathPart) continue;
+    targets.push(pathPart);
+  }
+  return targets;
+}
+
+/** Return the body of the `## `-level section whose heading includes `needle`. */
+function sectionBody(content: string, needle: string): string | null {
+  const lines = content.split("\n");
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith("## ") && lines[i].includes(needle)) {
+      start = i;
+      break;
+    }
+  }
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i].startsWith("## ")) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+Deno.test("README relative links all resolve on disk", async () => {
+  const content = await Deno.readTextFile(README);
+  const targets = relativeLinkTargets(content);
+  const failures = await Promise.all(
+    targets.map(async (pathPart) => {
+      const resolved = resolve(dirname(README), pathPart);
+      try {
+        await Deno.stat(resolved);
+        return null;
+      } catch {
+        return `broken link: ${pathPart} (resolved to ${resolved})`;
+      }
+    }),
+  );
+  const broken = failures.filter((r): r is string => r !== null);
+  assert(broken.length === 0, `README has broken links:\n${broken.join("\n")}`);
+});
+
+Deno.test("README defers to the canonical docs/README.md index", async () => {
+  const content = await Deno.readTextFile(README);
+  const docsMap = sectionBody(content, "Docs map");
+  assert(
+    docsMap !== null,
+    "README must keep a single '## 📖 Docs map' section",
+  );
+  assert(
+    docsMap.includes("docs/README.md"),
+    "the Docs map must link to the canonical docs/README.md index",
+  );
+});
+
+Deno.test("README no longer carries a second '## 📚 Documentation' catalogue", async () => {
+  const content = await Deno.readTextFile(README);
+  const duplicate = sectionBody(content, "📚 Documentation");
+  assert(
+    duplicate === null,
+    "README must not re-implement a second documentation catalogue; the " +
+      "canonical index lives in docs/README.md",
+  );
+});
+
+Deno.test("README Docs map is a pointer, not a duplicate catalogue", async () => {
+  const [readme, docsIndex] = await Promise.all([
+    Deno.readTextFile(README),
+    Deno.readTextFile(DOCS_README),
+  ]);
+
+  // Count distinct long-form guides under docs/ that each file links to,
+  // excluding the canonical index and the glossary/style foundation docs
+  // that are legitimate top entry points from the README.
+  const foundation = new Set(["README.md", "GLOSSARY.md", "DOC_STYLE.md"]);
+  const guidesLinked = (content: string): Set<string> => {
+    const guides = new Set<string>();
+    for (const target of relativeLinkTargets(content)) {
+      const m = target.match(/(?:^|\/)docs\/([^/]+\.md)$/) ??
+        target.match(/^([A-Z0-9_]+\.md)$/); // docs/README.md's own relative form
+      if (!m) continue;
+      const file = m[1];
+      if (foundation.has(file)) continue;
+      guides.add(file);
+    }
+    return guides;
+  };
+
+  const readmeGuides = guidesLinked(readme);
+  const docsGuides = guidesLinked(docsIndex);
+
+  // The README must be a short pointer: it should not re-catalogue the bulk
+  // of the topic guides that docs/README.md owns. A handful of contextual
+  // links inside feature prose is fine; a parallel catalogue is not.
+  assert(
+    readmeGuides.size < docsGuides.size,
+    `README links to ${readmeGuides.size} docs/ guides but the canonical ` +
+      `index links to ${docsGuides.size}; the README must defer the ` +
+      `catalogue to docs/README.md, not duplicate it`,
+  );
+});


### PR DESCRIPTION
# PR Summary — Issue #3288

## Summary

`README.md` maintained **two** overlapping documentation indexes in the same
file — `## 📖 Docs map` and `## 📚 Documentation` — while a third, canonical
index already lived in `docs/README.md`. The two README blocks duplicated the
same guides and had **already drifted apart** (each linked docs the other
omitted). Three parallel indexes of the same guides cannot stay in sync, so a
reader got a different, incomplete picture depending on which block they
scrolled to, and every new doc had to be remembered in three places.

This PR makes `docs/README.md` the single source of truth for the topic-by-topic
index and reduces the README to a pointer:

- **Trimmed `## 📖 Docs map`** to a short pointer that defers to
  `docs/README.md`, plus a handful of top entry-point links (`CONTRIBUTING.md`,
  `AGENTS.md`, `Glossary`, `COMPARISON.md`). The inline "Topic guides"
  sub-catalogue that duplicated `docs/README.md` was removed.
- **Deleted the second `## 📚 Documentation` catalogue** entirely. Every guide
  it listed is already indexed in `docs/README.md`.
- No other README content changed; contextual links inside feature prose (e.g.
  the Discovery and Predictive Coding references) are untouched.

Closes #3288.

## Evidence

This is a documentation + test change with no web interface to screenshot.
Verification is via the new behavioural tests and the existing docs suite.

Before → after structure:

```mermaid
flowchart TB
    subgraph Before["Before — three parallel, drifting indexes"]
        R1["README.md<br/>## 📖 Docs map"] -.->|overlap| D1["docs/README.md<br/>canonical index"]
        R2["README.md<br/>## 📚 Documentation"] -.->|overlap| D1
        R1 -.->|drift| R2
    end
    subgraph After["After — one index, README links off"]
        RA["README.md<br/>## 📖 Docs map (pointer)"] -->|links off to| DA["docs/README.md<br/>single canonical index"]
    end
```

Test run:

```
running 4 tests from ./test/docs/ReadmeSingleDocsIndex.ts
README relative links all resolve on disk ... ok
README defers to the canonical docs/README.md index ... ok
README no longer carries a second '## 📚 Documentation' catalogue ... ok
README Docs map is a pointer, not a duplicate catalogue ... ok
ok | 4 passed | 0 failed
```

The full `test/docs/` suite (102 tests) passes, confirming no other doc test
relied on the removed README catalogue. `deno fmt --check` and `deno lint` pass
on the changed files.

## Test Plan

Added `test/docs/ReadmeSingleDocsIndex.ts` — behavioural ("what") tests that
read the committed Markdown and assert on observable facts:

- **README relative links all resolve on disk** — guards against broken links
  introduced by the edit.
- **README defers to the canonical docs/README.md index** — the single
  `Docs
  map` section links to `docs/README.md`.
- **README no longer carries a second `## 📚 Documentation` catalogue** — the
  regression guard; this test failed against the pre-fix README and passes now.
- **README Docs map is a pointer, not a duplicate catalogue** — the README links
  to fewer `docs/` guides than the canonical index, i.e. it does not
  re-catalogue the guides `docs/README.md` owns.



## Milestone
This PR is part of the **Docs** milestone and targets the `milestone/docs` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrevfyhf-287d50`<!-- vibe-worker-issue-3288 -->