### PR TITLE
🟠 Job `shellcheck` checkout persists credentials (`.github/workflows/shellcheck.yml`) (Issue #3357)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -20,8 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # `persist-credentials: false` (Issue #3357) — the default `true` writes
+      # the workflow `GITHUB_TOKEN` into `.git/config` as an auth header for the
+      # rest of the job. This job only reads the repo and lints shell scripts; it
+      # never pushes back or fetches private submodules, so the persisted
+      # credential is unnecessary and keeping it on disk only widens the blast
+      # radius of a compromised step.
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       # Runs koalaman/shellcheck (https://github.com/koalaman/shellcheck) via the
       # ludeeus/action-shellcheck wrapper to lint shell scripts in the repository.
       # ludeeus/action-shellcheck@2.0.0

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.10",
+  "version": "5.9.11",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3357.md
+++ b/docs/archive/pr-summaries/pr-summary-3357.md
@@ -1,0 +1,41 @@
+# Harden `shellcheck` workflow checkout — `persist-credentials: false`
+
+## Summary
+
+The `shellcheck` job in `.github/workflows/shellcheck.yml` ran
+`actions/checkout` with the default `persist-credentials: true`, which writes
+the workflow `GITHUB_TOKEN` into `.git/config` as an auth header for the rest of
+the job. This job only reads the repo and lints shell scripts via
+`ludeeus/action-shellcheck` — it never pushes back or fetches private
+submodules — so the persisted credential is unnecessary and only widens the
+blast radius of a compromised step.
+
+Added `persist-credentials: false` to the checkout step, matching the existing
+convention already applied across sibling workflows (e.g. `markdown-lint.yml`,
+Issue #3354). Closes #3357.
+
+## Evidence
+
+Pure CI workflow YAML change — no web interface or runtime code path to
+screenshot. Validated with `actionlint`, which passes cleanly:
+
+```
+actionlint .github/workflows/shellcheck.yml   # actionlint OK
+```
+
+The checkout hardening flow:
+
+```mermaid
+flowchart LR
+    A[checkout default] -->|persist-credentials: true| B[GITHUB_TOKEN in .git/config]
+    B --> C[any later step can read token]
+    A2[checkout hardened] -->|persist-credentials: false| D[no token on disk]
+    D --> E[reduced blast radius]
+```
+
+## Test Plan
+
+- `actionlint .github/workflows/shellcheck.yml` — passes.
+- Confirmed the added `persist-credentials: false` key matches the indentation
+  and commenting convention used by the other hardened workflows in
+  `.github/workflows/`.

--- a/docs/archive/pr-summaries/pr-summary-3357.md
+++ b/docs/archive/pr-summaries/pr-summary-3357.md
@@ -6,9 +6,9 @@ The `shellcheck` job in `.github/workflows/shellcheck.yml` ran
 `actions/checkout` with the default `persist-credentials: true`, which writes
 the workflow `GITHUB_TOKEN` into `.git/config` as an auth header for the rest of
 the job. This job only reads the repo and lints shell scripts via
-`ludeeus/action-shellcheck` — it never pushes back or fetches private
-submodules — so the persisted credential is unnecessary and only widens the
-blast radius of a compromised step.
+`ludeeus/action-shellcheck` — it never pushes back or fetches private submodules
+— so the persisted credential is unnecessary and only widens the blast radius of
+a compromised step.
 
 Added `persist-credentials: false` to the checkout step, matching the existing
 convention already applied across sibling workflows (e.g. `markdown-lint.yml`,


### PR DESCRIPTION
# Harden `shellcheck` workflow checkout — `persist-credentials: false`

## Summary

The `shellcheck` job in `.github/workflows/shellcheck.yml` ran
`actions/checkout` with the default `persist-credentials: true`, which writes
the workflow `GITHUB_TOKEN` into `.git/config` as an auth header for the rest of
the job. This job only reads the repo and lints shell scripts via
`ludeeus/action-shellcheck` — it never pushes back or fetches private submodules
— so the persisted credential is unnecessary and only widens the blast radius of
a compromised step.

Added `persist-credentials: false` to the checkout step, matching the existing
convention already applied across sibling workflows (e.g. `markdown-lint.yml`,
Issue #3354). Closes #3357.

## Evidence

Pure CI workflow YAML change — no web interface or runtime code path to
screenshot. Validated with `actionlint`, which passes cleanly:

```
actionlint .github/workflows/shellcheck.yml   # actionlint OK
```

The checkout hardening flow:

```mermaid
flowchart LR
    A[checkout default] -->|persist-credentials: true| B[GITHUB_TOKEN in .git/config]
    B --> C[any later step can read token]
    A2[checkout hardened] -->|persist-credentials: false| D[no token on disk]
    D --> E[reduced blast radius]
```

## Test Plan

- `actionlint .github/workflows/shellcheck.yml` — passes.
- Confirmed the added `persist-credentials: false` key matches the indentation
  and commenting convention used by the other hardened workflows in
  `.github/workflows/`.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrn0a96g-6cca0a`<!-- vibe-worker-issue-3357 -->