### PR TITLE
Cache-first WASM activation bundle loading (backoff retry on cache miss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,21 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Issue #3419 (recurrence of #3230):** WASM activation bundle loading is now
+  cache-first, removing the runtime network dependency on process start. The
+  loader previously let wasm-bindgen fetch
+  `wasm_activation/pkg/wasm_activation_bg.wasm` from jsr.io on **every** start,
+  so a transient DNS/network blip left the bundle unloaded and later crashed
+  breeding uncaught in `WasmTopologyOps.validateTopology` → `requireWasm`. The
+  bundle for a given version is immutable, so the network is only needed when
+  the version changes. `initWasmActivation` now loads the bytes via
+  `loadWasmBundleBytes` (`src/wasm/WasmBundleCache.ts`): a JSR (`https:`)
+  install reads the bytes from a version-keyed on-disk cache with **no network**
+  on a cache hit, and a cache miss fetches with **bounded exponential backoff**
+  before erroring; the fetched bytes are persisted for the next start. Local
+  (`file:`) checkouts are unchanged (direct read, no cache). Fail-loud is
+  preserved: when the bytes genuinely cannot be obtained, the existing "requires
+  the NEAT-AI-core WASM bundle" error still surfaces.
 - **Issue #2871:** Evolution now always finalizes even when an optional training
   task never settles. Training is a best-effort phase, but the finish-up loop in
   `Neat.finishUp()` only bounded the wait for _discovery_ tasks — the _training_

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.8.6",
+  "version": "5.9.0",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.8.5",
+  "version": "5.8.6",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.8.4",
+  "version": "5.8.5",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/src/wasm/WasmBundleCache.ts
+++ b/src/wasm/WasmBundleCache.ts
@@ -1,0 +1,259 @@
+/**
+ * Cache-first WASM activation bundle loading.
+ *
+ * Issue #3419 / recurrence of #3230: NEAT-AI fetched its WASM activation bundle
+ * (`wasm_activation/pkg/wasm_activation_bg.wasm`) from jsr.io at runtime on
+ * every process start. A transient DNS/network failure at startup left the
+ * bundle unloaded and later crashed breeding uncaught in
+ * `WasmTopologyOps.validateTopology`.
+ *
+ * The bundle for a given NEAT-AI version is immutable, so the network is only
+ * genuinely needed when the version changes. This module makes bundle loading
+ * cache-first:
+ *
+ *  - The bytes are cached on disk keyed by the *versioned* bundle URL (a JSR
+ *    URL embeds the package version, so a version bump changes the key).
+ *  - On startup the bytes are read from that cache with **no network access**
+ *    when the cached version matches the running version (cache hit).
+ *  - A cache miss triggers a fetch that **retries with bounded backoff** before
+ *    giving up, so a single transient DNS/network blip no longer aborts start.
+ *  - Local (`file:`) builds read the vendored bundle directly — no cache, no
+ *    network.
+ *
+ * Fail-loud (Issue #3234): if the bytes genuinely cannot be obtained, the last
+ * error is thrown so the caller (`initWasmActivation`) records it and the
+ * existing "requires the NEAT-AI-core WASM bundle" guard still surfaces.
+ */
+
+import { dirname, fromFileUrl, join } from "@std/path";
+import { getLogger } from "@utils/Logger.ts";
+
+/** Options for {@link loadWasmBundleBytes}; all are injectable for testing. */
+export interface LoadWasmBundleOptions {
+  /** Fetch implementation. Defaults to the global `fetch`. */
+  fetchFn?: typeof fetch;
+  /** Sleep between retry attempts. Defaults to a real `setTimeout` delay. */
+  sleepFn?: (ms: number) => Promise<void>;
+  /**
+   * Maximum number of fetch attempts on a cache miss (the first try plus
+   * retries). Must be at least 1. Defaults to {@link DEFAULT_MAX_ATTEMPTS}.
+   */
+  maxAttempts?: number;
+  /** Base backoff delay in milliseconds. Defaults to {@link DEFAULT_BASE_DELAY_MS}. */
+  baseDelayMs?: number;
+  /**
+   * Override the cache directory. When omitted it is derived from the
+   * environment (`NEAT_AI_WASM_CACHE_DIR`, then the platform cache dir).
+   */
+  cacheDir?: string;
+}
+
+/** Default bounded number of fetch attempts on a cache miss. */
+export const DEFAULT_MAX_ATTEMPTS = 5;
+
+/** Default base backoff delay in milliseconds (doubles each attempt). */
+export const DEFAULT_BASE_DELAY_MS = 250;
+
+/** Real sleep used when no `sleepFn` is injected. */
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Resolve the base directory used to cache WASM bundles.
+ *
+ * Prefers `NEAT_AI_WASM_CACHE_DIR`, then the platform cache directory
+ * (`XDG_CACHE_HOME`, `HOME/.cache`, or `LOCALAPPDATA` on Windows). Returns
+ * `null` when no directory can be determined or environment access is denied —
+ * in which case caching is skipped and loading falls back to a plain
+ * fetch-with-retry.
+ */
+export function resolveCacheDir(override?: string): string | null {
+  if (override !== undefined && override !== "") {
+    return override;
+  }
+  try {
+    const explicit = Deno.env.get("NEAT_AI_WASM_CACHE_DIR");
+    if (explicit) {
+      return explicit;
+    }
+    const xdg = Deno.env.get("XDG_CACHE_HOME");
+    if (xdg) {
+      return join(xdg, "neat-ai", "wasm");
+    }
+    if (Deno.build.os === "windows") {
+      const local = Deno.env.get("LOCALAPPDATA");
+      if (local) {
+        return join(local, "neat-ai", "wasm");
+      }
+    }
+    const home = Deno.env.get("HOME");
+    if (home) {
+      return join(home, ".cache", "neat-ai", "wasm");
+    }
+  } catch {
+    // Environment access denied — degrade to no caching.
+  }
+  return null;
+}
+
+/** Lowercase hex encoding of a byte array. */
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) {
+    out += b.toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+/**
+ * Compute the version-keyed cache file path for a bundle URL.
+ *
+ * The key is a SHA-256 of the full bundle URL. A JSR URL embeds the package
+ * version (`.../@stsoftware/neat-ai/<version>/...`), so a version change yields
+ * a different key and therefore a cache miss — exactly when a fresh fetch is
+ * warranted.
+ */
+export async function wasmCacheFilePath(
+  wasmUrl: URL,
+  cacheDir: string,
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(wasmUrl.href),
+  );
+  const key = toHex(new Uint8Array(digest));
+  return join(cacheDir, `${key}.wasm`);
+}
+
+/** Read cached bytes, or `null` when the file is absent. Rethrows real errors. */
+async function readCache(path: string): Promise<Uint8Array | null> {
+  try {
+    return await Deno.readFile(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return null;
+    }
+    // A permission or IO error is not a cache miss — log and skip the cache,
+    // but do not mask it as success.
+    getLogger().warn(
+      `WASM bundle cache: unreadable cache entry at ${path}:`,
+      error,
+    );
+    return null;
+  }
+}
+
+/**
+ * Atomically write bytes to the cache. Best-effort: a write failure (e.g.
+ * read-only cache dir) is logged but never fatal — the freshly-fetched bytes
+ * are still returned to the caller.
+ */
+async function writeCache(path: string, bytes: Uint8Array): Promise<void> {
+  try {
+    const dir = dirname(path);
+    await Deno.mkdir(dir, { recursive: true });
+    // Write to a unique temp file in the same dir, then rename for atomicity.
+    const tmp = await Deno.makeTempFile({ dir, suffix: ".wasm.tmp" });
+    await Deno.writeFile(tmp, bytes);
+    await Deno.rename(tmp, path);
+  } catch (error) {
+    getLogger().warn(
+      `WASM bundle cache: could not persist bundle to ${path}:`,
+      error,
+    );
+  }
+}
+
+/** Fetch the bundle bytes with bounded exponential backoff. Fails loud. */
+async function fetchWithRetry(
+  wasmUrl: URL,
+  fetchFn: typeof fetch,
+  sleepFn: (ms: number) => Promise<void>,
+  maxAttempts: number,
+  baseDelayMs: number,
+): Promise<Uint8Array> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      // deno-lint-ignore no-await-in-loop -- retries are inherently sequential.
+      const response = await fetchFn(wasmUrl);
+      if (!response.ok) {
+        throw new Error(
+          `WASM bundle fetch failed: HTTP ${response.status} for ${wasmUrl.href}`,
+        );
+      }
+      // deno-lint-ignore no-await-in-loop -- sequential by design.
+      const buffer = await response.arrayBuffer();
+      return new Uint8Array(buffer);
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxAttempts) {
+        const delay = baseDelayMs * 2 ** (attempt - 1);
+        getLogger().warn(
+          `WASM bundle fetch attempt ${attempt}/${maxAttempts} failed for ` +
+            `${wasmUrl.href}; retrying in ${delay}ms:`,
+          error,
+        );
+        // deno-lint-ignore no-await-in-loop -- backoff must pause between tries.
+        await sleepFn(delay);
+      }
+    }
+  }
+  // Fail loud: surface the real network cause after exhausting retries.
+  throw new Error(
+    `WASM bundle could not be fetched from ${wasmUrl.href} after ` +
+      `${maxAttempts} attempt(s)`,
+    { cause: lastError },
+  );
+}
+
+/**
+ * Load the WASM activation bundle bytes, cache-first.
+ *
+ * - `file:` URL → read the vendored bundle directly (local build); no cache.
+ * - otherwise → return cached bytes when present (no network), else
+ *   fetch-with-backoff and persist to the version-keyed cache.
+ *
+ * @throws when the bytes genuinely cannot be obtained (fail-loud).
+ */
+export async function loadWasmBundleBytes(
+  wasmUrl: URL,
+  options: LoadWasmBundleOptions = {},
+): Promise<Uint8Array> {
+  // Local build: the bundle is on disk beside the JS glue. No cache/network.
+  if (wasmUrl.protocol === "file:") {
+    return await Deno.readFile(fromFileUrl(wasmUrl));
+  }
+
+  const fetchFn = options.fetchFn ?? fetch;
+  const sleepFn = options.sleepFn ?? defaultSleep;
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+
+  const cacheDir = resolveCacheDir(options.cacheDir);
+  const cachePath = cacheDir === null
+    ? null
+    : await wasmCacheFilePath(wasmUrl, cacheDir);
+
+  // Cache hit: return the immutable bundle with no network access.
+  if (cachePath !== null) {
+    const cached = await readCache(cachePath);
+    if (cached !== null) {
+      return cached;
+    }
+  }
+
+  // Cache miss: fetch with backoff, then persist for the next start.
+  const bytes = await fetchWithRetry(
+    wasmUrl,
+    fetchFn,
+    sleepFn,
+    maxAttempts,
+    baseDelayMs,
+  );
+  if (cachePath !== null) {
+    await writeCache(cachePath, bytes);
+  }
+  return bytes;
+}

