### PR TITLE
Milestone: #3332 Fix JSR provenance for @stsoftware/neat-ai; best-effort Node runtime compat

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,16 @@ jobs:
         if: steps.needs_publish.outputs.publish == 'true'
         run: deno run --allow-read=deno.json --allow-net=jsr.io scripts/verify_provenance.ts
 
+      # Issue #3334 (parent #3332): fail LOUDLY when a release publishes with no
+      # Sigstore provenance. v5.8.1 published with rekorLogId null on JSR while
+      # CI stayed green. This guardrail polls the just-published version's meta
+      # endpoint and exits non-zero if rekorLogId is null/absent, so a
+      # no-provenance release blocks the workflow instead of passing quietly.
+      # Runs only when a publish actually occurred (skipped otherwise).
+      - name: Verify JSR provenance was recorded
+        if: steps.needs_publish.outputs.publish == 'true'
+        run: ./scripts/verify_jsr_provenance.sh
+
       # Issue #3008 (SCR-SBOM): emit a machine-readable Software Bill of
       # Materials for the published version. Deno has no first-class SBOM
       # emitter, so generate a CycloneDX document over the committed deno.lock

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,9 +70,27 @@ jobs:
       # For runs triggered by bots (e.g. stservice): scope admin must disable
       # "Only allow publishing when triggered by a scope member" in scope settings.
       # See https://jsr.io/docs/scopes#github-actions-publishing-security
+      #
+      # Issue #3333: publish with the job's installed Deno (`deno publish`),
+      # NOT `npx jsr publish`. The npm shim downloads its own pinned Deno binary
+      # and delegates to `deno publish`, bypassing setup-deno v2.x above — that
+      # indirection silently dropped Sigstore provenance for v5.8.0/v5.8.1
+      # (rekorLogId: null). `deno publish` enables provenance by default on
+      # GitHub Actions when `id-token: write` is granted, so the transparency-log
+      # entry is recorded. The verify step below fails the run if it is not.
       - name: Publish to JSR
         if: steps.needs_publish.outputs.publish == 'true'
-        run: npx jsr publish
+        run: deno publish
+
+      # Issue #3333: the pre-fix failure was silent — JSR accepted the publish
+      # and nothing inspected the attestation. Poll the version meta endpoint and
+      # fail the run when `rekorLogId` is null/missing, so any regression (CLI
+      # swap, OIDC env loss, --no-provenance) turns the publish run red on the
+      # same run that produced the unattested version (never fail silently,
+      # Issue #3234).
+      - name: Verify JSR provenance attestation
+        if: steps.needs_publish.outputs.publish == 'true'
+        run: deno run --allow-read=deno.json --allow-net=jsr.io scripts/verify_provenance.ts
 
       # Issue #3008 (SCR-SBOM): emit a machine-readable Software Bill of
       # Materials for the published version. Deno has no first-class SBOM

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.8.1",
+  "version": "5.8.2",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3333.md
+++ b/docs/archive/pr-summaries/pr-summary-3333.md
@@ -6,20 +6,21 @@
 (`id-token: write`) granted, yet both recorded **no Sigstore provenance**
 (`rekorLogId: null`). The publish pipeline was silently failing to attest.
 
-**Root cause.** `.github/workflows/publish.yml` published with `npx jsr publish`.
-The `jsr` npm CLI is a thin shim: it downloads its **own pinned Deno binary**
-into `.download/` and delegates to `deno publish`, completely bypassing the
-Deno 2.x that `setup-deno` already installs in the job. Provenance behaviour is
-therefore governed by that pinned, indirect binary — which produced no
-transparency-log entry for v5.8.0/v5.8.1. (Verified against the jsr-npm source:
-`getOrDownloadBinPath` → `getDenoVersionToDownload` returns a hard-pinned
-version, then `exec(binPath, ["publish", ...])`.)
+**Root cause.** `.github/workflows/publish.yml` published with
+`npx jsr publish`. The `jsr` npm CLI is a thin shim: it downloads its **own
+pinned Deno binary** into `.download/` and delegates to `deno publish`,
+completely bypassing the Deno 2.x that `setup-deno` already installs in the job.
+Provenance behaviour is therefore governed by that pinned, indirect binary —
+which produced no transparency-log entry for v5.8.0/v5.8.1. (Verified against
+the jsr-npm source: `getOrDownloadBinPath` → `getDenoVersionToDownload` returns
+a hard-pinned version, then `exec(binPath, ["publish", ...])`.)
 
 **Fix.** Publish with the job's installed Deno directly (`deno publish`).
 `deno publish` **enables Sigstore provenance by default on GitHub Actions** when
 `id-token: write` is granted (opt-out is `--no-provenance`), so the next release
 records a non-null `rekorLogId`. The tokenless-OIDC posture and the #2904
-version-gate are unchanged; permissions stay `id-token: write` + `contents:
+version-gate are unchanged; permissions stay `id-token: write` +
+`contents:
 read` (least privilege).
 
 **Detection (never fail silently — Issue #3234).** The original failure was
@@ -46,9 +47,9 @@ attestation). ...
 ```
 
 Acceptance is confirmed post-merge on the next release: the version's
-`_meta.json` shows a non-null `rekorLogId` and the JSR score page shows
-"Has provenance" ✓. A ✗ there with a green publish run would mean the CI gate
-itself has regressed.
+`_meta.json` shows a non-null `rekorLogId` and the JSR score page shows "Has
+provenance" ✓. A ✗ there with a green publish run would mean the CI gate itself
+has regressed.
 
 ### Publish flow — before vs after
 
@@ -83,9 +84,10 @@ flowchart TB
     and fails loud after exhausting retries on network errors;
   - `metaUrl` builds the JSR endpoint and honours a custom base URL.
 - `test/ci/ProvenancePublishWorkflow.ts` (new) — parses the committed
