### PR TITLE
Set persist-credentials: false on github-release checkout (Issue #3353)

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Checkout code
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # No step pushes back or fetches private submodules, so the token
+          # need not be persisted to .git/config (Issue #3353).
+          persist-credentials: false
 
       - name: Read version from deno.json
         id: version

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.4",
+  "version": "5.9.5",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3353.md
+++ b/docs/archive/pr-summaries/pr-summary-3353.md
@@ -1,0 +1,40 @@
+## Summary
+
+The `release` job in `.github/workflows/github-release.yml` checked out the
+repository without `persist-credentials: false`. By default `actions/checkout`
+writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job could read it. This job only reads the version from
+`deno.json` and creates a GitHub Release via `softprops/action-gh-release`
+(which authenticates with the token passed via env, not from `.git/config`); it
+never pushes back or fetches private submodules, so the persisted credential is
+not needed and only widens the blast radius of a compromised step.
+
+Added `persist-credentials: false` to the checkout step so the token is never
+written to disk. Closes #3353.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the
+existing `test/ci/WorkflowPersistCredentialsFalse.ts` suite, extended with a
+scoped test for the `release` job. The new test fails against the unfixed
+workflow and passes after the fix:
+
+```
+.github/workflows/github-release.yml checkout must set persist-credentials: false (Issue #3353) ... ok
+ok | 9 passed | 0 failed
+```
+
+```mermaid
+flowchart LR
+    A[push to Develop] --> B[checkout<br/>persist-credentials: false]
+    B --> C[read version from deno.json]
+    C --> D[softprops/action-gh-release<br/>token via env]
+```
+
+## Test Plan
+
+- Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
+  `.github/workflows/github-release.yml checkout must set persist-credentials:
+  false (Issue #3353)`, which asserts the `release` job's checkout step sets
+  `persist-credentials: false`. Confirmed it fails on the pre-fix workflow and
+  passes after the change.

--- a/docs/archive/pr-summaries/pr-summary-3353.md
+++ b/docs/archive/pr-summaries/pr-summary-3353.md
@@ -35,6 +35,7 @@ flowchart LR
 
 - Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
   `.github/workflows/github-release.yml checkout must set persist-credentials:
-  false (Issue #3353)`, which asserts the `release` job's checkout step sets
+  false (Issue #3353)`,
+  which asserts the `release` job's checkout step sets
   `persist-credentials: false`. Confirmed it fails on the pre-fix workflow and
   passes after the change.

--- a/test/ci/WorkflowPersistCredentialsFalse.ts
+++ b/test/ci/WorkflowPersistCredentialsFalse.ts
@@ -232,6 +232,39 @@ Deno.test(
   },
 );
 
+/**
+ * Issue #3353 — the github-release `release` job only reads the version from
+ * deno.json and creates a GitHub Release via `softprops/action-gh-release`
+ * (which authenticates with the token passed via env, not from `.git/config`);
+ * it never pushes back or fetches private submodules. The default
+ * `persist-credentials: true` still writes the workflow `GITHUB_TOKEN` into
+ * `.git/config`, where a later step running compromised code could read it.
+ * The read-only checkout must set `persist-credentials: false`.
+ */
+Deno.test(
+  ".github/workflows/github-release.yml checkout must set persist-credentials: false (Issue #3353)",
+  async () => {
+    const wf = await readWorkflow(".github/workflows/github-release.yml");
+    const job = wf.jobs?.release;
+    assert(job, "github-release.yml expected a `release` job");
+    const checkoutSteps = (job.steps ?? []).filter(isCheckoutStep);
+    assert(
+      checkoutSteps.length > 0,
+      "release job expected at least one actions/checkout step",
+    );
+    for (const step of checkoutSteps) {
+      assertEquals(
+        step.with?.["persist-credentials"],
+        false,
+        `release job step "${step.name ?? "<unnamed>"}" must set ` +
+          "persist-credentials: false. This job only reads the version and " +
+          "creates a GitHub Release, so persisting the GITHUB_TOKEN to " +
+          ".git/config only widens the blast radius of a compromised step.",
+      );
+    }
+  },
+);
+
 function isGitPushStep(step: Step): boolean {
   if (typeof step.run !== "string") return false;
   return /\bgit\b/.test(step.run) && /\bpush\s+origin\b/.test(step.run);


### PR DESCRIPTION
## Summary

The `release` job in `.github/workflows/github-release.yml` checked out the
repository without `persist-credentials: false`. By default `actions/checkout`
writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where
any later step in the job could read it. This job only reads the version from
`deno.json` and creates a GitHub Release via `softprops/action-gh-release`
(which authenticates with the token passed via env, not from `.git/config`); it
never pushes back or fetches private submodules, so the persisted credential is
not needed and only widens the blast radius of a compromised step.

Added `persist-credentials: false` to the checkout step so the token is never
written to disk. Closes #3353.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the
existing `test/ci/WorkflowPersistCredentialsFalse.ts` suite, extended with a
scoped test for the `release` job. The new test fails against the unfixed
workflow and passes after the fix:

```
.github/workflows/github-release.yml checkout must set persist-credentials: false (Issue #3353) ... ok
ok | 9 passed | 0 failed
```

```mermaid
flowchart LR
    A[push to Develop] --> B[checkout<br/>persist-credentials: false]
    B --> C[read version from deno.json]
    C --> D[softprops/action-gh-release<br/>token via env]
```

## Test Plan

- Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
  `.github/workflows/github-release.yml checkout must set persist-credentials:
  false (Issue #3353)`, which asserts the `release` job's checkout step sets
  `persist-credentials: false`. Confirmed it fails on the pre-fix workflow and
  passes after the change.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrmpk38c-aee672`<!-- vibe-worker-issue-3353 -->