--- a/src/wasm/WasmModuleLoader.ts
+++ b/src/wasm/WasmModuleLoader.ts
@@ -12,6 +12,7 @@
 
 import { getLogger } from "@utils/Logger.ts";
 import type { WasmCompiledNetworkConstructor } from "@wasm/WasmCompiledNetwork.ts";
+import { loadWasmBundleBytes } from "@wasm/WasmBundleCache.ts";
 
 // deno-lint-ignore no-explicit-any
 type WasmModule = any;
@@ -495,7 +496,25 @@ export async function initWasmActivation(): Promise<boolean> {
         new URL("../../wasm_activation/pkg/wasm_activation.js", import.meta.url)
           .href;
       const module = await import(modulePath);
-      await module.default();
+      const wasmUrl = new URL(
+        "../../wasm_activation/pkg/wasm_activation_bg.wasm",
+        import.meta.url,
+      );
+      if (wasmUrl.protocol === "file:") {
+        // Local build: the vendored bundle is on disk beside the JS glue.
+        // wasm-bindgen's default init reads it directly (no network) and names
+        // the WASM module after the file for readable trap stacks.
+        await module.default();
+      } else {
+        // Issue #3419: cache-first bundle loading for remote (JSR) installs.
+        // Read the immutable, version-keyed bundle from the local cache (no
+        // network) when present, otherwise fetch-with-backoff and persist it.
+        // Passing the bytes to the init avoids wasm-bindgen's default
+        // fetch-at-startup from jsr.io, which crashed breeding on a transient
+        // DNS failure (recurrence of #3230).
+        const wasmBytes = await loadWasmBundleBytes(wasmUrl);
+        await module.default({ module_or_path: wasmBytes });
+      }
       assignFunctionPointers(module);
       lastLoadError = null;
       return true;

--- a/test/wasm/WasmBundleCache.ts
+++ b/test/wasm/WasmBundleCache.ts
@@ -1,0 +1,156 @@
+/**
+ * Issue #3419 — Cache-first WASM activation bundle loading.
+ *
+ * These tests exercise {@link loadWasmBundleBytes} directly with an injected
+ * fetch/sleep and a temporary cache directory, covering the three acceptance
+ * scenarios:
+ *   1. cache hit, offline — pre-seeded cache, fetch denied, zero network;
+ *   2. cache miss + transient failure — first fetch rejects with a DNS-style
+ *      `TypeError: fetch failed`, backoff retry succeeds, cache is written;
+ *   3. cache miss + exhausted retries — all attempts fail, bounded attempts,
+ *      the fetch error surfaces (fail-loud, preserved by `requireWasm`).
+ */
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  loadWasmBundleBytes,
+  wasmCacheFilePath,
+} from "@wasm/WasmBundleCache.ts";
+
+const BUNDLE_URL = new URL(
+  "https://jsr.io/@stsoftware/neat-ai/9.9.9/wasm_activation/pkg/wasm_activation_bg.wasm",
+);
+
+/** A fetch that fails the test if it is ever called. */
+function denyFetch(): typeof fetch {
+  return (() => {
+    throw new Error("network access attempted on a cache hit");
+  }) as unknown as typeof fetch;
+}
+
+/** A Response carrying the given bytes. */
+function bytesResponse(bytes: Uint8Array): Response {
+  return new Response(bytes as unknown as BodyInit, { status: 200 });
+}
+
+/** No-op sleep so backoff adds no real delay in tests. */
+const noSleep = (_ms: number): Promise<void> => Promise.resolve();
+
+Deno.test("WasmBundleCache: cache hit loads offline with no network", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const seeded = new Uint8Array([1, 2, 3, 4, 5]);
+    const cachePath = await wasmCacheFilePath(BUNDLE_URL, cacheDir);
+    await Deno.writeFile(cachePath, seeded);
+
+    const bytes = await loadWasmBundleBytes(BUNDLE_URL, {
+      cacheDir,
+      fetchFn: denyFetch(),
+      sleepFn: noSleep,
+    });
+
+    assertEquals(bytes, seeded, "cached bytes should be returned verbatim");
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmBundleCache: cache miss retries with backoff then succeeds and caches", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const payload = new Uint8Array([9, 8, 7, 6]);
+    let attempts = 0;
+    const delays: number[] = [];
+
+    const fetchFn = ((_url: URL) => {
+      attempts++;
+      if (attempts === 1) {
+        // DNS-style transient failure on the first attempt.
+        return Promise.reject(new TypeError("fetch failed"));
+      }
+      return Promise.resolve(bytesResponse(payload));
+    }) as unknown as typeof fetch;
+
+    const bytes = await loadWasmBundleBytes(BUNDLE_URL, {
+      cacheDir,
+      fetchFn,
+      sleepFn: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+      maxAttempts: 5,
+      baseDelayMs: 10,
+    });
+
+    assertEquals(bytes, payload, "retried fetch should return the payload");
+    assertEquals(attempts, 2, "should succeed on the second attempt");
+    assertEquals(delays, [10], "should back off once before the retry");
+
+    // The cache is written so the next start is offline.
+    const cachePath = await wasmCacheFilePath(BUNDLE_URL, cacheDir);
+    const persisted = await Deno.readFile(cachePath);
+    assertEquals(persisted, payload, "fetched bundle should be persisted");
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmBundleCache: cache miss with exhausted retries fails loud", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    let attempts = 0;
+    const fetchFn = ((_url: URL) => {
+      attempts++;
+      return Promise.reject(new TypeError("fetch failed"));
+    }) as unknown as typeof fetch;
+
+    const error = await assertRejects(
+      () =>
+        loadWasmBundleBytes(BUNDLE_URL, {
+          cacheDir,
+          fetchFn,
+          sleepFn: noSleep,
+          maxAttempts: 3,
+          baseDelayMs: 1,
+        }),
+      Error,
+      "could not be fetched",
+    );
+
+    // Bounded attempts — exactly maxAttempts tries, no unbounded looping.
+    assertEquals(attempts, 3, "should stop after the bounded attempt count");
+    // The real network cause is attached for fail-loud diagnostics.
+    assert(error.cause instanceof TypeError, "underlying cause is preserved");
+    assertEquals(
+      (error.cause as TypeError).message,
+      "fetch failed",
+      "cause carries the DNS-style fetch failure",
+    );
+
+    // Nothing was cached on a total failure.
+    const cachePath = await wasmCacheFilePath(BUNDLE_URL, cacheDir);
+    await assertRejects(
+      () => Deno.readFile(cachePath),
+      Deno.errors.NotFound,
+    );
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmBundleCache: file URL reads local bundle without caching", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const local = new Uint8Array([42, 43, 44]);
+    const filePath = `${dir}/wasm_activation_bg.wasm`;
+    await Deno.writeFile(filePath, local);
+
+    const bytes = await loadWasmBundleBytes(
+      new URL(`file://${filePath}`),
+      { fetchFn: denyFetch(), sleepFn: noSleep },
+    );
+    assertEquals(bytes, local, "local file bundle should load directly");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Makes WASM activation bundle loading **cache-first**, removing NEAT-AI's runtime
network dependency on process start. This is a recurrence of #3230 (closed at
5.7.12; the runtime dependency survived to 5.8.3).

