### PR TITLE
Trigger coverage shard OOM retry on V8 fatal-OOM log signature (Issue #3371)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -142,16 +142,37 @@ jobs:
           run_tests "${V8_MEMORY_MB}" "${JOBS}" || TEST_EXIT_CODE=$?
           TEST_EXIT_CODE="${TEST_EXIT_CODE:-0}"
 
-          # On OOM/termination signals (143/137/134/133) retry once via the
+          # Detect an out-of-memory failure from EITHER a termination signal OR
+          # the V8 fatal-OOM log signature (Issue #3371). V8's "Fatal JavaScript
+          # out of memory: Ineffective mark-compacts near heap limit" abort
+          # exits the test-runner process with code 1 — indistinguishable, by
+          # exit code alone, from an ordinary test failure — so the signal-only
+          # trigger (133/134/137/143) silently missed it and the capped-worker
+          # retry never engaged. Inspect the captured stderr for the fatal-OOM
+          # signature so recovery fires regardless of exit code. `grep -q` under
+          # `set -e` is safe inside an `if` condition (a no-match exit 1 is the
+          # tested branch, not an uncaught error).
+          is_oom_failure() {
+            local code="$1"
+            case "$code" in
+              133 | 134 | 137 | 143) return 0 ;;
+            esac
+            if [ -f test-errors.log ] && \
+              grep -qE 'Fatal JavaScript out of memory|Ineffective mark-compacts' test-errors.log; then
+              return 0
+            fi
+            return 1
+          }
+
+          # On an OOM (signal OR fatal-OOM log signature) retry once via the
           # scoped `--mode=retry` plan: a smaller heap AND a capped worker count.
           # Recovery stays parallel (scoped to this shard's slice) rather than
           # dropping to a whole-shard serial re-run that blows the timeout
-          # (Issue #3174). 133 (128+SIGTRAP) is how V8 aborts on heap
-          # exhaustion — "Fatal JavaScript out of memory: Ineffective
-          # mark-compacts near heap limit" surfaces as a Trace/breakpoint trap,
-          # not SIGKILL/SIGTERM/SIGABRT — so it must trigger the same recovery.
-          if [ "$TEST_EXIT_CODE" -eq 143 ] || [ "$TEST_EXIT_CODE" -eq 137 ] || [ "$TEST_EXIT_CODE" -eq 134 ] || [ "$TEST_EXIT_CODE" -eq 133 ]; then
-            echo "⚠️  shard exited ${TEST_EXIT_CODE} (OOM/signal). Retrying parallel with capped workers + reduced heap..."
+          # (Issue #3174). 133 (128+SIGTRAP) is how V8 aborts on heap exhaustion
+          # via SIGTRAP; the exit-1 fatal-OOM path is caught by the log-signature
+          # check above (Issue #3371).
+          if is_oom_failure "$TEST_EXIT_CODE"; then
+            echo "⚠️  shard OOM detected (exit ${TEST_EXIT_CODE}). Retrying parallel with capped workers + reduced heap..."
             eval "$(deno run scripts/coverage_run_plan.ts \
               --mode=retry --cores="${CPU_CORES}" --memory-mb="${TOTAL_MEMORY_MB}")"
             V8_RETRY="${HEAP_MB}"

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.6",
+  "version": "5.9.7",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3371.md
+++ b/docs/archive/pr-summaries/pr-summary-3371.md
@@ -1,0 +1,69 @@
+# Coverage shard OOM retry now fires on the V8 fatal-OOM log signature
+
+## Summary
+
+`Coverage shard 2` in the `Test Coverage` workflow flakily hit a **V8 fatal
+out-of-memory**
+(`Fatal JavaScript out of memory: Ineffective mark-compacts near
+heap limit`).
+That abort exits the test-runner process with code **1** — not one of the signal
+codes (133/134/137/143) — so the existing capped-worker retry never engaged and
+the shard failed hard.
+
+This PR broadens the OOM-recovery trigger in `.github/workflows/coverage.yaml`
+so recovery fires on **either** a termination signal **or** the fatal-OOM log
+signature in the captured stderr, regardless of exit code. The retry decision is
+now an `is_oom_failure()` helper that inspects `test-errors.log` for
+`Fatal JavaScript out of memory` / `Ineffective mark-compacts` in addition to
+the signal codes. Fail-loud behaviour is preserved: a genuine test failure (exit
+1 with no OOM signature) is still recorded as `failed`, not retried.
+
+The two other resilience concerns raised in the issue were already resolved in
+mainline and are left intact:
+
+- The JUnit-extraction `grep` is already guarded with `|| true`, so a crashed
+  shard still records `shard-status-<n>.txt` and uploads partial artifacts.
+- Signal code `133` (128+SIGTRAP) already triggers recovery.
+
+Closes #3371.
+
+## Root cause
+
+```mermaid
+flowchart TD
+    A[deno test shard] --> B{exit code / stderr}
+    B -->|133/134/137/143 signal| R[capped-worker retry]
+    B -->|exit 1 + fatal-OOM signature| R
+    B -->|exit 1, no OOM signature| F[record failed]
+    B -->|exit 0| P[record passed]
+    R --> S[record status from retry outcome]
+    style R fill:#cfe8cc
+```
+
+Before this change the `exit 1 + fatal-OOM signature` edge was missing — an
+exit-1 OOM fell through to `record failed` and never retried.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via:
+
+- New TDD test
+  `test/ci/CoverageOomRetryParallel.ts::"coverage shard OOM
+  recovery also fires on the V8 fatal-OOM log signature (exit 1)"`
+  — fails against the unfixed workflow, passes after the fix.
+- Shell-branch simulation of `is_oom_failure()` under `set -Eeuo pipefail`
+  confirming: exit-1 + signature → retry; plain exit-1 → no retry; signal 133 →
+  retry; exit 0 → no retry; missing log → no retry; no `set -e` abort.
+- `actionlint` (with embedded `shellcheck`) passes on the workflow.
+- `./quality.sh --lint-only` passes (fmt, lint, bash checks).
+- All 22 coverage-related CI tests pass.
+
+## Test Plan
+
+- Added
+  `test/ci/CoverageOomRetryParallel.ts::"coverage shard OOM recovery also
+  fires on the V8 fatal-OOM log signature (exit 1)"`
+  — asserts the shard run script matches the fatal-OOM log signature and greps
+  `test-errors.log` to gate the retry.
+- Re-ran the existing OOM-retry, run-plan, and shard-matrix CI suites — all
+  green (22 passed).

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -282,6 +282,7 @@
     "finalisers",
     "fixpoint",
     "flamegraph",
