### PR TITLE
dead-code: make DEGRADED_MAX_NEURONS_FACTOR module-private (Issue #3317)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3317.md
+++ b/docs/archive/pr-summaries/pr-summary-3317.md
@@ -1,0 +1,46 @@
+# dead-code: make `DEGRADED_MAX_NEURONS_FACTOR` module-private
+
+## Summary
+
+The exported constant `DEGRADED_MAX_NEURONS_FACTOR` in
+`src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` was
+read **only** within its own module (the quarter focus-breadth reduction inside
+`computeDegradedAnalysisKnobs`). A word-boundary search across every `.ts` file
+found no importer or re-export anywhere in the repo, so the `export` keyword
+added public surface with no consumer.
+
+This PR drops the `export` keyword, keeping the constant module-private. Its
+single internal read is unchanged, so behaviour is identical — only dead public
+surface is removed. `Closes #3317`.
+
+## Evidence
+
+Backend/CLI change with no web interface to screenshot. Verified via the test
+suite and quality gate:
+
+- `deno test test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` — 7
+  passed / 0 failed.
+- `./quality.sh --lint-only` and `./quality.sh --check-only` — clean
+  (formatting, lint, bash syntax, and full-tree `deno check` all pass,
+  confirming no broken imports anywhere).
+
+```mermaid
+flowchart LR
+    A["DEGRADED_MAX_NEURONS_FACTOR<br/>(was exported)"] -->|only reader| B["computeDegradedAnalysisKnobs()"]
+    B -->|public API| C["consumers / tests"]
+    A -. "no external importer" .-x C
+```
+
+The constant feeds only the public function; consumers reach its effect through
+`computeDegradedAnalysisKnobs`, never the constant directly — so it is safe to
+keep private.
+
+## Test Plan
+
+- Added `test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts::`
+  `"computeDegradedAnalysisKnobs: applies the quarter focus-breadth factor observably"`
+  — pins the 0.25 factor through the public API (`discoveryMaxNeurons: 100` →
+  `ceil(100 * 0.25) = 25`), guarding the now-private constant's value observably
+  rather than by importing it.
+- Existing tests in the same file (quarter reduction, chunk bounding, floors,
+  non-finite fallback) continue to pass — none imported the removed export.

--- a/src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
@@ -59,8 +59,10 @@ export const MIN_DEGRADED_MAX_NEURONS = 1;
 /**
  * Fraction of the current focus breadth kept when degrading. A quarter keeps a
  * meaningful (but much smaller) working set so candidates can still be found.
+ *
+ * Module-private: read only within this module (Issue #3317).
  */
-export const DEGRADED_MAX_NEURONS_FACTOR = 0.25;
+const DEGRADED_MAX_NEURONS_FACTOR = 0.25;
 
 /**
  * Chunk size the degraded analysis bounds each Rust FFI call to. Small enough to

--- a/test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
@@ -26,6 +26,18 @@ Deno.test("computeDegradedAnalysisKnobs: reduces focus breadth to a quarter and 
   assert(decision.reason.includes("chunkSize 32->4"));
 });
 
+Deno.test("computeDegradedAnalysisKnobs: applies the quarter focus-breadth factor observably", () => {
+  // Pins the quarter (0.25) reduction through the public API so the
+  // module-private DEGRADED_MAX_NEURONS_FACTOR value stays guarded even though
+  // the constant is no longer exported (Issue #3317).
+  const decision = computeDegradedAnalysisKnobs({
+    discoveryMaxNeurons: 100,
+    analysisChunkSize: 8,
+  });
+  assertEquals(decision.knobs.discoveryMaxNeurons, 25); // ceil(100 * 0.25)
+  assert(decision.reason.includes("maxNeurons 100->25"));
+});
+
 Deno.test("computeDegradedAnalysisKnobs: an unbounded chunk size is bounded to the degraded chunk", () => {
   const decision = computeDegradedAnalysisKnobs({
     discoveryMaxNeurons: 12,


### PR DESCRIPTION
# dead-code: make `DEGRADED_MAX_NEURONS_FACTOR` module-private

## Summary

The exported constant `DEGRADED_MAX_NEURONS_FACTOR` in
`src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` was
read **only** within its own module (the quarter focus-breadth reduction inside
`computeDegradedAnalysisKnobs`). A word-boundary search across every `.ts` file
found no importer or re-export anywhere in the repo, so the `export` keyword
added public surface with no consumer.

This PR drops the `export` keyword, keeping the constant module-private. Its
single internal read is unchanged, so behaviour is identical — only dead public
surface is removed. `Closes #3317`.

## Evidence

Backend/CLI change with no web interface to screenshot. Verified via the test
suite and quality gate:

- `deno test test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` — 7
  passed / 0 failed.
- `./quality.sh --lint-only` and `./quality.sh --check-only` — clean
  (formatting, lint, bash syntax, and full-tree `deno check` all pass,
  confirming no broken imports anywhere).

```mermaid
flowchart LR
    A["DEGRADED_MAX_NEURONS_FACTOR<br/>(was exported)"] -->|only reader| B["computeDegradedAnalysisKnobs()"]
    B -->|public API| C["consumers / tests"]
    A -. "no external importer" .-x C
```

The constant feeds only the public function; consumers reach its effect through
`computeDegradedAnalysisKnobs`, never the constant directly — so it is safe to
keep private.

## Test Plan

- Added `test/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts::`
  `"computeDegradedAnalysisKnobs: applies the quarter focus-breadth factor observably"`
  — pins the 0.25 factor through the public API (`discoveryMaxNeurons: 100` →
  `ceil(100 * 0.25) = 25`), guarding the now-private constant's value observably
  rather than by importing it.
- Existing tests in the same file (quarter reduction, chunk bounding, floors,
  non-finite fallback) continue to pass — none imported the removed export.



## Milestone
This PR is part of the **Dead code** milestone and targets the `milestone/dead-code` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrfwnq6f-b3ba05`<!-- vibe-worker-issue-3317 -->