### PR TITLE
Gate milestone PRs in Semgrep CI workflow (Issue #3363)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,14 @@ name: Semgrep
 
 on:
   pull_request:
-    branches: ["Develop"]
+    branches:
+      - Develop
+      # Also gate milestone sub-issue PRs. They target a shared
+      # `milestone/<slug>` branch (planning delivery workflow); without this
+      # glob the SAST scan never ran on them and they merged into the
+      # milestone branch unchecked (Issue #3363). Milestone names have no
+      # nested slashes, so the single-level `milestone/*` glob is sufficient.
+      - milestone/*
 
 # Cancel superseded runs on the same ref so rapid successive pushes don't
 # pile up redundant SAST scans (Issue #2842).

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.15",
+  "version": "5.9.16",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3363.md
+++ b/docs/archive/pr-summaries/pr-summary-3363.md
@@ -1,0 +1,46 @@
+# CI Semgrep workflow now gates milestone PRs
+
+## Summary
+
+The Semgrep SAST quality gate (`.github/workflows/semgrep.yml`) only ran on PRs
+targeting `Develop`, so milestone sub-issue PRs — which target a shared
+`milestone/<slug>` branch under the planning delivery workflow — merged without
+the scan gating them. The gap was only caught later at the single rollup PR into
+the default branch.
+
+Added the single-level `milestone/*` glob to the workflow's
+`pull_request.branches` filter (mirroring the sibling fix in `coverage.yaml`,
+Issue #3360) so the SAST gate runs on every intermediate milestone PR too. The
+existing `Develop` gate is preserved — the glob is additive. Milestone names are
+`milestone/<slug>` with no nested slashes, so the single-level glob suffices.
+
+Closes #3363.
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot. Verified via a
+new test that parses the committed workflow YAML and asserts on the resolved
+branch filter.
+
+```mermaid
+flowchart LR
+    A[milestone sub-issue PR] --> B{semgrep pull_request.branches}
+    B -- "before: [Develop] only" --> C[scan skipped ❌]
+    B -- "after: [Develop, milestone/*]" --> D[SAST scan runs ✅]
+```
+
+Test run:
+
+```
+semgrep.yml pull_request branch filter includes milestone/* (Issue #3363) ... ok
+ok | 1 passed | 0 failed
+```
+
+`./quality.sh` passes cleanly: `7652 passed | 0 failed | 4 ignored`.
+
+## Test Plan
+
+- Added `test/ci/SemgrepMilestoneBranchFilter.ts` — parses
+  `.github/workflows/semgrep.yml` and asserts `pull_request.branches` includes
+  both `milestone/*` and `Develop`. Fails against the pre-fix `["Develop"]`
+  filter, passes after the change.

--- a/test/ci/SemgrepMilestoneBranchFilter.ts
+++ b/test/ci/SemgrepMilestoneBranchFilter.ts
@@ -1,0 +1,63 @@
+import { assert } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verifies the Semgrep CI quality gate runs on milestone feature-branch PRs,
+ * not just PRs into `Develop` (Issue #3363).
+ *
+ * Milestone sub-issue PRs target a shared `milestone/<slug>` branch (planning
+ * delivery workflow). If the semgrep workflow's `pull_request.branches` filter
+ * matched only `Develop`, the SAST scan never ran on those PRs and they merged
+ * into the milestone branch unchecked — the gap surfacing only later at the
+ * single rollup PR into the default branch. Adding the single-level
+ * `milestone/*` glob (milestone names are `milestone/<slug>` with no nested
+ * slashes) makes the gate run on every intermediate milestone PR too.
+ *
+ * This is a "what" test: it parses the committed workflow YAML and asserts on
+ * the resulting `pull_request.branches` filter, not on how it is written.
+ */
+
+interface PullRequestTrigger {
+  branches?: string[];
+}
+
+interface Workflow {
+  on?: { "pull_request"?: PullRequestTrigger };
+}
+
+const SEMGREP_WORKFLOW = ".github/workflows/semgrep.yml";
+
+async function readWorkflow(path: string): Promise<Workflow> {
+  const text = await Deno.readTextFile(path);
+  // `@std/yaml` keeps `on` as the string key "on" (it is not coerced to the
+  // YAML 1.1 boolean `true`), so `wf.on` is the trigger map.
+  return parse(text) as Workflow;
+}
+
+Deno.test(
+  "semgrep.yml pull_request branch filter includes milestone/* (Issue #3363)",
+  async () => {
+    const wf = await readWorkflow(SEMGREP_WORKFLOW);
+    const branches = wf.on?.pull_request?.branches;
+
+    assert(
+      Array.isArray(branches) && branches.length > 0,
+      "semgrep.yml must declare a non-empty pull_request.branches filter",
+    );
+
+    assert(
+      branches.includes("milestone/*"),
+      "semgrep.yml pull_request.branches must include 'milestone/*' so the " +
+        "SAST gate runs on milestone sub-issue PRs; got: " +
+        JSON.stringify(branches),
+    );
+
+    // The existing Develop gate must be preserved — the milestone glob is
+    // additive, not a replacement.
+    assert(
+      branches.includes("Develop"),
+      "semgrep.yml pull_request.branches must still include 'Develop'; got: " +
+        JSON.stringify(branches),
+    );
+  },
+);


### PR DESCRIPTION
# CI Semgrep workflow now gates milestone PRs

## Summary

The Semgrep SAST quality gate (`.github/workflows/semgrep.yml`) only ran on PRs
targeting `Develop`, so milestone sub-issue PRs — which target a shared
`milestone/<slug>` branch under the planning delivery workflow — merged without
the scan gating them. The gap was only caught later at the single rollup PR into
the default branch.

Added the single-level `milestone/*` glob to the workflow's
`pull_request.branches` filter (mirroring the sibling fix in `coverage.yaml`,
Issue #3360) so the SAST gate runs on every intermediate milestone PR too. The
existing `Develop` gate is preserved — the glob is additive. Milestone names are
`milestone/<slug>` with no nested slashes, so the single-level glob suffices.

Closes #3363.

## Evidence

Backend/CI-config change only — no web interface to screenshot. Verified via a
new test that parses the committed workflow YAML and asserts on the resolved
branch filter.

```mermaid
flowchart LR
    A[milestone sub-issue PR] --> B{semgrep pull_request.branches}
    B -- "before: [Develop] only" --> C[scan skipped ❌]
    B -- "after: [Develop, milestone/*]" --> D[SAST scan runs ✅]
```

Test run:

```
semgrep.yml pull_request branch filter includes milestone/* (Issue #3363) ... ok
ok | 1 passed | 0 failed
```

`./quality.sh` passes cleanly: `7652 passed | 0 failed | 4 ignored`.

## Test Plan

- Added `test/ci/SemgrepMilestoneBranchFilter.ts` — parses
  `.github/workflows/semgrep.yml` and asserts `pull_request.branches` includes
  both `milestone/*` and `Develop`. Fails against the pre-fix `["Develop"]`
  filter, passes after the change.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrnovb54-feda45`<!-- vibe-worker-issue-3363 -->