+    "flakily",
     "footgun",
     "footguns",
     "forex",

--- a/test/ci/CoverageOomRetryParallel.ts
+++ b/test/ci/CoverageOomRetryParallel.ts
@@ -100,3 +100,30 @@ Deno.test("coverage shard OOM recovery narrows workers instead of going serial",
     `RETRY_JOBS must be a positive worker count, got ${match[1]}`,
   );
 });
+
+Deno.test("coverage shard OOM recovery also fires on the V8 fatal-OOM log signature (exit 1)", async () => {
+  const run = await readShardRunScript();
+  // A V8 fatal out-of-memory ("Fatal JavaScript out of memory: Ineffective
+  // mark-compacts near heap limit") aborts the `deno test` process with exit
+  // code 1 — NOT one of the signal codes (133/134/137/143). Relying only on
+  // exit codes therefore misses this OOM and the capped-worker retry never
+  // engages (Issue #3371). The recovery decision must ALSO inspect the captured
+  // stderr for the fatal-OOM signature, regardless of exit code.
+  for (
+    const signature of [
+      "Fatal JavaScript out of memory",
+      "Ineffective mark-compacts",
+    ]
+  ) {
+    assert(
+      run.includes(signature),
+      `OOM recovery must match the fatal-OOM log signature "${signature}" so an exit-1 OOM triggers the retry (Issue #3371)`,
+    );
+  }
+  // The signature must be matched against the captured test stderr so the
+  // decision is driven by the actual crash output, not a hard-coded exit code.
+  assert(
+    /grep[^\n]*test-errors\.log/.test(run),
+    "OOM recovery must grep test-errors.log for the fatal-OOM signature (Issue #3371)",
+  );
+});


### PR DESCRIPTION
# Coverage shard OOM retry now fires on the V8 fatal-OOM log signature

## Summary

`Coverage shard 2` in the `Test Coverage` workflow flakily hit a **V8 fatal
out-of-memory**
(`Fatal JavaScript out of memory: Ineffective mark-compacts near
heap limit`).
That abort exits the test-runner process with code **1** — not one of the signal
codes (133/134/137/143) — so the existing capped-worker retry never engaged and
the shard failed hard.

This PR broadens the OOM-recovery trigger in `.github/workflows/coverage.yaml`
so recovery fires on **either** a termination signal **or** the fatal-OOM log
signature in the captured stderr, regardless of exit code. The retry decision is
now an `is_oom_failure()` helper that inspects `test-errors.log` for
`Fatal JavaScript out of memory` / `Ineffective mark-compacts` in addition to
the signal codes. Fail-loud behaviour is preserved: a genuine test failure (exit
1 with no OOM signature) is still recorded as `failed`, not retried.

The two other resilience concerns raised in the issue were already resolved in
mainline and are left intact:

- The JUnit-extraction `grep` is already guarded with `|| true`, so a crashed
  shard still records `shard-status-<n>.txt` and uploads partial artifacts.
- Signal code `133` (128+SIGTRAP) already triggers recovery.

Closes #3371.

## Root cause

```mermaid
flowchart TD
    A[deno test shard] --> B{exit code / stderr}
    B -->|133/134/137/143 signal| R[capped-worker retry]
    B -->|exit 1 + fatal-OOM signature| R
    B -->|exit 1, no OOM signature| F[record failed]
    B -->|exit 0| P[record passed]
    R --> S[record status from retry outcome]
    style R fill:#cfe8cc
```

Before this change the `exit 1 + fatal-OOM signature` edge was missing — an
exit-1 OOM fell through to `record failed` and never retried.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via:

- New TDD test
  `test/ci/CoverageOomRetryParallel.ts::"coverage shard OOM
  recovery also fires on the V8 fatal-OOM log signature (exit 1)"`
  — fails against the unfixed workflow, passes after the fix.
- Shell-branch simulation of `is_oom_failure()` under `set -Eeuo pipefail`
  confirming: exit-1 + signature → retry; plain exit-1 → no retry; signal 133 →
  retry; exit 0 → no retry; missing log → no retry; no `set -e` abort.
- `actionlint` (with embedded `shellcheck`) passes on the workflow.
- `./quality.sh --lint-only` passes (fmt, lint, bash checks).
- All 22 coverage-related CI tests pass.

## Test Plan

- Added
  `test/ci/CoverageOomRetryParallel.ts::"coverage shard OOM recovery also
  fires on the V8 fatal-OOM log signature (exit 1)"`
  — asserts the shard run script matches the fatal-OOM log signature and greps
  `test-errors.log` to gate the retry.
- Re-ran the existing OOM-retry, run-plan, and shard-matrix CI suites — all
  green (22 passed).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrmug759-6129b3`<!-- vibe-worker-issue-3371 -->