### PR TITLE
feat: add RMSE to BUILT_IN_COST_NAMES (NEAT-AI-scorer#340)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.8.2",
+  "version": "5.8.3",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -418,6 +418,7 @@
     "rglob",
     "rhysd",
     "rlib",
+    "rmse",
     "rotl",
     "roundtrip",
     "runlib",

--- a/src/Costs.ts
+++ b/src/Costs.ts
@@ -11,6 +11,7 @@ import { MAE } from "@costs/MAE.ts";
 import { MAPE } from "@costs/MAPE.ts";
 import { MSE } from "@costs/MSE.ts";
 import { MSLE } from "@costs/MSLE.ts";
+import { RMSE } from "@costs/RMSE.ts";
 
 /**
  * Built-in cost names supported by this library.
@@ -22,6 +23,9 @@ import { MSLE } from "@costs/MSLE.ts";
 export const BUILT_IN_COST_NAMES = [
   CrossEntropy.NAME,
   MSE.NAME,
+  // RMSE sits next to MSE: it reuses the MSE squared-error sum and only adds a
+  // host-side `sqrt`, mirroring the rust `CostKind` ordering (NEAT-AI-scorer#340).
+  RMSE.NAME,
   MAE.NAME,
   MAPE.NAME,
   MSLE.NAME,
@@ -64,6 +68,7 @@ export class Costs {
     // Register predefined cost functions using their getName() method
     this.registerFromInstance(new CrossEntropy());
     this.registerFromInstance(new MSE());
+    this.registerFromInstance(new RMSE());
     this.registerFromInstance(new MAE());
     this.registerFromInstance(new MAPE());
     this.registerFromInstance(new MSLE());

--- a/src/config/RustScorerConfig.ts
+++ b/src/config/RustScorerConfig.ts
@@ -5,8 +5,8 @@
  * `rust_scorer` binary for improved throughput on large production datasets.
  *
  * Issue #2745 passes the configured `costName` through to the binary via
- * `--cost <NAME>`. All six `BUILT_IN_COST_NAMES` values — `MSE`, `MAE`,
- * `MAPE`, `MSLE`, `CROSS_ENTROPY`, and `HINGE` — are
+ * `--cost <NAME>`. All seven `BUILT_IN_COST_NAMES` values — `MSE`, `RMSE`,
+ * `MAE`, `MAPE`, `MSLE`, `CROSS_ENTROPY`, and `HINGE` — are
  * eligible for native off-load once the scorer release containing
  * NEAT-AI-scorer#134 is deployed. When the probed binary does not advertise
  * `--cost`, a non-`MSE` cost falls back to WASM scoring; custom (user-

--- a/src/costs/CostDescriptor.ts
+++ b/src/costs/CostDescriptor.ts
@@ -13,7 +13,7 @@
  *
  * | costName               | topology     | range        | output squash family |
  * |------------------------|--------------|--------------|----------------------|
- * | MSE, MAE               | independent  | unbounded    | unbounded            |
+ * | MSE, RMSE, MAE         | independent  | unbounded    | unbounded            |
  * | MAPE, MSLE             | independent  | positive     | positive             |
  * | BINARY_CROSS_ENTROPY   | independent  | unit         | bounded_unipolar     |
  * | CROSS_ENTROPY          | simplex      | unit         | bounded_unipolar     |
@@ -62,6 +62,14 @@ const NEUTRAL_OTHER: TaskDescriptor = Object.freeze({
 const TABLE: Readonly<Record<string, TaskDescriptor>> = Object.freeze({
   MSE: {
     costName: "MSE",
+    topology: "independent",
+    range: "unbounded",
+    outputSquashFamily: "unbounded",
+  },
+  // RMSE is the square root of MSE — monotonic in it and reported in the same
+  // units — so it shares MSE's task characteristics.
+  RMSE: {
+    costName: "RMSE",
     topology: "independent",
     range: "unbounded",
     outputSquashFamily: "unbounded",

--- a/src/costs/CostTaskDescriptor.ts
+++ b/src/costs/CostTaskDescriptor.ts
@@ -115,6 +115,14 @@ const BUILT_IN_DESCRIPTORS: ReadonlyMap<string, TaskDescriptor> = new Map(
       outputSquashFamily: "unbounded",
     },
     {
+      // RMSE is the square root of MSE — monotonic in it and reported in the
+      // same units — so it shares MSE's task characteristics.
+      costName: "RMSE",
+      topology: "independent",
+      range: "unbounded",
+      outputSquashFamily: "unbounded",
+    },
+    {
       costName: "MAE",
       topology: "independent",
       range: "unbounded",

--- a/src/costs/RMSE.ts
+++ b/src/costs/RMSE.ts
@@ -1,0 +1,74 @@
+import type { CostInterface } from "@costs/CostInterface.ts";
+
+/**
+ * Root Mean Squared Error (RMSE) cost function.
+ *
+ * RMSE is the square root of the {@link MSE | Mean Squared Error}. It reports
+ * the error in the same units as the target values, which makes it easier to
+ * interpret than MSE while preserving MSE's heavier penalty on large errors.
+ *
+ * **Formula:** RMSE = √( (1/n) * Σ(y_true - y_pred)² )
+ *
+ * **Characteristics:**
+ * - Same units as the target, so the magnitude is directly interpretable
+ * - Monotonic in MSE — sorting creatures by RMSE and by MSE gives the same
+ *   order — so it reuses the MSE squared-error sum unchanged and only adds a
+ *   host-side `sqrt` at finalisation
+ * - Sensitive to outliers due to the squared term (inherited from MSE)
+ * - Commonly used for regression problems
+ *
+ * **Rust scorer parity:** the native `rust_scorer` binary serves `RMSE` on the
+ * existing MSE GPU kernel with a host-side `sqrt` (NEAT-AI-scorer#339), so
+ * `costName: "RMSE"` runs end-to-end at full MSE speed. This class keeps the
+ * TypeScript `BUILT_IN_COST_NAMES` tuple in sync with the rust `CostKind` list
+ * (NEAT-AI-scorer#340).
+ *
+ * **References:**
+ * - [Wikipedia: Root-mean-square deviation](https://en.wikipedia.org/wiki/Root-mean-square_deviation)
+ * - [Wikipedia: Loss function](https://en.wikipedia.org/wiki/Loss_function)
+ *
+ * @example
+ * ```typescript
+ * const rmse = new RMSE();
+ * const target = new Float32Array([1.0, 2.0, 3.0]);
+ * const output = new Float32Array([0.9, 2.1, 2.8]);
+ * const error = rmse.calculate(target, output);
+ * getLogger().info(error); // Root of the average squared error
+ * ```
+ */
+export class RMSE implements CostInterface {
+  static readonly NAME = "RMSE";
+
+  /**
+   * Returns the name of this cost function.
+   * @returns The string "RMSE"
+   */
+  getName(): string {
+    return RMSE.NAME;
+  }
+
+  /**
+   * Calculates the root mean squared error between target and output arrays.
+   *
+   * Computes the mean squared error and takes its square root, so the result
+   * is always non-negative and reported in the same units as the targets.
+   *
+   * @param target - The true/expected values
+   * @param output - The predicted values
+   * @returns The root mean squared error (always non-negative)
+   *
+   * @throws {Error} If target and output arrays have different lengths
+   */
+  calculate(target: Float32Array, output: Float32Array): number {
+    let error = 0;
+    const len = output.length;
+    const invLen = 1 / len;
+
+    for (let i = len; i--;) {
+      const diff = target[i] - output[i];
+      error += diff * diff;
+    }
+
+    return Math.sqrt(error * invLen);
+  }
+}

--- a/test/architecture/PublicAPI.ts
+++ b/test/architecture/PublicAPI.ts
@@ -93,7 +93,15 @@ Deno.test("Public API: CrisprError is exported and constructable", () => {
 });
 
 Deno.test("Public API: Costs.find returns built-in cost functions", () => {
-  const costNames = ["MSE", "MAE", "MAPE", "MSLE", "CROSS_ENTROPY", "HINGE"];
+  const costNames = [
+    "MSE",
+    "RMSE",
+    "MAE",
+    "MAPE",
+    "MSLE",
+    "CROSS_ENTROPY",
+    "HINGE",
+  ];
   for (const name of costNames) {
     const cost: CostInterface = Costs.find(name);
     assertEquals(cost.getName(), name);

--- a/test/costs/CostName.ts
+++ b/test/costs/CostName.ts
@@ -9,6 +9,7 @@ Deno.test("BUILT_IN_COST_NAMES - should stay in sync with supported costs", () =
   assertEquals(BUILT_IN_COST_NAMES, [
     "CROSS_ENTROPY",
     "MSE",
+    "RMSE",
     "MAE",
     "MAPE",
     "MSLE",

--- a/test/costs/CostsRegistry.ts
+++ b/test/costs/CostsRegistry.ts
@@ -7,6 +7,19 @@ Deno.test("Costs.find - returns MSE instance", () => {
   assertEquals(cost.getName(), "MSE");
 });
 
+Deno.test("Costs.find - returns RMSE instance", () => {
+  const cost = Costs.find("RMSE");
+  assertEquals(cost.getName(), "RMSE");
+});
+
+Deno.test("Costs.find - RMSE equals sqrt of MSE", () => {
+  const target = new Float32Array([1.0, 2.0, 3.0]);
+  const output = new Float32Array([0.5, 2.5, 2.0]);
+  const mse = Costs.find("MSE").calculate(target, output);
+  const rmse = Costs.find("RMSE").calculate(target, output);
+  assertEquals(rmse, Math.sqrt(mse));
+});
+
 Deno.test("Costs.find - returns MAE instance", () => {
   const cost = Costs.find("MAE");
   assertEquals(cost.getName(), "MAE");
@@ -48,6 +61,7 @@ Deno.test("Costs.find - throws for unknown cost", () => {
 Deno.test("Costs.getAvailableCosts - includes all built-in costs", () => {
   const available = Costs.getAvailableCosts();
   assert(available.includes("MSE"), "Should include MSE");
+  assert(available.includes("RMSE"), "Should include RMSE");
   assert(available.includes("MAE"), "Should include MAE");
   assert(available.includes("MAPE"), "Should include MAPE");
   assert(available.includes("MSLE"), "Should include MSLE");


### PR DESCRIPTION
## Summary

Adds a **Root Mean Squared Error** (`RMSE = √MSE`) built-in cost so upstream
config validation accepts `costName: "RMSE"` and passes it through
`NeatOptions.costName` to the native `rust_scorer` binary unchanged. This is the
cross-repo half of **NEAT-AI-scorer#340** — keeping the TypeScript
`BUILT_IN_COST_NAMES` tuple in sync with the rust `CostKind` list.

Companion scorer-side PR (sync-verification test): stSoftwareAU/NEAT-AI-scorer#340.

### What changed

- **`src/costs/RMSE.ts`** — new `RMSE` cost class (`NAME = "RMSE"`), computes
  `√(mean squared error)`. Reuses the MSE formula and takes a `Math.sqrt` at the
  end, so it is monotonic in MSE and reports error in target units.
- **`src/Costs.ts`** — import + register `RMSE`, and add `RMSE.NAME` to
  `BUILT_IN_COST_NAMES` **next to MSE** (mirrors the rust `CostKind` ordering:
  RMSE reuses the MSE squared-error sum + a host-side `sqrt`).
- **`src/config/RustScorerConfig.ts`** — doc comment now enumerates the seven
  pass-through cost names including `RMSE`.
- **Tests** — `test/costs/CostName.ts` sync assertion updated; new
  `Costs.find("RMSE")` + `RMSE == sqrt(MSE)` behaviour tests in
  `test/costs/CostsRegistry.ts`; `getAvailableCosts` and `PublicAPI` coverage
  extended to `RMSE`.

```mermaid
flowchart LR
    A["GRQ costName: RMSE"] --> B["NeatOptions validation<br/>BUILT_IN_COST_NAMES"]
    B --> C["rust_scorer --cost RMSE"]
    C --> D["MSE kernel + host sqrt<br/>(NEAT-AI-scorer#339)"]
```

## Test Plan

- `deno test test/costs/CostName.ts test/costs/CostsRegistry.ts` → 16 passed.
- `deno test test/architecture/PublicAPI.ts` → 20 passed.
- `deno fmt` / `deno lint` clean on changed files.

## Release note

Do **not** auto-merge or publish. A human releases NEAT-AI once reviewed; the
GRQ / scorer end-to-end bump follows the normal dependency-bump flow after the
RMSE-bearing release lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)