### PR TITLE
dead-code: make readV8HeapLimitMb module-private (Issue #3316)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3316.md
+++ b/docs/archive/pr-summaries/pr-summary-3316.md
@@ -1,0 +1,45 @@
+## Summary
+
+Removed the `export` keyword from `readV8HeapLimitMb` in
+`src/workers/WorkerHandlerBase.ts`, making it module-private. A repo-wide
+word-boundary search confirmed the symbol has no importer anywhere: it is
+referenced only within its own module as the default `heapLimitMb` argument of
+`verifyWorkerHeapBudget`, and it is not re-exported from any barrel
+(`src/workers/mod.ts`) nor injected by any test. Dropping the `export` removes
+dead public surface while preserving behaviour. Closes #3316.
+
+## Evidence
+
+Backend-only change with no web interface — verified via the test suite. The
+function is now declared `function readV8HeapLimitMb()` and remains wired as the
+default parameter at the call site, so `verifyWorkerHeapBudget()` still resolves
+the isolate heap limit when no reader is supplied.
+
+```mermaid
+flowchart LR
+    A[verifyWorkerHeapBudget] -->|heapLimitMb default| B[readV8HeapLimitMb]
+    B -->|module-private| C[v8.getHeapStatistics]
+```
+
+Test run (affected file):
+
+```
+running 11 tests from ./test/workers/WorkerHeapBudget.ts
+...
+verifyWorkerHeapBudget: uses the module-private readV8HeapLimitMb default when no heap reader is supplied (Issue #3316) ... ok
+ok | 11 passed | 0 failed
+```
+
+`deno lint` and `deno check` pass cleanly on both changed files.
+
+## Test Plan
+
+- Added `test/workers/WorkerHeapBudget.ts` →
+  `"verifyWorkerHeapBudget: uses the module-private readV8HeapLimitMb default
+  when no heap reader is supplied (Issue #3316)"`, which calls
+  `verifyWorkerHeapBudget` with no `heapLimitMb` argument, forcing the internal
+  `readV8HeapLimitMb` default path, and asserts the configured budget is
+  resolved and logged. This guards the internal default now that the symbol is
+  no longer exported.
+- All pre-existing `WorkerHeapBudget.ts` and `WorkerHeapBudgetCore.ts` tests
+  continue to pass (24 passed / 0 failed).

--- a/src/workers/WorkerHandlerBase.ts
+++ b/src/workers/WorkerHandlerBase.ts
@@ -93,8 +93,13 @@ export function requiredWorkerV8Flag(budgetMb: number): string {
   return `--max-old-space-size=${budgetMb}`;
 }
 
-/** The current isolate's V8 old-space heap limit, in MB. */
-export function readV8HeapLimitMb(): number {
+/**
+ * The current isolate's V8 old-space heap limit, in MB.
+ *
+ * Module-private: consumed only as the default `heapLimitMb` argument of
+ * {@link verifyWorkerHeapBudget} below (Issue #3316).
+ */
+function readV8HeapLimitMb(): number {
   return Math.round(v8.getHeapStatistics().heap_size_limit / BYTES_PER_MB);
 }
 

--- a/test/workers/WorkerHeapBudget.ts
+++ b/test/workers/WorkerHeapBudget.ts
@@ -136,6 +136,25 @@ Deno.test("verifyWorkerHeapBudget: warns when the worker heap limit is materiall
   );
 });
 
+Deno.test("verifyWorkerHeapBudget: uses the module-private readV8HeapLimitMb default when no heap reader is supplied (Issue #3316)", () => {
+  // No `heapLimitMb` argument, so the call falls through to the module-private
+  // `readV8HeapLimitMb` default. It must still resolve the configured budget and
+  // emit a heap-limit log line — this guards the internal default now that the
+  // symbol is no longer exported.
+  const { logger, lines } = makeRecordingLogger();
+  const budget = verifyWorkerHeapBudget(
+    "disc-worker-default",
+    envFrom({ [DISCOVERY_HEAP_SIZE_ENV]: "4096" }),
+    undefined,
+    logger,
+  );
+  assertEquals(budget, 4096);
+  assert(
+    lines.some((l) => l.message.includes("4096")),
+    "expected a heap-limit log line mentioning the budget via the default reader",
+  );
+});
+
 Deno.test("verifyWorkerHeapBudget: no budget configured returns undefined and does not warn", () => {
   const { logger, lines } = makeRecordingLogger();
   const budget = verifyWorkerHeapBudget(


### PR DESCRIPTION
## Summary

Removed the `export` keyword from `readV8HeapLimitMb` in
`src/workers/WorkerHandlerBase.ts`, making it module-private. A repo-wide
word-boundary search confirmed the symbol has no importer anywhere: it is
referenced only within its own module as the default `heapLimitMb` argument of
`verifyWorkerHeapBudget`, and it is not re-exported from any barrel
(`src/workers/mod.ts`) nor injected by any test. Dropping the `export` removes
dead public surface while preserving behaviour. Closes #3316.

## Evidence

Backend-only change with no web interface — verified via the test suite. The
function is now declared `function readV8HeapLimitMb()` and remains wired as the
default parameter at the call site, so `verifyWorkerHeapBudget()` still resolves
the isolate heap limit when no reader is supplied.

```mermaid
flowchart LR
    A[verifyWorkerHeapBudget] -->|heapLimitMb default| B[readV8HeapLimitMb]
    B -->|module-private| C[v8.getHeapStatistics]
```

Test run (affected file):

```
running 11 tests from ./test/workers/WorkerHeapBudget.ts
...
verifyWorkerHeapBudget: uses the module-private readV8HeapLimitMb default when no heap reader is supplied (Issue #3316) ... ok
ok | 11 passed | 0 failed
```

`deno lint` and `deno check` pass cleanly on both changed files.

## Test Plan

- Added `test/workers/WorkerHeapBudget.ts` →
  `"verifyWorkerHeapBudget: uses the module-private readV8HeapLimitMb default
  when no heap reader is supplied (Issue #3316)"`, which calls
  `verifyWorkerHeapBudget` with no `heapLimitMb` argument, forcing the internal
  `readV8HeapLimitMb` default path, and asserts the configured budget is
  resolved and logged. This guards the internal default now that the symbol is
  no longer exported.
- All pre-existing `WorkerHeapBudget.ts` and `WorkerHeapBudgetCore.ts` tests
  continue to pass (24 passed / 0 failed).



## Milestone
This PR is part of the **Dead code** milestone and targets the `milestone/dead-code` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrfrunzk-d593fb`<!-- vibe-worker-issue-3316 -->