### PR TITLE
Benchmark: Score-per-wall-clock-hour harness (#3398)

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -15,6 +15,10 @@ on:
       - "bench/**"
       - "deno.json"
       - ".github/workflows/bench.yaml"
+  # Weekly scheduled run drives the score-per-hour regression gate (Issue
+  # #3398) against the checked-in baseline trajectory.
+  schedule:
+    - cron: "0 4 * * 1"
   workflow_dispatch:
 
 # Cancel superseded runs on the same ref so rapid pushes don't pile up.
@@ -68,4 +72,58 @@ jobs:
           name: bench-smoke-output
           path: bench-smoke-output.txt
           retention-days: 7
+          if-no-files-found: warn
+
+  score-per-hour-regression:
+    name: Score-per-hour regression gate
+    # Only on the weekly schedule / manual dispatch — this runs a real
+    # (bounded) evolution and is slower than the smoke pass (Issue #3398).
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NEAT_RUST_DISCOVERY_OPTIONAL: "true"
+    steps:
+      - name: Checkout Code
+        # `persist-credentials: false` (Issue #3349) — this job only reads the
+        # repo and uploads an artifact; it never pushes back.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Deno
+        # denoland/setup-deno@v2.0.4
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+
+      - name: Sync WASM package from NEAT-AI-core
+        run: ./build.sh --verify-only
+
+      - name: Run score-per-hour harness against the baseline trajectory
+        # Same seeded config as bench/baseline_score_trajectory.json. The gate
+        # fails (non-zero exit) if the deterministic evolution outcome regresses
+        # below the checked-in baseline, or if the run produced no score samples
+        # (silent-failure guard). Score/hour drift is reported as an advisory
+        # warning, not a hard failure, because wall-clock timing is
+        # machine-load-dependent.
+        run: |
+          set -Eeuo pipefail
+          export NO_COLOR=true
+          deno run --allow-read --allow-write --allow-env --allow-ffi \
+            bench/score_per_hour_harness.ts \
+            --scale=grq-3397 --inputs=2461 --outputs=2 --samples=20 \
+            --population=10 --max-generations=10 --time-budget-ms=600000 \
+            --seed=3396 --train-per-gen=0 \
+            --baseline=bench/baseline_score_trajectory.json \
+            --out=score-per-hour-trajectory.json 2>&1 | tee score-per-hour-output.txt
+
+      - name: Upload score-per-hour trajectory
+        if: ${{ always() }}
+        # actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: score-per-hour-trajectory
+          path: |
+            score-per-hour-trajectory.json
+            score-per-hour-output.txt
+          retention-days: 30
           if-no-files-found: warn

--- a/bench/baseline_score_trajectory.json
+++ b/bench/baseline_score_trajectory.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "config": {
+    "seed": 3396,
+    "scale": "grq-3397",
+    "inputCount": 2461,
+    "outputCount": 2,
+    "sampleCount": 20,
+    "populationSize": 10,
+    "maxGenerations": 10,
+    "timeBudgetMs": 600000,
+    "threads": 1,
+    "trainPerGen": 0,
+    "discoverySampleRate": -1
+  },
+  "topology": {
+    "neurons": 1666,
+    "synapses": 21560,
+    "inputs": 2461
+  },
+  "usedRealTrainData": false,
+  "scoreTrajectory": [
+    {
+      "generation": 1,
+      "elapsedMs": 7598.385458,
+      "bestFitness": -1.4394885350527997e+31,
+      "averageFitness": -1.6850841423201814e+31
+    },
+    {
+      "generation": 2,
+      "elapsedMs": 12890.169625,
+      "bestFitness": -1.4394885350527997e+31,
+      "averageFitness": -1.5173458155349338e+31
+    },
+    {
+      "generation": 3,
+      "elapsedMs": 16480.266625,
+      "bestFitness": -1.3685010273181068e+31,
+      "averageFitness": -1.5317111232301896e+31
+    },
+    {
+      "generation": 4,
+      "elapsedMs": 20005.7995,
+      "bestFitness": -1.3681436502264738e+31,
+      "averageFitness": -1.427926354625945e+31
+    },
+    {
+      "generation": 5,
+      "elapsedMs": 23770.362583000002,
+      "bestFitness": -1.289385276135227e+31,
+      "averageFitness": -1.3756106209682727e+31
+    },
+    {
+      "generation": 6,
+      "elapsedMs": 27345.400041,
+      "bestFitness": -1.289385276135227e+31,
+      "averageFitness": -1.317348193091206e+31
+    },
+    {
+      "generation": 7,
+      "elapsedMs": 30242.415083,
+      "bestFitness": -1.283532610770523e+31,
+      "averageFitness": -1.2884098317519917e+31
+    },
+    {
+      "generation": 8,
+      "elapsedMs": 33526.086708,
+      "bestFitness": -1.2576869685680517e+31,
+      "averageFitness": -1.3001487879634245e+31
+    },
+    {
+      "generation": 9,
+      "elapsedMs": 37411.024958,
+      "bestFitness": -1.2576869685680517e+31,
+      "averageFitness": -1.303180510700828e+31
+    },
+    {
+      "generation": 10,
+      "elapsedMs": 40672.714916000004,
+      "bestFitness": -1.257652533664427e+31,
+      "averageFitness": -1.284502823232164e+31
+    }
+  ],
+  "initialBestFitness": -1.4394885350527997e+31,
+  "finalBestFitness": -1.257652533664427e+31,
+  "bestFitness": -1.257652533664427e+31,
+  "totalElapsedMs": 40710.551416,
+  "scorePerHour": 1.607960546417133e+32
+}

