### PR TITLE
🟠 Job `dependency-review` checkout persists credentials (`.github/workflows/dependency-review.yml`) (Issue #3352)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -37,6 +37,8 @@ jobs:
       - name: "Checkout repository"
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: "Dependency Review"
         # actions/dependency-review-action@v5.0.0
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.3",
+  "version": "5.9.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3352.md
+++ b/docs/archive/pr-summaries/pr-summary-3352.md
@@ -1,0 +1,45 @@
+## Summary
+
+Hardened the `dependency-review` workflow's checkout step against credential
+persistence. `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
+`.git/config` as an auth header by default, where any later step — including a
+compromised dependency — could read it and act as the token. The
+`dependency-review` job only checks out the repo to scan changed dependency
+manifests; it never pushes back or fetches private submodules, so it does not
+need the persisted credential. Added `persist-credentials: false` to the
+checkout step to keep the token off disk and narrow the blast radius of a
+compromised step. This matches the existing pattern already used across sibling
+workflows (`actionlint.yml`, `osv-scan.yml`, `pages.yml`, `quality.yml`).
+
+Closes #3352.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. The affected file is a
+GitHub Actions workflow YAML; the relevant validation gate is `actionlint`,
+which passes cleanly:
+
+```
+actionlint .github/workflows/dependency-review.yml
+actionlint exit: 0
+```
+
+The diff adds a `with:` block to the existing checkout step:
+
+```yaml
+      - name: "Checkout repository"
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: "Dependency Review"
+```
+
+## Test Plan
+
+- Ran `actionlint .github/workflows/dependency-review.yml` — exit 0, no
+  warnings.
+- Verified the fix mirrors the already-present `persist-credentials: false`
+  usage in `actionlint.yml`, `osv-scan.yml`, `pages.yml`, and `quality.yml`.
+- The `dependency-review` job performs no push or private-submodule fetch, so
+  removing the persisted credential does not affect its behaviour.

--- a/docs/archive/pr-summaries/pr-summary-3352.md
+++ b/docs/archive/pr-summaries/pr-summary-3352.md
@@ -27,12 +27,12 @@ actionlint exit: 0
 The diff adds a `with:` block to the existing checkout step:
 
 ```yaml
-      - name: "Checkout repository"
-        # actions/checkout@v6.0.2
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-      - name: "Dependency Review"
+- name: "Checkout repository"
+  # actions/checkout@v6.0.2
+  uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+  with:
+    persist-credentials: false
+- name: "Dependency Review"
 ```
 
 ## Test Plan

--- a/test/ci/WorkflowPersistCredentialsFalse.ts
+++ b/test/ci/WorkflowPersistCredentialsFalse.ts
@@ -200,6 +200,38 @@ Deno.test(
   },
 );
 
+/**
+ * Issue #3352 — the dependency-review job only checks out the repo and runs
+ * `actions/dependency-review-action` to scan changed dependency manifests; it
+ * never pushes back or fetches private submodules. The default
+ * `persist-credentials: true` still writes the workflow `GITHUB_TOKEN` into
+ * `.git/config`, where a later step running PR-controlled code could read it.
+ * The read-only checkout must set `persist-credentials: false`.
+ */
+Deno.test(
+  ".github/workflows/dependency-review.yml checkout must set persist-credentials: false (Issue #3352)",
+  async () => {
+    const wf = await readWorkflow(".github/workflows/dependency-review.yml");
+    const job = wf.jobs?.["dependency-review"];
+    assert(job, "dependency-review.yml expected a `dependency-review` job");
+    const checkoutSteps = (job.steps ?? []).filter(isCheckoutStep);
+    assert(
+      checkoutSteps.length > 0,
+      "dependency-review job expected at least one actions/checkout step",
+    );
+    for (const step of checkoutSteps) {
+      assertEquals(
+        step.with?.["persist-credentials"],
+        false,
+        `dependency-review job step "${step.name ?? "<unnamed>"}" must set ` +
+          "persist-credentials: false. This job only reads the repo and " +
+          "scans dependency manifests, so persisting the GITHUB_TOKEN to " +
+          ".git/config only widens the blast radius of a compromised step.",
+      );
+    }
+  },
+);
+
 function isGitPushStep(step: Step): boolean {
   if (typeof step.run !== "string") return false;
   return /\bgit\b/.test(step.run) && /\bpush\s+origin\b/.test(step.run);


### PR DESCRIPTION
## Summary

Hardened the `dependency-review` workflow's checkout step against credential
persistence. `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
`.git/config` as an auth header by default, where any later step — including a
compromised dependency — could read it and act as the token. The
`dependency-review` job only checks out the repo to scan changed dependency
manifests; it never pushes back or fetches private submodules, so it does not
need the persisted credential. Added `persist-credentials: false` to the
checkout step to keep the token off disk and narrow the blast radius of a
compromised step. This matches the existing pattern already used across sibling
workflows (`actionlint.yml`, `osv-scan.yml`, `pages.yml`, `quality.yml`).

Closes #3352.

## Evidence

Backend/CI-only change — no web interface to screenshot. The affected file is a
GitHub Actions workflow YAML; the relevant validation gate is `actionlint`,
which passes cleanly:

```
actionlint .github/workflows/dependency-review.yml
actionlint exit: 0
```

The diff adds a `with:` block to the existing checkout step:

```yaml
- name: "Checkout repository"
  # actions/checkout@v6.0.2
  uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
  with:
    persist-credentials: false
- name: "Dependency Review"
```

## Test Plan

- Ran `actionlint .github/workflows/dependency-review.yml` — exit 0, no
  warnings.
- Verified the fix mirrors the already-present `persist-credentials: false`
  usage in `actionlint.yml`, `osv-scan.yml`, `pages.yml`, and `quality.yml`.
- The `dependency-review` job performs no push or private-submodule fetch, so
  removing the persisted credential does not affect its behaviour.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrmpk38c-aee672`<!-- vibe-worker-issue-3352 -->