### PR TITLE
fix: stop discovery crashing on aggregate-squash neurons (#3419)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.26",
+  "version": "5.9.27",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts
@@ -11,6 +11,9 @@ import type { Creature } from "@creature";
 import { TopologyError } from "@errors/TopologyError.ts";
 import type { ActivationInterface } from "@methods/activations/ActivationInterface.ts";
 import { Activations } from "@methods/activations/Activations.ts";
+import { hasScalarSquash } from "@methods/activations/TypeGuards.ts";
+import { IF } from "@methods/activations/aggregate/IF.ts";
+import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
 import { getRandomNumberGenerator } from "@utils/RandomNumberGenerator.ts";
 import type {
   CandidateHarmfulNeuron,
@@ -114,6 +117,40 @@ export function calculateSquashErrorFromRaw(
 }
 
 /**
+ * Sentinel distinguishing "aggregate neuron excluded from swap scoring" from
+ * "genuine scalar squash resolved" — {@link resolveScoringSquash} returns it
+ * for `IF`, which callers treat as "skip this neuron without throwing".
+ */
+const EXCLUDED_FROM_SWAP = Symbol("excluded-from-swap");
+
+/**
+ * Resolve the scalar squash method to score a focus neuron against.
+ *
+ * Issue #3419: aggregate-squash neurons (`MAXIMUM`, `MINIMUM`, `IF`) implement
+ * `activate(neuron)` but expose no scalar `squash(x)`. #3389 began recording
+ * their value/error, so they now reach the squash analysis for the first time;
+ * the old unchecked `Activations.find(...) as ActivationInterface` cast then
+ * threw `squash is not a function`, aborting the whole discovery run. Resolve a
+ * scalar stand-in instead of throwing:
+ *
+ * - a genuine scalar squash resolves to itself;
+ * - `MAXIMUM`/`MINIMUM` pass their aggregated value straight through, so they
+ *   resolve to the `IDENTITY` pass-through — simple-squash replacements are then
+ *   scored against the recorded ideal values like any other candidate;
+ * - `IF` routes typed condition/positive/negative connections whose meaning a
+ *   scalar squash would change, so it resolves to {@link EXCLUDED_FROM_SWAP} and
+ *   is skipped (never thrown on).
+ */
+function resolveScoringSquash(
+  squashName: string,
+): ActivationInterface | typeof EXCLUDED_FROM_SWAP {
+  const activation = Activations.find(squashName);
+  if (hasScalarSquash(activation)) return activation;
+  if (squashName === IF.NAME) return EXCLUDED_FROM_SWAP;
+  return Activations.find(IDENTITY.NAME) as ActivationInterface;
+}
+
+/**
  * Core squash analysis: tries all activation functions, picks best.
  *
  * @param creature - The creature containing the neuron
@@ -165,9 +202,13 @@ export function findCandidateSquash(
   assert(neuronUuid, `Missing wire uuid for neuron ${neuronId}`);
   const currentSquash = neuron.squash;
   assert(currentSquash, "Squash function not found");
-  const currentSquashMethod = Activations.find(
-    currentSquash,
-  ) as ActivationInterface;
+  // Issue #3419: aggregate-squash neurons expose no scalar squash(x). Resolve a
+  // stand-in (IDENTITY for MAXIMUM/MINIMUM) or skip IF entirely, rather than
+  // calling `.squash` on an aggregate and aborting discovery.
+  const currentSquashMethod = resolveScoringSquash(currentSquash);
+  if (currentSquashMethod === EXCLUDED_FROM_SWAP) {
+    return undefined;
+  }
 
   records.forEach((record) => {
     const value = record.value;
@@ -475,10 +516,12 @@ export async function analyzeSelectedNeuronsForHarmfulRemoval(
       const currentSquash = neuron.squash;
       if (!currentSquash) return undefined;
 
-      const currentSquashMethod = Activations.find(
-        currentSquash,
-      ) as ActivationInterface;
-      if (!currentSquashMethod) return undefined;
+      // Issue #3419: aggregate-squash neurons expose no scalar squash(x). The
+      // same unchecked cast crashed this path per-neuron; resolve a stand-in
+      // (IDENTITY for MAXIMUM/MINIMUM) or skip IF instead of calling `.squash`
+      // on an aggregate.
+      const currentSquashMethod = resolveScoringSquash(currentSquash);
+      if (currentSquashMethod === EXCLUDED_FROM_SWAP) return undefined;
 
       let activationSum = 0;
       let activationCount = 0;

--- a/src/methods/activations/TypeGuards.ts
+++ b/src/methods/activations/TypeGuards.ts
@@ -8,8 +8,23 @@
  */
 
 import type { AbstractActivationInterface } from "@methods/activations/AbstractActivationInterface.ts";
+import type { ActivationInterface } from "@methods/activations/ActivationInterface.ts";
 import type { UnSquashInterface } from "@methods/activations/UnSquashInterface.ts";
 import type { SimplifyBiasInterface } from "@optimize/SimplifyBiasInterface.ts";
+
+/**
+ * Check whether an activation exposes a scalar `squash(x)` method.
+ *
+ * Aggregate activations (`MAXIMUM`, `MINIMUM`, `IF`) operate over a whole
+ * neuron via `activate(neuron)` and do NOT implement `squash(x)`, so they are
+ * excluded by this guard. Callers use it to avoid the unchecked cast that threw
+ * `squash is not a function` on aggregate-squash neurons (Issue #3419).
+ */
+export function hasScalarSquash(
+  activation: AbstractActivationInterface,
+): activation is ActivationInterface {
+  return typeof (activation as ActivationInterface).squash === "function";
+}
 
 /** Check whether an activation implements the `unSquash()` method. */
 export function hasUnSquash(

--- a/test/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts
@@ -323,3 +323,131 @@ Deno.test(
     assertNotEquals(result?.[0]?.expectedCreatureScoreGain, synthetic);
   },
 );
+
+/**
+ * Focus neuron using an aggregate squash (`MAXIMUM`/`MINIMUM`) fed by two
+ * inputs. Issue #3389 began recording these neurons' value/error, so they now
+ * reach the squash analysis; Issue #3419 keeps that analysis from crashing.
+ */
+function aggregateFocusCreature(squash: string): Creature {
+  return Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "agg", squash, bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "agg", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "agg", weight: 0.5 },
+      { fromUUID: "agg", toUUID: "output-0", weight: 1 },
+    ],
+  });
+}
+
+/** IF focus neuron with the typed condition/positive/negative connections. */
+function ifFocusCreature(): Creature {
+  return Creature.fromJSON({
+    input: 3,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "if-h", squash: "IF", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "if-h", weight: 0.2, type: "condition" },
+      { fromUUID: "input-1", toUUID: "if-h", weight: 0.3, type: "positive" },
+      { fromUUID: "input-2", toUUID: "if-h", weight: -0.4, type: "negative" },
+      { fromUUID: "if-h", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+}
+
+// Issue #3419: MAXIMUM/MINIMUM aggregate neurons expose no scalar squash(x).
+// Pre-fix `findCandidateSquash` cast the aggregate to ActivationInterface and
+// called `.squash(idealValue)`, throwing `squash is not a function` and
+// aborting the whole discovery run. It must now score simple-squash
+// replacements against the IDENTITY pass-through instead of throwing.
+for (const squash of ["MAXIMUM", "MINIMUM"]) {
+  Deno.test(
+    `DiscoverSquashAnalysis - findCandidateSquash scores ${squash} focus neuron without throwing (#3419)`,
+    () => {
+      const creature = aggregateFocusCreature(squash);
+      const aggId = buildWireToRuntimeIdMap(creature).get("agg")!;
+
+      const records = [
+        { value: 0.3, activation: 0.3, errors: [0.05] },
+        { value: 0.6, activation: 0.6, errors: [-0.05] },
+        { value: -0.2, activation: -0.2, errors: [0.1] },
+      ];
+
+      // The bug reproduced here: pre-fix this call threw a TypeError.
+      const candidate = findCandidateSquash(
+        creature,
+        aggId,
+        records,
+        () => 1,
+        false,
+        () => {},
+      );
+
+      // A swap candidate is optional (low score is a valid state); when one is
+      // returned it must describe swapping away from the aggregate squash.
+      if (candidate !== undefined) {
+        assertEquals(candidate.previousSquash, squash);
+        assertNotEquals(candidate.squash, squash);
+      }
+    },
+  );
+}
+
+Deno.test(
+  "DiscoverSquashAnalysis - findCandidateSquash excludes IF focus neuron without throwing (#3419)",
+  () => {
+    const creature = ifFocusCreature();
+    const ifId = buildWireToRuntimeIdMap(creature).get("if-h")!;
+
+    const records = [
+      { value: 0.4, activation: 0.4, errors: [0.05] },
+      { value: -0.1, activation: -0.1, errors: [-0.05] },
+    ];
+
+    // IF routes typed connections a scalar squash would reinterpret, so it is
+    // excluded from swap scoring — no candidate, and crucially no throw.
+    const candidate = findCandidateSquash(
+      creature,
+      ifId,
+      records,
+      () => 1,
+      false,
+      () => {},
+    );
+
+    assertEquals(candidate, undefined);
+  },
+);
+
+Deno.test(
+  "DiscoverSquashAnalysis - harmful removal analysis tolerates aggregate focus neuron (#3419)",
+  async () => {
+    const creature = aggregateFocusCreature("MAXIMUM");
+    const aggId = buildWireToRuntimeIdMap(creature).get("agg")!;
+
+    // Pre-fix this path threw `squash is not a function` per neuron (logged);
+    // now it completes and, for reasonable errors, promotes nothing.
+    const result = await analyzeSelectedNeuronsForHarmfulRemoval(
+      creature,
+      [aggId],
+      () =>
+        Promise.resolve([
+          { value: 0.3, activation: 0.3, errors: [0.05] },
+          { value: 0.6, activation: 0.6, errors: [-0.05] },
+        ]),
+      "/tmp/discovery",
+      false,
+      () => {},
+    );
+
+    assertEquals(result, undefined);
+  },
+);


### PR DESCRIPTION
## Summary

Fixes the `TypeError: currentSquashMethod.squash is not a function` that aborted whole discovery runs (phase `analysis_parallel`) whenever a focus neuron used an aggregate squash. Reported downstream via stSoftwareAU/GRQ#3551 (GRQ-16 location run, symbol AZ, discovery `491e2c8d`).

Closes #3419.

## Root cause

`DiscoverSquashAnalysis.ts` cast every focus neuron's activation to `ActivationInterface` and called `.squash(idealValue)`. Aggregate activations (`MAXIMUM`, `MINIMUM`, `IF`) implement only `activate(neuron)` — no scalar `squash(x)`. #3389 began recording aggregate neurons' own value/error, so they reached this analysis for the first time and the unchecked cast threw.

## Fix

`resolveScoringSquash(name)` replaces the unchecked cast (`hasScalarSquash` guard added to the shared `TypeGuards`):

- genuine scalar squash → itself;
- `MAXIMUM`/`MINIMUM` pass their aggregated value straight through → resolve to the `IDENTITY` pass-through, so simple-squash replacements are scored against the recorded ideal values like any other candidate (the developer-chosen "score the swap", not "guard-and-skip");
- `IF` routes typed condition/positive/negative connections whose meaning a scalar squash would change → excluded from swap scoring (skipped, never thrown on).

Both the swap-analysis path (`findCandidateSquash`) and the harmful-removal path (`analyzeSelectedNeuronsForHarmfulRemoval`) hit the same cast and are both fixed. The analysis now **never throws** on an aggregate-squash neuron — an ineligible/low-scoring swap is a valid state, not an error.

```mermaid
flowchart TD
    A[focus neuron squash] --> B{scalar squash?}
    B -- yes --> C[score candidates vs squash ideal]
    B -- no, MAXIMUM/MINIMUM --> D[IDENTITY pass-through stand-in\nscore simple-squash replacements]
    B -- no, IF --> E[exclude from swap scoring\nreturn undefined]
    C --> F[CandidateSquash or undefined]
    D --> F
    E --> F
```

## Tests

`test/ErrorGuidedStructuralEvolution/DiscoverSquashAnalysis.ts`:
- `findCandidateSquash scores MAXIMUM/MINIMUM focus neuron without throwing (#3419)` — reproduces the exact `squash is not a function` TypeError against unfixed code; passes after the fix.
- `findCandidateSquash excludes IF focus neuron without throwing (#3419)` — IF returns `undefined`, no throw.
- `harmful removal analysis tolerates aggregate focus neuron (#3419)`.

All 18 tests in the file pass; `deno lint`/`deno check`/`deno fmt` clean on the changed files.

## Release note

Per stSoftwareAU#2944 this PR is **not** auto-merged/published; the GRQ consumer bump (stSoftwareAU/GRQ#3551) waits for a human-gated release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)