### PR TITLE
Fail loudly when a JSR release has no provenance (Issue #3334)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,16 @@ jobs:
         if: steps.needs_publish.outputs.publish == 'true'
         run: deno run --allow-read=deno.json --allow-net=jsr.io scripts/verify_provenance.ts
 
+      # Issue #3334 (parent #3332): fail LOUDLY when a release publishes with no
+      # Sigstore provenance. v5.8.1 published with rekorLogId null on JSR while
+      # CI stayed green. This guardrail polls the just-published version's meta
+      # endpoint and exits non-zero if rekorLogId is null/absent, so a
+      # no-provenance release blocks the workflow instead of passing quietly.
+      # Runs only when a publish actually occurred (skipped otherwise).
+      - name: Verify JSR provenance was recorded
+        if: steps.needs_publish.outputs.publish == 'true'
+        run: ./scripts/verify_jsr_provenance.sh
+
       # Issue #3008 (SCR-SBOM): emit a machine-readable Software Bill of
       # Materials for the published version. Deno has no first-class SBOM
       # emitter, so generate a CycloneDX document over the committed deno.lock

--- a/docs/archive/pr-summaries/pr-summary-3334.md
+++ b/docs/archive/pr-summaries/pr-summary-3334.md
@@ -1,0 +1,62 @@
+# Fail loudly when a JSR release has no provenance (Issue #3334)
+
+## Summary
+
+The publish pipeline silently succeeded while producing **no** provenance
+attestation for v5.8.1 (`rekorLogId` null on JSR). Parent #3332 requires this
+failure mode to be **loud, not silent**: a release that publishes without
+provenance must fail the CI job, not pass quietly.
+
+This adds a post-publish guardrail — independent of the root-cause fix — that
+protects against any future attestation regression regardless of cause:
+
+- **`scripts/verify_jsr_provenance.sh`** — polls
+  `https://jsr.io/<name>/<version>_meta.json` for the just-published version and
+  exits non-zero when `rekorLogId` is null/absent, emitting an actionable error
+  naming the version and the missing attestation. It reuses the
+  `jq -r .name/.version deno.json` extraction pattern already in the workflow,
+  and applies a bounded retry/poll (tunable via `VERIFY_JSR_MAX_ATTEMPTS` /
+  `VERIFY_JSR_RETRY_DELAY`) to absorb JSR eventual consistency without becoming
+  flaky — it still ultimately fails if provenance never appears. Per the
+  fail-loud principle, a fetch failure is never masked as a valid empty result.
+- **`.github/workflows/publish.yml`** — a new "Verify JSR provenance was
+  recorded" step runs `./scripts/verify_jsr_provenance.sh`, gated on
+  `steps.needs_publish.outputs.publish == 'true'` so it is skipped on runs where
+  nothing was published and does not weaken the existing concurrency / version
+  gate (#2842, #2904).
+
+CI/publish-pipeline only — no runtime code changes.
+
+Closes #3334.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified by driving the real
+script against local meta fixtures and by parsing the committed workflow YAML
+(see Test Plan). All new tests pass; `./quality.sh --lint-only` is clean
+(format, lint, bash syntax including the new script).
+
+```mermaid
+flowchart TD
+    A[Determine whether the version needs publishing] -->|publish == 'true'| B[Publish to JSR]
+    A -->|publish == 'false'| Z[Skip — already on JSR]
+    B --> C{Verify JSR provenance was recorded}
+    C -->|poll _meta.json| D{rekorLogId non-null?}
+    D -->|yes| E[✅ Step passes → continue to SBOM]
+    D -->|null/absent after retries| F[❌ Fail the job — loud, not silent]
+```
+
+## Test Plan
+
+- `test/scripts/VerifyJsrProvenance.ts` — drives the script end-to-end:
+  - passes when `rekorLogId` is a non-null value,
+  - fails loudly (exit 1, actionable message naming the version) when
+    `rekorLogId` is explicitly `null`, when it is absent, and when the meta
+    document cannot be fetched,
+  - `--help` and unknown-option handling.
+- `test/ci/PublishProvenanceGate.ts` — parses `publish.yml` and asserts the
+  verification step is present and gated on
+  `steps.needs_publish.outputs.publish == 'true'`, guarding against the gate
+  itself being deleted or its `if:` guard broken.
+- `test/scripts/ShellcheckLint.ts` (existing) — the new script passes
+  `shellcheck --severity=warning`.

--- a/scripts/verify_jsr_provenance.sh
+++ b/scripts/verify_jsr_provenance.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Verify that a just-published JSR release carries Sigstore provenance.
+#
+# Issue #3334 (parent #3332): the publish pipeline silently succeeded while
+# producing NO provenance attestation for v5.8.1 (rekorLogId null on JSR). A
+# release that publishes without provenance must fail LOUDLY (non-zero exit),
+# not pass quietly. This script is the guardrail: it polls the JSR version
+# meta endpoint and fails the job when rekorLogId is null/absent.
+#
+# Usage:
+#   scripts/verify_jsr_provenance.sh                 # read name/version from deno.json
+#   scripts/verify_jsr_provenance.sh --name @scope/pkg --version 1.2.3
+#   scripts/verify_jsr_provenance.sh --meta-file fixture.json   # local meta (tests)
+#   scripts/verify_jsr_provenance.sh --help
+#
+# JSR is eventually consistent, so the check retries a bounded number of times
+# before giving up. Tuning knobs (used by tests to stay fast):
+#   VERIFY_JSR_MAX_ATTEMPTS   attempts before failing (default 5)
+#   VERIFY_JSR_RETRY_DELAY    seconds between attempts (default 6)
+#
+# Exit codes:
+#   0  provenance recorded (non-null rekorLogId)
+#   1  no provenance after all attempts, or a usage/lookup error
+
+set -Eeuo pipefail
+
+MAX_ATTEMPTS="${VERIFY_JSR_MAX_ATTEMPTS:-5}"
+RETRY_DELAY="${VERIFY_JSR_RETRY_DELAY:-6}"
+
+NAME=""
+VERSION=""
+META_FILE=""
+
+show_help() {
+  cat <<'HELP'
+Usage: scripts/verify_jsr_provenance.sh [OPTIONS]
+
+Fail loudly when a published JSR version has no Sigstore provenance
+(rekorLogId is null/absent). Reuses the name/version extraction pattern
+from .github/workflows/publish.yml.
+
+Options:
+  --name NAME         Package name (default: jq -r .name deno.json)
+  --version VERSION   Package version (default: jq -r .version deno.json)
+  --meta-file FILE    Read meta JSON from a local file instead of JSR
+                      (bypasses the network; used by tests)
+  --help              Show this help and exit
+
+Environment:
+  VERIFY_JSR_MAX_ATTEMPTS   Retry attempts before failing (default 5)
+  VERIFY_JSR_RETRY_DELAY    Seconds between attempts (default 6)
+
+Exit codes:
+  0  provenance recorded (non-null rekorLogId)
+  1  no provenance after all attempts, or a usage/lookup error
+HELP
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name)
+      NAME="${2:-}"
+      shift 2
+      ;;
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --meta-file)
+      META_FILE="${2:-}"
+      shift 2
+      ;;
+    --help | -h)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Run 'scripts/verify_jsr_provenance.sh --help' for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Fall back to deno.json for anything not supplied explicitly. Mirror the
+# `jq -r .name/.version deno.json` pattern already used in publish.yml.
+if [ -z "$NAME" ]; then
+  NAME=$(jq -r .name deno.json)
+fi
+if [ -z "$VERSION" ]; then
+  VERSION=$(jq -r .version deno.json)
+fi
+
+if [ -z "$NAME" ] || [ "$NAME" = "null" ] || [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+  echo "❌ Could not determine package name/version for provenance check." >&2
+  exit 1
+fi
+
+META_URL="https://jsr.io/${NAME}/${VERSION}_meta.json"
+
+# Fetch the meta document into $1. Returns non-zero when the document could
+# not be retrieved so the caller can retry. Never masks a fetch failure as a
+# valid (empty) document.
+fetch_meta() {
+  local out="$1"
+  if [ -n "$META_FILE" ]; then
+    [ -f "$META_FILE" ] || return 1
+    cat "$META_FILE" >"$out"
+    return 0
+  fi
+  curl -sf "$META_URL" -o "$out"
+}
+
+echo "🔎 Verifying JSR provenance for ${NAME}@${VERSION}"
+[ -n "$META_FILE" ] && echo "   (meta source: ${META_FILE})"
+
+tmp_meta="$(mktemp)"
+trap 'rm -f "$tmp_meta"' EXIT
+
+attempt=1
+while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+  if fetch_meta "$tmp_meta"; then
+    # rekorLogId is the Sigstore transparency-log entry recorded when JSR
+    # attests provenance. Absent/null means no attestation was produced.
+    rekor=$(jq -r '.rekorLogId // "null"' "$tmp_meta" 2>/dev/null || echo "null")
+    if [ -n "$rekor" ] && [ "$rekor" != "null" ]; then
+      echo "✅ Provenance recorded for ${NAME}@${VERSION} (rekorLogId=${rekor})."
+      exit 0
+    fi
+    echo "… attempt ${attempt}/${MAX_ATTEMPTS}: rekorLogId still null/absent for ${NAME}@${VERSION}." >&2
+  else
+    echo "… attempt ${attempt}/${MAX_ATTEMPTS}: could not fetch ${META_URL} (JSR eventual consistency?)." >&2
+  fi
+
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    sleep "$RETRY_DELAY"
+  fi
+  attempt=$((attempt + 1))
+done
+
+echo "❌ No Sigstore provenance for ${NAME}@${VERSION}: rekorLogId is null/absent" >&2
+echo "   after ${MAX_ATTEMPTS} attempt(s) against ${META_URL}." >&2
+echo "   A release must publish WITH provenance (Issue #3334). Failing the job." >&2
+exit 1

--- a/test/ci/PublishProvenanceGate.ts
+++ b/test/ci/PublishProvenanceGate.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue #3334 (parent #3332) — the publish pipeline silently succeeded while
+ * producing NO provenance attestation for v5.8.1 (rekorLogId null on JSR). A
+ * release that publishes without provenance must fail LOUDLY, not pass quietly.
+ *
+ * `publish.yml` now runs a post-publish verification step that polls the JSR
+ * version meta endpoint and fails the job when rekorLogId is null/absent.
+ *
+ * These tests parse the committed workflow YAML and assert on the resulting
+ * configuration — they guard against the gate itself regressing (step deleted,
+ * or its `if:` guard broken so it never runs), which is exactly the failure
+ * surface the issue calls out. They are "what" tests over CI config: there is
+ * no runtime behaviour to exercise, only the shipped workflow.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const PUBLISH_WORKFLOW = join(REPO_ROOT, ".github/workflows/publish.yml");
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  if?: string;
+}
+
+interface Job {
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(PUBLISH_WORKFLOW);
+  return parse(text) as Workflow;
+}
+
+function allSteps(wf: Workflow): Step[] {
+  const steps: Step[] = [];
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const step of job.steps ?? []) steps.push(step);
+  }
+  return steps;
+}
+
+function provenanceStep(wf: Workflow): Step | undefined {
+  return allSteps(wf).find(
+    (s) => typeof s.run === "string" && /verify_jsr_provenance\.sh/.test(s.run),
+  );
+}
+
+Deno.test("publish.yml runs the JSR provenance verification step (Issue #3334)", async () => {
+  const wf = await readWorkflow();
+  const step = provenanceStep(wf);
+  assert(
+    step !== undefined,
+    "publish.yml must run scripts/verify_jsr_provenance.sh after publishing so " +
+      "a release with no Sigstore provenance (rekorLogId null) fails the job",
+  );
+});
+
+Deno.test("publish.yml only verifies provenance when a publish ran (Issue #3334)", async () => {
+  const wf = await readWorkflow();
+  const step = provenanceStep(wf);
+  assert(step !== undefined, "provenance verification step missing");
+
+  // Every push to Develop runs this workflow, but a publish only happens on a
+  // release commit. The check must be gated on the same needs_publish signal
+  // that gates the JSR publish step — otherwise it runs (and fails) on pushes
+  // where nothing was published.
+  const cond = step!.if ?? "";
+  assert(
+    /needs_publish\.outputs\.publish\s*==\s*'true'/.test(cond),
+    "the provenance verification step must be gated on " +
+      "steps.needs_publish.outputs.publish == 'true' so it only runs for a " +
+      `new release version, got if: '${cond}'`,
+  );
+});

