### PR TITLE
🟠 Job `spellcheck` checkout persists credentials (`.github/workflows/spellcheck.yaml`) (Issue #3358)

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -22,6 +22,10 @@ jobs:
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # Read-only job (spell-check + upload); do not persist the
+          # GITHUB_TOKEN to .git/config (Issue #3358).
+          persist-credentials: false
       # streetsidesoftware/cspell-action@v8.4.0
       - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2
         with:

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.9",
+  "version": "5.9.10",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3358.md
+++ b/docs/archive/pr-summaries/pr-summary-3358.md
@@ -1,0 +1,40 @@
+## Summary
+
+The `spellcheck` job in `.github/workflows/spellcheck.yaml` checked out the repo
+with `actions/checkout` at its default `persist-credentials: true`, which writes
+the workflow `GITHUB_TOKEN` into `.git/config` as an auth header. This job only
+reads the repo and runs `streetsidesoftware/cspell-action` — it never pushes
+back or fetches private submodules — so the persisted credential is unnecessary
+and only widens the blast radius of a compromised step.
+
+Added `persist-credentials: false` to the checkout step so the token is never
+written to disk, matching the existing convention across the repo's other
+read-only workflows (bench, coverage, dependency-review, markdown-lint, semgrep,
+etc.). Closes #3358.
+
+```mermaid
+flowchart LR
+    A[checkout persist-credentials: false] --> B[GITHUB_TOKEN not written to .git/config]
+    B --> C[cspell-action spell-checks files]
+    C --> D[compromised step cannot read a persisted token]
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+- Extended `test/ci/WorkflowPersistCredentialsFalse.ts` with a test asserting the
+  `spellcheck` job checkout sets `persist-credentials: false` (Issue #3358). The
+  test failed against the unfixed workflow (`undefined` vs `false`) and passes
+  after the fix.
+- Full test file result: `12 passed | 0 failed`.
+- `deno fmt`, `deno lint`, and `deno check` pass on the modified test file; the
+  workflow YAML parses correctly with the new `with.persist-credentials: false`.
+
+## Test Plan
+
+- Added `test/ci/WorkflowPersistCredentialsFalse.ts` ::
+  `.github/workflows/spellcheck.yaml checkout must set persist-credentials: false (Issue #3358)`
+  — reproduces the finding (fails before the fix) and verifies the fix.
+- Ran the full `WorkflowPersistCredentialsFalse.ts` suite to confirm no
+  regression in the sibling workflow assertions.

--- a/docs/archive/pr-summaries/pr-summary-3358.md
+++ b/docs/archive/pr-summaries/pr-summary-3358.md
@@ -23,10 +23,10 @@ flowchart LR
 
 Backend/CI-only change — no web interface to screenshot.
 
-- Extended `test/ci/WorkflowPersistCredentialsFalse.ts` with a test asserting the
-  `spellcheck` job checkout sets `persist-credentials: false` (Issue #3358). The
-  test failed against the unfixed workflow (`undefined` vs `false`) and passes
-  after the fix.
+- Extended `test/ci/WorkflowPersistCredentialsFalse.ts` with a test asserting
+  the `spellcheck` job checkout sets `persist-credentials: false` (Issue #3358).
+  The test failed against the unfixed workflow (`undefined` vs `false`) and
+  passes after the fix.
 - Full test file result: `12 passed | 0 failed`.
 - `deno fmt`, `deno lint`, and `deno check` pass on the modified test file; the
   workflow YAML parses correctly with the new `with.persist-credentials: false`.

--- a/test/ci/WorkflowPersistCredentialsFalse.ts
+++ b/test/ci/WorkflowPersistCredentialsFalse.ts
@@ -329,6 +329,38 @@ Deno.test(
   },
 );
 
+/**
+ * Issue #3358 — the spellcheck `spellcheck` job only checks out the repo and
+ * runs `streetsidesoftware/cspell-action` to spell-check files; it never pushes
+ * back or fetches private submodules. The default `persist-credentials: true`
+ * still writes the workflow `GITHUB_TOKEN` into `.git/config`, where a later
+ * step running PR-controlled code could read it. The read-only checkout must
+ * set `persist-credentials: false`.
+ */
+Deno.test(
+  ".github/workflows/spellcheck.yaml checkout must set persist-credentials: false (Issue #3358)",
+  async () => {
+    const wf = await readWorkflow(".github/workflows/spellcheck.yaml");
+    const job = wf.jobs?.spellcheck;
+    assert(job, "spellcheck.yaml expected a `spellcheck` job");
+    const checkoutSteps = (job.steps ?? []).filter(isCheckoutStep);
+    assert(
+      checkoutSteps.length > 0,
+      "spellcheck job expected at least one actions/checkout step",
+    );
+    for (const step of checkoutSteps) {
+      assertEquals(
+        step.with?.["persist-credentials"],
+        false,
+        `spellcheck job step "${step.name ?? "<unnamed>"}" must set ` +
+          "persist-credentials: false. This job only reads the repo and " +
+          "spell-checks files, so persisting the GITHUB_TOKEN to .git/config " +
+          "only widens the blast radius of a compromised step.",
+      );
+    }
+  },
+);
+
 function isGitPushStep(step: Step): boolean {
   if (typeof step.run !== "string") return false;
   return /\bgit\b/.test(step.run) && /\bpush\s+origin\b/.test(step.run);


### PR DESCRIPTION
## Summary

The `spellcheck` job in `.github/workflows/spellcheck.yaml` checked out the repo
with `actions/checkout` at its default `persist-credentials: true`, which writes
the workflow `GITHUB_TOKEN` into `.git/config` as an auth header. This job only
reads the repo and runs `streetsidesoftware/cspell-action` — it never pushes
back or fetches private submodules — so the persisted credential is unnecessary
and only widens the blast radius of a compromised step.

Added `persist-credentials: false` to the checkout step so the token is never
written to disk, matching the existing convention across the repo's other
read-only workflows (bench, coverage, dependency-review, markdown-lint, semgrep,
etc.). Closes #3358.

```mermaid
flowchart LR
    A[checkout persist-credentials: false] --> B[GITHUB_TOKEN not written to .git/config]
    B --> C[cspell-action spell-checks files]
    C --> D[compromised step cannot read a persisted token]
```

## Evidence

Backend/CI-only change — no web interface to screenshot.

- Extended `test/ci/WorkflowPersistCredentialsFalse.ts` with a test asserting the
  `spellcheck` job checkout sets `persist-credentials: false` (Issue #3358). The
  test failed against the unfixed workflow (`undefined` vs `false`) and passes
  after the fix.
- Full test file result: `12 passed | 0 failed`.
- `deno fmt`, `deno lint`, and `deno check` pass on the modified test file; the
  workflow YAML parses correctly with the new `with.persist-credentials: false`.

## Test Plan

- Added `test/ci/WorkflowPersistCredentialsFalse.ts` ::
  `.github/workflows/spellcheck.yaml checkout must set persist-credentials: false (Issue #3358)`
  — reproduces the finding (fails before the fix) and verifies the fix.
- Ran the full `WorkflowPersistCredentialsFalse.ts` suite to confirm no
  regression in the sibling workflow assertions.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrn0a96g-6cca0a`<!-- vibe-worker-issue-3358 -->