### PR TITLE
Accept UUID strings for discovery focus neurons (GRQ#3493)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.21",
+  "version": "5.9.22",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureBase.ts
@@ -41,6 +41,7 @@ import type {
 import {
   truncateForLogValue as truncateForLogValueImpl,
 } from "@architecture/ErrorGuidedStructuralEvolution/RustFlushDiagnostics.ts";
+import { resolveForcedFocusReferences } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { clearForGc } from "@utils/ReleasableRef.ts";
 import { logDiscoveryDiskUsage } from "@discovery/DiskSpaceMonitor.ts";
@@ -346,9 +347,42 @@ export class DiscoverStructureBase {
     this.analysisTimeoutGuardEnabled = false;
   }
 
-  public setForcedFocusNeurons(neuronIds: readonly number[]): void {
-    const usable = Array.isArray(neuronIds)
-      ? neuronIds.filter((id) => typeof id === "number" && Number.isInteger(id))
+  /**
+   * Resolve a mixed list of forced-focus references to runtime neuron ids.
+   *
+   * References may be:
+   *   - a numeric runtime id (used directly), or
+   *   - a stable wire UUID string such as `input-2460` or a hidden/output
+   *     neuron UUID (resolved to a runtime id against this creature), or
+   *   - a bare integer string such as `"42"` (treated as a runtime id).
+   *
+   * Unresolvable string tokens are dropped with a WARN so a bad identifier
+   * never silently degrades to weighted selection without a trace.
+   */
+  private resolveForcedFocusRuntimeIds(
+    neuronRefs: readonly (number | string)[],
+  ): number[] {
+    const { ids, unresolved } = resolveForcedFocusReferences(
+      this.creature,
+      neuronRefs,
+    );
+    if (unresolved.length > 0 && this.loggingEnabled) {
+      for (const token of unresolved) {
+        this.log(
+          "warn",
+          `Forced focus neuron '${token}' did not resolve to a known wire ` +
+            `UUID or runtime id and will be ignored.`,
+        );
+      }
+    }
+    return ids;
+  }
+
+  public setForcedFocusNeurons(
+    neuronRefs: readonly (number | string)[],
+  ): void {
+    const usable = Array.isArray(neuronRefs)
+      ? this.resolveForcedFocusRuntimeIds(neuronRefs)
       : [];
 
     if (usable.length === 0) {

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts
@@ -45,6 +45,54 @@ export function resolveWireToRuntimeId(
   return wireToId.get(wireUuid);
 }
 
+/**
+ * Resolve a mixed list of forced-focus references to runtime neuron ids.
+ *
+ * References may be:
+ *   - a numeric runtime id (used directly), or
+ *   - a stable wire UUID string such as `input-2460` or a hidden/output
+ *     neuron UUID (resolved to a runtime id against `creature`), or
+ *   - a bare integer string such as `"42"` (treated as a runtime id).
+ *
+ * Order and identity are preserved. Empty and unresolvable string tokens are
+ * returned in `unresolved` so the caller can report them loudly rather than
+ * silently degrading — a bad identifier is never swallowed without a trace.
+ */
+export function resolveForcedFocusReferences(
+  creature: Creature,
+  refs: readonly (number | string)[],
+): { ids: number[]; unresolved: string[] } {
+  const wireToId = buildWireToRuntimeIdMap(creature);
+  const ids: number[] = [];
+  const unresolved: string[] = [];
+  for (const ref of refs) {
+    if (typeof ref === "number" && Number.isInteger(ref)) {
+      ids.push(ref);
+      continue;
+    }
+    if (typeof ref !== "string") {
+      continue;
+    }
+    const token = ref.trim();
+    if (token.length === 0) {
+      continue;
+    }
+    const resolved = wireToId.get(token);
+    if (resolved !== undefined) {
+      ids.push(resolved);
+      continue;
+    }
+    // Fall back to a bare integer string (e.g. "42") = runtime id.
+    const asInt = Number(token);
+    if (Number.isInteger(asInt)) {
+      ids.push(asInt);
+      continue;
+    }
+    unresolved.push(token);
+  }
+  return { ids, unresolved };
+}
+
 export function resolveRuntimeIdToWireUuid(
   idToWire: Map<number, string>,
   runtimeId: number | undefined,

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -422,10 +422,15 @@ export interface NeatArguments {
   discoveryDrainEveryNBatches: number;
 
   /**
-   * Optional ordered list of neuron UUIDs to prioritise during discovery analysis.
-   * When provided, discovery focuses on these neurons before performing weighted selection.
+   * Optional ordered list of neuron identifiers to prioritise during discovery
+   * analysis. Each entry is either a stable wire UUID string (for example
+   * `input-2460`, or a hidden/output neuron's UUID) or a numeric runtime neuron
+   * id. String UUIDs are resolved to runtime ids against the creature before
+   * selection, so callers may focus by the documented UUID rather than the
+   * internal numeric id. When provided, discovery focuses on these neurons
+   * before performing weighted selection.
    */
-  discoveryFocusNeuronUUIDs: number[];
+  discoveryFocusNeuronUUIDs: Array<number | string>;
 
   /**
    * Disable the internal evaluation summary logging. When set to true, the library

--- a/src/config/NeatConfigValidation.ts
+++ b/src/config/NeatConfigValidation.ts
@@ -238,9 +238,13 @@ export function validateNeatConfig(config: NeatArguments): void {
     );
   }
   for (const uuid of config.discoveryFocusNeuronUUIDs) {
-    if (typeof uuid !== "number" || !Number.isInteger(uuid)) {
+    const isInteger = typeof uuid === "number" && Number.isInteger(uuid);
+    const isNonEmptyString = typeof uuid === "string" &&
+      uuid.trim().length > 0;
+    if (!isInteger && !isNonEmptyString) {
       throw new ConfigurationError(
-        `Discovery focus neuron IDs must be integers, found: ${String(uuid)}`,
+        `Discovery focus neuron IDs must be integers or non-empty UUID ` +
+          `strings, found: ${String(uuid)}`,
         "INVALID_TYPE",
       );
     }

--- a/test/ErrorGuidedStructuralEvolution/ForcedFocusNeuronUuidResolution.ts
+++ b/test/ErrorGuidedStructuralEvolution/ForcedFocusNeuronUuidResolution.ts
@@ -1,0 +1,120 @@
+/**
+ * Forced-focus neuron references may be numeric runtime ids OR stable wire
+ * UUID strings (for example `input-2460`, or a hidden/output neuron UUID).
+ * `resolveForcedFocusReferences` resolves strings to runtime ids while
+ * preserving order and identity, and reports unresolvable tokens loudly
+ * instead of silently dropping them.
+ *
+ * Issue #3493 — Discovery: preserve UUIDs passed through --focusNeurons.
+ * Test created: 19-Jul-2026
+ */
+
+import { assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+import { TANH } from "@methods/activations/types/TANH.ts";
+import {
+  buildWireToRuntimeIdMap,
+  resolveForcedFocusReferences,
+} from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
+
+function makeCreature(): Creature {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: IDENTITY.NAME, bias: 0 },
+      { type: "hidden", uuid: "hidden-1", squash: TANH.NAME, bias: 0 },
+      { type: "hidden", uuid: "hidden-2", squash: IDENTITY.NAME, bias: 0 },
+      { type: "output", uuid: "output-0", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 1.0 },
+      { fromUUID: "input-1", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "input-2", toUUID: "hidden-2", weight: 0.3 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 1.0 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 1.0 },
+      { fromUUID: "hidden-2", toUUID: "output-0", weight: 0.2 },
+    ],
+    input: 3,
+    output: 1,
+  };
+  const creature = Creature.fromJSON(json);
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+Deno.test("resolveForcedFocusReferences resolves a hidden-neuron UUID string", () => {
+  const creature = makeCreature();
+  const wireToId = buildWireToRuntimeIdMap(creature);
+  const expected = wireToId.get("hidden-1");
+  assertEquals(typeof expected, "number");
+
+  const { ids, unresolved } = resolveForcedFocusReferences(creature, [
+    "hidden-1",
+  ]);
+  assertEquals(ids, [expected]);
+  assertEquals(unresolved, []);
+});
+
+Deno.test("resolveForcedFocusReferences resolves an input-N wire UUID", () => {
+  const creature = makeCreature();
+  // Input runtime ids are the input index: `input-2` -> 2.
+  const { ids, unresolved } = resolveForcedFocusReferences(creature, [
+    "input-2",
+  ]);
+  assertEquals(ids, [2]);
+  assertEquals(unresolved, []);
+});
+
+Deno.test("resolveForcedFocusReferences preserves order and identity of multiple UUIDs", () => {
+  const creature = makeCreature();
+  const wireToId = buildWireToRuntimeIdMap(creature);
+  const id2 = wireToId.get("hidden-2");
+  const id0 = wireToId.get("hidden-0");
+
+  const { ids, unresolved } = resolveForcedFocusReferences(creature, [
+    "hidden-2",
+    "hidden-0",
+  ]);
+  assertEquals(ids, [id2, id0]);
+  assertEquals(unresolved, []);
+});
+
+Deno.test("resolveForcedFocusReferences passes numeric runtime ids through unchanged", () => {
+  const creature = makeCreature();
+  const wireToId = buildWireToRuntimeIdMap(creature);
+  const hiddenId = wireToId.get("hidden-1")!;
+
+  const { ids, unresolved } = resolveForcedFocusReferences(creature, [
+    hiddenId,
+  ]);
+  assertEquals(ids, [hiddenId]);
+  assertEquals(unresolved, []);
+});
+
+Deno.test("resolveForcedFocusReferences treats a bare integer string as a runtime id", () => {
+  const creature = makeCreature();
+  const wireToId = buildWireToRuntimeIdMap(creature);
+  const hiddenId = wireToId.get("hidden-1")!;
+
+  const { ids, unresolved } = resolveForcedFocusReferences(creature, [
+    String(hiddenId),
+  ]);
+  assertEquals(ids, [hiddenId]);
+  assertEquals(unresolved, []);
+});
+
+Deno.test("resolveForcedFocusReferences reports unresolvable tokens without dropping valid ones", () => {
+  const creature = makeCreature();
+  const wireToId = buildWireToRuntimeIdMap(creature);
+  const id1 = wireToId.get("hidden-1");
+
+  const { ids, unresolved } = resolveForcedFocusReferences(creature, [
+    "hidden-1",
+    "not-a-real-neuron",
+  ]);
+  assertEquals(ids, [id1]);
+  assertEquals(unresolved, ["not-a-real-neuron"]);
+});

--- a/test/NEAT/NeatConfigCoverage.ts
+++ b/test/NEAT/NeatConfigCoverage.ts
@@ -86,6 +86,22 @@ Deno.test("NEAT/NeatConfigCoverage - discoveryFocusNeuronUUIDs entries must be i
   }
 });
 
+Deno.test("NEAT/NeatConfigCoverage - discoveryFocusNeuronUUIDs accepts non-empty UUID strings (#3493)", () => {
+  const config = createNeatConfig({
+    discoveryFocusNeuronUUIDs: [
+      "input-2460",
+      "d7c1f2a0-1234-4abc-8def-0123456789ab",
+      7,
+    ],
+  });
+  // Order and identity are preserved; strings are not coerced to numbers.
+  assertEquals(config.discoveryFocusNeuronUUIDs, [
+    "input-2460",
+    "d7c1f2a0-1234-4abc-8def-0123456789ab",
+    7,
+  ]);
+});
+
 Deno.test("NEAT/NeatConfigCoverage - discoveryReplayConcurrency rejects non-positive", () => {
   try {
     createNeatConfig({ discoveryReplayConcurrency: 0 });


### PR DESCRIPTION
## Summary

`discoveryFocusNeuronUUIDs` was typed `number[]` and validated integer-only, matched solely against numeric runtime neuron ids — even though the option is named "UUIDs" and downstream consumers (GRQ Discovery CLI/README) document `--focusNeurons=UUID[,UUID...]`. Real neuron UUID strings such as `input-2460` could never reach or drive discovery focus.

This is the root-cause fix for **stSoftwareAU/GRQ#3493**: GRQ's `buildDiscoveryOptions` coerced the whole focus list with `Number`, turning UUIDs into `NaN`. GRQ can only pass focus UUIDs through as strings once this option accepts strings.

### Changes
- `NeatArguments.ts` — widen `discoveryFocusNeuronUUIDs` to `Array<number | string>` and document the UUID-string / runtime-id contract.
- `NeatConfigValidation.ts` — accept integers **or** non-empty UUID strings; still reject empty/other values.
- `DiscoveryWireIdentity.ts` — new pure `resolveForcedFocusReferences(creature, refs)`: resolves wire-UUID strings (`input-N`, hidden/output UUIDs) to runtime ids, passes numeric ids and bare integer strings through, preserves order/identity, and returns unresolvable tokens for loud reporting (never silent).
- `DiscoverStructureBase.setForcedFocusNeurons` — accept `(number | string)[]`, resolve via the helper, and WARN on unresolvable tokens.

Backward compatible: numeric ids behave exactly as before.

### Tests
- `test/ErrorGuidedStructuralEvolution/ForcedFocusNeuronUuidResolution.ts` — hidden-UUID, `input-N`, multiple-in-order, numeric passthrough, integer-string, and unresolvable-token cases.
- `test/NEAT/NeatConfigCoverage.ts` — new case: non-empty UUID strings accepted and preserved (not coerced); existing empty-string rejection retained.

`deno check`, `deno lint`, `deno fmt`, and the touched test suites pass locally.

> Release note: do not auto-release. The GRQ consumer bump (GRQ#3493) is gated on a human-published release of this change.

Co-Authored-By: Claude <noreply@anthropic.com>