Previously `initWasmActivation` let wasm-bindgen fetch
`wasm_activation/pkg/wasm_activation_bg.wasm` from **jsr.io on every start**. On
GRQ-12 a transient DNS failure left the bundle unloaded and ~41s later crashed
breeding uncaught in `WasmTopologyOps.validateTopology` → `requireWasm`:

```
Failed to initialise WASM activation module: TypeError: fetch failed
  dns error: failed to lookup address information: Temporary failure in name resolution
error: Uncaught (in promise) Error: WasmTopologyOps.validateTopology requires the
  NEAT-AI-core WASM bundle, but it could not be loaded
```

The bundle for a given version is immutable, so the network is only genuinely
needed when the version changes.

### Change

- New `src/wasm/WasmBundleCache.ts` exporting `loadWasmBundleBytes(wasmUrl)`:
  - **`file:` URL** (local checkout) → read the vendored bundle directly; no
    cache, no network. `initWasmActivation` keeps calling `module.default()`
    for local builds so trap stacks stay named after the file.
  - **`https:` URL** (JSR install) → return **version-keyed cached bytes** with
    **no network** on a cache hit; on a cache miss, **fetch with bounded
    exponential backoff** (default 5 attempts) and persist the bytes for the
    next start.
- `initWasmActivation` (`src/wasm/WasmModuleLoader.ts`) now feeds those bytes to
  the wasm-bindgen init for remote installs, avoiding the default
  fetch-at-startup.
