### PR TITLE
Fix silent JSR provenance failure: publish with deno publish + verify gate (Issue #3333)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,9 +70,27 @@ jobs:
       # For runs triggered by bots (e.g. stservice): scope admin must disable
       # "Only allow publishing when triggered by a scope member" in scope settings.
       # See https://jsr.io/docs/scopes#github-actions-publishing-security
+      #
+      # Issue #3333: publish with the job's installed Deno (`deno publish`),
+      # NOT `npx jsr publish`. The npm shim downloads its own pinned Deno binary
+      # and delegates to `deno publish`, bypassing setup-deno v2.x above — that
+      # indirection silently dropped Sigstore provenance for v5.8.0/v5.8.1
+      # (rekorLogId: null). `deno publish` enables provenance by default on
+      # GitHub Actions when `id-token: write` is granted, so the transparency-log
+      # entry is recorded. The verify step below fails the run if it is not.
       - name: Publish to JSR
         if: steps.needs_publish.outputs.publish == 'true'
-        run: npx jsr publish
+        run: deno publish
+
+      # Issue #3333: the pre-fix failure was silent — JSR accepted the publish
+      # and nothing inspected the attestation. Poll the version meta endpoint and
+      # fail the run when `rekorLogId` is null/missing, so any regression (CLI
+      # swap, OIDC env loss, --no-provenance) turns the publish run red on the
+      # same run that produced the unattested version (never fail silently,
+      # Issue #3234).
+      - name: Verify JSR provenance attestation
+        if: steps.needs_publish.outputs.publish == 'true'
+        run: deno run --allow-read=deno.json --allow-net=jsr.io scripts/verify_provenance.ts
 
       # Issue #3008 (SCR-SBOM): emit a machine-readable Software Bill of
       # Materials for the published version. Deno has no first-class SBOM

--- a/docs/archive/pr-summaries/pr-summary-3333.md
+++ b/docs/archive/pr-summaries/pr-summary-3333.md
@@ -1,0 +1,96 @@
+# Fix silent JSR provenance failure — next release carries a Sigstore attestation
+
+## Summary
+
+`@stsoftware/neat-ai` v5.8.0 and v5.8.1 were published to JSR with OIDC
+(`id-token: write`) granted, yet both recorded **no Sigstore provenance**
+(`rekorLogId: null`). The publish pipeline was silently failing to attest.
+
+**Root cause.** `.github/workflows/publish.yml` published with `npx jsr publish`.
+The `jsr` npm CLI is a thin shim: it downloads its **own pinned Deno binary**
+into `.download/` and delegates to `deno publish`, completely bypassing the
+Deno 2.x that `setup-deno` already installs in the job. Provenance behaviour is
+therefore governed by that pinned, indirect binary — which produced no
+transparency-log entry for v5.8.0/v5.8.1. (Verified against the jsr-npm source:
+`getOrDownloadBinPath` → `getDenoVersionToDownload` returns a hard-pinned
+version, then `exec(binPath, ["publish", ...])`.)
+
+**Fix.** Publish with the job's installed Deno directly (`deno publish`).
+`deno publish` **enables Sigstore provenance by default on GitHub Actions** when
+`id-token: write` is granted (opt-out is `--no-provenance`), so the next release
+records a non-null `rekorLogId`. The tokenless-OIDC posture and the #2904
+version-gate are unchanged; permissions stay `id-token: write` + `contents:
+read` (least privilege).
+
+**Detection (never fail silently — Issue #3234).** The original failure was
+silent by definition, so a CI gate is added: a new `verify-provenance` step runs
+`scripts/verify_provenance.ts` immediately after publishing. It polls
+`https://jsr.io/@stsoftware/neat-ai/<version>_meta.json` (short retry loop for
+meta-endpoint propagation) and **fails the job** when `rekorLogId` is null or
+missing. Any future regression (CLI swap, OIDC env loss, `--no-provenance`)
+turns the publish run red on the same run that produced the unattested version.
+
+Closes #3333.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+The new script fails loud against the current (unattested) real version:
+
+```
+$ deno run --allow-net=jsr.io --allow-read scripts/verify_provenance.ts   # against 5.8.1
+❌ JSR provenance verification failed: @stsoftware/neat-ai@5.8.1 has no JSR
+provenance attestation after 10 attempt(s): rekorLogId is null (no Sigstore
+attestation). ...
+```
+
+Acceptance is confirmed post-merge on the next release: the version's
+`_meta.json` shows a non-null `rekorLogId` and the JSR score page shows
+"Has provenance" ✓. A ✗ there with a green publish run would mean the CI gate
+itself has regressed.
+
+### Publish flow — before vs after
+
+```mermaid
+flowchart TB
+    subgraph before["Before (silent failure)"]
+        A1[setup-deno v2.x installed] --> A2["npx jsr publish"]
+        A2 --> A3[jsr npm shim downloads<br/>its own pinned Deno]
+        A3 --> A4[deno publish via shim]
+        A4 --> A5[JSR accepts publish]
+        A5 --> A6[["rekorLogId: null<br/>nothing checks — green + broken"]]
+    end
+    subgraph after["After (attested + gated)"]
+        B1[setup-deno v2.x installed] --> B2["deno publish<br/>(provenance default-on in GHA)"]
+        B2 --> B3[JSR records Sigstore<br/>transparency-log entry]
+        B3 --> B4["verify_provenance.ts<br/>polls _meta.json"]
+        B4 -->|rekorLogId set| B5[["✅ job green"]]
+        B4 -->|null / missing| B6[["❌ job red — fail loud"]]
+    end
+```
+
+## Test Plan
+
+- `test/ci/VerifyProvenance.ts` (new) — unit tests calling the real
+  `hasProvenance`, `metaUrl`, and `verifyProvenance` with an injected
+  fetch/sleep (no network):
+  - attested `rekorLogId` returns the id; null/missing/empty/whitespace and
+    non-object inputs are "no provenance";
+  - `verifyProvenance` throws (naming the version) when `rekorLogId` is null —
+    reproduces the #3333 bug;
+  - retries until provenance propagates, retries through a transient non-200,
+    and fails loud after exhausting retries on network errors;
+  - `metaUrl` builds the JSR endpoint and honours a custom base URL.
+- `test/ci/ProvenancePublishWorkflow.ts` (new) — parses the committed
+  `publish.yml` and asserts it publishes via `deno publish` (not `npx jsr
+  publish`), does not pass `--no-provenance`, runs the `verify_provenance.ts`
+  gate (guarded on the version-publish output), and keeps
+  `id-token: write` + `contents: read`.
+- `test/scripts/PublishBranchGuard.ts` (modified) — the publish-step detector
+  matched only `jsr publish`; broadened to `deno|jsr publish` so the #2904
+  branch-guard assertions stay valid after the command switch. **No assertion
+  was weakened or removed** — only the step-locator regex changed.
+
+All `test/ci/*` and `test/scripts/*` suites pass (255 tests, 0 failed);
+`deno fmt`, `deno lint`, and `deno check` are clean on the new files.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -10,6 +10,9 @@
   ],
   "words": [
     "AJSON",
+    "Sigstore",
+    "Rekor",
+    "automatable",
     "Abramowitz",
     "Accum",
     "Aggr",

--- a/scripts/verify_provenance.ts
+++ b/scripts/verify_provenance.ts
@@ -1,0 +1,186 @@
+/**
+ * Issue #3333 — verify a freshly published JSR version carries a Sigstore
+ * provenance attestation (a non-null `rekorLogId`).
+ *
+ * ## Why this exists
+ *
+ * `@stsoftware/neat-ai` v5.8.0 and v5.8.1 were published to JSR from
+ * `.github/workflows/publish.yml` with OIDC (`id-token: write`) granted, yet
+ * their `<version>_meta.json` recorded `rekorLogId: null` — JSR held no
+ * transparency-log entry. The publish step ran `npx jsr publish`, whose npm
+ * shim downloads its *own* pinned Deno binary and delegates to `deno publish`,
+ * bypassing the job's `setup-deno` v2.x. That indirection is where attestation
+ * was silently lost. The fix publishes with the job's installed Deno directly
+ * (`deno publish`), which enables Sigstore provenance by default on GitHub
+ * Actions.
+ *
+ * ## Why a gate, not just a fix
+ *
+ * The original failure mode was *silent* (Issue #3234): JSR accepts an
+ * unattested publish and nothing downstream notices. This module polls the JSR
+ * version meta endpoint after publishing and exits non-zero when `rekorLogId`
+ * is null or missing, so any future regression (CLI swap, OIDC env loss,
+ * `--no-provenance` creeping in) turns the publish run red on the same run that
+ * produced the unattested version — it fails loud rather than green-and-broken.
+ *
+ * The functions here are pure and take an injectable `fetch`/`sleep` so the
+ * logic is unit-tested in `test/ci/VerifyProvenance.ts`; the real Sigstore
+ * attestation itself can only occur in the GitHub Actions OIDC context, so the
+ * in-workflow post-publish check is the only automatable detection surface.
+ */
+
+/** Shape of the fields we read from `<name>/<version>_meta.json`. */
+export interface VersionMeta {
+  /** Sigstore/Rekor transparency-log entry id; null/absent means no provenance. */
+  rekorLogId?: string | null;
+}
+
+export interface VerifyOptions {
+  /** Injectable fetch (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Registry base URL (defaults to https://jsr.io). */
+  baseUrl?: string;
+  /** Total attempts before giving up (default 10). */
+  retries?: number;
+  /** Delay between attempts in milliseconds (default 6000). */
+  delayMs?: number;
+  /** Injectable sleep (defaults to a real timer); tests pass a no-op. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable logger (defaults to console.error). */
+  log?: (msg: string) => void;
+}
+
+/**
+ * True only when `meta` is an object carrying a non-empty string `rekorLogId`.
+ * Null, undefined, empty string, or a non-string are all "no provenance".
+ */
+export function hasProvenance(meta: unknown): boolean {
+  if (meta === null || typeof meta !== "object") return false;
+  const id = (meta as VersionMeta).rekorLogId;
+  return typeof id === "string" && id.trim().length > 0;
+}
+
+/** Build the JSR version meta URL for a package name and version. */
+export function metaUrl(
+  name: string,
+  version: string,
+  baseUrl = "https://jsr.io",
+): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  return `${base}/${name}/${version}_meta.json`;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll the JSR meta endpoint until the version reports a non-null `rekorLogId`,
+ * returning that id. Throws a descriptive Error if provenance is still absent
+ * after all retries, or if the endpoint never returns a usable response — the
+ * absence of a positive attestation is treated as failure, never as success
+ * (Issue #3234).
+ */
+export async function verifyProvenance(
+  name: string,
+  version: string,
+  options: VerifyOptions = {},
+): Promise<string> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const baseUrl = options.baseUrl ?? "https://jsr.io";
+  const retries = options.retries ?? 10;
+  const delayMs = options.delayMs ?? 6000;
+  const sleep = options.sleep ?? defaultSleep;
+  const log = options.log ?? ((m: string) => console.error(m));
+
+  const url = metaUrl(name, version, baseUrl);
+
+  // One poll attempt: resolve to the rekorLogId on success, or a human-readable
+  // reason string on failure. Kept as a helper so the loop awaits exactly once.
+  const attemptOnce = async (): Promise<
+    { id: string } | { reason: string }
+  > => {
+    try {
+      const res = await fetchImpl(url);
+      if (!res.ok) {
+        // Consume the body so the connection can be reused/closed cleanly.
+        await res.body?.cancel();
+        return { reason: `HTTP ${res.status} from ${url}` };
+      }
+      const meta = (await res.json()) as VersionMeta;
+      if (hasProvenance(meta)) return { id: meta.rekorLogId as string };
+      return {
+        reason: `rekorLogId is ${
+          JSON.stringify(meta.rekorLogId ?? null)
+        } (no Sigstore attestation)`,
+      };
+    } catch (error: unknown) {
+      return { reason: error instanceof Error ? error.message : String(error) };
+    }
+  };
+
+  let lastReason = "no attempt was made";
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    // Sequential polling: each attempt must observe the previous result.
+    // deno-lint-ignore no-await-in-loop -- intentional sequential poll.
+    const result = await attemptOnce();
+    if ("id" in result) {
+      log(
+        `✅ ${name}@${version} has JSR provenance (rekorLogId=${result.id}).`,
+      );
+      return result.id;
+    }
+    lastReason = result.reason;
+
+    if (attempt < retries) {
+      log(
+        `⏳ attempt ${attempt}/${retries}: ${lastReason}; ` +
+          `retrying in ${delayMs}ms (meta endpoint may still be propagating).`,
+      );
+      // deno-lint-ignore no-await-in-loop -- intentional back-off between polls.
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error(
+    `${name}@${version} has no JSR provenance attestation after ${retries} ` +
+      `attempt(s): ${lastReason}. The publish step must run \`deno publish\` ` +
+      `on GitHub Actions with \`id-token: write\` so JSR records a Sigstore ` +
+      `transparency-log entry (Issue #3333).`,
+  );
+}
+
+interface DenoJson {
+  name?: string;
+  version?: string;
+}
+
+/** Read `name` and `version` from a deno.json(c) file. */
+export async function readPackageIdentity(
+  path = "deno.json",
+): Promise<{ name: string; version: string }> {
+  const text = await Deno.readTextFile(path);
+  const json = JSON.parse(text) as DenoJson;
+  if (!json.name || !json.version) {
+    throw new Error(
+      `${path} must define both \`name\` and \`version\`; got ` +
+        `${JSON.stringify({ name: json.name, version: json.version })}`,
+    );
+  }
+  return { name: json.name, version: json.version };
+}
+
+async function main(): Promise<void> {
+  try {
+    const { name, version } = await readPackageIdentity();
+    await verifyProvenance(name, version);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`❌ JSR provenance verification failed: ${message}`);
+    Deno.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/test/ci/ProvenancePublishWorkflow.ts
+++ b/test/ci/ProvenancePublishWorkflow.ts
@@ -1,0 +1,111 @@
+/**
+ * Issue #3333 — the release pipeline must (a) publish with the job's installed
+ * Deno so JSR records a Sigstore provenance attestation, and (b) verify that
+ * attestation on the same run so a regression fails loud instead of silently.
+ *
+ * Background: `@stsoftware/neat-ai` v5.8.0/v5.8.1 published with OIDC granted
+ * but `rekorLogId: null`. The old step ran `npx jsr publish`, whose npm shim
+ * downloads its own pinned Deno and bypasses the job's `setup-deno` v2.x,
+ * silently losing provenance. Publishing with `deno publish` directly restores
+ * it (provenance is default-on for `deno publish` on GitHub Actions).
+ *
+ * These are "what" tests: they parse the committed workflow YAML and assert on
+ * the resulting configuration, not on the exact wording of each step.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const PUBLISH_WORKFLOW = join(REPO_ROOT, ".github/workflows/publish.yml");
+
+interface Step {
+  name?: string;
+  id?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+}
+interface Job {
+  permissions?: Record<string, string>;
+  steps?: Step[];
+}
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(): Promise<Workflow> {
+  return parse(await Deno.readTextFile(PUBLISH_WORKFLOW)) as Workflow;
+}
+
+function steps(wf: Workflow): Step[] {
+  const out: Step[] = [];
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const s of job.steps ?? []) out.push(s);
+  }
+  return out;
+}
+
+Deno.test("publish.yml publishes with `deno publish`, not the npm shim (Issue #3333)", async () => {
+  const wf = await readWorkflow();
+  const all = steps(wf);
+
+  const publishStep = all.find((s) => /\bdeno\s+publish\b/.test(s.run ?? ""));
+  assert(
+    publishStep !== undefined,
+    "publish job must publish via `deno publish` so the job's installed " +
+      "Deno (setup-deno v2.x) attaches Sigstore provenance on GitHub Actions",
+  );
+
+  // The npm shim (`npx jsr publish`) downloads its own pinned Deno and bypasses
+  // setup-deno, which silently dropped provenance for v5.8.0/v5.8.1.
+  const shimStep = all.find((s) => /npx\s+jsr\s+publish/.test(s.run ?? ""));
+  assert(
+    shimStep === undefined,
+    "publish job must NOT use `npx jsr publish` — its npm shim bypasses the " +
+      "job's Deno and silently dropped JSR provenance (Issue #3333)",
+  );
+
+  // Provenance must not be explicitly disabled.
+  assert(
+    !/--no-provenance/.test(publishStep!.run ?? ""),
+    "the publish step must not pass --no-provenance",
+  );
+});
+
+Deno.test("publish.yml verifies the provenance attestation after publishing (Issue #3333)", async () => {
+  const wf = await readWorkflow();
+  const all = steps(wf);
+
+  const verifyStep = all.find((s) => /verify_provenance\.ts/.test(s.run ?? ""));
+  assert(
+    verifyStep !== undefined,
+    "publish job must run scripts/verify_provenance.ts after publishing so a " +
+      "missing Sigstore attestation fails the run instead of passing silently",
+  );
+
+  // The gate only makes sense when a publish actually happened, so it must be
+  // gated on the same needs_publish signal as the publish step.
+  const cond = verifyStep!.if ?? "";
+  assert(
+    cond.includes("steps.") && cond.includes("outputs."),
+    "the verify-provenance step must be gated on the version-publish check " +
+      `output; got: ${JSON.stringify(verifyStep!.if)}`,
+  );
+});
+
+Deno.test("publish job keeps least-privilege OIDC permissions (Issue #3333)", async () => {
+  const wf = await readWorkflow();
+  const job = (wf.jobs ?? {})["publish"];
+  assert(job !== undefined, "publish.yml must define a `publish` job");
+  const perms = job.permissions ?? {};
+  assert(
+    perms["id-token"] === "write",
+    "publish job must keep `id-token: write` (OIDC for JSR provenance)",
+  );
+  assert(
+    perms["contents"] === "read",
+    "publish job must keep `contents: read` (least privilege)",
+  );
+});

--- a/test/ci/VerifyProvenance.ts
+++ b/test/ci/VerifyProvenance.ts
@@ -1,0 +1,157 @@
+/**
+ * Issue #3333 — unit tests for `scripts/verify_provenance.ts`, the post-publish
+ * gate that fails the release run when a freshly published JSR version carries
+ * no Sigstore provenance (`rekorLogId` null or missing).
+ *
+ * These call the real functions with an injected fetch/sleep so no network is
+ * touched. The attestation itself only happens in the GitHub Actions OIDC
+ * context at publish time, so this exercises the *detection* logic — the only
+ * automatable surface — not the signing.
+ */
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  hasProvenance,
+  metaUrl,
+  verifyProvenance,
+} from "../../scripts/verify_provenance.ts";
+
+const noSleep = (_ms: number) => Promise.resolve();
+
+/** Build a Response-returning fetch from a fixed body/status. */
+function stubFetch(
+  body: unknown,
+  status = 200,
+): { fetch: typeof fetch; calls: string[] } {
+  const calls: string[] = [];
+  const fetchImpl = ((input: string | URL | Request) => {
+    calls.push(String(input));
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+  return { fetch: fetchImpl, calls };
+}
+
+Deno.test("hasProvenance: non-empty rekorLogId string means attested", () => {
+  assert(hasProvenance({ rekorLogId: "108e9186e8c5677a..." }));
+});
+
+Deno.test("hasProvenance: null / missing / empty means not attested", () => {
+  assertEquals(hasProvenance({ rekorLogId: null }), false);
+  assertEquals(hasProvenance({}), false);
+  assertEquals(hasProvenance({ rekorLogId: "" }), false);
+  assertEquals(hasProvenance({ rekorLogId: "   " }), false);
+});
+
+Deno.test("hasProvenance: non-object inputs are not attested", () => {
+  assertEquals(hasProvenance(null), false);
+  assertEquals(hasProvenance(undefined), false);
+  assertEquals(hasProvenance("108e9..."), false);
+  assertEquals(hasProvenance(42), false);
+});
+
+Deno.test("metaUrl builds the JSR version meta endpoint", () => {
+  assertEquals(
+    metaUrl("@stsoftware/neat-ai", "5.8.1"),
+    "https://jsr.io/@stsoftware/neat-ai/5.8.1_meta.json",
+  );
+});
+
+Deno.test("metaUrl honours a custom base URL without doubling slashes", () => {
+  assertEquals(
+    metaUrl("@scope/pkg", "1.0.0", "https://example.test/"),
+    "https://example.test/@scope/pkg/1.0.0_meta.json",
+  );
+});
+
+Deno.test("verifyProvenance returns the rekorLogId when attested", async () => {
+  const { fetch, calls } = stubFetch({ rekorLogId: "abc123" });
+  const id = await verifyProvenance("@scope/pkg", "1.0.0", {
+    fetchImpl: fetch,
+    log: () => {},
+  });
+  assertEquals(id, "abc123");
+  assertEquals(calls, ["https://jsr.io/@scope/pkg/1.0.0_meta.json"]);
+});
+
+Deno.test("verifyProvenance throws when rekorLogId is null (the #3333 bug)", async () => {
+  const { fetch } = stubFetch({ rekorLogId: null });
+  const err = await assertRejects(
+    () =>
+      verifyProvenance("@stsoftware/neat-ai", "5.8.1", {
+        fetchImpl: fetch,
+        retries: 3,
+        delayMs: 1,
+        sleep: noSleep,
+        log: () => {},
+      }),
+    Error,
+    "no JSR provenance attestation",
+  );
+  // Message must name the version so the red CI run is self-explanatory.
+  assert(err.message.includes("5.8.1"));
+});
+
+Deno.test("verifyProvenance retries until provenance appears (meta propagation)", async () => {
+  let attempt = 0;
+  const fetchImpl = (() => {
+    attempt++;
+    const body = attempt < 3 ? { rekorLogId: null } : { rekorLogId: "late-id" };
+    return Promise.resolve(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+  }) as typeof fetch;
+
+  const id = await verifyProvenance("@scope/pkg", "2.0.0", {
+    fetchImpl,
+    retries: 5,
+    delayMs: 1,
+    sleep: noSleep,
+    log: () => {},
+  });
+  assertEquals(id, "late-id");
+  assertEquals(attempt, 3);
+});
+
+Deno.test("verifyProvenance retries on transient non-200 then succeeds", async () => {
+  let attempt = 0;
+  const fetchImpl = (() => {
+    attempt++;
+    if (attempt === 1) {
+      return Promise.resolve(new Response("nope", { status: 404 }));
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ rekorLogId: "ok" }), { status: 200 }),
+    );
+  }) as typeof fetch;
+
+  const id = await verifyProvenance("@scope/pkg", "3.0.0", {
+    fetchImpl,
+    retries: 4,
+    delayMs: 1,
+    sleep: noSleep,
+    log: () => {},
+  });
+  assertEquals(id, "ok");
+});
+
+Deno.test("verifyProvenance fails loud after exhausting retries on errors", async () => {
+  const fetchImpl =
+    (() => Promise.reject(new Error("network down"))) as typeof fetch;
+  await assertRejects(
+    () =>
+      verifyProvenance("@scope/pkg", "4.0.0", {
+        fetchImpl,
+        retries: 2,
+        delayMs: 1,
+        sleep: noSleep,
+        log: () => {},
+      }),
+    Error,
+    "network down",
+  );
+});

--- a/test/scripts/PublishBranchGuard.ts
+++ b/test/scripts/PublishBranchGuard.ts
@@ -111,10 +111,16 @@ Deno.test("publish step is gated on a prior version-published check", async () =
   const job = publishJob(wf);
   const steps = job.steps ?? [];
 
-  const publishStep = steps.find((s) => (s.run ?? "").includes("jsr publish"));
+  // Issue #3333 switched the publish command from `npx jsr publish` to
+  // `deno publish` (native provenance). Match either CLI so this branch-guard
+  // test stays valid regardless of which publish command is in use.
+  const publishStep = steps.find((s) =>
+    /\b(?:deno|jsr)\s+publish\b/.test(s.run ?? "")
+  );
   assert(
     publishStep !== undefined,
-    "publish job must contain a step that runs `jsr publish`",
+    "publish job must contain a step that runs a JSR publish command " +
+      "(`deno publish` or `jsr publish`)",
   );
 
   const condition = publishStep.if ?? "";


### PR DESCRIPTION
# Fix silent JSR provenance failure — next release carries a Sigstore attestation

## Summary

`@stsoftware/neat-ai` v5.8.0 and v5.8.1 were published to JSR with OIDC
(`id-token: write`) granted, yet both recorded **no Sigstore provenance**
(`rekorLogId: null`). The publish pipeline was silently failing to attest.

**Root cause.** `.github/workflows/publish.yml` published with `npx jsr publish`.
The `jsr` npm CLI is a thin shim: it downloads its **own pinned Deno binary**
into `.download/` and delegates to `deno publish`, completely bypassing the
Deno 2.x that `setup-deno` already installs in the job. Provenance behaviour is
therefore governed by that pinned, indirect binary — which produced no
transparency-log entry for v5.8.0/v5.8.1. (Verified against the jsr-npm source:
`getOrDownloadBinPath` → `getDenoVersionToDownload` returns a hard-pinned
version, then `exec(binPath, ["publish", ...])`.)

**Fix.** Publish with the job's installed Deno directly (`deno publish`).
`deno publish` **enables Sigstore provenance by default on GitHub Actions** when
`id-token: write` is granted (opt-out is `--no-provenance`), so the next release
records a non-null `rekorLogId`. The tokenless-OIDC posture and the #2904
version-gate are unchanged; permissions stay `id-token: write` + `contents:
read` (least privilege).

**Detection (never fail silently — Issue #3234).** The original failure was
silent by definition, so a CI gate is added: a new `verify-provenance` step runs
`scripts/verify_provenance.ts` immediately after publishing. It polls
`https://jsr.io/@stsoftware/neat-ai/<version>_meta.json` (short retry loop for
meta-endpoint propagation) and **fails the job** when `rekorLogId` is null or
missing. Any future regression (CLI swap, OIDC env loss, `--no-provenance`)
turns the publish run red on the same run that produced the unattested version.

Closes #3333.

## Evidence

Backend/CI-only change — no web interface to screenshot.

The new script fails loud against the current (unattested) real version:

```
$ deno run --allow-net=jsr.io --allow-read scripts/verify_provenance.ts   # against 5.8.1
❌ JSR provenance verification failed: @stsoftware/neat-ai@5.8.1 has no JSR
provenance attestation after 10 attempt(s): rekorLogId is null (no Sigstore
attestation). ...
```

Acceptance is confirmed post-merge on the next release: the version's
`_meta.json` shows a non-null `rekorLogId` and the JSR score page shows
"Has provenance" ✓. A ✗ there with a green publish run would mean the CI gate
itself has regressed.

### Publish flow — before vs after

```mermaid
flowchart TB
    subgraph before["Before (silent failure)"]
        A1[setup-deno v2.x installed] --> A2["npx jsr publish"]
        A2 --> A3[jsr npm shim downloads<br/>its own pinned Deno]
        A3 --> A4[deno publish via shim]
        A4 --> A5[JSR accepts publish]
        A5 --> A6[["rekorLogId: null<br/>nothing checks — green + broken"]]
    end
    subgraph after["After (attested + gated)"]
        B1[setup-deno v2.x installed] --> B2["deno publish<br/>(provenance default-on in GHA)"]
        B2 --> B3[JSR records Sigstore<br/>transparency-log entry]
        B3 --> B4["verify_provenance.ts<br/>polls _meta.json"]
        B4 -->|rekorLogId set| B5[["✅ job green"]]
        B4 -->|null / missing| B6[["❌ job red — fail loud"]]
    end
```

## Test Plan

- `test/ci/VerifyProvenance.ts` (new) — unit tests calling the real
  `hasProvenance`, `metaUrl`, and `verifyProvenance` with an injected
  fetch/sleep (no network):
  - attested `rekorLogId` returns the id; null/missing/empty/whitespace and
    non-object inputs are "no provenance";
  - `verifyProvenance` throws (naming the version) when `rekorLogId` is null —
    reproduces the #3333 bug;
  - retries until provenance propagates, retries through a transient non-200,
    and fails loud after exhausting retries on network errors;
  - `metaUrl` builds the JSR endpoint and honours a custom base URL.
- `test/ci/ProvenancePublishWorkflow.ts` (new) — parses the committed
  `publish.yml` and asserts it publishes via `deno publish` (not `npx jsr
  publish`), does not pass `--no-provenance`, runs the `verify_provenance.ts`
  gate (guarded on the version-publish output), and keeps
  `id-token: write` + `contents: read`.
- `test/scripts/PublishBranchGuard.ts` (modified) — the publish-step detector
  matched only `jsr publish`; broadened to `deno|jsr publish` so the #2904
  branch-guard assertions stay valid after the command switch. **No assertion
  was weakened or removed** — only the step-locator regex changed.

All `test/ci/*` and `test/scripts/*` suites pass (255 tests, 0 failed);
`deno fmt`, `deno lint`, and `deno check` are clean on the new files.



## Milestone
This PR is part of the **#3332 Fix JSR provenance for @stsoftware/neat-ai; best-effort Node runtime compat** milestone and targets the `milestone/3332-fix-jsr-provenance-for-stsoftware-neat-ai-bes` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrj2hk5y-4e2be3`<!-- vibe-worker-issue-3333 -->