-  `publish.yml` and asserts it publishes via `deno publish` (not `npx jsr
-  publish`), does not pass `--no-provenance`, runs the `verify_provenance.ts`
-  gate (guarded on the version-publish output), and keeps
+  `publish.yml` and asserts it publishes via `deno publish` (not
+  `npx jsr
+  publish`), does not pass `--no-provenance`, runs the
+  `verify_provenance.ts` gate (guarded on the version-publish output), and keeps
   `id-token: write` + `contents: read`.
 - `test/scripts/PublishBranchGuard.ts` (modified) — the publish-step detector
   matched only `jsr publish`; broadened to `deno|jsr publish` so the #2904

--- a/docs/archive/pr-summaries/pr-summary-3333.md
+++ b/docs/archive/pr-summaries/pr-summary-3333.md
@@ -1,0 +1,96 @@
+# Fix silent JSR provenance failure — next release carries a Sigstore attestation
+
+## Summary
+
+`@stsoftware/neat-ai` v5.8.0 and v5.8.1 were published to JSR with OIDC
+(`id-token: write`) granted, yet both recorded **no Sigstore provenance**
+(`rekorLogId: null`). The publish pipeline was silently failing to attest.
+
+**Root cause.** `.github/workflows/publish.yml` published with `npx jsr publish`.
+The `jsr` npm CLI is a thin shim: it downloads its **own pinned Deno binary**
+into `.download/` and delegates to `deno publish`, completely bypassing the
+Deno 2.x that `setup-deno` already installs in the job. Provenance behaviour is
+therefore governed by that pinned, indirect binary — which produced no
+transparency-log entry for v5.8.0/v5.8.1. (Verified against the jsr-npm source:
+`getOrDownloadBinPath` → `getDenoVersionToDownload` returns a hard-pinned
+version, then `exec(binPath, ["publish", ...])`.)
+
+**Fix.** Publish with the job's installed Deno directly (`deno publish`).
+`deno publish` **enables Sigstore provenance by default on GitHub Actions** when
+`id-token: write` is granted (opt-out is `--no-provenance`), so the next release
+records a non-null `rekorLogId`. The tokenless-OIDC posture and the #2904
+version-gate are unchanged; permissions stay `id-token: write` + `contents:
+read` (least privilege).
+
+**Detection (never fail silently — Issue #3234).** The original failure was
+silent by definition, so a CI gate is added: a new `verify-provenance` step runs
+`scripts/verify_provenance.ts` immediately after publishing. It polls
+`https://jsr.io/@stsoftware/neat-ai/<version>_meta.json` (short retry loop for
+meta-endpoint propagation) and **fails the job** when `rekorLogId` is null or
+missing. Any future regression (CLI swap, OIDC env loss, `--no-provenance`)
+turns the publish run red on the same run that produced the unattested version.
+
+Closes #3333.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+The new script fails loud against the current (unattested) real version:
+
+```
+$ deno run --allow-net=jsr.io --allow-read scripts/verify_provenance.ts   # against 5.8.1
+❌ JSR provenance verification failed: @stsoftware/neat-ai@5.8.1 has no JSR
+provenance attestation after 10 attempt(s): rekorLogId is null (no Sigstore
+attestation). ...
+```
+
+Acceptance is confirmed post-merge on the next release: the version's
+`_meta.json` shows a non-null `rekorLogId` and the JSR score page shows
+"Has provenance" ✓. A ✗ there with a green publish run would mean the CI gate
+itself has regressed.
+
+### Publish flow — before vs after
+
+```mermaid
+flowchart TB
+    subgraph before["Before (silent failure)"]
+        A1[setup-deno v2.x installed] --> A2["npx jsr publish"]
+        A2 --> A3[jsr npm shim downloads<br/>its own pinned Deno]
+        A3 --> A4[deno publish via shim]
+        A4 --> A5[JSR accepts publish]
+        A5 --> A6[["rekorLogId: null<br/>nothing checks — green + broken"]]
+    end
+    subgraph after["After (attested + gated)"]
+        B1[setup-deno v2.x installed] --> B2["deno publish<br/>(provenance default-on in GHA)"]
+        B2 --> B3[JSR records Sigstore<br/>transparency-log entry]
+        B3 --> B4["verify_provenance.ts<br/>polls _meta.json"]
+        B4 -->|rekorLogId set| B5[["✅ job green"]]
+        B4 -->|null / missing| B6[["❌ job red — fail loud"]]
+    end
+```
+
+## Test Plan
+
+- `test/ci/VerifyProvenance.ts` (new) — unit tests calling the real
+  `hasProvenance`, `metaUrl`, and `verifyProvenance` with an injected
+  fetch/sleep (no network):
+  - attested `rekorLogId` returns the id; null/missing/empty/whitespace and
+    non-object inputs are "no provenance";
+  - `verifyProvenance` throws (naming the version) when `rekorLogId` is null —
+    reproduces the #3333 bug;
+  - retries until provenance propagates, retries through a transient non-200,
+    and fails loud after exhausting retries on network errors;
+  - `metaUrl` builds the JSR endpoint and honours a custom base URL.
+- `test/ci/ProvenancePublishWorkflow.ts` (new) — parses the committed
+  `publish.yml` and asserts it publishes via `deno publish` (not `npx jsr
+  publish`), does not pass `--no-provenance`, runs the `verify_provenance.ts`
+  gate (guarded on the version-publish output), and keeps
+  `id-token: write` + `contents: read`.
+- `test/scripts/PublishBranchGuard.ts` (modified) — the publish-step detector
+  matched only `jsr publish`; broadened to `deno|jsr publish` so the #2904
+  branch-guard assertions stay valid after the command switch. **No assertion
+  was weakened or removed** — only the step-locator regex changed.
+
+All `test/ci/*` and `test/scripts/*` suites pass (255 tests, 0 failed);
+`deno fmt`, `deno lint`, and `deno check` are clean on the new files.

--- a/docs/archive/pr-summaries/pr-summary-3334.md
+++ b/docs/archive/pr-summaries/pr-summary-3334.md
@@ -1,0 +1,62 @@
+# Fail loudly when a JSR release has no provenance (Issue #3334)
+
+## Summary
+
+The publish pipeline silently succeeded while producing **no** provenance
+attestation for v5.8.1 (`rekorLogId` null on JSR). Parent #3332 requires this
+failure mode to be **loud, not silent**: a release that publishes without
+provenance must fail the CI job, not pass quietly.
+
+This adds a post-publish guardrail — independent of the root-cause fix — that
+protects against any future attestation regression regardless of cause:
+
+- **`scripts/verify_jsr_provenance.sh`** — polls
+  `https://jsr.io/<name>/<version>_meta.json` for the just-published version and
+  exits non-zero when `rekorLogId` is null/absent, emitting an actionable error
+  naming the version and the missing attestation. It reuses the
+  `jq -r .name/.version deno.json` extraction pattern already in the workflow,
+  and applies a bounded retry/poll (tunable via `VERIFY_JSR_MAX_ATTEMPTS` /
+  `VERIFY_JSR_RETRY_DELAY`) to absorb JSR eventual consistency without becoming
+  flaky — it still ultimately fails if provenance never appears. Per the
+  fail-loud principle, a fetch failure is never masked as a valid empty result.
+- **`.github/workflows/publish.yml`** — a new "Verify JSR provenance was
+  recorded" step runs `./scripts/verify_jsr_provenance.sh`, gated on
+  `steps.needs_publish.outputs.publish == 'true'` so it is skipped on runs where
+  nothing was published and does not weaken the existing concurrency / version
+  gate (#2842, #2904).
+
+CI/publish-pipeline only — no runtime code changes.
+
+Closes #3334.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified by driving the real
+script against local meta fixtures and by parsing the committed workflow YAML
+(see Test Plan). All new tests pass; `./quality.sh --lint-only` is clean
+(format, lint, bash syntax including the new script).
+
+```mermaid
+flowchart TD
+    A[Determine whether the version needs publishing] -->|publish == 'true'| B[Publish to JSR]
+    A -->|publish == 'false'| Z[Skip — already on JSR]
+    B --> C{Verify JSR provenance was recorded}
+    C -->|poll _meta.json| D{rekorLogId non-null?}
+    D -->|yes| E[✅ Step passes → continue to SBOM]
+    D -->|null/absent after retries| F[❌ Fail the job — loud, not silent]
+```
+
+## Test Plan
+
+- `test/scripts/VerifyJsrProvenance.ts` — drives the script end-to-end:
+  - passes when `rekorLogId` is a non-null value,
+  - fails loudly (exit 1, actionable message naming the version) when
+    `rekorLogId` is explicitly `null`, when it is absent, and when the meta
+    document cannot be fetched,
+  - `--help` and unknown-option handling.
+- `test/ci/PublishProvenanceGate.ts` — parses `publish.yml` and asserts the
+  verification step is present and gated on
+  `steps.needs_publish.outputs.publish == 'true'`, guarding against the gate
+  itself being deleted or its `if:` guard broken.
+- `test/scripts/ShellcheckLint.ts` (existing) — the new script passes
+  `shellcheck --severity=warning`.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -10,6 +10,9 @@
   ],
   "words": [
     "AJSON",
+    "Sigstore",
+    "Rekor",
+    "automatable",
     "Abramowitz",
     "Accum",
     "Aggr",

--- a/scripts/verify_jsr_provenance.sh
+++ b/scripts/verify_jsr_provenance.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Verify that a just-published JSR release carries Sigstore provenance.
+#
+# Issue #3334 (parent #3332): the publish pipeline silently succeeded while
+# producing NO provenance attestation for v5.8.1 (rekorLogId null on JSR). A
+# release that publishes without provenance must fail LOUDLY (non-zero exit),
+# not pass quietly. This script is the guardrail: it polls the JSR version
+# meta endpoint and fails the job when rekorLogId is null/absent.
+#
+# Usage:
+#   scripts/verify_jsr_provenance.sh                 # read name/version from deno.json
+#   scripts/verify_jsr_provenance.sh --name @scope/pkg --version 1.2.3
+#   scripts/verify_jsr_provenance.sh --meta-file fixture.json   # local meta (tests)
+#   scripts/verify_jsr_provenance.sh --help
+#
+# JSR is eventually consistent, so the check retries a bounded number of times
+# before giving up. Tuning knobs (used by tests to stay fast):
+#   VERIFY_JSR_MAX_ATTEMPTS   attempts before failing (default 5)
+#   VERIFY_JSR_RETRY_DELAY    seconds between attempts (default 6)
+#
+# Exit codes:
+#   0  provenance recorded (non-null rekorLogId)
+#   1  no provenance after all attempts, or a usage/lookup error
+
+set -Eeuo pipefail
+
+MAX_ATTEMPTS="${VERIFY_JSR_MAX_ATTEMPTS:-5}"
+RETRY_DELAY="${VERIFY_JSR_RETRY_DELAY:-6}"
+
+NAME=""
+VERSION=""
+META_FILE=""
+
+show_help() {
+  cat <<'HELP'
+Usage: scripts/verify_jsr_provenance.sh [OPTIONS]
+
+Fail loudly when a published JSR version has no Sigstore provenance
+(rekorLogId is null/absent). Reuses the name/version extraction pattern
+from .github/workflows/publish.yml.
+
+Options:
+  --name NAME         Package name (default: jq -r .name deno.json)
+  --version VERSION   Package version (default: jq -r .version deno.json)
+  --meta-file FILE    Read meta JSON from a local file instead of JSR
+                      (bypasses the network; used by tests)
+  --help              Show this help and exit
+
+Environment:
+  VERIFY_JSR_MAX_ATTEMPTS   Retry attempts before failing (default 5)
+  VERIFY_JSR_RETRY_DELAY    Seconds between attempts (default 6)
+
+Exit codes:
+  0  provenance recorded (non-null rekorLogId)
+  1  no provenance after all attempts, or a usage/lookup error
+HELP
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name)
+      NAME="${2:-}"
+      shift 2
+      ;;
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --meta-file)
+      META_FILE="${2:-}"
+      shift 2
+      ;;
+    --help | -h)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Run 'scripts/verify_jsr_provenance.sh --help' for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Fall back to deno.json for anything not supplied explicitly. Mirror the
+# `jq -r .name/.version deno.json` pattern already used in publish.yml.
+if [ -z "$NAME" ]; then
+  NAME=$(jq -r .name deno.json)
+fi
+if [ -z "$VERSION" ]; then
+  VERSION=$(jq -r .version deno.json)
+fi
+
+if [ -z "$NAME" ] || [ "$NAME" = "null" ] || [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+  echo "❌ Could not determine package name/version for provenance check." >&2
+  exit 1
+fi
+
+META_URL="https://jsr.io/${NAME}/${VERSION}_meta.json"
+
+# Fetch the meta document into $1. Returns non-zero when the document could
+# not be retrieved so the caller can retry. Never masks a fetch failure as a
+# valid (empty) document.
+fetch_meta() {
+  local out="$1"
+  if [ -n "$META_FILE" ]; then
+    [ -f "$META_FILE" ] || return 1
+    cat "$META_FILE" >"$out"
+    return 0
+  fi
+  curl -sf "$META_URL" -o "$out"
+}
+
+echo "🔎 Verifying JSR provenance for ${NAME}@${VERSION}"
+[ -n "$META_FILE" ] && echo "   (meta source: ${META_FILE})"
+
+tmp_meta="$(mktemp)"
+trap 'rm -f "$tmp_meta"' EXIT
+
+attempt=1
+while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+  if fetch_meta "$tmp_meta"; then
+    # rekorLogId is the Sigstore transparency-log entry recorded when JSR
+    # attests provenance. Absent/null means no attestation was produced.
+    rekor=$(jq -r '.rekorLogId // "null"' "$tmp_meta" 2>/dev/null || echo "null")
+    if [ -n "$rekor" ] && [ "$rekor" != "null" ]; then
+      echo "✅ Provenance recorded for ${NAME}@${VERSION} (rekorLogId=${rekor})."
+      exit 0
+    fi
+    echo "… attempt ${attempt}/${MAX_ATTEMPTS}: rekorLogId still null/absent for ${NAME}@${VERSION}." >&2
+  else
+    echo "… attempt ${attempt}/${MAX_ATTEMPTS}: could not fetch ${META_URL} (JSR eventual consistency?)." >&2
+  fi
+
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    sleep "$RETRY_DELAY"
+  fi
+  attempt=$((attempt + 1))
+done
+
+echo "❌ No Sigstore provenance for ${NAME}@${VERSION}: rekorLogId is null/absent" >&2
+echo "   after ${MAX_ATTEMPTS} attempt(s) against ${META_URL}." >&2
+echo "   A release must publish WITH provenance (Issue #3334). Failing the job." >&2
+exit 1

--- a/scripts/verify_provenance.ts
+++ b/scripts/verify_provenance.ts
@@ -1,0 +1,186 @@
+/**
+ * Issue #3333 — verify a freshly published JSR version carries a Sigstore
+ * provenance attestation (a non-null `rekorLogId`).
+ *
+ * ## Why this exists
+ *
+ * `@stsoftware/neat-ai` v5.8.0 and v5.8.1 were published to JSR from
+ * `.github/workflows/publish.yml` with OIDC (`id-token: write`) granted, yet
+ * their `<version>_meta.json` recorded `rekorLogId: null` — JSR held no
+ * transparency-log entry. The publish step ran `npx jsr publish`, whose npm
+ * shim downloads its *own* pinned Deno binary and delegates to `deno publish`,
+ * bypassing the job's `setup-deno` v2.x. That indirection is where attestation
+ * was silently lost. The fix publishes with the job's installed Deno directly
+ * (`deno publish`), which enables Sigstore provenance by default on GitHub
+ * Actions.
+ *
+ * ## Why a gate, not just a fix
+ *
+ * The original failure mode was *silent* (Issue #3234): JSR accepts an
+ * unattested publish and nothing downstream notices. This module polls the JSR
+ * version meta endpoint after publishing and exits non-zero when `rekorLogId`
+ * is null or missing, so any future regression (CLI swap, OIDC env loss,
+ * `--no-provenance` creeping in) turns the publish run red on the same run that
+ * produced the unattested version — it fails loud rather than green-and-broken.
+ *
+ * The functions here are pure and take an injectable `fetch`/`sleep` so the
+ * logic is unit-tested in `test/ci/VerifyProvenance.ts`; the real Sigstore
+ * attestation itself can only occur in the GitHub Actions OIDC context, so the
+ * in-workflow post-publish check is the only automatable detection surface.
+ */
+
+/** Shape of the fields we read from `<name>/<version>_meta.json`. */
+export interface VersionMeta {
+  /** Sigstore/Rekor transparency-log entry id; null/absent means no provenance. */
+  rekorLogId?: string | null;
+}
+
+export interface VerifyOptions {
+  /** Injectable fetch (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Registry base URL (defaults to https://jsr.io). */
+  baseUrl?: string;
+  /** Total attempts before giving up (default 10). */
+  retries?: number;
+  /** Delay between attempts in milliseconds (default 6000). */
+  delayMs?: number;
+  /** Injectable sleep (defaults to a real timer); tests pass a no-op. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable logger (defaults to console.error). */
+  log?: (msg: string) => void;
+}
+
+/**
+ * True only when `meta` is an object carrying a non-empty string `rekorLogId`.
+ * Null, undefined, empty string, or a non-string are all "no provenance".
+ */
+export function hasProvenance(meta: unknown): boolean {
+  if (meta === null || typeof meta !== "object") return false;
+  const id = (meta as VersionMeta).rekorLogId;
+  return typeof id === "string" && id.trim().length > 0;
+}
+
+/** Build the JSR version meta URL for a package name and version. */
+export function metaUrl(
+  name: string,
+  version: string,
+  baseUrl = "https://jsr.io",
+): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  return `${base}/${name}/${version}_meta.json`;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll the JSR meta endpoint until the version reports a non-null `rekorLogId`,
+ * returning that id. Throws a descriptive Error if provenance is still absent
+ * after all retries, or if the endpoint never returns a usable response — the
+ * absence of a positive attestation is treated as failure, never as success
+ * (Issue #3234).
+ */
+export async function verifyProvenance(
+  name: string,
+  version: string,
+  options: VerifyOptions = {},
+): Promise<string> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const baseUrl = options.baseUrl ?? "https://jsr.io";
+  const retries = options.retries ?? 10;
+  const delayMs = options.delayMs ?? 6000;
+  const sleep = options.sleep ?? defaultSleep;
+  const log = options.log ?? ((m: string) => console.error(m));
+
+  const url = metaUrl(name, version, baseUrl);
+
+  // One poll attempt: resolve to the rekorLogId on success, or a human-readable
+  // reason string on failure. Kept as a helper so the loop awaits exactly once.
+  const attemptOnce = async (): Promise<
+    { id: string } | { reason: string }
+  > => {
+    try {
+      const res = await fetchImpl(url);
+      if (!res.ok) {
+        // Consume the body so the connection can be reused/closed cleanly.
+        await res.body?.cancel();
+        return { reason: `HTTP ${res.status} from ${url}` };
+      }
+      const meta = (await res.json()) as VersionMeta;
+      if (hasProvenance(meta)) return { id: meta.rekorLogId as string };
+      return {
+        reason: `rekorLogId is ${
+          JSON.stringify(meta.rekorLogId ?? null)
+        } (no Sigstore attestation)`,
+      };
+    } catch (error: unknown) {
+      return { reason: error instanceof Error ? error.message : String(error) };
+    }
+  };
+
+  let lastReason = "no attempt was made";
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    // Sequential polling: each attempt must observe the previous result.
+    // deno-lint-ignore no-await-in-loop -- intentional sequential poll.
+    const result = await attemptOnce();
+    if ("id" in result) {
+      log(
+        `✅ ${name}@${version} has JSR provenance (rekorLogId=${result.id}).`,
+      );
+      return result.id;
+    }
+    lastReason = result.reason;
+
+    if (attempt < retries) {
+      log(
+        `⏳ attempt ${attempt}/${retries}: ${lastReason}; ` +
+          `retrying in ${delayMs}ms (meta endpoint may still be propagating).`,
+      );
+      // deno-lint-ignore no-await-in-loop -- intentional back-off between polls.
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error(
+    `${name}@${version} has no JSR provenance attestation after ${retries} ` +
+      `attempt(s): ${lastReason}. The publish step must run \`deno publish\` ` +
+      `on GitHub Actions with \`id-token: write\` so JSR records a Sigstore ` +
+      `transparency-log entry (Issue #3333).`,
+  );
+}
+
+interface DenoJson {
+  name?: string;
+  version?: string;
+}
+
+/** Read `name` and `version` from a deno.json(c) file. */
+export async function readPackageIdentity(
+  path = "deno.json",
+): Promise<{ name: string; version: string }> {
+  const text = await Deno.readTextFile(path);
+  const json = JSON.parse(text) as DenoJson;
+  if (!json.name || !json.version) {
+    throw new Error(
+      `${path} must define both \`name\` and \`version\`; got ` +
+        `${JSON.stringify({ name: json.name, version: json.version })}`,
+    );
+  }
+  return { name: json.name, version: json.version };
+}
+
+async function main(): Promise<void> {
+  try {
+    const { name, version } = await readPackageIdentity();
+    await verifyProvenance(name, version);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`❌ JSR provenance verification failed: ${message}`);
+    Deno.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/test/ci/ProvenancePublishWorkflow.ts
+++ b/test/ci/ProvenancePublishWorkflow.ts
@@ -1,0 +1,111 @@
+/**
+ * Issue #3333 — the release pipeline must (a) publish with the job's installed
+ * Deno so JSR records a Sigstore provenance attestation, and (b) verify that
+ * attestation on the same run so a regression fails loud instead of silently.
+ *
+ * Background: `@stsoftware/neat-ai` v5.8.0/v5.8.1 published with OIDC granted
+ * but `rekorLogId: null`. The old step ran `npx jsr publish`, whose npm shim
+ * downloads its own pinned Deno and bypasses the job's `setup-deno` v2.x,
+ * silently losing provenance. Publishing with `deno publish` directly restores
+ * it (provenance is default-on for `deno publish` on GitHub Actions).
+ *
+ * These are "what" tests: they parse the committed workflow YAML and assert on
+ * the resulting configuration, not on the exact wording of each step.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const PUBLISH_WORKFLOW = join(REPO_ROOT, ".github/workflows/publish.yml");
+
+interface Step {
+  name?: string;
+  id?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+}
+interface Job {
+  permissions?: Record<string, string>;
+  steps?: Step[];
+}
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(): Promise<Workflow> {
+  return parse(await Deno.readTextFile(PUBLISH_WORKFLOW)) as Workflow;
+}
+
+function steps(wf: Workflow): Step[] {
+  const out: Step[] = [];
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const s of job.steps ?? []) out.push(s);
+  }
+  return out;
+}
+
+Deno.test("publish.yml publishes with `deno publish`, not the npm shim (Issue #3333)", async () => {
+  const wf = await readWorkflow();
+  const all = steps(wf);
+
+  const publishStep = all.find((s) => /\bdeno\s+publish\b/.test(s.run ?? ""));
+  assert(
+    publishStep !== undefined,
+    "publish job must publish via `deno publish` so the job's installed " +
+      "Deno (setup-deno v2.x) attaches Sigstore provenance on GitHub Actions",
+  );
+
+  // The npm shim (`npx jsr publish`) downloads its own pinned Deno and bypasses
+  // setup-deno, which silently dropped provenance for v5.8.0/v5.8.1.
+  const shimStep = all.find((s) => /npx\s+jsr\s+publish/.test(s.run ?? ""));
+  assert(
+    shimStep === undefined,
+    "publish job must NOT use `npx jsr publish` — its npm shim bypasses the " +
+      "job's Deno and silently dropped JSR provenance (Issue #3333)",
+  );
+
+  // Provenance must not be explicitly disabled.
+  assert(
+    !/--no-provenance/.test(publishStep!.run ?? ""),
+    "the publish step must not pass --no-provenance",
+  );
+});
+
+Deno.test("publish.yml verifies the provenance attestation after publishing (Issue #3333)", async () => {
+  const wf = await readWorkflow();
+  const all = steps(wf);
+
+  const verifyStep = all.find((s) => /verify_provenance\.ts/.test(s.run ?? ""));
+  assert(
+    verifyStep !== undefined,
+    "publish job must run scripts/verify_provenance.ts after publishing so a " +
+      "missing Sigstore attestation fails the run instead of passing silently",
+  );
+
+  // The gate only makes sense when a publish actually happened, so it must be
+  // gated on the same needs_publish signal as the publish step.
+  const cond = verifyStep!.if ?? "";
+  assert(
+    cond.includes("steps.") && cond.includes("outputs."),
+    "the verify-provenance step must be gated on the version-publish check " +
+      `output; got: ${JSON.stringify(verifyStep!.if)}`,
+  );
+});
+
+Deno.test("publish job keeps least-privilege OIDC permissions (Issue #3333)", async () => {
+  const wf = await readWorkflow();
+  const job = (wf.jobs ?? {})["publish"];
+  assert(job !== undefined, "publish.yml must define a `publish` job");
+  const perms = job.permissions ?? {};
+  assert(
+    perms["id-token"] === "write",
+    "publish job must keep `id-token: write` (OIDC for JSR provenance)",
+  );
+  assert(
+    perms["contents"] === "read",
+    "publish job must keep `contents: read` (least privilege)",
+  );
+});

--- a/test/ci/PublishProvenanceGate.ts
+++ b/test/ci/PublishProvenanceGate.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue #3334 (parent #3332) — the publish pipeline silently succeeded while
+ * producing NO provenance attestation for v5.8.1 (rekorLogId null on JSR). A
+ * release that publishes without provenance must fail LOUDLY, not pass quietly.
+ *
+ * `publish.yml` now runs a post-publish verification step that polls the JSR
+ * version meta endpoint and fails the job when rekorLogId is null/absent.
+ *
+ * These tests parse the committed workflow YAML and assert on the resulting
+ * configuration — they guard against the gate itself regressing (step deleted,
+ * or its `if:` guard broken so it never runs), which is exactly the failure
+ * surface the issue calls out. They are "what" tests over CI config: there is
+ * no runtime behaviour to exercise, only the shipped workflow.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const PUBLISH_WORKFLOW = join(REPO_ROOT, ".github/workflows/publish.yml");
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  if?: string;
+}
+
+interface Job {
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(PUBLISH_WORKFLOW);
+  return parse(text) as Workflow;
+}
+
+function allSteps(wf: Workflow): Step[] {
+  const steps: Step[] = [];
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const step of job.steps ?? []) steps.push(step);
+  }
+  return steps;
+}
+
+function provenanceStep(wf: Workflow): Step | undefined {
+  return allSteps(wf).find(
+    (s) => typeof s.run === "string" && /verify_jsr_provenance\.sh/.test(s.run),
+  );
+}
+
+Deno.test("publish.yml runs the JSR provenance verification step (Issue #3334)", async () => {
+  const wf = await readWorkflow();
+  const step = provenanceStep(wf);
+  assert(
+    step !== undefined,
+    "publish.yml must run scripts/verify_jsr_provenance.sh after publishing so " +
+      "a release with no Sigstore provenance (rekorLogId null) fails the job",
+  );
+});
+
+Deno.test("publish.yml only verifies provenance when a publish ran (Issue #3334)", async () => {
+  const wf = await readWorkflow();
+  const step = provenanceStep(wf);
+  assert(step !== undefined, "provenance verification step missing");
+
+  // Every push to Develop runs this workflow, but a publish only happens on a
+  // release commit. The check must be gated on the same needs_publish signal
+  // that gates the JSR publish step — otherwise it runs (and fails) on pushes
+  // where nothing was published.
+  const cond = step!.if ?? "";
+  assert(
+    /needs_publish\.outputs\.publish\s*==\s*'true'/.test(cond),
+    "the provenance verification step must be gated on " +
+      "steps.needs_publish.outputs.publish == 'true' so it only runs for a " +
+      `new release version, got if: '${cond}'`,
+  );
+});

--- a/test/ci/VerifyProvenance.ts
+++ b/test/ci/VerifyProvenance.ts
@@ -1,0 +1,157 @@
+/**
+ * Issue #3333 — unit tests for `scripts/verify_provenance.ts`, the post-publish
+ * gate that fails the release run when a freshly published JSR version carries
+ * no Sigstore provenance (`rekorLogId` null or missing).
+ *
+ * These call the real functions with an injected fetch/sleep so no network is
+ * touched. The attestation itself only happens in the GitHub Actions OIDC
+ * context at publish time, so this exercises the *detection* logic — the only
+ * automatable surface — not the signing.
+ */
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  hasProvenance,
+  metaUrl,
+  verifyProvenance,
+} from "../../scripts/verify_provenance.ts";
+
+const noSleep = (_ms: number) => Promise.resolve();
+
+/** Build a Response-returning fetch from a fixed body/status. */
+function stubFetch(
+  body: unknown,
+  status = 200,
+): { fetch: typeof fetch; calls: string[] } {
+  const calls: string[] = [];
+  const fetchImpl = ((input: string | URL | Request) => {
+    calls.push(String(input));
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+  return { fetch: fetchImpl, calls };
+}
+
+Deno.test("hasProvenance: non-empty rekorLogId string means attested", () => {
+  assert(hasProvenance({ rekorLogId: "108e9186e8c5677a..." }));
+});
+
+Deno.test("hasProvenance: null / missing / empty means not attested", () => {
+  assertEquals(hasProvenance({ rekorLogId: null }), false);
+  assertEquals(hasProvenance({}), false);
+  assertEquals(hasProvenance({ rekorLogId: "" }), false);
+  assertEquals(hasProvenance({ rekorLogId: "   " }), false);
+});
+
+Deno.test("hasProvenance: non-object inputs are not attested", () => {
+  assertEquals(hasProvenance(null), false);
+  assertEquals(hasProvenance(undefined), false);
+  assertEquals(hasProvenance("108e9..."), false);
+  assertEquals(hasProvenance(42), false);
+});
+
+Deno.test("metaUrl builds the JSR version meta endpoint", () => {
+  assertEquals(
+    metaUrl("@stsoftware/neat-ai", "5.8.1"),
+    "https://jsr.io/@stsoftware/neat-ai/5.8.1_meta.json",
+  );
+});
+
+Deno.test("metaUrl honours a custom base URL without doubling slashes", () => {
+  assertEquals(
+    metaUrl("@scope/pkg", "1.0.0", "https://example.test/"),
+    "https://example.test/@scope/pkg/1.0.0_meta.json",
+  );
+});
+
+Deno.test("verifyProvenance returns the rekorLogId when attested", async () => {
+  const { fetch, calls } = stubFetch({ rekorLogId: "abc123" });
+  const id = await verifyProvenance("@scope/pkg", "1.0.0", {
+    fetchImpl: fetch,
+    log: () => {},
+  });
+  assertEquals(id, "abc123");
+  assertEquals(calls, ["https://jsr.io/@scope/pkg/1.0.0_meta.json"]);
+});
+
+Deno.test("verifyProvenance throws when rekorLogId is null (the #3333 bug)", async () => {
+  const { fetch } = stubFetch({ rekorLogId: null });
+  const err = await assertRejects(
+    () =>
+      verifyProvenance("@stsoftware/neat-ai", "5.8.1", {
+        fetchImpl: fetch,
+        retries: 3,
+        delayMs: 1,
+        sleep: noSleep,
+        log: () => {},
+      }),
+    Error,
+    "no JSR provenance attestation",
+  );
+  // Message must name the version so the red CI run is self-explanatory.
+  assert(err.message.includes("5.8.1"));
+});
+
+Deno.test("verifyProvenance retries until provenance appears (meta propagation)", async () => {
+  let attempt = 0;
+  const fetchImpl = (() => {
+    attempt++;
+    const body = attempt < 3 ? { rekorLogId: null } : { rekorLogId: "late-id" };
+    return Promise.resolve(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+  }) as typeof fetch;
+
+  const id = await verifyProvenance("@scope/pkg", "2.0.0", {
+    fetchImpl,
+    retries: 5,
+    delayMs: 1,
+    sleep: noSleep,
+    log: () => {},
+  });
+  assertEquals(id, "late-id");
+  assertEquals(attempt, 3);
+});
+
+Deno.test("verifyProvenance retries on transient non-200 then succeeds", async () => {
+  let attempt = 0;
+  const fetchImpl = (() => {
+    attempt++;
+    if (attempt === 1) {
+      return Promise.resolve(new Response("nope", { status: 404 }));
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ rekorLogId: "ok" }), { status: 200 }),
+    );
+  }) as typeof fetch;
+
+  const id = await verifyProvenance("@scope/pkg", "3.0.0", {
+    fetchImpl,
+    retries: 4,
+    delayMs: 1,
+    sleep: noSleep,
+    log: () => {},
+  });
+  assertEquals(id, "ok");
+});
+
+Deno.test("verifyProvenance fails loud after exhausting retries on errors", async () => {
+  const fetchImpl =
+    (() => Promise.reject(new Error("network down"))) as typeof fetch;
+  await assertRejects(
+    () =>
+      verifyProvenance("@scope/pkg", "4.0.0", {
+        fetchImpl,
+        retries: 2,
+        delayMs: 1,
+        sleep: noSleep,
+        log: () => {},
+      }),
+    Error,
+    "network down",
+  );
+});

--- a/test/scripts/PublishBranchGuard.ts
+++ b/test/scripts/PublishBranchGuard.ts
@@ -111,10 +111,16 @@ Deno.test("publish step is gated on a prior version-published check", async () =
   const job = publishJob(wf);
   const steps = job.steps ?? [];
 
-  const publishStep = steps.find((s) => (s.run ?? "").includes("jsr publish"));
+  // Issue #3333 switched the publish command from `npx jsr publish` to
+  // `deno publish` (native provenance). Match either CLI so this branch-guard
+  // test stays valid regardless of which publish command is in use.
+  const publishStep = steps.find((s) =>
+    /\b(?:deno|jsr)\s+publish\b/.test(s.run ?? "")
+  );
   assert(
     publishStep !== undefined,
-    "publish job must contain a step that runs `jsr publish`",
+    "publish job must contain a step that runs a JSR publish command " +
+      "(`deno publish` or `jsr publish`)",
   );
 
   const condition = publishStep.if ?? "";

--- a/test/scripts/VerifyJsrProvenance.ts
+++ b/test/scripts/VerifyJsrProvenance.ts
@@ -1,0 +1,136 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+
+/**
+ * Tests for scripts/verify_jsr_provenance.sh.
+ *
+ * Issue #3334 (parent #3332) — the publish pipeline must fail LOUDLY when a
+ * JSR release carries no Sigstore provenance (rekorLogId null/absent), rather
+ * than succeeding silently as it did for v5.8.1.
+ *
+ * The tests drive the script's real behaviour against local meta fixtures
+ * (via --meta-file, bypassing the network) and assert on exit code and
+ * message — never grepping the source.
+ */
+
+const SCRIPT = "scripts/verify_jsr_provenance.sh";
+
+async function runScript(
+  args: string[] = [],
+  env: Record<string, string> = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const cmd = new Deno.Command("bash", {
+    args: [SCRIPT, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    // Keep retries fast and bounded for the null path.
+    env: { VERIFY_JSR_MAX_ATTEMPTS: "1", VERIFY_JSR_RETRY_DELAY: "0", ...env },
+  });
+  const { code, stdout, stderr } = await cmd.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+async function withMetaFile(
+  contents: string,
+  fn: (path: string) => Promise<void>,
+): Promise<void> {
+  const path = await Deno.makeTempFile({ suffix: ".json" });
+  try {
+    await Deno.writeTextFile(path, contents);
+    await fn(path);
+  } finally {
+    await Deno.remove(path).catch(() => {});
+  }
+}
+
+Deno.test("verify_jsr_provenance.sh exists", async () => {
+  const info = await Deno.stat(SCRIPT);
+  assert(info.isFile, `${SCRIPT} should be a file`);
+});
+
+Deno.test("verify_jsr_provenance.sh --help prints usage and exits 0", async () => {
+  const { code, stdout } = await runScript(["--help"]);
+  assertEquals(code, 0, "help must exit cleanly");
+  assertStringIncludes(stdout, "Usage: scripts/verify_jsr_provenance.sh");
+  assertStringIncludes(stdout, "--meta-file");
+  assertStringIncludes(stdout, "rekorLogId");
+});
+
+Deno.test("verify_jsr_provenance.sh rejects unknown options with exit 1", async () => {
+  const { code, stderr } = await runScript(["--nope"]);
+  assertEquals(code, 1, "unknown option must exit non-zero");
+  assertStringIncludes(stderr, "Unknown option: --nope");
+});
+
+Deno.test("passes when rekorLogId is a non-null value", async () => {
+  await withMetaFile(
+    JSON.stringify({ rekorLogId: "108e9186e8c5677a" }),
+    async (path) => {
+      const { code, stdout } = await runScript([
+        "--name",
+        "@stsoftware/neat-ai",
+        "--version",
+        "5.9.0",
+        "--meta-file",
+        path,
+      ]);
+      assertEquals(code, 0, "non-null rekorLogId must pass");
+      assertStringIncludes(stdout, "Provenance recorded");
+      assertStringIncludes(stdout, "5.9.0");
+    },
+  );
+});
+
+Deno.test("fails loudly when rekorLogId is explicitly null", async () => {
+  await withMetaFile(
+    JSON.stringify({ rekorLogId: null }),
+    async (path) => {
+      const { code, stderr } = await runScript([
+        "--name",
+        "@stsoftware/neat-ai",
+        "--version",
+        "5.8.1",
+        "--meta-file",
+        path,
+      ]);
+      assertEquals(code, 1, "null rekorLogId must fail the job");
+      assertStringIncludes(stderr, "No Sigstore provenance");
+      assertStringIncludes(stderr, "5.8.1");
+    },
+  );
+});
+
+Deno.test("fails loudly when rekorLogId is absent", async () => {
+  await withMetaFile(
+    JSON.stringify({ version: "5.8.1", moduleGraph2: {} }),
+    async (path) => {
+      const { code, stderr } = await runScript([
+        "--name",
+        "@stsoftware/neat-ai",
+        "--version",
+        "5.8.1",
+        "--meta-file",
+        path,
+      ]);
+      assertEquals(code, 1, "absent rekorLogId must fail the job");
+      assertStringIncludes(stderr, "No Sigstore provenance");
+      assertStringIncludes(stderr, "@stsoftware/neat-ai");
+    },
+  );
+});
+
+Deno.test("fails loudly when the meta document cannot be fetched", async () => {
+  const { code, stderr } = await runScript([
+    "--name",
+    "@stsoftware/neat-ai",
+    "--version",
+    "5.8.1",
+    "--meta-file",
+    "/nonexistent/does-not-exist.json",
+  ]);
+  assertEquals(code, 1, "unreachable meta must fail loudly");
+  assertStringIncludes(stderr, "No Sigstore provenance");
+});


### PR DESCRIPTION
## Milestone: #3332 Fix JSR provenance for @stsoftware/neat-ai; best-effort Node runtime compat

This PR merges the completed milestone branch into Develop.
Closes #3338

### Issues addressed
- #3335: Best-effort Node runtime compatibility for @stsoftware/neat-ai (Deno-no-regression guardrail)
- #3334: Make publish pipeline fail loudly when a JSR release has no provenance
- #3333: Fix silent JSR provenance failure: next release must carry a Sigstore attestation (rekorLogId)

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.