### PR TITLE
Dependency bump rejected: deno missing from worker PATH (VibeCoding#3532) (Issue #3417)

### DIFF
--- a/bump-deps.sh
+++ b/bump-deps.sh
@@ -156,8 +156,45 @@ if ! [[ "$QUARANTINE_HOURS" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-if ! command -v deno >/dev/null 2>&1; then
+# Resolve the `deno` binary before doing anything else. The Vibe Coder
+# worker sometimes spawns this script with an unattended launchd/cron PATH
+# that lacks ~/.deno/bin (the official installer location), so a bare
+# `command -v deno` fails even though deno is installed (Issue #3417). Probe
+# the known install locations as defence in depth — first match wins — and
+# prepend the winner's directory to PATH so every later `deno` call resolves.
+# The real fix is worker-side PATH bootstrap (VibeCoding#3532); this is a
+# local hardening layer. When no candidate exists we still fail loud
+# (ERROR + exit 1) rather than silently skipping the bump.
+#
+# BUMP_DEPS_DENO_FALLBACKS (colon-separated) overrides the probe list. It is
+# a test seam and defaults to the canonical installer locations.
+DENO_FALLBACK_PATHS="${BUMP_DEPS_DENO_FALLBACKS:-$HOME/.deno/bin/deno:/opt/homebrew/bin/deno:/usr/local/bin/deno}"
+
+resolve_deno() {
+  if command -v deno >/dev/null 2>&1; then
+    return 0
+  fi
+  local candidate
+  # Split the colon-separated fallback list without a subshell (bash 3.2-safe).
+  local IFS=':'
+  # shellcheck disable=SC2086 # intentional word-splitting on ':'
+  for candidate in $DENO_FALLBACK_PATHS; do
+    [[ -n "$candidate" ]] || continue
+    if [[ -x "$candidate" ]]; then
+      PATH="$(dirname "$candidate"):$PATH"
+      export PATH
+      echo "Resolved deno via fallback: $candidate (not on PATH)" >&2
+      return 0
+    fi
+  done
+  return 1
+}
+
+if ! resolve_deno; then
   echo "ERROR: deno is required" >&2
+  echo "       deno is not on PATH and no fallback binary was found in:" >&2
+  echo "       ${DENO_FALLBACK_PATHS}" >&2
+  echo "       Install deno (https://deno.land) or add ~/.deno/bin to PATH." >&2
   exit 1
 fi
 

--- a/bump-deps.sh
+++ b/bump-deps.sh
@@ -175,10 +175,12 @@ resolve_deno() {
     return 0
   fi
   local candidate
-  # Split the colon-separated fallback list without a subshell (bash 3.2-safe).
-  local IFS=':'
-  # shellcheck disable=SC2086 # intentional word-splitting on ':'
-  for candidate in $DENO_FALLBACK_PATHS; do
+  # Split the colon-separated fallback list without setting IFS globally
+  # (avoids the ifs-tampering SAST finding) and without a subshell
+  # (bash 3.2-safe): scope IFS to the single `read` that does the splitting.
+  local candidates=()
+  IFS=':' read -r -a candidates <<<"$DENO_FALLBACK_PATHS"
+  for candidate in ${candidates[@]+"${candidates[@]}"}; do
     [[ -n "$candidate" ]] || continue
     if [[ -x "$candidate" ]]; then
       PATH="$(dirname "$candidate"):$PATH"

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.25",
+  "version": "5.9.26",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3417.md
+++ b/docs/archive/pr-summaries/pr-summary-3417.md
@@ -1,0 +1,65 @@
+# Harden bump-deps.sh against a missing deno on the worker PATH
+
+## Summary
+
+Dependency bumps on host Mac-Ultra-M2 were rejected because `bump-deps.sh`'s
+`command -v deno` pre-flight failed: the Vibe Coder worker spawns the script
+with the unattended launchd/cron PATH, which lacks `~/.deno/bin` (the official
+installer location). The bump was reverted and PR #3416 shipped without it.
+
+The root cause is worker-side and tracked separately as
+`stSoftwareAU/VibeCoding#3532`. This PR adds a **local defence-in-depth layer**:
+when `command -v deno` fails, `bump-deps.sh` now probes the known install
+locations — `~/.deno/bin/deno`, `/opt/homebrew/bin/deno`, `/usr/local/bin/deno`
+(first match wins) — and prepends the winner's directory to `PATH` so every
+later `deno` call resolves. When no candidate exists it still **fails loud**
+with the existing `ERROR: deno is required` message and exit 1, so the worker
+reverts per VibeCoding#1613 — no silent skip.
+
+The fallback list is overridable via `BUMP_DEPS_DENO_FALLBACKS` (a
+colon-separated test seam) that defaults to the three canonical locations.
+
+Closes #3417.
+
+> Note: the verify-and-close step in the issue depends on VibeCoding#3532
+> landing on an affected host; this PR delivers the hardening half, which does
+> not depend on the worker fix.
+
+## Deno regression avoided
+
+Implemented the probe as native bash within the existing Deno-repo tooling — no
+Node-only helper or dependency introduced.
+
+## Evidence
+
+Backend/CLI change (a bash script) — no web interface to screenshot. Verified
+via the `deno test` specs below.
+
+```mermaid
+flowchart TD
+    A[bump-deps.sh start] --> B{command -v deno?}
+    B -- found --> Z[proceed with bump]
+    B -- missing --> C[probe fallback list<br/>~/.deno/bin, /opt/homebrew/bin, /usr/local/bin]
+    C -- match --> D[prepend dir to PATH] --> Z
+    C -- none --> E[ERROR: deno is required<br/>exit 1 fail loud]
+```
+
+Targeted run (`deno test --allow-all test/scripts/BumpDepsScript.ts`): all 13
+specs pass, including the two new Issue #3417 specs.
+
+## Test Plan
+
+Added to `test/scripts/BumpDepsScript.ts`:
+
+- `bump-deps.sh resolves deno from ~/.deno/bin fallback when PATH lacks it
+  (Issue #3417)`
+  — stubs a deno binary under a temp `HOME/.deno/bin`, runs the script with a
+  PATH that excludes deno, and asserts exit 0 with no `deno is required` error.
+  Reproduces the #3416 failure against the unfixed script (which would exit 1)
+  and passes after the fix.
+- `bump-deps.sh fails loud when deno is absent and no fallback exists
+  (Issue #3417)`
+  — points `BUMP_DEPS_DENO_FALLBACKS` at non-existent binaries with a deno-free
+  PATH and asserts non-zero exit plus the fail-loud `deno is required` message.
+
+All existing `BumpDepsScript.ts` specs continue to pass unchanged.

--- a/test/scripts/BumpDepsScript.ts
+++ b/test/scripts/BumpDepsScript.ts
@@ -198,6 +198,72 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "bump-deps.sh resolves deno from ~/.deno/bin fallback when PATH lacks it (Issue #3417)",
+  fn: async () => {
+    // Simulate the unattended launchd/cron PATH: deno installed at
+    // ~/.deno/bin but that directory absent from PATH. The script must probe
+    // the fallback location and proceed, not fail loud.
+    const home = await Deno.makeTempDir();
+    try {
+      const binDir = `${home}/.deno/bin`;
+      await Deno.mkdir(binDir, { recursive: true });
+      const stub = `${binDir}/deno`;
+      // Stub deno tolerates any invocation (read_neat_core_rev calls
+      // `deno eval` even under --dry-run) and exits 0.
+      await Deno.writeTextFile(stub, "#!/bin/sh\nexit 0\n");
+      await Deno.chmod(stub, 0o755);
+
+      const result = await runBump(
+        ["--dry-run", "--no-internal", "--no-external"],
+        { PATH: "/usr/bin:/bin", HOME: home },
+      );
+      assertEquals(
+        result.code,
+        0,
+        `expected exit 0 via fallback deno; stderr=${result.stderr}`,
+      );
+      assert(
+        !result.stderr.includes("deno is required"),
+        `must not fail loud when a fallback deno exists; stderr=${result.stderr}`,
+      );
+    } finally {
+      await Deno.remove(home, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "bump-deps.sh fails loud when deno is absent and no fallback exists (Issue #3417)",
+  fn: async () => {
+    // PATH without deno and a fallback list pointing only at non-existent
+    // binaries must reproduce the original fail-loud behaviour.
+    const home = await Deno.makeTempDir();
+    try {
+      const result = await runBump(
+        ["--dry-run", "--no-internal", "--no-external"],
+        {
+          PATH: "/usr/bin:/bin",
+          HOME: home,
+          BUMP_DEPS_DENO_FALLBACKS: `${home}/none-a/deno:${home}/none-b/deno`,
+        },
+      );
+      assert(
+        result.code !== 0,
+        `expected non-zero exit when no deno is resolvable; stderr=${result.stderr}`,
+      );
+      assert(
+        result.stderr.includes("deno is required"),
+        `expected fail-loud 'deno is required'; stderr=${result.stderr}`,
+      );
+    } finally {
+      await Deno.remove(home, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
   name: "bump-deps.sh exists and is executable",
   fn: async () => {
     const stat = await Deno.stat("bump-deps.sh");


### PR DESCRIPTION
# Harden bump-deps.sh against a missing deno on the worker PATH

## Summary

Dependency bumps on host Mac-Ultra-M2 were rejected because `bump-deps.sh`'s
`command -v deno` pre-flight failed: the Vibe Coder worker spawns the script
with the unattended launchd/cron PATH, which lacks `~/.deno/bin` (the official
installer location). The bump was reverted and PR #3416 shipped without it.

The root cause is worker-side and tracked separately as
`stSoftwareAU/VibeCoding#3532`. This PR adds a **local defence-in-depth layer**:
when `command -v deno` fails, `bump-deps.sh` now probes the known install
locations — `~/.deno/bin/deno`, `/opt/homebrew/bin/deno`, `/usr/local/bin/deno`
(first match wins) — and prepends the winner's directory to `PATH` so every
later `deno` call resolves. When no candidate exists it still **fails loud**
with the existing `ERROR: deno is required` message and exit 1, so the worker
reverts per VibeCoding#1613 — no silent skip.

The fallback list is overridable via `BUMP_DEPS_DENO_FALLBACKS` (a
colon-separated test seam) that defaults to the three canonical locations.

Closes #3417.

> Note: the verify-and-close step in the issue depends on VibeCoding#3532
> landing on an affected host; this PR delivers the hardening half, which does
> not depend on the worker fix.

## Deno regression avoided

Implemented the probe as native bash within the existing Deno-repo tooling — no
Node-only helper or dependency introduced.

## Evidence

Backend/CLI change (a bash script) — no web interface to screenshot. Verified
via the `deno test` specs below.

```mermaid
flowchart TD
    A[bump-deps.sh start] --> B{command -v deno?}
    B -- found --> Z[proceed with bump]
    B -- missing --> C[probe fallback list<br/>~/.deno/bin, /opt/homebrew/bin, /usr/local/bin]
    C -- match --> D[prepend dir to PATH] --> Z
    C -- none --> E[ERROR: deno is required<br/>exit 1 fail loud]
```

Targeted run (`deno test --allow-all test/scripts/BumpDepsScript.ts`): all 13
specs pass, including the two new Issue #3417 specs.

## Test Plan

Added to `test/scripts/BumpDepsScript.ts`:

- `bump-deps.sh resolves deno from ~/.deno/bin fallback when PATH lacks it
  (Issue #3417)`
  — stubs a deno binary under a temp `HOME/.deno/bin`, runs the script with a
  PATH that excludes deno, and asserts exit 0 with no `deno is required` error.
  Reproduces the #3416 failure against the unfixed script (which would exit 1)
  and passes after the fix.
- `bump-deps.sh fails loud when deno is absent and no fallback exists
  (Issue #3417)`
  — points `BUMP_DEPS_DENO_FALLBACKS` at non-existent binaries with a deno-free
  PATH and asserts non-zero exit plus the fail-loud `deno is required` message.

All existing `BumpDepsScript.ts` specs continue to pass unchanged.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrt4mih6-635525`<!-- vibe-worker-issue-3417 -->