### PR TITLE
Harden semgrep checkout: persist-credentials: false (Issue #3356)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # Semgrep only reads the tree; it never pushes or fetches private
+          # submodules, so the GITHUB_TOKEN must not be persisted to .git/config
+          # where a compromised step could read it (Issue #3356).
+          persist-credentials: false
       - run: semgrep ci --config p/default --config p/security-audit --config p/owasp-top-ten
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.8",
+  "version": "5.9.9",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3356.md
+++ b/docs/archive/pr-summaries/pr-summary-3356.md
@@ -1,0 +1,41 @@
+## Summary
+
+The `semgrep` job in `.github/workflows/semgrep.yml` checked out the repository
+with `actions/checkout` at its default `persist-credentials: true`, which writes
+the workflow `GITHUB_TOKEN` into `.git/config` as an auth header. This job only
+reads the tree to run a Semgrep SAST scan (authenticated separately via
+`SEMGREP_APP_TOKEN`); it never pushes back or fetches private submodules, so the
+persisted credential is unnecessary and only widens the blast radius of a
+compromised step.
+
+Added `persist-credentials: false` to the checkout step so the token is never
+written to disk. This matches the existing hardening already applied to the
+other read-only workflows in this repo (bench, coverage, dependency-review,
+github-release, markdown-lint). Closes #3356.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+```mermaid
+flowchart LR
+    A[checkout<br/>persist-credentials: false] --> B[semgrep ci scan]
+    A -. token NOT written<br/>to .git/config .-> C[(.git/config)]
+```
+
+Verification:
+
+- `deno test --allow-read test/ci/WorkflowPersistCredentialsFalse.ts` — 11
+  passed, 0 failed, including the new Issue #3356 case.
+- `actionlint .github/workflows/semgrep.yml` — exit 0.
+- `deno fmt --check`, `deno lint`, `deno check` on the modified test file — all
+  clean.
+
+## Test Plan
+
+- Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
+  `.github/workflows/semgrep.yml checkout must set persist-credentials: false
+  (Issue #3356)`,
+  which parses the workflow and asserts the `semgrep` job's checkout step sets
+  `persist-credentials: false`. It fails against the unfixed workflow (default
+  `undefined`) and passes after the fix.

--- a/test/ci/WorkflowPersistCredentialsFalse.ts
+++ b/test/ci/WorkflowPersistCredentialsFalse.ts
@@ -297,6 +297,38 @@ Deno.test(
   },
 );
 
+/**
+ * Issue #3356 — the semgrep `semgrep` job only checks out the repo and runs
+ * `semgrep ci` (a SAST scan authenticated via SEMGREP_APP_TOKEN, not the
+ * checkout credential); it never pushes back or fetches private submodules. The
+ * default `persist-credentials: true` still writes the workflow `GITHUB_TOKEN`
+ * into `.git/config`, where a later step running PR-controlled code could read
+ * it. The read-only checkout must set `persist-credentials: false`.
+ */
+Deno.test(
+  ".github/workflows/semgrep.yml checkout must set persist-credentials: false (Issue #3356)",
+  async () => {
+    const wf = await readWorkflow(".github/workflows/semgrep.yml");
+    const job = wf.jobs?.semgrep;
+    assert(job, "semgrep.yml expected a `semgrep` job");
+    const checkoutSteps = (job.steps ?? []).filter(isCheckoutStep);
+    assert(
+      checkoutSteps.length > 0,
+      "semgrep job expected at least one actions/checkout step",
+    );
+    for (const step of checkoutSteps) {
+      assertEquals(
+        step.with?.["persist-credentials"],
+        false,
+        `semgrep job step "${step.name ?? "<unnamed>"}" must set ` +
+          "persist-credentials: false. This job only reads the repo and runs " +
+          "a Semgrep SAST scan, so persisting the GITHUB_TOKEN to .git/config " +
+          "only widens the blast radius of a compromised step.",
+      );
+    }
+  },
+);
+
 function isGitPushStep(step: Step): boolean {
   if (typeof step.run !== "string") return false;
   return /\bgit\b/.test(step.run) && /\bpush\s+origin\b/.test(step.run);


### PR DESCRIPTION
## Summary

The `semgrep` job in `.github/workflows/semgrep.yml` checked out the repository
with `actions/checkout` at its default `persist-credentials: true`, which writes
the workflow `GITHUB_TOKEN` into `.git/config` as an auth header. This job only
reads the tree to run a Semgrep SAST scan (authenticated separately via
`SEMGREP_APP_TOKEN`); it never pushes back or fetches private submodules, so the
persisted credential is unnecessary and only widens the blast radius of a
compromised step.

Added `persist-credentials: false` to the checkout step so the token is never
written to disk. This matches the existing hardening already applied to the
other read-only workflows in this repo (bench, coverage, dependency-review,
github-release, markdown-lint). Closes #3356.

## Evidence

Backend/CI-only change — no web interface to screenshot.

```mermaid
flowchart LR
    A[checkout<br/>persist-credentials: false] --> B[semgrep ci scan]
    A -. token NOT written<br/>to .git/config .-> C[(.git/config)]
```

Verification:

- `deno test --allow-read test/ci/WorkflowPersistCredentialsFalse.ts` — 11
  passed, 0 failed, including the new Issue #3356 case.
- `actionlint .github/workflows/semgrep.yml` — exit 0.
- `deno fmt --check`, `deno lint`, `deno check` on the modified test file — all
  clean.

## Test Plan

- Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
  `.github/workflows/semgrep.yml checkout must set persist-credentials: false
  (Issue #3356)`,
  which parses the workflow and asserts the `semgrep` job's checkout step sets
  `persist-credentials: false`. It fails against the unfixed workflow (default
  `undefined`) and passes after the fix.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrmwzgkh-6bfaae`<!-- vibe-worker-issue-3356 -->