### PR TITLE
Gate milestone PRs in quality workflow (Issue #3362)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches:
       - Develop
+      # Also gate milestone sub-issue PRs. They target a shared
+      # `milestone/<slug>` branch (planning delivery workflow); without this
+      # glob the quality gate never ran on them and they merged into the
+      # milestone branch unchecked (Issue #3362). Milestone names have no
+      # nested slashes, so the single-level `milestone/*` glob is sufficient.
+      - milestone/*
   workflow_dispatch: # Allow manual trigger if needed
 
 # Cancel superseded runs on the same ref so rapid successive pushes don't

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.16",
+  "version": "5.9.17",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3362.md
+++ b/docs/archive/pr-summaries/pr-summary-3362.md
@@ -1,0 +1,44 @@
+## Summary
+
+The `Quality reviews` CI workflow (`.github/workflows/quality.yml`) only ran on
+PRs targeting `Develop`, so it never gated milestone sub-issue PRs. Those PRs
+target a shared `milestone/<slug>` branch (planning delivery workflow) and were
+merging into the milestone branch unchecked, with the gap only caught later at
+the single rollup PR into the default branch.
+
+Added the single-level `milestone/*` glob to the workflow's
+`pull_request.branches` filter so the quality gate runs on every intermediate
+milestone PR too. Milestone names are `milestone/<slug>` with no nested slashes,
+so `milestone/*` is sufficient. The existing `Develop` gate is preserved — the
+glob is additive. This mirrors the equivalent coverage-workflow fix (Issue
+#3360).
+
+Closes #3362.
+
+## Evidence
+
+Backend/CI-config change with no web interface to screenshot. Verified via a
+new "what" test that parses the committed workflow YAML and asserts on the
+resulting branch filter.
+
+```mermaid
+flowchart LR
+    PR[Milestone sub-issue PR<br/>base: milestone/&lt;slug&gt;] -->|before: no match| Skip[Quality gate skipped ❌]
+    PR -->|after: milestone/* matches| Run[Quality gate runs ✅]
+```
+
+Test run after the fix:
+
+```
+quality.yml pull_request branch filter includes milestone/* (Issue #3362) ... ok
+ok | 1 passed | 0 failed
+```
+
+Full `test/ci/*.ts` suite: `147 passed | 0 failed`.
+
+## Test Plan
+
+- Added `test/ci/QualityMilestoneBranchFilter.ts` — parses
+  `.github/workflows/quality.yml` and asserts `pull_request.branches` includes
+  both `milestone/*` (new) and `Develop` (preserved). Confirmed it fails against
+  the unfixed workflow (`got: ["Develop"]`) and passes after the fix.

--- a/docs/archive/pr-summaries/pr-summary-3362.md
+++ b/docs/archive/pr-summaries/pr-summary-3362.md
@@ -17,9 +17,9 @@ Closes #3362.
 
 ## Evidence
 
-Backend/CI-config change with no web interface to screenshot. Verified via a
-new "what" test that parses the committed workflow YAML and asserts on the
-resulting branch filter.
+Backend/CI-config change with no web interface to screenshot. Verified via a new
+"what" test that parses the committed workflow YAML and asserts on the resulting
+branch filter.
 
 ```mermaid
 flowchart LR

--- a/test/ci/QualityMilestoneBranchFilter.ts
+++ b/test/ci/QualityMilestoneBranchFilter.ts
@@ -1,0 +1,63 @@
+import { assert } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verifies the Quality reviews CI quality gate runs on milestone feature-branch
+ * PRs, not just PRs into `Develop` (Issue #3362).
+ *
+ * Milestone sub-issue PRs target a shared `milestone/<slug>` branch (planning
+ * delivery workflow). If the quality workflow's `pull_request.branches` filter
+ * matched only `Develop`, the gate never ran on those PRs and they merged into
+ * the milestone branch unchecked — the gap surfacing only later at the single
+ * rollup PR into the default branch. Adding the single-level `milestone/*` glob
+ * (milestone names are `milestone/<slug>` with no nested slashes) makes the
+ * gate run on every intermediate milestone PR too.
+ *
+ * This is a "what" test: it parses the committed workflow YAML and asserts on
+ * the resulting `pull_request.branches` filter, not on how it is written.
+ */
+
+interface PullRequestTrigger {
+  branches?: string[];
+}
+
+interface Workflow {
+  on?: { "pull_request"?: PullRequestTrigger };
+}
+
+const QUALITY_WORKFLOW = ".github/workflows/quality.yml";
+
+async function readWorkflow(path: string): Promise<Workflow> {
+  const text = await Deno.readTextFile(path);
+  // `@std/yaml` keeps `on` as the string key "on" (it is not coerced to the
+  // YAML 1.1 boolean `true`), so `wf.on` is the trigger map.
+  return parse(text) as Workflow;
+}
+
+Deno.test(
+  "quality.yml pull_request branch filter includes milestone/* (Issue #3362)",
+  async () => {
+    const wf = await readWorkflow(QUALITY_WORKFLOW);
+    const branches = wf.on?.pull_request?.branches;
+
+    assert(
+      Array.isArray(branches) && branches.length > 0,
+      "quality.yml must declare a non-empty pull_request.branches filter",
+    );
+
+    assert(
+      branches.includes("milestone/*"),
+      "quality.yml pull_request.branches must include 'milestone/*' so the " +
+        "quality gate runs on milestone sub-issue PRs; got: " +
+        JSON.stringify(branches),
+    );
+
+    // The existing Develop gate must be preserved — the milestone glob is
+    // additive, not a replacement.
+    assert(
+      branches.includes("Develop"),
+      "quality.yml pull_request.branches must still include 'Develop'; got: " +
+        JSON.stringify(branches),
+    );
+  },
+);


### PR DESCRIPTION
## Summary

The `Quality reviews` CI workflow (`.github/workflows/quality.yml`) only ran on
PRs targeting `Develop`, so it never gated milestone sub-issue PRs. Those PRs
target a shared `milestone/<slug>` branch (planning delivery workflow) and were
merging into the milestone branch unchecked, with the gap only caught later at
the single rollup PR into the default branch.

Added the single-level `milestone/*` glob to the workflow's
`pull_request.branches` filter so the quality gate runs on every intermediate
milestone PR too. Milestone names are `milestone/<slug>` with no nested slashes,
so `milestone/*` is sufficient. The existing `Develop` gate is preserved — the
glob is additive. This mirrors the equivalent coverage-workflow fix (Issue
#3360).

Closes #3362.

## Evidence

Backend/CI-config change with no web interface to screenshot. Verified via a
new "what" test that parses the committed workflow YAML and asserts on the
resulting branch filter.

```mermaid
flowchart LR
    PR[Milestone sub-issue PR<br/>base: milestone/&lt;slug&gt;] -->|before: no match| Skip[Quality gate skipped ❌]
    PR -->|after: milestone/* matches| Run[Quality gate runs ✅]
```

Test run after the fix:

```
quality.yml pull_request branch filter includes milestone/* (Issue #3362) ... ok
ok | 1 passed | 0 failed
```

Full `test/ci/*.ts` suite: `147 passed | 0 failed`.

## Test Plan

- Added `test/ci/QualityMilestoneBranchFilter.ts` — parses
  `.github/workflows/quality.yml` and asserts `pull_request.branches` includes
  both `milestone/*` (new) and `Develop` (preserved). Confirmed it fails against
  the unfixed workflow (`got: ["Develop"]`) and passes after the fix.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrnop28f-6b62f9`<!-- vibe-worker-issue-3362 -->