### PR TITLE
🟠 CI quality workflow skips milestone PRs (`.github/workflows/coverage.yaml`) (Issue #3360)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches:
       - Develop
+      # Also gate milestone sub-issue PRs. They target a shared
+      # `milestone/<slug>` branch (planning delivery workflow); without this
+      # glob the coverage gate never ran on them and they merged into the
+      # milestone branch unchecked (Issue #3360). Milestone names have no
+      # nested slashes, so the single-level `milestone/*` glob is sufficient.
+      - milestone/*
 
 # Cancel superseded runs on the same ref so rapid successive pushes don't
 # pile up redundant (heavy) coverage runs (Issue #2842).

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.12",
+  "version": "5.9.13",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3360.md
+++ b/docs/archive/pr-summaries/pr-summary-3360.md
@@ -1,0 +1,41 @@
+## Summary
+
+The **Test Coverage** CI quality gate (`.github/workflows/coverage.yaml`) only
+ran on PRs targeting `Develop`. Milestone sub-issue PRs target a shared
+`milestone/<slug>` branch (planning delivery workflow), so the coverage gate
+never ran on them and they merged into the milestone branch unchecked — the gap
+only surfacing later at the single rollup PR into the default branch.
+
+Added the single-level `milestone/*` glob to the workflow's
+`pull_request.branches` filter so the gate runs on every intermediate milestone
+PR too. Milestone names are `milestone/<slug>` with no nested slashes, so the
+single-level glob is sufficient. The existing `Develop` gate is preserved — the
+change is additive.
+
+Closes #3360.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via a new
+"what" test that parses the committed workflow YAML and asserts on the resulting
+`pull_request.branches` filter, plus `actionlint` on the workflow.
+
+```mermaid
+flowchart LR
+    A[Milestone sub-issue PR<br/>→ milestone/&lt;slug&gt;] -->|before: filter=Develop only| B[Coverage gate SKIPPED]
+    A -->|after: filter += milestone/*| C[Coverage gate RUNS]
+```
+
+Test run (TDD red → green):
+
+- Before the workflow edit: `AssertionError … got: ["Develop"]` (red).
+- After: `1 passed`.
+- Full `test/ci/` suite: `145 passed | 0 failed`.
+- `actionlint .github/workflows/coverage.yaml` → OK.
+
+## Test Plan
+
+- Added `test/ci/CoverageMilestoneBranchFilter.ts` — parses `coverage.yaml` and
+  asserts `pull_request.branches` includes both `milestone/*` (the fix) and
+  `Develop` (regression guard that the milestone glob is additive, not a
+  replacement).

--- a/test/ci/CoverageMilestoneBranchFilter.ts
+++ b/test/ci/CoverageMilestoneBranchFilter.ts
@@ -1,0 +1,63 @@
+import { assert } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verifies the Test Coverage CI quality gate runs on milestone feature-branch
+ * PRs, not just PRs into `Develop` (Issue #3360).
+ *
+ * Milestone sub-issue PRs target a shared `milestone/<slug>` branch (planning
+ * delivery workflow). If the coverage workflow's `pull_request.branches`
+ * filter matched only `Develop`, the gate never ran on those PRs and they
+ * merged into the milestone branch unchecked — the gap surfacing only later at
+ * the single rollup PR into the default branch. Adding the single-level
+ * `milestone/*` glob (milestone names are `milestone/<slug>` with no nested
+ * slashes) makes the gate run on every intermediate milestone PR too.
+ *
+ * This is a "what" test: it parses the committed workflow YAML and asserts on
+ * the resulting `pull_request.branches` filter, not on how it is written.
+ */
+
+interface PullRequestTrigger {
+  branches?: string[];
+}
+
+interface Workflow {
+  on?: { "pull_request"?: PullRequestTrigger };
+}
+
+const COVERAGE_WORKFLOW = ".github/workflows/coverage.yaml";
+
+async function readWorkflow(path: string): Promise<Workflow> {
+  const text = await Deno.readTextFile(path);
+  // `@std/yaml` keeps `on` as the string key "on" (it is not coerced to the
+  // YAML 1.1 boolean `true`), so `wf.on` is the trigger map.
+  return parse(text) as Workflow;
+}
+
+Deno.test(
+  "coverage.yaml pull_request branch filter includes milestone/* (Issue #3360)",
+  async () => {
+    const wf = await readWorkflow(COVERAGE_WORKFLOW);
+    const branches = wf.on?.pull_request?.branches;
+
+    assert(
+      Array.isArray(branches) && branches.length > 0,
+      "coverage.yaml must declare a non-empty pull_request.branches filter",
+    );
+
+    assert(
+      branches.includes("milestone/*"),
+      "coverage.yaml pull_request.branches must include 'milestone/*' so the " +
+        "coverage gate runs on milestone sub-issue PRs; got: " +
+        JSON.stringify(branches),
+    );
+
+    // The existing Develop gate must be preserved — the milestone glob is
+    // additive, not a replacement.
+    assert(
+      branches.includes("Develop"),
+      "coverage.yaml pull_request.branches must still include 'Develop'; got: " +
+        JSON.stringify(branches),
+    );
+  },
+);


### PR DESCRIPTION
## Summary

The **Test Coverage** CI quality gate (`.github/workflows/coverage.yaml`) only
ran on PRs targeting `Develop`. Milestone sub-issue PRs target a shared
`milestone/<slug>` branch (planning delivery workflow), so the coverage gate
never ran on them and they merged into the milestone branch unchecked — the gap
only surfacing later at the single rollup PR into the default branch.

Added the single-level `milestone/*` glob to the workflow's
`pull_request.branches` filter so the gate runs on every intermediate milestone
PR too. Milestone names are `milestone/<slug>` with no nested slashes, so the
single-level glob is sufficient. The existing `Develop` gate is preserved — the
change is additive.

Closes #3360.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via a new
"what" test that parses the committed workflow YAML and asserts on the resulting
`pull_request.branches` filter, plus `actionlint` on the workflow.

```mermaid
flowchart LR
    A[Milestone sub-issue PR<br/>→ milestone/&lt;slug&gt;] -->|before: filter=Develop only| B[Coverage gate SKIPPED]
    A -->|after: filter += milestone/*| C[Coverage gate RUNS]
```

Test run (TDD red → green):

- Before the workflow edit: `AssertionError … got: ["Develop"]` (red).
- After: `1 passed`.
- Full `test/ci/` suite: `145 passed | 0 failed`.
- `actionlint .github/workflows/coverage.yaml` → OK.

## Test Plan

- Added `test/ci/CoverageMilestoneBranchFilter.ts` — parses `coverage.yaml` and
  asserts `pull_request.branches` includes both `milestone/*` (the fix) and
  `Develop` (regression guard that the milestone glob is additive, not a
  replacement).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrng7w82-c7a595`<!-- vibe-worker-issue-3360 -->