### PR TITLE
🟡 Test/lint workflow triggers on push to `Develop` (`.github/workflows/actionlint.yml`) (Issue #3347)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,17 +1,22 @@
 name: Actionlint
 
-# Lint every GitHub Actions workflow file on push and pull request so
-# regressions in `.github/workflows/*.y*ml` fail the build before they
-# merge (Issue #2762). actionlint catches mistyped expressions, missing
-# permission blocks, unsupported runners, shell-script issues inside
-# `run:` blocks, and many other workflow-only foot-guns that no other
-# linter in this repo covers.
+# Lint every GitHub Actions workflow file on pull request so regressions
+# in `.github/workflows/*.y*ml` fail the build before they merge (Issue
+# #2762). actionlint catches mistyped expressions, missing permission
+# blocks, unsupported runners, shell-script issues inside `run:` blocks,
+# and many other workflow-only foot-guns that no other linter in this repo
+# covers.
+#
+# This is a PR gate, not a deploy/release workflow, so it no longer fires
+# on push to the default branch (`Develop`). The PR run already gated the
+# change; re-running on the post-merge push just duplicated that work,
+# wasting CI minutes and risking a red tick on `Develop` for a check that
+# already passed (Issue #3347). `workflow_dispatch` keeps a manual trigger.
 
 on:
   pull_request:
     branches: ["*"]
-  push:
-    branches: [Develop, main, master]
+  workflow_dispatch:
 
 # Cancel superseded runs on the same ref so rapid successive pushes don't
 # pile up redundant lint runs (Issue #2842).

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.8.3",
+  "version": "5.8.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3347.md
+++ b/docs/archive/pr-summaries/pr-summary-3347.md
@@ -1,0 +1,70 @@
+## Summary
+
+`.github/workflows/actionlint.yml` is a **checker** (it lints workflow files),
+not a deploy/publish/release workflow. It was triggering on `push` to the
+default branch (`Develop`, plus `main`/`master`), so every merge into `Develop`
+re-ran the exact lint that had already gated the pull request. That duplicate
+post-merge run wasted CI minutes and could leave a red tick on `Develop` for a
+check that already passed on the PR.
+
+The fix drops the `push:` trigger and keeps the PR gate, adding
+`workflow_dispatch` so the linter can still be run manually. Deploy/release
+workflows (`publish.yml`, `github-release.yml`) are intentionally left firing on
+push — only the checker changes. Closes #3347.
+
+### Trigger change
+
+```mermaid
+flowchart LR
+    subgraph Before
+        PR1[Open / update PR] --> Run1[actionlint runs]
+        Merge1[Merge to Develop] --> Run2[actionlint runs again<br/>duplicate, wasted CI]
+    end
+    subgraph After
+        PR2[Open / update PR] --> Run3[actionlint runs]
+        Merge2[Merge to Develop] --> NoRun[no re-run]
+        Manual[workflow_dispatch] --> Run4[actionlint runs on demand]
+    end
+```
+
+`on:` block after the change:
+
+```yaml
+on:
+  pull_request:
+    branches: ["*"]
+  workflow_dispatch:
+```
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+`test/ci/ActionlintWorkflow.ts` suite, which parses the workflow YAML and
+asserts its shape:
+
+```
+running 5 tests from ./test/ci/ActionlintWorkflow.ts
+actionlint workflow file exists (Issue #2762) ... ok
+actionlint workflow triggers on pull_request but not push (Issue #3347) ... ok
+actionlint workflow declares read-only contents permission (Issue #2762) ... ok
+actionlint workflow invokes the actionlint linter (Issue #2762) ... ok
+actionlint workflow checks out the repository before linting (Issue #2762) ... ok
+ok | 5 passed | 0 failed
+```
+
+Full `test/ci/` suite: `133 passed | 0 failed`. In particular
+`WorkflowConcurrencyGroup.ts` (which still lists `actionlint.yml` as a
+PR-triggered, pile-up-prone workflow) continues to pass because the
+`concurrency:` block is unchanged.
+
+## Test Plan
+
+- Updated `test/ci/ActionlintWorkflow.ts`: the trigger test now asserts the
+  workflow triggers on `pull_request` but **not** on `push` (renamed to
+  "actionlint workflow triggers on pull_request but not push (Issue #3347)").
+  This is a deliberate business-logic change — the old test asserted `push` was
+  present, which is exactly the behaviour the issue asks to remove. Against the
+  pre-fix workflow the updated assertion fails; against the fixed workflow it
+  passes, so it acts as a regression test.
+- Ran `deno fmt`, `deno lint`, and `deno check` on the changed test file — all
+  clean.

--- a/test/ci/ActionlintWorkflow.ts
+++ b/test/ci/ActionlintWorkflow.ts
@@ -13,7 +13,10 @@
  * cannot be silently removed or downgraded:
  *
  *   1. The file exists at `.github/workflows/actionlint.yml`.
- *   2. It triggers on both `pull_request` and `push`.
+ *   2. It triggers on `pull_request` (the PR gate) but NOT on `push` —
+ *      this is a checker, not a deploy/release workflow, so it must not
+ *      re-run on push to the default branch (`Develop`) and duplicate the
+ *      run that already gated the PR (Issue #3347).
  *   3. At least one job runs the `actionlint` binary (either via an
  *      action wrapper or by invoking the binary directly).
  *   4. It declares a read-only `contents: read` permission block so the
@@ -57,18 +60,20 @@ Deno.test("actionlint workflow file exists (Issue #2762)", async () => {
 });
 
 Deno.test(
-  "actionlint workflow triggers on both pull_request and push (Issue #2762)",
+  "actionlint workflow triggers on pull_request but not push (Issue #3347)",
   async () => {
     const wf = await readWorkflow();
     assert(wf.on, "actionlint workflow must declare an `on:` trigger");
     const triggers = wf.on as Record<string, unknown>;
     assert(
       "pull_request" in triggers,
-      "actionlint workflow must trigger on pull_request",
+      "actionlint workflow must trigger on pull_request (the PR gate)",
     );
     assert(
-      "push" in triggers,
-      "actionlint workflow must trigger on push",
+      !("push" in triggers),
+      "actionlint is a checker, not a deploy workflow: it must NOT trigger " +
+        "on push, so it does not duplicate the PR run on merge to Develop " +
+        "(Issue #3347)",
     );
   },
 );


### PR DESCRIPTION
## Summary

`.github/workflows/actionlint.yml` is a **checker** (it lints workflow files),
not a deploy/publish/release workflow. It was triggering on `push` to the
default branch (`Develop`, plus `main`/`master`), so every merge into `Develop`
re-ran the exact lint that had already gated the pull request. That duplicate
post-merge run wasted CI minutes and could leave a red tick on `Develop` for a
check that already passed on the PR.

The fix drops the `push:` trigger and keeps the PR gate, adding
`workflow_dispatch` so the linter can still be run manually. Deploy/release
workflows (`publish.yml`, `github-release.yml`) are intentionally left firing on
push — only the checker changes. Closes #3347.

### Trigger change

```mermaid
flowchart LR
    subgraph Before
        PR1[Open / update PR] --> Run1[actionlint runs]
        Merge1[Merge to Develop] --> Run2[actionlint runs again<br/>duplicate, wasted CI]
    end
    subgraph After
        PR2[Open / update PR] --> Run3[actionlint runs]
        Merge2[Merge to Develop] --> NoRun[no re-run]
        Manual[workflow_dispatch] --> Run4[actionlint runs on demand]
    end
```

`on:` block after the change:

```yaml
on:
  pull_request:
    branches: ["*"]
  workflow_dispatch:
```

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via the
`test/ci/ActionlintWorkflow.ts` suite, which parses the workflow YAML and
asserts its shape:

```
running 5 tests from ./test/ci/ActionlintWorkflow.ts
actionlint workflow file exists (Issue #2762) ... ok
actionlint workflow triggers on pull_request but not push (Issue #3347) ... ok
actionlint workflow declares read-only contents permission (Issue #2762) ... ok
actionlint workflow invokes the actionlint linter (Issue #2762) ... ok
actionlint workflow checks out the repository before linting (Issue #2762) ... ok
ok | 5 passed | 0 failed
```

Full `test/ci/` suite: `133 passed | 0 failed`. In particular
`WorkflowConcurrencyGroup.ts` (which still lists `actionlint.yml` as a
PR-triggered, pile-up-prone workflow) continues to pass because the
`concurrency:` block is unchanged.

## Test Plan

- Updated `test/ci/ActionlintWorkflow.ts`: the trigger test now asserts the
  workflow triggers on `pull_request` but **not** on `push` (renamed to
  "actionlint workflow triggers on pull_request but not push (Issue #3347)").
  This is a deliberate business-logic change — the old test asserted `push` was
  present, which is exactly the behaviour the issue asks to remove. Against the
  pre-fix workflow the updated assertion fails; against the fixed workflow it
  passes, so it acts as a regression test.
- Ran `deno fmt`, `deno lint`, and `deno check` on the changed test file — all
  clean.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrm85cum-a733eb`<!-- vibe-worker-issue-3347 -->