### PR TITLE
Harden bench smoke checkout: persist-credentials false (Issue #3349)

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -37,7 +37,15 @@ jobs:
       NEAT_RUST_DISCOVERY_OPTIONAL: "true"
     steps:
       - name: Checkout Code
+        # `persist-credentials: false` (Issue #3349) — the default `true`
+        # writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth
+        # header for the rest of the job. This smoke job only reads the repo
+        # and uploads an artifact; it never pushes back or fetches private
+        # submodules, so the persisted credential is unnecessary and keeping
+        # it on disk only widens the blast radius of a compromised step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Deno
         # denoland/setup-deno@v2.0.4

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.0",
+  "version": "5.9.1",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3349.md
+++ b/docs/archive/pr-summaries/pr-summary-3349.md
@@ -1,0 +1,45 @@
+# Harden bench smoke checkout — `persist-credentials: false`
+
+## Summary
+
+The `smoke` job in `.github/workflows/bench.yaml` ran `actions/checkout` without
+`persist-credentials: false`. By default checkout writes the workflow's
+`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
+job — including a compromised dependency or an injected script (e.g. the
+subsequent `./build.sh --verify-only`) — can read it and act as the token. The
+job only reads the repo and uploads an artifact; it never pushes back or fetches
+private submodules, so the persisted credential is unnecessary and only widens
+the blast radius of a compromised step.
+
+Added `persist-credentials: false` to the checkout so the token is never written
+to disk, plus a regression test guarding the behaviour. Closes #3349.
+
+```mermaid
+flowchart LR
+    A[checkout default<br/>persist-credentials: true] -->|token written to<br/>.git/config| B[Later step runs<br/>PR-controlled code]
+    B -->|reads token| C[Blast radius:<br/>token exfiltration]
+    D[checkout with<br/>persist-credentials: false] -->|no token on disk| E[Later step<br/>cannot read token]
+```
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot.
+
+- `actionlint .github/workflows/bench.yaml` → OK.
+- TDD confirmation: the new test fails against the unfixed workflow and passes
+  after the fix:
+  - Before fix: `bench.yaml smoke checkout ... FAILED` (persist-credentials was
+    `undefined`, expected `false`).
+  - After fix: `5 passed | 0 failed`.
+- Full `./quality.sh` passed cleanly: `ok | 7627 passed (5 steps) | 0 failed`.
+
+## Test Plan
+
+- Added `test/ci/WorkflowPersistCredentialsFalse.ts` test
+  `.github/workflows/bench.yaml smoke checkout must set persist-credentials:
+  false (Issue #3349)`
+  — parses the workflow YAML and asserts every `actions/checkout` step sets
+  `persist-credentials: false`.
+- Verified the test reproduces the finding (fails before the workflow edit,
+  passes after).
+- Existing Issue #2727 persist-credentials tests continue to pass unchanged.

--- a/test/ci/WorkflowPersistCredentialsFalse.ts
+++ b/test/ci/WorkflowPersistCredentialsFalse.ts
@@ -98,6 +98,36 @@ for (const workflow of SENSITIVE_WORKFLOWS) {
   );
 }
 
+/**
+ * Issue #3349 — the benchmark smoke job only reads the repo and uploads an
+ * artifact; it never pushes back or fetches private submodules. The default
+ * `persist-credentials: true` still writes the workflow `GITHUB_TOKEN` into
+ * `.git/config`, where a later step running PR-controlled code (e.g.
+ * `./build.sh --verify-only`) could read it. The read-only checkout must set
+ * `persist-credentials: false` so the token never lands on disk.
+ */
+Deno.test(
+  ".github/workflows/bench.yaml smoke checkout must set persist-credentials: false (Issue #3349)",
+  async () => {
+    const wf = await readWorkflow(".github/workflows/bench.yaml");
+    const checkoutSteps = collectSteps(wf).filter(isCheckoutStep);
+    assert(
+      checkoutSteps.length > 0,
+      "bench.yaml expected at least one actions/checkout step",
+    );
+    for (const step of checkoutSteps) {
+      assertEquals(
+        step.with?.["persist-credentials"],
+        false,
+        `bench.yaml step "${step.name ?? "<unnamed>"}" must set ` +
+          "persist-credentials: false. This job only reads the repo and " +
+          "uploads an artifact, so persisting the GITHUB_TOKEN to " +
+          ".git/config only widens the blast radius of a compromised step.",
+      );
+    }
+  },
+);
+
 function isGitPushStep(step: Step): boolean {
   if (typeof step.run !== "string") return false;
   return /\bgit\b/.test(step.run) && /\bpush\s+origin\b/.test(step.run);


### PR DESCRIPTION
# Harden bench smoke checkout — `persist-credentials: false`

## Summary

The `smoke` job in `.github/workflows/bench.yaml` ran `actions/checkout` without
`persist-credentials: false`. By default checkout writes the workflow's
`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
job — including a compromised dependency or an injected script (e.g. the
subsequent `./build.sh --verify-only`) — can read it and act as the token. The
job only reads the repo and uploads an artifact; it never pushes back or fetches
private submodules, so the persisted credential is unnecessary and only widens
the blast radius of a compromised step.

Added `persist-credentials: false` to the checkout so the token is never written
to disk, plus a regression test guarding the behaviour. Closes #3349.

```mermaid
flowchart LR
    A[checkout default<br/>persist-credentials: true] -->|token written to<br/>.git/config| B[Later step runs<br/>PR-controlled code]
    B -->|reads token| C[Blast radius:<br/>token exfiltration]
    D[checkout with<br/>persist-credentials: false] -->|no token on disk| E[Later step<br/>cannot read token]
```

## Evidence

Backend/CI-config change only — no web interface to screenshot.

- `actionlint .github/workflows/bench.yaml` → OK.
- TDD confirmation: the new test fails against the unfixed workflow and passes
  after the fix:
  - Before fix: `bench.yaml smoke checkout ... FAILED` (persist-credentials was
    `undefined`, expected `false`).
  - After fix: `5 passed | 0 failed`.
- Full `./quality.sh` passed cleanly: `ok | 7627 passed (5 steps) | 0 failed`.

## Test Plan

- Added `test/ci/WorkflowPersistCredentialsFalse.ts` test
  `.github/workflows/bench.yaml smoke checkout must set persist-credentials:
  false (Issue #3349)`
  — parses the workflow YAML and asserts every `actions/checkout` step sets
  `persist-credentials: false`.
- Verified the test reproduces the finding (fails before the workflow edit,
  passes after).
- Existing Issue #2727 persist-credentials tests continue to pass unchanged.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrmid7cg-eba3f3`<!-- vibe-worker-issue-3349 -->