### PR TITLE
Stop Markdown Lint checker re-running on push to Develop (Issue #3348)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -3,8 +3,12 @@ name: Markdown Lint
 on:
   pull_request:
     branches: ["*"]
+  # Lint gates the pull request only. It must NOT re-run on push to the default
+  # branch (Develop) — that merge already passed this check on the PR, so the
+  # post-merge run is a duplicate that wastes CI minutes (Issue #3348). Keep
+  # push for non-default branches so direct pushes there are still linted.
   push:
-    branches: [Develop, main, master]
+    branches: [main, master]
 
 # Cancel superseded runs on the same ref so rapid successive pushes don't
 # pile up redundant lint runs (Issue #2842).

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.8.4",
+  "version": "5.8.5",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3348.md
+++ b/docs/archive/pr-summaries/pr-summary-3348.md
@@ -1,0 +1,58 @@
+# Stop the Markdown Lint checker re-running on push to `Develop`
+
+## Summary
+
+The Markdown Lint workflow (`.github/workflows/markdown-lint.yml`) is a
+test/lint **checker** — it gates the pull request. It still triggered on `push:`
+to the default branch `Develop`, so every merge into `Develop` re-ran a lint
+that had already passed on the PR. That duplicate post-merge run wastes CI
+minutes and can leave a red tick on the default branch for a check that already
+passed.
+
+This change drops `Develop` from the workflow's `push.branches` filter, keeping
+the `pull_request` trigger (the PR gate) and the `main`/`master` push triggers
+(so direct pushes to non-default branches are still linted). Deploy/publish
+workflows are untouched — they must keep firing on push to the default branch.
+
+Closes #3348.
+
+## Evidence
+
+Backend/CI-config change only — there is no web interface to screenshot.
+Verified via a new "what" test that parses the committed workflow YAML and
+asserts on the resulting trigger configuration.
+
+```mermaid
+flowchart LR
+    PR[Pull request] -->|pull_request| Lint[Markdown Lint]
+    Merge[Merge into Develop] -.->|push: Develop REMOVED| Lint
+    Push[Push to main/master] -->|push| Lint
+```
+
+Before → after `on:` block:
+
+```yaml
+# before
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [Develop, main, master]
+
+# after
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master]
+```
+
+## Test Plan
+
+- Added `test/ci/CheckerWorkflowNoDefaultBranchPush.ts`, which parses
+  `markdown-lint.yml` and asserts its `push.branches` filter excludes the
+  default branch `Develop` (and rejects catch-all globs that would match it).
+  This fails against the unfixed workflow and passes after the fix.
+- Confirmed `test/ci/WorkflowConcurrencyGroup.ts` still passes — the
+  `concurrency:` hardening from Issue #2842 is unaffected.
+- Ran `./quality.sh` and confirmed a clean pass.

--- a/test/ci/CheckerWorkflowNoDefaultBranchPush.ts
+++ b/test/ci/CheckerWorkflowNoDefaultBranchPush.ts
@@ -1,0 +1,85 @@
+import { assert } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verifies that test/lint/scan (checker) workflows do NOT trigger on `push:`
+ * to the default branch `Develop` (Issue #3348 — finding
+ * `BP-TRIGGER-markdown-lint`).
+ *
+ * A checker workflow gates the pull request. Once it is a required status
+ * check, letting it also fire on `push: Develop` re-runs it on every merge
+ * into the default branch — a duplicate of the run that already gated the PR.
+ * The post-merge run wastes CI minutes and can leave a red tick on the
+ * default branch for a check that already passed on the PR.
+ *
+ * Deploy/publish/release workflows are deliberately excluded: they MUST keep
+ * firing on `push: Develop` to release from the default branch. This test only
+ * constrains checkers.
+ *
+ * This is a "what" test: it parses the committed workflow YAML and asserts on
+ * the resulting trigger configuration, not on how the value is written.
+ */
+
+interface PushTrigger {
+  branches?: string[];
+}
+
+interface OnBlock {
+  push?: PushTrigger | null;
+}
+
+interface Workflow {
+  on?: OnBlock;
+}
+
+const WORKFLOW_DIR = ".github/workflows";
+const DEFAULT_BRANCH = "Develop";
+
+// Test/lint/scan workflows that gate the PR. None of these should re-run on a
+// push to the default branch.
+const CHECKER_WORKFLOWS = [
+  "markdown-lint.yml",
+];
+
+async function readWorkflow(name: string): Promise<Workflow> {
+  const text = await Deno.readTextFile(`${WORKFLOW_DIR}/${name}`);
+  return parse(text) as Workflow;
+}
+
+for (const name of CHECKER_WORKFLOWS) {
+  Deno.test(
+    `${name} does not trigger on push to the default branch ${DEFAULT_BRANCH} (Issue #3348)`,
+    async () => {
+      const wf = await readWorkflow(name);
+      const push = wf.on?.push;
+
+      // No push trigger at all is fine — the checker gates the PR only.
+      if (push === undefined || push === null) return;
+
+      const branches = push.branches;
+      assert(
+        Array.isArray(branches),
+        `${name}: push trigger must declare an explicit branches filter so it ` +
+          `cannot reach the default branch ${DEFAULT_BRANCH}; got: ${
+            JSON.stringify(branches)
+          }`,
+      );
+
+      assert(
+        !branches.includes(DEFAULT_BRANCH),
+        `${name}: checker workflow must not run on push to the default branch ` +
+          `${DEFAULT_BRANCH} — it already gated the PR. Drop ${DEFAULT_BRANCH} ` +
+          `from the push.branches filter. Got: ${JSON.stringify(branches)}`,
+      );
+
+      // A bare "*" glob matches the default branch too.
+      assert(
+        !branches.includes("*") && !branches.includes("**"),
+        `${name}: push.branches must not use a catch-all glob (${
+          JSON.stringify(branches)
+        }) ` +
+          `that also matches the default branch ${DEFAULT_BRANCH}`,
+      );
+    },
+  );
+}


### PR DESCRIPTION
# Stop the Markdown Lint checker re-running on push to `Develop`

## Summary

The Markdown Lint workflow (`.github/workflows/markdown-lint.yml`) is a
test/lint **checker** — it gates the pull request. It still triggered on `push:`
to the default branch `Develop`, so every merge into `Develop` re-ran a lint
that had already passed on the PR. That duplicate post-merge run wastes CI
minutes and can leave a red tick on the default branch for a check that already
passed.

This change drops `Develop` from the workflow's `push.branches` filter, keeping
the `pull_request` trigger (the PR gate) and the `main`/`master` push triggers
(so direct pushes to non-default branches are still linted). Deploy/publish
workflows are untouched — they must keep firing on push to the default branch.

Closes #3348.

## Evidence

Backend/CI-config change only — there is no web interface to screenshot.
Verified via a new "what" test that parses the committed workflow YAML and
asserts on the resulting trigger configuration.

```mermaid
flowchart LR
    PR[Pull request] -->|pull_request| Lint[Markdown Lint]
    Merge[Merge into Develop] -.->|push: Develop REMOVED| Lint
    Push[Push to main/master] -->|push| Lint
```

Before → after `on:` block:

```yaml
# before
on:
  pull_request:
    branches: ["*"]
  push:
    branches: [Develop, main, master]

# after
on:
  pull_request:
    branches: ["*"]
  push:
    branches: [main, master]
```

## Test Plan

- Added `test/ci/CheckerWorkflowNoDefaultBranchPush.ts`, which parses
  `markdown-lint.yml` and asserts its `push.branches` filter excludes the
  default branch `Develop` (and rejects catch-all globs that would match it).
  This fails against the unfixed workflow and passes after the fix.
- Confirmed `test/ci/WorkflowConcurrencyGroup.ts` still passes — the
  `concurrency:` hardening from Issue #2842 is unaffected.
- Ran `./quality.sh` and confirmed a clean pass.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrm85cum-a733eb`<!-- vibe-worker-issue-3348 -->