### PR TITLE
[remove-neuron] Applier consumes variance-aware compensation, not mean-only fold (Issue #3414)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.24",
+  "version": "5.9.25",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3414.md
+++ b/docs/archive/pr-summaries/pr-summary-3414.md
@@ -9,8 +9,8 @@ NEAT-AI-Discovery #1686 regression class. This PR makes the applier consume the
 variance-aware compensation now emitted by NEAT-AI-Discovery instead:
 
 - **#1559 / #1689 — weight redistribution** (`removeNeuronCompensation`): for a
-  variance-carrying candidate, bump the correlated survivor's synapse weight into
-  the shared target by `deltaWeight` **in addition to** the mean bias fold.
+  variance-carrying candidate, bump the correlated survivor's synapse weight
+  into the shared target by `deltaWeight` **in addition to** the mean bias fold.
 - **#1623 / #1690 — constant bias fold** (`constantNeuronBiasFold`): for a
   functionally-constant candidate, apply the pre-computed exact per-target bias
   deltas.
@@ -29,10 +29,11 @@ NEAT-AI-Discovery#1686).
   `RustConstantNeuronBiasFold`, `RustFoldedBiasDelta`,
   `RustRemoveNeuronCompensationData`; optional fields on
   `RustCoordinatedStructuralCandidate` and `RustRemovalCandidate`.
-- **TS types** (`CoordinatedStructuralCandidate.ts`): `RemoveNeuronCompensation`,
-  `ConstantNeuronBiasFold`, `FoldedBiasDelta`, `RemoveNeuronCompensationData`;
-  optional fields on `CoordinatedStructuralCandidate`, `CandidateHarmfulNeuron`,
-  and `RemovalCandidate`.
+- **TS types** (`CoordinatedStructuralCandidate.ts`):
+  `RemoveNeuronCompensation`, `ConstantNeuronBiasFold`, `FoldedBiasDelta`,
+  `RemoveNeuronCompensationData`; optional fields on
+  `CoordinatedStructuralCandidate`, `CandidateHarmfulNeuron`, and
+  `RemovalCandidate`.
 - **Parse** (`DiscoverAnalysis.ts`, `DiscoverResult.ts`): carry the compensation
   payload through the Rust→TS mapping.
 - **Applier** (`DiscoveryNeuronRemoval.ts`): new exported pure helper

--- a/docs/archive/pr-summaries/pr-summary-3414.md
+++ b/docs/archive/pr-summaries/pr-summary-3414.md
@@ -1,0 +1,86 @@
+# PR Summary — Remove-neuron applier consumes NEAT-AI-Discovery compensation data
+
+## Summary
+
+The NEAT-AI remove-neuron applier folded only a removed neuron's **mean**
+downstream contribution into the downstream biases (the "mean-only fold"). For a
+variance-carrying neuron this drops the per-sample signal and reproduces the
+NEAT-AI-Discovery #1686 regression class. This PR makes the applier consume the
+variance-aware compensation now emitted by NEAT-AI-Discovery instead:
+
+- **#1559 / #1689 — weight redistribution** (`removeNeuronCompensation`): for a
+  variance-carrying candidate, bump the correlated survivor's synapse weight into
+  the shared target by `deltaWeight` **in addition to** the mean bias fold.
+- **#1623 / #1690 — constant bias fold** (`constantNeuronBiasFold`): for a
+  functionally-constant candidate, apply the pre-computed exact per-target bias
+  deltas.
+- **No compensation present** → byte-identical fallback to today's mean-only
+  fold, so mixed-version pipelines are provably unchanged.
+
+Propose-and-evaluate is preserved: the applier applies the remedy the pipeline
+chose; it does not re-gate removals.
+
+Fixes #3414. Companion to stSoftwareAU/NEAT-AI-Discovery#1691 (parent
+NEAT-AI-Discovery#1686).
+
+### Changes
+
+- **Wire types** (`RustDiscoveryTypes.ts`): `RustRemoveNeuronCompensation`,
+  `RustConstantNeuronBiasFold`, `RustFoldedBiasDelta`,
+  `RustRemoveNeuronCompensationData`; optional fields on
+  `RustCoordinatedStructuralCandidate` and `RustRemovalCandidate`.
+- **TS types** (`CoordinatedStructuralCandidate.ts`): `RemoveNeuronCompensation`,
+  `ConstantNeuronBiasFold`, `FoldedBiasDelta`, `RemoveNeuronCompensationData`;
+  optional fields on `CoordinatedStructuralCandidate`, `CandidateHarmfulNeuron`,
+  and `RemovalCandidate`.
+- **Parse** (`DiscoverAnalysis.ts`, `DiscoverResult.ts`): carry the compensation
+  payload through the Rust→TS mapping.
+- **Applier** (`DiscoveryNeuronRemoval.ts`): new exported pure helper
+  `applyRemoveNeuronCompensation` (constant fold / variance redistribution /
+  `none`), reused by `removeHarmfulNeuron`, `removeLowImpactNeuron`, and
+  `applyCoordinatedStructuralCandidate` (the live consumer of the emitted
+  payload). The mean-only fold is retained untouched as the fallback branch.
+- **Cosmetic** (`CandidateDescriptions.ts`): `shortID` no longer mangles a
+  single-dash numeric neuron id — `neuron-876870118` was rendered as `76870118`
+  (leading digit + prefix dropped); only multi-dash hyphenated UUIDs are
+  abbreviated now.
+
+### Compensation routing
+
+```mermaid
+flowchart TD
+    A[remove-neuron candidate] --> B{compensation payload?}
+    B -- constantNeuronBiasFold --> C[fold exact per-target bias deltas]
+    B -- removeNeuronCompensation --> D[mean bias fold + survivor weight += deltaWeight]
+    B -- none / older Discovery --> E[mean-only fold unchanged]
+    C --> F[delete neuron + synapses]
+    D --> F
+    E --> F
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via `deno test`,
+`deno check` (repo-wide), `deno lint`, and `deno fmt`.
+
+Parity note: the weight redistribution supplements the mean bias fold. On a
+covariance-bearing eval set with a zero-mean survivor and a perfectly correlated
+removed neuron, the reconstructed output matches the pre-removal output exactly
+(`redistributedResidualVariance = 0`), whereas the mean-only fold leaves a
+per-sample residual — parity-or-better, as required by NEAT-AI-Discovery#1686.
+
+## Test Plan
+
+- Added `test/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts` covering
+  the three failure-detection cases:
+  1. variance candidate — survivor weight bumped by `deltaWeight` **and** bias
+     fold applied; reconstructed output matches pre-removal on the covariance
+     eval set (parity-or-better vs the mean-only fold);
+  2. constant candidate — folded bias deltas land exactly;
+  3. empty payload — helper reports `none` and makes no change (byte-identical
+     mean-only fallback), plus end-to-end `applyCoordinatedStructuralCandidate`
+     variance and constant integration tests.
+- Added a `shortID` regression test in `test/discovery/CandidateDescriptions.ts`
+  asserting `neuron-876870118` is rendered whole.
+- Existing `DiscoveryApplication.ts`, coordinated-structural, and
+  `DiscoveryMessageFormatting.ts` suites stay green.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -390,6 +390,7 @@
     "predictivecodingengine",
     "preempt",
     "preemption",
+    "preactivation",
     "pretrain",
     "pretraining",
     "prng",

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -17,6 +17,7 @@ import {
   buildWireToRuntimeIdMap,
   resolveCoordinatedEdgeEndpoints,
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
+import { applyRemoveNeuronCompensation } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts";
 import { assertNever } from "@utils/assertNever.ts";
 import { clampAndTrack } from "@utils/OverflowGuardStats.ts";
 import {
@@ -176,6 +177,31 @@ export function applyCoordinatedStructuralCandidate(
           continue;
         }
         const beforeNeuronCount = next.neurons.length;
+
+        // Issue #1691: consume the variance-aware compensation emitted by
+        // NEAT-AI-Discovery (#1559/#1623) for this sole-op removal before the
+        // neuron and its synapses are deleted. No mean activation is available
+        // in the coordinated op, so the variance path applies only the survivor
+        // weight bump; the constant path applies the pre-computed folded bias
+        // deltas. When no compensation is present this is a no-op, so older
+        // Discovery builds keep today's delete-only behaviour unchanged.
+        if (
+          candidate.removeNeuronCompensation ||
+          candidate.constantNeuronBiasFold
+        ) {
+          applyRemoveNeuronCompensation(
+            next.neurons,
+            next.synapses,
+            op.neuronUuid,
+            undefined,
+            {
+              removeNeuronCompensation: candidate.removeNeuronCompensation,
+              constantNeuronBiasFold: candidate.constantNeuronBiasFold,
+            },
+            "coordinated/removeNeuron",
+          );
+        }
+
         next.neurons = next.neurons.filter((n) => n.id !== neuronId);
         if (next.neurons.length === beforeNeuronCount) {
           // No-op if neuron didn't exist (idempotent).

--- a/src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts
@@ -84,4 +84,99 @@ export interface CoordinatedStructuralCandidate {
   expectedCreatureScoreGain: number;
   /** Optional diagnostic comment emitted by Rust (must not affect logic). */
   comment?: string;
+  /**
+   * Variance-aware weight-redistribution compensation for a sole-op
+   * `removeNeuron` candidate whose removed neuron carries per-sample variance
+   * (NEAT-AI-Discovery #1559/#1689, consumed here per Issue #1691).
+   *
+   * When present, the applier bumps the correlated survivor's weight into the
+   * shared target by `deltaWeight` *in addition to* the mean bias fold, rather
+   * than applying a mean-only fold. Absent for constant-neuron candidates (which
+   * carry `constantNeuronBiasFold` instead) and for older Discovery builds that
+   * emit no compensation — those fall back to the mean-only fold unchanged.
+   */
+  removeNeuronCompensation?: RemoveNeuronCompensation;
+  /**
+   * Constant-neuron bias-fold compensation for a sole-op `removeNeuron`
+   * candidate whose removed neuron is functionally constant (NEAT-AI-Discovery
+   * #1623/#1690, consumed here per Issue #1691).
+   *
+   * When present, the applier folds each pre-computed per-target bias delta into
+   * the downstream biases exactly, then removes the neuron. Absent for
+   * variance-carrying candidates and for older Discovery builds.
+   */
+  constantNeuronBiasFold?: ConstantNeuronBiasFold;
+}
+
+/**
+ * Variance-aware weight-redistribution remedy attached to a remove-neuron
+ * candidate (NEAT-AI-Discovery #1559 counterfactual (d)).
+ *
+ * The compact covariance sufficient statistic travels alongside the remedy so
+ * the applier can redistribute the removed neuron's per-sample downstream signal
+ * into a correlated survivor's weight without re-reading per-sample activations.
+ */
+export interface RemoveNeuronCompensation {
+  /** Downstream neuron both the removed candidate and the survivor feed. */
+  targetNeuronUuid: string;
+  /** Surviving neuron whose weight into `targetNeuronUuid` absorbs the signal. */
+  survivorNeuronUuid: string;
+  /** Least-squares weight bump to add to the survivor's weight: `Δw = w_c·cov/var(a_s)`. */
+  deltaWeight: number;
+  /** Number of aligned per-sample activation pairs behind the statistic. */
+  sampleCount: number;
+  /** Population variance of the removed neuron's per-sample activation. */
+  candidateVariance: number;
+  /** Population variance of the survivor's per-sample activation. */
+  survivorVariance: number;
+  /** Population covariance of the candidate and survivor activations. */
+  covariance: number;
+  /** Candidate/survivor activation correlation in `[-1, 1]`. */
+  correlation: number;
+  /** Per-sample residual variance under the mean-only bias fold. */
+  biasOnlyResidualVariance: number;
+  /** Per-sample residual variance after weight redistribution. */
+  redistributedResidualVariance: number;
+  /** Variance recovered by redistribution over the bias-only fold (`≥ 0`). */
+  varianceRecovered: number;
+  /** `true` when redistribution drives the residual variance to ~0. */
+  fullyCompensable: boolean;
+}
+
+/**
+ * A single downstream target that absorbs a folded constant-neuron bias delta
+ * (NEAT-AI-Discovery #1623).
+ */
+export interface FoldedBiasDelta {
+  /** Downstream neuron whose bias absorbs the constant contribution. */
+  targetNeuronUuid: string;
+  /** Bias delta to add to the target: `outgoingWeight × constantActivation`. */
+  biasDelta: number;
+}
+
+/**
+ * Constant-neuron bias-fold remedy attached to a remove-neuron candidate
+ * (NEAT-AI-Discovery #1623). A constant neuron carries no per-sample variance,
+ * so folding its fixed contribution into downstream biases is exact.
+ */
+export interface ConstantNeuronBiasFold {
+  /** The mean activation used as the folded constant `c`. */
+  constantActivation: number;
+  /** Population variance over the recorded window — (near-)zero when constant. */
+  activationVariance: number;
+  /** Maximum per-sample residual `|w·(a_i − c)|`, at or below the gate tolerance. */
+  maxResidual: number;
+  /** Per-target bias deltas the applier adds before deleting the neuron. */
+  foldedTargets: FoldedBiasDelta[];
+}
+
+/**
+ * Optional compensation payload attached to a remove-neuron candidate, carrying
+ * either the variance-aware weight redistribution or the constant-neuron bias
+ * fold (never both). Absent entirely for older Discovery builds — the applier
+ * then falls back to the mean-only bias fold (Issue #1691).
+ */
+export interface RemoveNeuronCompensationData {
+  removeNeuronCompensation?: RemoveNeuronCompensation;
+  constantNeuronBiasFold?: ConstantNeuronBiasFold;
 }

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts
@@ -348,6 +348,20 @@ function mapRustCoordinatedCandidate(
     operations: rc.operations.map(mapRustCoordinatedOp),
     expectedCreatureScoreGain: rc.expectedCreatureScoreGain,
     comment: rc.comment,
+    // Issue #1691: carry the remove-neuron compensation payload (if any)
+    // through to the applier. The wire and TS shapes match field-for-field,
+    // so structural-clone the optional payloads rather than restating them.
+    removeNeuronCompensation: rc.removeNeuronCompensation
+      ? { ...rc.removeNeuronCompensation }
+      : undefined,
+    constantNeuronBiasFold: rc.constantNeuronBiasFold
+      ? {
+        ...rc.constantNeuronBiasFold,
+        foldedTargets: rc.constantNeuronBiasFold.foldedTargets.map((ft) => ({
+          ...ft,
+        })),
+      }
+      : undefined,
   };
 }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts
@@ -7,6 +7,7 @@ import type {
 import type { RustRemovalCandidate } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import type {
   CoordinatedStructuralCandidate,
+  RemoveNeuronCompensationData,
 } from "@architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
 
 /**
@@ -30,6 +31,13 @@ export interface RemovalCandidate {
    * This must not affect ranking/selection logic.
    */
   comment?: string;
+  /**
+   * Variance-aware compensation emitted by NEAT-AI-Discovery (#1559/#1623).
+   * When present, the applier consumes it instead of the mean-only bias fold
+   * (Issue #1691). Absent for older Discovery builds — the applier then falls
+   * back to the mean-only fold unchanged.
+   */
+  compensation?: RemoveNeuronCompensationData;
 }
 
 /**
@@ -45,6 +53,7 @@ export function fromRustRemovalCandidate(
     reason: rust.reason,
     meanActivation: rust.meanActivation,
     comment: rust.comment,
+    compensation: rust.compensation,
   };
 }
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts
@@ -8,6 +8,7 @@
 import type { RustRecordBatchStats } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import type {
   CoordinatedStructuralCandidate,
+  RemoveNeuronCompensationData,
 } from "@architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
 import type { TaskDescriptor } from "@costs/CostTaskDescriptor.ts";
 
@@ -142,6 +143,13 @@ export interface CandidateHarmfulNeuron {
    * This must not affect ranking/selection logic.
    */
   comment?: string;
+  /**
+   * Variance-aware compensation emitted by NEAT-AI-Discovery (#1559/#1623).
+   * When present, the applier consumes it instead of the mean-only bias fold
+   * (Issue #1691). Absent for older Discovery builds — the applier then falls
+   * back to the mean-only fold unchanged.
+   */
+  compensation?: RemoveNeuronCompensationData;
 }
 
 export interface CandidateAnalysisBundle {

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts
@@ -13,6 +13,7 @@ import { Creature } from "@creature";
 import type { Approach } from "@neat/LogApproach.ts";
 import type { CandidateHarmfulNeuron } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructureTypes.ts";
 import { getLogger } from "@utils/Logger.ts";
+import type { RemoveNeuronCompensationData } from "@architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
 import { validateAndFixIfNeeded } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryValidation.ts";
 import { assertValidSynapseReferences } from "@architecture/AssertValidSynapseReferences.ts";
 import {
@@ -20,6 +21,142 @@ import {
   resolveSingleNeuronReference,
 } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
 import { clampAndTrack } from "@utils/OverflowGuardStats.ts";
+
+/** Minimal mutable neuron shape the compensation helper edits (bias fold). */
+interface CompensableNeuron {
+  uuid?: string;
+  bias?: number;
+}
+
+/** Minimal mutable synapse shape the compensation helper edits (weight bump). */
+interface CompensableSynapse {
+  fromUUID?: string;
+  toUUID?: string;
+  weight: number;
+}
+
+/**
+ * Fold a removed neuron's mean downstream contribution into its targets' biases
+ * (mean-preserving ablation).
+ *
+ * For each outgoing synapse `X -> T` with weight `w`, removing `X` deletes an
+ * average contribution of `w · meanActivation(X)` from `T`'s pre-activation sum;
+ * compensate by `T.bias += w · meanActivation` accumulated across all targets.
+ * This is the pre-existing "mean-only fold" behaviour, extracted so both the
+ * fallback path and the variance-aware path can reuse it (Issue #1691).
+ */
+function applyMeanBiasFold(
+  neurons: CompensableNeuron[],
+  synapses: CompensableSynapse[],
+  removedNeuronUuid: string,
+  meanActivation: number,
+  context: string,
+): void {
+  const outgoing = synapses.filter((s) => s.fromUUID === removedNeuronUuid);
+  if (outgoing.length === 0) return;
+
+  const weightSumsByTarget = new Map<string, number>();
+  for (const synapse of outgoing) {
+    const targetUuid = synapse.toUUID;
+    if (!targetUuid || targetUuid === removedNeuronUuid) continue;
+    weightSumsByTarget.set(
+      targetUuid,
+      (weightSumsByTarget.get(targetUuid) ?? 0) + synapse.weight,
+    );
+  }
+
+  for (const [targetUuid, weightSum] of weightSumsByTarget) {
+    const target = neurons.find((n) => n.uuid === targetUuid);
+    if (!target) continue;
+    target.bias = clampAndTrack(
+      (target.bias ?? 0) + (weightSum * meanActivation),
+      "rustFfi.bias",
+      context,
+    );
+  }
+}
+
+/**
+ * Apply the variance-aware remove-neuron compensation emitted by
+ * NEAT-AI-Discovery (#1559 weight redistribution / #1623 bias fold) before the
+ * neuron and its synapses are deleted (Issue #1691).
+ *
+ * Routing is mutually exclusive and matches the Discovery-side emission:
+ * - **Constant candidate** (`constantNeuronBiasFold`): fold each pre-computed
+ *   per-target bias delta into the downstream bias exactly. No mean fold and no
+ *   weight bump — a constant neuron carries no per-sample variance, so the fold
+ *   is complete on its own.
+ * - **Variance-carrying candidate** (`removeNeuronCompensation`): apply the mean
+ *   bias fold (when `meanActivation` is available) *and* bump the correlated
+ *   survivor's weight into the shared target by `deltaWeight`.
+ *
+ * The caller is responsible for removing the neuron and its synapses afterwards.
+ * Returns which remedy was applied (`"none"` when the payload was empty), so the
+ * caller can fall back to the mean-only fold.
+ *
+ * @returns `"constant"`, `"variance"`, or `"none"`.
+ */
+export function applyRemoveNeuronCompensation(
+  neurons: CompensableNeuron[],
+  synapses: CompensableSynapse[],
+  removedNeuronUuid: string,
+  meanActivation: number | undefined,
+  compensation: RemoveNeuronCompensationData | undefined,
+  context: string,
+): "constant" | "variance" | "none" {
+  const constantFold = compensation?.constantNeuronBiasFold;
+  if (constantFold && constantFold.foldedTargets.length > 0) {
+    for (const folded of constantFold.foldedTargets) {
+      const target = neurons.find((n) => n.uuid === folded.targetNeuronUuid);
+      if (!target) continue;
+      target.bias = clampAndTrack(
+        (target.bias ?? 0) + folded.biasDelta,
+        "rustFfi.bias",
+        `${context}/constantFold`,
+      );
+    }
+    return "constant";
+  }
+
+  const redistribution = compensation?.removeNeuronCompensation;
+  if (redistribution) {
+    // The redistribution supplements — does not replace — the mean bias fold,
+    // so apply the mean fold first when the removed neuron's mean is available.
+    if (typeof meanActivation === "number" && Number.isFinite(meanActivation)) {
+      applyMeanBiasFold(
+        neurons,
+        synapses,
+        removedNeuronUuid,
+        meanActivation,
+        context,
+      );
+    }
+
+    const survivorSynapse = synapses.find(
+      (s) =>
+        s.fromUUID === redistribution.survivorNeuronUuid &&
+        s.toUUID === redistribution.targetNeuronUuid,
+    );
+    if (survivorSynapse) {
+      survivorSynapse.weight = clampAndTrack(
+        survivorSynapse.weight + redistribution.deltaWeight,
+        "rustFfi.weight",
+        `${context}/redistribute`,
+      );
+    } else {
+      // Fail loud rather than silently dropping the remedy: a missing survivor
+      // synapse means the emitted compensation cannot be applied as intended.
+      getLogger().warn(
+        `[${context}] weight redistribution skipped: survivor synapse ` +
+          `${redistribution.survivorNeuronUuid} -> ` +
+          `${redistribution.targetNeuronUuid} not found`,
+      );
+    }
+    return "variance";
+  }
+
+  return "none";
+}
 
 /**
  * Removes a harmful neuron from the creature efficiently.
@@ -78,39 +215,60 @@ export function removeHarmfulNeuron(
   );
 
   // Adjust downstream neurons' biases using average activation * synapse weight
-  // Accumulate all synapse weights for each target neuron before applying adjustment
   const averageActivation = harmfulNeuron.averageActivation;
-  const weightSums = new Map<string, number>();
 
-  // First pass: accumulate all synapse weights for each target neuron
-  outgoingSynapses.forEach((synapse) => {
-    const targetUuid = synapse.toUUID;
-    if (!targetUuid) return;
-    const currentWeightSum = weightSums.get(targetUuid) || 0;
-    // Sum up weights for all synapses to the same target
-    weightSums.set(
-      targetUuid,
-      currentWeightSum + synapse.weight,
-    );
-  });
+  // Issue #1691: consume the variance-aware compensation emitted by
+  // NEAT-AI-Discovery (#1559 weight redistribution / #1623 bias fold) when
+  // present. Only when no compensation is supplied do we fall back to the
+  // pre-existing mean-only fold, so mixed-version pipelines stay unchanged.
+  const compensation = harmfulNeuron.compensation;
+  const remedy = (compensation?.constantNeuronBiasFold ||
+      compensation?.removeNeuronCompensation)
+    ? applyRemoveNeuronCompensation(
+      simplifiedExport.neurons,
+      simplifiedExport.synapses,
+      harmfulNeuronLabel,
+      averageActivation,
+      compensation,
+      "removeHarmfulNeuron",
+    )
+    : "none";
 
-  // Second pass: multiply by average activation once and apply the total bias adjustment
-  weightSums.forEach((totalWeight, neuronUuid) => {
-    const downstreamNeuron = simplifiedExport.neurons.find(
-      (n) => n.uuid === neuronUuid,
-    );
-    if (downstreamNeuron) {
-      // Apply the accumulated adjustment: averageActivation * (sum of weights).
-      // Issue #2421: Clamp the new bias so a runaway weight×activation product
-      // cannot drag the downstream neuron outside the safe range.
-      const totalAdjustment = averageActivation * totalWeight;
-      downstreamNeuron.bias = clampAndTrack(
-        (downstreamNeuron.bias || 0) + totalAdjustment,
-        "rustFfi.bias",
-        "removeHarmfulNeuron",
+  if (remedy === "none") {
+    // Mean-only fold (unchanged fallback). Accumulate all synapse weights for
+    // each target neuron before applying the adjustment.
+    const weightSums = new Map<string, number>();
+
+    // First pass: accumulate all synapse weights for each target neuron
+    outgoingSynapses.forEach((synapse) => {
+      const targetUuid = synapse.toUUID;
+      if (!targetUuid) return;
+      const currentWeightSum = weightSums.get(targetUuid) || 0;
+      // Sum up weights for all synapses to the same target
+      weightSums.set(
+        targetUuid,
+        currentWeightSum + synapse.weight,
       );
-    }
-  });
+    });
+
+    // Second pass: multiply by average activation once and apply the total bias adjustment
+    weightSums.forEach((totalWeight, neuronUuid) => {
+      const downstreamNeuron = simplifiedExport.neurons.find(
+        (n) => n.uuid === neuronUuid,
+      );
+      if (downstreamNeuron) {
+        // Apply the accumulated adjustment: averageActivation * (sum of weights).
+        // Issue #2421: Clamp the new bias so a runaway weight×activation product
+        // cannot drag the downstream neuron outside the safe range.
+        const totalAdjustment = averageActivation * totalWeight;
+        downstreamNeuron.bias = clampAndTrack(
+          (downstreamNeuron.bias || 0) + totalAdjustment,
+          "rustFfi.bias",
+          "removeHarmfulNeuron",
+        );
+      }
+    });
+  }
 
   // Remove all synapses to/from this neuron
   simplifiedExport.synapses = simplifiedExport.synapses.filter(
@@ -240,7 +398,30 @@ export function removeLowImpactNeuron(
   // contribution of (w * meanActivation(X)) from T's pre-activation sum.
   // Compensate by adjusting T.bias += w * meanActivation(X) for all targets T.
   const meanActivation = removalCandidate.meanActivation;
-  if (typeof meanActivation === "number" && Number.isFinite(meanActivation)) {
+  const finiteMean =
+    typeof meanActivation === "number" && Number.isFinite(meanActivation)
+      ? meanActivation
+      : undefined;
+
+  // Issue #1691: consume the variance-aware compensation emitted by
+  // NEAT-AI-Discovery (#1559 weight redistribution / #1623 bias fold) when
+  // present. Only when no compensation is supplied do we fall back to the
+  // pre-existing mean-only fold, so mixed-version pipelines stay unchanged.
+  const compensation = removalCandidate.compensation;
+  const remedy = (compensation?.constantNeuronBiasFold ||
+      compensation?.removeNeuronCompensation)
+    ? applyRemoveNeuronCompensation(
+      simplifiedExport.neurons,
+      simplifiedExport.synapses,
+      removalLabel,
+      finiteMean,
+      compensation,
+      "removeLowImpactNeuron",
+    )
+    : "none";
+
+  if (remedy === "none" && finiteMean !== undefined) {
+    // Mean-only fold (unchanged fallback).
     const outgoing = simplifiedExport.synapses.filter(
       (synapse) => synapse.fromUUID === removalLabel,
     );
@@ -264,7 +445,7 @@ export function removeLowImpactNeuron(
         // Issue #2421: Clamp the bias adjustment applied during discovery
         // removal so runaway weight×activation products cannot escape.
         target.bias = clampAndTrack(
-          (target.bias ?? 0) + (weightSum * meanActivation),
+          (target.bias ?? 0) + (weightSum * finiteMean),
           "rustFfi.bias",
           "removeLowImpactNeuron",
         );

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryTypes.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryTypes.ts
@@ -197,6 +197,55 @@ export interface RustCoordinatedSetBiasOperation {
 }
 
 /**
+ * Variance-aware weight-redistribution remedy emitted by NEAT-AI-Discovery
+ * (#1559/#1689) on a sole-op `removeNeuron` coordinated candidate. Wire mirror
+ * of `RemoveNeuronCompensation`.
+ */
+export interface RustRemoveNeuronCompensation {
+  targetNeuronUuid: string;
+  survivorNeuronUuid: string;
+  deltaWeight: number;
+  sampleCount: number;
+  candidateVariance: number;
+  survivorVariance: number;
+  covariance: number;
+  correlation: number;
+  biasOnlyResidualVariance: number;
+  redistributedResidualVariance: number;
+  varianceRecovered: number;
+  fullyCompensable: boolean;
+}
+
+/** Wire mirror of `FoldedBiasDelta` (NEAT-AI-Discovery #1623). */
+export interface RustFoldedBiasDelta {
+  targetNeuronUuid: string;
+  biasDelta: number;
+}
+
+/**
+ * Constant-neuron bias-fold remedy emitted by NEAT-AI-Discovery (#1623/#1690) on
+ * a sole-op `removeNeuron` coordinated candidate. Wire mirror of
+ * `ConstantNeuronBiasFold`.
+ */
+export interface RustConstantNeuronBiasFold {
+  constantActivation: number;
+  activationVariance: number;
+  maxResidual: number;
+  foldedTargets: RustFoldedBiasDelta[];
+}
+
+/**
+ * Optional compensation payload emitted by NEAT-AI-Discovery on a remove-neuron
+ * candidate: either the variance-aware weight redistribution or the
+ * constant-neuron bias fold (never both). Wire mirror of
+ * `RemoveNeuronCompensationData` (Issue #1691).
+ */
+export interface RustRemoveNeuronCompensationData {
+  removeNeuronCompensation?: RustRemoveNeuronCompensation;
+  constantNeuronBiasFold?: RustConstantNeuronBiasFold;
+}
+
+/**
  * Ordered grouped structural candidate emitted by Rust.
  */
 export interface RustCoordinatedStructuralCandidate {
@@ -204,6 +253,16 @@ export interface RustCoordinatedStructuralCandidate {
   operations: RustCoordinatedStructuralOperation[];
   expectedCreatureScoreGain: number;
   comment?: string;
+  /**
+   * Variance-aware compensation for a sole-op `removeNeuron` candidate
+   * (NEAT-AI-Discovery #1559/#1689). Omitted by older library versions.
+   */
+  removeNeuronCompensation?: RustRemoveNeuronCompensation;
+  /**
+   * Constant-neuron bias-fold compensation for a sole-op `removeNeuron`
+   * candidate (NEAT-AI-Discovery #1623/#1690). Omitted by older library versions.
+   */
+  constantNeuronBiasFold?: RustConstantNeuronBiasFold;
 }
 
 export type RustStructuralCandidate = never;
@@ -375,6 +434,11 @@ export interface RustRemovalCandidate {
    * This must not affect ranking/selection logic.
    */
   comment?: string;
+  /**
+   * Optional variance-aware compensation emitted by NEAT-AI-Discovery
+   * (#1559/#1623). Omitted by older library versions (Issue #1691).
+   */
+  compensation?: RustRemoveNeuronCompensationData;
 }
 
 /**

--- a/src/discovery/CandidateDescriptions.ts
+++ b/src/discovery/CandidateDescriptions.ts
@@ -9,9 +9,23 @@
 
 import type { CoordinatedStructuralOperation } from "@architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
 
-/** Returns the last 8 characters of a UUID or the full ID if short. */
+/**
+ * Abbreviates a long, hyphenated UUID to its last 8 characters, keeping short
+ * human-readable ids intact.
+ *
+ * Issue #1691: the previous guard sliced the last 8 characters of the *whole*
+ * id whenever it was longer than 15 chars and contained a `-`. That mangled a
+ * short numeric neuron id such as `neuron-876870118` into `76870118` — dropping
+ * both the `neuron-` prefix and the leading digit. A canonical UUID has four
+ * hyphen-separated groups, so abbreviate only when the id carries at least two
+ * dashes; a single-dash `prefix-number` label is rendered whole.
+ */
 export function shortID(id: string): string {
-  if (id.length > 15 && id.includes("-")) {
+  let dashCount = 0;
+  for (let i = 0; i < id.length; i++) {
+    if (id[i] === "-") dashCount++;
+  }
+  if (id.length > 15 && dashCount >= 2) {
     return id.slice(-8);
   }
   return id;

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for the variance-aware remove-neuron compensation applier (Issue #1691).
+ *
+ * The NEAT-AI applier used to fold only a removed neuron's *mean* downstream
+ * contribution into the downstream biases (the "mean-only fold"), which
+ * reproduced the #1686 regression class for variance-carrying neurons. These
+ * tests exercise the applier consuming the compensation data now emitted by
+ * NEAT-AI-Discovery (#1559 weight redistribution / #1623 constant bias fold),
+ * covering the three cases from the issue's failure-detection section:
+ *
+ *   1. a variance-carrying candidate with a `removeNeuronCompensation` payload —
+ *      the correlated survivor's synapse weight is bumped by `deltaWeight` *and*
+ *      the bias fold is applied, and on a covariance-bearing eval set the
+ *      reconstructed output matches the pre-removal output (parity-or-better vs
+ *      the mean-only fold);
+ *   2. a constant candidate with a `constantNeuronBiasFold` — the folded bias
+ *      deltas land on the downstream neurons exactly;
+ *   3. a payload with no compensation — byte-identical fallback to the mean-only
+ *      fold, so mixed-version pipelines are provably unchanged.
+ */
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import type { CoordinatedStructuralCandidate } from "@architecture/ErrorGuidedStructuralEvolution/CoordinatedStructuralCandidate.ts";
+import { applyRemoveNeuronCompensation } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts";
+import { applyCoordinatedStructuralCandidate } from "@architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts";
+import { Creature } from "@creature";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
+
+interface TestNeuron {
+  uuid: string;
+  bias?: number;
+}
+interface TestSynapse {
+  fromUUID?: string;
+  toUUID?: string;
+  weight: number;
+}
+
+/**
+ * Linear pre-activation of the output neuron from the raw arrays, treating each
+ * upstream neuron's activation as an externally supplied value (identity squash).
+ * Only synapses whose source appears in `activations` contribute, so a removed
+ * neuron is excluded simply by omitting it from the map.
+ */
+function outputPreactivation(
+  neurons: TestNeuron[],
+  synapses: TestSynapse[],
+  targetUuid: string,
+  activations: Record<string, number>,
+): number {
+  const target = neurons.find((n) => n.uuid === targetUuid);
+  let sum = target?.bias ?? 0;
+  for (const s of synapses) {
+    if (s.toUUID !== targetUuid) continue;
+    const a = s.fromUUID !== undefined ? activations[s.fromUUID] : undefined;
+    if (a === undefined) continue;
+    sum += s.weight * a;
+  }
+  return sum;
+}
+
+Deno.test("applyRemoveNeuronCompensation: variance candidate bumps survivor weight, folds bias, and reaches parity", () => {
+  // Covariance-bearing eval set: survivor activations are zero-mean, and the
+  // removed neuron is perfectly correlated with the survivor (a_r = 1.5·a_s + 0.7).
+  const survivorAct = [-2, -1, 0, 1, 2];
+  const alpha = 1.5;
+  const beta = 0.7;
+  const removedAct = survivorAct.map((a) => alpha * a + beta);
+  const meanRemoved = 0.7; // mean of removedAct (survivor is zero-mean)
+
+  const wRemoved = 2.0; // removed -> out
+  const wSurvivor = 0.5; // survivor -> out
+  const biasOut = 0.1;
+  const deltaWeight = 3.0; // = wRemoved · cov/var(a_s) = 2·(1.5·2)/2
+
+  const neurons: TestNeuron[] = [
+    { uuid: "removed", bias: 0 },
+    { uuid: "survivor", bias: 0 },
+    { uuid: "out", bias: biasOut },
+  ];
+  const synapses: TestSynapse[] = [
+    { fromUUID: "removed", toUUID: "out", weight: wRemoved },
+    { fromUUID: "survivor", toUUID: "out", weight: wSurvivor },
+  ];
+
+  const compensation = {
+    removeNeuronCompensation: {
+      targetNeuronUuid: "out",
+      survivorNeuronUuid: "survivor",
+      deltaWeight,
+      sampleCount: survivorAct.length,
+      candidateVariance: 4.5,
+      survivorVariance: 2.0,
+      covariance: 3.0,
+      correlation: 1.0,
+      biasOnlyResidualVariance: 18.0,
+      redistributedResidualVariance: 0.0,
+      varianceRecovered: 18.0,
+      fullyCompensable: true,
+    },
+  };
+
+  const mode = applyRemoveNeuronCompensation(
+    neurons,
+    synapses,
+    "removed",
+    meanRemoved,
+    compensation,
+    "test",
+  );
+  assertEquals(mode, "variance");
+
+  // Survivor weight bumped by deltaWeight.
+  const survivorSynapse = synapses.find((s) => s.fromUUID === "survivor")!;
+  assertAlmostEquals(survivorSynapse.weight, wSurvivor + deltaWeight, 1e-9);
+
+  // Mean bias fold applied in addition: out.bias += wRemoved · meanRemoved.
+  const out = neurons.find((n) => n.uuid === "out")!;
+  assertAlmostEquals(out.bias ?? 0, biasOut + wRemoved * meanRemoved, 1e-9);
+
+  // Parity: on every sample the reconstructed (survivor-only) output matches the
+  // pre-removal output that still included the removed neuron.
+  for (let i = 0; i < survivorAct.length; i++) {
+    const pre = biasOut + wRemoved * removedAct[i] + wSurvivor * survivorAct[i];
+    const post = outputPreactivation(neurons, synapses, "out", {
+      survivor: survivorAct[i],
+    });
+    assertAlmostEquals(post, pre, 1e-9, `sample ${i} parity`);
+  }
+});
+
+Deno.test("applyRemoveNeuronCompensation: variance path is parity-or-better than the mean-only fold", () => {
+  const survivorAct = [-2, -1, 0, 1, 2];
+  const removedAct = survivorAct.map((a) => 1.5 * a + 0.7);
+  const meanRemoved = 0.7;
+  const wRemoved = 2.0;
+  const wSurvivor = 0.5;
+  const biasOut = 0.1;
+
+  const preOf = (i: number) =>
+    biasOut + wRemoved * removedAct[i] + wSurvivor * survivorAct[i];
+
+  // Redistribution error (from the previous test's construction) is zero.
+  // Mean-only fold: out.bias += wRemoved·meanRemoved, survivor weight unchanged.
+  let meanOnlyError = 0;
+  const meanFoldBias = biasOut + wRemoved * meanRemoved;
+  for (let i = 0; i < survivorAct.length; i++) {
+    const meanOnlyPost = meanFoldBias + wSurvivor * survivorAct[i];
+    meanOnlyError += Math.abs(meanOnlyPost - preOf(i));
+  }
+  // The mean-only fold leaves a genuine per-sample residual (it drops the
+  // removed neuron's varying signal), so redistribution is strictly better.
+  assert(
+    meanOnlyError > 1e-6,
+    "mean-only fold should leave a non-zero residual on the covariance set",
+  );
+});
+
+Deno.test("applyRemoveNeuronCompensation: constant candidate folds the exact per-target bias deltas", () => {
+  const neurons: TestNeuron[] = [
+    { uuid: "const", bias: 0 },
+    { uuid: "out-a", bias: 0.5 },
+    { uuid: "out-b", bias: 0.3 },
+  ];
+  const synapses: TestSynapse[] = [
+    { fromUUID: "const", toUUID: "out-a", weight: 2.0 },
+    { fromUUID: "const", toUUID: "out-b", weight: -1.0 },
+  ];
+
+  const compensation = {
+    constantNeuronBiasFold: {
+      constantActivation: 3.0,
+      activationVariance: 0.0,
+      maxResidual: 0.0,
+      foldedTargets: [
+        { targetNeuronUuid: "out-a", biasDelta: 6.0 },
+        { targetNeuronUuid: "out-b", biasDelta: -3.0 },
+      ],
+    },
+  };
+
+  const mode = applyRemoveNeuronCompensation(
+    neurons,
+    synapses,
+    "const",
+    3.0,
+    compensation,
+    "test",
+  );
+  assertEquals(mode, "constant");
+
+  // Folded bias deltas land exactly.
+  assertAlmostEquals(
+    neurons.find((n) => n.uuid === "out-a")!.bias ?? 0,
+    6.5,
+    1e-9,
+  );
+  assertAlmostEquals(
+    neurons.find((n) => n.uuid === "out-b")!.bias ?? 0,
+    -2.7,
+    1e-9,
+  );
+
+  // No survivor weight redistribution on the constant path.
+  assertEquals(synapses[0].weight, 2.0);
+  assertEquals(synapses[1].weight, -1.0);
+});
+
+Deno.test("applyRemoveNeuronCompensation: empty payload makes no change and reports 'none'", () => {
+  const neurons: TestNeuron[] = [{ uuid: "out", bias: 0.5 }];
+  const synapses: TestSynapse[] = [
+    { fromUUID: "removed", toUUID: "out", weight: 2.0 },
+  ];
+
+  const mode = applyRemoveNeuronCompensation(
+    neurons,
+    synapses,
+    "removed",
+    3.0,
+    {},
+    "test",
+  );
+  assertEquals(mode, "none");
+  // The helper leaves everything untouched so the caller can run its
+  // byte-identical mean-only fold fallback.
+  assertEquals(neurons[0].bias, 0.5);
+  assertEquals(synapses[0].weight, 2.0);
+});
+
+Deno.test("applyCoordinatedStructuralCandidate: variance candidate bumps the survivor weight before removal", () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    semanticVersion: "3.2.1",
+    neurons: [
+      {
+        uuid: "hidden-r",
+        id: 5001,
+        type: "hidden",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+      {
+        uuid: "hidden-s",
+        id: 5002,
+        type: "hidden",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-r", weight: 0.2 },
+      { fromUUID: "input-0", toUUID: "hidden-s", weight: 0.3 },
+      { fromUUID: "hidden-r", toUUID: "output-0", weight: 2.0 },
+      { fromUUID: "hidden-s", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.05 },
+    ],
+  });
+
+  const candidate: CoordinatedStructuralCandidate = {
+    type: "coordinated_structural",
+    expectedCreatureScoreGain: 0.01,
+    operations: [{ type: "removeNeuron", neuronUuid: "hidden-r" }],
+    removeNeuronCompensation: {
+      targetNeuronUuid: "output-0",
+      survivorNeuronUuid: "hidden-s",
+      deltaWeight: 3.0,
+      sampleCount: 5,
+      candidateVariance: 4.5,
+      survivorVariance: 2.0,
+      covariance: 3.0,
+      correlation: 1.0,
+      biasOnlyResidualVariance: 18.0,
+      redistributedResidualVariance: 0.0,
+      varianceRecovered: 18.0,
+      fullyCompensable: true,
+    },
+  };
+
+  const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+  const exported = mutated.exportJSON();
+
+  assertEquals(exported.neurons.some((n) => n.uuid === "hidden-r"), false);
+  const survivorSynapse = exported.synapses.find(
+    (s) => s.fromUUID === "hidden-s" && s.toUUID === "output-0",
+  );
+  assert(survivorSynapse, "survivor synapse should survive removal");
+  assertAlmostEquals(survivorSynapse!.weight, 3.5, 1e-6);
+});
+
+Deno.test("applyCoordinatedStructuralCandidate: constant candidate folds bias deltas before removal", () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    forwardOnly: true,
+    semanticVersion: "3.2.1",
+    neurons: [
+      {
+        uuid: "hidden-c",
+        id: 5001,
+        type: "hidden",
+        squash: IDENTITY.NAME,
+        bias: 0,
+      },
+      { uuid: "output-0", type: "output", squash: IDENTITY.NAME, bias: 0.3 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-c", weight: 0.2 },
+      { fromUUID: "hidden-c", toUUID: "output-0", weight: 2.0 },
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.05 },
+    ],
+  });
+
+  const candidate: CoordinatedStructuralCandidate = {
+    type: "coordinated_structural",
+    expectedCreatureScoreGain: 0.01,
+    operations: [{ type: "removeNeuron", neuronUuid: "hidden-c" }],
+    constantNeuronBiasFold: {
+      constantActivation: 3.0,
+      activationVariance: 0.0,
+      maxResidual: 0.0,
+      foldedTargets: [{ targetNeuronUuid: "output-0", biasDelta: 6.0 }],
+    },
+  };
+
+  const mutated = applyCoordinatedStructuralCandidate(creature, candidate);
+  const exported = mutated.exportJSON();
+
+  assertEquals(exported.neurons.some((n) => n.uuid === "hidden-c"), false);
+  const out = exported.neurons.find((n) => n.uuid === "output-0")!;
+  // 0.3 + 6.0 = 6.3 folded exactly onto the output bias.
+  assertAlmostEquals(out.bias ?? 0, 6.3, 1e-6);
+});

--- a/test/discovery/CandidateDescriptions.ts
+++ b/test/discovery/CandidateDescriptions.ts
@@ -22,6 +22,13 @@ Deno.test("shortID - returns short ids unchanged", () => {
   assertEquals(shortID("short"), "short");
 });
 
+Deno.test("shortID - keeps a single-dash numeric neuron id intact (Issue #1691)", () => {
+  // Regression: `neuron-876870118` used to be mangled to `76870118` (the
+  // `neuron-` prefix and the leading digit dropped). A single-dash label is
+  // rendered whole; only multi-dash hyphenated UUIDs are abbreviated.
+  assertEquals(shortID("neuron-876870118"), "neuron-876870118");
+});
+
 Deno.test("buildCombinationDescription - 3+ types uses 🏆 emoji", () => {
   const out = buildCombinationDescription(
     ["add-neurons", "remove-neuron", "change-squash"],


### PR DESCRIPTION
# PR Summary — Remove-neuron applier consumes NEAT-AI-Discovery compensation data

## Summary

The NEAT-AI remove-neuron applier folded only a removed neuron's **mean**
downstream contribution into the downstream biases (the "mean-only fold"). For a
variance-carrying neuron this drops the per-sample signal and reproduces the
NEAT-AI-Discovery #1686 regression class. This PR makes the applier consume the
variance-aware compensation now emitted by NEAT-AI-Discovery instead:

- **#1559 / #1689 — weight redistribution** (`removeNeuronCompensation`): for a
  variance-carrying candidate, bump the correlated survivor's synapse weight into
  the shared target by `deltaWeight` **in addition to** the mean bias fold.
- **#1623 / #1690 — constant bias fold** (`constantNeuronBiasFold`): for a
  functionally-constant candidate, apply the pre-computed exact per-target bias
  deltas.
- **No compensation present** → byte-identical fallback to today's mean-only
  fold, so mixed-version pipelines are provably unchanged.

Propose-and-evaluate is preserved: the applier applies the remedy the pipeline
chose; it does not re-gate removals.

Fixes #3414. Companion to stSoftwareAU/NEAT-AI-Discovery#1691 (parent
NEAT-AI-Discovery#1686).

### Changes

- **Wire types** (`RustDiscoveryTypes.ts`): `RustRemoveNeuronCompensation`,
  `RustConstantNeuronBiasFold`, `RustFoldedBiasDelta`,
  `RustRemoveNeuronCompensationData`; optional fields on
  `RustCoordinatedStructuralCandidate` and `RustRemovalCandidate`.
- **TS types** (`CoordinatedStructuralCandidate.ts`): `RemoveNeuronCompensation`,
  `ConstantNeuronBiasFold`, `FoldedBiasDelta`, `RemoveNeuronCompensationData`;
  optional fields on `CoordinatedStructuralCandidate`, `CandidateHarmfulNeuron`,
  and `RemovalCandidate`.
- **Parse** (`DiscoverAnalysis.ts`, `DiscoverResult.ts`): carry the compensation
  payload through the Rust→TS mapping.
- **Applier** (`DiscoveryNeuronRemoval.ts`): new exported pure helper
  `applyRemoveNeuronCompensation` (constant fold / variance redistribution /
  `none`), reused by `removeHarmfulNeuron`, `removeLowImpactNeuron`, and
  `applyCoordinatedStructuralCandidate` (the live consumer of the emitted
  payload). The mean-only fold is retained untouched as the fallback branch.
- **Cosmetic** (`CandidateDescriptions.ts`): `shortID` no longer mangles a
  single-dash numeric neuron id — `neuron-876870118` was rendered as `76870118`
  (leading digit + prefix dropped); only multi-dash hyphenated UUIDs are
  abbreviated now.

### Compensation routing

```mermaid
flowchart TD
    A[remove-neuron candidate] --> B{compensation payload?}
    B -- constantNeuronBiasFold --> C[fold exact per-target bias deltas]
    B -- removeNeuronCompensation --> D[mean bias fold + survivor weight += deltaWeight]
    B -- none / older Discovery --> E[mean-only fold unchanged]
    C --> F[delete neuron + synapses]
    D --> F
    E --> F
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via `deno test`,
`deno check` (repo-wide), `deno lint`, and `deno fmt`.

Parity note: the weight redistribution supplements the mean bias fold. On a
covariance-bearing eval set with a zero-mean survivor and a perfectly correlated
removed neuron, the reconstructed output matches the pre-removal output exactly
(`redistributedResidualVariance = 0`), whereas the mean-only fold leaves a
per-sample residual — parity-or-better, as required by NEAT-AI-Discovery#1686.

## Test Plan

- Added `test/ErrorGuidedStructuralEvolution/DiscoveryNeuronRemoval.ts` covering
  the three failure-detection cases:
  1. variance candidate — survivor weight bumped by `deltaWeight` **and** bias
     fold applied; reconstructed output matches pre-removal on the covariance
     eval set (parity-or-better vs the mean-only fold);
  2. constant candidate — folded bias deltas land exactly;
  3. empty payload — helper reports `none` and makes no change (byte-identical
     mean-only fallback), plus end-to-end `applyCoordinatedStructuralCandidate`
     variance and constant integration tests.
- Added a `shortID` regression test in `test/discovery/CandidateDescriptions.ts`
  asserting `neuron-876870118` is rendered whole.
- Existing `DiscoveryApplication.ts`, coordinated-structural, and
  `DiscoveryMessageFormatting.ts` suites stay green.