--- a/test/scripts/VerifyJsrProvenance.ts
+++ b/test/scripts/VerifyJsrProvenance.ts
@@ -1,0 +1,136 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+
+/**
+ * Tests for scripts/verify_jsr_provenance.sh.
+ *
+ * Issue #3334 (parent #3332) — the publish pipeline must fail LOUDLY when a
+ * JSR release carries no Sigstore provenance (rekorLogId null/absent), rather
+ * than succeeding silently as it did for v5.8.1.
+ *
+ * The tests drive the script's real behaviour against local meta fixtures
+ * (via --meta-file, bypassing the network) and assert on exit code and
+ * message — never grepping the source.
+ */
+
+const SCRIPT = "scripts/verify_jsr_provenance.sh";
+
+async function runScript(
+  args: string[] = [],
+  env: Record<string, string> = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const cmd = new Deno.Command("bash", {
+    args: [SCRIPT, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    // Keep retries fast and bounded for the null path.
+    env: { VERIFY_JSR_MAX_ATTEMPTS: "1", VERIFY_JSR_RETRY_DELAY: "0", ...env },
+  });
+  const { code, stdout, stderr } = await cmd.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+async function withMetaFile(
+  contents: string,
+  fn: (path: string) => Promise<void>,
+): Promise<void> {
+  const path = await Deno.makeTempFile({ suffix: ".json" });
+  try {
+    await Deno.writeTextFile(path, contents);
+    await fn(path);
+  } finally {
+    await Deno.remove(path).catch(() => {});
+  }
+}
+
+Deno.test("verify_jsr_provenance.sh exists", async () => {
+  const info = await Deno.stat(SCRIPT);
+  assert(info.isFile, `${SCRIPT} should be a file`);
+});
+
+Deno.test("verify_jsr_provenance.sh --help prints usage and exits 0", async () => {
+  const { code, stdout } = await runScript(["--help"]);
+  assertEquals(code, 0, "help must exit cleanly");
+  assertStringIncludes(stdout, "Usage: scripts/verify_jsr_provenance.sh");
+  assertStringIncludes(stdout, "--meta-file");
+  assertStringIncludes(stdout, "rekorLogId");
+});
+
+Deno.test("verify_jsr_provenance.sh rejects unknown options with exit 1", async () => {
+  const { code, stderr } = await runScript(["--nope"]);
+  assertEquals(code, 1, "unknown option must exit non-zero");
+  assertStringIncludes(stderr, "Unknown option: --nope");
+});
+
+Deno.test("passes when rekorLogId is a non-null value", async () => {
+  await withMetaFile(
+    JSON.stringify({ rekorLogId: "108e9186e8c5677a" }),
+    async (path) => {
+      const { code, stdout } = await runScript([
+        "--name",
+        "@stsoftware/neat-ai",
+        "--version",
+        "5.9.0",
+        "--meta-file",
+        path,
+      ]);
+      assertEquals(code, 0, "non-null rekorLogId must pass");
+      assertStringIncludes(stdout, "Provenance recorded");
+      assertStringIncludes(stdout, "5.9.0");
+    },
+  );
+});
+
+Deno.test("fails loudly when rekorLogId is explicitly null", async () => {
+  await withMetaFile(
+    JSON.stringify({ rekorLogId: null }),
+    async (path) => {
+      const { code, stderr } = await runScript([
+        "--name",
+        "@stsoftware/neat-ai",
+        "--version",
+        "5.8.1",
+        "--meta-file",
+        path,
+      ]);
+      assertEquals(code, 1, "null rekorLogId must fail the job");
+      assertStringIncludes(stderr, "No Sigstore provenance");
+      assertStringIncludes(stderr, "5.8.1");
+    },
+  );
+});
+
+Deno.test("fails loudly when rekorLogId is absent", async () => {
+  await withMetaFile(
+    JSON.stringify({ version: "5.8.1", moduleGraph2: {} }),
+    async (path) => {
+      const { code, stderr } = await runScript([
+        "--name",
+        "@stsoftware/neat-ai",
+        "--version",
+        "5.8.1",
+        "--meta-file",
+        path,
+      ]);
+      assertEquals(code, 1, "absent rekorLogId must fail the job");
+      assertStringIncludes(stderr, "No Sigstore provenance");
+      assertStringIncludes(stderr, "@stsoftware/neat-ai");
+    },
+  );
+});
+
+Deno.test("fails loudly when the meta document cannot be fetched", async () => {
+  const { code, stderr } = await runScript([
+    "--name",
+    "@stsoftware/neat-ai",
+    "--version",
+    "5.8.1",
+    "--meta-file",
+    "/nonexistent/does-not-exist.json",
+  ]);
+  assertEquals(code, 1, "unreachable meta must fail loudly");
+  assertStringIncludes(stderr, "No Sigstore provenance");
+});


### PR DESCRIPTION
# Fail loudly when a JSR release has no provenance (Issue #3334)

## Summary

The publish pipeline silently succeeded while producing **no** provenance
attestation for v5.8.1 (`rekorLogId` null on JSR). Parent #3332 requires this
failure mode to be **loud, not silent**: a release that publishes without
provenance must fail the CI job, not pass quietly.

This adds a post-publish guardrail — independent of the root-cause fix — that
protects against any future attestation regression regardless of cause:

- **`scripts/verify_jsr_provenance.sh`** — polls
  `https://jsr.io/<name>/<version>_meta.json` for the just-published version and
  exits non-zero when `rekorLogId` is null/absent, emitting an actionable error
  naming the version and the missing attestation. It reuses the
  `jq -r .name/.version deno.json` extraction pattern already in the workflow,
  and applies a bounded retry/poll (tunable via `VERIFY_JSR_MAX_ATTEMPTS` /
  `VERIFY_JSR_RETRY_DELAY`) to absorb JSR eventual consistency without becoming
  flaky — it still ultimately fails if provenance never appears. Per the
  fail-loud principle, a fetch failure is never masked as a valid empty result.
- **`.github/workflows/publish.yml`** — a new "Verify JSR provenance was
  recorded" step runs `./scripts/verify_jsr_provenance.sh`, gated on
  `steps.needs_publish.outputs.publish == 'true'` so it is skipped on runs where
  nothing was published and does not weaken the existing concurrency / version
  gate (#2842, #2904).

CI/publish-pipeline only — no runtime code changes.

Closes #3334.

## Evidence

Backend/CI change — no web interface to screenshot. Verified by driving the real
script against local meta fixtures and by parsing the committed workflow YAML
(see Test Plan). All new tests pass; `./quality.sh --lint-only` is clean
(format, lint, bash syntax including the new script).

```mermaid
flowchart TD
    A[Determine whether the version needs publishing] -->|publish == 'true'| B[Publish to JSR]
    A -->|publish == 'false'| Z[Skip — already on JSR]
    B --> C{Verify JSR provenance was recorded}
    C -->|poll _meta.json| D{rekorLogId non-null?}
    D -->|yes| E[✅ Step passes → continue to SBOM]
    D -->|null/absent after retries| F[❌ Fail the job — loud, not silent]
```

## Test Plan

- `test/scripts/VerifyJsrProvenance.ts` — drives the script end-to-end:
  - passes when `rekorLogId` is a non-null value,
  - fails loudly (exit 1, actionable message naming the version) when
    `rekorLogId` is explicitly `null`, when it is absent, and when the meta
    document cannot be fetched,
  - `--help` and unknown-option handling.
- `test/ci/PublishProvenanceGate.ts` — parses `publish.yml` and asserts the
  verification step is present and gated on
  `steps.needs_publish.outputs.publish == 'true'`, guarding against the gate
  itself being deleted or its `if:` guard broken.
- `test/scripts/ShellcheckLint.ts` (existing) — the new script passes
  `shellcheck --severity=warning`.



## Milestone
This PR is part of the **#3332 Fix JSR provenance for @stsoftware/neat-ai; best-effort Node runtime compat** milestone and targets the `milestone/3332-fix-jsr-provenance-for-stsoftware-neat-ai-bes` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrj2hk5y-4e2be3`<!-- vibe-worker-issue-3334 -->