### PR TITLE
Remove wall-clock timing assertion from DiscoverAnalysisPerChunkTimeout test (#3365)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.17",
+  "version": "5.9.18",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3365.md
+++ b/docs/archive/pr-summaries/pr-summary-3365.md
@@ -1,18 +1,19 @@
 ## Summary
 
 Removed the machine-dependent wall-clock timing assertion from the first test in
-`test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`. Closes #3365.
+`test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`. Closes
+#3365.
 
-The test *"runAnalysisLoop aborts runParallelAnalysis mid-flight when it never
-resolves"* measured `Date.now()` around the run and asserted
-`elapsed < 60_000`. That is a HOW-test of the runner's real-time performance,
-not a WHAT-test of observable behaviour, and it violates the project testing
-policy (no timing APIs in `test/`). The genuine contract — that a never-resolving
-`runParallelAnalysis` is aborted mid-flight — is already fully asserted by
+The test _"runAnalysisLoop aborts runParallelAnalysis mid-flight when it never
+resolves"_ measured `Date.now()` around the run and asserted `elapsed < 60_000`.
+That is a HOW-test of the runner's real-time performance, not a WHAT-test of
+observable behaviour, and it violates the project testing policy (no timing APIs
+in `test/`). The genuine contract — that a never-resolving `runParallelAnalysis`
+is aborted mid-flight — is already fully asserted by
 `assert(perfStats.analysisStalled, …)`. The wall-clock check only tied the test
 to the host machine's scheduling (CI load, ARM vs x86), risking flakes without
-guarding any real regression. This mirrors the fix already applied to the sibling
-file `DiscoveryTimeout.ts` in #2998 / PR #3011.
+guarding any real regression. This mirrors the fix already applied to the
+sibling file `DiscoveryTimeout.ts` in #2998 / PR #3011.
 
 Applied resolution (a) from the issue: deleted the `elapsed < 60_000` assertion
 and the now-unused `started` / `elapsed` `Date.now()` measurements, leaving a
@@ -32,8 +33,8 @@ runAnalysisLoop defence-in-depth cap aborts remaining chunks when iteration wall
 ok | 3 passed | 0 failed
 ```
 
-`./quality.sh --lint-only` (format, lint, bash syntax) and
-`deno check` on the modified file both pass cleanly.
+`./quality.sh --lint-only` (format, lint, bash syntax) and `deno check` on the
+modified file both pass cleanly.
 
 The remaining assertions — `perfStats.analysisStalled` (the observable stall
 outcome) and `callCount >= 1` (the driver was invoked) — continue to verify the
@@ -41,9 +42,10 @@ timeout's behaviour with no reliance on real elapsed time.
 
 ## Test Plan
 
-- Modified `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`:
-  removed the `elapsed < 60_000` wall-clock assertion and its `started`/`elapsed`
-  `Date.now()` measurements from the first test.
-- Ran the full file: all 3 tests pass, including the two deterministic tests that
-  already model the correct fake-clock technique.
+- Modified
+  `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`:
+  removed the `elapsed < 60_000` wall-clock assertion and its
+  `started`/`elapsed` `Date.now()` measurements from the first test.
+- Ran the full file: all 3 tests pass, including the two deterministic tests
+  that already model the correct fake-clock technique.
 - No production code changed; no tests removed or commented out.

--- a/docs/archive/pr-summaries/pr-summary-3365.md
+++ b/docs/archive/pr-summaries/pr-summary-3365.md
@@ -1,0 +1,49 @@
+## Summary
+
+Removed the machine-dependent wall-clock timing assertion from the first test in
+`test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`. Closes #3365.
+
+The test *"runAnalysisLoop aborts runParallelAnalysis mid-flight when it never
+resolves"* measured `Date.now()` around the run and asserted
+`elapsed < 60_000`. That is a HOW-test of the runner's real-time performance,
+not a WHAT-test of observable behaviour, and it violates the project testing
+policy (no timing APIs in `test/`). The genuine contract — that a never-resolving
+`runParallelAnalysis` is aborted mid-flight — is already fully asserted by
+`assert(perfStats.analysisStalled, …)`. The wall-clock check only tied the test
+to the host machine's scheduling (CI load, ARM vs x86), risking flakes without
+guarding any real regression. This mirrors the fix already applied to the sibling
+file `DiscoveryTimeout.ts` in #2998 / PR #3011.
+
+Applied resolution (a) from the issue: deleted the `elapsed < 60_000` assertion
+and the now-unused `started` / `elapsed` `Date.now()` measurements, leaving a
+strictly behavioural test.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+The affected test file passes after the change:
+
+```
+runAnalysisLoop aborts runParallelAnalysis mid-flight when it never resolves ... ok
+runAnalysisLoop records no stall when runParallelAnalysis resolves within budget ... ok
+runAnalysisLoop defence-in-depth cap aborts remaining chunks when iteration wall-clock exceeds perChunkMaxMs * chunks ... ok
+
+ok | 3 passed | 0 failed
+```
+
+`./quality.sh --lint-only` (format, lint, bash syntax) and
+`deno check` on the modified file both pass cleanly.
+
+The remaining assertions — `perfStats.analysisStalled` (the observable stall
+outcome) and `callCount >= 1` (the driver was invoked) — continue to verify the
+timeout's behaviour with no reliance on real elapsed time.
+
+## Test Plan
+
+- Modified `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`:
+  removed the `elapsed < 60_000` wall-clock assertion and its `started`/`elapsed`
+  `Date.now()` measurements from the first test.
+- Ran the full file: all 3 tests pass, including the two deterministic tests that
+  already model the correct fake-clock technique.
+- No production code changed; no tests removed or commented out.

--- a/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts
@@ -164,7 +164,6 @@ async function runAnalysisLoopWithStub(
 }
 
 Deno.test("runAnalysisLoop aborts runParallelAnalysis mid-flight when it never resolves", async () => {
-  const started = Date.now();
   const { perfStats, callCount } = await runAnalysisLoopWithStub({
     // Stub driver that never resolves — simulates a hung Rust FFI call.
     runParallelAnalysis: () => new Promise(() => {}),
@@ -173,17 +172,13 @@ Deno.test("runAnalysisLoop aborts runParallelAnalysis mid-flight when it never r
     perChunkGraceMs: 50,
     discoveryMaxNeurons: 3,
   });
-  const elapsed = Date.now() - started;
 
+  // The observable contract: the never-resolving driver was aborted
+  // mid-flight and the stall was recorded. No wall-clock measurement —
+  // that would be a machine-dependent HOW-test (see Issue #3365).
   assert(
     perfStats.analysisStalled,
     "analysisStalled must be set when runParallelAnalysis times out mid-flight",
-  );
-  // The timeout must fire — elapsed should be well under the 10-minute
-  // deadline. Allow generous slack for CI scheduling.
-  assert(
-    elapsed < 60_000,
-    `timeout should fire promptly, elapsed=${elapsed}ms`,
   );
   // The stub is invoked at most once per iteration before the timeout
   // aborts the chunk loop. One call is expected.


### PR DESCRIPTION
## Summary

Removed a wall-clock timing assertion from a unit test in
`test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`. Closes
#3365.

The test _"runAnalysisLoop aborts runParallelAnalysis mid-flight when it never
resolves"_ measured `const started = Date.now()` …
`const elapsed = Date.now() -
started` and then asserted `elapsed < 60_000`.
That is a **HOW-test** of the runner's real-time performance rather than a
**WHAT-test** of the timeout's observable behaviour. The genuine behaviour under
test — that a never-resolving `runParallelAnalysis` is aborted mid-flight — is
already fully captured two lines earlier by
`assert(perfStats.analysisStalled, …)`. The `elapsed < 60_000` check added
nothing to that contract; it only tied the test to the wall-clock of whatever
machine ran it, so on a loaded CI runner or an ARM-vs-x86 host it could fail
even when the timeout fired correctly.

This is also the exact anti-pattern the project bans in `AGENTS.md` ("Using
timing APIs (`performance.now()`, `Date.now()`) inside `test/` files will cause
flaky, unreliable results because tests run in parallel"), and it was already
removed from the sibling file `DiscoveryTimeout.ts` in Issue #2998 (PR #3011).

### What changed

Applied resolution **(a)** from the issue: deleted the wall-clock assertion and
the now-unused `started`/`elapsed` `Date.now()` measurements, leaving a strictly
behavioural test. The two remaining assertions are pure WHAT-assertions:

- `assert(perfStats.analysisStalled, …)` — the never-resolving driver was
  aborted and the stall recorded.
- `assert(callCount >= 1, …)` — the stubbed driver was invoked before the abort.

No production code changed; the timeout behaviour is unchanged. The file's third
test already models the correct deterministic technique (fake `now` clock via
`advanceNow`, asserting on `analysisStalled` + `callCount`), so the file is now
internally consistent.

```mermaid
flowchart LR
    A["never-resolving<br/>runParallelAnalysis"] --> B[per-chunk timeout fires]
    B --> C["assert analysisStalled == true<br/>(WHAT)"]
    B --> D["assert callCount >= 1<br/>(WHAT)"]
    X["elapsed &lt; 60_000<br/>(HOW — removed)"]:::gone
    classDef gone stroke-dasharray: 5 5,color:#999;
```

## Evidence

Backend/test-only change — no web interface to screenshot. Verified by running
the modified spec:

```
runAnalysisLoop aborts runParallelAnalysis mid-flight when it never resolves ... ok
runAnalysisLoop records no stall when runParallelAnalysis resolves within budget ... ok
runAnalysisLoop defence-in-depth cap aborts remaining chunks ... ok
ok | 3 passed | 0 failed
```

`deno lint`, `deno fmt --check`, and `deno check` all pass for the file.

## Test Plan

- Modified
  `test/ErrorGuidedStructuralEvolution/DiscoverAnalysisPerChunkTimeout.ts`:
  removed the `elapsed < 60_000` wall-clock assertion and the
  `started`/`elapsed` `Date.now()` measurements from the _"aborts
  runParallelAnalysis mid-flight"_ test.
- All three tests in the file still pass; the behavioural contract
  (`analysisStalled`, `callCount >= 1`) is unchanged.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrnv7mo8-736efa`<!-- vibe-worker-issue-3365 -->