### PR TITLE
Evolution heap: bound discovery flush peak + population topology telemetry (#3402)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.19",
+  "version": "5.9.20",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3402.md
+++ b/docs/archive/pr-summaries/pr-summary-3402.md
@@ -1,0 +1,81 @@
+## Summary
+
+Two changes addressing the GRQ-19 single-generation heap OOM (V8 fatal OOM in
+`Learn.ts`, heap 789 MB → 4 GB within one generation). **Closes #3402.**
+
+1. **Retainer fix — bound the discovery flush peak.** The one *confirmed*
+   unbounded per-sample × per-neuron heap retainer in the evolution engine is
+   the discovery record phase (`activateAndTrace` + `record()`), which the repo
+   already documents as the OOM retainer `MemoryMonitor` cannot free
+   (`AnalysisHeapGuard`, #2594). This is exactly the ".trace store accumulation"
+   suspect the issue names. `shouldFlushRustChunk()` decided the flush against
+   only the *accumulator* estimate (`rustAccumulatedEstimatedBytes`), but
+   `writeRustParquetChunk()` then materialises a **second**, plain-object FFI
+   payload of every pending sample that coexists with the still-live
+   accumulator — so the true peak heap at flush is ~2× the estimate. The
+   byte-based flush now fires against that projected peak, keeping
+   accumulator + transform copy under `rustFlushBytesThreshold` instead of
+   overshooting it by the copy.
+
+2. **Telemetry fix — population topology averages.** The memory-profile line
+   carried `avg_neurons=0 avg_synapses=0`, so a heap that ballooned in one
+   generation could not be attributed to runaway topology. `GenerationCompleteEvent`
+   now carries `averageNeurons` / `averageSynapses`, computed alongside the
+   existing squash histogram in `evolve()`.
+
+### Investigation note (scope honesty)
+
+The reported Learn flags include `--discoverySampleRate=0`, which
+`scheduleDiscovery` treats as "discovery off" (`discoverySampleRate <= 0`
+returns early) and which makes the discovery sample size `ceil(records × 0) = 0`.
+The active heavy paths for those flags (batch scoring, CRISPR, per-generation
+training) were all audited and found to reuse pre-allocated buffers or clear
+their per-generation state — none retains unbounded per-sample data on the main
+isolate. Because Deno Workers are separate V8 isolates in the same process, a
+training/discovery **worker** isolate can independently reach the
+`--max-old-space-size` cap while the main-isolate memprofile still reads
+`heap=789`. This PR fixes the confirmed unbounded retainer of that class (the
+discovery record accumulation) and adds the topology telemetry the issue
+explicitly requested so the exact production spike can be confirmed from a heap
+snapshot on the next occurrence.
+
+## Evidence
+
+Backend/CLI change — no UI to screenshot. Verified by the full quality gate
+(`./quality.sh`): formatting, lint, bash-syntax, type-check, discovery build,
+WASM sync, and the full test suite — **7670 passed / 0 failed**.
+
+### Flush peak accounting
+
+```mermaid
+flowchart TD
+    S[recording loop: one sample] --> A["push into accumulator<br/>rustAccumulatedData +<br/>rustAccumulatedNeuronData"]
+    A --> C{shouldFlushRustChunk?}
+    C -- "records ≥ rustFlushRecords" --> F[flush chunk]
+    C -- "estimate × 2 ≥ bytesThreshold<br/>(#3402: projected peak)" --> F
+    C -- "no" --> S
+    F --> T["writeRustParquetChunk:<br/>build 2nd plain-object payload<br/>(coexists with accumulator)"]
+    T --> R[recordDiscovery FFI]
+    R --> Z["clear accumulator +<br/>estimated bytes = 0"]
+    Z --> S
+```
+
+Before #3402 the flush compared only the accumulator estimate against the
+threshold, so real peak (accumulator + the transform payload built at `T`)
+overshot `rustFlushBytesThreshold` by the size of the copy. Multiplying the
+estimate by `RUST_FLUSH_PEAK_COPY_MULTIPLIER` (= 2) flushes early enough that
+the peak stays under the configured threshold. The record-count ceiling
+(`rustFlushRecords`) is unchanged.
+
+## Test Plan
+
+- `test/NEAT/TopologyAverages.ts` — `computeTopologyAverages` happy path, cross-
+  population averaging, empty-population zeroes (not `NaN`), and the monotonicity
+  signal (larger topology ⇒ larger averages).
+- `test/config/TrainingEvent.ts` — extended the `generation_complete` structure
+  assertion to require finite, strictly-positive `averageNeurons` /
+  `averageSynapses` on the emitted event.
+- `test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts` — `shouldFlushRustChunk`
+  fires once the projected ~2× peak crosses the byte threshold, does **not** fire
+  while the projected peak is under it, and still honours the record-count ceiling.
+- Full `./quality.sh` gate: 7670 passed / 0 failed.

--- a/docs/archive/pr-summaries/pr-summary-3402.md
+++ b/docs/archive/pr-summaries/pr-summary-3402.md
@@ -3,41 +3,40 @@
 Two changes addressing the GRQ-19 single-generation heap OOM (V8 fatal OOM in
 `Learn.ts`, heap 789 MB → 4 GB within one generation). **Closes #3402.**
 
-1. **Retainer fix — bound the discovery flush peak.** The one *confirmed*
+1. **Retainer fix — bound the discovery flush peak.** The one _confirmed_
    unbounded per-sample × per-neuron heap retainer in the evolution engine is
    the discovery record phase (`activateAndTrace` + `record()`), which the repo
    already documents as the OOM retainer `MemoryMonitor` cannot free
    (`AnalysisHeapGuard`, #2594). This is exactly the ".trace store accumulation"
    suspect the issue names. `shouldFlushRustChunk()` decided the flush against
-   only the *accumulator* estimate (`rustAccumulatedEstimatedBytes`), but
+   only the _accumulator_ estimate (`rustAccumulatedEstimatedBytes`), but
    `writeRustParquetChunk()` then materialises a **second**, plain-object FFI
-   payload of every pending sample that coexists with the still-live
-   accumulator — so the true peak heap at flush is ~2× the estimate. The
-   byte-based flush now fires against that projected peak, keeping
-   accumulator + transform copy under `rustFlushBytesThreshold` instead of
-   overshooting it by the copy.
+   payload of every pending sample that coexists with the still-live accumulator
+   — so the true peak heap at flush is ~2× the estimate. The byte-based flush
+   now fires against that projected peak, keeping accumulator + transform copy
+   under `rustFlushBytesThreshold` instead of overshooting it by the copy.
 
 2. **Telemetry fix — population topology averages.** The memory-profile line
    carried `avg_neurons=0 avg_synapses=0`, so a heap that ballooned in one
-   generation could not be attributed to runaway topology. `GenerationCompleteEvent`
-   now carries `averageNeurons` / `averageSynapses`, computed alongside the
-   existing squash histogram in `evolve()`.
+   generation could not be attributed to runaway topology.
+   `GenerationCompleteEvent` now carries `averageNeurons` / `averageSynapses`,
+   computed alongside the existing squash histogram in `evolve()`.
 
 ### Investigation note (scope honesty)
 
 The reported Learn flags include `--discoverySampleRate=0`, which
 `scheduleDiscovery` treats as "discovery off" (`discoverySampleRate <= 0`
-returns early) and which makes the discovery sample size `ceil(records × 0) = 0`.
-The active heavy paths for those flags (batch scoring, CRISPR, per-generation
-training) were all audited and found to reuse pre-allocated buffers or clear
-their per-generation state — none retains unbounded per-sample data on the main
-isolate. Because Deno Workers are separate V8 isolates in the same process, a
-training/discovery **worker** isolate can independently reach the
-`--max-old-space-size` cap while the main-isolate memprofile still reads
-`heap=789`. This PR fixes the confirmed unbounded retainer of that class (the
-discovery record accumulation) and adds the topology telemetry the issue
-explicitly requested so the exact production spike can be confirmed from a heap
-snapshot on the next occurrence.
+returns early) and which makes the discovery sample size
+`ceil(records × 0) = 0`. The active heavy paths for those flags (batch scoring,
+CRISPR, per-generation training) were all audited and found to reuse
+pre-allocated buffers or clear their per-generation state — none retains
+unbounded per-sample data on the main isolate. Because Deno Workers are separate
+V8 isolates in the same process, a training/discovery **worker** isolate can
+independently reach the `--max-old-space-size` cap while the main-isolate
+memprofile still reads `heap=789`. This PR fixes the confirmed unbounded
+retainer of that class (the discovery record accumulation) and adds the topology
+telemetry the issue explicitly requested so the exact production spike can be
+confirmed from a heap snapshot on the next occurrence.
 
 ## Evidence
 
@@ -70,12 +69,13 @@ the peak stays under the configured threshold. The record-count ceiling
 ## Test Plan
 
 - `test/NEAT/TopologyAverages.ts` — `computeTopologyAverages` happy path, cross-
-  population averaging, empty-population zeroes (not `NaN`), and the monotonicity
-  signal (larger topology ⇒ larger averages).
+  population averaging, empty-population zeroes (not `NaN`), and the
+  monotonicity signal (larger topology ⇒ larger averages).
 - `test/config/TrainingEvent.ts` — extended the `generation_complete` structure
   assertion to require finite, strictly-positive `averageNeurons` /
   `averageSynapses` on the emitted event.
-- `test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts` — `shouldFlushRustChunk`
-  fires once the projected ~2× peak crosses the byte threshold, does **not** fire
-  while the projected peak is under it, and still honours the record-count ceiling.
+- `test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts` —
+  `shouldFlushRustChunk` fires once the projected ~2× peak crosses the byte
+  threshold, does **not** fire while the projected peak is under it, and still
+  honours the record-count ceiling.
 - Full `./quality.sh` gate: 7670 passed / 0 failed.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -340,6 +340,7 @@
     "memcpy",
     "memetically",
     "memetics",
+    "memprofile",
     "memoises",
     "memoising",
     "mergesort",

--- a/src/NEAT/NeatEvolution.ts
+++ b/src/NEAT/NeatEvolution.ts
@@ -37,6 +37,10 @@ import {
   computeSquashHistogram,
   type SquashHistogram,
 } from "@neat/SquashHistogram.ts";
+import {
+  computeTopologyAverages,
+  type TopologyAverages,
+} from "@neat/TopologyAverages.ts";
 import type {
   GenerationPhaseTiming,
   GenerationThroughputMetrics,
@@ -84,6 +88,12 @@ export interface EvolveResult {
    * squash-budget A/B experiment.
    */
   squashHistogram: SquashHistogram;
+  /**
+   * Issue #3402: mean neuron and synapse counts across the population after
+   * this generation. Forwarded onto `generation_complete` events so a
+   * memory-profile line can attribute heap growth to topology growth.
+   */
+  topologyAverages: TopologyAverages;
 }
 
 /**
@@ -1095,5 +1105,7 @@ export async function evolve(
     // Issue #3263: population squash mix after this generation, for the
     // squash-budget A/B experiment.
     squashHistogram: computeSquashHistogram(neat.population),
+    // Issue #3402: population topology averages for memory-profile diagnosis.
+    topologyAverages: computeTopologyAverages(neat.population),
   };
 }

--- a/src/NEAT/TopologyAverages.ts
+++ b/src/NEAT/TopologyAverages.ts
@@ -1,0 +1,63 @@
+/**
+ * TopologyAverages.ts - Per-generation population topology telemetry
+ * (Issue #3402).
+ *
+ * Reports the mean neuron and synapse counts across a population. Surfaced on
+ * every `generation_complete` training event so an operator watching a
+ * `[memprofile]`-style line can correlate heap growth with topology growth.
+ *
+ * The GRQ-19 OOM post-mortem (Issue #3402) found the memory-profile line
+ * carried `avg_neurons=0 avg_synapses=0`, so a heap that ballooned within one
+ * generation could not be attributed to runaway topology — a population of 19
+ * creatures should not retain gigabytes. Emitting the real averages closes that
+ * diagnostic gap.
+ *
+ * "Neurons" counts every neuron (input + hidden + output), matching the
+ * `bestNeurons` semantics already used by `EvolveRLMilestoneEvent`.
+ */
+
+import type { Creature } from "@creature";
+
+/**
+ * Mean topology size across a population.
+ */
+export interface TopologyAverages {
+  /**
+   * Mean neuron count (input + hidden + output) across the population.
+   * `0` for an empty population.
+   */
+  readonly averageNeurons: number;
+  /**
+   * Mean synapse count across the population. `0` for an empty population.
+   */
+  readonly averageSynapses: number;
+}
+
+/**
+ * Compute the mean neuron and synapse counts for a population.
+ *
+ * @param creatures - The population to summarise.
+ * @returns The mean neuron and synapse counts. An empty population yields
+ *   `{ averageNeurons: 0, averageSynapses: 0 }` rather than `NaN`, so the
+ *   telemetry never emits a non-finite value.
+ */
+export function computeTopologyAverages(
+  creatures: readonly Creature[],
+): TopologyAverages {
+  const count = creatures.length;
+  if (count === 0) {
+    return { averageNeurons: 0, averageSynapses: 0 };
+  }
+
+  let totalNeurons = 0;
+  let totalSynapses = 0;
+  for (const creature of creatures) {
+    totalNeurons += creature.neurons.length;
+    totalSynapses += creature.synapses.length;
+  }
+
+  return {
+    averageNeurons: totalNeurons / count,
+    averageSynapses: totalSynapses / count,
+  };
+}

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
@@ -36,6 +36,7 @@ import {
   logDiscoveryDiskUsage,
 } from "@discovery/DiskSpaceMonitor.ts";
 import { neuronUuid } from "@neuron/NeuronSerialization.ts";
+import { RUST_FLUSH_PEAK_COPY_MULTIPLIER } from "@architecture/ErrorGuidedStructuralEvolution/constants.ts";
 
 /**
  * Adds recording, chunk management, and flush methods to the
@@ -210,7 +211,16 @@ export class DiscoverStructureRecording extends DiscoverStructureBase {
       "Discovery requires Rust discovery to be enabled.",
     );
     if (this.rustAccumulatedData.length >= this.rustFlushRecords) return true;
-    return this.rustAccumulatedEstimatedBytes >= this.rustFlushBytesThreshold;
+    // Issue #3402: the flush transform (writeRustParquetChunk) builds a second
+    // plain-object FFI payload of every pending sample that coexists with the
+    // still-live accumulator, so the true peak heap at flush is ~2× the
+    // accumulated estimate. Trigger the byte-based flush against that projected
+    // peak so it stays under `rustFlushBytesThreshold` instead of overshooting
+    // it by the copy — the discovery heap retainer MemoryMonitor cannot free
+    // (#2594).
+    const projectedPeakBytes = this.rustAccumulatedEstimatedBytes *
+      RUST_FLUSH_PEAK_COPY_MULTIPLIER;
+    return projectedPeakBytes >= this.rustFlushBytesThreshold;
   }
 
   private getNextChunkDir(): string {

--- a/src/architecture/ErrorGuidedStructuralEvolution/constants.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/constants.ts
@@ -14,3 +14,24 @@ export const DEFAULT_RUST_FLUSH_RECORDS = 4_096;
  * JSON.stringify() when preparing FFI payloads (e.g. "Invalid string length").
  */
 export const DEFAULT_RUST_FLUSH_BYTES = 50 * 1024 * 1024; // ~50 MiB
+
+/**
+ * Multiplier applied to the accumulated per-sample estimate when deciding
+ * whether to flush a Rust discovery chunk (Issue #3402).
+ *
+ * `rustAccumulatedEstimatedBytes` estimates the size of the *accumulator*
+ * (`rustAccumulatedData` + `rustAccumulatedNeuronData`). But `writeRustParquetChunk`
+ * transforms that accumulator into a **second**, plain-object FFI payload
+ * (`rustTrainingData`: `Array.from` inputs/outputs plus a per-neuron object with
+ * a UUID string and a copied errors array) that is held *simultaneously* with
+ * the still-live accumulator during the FFI call. The true peak heap at flush is
+ * therefore roughly double the accumulated estimate.
+ *
+ * Comparing only the accumulator estimate against `rustFlushBytesThreshold`
+ * (whose documented purpose is to bound the FFI *payload*) lets the real peak
+ * overshoot the threshold by the copy — the single-generation discovery heap
+ * retainer `MemoryMonitor` cannot free (documented in `AnalysisHeapGuard`,
+ * #2594). Multiplying the estimate by this factor triggers the flush early
+ * enough that peak (accumulator + transform copy) stays under the threshold.
+ */
+export const RUST_FLUSH_PEAK_COPY_MULTIPLIER = 2;

--- a/src/config/TrainingEvent.ts
+++ b/src/config/TrainingEvent.ts
@@ -316,6 +316,21 @@ export interface GenerationCompleteEvent {
   readonly averageFitness: number;
   /** Current population size. */
   readonly populationSize: number;
+  /**
+   * Mean neuron count (input + hidden + output) across the population after
+   * this generation. Always a finite number (`0` for an empty population).
+   *
+   * Issue #3402: the GRQ-19 OOM memprofile line carried `avg_neurons=0`, so a
+   * heap that ballooned within one generation could not be attributed to
+   * runaway topology. Surfacing the real average closes that diagnostic gap.
+   */
+  readonly averageNeurons: number;
+  /**
+   * Mean synapse count across the population after this generation. Always a
+   * finite number (`0` for an empty population). Issue #3402 — see
+   * {@link GenerationCompleteEvent.averageNeurons}.
+   */
+  readonly averageSynapses: number;
   /** Time elapsed for this generation in milliseconds. */
   readonly elapsedMs: number;
   /**

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -633,6 +633,9 @@ export async function evolveDir(
       bestFitness: fittestScore,
       averageFitness: result.averageScore,
       populationSize: neat.population.length,
+      // Issue #3402: population topology averages for memory-profile diagnosis.
+      averageNeurons: result.topologyAverages.averageNeurons,
+      averageSynapses: result.topologyAverages.averageSynapses,
       elapsedMs: generationElapsedMs,
       phaseTiming,
       throughput: result.throughput,
@@ -960,6 +963,9 @@ export async function evolveEnv<S, A>(
       bestFitness: fittestScore,
       averageFitness: result.averageScore,
       populationSize: neat.population.length,
+      // Issue #3402: population topology averages for memory-profile diagnosis.
+      averageNeurons: result.topologyAverages.averageNeurons,
+      averageSynapses: result.topologyAverages.averageSynapses,
       elapsedMs: generationElapsedMs,
       phaseTiming,
       throughput: result.throughput,
@@ -1468,6 +1474,9 @@ export async function evolveRL<S, A>(
       bestFitness: fittestScore,
       averageFitness: result.averageScore,
       populationSize: neat.population.length,
+      // Issue #3402: population topology averages for memory-profile diagnosis.
+      averageNeurons: result.topologyAverages.averageNeurons,
+      averageSynapses: result.topologyAverages.averageSynapses,
       elapsedMs: generationElapsedMs,
       phaseTiming,
       throughput: result.throughput,

--- a/test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts
+++ b/test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the flush-threshold peak-copy accounting (Issue #3402).
+ *
+ * `writeRustParquetChunk` transforms the accumulator into a second, plain-object
+ * FFI payload that coexists with the still-live accumulator during the FFI call,
+ * so the true peak heap at flush is ~2× `rustAccumulatedEstimatedBytes`.
+ * `shouldFlushRustChunk` must decide against that projected peak so it stays
+ * under `rustFlushBytesThreshold` rather than overshooting it by the copy — the
+ * single-generation discovery heap retainer `MemoryMonitor` cannot free (#2594).
+ */
+
+import { assertEquals } from "@std/assert";
+import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { DiscoverStructureDeps } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { Creature } from "@creature";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { RUST_FLUSH_PEAK_COPY_MULTIPLIER } from "@architecture/ErrorGuidedStructuralEvolution/constants.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+function makeTestCreature(): Creature {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { uuid: "hidden-a", type: "hidden", squash: IDENTITY.NAME, bias: 0 },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-a", weight: 0.5 },
+      { fromUUID: "hidden-a", toUUID: "output-0", weight: 0.5 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+function buildStructure(): DiscoverStructure {
+  const deps: Partial<DiscoverStructureDeps> = {
+    isRustDiscoveryEnabled: () => true,
+    isRustLibraryAvailable: () => true,
+    recordDiscovery: () => ({ success: true, file: "/tmp/ignored.parquet" }),
+  };
+  const structure = new DiscoverStructure(makeTestCreature(), 600, 4096, deps);
+  structure.initialize(new Map());
+  // Mark the Rust dual-write path active so `shouldFlushRustChunk` runs.
+  (structure as unknown as { usingRustDualWrite: boolean }).usingRustDualWrite =
+    true;
+  return structure;
+}
+
+Deno.test("shouldFlushRustChunk: fires once projected peak (2x estimate) crosses the byte threshold", async () => {
+  await initWasmForTests();
+  const structure = buildStructure();
+  const s = structure as unknown as {
+    rustFlushBytesThreshold: number;
+    rustAccumulatedEstimatedBytes: number;
+    rustAccumulatedData: unknown[];
+    shouldFlushRustChunk: () => boolean;
+  };
+
+  s.rustFlushBytesThreshold = 1000;
+  // Two accumulated samples so the record-count path (4096) is not the trigger.
+  s.rustAccumulatedData = [{}, {}];
+
+  // Accumulator estimate below threshold but its ~2x flush-time peak is at/above
+  // it: the old estimate-only check under-fired and let the real payload
+  // overshoot. It must now flush.
+  s.rustAccumulatedEstimatedBytes = Math.ceil(
+    1000 / RUST_FLUSH_PEAK_COPY_MULTIPLIER,
+  );
+  assertEquals(structure.shouldFlushRustChunk(), true);
+});
+
+Deno.test("shouldFlushRustChunk: does not fire while the projected peak is under the threshold", async () => {
+  await initWasmForTests();
+  const structure = buildStructure();
+  const s = structure as unknown as {
+    rustFlushBytesThreshold: number;
+    rustAccumulatedEstimatedBytes: number;
+    rustAccumulatedData: unknown[];
+    shouldFlushRustChunk: () => boolean;
+  };
+
+  s.rustFlushBytesThreshold = 1000;
+  s.rustAccumulatedData = [{}, {}];
+  // Projected peak = 2 * 400 = 800 < 1000 — no flush.
+  s.rustAccumulatedEstimatedBytes = 400;
+  assertEquals(structure.shouldFlushRustChunk(), false);
+});
+
+Deno.test("shouldFlushRustChunk: record-count ceiling still forces a flush", async () => {
+  await initWasmForTests();
+  const structure = buildStructure();
+  const s = structure as unknown as {
+    rustFlushRecords: number;
+    rustFlushBytesThreshold: number;
+    rustAccumulatedEstimatedBytes: number;
+    rustAccumulatedData: unknown[];
+    shouldFlushRustChunk: () => boolean;
+  };
+
+  s.rustFlushRecords = 3;
+  s.rustFlushBytesThreshold = Number.MAX_SAFE_INTEGER;
+  s.rustAccumulatedEstimatedBytes = 0;
+  s.rustAccumulatedData = [{}, {}, {}];
+  assertEquals(structure.shouldFlushRustChunk(), true);
+});

--- a/test/NEAT/TopologyAverages.ts
+++ b/test/NEAT/TopologyAverages.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the per-generation topology-average telemetry (Issue #3402).
+ */
+
+import { assertEquals } from "@std/assert";
+import { Creature, type CreatureExport } from "../../mod.ts";
+import { computeTopologyAverages } from "@neat/TopologyAverages.ts";
+
+/**
+ * Build a creature with `hidden` hidden neurons and one output, each wired from
+ * `input-0`. Neuron count is `hidden + output` (this project's `neurons` array
+ * excludes the input placeholders when constructed from a UUID-only export, so
+ * the assertions below use the resulting `creature.neurons.length`).
+ */
+function makeCreature(hidden: number): Creature {
+  const neurons: CreatureExport["neurons"] = [];
+  const synapses: CreatureExport["synapses"] = [];
+
+  for (let i = 0; i < hidden; i++) {
+    neurons.push({
+      type: "hidden",
+      uuid: `hidden-${i}`,
+      squash: "TANH",
+      bias: 0,
+    });
+    synapses.push({ fromUUID: "input-0", toUUID: `hidden-${i}`, weight: 0.5 });
+    synapses.push({ fromUUID: `hidden-${i}`, toUUID: "output-0", weight: 0.5 });
+  }
+  neurons.push({
+    type: "output",
+    uuid: "output-0",
+    squash: "IDENTITY",
+    bias: 0,
+  });
+  synapses.push({ fromUUID: "input-0", toUUID: "output-0", weight: 0.5 });
+
+  const json: CreatureExport = {
+    input: 1,
+    output: 1,
+    neurons,
+    synapses,
+  };
+  return Creature.fromJSON(json);
+}
+
+Deno.test("computeTopologyAverages: single creature returns its own counts", () => {
+  const creature = makeCreature(2);
+  const averages = computeTopologyAverages([creature]);
+  assertEquals(averages.averageNeurons, creature.neurons.length);
+  assertEquals(averages.averageSynapses, creature.synapses.length);
+});
+
+Deno.test("computeTopologyAverages: averages across a population", () => {
+  const small = makeCreature(1);
+  const large = makeCreature(3);
+  const averages = computeTopologyAverages([small, large]);
+
+  const expectedNeurons = (small.neurons.length + large.neurons.length) / 2;
+  const expectedSynapses = (small.synapses.length + large.synapses.length) / 2;
+  assertEquals(averages.averageNeurons, expectedNeurons);
+  assertEquals(averages.averageSynapses, expectedSynapses);
+});
+
+Deno.test("computeTopologyAverages: empty population yields zeroes, not NaN", () => {
+  const averages = computeTopologyAverages([]);
+  assertEquals(averages, { averageNeurons: 0, averageSynapses: 0 });
+});
+
+Deno.test("computeTopologyAverages: larger topology raises both averages", () => {
+  const before = computeTopologyAverages([makeCreature(1)]);
+  const after = computeTopologyAverages([makeCreature(5)]);
+  // Both counts must strictly increase with topology size — this is the signal
+  // the GRQ-19 memprofile line was missing (Issue #3402).
+  assertEquals(after.averageNeurons > before.averageNeurons, true);
+  assertEquals(after.averageSynapses > before.averageSynapses, true);
+});

--- a/test/config/TrainingEvent.ts
+++ b/test/config/TrainingEvent.ts
@@ -52,6 +52,17 @@ Deno.test("TrainingEvent - generation_complete events are emitted", async () => 
   assertEquals(typeof first.bestFitness, "number");
   assertEquals(typeof first.averageFitness, "number");
   assertGreater(first.populationSize, 0);
+  // Issue #3402: population topology averages must be present and finite so a
+  // memory-profile line can attribute heap growth to topology growth.
+  assertEquals(typeof first.averageNeurons, "number");
+  assertEquals(Number.isFinite(first.averageNeurons), true);
+  assertEquals(typeof first.averageSynapses, "number");
+  assertEquals(Number.isFinite(first.averageSynapses), true);
+  // A 2-input/1-output creature always has at least one neuron and one synapse,
+  // so the population averages must be strictly positive (not the 0 the GRQ-19
+  // memprofile line reported).
+  assertGreater(first.averageNeurons, 0);
+  assertGreater(first.averageSynapses, 0);
   assertGreater(first.elapsedMs, -1);
 
   // Timestamp should be a valid ISO-8601 string


### PR DESCRIPTION
## Summary

Two changes addressing the GRQ-19 single-generation heap OOM (V8 fatal OOM in
`Learn.ts`, heap 789 MB → 4 GB within one generation). **Closes #3402.**

1. **Retainer fix — bound the discovery flush peak.** The one *confirmed*
   unbounded per-sample × per-neuron heap retainer in the evolution engine is
   the discovery record phase (`activateAndTrace` + `record()`), which the repo
   already documents as the OOM retainer `MemoryMonitor` cannot free
   (`AnalysisHeapGuard`, #2594). This is exactly the ".trace store accumulation"
   suspect the issue names. `shouldFlushRustChunk()` decided the flush against
   only the *accumulator* estimate (`rustAccumulatedEstimatedBytes`), but
   `writeRustParquetChunk()` then materialises a **second**, plain-object FFI
   payload of every pending sample that coexists with the still-live
   accumulator — so the true peak heap at flush is ~2× the estimate. The
   byte-based flush now fires against that projected peak, keeping
   accumulator + transform copy under `rustFlushBytesThreshold` instead of
   overshooting it by the copy.

2. **Telemetry fix — population topology averages.** The memory-profile line
   carried `avg_neurons=0 avg_synapses=0`, so a heap that ballooned in one
   generation could not be attributed to runaway topology. `GenerationCompleteEvent`
   now carries `averageNeurons` / `averageSynapses`, computed alongside the
   existing squash histogram in `evolve()`.

### Investigation note (scope honesty)

The reported Learn flags include `--discoverySampleRate=0`, which
`scheduleDiscovery` treats as "discovery off" (`discoverySampleRate <= 0`
returns early) and which makes the discovery sample size `ceil(records × 0) = 0`.
The active heavy paths for those flags (batch scoring, CRISPR, per-generation
training) were all audited and found to reuse pre-allocated buffers or clear
their per-generation state — none retains unbounded per-sample data on the main
isolate. Because Deno Workers are separate V8 isolates in the same process, a
training/discovery **worker** isolate can independently reach the
`--max-old-space-size` cap while the main-isolate memprofile still reads
`heap=789`. This PR fixes the confirmed unbounded retainer of that class (the
discovery record accumulation) and adds the topology telemetry the issue
explicitly requested so the exact production spike can be confirmed from a heap
snapshot on the next occurrence.

## Evidence

Backend/CLI change — no UI to screenshot. Verified by the full quality gate
(`./quality.sh`): formatting, lint, bash-syntax, type-check, discovery build,
WASM sync, and the full test suite — **7670 passed / 0 failed**.

### Flush peak accounting

```mermaid
flowchart TD
    S[recording loop: one sample] --> A["push into accumulator<br/>rustAccumulatedData +<br/>rustAccumulatedNeuronData"]
    A --> C{shouldFlushRustChunk?}
    C -- "records ≥ rustFlushRecords" --> F[flush chunk]
    C -- "estimate × 2 ≥ bytesThreshold<br/>(#3402: projected peak)" --> F
    C -- "no" --> S
    F --> T["writeRustParquetChunk:<br/>build 2nd plain-object payload<br/>(coexists with accumulator)"]
    T --> R[recordDiscovery FFI]
    R --> Z["clear accumulator +<br/>estimated bytes = 0"]
    Z --> S
```

Before #3402 the flush compared only the accumulator estimate against the
threshold, so real peak (accumulator + the transform payload built at `T`)
overshot `rustFlushBytesThreshold` by the size of the copy. Multiplying the
estimate by `RUST_FLUSH_PEAK_COPY_MULTIPLIER` (= 2) flushes early enough that
the peak stays under the configured threshold. The record-count ceiling
(`rustFlushRecords`) is unchanged.

## Test Plan

- `test/NEAT/TopologyAverages.ts` — `computeTopologyAverages` happy path, cross-
  population averaging, empty-population zeroes (not `NaN`), and the monotonicity
  signal (larger topology ⇒ larger averages).
- `test/config/TrainingEvent.ts` — extended the `generation_complete` structure
  assertion to require finite, strictly-positive `averageNeurons` /
  `averageSynapses` on the emitted event.
- `test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts` — `shouldFlushRustChunk`
  fires once the projected ~2× peak crosses the byte threshold, does **not** fire
  while the projected peak is under it, and still honours the record-count ceiling.
- Full `./quality.sh` gate: 7670 passed / 0 failed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrpxzd9u-7fc8e4`<!-- vibe-worker-issue-3402 -->