### PR TITLE
Set persist-credentials: false on coverage merge-job checkout (Issue #3351)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -217,7 +217,16 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout Code
+        # `persist-credentials: false` (Issue #3351) — the default `true`
+        # writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth
+        # header for the rest of the job. This merge job only reads the repo,
+        # downloads shard artifacts, merges the partial coverage + JUnit
+        # reports, and uploads them to Codecov; it never pushes back or fetches
+        # private submodules, so the persisted credential is unnecessary and
+        # keeping it on disk only widens the blast radius of a compromised step.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Deno
         # denoland/setup-deno@v2.0.4

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3351.md
+++ b/docs/archive/pr-summaries/pr-summary-3351.md
@@ -1,12 +1,12 @@
 ## Summary
 
-The coverage workflow's `merge` job checked out the repo with
-`actions/checkout` at its default `persist-credentials: true`, writing the
-workflow `GITHUB_TOKEN` into `.git/config` as an auth header for the rest of
-the job. That job only reads the repo, downloads shard artifacts, merges the
-partial coverage + JUnit reports, and uploads them to Codecov — it never pushes
-back or fetches private submodules, so the persisted credential is unnecessary
-and only widens the blast radius of a compromised step.
+The coverage workflow's `merge` job checked out the repo with `actions/checkout`
+at its default `persist-credentials: true`, writing the workflow `GITHUB_TOKEN`
+into `.git/config` as an auth header for the rest of the job. That job only
+reads the repo, downloads shard artifacts, merges the partial coverage + JUnit
+reports, and uploads them to Codecov — it never pushes back or fetches private
+submodules, so the persisted credential is unnecessary and only widens the blast
+radius of a compromised step.
 
 Added `persist-credentials: false` to the `merge` job's checkout step in
 `.github/workflows/coverage.yaml`, matching the fix already applied to the
@@ -37,8 +37,8 @@ flowchart LR
 - Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
   `.github/workflows/coverage.yaml merge-job checkout must set persist-credentials: false (Issue #3351)`,
   which parses the workflow, isolates the `merge` job, and asserts every
-  `actions/checkout` step sets `persist-credentials: false`. This reproduces
-  the finding (fails before the fix) and confirms the fix.
+  `actions/checkout` step sets `persist-credentials: false`. This reproduces the
+  finding (fails before the fix) and confirms the fix.
 - Re-ran the full `WorkflowPersistCredentialsFalse.ts` suite (7 passed) plus
   `ActionlintWorkflow.ts` and `WorkflowActionPinning.ts` (12 passed) to confirm
   the workflow still lints and every action stays SHA-pinned.

--- a/docs/archive/pr-summaries/pr-summary-3351.md
+++ b/docs/archive/pr-summaries/pr-summary-3351.md
@@ -1,0 +1,44 @@
+## Summary
+
+The coverage workflow's `merge` job checked out the repo with
+`actions/checkout` at its default `persist-credentials: true`, writing the
+workflow `GITHUB_TOKEN` into `.git/config` as an auth header for the rest of
+the job. That job only reads the repo, downloads shard artifacts, merges the
+partial coverage + JUnit reports, and uploads them to Codecov — it never pushes
+back or fetches private submodules, so the persisted credential is unnecessary
+and only widens the blast radius of a compromised step.
+
+Added `persist-credentials: false` to the `merge` job's checkout step in
+`.github/workflows/coverage.yaml`, matching the fix already applied to the
+sibling `coverage` shard job (Issue #3350). Closes #3351.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the CI
+guard test, which fails against the unfixed workflow and passes after the fix.
+
+```
+.github/workflows/coverage.yaml merge-job checkout must set persist-credentials: false (Issue #3351) ... ok
+ok | 7 passed | 0 failed
+```
+
+Data flow of the `merge` job (read-only, no push-back — so no persisted
+credential is needed):
+
+```mermaid
+flowchart LR
+    CO[Checkout<br/>persist-credentials: false] --> DL[Download shard artifacts]
+    DL --> MJ[Merge JUnit + coverage]
+    MJ --> CC[Upload to Codecov]
+```
+
+## Test Plan
+
+- Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
+  `.github/workflows/coverage.yaml merge-job checkout must set persist-credentials: false (Issue #3351)`,
+  which parses the workflow, isolates the `merge` job, and asserts every
+  `actions/checkout` step sets `persist-credentials: false`. This reproduces
+  the finding (fails before the fix) and confirms the fix.
+- Re-ran the full `WorkflowPersistCredentialsFalse.ts` suite (7 passed) plus
+  `ActionlintWorkflow.ts` and `WorkflowActionPinning.ts` (12 passed) to confirm
+  the workflow still lints and every action stays SHA-pinned.

--- a/test/ci/WorkflowPersistCredentialsFalse.ts
+++ b/test/ci/WorkflowPersistCredentialsFalse.ts
@@ -163,6 +163,43 @@ Deno.test(
   },
 );
 
+/**
+ * Issue #3351 — the coverage `merge` job only checks out the repo, downloads
+ * every shard's artifacts, merges the partial coverage + JUnit reports, and
+ * uploads them to Codecov; it never pushes back or fetches private submodules.
+ * The default `persist-credentials: true` still writes the workflow
+ * `GITHUB_TOKEN` into `.git/config`, where a later step running PR-controlled
+ * code could read it. The read-only checkout must set
+ * `persist-credentials: false`.
+ *
+ * Scoped to the `merge` job only — the sibling `coverage` shard job is tracked
+ * separately (Issue #3350).
+ */
+Deno.test(
+  ".github/workflows/coverage.yaml merge-job checkout must set persist-credentials: false (Issue #3351)",
+  async () => {
+    const wf = await readWorkflow(".github/workflows/coverage.yaml");
+    const job = wf.jobs?.merge;
+    assert(job, "coverage.yaml expected a `merge` job");
+    const checkoutSteps = (job.steps ?? []).filter(isCheckoutStep);
+    assert(
+      checkoutSteps.length > 0,
+      "merge job expected at least one actions/checkout step",
+    );
+    for (const step of checkoutSteps) {
+      assertEquals(
+        step.with?.["persist-credentials"],
+        false,
+        `merge job step "${step.name ?? "<unnamed>"}" must set ` +
+          "persist-credentials: false. This job only reads the repo, merges " +
+          "shard artifacts, and uploads to Codecov, so persisting the " +
+          "GITHUB_TOKEN to .git/config only widens the blast radius of a " +
+          "compromised step.",
+      );
+    }
+  },
+);
+
 function isGitPushStep(step: Step): boolean {
   if (typeof step.run !== "string") return false;
   return /\bgit\b/.test(step.run) && /\bpush\s+origin\b/.test(step.run);


### PR DESCRIPTION
## Summary

The coverage workflow's `merge` job checked out the repo with
`actions/checkout` at its default `persist-credentials: true`, writing the
workflow `GITHUB_TOKEN` into `.git/config` as an auth header for the rest of
the job. That job only reads the repo, downloads shard artifacts, merges the
partial coverage + JUnit reports, and uploads them to Codecov — it never pushes
back or fetches private submodules, so the persisted credential is unnecessary
and only widens the blast radius of a compromised step.

Added `persist-credentials: false` to the `merge` job's checkout step in
`.github/workflows/coverage.yaml`, matching the fix already applied to the
sibling `coverage` shard job (Issue #3350). Closes #3351.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the CI
guard test, which fails against the unfixed workflow and passes after the fix.

```
.github/workflows/coverage.yaml merge-job checkout must set persist-credentials: false (Issue #3351) ... ok
ok | 7 passed | 0 failed
```

Data flow of the `merge` job (read-only, no push-back — so no persisted
credential is needed):

```mermaid
flowchart LR
    CO[Checkout<br/>persist-credentials: false] --> DL[Download shard artifacts]
    DL --> MJ[Merge JUnit + coverage]
    MJ --> CC[Upload to Codecov]
```

## Test Plan

- Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
  `.github/workflows/coverage.yaml merge-job checkout must set persist-credentials: false (Issue #3351)`,
  which parses the workflow, isolates the `merge` job, and asserts every
  `actions/checkout` step sets `persist-credentials: false`. This reproduces
  the finding (fails before the fix) and confirms the fix.
- Re-ran the full `WorkflowPersistCredentialsFalse.ts` suite (7 passed) plus
  `ActionlintWorkflow.ts` and `WorkflowActionPinning.ts` (12 passed) to confirm
  the workflow still lints and every action stays SHA-pinned.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrmn79zi-ff65bb`<!-- vibe-worker-issue-3351 -->