--- a/bench/score_per_hour_harness.ts
+++ b/bench/score_per_hour_harness.ts
@@ -1,0 +1,653 @@
+/**
+ * Issue #3398 — Score-per-wall-clock-hour benchmark harness.
+ *
+ * The agreed success metric for the #3396 evolution-performance milestone is
+ * **score improvement per wall-clock hour** inside the production learn/sampler
+ * time-boxes — not raw throughput. This harness measures that metric directly
+ * so every #3396 implementation sub-issue can show honest, apples-to-apples
+ * before/after evidence within a fixed time budget.
+ *
+ * What it does:
+ *   1. Deterministically generates the production-scale synthetic topology used
+ *      by `worker/learn.sh` / `worker/sampler.sh` (the `grq-3397` preset:
+ *      ~1,666 neurons / ~21,513 synapses / 2,461 inputs) via the shared
+ *      `test/propagate/large/ProductionScaleCreature.ts` generators.
+ *   2. Runs `evolveDataSet` under a fixed wall-clock budget (or generation cap),
+ *      seeding the NEAT RNG so runs are reproducible.
+ *   3. Records a **score-vs-time curve** (best/average fitness at each
+ *      generation, with cumulative wall-clock elapsed) and derives the
+ *      **score gained per hour**.
+ *   4. Emits machine-readable JSON for CI/regression tracking.
+ *
+ * Determinism: the NEAT engine is seeded (`seed`), so the score trajectory
+ * (generation → best/average fitness) is byte-identical across runs. Wall-clock
+ * timing is injected via a `now()` clock so a determinism smoke test can drive
+ * a virtual clock and get byte-identical timing too; production runs use
+ * `performance.now()`.
+ *
+ * Silent-failure guard (Issue #3234): the run throws if it produced no score
+ * samples, so a wedged learn/sampler invocation surfaces as a hard failure
+ * rather than an empty report.
+ *
+ * CLI:
+ *   deno run --allow-read --allow-write --allow-env --allow-ffi \
+ *     bench/score_per_hour_harness.ts \
+ *     --scale=grq-3397 --time-budget-ms=2700000 --max-generations=100 \
+ *     --population=20 --seed=3396 --out=trajectory.json
+ *
+ *   # Regression gate against the checked-in baseline:
+ *   deno run ... bench/score_per_hour_harness.ts \
+ *     --baseline=bench/baseline_score_trajectory.json
+ */
+
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import type { TrainingEvent } from "@config/TrainingEvent.ts";
+import {
+  createSeededRng,
+  generateProductionCreature,
+  generateTrainingData,
+} from "../test/propagate/large/ProductionScaleCreature.ts";
+
+/** Machine-readable output schema version. Bump on breaking shape changes. */
+export const HARNESS_SCHEMA_VERSION = 1 as const;
+
+/** Configuration for a single harness run. Fully serialised into the output. */
+export interface HarnessConfig {
+  /** Seed for the NEAT RNG and the synthetic generators — drives reproducibility. */
+  readonly seed: number;
+  /** Synthetic topology preset from ProductionScaleCreature. */
+  readonly scale: "default" | "grq-cluster" | "grq-3397";
+  /** Number of inputs (2,461 matches the production `network.json`). */
+  readonly inputCount: number;
+  /** Number of outputs. */
+  readonly outputCount: number;
+  /** Number of synthetic training samples. */
+  readonly sampleCount: number;
+  /** Population size (`worker/learn.sh` production value is 20). */
+  readonly populationSize: number;
+  /** Hard generation cap — the run also stops at `timeBudgetMs`. */
+  readonly maxGenerations: number;
+  /** Wall-clock budget in milliseconds (learn.sh ≈ 45 min; sampler ≈ 1 h). */
+  readonly timeBudgetMs: number;
+  /** Worker threads (1 keeps the harness deterministic and portable). */
+  readonly threads: number;
+  /**
+   * Backprop training sessions per generation. Defaults to `0` — pure seeded
+   * neuroevolution (mutation + selection), which is byte-reproducible and still
+   * improves the score across generations. Async backprop training (`>= 1`)
+   * makes score improvement faster but completes on worker threads whose
+   * scheduling is wall-clock-dependent, so runs are seeded-but-not-byte-
+   * identical; use it for a production-faithful measurement, not the
+   * determinism smoke test.
+   */
+  readonly trainPerGen: number;
+  /**
+   * Discovery sample rate passed straight to `evolveDataSet`. Defaults to `-1`
+   * (discovery disabled) so the measured score trajectory depends only on the
+   * seeded evolution loop and is byte-reproducible — the native discovery
+   * library adds FFI, disk, and timing non-determinism that would break the
+   * determinism guarantee. Raise it for a fuller production-faithful run.
+   */
+  readonly discoverySampleRate: number;
+  /**
+   * Optional path to a real `.trainData` JSON sample (array of
+   * `{ input, output }`). When set, its records replace the synthetic training
+   * data so the harness can sanity-check against real data where cheap.
+   */
+  readonly trainDataPath?: string;
+}
+
+/** One point on the score-vs-time curve. */
+export interface ScoreSample {
+  /** 1-based generation number. */
+  readonly generation: number;
+  /** Cumulative wall-clock milliseconds since the run started. */
+  readonly elapsedMs: number;
+  /** Best fitness in the population at this generation (higher is better). */
+  readonly bestFitness: number;
+  /** Average fitness across the population at this generation. */
+  readonly averageFitness: number;
+}
+
+/** Full machine-readable harness result. */
+export interface HarnessResult {
+  readonly schemaVersion: number;
+  readonly config: HarnessConfig;
+  /** Actual topology exercised — a guard that the preset matches production. */
+  readonly topology: {
+    readonly neurons: number;
+    readonly synapses: number;
+    readonly inputs: number;
+  };
+  /** Whether the real `.trainData` sample was used instead of synthetic data. */
+  readonly usedRealTrainData: boolean;
+  /** The score-vs-time curve. */
+  readonly scoreTrajectory: readonly ScoreSample[];
+  /** Best fitness of the first recorded generation. */
+  readonly initialBestFitness: number;
+  /** Best fitness of the last recorded generation. */
+  readonly finalBestFitness: number;
+  /** Maximum best fitness reached anywhere in the trajectory. */
+  readonly bestFitness: number;
+  /** Total wall-clock milliseconds for the run. */
+  readonly totalElapsedMs: number;
+  /**
+   * Score gained per wall-clock hour:
+   * `(finalBestFitness - initialBestFitness) / (totalElapsedMs / 3_600_000)`.
+   * `0` when no measurable time elapsed.
+   */
+  readonly scorePerHour: number;
+}
+
+/** Options that steer the run but are not serialised into the result. */
+export interface RunOptions {
+  /**
+   * Injectable monotonic clock in milliseconds. Defaults to
+   * `performance.now()`. A determinism test injects a virtual clock so the
+   * timing fields become byte-reproducible.
+   */
+  readonly now?: () => number;
+}
+
+/** Fill in the defaults for a partial config (used by the CLI). */
+export function withConfigDefaults(
+  partial: Partial<HarnessConfig> = {},
+): HarnessConfig {
+  return {
+    seed: partial.seed ?? 3396,
+    scale: partial.scale ?? "grq-3397",
+    inputCount: partial.inputCount ?? 2461,
+    outputCount: partial.outputCount ?? 2,
+    sampleCount: partial.sampleCount ?? 50,
+    populationSize: partial.populationSize ?? 20,
+    maxGenerations: partial.maxGenerations ?? 100,
+    timeBudgetMs: partial.timeBudgetMs ?? 45 * 60_000,
+    threads: partial.threads ?? 1,
+    trainPerGen: partial.trainPerGen ?? 0,
+    discoverySampleRate: partial.discoverySampleRate ?? -1,
+    trainDataPath: partial.trainDataPath,
+  };
+}
+
+/** Load and validate a real `.trainData` sample into typed records. */
+async function loadRealTrainData(
+  path: string,
+): Promise<DataRecordInterface[]> {
+  const text = await Deno.readTextFile(path);
+  const parsed = JSON.parse(text);
+  const rawRecords: unknown = Array.isArray(parsed) ? parsed : parsed?.data;
+  if (!Array.isArray(rawRecords) || rawRecords.length === 0) {
+    throw new Error(
+      `trainData sample '${path}' must be a non-empty array of {input, output} records`,
+    );
+  }
+  return rawRecords.map((record, index) => {
+    const rec = record as { input?: unknown; output?: unknown };
+    if (!Array.isArray(rec.input) || !Array.isArray(rec.output)) {
+      throw new Error(
+        `trainData sample '${path}' record ${index} is missing numeric input/output arrays`,
+      );
+    }
+    return {
+      input: new Float32Array(rec.input as number[]),
+      output: new Float32Array(rec.output as number[]),
+    };
+  });
+}
+
+/**
+ * Run the harness and return the machine-readable trajectory + score/hour.
+ *
+ * Throws when the run produces no score samples (Issue #3234 — never report an
+ * empty run as a clean outcome).
+ */
+export async function runScorePerHourHarness(
+  config: HarnessConfig,
+  options: RunOptions = {},
+): Promise<HarnessResult> {
+  const now = options.now ?? (() => performance.now());
+
+  const creatureRng = createSeededRng(config.seed);
+  const creatureExport: CreatureExport = generateProductionCreature(
+    config.inputCount,
+    config.outputCount,
+    creatureRng,
+    { scale: config.scale },
+  );
+
+  let trainingData: DataRecordInterface[];
+  let usedRealTrainData = false;
+  if (config.trainDataPath) {
+    trainingData = await loadRealTrainData(config.trainDataPath);
+    usedRealTrainData = true;
+  } else {
+    const dataRng = createSeededRng(config.seed + 1_000);
+    trainingData = generateTrainingData(
+      config.inputCount,
+      config.outputCount,
+      config.sampleCount,
+      dataRng,
+    );
+  }
+
+  const samples: ScoreSample[] = [];
+  const start = now();
+
+  const evolveOptions: NeatOptions = {
+    iterations: config.maxGenerations,
+    timeoutMinutes: config.timeBudgetMs / 60_000,
+    targetError: 0,
+    populationSize: config.populationSize,
+    threads: config.threads,
+    seed: config.seed,
+    trainPerGen: config.trainPerGen,
+    discoverySampleRate: config.discoverySampleRate,
+    onTrainingEvent: (event: TrainingEvent) => {
+      if (event.kind === "generation_complete") {
+        samples.push({
+          generation: event.generation,
+          elapsedMs: now() - start,
+          bestFitness: event.bestFitness,
+          averageFitness: event.averageFitness,
+        });
+      }
+    },
+  };
+
+  const creature = Creature.fromJSON(creatureExport);
+  await creature.evolveDataSet(trainingData, evolveOptions);
+
+  const totalElapsedMs = now() - start;
+
+  return summariseTrajectory(samples, totalElapsedMs, {
+    config,
+    topology: {
+      neurons: creatureExport.neurons.length,
+      synapses: creatureExport.synapses.length,
+      inputs: creatureExport.input,
+    },
+    usedRealTrainData,
+  });
+}
+
+/**
+ * Derive the score-per-hour summary from a raw score-vs-time curve.
+ *
+ * Silent-failure guard (Issue #3234): throws when the curve is empty — an empty
+ * curve means the run wedged or completed no generation, and reporting it as a
+ * clean result would mask the fault.
+ */
+export function summariseTrajectory(
+  samples: readonly ScoreSample[],
+  totalElapsedMs: number,
+  meta: {
+    config: HarnessConfig;
+    topology: HarnessResult["topology"];
+    usedRealTrainData: boolean;
+  },
+): HarnessResult {
+  if (samples.length === 0) {
+    throw new Error(
+      "Score-per-hour harness produced no score samples — the evolution run " +
+        "completed no generations within the time budget. Refusing to emit an " +
+        "empty trajectory (Issue #3234).",
+    );
+  }
+
+  const initialBestFitness = samples[0].bestFitness;
+  const finalBestFitness = samples[samples.length - 1].bestFitness;
+  const bestFitness = samples.reduce(
+    (max, s) => (s.bestFitness > max ? s.bestFitness : max),
+    samples[0].bestFitness,
+  );
+  const elapsedHours = totalElapsedMs / 3_600_000;
+  const scorePerHour = elapsedHours > 0
+    ? (finalBestFitness - initialBestFitness) / elapsedHours
+    : 0;
+
+  return {
+    schemaVersion: HARNESS_SCHEMA_VERSION,
+    config: meta.config,
+    topology: meta.topology,
+    usedRealTrainData: meta.usedRealTrainData,
+    scoreTrajectory: samples,
+    initialBestFitness,
+    finalBestFitness,
+    bestFitness,
+    totalElapsedMs,
+    scorePerHour,
+  };
+}
+
+/**
+ * Schema-validate a parsed harness result. Returns the list of problems found
+ * (empty array = valid). Used by the determinism smoke test and the CLI so a
+ * malformed output fails CI rather than being silently trusted.
+ */
+export function validateHarnessResult(value: unknown): string[] {
+  const problems: string[] = [];
+  const isFiniteNumber = (n: unknown): n is number =>
+    typeof n === "number" && Number.isFinite(n);
+
+  if (typeof value !== "object" || value === null) {
+    return ["result is not an object"];
+  }
+  const r = value as Record<string, unknown>;
+
+  if (r.schemaVersion !== HARNESS_SCHEMA_VERSION) {
+    problems.push(
+      `schemaVersion must be ${HARNESS_SCHEMA_VERSION}, got ${
+        String(r.schemaVersion)
+      }`,
+    );
+  }
+  if (typeof r.config !== "object" || r.config === null) {
+    problems.push("config missing");
+  }
+  const topology = r.topology as Record<string, unknown> | undefined;
+  if (
+    !topology || !isFiniteNumber(topology.neurons) ||
+    !isFiniteNumber(topology.synapses) || !isFiniteNumber(topology.inputs)
+  ) {
+    problems.push("topology missing numeric neurons/synapses/inputs");
+  }
+  if (typeof r.usedRealTrainData !== "boolean") {
+    problems.push("usedRealTrainData must be a boolean");
+  }
+
+  const trajectory = r.scoreTrajectory;
+  if (!Array.isArray(trajectory) || trajectory.length === 0) {
+    problems.push("scoreTrajectory must be a non-empty array");
+  } else {
+    trajectory.forEach((sample, index) => {
+      const s = sample as Record<string, unknown>;
+      if (!isFiniteNumber(s.generation)) {
+        problems.push(`scoreTrajectory[${index}].generation not finite`);
+      }
+      if (!isFiniteNumber(s.elapsedMs) || (s.elapsedMs as number) < 0) {
+        problems.push(`scoreTrajectory[${index}].elapsedMs invalid`);
+      }
+      if (!isFiniteNumber(s.bestFitness)) {
+        problems.push(`scoreTrajectory[${index}].bestFitness not finite`);
+      }
+      if (!isFiniteNumber(s.averageFitness)) {
+        problems.push(`scoreTrajectory[${index}].averageFitness not finite`);
+      }
+    });
+  }
+
+  for (
+    const key of [
+      "initialBestFitness",
+      "finalBestFitness",
+      "bestFitness",
+      "totalElapsedMs",
+      "scorePerHour",
+    ]
+  ) {
+    if (!isFiniteNumber(r[key])) {
+      problems.push(`${key} not finite`);
+    }
+  }
+
+  return problems;
+}
+
+/** Outcome of a baseline regression comparison. */
+export interface BaselineComparison {
+  /** `true` when no hard (deterministic outcome) regression was detected. */
+  readonly passed: boolean;
+  /** Hard-failure reasons — deterministic evolution-outcome regressions. */
+  readonly reasons: string[];
+  /**
+   * Advisory warnings that do NOT fail the gate — currently the score/hour
+   * drop, which is wall-clock- and machine-load-dependent and would be flaky as
+   * a hard gate. Surfaced in logs/artifacts as evidence, not as a blocker.
+   */
+  readonly warnings: string[];
+  readonly scorePerHourDropPct: number;
+  readonly finalScoreDelta: number;
+  /** Whether the seeded per-generation score trajectory matched the baseline. */
+  readonly trajectoryMatched: boolean;
+}
+
+/** Tuning knobs for {@link compareToBaseline}. */
+export interface BaselineComparisonOptions {
+  /** Max allowed score/hour drop below baseline before failing (percent). */
+  readonly maxScorePerHourDropPct?: number;
+  /**
+   * Relative tolerance for the deterministic score checks. The seeded trajectory
+   * is reproducible, but tiny cross-platform float differences (e.g. `Math.tanh`)
+   * can appear, so a small relative epsilon avoids false positives while still
+   * catching genuine outcome regressions.
+   */
+  readonly scoreRelTolerance?: number;
+}
+
+/** Is `value` worse than `baseline` (lower) beyond a relative tolerance? */
+function regressedBelow(
+  value: number,
+  baseline: number,
+  relTolerance: number,
+): boolean {
+  const allowance = Math.abs(baseline) * relTolerance;
+  return value < baseline - allowance;
+}
+
+/**
+ * Compare a fresh result against a checked-in baseline trajectory.
+ *
+ * The **deterministic evolution outcome** — the per-generation best-fitness
+ * trajectory and the final best score — is the machine-independent guardrail: a
+ * change that speeds evolution up but worsens the scores it reaches is flagged
+ * here (as a hard failure) regardless of how fast the CI runner is.
+ *
+ * Score/hour is inherently wall-clock- and therefore machine-load-dependent —
+ * the same code can vary well beyond 10% between runs on the same host — so a
+ * hard threshold on it would be flaky. It is reported as an advisory **warning**
+ * (see `warnings`), not a blocker. Pure speed-ups that keep or improve the
+ * scores never fail; genuine outcome regressions always do.
+ */
+export function compareToBaseline(
+  result: HarnessResult,
+  baseline: HarnessResult,
+  options: BaselineComparisonOptions = {},
+): BaselineComparison {
+  const maxScorePerHourDropPct = options.maxScorePerHourDropPct ?? 10;
+  const scoreRelTolerance = options.scoreRelTolerance ?? 1e-6;
+  const reasons: string[] = [];
+  const warnings: string[] = [];
+
+  // 1. Final best score must not regress (machine-independent, deterministic).
+  const finalScoreDelta = result.finalBestFitness - baseline.finalBestFitness;
+  if (
+    regressedBelow(
+      result.finalBestFitness,
+      baseline.finalBestFitness,
+      scoreRelTolerance,
+    )
+  ) {
+    reasons.push(
+      `final best score regressed by ${Math.abs(finalScoreDelta)}: ` +
+        `${result.finalBestFitness} vs baseline ${baseline.finalBestFitness}`,
+    );
+  }
+
+  // 2. The seeded per-generation best-fitness trajectory must not regress.
+  let trajectoryMatched = true;
+  const n = Math.min(
+    result.scoreTrajectory.length,
+    baseline.scoreTrajectory.length,
+  );
+  if (result.scoreTrajectory.length !== baseline.scoreTrajectory.length) {
+    trajectoryMatched = false;
+    reasons.push(
+      `trajectory length changed: ${result.scoreTrajectory.length} vs ` +
+        `baseline ${baseline.scoreTrajectory.length} generations`,
+    );
+  }
+  for (let i = 0; i < n; i++) {
+    const got = result.scoreTrajectory[i].bestFitness;
+    const want = baseline.scoreTrajectory[i].bestFitness;
+    if (regressedBelow(got, want, scoreRelTolerance)) {
+      trajectoryMatched = false;
+      reasons.push(
+        `generation ${
+          result.scoreTrajectory[i].generation
+        } best fitness regressed: ${got} vs baseline ${want}`,
+      );
+    }
+  }
+
+  // 3. Score/hour drop (advisory warning — wall-clock- and machine-dependent).
+  const baseScorePerHour = baseline.scorePerHour;
+  const scorePerHourDropPct = baseScorePerHour !== 0
+    ? ((baseScorePerHour - result.scorePerHour) / Math.abs(baseScorePerHour)) *
+      100
+    : 0;
+  if (scorePerHourDropPct > maxScorePerHourDropPct) {
+    warnings.push(
+      `score/hour dropped ${scorePerHourDropPct.toFixed(2)}% below baseline ` +
+        `(advisory limit ${maxScorePerHourDropPct}%): ${result.scorePerHour} ` +
+        `vs ${baseScorePerHour} — wall-clock-dependent, not a hard failure`,
+    );
+  }
+
+  return {
+    passed: reasons.length === 0,
+    reasons,
+    warnings,
+    scorePerHourDropPct,
+    finalScoreDelta,
+    trajectoryMatched,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────
+// CLI
+// ──────────────────────────────────────────────────────────────────
+
+function parseArgs(args: string[]): {
+  config: HarnessConfig;
+  out?: string;
+  baseline?: string;
+} {
+  const map = new Map<string, string>();
+  for (const arg of args) {
+    const match = /^--([^=]+)=(.*)$/.exec(arg);
+    if (match) {
+      map.set(match[1], match[2]);
+    } else if (arg.startsWith("--")) {
+      map.set(arg.slice(2), "true");
+    }
+  }
+
+  const num = (key: string): number | undefined => {
+    const raw = map.get(key);
+    if (raw === undefined) return undefined;
+    const value = Number(raw);
+    if (!Number.isFinite(value)) {
+      throw new Error(`--${key} must be a finite number, got '${raw}'`);
+    }
+    return value;
+  };
+
+  const scaleRaw = map.get("scale");
+  if (
+    scaleRaw !== undefined &&
+    scaleRaw !== "default" && scaleRaw !== "grq-cluster" &&
+    scaleRaw !== "grq-3397"
+  ) {
+    throw new Error(
+      `--scale must be one of default|grq-cluster|grq-3397, got '${scaleRaw}'`,
+    );
+  }
+
+  const config = withConfigDefaults({
+    seed: num("seed"),
+    scale: scaleRaw as HarnessConfig["scale"] | undefined,
+    inputCount: num("inputs"),
+    outputCount: num("outputs"),
+    sampleCount: num("samples"),
+    populationSize: num("population"),
+    maxGenerations: num("max-generations"),
+    timeBudgetMs: num("time-budget-ms"),
+    threads: num("threads"),
+    trainPerGen: num("train-per-gen"),
+    discoverySampleRate: num("discovery-sample-rate"),
+    trainDataPath: map.get("train-data"),
+  });
+
+  return { config, out: map.get("out"), baseline: map.get("baseline") };
+}
+
+async function main(args: string[]): Promise<number> {
+  const { config, out, baseline } = parseArgs(args);
+
+  const result = await runScorePerHourHarness(config);
+
+  const problems = validateHarnessResult(
+    JSON.parse(JSON.stringify(result)),
+  );
+  if (problems.length > 0) {
+    console.error("Harness output failed schema validation:");
+    for (const problem of problems) console.error(`  - ${problem}`);
+    return 1;
+  }
+
+  const json = JSON.stringify(result, null, 2);
+  if (out) {
+    await Deno.writeTextFile(out, json + "\n");
+    console.error(`Wrote trajectory to ${out}`);
+  } else {
+    console.log(json);
+  }
+
+  console.error(
+    `\nTopology: ${result.topology.neurons} neurons, ` +
+      `${result.topology.synapses} synapses, ${result.topology.inputs} inputs`,
+  );
+  console.error(
+    `Generations: ${result.scoreTrajectory.length}, ` +
+      `best fitness: ${result.bestFitness}, ` +
+      `score/hour: ${result.scorePerHour.toFixed(6)}`,
+  );
+
+  if (baseline) {
+    const baselineResult = JSON.parse(
+      await Deno.readTextFile(baseline),
+    ) as HarnessResult;
+    const comparison = compareToBaseline(result, baselineResult);
+    for (const warning of comparison.warnings) {
+      console.error(`  ⚠ ${warning}`);
+    }
+    if (!comparison.passed) {
+      console.error("\nBASELINE REGRESSION DETECTED:");
+      for (const reason of comparison.reasons) {
+        console.error(`  - ${reason}`);
+      }
+      return 1;
+    }
+    console.error(
+      `\nBaseline check passed (evolution outcome preserved; score/hour drop ` +
+        `${comparison.scorePerHourDropPct.toFixed(2)}%, ` +
+        `final score delta ${comparison.finalScoreDelta}).`,
+    );
+  }
+
+  return 0;
+}
+
+if (import.meta.main) {
+  main(Deno.args)
+    .then((code) => {
+      if (code !== 0) Deno.exit(code);
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      Deno.exit(1);
+    });
+}

--- a/bench/score_per_hour_harness_test.ts
+++ b/bench/score_per_hour_harness_test.ts
@@ -1,0 +1,214 @@
+/**
+ * Issue #3398 — Tests for the score-per-wall-clock-hour benchmark harness.
+ *
+ * These run in the standard `deno test` CI suite (the `bench/**\/*_test.ts`
+ * glob is registered in `deno.json` `test.include`, and excluded from the
+ * `deno bench` set so `deno task bench` never treats it as a benchmark).
+ *
+ * They form the earliest failure-detection point for the harness: a broken
+ * harness, non-deterministic seeding, or malformed machine-readable output
+ * fails the PR before any #3396 sub-issue can cite it as evidence.
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import {
+  compareToBaseline,
+  type HarnessConfig,
+  type HarnessResult,
+  runScorePerHourHarness,
+  type ScoreSample,
+  summariseTrajectory,
+  validateHarnessResult,
+  withConfigDefaults,
+} from "./score_per_hour_harness.ts";
+
+/**
+ * A deterministic virtual clock: each call advances a fixed step. Because the
+ * harness calls `now()` a deterministic number of times (once at start, once
+ * per generation, once at the end) for a seeded run, two runs sharing this
+ * clock design produce byte-identical timing fields.
+ */
+function virtualClock(stepMs = 1_000): () => number {
+  let t = 0;
+  return () => {
+    const value = t;
+    t += stepMs;
+    return value;
+  };
+}
+
+/** Tiny, fast, deterministic config for the smoke tests. */
+function tinyConfig(): HarnessConfig {
+  return withConfigDefaults({
+    scale: "default",
+    inputCount: 16,
+    outputCount: 2,
+    sampleCount: 8,
+    populationSize: 6,
+    maxGenerations: 4,
+    timeBudgetMs: 60_000,
+    threads: 1,
+    seed: 3396,
+    // Pure seeded neuroevolution (default) — byte-reproducible. Async backprop
+    // (trainPerGen >= 1) would introduce worker-scheduling jitter.
+    trainPerGen: 0,
+  });
+}
+
+Deno.test("score-per-hour harness: identical seeds produce identical score trajectories", async () => {
+  const config = tinyConfig();
+
+  const first = await runScorePerHourHarness(config, { now: virtualClock() });
+  const second = await runScorePerHourHarness(config, { now: virtualClock() });
+
+  // Byte-identical machine-readable output (curve + score/hour), including the
+  // virtual-clock timing, proves seeded reproducibility.
+  assertEquals(
+    JSON.stringify(second),
+    JSON.stringify(first),
+    "same seed + config + virtual clock must yield byte-identical output",
+  );
+
+  // The output must schema-validate (a malformed shape fails CI here).
+  assertEquals(
+    validateHarnessResult(JSON.parse(JSON.stringify(first))),
+    [],
+    "harness output should pass schema validation",
+  );
+
+  assert(first.scoreTrajectory.length > 0, "trajectory must be non-empty");
+});
+
+Deno.test("score-per-hour harness: a different seed changes the trajectory", async () => {
+  const base = tinyConfig();
+  const a = await runScorePerHourHarness(base, { now: virtualClock() });
+  const b = await runScorePerHourHarness(
+    { ...base, seed: base.seed + 7 },
+    { now: virtualClock() },
+  );
+
+  const scoresA = a.scoreTrajectory.map((s) => s.bestFitness);
+  const scoresB = b.scoreTrajectory.map((s) => s.bestFitness);
+  assert(
+    JSON.stringify(scoresA) !== JSON.stringify(scoresB),
+    "a different seed should produce a different score trajectory",
+  );
+});
+
+Deno.test("score-per-hour harness: topology matches the requested preset", async () => {
+  const result = await runScorePerHourHarness(tinyConfig(), {
+    now: virtualClock(),
+  });
+  assertEquals(result.topology.inputs, 16);
+  assert(result.topology.neurons > 0);
+  assert(result.topology.synapses > 0);
+});
+
+Deno.test("score-per-hour harness: score/hour is derived from first→last gain over elapsed hours", () => {
+  const samples: ScoreSample[] = [
+    { generation: 1, elapsedMs: 0, bestFitness: -10, averageFitness: -12 },
+    { generation: 2, elapsedMs: 1_000, bestFitness: -6, averageFitness: -8 },
+  ];
+  // 30 minutes of wall-clock → 0.5 h. Gain = (-6) - (-10) = 4. 4 / 0.5 = 8/h.
+  const result = summariseTrajectory(samples, 30 * 60_000, {
+    config: tinyConfig(),
+    topology: { neurons: 1, synapses: 1, inputs: 1 },
+    usedRealTrainData: false,
+  });
+  assertEquals(result.initialBestFitness, -10);
+  assertEquals(result.finalBestFitness, -6);
+  assertEquals(result.bestFitness, -6);
+  assertEquals(result.scorePerHour, 8);
+});
+
+Deno.test("score-per-hour harness: empty trajectory fails loud (silent-failure guard)", () => {
+  assertThrows(
+    () =>
+      summariseTrajectory([], 1_000, {
+        config: tinyConfig(),
+        topology: { neurons: 1, synapses: 1, inputs: 1 },
+        usedRealTrainData: false,
+      }),
+    Error,
+    "no score samples",
+  );
+});
+
+Deno.test("score-per-hour harness: schema validation rejects malformed output", () => {
+  assert(validateHarnessResult(null).length > 0);
+  assert(validateHarnessResult({}).length > 0);
+
+  const good: HarnessResult = summariseTrajectory(
+    [{ generation: 1, elapsedMs: 0, bestFitness: 1, averageFitness: 0.5 }],
+    1_000,
+    {
+      config: tinyConfig(),
+      topology: { neurons: 1, synapses: 1, inputs: 1 },
+      usedRealTrainData: false,
+    },
+  );
+  assertEquals(validateHarnessResult(JSON.parse(JSON.stringify(good))), []);
+
+  // A NaN score must be rejected.
+  const bad = { ...good, scoreTrajectory: [] };
+  assert(validateHarnessResult(bad).length > 0);
+});
+
+Deno.test("score-per-hour harness: baseline regression gate flags worse evolution outcome", () => {
+  const meta = {
+    config: tinyConfig(),
+    topology: { neurons: 1, synapses: 1, inputs: 1 },
+    usedRealTrainData: false,
+  };
+  const baseline = summariseTrajectory(
+    [
+      { generation: 1, elapsedMs: 0, bestFitness: -10, averageFitness: -11 },
+      { generation: 2, elapsedMs: 1_000, bestFitness: -4, averageFitness: -5 },
+    ],
+    60 * 60_000, // 1 h → score/hour = 6
+    meta,
+  );
+
+  // Identical run passes.
+  assert(compareToBaseline(baseline, baseline).passed);
+
+  // A run that is faster but reaches a worse final score must fail.
+  const worseOutcome = summariseTrajectory(
+    [
+      { generation: 1, elapsedMs: 0, bestFitness: -10, averageFitness: -11 },
+      { generation: 2, elapsedMs: 1_000, bestFitness: -7, averageFitness: -8 },
+    ],
+    10 * 60_000, // faster: score/hour = 18 (higher!) but final score worse
+    meta,
+  );
+  const regression = compareToBaseline(worseOutcome, baseline);
+  assert(
+    !regression.passed,
+    "a worse final score must fail even when it is faster",
+  );
+  assert(
+    regression.reasons.some((r) => r.includes("final best score regressed")),
+  );
+
+  // A run with identical scores but a >10% score/hour drop must NOT fail the
+  // gate (wall-clock is machine-dependent) — it is surfaced as an advisory
+  // warning instead.
+  const slowerScoring = summariseTrajectory(
+    [
+      { generation: 1, elapsedMs: 0, bestFitness: -10, averageFitness: -11 },
+      { generation: 2, elapsedMs: 1_000, bestFitness: -4, averageFitness: -5 },
+    ],
+    120 * 60_000, // 2 h → score/hour = 3, a 50% drop from baseline's 6
+    meta,
+  );
+  const scoreHourAdvisory = compareToBaseline(slowerScoring, baseline);
+  assert(
+    scoreHourAdvisory.passed,
+    "a pure timing slowdown with unchanged scores must not fail the gate",
+  );
+  assert(
+    scoreHourAdvisory.warnings.some((w) => w.includes("score/hour dropped")),
+    "the score/hour drop should be reported as an advisory warning",
+  );
+  assert(scoreHourAdvisory.trajectoryMatched);
+});

--- a/deno.json
+++ b/deno.json
@@ -62,11 +62,13 @@
   },
   "tasks": {
     "bench": "deno bench --allow-read --allow-write --allow-env --allow-ffi",
-    "bench:smoke": "deno bench --allow-read --allow-write --allow-env --allow-ffi bench/FatherCompatibility.ts bench/Activate.ts"
+    "bench:smoke": "deno bench --allow-read --allow-write --allow-env --allow-ffi bench/FatherCompatibility.ts bench/Activate.ts",
+    "bench:score-per-hour": "deno run --allow-read --allow-write --allow-env --allow-ffi bench/score_per_hour_harness.ts"
   },
   "test": {
     "include": [
-      "test/**/*.ts"
+      "test/**/*.ts",
+      "bench/**/*_test.ts"
     ]
   },
   "bench": {
@@ -74,6 +76,7 @@
       "bench/**/*.ts"
     ],
     "exclude": [
+      "bench/score_per_hour_harness_test.ts",
       "bench/ActivateAndTraceApp.ts",
       "bench/ActivateApp.ts",
       "bench/AdaptiveLearningRateConvergence.ts",

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,9 @@ Tuning guides and benchmark research.
   migration learnings from the WASM transition.
 - **[PREDICTIVE_CODING_BENCHMARKS.md](PREDICTIVE_CODING_BENCHMARKS.md)** —
   benchmark results for the predictive-coding training mode.
+- **[SCORE_PER_HOUR_HARNESS.md](SCORE_PER_HOUR_HARNESS.md)** — the
+  score-improvement-per-wall-clock-hour benchmark harness: the reproducible
+  evidence gate for the #3396 evolution-performance milestone.
 
 ## 📖 Reference
 

--- a/docs/SCORE_PER_HOUR_HARNESS.md
+++ b/docs/SCORE_PER_HOUR_HARNESS.md
@@ -1,0 +1,105 @@
+# Score-per-wall-clock-hour benchmark harness
+
+> Issue #3398 — the evidence gate for the #3396 evolution-performance milestone.
+
+The agreed success metric for the #3396 work is **score improvement per
+wall-clock hour** inside the production learn/sampler time-boxes — _not_ raw
+throughput. This harness measures that metric directly so every #3396
+implementation sub-issue can show honest, apples-to-apples before/after evidence
+within a fixed time budget.
+
+Source: [`bench/score_per_hour_harness.ts`](../bench/score_per_hour_harness.ts).
+Tests:
+[`bench/score_per_hour_harness_test.ts`](../bench/score_per_hour_harness_test.ts).
+
+## The one documented command
+
+```bash
+deno task bench:score-per-hour \
+  --scale=grq-3397 --inputs=2461 --outputs=2 --samples=20 \
+  --population=10 --max-generations=10 --time-budget-ms=600000 \
+  --seed=3396 --train-per-gen=0 \
+  --out=trajectory.json
+```
+
+This drives the same production-scale synthetic topology used by
+`worker/learn.sh` / `worker/sampler.sh` — the `grq-3397` preset: **1,666 neurons
+/ ~21,513 synapses / 2,461 inputs** — from
+[`test/propagate/large/ProductionScaleCreature.ts`](../test/propagate/large/ProductionScaleCreature.ts),
+and writes a machine-readable JSON trajectory containing:
+
+- `scoreTrajectory` — the **score-vs-time curve**: best/average fitness and
+  cumulative wall-clock elapsed at each generation.
+- `bestFitness`, `initialBestFitness`, `finalBestFitness` — best score reached.
+- `scorePerHour` — **score gained per wall-clock hour**
+  (`(finalBestFitness − initialBestFitness) / hours`).
+
+Run with `--baseline=bench/baseline_score_trajectory.json` to additionally gate
+the run against the checked-in baseline (exit non-zero on an evolution-outcome
+regression).
+
+### Key flags
+
+| Flag                      | Default      | Meaning                                                                    |
+| ------------------------- | ------------ | -------------------------------------------------------------------------- |
+| `--seed`                  | `3396`       | Seeds the NEAT RNG and synthetic generators — drives reproducibility.      |
+| `--scale`                 | `grq-3397`   | Topology preset (`default` \| `grq-cluster` \| `grq-3397`).                |
+| `--inputs` / `--outputs`  | `2461` / `2` | Network I/O width.                                                         |
+| `--samples`               | `50`         | Number of synthetic training records.                                      |
+| `--population`            | `20`         | Population size (`learn.sh` production value).                             |
+| `--max-generations`       | `100`        | Hard generation cap.                                                       |
+| `--time-budget-ms`        | `2700000`    | Wall-clock budget (learn.sh ≈ 45 min).                                     |
+| `--train-per-gen`         | `0`          | Backprop sessions/generation. `0` = byte-reproducible pure neuroevolution. |
+| `--discovery-sample-rate` | `-1`         | `-1` disables discovery (deterministic).                                   |
+| `--train-data`            | —            | Optional real `.trainData` JSON sample to sanity-check.                    |
+| `--out`                   | stdout       | Write the JSON trajectory to a file.                                       |
+| `--baseline`              | —            | Compare against a checked-in baseline and gate on regressions.             |
+
+## Reproducibility
+
+With the defaults (`--train-per-gen=0`, `--discovery-sample-rate=-1`) the run is
+**pure seeded neuroevolution**: identical seed + config produces a
+byte-identical score trajectory. The determinism smoke test
+(`identical seeds produce identical score trajectories`) runs in the standard
+`deno test` CI suite and asserts byte-identical machine-readable output plus a
+schema check on every PR.
+
+Async backprop training (`--train-per-gen >= 1`) improves scores faster but
+completes on worker threads whose scheduling is wall-clock-dependent, so those
+runs are seeded-but-not-byte-identical. Use them for a production-faithful
+measurement, not for the determinism gate.
+
+## Guardrails
+
+```mermaid
+flowchart TD
+    A[Run harness with --seed] --> B{Any score samples?}
+    B -- no --> F[Exit non-zero: silent-failure guard]
+    B -- yes --> C[Emit machine-readable trajectory JSON]
+    C --> D{--baseline given?}
+    D -- no --> Z[Report bestScore, curve, score/hour]
+    D -- yes --> E[compareToBaseline]
+    E --> G{Deterministic outcome<br/>regressed vs baseline?}
+    G -- yes --> H[Exit non-zero: BASELINE REGRESSION]
+    G -- no --> I[Pass; score/hour drift is advisory only]
+```
+
+Three protections back the metric:
+
+1. **Silent-failure guard (Issue #3234).** The run exits non-zero if it produced
+   no score samples (a wedged learn/sampler invocation) rather than emitting an
+   empty report.
+2. **Evolution-outcome regression gate.** `compareToBaseline` fails when the
+   final best score or the per-generation best-fitness trajectory regresses
+   below the checked-in baseline
+   ([`bench/baseline_score_trajectory.json`](../bench/baseline_score_trajectory.json)).
+   This is machine-independent (the seeded trajectory is deterministic), so it
+   reliably flags a change that speeds evolution up **but reaches worse scores**
+   — pure speed at the cost of worse outcome is unacceptable.
+3. **Score/hour drift (advisory).** The score/hour drop vs baseline is reported
+   as a warning, not a hard failure, because wall-clock timing is
+   machine-load-dependent and would be flaky as a blocking gate.
+
+The scheduled `Score-per-hour regression gate` job in
+[`.github/workflows/bench.yaml`](../.github/workflows/bench.yaml) runs the
+harness weekly at the baseline config and uploads the trajectory artifact.

--- a/docs/archive/pr-summaries/pr-summary-3398.md
+++ b/docs/archive/pr-summaries/pr-summary-3398.md
@@ -1,0 +1,130 @@
+## Summary
+
+Adds the **score-improvement-per-wall-clock-hour benchmark harness** — the
+reproducible evidence gate every #3396 implementation sub-issue depends on to
+show honest before/after evidence inside a fixed time budget. Closes #3398.
+
+The agreed #3396 success metric is _score improvement per wall-clock hour_
+within the learn/sampler time-boxes, not throughput. The harness measures that
+metric directly against the production-scale synthetic generators already in
+`bench/` (the `grq-3397` preset: 1,666 neurons / ~21,513 synapses / 2,461 inputs
+— the `worker/learn.sh` / `worker/sampler.sh` topology).
+
+What landed:
+
+- **`bench/score_per_hour_harness.ts`** — seeded harness that runs
+  `evolveDataSet` under a fixed wall-clock budget (or generation cap), records a
+  machine-readable **score-vs-time curve** (best/average fitness + cumulative
+  elapsed per generation) and derives **score gained per hour**. Accepts an
+  optional real `.trainData` sample. Exposes `runScorePerHourHarness`,
+  `summariseTrajectory`, `validateHarnessResult`, and `compareToBaseline`.
+- **Determinism** — with the defaults (`--train-per-gen=0`,
+  `--discovery-sample-rate=-1`) the run is pure seeded neuroevolution, so the
+  score trajectory is byte-reproducible. An injectable clock makes the timing
+  fields reproducible too, so the determinism smoke test gets byte-identical
+  output.
+- **Silent-failure guard (Issue #3234)** — the run throws / exits non-zero if it
+  produced no score samples, so a wedged learn/sampler invocation surfaces as a
+  hard failure rather than an empty report.
+- **`bench/score_per_hour_harness_test.ts`** — determinism smoke test, schema
+  validation, silent-failure guard, and baseline regression-gate tests; runs in
+  the standard `deno test` suite.
+- **`bench/baseline_score_trajectory.json`** — checked-in baseline trajectory
+  (seeded `grq-3397`, 10 generations) for the regression gate.
+- **`.github/workflows/bench.yaml`** — weekly scheduled
+  `Score-per-hour
+  regression gate` job that runs the harness at the baseline
+  config and uploads the trajectory artifact.
+- **`deno.json`** — `bench:score-per-hour` task; registers `bench/**/*_test.ts`
+  in the test suite (excluded from `deno bench`).
+- **Docs** — `docs/SCORE_PER_HOUR_HARNESS.md` guide (with Mermaid flow) + index
+  entry.
+
+### Design decisions worth calling out
+
+- **The regression gate is the deterministic evolution outcome, not
+  score/hour.** `compareToBaseline` hard-fails when the final best score or the
+  per-generation best-fitness trajectory regresses below baseline — this is
+  machine-independent (the seeded trajectory is deterministic) and is exactly
+  what flags "a change that speeds evolution up but reaches worse scores".
+  Score/hour is inherently wall-clock- and machine-load-dependent (observed >10%
+  run-to-run swing on the same host), so it is reported as an **advisory
+  warning**, not a hard gate, to avoid CI flakiness. This honours the
+  guardrail's intent — pure speed at the cost of worse scores is caught —
+  without a flaky timing threshold.
+- **Test path.** `deno test` only discovers `test.include` globs, so the test
+  file at the issue's named path `bench/score_per_hour_harness_test.ts` would
+  have been silently skipped by CI. Rather than let it fail silently, the glob
+  `bench/**/*_test.ts` was added to `test.include` (and excluded from
+  `deno
+  bench`) so the test actually runs on every PR.
+- **Discovery disabled by default** — the native discovery library adds FFI,
+  disk, and timing non-determinism that would break byte-reproducibility, so it
+  is off by default and configurable up for a fuller production-faithful run.
+
+### Deno regression avoided
+
+Implemented entirely with Deno-native tooling — `deno run` / `deno test` /
+`deno bench` and a `deno.json` task — no Node tooling introduced.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via tests and
+direct harness runs.
+
+Determinism (two runs, same seed → byte-identical score trajectory):
+
+```text
+score trajectory identical: True
+final identical: True
+```
+
+Baseline gate is stable across repeated runs (score/hour drift is advisory):
+
+```text
+run 1 gate exit=0
+run 2 gate exit=0
+Baseline check passed (evolution outcome preserved; score/hour drop 4.62%, final score delta 0).
+```
+
+Harness output on the production `grq-3397` topology:
+
+```text
+Topology: 1666 neurons, 21560 synapses, 2461 inputs
+Generations: 10, best fitness: -1.257652533664427e+31, score/hour: 1.53e+32
+```
+
+```mermaid
+flowchart TD
+    A[Run harness with --seed] --> B{Any score samples?}
+    B -- no --> F[Exit non-zero: silent-failure guard]
+    B -- yes --> C[Emit machine-readable trajectory JSON]
+    C --> D{--baseline given?}
+    D -- no --> Z[Report bestScore, curve, score/hour]
+    D -- yes --> E[compareToBaseline]
+    E --> G{Deterministic outcome regressed?}
+    G -- yes --> H[Exit non-zero: BASELINE REGRESSION]
+    G -- no --> I[Pass; score/hour drift advisory only]
+```
+
+## Test Plan
+
+New tests in `bench/score_per_hour_harness_test.ts` (all pass,
+`7 passed | 0
+failed`):
+
+- `identical seeds produce identical score trajectories` — byte-identical
+  machine-readable output across two seeded runs + schema validation.
+- `a different seed changes the trajectory` — seeding actually varies output.
+- `topology matches the requested preset` — exercises the synthetic generators.
+- `score/hour is derived from first→last gain over elapsed hours` — metric
+  maths.
+- `empty trajectory fails loud (silent-failure guard)` — `summariseTrajectory`
+  throws on an empty curve (Issue #3234).
+- `schema validation rejects malformed output` — `validateHarnessResult`.
+- `baseline regression gate flags worse evolution outcome` — a faster-but-worse
+  run fails; a pure timing slowdown with unchanged scores passes with an
+  advisory warning.
+
+Also run: `deno fmt`, `deno lint bench test`, project-wide `deno check`, and
+`markdownlint-cli2` — all clean.


### PR DESCRIPTION
## Summary

Adds the **score-improvement-per-wall-clock-hour benchmark harness** — the
reproducible evidence gate every #3396 implementation sub-issue depends on to
show honest before/after evidence inside a fixed time budget. Closes #3398.

The agreed #3396 success metric is _score improvement per wall-clock hour_
within the learn/sampler time-boxes, not throughput. The harness measures that
metric directly against the production-scale synthetic generators already in
`bench/` (the `grq-3397` preset: 1,666 neurons / ~21,513 synapses / 2,461 inputs
— the `worker/learn.sh` / `worker/sampler.sh` topology).

What landed:

- **`bench/score_per_hour_harness.ts`** — seeded harness that runs
  `evolveDataSet` under a fixed wall-clock budget (or generation cap), records a
  machine-readable **score-vs-time curve** (best/average fitness + cumulative
  elapsed per generation) and derives **score gained per hour**. Accepts an
  optional real `.trainData` sample. Exposes `runScorePerHourHarness`,
  `summariseTrajectory`, `validateHarnessResult`, and `compareToBaseline`.
- **Determinism** — with the defaults (`--train-per-gen=0`,
  `--discovery-sample-rate=-1`) the run is pure seeded neuroevolution, so the
  score trajectory is byte-reproducible. An injectable clock makes the timing
  fields reproducible too, so the determinism smoke test gets byte-identical
  output.
- **Silent-failure guard (Issue #3234)** — the run throws / exits non-zero if it
  produced no score samples, so a wedged learn/sampler invocation surfaces as a
  hard failure rather than an empty report.
- **`bench/score_per_hour_harness_test.ts`** — determinism smoke test, schema
  validation, silent-failure guard, and baseline regression-gate tests; runs in
  the standard `deno test` suite.
- **`bench/baseline_score_trajectory.json`** — checked-in baseline trajectory
  (seeded `grq-3397`, 10 generations) for the regression gate.
- **`.github/workflows/bench.yaml`** — weekly scheduled
  `Score-per-hour
  regression gate` job that runs the harness at the baseline
  config and uploads the trajectory artifact.
- **`deno.json`** — `bench:score-per-hour` task; registers `bench/**/*_test.ts`
  in the test suite (excluded from `deno bench`).
- **Docs** — `docs/SCORE_PER_HOUR_HARNESS.md` guide (with Mermaid flow) + index
  entry.

### Design decisions worth calling out

- **The regression gate is the deterministic evolution outcome, not
  score/hour.** `compareToBaseline` hard-fails when the final best score or the
  per-generation best-fitness trajectory regresses below baseline — this is
  machine-independent (the seeded trajectory is deterministic) and is exactly
  what flags "a change that speeds evolution up but reaches worse scores".
  Score/hour is inherently wall-clock- and machine-load-dependent (observed >10%
  run-to-run swing on the same host), so it is reported as an **advisory
  warning**, not a hard gate, to avoid CI flakiness. This honours the
  guardrail's intent — pure speed at the cost of worse scores is caught —
  without a flaky timing threshold.
- **Test path.** `deno test` only discovers `test.include` globs, so the test
  file at the issue's named path `bench/score_per_hour_harness_test.ts` would
  have been silently skipped by CI. Rather than let it fail silently, the glob
  `bench/**/*_test.ts` was added to `test.include` (and excluded from
  `deno
  bench`) so the test actually runs on every PR.
- **Discovery disabled by default** — the native discovery library adds FFI,
  disk, and timing non-determinism that would break byte-reproducibility, so it
  is off by default and configurable up for a fuller production-faithful run.

### Deno regression avoided

Implemented entirely with Deno-native tooling — `deno run` / `deno test` /
`deno bench` and a `deno.json` task — no Node tooling introduced.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via tests and
direct harness runs.

Determinism (two runs, same seed → byte-identical score trajectory):

```text
score trajectory identical: True
final identical: True
```

Baseline gate is stable across repeated runs (score/hour drift is advisory):

```text
run 1 gate exit=0
run 2 gate exit=0
Baseline check passed (evolution outcome preserved; score/hour drop 4.62%, final score delta 0).
```

Harness output on the production `grq-3397` topology:

```text
Topology: 1666 neurons, 21560 synapses, 2461 inputs
Generations: 10, best fitness: -1.257652533664427e+31, score/hour: 1.53e+32
```

```mermaid
flowchart TD
    A[Run harness with --seed] --> B{Any score samples?}
    B -- no --> F[Exit non-zero: silent-failure guard]
    B -- yes --> C[Emit machine-readable trajectory JSON]
    C --> D{--baseline given?}
    D -- no --> Z[Report bestScore, curve, score/hour]
    D -- yes --> E[compareToBaseline]
    E --> G{Deterministic outcome regressed?}
    G -- yes --> H[Exit non-zero: BASELINE REGRESSION]
    G -- no --> I[Pass; score/hour drift advisory only]
```

## Test Plan

New tests in `bench/score_per_hour_harness_test.ts` (all pass,
`7 passed | 0
failed`):

- `identical seeds produce identical score trajectories` — byte-identical
  machine-readable output across two seeded runs + schema validation.
- `a different seed changes the trajectory` — seeding actually varies output.
- `topology matches the requested preset` — exercises the synthetic generators.
- `score/hour is derived from first→last gain over elapsed hours` — metric
  maths.
- `empty trajectory fails loud (silent-failure guard)` — `summariseTrajectory`
  throws on an empty curve (Issue #3234).
- `schema validation rejects malformed output` — `validateHarnessResult`.
- `baseline regression gate flags worse evolution outcome` — a faster-but-worse
  run fails; a pure timing slowdown with unchanged scores passes with an
  advisory warning.

Also run: `deno fmt`, `deno lint bench test`, project-wide `deno check`, and
`markdownlint-cli2` — all clean.



## Milestone
This PR is part of the **#3396 Suggest evolution performance improvements for production learn/sampler runs** milestone and targets the `milestone/3396-suggest-evolution-performance-improvements-fo` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrq3zkeb-42a2da`<!-- vibe-worker-issue-3398 -->