- **Fail-loud preserved (#3234):** when the bytes genuinely cannot be obtained,
  the fetch error is thrown, recorded as `lastLoadError`, and the existing
  "requires the NEAT-AI-core WASM bundle" guard still surfaces — no silent skip
  of 4.x validation.

The cache key is a SHA-256 of the full bundle URL; a JSR URL embeds the package
version, so a version bump changes the key → cache miss → fetch. The cache dir is
`NEAT_AI_WASM_CACHE_DIR`, else the platform cache dir (`XDG_CACHE_HOME` /
`HOME/.cache` / `LOCALAPPDATA`).

```mermaid
flowchart TD
    A[initWasmActivation] --> B{bundle URL protocol}
    B -->|file:| C[module.default&#40;&#41; reads local file] --> H[assign fn pointers]
    B -->|https:| D{version-keyed cache hit?}
    D -->|yes| E[read cached bytes<br/>NO network] --> G[module.default&#40;bytes&#41;]
    D -->|no| F[fetch with bounded backoff retry]
    F -->|success| F2[persist to cache] --> G
    F -->|all attempts fail| X[throw &rarr; lastLoadError &rarr;<br/>requireWasm fails loud]
    G --> H
```

## Scope note

This fixes the **main-thread** loader path (`WasmModuleLoader` →
`WasmTopologyOps.validateTopology`) named in the crash and acceptance criteria.
The separate worker-payload fetch (`loadWasmActivationInitPayloadAsync` in
`src/workers/WasmActivationPayload.ts`) also fetches the JS glue from jsr.io and
is intentionally left unchanged here.

## Test Plan

New `test/wasm/WasmBundleCache.ts` (exercises `loadWasmBundleBytes` directly with
injected fetch/sleep and a temp cache dir):

- **cache hit, offline** — pre-seed the version-keyed cache, deny `fetch`, assert
  bytes load with zero network calls.
- **cache miss + transient failure** — first fetch rejects with a DNS-style
  `TypeError: fetch failed`; assert backoff retry succeeds and the cache is
  written.
- **cache miss + exhausted retries** — all attempts fail; assert bounded attempt
  count and the fetch error surfaces with the real cause attached (fail-loud).
- **file URL** — reads the local bundle directly without caching.

Existing guards stay green: `test/wasm/WasmModuleLoader.ts`,
`test/wasm/WasmTopologyOpsRequireWasm.ts`, and
`test/wasm/WasmCreatureActivationCreateTrapGuard.ts`. Full `test/wasm/*.ts`:
**578 passed, 0 failed, 1 ignored**. Repo-wide `deno lint`, `deno fmt --check`,
and `deno check` on the changed files pass.

> Release is human-gated (GRQ #3409 / #3419): please do not squash-merge to
> `Develop` until ready to cut the release that GRQ will then bump to.

Refs stSoftwareAU/GRQ#3419, #3230
