### PR TITLE
Discovery: drop unused export on wrapBestCandidate (#3314)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3314.md
+++ b/docs/archive/pr-summaries/pr-summary-3314.md
@@ -1,0 +1,60 @@
+# Remove dead `export` on `wrapBestCandidate` (Issue #3314)
+
+## Summary
+
+`wrapBestCandidate` in `src/discovery/CombinedCandidates.ts` was exported but
+had no importer anywhere in the repository — it is called only from within its
+own module (by `buildBestOfCategoryCandidate`). The `export` keyword added
+public API surface with no consumer, so it has been dropped, making the helper
+module-private. Behaviour is unchanged. Closes #3314.
+
+Verification that the removal is safe:
+
+- A word-boundary search for `wrapBestCandidate` across every `.ts` file finds
+  occurrences **only** in `src/discovery/CombinedCandidates.ts` (declaration
+  plus three internal call sites).
+- The helper is **not** re-exported from `mod.ts` nor from the
+  `DiscoveryCandidates.ts` backwards-compatibility barrel.
+- No dynamic `import()` or reflective use targets the name; no non-`.ts` file
+  references it.
+
+## Change
+
+```mermaid
+flowchart LR
+    A["buildBestOfCategoryCandidate()<br/>(same module)"] --> B["wrapBestCandidate()<br/>now module-private"]
+    X["No external importer"] -. removed public surface .-> B
+```
+
+- `src/discovery/CombinedCandidates.ts` — removed the `export` keyword from
+  `function wrapBestCandidate` and noted in the doc comment that it is now
+  module-private (Issue #3314). The three internal call sites are unchanged.
+
+## Evidence
+
+Backend-only change with no web interface, so no screenshot applies.
+
+The helper's selection logic (picking the top-scoring candidate) is already
+covered behaviourally through the public `buildDiscoveryCandidates` path by the
+existing test suite — dropping the `export` keeps that coverage green, which is
+the regression guarantee. A new test asserting "the symbol is not exported"
+would be a forbidden "how" test (it inspects API surface rather than
+behaviour), so none was added.
+
+- Targeted run — `test/discovery/DiscoveryCandidatesIndividual.ts`:
+  `7 passed | 0 failed`, including
+  `buildDiscoveryCandidates combines best candidate from each category` and
+  `buildDiscoveryCandidates includes removeHarmfulNeurons in best-of-category
+  candidate`, both of which exercise `wrapBestCandidate` via
+  `buildBestOfCategoryCandidate`.
+- `deno check` and `deno lint` on the affected modules: clean.
+- Full `./quality.sh`: `7601 passed (5 steps) | 0 failed | 4 ignored`.
+
+## Test Plan
+
+- No new tests added (see Evidence — a non-exportedness assertion would be a
+  "how" test). Existing behavioural coverage in
+  `test/discovery/DiscoveryCandidatesIndividual.ts` verifies the helper's
+  selection logic through the public API and continues to pass.
+- Ran the full quality gate (`./quality.sh`) — lint, format, type-check, and
+  all tests pass.

--- a/docs/archive/pr-summaries/pr-summary-3314.md
+++ b/docs/archive/pr-summaries/pr-summary-3314.md
@@ -38,15 +38,15 @@ The helper's selection logic (picking the top-scoring candidate) is already
 covered behaviourally through the public `buildDiscoveryCandidates` path by the
 existing test suite — dropping the `export` keeps that coverage green, which is
 the regression guarantee. A new test asserting "the symbol is not exported"
-would be a forbidden "how" test (it inspects API surface rather than
-behaviour), so none was added.
+would be a forbidden "how" test (it inspects API surface rather than behaviour),
+so none was added.
 
 - Targeted run — `test/discovery/DiscoveryCandidatesIndividual.ts`:
   `7 passed | 0 failed`, including
   `buildDiscoveryCandidates combines best candidate from each category` and
   `buildDiscoveryCandidates includes removeHarmfulNeurons in best-of-category
-  candidate`, both of which exercise `wrapBestCandidate` via
-  `buildBestOfCategoryCandidate`.
+  candidate`,
+  both of which exercise `wrapBestCandidate` via `buildBestOfCategoryCandidate`.
 - `deno check` and `deno lint` on the affected modules: clean.
 - Full `./quality.sh`: `7601 passed (5 steps) | 0 failed | 4 ignored`.
 
@@ -56,5 +56,5 @@ behaviour), so none was added.
   "how" test). Existing behavioural coverage in
   `test/discovery/DiscoveryCandidatesIndividual.ts` verifies the helper's
   selection logic through the public API and continues to pass.
-- Ran the full quality gate (`./quality.sh`) — lint, format, type-check, and
-  all tests pass.
+- Ran the full quality gate (`./quality.sh`) — lint, format, type-check, and all
+  tests pass.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -258,6 +258,7 @@
     "evolverl",
     "exampletoken",
     "exportjson",
+    "exportedness",
     "extern",
     "externref",
     "externrefs",

--- a/src/discovery/CombinedCandidates.ts
+++ b/src/discovery/CombinedCandidates.ts
@@ -231,8 +231,11 @@ export function buildBestOfCategoryCandidate(
 
 /**
  * Wrap the single best-scoring entry from a candidate array into a 1-element array.
+ *
+ * Module-private: used only by `buildBestOfCategoryCandidate` within this file
+ * (dead public surface removed, Issue #3314).
  */
-export function wrapBestCandidate<
+function wrapBestCandidate<
   T extends { expectedCreatureScoreGain?: number },
 >(
   entries: T[] | undefined,


### PR DESCRIPTION
## Summary

`wrapBestCandidate` in `src/discovery/CombinedCandidates.ts` was exported but
had no importer anywhere in the repository — it is called only from within its
own module by `buildBestOfCategoryCandidate` (three internal call sites). The
`export` keyword added public API surface with no consumer, so it has been
dropped, making the helper module-private. Behaviour is unchanged. Closes #3314.

> Note on base branch: this issue was filed against the `milestone/dead-code`
> branch, but that branch has since been deleted (its work merged), which
> auto-closed the earlier PR #3321. This PR therefore targets `Develop`. The fix
> is confirmed **not** present on `Develop` (it still exports the helper).

Verification the removal is safe:

- A word-boundary search for `wrapBestCandidate` across every `.ts` file finds
  occurrences **only** in `src/discovery/CombinedCandidates.ts` (declaration
  plus three internal call sites).
- Not re-exported from `mod.ts` nor the `DiscoveryCandidates.ts` compatibility
  barrel; no dynamic `import()` or non-`.ts` reference targets the name.

## Evidence

Backend/library change with no web interface to screenshot. The helper's
selection logic is covered behaviourally through the public
`combo-best-of-category` path by existing tests in
`test/discovery/DiscoveryCandidatesIndividual.ts`, which continue to pass.

Full `./quality.sh`: `7601 passed (5 steps) | 0 failed | 4 ignored`.

## Test Plan

- No new test added — this is a pure visibility reduction with no new behaviour;
  a "not exported" assertion would be a forbidden "how" test. Existing
  behavioural coverage of `buildBestOfCategoryCandidate` verifies the helper's
  logic through the public API.
- Ran the full quality gate (`./quality.sh`) — lint, format, type-check, and all
  tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)